### PR TITLE
Streamlines devcontainer Dockerfile and adds fontconfig

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,9 +1,11 @@
 FROM mcr.microsoft.com/vscode/devcontainers/java:11
 
-# Set up nodesource, install node, yarn, fontconfig (for static viz), and Clojure
+# Set up nodesource, install node, yarn, fontconfig for static viz, rlwrap for dev ergonomics
 
 RUN ( curl -fsSL https://deb.nodesource.com/setup_14.x | bash ) \
   && export DEBIAN_FRONTEND=noninteractive \
   && apt-key adv --refresh-keys --keyserver keyserver.ubuntu.com \
-  && apt-get update && apt-get -y install --no-install-recommends nodejs yarn fontconfig \
-  && ( curl https://download.clojure.org/install/linux-install-1.11.0.1100.sh | bash )
+  && apt-get update && apt-get -y install --no-install-recommends nodejs yarn rlwrap fontconfig
+
+# install Clojure
+RUN curl https://download.clojure.org/install/linux-install-1.11.0.1100.sh | bash

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,11 +1,9 @@
 FROM mcr.microsoft.com/vscode/devcontainers/java:11
 
-RUN apt-key adv --refresh-keys --keyserver keyserver.ubuntu.com\
-  && apt-get update && export DEBIAN_FRONTEND=noninteractive \
-  && apt-get -y install --no-install-recommends yarn
+# Set up nodesource, install node, yarn, fontconfig (for static viz), and Clojure
 
-RUN curl -fsSL https://deb.nodesource.com/setup_14.x | bash
-RUN apt-get update && apt-get -y install --no-install-recommends nodejs
-
-RUN curl -O https://download.clojure.org/install/linux-install-1.11.0.1100.sh \
-  && bash ./linux-install-1.11.0.1100.sh
+RUN ( curl -fsSL https://deb.nodesource.com/setup_14.x | bash ) \
+  && export DEBIAN_FRONTEND=noninteractive \
+  && apt-key adv --refresh-keys --keyserver keyserver.ubuntu.com \
+  && apt-get update && apt-get -y install --no-install-recommends nodejs yarn fontconfig \
+  && ( curl https://download.clojure.org/install/linux-install-1.11.0.1100.sh | bash )


### PR DESCRIPTION
I noticed that I couldn't successfully run all tests with `clojure -X:dev:test` inside of our VS Code dev container by default.

Installing `fontconfig` enables running pulse rendering tests in a devcontainer with a headless JVM. The `.devcontainer/Dockerfile` has been streamlined and a comment added to explain the additional requirement.