### PR TITLE
Fix stacked static chart render failure

### DIFF
--- a/frontend/src/metabase/static-viz/components/XYChart/utils/series.ts
+++ b/frontend/src/metabase/static-viz/components/XYChart/utils/series.ts
@@ -51,27 +51,25 @@ export const sortSeries = (series: Series[], type: XAxisType) => {
 };
 
 export const calculateStackedItems = (multipleSeries: Series[]) => {
-  const dimensionSeriesIndexMap = multipleSeries.reduce(
-    (map, series, seriesIndex) => {
-      series.data.forEach(datum => {
-        const dimension = getX(datum);
-        if (!map[dimension]) {
-          map[dimension] = {};
-        }
-        map[dimension][seriesIndex] = datum;
-      });
-      return map;
-    },
-    {} as {
-      [dimension: string]: {
-        [seriesIndex: number]: SeriesDatum;
-      };
-    },
-  );
+  const dimensionSeriesIndexMap: Record<
+    string,
+    Record<number, SeriesDatum>
+  > = {};
+
+  multipleSeries.forEach((series, seriesIndex) => {
+    series.data.forEach(datum => {
+      const dimension = getX(datum);
+      if (!dimensionSeriesIndexMap[dimension]) {
+        dimensionSeriesIndexMap[dimension] = {};
+      }
+      dimensionSeriesIndexMap[dimension][seriesIndex] = datum;
+    });
+    return dimensionSeriesIndexMap;
+  });
 
   // Stacked charts work only for a single dataset with one dimension
   return multipleSeries.map((series, seriesIndex) => {
-    const stackedData = series.data.map((datum, datumIndex) => {
+    const stackedData = series.data.map(datum => {
       const [x, y] = datum;
 
       let y1 = 0;

--- a/frontend/src/metabase/static-viz/components/XYChart/utils/series.unit.spec.ts
+++ b/frontend/src/metabase/static-viz/components/XYChart/utils/series.unit.spec.ts
@@ -103,40 +103,39 @@ describe("sortSeries", () => {
 });
 
 describe("calculateStackedItems", () => {
-  const series: Series[] = [
-    {
-      name: "series 1",
-      color: "#509ee3",
-      yAxisPosition: "left",
-      type: "area",
-      data: [
-        ["2020-10-18", 10],
-        ["2020-10-19", -10],
-      ],
-    },
-    {
-      name: "series 2",
-      color: "#a989c5",
-      yAxisPosition: "left",
-      type: "area",
-      data: [
-        ["2020-10-18", 20],
-        ["2020-10-19", -20],
-      ],
-    },
-    {
-      name: "series 3",
-      color: "#ef8c8c",
-      yAxisPosition: "left",
-      type: "area",
-      data: [
-        ["2020-10-18", -30],
-        ["2020-10-19", 30],
-      ],
-    },
-  ];
-
   it("calculates stacked items separating positive and negative values", () => {
+    const series: Series[] = [
+      {
+        name: "series 1",
+        color: "#509ee3",
+        yAxisPosition: "left",
+        type: "area",
+        data: [
+          ["2020-10-18", 10],
+          ["2020-10-19", -10],
+        ],
+      },
+      {
+        name: "series 2",
+        color: "#a989c5",
+        yAxisPosition: "left",
+        type: "area",
+        data: [
+          ["2020-10-18", 20],
+          ["2020-10-19", -20],
+        ],
+      },
+      {
+        name: "series 3",
+        color: "#ef8c8c",
+        yAxisPosition: "left",
+        type: "area",
+        data: [
+          ["2020-10-18", -30],
+          ["2020-10-19", 30],
+        ],
+      },
+    ];
     const stackedSeries = calculateStackedItems(series);
 
     /**
@@ -158,6 +157,68 @@ describe("calculateStackedItems", () => {
       [
         ["2020-10-18", 30, 10],
         ["2020-10-19", -30, -10],
+      ],
+      [
+        ["2020-10-18", -30, 0],
+        ["2020-10-19", 30, 0],
+      ],
+    ]);
+  });
+
+  it("calculates stacked items separating positive and negative values even when data has gaps #20752", () => {
+    const stackedSeriesWithGaps: Series[] = [
+      {
+        name: "series 1",
+        color: "#509ee3",
+        yAxisPosition: "left",
+        type: "area",
+        data: [
+          ["2020-10-18", 10],
+          ["2020-10-19", -10],
+        ],
+      },
+      {
+        name: "series 2",
+        color: "#a989c5",
+        yAxisPosition: "left",
+        type: "area",
+        data: [
+          ["2020-10-19", -20],
+          ["2020-10-20", 20],
+        ],
+      },
+      {
+        name: "series 3",
+        color: "#ef8c8c",
+        yAxisPosition: "left",
+        type: "area",
+        data: [
+          ["2020-10-18", -30],
+          ["2020-10-19", 30],
+        ],
+      },
+    ];
+    const stackedSeries = calculateStackedItems(stackedSeriesWithGaps);
+
+    /**
+     *
+     *  30|  -   3   -
+     *  20|  -   3   2
+     *  10|  1   3   2
+     *     ---------
+     * -10|  3   1   -
+     * -20|  3   2   -
+     * -30|  3   2   -
+     *
+     */
+    expect(stackedSeries.map(s => s.stackedData)).toStrictEqual([
+      [
+        ["2020-10-18", 10, 0],
+        ["2020-10-19", -10, 0],
+      ],
+      [
+        ["2020-10-19", -30, -10],
+        ["2020-10-20", 20, 0],
       ],
       [
         ["2020-10-18", -30, 0],


### PR DESCRIPTION
Epic: https://github.com/metabase/metabase/issues/24759
Issue: https://github.com/metabase/metabase/issues/20752

## How to test
Follow the repro in https://github.com/metabase/metabase/issues/20752

## Note
The code change that relies on a map instead of looping an array is needed because there are 2 problems with looping through arrays
1. different series could have different numbers of data
2. different series could have data from different dimensions even with the same data index

The following example data is the 5 last data point of each series using the repro steps from https://github.com/metabase/metabase/issues/20752 which clearly demonstrates the 2 problems described above.
#### Series 1
```
["2019-01-20T00:00:00Z", 3],
["2019-03-03T00:00:00Z", 1],
["2019-03-24T00:00:00Z", 1],
["2019-03-31T00:00:00Z", 1],
["2019-04-14T00:00:00Z", 1],
```

#### Series 2
```
["2018-11-11T00:00:00Z", 1],
["2019-01-06T00:00:00Z", 1],
["2019-02-10T00:00:00Z", 1],
["2019-03-31T00:00:00Z", 1],
["2019-04-07T00:00:00Z", 1],
```

#### Series 3
```
["2018-09-30T00:00:00Z", 1],
["2019-01-13T00:00:00Z", 1],
["2019-02-03T00:00:00Z", 1],
["2019-03-31T00:00:00Z", 1],
["2019-04-07T00:00:00Z", 1],
```

#### Series 4
```
["2018-11-11T00:00:00Z", 1],
["2018-12-02T00:00:00Z", 1],
["2019-01-13T00:00:00Z", 1],
["2019-02-03T00:00:00Z", 1],
["2019-03-31T00:00:00Z", 1],
```

## Results
#### After
![image](https://user-images.githubusercontent.com/1937582/200509236-3b561464-9a08-4022-987b-03dc165119e3.png)

#### Before
![image](https://user-images.githubusercontent.com/1937582/200509222-d1d907e8-96c4-45db-b045-7752b63a36bb.png)
