### PR TITLE
Increase backend tests timeout for GitHub Actions [ci skip]

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -79,7 +79,7 @@ jobs:
   be-tests:
     runs-on: ubuntu-20.04
     name: be-tests-java-${{ matrix.java-version }}-${{ matrix.edition }}
-    timeout-minutes: 20
+    timeout-minutes: 25
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
I'm seeing backend tests timing out more and more often.
Bumping the timeout to 25 minutes until we figure out why did running time go up significantly.