### PR TITLE
Remove legacy MBQL syntax in tests

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/sandbox/api/field_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/api/field_test.clj
@@ -10,7 +10,7 @@
 (deftest fetch-field-test
   (testing "GET /api/field/:id"
     (mt/with-gtaps {:gtaps      {:venues {:query      (mt.tu/restricted-column-query (mt/id))
-                                          :remappings {:cat [:variable [:field-id (mt/id :venues :category_id)]]}}}
+                                          :remappings {:cat [:variable [:field (mt/id :venues :category_id) nil]]}}}
                     :attributes {:cat 50}}
       (testing "Can I fetch a Field that I don't have read access for if I have segmented table access for it?"
         (let [result (mt/user-http-request :rasta :get 200 (str "field/" (mt/id :venues :name)))]
@@ -110,7 +110,7 @@
         (is (= [[1 "$"] [2 "$$"] [3 "$$$"] [4 "$$$$"]]
                (:values (mt/user-http-request :rasta :get 200 (format "field/%d/values" field-id)))))
         (mt/with-gtaps {:gtaps      {:venues
-                                     {:remappings {:cat [:variable [:field-id (mt/id :venues :category_id)]]}}}
+                                     {:remappings {:cat [:variable [:field (mt/id :venues :category_id) nil]]}}}
                         :attributes {:cat 4}}
           (is (= [[1 "$"] [3 "$$$"]]
                  (:values (mt/user-http-request :rasta :get 200 (format "field/%d/values" (mt/id :venues :price)))))))))))
@@ -118,7 +118,7 @@
 (deftest search-test
   (testing "GET /api/field/:id/search/:search-id"
     (mt/with-gtaps {:gtaps      {:venues
-                                 {:remappings {:cat [:variable [:field-id (mt/id :venues :category_id)]]}
+                                 {:remappings {:cat [:variable [:field (mt/id :venues :category_id) nil]]}
                                   :query      (mt.tu/restricted-column-query (mt/id))}}
                     :attributes {:cat 50}}
       (testing (str "Searching via the query builder needs to use a GTAP when the user has segmented permissions. "
@@ -137,7 +137,7 @@
 (deftest caching-test
   (mt/with-gtaps {:gtaps
                   {:venues
-                   {:remappings {:cat [:variable [:field-id (mt/id :venues :category_id)]]}
+                   {:remappings {:cat [:variable [:field (mt/id :venues :category_id) nil]]}
                     :query      (mt.tu/restricted-column-query (mt/id))}}
                   :attributes {:cat 50}}
     (let [field (db/select-one Field :id (mt/id :venues :name))]
@@ -156,7 +156,7 @@
         (let [password (mt/random-name)]
           (mt/with-temp User [another-user {:password password}]
             (mt/with-gtaps-for-user another-user {:gtaps      {:venues
-                                                               {:remappings {:cat [:variable [:field-id (mt/id :venues :category_id)]]}
+                                                               {:remappings {:cat [:variable [:field (mt/id :venues :category_id) nil]]}
                                                                 :query      (mt.tu/restricted-column-query (mt/id))}}
                                                   :attributes {:cat 5}}
               (mt/user-http-request another-user :get 200 (str "field/" (:id field) "/values"))

--- a/enterprise/backend/test/metabase_enterprise/sandbox/api/table_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/api/table_test.clj
@@ -17,7 +17,7 @@
                   (set (map (comp str/upper-case :name) fields))
                   response)))]
       (mt/with-gtaps {:gtaps      {:venues
-                                   {:remappings {:cat [:variable [:field-id (mt/id :venues :category_id)]]}
+                                   {:remappings {:cat [:variable [:field (mt/id :venues :category_id) nil]]}
                                     :query      (mt.tu/restricted-column-query (mt/id))}}
                       :attributes {:cat 50}}
         (testing "Users with restricted access to the columns of a table should only see columns included in the GTAP question"
@@ -31,7 +31,7 @@
       (testing (str "If a GTAP has a question, but that question doesn't include a clause to restrict the columns that "
                     "are returned, all fields should be returned")
         (mt/with-gtaps {:gtaps      {:venues {:query      (mt/mbql-query venues)
-                                              :remappings {:cat [:variable [:field-id (mt/id :venues :category_id)]]}}}
+                                              :remappings {:cat [:variable [:field (mt/id :venues :category_id) nil]]}}}
                         :attributes {:cat 50}}
           (is (= all-columns
                  (field-names :rasta))))))))

--- a/modules/drivers/mongo/test/metabase/driver/mongo/query_processor_test.clj
+++ b/modules/drivers/mongo/test/metabase/driver/mongo/query_processor_test.clj
@@ -310,7 +310,7 @@
                   (qp/compile
                    (mt/mbql-query checkins
                      {:filter   [:time-interval $date -4 :month]
-                      :breakout [[:datetime-field $date :day]]}))))))))))
+                      :breakout [!day.date]}))))))))))
 
 (deftest temporal-arithmetic-test
   (testing "Mixed integer and date arithmetic works with Mongo 5+"

--- a/test/metabase/api/automagic_dashboards_test.clj
+++ b/test/metabase/api/automagic_dashboards_test.clj
@@ -59,7 +59,7 @@
 
 (deftest segment-xray-test
   (tt/with-temp Segment [{segment-id :id} {:table_id   (mt/id :venues)
-                                           :definition {:filter [:> [:field-id (mt/id :venues :price)] 10]}}]
+                                           :definition {:filter [:> [:field (mt/id :venues :price) nil] 10]}}]
     (testing "GET /api/automagic-dashboards/segment/:id"
       (is (some? (api-call "segment/%s" [segment-id]))))
 
@@ -77,7 +77,7 @@
 
 (deftest card-xray-test
   (mt/with-non-admin-groups-no-root-collection-perms
-    (let [cell-query (#'magic/encode-base64-json [:> [:field-id (mt/id :venues :price)] 5])]
+    (let [cell-query (#'magic/encode-base64-json [:> [:field (mt/id :venues :price) nil] 5])]
       (doseq [test-fn
               [(fn [collection-id card-id]
                  (testing "GET /api/automagic-dashboards/question/:id"
@@ -107,7 +107,7 @@
                (mt/mbql-query venues
                  {:filter [:> $price 10]}))
         cell-query (#'magic/encode-base64-json
-                    [:> [:field-id (mt/id :venues :price)] 5])]
+                    [:> [:field (mt/id :venues :price) nil] 5])]
     (testing "GET /api/automagic-dashboards/adhoc/:query"
       (is (some? (api-call "adhoc/%s" [query]))))
 
@@ -123,7 +123,7 @@
 (def ^:private segment
   (delay
     {:table_id   (mt/id :venues)
-     :definition {:filter [:> [:field-id (mt/id :venues :price)] 10]}}))
+     :definition {:filter [:> [:field (mt/id :venues :price) nil] 10]}}))
 
 (deftest comparisons-test
   (tt/with-temp Segment [{segment-id :id} @segment]
@@ -143,7 +143,7 @@
                      [(->> (mt/mbql-query venues
                              {:filter [:> $price 10]})
                            (#'magic/encode-base64-json))
-                      (->> [:= [:field-id (mt/id :venues :price)] 15]
+                      (->> [:= [:field (mt/id :venues :price) nil] 15]
                            (#'magic/encode-base64-json))
                       segment-id]))))))
 

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -1272,8 +1272,8 @@
             :f              (fn [{:keys [card]}]
                               (mt/user-http-request :crowberto :put 200 (str "card/" (u/the-id card))
                                                     {:dataset_query (assoc-in (mbql-count-query (mt/id) (mt/id :checkins))
-                                                                              [:query :breakout] [[:datetime-field (mt/id :checkins :date) "hour"]
-                                                                                                  [:datetime-field (mt/id :checkins :date) "minute"]])}))}
+                                                                              [:query :breakout] [[:field (mt/id :checkins :date) {:temporal-unit :hour}]
+                                                                                                  [:field (mt/id :checkins :date) {:temporal-unit :minute}]])}))}
            {:message        "Adding an additional breakout will cause the alert to be removed if a goal is set"
             :card           {:display                :line
                              :visualization_settings {:graph.goal_value 10}
@@ -1288,8 +1288,8 @@
             :f              (fn [{:keys [card]}]
                               (mt/user-http-request :crowberto :put 200 (str "card/" (u/the-id card))
                                                     {:dataset_query (assoc-in (mbql-count-query (mt/id) (mt/id :checkins))
-                                                                              [:query :breakout] [[:datetime-field (mt/id :checkins :date) "hour"]
-                                                                                                  [:datetime-field (mt/id :checkins :date) "minute"]])}))}]]
+                                                                              [:query :breakout] [[:field (mt/id :checkins :date) {:temporal-unit :hour}]
+                                                                                                  [:field (mt/id :checkins :date) {:temporal-unit :minute}]])}))}]]
     (testing message
       (mt/with-temp* [Card                  [card  card]
                       Pulse                 [pulse {:alert_condition  "rows"

--- a/test/metabase/api/preview_embed_test.clj
+++ b/test/metabase/api/preview_embed_test.clj
@@ -379,8 +379,8 @@
                                                                :parameter_mappings [{:parameter_id "_VENUE_ID_"
                                                                                      :card_id      (u/the-id card)
                                                                                      :target       [:dimension
-                                                                                                    [:field-id
-                                                                                                     (mt/id :venues :id)]]}]}}]
+                                                                                                    [:field
+                                                                                                     (mt/id :venues :id) nil]]}]}}]
             (is (= [[1]]
                    (mt/rows (mt/user-http-request :crowberto :get (str (dashcard-url dashcard {:_embedding_params {:venue_id "enabled"}})
                                                                        "?venue_id=1")))))))))))

