### PR TITLE
Funnel Static-viz Order not respected fix

### DIFF
--- a/dev/src/dev/render_png.clj
+++ b/dev/src/dev/render_png.clj
@@ -65,16 +65,15 @@
     (.deleteOnExit tmp-file)
     (open tmp-file)))
 
-(defn open-hiccup-as-html [hiccup]
-  (let [html-str (hiccup/html hiccup)
+(defn open-hiccup-as-html [hiccup]  (let [html-str (hiccup/html hiccup)
         tmp-file (java.io.File/createTempFile "card-html" ".html")]
     (with-open [w (clojure.java.io/writer tmp-file)]
       (.write w html-str))
     (.deleteOnExit tmp-file)
     (open tmp-file)))
-    
+
 (comment
-  (render-card-to-png 1) 
+  (render-card-to-png 1)
   ;; open viz in your browser
   (-> [["A" "B"]
        [1 2]


### PR DESCRIPTION
This is a small change to funnel static-viz that applies the correct order, visibility, and name to the funnel steps, by ensuring the viz-settings are properly used on the backend before sending the funnel-steps data to the static-viz js.