### PR TITLE
Retrofit the release workflow to be useful for doing a pre-release

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -12,6 +12,7 @@ env:
 
 jobs:
   build:
+    if: ${{ github.repository }} != 'metabase/metabase'
     name: Build Metabase ${{ matrix.edition }} @${{ github.event.inputs.commit }}
     runs-on: ubuntu-20.04
     timeout-minutes: 40
@@ -102,12 +103,12 @@ jobs:
         context: bin/docker/.
         platforms: linux/amd64
         network: host
-        tags: localhost:5000/local-metabase:${{ env.COMMIT_IDENTIFIER }}
+        tags: localhost:5000/local-metabase:${{ env.COMMIT_IDENTIFIER }}-${{ matrix.edition }}
         no-cache: true
         push: true
 
     - name: Launch container
-      run: docker run --rm -dp 3000:3000 localhost:5000/local-metabase:${{ env.COMMIT_IDENTIFIER }}
+      run: docker run --rm -dp 3000:3000 localhost:5000/local-metabase:${{ env.COMMIT_IDENTIFIER }}-${{ matrix.edition }}
       timeout-minutes: 5
     - name: Wait for Metabase to start
       run: while ! curl -s 'http://localhost:3000/api/health' | grep '{"status":"ok"}'; do sleep 1; done
@@ -120,23 +121,13 @@ jobs:
         password: ${{ secrets.DOCKERHUB_RELEASE_TOKEN }}
     - name: Determine the target Docker Hub repository
       run: |
-        if [[ ${{ matrix.edition }} == ee ]]; then
-          docker_image="metabase_enterprise:${{ env.COMMIT_IDENTIFIER }}"
-        else
-          docker_image="metabase:${{ env.COMMIT_IDENTIFIER }}"
-        fi
-
-        if [[ ${{ github.repository }} == 'metabase/metabase' ]]; then
-          echo "Metabase ${{ matrix.edition }}: image is going to be pushed to metabase/$docker_image"
-          echo "DOCKERHUB_REPO=metabase/$docker_image" >> $GITHUB_ENV
-        else
-          echo "DOCKERHUB_REPO=${{ github.repository_owner }}/${{ secrets.CUSTOM_RELEASE_REPO }}:${{ env.COMMIT_IDENTIFIER }}-${{ matrix-edition }}" >> $GITHUB_ENV
-        fi
+          echo "DOCKERHUB_REPO=${{ github.repository_owner }}/${{ secrets.CUSTOM_RELEASE_REPO }}" >> $GITHUB_ENV
+          echo "IMAGE_NAME=${{ env.COMMIT_IDENTIFIER }}-${{ matrix-edition }}" >> $GITHUB_ENV
     - name: Retag and push container image to Docker Hub
       run: |
-        echo "Pushing container image ${{ env.DOCKERHUB_REPO }} ..."
-        docker tag localhost:5000/local-metabase:${{ env.COMMIT_IDENTIFIER }} ${{ env.DOCKERHUB_REPO }}
-        docker push ${{ env.DOCKERHUB_REPO }}
+        echo "Pushing container image ${{ env.IMAGE_NAME}} to ${{ env.DOCKERHUB_REPO }} ..."
+        docker tag localhost:5000/local-metabase:${{ env.IMAGE_NAME }} ${{ env.DOCKERHUB_REPO }}:${{ env.IMAGE_NAME }}
+        docker push ${{ env.DOCKERHUB_REPO }}:${{ env.IMAGE_NAME }}
         echo "Finished!"
 
   verify-docker-pull:
@@ -161,24 +152,15 @@ jobs:
         password: ${{ secrets.DOCKERHUB_RELEASE_TOKEN }}
     - name: Determine the container image to pull
       run: |
