### PR TITLE
Serdes v2: Migrate `DashboardCard`s to be inlined in their `Dashboard`s

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/models.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/models.clj
@@ -5,7 +5,6 @@
   ["Card"
    "Collection"
    "Dashboard"
-   "DashboardCard"
    "Database"
    "Dimension"
    "Field"

--- a/enterprise/backend/test/metabase_enterprise/serialization/api/serialize_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/api/serialize_test.clj
@@ -45,16 +45,8 @@
              (is (= 1
                     (count (files "Collection")))))
            (testing "Dashboard"
-             (is (= 2
-                    (count (files "Dashboard"))))
-             (let [[f1 f2]         (files "Dashboard")
-                   [path-1 path-2] (map u.files/get-path [f1 f2])]
-               (testing "Should have one subdirectory"
-                 (is (= 1
-                        (count (filter true? (map u.files/regular-file? [path-1 path-2]))))))
-               (let [subdirectory-path (first (remove u.files/regular-file? [path-1 path-2]))]
-                 (is (= 1
-                        (count (path-files subdirectory-path)))))))))))))
+             (is (= 1
+                    (count (files "Dashboard")))))))))))
 
 (deftest serialize-data-model-validation-test
   (do-serialize-data-model

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/e2e/yaml_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/e2e/yaml_test.clj
@@ -178,14 +178,6 @@
           (testing "for dashboards"
             (is (= 100 (count (dir->file-set (io/file dump-dir "Dashboard"))))))
 
-          (testing "for dashboard cards"
-            (is (= 300
-                   (reduce + (for [dash (get @entities "Dashboard")
-                                   :let [card-dir (io/file dump-dir "Dashboard" (:entity_id dash) "DashboardCard")]]
-                               (if (.exists card-dir)
-                                 (count (dir->file-set card-dir))
-                                 0))))))
-
           (testing "for dimensions"
             (is (= 40 (count (dir->file-set (io/file dump-dir "Dimension"))))))
 

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
@@ -182,16 +182,14 @@
                                                                :collection_id dave-coll-id
                                                                :creator_id    mark-id
                                                                :parameters    []}]
-                       DashboardCard [{dc1-id  :id
-                                       dc1-eid :entity_id}    {:card_id      c1-id
+                       DashboardCard [_                       {:card_id      c1-id
                                                                :dashboard_id dash-id
                                                                :parameter_mappings
                                                                [{:parameter_id "12345678"
                                                                  :card_id      c1-id
                                                                  :target [:dimension [:field field-id
                                                                                       {:source-field field2-id}]]}]}]
-                       DashboardCard [{dc2-id  :id
-                                       dc2-eid :entity_id}    {:card_id      c2-id
+                       DashboardCard [_                       {:card_id      c2-id
                                                                :dashboard_id other-dash-id
                                                                :visualization_settings
                                                                {:table.pivot_column "SOURCE"
@@ -312,31 +310,6 @@
                       {:model "Schema"     :id "PUBLIC"}
                       {:model "Table"      :id "Schema'd Table"}
                       {:model "Field"      :id "Other Field"}]}
-                   (set (serdes.base/serdes-dependencies ser))))))
-
-        (let [ser (serdes.base/extract-one "DashboardCard" {} (db/select-one 'DashboardCard :id dc1-id))]
-          (is (schema= {:serdes/meta         (s/eq [{:model "Dashboard" :id dash-eid}
-                                                    {:model "DashboardCard" :id dc1-eid}])
-                        :dashboard_id        (s/eq dash-eid)
-                        :parameter_mappings  (s/eq [{:parameter_id "12345678"
-                                                     :card_id      c1-eid
-                                                     :target [:dimension [:field ["My Database" nil "Schemaless Table" "Some Field"]
-                                                                          {:source-field ["My Database" "PUBLIC" "Schema'd Table" "Other Field"]}]]}])
-                        :created_at          LocalDateTime
-                        s/Keyword            s/Any}
-                       ser))
-          (is (not (contains? ser :id)))
-
-          (testing "cards depend on their Dashboard and Card, and any fields in their parameter_mappings"
-            (is (= #{[{:model "Card"       :id c1-eid}]
-                     [{:model "Dashboard"  :id dash-eid}]
-                     [{:model "Database"   :id "My Database"}
-                      {:model "Table"      :id "Schemaless Table"}
-                      {:model "Field"      :id "Some Field"}]
-                     [{:model "Database"   :id "My Database"}
-                      {:model "Schema"     :id "PUBLIC"}
-                      {:model "Table"      :id "Schema'd Table"}
-                      {:model "Field"      :id "Other Field"}]}
                    (set (serdes.base/serdes-dependencies ser)))))))
 
       (testing "Cards can be based on other cards"
@@ -362,43 +335,45 @@
                      [{:model "Card"       :id c4-eid}]}
                    (set (serdes.base/serdes-dependencies ser)))))))
 
