### PR TITLE
Adding Tests for hasColumnSettings, Fixing currency bug

### DIFF
--- a/frontend/src/metabase/visualizations/components/ChartSettings.jsx
+++ b/frontend/src/metabase/visualizations/components/ChartSettings.jsx
@@ -172,6 +172,10 @@ class ChartSettings extends Component {
       settings,
       computedSettings,
       col,
+      _.noop,
+      {
+        series,
+      },
     ).some(widget => !widget.hidden);
   }
 

--- a/frontend/src/metabase/visualizations/lib/settings/column.js
+++ b/frontend/src/metabase/visualizations/lib/settings/column.js
@@ -366,9 +366,7 @@ export const NUMBER_COLUMN_SETTINGS = {
     default: true,
     getHidden: (column, settings, { series }) =>
       settings["number_style"] !== "currency" ||
-      // FIXME: temp stub to unbreak the page
-      // https://metaboat.slack.com/archives/C505ZNNH4/p1665002329746859
-      series?.[0].card.display !== "table",
+      series[0].card.display !== "table",
     readDependencies: ["number_style"],
   },
   number_separators: {

--- a/frontend/test/metabase/visualizations/components/settings/ChartSettingFieldPicker.unit.spec.js
+++ b/frontend/test/metabase/visualizations/components/settings/ChartSettingFieldPicker.unit.spec.js
@@ -1,0 +1,77 @@
+import React from "react";
+import { within } from "@testing-library/dom";
+import { renderWithProviders } from "__support__/ui";
+
+// these tests use ChartSettings directly, but logic we're testing lives in ChartNestedSettingSeries
+import ChartSettings from "metabase/visualizations/components/ChartSettings";
+
+function getSeries(metricColumnProps) {
+  return [
+    {
+      card: {
+        display: "line",
+        visualization_settings: {
+          "graph.dimensions": ["FOO"],
+          "graph.metrics": ["BAR"],
+        },
+      },
+      data: {
+        rows: [
+          ["a", 1],
+          ["b", 2],
+        ],
+        cols: [
+          {
+            name: "FOO",
+            display_name: "FOO",
+            source: "native",
+            base_type: "type/Text",
+            field_ref: ["field", "FOO", {}],
+          },
+          {
+            name: "BAR",
+            display_name: "BAR",
+            source: "native",
+            base_type: "type/Integer",
+            field_ref: ["field", "BAR", {}],
+            ...metricColumnProps,
+          },
+        ],
+      },
+    },
+  ];
+}
+
+const setup = seriesDisplay => {
+  const series = getSeries(seriesDisplay);
+  return renderWithProviders(
+    <ChartSettings series={series} initial={{ section: "Data" }} />,
+    {
+      withSettings: true,
+      withEmbedSettings: true,
+    },
+  );
+};
+
+describe("ChartSettinFieldPicker", () => {
+  it("should not show ellipsis when a colum has no settings", () => {
+    const { getAllByTestId } = setup();
+
+    const fields = getAllByTestId("chartsettings-field-picker");
+
+    expect(fields[0]).toHaveTextContent("FOO");
+    expect(fields[1]).toHaveTextContent("BAR");
+
+    expect(
+      within(fields[0]).queryByRole("img", { name: /ellipsis/i }),
+    ).not.toBeInTheDocument();
+
+    expect(
+      within(fields[1]).queryByRole("img", { name: /ellipsis/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("Should handle 'hasColumnSettings' check when dealing with currency", () => {
+    setup({ semantic_type: "type/Currency" });
+  });
+});

--- a/frontend/test/metabase/visualizations/components/settings/ChartSettingFieldPicker.unit.spec.js
+++ b/frontend/test/metabase/visualizations/components/settings/ChartSettingFieldPicker.unit.spec.js
@@ -2,7 +2,7 @@ import React from "react";
 import { within } from "@testing-library/dom";
 import { renderWithProviders } from "__support__/ui";
 
-// these tests use ChartSettings directly, but logic we're testing lives in ChartNestedSettingSeries
+// these tests use ChartSettings directly, but logic we're testing logic in ChartSettingFieldPicker
 import ChartSettings from "metabase/visualizations/components/ChartSettings";
 
 function getSeries(metricColumnProps) {


### PR DESCRIPTION
Fixing an issue where the query builder would throw an error when we checked hasColumnSettings on a graph that contained a currency column. Additional details can be found [here](https://metaboat.slack.com/archives/C505ZNNH4/p1665002329746859)

Also added unit tests around showing the ellipsis for `ChartSettingFieldPicker`.