### PR TITLE
Use proper data app page URLs in recent & popular items

### DIFF
--- a/frontend/src/metabase/home/components/RecentViews.jsx
+++ b/frontend/src/metabase/home/components/RecentViews.jsx
@@ -31,6 +31,8 @@ export default class RecentViews extends Component {
       return "dashboard";
     } else if (model === "dataset") {
       return "model";
+    } else if (model === "page") {
+      return "document";
     } else if (model === "table") {
       return "database";
     } else {

--- a/frontend/src/metabase/lib/urls/misc.js
+++ b/frontend/src/metabase/lib/urls/misc.js
@@ -1,4 +1,5 @@
 import { dashboard } from "./dashboards";
+import { dataAppPage } from "./dataApps";
 import { question, dataset, tableRowsQuery } from "./questions";
 import { pulse } from "./pulses";
 
@@ -29,7 +30,7 @@ export function modelToUrl(item) {
     case "dashboard":
       return dashboard(modelData);
     case "page":
-      return dashboard(modelData);
+      return dataAppPage({ id: modelData.app_id }, { id: modelData.id });
     case "pulse":
       return pulse(modelData.id);
     case "table":


### PR DESCRIPTION
Fixes we were using a dashboard URL builder for data app pages. This resulted in pages opened from recent/popular item sections being open at `/dashboard/:id` instead of `/a/:appId/page/:pageId`

### To Verify

1. Play around with an app, jump between a few pages
2. Focus on the main search input (don't fill in any search queries)
3. Click one of the page links in the recent items section that shows up
4. Make sure you're now at `/a/:appId/page/:pageId` and the app functions correctly

### Demo

**Before**

https://user-images.githubusercontent.com/17258145/198289761-b53bf306-778c-45e7-a3f1-74615758a836.mp4

**After**

https://user-images.githubusercontent.com/17258145/198289850-3a3531f0-5f08-4c4a-81d4-bdc5f9fe0542.mp4

