### PR TITLE
Fix scrolling table list in scaffolding data picker

### DIFF
--- a/frontend/src/metabase/containers/DataPicker/PanePicker/PanePicker.styled.tsx
+++ b/frontend/src/metabase/containers/DataPicker/PanePicker/PanePicker.styled.tsx
@@ -54,4 +54,5 @@ export const TreeContainer = styled.div``;
 export const RightPaneContainer = styled.div`
   display: flex;
   flex: 1;
+  overflow-y: scroll;
 `;


### PR DESCRIPTION
Just adding an `overflow: scroll`