### PR TITLE
Separate MBQL schema for time vs date/datetime literals

### DIFF
--- a/shared/src/metabase/mbql/schema.cljc
+++ b/shared/src/metabase/mbql/schema.cljc
@@ -150,15 +150,6 @@
   "Schema for an ISO-8601-formatted time string literal."
   (s/constrained helpers/NonBlankString can-parse-time? "valid ISO-8601 time string literal"))
 
-(def TemporalLiteralString
-  "Schema for either a literal datetime string, literal date string, or a literal time string."
-  (s/named
-   (s/conditional
-    can-parse-datetime? LiteralDatetimeString
-    can-parse-date?     LiteralDateString
-    can-parse-time?     LiteralTimeString)
-   "valid ISO-8601 datetime, date, or time string literal"))
-
 ;; TODO - `unit` is not allowed if `n` is `current`
 (defclause relative-datetime
   n    (s/cond-pre (s/eq :current) s/Int)

--- a/shared/src/metabase/mbql/schema.cljc
+++ b/shared/src/metabase/mbql/schema.cljc
@@ -216,32 +216,56 @@
           :cljs js/Date)
   unit TimeUnit)
 
-(def ^:private DatetimeLiteral
-  "Schema for valid absolute datetime literals."
+(def ^:private DateOrDatetimeLiteral
+  "Schema for a valid date or datetime literal."
   (s/conditional
    (partial is-clause? :absolute-datetime)
    absolute-datetime
 
-   (partial is-clause? :time)
-   time
+   can-parse-datetime?
+   LiteralDatetimeString
+
+   can-parse-date?
+   LiteralDateString
 
    :else
    (s/cond-pre
     ;; literal datetime strings and Java types will get transformed to `absolute-datetime` clauses automatically by
     ;; middleware so drivers don't need to deal with these directly. You only need to worry about handling
     ;; `absolute-datetime` clauses.
-    TemporalLiteralString
-
     #?@(:clj
-        [java.time.LocalTime
-         java.time.LocalDate
+        [java.time.LocalDate
          java.time.LocalDateTime
-         java.time.OffsetTime
          java.time.OffsetDateTime
          java.time.ZonedDateTime]
 
         :cljs
         [js/Date]))))
+
+(def ^:private TimeLiteral
+  "Schema for valid time literals."
+  (s/conditional
+   (partial is-clause? :time)
+   time
+
+   can-parse-time?
+   LiteralTimeString
+
+   :else
+   (s/cond-pre
+    ;; literal datetime strings and Java types will get transformed to `time` clauses automatically by
+    ;; middleware so drivers don't need to deal with these directly. You only need to worry about handling
+    ;; `time` clauses.
+    #?@(:clj
+        [java.time.LocalTime
+         java.time.OffsetTime]
+
+        :cljs
+        [js/Date]))))
+
+(def ^:private TemporalLiteral
+  "Schema for valid temporal literals."
+  (s/cond-pre TimeLiteral DateOrDatetimeLiteral))
 
 (def DateTimeValue
   "Schema for a datetime value drivers will personally have to handle, either an `absolute-datetime` form or a
@@ -739,7 +763,7 @@
     s/Bool
     s/Num
     s/Str
-    DatetimeLiteral
+    TemporalLiteral
     FieldOrRelativeDatetime
     ExpressionArg
     value)))
@@ -751,7 +775,7 @@
     (s/cond-pre
      s/Num
      s/Str
-     DatetimeLiteral
+     TemporalLiteral
      ExpressionArg
      FieldOrRelativeDatetime)))
 

--- a/shared/test/metabase/mbql/schema_test.cljc
+++ b/shared/test/metabase/mbql/schema_test.cljc
@@ -3,39 +3,40 @@
             [metabase.mbql.schema :as mbql.s]
             [schema.core :as s]))
 
