### PR TITLE
Object Detail Viz Improvements

### DIFF
--- a/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetail.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetail.styled.tsx
@@ -2,26 +2,33 @@ import styled from "@emotion/styled";
 import Modal from "metabase/components/Modal";
 import { breakpointMinMedium } from "metabase/styled-components/theme/media-queries";
 import { color } from "metabase/lib/colors";
+import TableFooter from "../TableSimple/TableFooter";
 
-interface ObjectDetailModalProps {
+interface ObjectDetailContainerProps {
   wide: boolean;
 }
 
-export const CenteredLayout = styled.div`
-  display: flex;
-  flex: 1;
-  justify-content: center;
-  align-items: center;
-`;
-
-export const ObjectDetailModal = styled.div<ObjectDetailModalProps>`
-  overflow-y: scroll;
+export const ObjectDetailContainer = styled.div<ObjectDetailContainerProps>`
+  overflow-y: auto;
   height: 100%;
+`;
+export const ObjectDetailWrapperDiv = styled.div`
+  height: 100%;
+  display: flex;
+  flex-direction: column;
 `;
 
 export const ObjectDetailBodyWrapper = styled.div`
   font-size: 1rem;
+  flex: 1;
   overflow-y: auto;
+`;
+
+export const ObjectDetailHeaderWrapper = styled.div`
+  flex-shrink: 0;
+  display: flex;
+  position: relative;
+  border-bottom: 1px solid ${color("border")};
 `;
 
 export const ObjectIdLabel = styled.span`
@@ -74,7 +81,7 @@ export const GridCell = styled.div<GridItemProps>`
 `;
 
 export const RootModal = styled(Modal)`
-  ${ObjectDetailModal} {
+  ${ObjectDetailContainer} {
     overflow: hidden;
     ${breakpointMinMedium} {
       width: ${({ wide }) => (wide ? "64rem" : "48rem")};
@@ -125,4 +132,9 @@ export const ObjectRelationContent = styled.div<ObjectRelationshipContentProps>`
   &:hover {
     color: ${props => props.isClickable && color("brand")};
   }
+`;
+
+export const PaginationFooter = styled(TableFooter)`
+  margin-top: 0.5rem;
+  text-align: right;
 `;

--- a/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetail.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetail.styled.tsx
@@ -1,7 +1,8 @@
 import styled from "@emotion/styled";
 import Modal from "metabase/components/Modal";
+import Link from "metabase/core/components/Link";
 import { breakpointMinMedium } from "metabase/styled-components/theme/media-queries";
-import { color } from "metabase/lib/colors";
+import { color, lighten } from "metabase/lib/colors";
 import TableFooter from "../TableSimple/TableFooter";
 
 interface ObjectDetailContainerProps {
@@ -137,4 +138,16 @@ export const ObjectRelationContent = styled.div<ObjectRelationshipContentProps>`
 export const PaginationFooter = styled(TableFooter)`
   margin-top: 0.5rem;
   text-align: right;
+`;
+
+export const QuestionLink = styled(Link)`
+  position: absolute;
+  top: 15px;
+  right: 15px;
+  z-index: 1;
+  text-align: right;
+  color: ${color("brand")};
+  &:hover {
+    color: ${lighten("brand", 0.1)};
+  }
 `;

--- a/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetail.tsx
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetail.tsx
@@ -1,7 +1,6 @@
 import React, { useState, useEffect, useCallback } from "react";
 import { connect } from "react-redux";
 import { t } from "ttag";
-import { Link } from "react-router";
 
 import { State } from "metabase-types/store";
 import type {
@@ -63,6 +62,7 @@ import {
   ErrorWrapper,
   PaginationFooter,
   ObjectDetailWrapperDiv,
+  QuestionLink,
 } from "./ObjectDetail.styled";
 
 const mapStateToProps = (state: State, { data }: ObjectDetailProps) => {
@@ -302,17 +302,18 @@ export function ObjectDetailWrapper({
     );
   }
 
-  const shouldShowPagination = data?.rows?.length > 1;
-  const shouldShowQuestionLink = !isDataApp && dashcard && (question || card);
+  const hasPagination = data?.rows?.length > 1;
+  const hasQuestionLink = !isDataApp && dashcard && (question || card);
 
   return (
     <>
-      {shouldShowQuestionLink && (
-        <QuestionLink
-          title={question?.displayName() ?? card?.name ?? t`View Question`}
-          cardId={question?.id() ?? card?.id}
-          // onClick={props.onChangeCardAndRun({ nextCard: question.card() })}
-        />
+      {hasQuestionLink && (
+        <QuestionLink to={`/question/${question?.id() ?? card?.id}`}>
+          <Icon
+            name="insight"
+            tooltip={question?.displayName() ?? card?.name ?? t`View Question`}
+          />
+        </QuestionLink>
       )}
       <ObjectDetailFn
         {...props}
@@ -325,7 +326,7 @@ export function ObjectDetailWrapper({
         closeObjectDetail={closeObjectDetail}
         isDataApp={isDataApp}
       />
-      {shouldShowPagination && (
+      {hasPagination && (
         <PaginationFooter
           start={currentObjectIndex}
           end={currentObjectIndex}
@@ -460,18 +461,6 @@ export function ObjectDetailBody({
     </ObjectDetailBodyWrapper>
   );
 }
-
-const QuestionLink = ({ title, cardId }: { title: string; cardId: number }) => (
-  <Link
-    to={`/question/${cardId}`}
-    style={{ position: "absolute", top: 10, right: 10, zIndex: 1 }}
-    className="text-right text-brand cursor-pointer"
-  >
-    <Tooltip tooltip={title}>
-      <Icon name="insight" size={16} />
-    </Tooltip>
-  </Link>
-);
 
 export default connect(
   mapStateToProps,

--- a/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetail.tsx
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetail.tsx
@@ -117,6 +117,7 @@ export function ObjectDetailFn({
   canZoomNextRow,
   showActions = true,
   showRelations = true,
+  showHeader,
   onVisualizationClick,
   visualizationIsClickable,
   fetchTableFks,
@@ -225,8 +226,6 @@ export function ObjectDetailFn({
   const hasRelationships =
     showRelations && !!(tableForeignKeys && !!tableForeignKeys.length && hasPk);
 
-  const showHeader = !!settings["detail.showHeader"];
-
   return (
     <ObjectDetailContainer wide={hasRelationships}>
       {hasNotFoundError ? (
@@ -294,6 +293,7 @@ export function ObjectDetailWrapper({
       >
         <ObjectDetailFn
           {...props}
+          showHeader
           data={data}
           question={question}
           closeObjectDetail={closeObjectDetail}
@@ -319,6 +319,7 @@ export function ObjectDetailWrapper({
         zoomedRow={data.rows[currentObjectIndex]}
         data={data}
         question={question}
+        showHeader={props.settings["detail.showHeader"]}
         showActions={false}
         showRelations={false}
         closeObjectDetail={closeObjectDetail}

--- a/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetail.tsx
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetail.tsx
@@ -225,7 +225,7 @@ export function ObjectDetailFn({
   const hasRelationships =
     showRelations && !!(tableForeignKeys && !!tableForeignKeys.length && hasPk);
 
-  const showHeader = settings["detail.showHeader"] !== false;
+  const showHeader = !!settings["detail.showHeader"];
 
   return (
     <ObjectDetailContainer wide={hasRelationships}>

--- a/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetail.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetail.unit.spec.tsx
@@ -94,6 +94,7 @@ describe("Object Detail", () => {
         zoomedRowID={0}
         tableForeignKeys={[]}
         tableForeignKeyReferences={[]}
+        showHeader
         settings={{
           column: () => null,
         }}

--- a/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetailsTable.tsx
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetailsTable.tsx
@@ -43,8 +43,9 @@ export function DetailsTableCell({
   const clicked = { column: null, value: null };
   let isLink;
 
+  const columnSettings = settings?.column?.(column) ?? {};
   const columnTitle =
-    settings?.column?.(column)?.["_column_title_full"] || formatColumn(column);
+    columnSettings?.["_column_title_full"] || formatColumn(column);
 
   if (isColumnName) {
     cellValue = column !== null ? columnTitle : null;
@@ -66,7 +67,7 @@ export function DetailsTableCell({
       cellValue = <pre className="ObjectJSON">{formattedJson}</pre>;
     } else {
       cellValue = formatValue(value, {
-        ...settings.column(column),
+        ...columnSettings,
         jsx: true,
         rich: true,
       });

--- a/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetailsTable.tsx
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetailsTable.tsx
@@ -44,7 +44,7 @@ export function DetailsTableCell({
   let isLink;
 
   const columnTitle =
-    settings.column(column)["_column_title_full"] || formatColumn(column);
+    settings?.column?.(column)?.["_column_title_full"] || formatColumn(column);
 
   if (isColumnName) {
     cellValue = column !== null ? columnTitle : null;

--- a/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetailsTable.tsx
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetailsTable.tsx
@@ -2,7 +2,8 @@ import React from "react";
 import cx from "classnames";
 import { t } from "ttag";
 
-import { DatasetData } from "metabase-types/types/Dataset";
+import type { DatasetData } from "metabase-types/types/Dataset";
+import type { VisualizationSettings } from "metabase-types/api";
 
 import ExpandableString from "metabase/query_builder/components/ExpandableString";
 import EmptyState from "metabase/components/EmptyState";
@@ -10,8 +11,9 @@ import EmptyState from "metabase/components/EmptyState";
 import { formatValue, formatColumn } from "metabase/lib/formatting";
 import { isa, isID } from "metabase-lib/types/utils/isa";
 import { TYPE } from "metabase-lib/types/constants";
+import { findColumnIndexForColumnSetting } from "metabase-lib/queries/utils/dataset";
 
-import { OnVisualizationClickType } from "./types";
+import type { OnVisualizationClickType } from "./types";
 import {
   ObjectDetailsTable,
   GridContainer,
@@ -41,8 +43,11 @@ export function DetailsTableCell({
   const clicked = { column: null, value: null };
   let isLink;
 
+  const columnTitle =
+    settings.column(column)["_column_title_full"] || formatColumn(column);
+
   if (isColumnName) {
-    cellValue = column !== null ? formatColumn(column) : null;
+    cellValue = column !== null ? columnTitle : null;
     clicked.column = column;
     isLink = false;
   } else {
@@ -103,7 +108,7 @@ export function DetailsTableCell({
 export interface DetailsTableProps {
   data: DatasetData;
   zoomedRow: unknown[];
-  settings: unknown;
+  settings: VisualizationSettings;
   onVisualizationClick: OnVisualizationClickType;
   visualizationIsClickable: (clicked: any) => boolean;
 }
@@ -115,8 +120,28 @@ export function DetailsTable({
   onVisualizationClick,
   visualizationIsClickable,
 }: DetailsTableProps): JSX.Element {
-  const { cols } = data;
-  const row = zoomedRow;
+  const { cols: columns } = data;
+
+  const { cols, row } = React.useMemo(() => {
+    const columnSettings = settings["detail.columns"];
+    if (!columnSettings) {
+      return { cols: columns, row: zoomedRow };
+    }
+    const columnIndexes = columnSettings
+      .filter((columnSetting: any) => columnSetting.enabled)
+      .map((columnSetting: any) =>
+        findColumnIndexForColumnSetting(columns, columnSetting),
+      )
+      .filter(
+        (columnIndex: number) =>
+          columnIndex >= 0 && columnIndex < columns.length,
+      );
+
+    return {
+      cols: columnIndexes.map((i: number) => columns[i]) as any[],
+      row: columnIndexes.map((i: number) => zoomedRow[i]),
+    };
+  }, [columns, zoomedRow, settings]);
 
   if (!row?.length) {
     return <EmptyState message={t`No details found`} />;

--- a/frontend/src/metabase/visualizations/components/ObjectDetail/types.ts
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/types.ts
@@ -39,6 +39,7 @@ export interface ObjectDetailProps {
   isDataApp?: boolean;
   showActions?: boolean;
   showRelations?: boolean;
+  showHeader?: boolean;
   onVisualizationClick: OnVisualizationClickType;
   visualizationIsClickable: (clicked: any) => boolean;
   fetchTableFks: (id: number) => void;

--- a/frontend/src/metabase/visualizations/components/ObjectDetail/types.ts
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/types.ts
@@ -1,3 +1,10 @@
+import type { DatasetData } from "metabase-types/types/Dataset";
+import type { SavedCard } from "metabase-types/types/Card";
+import type { DashboardOrderedCard, ForeignKey } from "metabase-types/api";
+
+import type Table from "metabase-lib/metadata/Table";
+import type Question from "metabase-lib/Question";
+
 export type ObjectId = number | string;
 
 export type OnVisualizationClickType =
@@ -11,3 +18,33 @@ export type OnVisualizationClickType =
       element: Element;
     }) => void)
   | undefined;
+
+export interface ObjectDetailProps {
+  data: DatasetData;
+  question: Question;
+  card?: SavedCard;
+  dashcard?: DashboardOrderedCard;
+  isObjectDetail?: boolean; // whether this should be shown in a modal
+  table: Table | null;
+  zoomedRow: unknown[] | undefined;
+  zoomedRowID: ObjectId;
+  tableForeignKeys: ForeignKey[];
+  tableForeignKeyReferences: {
+    [key: number]: { status: number; value: number };
+  };
+  settings: any;
+  canZoom: boolean;
+  canZoomPreviousRow: boolean;
+  canZoomNextRow: boolean;
+  isDataApp?: boolean;
+  showActions?: boolean;
+  showRelations?: boolean;
+  onVisualizationClick: OnVisualizationClickType;
+  visualizationIsClickable: (clicked: any) => boolean;
+  fetchTableFks: (id: number) => void;
+  loadObjectDetailFKReferences: (opts: { objectId: ObjectId }) => void;
+  followForeignKey: (opts: { objectId: ObjectId; fk: ForeignKey }) => void;
+  viewPreviousObjectDetail: () => void;
+  viewNextObjectDetail: () => void;
+  closeObjectDetail: () => void;
+}

--- a/frontend/src/metabase/visualizations/components/TableSimple/TableFooter.tsx
+++ b/frontend/src/metabase/visualizations/components/TableSimple/TableFooter.tsx
@@ -38,16 +38,17 @@ const TableFooter = React.forwardRef<HTMLDivElement, TableFooterProps>(
     ref,
   ) {
     const paginateMessage = useMemo(() => {
-      const totalMessage =
-        limit === undefined && total >= HARD_ROW_LIMIT
-          ? t`of first ${total}`
-          : t`of ${total}`;
+      const isOverLimit = limit === undefined && total >= HARD_ROW_LIMIT;
 
       if (singleItem) {
-        return t`Item ${start + 1} ${totalMessage}`;
+        return isOverLimit
+          ? t`Item ${start + 1} of first ${total}`
+          : t`Item ${start + 1} of ${total}`;
       }
 
-      return t`Rows ${start + 1}-${end + 1} ${totalMessage}`;
+      return isOverLimit
+        ? t`Rows ${start + 1}-${end + 1} of first ${total}`
+        : t`Rows ${start + 1}-${end + 1} of ${total}`;
     }, [total, start, end, limit, singleItem]);
 
     const handlePreviousPage = useCallback(

--- a/frontend/src/metabase/visualizations/components/TableSimple/TableFooter.tsx
+++ b/frontend/src/metabase/visualizations/components/TableSimple/TableFooter.tsx
@@ -20,6 +20,7 @@ interface TableFooterProps {
   limit?: number;
   onPreviousPage: () => void;
   onNextPage: () => void;
+  singleItem?: boolean;
 }
 
 const TableFooter = React.forwardRef<HTMLDivElement, TableFooterProps>(
@@ -32,15 +33,22 @@ const TableFooter = React.forwardRef<HTMLDivElement, TableFooterProps>(
       total,
       onPreviousPage,
       onNextPage,
+      singleItem,
     }: TableFooterProps,
     ref,
   ) {
     const paginateMessage = useMemo(() => {
-      if (limit === undefined && total >= HARD_ROW_LIMIT) {
-        return t`Rows ${start + 1}-${end + 1} of first ${total}`;
+      const totalMessage =
+        limit === undefined && total >= HARD_ROW_LIMIT
+          ? t`of first ${total}`
+          : t`of ${total}`;
+
+      if (singleItem) {
+        return t`Item ${start + 1} ${totalMessage}`;
       }
-      return t`Rows ${start + 1}-${end + 1} of ${total}`;
-    }, [total, start, end, limit]);
+
+      return t`Rows ${start + 1}-${end + 1} ${totalMessage}`;
+    }, [total, start, end, limit, singleItem]);
 
     const handlePreviousPage = useCallback(
       (event: MouseEvent) => {

--- a/frontend/src/metabase/visualizations/register.js
+++ b/frontend/src/metabase/visualizations/register.js
@@ -21,7 +21,7 @@ import MapViz from "./visualizations/Map";
 import ScatterPlot from "./visualizations/ScatterPlot";
 import Funnel from "./visualizations/Funnel";
 import Gauge from "./visualizations/Gauge";
-import ObjectDetail from "./components/ObjectDetail";
+import ObjectDetail from "./visualizations/ObjectDetail";
 import PivotTable from "./visualizations/PivotTable";
 import ListViz from "./visualizations/List";
 

--- a/frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx
@@ -1,0 +1,75 @@
+import { t } from "ttag";
+import _ from "underscore";
+
+import ObjectDetail from "metabase/visualizations/components/ObjectDetail";
+import ChartSettingOrderedColumns from "metabase/visualizations/components/settings/ChartSettingOrderedColumns";
+import { formatColumn } from "metabase/lib/formatting";
+
+import { columnSettings } from "metabase/visualizations/lib/settings/column";
+import { findColumnIndexForColumnSetting } from "metabase-lib/queries/utils/dataset";
+
+const ObjectDetailProperties = {
+  uiName: t`Object Detail`,
+  identifier: "object",
+  iconName: "document",
+  noun: t`object`,
+  hidden: false,
+  settings: {
+    ...columnSettings({ hidden: true }),
+    "detail.columns": {
+      section: t`Columns`,
+      title: t`Columns`,
+      widget: ChartSettingOrderedColumns,
+      getHidden: () => false,
+      isValid: ([{ card, data }]) =>
+        // If "detail.columns" happened to be an empty array,
+        // it will be treated as "all columns are hidden",
+        // This check ensures it's not empty,
+        // otherwise it will be overwritten by `getDefault` below
+        card.visualization_settings["detail.columns"].length !== 0 &&
+        _.all(
+          card.visualization_settings["detail.columns"],
+          columnSetting =>
+            findColumnIndexForColumnSetting(data.cols, columnSetting) >= 0,
+        ),
+      getDefault: ([
+        {
+          data: { cols },
+        },
+      ]) =>
+        cols.map(col => ({
+          name: col.name,
+          fieldRef: col.field_ref,
+          enabled: col.visibility_type !== "hidden",
+        })),
+      getProps: ([
+        {
+          data: { cols },
+        },
+      ]) => ({
+        columns: cols,
+      }),
+    },
+    "detail.showHeader": {
+      section: t`Options`,
+      title: t`Show Header`,
+      widget: "toggle",
+      default: true,
+    },
+  },
+  columnSettings: column => {
+    const settings = {
+      column_title: {
+        title: t`Column title`,
+        widget: "input",
+        getDefault: column => formatColumn(column),
+      },
+      click_behavior: {},
+    };
+
+    return settings;
+  },
+  isSensible: () => true,
+};
+
+export default Object.assign(ObjectDetail, ObjectDetailProperties);

--- a/frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx
@@ -54,7 +54,7 @@ const ObjectDetailProperties = {
       section: t`Options`,
       title: t`Show Header`,
       widget: "toggle",
-      default: true,
+      default: false,
     },
   },
   columnSettings: column => {

--- a/frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx
@@ -9,7 +9,7 @@ import { columnSettings } from "metabase/visualizations/lib/settings/column";
 import { findColumnIndexForColumnSetting } from "metabase-lib/queries/utils/dataset";
 
 const ObjectDetailProperties = {
-  uiName: t`Object Detail`,
+  uiName: t`Detail`,
   identifier: "object",
   iconName: "document",
   noun: t`object`,

--- a/frontend/src/metabase/writeback/utils.ts
+++ b/frontend/src/metabase/writeback/utils.ts
@@ -106,13 +106,18 @@ export const shouldPrefetchValues = (action: WritebackAction) => {
   return action.slug === "update";
 };
 
-const vizTypesToHideHeader = ["object"];
-const vizTypesToHideHeaderInApps = ["object", "list"];
+const VIZ_TYPES_TO_HIDE_HEADER = ["object"];
+const VIZ_TYPES_TO_HIDE_HEADER_IN_APPS = ["object", "list"];
 
 export const shouldHideDashcardHeader = (
   dashboard: Dashboard,
   dashcard: DashCard,
-): boolean =>
-  !!(
-    dashboard.is_app_page ? vizTypesToHideHeaderInApps : vizTypesToHideHeader
-  ).includes(dashcard?.card?.display ?? "");
+): boolean => {
+  const headerHiddenVizTypes = dashboard.is_app_page
+    ? VIZ_TYPES_TO_HIDE_HEADER_IN_APPS
+    : VIZ_TYPES_TO_HIDE_HEADER;
+
+  const dashcardDisplayType = dashcard?.card?.display ?? "";
+
+  return headerHiddenVizTypes.includes(dashcardDisplayType);
+};

--- a/frontend/src/metabase/writeback/utils.ts
+++ b/frontend/src/metabase/writeback/utils.ts
@@ -106,11 +106,13 @@ export const shouldPrefetchValues = (action: WritebackAction) => {
   return action.slug === "update";
 };
 
+const vizTypesToHideHeader = ["object"];
+const vizTypesToHideHeaderInApps = ["object", "list"];
+
 export const shouldHideDashcardHeader = (
   dashboard: Dashboard,
   dashcard: DashCard,
 ): boolean =>
   !!(
-    dashboard.is_app_page &&
-    ["list", "object"].includes(dashcard?.card?.display ?? "")
-  );
+    dashboard.is_app_page ? vizTypesToHideHeaderInApps : vizTypesToHideHeader
+  ).includes(dashcard?.card?.display ?? "");

--- a/frontend/test/metabase/scenarios/question/nulls.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/nulls.cy.spec.js
@@ -36,8 +36,10 @@ describe("scenarios > question > null", () => {
 
     cy.log("'No Results since at least v0.34.3");
     cy.get("#detail-shortcut").click();
-    cy.findByText("Discount");
-    cy.findByText("Empty");
+    cy.get(".ObjectDetail").within(() => {
+      cy.findByText(/Discount/i);
+      cy.findByText(/Empty/i);
+    });
   });
 
   // [quarantine]


### PR DESCRIPTION
## Description

- Adds standard column formatting settings 
- Adds header-hide toggle setting (defaults to hidden)
- Adds pagination so we can use the viz with multi-record queries
- Adds object link icon to header (instead of question name) in dashboards
- Styling updates to make internal scroll work properly on dashboards

## Screenshots

![Screen Shot 2022-11-02 at 3 22 12 PM](https://user-images.githubusercontent.com/30528226/199605012-715c0527-086b-4d5a-9818-9d14937fa03c.png)

![detailSettings](https://user-images.githubusercontent.com/30528226/199605218-fb0e2ac1-ffa3-42e0-8cc7-b33537cc21c5.gif)


## Testing Steps

Query Editor
- Create a Question with multiple rows
- set the viz type to "object detail"
- see that you can page through the rows 1 at a time
- see that you can rearrange, hide, and rename columns
- see that you can show or hide the header

Dashboards
- save and add your question to a dashboard
- see that you can page through the rows 1 at a time
- see that you can rearrange, hide, and rename columns
- see that you can show or hide the header

Modal
- object detail modal should always show header
- modal should appear and scroll properly throughout the app