### PR TITLE
Add formik wrappers for basic components

### DIFF
--- a/frontend/src/metabase/auth/components/LoginForm/LoginForm.tsx
+++ b/frontend/src/metabase/auth/components/LoginForm/LoginForm.tsx
@@ -10,13 +10,13 @@ import FormInput from "metabase/core/components/FormInput";
 import FormSubmitButton from "metabase/core/components/FormSubmitButton";
 import { LoginData } from "../../types";
 
-const LdapSchema = Yup.object().shape({
+const LDAP_SCHEMA = Yup.object().shape({
   username: Yup.string().required(t`required`),
   password: Yup.string().required(t`required`),
   remember: Yup.boolean(),
 });
 
-const PasswordSchema = LdapSchema.shape({
+const PASSWORD_SCHEMA = LDAP_SCHEMA.shape({
   username: Yup.string()
     .required(t`required`)
     .email(t`must be a valid email address`),
@@ -43,7 +43,7 @@ const LoginForm = ({
   return (
     <Formik
       initialValues={initialValues}
-      validationSchema={isLdapEnabled ? LdapSchema : PasswordSchema}
+      validationSchema={isLdapEnabled ? LDAP_SCHEMA : PASSWORD_SCHEMA}
       isInitialValid={false}
       onSubmit={handleSubmit}
     >

--- a/frontend/src/metabase/core/components/FormCheckBox/FormCheckBox.tsx
+++ b/frontend/src/metabase/core/components/FormCheckBox/FormCheckBox.tsx
@@ -11,16 +11,16 @@ const FormCheckBox = forwardRef(function FormCheckBox(
   { name, ...props }: FormCheckBoxProps,
   ref: Ref<HTMLLabelElement>,
 ) {
-  const [field] = useField(name);
+  const [{ value, onChange, onBlur }] = useField(name);
 
   return (
     <CheckBox
       {...props}
       ref={ref}
       name={name}
-      checked={field.value}
-      onChange={field.onChange}
-      onBlur={field.onBlur}
+      checked={value}
+      onChange={onChange}
+      onBlur={onBlur}
     />
   );
 });

--- a/frontend/src/metabase/core/components/FormCheckBox/FormCheckBox.unit.spec.tsx
+++ b/frontend/src/metabase/core/components/FormCheckBox/FormCheckBox.unit.spec.tsx
@@ -6,7 +6,7 @@ import userEvent from "@testing-library/user-event";
 import FormField from "metabase/core/components/FormField";
 import FormCheckBox from "./FormCheckBox";
 
-const TestSchema = Yup.object().shape({
+const TEST_SCHEMA = Yup.object().shape({
   value: Yup.boolean().isTrue("error"),
 });
 
@@ -22,7 +22,7 @@ const TestFormCheckBox = ({
   return (
     <Formik
       initialValues={{ value: initialValue }}
-      validationSchema={TestSchema}
+      validationSchema={TEST_SCHEMA}
       onSubmit={onSubmit}
     >
       <Form>

--- a/frontend/src/metabase/core/components/FormCheckBox/FormCheckBox.unit.spec.tsx
+++ b/frontend/src/metabase/core/components/FormCheckBox/FormCheckBox.unit.spec.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { Formik, Form } from "formik";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import FormField from "metabase/core/components/FormField";
+import FormSubmitButton from "metabase/core/components/FormSubmitButton";
+import FormCheckBox from "./FormCheckBox";
+
+describe("FormCheckBox", () => {
+  it("should set the value in the formik context", () => {
+    const initialValues = { remember: false };
+    const onSubmit = jest.fn();
+
+    render(
+      <Formik initialValues={initialValues} onSubmit={onSubmit}>
+        <Form>
+          <FormField name="remember" title="Remember me">
+            <FormCheckBox name="remember" />
+          </FormField>
+          <FormSubmitButton />
+        </Form>
+      </Formik>,
+    );
+
+    userEvent.click(screen.getByLabelText("Remember me"));
+    userEvent.click(screen.getByText("Submit"));
+
+    waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith({ remember: true });
+    });
+  });
+});

--- a/frontend/src/metabase/core/components/FormCheckBox/FormCheckBox.unit.spec.tsx
+++ b/frontend/src/metabase/core/components/FormCheckBox/FormCheckBox.unit.spec.tsx
@@ -1,28 +1,74 @@
 import React from "react";
-import { Formik, Form } from "formik";
+import { Form, Formik } from "formik";
+import * as Yup from "yup";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import FormField from "metabase/core/components/FormField";
 import FormCheckBox from "./FormCheckBox";
 
+const TestSchema = Yup.object().shape({
+  value: Yup.boolean().isTrue("error"),
+});
+
+interface TestFormCheckBoxProps {
+  initialValue?: boolean;
+  onSubmit: () => void;
+}
+
+const TestFormCheckBox = ({
+  initialValue = false,
+  onSubmit,
+}: TestFormCheckBoxProps) => {
+  return (
+    <Formik
+      initialValues={{ value: initialValue }}
+      validationSchema={TestSchema}
+      onSubmit={onSubmit}
+    >
+      <Form>
+        <FormField name="value" title="Label">
+          <FormCheckBox name="value" />
+        </FormField>
+        <button type="submit">Submit</button>
+      </Form>
+    </Formik>
+  );
+};
+
 describe("FormCheckBox", () => {
-  it("should submit the form with the value", () => {
-    const initialValues = { remember: false };
+  it("should use the initial value from the form", () => {
     const onSubmit = jest.fn();
 
-    render(
-      <Formik initialValues={initialValues} onSubmit={onSubmit}>
-        <Form>
-          <FormCheckBox name="remember" />
-          <button type="submit">Submit</button>
-        </Form>
-      </Formik>,
-    );
+    render(<TestFormCheckBox initialValue={true} onSubmit={onSubmit} />);
 
+    expect(screen.getByRole("checkbox")).toBeChecked();
+  });
+
+  it("should propagate the changed value to the form", () => {
+    const onSubmit = jest.fn();
+
+    render(<TestFormCheckBox onSubmit={onSubmit} />);
     userEvent.click(screen.getByRole("checkbox"));
-    userEvent.click(screen.getByText("Submit"));
+    userEvent.click(screen.getByRole("button"));
 
-    waitFor(() => {
-      expect(onSubmit).toHaveBeenCalledWith({ remember: true });
-    });
+    waitFor(() => expect(onSubmit).toHaveBeenCalledWith({ value: true }));
+  });
+
+  it("should be referenced by the label", () => {
+    const onSubmit = jest.fn();
+
+    render(<TestFormCheckBox onSubmit={onSubmit} />);
+
+    expect(screen.getByLabelText("Label")).toBeInTheDocument();
+  });
+
+  it("should be validated on blur", () => {
+    const onSubmit = jest.fn();
+
+    render(<TestFormCheckBox initialValue={true} onSubmit={onSubmit} />);
+    userEvent.click(screen.getByRole("checkbox"));
+    userEvent.tab();
+
+    waitFor(() => expect(screen.getByText("Label: error")).toBeInTheDocument());
   });
 });

--- a/frontend/src/metabase/core/components/FormCheckBox/FormCheckBox.unit.spec.tsx
+++ b/frontend/src/metabase/core/components/FormCheckBox/FormCheckBox.unit.spec.tsx
@@ -2,27 +2,23 @@ import React from "react";
 import { Formik, Form } from "formik";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import FormField from "metabase/core/components/FormField";
-import FormSubmitButton from "metabase/core/components/FormSubmitButton";
 import FormCheckBox from "./FormCheckBox";
 
 describe("FormCheckBox", () => {
-  it("should set the value in the formik context", () => {
+  it("should submit the form with the value", () => {
     const initialValues = { remember: false };
     const onSubmit = jest.fn();
 
     render(
       <Formik initialValues={initialValues} onSubmit={onSubmit}>
         <Form>
-          <FormField name="remember" title="Remember me">
-            <FormCheckBox name="remember" />
-          </FormField>
-          <FormSubmitButton />
+          <FormCheckBox name="remember" />
+          <button type="submit">Submit</button>
         </Form>
       </Formik>,
     );
 
-    userEvent.click(screen.getByLabelText("Remember me"));
+    userEvent.click(screen.getByRole("checkbox"));
     userEvent.click(screen.getByText("Submit"));
 
     waitFor(() => {

--- a/frontend/src/metabase/core/components/FormCheckBox/FormCheckBox.unit.spec.tsx
+++ b/frontend/src/metabase/core/components/FormCheckBox/FormCheckBox.unit.spec.tsx
@@ -49,7 +49,7 @@ describe("FormCheckBox", () => {
 
     render(<TestFormCheckBox onSubmit={onSubmit} />);
     userEvent.click(screen.getByRole("checkbox"));
-    userEvent.click(screen.getByRole("button"));
+    userEvent.click(screen.getByText("Submit"));
 
     waitFor(() => expect(onSubmit).toHaveBeenCalledWith({ value: true }));
   });

--- a/frontend/src/metabase/core/components/FormInput/FormInput.tsx
+++ b/frontend/src/metabase/core/components/FormInput/FormInput.tsx
@@ -11,7 +11,7 @@ const FormInput = forwardRef(function FormInput(
   { name, ...props }: FormInputProps,
   ref: Ref<HTMLInputElement>,
 ) {
-  const [field, meta] = useField(name);
+  const [{ value, onChange, onBlur }, { error, touched }] = useField(name);
 
   return (
     <Input
@@ -19,10 +19,10 @@ const FormInput = forwardRef(function FormInput(
       ref={ref}
       id={name}
       name={name}
-      value={field.value}
-      error={meta.touched && meta.error != null}
-      onChange={field.onChange}
-      onBlur={field.onBlur}
+      value={value}
+      error={touched && error != null}
+      onChange={onChange}
+      onBlur={onBlur}
     />
   );
 });

--- a/frontend/src/metabase/core/components/FormInput/FormInput.unit.spec.tsx
+++ b/frontend/src/metabase/core/components/FormInput/FormInput.unit.spec.tsx
@@ -6,7 +6,7 @@ import userEvent from "@testing-library/user-event";
 import FormField from "metabase/core/components/FormField";
 import FormInput from "./FormInput";
 
-const TestSchema = Yup.object().shape({
+const TEST_SCHEMA = Yup.object().shape({
   value: Yup.string().required("error"),
 });
 
@@ -19,7 +19,7 @@ const TestFormInput = ({ initialValue = "", onSubmit }: TestFormInputProps) => {
   return (
     <Formik
       initialValues={{ value: initialValue }}
-      validationSchema={TestSchema}
+      validationSchema={TEST_SCHEMA}
       onSubmit={onSubmit}
     >
       <Form>

--- a/frontend/src/metabase/core/components/FormInput/FormInput.unit.spec.tsx
+++ b/frontend/src/metabase/core/components/FormInput/FormInput.unit.spec.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+import { Formik, Form } from "formik";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import FormField from "metabase/core/components/FormField";
+import FormSubmitButton from "metabase/core/components/FormSubmitButton";
+import FormInput from "./FormInput";
+
+describe("FormInput", () => {
+  it("should set the value in the formik context", () => {
+    const initialValues = { name: "Orders" };
+    const onSubmit = jest.fn();
+
+    render(
+      <Formik initialValues={initialValues} onSubmit={onSubmit}>
+        <Form>
+          <FormField name="name" title="Name">
+            <FormInput name="name" />
+          </FormField>
+          <FormSubmitButton />
+        </Form>
+      </Formik>,
+    );
+
+    const input = screen.getByLabelText("Name");
+    userEvent.clear(input);
+    userEvent.type(input, "Orders by month");
+    userEvent.click(screen.getByText("Submit"));
+
+    waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith({ name: "Orders by month" });
+    });
+  });
+});

--- a/frontend/src/metabase/core/components/FormInput/FormInput.unit.spec.tsx
+++ b/frontend/src/metabase/core/components/FormInput/FormInput.unit.spec.tsx
@@ -2,8 +2,6 @@ import React from "react";
 import { Formik, Form } from "formik";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import FormField from "metabase/core/components/FormField";
-import FormSubmitButton from "metabase/core/components/FormSubmitButton";
 import FormInput from "./FormInput";
 
 describe("FormInput", () => {
@@ -14,15 +12,13 @@ describe("FormInput", () => {
     render(
       <Formik initialValues={initialValues} onSubmit={onSubmit}>
         <Form>
-          <FormField name="name" title="Name">
-            <FormInput name="name" />
-          </FormField>
-          <FormSubmitButton />
+          <FormInput name="name" />
+          <button type="submit">Submit</button>
         </Form>
       </Formik>,
     );
 
-    const input = screen.getByDisplayValue("Orders");
+    const input = screen.getByRole("textbox");
     userEvent.clear(input);
     userEvent.type(input, "Orders by month");
     userEvent.click(screen.getByText("Submit"));

--- a/frontend/src/metabase/core/components/FormInput/FormInput.unit.spec.tsx
+++ b/frontend/src/metabase/core/components/FormInput/FormInput.unit.spec.tsx
@@ -46,7 +46,7 @@ describe("FormInput", () => {
 
     render(<TestFormInput onSubmit={onSubmit} />);
     userEvent.type(screen.getByRole("textbox"), "Text");
-    userEvent.click(screen.getByRole("button"));
+    userEvent.click(screen.getByText("Submit"));
 
     waitFor(() => expect(onSubmit).toHaveBeenCalledWith({ value: "Text" }));
   });

--- a/frontend/src/metabase/core/components/FormNumericInput/FormNumericInput.tsx
+++ b/frontend/src/metabase/core/components/FormNumericInput/FormNumericInput.tsx
@@ -13,7 +13,7 @@ const FormNumericInput = forwardRef(function FormNumericInput(
   { name, ...props }: FormNumericInputProps,
   ref: Ref<HTMLInputElement>,
 ) {
-  const [field, meta, helpers] = useField(name);
+  const [{ value, onBlur }, { error, touched }, { setValue }] = useField(name);
 
   return (
     <NumericInput
@@ -21,10 +21,10 @@ const FormNumericInput = forwardRef(function FormNumericInput(
       ref={ref}
       id={name}
       name={name}
-      value={field.value}
-      error={meta.touched && meta.error != null}
-      onChange={helpers.setValue}
-      onBlur={field.onBlur}
+      value={value}
+      error={touched && error != null}
+      onChange={setValue}
+      onBlur={onBlur}
     />
   );
 });

--- a/frontend/src/metabase/core/components/FormNumericInput/FormNumericInput.tsx
+++ b/frontend/src/metabase/core/components/FormNumericInput/FormNumericInput.tsx
@@ -1,0 +1,32 @@
+import React, { forwardRef, Ref } from "react";
+import { useField } from "formik";
+import NumericInput, {
+  NumericInputProps,
+} from "metabase/core/components/NumericInput";
+
+export interface FormNumericInputProps
+  extends Omit<NumericInputProps, "value" | "error" | "onChange" | "onBlur"> {
+  name: string;
+}
+
+const FormNumericInput = forwardRef(function FormNumericInput(
+  { name, ...props }: FormNumericInputProps,
+  ref: Ref<HTMLInputElement>,
+) {
+  const [field, meta, helpers] = useField(name);
+
+  return (
+    <NumericInput
+      {...props}
+      ref={ref}
+      id={name}
+      name={name}
+      value={field.value}
+      error={meta.touched && meta.error != null}
+      onChange={helpers.setValue}
+      onBlur={field.onBlur}
+    />
+  );
+});
+
+export default FormNumericInput;

--- a/frontend/src/metabase/core/components/FormNumericInput/FormNumericInput.unit.spec.tsx
+++ b/frontend/src/metabase/core/components/FormNumericInput/FormNumericInput.unit.spec.tsx
@@ -6,7 +6,7 @@ import userEvent from "@testing-library/user-event";
 import FormField from "metabase/core/components/FormField";
 import FormNumericInput from "./FormNumericInput";
 
-const TEST_SCHEMA = Yup.object().shape({
+const TestSchema = Yup.object().shape({
   value: Yup.number().required("error"),
 });
 
@@ -22,7 +22,7 @@ const TestFormNumericInput = ({
   return (
     <Formik
       initialValues={{ value: initialValue }}
-      validationSchema={TEST_SCHEMA}
+      validationSchema={TestSchema}
       onSubmit={onSubmit}
     >
       <Form>
@@ -49,7 +49,7 @@ describe("FormNumericInput", () => {
 
     render(<TestFormNumericInput onSubmit={onSubmit} />);
     userEvent.type(screen.getByRole("textbox"), "10");
-    userEvent.click(screen.getByRole("button"));
+    userEvent.click(screen.getByText("Submit"));
 
     waitFor(() => expect(onSubmit).toHaveBeenCalledWith({ value: 10 }));
   });

--- a/frontend/src/metabase/core/components/FormNumericInput/FormNumericInput.unit.spec.tsx
+++ b/frontend/src/metabase/core/components/FormNumericInput/FormNumericInput.unit.spec.tsx
@@ -2,8 +2,6 @@ import React from "react";
 import { Formik, Form } from "formik";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import FormField from "metabase/core/components/FormField";
-import FormSubmitButton from "metabase/core/components/FormSubmitButton";
 import FormNumericInput from "./FormNumericInput";
 
 describe("FormNumericInput", () => {
@@ -14,15 +12,13 @@ describe("FormNumericInput", () => {
     render(
       <Formik initialValues={initialValues} onSubmit={onSubmit}>
         <Form>
-          <FormField name="value" title="Goal">
-            <FormNumericInput name="value" />
-          </FormField>
-          <FormSubmitButton />
+          <FormNumericInput name="value" />
+          <button type="submit">Submit</button>
         </Form>
       </Formik>,
     );
 
-    const input = screen.getByDisplayValue("10");
+    const input = screen.getByRole("textbox");
     userEvent.clear(input);
     userEvent.type(input, "20");
     userEvent.click(screen.getByText("Submit"));

--- a/frontend/src/metabase/core/components/FormNumericInput/FormNumericInput.unit.spec.tsx
+++ b/frontend/src/metabase/core/components/FormNumericInput/FormNumericInput.unit.spec.tsx
@@ -1,30 +1,74 @@
 import React from "react";
-import { Formik, Form } from "formik";
+import { Form, Formik } from "formik";
+import * as Yup from "yup";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import FormField from "metabase/core/components/FormField";
 import FormNumericInput from "./FormNumericInput";
 
+const TestSchema = Yup.object().shape({
+  value: Yup.number().required("error"),
+});
+
+interface TestFormNumericInputProps {
+  initialValue?: number;
+  onSubmit: () => void;
+}
+
+const TestFormNumericInput = ({
+  initialValue,
+  onSubmit,
+}: TestFormNumericInputProps) => {
+  return (
+    <Formik
+      initialValues={{ value: initialValue }}
+      validationSchema={TestSchema}
+      onSubmit={onSubmit}
+    >
+      <Form>
+        <FormField name="value" title="Label">
+          <FormNumericInput name="value" />
+        </FormField>
+        <button type="submit">Submit</button>
+      </Form>
+    </Formik>
+  );
+};
+
 describe("FormNumericInput", () => {
-  it("should set the value in the formik context", () => {
-    const initialValues = { value: 10 };
+  it("should use the initial value from the form", () => {
     const onSubmit = jest.fn();
 
-    render(
-      <Formik initialValues={initialValues} onSubmit={onSubmit}>
-        <Form>
-          <FormNumericInput name="value" />
-          <button type="submit">Submit</button>
-        </Form>
-      </Formik>,
-    );
+    render(<TestFormNumericInput initialValue={10} onSubmit={onSubmit} />);
 
-    const input = screen.getByRole("textbox");
-    userEvent.clear(input);
-    userEvent.type(input, "20");
-    userEvent.click(screen.getByText("Submit"));
+    expect(screen.getByRole("textbox")).toHaveValue("10");
+  });
 
-    waitFor(() => {
-      expect(onSubmit).toHaveBeenCalledWith({ value: 20 });
-    });
+  it("should propagate the changed value to the form", () => {
+    const onSubmit = jest.fn();
+
+    render(<TestFormNumericInput onSubmit={onSubmit} />);
+    userEvent.type(screen.getByRole("textbox"), "10");
+    userEvent.click(screen.getByRole("button"));
+
+    waitFor(() => expect(onSubmit).toHaveBeenCalledWith({ value: 10 }));
+  });
+
+  it("should be referenced by the label", () => {
+    const onSubmit = jest.fn();
+
+    render(<TestFormNumericInput onSubmit={onSubmit} />);
+
+    expect(screen.getByLabelText("Label")).toBeInTheDocument();
+  });
+
+  it("should be validated on blur", () => {
+    const onSubmit = jest.fn();
+
+    render(<TestFormNumericInput initialValue={10} onSubmit={onSubmit} />);
+    userEvent.clear(screen.getByRole("textbox"));
+    userEvent.tab();
+
+    waitFor(() => expect(screen.getByText("Label: error")).toBeInTheDocument());
   });
 });

--- a/frontend/src/metabase/core/components/FormNumericInput/FormNumericInput.unit.spec.tsx
+++ b/frontend/src/metabase/core/components/FormNumericInput/FormNumericInput.unit.spec.tsx
@@ -6,7 +6,7 @@ import userEvent from "@testing-library/user-event";
 import FormField from "metabase/core/components/FormField";
 import FormNumericInput from "./FormNumericInput";
 
-const TestSchema = Yup.object().shape({
+const TEST_SCHEMA = Yup.object().shape({
   value: Yup.number().required("error"),
 });
 
@@ -22,7 +22,7 @@ const TestFormNumericInput = ({
   return (
     <Formik
       initialValues={{ value: initialValue }}
-      validationSchema={TestSchema}
+      validationSchema={TEST_SCHEMA}
       onSubmit={onSubmit}
     >
       <Form>

--- a/frontend/src/metabase/core/components/FormNumericInput/FormNumericInput.unit.spec.tsx
+++ b/frontend/src/metabase/core/components/FormNumericInput/FormNumericInput.unit.spec.tsx
@@ -4,31 +4,31 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import FormField from "metabase/core/components/FormField";
 import FormSubmitButton from "metabase/core/components/FormSubmitButton";
-import FormInput from "./FormInput";
+import FormNumericInput from "./FormNumericInput";
 
-describe("FormInput", () => {
+describe("FormNumericInput", () => {
   it("should set the value in the formik context", () => {
-    const initialValues = { name: "Orders" };
+    const initialValues = { value: 10 };
     const onSubmit = jest.fn();
 
     render(
       <Formik initialValues={initialValues} onSubmit={onSubmit}>
         <Form>
-          <FormField name="name" title="Name">
-            <FormInput name="name" />
+          <FormField name="value" title="Goal">
+            <FormNumericInput name="value" />
           </FormField>
           <FormSubmitButton />
         </Form>
       </Formik>,
     );
 
-    const input = screen.getByDisplayValue("Orders");
+    const input = screen.getByDisplayValue("10");
     userEvent.clear(input);
-    userEvent.type(input, "Orders by month");
+    userEvent.type(input, "20");
     userEvent.click(screen.getByText("Submit"));
 
     waitFor(() => {
-      expect(onSubmit).toHaveBeenCalledWith({ name: "Orders by month" });
+      expect(onSubmit).toHaveBeenCalledWith({ value: 20 });
     });
   });
 });

--- a/frontend/src/metabase/core/components/FormNumericInput/index.ts
+++ b/frontend/src/metabase/core/components/FormNumericInput/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./FormNumericInput";
+export type { FormNumericInputProps } from "./FormNumericInput";

--- a/frontend/src/metabase/core/components/FormRadio/FormRadio.tsx
+++ b/frontend/src/metabase/core/components/FormRadio/FormRadio.tsx
@@ -22,7 +22,6 @@ const FormRadio = forwardRef(function FormRadio<
     <Radio
       {...props}
       ref={ref}
-      id={name}
       name={name}
       value={field.value}
       onChange={helpers.setValue}

--- a/frontend/src/metabase/core/components/FormRadio/FormRadio.tsx
+++ b/frontend/src/metabase/core/components/FormRadio/FormRadio.tsx
@@ -16,16 +16,16 @@ const FormRadio = forwardRef(function FormRadio<
   { name, ...props }: FormRadioProps<TValue, TOption>,
   ref: Ref<HTMLDivElement>,
 ) {
-  const [field, , helpers] = useField(name);
+  const [{ value, onBlur }, , { setValue }] = useField(name);
 
   return (
     <Radio
       {...props}
       ref={ref}
       name={name}
-      value={field.value}
-      onChange={helpers.setValue}
-      onBlur={field.onBlur}
+      value={value}
+      onChange={setValue}
+      onBlur={onBlur}
     />
   );
 });

--- a/frontend/src/metabase/core/components/FormRadio/FormRadio.tsx
+++ b/frontend/src/metabase/core/components/FormRadio/FormRadio.tsx
@@ -1,0 +1,34 @@
+import React, { forwardRef, Key, Ref } from "react";
+import { useField } from "formik";
+import Radio, { RadioOption, RadioProps } from "metabase/core/components/Radio";
+
+export interface FormRadioProps<
+  TValue extends Key,
+  TOption = RadioOption<TValue>,
+> extends Omit<RadioProps<TValue, TOption>, "value" | "onChange" | "onBlur"> {
+  name: string;
+}
+
+const FormRadio = forwardRef(function FormRadio<
+  TValue extends Key,
+  TOption = RadioOption<TValue>,
+>(
+  { name, ...props }: FormRadioProps<TValue, TOption>,
+  ref: Ref<HTMLDivElement>,
+) {
+  const [field, , helpers] = useField(name);
+
+  return (
+    <Radio
+      {...props}
+      ref={ref}
+      id={name}
+      name={name}
+      value={field.value}
+      onChange={helpers.setValue}
+      onBlur={field.onBlur}
+    />
+  );
+});
+
+export default FormRadio;

--- a/frontend/src/metabase/core/components/FormRadio/FormRadio.unit.spec.tsx
+++ b/frontend/src/metabase/core/components/FormRadio/FormRadio.unit.spec.tsx
@@ -6,12 +6,13 @@ import FormField from "metabase/core/components/FormField";
 import FormSubmitButton from "metabase/core/components/FormSubmitButton";
 import FormRadio from "./FormRadio";
 
+const OPTIONS = [
+  { name: "Line", value: "line" },
+  { name: "Bar", value: "bar" },
+];
+
 describe("FormRadio", () => {
   it("should set the value in the formik context", () => {
-    const options = [
-      { name: "Line", value: "line" },
-      { name: "Bar", value: "bar" },
-    ];
     const initialValues = { display: "line" };
     const onSubmit = jest.fn();
 
@@ -19,7 +20,7 @@ describe("FormRadio", () => {
       <Formik initialValues={initialValues} onSubmit={onSubmit}>
         <Form>
           <FormField name="display" title="Display">
-            <FormRadio name="display" options={options} />
+            <FormRadio name="display" options={OPTIONS} />
           </FormField>
           <FormSubmitButton />
         </Form>

--- a/frontend/src/metabase/core/components/FormRadio/FormRadio.unit.spec.tsx
+++ b/frontend/src/metabase/core/components/FormRadio/FormRadio.unit.spec.tsx
@@ -2,8 +2,6 @@ import React from "react";
 import { Formik, Form } from "formik";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import FormField from "metabase/core/components/FormField";
-import FormSubmitButton from "metabase/core/components/FormSubmitButton";
 import FormRadio from "./FormRadio";
 
 const OPTIONS = [
@@ -20,10 +18,8 @@ describe("FormRadio", () => {
     render(
       <Formik initialValues={initialValues} onSubmit={onSubmit}>
         <Form>
-          <FormField name="display" title="Display">
-            <FormRadio name="display" options={OPTIONS} />
-          </FormField>
-          <FormSubmitButton />
+          <FormRadio name="display" options={OPTIONS} />
+          <button type="submit">Submit</button>
         </Form>
       </Formik>,
     );

--- a/frontend/src/metabase/core/components/FormRadio/FormRadio.unit.spec.tsx
+++ b/frontend/src/metabase/core/components/FormRadio/FormRadio.unit.spec.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+import { Formik, Form } from "formik";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import FormField from "metabase/core/components/FormField";
+import FormSubmitButton from "metabase/core/components/FormSubmitButton";
+import FormRadio from "./FormRadio";
+
+describe("FormRadio", () => {
+  it("should set the value in the formik context", () => {
+    const options = [
+      { name: "Line", value: "line" },
+      { name: "Bar", value: "bar" },
+    ];
+    const initialValues = { display: "line" };
+    const onSubmit = jest.fn();
+
+    render(
+      <Formik initialValues={initialValues} onSubmit={onSubmit}>
+        <Form>
+          <FormField name="display" title="Display">
+            <FormRadio name="display" options={options} />
+          </FormField>
+          <FormSubmitButton />
+        </Form>
+      </Formik>,
+    );
+
+    userEvent.click(screen.getByText("Bar"));
+    userEvent.click(screen.getByText("Submit"));
+
+    waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith({ display: "bar" });
+    });
+  });
+});

--- a/frontend/src/metabase/core/components/FormRadio/FormRadio.unit.spec.tsx
+++ b/frontend/src/metabase/core/components/FormRadio/FormRadio.unit.spec.tsx
@@ -1,34 +1,69 @@
 import React from "react";
-import { Formik, Form } from "formik";
+import { Form, Formik } from "formik";
+import * as Yup from "yup";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import FormField from "metabase/core/components/FormField";
 import FormRadio from "./FormRadio";
 
-const OPTIONS = [
+const TEST_SCHEMA = Yup.object().shape({
+  value: Yup.string().notOneOf(["Bar"]),
+});
+
+const TEST_OPTIONS = [
   { name: "Line", value: "line" },
   { name: "Area", value: "area" },
   { name: "Bar", value: "bar" },
 ];
 
+interface TestFormRadioProps {
+  initialValue?: string;
+  onSubmit: () => void;
+}
+
+const TestFormRadio = ({ initialValue, onSubmit }: TestFormRadioProps) => {
+  return (
+    <Formik
+      initialValues={{ value: initialValue }}
+      validationSchema={TEST_SCHEMA}
+      onSubmit={onSubmit}
+    >
+      <Form>
+        <FormField name="value" title="Label">
+          <FormRadio name="value" options={TEST_OPTIONS} />
+        </FormField>
+        <button type="submit">Submit</button>
+      </Form>
+    </Formik>
+  );
+};
+
 describe("FormRadio", () => {
-  it("should set the value in the formik context", () => {
-    const initialValues = { display: "line" };
+  it("should use the initial value from the form", () => {
     const onSubmit = jest.fn();
 
-    render(
-      <Formik initialValues={initialValues} onSubmit={onSubmit}>
-        <Form>
-          <FormRadio name="display" options={OPTIONS} />
-          <button type="submit">Submit</button>
-        </Form>
-      </Formik>,
-    );
+    render(<TestFormRadio initialValue="line" onSubmit={onSubmit} />);
 
-    userEvent.click(screen.getByText("Bar"));
-    userEvent.click(screen.getByText("Submit"));
+    expect(screen.getByRole("radio", { name: "Line" })).toBeChecked();
+  });
 
-    waitFor(() => {
-      expect(onSubmit).toHaveBeenCalledWith({ display: "bar" });
-    });
+  it("should propagate the changed value to the form", () => {
+    const onSubmit = jest.fn();
+
+    render(<TestFormRadio onSubmit={onSubmit} />);
+    userEvent.click(screen.getByRole("radio", { name: "Line" }));
+    userEvent.click(screen.getByRole("button"));
+
+    waitFor(() => expect(onSubmit).toHaveBeenCalledWith({ value: "line" }));
+  });
+
+  it("should be validated on blur", () => {
+    const onSubmit = jest.fn();
+
+    render(<TestFormRadio initialValue="line" onSubmit={onSubmit} />);
+    userEvent.click(screen.getByRole("radio", { name: "Bar" }));
+    userEvent.tab();
+
+    waitFor(() => expect(screen.getByText("Label: error")).toBeInTheDocument());
   });
 });

--- a/frontend/src/metabase/core/components/FormRadio/FormRadio.unit.spec.tsx
+++ b/frontend/src/metabase/core/components/FormRadio/FormRadio.unit.spec.tsx
@@ -52,7 +52,7 @@ describe("FormRadio", () => {
 
     render(<TestFormRadio onSubmit={onSubmit} />);
     userEvent.click(screen.getByRole("radio", { name: "Line" }));
-    userEvent.click(screen.getByRole("button"));
+    userEvent.click(screen.getByText("Submit"));
 
     waitFor(() => expect(onSubmit).toHaveBeenCalledWith({ value: "line" }));
   });

--- a/frontend/src/metabase/core/components/FormRadio/index.ts
+++ b/frontend/src/metabase/core/components/FormRadio/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./FormRadio";
+export type { FormRadioProps } from "./FormRadio";

--- a/frontend/src/metabase/core/components/FormSelect/FormSelect.tsx
+++ b/frontend/src/metabase/core/components/FormSelect/FormSelect.tsx
@@ -22,7 +22,7 @@ function FormSelect<TValue, TOption = SelectOption<TValue>>({
       name={name}
       value={field.value}
       onChange={field.onChange}
-      buttonProps={{ onBlur: field.onBlur }}
+      buttonProps={{ id: name, onBlur: field.onBlur }}
     />
   );
 }

--- a/frontend/src/metabase/core/components/FormSelect/FormSelect.tsx
+++ b/frontend/src/metabase/core/components/FormSelect/FormSelect.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useMemo } from "react";
 import { useField } from "formik";
 import Select, {
   SelectOption,
@@ -14,15 +14,16 @@ function FormSelect<TValue, TOption = SelectOption<TValue>>({
   name,
   ...props
 }: FormSelectProps<TValue, TOption>) {
-  const [field] = useField(name);
+  const [{ value, onChange, onBlur }] = useField(name);
+  const buttonProps = useMemo(() => ({ id: name, onBlur }), [name, onBlur]);
 
   return (
     <Select
       {...props}
       name={name}
-      value={field.value}
-      onChange={field.onChange}
-      buttonProps={{ id: name, onBlur: field.onBlur }}
+      value={value}
+      onChange={onChange}
+      buttonProps={buttonProps}
     />
   );
 }

--- a/frontend/src/metabase/core/components/FormSelect/FormSelect.tsx
+++ b/frontend/src/metabase/core/components/FormSelect/FormSelect.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+import { useField } from "formik";
+import Select, {
+  SelectOption,
+  SelectProps,
+} from "metabase/core/components/Select";
+
+export interface FormSelectProps<TValue, TOption = SelectOption<TValue>>
+  extends Omit<SelectProps<TValue, TOption>, "value" | "onChange"> {
+  name: string;
+}
+
+function FormSelect<TValue, TOption = SelectOption<TValue>>({
+  name,
+  ...props
+}: FormSelectProps<TValue, TOption>) {
+  const [field] = useField(name);
+
+  return (
+    <Select
+      {...props}
+      name={name}
+      value={field.value}
+      onChange={field.onChange}
+      buttonProps={{ onBlur: field.onBlur }}
+    />
+  );
+}
+
+export default FormSelect;

--- a/frontend/src/metabase/core/components/FormSelect/FormSelect.unit.spec.tsx
+++ b/frontend/src/metabase/core/components/FormSelect/FormSelect.unit.spec.tsx
@@ -2,8 +2,6 @@ import React from "react";
 import { Formik, Form } from "formik";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import FormField from "metabase/core/components/FormField";
-import FormSubmitButton from "metabase/core/components/FormSubmitButton";
 import FormSelect from "./FormSelect";
 
 const OPTIONS = [
@@ -20,10 +18,8 @@ describe("FormSelect", () => {
     render(
       <Formik initialValues={initialValues} onSubmit={onSubmit}>
         <Form>
-          <FormField name="display" title="Display">
-            <FormSelect name="display" options={OPTIONS} />
-          </FormField>
-          <FormSubmitButton />
+          <FormSelect name="display" options={OPTIONS} />
+          <button type="submit">Submit</button>
         </Form>
       </Formik>,
     );

--- a/frontend/src/metabase/core/components/FormSelect/FormSelect.unit.spec.tsx
+++ b/frontend/src/metabase/core/components/FormSelect/FormSelect.unit.spec.tsx
@@ -4,7 +4,7 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import FormField from "metabase/core/components/FormField";
 import FormSubmitButton from "metabase/core/components/FormSubmitButton";
-import FormRadio from "./FormRadio";
+import FormSelect from "./FormSelect";
 
 const OPTIONS = [
   { name: "Line", value: "line" },
@@ -12,7 +12,7 @@ const OPTIONS = [
   { name: "Bar", value: "bar" },
 ];
 
-describe("FormRadio", () => {
+describe("FormSelect", () => {
   it("should set the value in the formik context", () => {
     const initialValues = { display: "line" };
     const onSubmit = jest.fn();
@@ -21,13 +21,14 @@ describe("FormRadio", () => {
       <Formik initialValues={initialValues} onSubmit={onSubmit}>
         <Form>
           <FormField name="display" title="Display">
-            <FormRadio name="display" options={OPTIONS} />
+            <FormSelect name="display" options={OPTIONS} />
           </FormField>
           <FormSubmitButton />
         </Form>
       </Formik>,
     );
 
+    userEvent.click(screen.getByText("Line"));
     userEvent.click(screen.getByText("Bar"));
     userEvent.click(screen.getByText("Submit"));
 

--- a/frontend/src/metabase/core/components/FormSelect/FormSelect.unit.spec.tsx
+++ b/frontend/src/metabase/core/components/FormSelect/FormSelect.unit.spec.tsx
@@ -1,35 +1,83 @@
 import React from "react";
-import { Formik, Form } from "formik";
+import { Form, Formik } from "formik";
+import * as Yup from "yup";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import FormField from "metabase/core/components/FormField";
 import FormSelect from "./FormSelect";
 
-const OPTIONS = [
+const TEST_SCHEMA = Yup.object().shape({
+  value: Yup.string().notOneOf(["Bar"]),
+});
+
+const TEST_OPTIONS = [
   { name: "Line", value: "line" },
   { name: "Area", value: "area" },
   { name: "Bar", value: "bar" },
 ];
 
+interface TestFormSelectProps {
+  initialValue?: string;
+  onSubmit: () => void;
+}
+
+const TestFormSelect = ({ initialValue, onSubmit }: TestFormSelectProps) => {
+  return (
+    <Formik
+      initialValues={{ value: initialValue }}
+      validationSchema={TEST_SCHEMA}
+      onSubmit={onSubmit}
+    >
+      <Form>
+        <FormField name="value" title="Label">
+          <FormSelect
+            name="value"
+            options={TEST_OPTIONS}
+            placeholder="Choose"
+          />
+        </FormField>
+        <button type="submit">Submit</button>
+      </Form>
+    </Formik>
+  );
+};
+
 describe("FormSelect", () => {
-  it("should set the value in the formik context", () => {
-    const initialValues = { display: "line" };
+  it("should use the initial value from the form", () => {
     const onSubmit = jest.fn();
 
-    render(
-      <Formik initialValues={initialValues} onSubmit={onSubmit}>
-        <Form>
-          <FormSelect name="display" options={OPTIONS} />
-          <button type="submit">Submit</button>
-        </Form>
-      </Formik>,
-    );
+    render(<TestFormSelect initialValue="line" onSubmit={onSubmit} />);
 
+    expect(screen.getByText("Line")).toBeInTheDocument();
+  });
+
+  it("should propagate the changed value to the form", () => {
+    const onSubmit = jest.fn();
+
+    render(<TestFormSelect onSubmit={onSubmit} />);
+    userEvent.click(screen.getByText("Choose"));
     userEvent.click(screen.getByText("Line"));
-    userEvent.click(screen.getByText("Bar"));
     userEvent.click(screen.getByText("Submit"));
 
-    waitFor(() => {
-      expect(onSubmit).toHaveBeenCalledWith({ display: "bar" });
-    });
+    waitFor(() => expect(onSubmit).toHaveBeenCalledWith({ value: "line" }));
+  });
+
+  it("should be referenced by the label", () => {
+    const onSubmit = jest.fn();
+
+    render(<TestFormSelect onSubmit={onSubmit} />);
+
+    expect(screen.getByLabelText("Label")).toBeInTheDocument();
+  });
+
+  it("should be validated on blur", () => {
+    const onSubmit = jest.fn();
+
+    render(<TestFormSelect initialValue="line" onSubmit={onSubmit} />);
+    userEvent.click(screen.getByText("Line"));
+    userEvent.click(screen.getByText("Bar"));
+    userEvent.tab();
+
+    waitFor(() => expect(screen.getByText("Label: error")).toBeInTheDocument());
   });
 });

--- a/frontend/src/metabase/core/components/FormSelect/index.ts
+++ b/frontend/src/metabase/core/components/FormSelect/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./FormSelect";
+export type { FormSelectProps } from "./FormSelect";

--- a/frontend/src/metabase/core/components/FormToggle/FormToggle.tsx
+++ b/frontend/src/metabase/core/components/FormToggle/FormToggle.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { forwardRef, Ref } from "react";
 import { useField } from "formik";
 import Toggle, { ToggleProps } from "metabase/core/components/Toggle";
 
@@ -7,12 +7,16 @@ export interface FormToggleProps
   name: string;
 }
 
-const FormToggle = ({ name, ...props }: FormToggleProps): JSX.Element => {
+const FormToggle = forwardRef(function FormToggle(
+  { name, ...props }: FormToggleProps,
+  ref: Ref<HTMLInputElement>,
+) {
   const [field, , helpers] = useField(name);
 
   return (
     <Toggle
       {...props}
+      ref={ref}
       id={name}
       name={name}
       value={field.value}
@@ -20,6 +24,6 @@ const FormToggle = ({ name, ...props }: FormToggleProps): JSX.Element => {
       onBlur={field.onBlur}
     />
   );
-};
+});
 
 export default FormToggle;

--- a/frontend/src/metabase/core/components/FormToggle/FormToggle.tsx
+++ b/frontend/src/metabase/core/components/FormToggle/FormToggle.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+import { useField } from "formik";
+import Toggle, { ToggleProps } from "metabase/core/components/Toggle";
+
+export interface FormToggleProps
+  extends Omit<ToggleProps, "value" | "onChange" | "onBlur"> {
+  name: string;
+}
+
+const FormToggle = ({ name, ...props }: FormToggleProps): JSX.Element => {
+  const [field, , helpers] = useField(name);
+
+  return (
+    <Toggle
+      {...props}
+      id={name}
+      name={name}
+      value={field.value}
+      onChange={helpers.setValue}
+      onBlur={field.onBlur}
+    />
+  );
+};
+
+export default FormToggle;

--- a/frontend/src/metabase/core/components/FormToggle/FormToggle.tsx
+++ b/frontend/src/metabase/core/components/FormToggle/FormToggle.tsx
@@ -11,7 +11,7 @@ const FormToggle = forwardRef(function FormToggle(
   { name, ...props }: FormToggleProps,
   ref: Ref<HTMLInputElement>,
 ) {
-  const [field, , helpers] = useField(name);
+  const [{ value, onBlur }, , { setValue }] = useField(name);
 
   return (
     <Toggle
@@ -19,9 +19,9 @@ const FormToggle = forwardRef(function FormToggle(
       ref={ref}
       id={name}
       name={name}
-      value={field.value}
-      onChange={helpers.setValue}
-      onBlur={field.onBlur}
+      value={value}
+      onChange={setValue}
+      onBlur={onBlur}
     />
   );
 });

--- a/frontend/src/metabase/core/components/FormToggle/FormToggle.unit.spec.tsx
+++ b/frontend/src/metabase/core/components/FormToggle/FormToggle.unit.spec.tsx
@@ -49,7 +49,7 @@ describe("FormToggle", () => {
 
     render(<TestFormToggle onSubmit={onSubmit} />);
     userEvent.click(screen.getByRole("switch"));
-    userEvent.click(screen.getByRole("button"));
+    userEvent.click(screen.getByText("Submit"));
 
     waitFor(() => expect(onSubmit).toHaveBeenCalledWith({ value: true }));
   });

--- a/frontend/src/metabase/core/components/FormToggle/FormToggle.unit.spec.tsx
+++ b/frontend/src/metabase/core/components/FormToggle/FormToggle.unit.spec.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { Formik, Form } from "formik";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import FormField from "metabase/core/components/FormField";
+import FormSubmitButton from "metabase/core/components/FormSubmitButton";
+import FormToggle from "./FormToggle";
+
+describe("FormToggle", () => {
+  it("should set the value in the formik context", () => {
+    const initialValues = { label: false };
+    const onSubmit = jest.fn();
+
+    render(
+      <Formik initialValues={initialValues} onSubmit={onSubmit}>
+        <Form>
+          <FormField name="label" title="Show label">
+            <FormToggle name="label" />
+          </FormField>
+          <FormSubmitButton />
+        </Form>
+      </Formik>,
+    );
+
+    userEvent.click(screen.getByLabelText("Show label"));
+    userEvent.click(screen.getByText("Submit"));
+
+    waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith({ label: true });
+    });
+  });
+});

--- a/frontend/src/metabase/core/components/FormToggle/FormToggle.unit.spec.tsx
+++ b/frontend/src/metabase/core/components/FormToggle/FormToggle.unit.spec.tsx
@@ -6,7 +6,7 @@ import userEvent from "@testing-library/user-event";
 import FormField from "metabase/core/components/FormField";
 import FormToggle from "./FormToggle";
 
-const TestSchema = Yup.object().shape({
+const TEST_SCHEMA = Yup.object().shape({
   value: Yup.boolean().isTrue("error"),
 });
 
@@ -22,7 +22,7 @@ const TestFormToggle = ({
   return (
     <Formik
       initialValues={{ value: initialValue }}
-      validationSchema={TestSchema}
+      validationSchema={TEST_SCHEMA}
       onSubmit={onSubmit}
     >
       <Form>

--- a/frontend/src/metabase/core/components/FormToggle/FormToggle.unit.spec.tsx
+++ b/frontend/src/metabase/core/components/FormToggle/FormToggle.unit.spec.tsx
@@ -1,9 +1,7 @@
 import React from "react";
-import { Formik, Form } from "formik";
+import { Form, Formik } from "formik";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import FormField from "metabase/core/components/FormField";
-import FormSubmitButton from "metabase/core/components/FormSubmitButton";
 import FormToggle from "./FormToggle";
 
 describe("FormToggle", () => {
@@ -14,15 +12,13 @@ describe("FormToggle", () => {
     render(
       <Formik initialValues={initialValues} onSubmit={onSubmit}>
         <Form>
-          <FormField name="label" title="Show label">
-            <FormToggle name="label" />
-          </FormField>
-          <FormSubmitButton />
+          <FormToggle name="label" />
+          <button type="submit">Submit</button>
         </Form>
       </Formik>,
     );
 
-    userEvent.click(screen.getByLabelText("Show label"));
+    userEvent.click(screen.getByRole("switch"));
     userEvent.click(screen.getByText("Submit"));
 
     waitFor(() => {

--- a/frontend/src/metabase/core/components/FormToggle/index.ts
+++ b/frontend/src/metabase/core/components/FormToggle/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./FormToggle";
+export type { FormToggleProps } from "./FormToggle";

--- a/frontend/src/metabase/core/components/NumericInput/NumericInput.tsx
+++ b/frontend/src/metabase/core/components/NumericInput/NumericInput.tsx
@@ -17,7 +17,6 @@ export type NumericInputAttributes = Omit<
 
 export interface NumericInputProps extends NumericInputAttributes {
   value?: number | string;
-  inputRef?: Ref<HTMLInputElement>;
   error?: boolean;
   fullWidth?: boolean;
   onChange?: (value: number | undefined) => void;

--- a/frontend/src/metabase/core/components/NumericInput/index.ts
+++ b/frontend/src/metabase/core/components/NumericInput/index.ts
@@ -1,1 +1,2 @@
 export { default } from "./NumericInput";
+export type { NumericInputProps } from "./NumericInput";

--- a/frontend/src/metabase/core/components/Radio/Radio.tsx
+++ b/frontend/src/metabase/core/components/Radio/Radio.tsx
@@ -61,7 +61,10 @@ export interface RadioOption<TValue> {
   value: TValue;
 }
 
-function RadioInner<TValue extends Key, TOption = RadioOption<TValue>>(
+const Radio = forwardRef(function Radio<
+  TValue extends Key,
+  TOption = RadioOption<TValue>,
+>(
   {
     name,
     value,
@@ -79,7 +82,7 @@ function RadioInner<TValue extends Key, TOption = RadioOption<TValue>>(
     ...props
   }: RadioProps<TValue, TOption>,
   ref: Ref<HTMLDivElement>,
-): JSX.Element {
+) {
   const { RadioGroup } = VARIANTS[variant];
   const groupName = useMemo(() => name ?? _.uniqueId("radio-"), [name]);
 
@@ -116,11 +119,7 @@ function RadioInner<TValue extends Key, TOption = RadioOption<TValue>>(
       })}
     </RadioGroup>
   );
-}
-
-const Radio = forwardRef(RadioInner) as <T extends Key>(
-  props: RadioProps<T> & { ref?: React.Ref<HTMLDivElement> },
-) => ReturnType<typeof RadioInner>;
+});
 
 interface RadioItemProps<TValue extends Key> {
   name: string;

--- a/frontend/src/metabase/core/components/Radio/Radio.tsx
+++ b/frontend/src/metabase/core/components/Radio/Radio.tsx
@@ -90,7 +90,7 @@ const Radio = forwardRef(function Radio<
     <RadioGroup
       {...props}
       role="radiogroup"
-      ref={ref as any}
+      ref={ref}
       variant={variant}
       vertical={vertical}
     >

--- a/frontend/src/metabase/core/components/Radio/index.ts
+++ b/frontend/src/metabase/core/components/Radio/index.ts
@@ -1,1 +1,2 @@
 export { default } from "./Radio";
+export type { RadioProps, RadioOption } from "./Radio";

--- a/frontend/src/metabase/core/components/Select/Select.tsx
+++ b/frontend/src/metabase/core/components/Select/Select.tsx
@@ -1,12 +1,20 @@
-import React, { Component } from "react";
-import PropTypes from "prop-types";
+import React, {
+  Component,
+  CSSProperties,
+  Key,
+  ReactElement,
+  ReactNode,
+  RefObject,
+} from "react";
 
 import _ from "underscore";
 import cx from "classnames";
 import { createSelector } from "reselect";
 import Icon from "metabase/components/Icon";
 import PopoverWithTrigger from "metabase/components/PopoverWithTrigger";
-import SelectButton from "metabase/core/components/SelectButton";
+import SelectButton, {
+  SelectButtonProps,
+} from "metabase/core/components/SelectButton";
 
 import { color } from "metabase/lib/colors";
 
@@ -16,70 +24,103 @@ import { SelectAccordionList } from "./Select.styled";
 
 const MIN_ICON_WIDTH = 20;
 
-class Select extends Component {
-  static propTypes = {
-    className: PropTypes.string,
+export interface SelectProps<TValue, TOption = SelectOption<TValue>> {
+  className?: string;
 
-    // one of these is required
-    options: PropTypes.any,
-    sections: PropTypes.any,
-    children: PropTypes.any,
+  options?: TOption[];
+  sections?: SelectSection<TOption>[];
+  children?: ReactNode;
 
-    value: PropTypes.any.isRequired,
-    name: PropTypes.string,
-    defaultValue: PropTypes.any,
-    onChange: PropTypes.func.isRequired,
-    multiple: PropTypes.bool,
-    placeholder: PropTypes.string,
-    disabled: PropTypes.bool,
-    hiddenIcons: PropTypes.bool,
+  value: TValue;
+  name?: string;
+  defaultValue?: TValue;
+  onChange: (event: SelectChangeEvent<TValue>) => void;
+  multiple?: boolean;
+  placeholder?: string;
+  disabled?: boolean;
+  hiddenIcons?: boolean;
 
-    // PopoverWithTrigger props
-    isInitiallyOpen: PropTypes.bool,
-    triggerElement: PropTypes.any,
-    onClose: PropTypes.func,
+  // PopoverWithTrigger props
+  isInitiallyOpen?: boolean;
+  triggerElement?: ReactNode;
+  onClose?: () => void;
 
-    // SelectButton props
-    buttonProps: PropTypes.object,
-    buttonText: PropTypes.string, // will override selected options text
+  // SelectButton props
+  buttonProps?: Partial<SelectButtonProps>;
+  buttonText?: string; // will override selected options text
 
-    // AccordianList props
-    searchProp: PropTypes.string,
-    searchCaseInsensitive: PropTypes.bool,
-    searchPlaceholder: PropTypes.string,
-    searchFuzzy: PropTypes.bool,
-    hideEmptySectionsInSearch: PropTypes.bool,
-    width: PropTypes.number,
+  // AccordionList props
+  searchProp?: string;
+  searchCaseInsensitive?: boolean;
+  searchPlaceholder?: string;
+  searchFuzzy?: boolean;
+  hideEmptySectionsInSearch?: boolean;
+  width?: number;
 
-    optionNameFn: PropTypes.func,
-    optionValueFn: PropTypes.func,
-    optionDescriptionFn: PropTypes.func,
-    optionSectionFn: PropTypes.func,
-    optionDisabledFn: PropTypes.func,
-    optionIconFn: PropTypes.func,
-    optionClassNameFn: PropTypes.func,
-    optionStylesFn: PropTypes.func,
+  optionNameFn?: (option: TOption) => string | undefined;
+  optionValueFn?: (option: TOption) => TValue;
+  optionDescriptionFn?: (option: TOption) => string | undefined;
+  optionSectionFn?: (option: TOption) => string;
+  optionDisabledFn?: (option: TOption) => boolean;
+  optionIconFn?: (option: TOption) => string | undefined;
+  optionClassNameFn?: (option: TOption) => string | undefined;
+  optionStylesFn?: (option: TOption) => CSSProperties | undefined;
 
-    footer: PropTypes.node,
-  };
+  footer?: ReactNode;
+}
+
+export interface SelectOption<T = Key> {
+  value: T;
+  name?: string;
+  description?: string;
+  icon?: string;
+  iconSize?: number;
+  iconColor?: string;
+  disabled?: boolean;
+  children?: ReactNode;
+}
+
+export interface SelectSection<TOption = SelectOption> {
+  name?: string;
+  icon?: string;
+  items: TOption[];
+}
+
+export interface SelectChangeEvent<TValue> {
+  target: SelectChangeTarget<TValue>;
+}
+
+export interface SelectChangeTarget<TValue> {
+  name?: string;
+  value: TValue;
+}
+
+class Select<TValue, TOption = SelectOption<TValue>> extends Component<
+  SelectProps<TValue, TOption>
+> {
+  _popover?: any;
+  selectButtonRef: RefObject<any>;
+  _getValues: () => TValue[];
+  _getValuesSet: () => Set<TValue>;
 
   static defaultProps = {
-    optionNameFn: option => option.children || option.name,
-    optionValueFn: option => option.value,
-    optionDescriptionFn: option => option.description,
-    optionDisabledFn: option => option.disabled,
-    optionIconFn: option => option.icon,
+    optionNameFn: (option: SelectOption) => option.children || option.name,
+    optionValueFn: (option: SelectOption) => option.value,
+    optionDescriptionFn: (option: SelectOption) => option.description,
+    optionDisabledFn: (option: SelectOption) => option.disabled,
+    optionIconFn: (option: SelectOption) => option.icon,
   };
 
-  constructor(props) {
+  constructor(props: SelectProps<TValue, TOption>) {
     super(props);
 
     // reselect selectors
-    const _getValue = props =>
+    const _getValue = (props: SelectProps<TValue, TOption>) =>
       // If a defaultValue is passed, replace a null value with it.
       // Otherwise, allow null values since we sometimes want them.
       Object.prototype.hasOwnProperty.call(props, "defaultValue") &&
-      props.value == null
+      props.value == null &&
+      props.defaultValue != null
         ? props.defaultValue
         : props.value;
 
@@ -95,19 +136,22 @@ class Select extends Component {
     this.selectButtonRef = React.createRef();
   }
 
-  _getSections() {
+  _getSections(): SelectSection<TOption>[] {
     // normalize `children`/`options` into same format as `sections`
     const { children, sections, options } = this.props;
     if (children) {
-      const optionToItem = option => option.props;
-      const first = Array.isArray(children) ? children[0] : children;
-      if (first && first.type === OptionSection) {
+      const optionToItem = (option: any) => option.props;
+      const first = (Array.isArray(children) ? children[0] : children) as any;
+      if (first && (first as ReactElement).type === OptionSection) {
         return React.Children.map(children, child => ({
-          ...child.props,
-          items: React.Children.map(child.props.children, optionToItem),
-        }));
+          ...(child as ReactElement<OptionProps<TValue>>).props,
+          items: React.Children.map(
+            (child as any).props.children,
+            optionToItem,
+          ),
+        })) as any;
       } else if (first && first.type === Option) {
-        return [{ items: React.Children.map(children, optionToItem) }];
+        return [{ items: React.Children.map(children, optionToItem) }] as any;
       }
     } else if (options) {
       if (this.props.optionSectionFn) {
@@ -125,17 +169,20 @@ class Select extends Component {
     return [];
   }
 
-  itemIsSelected = option => {
-    const optionValue = this.props.optionValueFn(option);
+  itemIsSelected = (option: TOption) => {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const optionValue = this.props.optionValueFn!(option);
     return this._getValuesSet().has(optionValue);
   };
 
-  itemIsClickable = option => !this.props.optionDisabledFn(option);
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  itemIsClickable = (option: TOption) => !this.props.optionDisabledFn!(option);
 
-  handleChange = option => {
+  handleChange = (option: TOption) => {
     const { name, multiple, onChange } = this.props;
-    const optionValue = this.props.optionValueFn(option);
-    let value;
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const optionValue = this.props.optionValueFn!(option);
+    let value: any;
     if (multiple) {
       const values = this._getValues();
       value = this.itemIsSelected(option)
@@ -147,23 +194,24 @@ class Select extends Component {
     }
     onChange({ target: { name, value } });
     if (!multiple) {
-      this._popover.close();
+      this._popover?.close();
       this.handleClose();
     }
   };
 
-  renderItemIcon = item => {
+  renderItemIcon = (item: TOption) => {
     if (this.props.hiddenIcons) {
       return null;
     }
 
-    const icon = this.props.optionIconFn(item);
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const icon = this.props.optionIconFn!(item);
     if (icon) {
       return (
         <Icon
           name={icon}
-          size={item.iconSize || 18}
-          color={item.iconColor || color("text-dark")}
+          size={(item as any).iconSize || 18}
+          color={(item as any).iconColor || color("text-dark")}
           style={{ minWidth: MIN_ICON_WIDTH }}
         />
       );
@@ -211,7 +259,11 @@ class Select extends Component {
     const sections = this._getSections();
     const selectedNames = sections
       .map(section =>
-        section.items.filter(this.itemIsSelected).map(this.props.optionNameFn),
+        this.props.optionNameFn
+          ? section.items
+              .filter(this.itemIsSelected)
+              .map(this.props.optionNameFn)
+          : [],
       )
       .flat()
       .filter(n => n);
@@ -278,27 +330,31 @@ class Select extends Component {
 }
 
 export default Uncontrollable()(Select);
-export class OptionSection extends Component {
-  static propTypes = {
-    name: PropTypes.any,
-    icon: PropTypes.any,
-    children: PropTypes.any.isRequired,
-  };
+
+export interface OptionSectionProps {
+  name?: string;
+  icon?: string;
+  children?: ReactNode;
+}
+
+export class OptionSection extends Component<OptionSectionProps> {
   render() {
     return null;
   }
 }
-export class Option extends Component {
-  static propTypes = {
-    value: PropTypes.any.isRequired,
 
-    // one of these two is required
-    name: PropTypes.any,
-    children: PropTypes.any,
+export interface OptionProps<TValue> {
+  value: TValue;
 
-    icon: PropTypes.any,
-    disabled: PropTypes.bool,
-  };
+  // one of these two is required
+  name?: string;
+  children?: ReactNode;
+
+  icon?: string;
+  disabled?: boolean;
+}
+
+export class Option<TValue> extends Component<OptionProps<TValue>> {
   render() {
     return null;
   }

--- a/frontend/src/metabase/core/components/Select/Select.tsx
+++ b/frontend/src/metabase/core/components/Select/Select.tsx
@@ -69,8 +69,8 @@ export interface SelectProps<TValue, TOption = SelectOption<TValue>> {
   footer?: ReactNode;
 }
 
-export interface SelectOption<T = Key> {
-  value: T;
+export interface SelectOption<TValue = Key> {
+  value: TValue;
   name?: string;
   description?: string;
   icon?: string;

--- a/frontend/src/metabase/core/components/Select/Select.tsx
+++ b/frontend/src/metabase/core/components/Select/Select.tsx
@@ -119,9 +119,8 @@ class Select<TValue, TOption = SelectOption<TValue>> extends Component<
       // If a defaultValue is passed, replace a null value with it.
       // Otherwise, allow null values since we sometimes want them.
       Object.prototype.hasOwnProperty.call(props, "defaultValue") &&
-      props.value == null &&
-      props.defaultValue != null
-        ? props.defaultValue
+      props.value == null
+        ? (props.defaultValue as any)
         : props.value;
 
     const _getValues = createSelector([_getValue], value =>

--- a/frontend/src/metabase/core/components/Select/index.ts
+++ b/frontend/src/metabase/core/components/Select/index.ts
@@ -1,2 +1,8 @@
-export { default } from "./Select";
-export * from "./Select";
+export { default, Option, OptionSection } from "./Select";
+export type {
+  SelectProps,
+  SelectOption,
+  SelectSection,
+  SelectChangeEvent,
+  SelectChangeTarget,
+} from "./Select";

--- a/frontend/src/metabase/core/components/SelectButton/index.ts
+++ b/frontend/src/metabase/core/components/SelectButton/index.ts
@@ -1,1 +1,2 @@
 export { default } from "./SelectButton";
+export type { SelectButtonProps } from "./SelectButton";

--- a/frontend/src/metabase/core/components/Toggle/index.ts
+++ b/frontend/src/metabase/core/components/Toggle/index.ts
@@ -1,1 +1,2 @@
 export { default } from "./Toggle";
+export type { ToggleProps } from "./Toggle";


### PR DESCRIPTION
Follow up on https://github.com/metabase/metabase/pull/26100

Initially we had:
- FormInput
- FormCheckBox

Adding:
- FormToggle
- FormRadio
- FormSelect
- FormNumericInput

Also converted `Select` to TypeScript without changing its code in any way. I had to use `any` because of that, but the exported types are without `any`. The primary motivation was to get `SelectProps` I could use in `FormSelect`.