### PR TITLE
[E2E] Fix grep spec filtering

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -147,7 +147,7 @@ jobs:
       if: matrix.edition == 'oss'
       run: |
         yarn run test-cypress-run \
-        --env grepTags=@OSS,grepFilterSpecs=true \
+        --env grepTags=@OSS \
         --spec './frontend/test/metabase/scenarios/**/*.cy.spec.js'
       env:
         TERM: xterm

--- a/frontend/test/__support__/e2e/config.js
+++ b/frontend/test/__support__/e2e/config.js
@@ -33,8 +33,6 @@ const defaultConfig = {
 
     // `on` is used to hook into various events Cypress emits
     // `config` is the resolved Cypress config
-    require("@cypress/grep/src/plugin")(config);
-
     /********************************************************************
      **                        PREPROCESSOR                            **
      ********************************************************************/
@@ -72,6 +70,9 @@ const defaultConfig = {
         "frontend/test/snapshot-creators/qa-db.cy.snap.js";
     }
 
+    // `grepIntegrationFolder` needs to point to the root!
+    // See: https://github.com/cypress-io/cypress/issues/24452#issuecomment-1295377775
+    config.env.grepIntegrationFolder = "../../../../";
     config.env.grepFilterSpecs = true;
 
     config.env.HAS_ENTERPRISE_TOKEN = hasEnterpriseToken;
@@ -79,6 +80,8 @@ const defaultConfig = {
     config.env.SNOWPLOW_MICRO_URL = snowplowMicroUrl;
     config.env.SOURCE_VERSION = sourceVersion;
     config.env.TARGET_VERSION = targetVersion;
+
+    require("@cypress/grep/src/plugin")(config);
 
     return config;
   },

--- a/frontend/test/__support__/e2e/config.js
+++ b/frontend/test/__support__/e2e/config.js
@@ -72,6 +72,8 @@ const defaultConfig = {
         "frontend/test/snapshot-creators/qa-db.cy.snap.js";
     }
 
+    config.env.grepFilterSpecs = true;
+
     config.env.HAS_ENTERPRISE_TOKEN = hasEnterpriseToken;
     config.env.HAS_SNOWPLOW_MICRO = hasSnowplowMicro;
     config.env.SNOWPLOW_MICRO_URL = snowplowMicroUrl;


### PR DESCRIPTION
### Status
READY

### What does this PR accomplish?
- Fixes Cypress grep (pre) filtering option so that the job depending on `grepTags` doesn't take 30-35 minutes

### Explanation
`grepFilterSpecs` option first goes through all the specs (matching a glob pattern) and finds the ones that have a certain tag associated with them. That is an amazing optimization because it greatly reduces the running time. Instead of going through all 400+ specs (that we currently have), it finds less than 10 affected specs and scopes the job accordingly.

Read more about the mechanism [here](https://github.com/cypress-io/cypress/tree/develop/npm/grep#pre-filter-specs-grepfilterspecs).

Ever since we [upgraded Cypress to v10.9.0](https://github.com/metabase/metabase/pull/25665), this functionality stopped working and we've seen an increased time for this job. It suddenly took 30 to 35 minutes to finish, increasing the overall E2E CI time!

It was hard to debug why this happened, because a crucial piece of information isn't documented. One needs to sift through the [source code](https://github.com/cypress-io/cypress/blob/develop/npm/grep/src/plugin.js).

These lines were crucial:
```js
// This was always resolving to the current working folder, which is the folder the config is in
// frontend/test/__support__/e2e/
const integrationFolder = env.grepIntegrationFolder || process.cwd()

// specPattern is obtained from the config itself
const specFiles = globby.sync(specPattern, {
  cwd: integrationFolder,
  ignore: excludeSpecPattern,
  absolute: true,
})
```

Debugging the plugin showed that `specFiles` always resulted in an empty array `[]` (found 0 spec files)
`DEBUG=cypress-grep yarn run test-cypress-run --env grepTags='@OSS'`

```
cypress-grep cypress-grep plugin version 3.1.0 +0ms
cypress-grep Cypress config env object: { grepTags: '@OSS', grepFilterSpecs: true } +0ms
cypress-grep: filtering using tag(s) "@OSS"
cypress-grep parsed grep tags [ [ { tag: '@OSS', invert: false } ] ] +1ms
cypress-grep specPattern frontend/test/**.cy.spec.js +0ms
cypress-grep excludeSpecPattern frontend/test/snapshot-creators/qa-db.cy.snap.js +0ms
cypress-grep integrationFolder /Users/metabase/code/metabase/frontend/test/__support__/e2e +0ms
cypress-grep found 0 spec files +3ms
cypress-grep [] +0ms
cypress-grep parsed grep tags { title: [], tags: [ [ [Object] ] ] } +0ms
cypress-grep found grep tags "@OSS" in 0 specs +1ms
cypress-grep [] +0ms
grep and/or grepTags has eliminated all specs
grepTags: @OSS
Will leave all specs to run to filter at run-time
```

At least the debugger showed that we're passing `grepTags` and `grepFilterSpecs` correctly.

I then needed to look at the [`globby`](https://github.com/sindresorhus/globby) and [`fast-glob`](https://github.com/mrmlnc/fast-glob) to understand how `.sync(pattern, options)` work.

The crucial part was `cwd` which (in the Cypress grep plugin) gets assigned the value of `integrationFolder`. Unfortunately, that piece of information is not documented anywhere in Cypress. Basically, if your config doesn't live in the project root, you'll have bad time with this plugin.

The solution was to add `grepIntegrationFolder` flag to Cypress envs and to point it to the project root (4 folders up from where the config lives).

Shoutout to @s4ms00n9 because [his comment](https://github.com/cypress-io/cypress/issues/24452#issuecomment-1295377775) sent me in the right direction, which [joshuajtward](https://github.com/joshuajtward) later [confirmed](https://github.com/cypress-io/cypress/issues/24452#issuecomment-1295377778).

### Final result
- Before: [30m40s](https://github.com/metabase/metabase/actions/runs/3439808887/jobs/5737763353)
- After: [6m7s](https://github.com/metabase/metabase/actions/runs/3441178655/jobs/5740617113)