### PR TITLE
Bump woodstox : CVE-2022-40151

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -33,6 +33,7 @@
   com.google.guava/guava                    {:mvn/version "31.0.1-jre"}         ; dep for BigQuery, Spark, and GA. Require here rather than letting different dep versions stomp on each other — see comments on #9697
   com.fasterxml.jackson.core/jackson-databind
                                             {:mvn/version "2.13.2.2"}           ; JSON processor used by snowplow-java-tracker (pinned version due to CVE-2020-36518)
+  com.fasterxml.woodstox/woodstox-core      {:mvn/version "6.4.0"}              ; trans dep of commons-codec (pinned version due to CVE-2022-40151)
   com.h2database/h2                         {:mvn/version "1.4.197"}            ; embedded SQL database
   com.snowplowanalytics/snowplow-java-tracker
                                             {:mvn/version "0.12.0"              ; Snowplow analytics


### PR DESCRIPTION
First seen in trivy report:
https://github.com/metabase/metabase/pull/26161/checks?check_run_id=9326286850

<img width="1200" alt="image" src="https://user-images.githubusercontent.com/6377293/200342306-2f9e2abd-d7ff-4146-ba5f-817ec63322e1.png">

We are on version 6.2.6 as a transitive dep of commons-codec/commons-codec 1.15. Upgrading `6.2.6` -> `6.4.0` as per recommendation in CVE.


CVE:
https://avd.aquasec.com/nvd/cve-2022-40151

xstream: Xstream to serialise XML data was vulnerable to Denial of Service attacks High
Package: com.fasterxml.woodstox:woodstox-core
Installed Version: 6.2.6
Vulnerability CVE-2022-40151
Severity: HIGH
Fixed Version: 5.4.0, 6.4.0

Bumping deps and comparing `clj -X:deps tree` shows the change only adds the new dep top level and no new deps are brought in by the change.

```diff
❯ diff --unified deps deps-updated
--- deps	2022-11-07 08:43:21.000000000 -0600
+++ deps-updated	2022-11-07 08:49:56.000000000 -0600
@@ -9,6 +9,8 @@
   X org.slf4j/slf4j-api 1.7.25 :use-top
   X org.apache.logging.log4j/log4j-api 2.18.0 :use-top
   X org.apache.logging.log4j/log4j-core 2.18.0 :use-top
+com.fasterxml.woodstox/woodstox-core 6.4.0
+  . org.codehaus.woodstox/stax2-api 4.2.1
 joda-time/joda-time 2.10.13
 commons-codec/commons-codec 1.15
 weavejester/dependency 0.2.1
@@ -285,8 +287,7 @@
   . org.apache.santuario/xmlsec 2.3.0
     X org.slf4j/slf4j-api 1.7.32 :use-top
     X commons-codec/commons-codec 1.15 :use-top
-    . com.fasterxml.woodstox/woodstox-core 6.2.6
-      . org.codehaus.woodstox/stax2-api 4.2.1
+    X com.fasterxml.woodstox/woodstox-core 6.2.6 :use-top
     . jakarta.xml.bind/jakarta.xml.bind-api 2.3.3
       . jakarta.activation/jakarta.activation-api 1.2.2
   . org.opensaml/opensaml-xmlsec-api 3.4.6
```
