### PR TITLE
Support for Action Form Field Ordering

### DIFF
--- a/frontend/src/metabase/lib/array.ts
+++ b/frontend/src/metabase/lib/array.ts
@@ -1,9 +1,5 @@
-export const moveElement = (
-  array: unknown[],
-  oldIndex: number,
-  newIndex: number,
-) => {
+export function moveElement<T>(array: T[], oldIndex: number, newIndex: number) {
   const arrayCopy = [...array];
   arrayCopy.splice(newIndex, 0, arrayCopy.splice(oldIndex, 1)[0]);
   return arrayCopy;
-};
+}

--- a/frontend/src/metabase/lib/array.ts
+++ b/frontend/src/metabase/lib/array.ts
@@ -1,0 +1,9 @@
+export const moveElement = (
+  array: unknown[],
+  oldIndex: number,
+  newIndex: number,
+) => {
+  const arrayCopy = [...array];
+  arrayCopy.splice(newIndex, 0, arrayCopy.splice(oldIndex, 1)[0]);
+  return arrayCopy;
+};

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPicker.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPicker.jsx
@@ -3,7 +3,7 @@ import React from "react";
 import { t } from "ttag";
 import { DragDropContext, Droppable, Draggable } from "react-beautiful-dnd";
 
-import { moveElement } from "metabase/visualizations/lib/utils";
+import { moveElement } from "metabase/lib/array";
 
 import ChartSettingFieldPicker from "./ChartSettingFieldPicker";
 import { AddAnotherContainer } from "./ChartSettingFieldsPicker.styled";

