### PR TITLE
[CI] Redo the release script and trigger it manually

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,87 +1,98 @@
-name: Release
+name: Release [WIP]
 
 on:
-  push:
-    tags:
-    - 'v*'
+  workflow_dispatch:
+    inputs:
+      commit:
+        description: 'A commit hash'
+        required: true
+      oss-tag:
+        description: 'OSS version tag'
+        required: true
+      ee-tag:
+        description: 'EE version tag'
+        required: true
 
 jobs:
-
-  download-uberjar:
+  build:
+    name: Build Metabase ${{ matrix.edition }} @${{ github.event.inputs.commit }}
     runs-on: ubuntu-20.04
-    timeout-minutes: 10
+    timeout-minutes: 40
+    strategy:
+      matrix:
+        edition: [oss, ee]
+    env:
+      MB_EDITION: ${{ matrix.edition }}
+      INTERACTIVE: false
     steps:
-    - name: Download Uberjar for ${{ github.ref_name }}
-      run: |
-        JAR_DOWNLOAD_URL=https://downloads.metabase.com/${{ github.ref_name }}/metabase.jar
-        if [[ ${{ github.ref_name }} == v1* ]]; then
-          JAR_DOWNLOAD_URL=https://downloads.metabase.com/enterprise/${{ github.ref_name }}/metabase.jar
-        fi
-        echo $JAR_DOWNLOAD_URL > url.txt
-        echo "----- Downloading Uberjar from $JAR_DOWNLOAD_URL -----"
-        curl -OL $JAR_DOWNLOAD_URL
-        stat ./metabase.jar
-        date | tee timestamp
-    - name: Calculate SHA256 checksum
-      run: sha256sum ./metabase.jar | tee SHA256.sum
-    - name: Upload Uberjar as artifact
-      uses: actions/upload-artifact@v2
+    - name: Check out the code
+      uses: actions/checkout@v3
       with:
-        name: metabase-uberjar-${{ github.ref_name }}
-        path: |
-          ./metabase.jar
-          ./url.txt
-          ./timestamp
-          ./SHA256.sum
+        ref: ${{ github.event.inputs.commit }}
+    - name: Prepare front-end environment
+      uses: ./.github/actions/prepare-frontend
+    - name: Prepare back-end environment
+      uses: ./.github/actions/prepare-backend
+    - name: Build
+      run: ./bin/build
+    - name: Prepare uberjar artifact
+      uses: ./.github/actions/prepare-uberjar-artifact
 
-  check-uberjar:
+  check-uberjar-health:
     runs-on: ubuntu-20.04
-    needs: download-uberjar
+    name: Is ${{ matrix.edition }} (java ${{ matrix.java-version }}) healthy?
+    needs: build
     timeout-minutes: 10
+    strategy:
+      matrix:
+        edition: [oss, ee]
+        java-version: [11, 17]
     steps:
     - name: Prepare JRE (Java Run-time Environment)
       uses: actions/setup-java@v3
       with:
         java-package: jre
-        java-version: 11
+        java-version: ${{ matrix.java-version }}
         distribution: 'temurin'
+    - run: java -version
     - uses: actions/download-artifact@v2
-      name: Retrieve previously downloaded Uberjar
+      name: Retrieve uberjar artifact
       with:
-        name: metabase-uberjar-${{ github.ref_name }}
-    - name: Reveal its version.properties
-      run: jar xf metabase.jar version.properties && cat version.properties
-    - name: Display when and where it was downloaded
-      run: |
-        cat timestamp
-        cat url.txt
-    - name: Show the checksum
-      run: cat SHA256.sum
-    - name: Launch Metabase Uberjar (and keep it running)
-      run: java -jar ./metabase.jar &
+        name: metabase-${{ matrix.edition }}-uberjar
+    - name: Launch uberjar (and keep it running)
+      run: java -jar ./target/uberjar/metabase.jar &
     - name: Wait for Metabase to start
-      run: while ! curl -s localhost:3000/api/health; do sleep 1; done
-      timeout-minutes: 3
-    - name: Check API health
-      run: curl -s localhost:3000/api/health
+      run: while ! curl -s 'http://localhost:3000/api/health' | grep '{"status":"ok"}'; do sleep 1; done
 
   containerize:
     runs-on: ubuntu-20.04
-    needs: check-uberjar
+    needs: check-uberjar-health
     timeout-minutes: 15
+    strategy:
+      matrix:
+        edition: [oss, ee]
     services:
       registry:
         image: registry:2
         ports:
           - 5000:5000
     steps:
+    - name: Set the image tag based on the edition
+      run: |
+        if [[ ${{ matrix.edition }} == ee ]]; then
+          echo "IMAGE_TAG=${{ github.event.inputs.ee-tag }}" >> $GITHUB_ENV
+        else
+          echo "IMAGE_TAG=${{ github.event.inputs.oss-tag }}" >> $GITHUB_ENV
+        fi
     - uses: actions/checkout@v3
-    - uses: actions/download-artifact@v2
-      name: Retrieve previously downloaded Uberjar
       with:
-        name: metabase-uberjar-${{ github.ref_name }}
+        ref: ${{ github.event.inputs.commit }}
+    - uses: actions/download-artifact@v2
+      name: Retrieve uberjar artifact
+      with:
+        name: metabase-${{ matrix.edition }}-uberjar
     - name: Move the Uberjar to the context dir
