### PR TITLE
Fix Action Creator Error Flash

### DIFF
--- a/frontend/src/metabase/writeback/components/ActionCreator/ActionCreator.tsx
+++ b/frontend/src/metabase/writeback/components/ActionCreator/ActionCreator.tsx
@@ -121,7 +121,7 @@ function ActionCreatorComponent({
             form={isNew ? Actions.forms.saveForm : Actions.forms.updateForm}
             action={{
               id: (question.card() as SavedCard).id,
-              name: question.displayName(),
+              name: question?.displayName() ?? t`New Action`,
               description: question.description(),
               model_id: defaultModelId,
               formSettings,


### PR DESCRIPTION
## Description

At long last, the bugfix you've all been waiting for! (seriously, this has been reported at least 35 times).  The action creator no longer falsely tells users that action name is a required field when they have already entered a valid name.

Before | After
--- | ---
![after](https://user-images.githubusercontent.com/30528226/199341896-c798d411-1c2c-4e49-913a-e20f9538644c.gif) | ![before](https://user-images.githubusercontent.com/30528226/199341895-e8acb9cc-0d70-4e23-b6b6-71e4d7ecc645.gif) | 
