### PR TITLE
Forward action execution error messages to the frontend

### DIFF
--- a/src/metabase/actions/execution.clj
+++ b/src/metabase/actions/execution.clj
@@ -77,7 +77,8 @@
           (throw e)
           (do
             (log/error e (tru "Error executing action."))
-            {:body {:message (tru "Error executing action.")} :status 500}))))))
+            {:body {:message (tru "Error executing action: {0}" (ex-message e))}
+             :status 500}))))))
 
 (defn- implicit-action-table
   [card_id]
@@ -162,7 +163,8 @@
       (actions/perform-action! implicit-action arg-map)
       (catch Exception e
         (log/error e (tru "Error executing action."))
-        {:body {:message (tru "Error executing action.")} :status 500}))))
+        {:body {:message (tru "Error executing action: {0}" (ex-message e))}
+         :status 500}))))
 
 (defn execute-dashcard!
   "Execute the given action in the dashboard/dashcard context with the given parameters

--- a/src/metabase/actions/execution.clj
+++ b/src/metabase/actions/execution.clj
@@ -50,6 +50,15 @@
             :parameters request-parameters}
            e))))))
 
+(defn- handle-action-execution-error [ex]
+  (log/error ex (tru "Error executing action."))
+  (if-let [ed (ex-data ex)]
+    (if (:message ed)
+      (throw ex)
+      (throw (ex-info (ex-message ex) (assoc ed :message (ex-message ex)))))
+    {:body {:message (or (ex-message ex) (tru "Error executing action."))}
+     :status 500}))
+
 (defn- execute-custom-action [action-id request-parameters]
   (let [action (api/check-404 (first (action/select-actions :id action-id)))
         action-type (:type action)
@@ -73,12 +82,7 @@
         :http
         (http-action/execute-http-action! action request-parameters))
       (catch Exception e
-        (if (:status-code (ex-data e))
-          (throw e)
-          (do
-            (log/error e (tru "Error executing action."))
-            {:body {:message (tru "Error executing action: {0}" (ex-message e))}
-             :status 500}))))))
+        (handle-action-execution-error e)))))
 
 (defn- implicit-action-table
   [card_id]
@@ -162,9 +166,7 @@
     (try
       (actions/perform-action! implicit-action arg-map)
       (catch Exception e
-        (log/error e (tru "Error executing action."))
-        {:body {:message (tru "Error executing action: {0}" (ex-message e))}
-         :status 500}))))
+        (handle-action-execution-error e)))))
 
 (defn execute-dashcard!
   "Execute the given action in the dashboard/dashcard context with the given parameters


### PR DESCRIPTION

Fixes #26448.

This is a crude temporary solution necessary to be able to debug problems related to executing actions.

Although error parsing has been implemented for Postgres (only) with the goal to provide information for
the FE like `{"errors":{"id":"violates foreign key constraint note_subject_id_fkey"}}`. This code doesn't
care about the error message itself. This PR forwards the error message from the DB to the FE.

![action-error](https://user-images.githubusercontent.com/103100869/201765990-585f3c7e-f3af-4369-b2fd-50b8e78b7d42.png)