--- a/frontend/src/metabase/writeback/components/ActionCreator/FormCreator/FormCreator.styled.tsx
+++ b/frontend/src/metabase/writeback/components/ActionCreator/FormCreator/FormCreator.styled.tsx
@@ -19,6 +19,7 @@ export const FormItemWrapper = styled.div`
   padding: ${space(2)};
   border-radius: ${space(1)};
   margin-bottom: ${space(1)};
+  background-color: ${color("bg-white")};
 `;
 
 export const FormSettings = styled.div`

--- a/frontend/src/metabase/writeback/components/ActionCreator/FormCreator/utils.ts
+++ b/frontend/src/metabase/writeback/components/ActionCreator/FormCreator/utils.ts
@@ -3,7 +3,7 @@ import _ from "underscore";
 
 import validate from "metabase/lib/validate";
 import { humanize, slugify } from "metabase/lib/formatting";
-import { moveElement } from "metabase/visualizations/lib/utils";
+import { moveElement } from "metabase/lib/array";
 
 import type {
   ActionFormSettings,

--- a/frontend/src/metabase/writeback/components/ActionCreator/FormCreator/utils.ts
+++ b/frontend/src/metabase/writeback/components/ActionCreator/FormCreator/utils.ts
@@ -48,7 +48,7 @@ export const getDefaultFieldSettings = (
   title: "",
   description: "",
   placeholder: "",
-  order: 100,
+  order: 999,
   fieldType: "string",
   inputType: "string",
   required: true,
@@ -181,7 +181,7 @@ export const generateFieldSettingsFromParameters = (
     fields?.map(f => [slugify(f.name), f]) ?? [],
   );
 
-  params.forEach(param => {
+  params.forEach((param, index) => {
     const field = fieldMetadataMap[param.id]
       ? new Field(fieldMetadataMap[param.id])
       : undefined;
@@ -194,6 +194,7 @@ export const generateFieldSettingsFromParameters = (
       title: displayName,
       placeholder: displayName,
       required: !!param?.required,
+      order: index,
       description: field?.description ?? "",
       fieldType: getFieldType(param),
       inputType: getInputType(param, field),

--- a/frontend/src/metabase/writeback/components/ActionCreator/FormCreator/utils.ts
+++ b/frontend/src/metabase/writeback/components/ActionCreator/FormCreator/utils.ts
@@ -2,12 +2,14 @@ import { t } from "ttag";
 import _ from "underscore";
 
 import validate from "metabase/lib/validate";
-import { slugify } from "metabase/lib/formatting";
+import { humanize, slugify } from "metabase/lib/formatting";
+import { moveElement } from "metabase/visualizations/lib/utils";
 
 import type {
   ActionFormSettings,
   WritebackAction,
   FieldSettings,
+  FieldSettingsMap,
   ParameterId,
   WritebackParameter,
   ActionFormOption,
@@ -46,7 +48,7 @@ export const getDefaultFieldSettings = (
   title: "",
   description: "",
   placeholder: "",
-  order: 0,
+  order: 100,
   fieldType: "string",
   inputType: "string",
   required: true,
@@ -123,8 +125,11 @@ export const getForm = (
   parameters: WritebackParameter[],
   fieldSettings: Record<string, FieldSettings>,
 ): ActionFormProps => {
+  const sortedParams = parameters.sort(
+    sortActionParams({ fields: fieldSettings } as ActionFormSettings),
+  );
   return {
-    fields: parameters
+    fields: sortedParams
       ?.map(param => getFormField(param, fieldSettings[param.id] ?? {}))
       .filter(Boolean) as ActionFormFieldProps[],
   };
@@ -243,3 +248,40 @@ export const getInputType = (param: Parameter, field?: Field) => {
   }
   return "string";
 };
+
+export const reorderFields = (
+  fields: FieldSettingsMap,
+  oldIndex: number,
+  newIndex: number,
+) => {
+  // we have to jump through some hoops here because fields settings are an unordered map
+  // with order properties
+  const fieldsWithIds = _.mapObject(fields, (field, key) => ({
+    ...field,
+    id: key,
+  }));
+  const orderedFields = _.sortBy(Object.values(fieldsWithIds), "order");
+  const reorderedFields = moveElement(orderedFields, oldIndex, newIndex);
+
+  const fieldsWithUpdatedOrderProperty = reorderedFields.map(
+    (field, index) => ({
+      ...field,
+      order: index,
+    }),
+  );
+
+  return _.indexBy(fieldsWithUpdatedOrderProperty, "id");
+};
+
+export const sortActionParams =
+  (formSettings: ActionFormSettings) => (a: Parameter, b: Parameter) => {
+    const aOrder = formSettings.fields[a.id]?.order ?? 0;
+    const bOrder = formSettings.fields[b.id]?.order ?? 0;
+
+    return aOrder - bOrder;
+  };
+
+export const hasNewParams = (
+  params: Parameter[],
+  formSettings: ActionFormSettings,
+) => !!params.find(param => !formSettings.fields[param.id]);

--- a/frontend/src/metabase/writeback/selectors.ts
+++ b/frontend/src/metabase/writeback/selectors.ts
@@ -19,6 +19,7 @@ export function createQuestionFromAction(
       name: action.name,
       description: action.description,
       dataset_query: action.dataset_query,
+      visualization_settings: action.visualization_settings,
     },
     getMetadata(state),
   ).setParameters(action.parameters);

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@react-oauth/google": "^0.4.0",
     "@snowplow/browser-tracker": "^3.1.6",
     "@tippyjs/react": "^4.2.6",
+    "@types/react-beautiful-dnd": "^13.1.2",
     "@visx/axis": "1.8.0",
     "@visx/clip-path": "^2.1.0",
     "@visx/event": "^2.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5486,6 +5486,13 @@
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.4.tgz#cd667bcfdd025213aafb7ca5915a932590acdcdc"
   integrity sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==
 
+"@types/react-beautiful-dnd@^13.1.2":
+  version "13.1.2"
+  resolved "https://registry.yarnpkg.com/@types/react-beautiful-dnd/-/react-beautiful-dnd-13.1.2.tgz#510405abb09f493afdfd898bf83995dc6385c130"
+  integrity sha512-+OvPkB8CdE/bGdXKyIhc/Lm2U7UAYCCJgsqmopFmh9gbAudmslkI8eOrPDjg4JhwSE6wytz4a3/wRjKtovHVJg==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react-collapse@^5.0.1":
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/@types/react-collapse/-/react-collapse-5.0.1.tgz#078ea1ad15e00ba2063f2e4d8d6760c9375a2023"


### PR DESCRIPTION
closes #26583 

## Description

Users can now drag-and-drop fields in the action creator to reorder them! The defined order should be consistently displayed in action forms both inline and in modals

![reorderFields](https://user-images.githubusercontent.com/30528226/203179282-88ef6588-7df6-4562-a924-71403ed5dcb2.gif)

## Testing Steps
- create a new action from the add-action sidebar with a few fields
- put them in order
- add the action to the page and see that the fields are ordered how you want
- go back and edit that same action and change the order
- see that (after saving the page) the new field order is reflected


> **Warning**
> there is a failing unit test that should pass once https://github.com/metabase/metabase/pull/26619 merges

> **Note**
> Field order should update without saving the page once https://github.com/metabase/metabase/pull/26646 merges