### PR TITLE
Show scaffolding errors on the frontend

### DIFF
--- a/frontend/src/metabase/containers/FormikForm/FormikForm.tsx
+++ b/frontend/src/metabase/containers/FormikForm/FormikForm.tsx
@@ -15,6 +15,12 @@ import {
 } from "metabase-types/forms";
 
 import { OptionalFormViewProps } from "metabase/components/form/FormikCustomForm/types";
+
+import {
+  getResponseErrorMessage,
+  GenericErrorResponse,
+} from "metabase/lib/errors";
+
 import { makeFormObject, cleanObject, isNestedFieldName } from "../formUtils";
 import FormikFormViewAdapter from "./FormikFormViewAdapter";
 import useInlineFields from "./useInlineFields";
@@ -48,38 +54,10 @@ interface FormContainerProps<Values extends BaseFieldValues>
   children?: ReactNode | ((opts: any) => any);
 }
 
-type ServerErrorResponse = {
-  data?:
-    | {
-        message?: string;
-        errors?: Record<string, string>;
-      }
-    | string;
-  errors?: Record<string, string>;
-  message?: string;
-};
-
 function maybeBlurActiveElement() {
   // HACK: blur the current element to ensure we show the error
   if (document.activeElement && "blur" in document.activeElement) {
     (document.activeElement as HTMLInputElement).blur();
-  }
-}
-
-function getGeneralErrorMessage(error: ServerErrorResponse) {
-  if (typeof error.data === "object") {
-    if (error.data.message) {
-      return error.data.message;
-    }
-    if (error.data?.errors?._error) {
-      return error.data.errors._error;
-    }
-  }
-  if (error.message) {
-    return error.message;
-  }
-  if (typeof error.data === "string") {
-    return error.data;
   }
 }
 
