### PR TITLE
Refactor `DashCard` component

### DIFF
--- a/frontend/src/metabase/dashboard/components/DashCard/DashCard.jsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCard.jsx
@@ -32,7 +32,12 @@ import { getParameterValuesBySlug } from "metabase-lib/parameters/utils/paramete
 import ClickBehaviorSidebarOverlay from "./ClickBehaviorSidebarOverlay";
 import DashCardActionButtons from "./DashCardActionButtons";
 import DashCardParameterMapper from "./DashCardParameterMapper";
-import { DashCardRoot, DashboardCardActionsPanel } from "./DashCard.styled";
+import {
+  DashCardRoot,
+  DashboardCardActionsPanel,
+  VirtualDashCardOverlayRoot,
+  VirtualDashCardOverlayText,
+} from "./DashCard.styled";
 
 const DATASET_USUALLY_FAST_THRESHOLD = 15 * 1000;
 
@@ -241,11 +246,11 @@ function DashCard({
         const isTextCard =
           dashcard.visualization_settings.virtual_card.display === "text";
         return (
-          <div className="flex full-height align-center justify-center">
-            <h4 className="text-medium">
+          <VirtualDashCardOverlayRoot>
+            <VirtualDashCardOverlayText>
               {isTextCard ? t`Text card` : t`Action button`}
-            </h4>
-          </div>
+            </VirtualDashCardOverlayText>
+          </VirtualDashCardOverlayRoot>
         );
       }
       return (

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCard.jsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCard.jsx
@@ -84,8 +84,68 @@ class DashCard extends Component {
     }));
   };
 