-(t/deftest ^:parallel temporal-literal-test
-  (t/testing "Make sure our schema validates temporal literal clauses correctly"
-    (doseq [[schema-var cases] {#'mbql.s/TemporalLiteral       [[true "00:00:00"]
-                                                                [true "00:00:00Z"]
-                                                                [true "00:00:00+00:00"]
-                                                                [true "2022-01-01"]
-                                                                [true "2022-01-01T00:00:00"]
-                                                                [true "2022-01-01T00:00:00+00:00"]
-                                                                [true "2022-01-01T00:00:00Z"]
-                                                                [false "2022-01-01 00:00:00"]
-                                                                [false "a string"]]
-                                #'mbql.s/DateOrDatetimeLiteral [[false "00:00:00"]
-                                                                [false "00:00:00Z"]
-                                                                [false "00:00:00+00:00"]
-                                                                [true "2022-01-01"]
-                                                                [true "2022-01-01T00:00:00"]
-                                                                [true "2022-01-01T00:00:00+00:00"]
-                                                                [true "2022-01-01T00:00:00Z"]
-                                                                [false "2022-01-01 00:00:00"]
-                                                                [false "a string"]]
-                                #'mbql.s/TimeLiteral           [[true "00:00:00"]
-                                                                [true "00:00:00Z"]
-                                                                [true "00:00:00+00:00"]
-                                                                [false "2022-01-01"]
-                                                                [false "2022-01-01T00:00:00"]
-                                                                [false "2022-01-01T00:00:00+00:00"]
-                                                                [false "2022-01-01T00:00:00Z"]
-                                                                [false "2022-01-01 00:00:00"]
-                                                                [false "a string"]]}
-            [expected clause] cases]
-      (t/testing (pr-str schema-var clause)
-        (t/is (= expected
-                 (not (s/check @schema-var clause))))))))
+#?(:clj
+   (t/deftest ^:parallel temporal-literal-test
+     (t/testing "Make sure our schema validates temporal literal clauses correctly"
+       (doseq [[schema-var cases] {#'mbql.s/TemporalLiteral       [[true "00:00:00"]
+                                                                   [true "00:00:00Z"]
+                                                                   [true "00:00:00+00:00"]
+                                                                   [true "2022-01-01"]
+                                                                   [true "2022-01-01T00:00:00"]
+                                                                   [true "2022-01-01T00:00:00+00:00"]
+                                                                   [true "2022-01-01T00:00:00Z"]
+                                                                   [false "2022-01-01 00:00:00"]
+                                                                   [false "a string"]]
+                                   #'mbql.s/DateOrDatetimeLiteral [[false "00:00:00"]
+                                                                   [false "00:00:00Z"]
+                                                                   [false "00:00:00+00:00"]
+                                                                   [true "2022-01-01"]
+                                                                   [true "2022-01-01T00:00:00"]
+                                                                   [true "2022-01-01T00:00:00+00:00"]
+                                                                   [true "2022-01-01T00:00:00Z"]
+                                                                   [false "2022-01-01 00:00:00"]
+                                                                   [false "a string"]]
+                                   #'mbql.s/TimeLiteral           [[true "00:00:00"]
+                                                                   [true "00:00:00Z"]
+                                                                   [true "00:00:00+00:00"]
+                                                                   [false "2022-01-01"]
+                                                                   [false "2022-01-01T00:00:00"]
+                                                                   [false "2022-01-01T00:00:00+00:00"]
+                                                                   [false "2022-01-01T00:00:00Z"]
+                                                                   [false "2022-01-01 00:00:00"]
+                                                                   [false "a string"]]}
+               [expected clause] cases]
+         (t/testing (pr-str schema-var clause)
+           (t/is (= expected
+                    (not (s/check @schema-var clause)))))))))
 
 (t/deftest ^:parallel field-clause-test
   (t/testing "Make sure our schema validates `:field` clauses correctly"

--- a/shared/test/metabase/mbql/schema_test.cljc
+++ b/shared/test/metabase/mbql/schema_test.cljc
@@ -5,37 +5,37 @@
 
 (t/deftest ^:parallel temporal-literal-test
   (t/testing "Make sure our schema validates temporal literal clauses correctly"
-    (doseq [[schema cases] {#'mbql.s/TemporalLiteral       [[true "00:00:00"]
-                                                            [true "00:00:00Z"]
-                                                            [true "00:00:00+00:00"]
-                                                            [true "2022-01-01"]
-                                                            [true "2022-01-01T00:00:00"]
-                                                            [true "2022-01-01T00:00:00+00:00"]
-                                                            [true "2022-01-01T00:00:00Z"]
-                                                            [false "2022-01-01 00:00:00"]
-                                                            [false "a string"]]
-                            #'mbql.s/DateOrDatetimeLiteral [[false "00:00:00"]
-                                                            [false "00:00:00Z"]
-                                                            [false "00:00:00+00:00"]
-                                                            [true "2022-01-01"]
-                                                            [true "2022-01-01T00:00:00"]
-                                                            [true "2022-01-01T00:00:00+00:00"]
-                                                            [true "2022-01-01T00:00:00Z"]
-                                                            [false "2022-01-01 00:00:00"]
-                                                            [false "a string"]]
-                            #'mbql.s/TimeLiteral           [[true "00:00:00"]
-                                                            [true "00:00:00Z"]
-                                                            [true "00:00:00+00:00"]
-                                                            [false "2022-01-01"]
-                                                            [false "2022-01-01T00:00:00"]
-                                                            [false "2022-01-01T00:00:00+00:00"]
-                                                            [false "2022-01-01T00:00:00Z"]
-                                                            [false "2022-01-01 00:00:00"]
-                                                            [false "a string"]]}
+    (doseq [[schema-var cases] {#'mbql.s/TemporalLiteral       [[true "00:00:00"]
+                                                                [true "00:00:00Z"]
+                                                                [true "00:00:00+00:00"]
+                                                                [true "2022-01-01"]
+                                                                [true "2022-01-01T00:00:00"]
+                                                                [true "2022-01-01T00:00:00+00:00"]
+                                                                [true "2022-01-01T00:00:00Z"]
+                                                                [false "2022-01-01 00:00:00"]
+                                                                [false "a string"]]
+                                #'mbql.s/DateOrDatetimeLiteral [[false "00:00:00"]
+                                                                [false "00:00:00Z"]
+                                                                [false "00:00:00+00:00"]
+                                                                [true "2022-01-01"]
+                                                                [true "2022-01-01T00:00:00"]
+                                                                [true "2022-01-01T00:00:00+00:00"]
+                                                                [true "2022-01-01T00:00:00Z"]
+                                                                [false "2022-01-01 00:00:00"]
+                                                                [false "a string"]]
+                                #'mbql.s/TimeLiteral           [[true "00:00:00"]
+                                                                [true "00:00:00Z"]
+                                                                [true "00:00:00+00:00"]
+                                                                [false "2022-01-01"]
+                                                                [false "2022-01-01T00:00:00"]
+                                                                [false "2022-01-01T00:00:00+00:00"]
+                                                                [false "2022-01-01T00:00:00Z"]
+                                                                [false "2022-01-01 00:00:00"]
+                                                                [false "a string"]]}
             [expected clause] cases]
-      (t/testing (pr-str schema clause)
+      (t/testing (pr-str schema-var clause)
         (t/is (= expected
-                 (not (s/check (var-get schema) clause))))))))
+                 (not (s/check @schema-var clause))))))))
 
 (t/deftest ^:parallel field-clause-test
   (t/testing "Make sure our schema validates `:field` clauses correctly"

--- a/shared/test/metabase/mbql/schema_test.cljc
+++ b/shared/test/metabase/mbql/schema_test.cljc
@@ -3,6 +3,40 @@
             [metabase.mbql.schema :as mbql.s]
             [schema.core :as s]))
 
