### PR TITLE
Make sure lazy seqs get realized during CSV exports

### DIFF
--- a/src/metabase/query_processor/streaming/common.clj
+++ b/src/metabase/query_processor/streaming/common.clj
@@ -4,7 +4,8 @@
             [metabase.query-processor.store :as qp.store]
             [metabase.query-processor.timezone :as qp.timezone]
             [metabase.util.date-2 :as u.date])
-  (:import [java.time LocalDate LocalDateTime LocalTime OffsetDateTime OffsetTime ZonedDateTime]))
+  (:import clojure.lang.LazySeq
+           [java.time LocalDate LocalDateTime LocalTime OffsetDateTime OffsetTime ZonedDateTime]))
 
 (defn in-result-time-zone
   "Set the time zone of a temporal value `t` to result timezone without changing the actual moment in time. e.g.
@@ -28,6 +29,9 @@
 
   Object
   (format-value [this] this)
+
+  LazySeq
+  (format-value [this] (apply list this))
 
   LocalDate
   (format-value [t]

--- a/src/metabase/query_processor/streaming/common.clj
+++ b/src/metabase/query_processor/streaming/common.clj
@@ -32,7 +32,7 @@
 
   ISeq
   (format-value [this]
-    (into [] (map format-value this)))
+    (mapv format-value this))
 
   LocalDate
   (format-value [t]

--- a/src/metabase/query_processor/streaming/common.clj
+++ b/src/metabase/query_processor/streaming/common.clj
@@ -4,7 +4,7 @@
             [metabase.query-processor.store :as qp.store]
             [metabase.query-processor.timezone :as qp.timezone]
             [metabase.util.date-2 :as u.date])
-  (:import clojure.lang.LazySeq
+  (:import clojure.lang.ISeq
            [java.time LocalDate LocalDateTime LocalTime OffsetDateTime OffsetTime ZonedDateTime]))
 
 (defn in-result-time-zone
@@ -30,8 +30,9 @@
   Object
   (format-value [this] this)
 
-  LazySeq
-  (format-value [this] (apply list this))
+  ISeq
+  (format-value [this]
+    (into [] (map format-value this)))
 
   LocalDate
   (format-value [t]

--- a/test/metabase/query_processor/streaming/csv_test.clj
+++ b/test/metabase/query_processor/streaming/csv_test.clj
@@ -2,8 +2,10 @@
   (:require [cheshire.core :as json]
             [clojure.data.csv :as csv]
             [clojure.test :refer :all]
+            [metabase.query-processor.streaming.interface :as qp.si]
             [metabase.test :as mt]
-            [metabase.test.data.dataset-definitions :as defs]))
+            [metabase.test.data.dataset-definitions :as defs])
+  (:import [java.io BufferedOutputStream ByteArrayOutputStream]))
 
 (defn- parse-and-sort-csv [response]
   (assert (some? response))
@@ -55,3 +57,23 @@
             ["4" "Simcha Yan"          "2014-01-01T08:30:00"]
             ["5" "Quentin Sören"       "2014-10-03T17:30:00"]]
            (parse-and-sort-csv result)))))
+
+(defn- csv-export
+  "Given a seq of result rows, write it as a CSV, then read the CSV and return the resulting data."
+  [rows]
+  (with-open [bos (ByteArrayOutputStream.)
+              os  (BufferedOutputStream. bos)]
+    (let [results-writer (qp.si/streaming-results-writer :csv os)]
+      (qp.si/begin! results-writer {:data {:ordered-cols []}} {})
+      (doall (map-indexed
+              (fn [i row] (qp.si/write-row! results-writer row i [] {}))
+              rows))
+      (qp.si/finish! results-writer {:row_count (count rows)}))
+    (let [bytea (.toByteArray bos)]
+      (rest (csv/read-csv (String. bytea))))))
+
+(deftest lazy-seq-realized-test
+  (testing "Lazy seqs within rows are automatically realized during exports (#26261)"
+    (let [row (first (csv-export [[(lazy-seq [1 2 3])]]))]
+      (is (= ["(1 2 3)"] row))
+      (is (not (instance? clojure.lang.LazySeq row))))))