-      run: mv ./metabase.jar bin/docker/.
+      run: mv ./target/uberjar/metabase.jar bin/docker/.
     - name: Set up Docker Buildx
       id: buildx
       uses: docker/setup-buildx-action@v1
@@ -93,12 +104,12 @@ jobs:
         context: bin/docker/.
         platforms: linux/amd64
         network: host
-        tags: localhost:5000/local-metabase:${{ github.ref_name }}
+        tags: localhost:5000/local-metabase:${{ env.IMAGE_TAG }}
         no-cache: true
         push: true
 
     - name: Launch container
-      run: docker run --rm -dp 3000:3000 localhost:5000/local-metabase:${{ github.ref_name }}
+      run: docker run --rm -dp 3000:3000 localhost:5000/local-metabase:${{ env.IMAGE_TAG }}
       timeout-minutes: 5
     - name: Wait for Metabase to start
       run: while ! curl -s 'http://localhost:3000/api/health' | grep '{"status":"ok"}'; do sleep 1; done
@@ -106,23 +117,25 @@ jobs:
 
     - name: Determine the target Docker Hub repository
       run: |
-        if [[ ${{ github.ref_name }} == v1* ]]; then
-          echo "Metabase EE: image is going to be pushed to ${{ github.repository_owner }}/test-metabase-enterprise"
-          echo "DOCKERHUB_REPO=${{ github.repository_owner }}/test-metabase-enterprise" >> $GITHUB_ENV
+        if [[ ${{ github.repository }} == 'metabase/metabase' ]]; then
+          if [[ ${{ matrix.edition }} == ee ]]; then
+            echo "Metabase EE: image ${{ env.IMAGE_TAG }} is going to be pushed to metabase/test-metabase-enterprise"
+            echo "DOCKERHUB_REPO=metabase/test-metabase-enterprise" >> $GITHUB_ENV
+          else
+            echo "Metabase OSS: image ${{ env.IMAGE_TAG }} is going to be pushed to metabase/test-metabase"
+            echo "DOCKERHUB_REPO=metabase/test-metabase" >> $GITHUB_ENV
+          fi
         else
-          echo "Metabase OSS: image is going to be pushed to ${{ github.repository_owner }}/test-metabase"
-          echo "DOCKERHUB_REPO=${{ github.repository_owner }}/test-metabase" >> $GITHUB_ENV
+          echo "DOCKERHUB_REPO=${{ github.repository_owner }}/${{ secrets.CUSTOM_RELEASE_REPO }}" >> $GITHUB_ENV
         fi
-
-
     - name: Login to Docker Hub
       uses: docker/login-action@v1
       with:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_TOKEN }}
-    - name: Retag and push container image to Docker Hub
+        username: ${{ secrets.DOCKERHUB_RELEASE_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_RELEASE_TOKEN }}
+    - name: Retag and push container image to Metabase Docker Hub
       run: |
-        echo "Pushing ${{ github.ref_name }} to ${{ env.DOCKERHUB_REPO }} ..."
-        docker tag localhost:5000/local-metabase:${{ github.ref_name }} ${{ env.DOCKERHUB_REPO }}:${{ github.ref_name }}
-        docker push ${{ env.DOCKERHUB_REPO }}:${{ github.ref_name }}
+        echo "Pushing ${{ env.IMAGE_TAG }} to ${{ env.DOCKERHUB_REPO }} ..."
+        docker tag localhost:5000/local-metabase:${{ env.IMAGE_TAG }} ${{ env.DOCKERHUB_REPO }}:${{ env.IMAGE_TAG }}
+        docker push ${{ env.DOCKERHUB_REPO }}:${{ env.IMAGE_TAG }}
         echo "Finished!"


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- It piggybacks on a great foundation already laid out by @ariya who created a first draft of the release script.
- Replaces the trigger for this workflow from the `push` (on tag) to the manual input where a _commit hash is the king_*
- Builds the uberjar for the given commit and then uploads it to the appropriate DockerHub repo
- Accounts for the alternative repositories, other than the (official) main Metabase repo which could help our customers with their custom builds

*_commit hash_ has to be the ultimate source of truth for the release. If we use the tag as the starting point, it's possible in some rare situations to end up with OSS tag on a commit A, while EE tag is on a commit B. We want to avoid that.

> **Warning**
>This script is still not finished! It will have many more iterations until we account for all the nuances of the release process.

Although the script is not done, this PR is mergeable.
Rather than working on a gigantic script and getting lost in details, I opted for the incremental approach. Given that the script has to be triggered manually and that it still uses `test-metabase` and `test-metabase-enterprise` repositories, there is no risk of accidentally publishing an incomplete release to the official repo.

## Note
In order to test this, the PR needs to be merged to the main repo. After that, you'll see a "Run workflow" button that will open a "form" with the input fields. Values from those input fields will be passed as the payload to the release script and can be referenced like so: ` ${{ github.event.inputs.<input-field> }}`
<img width="397" alt="image" src="https://user-images.githubusercontent.com/31325167/197874519-ce832d9a-b967-4176-9d26-1b59231a9b5b.png">