+  handleShowClickBehaviorSidebar = () => {
+    const { dashcard, showClickBehaviorSidebar } = this.props;
+    showClickBehaviorSidebar(dashcard.id);
+  };
+
+  handleCardChangeAndRun = ({ nextCard, previousCard, objectId }) => {
+    const { dashcard, navigateToNewCardFromDashboard } = this.props;
+    navigateToNewCardFromDashboard({
+      nextCard,
+      previousCard,
+      dashcard,
+      objectId,
+    });
+  };
+
   preventDragging = e => {
     e.stopPropagation();
+  };
+
+  renderVisualizationOverlay = ({ isAction }) => {
+    const {
+      dashcard,
+      dashboard,
+      clickBehaviorSidebarDashcard,
+      gridItemWidth,
+      isMobile,
+      isEditingParameter,
+      showClickBehaviorSidebar,
+    } = this.props;
+
+    if (clickBehaviorSidebarDashcard != null) {
+      if (isVirtualDashCard(dashcard)) {
+        return (
+          <div className="flex full-height align-center justify-center">
+            <h4 className="text-medium">
+              {dashcard.visualization_settings.virtual_card.display === "text"
+                ? t`Text card`
+                : t`Action button`}
+            </h4>
+          </div>
+        );
+      }
+      return (
+        <ClickBehaviorSidebarOverlay
+          dashcard={dashcard}
+          dashcardWidth={gridItemWidth}
+          dashboard={dashboard}
+          showClickBehaviorSidebar={showClickBehaviorSidebar}
+          isShowingThisClickBehaviorSidebar={
+            clickBehaviorSidebarDashcard.id === dashcard.id
+          }
+        />
+      );
+    }
+
+    if (isEditingParameter && !isAction) {
+      return (
+        <DashCardParameterMapper dashcard={dashcard} isMobile={isMobile} />
+      );
+    }
+
+    return null;
   };
 
   render() {
@@ -99,7 +159,6 @@ class DashCard extends Component {
       parameterValues,
       mode,
       headerIcon,
-      gridItemWidth,
       totalNumGridCols,
       isEditing,
       isNightMode,
@@ -111,7 +170,6 @@ class DashCard extends Component {
       navigateToNewCardFromDashboard,
       onUpdateVisualizationSettings,
       onReplaceAllVisualizationSettings,
-      showClickBehaviorSidebar,
       onChangeLocation,
       dispatch,
     } = this.props;
@@ -191,6 +249,10 @@ class DashCard extends Component {
 
     const gridSize = { width: dashcard.size_x, height: dashcard.size_y };
 
+    const onChangeCardAndRun = navigateToNewCardFromDashboard
+      ? this.handleCardChangeAndRun
+      : null;
+
     return (
       <DashCardRoot
         className="Card rounded flex flex-column hover-parent hover--visibility"
@@ -211,9 +273,7 @@ class DashCard extends Component {
               onReplaceAllVisualizationSettings={
                 onReplaceAllVisualizationSettings
               }
-              showClickBehaviorSidebar={() =>
-                showClickBehaviorSidebar(dashcard.id)
-              }
+              showClickBehaviorSidebar={this.handleShowClickBehaviorSidebar}
               isPreviewing={isPreviewingCard}
               onPreviewToggle={this.handlePreviewToggle}
               dashboard={dashboard}
@@ -261,49 +321,10 @@ class DashCard extends Component {
             ) : null
           }
           onUpdateVisualizationSettings={onUpdateVisualizationSettings}
-          replacementContent={
-            clickBehaviorSidebarDashcard != null &&
-            isVirtualDashCard(dashcard) ? (
-              <div className="flex full-height align-center justify-center">
-                <h4 className="text-medium">
-                  {dashcard.visualization_settings.virtual_card.display ===
-                  "text"
-                    ? t`Text card`
-                    : t`Action button`}
-                </h4>
-              </div>
-            ) : isEditingParameter && !isAction ? (
-              <DashCardParameterMapper
-                dashcard={dashcard}
-                isMobile={isMobile}
-              />
-            ) : clickBehaviorSidebarDashcard != null ? (
-              <ClickBehaviorSidebarOverlay
-                dashcard={dashcard}
-                dashcardWidth={gridItemWidth}
-                dashboard={dashboard}
-                showClickBehaviorSidebar={showClickBehaviorSidebar}
-                isShowingThisClickBehaviorSidebar={
-                  clickBehaviorSidebarDashcard.id === dashcard.id
-                }
-              />
-            ) : null
-          }
+          replacementContent={this.renderVisualizationOverlay({ isAction })}
           metadata={metadata}
           mode={mode}
-          onChangeCardAndRun={
-            navigateToNewCardFromDashboard
-              ? ({ nextCard, previousCard, objectId }) => {
-                  // navigateToNewCardFromDashboard needs `dashcard` for applying active filters to the query
-                  navigateToNewCardFromDashboard({
-                    nextCard,
-                    previousCard,
-                    dashcard,
-                    objectId,
-                  });
-                }
-              : null
-          }
+          onChangeCardAndRun={onChangeCardAndRun}
           onChangeLocation={onChangeLocation}
         />
       </DashCardRoot>

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCard.jsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCard.jsx
@@ -148,6 +148,66 @@ class DashCard extends Component {
     return null;
   };
 
+  renderDashCardActions = ({
+    mainCard,
+    series,
+    loading,
+    errorMessage,
+    isEditingDashboardLayout,
+  }) => {
+    const {
+      dashcard,
+      dashboard,
+      onAddSeries,
+      onRemove,
+      onReplaceAllVisualizationSettings,
+    } = this.props;
+    const { isPreviewingCard } = this.state;
+
+    if (isEditingDashboardLayout) {
+      return (
+        <DashboardCardActionsPanel onMouseDown={this.preventDragging}>
+          <DashCardActionButtons
+            card={mainCard}
+            series={series}
+            dashboard={dashboard}
+            isLoading={loading}
+            isPreviewing={isPreviewingCard}
+            isVirtualDashCard={isVirtualDashCard(dashcard)}
+            hasError={!!errorMessage}
+            onAddSeries={onAddSeries}
+            onRemove={onRemove}
+            onReplaceAllVisualizationSettings={
+              onReplaceAllVisualizationSettings
+            }
+            showClickBehaviorSidebar={this.handleShowClickBehaviorSidebar}
+            onPreviewToggle={this.handlePreviewToggle}
+          />
+        </DashboardCardActionsPanel>
+      );
+    }
+
+    return null;
+  };
+
+  renderActionButtons = ({ parameterValuesBySlug, isEmbed }) => {
+    const { dashcard } = this.props;
+    if (isEmbed) {
+      return (
+        <QueryDownloadWidget
+          className="m1 text-brand-hover text-light"
+          classNameClose="hover-child"
+          card={dashcard.card}
+          params={parameterValuesBySlug}
+          dashcardId={dashcard.id}
+          token={dashcard.dashboard_id}
+          icon="download"
+        />
+      );
+    }
+    return null;
+  };
+
   render() {
     const {
       dashcard,
@@ -165,11 +225,8 @@ class DashCard extends Component {
       isFullscreen,
       isMobile,
       isEditingParameter,
-      onAddSeries,
-      onRemove,
       navigateToNewCardFromDashboard,
       onUpdateVisualizationSettings,
-      onReplaceAllVisualizationSettings,
       onChangeLocation,
       dispatch,
     } = this.props;
@@ -260,72 +317,52 @@ class DashCard extends Component {
         isNightMode={isNightMode}
         isUsuallySlow={isSlow === "usually-slow"}
       >
-        {isEditingDashboardLayout ? (
-          <DashboardCardActionsPanel onMouseDown={this.preventDragging}>
-            <DashCardActionButtons
-              card={mainCard}
-              series={series}
-              isLoading={loading}
-              isVirtualDashCard={isVirtualDashCard(dashcard)}
-              hasError={!!errorMessage}
-              onRemove={onRemove}
-              onAddSeries={onAddSeries}
-              onReplaceAllVisualizationSettings={
-                onReplaceAllVisualizationSettings
-              }
-              showClickBehaviorSidebar={this.handleShowClickBehaviorSidebar}
-              isPreviewing={isPreviewingCard}
-              onPreviewToggle={this.handlePreviewToggle}
-              dashboard={dashboard}
-            />
-          </DashboardCardActionsPanel>
-        ) : null}
+        {this.renderDashCardActions({
+          mainCard,
+          series,
+          loading,
+          errorMessage,
+          isEditingDashboardLayout,
+        })}
         <WrappedVisualization
           className={cx("flex-full overflow-hidden", {
             "pointer-events-none": isEditingDashboardLayout,
           })}
-          classNameWidgets={isEmbed && "text-light text-medium-hover"}
-          error={errorMessage}
-          headerIcon={headerIcon}
-          errorIcon={errorIcon}
-          isSlow={isSlow}
-          isDataApp={false}
-          expectedDuration={expectedDuration}
-          rawSeries={series}
-          showTitle
-          isFullscreen={isFullscreen}
-          isNightMode={isNightMode}
-          isDashboard
-          dispatch={dispatch}
+          classNameWidgets={cx({
+            "text-light text-medium-hover": isEmbed,
+          })}
           dashboard={dashboard}
           dashcard={dashcard}
           parameterValues={parameterValues}
           parameterValuesBySlug={parameterValuesBySlug}
+          rawSeries={series}
+          headerIcon={headerIcon}
+          error={errorMessage}
+          errorIcon={errorIcon}
+          gridSize={gridSize}
+          metadata={metadata}
+          mode={mode}
+          totalNumGridCols={totalNumGridCols}
+          isSlow={isSlow}
+          isDataApp={false}
+          expectedDuration={expectedDuration}
+          showTitle
+          isFullscreen={isFullscreen}
+          isNightMode={isNightMode}
+          isDashboard
           isEditing={isEditing}
           isPreviewing={isPreviewingCard}
           isEditingParameter={isEditingParameter}
           isMobile={isMobile}
-          gridSize={gridSize}
-          totalNumGridCols={totalNumGridCols}
-          actionButtons={
-            isEmbed ? (
-              <QueryDownloadWidget
-                className="m1 text-brand-hover text-light"
-                classNameClose="hover-child"
-                card={dashcard.card}
-                params={parameterValuesBySlug}
-                dashcardId={dashcard.id}
-                token={dashcard.dashboard_id}
-                icon="download"
-              />
-            ) : null
-          }
+          actionButtons={this.renderActionButtons({
+            parameterValuesBySlug,
+            isEmbed,
+          })}
           onUpdateVisualizationSettings={onUpdateVisualizationSettings}
           replacementContent={this.renderVisualizationOverlay({ isAction })}
-          metadata={metadata}
-          mode={mode}
           onChangeCardAndRun={onChangeCardAndRun}
           onChangeLocation={onChangeLocation}
+          dispatch={dispatch}
         />
       </DashCardRoot>
     );

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCard.jsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCard.jsx
@@ -93,21 +93,31 @@ class DashCard extends Component {
       dashcard,
       dashcardData,
       slowCards,
-      isEditing,
-      clickBehaviorSidebarDashcard,
-      isEditingParameter,
-      isFullscreen,
-      isMobile,
-      onAddSeries,
-      onRemove,
-      navigateToNewCardFromDashboard,
       metadata,
       dashboard,
+      clickBehaviorSidebarDashcard,
       parameterValues,
       mode,
       headerIcon,
+      gridItemWidth,
+      totalNumGridCols,
+      isEditing,
       isNightMode,
+      isFullscreen,
+      isMobile,
+      isEditingParameter,
+      onAddSeries,
+      onRemove,
+      navigateToNewCardFromDashboard,
+      onUpdateVisualizationSettings,
+      onReplaceAllVisualizationSettings,
+      showClickBehaviorSidebar,
+      onChangeLocation,
+      dispatch,
     } = this.props;
+    const { isPreviewingCard } = this.state;
+
+    const isEmbed = Utils.isJWT(dashboardId);
 
     const mainCard = {
       ...dashcard.card,
@@ -116,9 +126,10 @@ class DashCard extends Component {
         dashcard.visualization_settings,
       ),
     };
+
     const cards = [mainCard].concat(dashcard.series || []);
     const dashboardId = dashcard.dashboard_id;
-    const isEmbed = Utils.isJWT(dashboardId);
+
     const series = cards.map(card => ({
       ...getIn(dashcardData, [dashcard.id, card.id]),
       card: card,
@@ -198,12 +209,12 @@ class DashCard extends Component {
               onRemove={onRemove}
               onAddSeries={onAddSeries}
               onReplaceAllVisualizationSettings={
-                this.props.onReplaceAllVisualizationSettings
+                onReplaceAllVisualizationSettings
               }
               showClickBehaviorSidebar={() =>
-                this.props.showClickBehaviorSidebar(dashcard.id)
+                showClickBehaviorSidebar(dashcard.id)
               }
-              isPreviewing={this.state.isPreviewingCard}
+              isPreviewing={isPreviewingCard}
               onPreviewToggle={this.handlePreviewToggle}
               dashboard={dashboard}
             />
@@ -225,17 +236,17 @@ class DashCard extends Component {
           isFullscreen={isFullscreen}
           isNightMode={isNightMode}
           isDashboard
-          dispatch={this.props.dispatch}
+          dispatch={dispatch}
           dashboard={dashboard}
           dashcard={dashcard}
           parameterValues={parameterValues}
           parameterValuesBySlug={parameterValuesBySlug}
           isEditing={isEditing}
-          isPreviewing={this.state.isPreviewingCard}
+          isPreviewing={isPreviewingCard}
           isEditingParameter={isEditingParameter}
           isMobile={isMobile}
           gridSize={gridSize}
-          totalNumGridCols={this.props.totalNumGridCols}
+          totalNumGridCols={totalNumGridCols}
           actionButtons={
             isEmbed ? (
               <QueryDownloadWidget
@@ -249,9 +260,7 @@ class DashCard extends Component {
               />
             ) : null
           }
-          onUpdateVisualizationSettings={
-            this.props.onUpdateVisualizationSettings
-          }
+          onUpdateVisualizationSettings={onUpdateVisualizationSettings}
           replacementContent={
             clickBehaviorSidebarDashcard != null &&
             isVirtualDashCard(dashcard) ? (
@@ -271,9 +280,9 @@ class DashCard extends Component {
             ) : clickBehaviorSidebarDashcard != null ? (
               <ClickBehaviorSidebarOverlay
                 dashcard={dashcard}
-                dashcardWidth={this.props.gridItemWidth}
+                dashcardWidth={gridItemWidth}
                 dashboard={dashboard}
-                showClickBehaviorSidebar={this.props.showClickBehaviorSidebar}
+                showClickBehaviorSidebar={showClickBehaviorSidebar}
                 isShowingThisClickBehaviorSidebar={
                   clickBehaviorSidebarDashcard.id === dashcard.id
                 }
@@ -295,7 +304,7 @@ class DashCard extends Component {
                 }
               : null
           }
-          onChangeLocation={this.props.onChangeLocation}
+          onChangeLocation={onChangeLocation}
         />
       </DashCardRoot>
     );

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCard.jsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCard.jsx
@@ -198,8 +198,8 @@ function DashCard({
   );
 
   const gridSize = useMemo(
-    () => ({ width: dashcard.sizeX, height: dashcard.sizeY }),
-    [dashcard.sizeX, dashcard.sizeY],
+    () => ({ width: dashcard.size_x, height: dashcard.size_y }),
+    [dashcard],
   );
 
   const hasHiddenBackground = useMemo(() => {

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCard.jsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCard.jsx
@@ -183,11 +183,7 @@ class DashCard extends Component {
     return (
       <DashCardRoot
         className="Card rounded flex flex-column hover-parent hover--visibility"
-        style={
-          hideBackground
-            ? { border: 0, background: "transparent", boxShadow: "none" }
-            : null
-        }
+        hasHiddenBackground={hideBackground}
         isNightMode={isNightMode}
         isUsuallySlow={isSlow === "usually-slow"}
       >

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCard.styled.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCard.styled.tsx
@@ -56,3 +56,14 @@ export const DashboardCardActionsPanel = styled.div`
     display: none;
   }
 `;
+
+export const VirtualDashCardOverlayRoot = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+`;
+
+export const VirtualDashCardOverlayText = styled.h4`
+  color: ${color("text-medium")};
+`;

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCard.styled.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCard.styled.tsx
@@ -18,9 +18,9 @@ const rootSlowCardStyle = css`
 `;
 
 const rootTransparentBackgroundStyle = css`
-  border: 0;
-  background: transparent;
-  box-shadow: none;
+  border: 0 !important;
+  background: transparent !important;
+  box-shadow: none !important;
 `;
 
 export const DashCardRoot = styled.div<DashCardRootProps>`

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCard.styled.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCard.styled.tsx
@@ -5,23 +5,31 @@ import { color } from "metabase/lib/colors";
 export interface DashCardRootProps {
   isNightMode: boolean;
   isUsuallySlow: boolean;
+  hasHiddenBackground: boolean;
 }
+
+const rootNightModeStyle = css`
+  border-color: ${color("bg-night")};
+  background-color: ${color("bg-night")};
+`;
+
+const rootSlowCardStyle = css`
+  border-color: ${color("accent4")};
+`;
+
+const rootTransparentBackgroundStyle = css`
+  border: 0;
+  background: transparent;
+  box-shadow: none;
+`;
 
 export const DashCardRoot = styled.div<DashCardRootProps>`
   background-color: ${color("white")};
 
-  ${({ isNightMode }) =>
-    isNightMode &&
-    css`
-      border-color: ${color("bg-night")};
-      background-color: ${color("bg-night")};
-    `}
-
-  ${({ isUsuallySlow }) =>
-    isUsuallySlow &&
-    css`
-      border-color: ${color("accent4")};
-    `}
+  ${({ isNightMode }) => isNightMode && rootNightModeStyle}
+  ${({ isUsuallySlow }) => isUsuallySlow && rootSlowCardStyle}
+  ${({ hasHiddenBackground }) =>
+    hasHiddenBackground && rootTransparentBackgroundStyle}
 `;
 
 export const DashboardCardActionsPanel = styled.div`


### PR DESCRIPTION
Based on #26640 and #26639

Essentially turns `DashCard` into a functional component, memorizing most of the stuff that used to be re-computed on each render. Also drops direct usage of `react-dom` (replaced `ReactDOM.findDOMNode` with React ref)