### PR TITLE
Migrate UserInviteForm to formik

### DIFF
--- a/frontend/src/metabase-types/store/setup.ts
+++ b/frontend/src/metabase-types/store/setup.ts
@@ -13,8 +13,8 @@ export interface UserInfo {
 }
 
 export interface InviteInfo {
-  first_name: string;
-  last_name: string;
+  first_name: string | null;
+  last_name: string | null;
   email: string;
 }
 

--- a/frontend/src/metabase/setup/components/DatabaseStep/DatabaseStep.styled.tsx
+++ b/frontend/src/metabase/setup/components/DatabaseStep/DatabaseStep.styled.tsx
@@ -24,12 +24,6 @@ export const StepDescription = styled.div`
   color: ${color("text-medium")};
 `;
 
-export const StepFormGroup = styled.div`
-  display: grid;
-  grid-template-columns: repeat(2, 1fr);
-  gap: 1rem;
-`;
-
 export const FormActions = styled.div`
   display: flex;
   align-items: center;

--- a/frontend/src/metabase/setup/components/DatabaseStep/DatabaseStep.tsx
+++ b/frontend/src/metabase/setup/components/DatabaseStep/DatabaseStep.tsx
@@ -3,17 +3,16 @@ import { t } from "ttag";
 import _ from "underscore";
 import { updateIn } from "icepick";
 import Button from "metabase/core/components/Button";
-import Users from "metabase/entities/users";
 import Databases from "metabase/entities/databases";
 import DriverWarning from "metabase/containers/DriverWarning";
 import { DatabaseInfo, InviteInfo, UserInfo } from "metabase-types/store";
 import ActiveStep from "../ActiveStep";
 import InactiveStep from "../InvactiveStep";
+import InviteUserForm from "../InviteUserForm";
 import SetupSection from "../SetupSection";
 import {
   StepActions,
   StepDescription,
-  StepFormGroup,
   StepButton,
   FormActions,
 } from "./DatabaseStep.styled";
@@ -87,7 +86,11 @@ const DatabaseStep = ({
           title={t`Need help connecting to your data?`}
           description={t`Invite a teammate. We’ll make them an admin so they can configure your database. You can always change this later on.`}
         >
-          <InviteForm user={user} invite={invite} onSubmit={onInviteSubmit} />
+          <InviteUserForm
+            user={user}
+            invite={invite}
+            onSubmit={onInviteSubmit}
+          />
         </SetupSection>
       )}
     </ActiveStep>
@@ -165,37 +168,6 @@ const DatabaseForm = ({
         </Form>
       )}
     </Databases.Form>
-  );
-};
-
-interface InviteFormProps {
-  user?: UserInfo;
-  invite?: InviteInfo;
-  onSubmit: (invite: InviteInfo) => void;
-}
-
-const InviteForm = ({
-  user,
-  invite,
-  onSubmit,
-}: InviteFormProps): JSX.Element => {
-  return (
-    <Users.Form
-      form={Users.forms.setup_invite(user)}
-      user={invite}
-      onSubmit={onSubmit}
-    >
-      {({ Form, FormField, FormFooter }: FormProps) => (
-        <Form>
-          <StepFormGroup>
-            <FormField name="first_name" />
-            <FormField name="last_name" />
-          </StepFormGroup>
-          <FormField name="email" />
-          <FormFooter submitTitle={t`Send invitation`} />
-        </Form>
-      )}
-    </Users.Form>
   );
 };
 

--- a/frontend/src/metabase/setup/components/DatabaseStep/DatabaseStep.unit.spec.tsx
+++ b/frontend/src/metabase/setup/components/DatabaseStep/DatabaseStep.unit.spec.tsx
@@ -10,11 +10,6 @@ jest.mock("metabase/entities/databases", () => ({
   Form: ComponentMock,
 }));
 
-jest.mock("metabase/entities/users", () => ({
-  forms: { setup_invite: jest.fn() },
-  Form: ComponentMock,
-}));
-
 jest.mock("metabase/containers/DriverWarning", () => ComponentMock);
 
 describe("DatabaseStep", () => {

--- a/frontend/src/metabase/setup/components/InviteUserForm/InviteUserForm.styled.tsx
+++ b/frontend/src/metabase/setup/components/InviteUserForm/InviteUserForm.styled.tsx
@@ -1,0 +1,10 @@
+import styled from "@emotion/styled";
+import { breakpointMinSmall } from "metabase/styled-components/theme";
+
+export const UserFieldGroup = styled.div`
+  ${breakpointMinSmall} {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 1rem;
+  }
+`;

--- a/frontend/src/metabase/setup/components/InviteUserForm/InviteUserForm.tsx
+++ b/frontend/src/metabase/setup/components/InviteUserForm/InviteUserForm.tsx
@@ -1,0 +1,74 @@
+import React, { useCallback, useMemo } from "react";
+import { t } from "ttag";
+import * as Yup from "yup";
+import Form from "metabase/core/components/Form";
+import FormInput from "metabase/core/components/FormInput";
+import FormProvider from "metabase/core/components/FormProvider";
+import { InviteInfo, UserInfo } from "metabase-types/store";
+import { UserFieldGroup } from "./InviteUserForm.styled";
+
+const InviteUserSchema = Yup.object().shape({
+  first_name: Yup.string().max(100, t`must be 100 characters or less`),
+  last_name: Yup.string().max(100, t`must be 100 characters or less`),
+  email: Yup.string()
+    .required(t`required`)
+    .email(t`must be a valid email address`),
+});
+
+interface InviteUserFormProps {
+  user?: UserInfo;
+  invite?: InviteInfo;
+  onSubmit: (invite: InviteInfo) => void;
+}
+
+const InviteUserForm = ({
+  user,
+  invite,
+  onSubmit,
+}: InviteUserFormProps): JSX.Element => {
+  const initialValues = useMemo(() => {
+    return getInitialValues(invite);
+  }, [invite]);
+
+  const handleSubmit = useCallback(
+    (values: InviteInfo) => {
+      onSubmit(getSubmitValues(values));
+    },
+    [onSubmit],
+  );
+
+  return (
+    <FormProvider
+      initialValues={initialValues}
+      validationSchema={InviteUserSchema}
+      onSubmit={handleSubmit}
+    >
+      <Form>
+        <UserFieldGroup>
+          <FormInput name="first_name" />
+          <FormInput name="last_name" />
+        </UserFieldGroup>
+        <FormInput name="email" />
+      </Form>
+    </FormProvider>
+  );
+};
+
+const getInitialValues = (invite?: InviteInfo): InviteInfo => {
+  return {
+    email: "",
+    ...invite,
+    first_name: invite?.first_name || "",
+    last_name: invite?.last_name || "",
+  };
+};
+
+const getSubmitValues = (invite: InviteInfo): InviteInfo => {
+  return {
+    ...invite,
+    first_name: invite.first_name || null,
+    last_name: invite.last_name || null,
+  };
+};
+
+export default InviteUserForm;

--- a/frontend/src/metabase/setup/components/InviteUserForm/InviteUserForm.tsx
+++ b/frontend/src/metabase/setup/components/InviteUserForm/InviteUserForm.tsx
@@ -31,7 +31,9 @@ const InviteUserForm = ({
   invite,
   onSubmit,
 }: InviteUserFormProps): JSX.Element => {
-  const initialValues = useMemo(() => getInitialValues(invite), [invite]);
+  const initialValues = useMemo(() => {
+    return getInitialValues(invite);
+  }, [invite]);
 
   const handleSubmit = useCallback(
     (values: InviteInfo) => onSubmit(getSubmitValues(values)),

--- a/frontend/src/metabase/setup/components/InviteUserForm/InviteUserForm.tsx
+++ b/frontend/src/metabase/setup/components/InviteUserForm/InviteUserForm.tsx
@@ -7,14 +7,6 @@ import FormProvider from "metabase/core/components/FormProvider";
 import { InviteInfo, UserInfo } from "metabase-types/store";
 import { UserFieldGroup } from "./InviteUserForm.styled";
 
-const InviteUserSchema = Yup.object().shape({
-  first_name: Yup.string().max(100, t`must be 100 characters or less`),
-  last_name: Yup.string().max(100, t`must be 100 characters or less`),
-  email: Yup.string()
-    .required(t`required`)
-    .email(t`must be a valid email address`),
-});
-
 interface InviteUserFormProps {
   user?: UserInfo;
   invite?: InviteInfo;
@@ -26,21 +18,18 @@ const InviteUserForm = ({
   invite,
   onSubmit,
 }: InviteUserFormProps): JSX.Element => {
-  const initialValues = useMemo(() => {
-    return getInitialValues(invite);
-  }, [invite]);
+  const initialValues = useMemo(() => getInitialValues(invite), [invite]);
+  const validationSchema = useMemo(() => getValidationSchema(user), [user]);
 
   const handleSubmit = useCallback(
-    (values: InviteInfo) => {
-      onSubmit(getSubmitValues(values));
-    },
+    (values: InviteInfo) => onSubmit(getSubmitValues(values)),
     [onSubmit],
   );
 
   return (
     <FormProvider
       initialValues={initialValues}
-      validationSchema={InviteUserSchema}
+      validationSchema={validationSchema}
       onSubmit={handleSubmit}
     >
       <Form>
@@ -69,6 +58,20 @@ const getSubmitValues = (invite: InviteInfo): InviteInfo => {
     first_name: invite.first_name || null,
     last_name: invite.last_name || null,
   };
+};
+
+const getValidationSchema = (user?: UserInfo) => {
+  return Yup.object().shape({
+    first_name: Yup.string().max(100, t`must be 100 characters or less`),
+    last_name: Yup.string().max(100, t`must be 100 characters or less`),
+    email: Yup.string()
+      .required(t`required`)
+      .email(t`must be a valid email address`)
+      .notOneOf(
+        [user?.email],
+        t`must be different from the email address you used in setup`,
+      ),
+  });
 };
 
 export default InviteUserForm;

--- a/frontend/src/metabase/setup/components/InviteUserForm/InviteUserForm.tsx
+++ b/frontend/src/metabase/setup/components/InviteUserForm/InviteUserForm.tsx
@@ -8,6 +8,18 @@ import FormSubmitButton from "metabase/core/components/FormSubmitButton";
 import { InviteInfo, UserInfo } from "metabase-types/store";
 import { UserFieldGroup } from "./InviteUserForm.styled";
 
+const InviteUserSchema = Yup.object({
+  first_name: Yup.string().max(100, t`must be 100 characters or less`),
+  last_name: Yup.string().max(100, t`must be 100 characters or less`),
+  email: Yup.string()
+    .required(t`required`)
+    .email(t`must be a valid email address`)
+    .notOneOf(
+      [Yup.ref("$email")],
+      t`must be different from the email address you used in setup`,
+    ),
+});
+
 interface InviteUserFormProps {
   user?: UserInfo;
   invite?: InviteInfo;
@@ -20,7 +32,6 @@ const InviteUserForm = ({
   onSubmit,
 }: InviteUserFormProps): JSX.Element => {
   const initialValues = useMemo(() => getInitialValues(invite), [invite]);
-  const validationSchema = useMemo(() => getValidationSchema(user), [user]);
 
   const handleSubmit = useCallback(
     (values: InviteInfo) => onSubmit(getSubmitValues(values)),
@@ -30,8 +41,8 @@ const InviteUserForm = ({
   return (
     <FormProvider
       initialValues={initialValues}
-      validationSchema={validationSchema}
-      isInitialValid={false}
+      validationSchema={InviteUserSchema}
+      validationContext={user}
       onSubmit={handleSubmit}
     >
       <Form>
@@ -77,20 +88,6 @@ const getSubmitValues = (invite: InviteInfo): InviteInfo => {
     first_name: invite.first_name || null,
     last_name: invite.last_name || null,
   };
-};
-
-const getValidationSchema = (user?: UserInfo) => {
-  return Yup.object().shape({
-    first_name: Yup.string().max(100, t`must be 100 characters or less`),
-    last_name: Yup.string().max(100, t`must be 100 characters or less`),
-    email: Yup.string()
-      .required(t`required`)
-      .email(t`must be a valid email address`)
-      .notOneOf(
-        [user?.email],
-        t`must be different from the email address you used in setup`,
-      ),
-  });
 };
 
 export default InviteUserForm;

--- a/frontend/src/metabase/setup/components/InviteUserForm/InviteUserForm.tsx
+++ b/frontend/src/metabase/setup/components/InviteUserForm/InviteUserForm.tsx
@@ -2,8 +2,9 @@ import React, { useCallback, useMemo } from "react";
 import { t } from "ttag";
 import * as Yup from "yup";
 import Form from "metabase/core/components/Form";
-import FormInput from "metabase/core/components/FormInput";
 import FormProvider from "metabase/core/components/FormProvider";
+import FormInput from "metabase/core/components/FormInput";
+import FormSubmitButton from "metabase/core/components/FormSubmitButton";
 import { InviteInfo, UserInfo } from "metabase-types/store";
 import { UserFieldGroup } from "./InviteUserForm.styled";
 
@@ -30,14 +31,32 @@ const InviteUserForm = ({
     <FormProvider
       initialValues={initialValues}
       validationSchema={validationSchema}
+      isInitialValid={false}
       onSubmit={handleSubmit}
     >
       <Form>
         <UserFieldGroup>
-          <FormInput name="first_name" />
-          <FormInput name="last_name" />
+          <FormInput
+            name="first_name"
+            title={t`First name`}
+            placeholder={t`Johnny`}
+            autoFocus
+            fullWidth
+          />
+          <FormInput
+            name="last_name"
+            title={t`Last name`}
+            placeholder={t`Appleseed`}
+            fullWidth
+          />
         </UserFieldGroup>
-        <FormInput name="email" />
+        <FormInput
+          name="email"
+          title={t`Email`}
+          placeholder={"nicetoseeyou@email.com"}
+          fullWidth
+        />
+        <FormSubmitButton title={`Send invitation`} primary />
       </Form>
     </FormProvider>
   );

--- a/frontend/src/metabase/setup/components/InviteUserForm/index.ts
+++ b/frontend/src/metabase/setup/components/InviteUserForm/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./InviteUserForm";


### PR DESCRIPTION
Epic https://github.com/metabase/metabase/issues/26178

How to test:
- `npx maildev -s 25 -w 80`
- `MB_EMAIL_SMTP_HOST=localhost MB_EMAIL_SMTP_PORT=25 MB_EMAIL_SMTP_USERNAME=admin MB_EMAIL_SMTP_PASSWORD=admin MB_EMAIL_SMTP_SECURITY=none MB_EMAIL_EMAIL_FROM_ADDRESS=mailer@metabase.test yarn dev` with a fresh Metabase instance
- Go to the database step. There should be a new section for inviting a user for database setup.

<img width="718" alt="Screenshot 2022-11-02 at 18 09 16" src="https://user-images.githubusercontent.com/8542534/199541782-d6d9c831-d758-4f9f-80b2-6658a7c0362e.png">

<img width="713" alt="Screenshot 2022-11-03 at 13 10 24" src="https://user-images.githubusercontent.com/8542534/199706266-0f8212d6-deab-4269-8344-764340a18051.png">

