### PR TITLE
Change zero-argument custom expression functions format with parens

### DIFF
--- a/docs/questions/query-builder/expressions-list.md
+++ b/docs/questions/query-builder/expressions-list.md
@@ -80,9 +80,9 @@ Example: `Average([Quantity])` would return the mean for the `Quantity` field.
 
 Returns the count of rows (also known as records) in the selected data.
 
-Syntax: `Count`
+Syntax: `Count()`
 
-Example: `Count` If a table or result returns 10 rows, `Count` will return `10`.
+Example: `Count()` If a table or result returns 10 rows, `Count()` will return `10`.
 
 ### CountIf
 
@@ -96,9 +96,9 @@ Example: `CountIf([Subtotal] > 100)` would return the number of rows where the s
 
 The additive total of rows across a breakout.
 
-Syntax: `CumulativeCount`.
+Syntax: `CumulativeCount()`.
 
-Example: `CumulativeCount`.
+Example: `CumulativeCount()`.
 
 ### CumulativeSum
 

--- a/frontend/src/metabase-lib/expressions/format.js
+++ b/frontend/src/metabase-lib/expressions/format.js
@@ -111,9 +111,7 @@ function formatFunction([fn, ...args], options) {
   }
   const formattedName = getExpressionName(fn);
   const formattedArgs = args.map(arg => format(arg, options));
