### PR TITLE
Match static combo chart colors and legends with app viz colors

### DIFF
--- a/frontend/src/metabase/lib/colors/charts.ts
+++ b/frontend/src/metabase/lib/colors/charts.ts
@@ -12,7 +12,7 @@ export const getColorsForValues = (
       keys,
       getAccentColors({ light: false, dark: false }, palette),
       existingMapping,
-      getPreferredColor,
+      (color: string) => getPreferredColor(color, palette),
     );
   } else {
     return getOrderBasedMapping(
@@ -22,7 +22,7 @@ export const getColorsForValues = (
         palette,
       ),
       existingMapping,
-      getPreferredColor,
+      (color: string) => getPreferredColor(color, palette),
     );
   }
 };

--- a/frontend/src/metabase/lib/colors/charts.ts
+++ b/frontend/src/metabase/lib/colors/charts.ts
@@ -1,21 +1,26 @@
 import { getAccentColors, getPreferredColor } from "./groups";
 import { ACCENT_COUNT } from "./palette";
+import { ColorPalette } from "./types";
 
 export const getColorsForValues = (
   keys: string[],
   existingMapping?: Record<string, string> | null,
+  palette?: ColorPalette,
 ) => {
   if (keys.length <= ACCENT_COUNT) {
     return getHashBasedMapping(
       keys,
-      getAccentColors({ light: false, dark: false }),
+      getAccentColors({ light: false, dark: false }, palette),
       existingMapping,
       getPreferredColor,
     );
   } else {
     return getOrderBasedMapping(
       keys,
-      getAccentColors({ light: keys.length > ACCENT_COUNT * 2, harmony: true }),
+      getAccentColors(
+        { light: keys.length > ACCENT_COUNT * 2, harmony: true },
+        palette,
+      ),
       existingMapping,
       getPreferredColor,
     );

--- a/frontend/src/metabase/lib/colors/groups.ts
+++ b/frontend/src/metabase/lib/colors/groups.ts
@@ -1,31 +1,34 @@
 import _ from "underscore";
 import { ACCENT_COUNT, color } from "./palette";
-import { AccentColorOptions } from "./types";
+import { AccentColorOptions, ColorPalette } from "./types";
 
-export const getAccentColors = ({
-  main = true,
-  light = true,
-  dark = true,
-  harmony = false,
-}: AccentColorOptions = {}) => {
+export const getAccentColors = (
+  {
+    main = true,
+    light = true,
+    dark = true,
+    harmony = false,
+  }: AccentColorOptions = {},
+  palette?: ColorPalette,
+) => {
   const ranges = [];
-  main && ranges.push(getMainAccentColors());
-  light && ranges.push(getLightAccentColors());
-  dark && ranges.push(getDarkAccentColors());
+  main && ranges.push(getMainAccentColors(palette));
+  light && ranges.push(getLightAccentColors(palette));
+  dark && ranges.push(getDarkAccentColors(palette));
 
   return harmony ? _.unzip(ranges).flat() : ranges.flat();
 };
 
-export const getMainAccentColors = () => {
-  return _.times(ACCENT_COUNT, i => color(`accent${i}`));
+export const getMainAccentColors = (palette?: ColorPalette) => {
+  return _.times(ACCENT_COUNT, i => color(`accent${i}`, palette));
 };
 
-export const getLightAccentColors = () => {
-  return _.times(ACCENT_COUNT, i => color(`accent${i}-light`));
+export const getLightAccentColors = (palette?: ColorPalette) => {
+  return _.times(ACCENT_COUNT, i => color(`accent${i}-light`, palette));
 };
 
-export const getDarkAccentColors = () => {
-  return _.times(ACCENT_COUNT, i => color(`accent${i}-dark`));
+export const getDarkAccentColors = (palette?: ColorPalette) => {
+  return _.times(ACCENT_COUNT, i => color(`accent${i}-dark`, palette));
 };
 
 export const getStatusColorRanges = () => {

--- a/frontend/src/metabase/lib/colors/groups.ts
+++ b/frontend/src/metabase/lib/colors/groups.ts
@@ -38,7 +38,7 @@ export const getStatusColorRanges = () => {
   ];
 };
 
-export const getPreferredColor = (key: string) => {
+export const getPreferredColor = (key: string, palette?: ColorPalette) => {
   switch (key.toLowerCase()) {
     case "success":
     case "succeeded":
@@ -50,7 +50,7 @@ export const getPreferredColor = (key: string) => {
     case "accepted":
     case "active":
     case "profit":
-      return color("success");
+      return color("success", palette);
     case "cancel":
     case "canceled":
     case "cancelled":
@@ -66,17 +66,17 @@ export const getPreferredColor = (key: string) => {
     case "cost":
     case "deleted":
     case "pending":
-      return color("error");
+      return color("error", palette);
     case "warn":
     case "warning":
     case "incomplete":
     case "unstable":
-      return color("warning");
+      return color("warning", palette);
     case "count":
-      return color("brand");
+      return color("brand", palette);
     case "sum":
-      return color("accent1");
+      return color("accent1", palette);
     case "average":
-      return color("accent2");
+      return color("accent2", palette);
   }
 };

--- a/frontend/src/metabase/static-viz/components/LineAreaBarChart/LineAreaBarChart.tsx
+++ b/frontend/src/metabase/static-viz/components/LineAreaBarChart/LineAreaBarChart.tsx
@@ -1,5 +1,9 @@
 import React from "react";
 import { ColorGetter } from "metabase/static-viz/lib/colors";
+import { isNotNull } from "metabase/core/utils/array";
+import { getColorsForValues } from "metabase/lib/colors/charts";
+import { formatStaticValue } from "metabase/static-viz/lib/format-static-value";
+import { colors } from "metabase/lib/colors/palette";
 import { XYChart } from "../XYChart";
 import { ChartSettings, ChartStyle, Series } from "../XYChart/types";
 import { Colors } from "./types";
@@ -20,6 +24,7 @@ const LineAreaBarChart = ({
   series,
   settings,
   getColor,
+  colors: instanceColors,
 }: LineAreaBarChartProps) => {
   const chartStyle: ChartStyle = {
     fontFamily: "Lato, sans-serif",
@@ -60,9 +65,29 @@ const LineAreaBarChart = ({
     chartSize,
   );
 
+  const keys = series
+    .map(singleSeries => {
+      if (singleSeries.seriesKey) {
+        return singleSeries.seriesKey;
+      }
+
+      return formatStaticValue(singleSeries.name, {
+        column: singleSeries.column,
+      });
+    })
+    .filter(isNotNull);
+  const palette = { ...colors, ...instanceColors };
+  const chartColors = getColorsForValues(keys, undefined, palette);
+  const seriesWithColors = series.map((singleSeries, index) => {
+    return {
+      ...singleSeries,
+      color: chartColors[keys[index]],
+    };
+  });
+
   return (
     <XYChart
-      series={series}
+      series={seriesWithColors}
       settings={adjustedSettings}
       style={chartStyle}
       width={chartSize.width}

--- a/frontend/src/metabase/static-viz/components/LineAreaBarChart/LineAreaBarChart.tsx
+++ b/frontend/src/metabase/static-viz/components/LineAreaBarChart/LineAreaBarChart.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import _ from "underscore";
 import { ColorGetter } from "metabase/static-viz/lib/colors";
 import { isNotNull } from "metabase/core/utils/array";
 import { getColorsForValues } from "metabase/lib/colors/charts";
@@ -77,7 +78,12 @@ const LineAreaBarChart = ({
     })
     .filter(isNotNull);
   const palette = { ...colors, ...instanceColors };
-  const chartColors = getColorsForValues(keys, undefined, palette);
+  const seriesColors = settings.series_settings
+    ? _.mapObject(settings.series_settings, value => {
+        return value.color;
+      })
+    : undefined;
+  const chartColors = getColorsForValues(keys, seriesColors, palette);
   const seriesWithColors = series.map((singleSeries, index) => {
     return {
       ...singleSeries,

--- a/frontend/src/metabase/static-viz/components/LineAreaBarChart/LineAreaBarChart.tsx
+++ b/frontend/src/metabase/static-viz/components/LineAreaBarChart/LineAreaBarChart.tsx
@@ -1,7 +1,5 @@
 import React from "react";
-import { merge } from "icepick";
 import { ColorGetter } from "metabase/static-viz/lib/colors";
-import { colors } from "metabase/lib/colors";
 import { XYChart } from "../XYChart";
 import { CardSeries, ChartSettings, ChartStyle } from "../XYChart/types";
 import { Colors } from "./types";

--- a/frontend/src/metabase/static-viz/components/LineAreaBarChart/LineAreaBarChart.tsx
+++ b/frontend/src/metabase/static-viz/components/LineAreaBarChart/LineAreaBarChart.tsx
@@ -23,14 +23,14 @@ import {
 
 interface LineAreaBarChartProps {
   multipleSeries: (SeriesWithOneOrLessDimensions | SeriesWithTwoDimensions)[][];
-  multipleSettings: ChartSettings[];
+  settings: ChartSettings;
   colors: Colors;
   getColor: ColorGetter;
 }
 
 const LineAreaBarChart = ({
   multipleSeries,
-  multipleSettings,
+  settings,
   getColor,
   colors: instanceColors,
 }: LineAreaBarChartProps) => {
@@ -64,23 +64,19 @@ const LineAreaBarChart = ({
   };
 
   const palette = { ...colors, ...instanceColors };
-  const mainSettings = multipleSettings[0];
   const seriesWithColors = getSeriesWithColors(
     multipleSeries,
-    mainSettings,
+    settings,
     palette,
   );
-  const seriesWithLegends = getSeriesWithLegends(
-    seriesWithColors,
-    mainSettings,
-  );
+  const seriesWithLegends = getSeriesWithLegends(seriesWithColors, settings);
   const series = removeNoneSeriesFields(seriesWithLegends);
 
   const minTickSize = chartStyle.axes.ticks.fontSize * 1.5;
   const xValuesCount = getXValuesCount(series);
-  const chartSize = calculateChartSize(mainSettings, xValuesCount, minTickSize);
+  const chartSize = calculateChartSize(settings, xValuesCount, minTickSize);
   const adjustedSettings = adjustSettings(
-    mainSettings,
+    settings,
     xValuesCount,
     minTickSize,
     chartSize,

--- a/frontend/src/metabase/static-viz/components/LineAreaBarChart/LineAreaBarChart.tsx
+++ b/frontend/src/metabase/static-viz/components/LineAreaBarChart/LineAreaBarChart.tsx
@@ -15,7 +15,11 @@ import {
   calculateChartSize,
   getXValuesCount,
 } from "./utils/settings";
-import { getSeriesWithColors, removeNoneSeriesFields } from "./utils/series";
+import {
+  getSeriesWithColors,
+  getSeriesWithLegends,
+  removeNoneSeriesFields,
+} from "./utils/series";
 
 interface LineAreaBarChartProps {
   multipleSeries: (SeriesWithOneOrLessDimensions | SeriesWithTwoDimensions)[][];
@@ -60,16 +64,20 @@ const LineAreaBarChart = ({
   };
 
   const palette = { ...colors, ...instanceColors };
+  const mainSettings = multipleSettings[0];
   const seriesWithColors = getSeriesWithColors(
     multipleSeries,
-    multipleSettings[0],
+    mainSettings,
     palette,
-  ).map(series => merge(series, { name: series.name ?? series.cardName }));
-  const series = removeNoneSeriesFields(seriesWithColors);
+  );
+  const seriesWithLegends = getSeriesWithLegends(
+    seriesWithColors,
+    mainSettings,
+  );
+  const series = removeNoneSeriesFields(seriesWithLegends);
 
   const minTickSize = chartStyle.axes.ticks.fontSize * 1.5;
   const xValuesCount = getXValuesCount(series);
-  const mainSettings = multipleSettings[0];
   const chartSize = calculateChartSize(mainSettings, xValuesCount, minTickSize);
   const adjustedSettings = adjustSettings(
     mainSettings,

--- a/frontend/src/metabase/static-viz/components/LineAreaBarChart/LineAreaBarChart.tsx
+++ b/frontend/src/metabase/static-viz/components/LineAreaBarChart/LineAreaBarChart.tsx
@@ -58,11 +58,10 @@ const LineAreaBarChart = ({
     goalColor: getColor("text-medium"),
   };
 
-  const palette = { ...colors, ...instanceColors };
   const seriesWithColors = getSeriesWithColors(
     multipleSeries,
     settings,
-    palette,
+    instanceColors,
   );
   const seriesWithLegends = getSeriesWithLegends(seriesWithColors, settings);
   const series = removeNoneSeriesFields(seriesWithLegends);

--- a/frontend/src/metabase/static-viz/components/LineAreaBarChart/LineAreaBarChart.tsx
+++ b/frontend/src/metabase/static-viz/components/LineAreaBarChart/LineAreaBarChart.tsx
@@ -3,12 +3,7 @@ import { merge } from "icepick";
 import { ColorGetter } from "metabase/static-viz/lib/colors";
 import { colors } from "metabase/lib/colors";
 import { XYChart } from "../XYChart";
-import {
-  ChartSettings,
-  ChartStyle,
-  SeriesWithOneOrLessDimensions,
-  SeriesWithTwoDimensions,
-} from "../XYChart/types";
+import { CardSeries, ChartSettings, ChartStyle } from "../XYChart/types";
 import { Colors } from "./types";
 import {
   adjustSettings,
@@ -22,7 +17,7 @@ import {
 } from "./utils/series";
 
 interface LineAreaBarChartProps {
-  multipleSeries: (SeriesWithOneOrLessDimensions | SeriesWithTwoDimensions)[][];
+  multipleSeries: CardSeries[];
   settings: ChartSettings;
   colors: Colors;
   getColor: ColorGetter;

--- a/frontend/src/metabase/static-viz/components/LineAreaBarChart/constants.ts
+++ b/frontend/src/metabase/static-viz/components/LineAreaBarChart/constants.ts
@@ -2,398 +2,395 @@ import _ from "underscore";
 
 export const LINE_AREA_BAR_CHART_TYPE = "combo-chart";
 
+// TODO: Add `cardName` and `column` and maybe `breakoutValue` so we could see the colors
 export const LINE_AREA_BAR_DEFAULT_OPTIONS_1 = {
-  settings: {
-    show_values: true,
-    goal: {
-      value: 140,
-      label: "Goal",
-    },
-    x: {
-      type: "timeseries",
-    },
-    y: {
-      type: "linear",
-    },
-    labels: {
-      left: "Count",
-      right: "Sum",
-      bottom: "Date",
-    },
-  },
-  series: [
+  multipleSettings: [
     {
-      name: "line series",
-      color: "#509ee3",
-      yAxisPosition: "left",
-      type: "line",
-      data: [
-        ["2020-10-20", 15],
-        ["2020-10-21", 20],
-        ["2020-10-22", 35],
-        ["2020-10-23", 40],
-        ["2020-10-24", 55],
-        ["2020-10-25", 60],
-        ["2020-10-26", 75],
-        ["2020-10-27", 80],
-        ["2020-10-28", 95],
-      ],
-      seriesKey: "count",
+      show_values: true,
+      goal: {
+        value: 140,
+        label: "Goal",
+      },
+      x: {
+        type: "timeseries",
+      },
+      y: {
+        type: "linear",
+      },
+      labels: {
+        left: "Count",
+        right: "Sum",
+        bottom: "Date",
+      },
     },
-    {
-      name: "bar series 1",
-      color: "#88bf4d",
-      yAxisPosition: "left",
-      type: "bar",
-      data: [
-        ["2020-10-20", 90],
-        ["2020-10-21", 80],
-        ["2020-10-22", 70],
-        ["2020-10-23", 60],
-        ["2020-10-24", 50],
-        ["2020-10-25", 40],
-        ["2020-10-26", 30],
-        ["2020-10-27", 20],
-        ["2020-10-28", 10],
-      ],
-      seriesKey: "bar series 1",
-    },
-    {
-      name: "bar series 2 with a really really really long name",
-      color: "#a989c5",
-      yAxisPosition: "right",
-      type: "bar",
-      data: [
-        ["2020-10-20", 4],
-        ["2020-10-21", 5],
-        ["2020-10-22", 6],
-        ["2020-10-23", 7],
-        ["2020-10-24", 6],
-        ["2020-10-25", 5],
-        ["2020-10-26", 4],
-        ["2020-10-27", 3],
-        ["2020-10-28", 2],
-      ],
-      seriesKey: "bar series 2 with a really really really long name",
-    },
-    {
-      name: "area series",
-      color: "#ef8c8c",
-      yAxisPosition: "right",
-      type: "area",
-      data: [
-        ["2020-10-20", 4],
-        ["2020-10-21", 5],
-        ["2020-10-22", 3],
-        ["2020-10-23", 4],
-        ["2020-10-24", 5],
-        ["2020-10-25", 8],
-        ["2020-10-26", 9],
-        ["2020-10-27", 12],
-        ["2020-10-28", 15],
-      ],
-      seriesKey: "area series",
-    },
+  ],
+  multipleSeries: [
+    [
+      {
+        name: "line series",
+        yAxisPosition: "left",
+        type: "line",
+        data: [
+          ["2020-10-20", 15],
+          ["2020-10-21", 20],
+          ["2020-10-22", 35],
+          ["2020-10-23", 40],
+          ["2020-10-24", 55],
+          ["2020-10-25", 60],
+          ["2020-10-26", 75],
+          ["2020-10-27", 80],
+          ["2020-10-28", 95],
+        ],
+      },
+      {
+        name: "bar series 1",
+        yAxisPosition: "left",
+        type: "bar",
+        data: [
+          ["2020-10-20", 90],
+          ["2020-10-21", 80],
+          ["2020-10-22", 70],
+          ["2020-10-23", 60],
+          ["2020-10-24", 50],
+          ["2020-10-25", 40],
+          ["2020-10-26", 30],
+          ["2020-10-27", 20],
+          ["2020-10-28", 10],
+        ],
+      },
+      {
+        name: "bar series 2 with a really really really long name",
+        yAxisPosition: "right",
+        type: "bar",
+        data: [
+          ["2020-10-20", 4],
+          ["2020-10-21", 5],
+          ["2020-10-22", 6],
+          ["2020-10-23", 7],
+          ["2020-10-24", 6],
+          ["2020-10-25", 5],
+          ["2020-10-26", 4],
+          ["2020-10-27", 3],
+          ["2020-10-28", 2],
+        ],
+      },
+      {
+        name: "area series",
+        yAxisPosition: "right",
+        type: "area",
+        data: [
+          ["2020-10-20", 4],
+          ["2020-10-21", 5],
+          ["2020-10-22", 3],
+          ["2020-10-23", 4],
+          ["2020-10-24", 5],
+          ["2020-10-25", 8],
+          ["2020-10-26", 9],
+          ["2020-10-27", 12],
+          ["2020-10-28", 15],
+        ],
+      },
+    ],
   ],
 };
 
 export const LINE_AREA_BAR_DEFAULT_OPTIONS_2 = {
-  settings: {
-    x: {
-      type: "timeseries",
-    },
-    y: {
-      type: "linear",
-      format: {
-        number_style: "currency",
-        currency: "USD",
-        currency_style: "symbol",
-        decimals: 2,
+  multipleSettings: [
+    {
+      x: {
+        type: "timeseries",
+      },
+      y: {
+        type: "linear",
+        format: {
+          number_style: "currency",
+          currency: "USD",
+          currency_style: "symbol",
+          decimals: 2,
+        },
+      },
+      labels: {
+        right: "Sum",
+        bottom: "Date",
       },
     },
-    labels: {
-      right: "Sum",
-      bottom: "Date",
-    },
-  },
-  series: [
-    {
-      name: "line series",
-      color: "#509ee3",
-      yAxisPosition: "right",
-      type: "line",
-      data: [
-        ["2020-10-18", -65],
-        ["2020-10-19", -55],
-        ["2020-10-20", -45],
-        ["2020-10-21", -30],
-        ["2020-10-22", -25],
-        ["2020-10-23", -10],
-        ["2020-10-24", 0],
-        ["2020-10-25", 10],
-        ["2020-10-26", 20],
-        ["2020-10-27", 80],
-      ],
-      seriesKey: "sum",
-    },
-    {
-      name: "bar series",
-      color: "#88bf4d",
-      yAxisPosition: "right",
-      type: "bar",
-      data: [
-        ["2020-10-20", -90],
-        ["2020-10-21", -80],
-        ["2020-10-22", -70],
-        ["2020-10-23", -60],
-        ["2020-10-24", 10],
-        ["2020-10-25", 20],
-        ["2020-10-26", 30],
-        ["2020-10-27", 40],
-        ["2020-10-28", 50],
-      ],
-      seriesKey: "bar series",
-    },
-    {
-      name: "area series",
-      color: "#ef8c8c",
-      yAxisPosition: "right",
-      type: "area",
-      data: [
-        ["2020-10-22", 13],
-        ["2020-10-23", 10],
-        ["2020-10-24", 5],
-        ["2020-10-25", -8],
-        ["2020-10-26", -9],
-        ["2020-10-27", -22],
-        ["2020-10-28", -85],
-        ["2020-10-29", -100],
-        ["2020-10-30", -120],
-      ],
-      seriesKey: "area series",
-    },
+  ],
+  multipleSeries: [
+    [
+      {
+        name: "line series",
+        yAxisPosition: "right",
+        type: "line",
+        data: [
+          ["2020-10-18", -65],
+          ["2020-10-19", -55],
+          ["2020-10-20", -45],
+          ["2020-10-21", -30],
+          ["2020-10-22", -25],
+          ["2020-10-23", -10],
+          ["2020-10-24", 0],
+          ["2020-10-25", 10],
+          ["2020-10-26", 20],
+          ["2020-10-27", 80],
+        ],
+      },
+      {
+        name: "bar series",
+        yAxisPosition: "right",
+        type: "bar",
+        data: [
+          ["2020-10-20", -90],
+          ["2020-10-21", -80],
+          ["2020-10-22", -70],
+          ["2020-10-23", -60],
+          ["2020-10-24", 10],
+          ["2020-10-25", 20],
+          ["2020-10-26", 30],
+          ["2020-10-27", 40],
+          ["2020-10-28", 50],
+        ],
+      },
+      {
+        name: "area series",
+        yAxisPosition: "right",
+        type: "area",
+        data: [
+          ["2020-10-22", 13],
+          ["2020-10-23", 10],
+          ["2020-10-24", 5],
+          ["2020-10-25", -8],
+          ["2020-10-26", -9],
+          ["2020-10-27", -22],
+          ["2020-10-28", -85],
+          ["2020-10-29", -100],
+          ["2020-10-30", -120],
+        ],
+      },
+    ],
   ],
 };
 
 export const LINE_AREA_BAR_DEFAULT_OPTIONS_3 = {
-  settings: {
-    goal: {
-      value: 120,
-      label: "Goal",
-    },
-    x: {
-      type: "ordinal",
-    },
-    y: {
-      type: "linear",
-    },
-    labels: {
-      left: "Count",
-      right: "Sum",
-      bottom: "Date",
-    },
-  },
-  series: [
+  multipleSettings: [
     {
-      name: "line series",
-      color: "#509ee3",
-      yAxisPosition: "left",
-      type: "line",
-      data: [
-        ["Alden Sparks", 70],
-        ["Areli Guerra", 30],
-        ["Arturo Hopkins", 80],
-        ["Beatrice Lane", 120],
-        ["Brylee Davenport", 100],
-        ["Cali Nixon", 60],
-        ["Dane Terrell", 150],
-        ["Deshawn Rollins", 40],
-        ["Isabell Bright", 70],
-        ["Kaya Rowe", 20],
-        ["Roderick Herman", 50],
-        ["Ruth Dougherty", 75],
-      ],
-      seriesKey: "sum",
+      goal: {
+        value: 120,
+        label: "Goal",
+      },
+      x: {
+        type: "ordinal",
+      },
+      y: {
+        type: "linear",
+      },
+      labels: {
+        left: "Count",
+        right: "Sum",
+        bottom: "Date",
+      },
     },
-    {
-      name: "bar series 1",
-      color: "#88bf4d",
-      yAxisPosition: "left",
-      type: "bar",
-      data: [
-        ["Alden Sparks", 20],
-        ["Areli Guerra", 80],
-        ["Arturo Hopkins", 10],
-        ["Beatrice Lane", 10],
-        ["Brylee Davenport", 15],
-        ["Cali Nixon", 20],
-        ["Dane Terrell", 40],
-        ["Deshawn Rollins", 60],
-        ["Isabell Bright", 80],
-        ["Kaya Rowe", 50],
-        ["Roderick Herman", 40],
-        ["Ruth Dougherty", 65],
-      ],
-      seriesKey: "bar series 1",
-    },
+  ],
+  multipleSeries: [
+    [
+      {
+        name: "line series",
+        yAxisPosition: "left",
+        type: "line",
+        data: [
+          ["Alden Sparks", 70],
+          ["Areli Guerra", 30],
+          ["Arturo Hopkins", 80],
+          ["Beatrice Lane", 120],
+          ["Brylee Davenport", 100],
+          ["Cali Nixon", 60],
+          ["Dane Terrell", 150],
+          ["Deshawn Rollins", 40],
+          ["Isabell Bright", 70],
+          ["Kaya Rowe", 20],
+          ["Roderick Herman", 50],
+          ["Ruth Dougherty", 75],
+        ],
+      },
+      {
+        name: "bar series 1",
+        yAxisPosition: "left",
+        type: "bar",
+        data: [
+          ["Alden Sparks", 20],
+          ["Areli Guerra", 80],
+          ["Arturo Hopkins", 10],
+          ["Beatrice Lane", 10],
+          ["Brylee Davenport", 15],
+          ["Cali Nixon", 20],
+          ["Dane Terrell", 40],
+          ["Deshawn Rollins", 60],
+          ["Isabell Bright", 80],
+          ["Kaya Rowe", 50],
+          ["Roderick Herman", 40],
+          ["Ruth Dougherty", 65],
+        ],
+      },
+    ],
   ],
 };
 
 export const LINE_AREA_BAR_DEFAULT_OPTIONS_4 = {
-  settings: {
-    stacking: "stack",
-    x: {
-      type: "timeseries",
-    },
-    y: {
-      type: "linear",
-      format: {
-        number_style: "currency",
-        currency: "USD",
-        currency_style: "symbol",
-        decimals: 2,
+  multipleSettings: [
+    {
+      stacking: "stack",
+      x: {
+        type: "timeseries",
+      },
+      y: {
+        type: "linear",
+        format: {
+          number_style: "currency",
+          currency: "USD",
+          currency_style: "symbol",
+          decimals: 2,
+        },
+      },
+      labels: {
+        left: "Sum",
+        bottom: "Date",
       },
     },
-    labels: {
-      left: "Sum",
-      bottom: "Date",
-    },
-  },
-  series: [
-    {
-      name: "series 1",
-      color: "#509ee3",
-      yAxisPosition: "left",
-      type: "area",
-      data: [
-        ["2020-10-18", 10],
-        ["2020-10-19", 20],
-        ["2020-10-20", 30],
-        ["2020-10-21", 40],
-        ["2020-10-22", 45],
-        ["2020-10-23", 55],
-      ],
-      seriesKey: "sum",
-    },
-    {
-      name: "series 2",
-      color: "#a989c5",
-      yAxisPosition: "left",
-      type: "area",
-      data: [
-        ["2020-10-18", 10],
-        ["2020-10-19", 40],
-        ["2020-10-20", 80],
-        ["2020-10-21", 60],
-        ["2020-10-22", 70],
-        ["2020-10-23", 65],
-      ],
-      seriesKey: "series 2",
-    },
-    {
-      name: "series 3",
-      color: "#ef8c8c",
-      yAxisPosition: "left",
-      type: "area",
-      data: [
-        ["2020-10-18", -40],
-        ["2020-10-19", -20],
-        ["2020-10-20", -10],
-        ["2020-10-21", -20],
-        ["2020-10-22", -45],
-        ["2020-10-23", -55],
-      ],
-      seriesKey: "series 3",
-    },
-    {
-      name: "series 4",
-      color: "#88bf4d",
-      yAxisPosition: "left",
-      type: "area",
-      data: [
-        ["2020-10-18", -40],
-        ["2020-10-19", -50],
-        ["2020-10-20", -60],
-        ["2020-10-21", -20],
-        ["2020-10-22", -10],
-        ["2020-10-23", -5],
-      ],
-      seriesKey: "series 4",
-    },
+  ],
+  multipleSeries: [
+    [
+      {
+        name: "series 1",
+        yAxisPosition: "left",
+        type: "area",
+        data: [
+          ["2020-10-18", 10],
+          ["2020-10-19", 20],
+          ["2020-10-20", 30],
+          ["2020-10-21", 40],
+          ["2020-10-22", 45],
+          ["2020-10-23", 55],
+        ],
+      },
+      {
+        name: "series 2",
+        yAxisPosition: "left",
+        type: "area",
+        data: [
+          ["2020-10-18", 10],
+          ["2020-10-19", 40],
+          ["2020-10-20", 80],
+          ["2020-10-21", 60],
+          ["2020-10-22", 70],
+          ["2020-10-23", 65],
+        ],
+      },
+      {
+        name: "series 3",
+        yAxisPosition: "left",
+        type: "area",
+        data: [
+          ["2020-10-18", -40],
+          ["2020-10-19", -20],
+          ["2020-10-20", -10],
+          ["2020-10-21", -20],
+          ["2020-10-22", -45],
+          ["2020-10-23", -55],
+        ],
+      },
+      {
+        name: "series 4",
+        yAxisPosition: "left",
+        type: "area",
+        data: [
+          ["2020-10-18", -40],
+          ["2020-10-19", -50],
+          ["2020-10-20", -60],
+          ["2020-10-21", -20],
+          ["2020-10-22", -10],
+          ["2020-10-23", -5],
+        ],
+      },
+    ],
   ],
 };
 
 export const LINE_AREA_BAR_DEFAULT_OPTIONS_5 = {
-  settings: {
-    x: {
-      type: "ordinal",
-    },
-    y: {
-      type: "linear",
-    },
-    labels: {
-      left: "Count",
-      bottom: "Date",
-    },
-  },
-  series: [
+  multipleSettings: [
     {
-      name: "bar series",
-      color: "#509ee3",
-      yAxisPosition: "left",
-      type: "bar",
-      data: _.range(48).map(n => [`bar ${n + 1}`, n + 1]),
-      seriesKey: "sum",
+      x: {
+        type: "ordinal",
+      },
+      y: {
+        type: "linear",
+      },
+      labels: {
+        left: "Count",
+        bottom: "Date",
+      },
     },
+  ],
+  multipleSeries: [
+    [
+      {
+        name: "bar series",
+        yAxisPosition: "left",
+        type: "bar",
+        data: _.range(48).map(n => [`bar ${n + 1}`, n + 1]),
+      },
+    ],
   ],
 };
 
 export const LINE_AREA_BAR_DEFAULT_OPTIONS_6 = {
-  settings: {
-    x: {
-      type: "ordinal",
-    },
-    y: {
-      type: "linear",
-    },
-    labels: {
-      left: "Count",
-      bottom: "Date",
-    },
-  },
-  series: [
+  multipleSettings: [
     {
-      name: "bar series",
-      color: "#509ee3",
-      yAxisPosition: "left",
-      type: "bar",
-      data: _.range(200).map(n => [`bar ${n + 1}`, n + 1]),
-      seriesKey: "warn",
+      x: {
+        type: "ordinal",
+      },
+      y: {
+        type: "linear",
+      },
+      labels: {
+        left: "Count",
+        bottom: "Date",
+      },
     },
+  ],
+  multipleSeries: [
+    [
+      {
+        name: "bar series",
+        yAxisPosition: "left",
+        type: "bar",
+        data: _.range(200).map(n => [`bar ${n + 1}`, n + 1]),
+      },
+    ],
   ],
 };
 
 export const LINE_AREA_BAR_DEFAULT_OPTIONS_7 = {
-  settings: {
-    x: {
-      type: "ordinal",
-    },
-    y: {
-      type: "linear",
-    },
-    labels: {
-      left: "Count",
-      bottom: "Date",
-    },
-  },
-  series: [
+  multipleSettings: [
     {
-      name: "bar series",
-      color: "#509ee3",
-      yAxisPosition: "left",
-      type: "bar",
-      data: _.range(20).map(n => [`bar ${n + 1}`, n + 1]),
-      seriesKey: "loss",
+      x: {
+        type: "ordinal",
+      },
+      y: {
+        type: "linear",
+      },
+      labels: {
+        left: "Count",
+        bottom: "Date",
+      },
     },
+  ],
+  multipleSeries: [
+    [
+      {
+        name: "bar series",
+        yAxisPosition: "left",
+        type: "bar",
+        data: _.range(20).map(n => [`bar ${n + 1}`, n + 1]),
+      },
+    ],
   ],
 };

--- a/frontend/src/metabase/static-viz/components/LineAreaBarChart/constants.ts
+++ b/frontend/src/metabase/static-viz/components/LineAreaBarChart/constants.ts
@@ -2,32 +2,29 @@ import _ from "underscore";
 
 export const LINE_AREA_BAR_CHART_TYPE = "combo-chart";
 
-// TODO: Add `cardName` and `column` and maybe `breakoutValue` so we could see the colors
 export const LINE_AREA_BAR_DEFAULT_OPTIONS_1 = {
-  multipleSettings: [
-    {
-      show_values: true,
-      goal: {
-        value: 140,
-        label: "Goal",
-      },
-      x: {
-        type: "timeseries",
-      },
-      y: {
-        type: "linear",
-      },
-      labels: {
-        left: "Count",
-        right: "Sum",
-        bottom: "Date",
-      },
+  settings: {
+    show_values: true,
+    goal: {
+      value: 140,
+      label: "Goal",
     },
-  ],
+    x: {
+      type: "timeseries",
+    },
+    y: {
+      type: "linear",
+    },
+    labels: {
+      left: "Count",
+      right: "Sum",
+      bottom: "Date",
+    },
+  },
   multipleSeries: [
     [
       {
-        name: "line series",
+        cardName: "line series",
         yAxisPosition: "left",
         type: "line",
         data: [
@@ -41,9 +38,19 @@ export const LINE_AREA_BAR_DEFAULT_OPTIONS_1 = {
           ["2020-10-27", 80],
           ["2020-10-28", 95],
         ],
+        column: {
+          semantic_type: "type/CreationTimestamp",
+          unit: "year",
+          name: "CREATED_AT",
+          source: "breakout",
+          display_name: "Created At",
+        },
+        breakoutValue: "2020-01-01T00:00:00Z",
       },
+    ],
+    [
       {
-        name: "bar series 1",
+        cardName: "bar series 1",
         yAxisPosition: "left",
         type: "bar",
         data: [
@@ -57,9 +64,19 @@ export const LINE_AREA_BAR_DEFAULT_OPTIONS_1 = {
           ["2020-10-27", 20],
           ["2020-10-28", 10],
         ],
+        column: {
+          semantic_type: "type/CreationTimestamp",
+          unit: "year",
+          name: "CREATED_AT",
+          source: "breakout",
+          display_name: "Created At",
+        },
+        breakoutValue: "2020-01-01T00:00:00Z",
       },
+    ],
+    [
       {
-        name: "bar series 2 with a really really really long name",
+        cardName: "bar series 2 with a really really really long name",
         yAxisPosition: "right",
         type: "bar",
         data: [
@@ -73,9 +90,19 @@ export const LINE_AREA_BAR_DEFAULT_OPTIONS_1 = {
           ["2020-10-27", 3],
           ["2020-10-28", 2],
         ],
+        column: {
+          semantic_type: "type/CreationTimestamp",
+          unit: "year",
+          name: "CREATED_AT",
+          source: "breakout",
+          display_name: "Created At",
+        },
+        breakoutValue: "2020-01-01T00:00:00Z",
       },
+    ],
+    [
       {
-        name: "area series",
+        cardName: "area series",
         yAxisPosition: "right",
         type: "area",
         data: [
@@ -89,36 +116,42 @@ export const LINE_AREA_BAR_DEFAULT_OPTIONS_1 = {
           ["2020-10-27", 12],
           ["2020-10-28", 15],
         ],
+        column: {
+          semantic_type: "type/CreationTimestamp",
+          unit: "year",
+          name: "CREATED_AT",
+          source: "breakout",
+          display_name: "Created At",
+        },
+        breakoutValue: "2020-01-01T00:00:00Z",
       },
     ],
   ],
 };
 
 export const LINE_AREA_BAR_DEFAULT_OPTIONS_2 = {
-  multipleSettings: [
-    {
-      x: {
-        type: "timeseries",
-      },
-      y: {
-        type: "linear",
-        format: {
-          number_style: "currency",
-          currency: "USD",
-          currency_style: "symbol",
-          decimals: 2,
-        },
-      },
-      labels: {
-        right: "Sum",
-        bottom: "Date",
+  settings: {
+    x: {
+      type: "timeseries",
+    },
+    y: {
+      type: "linear",
+      format: {
+        number_style: "currency",
+        currency: "USD",
+        currency_style: "symbol",
+        decimals: 2,
       },
     },
-  ],
+    labels: {
+      right: "Sum",
+      bottom: "Date",
+    },
+  },
   multipleSeries: [
     [
       {
-        name: "line series",
+        cardName: "line series",
         yAxisPosition: "right",
         type: "line",
         data: [
@@ -133,9 +166,19 @@ export const LINE_AREA_BAR_DEFAULT_OPTIONS_2 = {
           ["2020-10-26", 20],
           ["2020-10-27", 80],
         ],
+        column: {
+          semantic_type: "type/CreationTimestamp",
+          unit: "year",
+          name: "CREATED_AT",
+          source: "breakout",
+          display_name: "Created At",
+        },
+        breakoutValue: "2020-01-01T00:00:00Z",
       },
+    ],
+    [
       {
-        name: "bar series",
+        cardName: "bar series",
         yAxisPosition: "right",
         type: "bar",
         data: [
@@ -149,9 +192,19 @@ export const LINE_AREA_BAR_DEFAULT_OPTIONS_2 = {
           ["2020-10-27", 40],
           ["2020-10-28", 50],
         ],
+        column: {
+          semantic_type: "type/CreationTimestamp",
+          unit: "year",
+          name: "CREATED_AT",
+          source: "breakout",
+          display_name: "Created At",
+        },
+        breakoutValue: "2020-01-01T00:00:00Z",
       },
+    ],
+    [
       {
-        name: "area series",
+        cardName: "area series",
         yAxisPosition: "right",
         type: "area",
         data: [
@@ -165,35 +218,41 @@ export const LINE_AREA_BAR_DEFAULT_OPTIONS_2 = {
           ["2020-10-29", -100],
           ["2020-10-30", -120],
         ],
+        column: {
+          semantic_type: "type/CreationTimestamp",
+          unit: "year",
+          name: "CREATED_AT",
+          source: "breakout",
+          display_name: "Created At",
+        },
+        breakoutValue: "2020-01-01T00:00:00Z",
       },
     ],
   ],
 };
 
 export const LINE_AREA_BAR_DEFAULT_OPTIONS_3 = {
-  multipleSettings: [
-    {
-      goal: {
-        value: 120,
-        label: "Goal",
-      },
-      x: {
-        type: "ordinal",
-      },
-      y: {
-        type: "linear",
-      },
-      labels: {
-        left: "Count",
-        right: "Sum",
-        bottom: "Date",
-      },
+  settings: {
+    goal: {
+      value: 120,
+      label: "Goal",
     },
-  ],
+    x: {
+      type: "ordinal",
+    },
+    y: {
+      type: "linear",
+    },
+    labels: {
+      left: "Count",
+      right: "Sum",
+      bottom: "Date",
+    },
+  },
   multipleSeries: [
     [
       {
-        name: "line series",
+        cardName: "line series",
         yAxisPosition: "left",
         type: "line",
         data: [
@@ -210,9 +269,14 @@ export const LINE_AREA_BAR_DEFAULT_OPTIONS_3 = {
           ["Roderick Herman", 50],
           ["Ruth Dougherty", 75],
         ],
+        column: {
+          name: "count",
+          source: "aggregation",
+          display_name: "Count",
+        },
       },
       {
-        name: "bar series 1",
+        cardName: "bar series 1",
         yAxisPosition: "left",
         type: "bar",
         data: [
@@ -229,37 +293,40 @@ export const LINE_AREA_BAR_DEFAULT_OPTIONS_3 = {
           ["Roderick Herman", 40],
           ["Ruth Dougherty", 65],
         ],
+        column: {
+          name: "sum",
+          source: "aggregation",
+          display_name: "Sum",
+        },
       },
     ],
   ],
 };
 
 export const LINE_AREA_BAR_DEFAULT_OPTIONS_4 = {
-  multipleSettings: [
-    {
-      stacking: "stack",
-      x: {
-        type: "timeseries",
-      },
-      y: {
-        type: "linear",
-        format: {
-          number_style: "currency",
-          currency: "USD",
-          currency_style: "symbol",
-          decimals: 2,
-        },
-      },
-      labels: {
-        left: "Sum",
-        bottom: "Date",
+  settings: {
+    stacking: "stack",
+    x: {
+      type: "timeseries",
+    },
+    y: {
+      type: "linear",
+      format: {
+        number_style: "currency",
+        currency: "USD",
+        currency_style: "symbol",
+        decimals: 2,
       },
     },
-  ],
+    labels: {
+      left: "Sum",
+      bottom: "Date",
+    },
+  },
   multipleSeries: [
     [
       {
-        name: "series 1",
+        cardName: "series 1",
         yAxisPosition: "left",
         type: "area",
         data: [
@@ -270,9 +337,19 @@ export const LINE_AREA_BAR_DEFAULT_OPTIONS_4 = {
           ["2020-10-22", 45],
           ["2020-10-23", 55],
         ],
+        column: {
+          semantic_type: "type/CreationTimestamp",
+          unit: "year",
+          name: "CREATED_AT",
+          source: "breakout",
+          display_name: "Created At",
+        },
+        breakoutValue: "2020-01-01T00:00:00Z",
       },
+    ],
+    [
       {
-        name: "series 2",
+        cardName: "series 2",
         yAxisPosition: "left",
         type: "area",
         data: [
@@ -283,9 +360,19 @@ export const LINE_AREA_BAR_DEFAULT_OPTIONS_4 = {
           ["2020-10-22", 70],
           ["2020-10-23", 65],
         ],
+        column: {
+          semantic_type: "type/CreationTimestamp",
+          unit: "year",
+          name: "CREATED_AT",
+          source: "breakout",
+          display_name: "Created At",
+        },
+        breakoutValue: "2020-01-01T00:00:00Z",
       },
+    ],
+    [
       {
-        name: "series 3",
+        cardName: "series 3",
         yAxisPosition: "left",
         type: "area",
         data: [
@@ -296,9 +383,19 @@ export const LINE_AREA_BAR_DEFAULT_OPTIONS_4 = {
           ["2020-10-22", -45],
           ["2020-10-23", -55],
         ],
+        column: {
+          semantic_type: "type/CreationTimestamp",
+          unit: "year",
+          name: "CREATED_AT",
+          source: "breakout",
+          display_name: "Created At",
+        },
+        breakoutValue: "2020-01-01T00:00:00Z",
       },
+    ],
+    [
       {
-        name: "series 4",
+        cardName: "series 4",
         yAxisPosition: "left",
         type: "area",
         data: [
@@ -309,87 +406,104 @@ export const LINE_AREA_BAR_DEFAULT_OPTIONS_4 = {
           ["2020-10-22", -10],
           ["2020-10-23", -5],
         ],
+        column: {
+          semantic_type: "type/CreationTimestamp",
+          unit: "year",
+          name: "CREATED_AT",
+          source: "breakout",
+          display_name: "Created At",
+        },
+        breakoutValue: "2020-01-01T00:00:00Z",
       },
     ],
   ],
 };
 
 export const LINE_AREA_BAR_DEFAULT_OPTIONS_5 = {
-  multipleSettings: [
-    {
-      x: {
-        type: "ordinal",
-      },
-      y: {
-        type: "linear",
-      },
-      labels: {
-        left: "Count",
-        bottom: "Date",
-      },
+  settings: {
+    x: {
+      type: "ordinal",
     },
-  ],
+    y: {
+      type: "linear",
+    },
+    labels: {
+      left: "Count",
+      bottom: "Date",
+    },
+  },
   multipleSeries: [
     [
       {
-        name: "bar series",
+        cardName: "bar series",
         yAxisPosition: "left",
         type: "bar",
         data: _.range(48).map(n => [`bar ${n + 1}`, n + 1]),
+        column: {
+          name: "count",
+          source: "aggregation",
+          display_name: "Count",
+        },
       },
     ],
   ],
 };
 
 export const LINE_AREA_BAR_DEFAULT_OPTIONS_6 = {
-  multipleSettings: [
-    {
-      x: {
-        type: "ordinal",
-      },
-      y: {
-        type: "linear",
-      },
-      labels: {
-        left: "Count",
-        bottom: "Date",
-      },
+  settings: {
+    x: {
+      type: "ordinal",
     },
-  ],
+    y: {
+      type: "linear",
+    },
+    labels: {
+      left: "Count",
+      bottom: "Date",
+    },
+  },
   multipleSeries: [
     [
       {
-        name: "bar series",
+        cardName: "bar series",
         yAxisPosition: "left",
         type: "bar",
         data: _.range(200).map(n => [`bar ${n + 1}`, n + 1]),
+        column: {
+          name: "count",
+          source: "aggregation",
+          display_name: "Count",
+        },
       },
     ],
   ],
 };
 
 export const LINE_AREA_BAR_DEFAULT_OPTIONS_7 = {
-  multipleSettings: [
-    {
-      x: {
-        type: "ordinal",
-      },
-      y: {
-        type: "linear",
-      },
-      labels: {
-        left: "Count",
-        bottom: "Date",
-      },
+  settings: {
+    x: {
+      type: "ordinal",
     },
-  ],
+    y: {
+      type: "linear",
+    },
+    labels: {
+      left: "Count",
+      bottom: "Date",
+    },
+  },
   multipleSeries: [
     [
       {
-        name: "bar series",
+        cardName: "bar series",
         yAxisPosition: "left",
         type: "bar",
         data: _.range(20).map(n => [`bar ${n + 1}`, n + 1]),
+        column: {
+          name: "count",
+          source: "aggregation",
+          display_name: "Count",
+        },
       },
     ],
   ],

--- a/frontend/src/metabase/static-viz/components/LineAreaBarChart/constants.ts
+++ b/frontend/src/metabase/static-viz/components/LineAreaBarChart/constants.ts
@@ -38,6 +38,7 @@ export const LINE_AREA_BAR_DEFAULT_OPTIONS_1 = {
         ["2020-10-27", 80],
         ["2020-10-28", 95],
       ],
+      seriesKey: "count",
     },
     {
       name: "bar series 1",
@@ -55,6 +56,7 @@ export const LINE_AREA_BAR_DEFAULT_OPTIONS_1 = {
         ["2020-10-27", 20],
         ["2020-10-28", 10],
       ],
+      seriesKey: "bar series 1",
     },
     {
       name: "bar series 2 with a really really really long name",
@@ -72,6 +74,7 @@ export const LINE_AREA_BAR_DEFAULT_OPTIONS_1 = {
         ["2020-10-27", 3],
         ["2020-10-28", 2],
       ],
+      seriesKey: "bar series 2 with a really really really long name",
     },
     {
       name: "area series",
@@ -89,6 +92,7 @@ export const LINE_AREA_BAR_DEFAULT_OPTIONS_1 = {
         ["2020-10-27", 12],
         ["2020-10-28", 15],
       ],
+      seriesKey: "area series",
     },
   ],
 };
@@ -130,6 +134,7 @@ export const LINE_AREA_BAR_DEFAULT_OPTIONS_2 = {
         ["2020-10-26", 20],
         ["2020-10-27", 80],
       ],
+      seriesKey: "sum",
     },
     {
       name: "bar series",
@@ -147,6 +152,7 @@ export const LINE_AREA_BAR_DEFAULT_OPTIONS_2 = {
         ["2020-10-27", 40],
         ["2020-10-28", 50],
       ],
+      seriesKey: "bar series",
     },
     {
       name: "area series",
@@ -164,6 +170,7 @@ export const LINE_AREA_BAR_DEFAULT_OPTIONS_2 = {
         ["2020-10-29", -100],
         ["2020-10-30", -120],
       ],
+      seriesKey: "area series",
     },
   ],
 };
@@ -206,6 +213,7 @@ export const LINE_AREA_BAR_DEFAULT_OPTIONS_3 = {
         ["Roderick Herman", 50],
         ["Ruth Dougherty", 75],
       ],
+      seriesKey: "sum",
     },
     {
       name: "bar series 1",
@@ -226,6 +234,7 @@ export const LINE_AREA_BAR_DEFAULT_OPTIONS_3 = {
         ["Roderick Herman", 40],
         ["Ruth Dougherty", 65],
       ],
+      seriesKey: "bar series 1",
     },
   ],
 };
@@ -264,6 +273,7 @@ export const LINE_AREA_BAR_DEFAULT_OPTIONS_4 = {
         ["2020-10-22", 45],
         ["2020-10-23", 55],
       ],
+      seriesKey: "sum",
     },
     {
       name: "series 2",
@@ -278,6 +288,7 @@ export const LINE_AREA_BAR_DEFAULT_OPTIONS_4 = {
         ["2020-10-22", 70],
         ["2020-10-23", 65],
       ],
+      seriesKey: "series 2",
     },
     {
       name: "series 3",
@@ -292,6 +303,7 @@ export const LINE_AREA_BAR_DEFAULT_OPTIONS_4 = {
         ["2020-10-22", -45],
         ["2020-10-23", -55],
       ],
+      seriesKey: "series 3",
     },
     {
       name: "series 4",
@@ -306,6 +318,7 @@ export const LINE_AREA_BAR_DEFAULT_OPTIONS_4 = {
         ["2020-10-22", -10],
         ["2020-10-23", -5],
       ],
+      seriesKey: "series 4",
     },
   ],
 };
@@ -330,6 +343,7 @@ export const LINE_AREA_BAR_DEFAULT_OPTIONS_5 = {
       yAxisPosition: "left",
       type: "bar",
       data: _.range(48).map(n => [`bar ${n + 1}`, n + 1]),
+      seriesKey: "sum",
     },
   ],
 };
@@ -354,6 +368,7 @@ export const LINE_AREA_BAR_DEFAULT_OPTIONS_6 = {
       yAxisPosition: "left",
       type: "bar",
       data: _.range(200).map(n => [`bar ${n + 1}`, n + 1]),
+      seriesKey: "warn",
     },
   ],
 };
@@ -378,6 +393,7 @@ export const LINE_AREA_BAR_DEFAULT_OPTIONS_7 = {
       yAxisPosition: "left",
       type: "bar",
       data: _.range(20).map(n => [`bar ${n + 1}`, n + 1]),
+      seriesKey: "loss",
     },
   ],
 };

--- a/frontend/src/metabase/static-viz/components/LineAreaBarChart/utils/series.tsx
+++ b/frontend/src/metabase/static-viz/components/LineAreaBarChart/utils/series.tsx
@@ -1,0 +1,48 @@
+import _ from "underscore";
+import { isNotNull } from "metabase/core/utils/array";
+import { getColorsForValues } from "metabase/lib/colors/charts";
+import { formatStaticValue } from "metabase/static-viz/lib/format-static-value";
+import { ColorPalette } from "metabase/lib/colors/types";
+import {
+  ChartSettings,
+  Series,
+  SeriesWithBreakoutValues,
+  SeriesWithoutBreakoutValues,
+} from "../../XYChart/types";
+
+export function getSeriesWithColors(
+  multipleSeries: (SeriesWithoutBreakoutValues | SeriesWithBreakoutValues)[],
+  palette: ColorPalette,
+  settings: ChartSettings,
+): Series[] {
+  const keys = multipleSeries
+    .map(series => {
+      if (hasBreakoutValues(series)) {
+        return formatStaticValue(series.name, {
+          column: series.column,
+        });
+      }
+
+      return series.seriesKey;
+    })
+    .filter(isNotNull);
+  const seriesColors = settings.series_settings
+    ? _.mapObject(settings.series_settings, value => {
+        return value.color;
+      })
+    : undefined;
+  const chartColors = getColorsForValues(keys, seriesColors, palette);
+
+  return multipleSeries.map((series, index) => {
+    return {
+      ...(_.omit(series, "column", "seriesKey") as Series),
+      color: chartColors[keys[index]],
+    };
+  });
+}
+
+function hasBreakoutValues(
+  series: SeriesWithBreakoutValues | SeriesWithoutBreakoutValues,
+): series is SeriesWithBreakoutValues {
+  return Boolean((series as SeriesWithBreakoutValues).column);
+}

--- a/frontend/src/metabase/static-viz/components/LineAreaBarChart/utils/series.tsx
+++ b/frontend/src/metabase/static-viz/components/LineAreaBarChart/utils/series.tsx
@@ -13,11 +13,107 @@ import {
 
 export function getSeriesWithColors(
   multipleSeries: (SeriesWithOneOrLessDimensions | SeriesWithTwoDimensions)[][],
-  multipleSetting: ChartSettings,
+  settings: ChartSettings,
   palette: ColorPalette,
-): (SeriesWithOneOrLessDimensions | SeriesWithTwoDimensions)[] {
+): (SeriesWithOneOrLessDimensions | SeriesWithTwoDimensions)[][] {
   const isMultipleSeries = multipleSeries.length > 1;
-  const keys = multipleSeries
+  const keys = getSeriesKeys(multipleSeries, isMultipleSeries);
+
+  const seriesColors = settings.series_settings
+    ? _.mapObject(settings.series_settings, value => {
+        return value.color;
+      })
+    : undefined;
+  const chartColors = getColorsForValues(
+    keys,
+    removeEmptyValues(seriesColors),
+    palette,
+  );
+
+  let index = -1;
+  return multipleSeries.map(questionSeries =>
+    questionSeries.map(series => {
+      index++;
+
+      return merge(series, {
+        color: chartColors[keys[index]],
+      });
+    }),
+  );
+}
+
+export function getSeriesWithLegends(
+  multipleSeries: (SeriesWithOneOrLessDimensions | SeriesWithTwoDimensions)[][],
+  settings: ChartSettings,
+): (SeriesWithOneOrLessDimensions | SeriesWithTwoDimensions)[][] {
+  const keys = getSeriesKeys(multipleSeries, multipleSeries.length > 1);
+  const isMultipleSeries = multipleSeries.length > 1;
+
+  const seriesTitles = settings.series_settings
+    ? _.mapObject(settings.series_settings, value => {
+        return value.title;
+      })
+    : undefined;
+
+  let index = -1;
+  const legends = multipleSeries
+    .flatMap((questionSeries, seriesIndex) => {
+      return questionSeries.map(series => {
+        index++;
+
+        if (!hasTwoDimensions(series)) {
+          // One or zero dimensions
+
+          if (seriesIndex === 0 && series.name) {
+            return series.name;
+          }
+
+          const hasOneMetric = questionSeries.length === 1;
+          if (hasOneMetric) {
+            return series.cardName;
+          }
+
+          if (!isMultipleSeries) {
+            return series.column.display_name;
+          }
+
+          // is multiple series card
+          return `${series.cardName}: ${series.column.display_name}`;
+        } else {
+          // Two dimensions
+
+          const columnKey = formatStaticValue(series.breakoutValue, {
+            column: series.column,
+          });
+
+          if (!isMultipleSeries) {
+            return seriesTitles?.[keys[index]] ?? columnKey;
+          }
+
+          // is multiple series card
+          return `${series.cardName}: ${columnKey}`;
+        }
+      });
+    })
+    .filter(isNotNull);
+
+  index = -1;
+  return multipleSeries.map(questionSeries =>
+    questionSeries.map(series => {
+      index++;
+
+      return merge(series, {
+        name: legends[index],
+      });
+    }),
+  );
+}
+
+function getSeriesKeys(
+  multipleSeries: (SeriesWithOneOrLessDimensions | SeriesWithTwoDimensions)[][],
+  isMultipleSeries: boolean,
+) {
+  return multipleSeries
     .flatMap((questionSeries, seriesIndex) => {
       return questionSeries.map(series => {
         if (!hasTwoDimensions(series)) {
@@ -33,36 +129,22 @@ export function getSeriesWithColors(
 
           // is multiple series card
           return `${series.cardName}: ${series.column.display_name}`;
+        } else {
+          // Two dimension
+          const columnKey = formatStaticValue(series.breakoutValue, {
+            column: series.column,
+          });
+
+          if (!isMultipleSeries) {
+            return columnKey;
+          }
+
+          // is multiple series card
+          return `${series.cardName}: ${columnKey}`;
         }
-
-        const columnKey = formatStaticValue(series.breakoutValue, {
-          column: series.column,
-        });
-
-        if (!isMultipleSeries) {
-          return columnKey;
-        }
-
-        // is multiple series card
-        return `${series.cardName}: ${columnKey}`;
       });
     })
     .filter(isNotNull);
-
-  const seriesColors = multipleSetting.series_settings
-    ? _.mapObject(multipleSetting.series_settings, value => {
-        return value.color;
-      })
-    : undefined;
-  const chartColors = getColorsForValues(keys, seriesColors, palette);
-
-  return multipleSeries
-    .flatMap(questionSeries => questionSeries)
-    .map((series, index) => {
-      return merge(series, {
-        color: chartColors[keys[index]],
-      });
-    });
 }
 
 function hasTwoDimensions(
@@ -72,9 +154,21 @@ function hasTwoDimensions(
 }
 
 export function removeNoneSeriesFields(
-  series: (SeriesWithOneOrLessDimensions | SeriesWithTwoDimensions)[],
+  series: (SeriesWithOneOrLessDimensions | SeriesWithTwoDimensions)[][],
 ): Series[] {
-  return series.map(
-    series => _.omit(series, "cardName", "column", "breakoutValue") as Series,
-  );
+  return series
+    .flat()
+    .map(
+      series => _.omit(series, "cardName", "column", "breakoutValue") as Series,
+    );
+}
+
+function removeEmptyValues(
+  seriesColors: { [x: string]: string | undefined } | undefined,
+): Record<string, string> | undefined {
+  if (seriesColors) {
+    return Object.fromEntries(
+      Object.entries(seriesColors).filter(([key, value]) => isNotNull(value)),
+    ) as unknown as Record<string, string>;
+  }
 }

--- a/frontend/src/metabase/static-viz/components/LineAreaBarChart/utils/series.tsx
+++ b/frontend/src/metabase/static-viz/components/LineAreaBarChart/utils/series.tsx
@@ -1,5 +1,5 @@
 import _ from "underscore";
-import { isNotNull } from "metabase/core/utils/array";
+import { isNotNull } from "metabase/core/utils/types";
 import { getColorsForValues } from "metabase/lib/colors/charts";
 import { formatStaticValue } from "metabase/static-viz/lib/format-static-value";
 import { ColorPalette } from "metabase/lib/colors/types";
@@ -44,5 +44,5 @@ export function getSeriesWithColors(
 function hasBreakoutValues(
   series: SeriesWithBreakoutValues | SeriesWithoutBreakoutValues,
 ): series is SeriesWithBreakoutValues {
-  return Boolean((series as SeriesWithBreakoutValues).column);
+  return "column" in series;
 }

--- a/frontend/src/metabase/static-viz/components/LineAreaBarChart/utils/series.tsx
+++ b/frontend/src/metabase/static-viz/components/LineAreaBarChart/utils/series.tsx
@@ -61,6 +61,11 @@ export function getSeriesWithLegends(
       return questionSeries.map(series => {
         index++;
 
+        const customSeriesTitle = seriesTitles?.[keys[index]];
+        if (customSeriesTitle) {
+          return customSeriesTitle;
+        }
+
         if (!hasTwoDimensions(series)) {
           // One or zero dimensions
 
@@ -87,7 +92,7 @@ export function getSeriesWithLegends(
           });
 
           if (!isMultipleSeries) {
-            return seriesTitles?.[keys[index]] ?? columnKey;
+            return columnKey;
           }
 
           // is multiple series card

--- a/frontend/src/metabase/static-viz/components/LineAreaBarChart/utils/series.tsx
+++ b/frontend/src/metabase/static-viz/components/LineAreaBarChart/utils/series.tsx
@@ -66,6 +66,11 @@ export function getSeriesWithLegends(
           return customSeriesTitle;
         }
 
+        // When rendering multiple scalars `column` would be null.
+        if (series.column == null) {
+          return series.cardName;
+        }
+
         if (!hasTwoDimensions(series)) {
           // One or zero dimensions
 
@@ -121,6 +126,11 @@ function getSeriesKeys(
   return multipleSeries
     .flatMap((questionSeries, seriesIndex) => {
       return questionSeries.map(series => {
+        // When rendering multiple scalars `column` would be null.
+        if (series.column == null) {
+          return series.cardName;
+        }
+
         if (!hasTwoDimensions(series)) {
           // One or zero dimensions
           if (seriesIndex === 0) {

--- a/frontend/src/metabase/static-viz/components/LineAreaBarChart/utils/series.tsx
+++ b/frontend/src/metabase/static-viz/components/LineAreaBarChart/utils/series.tsx
@@ -1,48 +1,80 @@
 import _ from "underscore";
+import { merge } from "icepick";
 import { isNotNull } from "metabase/core/utils/types";
 import { getColorsForValues } from "metabase/lib/colors/charts";
-import { formatStaticValue } from "metabase/static-viz/lib/format-static-value";
+import { formatStaticValue } from "metabase/static-viz/lib/format";
 import { ColorPalette } from "metabase/lib/colors/types";
 import {
   ChartSettings,
   Series,
-  SeriesWithBreakoutValues,
-  SeriesWithoutBreakoutValues,
+  SeriesWithOneOrLessDimensions,
+  SeriesWithTwoDimensions,
 } from "../../XYChart/types";
 
 export function getSeriesWithColors(
-  multipleSeries: (SeriesWithoutBreakoutValues | SeriesWithBreakoutValues)[],
+  multipleSeries: (SeriesWithOneOrLessDimensions | SeriesWithTwoDimensions)[][],
+  multipleSetting: ChartSettings,
   palette: ColorPalette,
-  settings: ChartSettings,
-): Series[] {
+): (SeriesWithOneOrLessDimensions | SeriesWithTwoDimensions)[] {
+  const isMultipleSeries = multipleSeries.length > 1;
   const keys = multipleSeries
-    .map(series => {
-      if (hasBreakoutValues(series)) {
-        return formatStaticValue(series.name, {
+    .flatMap((questionSeries, seriesIndex) => {
+      return questionSeries.map(series => {
+        if (!hasTwoDimensions(series)) {
+          // One or zero dimensions
+          if (seriesIndex === 0) {
+            return series.column.name;
+          }
+
+          const hasOneMetric = questionSeries.length === 1;
+          if (!isMultipleSeries || hasOneMetric) {
+            return series.cardName;
+          }
+
+          // is multiple series card
+          return `${series.cardName}: ${series.column.display_name}`;
+        }
+
+        const columnKey = formatStaticValue(series.breakoutValue, {
           column: series.column,
         });
-      }
 
-      return series.seriesKey;
+        if (!isMultipleSeries) {
+          return columnKey;
+        }
+
+        // is multiple series card
+        return `${series.cardName}: ${columnKey}`;
+      });
     })
     .filter(isNotNull);
-  const seriesColors = settings.series_settings
-    ? _.mapObject(settings.series_settings, value => {
+
+  const seriesColors = multipleSetting.series_settings
+    ? _.mapObject(multipleSetting.series_settings, value => {
         return value.color;
       })
     : undefined;
   const chartColors = getColorsForValues(keys, seriesColors, palette);
 
-  return multipleSeries.map((series, index) => {
-    return {
-      ...(_.omit(series, "column", "seriesKey") as Series),
-      color: chartColors[keys[index]],
-    };
-  });
+  return multipleSeries
+    .flatMap(questionSeries => questionSeries)
+    .map((series, index) => {
+      return merge(series, {
+        color: chartColors[keys[index]],
+      });
+    });
 }
 
-function hasBreakoutValues(
-  series: SeriesWithBreakoutValues | SeriesWithoutBreakoutValues,
-): series is SeriesWithBreakoutValues {
-  return "column" in series;
+function hasTwoDimensions(
+  series: SeriesWithOneOrLessDimensions | SeriesWithTwoDimensions,
+): series is SeriesWithTwoDimensions {
+  return "breakoutValue" in series;
+}
+
+export function removeNoneSeriesFields(
+  series: (SeriesWithOneOrLessDimensions | SeriesWithTwoDimensions)[],
+): Series[] {
+  return series.map(
+    series => _.omit(series, "cardName", "column", "breakoutValue") as Series,
+  );
 }

--- a/frontend/src/metabase/static-viz/components/LineAreaBarChart/utils/series.unit.spec.ts
+++ b/frontend/src/metabase/static-viz/components/LineAreaBarChart/utils/series.unit.spec.ts
@@ -1,0 +1,378 @@
+import { merge } from "icepick";
+import { colors } from "metabase/lib/colors";
+import type {
+  ChartSettings,
+  SeriesWithBreakoutValues,
+  SeriesWithoutBreakoutValues,
+} from "../../XYChart/types";
+import { getSeriesWithColors } from "./series";
+
+const settings: ChartSettings = {
+  x: {
+    type: "ordinal",
+  },
+  y: {
+    type: "linear",
+  },
+  labels: {
+    left: "Count",
+    bottom: "Date",
+  },
+};
+
+describe("getSeriesWithColors", () => {
+  it("should return an empty series given an empty series", () => {
+    const seriesWithColors = getSeriesWithColors([], getPalette({}), settings);
+
+    expect(seriesWithColors).toEqual([]);
+  });
+
+  describe("Series without breakout values", () => {
+    const series: SeriesWithoutBreakoutValues[] = [
+      {
+        name: "Count",
+        yAxisPosition: "left",
+        type: "bar",
+        data: [
+          ["Doohickey", 3976],
+          ["Gadget", 4939],
+          ["Gizmo", 4784],
+          ["Widget", 5061],
+        ],
+        seriesKey: "count",
+      },
+    ];
+
+    it("should assign colors given series", () => {
+      const seriesWithColors = getSeriesWithColors(
+        series,
+        getPalette({}),
+        settings,
+      );
+
+      const expectedSeries = [
+        {
+          name: "Count",
+          color: "#509EE3", // brand color
+          yAxisPosition: "left",
+          type: "bar",
+          data: [
+            ["Doohickey", 3976],
+            ["Gadget", 4939],
+            ["Gizmo", 4784],
+            ["Widget", 5061],
+          ],
+        },
+      ];
+
+      expect(seriesWithColors).toEqual(expectedSeries);
+    });
+
+    it("should assign colors from whitelabel colors", () => {
+      const seriesWithColors = getSeriesWithColors(
+        series,
+        getPalette({ brand: "#123456", summarize: "#ffffff" }),
+        settings,
+      );
+
+      const expectedSeries = [
+        {
+          name: "Count",
+          color: "#123456", // whitelabel color
+          yAxisPosition: "left",
+          type: "bar",
+          data: [
+            ["Doohickey", 3976],
+            ["Gadget", 4939],
+            ["Gizmo", 4784],
+            ["Widget", 5061],
+          ],
+        },
+      ];
+
+      expect(seriesWithColors).toEqual(expectedSeries);
+    });
+
+    it("it should assign colors from column colors", () => {
+      const seriesWithColors = getSeriesWithColors(
+        series,
+        getPalette({ brand: "#123456", summarize: "#ffffff" }),
+        merge(settings, {
+          series_settings: {
+            count: {
+              color: "#987654",
+            },
+          },
+        }),
+      );
+
+      const expectedSeries = [
+        {
+          name: "Count",
+          color: "#987654", // column color
+          yAxisPosition: "left",
+          type: "bar",
+          data: [
+            ["Doohickey", 3976],
+            ["Gadget", 4939],
+            ["Gizmo", 4784],
+            ["Widget", 5061],
+          ],
+        },
+      ];
+
+      expect(seriesWithColors).toEqual(expectedSeries);
+    });
+  });
+
+  describe("Series with preferred colors", () => {
+    const series: SeriesWithoutBreakoutValues[] = [
+      {
+        name: "Sum of Total",
+        yAxisPosition: "left",
+        type: "bar",
+        data: [["2016-04-24T00:00:00Z", 52.75594257942132]],
+        seriesKey: "sum",
+      },
+    ];
+
+    it("should assign colors from preferred color", () => {
+      const seriesWithColors = getSeriesWithColors(
+        series,
+        getPalette({ brand: "#123456", summarize: "#ffffff" }),
+        merge(settings, { x: { type: "timeseries" } }),
+      );
+
+      const expectedSeries = [
+        {
+          name: "Sum of Total",
+          color: "#88BF4D", // accent1 color
+          yAxisPosition: "left",
+          type: "bar",
+          data: [["2016-04-24T00:00:00Z", 52.75594257942132]],
+        },
+      ];
+
+      expect(seriesWithColors).toEqual(expectedSeries);
+    });
+
+    it("should assign colors from whitelabel colors", () => {
+      const seriesWithColors = getSeriesWithColors(
+        series,
+        getPalette({ accent1: "#123456", summarize: "#ffffff" }),
+        merge(settings, {
+          x: { type: "timeseries" },
+        }),
+      );
+
+      const expectedSeries = [
+        {
+          name: "Sum of Total",
+          color: "#123456", // whitelabel color
+          yAxisPosition: "left",
+          type: "bar",
+          data: [["2016-04-24T00:00:00Z", 52.75594257942132]],
+        },
+      ];
+
+      expect(seriesWithColors).toEqual(expectedSeries);
+    });
+
+    it("should assign colors from column colors", () => {
+      const seriesWithColors = getSeriesWithColors(
+        series,
+        getPalette({ brand: "#123456", summarize: "#ffffff" }),
+        merge(settings, {
+          x: { type: "timeseries" },
+          series_settings: {
+            sum: {
+              color: "#987654",
+            },
+          },
+        }),
+      );
+
+      const expectedSeries = [
+        {
+          name: "Sum of Total",
+          color: "#987654", // column color
+          yAxisPosition: "left",
+          type: "bar",
+          data: [["2016-04-24T00:00:00Z", 52.75594257942132]],
+        },
+      ];
+
+      expect(seriesWithColors).toEqual(expectedSeries);
+    });
+  });
+
+  describe("Series with breakout values", () => {
+    const series: SeriesWithBreakoutValues[] = [
+      {
+        name: "2016-01-01T00:00:00Z",
+        type: "area",
+        data: [
+          ["Doohickey", 177],
+          ["Gadget", 199],
+          ["Gizmo", 158],
+          ["Widget", 210],
+        ],
+        yAxisPosition: "left",
+        column: {
+          semantic_type: "type/CreationTimestamp",
+          unit: "year",
+          name: "CREATED_AT",
+          source: "breakout",
+          display_name: "Created At",
+        },
+      },
+      {
+        name: "2017-01-01T00:00:00Z",
+        type: "area",
+        data: [
+          ["Doohickey", 1206],
+          ["Gadget", 1505],
+          ["Gizmo", 1592],
+          ["Widget", 1531],
+        ],
+        yAxisPosition: "left",
+        column: {
+          semantic_type: "type/CreationTimestamp",
+          unit: "year",
+          name: "CREATED_AT",
+          source: "breakout",
+          display_name: "Created At",
+        },
+      },
+    ];
+
+    it("should assign colors given series", () => {
+      const seriesWithColors = getSeriesWithColors(
+        series,
+        getPalette({}),
+        merge(settings, {
+          x: { type: "timeseries" },
+        }),
+      );
+
+      const expectedSeries = [
+        {
+          name: "2016-01-01T00:00:00Z",
+          color: "#EF8C8C", // accent3 color
+          type: "area",
+          data: [
+            ["Doohickey", 177],
+            ["Gadget", 199],
+            ["Gizmo", 158],
+            ["Widget", 210],
+          ],
+          yAxisPosition: "left",
+        },
+        {
+          name: "2017-01-01T00:00:00Z",
+          color: "#F9D45C", // accent4 color
+          type: "area",
+          data: [
+            ["Doohickey", 1206],
+            ["Gadget", 1505],
+            ["Gizmo", 1592],
+            ["Widget", 1531],
+          ],
+          yAxisPosition: "left",
+        },
+      ];
+
+      expect(seriesWithColors).toEqual(expectedSeries);
+    });
+
+    it("should assign colors from whitelabel colors", () => {
+      const seriesWithColors = getSeriesWithColors(
+        series,
+        getPalette({ accent3: "#123456" }),
+        merge(settings, {
+          x: { type: "timeseries" },
+        }),
+      );
+
+      const expectedSeries = [
+        {
+          name: "2016-01-01T00:00:00Z",
+          color: "#123456", // whitelabel color
+          type: "area",
+          data: [
+            ["Doohickey", 177],
+            ["Gadget", 199],
+            ["Gizmo", 158],
+            ["Widget", 210],
+          ],
+          yAxisPosition: "left",
+        },
+        {
+          name: "2017-01-01T00:00:00Z",
+          color: "#F9D45C", // accent4 color
+          type: "area",
+          data: [
+            ["Doohickey", 1206],
+            ["Gadget", 1505],
+            ["Gizmo", 1592],
+            ["Widget", 1531],
+          ],
+          yAxisPosition: "left",
+        },
+      ];
+
+      expect(seriesWithColors).toEqual(expectedSeries);
+    });
+
+    it("should assign colors from column colors", () => {
+      const seriesWithColors = getSeriesWithColors(
+        series,
+        getPalette({ accent3: "#123456" }),
+        merge(settings, {
+          x: { type: "timeseries" },
+          series_settings: {
+            2017: {
+              color: "#987654",
+            },
+          },
+        }),
+      );
+
+      const expectedSeries = [
+        {
+          name: "2016-01-01T00:00:00Z",
+          color: "#123456", // whitelabel color
+          type: "area",
+          data: [
+            ["Doohickey", 177],
+            ["Gadget", 199],
+            ["Gizmo", 158],
+            ["Widget", 210],
+          ],
+          yAxisPosition: "left",
+        },
+        {
+          name: "2017-01-01T00:00:00Z",
+          color: "#987654", // column color
+          type: "area",
+          data: [
+            ["Doohickey", 1206],
+            ["Gadget", 1505],
+            ["Gizmo", 1592],
+            ["Widget", 1531],
+          ],
+          yAxisPosition: "left",
+        },
+      ];
+
+      expect(seriesWithColors).toEqual(expectedSeries);
+    });
+  });
+});
+
+function getPalette(instanceColors: Record<string, string>) {
+  return {
+    ...colors,
+    ...instanceColors,
+  };
+}

--- a/frontend/src/metabase/static-viz/components/LineAreaBarChart/utils/series.unit.spec.ts
+++ b/frontend/src/metabase/static-viz/components/LineAreaBarChart/utils/series.unit.spec.ts
@@ -2,8 +2,8 @@ import { merge } from "icepick";
 import { colors } from "metabase/lib/colors";
 import type {
   ChartSettings,
-  SeriesWithBreakoutValues,
-  SeriesWithoutBreakoutValues,
+  SeriesWithOneOrLessDimensions,
+  SeriesWithTwoDimensions,
 } from "../../XYChart/types";
 import { getSeriesWithColors } from "./series";
 
@@ -22,38 +22,17 @@ const settings: ChartSettings = {
 
 describe("getSeriesWithColors", () => {
   it("should return an empty series given an empty series", () => {
-    const seriesWithColors = getSeriesWithColors([], getPalette({}), settings);
+    const seriesWithColors = getSeriesWithColors([], settings, getPalette({}));
 
     expect(seriesWithColors).toEqual([]);
   });
 
-  describe("Series without breakout values", () => {
-    const series: SeriesWithoutBreakoutValues[] = [
-      {
-        name: "Count",
-        yAxisPosition: "left",
-        type: "bar",
-        data: [
-          ["Doohickey", 3976],
-          ["Gadget", 4939],
-          ["Gizmo", 4784],
-          ["Widget", 5061],
-        ],
-        seriesKey: "count",
-      },
-    ];
-
-    it("should assign colors given series", () => {
-      const seriesWithColors = getSeriesWithColors(
-        series,
-        getPalette({}),
-        settings,
-      );
-
-      const expectedSeries = [
+  describe("Series without ones or less dimensions", () => {
+    const multipleSeries: SeriesWithOneOrLessDimensions[][] = [
+      [
         {
           name: "Count",
-          color: "#509EE3", // brand color
+          cardName: "Bar chart",
           yAxisPosition: "left",
           type: "bar",
           data: [
@@ -62,7 +41,34 @@ describe("getSeriesWithColors", () => {
             ["Gizmo", 4784],
             ["Widget", 5061],
           ],
+          column: {
+            name: "count",
+            source: "aggregation",
+            display_name: "Count",
+          },
         },
+      ],
+    ];
+
+    it("should assign colors given series", () => {
+      const seriesWithColors = getSeriesWithColors(
+        multipleSeries,
+        settings,
+        getPalette({}),
+      );
+
+      const expectedSeries = [
+        [
+          {
+            color: "#509EE3", // brand color
+            name: expect.anything(),
+            cardName: expect.anything(),
+            yAxisPosition: expect.anything(),
+            type: expect.anything(),
+            data: expect.anything(),
+            column: expect.anything(),
+          },
+        ],
       ];
 
       expect(seriesWithColors).toEqual(expectedSeries);
@@ -70,24 +76,23 @@ describe("getSeriesWithColors", () => {
 
     it("should assign colors from whitelabel colors", () => {
       const seriesWithColors = getSeriesWithColors(
-        series,
-        getPalette({ brand: "#123456", summarize: "#ffffff" }),
+        multipleSeries,
         settings,
+        getPalette({ brand: "#123456", summarize: "#ffffff" }),
       );
 
       const expectedSeries = [
-        {
-          name: "Count",
-          color: "#123456", // whitelabel color
-          yAxisPosition: "left",
-          type: "bar",
-          data: [
-            ["Doohickey", 3976],
-            ["Gadget", 4939],
-            ["Gizmo", 4784],
-            ["Widget", 5061],
-          ],
-        },
+        [
+          {
+            color: "#123456", // whitelabel color
+            name: expect.anything(),
+            cardName: expect.anything(),
+            yAxisPosition: expect.anything(),
+            type: expect.anything(),
+            data: expect.anything(),
+            column: expect.anything(),
+          },
+        ],
       ];
 
       expect(seriesWithColors).toEqual(expectedSeries);
@@ -95,8 +100,7 @@ describe("getSeriesWithColors", () => {
 
     it("it should assign colors from column colors", () => {
       const seriesWithColors = getSeriesWithColors(
-        series,
-        getPalette({ brand: "#123456", summarize: "#ffffff" }),
+        multipleSeries,
         merge(settings, {
           series_settings: {
             count: {
@@ -104,21 +108,21 @@ describe("getSeriesWithColors", () => {
             },
           },
         }),
+        getPalette({ brand: "#123456", summarize: "#ffffff" }),
       );
 
       const expectedSeries = [
-        {
-          name: "Count",
-          color: "#987654", // column color
-          yAxisPosition: "left",
-          type: "bar",
-          data: [
-            ["Doohickey", 3976],
-            ["Gadget", 4939],
-            ["Gizmo", 4784],
-            ["Widget", 5061],
-          ],
-        },
+        [
+          {
+            color: "#987654", // column color
+            name: expect.anything(),
+            cardName: expect.anything(),
+            yAxisPosition: expect.anything(),
+            type: expect.anything(),
+            data: expect.anything(),
+            column: expect.anything(),
+          },
+        ],
       ];
 
       expect(seriesWithColors).toEqual(expectedSeries);
@@ -126,31 +130,42 @@ describe("getSeriesWithColors", () => {
   });
 
   describe("Series with preferred colors", () => {
-    const series: SeriesWithoutBreakoutValues[] = [
-      {
-        name: "Sum of Total",
-        yAxisPosition: "left",
-        type: "bar",
-        data: [["2016-04-24T00:00:00Z", 52.75594257942132]],
-        seriesKey: "sum",
-      },
+    const multipleSeries: SeriesWithOneOrLessDimensions[][] = [
+      [
+        {
+          name: "Sum of Total",
+          cardName: "Bar chart",
+          yAxisPosition: "left",
+          type: "bar",
+          data: [["2016-04-24T00:00:00Z", 52.75594257942132]],
+          column: {
+            name: "sum",
+            source: "aggregation",
+            display_name: "Sum of Total",
+          },
+        },
+      ],
     ];
 
     it("should assign colors from preferred color", () => {
       const seriesWithColors = getSeriesWithColors(
-        series,
-        getPalette({ brand: "#123456", summarize: "#ffffff" }),
+        multipleSeries,
         merge(settings, { x: { type: "timeseries" } }),
+        getPalette({ brand: "#123456", summarize: "#ffffff" }),
       );
 
       const expectedSeries = [
-        {
-          name: "Sum of Total",
-          color: "#88BF4D", // accent1 color
-          yAxisPosition: "left",
-          type: "bar",
-          data: [["2016-04-24T00:00:00Z", 52.75594257942132]],
-        },
+        [
+          {
+            color: "#88BF4D", // accent1 color
+            name: expect.anything(),
+            cardName: expect.anything(),
+            yAxisPosition: expect.anything(),
+            type: expect.anything(),
+            data: expect.anything(),
+            column: expect.anything(),
+          },
+        ],
       ];
 
       expect(seriesWithColors).toEqual(expectedSeries);
@@ -158,21 +173,25 @@ describe("getSeriesWithColors", () => {
 
     it("should assign colors from whitelabel colors", () => {
       const seriesWithColors = getSeriesWithColors(
-        series,
-        getPalette({ accent1: "#123456", summarize: "#ffffff" }),
+        multipleSeries,
         merge(settings, {
           x: { type: "timeseries" },
         }),
+        getPalette({ accent1: "#123456", summarize: "#ffffff" }),
       );
 
       const expectedSeries = [
-        {
-          name: "Sum of Total",
-          color: "#123456", // whitelabel color
-          yAxisPosition: "left",
-          type: "bar",
-          data: [["2016-04-24T00:00:00Z", 52.75594257942132]],
-        },
+        [
+          {
+            color: "#123456", // whitelabel color
+            name: expect.anything(),
+            cardName: expect.anything(),
+            yAxisPosition: expect.anything(),
+            type: expect.anything(),
+            data: expect.anything(),
+            column: expect.anything(),
+          },
+        ],
       ];
 
       expect(seriesWithColors).toEqual(expectedSeries);
@@ -180,8 +199,7 @@ describe("getSeriesWithColors", () => {
 
     it("should assign colors from column colors", () => {
       const seriesWithColors = getSeriesWithColors(
-        series,
-        getPalette({ brand: "#123456", summarize: "#ffffff" }),
+        multipleSeries,
         merge(settings, {
           x: { type: "timeseries" },
           series_settings: {
@@ -190,75 +208,33 @@ describe("getSeriesWithColors", () => {
             },
           },
         }),
+        getPalette({ brand: "#123456", summarize: "#ffffff" }),
       );
 
       const expectedSeries = [
-        {
-          name: "Sum of Total",
-          color: "#987654", // column color
-          yAxisPosition: "left",
-          type: "bar",
-          data: [["2016-04-24T00:00:00Z", 52.75594257942132]],
-        },
+        [
+          {
+            color: "#987654", // column color
+            name: expect.anything(),
+            cardName: expect.anything(),
+            yAxisPosition: expect.anything(),
+            type: expect.anything(),
+            data: expect.anything(),
+            column: expect.anything(),
+          },
+        ],
       ];
 
       expect(seriesWithColors).toEqual(expectedSeries);
     });
   });
 
-  describe("Series with breakout values", () => {
-    const series: SeriesWithBreakoutValues[] = [
-      {
-        name: "2016-01-01T00:00:00Z",
-        type: "area",
-        data: [
-          ["Doohickey", 177],
-          ["Gadget", 199],
-          ["Gizmo", 158],
-          ["Widget", 210],
-        ],
-        yAxisPosition: "left",
-        column: {
-          semantic_type: "type/CreationTimestamp",
-          unit: "year",
-          name: "CREATED_AT",
-          source: "breakout",
-          display_name: "Created At",
-        },
-      },
-      {
-        name: "2017-01-01T00:00:00Z",
-        type: "area",
-        data: [
-          ["Doohickey", 1206],
-          ["Gadget", 1505],
-          ["Gizmo", 1592],
-          ["Widget", 1531],
-        ],
-        yAxisPosition: "left",
-        column: {
-          semantic_type: "type/CreationTimestamp",
-          unit: "year",
-          name: "CREATED_AT",
-          source: "breakout",
-          display_name: "Created At",
-        },
-      },
-    ];
-
-    it("should assign colors given series", () => {
-      const seriesWithColors = getSeriesWithColors(
-        series,
-        getPalette({}),
-        merge(settings, {
-          x: { type: "timeseries" },
-        }),
-      );
-
-      const expectedSeries = [
+  describe("Series with 2 dimension", () => {
+    const multipleSeries: SeriesWithTwoDimensions[][] = [
+      [
         {
-          name: "2016-01-01T00:00:00Z",
-          color: "#EF8C8C", // accent3 color
+          name: null,
+          cardName: "Area chart",
           type: "area",
           data: [
             ["Doohickey", 177],
@@ -267,10 +243,18 @@ describe("getSeriesWithColors", () => {
             ["Widget", 210],
           ],
           yAxisPosition: "left",
+          column: {
+            semantic_type: "type/CreationTimestamp",
+            unit: "year",
+            name: "CREATED_AT",
+            source: "breakout",
+            display_name: "Created At",
+          },
+          breakoutValue: "2016-01-01T00:00:00Z",
         },
         {
-          name: "2017-01-01T00:00:00Z",
-          color: "#F9D45C", // accent4 color
+          name: null,
+          cardName: "Area chart",
           type: "area",
           data: [
             ["Doohickey", 1206],
@@ -279,7 +263,50 @@ describe("getSeriesWithColors", () => {
             ["Widget", 1531],
           ],
           yAxisPosition: "left",
+          column: {
+            semantic_type: "type/CreationTimestamp",
+            unit: "year",
+            name: "CREATED_AT",
+            source: "breakout",
+            display_name: "Created At",
+          },
+          breakoutValue: "2017-01-01T00:00:00Z",
         },
+      ],
+    ];
+
+    it("should assign colors given series", () => {
+      const seriesWithColors = getSeriesWithColors(
+        multipleSeries,
+        merge(settings, {
+          x: { type: "timeseries" },
+        }),
+        getPalette({}),
+      );
+
+      const expectedSeries = [
+        [
+          {
+            color: "#EF8C8C", // accent3 color
+            name: null,
+            cardName: expect.anything(),
+            yAxisPosition: expect.anything(),
+            type: expect.anything(),
+            data: expect.anything(),
+            column: expect.anything(),
+            breakoutValue: expect.anything(),
+          },
+          {
+            color: "#F9D45C", // accent4 color
+            name: null,
+            cardName: expect.anything(),
+            yAxisPosition: expect.anything(),
+            type: expect.anything(),
+            data: expect.anything(),
+            column: expect.anything(),
+            breakoutValue: expect.anything(),
+          },
+        ],
       ];
 
       expect(seriesWithColors).toEqual(expectedSeries);
@@ -287,38 +314,36 @@ describe("getSeriesWithColors", () => {
 
     it("should assign colors from whitelabel colors", () => {
       const seriesWithColors = getSeriesWithColors(
-        series,
-        getPalette({ accent3: "#123456" }),
+        multipleSeries,
         merge(settings, {
           x: { type: "timeseries" },
         }),
+        getPalette({ accent3: "#123456" }),
       );
 
       const expectedSeries = [
-        {
-          name: "2016-01-01T00:00:00Z",
-          color: "#123456", // whitelabel color
-          type: "area",
-          data: [
-            ["Doohickey", 177],
-            ["Gadget", 199],
-            ["Gizmo", 158],
-            ["Widget", 210],
-          ],
-          yAxisPosition: "left",
-        },
-        {
-          name: "2017-01-01T00:00:00Z",
-          color: "#F9D45C", // accent4 color
-          type: "area",
-          data: [
-            ["Doohickey", 1206],
-            ["Gadget", 1505],
-            ["Gizmo", 1592],
-            ["Widget", 1531],
-          ],
-          yAxisPosition: "left",
-        },
+        [
+          {
+            color: "#123456", // whitelabel color
+            name: null,
+            cardName: expect.anything(),
+            yAxisPosition: expect.anything(),
+            type: expect.anything(),
+            data: expect.anything(),
+            column: expect.anything(),
+            breakoutValue: expect.anything(),
+          },
+          {
+            color: "#F9D45C", // accent4 color
+            name: null,
+            cardName: expect.anything(),
+            yAxisPosition: expect.anything(),
+            type: expect.anything(),
+            data: expect.anything(),
+            column: expect.anything(),
+            breakoutValue: expect.anything(),
+          },
+        ],
       ];
 
       expect(seriesWithColors).toEqual(expectedSeries);
@@ -326,8 +351,7 @@ describe("getSeriesWithColors", () => {
 
     it("should assign colors from column colors", () => {
       const seriesWithColors = getSeriesWithColors(
-        series,
-        getPalette({ accent3: "#123456" }),
+        multipleSeries,
         merge(settings, {
           x: { type: "timeseries" },
           series_settings: {
@@ -336,33 +360,32 @@ describe("getSeriesWithColors", () => {
             },
           },
         }),
+        getPalette({ accent3: "#123456" }),
       );
 
       const expectedSeries = [
-        {
-          name: "2016-01-01T00:00:00Z",
-          color: "#123456", // whitelabel color
-          type: "area",
-          data: [
-            ["Doohickey", 177],
-            ["Gadget", 199],
-            ["Gizmo", 158],
-            ["Widget", 210],
-          ],
-          yAxisPosition: "left",
-        },
-        {
-          name: "2017-01-01T00:00:00Z",
-          color: "#987654", // column color
-          type: "area",
-          data: [
-            ["Doohickey", 1206],
-            ["Gadget", 1505],
-            ["Gizmo", 1592],
-            ["Widget", 1531],
-          ],
-          yAxisPosition: "left",
-        },
+        [
+          {
+            color: "#123456", // whitelabel color
+            name: null,
+            cardName: expect.anything(),
+            yAxisPosition: expect.anything(),
+            type: expect.anything(),
+            data: expect.anything(),
+            column: expect.anything(),
+            breakoutValue: expect.anything(),
+          },
+          {
+            color: "#987654", // column color
+            name: null,
+            cardName: expect.anything(),
+            yAxisPosition: expect.anything(),
+            type: expect.anything(),
+            data: expect.anything(),
+            column: expect.anything(),
+            breakoutValue: expect.anything(),
+          },
+        ],
       ];
 
       expect(seriesWithColors).toEqual(expectedSeries);

--- a/frontend/src/metabase/static-viz/components/LineAreaBarChart/utils/series.unit.spec.ts
+++ b/frontend/src/metabase/static-viz/components/LineAreaBarChart/utils/series.unit.spec.ts
@@ -50,6 +50,47 @@ describe("getSeriesWithColors", () => {
       ],
     ];
 
+    const multipleSeriesDashcard: SeriesWithOneOrLessDimensions[][] = [
+      [
+        {
+          name: "Count",
+          cardName: "Bar chart",
+          yAxisPosition: "left",
+          type: "bar",
+          data: [
+            ["Doohickey", 3976],
+            ["Gadget", 4939],
+            ["Gizmo", 4784],
+            ["Widget", 5061],
+          ],
+          column: {
+            name: "count",
+            source: "aggregation",
+            display_name: "Count",
+          },
+        },
+      ],
+      [
+        {
+          name: "Count",
+          cardName: "Area chart",
+          yAxisPosition: "left",
+          type: "area",
+          data: [
+            ["Doohickey", 3976],
+            ["Gadget", 4939],
+            ["Gizmo", 4784],
+            ["Widget", 5061],
+          ],
+          column: {
+            name: "count",
+            source: "aggregation",
+            display_name: "Count",
+          },
+        },
+      ],
+    ];
+
     it("should assign colors given series", () => {
       const seriesWithColors = getSeriesWithColors(
         multipleSeries,
@@ -115,6 +156,41 @@ describe("getSeriesWithColors", () => {
         [
           {
             color: "#987654", // column color
+            name: expect.anything(),
+            cardName: expect.anything(),
+            yAxisPosition: expect.anything(),
+            type: expect.anything(),
+            data: expect.anything(),
+            column: expect.anything(),
+          },
+        ],
+      ];
+
+      expect(seriesWithColors).toEqual(expectedSeries);
+    });
+
+    it("it should assign colors on multiple series dashcard", () => {
+      const seriesWithColors = getSeriesWithColors(
+        multipleSeriesDashcard,
+        settings,
+        getPalette({}),
+      );
+
+      const expectedSeries = [
+        [
+          {
+            color: "#509EE3", // brand color
+            name: expect.anything(),
+            cardName: expect.anything(),
+            yAxisPosition: expect.anything(),
+            type: expect.anything(),
+            data: expect.anything(),
+            column: expect.anything(),
+          },
+        ],
+        [
+          {
+            color: "#EF8C8C",
             name: expect.anything(),
             cardName: expect.anything(),
             yAxisPosition: expect.anything(),
@@ -275,6 +351,94 @@ describe("getSeriesWithColors", () => {
       ],
     ];
 
+    const multipleSeriesDashcard: SeriesWithTwoDimensions[][] = [
+      [
+        {
+          name: null,
+          cardName: "Area chart",
+          type: "area",
+          data: [
+            ["Doohickey", 177],
+            ["Gadget", 199],
+            ["Gizmo", 158],
+            ["Widget", 210],
+          ],
+          yAxisPosition: "left",
+          column: {
+            semantic_type: "type/CreationTimestamp",
+            unit: "year",
+            name: "CREATED_AT",
+            source: "breakout",
+            display_name: "Created At",
+          },
+          breakoutValue: "2016-01-01T00:00:00Z",
+        },
+        {
+          name: null,
+          cardName: "Area chart",
+          type: "area",
+          data: [
+            ["Doohickey", 1206],
+            ["Gadget", 1505],
+            ["Gizmo", 1592],
+            ["Widget", 1531],
+          ],
+          yAxisPosition: "left",
+          column: {
+            semantic_type: "type/CreationTimestamp",
+            unit: "year",
+            name: "CREATED_AT",
+            source: "breakout",
+            display_name: "Created At",
+          },
+          breakoutValue: "2017-01-01T00:00:00Z",
+        },
+      ],
+
+      [
+        {
+          name: null,
+          cardName: "Bar chart",
+          type: "bar",
+          data: [
+            ["Doohickey", 177],
+            ["Gadget", 199],
+            ["Gizmo", 158],
+            ["Widget", 210],
+          ],
+          yAxisPosition: "left",
+          column: {
+            semantic_type: "type/CreationTimestamp",
+            unit: "year",
+            name: "CREATED_AT",
+            source: "breakout",
+            display_name: "Created At",
+          },
+          breakoutValue: "2016-01-01T00:00:00Z",
+        },
+        {
+          name: null,
+          cardName: "Bar chart",
+          type: "bar",
+          data: [
+            ["Doohickey", 1206],
+            ["Gadget", 1505],
+            ["Gizmo", 1592],
+            ["Widget", 1531],
+          ],
+          yAxisPosition: "left",
+          column: {
+            semantic_type: "type/CreationTimestamp",
+            unit: "year",
+            name: "CREATED_AT",
+            source: "breakout",
+            display_name: "Created At",
+          },
+          breakoutValue: "2017-01-01T00:00:00Z",
+        },
+      ],
+    ];
+
     it("should assign colors given series", () => {
       const seriesWithColors = getSeriesWithColors(
         multipleSeries,
@@ -377,6 +541,63 @@ describe("getSeriesWithColors", () => {
           },
           {
             color: "#987654", // column color
+            name: null,
+            cardName: expect.anything(),
+            yAxisPosition: expect.anything(),
+            type: expect.anything(),
+            data: expect.anything(),
+            column: expect.anything(),
+            breakoutValue: expect.anything(),
+          },
+        ],
+      ];
+
+      expect(seriesWithColors).toEqual(expectedSeries);
+    });
+
+    it("it should assign colors on multiple series dashcard", () => {
+      const seriesWithColors = getSeriesWithColors(
+        multipleSeriesDashcard,
+        settings,
+        getPalette({}),
+      );
+
+      const expectedSeries = [
+        [
+          {
+            color: "#F9D45C", // brand color
+            name: null,
+            cardName: expect.anything(),
+            yAxisPosition: expect.anything(),
+            type: expect.anything(),
+            data: expect.anything(),
+            column: expect.anything(),
+            breakoutValue: expect.anything(),
+          },
+          {
+            color: "#F2A86F", // column color
+            name: null,
+            cardName: expect.anything(),
+            yAxisPosition: expect.anything(),
+            type: expect.anything(),
+            data: expect.anything(),
+            column: expect.anything(),
+            breakoutValue: expect.anything(),
+          },
+        ],
+        [
+          {
+            color: "#98D9D9",
+            name: null,
+            cardName: expect.anything(),
+            yAxisPosition: expect.anything(),
+            type: expect.anything(),
+            data: expect.anything(),
+            column: expect.anything(),
+            breakoutValue: expect.anything(),
+          },
+          {
+            color: "#7172AD", // column color
             name: null,
             cardName: expect.anything(),
             yAxisPosition: expect.anything(),

--- a/frontend/src/metabase/static-viz/components/LineAreaBarChart/utils/series.unit.spec.ts
+++ b/frontend/src/metabase/static-viz/components/LineAreaBarChart/utils/series.unit.spec.ts
@@ -1,11 +1,11 @@
-import { merge } from "icepick";
+import { merge, setIn } from "icepick";
 import { colors } from "metabase/lib/colors";
 import type {
   ChartSettings,
   SeriesWithOneOrLessDimensions,
   SeriesWithTwoDimensions,
 } from "../../XYChart/types";
-import { getSeriesWithColors } from "./series";
+import { getSeriesWithColors, getSeriesWithLegends } from "./series";
 
 const settings: ChartSettings = {
   x: {
@@ -620,3 +620,411 @@ function getPalette(instanceColors: Record<string, string>) {
     ...instanceColors,
   };
 }
+
+describe("getSeriesWithLegends", () => {
+  it("should return an empty series given an empty series", () => {
+    const seriesWithLegends = getSeriesWithLegends([], settings);
+
+    expect(seriesWithLegends).toEqual([]);
+  });
+
+  describe("Series without ones or less dimensions", () => {
+    const multipleSeries: SeriesWithOneOrLessDimensions[][] = [
+      [
+        {
+          name: "Count",
+          cardName: "Bar chart",
+          yAxisPosition: "left",
+          type: "bar",
+          data: [
+            ["Doohickey", 3976],
+            ["Gadget", 4939],
+            ["Gizmo", 4784],
+            ["Widget", 5061],
+          ],
+          column: {
+            name: "count",
+            source: "aggregation",
+            display_name: "Count",
+          },
+        },
+      ],
+    ];
+
+    const multipleSeriesDashcard: SeriesWithOneOrLessDimensions[][] = [
+      [
+        {
+          name: "Count",
+          cardName: "Bar chart",
+          yAxisPosition: "left",
+          type: "bar",
+          data: [
+            ["Doohickey", 3976],
+            ["Gadget", 4939],
+            ["Gizmo", 4784],
+            ["Widget", 5061],
+          ],
+          column: {
+            name: "count",
+            source: "aggregation",
+            display_name: "Count",
+          },
+        },
+      ],
+      [
+        {
+          name: "Count",
+          cardName: "Area chart",
+          yAxisPosition: "left",
+          type: "area",
+          data: [
+            ["Doohickey", 3976],
+            ["Gadget", 4939],
+            ["Gizmo", 4784],
+            ["Widget", 5061],
+          ],
+          column: {
+            name: "count",
+            source: "aggregation",
+            display_name: "Count",
+          },
+        },
+      ],
+    ];
+
+    it("should assign legends given series", () => {
+      const seriesWithLegends = getSeriesWithLegends(multipleSeries, settings);
+
+      const expectedSeries = [
+        [
+          {
+            name: "Count",
+            cardName: expect.anything(),
+            yAxisPosition: expect.anything(),
+            type: expect.anything(),
+            data: expect.anything(),
+            column: expect.anything(),
+          },
+        ],
+      ];
+
+      expect(seriesWithLegends).toEqual(expectedSeries);
+    });
+
+    it("it should assign legends from column custom name", () => {
+      const seriesWithLegends = getSeriesWithLegends(
+        // This might not be apparent, but series' `name` would be set to
+        // custom metric name for series with one or less dimensions.
+        setIn(multipleSeries, [0, 0, "name"], "Custom count"),
+        settings,
+      );
+
+      const expectedSeries = [
+        [
+          {
+            name: "Custom count",
+            cardName: expect.anything(),
+            yAxisPosition: expect.anything(),
+            type: expect.anything(),
+            data: expect.anything(),
+            column: expect.anything(),
+          },
+        ],
+      ];
+
+      expect(seriesWithLegends).toEqual(expectedSeries);
+    });
+
+    it("it should assign legends on multiple series dashcard", () => {
+      const seriesWithLegends = getSeriesWithLegends(
+        multipleSeriesDashcard,
+        settings,
+      );
+
+      const expectedSeries = [
+        [
+          {
+            name: "Count",
+            cardName: expect.anything(),
+            yAxisPosition: expect.anything(),
+            type: expect.anything(),
+            data: expect.anything(),
+            column: expect.anything(),
+          },
+        ],
+        [
+          {
+            name: "Area chart",
+            cardName: expect.anything(),
+            yAxisPosition: expect.anything(),
+            type: expect.anything(),
+            data: expect.anything(),
+            column: expect.anything(),
+          },
+        ],
+      ];
+
+      expect(seriesWithLegends).toEqual(expectedSeries);
+    });
+  });
+
+  describe("Series with 2 dimension", () => {
+    const multipleSeries: SeriesWithTwoDimensions[][] = [
+      [
+        {
+          name: null,
+          cardName: "Area chart",
+          type: "area",
+          data: [
+            ["Doohickey", 177],
+            ["Gadget", 199],
+            ["Gizmo", 158],
+            ["Widget", 210],
+          ],
+          yAxisPosition: "left",
+          column: {
+            semantic_type: "type/CreationTimestamp",
+            unit: "year",
+            name: "CREATED_AT",
+            source: "breakout",
+            display_name: "Created At",
+          },
+          breakoutValue: "2016-01-01T00:00:00Z",
+        },
+        {
+          name: null,
+          cardName: "Area chart",
+          type: "area",
+          data: [
+            ["Doohickey", 1206],
+            ["Gadget", 1505],
+            ["Gizmo", 1592],
+            ["Widget", 1531],
+          ],
+          yAxisPosition: "left",
+          column: {
+            semantic_type: "type/CreationTimestamp",
+            unit: "year",
+            name: "CREATED_AT",
+            source: "breakout",
+            display_name: "Created At",
+          },
+          breakoutValue: "2017-01-01T00:00:00Z",
+        },
+      ],
+    ];
+
+    const multipleSeriesDashcard: SeriesWithTwoDimensions[][] = [
+      [
+        {
+          name: null,
+          cardName: "Area chart",
+          type: "area",
+          data: [
+            ["Doohickey", 177],
+            ["Gadget", 199],
+            ["Gizmo", 158],
+            ["Widget", 210],
+          ],
+          yAxisPosition: "left",
+          column: {
+            semantic_type: "type/CreationTimestamp",
+            unit: "year",
+            name: "CREATED_AT",
+            source: "breakout",
+            display_name: "Created At",
+          },
+          breakoutValue: "2016-01-01T00:00:00Z",
+        },
+        {
+          name: null,
+          cardName: "Area chart",
+          type: "area",
+          data: [
+            ["Doohickey", 1206],
+            ["Gadget", 1505],
+            ["Gizmo", 1592],
+            ["Widget", 1531],
+          ],
+          yAxisPosition: "left",
+          column: {
+            semantic_type: "type/CreationTimestamp",
+            unit: "year",
+            name: "CREATED_AT",
+            source: "breakout",
+            display_name: "Created At",
+          },
+          breakoutValue: "2017-01-01T00:00:00Z",
+        },
+      ],
+
+      [
+        {
+          name: null,
+          cardName: "Bar chart",
+          type: "bar",
+          data: [
+            ["Doohickey", 177],
+            ["Gadget", 199],
+            ["Gizmo", 158],
+            ["Widget", 210],
+          ],
+          yAxisPosition: "left",
+          column: {
+            semantic_type: "type/CreationTimestamp",
+            unit: "year",
+            name: "CREATED_AT",
+            source: "breakout",
+            display_name: "Created At",
+          },
+          breakoutValue: "2016-01-01T00:00:00Z",
+        },
+        {
+          name: null,
+          cardName: "Bar chart",
+          type: "bar",
+          data: [
+            ["Doohickey", 1206],
+            ["Gadget", 1505],
+            ["Gizmo", 1592],
+            ["Widget", 1531],
+          ],
+          yAxisPosition: "left",
+          column: {
+            semantic_type: "type/CreationTimestamp",
+            unit: "year",
+            name: "CREATED_AT",
+            source: "breakout",
+            display_name: "Created At",
+          },
+          breakoutValue: "2017-01-01T00:00:00Z",
+        },
+      ],
+    ];
+
+    it("should assign legends given series", () => {
+      const seriesWithLegends = getSeriesWithLegends(
+        multipleSeries,
+        merge(settings, {
+          x: { type: "timeseries" },
+        }),
+      );
+
+      const expectedSeries = [
+        [
+          {
+            name: "2016",
+            cardName: expect.anything(),
+            yAxisPosition: expect.anything(),
+            type: expect.anything(),
+            data: expect.anything(),
+            column: expect.anything(),
+            breakoutValue: expect.anything(),
+          },
+          {
+            name: "2017",
+            cardName: expect.anything(),
+            yAxisPosition: expect.anything(),
+            type: expect.anything(),
+            data: expect.anything(),
+            column: expect.anything(),
+            breakoutValue: expect.anything(),
+          },
+        ],
+      ];
+
+      expect(seriesWithLegends).toEqual(expectedSeries);
+    });
+
+    it("should assign legends from column custom name", () => {
+      const seriesWithLegends = getSeriesWithLegends(
+        multipleSeries,
+        merge(settings, {
+          x: { type: "timeseries" },
+          series_settings: {
+            2017: {
+              title: "custom 2017",
+            },
+          },
+        }),
+      );
+
+      const expectedSeries = [
+        [
+          {
+            name: "2016",
+            cardName: expect.anything(),
+            yAxisPosition: expect.anything(),
+            type: expect.anything(),
+            data: expect.anything(),
+            column: expect.anything(),
+            breakoutValue: expect.anything(),
+          },
+          {
+            name: "custom 2017",
+            cardName: expect.anything(),
+            yAxisPosition: expect.anything(),
+            type: expect.anything(),
+            data: expect.anything(),
+            column: expect.anything(),
+            breakoutValue: expect.anything(),
+          },
+        ],
+      ];
+
+      expect(seriesWithLegends).toEqual(expectedSeries);
+    });
+
+    it("it should assign legends on multiple series dashcard", () => {
+      const seriesWithLegends = getSeriesWithLegends(
+        multipleSeriesDashcard,
+        settings,
+      );
+
+      const expectedSeries = [
+        [
+          {
+            name: "Area chart: 2016",
+            cardName: expect.anything(),
+            yAxisPosition: expect.anything(),
+            type: expect.anything(),
+            data: expect.anything(),
+            column: expect.anything(),
+            breakoutValue: expect.anything(),
+          },
+          {
+            name: "Area chart: 2017",
+            cardName: expect.anything(),
+            yAxisPosition: expect.anything(),
+            type: expect.anything(),
+            data: expect.anything(),
+            column: expect.anything(),
+            breakoutValue: expect.anything(),
+          },
+        ],
+        [
+          {
+            name: "Bar chart: 2016",
+            cardName: expect.anything(),
+            yAxisPosition: expect.anything(),
+            type: expect.anything(),
+            data: expect.anything(),
+            column: expect.anything(),
+            breakoutValue: expect.anything(),
+          },
+          {
+            name: "Bar chart: 2017",
+            cardName: expect.anything(),
+            yAxisPosition: expect.anything(),
+            type: expect.anything(),
+            data: expect.anything(),
+            column: expect.anything(),
+            breakoutValue: expect.anything(),
+          },
+        ],
+      ];
+
+      expect(seriesWithLegends).toEqual(expectedSeries);
+    });
+  });
+});

--- a/frontend/src/metabase/static-viz/components/ProgressBar/ProgressBar.tsx
+++ b/frontend/src/metabase/static-viz/components/ProgressBar/ProgressBar.tsx
@@ -3,16 +3,12 @@ import { t } from "ttag";
 import { scaleLinear } from "@visx/scale";
 import { Group } from "@visx/group";
 import { ClipPath } from "@visx/clip-path";
+import { ColorGetter } from "metabase/static-viz/lib/colors";
 import { formatNumber } from "../../lib/numbers";
 import { Text } from "../Text";
 import { Pointer } from "./Pointer";
 import { CheckMarkIcon } from "./CheckMarkIcon";
-import {
-  createPalette,
-  getBarText,
-  getColors,
-  calculatePointerLabelShift,
-} from "./utils";
+import { getBarText, getColors, calculatePointerLabelShift } from "./utils";
 import { ProgressBarData } from "./types";
 
 const layout = {
@@ -40,14 +36,15 @@ interface ProgressBarProps {
     color: string;
     format: any;
   };
+  getColor: ColorGetter;
 }
 
 const ProgressBar = ({
   data,
   settings: { color, format },
+  getColor,
 }: ProgressBarProps) => {
-  const palette = createPalette(color);
-  const colors = getColors(data, palette);
+  const colors = getColors(data, color || getColor("accent1"));
   const barWidth = layout.width - layout.margin.left - layout.margin.right;
 
   const xMin = layout.margin.left;

--- a/frontend/src/metabase/static-viz/components/ProgressBar/utils.ts
+++ b/frontend/src/metabase/static-viz/components/ProgressBar/utils.ts
@@ -3,21 +3,19 @@ import { t } from "ttag";
 import { measureText } from "metabase/static-viz/lib/text";
 import { ProgressBarData } from "./types";
 
-export const createPalette = (color: string) => ({
-  unachieved: color,
-  achieved: Color(color).darken(0.25).hex(),
-  exceeded: Color(color).darken(0.5).hex(),
+const createPalette = (color: string) => ({
+  light: Color(color).lighten(0.25).hex(),
+  main: color,
+  dark: Color(color).darken(0.3).hex(),
 });
 
-export const getColors = (
-  { value, goal }: ProgressBarData,
-  palette: ReturnType<typeof createPalette>,
-) => {
+export const getColors = ({ value, goal }: ProgressBarData, color: string) => {
+  const palette = createPalette(color);
   const isExceeded = value > goal;
 
-  const backgroundBar = isExceeded ? palette.exceeded : palette.unachieved;
-  const foregroundBar = palette.achieved;
-  const pointer = isExceeded ? palette.exceeded : palette.achieved;
+  const backgroundBar = isExceeded ? palette.dark : palette.light;
+  const foregroundBar = palette.main;
+  const pointer = isExceeded ? palette.dark : palette.main;
 
   return {
     backgroundBar,

--- a/frontend/src/metabase/static-viz/components/XYChart/types.ts
+++ b/frontend/src/metabase/static-viz/components/XYChart/types.ts
@@ -1,4 +1,5 @@
 import type { ScaleBand, ScaleLinear, ScaleTime } from "d3-scale";
+import { DatasetColumn } from "metabase-types/api";
 import type { DateFormatOptions } from "metabase/static-viz/lib/dates";
 import type { NumberFormatOptions } from "metabase/static-viz/lib/numbers";
 import { ContinuousScaleType } from "metabase/visualizations/shared/types/scale";
@@ -15,16 +16,23 @@ export type YAxisPosition = "left" | "right";
 
 export type VisualizationType = "line" | "area" | "bar" | "waterfall";
 
-export type Series = {
+interface BaseSeries {
   name: string;
   color: string;
   data: SeriesData;
   type: VisualizationType;
   yAxisPosition: YAxisPosition;
-  seriesKey?: string;
-  // TODO: fix the type
-  column?: any;
-};
+}
+
+interface SeriesWithoutBreakoutValues extends BaseSeries {
+  seriesKey: string;
+}
+
+export interface SeriesWithBreakoutValues extends BaseSeries {
+  column: DatasetColumn;
+}
+
+export type Series = SeriesWithoutBreakoutValues | SeriesWithBreakoutValues;
 
 export type StackedDatum = [XValue, YValue, YValue];
 

--- a/frontend/src/metabase/static-viz/components/XYChart/types.ts
+++ b/frontend/src/metabase/static-viz/components/XYChart/types.ts
@@ -21,6 +21,9 @@ export type Series = {
   data: SeriesData;
   type: VisualizationType;
   yAxisPosition: YAxisPosition;
+  seriesKey?: string;
+  // TODO: fix the type
+  column?: any;
 };
 
 export type StackedDatum = [XValue, YValue, YValue];

--- a/frontend/src/metabase/static-viz/components/XYChart/types.ts
+++ b/frontend/src/metabase/static-viz/components/XYChart/types.ts
@@ -56,6 +56,7 @@ export type ChartSettings = {
     bottom?: string;
     right?: string;
   };
+  series_settings?: Record<string, { color: string }>;
 };
 
 export interface Dimensions {

--- a/frontend/src/metabase/static-viz/components/XYChart/types.ts
+++ b/frontend/src/metabase/static-viz/components/XYChart/types.ts
@@ -18,13 +18,12 @@ export type VisualizationType = "line" | "area" | "bar" | "waterfall";
 
 interface BaseSeries {
   name: string;
-  color: string;
   data: SeriesData;
   type: VisualizationType;
   yAxisPosition: YAxisPosition;
 }
 
-interface SeriesWithoutBreakoutValues extends BaseSeries {
+export interface SeriesWithoutBreakoutValues extends BaseSeries {
   seriesKey: string;
 }
 
@@ -32,7 +31,9 @@ export interface SeriesWithBreakoutValues extends BaseSeries {
   column: DatasetColumn;
 }
 
-export type Series = SeriesWithoutBreakoutValues | SeriesWithBreakoutValues;
+export interface Series extends BaseSeries {
+  color: string;
+}
 
 export type StackedDatum = [XValue, YValue, YValue];
 

--- a/frontend/src/metabase/static-viz/components/XYChart/types.ts
+++ b/frontend/src/metabase/static-viz/components/XYChart/types.ts
@@ -17,21 +17,25 @@ export type YAxisPosition = "left" | "right";
 export type VisualizationType = "line" | "area" | "bar" | "waterfall";
 
 interface BaseSeries {
-  name: string;
+  name: string | null;
   data: SeriesData;
   type: VisualizationType;
   yAxisPosition: YAxisPosition;
 }
 
-export interface SeriesWithoutBreakoutValues extends BaseSeries {
-  seriesKey: string;
-}
-
-export interface SeriesWithBreakoutValues extends BaseSeries {
+export interface SeriesWithOneOrLessDimensions extends BaseSeries {
+  cardName: string;
   column: DatasetColumn;
 }
 
+export interface SeriesWithTwoDimensions extends BaseSeries {
+  cardName: string;
+  column: DatasetColumn;
+  breakoutValue: string;
+}
+
 export interface Series extends BaseSeries {
+  name: string;
   color: string;
 }
 

--- a/frontend/src/metabase/static-viz/components/XYChart/types.ts
+++ b/frontend/src/metabase/static-viz/components/XYChart/types.ts
@@ -25,7 +25,8 @@ interface BaseSeries {
 
 export interface SeriesWithOneOrLessDimensions extends BaseSeries {
   cardName: string;
-  column: DatasetColumn;
+  // this could be null when rendering multiple scalars
+  column: DatasetColumn | null;
 }
 
 export interface SeriesWithTwoDimensions extends BaseSeries {

--- a/frontend/src/metabase/static-viz/components/XYChart/types.ts
+++ b/frontend/src/metabase/static-viz/components/XYChart/types.ts
@@ -69,7 +69,7 @@ export type ChartSettings = {
     bottom?: string;
     right?: string;
   };
-  series_settings?: Record<string, { color: string }>;
+  series_settings?: Record<string, { color?: string; title?: string }>;
 };
 
 export interface Dimensions {

--- a/frontend/src/metabase/static-viz/components/XYChart/types.ts
+++ b/frontend/src/metabase/static-viz/components/XYChart/types.ts
@@ -34,6 +34,11 @@ export interface SeriesWithTwoDimensions extends BaseSeries {
   breakoutValue: string;
 }
 
+export type CardSeries = (
+  | SeriesWithOneOrLessDimensions
+  | SeriesWithTwoDimensions
+)[];
+
 export interface Series extends BaseSeries {
   name: string;
   color: string;

--- a/resources/frontend_shared/static_viz_interface.js
+++ b/resources/frontend_shared/static_viz_interface.js
@@ -22,12 +22,12 @@ function row_chart(settings, data, colors) {
   });
 }
 
-function combo_chart(series, settings, colors) {
+function combo_chart(series, settings, instanceColors) {
   // Thinking of combo as similar to multiple, although they're different in BE
   return StaticViz.RenderChart("combo-chart", {
     multipleSeries: JSON.parse(series),
     settings: JSON.parse(settings),
-    colors: JSON.parse(colors),
+    colors: JSON.parse(instanceColors),
   });
 }
 
@@ -55,18 +55,18 @@ function funnel(data, settings) {
   });
 }
 
-function categorical_donut(rows, colors, settings) {
+function categorical_donut(rows, legendColors, settings) {
   return StaticViz.RenderChart("categorical/donut", {
     data: toJSArray(rows),
-    colors: toJSMap(colors),
+    colors: toJSMap(legendColors),
     settings: JSON.parse(settings),
   });
 }
 
-function progress(data, settings, colors) {
+function progress(data, settings, instanceColors) {
   return StaticViz.RenderChart("progress", {
     data: JSON.parse(data),
     settings: JSON.parse(settings),
-    colors: JSON.parse(colors),
+    colors: JSON.parse(instanceColors),
   });
 }

--- a/resources/frontend_shared/static_viz_interface.js
+++ b/resources/frontend_shared/static_viz_interface.js
@@ -25,8 +25,8 @@ function row_chart(settings, data, colors) {
 function combo_chart(series, settings, colors) {
   // Thinking of combo as similar to multiple, although they're different in BE
   return StaticViz.RenderChart("combo-chart", {
-    series: JSON.parse(series),
-    settings: JSON.parse(settings),
+    multipleSeries: JSON.parse(series),
+    multipleSettings: JSON.parse(settings),
     colors: JSON.parse(colors),
   });
 }

--- a/resources/frontend_shared/static_viz_interface.js
+++ b/resources/frontend_shared/static_viz_interface.js
@@ -63,9 +63,10 @@ function categorical_donut(rows, colors, settings) {
   });
 }
 
-function progress(data, settings) {
+function progress(data, settings, colors) {
   return StaticViz.RenderChart("progress", {
     data: JSON.parse(data),
     settings: JSON.parse(settings),
+    colors: JSON.parse(colors),
   });
 }

--- a/resources/frontend_shared/static_viz_interface.js
+++ b/resources/frontend_shared/static_viz_interface.js
@@ -26,7 +26,7 @@ function combo_chart(series, settings, colors) {
   // Thinking of combo as similar to multiple, although they're different in BE
   return StaticViz.RenderChart("combo-chart", {
     multipleSeries: JSON.parse(series),
-    multipleSettings: JSON.parse(settings),
+    settings: JSON.parse(settings),
     colors: JSON.parse(colors),
   });
 }

--- a/src/metabase/pulse/render/body.clj
+++ b/src/metabase/pulse/render/body.clj
@@ -335,7 +335,9 @@
       :labels      labels}
      (when (:graph.show_goal viz-settings)
        {:goal {:value (:graph.goal_value viz-settings)
-               :label (or (:graph.goal_label viz-settings) (tru "Goal"))}}))))
+               :label (or (:graph.goal_label viz-settings) (tru "Goal"))}})
+     (when (:series_settings viz-settings)
+       {:series_settings (:series_settings viz-settings)}))))
 
 (defn- set-default-stacked
   "Default stack type is stacked for area chart with more than one metric.

--- a/src/metabase/pulse/render/body.clj
+++ b/src/metabase/pulse/render/body.clj
@@ -495,8 +495,7 @@
   (let [viz-settings (merge viz-settings (:visualization_settings dashcard))
         value        (ffirst rows)
         goal         (:progress.goal viz-settings)
-        ;; See issue #19248 on GH for why it's the second color
-        color        (or (:progress.color viz-settings) (second colors))
+        color        (:progress.color viz-settings)
         settings     (assoc
                       (->js-viz (first cols) (first cols) viz-settings)
                       :color color)

--- a/src/metabase/pulse/render/body.clj
+++ b/src/metabase/pulse/render/body.clj
@@ -597,8 +597,8 @@
 
 (defn- join-series
   [names types row-seqs y-axis-positions y-col]
-  (for [[idx [card-name card-type rows y-axis-position]]
-        (map-indexed vector (map vector names types row-seqs y-axis-positions))]
+  (for [[idx card-name card-type rows y-axis-position]
+        (map vector (range) names types row-seqs y-axis-positions)]
     {:name          card-name
      :type          card-type
      :data          rows

--- a/src/metabase/pulse/render/body.clj
+++ b/src/metabase/pulse/render/body.clj
@@ -603,9 +603,9 @@
      :type          card-type
      :data          rows
      :yAxisPosition y-axis-position
-     :seriesKey     (cond
-                      (= idx 0) (:name y-col)
-                      :else card-name)}))
+     :seriesKey     (if (zero? idx)
+                      (:name y-col)
+                      card-name)}))
 
 (defn- attach-image-bundle
   [image-bundle]

--- a/src/metabase/pulse/render/body.clj
+++ b/src/metabase/pulse/render/body.clj
@@ -595,14 +595,16 @@
         "line"))
 
 (defn- join-series
-  [names colors types row-seqs y-axis-positions]
-  (vec (for [[card-name card-color card-type rows y-axis-position]
-             (map vector names colors types row-seqs y-axis-positions)]
-         {:name          card-name
-          :color         card-color
-          :type          card-type
-          :data          rows
-          :yAxisPosition y-axis-position})))
+  [names types row-seqs y-axis-positions y-col]
+  (for [[idx [card-name card-type rows y-axis-position]]
+        (map-indexed vector (map vector names types row-seqs y-axis-positions))]
+    {:name          card-name
+     :type          card-type
+     :data          rows
+     :yAxisPosition y-axis-position
+     :seriesKey     (cond
+                      (= idx 0) (:name y-col)
+                      :else card-name)}))
 
 (defn- attach-image-bundle
   [image-bundle]
@@ -637,7 +639,6 @@
         [x-col y-col] ((juxt (first first-rowfns) (second first-rowfns)) (first col-seqs))
         labels        (x-and-y-axis-label-info x-col y-col viz-settings)
         names         (map :name cards)
-        colors        (take (count multi-data) colors)
         types         (replace {:scalar :bar} (map :display cards))
         settings      (->ts-viz x-col y-col labels viz-settings)
         y-pos         (take (count names) (default-y-pos data axis-group-threshold))
@@ -690,8 +691,6 @@
           card-name     (or (series-setting viz-settings y-col-key :name)
                             (series-setting viz-settings y-col-key :title)
                             (:display_name y-col))
-          card-color    (or (series-setting viz-settings y-col-key :color)
-                            (nth colors idx))
           card-type     (or (series-setting viz-settings y-col-key :display)
                             chart-type
                             (nth default-combo-chart-types idx))
@@ -699,10 +698,10 @@
           y-axis-pos    (or (series-setting viz-settings y-col-key :axis)
                             (nth (default-y-pos data axis-group-threshold) idx))]
       {:name          card-name
-       :color         card-color
        :type          card-type
        :data          selected-rows
-       :yAxisPosition y-axis-pos})))
+       :yAxisPosition y-axis-pos
+       :seriesKey    (name y-col-key)})))
 
 (defn- double-x-axis-combo-series
   "This munges rows and columns into series in the format that we want for combo staticviz for literal combo displaytype,
@@ -710,7 +709,7 @@
 
   This mimics default behavior in JS viz, which is to group by the second dimension and make every group-by-value a series.
   This can have really high cardinality of series but the JS viz will complain about more than 100 already"
-  [chart-type joined-rows _x-cols _y-cols {:keys [viz-settings] :as data}]
+  [chart-type joined-rows x-cols _y-cols {:keys [viz-settings] :as data}]
   (let [grouped-rows (group-by #(second (first %)) joined-rows)
         groups       (keys grouped-rows)]
     (for [[idx group-key] (map-indexed vector groups)]
@@ -719,18 +718,16 @@
             card-name          (or (series-setting viz-settings group-key :name)
                                    (series-setting viz-settings group-key :title)
                                    group-key)
-            card-color         (or (series-setting viz-settings group-key :color)
-                                   (nth colors idx))
             card-type          (or (series-setting viz-settings group-key :display)
                                    chart-type
                                    (nth default-combo-chart-types idx))
             y-axis-pos         (or (series-setting viz-settings group-key :axis)
                                    (nth (default-y-pos data axis-group-threshold) idx))]
         {:name          card-name
-         :color         card-color
          :type          card-type
          :data          selected-row-group
-         :yAxisPosition y-axis-pos}))))
+         :yAxisPosition y-axis-pos
+         :column        (second x-cols)}))))
 
 (defn- lab-image-bundle
   "Generate an image-bundle for a Line Area Bar chart (LAB)

--- a/src/metabase/pulse/render/body.clj
+++ b/src/metabase/pulse/render/body.clj
@@ -712,7 +712,7 @@
         labels            (x-and-y-axis-label-info x-col y-col viz-settings)
         names             (map :name cards)
         types             (replace {:scalar :bar} (map :display cards))
-        settings-seqs     (map (partial ->ts-viz x-col y-col labels) viz-settings-seqs)
+        settings          (->ts-viz x-col y-col labels viz-settings)
         y-axis-positions  (take (count names) (default-y-pos data axis-group-threshold))
         series            (for [[enforced-type rows cols viz-settings [x-axis-rowfn y-axis-rowfn] y-axis-position card-name]
                                 (map vector types row-seqs col-seqs viz-settings-seqs rowfns y-axis-positions names)]
@@ -727,7 +727,7 @@
                                (if (= (count x-cols) 1)
                                  (single-x-axis-combo-series enforced-type joined-rows x-cols y-cols viz-settings card-name)
                                  (double-x-axis-combo-series enforced-type joined-rows x-cols y-cols viz-settings card-name)))))]
-    (attach-image-bundle (image-bundle/make-image-bundle render-type (js-svg/combo-chart series settings-seqs)))))
+    (attach-image-bundle (image-bundle/make-image-bundle render-type (js-svg/combo-chart series settings)))))
 
 (defn- lab-image-bundle
   "Generate an image-bundle for a Line Area Bar chart (LAB)
@@ -753,7 +753,7 @@
                            (double-x-axis-combo-series enforced-type joined-rows x-cols y-cols data card-name))]
 
         labels          (combo-label-info x-cols y-cols viz-settings)
-        settings        [(->ts-viz (first x-cols) (first y-cols) labels viz-settings)]]
+        settings        (->ts-viz (first x-cols) (first y-cols) labels viz-settings)]
     (image-bundle/make-image-bundle
      render-type
      (js-svg/combo-chart series settings))))

--- a/src/metabase/pulse/render/body.clj
+++ b/src/metabase/pulse/render/body.clj
@@ -629,10 +629,10 @@
         x-cols       [{:base_type :type/Text
                        :effective_type :type/Text}]
         y-cols       (select-keys (first (:cols data)) [:base_type :effective_type])
-        series       (multiple-scalar-series (mapv vector x-rows (flatten y-rows)) x-cols y-cols viz-settings)
+        series-seqs  (multiple-scalar-series (mapv vector x-rows (flatten y-rows)) x-cols y-cols viz-settings)
         labels       (combo-label-info x-cols y-cols viz-settings)
         settings     (->ts-viz (first x-cols) (first y-cols) labels viz-settings)]
-    (attach-image-bundle (image-bundle/make-image-bundle render-type (js-svg/combo-chart series settings)))))
+    (attach-image-bundle (image-bundle/make-image-bundle render-type (js-svg/combo-chart series-seqs settings)))))
 
 (defn- series-setting [viz-settings outer-key inner-key]
   (get-in viz-settings [:series_settings (keyword outer-key) inner-key]))
@@ -724,8 +724,8 @@
         [[x-col] [y-col]] ((juxt x-fn y-fn) (first col-seqs))
         labels            (x-and-y-axis-label-info x-col y-col viz-settings)
         settings          (->ts-viz x-col y-col labels viz-settings)
-        series            (map-indexed card-result->series (cons {:card card :result {:data data}} multi-res))]
-    (attach-image-bundle (image-bundle/make-image-bundle render-type (js-svg/combo-chart series settings)))))
+        series-seqs       (map-indexed card-result->series (cons {:card card :result {:data data}} multi-res))]
+    (attach-image-bundle (image-bundle/make-image-bundle render-type (js-svg/combo-chart series-seqs settings)))))
 
 (defn- lab-image-bundle
   "Generate an image-bundle for a Line Area Bar chart (LAB)
@@ -746,7 +746,7 @@
                           chart-type)
         card-name       (:name card)
         ;; NB: There's a hardcoded limit of arity 2 on x-axis, so there's only the 1-axis or 2-axis case
-        series          [(if (= (count x-cols) 1)
+        series-seqs     [(if (= (count x-cols) 1)
                            (single-x-axis-combo-series enforced-type joined-rows x-cols y-cols data card-name)
                            (double-x-axis-combo-series enforced-type joined-rows x-cols y-cols data card-name))]
 
@@ -754,7 +754,7 @@
         settings        (->ts-viz (first x-cols) (first y-cols) labels viz-settings)]
     (image-bundle/make-image-bundle
      render-type
-     (js-svg/combo-chart series settings))))
+     (js-svg/combo-chart series-seqs settings))))
 
 (s/defmethod render :multiple
   [_ render-type _timezone-id card dashcard data]

--- a/src/metabase/pulse/render/body.clj
+++ b/src/metabase/pulse/render/body.clj
@@ -646,8 +646,7 @@
   (for [[idx y-col] (map-indexed vector y-cols)]
     (let [y-col-key     (keyword (:name y-col))
           metric-name          (or (series-setting viz-settings y-col-key :name)
-                                   (series-setting viz-settings y-col-key :title)
-                                   (:display_name y-col))
+                                   (series-setting viz-settings y-col-key :title))
           card-type     (or (series-setting viz-settings y-col-key :display)
                             chart-type
                             (nth default-combo-chart-types idx))

--- a/src/metabase/pulse/render/body.clj
+++ b/src/metabase/pulse/render/body.clj
@@ -609,13 +609,13 @@
 
 (defn- multiple-scalar-series
   [joined-rows _x-cols _y-cols _viz-settings]
-  ;; TODO: Extra vars could be used for color settings
-  (for [[idx row-val] (map-indexed vector joined-rows)]
-    {:name  (first row-val)
-     :color (nth colors idx)
-     :type  :bar
-     :data [row-val]
-     :yAxisPosition "left"}))
+  [(for [[row-val] (map vector joined-rows)]
+     {:name          nil
+      :cardName      (first row-val)
+      :type          :bar
+      :data          [row-val]
+      :yAxisPosition "left"
+      :column        nil})])
 
 (defn- render-multiple-scalars
   "When multiple scalar cards are combined, they render as a bar chart"

--- a/src/metabase/pulse/render/js_svg.clj
+++ b/src/metabase/pulse/render/js_svg.clj
@@ -171,7 +171,8 @@
   [value goal settings]
   (let [js-res (js/execute-fn-name (context) "progress"
                                    (json/generate-string {:value value :goal goal})
-                                   (json/generate-string settings))
+                                   (json/generate-string settings)
+                                   (json/generate-string (:colors settings)))
         svg-string (.asString js-res)]
     (svg-string->bytes svg-string)))
 

--- a/src/metabase/pulse/render/js_svg.clj
+++ b/src/metabase/pulse/render/js_svg.clj
@@ -133,13 +133,13 @@
   Series should be list of dicts of {rows: rows, cols: cols, type: type}, where types is 'line' or 'bar' or 'area'.
   Rows should be tuples of [datetime numeric-value]. Labels is a
   map of {:left \"left-label\" :botton \"bottom-label\"}. Returns a byte array of a png file."
-  [series settings]
+  [series-seqs settings-seqs]
   (svg-string->bytes
    (.asString (js/execute-fn-name (context)
                                   "combo_chart"
-                                  (json/generate-string series)
-                                  (json/generate-string settings)
-                                  (json/generate-string (:colors settings))))))
+                                  (json/generate-string series-seqs)
+                                  (json/generate-string settings-seqs)
+                                  (json/generate-string (:colors (first settings-seqs)))))))
 
 (defn row-chart
   "Clojure entrypoint to render a row chart."

--- a/src/metabase/pulse/render/js_svg.clj
+++ b/src/metabase/pulse/render/js_svg.clj
@@ -133,13 +133,13 @@
   Series should be list of dicts of {rows: rows, cols: cols, type: type}, where types is 'line' or 'bar' or 'area'.
   Rows should be tuples of [datetime numeric-value]. Labels is a
   map of {:left \"left-label\" :botton \"bottom-label\"}. Returns a byte array of a png file."
-  [series-seqs settings-seqs]
+  [series-seqs settings]
   (svg-string->bytes
    (.asString (js/execute-fn-name (context)
                                   "combo_chart"
                                   (json/generate-string series-seqs)
-                                  (json/generate-string settings-seqs)
-                                  (json/generate-string (:colors (first settings-seqs)))))))
+                                  (json/generate-string settings)
+                                  (json/generate-string (:colors settings))))))
 
 (defn row-chart
   "Clojure entrypoint to render a row chart."

--- a/src/metabase/pulse/render/js_svg.clj
+++ b/src/metabase/pulse/render/js_svg.clj
@@ -139,7 +139,7 @@
                                   "combo_chart"
                                   (json/generate-string series-seqs)
                                   (json/generate-string settings)
-                                  (json/generate-string (:colors settings))))))
+                                  (json/generate-string (public-settings/application-colors))))))
 
 (defn row-chart
   "Clojure entrypoint to render a row chart."
@@ -153,8 +153,8 @@
 (defn categorical-donut
   "Clojure entrypoint to render a categorical donut chart. Rows should be tuples of [category numeric-value]. Returns a
   byte array of a png file"
-  [rows colors settings]
-  (let [svg-string (.asString (js/execute-fn-name (context) "categorical_donut" rows (seq colors) (json/generate-string settings)))]
+  [rows legend-colors settings]
+  (let [svg-string (.asString (js/execute-fn-name (context) "categorical_donut" rows (seq legend-colors) (json/generate-string settings)))]
     (svg-string->bytes svg-string)))
 
 (defn gauge
@@ -172,7 +172,7 @@
   (let [js-res (js/execute-fn-name (context) "progress"
                                    (json/generate-string {:value value :goal goal})
                                    (json/generate-string settings)
-                                   (json/generate-string (:colors settings)))
+                                   (json/generate-string (public-settings/application-colors)))
         svg-string (.asString js-res)]
     (svg-string->bytes svg-string)))
 

--- a/src/metabase/util/ui_logic.clj
+++ b/src/metabase/util/ui_logic.clj
@@ -93,7 +93,7 @@
     (when (seq col-indices)
       (fn [row]
         (let [res (vec (for [idx col-indices]
-                         (get row idx)))]
+                         (nth row idx)))]
           (if (every? some? res)
             res
             nil))))))
@@ -108,7 +108,7 @@
     (when (seq col-indices)
       (fn [row]
         (let [res (vec (for [idx col-indices]
-                         (get row idx)))]
+                         (nth row idx)))]
           (if (every? some? res)
             res
             nil))))))

--- a/test/metabase/pulse/render/body_test.clj
+++ b/test/metabase/pulse/render/body_test.clj
@@ -466,31 +466,6 @@
             {:cols default-multi-columns
              :rows [[10.0 1 1231 1] [5.0 10 nil 111] [2.50 20 11 1] [1.25 nil 1231 11]]})))))
 
-(deftest series-with-color-test
-  (testing "Check if single x-axis combo series can convert colors"
-    (is (= [{:name "NumPurchased", :color "#a7cf7b", :type :bar, :data [[10.0 1] [5.0 10] [1.25 20]], :yAxisPosition "left"}]
-           (#'body/single-x-axis-combo-series
-            :bar
-            [[[10.0] [1]] [[5.0] [10]] [[1.25] [20]]]
-            [{:name "Price", :display_name "Price", :base_type :type/BigInteger, :semantic_type nil}]
-            [{:name "NumPurchased", :display_name "NumPurchased", :base_type :type/BigInteger, :semantic_type nil}]
-            {:viz-settings {:series_settings {:NumPurchased {:color "#a7cf7b"}}}}))))
-  (testing "Check if double x-axis combo series can convert colors"
-    (is (= [{:name "Bob", :color "#c5a9cf", :type "line", :data [[10.0 123]], :yAxisPosition "left"}
-            {:name "Dobbs", :color "#a7cf7b", :type "bar", :data [[5.0 12]], :yAxisPosition "right"}
-            {:name "Robbs", :color "#34517d", :type "bar", :data [[2.5 1337]], :yAxisPosition "right"}
-            {:name "Mobbs", :color "#e0be40", :type "bar", :data [[1.25 -22]], :yAxisPosition "right"}]
-           (#'body/double-x-axis-combo-series
-            nil
-            [[[10.0 "Bob"] [123]] [[5.0 "Dobbs"] [12]] [[2.5 "Robbs"] [1337]] [[1.25 "Mobbs"] [-22]]]
-            [{:base_type :type/BigInteger, :display_name "Price", :name "Price", :semantic_type nil}
-             {:base_type :type/BigInteger, :display_name "NumPurchased", :name "NumPurchased", :semantic_type nil}]
-            [{:base_type :type/BigInteger, :display_name "NumKazoos", :name "NumKazoos", :semantic_type nil}]
-            {:viz-settings {:series_settings {:Bob {:color "#c5a9cf"}
-                                              :Dobbs {:color "#a7cf7b"}
-                                              :Robbs {:color "#34517d"}
-                                              :Mobbs {:color "#e0be40"}}}})))))
-
 (deftest series-with-custom-names-test
   (testing "Check if single x-axis combo series uses custom series names (#21503)"
     (is (= #{"Bought" "Sold"}

--- a/test/metabase/pulse/render/body_test.clj
+++ b/test/metabase/pulse/render/body_test.clj
@@ -446,8 +446,8 @@
                               :rows [[10.0 1] [5.0 10] [2.50 20] [1.25 30]]}))))
   (testing "Render a stacked area graph"
     (is (has-inline-image?
-          (render-stack-area-graph {:cols default-columns
-                                    :rows [[10.0 1] [5.0 10] [2.50 20] [1.25 30]]}))))
+          (render-stack-area-graph {:cols default-multi-columns
+                                    :rows [[10.0 1 1231 1] [5.0 10 nil 111] [2.50 20 11 1] [1.25 nil 1231 11]]}))))
   (testing "Check to make sure we allow nil values for the y-axis"
     (is (has-inline-image?
           (render-area-graph {:cols default-columns
@@ -478,7 +478,8 @@
                         {:name "NumSold", :display_name "NumSold", :base_type :type/Number}]
                        {:viz-settings
                         {:series_settings {:NumPurchased {:color "#a7cf7b" :title "Bought"}
-                                           :NumSold      {:color "#a7cf7b" :title "Sold"}}}}))))))
+                                           :NumSold      {:color "#a7cf7b" :title "Sold"}}}}
+                       "Card name"))))))
   (testing "Check if double x-axis combo series uses custom series names (#21503)"
     (is (= #{"Bobby" "Dobby" "Robby" "Mobby"}
            (set (map :name
@@ -492,7 +493,8 @@
                         {:series_settings {:Bob   {:color "#c5a9cf" :title "Bobby"}
                                            :Dobbs {:color "#a7cf7b" :title "Dobby"}
                                            :Robbs {:color "#34517d" :title "Robby"}
-                                           :Mobbs {:color "#e0be40" :title "Mobby"}}}})))))))
+                                           :Mobbs {:color "#e0be40" :title "Mobby"}}}}
+                       "Card name")))))))
 
 (defn- render-waterfall [results]
   (body/render :waterfall :inline pacific-tz render.tu/test-card nil results))

--- a/test/metabase/pulse/render/js_svg_test.clj
+++ b/test/metabase/pulse/render/js_svg_test.clj
@@ -318,5 +318,6 @@
                                   context
                                   "progress"
                                   (json/generate-string {:value value :goal goal})
-                                  (json/generate-string settings)))]
+                                  (json/generate-string settings)
+                                  (json/generate-string {})))]
       (validate-svg-string :progress svg-string))))

--- a/test/metabase/pulse/render/js_svg_test.clj
+++ b/test/metabase/pulse/render/js_svg_test.clj
@@ -91,47 +91,47 @@
   (and (vector? x) (= (first x) "#text")))
 
 (defn- combo-chart-string
-  [series-seqs settings-seqs]
+  [series-seqs settings]
   (let [s (.asString (js/execute-fn-name context
                                          "combo_chart"
                                          (json/generate-string series-seqs)
-                                         (json/generate-string settings-seqs)
-                                         (json/generate-string (:colors (first settings-seqs)))))]
+                                         (json/generate-string settings)
+                                         (json/generate-string (:colors settings))))]
     s))
 
 (defn- combo-chart-hiccup
-  [series-seqs settings-seqs]
+  [series-seqs settings]
   (let [s (.asString (js/execute-fn-name context
                                          "combo_chart"
                                          (json/generate-string series-seqs)
-                                         (json/generate-string settings-seqs)
-                                         (json/generate-string (:colors (first settings-seqs)))))]
+                                         (json/generate-string settings)
+                                         (json/generate-string (:colors settings))))]
     (-> s parse-svg document-tag-hiccup)))
 
 (deftest timelineseries-line-test
-  (let [rows          [[#t "2020" 2]
-                       [#t "2021" 3]]
-        series-seqs   [[{:type          :line
-                         :color         "#999AC4"
-                         :data          rows
-                         :yAxisPosition "left"
-                         :column        {:name "count"}}]]
-        settings-seqs [{:colors {:brand     "#5E81AC"
-                                 :filter    "#A3BE8C"
-                                 :summarize "#B48EAD"},
-                        :x      {:type   "timeseries"
-                                 :format {:date_style "YYYY/MM/DD"}}
-                        :y      {:type   "linear"
-                                 :format {:prefix   "prefix"
-                                          :decimals 2}}
-                        :labels {:bottom ""
-                                 :left   ""
-                                 :right  ""}}]
-        svg-string    (combo-chart-string series-seqs settings-seqs)]
+  (let [rows        [[#t "2020" 2]
+                     [#t "2021" 3]]
+        series-seqs [[{:type          :line
+                       :color         "#999AC4"
+                       :data          rows
+                       :yAxisPosition "left"
+                       :column        {:name "count"}}]]
+        settings    {:colors {:brand     "#5E81AC"
+                              :filter    "#A3BE8C"
+                              :summarize "#B48EAD"},
+                     :x      {:type   "timeseries"
+                              :format {:date_style "YYYY/MM/DD"}}
+                     :y      {:type   "linear"
+                              :format {:prefix   "prefix"
+                                       :decimals 2}}
+                     :labels {:bottom ""
+                              :left   ""
+                              :right  ""}}
+        svg-string  (combo-chart-string series-seqs settings)]
     (testing "It returns bytes"
-      (let [svg-bytes (js-svg/combo-chart series-seqs settings-seqs)]
+      (let [svg-bytes (js-svg/combo-chart series-seqs settings)]
         (is (bytes? svg-bytes))))
-    (let [svg-hiccup (combo-chart-hiccup series-seqs settings-seqs)]
+    (let [svg-hiccup (combo-chart-hiccup series-seqs settings)]
       (testing "it returns a valid svg string with no html"
         (validate-svg-string :timelineseries-line svg-string))
       (testing "The svg string has formatted axes"
@@ -150,29 +150,29 @@
               text-nodes))))))
 
 (deftest timelineseries-bar-test
-  (let [rows          [[#t "2020" 2]
-                       [#t "2021" 3]]
-        series-seqs   [[{:type          :bar
-                         :color         "#999AC4"
-                         :data          rows
-                         :yAxisPosition "left"
-                         :column        {:name "count"}}]]
-        settings-seqs [{:colors {:brand     "#5E81AC"
-                                 :filter    "#A3BE8C"
-                                 :summarize "#B48EAD"},
-                        :x      {:type   "timeseries"
-                                 :format {:date_style "YYYY/MM/DD"}}
-                        :y      {:type   "linear"
-                                 :format {:prefix   "prefix"
-                                          :decimals 4}}
-                        :labels {:bottom ""
-                                 :left   ""
-                                 :right  ""}}]
-        svg-string    (combo-chart-string series-seqs settings-seqs)]
+  (let [rows        [[#t "2020" 2]
+                     [#t "2021" 3]]
+        series-seqs [[{:type          :bar
+                       :color         "#999AC4"
+                       :data          rows
+                       :yAxisPosition "left"
+                       :column        {:name "count"}}]]
+        settings    {:colors {:brand     "#5E81AC"
+                              :filter    "#A3BE8C"
+                              :summarize "#B48EAD"},
+                     :x      {:type   "timeseries"
+                              :format {:date_style "YYYY/MM/DD"}}
+                     :y      {:type   "linear"
+                              :format {:prefix   "prefix"
+                                       :decimals 4}}
+                     :labels {:bottom ""
+                              :left   ""
+                              :right  ""}}
+        svg-string  (combo-chart-string series-seqs settings)]
     (testing "It returns bytes"
-      (let [svg-bytes (js-svg/combo-chart series-seqs settings-seqs)]
+      (let [svg-bytes (js-svg/combo-chart series-seqs settings)]
         (is (bytes? svg-bytes))))
-    (let [svg-hiccup (combo-chart-hiccup series-seqs settings-seqs)]
+    (let [svg-hiccup (combo-chart-hiccup series-seqs settings)]
       (testing "it returns a valid svg string with no html"
         (validate-svg-string :timelineseries-bar svg-string))
       (testing "The svg string has formatted axes"
@@ -191,28 +191,28 @@
               text-nodes))))))
 
 (deftest area-test
-  (let [rows          [["bob" 2]
-                       ["dobbs" 3]]
-        series-seqs   [[{:type          :area
-                         :color         "#999AC4"
-                         :data          rows
-                         :yAxisPosition "left"
-                         :column        {:name "count"}}]]
-        settings-seqs [{:colors {:brand     "#5E81AC"
-                                 :filter    "#A3BE8C"
-                                 :summarize "#B48EAD"},
-                        :x      {:type "ordinal"}
-                        :y      {:type   "linear"
-                                 :format {:prefix   "prefix"
-                                          :decimals 4}}
-                        :labels {:bottom ""
-                                 :left   ""
-                                 :right  ""}}]
-        svg-string    (combo-chart-string series-seqs settings-seqs)]
+  (let [rows        [["bob" 2]
+                     ["dobbs" 3]]
+        series-seqs [[{:type          :area
+                       :color         "#999AC4"
+                       :data          rows
+                       :yAxisPosition "left"
+                       :column        {:name "count"}}]]
+        settings    {:colors {:brand     "#5E81AC"
+                              :filter    "#A3BE8C"
+                              :summarize "#B48EAD"},
+                     :x      {:type "ordinal"}
+                     :y      {:type   "linear"
+                              :format {:prefix   "prefix"
+                                       :decimals 4}}
+                     :labels {:bottom ""
+                              :left   ""
+                              :right  ""}}
+        svg-string  (combo-chart-string series-seqs settings)]
     (testing "It returns bytes"
-      (let [svg-bytes (js-svg/combo-chart series-seqs settings-seqs)]
+      (let [svg-bytes (js-svg/combo-chart series-seqs settings)]
         (is (bytes? svg-bytes))))
-    (let [svg-hiccup (combo-chart-hiccup series-seqs settings-seqs)]
+    (let [svg-hiccup (combo-chart-hiccup series-seqs settings)]
       (testing "it returns a valid svg string with no html"
         (validate-svg-string :categorical-area svg-string))
       (testing "The svg string has formatted axes"
@@ -234,18 +234,16 @@
                            :data          [["A" 1] ["B" 20] ["C" -4] ["D" 100]]
                            :yAxisPosition "left"
                            :column        {:name "count"}}]]
-        settings-seqs   [{:x      {:type "ordinal"}
-                          :y      {:type "linear"}
-                          :labels {:bottom ""
-                                   :left   ""
-                                   :right  ""}}]
-        non-goal-hiccup (combo-chart-hiccup series-seqs settings-seqs)
+        settings        {:x      {:type "ordinal"}
+                         :y      {:type "linear"}
+                         :labels {:bottom ""
+                                  :left   ""
+                                  :right  ""}}
+        non-goal-hiccup (combo-chart-hiccup series-seqs settings)
         non-goal-node   (->> non-goal-hiccup (tree-seq vector? rest) (filter #(= goal-label (second %))) first)]
     (testing "No goal line exists when there are no goal settings."
       (is (= nil (second non-goal-node))))
-    (let [goal-hiccup (combo-chart-hiccup series-seqs (->> settings-seqs
-                                                          (map (partial merge {:goal {:value 0
-                                                                         :label goal-label}}))))
+    (let [goal-hiccup (combo-chart-hiccup series-seqs (merge settings {:goal {:value 0 :label goal-label}}))
           goal-node   (->> goal-hiccup (tree-seq vector? rest) (filter #(= goal-label (second %))) first)]
       (testing "A goal line does exist when goal settings are present in the viz-settings"
         (is (= goal-label (second goal-node)))))))
@@ -282,39 +280,39 @@
           (validate-svg-string :categorical-waterfall svg-string))))))
 
 (deftest combo-test
-  (let [rows1         [[#t "1998-03-01T00:00:00Z" 2]
-                       [#t "1999-03-01T00:00:00Z" 3]]
-        rows2         [[#t "2000-03-01T00:00:00Z" 3]
-                       [#t "2002-03-01T00:00:00Z" 4]]
+  (let [rows1       [[#t "1998-03-01T00:00:00Z" 2]
+                     [#t "1999-03-01T00:00:00Z" 3]]
+        rows2       [[#t "2000-03-01T00:00:00Z" 3]
+                     [#t "2002-03-01T00:00:00Z" 4]]
         ;; this one needs more stuff because of stricter ts types
-        series-seqs   [[{:name          "bob"
-                         :color         "#cccccc"
-                         :type          "area"
-                         :data          rows1
-                         :yAxisPosition "left"
-                         :column        {:name "count"}}
-                        {:name          "bob2"
-                         :color         "#cccccc"
-                         :type          "line"
-                         :data          rows2
-                         :yAxisPosition "right"
-                         :column        {:name "count"}}]]
-        labels        {:left   "count"
-                       :bottom "year"
-                       :right  "something"}
-        settings-seqs [{:x      {:type   "timeseries"
-                                 :format {:date_style "YYYY"}}
-                        :y      {:type   "linear"
-                                 :format {:number_style "decimal"
-                                          :decimals     4}}
-                        :colors {}
-                        :labels labels}]]
+        series-seqs [[{:name          "bob"
+                       :color         "#cccccc"
+                       :type          "area"
+                       :data          rows1
+                       :yAxisPosition "left"
+                       :column        {:name "count"}}
+                      {:name          "bob2"
+                       :color         "#cccccc"
+                       :type          "line"
+                       :data          rows2
+                       :yAxisPosition "right"
+                       :column        {:name "count"}}]]
+        labels      {:left   "count"
+                     :bottom "year"
+                     :right  "something"}
+        settings    {:x      {:type   "timeseries"
+                              :format {:date_style "YYYY"}}
+                     :y      {:type   "linear"
+                              :format {:number_style "decimal"
+                                       :decimals     4}}
+                     :colors {}
+                     :labels labels}]
     (testing "It returns bytes"
-      (let [svg-bytes (js-svg/combo-chart series-seqs settings-seqs)]
+      (let [svg-bytes (js-svg/combo-chart series-seqs settings)]
         (is (bytes? svg-bytes))))
     (let [svg-string (.asString (js/execute-fn-name context "combo_chart"
                                                     (json/generate-string series-seqs)
-                                                    (json/generate-string settings-seqs)
+                                                    (json/generate-string settings)
                                                     (json/generate-string {})))]
       (testing "it returns a valid svg string (no html in it)"
         (validate-svg-string :combo-chart svg-string)))))

--- a/test/metabase/pulse/render/js_svg_test.clj
+++ b/test/metabase/pulse/render/js_svg_test.clj
@@ -91,143 +91,162 @@
   (and (vector? x) (= (first x) "#text")))
 
 (defn- combo-chart-string
-  [series settings]
+  [series-seqs settings-seqs]
   (let [s (.asString (js/execute-fn-name context
                                          "combo_chart"
-                                         (json/generate-string series)
-                                         (json/generate-string settings)
-                                         (json/generate-string (:colors settings))))]
+                                         (json/generate-string series-seqs)
+                                         (json/generate-string settings-seqs)
+                                         (json/generate-string (:colors (first settings-seqs)))))]
     s))
 
 (defn- combo-chart-hiccup
-  [series settings]
+  [series-seqs settings-seqs]
   (let [s (.asString (js/execute-fn-name context
                                          "combo_chart"
-                                         (json/generate-string series)
-                                         (json/generate-string settings)
-                                         (json/generate-string (:colors settings))))]
+                                         (json/generate-string series-seqs)
+                                         (json/generate-string settings-seqs)
+                                         (json/generate-string (:colors (first settings-seqs)))))]
     (-> s parse-svg document-tag-hiccup)))
 
 (deftest timelineseries-line-test
-  (let [rows       [[#t "2020" 2]
-                    [#t "2021" 3]]
-        series     [{:type          :line
-                     :color         "#999AC4"
-                     :data          rows
-                     :yAxisPosition "left"}]
-        settings   {:colors {:brand "#5E81AC", :filter "#A3BE8C", :summarize "#B48EAD"},
-                    :x      {:type   "timeseries"
-                             :format {:date_style "YYYY/MM/DD"}}
-                    :y      {:type   "linear"
-                             :format {:prefix   "prefix"
-                                      :decimals 2}}
-                    :labels {:bottom "" :left "" :right ""}}
-        svg-string (combo-chart-string series settings)]
+  (let [rows          [[#t "2020" 2]
+                       [#t "2021" 3]]
+        series-seqs   [[{:type          :line
+                         :color         "#999AC4"
+                         :data          rows
+                         :yAxisPosition "left"
+                         :column        {:name "count"}}]]
+        settings-seqs [{:colors {:brand     "#5E81AC"
+                                 :filter    "#A3BE8C"
+                                 :summarize "#B48EAD"},
+                        :x      {:type   "timeseries"
+                                 :format {:date_style "YYYY/MM/DD"}}
+                        :y      {:type   "linear"
+                                 :format {:prefix   "prefix"
+                                          :decimals 2}}
+                        :labels {:bottom ""
+                                 :left   ""
+                                 :right  ""}}]
+        svg-string    (combo-chart-string series-seqs settings-seqs)]
     (testing "It returns bytes"
-      (let [svg-bytes (js-svg/combo-chart series settings)]
+      (let [svg-bytes (js-svg/combo-chart series-seqs settings-seqs)]
         (is (bytes? svg-bytes))))
-    (let [svg-hiccup (combo-chart-hiccup series settings)]
-       (testing "it returns a valid svg string with no html"
+    (let [svg-hiccup (combo-chart-hiccup series-seqs settings-seqs)]
+      (testing "it returns a valid svg string with no html"
         (validate-svg-string :timelineseries-line svg-string))
       (testing "The svg string has formatted axes"
         (let [spec       (s/cat :y-axis-labels (s/+ (s/tuple
-                                                      #{"#text"}
-                                                      #(and (string? %)
+                                                     #{"#text"}
+                                                     #(and (string? %)
                                                             ;; ["#text" "prefix0.00"]
-                                                            (re-matches #"prefix\d+\.\d{2}" %))))
+                                                           (re-matches #"prefix\d+\.\d{2}" %))))
                                 :x-axis-labels (s/+ (s/tuple
-                                                      #{"#text"}
-                                                      #(and (string? %)
+                                                     #{"#text"}
+                                                     #(and (string? %)
                                                             ;; ["#text" "2020/01/02"]
-                                                            (re-matches #"\d{4}/\d{2}/\d{2}" %)))))
+                                                           (re-matches #"\d{4}/\d{2}/\d{2}" %)))))
               text-nodes (->> svg-hiccup (tree-seq vector? rest) (filter text-node?))]
           (is (= true (s/valid? spec text-nodes))
               text-nodes))))))
 
 (deftest timelineseries-bar-test
-  (let [rows       [[#t "2020" 2]
-                    [#t "2021" 3]]
-        series     [{:type          :bar
-                     :color         "#999AC4"
-                     :data          rows
-                     :yAxisPosition "left"}]
-        settings   {:colors {:brand "#5E81AC", :filter "#A3BE8C", :summarize "#B48EAD"},
-                    :x      {:type   "timeseries"
-                             :format {:date_style "YYYY/MM/DD"}}
-                    :y      {:type   "linear"
-                             :format {:prefix   "prefix"
-                                      :decimals 4}}
-                    :labels {:bottom "" :left "" :right ""}}
-        svg-string (combo-chart-string series settings)]
+  (let [rows          [[#t "2020" 2]
+                       [#t "2021" 3]]
+        series-seqs   [[{:type          :bar
+                         :color         "#999AC4"
+                         :data          rows
+                         :yAxisPosition "left"
+                         :column        {:name "count"}}]]
+        settings-seqs [{:colors {:brand     "#5E81AC"
+                                 :filter    "#A3BE8C"
+                                 :summarize "#B48EAD"},
+                        :x      {:type   "timeseries"
+                                 :format {:date_style "YYYY/MM/DD"}}
+                        :y      {:type   "linear"
+                                 :format {:prefix   "prefix"
+                                          :decimals 4}}
+                        :labels {:bottom ""
+                                 :left   ""
+                                 :right  ""}}]
+        svg-string    (combo-chart-string series-seqs settings-seqs)]
     (testing "It returns bytes"
-      (let [svg-bytes (js-svg/combo-chart series settings)]
+      (let [svg-bytes (js-svg/combo-chart series-seqs settings-seqs)]
         (is (bytes? svg-bytes))))
-    (let [svg-hiccup (combo-chart-hiccup series settings)]
-       (testing "it returns a valid svg string with no html"
+    (let [svg-hiccup (combo-chart-hiccup series-seqs settings-seqs)]
+      (testing "it returns a valid svg string with no html"
         (validate-svg-string :timelineseries-bar svg-string))
       (testing "The svg string has formatted axes"
         (let [spec       (s/cat :y-axis-labels (s/+ (s/tuple
-                                                      #{"#text"}
-                                                      #(and (string? %)
+                                                     #{"#text"}
+                                                     #(and (string? %)
                                                             ;; ["#text" "prefix0.0000"]
-                                                            (re-matches #"prefix\d+\.\d{4}" %))))
+                                                           (re-matches #"prefix\d+\.\d{4}" %))))
                                 :x-axis-labels (s/+ (s/tuple
-                                                      #{"#text"}
-                                                      #(and (string? %)
+                                                     #{"#text"}
+                                                     #(and (string? %)
                                                             ;; ["#text" "2020/01/02"]
-                                                            (re-matches #"\d{4}/\d{2}/\d{2}" %)))))
+                                                           (re-matches #"\d{4}/\d{2}/\d{2}" %)))))
               text-nodes (->> svg-hiccup (tree-seq vector? rest) (filter text-node?))]
           (is (= true (s/valid? spec text-nodes))
               text-nodes))))))
 
 (deftest area-test
-  (let [rows       [["bob" 2]
-                    ["dobbs" 3]]
-        series     [{:type          :area
-                     :color         "#999AC4"
-                     :data          rows
-                     :yAxisPosition "left"}]
-        settings   {:colors {:brand "#5E81AC", :filter "#A3BE8C", :summarize "#B48EAD"},
-                    :x      {:type   "ordinal"}
-                    :y      {:type   "linear"
-                             :format {:prefix   "prefix"
-                                      :decimals 4}}
-                    :labels {:bottom "" :left "" :right ""}}
-        svg-string (combo-chart-string series settings)]
+  (let [rows          [["bob" 2]
+                       ["dobbs" 3]]
+        series-seqs   [[{:type          :area
+                         :color         "#999AC4"
+                         :data          rows
+                         :yAxisPosition "left"
+                         :column        {:name "count"}}]]
+        settings-seqs [{:colors {:brand     "#5E81AC"
+                                 :filter    "#A3BE8C"
+                                 :summarize "#B48EAD"},
+                        :x      {:type "ordinal"}
+                        :y      {:type   "linear"
+                                 :format {:prefix   "prefix"
+                                          :decimals 4}}
+                        :labels {:bottom ""
+                                 :left   ""
+                                 :right  ""}}]
+        svg-string    (combo-chart-string series-seqs settings-seqs)]
     (testing "It returns bytes"
-      (let [svg-bytes (js-svg/combo-chart series settings)]
+      (let [svg-bytes (js-svg/combo-chart series-seqs settings-seqs)]
         (is (bytes? svg-bytes))))
-    (let [svg-hiccup (combo-chart-hiccup series settings)]
-       (testing "it returns a valid svg string with no html"
+    (let [svg-hiccup (combo-chart-hiccup series-seqs settings-seqs)]
+      (testing "it returns a valid svg string with no html"
         (validate-svg-string :categorical-area svg-string))
       (testing "The svg string has formatted axes"
         (let [spec       (s/cat :y-axis-labels (s/+ (s/tuple
-                                                      #{"#text"}
-                                                      #(and (string? %)
+                                                     #{"#text"}
+                                                     #(and (string? %)
                                                             ;; ["#text" "prefix0.0000"]
-                                                            (re-matches #"prefix\d+\.\d{4}" %))))
+                                                           (re-matches #"prefix\d+\.\d{4}" %))))
                                 :x-axis-labels (s/+ (s/tuple
-                                                      #{"#text"}
-                                                      string?)))
+                                                     #{"#text"}
+                                                     string?)))
               text-nodes (->> svg-hiccup (tree-seq vector? rest) (filter text-node?))]
           (is (= true (s/valid? spec text-nodes))
               text-nodes))))))
 
 (deftest goal-line-test
   (let [goal-label      "ASDF"
-        series          [{:color         "#999AC4"
-                          :type          :line
-                          :data          [["A" 1] ["B" 20] ["C" -4] ["D" 100]]
-                          :yAxisPosition "left"}]
-        settings        {:x      {:type "ordinal"}
-                         :y      {:type "linear"}
-                         :labels {:bottom "" :left "" :right ""}}
-        non-goal-hiccup (combo-chart-hiccup series settings)
+        series-seqs     [[{:type          :line
+                           :data          [["A" 1] ["B" 20] ["C" -4] ["D" 100]]
+                           :yAxisPosition "left"
+                           :column        {:name "count"}}]]
+        settings-seqs   [{:x      {:type "ordinal"}
+                          :y      {:type "linear"}
+                          :labels {:bottom ""
+                                   :left   ""
+                                   :right  ""}}]
+        non-goal-hiccup (combo-chart-hiccup series-seqs settings-seqs)
         non-goal-node   (->> non-goal-hiccup (tree-seq vector? rest) (filter #(= goal-label (second %))) first)]
     (testing "No goal line exists when there are no goal settings."
       (is (= nil (second non-goal-node))))
-    (let [goal-hiccup     (combo-chart-hiccup series (merge settings {:goal {:value 0 :label goal-label}}))
-          goal-node       (->> goal-hiccup (tree-seq vector? rest) (filter #(= goal-label (second %))) first)]
+    (let [goal-hiccup (combo-chart-hiccup series-seqs (->> settings-seqs
+                                                          (map (partial merge {:goal {:value 0
+                                                                         :label goal-label}}))))
+          goal-node   (->> goal-hiccup (tree-seq vector? rest) (filter #(= goal-label (second %))) first)]
       (testing "A goal line does exist when goal settings are present in the viz-settings"
         (is (= goal-label (second goal-node)))))))
 
@@ -263,34 +282,39 @@
           (validate-svg-string :categorical-waterfall svg-string))))))
 
 (deftest combo-test
-  (let [rows1    [[#t "1998-03-01T00:00:00Z" 2]
-                  [#t "1999-03-01T00:00:00Z" 3]]
-        rows2    [[#t "2000-03-01T00:00:00Z" 3]
-                  [#t "2002-03-01T00:00:00Z" 4]]
+  (let [rows1         [[#t "1998-03-01T00:00:00Z" 2]
+                       [#t "1999-03-01T00:00:00Z" 3]]
+        rows2         [[#t "2000-03-01T00:00:00Z" 3]
+                       [#t "2002-03-01T00:00:00Z" 4]]
         ;; this one needs more stuff because of stricter ts types
-        series   [{:name          "bob"
-                   :color         "#cccccc"
-                   :type          "area"
-                   :data          rows1
-                   :yAxisPosition "left"}
-                  {:name          "bob2"
-                   :color         "#cccccc"
-                   :type          "line"
-                   :data          rows2
-                   :yAxisPosition "right"}]
-        labels   {:left "count" :bottom "year" :right "something"}
-        settings {:x {:type "timeseries"
-                      :format {:date_style "YYYY"}}
-                  :y {:type "linear"
-                      :format {:number_style "decimal" :decimals 4}}
-                  :colors {}
-                  :labels labels}]
+        series-seqs   [[{:name          "bob"
+                         :color         "#cccccc"
+                         :type          "area"
+                         :data          rows1
+                         :yAxisPosition "left"
+                         :column        {:name "count"}}
+                        {:name          "bob2"
+                         :color         "#cccccc"
+                         :type          "line"
+                         :data          rows2
+                         :yAxisPosition "right"
+                         :column        {:name "count"}}]]
+        labels        {:left   "count"
+                       :bottom "year"
+                       :right  "something"}
+        settings-seqs [{:x      {:type   "timeseries"
+                                 :format {:date_style "YYYY"}}
+                        :y      {:type   "linear"
+                                 :format {:number_style "decimal"
+                                          :decimals     4}}
+                        :colors {}
+                        :labels labels}]]
     (testing "It returns bytes"
-      (let [svg-bytes (js-svg/combo-chart series settings)]
+      (let [svg-bytes (js-svg/combo-chart series-seqs settings-seqs)]
         (is (bytes? svg-bytes))))
     (let [svg-string (.asString (js/execute-fn-name context "combo_chart"
-                                                    (json/generate-string series)
-                                                    (json/generate-string settings)
+                                                    (json/generate-string series-seqs)
+                                                    (json/generate-string settings-seqs)
                                                     (json/generate-string {})))]
       (testing "it returns a valid svg string (no html in it)"
         (validate-svg-string :combo-chart svg-string)))))


### PR DESCRIPTION
Epic: https://github.com/metabase/metabase/issues/24759
Issue: https://github.com/metabase/metabase/issues/21506
### Todos
- [x] Fix progress chart colors
- [x] Fix certain combo charts that don't respect Whitelabel colors 
- [x] ~Fix funnel chart colors~ Already working
- [x] Fix combo chart colors on internal page
- [x] Fix `Series` type. Need to separate between the type coming from BE and the type we used internally.
- [x] Fix BE tests
- [x] Add FE unit test for `getSeriesWithLegends`
- [x] Fix internal static page `/_internal/static-viz` crashing
- [ ] Fix data point values (followed up PR)

### Note
This PR fixes 2 things
1. Colors on static viz not respecting original charts
2. Some static viz legends aren't formatted

This PR only fixes colors for static line/area/bar charts as static pie charts' legend is implemented in BE, so if we want to make sure both legends and the chart have the same color as in the app we need to reimplement pie chart legend in FE.

And there's no need to change
- Gauge chart
- Waterfall chart
as they're already working

### Results
#### App viz
- ![image](https://user-images.githubusercontent.com/1937582/199480495-934d84f6-6623-4a08-b9d2-f512b845add4.png)
- ![Screenshot 2022-11-08 at 7 22 21 PM](https://user-images.githubusercontent.com/1937582/200562684-b1796d12-929a-499f-b226-7c5ef658ae11.png)
- ![Screenshot 2022-11-08 at 7 21 53 PM](https://user-images.githubusercontent.com/1937582/200562705-760c8f2e-892b-45f9-8a20-839ebf5afa1e.png)
- ![Screenshot 2022-11-10 at 7 31 47 PM](https://user-images.githubusercontent.com/1937582/201092553-eb017882-8b6a-4924-a374-e622fd194def.png)

#### Static viz (after)
- ![localhost_email_rDUEBny0_html](https://user-images.githubusercontent.com/1937582/199480654-2017a31d-5f21-4948-96bc-80a5273d0c44.png)
- ![Screenshot 2022-11-08 at 7 22 32 PM](https://user-images.githubusercontent.com/1937582/200562917-88ca1d4c-a4dd-491c-9320-ca2a43488e57.png)
- ![Screenshot 2022-11-08 at 7 22 35 PM](https://user-images.githubusercontent.com/1937582/202690827-38fdabf9-c184-471e-872a-baa77ae17c71.png)
- ![Screenshot 2022-11-10 at 7 32 02 PM](https://user-images.githubusercontent.com/1937582/201092600-c5cabad5-d23c-44cc-bc1e-1186f5befecb.png)


#### Static viz (before)
- ![image](https://user-images.githubusercontent.com/1937582/199480571-98c638b5-3e38-4dc5-abf5-7acb8b39f86c.png)
- ![Screenshot 2022-11-08 at 7 27 06 PM](https://user-images.githubusercontent.com/1937582/200563532-fe01db91-94e8-4cf1-a5b7-7af2a8f00871.png)
- ![image](https://user-images.githubusercontent.com/1937582/200563459-6b2a50b8-1cc4-4bd4-8246-8c32f40f7280.png)
- ![Screenshot 2022-11-10 at 7 32 02 PM](https://user-images.githubusercontent.com/1937582/201092600-c5cabad5-d23c-44cc-bc1e-1186f5befecb.png) (funnel charts already respect whitelabel colors)
