### PR TITLE
Add app DB and version to common snowplow event context

### DIFF
--- a/snowplow/iglu-client-embedded/schemas/com.metabase/instance/jsonschema/1-1-1
+++ b/snowplow/iglu-client-embedded/schemas/com.metabase/instance/jsonschema/1-1-1
@@ -1,0 +1,108 @@
+{
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "description": "Metabase instance",
+  "self": {
+    "vendor": "com.metabase",
+    "name": "instance",
+    "format": "jsonschema",
+    "version": "1-1-1"
+  },
+  "type": "object",
+  "properties": {
+    "id": {
+      "description": "Instance ID",
+      "type": "string",
+      "maxLength": 1024
+    },
+    "version": {
+      "description": "Instance version",
+      "type": "object",
+      "properties": {
+        "tag": {
+          "description": "Instance version tag",
+          "type": "string",
+          "maxLength": 1024
+        }
+      },
+      "required": [
+        "tag"
+      ]
+    },
+    "created_at": {
+      "description": "The date the instance was created",
+      "type": [
+        "string",
+        "null"
+      ],
+      "format": "date-time",
+      "maxLength": 1024
+    },
+    "token_features": {
+      "description": "Premium token features",
+      "type": [
+        "object",
+        "null"
+      ],
+      "properties": {
+        "embedding": {
+          "description": "Should we hide the 'Powered by Metabase' attribution on the embedding pages?",
+          "type": "boolean"
+        },
+        "whitelabel": {
+          "description": "Should we allow full whitelabel embedding (reskinning the entire interface?)",
+          "type": "boolean"
+        },
+        "audit_app": {
+          "description": "Should we enable the Audit Logs interface in the Admin UI?",
+          "type": "boolean"
+        },
+        "sandboxes": {
+          "description": "Should we enable data sandboxes (row-level permissions)?",
+          "type": "boolean"
+        },
+        "sso": {
+          "description": "Should we enable advanced SSO features (SAML and JWT authentication; role and group mapping)?",
+          "type": "boolean"
+        },
+        "advanced_config": {
+          "description": "Should we enable knobs and levers for more complex orgs (granular caching controls, allow-lists email domains for notifications, more in the future)?",
+          "type": "boolean"
+        },
+        "advanced_permissions": {
+          "description": "Should we enable extra knobs around permissions (block access, and in the future, moderator roles, feature-level permissions, etc.)?",
+          "type": "boolean"
+        },
+        "content_management": {
+          "description": "Should we enable official Collections, Question verifications (and more in the future, like workflows, forking, etc.)?",
+          "type": "boolean"
+        },
+        "hosting": {
+          "description": "Is the Metabase instance running in the cloud?",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        }
+      }
+    },
+    "application_database": {
+      "description": "Application database type",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "application_database_version": {
+      "description": "Application database version",
+      "type": [
+        "string",
+        "null"
+      ]
+    }
+  },
+  "required": [
+    "id",
+    "version"
+  ],
+  "additionalProperties": true
+}

--- a/snowplow/iglu-client-embedded/schemas/com.metabase/instance/jsonschema/1-1-1
+++ b/snowplow/iglu-client-embedded/schemas/com.metabase/instance/jsonschema/1-1-1
@@ -90,14 +90,16 @@
       "type": [
         "string",
         "null"
-      ]
+      ],
+      "maxLength": 1024
     },
     "application_database_version": {
       "description": "Application database version",
       "type": [
         "string",
         "null"
-      ]
+      ],
+      "maxLength": 1024
     }
   },
   "required": [

--- a/src/metabase/analytics/snowplow.clj
+++ b/src/metabase/analytics/snowplow.clj
@@ -133,6 +133,12 @@
    ::timeline  "1-0-0"
    ::task      "1-0-0"})
 
+(defn app-db-type
+  "Returns the type of the Metabase application database as a string (e.g. PostgreSQL, MySQL)"
+  []
+  (clojure.java.jdbc/with-db-metadata [metadata (db/connection)]
+    (.getDatabaseProductName metadata)))
+
 (defn app-db-version
   "Returns the version of the Metabase application database as a string"
   []
@@ -148,7 +154,7 @@
         "version"                      {"tag" (:tag (public-settings/version))}
         "token_features"               (m/map-keys name (public-settings/token-features))
         "created_at"                   (instance-creation)
-        "application_database"         (config/config-str :mb-db-type)
+        "application_database"         (app-db-type)
         "application_database_version" (app-db-version)}))
 
 (defn- normalize-kw

--- a/src/metabase/analytics/snowplow.clj
+++ b/src/metabase/analytics/snowplow.clj
@@ -133,16 +133,16 @@
    ::timeline  "1-0-0"
    ::task      "1-0-0"})
 
