### PR TITLE
Adding option to hide edit button on ChartSettingOrderedSimple component

### DIFF
--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedSimple.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedSimple.tsx
@@ -25,6 +25,7 @@ interface ChartSettingOrderedSimpleProps {
     ref: HTMLElement | undefined,
   ) => void;
   series: Series;
+  hasEditSettings: boolean;
 }
 
 export const ChartSettingOrderedSimple = ({
@@ -33,6 +34,7 @@ export const ChartSettingOrderedSimple = ({
   value: orderedItems,
   series,
   onShowWidget,
+  hasEditSettings = true,
 }: ChartSettingOrderedSimpleProps) => {
   const toggleDisplay = (selectedItem: SortableItem) => {
     const index = orderedItems.findIndex(
@@ -78,7 +80,7 @@ export const ChartSettingOrderedSimple = ({
           onRemove={toggleDisplay}
           onEnable={toggleDisplay}
           onSortEnd={handleSortEnd}
-          onEdit={handleOnEdit}
+          onEdit={hasEditSettings ? handleOnEdit : undefined}
           distance={5}
         />
       ) : (

--- a/frontend/src/metabase/visualizations/visualizations/Funnel.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Funnel.jsx
@@ -136,8 +136,9 @@ export default class Funnel extends Component {
           enabled: true,
         }));
       },
-      getProps: transformedSeries => ({
+      getProps: (transformedSeries, settings, extra) => ({
         items: transformedSeries.map(s => s.card),
+        hasEditSettings: false,
       }),
       dataTestId: "funnel-row-sort",
     },

--- a/frontend/src/metabase/visualizations/visualizations/Funnel.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Funnel.jsx
@@ -136,7 +136,7 @@ export default class Funnel extends Component {
           enabled: true,
         }));
       },
-      getProps: (transformedSeries, settings, extra) => ({
+      getProps: transformedSeries => ({
         items: transformedSeries.map(s => s.card),
         hasEditSettings: false,
       }),


### PR DESCRIPTION
Adding prop to the `ChartSettingOrderedSimple` component to show/hide ellipsis icon when appropriate, and using it in `Funnel` visualization.

Before:
![image](https://user-images.githubusercontent.com/1328979/201231856-95c79819-6131-4cfa-b021-0c9a74611cbc.png)

After:
![image](https://user-images.githubusercontent.com/1328979/201231889-1fea4ced-6b00-40dc-96f9-51e4b20482d2.png)


