### PR TITLE
Have convertTimezone use browser tz

### DIFF
--- a/frontend/src/metabase-lib/expressions/config.js
+++ b/frontend/src/metabase-lib/expressions/config.js
@@ -383,6 +383,13 @@ export const MBQL_CLAUSES = {
     type: "expression",
     args: ["expression", "number", "string"],
   },
+  "convert-timezone": {
+    displayName: `convertTimezone`,
+    type: "expression",
+    args: ["expression", "string"],
+    hasOptions: true,
+    requiresFeature: "convert-timezone",
+  },
 };
 
 for (const [name, clause] of Object.entries(MBQL_CLAUSES)) {
@@ -467,6 +474,7 @@ export const EXPRESSION_FUNCTIONS = new Set([
   "get-second",
   "datetime-add",
   "datetime-subtract",
+  "convert-timezone",
   // boolean
   "contains",
   "ends-with",

--- a/frontend/src/metabase-lib/expressions/config.js
+++ b/frontend/src/metabase-lib/expressions/config.js
@@ -386,7 +386,7 @@ export const MBQL_CLAUSES = {
   "convert-timezone": {
     displayName: `convertTimezone`,
     type: "expression",
-    args: ["expression", "string"],
+    args: ["expression"],
     hasOptions: true,
     requiresFeature: "convert-timezone",
   },

--- a/frontend/src/metabase-lib/expressions/helper-text-strings.ts
+++ b/frontend/src/metabase-lib/expressions/helper-text-strings.ts
@@ -760,6 +760,34 @@ const helperTextStrings: HelpText[] = [
       },
     ],
   },
+  {
+    name: "convert-timezone",
+    structure:
+      "convertTimezone(" +
+      t`column` +
+      ", " +
+      t`target` +
+      ", [" +
+      t`source` +
+      "])",
+    description: t`Convert timezone of a date or timestamp column.`,
+    example:
+      "convertTimezone([" + t`Created At` + '], "Asia/Ho_Chi_Minh", "UTC")',
+    args: [
+      {
+        name: t`column`,
+        description: t`The column with your date or timestamp values.`,
+      },
+      {
+        name: t`target`,
+        description: t`The timezone you want to assign to your column.`,
+      },
+      {
+        name: t`source`,
+        description: t`(Optional) The current timezone of your column. The default timezone is your report timezone.`,
+      },
+    ],
+  },
 ];
 
 export const getHelpText = (name: string): HelpText | undefined => {

--- a/frontend/src/metabase-lib/expressions/resolver.js
+++ b/frontend/src/metabase-lib/expressions/resolver.js
@@ -142,7 +142,7 @@ export function resolve(expression, type = "expression", fn = undefined) {
     if (!multiple) {
       const expectedArgsLength = args.length;
       const maxArgCount = hasOptions
-        ? expectedArgsLength + 1
+        ? expectedArgsLength + 2
         : expectedArgsLength;
       if (
         operands.length < expectedArgsLength ||

--- a/frontend/src/metabase-lib/expressions/typeinferencer.js
+++ b/frontend/src/metabase-lib/expressions/typeinferencer.js
@@ -37,6 +37,7 @@ export function infer(mbql, env) {
     case "case":
       return infer(mbql[1][0][1], env);
     case "coalesce":
+    case "convert-timezone":
     case "datetime-add":
     case "datetime-subtract":
       return infer(mbql[1], env);

--- a/frontend/src/metabase-lib/queries/utils/expression.js
+++ b/frontend/src/metabase-lib/queries/utils/expression.js
@@ -12,7 +12,6 @@ export function getExpressionsList(expressions = {}) {
 }
 
 export function addExpression(expressions = {}, name, expression) {
-  expression = maybeUseBrowserTimezoneInConvertTimezone(expression);
   return { ...expressions, [name]: expression };
 }
 export function updateExpression(expressions = {}, name, expression, oldName) {
@@ -62,23 +61,4 @@ function getUniqueName(expressionNames, originalName, index) {
   return isUnique
     ? nameWithIndexAppended
     : getUniqueName(expressionNames, originalName, index + 1);
-}
-
-/*
- * Function convertTimezone can take an optional second argument.
- * If it's ommitted, or is set to "User", we will fetch the timezone string
- * from the browser, for example "US/Hawaii", and use it in the expression.
- */
-function maybeUseBrowserTimezoneInConvertTimezone(expression) {
-  const userTimeZone = Intl.DateTimeFormat?.().resolvedOptions?.().timeZone;
-
-  if (
-    expression[0] === "convert-timezone" &&
-    (!expression[2] || expression[2] === "User") &&
-    userTimeZone
-  ) {
-    expression[2] = userTimeZone;
-  }
-
-  return expression;
 }

--- a/frontend/src/metabase-lib/queries/utils/expression.js
+++ b/frontend/src/metabase-lib/queries/utils/expression.js
@@ -12,6 +12,7 @@ export function getExpressionsList(expressions = {}) {
 }
 
 export function addExpression(expressions = {}, name, expression) {
+  expression = maybeUseBrowserTimezoneInConvertTimezone(expression);
   return { ...expressions, [name]: expression };
 }
 export function updateExpression(expressions = {}, name, expression, oldName) {
@@ -61,4 +62,23 @@ function getUniqueName(expressionNames, originalName, index) {
   return isUnique
     ? nameWithIndexAppended
     : getUniqueName(expressionNames, originalName, index + 1);
+}
+
+/*
+ * Function convertTimezone can take an optional second argument.
+ * If it's ommitted, or is set to "User", we will fetch the timezone string
+ * from the browser, for example "US/Hawaii", and use it in the expression.
+ */
+function maybeUseBrowserTimezoneInConvertTimezone(expression) {
+  const userTimeZone = Intl.DateTimeFormat?.().resolvedOptions?.().timeZone;
+
+  if (
+    expression[0] === "convert-timezone" &&
+    (!expression[2] || expression[2] === "User") &&
+    userTimeZone
+  ) {
+    expression[2] = userTimeZone;
+  }
+
+  return expression;
 }

--- a/frontend/test/metabase/lib/expressions/resolver.unit.spec.js
+++ b/frontend/test/metabase/lib/expressions/resolver.unit.spec.js
@@ -77,13 +77,13 @@ describe("metabase-lib/expressions/resolve", () => {
     it("should catch mismatched number of function parameters", () => {
       expect(() => filter(["contains"])).toThrow();
       expect(() => filter(["contains", Y])).toThrow();
-      expect(() => filter(["contains", Y, "A", "B", "C"])).toThrow();
+      expect(() => filter(["contains", Y, "A", "B", "C", "D"])).toThrow();
       expect(() => filter(["starts-with"])).toThrow();
       expect(() => filter(["starts-with", A])).toThrow();
-      expect(() => filter(["starts-with", A, "P", "Q", "R"])).toThrow();
+      expect(() => filter(["starts-with", A, "P", "Q", "R", "S"])).toThrow();
       expect(() => filter(["ends-with"])).toThrow();
       expect(() => filter(["ends-with", B])).toThrow();
-      expect(() => filter(["ends-with", B, "P", "Q", "R"])).toThrow();
+      expect(() => filter(["ends-with", B, "P", "Q", "R", "S"])).toThrow();
     });
 
     it("should allow a comparison (lexicographically) on strings", () => {

--- a/frontend/test/metabase/scenarios/custom-column/cc-data-type.cy.spec.js
+++ b/frontend/test/metabase/scenarios/custom-column/cc-data-type.cy.spec.js
@@ -58,6 +58,14 @@ describe("scenarios > question > custom column > data type", () => {
         name: "Datetime Subtract",
         formula: 'datetimeSubtract([Created At], 1, "month")',
       },
+      {
+        name: "ConvertTimezone 3 args",
+        formula: 'convertTimezone([Created At], "Asia/Ho_Chi_Minh", "UTC")',
+      },
+      {
+        name: "ConvertTimezone 2 args",
+        formula: 'convertTimezone([Created At], "Asia/Ho_Chi_Minh")',
+      },
     ]);
 
     visualize();

--- a/modules/drivers/redshift/src/metabase/driver/redshift.clj
+++ b/modules/drivers/redshift/src/metabase/driver/redshift.clj
@@ -84,7 +84,10 @@
   [_]
   :sunday)
 
-
+(defmethod driver/database-supports? [:redshift :convert-timezone]
+  [_driver _feat _db]
+  ;; TODO redshift could supports convert-timezone
+  false)
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                           metabase.driver.sql impls                                            |

--- a/shared/src/metabase/mbql/predicates.cljc
+++ b/shared/src/metabase/mbql/predicates.cljc
@@ -18,6 +18,10 @@
   "Is `unit` a valid datetime bucketing unit?"
   (complement (s/checker mbql.s/DateTimeUnit)))
 
+(def ^{:arglists '([unit])} TimezoneId?
+  "Is `unit` a valid datetime bucketing unit?"
+  (complement (s/checker mbql.s/TimezoneId)))
+
 (def ^{:arglists '([ag-clause])} Aggregation?
   "Is this a valid Aggregation clause?"
   (complement (s/checker mbql.s/Aggregation)))

--- a/shared/src/metabase/mbql/schema.cljc
+++ b/shared/src/metabase/mbql/schema.cljc
@@ -9,14 +9,22 @@
      [metabase.mbql.schema.helpers :as helpers :refer [is-clause?]]
      [metabase.mbql.schema.macros :refer [defclause one-of]]
      [schema.core :as s])
-    (:import java.time.format.DateTimeFormatter)]
+    (:import java.time.format.DateTimeFormatter
+             java.time.ZoneId)]
    :cljs
    [(:require
+     ["moment" :as moment]
+     ["moment-timezone" :as mtz]
      [clojure.core :as core]
      [clojure.set :as set]
      [metabase.mbql.schema.helpers :as helpers :refer [is-clause?]]
      [metabase.mbql.schema.macros :refer [defclause one-of]]
      [schema.core :as s])]))
+
+#?(:cljs
+   (comment
+     moment/keepme
+     mtz/keepme)) ;; to get the timezone list from moment
 
 ;; A NOTE ABOUT METADATA:
 ;;
@@ -77,6 +85,13 @@
   (s/named
    (apply s/enum datetime-bucketing-units)
    "datetime-bucketing-unit"))
+
+(def TimezoneId
+  "Valid timezone id."
+  (s/named
+    #?(:clj  (apply s/enum (ZoneId/getAvailableZoneIds)) ;; 600 timezones on java 17
+       :cljs (apply s/enum (.names (.-tz moment))))      ;; 596 timezones on moment-timezone 0.5.38
+    "timezone-id"))
 
 (def TemporalExtractUnits
   "Valid units to extract from a temporal."
@@ -520,7 +535,7 @@
 
 (def date+time+timezone-functions
   "Date, time, and timezone related functions."
-  (set/union temporal-extract-functions date-arithmetic-functions))
+  (set/union temporal-extract-functions date-arithmetic-functions #{:convert-timezone}))
 
 (declare ArithmeticExpression)
 (declare BooleanExpression)
@@ -555,8 +570,8 @@
    (partial is-clause? :value)
    value
 
-    ;; Recursively doing date math
-   (partial is-clause? date-arithmetic-functions)
+   ;; Recursively doing date math or convert-timezone
+   (partial is-clause? (set/union date-arithmetic-functions #{:convert-timezone}))
    (s/recursive #'DatetimeExpression)
 
    :else
@@ -720,6 +735,11 @@
 (defclause ^{:requires-features #{:temporal-extract}} ^:sugar get-second
   datetime DateTimeExpressionArg)
 
+(defclause ^{:requires-features #{:convert-timezone}} convert-timezone
+  datetime DateTimeExpressionArg
+  to       TimezoneId
+  from     (optional TimezoneId))
+
 (def ^:private ArithmeticDateTimeUnit
   (s/named
    (apply s/enum #{:millisecond :second :minute :hour :day :week :month :quarter :year})
@@ -736,7 +756,7 @@
   unit     ArithmeticDateTimeUnit)
 
 (def ^:private DatetimeExpression*
-  (one-of + temporal-extract datetime-add datetime-subtract
+  (one-of + temporal-extract datetime-add datetime-subtract convert-timezone
           ;; SUGAR drivers do not need to implement
           get-year get-quarter get-month get-week get-day get-day-of-week
           get-hour get-minute get-second))

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -445,6 +445,10 @@
     ;; DEFAULTS TO TRUE
     :date-arithmetics
 
+    ;; Does the driver support converting timezone?
+    ;; DEFAULTS TO FALSE
+    :convert-timezone
+
     ;; Does the driver support :datetime-diff functions
     :datetime-diff
 
@@ -476,6 +480,7 @@
 (defmethod supports? [::driver :case-sensitivity-string-filter-options] [_ _] true)
 (defmethod supports? [::driver :date-arithmetics] [_ _] true)
 (defmethod supports? [::driver :temporal-extract] [_ _] true)
+(defmethod supports? [::driver :convert-timezone] [_ _] false)
 
 (defmulti database-supports?
   "Does this driver and specific instance of a database support a certain `feature`?

--- a/src/metabase/query_processor/middleware/annotate.clj
+++ b/src/metabase/query_processor/middleware/annotate.clj
@@ -175,8 +175,22 @@
            (select-keys (infer-expression-type expression) type-info-columns)))
        clauses))
 
+    (mbql.u/is-clause? :convert-timezone expression)
+    {:converted_timezone (nth expression 2)
+     :base_type          :type/DateTime}
+
     (datetime-arithmetics? expression)
-    {:base_type :type/DateTime}
+    ;; make sure converted_timezone survived if we do nested datetime operations
+    ;; FIXME: this does not preverse converted_timezone for cases nested expressions
+    ;; i.e:
+    ;; {"expression" {"converted-exp" [:convert-timezone "created-at" "Asia/Ho_Chi_Minh"]
+    ;;                "date-add-exp"  [:datetime-add [:expression "converted-exp"] 2 :month]}}
+    ;; The converted_timezone metadata added for "converted-exp" will not be brought over
+    ;; to ["date-add-exp"].
+    ;; maybe this `infer-expression-type` should takes an `inner-query` and look up the
+    ;; source expresison as well?
+    (merge (select-keys (infer-expression-type (second expression)) [:converted_timezone])
+     {:base_type :type/DateTime})
 
     (mbql.u/is-clause? mbql.s/string-expressions expression)
     {:base_type :type/Text}

--- a/src/metabase/query_processor/middleware/format_rows.clj
+++ b/src/metabase/query_processor/middleware/format_rows.clj
@@ -53,10 +53,14 @@
   (format-value [t timezone-id]
     (t/format :iso-offset-date-time (u.date/with-time-zone-same-instant t timezone-id))))
 
-(defn- format-rows-xform [rf]
+(defn- format-rows-xform [rf metadata]
   {:pre [(fn? rf)]}
   (log/debug (tru "Formatting rows with results timezone ID {0}" (qp.timezone/results-timezone-id)))
-  (let [timezone-id (t/zone-id (qp.timezone/results-timezone-id))]
+  (let [timezone-id  (t/zone-id (qp.timezone/results-timezone-id))
+        ;; a column will have `converted_timezone` metadata if it is the result of `convert-timezone` expression
+        ;; in that case, we'll format the results with the target timezone.
+        ;; Otherwise format it with results-timezone
+        cols-zone-id (map #(t/zone-id (get % :converted_timezone timezone-id)) (:cols metadata))]
     (fn
       ([]
        (rf))
@@ -65,12 +69,12 @@
        (rf result))
 
       ([result row]
-       (rf result (mapv #(format-value % timezone-id) row))))))
+       (rf result (mapv format-value row cols-zone-id))))))
 
 (defn format-rows
   "Format individual query result values as needed.  Ex: format temporal values as ISO-8601 strings w/ timezone offset."
   [{{:keys [format-rows?] :or {format-rows? true}} :middleware, :as _query} rff]
   (if format-rows?
     (fn format-rows-rff* [metadata]
-      (format-rows-xform (rff metadata)))
+      (format-rows-xform (rff metadata) metadata))
     rff))

--- a/test/metabase/query_processor/middleware/annotate_test.clj
+++ b/test/metabase/query_processor/middleware/annotate_test.clj
@@ -279,17 +279,39 @@
                 {:expressions {"double-price" [:* $price 2]}}
                 [:expression "double-price"])))))
 
-    (testing "if there is no matching expression it should give a meaningful error message"
-      (is (= {:data    {:expression-name "double-price"
-                        :tried           ["double-price" :double-price]
-                        :found           #{"one-hundred"}
-                        :type            :invalid-query}
-              :message "No expression named 'double-price'"}
-             (try
-               (mt/$ids venues
-                 (#'annotate/col-info-for-field-clause {:expressions {"one-hundred" 100}} [:expression "double-price"]))
-               (catch Throwable e {:message (.getMessage e), :data (ex-data e)})))))))
+    (testing "col-info for convert-timezone should have a `converted_timezone` property"
+      (is (= {:converted_timezone "Asia/Ho_Chi_Minh",
+              :base_type          :type/DateTime,
+              :name               "last-login-converted",
+              :display_name       "last-login-converted",
+              :expression_name    "last-login-converted",
+              :field_ref          [:expression "last-login-converted"]}
+             (mt/$ids users
+               (#'annotate/col-info-for-field-clause
+                 {:expressions {"last-login-converted" [:convert-timezone $last_login "Asia/Ho_Chi_Minh" "UTC"]}}
+                 [:expression "last-login-converted"]))))
+      (is (= {:converted_timezone "Asia/Ho_Chi_Minh",
+              :base_type          :type/DateTime,
+              :name               "last-login-converted",
+              :display_name       "last-login-converted",
+              :expression_name    "last-login-converted",
+              :field_ref          [:expression "last-login-converted"]}
+             (mt/$ids users
+               (#'annotate/col-info-for-field-clause
+                 {:expressions {"last-login-converted" [:datetime-add
+                                                        [:convert-timezone $last_login "Asia/Ho_Chi_Minh" "UTC"] 2 :hour]}}
+                 [:expression "last-login-converted"])))))
 
+   (testing "if there is no matching expression it should give a meaningful error message"
+     (is (= {:data    {:expression-name "double-price"
+                       :tried           ["double-price" :double-price]
+                       :found           #{"one-hundred"}
+                       :type            :invalid-query}
+             :message "No expression named 'double-price'"}
+            (try
+              (mt/$ids venues
+                (#'annotate/col-info-for-field-clause {:expressions {"one-hundred" 100}} [:expression "double-price"]))
+              (catch Throwable e {:message (.getMessage e), :data (ex-data e)})))))))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                    (MBQL) Col info for Aggregation clauses                                     |


### PR DESCRIPTION
With this PR, the user can write 

`convertTimezone([ColumnName])`
`convertTimezone([ColumnName], "User")`

and the user's timezone set in the browser will be picked up.

To make this optional second argument work, the expression editor compiler is updated to accept two extra arguments when a function is tagged with `hasOptions: true`, instead of the current state in which we accept one extra argument.

This is because `convertTimezone` already takes a 3rd optional argument.

Considering what we have here a PoC as we first want to decide on the api for the end-users.