-        if [[ ${{ matrix.edition }} == ee ]]; then
-          docker_image="metabase_enterprise:${{ env.COMMIT_IDENTIFIER }}"
-        else
-          docker_image="metabase:${{ env.COMMIT_IDENTIFIER }}"
-        fi
-
-        if [[ ${{ github.repository }} == 'metabase/metabase' ]]; then
-          echo "DOCKERHUB_REPO=metabase/$docker_image" >> $GITHUB_ENV
-        else
-          echo "DOCKERHUB_REPO=${{ github.repository_owner }}/${{ secrets.CUSTOM_RELEASE_REPO }}:${{ env.COMMIT_IDENTIFIER }}-${{ matrix-edition }}" >> $GITHUB_ENV
-        fi
+          echo "DOCKERHUB_REPO=${{ github.repository_owner }}/${{ secrets.CUSTOM_RELEASE_REPO }}" >> $GITHUB_ENV
+          echo "IMAGE_NAME=${{ env.COMMIT_IDENTIFIER }}-${{ matrix-edition }}" >> $GITHUB_ENV
     - name: Pull the container image
       run: |
-        echo "Pulling container image ${{ env.DOCKERHUB_REPO }} ..."
-        docker pull ${{ env.DOCKERHUB_REPO }}
+        echo "Pulling container image ${{ env.DOCKERHUB_REPO }}:${{ env.IMAGE_NAME }} ..."
+        docker pull ${{ env.DOCKERHUB_REPO }}:${{ env.IMAGE_NAME }}
         echo "Successful!"
     - name: Launch container
-      run: docker run --rm -dp 3000:3000 ${{ env.DOCKERHUB_REPO }}
+      run: docker run --rm -dp 3000:3000 ${{ env.DOCKERHUB_REPO }}:${{ env.IMAGE_NAME }}
       timeout-minutes: 5
     - name: Wait for Metabase to start
       run: while ! curl -s 'http://localhost:3000/api/health' | grep '{"status":"ok"}'; do sleep 1; done

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -7,6 +7,9 @@ on:
         description: 'A commit hash'
         required: true
 
+env:
+  MAX_HASH_LENGTH: 8
+
 jobs:
   build:
     name: Build Metabase ${{ matrix.edition }} @${{ github.event.inputs.commit }}
@@ -75,6 +78,13 @@ jobs:
       uses: actions/checkout@v3
     - name: Switch to commit ${{ github.event.inputs.commit }}
       run: git checkout ${{ github.event.inputs.commit }}
+    - name: Truncate commit hash
+      run: |
+        commit_id=${{ github.event.inputs.commit }}
+        truncated_hash=${commit_id:0:${{ env.MAX_HASH_LENGTH }}}
+
+        echo "COMMMIT_IDENTIFIER=$truncated_hash" >> $GITHUB_ENV
+      shell: bash
     - uses: actions/download-artifact@v3
       name: Retrieve uberjar artifact
       with:
@@ -92,12 +102,12 @@ jobs:
         context: bin/docker/.
         platforms: linux/amd64
         network: host
-        tags: localhost:5000/local-metabase:${{ github.event.inputs.commit }}
+        tags: localhost:5000/local-metabase:${{ env.COMMIT_IDENTIFIER }}
         no-cache: true
         push: true
 
     - name: Launch container
-      run: docker run --rm -dp 3000:3000 localhost:5000/local-metabase:${{ github.event.inputs.commit }}
+      run: docker run --rm -dp 3000:3000 localhost:5000/local-metabase:${{ env.COMMIT_IDENTIFIER }}
       timeout-minutes: 5
     - name: Wait for Metabase to start
       run: while ! curl -s 'http://localhost:3000/api/health' | grep '{"status":"ok"}'; do sleep 1; done
@@ -111,21 +121,21 @@ jobs:
     - name: Determine the target Docker Hub repository
       run: |
         if [[ ${{ matrix.edition }} == ee ]]; then
-          docker_image="metabase_enterprise:${{ github.event.inputs.commit }}"
+          docker_image="metabase_enterprise:${{ env.COMMIT_IDENTIFIER }}"
         else
-          docker_image="metabase:${{ github.event.inputs.commit }}"
+          docker_image="metabase:${{ env.COMMIT_IDENTIFIER }}"
         fi
 
         if [[ ${{ github.repository }} == 'metabase/metabase' ]]; then
           echo "Metabase ${{ matrix.edition }}: image is going to be pushed to metabase/$docker_image"
           echo "DOCKERHUB_REPO=metabase/$docker_image" >> $GITHUB_ENV
         else
