### PR TITLE
Data Apps: default to primary buttons

### DIFF
--- a/frontend/src/metabase/writeback/components/ActionViz/ActionButtonView.tsx
+++ b/frontend/src/metabase/writeback/components/ActionViz/ActionButtonView.tsx
@@ -16,7 +16,7 @@ function ActionButtonView({
   onClick,
 }: ActionButtonViewProps) {
   const label = settings["button.label"];
-  const variant = settings["button.variant"];
+  const variant = settings["button.variant"] ?? "primary";
 
   const variantProps: any = {};
   if (variant !== "default") {

--- a/frontend/src/metabase/writeback/components/ActionViz/ActionViz.tsx
+++ b/frontend/src/metabase/writeback/components/ActionViz/ActionViz.tsx
@@ -43,11 +43,11 @@ export default Object.assign(Action, {
       section: t`Display`,
       title: t`Variant`,
       widget: "select",
-      default: "default",
+      default: "primary",
       props: {
         options: [
-          { name: t`Default`, value: "default" },
           { name: t`Primary`, value: "primary" },
+          { name: t`Outline`, value: "default" },
           { name: t`Danger`, value: "danger" },
           { name: t`Success`, value: "success" },
           { name: t`Borderless`, value: "borderless" },


### PR DESCRIPTION
## Descriptions

Use Primary buttons as the default. Works seamlessly with scaffolding.

![Screen Shot 2022-10-27 at 2 22 06 PM](https://user-images.githubusercontent.com/30528226/198391421-3280deb9-58e0-4d80-aec4-a6a7f61fe52c.png)

