### PR TITLE
Preview Actions in Viz Settings Modal

### DIFF
--- a/frontend/src/metabase/dashboard/components/DashCard.jsx
+++ b/frontend/src/metabase/dashboard/components/DashCard.jsx
@@ -228,6 +228,7 @@ export default class DashCard extends Component {
               isPreviewing={this.state.isPreviewingCard}
               onPreviewToggle={this.handlePreviewToggle}
               dashboard={dashboard}
+              dashcard={dashcard}
             />
           </DashboardCardActionsPanel>
         ) : null}
@@ -362,6 +363,7 @@ const DashCardActionButtons = ({
   onPreviewToggle,
   isPreviewing,
   dashboard,
+  dashcard,
 }) => {
   const analyticsContext = dashboard.is_app_page
     ? "Data App Page"
@@ -390,6 +392,7 @@ const DashCardActionButtons = ({
           series={series}
           onReplaceAllVisualizationSettings={onReplaceAllVisualizationSettings}
           dashboard={dashboard}
+          dashcard={dashcard}
         />,
       );
     }
@@ -438,6 +441,7 @@ const ChartSettingsButton = ({
   series,
   onReplaceAllVisualizationSettings,
   dashboard,
+  dashcard,
 }) => (
   <ModalWithTrigger
     wide
@@ -460,6 +464,7 @@ const ChartSettingsButton = ({
       onChange={onReplaceAllVisualizationSettings}
       isDashboard
       dashboard={dashboard}
+      dashcard={dashcard}
     />
   </ModalWithTrigger>
 );

--- a/frontend/src/metabase/visualizations/components/ChartSettings.jsx
+++ b/frontend/src/metabase/visualizations/components/ChartSettings.jsx
@@ -243,8 +243,15 @@ class ChartSettings extends Component {
   };
 
   render() {
-    const { className, question, addField, noPreview, dashboard, isDashboard } =
-      this.props;
+    const {
+      className,
+      question,
+      addField,
+      noPreview,
+      dashboard,
+      isDashboard,
+      dashcard,
+    } = this.props;
     const { currentWidget, popoverRef } = this.state;
 
     const settings = this._getSettings();
@@ -389,6 +396,7 @@ class ChartSettings extends Component {
                   isEditing
                   isDashboard
                   dashboard={dashboard}
+                  dashcard={dashcard}
                   isSettings
                   showWarnings
                   onUpdateVisualizationSettings={this.handleChangeSettings}

--- a/frontend/src/metabase/writeback/components/ActionViz/Action.tsx
+++ b/frontend/src/metabase/writeback/components/ActionViz/Action.tsx
@@ -44,10 +44,9 @@ function ActionComponent({
   onVisualizationClick,
   parameterValues,
 }: ActionProps) {
-  const dashcardSettings = dashcard.visualization_settings;
   const actionSettings = dashcard.action?.visualization_settings;
   const actionDisplayType =
-    dashcardSettings?.actionDisplayType ?? actionSettings?.type ?? "button";
+    settings?.actionDisplayType ?? actionSettings?.type ?? "button";
 
   const dashcardParamValues = useMemo(
     () => getDashcardParamValues(dashcard, parameterValues),
@@ -95,14 +94,20 @@ function ActionComponent({
     [page, dashcard, dashcardParamValues, dispatch, shouldDisplayButton],
   );
 
+  const showParameterMapper = isEditing && !isSettings;
+
   if (dashcard.action) {
     return (
       <>
-        {isEditing && <ActionParameterMapper dashcard={dashcard} page={page} />}
+        {showParameterMapper && (
+          <ActionParameterMapper dashcard={dashcard} page={page} />
+        )}
         <ActionForm
           onSubmit={onSubmit}
           dashcard={dashcard}
           page={page}
+          settings={settings}
+          isSettings={isSettings}
           missingParameters={missingParameters}
           dashcardParamValues={dashcardParamValues}
           action={dashcard.action as WritebackQueryAction}

--- a/frontend/src/metabase/writeback/components/ActionViz/ActionForm.tsx
+++ b/frontend/src/metabase/writeback/components/ActionViz/ActionForm.tsx
@@ -8,6 +8,7 @@ import type {
   ActionDashboardCard,
   ParametersForActionExecution,
   DataAppPage,
+  VisualizationSettings,
 } from "metabase-types/api";
 import { getFormTitle } from "metabase/writeback/components/ActionCreator/FormCreator";
 
@@ -24,6 +25,8 @@ import {
 interface ActionFormProps {
   onSubmit: OnSubmitActionForm;
   dashcard: ActionDashboardCard;
+  settings: VisualizationSettings;
+  isSettings: boolean;
   page: DataAppPage;
   missingParameters: WritebackParameter[];
   dashcardParamValues: ParametersForActionExecution;
@@ -34,6 +37,8 @@ interface ActionFormProps {
 function ActionForm({
   onSubmit,
   dashcard,
+  settings,
+  isSettings,
   page,
   missingParameters,
   dashcardParamValues,
@@ -68,7 +73,8 @@ function ActionForm({
       <>
         <ActionButtonView
           onClick={onClick}
-          settings={dashcard.visualization_settings}
+          settings={settings}
+          isFullHeight={!isSettings}
         />
         {showModal && (
           <ActionParametersInputModal

--- a/frontend/src/metabase/writeback/components/ActionViz/ActionViz.tsx
+++ b/frontend/src/metabase/writeback/components/ActionViz/ActionViz.tsx
@@ -1,5 +1,9 @@
 import { t } from "ttag";
+import type { VisualizationSettings } from "metabase-types/api";
 import Action from "./Action";
+
+const isForm = (object: any, computedSettings: VisualizationSettings) =>
+  computedSettings.actionDisplayType === "form";
 
 export default Object.assign(Action, {
   uiName: t`Action`,
@@ -38,12 +42,14 @@ export default Object.assign(Action, {
       section: t`Display`,
       title: t`Label`,
       widget: "input",
+      getHidden: isForm,
     },
     "button.variant": {
       section: t`Display`,
       title: t`Variant`,
       widget: "select",
       default: "primary",
+      getHidden: isForm,
       props: {
         options: [
           { name: t`Primary`, value: "primary" },


### PR DESCRIPTION
closes #26449

## Description
- Properly preview action buttons and forms in viz settings modal
- hide button-related viz settings when the action type is form

![actionVizSettings](https://user-images.githubusercontent.com/30528226/202566607-a6c8a472-695f-47ad-9830-6d4ba4bdc361.gif)
