### PR TITLE
[CI] Update deprecated `set-output` command in backport actions

### DIFF
--- a/.github/actions/find-squashed-commit/action.yml
+++ b/.github/actions/find-squashed-commit/action.yml
@@ -22,7 +22,7 @@ runs:
         COMMIT=$(env -i git log $BASE_REF --grep="(#$PULL_REQUEST_NUMBER)" --format="%H")
         echo "commit SHA $COMMIT"
 
-        echo "::set-output name=commit::$COMMIT"
+        echo "commit=$COMMIT" >> $GITHUB_OUTPUT
       id: find-squashed-commit
       shell: bash
       env:

--- a/.github/workflows/auto-backport.yml
+++ b/.github/workflows/auto-backport.yml
@@ -43,13 +43,13 @@ jobs:
           CONFLICTS=$(git ls-files -u | wc -l)
           if [ "$CONFLICTS" -gt 0 ]; then
             echo "Could not cherry pick because of a conflict"
-            echo "::set-output name=has-conflicts::true"
+            echo "has-conflicts=true" >> $GITHUB_OUTPUT
             git cherry-pick --abort
             git checkout master
             exit 0
           fi
 
-          echo "::set-output name=has-conflicts::false"
+          echo "has-conflicts=false" >> $GITHUB_OUTPUT
 
           git checkout master
           git push -u origin ${BACKPORT_BRANCH}
@@ -60,7 +60,7 @@ jobs:
 
           BACKPORT_PR_NUMBER=${BACKPORT_PR_URL##*/}
 
-          echo "::set-output name=backport_pr_number::$BACKPORT_PR_NUMBER"
+          echo "backport_pr_number=$BACKPORT_PR_NUMBER" >> $GITHUB_OUTPUT
         env:
           TARGET_BRANCH: ${{ steps.get_latest_release_branch.outputs.branch-name }}
           ORIGINAL_PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -117,7 +117,7 @@ jobs:
 
               BACKPORT_PR_NUMBER=${BACKPORT_PR_URL##*/}
 
-              echo "::set-output name=backport_pr_number::$BACKPORT_PR_NUMBER"
+              echo "backport_pr_number=$BACKPORT_PR_NUMBER" >> $GITHUB_OUTPUT
               echo "New PR has been created"
           fi
         env:


### PR DESCRIPTION
GitHub is deprecating `set-output` command:
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

This PR updates it to a newer syntax, which should remove warnings, like these ones:
https://github.com/metabase/metabase/actions/runs/3444804861