-          echo "DOCKERHUB_REPO=${{ github.repository_owner }}/${{ secrets.CUSTOM_RELEASE_REPO }}:${{ github.event.inputs.commit }}-${{ matrix-edition }}" >> $GITHUB_ENV
+          echo "DOCKERHUB_REPO=${{ github.repository_owner }}/${{ secrets.CUSTOM_RELEASE_REPO }}:${{ env.COMMIT_IDENTIFIER }}-${{ matrix-edition }}" >> $GITHUB_ENV
         fi
     - name: Retag and push container image to Docker Hub
       run: |
         echo "Pushing container image ${{ env.DOCKERHUB_REPO }} ..."
-        docker tag localhost:5000/local-metabase:${{ github.event.inputs.commit }} ${{ env.DOCKERHUB_REPO }}
+        docker tag localhost:5000/local-metabase:${{ env.COMMIT_IDENTIFIER }} ${{ env.DOCKERHUB_REPO }}
         docker push ${{ env.DOCKERHUB_REPO }}
         echo "Finished!"
 
@@ -137,6 +147,13 @@ jobs:
       matrix:
         edition: [oss, ee]
     steps:
+    - name: Truncate commit hash
+      run: |
+        commit_id=${{ github.event.inputs.commit }}
+        truncated_hash=${commit_id:0:${{ env.MAX_HASH_LENGTH }}}
+
+        echo "COMMMIT_IDENTIFIER=$truncated_hash" >> $GITHUB_ENV
+      shell: bash
     - name: Login to Docker Hub # authenticated, to avoid being rate-throttled
       uses: docker/login-action@v2
       with:
@@ -145,15 +162,15 @@ jobs:
     - name: Determine the container image to pull
       run: |
         if [[ ${{ matrix.edition }} == ee ]]; then
-          docker_image="metabase_enterprise:${{ github.event.inputs.commit }}"
+          docker_image="metabase_enterprise:${{ env.COMMIT_IDENTIFIER }}"
         else
-          docker_image="metabase:${{ github.event.inputs.commit }}"
+          docker_image="metabase:${{ env.COMMIT_IDENTIFIER }}"
         fi
 
         if [[ ${{ github.repository }} == 'metabase/metabase' ]]; then
           echo "DOCKERHUB_REPO=metabase/$docker_image" >> $GITHUB_ENV
         else
-          echo "DOCKERHUB_REPO=${{ github.repository_owner }}/${{ secrets.CUSTOM_RELEASE_REPO }}:${{ github.event.inputs.commit }}-${{ matrix-edition }}" >> $GITHUB_ENV
+          echo "DOCKERHUB_REPO=${{ github.repository_owner }}/${{ secrets.CUSTOM_RELEASE_REPO }}:${{ env.COMMIT_IDENTIFIER }}-${{ matrix-edition }}" >> $GITHUB_ENV
         fi
     - name: Pull the container image
       run: |

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -111,11 +111,16 @@ jobs:
     - name: Determine the target Docker Hub repository
       run: |
         if [[ ${{ matrix.edition }} == ee ]]; then
-          echo "Metabase EE: image is going to be pushed to ${{ github.repository_owner }}/metabase-enterprise:${{ github.event.inputs.commit }}"
-          echo "DOCKERHUB_REPO=${{ github.repository_owner }}/metabase-enterprise:${{ github.event.inputs.commit }}" >> $GITHUB_ENV
+          docker_image="metabase_enterprise:${{ github.event.inputs.commit }}"
         else
-          echo "Metabase OSS: image is going to be pushed to ${{ github.repository_owner }}/metabase:${{ github.event.inputs.commit }}"
-          echo "DOCKERHUB_REPO=${{ github.repository_owner }}/metabase:${{ github.event.inputs.commit }}" >> $GITHUB_ENV
+          docker_image="metabase:${{ github.event.inputs.commit }}"
+        fi
+
+        if [[ ${{ github.repository }} == 'metabase/metabase' ]]; then
+          echo "Metabase ${{ matrix.edition }}: image is going to be pushed to metabase/$docker_image"
+          echo "DOCKERHUB_REPO=metabase/$docker_image" >> $GITHUB_ENV
+        else
+          echo "DOCKERHUB_REPO=${{ github.repository_owner }}/${{ secrets.CUSTOM_RELEASE_REPO }}:${{ github.event.inputs.commit }}-${{ matrix-edition }}" >> $GITHUB_ENV
         fi
     - name: Retag and push container image to Docker Hub
       run: |
