### PR TITLE
Allow mapping the same dashboard param to many action parameter fields

### DIFF
--- a/frontend/src/metabase/dashboard/actions/parameters.js
+++ b/frontend/src/metabase/dashboard/actions/parameters.js
@@ -15,6 +15,7 @@ import { SIDEBAR_NAME } from "metabase/dashboard/constants";
 import { DashboardApi } from "metabase/services";
 
 import { getMetadata } from "metabase/selectors/metadata";
+import { isActionDashCard } from "metabase/writeback/utils";
 import {
   getDashboard,
   getParameterValues,
@@ -108,10 +109,17 @@ export const setParameterMapping = createThunkAction(
   (parameter_id, dashcard_id, card_id, target) => (dispatch, getState) => {
     const dashcard = getState().dashboard.dashcards[dashcard_id];
     const isVirtual = isVirtualDashCard(dashcard);
+    const isAction = isActionDashCard(dashcard);
+
     let parameter_mappings = dashcard.parameter_mappings || [];
-    parameter_mappings = parameter_mappings.filter(
-      m => m.card_id !== card_id || m.parameter_id !== parameter_id,
-    );
+
+    // allow mapping the same parameeter to multiple action targets
+    if (!isAction) {
+      parameter_mappings = parameter_mappings.filter(
+        m => m.card_id !== card_id || m.parameter_id !== parameter_id,
+      );
+    }
+
     if (target) {
       if (isVirtual) {
         // If this is a virtual (text) card, remove any existing mappings for the target, since text card variables


### PR DESCRIPTION
closes #26589 

# Description

Removes the 1-mapping per parameter restriction for action dashcards. Not sure how useful this will be, but there seems to be no good reason to restrict it.

![set multiple action params](https://user-images.githubusercontent.com/30528226/203182455-52bb9af7-f29b-4069-a4e2-cb1b937e0fae.gif)
