### PR TITLE
Archive personal collections when users are deactivated

### DIFF
--- a/frontend/src/metabase-types/api/collection.ts
+++ b/frontend/src/metabase-types/api/collection.ts
@@ -29,6 +29,7 @@ export interface Collection {
 
   parent_id?: CollectionId;
   personal_owner_id?: UserId;
+  personal_owner_active?: boolean;
 
   location?: string;
   effective_ancestors?: Collection[];

--- a/frontend/src/metabase/admin/people/containers/UserActivationModal.jsx
+++ b/frontend/src/metabase/admin/people/containers/UserActivationModal.jsx
@@ -25,7 +25,7 @@ class UserActivationModalInner extends React.Component {
           title={t`Deactivate ${user.common_name}?`}
           onClose={onClose}
         >
-          <Text>{t`${user.common_name} won't be able to log in anymore.`}</Text>
+          <Text>{t`${user.common_name} won't be able to log in anymore, and their personal collection will be archived.`}</Text>
           <Button
             ml="auto"
             danger
@@ -42,7 +42,7 @@ class UserActivationModalInner extends React.Component {
           onClose={onClose}
         >
           <Text>
-            {t`They'll be able to log in again, and they'll be placed back into the groups they were in before their account was deactivated.`}
+            {t`They'll be able to log in again, their personal collection will be unarchived, and they'll be placed back into the groups they were in before their account was deactivated.`}
           </Text>
           <Button
             ml="auto"

--- a/frontend/src/metabase/collections/components/CollectionHeader/CollectionMenu.tsx
+++ b/frontend/src/metabase/collections/components/CollectionHeader/CollectionMenu.tsx
@@ -55,6 +55,13 @@ const CollectionMenu = ({
       link: `${url}/move`,
       event: `${ANALYTICS_CONTEXT};Edit Menu;Move Collection`,
     });
+  }
+
+  if (
+    !isRoot &&
+    canWrite &&
+    (!isPersonal || !collection.personal_owner_active)
+  ) {
     items.push({
       title: t`Archive`,
       icon: "archive",

--- a/frontend/src/metabase/containers/UserCollectionList.jsx
+++ b/frontend/src/metabase/containers/UserCollectionList.jsx
@@ -39,23 +39,25 @@ const UserCollectionList = ({ collectionsById }) => (
         ]}
       />
     </ListHeader>
-    <User.ListLoader>
+    <User.ListLoader
+      query={{
+        status: "all",
+      }}
+    >
       {({ list }) => {
         return (
           <div>
             <Grid>
               {
-                // map through all users that have logged in at least once
-                // which gives them a personal collection ID
-                list.map(
-                  user =>
-                    user.personal_collection_id && (
+                // Render all personal collections that exist and are non-archived
+                list.map(user => {
+                  const collection =
+                    collectionsById[user.personal_collection_id];
+                  return (
+                    collection &&
+                    !collection.archived && (
                       <ListGridItem key={user.personal_collection_id}>
-                        <Link
-                          to={Urls.collection(
-                            collectionsById[user.personal_collection_id],
-                          )}
-                        >
+                        <Link to={Urls.collection(collection)}>
                           <Card p={2} hoverable>
                             <CardContent>
                               <Icon
@@ -69,8 +71,9 @@ const UserCollectionList = ({ collectionsById }) => (
                           </Card>
                         </Link>
                       </ListGridItem>
-                    ),
-                )
+                    )
+                  );
+                })
               }
             </Grid>
           </div>

--- a/src/metabase/api/collection.clj
+++ b/src/metabase/api/collection.clj
@@ -889,7 +889,7 @@
     ;; Check that we have approprate perms
     (api/check-403
      (perms/set-has-full-permissions-for-set? @api/*current-user-permissions-set*
-       (collection/perms-for-archiving collection-before-update)))))
+       (collection/perms-for-archiving collection-before-update (:archived collection-updates))))))
 
 (defn- maybe-send-archived-notificaitons!
   "When a collection is archived, all of it's cards are also marked as archived, but this is down in the model layer

--- a/src/metabase/api/user.clj
+++ b/src/metabase/api/user.clj
@@ -404,7 +404,7 @@
 
 #_{:clj-kondo/ignore [:deprecated-var]}
 (api/defendpoint-schema DELETE "/:id"
-  "Disable a `User`.  This does not remove the `User` from the DB, but instead disables their account."
+  "Disable a `User`. This does not remove the `User` from the DB, but instead disables their account."
   [id]
   (api/check-superuser)
   (api/check-500 (db/update! User id, :is_active false))

--- a/src/metabase/models/collection.clj
+++ b/src/metabase/models/collection.clj
@@ -623,7 +623,7 @@
          :location [:like (str (children-location collection) "%")]
          additional-conditions))
 
-(s/defn ^:private archive-collection!
+(s/defn archive-collection!
   "Archive a Collection and its descendant Collections and their Cards, Dashboards, and Pulses."
   [collection :- CollectionWithLocationAndIDOrRoot]
   (let [affected-collection-ids (cons (u/the-id collection)
@@ -637,7 +637,7 @@
                                 :archived      false}
                          :archived true)))))
 
-(s/defn ^:private unarchive-collection!
+(s/defn unarchive-collection!
   "Unarchive a Collection and its descendant Collections and their Cards, Dashboards, and Pulses."
   [collection :- CollectionWithLocationAndIDOrRoot]
   (let [affected-collection-ids (cons (u/the-id collection)

--- a/src/metabase/models/collection.clj
+++ b/src/metabase/models/collection.clj
@@ -561,7 +561,7 @@
     (throw (Exception. (tru "You cannot archive the Root Collection."))))
   ;; also make sure we're not trying to archive a PERSONAL Collection of an active user
   (when-let [owner-id (db/select-one-field :personal_owner_id Collection :id (u/the-id collection))]
-    (when (:is_active ('User owner-id))
+    (when-not (false? (:is_active ('User owner-id)))
       (throw (Exception. (tru "You cannot archive an active user's Personal Collection.")))))
   (set
    (for [collection-or-id (cons
@@ -742,8 +742,8 @@
                       :authority_level   (tru "You are not allowed to change the authority level of a Personal Collection.")
                       ;; The check below should be redundant because the `perms-for-moving` functions also check to
                       ;; make sure you're not operating on Personal Collections. But as an extra safety net it doesn't
-                      ;; hurt to check here too. Personal collections can be archived by admins if they belong to
-                      ;; deactivated users so we don't check that here.
+                      ;; hurt to check here too. Personal collections can be archived or unarchived by admins if they
+                      ;; belong to deactivated users so we don't check that here.
                       :location          (tru "You are not allowed to move a Personal Collection.")}]
     (when-let [[k msg] (->> unchangeable
                             (filter (fn [[k _msg]]

--- a/src/metabase/models/collection.clj
+++ b/src/metabase/models/collection.clj
@@ -566,7 +566,7 @@
    ;; Also make sure we're not trying to archive a PERSONAL Collection of an active user.
    ;; Personal collections of archived users may be unarchived.
    (when-let [owner-id (db/select-one-field :personal_owner_id Collection :id (u/the-id collection))]
-     (when (and archiving? (:is_active ('User owner-id)))
+     (when (and archiving? (t2/select-one-fn :is_active 'User :id owner-id))
        (throw (Exception. (tru "You cannot archive an active user's Personal Collection.")))))
    (set (for [collection-or-id (cons
                                 (parent collection)

--- a/src/metabase/models/user.clj
+++ b/src/metabase/models/user.clj
@@ -112,12 +112,12 @@
   (when locale
     (assert (i18n/available-locale? locale) (tru "Invalid locale: {0}" (pr-str locale))))
   ;; delete all subscriptions to pulses/alerts/etc. if the User is getting archived (`:is_active` status changes)
-  (when (not active?)
+  (when (false? active?)
     (db/delete! 'PulseChannelRecipient :user_id id))
   ;; archive or unarchive the user's personal collection as necessary
-  (let [{archived? :archived :as personal-collection} (db/select-one Collection :personal_owner_id id)]
+  (when-let [{archived? :archived :as personal-collection} (db/select-one Collection :personal_owner_id id)]
     (cond
-      (and (not active?) (not archived?))
+      (and (false? active?) (not archived?))
       (collection/archive-collection! personal-collection)
 
       (and active? archived?)

--- a/test/metabase/api/collection_test.clj
+++ b/test/metabase/api/collection_test.clj
@@ -836,19 +836,20 @@
 (defn- lucky-personal-collection []
   (merge
    (mt/object-defaults Collection)
-   {:slug                "lucky_pigeon_s_personal_collection"
-    :color               "#31698A"
-    :can_write           true
-    :name                "Lucky Pigeon's Personal Collection"
-    :personal_owner_id   (mt/user->id :lucky)
-    :effective_ancestors [{:metabase.models.collection.root/is-root? true
-                           :name                                     "Our analytics"
-                           :id                                       "root"
-                           :authority_level                          nil
-                           :can_write                                true}]
-    :effective_location  "/"
-    :parent_id           nil
-    :location            "/"}
+   {:slug                  "lucky_pigeon_s_personal_collection"
+    :color                 "#31698A"
+    :can_write             true
+    :name                  "Lucky Pigeon's Personal Collection"
+    :personal_owner_id     (mt/user->id :lucky)
+    :personal_owner_active true
+    :effective_ancestors   [{:metabase.models.collection.root/is-root? true
+                              :name                                     "Our analytics"
+                              :id                                       "root"
+                              :authority_level                          nil
+                              :can_write                                true}]
+    :effective_location    "/"
+    :parent_id             nil
+    :location              "/"}
    (select-keys (collection/user->personal-collection (mt/user->id :lucky))
                 [:id :entity_id :created_at])))
 

--- a/test/metabase/models/collection_test.clj
+++ b/test/metabase/models/collection_test.clj
@@ -1215,13 +1215,6 @@
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
 (deftest personal-collections-restrictions-test
-  (testing "Make sure we're not allowed to *unarchive* a Personal Collection"
-    (mt/with-temp User [my-cool-user]
-      (let [personal-collection (collection/user->personal-collection my-cool-user)]
-        (is (thrown?
-             Exception
-             (db/update! Collection (u/the-id personal-collection) :archived true))))))
-
   (testing "Make sure we're not allowed to *move* a Personal Collection"
     (mt/with-temp* [User       [my-cool-user]
                     Collection [some-other-collection]]


### PR DESCRIPTION
Resolves #25830

Updates the logic around deactivating users to also archive the user's personal collection automatically, as well as unarchive it if the user is reactivated. 

A deactivated user's personal collection can be unarchived manually by an admin if they still need access to its contents. This required some small FE changes to ensure that it would show up properly in the personal collections list, and that it can be subsequently re-archived. I've made these changes and added a Cypress test that exercises this flow.