@@ -140,9 +145,15 @@ jobs:
     - name: Determine the container image to pull
       run: |
         if [[ ${{ matrix.edition }} == ee ]]; then
-          echo "DOCKERHUB_REPO=${{ github.repository_owner }}/metabase-enterprise:${{ github.event.inputs.commit }}" >> $GITHUB_ENV
+          docker_image="metabase_enterprise:${{ github.event.inputs.commit }}"
         else
-          echo "DOCKERHUB_REPO=${{ github.repository_owner }}/metabase:${{ github.event.inputs.commit }}" >> $GITHUB_ENV
+          docker_image="metabase:${{ github.event.inputs.commit }}"
+        fi
+
+        if [[ ${{ github.repository }} == 'metabase/metabase' ]]; then
+          echo "DOCKERHUB_REPO=metabase/$docker_image" >> $GITHUB_ENV
+        else
+          echo "DOCKERHUB_REPO=${{ github.repository_owner }}/${{ secrets.CUSTOM_RELEASE_REPO }}:${{ github.event.inputs.commit }}-${{ matrix-edition }}" >> $GITHUB_ENV
         fi
     - name: Pull the container image
       run: |

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -9,6 +9,7 @@ on:
 
 env:
   MAX_HASH_LENGTH: 8
+  CUSTOM_REPO: ${{ secrets.CUSTOM_RELEASE_REPO }}
 
 jobs:
   build:
@@ -63,6 +64,7 @@ jobs:
       run: while ! curl -s 'http://localhost:3000/api/health' | grep '{"status":"ok"}'; do sleep 1; done
 
   containerize:
+    if: env.CUSTOM_REPO != null
     runs-on: ubuntu-20.04
     needs: check-uberjar-health
     timeout-minutes: 15
@@ -121,7 +123,7 @@ jobs:
         password: ${{ secrets.DOCKERHUB_RELEASE_TOKEN }}
     - name: Determine the target Docker Hub repository
       run: |
-          echo "DOCKERHUB_REPO=${{ github.repository_owner }}/${{ secrets.CUSTOM_RELEASE_REPO }}" >> $GITHUB_ENV
+          echo "DOCKERHUB_REPO=${{ github.repository_owner }}/${{ env.CUSTOM_REPO }}" >> $GITHUB_ENV
           echo "IMAGE_NAME=${{ env.COMMIT_IDENTIFIER }}-${{ matrix-edition }}" >> $GITHUB_ENV
     - name: Retag and push container image to Docker Hub
       run: |
@@ -152,7 +154,7 @@ jobs:
         password: ${{ secrets.DOCKERHUB_RELEASE_TOKEN }}
     - name: Determine the container image to pull
       run: |
-          echo "DOCKERHUB_REPO=${{ github.repository_owner }}/${{ secrets.CUSTOM_RELEASE_REPO }}" >> $GITHUB_ENV
+          echo "DOCKERHUB_REPO=${{ github.repository_owner }}/${{ env.CUSTOM_REPO }}" >> $GITHUB_ENV
           echo "IMAGE_NAME=${{ env.COMMIT_IDENTIFIER }}-${{ matrix-edition }}" >> $GITHUB_ENV
     - name: Pull the container image
       run: |

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -1,16 +1,10 @@
-name: Release [WIP]
+name: Pre-release [WIP]
 
 on:
   workflow_dispatch:
     inputs:
       commit:
         description: 'A commit hash'
-        required: true
-      oss-tag:
-        description: 'OSS version tag'
-        required: true
-      ee-tag:
-        description: 'EE version tag'
         required: true
 
 jobs:
@@ -27,8 +21,8 @@ jobs:
     steps:
     - name: Check out the code
       uses: actions/checkout@v3
-      with:
-        ref: ${{ github.event.inputs.commit }}
+    - name: Switch to commit ${{ github.event.inputs.commit }}
+      run: git checkout ${{ github.event.inputs.commit }}
     - name: Prepare front-end environment
       uses: ./.github/actions/prepare-frontend
     - name: Prepare back-end environment
@@ -77,16 +71,10 @@ jobs:
         ports:
           - 5000:5000
     steps:
