### PR TITLE
Extract common error messages

### DIFF
--- a/frontend/src/metabase/account/password/components/UserPasswordForm/UserPasswordForm.tsx
+++ b/frontend/src/metabase/account/password/components/UserPasswordForm/UserPasswordForm.tsx
@@ -7,23 +7,22 @@ import FormProvider from "metabase/core/components/FormProvider";
 import FormInput from "metabase/core/components/FormInput";
 import FormSubmitButton from "metabase/core/components/FormSubmitButton";
 import FormErrorMessage from "metabase/core/components/FormErrorMessage";
+import * as Errors from "metabase/core/utils/errors";
 import { User } from "metabase-types/api";
 import { UserPasswordData } from "../../types";
 
 const USER_PASSWORD_SCHEMA = Yup.object({
-  old_password: Yup.string()
-    .default("")
-    .required(t`required`),
+  old_password: Yup.string().default("").required(Errors.required),
   password: Yup.string()
     .default("")
-    .required(t`required`)
+    .required(Errors.required)
     .test(async (value = "", context) => {
       const error = await context.options.context?.onValidatePassword(value);
       return error ? context.createError({ message: error }) : true;
     }),
   password_confirm: Yup.string()
     .default("")
-    .required(t`required`)
+    .required(Errors.required)
     .oneOf([Yup.ref("password")], t`passwords do not match`),
 });
 

--- a/frontend/src/metabase/account/profile/components/UserProfileForm/UserProfileForm.tsx
+++ b/frontend/src/metabase/account/profile/components/UserProfileForm/UserProfileForm.tsx
@@ -8,6 +8,7 @@ import FormInput from "metabase/core/components/FormInput";
 import FormSelect from "metabase/core/components/FormSelect";
 import FormSubmitButton from "metabase/core/components/FormSubmitButton";
 import FormErrorMessage from "metabase/core/components/FormErrorMessage";
+import * as Errors from "metabase/core/utils/errors";
 import { LocaleData, User } from "metabase-types/api";
 import { UserProfileData } from "../../types";
 
