### PR TITLE
[E2E] Remove `cy2` (hosted library for sorry-cypress dashboard analytics)

### DIFF
--- a/.github/workflows/e2e-main.yml
+++ b/.github/workflows/e2e-main.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - "master"
       - 'release-**'
-      - 'e2e-remove-currents'
     paths-ignore:
       - "docs/**"
       - "**.md"
@@ -124,7 +123,7 @@ jobs:
     - uses: actions/checkout@v3
     # Test runs will be recorded using Deploysentinel on `master` only
     - name: Set conditional ENVs
-      if: github.ref == 'refs/heads/e2e-remove-currents'
+      if: github.ref == 'refs/heads/master'
       run: |
         echo "CYPRESS_DEPLOYSENTINEL_KEY=${{ secrets.CYPRESS_DEPLOYSENTINEL_KEY }}" >> $GITHUB_ENV
     - name: Prepare front-end environment

--- a/.github/workflows/e2e-main.yml
+++ b/.github/workflows/e2e-main.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - "master"
       - 'release-**'
+      - 'e2e-remove-currents'
     paths-ignore:
       - "docs/**"
       - "**.md"
@@ -123,7 +124,7 @@ jobs:
     - uses: actions/checkout@v3
     # Test runs will be recorded using Deploysentinel on `master` only
     - name: Set conditional ENVs
-      if: github.ref == 'refs/heads/master'
+      if: github.ref == 'refs/heads/e2e-remove-currents'
       run: |
         echo "CYPRESS_DEPLOYSENTINEL_KEY=${{ secrets.CYPRESS_DEPLOYSENTINEL_KEY }}" >> $GITHUB_ENV
     - name: Prepare front-end environment

--- a/.github/workflows/e2e-main.yml
+++ b/.github/workflows/e2e-main.yml
@@ -52,7 +52,6 @@ jobs:
       MB_PREMIUM_EMBEDDING_TOKEN: ${{ secrets.ENTERPRISE_TOKEN }}
       MB_SNOWPLOW_AVAILABLE: true
       MB_SNOWPLOW_URL: "http://localhost:9090"  # Snowplow micro
-      RECORDING_ENABLED: ${{ secrets.CURRENTS_KEY }}
       ELECTRON_EXTRA_LAUNCH_ARGS: '--remote-debugging-port=40500' # deploysentinel
     strategy:
       fail-fast: false
@@ -122,6 +121,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
     steps:
     - uses: actions/checkout@v3
+    # Test runs will be recorded using Deploysentinel on `master` only
     - name: Set conditional ENVs
       if: github.ref == 'refs/heads/master'
       run: |
@@ -156,19 +156,9 @@ jobs:
       env:
         TERM: xterm
 
-    - name: Run and record Cypress tests on ${{ matrix.folder }} - master branch
-      if: github.ref == 'refs/heads/master' && env.RECORDING_ENABLED != null && matrix.edition == 'ee'
-      run: |
-        yarn run test-cypress-run \
-          --folder ${{ matrix.folder }} \
-          --record --key ${{ secrets.CURRENTS_KEY }} \
-          --group ${{ matrix.folder }}-${{ matrix.edition }} \
-          --ci-build-id "${{ github.run_id }}-${{ github.run_attempt }}"
-      env:
-        TERM: xterm
-
-    - name: Run Cypress tests on ${{ matrix.folder }} - branches other than master
-      if: github.ref != 'refs/heads/master' && matrix.edition == 'ee'
+    # These are EE-specific and version-agnostic tests
+    - name: Run Cypress E2E tests against EE uberjar
+      if: matrix.edition == 'ee'
       run: |
         yarn run test-cypress-run \
           --folder ${{ matrix.folder }}

--- a/frontend/test/__runner__/cypress-runner-run-tests.js
+++ b/frontend/test/__runner__/cypress-runner-run-tests.js
@@ -1,4 +1,3 @@
-const { patch } = require("cy2");
 const cypress = require("cypress");
 const arg = require("arg");
 
@@ -41,18 +40,6 @@ const runCypress = async (baseUrl, exitFunction) => {
     command: "yarn run clean-cypress-artifacts",
     message: "Removing the existing Cypress artifacts\n",
   });
-
-  /**
-   * We need to patch CYPRESS_API_URL with cy2 in order to use currents.dev dashboard for recording.
-   * This is applicable only when you explicitly use the `--record` flag, with the provided `--key`.
-   */
-  try {
-    patch("https://cy.currents.dev");
-  } catch (e) {
-    console.error("Failed to patch Cypress!\n", e);
-
-    await exitFunction(1);
-  }
 
   const defaultConfig = {
     browser: "chrome",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "cron-expression-validator": "^1.0.20",
     "cronstrue": "^2.11.0",
     "crossfilter": "^1.3.12",
-    "cy2": "^1.3.0",
     "d3": "^3.5.17",
     "d3-array": "^3.1.1",
     "d3-scale": "^3.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9323,15 +9323,6 @@ currently-unhandled@^0.4.1:
   dependencies:
     array-find-index "^1.0.1"
 
-cy2@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/cy2/-/cy2-1.3.0.tgz#b01e731e6bef5c053602088e71be45411188a974"
-  integrity sha512-VE0YOGw9LmQHnmND1RrtJ/BJaCNCCGeOF8C4FUcV5OgS8G2zZytND3TC1TKuwEuFM/br17KIfgheql/rNRfv3g==
-  dependencies:
-    debug "^4.3.2"
-    js-yaml "^4.0.0"
-    npm-which "^3.0.1"
-
 cyclist@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-1.0.1.tgz#596e9698fd0c80e12038c2b82d6eb1b35b6224d9"


### PR DESCRIPTION
### Status
PENDING CI && PENDING REVIEW

### What does this PR accomplish?
Removes integration with https://currents.dev/, which is the hosted Cypress analytics dashboard based on https://sorry-cypress.dev/.

We will evaluate deplysentinel.com in the next 6 months so it doesn't make sense to have two analytics dashboards and to pay for two services.