### PR TITLE
Serdes v2: Fixing some more cases of malformed SQL with empty databases

### DIFF
--- a/src/metabase/models/dashboard_card.clj
+++ b/src/metabase/models/dashboard_card.clj
@@ -224,7 +224,8 @@
 (defmethod serdes.base/extract-query "DashboardCard" [_ {:keys [collection-set]}]
   (if (seq collection-set)
     (let [dashboards (db/select-ids 'Dashboard :collection_id [:in collection-set])]
-      (db/select-reducible DashboardCard :dashboard_id [:in dashboards]))
+      (when (seq dashboards)
+        (db/select-reducible DashboardCard :dashboard_id [:in dashboards])))
     (db/select-reducible DashboardCard)))
 
 (defmethod serdes.base/serdes-dependencies "DashboardCard"


### PR DESCRIPTION
Mostly this was caused by `:id [:in []]` empty lists if eg. you don't
have any non-personal collections, or no dashboards exist.

Also I broke the argument passing to the selective dump command
`extract-subtrees` a while back and this fixes it.