@@ -187,7 +165,7 @@ function Form<Values extends BaseFieldValues>({
   );
 
   const handleError = useCallback(
-    (error: ServerErrorResponse, formikHelpers: FormikHelpers<Values>) => {
+    (error: GenericErrorResponse, formikHelpers: FormikHelpers<Values>) => {
       maybeBlurActiveElement();
       const DEFAULT_ERROR_MESSAGE = t`An error occurred`;
 
@@ -198,8 +176,10 @@ function Form<Values extends BaseFieldValues>({
         );
 
         if (hasUnknownFields) {
-          const generalMessage =
-            getGeneralErrorMessage(error) || DEFAULT_ERROR_MESSAGE;
+          const generalMessage = getResponseErrorMessage(
+            error,
+            DEFAULT_ERROR_MESSAGE,
+          );
           setError(generalMessage);
         }
 
@@ -208,7 +188,7 @@ function Form<Values extends BaseFieldValues>({
       }
 
       if (error) {
-        const message = getGeneralErrorMessage(error) || DEFAULT_ERROR_MESSAGE;
+        const message = getResponseErrorMessage(error, DEFAULT_ERROR_MESSAGE);
         setError(message);
         return message;
       }
@@ -227,7 +207,7 @@ function Form<Values extends BaseFieldValues>({
         setError(null); // clear any previous errors
         return result;
       } catch (e) {
-        const error = handleError(e as ServerErrorResponse, formikHelpers);
+        const error = handleError(e as GenericErrorResponse, formikHelpers);
         // Need to throw, so e.g. submit button can react to an error
         throw error;
       }

--- a/frontend/src/metabase/lib/errors.ts
+++ b/frontend/src/metabase/lib/errors.ts
@@ -1,3 +1,37 @@
+import { t } from "ttag";
+
+export type GenericErrorResponse = {
+  data?:
+    | {
+        message?: string;
+        errors?: Record<string, string>;
+      }
+    | string;
+  errors?: Record<string, string>;
+  message?: string;
+};
+
 export const SERVER_ERROR_TYPES = {
   missingPermissions: "missing-required-permissions",
 };
+
+export function getResponseErrorMessage(
+  error: GenericErrorResponse,
+  fallback = t`An error occurred`,
+) {
+  if (typeof error.data === "object") {
+    if (error.data.message) {
+      return error.data.message;
+    }
+    if (error.data?.errors?._error) {
+      return error.data.errors._error;
+    }
+  }
+  if (error.message) {
+    return error.message;
+  }
+  if (typeof error.data === "string") {
+    return error.data;
+  }
+  return fallback;
+}

--- a/frontend/src/metabase/writeback/containers/CreateDataAppModal/DataAppScaffoldingModal.styled.tsx
+++ b/frontend/src/metabase/writeback/containers/CreateDataAppModal/DataAppScaffoldingModal.styled.tsx
@@ -37,12 +37,17 @@ export const ModalBody = styled.div`
 
 export const ModalFooter = styled.div`
   display: flex;
-  justify-content: flex-end;
+  justify-content: space-between;
 
-  gap: 1rem;
   padding: 1.5rem 2rem;
 
   border-top: 1px solid ${color("border")};
+`;
+
+export const ModalFooterContent = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 1rem;
 `;
 
 export const SearchInputContainer = styled.div`
@@ -80,4 +85,8 @@ export const SearchInput = styled.input`
     color: ${color("text-light")};
     font-weight: 700;
   }
+`;
+
+export const ErrorMessage = styled.span`
+  color: ${color("error")};
 `;

--- a/frontend/src/metabase/writeback/containers/ScaffoldDataAppPagesModal/ScaffoldDataAppPagesModal.styled.tsx
+++ b/frontend/src/metabase/writeback/containers/ScaffoldDataAppPagesModal/ScaffoldDataAppPagesModal.styled.tsx
@@ -33,10 +33,19 @@ export const ModalBody = styled.div`
 
 export const ModalFooter = styled.div`
   display: flex;
-  justify-content: flex-end;
+  justify-content: space-between;
 
-  gap: 1rem;
   padding: 1.5rem 2rem;
 
   border-top: 1px solid ${color("border")};
+`;
+
+export const ModalFooterContent = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+`;
+
+export const ErrorMessage = styled.span`
+  color: ${color("error")};
 `;

--- a/frontend/src/metabase/writeback/containers/ScaffoldDataAppPagesModal/ScaffoldDataAppPagesModal.tsx
+++ b/frontend/src/metabase/writeback/containers/ScaffoldDataAppPagesModal/ScaffoldDataAppPagesModal.tsx
@@ -1,10 +1,16 @@
-import React, { useCallback } from "react";
+import React, { useCallback, useState } from "react";
 import { t } from "ttag";
 import { connect } from "react-redux";
 
 import Button from "metabase/core/components/Button";
 
 import { useDataPickerValue } from "metabase/containers/DataPicker";
+
+import {
+  getResponseErrorMessage,
+  GenericErrorResponse,
+} from "metabase/lib/errors";
+
 import {
   scaffoldDataAppPages,
   ScaffoldNewPagesParams,
@@ -20,6 +26,8 @@ import {
   ModalTitle,
   ModalBody,
   ModalFooter,
+  ModalFooterContent,
+  ErrorMessage,
 } from "./ScaffoldDataAppPagesModal.styled";
 
 interface OwnProps {
@@ -48,18 +56,34 @@ function ScaffoldDataAppPagesModal({
   onClose,
 }: Props) {
   const [value, setValue] = useDataPickerValue();
+  const [error, setError] = useState("");
+
   const { tableIds } = value;
 
+  const handleValueChange = useCallback(
+    nextValue => {
+      setValue(nextValue);
+      setError("");
+    },
+    [setValue],
+  );
+
   const handleAdd = useCallback(async () => {
-    const dataApp = await onScaffold({
-      dataAppId,
-      tables: tableIds as number[],
-    });
-    onClose();
-    onAdd(dataApp);
+    try {
+      const dataApp = await onScaffold({
+        dataAppId,
+        tables: tableIds as number[],
+      });
+      onClose();
+      onAdd(dataApp);
+    } catch (error) {
+      const response = error as GenericErrorResponse;
+      setError(getResponseErrorMessage(response));
+    }
   }, [dataAppId, tableIds, onAdd, onScaffold, onClose]);
 
-  const canSubmit = tableIds.length > 0;
+  const hasError = error.length > 0;
+  const canSubmit = tableIds.length > 0 && !hasError;
 
   return (
     <ModalRoot>
@@ -70,12 +94,17 @@ function ScaffoldDataAppPagesModal({
         <DataAppScaffoldingDataPicker value={value} onChange={setValue} />
       </ModalBody>
       <ModalFooter>
-        <Button onClick={onClose}>{t`Cancel`}</Button>
-        <Button
-          primary
-          disabled={!canSubmit}
-          onClick={handleAdd}
-        >{t`Add`}</Button>
+        <ModalFooterContent>
+          {hasError && <ErrorMessage>{error}</ErrorMessage>}
+        </ModalFooterContent>
+        <ModalFooterContent>
+          <Button onClick={onClose}>{t`Cancel`}</Button>
+          <Button
+            primary
+            disabled={!canSubmit}
+            onClick={handleAdd}
+          >{t`Add`}</Button>
+        </ModalFooterContent>
       </ModalFooter>
     </ModalRoot>
   );


### PR DESCRIPTION
Fixes #26375

Ensures the FE shows scaffolding API errors in "New app" and "Add data" flows. Metabase API can return errors in different shapes, so the FE developed a generic function handling different response structures. Before, it lived in the form framework code. This PR extracts that part to `metabase/lib/errors` and makes scaffolding modals use it.

### To Verify

1. Admin > Data Model > Sample Database > Orders
2. Set the "Quantity" column's type to "Entity Key" (PK)
3. New > App > Raw Data > Sample Database
4. Pick Orders and click "Create"
5. Ensure you can see the error message at the bottom left of the modal. Ensure the "Create" button is now disabled
6. Pick another table instead of Orders and click "Create" again, ensure the app was created successfully
7. On the app page, click "+" at the app navigation bar, pick "Data"
8. Select Raw Data > Sample Database > Orders all over again and click "Create"
9. Ensure you can see the error message at the bottom left of the modal. Ensure the "Create" button is now disabled
10. Pick another table instead of Orders and click "Add", ensure new pages were scaffolded successfully

### Demo

https://user-images.githubusercontent.com/17258145/201350753-cbb1eb6a-16e2-4e98-b9ae-4c43c78b33c6.mp4

