### PR TITLE
BE endpoint to clear group memberships

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/api/group_manager_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/api/group_manager_test.clj
@@ -90,6 +90,16 @@
                                                                           :group_id (:id group-info)}]]
                   (mt/user-http-request user :delete status (format "permissions/membership/%d" pgm-id)))))
 
+            (clear-memberships [user status group-info]
+              (testing (format ", clearing group memberships with %s user" (mt/user-descriptor :crowberto))
+                (mt/with-temp* [User                       [user-info-1]
+                                User                       [user-info-2]
+                                PermissionsGroupMembership [_ {:user_id  (:id user-info-1)
+                                                               :group_id (:id group-info)}]
+                                PermissionsGroupMembership [_ {:user_id  (:id user-info-2)
+                                                               :group_id (:id group-info)}]]
+                  (mt/user-http-request user :put status (format "permissions/membership/%d/clear" (:id group-info))))))
+
             (membership->groups-ids [membership]
               (->> membership
                    vals
@@ -107,11 +117,17 @@
               (add-membership user 403 group false)
               (update-membership user 402 group false)
               (delete-membership user 403 group)
+              (clear-memberships user 403 group)
               (get-membership :crowberto 200)
               (add-membership :crowberto 200 group false)
               (update-membership :crowberto 402 group false)
-              (delete-membership :crowberto 204 group)))
+              (delete-membership :crowberto 204 group)
+              (clear-memberships :crowberto 204 group))))
 
