### PR TITLE
Better Alignment of Things In Apps

### DIFF
--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.jsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.jsx
@@ -299,6 +299,7 @@ class Dashboard extends Component {
                   <ParametersWidgetContainer
                     data-testid="edit-dashboard-parameters-widget-container"
                     isEditing={isEditing}
+                    isDataApp={isDataApp}
                   >
                     {parametersWidget}
                   </ParametersWidgetContainer>

--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.styled.jsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.styled.jsx
@@ -15,6 +15,8 @@ import {
   NAV_SIDEBAR_WIDTH,
 } from "metabase/nav/constants";
 
+import { DATA_APPS_MAX_WIDTH } from "metabase/lib/dashboard_grid";
+
 // Class names are added here because we still use traditional css,
 // see dashboard.css
 export const DashboardLoadingAndErrorWrapper = styled(
@@ -139,7 +141,8 @@ export const ParametersWidgetContainer = styled(FullWidthContainer)`
     ${({ isDataApp }) =>
     isDataApp &&
     css`
-      max-width: 1200px;
+      box-sizing: content-box;
+      max-width: ${DATA_APPS_MAX_WIDTH}px;
     `}
 `;
 

--- a/frontend/src/metabase/dashboard/components/DashboardGrid.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardGrid.jsx
@@ -17,6 +17,7 @@ import { color } from "metabase/lib/colors";
 import {
   GRID_WIDTH,
   GRID_ASPECT_RATIO,
+  GRID_MARGIN,
   GRID_BREAKPOINTS,
   GRID_COLUMNS,
   DEFAULT_CARD_SIZE,
@@ -25,6 +26,7 @@ import {
   DATA_APPS_ASPECT_RATIO,
   DATA_APPS_MAX_WIDTH,
   DATA_APPS_GRID_MARGIN,
+  DATA_APPS_GRID_BREAKPOINTS,
 } from "metabase/lib/dashboard_grid";
 import { ContentViewportContext } from "metabase/core/context/ContentViewportContext";
 import { DashboardCard } from "./DashboardGrid.styled";
@@ -366,9 +368,15 @@ class DashboardGrid extends Component {
   );
 
   renderGrid() {
-    const { dashboard, width, isEditing } = this.props;
+    const { dashboard, width } = this.props;
     const { layouts } = this.state;
     const rowHeight = this.getRowHeight();
+
+    const isDataApp = dashboard.is_app_page;
+
+    const gridWidth =
+      isDataApp && width > DATA_APPS_MAX_WIDTH ? DATA_APPS_MAX_WIDTH : width;
+
     return (
       <GridLayout
         className={cx("DashboardGrid", {
@@ -376,16 +384,10 @@ class DashboardGrid extends Component {
           "Dash--dragging": this.state.isDragging,
         })}
         layouts={layouts}
-        breakpoints={GRID_BREAKPOINTS}
+        breakpoints={isDataApp ? DATA_APPS_GRID_BREAKPOINTS : GRID_BREAKPOINTS}
         cols={GRID_COLUMNS}
-        width={
-          dashboard.is_app_page && !isEditing ? DATA_APPS_MAX_WIDTH : width
-        }
-        margin={
-          dashboard.is_app_page
-            ? DATA_APPS_GRID_MARGIN
-            : { desktop: [6, 6], mobile: [6, 10] }
-        }
+        width={gridWidth}
+        margin={isDataApp ? DATA_APPS_GRID_MARGIN : GRID_MARGIN}
         containerPadding={[0, 0]}
         rowHeight={rowHeight}
         onLayoutChange={this.onLayoutChange}

--- a/frontend/src/metabase/dashboard/components/DashboardHeader.styled.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHeader.styled.tsx
@@ -38,7 +38,8 @@ export const HeaderRoot = styled(
   ${props =>
     props.isDataApp &&
     css`
-      max-width: ${DATA_APPS_MAX_WIDTH + 64}px;
+      box-sizing: content-box;
+      max-width: ${DATA_APPS_MAX_WIDTH}px;
       margin: 0 auto;
       padding: 0 2rem;
     `}

--- a/frontend/src/metabase/dashboard/components/DashboardHeader.styled.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHeader.styled.tsx
@@ -11,6 +11,7 @@ import {
   breakpointMaxMedium,
 } from "metabase/styled-components/theme";
 import { FullWidthContainer } from "metabase/styled-components/layout/FullWidthContainer";
+import { DATA_APPS_MAX_WIDTH } from "metabase/lib/dashboard_grid";
 
 import DataAppPageTitle from "metabase/writeback/containers/DataAppPageTitle";
 
@@ -37,10 +38,9 @@ export const HeaderRoot = styled(
   ${props =>
     props.isDataApp &&
     css`
-      width: 1200px;
-      margin-left: auto;
-      margin-right: auto;
-      padding: 0;
+      max-width: ${DATA_APPS_MAX_WIDTH + 64}px;
+      margin: 0 auto;
+      padding: 0 2rem;
     `}
 
   ${breakpointMaxSmall} {

--- a/frontend/src/metabase/lib/dashboard_grid.js
+++ b/frontend/src/metabase/lib/dashboard_grid.js
@@ -7,15 +7,26 @@ export const DATA_APPS_MIN_ROW_HEIGHT = 42;
 export const DATA_APPS_GRID_MARGIN = { desktop: [32, 18], mobile: [6, 10] };
 
 const MOBILE_BREAKPOINT = 752;
+const DATA_APP_MOBILE_BREAKPOINT = MOBILE_BREAKPOINT / 2;
 
 export const GRID_BREAKPOINTS = {
   desktop: MOBILE_BREAKPOINT + 1,
   mobile: MOBILE_BREAKPOINT,
 };
 
+export const DATA_APPS_GRID_BREAKPOINTS = {
+  desktop: DATA_APP_MOBILE_BREAKPOINT + 1,
+  mobile: DATA_APP_MOBILE_BREAKPOINT,
+};
+
 export const GRID_COLUMNS = {
   desktop: GRID_WIDTH,
   mobile: 1,
+};
+
+export const GRID_MARGIN = {
+  desktop: [6, 6],
+  mobile: [6, 10],
 };
 
 export const DEFAULT_CARD_SIZE = { width: 4, height: 4 };


### PR DESCRIPTION
## Description

Header, Filters, and dashboard content now align more consistently in Data Apps. We also allow data apps to shrink below 1200px width (and the mobile breakpoint is MUCH smaller, so you shouldn't hit it unless you're actually on a phone).

In view Mode
![viewMode](https://user-images.githubusercontent.com/30528226/201220094-6ea9d26b-a436-42f9-a3fb-96044bc8a12c.gif)

In Edit Mode
![editMode](https://user-images.githubusercontent.com/30528226/201220108-7ca569b4-8bbf-4ce3-a175-b2b4bc2efd05.gif)

And the transition between is better
![transition](https://user-images.githubusercontent.com/30528226/201220082-3c05a842-4de4-4e3e-a8da-5cc99968ffa5.gif)

The sidebar in edit mode is still a little 🥴 , but tackling that is it's own can of worms.
![sidebar](https://user-images.githubusercontent.com/30528226/201220071-f3b62037-e98c-48c3-83ec-d82446d94c13.gif)

