### PR TITLE
Wrap sidebar actions in Query Builder View Footer

### DIFF
--- a/frontend/src/metabase/query_builder/components/view/ViewFooter.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewFooter.jsx
@@ -83,7 +83,9 @@ const ViewFooter = ({
               result={result}
               active={isShowingChartTypeSidebar}
               onClick={
-                isShowingChartTypeSidebar ? onCloseChartType : onOpenChartType
+                isShowingChartTypeSidebar
+                  ? () => onCloseChartType()
+                  : () => onOpenChartType()
               }
             />
           ),
@@ -95,8 +97,8 @@ const ViewFooter = ({
               active={isShowingChartSettingsSidebar}
               onClick={
                 isShowingChartSettingsSidebar
-                  ? onCloseChartSettings
-                  : onOpenChartSettings
+                  ? () => onCloseChartSettings()
+                  : () => onOpenChartSettings()
               }
             />
           ),


### PR DESCRIPTION
I noticed when opening the viz settings sidebar my console would get flooded with console errors about trying to asynchronously access synthetic events, which would cause some stuttering and really pollute the console when I was actually looking for errors. This was caused by the event being passed to a redux action as the payload, and redux dev tools was examining the object after it had been cleaned up by React. In the case of `onOpenChartSettings`, we were also incorrectly storing the event object as the `initialChartSetting`, which is meant to be the starting tab in `<ChartSettings />`. This small fix resolves the issue, whether you have redux dev tools open or not.