### PR TITLE
Adding graph.series_order_dimension

### DIFF
--- a/frontend/src/metabase-types/api/card.ts
+++ b/frontend/src/metabase-types/api/card.ts
@@ -37,8 +37,9 @@ export type SeriesSettings = {
 
 export type SeriesOrderSetting = {
   name: string;
-  originalIndex: number;
+  key: string;
   enabled: boolean;
+  color?: string;
 };
 
 export type VisualizationSettings = {

--- a/frontend/src/metabase/visualizations/components/FunnelNormal.jsx
+++ b/frontend/src/metabase/visualizations/components/FunnelNormal.jsx
@@ -29,7 +29,11 @@ export default class FunnelNormal extends Component {
     const rows = settings["funnel.rows"]
       ? settings["funnel.rows"]
           .filter(fr => fr.enabled)
-          .map(fr => series[fr.originalIndex].data.rows[0])
+          .map(
+            fr =>
+              series.find(singleSeries => singleSeries.card.name === fr.key)
+                .data.rows[0],
+          )
       : series.map(s => s.data.rows[0]);
 
     const isNarrow = gridSize && gridSize.width < 7;

--- a/frontend/src/metabase/visualizations/components/FunnelNormal.jsx
+++ b/frontend/src/metabase/visualizations/components/FunnelNormal.jsx
@@ -6,6 +6,7 @@ import cx from "classnames";
 import Ellipsified from "metabase/core/components/Ellipsified";
 import { formatValue } from "metabase/lib/formatting";
 import { getFriendlyName } from "metabase/visualizations/lib/utils";
+import { findSeriesByKey } from "metabase/visualizations/lib/series";
 
 import { color } from "metabase/lib/colors";
 import styles from "./FunnelNormal.css";
@@ -29,11 +30,7 @@ export default class FunnelNormal extends Component {
     const rows = settings["funnel.rows"]
       ? settings["funnel.rows"]
           .filter(fr => fr.enabled)
-          .map(
-            fr =>
-              series.find(singleSeries => singleSeries.card.name === fr.key)
-                .data.rows[0],
-          )
+          .map(fr => findSeriesByKey(series, fr.key).data.rows[0])
       : series.map(s => s.data.rows[0]);
 
     const isNarrow = gridSize && gridSize.width < 7;

--- a/frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx
+++ b/frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx
@@ -20,7 +20,7 @@ import {
   validateDatasetRows,
   validateStacking,
 } from "metabase/visualizations/lib/settings/validation";
-import { keyForSingleSeries } from "metabase/visualizations/lib/settings/series";
+import { findSeriesByKey } from "metabase/visualizations/lib/series";
 import { getAccentColors } from "metabase/lib/colors/groups";
 import {
   isNumeric,
@@ -353,12 +353,7 @@ export default class LineAreaBarChart extends Component {
       (settings["graph.dimensions"]?.length > 1 &&
         settings["graph.series_order"]
           ?.filter(orderedItem => orderedItem.enabled)
-          .map(orderedItem =>
-            series.find(
-              singleSeries =>
-                keyForSingleSeries(singleSeries) === orderedItem.key,
-            ),
-          )) ||
+          .map(orderedItem => findSeriesByKey(series, orderedItem.key))) ||
       series;
 
     const {

--- a/frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx
+++ b/frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx
@@ -20,6 +20,7 @@ import {
   validateDatasetRows,
   validateStacking,
 } from "metabase/visualizations/lib/settings/validation";
+import { keyForSingleSeries } from "metabase/visualizations/lib/settings/series";
 import { getAccentColors } from "metabase/lib/colors/groups";
 import {
   isNumeric,
@@ -352,7 +353,12 @@ export default class LineAreaBarChart extends Component {
       (settings["graph.dimensions"]?.length > 1 &&
         settings["graph.series_order"]
           ?.filter(orderedItem => orderedItem.enabled)
-          .map(orderedItem => series[orderedItem.originalIndex])) ||
+          .map(orderedItem =>
+            series.find(
+              singleSeries =>
+                keyForSingleSeries(singleSeries) === orderedItem.key,
+            ),
+          )) ||
       series;
 
     const {

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedSimple.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedSimple.tsx
@@ -2,6 +2,7 @@ import { updateIn } from "icepick";
 import React from "react";
 import { t } from "ttag";
 import { keyForSingleSeries } from "metabase/visualizations/lib/settings/series";
+import { findSeriesByKey } from "metabase/visualizations/lib/series";
 import { Series } from "metabase-types/types/Visualization";
 
 import { ChartSettingOrderedItems } from "./ChartSettingOrderedItems";
@@ -11,8 +12,8 @@ import {
 } from "./ChartSettingOrderedSimple.styled";
 
 interface SortableItem {
+  key: string;
   enabled: boolean;
-  originalIndex: number;
   name: string;
   color?: string;
 }
@@ -40,9 +41,7 @@ export const ChartSettingOrderedSimple = ({
   onChangeSeriesColor,
 }: ChartSettingOrderedSimpleProps) => {
   const toggleDisplay = (selectedItem: SortableItem) => {
-    const index = orderedItems.findIndex(
-      item => item.originalIndex === selectedItem.originalIndex,
-    );
+    const index = orderedItems.findIndex(item => item.key === selectedItem.key);
     onChange(updateIn(orderedItems, [index, "enabled"], enabled => !enabled));
   };
 
@@ -59,15 +58,14 @@ export const ChartSettingOrderedSimple = ({
   };
 
   const getItemTitle = (item: SortableItem) => {
-    return items[item.originalIndex]?.name || "Unknown";
+    return items.find(i => i.key === item.key)?.name || "Unknown";
   };
 
   const handleOnEdit = (item: SortableItem, ref: HTMLElement | undefined) => {
-    const single = series[item.originalIndex];
     onShowWidget(
       {
         props: {
-          seriesKey: keyForSingleSeries(single),
+          seriesKey: keyForSingleSeries(item.key),
         },
       },
       ref,
@@ -75,7 +73,7 @@ export const ChartSettingOrderedSimple = ({
   };
 
   const handleColorChange = (item: SortableItem, color: string) => {
-    const singleSeries = series[item.originalIndex];
+    const singleSeries = findSeriesByKey(series, item.key);
     const seriesKey = keyForSingleSeries(singleSeries);
     onChangeSeriesColor(seriesKey, color);
   };
@@ -86,7 +84,7 @@ export const ChartSettingOrderedSimple = ({
         <ChartSettingOrderedItems
           items={orderedItems.map(item => ({
             ...item,
-            color: items[item.originalIndex].color,
+            color: items.find(i => i.key === item.key)?.color,
           }))}
           getItemName={getItemTitle}
           onRemove={toggleDisplay}

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedSimple.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedSimple.tsx
@@ -71,8 +71,6 @@ export const ChartSettingOrderedSimple = ({
     onChangeSeriesColor(item.key, color);
   };
 
-  console.log(orderedItems);
-
   return (
     <ChartSettingOrderedSimpleRoot>
       {orderedItems.length > 0 ? (

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedSimple.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedSimple.tsx
@@ -1,8 +1,6 @@
 import { updateIn } from "icepick";
 import React from "react";
 import { t } from "ttag";
-import { keyForSingleSeries } from "metabase/visualizations/lib/settings/series";
-import { findSeriesByKey } from "metabase/visualizations/lib/series";
 import { Series } from "metabase-types/types/Visualization";
 
 import { ChartSettingOrderedItems } from "./ChartSettingOrderedItems";
@@ -20,7 +18,6 @@ interface SortableItem {
 
 interface ChartSettingOrderedSimpleProps {
   onChange: (rows: SortableItem[]) => void;
-  items: SortableItem[];
   value: SortableItem[];
   onShowWidget: (
     widget: { props: { seriesKey: string } },
@@ -33,9 +30,7 @@ interface ChartSettingOrderedSimpleProps {
 
 export const ChartSettingOrderedSimple = ({
   onChange,
-  items,
   value: orderedItems,
-  series,
   onShowWidget,
   hasEditSettings = true,
   onChangeSeriesColor,
@@ -58,7 +53,7 @@ export const ChartSettingOrderedSimple = ({
   };
 
   const getItemTitle = (item: SortableItem) => {
-    return items.find(i => i.key === item.key)?.name || "Unknown";
+    return item.name || "Unknown";
   };
 
   const handleOnEdit = (item: SortableItem, ref: HTMLElement | undefined) => {
@@ -73,19 +68,16 @@ export const ChartSettingOrderedSimple = ({
   };
 
   const handleColorChange = (item: SortableItem, color: string) => {
-    const singleSeries = findSeriesByKey(series, item.key);
-    const seriesKey = keyForSingleSeries(singleSeries);
-    onChangeSeriesColor(seriesKey, color);
+    onChangeSeriesColor(item.key, color);
   };
+
+  console.log(orderedItems);
 
   return (
     <ChartSettingOrderedSimpleRoot>
       {orderedItems.length > 0 ? (
         <ChartSettingOrderedItems
-          items={orderedItems.map(item => ({
-            ...item,
-            color: items.find(i => i.key === item.key)?.color,
-          }))}
+          items={orderedItems}
           getItemName={getItemTitle}
           onRemove={toggleDisplay}
           onEnable={toggleDisplay}

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedSimple.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedSimple.tsx
@@ -65,7 +65,7 @@ export const ChartSettingOrderedSimple = ({
     onShowWidget(
       {
         props: {
-          seriesKey: keyForSingleSeries(item.key),
+          seriesKey: item.key,
         },
       },
       ref,

--- a/frontend/src/metabase/visualizations/lib/series.ts
+++ b/frontend/src/metabase/visualizations/lib/series.ts
@@ -1,6 +1,7 @@
 import { assocIn } from "icepick";
 import { VisualizationSettings } from "metabase-types/api/card";
-import { SETTING_ID } from "./settings/series";
+import { Series } from "metabase-types/types/Visualization";
+import { SETTING_ID, keyForSingleSeries } from "./settings/series";
 
 export const updateSeriesColor = (
   settings: VisualizationSettings,
@@ -8,4 +9,8 @@ export const updateSeriesColor = (
   color: string,
 ) => {
   return assocIn(settings, [SETTING_ID, seriesKey, "color"], color);
+};
+
+export const findSeriesByKey = (series: Series, key: string) => {
+  return series.find(singleSeries => keyForSingleSeries(singleSeries) === key);
 };

--- a/frontend/src/metabase/visualizations/lib/settings/graph.js
+++ b/frontend/src/metabase/visualizations/lib/settings/graph.js
@@ -153,6 +153,8 @@ export const GRAPH_DATA_SETTINGS = {
   },
   "graph.series_order_dimension": {
     getValue: (_series, settings) => settings["graph.dimensions"][1],
+    // This read dependency is set so that "graph.series_order" is computed *before* this value, ensuring that
+    // that it uses the stored value if one exists. This is needed to check if the dimension has actually changed
     readDependencies: ["graph.series_order"],
   },
   "graph.series_order": {
@@ -163,6 +165,8 @@ export const GRAPH_DATA_SETTINGS = {
     getValue: (series, settings) => {
       const seriesKeys = series.map(s => keyForSingleSeries(s));
       const seriesOrder = settings["graph.series_order"];
+      // Because this setting is a read dependency of graph.series_order_dimension, this should
+      // Always be the stored setting, not calculated.
       const seriesOrderDimension = settings["graph.series_order_dimension"];
       const currentDimension = settings["graph.dimensions"][1];
 
@@ -191,7 +195,6 @@ export const GRAPH_DATA_SETTINGS = {
         ...removeMissingOrder(seriesKeys, seriesOrder),
         ...generateDefault(newKeys(seriesKeys, seriesOrder)),
       ];
-      // return seriesOrder;
     },
     getProps: (series, settings) => {
       const seriesSettings = settings["series_settings"] || {};

--- a/frontend/src/metabase/visualizations/lib/settings/graph.js
+++ b/frontend/src/metabase/visualizations/lib/settings/graph.js
@@ -151,26 +151,38 @@ export const GRAPH_DATA_SETTINGS = {
     dashboard: false,
     useRawSeries: true,
   },
+  "graph.series_order_dimension": {
+    getValue: (_series, settings) => settings["graph.dimensions"][1],
+    readDependencies: ["graph.series_order"],
+  },
   "graph.series_order": {
     section: t`Data`,
     widget: ChartSettingOrderedSimple,
     marginBottom: "1rem",
-    isValid: (series, settings) => {
-      const seriesOrder = settings["graph.series_order"];
 
-      if (!seriesOrder || !_.isArray(seriesOrder)) {
-        return false;
+    getValue: (series, settings) => {
+      const seriesOrder = settings["graph.series_order"];
+      const seriesOrderDimension = settings["graph.series_order_dimension"];
+      const currentDimension = settings["graph.dimensions"][1];
+
+      const generateDefault = series => {
+        const keys = series.map(s => keyForSingleSeries(s));
+        return keys.map((key, index) => ({
+          name: key,
+          originalIndex: index,
+          enabled: true,
+        }));
+      };
+
+      if (
+        !seriesOrder ||
+        !_.isArray(seriesOrder) ||
+        seriesOrderDimension !== currentDimension
+      ) {
+        return generateDefault(series);
       }
 
-      return seriesOrder.length === series.length;
-    },
-    getDefault: series => {
-      const keys = series.map(s => keyForSingleSeries(s));
-      return keys.map((key, index) => ({
-        name: key,
-        originalIndex: index,
-        enabled: true,
-      }));
+      return seriesOrder;
     },
     getProps: (series, settings) => {
       const seriesSettings = settings["series_settings"] || {};
@@ -190,6 +202,7 @@ export const GRAPH_DATA_SETTINGS = {
     },
     dashboard: false,
     readDependencies: ["series_settings.colors"],
+    writeDependencies: ["graph.series_order_dimension"],
   },
   "graph.metrics": {
     section: t`Data`,

--- a/frontend/src/metabase/visualizations/lib/settings/graph.js
+++ b/frontend/src/metabase/visualizations/lib/settings/graph.js
@@ -161,37 +161,46 @@ export const GRAPH_DATA_SETTINGS = {
     marginBottom: "1rem",
 
     getValue: (series, settings) => {
+      const seriesKeys = series.map(s => keyForSingleSeries(s));
       const seriesOrder = settings["graph.series_order"];
       const seriesOrderDimension = settings["graph.series_order_dimension"];
       const currentDimension = settings["graph.dimensions"][1];
 
-      const generateDefault = series => {
-        const keys = series.map(s => keyForSingleSeries(s));
-        return keys.map((key, index) => ({
+      const generateDefault = keys => {
+        return keys.map(key => ({
+          key,
           name: key,
-          originalIndex: index,
           enabled: true,
         }));
       };
+
+      const removeMissingOrder = (keys, order) =>
+        order.filter(o => keys.includes(o.key));
+      const newKeys = (keys, order) =>
+        keys.filter(key => !order.find(o => o.key === key));
 
       if (
         !seriesOrder ||
         !_.isArray(seriesOrder) ||
         seriesOrderDimension !== currentDimension
       ) {
-        return generateDefault(series);
+        return generateDefault(seriesKeys);
       }
 
-      return seriesOrder;
+      return [
+        ...removeMissingOrder(seriesKeys, seriesOrder),
+        ...generateDefault(newKeys(seriesKeys, seriesOrder)),
+      ];
+      // return seriesOrder;
     },
     getProps: (series, settings) => {
       const seriesSettings = settings["series_settings"] || {};
       const seriesColors = settings["series_settings.colors"] || {};
       const keys = series.map(s => keyForSingleSeries(s));
       return {
-        items: keys.map((key, index) => ({
+        items: keys.map(key => ({
+          key,
           name: seriesSettings[key]?.title || key,
-          originalIndex: index,
           color: seriesColors[key],
         })),
         series,

--- a/frontend/src/metabase/visualizations/lib/settings/graph.js
+++ b/frontend/src/metabase/visualizations/lib/settings/graph.js
@@ -139,6 +139,9 @@ export const GRAPH_DATA_SETTINGS = {
         addAnother:
           options.length > addedDimensions.length &&
           addedDimensions.length < maxDimensionsSupported &&
+          addedDimensions.every(
+            dimension => dimension !== undefined && dimension !== null,
+          ) &&
           vizSettings["graph.metrics"].length < 2
             ? t`Add series breakout`
             : null,
@@ -171,6 +174,10 @@ export const GRAPH_DATA_SETTINGS = {
       // Always be the stored setting, not calculated.
       const seriesOrderDimension = settings["graph.series_order_dimension"];
       const currentDimension = settings["graph.dimensions"][1];
+
+      if (currentDimension === undefined) {
+        return [];
+      }
 
       const generateDefault = keys => {
         return keys.map(key => ({

--- a/frontend/src/metabase/visualizations/lib/settings/graph.js
+++ b/frontend/src/metabase/visualizations/lib/settings/graph.js
@@ -197,7 +197,10 @@ export const GRAPH_DATA_SETTINGS = {
         !seriesOrder ||
         !_.isArray(seriesOrder) ||
         !seriesOrder.every(
-          order => !!order.key && !!order.name && !!order.color,
+          order =>
+            order.key !== undefined &&
+            order.name !== undefined &&
+            order.color !== undefined,
         ) ||
         seriesOrderDimension !== currentDimension
       ) {

--- a/frontend/src/metabase/visualizations/shared/utils/data.ts
+++ b/frontend/src/metabase/visualizations/shared/utils/data.ts
@@ -253,7 +253,13 @@ export const getOrderedSeries = (
 
   return seriesOrder
     .filter(orderSetting => orderSetting.enabled)
-    .map(orderSetting =>
-      series.find(singleSeries => singleSeries.seriesKey === orderSetting.key),
-    );
+    .map(orderSetting => {
+      const foundSeries = series.find(
+        singleSeries => singleSeries.seriesKey === orderSetting.key,
+      );
+      if (foundSeries === undefined) {
+        throw new TypeError("Series not found");
+      }
+      return foundSeries;
+    });
 };

--- a/frontend/src/metabase/visualizations/shared/utils/data.ts
+++ b/frontend/src/metabase/visualizations/shared/utils/data.ts
@@ -253,5 +253,7 @@ export const getOrderedSeries = (
 
   return seriesOrder
     .filter(orderSetting => orderSetting.enabled)
-    .map(orderSetting => series[orderSetting.originalIndex]);
+    .map(orderSetting =>
+      series.find(singleSeries => singleSeries.seriesKey === orderSetting.key),
+    );
 };

--- a/frontend/src/metabase/visualizations/shared/utils/data.ts
+++ b/frontend/src/metabase/visualizations/shared/utils/data.ts
@@ -247,7 +247,7 @@ export const getOrderedSeries = (
   series: Series<GroupedDatum, SeriesInfo>[],
   seriesOrder?: SeriesOrderSetting[],
 ) => {
-  if (seriesOrder == null) {
+  if (seriesOrder == null || seriesOrder.length === 0) {
     return series;
   }
 

--- a/frontend/src/metabase/visualizations/visualizations/Funnel.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Funnel.jsx
@@ -150,13 +150,9 @@ export default class Funnel extends Component {
           ...getDefault(newKeys(seriesKeys, seriesOrder)),
         ];
       },
-      getProps: transformedSeries => ({
-        items: transformedSeries.map(s => ({
-          ...s.card,
-          key: s.card.name,
-        })),
+      props: {
         hasEditSettings: false,
-      }),
+      },
       writeDependencies: ["funnel.order_dimension"],
       dataTestId: "funnel-row-sort",
     },

--- a/frontend/src/metabase/visualizations/visualizations/Funnel.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Funnel.jsx
@@ -153,6 +153,9 @@ export default class Funnel extends Component {
       props: {
         hasEditSettings: false,
       },
+      getHidden: (series, settings) =>
+        settings["funnel.dimension"] === null ||
+        settings["funnel.metric"] === null,
       writeDependencies: ["funnel.order_dimension"],
       dataTestId: "funnel-row-sort",
     },

--- a/frontend/src/metabase/visualizations/visualizations/Funnel.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Funnel.jsx
@@ -19,6 +19,7 @@ import {
   dimensionSetting,
 } from "metabase/visualizations/lib/settings/utils";
 import { columnSettings } from "metabase/visualizations/lib/settings/column";
+import { keyForSingleSeries } from "metabase/visualizations/lib/settings/series";
 
 import ChartCaption from "metabase/visualizations/components/ChartCaption";
 import { ChartSettingOrderedSimple } from "metabase/visualizations/components/settings/ChartSettingOrderedSimple";
@@ -110,36 +111,53 @@ export default class Funnel extends Component {
       showColumnSetting: true,
       marginBottom: "0.625rem",
     }),
+    "funnel.order_dimension": {
+      getValue: (_series, settings) => settings["funnel.dimension"],
+      readDependencies: ["funnel.rows"],
+    },
     "funnel.rows": {
       section: t`Data`,
       widget: ChartSettingOrderedSimple,
-      isValid: (series, settings) => {
-        const funnelRows = settings["funnel.rows"];
 
-        if (!funnelRows || !_.isArray(funnelRows)) {
-          return false;
+      getValue: (series, settings) => {
+        const seriesOrder = settings["funnel.rows"];
+        const seriesKeys = series.map(s => keyForSingleSeries(s));
+        const orderDimension = settings["funnel.order_dimension"];
+        const dimension = settings["funnel.dimension"];
+
+        const getDefault = keys =>
+          keys.map(key => ({
+            key,
+            name: key,
+            enabled: true,
+          }));
+        if (
+          !seriesOrder ||
+          !_.isArray(seriesOrder) ||
+          !seriesOrder.every(setting => setting.key !== undefined) ||
+          orderDimension !== dimension
+        ) {
+          return getDefault(seriesKeys);
         }
-        if (!funnelRows.every(setting => setting.originalIndex !== undefined)) {
-          return false;
-        }
 
-        return (
-          funnelRows.every(setting => series[setting.originalIndex]) &&
-          funnelRows.length === series.length
-        );
-      },
+        const removeMissingOrder = (keys, order) =>
+          order.filter(o => keys.includes(o.key));
+        const newKeys = (keys, order) =>
+          keys.filter(key => !order.find(o => o.key === key));
 
-      getDefault: transformedSeries => {
-        return transformedSeries.map(s => ({
-          name: s.card.name,
-          originalIndex: s.card.originalIndex,
-          enabled: true,
-        }));
+        return [
+          ...removeMissingOrder(seriesKeys, seriesOrder),
+          ...getDefault(newKeys(seriesKeys, seriesOrder)),
+        ];
       },
       getProps: transformedSeries => ({
-        items: transformedSeries.map(s => s.card),
+        items: transformedSeries.map(s => ({
+          ...s.card,
+          key: s.card.name,
+        })),
         hasEditSettings: false,
       }),
+      writeDependencies: ["funnel.order_dimension"],
       dataTestId: "funnel-row-sort",
     },
     ...metricSetting("funnel.metric", {

--- a/frontend/test/metabase/scenarios/visualizations/bar_chart.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/bar_chart.cy.spec.js
@@ -4,6 +4,7 @@ import {
   sidebar,
   getDraggableElements,
   moveColumnDown,
+  popover,
 } from "__support__/e2e/helpers";
 
 import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
@@ -175,6 +176,52 @@ describe("scenarios > visualizations > bar chart", () => {
           cy.findAllByTestId("legend-item").should("have.length", 4);
           cy.get(".enable-dots").should("have.length", 4);
         });
+    });
+
+    it("should gracefully handle removing filtered items, and adding new items to the end of the list", () => {
+      moveColumnDown(getDraggableElements().first(), 2);
+
+      getDraggableElements()
+        .eq(1)
+        .within(() => {
+          cy.icon("eye_filled").click();
+        });
+
+      cy.findByText("Filter").click();
+      cy.findByText("Product").click();
+
+      cy.findByTestId("filter-field-Category").within(() => {
+        cy.findByTestId("operator-select").click();
+      });
+
+      popover().within(() => {
+        cy.findByText("Is not").click();
+      });
+
+      cy.findByTestId("filter-field-Category").within(() => {
+        cy.findByText("Gadget").click();
+      });
+
+      cy.findByText("Apply Filters").click();
+
+      getDraggableElements().should("have.length", 3);
+
+      //Ensures that "Gizmo" is still hidden, so it's state hasn't changed.
+      getDraggableElements()
+        .eq(0)
+        .within(() => {
+          cy.icon("eye_crossed_out").click();
+        });
+
+      cy.findByTestId("qb-filters-panel").within(() => {
+        cy.icon("close").click();
+      });
+
+      getDraggableElements().should("have.length", 4);
+
+      //Re-added items should appear at the end of the list.
+      getDraggableElements().eq(0).should("have.text", "Gizmo");
+      getDraggableElements().eq(3).should("have.text", "Gadget");
     });
   });
 });

--- a/frontend/test/metabase/scenarios/visualizations/funnel.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/funnel.cy.spec.js
@@ -4,6 +4,7 @@ import {
   sidebar,
   getDraggableElements,
   moveColumnDown,
+  popover,
 } from "__support__/e2e/helpers";
 
 import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
@@ -68,5 +69,52 @@ describe("scenarios > visualizations > funnel chart", () => {
         cy.icon("eye_crossed_out").click();
       });
     cy.findAllByTestId("funnel-chart-header").should("have.length", 5);
+  });
+
+  it("should handle row items being filterd out and returned gracefully", () => {
+    moveColumnDown(getDraggableElements().first(), 2);
+
+    getDraggableElements()
+      .eq(1)
+      .within(() => {
+        cy.icon("eye_filled").click();
+      });
+
+    cy.findByText("Filter").click();
+
+    cy.findByTestId("filter-field-Source").within(() => {
+      cy.findByTestId("operator-select").click();
+    });
+
+    popover().within(() => {
+      cy.findByText("Is not").click();
+    });
+
+    cy.findByTestId("filter-field-Source").within(() => {
+      cy.findByText("Facebook").click();
+    });
+
+    cy.findByText("Apply Filters").click();
+
+    getDraggableElements().should("have.length", 4);
+
+    //Ensures that "Google" is still hidden, so it's state hasn't changed.
+    getDraggableElements()
+      .eq(0)
+      .within(() => {
+        cy.icon("eye_crossed_out").click();
+      });
+
+    cy.log("remove filter");
+
+    cy.findByTestId("qb-filters-panel").within(() => {
+      cy.icon("close").click();
+    });
+
+    getDraggableElements().should("have.length", 5);
+
+    //Re-added items should appear at the end of the list.
+    getDraggableElements().eq(0).should("have.text", "Google");
+    getDraggableElements().eq(4).should("have.text", "Facebook");
   });
 });


### PR DESCRIPTION
Fixes https://metaboat.slack.com/archives/C03SD8HDJLC/p1664930176820349

This PR aims to resolve the issue of order being preserved when the series changes. We no longer look at the length of the series to decide if we are invalidating `graph.series_order`, but we look at what the second dimension of the graph is. This value is stored as `graph.series_order_dimension`.

It's worth noting that the new `graph.series_order` isn't actually saved as a stored visual setting until you make a change to the series order. So your order/enabled flags are actually preserved when switching from one dimension to another, and then back again.

Example:
![chrome_rhusD0Lx7G](https://user-images.githubusercontent.com/1328979/202787383-1dc5a99b-6e43-4fe2-8fcb-17b097203d0e.gif)
