### PR TITLE
fix backport comment command

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -11,23 +11,23 @@ jobs:
     if: contains(github.event.comment.body, '@metabase-bot backport')
     runs-on: ubuntu-20.04
     steps:
+      - uses: tibdex/github-app-token@v1.6.0
+        id: generate-token
+        with:
+          app_id: ${{ secrets.METABASE_BOT_APP_ID }}
+          private_key: ${{ secrets.METABASE_BOT_APP_PRIVATE_KEY }}
       - id: is_organization_member
         uses: JamesSingleton/is-organization-member@1.0.0
         with:
           organization: metabase
           username: ${{ github.event.issue.user.login }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.generate-token.outputs.token }}
       - run: |
           result=${{ steps.is_organization_member.outputs.result }}
           if [ $result == false ]; then
               echo User ${{ github.event.comment.user.login }} is not a member of Metabase organization
               exit 1
           fi
-      - uses: tibdex/github-app-token@v1.6.0
-        id: generate-token
-        with:
-          app_id: ${{ secrets.METABASE_BOT_APP_ID }}
-          private_key: ${{ secrets.METABASE_BOT_APP_PRIVATE_KEY }}
       - uses: actions/github-script@v4
         id: branch_info
         with:

--- a/.github/workflows/percy-issue-comment.yml
+++ b/.github/workflows/percy-issue-comment.yml
@@ -14,12 +14,17 @@ jobs:
       branch_name: ${{ fromJson(steps.fetch_pr.outputs.data).head.ref }}
       commit_sha: ${{ fromJson(steps.fetch_pr.outputs.data).head.sha }}
     steps:
+      - uses: tibdex/github-app-token@v1.6.0
+        id: generate-token
+        with:
+          app_id: ${{ secrets.METABASE_BOT_APP_ID }}
+          private_key: ${{ secrets.METABASE_BOT_APP_PRIVATE_KEY }}
       - id: is_organization_member
         uses: JamesSingleton/is-organization-member@1.0.0
         with:
           organization: metabase
           username: ${{ github.event.issue.user.login }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.generate-token.outputs.token }}
       - run: |
           result=${{ steps.is_organization_member.outputs.result }}
           if [ $result == false ]; then


### PR DESCRIPTION
[Slack convo](https://metaboat.slack.com/archives/C5XHN8GLW/p1667232827671389) 

In workflows that are triggered by a comment, we check if a user belongs to the organization. However, the action used GHA bot token which can't see private organization memberships which leads to failed backports when using `@metabase-bot backport release-....` command. Using our own Metabase Bot token should solve the issue