### PR TITLE
Revert "Update IP geolocation tests..."

### DIFF
--- a/test/metabase/api/login_history_test.clj
+++ b/test/metabase/api/login_history_test.clj
@@ -77,7 +77,7 @@
                         :device_description (s/eq "Browser (Chrome/Windows)")
                         :ip_address         (s/eq "52.206.149.9")
                         :active             (s/eq false)
-                        :location           (s/eq "Ashburn, United States")
+                        :location           (s/eq "Ashburn, Virginia, United States")
                         :timezone           (s/eq "ET")}
                        "Virginia")]
                      (mt/client session-id :get 200 "login-history/current")))))))

--- a/test/metabase/server/request/util_test.clj
+++ b/test/metabase/server/request/util_test.clj
@@ -102,7 +102,7 @@
     ;; multiple addresses at once
     ;; store.metabase.com, Google DNS
     ["52.206.149.9" "2001:4860:4860::8844"]
-    {(s/required-key "52.206.149.9")         {:description (s/eq "Ashburn, United States")
+    {(s/required-key "52.206.149.9")         {:description (s/eq "Ashburn, Virginia, United States")
                                               :timezone    (s/eq (t/zone-id "America/New_York"))}
      (s/required-key "2001:4860:4860::8844") {:description (s/eq "United States")
                                               :timezone    (s/eq (t/zone-id "America/Chicago"))}}


### PR DESCRIPTION
This reverts commit 2a857d7de55511789558efd06a5caa17042edea9.

The service provider's output has changed back again.
