### PR TITLE
Fix feedback on dashcard resizing

### DIFF
--- a/frontend/src/metabase/visualizations/components/CardRenderer.jsx
+++ b/frontend/src/metabase/visualizations/components/CardRenderer.jsx
@@ -106,5 +106,11 @@ class CardRenderer extends Component {
 
 export default ExplicitSize({
   wrapped: true,
-  refreshMode: props => (props.isDashboard ? "debounceLeading" : "throttle"),
+  refreshMode: props => {
+    const { isDashboard, isEditing } = props;
+    if (isDashboard) {
+      return isEditing ? "debounce" : "debounceLeading";
+    }
+    return "throttle";
+  },
 })(CardRenderer);


### PR DESCRIPTION
This should hopefully fix an issue with re-rendering visualizations on dashboard card resize. The fix reverts `ExplicitSize's` `resizeMode` to "debounce" in dashboard editing mode. Other states should stay the same ("debounceLeading" for dashboard view mode, "throttle" anywhere else)

### Demo

https://user-images.githubusercontent.com/17258145/202452105-97c1effb-d115-406a-8c36-c0e6dc8acaf4.mp4

