### PR TITLE
Always show "Archive app" action

### DIFF
--- a/frontend/src/metabase/collections/components/CollectionHeader/CollectionHeader.tsx
+++ b/frontend/src/metabase/collections/components/CollectionHeader/CollectionHeader.tsx
@@ -25,7 +25,6 @@ export interface CollectionHeaderProps {
 
 const CollectionHeader = ({
   collection,
-  location,
   isAdmin,
   isBookmarked,
   isPersonalCollectionChild,
@@ -49,13 +48,14 @@ const CollectionHeader = ({
           onCreateBookmark={onCreateBookmark}
           onDeleteBookmark={onDeleteBookmark}
         />
-        <CollectionMenu
-          collection={collection}
-          isAdmin={isAdmin}
-          isDataApp={isDataApp}
-          isPersonalCollectionChild={isPersonalCollectionChild}
-          onUpdateCollection={onUpdateCollection}
-        />
+        {!isDataApp && (
+          <CollectionMenu
+            collection={collection}
+            isAdmin={isAdmin}
+            isPersonalCollectionChild={isPersonalCollectionChild}
+            onUpdateCollection={onUpdateCollection}
+          />
+        )}
       </HeaderActions>
     </HeaderRoot>
   );

--- a/frontend/src/metabase/collections/components/CollectionHeader/CollectionMenu.tsx
+++ b/frontend/src/metabase/collections/components/CollectionHeader/CollectionMenu.tsx
@@ -16,7 +16,6 @@ export interface CollectionMenuProps {
   collection: Collection;
   isAdmin: boolean;
   isPersonalCollectionChild: boolean;
-  isDataApp: boolean;
   onUpdateCollection: (entity: Collection, values: Partial<Collection>) => void;
 }
 
@@ -24,13 +23,10 @@ const CollectionMenu = ({
   collection,
   isAdmin,
   isPersonalCollectionChild,
-  isDataApp,
   onUpdateCollection,
 }: CollectionMenuProps): JSX.Element | null => {
   const items = [];
-  const url = isDataApp
-    ? Urls.collection(_.omit(collection, "app_id"))
-    : Urls.collection(collection);
+  const url = Urls.collection(collection);
   const isRoot = isRootCollection(collection);
   const isPersonal = isPersonalCollection(collection);
   const canWrite = collection.can_write;
@@ -44,7 +40,7 @@ const CollectionMenu = ({
     );
   }
 
-  if (isAdmin && !isPersonal && !isPersonalCollectionChild && !isDataApp) {
+  if (isAdmin && !isPersonal && !isPersonalCollectionChild) {
     items.push({
       title: t`Edit permissions`,
       icon: "lock",
@@ -54,20 +50,20 @@ const CollectionMenu = ({
   }
 
   if (!isRoot && !isPersonal && canWrite) {
-    if (!isDataApp) {
-      items.push({
+    items.push(
+      {
         title: t`Move`,
         icon: "move",
         link: `${url}/move`,
         event: `${ANALYTICS_CONTEXT};Edit Menu;Move Collection`,
-      });
-    }
-    items.push({
-      title: t`Archive`,
-      icon: "archive",
-      link: `${url}/archive`,
-      event: `${ANALYTICS_CONTEXT};Edit Menu;Archive Collection`,
-    });
+      },
+      {
+        title: t`Archive`,
+        icon: "archive",
+        link: `${url}/archive`,
+        event: `${ANALYTICS_CONTEXT};Edit Menu;Archive Collection`,
+      },
+    );
   }
 
   if (items.length > 0) {

--- a/frontend/src/metabase/nav/containers/MainNavbar/DataAppNavbar/DataAppActionPanel/DataAppActionPanel.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/DataAppNavbar/DataAppActionPanel/DataAppActionPanel.tsx
@@ -7,14 +7,14 @@ import Tooltip from "metabase/components/Tooltip";
 
 import * as Urls from "metabase/lib/urls";
 
-import type { DataApp, DataAppPage } from "metabase-types/api";
+import type { DataApp } from "metabase-types/api";
 
 import { Root } from "./DataAppActionPanel.styled";
 
 interface Props {
   dataApp: DataApp;
-  selectedPageId?: DataAppPage["id"];
-  archiveActionTarget: "app" | "page";
+  hasEditPageAction?: boolean;
+  hasArchivePageAction?: boolean;
   hasManageContentAction?: boolean;
   onEditAppPage: () => void;
   onEditAppSettings: () => void;
@@ -31,16 +31,14 @@ type MenuItem = {
 
 function DataAppActionPanel({
   dataApp,
-  selectedPageId,
-  archiveActionTarget,
+  hasEditPageAction = true,
+  hasArchivePageAction = true,
   hasManageContentAction = true,
   onEditAppPage,
   onEditAppSettings,
   onArchiveApp,
   onArchivePage,
 }: Props) {
-  const hasSelectedPage = typeof selectedPageId === "number";
-
   const menuItems = useMemo(() => {
     const items: MenuItem[] = [
       {
@@ -58,20 +56,24 @@ function DataAppActionPanel({
       });
     }
 
-    if (hasSelectedPage) {
-      const isArchiveApp = archiveActionTarget === "app";
+    if (hasArchivePageAction) {
       items.push({
-        title: isArchiveApp ? t`Archive this app` : t`Archive this page`,
+        title: t`Archive this page`,
         icon: "archive",
-        action: isArchiveApp ? onArchiveApp : onArchivePage,
+        action: onArchivePage,
       });
     }
+
+    items.push({
+      title: t`Archive this app`,
+      icon: "archive",
+      action: onArchiveApp,
+    });
 
     return items;
   }, [
     dataApp,
-    archiveActionTarget,
-    hasSelectedPage,
+    hasArchivePageAction,
     hasManageContentAction,
     onEditAppSettings,
     onArchiveApp,
@@ -80,7 +82,7 @@ function DataAppActionPanel({
 
   return (
     <Root>
-      {hasSelectedPage && (
+      {hasEditPageAction && (
         <Tooltip tooltip={t`Edit page`}>
           <Button icon="pencil" onlyIcon onClick={onEditAppPage} />
         </Tooltip>

--- a/frontend/src/metabase/nav/containers/MainNavbar/DataAppNavbar/DataAppNavbarView.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/DataAppNavbar/DataAppNavbarView.tsx
@@ -80,6 +80,13 @@ function DataAppNavbarView({
     [dataApp, pageMap, dataAppPage],
   );
 
+  const hasSelectedPage = !!dataAppPage?.id;
+
+  // Archiving last app page would lead a user into a weird app state
+  // For now we'd just hide the action when there's only one top-level page left
+  // and only let people archive the whole app instead
+  const hasArchivePageAction = hasSelectedPage && navItems.length > 1;
+
   return (
     <Root>
       <NavItemsList>
@@ -90,9 +97,9 @@ function DataAppNavbarView({
       </NavItemsList>
       <DataAppActionPanel
         dataApp={dataApp}
-        selectedPageId={dataAppPage?.id as DataAppPageId}
-        archiveActionTarget={navItems.length > 1 ? "page" : "app"}
+        hasEditPageAction={hasSelectedPage}
         hasManageContentAction={mode !== "manage-content"}
+        hasArchivePageAction={hasArchivePageAction}
         onEditAppPage={onEditAppPage}
         onEditAppSettings={onEditAppSettings}
         onArchiveApp={onArchiveApp}


### PR DESCRIPTION
#26095 made it possible to archive data app pages. We don't have a UI state for apps without any pages yet, so what we decided to do for now is to replace the "Archive page" action with the "Archive app" action when there's only one top-level page left to archive.

We figured it would make sense to keep the archive app actions at hand all the time, so this PR puts it in the menu. We'd still hide the "Archive page" action when there's only one top-level page left. Also, that allows up to remove the "..." menu in the app content view that was only holding the archive app button all that time.

### To Verify

1. New > App > Pick a few tables > Create
2. Open a page, click "..." at the top right, and ensure you see both "Archive page" and "Archive app" actions
3. Archive a few pages, and make sure everything works correctly
4. When there's only one top-level page left (in the app navbar), click "..." and make sure the "Archive page" action is gone, and you can only archive the whole app
5. Pick "Manage content" from the "..." menu and make sure there's no "..." menu in the collection view itself
6. Archive the app, and make sure it works as it should

### Demo

https://user-images.githubusercontent.com/17258145/198038148-89c47644-9951-4cd4-8768-ff7d8ceb721a.mp4

