### PR TITLE
Extend honeysql with `:oredered-join` clause

### DIFF
--- a/modules/drivers/oracle/test/metabase/driver/oracle_test.clj
+++ b/modules/drivers/oracle/test/metabase/driver/oracle_test.clj
@@ -280,11 +280,12 @@
                              [(id "price" "number")
                               (hx/identifier :field-alias "price")]]
                             :from      [(hx/identifier :table oracle.tx/session-schema "test_data_venues")]
-                            :left-join [[(hx/identifier :table oracle.tx/session-schema "test_data_categories")
-                                         (hx/identifier :table-alias "test_data_categories__via__cat")]
-                                        [:=
-                                         (id "category_id" "number")
-                                         (id "test_data_categories__via__cat" "id" "number")]]
+                            :ordered-join [:left
+                                           [(hx/identifier :table oracle.tx/session-schema "test_data_categories")
+                                            (hx/identifier :table-alias "test_data_categories__via__cat")]
+                                           [:=
+                                            (id "category_id" "number")
+                                            (id "test_data_categories__via__cat" "id" "number")]]
                             :where     [:=
                                         (id "test_data_categories__via__cat" "name" "varchar2")
                                         "BBQ"]

--- a/test/metabase/query_processor_test/explicit_joins_test.clj
+++ b/test/metabase/query_processor_test/explicit_joins_test.clj
@@ -956,7 +956,7 @@
 
 (defn- joins-for-mbql
   "Generate content for `:joins` clause of mbql query used in [[join-ordering-test]].
-   
+
    Input is one `join-seq` eg. `[:left-join :full-join]`. See [[join-seqs]]."
   [join-seq]
   (map (fn [strategy data]
@@ -974,16 +974,16 @@
 
 (defn- expected-join-data
   "Generate data used to verify that `:joins` in mbql match joins in honeysql in [[join-ordering-test]]
-   
+
    Structure of data returned is as follows:
    `[[<type of join>
-      <table> 
-      <last component of left `=` operand> 
+      <table>
+      <last component of left `=` operand>
       <last component of righ `=` operand>]
      ...]`
-   
+
    Eg. `([:left :checkins :id :venue_id]
-         [:right :users :user_id :id] 
+         [:right :users :user_id :id]
          [:full :categories :category_id :id])`
 
    Data are matched against output of [[actual-join-data]]."
@@ -1001,7 +1001,7 @@
   [join-triplet]
   (let [join-type (-> join-triplet first)
         table (->> join-triplet
-                   ;; get table name 
+                   ;; get table name
                    second first :components last str/lower-case
                     ;; remove db qualifier for table
                    (re-find #"\p{Alnum}+$")
@@ -1025,7 +1025,7 @@
 
 (defn- actual-join-data
   "Extract test data from honeysql generated with [[sql.qp/mbql->honeysql]] in [[join-ordering-test]]
-   
+
    Return value is matched against output of [[expected-join-data]]"
   [hsql-form]
   (actual-join-data--extract driver/*driver* hsql-form))


### PR DESCRIPTION
Fixes #15342

Even though #21411 is work in progress, I've decided to share this fix because:
1. fix is ~20 lines + tests
2. P1 priority
3. last activity in #21411 was some time ago (April 2022)

### On implementation

Code in this PR extends honeysql with `:ordered-join` clause and modifies mbql query transaltion to use this clause instead of out of the box join clauses. 

I've came across [this workaround](https://github.com/seancorfield/honeysql/issues/277#issue-713661729) while researching honeysql issues regarding join ordering problem. This PR is just it's integration into metabase codebase plus tests.

Tests check that:
1. joins mbql query match joins in `:ordered-join` clause in _generated honeysql_
2. order of joins in _generated sql_ is correct
3. query execution _returns expected results_

At first I've expected that implementing the fix would require more adjusments to existing tests. It turned out that only `metabase.driver.oracle-test/honeysql-test` explicitly compares generated honeysql. Hence I've updated only this test to handle `:oreder-join`. Other tests I've checked use `sql.qp-test-util/query->sql-map` to retranslate generated sql into "HoneySQL-esque map" so those work properly without any changes.



---

###### Before submitting the PR, please make sure you do the following

- [ ] If you're attempting to fix a translation issue, please submit your changes to our [POEditor project](https://poeditor.com/join/project/ynjQmwSsGh) instead of opening a PR.

### Tests

- [X] Run the frontend and Cypress end-to-end tests with `yarn lint && yarn test`)
- [X] If there are changes to the backend codebase, run the backend tests with `clojure -X:dev:test`
- [X] Sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform)
      (unless it's a tiny documentation change).

### Notes on "Before submitting the PR" responsibilities
#### Backend tests
I've run backend tests locally with following drivers:
- `h2`
- `postgres`
- `mysql`
- `sqlserver`
- `vertica`
- `oracle`
- `sqlite`

Test `metabase.driver.sql-jdbc.connection-test/c3p0-datasource-name-test` has failed for `oracle`. I suspect this failure is happening because my local environment is not setup properly. Test also fails on `master` without my changes. I assume running it in `ci` would produce successful result. In case my assumption is not correct, I'd be willing to investigate further.

All tests but aformentioned one have passed for all drivers listed.

#### Frontend tests
All unit tests have succeeded locally.

Regarding e2e tests, there were few failures (listed below). But the same holds true here, regarding my environment and "further investigation", as with  [Backend tests](#Backend-tests).

Following `specs` have failures:
- `frontend/test/metabase/scenarios/cross-version/source/00-setup.cy.spec.js`
- `frontend/test/metabase/scenarios/cross-version/source/03-questions.cy.spec.js`
- `frontend/test/metabase/scenarios/cross-version/target/smoke.cy.spec.js`
- `frontend/test/metabase/scenarios/onboarding/setup/setup.cy.spec.js`
- `frontend/test/metabase/scenarios/organization/timelines-collection.cy.spec.js`
