### PR TITLE
[E2E] Optimize testing matrix on `master` and `release` branches

### DIFF
--- a/.github/workflows/e2e-main.yml
+++ b/.github/workflows/e2e-main.yml
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-20.04
     timeout-minutes: 45
     needs: build
-    name: e2e-tests-${{ matrix.folder }}-${{ matrix.edition }}
+    name: e2e-tests-${{ matrix.folder }}${{ matrix.context }}-${{ matrix.edition }}
     env:
       MB_EDITION: ${{ matrix.edition }}
       DISPLAY: ""
@@ -58,7 +58,7 @@ jobs:
       fail-fast: false
       matrix:
         java-version: [11]
-        edition: [oss, ee]
+        edition: [ee]
         folder:
           - "admin"
           - "binning"
@@ -79,6 +79,10 @@ jobs:
           - "question"
           - "sharing"
           - "visualizations"
+        include:
+          - edition: oss
+            context: grep
+            java-version: 11
     services:
       maildev:
         image: maildev/maildev:1.1.0
@@ -143,8 +147,17 @@ jobs:
         jar xf target/uberjar/metabase.jar version.properties
         mv version.properties resources/
 
-    - name: Run and record Cypress tests on ${{ matrix.folder }} - Master Branch
-      if: github.ref == 'refs/heads/master' && env.RECORDING_ENABLED != null
+    - name: Run OSS-specific Cypress tests
+      if: matrix.edition == 'oss'
+      run: |
+        yarn run test-cypress-run \
+        --env grepTags=@OSS \
+        --spec './frontend/test/metabase/scenarios/**/*.cy.spec.js'
+      env:
+        TERM: xterm
+
+    - name: Run and record Cypress tests on ${{ matrix.folder }} - master branch
+      if: github.ref == 'refs/heads/master' && env.RECORDING_ENABLED != null && matrix.edition == 'ee'
       run: |
         yarn run test-cypress-run \
           --folder ${{ matrix.folder }} \
@@ -154,8 +167,8 @@ jobs:
       env:
         TERM: xterm
 
-    - name: Run Cypress tests on ${{ matrix.folder }}
-      if: ${{ github.ref != 'refs/heads/master' }}
+    - name: Run Cypress tests on ${{ matrix.folder }} - branches other than master
+      if: github.ref != 'refs/heads/master' && matrix.edition == 'ee'
       run: |
         yarn run test-cypress-run \
           --folder ${{ matrix.folder }}
@@ -166,7 +179,7 @@ jobs:
       uses: actions/upload-artifact@v3
       if: failure()
       with:
-        name: cypress-artifacts-${{ matrix.folder }}-${{ matrix.edition }}
+        name: cypress-recording-${{ matrix.folder }}${{ matrix.context }}-${{ matrix.edition }}
         path: |
           ./cypress
           ./logs/test.log

--- a/.github/workflows/e2e-main.yml
+++ b/.github/workflows/e2e-main.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - "master"
       - 'release-**'
-      - 'e2e-optimize-matrix'
     paths-ignore:
       - "docs/**"
       - "**.md"

--- a/.github/workflows/e2e-main.yml
+++ b/.github/workflows/e2e-main.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - "master"
       - 'release-**'
+      - 'e2e-optimize-matrix'
     paths-ignore:
       - "docs/**"
       - "**.md"


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Applies the same logic we're using for E2E tests on PRs to the main E2E workflow
    - No need to run the full test suite against both OSS and EE uberjars
    - We can run **all** EE tests against EE uberjar and then only a small subset of OSS-specific tests against OSS uberjar
    - That way we covered all features across both versions in half the amount of tests

### Why?
- Our monthly test usage is enormous, even if we record on `master` only
- The current way of testing is redundant. We **don't** actually need to verify both uberjars on every single commit and especially not on `master` branch

### How to test?
- Take a look at this temporary run: https://github.com/metabase/metabase/actions/runs/3515639045
- All tests should still work, but the only OSS job in the list should be the grep-oss; you shouldn't see admin-oss, binning-oss, etc.

### Related previous PRs
- https://github.com/metabase/metabase/pull/21676
- https://github.com/metabase/metabase/pull/23009

## The next steps:
- We still have to make sure we can run the most extensive set of E2E tests prior to the release
    - this can be a manual trigger or a scheduled one*
Either:
- Create a new workflow (which might be excessive)
- Create a reusable workflow and conditionally determine what should run and where (based on the trigger)
    - this might be slightly hacky and/or hard to achieve but will greatly help with the deduplication of code

*Note: Scheduled workflows run only on the `master` branch and we most likely need it on release branch.