### PR TITLE
Add frontend support for sharing data app pages

### DIFF
--- a/frontend/src/metabase-types/api/dashboard.ts
+++ b/frontend/src/metabase-types/api/dashboard.ts
@@ -18,6 +18,7 @@ export interface Dashboard {
   name: string;
   description: string | null;
   model?: string;
+  public_uuid: string | null;
   ordered_cards: DashboardOrderedCard[];
   parameters?: Parameter[] | null;
   can_write: boolean;

--- a/frontend/src/metabase-types/api/mocks/dashboard.ts
+++ b/frontend/src/metabase-types/api/mocks/dashboard.ts
@@ -8,5 +8,6 @@ export const createMockDashboard = (opts?: Partial<Dashboard>): Dashboard => ({
   can_write: true,
   description: "",
   cache_ttl: null,
+  public_uuid: null,
   ...opts,
 });

--- a/frontend/src/metabase/dashboard/containers/DashboardSharingEmbeddingModal.jsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardSharingEmbeddingModal.jsx
@@ -97,7 +97,11 @@ class DashboardSharingEmbeddingModal extends Component {
             this._modal && this._modal.close();
             additionalClickActions();
           }}
-          getPublicUrl={({ public_uuid }) => Urls.publicDashboard(public_uuid)}
+          getPublicUrl={({ public_uuid }) =>
+            dashboard.is_app_page
+              ? Urls.publicDataAppPage(public_uuid)
+              : Urls.publicDashboard(public_uuid)
+          }
         />
       </ModalWithTrigger>
     );