+(t/deftest ^:parallel temporal-literal-test
+  (t/testing "Make sure our schema validates temporal literal clauses correctly"
+    (doseq [[schema cases] {#'mbql.s/TemporalLiteral       [[true "00:00:00"]
+                                                            [true "00:00:00Z"]
+                                                            [true "00:00:00+00:00"]
+                                                            [true "2022-01-01"]
+                                                            [true "2022-01-01T00:00:00"]
+                                                            [true "2022-01-01T00:00:00+00:00"]
+                                                            [true "2022-01-01T00:00:00Z"]
+                                                            [false "2022-01-01 00:00:00"]
+                                                            [false "a string"]]
+                            #'mbql.s/DateOrDatetimeLiteral [[false "00:00:00"]
+                                                            [false "00:00:00Z"]
+                                                            [false "00:00:00+00:00"]
+                                                            [true "2022-01-01"]
+                                                            [true "2022-01-01T00:00:00"]
+                                                            [true "2022-01-01T00:00:00+00:00"]
+                                                            [true "2022-01-01T00:00:00Z"]
+                                                            [false "2022-01-01 00:00:00"]
+                                                            [false "a string"]]
+                            #'mbql.s/TimeLiteral           [[true "00:00:00"]
+                                                            [true "00:00:00Z"]
+                                                            [true "00:00:00+00:00"]
+                                                            [false "2022-01-01"]
+                                                            [false "2022-01-01T00:00:00"]
+                                                            [false "2022-01-01T00:00:00+00:00"]
+                                                            [false "2022-01-01T00:00:00Z"]
+                                                            [false "2022-01-01 00:00:00"]
+                                                            [false "a string"]]}
+            [expected clause] cases]
+      (t/testing (pr-str schema clause)
+        (t/is (= expected
+                 (not (s/check (var-get schema) clause))))))))
+
 (t/deftest ^:parallel field-clause-test
   (t/testing "Make sure our schema validates `:field` clauses correctly"
     (doseq [[clause expected] {[:field 1 nil]                                                          true


### PR DESCRIPTION
This PR creates separate MBQL schema for time literals vs date or datetime literals.

This enables tighter constraints on MBQL clauses that can take date or datetime literals as arguments, but not time literals. The upcoming `convert-timezone`, and `datetime-diff` clauses are examples.

Note it is only possible to differentiate between time and date/datetime literal strings in Clojure and not ClojureScript, as we don't have functions to parse date vs datetime vs time ClojureScript.