### PR TITLE
Fix can't change title template for raw data app pages

### DIFF
--- a/frontend/src/metabase/dashboard/actions/save.js
+++ b/frontend/src/metabase/dashboard/actions/save.js
@@ -190,14 +190,20 @@ export const saveDashboardAndCards = createThunkAction(
 );
 
 function updateDataAppPageTitle(dataApp, pageId, titleTemplate) {
-  const navItems = dataApp.nav_items.map(navItem => {
-    if (navItem.page_id === pageId) {
-      return {
-        ...navItem,
-        title_template: titleTemplate,
-      };
-    }
-    return navItem;
-  });
-  return DataApps.actions.update({ id: dataApp.id, nav_items: navItems });
+  const nextNavItems = [...dataApp.nav_items];
+  const targetIndex = nextNavItems.findIndex(item => item.id === pageId);
+
+  if (targetIndex !== -1) {
+    nextNavItems[targetIndex] = {
+      ...nextNavItems[targetIndex],
+      title_template: titleTemplate,
+    };
+  } else {
+    nextNavItems.push({
+      page_id: pageId,
+      title_template: titleTemplate,
+    });
+  }
+
+  return DataApps.actions.update({ id: dataApp.id, nav_items: nextNavItems });
 }

--- a/frontend/src/metabase/dashboard/actions/save.js
+++ b/frontend/src/metabase/dashboard/actions/save.js
@@ -191,7 +191,7 @@ export const saveDashboardAndCards = createThunkAction(
 
 function updateDataAppPageTitle(dataApp, pageId, titleTemplate) {
   const nextNavItems = [...dataApp.nav_items];
-  const targetIndex = nextNavItems.findIndex(item => item.id === pageId);
+  const targetIndex = nextNavItems.findIndex(item => item.page_id === pageId);
 
   if (targetIndex !== -1) {
     nextNavItems[targetIndex] = {

--- a/frontend/src/metabase/nav/containers/MainNavbar/DataAppNavbar/DataAppNavbarContainer.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/DataAppNavbar/DataAppNavbarContainer.tsx
@@ -14,13 +14,13 @@ import DataApps, {
   getPreviousNavItem,
   isTopLevelNavItem,
 } from "metabase/entities/data-apps";
-import Dashboards from "metabase/entities/dashboards";
 import Search from "metabase/entities/search";
 
 import { setEditingDashboard as setEditingDataAppPage } from "metabase/dashboard/actions";
 
 import ArchiveDataAppModal from "metabase/writeback/containers/ArchiveDataAppModal";
 import ArchiveDataAppPageModal from "metabase/writeback/containers/ArchiveDataAppPageModal";
+import CreateDataAppPageModalForm from "metabase/writeback/containers/CreateDataAppPageModalForm";
 import ScaffoldDataAppPagesModal from "metabase/writeback/containers/ScaffoldDataAppPagesModal";
 
 import type { DataApp, DataAppPage } from "metabase-types/api";
@@ -202,14 +202,10 @@ function DataAppNavbarContainer({
     }
     if (modal === "MODAL_NEW_PAGE") {
       return (
-        <Dashboards.ModalForm
-          form={Dashboards.forms.dataAppPage}
-          title={t`New page`}
-          dashboard={{
-            collection_id: dataApp.collection_id,
-          }}
+        <CreateDataAppPageModalForm
+          dataApp={dataApp}
           onClose={closeModal}
-          onSaved={(page: DataAppPage) => {
+          onSave={(page: DataAppPage) => {
             closeModal();
             onChangeLocation(Urls.dataAppPage(dataApp, page));
           }}

--- a/frontend/src/metabase/writeback/containers/CreateDataAppPageModalForm.tsx
+++ b/frontend/src/metabase/writeback/containers/CreateDataAppPageModalForm.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+import { t } from "ttag";
+
+import Dashboards from "metabase/entities/dashboards";
+
+import type { DataApp, DataAppPage } from "metabase-types/api";
+
+interface Props {
+  dataApp: DataApp;
+  onSave: (dataAppPage: DataAppPage) => void;
+  onClose: () => void;
+}
+
+function CreateDataAppPageModalForm({ dataApp, onSave, onClose }: Props) {
+  return (
+    <Dashboards.ModalForm
+      form={Dashboards.forms.dataAppPage}
+      title={t`New page`}
+      dashboard={{
+        collection_id: dataApp.collection_id,
+      }}
+      onClose={onClose}
+      onSaved={onSave}
+    />
+  );
+}
+
+export default CreateDataAppPageModalForm;

--- a/frontend/src/metabase/writeback/containers/CreateDataAppPageModalForm.tsx
+++ b/frontend/src/metabase/writeback/containers/CreateDataAppPageModalForm.tsx
@@ -1,17 +1,45 @@
-import React from "react";
+import React, { useCallback } from "react";
 import { t } from "ttag";
+import { connect } from "react-redux";
 
+import DataApps from "metabase/entities/data-apps";
 import Dashboards from "metabase/entities/dashboards";
 
 import type { DataApp, DataAppPage } from "metabase-types/api";
 
-interface Props {
+interface OwnProps {
   dataApp: DataApp;
   onSave: (dataAppPage: DataAppPage) => void;
   onClose: () => void;
 }
 
-function CreateDataAppPageModalForm({ dataApp, onSave, onClose }: Props) {
+interface DispatchProps {
+  handleUpdateDataApp: (
+    dataApp: Partial<DataApp> & { id: DataApp["id"] },
+  ) => void;
+}
+
+type Props = OwnProps & DispatchProps;
+
+const mapDispatchToProps = {
+  handleUpdateDataApp: DataApps.actions.update,
+};
+
+function CreateDataAppPageModalForm({
+  dataApp,
+  handleUpdateDataApp,
+  onSave,
+  onClose,
+}: Props) {
+  const onSaved = useCallback(
+    (dataAppPage: DataAppPage) => {
+      const navItems = [...dataApp.nav_items, { page_id: dataAppPage.id }];
+      handleUpdateDataApp({ id: dataApp.id, nav_items: navItems });
+      onSave(dataAppPage);
+    },
+    [dataApp, handleUpdateDataApp, onSave],
+  );
+
   return (
     <Dashboards.ModalForm
       form={Dashboards.forms.dataAppPage}
@@ -20,9 +48,9 @@ function CreateDataAppPageModalForm({ dataApp, onSave, onClose }: Props) {
         collection_id: dataApp.collection_id,
       }}
       onClose={onClose}
-      onSaved={onSave}
+      onSaved={onSaved}
     />
   );
 }
 
-export default CreateDataAppPageModalForm;
+export default connect(null, mapDispatchToProps)(CreateDataAppPageModalForm);


### PR DESCRIPTION
Fixes it's impossible to set `title_template` (from #25938) for data app pages created via "Add > Page" vs. "Add > Data" flow.

The issue is that `title_template` is set on a data app nav item vs. page (dashboard) record, and we don't create nav items automatically for pages created via the "Add > Page" flow. The PR should fix this by doing two things:

* extending `updateDataAppPageTitle` to check if there's a nav item for a page we're working with. If there's none, we're going to create one and push it to the very end of the app's `nav_items` list
* extending the "New page" form to create a nav item for a recently created page

### To Verify

1. New > App > Pick a few tables > Create
2. Click the plus button at the navbar, pick "Page", fill in a name, and click "Save"
3. Click the pencil button in the navbar to enter the editing mode
4. Click the page title, change it to something else, and click "Save"
5. Ensure the title change is persisted