--- a/test/metabase/api/public_test.clj
+++ b/test/metabase/api/public_test.clj
@@ -305,7 +305,7 @@
          :dataset_query {:database (mt/id)
                          :type     :query
                          :query   {:source-table (mt/id :checkins)
-                                   :breakout     [[:datetime-field [:field (mt/id :checkins :date) nil]  :month]]
+                                   :breakout     [[:field (mt/id :checkins :date) {:temporal-unit :month}]]
                                    :aggregation  [[:count]]}}))
 
 (deftest make-sure-we-include-all-the-relevant-fields-like-insights

--- a/test/metabase/api/segment_test.clj
+++ b/test/metabase/api/segment_test.clj
@@ -93,7 +93,7 @@
                                                     :caveats                 nil
                                                     :points_of_interest      nil
                                                     :table_id                id
-                                                    :definition              {:filter [:= [:field-id 10] 20]}}))))))
+                                                    :definition              {:filter [:= [:field 10 nil] 20]}}))))))
 
 
 ;; ## PUT /api/segment
@@ -153,7 +153,7 @@
                 :points_of_interest      nil
                 :table_id                456
                 :revision_message        "I got me some revisions"
-                :definition              {:filter [:!= [:field-id 2] "cans"]}})))))))
+                :definition              {:filter [:!= [:field 2 nil] "cans"]}})))))))
 
 (deftest partial-update-test
   (testing "PUT /api/segment/:id"
@@ -245,7 +245,7 @@
                     Table    [{table-id :id} {:db_id database-id}]
                     Segment  [{:keys [id]}   {:creator_id (mt/user->id :crowberto)
                                               :table_id   table-id
-                                              :definition {:filter [:= [:field-id 2] "cans"]}}]]
+                                              :definition {:filter [:= [:field 2 nil] "cans"]}}]]
       (is (= {:name                    "Toucans in the rainforest"
               :description             "Lookin' for a blueberry"
               :show_in_getting_started false
@@ -283,7 +283,7 @@
                     Segment  [{:keys [id]} {:creator_id (mt/user->id :crowberto)
                                             :table_id   table-id
                                             :definition {:database 123
-                                                         :query    {:filter [:= [:field-id 2] "cans"]}}}]
+                                                         :query    {:filter [:= [:field 2 nil] "cans"]}}}]
                     Revision [_ {:model       "Segment"
                                  :model_id    id
                                  :object      {:name       "b"
@@ -342,7 +342,7 @@
                                                  :show_in_getting_started false
                                                  :caveats                 nil
                                                  :points_of_interest      nil
-                                                 :definition              {:filter [:= [:field-id 2] "cans"]}}]
+                                                 :definition              {:filter [:= [:field 2 nil] "cans"]}}]
                     Revision [{revision-id :id} {:model       "Segment"
                                                  :model_id    id
                                                  :object      {:creator_id              (mt/user->id :crowberto)
@@ -352,7 +352,7 @@
                                                                :show_in_getting_started false
                                                                :caveats                 nil
                                                                :points_of_interest      nil
-                                                               :definition              {:filter [:= [:field-id 2] "cans"]}}
+                                                               :definition              {:filter [:= [:field 2 nil] "cans"]}}
                                                  :is_creation true}]
                     Revision [_                 {:model    "Segment"
                                                  :model_id id
@@ -364,7 +364,7 @@
                                                             :show_in_getting_started false
                                                             :caveats                 nil
                                                             :points_of_interest      nil
-                                                            :definition              {:filter [:= [:field-id 2] "cans"]}}
+                                                            :definition              {:filter [:= [:field 2 nil] "cans"]}}
                                                  :message  "updated"}]]
       (testing "the api response"
         (is (= {:is_reversion true

--- a/test/metabase/automagic_dashboards/core_test.clj
+++ b/test/metabase/automagic_dashboards/core_test.clj
@@ -288,7 +288,7 @@
   (mt/with-test-user :rasta
     (automagic-dashboards.test/with-dashboard-cleanup
       (let [q (query/adhoc-query {:query {:aggregation [[:count]]
-                                          :breakout [[:fk-> (mt/id :checkins) (mt/id :venues :category_id)]]
+                                          :breakout [[:field (mt/id :venues :category_id) {:source-field (mt/id :checkins)}]]
                                           :source-table (mt/id :checkins)}
                                   :type :query
                                   :database (mt/id)})]

--- a/test/metabase/driver/postgres_test.clj
+++ b/test/metabase/driver/postgres_test.clj
@@ -736,7 +736,7 @@
                         {:database (u/the-id db)
                          :type     :query
                          :query    {:source-table table-id
-                                    :filter       [:= [:field-id (u/the-id bird-type-field-id)] "toucan"]
+                                    :filter       [:= [:field (u/the-id bird-type-field-id) nil] "toucan"]
                                     :limit        10}})
                        :data
                        (select-keys [:rows :native_form]))))))))))

