### PR TITLE
Add dashboard state to metabase-types/store

### DIFF
--- a/frontend/src/metabase-types/store/dashboard.ts
+++ b/frontend/src/metabase-types/store/dashboard.ts
@@ -1,0 +1,60 @@
+import type {
+  Dashboard,
+  DashboardId,
+  DashboardOrderedCard,
+  DashCardId,
+  DashCardDataMap,
+  ParameterId,
+} from "metabase-types/api";
+import { ParameterValueOrArray } from "metabase-types/types/Parameter";
+
+export type DashboardSidebarName =
+  | "addQuestion"
+  | "addActionButton"
+  | "addActionForm"
+  | "clickBehavior"
+  | "editParameter"
+  | "sharing"
+  | "info";
+
+type ParameterValueCacheKey = string;
+
+export interface DashboardState {
+  dashboardId: DashboardId | null;
+  dashboards: Record<DashboardId, Dashboard>;
+
+  dashcards: Record<DashCardId, DashboardOrderedCard>;
+  dashcardData: DashCardDataMap;
+
+  parameterValues: Record<ParameterId, ParameterValueOrArray>;
+  parameterValuesSearchCache: Record<
+    ParameterValueCacheKey,
+    {
+      has_more_values: boolean;
+      results: ParameterValueOrArray[];
+    }
+  >;
+
+  loadingDashCards: {
+    dashcardIds: DashCardId[];
+    loadingIds: DashCardId[];
+    loadingStatus: "idle" | "running" | "complete";
+    startTime: number | null;
+  };
+  loadingControls: {
+    documentTitle?: string;
+    showLoadCompleteFavicon?: boolean;
+  };
+
+  isEditing: Dashboard | null;
+  isAddParameterPopoverOpen: boolean;
+
+  slowCards: Record<DashCardId, unknown>;
+
+  sidebar: {
+    name?: DashboardSidebarName;
+    props: Record<string, unknown>;
+  };
+
+  titleTemplateChange: string | null;
+}

--- a/frontend/src/metabase-types/store/index.ts
+++ b/frontend/src/metabase-types/store/index.ts
@@ -1,5 +1,6 @@
 export * from "./admin";
 export * from "./app";
+export * from "./dashboard";
 export * from "./embed";
 export * from "./entities";
 export * from "./forms";

--- a/frontend/src/metabase-types/store/mocks/dashboard.ts
+++ b/frontend/src/metabase-types/store/mocks/dashboard.ts
@@ -1,0 +1,32 @@
+import { createMockDashboard } from "metabase-types/api/mocks";
+import type { DashboardState } from "metabase-types/store";
+
+export const createMockDashboardState = ({
+  dashboardId = 1,
+  dashboards = {
+    [dashboardId as number]: createMockDashboard({ id: dashboardId as number }),
+  },
+  ...opts
+}: Partial<DashboardState> = {}): DashboardState => ({
+  dashboardId,
+  dashboards,
+  dashcards: {},
+  dashcardData: {},
+  parameterValues: {},
+  parameterValuesSearchCache: {},
+  loadingDashCards: {
+    dashcardIds: [],
+    loadingIds: [],
+    loadingStatus: "idle",
+    startTime: null,
+  },
+  loadingControls: {},
+  isEditing: null,
+  isAddParameterPopoverOpen: false,
+  slowCards: {},
+  sidebar: {
+    props: {},
+  },
+  titleTemplateChange: null,
+  ...opts,
+});

--- a/frontend/src/metabase-types/store/mocks/dashboard.ts
+++ b/frontend/src/metabase-types/store/mocks/dashboard.ts
@@ -1,15 +1,11 @@
 import { createMockDashboard } from "metabase-types/api/mocks";
 import type { DashboardState } from "metabase-types/store";
 
-export const createMockDashboardState = ({
-  dashboardId = 1,
-  dashboards = {
-    [dashboardId as number]: createMockDashboard({ id: dashboardId as number }),
-  },
-  ...opts
-}: Partial<DashboardState> = {}): DashboardState => ({
-  dashboardId,
-  dashboards,
+export const createMockDashboardState = (
+  opts: Partial<DashboardState> = {},
+): DashboardState => ({
+  dashboardId: null,
+  dashboards: {},
   dashcards: {},
   dashcardData: {},
   parameterValues: {},

--- a/frontend/src/metabase-types/store/mocks/index.ts
+++ b/frontend/src/metabase-types/store/mocks/index.ts
@@ -1,5 +1,6 @@
 export * from "./admin";
 export * from "./app";
+export * from "./dashboard";
 export * from "./embed";
 export * from "./entities";
 export * from "./forms";

--- a/frontend/src/metabase-types/store/mocks/state.ts
+++ b/frontend/src/metabase-types/store/mocks/state.ts
@@ -3,6 +3,7 @@ import { createMockUser } from "metabase-types/api/mocks";
 import {
   createMockAdminState,
   createMockAppState,
+  createMockDashboardState,
   createMockEmbedState,
   createMockEntitiesState,
   createMockFormState,
@@ -15,6 +16,7 @@ export const createMockState = (opts?: Partial<State>): State => ({
   admin: createMockAdminState(),
   app: createMockAppState(),
   currentUser: createMockUser(),
+  dashboard: createMockDashboardState(),
   embed: createMockEmbedState(),
   entities: createMockEntitiesState(),
   form: createMockFormState(),

--- a/frontend/src/metabase-types/store/state.ts
+++ b/frontend/src/metabase-types/store/state.ts
@@ -1,6 +1,7 @@
 import { User } from "metabase-types/api";
 import { AdminState } from "./admin";
 import { AppState } from "./app";
+import { DashboardState } from "./dashboard";
 import { EmbedState } from "./embed";
 import { EntitiesState } from "./entities";
 import { FormState } from "./forms";
@@ -12,6 +13,7 @@ export interface State {
   admin: AdminState;
   app: AppState;
   currentUser: User | null;
+  dashboard: DashboardState;
   embed: EmbedState;
   entities: EntitiesState;
   form: FormState;


### PR DESCRIPTION
Adds `DashboardState` type to `metabase-types/store/state` and implements `createMockDashboardState` for unit tests.
Reference: [dashboard reducer file](https://github.com/metabase/metabase/blob/master/frontend/src/metabase/dashboard/reducers.js)