### PR TITLE
Serdes: Hide `entity_id` from Serdes v1; it was causing errors (#26141)

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/serialization/serialize.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/serialize.clj
@@ -100,7 +100,7 @@
   [entity]
   (cond-> (dissoc entity :id :creator_id :created_at :updated_at :db_id :location
                   :dashboard_id :fields_hash :personal_owner_id :made_public_by_id :collection_id
-                  :pulse_id :result_metadata)
+                  :pulse_id :result_metadata :entity_id)
     (some #(instance? % entity) (map type [Metric Field Segment])) (dissoc :table_id)))
 
 (defmulti ^:private serialize-one


### PR DESCRIPTION
Backports https://github.com/metabase/metabase/pull/26141