### PR TITLE
Don't use dashboard analytics context for data apps

### DIFF
--- a/frontend/src/metabase/dashboard/components/AddSeriesModal/QuestionList.jsx
+++ b/frontend/src/metabase/dashboard/components/AddSeriesModal/QuestionList.jsx
@@ -2,6 +2,7 @@ import React, { useState, useMemo, useEffect, useCallback } from "react";
 import PropTypes from "prop-types";
 import { t } from "ttag";
 import { AutoSizer, List } from "react-virtualized";
+import { connect } from "react-redux";
 
 import Icon from "metabase/components/Icon";
 import * as MetabaseAnalytics from "metabase/lib/analytics";
@@ -9,6 +10,10 @@ import { useDebouncedValue } from "metabase/hooks/use-debounced-value";
 import { SEARCH_DEBOUNCE_DURATION } from "metabase/lib/constants";
 import EmptyState from "metabase/components/EmptyState";
 
+import { getIsDataAppPage } from "metabase/dashboard/selectors";
+
+import { isQuestionCompatible } from "./utils";
+import { QuestionListItem } from "./QuestionListItem";
 import {
   LoadMoreButton,
   LoadMoreRow,
@@ -18,10 +23,14 @@ import {
   EmptyStateContainer,
   QuestionListWrapper,
 } from "./QuestionList.styled";
-import { QuestionListItem } from "./QuestionListItem";
-import { isQuestionCompatible } from "./utils";
 
 const LOAD_CHUNK_SIZE = 15;
+
+function mapStateToProps(state) {
+  return {
+    isDataAppPage: getIsDataAppPage(state),
+  };
+}
 
 const propTypes = {
   questions: PropTypes.object,
@@ -34,9 +43,10 @@ const propTypes = {
   loadMetadataForQueries: PropTypes.function,
   visualization: PropTypes.object,
   isLoadingMetadata: PropTypes.bool,
+  isDataAppPage: PropTypes.bool,
 };
 
-export const QuestionList = React.memo(function QuestionList({
+const QuestionList = React.memo(function QuestionList({
   questions,
   badQuestions,
   enabledQuestions,
@@ -47,6 +57,7 @@ export const QuestionList = React.memo(function QuestionList({
   loadMetadataForQueries,
   visualization,
   isLoadingMetadata,
+  isDataAppPage,
 }) {
   const [searchText, setSearchText] = useState("");
   const debouncedSearchText = useDebouncedValue(
@@ -56,7 +67,7 @@ export const QuestionList = React.memo(function QuestionList({
 
   const handleSearchFocus = () => {
     MetabaseAnalytics.trackStructEvent(
-      "Dashboard",
+      isDataAppPage ? "Data App Page" : "Dashboard",
       "Edit Series Modal",
       "search",
     );
@@ -193,3 +204,5 @@ export const QuestionList = React.memo(function QuestionList({
 });
 
 QuestionList.propTypes = propTypes;
+
+export default connect(mapStateToProps)(QuestionList);

--- a/frontend/src/metabase/dashboard/components/DashCard.jsx
+++ b/frontend/src/metabase/dashboard/components/DashCard.jsx
@@ -363,6 +363,9 @@ const DashCardActionButtons = ({
   isPreviewing,
   dashboard,
 }) => {
+  const analyticsContext = dashboard.is_app_page
+    ? "Data App Page"
+    : "Dashboard";
   const buttons = [];
 
   if (getVisualizationRaw(series).visualization.supportPreviewing) {
@@ -371,6 +374,7 @@ const DashCardActionButtons = ({
         key="toggle-card-preview-button"
         isPreviewing={isPreviewing}
         onPreviewToggle={onPreviewToggle}
+        analyticsContext={analyticsContext}
       />,
     );
   }
@@ -394,7 +398,7 @@ const DashCardActionButtons = ({
         <Tooltip key="click-behavior-tooltip" tooltip={t`Click behavior`}>
           <a
             className="text-dark-hover drag-disabled mr1"
-            data-metabase-event="Dashboard;Open Click Behavior Sidebar"
+            data-metabase-event={`${analyticsContext};Open Click Behavior Sidebar`}
             onClick={showClickBehaviorSidebar}
             style={HEADER_ACTION_STYLE}
           >
@@ -410,6 +414,7 @@ const DashCardActionButtons = ({
           key="add-series-button"
           series={series}
           onAddSeries={onAddSeries}
+          analyticsContext={analyticsContext}
         />,
       );
     }
@@ -419,7 +424,11 @@ const DashCardActionButtons = ({
     <span className="flex align-center text-medium" style={{ lineHeight: 1 }}>
       {buttons}
       <Tooltip tooltip={t`Remove`}>
-        <RemoveButton className="ml1" onRemove={onRemove} />
+        <RemoveButton
+          className="ml1"
+          onRemove={onRemove}
+          analyticsContext={analyticsContext}
+        />
       </Tooltip>
     </span>
   );
@@ -455,10 +464,10 @@ const ChartSettingsButton = ({
   </ModalWithTrigger>
 );
 
-const RemoveButton = ({ onRemove }) => (
+const RemoveButton = ({ onRemove, analyticsContext }) => (
   <a
     className="text-dark-hover drag-disabled"
-    data-metabase-event="Dashboard;Remove Card Modal"
+    data-metabase-event={`${analyticsContext};Remove Card Modal`}
     onClick={onRemove}
     style={HEADER_ACTION_STYLE}
   >
@@ -466,10 +475,10 @@ const RemoveButton = ({ onRemove }) => (
   </a>
 );
 
-const AddSeriesButton = ({ series, onAddSeries }) => (
+const AddSeriesButton = ({ series, onAddSeries, analyticsContext }) => (
   <a
     data-testid="add-series-button"
-    data-metabase-event="Dashboard;Edit Series Modal;open"
+    data-metabase-event={`${analyticsContext};Edit Series Modal;open`}
     className="text-dark-hover cursor-pointer h3 flex-no-shrink relative mr1 drag-disabled"
     onClick={onAddSeries}
     style={HEADER_ACTION_STYLE}
@@ -490,10 +499,14 @@ const AddSeriesButton = ({ series, onAddSeries }) => (
   </a>
 );
 
-const ToggleCardPreviewButton = ({ isPreviewing, onPreviewToggle }) => {
+const ToggleCardPreviewButton = ({
+  isPreviewing,
+  onPreviewToggle,
+  analyticsContext,
+}) => {
   return (
     <a
-      data-metabase-event="Dashboard;Text;edit"
+      data-metabase-event={`${analyticsContext};Text;edit`}
       className="text-dark-hover cursor-pointer h3 flex-no-shrink relative mr1 drag-disabled"
       onClick={onPreviewToggle}
       style={HEADER_ACTION_STYLE}

--- a/frontend/src/metabase/dashboard/components/DashboardGrid.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardGrid.jsx
@@ -136,7 +136,10 @@ class DashboardGrid extends Component {
 
     if (changes.length > 0) {
       setMultipleDashCardAttributes(changes);
-      MetabaseAnalytics.trackStructEvent("Dashboard", "Layout Changed");
+      MetabaseAnalytics.trackStructEvent(
+        dashboard.is_app_page ? "Data App Page" : "Dashboard",
+        "Layout Changed",
+      );
     }
   };
 

--- a/frontend/src/metabase/dashboard/components/DashboardSidebars.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardSidebars.jsx
@@ -78,9 +78,12 @@ export function DashboardSidebars({
         dashId: dashboard.id,
         cardId: cardId,
       });
-      MetabaseAnalytics.trackStructEvent("Dashboard", "Add Card");
+      MetabaseAnalytics.trackStructEvent(
+        dashboard.is_app_page ? "Data App Page" : "Dashboard",
+        "Add Card",
+      );
     },
-    [addCardToDashboard, dashboard.id],
+    [dashboard, addCardToDashboard],
   );
 
   if (isFullscreen) {

--- a/frontend/src/metabase/dashboard/components/RemoveFromDashboardModal.jsx
+++ b/frontend/src/metabase/dashboard/components/RemoveFromDashboardModal.jsx
@@ -15,13 +15,19 @@ export default class RemoveFromDashboardModal extends Component {
   };
 
   onRemove() {
-    this.props.removeCardFromDashboard({
-      dashId: this.props.dashboard.id,
-      dashcardId: this.props.dashcard.id,
-    });
-    this.props.onClose();
+    const { dashboard, dashcard, removeCardFromDashboard, onClose } =
+      this.props;
 
-    MetabaseAnalytics.trackStructEvent("Dashboard", "Remove Card");
+    removeCardFromDashboard({
+      dashId: dashboard.id,
+      dashcardId: dashcard.id,
+    });
+    onClose();
+
+    MetabaseAnalytics.trackStructEvent(
+      dashboard.is_app_page ? "Data App Page" : "Dashboard",
+      "Remove Card",
+    );
   }
 
   render() {

--- a/frontend/src/metabase/dashboard/containers/DashboardHeader.jsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardHeader.jsx
@@ -159,6 +159,11 @@ class DashboardHeader extends Component {
     this.onDoneEditing();
   }
 
+  getAnalyticsContext = () => {
+    const { dashboard } = this.props;
+    return dashboard.is_app_page ? "Data App Page" : "Dashboard";
+  };
+
   getEditWarning(dashboard) {
     if (dashboard.embedding_params) {
       const currentSlugs = Object.keys(dashboard.embedding_params);
@@ -183,9 +188,11 @@ class DashboardHeader extends Component {
     const canSave =
       !isDataAppPage || pageTitleTemplate === null || pageTitleTemplate !== "";
 
+    const analyticsContext = this.getAnalyticsContext();
+
     return [
       <Button
-        data-metabase-event="Dashboard;Cancel Edits"
+        data-metabase-event={`${analyticsContext}Cancel Edits`}
         key="cancel"
         className="Button Button--small mr1"
         onClick={() => this.onCancel()}
@@ -227,6 +234,7 @@ class DashboardHeader extends Component {
 
     const isDataAppPage = dashboard.is_app_page;
     const canEdit = dashboard.can_write && isEditable && !!dashboard;
+    const analyticsContext = this.getAnalyticsContext();
 
     const buttons = [];
     const extraButtons = [];
@@ -248,7 +256,7 @@ class DashboardHeader extends Component {
             icon="add"
             isActive={activeSidebarName === SIDEBAR_NAME.addQuestion}
             onClick={() => toggleSidebar(SIDEBAR_NAME.addQuestion)}
-            data-metabase-event="Dashboard;Add Card Sidebar"
+            data-metabase-event={`${analyticsContext};Add Card Sidebar`}
           />
         </Tooltip>,
       );
@@ -257,7 +265,7 @@ class DashboardHeader extends Component {
       buttons.push(
         <Tooltip key="add-a-text-box" tooltip={t`Add a text box`}>
           <a
-            data-metabase-event="Dashboard;Add Text Box"
+            data-metabase-event={`${analyticsContext};Add Text Box`}
             key="add-text"
             className="text-brand-hover cursor-pointer"
             onClick={() => this.onAddTextBox()}
@@ -312,7 +320,7 @@ class DashboardHeader extends Component {
               <DashboardHeaderButton
                 isActive={activeSidebarName === SIDEBAR_NAME.addActionForm}
                 onClick={() => toggleSidebar(SIDEBAR_NAME.addActionForm)}
-                data-metabase-event="Dashboard;Add Card Sidebar"
+                data-metabase-event={`${analyticsContext};Add Card Sidebar`}
               >
                 <Icon name="list" size={18} />
               </DashboardHeaderButton>
@@ -321,7 +329,7 @@ class DashboardHeader extends Component {
               <DashboardHeaderButton
                 isActive={activeSidebarName === SIDEBAR_NAME.addActionButton}
                 onClick={() => toggleSidebar(SIDEBAR_NAME.addActionButton)}
-                data-metabase-event="Dashboard;Add Card Sidebar"
+                data-metabase-event={`${analyticsContext};Add Card Sidebar`}
               >
                 <Icon name="click" size={18} />
               </DashboardHeaderButton>
@@ -334,7 +342,7 @@ class DashboardHeader extends Component {
         title: t`Revision history`,
         icon: "history",
         link: `${location.pathname}/history`,
-        event: "Dashboard;Revisions",
+        event: `${analyticsContext};Revisions`,
       });
     }
 
@@ -346,7 +354,7 @@ class DashboardHeader extends Component {
         >
           <DashboardHeaderButton
             key="edit"
-            data-metabase-event="Dashboard;Edit"
+            data-metabase-event={`${analyticsContext};Edit`}
             icon="pencil"
             className="text-brand-hover cursor-pointer"
             onClick={() => this.handleEdit(dashboard)}
@@ -361,7 +369,7 @@ class DashboardHeader extends Component {
           title: t`Enter fullscreen`,
           icon: "expand",
           action: e => onFullscreenChange(!isFullscreen, !e.altKey),
-          event: `Dashboard;Fullscreen Mode;${!isFullscreen}`,
+          event: `${analyticsContext};Fullscreen Mode;${!isFullscreen}`,
         });
       }
 
@@ -369,7 +377,7 @@ class DashboardHeader extends Component {
         title: t`Duplicate`,
         icon: "copy",
         link: `${location.pathname}/copy`,
-        event: "Dashboard;Copy",
+        event: `${analyticsContext};Copy`,
       });
 
       if (canEdit) {
@@ -377,14 +385,14 @@ class DashboardHeader extends Component {
           title: t`Move`,
           icon: "move",
           link: `${location.pathname}/move`,
-          event: "Dashboard;Move",
+          event: `${analyticsContext};Move`,
         });
 
         extraButtons.push({
           title: t`Archive`,
           icon: "view_archive",
           link: `${location.pathname}/archive`,
-          event: "Dashboard;Archive",
+          event: `${analyticsContext};Archive`,
         });
       }
     }
@@ -448,7 +456,7 @@ class DashboardHeader extends Component {
       <Header
         headerClassName="wrapper"
         objectType="dashboard"
-        analyticsContext="Dashboard"
+        analyticsContext={dashboard.is_app_page ? "Page" : "Dashboard"}
         dashboard={dashboard}
         dataAppNavItem={dataAppNavItem}
         pageTitleTemplate={pageTitleTemplate}

--- a/frontend/src/metabase/dashboard/selectors.js
+++ b/frontend/src/metabase/dashboard/selectors.js
@@ -256,3 +256,8 @@ export const getDataAppNavItem = (state, routerParams) => {
 
 export const getPageTitleTemplateChange = state =>
   state.dashboard.titleTemplateChange;
+
+export const getIsDataAppPage = createSelector(
+  [getDashboardComplete],
+  dashboard => dashboard?.is_app_page,
+);


### PR DESCRIPTION
Our dashboard code is covered with analytics events which are prefixed with "Dashboard" which shouldn't really be the case for data app pages. The PR should fix any occurrence of event keys to use "Data App Page" when looking at a page.