### PR TITLE
Log errors caught during sync steps

### DIFF
--- a/src/metabase/sync/util.clj
+++ b/src/metabase/sync/util.clj
@@ -388,7 +388,9 @@
                          (apply sync-fn database args)
                          (catch Throwable e
                            (if *log-exceptions-and-continue?*
-                             {:throwable e}
+                             (do
+                               ((log/warn e (trs "Error running step ''{0}'' for {1}" step-name (name-for-logging database))))
+                               {:throwable e})
                              (throw (ex-info (format "Error in sync step %s: %s" step-name (ex-message e)) {} e)))))))
         end-time   (t/zoned-date-time)]
     [step-name (assoc results

--- a/src/metabase/sync/util.clj
+++ b/src/metabase/sync/util.clj
@@ -389,7 +389,7 @@
                          (catch Throwable e
                            (if *log-exceptions-and-continue?*
                              (do
-                               ((log/warn e (trs "Error running step ''{0}'' for {1}" step-name (name-for-logging database))))
+                               (log/warn e (trs "Error running step ''{0}'' for {1}" step-name (name-for-logging database)))
                                {:throwable e})
                              (throw (ex-info (format "Error in sync step %s: %s" step-name (ex-message e)) {} e)))))))
         end-time   (t/zoned-date-time)]


### PR DESCRIPTION
Currently, when exceptions are thrown during sync steps, they're caught within `run-step-with-metadata` and stuffed into the run metadata in the `:throwable` field. This is put into the `task_history` table in the app db but doesn't show up in the logs at all, which makes issues like https://github.com/metabase/metabase/issues/26268 pretty tricky to detect and diagnose if you're not aware of that table. This PR just adds a log when exceptions are caught here.

I'll note that there's already similar error handling & logging in [do-sync-operation](https://github.com/metabase/metabase/blob/dacort-athena-driver/src/metabase/sync/util.clj#L186) which wraps the entire sync-metadata job. But it never sees errors that are thrown within individual steps, because they're intercepted by `run-step-with-metadata`. This is worth keeping since `do-sync-operation` is used for other sync jobs as well, but perhaps this is the reason that logging here was overlooked.