### PR TITLE
Fixing breaking changes from actions/github-script

### DIFF
--- a/.github/actions/get-latest-release-branch/action.yml
+++ b/.github/actions/get-latest-release-branch/action.yml
@@ -12,7 +12,7 @@ runs:
       with:
         result-encoding: string
         script: |
-          const releaseBranches = await github.git.listMatchingRefs({
+          const releaseBranches = await github.rest.git.listMatchingRefs({
             owner: context.repo.owner,
             repo: context.repo.repo,
             ref: "heads/release-x.",

--- a/.github/actions/notify-pull-request/action.yml
+++ b/.github/actions/notify-pull-request/action.yml
@@ -26,7 +26,7 @@ runs:
             body += ` [[Logs]](${runUrl})`;
           }
 
-          github.issues.createComment({
+          github.rest.issues.createComment({
             issue_number: context.payload.number,
             owner: context.repo.owner,
             repo: context.repo.repo,

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -28,7 +28,7 @@ jobs:
               echo User ${{ github.event.comment.user.login }} is not a member of Metabase organization
               exit 1
           fi
-      - uses: actions/github-script@v4
+      - uses: actions/github-script@v6
         id: branch_info
         with:
           script: |
@@ -36,19 +36,19 @@ jobs:
             const [_botName, _command, targetBranch] = context.payload.comment.body.split(" ");
             console.log(`Target branch is ${targetBranch}`);
 
-            const { data: originalPullRequest } = await github.pulls.get({
+            const { data: originalPullRequest } = await github.rest.pulls.get({
               owner: context.repo.owner,
               repo: context.repo.repo,
               pull_number: context.payload.issue.number,
             });
 
-            const { data: commits } = await github.pulls.listCommits({
+            const { data: commits } = await github.rest.pulls.listCommits({
               owner: context.repo.owner,
               repo: context.repo.repo,
               pull_number: context.payload.issue.number,
             });
 
-            const targetRef = await github.git.getRef({
+            const targetRef = await github.rest.git.getRef({
               owner: context.repo.owner,
               repo: context.repo.repo,
               ref: `heads/${targetBranch}`,
@@ -57,14 +57,14 @@ jobs:
             const backportBranch = `backport-${originalPullRequest.head.ref}`
 
             try {
-              await github.git.getRef({
+              await github.rest.git.getRef({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 ref: `heads/${backportBranch}`,
               });
             } catch(e) {
               if (e.status === 404) {
-                await github.git.createRef({
+                await github.rest.git.createRef({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   ref: `refs/heads/${backportBranch}`,


### PR DESCRIPTION
https://github.com/actions/github-script#breaking-changes-in-v5 mentions that due to a bump in a dependency, now we can't use github.module.action but rather it's github.rest.module.action. This PR tends to fix that