### PR TITLE
Data apps/external link bug

### DIFF
--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/LinkOptions/CustomURLPicker.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/LinkOptions/CustomURLPicker.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from "react";
+import React, { useCallback, useState } from "react";
 import { t } from "ttag";
 
 import InputBlurChange from "metabase/components/InputBlurChange";
@@ -38,18 +38,19 @@ function CustomURLPicker({
   dashcard,
   parameters,
 }: Props) {
-  const hasLinkTemplate = clickBehavior.linkTemplate != null;
-  const canSelect = clickBehaviorIsValid(clickBehavior);
+  const [url, setUrl] = useState(clickBehavior?.linkTemplate ?? "");
+  const hasLinkTemplate = !!clickBehavior.linkTemplate;
+  const canSelect = clickBehaviorIsValid({
+    ...clickBehavior,
+    linkTemplate: url,
+  });
 
-  const handleLinkTemplateChange = useCallback(
-    e => {
-      updateSettings({
-        ...clickBehavior,
-        linkTemplate: e.target.value,
-      });
-    },
-    [clickBehavior, updateSettings],
-  );
+  const handleLinkTemplateChange = useCallback(() => {
+    updateSettings({
+      ...clickBehavior,
+      linkTemplate: url,
+    });
+  }, [clickBehavior, updateSettings, url]);
 
   const handleReset = useCallback(() => {
     updateSettings({
@@ -86,9 +87,11 @@ function CustomURLPicker({
           </FormDescription>
           <InputBlurChange
             autoFocus
-            value={clickBehavior.linkTemplate}
+            value={url}
             placeholder={t`e.g. http://acme.com/id/\{\{user_id\}\}`}
-            onChange={handleLinkTemplateChange}
+            onChange={(e: React.FormEvent<HTMLInputElement>) =>
+              setUrl(e.currentTarget.value)
+            }
             className="input block full"
           />
           {isTableDisplay(dashcard) && (
@@ -100,7 +103,11 @@ function CustomURLPicker({
           <ValuesYouCanReference dashcard={dashcard} parameters={parameters} />
           <DoneButton
             primary
-            onClick={onClose}
+            type="button"
+            onClick={() => {
+              handleLinkTemplateChange();
+              onClose();
+            }}
             disabled={!canSelect}
           >{t`Done`}</DoneButton>
         </ModalContent>

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/LinkOptions/ValuesYouCanReference.jsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/LinkOptions/ValuesYouCanReference.jsx
@@ -46,6 +46,11 @@ const ValuesYouCanReference = withUserAttributes(
         name: t`User attributes`,
       },
     ].filter(section => section.items.length > 0);
+
+    if (!sections.length) {
+      return null;
+    }
+
     return (
       <PopoverWithTrigger
         triggerElement={


### PR DESCRIPTION
## Description

Previously, typing in an external link on an action button would close the modal after the first input event 🤯 . This was because the action sidebar is set to close when a valid action is added, and technically a 1-character url is a valid url 🤷 

This makes the url modal not update the action state until it is closed. 🥳 

![addLink](https://user-images.githubusercontent.com/30528226/199295015-6c06b2df-a6f2-40e3-8fba-bda8770bfc19.gif)

Also threw in a little fix for the "values you can reference" section. It won't show at all if there aren't any values you can reference.
