### PR TITLE
Fix mongo failed to parse `absolute-datetime`

### DIFF
--- a/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
@@ -328,8 +328,8 @@
                      java.time.LocalDate      t
                      java.time.LocalTime      t
                      java.time.LocalDateTime  t
-                     java.time.OffsetTime     (t/with-offset-same-instant t (.. report-zone getRules (getOffset (t/instant t))))
-                     java.time.OffsetDateTime (t/with-offset-same-instant t (.. report-zone getRules (getOffset (t/instant t))))
+                     java.time.OffsetTime     (t/offset-time t report-zone)
+                     java.time.OffsetDateTime (t/offset-date-time t report-zone)
                      java.time.ZonedDateTime  (t/offset-date-time (t/with-zone-same-instant t report-zone)))]
     (letfn [(extract [unit]
               (u.date/extract t unit))

--- a/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
@@ -330,7 +330,7 @@
                      java.time.LocalDateTime  t
                      java.time.OffsetTime     (t/offset-time t report-zone)
                      java.time.OffsetDateTime (t/offset-date-time t report-zone)
-                     java.time.ZonedDateTime  (t/offset-date-time (t/with-zone-same-instant t report-zone)))]
+                     java.time.ZonedDateTime  (t/offset-date-time t report-zone))]
     (letfn [(extract [unit]
               (u.date/extract t unit))
             (bucket [unit]

--- a/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
@@ -322,15 +322,16 @@
 
 (defmethod ->rvalue :absolute-datetime
   [[_ t unit]]
-  (let [report-zone (t/zone-id (or (qp.timezone/report-timezone-id-if-supported :mongo)
-                                   "UTC"))
-        t           (condp = (class t)
-                      java.time.LocalDate      t
-                      java.time.LocalTime      t
-                      java.time.LocalDateTime  t
-                      java.time.OffsetTime     (t/with-offset-same-instant t report-zone)
-                      java.time.OffsetDateTime (t/with-offset-same-instant t report-zone)
-                      java.time.ZonedDateTime  (t/offset-date-time (t/with-zone-same-instant t report-zone)))]
+  (let [report-zone   (t/zone-id (or (qp.timezone/report-timezone-id-if-supported :mongo)
+                                     "UTC"))
+        report-offset (.. report-zone getRules (getOffset (t/instant t)))
+        t             (condp = (class t)
+                        java.time.LocalDate      t
+                        java.time.LocalTime      t
+                        java.time.LocalDateTime  t
+                        java.time.OffsetTime     (t/with-offset-same-instant t report-offset)
+                        java.time.OffsetDateTime (t/with-offset-same-instant t report-offset)
+                        java.time.ZonedDateTime  (t/offset-date-time (t/with-zone-same-instant t report-offset)))]
     (letfn [(extract [unit]
               (u.date/extract t unit))
             (bucket [unit]

--- a/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
@@ -320,18 +320,21 @@
 (defn- $date-from-string [s]
   {:$dateFromString {:dateString (str s)}})
 
+(defn- parse-datetime
+  [t]
+  (let [report-zone (t/zone-id (or (qp.timezone/report-timezone-id-if-supported :mongo)
+                                   "UTC"))]
+    (condp = (class t)
+      java.time.LocalDate      t
+      java.time.LocalTime      t
+      java.time.LocalDateTime  t
+      java.time.OffsetTime     (t/with-offset-same-instant t (.. report-zone getRules (getOffset (t/instant t))))
+      java.time.OffsetDateTime (t/with-offset-same-instant t (.. report-zone getRules (getOffset (t/instant t))))
+      java.time.ZonedDateTime  (t/offset-date-time (t/with-zone-same-instant t (.. report-zone getRules (getOffset (t/instant t))))))))
+
 (defmethod ->rvalue :absolute-datetime
   [[_ t unit]]
-  (let [report-zone   (t/zone-id (or (qp.timezone/report-timezone-id-if-supported :mongo)
-                                     "UTC"))
-        report-offset (.. report-zone getRules (getOffset (t/instant t)))
-        t             (condp = (class t)
-                        java.time.LocalDate      t
-                        java.time.LocalTime      t
-                        java.time.LocalDateTime  t
-                        java.time.OffsetTime     (t/with-offset-same-instant t report-offset)
-                        java.time.OffsetDateTime (t/with-offset-same-instant t report-offset)
-                        java.time.ZonedDateTime  (t/offset-date-time (t/with-zone-same-instant t report-offset)))]
+  (let [t (parse-datetime t)]
     (letfn [(extract [unit]
               (u.date/extract t unit))
             (bucket [unit]

--- a/modules/drivers/mongo/test/metabase/driver/mongo/query_processor_test.clj
+++ b/modules/drivers/mongo/test/metabase/driver/mongo/query_processor_test.clj
@@ -57,6 +57,22 @@
                     {:aggregation [[:count]]
                      :filter      [:time-interval $datetime :last :month]})))))))))
 
+(deftest absolute-datetime-test
+  (mt/test-driver :mongo
+    (testing "Make sure absolute-datetime are compiled correctly"
+      (doseq [[expected date]
+              [["2014-01-01"        (t/local-date "2014-01-01")]
+               ["10:00"             (t/local-time "10:00:00")]
+               ["2014-01-01T10:00"  (t/local-date-time "2014-01-01T10:00")]
+               ["03:00Z"            (t/offset-time "10:00:00+07:00")]
+               ["2014-01-01T03:00Z" (t/offset-date-time "2014-01-01T10:00+07:00")]
+               ["2014-01-01T00:00Z" (t/zoned-date-time "2014-01-01T00:00:00Z[UTC]")]]]
+        (testing (format "with %s" (type date))
+          (is (= {:$expr {"$lt" ["$date-field" {:$dateFromString {:dateString expected}}]}}
+                 (mongo.qp/compile-filter [:<
+                                           [:field "date-field"]
+                                           [:absolute-datetime date]]))))))))
+
 (deftest no-initial-projection-test
   (mt/test-driver :mongo
     (testing "Don't need to create initial projections anymore (#4216)"

--- a/modules/drivers/mongo/test/metabase/driver/mongo/query_processor_test.clj
+++ b/modules/drivers/mongo/test/metabase/driver/mongo/query_processor_test.clj
@@ -66,7 +66,7 @@
                ["2014-01-01T10:00"  (t/local-date-time "2014-01-01T10:00")]
                ["03:00Z"            (t/offset-time "10:00:00+07:00")]
                ["2014-01-01T03:00Z" (t/offset-date-time "2014-01-01T10:00+07:00")]
-               ["2014-01-01T00:00Z" (t/zoned-date-time "2014-01-01T00:00:00Z[UTC]")]]]
+               ["2014-01-01T00:00Z" (t/zoned-date-time "2014-01-01T07:00:00+07:00[Asia/Ho_Chi_Minh]")]]]
         (testing (format "with %s" (type date))
           (is (= {:$expr {"$lt" ["$date-field" {:$dateFromString {:dateString expected}}]}}
                  (mongo.qp/compile-filter [:<


### PR DESCRIPTION
Fixes #16828

The bug was because FE sent an absolute datetime with an `offset` (`2020-12-01T00:00:00+08:00`) when you zoom in on chart.

Even though it's a bit weird that FE will send a datetime `without offset` when you use the datetime filter. But we still need to fix our driver to handle all cases.