### PR TITLE
Make Sure App Pages Open in the Correct App

### DIFF
--- a/frontend/src/metabase/entities/data-apps/utils.ts
+++ b/frontend/src/metabase/entities/data-apps/utils.ts
@@ -31,6 +31,12 @@ export function getDataAppHomePageId(dataApp: DataApp, pages: Dashboard[]) {
   return firstPage?.id;
 }
 
+export function getDataAppIdForPage(dashboard: Dashboard, dataApps: DataApp[]) {
+  return dataApps.find(
+    dataApp => dataApp.collection_id === dashboard.collection_id,
+  )?.id;
+}
+
 function isParentPage(
   targetPageIndent: number,
   maybeParentNavItem: DataAppNavItem,

--- a/frontend/src/metabase/lib/urls/dataApps.ts
+++ b/frontend/src/metabase/lib/urls/dataApps.ts
@@ -10,6 +10,7 @@ import type {
 import { appendSlug } from "./utils";
 
 const DATA_APP_PAGE_URL_PATTERN = /\/a\/(\d+)\/page\/(\d+)/;
+const DATA_APP_URL_PATTERN = /\/a\/(\d+)/;
 
 type DataAppUrlMode = "preview" | "internal" | "app-url";
 
@@ -69,4 +70,10 @@ export function isDataAppHomepagePath(pathname: string) {
 
 export function isDataAppPagePath(pathname: string) {
   return DATA_APP_PAGE_URL_PATTERN.test(pathname);
+}
+
+export function getDataAppIdFromPath(pathname: string) {
+  return isDataAppPath(pathname)
+    ? Number(DATA_APP_URL_PATTERN.exec(pathname)?.[1])
+    : null;
 }

--- a/frontend/src/metabase/writeback/containers/DataAppPageLanding.tsx
+++ b/frontend/src/metabase/writeback/containers/DataAppPageLanding.tsx
@@ -1,18 +1,32 @@
 import React from "react";
 import { connect } from "react-redux";
+import { replace } from "react-router-redux";
+import _ from "underscore";
+
 import type { Location } from "history";
+
+import { useDebouncedEffect } from "metabase/hooks/use-debounced-effect";
 
 import DashboardApp from "metabase/dashboard/containers/DashboardApp";
 import DataAppNavbarContainer from "metabase/nav/containers/MainNavbar/DataAppNavbar";
 
-import { getIsEditing } from "metabase/dashboard/selectors";
+import DataApps from "metabase/entities/data-apps";
+import { getDataAppIdForPage } from "metabase/entities/data-apps/utils";
+import {
+  getIsEditing,
+  getDashboardComplete,
+} from "metabase/dashboard/selectors";
+import { getDataAppIdFromPath } from "metabase/lib/urls";
 
-import type { DataAppPageId } from "metabase-types/api";
-import type { State } from "metabase-types/store";
+import type { DataAppPageId, DataApp, Dashboard } from "metabase-types/api";
+import type { Dispatch, State } from "metabase-types/store";
 
 interface DataAppPageLandingOwnProps {
   dashboardId?: DataAppPageId;
   location: Location;
+  dashboard: Dashboard;
+  dataApps: DataApp[];
+  dispatch: Dispatch;
   params: {
     slug: string; // data app ID
     pageId?: string;
@@ -29,10 +43,33 @@ type DataAppPageLandingProps = DataAppPageLandingOwnProps &
 function mapStateToProps(state: State) {
   return {
     isEditing: getIsEditing(state),
+    dashboard: getDashboardComplete(state),
   };
 }
 
-function DataAppPageLanding({ isEditing, ...props }: DataAppPageLandingProps) {
+function DataAppPageLanding({
+  isEditing,
+  dashboard,
+  dataApps,
+  dispatch,
+  ...props
+}: DataAppPageLandingProps) {
+  useDebouncedEffect(
+    () => {
+      if (dashboard?.is_app_page && dataApps) {
+        // check if we're in the correct app for this page
+        const urlAppId = getDataAppIdFromPath(location.pathname);
+        const pageAppId = getDataAppIdForPage(dashboard, dataApps);
+
+        if (urlAppId !== pageAppId) {
+          dispatch(replace(`/a/${pageAppId}/page/${dashboard.id}`));
+        }
+      }
+    },
+    10,
+    [dashboard, dataApps, dispatch, location],
+  );
+
   return (
     <>
       {!isEditing && <DataAppNavbarContainer />}
@@ -41,4 +78,7 @@ function DataAppPageLanding({ isEditing, ...props }: DataAppPageLandingProps) {
   );
 }
 
-export default connect(mapStateToProps)(DataAppPageLanding);
+export default _.compose(
+  DataApps.loadList(),
+  connect(mapStateToProps),
+)(DataAppPageLanding);

--- a/frontend/src/metabase/writeback/containers/DataAppPageLanding.tsx
+++ b/frontend/src/metabase/writeback/containers/DataAppPageLanding.tsx
@@ -55,6 +55,8 @@ function DataAppPageLanding({
   ...props
 }: DataAppPageLandingProps) {
   useDebouncedEffect(
+    // we need to debounce this slightly because the dashboard and app id state changes happen at different times
+    // which potentially causes infinite replacement loops
     () => {
       if (dashboard?.is_app_page && dataApps) {
         // check if we're in the correct app for this page


### PR DESCRIPTION
## Description

- When switching app pages, check if we're in the correct app for that page, and if not, update the URL to the correct app
- Had to use `useDebouncedEffect` instead of `useEffect` because on some navigations (like back), the page id and app id update separately and causes an infinite loop of state replacement.