### PR TITLE
Better null handling in action forms

### DIFF
--- a/frontend/src/metabase-types/api/writeback.ts
+++ b/frontend/src/metabase-types/api/writeback.ts
@@ -57,7 +57,7 @@ export type WritebackAction = WritebackActionBase & (QueryAction | HttpAction);
 export type ParameterMappings = Record<ParameterId, ParameterTarget>;
 
 export type ParametersForActionExecution = {
-  [id: ParameterId]: string | number;
+  [id: ParameterId]: string | number | null;
 };
 
 export interface ActionFormSubmitResult {

--- a/frontend/src/metabase/writeback/containers/ActionParametersInputForm/utils.ts
+++ b/frontend/src/metabase/writeback/containers/ActionParametersInputForm/utils.ts
@@ -26,8 +26,8 @@ export function setNumericValues(
   fieldSettings: { [tagId: string]: FieldSettings },
 ) {
   Object.entries(params).forEach(([key, value]) => {
-    if (fieldSettings[key]?.fieldType === "number") {
-      params[key] = Number(value) ?? 0;
+    if (fieldSettings[key]?.fieldType === "number" && !isEmpty(value)) {
+      params[key] = Number(value) ?? null;
     }
   });
 
@@ -41,6 +41,11 @@ export const getChangedValues = (
   const changedValues = Object.entries(newValues).filter(
     ([newKey, newValue]) => {
       const oldValue = oldValues[newKey];
+
+      // don't flag a change when the input changes itself to an empty string
+      if (oldValue === null && newValue === "") {
+        return false;
+      }
       return newValue !== oldValue;
     },
   );
@@ -48,12 +53,17 @@ export const getChangedValues = (
   return Object.fromEntries(changedValues);
 };
 
-const formatValue = (value: string | number, inputType?: string) => {
-  if (inputType === "date") {
-    return moment(value).format("YYYY-MM-DD");
-  }
-  if (inputType === "datetime-local") {
-    return moment(value).format("YYYY-MM-DD HH:mm:ss");
+export const formatValue = (
+  value: string | number | null,
+  inputType?: string,
+) => {
+  if (!isEmpty(value) && moment(value).isValid()) {
+    if (inputType === "date") {
+      return moment(value).utc(false).format("YYYY-MM-DD");
+    }
+    if (inputType === "datetime-local") {
+      return moment(value).utc(false).format("YYYY-MM-DDTHH:mm:ss");
+    }
   }
   if (inputType === "time") {
     return String(value).replace(/z/gi, "");

--- a/frontend/src/metabase/writeback/containers/ActionParametersInputForm/utils.ts
+++ b/frontend/src/metabase/writeback/containers/ActionParametersInputForm/utils.ts
@@ -64,9 +64,9 @@ export const formatValue = (
     if (inputType === "datetime-local" && moment(value).isValid()) {
       return moment(value).utc(false).format("YYYY-MM-DDTHH:mm:ss");
     }
-  }
-  if (inputType === "time") {
-    return String(value).replace(/z/gi, "");
+    if (inputType === "time") {
+      return String(value).replace(/z/gi, "");
+    }
   }
   return value;
 };

--- a/frontend/src/metabase/writeback/containers/ActionParametersInputForm/utils.ts
+++ b/frontend/src/metabase/writeback/containers/ActionParametersInputForm/utils.ts
@@ -57,11 +57,11 @@ export const formatValue = (
   value: string | number | null,
   inputType?: string,
 ) => {
-  if (!isEmpty(value) && moment(value).isValid()) {
-    if (inputType === "date") {
+  if (!isEmpty(value)) {
+    if (inputType === "date" && moment(value).isValid()) {
       return moment(value).utc(false).format("YYYY-MM-DD");
     }
-    if (inputType === "datetime-local") {
+    if (inputType === "datetime-local" && moment(value).isValid()) {
       return moment(value).utc(false).format("YYYY-MM-DDTHH:mm:ss");
     }
   }

--- a/frontend/src/metabase/writeback/containers/ActionParametersInputForm/utils.unit.spec.ts
+++ b/frontend/src/metabase/writeback/containers/ActionParametersInputForm/utils.unit.spec.ts
@@ -1,5 +1,10 @@
 import type { FieldSettingsMap } from "metabase-types/api";
-import { setDefaultValues } from "./utils";
+import {
+  setDefaultValues,
+  getChangedValues,
+  setNumericValues,
+  formatValue,
+} from "./utils";
 
 describe("writeback > containers > ActionParametersInputForm > utils", () => {
   describe("setDefaultValues", () => {
@@ -107,6 +112,112 @@ describe("writeback > containers > ActionParametersInputForm > utils", () => {
         "abc-def": "bar",
         "ghi-jkl": "baz",
       });
+    });
+  });
+
+  describe("formatValue", () => {
+    it("ignores null values", () => {
+      const result = formatValue(null);
+      expect(result).toEqual(null);
+    });
+
+    it("ignores numeric values", () => {
+      const result = formatValue(123);
+      expect(result).toEqual(123);
+    });
+
+    it("ignores string values", () => {
+      const result = formatValue("123");
+      expect(result).toEqual("123");
+    });
+
+    it("formats dates", () => {
+      const result = formatValue("2020-05-01T00:00:00Z", "date");
+      expect(result).toEqual("2020-05-01");
+    });
+
+    it("formats datetimes", () => {
+      const result = formatValue("2020-05-01T05:00:00Z", "datetime-local");
+      expect(result).toEqual("2020-05-01T05:00:00");
+    });
+  });
+
+  describe("setNumericValues", () => {
+    it("should set a numeric value for a numeric form field", () => {
+      const params = {
+        "abc-def": "123",
+      };
+
+      const fieldSettings = {
+        "abc-def": {
+          fieldType: "number",
+        },
+      };
+
+      const result = setNumericValues(
+        params,
+        fieldSettings as unknown as FieldSettingsMap,
+      );
+
+      expect(result).toEqual({
+        "abc-def": 123,
+      });
+    });
+
+    it("should not alter string fields", () => {
+      const params = {
+        "abc-def": "123",
+        "ghi-jkl": "456",
+      };
+
+      const fieldSettings = {
+        "abc-def": {
+          fieldType: "number",
+        },
+        "ghi-jkl": {
+          fieldType: "string",
+        },
+      };
+
+      const result = setNumericValues(
+        params,
+        fieldSettings as unknown as FieldSettingsMap,
+      );
+
+      expect(result).toEqual({
+        "abc-def": 123,
+        "ghi-jkl": "456",
+      });
+    });
+  });
+
+  describe("getChangedValues", () => {
+    it("should flag changed fields", () => {
+      const oldValues = {
+        "abc-def": null,
+      };
+
+      const newValues = {
+        "abc-def": "abc",
+      };
+
+      const result = getChangedValues(newValues, oldValues);
+
+      expect(result).toEqual(newValues);
+    });
+
+    it("should not flag fields changed from null to empty string", () => {
+      const oldValues = {
+        "abc-def": null,
+      };
+
+      const newValues = {
+        "abc-def": "",
+      };
+
+      const result = getChangedValues(newValues, oldValues);
+
+      expect(result).toEqual({});
     });
   });
 });


### PR DESCRIPTION
closes #26577 

## Description

Our form components were changing null values to `0` or `''` instead of leaving them null, this adds checks on save to preserve null values where appropriate.

This also adds unit tests for a few action-payload formatting functions.

## Testing steps
- open an update form for a table with non-required columns that have null values.
- edit something in the form, but leave the null column alone
- the column should remain null instead of being populated with 0 or an empty string
