### PR TITLE
Show data apps in collection picker

### DIFF
--- a/frontend/src/metabase-types/store/entities.ts
+++ b/frontend/src/metabase-types/store/entities.ts
@@ -7,9 +7,16 @@ import {
   Table,
 } from "metabase-types/api";
 
+type EntityList<T> = Record<
+  any, // Usually a JSON stringified list query object or `null`
+  { list: T[]; metadata: { total?: number; limit?: number; offset?: number } }
+>;
+
 export interface EntitiesState {
   collections?: Record<CollectionId, Collection>;
   dataApps?: Record<DataAppId, DataApp>;
+  dataAppCollections?: Record<CollectionId, Collection>;
+  dataAppCollections_list?: EntityList<Collection>;
   databases?: Record<number, Database>;
   tables?: Record<number | string, Table>;
 }

--- a/frontend/src/metabase-types/store/entities.ts
+++ b/frontend/src/metabase-types/store/entities.ts
@@ -7,16 +7,10 @@ import {
   Table,
 } from "metabase-types/api";
 
-type EntityList<T> = Record<
-  any, // Usually a JSON stringified list query object or `null`
-  { list: T[]; metadata: { total?: number; limit?: number; offset?: number } }
->;
-
 export interface EntitiesState {
   collections?: Record<CollectionId, Collection>;
   dataApps?: Record<DataAppId, DataApp>;
   dataAppCollections?: Record<CollectionId, Collection>;
-  dataAppCollections_list?: EntityList<Collection>;
   databases?: Record<number, Database>;
   tables?: Record<number | string, Table>;
 }

--- a/frontend/src/metabase/containers/ItemPicker/ItemPicker.tsx
+++ b/frontend/src/metabase/containers/ItemPicker/ItemPicker.tsx
@@ -7,6 +7,7 @@ import { IconProps } from "metabase/components/Icon";
 import { getCrumbs } from "metabase/lib/collections";
 
 import Collections from "metabase/entities/collections";
+import DataAppCollections from "metabase/entities/data-app-collections";
 
 import { entityListLoader } from "metabase/entities/containers/EntityListLoader";
 import { entityObjectLoader } from "metabase/entities/containers/EntityObjectLoader";
@@ -37,12 +38,16 @@ interface OwnProps {
   onChange: (value: PickerValue) => void;
 }
 
+interface DataAppCollectionsLoaderProps {
+  dataAppCollections: Collection[];
+}
+
 interface StateProps {
   collectionsById: Record<Collection["id"], Collection>;
   getCollectionIcon: (collection: Collection) => IconProps;
 }
 
