### PR TITLE
[CI] Increase drivers tests timeout

### DIFF
--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -17,7 +17,7 @@ jobs:
 
   be-tests-druid-ee:
     runs-on: buildjet-2vcpu-ubuntu-2004
-    timeout-minutes: 25
+    timeout-minutes: 30
     env:
       CI: 'true'
       DRIVERS: druid
@@ -37,7 +37,7 @@ jobs:
 
   be-tests-mariadb-10-2-ee:
     runs-on: ubuntu-20.04
-    timeout-minutes: 25
+    timeout-minutes: 30
     env:
       CI: 'true'
       DRIVERS: mysql
@@ -61,7 +61,7 @@ jobs:
 
   be-tests-mariadb-latest-ee:
     runs-on: ubuntu-20.04
-    timeout-minutes: 25
+    timeout-minutes: 30
     env:
       CI: 'true'
       DRIVERS: mysql
@@ -85,7 +85,7 @@ jobs:
 
   be-tests-mongo-4-0-ee:
     runs-on: ubuntu-20.04
-    timeout-minutes: 25
+    timeout-minutes: 30
     env:
       CI: 'true'
       DRIVERS: mongo
@@ -103,7 +103,7 @@ jobs:
 
   be-tests-mongo-5-0-ee:
     runs-on: ubuntu-20.04
-    timeout-minutes: 25
+    timeout-minutes: 30
     env:
       CI: 'true'
       DRIVERS: mongo
@@ -121,7 +121,7 @@ jobs:
 
   be-tests-mongo-latest-ee:
     runs-on: ubuntu-20.04
-    timeout-minutes: 25
+    timeout-minutes: 30
     env:
       CI: 'true'
       DRIVERS: mongo
@@ -142,7 +142,7 @@ jobs:
 
   be-tests-mysql-5-7-ee:
     runs-on: ubuntu-20.04
-    timeout-minutes: 25
+    timeout-minutes: 30
     env:
       CI: 'true'
       DRIVERS: mysql
@@ -166,7 +166,7 @@ jobs:
 
   be-tests-postgres-ee:
     runs-on: ubuntu-20.04
-    timeout-minutes: 25
+    timeout-minutes: 30
     env:
       CI: 'true'
       DRIVERS: postgres
@@ -193,7 +193,7 @@ jobs:
 
   be-tests-postgres-latest-ee:
     runs-on: ubuntu-20.04
-    timeout-minutes: 25
+    timeout-minutes: 30
     env:
       CI: 'true'
       DRIVERS: postgres
@@ -224,7 +224,7 @@ jobs:
 
   be-tests-presto-186-ee:
     runs-on: ubuntu-20.04
-    timeout-minutes: 25
+    timeout-minutes: 30
     env:
       CI: 'true'
       DRIVERS: presto
@@ -244,7 +244,7 @@ jobs:
 
   be-tests-sparksql-ee:
     runs-on: buildjet-2vcpu-ubuntu-2004
-    timeout-minutes: 25
+    timeout-minutes: 30
     env:
       CI: 'true'
       DRIVERS: sparksql
@@ -262,7 +262,7 @@ jobs:
 
   be-tests-sqlite-ee:
     runs-on: ubuntu-20.04
-    timeout-minutes: 25
+    timeout-minutes: 30
     env:
       CI: 'true'
       DRIVERS: sqlite
@@ -275,7 +275,7 @@ jobs:
 
   be-tests-sqlserver-ee:
     runs-on: ubuntu-20.04
-    timeout-minutes: 25
+    timeout-minutes: 30
     env:
       CI: 'true'
       DRIVERS: sqlserver


### PR DESCRIPTION
From the get go, drivers tests started timing out.
25 minutes is barely enough. Increasing the timeout to 30 minutes.