### PR TITLE
Tweak action toast messages

### DIFF
--- a/frontend/src/metabase/dashboard/actions/writeback.ts
+++ b/frontend/src/metabase/dashboard/actions/writeback.ts
@@ -261,7 +261,7 @@ function getImplicitActionExecutionMessage(action: WritebackAction) {
   if (action.slug === "delete") {
     return t`Successfully deleted`;
   }
-  return t`Successfully run the action`;
+  return t`Successfully ran the action`;
 }
 
 function getActionExecutionMessage(action: WritebackAction, result: any) {

--- a/frontend/src/metabase/dashboard/actions/writeback.ts
+++ b/frontend/src/metabase/dashboard/actions/writeback.ts
@@ -1,5 +1,9 @@
 import { t } from "ttag";
 
+import {
+  getResponseErrorMessage,
+  GenericErrorResponse,
+} from "metabase/lib/errors";
 import { createAction } from "metabase/lib/redux";
 import { addUndo } from "metabase/redux/undo";
 
@@ -282,9 +286,12 @@ export const executeRowAction = async ({
 
     return { success: true, message };
   } catch (err) {
-    const message =
-      (<any>err)?.data?.message ||
-      t`Something went wrong while executing the action`;
+    const response = err as GenericErrorResponse;
+    const message = getResponseErrorMessage(
+      response,
+      t`Something went wrong while executing the action`,
+    );
+
     if (shouldToast) {
       dispatch(
         addUndo({
@@ -294,6 +301,7 @@ export const executeRowAction = async ({
         }),
       );
     }
+
     return { success: false, error: message, message };
   }
 };

--- a/frontend/src/metabase/dashboard/actions/writeback.ts
+++ b/frontend/src/metabase/dashboard/actions/writeback.ts
@@ -271,7 +271,7 @@ function getActionExecutionMessage(action: WritebackAction, result: any) {
   if (hasDataFromExplicitAction(result)) {
     return t`Success! The action returned: ${JSON.stringify(result)}`;
   }
-  return `${action.name} ${t`was run successfully`}`;
+  return t`${action.name} was run successfully`;
 }
 
 export const executeRowAction = async ({


### PR DESCRIPTION
Closes #26349

Tweaks messages Metabase is going to show on successful action execution:

* says "Successfully saved/updated/deleted" for implicit insert/update/delete actions
* says "Success! The action returned {JSON}" for explicit actions returning something back (only for HTTP actions which are out of scope right now"
* says "{ACTION_NAME} was run successfully"

### Demo

https://user-images.githubusercontent.com/17258145/201383127-e1b4ac0b-675d-4b49-a3d1-aa1f8175fcb8.mp4

