### PR TITLE
[CI] Increase health check timeout

### DIFF
--- a/.github/workflows/uberjar.yml
+++ b/.github/workflows/uberjar.yml
@@ -106,7 +106,7 @@ jobs:
       run: docker ps
     - name: Wait for Metabase to start and reach 100% health
       run: while ! curl -s 'http://localhost:3000/api/health' | grep '{"status":"ok"}'; do sleep 1; done
-      timeout-minutes: 1
+      timeout-minutes: 3
     - name: Login to Docker Hub
       uses: docker/login-action@v1
       with:


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Increases the health check timeout in `uberjar` workflow as it started failing more and more often. Rerunning usually doesn't help

Example of a failure:
https://github.com/metabase/metabase/actions/runs/3478010782/jobs/5815119059