-      (testing "Dashcard :visualization_settings are included in their deps"
-        (let [ser (serdes.base/extract-one "DashboardCard" {} (db/select-one 'DashboardCard :id dc2-id))]
-          (is (schema= {:serdes/meta            (s/eq [{:model "Dashboard" :id other-dash}
-                                                       {:model "DashboardCard" :id dc2-eid}])
-                        :dashboard_id           (s/eq other-dash)
-                        :visualization_settings (s/eq {:table.pivot_column "SOURCE"
-                                                       :table.cell_column "sum"
-                                                       :table.columns
-                                                       [{:name "SOME_FIELD"
-                                                         :fieldRef [:field ["My Database" nil "Schemaless Table" "Some Field"] nil]
-                                                         :enabled true}
-                                                        {:name "sum"
-                                                         :fieldRef [:field "sum" {:base-type :type/Float}]
-                                                         :enabled true}
-                                                        {:name "count"
-                                                         :fieldRef [:field "count" {:base-type :type/BigInteger}]
-                                                         :enabled true}
-                                                        {:name "Average order total"
-                                                         :fieldRef [:field "Average order total" {:base-type :type/Float}]
-                                                         :enabled true}]
-                                                       :column_settings
-                                                       {"[\"ref\",[\"field\",[\"My Database\",\"PUBLIC\",\"Schema'd Table\",\"Other Field\"],null]]" {:column_title "Locus"}}})
+      (testing "Dashboards include their Dashcards"
+        (let [ser (serdes.base/extract-one "Dashboard" {} (db/select-one 'Dashboard :id other-dash-id))]
+          (is (schema= {:serdes/meta            (s/eq [{:model "Dashboard" :id other-dash}])
+                        :entity_id              (s/eq other-dash)
+                        :ordered_cards
+                        [{:visualization_settings (s/eq {:table.pivot_column "SOURCE"
+                                                         :table.cell_column "sum"
+                                                         :table.columns
+                                                         [{:name "SOME_FIELD"
+                                                           :fieldRef [:field ["My Database" nil "Schemaless Table" "Some Field"] nil]
+                                                           :enabled true}
+                                                          {:name "sum"
+                                                           :fieldRef [:field "sum" {:base-type :type/Float}]
+                                                           :enabled true}
+                                                          {:name "count"
+                                                           :fieldRef [:field "count" {:base-type :type/BigInteger}]
+                                                           :enabled true}
+                                                          {:name "Average order total"
+                                                           :fieldRef [:field "Average order total" {:base-type :type/Float}]
+                                                           :enabled true}]
+                                                         :column_settings
+                                                         {"[\"ref\",[\"field\",[\"My Database\",\"PUBLIC\",\"Schema'd Table\",\"Other Field\"],null]]" {:column_title "Locus"}}})
+                          :created_at             LocalDateTime
+                          s/Keyword               s/Any}]
                         :created_at             LocalDateTime
                         s/Keyword               s/Any}
                        ser))
           (is (not (contains? ser :id)))
 
-          (testing "DashboardCard depend on their Dashboard and Card, and any fields in their visualization_settings"
+          (testing "and depend on all referenced cards, including those in visualization_settings"
             (is (= #{[{:model "Card"       :id c2-eid}]
-                     [{:model "Dashboard"  :id other-dash}]
                      [{:model "Database"   :id "My Database"}
                       {:model "Table"      :id "Schemaless Table"}
                       {:model "Field"      :id "Some Field"}]
                      [{:model "Database"   :id "My Database"}
                       {:model "Schema"     :id "PUBLIC"}
                       {:model "Table"      :id "Schema'd Table"}
-                      {:model "Field"      :id "Other Field"}]}
+                      {:model "Field"      :id "Other Field"}]
+                     [{:model "Collection" :id dave-coll-eid}]}
                    (set (serdes.base/serdes-dependencies ser)))))))
 
       (testing "collection filtering based on :user option"
@@ -431,23 +406,7 @@
           (is (= #{dash-eid other-dash}
                  (->> {:collection-set (extract/collection-set-for-user dave-id)}
                       (serdes.base/extract-all "Dashboard")
-                      (by-model "Dashboard"))))))
-
-      (testing "dashboard cards are filtered based on :user"
-        (testing "dashboard cards whose dashboards are in unowned collections are always returned"
-          (is (= #{dc1-eid}
-                 (->> {:collection-set (extract/collection-set-for-user nil)}
-                      (serdes.base/extract-all "DashboardCard")
-                      (by-model "DashboardCard"))))
-          (is (= #{dc1-eid}
-                 (->> {:collection-set (extract/collection-set-for-user mark-id)}
-                      (serdes.base/extract-all "DashboardCard")
-                      (by-model "DashboardCard")))))
-        (testing "dashboard cards whose dashboards are in personal collections are returned for the :user"
-          (is (= #{dc1-eid dc2-eid}
-                 (->> {:collection-set (extract/collection-set-for-user dave-id)}
-                      (serdes.base/extract-all "DashboardCard")
-                      (by-model "DashboardCard")))))))))
+                      (by-model "Dashboard")))))))))
 
 (deftest dimensions-test
   (ts/with-empty-h2-app-db
@@ -908,10 +867,10 @@
                        ser))
           (is (not (contains? ser :id)))
 
