### PR TITLE
Fix Bigquery timestamp to date/datetime conversion with report time zone

### DIFF
--- a/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk/query_processor.clj
+++ b/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk/query_processor.clj
@@ -291,8 +291,9 @@
         (do
           (log/tracef "Coercing %s (temporal type = %s) to %s" (binding [*print-meta* true] (pr-str x)) (pr-str (temporal-type x)) bigquery-type)
           (let [expr (sql.qp/->honeysql :bigquery-cloud-sdk x)]
-            (if-let [report-zone (when (= bigquery-type :timestamp) (qp.timezone/report-timezone-id-if-supported :bigquery-cloud-sdk))]
-              (with-temporal-type (hsql/call :timestamp expr (hx/literal report-zone)) target-type)
+            (if-let [report-zone (when (contains? #{bigquery-type (temporal-type hsql-form)} :timestamp)
+                                   (qp.timezone/report-timezone-id-if-supported :bigquery-cloud-sdk))]
+              (with-temporal-type (hsql/call target-type expr (hx/literal report-zone)) target-type)
               (with-temporal-type (hsql/call bigquery-type expr) target-type))))
 
         :else

--- a/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk/query_processor.clj
+++ b/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk/query_processor.clj
@@ -293,7 +293,7 @@
           (let [expr (sql.qp/->honeysql :bigquery-cloud-sdk x)]
             (if-let [report-zone (when (= bigquery-type :timestamp) (qp.timezone/report-timezone-id-if-supported :bigquery-cloud-sdk))]
               (with-temporal-type (hsql/call :timestamp expr (hx/literal report-zone)) target-type)
-              (with-temporal-type (hsql/call :cast expr (hsql/raw (name bigquery-type))) target-type))))
+              (with-temporal-type (hsql/call bigquery-type expr) target-type))))
 
         :else
         x))))

--- a/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk/query_processor.clj
+++ b/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk/query_processor.clj
@@ -293,7 +293,7 @@
           (let [expr (sql.qp/->honeysql :bigquery-cloud-sdk x)]
             (if-let [report-zone (when (contains? #{bigquery-type (temporal-type hsql-form)} :timestamp)
                                    (qp.timezone/report-timezone-id-if-supported :bigquery-cloud-sdk))]
-              (with-temporal-type (hsql/call target-type expr (hx/literal report-zone)) target-type)
+              (with-temporal-type (hsql/call bigquery-type expr (hx/literal report-zone)) target-type)
               (with-temporal-type (hsql/call bigquery-type expr) target-type))))
 
         :else

