### PR TITLE
Serdes v2: Inline TimelineEvents under Timelines

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/load.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/load.clj
@@ -58,9 +58,9 @@
                              (update :expanding disj path))
                 ;; Use the abstract path as attached by the ingestion process, not the original one we were passed.
                 rebuilt-path    (serdes.base/serdes-path ingested)
-                local-pk-or-nil (serdes.base/load-find-local rebuilt-path)]
+                local-or-nil    (serdes.base/load-find-local rebuilt-path)]
             (try
-              (serdes.base/load-one! ingested local-pk-or-nil)
+              (serdes.base/load-one! ingested local-or-nil)
               ctx
               (catch Exception e
                 (throw (ex-info (format "Failed to load into database for %s" (pr-str path))

--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/models.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/models.clj
@@ -17,5 +17,4 @@
    "Segment"
    "Setting"
    "Table"
-   "Timeline"
-   "TimelineEvent"])
+   "Timeline"])

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/e2e/yaml_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/e2e/yaml_test.clj
@@ -208,12 +208,7 @@
             (is (= 10 (count (dir->file-set (io/file dump-dir "NativeQuerySnippet"))))))
 
           (testing "for timelines and events"
-            (is (= 10 (count (dir->file-set (io/file dump-dir "Timeline")))))
-
-            (is (= 90 (reduce + (for [timeline (get @entities "Timeline")]
-                                  (->> (io/file dump-dir "Timeline" (:entity_id timeline) "TimelineEvent")
-                                       dir->file-set
-                                       count))))))
+            (is (= 10 (count (dir->file-set (io/file dump-dir "Timeline"))))))
 
           (testing "for settings"
             (is (.exists (io/file dump-dir "settings.yaml")))))
@@ -336,13 +331,6 @@
                   (is (= (clean-entity timeline)
                          (->> (db/select-one 'Timeline :entity_id entity_id)
                               (serdes.base/extract-one "Timeline" {})
-                              clean-entity))))
-
-                (doseq [{:keys [timeline_id timestamp] :as event} (get @entities "TimelineEvent")]
-                  (is (= (clean-entity event)
-                         (->> (db/select-one-id 'Timeline :entity_id timeline_id)
-                              (db/select-one 'TimelineEvent :timestamp timestamp :timeline_id)
-                              (serdes.base/extract-one "TimelineEvent" {})
                               clean-entity)))))
 
               (testing "for settings"

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
@@ -6,10 +6,11 @@
             [metabase-enterprise.serialization.v2.ingest :as serdes.ingest]
             [metabase-enterprise.serialization.v2.load :as serdes.load]
             [metabase.models :refer [Card Collection Dashboard DashboardCard Database Field FieldValues Metric Pulse
-                                     PulseChannel PulseChannelRecipient Segment Table User]]
+                                     PulseChannel PulseChannelRecipient Segment Table Timeline TimelineEvent User]]
             [metabase.models.serialization.base :as serdes.base]
             [schema.core :as s]
-            [toucan.db :as db]))
+            [toucan.db :as db])
+  (:import java.time.OffsetDateTime))
 
 (defn- no-labels [path]
   (mapv #(dissoc % :label) path))
@@ -624,6 +625,114 @@
                        :target       [:dimension [:field (:id @field1d) {:source-field (:id @field2d)}]]}]
                      (:parameter_mappings @dashcard1d))))))))))
 