-(defn app-db-type
+(defn- app-db-type
   "Returns the type of the Metabase application database as a string (e.g. PostgreSQL, MySQL)"
   []
-  (clojure.java.jdbc/with-db-metadata [metadata (db/connection)]
+  (jdbc/with-db-metadata [metadata (db/connection)]
     (.getDatabaseProductName metadata)))
 
-(defn app-db-version
+(defn- app-db-version
   "Returns the version of the Metabase application database as a string"
   []
-  (clojure.java.jdbc/with-db-metadata [metadata (db/connection)]
+  (jdbc/with-db-metadata [metadata (db/connection)]
     (format "%d.%d" (.getDatabaseMajorVersion metadata) (.getDatabaseMinorVersion metadata))))
 
 (defn- context

--- a/test/metabase/analytics/snowplow_test.clj
+++ b/test/metabase/analytics/snowplow_test.clj
@@ -3,7 +3,6 @@
             [clojure.test :refer :all]
             [clojure.walk :as walk]
             [metabase.analytics.snowplow :as snowplow]
-            [metabase.config :as config]
             [metabase.models.setting :as setting :refer [Setting]]
             [metabase.public-settings :as public-settings]
             [metabase.test :as mt]

--- a/test/metabase/analytics/snowplow_test.clj
+++ b/test/metabase/analytics/snowplow_test.clj
@@ -94,7 +94,7 @@
                      :version                      {:tag (:tag (public-settings/version))},
                      :token_features               (public-settings/token-features)
                      :created_at                   (snowplow/instance-creation)
-                     :application_database         (config/config-str :mb-db-type)
+                     :application_database         (snowplow/app-db-type)
                      :application_database_version (snowplow/app-db-version)}}
              (:context (first @*snowplow-collector*))))
 

--- a/test/metabase/analytics/snowplow_test.clj
+++ b/test/metabase/analytics/snowplow_test.clj
@@ -93,8 +93,8 @@
                      :version                      {:tag (:tag (public-settings/version))},
                      :token_features               (public-settings/token-features)
                      :created_at                   (snowplow/instance-creation)
-                     :application_database         (snowplow/app-db-type)
-                     :application_database_version (snowplow/app-db-version)}}
+                     :application_database         (#'snowplow/app-db-type)
+                     :application_database_version (#'snowplow/app-db-version)}}
              (:context (first @*snowplow-collector*))))
 
       (testing "the created_at should have the format yyyy-MM-dd'T'hh:mm:ss.SSXXX"

--- a/test/metabase/analytics/snowplow_test.clj
+++ b/test/metabase/analytics/snowplow_test.clj
@@ -3,6 +3,7 @@
             [clojure.test :refer :all]
             [clojure.walk :as walk]
             [metabase.analytics.snowplow :as snowplow]
+            [metabase.config :as config]
             [metabase.models.setting :as setting :refer [Setting]]
             [metabase.public-settings :as public-settings]
             [metabase.test :as mt]
@@ -89,10 +90,12 @@
     (with-fake-snowplow-collector
       (snowplow/track-event! ::snowplow/new-instance-created)
       (is (= {:schema "iglu:com.metabase/instance/jsonschema/1-1-0",
-              :data {:id             (snowplow/analytics-uuid)
-                     :version        {:tag (:tag (public-settings/version))},
-                     :token_features (public-settings/token-features)
-                     :created_at     (snowplow/instance-creation)}}
+              :data {:id                           (snowplow/analytics-uuid)
+                     :version                      {:tag (:tag (public-settings/version))},
+                     :token_features               (public-settings/token-features)
+                     :created_at                   (snowplow/instance-creation)
+                     :application_database         (config/config-str :mb-db-type)
+                     :application_database_version (snowplow/app-db-version)}}
              (:context (first @*snowplow-collector*))))
 
       (testing "the created_at should have the format yyyy-MM-dd'T'hh:mm:ss.SSXXX"


### PR DESCRIPTION
- Updates the `instance` schema to the next patch version (1.1.1) to add two nullable fields: `application_database` and `application_database_version`. I believe it should be OK to just bump the patch version here since these are nullable and not required.
- Updates the backend Snowplow infra to add these fields to the common context included in every (backend) event.

Closes #26329