### PR TITLE
Fix google-auth-enabled when upgrading from pre x.45

### DIFF
--- a/src/metabase/integrations/google.clj
+++ b/src/metabase/integrations/google.clj
@@ -44,6 +44,10 @@
   (deferred-tru "Is Google Sign-in currently enabled?")
   :visibility :public
   :type       :boolean
+  :getter     (fn []
+                (if-some [value setting/get-value-of-type :boolean :google-auth-enabled]
+                  value
+                  (boolean (google-auth-client-id))))
   :setter     (fn [new-value]
                 (if-let [new-value (boolean new-value)]
                   (if-not (google-auth-client-id)

--- a/src/metabase/integrations/google.clj
+++ b/src/metabase/integrations/google.clj
@@ -45,7 +45,7 @@
   :visibility :public
   :type       :boolean
   :getter     (fn []
-                (if-some [value setting/get-value-of-type :boolean :google-auth-enabled]
+                (if-some [value (setting/get-value-of-type :boolean :google-auth-enabled)]
                   value
                   (boolean (google-auth-client-id))))
   :setter     (fn [new-value]


### PR DESCRIPTION
How to test:
- Run a **fresh** Metabase 0.44 and setup google auth in Admin
- Checkout this PR and run Metabase again (it's ~0.45 now)
- Go to Admin -> Settings -> Authentication
- Google auth should be automatically enabled
- Make sure toggling off and on works 