### PR TITLE
Refactor ItemPicker 4 — Convert to TypeScript

### DIFF
--- a/frontend/src/metabase/containers/ItemPicker/Item.styled.tsx
+++ b/frontend/src/metabase/containers/ItemPicker/Item.styled.tsx
@@ -8,7 +8,7 @@ import { color } from "metabase/lib/colors";
 export interface ItemRootProps {
   canSelect: boolean;
   isSelected: boolean;
-  hasChildren: boolean;
+  hasChildren?: boolean;
 }
 
 export const ItemRoot = styled.div<ItemRootProps>`

--- a/frontend/src/metabase/containers/ItemPicker/Item.tsx
+++ b/frontend/src/metabase/containers/ItemPicker/Item.tsx
@@ -1,10 +1,25 @@
-/* eslint-disable react/prop-types */
 import React, { useCallback, useMemo } from "react";
 import _ from "underscore";
 
-import Icon from "metabase/components/Icon";
+import Icon, { IconProps } from "metabase/components/Icon";
 
 import { ItemRoot, ItemContent, ItemTitle, ExpandButton } from "./Item.styled";
+
+type IItem = {
+  id: number | string;
+};
+
+interface Props {
+  item: IItem;
+  name: string;
+  icon: string | IconProps;
+  color: string;
+  selected: boolean;
+  canSelect: boolean;
+  hasChildren: boolean;
+  onChange: (item: IItem) => void;
+  onChangeOpenCollectionId: (id: number | string) => void;
+}
 
 function Item({
   item,
@@ -16,7 +31,7 @@ function Item({
   hasChildren,
   onChange,
   onChangeOpenCollectionId,
-}) {
+}: Props) {
   const handleClick = useMemo(() => {
     if (canSelect) {
       return () => onChange(item);

--- a/frontend/src/metabase/containers/ItemPicker/Item.tsx
+++ b/frontend/src/metabase/containers/ItemPicker/Item.tsx
@@ -3,22 +3,20 @@ import _ from "underscore";
 
 import Icon, { IconProps } from "metabase/components/Icon";
 
+import type { PickerItem, PickerItemId } from "./types";
+
 import { ItemRoot, ItemContent, ItemTitle, ExpandButton } from "./Item.styled";
 
-type IItem = {
-  id: number | string;
-};
-
 interface Props {
-  item: IItem;
+  item: PickerItem;
   name: string;
   icon: string | IconProps;
   color: string;
   selected: boolean;
   canSelect: boolean;
-  hasChildren: boolean;
-  onChange: (item: IItem) => void;
-  onChangeOpenCollectionId: (id: number | string) => void;
+  hasChildren?: boolean;
+  onChange: (item: PickerItem) => void;
+  onChangeOpenCollectionId?: (id: PickerItemId) => void;
 }
 
 function Item({
@@ -37,7 +35,7 @@ function Item({
       return () => onChange(item);
     }
     if (hasChildren) {
-      return () => onChangeOpenCollectionId(item.id);
+      return () => onChangeOpenCollectionId?.(item.id);
     }
     return;
   }, [item, canSelect, hasChildren, onChange, onChangeOpenCollectionId]);
@@ -45,7 +43,7 @@ function Item({
   const handleExpand = useCallback(
     event => {
       event.stopPropagation();
-      onChangeOpenCollectionId(item.id);
+      onChangeOpenCollectionId?.(item.id);
     },
     [item, onChangeOpenCollectionId],
   );

--- a/frontend/src/metabase/containers/ItemPicker/types.ts
+++ b/frontend/src/metabase/containers/ItemPicker/types.ts
@@ -1,0 +1,26 @@
+import { IconProps } from "metabase/components/Icon";
+
+import type { Collection } from "metabase-types/api";
+
+export type PickerModel =
+  | "card"
+  | "collection"
+  | "dataset"
+  | "dashboard"
+  | "page";
+
+export type PickerItemId = number | null;
+
+export type PickerValue = { id: PickerItemId; model: PickerModel };
+
+export type PickerItem = {
+  id: PickerItemId;
+  model: PickerModel;
+  collection_id: Collection["id"];
+  can_write: boolean;
+
+  // Coming from `wrapped` entities
+  getName: () => string;
+  getColor: () => string;
+  getIcon: () => IconProps;
+};


### PR DESCRIPTION
Converts recently refactored `ItemPicker` to TypeScript. The next step is to break it down into container and view components.