### PR TITLE
Auto-populate database Id in action creator

### DIFF
--- a/frontend/src/metabase-types/api/card.ts
+++ b/frontend/src/metabase-types/api/card.ts
@@ -7,6 +7,7 @@ export interface Card extends UnsavedCard {
   name: string;
   description: string | null;
   dataset: boolean;
+  database_id?: number;
   can_write: boolean;
   cache_ttl: number | null;
   last_query_start: string | null;

--- a/frontend/src/metabase/containers/ActionPicker/ActionPicker.tsx
+++ b/frontend/src/metabase/containers/ActionPicker/ActionPicker.tsx
@@ -117,6 +117,7 @@ function ModelActionPicker({
       {isActionCreatorOpen && (
         <ActionCreator
           modelId={model.id}
+          databaseId={model.database_id}
           actionId={editingActionId}
           onClose={closeModal}
         />

--- a/frontend/src/metabase/models/components/ModelDetailPage/ModelActionDetails/ModelActionDetails.tsx
+++ b/frontend/src/metabase/models/components/ModelDetailPage/ModelActionDetails/ModelActionDetails.tsx
@@ -17,6 +17,7 @@ import type { WritebackAction } from "metabase-types/api";
 import type { State } from "metabase-types/store";
 
 import { ActionCreator } from "metabase/writeback/components/ActionCreator";
+import type Question from "metabase-lib/Question";
 
 import {
   EmptyStateContainer,
@@ -29,14 +30,14 @@ const mapDispatchToProps = {
 };
 
 interface Props {
-  modelId: number;
+  model: Question;
   actions: WritebackAction[];
   enableImplicitActionsForModel: (modelId: number) => void;
 }
 
 function ModelActionDetails({
   actions,
-  modelId,
+  model,
   enableImplicitActionsForModel,
 }: Props) {
   const [editingActionId, setEditingActionId] = useState<number | undefined>(
@@ -54,7 +55,7 @@ function ModelActionDetails({
   };
 
   const handleCreateImplicitActions = async () => {
-    await enableImplicitActionsForModel(modelId);
+    await enableImplicitActionsForModel(model.id());
   };
 
   const handleItemClick = useCallback(
@@ -83,7 +84,7 @@ function ModelActionDetails({
 
   return (
     <>
-      {!modelHasImplicitActions && modelId && (
+      {!modelHasImplicitActions && model?.id() && (
         <Button onClick={handleCreateImplicitActions} icon="add">
           {t`Enable implicit actions`}
         </Button>
@@ -110,7 +111,8 @@ function ModelActionDetails({
       </ul>
       {isActionCreatorOpen && (
         <ActionCreator
-          modelId={modelId}
+          modelId={model.id()}
+          databaseId={model.databaseId()}
           actionId={editingActionId}
           onClose={closeModal}
         />
@@ -129,8 +131,8 @@ const AddActionButton = ({ onClick }: { onClick: () => void }) => (
 
 export default Actions.loadList(
   {
-    query: (state: State, props: { modelId?: number | null }) => ({
-      "model-id": props?.modelId,
+    query: (state: State, props: { model?: Question }) => ({
+      "model-id": props?.model?.id(),
     }),
   },
   connect(null, mapDispatchToProps),

--- a/frontend/src/metabase/models/components/ModelDetailPage/ModelDetailPage.tsx
+++ b/frontend/src/metabase/models/components/ModelDetailPage/ModelDetailPage.tsx
@@ -91,7 +91,7 @@ function ModelDetailPage({ model, mainTable, onChangeModel }: Props) {
             <ModelSchemaDetails model={model} />
           </TabPanel>
           <TabPanel value="actions">
-            <ModelActionDetails modelId={model.id()} />
+            <ModelActionDetails model={model} />
           </TabPanel>
           <TabPanel value="apps">
             <ModelApps model={model} />

--- a/frontend/src/metabase/writeback/components/ActionCreator/ActionCreator.tsx
+++ b/frontend/src/metabase/writeback/components/ActionCreator/ActionCreator.tsx
@@ -60,6 +60,7 @@ interface ActionCreatorProps {
   question?: Question;
   actionId?: number;
   modelId?: number;
+  databaseId?: number;
   push: (url: string) => void;
   update: (action: ActionParams) => void;
   onClose?: () => void;
@@ -70,11 +71,12 @@ function ActionCreatorComponent({
   question: passedQuestion,
   actionId,
   modelId,
+  databaseId,
   update,
   onClose,
 }: ActionCreatorProps) {
   const [question, setQuestion] = useState(
-    passedQuestion ?? newQuestion(metadata),
+    passedQuestion ?? newQuestion(metadata, databaseId),
   );
   const [formSettings, setFormSettings] = useState<
     ActionFormSettings | undefined
@@ -85,7 +87,7 @@ function ActionCreatorComponent({
     useToggle(false);
 
   useEffect(() => {
-    setQuestion(passedQuestion ?? newQuestion(metadata));
+    setQuestion(passedQuestion ?? newQuestion(metadata, databaseId));
 
     // we do not want to update this any time the props or metadata change, only if action id changes
   }, [actionId]); // eslint-disable-line react-hooks/exhaustive-deps

--- a/frontend/src/metabase/writeback/components/ActionCreator/utils.ts
+++ b/frontend/src/metabase/writeback/components/ActionCreator/utils.ts
@@ -1,12 +1,12 @@
 import Question from "metabase-lib/Question";
 import type Metadata from "metabase-lib/metadata/Metadata";
 
-export const newQuestion = (metadata: Metadata) => {
+export const newQuestion = (metadata: Metadata, databaseId?: number) => {
   return new Question(
     {
       dataset_query: {
         type: "native",
-        database: null,
+        database: databaseId ?? null,
         native: {
           query: "",
         },


### PR DESCRIPTION
closes #26348 

## Description
Auto-selects database for the current model in the action creator

![dbSelect](https://user-images.githubusercontent.com/30528226/202010378-88d2ef7e-a846-4603-afde-b837bd2a6dfc.gif)

## Testing steps
In a data app
- open the action creation sidebar and select a `+` on a model to open the action creator. The db of the model should be selected y default.

In a model detail page
- select the actions tab and click "create a new action" The db of the model should be selected y default.
