### PR TITLE
Format date + time properly in action forms

### DIFF
--- a/frontend/src/metabase-lib/metadata/Field.ts
+++ b/frontend/src/metabase-lib/metadata/Field.ts
@@ -8,6 +8,7 @@ import type { FieldFingerprint } from "metabase-types/api/field";
 import type { Field as FieldRef } from "metabase-types/types/Query";
 import {
   isDate,
+  isDateWithoutTime,
   isTime,
   isNumber,
   isNumeric,
@@ -140,6 +141,10 @@ class FieldInner extends Base {
 
   isDate() {
     return isDate(this);
+  }
+
+  isDateWithoutTime() {
+    return isDateWithoutTime(this);
   }
 
   isTime() {

--- a/frontend/src/metabase/writeback/components/ActionCreator/FormCreator/constants.ts
+++ b/frontend/src/metabase/writeback/components/ActionCreator/FormCreator/constants.ts
@@ -77,14 +77,14 @@ export const getInputTypes = (): InputOptionsMap => ({
       value: "datetime",
       name: t`date + time`,
     },
-    {
-      value: "monthyear",
-      name: t`month + year`,
-    },
-    {
-      value: "quarteryear",
-      name: t`quarter + year`,
-    },
+    // {
+    //   value: "monthyear",
+    //   name: t`month + year`,
+    // },
+    // {
+    //   value: "quarteryear",
+    //   name: t`quarter + year`,
+    // },
   ],
   category: [...getSelectInputs()],
 });

--- a/frontend/src/metabase/writeback/components/ActionCreator/FormCreator/utils.ts
+++ b/frontend/src/metabase/writeback/components/ActionCreator/FormCreator/utils.ts
@@ -68,7 +68,7 @@ const fieldPropsTypeMap: FieldPropTypeMap = {
   string: "input",
   text: "text",
   date: "date",
-  datetime: "date",
+  datetime: "datetime-local",
   monthyear: "date",
   quarteryear: "date",
   email: "email",
@@ -112,10 +112,6 @@ export const getFormField = (
     fieldProps.options = fieldSettings.valueOptions?.length
       ? getOptionsFromArray(fieldSettings.valueOptions)
       : getSampleOptions();
-  }
-
-  if (fieldProps.type === "date") {
-    fieldProps.values = {};
   }
 
   return fieldProps;
@@ -223,7 +219,7 @@ export const getInputType = (param: Parameter, field?: Field) => {
     return "boolean";
   }
   if (field.isDate()) {
-    return "date";
+    return field.isDateWithoutTime() ? "date" : "datetime";
   }
   if (field.semantic_type === TYPE.Email) {
     return "email";

--- a/frontend/src/metabase/writeback/containers/ActionParametersInputForm/utils.ts
+++ b/frontend/src/metabase/writeback/containers/ActionParametersInputForm/utils.ts
@@ -1,3 +1,4 @@
+import moment from "moment-timezone";
 import { isEmpty } from "metabase/lib/validate";
 
 import type {
@@ -53,6 +54,15 @@ export const getInitialValues = (
   prefetchValues: ParametersForActionExecution,
 ) => {
   return Object.fromEntries(
-    form.fields.map(field => [field.name, prefetchValues[field.name] ?? ""]),
+    form.fields.map(field => {
+      const value = prefetchValues[field.name];
+      const formattedValue =
+        field.type === "date"
+          ? moment(value).format("YYYY-MM-DD")
+          : field.type === "datetime-local"
+          ? moment(value).format("YYYY-MM-DDThh:mm")
+          : value ?? "";
+      return [field.name, formattedValue];
+    }),
   );
 };

--- a/frontend/src/metabase/writeback/containers/ActionParametersInputForm/utils.ts
+++ b/frontend/src/metabase/writeback/containers/ActionParametersInputForm/utils.ts
@@ -48,21 +48,25 @@ export const getChangedValues = (
   return Object.fromEntries(changedValues);
 };
 
+const formatValue = (value: string | number, inputType?: string) => {
+  if (inputType === "date") {
+    return moment(value).format("YYYY-MM-DD");
+  }
+  if (inputType === "datetime-local") {
+    return moment(value).format("YYYY-MM-DD HH:mm:ss");
+  }
+  return value;
+};
+
 // maps intial values, if any, into an intialValues map
 export const getInitialValues = (
   form: ActionFormProps,
   prefetchValues: ParametersForActionExecution,
 ) => {
   return Object.fromEntries(
-    form.fields.map(field => {
-      const value = prefetchValues[field.name];
-      const formattedValue =
-        field.type === "date"
-          ? moment(value).utc(false).format("YYYY-MM-DD")
-          : field.type === "datetime-local"
-          ? moment(value).utc(false).format("YYYY-MM-DDTHH:mm")
-          : value ?? "";
-      return [field.name, formattedValue];
-    }),
+    form.fields.map(field => [
+      field.name,
+      formatValue(prefetchValues[field.name], field.type),
+    ]),
   );
 };

--- a/frontend/src/metabase/writeback/containers/ActionParametersInputForm/utils.ts
+++ b/frontend/src/metabase/writeback/containers/ActionParametersInputForm/utils.ts
@@ -58,9 +58,9 @@ export const getInitialValues = (
       const value = prefetchValues[field.name];
       const formattedValue =
         field.type === "date"
-          ? moment(value).format("YYYY-MM-DD")
+          ? moment(value).utc(false).format("YYYY-MM-DD")
           : field.type === "datetime-local"
-          ? moment(value).format("YYYY-MM-DDThh:mm")
+          ? moment(value).utc(false).format("YYYY-MM-DDTHH:mm")
           : value ?? "";
       return [field.name, formattedValue];
     }),


### PR DESCRIPTION
closes #26442

## Description

This is a band-aid fix for date editing that simply uses native date and [datetime-local](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/datetime-local) inputs in action forms. Datetime-local is a wonderful web primitive, but doesn't have awesome browser support in non-chromium browsers. Nonetheless, it makes dates actually editable in action forms for now.

Why not just fix it right and use a real, robust date component? I'm glad you asked. We're in the process of migrating all of our forms to formik, so as part of this process, we basically need to fork the old `FormWidget` component, and hook it up to all the new form components, including the new date component. This gets date forms basically working with minimal changes and doesn't waste time building date support into our old form framework. ([slack thread](https://metaboat.slack.com/archives/C049USTRF60/p1668543086349249?thread_ts=1668542534.542229&cid=C049USTRF60))

This also disables the quarter/year and month/year options for data parameters because we don't support those components yet.

![Screen Shot 2022-11-15 at 3 24 22 PM](https://user-images.githubusercontent.com/30528226/202038772-3b883972-b8ba-4b78-bc12-82a9b0ac5da7.png)

![Screen Shot 2022-11-15 at 2 38 52 PM](https://user-images.githubusercontent.com/30528226/202038811-fb1dd3b1-4f2c-4754-afb8-5f568cf487dc.png)

## Testing Steps

- Edit a detail record in the People table in the sample database
- see that when you open a record in the edit modal for the scaffolded action, the date populates and is editable