--- a/test/metabase/models/card_test.clj
+++ b/test/metabase/models/card_test.clj
@@ -333,7 +333,7 @@
            (mt/with-temp Card [_ {:parameter_mappings {:a :b}}])))
 
      (mt/with-temp Card [card {:parameter_mappings [{:parameter_id "valid-id"
-                                                     :target       [:field-id 1000]}]}]
+                                                     :target       [:field 1000 nil]}]}]
        (is (some? card))))
 
     (testing "updating"
@@ -344,7 +344,7 @@
              (db/update! Card id :parameter_mappings [{:parameter_id 100}])))
 
         (is (some? (db/update! Card id :parameter_mappings [{:parameter_id "new-valid-id"
-                                                             :target       [:field-id 1000]}])))))))
+                                                             :target       [:field 1000 nil]}])))))))
 
 (deftest normalize-parameter-mappings-test
   (testing ":parameter_mappings should get normalized when coming out of the DB"

--- a/test/metabase/models/on_demand_test.clj
+++ b/test/metabase/models/on_demand_test.clj
@@ -160,7 +160,7 @@
 
 (defn- parameter-mappings-for-card-and-field [card-or-id field-or-id]
   [{:card_id (u/the-id card-or-id)
-    :target  [:dimension [:field-id (u/the-id field-or-id)]]}])
+    :target  [:dimension [:field (u/the-id field-or-id) nil]]}])
 
 (defn- add-dashcard-with-parameter-mapping! [dashboard-or-id card-or-id field-or-id]
   (dashboard/add-dashcard! dashboard-or-id card-or-id

--- a/test/metabase/models/query/permissions_test.clj
+++ b/test/metabase/models/query/permissions_test.clj
@@ -116,7 +116,7 @@
   (is (= #{(perms/table-query-path (mt/id) "PUBLIC" (mt/id :venues))}
          (query-perms/perms-set
           {:query    {:source-table (mt/id :venues)
-                      :filter       [:> [:field-id (mt/id :venues :id)] 10]}
+                      :filter       [:> [:field (mt/id :venues :id) nil] 10]}
            :type     :query
            :database (mt/id)})))
 

--- a/test/metabase/models/query/permissions_test.clj
+++ b/test/metabase/models/query/permissions_test.clj
@@ -187,7 +187,7 @@
                               {:database (mt/id)
                                :type     :query
                                :query    {:source-table (mt/id :checkins)
-                                          :order-by     [[:asc [:fk-> (mt/id :checkins :user_id) (mt/id :users :id)]]]}}}]
+                                          :order-by     [[:asc [:field (mt/id :users :id) {:source-field (mt/id :checkins :user_id)}]]]}}}]
       (is (= #{"/collection/root/read/"}
              (query-perms/perms-set
               (query-with-source-card card)))))))

--- a/test/metabase/pulse/render/body_test.clj
+++ b/test/metabase/pulse/render/body_test.clj
@@ -122,7 +122,7 @@
                     :base_type       :type/DateTime
                     :semantic_type    nil
                     :visibility_type :normal
