### PR TITLE
Rerun flaky workflows on `master` and `release` branches

### DIFF
--- a/.github/workflows/rerun-workflows.yml
+++ b/.github/workflows/rerun-workflows.yml
@@ -1,0 +1,31 @@
+name: Rerun Flaky Workflows
+
+on:
+  workflow_run:
+    workflows: [Backend, Driver Tests, E2E Tests, Frontend]
+    types: [completed]
+    branches: [master, 'release-**']
+
+jobs:
+  rerun-on-failure:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion }} == 'failure'
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          script: |
+            const MAX_ATTEMPTS = 2;
+            const ATTEMPT = ${{ github.event.workflow_run.run_attempt }};
+
+            if (ATTEMPT <= MAX_ATTEMPTS) {
+              console.log("Rerruning...");
+
+              github.rest.actions.reRunWorkflowFailedJobs({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                run_id: ${{ github.event.workflow_run.id }},
+              });
+            } else {
+              console.log("Rerunning didn't help!");
+              console.log("Please check workflow " + ${{ github.event.workflow_run.id }});
+            }


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- It adds an additional workflow that will be triggered ONLY when some of the listed (flaky) workflows fail on `master` or on the release branches.
- It also adds the maximum number of retries and sets that to two

### Why?
We're experiencing H2 timeouts that can affect backend and E2E tests. Our `master` branch appears mostly red because of this, while all it needs is a rerun. It's tedious to do it manually. That's where this workflow steps in.

Even when/if we solve this timeout issue, this workflow should do no harm as it only gets triggered when the listed workflows fail.