-  return args.length === 0
-    ? formattedName + "()"
-    : `${formattedName}(${formattedArgs.join(", ")})`;
+  return `${formattedName}(${formattedArgs.join(", ")})`;
 }
 
 function formatOperator([op, ...args], options) {

--- a/frontend/src/metabase-lib/expressions/format.js
+++ b/frontend/src/metabase-lib/expressions/format.js
@@ -112,7 +112,7 @@ function formatFunction([fn, ...args], options) {
   const formattedName = getExpressionName(fn);
   const formattedArgs = args.map(arg => format(arg, options));
   return args.length === 0
-    ? formattedName
+    ? formattedName + "()"
     : `${formattedName}(${formattedArgs.join(", ")})`;
 }
 

--- a/frontend/src/metabase-lib/expressions/helper-text-strings.ts
+++ b/frontend/src/metabase-lib/expressions/helper-text-strings.ts
@@ -4,16 +4,16 @@ import { HelpText } from "./types";
 const helperTextStrings: HelpText[] = [
   {
     name: "count",
-    structure: "Count",
+    structure: "Count()",
     description: t`Returns the count of rows in the selected data.`,
-    example: "Count",
+    example: "Count()",
     args: [],
   },
   {
     name: "cum-count",
-    structure: "CumulativeCount",
+    structure: "CumulativeCount()",
     description: t`The additive total of rows across a breakout.`,
-    example: "CumulativeCount",
+    example: "CumulativeCount()",
     args: [],
   },
   {

--- a/frontend/src/metabase-lib/expressions/suggest.js
+++ b/frontend/src/metabase-lib/expressions/suggest.js
@@ -16,11 +16,7 @@ import {
   formatSegmentName,
 } from "./index";
 
-const suggestionText = func => {
-  const { displayName, args } = func;
-  const suffix = args.length > 0 ? "(" : " ";
-  return displayName + suffix;
-};
+const suggestionText = func => func.displayName + "(";
 
 export function suggest({
   source,

--- a/frontend/test/metabase/lib/expressions/__support__/shared.js
+++ b/frontend/test/metabase/lib/expressions/__support__/shared.js
@@ -73,16 +73,16 @@ const expression = [
 ];
 
 const aggregation = [
-  ["Count", ["count"], "aggregation with no arguments"],
+  ["Count()", ["count()"], "aggregation with no arguments"],
   ["Sum([Total])", ["sum", total], "aggregation with one argument"],
-  ["1 - Count", ["-", 1, ["count"]], "aggregation with math outside"],
+  ["1 - Count()", ["-", 1, ["count"]], "aggregation with math outside"],
   [
     "Sum([Total] * 2)",
     ["sum", ["*", total, 2]],
     "aggregation with math inside",
   ],
   [
-    "1 - Sum([Total] * 2) / Count",
+    "1 - Sum([Total] * 2) / Count()",
     ["-", 1, ["/", ["sum", ["*", total, 2]], ["count"]]],
     "aggregation with math inside and outside",
   ],
@@ -117,14 +117,14 @@ const aggregation = [
   // should not compile:
   ["Count([Total])", undefined, "invalid count arguments"],
   ["SumIf([Total] > 50, [Total])", undefined, "invalid sum-where arguments"],
-  ["Count + Share((", undefined, "invalid share"],
+  ["Count() + Share((", undefined, "invalid share"],
 ];
 
 // Skipped for now: temporary, known regression
 /* eslint-disable no-unused-vars */
 const nested_aggregation = [
   // should not compile:
-  ["Sum(Count)", undefined, "aggregation nested inside another aggregation"],
+  ["Sum(Count())", undefined, "aggregation nested inside another aggregation"],
 ];
 /* eslint-enable no-unused-vars */
 

--- a/frontend/test/metabase/lib/expressions/__support__/shared.js
+++ b/frontend/test/metabase/lib/expressions/__support__/shared.js
@@ -73,7 +73,7 @@ const expression = [
 ];
 
 const aggregation = [
-  ["Count()", ["count()"], "aggregation with no arguments"],
+  ["Count()", ["count"], "aggregation with no arguments"],
   ["Sum([Total])", ["sum", total], "aggregation with one argument"],
   ["1 - Count()", ["-", 1, ["count"]], "aggregation with math outside"],
   [

--- a/frontend/test/metabase/lib/expressions/suggest.unit.spec.js
+++ b/frontend/test/metabase/lib/expressions/suggest.unit.spec.js
@@ -208,9 +208,9 @@ describe("metabase/lib/expression/suggest", () => {
       it("should suggest partial matches after an aggregation", () => {
         expect(suggest({ source: "average(c", ...aggregationOpts })).toEqual([
           // FIXME: the next four should not appear
-          { type: "aggregations", text: "Count " },
+          { type: "aggregations", text: "Count(" },
           { type: "aggregations", text: "CountIf(" },
-          { type: "aggregations", text: "CumulativeCount " },
+          { type: "aggregations", text: "CumulativeCount(" },
           { type: "aggregations", text: "CumulativeSum(" },
           { type: "fields", text: "[C] " },
           { type: "fields", text: "[count] " },
@@ -224,9 +224,9 @@ describe("metabase/lib/expression/suggest", () => {
 
       it("should suggest partial matches in aggregation", () => {
         expect(suggest({ source: "1 + C", ...aggregationOpts })).toEqual([
-          { type: "aggregations", text: "Count " },
+          { type: "aggregations", text: "Count(" },
           { type: "aggregations", text: "CountIf(" },
-          { type: "aggregations", text: "CumulativeCount " },
+          { type: "aggregations", text: "CumulativeCount(" },
           { type: "aggregations", text: "CumulativeSum(" },
           { type: "fields", text: "[C] " },
           { type: "fields", text: "[count] " },
@@ -259,7 +259,7 @@ describe("metabase/lib/expression/suggest", () => {
             startRule: "aggregation",
           }),
         ).toEqual([
-          { type: "aggregations", text: "Count " },
+          { type: "aggregations", text: "Count(" },
           { type: "aggregations", text: "CountIf(" },
         ]);
       });


### PR DESCRIPTION
Changes zero-argument functions to read like `<function-name>()` instead of just `<function-name>` in the custom expression editor. The new format will still compile to the same MBQL data structure in JSON/EDN.

<img width="291" alt="image" src="https://user-images.githubusercontent.com/39073188/203128151-e23e0b6e-b37d-4614-b507-e768afd4e217.png">

One side-effect of this is that all existing custom expressions that contain `count` without parentheses will now appear as `count()` to the user. Users can still write `count`, and when they close and open the custom expression editor again it will be rendered as `count()`.

[Slack thread](https://metaboat.slack.com/archives/C03SHMZ266R/p1668676917056199) for context on why we're making this change, which came from a discussion on [the now() function](https://github.com/metabase/metabase/pull/26548).