+        ;; Use different groups for each block since `clear-memberships` is destructive
+        (mt/with-user-in-groups
+          [group  {:name "New Group"}
+           user   [group]]
           (testing "if `advanced-permissions` is enabled"
             (premium-features-test/with-premium-features #{:advanced-permissions}
               (testing "requires Group Manager or admins"
@@ -119,19 +135,25 @@
                 (add-membership user 403 group false)
                 (update-membership user 403 group false)
                 (delete-membership user 403 group)
+                (clear-memberships user 403 group)
                 (get-membership :crowberto 200)
                 (add-membership :crowberto 200 group false)
                 (update-membership :crowberto 200 group false)
-                (delete-membership :crowberto 204 group))
+                (delete-membership :crowberto 204 group)
+                (clear-memberships :crowberto 204 group))
 
-              (testing "succeed if users access group that they are manager of"
-                (db/update-where! PermissionsGroupMembership {:user_id  (:id user)
-                                                              :group_id (:id group)}
-                                  :is_group_manager true)
-                (get-membership user 200)
-                (add-membership user 200 group false)
-                (update-membership user 200 group false)
-                (delete-membership user 204 group))))))
+              (mt/with-user-in-groups
+                [group-2  {:name "New Group 2"}
+                 user-2   [group-2]]
+                (testing "succeed if users access group that they are manager of"
+                  (db/update-where! PermissionsGroupMembership {:user_id  (:id user-2)
+                                                                :group_id (:id group-2)}
+                                    :is_group_manager true)
+                  (get-membership user-2 200)
+                  (add-membership user-2 200 group-2 false)
+                  (update-membership user-2 200 group-2 false)
+                  (delete-membership user-2 204 group-2)
+                  (clear-memberships user-2 204 group-2)))))))
 
       (testing "edge case tests - "
         (mt/with-user-in-groups
@@ -201,27 +223,27 @@
 
   (testing "GET /api/user?group_id=:group_id"
     (testing "should sort by admins -> group managers -> normal users when filter by group_id"
-    (mt/with-temp* [User                       [user-a {:first_name "A"
-                                                        :last_name  "A"}]
-                    User                       [user-b {:first_name "B"
-                                                        :last_name  "B"}]
-                    User                       [user-c {:first_name "C"
-                                                        :last_name  "C"
-                                                        :is_superuser true}]
-                    PermissionsGroup           [group]
-                    PermissionsGroupMembership [_ {:user_id (:id user-a)
-                                                   :group_id (:id group)
-                                                   :is_group_manager false}]
-                    PermissionsGroupMembership [_ {:user_id  (:id user-b)
-                                                   :group_id (:id group)
-                                                   :is_group_manager true}]
-                    PermissionsGroupMembership [_ {:user_id  (:id user-c)
-                                                   :group_id (:id group)
-                                                   :is_group_manager false}]]
-      (is (= ["C" "B" "A"]
-             (->> (mt/user-http-request :crowberto :get 200 (format "/user?limit=25&offset=0&group_id=%d" (:id group)))
-                  :data
-                  (map :first_name))))))))
+     (mt/with-temp* [User                       [user-a {:first_name "A"
+                                                         :last_name  "A"}]
+                     User                       [user-b {:first_name "B"
+                                                         :last_name  "B"}]
+                     User                       [user-c {:first_name "C"
+                                                         :last_name  "C"
+                                                         :is_superuser true}]
+                     PermissionsGroup           [group]
+                     PermissionsGroupMembership [_ {:user_id (:id user-a)
+                                                    :group_id (:id group)
+                                                    :is_group_manager false}]
+                     PermissionsGroupMembership [_ {:user_id  (:id user-b)
+                                                    :group_id (:id group)
+                                                    :is_group_manager true}]
+                     PermissionsGroupMembership [_ {:user_id  (:id user-c)
+                                                    :group_id (:id group)
+                                                    :is_group_manager false}]]
+       (is (= ["C" "B" "A"]
+              (->> (mt/user-http-request :crowberto :get 200 (format "/user?limit=25&offset=0&group_id=%d" (:id group)))
+                   :data
+                   (map :first_name))))))))
 
 
 (deftest get-user-api-test
@@ -269,13 +291,13 @@
                   (db/delete! PermissionsGroupMembership
                               :user_id (:id user-to-update)
                               :group_id (:id group-to-add))
-                    (let [current-user-group-membership (gm/user-group-memberships user-to-update)
-                          new-user-group-membership     (conj current-user-group-membership
-                                                              {:id               (:id group-to-add)
-                                                               :is_group_manager true})]
-                      (testing (format "- add user to group with %s user" (mt/user-descriptor user))
-                        (mt/user-http-request req-user :put status (format "user/%d" (:id user-to-update))
-                                              {:user_group_memberships new-user-group-membership}))))
+                  (let [current-user-group-membership (gm/user-group-memberships user-to-update)
+                        new-user-group-membership     (conj current-user-group-membership
+                                                            {:id               (:id group-to-add)
+                                                             :is_group_manager true})]
+                    (testing (format "- add user to group with %s user" (mt/user-descriptor user))
+                      (mt/user-http-request req-user :put status (format "user/%d" (:id user-to-update))
+                                            {:user_group_memberships new-user-group-membership}))))
 
                 (remove-user-from-group [req-user status group-to-remove]
                   (u/ignore-exceptions
@@ -283,13 +305,13 @@
                    (db/insert! PermissionsGroupMembership
                                :user_id (:id user-to-update)
                                :group_id (:id group-to-remove)))
-                    (let [current-user-group-membership (gm/user-group-memberships user-to-update)
-                          new-user-group-membership     (into [] (filter #(not= (:id group-to-remove)
-                                                                                (:id %))
-                                                                         current-user-group-membership))]
-                      (testing (format "- remove user from group with %s user" (mt/user-descriptor user))
-                        (mt/user-http-request req-user :put status (format "user/%d" (:id user-to-update))
-                                              {:user_group_memberships new-user-group-membership}))))]
+                  (let [current-user-group-membership (gm/user-group-memberships user-to-update)
+                        new-user-group-membership     (into [] (filter #(not= (:id group-to-remove)
+                                                                              (:id %))
+                                                                       current-user-group-membership))]
+                    (testing (format "- remove user from group with %s user" (mt/user-descriptor user))
+                      (mt/user-http-request req-user :put status (format "user/%d" (:id user-to-update))
+                                            {:user_group_memberships new-user-group-membership}))))]
 
 
           (testing "if `advanced-permissions` is disabled, requires admins"

--- a/src/metabase/api/permissions.clj
+++ b/src/metabase/api/permissions.clj
@@ -205,6 +205,14 @@
                 :is_group_manager is_group_manager)
     (db/select-one PermissionsGroupMembership :id (:id old))))
 
+(api/defendpoint PUT "/membership/:group-id/clear"
+  "Remove all members from a `PermissionsGroup`."
+  [group-id]
+  (validation/check-manager-of-group group-id)
+  (api/check-404 (db/exists? PermissionsGroup :id group-id))
+  (db/delete! PermissionsGroupMembership :group_id group-id)
+  api/generic-204-no-content)
+
 (api/defendpoint DELETE "/membership/:id"
   "Remove a User from a PermissionsGroup (delete their membership)."
   [id]


### PR DESCRIPTION
Pursuant to this project: https://www.notion.so/metabase/Make-SSO-group-mapping-clearer-b9ed33e4ee8c4facb2220f20b565e51f

We are introducing a new UX which prompts an admin who is unmapping an SSO group whether they want to additionally remove existing users from the group, or delete the group entirely. This new endpoint is necessary to power the former option.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/26555)
<!-- Reviewable:end -->
