### PR TITLE
Show data apps in item picker

### DIFF
--- a/frontend/src/metabase/containers/ItemPicker.unit.spec.js
+++ b/frontend/src/metabase/containers/ItemPicker.unit.spec.js
@@ -92,6 +92,11 @@ function mockCollectionEndpoint({ extraCollections = [] } = {}) {
 }
 
 function mockCollectionItemsEndpoint() {
+  // additional app collection api call
+  xhrMock.get(/\/api\/collection\?namespace=apps/, (req, res) => {
+    return res.status(200).body(JSON.stringify([]));
+  });
+
   xhrMock.get(/\/api\/collection\/(root|[1-9]\d*)\/items.*/, (req, res) => {
     const collectionIdParam = req.url().path.split("/")[3];
     const collectionId =

--- a/frontend/src/metabase/entities/data-app-collections.js
+++ b/frontend/src/metabase/entities/data-app-collections.js
@@ -1,0 +1,44 @@
+import _ from "underscore";
+import { createSelector } from "reselect";
+
+import { createEntity } from "metabase/lib/entities";
+
+import { DataAppCollectionSchema } from "metabase/schema";
+import NormalCollections, {
+  getExpandedCollectionsById,
+} from "metabase/entities/collections";
+
+const DataAppCollections = createEntity({
+  name: "dataAppCollections",
+  schema: DataAppCollectionSchema,
+
+  api: _.mapObject(
+    NormalCollections.api,
+    fn =>
+      (params, ...opts) =>
+        fn({ ...params, namespace: "apps" }, ...opts),
+  ),
+
+  selectors: {
+    getExpandedCollectionsById: createSelector(
+      [
+        state => state.entities.dataAppCollections,
+        state => {
+          const { list } = state.entities.dataAppCollections_list[null] || {};
+          return list || [];
+        },
+      ],
+      (collections, collectionsIds) =>
+        getExpandedCollectionsById(
+          collectionsIds.map(id => collections[id]),
+          null,
+        ),
+    ),
+  },
+
+  objectSelectors: {
+    getIcon: () => ({ name: "star" }),
+  },
+});
+
+export default DataAppCollections;

--- a/frontend/src/metabase/entities/index.js
+++ b/frontend/src/metabase/entities/index.js
@@ -3,6 +3,7 @@ export { default as alerts } from "./alerts";
 export { default as collections } from "./collections";
 export { default as snippetCollections } from "./snippet-collections";
 export { default as dataApps } from "./data-apps";
+export { default as dataAppCollections } from "./data-app-collections";
 export { default as dashboards } from "./dashboards";
 export { default as databaseCandidates } from "./database-candidates";
 export { default as pulses } from "./pulses";

--- a/frontend/src/metabase/schema.js
+++ b/frontend/src/metabase/schema.js
@@ -64,6 +64,7 @@ export const MetricSchema = new schema.Entity("metrics");
 export const PersistedModelSchema = new schema.Entity("persistedModels");
 export const SnippetSchema = new schema.Entity("snippets");
 export const SnippetCollectionSchema = new schema.Entity("snippetCollections");
+export const DataAppCollectionSchema = new schema.Entity("dataAppCollections");
 export const TimelineSchema = new schema.Entity("timelines");
 export const TimelineEventSchema = new schema.Entity("timelineEvents");
 


### PR DESCRIPTION
Fixes it was impossible to conveniently add a new action to a model via New > Action flow. Since data apps collections were moved to a different collection namespace (`apps`), they don't get included in the regular `GET /api/collection` response and have to be fetched separately.

This PR fixes this issue in one of the most prominent places — the item picker. Now it'd fetch app collections and merge them into regular collections.

### To Verify

1. Scaffold a few collections based on different tables
2. New > Action
3. Fill in some query and click save
4. Click "Pick model"
5. Make sure you can navigate between both collections and apps and pick models inside