--- a/test/metabase/query_processor/streaming/csv_test.clj
+++ b/test/metabase/query_processor/streaming/csv_test.clj
@@ -2,7 +2,6 @@
   (:require [cheshire.core :as json]
             [clojure.data.csv :as csv]
             [clojure.test :refer :all]
-            [java-time :as t]
             [metabase.query-processor.streaming.interface :as qp.si]
             [metabase.test :as mt]
             [metabase.test.data.dataset-definitions :as defs])

--- a/test/metabase/query_processor/streaming/csv_test.clj
+++ b/test/metabase/query_processor/streaming/csv_test.clj
@@ -78,8 +78,8 @@
       (is (= ["[1 2 3]"] row))))
 
   (testing "ZonedDateTime in a lazy seq (checking that elements in a lazy seq are formatted correctly)"
-    (mt/with-driver :postgres
-      (mt/with-report-timezone-id "US/Pacific"
-        (mt/with-everything-store
-          (let [row (first (csv-export [[(lazy-seq [#t "2021-03-30T20:06:00Z"])]]))]
-            (is (= ["[\"2021-03-30T13:06:00-07:00\"]"] row))))))))
+    (mt/test-drivers (mt/normal-drivers)
+     (mt/with-report-timezone-id "US/Pacific"
+       (mt/with-everything-store
+         (let [row (first (csv-export [[(lazy-seq [#t "2021-03-30T20:06:00Z"])]]))]
+           (is (= ["[\"2021-03-30T20:06:00Z\"]"] row))))))))

--- a/test/metabase/query_processor/streaming/csv_test.clj
+++ b/test/metabase/query_processor/streaming/csv_test.clj
@@ -77,9 +77,7 @@
     (let [row (first (csv-export [[(lazy-seq [1 2 3])]]))]
       (is (= ["[1 2 3]"] row))))
 
-  (testing "ZonedDateTime in a lazy seq (checking that elements in a lazy seq are formatted correctly)"
-    (mt/test-drivers (mt/normal-drivers)
-     (mt/with-report-timezone-id "US/Pacific"
-       (mt/with-everything-store
-         (let [row (first (csv-export [[(lazy-seq [#t "2021-03-30T20:06:00Z"])]]))]
-           (is (= ["[\"2021-03-30T20:06:00Z\"]"] row))))))))
+  (testing "LocalDate in a lazy seq (checking that elements in a lazy seq are formatted correctly as strings)"
+   (mt/with-everything-store
+     (let [row (first (csv-export [[(lazy-seq [#t "2021-03-30T"])]]))]
+       (is (= ["[\"2021-03-30\"]"] row))))))

--- a/test/metabase/query_processor/streaming_test.clj
+++ b/test/metabase/query_processor/streaming_test.clj
@@ -131,7 +131,7 @@
 ;; see also `metabase.query-processor.streaming.xlsx-test/report-timezone-test`
 ;; TODO this test doesn't seem to run?
 (deftest report-timezone-test
-  (testing "Export downloads should format stuff with the report timezone rather than UTC (#13677)\n"
+  (testing "Export downloads should format stuff with the report timezone rather than UTC (#13677)"
     (mt/test-driver :postgres
       (let [query     (mt/dataset attempted-murders
                         (mt/mbql-query attempts


### PR DESCRIPTION
Resolves #26261

The issue is that apparently BigQuery arrays are represented as Clojure lazy seqs when they get to the CSV streaming code, and the CSV writer just converts these to the string representation of the class (unlike XLSX/JSON which apparently realize the data automatically).

I've extended the `FormatValue` protocol to handle `clojure.lang.LazySeq` and convert it to a normal, non-lazy list before we write it.