### PR TITLE
Datetime extraction and arithmetics for text column in mongo

### DIFF
--- a/modules/drivers/mongo/test/metabase/driver/mongo/query_processor_test.clj
+++ b/modules/drivers/mongo/test/metabase/driver/mongo/query_processor_test.clj
@@ -355,26 +355,27 @@
       ;; date arithmetic doesn't supports until mongo 5+
       (when (driver/database-supports? :mongo :date-arithmetics (mt/db))
         (testing "date arithmetic with datetime columns"
-          (let [[col-type field-id] [:datetime (mt/id :times :dt)]]
-            (doseq [op               [:datetime-add :datetime-subtract]
-                    unit             [:year :quarter :month :day :hour :minute :second :millisecond]
-                    {:keys [expected query]}
-                    [{:expected [(qp.datetime-test/datetime-math op #t "2004-03-19 09:19:09" 2 unit col-type)
-                                 (qp.datetime-test/datetime-math op #t "2008-06-20 10:20:10" 2 unit col-type)
-                                 (qp.datetime-test/datetime-math op #t "2012-11-21 11:21:11" 2 unit col-type)
-                                 (qp.datetime-test/datetime-math op #t "2012-11-21 11:21:11" 2 unit col-type)]
-                      :query    {:expressions {"expr" [op [:field field-id nil] 2 unit]}
-                                 :fields      [[:expression "expr"]]}}
-                     {:expected (into [] (frequencies
-                                          [(qp.datetime-test/datetime-math op #t "2004-03-19 09:19:09" 2 unit col-type)
-                                           (qp.datetime-test/datetime-math op #t "2008-06-20 10:20:10" 2 unit col-type)
-                                           (qp.datetime-test/datetime-math op #t "2012-11-21 11:21:11" 2 unit col-type)
-                                           (qp.datetime-test/datetime-math op #t "2012-11-21 11:21:11" 2 unit col-type)]))
-                      :query    {:expressions {"expr" [op [:field field-id nil] 2 unit]}
-                                 :aggregation [[:count]]
-                                 :breakout    [[:expression "expr"]]}}]]
-              (testing (format "%s %s function works as expected on %s column for driver %s" op unit col-type driver/*driver*)
-                (is (= (set expected) (set (qp.datetime-test/test-datetime-math query))))))))
+          (doseq [[col-type field-id] [[:datetime (mt/id :times :dt)]
+                                       [:text-as-datetime (mt/id :times :as_dt)]]
+                  op                  [:datetime-add :datetime-subtract]
+                  unit                [:year :quarter :month :day :hour :minute :second :millisecond]
+                  {:keys [expected query]}
+                  [{:expected [(qp.datetime-test/datetime-math op #t "2004-03-19 09:19:09" 2 unit col-type)
+                               (qp.datetime-test/datetime-math op #t "2008-06-20 10:20:10" 2 unit col-type)
+                               (qp.datetime-test/datetime-math op #t "2012-11-21 11:21:11" 2 unit col-type)
+                               (qp.datetime-test/datetime-math op #t "2012-11-21 11:21:11" 2 unit col-type)]
+                    :query    {:expressions {"expr" [op [:field field-id nil] 2 unit]}
+                               :fields      [[:expression "expr"]]}}
+                   {:expected (into [] (frequencies
+                                        [(qp.datetime-test/datetime-math op #t "2004-03-19 09:19:09" 2 unit col-type)
+                                         (qp.datetime-test/datetime-math op #t "2008-06-20 10:20:10" 2 unit col-type)
+                                         (qp.datetime-test/datetime-math op #t "2012-11-21 11:21:11" 2 unit col-type)
+                                         (qp.datetime-test/datetime-math op #t "2012-11-21 11:21:11" 2 unit col-type)]))
+                    :query    {:expressions {"expr" [op [:field field-id nil] 2 unit]}
+                               :aggregation [[:count]]
+                               :breakout    [[:expression "expr"]]}}]]
+            (testing (format "%s %s function works as expected on %s column for driver %s" op unit col-type driver/*driver*)
+              (is (= (set expected) (set (qp.datetime-test/test-datetime-math query)))))))
 
         (testing "date arithmetic with date columns"
           (let [[col-type field-id] [:date (mt/id :times :d)]]

--- a/test/metabase/query_processor_test/date_time_zone_functions_test.clj
+++ b/test/metabase/query_processor_test/date_time_zone_functions_test.clj
@@ -92,8 +92,7 @@
 
 (deftest extraction-function-tests
   (mt/dataset times-mixed
-    ;; need to have seperate tests for mongo because it doesn't have supports for casting yet
-    (mt/test-drivers (disj (mt/normal-drivers-with-feature :temporal-extract) :mongo)
+    (mt/test-drivers (mt/normal-drivers-with-feature :temporal-extract)
       (testing "with datetime columns"
         (doseq [[col-type field-id] [[:datetime (mt/id :times :dt)] [:text-as-datetime (mt/id :times :as_dt)]]
                 op                  [:get-year :get-quarter :get-month :get-day
@@ -101,34 +100,17 @@
                 {:keys [expected-fn query-fn]}
                 extraction-test-cases]
           (testing (format "extract %s function works as expected on %s column for driver %s" op col-type driver/*driver*)
-            (is (= (set (expected-fn op)) (set (test-temporal-extract (query-fn op field-id))))))))
+            (is (= (set (expected-fn op)) (set (test-temporal-extract (query-fn op field-id)))))))))
 
-     (testing "with date columns"
-       (doseq [[col-type field-id] [[:date (mt/id :times :d)] [:text-as-date (mt/id :times :as_d)]]
-               op                  [:get-year :get-quarter :get-month :get-day :get-day-of-week]
-               {:keys [expected-fn query-fn]}
-               extraction-test-cases]
-        (testing (format "extract %s function works as expected on %s column for driver %s" op col-type driver/*driver*)
-          (is (= (set (expected-fn op)) (set (test-temporal-extract (query-fn op field-id)))))))))
-
-    (mt/test-driver :mongo
-      (testing "with datetimes columns"
-        (let [[col-type field-id] [:datetime (mt/id :times :dt)]]
-          (doseq [op              [:get-year :get-quarter :get-month :get-day
-                                   :get-day-of-week :get-hour :get-minute :get-second]
-                  {:keys [expected-fn query-fn]}
-                  extraction-test-cases]
-           (testing (format "extract %s function works as expected on %s column for driver %s" op col-type driver/*driver*)
-             (is (= (set (expected-fn op)) (set (test-temporal-extract (query-fn op field-id)))))))))
-
+    ;; mongo doesn't supports cast string to date
+    (mt/test-drivers (disj (mt/normal-drivers-with-feature :temporal-extract) :mongo)
       (testing "with date columns"
-        (let [[col-type field-id] [:date (mt/id :times :d)]]
-          (doseq [op               [:get-year :get-quarter :get-month :get-day :get-day-of-week]
-                  {:keys [expected-fn query-fn]}
-                  extraction-test-cases]
-           (testing (format "extract %s function works as expected on %s column for driver %s" op col-type driver/*driver*)
-             (is (= (set (expected-fn op)) (set (test-temporal-extract (query-fn op field-id))))))))))))
-
+        (doseq [[col-type field-id] [[:date (mt/id :times :d)] [:text-as-date (mt/id :times :as_d)]]
+                op                  [:get-year :get-quarter :get-month :get-day :get-day-of-week]
+                {:keys [expected-fn query-fn]}
+                extraction-test-cases]
+         (testing (format "extract %s function works as expected on %s column for driver %s" op col-type driver/*driver*)
+           (is (= (set (expected-fn op)) (set (test-temporal-extract (query-fn op field-id)))))))))))
 
 (deftest temporal-extraction-with-filter-expresion-tests
   (mt/test-drivers (mt/normal-drivers-with-feature :temporal-extract)


### PR DESCRIPTION
Datetime extraction and arithmetics were implemented in https://github.com/metabase/metabase/pull/25277 and https://github.com/metabase/metabase/pull/25414 respectively.
But at the time, Mongo hadn't supported casting a `text` column to `datetime` so some tests were skipped for Mongo.

Now we added it in https://github.com/metabase/metabase/pull/22313, we should run those tests for Mongo