### PR TITLE
Update how we handle autocomplete and format for zero-arity functions in ExpressionEditor

### DIFF
--- a/frontend/src/metabase-lib/expressions/format.js
+++ b/frontend/src/metabase-lib/expressions/format.js
@@ -112,7 +112,7 @@ function formatFunction([fn, ...args], options) {
   const formattedName = getExpressionName(fn);
   const formattedArgs = args.map(arg => format(arg, options));
   return args.length === 0
-    ? formattedName
+    ? formattedName + "()"
     : `${formattedName}(${formattedArgs.join(", ")})`;
 }
 

--- a/frontend/src/metabase-lib/expressions/suggest.js
+++ b/frontend/src/metabase-lib/expressions/suggest.js
@@ -16,11 +16,7 @@ import {
   formatSegmentName,
 } from "./index";
 
-const suggestionText = func => {
-  const { displayName, args } = func;
-  const suffix = args.length > 0 ? "(" : " ";
-  return displayName + suffix;
-};
+const suggestionText = func => func.displayName + "(";
 
 export function suggest({
   source,

--- a/frontend/src/metabase-lib/expressions/suggest.js
+++ b/frontend/src/metabase-lib/expressions/suggest.js
@@ -16,7 +16,11 @@ import {
   formatSegmentName,
 } from "./index";
 
-const suggestionText = func => func.displayName + "(";
+const suggestionText = func => {
+  const { displayName, args } = func;
+  const suffix = args.length > 0 ? "(" : "()";
+  return displayName + suffix;
+};
 
 export function suggest({
   source,

--- a/frontend/src/metabase-lib/expressions/suggest.js
+++ b/frontend/src/metabase-lib/expressions/suggest.js
@@ -16,11 +16,7 @@ import {
   formatSegmentName,
 } from "./index";
 
-const suggestionText = func => {
-  const { displayName, args } = func;
-  const suffix = args.length > 0 ? "(" : "()";
-  return displayName + suffix;
-};
+const suggestionText = func => func.displayName + "(";
 
 export function suggest({
   source,


### PR DESCRIPTION
### 1.
When accepting autocomplete suggestions for `now` (in Custom Column), or for `Count`/`CumulativeCount` (in Summarize), added function name will have an opening parenthesis add, as in `now(`.

This will keep the behaviour consistent with function with different arities, displaying the helper popup.

### 2.

When going back to an added Custom Column or Summarize definition, that is, reopening the ExpressionEditor popover, zero-arity functions will always be displayed with appended `()`.