### PR TITLE
List Viz Rework 2: Easier Avatars

### DIFF
--- a/frontend/src/metabase/components/UserAvatar/UserAvatar.tsx
+++ b/frontend/src/metabase/components/UserAvatar/UserAvatar.tsx
@@ -2,7 +2,7 @@
 import React from "react";
 
 import MetabaseUtils from "metabase/lib/utils";
-import { Avatar, AvatarProps } from "./UserAvatar.styled";
+import { Avatar as StlyedAvatar, AvatarProps } from "./UserAvatar.styled";
 
 interface UserAvatarProps extends AvatarProps {
   user: User;
@@ -27,7 +27,11 @@ export default function UserAvatar({
   user,
   ...props
 }: UserAvatarProps | GroupProps) {
-  return <Avatar {...props}>{userInitials(user) || "?"}</Avatar>;
+  return <StlyedAvatar {...props}>{userInitials(user) || "?"}</StlyedAvatar>;
+}
+
+export function Avatar({ children, ...props }: { children: string }) {
+  return <StlyedAvatar {...props}>{initial(children) ?? "?"}</StlyedAvatar>;
 }
 
 function initial(name?: string | null) {

--- a/frontend/src/metabase/components/UserAvatar/index.js
+++ b/frontend/src/metabase/components/UserAvatar/index.js
@@ -1,1 +1,1 @@
-export { default } from "./UserAvatar";
+export { default, Avatar } from "./UserAvatar";

--- a/frontend/src/metabase/visualizations/components/List/List.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/List/List.styled.tsx
@@ -31,7 +31,7 @@ export const ListBody = styled.ul`
 `;
 
 export const ListItemRow = styled.li<{ isClickable?: boolean }>`
-  padding: 1rem 2rem;
+  padding: 1rem 1.5rem;
   cursor: ${props => (props?.isClickable ? "pointer" : "default")};
   width: 100%;
   border-bottom: 1px solid ${color("border")};

--- a/frontend/src/metabase/visualizations/components/List/List.tsx
+++ b/frontend/src/metabase/visualizations/components/List/List.tsx
@@ -13,6 +13,8 @@ import { DashboardWithCards } from "metabase-types/types/Dashboard";
 import { VisualizationProps } from "metabase-types/types/Visualization";
 import Metadata from "metabase-lib/lib/metadata/Metadata";
 
+import type { ListColumnIndexes } from "./types";
+
 import {
   Root,
   Footer,
@@ -96,7 +98,7 @@ function List({
     [rowIndexes, start, end],
   );
 
-  const listColumnIndexes = useMemo<{ left: number[]; right: number[] }>(() => {
+  const listColumnIndexes = useMemo<ListColumnIndexes>(() => {
     function getColumnIndex(idOrFieldRef: any) {
       if (idOrFieldRef === null) {
         return null;
@@ -107,9 +109,10 @@ function List({
       );
     }
 
-    const left = settings["list.columns"].left.map(getColumnIndex);
-    const right = settings["list.columns"].right.map(getColumnIndex);
-    return { left, right };
+    const image = settings["list.columns"].image?.map(getColumnIndex) ?? [];
+    const left = settings["list.columns"].left?.map(getColumnIndex) ?? [];
+    const right = settings["list.columns"].right?.map(getColumnIndex) ?? [];
+    return { image, left, right };
   }, [cols, settings]);
 
   const renderListItem = useCallback(

--- a/frontend/src/metabase/visualizations/components/List/ListCell.tsx
+++ b/frontend/src/metabase/visualizations/components/List/ListCell.tsx
@@ -3,7 +3,6 @@ import cx from "classnames";
 
 import ExternalLink from "metabase/core/components/ExternalLink";
 import Tooltip from "metabase/components/Tooltip";
-import { Avatar } from "metabase/components/UserAvatar/UserAvatar.styled";
 
 import { formatValue } from "metabase/lib/formatting";
 import { getColumnExtent } from "metabase/visualizations/lib/utils";

--- a/frontend/src/metabase/visualizations/components/List/VariantInfo.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/List/VariantInfo.styled.tsx
@@ -26,6 +26,9 @@ export const ListItemSubtitle = styled.div`
 `;
 
 export const InfoLeft = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 1rem;
   min-width: 0;
   font-size: 0.75rem;
   font-weight: bold;

--- a/frontend/src/metabase/visualizations/components/List/VariantInfo.tsx
+++ b/frontend/src/metabase/visualizations/components/List/VariantInfo.tsx
@@ -1,6 +1,9 @@
 import React from "react";
 
 import { isEmpty } from "metabase/lib/validate";
+import { Avatar } from "metabase/components/UserAvatar/UserAvatar.styled";
+
+import { isImageURL } from "metabase-lib/lib/types/utils/isa";
 
 import type { ListVariantProps } from "./types";
 import {
@@ -24,50 +27,69 @@ export const VariantInfo = ({
     return null;
   }
 
+  const [imageIndex] = listColumnIndexes.image;
   const [titleIndex, subtitleIndex, subtitle2Index] = listColumnIndexes.left;
   const [infoIndex] = listColumnIndexes.right;
 
+  const image = row[imageIndex];
   const title = row[titleIndex];
   const subtitle = row[subtitleIndex];
   const subtitle2 = row[subtitle2Index];
-
   const info = row[infoIndex];
+
+  const imageColIsImage = isImageURL(data.cols[imageIndex]);
 
   return (
     <InfoListItem>
       <InfoLeft>
-        <ListItemTitle>
-          {!isEmpty(title) && (
-            <ListCell
-              value={title}
-              columnTitle={getColumnTitle(titleIndex)}
-              data={data}
-              settings={settings}
-              columnIndex={titleIndex}
-            />
-          )}
-        </ListItemTitle>
-        <ListItemSubtitle>
-          {!isEmpty(subtitle) && (
-            <ListCell
-              value={subtitle}
-              columnTitle={getColumnTitle(subtitleIndex)}
-              data={data}
-              settings={settings}
-              columnIndex={subtitleIndex}
-            />
-          )}
-          {!isEmpty(subtitle) && !isEmpty(subtitle2) && " - "}
-          {!isEmpty(subtitle2) && (
-            <ListCell
-              value={subtitle2}
-              columnTitle={getColumnTitle(subtitle2Index)}
-              data={data}
-              settings={settings}
-              columnIndex={subtitle2Index}
-            />
-          )}
-        </ListItemSubtitle>
+        {image && imageColIsImage && (
+          <ListCell
+            value={image}
+            columnTitle={getColumnTitle(imageIndex)}
+            data={data}
+            settings={settings}
+            columnIndex={imageIndex}
+          />
+        )}
+        {image && !imageColIsImage && (
+          <Avatar>
+            {String(row?.[imageIndex])?.slice(0, 1)?.toUpperCase()}
+          </Avatar>
+        )}
+        <div>
+          <ListItemTitle>
+            {!isEmpty(title) && (
+              <ListCell
+                value={title}
+                columnTitle={getColumnTitle(titleIndex)}
+                data={data}
+                settings={settings}
+                columnIndex={titleIndex}
+              />
+            )}
+          </ListItemTitle>
+          <ListItemSubtitle>
+            {!isEmpty(subtitle) && (
+              <ListCell
+                value={subtitle}
+                columnTitle={getColumnTitle(subtitleIndex)}
+                data={data}
+                settings={settings}
+                columnIndex={subtitleIndex}
+              />
+            )}
+            {!isEmpty(subtitle) && !isEmpty(subtitle2) && " - "}
+            {!isEmpty(subtitle2) && (
+              <ListCell
+                value={subtitle2}
+                columnTitle={getColumnTitle(subtitle2Index)}
+                data={data}
+                settings={settings}
+                columnIndex={subtitle2Index}
+              />
+            )}
+          </ListItemSubtitle>
+        </div>
       </InfoLeft>
       <InfoRight>
         {!isEmpty(info) && (

--- a/frontend/src/metabase/visualizations/components/List/VariantInfo.tsx
+++ b/frontend/src/metabase/visualizations/components/List/VariantInfo.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 
 import { isEmpty } from "metabase/lib/validate";
-import { Avatar } from "metabase/components/UserAvatar/UserAvatar.styled";
+import { Avatar } from "metabase/components/UserAvatar";
 
 import { isImageURL } from "metabase-lib/lib/types/utils/isa";
 
@@ -52,9 +52,7 @@ export const VariantInfo = ({
           />
         )}
         {image && !imageColIsImage && (
-          <Avatar>
-            {String(row?.[imageIndex])?.slice(0, 1)?.toUpperCase()}
-          </Avatar>
+          <Avatar>{String(row?.[imageIndex])}</Avatar>
         )}
         <div>
           <ListItemTitle>

--- a/frontend/src/metabase/visualizations/components/List/types.ts
+++ b/frontend/src/metabase/visualizations/components/List/types.ts
@@ -1,9 +1,16 @@
 import type { VisualizationProps } from "metabase-types/types/Visualization";
 import type { Row } from "metabase-types/types/Dataset";
+
 export type ListVariant = "basic" | "info";
+
+export interface ListColumnIndexes {
+  left: number[];
+  right: number[];
+  image: number[];
+}
 
 export type ListVariantProps = Pick<VisualizationProps, "settings" | "data"> & {
   row: Row;
-  listColumnIndexes: { left: number[]; right: number[] };
+  listColumnIndexes: ListColumnIndexes;
   getColumnTitle: (columnIndex: number) => string;
 };

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingsListColumns/ChartSettingsListColumns.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingsListColumns/ChartSettingsListColumns.tsx
@@ -19,6 +19,7 @@ import {
 type FieldIdOrFieldRef = FieldId | ConcreteField;
 
 type SettingValue = {
+  image: FieldIdOrFieldRef[];
   left: FieldIdOrFieldRef[];
   right: FieldIdOrFieldRef[];
 };
@@ -31,7 +32,7 @@ interface Props {
   onShowWidget: (config: unknown, targetElement: HTMLElement | null) => void;
 }
 
-type ListColumnSlot = "left" | "right";
+type ListColumnSlot = "left" | "right" | "image";
 
 function formatValueForSelect(value: FieldIdOrFieldRef): string | number {
   const isFieldReference = Array.isArray(value);
@@ -103,6 +104,24 @@ function ChartSettingsListColumns({
 
   return (
     <div>
+      <GroupName>{t`Image`}</GroupName>
+      {(value.image ?? [null]).map((fieldIdOrFieldRef, index) => (
+        <ColumnItemContainer key={index}>
+          <StyledSelect
+            value={formatValueForSelect(fieldIdOrFieldRef)}
+            options={options}
+            onChange={(e: ChangeEvent<HTMLSelectElement>) => {
+              onChangeColumn("image", index, parseSelectValue(e));
+            }}
+          />
+          <Button
+            icon="gear"
+            onlyIcon
+            disabled={fieldIdOrFieldRef === null}
+            onClick={e => onColumnSettingsClick(fieldIdOrFieldRef, e.target)}
+          />
+        </ColumnItemContainer>
+      ))}
       <GroupName>{t`Left`}</GroupName>
       {value.left.map((fieldIdOrFieldRef, index) => (
         <ColumnItemContainer key={index}>

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingsListColumns/ChartSettingsListColumns.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingsListColumns/ChartSettingsListColumns.tsx
@@ -34,7 +34,9 @@ interface Props {
 
 type ListColumnSlot = "left" | "right" | "image";
 
-function formatValueForSelect(value: FieldIdOrFieldRef): string | number {
+function formatValueForSelect(
+  value: FieldIdOrFieldRef,
+): string | number | null {
   const isFieldReference = Array.isArray(value);
   return isFieldReference ? JSON.stringify(value) : value;
 }
@@ -102,10 +104,13 @@ function ChartSettingsListColumns({
     ...columnOptions,
   ];
 
+  const nullIfEmpty = (value: FieldIdOrFieldRef[]) =>
+    value?.length ? value : [null];
+
   return (
     <div>
       <GroupName>{t`Image`}</GroupName>
-      {(value.image ?? [null]).map((fieldIdOrFieldRef, index) => (
+      {nullIfEmpty(value.image).map((fieldIdOrFieldRef, index) => (
         <ColumnItemContainer key={index}>
           <StyledSelect
             value={formatValueForSelect(fieldIdOrFieldRef)}
@@ -123,7 +128,7 @@ function ChartSettingsListColumns({
         </ColumnItemContainer>
       ))}
       <GroupName>{t`Left`}</GroupName>
-      {value.left.map((fieldIdOrFieldRef, index) => (
+      {nullIfEmpty(value.left).map((fieldIdOrFieldRef, index) => (
         <ColumnItemContainer key={index}>
           <StyledSelect
             value={formatValueForSelect(fieldIdOrFieldRef)}
@@ -141,7 +146,7 @@ function ChartSettingsListColumns({
         </ColumnItemContainer>
       ))}
       <GroupName>{t`Right`}</GroupName>
-      {value.right.map((fieldIdOrFieldRef, index) => (
+      {nullIfEmpty(value.right).map((fieldIdOrFieldRef, index) => (
         <ColumnItemContainer key={index}>
           <StyledSelect
             key={index}

--- a/frontend/src/metabase/visualizations/visualizations/List.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/List.tsx
@@ -86,6 +86,7 @@ export default Object.assign(ListViz, {
         const firstThreeColumns = columns.slice(0, 3).filter(Boolean);
         const fourthColumn = columns.slice(3, 4).filter(Boolean);
         return {
+          image: [null],
           left: firstThreeColumns.map(col => col.id || col.field_ref),
           right: fourthColumn.map(col => col.id || col.field_ref),
         };


### PR DESCRIPTION
## Description

- adds a broken-out settings field for an image to make it easier to use
- if a non-image column is selected for that field, show a text avatar

![AvatarOptions](https://user-images.githubusercontent.com/30528226/197897662-ee129eb6-37a1-412d-933b-dc4895252025.gif)