-                    :field_ref       [:field-id 321]}
+                    :field_ref       [:field 321 nil]}
                    {:name            "name"
                     :display_name    "Name"
                     :base_type       :type/Text

--- a/test/metabase/pulse_test.clj
+++ b/test/metabase/pulse_test.clj
@@ -315,7 +315,7 @@
   (testing "card with CSV and XLS attachments, but no data. Should not include an attachment"
     (do-test
      {:card       (pulse.test-util/checkins-query-card {:filter   [:> $date "2017-10-24"]
-                                        :breakout [!day.date]})
+                                                        :breakout [!day.date]})
       :pulse      {:skip_if_empty false}
       :pulse-card {:include_csv true
                    :include_xls true}
@@ -410,7 +410,7 @@
 (deftest empty-results-test
   (testing "Pulse where the card has no results"
     (tests {:card (pulse.test-util/checkins-query-card {:filter   [:> $date "2017-10-24"]
-                                        :breakout [!day.date]})}
+                                                        :breakout [!day.date]})}
       "skip if empty = false"
       {:pulse    {:skip_if_empty false}
        :assert {:email (fn [_ _]
@@ -456,7 +456,7 @@
       "with no data"
       {:card
        (pulse.test-util/checkins-query-card {:filter   [:> $date "2017-10-24"]
-                             :breakout [!day.date]})
+                                             :breakout [!day.date]})
        :assert
        {:email
         (fn [_ _]
@@ -519,7 +519,7 @@
     "first run alert with no data"
     {:card
      (pulse.test-util/checkins-query-card {:filter   [:> $date "2017-10-24"]
-                           :breakout [!day.date]})
+                                           :breakout [!day.date]})
 
      :assert
      {:email
@@ -538,7 +538,7 @@
       "with data"
       {:card
        (merge (pulse.test-util/checkins-query-card {:filter   [:between $date "2014-04-01" "2014-06-01"]
-                                    :breakout [!day.date]})
+                                                    :breakout [!day.date]})
               {:display                :line
                :visualization_settings {:graph.show_goal true :graph.goal_value 5.9}})
 
@@ -552,7 +552,7 @@
       "no data"
       {:card
        (merge (pulse.test-util/checkins-query-card {:filter   [:between $date "2014-02-01" "2014-04-01"]
-                                    :breakout [!day.date]})
+                                                    :breakout [!day.date]})
               {:display                :area
                :visualization_settings {:graph.show_goal true :graph.goal_value 5.9}})
 
@@ -584,7 +584,7 @@
       "with data"
       {:card
        (pulse.test-util/checkins-query-card {:filter   [:between $date "2014-02-12" "2014-02-17"]
-                             :breakout [!day.date]})
+                                             :breakout [!day.date]})
        :display :line
 
        :assert
@@ -597,7 +597,7 @@
       "with no satisfying data"
       {:card
        (pulse.test-util/checkins-query-card {:filter   [:between $date "2014-02-10" "2014-02-12"]
-                             :breakout [!day.date]})
+                                             :breakout [!day.date]})
        :display :bar
 
        :assert
@@ -679,7 +679,7 @@
 (deftest basic-slack-test-2
   (testing "Basic slack test, 2 cards, 1 recipient channel"
     (mt/with-temp* [Card         [{card-id-1 :id} (pulse.test-util/checkins-query-card {:breakout [!day.date]})]
-                    Card         [{card-id-2 :id} (-> {:breakout [[:datetime-field (mt/id :checkins :date) "minute"]]}
+                    Card         [{card-id-2 :id} (-> {:breakout [[:field (mt/id :checkins :date) {:temporal-unit :month}]]}
                                                       pulse.test-util/checkins-query-card
                                                       (assoc :name "Test card 2"))]
                     Pulse        [{pulse-id :id}  {:name          "Pulse Name"

--- a/test/metabase/query_processor/middleware/cache_test.clj
+++ b/test/metabase/query_processor/middleware/cache_test.clj
@@ -362,7 +362,7 @@
   (testing "Insights should work on cahced results (#12556)"
     (with-mock-cache [save-chan]
       (let [query (-> checkins
-                      (mt/mbql-query {:breakout    [[:datetime-field (mt/id :checkins :date) :month]]
+                      (mt/mbql-query {:breakout    [!month.date]
                                       :aggregation [[:count]]})
                       (assoc :cache-ttl 100))]
         (qp/process-query query)

--- a/test/metabase/query_processor/pivot_test.clj
+++ b/test/metabase/query_processor/pivot_test.clj
@@ -189,7 +189,7 @@
             {:database (mt/id)
              :type     :query
              :query    {:source-table (mt/id table)
-                        :breakout     [[:field-id (mt/id table col)]]}})))
+                        :breakout     [[:field (mt/id table col) nil]]}})))
        (map first)
        set))
 

--- a/test/metabase/query_processor/reducible_test.clj
+++ b/test/metabase/query_processor/reducible_test.clj
@@ -177,7 +177,7 @@
                          {:database (mt/id)
                           :type     :query
                           :query    {:source-table (mt/id :venues)
-                                     :fields       [[:field-id (mt/id :venues :id)]]}}
+                                     :fields       [[:field (mt/id :venues :id) nil]]}}
                          additional-options)
                         rows)))]
               (is (= [[1]

--- a/test/metabase/query_processor_test/aggregation_test.clj
+++ b/test/metabase/query_processor_test/aggregation_test.clj
@@ -250,7 +250,7 @@
   (testing "Does `:settings` show up for aggregate Fields?"
     (tu/with-temp-vals-in-db Field (data/id :venues :price) {:settings {:is_priceless false}}
       (let [results (mt/run-mbql-query venues
-                      {:aggregation [[:sum [:field-id $price]]]})]
+                      {:aggregation [[:sum $price]]})]
         (is (= (assoc (qp.test/aggregate-col :sum :venues :price)
                       :settings {:is_priceless false})
                (or (-> results mt/cols first)

--- a/test/metabase/query_processor_test/alternative_date_test.clj
+++ b/test/metabase/query_processor_test/alternative_date_test.clj
@@ -46,7 +46,7 @@
   (mt/test-drivers (mt/normal-drivers)
     (mt/dataset sad-toucan-incidents
       (let [query (mt/mbql-query incidents
-                     {:filter   [:= [:datetime-field $timestamp :day] "2015-06-02"]
+                     {:filter   [:= !day.timestamp "2015-06-02"]
                       :order-by [[:asc $timestamp]]})]
         ;; There's a race condition with this test. If we happen to grab a connection that is in a session with the
         ;; timezone set to pacific, we'll get 9 results even when the above if statement is true. It seems to be pretty
@@ -233,13 +233,13 @@
           (is (= 1
                  (count (mt/rows (mt/dataset string-times
                                    (mt/run-mbql-query times
-                                     {:filter   [:= [:datetime-field $ts :day] "2008-10-19"]}))))))))
+                                     {:filter   [:= !day.ts "2008-10-19"]}))))))))
       (testing "a date field"
         (mt/test-drivers (disj (sql-jdbc.tu/sql-jdbc-drivers) :oracle :sparksql)
           (is (= 1
                  (count (mt/rows (mt/dataset string-times
                                    (mt/run-mbql-query times
-                                     {:filter   [:= [:datetime-field $d :day] "2008-10-19"]})))))))))))
+                                     {:filter   [:= !day.d "2008-10-19"]})))))))))))
 
 (mt/defdataset yyyymmddhhss-times
   [["times" [{:field-name "name"

--- a/test/metabase/query_processor_test/count_where_test.clj
+++ b/test/metabase/query_processor_test/count_where_test.clj
@@ -7,7 +7,7 @@
 (deftest basic-test
   (mt/test-drivers (mt/normal-drivers-with-feature :basic-aggregations)
     (is (= 94
-           (->> {:aggregation [[:count-where [:< [:field-id (mt/id :venues :price)] 4]]]}
+           (->> {:aggregation [[:count-where [:< [:field (mt/id :venues :price) nil] 4]]]}
                 (mt/run-mbql-query venues)
                 mt/rows
                 ffirst
@@ -25,10 +25,10 @@
     (is (= 17
            (->> {:aggregation [[:count-where
                                 [:and
-                                 [:< [:field-id (mt/id :venues :price)] 4]
+                                 [:< [:field (mt/id :venues :price) nil] 4]
                                  [:or
-                                  [:starts-with [:field-id (mt/id :venues :name)] "M"]
-                                  [:ends-with [:field-id (mt/id :venues :name)] "t"]]]]]}
+                                  [:starts-with [:field (mt/id :venues :name) nil] "M"]
+                                  [:ends-with [:field (mt/id :venues :name) nil] "t"]]]]]}
                 (mt/run-mbql-query venues)
                 mt/rows
                 ffirst
@@ -37,8 +37,8 @@
 (deftest filter-test
   (mt/test-drivers (mt/normal-drivers-with-feature :basic-aggregations)
     (is (= nil
-           (->> {:aggregation [[:count-where [:< [:field-id (mt/id :venues :price)] 4]]]
-                 :filter      [:> [:field-id (mt/id :venues :price)] Long/MAX_VALUE]}
+           (->> {:aggregation [[:count-where [:< [:field (mt/id :venues :price) nil] 4]]]
+                 :filter      [:> [:field (mt/id :venues :price) nil] Long/MAX_VALUE]}
                 (mt/run-mbql-query venues)
                 mt/rows
                 ffirst)))))
@@ -49,8 +49,8 @@
             [3 0]
             [4 1]
             [5 1]]
-           (->> {:aggregation [[:count-where [:< [:field-id (mt/id :venues :price)] 2]]]
-                 :breakout    [[:field-id (mt/id :venues :category_id)]]
+           (->> {:aggregation [[:count-where [:< [:field (mt/id :venues :price) nil] 2]]]
+                 :breakout    [[:field (mt/id :venues :category_id) nil]]
                  :limit       4}
                 (mt/run-mbql-query venues)
                 (mt/round-all-decimals 2)
@@ -63,7 +63,7 @@
     (is (= 48
            (->> {:aggregation [[:+
                                 [:/
-                                 [:count-where [:< [:field-id (mt/id :venues :price)] 4]]
+                                 [:count-where [:< [:field (mt/id :venues :price) nil] 4]]
                                  2]
                                 1]]}
                 (mt/run-mbql-query venues)
@@ -75,7 +75,7 @@
   (mt/test-drivers (mt/normal-drivers-with-feature :basic-aggregations)
     (mt/with-temp Segment [{segment-id :id} {:table_id   (mt/id :venues)
                                              :definition {:source-table (mt/id :venues)
-                                                          :filter       [:< [:field-id (mt/id :venues :price)] 4]}}]
+                                                          :filter       [:< [:field (mt/id :venues :price) nil] 4]}}]
       (is (= 94
              (->> {:aggregation [[:count-where [:segment segment-id]]]}
                   (mt/run-mbql-query venues)
@@ -88,7 +88,7 @@
     (mt/with-temp Metric [{metric-id :id} {:table_id   (mt/id :venues)
                                            :definition {:source-table (mt/id :venues)
                                                         :aggregation  [:count-where
-                                                                       [:< [:field-id (mt/id :venues :price)] 4]]}}]
+                                                                       [:< [:field (mt/id :venues :price) nil] 4]]}}]
       (is (= 94
              (->> {:aggregation [[:metric metric-id]]}
                   (mt/run-mbql-query venues)

--- a/test/metabase/query_processor_test/date_bucketing_test.clj
+++ b/test/metabase/query_processor_test/date_bucketing_test.clj
@@ -1113,7 +1113,7 @@
                (qp/compile
                 (mt/mbql-query checkins
                   {:filter   [:time-interval $date -4 :month]
-                   :breakout [[:datetime-field $date :day]]})))))))))
+                   :breakout [!day.date]})))))))))
 
 (deftest field-filter-start-of-week-test
   (testing "Field Filters with relative date ranges should respect the custom start of week setting (#14294)"

--- a/test/metabase/query_processor_test/explicit_joins_test.clj
+++ b/test/metabase/query_processor_test/explicit_joins_test.clj
@@ -167,7 +167,7 @@
                                   :condition    [:= $flock_id &f.flock.id]
                                   :alias        "f"
                                   :fields       :all}]
