### PR TITLE
Remove unused `underscore` import

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,5 +1,4 @@
 /* eslint-disable import/no-commonjs */
-const _ = require("underscore");
 const glob = require("glob");
 
 // eslint-disable-next-line no-undef


### PR DESCRIPTION
It was used last time here:
https://github.com/metabase/metabase/pull/18860/files#diff-05ed1c7f99e45b485708115502a1e0f28c8547e9a9a29c1b8664f79103cf7873L10