+(deftest timelines-test
+  (testing "timelines"
+    (let [serialized (atom nil)
+          coll1s     (atom nil)
+          user1s     (atom nil)
+          timeline1s (atom nil)
+          event1s    (atom nil)
+          event2s    (atom nil)
+          timeline2s (atom nil)
+          event3s    (atom nil)
+
+          coll1d     (atom nil)
+          user1d     (atom nil)
+          timeline1d (atom nil)
+          timeline2d (atom nil)
+          eventsT1   (atom nil)
+          eventsT2   (atom nil)]
+
+      (ts/with-source-and-dest-dbs
+        (testing "serialize correctly"
+          (ts/with-source-db
+            (reset! coll1s     (ts/create! Collection :name "col1"))
+            (reset! user1s     (ts/create! User  :first_name "Tom" :last_name "Scholz" :email "tom@bost.on"))
+            (reset! timeline1s (ts/create! Timeline :name "Some events" :creator_id (:id @user1s)
+                                           :collection_id (:id @coll1s)))
+            (reset! event1s    (ts/create! TimelineEvent :name "First thing"  :timeline_id (:id @timeline1s)
+                                           :creator_id (:id @user1s) :timezone "America/New_York"
+                                           :timestamp (t/local-date 2022 11 3)))
+            (reset! event2s    (ts/create! TimelineEvent :name "Second thing" :timeline_id (:id @timeline1s)
+                                           :creator_id (:id @user1s) :timezone "America/New_York"
+                                           :timestamp (t/local-date 2022 11 8)))
+            (reset! timeline2s (ts/create! Timeline :name "More events" :creator_id (:id @user1s)
+                                           :collection_id (:id @coll1s)))
+            (reset! event3s    (ts/create! TimelineEvent :name "Different event"  :timeline_id (:id @timeline2s)
+                                           :creator_id (:id @user1s) :timezone "America/New_York"
+                                           :time_matters true :timestamp (t/offset-date-time 2022 10 31 19 00 00)))
+
+            (testing "expecting 3 events"
+              (is (= 3 (db/count TimelineEvent))))
+
+            (reset! serialized (into [] (serdes.extract/extract-metabase {})))
+
+            (let [timelines (by-model @serialized "Timeline")
+                  timeline1 (first (filter #(= (:entity_id %) (:entity_id @timeline1s)) timelines))
+                  timeline2 (first (filter #(= (:entity_id %) (:entity_id @timeline2s)) timelines))]
+              (testing "with inline :events"
+                (is (schema= {:archived                    (s/eq false)
+                              :collection_id               (s/eq (:entity_id @coll1s))
+                              :name                        (s/eq "Some events")
+                              :creator_id                  (s/eq "tom@bost.on")
+                              (s/optional-key :updated_at) OffsetDateTime
+                              :created_at                  OffsetDateTime
+                              :serdes/meta                 (s/eq [{:model "Timeline" :id (:entity_id timeline1)}])
+                              :entity_id                   (s/eq (:entity_id timeline1))
+                              (s/optional-key :icon)       (s/maybe s/Str)
+                              :description                 (s/maybe s/Str)
+                              (s/optional-key :default)    s/Bool
+                              :events                      [{:timezone                    s/Str
+                                                             :time_matters                s/Bool
+                                                             :name                        s/Str
+                                                             :archived                    s/Bool
+                                                             :description                 (s/maybe s/Str)
+                                                             :creator_id                  s/Str
+                                                             (s/optional-key :icon)       (s/maybe s/Str)
+                                                             :created_at                  OffsetDateTime
+                                                             (s/optional-key :updated_at) OffsetDateTime
+                                                             :timestamp                   s/Str}]}
+                             timeline1))
+                (is (= 2 (-> timeline1 :events count)))
+                (is (= 1 (-> timeline2 :events count)))))))
+
+        (testing "deserializing merges events properly"
+          (ts/with-dest-db
+            ;; The collection, timeline 1 and event 2 already exist. Event 1, plus timeline 2 and its event 3, are new.
+            (reset! user1d     (ts/create! User  :first_name "Tom" :last_name "Scholz" :email "tom@bost.on"))
+            (reset! coll1d     (ts/create! Collection :name "col1" :entity_id (:entity_id @coll1s)))
+            (reset! timeline1d (ts/create! Timeline :name "Some events" :creator_id (:id @user1s)
+                                           :entity_id (:entity_id @timeline1s)
+                                           :collection_id (:id @coll1d)))
+            (ts/create! TimelineEvent :name "Second thing with different name" :timeline_id (:id @timeline1s)
+                        :timestamp  (:timestamp @event2s)
+                        :creator_id (:id @user1s) :timezone "America/New_York")
+
+            ;; Load the serialized content.
+            (serdes.load/load-metabase (ingestion-in-memory @serialized))
+
+            ;; Fetch the relevant bits
+            (reset! timeline2d (db/select-one Timeline :entity_id (:entity_id @timeline2s)))
+            (reset! eventsT1   (db/select TimelineEvent :timeline_id (:id @timeline1d)))
+            (reset! eventsT2   (db/select TimelineEvent :timeline_id (:id @timeline2d)))
+
+            (testing "no duplication - there are two timelines with the right event counts"
+              (is (some? @timeline2d))
+              (is (= 2 (count @eventsT1)))
+              (is (= 1 (count @eventsT2))))
+
+            (testing "resulting events match up"
+              (let [[event1 event2] (sort-by :timestamp @eventsT1)]
+                (is (= (:timestamp @event1s) (:timestamp event1)))
+                (is (= (:timestamp @event2s) (:timestamp event2)))
+
+                (is (= (:timestamp @event3s)
+                       (:timestamp (first @eventsT2))))
+
+                (is (= (:name @event2s)
+                       (:name event2))
+                    "existing event name should be updated")))))))))
+
 (deftest users-test
   ;; Users are serialized as their email address. If a corresponding user is found during deserialization, its ID is
   ;; used. However, if no such user exists, a new one is created with mostly blank fields.
@@ -781,7 +890,7 @@
               (is (= 2 (db/count FieldValues :field_id [:in fields])))))
 
           (testing "existing FieldValues are properly found and updated"
-            (is (= (:values @fv1s) (:values @fv1d))))
+            (is (= (set (:values @fv1s)) (set (:values @fv1d)))))
           (testing "new FieldValues are properly added"
             (is (= (dissoc @fv2s :id :field_id :created_at :updated_at)
                    (dissoc @fv2d :id :field_id :created_at :updated_at)))))))))