-                      :order-by [[:asc [:field-id $name]]]})))))))))
+                      :order-by [[:asc $name]]})))))))))
 
 (deftest include-no-fields-test
   (mt/test-drivers (mt/normal-drivers-with-feature :left-join)
@@ -199,7 +199,7 @@
                                   :condition    [:= $flock_id &f.flock.id]
                                   :alias        "f"
                                   :fields       :none}]
-                      :order-by [[:asc [:field-id $name]]]})))))))))
+                      :order-by [[:asc $name]]})))))))))
 
 (deftest specific-fields-test
   (mt/test-drivers (mt/normal-drivers-with-feature :left-join)
@@ -213,7 +213,7 @@
                                                         :condition    [:= $flock_id &f.flock.id]
                                                         :alias        "f"
                                                         :fields       [&f.flock.name]}]
-                                            :order-by [[:asc [:field-id $name]]]}))))]
+                                            :order-by [[:asc $name]]}))))]
         (is (= (mapv mt/format-name ["id" "name" "name_2"])
                columns))
         (is (= [[2  "Big Red"         "Bayview Brood"]

--- a/test/metabase/query_processor_test/expression_aggregations_test.clj
+++ b/test/metabase/query_processor_test/expression_aggregations_test.clj
@@ -202,20 +202,20 @@
   (mt/test-drivers (mt/normal-drivers-with-feature :expression-aggregations)
     (testing "check that we can handle Metrics inside expression aggregation clauses"
       (mt/with-temp Metric [metric {:table_id   (mt/id :venues)
-                                    :definition {:aggregation [:sum [:field-id (mt/id :venues :price)]]
-                                                 :filter      [:> [:field-id (mt/id :venues :price)] 1]}}]
+                                    :definition {:aggregation [:sum [:field (mt/id :venues :price) nil]]
+                                                 :filter      [:> [:field (mt/id :venues :price) nil] 1]}}]
         (is (= [[2 119]
                 [3  40]
                 [4  25]]
                (mt/formatted-rows [int int]
                  (mt/run-mbql-query venues
                    {:aggregation [:+ [:metric (u/the-id metric)] 1]
-                    :breakout    [[:field-id $price]]}))))))
+                    :breakout    [$price]}))))))
 
     (testing "check that we can handle Metrics inside an `:aggregation-options` clause"
       (mt/with-temp Metric [metric {:table_id   (mt/id :venues)
-                                    :definition {:aggregation [:sum [:field-id (mt/id :venues :price)]]
-                                                 :filter      [:> [:field-id (mt/id :venues :price)] 1]}}]
+                                    :definition {:aggregation [:sum [:field (mt/id :venues :price) nil]]
+                                                 :filter      [:> [:field (mt/id :venues :price) nil] 1]}}]
         (is (= {:rows    [[2 118]
                           [3  39]
                           [4  24]]
@@ -225,7 +225,7 @@
                  (mt/rows+column-names
                    (mt/run-mbql-query venues
                      {:aggregation [[:aggregation-options [:metric (u/the-id metric)] {:name "auto_generated_name"}]]
-                      :breakout    [[:field-id $price]]})))))))
+                      :breakout    [$price]})))))))
 
     (testing "check that Metrics with a nested aggregation still work inside an `:aggregation-options` clause"
       (mt/with-temp Metric [metric (mt/$ids venues
@@ -241,7 +241,7 @@
                  (mt/rows+column-names
                    (mt/run-mbql-query venues
                      {:aggregation [[:aggregation-options [:metric (u/the-id metric)] {:name "auto_generated_name"}]]
-                      :breakout    [[:field-id $price]]})))))))))
+                      :breakout    [$price]})))))))))
 
 (deftest named-aggregations-metadata-test
   (mt/test-drivers (mt/normal-drivers-with-feature :expression-aggregations)

--- a/test/metabase/query_processor_test/expression_aggregations_test.clj
+++ b/test/metabase/query_processor_test/expression_aggregations_test.clj
@@ -155,7 +155,7 @@
              (mt/formatted-rows [int int]
                (mt/run-mbql-query users
                  {:aggregation [[:* [:count] 2]]
-                  :breakout    [[:datetime-field $last_login :month-of-year]]
+                  :breakout    [!month-of-year.last_login]
                   :order-by    [[:asc [:aggregation 0]]]})))))))
 
 (deftest math-inside-the-aggregation-test

--- a/test/metabase/query_processor_test/expressions_test.clj
+++ b/test/metabase/query_processor_test/expressions_test.clj
@@ -431,8 +431,8 @@
         (let [r-word  "r_word"
               no-sp   "no_spaces"
               results (mt/run-mbql-query venues
-                        {:expressions  {r-word [:regex-match-first [:field-id (mt/id :venues :name)] "^R[^ ]+"]
-                                        no-sp  [:replace [:field-id (mt/id :venues :name)] " " ""]}
+                        {:expressions  {r-word [:regex-match-first $name "^R[^ ]+"]
+                                        no-sp  [:replace $name " " ""]}
                          :source-query {:source-table $$venues}
                          :fields       [$name [:expression r-word] [:expression no-sp]]
                          :filter       [:= $id 1 95]

--- a/test/metabase/query_processor_test/filter_test.clj
+++ b/test/metabase/query_processor_test/filter_test.clj
@@ -110,7 +110,7 @@
                (mt/format-rows-by [int]
                  (mt/run-mbql-query checkins
                    {:aggregation [[:count]]
-                    :filter      [:between [:datetime-field $date :day] "2015-04-01" "2015-05-01"]}))))))))
+                    :filter      [:between !day.date "2015-04-01" "2015-05-01"]}))))))))
 
 (defn- mongo-major-version [db]
   (when (= driver/*driver* :mongo)
@@ -490,12 +490,12 @@
       (testing "make sure that filtering with timestamps truncating to minutes works (#4632)"
         (is (= 4
                (count-with-filter-clause checkins [:between
-                                                   [:datetime-field $timestamp :minute]
+                                                   !minute.timestamp
                                                    "2019-01-01T12:30:00"
                                                    "2019-01-14"])))))
     (testing "make sure that filtering with dates bucketing by weeks works (#4956)"
       (is (= 7
-             (count-with-filter-clause checkins [:= [:datetime-field $date :week] "2015-06-21T07:00:00.000000000-00:00"]))))))
+             (count-with-filter-clause checkins [:= !week.date "2015-06-21T07:00:00.000000000-00:00"]))))))
 
 (deftest string-escape-test
   ;; test `:sql` drivers that support native parameters

--- a/test/metabase/query_processor_test/share_test.clj
+++ b/test/metabase/query_processor_test/share_test.clj
@@ -25,7 +25,7 @@
                (mt/run-mbql-query venues
                  {:aggregation [[:share
                                  [:and
-                                  [:< [:field-id $price] 4]
+                                  [:< $price 4]
                                   [:or
                                    [:starts-with $name "M"]
                                    [:ends-with $name "t"]]]]]})))))
@@ -45,7 +45,7 @@
     (testing "Share containing a Segment"
       (mt/with-temp Segment [{segment-id :id} {:table_id   (mt/id :venues)
                                                :definition {:source-table (mt/id :venues)
-                                                            :filter       [:< [:field-id (mt/id :venues :price)] 4]}}]
+                                                            :filter       [:< [:field (mt/id :venues :price) nil] 4]}}]
         (is (= [[0.94]]
                (mt/formatted-rows [2.0]
                  (mt/run-mbql-query venues
@@ -54,7 +54,7 @@
     (testing "Share inside a Metric"
       (mt/with-temp Metric [{metric-id :id} {:table_id   (mt/id :venues)
                                              :definition {:source-table (mt/id :venues)
-                                                          :aggregation  [:share [:< [:field-id (mt/id :venues :price)] 4]]}}]
+                                                          :aggregation  [:share [:< [:field (mt/id :venues :price) nil] 4]]}}]
         (is (= [[0.94]]
                (mt/formatted-rows [2.0]
                  (mt/run-mbql-query venues
@@ -69,12 +69,12 @@
               [5 0.14]]
              (mt/formatted-rows [int 2.0]
                (mt/run-mbql-query venues
-                 {:aggregation [[:share [:< [:field-id (mt/id :venues :price)] 2]]]
-                  :breakout    [[:field-id (mt/id :venues :category_id)]]
+                 {:aggregation [[:share [:< $price 2]]]
+                  :breakout    [[:field $category_id nil]]
                   :limit       4})))))
 
     (testing "Share inside an expression"
       (is (= [[1.47]]
              (mt/formatted-rows [2.0]
                (mt/run-mbql-query venues
-                 {:aggregation [[:+ [:/ [:share [:< [:field-id (mt/id :venues :price)] 4]] 2] 1]]})))))))
+                 {:aggregation [[:+ [:/ [:share [:< $price 4]] 2] 1]]})))))))

--- a/test/metabase/query_processor_test/string_extracts_test.clj
+++ b/test/metabase/query_processor_test/string_extracts_test.clj
@@ -11,7 +11,7 @@
         ;; filter clause is optional
         :filter      filter
         ;; To ensure stable ordering
-        :order-by    [[:asc [:field-id (data/id :venues :id)]]]
+        :order-by    [[:asc [:field (data/id :venues :id) nil]]]
         :limit       1}
        (mt/run-mbql-query venues)
        mt/rows
@@ -35,22 +35,22 @@
 
 (deftest test-upper
   (mt/test-drivers (mt/normal-drivers-with-feature :expressions)
-    (is (= "RED MEDICINE" (test-string-extract [:upper [:field-id (data/id :venues :name)]])))))
+    (is (= "RED MEDICINE" (test-string-extract [:upper [:field (data/id :venues :name) nil]])))))
 
 (deftest test-lower
   (mt/test-drivers (mt/normal-drivers-with-feature :expressions)
-    (is (= "red medicine" (test-string-extract [:lower [:field-id (data/id :venues :name)]])))))
+    (is (= "red medicine" (test-string-extract [:lower [:field (data/id :venues :name) nil]])))))
 
 (deftest test-substring
   (mt/test-drivers (mt/normal-drivers-with-feature :expressions)
-    (is (= "Red" (test-string-extract [:substring [:field-id (data/id :venues :name)] 1 3])))
-    (is (= "ed Medicine" (test-string-extract [:substring [:field-id (data/id :venues :name)] 2])))
-    (is (= "Red Medicin" (test-string-extract [:substring [:field-id (data/id :venues :name)]
-                                               1 [:- [:length [:field-id (data/id :venues :name)]] 1]])))))
+    (is (= "Red" (test-string-extract [:substring [:field (data/id :venues :name) nil] 1 3])))
+    (is (= "ed Medicine" (test-string-extract [:substring [:field (data/id :venues :name) nil] 2])))
+    (is (= "Red Medicin" (test-string-extract [:substring [:field (data/id :venues :name) nil]
+                                               1 [:- [:length [:field (data/id :venues :name) nil]] 1]])))))
 
 (deftest test-replace
   (mt/test-drivers (mt/normal-drivers-with-feature :expressions)
-    (is (= "Red Baloon" (test-string-extract [:replace [:field-id (data/id :venues :name)] "Medicine" "Baloon"])))))
+    (is (= "Red Baloon" (test-string-extract [:replace [:field (data/id :venues :name) nil] "Medicine" "Baloon"])))))
 
 (deftest test-coalesce
   (mt/test-drivers (mt/normal-drivers-with-feature :expressions)
@@ -64,16 +64,16 @@
 
 (deftest test-regex-match-first
   (mt/test-drivers (mt/normal-drivers-with-feature :expressions :regex)
-    (is (= "Red" (test-string-extract [:regex-match-first [:field-id (data/id :venues :name)] "(.ed+)"])))))
+    (is (= "Red" (test-string-extract [:regex-match-first [:field (data/id :venues :name) nil] "(.ed+)"])))))
 
 (deftest test-nesting
   (mt/test-drivers (mt/normal-drivers-with-feature :expressions)
-    (is (= "MED" (test-string-extract [:upper [:substring [:trim [:substring [:field-id (data/id :venues :name)] 4]] 1 3]])))))
+    (is (= "MED" (test-string-extract [:upper [:substring [:trim [:substring [:field (data/id :venues :name) nil] 4]] 1 3]])))))
 
 (deftest test-breakout
   (mt/test-drivers (mt/normal-drivers-with-feature :expressions)
     (is (= ["20th Century Cafefoo" 1]
-           (->> {:expressions  {"test" [:concat [:field-id (data/id :venues :name)] "foo"]}
+           (->> {:expressions  {"test" [:concat [:field (data/id :venues :name) nil] "foo"]}
                  :breakout     [[:expression "test"]]
                  :aggregation  [[:count]]
                  :limit        1}
@@ -85,15 +85,15 @@
   (mt/test-drivers
     (mt/normal-drivers-with-feature :expressions)
     (is (= "Larry's The Prime Rib" (test-string-extract
-                                    [:replace [:field-id (data/id :venues :name)] "Lawry's" "Larry's"]
-                                    [:= [:field-id (data/id :venues :name)] "Lawry's The Prime Rib"])))))
+                                    [:replace [:field (data/id :venues :name) nil] "Lawry's" "Larry's"]
+                                    [:= [:field (data/id :venues :name) nil] "Lawry's The Prime Rib"])))))
 
 (deftest regex-match-first-escaping-test
   (mt/test-drivers
     (mt/normal-drivers-with-feature :expressions :regex)
     (is (= "Taylor's" (test-string-extract
-                       [:regex-match-first [:field-id (data/id :venues :name)] "^Taylor's"]
-                       [:= [:field-id (data/id :venues :name)] "Taylor's Prime Steak House"])))))
+                       [:regex-match-first [:field (data/id :venues :name) nil] "^Taylor's"]
+                       [:= [:field (data/id :venues :name) nil] "Taylor's Prime Steak House"])))))
 
 (deftest regex-extract-in-explict-join-test
   (testing "Should be able to use regex extra in an explict join (#17790)"

--- a/test/metabase/query_processor_test/sum_where_test.clj
+++ b/test/metabase/query_processor_test/sum_where_test.clj
@@ -8,8 +8,8 @@
   (mt/test-drivers (mt/normal-drivers-with-feature :basic-aggregations)
     (is (= 179.0
            (->> {:aggregation [[:sum-where
-                                [:field-id (mt/id :venues :price)]
-                                [:< [:field-id (mt/id :venues :price)] 4]]]}
+                                [:field (mt/id :venues :price) nil]
+                                [:< [:field (mt/id :venues :price) nil] 4]]]}
                 (mt/run-mbql-query venues)
                 mt/rows
                 ffirst
@@ -18,8 +18,8 @@
     (testing "Should get normalized correctly and work as expected"
       (is (= 179.0
              (->> {:aggregation [["sum-where"
-                                  ["field-id" (mt/id :venues :price)]
-                                  ["<" ["field-id" (mt/id :venues :price)] 4]]]}
+                                  ["field" (mt/id :venues :price) nil]
+                                  ["<" ["field" (mt/id :venues :price) nil] 4]]]}
                   (mt/run-mbql-query venues)
                   mt/rows
                   ffirst
@@ -29,10 +29,10 @@
   (mt/test-drivers (mt/normal-drivers-with-feature :basic-aggregations)
     (is (= 34.0
            (->> {:aggregation [[:sum-where
-                                [:field-id (mt/id :venues :price)]
-                                [:and [:< [:field-id (mt/id :venues :price)] 4]
-                                 [:or [:starts-with [:field-id (mt/id :venues :name)] "M"]
-                                  [:ends-with [:field-id (mt/id :venues :name)] "t"]]]]]}
+                                [:field (mt/id :venues :price) nil]
+                                [:and [:< [:field (mt/id :venues :price) nil] 4]
+                                 [:or [:starts-with [:field (mt/id :venues :name) nil] "M"]
+                                  [:ends-with [:field (mt/id :venues :name) nil] "t"]]]]]}
                 (mt/run-mbql-query venues)
                 mt/rows
                 ffirst
@@ -41,8 +41,8 @@
 (deftest filter-test
   (mt/test-drivers (mt/normal-drivers-with-feature :basic-aggregations)
     (is (= nil
-           (->> {:aggregation [[:sum-where [:field-id (mt/id :venues :price)] [:< [:field-id (mt/id :venues :price)] 4]]]
-                 :filter      [:> [:field-id (mt/id :venues :price)] Long/MAX_VALUE]}
+           (->> {:aggregation [[:sum-where [:field (mt/id :venues :price) nil] [:< [:field (mt/id :venues :price) nil] 4]]]
+                 :filter      [:> [:field (mt/id :venues :price) nil] Long/MAX_VALUE]}
                 (mt/run-mbql-query venues)
                 mt/rows
                 ffirst)))))
@@ -54,9 +54,9 @@
             [4 1.0]
             [5 1.0]]
            (->> {:aggregation [[:sum-where
-                                [:field-id (mt/id :venues :price)]
-                                [:< [:field-id (mt/id :venues :price)] 2]]]
-                 :breakout    [[:field-id (mt/id :venues :category_id)]]
+                                [:field (mt/id :venues :price) nil]
+                                [:< [:field (mt/id :venues :price) nil] 2]]]
+                 :breakout    [[:field (mt/id :venues :category_id) nil]]
                  :limit       4}
                 (mt/run-mbql-query venues)
                 (mt/round-all-decimals 2)
@@ -70,8 +70,8 @@
            (->> {:aggregation [[:+
                                 [:/
                                  [:sum-where
-                                  [:field-id (mt/id :venues :price)]
-                                  [:< [:field-id (mt/id :venues :price)] 4]]
+                                  [:field (mt/id :venues :price) nil]
+                                  [:< [:field (mt/id :venues :price) nil] 4]]
                                  2]
                                 1]]}
                 (mt/run-mbql-query venues)
@@ -83,9 +83,9 @@
   (mt/test-drivers (mt/normal-drivers-with-feature :basic-aggregations)
     (mt/with-temp Segment [{segment-id :id} {:table_id   (mt/id :venues)
                                              :definition {:source-table (mt/id :venues)
-                                                          :filter       [:< [:field-id (mt/id :venues :price)] 4]}}]
+                                                          :filter       [:< [:field (mt/id :venues :price) nil] 4]}}]
       (is (= 179.0
-             (->> {:aggregation [[:sum-where [:field-id (mt/id :venues :price)] [:segment segment-id]]]}
+             (->> {:aggregation [[:sum-where [:field (mt/id :venues :price) nil] [:segment segment-id]]]}
                   (mt/run-mbql-query venues)
                   mt/rows
                   ffirst
@@ -96,8 +96,8 @@
     (mt/with-temp Metric [{metric-id :id} {:table_id   (mt/id :venues)
                                            :definition {:source-table (mt/id :venues)
                                                         :aggregation  [:sum-where
-                                                                       [:field-id (mt/id :venues :price)]
-                                                                       [:< [:field-id (mt/id :venues :price)] 4]]}}]
+                                                                       [:field (mt/id :venues :price) nil]
+                                                                       [:< [:field (mt/id :venues :price) nil] 4]]}}]
       (is (= 179.0
              (->> {:aggregation [[:metric metric-id]]}
                   (mt/run-mbql-query venues)

--- a/test/metabase/related_test.clj
+++ b/test/metabase/related_test.clj
@@ -12,7 +12,7 @@
 (deftest collect-context-bearing-forms-test
   (is (= #{[:field 1 nil] [:metric 1] [:field 2 nil] [:segment 1]}
          (#'related/collect-context-bearing-forms [[:> [:field 1 nil] 3]
-                                                   ["and" [:= ["FIELD-ID" 2] 2]
+                                                   ["and" [:= ["field" 2 nil] 2]
                                                     ["segment" 1]]
                                                    [:metric 1]]))))
 

--- a/test/metabase/timeseries_query_processor_test.clj
+++ b/test/metabase/timeseries_query_processor_test.clj
@@ -784,6 +784,6 @@
              (mt/formatted-rows [str 1.0]
                (mt/run-mbql-query checkins
                  {:aggregation [[:avg $venue_price]]
-                  :breakout    [[:field-id $venue_category_name]]
+                  :breakout    [[:field $venue_category_name nil]]
                   :order-by    [[:desc [:aggregation 0]]]
                   :limit       4})))))))

--- a/test/metabase/transforms/core_test.clj
+++ b/test/metabase/transforms/core_test.clj
@@ -29,8 +29,8 @@
 
 (deftest add-bindings-test
   (testing "Can we accure bindings?"
-    (let [new-bindings {"D2" [:sum [:field-id 4]]
-                        "D3" [:field-id 5]}]
+    (let [new-bindings {"D2" [:sum [:field 4 nil]]
+                        "D3" [:field 5 nil]}]
       (is (= (update-in @test-bindings ["Venues" :dimensions] merge new-bindings)
              (#'tf/add-bindings @test-bindings "Venues" new-bindings)))))
 
@@ -79,7 +79,7 @@
     (with-test-transform-specs
       (is (= [(mt/id :venues)]
              (map u/the-id (#'tf/resulting-entities {"VenuesEnhanced" {:entity     (db/select-one Table :id (mt/id :venues))
-                                                                       :dimensions {"D1" [:field-id 1]}}}
+                                                                       :dimensions {"D1" [:field 1 nil]}}}
                                                     (first @tf.specs/transform-specs))))))))
 
 (deftest tables-matching-requirements-test
@@ -105,14 +105,14 @@
                                                                    {:result_metadata [{:name "AvgPrice"}
                                                                                       {:name "MaxPrice"}
                                                                                       {:name "MinPrice"}]})
-                                                      :dimensions {"D1" [:field-id 1]}}}
+                                                      :dimensions {"D1" [:field 1 nil]}}}
                                    (first @tf.specs/transform-specs))))
 
       (testing "... and do we throw if we didn't get what we expected?"
         (is (thrown?
              java.lang.AssertionError
              (#'tf/validate-results {"VenuesEnhanced" {:entity     (db/select-one Table :id (mt/id :venues))
-                                                       :dimensions {"D1" [:field-id 1]}}}
+                                                       :dimensions {"D1" [:field 1 nil]}}}
                                     (first @tf.specs/transform-specs))))))))
 
 (deftest transform-test


### PR DESCRIPTION
Following Cam's work on refactoring our mbql for fields in this [PR](https://github.com/metabase/metabase/pull/14897),
This PR updates the test that uses the legacy syntax to use the new syntax.

List of changes
```
1. [:field-id id]                     => [:field id nil] or $name
2. [:datetime-field [:field id] unit] => [:field id {:temporal-unit unit}]] or !unit.name
3. [:fk-> [:field 1] [:field 2]]      => [:field 2 {:source-field 1}]
```
There are still a few of these left and they are tests for compatibility
Most of them are in `test/metabase/models/card_test.clj` and `test/metabase/models/dashboard_card_test.clj`