### PR TITLE
Record Cypress runs using Deploysentinel on `master` only

### DIFF
--- a/.github/workflows/e2e-main.yml
+++ b/.github/workflows/e2e-main.yml
@@ -53,7 +53,6 @@ jobs:
       MB_SNOWPLOW_AVAILABLE: true
       MB_SNOWPLOW_URL: "http://localhost:9090"  # Snowplow micro
       RECORDING_ENABLED: ${{ secrets.CURRENTS_KEY }}
-      CYPRESS_DEPLOYSENTINEL_KEY: ${{ secrets.CYPRESS_DEPLOYSENTINEL_KEY }}
       ELECTRON_EXTRA_LAUNCH_ARGS: '--remote-debugging-port=40500' # deploysentinel
     strategy:
       fail-fast: false
@@ -119,6 +118,10 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
     steps:
     - uses: actions/checkout@v3
+    - name: Set conditional ENVs
+      if: github.ref == 'refs/heads/master'
+      run: |
+        echo "CYPRESS_DEPLOYSENTINEL_KEY=${{ secrets.CYPRESS_DEPLOYSENTINEL_KEY }}" >> $GITHUB_ENV
     - name: Prepare front-end environment
       uses: ./.github/actions/prepare-frontend
     - name: Prepare JDK ${{ matrix.java-version }}
@@ -140,7 +143,7 @@ jobs:
         jar xf target/uberjar/metabase.jar version.properties
         mv version.properties resources/
 
-    - name: Run Cypress tests on ${{ matrix.folder }} - Master Branch
+    - name: Run and record Cypress tests on ${{ matrix.folder }} - Master Branch
       if: github.ref == 'refs/heads/master' && env.RECORDING_ENABLED != null
       run: |
         yarn run test-cypress-run \


### PR DESCRIPTION
There's no point in recording E2E runs on release branches.
We already did the same for the Currents dashboard, so this PR mimics that behavior for the Deploysentinel.