### PR TITLE
[CI] Fix another typo in the pre-release workflow

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -88,7 +88,7 @@ jobs:
         commit_id=${{ github.event.inputs.commit }}
         truncated_hash=${commit_id:0:${{ env.MAX_HASH_LENGTH }}}
 
-        echo "COMMMIT_IDENTIFIER=$truncated_hash" >> $GITHUB_ENV
+        echo "COMMIT_IDENTIFIER=$truncated_hash" >> $GITHUB_ENV
       shell: bash
     - uses: actions/download-artifact@v3
       name: Retrieve uberjar artifact
@@ -147,7 +147,7 @@ jobs:
         commit_id=${{ github.event.inputs.commit }}
         truncated_hash=${commit_id:0:${{ env.MAX_HASH_LENGTH }}}
 
-        echo "COMMMIT_IDENTIFIER=$truncated_hash" >> $GITHUB_ENV
+        echo "COMMIT_IDENTIFIER=$truncated_hash" >> $GITHUB_ENV
       shell: bash
     - name: Login to Docker Hub # authenticated, to avoid being rate-throttled
       uses: docker/login-action@v2


### PR DESCRIPTION
After this PR, I can test the pre-release workflow on my fork:

![image](https://user-images.githubusercontent.com/7288/203197583-5c49ff2c-b273-4905-948d-e50788a13c4e.png)