--- a/src/metabase/models/database.clj
+++ b/src/metabase/models/database.clj
@@ -304,7 +304,7 @@
 
 (defmethod serdes.base/load-find-local "Database"
   [[{:keys [id]}]]
-  (db/select-one-field :id Database :name id))
+  (db/select-one Database :name id))
 
 (defmethod serdes.base/load-xform "Database"
   [database]

--- a/src/metabase/models/field.clj
+++ b/src/metabase/models/field.clj
@@ -416,5 +416,5 @@
 
 (defmethod serdes.base/load-find-local "Field"
   [path]
-  (let [table-id (serdes.base/load-find-local (pop path))]
-    (db/select-one-field :id Field :name (-> path last :id) :table_id table-id)))
+  (let [table (serdes.base/load-find-local (pop path))]
+    (db/select-one Field :name (-> path last :id) :table_id (:id table))))

--- a/src/metabase/models/field_values.clj
+++ b/src/metabase/models/field_values.clj
@@ -445,8 +445,8 @@
 
 (defmethod serdes.base/load-find-local "FieldValues" [path]
   ;; Delegate to finding the parent Field, then look up its corresponding FieldValues.
-  (let [field-id (serdes.base/load-find-local (pop path))]
-    (db/select-one-id FieldValues :field_id field-id)))
+  (let [field (serdes.base/load-find-local (pop path))]
+    (db/select-one FieldValues :field_id (:id field))))
 
 (defmethod serdes.base/load-update! "FieldValues" [_ ingested local]
   ;; It's illegal to change the :type and :hash_key fields, and there's a pre-update check for this.

--- a/src/metabase/models/table.clj
+++ b/src/metabase/models/table.clj
@@ -252,8 +252,8 @@
         schema-name (when (= 3 (count path))
                       (-> path second :id))
         table-name  (-> path last :id)
-        db-id       (db/select-one-field :id Database :name db-name)]
-    (db/select-one-field :id Table :name table-name :db_id db-id :schema schema-name)))
+        db-id       (db/select-one-id Database :name db-name)]
+    (db/select-one Table :name table-name :db_id db-id :schema schema-name)))
 
 (defmethod serdes.base/extract-one "Table"
   [_model-name _opts {:keys [db_id] :as table}]

--- a/src/metabase/models/timeline_event.clj
+++ b/src/metabase/models/timeline_event.clj
@@ -1,6 +1,5 @@
 (ns metabase.models.timeline-event
-  (:require [java-time :as t]
-            [metabase.models.interface :as mi]
+  (:require [metabase.models.interface :as mi]
             [metabase.models.serialization.base :as serdes.base]
             [metabase.models.serialization.hash :as serdes.hash]
             [metabase.models.serialization.util :as serdes.util]
@@ -105,29 +104,10 @@
   [:name :timestamp (serdes.hash/hydrated-hash :timeline) :created_at])
 
 ;;;; serialization
-(defmethod serdes.base/serdes-entity-id "TimelineEvent" [_model-name {:keys [timestamp]}]
-  (u.date/format (t/offset-date-time timestamp)))
-
-(defmethod serdes.base/serdes-generate-path "TimelineEvent"
-  [_ event]
-  (let [timeline (db/select-one 'Timeline :id (:timeline_id event))
-        self     (serdes.base/infer-self-path "TimelineEvent" event)]
-    (conj (serdes.base/serdes-generate-path "Timeline" timeline)
-          (assoc self :label (:name event)))))
-
-(defmethod serdes.base/extract-one "TimelineEvent"
-  [_model-name _opts event]
-  (-> (serdes.base/extract-one-basics "TimelineEvent" event)
-      (update :timeline_id serdes.util/export-fk 'Timeline)
-      (update :creator_id  serdes.util/export-user)
-      (update :timestamp   #(u.date/format (t/offset-date-time %)))))
-
+;; TimelineEvents are inlined under their Timelines, but we can reuse the [[load-one!]] logic using [[load-xform]].
 (defmethod serdes.base/load-xform "TimelineEvent" [event]
   (-> event
       serdes.base/load-xform-basics
       (update :timeline_id serdes.util/import-fk 'Timeline)
       (update :creator_id  serdes.util/import-user)
       (update :timestamp   u.date/parse)))
-
-(defmethod serdes.base/serdes-dependencies "TimelineEvent" [{:keys [timeline_id]}]
-  [[{:model "Timeline" :id timeline_id}]])


### PR DESCRIPTION
This also changes the semantics of
`metabase.models.serialization.base/load-find-local` to return the whole
entity, not just the ID. `load-one!` always needs the whole entity (if
it exists) anyway, and some of the `load-find-local` implementations had
the entity already loaded but just passed along the ID. This saves some
double lookups, especially for inlining eg. `DashboardCard`s under
`Dashboard`.
