### PR TITLE
Contextualize new data app flow

### DIFF
--- a/frontend/src/metabase/components/NewItemMenu/NewItemMenu.styled.tsx
+++ b/frontend/src/metabase/components/NewItemMenu/NewItemMenu.styled.tsx
@@ -1,6 +1,0 @@
-import styled from "@emotion/styled";
-import Modal from "metabase/components/Modal";
-
-export const WideModal = styled(Modal)`
-  width: 60%;
-`;

--- a/frontend/src/metabase/components/NewItemMenu/NewItemMenu.tsx
+++ b/frontend/src/metabase/components/NewItemMenu/NewItemMenu.tsx
@@ -12,8 +12,6 @@ import CreateDataAppModal from "metabase/writeback/containers/CreateDataAppModal
 
 import type { Collection, CollectionId } from "metabase-types/api";
 
-import { WideModal } from "./NewItemMenu.styled";
-
 type ModalType = "new-app" | "new-dashboard" | "new-collection";
 
 export interface NewItemMenuProps {
@@ -153,9 +151,7 @@ const NewItemMenu = ({
               />
             </Modal>
           ) : modal === "new-app" ? (
-            <WideModal onClose={handleModalClose}>
-              <CreateDataAppModal onClose={handleModalClose} />
-            </WideModal>
+            <CreateDataAppModal onClose={handleModalClose} />
           ) : null}
         </>
       )}

--- a/frontend/src/metabase/writeback/containers/CreateDataAppModal/CreateDataAppModal.tsx
+++ b/frontend/src/metabase/writeback/containers/CreateDataAppModal/CreateDataAppModal.tsx
@@ -1,0 +1,33 @@
+import React, { useState } from "react";
+
+import Modal from "metabase/components/Modal";
+
+import DataAppScaffoldingModal from "./DataAppScaffoldingModal";
+import DataAppEducationModal from "./DataAppEducationModal";
+
+interface Props {
+  onClose: () => void;
+}
+
+function CreateDataAppModal({ onClose }: Props) {
+  const [modal, setModal] = useState<"education" | "scaffolding">("education");
+
+  if (modal === "education") {
+    return (
+      <Modal small onClose={onClose}>
+        <DataAppEducationModal
+          onNextStep={() => setModal("scaffolding")}
+          onClose={onClose}
+        />
+      </Modal>
+    );
+  }
+
+  return (
+    <Modal medium onClose={onClose}>
+      <DataAppScaffoldingModal onClose={onClose} />
+    </Modal>
+  );
+}
+
+export default CreateDataAppModal;

--- a/frontend/src/metabase/writeback/containers/CreateDataAppModal/DataAppEducationModal.styled.tsx
+++ b/frontend/src/metabase/writeback/containers/CreateDataAppModal/DataAppEducationModal.styled.tsx
@@ -1,0 +1,56 @@
+import styled from "@emotion/styled";
+
+import Icon from "metabase/components/Icon";
+
+import { alpha, color } from "metabase/lib/colors";
+
+export const ModalContentContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+
+  text-align: center;
+`;
+
+export const IconContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+
+  margin-top: 2rem;
+`;
+
+export const AppIcon = styled(Icon)`
+  display: block;
+  color: ${color("brand")};
+`;
+
+export const InsightIcon = styled(Icon)`
+  display: block;
+  color: ${alpha(color("brand"), 0.5)};
+
+  margin-left: 3rem;
+  margin-top: 1rem;
+`;
+
+export const MessageContent = styled.div`
+  width: 70%;
+`;
+
+export const ModalMessage = styled.span`
+  display: block;
+  color: ${color("text-dark")};
+
+  font-size: 1.14rem;
+  font-weight: 700;
+
+  margin-top: 2.4rem;
+`;
+
+export const ModalSubtitle = styled.span`
+  display: block;
+  color: ${alpha(color("text-dark"), 0.66)};
+  margin-top: 1rem;
+  margin-bottom: 2rem;
+`;

