### PR TITLE
Remove fullWidth from form components

### DIFF
--- a/frontend/src/metabase/account/password/components/UserPasswordForm/UserPasswordForm.tsx
+++ b/frontend/src/metabase/account/password/components/UserPasswordForm/UserPasswordForm.tsx
@@ -65,7 +65,6 @@ const UserPasswordForm = ({
           title={t`Current password`}
           placeholder={t`Shhh...`}
           autoComplete="current-password"
-          fullWidth
         />
         <FormInput
           name="password"
@@ -73,7 +72,6 @@ const UserPasswordForm = ({
           title={t`Create a password`}
           placeholder={t`Shhh...`}
           autoComplete="new-password"
-          fullWidth
         />
         <FormInput
           name="password_confirm"
@@ -81,7 +79,6 @@ const UserPasswordForm = ({
           title={t`Confirm your password`}
           placeholder={t`Shhh... but one more time so we get it right`}
           autoComplete="new-password"
-          fullWidth
         />
         <FormSubmitButton title={t`Save`} primary />
         <FormErrorMessage />

--- a/frontend/src/metabase/account/profile/components/UserProfileForm/UserProfileForm.tsx
+++ b/frontend/src/metabase/account/profile/components/UserProfileForm/UserProfileForm.tsx
@@ -65,20 +65,17 @@ const UserProfileForm = ({
                 name="first_name"
                 title={t`First name`}
                 placeholder={t`Johnny`}
-                fullWidth
               />
               <FormInput
                 name="last_name"
                 title={t`Last name`}
                 placeholder={t`Appleseed`}
-                fullWidth
               />
               <FormInput
                 name="email"
                 type="email"
                 title={t`Email`}
                 placeholder="nicetoseeyou@email.com"
-                fullWidth
               />
             </>
           )}

--- a/frontend/src/metabase/auth/components/ForgotPasswordForm/ForgotPasswordForm.tsx
+++ b/frontend/src/metabase/auth/components/ForgotPasswordForm/ForgotPasswordForm.tsx
@@ -52,7 +52,6 @@ const ForgotPasswordForm = ({
             title={t`Email address`}
             placeholder={t`The email you use for your Metabase account`}
             autoFocus
-            fullWidth
           />
           <FormSubmitButton
             title={t`Send password reset email`}

--- a/frontend/src/metabase/auth/components/LoginForm/LoginForm.tsx
+++ b/frontend/src/metabase/auth/components/LoginForm/LoginForm.tsx
@@ -63,14 +63,12 @@ const LoginForm = ({
           type={isLdapEnabled ? "input" : "email"}
           placeholder="nicetoseeyou@email.com"
           autoFocus
-          fullWidth
         />
         <FormInput
           name="password"
           title={t`Password`}
           type="password"
           placeholder={t`Shhh...`}
-          fullWidth
         />
         {!hasSessionCookies && (
           <FormCheckBox name="remember" title={t`Remember me`} />

--- a/frontend/src/metabase/auth/components/ResetPasswordForm/ResetPasswordForm.tsx
+++ b/frontend/src/metabase/auth/components/ResetPasswordForm/ResetPasswordForm.tsx
@@ -70,7 +70,6 @@ const ResetPasswordForm = ({
             placeholder={t`Shhh...`}
             autoComplete="new-password"
             autoFocus
-            fullWidth
           />
           <FormInput
             name="password_confirm"
@@ -78,7 +77,6 @@ const ResetPasswordForm = ({
             title={t`Confirm your password`}
             placeholder={t`Shhh... but one more time so we get it right`}
             autoComplete="new-password"
-            fullWidth
           />
           <FormSubmitButton title={t`Save new password`} primary fullWidth />
           <FormErrorMessage />

--- a/frontend/src/metabase/core/components/FormDateInput/FormDateInput.tsx
+++ b/frontend/src/metabase/core/components/FormDateInput/FormDateInput.tsx
@@ -8,7 +8,10 @@ import DateWidget, {
 import FormField from "metabase/core/components/FormField";
 
 export interface FormDateInputProps
-  extends Omit<DateWidgetProps, "value" | "error" | "onChange" | "onBlur"> {
+  extends Omit<
+    DateWidgetProps,
+    "value" | "error" | "fullWidth" | "onChange" | "onBlur"
+  > {
   name: string;
   title?: string;
   description?: ReactNode;
@@ -48,6 +51,7 @@ const FormDateInput = forwardRef(function FormDateInput(
         name={name}
         value={date}
         error={touched && error != null}
+        fullWidth
         onChange={handleChange}
         onBlur={onBlur}
       />

--- a/frontend/src/metabase/core/components/FormInput/FormInput.tsx
+++ b/frontend/src/metabase/core/components/FormInput/FormInput.tsx
@@ -5,7 +5,10 @@ import Input, { InputProps } from "metabase/core/components/Input";
 import FormField from "metabase/core/components/FormField";
 
 export interface FormInputProps
-  extends Omit<InputProps, "value" | "error" | "onChange" | "onBlur"> {
+  extends Omit<
+    InputProps,
+    "value" | "error" | "fullWidth" | "onChange" | "onBlur"
+  > {
   name: string;
   title?: string;
   description?: ReactNode;
@@ -34,6 +37,7 @@ const FormInput = forwardRef(function FormInput(
         name={name}
         value={value}
         error={touched && error != null}
+        fullWidth
         onChange={onChange}
         onBlur={onBlur}
       />

--- a/frontend/src/metabase/core/components/FormNumericInput/FormNumericInput.tsx
+++ b/frontend/src/metabase/core/components/FormNumericInput/FormNumericInput.tsx
@@ -7,7 +7,10 @@ import NumericInput, {
 import FormField from "metabase/core/components/FormField";
 
 export interface FormNumericInputProps
-  extends Omit<NumericInputProps, "value" | "error" | "onChange" | "onBlur"> {
+  extends Omit<
+    NumericInputProps,
+    "value" | "error" | "fullWidth" | "onChange" | "onBlur"
+  > {
   name: string;
   title?: string;
   description?: ReactNode;
@@ -43,6 +46,7 @@ const FormNumericInput = forwardRef(function FormNumericInput(
         name={name}
         value={value}
         error={touched && error != null}
+        fullWidth
         onChange={setValue}
         onBlur={onBlur}
       />

--- a/frontend/src/metabase/setup/components/InviteUserForm/InviteUserForm.tsx
+++ b/frontend/src/metabase/setup/components/InviteUserForm/InviteUserForm.tsx
@@ -60,20 +60,17 @@ const InviteUserForm = ({
             title={t`First name`}
             placeholder={t`Johnny`}
             autoFocus
-            fullWidth
           />
           <FormInput
             name="last_name"
             title={t`Last name`}
             placeholder={t`Appleseed`}
-            fullWidth
           />
         </UserFieldGroup>
         <FormInput
           name="email"
           title={t`Email`}
           placeholder={"nicetoseeyou@email.com"}
-          fullWidth
         />
         <FormSubmitButton title={t`Send invitation`} primary />
       </Form>

--- a/frontend/src/metabase/setup/components/NewsletterForm/NewsletterForm.tsx
+++ b/frontend/src/metabase/setup/components/NewsletterForm/NewsletterForm.tsx
@@ -67,7 +67,6 @@ const NewsletterForm = ({
               type="email"
               placeholder="nicetoseeyou@email.com"
               autoFocus
-              fullWidth
             />
             <FormSubmitButton title={t`Subscribe`} />
           </EmailForm>

--- a/frontend/src/metabase/setup/components/UserForm/UserForm.tsx
+++ b/frontend/src/metabase/setup/components/UserForm/UserForm.tsx
@@ -69,13 +69,11 @@ const UserForm = ({ user, onValidatePassword, onSubmit }: UserFormProps) => {
             title={t`First name`}
             placeholder={t`Johnny`}
             autoFocus
-            fullWidth
           />
           <FormInput
             name="last_name"
             title={t`Last name`}
             placeholder={t`Appleseed`}
-            fullWidth
           />
         </UserFieldGroup>
         <FormInput
@@ -83,27 +81,23 @@ const UserForm = ({ user, onValidatePassword, onSubmit }: UserFormProps) => {
           type="email"
           title={t`Email`}
           placeholder="nicetoseeyou@email.com"
-          fullWidth
         />
         <FormInput
           name="site_name"
           title={t`Company or team name`}
           placeholder={t`Department of Awesome`}
-          fullWidth
         />
         <FormInput
           name="password"
           type="password"
           title={t`Create a password`}
           placeholder={t`Shhh...`}
-          fullWidth
         />
         <FormInput
           name="password_confirm"
           type="password"
           title={t`Confirm your password`}
           placeholder={t`Shhh... but one more time so we get it right`}
-          fullWidth
         />
         <FormSubmitButton title={t`Next`} primary />
       </UserFormRoot>

--- a/frontend/src/metabase/timelines/common/components/EventForm/EventForm.tsx
+++ b/frontend/src/metabase/timelines/common/components/EventForm/EventForm.tsx
@@ -67,13 +67,11 @@ const EventForm = ({
             title={t`Event name`}
             placeholder={t`Product launch`}
             autoFocus
-            fullWidth
           />
           <FormDateInput
             name="timestamp"
             title={t`Date`}
             hasTime={values.time_matters}
-            fullWidth
             onHasTimeChange={value => setFieldValue("time_matters", value)}
           />
           <FormTextArea

--- a/frontend/src/metabase/timelines/common/components/TimelineForm/TimelineForm.tsx
+++ b/frontend/src/metabase/timelines/common/components/TimelineForm/TimelineForm.tsx
@@ -54,7 +54,6 @@ const TimelineForm = ({
             title={t`Name`}
             placeholder={t`Product releases`}
             autoFocus
-            fullWidth
           />
           <FormTextArea name="description" title={t`Description`} fullWidth />
           <FormSelect name="icon" title={t`Default icon`} options={icons} />


### PR DESCRIPTION
Epic https://github.com/metabase/metabase/issues/26178

It should be `fullWidth=true` in 100% cases for all forms, event when there are multiple fields on the same row (because it's `fullWidth` within the `FormField`). There is no point in this prop in forms.