### PR TITLE
Execute publicly shared actions with full permissions

### DIFF
--- a/src/metabase/query_processor/middleware/permissions.clj
+++ b/src/metabase/query_processor/middleware/permissions.clj
@@ -126,8 +126,6 @@
 (s/defn ^:private check-query-action-permissions*
   "Check that User with `user-id` has permissions to run query action `query`, or throw an exception."
   [outer-query :- su/Map]
-  (when-not *current-user-id*
-    (throw (ex-info (tru "Query actions have to executed by a user.") {})))
   (log/tracef "Checking query permissions. Current user perms set = %s" (pr-str @*current-user-permissions-set*))
   (check-card-read-perms *card-id*)
   (when-not (has-data-perms? (required-perms outer-query))

--- a/test/metabase/api/public_test.clj
+++ b/test/metabase/api/public_test.clj
@@ -1157,6 +1157,25 @@
               (is (str/starts-with? (:body throttled-response) "Too many attempts!"))
               (is (contains? (:headers throttled-response) "Retry-After")))))))))
 
+(deftest execute-public-dashcard-custom-action-test
+  (mt/with-temp-copy-of-db
+    (perms/revoke-data-perms! (perms-group/all-users) (mt/db))
+    (actions.test-util/with-actions-test-data-and-actions-enabled
+      (mt/with-temporary-setting-values [enable-public-sharing true]
+        (with-temp-public-dashboard [dash {:parameters []}]
+          (actions.test-util/with-action [{:keys [action-id]} {}]
+            (mt/with-temp* [Card [{card-id :id} {:dataset true}]
+                            ModelAction [_ {:slug "custom" :card_id card-id :action_id action-id}]
+                            DashboardCard [{dashcard-id :id} {:dashboard_id (:id dash)
+                                                              :card_id card-id}]]
+              (is (partial= {:rows-affected 1}
+                            (client/client
+                             :post 200
+                             (format "public/dashboard/%s/dashcard/%s/execute/custom"
+                                     (:public_uuid dash)
+                                     dashcard-id)
+                             {:parameters {:id 1 :name "European"}}))))))))))
+
 (deftest fetch-public-dashcard-action-test
   (actions.test-util/with-actions-test-data-and-actions-enabled
     (mt/with-temporary-setting-values [enable-public-sharing true]


### PR DESCRIPTION
Similar to executing publicly shared dashboards, we execute actions on publicly shared pages with full permissions.
Before merging this to master, we should consider making this stricter.

The fact, that we haven't noticed this bug while using implicit actions shows that permission handling is mostly missing for implicit actions.