### PR TITLE
Fixes "Add series" modal when an instance has corrupted questions

### DIFF
--- a/frontend/src/metabase-lib/Question.ts
+++ b/frontend/src/metabase-lib/Question.ts
@@ -194,7 +194,7 @@ class QuestionInner {
       }
     }
 
-    throw new Error("Unknown query type: " + datasetQuery.type);
+    console.warn("Unknown query type: " + datasetQuery?.type);
   }
 
   isNative(): boolean {

--- a/frontend/src/metabase-lib/queries/InternalQuery.ts
+++ b/frontend/src/metabase-lib/queries/InternalQuery.ts
@@ -11,6 +11,6 @@ import AtomicQuery from "metabase-lib/queries/AtomicQuery"; // Internal queries 
 
 export default class InternalQuery extends AtomicQuery {
   static isDatasetQueryType(datasetQuery: DatasetQuery) {
-    return datasetQuery.type === "internal";
+    return datasetQuery?.type === "internal";
   }
 }

--- a/frontend/src/metabase-lib/queries/NativeQuery.ts
+++ b/frontend/src/metabase-lib/queries/NativeQuery.ts
@@ -137,7 +137,7 @@ export default class NativeQuery extends AtomicQuery {
   }
 
   static isDatasetQueryType(datasetQuery: DatasetQuery) {
-    return datasetQuery && datasetQuery.type === NATIVE_QUERY_TEMPLATE.type;
+    return datasetQuery?.type === NATIVE_QUERY_TEMPLATE.type;
   }
 
   /* Query superclass methods */

--- a/frontend/src/metabase-lib/queries/StructuredQuery.ts
+++ b/frontend/src/metabase-lib/queries/StructuredQuery.ts
@@ -99,7 +99,7 @@ export interface SegmentOption {
 
 class StructuredQueryInner extends AtomicQuery {
   static isDatasetQueryType(datasetQuery: DatasetQuery) {
-    return datasetQuery && datasetQuery.type === STRUCTURED_QUERY_TEMPLATE.type;
+    return datasetQuery?.type === STRUCTURED_QUERY_TEMPLATE.type;
   }
 
   // For Flow type completion


### PR DESCRIPTION
Related to https://github.com/metabase/metabase/issues/15222

## Changes

Replaces throwing an error with a console warning when a question has an invalid query. Ideally, the BE should not return questions like that which possibly will be implemented. For now, we need to stop throwing this error to prevent the entire app from crashing when users open "Add a series" modal and their instance has at least one question with a broken query.

## How to verify

- Create Q1: Orders, Count, Summarized by Created At
- Create Q2: Orders, Average of Total, Summarized by Created At
- Open your app db, find the Q2 question in the `report_card` table and corrupt its `dataset_query`
- Create a dashboard, add Q1
- Click "Add a series"
- Ensure the app has not crashed