--- a/frontend/src/metabase/writeback/containers/CreateDataAppModal/DataAppEducationModal.tsx
+++ b/frontend/src/metabase/writeback/containers/CreateDataAppModal/DataAppEducationModal.tsx
@@ -1,0 +1,49 @@
+import React from "react";
+import { t } from "ttag";
+
+import Button from "metabase/core/components/Button";
+import ModalContent from "metabase/components/ModalContent";
+
+import {
+  AppIcon,
+  ModalContentContainer,
+  MessageContent,
+  ModalMessage,
+  ModalSubtitle,
+  InsightIcon,
+  IconContainer,
+} from "./DataAppEducationModal.styled";
+
+interface Props {
+  onNextStep: () => void;
+  onClose: () => void;
+}
+
+function DataAppEducationModal({ onNextStep, onClose }: Props) {
+  return (
+    <ModalContent
+      formModal={false}
+      footer={[
+        <Button
+          key="pick data"
+          primary
+          onClick={onNextStep}
+        >{t`Pick data`}</Button>,
+      ]}
+      onClose={onClose}
+    >
+      <ModalContentContainer>
+        <IconContainer>
+          <InsightIcon name="insight" size={17} />
+          <AppIcon name="app" size={30} />
+        </IconContainer>
+        <MessageContent>
+          <ModalMessage>{t`Build tools to work with, create, and update data.`}</ModalMessage>
+          <ModalSubtitle>{t`Metabase will help get you started with some basic pages you can customize.`}</ModalSubtitle>
+        </MessageContent>
+      </ModalContentContainer>
+    </ModalContent>
+  );
+}
+
+export default DataAppEducationModal;

--- a/frontend/src/metabase/writeback/containers/CreateDataAppModal/DataAppScaffoldingModal.styled.tsx
+++ b/frontend/src/metabase/writeback/containers/CreateDataAppModal/DataAppScaffoldingModal.styled.tsx
@@ -3,7 +3,6 @@ import styled from "@emotion/styled";
 import Icon from "metabase/components/Icon";
 
 import { color } from "metabase/lib/colors";
-import { space } from "metabase/styled-components/theme";
 
 export const ModalRoot = styled.div`
   display: flex;

--- a/frontend/src/metabase/writeback/containers/CreateDataAppModal/DataAppScaffoldingModal.tsx
+++ b/frontend/src/metabase/writeback/containers/CreateDataAppModal/DataAppScaffoldingModal.tsx
@@ -31,7 +31,7 @@ import {
   SearchInputContainer,
   SearchInput,
   SearchIcon,
-} from "./CreateDataAppModal.styled";
+} from "./DataAppScaffoldingModal.styled";
 
 interface OwnProps {
   onClose: () => void;
@@ -78,7 +78,11 @@ function DataPickerSearchInput({ value }: { value: DataPickerValue }) {
   );
 }
 
-function CreateDataAppModal({ onCreate, onChangeLocation, onClose }: Props) {
+function DataAppScaffoldingModal({
+  onCreate,
+  onChangeLocation,
+  onClose,
+}: Props) {
   const [value, setValue] = useDataPickerValue();
 
   const { tableIds } = value;
@@ -124,4 +128,4 @@ export default connect<unknown, DispatchProps, OwnProps, State>(
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
   mapDispatchToProps,
-)(CreateDataAppModal);
+)(DataAppScaffoldingModal);

--- a/frontend/src/metabase/writeback/containers/CreateDataAppModal/index.ts
+++ b/frontend/src/metabase/writeback/containers/CreateDataAppModal/index.ts
@@ -1,1 +1,1 @@
-export { default } from "./DataAppScaffoldingModal";
+export { default } from "./CreateDataAppModal";

--- a/frontend/src/metabase/writeback/containers/CreateDataAppModal/index.ts
+++ b/frontend/src/metabase/writeback/containers/CreateDataAppModal/index.ts
@@ -1,1 +1,1 @@
-export { default } from "./CreateDataAppModal";
+export { default } from "./DataAppScaffoldingModal";


### PR DESCRIPTION
Resolves #26345

Adds an educational modal right before the data app scaffolding data picker explaining what's going on

> **Warning**
> You can see a huge diff in `CreateDataAppModal`. Actually, I've just renamed it to `DataAppScaffoldingModal` and added another `CreateDataAppModal` that'd only switch between education/scaffolding modals, so you can ignore the diff and just take a look at the endfile

### To Verify

1. New > App
2. Click "x" and ensure the modal closes
3. New > App > Pick data
4. Pick some tables/models, click "Create" and ensure the app is created
5. New > App
6. Ensure you still see the educational modal

### Demo


https://user-images.githubusercontent.com/17258145/201344668-66f73be6-d602-40ce-b751-f44ca96d9aa6.mp4

