### PR TITLE
Support filtering apps using a given model

### DIFF
--- a/src/metabase/api/app.clj
+++ b/src/metabase/api/app.clj
@@ -3,6 +3,7 @@
     [clojure.string :as str]
     [clojure.walk :as walk]
     [compojure.core :refer [POST PUT]]
+    [honeysql.helpers :as hh]
     [medley.core :as m]
     [metabase.api.card :as api.card]
     [metabase.api.collection :as api.collection]
@@ -61,22 +62,53 @@
   (db/update! App app-id (select-keys body [:dashboard_id :options :nav_items]))
   (hydrate-details (db/select-one App :id app-id)))
 
+(defn- using-model-condition [model-id]
+  (let [model-ref-condition
+        [:or
+         [:= :c.id model-id]
+         [:like :c.dataset_query (format "%%card__%s%%" model-id)]
+         [:like :c.dataset_query (format "%%#%s%%" model-id)]]]
+    [:exists
+     {:union-all [;; the model or a question (possibly) with the model in the app collection
+                  {:select [0]
+                   :from [[:report_card :c]]
+                   :where [:and
+                           [:= :c.collection_id :app.collection_id]
+                           model-ref-condition]}
+                  ;; the model or a question (possibly) with the model on a dashboard in the app collection
+                  {:select [0]
+                   :from [[:report_card :c]]
+                   :join [[:report_dashboardcard :dc] [:= :dc.card_id :c.id]
+                          [:report_dashboard :d] [:= :d.id :dc.dashboard_id]]
+                   :where [:and
+                           [:= :d.collection_id :app.collection_id]
+                           model-ref-condition]}]}]))
+
 (api/defendpoint GET "/"
   "Fetch a list of all Apps that the current user has read permissions for.
 
   By default, this returns Apps with non-archived Collections, but instead you can show archived ones by passing
-  `?archived=true`."
-  [archived]
-  {archived (s/maybe su/BooleanString)}
-  (let [archived? (Boolean/parseBoolean archived)]
-    (hydrate-details
-     (db/select [App :app.*]
-       {:left-join [:collection [:= :collection.id :app.collection_id]]
-        :where    [:and
-                   [:= :collection.archived archived?]
-                   (collection/visible-collection-ids->honeysql-filter-clause
-                    (collection/permissions-set->visible-collection-ids @api/*current-user-permissions-set*))]
-        :order-by [[:%lower.collection.name :asc]]}))))
+  `archived=true`. By specifying `using_model=<model-id>` the list can be restricted to the apps using the given
+  model."
+  [archived using_model]
+  {archived    (s/maybe su/BooleanString)
+   using_model (s/maybe su/IntStringGreaterThanZero)}
+  (let [archived? (Boolean/parseBoolean archived)
+        using-model (some-> using_model parse-long)
+        candidates (db/select [App :app.*]
+                     (cond-> {:left-join [:collection [:= :collection.id :app.collection_id]]
+                              :where [:and
+                                      [:= :collection.archived archived?]
+                                      (-> @api/*current-user-permissions-set*
+                                          collection/permissions-set->visible-collection-ids
+                                          collection/visible-collection-ids->honeysql-filter-clause)]
+                              :order-by [[:%lower.collection.name :asc]]}
+                       using-model (hh/merge-where (using-model-condition using-model))))]
+    (if using-model
+      ;; make sure the returned apps really use the specified model
+      (filter (fn [{:keys [models]}] (some #{using-model} (map :id models)))
+              (hydrate-details candidates :models))
+      (hydrate-details candidates))))
 
 (api/defendpoint GET "/:id"
   "Fetch a specific App"

--- a/src/metabase/models/app.clj
+++ b/src/metabase/models/app.clj
@@ -1,5 +1,6 @@
 (ns metabase.models.app
-  (:require [metabase.models.collection :as collection :refer [Collection]]
+  (:require [metabase.models.card :as card :refer [Card]]
+            [metabase.models.collection :as collection :refer [Collection]]
             [metabase.models.interface :as mi]
             [metabase.models.query :as query]
             [metabase.models.serialization.hash :as serdes.hash]
@@ -58,24 +59,22 @@
   (->> (db/query {:union
                   [{:select [:c.*]
                     :from [[:report_card :c]]
-                    :where [:and
-                            [:= :c.collection_id (:collection_id app)]]}
+                    :where [:= :c.collection_id (:collection_id app)]}
                    {:select [:c.*]
                     :from [[:report_card :c]]
                     :join [[:report_dashboardcard :dc] [:= :dc.card_id :c.id]
                            [:report_dashboard :d] [:= :d.id :dc.dashboard_id]]
-                    :where [:and
-                            [:= :d.collection_id (:collection_id app)]]}]})
-       (db/do-post-select 'Card)))
+                    :where [:= :d.collection_id (:collection_id app)]}]})
+       (db/do-post-select Card)))
 
 (defn- referenced-models [cards]
   (when-let [model-ids
              (->> cards
                   (into #{} (mapcat (comp query/collect-card-ids :dataset_query)))
                   not-empty)]
-    (db/select 'Card {:where [:and
-                              [:in :id model-ids]
-                              :dataset]})))
+    (db/select Card {:where [:and
+                             [:in :id model-ids]
+                             :dataset]})))
 
 (defn add-models
   "Add the fully hydrated models used by the app."


### PR DESCRIPTION
On the model details page we would like to list the apps using the model.
This PR adds a filtering option to the endpoint for listing apps.

The logic implemented here is intended to be the inverse of the logic
for getting the models for a given app (see #25823).