### PR TITLE
Change TableMetadata schema to allow empty strings as table descriptions

### DIFF
--- a/src/metabase/sync/interface.clj
+++ b/src/metabase/sync/interface.clj
@@ -14,7 +14,7 @@
   {:name                         su/NonBlankString
    :schema                       (s/maybe su/NonBlankString)
    ;; `:description` in this case should be a column/remark on the Table, if there is one.
-   (s/optional-key :description) (s/maybe su/NonBlankString)})
+   (s/optional-key :description) (s/maybe s/Str)})
 
 (def DatabaseMetadata
   "Schema for the expected output of `describe-database`."
@@ -41,10 +41,10 @@
 
 (def TableMetadata
   "Schema for the expected output of `describe-table`."
-  {:name   su/NonBlankString
-   :schema (s/maybe su/NonBlankString)
-   :fields #{TableMetadataField}
-   (s/optional-key :description)   (s/maybe su/NonBlankString)})
+  {:name                         su/NonBlankString
+   :schema                       (s/maybe su/NonBlankString)
+   :fields                       #{TableMetadataField}
+   (s/optional-key :description) (s/maybe s/Str)})
 
 (def NestedFCMetadata
   "Schema for the expected output of `describe-nested-field-columns`."

--- a/src/metabase/util/schema.clj
+++ b/src/metabase/util/schema.clj
@@ -144,8 +144,7 @@
                      (str
                       (api-error-message k (inc indent-depth))
                       " : "
-                      (api-error-message (get schema k) (inc indent-depth)))
-                     ))
+                      (api-error-message (get schema k) (inc indent-depth)))))
                   "\n"
                   spaces
                   ")")))))))

--- a/test/metabase/sync_test.clj
+++ b/test/metabase/sync_test.clj
@@ -39,7 +39,8 @@
                        {:name              "studio"
                         :database-type     "VARCHAR"
                         :base-type         :type/Text
-                        :database-position 2}}}
+                        :database-position 2}}
+             :description nil}
    "studio" {:name   "studio"
              :schema nil
              :fields #{{:name              "studio"
@@ -50,7 +51,8 @@
                        {:name              "name"
                         :database-type     "VARCHAR"
                         :base-type         :type/Text
-                        :database-position 1}}}})
+                        :database-position 1}}
+             :description ""}})
 
 (driver/register! ::sync-test, :abstract? true)
 


### PR DESCRIPTION
Resolves #26268

Pretty simple issue. #21880 relaxed backend requirements for what can be in the `:description` field in table metadata to allow empty strings, since the frontend sends an empty string when you clear it. But the `TableMetadata` schema used by sync still used `su/NonBlankString` for this field, so it would throw a schema error and cause sync to fail.

I think there's some more improvements to do regarding how sync errors are logged (this issue was hard to track down because the error was basically squashed, and only recorded in the `task_history` table in the app db). I'll do that in the next PR.