### PR TITLE
Fix BulkFilterModal breaking "between" custom expressions

### DIFF
--- a/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterModal/utils.ts
+++ b/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterModal/utils.ts
@@ -11,7 +11,9 @@ import type Dimension from "metabase-lib/lib/Dimension";
 export function fixBetweens(query: StructuredQuery): StructuredQuery {
   const betweenFilters = query
     .filters()
-    .filter(filter => filter.operatorName() === "between");
+    .filter(
+      filter => filter.isStandard() && filter.operatorName() === "between",
+    );
 
   // find the first invalid filter (if any), and fix it recursively
   for (const filter of betweenFilters) {

--- a/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterModal/utils.unit.spec.ts
+++ b/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterModal/utils.unit.spec.ts
@@ -1,4 +1,8 @@
-import { SAMPLE_DATABASE, ORDERS } from "__support__/sample_database_fixture";
+import {
+  SAMPLE_DATABASE,
+  ORDERS,
+  PEOPLE,
+} from "__support__/sample_database_fixture";
 
 import StructuredQuery, {
   isDimensionOption,
@@ -138,7 +142,7 @@ describe("BulkFilterModal utils", () => {
       expect(newFilter.operatorName()).toEqual("between");
     });
 
-    it("ignores non-betwee filters", () => {
+    it("ignores non-between filters", () => {
       const filter = new Filter(
         ["=", ["field", ORDERS.fields[1].id, null], 40, 50],
         null,
@@ -149,6 +153,24 @@ describe("BulkFilterModal utils", () => {
       const newFilter = newQuery.filters()[0];
       expect(newFilter.arguments()).toEqual([40, 50]);
       expect(newFilter.operatorName()).toEqual("=");
+    });
+
+    it("ignores between custom expressions", () => {
+      const filter = new Filter(
+        [
+          "between",
+          ["field", ORDERS.CREATED_AT.id, null],
+          ["field", PEOPLE.BIRTH_DATE.id, { "source-field": PEOPLE.ID.id }],
+          ["field", PEOPLE.CREATED_AT.id, { "source-field": PEOPLE.ID.id }],
+        ],
+        null,
+        query,
+      );
+
+      const newQuery = fixBetweens(filter.add());
+      const newFilter = newQuery.filters()[0];
+
+      expect(newFilter).toEqual(filter);
     });
 
     it("handles multiple invalid between filters", () => {


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/26025

How to test:
- Follow the steps from the issue
- There is also a unit test for the fixed behavior