-          (testing "depends on the pulse, card and dashcard"
+          (testing "depends on the pulse, card and parent dashboard"
             (is (= #{[{:model "Pulse" :id sub-eid}]
                      [{:model "Card"  :id card1-eid}]
-                     [{:model "Dashboard" :id dash-eid} {:model "DashboardCard" :id dashcard-eid}]}
+                     [{:model "Dashboard" :id dash-eid}]}
                    (set (serdes.base/serdes-dependencies ser))))))))))
 
 (deftest selective-serialization-basic-test
@@ -960,9 +919,9 @@
                                                                :collection_id coll1-id
                                                                :creator_id    mark-id}]
 
-                       DashboardCard [{dc1-1-eid :entity_id}  {:card_id      c1-1-id
+                       DashboardCard [_                       {:card_id      c1-1-id
                                                                :dashboard_id dash1-id}]
-                       DashboardCard [{dc1-2-eid :entity_id}  {:card_id      c1-2-id
+                       DashboardCard [_                       {:card_id      c1-2-id
                                                                :dashboard_id dash1-id}]
 
                        ;; Second dashboard, in the middle collection.
@@ -988,9 +947,9 @@
                                                                :collection_id coll2-id
                                                                :creator_id    mark-id}]
 
-                       DashboardCard [{dc2-1-eid :entity_id}  {:card_id      c2-1-id
+                       DashboardCard [_                       {:card_id      c2-1-id
                                                                :dashboard_id dash2-id}]
-                       DashboardCard [{dc2-2-eid :entity_id}  {:card_id      c2-2-id
+                       DashboardCard [_                       {:card_id      c2-2-id
                                                                :dashboard_id dash2-id}]
 
                        ;; Third dashboard, in the grandchild collection.
@@ -1016,18 +975,14 @@
                                                                :collection_id coll3-id
                                                                :creator_id    mark-id}]
 
-                       DashboardCard [{dc3-1-eid :entity_id}  {:card_id      c3-1-id
+                       DashboardCard [_                       {:card_id      c3-1-id
                                                                :dashboard_id dash3-id}]
-                       DashboardCard [{dc3-2-eid :entity_id}  {:card_id      c3-2-id
+                       DashboardCard [_                       {:card_id      c3-2-id
                                                                :dashboard_id dash3-id}]]
 
-      (testing "selecting a dashboard gets its dashcards and cards as well"
+      (testing "selecting a dashboard gets all cards its dashcards depend on"
         (testing "grandparent dashboard"
           (is (= #{[{:model "Dashboard" :id dash1-eid}]
-                   [{:model "Dashboard" :id dash1-eid}
-                    {:model "DashboardCard" :id dc1-1-eid}]
-                   [{:model "Dashboard" :id dash1-eid}
-                    {:model "DashboardCard" :id dc1-2-eid}]
                    [{:model "Card" :id c1-1-eid}]
                    [{:model "Card" :id c1-2-eid}]}
                  (->> (extract/extract-subtrees {:targets [["Dashboard" dash1-id]]})
@@ -1036,10 +991,6 @@
 
         (testing "middle dashboard"
           (is (= #{[{:model "Dashboard" :id dash2-eid}]
-                   [{:model "Dashboard" :id dash2-eid}
-                    {:model "DashboardCard" :id dc2-1-eid}]
-                   [{:model "Dashboard" :id dash2-eid}
-                    {:model "DashboardCard" :id dc2-2-eid}]
                    [{:model "Card" :id c2-1-eid}]
                    [{:model "Card" :id c2-2-eid}]}
                  (->> (extract/extract-subtrees {:targets [["Dashboard" dash2-id]]})
@@ -1048,10 +999,6 @@
 
         (testing "grandchild dashboard"
           (is (= #{[{:model "Dashboard" :id dash3-eid}]
-                   [{:model "Dashboard" :id dash3-eid}
-                    {:model "DashboardCard" :id dc3-1-eid}]
-                   [{:model "Dashboard" :id dash3-eid}
-                    {:model "DashboardCard" :id dc3-2-eid}]
                    [{:model "Card" :id c3-1-eid}]
                    [{:model "Card" :id c3-2-eid}]}
                  (->> (extract/extract-subtrees {:targets [["Dashboard" dash3-id]]})
@@ -1061,28 +1008,16 @@
       (testing "selecting a collection gets all its contents"
         (let [grandchild-paths  #{[{:model "Collection"    :id coll3-eid :label "grandchild_collection"}]
                                   [{:model "Dashboard"     :id dash3-eid}]
-                                  [{:model "Dashboard"     :id dash3-eid}
-                                   {:model "DashboardCard" :id dc3-1-eid}]
-                                  [{:model "Dashboard"     :id dash3-eid}
-                                   {:model "DashboardCard" :id dc3-2-eid}]
                                   [{:model "Card"          :id c3-1-eid}]
                                   [{:model "Card"          :id c3-2-eid}]
                                   [{:model "Card"          :id c3-3-eid}]}
               middle-paths      #{[{:model "Collection"    :id coll2-eid :label "nested_collection"}]
                                   [{:model "Dashboard"     :id dash2-eid}]
-                                  [{:model "Dashboard"     :id dash2-eid}
-                                   {:model "DashboardCard" :id dc2-1-eid}]
-                                  [{:model "Dashboard"     :id dash2-eid}
-                                   {:model "DashboardCard" :id dc2-2-eid}]
                                   [{:model "Card"          :id c2-1-eid}]
                                   [{:model "Card"          :id c2-2-eid}]
                                   [{:model "Card"          :id c2-3-eid}]}
               grandparent-paths #{[{:model "Collection"    :id coll1-eid :label "some_collection"}]
                                   [{:model "Dashboard"     :id dash1-eid}]
-                                  [{:model "Dashboard"     :id dash1-eid}
-                                   {:model "DashboardCard" :id dc1-1-eid}]
-                                  [{:model "Dashboard"     :id dash1-eid}
-                                   {:model "DashboardCard" :id dc1-2-eid}]
                                   [{:model "Card"          :id c1-1-eid}]
                                   [{:model "Card"          :id c1-2-eid}]
                                   [{:model "Card"          :id c1-3-eid}]}]

--- a/src/metabase/models/dashboard.clj
+++ b/src/metabase/models/dashboard.clj
@@ -410,31 +410,71 @@
 ;;; |                                               SERIALIZATION                                                    |
 ;;; +----------------------------------------------------------------------------------------------------------------+
 (defmethod serdes.base/extract-query "Dashboard" [_ {:keys [collection-set]}]
-  (if (seq collection-set)
-    (db/select-reducible Dashboard :collection_id [:in collection-set])
-    (db/select-reducible Dashboard)))
+  (eduction (map #(hydrate % :ordered_cards))
+            (if (seq collection-set)
+              (db/select-reducible Dashboard :collection_id [:in collection-set])
+              (db/select-reducible Dashboard))))
 
-;; TODO Maybe nest collections -> dashboards -> dashcards?
+(defn- extract-dashcard
+  [dashcard]
+  (-> (into (sorted-map) dashcard)
+      (dissoc :id :collection_authority_level :dashboard_id :updated_at)
+      (update :card_id                serdes.util/export-fk 'Card)
+      (update :parameter_mappings     serdes.util/export-parameter-mappings)
+      (update :visualization_settings serdes.util/export-visualization-settings)))
+
 (defmethod serdes.base/extract-one "Dashboard"
   [_model-name _opts dash]
-  (-> (serdes.base/extract-one-basics "Dashboard" dash)
-      (update :collection_id     serdes.util/export-fk 'Collection)
-      (update :creator_id        serdes.util/export-user)
-      (update :made_public_by_id serdes.util/export-user)))
+  (let [dash (if (contains? dash :ordered_cards)
+               dash
+               (hydrate dash :ordered_cards))]
+    (-> (serdes.base/extract-one-basics "Dashboard" dash)
+        (update :ordered_cards     #(mapv extract-dashcard %))
+        (update :collection_id     serdes.util/export-fk 'Collection)
+        (update :creator_id        serdes.util/export-user)
+        (update :made_public_by_id serdes.util/export-user))))
 
 (defmethod serdes.base/load-xform "Dashboard"
   [dash]
   (-> dash
       serdes.base/load-xform-basics
+      ;; Deliberately not doing anything to :ordered_cards - they get handled by load-insert! and load-update! below.
       (update :collection_id     serdes.util/import-fk 'Collection)
       (update :creator_id        serdes.util/import-user)
       (update :made_public_by_id serdes.util/import-user)))
 
+(defn- dashcard-for [dashcard dashboard]
+  (assoc dashcard
+         :dashboard_id (:entity_id dashboard)
+         :serdes/meta [{:model "Dashboard"     :id (:entity_id dashboard)}
+                       {:model "DashboardCard" :id (:entity_id dashcard)}]))
+
+;; Call the default load-one! for the Dashboard, then for each DashboardCard.
+(defmethod serdes.base/load-one! "Dashboard" [ingested maybe-local]
+  (let [dashboard ((get-method serdes.base/load-one! :default) (dissoc ingested :ordered_cards) maybe-local)]
+    (doseq [dashcard (:ordered_cards ingested)]
+      (serdes.base/load-one! (dashcard-for dashcard dashboard)
+                             (db/select-one 'DashboardCard :entity_id (:entity_id dashcard))))))
+
+(defn- serdes-deps-dashcard
+  [{:keys [card_id parameter_mappings visualization_settings]}]
+  (->> (mapcat serdes.util/mbql-deps parameter_mappings)
+       (concat (serdes.util/visualization-settings-deps visualization_settings))
+       (concat (when card_id #{[{:model "Card" :id card_id}]}))
+       set))
+
 (defmethod serdes.base/serdes-dependencies "Dashboard"
-  [{:keys [collection_id]}]
-  [[{:model "Collection" :id collection_id}]])
+  [{:keys [collection_id ordered_cards]}]
+  (->> ordered_cards
+       (map serdes-deps-dashcard)
+       (reduce set/union #{[{:model "Collection" :id collection_id}]})))
 
 (defmethod serdes.base/serdes-descendants "Dashboard" [_model-name id]
-  ;; Return the set of DashboardCards that belong to this dashboard.
-  (set (for [dc-id (db/select-ids 'DashboardCard :dashboard_id id)]
-         ["DashboardCard" dc-id])))
+  ;; DashboardCards are inlined into Dashboards, but we need to capture what those those DashboardCards rely on
+  ;; here. So their cards, both direct and mentioned in their parameters.
+  (set (for [{:keys [card_id parameter_mappings]} (db/select ['DashboardCard :card_id :parameter_mappings]
+                                                             :dashboard_id id)
+             ;; Capture all card_ids in the parameters, plus this dashcard's card_id if non-nil.
+             card-id  (cond-> (set (keep :card_id parameter_mappings))
+                        card_id (conj card_id))]
+         ["Card" card-id])))

--- a/src/metabase/models/dashboard_card.clj
+++ b/src/metabase/models/dashboard_card.clj
@@ -221,47 +221,17 @@
     (events/publish-event! :dashboard-remove-cards {:id id :actor_id user-id :dashcards [dashboard-card]})))
 
 ;;; ----------------------------------------------- SERIALIZATION ----------------------------------------------------
-(defmethod serdes.base/extract-query "DashboardCard" [_ {:keys [collection-set]}]
-  (if (seq collection-set)
-    (let [dashboards (db/select-ids 'Dashboard :collection_id [:in collection-set])]
-      (when (seq dashboards)
-        (db/select-reducible DashboardCard :dashboard_id [:in dashboards])))
-    (db/select-reducible DashboardCard)))
-
-(defmethod serdes.base/serdes-dependencies "DashboardCard"
-  [{:keys [card_id dashboard_id parameter_mappings visualization_settings]}]
-  (->> (mapcat serdes.util/mbql-deps parameter_mappings)
-       (concat (serdes.util/visualization-settings-deps visualization_settings))
-       (concat #{[{:model "Dashboard" :id dashboard_id}] })
-       (concat (when card_id #{[{:model "Card" :id card_id}]}))
-       set))
-
+;; DashboardCards are not serialized as their own, separate entities. They are inlined onto their parent Dashboards.
+;; However, we can reuse some of the serdes machinery (especially load-one!) by implementing a few serdes methods.
 (defmethod serdes.base/serdes-generate-path "DashboardCard" [_ dashcard]
   [(serdes.base/infer-self-path "Dashboard" (db/select-one 'Dashboard :id (:dashboard_id dashcard)))
    (serdes.base/infer-self-path "DashboardCard" dashcard)])
 
-(defmethod serdes.base/extract-one "DashboardCard"
-  [_model-name _opts dashcard]
-  (-> (serdes.base/extract-one-basics "DashboardCard" dashcard)
-      (update :card_id                serdes.util/export-fk 'Card)
-      (update :dashboard_id           serdes.util/export-fk 'Dashboard)
-      (update :parameter_mappings     serdes.util/export-parameter-mappings)
-      (update :visualization_settings serdes.util/export-visualization-settings)))
-
 (defmethod serdes.base/load-xform "DashboardCard"
   [dashcard]
-  (-> (serdes.base/load-xform-basics dashcard)
+  (-> dashcard
+      (dissoc :serdes/meta)
       (update :card_id                serdes.util/import-fk 'Card)
       (update :dashboard_id           serdes.util/import-fk 'Dashboard)
       (update :parameter_mappings     serdes.util/import-parameter-mappings)
       (update :visualization_settings serdes.util/import-visualization-settings)))
-
-(defmethod serdes.base/serdes-descendants "DashboardCard" [_model-name id]
-  (let [{:keys [card_id dashboard_id parameter_mappings]} (db/select-one DashboardCard :id id)
-        cards-in-params (set (for [{:keys [card_id]} parameter_mappings
-                                   :when card_id]
-                               ["Card" card_id]))]
-    (cond-> #{["Dashboard" dashboard_id]}
-      ;; card_id is nil for text cards; in that case there's no Card to depend on.
-      card_id               (conj ["Card" card_id])
-      (seq cards-in-params) (set/union cards-in-params))))

--- a/src/metabase/models/pulse_card.clj
+++ b/src/metabase/models/pulse_card.clj
@@ -76,6 +76,6 @@
 (defmethod serdes.base/serdes-dependencies "PulseCard" [{:keys [card_id dashboard_card_id pulse_id]}]
   (let [base [[{:model "Card" :id card_id}]
               [{:model "Pulse" :id pulse_id}]]]
-    (if-let [[dash-id dc-id] dashboard_card_id]
-      (conj base [{:model "Dashboard" :id dash-id} {:model "DashboardCard" :id dc-id}])
+    (if-let [[dash-id _] dashboard_card_id]
+      (conj base [{:model "Dashboard" :id dash-id} ])
       base)))


### PR DESCRIPTION
This stops serializing `DashboardCard` is its own top-level entity.
Things that used to depend on `DashboardCard` (`PulseCard`) now depend on the
parent `Dashboard` instead.

`Dashboard`s now have the underlying `Card`s as direct `serdes-descendants`,
rather than transitively through `DashboardCard`.