-type Props = OwnProps & StateProps;
+type Props = OwnProps & DataAppCollectionsLoaderProps & StateProps;
 
 function canWriteToCollectionOrChildren(collection: Collection) {
   return (
@@ -51,10 +56,42 @@ function canWriteToCollectionOrChildren(collection: Collection) {
   );
 }
 
-function mapStateToProps(state: State, props: OwnProps) {
+function mapStateToProps(
+  state: State,
+  props: OwnProps & DataAppCollectionsLoaderProps,
+) {
   const entity = props.entity || Collections;
+  const isPickingRegularCollections = !props.entity;
+
+  const defaultCollectionsById =
+    entity.selectors.getExpandedCollectionsById(state);
+
+  let collectionsById = {};
+
+  if (isPickingRegularCollections) {
+    const { root: rootDataAppCollection } =
+      DataAppCollections.selectors.getExpandedCollectionsById(state);
+
+    const { root: rootCollection, ...normalCollectionsById } =
+      defaultCollectionsById;
+
+    const dataAppCollections = rootDataAppCollection.children;
+    const dataAppCollectionsById = _.indexBy(dataAppCollections, "id");
+
+    collectionsById = {
+      ...normalCollectionsById,
+      ...dataAppCollectionsById,
+      root: {
+        ...rootCollection,
+        children: [...rootCollection.children, ...dataAppCollections],
+      },
+    };
+  } else {
+    collectionsById = defaultCollectionsById;
+  }
+
   return {
-    collectionsById: entity.selectors.getExpandedCollectionsById(state),
+    collectionsById,
     getCollectionIcon: entity.objectSelectors.getIcon,
   };
 }
@@ -239,6 +276,10 @@ export default _.compose(
   entityListLoader({
     entityType: getEntityLoaderType,
     loadingAndErrorWrapper: false,
+  }),
+  DataAppCollections.loadList({
+    loadingAndErrorWrapper: false,
+    listName: "dataAppCollections",
   }),
   connect(mapStateToProps),
 )(ItemPicker);

--- a/frontend/src/metabase/containers/ItemPicker/ItemPicker.tsx
+++ b/frontend/src/metabase/containers/ItemPicker/ItemPicker.tsx
@@ -75,7 +75,7 @@ function mapStateToProps(
     const { root: rootCollection, ...normalCollectionsById } =
       defaultCollectionsById;
 
-    const dataAppCollections = rootDataAppCollection.children;
+    const dataAppCollections = rootDataAppCollection?.children;
     const dataAppCollectionsById = _.indexBy(dataAppCollections, "id");
 
     collectionsById = {

--- a/frontend/src/metabase/containers/ItemPicker/ItemPicker.unit.spec.js
+++ b/frontend/src/metabase/containers/ItemPicker/ItemPicker.unit.spec.js
@@ -92,6 +92,10 @@ function mockCollectionEndpoint({ extraCollections = [] } = {}) {
 }
 
 function mockCollectionItemsEndpoint() {
+  xhrMock.get(/\/api\/collection\?namespace=apps/, (req, res) => {
+    return res.status(200).body(JSON.stringify([]));
+  });
+
   xhrMock.get(/\/api\/collection\/(root|[1-9]\d*)\/items.*/, (req, res) => {
     const collectionIdParam = req.url().path.split("/")[3];
     const collectionId =

--- a/frontend/src/metabase/entities/data-app-collections.js
+++ b/frontend/src/metabase/entities/data-app-collections.js
@@ -23,7 +23,7 @@ const DataAppCollections = createEntity({
 
   selectors: {
     getExpandedCollectionsById: createSelector(
-      state => state.entities.dataAppCollections,
+      state => state.entities.dataAppCollections || {},
       collections =>
         getExpandedCollectionsById(Object.values(collections), null),
     ),

--- a/frontend/src/metabase/entities/data-app-collections.js
+++ b/frontend/src/metabase/entities/data-app-collections.js
@@ -1,0 +1,46 @@
+import _ from "underscore";
+import { createSelector } from "reselect";
+
+import { createEntity } from "metabase/lib/entities";
+
+import { DataAppCollectionSchema } from "metabase/schema";
+import NormalCollections, {
+  getExpandedCollectionsById,
+} from "metabase/entities/collections";
+
+import { getDataAppIcon } from "./data-apps";
+
+const DataAppCollections = createEntity({
+  name: "dataAppCollections",
+  schema: DataAppCollectionSchema,
+
+  api: _.mapObject(
+    NormalCollections.api,
+    fn =>
+      (params, ...opts) =>
+        fn({ ...params, namespace: "apps" }, ...opts),
+  ),
+
+  selectors: {
+    getExpandedCollectionsById: createSelector(
+      [
+        state => state.entities.dataAppCollections,
+        state => {
+          const list = state.entities.dataAppCollections_list?.null?.list;
+          return list || [];
+        },
+      ],
+      (collections, collectionsIds) =>
+        getExpandedCollectionsById(
+          collectionsIds.map(id => collections[id]),
+          null,
+        ),
+    ),
+  },
+
+  objectSelectors: {
+    getIcon: () => getDataAppIcon(),
+  },
+});
+
+export default DataAppCollections;

--- a/frontend/src/metabase/entities/data-app-collections.js
+++ b/frontend/src/metabase/entities/data-app-collections.js
@@ -23,18 +23,9 @@ const DataAppCollections = createEntity({
 
   selectors: {
     getExpandedCollectionsById: createSelector(
-      [
-        state => state.entities.dataAppCollections,
-        state => {
-          const list = state.entities.dataAppCollections_list?.null?.list;
-          return list || [];
-        },
-      ],
-      (collections, collectionsIds) =>
-        getExpandedCollectionsById(
-          collectionsIds.map(id => collections[id]),
-          null,
-        ),
+      state => state.entities.dataAppCollections,
+      collections =>
+        getExpandedCollectionsById(Object.values(collections), null),
     ),
   },
 

--- a/frontend/src/metabase/entities/index.js
+++ b/frontend/src/metabase/entities/index.js
@@ -3,6 +3,7 @@ export { default as alerts } from "./alerts";
 export { default as collections } from "./collections";
 export { default as snippetCollections } from "./snippet-collections";
 export { default as dataApps } from "./data-apps";
+export { default as dataAppCollections } from "./data-app-collections";
 export { default as dashboards } from "./dashboards";
 export { default as databaseCandidates } from "./database-candidates";
 export { default as pulses } from "./pulses";

--- a/frontend/src/metabase/schema.js
+++ b/frontend/src/metabase/schema.js
@@ -14,6 +14,7 @@ export const CollectionSchema = new schema.Entity("collections");
 
 export const DatabaseSchema = new schema.Entity("databases");
 export const DataAppSchema = new schema.Entity("dataApps");
+export const DataAppCollectionSchema = new schema.Entity("dataAppCollections");
 export const SchemaSchema = new schema.Entity("schemas");
 export const TableSchema = new schema.Entity(
   "tables",


### PR DESCRIPTION
Basically getting #26153 back to `data-apps-main` after syncing the branch with `master` where `ItemPicker` is refactored