### PR TITLE
Add "Apps" tab to model detail page

### DIFF
--- a/frontend/src/metabase/models/components/ModelDetailPage/ModelApps/ModelApps.styled.tsx
+++ b/frontend/src/metabase/models/components/ModelDetailPage/ModelApps/ModelApps.styled.tsx
@@ -1,0 +1,27 @@
+import styled from "@emotion/styled";
+
+import Link from "metabase/core/components/Link";
+
+import { color } from "metabase/lib/colors";
+
+export const AppTitle = styled.span`
+  font-weight: 700;
+`;
+
+export const AppListItem = styled(Link)`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+
+  width: 100%;
+  border-radius: 8px;
+  padding: 1rem 0.5rem;
+
+  ${AppTitle} {
+    margin-left: 1rem;
+  }
+
+  &:hover {
+    background-color: ${color("brand-light")};
+  }
+`;

--- a/frontend/src/metabase/models/components/ModelDetailPage/ModelApps/ModelApps.tsx
+++ b/frontend/src/metabase/models/components/ModelDetailPage/ModelApps/ModelApps.tsx
@@ -1,0 +1,61 @@
+import React from "react";
+import { t } from "ttag";
+
+import Icon from "metabase/components/Icon";
+
+import DataApps from "metabase/entities/data-apps";
+
+import * as Urls from "metabase/lib/urls";
+
+import type { DataApp } from "metabase-types/api";
+import type { State } from "metabase-types/store";
+import type Question from "metabase-lib/Question";
+
+import {
+  EmptyStateContainer,
+  EmptyStateTitle,
+} from "../ModelDetailPage.styled";
+import { AppListItem, AppTitle } from "./ModelApps.styled";
+
+interface OwnProps {
+  model: Question;
+}
+
+interface DataAppsLoaderProps {
+  dataApps: DataApp[];
+}
+
+type Props = OwnProps & DataAppsLoaderProps;
+
+function ModelApps({ dataApps }: Props) {
+  if (dataApps.length === 0) {
+    return (
+      <EmptyStateContainer>
+        <EmptyStateTitle>{t`This model is not used in any apps yet.`}</EmptyStateTitle>
+      </EmptyStateContainer>
+    );
+  }
+
+  return (
+    <ul>
+      {dataApps.map(dataApp => (
+        <li key={dataApp.id}>
+          <AppListItem to={Urls.dataApp(dataApp)}>
+            <Icon name="star" />
+            <AppTitle>{dataApp.collection.name}</AppTitle>
+          </AppListItem>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function getDataAppsQuery(state: State, { model }: OwnProps) {
+  return {
+    using_model: model.id(),
+  };
+}
+
+export default DataApps.loadList({
+  query: getDataAppsQuery,
+})(ModelApps);

--- a/frontend/src/metabase/models/components/ModelDetailPage/ModelApps/index.ts
+++ b/frontend/src/metabase/models/components/ModelDetailPage/ModelApps/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ModelApps";

--- a/frontend/src/metabase/models/components/ModelDetailPage/ModelDetailPage.tsx
+++ b/frontend/src/metabase/models/components/ModelDetailPage/ModelDetailPage.tsx
@@ -12,6 +12,7 @@ import type Question from "metabase-lib/Question";
 import type Table from "metabase-lib/metadata/Table";
 
 import ModelActionDetails from "./ModelActionDetails";
+import ModelApps from "./ModelApps";
 import ModelInfoSidePanel from "./ModelInfoSidePanel";
 import ModelSchemaDetails from "./ModelSchemaDetails";
 import ModelUsageDetails from "./ModelUsageDetails";
@@ -31,7 +32,7 @@ interface Props {
   onChangeModel: (model: Card) => void;
 }
 
-type ModelTab = "schema" | "actions" | "usage";
+type ModelTab = "schema" | "actions" | "usage" | "apps";
 
 function ModelDetailPage({ model, mainTable, onChangeModel }: Props) {
   const [tab, setTab] = useState<ModelTab>("usage");
@@ -79,6 +80,7 @@ function ModelDetailPage({ model, mainTable, onChangeModel }: Props) {
               { value: "usage", name: t`Used by` },
               { value: "schema", name: t`Schema` },
               { value: "actions", name: t`Actions` },
+              { value: "apps", name: t`Apps` },
             ]}
             onChange={tab => setTab(tab as ModelTab)}
           />
@@ -90,6 +92,9 @@ function ModelDetailPage({ model, mainTable, onChangeModel }: Props) {
           </TabPanel>
           <TabPanel value="actions">
             <ModelActionDetails modelId={model.id()} />
+          </TabPanel>
+          <TabPanel value="apps">
+            <ModelApps model={model} />
           </TabPanel>
         </TabContent>
       </ModelMain>


### PR DESCRIPTION
Adds an "Apps" tab to the model detail page listing apps using a model. Based on an extension to `GET /api/apps` endpoint added in #26124

### To Verify

1. Open a few models from the collection view
2. Click the "Apps" tab
3. Ensure the list makes sense

### Demo

https://user-images.githubusercontent.com/17258145/198312319-6e1b85ca-1ecf-46d3-b8da-3736190b10f1.mp4
