### PR TITLE
Fix new app modal freeze

### DIFF
--- a/frontend/src/metabase/entities/data-apps/data-apps.ts
+++ b/frontend/src/metabase/entities/data-apps/data-apps.ts
@@ -13,7 +13,7 @@ import { createNewAppForm, createAppSettingsForm } from "./forms";
 import reducer from "./reducer";
 import { getDataAppIcon } from "./utils";
 
-type EditableDataAppParams = Pick<
+export type EditableDataAppParams = Pick<
   DataApp,
   "dashboard_id" | "options" | "nav_items"
 > &

--- a/frontend/src/metabase/entities/data-apps/data-apps.ts
+++ b/frontend/src/metabase/entities/data-apps/data-apps.ts
@@ -26,16 +26,6 @@ type UpdateDataAppParams = Pick<DataApp, "id" | "collection_id"> & {
   collection: Pick<Collection, "name" | "description">;
 };
 
-export type ScaffoldNewAppParams = {
-  name: EditableDataAppParams["name"];
-  tables: number[]; // list of table IDs
-};
-
-export type ScaffoldNewPagesParams = {
-  dataAppId: DataApp["id"];
-  tables: number[]; // list of table IDs
-};
-
 const DataApps = createEntity({
   name: "dataApps",
   nameOne: "dataApp",
@@ -71,29 +61,6 @@ const DataApps = createEntity({
         await CollectionsApi.update({ ...collection, id: collection_id });
       }
       return DataAppsApi.update({ id, ...rest });
-    },
-  },
-
-  objectActions: {
-    scaffoldNewApp: async ({ name, tables }: ScaffoldNewAppParams) => {
-      const dataApp = await DataAppsApi.scaffoldNewApp({
-        "app-name": name,
-        "table-ids": tables,
-      });
-      return {
-        type: DataApps.actionTypes.CREATE,
-        payload: DataApps.normalize(dataApp),
-      };
-    },
-    scaffoldNewPages: async ({ dataAppId, tables }: ScaffoldNewPagesParams) => {
-      const dataApp = await DataAppsApi.scaffoldNewPages({
-        id: dataAppId,
-        "table-ids": tables,
-      });
-      return {
-        type: DataApps.actionTypes.UPDATE,
-        payload: DataApps.normalize(dataApp),
-      };
     },
   },
 

--- a/frontend/src/metabase/writeback/actions.ts
+++ b/frontend/src/metabase/writeback/actions.ts
@@ -127,6 +127,28 @@ export const scaffoldDataApp = ({ name, tables }: ScaffoldNewAppParams) => {
   };
 };
 
+export type ScaffoldNewPagesParams = {
+  dataAppId: DataApp["id"];
+  tables: number[]; // list of table IDs
+};
+
+export const scaffoldDataAppPages = ({
+  dataAppId,
+  tables,
+}: ScaffoldNewPagesParams) => {
+  return async (dispatch: Dispatch) => {
+    const dataApp = await DataAppsApi.scaffoldNewPages({
+      id: dataAppId,
+      "table-ids": tables,
+    });
+    dispatch({
+      type: DataApps.actionTypes.UPDATE,
+      payload: DataApps.normalize(dataApp),
+    });
+    return dataApp;
+  };
+};
+
 export type ArchiveDataAppPayload = {
   id: DataApp["id"];
 };

--- a/frontend/src/metabase/writeback/actions.ts
+++ b/frontend/src/metabase/writeback/actions.ts
@@ -1,9 +1,6 @@
 import { ActionsApi } from "metabase/services";
 
-import DataApps, {
-  getChildNavItems,
-  isTopLevelNavItem,
-} from "metabase/entities/data-apps";
+import DataApps, { getChildNavItems } from "metabase/entities/data-apps";
 import Dashboards from "metabase/entities/dashboards";
 
 import type { DataApp, DataAppPage } from "metabase-types/api";

--- a/frontend/src/metabase/writeback/actions.ts
+++ b/frontend/src/metabase/writeback/actions.ts
@@ -1,6 +1,9 @@
-import { ActionsApi } from "metabase/services";
+import { ActionsApi, DataAppsApi } from "metabase/services";
 
-import DataApps, { getChildNavItems } from "metabase/entities/data-apps";
+import DataApps, {
+  getChildNavItems,
+  EditableDataAppParams,
+} from "metabase/entities/data-apps";
 import Dashboards from "metabase/entities/dashboards";
 
 import type { DataApp, DataAppPage } from "metabase-types/api";
@@ -103,6 +106,25 @@ export const deleteManyRows = (payload: BulkDeletePayload) => {
     },
     { bodyParamName: "body" },
   );
