### PR TITLE
Fix can't select nested collection in scaffolding data picker

### DIFF
--- a/frontend/src/metabase/containers/DataPicker/CardPicker/CardPickerContainer.tsx
+++ b/frontend/src/metabase/containers/DataPicker/CardPicker/CardPickerContainer.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/prop-types */
 import React, { useCallback, useMemo } from "react";
 import _ from "underscore";
 import { connect } from "react-redux";
@@ -36,6 +35,7 @@ interface CardPickerStateProps {
 }
 
 interface CollectionsLoaderProps {
+  collectionTree: Collection[];
   collections: Collection[];
   rootCollection: Collection;
 }
@@ -58,6 +58,7 @@ function mapStateToProps(state: State) {
 function CardPickerContainer({
   value,
   collections,
+  collectionTree,
   rootCollection,
   schema: selectedSchema,
   currentUser,
@@ -77,15 +78,15 @@ function CardPickerContainer({
     [collections],
   );
 
-  const collectionTree = useMemo(
+  const tree = useMemo(
     () =>
       buildCollectionTree({
-        collections,
+        collections: collectionTree,
         rootCollection,
         currentUser,
         targetModel,
       }),
-    [collections, rootCollection, currentUser, targetModel],
+    [collectionTree, rootCollection, currentUser, targetModel],
   );
 
   const selectedItems = useMemo(() => {
@@ -128,7 +129,7 @@ function CardPickerContainer({
 
   return (
     <CardPickerView
-      collectionTree={collectionTree}
+      collectionTree={tree}
       virtualTables={selectedSchema?.tables}
       selectedItems={selectedItems}
       targetModel={targetModel}
@@ -147,6 +148,10 @@ export default _.compose(
   }),
   Collections.loadList({
     query: () => ({ tree: true }),
+    listName: "collectionTree",
+  }),
+  Collections.loadList({
+    listName: "collections",
   }),
   Schemas.load({
     id: (state: State, props: CardPickerOwnProps) => props.value.schemaId,


### PR DESCRIPTION
Fixes it's impossible to select a nested collection in the scaffolding data picker

When a collection is clicked, it triggers the `handleSelectedCollectionChange` callback. The callback only receives the collection ID, and it checks we have this collection in the `collectionMap` ([here](https://github.com/metabase/metabase/blob/0dbc8b9a27c66d028ed24502d5544b3f0e6a4b7b/frontend/src/metabase/containers/DataPicker/CardPicker/CardPickerContainer.tsx#L112)). Because we use the "tree" collection list endpoint, nested collections don't appear on the top level of the list, but they're packed into parent collection's `children` list. To fix this, the PR fetches a flat collection list and uses it to build the collection map instead of a tree representation. Perhaps we should come up with a selector that'd build a flat list out of a tree, but we can tackle it as an optimization later IMO.

### To Verify

1. Put a model into a nested collection (e.g. root > models > e-commerce models > order model)
2. New > App > Models
3. Try to pick your model using the pane picker
4. It should work