### PR TITLE
docs - datetimeAdd and datetimeSubtract

### DIFF
--- a/docs/questions/query-builder/expressions-list.md
+++ b/docs/questions/query-builder/expressions-list.md
@@ -32,8 +32,8 @@ For an introduction to expressions, check out [Writing expressions in the notebo
   - [coalesce](./expressions/coalesce.md)
   - [concat](./expressions/concat.md)
   - [contains](#contains)
-  - [datetimeAdd](#datetimeadd)
-  - [datetimeSubtract](#datetimesubtract)
+  - [datetimeAdd](./expressions/datetimeadd.md)
+  - [datetimeSubtract](./expressions/datetimesubtract.md)
   - [day](#day)
   - [endswith](#endswith)
   - [exp](#exp)
@@ -266,7 +266,7 @@ Example: `contains([Status], "Class")`. If `Status` were "Classified", the expre
 
 Related: [regexextract](#regexextract).
 
-### datetimeAdd
+### [datetimeAdd](./expressions/datetimeadd.md)
 
 Adds some unit of time to a date or timestamp value.
 
@@ -278,7 +278,7 @@ Syntax: `datetimeAdd(column, amount, unit)`.
 
 Example: `datetimeAdd("March 25, 2021, 12:52:37", 1, "month")` would return `April 25, 2021, 12:52:37`.
 
-### datetimeSubtract
+### [datetimeSubtract](./expressions/datetimesubtract.md)
 
 Subtracts some unit of time from a date or timestamp value.
 

--- a/docs/questions/query-builder/expressions/concat.md
+++ b/docs/questions/query-builder/expressions/concat.md
@@ -93,4 +93,4 @@ concat([City], ", ", [Country])
 ## Further reading
 
 - [Custom expressions documentation](../expressions.md)
-- [Custom expressions tutorial](https://www.metabase.com/learn/questions/)
+- [Custom expressions tutorial](https://www.metabase.com/learn/questions/custom-expressions)

--- a/docs/questions/query-builder/expressions/datetimeadd.md
+++ b/docs/questions/query-builder/expressions/datetimeadd.md
@@ -79,7 +79,7 @@ This section covers functions and formulas that work the same way as the Metabas
 
 ### datetimeSubtract
 
-`datetimeSubtract` and `datetimeAdd` are interchangeable, since you can use a negative number for `amount`.
+`datetimeSubtract` and `datetimeAdd` are interchangeable, since you can use a negative number for `amount`. It's generally a good idea to avoid double negatives (such as subtracting a negative number).
 
 ```
 datetimeSubtract([Opened On], -14, "day")

--- a/docs/questions/query-builder/expressions/datetimeadd.md
+++ b/docs/questions/query-builder/expressions/datetimeadd.md
@@ -32,7 +32,7 @@ Here, **Finish By** is a custom column with the expression:
 datetimeAdd([Opened On], 14, 'day')
 ```
 
-You can use the [`between` expression](../expressions-list.md#between) to check if a given date falls between your "start" and "end" dates. 
+You can use the [`between`](../expressions-list.md#between) or [interval](../expressions-list.md#interval) expressions to check if a given date falls between your start and end datetimes.
 
 ## Accepted data types
 
@@ -65,7 +65,7 @@ The result should give you a **Today** column that's non-empty if today's date f
 
 ## Related functions
 
-This section covers functions and formulas that work the same way as the Metabase `regexextract` expression, with notes on how to choose the best option for your use case.
+This section covers functions and formulas that work the same way as the Metabase `datetimeAdd` expression, with notes on how to choose the best option for your use case.
 
 **[Metabase expressions](../expressions-list.md)**
 
@@ -141,4 +141,7 @@ datetimeAdd([Opened On], 14, 'day')
 ## Further reading
 
 - [Custom expressions documentation](../expressions.md)
-- [Custom expressions tutorial](https://www.metabase.com/learn/questions/)
+- [Custom expressions tutorial](https://www.metabase.com/learn/questions/custom-expressions)
+- [Time series comparisons](https://www.metabase.com/learn/questions/time-series-comparisons)
+- [How to compare one time period to another](https://www.metabase.com/learn/dashboards/compare-times)
+- [Working with dates in SQL](https://www.metabase.com/learn/sql-questions/dates-in-sql)

--- a/docs/questions/query-builder/expressions/datetimeadd.md
+++ b/docs/questions/query-builder/expressions/datetimeadd.md
@@ -4,7 +4,7 @@ title: DatetimeAdd
 
 # DatetimeAdd
 
-`datetimeAdd` takes a date and adds some unit of time to it. This function is useful when you're working with time series data that's marked by a "start" and an "end", such as sessions or subscriptions data.
+`datetimeAdd` takes a datetime value and adds some unit of time to it. This function is useful when you're working with time series data that's marked by a "start" and an "end", such as sessions or subscriptions data.
 
 | Syntax                                                                              | Example                                              |
 |-------------------------------------------------------------------------------------|------------------------------------------------------|
@@ -32,7 +32,7 @@ Here, **Finish By** is a custom column with the expression:
 datetimeAdd([Opened On], 14, 'day')
 ```
 
-You can use the [`between`](../expressions-list.md#between) or [interval](../expressions-list.md#interval) expressions to check if a given date falls between your start and end datetimes.
+You can use the [`between`](../expressions-list.md#between) or [`interval`](../expressions-list.md#interval) expressions to check if a given date falls between your start and end datetimes.
 
 ## Accepted data types
 
@@ -43,6 +43,8 @@ You can use the [`between`](../expressions-list.md#between) or [interval](../exp
 | Timestamp               | ✅                   |
 | Boolean                 | ❌                   |
 | JSON                    | ❌                   |
+
+This table uses `timestamp` and `datetime` interchangeably---just make sure that your dates and times aren't stored as string or a number data types in your database.
 
 ## Limitations
 
@@ -99,7 +101,7 @@ If our [coffee sample data](#calculating-an-end-date) is stored in a PostgreSQL 
 
 ```sql
 SELECT opened_on + INTERVAL '14 days' AS finish_by
-FROM events
+FROM coffee
 ```
 
 is equivalent to the Metabase `datetimeAdd` expression:
@@ -126,7 +128,7 @@ Most spreadsheet tools require use different functions for different time units 
 
 ### Python
 
-Assuming the [coffee sample data](#calculating-an-end-date) is in a dataframe column called `df`, you can use the built-in `datetime` module with `pandas` to add time to a datetime value:
+Assuming the [coffee sample data](#calculating-an-end-date) is in a `pandas` dataframe column called `df`, you can import the `datetime` module and use the `timedelta` function:
 
 ```
 df['Finish By'] = df['Opened On'] + datetime.timedelta(days=14)

--- a/docs/questions/query-builder/expressions/datetimeadd.md
+++ b/docs/questions/query-builder/expressions/datetimeadd.md
@@ -1,0 +1,69 @@
+---
+title: DatetimeAdd
+---
+
+# DatetimeAdd
+
+`datetimeAdd` takes a date and adds some unit of time to it. It's useful whenever you need to do calculations over a window of time, like taking a rolling metric (such as a moving average) over a 7 day period.
+
+| Syntax                                                                              | Example                                              |
+|-------------------------------------------------------------------------------------|------------------------------------------------------|
+| `datetimeAdd(column, amount, unit)`                                                 | `datetimeAdd("March 25, 2021, 12:52:37", 1, "month")`|
+| Takes a timestamp or date value and adds the specified number of time units to it.  | `April 25, 2021, 12:52:37`                           |
+
+## Parameters
+
+Units can be any of: "year", "quarter", "month", "day", "hour", "second", or "millisecond".
+
+## Rolling metrics
+
+Let's say we want to take the 7 day rolling average (moving average) for the temperature inside Mount Doom. Rolling metrics are calculated over a time period _relative_ to the reporting date. 
+
+So, if we're reporting on the rolling average on Nov 7, 2022, we need to pick a 7 day window relative to Nov 7, 2022, such as:
+
+- [Lagging or trailing](#lagging-or-trailing-metrics) 7 days (from Nov 1, 2022 to Nov 7, 2022)
+- [Leading](#leading-metrics) 7 days (from Nov 7, 2022 to Nov 13, 2022)
+
+Of course, you can choose any size of window you want, and place it anywhere you want. For example, you could report a 7 day rolling average on Nov 7, 2022 that takes the average temperature between Nov 4, 2022 and Nov 10, 2022 (placing the window evenly "around" the reporting date).
+
+## Lagging or trailing metrics
+
+| Report Date | Relative Date | Temperature | 7 Day Lagging Average |
+|-------------|---------------|-------------|-----------------------|
+| 2022-11-02  | Today - 6     | 1140        |                       |
+| 2022-11-03  | Today - 5     | 1170        |                       |
+| 2022-11-04  | Today - 4     | 1130        |                       |
+| 2022-11-05  | Today - 3     | 1140        |                       |
+| 2022-11-06  | Today - 2     | 1190        |                       |
+| 2022-11-07  | Yesterday     | 1200        |                       |
+| 2022-11-08  | Today         | 1250        |                       |
+
+
+## Leading metrics
+
+Leading metrics are a bit tricky to wrap your head around. The report dates for a leading metric are almost always in the past.
+
+## Accepted data types
+
+| [Data type](https://www.metabase.com/learn/databases/data-types-overview#examples-of-data-types) | Works with `datetimeAdd`  |
+| ----------------------- | -------------------- |
+| String                  | ❌                   |
+| Number                  | ❌                   |
+| Timestamp               | ✅                   |
+| Boolean                 | ❌                   |
+| JSON                    | ❌                   |
+
+## Limitations
+
+## Related functions
+
+### SQL
+
+### Spreadsheets 
+
+### Python
+
+## Further reading
+
+- [Custom expressions documentation](../expressions.md)
+- [Custom expressions tutorial](https://www.metabase.com/learn/questions/)

--- a/docs/questions/query-builder/expressions/datetimesubtract.md
+++ b/docs/questions/query-builder/expressions/datetimesubtract.md
@@ -32,7 +32,7 @@ Here, **Depart At** is a custom column with the expression:
 datetimeSubtract([Arrive By], 30, "minute")
 ```
 
-You can also use the [`between` expression](../expressions-list.md#between) to check if a given datetime falls between your "start" and "end" datetimes. 
+You can use the [`between`](../expressions-list.md#between) or [interval](../expressions-list.md#interval) expressions to check if a given date falls between your start and end datetimes.
 
 ## Accepted data types
 
@@ -79,7 +79,7 @@ This section covers functions and formulas that work the same way as the Metabas
 
 ### datetimeAdd
 
-`datetimeSubtract` and `datetimeAdd` are interchangeable, since you can use a negative number for `amount`. We could use either expression for our [events example](#calculating-a-start-date), but you should try to avoid "double negatives" (such as subtracting a negative number) if possible.
+`datetimeSubtract` and `datetimeAdd` are interchangeable, since you can use a negative number for `amount`. We could use either expression for our [events example](#calculating-a-start-date), but you should try to avoid "double negatives" (such as subtracting a negative number).
 
 ```
 datetimeAdd([Arrive By], -30, "minute")
@@ -110,7 +110,7 @@ datetimeSubtract([Arrive By], 30, "minute")
 
 ### Spreadsheets 
 
-Assuming the [events sample data](#calculating-a-start-date) is in a spreadsheet where "Arrive By" is in column A with a date and time format, the spreadsheet function
+Assuming the [events sample data](#calculating-a-start-date) is in a spreadsheet where "Arrive By" is in column A with a datetime format, the spreadsheet function
 
 ```
 A:A - 30/(60*24)
@@ -141,4 +141,7 @@ datetimeSubtract([Arrive By], 30, "minute")
 ## Further reading
 
 - [Custom expressions documentation](../expressions.md)
-- [Custom expressions tutorial](https://www.metabase.com/learn/questions/)
+- [Custom expressions tutorial](https://www.metabase.com/learn/questions/custom-expressions)
+- [Time series comparisons](https://www.metabase.com/learn/questions/time-series-comparisons)
+- [How to compare one time period to another](https://www.metabase.com/learn/dashboards/compare-times)
+- [Working with dates in SQL](https://www.metabase.com/learn/sql-questions/dates-in-sql)

--- a/docs/questions/query-builder/expressions/datetimesubtract.md
+++ b/docs/questions/query-builder/expressions/datetimesubtract.md
@@ -4,7 +4,7 @@ title: DatetimeSubtract
 
 # DatetimeSubtract
 
-`datetimeSubtract` takes a date and subtracts some unit of time from it. You might want to use this function when working with time series data that's marked by a "start" and an "end", such as sessions or subscriptions data.
+`datetimeSubtract` takes a datetime value and subtracts some unit of time from it. You might want to use this function when working with time series data that's marked by a "start" and an "end", such as sessions or subscriptions data.
 
 | Syntax                                                                                    | Example                                                   |
 |-------------------------------------------------------------------------------------------|-----------------------------------------------------------|
@@ -14,7 +14,7 @@ title: DatetimeSubtract
 ## Parameters
 
 - Units can be any of: "year", "quarter", "month", "day", "hour", "second", or "millisecond".
-- Amounts can be negative: `datetimeSubtract("March 25, 2021, 12:52:37", -1, "month")` will return `March 25, 2021, 12:52:37`.
+- Amounts can be negative: `datetimeSubtract("March 25, 2021, 12:52:37", -1, "month")` will return `April 25, 2021, 12:52:37`.
 
 ## Calculating a start date
 
@@ -32,7 +32,7 @@ Here, **Depart At** is a custom column with the expression:
 datetimeSubtract([Arrive By], 30, "minute")
 ```
 
-You can use the [`between`](../expressions-list.md#between) or [interval](../expressions-list.md#interval) expressions to check if a given date falls between your start and end datetimes.
+You can use the [`between`](../expressions-list.md#between) or [`interval`](../expressions-list.md#interval) expressions to check if a given date falls between your start and end datetimes.
 
 ## Accepted data types
 
@@ -44,11 +44,13 @@ You can use the [`between`](../expressions-list.md#between) or [interval](../exp
 | Boolean                 | ❌                   |
 | JSON                    | ❌                   |
 
+This table uses `timestamp` and `datetime` interchangeably---just make sure that your dates and times aren't stored as string or a number data types in your database.
+
 ## Limitations
 
 You can use `datetimeSubtract` to calculate relative dates given a column of date values, but unfortunately Metabase doesn't currently let you _generate_ a relative date (such as today's date).
 
-What if you want to check if today's date falls between **Arrive By** and **Depart At** in the [Events example](#calculating-a-start-date)?
+What if you want to check if today's date falls between **Arrive By** and **Depart At** in our [events example](#calculating-a-start-date)?
 
 1. Ask your database admin if there's table in your database that stores datetimes for reporting (sometimes called a date dimension table).
 2. Create a new question using the date dimension table, with a filter for "Today".
@@ -93,7 +95,7 @@ datetimeSubtract([Arrive By], 30, "minute")
 
 ### SQL
 
-When you run a question using the [query_builder](https://www.metabase.com/glossary/query_builder), Metabase will convert your graphical query settings (filters, summaries, etc.) into a query, and run that query against your database to get your results.
+When you run a question using the [query builder](https://www.metabase.com/glossary/query_builder), Metabase will convert your graphical query settings (filters, summaries, etc.) into a query, and run that query against your database to get your results.
 
 If our [events sample data](#calculating-a-start-date) is stored in a PostgreSQL database:
 
@@ -126,7 +128,7 @@ Most spreadsheets require you to use different calculations for different time u
 
 ### Python
 
-If our [events sample data](#calculating-a-start-date) is in a dataframe column called `df`, you can use the built-in `datetime` module with `pandas` to subtract (or add) time to a datetime value:
+If our [events sample data](#calculating-a-start-date) is in a `pandas` dataframe column called `df`, you can import the `datetime` module and use the `timedelta` function:
 
 ```
 df['Depart At'] = df['Arrive By'] - datetime.timedelta(minutes=30)

--- a/docs/questions/query-builder/expressions/datetimesubtract.md
+++ b/docs/questions/query-builder/expressions/datetimesubtract.md
@@ -79,7 +79,7 @@ This section covers functions and formulas that work the same way as the Metabas
 
 ### datetimeAdd
 
-`datetimeSubtract` and `datetimeAdd` are interchangeable, since you can use a negative number for `amount`. We could use either expression for our [events example](#calculating-a-start-date):
+`datetimeSubtract` and `datetimeAdd` are interchangeable, since you can use a negative number for `amount`. We could use either expression for our [events example](#calculating-a-start-date), but you should try to avoid "double negatives" (such as subtracting a negative number) if possible.
 
 ```
 datetimeAdd([Arrive By], -30, "minute")

--- a/docs/questions/query-builder/expressions/datetimesubtract.md
+++ b/docs/questions/query-builder/expressions/datetimesubtract.md
@@ -1,0 +1,144 @@
+---
+title: DatetimeSubtract
+---
+
+# DatetimeSubtract
+
+`datetimeSubtract` takes a date and subtracts some unit of time from it. You might want to use this function when working with time series data that's marked by a "start" and an "end", such as sessions or subscriptions data.
+
+| Syntax                                                                                    | Example                                                   |
+|-------------------------------------------------------------------------------------------|-----------------------------------------------------------|
+| `datetimeSubtract(column, amount, unit)`                                                  | `datetimeSubtract("March 25, 2021, 12:52:37", 1, "month")`|
+| Takes a timestamp or date value and subtracts the specified number of time units from it. | `February 25, 2021, 12:52:37`                             |
+
+## Parameters
+
+- Units can be any of: "year", "quarter", "month", "day", "hour", "second", or "millisecond".
+- Amounts can be negative: `datetimeSubtract("March 25, 2021, 12:52:37", -1, "month")` will return `March 25, 2021, 12:52:37`.
+
+## Calculating a start date
+
+Let's say you're planning a fun night out. You know it takes 30 minutes to get from place to place, and you need to figure out what time you have to leave to get to each of your reservations:
+
+| Event   | Arrive By           | Depart At           |
+|---------|---------------------|---------------------|
+| Drinks  | 2022-11-12 18:30:00 | 2022-11-12 18:00:00 |
+| Dinner  | 2022-11-12 20:00:00 | 2022-11-12 19:30:00 |
+| Dancing | 2022-11-13 00:00:00 | 2022-11-12 23:30:00 |
+
+Here, **Depart At** is a custom column with the expression:
+
+```
+datetimeSubtract([Arrive By], 30, "minute")
+```
+
+You can also use the [`between` expression](../expressions-list.md#between) to check if a given datetime falls between your "start" and "end" datetimes. 
+
+## Accepted data types
+
+| [Data type](https://www.metabase.com/learn/databases/data-types-overview#examples-of-data-types) | Works with `datetimeSubtract`  |
+| ----------------------- | -------------------- |
+| String                  | ❌                   |
+| Number                  | ❌                   |
+| Timestamp               | ✅                   |
+| Boolean                 | ❌                   |
+| JSON                    | ❌                   |
+
+## Limitations
+
+You can use `datetimeSubtract` to calculate relative dates given a column of date values, but unfortunately Metabase doesn't currently let you _generate_ a relative date (such as today's date).
+
+What if you want to check if today's date falls between **Arrive By** and **Depart At** in the [Events example](#calculating-a-start-date)?
+
+1. Ask your database admin if there's table in your database that stores datetimes for reporting (sometimes called a date dimension table).
+2. Create a new question using the date dimension table, with a filter for "Today".
+3. Turn the "Today" question into a model.
+4. Create a left join between **Events** and the "Today" model on `[Arrive By] <= [Today]` and `[Depart At] >= [Today]`.
+
+The result should give you an **Today** column that's non-empty for events that are happening while the night is still young:
+
+| Event   | Arrive By           | Depart At           | Today               |
+|---------|---------------------|---------------------|---------------------|
+| Drinks  | 2022-11-12 18:30:00 | 2022-11-12 18:00:00 | 2022-11-12 00:00:00 |
+| Dinner  | 2022-11-12 20:00:00 | 2022-11-12 19:30:00 | 2022-11-12 00:00:00 |
+| Dancing | 2022-11-13 00:00:00 | 2022-11-12 23:30:00 |                     |
+
+## Related functions
+
+This section covers functions and formulas that work the same way as the Metabase `datetimeSubtract` expression, with notes on how to choose the best option for your use case.
+
+**[Metabase expressions](../expressions-list.md)**
+
+- [datetimeAdd](#datetimeadd)
+
+**Other tools**
+
+- [SQL](#sql)
+- [Spreadsheets](#spreadsheets)
+- [Python](#python)
+
+### datetimeAdd
+
+`datetimeSubtract` and `datetimeAdd` are interchangeable, since you can use a negative number for `amount`. We could use either expression for our [events example](#calculating-a-start-date):
+
+```
+datetimeAdd([Arrive By], -30, "minute")
+```
+
+does the same thing as
+
+```
+datetimeSubtract([Arrive By], 30, "minute")
+```
+
+### SQL
+
+When you run a question using the [query_builder](https://www.metabase.com/glossary/query_builder), Metabase will convert your graphical query settings (filters, summaries, etc.) into a query, and run that query against your database to get your results.
+
+If our [events sample data](#calculating-a-start-date) is stored in a PostgreSQL database:
+
+```sql
+SELECT arrive_by - INTERVAL '30 minutes' AS depart_at
+FROM events
+```
+
+is equivalent to the Metabase `datetimeSubtract` expression:
+
+```
+datetimeSubtract([Arrive By], 30, "minute")
+```
+
+### Spreadsheets 
+
+Assuming the [events sample data](#calculating-a-start-date) is in a spreadsheet where "Arrive By" is in column A with a date and time format, the spreadsheet function
+
+```
+A:A - 30/(60*24)
+```
+
+produces the same result as
+
+```
+datetimeSubtract([Arrive By], 30, "minute")
+```
+
+Most spreadsheets require you to use different calculations for different time units (for example, you'd need to use a different calculation to subtract "days" from a date). `datetimeSubtract` makes it easy for you to convert all of those functions to a single consistent syntax.
+
+### Python
+
+If our [events sample data](#calculating-a-start-date) is in a dataframe column called `df`, you can use the built-in `datetime` module with `pandas` to subtract (or add) time to a datetime value:
+
+```
+df['Depart At'] = df['Arrive By'] - datetime.timedelta(minutes=30)
+```
+
+is equivalent to
+
+```
+datetimeSubtract([Arrive By], 30, "minute")
+```
+
+## Further reading
+
+- [Custom expressions documentation](../expressions.md)
+- [Custom expressions tutorial](https://www.metabase.com/learn/questions/)

--- a/docs/questions/query-builder/expressions/regexextract.md
+++ b/docs/questions/query-builder/expressions/regexextract.md
@@ -137,4 +137,4 @@ regexextract([URL], "^[^?#]+\?utm_campaign=(.*)")
 ## Further reading
 
 - [Custom expressions documentation](../expressions.md)
-- [Custom expressions tutorial](https://www.metabase.com/learn/questions/)
+- [Custom expressions tutorial](https://www.metabase.com/learn/questions/custom-expressions)

--- a/docs/questions/query-builder/expressions/substring.md
+++ b/docs/questions/query-builder/expressions/substring.md
@@ -149,4 +149,4 @@ substring([Mission ID], 9, 3)
 ## Further reading
 
 - [Custom expressions documentation](../expressions.md)
-- [Custom expressions tutorial](https://www.metabase.com/learn/questions/)
+- [Custom expressions tutorial](https://www.metabase.com/learn/questions/custom-expressions)


### PR DESCRIPTION
Docs are almost identical (and the expressions themselves are interchangeable). I tried to adapt the use cases so that they're more intuitive for add vs. subtract.

Specific feedback requested:
In practice, these functions are almost always used with a `TODAY()` function. What do you think of the workaround noted under the "Limitations" section? 

I wanted to give people just enough to get value out of add & subtract -- could move the steps into a Learn tutorial eventually (or just leave it until `TODAY()` gets implemented).

To do: 
Check formatting and test the related functions.