### PR TITLE
Fix missing lastEditInfo error when referencing card in native query editor

### DIFF
--- a/frontend/src/metabase/query_builder/components/dataref/QuestionPane/QuestionPane.tsx
+++ b/frontend/src/metabase/query_builder/components/dataref/QuestionPane/QuestionPane.tsx
@@ -84,18 +84,20 @@ const QuestionPane = ({
             {collection?.name ?? t`Our analytics`}
           </QuestionPaneDetailText>
         </QuestionPaneDetail>
-        <QuestionPaneDetail>
-          <QuestionPaneIcon name="calendar" />
-          <QuestionPaneDetailText>
-            {jt`Last edited ${(
-              <DateTime
-                key="day"
-                unit="day"
-                value={question.lastEditInfo().timestamp}
-              />
-            )}`}
-          </QuestionPaneDetailText>
-        </QuestionPaneDetail>
+        {question.lastEditInfo() && (
+          <QuestionPaneDetail>
+            <QuestionPaneIcon name="calendar" />
+            <QuestionPaneDetailText>
+              {jt`Last edited ${(
+                <DateTime
+                  key="day"
+                  unit="day"
+                  value={question.lastEditInfo().timestamp}
+                />
+              )}`}
+            </QuestionPaneDetailText>
+          </QuestionPaneDetail>
+        )}
         {table.fields && (
           <FieldList
             fields={table.fields}


### PR DESCRIPTION
Fixes an error that occurs if a card has no `last-edit-info` on the client, and the user references it from the native query editor.

Demo video:
https://metaboat.slack.com/files/U01TH98M6J2/F047Y2KANB1/cleanshot_2022-10-27_at_14.16.42.mp4