### PR TITLE
[CI] Bump junit report action to v3

### DIFF
--- a/.github/actions/test-driver/action.yml
+++ b/.github/actions/test-driver/action.yml
@@ -18,7 +18,7 @@ runs:
       run: clojure -X:dev:ci:ee:ee-dev:drivers:drivers-dev:test
       shell: bash
     - name: Publish Test Report (JUnit)
-      uses: mikepenz/action-junit-report@v2
+      uses: mikepenz/action-junit-report@v3
       if: always()
       with:
         report_paths: 'target/junit/**/*_test.xml'

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -113,7 +113,7 @@ jobs:
     - name: Run tests
       run: clojure -X:dev:ci:test:${{ matrix.edition }}:${{ matrix.edition }}-dev
     - name: Publish Test Report (JUnit)
-      uses: mikepenz/action-junit-report@v2
+      uses: mikepenz/action-junit-report@v3
       if: always()
       with:
         report_paths: 'target/junit/**/*_test.xml'


### PR DESCRIPTION
### Status
PENDING CI && PENDING REVIEW

### What does this PR accomplish?
- Increases the [junit report action](https://github.com/mikepenz/action-junit-report) to v3, in order to avoid warning messages about Node 12 being unsupported.

Take a look at this workflow summary: https://github.com/metabase/metabase/actions/runs/3441178664
It's riddled with this warning, which makes it hard to focus on the test output:

`Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: mikepenz/action-junit-report
`

### How to test?
This PR should remove that warning.
Check [the summary of drivers workflow after this PR](https://github.com/metabase/metabase/actions/runs/3443859821) and make sure warning is not there.
Make sure all tests are still passing.