--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk/query_processor_test.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk/query_processor_test.clj
@@ -263,13 +263,13 @@
    (let [unix-ts (sql.qp/unix-timestamp->honeysql :bigquery-cloud-sdk :seconds :some_field)]
      {:value unix-ts
       :type  :timestamp
-      :as    {:date     (hsql/call :cast unix-ts (hsql/raw "date"))
-              :datetime (hsql/call :cast unix-ts (hsql/raw "datetime"))}})
+      :as    {:date     (hsql/call :date unix-ts)
+              :datetime (hsql/call :datetime unix-ts)}})
    (let [unix-ts (sql.qp/unix-timestamp->honeysql :bigquery-cloud-sdk :milliseconds :some_field)]
      {:value unix-ts
       :type  :timestamp
-      :as    {:date     (hsql/call :cast unix-ts (hsql/raw "date"))
-              :datetime (hsql/call :cast unix-ts (hsql/raw "datetime"))}})])
+      :as    {:date     (hsql/call :date unix-ts)
+              :datetime (hsql/call :datetime unix-ts)}})])
 
 (deftest temporal-type-test
   (testing "Make sure we can detect temporal types correctly"
@@ -344,7 +344,7 @@
                                                                       ::bigquery.qp/do-not-qualify? true)
                                            expected-identifier (case temporal-type
                                                                  :date      (hx/with-database-type-info identifier "date")
-                                                                 :datetime  (hsql/call :cast identifier (hsql/raw "timestamp"))
+                                                                 :datetime  (hsql/call :timestamp identifier)
                                                                  :timestamp (hx/with-database-type-info identifier "timestamp"))]]
               (testing (format "\ntemporal-type = %s" temporal-type)
                 (is (= [:= (hsql/call :extract :dayofweek expected-identifier) 1]
@@ -374,22 +374,23 @@
                    (:status (qp/process-query query))))))))))
 
 (deftest reconcile-relative-datetimes-test
-  (testing "relative-datetime clauses on their own"
-    (doseq [[t [unit expected-sql]]
-            {:time      [:hour "time_trunc(time_add(current_time(), INTERVAL -1 hour), hour)"]
-             :date      [:year "date_trunc(date_add(current_date(), INTERVAL -1 year), year)"]
-             :datetime  [:year "datetime_trunc(datetime_add(current_datetime(), INTERVAL -1 year), year)"]
-             ;; timestamp_add doesn't support `year` so this should cast a datetime instead
-             :timestamp [:year "CAST(datetime_trunc(datetime_add(current_datetime(), INTERVAL -1 year), year) AS timestamp)"]}]
-      (testing t
-        (let [reconciled-clause (#'bigquery.qp/->temporal-type t [:relative-datetime -1 unit])]
-          (testing "Should have correct type metadata after reconciliation"
-            (is (= t
-                   (#'bigquery.qp/temporal-type reconciled-clause))))
-          (testing "Should get converted to the correct SQL"
-            (is (= [(str "WHERE " expected-sql)]
-                   (sql.qp/format-honeysql :bigquery-cloud-sdk
-                                           {:where (sql.qp/->honeysql :bigquery-cloud-sdk reconciled-clause)}))))))))
+  (mt/with-driver :bigquery-cloud-sdk
+    (testing "relative-datetime clauses on their own"
+      (doseq [[t [unit expected-sql]]
+              {:time      [:hour "time_trunc(time_add(current_time(), INTERVAL -1 hour), hour)"]
+               :date      [:year "date_trunc(date_add(current_date(), INTERVAL -1 year), year)"]
+               :datetime  [:year "datetime_trunc(datetime_add(current_datetime(), INTERVAL -1 year), year)"]
+               ;; timestamp_add doesn't support `year` so this should cast a datetime instead
+               :timestamp [:year "timestamp(datetime_trunc(datetime_add(current_datetime(), INTERVAL -1 year), year))"]}]
+        (testing t
+          (let [reconciled-clause (#'bigquery.qp/->temporal-type t [:relative-datetime -1 unit])]
+            (testing "Should have correct type metadata after reconciliation"
+              (is (= t
+                     (#'bigquery.qp/temporal-type reconciled-clause))))
+            (testing "Should get converted to the correct SQL"
+              (is (= [(str "WHERE " expected-sql)]
+                     (sql.qp/format-honeysql :bigquery-cloud-sdk
+                                             {:where (sql.qp/->honeysql :bigquery-cloud-sdk reconciled-clause)})))))))))
 
   (testing "relative-datetime clauses on their own when a reporting timezone is set"
     (doseq [timezone ["UTC" "US/Pacific"]]
@@ -411,21 +412,21 @@
                                                {:where (sql.qp/->honeysql :bigquery-cloud-sdk reconciled-clause)}))))))))))
 
   (testing "relative-datetime clauses inside filter clauses"
-    (doseq [[expected-type t] {:date      #t "2020-01-31"
-                               :datetime  #t "2020-01-31T20:43:00.000"
-                               :timestamp #t "2020-01-31T20:43:00.000-08:00"}]
-      (testing expected-type
-        (let [[_ _ relative-datetime :as clause] (sql.qp/->honeysql :bigquery-cloud-sdk
-                                                                    [:=
-                                                                     t
-                                                                     [:relative-datetime -1 :year]])]
-          (testing (format "\nclause = %s" (pr-str clause))
-            (is (= expected-type
-                   (#'bigquery.qp/temporal-type relative-datetime)))))))))
+      (doseq [[expected-type t] {:date      #t "2020-01-31"
+                                 :datetime  #t "2020-01-31T20:43:00.000"
+                                 :timestamp #t "2020-01-31T20:43:00.000-08:00"}]
+        (testing expected-type
+          (let [[_ _ relative-datetime :as clause] (sql.qp/->honeysql :bigquery-cloud-sdk
+                                                                      [:=
+                                                                       t
+                                                                       [:relative-datetime -1 :year]])]
+            (testing (format "\nclause = %s" (pr-str clause))
+              (is (= expected-type
+                     (#'bigquery.qp/temporal-type relative-datetime)))))))))
 
 (deftest field-literal-trunc-form-test
   (testing "`:field` clauses with literal string names should be quoted correctly when doing date truncation (#20806)"
-    (is (= ["datetime_trunc(CAST(`source`.`date` AS datetime), week(sunday))"]
+    (is (= ["datetime_trunc(datetime(`source`.`date`), week(sunday))"]
            (sql.qp/format-honeysql
             :bigquery-cloud-sdk
             (sql.qp/->honeysql
@@ -451,7 +452,7 @@
                               (t/local-date "2019-11-11")
                               (t/local-date "2019-11-12")]))))
       (testing "If first arg has no temporal-type info, should look at next arg"
-        (is (= ["WHERE CAST(field AS date) BETWEEN ? AND ?"
+        (is (= ["WHERE date(field) BETWEEN ? AND ?"
                 (t/local-date "2019-11-11")
                 (t/local-date "2019-11-12")]
                (between->sql [:between
@@ -637,55 +638,56 @@
       false)))
 
 (deftest filter-by-relative-date-ranges-test
-  (testing "Make sure the SQL we generate for filters against relative-datetimes is typed correctly"
-    (mt/with-everything-store
-      (doseq [[field-type [unit expected-sql]]
-              {:type/Time                [:hour (str "WHERE time_trunc(ABC.time, hour)"
-                                                     " = time_trunc(time_add(current_time(), INTERVAL -1 hour), hour)")]
-               :type/Date                [:year (str "WHERE date_trunc(ABC.date, year)"
-                                                     " = date_trunc(date_add(current_date(), INTERVAL -1 year), year)")]
-               :type/DateTime            [:year (str "WHERE datetime_trunc(ABC.datetime, year)"
-                                                     " = datetime_trunc(datetime_add(current_datetime(), INTERVAL -1 year), year)")]
+  (mt/with-driver :bigquery-cloud-sdk
+    (testing "Make sure the SQL we generate for filters against relative-datetimes is typed correctly"
+      (mt/with-everything-store
+        (doseq [[field-type [unit expected-sql]]
+                {:type/Time                [:hour (str "WHERE time_trunc(ABC.time, hour)"
+                                                       " = time_trunc(time_add(current_time(), INTERVAL -1 hour), hour)")]
+                 :type/Date                [:year (str "WHERE date_trunc(ABC.date, year)"
+                                                       " = date_trunc(date_add(current_date(), INTERVAL -1 year), year)")]
+                 :type/DateTime            [:year (str "WHERE datetime_trunc(ABC.datetime, year)"
+                                                       " = datetime_trunc(datetime_add(current_datetime(), INTERVAL -1 year), year)")]
                ;; `timestamp_add` doesn't support `year` so it should cast a `datetime_trunc` instead
-               :type/DateTimeWithLocalTZ [:year (str "WHERE timestamp_trunc(ABC.datetimewithlocaltz, year)"
-                                                     " = CAST(datetime_trunc(datetime_add(current_datetime(), INTERVAL -1 year), year) AS timestamp)")]}]
-        (mt/with-temp Field [f {:name          (str/lower-case (name field-type))
-                                :base_type     field-type
-                                :database_type (name (bigquery.tx/base-type->bigquery-type field-type))}]
-          (testing (format "%s field" field-type)
-            (is (= [expected-sql]
-                   (hsql/format {:where (sql.qp/->honeysql
-                                         :bigquery-cloud-sdk
-                                         [:=
-                                          [:field (:id f) {:temporal-unit     unit
-                                                           ::add/source-table "ABC"}]
-                                          [:relative-datetime -1 unit]])}))))))))
+                 :type/DateTimeWithLocalTZ [:year (str "WHERE timestamp_trunc(ABC.datetimewithlocaltz, year)"
+                                                       " = timestamp(datetime_trunc(datetime_add(current_datetime(), INTERVAL -1 year), year))")]}]
+          (mt/with-temp Field [f {:name          (str/lower-case (name field-type))
+                                  :base_type     field-type
+                                  :database_type (name (bigquery.tx/base-type->bigquery-type field-type))}]
+            (testing (format "%s field" field-type)
+              (is (= [expected-sql]
+                     (hsql/format {:where (sql.qp/->honeysql
+                                           :bigquery-cloud-sdk
+                                           [:=
+                                            [:field (:id f) {:temporal-unit     unit
+                                                             ::add/source-table "ABC"}]
+                                            [:relative-datetime -1 unit]])}))))))))
 
-  (testing "Make sure the SQL we generate for filters against relative-datetimes uses the reporting timezone when set"
-    (doseq [timezone ["UTC" "US/Pacific"]]
-      (mt/with-temporary-setting-values [report-timezone timezone]
-        (mt/with-everything-store
-          (doseq [[field-type [unit expected-sql]]
-                  {:type/Time                [:hour (str "WHERE time_trunc(ABC.time, hour)"
-                                                         " = time_trunc(time_add(current_time('" timezone "'), INTERVAL -1 hour), hour)")]
-                   :type/Date                [:year (str "WHERE date_trunc(ABC.date, year)"
-                                                         " = date_trunc(date_add(current_date('" timezone "'), INTERVAL -1 year), year)")]
-                   :type/DateTime            [:year (str "WHERE datetime_trunc(ABC.datetime, year)"
-                                                         " = datetime_trunc(datetime_add(current_datetime('" timezone "'), INTERVAL -1 year), year)")]
+    (testing "Make sure the SQL we generate for filters against relative-datetimes uses the reporting timezone when set"
+      (doseq [timezone ["UTC" "US/Pacific"]]
+        (mt/with-temporary-setting-values [report-timezone timezone]
+          (mt/with-everything-store
+            (doseq [[field-type [unit expected-sql]]
+                    {:type/Time                [:hour (str "WHERE time_trunc(ABC.time, hour)"
+                                                           " = time_trunc(time_add(current_time('" timezone "'), INTERVAL -1 hour), hour)")]
+                     :type/Date                [:year (str "WHERE date_trunc(ABC.date, year)"
+                                                           " = date_trunc(date_add(current_date('" timezone "'), INTERVAL -1 year), year)")]
+                     :type/DateTime            [:year (str "WHERE datetime_trunc(ABC.datetime, year)"
+                                                           " = datetime_trunc(datetime_add(current_datetime('" timezone "'), INTERVAL -1 year), year)")]
                    ;; `timestamp_add` doesn't support `year` so it should cast a `datetime_trunc` instead, but when it converts to a timestamp it needs to specify the tz
-                   :type/DateTimeWithLocalTZ [:year (str "WHERE timestamp_trunc(ABC.datetimewithlocaltz, year, '" timezone "')"
-                                                         " = timestamp(datetime_trunc(datetime_add(current_datetime('" timezone "'), INTERVAL -1 year), year), '" timezone "')")]}]
-            (mt/with-temp Field [f {:name          (str/lower-case (name field-type))
-                                    :base_type     field-type
-                                    :database_type (name (bigquery.tx/base-type->bigquery-type field-type))}]
-              (testing (format "%s field" field-type)
-                (is (= [expected-sql]
-                       (hsql/format {:where (sql.qp/->honeysql
-                                             :bigquery-cloud-sdk
-                                             [:=
-                                              [:field (:id f) {:temporal-unit     unit
-                                                               ::add/source-table "ABC"}]
-                                              [:relative-datetime -1 unit]])})))))))))))
+                     :type/DateTimeWithLocalTZ [:year (str "WHERE timestamp_trunc(ABC.datetimewithlocaltz, year, '" timezone "')"
+                                                           " = timestamp(datetime_trunc(datetime_add(current_datetime('" timezone "'), INTERVAL -1 year), year), '" timezone "')")]}]
+              (mt/with-temp Field [f {:name          (str/lower-case (name field-type))
+                                      :base_type     field-type
+                                      :database_type (name (bigquery.tx/base-type->bigquery-type field-type))}]
+                (testing (format "%s field" field-type)
+                  (is (= [expected-sql]
+                         (hsql/format {:where (sql.qp/->honeysql
+                                               :bigquery-cloud-sdk
+                                               [:=
+                                                [:field (:id f) {:temporal-unit     unit
+                                                                 ::add/source-table "ABC"}]
+                                                [:relative-datetime -1 unit]])}))))))))))))
 
 ;; This is a table of different BigQuery column types -> temporal units we should be able to bucket them by for
 ;; filtering purposes against RELATIVE-DATETIMES. `relative-datetime` only supports the unit below -- a subset of all


### PR DESCRIPTION
This PR fixes conversion from a timestamp to a date/datetime type using the `->temporal-type` function for bigquery when the report-timezone is not UTC. This will help simplify the implementation of https://github.com/metabase/metabase/pull/25722

[This](https://github.com/metabase/metabase/pull/25451) previous PR allowed conversion from date/datetime to timestamp taking report timezone into account with `->temporal-type`. However, `->temporal-type` does not take the report-timezone into account when converting in the opposite direction, from timestamp to date/datetime. To do the conversion from timestamp to datetime the current implementation currently uses the operation `cast(<timestamp> as datetime)` but we need to use `datetime(<timestamp>, <report-timezone>)`. And similarly for conversion from timestamp to date.

The problem is demonstrated by the following example:

Imagine our report timezone was 'Europe/Paris', and the timestamp was stored as '2021-01-01 00:00:00+00'.
Conversion from timestamp to datetime shouldn't change the time from the perspective of the report-timezone, but it does. 

```
> select extract(hour from timestamp('2022-01-01', 'UTC') at time zone 'Europe/Paris')
=> 1 
(this result should be preserved if we convert the timestamp to datetime)

> select extract(hour from datetime(timestamp('2022-01-01', 'UTC')))
=> 0 
(wrong, since the timestamp was converted without considering the report-timezone)

> select extract(hour from datetime(timestamp('2022-01-01', 'UTC'), 'Europe/Paris'))
=> 1 
(correct)
```

Tip for reviewers: read the commits in order