--- a/frontend/src/metabase/dashboard/containers/DashboardSharingEmbeddingModal.jsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardSharingEmbeddingModal.jsx
@@ -84,7 +84,7 @@ class DashboardSharingEmbeddingModal extends Component {
           className={className}
           resource={dashboard}
           resourceParameters={parameters}
-          resourceType="dashboard"
+          resourceType={dashboard.is_app_page ? "page" : "dashboard"}
           onCreatePublicLink={() => createPublicLink(dashboard)}
           onDisablePublicLink={() => deletePublicLink(dashboard)}
           onUpdateEnableEmbedding={enableEmbedding =>

--- a/frontend/src/metabase/lib/urls/dashboards.ts
+++ b/frontend/src/metabase/lib/urls/dashboards.ts
@@ -34,6 +34,11 @@ export function publicDashboard(uuid: string) {
   return `${siteUrl}/public/dashboard/${uuid}`;
 }
 
+export function publicDataAppPage(uuid: string) {
+  const siteUrl = MetabaseSettings.get("site-url");
+  return `${siteUrl}/public/page/${uuid}`;
+}
+
 export function embedDashboard(token: string) {
   const siteUrl = MetabaseSettings.get("site-url");
   return `${siteUrl}/embed/dashboard/${token}`;

--- a/frontend/src/metabase/nav/containers/MainNavbar/DataAppNavbar/DataAppActionPanel/DataAppActionPanel.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/DataAppNavbar/DataAppActionPanel/DataAppActionPanel.tsx
@@ -7,13 +7,15 @@ import Tooltip from "metabase/components/Tooltip";
 
 import * as Urls from "metabase/lib/urls";
 
-import type { DataApp } from "metabase-types/api";
+import type { DataApp, DataAppPage } from "metabase-types/api";
 
+import DataAppPageSharingControl from "./DataAppPageSharingControl";
 import NewButton from "./NewButton";
 import { Root, ActionsContainer } from "./DataAppActionPanel.styled";
 
 interface Props {
   dataApp: DataApp;
+  page?: DataAppPage;
   hasEditPageAction?: boolean;
   hasArchivePageAction?: boolean;
   hasManageContentAction?: boolean;
@@ -34,6 +36,7 @@ type MenuItem = {
 
 function DataAppActionPanel({
   dataApp,
+  page,
   hasEditPageAction = true,
   hasArchivePageAction = true,
   hasManageContentAction = true,
@@ -96,6 +99,7 @@ function DataAppActionPanel({
             <Button icon="pencil" onlyIcon onClick={onEditAppPage} />
           </Tooltip>
         )}
+        {page && <DataAppPageSharingControl page={page} />}
         <EntityMenu
           items={menuItems}
           triggerIcon="ellipsis"

--- a/frontend/src/metabase/nav/containers/MainNavbar/DataAppNavbar/DataAppActionPanel/DataAppPageSharingControl.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/DataAppNavbar/DataAppActionPanel/DataAppPageSharingControl.tsx
@@ -1,0 +1,62 @@
+import React from "react";
+import { t } from "ttag";
+import { connect } from "react-redux";
+
+import Button from "metabase/core/components/Button";
+import Tooltip from "metabase/components/Tooltip";
+
+import { getUserIsAdmin } from "metabase/selectors/user";
+import { getSetting } from "metabase/selectors/settings";
+
+import DashboardSharingEmbeddingModal from "metabase/dashboard/containers/DashboardSharingEmbeddingModal";
+
+import type { DataAppPage } from "metabase-types/api";
+import type { State } from "metabase-types/store";
+
+interface DataAppPageSharingControlOwnProps {
+  page: DataAppPage;
+}
+
+interface DataAppPageSharingControlStateProps {
+  isAdmin: boolean;
+  isPublicSharingEnabled: boolean;
+}
+
+type DataAppPageSharingControlProps = DataAppPageSharingControlOwnProps &
+  DataAppPageSharingControlStateProps;
+
+function mapStateToProps(state: State) {
+  return {
+    isAdmin: getUserIsAdmin(state),
+    isPublicSharingEnabled: getSetting(state, "enable-public-sharing"),
+  };
+}
+
+function DataAppPageSharingControl({
+  page,
+  isAdmin,
+  isPublicSharingEnabled,
+}: DataAppPageSharingControlProps) {
+  const isSharingAvailable =
+    isPublicSharingEnabled && (isAdmin || page.public_uuid);
+  const canSharePage = page.ordered_cards.length > 0;
+
+  return (
+    <DashboardSharingEmbeddingModal
+      dashboard={page}
+      enabled={isSharingAvailable}
+      isLinkEnabled={canSharePage}
+      linkText={
+        <Tooltip
+          tooltip={
+            canSharePage ? t`Sharing` : t`Add content to share this page`
+          }
+        >
+          <Button icon="share" onlyIcon disabled={!canSharePage} />
+        </Tooltip>
+      }
+    />
+  );
+}
+
+export default connect(mapStateToProps)(DataAppPageSharingControl);

--- a/frontend/src/metabase/nav/containers/MainNavbar/DataAppNavbar/DataAppNavbarContainer.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/DataAppNavbar/DataAppNavbarContainer.tsx
@@ -17,6 +17,7 @@ import DataApps, {
 import Search from "metabase/entities/search";
 
 import { setEditingDashboard as setEditingDataAppPage } from "metabase/dashboard/actions";
+import { getDashboardComplete } from "metabase/dashboard/selectors";
 
 import ArchiveDataAppModal from "metabase/writeback/containers/ArchiveDataAppModal";
 import ArchiveDataAppPageModal from "metabase/writeback/containers/ArchiveDataAppPageModal";
@@ -54,12 +55,17 @@ interface DataAppNavbarContainerOwnProps extends MainNavbarProps {
   pages: any[];
 }
 
+interface DataAppNavbarContainerStateProps {
+  page?: DataAppPage;
+}
+
 interface DataAppNavbarContainerDispatchProps {
   setEditingDataAppPage: (isEditing: boolean) => void;
   onChangeLocation: (location: LocationDescriptor) => void;
 }
 
 type DataAppNavbarContainerProps = DataAppNavbarContainerOwnProps &
+  DataAppNavbarContainerStateProps &
   DataAppNavbarContainerDispatchProps & {
     onReloadNavbar: () => Promise<void>;
   };
@@ -75,6 +81,17 @@ type SearchRenderProps = {
   reload: () => Promise<void>;
 };
 
+function mapStateToProps(
+  state: State,
+  { dataApp }: DataAppNavbarContainerProps,
+) {
+  const dashboard = getDashboardComplete(state);
+  const isDataAppPage =
+    dashboard?.is_app_page &&
+    dashboard?.collection_id === dataApp.collection_id;
+  return isDataAppPage ? { page: dashboard } : {};
+}
+
 const mapDispatchToProps = {
   setEditingDataAppPage,
   onChangeLocation: push,
@@ -82,6 +99,7 @@ const mapDispatchToProps = {
 
 function DataAppNavbarContainer({
   dataApp,
+  page: selectedPage,
   pages: fetchedPages,
   location,
   params,
@@ -255,6 +273,7 @@ function DataAppNavbarContainer({
       <DataAppNavbarView
         {...props}
         dataApp={dataApp}
+        selectedPage={selectedPage}
         pages={pages}
         selectedItems={selectedItems}
         mode={mode}
@@ -319,5 +338,5 @@ function getDataAppId(state: State, props: MainNavbarOwnProps) {
 export default _.compose(
   withRouter,
   DataApps.load({ id: getDataAppId }),
-  connect(null, mapDispatchToProps),
+  connect(mapStateToProps, mapDispatchToProps),
 )(DataAppNavbarContainerLoader);

--- a/frontend/src/metabase/nav/containers/MainNavbar/DataAppNavbar/DataAppNavbarView.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/DataAppNavbar/DataAppNavbarView.tsx
@@ -1,11 +1,7 @@
 import React, { useCallback, useMemo } from "react";
 import _ from "underscore";
 
-import type {
-  DataApp,
-  DataAppNavItem,
-  DataAppPageId,
-} from "metabase-types/api";
+import type { DataApp, DataAppNavItem, DataAppPage } from "metabase-types/api";
 
 import type { MainNavbarProps, SelectedItem } from "../types";
 import type { DataAppNavbarMode } from "./types";
@@ -17,6 +13,7 @@ import { Root, NavItemsList } from "./DataAppNavbarView.styled";
 
 interface Props extends Omit<MainNavbarProps, "location" | "params"> {
   dataApp: DataApp;
+  selectedPage?: DataAppPage;
   pages: any[];
   selectedItems: SelectedItem[];
   mode: DataAppNavbarMode;
@@ -30,6 +27,7 @@ interface Props extends Omit<MainNavbarProps, "location" | "params"> {
 
 function DataAppNavbarView({
   dataApp,
+  selectedPage,
   pages,
   selectedItems,
   mode,
@@ -79,7 +77,7 @@ function DataAppNavbarView({
     [dataApp, pageMap, dataAppPage],
   );
 
-  const hasSelectedPage = !!dataAppPage?.id;
+  const hasSelectedPage = !!selectedPage;
 
   // Archiving last app page would lead a user into a weird app state
   // For now we'd just hide the action when there's only one top-level page left
@@ -91,6 +89,7 @@ function DataAppNavbarView({
       <NavItemsList>{navItems.map(renderNavItem)}</NavItemsList>
       <DataAppActionPanel
         dataApp={dataApp}
+        page={selectedPage}
         hasEditPageAction={hasSelectedPage}
         hasManageContentAction={mode !== "manage-content"}
         hasArchivePageAction={hasArchivePageAction}

--- a/frontend/src/metabase/public/components/widgets/SharingPane.tsx
+++ b/frontend/src/metabase/public/components/widgets/SharingPane.tsx
@@ -57,6 +57,7 @@ export default function SharingPane({
   const publicLink = getPublicUrl(resource, extensionState);
   const iframeSource = getPublicEmbedHTML(getPublicUrl(resource));
 
+  const canEmbed = resourceType !== "page";
   const shouldDisableEmbedding = !isAdmin || !isApplicationEmbeddingEnabled;
 
   const embeddingHelperText = getEmbeddingHelperText({
@@ -103,7 +104,8 @@ export default function SharingPane({
       )}
 
       <SharingOption
-        className={cx("border-bottom", {
+        className={cx({
+          "border-bottom": canEmbed,
           disabled: !resource.public_uuid,
         })}
         illustration={
@@ -137,40 +139,44 @@ export default function SharingPane({
         )}
       </SharingOption>
 
-      <SharingOption
-        className={cx("border-bottom", {
-          disabled: !resource.public_uuid,
-        })}
-        illustration={
-          <ResponsiveImage imageUrl="app/assets/img/simple_embed.png" />
-        }
-      >
-        <PublicEmbedHeader>{t`Public embed`}</PublicEmbedHeader>
-        <Description className="mb1">{t`Embed this ${resourceType} in blog posts or web pages by copying and pasting this snippet:`}</Description>
-        <CopyWidget value={iframeSource} />
-      </SharingOption>
-
-      <SharingOption
-        className={cx({
-          disabled: shouldDisableEmbedding,
-          "cursor-pointer": !shouldDisableEmbedding,
-        })}
-        illustration={
-          <ResponsiveImage imageUrl="app/assets/img/secure_embed.png" />
-        }
-        onClick={() => {
-          if (!shouldDisableEmbedding) {
-            onChangeEmbedType("application");
+      {canEmbed && (
+        <SharingOption
+          className={cx("border-bottom", {
+            disabled: !resource.public_uuid,
+          })}
+          illustration={
+            <ResponsiveImage imageUrl="app/assets/img/simple_embed.png" />
           }
-        }}
-      >
-        <EmbedWidgetHeader>{t`Embed in your application`}</EmbedWidgetHeader>
-        <Description>{t`Add this ${resourceType} to your application server code. You’ll be able to preview the way it looks and behaves before making it securely visible for your users.`}</Description>
-        {embeddingHelperText && (
-          <Description enableMouseEvents>{embeddingHelperText}</Description>
-        )}
-        <Button primary>{t`Set up`}</Button>
-      </SharingOption>
+        >
+          <PublicEmbedHeader>{t`Public embed`}</PublicEmbedHeader>
+          <Description className="mb1">{t`Embed this ${resourceType} in blog posts or web pages by copying and pasting this snippet:`}</Description>
+          <CopyWidget value={iframeSource} />
+        </SharingOption>
+      )}
+
+      {canEmbed && (
+        <SharingOption
+          className={cx({
+            disabled: shouldDisableEmbedding,
+            "cursor-pointer": !shouldDisableEmbedding,
+          })}
+          illustration={
+            <ResponsiveImage imageUrl="app/assets/img/secure_embed.png" />
+          }
+          onClick={() => {
+            if (!shouldDisableEmbedding) {
+              onChangeEmbedType("application");
+            }
+          }}
+        >
+          <EmbedWidgetHeader>{t`Embed in your application`}</EmbedWidgetHeader>
+          <Description>{t`Add this ${resourceType} to your application server code. You’ll be able to preview the way it looks and behaves before making it securely visible for your users.`}</Description>
+          {embeddingHelperText && (
+            <Description enableMouseEvents>{embeddingHelperText}</Description>
+          )}
+          <Button primary>{t`Set up`}</Button>
+        </SharingOption>
+      )}
     </div>
   );
 }

--- a/frontend/src/metabase/routes-public.jsx
+++ b/frontend/src/metabase/routes-public.jsx
@@ -14,6 +14,7 @@ export const getRoutes = store => (
     <Route path="public" component={PublicApp}>
       <Route path="question/:uuid" component={PublicQuestion} />
       <Route path="dashboard/:uuid" component={PublicDashboard} />
+      <Route path="page/:uuid" component={PublicDashboard} />
       <Route path="*" component={PublicNotFound} />
     </Route>
     <Route path="*" component={PublicNotFound} />

--- a/frontend/src/metabase/routes.jsx
+++ b/frontend/src/metabase/routes.jsx
@@ -172,6 +172,7 @@ export const getRoutes = store => (
     <Route path="public">
       <Route path="question/:uuid" component={PublicQuestion} />
       <Route path="dashboard/:uuid" component={PublicDashboard} />
+      <Route path="page/:uuid" component={PublicDashboard} />
     </Route>
 
     {/* APP */}

--- a/frontend/src/metabase/services.js
+++ b/frontend/src/metabase/services.js
@@ -177,6 +177,9 @@ export const PublicApi = {
   dashboardCardQueryPivot: GET(
     PIVOT_PUBLIC_PREFIX + "dashboard/:uuid/dashcard/:dashcardId/card/:cardId",
   ),
+  executeAction: POST(
+    "/api/public/dashboard/:dashboardId/dashcard/:dashcardId/execute/:slug",
+  ),
 };
 
 export const EmbedApi = {


### PR DESCRIPTION
Adds basic support for public data app pages. For this, we're primarily reusing the public dashboard code with minor adjustments.

### To Verify

1. Sign in as admin
2. Go to `/admin/settings/public-sharing` and make sure public sharing is _disabled_
3. Open any data app page; ensure you can't see the sharing icon next to the "edit page" button (pencil icon at the top right)
4. Go to `/admin/settings/public-sharing` again, but now enable public sharing
5. Open any data app page (reload the page if the admin app was in a different tab)
6. Click the sharing icon in the data app navbar
7. Ensure there are no embedding controls, only sharing via a public link
8. Enable a public link for the page
9. Make sure the public URL is `/public/page/:uuid` (not `/public/dashboard/:uuid`)
10. Open the public link and play with the page. Try out implicit and explicit action execution

### Demo

https://user-images.githubusercontent.com/17258145/202754732-54fb7647-c345-4679-ae6d-afdf18814487.mp4
