### PR TITLE
Fix python code for iframe dashboard

### DIFF
--- a/frontend/src/metabase/public/lib/code.js
+++ b/frontend/src/metabase/public/lib/code.js
@@ -158,7 +158,7 @@ payload = {
   },
   "exp": round(time.time()) + (60 * 10) # 10 minute expiration
 }
-token = jwt.encode(payload, METABASE_SECRET_KEY, algorithm="HS256")
+token = jwt.encode(payload, METABASE_SECRET_KEY, algorithm="HS256").decode("UTF-8")
 
 iframeUrl = METABASE_SITE_URL + "/embed/${resourceType}/" + token${
     optionsToHashParams(displayOptions)


### PR DESCRIPTION
#### Problem

The token type is bytes, so if the token is concatenated with a string, it becomes `"{{string}}b'{{token}}'"‍`.

#### Solution

Use `.decode("UTF-8")`