### PR TITLE
Rename `dateAdd` to `datetimeAdd` - the missing file

### DIFF
--- a/frontend/src/metabase-lib/expressions/typeinferencer.js
+++ b/frontend/src/metabase-lib/expressions/typeinferencer.js
@@ -37,8 +37,8 @@ export function infer(mbql, env) {
     case "case":
       return infer(mbql[1][0][1], env);
     case "coalesce":
-    case "date-add":
-    case "date-subtract":
+    case "datetime-add":
+    case "datetime-subtract":
       return infer(mbql[1], env);
   }
 

--- a/frontend/test/metabase/lib/expressions/typeinferencer.unit.spec.js
+++ b/frontend/test/metabase/lib/expressions/typeinferencer.unit.spec.js
@@ -36,6 +36,8 @@ describe("metabase-lib/expressions/typeinferencer", () => {
       case "Location":
       case "Place":
         return "type/Coordinate";
+      case "CreatedAt":
+        return "type/Datetime";
     }
   }
 
@@ -111,5 +113,30 @@ describe("metabase-lib/expressions/typeinferencer", () => {
     expect(type("COALESCE([FirstName], [LastName])")).toEqual("string");
     expect(type("COALESCE([BirthDate], [MiscDate])")).toEqual("type/Temporal");
     expect(type("COALESCE([Place], [Location])")).toEqual("type/Coordinate");
+  });
+
+  it("should infer the result of datetimeAdd, datetimeSubtract", () => {
+    expect(type('datetimeAdd([CreatedAt], 2, "month")')).toEqual(
+      "type/Datetime",
+    );
+    expect(type('datetimeSubtract([CreatedAt], 2, "month")')).toEqual(
+      "type/Datetime",
+    );
+  });
+
+  it("should infer the result of datetimeExtract functions", () => {
+    const ops = [
+      "year",
+      "month",
+      "quarter",
+      "month",
+      "week",
+      "hour",
+      "minute",
+      "second",
+    ];
+    ops.forEach(op => {
+      expect(type(`${op}([Created At])`)).toEqual("number");
+    });
   });
 });


### PR DESCRIPTION
We named `dateAdd` and `dateSubtract` to `datetimeAdd` and `datetimeSubtract` in #26147, but we've missed one file. This PR makes sure it's whole.

Also adds some tests on FE for these expressions.