### PR TITLE
Fix static viz column formatting

### DIFF
--- a/frontend/src/metabase/lib/formatting/numbers.tsx
+++ b/frontend/src/metabase/lib/formatting/numbers.tsx
@@ -209,7 +209,7 @@ function formatNumberCompactWithoutOptions(value: number) {
   }
 }
 
-// replaces the decimale and grouping separators with those specified by a NumberSeparators option
+// replaces the decimal and grouping separators with those specified by a NumberSeparators option
 function replaceNumberSeparators(formatted: any, separators: any) {
   const [decimalSeparator, groupingSeparator] = (separators || ".,").split("");
 

--- a/frontend/src/metabase/static-viz/components/LineAreaBarChart/constants.ts
+++ b/frontend/src/metabase/static-viz/components/LineAreaBarChart/constants.ts
@@ -4,6 +4,7 @@ export const LINE_AREA_BAR_CHART_TYPE = "combo-chart";
 
 export const LINE_AREA_BAR_DEFAULT_OPTIONS_1 = {
   settings: {
+    show_values: true,
     goal: {
       value: 140,
       label: "Goal",

--- a/frontend/src/metabase/static-viz/lib/numbers.ts
+++ b/frontend/src/metabase/static-viz/lib/numbers.ts
@@ -62,10 +62,13 @@ export const formatNumber = (number: number, options?: NumberFormatOptions) => {
 
   const format = createFormat(compact);
 
+  const separatorMap = {
+    ",": grouping_separator || "",
+    ".": decimal_separator,
+  };
   const formattedNumber = format
     .format(number * scale)
-    .replace(/\./g, decimal_separator)
-    .replace(/,/g, grouping_separator ?? "");
+    .replace(/,|\./g, separator => separatorMap[separator as "." | ","]);
 
   return `${prefix}${formattedNumber}${suffix}`;
 };

--- a/frontend/src/metabase/static-viz/lib/numbers.unit.spec.js
+++ b/frontend/src/metabase/static-viz/lib/numbers.unit.spec.js
@@ -100,6 +100,16 @@ describe("formatNumber", () => {
     expect(text).toEqual("10000.11");
   });
 
+  it("should format `,.` number separators", () => {
+    const number = 10000.11;
+
+    const text = formatNumber(number, {
+      number_separators: ",.",
+    });
+
+    expect(text).toEqual("10.000,11");
+  });
+
   it("should format small number", () => {
     expect(formatNumber(0.00196)).toEqual("0.002");
     expect(formatNumber(0.00201)).toEqual("0.002");

--- a/frontend/src/metabase/visualizations/lib/settings/series.js
+++ b/frontend/src/metabase/visualizations/lib/settings/series.js
@@ -20,7 +20,7 @@ export function seriesSetting({
   ...def
 } = {}) {
   const settingId = "series_settings";
-  const colorSettingId = `${settingId}.colors`;
+  const colorSettingId = "series_settings.colors";
 
   const COMMON_SETTINGS = {
     // title, display, and color don't need widgets because they're handled direclty in ChartNestedSettingSeries


### PR DESCRIPTION
Epic: https://github.com/metabase/metabase/issues/24759

From https://github.com/metabase/metabase/pull/25493 There are 2 tasks at the end of that PR.
1. series colors not always correct when defaults used (FE/BE)
    1. This is not trivial to fix as there are hard-coded colors on the backend and dynamic settings that's calculated on FE and those settings couldn't be easily imported to static viz code meaning that we either have to reimplement them or extract the logic to a shared module, either way, they're not trivial.
1. currency style (symbol,code,name, and currency) seems inconsistent (FE)
    1. While I couldn't reliably reproduce this, I have found at least one case that the number separator doesn't look right in static viz.

#### Dashboard
![image](https://user-images.githubusercontent.com/1937582/198210963-ecee33b9-9f0d-40bc-9d70-139f24c9e319.png)

#### After
![image](https://user-images.githubusercontent.com/1937582/198211045-4fb570a3-9125-4ee0-bb10-047db4126c7b.png)

#### Before
![image](https://user-images.githubusercontent.com/1937582/198211379-0491066b-e224-4437-9ce9-b9997ea5d61a.png)

You can see that with this settings 
![image](https://user-images.githubusercontent.com/1937582/198211528-90272930-b0f5-4098-aed1-f5c7fc3d1405.png)

The static viz numbers weren't formatted correctly (**1.248.96** instead of **1.245,96**), this was because the code was replacing the decimal point and group separator separately rather than replacing both of them in one go.
https://github.com/metabase/metabase/blob/a1f0a896293865cc907b4cba5b1040edaba5949f/frontend/src/metabase/static-viz/lib/numbers.ts#L65-L68