-    - name: Set the image tag based on the edition
-      run: |
-        if [[ ${{ matrix.edition }} == ee ]]; then
-          echo "IMAGE_TAG=${{ github.event.inputs.ee-tag }}" >> $GITHUB_ENV
-        else
-          echo "IMAGE_TAG=${{ github.event.inputs.oss-tag }}" >> $GITHUB_ENV
-        fi
-    - uses: actions/checkout@v3
-      with:
-        ref: ${{ github.event.inputs.commit }}
+    - name: Check out the code
+      uses: actions/checkout@v3
+    - name: Switch to commit ${{ github.event.inputs.commit }}
+      run: git checkout ${{ github.event.inputs.commit }}
     - uses: actions/download-artifact@v3
       name: Retrieve uberjar artifact
       with:
@@ -95,47 +83,75 @@ jobs:
       run: mv ./target/uberjar/metabase.jar bin/docker/.
     - name: Set up Docker Buildx
       id: buildx
-      uses: docker/setup-buildx-action@v1
+      uses: docker/setup-buildx-action@v2
       with:
         driver-opts: network=host
     - name: Build ${{ matrix.edition }} container
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v3
       with:
         context: bin/docker/.
         platforms: linux/amd64
         network: host
-        tags: localhost:5000/local-metabase:${{ env.IMAGE_TAG }}
+        tags: localhost:5000/local-metabase:${{ github.event.inputs.commit }}
         no-cache: true
         push: true
 
     - name: Launch container
-      run: docker run --rm -dp 3000:3000 localhost:5000/local-metabase:${{ env.IMAGE_TAG }}
+      run: docker run --rm -dp 3000:3000 localhost:5000/local-metabase:${{ github.event.inputs.commit }}
       timeout-minutes: 5
     - name: Wait for Metabase to start
       run: while ! curl -s 'http://localhost:3000/api/health' | grep '{"status":"ok"}'; do sleep 1; done
       timeout-minutes: 3
 
-    - name: Determine the target Docker Hub repository
-      run: |
-        if [[ ${{ github.repository }} == 'metabase/metabase' ]]; then
-          if [[ ${{ matrix.edition }} == ee ]]; then
-            echo "Metabase EE: image ${{ env.IMAGE_TAG }} is going to be pushed to metabase/test-metabase-enterprise"
-            echo "DOCKERHUB_REPO=metabase/test-metabase-enterprise" >> $GITHUB_ENV
-          else
-            echo "Metabase OSS: image ${{ env.IMAGE_TAG }} is going to be pushed to metabase/test-metabase"
-            echo "DOCKERHUB_REPO=metabase/test-metabase" >> $GITHUB_ENV
-          fi
-        else
-          echo "DOCKERHUB_REPO=${{ github.repository_owner }}/${{ secrets.CUSTOM_RELEASE_REPO }}" >> $GITHUB_ENV
-        fi
     - name: Login to Docker Hub
-      uses: docker/login-action@v1
+      uses: docker/login-action@v2
       with:
         username: ${{ secrets.DOCKERHUB_RELEASE_USERNAME }}
         password: ${{ secrets.DOCKERHUB_RELEASE_TOKEN }}
-    - name: Retag and push container image to Metabase Docker Hub
+    - name: Determine the target Docker Hub repository
       run: |
-        echo "Pushing ${{ env.IMAGE_TAG }} to ${{ env.DOCKERHUB_REPO }} ..."
-        docker tag localhost:5000/local-metabase:${{ env.IMAGE_TAG }} ${{ env.DOCKERHUB_REPO }}:${{ env.IMAGE_TAG }}
-        docker push ${{ env.DOCKERHUB_REPO }}:${{ env.IMAGE_TAG }}
+        if [[ ${{ matrix.edition }} == ee ]]; then
+          echo "Metabase EE: image is going to be pushed to ${{ github.repository_owner }}/metabase-enterprise:${{ github.event.inputs.commit }}"
+          echo "DOCKERHUB_REPO=${{ github.repository_owner }}/metabase-enterprise:${{ github.event.inputs.commit }}" >> $GITHUB_ENV
+        else
+          echo "Metabase OSS: image is going to be pushed to ${{ github.repository_owner }}/metabase:${{ github.event.inputs.commit }}"
+          echo "DOCKERHUB_REPO=${{ github.repository_owner }}/metabase:${{ github.event.inputs.commit }}" >> $GITHUB_ENV
+        fi
+    - name: Retag and push container image to Docker Hub
+      run: |
+        echo "Pushing container image ${{ env.DOCKERHUB_REPO }} ..."
+        docker tag localhost:5000/local-metabase:${{ github.event.inputs.commit }} ${{ env.DOCKERHUB_REPO }}
+        docker push ${{ env.DOCKERHUB_REPO }}
         echo "Finished!"
