### PR TITLE
Use clone icon for duplicate in dashboard page

### DIFF
--- a/frontend/src/metabase/dashboard/containers/DashboardHeader.jsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardHeader.jsx
@@ -313,7 +313,7 @@ class DashboardHeader extends Component {
 
       extraButtons.push({
         title: t`Duplicate`,
-        icon: "copy",
+        icon: "clone",
         link: `${location.pathname}/copy`,
         event: "Dashboard;Copy",
       });


### PR DESCRIPTION
### How to Test

1. Go to a dashboard page
2. Open the ellipsis menu (top right)

You should see this icon by `Duplicate`.

<img width="284" alt="image" src="https://user-images.githubusercontent.com/380816/202730149-2eaf634a-bf7f-4aa1-89c3-c45cc09e0f4b.png">
