### PR TITLE
Tweak data app sidebars style

### DIFF
--- a/frontend/src/metabase/dashboard/components/DashboardGrid.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardGrid.jsx
@@ -192,16 +192,17 @@ class DashboardGrid extends Component {
   }
 
   getRowHeight() {
-    const { width, dashboard } = this.props;
+    const { width, dashboard, isEditing } = this.props;
 
     const contentViewportElement = this.context;
     const hasScroll =
       contentViewportElement?.clientHeight <
       contentViewportElement?.scrollHeight;
 
-    const aspect = dashboard.is_app_page
-      ? DATA_APPS_ASPECT_RATIO
-      : GRID_ASPECT_RATIO;
+    const aspect =
+      dashboard.is_app_page && !isEditing
+        ? DATA_APPS_ASPECT_RATIO
+        : GRID_ASPECT_RATIO;
     const minHeight = dashboard.is_app_page
       ? DATA_APPS_MIN_ROW_HEIGHT
       : MIN_ROW_HEIGHT;
@@ -365,7 +366,7 @@ class DashboardGrid extends Component {
   );
 
   renderGrid() {
-    const { dashboard, width } = this.props;
+    const { dashboard, width, isEditing } = this.props;
     const { layouts } = this.state;
     const rowHeight = this.getRowHeight();
     return (
@@ -377,7 +378,9 @@ class DashboardGrid extends Component {
         layouts={layouts}
         breakpoints={GRID_BREAKPOINTS}
         cols={GRID_COLUMNS}
-        width={dashboard.is_app_page ? DATA_APPS_MAX_WIDTH : width}
+        width={
+          dashboard.is_app_page && !isEditing ? DATA_APPS_MAX_WIDTH : width
+        }
         margin={
           dashboard.is_app_page
             ? DATA_APPS_GRID_MARGIN

--- a/frontend/src/metabase/dashboard/components/Sidebar.jsx
+++ b/frontend/src/metabase/dashboard/components/Sidebar.jsx
@@ -1,11 +1,16 @@
 import React from "react";
 import PropTypes from "prop-types";
+import cx from "classnames";
 import { t } from "ttag";
+
 import Button from "metabase/core/components/Button";
+
+import { useDataAppContext } from "metabase/writeback/containers/DataAppContext";
 
 const WIDTH = 384;
 
 const propTypes = {
+  isDataApp: PropTypes.bool,
   closeIsDisabled: PropTypes.bool,
   children: PropTypes.node,
   onClose: PropTypes.func,
@@ -13,12 +18,24 @@ const propTypes = {
 };
 
 function Sidebar({ closeIsDisabled, children, onClose, onCancel }) {
+  const { isDataApp } = useDataAppContext();
+
   return (
     <aside
-      style={{ width: WIDTH, minWidth: WIDTH }}
-      className="flex flex-column border-left bg-white"
+      style={{
+        width: WIDTH,
+        minWidth: WIDTH,
+        padding: isDataApp ? "20px 20px 20px 0" : 0,
+      }}
+      className={cx("flex flex-column", {
+        "border-left bg-white": !isDataApp,
+      })}
     >
-      <div className="flex flex-column flex-auto overflow-y-auto">
+      <div
+        className={cx("flex flex-column flex-auto overflow-y-auto", {
+          "bordered rounded bg-white": isDataApp,
+        })}
+      >
         {children}
       </div>
       {(onClose || onCancel) && (

--- a/frontend/src/metabase/writeback/containers/DataAppContext/DataAppContext.ts
+++ b/frontend/src/metabase/writeback/containers/DataAppContext/DataAppContext.ts
@@ -16,6 +16,7 @@ export type FormattedObjectDetail = Record<FieldName, ObjectDetailField>;
 export type DataContextType = Record<CardName, FormattedObjectDetail>;
 
 export type DataAppContextType = {
+  isDataApp: boolean;
   data: DataContextType;
   bulkActions: {
     cardId: number | null;
@@ -29,6 +30,7 @@ export type DataAppContextType = {
 };
 
 export const DataAppContext = createContext<DataAppContextType>({
+  isDataApp: true,
   data: {},
   bulkActions: {
     cardId: null,

--- a/frontend/src/metabase/writeback/containers/DataAppContext/DataAppContextProvider.tsx
+++ b/frontend/src/metabase/writeback/containers/DataAppContext/DataAppContextProvider.tsx
@@ -4,11 +4,13 @@ import _ from "lodash";
 import { getIn } from "icepick";
 
 import {
+  getDashboard,
   getDashcards,
   getCardData,
   getIsLoadingComplete,
 } from "metabase/dashboard/selectors";
 
+import type { DataAppPage } from "metabase-types/api";
 import type { CardId } from "metabase-types/types/Card";
 import type { DashCard, DashCardId } from "metabase-types/types/Dashboard";
 import type { Dataset } from "metabase-types/types/Dataset";
@@ -26,6 +28,7 @@ interface DataAppContextProviderOwnProps {
 }
 
 interface DataAppContextProviderStateProps {
+  page?: DataAppPage;
   dashCards: Record<DashCardId, DashCard>;
   dashCardData: Record<DashCardId, Record<CardId, Dataset>>;
   isLoaded: boolean;
@@ -36,6 +39,7 @@ type DataAppContextProviderProps = DataAppContextProviderOwnProps &
 
 function mapStateToProps(state: State) {
   return {
+    page: getDashboard(state),
     dashCards: getDashcards(state),
     dashCardData: getCardData(state),
     isLoaded: getIsLoadingComplete(state),
@@ -43,6 +47,7 @@ function mapStateToProps(state: State) {
 }
 
 function DataAppContextProvider({
+  page,
   dashCards = [],
   dashCardData = {},
   isLoaded,
@@ -103,6 +108,7 @@ function DataAppContextProvider({
 
   const context: DataAppContextType = useMemo(() => {
     const value: DataAppContextType = {
+      isDataApp: !!page?.is_app_page,
       data: dataContext,
       isLoaded,
       bulkActions: {
@@ -119,6 +125,7 @@ function DataAppContextProvider({
 
     return value;
   }, [
+    page,
     dataContext,
     isLoaded,
     bulkActionCardId,

--- a/frontend/src/metabase/writeback/containers/DataAppContext/DataAppContextProvider.tsx
+++ b/frontend/src/metabase/writeback/containers/DataAppContext/DataAppContextProvider.tsx
@@ -9,10 +9,10 @@ import {
   getIsLoadingComplete,
 } from "metabase/dashboard/selectors";
 
-import { CardId } from "metabase-types/types/Card";
-import { DashCard, DashCardId } from "metabase-types/types/Dashboard";
-import { Dataset } from "metabase-types/types/Dataset";
-import { State } from "metabase-types/store";
+import type { CardId } from "metabase-types/types/Card";
+import type { DashCard, DashCardId } from "metabase-types/types/Dashboard";
+import type { Dataset } from "metabase-types/types/Dataset";
+import type { State } from "metabase-types/store";
 
 import {
   DataAppContext,


### PR DESCRIPTION
Patches dashboard sidebar style in case we're viewing a data app page, so it doesn't look too ugly. It's a temporary fix, so I'm not proud of the code cleanliness here, to be honest, but it does the job.

The sidebars (e.g. add question, add action, add form, add filter) are supposed to push the dashboard grid content. This was looking a bit off after we introduced horizontal space around the page content. This PR would make the page canvas take all available horizontal space in the editing mode, so when a sidebar is open, everything looks fine (same behavior as for dashboards)

### To Verify

1. New > App > Pick a few tables > Create
2. Open an editing mode on a few pages (at least one list + at least one detail)
3. Open a few sidebars and make sure everything looks fine (e.g. add question, dashboard filter settings, click behavior sidebar, add action button / form, etc.)
4. Make sure regular dashboards look as before

### Demo

https://user-images.githubusercontent.com/17258145/197847681-c2e4f745-1bb2-4194-bffd-b3ee6de6a33e.mp4

