### PR TITLE
More Detailed List Viz Headers

### DIFF
--- a/frontend/src/metabase/visualizations/components/List/List.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/List/List.styled.tsx
@@ -25,15 +25,6 @@ export const Footer = styled(TableFooter)`
   margin-top: 0.5rem;
 `;
 
-export const ListHeader = styled.div`
-  display: flex;
-  padding: 0.5rem 1.5rem;
-  font-weight: bold;
-  font-size: 0.75rem;
-  justify-content: space-between;
-  color: ${color("text-medium")};
-`;
-
 export const ListBody = styled.ul`
   box-shadow: 0px 1px 10px ${color("shadow")};
   border-radius: ${LIST_ITEM_BORDER_RADIUS};

--- a/frontend/src/metabase/visualizations/components/List/List.tsx
+++ b/frontend/src/metabase/visualizations/components/List/List.tsx
@@ -21,12 +21,11 @@ import {
   Root,
   Footer,
   LIST_ITEM_BORDER_DIVIDER_WIDTH,
-  ListHeader,
   ListBody,
   ListItemRow,
 } from "./List.styled";
 
-import { VariantInfo } from "./VariantInfo";
+import { VariantInfoHeader, VariantInfoRow } from "./VariantInfo";
 
 function getBoundingClientRectSafe(ref: React.RefObject<HTMLBaseElement>) {
   return ref.current?.getBoundingClientRect?.() ?? ({} as DOMRect);
@@ -151,12 +150,11 @@ function List({
           isClickable={isClickable}
           data-testid="table-row"
         >
-          <VariantInfo
+          <VariantInfoRow
             data={data}
             row={row}
             listColumnIndexes={listColumnIndexes}
             settings={settings}
-            getColumnTitle={getColumnTitle}
           />
         </ListItemRow>
       );
@@ -168,16 +166,15 @@ function List({
       isDataApp,
       checkIsVisualizationClickable,
       onVisualizationClick,
-      getColumnTitle,
     ],
   );
 
   return (
     <Root className={className} isQueryBuilder={isQueryBuilder}>
-      <ListHeader>
-        <div></div>
-        <div>{getColumnTitle(listColumnIndexes.right[0])}</div>
-      </ListHeader>
+      <VariantInfoHeader
+        listColumnIndexes={listColumnIndexes}
+        getColumnTitle={getColumnTitle}
+      />
       <ListBody>{paginatedRowIndexes.map(renderListItem)}</ListBody>
       {pageSize < rows.length && (
         <Footer

--- a/frontend/src/metabase/visualizations/components/List/ListCell.tsx
+++ b/frontend/src/metabase/visualizations/components/List/ListCell.tsx
@@ -2,7 +2,6 @@ import React, { useMemo } from "react";
 import cx from "classnames";
 
 import ExternalLink from "metabase/core/components/ExternalLink";
-import Tooltip from "metabase/components/Tooltip";
 
 import { formatValue } from "metabase/lib/formatting";
 import { getColumnExtent } from "metabase/visualizations/lib/utils";
@@ -17,7 +16,6 @@ export interface ListCellProps
   extends Pick<VisualizationProps, "data" | "settings"> {
   value: Value;
   columnIndex: number;
-  columnTitle?: string;
 }
 
 interface CellDataProps {
@@ -60,7 +58,6 @@ function ListCellContent({
   data,
   settings,
   columnIndex,
-  columnTitle,
 }: ListCellProps) {
   const { rows, cols } = data;
   const column = cols[columnIndex];
@@ -85,15 +82,13 @@ function ListCellContent({
   });
 
   return (
-    <Tooltip tooltip={columnTitle}>
-      <CellContent
-        className={classNames}
-        isClickable={isLink}
-        data-testid="cell-data"
-      >
-        {cellData}
-      </CellContent>
-    </Tooltip>
+    <CellContent
+      className={classNames}
+      isClickable={isLink}
+      data-testid="cell-data"
+    >
+      {cellData}
+    </CellContent>
   );
 }
 

--- a/frontend/src/metabase/visualizations/components/List/VariantInfo.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/List/VariantInfo.styled.tsx
@@ -40,3 +40,13 @@ export const InfoRight = styled.div`
   font-size: 0.75rem;
   font-weight: bold;
 `;
+
+export const ListHeader = styled.div<{ hasImage?: boolean }>`
+  display: flex;
+  padding: 0.5rem 1.5rem;
+  ${({ hasImage }) => (hasImage ? "padding-left: 4.75rem;" : "")}
+  font-weight: bold;
+  font-size: 0.75rem;
+  justify-content: space-between;
+  color: ${color("text-medium")};
+`;

--- a/frontend/src/metabase/visualizations/components/List/VariantInfo.tsx
+++ b/frontend/src/metabase/visualizations/components/List/VariantInfo.tsx
@@ -1,6 +1,6 @@
 import React from "react";
+import { t } from "ttag";
 
-import humanize from "inflection";
 import { isEmpty } from "metabase/lib/validate";
 import { Avatar } from "metabase/components/UserAvatar";
 
@@ -48,14 +48,14 @@ export const VariantInfoHeader = ({
     getColumnTitle(subtitle2Index),
   ].filter(Boolean);
 
-  const leftTitleString =
+  const leftTitle =
     leftTitleArray.length === 3
-      ? `${leftTitleArray[0]}, ${leftTitleArray[1]}, and ${leftTitleArray[2]}`
+      ? t`${leftTitleArray[0]}, ${leftTitleArray[1]}, and ${leftTitleArray[2]}`
       : leftTitleArray.join(" & ");
 
   return (
     <ListHeader hasImage={!isEmpty(imageIndex)}>
-      <div>{leftTitleString}</div>
+      <div>{leftTitle}</div>
       <div>{getColumnTitle(infoIndex)}</div>
     </ListHeader>
   );

--- a/frontend/src/metabase/visualizations/components/List/VariantInfo.tsx
+++ b/frontend/src/metabase/visualizations/components/List/VariantInfo.tsx
@@ -5,9 +5,10 @@ import { Avatar } from "metabase/components/UserAvatar";
 
 import { isImageURL } from "metabase-lib/types/utils/isa";
 
-import type { ListVariantProps } from "./types";
+import type { ListColumnIndexes, ListVariantProps } from "./types";
 import {
   InfoListItem,
+  ListHeader,
   ListItemTitle,
   ListItemSubtitle,
   InfoLeft,
@@ -16,20 +17,61 @@ import {
 
 import ListCell from "./ListCell";
 
-export const VariantInfo = ({
+const getNamedColumnIndexes = (listColumnIndexes: ListColumnIndexes) => {
+  const [imageIndex] = listColumnIndexes.image;
+  const [titleIndex, subtitleIndex, subtitle2Index] = listColumnIndexes.left;
+  const [infoIndex] = listColumnIndexes.right;
+
+  return {
+    imageIndex,
+    titleIndex,
+    subtitleIndex,
+    subtitle2Index,
+    infoIndex,
+  };
+};
+
+export const VariantInfoHeader = ({
+  listColumnIndexes,
+  getColumnTitle,
+}: {
+  listColumnIndexes: ListColumnIndexes;
+  getColumnTitle: (columnIndex: number) => string;
+}) => {
+  const { imageIndex, titleIndex, subtitleIndex, subtitle2Index, infoIndex } =
+    getNamedColumnIndexes(listColumnIndexes);
+
+  const leftTitleArray = [
+    getColumnTitle(titleIndex),
+    getColumnTitle(subtitleIndex),
+    getColumnTitle(subtitle2Index),
+  ].filter(Boolean);
+
+  const leftTitleString =
+    leftTitleArray.length === 3
+      ? `${leftTitleArray[0]}, ${leftTitleArray[1]}, and ${leftTitleArray[2]}`
+      : leftTitleArray.join(" & ");
+
+  return (
+    <ListHeader hasImage={!isEmpty(imageIndex)}>
+      <div>{leftTitleString}</div>
+      <div>{getColumnTitle(infoIndex)}</div>
+    </ListHeader>
+  );
+};
+
+export const VariantInfoRow = ({
   data,
   row,
   listColumnIndexes,
   settings,
-  getColumnTitle,
 }: ListVariantProps) => {
   if (!data || !row) {
     return null;
   }
 
-  const [imageIndex] = listColumnIndexes.image;
-  const [titleIndex, subtitleIndex, subtitle2Index] = listColumnIndexes.left;
-  const [infoIndex] = listColumnIndexes.right;
+  const { imageIndex, titleIndex, subtitleIndex, subtitle2Index, infoIndex } =
+    getNamedColumnIndexes(listColumnIndexes);
 
   const image = row[imageIndex];
   const title = row[titleIndex];
@@ -45,7 +87,6 @@ export const VariantInfo = ({
         {image && imageColIsImage && (
           <ListCell
             value={image}
-            columnTitle={getColumnTitle(imageIndex)}
             data={data}
             settings={settings}
             columnIndex={imageIndex}
@@ -59,7 +100,6 @@ export const VariantInfo = ({
             {!isEmpty(title) && (
               <ListCell
                 value={title}
-                columnTitle={getColumnTitle(titleIndex)}
                 data={data}
                 settings={settings}
                 columnIndex={titleIndex}
@@ -70,7 +110,6 @@ export const VariantInfo = ({
             {!isEmpty(subtitle) && (
               <ListCell
                 value={subtitle}
-                columnTitle={getColumnTitle(subtitleIndex)}
                 data={data}
                 settings={settings}
                 columnIndex={subtitleIndex}
@@ -80,7 +119,6 @@ export const VariantInfo = ({
             {!isEmpty(subtitle2) && (
               <ListCell
                 value={subtitle2}
-                columnTitle={getColumnTitle(subtitle2Index)}
                 data={data}
                 settings={settings}
                 columnIndex={subtitle2Index}
@@ -93,7 +131,6 @@ export const VariantInfo = ({
         {!isEmpty(info) && (
           <ListCell
             value={info}
-            columnTitle={getColumnTitle(infoIndex)}
             data={data}
             settings={settings}
             columnIndex={infoIndex}

--- a/frontend/src/metabase/visualizations/components/List/VariantInfo.tsx
+++ b/frontend/src/metabase/visualizations/components/List/VariantInfo.tsx
@@ -1,13 +1,15 @@
 import React from "react";
 
+import humanize from "inflection";
 import { isEmpty } from "metabase/lib/validate";
 import { Avatar } from "metabase/components/UserAvatar";
 
 import { isImageURL } from "metabase-lib/types/utils/isa";
 
-import type { ListVariantProps } from "./types";
+import type { ListColumnIndexes, ListVariantProps } from "./types";
 import {
   InfoListItem,
+  ListHeader,
   ListItemTitle,
   ListItemSubtitle,
   InfoLeft,
@@ -16,20 +18,61 @@ import {
 
 import ListCell from "./ListCell";
 
-export const VariantInfo = ({
+const getNamedColumnIndexes = (listColumnIndexes: ListColumnIndexes) => {
+  const [imageIndex] = listColumnIndexes.image;
+  const [titleIndex, subtitleIndex, subtitle2Index] = listColumnIndexes.left;
+  const [infoIndex] = listColumnIndexes.right;
+
+  return {
+    imageIndex,
+    titleIndex,
+    subtitleIndex,
+    subtitle2Index,
+    infoIndex,
+  };
+};
+
+export const VariantInfoHeader = ({
+  listColumnIndexes,
+  getColumnTitle,
+}: {
+  listColumnIndexes: ListColumnIndexes;
+  getColumnTitle: (columnIndex: number) => string;
+}) => {
+  const { imageIndex, titleIndex, subtitleIndex, subtitle2Index, infoIndex } =
+    getNamedColumnIndexes(listColumnIndexes);
+
+  const leftTitleArray = [
+    getColumnTitle(titleIndex),
+    getColumnTitle(subtitleIndex),
+    getColumnTitle(subtitle2Index),
+  ].filter(Boolean);
+
+  const leftTitleString =
+    leftTitleArray.length === 3
+      ? `${leftTitleArray[0]}, ${leftTitleArray[1]}, and ${leftTitleArray[2]}`
+      : leftTitleArray.join(" & ");
+
+  return (
+    <ListHeader hasImage={!isEmpty(imageIndex)}>
+      <div>{leftTitleString}</div>
+      <div>{getColumnTitle(infoIndex)}</div>
+    </ListHeader>
+  );
+};
+
+export const VariantInfoRow = ({
   data,
   row,
   listColumnIndexes,
   settings,
-  getColumnTitle,
 }: ListVariantProps) => {
   if (!data || !row) {
     return null;
   }
 
-  const [imageIndex] = listColumnIndexes.image;
-  const [titleIndex, subtitleIndex, subtitle2Index] = listColumnIndexes.left;
-  const [infoIndex] = listColumnIndexes.right;
+  const { imageIndex, titleIndex, subtitleIndex, subtitle2Index, infoIndex } =
+    getNamedColumnIndexes(listColumnIndexes);
 
   const image = row[imageIndex];
   const title = row[titleIndex];
@@ -45,7 +88,6 @@ export const VariantInfo = ({
         {image && imageColIsImage && (
           <ListCell
             value={image}
-            columnTitle={getColumnTitle(imageIndex)}
             data={data}
             settings={settings}
             columnIndex={imageIndex}
@@ -59,7 +101,6 @@ export const VariantInfo = ({
             {!isEmpty(title) && (
               <ListCell
                 value={title}
-                columnTitle={getColumnTitle(titleIndex)}
                 data={data}
                 settings={settings}
                 columnIndex={titleIndex}
@@ -70,7 +111,6 @@ export const VariantInfo = ({
             {!isEmpty(subtitle) && (
               <ListCell
                 value={subtitle}
-                columnTitle={getColumnTitle(subtitleIndex)}
                 data={data}
                 settings={settings}
                 columnIndex={subtitleIndex}
@@ -80,7 +120,6 @@ export const VariantInfo = ({
             {!isEmpty(subtitle2) && (
               <ListCell
                 value={subtitle2}
-                columnTitle={getColumnTitle(subtitle2Index)}
                 data={data}
                 settings={settings}
                 columnIndex={subtitle2Index}
@@ -93,7 +132,6 @@ export const VariantInfo = ({
         {!isEmpty(info) && (
           <ListCell
             value={info}
-            columnTitle={getColumnTitle(infoIndex)}
             data={data}
             settings={settings}
             columnIndex={infoIndex}

--- a/frontend/src/metabase/visualizations/components/List/types.ts
+++ b/frontend/src/metabase/visualizations/components/List/types.ts
@@ -12,5 +12,4 @@ export interface ListColumnIndexes {
 export type ListVariantProps = Pick<VisualizationProps, "settings" | "data"> & {
   row: Row;
   listColumnIndexes: ListColumnIndexes;
-  getColumnTitle: (columnIndex: number) => string;
 };


### PR DESCRIPTION
## Description

Adds a left header to list viz. Also makes the header specific to the info viz, because it probably won't work for other variants.

Should work with 1, 2, or 3 columns in list viz, and should work with or without avatar images.

![Screen Shot 2022-10-28 at 2 35 18 PM](https://user-images.githubusercontent.com/30528226/198727632-6b93eea2-6e33-489e-9d56-afb755262311.png)
![Screen Shot 2022-10-28 at 2 35 41 PM](https://user-images.githubusercontent.com/30528226/198727630-ae651af5-247a-4d96-825d-d30f2b6a8561.png)
![Screen Shot 2022-10-28 at 2 35 53 PM](https://user-images.githubusercontent.com/30528226/198727628-58106fc3-8c17-4997-845f-f35883d672ca.png)
![Screen Shot 2022-10-28 at 2 34 16 PM](https://user-images.githubusercontent.com/30528226/198727633-83dc9074-85a4-45c1-9b88-1f417b868ae1.png)


