### PR TITLE
Sync Template Tags with Parameters in Action Creator

### DIFF
--- a/frontend/src/metabase-types/types/Parameter.ts
+++ b/frontend/src/metabase-types/types/Parameter.ts
@@ -40,6 +40,7 @@ export type ParameterMappingOptions = {
 export interface Parameter {
   id: ParameterId;
   name: string;
+  "display-name"?: string;
   type: ParameterType;
   slug: string;
   sectionId?: string;

--- a/frontend/src/metabase/writeback/components/ActionCreator/ActionCreator.tsx
+++ b/frontend/src/metabase/writeback/components/ActionCreator/ActionCreator.tsx
@@ -178,7 +178,7 @@ function ActionCreatorComponent({
 
             {!isDataRefOpen && (
               <FormCreator
-                tags={query?.templateTagsWithoutSnippets()}
+                params={question?.parameters() ?? []}
                 formSettings={
                   question?.card()?.visualization_settings as ActionFormSettings
                 }

--- a/frontend/src/metabase/writeback/components/ActionCreator/FormCreator/FormCreator.tsx
+++ b/frontend/src/metabase/writeback/components/ActionCreator/FormCreator/FormCreator.tsx
@@ -83,7 +83,7 @@ function FormItem({
   onChange: (fieldSettings: FieldSettings) => void;
 }) {
   const [isEditingOptions, setIsEditingOptions] = useState(false);
-  const name = param.name;
+  const name = param["display-name"] ?? param.name;
 
   const updateOptions = (newOptions: (string | number)[]) => {
     onChange({

--- a/frontend/src/metabase/writeback/components/ActionCreator/FormCreator/FormCreator.tsx
+++ b/frontend/src/metabase/writeback/components/ActionCreator/FormCreator/FormCreator.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from "react";
 import { t } from "ttag";
 
-import type { TemplateTag } from "metabase-types/types/Query";
+import type { Parameter } from "metabase-types/types/Parameter";
 import type { ActionFormSettings, FieldSettings } from "metabase-types/api";
 
 import { FieldSettingsPopover } from "./FieldSettingsPopover";
@@ -21,12 +21,12 @@ import {
 } from "./FormCreator.styled";
 
 export function FormCreator({
-  tags,
+  params,
   formSettings: passedFormSettings,
   onChange,
   onExampleClick,
 }: {
-  tags: TemplateTag[];
+  params: Parameter[];
   formSettings?: ActionFormSettings;
   onChange: (formSettings: ActionFormSettings) => void;
   onExampleClick: () => void;
@@ -40,48 +40,50 @@ export function FormCreator({
   }, [formSettings, onChange]);
 
   const handleChangeFieldSettings = (
-    tagId: string,
+    paramId: string,
     newFieldSettings: FieldSettings,
   ) => {
     setFormSettings({
       ...formSettings,
       fields: {
         ...formSettings.fields,
-        [tagId]: newFieldSettings,
+        [paramId]: newFieldSettings,
       },
     });
   };
 
   return (
     <FormCreatorWrapper>
-      {tags.map(tag => (
+      {params.map(param => (
         <FormItem
-          key={tag.id}
-          tag={tag}
+          key={param.id}
+          param={param}
           fieldSettings={
-            formSettings.fields?.[tag.id] ?? getDefaultFieldSettings()
+            formSettings.fields?.[param.id] ?? getDefaultFieldSettings()
           }
           onChange={(newSettings: FieldSettings) =>
-            handleChangeFieldSettings(tag.id, newSettings)
+            handleChangeFieldSettings(param.id, newSettings)
           }
         />
       ))}
-      {!tags.length && <EmptyFormPlaceholder onExampleClick={onExampleClick} />}
+      {!params.length && (
+        <EmptyFormPlaceholder onExampleClick={onExampleClick} />
+      )}
     </FormCreatorWrapper>
   );
 }
 
 function FormItem({
-  tag,
+  param,
   fieldSettings,
   onChange,
 }: {
-  tag: TemplateTag;
+  param: Parameter;
   fieldSettings: FieldSettings;
   onChange: (fieldSettings: FieldSettings) => void;
 }) {
   const [isEditingOptions, setIsEditingOptions] = useState(false);
-  const name = tag.name;
+  const name = param.name;
 
   const updateOptions = (newOptions: (string | number)[]) => {
     onChange({
@@ -106,7 +108,7 @@ function FormItem({
               onChange={updateOptions}
             />
           ) : (
-            <FormField tag={tag} fieldSettings={fieldSettings} />
+            <FormField param={param} fieldSettings={fieldSettings} />
           )}
           {!isEditingOptions && hasOptions && (
             <EditButton

--- a/frontend/src/metabase/writeback/components/ActionCreator/FormCreator/FormField.tsx
+++ b/frontend/src/metabase/writeback/components/ActionCreator/FormCreator/FormField.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import type { FieldSettings } from "metabase-types/api";
-import type { TemplateTag } from "metabase-types/types/Query";
+import type { Parameter } from "metabase-types/types/Parameter";
 
 import { getWidgetComponent } from "metabase/components/form/FormWidget";
 
@@ -8,13 +8,13 @@ import { getFormField } from "./utils";
 
 // sample form fields
 export function FormField({
-  tag,
+  param,
   fieldSettings,
 }: {
-  tag: TemplateTag;
+  param: Parameter;
   fieldSettings: FieldSettings;
 }) {
-  const fieldProps = getFormField(tag, fieldSettings);
+  const fieldProps = getFormField(param, fieldSettings);
   const InputField = getWidgetComponent(fieldProps);
   return <InputField field={fieldProps} {...fieldProps} />;
 }

--- a/frontend/src/metabase/writeback/components/ActionCreator/FormCreator/utils.ts
+++ b/frontend/src/metabase/writeback/components/ActionCreator/FormCreator/utils.ts
@@ -99,6 +99,7 @@ export const getFormField = (
     title:
       fieldSettings.title ||
       fieldSettings.name ||
+      parameter["display-name"] ||
       parameter.name ||
       parameter.id,
     description: fieldSettings.description ?? "",
@@ -183,7 +184,7 @@ export const generateFieldSettingsFromParameters = (
       ? new Field(fieldMetadataMap[param.id])
       : undefined;
 
-    const name = param.name ?? param.id;
+    const name = param["display-name"] ?? param.name ?? param.id;
     const displayName = field?.displayName?.() ?? name;
 
     fieldSettings[param.id] = getDefaultFieldSettings({

--- a/frontend/src/metabase/writeback/components/ActionCreator/FormCreator/utils.ts
+++ b/frontend/src/metabase/writeback/components/ActionCreator/FormCreator/utils.ts
@@ -17,7 +17,6 @@ import type {
 } from "metabase-types/api";
 
 import type { Parameter } from "metabase-types/types/Parameter";
-import type { TemplateTag } from "metabase-types/types/Query";
 
 import { isEditableField } from "metabase/writeback/utils";
 import Field from "metabase-lib/metadata/Field";
@@ -84,7 +83,7 @@ const inputTypeHasOptions = (fieldSettings: FieldSettings) =>
   ["dropdown", "radio"].includes(fieldSettings.inputType);
 
 export const getFormField = (
-  parameter: Parameter | TemplateTag,
+  parameter: Parameter,
   fieldSettings: FieldSettings,
 ) => {
   if (

--- a/frontend/src/metabase/writeback/components/ActionCreator/QueryActionEditor.tsx
+++ b/frontend/src/metabase/writeback/components/ActionCreator/QueryActionEditor.tsx
@@ -4,6 +4,8 @@ import NativeQueryEditor from "metabase/query_builder/components/NativeQueryEdit
 import type NativeQuery from "metabase-lib/queries/NativeQuery";
 import type Question from "metabase-lib/Question";
 
+import { getTemplateTagParameters } from "metabase-lib/parameters/utils/template-tags";
+
 export function QueryActionEditor({
   question,
   setQuestion,
@@ -18,11 +20,10 @@ export function QueryActionEditor({
         viewHeight="full"
         setDatasetQuery={(newQuery: NativeQuery) => {
           // we need to sync the query AND the template tags
-          setQuestion(
-            question
-              .setQuery(newQuery)
-              .setParameters(newQuery?.templateTagsWithoutSnippets()),
+          const newParams = getTemplateTagParameters(
+            newQuery.templateTagsWithoutSnippets(),
           );
+          setQuestion(question.setQuery(newQuery).setParameters(newParams));
         }}
         enableRun={false}
         hasEditingSidebar={false}

--- a/frontend/src/metabase/writeback/components/ActionCreator/QueryActionEditor.tsx
+++ b/frontend/src/metabase/writeback/components/ActionCreator/QueryActionEditor.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 
 import NativeQueryEditor from "metabase/query_builder/components/NativeQueryEditor";
-import type Query from "metabase-lib/queries/Query";
+import type NativeQuery from "metabase-lib/queries/NativeQuery";
 import type Question from "metabase-lib/Question";
 
 export function QueryActionEditor({
@@ -16,9 +16,14 @@ export function QueryActionEditor({
       <NativeQueryEditor
         query={question.query()}
         viewHeight="full"
-        setDatasetQuery={(newQuery: Query) =>
-          setQuestion(question.setQuery(newQuery))
-        }
+        setDatasetQuery={(newQuery: NativeQuery) => {
+          // we need to sync the query AND the template tags
+          setQuestion(
+            question
+              .setQuery(newQuery)
+              .setParameters(newQuery?.templateTagsWithoutSnippets()),
+          );
+        }}
         enableRun={false}
         hasEditingSidebar={false}
         isNativeEditorOpen


### PR DESCRIPTION
closes #26437 

## Description

When editing an already saved action, adding new parameters would apparently update the form (because it was looking at template tags), but actual forms (which use parameters) would not update.

This changes all the forms code to use parameters instead of template tags, and correctly propagates template tags to parameters.

Also updates parameters code to use the `display-name` in forms.

## Demo

When? | What?
--- | ---
Before | ![paramRepro](https://user-images.githubusercontent.com/30528226/201790310-607ffa18-b558-4550-8d03-d56886acf362.gif)
After | ![fixDemo](https://user-images.githubusercontent.com/30528226/201790325-cd69263a-14dc-46e5-b487-c59280029d77.gif)