+
+  verify-docker-pull:
+    runs-on: ubuntu-20.04
+    needs: containerize
+    timeout-minutes: 15
+    strategy:
+      matrix:
+        edition: [oss, ee]
+    steps:
+    - name: Login to Docker Hub # authenticated, to avoid being rate-throttled
+      uses: docker/login-action@v2
+      with:
+        username: ${{ secrets.DOCKERHUB_RELEASE_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_RELEASE_TOKEN }}
+    - name: Determine the container image to pull
+      run: |
+        if [[ ${{ matrix.edition }} == ee ]]; then
+          echo "DOCKERHUB_REPO=${{ github.repository_owner }}/metabase-enterprise:${{ github.event.inputs.commit }}" >> $GITHUB_ENV
+        else
+          echo "DOCKERHUB_REPO=${{ github.repository_owner }}/metabase:${{ github.event.inputs.commit }}" >> $GITHUB_ENV
+        fi
+    - name: Pull the container image
+      run: |
+        echo "Pulling container image ${{ env.DOCKERHUB_REPO }} ..."
+        docker pull ${{ env.DOCKERHUB_REPO }}
+        echo "Successful!"
+    - name: Launch container
+      run: docker run --rm -dp 3000:3000 ${{ env.DOCKERHUB_REPO }}
+      timeout-minutes: 5
+    - name: Wait for Metabase to start
+      run: while ! curl -s 'http://localhost:3000/api/health' | grep '{"status":"ok"}'; do sleep 1; done
+      timeout-minutes: 3

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       commit:
-        description: 'A commit hash'
+        description: 'A full-length commit SHA-1 hash'
         required: true
 
 env:
@@ -24,8 +24,8 @@ jobs:
     steps:
     - name: Check out the code
       uses: actions/checkout@v3
-    - name: Switch to commit ${{ github.event.inputs.commit }}
-      run: git checkout ${{ github.event.inputs.commit }}
+      with:
+        ref: ${{ github.event.inputs.commit }}
     - name: Prepare front-end environment
       uses: ./.github/actions/prepare-frontend
     - name: Prepare back-end environment
@@ -76,8 +76,8 @@ jobs:
     steps:
     - name: Check out the code
       uses: actions/checkout@v3
-    - name: Switch to commit ${{ github.event.inputs.commit }}
-      run: git checkout ${{ github.event.inputs.commit }}
+      with:
+        ref: ${{ github.event.inputs.commit }}
     - name: Truncate commit hash
       run: |
         commit_id=${{ github.event.inputs.commit }}


### PR DESCRIPTION
Once this PR is merged, there will be a manually-triggered workflow which does the following, for each OSS and EE edition, to facilitate testing both the Uberjars and container images (before a release):

1. Build Uberjars, stash the Uberjars as downloadable artifacts
2. Check the health check when launching each Uberjar with Java 11 and 17
3. Put the Uberjar in the container image, push it to DockerHub
4. Verify the image by doing `docker pull`

Step 3 and 4 are carried out in isolation, thereby allowing the full round-trip (`docker push` and `docker pull`) verification.

Testing this is easier done in a fork (e.g. in my case, [github.com/ariya/metabase](https://github.com/ariya/metabase)). The workflow can be triggered by supplying the commit hash which we want to check:

![image](https://user-images.githubusercontent.com/7288/202596636-efe9dcef-aff6-4f91-b92f-c57de85a65d2.png)

The visualization of all the jobs being executed thereafter:

![image](https://user-images.githubusercontent.com/7288/202596755-1510033b-482c-4da2-b49e-744cecaeaa4f.png)

The container image is also available in Docker Hub (shown here only for `metabase-enterprise`, but `metabase` the OSS edition is also available):

![image](https://user-images.githubusercontent.com/7288/202597011-96ded177-bc73-4fc1-968a-a7a73b35c16b.png)
