### PR TITLE
[Apps] Add required to action parameters

### DIFF
--- a/src/metabase/models/action.clj
+++ b/src/metabase/models/action.clj
@@ -110,14 +110,19 @@
                      (db/do-post-select 'Card))
           cards-by-action-id (m/index-by :action_id cards)]
       (keep (fn [action]
-              (let [{card-name :name :keys [description] :as card} (get cards-by-action-id (:id action))]
+              (let [{card-name :name :keys [description dataset_query] :as card} (get cards-by-action-id (:id action))
+                    tags (get-in dataset_query [:native :template-tags])
+                    params (for [param (:parameters card)
+                                 :let [tag (get tags (:slug param))]]
+                             (assoc param :required (:required tag)))]
                 (-> action
                     (merge
                       {:name card-name
                        :description description
                        :disabled (::disabled card)
-                       :card (dissoc card ::disabled)}
-                      (select-keys card [:parameters :parameter_mappings :visualization_settings])))))
+                       :card (dissoc card ::disabled)
+                       :parameters params}
+                      (select-keys card [:parameter_mappings :visualization_settings])))))
             actions))))
 
 (defn- normalize-http-actions [actions]
@@ -186,8 +191,9 @@
                                              {:id (u/slugify (:name field))
                                               :target [:variable [:template-tag (u/slugify (:name field))]]
                                               :type (:base_type field)
-                                              ::pk? (isa? (:semantic_type field) :type/PK)
-                                              ::field-id (:id field)})))]]
+                                              :required (:database_required field)
+                                              ::field-id (:id field)
+                                              ::pk? (isa? (:semantic_type field) :type/PK)})))]]
             [(:id card) parameters]))))
 
 (defn merged-model-action
@@ -217,6 +223,8 @@
                 implicit-action (when-let [parameters (get parameters-by-model-id (:card_id model-action))]
                                   {:parameters (cond->> parameters
                                                  (= "delete" (:slug model-action)) (filter ::pk?)
+                                                 (:requires_pk model-action) (map (fn [param] (cond-> param
+                                                                                                (::pk? param) (assoc :required true))))
                                                  :always (map #(dissoc % ::pk? ::field-id)))
                                    :type "implicit"})]]
       (m/deep-merge (-> model-action

--- a/test/metabase/actions/test_util.clj
+++ b/test/metabase/actions/test_util.clj
@@ -138,9 +138,11 @@
                                                                                               :required     false}}}}
                                            :name          "Query Example"
                                            :parameters    [{:id "id"
+                                                            :slug "id"
                                                             :type "number"
                                                             :target [:variable [:template-tag "id"]]}
                                                            {:id "name"
+                                                            :slug "name"
                                                             :type "text"
                                                             :required false
                                                             :target [:variable [:template-tag "name"]]}]

--- a/test/metabase/api/action_test.clj
+++ b/test/metabase/api/action_test.clj
@@ -36,13 +36,21 @@
           (let [response (mt/user-http-request :crowberto :get 200 (str "action?model-id=" card-id))]
             (is (partial= [{:slug "custom"
                             :action_id action-id
-                            :parameters [{:id "id"} {:id "name"}]
+                            :parameters [{:id "id" :required true} {:id "name" :required false}]
                             :card {:is_write true}
                             :type "query"
                             :name "Query Example"}
-                           {:slug "insert" :action_id nil :parameters [{:id "id"} {:id "name"}] :type "implicit"}
-                           {:slug "update" :action_id nil :parameters [{:id "id"} {:id "name"}] :type "implicit"}
-                           {:slug "delete" :action_id nil :parameters [{:id "id"}] :type "implicit"}]
+                           {:slug "insert"
+                            :action_id nil
+                            :parameters [{:id "id" :required false} {:id "name" :required true}]
+                            :type "implicit"}
+                           {:slug "update"
+                            :action_id nil
+                            :parameters [{:id "id" :required true} {:id "name" :required true}]
+                            :type "implicit"}
+                           {:slug "delete"
+                            :action_id nil
+                            :parameters [{:id "id" :required true}] :type "implicit"}]
                           response))
             (let [action (some (fn [action]
                                  (when (= (:id action) action-id)


### PR DESCRIPTION
Looks at `database_required` field values for implicit actions, and `required` template-tags for custom query actions. Bubble those values up onto `action.parameters`. Finally, look at `requires_pk` to see if pk fields should be marked as required regardless.
