### PR TITLE
Automatically handle null form values

### DIFF
--- a/frontend/src/metabase/account/password/components/UserPasswordForm/UserPasswordForm.tsx
+++ b/frontend/src/metabase/account/password/components/UserPasswordForm/UserPasswordForm.tsx
@@ -10,6 +10,12 @@ import FormErrorMessage from "metabase/core/components/FormErrorMessage";
 import { User } from "metabase-types/api";
 import { UserPasswordData } from "../../types";
 
+const defaultValues: UserPasswordData = {
+  old_password: "",
+  password: "",
+  password_confirm: "",
+};
+
 const userPasswordSchema = Yup.object({
   old_password: Yup.string().required(t`required`),
   password: Yup.string()
@@ -34,11 +40,6 @@ const UserPasswordForm = ({
   onValidatePassword,
   onSubmit,
 }: UserPasswordFormProps): JSX.Element => {
-  const initialValues = useMemo(
-    () => ({ old_password: "", password: "", password_confirm: "" }),
-    [],
-  );
-
   const validationContext = useMemo(
     () => ({ onValidatePassword: _.memoize(onValidatePassword) }),
     [onValidatePassword],
@@ -53,7 +54,7 @@ const UserPasswordForm = ({
 
   return (
     <FormProvider
-      initialValues={initialValues}
+      initialValues={defaultValues}
       validationSchema={userPasswordSchema}
       validationContext={validationContext}
       onSubmit={handleSubmit}

--- a/frontend/src/metabase/account/password/components/UserPasswordForm/UserPasswordForm.tsx
+++ b/frontend/src/metabase/account/password/components/UserPasswordForm/UserPasswordForm.tsx
@@ -10,7 +10,7 @@ import FormErrorMessage from "metabase/core/components/FormErrorMessage";
 import { User } from "metabase-types/api";
 import { UserPasswordData } from "../../types";
 
-const UserPasswordSchema = Yup.object({
+const userPasswordSchema = Yup.object({
   old_password: Yup.string().required(t`required`),
   password: Yup.string()
     .required(t`required`)
@@ -54,7 +54,7 @@ const UserPasswordForm = ({
   return (
     <FormProvider
       initialValues={initialValues}
-      validationSchema={UserPasswordSchema}
+      validationSchema={userPasswordSchema}
       validationContext={validationContext}
       onSubmit={handleSubmit}
     >

--- a/frontend/src/metabase/account/profile/actions.ts
+++ b/frontend/src/metabase/account/profile/actions.ts
@@ -7,10 +7,10 @@ import { UserProfileData } from "./types";
 export const UPDATE_USER = "metabase/account/profile/UPDATE_USER";
 export const updateUser = createThunkAction(
   UPDATE_USER,
-  (user: User, data: UserProfileData) => async (dispatch: Dispatch) => {
-    await dispatch(Users.actions.update({ ...data, id: user.id }));
+  (user: User, values: UserProfileData) => async (dispatch: Dispatch) => {
+    await dispatch(Users.actions.update(values));
 
-    if (user.locale !== data.locale) {
+    if (user.locale !== values.locale) {
       window.location.reload();
     }
   },

--- a/frontend/src/metabase/account/profile/components/UserProfileForm/UserProfileForm.tsx
+++ b/frontend/src/metabase/account/profile/components/UserProfileForm/UserProfileForm.tsx
@@ -11,11 +11,11 @@ import FormErrorMessage from "metabase/core/components/FormErrorMessage";
 import { LocaleData, User } from "metabase-types/api";
 import { UserProfileData } from "../../types";
 
-const SsoProfileSchema = Yup.object({
+const ssoProfileSchema = Yup.object({
   locale: Yup.string().nullable(true),
 });
 
-const LocalProfileSchema = SsoProfileSchema.shape({
+const localProfileSchema = ssoProfileSchema.shape({
   first_name: Yup.string().max(
     100,
     ({ max }) => t`must be ${max} characters or less`,
@@ -52,7 +52,7 @@ const UserProfileForm = ({
   return (
     <FormProvider
       initialValues={user}
-      validationSchema={isSsoUser ? SsoProfileSchema : LocalProfileSchema}
+      validationSchema={isSsoUser ? ssoProfileSchema : localProfileSchema}
       enableReinitialize
       onSubmit={handleSubmit}
     >

--- a/frontend/src/metabase/account/profile/components/UserProfileForm/UserProfileForm.tsx
+++ b/frontend/src/metabase/account/profile/components/UserProfileForm/UserProfileForm.tsx
@@ -33,7 +33,7 @@ export interface UserProfileFormProps {
   user: User;
   locales: LocaleData[] | null;
   isSsoUser: boolean;
-  onSubmit: (user: User, data: UserProfileData) => void;
+  onSubmit: (user: User, values: UserProfileData) => void;
 }
 
 const UserProfileForm = ({
@@ -42,17 +42,16 @@ const UserProfileForm = ({
   isSsoUser,
   onSubmit,
 }: UserProfileFormProps): JSX.Element => {
-  const initialValues = useMemo(() => getInitialValues(user), [user]);
   const localeOptions = useMemo(() => getLocaleOptions(locales), [locales]);
 
   const handleSubmit = useCallback(
-    (data: UserProfileData) => onSubmit(user, getSubmitValues(data)),
+    (values: UserProfileData) => onSubmit(user, values),
     [user, onSubmit],
   );
 
   return (
     <FormProvider
-      initialValues={initialValues}
+      initialValues={user}
       validationSchema={isSsoUser ? SsoProfileSchema : LocalProfileSchema}
       enableReinitialize
       onSubmit={handleSubmit}
@@ -90,23 +89,6 @@ const UserProfileForm = ({
       )}
     </FormProvider>
   );
-};
-
-const getInitialValues = (user: User): UserProfileData => {
-  return {
-    first_name: user.first_name || "",
-    last_name: user.last_name || "",
-    email: user.email,
-    locale: user.locale,
-  };
-};
-
-const getSubmitValues = (data: UserProfileData): UserProfileData => {
-  return {
-    ...data,
-    first_name: data.first_name || null,
-    last_name: data.last_name || null,
-  };
 };
 
 const getLocaleOptions = (locales: LocaleData[] | null) => {

--- a/frontend/src/metabase/account/profile/components/UserProfileForm/UserProfileForm.tsx
+++ b/frontend/src/metabase/account/profile/components/UserProfileForm/UserProfileForm.tsx
@@ -16,14 +16,12 @@ const ssoProfileSchema = Yup.object({
 });
 
 const localProfileSchema = ssoProfileSchema.shape({
-  first_name: Yup.string().max(
-    100,
-    ({ max }) => t`must be ${max} characters or less`,
-  ),
-  last_name: Yup.string().max(
-    100,
-    ({ max }) => t`must be ${max} characters or less`,
-  ),
+  first_name: Yup.string()
+    .nullable()
+    .max(100, ({ max }) => t`must be ${max} characters or less`),
+  last_name: Yup.string()
+    .nullable()
+    .max(100, ({ max }) => t`must be ${max} characters or less`),
   email: Yup.string()
     .required(t`required`)
     .email(t`must be a valid email address`),

--- a/frontend/src/metabase/account/profile/types.ts
+++ b/frontend/src/metabase/account/profile/types.ts
@@ -1,4 +1,5 @@
 export interface UserProfileData {
+  id: number;
   first_name: string | null;
   last_name: string | null;
   email: string;

--- a/frontend/src/metabase/auth/components/ForgotPasswordForm/ForgotPasswordForm.tsx
+++ b/frontend/src/metabase/auth/components/ForgotPasswordForm/ForgotPasswordForm.tsx
@@ -13,7 +13,7 @@ import {
   PasswordFormTitle,
 } from "./ForgotPasswordForm.styled";
 
-const ForgotPasswordSchema = Yup.object({
+const forgotPasswordSchema = Yup.object({
   email: Yup.string()
     .required(t`required`)
     .email(t`must be a valid email address`),
@@ -43,7 +43,7 @@ const ForgotPasswordForm = ({
       <PasswordFormTitle>{t`Forgot password`}</PasswordFormTitle>
       <FormProvider
         initialValues={initialValues}
-        validationSchema={ForgotPasswordSchema}
+        validationSchema={forgotPasswordSchema}
         onSubmit={handleSubmit}
       >
         <Form>

--- a/frontend/src/metabase/auth/components/LoginForm/LoginForm.tsx
+++ b/frontend/src/metabase/auth/components/LoginForm/LoginForm.tsx
@@ -9,7 +9,7 @@ import FormInput from "metabase/core/components/FormInput";
 import FormSubmitButton from "metabase/core/components/FormSubmitButton";
 import { LoginData } from "../../types";
 
-const LoginSchema = Yup.object().shape({
+const loginSchema = Yup.object().shape({
   username: Yup.string()
     .required(t`required`)
     .when("$isLdapEnabled", {
@@ -50,7 +50,7 @@ const LoginForm = ({
   return (
     <FormProvider
       initialValues={initialValues}
-      validationSchema={LoginSchema}
+      validationSchema={loginSchema}
       validationContext={validationContext}
       onSubmit={onSubmit}
     >

--- a/frontend/src/metabase/auth/components/ResetPasswordForm/ResetPasswordForm.tsx
+++ b/frontend/src/metabase/auth/components/ResetPasswordForm/ResetPasswordForm.tsx
@@ -14,7 +14,12 @@ import {
   PasswordFormTitle,
 } from "./ResetPasswordForm.styled";
 
-const ResetPasswordSchema = Yup.object({
+const defaultValues: ResetPasswordData = {
+  password: "",
+  password_confirm: "",
+};
+
+const resetPasswordSchema = Yup.object({
   password: Yup.string()
     .required(t`required`)
     .test(async (value = "", context) => {
@@ -35,11 +40,6 @@ const ResetPasswordForm = ({
   onValidatePassword,
   onSubmit,
 }: ResetPasswordFormProps): JSX.Element => {
-  const initialValues = useMemo(
-    () => ({ password: "", password_confirm: "" }),
-    [],
-  );
-
   const passwordDescription = useMemo(
     () => MetabaseSettings.passwordComplexityDescription(),
     [],
@@ -57,8 +57,8 @@ const ResetPasswordForm = ({
         {t`To keep your data secure, passwords ${passwordDescription}`}
       </PasswordFormMessage>
       <FormProvider
-        initialValues={initialValues}
-        validationSchema={ResetPasswordSchema}
+        initialValues={defaultValues}
+        validationSchema={resetPasswordSchema}
         validationContext={validationContext}
         onSubmit={onSubmit}
       >

--- a/frontend/src/metabase/core/components/FormCheckBox/FormCheckBox.tsx
+++ b/frontend/src/metabase/core/components/FormCheckBox/FormCheckBox.tsx
@@ -34,7 +34,7 @@ const FormCheckBox = forwardRef(function FormCheckBox(
         {...props}
         id={id}
         name={name}
-        checked={value}
+        checked={value ?? false}
         onChange={onChange}
         onBlur={onBlur}
       />

--- a/frontend/src/metabase/core/components/FormCheckBox/FormCheckBox.unit.spec.tsx
+++ b/frontend/src/metabase/core/components/FormCheckBox/FormCheckBox.unit.spec.tsx
@@ -5,7 +5,7 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import FormCheckBox from "./FormCheckBox";
 
-const TestSchema = Yup.object().shape({
+const testSchema = Yup.object().shape({
   value: Yup.boolean().isTrue("error"),
 });
 
@@ -21,7 +21,7 @@ const TestFormCheckBox = ({
   return (
     <Formik
       initialValues={{ value: initialValue }}
-      validationSchema={TestSchema}
+      validationSchema={testSchema}
       onSubmit={onSubmit}
     >
       <Form>

--- a/frontend/src/metabase/core/components/FormDateInput/FormDateInput.tsx
+++ b/frontend/src/metabase/core/components/FormDateInput/FormDateInput.tsx
@@ -29,7 +29,7 @@ const FormDateInput = forwardRef(function FormDateInput(
   }, [value]);
 
   const handleChange = useCallback(
-    (date?: Moment) => {
+    (date: Moment | undefined) => {
       setValue(date?.toISOString(true));
     },
     [setValue],

--- a/frontend/src/metabase/core/components/FormDateInput/FormDateInput.unit.spec.tsx
+++ b/frontend/src/metabase/core/components/FormDateInput/FormDateInput.unit.spec.tsx
@@ -5,7 +5,7 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import FormDateInput from "./FormDateInput";
 
-const TestSchema = Yup.object().shape({
+const testSchema = Yup.object().shape({
   value: Yup.string().required("error"),
 });
 
@@ -21,7 +21,7 @@ const TestFormDateInput = ({
   return (
     <Formik
       initialValues={{ value: initialValue }}
-      validationSchema={TestSchema}
+      validationSchema={testSchema}
       onSubmit={onSubmit}
     >
       <Form>

--- a/frontend/src/metabase/core/components/FormInput/FormInput.tsx
+++ b/frontend/src/metabase/core/components/FormInput/FormInput.tsx
@@ -1,4 +1,10 @@
-import React, { forwardRef, ReactNode, Ref } from "react";
+import React, {
+  ChangeEvent,
+  forwardRef,
+  ReactNode,
+  Ref,
+  useCallback,
+} from "react";
 import { useField } from "formik";
 import { useUniqueId } from "metabase/hooks/use-unique-id";
 import Input, { InputProps } from "metabase/core/components/Input";
@@ -19,7 +25,13 @@ const FormInput = forwardRef(function FormInput(
   ref: Ref<HTMLDivElement>,
 ) {
   const id = useUniqueId();
-  const [{ value, onChange, onBlur }, { error, touched }] = useField(name);
+  const [{ value, onBlur }, { error, touched }, { setValue }] = useField(name);
+
+  const handleChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) =>
+      setValue(event.target.value || null),
+    [setValue],
+  );
 
   return (
     <FormField
@@ -35,10 +47,10 @@ const FormInput = forwardRef(function FormInput(
         {...props}
         id={id}
         name={name}
-        value={value}
+        value={value ?? ""}
         error={touched && error != null}
         fullWidth
-        onChange={onChange}
+        onChange={handleChange}
         onBlur={onBlur}
       />
     </FormField>

--- a/frontend/src/metabase/core/components/FormInput/FormInput.unit.spec.tsx
+++ b/frontend/src/metabase/core/components/FormInput/FormInput.unit.spec.tsx
@@ -5,7 +5,7 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import FormInput from "./FormInput";
 
-const TestSchema = Yup.object().shape({
+const testSchema = Yup.object().shape({
   value: Yup.string().required("error"),
 });
 
@@ -18,7 +18,7 @@ const TestFormInput = ({ initialValue = "", onSubmit }: TestFormInputProps) => {
   return (
     <Formik
       initialValues={{ value: initialValue }}
-      validationSchema={TestSchema}
+      validationSchema={testSchema}
       onSubmit={onSubmit}
     >
       <Form>

--- a/frontend/src/metabase/core/components/FormNumericInput/FormNumericInput.tsx
+++ b/frontend/src/metabase/core/components/FormNumericInput/FormNumericInput.tsx
@@ -1,4 +1,10 @@
-import React, { forwardRef, ReactNode, Ref } from "react";
+import React, {
+  ChangeEvent,
+  forwardRef,
+  ReactNode,
+  Ref,
+  useCallback,
+} from "react";
 import { useField } from "formik";
 import { useUniqueId } from "metabase/hooks/use-unique-id";
 import NumericInput, {
@@ -30,6 +36,11 @@ const FormNumericInput = forwardRef(function FormNumericInput(
   const id = useUniqueId();
   const [{ value, onBlur }, { error, touched }, { setValue }] = useField(name);
 
+  const handleChange = useCallback(
+    (value: number | undefined) => setValue(value ?? null),
+    [setValue],
+  );
+
   return (
     <FormField
       ref={ref}
@@ -44,10 +55,10 @@ const FormNumericInput = forwardRef(function FormNumericInput(
         {...props}
         id={id}
         name={name}
-        value={value}
+        value={value ?? undefined}
         error={touched && error != null}
         fullWidth
-        onChange={setValue}
+        onChange={handleChange}
         onBlur={onBlur}
       />
     </FormField>

--- a/frontend/src/metabase/core/components/FormNumericInput/FormNumericInput.unit.spec.tsx
+++ b/frontend/src/metabase/core/components/FormNumericInput/FormNumericInput.unit.spec.tsx
@@ -5,7 +5,7 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import FormNumericInput from "./FormNumericInput";
 
-const TestSchema = Yup.object().shape({
+const testSchema = Yup.object().shape({
   value: Yup.number().required("error"),
 });
 
@@ -21,7 +21,7 @@ const TestFormNumericInput = ({
   return (
     <Formik
       initialValues={{ value: initialValue }}
-      validationSchema={TestSchema}
+      validationSchema={testSchema}
       onSubmit={onSubmit}
     >
       <Form>

--- a/frontend/src/metabase/core/components/FormRadio/FormRadio.unit.spec.tsx
+++ b/frontend/src/metabase/core/components/FormRadio/FormRadio.unit.spec.tsx
@@ -5,11 +5,11 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import FormRadio from "./FormRadio";
 
-const TestSchema = Yup.object().shape({
+const testSchema = Yup.object().shape({
   value: Yup.string().notOneOf(["bar"], "error"),
 });
 
-const TEST_OPTIONS = [
+const testOptions = [
   { name: "Line", value: "line" },
   { name: "Area", value: "area" },
   { name: "Bar", value: "bar" },
@@ -24,11 +24,11 @@ const TestFormRadio = ({ initialValue, onSubmit }: TestFormRadioProps) => {
   return (
     <Formik
       initialValues={{ value: initialValue }}
-      validationSchema={TestSchema}
+      validationSchema={testSchema}
       onSubmit={onSubmit}
     >
       <Form>
-        <FormRadio name="value" options={TEST_OPTIONS} title="Label" />
+        <FormRadio name="value" options={testOptions} title="Label" />
         <button type="submit">Submit</button>
       </Form>
     </Formik>

--- a/frontend/src/metabase/core/components/FormSelect/FormSelect.unit.spec.tsx
+++ b/frontend/src/metabase/core/components/FormSelect/FormSelect.unit.spec.tsx
@@ -5,11 +5,11 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import FormSelect from "./FormSelect";
 
-const TestSchema = Yup.object().shape({
+const testSchema = Yup.object().shape({
   value: Yup.string().notOneOf(["bar"], "error"),
 });
 
-const TEST_OPTIONS = [
+const testOptions = [
   { name: "Line", value: "line" },
   { name: "Area", value: "area" },
   { name: "Bar", value: "bar" },
@@ -24,14 +24,14 @@ const TestFormSelect = ({ initialValue, onSubmit }: TestFormSelectProps) => {
   return (
     <Formik
       initialValues={{ value: initialValue }}
-      validationSchema={TestSchema}
+      validationSchema={testSchema}
       onSubmit={onSubmit}
     >
       <Form>
         <FormSelect
           name="value"
           title="Label"
-          options={TEST_OPTIONS}
+          options={testOptions}
           placeholder="Choose"
         />
         <button type="submit">Submit</button>

--- a/frontend/src/metabase/core/components/FormTextArea/FormTextArea.tsx
+++ b/frontend/src/metabase/core/components/FormTextArea/FormTextArea.tsx
@@ -1,4 +1,10 @@
-import React, { forwardRef, ReactNode, Ref } from "react";
+import React, {
+  ChangeEvent,
+  forwardRef,
+  ReactNode,
+  Ref,
+  useCallback,
+} from "react";
 import { useField } from "formik";
 import { useUniqueId } from "metabase/hooks/use-unique-id";
 import TextArea, { TextAreaProps } from "metabase/core/components/TextArea";
@@ -27,7 +33,13 @@ const FormTextArea = forwardRef(function FormTextArea(
   ref: Ref<HTMLDivElement>,
 ) {
   const id = useUniqueId();
-  const [{ value, onChange, onBlur }, { error, touched }] = useField(name);
+  const [{ value, onBlur }, { error, touched }, { setValue }] = useField(name);
+
+  const handleChange = useCallback(
+    (event: ChangeEvent<HTMLTextAreaElement>) =>
+      setValue(event.target.value || null),
+    [setValue],
+  );
 
   return (
     <FormField
@@ -45,9 +57,9 @@ const FormTextArea = forwardRef(function FormTextArea(
         {...props}
         id={id}
         name={name}
-        value={value}
+        value={value ?? ""}
         error={touched && error != null}
-        onChange={onChange}
+        onChange={handleChange}
         onBlur={onBlur}
       />
     </FormField>

--- a/frontend/src/metabase/core/components/FormToggle/FormToggle.tsx
+++ b/frontend/src/metabase/core/components/FormToggle/FormToggle.tsx
@@ -33,7 +33,7 @@ const FormToggle = forwardRef(function FormToggle(
         {...props}
         id={id}
         name={name}
-        value={value}
+        value={value ?? false}
         onChange={setValue}
         onBlur={onBlur}
       />

--- a/frontend/src/metabase/core/components/FormToggle/FormToggle.unit.spec.tsx
+++ b/frontend/src/metabase/core/components/FormToggle/FormToggle.unit.spec.tsx
@@ -5,7 +5,7 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import FormToggle from "./FormToggle";
 
-const TestSchema = Yup.object().shape({
+const testSchema = Yup.object().shape({
   value: Yup.boolean().isTrue("error"),
 });
 
@@ -21,7 +21,7 @@ const TestFormToggle = ({
   return (
     <Formik
       initialValues={{ value: initialValue }}
-      validationSchema={TestSchema}
+      validationSchema={testSchema}
       onSubmit={onSubmit}
     >
       <Form>

--- a/frontend/src/metabase/setup/components/InviteUserForm/InviteUserForm.tsx
+++ b/frontend/src/metabase/setup/components/InviteUserForm/InviteUserForm.tsx
@@ -8,13 +8,13 @@ import FormSubmitButton from "metabase/core/components/FormSubmitButton";
 import { InviteInfo, UserInfo } from "metabase-types/store";
 import { UserFieldGroup } from "./InviteUserForm.styled";
 
-const DEFAULT_VALUES: InviteInfo = {
+const defaultValues: InviteInfo = {
   first_name: "",
   last_name: "",
   email: "",
 };
 
-const INVITE_USER_SCHEMA = Yup.object({
+const inviteUserSchema = Yup.object({
   first_name: Yup.string().max(
     100,
     ({ max }) => t`must be ${max} characters or less`,
@@ -45,8 +45,8 @@ const InviteUserForm = ({
 }: InviteUserFormProps): JSX.Element => {
   return (
     <FormProvider
-      initialValues={invite ?? DEFAULT_VALUES}
-      validationSchema={INVITE_USER_SCHEMA}
+      initialValues={invite ?? defaultValues}
+      validationSchema={inviteUserSchema}
       validationContext={user}
       onSubmit={onSubmit}
     >

--- a/frontend/src/metabase/setup/components/InviteUserForm/InviteUserForm.tsx
+++ b/frontend/src/metabase/setup/components/InviteUserForm/InviteUserForm.tsx
@@ -15,14 +15,12 @@ const defaultValues: InviteInfo = {
 };
 
 const inviteUserSchema = Yup.object({
-  first_name: Yup.string().max(
-    100,
-    ({ max }) => t`must be ${max} characters or less`,
-  ),
-  last_name: Yup.string().max(
-    100,
-    ({ max }) => t`must be ${max} characters or less`,
-  ),
+  first_name: Yup.string()
+    .nullable()
+    .max(100, ({ max }) => t`must be ${max} characters or less`),
+  last_name: Yup.string()
+    .nullable()
+    .max(100, ({ max }) => t`must be ${max} characters or less`),
   email: Yup.string()
     .required(t`required`)
     .email(t`must be a valid email address`)

--- a/frontend/src/metabase/setup/components/InviteUserForm/InviteUserForm.tsx
+++ b/frontend/src/metabase/setup/components/InviteUserForm/InviteUserForm.tsx
@@ -8,7 +8,13 @@ import FormSubmitButton from "metabase/core/components/FormSubmitButton";
 import { InviteInfo, UserInfo } from "metabase-types/store";
 import { UserFieldGroup } from "./InviteUserForm.styled";
 
-const InviteUserSchema = Yup.object({
+const DEFAULT_VALUES: InviteInfo = {
+  first_name: "",
+  last_name: "",
+  email: "",
+};
+
+const INVITE_USER_SCHEMA = Yup.object({
   first_name: Yup.string().max(
     100,
     ({ max }) => t`must be ${max} characters or less`,
@@ -37,21 +43,12 @@ const InviteUserForm = ({
   invite,
   onSubmit,
 }: InviteUserFormProps): JSX.Element => {
-  const initialValues = useMemo(() => {
-    return getInitialValues(invite);
-  }, [invite]);
-
-  const handleSubmit = useCallback(
-    (values: InviteInfo) => onSubmit(getSubmitValues(values)),
-    [onSubmit],
-  );
-
   return (
     <FormProvider
-      initialValues={initialValues}
-      validationSchema={InviteUserSchema}
+      initialValues={invite ?? DEFAULT_VALUES}
+      validationSchema={INVITE_USER_SCHEMA}
       validationContext={user}
-      onSubmit={handleSubmit}
+      onSubmit={onSubmit}
     >
       <Form>
         <UserFieldGroup>
@@ -76,23 +73,6 @@ const InviteUserForm = ({
       </Form>
     </FormProvider>
   );
-};
-
-const getInitialValues = (invite?: InviteInfo): InviteInfo => {
-  return {
-    email: "",
-    ...invite,
-    first_name: invite?.first_name || "",
-    last_name: invite?.last_name || "",
-  };
-};
-
-const getSubmitValues = (invite: InviteInfo): InviteInfo => {
-  return {
-    ...invite,
-    first_name: invite.first_name || null,
-    last_name: invite.last_name || null,
-  };
 };
 
 export default InviteUserForm;

--- a/frontend/src/metabase/setup/components/NewsletterForm/NewsletterForm.tsx
+++ b/frontend/src/metabase/setup/components/NewsletterForm/NewsletterForm.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from "react";
+import React, { useCallback, useMemo, useState } from "react";
 import { t } from "ttag";
 import * as Yup from "yup";
 import FormProvider from "metabase/core/components/FormProvider";
@@ -18,7 +18,7 @@ import {
   EmailFormInput,
 } from "./NewsletterForm.styled";
 
-const NewsletterSchema = Yup.object({
+const newsletterSchema = Yup.object({
   email: Yup.string()
     .required(t`required`)
     .email(t`must be a valid email address`),
@@ -33,8 +33,12 @@ const NewsletterForm = ({
   initialEmail = "",
   onSubscribe,
 }: NewsletterFormProps): JSX.Element => {
-  const initialValues = { email: initialEmail };
   const [isSubscribed, setIsSubscribed] = useState(false);
+
+  const initialValues = useMemo(
+    () => ({ email: initialEmail }),
+    [initialEmail],
+  );
 
   const handleSubmit = useCallback(
     async ({ email }: SubscribeInfo) => {
@@ -58,7 +62,7 @@ const NewsletterForm = ({
       {!isSubscribed && (
         <FormProvider
           initialValues={initialValues}
-          validationSchema={NewsletterSchema}
+          validationSchema={newsletterSchema}
           onSubmit={handleSubmit}
         >
           <EmailForm>

--- a/frontend/src/metabase/setup/components/UserForm/UserForm.tsx
+++ b/frontend/src/metabase/setup/components/UserForm/UserForm.tsx
@@ -18,14 +18,12 @@ const defaultValues: UserInfo = {
 };
 
 const userSchema = Yup.object({
-  first_name: Yup.string().max(
-    100,
-    ({ max }) => t`must be ${max} characters or less`,
-  ),
-  last_name: Yup.string().max(
-    100,
-    ({ max }) => t`must be ${max} characters or less`,
-  ),
+  first_name: Yup.string()
+    .nullable()
+    .max(100, ({ max }) => t`must be ${max} characters or less`),
+  last_name: Yup.string()
+    .nullable()
+    .max(100, ({ max }) => t`must be ${max} characters or less`),
   email: Yup.string()
     .required(t`required`)
     .email(t`must be a valid email address`),

--- a/frontend/src/metabase/setup/components/UserForm/UserForm.tsx
+++ b/frontend/src/metabase/setup/components/UserForm/UserForm.tsx
@@ -17,7 +17,7 @@ const defaultValues: UserInfo = {
   password_confirm: "",
 };
 
-const USER_SCHEMA = Yup.object({
+const userSchema = Yup.object({
   first_name: Yup.string().max(
     100,
     ({ max }) => t`must be ${max} characters or less`,
@@ -58,7 +58,7 @@ const UserForm = ({ user, onValidatePassword, onSubmit }: UserFormProps) => {
   return (
     <FormProvider
       initialValues={user ?? defaultValues}
-      validationSchema={USER_SCHEMA}
+      validationSchema={userSchema}
       validationContext={validationContext}
       onSubmit={onSubmit}
     >

--- a/frontend/src/metabase/setup/components/UserForm/UserForm.tsx
+++ b/frontend/src/metabase/setup/components/UserForm/UserForm.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo } from "react";
+import React, { useMemo } from "react";
 import { t } from "ttag";
 import * as Yup from "yup";
 import _ from "underscore";
@@ -7,6 +7,15 @@ import FormInput from "metabase/core/components/FormInput";
 import FormSubmitButton from "metabase/core/components/FormSubmitButton";
 import { UserInfo } from "metabase-types/store";
 import { UserFieldGroup, UserFormRoot } from "./UserForm.styled";
+
+const DEFAULT_VALUES: UserInfo = {
+  first_name: "",
+  last_name: "",
+  email: "",
+  site_name: "",
+  password: "",
+  password_confirm: "",
+};
 
 const UserSchema = Yup.object({
   first_name: Yup.string().max(
@@ -39,10 +48,6 @@ interface UserFormProps {
 }
 
 const UserForm = ({ user, onValidatePassword, onSubmit }: UserFormProps) => {
-  const initialValues = useMemo(() => {
-    return getInitialValues(user);
-  }, [user]);
-
   const validationContext = useMemo(
     () => ({
       onValidatePassword: _.memoize(onValidatePassword),
@@ -50,17 +55,12 @@ const UserForm = ({ user, onValidatePassword, onSubmit }: UserFormProps) => {
     [onValidatePassword],
   );
 
-  const handleSubmit = useCallback(
-    (values: UserInfo) => onSubmit(getSubmitValues(values)),
-    [onSubmit],
-  );
-
   return (
     <FormProvider
-      initialValues={initialValues}
+      initialValues={user ?? DEFAULT_VALUES}
       validationSchema={UserSchema}
       validationContext={validationContext}
-      onSubmit={handleSubmit}
+      onSubmit={onSubmit}
     >
       <UserFormRoot>
         <UserFieldGroup>
@@ -103,26 +103,6 @@ const UserForm = ({ user, onValidatePassword, onSubmit }: UserFormProps) => {
       </UserFormRoot>
     </FormProvider>
   );
-};
-
-const getInitialValues = (user?: UserInfo): UserInfo => {
-  return {
-    email: "",
-    site_name: "",
-    password: "",
-    password_confirm: "",
-    ...user,
-    first_name: user?.first_name || "",
-    last_name: user?.last_name || "",
-  };
-};
-
-const getSubmitValues = (user: UserInfo): UserInfo => {
-  return {
-    ...user,
-    first_name: user.first_name || null,
-    last_name: user.last_name || null,
-  };
 };
 
 export default UserForm;

--- a/frontend/src/metabase/setup/components/UserForm/UserForm.tsx
+++ b/frontend/src/metabase/setup/components/UserForm/UserForm.tsx
@@ -8,7 +8,7 @@ import FormSubmitButton from "metabase/core/components/FormSubmitButton";
 import { UserInfo } from "metabase-types/store";
 import { UserFieldGroup, UserFormRoot } from "./UserForm.styled";
 
-const DEFAULT_VALUES: UserInfo = {
+const defaultValues: UserInfo = {
   first_name: "",
   last_name: "",
   email: "",
@@ -17,7 +17,7 @@ const DEFAULT_VALUES: UserInfo = {
   password_confirm: "",
 };
 
-const UserSchema = Yup.object({
+const USER_SCHEMA = Yup.object({
   first_name: Yup.string().max(
     100,
     ({ max }) => t`must be ${max} characters or less`,
@@ -57,8 +57,8 @@ const UserForm = ({ user, onValidatePassword, onSubmit }: UserFormProps) => {
 
   return (
     <FormProvider
-      initialValues={user ?? DEFAULT_VALUES}
-      validationSchema={UserSchema}
+      initialValues={user ?? defaultValues}
+      validationSchema={USER_SCHEMA}
       validationContext={validationContext}
       onSubmit={onSubmit}
     >

--- a/frontend/src/metabase/timelines/common/components/EditEventModal/EditEventModal.tsx
+++ b/frontend/src/metabase/timelines/common/components/EditEventModal/EditEventModal.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo } from "react";
+import React, { useCallback } from "react";
 import { t } from "ttag";
 import { Timeline, TimelineEvent, TimelineEventData } from "metabase-types/api";
 import EventForm from "../EventForm";
@@ -26,13 +26,9 @@ const EditEventModal = ({
   onCancel,
   onClose,
 }: EditEventModalProps): JSX.Element => {
-  const initialValues = useMemo(() => {
-    return getInitialValues(event);
-  }, [event]);
-
   const handleSubmit = useCallback(
     async (values: TimelineEventData) => {
-      await onSubmit(getSubmitValues(event, values), timeline);
+      await onSubmit({ ...event, ...values }, timeline);
       onSubmitSuccess?.();
     },
     [event, timeline, onSubmit, onSubmitSuccess],
@@ -48,7 +44,7 @@ const EditEventModal = ({
       <ModalHeader title={t`Edit event`} onClose={onClose} />
       <ModalBody>
         <EventForm
-          initialValues={initialValues}
+          initialValues={event}
           onSubmit={handleSubmit}
           onArchive={handleArchive}
           onCancel={onCancel}
@@ -57,19 +53,5 @@ const EditEventModal = ({
     </div>
   );
 };
-
-const getInitialValues = (event: TimelineEvent): TimelineEventData => ({
-  ...event,
-  description: event.description || "",
-});
-
-const getSubmitValues = (
-  event: TimelineEvent,
-  values: TimelineEventData,
-): TimelineEvent => ({
-  ...event,
-  ...values,
-  description: values.description || null,
-});
 
 export default EditEventModal;

--- a/frontend/src/metabase/timelines/common/components/EditTimelineModal/EditTimelineModal.tsx
+++ b/frontend/src/metabase/timelines/common/components/EditTimelineModal/EditTimelineModal.tsx
@@ -26,7 +26,7 @@ const EditTimelineModal = ({
 }: EditTimelineModalProps): JSX.Element => {
   const handleSubmit = useCallback(
     async (values: TimelineData) => {
-      await onSubmit({ ...timeline, ...values });
+      await onSubmit({ ...timeline, ...values, default: false });
       onSubmitSuccess?.();
     },
     [timeline, onSubmit, onSubmitSuccess],

--- a/frontend/src/metabase/timelines/common/components/EditTimelineModal/EditTimelineModal.tsx
+++ b/frontend/src/metabase/timelines/common/components/EditTimelineModal/EditTimelineModal.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo } from "react";
+import React, { useCallback } from "react";
 import { t } from "ttag";
 import { Timeline, TimelineData } from "metabase-types/api";
 import ModalBody from "../ModalBody";
@@ -24,13 +24,9 @@ const EditTimelineModal = ({
   onCancel,
   onClose,
 }: EditTimelineModalProps): JSX.Element => {
-  const initialValues = useMemo(() => {
-    return getInitialValues(timeline);
-  }, [timeline]);
-
   const handleSubmit = useCallback(
     async (values: TimelineData) => {
-      await onSubmit(getSubmitValues(values, timeline));
+      await onSubmit({ ...timeline, ...values });
       onSubmitSuccess?.();
     },
     [timeline, onSubmit, onSubmitSuccess],
@@ -46,7 +42,7 @@ const EditTimelineModal = ({
       <ModalHeader title={t`Edit event timeline`} onClose={onClose} />
       <ModalBody>
         <TimelineForm
-          initialValues={initialValues}
+          initialValues={timeline}
           onSubmit={handleSubmit}
           onArchive={handleArchive}
           onCancel={onCancel}
@@ -55,20 +51,5 @@ const EditTimelineModal = ({
     </div>
   );
 };
-
-const getInitialValues = (timeline: Timeline): TimelineData => ({
-  ...timeline,
-  default: false,
-  description: timeline.description || "",
-});
-
-const getSubmitValues = (
-  values: TimelineData,
-  timeline: Timeline,
-): Timeline => ({
-  ...timeline,
-  ...values,
-  description: values.description || null,
-});
 
 export default EditTimelineModal;

--- a/frontend/src/metabase/timelines/common/components/EventForm/EventForm.tsx
+++ b/frontend/src/metabase/timelines/common/components/EventForm/EventForm.tsx
@@ -19,10 +19,9 @@ const eventSchema = Yup.object({
   name: Yup.string()
     .required(t`required`)
     .max(255, ({ max }) => t`must be ${max} characters or less`),
-  description: Yup.string().max(
-    255,
-    ({ max }) => t`must be ${max} characters or less`,
-  ),
+  description: Yup.string()
+    .nullable()
+    .max(255, ({ max }) => t`must be ${max} characters or less`),
   timestamp: Yup.string().required(`required`),
   time_matters: Yup.boolean(),
   icon: Yup.string().required(`required`),

--- a/frontend/src/metabase/timelines/common/components/EventForm/EventForm.tsx
+++ b/frontend/src/metabase/timelines/common/components/EventForm/EventForm.tsx
@@ -15,7 +15,7 @@ import { Timeline, TimelineEventData } from "metabase-types/api";
 import FormArchiveButton from "../FormArchiveButton";
 import { EventFormFooter } from "./EventForm.styled";
 
-const EventSchema = Yup.object({
+const eventSchema = Yup.object({
   name: Yup.string()
     .required(t`required`)
     .max(255, ({ max }) => t`must be ${max} characters or less`),
@@ -57,7 +57,7 @@ const EventForm = ({
   return (
     <FormProvider
       initialValues={initialValues}
-      validationSchema={EventSchema}
+      validationSchema={eventSchema}
       onSubmit={onSubmit}
     >
       {({ dirty, values, setFieldValue }) => (

--- a/frontend/src/metabase/timelines/common/components/NewEventModal/NewEventModal.tsx
+++ b/frontend/src/metabase/timelines/common/components/NewEventModal/NewEventModal.tsx
@@ -48,7 +48,7 @@ const NewEventModal = ({
   const handleSubmit = useCallback(
     async (values: TimelineEventData) => {
       const timeline = timelines.find(t => t.id === values.timeline_id);
-      await onSubmit(getSubmitValues(values), collection, timeline);
+      await onSubmit(values, collection, timeline);
       onSubmitSuccess?.();
     },
     [collection, timelines, onSubmit, onSubmitSuccess],
@@ -90,10 +90,5 @@ const getInitialValues = (
     question_id: cardId,
   };
 };
-
-const getSubmitValues = (values: TimelineEventData): TimelineEventData => ({
-  ...values,
-  description: values.description || null,
-});
 
 export default NewEventModal;

--- a/frontend/src/metabase/timelines/common/components/NewTimelineModal/NewTimelineModal.tsx
+++ b/frontend/src/metabase/timelines/common/components/NewTimelineModal/NewTimelineModal.tsx
@@ -28,7 +28,7 @@ const NewTimelineModal = ({
 
   const handleSubmit = useCallback(
     async (values: TimelineData) => {
-      await onSubmit(getSubmitValues(values), collection);
+      await onSubmit(values, collection);
       onSubmitSuccess?.();
     },
     [collection, onSubmit, onSubmitSuccess],
@@ -55,11 +55,6 @@ const getInitialValues = (collection: Collection): TimelineData => ({
   icon: getDefaultTimelineIcon(),
   default: false,
   archived: false,
-});
-
-const getSubmitValues = (values: TimelineData): TimelineData => ({
-  ...values,
-  description: values.description || null,
 });
 
 export default NewTimelineModal;

--- a/frontend/src/metabase/timelines/common/components/TimelineForm/TimelineForm.tsx
+++ b/frontend/src/metabase/timelines/common/components/TimelineForm/TimelineForm.tsx
@@ -14,7 +14,7 @@ import { TimelineData } from "metabase-types/api";
 import FormArchiveButton from "../FormArchiveButton";
 import { TimelineFormFooter } from "./TimelineForm.styled";
 
-const TimelineSchema = Yup.object({
+const timelineSchema = Yup.object({
   name: Yup.string()
     .required(t`required`)
     .max(255, ({ max }) => t`must be ${max} characters or less`),
@@ -44,7 +44,7 @@ const TimelineForm = ({
   return (
     <FormProvider
       initialValues={initialValues}
-      validationSchema={TimelineSchema}
+      validationSchema={timelineSchema}
       onSubmit={onSubmit}
     >
       {({ dirty }) => (

--- a/frontend/src/metabase/timelines/common/components/TimelineForm/TimelineForm.tsx
+++ b/frontend/src/metabase/timelines/common/components/TimelineForm/TimelineForm.tsx
@@ -18,10 +18,9 @@ const timelineSchema = Yup.object({
   name: Yup.string()
     .required(t`required`)
     .max(255, ({ max }) => t`must be ${max} characters or less`),
-  description: Yup.string().max(
-    255,
-    ({ max }) => t`must be ${max} characters or less`,
-  ),
+  description: Yup.string()
+    .nullable()
+    .max(255, ({ max }) => t`must be ${max} characters or less`),
   icon: Yup.string().required(t`required`),
 });
 


### PR DESCRIPTION
Epic https://github.com/metabase/metabase/issues/26178

Changes:
- Make form inputs handle `null` values conversion, e.g. accept `null` and convert an empty string back to `null`
- Unifies naming for default values and schema

How to test
- Go to Account -> Profile
- Remove either the first or last name and submit the form
- Make sure the value was converted to null automatically