@@ -16,18 +17,9 @@ const SSO_PROFILE_SCHEMA = Yup.object({
 });
 
 const LOCAL_PROFILE_SCHEMA = SSO_PROFILE_SCHEMA.shape({
-  first_name: Yup.string()
-    .nullable()
-    .default(null)
-    .max(100, ({ max }) => t`must be ${max} characters or less`),
-  last_name: Yup.string()
-    .nullable()
-    .default(null)
-    .max(100, ({ max }) => t`must be ${max} characters or less`),
-  email: Yup.string()
-    .ensure()
-    .required(t`required`)
-    .email(t`must be a valid email address`),
+  first_name: Yup.string().nullable().default(null).max(100, Errors.required),
+  last_name: Yup.string().nullable().default(null).max(100, Errors.maxLength),
+  email: Yup.string().ensure().required(Errors.required).email(Errors.email),
 });
 
 export interface UserProfileFormProps {

--- a/frontend/src/metabase/account/profile/components/UserProfileForm/UserProfileForm.tsx
+++ b/frontend/src/metabase/account/profile/components/UserProfileForm/UserProfileForm.tsx
@@ -17,7 +17,7 @@ const SSO_PROFILE_SCHEMA = Yup.object({
 });
 
 const LOCAL_PROFILE_SCHEMA = SSO_PROFILE_SCHEMA.shape({
-  first_name: Yup.string().nullable().default(null).max(100, Errors.required),
+  first_name: Yup.string().nullable().default(null).max(100, Errors.maxLength),
   last_name: Yup.string().nullable().default(null).max(100, Errors.maxLength),
   email: Yup.string().ensure().required(Errors.required).email(Errors.email),
 });

--- a/frontend/src/metabase/admin/settings/slack/components/SlackForm/SlackForm.tsx
+++ b/frontend/src/metabase/admin/settings/slack/components/SlackForm/SlackForm.tsx
@@ -6,16 +6,15 @@ import FormProvider from "metabase/core/components/FormProvider";
 import FormInput from "metabase/core/components/FormInput";
 import FormSubmitButton from "metabase/core/components/FormSubmitButton";
 import FormErrorMessage from "metabase/core/components/FormErrorMessage";
+import * as Errors from "metabase/core/utils/errors";
 import { SlackSettings } from "metabase-types/api";
 import { SlackFormMessage } from "./SlackForm.styled";
 
 const SLACK_SCHEMA = Yup.object({
-  "slack-app-token": Yup.string()
-    .ensure()
-    .required(t`required`),
+  "slack-app-token": Yup.string().ensure().required(Errors.required),
   "slack-files-channel": Yup.string()
     .ensure()
-    .required(t`required`)
+    .required(Errors.required)
     .lowercase(),
 });
 

--- a/frontend/src/metabase/auth/components/ForgotPasswordForm/ForgotPasswordForm.tsx
+++ b/frontend/src/metabase/auth/components/ForgotPasswordForm/ForgotPasswordForm.tsx
@@ -6,6 +6,7 @@ import Form from "metabase/core/components/Form";
 import FormInput from "metabase/core/components/FormInput";
 import FormSubmitButton from "metabase/core/components/FormSubmitButton";
 import FormErrorMessage from "metabase/core/components/FormErrorMessage";
+import * as Errors from "metabase/core/utils/errors";
 import { ForgotPasswordData } from "../../types";
 import {
   PasswordFormFooter,
@@ -14,9 +15,7 @@ import {
 } from "./ForgotPasswordForm.styled";
 
 const FORGOT_PASSWORD_SCHEMA = Yup.object({
-  email: Yup.string()
-    .required(t`required`)
-    .email(t`must be a valid email address`),
+  email: Yup.string().required(Errors.required).email(Errors.email),
 });
 
 export interface ForgotPasswordFormProps {

--- a/frontend/src/metabase/auth/components/LoginForm/LoginForm.tsx
+++ b/frontend/src/metabase/auth/components/LoginForm/LoginForm.tsx
@@ -7,16 +7,17 @@ import FormCheckBox from "metabase/core/components/FormCheckBox";
 import FormErrorMessage from "metabase/core/components/FormErrorMessage";
 import FormInput from "metabase/core/components/FormInput";
 import FormSubmitButton from "metabase/core/components/FormSubmitButton";
+import * as Errors from "metabase/core/utils/errors";
 import { LoginData } from "../../types";
 
 const LOGIN_SCHEMA = Yup.object().shape({
   username: Yup.string()
-    .required(t`required`)
+    .required(Errors.required)
     .when("$isLdapEnabled", {
       is: false,
-      then: schema => schema.email(t`must be a valid email address`),
+      then: schema => schema.email(Errors.email),
     }),
-  password: Yup.string().required(t`required`),
+  password: Yup.string().required(Errors.required),
   remember: Yup.boolean(),
 });
 

--- a/frontend/src/metabase/auth/components/ResetPasswordForm/ResetPasswordForm.tsx
+++ b/frontend/src/metabase/auth/components/ResetPasswordForm/ResetPasswordForm.tsx
@@ -8,7 +8,8 @@ import FormProvider from "metabase/core/components/FormProvider";
 import FormInput from "metabase/core/components/FormInput";
 import FormSubmitButton from "metabase/core/components/FormSubmitButton";
 import FormErrorMessage from "metabase/core/components/FormErrorMessage";
-import { ResetPasswordData } from "metabase/auth/types";
+import * as Errors from "metabase/core/utils/errors";
+import { ResetPasswordData } from "../../types";
 import {
   PasswordFormMessage,
   PasswordFormTitle,
@@ -17,14 +18,14 @@ import {
 const RESET_PASSWORD_SCHEMA = Yup.object({
   password: Yup.string()
     .default("")
-    .required(t`required`)
+    .required(Errors.required)
     .test(async (value = "", context) => {
       const error = await context.options.context?.onValidatePassword(value);
       return error ? context.createError({ message: error }) : true;
     }),
   password_confirm: Yup.string()
     .default("")
-    .required(t`required`)
+    .required(Errors.required)
     .oneOf([Yup.ref("password")], t`passwords do not match`),
 });
 

--- a/frontend/src/metabase/core/utils/errors/errors.ts
+++ b/frontend/src/metabase/core/utils/errors/errors.ts
@@ -1,0 +1,9 @@
+import { t } from "ttag";
+import { MaxLengthParams } from "./types";
+
+export const required = () => t`required`;
+
+export const email = () => t`must be a valid email address`;
+
+export const maxLength = ({ max }: MaxLengthParams) =>
+  t`must be ${max} characters or less`;

--- a/frontend/src/metabase/core/utils/errors/index.ts
+++ b/frontend/src/metabase/core/utils/errors/index.ts
@@ -1,0 +1,1 @@
+export { required, email, maxLength } from "./errors";

--- a/frontend/src/metabase/core/utils/errors/types.ts
+++ b/frontend/src/metabase/core/utils/errors/types.ts
@@ -1,0 +1,3 @@
+export interface MaxLengthParams {
+  max: number;
+}

--- a/frontend/src/metabase/setup/components/InviteUserForm/InviteUserForm.tsx
+++ b/frontend/src/metabase/setup/components/InviteUserForm/InviteUserForm.tsx
@@ -5,22 +5,17 @@ import Form from "metabase/core/components/Form";
 import FormProvider from "metabase/core/components/FormProvider";
 import FormInput from "metabase/core/components/FormInput";
 import FormSubmitButton from "metabase/core/components/FormSubmitButton";
+import * as Errors from "metabase/core/utils/errors";
 import { InviteInfo, UserInfo } from "metabase-types/store";
 import { UserFieldGroup } from "./InviteUserForm.styled";
 
 const INVITE_USER_SCHEMA = Yup.object({
-  first_name: Yup.string()
-    .nullable()
-    .default(null)
-    .max(100, ({ max }) => t`must be ${max} characters or less`),
-  last_name: Yup.string()
-    .nullable()
-    .default(null)
-    .max(100, ({ max }) => t`must be ${max} characters or less`),
+  first_name: Yup.string().nullable().default(null).max(100, Errors.maxLength),
+  last_name: Yup.string().nullable().default(null).max(100, Errors.maxLength),
   email: Yup.string()
     .default("")
-    .required(t`required`)
-    .email(t`must be a valid email address`)
+    .required(Errors.required)
+    .email(Errors.email)
     .notOneOf(
       [Yup.ref("$email")],
       t`must be different from the email address you used in setup`,

--- a/frontend/src/metabase/setup/components/NewsletterForm/NewsletterForm.tsx
+++ b/frontend/src/metabase/setup/components/NewsletterForm/NewsletterForm.tsx
@@ -3,6 +3,7 @@ import { t } from "ttag";
 import * as Yup from "yup";
 import FormProvider from "metabase/core/components/FormProvider";
 import FormSubmitButton from "metabase/core/components/FormSubmitButton";
+import * as Errors from "metabase/core/utils/errors";
 import { SubscribeInfo } from "metabase-types/store";
 import {
   EmailForm,
@@ -19,9 +20,7 @@ import {
 } from "./NewsletterForm.styled";
 
 const NEWSLETTER_SCHEMA = Yup.object({
-  email: Yup.string()
-    .required(t`required`)
-    .email(t`must be a valid email address`),
+  email: Yup.string().required(Errors.required).email(Errors.email),
 });
 
 export interface NewsletterFormProps {

--- a/frontend/src/metabase/setup/components/UserForm/UserForm.tsx
+++ b/frontend/src/metabase/setup/components/UserForm/UserForm.tsx
@@ -1,39 +1,29 @@
-import React, { useCallback, useMemo } from "react";
+import React, { useMemo } from "react";
 import { t } from "ttag";
 import * as Yup from "yup";
 import _ from "underscore";
 import FormProvider from "metabase/core/components/FormProvider";
 import FormInput from "metabase/core/components/FormInput";
 import FormSubmitButton from "metabase/core/components/FormSubmitButton";
+import * as Errors from "metabase/core/utils/errors";
 import { UserInfo } from "metabase-types/store";
 import { UserFieldGroup, UserFormRoot } from "./UserForm.styled";
 
 const USER_SCHEMA = Yup.object({
-  first_name: Yup.string()
-    .nullable()
-    .default(null)
-    .max(100, ({ max }) => t`must be ${max} characters or less`),
-  last_name: Yup.string()
-    .nullable()
-    .default(null)
-    .max(100, ({ max }) => t`must be ${max} characters or less`),
-  email: Yup.string()
-    .default("")
-    .required(t`required`)
-    .email(t`must be a valid email address`),
-  site_name: Yup.string()
-    .default("")
-    .required(t`required`),
+  first_name: Yup.string().nullable().default(null).max(100, Errors.maxLength),
+  last_name: Yup.string().nullable().default(null).max(100, Errors.maxLength),
+  email: Yup.string().default("").required(Errors.required).email(Errors.email),
+  site_name: Yup.string().default("").required(Errors.required),
   password: Yup.string()
     .default("")
-    .required(t`required`)
+    .required(Errors.required)
     .test(async (value = "", context) => {
       const error = await context.options.context?.onValidatePassword(value);
       return error ? context.createError({ message: error }) : true;
     }),
   password_confirm: Yup.string()
     .default("")
-    .required(t`required`)
+    .required(Errors.required)
     .oneOf([Yup.ref("password")], t`passwords do not match`),
 });
 

--- a/frontend/src/metabase/timelines/common/components/EventForm/EventForm.tsx
+++ b/frontend/src/metabase/timelines/common/components/EventForm/EventForm.tsx
@@ -11,6 +11,7 @@ import FormTextArea from "metabase/core/components/FormTextArea";
 import FormSelect from "metabase/core/components/FormSelect";
 import FormSubmitButton from "metabase/core/components/FormSubmitButton";
 import FormErrorMessage from "metabase/core/components/FormErrorMessage";
+import * as Errors from "metabase/core/utils/errors";
 import {
   FormattingSettings,
   Timeline,
@@ -20,15 +21,11 @@ import FormArchiveButton from "../FormArchiveButton";
 import { EventFormFooter } from "./EventForm.styled";
 
 const EVENT_SCHEMA = Yup.object({
-  name: Yup.string()
-    .required(t`required`)
-    .max(255, ({ max }) => t`must be ${max} characters or less`),
-  description: Yup.string()
-    .nullable()
-    .max(255, ({ max }) => t`must be ${max} characters or less`),
-  timestamp: Yup.string().required(`required`),
+  name: Yup.string().required(Errors.required).max(255, Errors.maxLength),
+  description: Yup.string().nullable().max(255, Errors.maxLength),
+  timestamp: Yup.string().required(Errors.required),
   time_matters: Yup.boolean(),
-  icon: Yup.string().required(`required`),
+  icon: Yup.string().required(Errors.required),
   timeline_id: Yup.number(),
 });
 

--- a/frontend/src/metabase/timelines/common/components/TimelineForm/TimelineForm.tsx
+++ b/frontend/src/metabase/timelines/common/components/TimelineForm/TimelineForm.tsx
@@ -10,18 +10,15 @@ import FormTextArea from "metabase/core/components/FormTextArea";
 import FormSelect from "metabase/core/components/FormSelect";
 import FormSubmitButton from "metabase/core/components/FormSubmitButton";
 import FormErrorMessage from "metabase/core/components/FormErrorMessage";
+import * as Errors from "metabase/core/utils/errors";
 import { TimelineData } from "metabase-types/api";
 import FormArchiveButton from "../FormArchiveButton";
 import { TimelineFormFooter } from "./TimelineForm.styled";
 
 const TIMELINE_SCHEMA = Yup.object({
-  name: Yup.string()
-    .required(t`required`)
-    .max(255, ({ max }) => t`must be ${max} characters or less`),
-  description: Yup.string()
-    .nullable()
-    .max(255, ({ max }) => t`must be ${max} characters or less`),
-  icon: Yup.string().required(t`required`),
+  name: Yup.string().required(Errors.required).max(255, Errors.maxLength),
+  description: Yup.string().nullable().max(255, Errors.maxLength),
+  icon: Yup.string().required(Errors.required),
 });
 
 export interface TimelineFormProps {


### PR DESCRIPTION
Epic https://github.com/metabase/metabase/issues/26178

Open questions:
- Should we import error message functions by star `import * as Errors` or plain functions? The former allows us to have shorter function names and matches how `yup` is used, i.e. `import * as Yup`
- What should be the name of the module? `errors` or something else? 