### PR TITLE
Check for PK requirement on Parameters

### DIFF
--- a/frontend/src/metabase-lib/metadata/Field.ts
+++ b/frontend/src/metabase-lib/metadata/Field.ts
@@ -57,7 +57,6 @@ class FieldInner extends Base {
   name: string;
   description: string | null;
   semantic_type: string | null;
-  database_required: boolean;
   fingerprint?: FieldFingerprint;
   base_type: string | null;
   table?: Table;

--- a/frontend/src/metabase-types/types/Parameter.ts
+++ b/frontend/src/metabase-types/types/Parameter.ts
@@ -44,6 +44,7 @@ export interface Parameter {
   slug: string;
   sectionId?: string;
   default?: any;
+  required?: boolean;
   filteringParameters?: ParameterId[];
   isMultiSelect?: boolean;
   value?: any;

--- a/frontend/src/metabase/writeback/components/ActionCreator/FormCreator/utils.ts
+++ b/frontend/src/metabase/writeback/components/ActionCreator/FormCreator/utils.ts
@@ -89,7 +89,7 @@ export const getFormField = (
 ) => {
   if (
     fieldSettings.fieldInstance &&
-    !isEditableField(fieldSettings.fieldInstance, parameter)
+    !isEditableField(fieldSettings.fieldInstance, parameter as Parameter)
   ) {
     return undefined;
   }

--- a/frontend/src/metabase/writeback/components/ActionCreator/FormCreator/utils.ts
+++ b/frontend/src/metabase/writeback/components/ActionCreator/FormCreator/utils.ts
@@ -89,7 +89,7 @@ export const getFormField = (
 ) => {
   if (
     fieldSettings.fieldInstance &&
-    !isEditableField(fieldSettings.fieldInstance)
+    !isEditableField(fieldSettings.fieldInstance, parameter)
   ) {
     return undefined;
   }
@@ -191,7 +191,7 @@ export const generateFieldSettingsFromParameters = (
       name,
       title: displayName,
       placeholder: displayName,
-      required: !!field?.database_required,
+      required: !!param?.required,
       description: field?.description ?? "",
       fieldType: getFieldType(param),
       inputType: getInputType(param, field),

--- a/frontend/src/metabase/writeback/components/ActionCreator/FormCreator/utils.unit.spec.ts
+++ b/frontend/src/metabase/writeback/components/ActionCreator/FormCreator/utils.unit.spec.ts
@@ -141,10 +141,8 @@ describe("writeback > ActionCreator > FormCreator > utils", () => {
     });
 
     it("sets required prop", () => {
-      const fields = [
-        createField({ name: "test-field", database_required: true }),
-      ];
-      const params = [createParameter({ id: "test-field" })];
+      const fields = [createField({ name: "test-field" })];
+      const params = [createParameter({ id: "test-field", required: true })];
       const [id, settings] = getFirstEntry(
         generateFieldSettingsFromParameters(params, fields),
       );
@@ -153,10 +151,8 @@ describe("writeback > ActionCreator > FormCreator > utils", () => {
     });
 
     it("sets required prop", () => {
-      const fields = [
-        createField({ name: "test-field", database_required: false }),
-      ];
-      const params = [createParameter({ id: "test-field" })];
+      const fields = [createField({ name: "test-field" })];
+      const params = [createParameter({ id: "test-field", required: false })];
       const [id, settings] = getFirstEntry(
         generateFieldSettingsFromParameters(params, fields),
       );

--- a/frontend/src/metabase/writeback/utils.ts
+++ b/frontend/src/metabase/writeback/utils.ts
@@ -53,7 +53,7 @@ export const isEditableField = (field: Field, parameter: Parameter) => {
   if (field.isPK()) {
     // Most of the time PKs are auto-generated,
     // but there are rare cases when they're not
-    // In this case they're marked as `database_required`
+    // In this case they're marked as `required`
     return parameter.required;
   }
 

--- a/frontend/src/metabase/writeback/utils.ts
+++ b/frontend/src/metabase/writeback/utils.ts
@@ -7,6 +7,7 @@ import type {
 } from "metabase-types/api";
 import type { SavedCard } from "metabase-types/types/Card";
 import type { DashCard } from "metabase-types/types/Dashboard";
+import type { Parameter } from "metabase-types/types/Parameter";
 
 import { TYPE } from "metabase-lib/types/constants";
 import type Database from "metabase-lib/metadata/Database";
@@ -42,7 +43,7 @@ const isAutomaticDateTimeField = (field: Field) => {
   return AUTOMATIC_DATE_TIME_FIELDS.includes(field.semantic_type);
 };
 
-export const isEditableField = (field: Field) => {
+export const isEditableField = (field: Field, parameter: Parameter) => {
   const isRealField = typeof field.id === "number";
   if (!isRealField) {
     // Filters out custom, aggregated columns, etc.
@@ -53,11 +54,11 @@ export const isEditableField = (field: Field) => {
     // Most of the time PKs are auto-generated,
     // but there are rare cases when they're not
     // In this case they're marked as `database_required`
-    return field.database_required;
+    return parameter.required;
   }
 
   if (isAutomaticDateTimeField(field)) {
-    return field.database_required;
+    return parameter.required;
   }
 
   return true;


### PR DESCRIPTION
## Description
- we now populate whether a field is required from a fancy new parameter property: `required`, so we can show that as a field where we would otherwise let it autogen.

*(trust me, this table does not auto-generate primary keys)*

![Screen Shot 2022-11-09 at 1 25 08 PM](https://user-images.githubusercontent.com/30528226/200935691-a8c7a80e-1bb0-4815-a588-10ca73806a03.png)