+};
+
+export type ScaffoldNewAppParams = {
+  name: EditableDataAppParams["name"];
+  tables: number[]; // list of table IDs
+};
+
+export const scaffoldDataApp = ({ name, tables }: ScaffoldNewAppParams) => {
+  return async (dispatch: Dispatch) => {
+    const dataApp = await DataAppsApi.scaffoldNewApp({
+      "app-name": name,
+      "table-ids": tables,
+    });
+    dispatch({
+      type: DataApps.actionTypes.CREATE,
+      payload: DataApps.normalize(dataApp),
+    });
+    return dataApp;
+  };
 };
 
 export type ArchiveDataAppPayload = {

--- a/frontend/src/metabase/writeback/containers/CreateDataAppModal/CreateDataAppModal.tsx
+++ b/frontend/src/metabase/writeback/containers/CreateDataAppModal/CreateDataAppModal.tsx
@@ -8,13 +8,15 @@ import Button from "metabase/core/components/Button";
 
 import * as Urls from "metabase/lib/urls";
 
-import DataApps, { ScaffoldNewAppParams } from "metabase/entities/data-apps";
-
 import DataPicker, {
   useDataPicker,
   useDataPickerValue,
   DataPickerValue,
 } from "metabase/containers/DataPicker";
+import {
+  scaffoldDataApp,
+  ScaffoldNewAppParams,
+} from "metabase/writeback/actions";
 import DataAppScaffoldingDataPicker from "metabase/writeback/components/DataAppScaffoldingDataPicker";
 
 import type { DataApp } from "metabase-types/api";
@@ -44,12 +46,8 @@ type Props = OwnProps & DispatchProps;
 
 function mapDispatchToProps(dispatch: Dispatch) {
   return {
-    onCreate: async (params: ScaffoldNewAppParams) => {
-      const action = await dispatch(
-        DataApps.objectActions.scaffoldNewApp(params),
-      );
-      return DataApps.HACK_getObjectFromAction(action);
-    },
+    onCreate: (params: ScaffoldNewAppParams) =>
+      dispatch(scaffoldDataApp(params)),
     onChangeLocation: (location: LocationDescriptor) =>
       dispatch(push(location)),
   };
@@ -121,5 +119,9 @@ function CreateDataAppModal({ onCreate, onChangeLocation, onClose }: Props) {
 
 export default connect<unknown, DispatchProps, OwnProps, State>(
   null,
+
+  // Need to figure out how to properly type curried actions
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
   mapDispatchToProps,
 )(CreateDataAppModal);

--- a/frontend/src/metabase/writeback/containers/ScaffoldDataAppPagesModal/ScaffoldDataAppPagesModal.tsx
+++ b/frontend/src/metabase/writeback/containers/ScaffoldDataAppPagesModal/ScaffoldDataAppPagesModal.tsx
@@ -4,9 +4,11 @@ import { connect } from "react-redux";
 
 import Button from "metabase/core/components/Button";
 
-import DataApps, { ScaffoldNewPagesParams } from "metabase/entities/data-apps";
-
 import { useDataPickerValue } from "metabase/containers/DataPicker";
+import {
+  scaffoldDataAppPages,
+  ScaffoldNewPagesParams,
+} from "metabase/writeback/actions";
 import DataAppScaffoldingDataPicker from "metabase/writeback/components/DataAppScaffoldingDataPicker";
 
 import type { DataApp } from "metabase-types/api";
@@ -34,12 +36,8 @@ type Props = OwnProps & DispatchProps;
 
 function mapDispatchToProps(dispatch: Dispatch) {
   return {
-    onScaffold: async (params: ScaffoldNewPagesParams) => {
-      const action = await dispatch(
-        DataApps.objectActions.scaffoldNewPages(params),
-      );
-      return DataApps.HACK_getObjectFromAction(action);
-    },
+    onScaffold: (params: ScaffoldNewPagesParams) =>
+      dispatch(scaffoldDataAppPages(params)),
   };
 }
 
@@ -85,5 +83,9 @@ function ScaffoldDataAppPagesModal({
 
 export default connect<unknown, DispatchProps, OwnProps, State>(
   null,
+
+  // Need to figure out how to properly type curried actions
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
   mapDispatchToProps,
 )(ScaffoldDataAppPagesModal);


### PR DESCRIPTION
Fixes #26380

For scaffolding apps and pages in existing apps, we were using data app entities `objectActions` API. Essentially, scaffolding an app is a subset of `metabase/dataApps/CREATE` action, and pages scaffolding for existing apps is a subset of `metabase/dataApps/UPDATE`. So what we did is just added two new actions that'd call scaffolding endpoints, receive a new shape of a data app from the backend, and dispatch a regular `CREATE` / `UPDATE` action, so the entity store gets correctly updated without a need to introduce an entity reducer.

Also, for scaffolding an app, we want the UI to get a recently created data app object, so it can navigate a user to the new app. What we did is just use the `DataApps.HACK_getObjectFromAction` entity helper to get the data app object from the data app `CREATE` action.

It worked fine, but a few internal users have been running into a bug when clicking the "Create" button would call the scaffolding endpoint as expected, create an app, but won't pass the new app object back to the UI, so no redirect was happening. For some reason, in these rare scenarios, `DataApps.objectActions.scaffoldNewApp({ ... })` wasn't returning any action object back, so there was no way to retrieve the data app object.

I still have no idea what's the root cause 🤪 What this PR does is just makes scaffolding actions plain redux actions vs. an entity object action. This seem to fix the issue 🤷 