### PR TITLE
Convert `DashCard` to TypeScript

### DIFF
--- a/frontend/src/metabase-lib/parameters/utils/targets.ts
+++ b/frontend/src/metabase-lib/parameters/utils/targets.ts
@@ -3,7 +3,7 @@ import {
   ParameterDimensionTarget,
   ParameterVariableTarget,
 } from "metabase-types/types/Parameter";
-import { SavedCard } from "metabase-types/types/Card";
+import type { Card } from "metabase-types/api";
 import { isDimensionTarget } from "metabase-types/guards";
 import Dimension from "metabase-lib/Dimension";
 import Metadata from "metabase-lib/metadata/Metadata";
@@ -54,7 +54,7 @@ export function buildTextTagTarget(tagName: string) {
 
 export function getTargetFieldFromCard(
   target: ParameterVariableTarget | ParameterDimensionTarget,
-  card: SavedCard,
+  card: Card,
   metadata: Metadata,
 ) {
   if (!card?.dataset_query) {

--- a/frontend/src/metabase-lib/parameters/utils/targets.unit.spec.ts
+++ b/frontend/src/metabase-lib/parameters/utils/targets.unit.spec.ts
@@ -5,7 +5,7 @@ import {
 } from "__support__/sample_database_fixture";
 import { ParameterDimensionTarget } from "metabase-types/types/Parameter";
 import { isDimensionTarget } from "metabase-types/guards";
-import { SavedCard } from "metabase-types/types/Card";
+import type { Card } from "metabase-types/api";
 import Database from "metabase-lib/metadata/Database";
 import {
   getParameterTargetField,
@@ -140,7 +140,7 @@ describe("parameters/utils/targets", () => {
     it("should return null when given a card without a `dataset_query`", () => {
       const card = {
         id: 1,
-      } as SavedCard;
+      } as Card;
 
       expect(getTargetFieldFromCard(target, card, metadata)).toBe(null);
     });
@@ -157,7 +157,7 @@ describe("parameters/utils/targets", () => {
             "source-table": PRODUCTS.id,
           },
         },
-      } as SavedCard;
+      } as Card;
 
       expect(getTargetFieldFromCard(target, card, metadata)).toEqual(
         expect.objectContaining({ id: field.id }),

--- a/frontend/src/metabase-types/api/card.ts
+++ b/frontend/src/metabase-types/api/card.ts
@@ -8,6 +8,7 @@ export interface Card extends UnsavedCard {
   dataset: boolean;
   can_write: boolean;
   cache_ttl: number | null;
+  query_average_duration?: number | null;
   last_query_start: string | null;
   archived: boolean;
 

--- a/frontend/src/metabase-types/api/dashboard.ts
+++ b/frontend/src/metabase-types/api/dashboard.ts
@@ -33,8 +33,12 @@ export type DashCardId = EntityId;
 
 export type BaseDashboardOrderedCard = {
   id: DashCardId;
+  dashboard_id: DashboardId;
+  size_x: number;
+  size_y: number;
   visualization_settings?: {
     [key: string]: unknown;
+    virtual_card?: Card;
   };
 };
 

--- a/frontend/src/metabase-types/api/dashboard.ts
+++ b/frontend/src/metabase-types/api/dashboard.ts
@@ -5,9 +5,7 @@ import type {
   Parameter,
 } from "metabase-types/types/Parameter";
 
-import type { CardId, SavedCard } from "metabase-types/types/Card";
-import type { WritebackAction } from "./writeback";
-
+import type { Card, CardId } from "./card";
 import type { Dataset } from "./dataset";
 
 export type DashboardId = number;
@@ -44,9 +42,9 @@ export type BaseDashboardOrderedCard = {
 
 export type DashboardOrderedCard = BaseDashboardOrderedCard & {
   card_id: CardId;
-  card: SavedCard;
+  card: Card;
   parameter_mappings?: DashboardParameterMapping[] | null;
-  series?: SavedCard[];
+  series?: Card[];
 };
 
 export type DashboardParameterMapping = {

--- a/frontend/src/metabase-types/api/mocks/data-app.ts
+++ b/frontend/src/metabase-types/api/mocks/data-app.ts
@@ -30,6 +30,9 @@ export const createMockDashboardActionButton = ({
   ...opts
 }: Partial<ActionDashboardCard> = {}): ActionDashboardCard => ({
   id: 1,
+  dashboard_id: 1,
+  size_x: 2,
+  size_y: 1,
   parameter_mappings: null,
   visualization_settings: merge(
     {

--- a/frontend/src/metabase-types/types/Visualization.ts
+++ b/frontend/src/metabase-types/types/Visualization.ts
@@ -82,7 +82,16 @@ export type ClickActionPopoverProps = {
   onClose: () => void;
 };
 
-export type SingleSeries = { card: Card; data: DatasetData };
+export type SingleSeries = {
+  card: Card;
+  data: DatasetData;
+  error_type?: string;
+  error?: {
+    status: number; // HTTP status code
+    data?: string;
+  };
+};
+
 export type RawSeries = SingleSeries[];
 export type TransformedSeries = RawSeries & { _raw: Series };
 export type Series = RawSeries | TransformedSeries;

--- a/frontend/src/metabase/parameters/utils/dashboards.ts
+++ b/frontend/src/metabase/parameters/utils/dashboards.ts
@@ -7,11 +7,11 @@ import type {
   ParameterMappingOptions,
 } from "metabase-types/types/Parameter";
 import type {
+  Card,
   Dashboard,
   DashboardParameterMapping,
   DashboardOrderedCard,
 } from "metabase-types/api";
-import type { SavedCard } from "metabase-types/types/Card";
 import { isFieldFilterParameter } from "metabase-lib/parameters/utils/parameter-type";
 import type {
   UiParameter,
@@ -27,7 +27,7 @@ import type Field from "metabase-lib/metadata/Field";
 
 type ExtendedMapping = DashboardParameterMapping & {
   dashcard_id: number;
-  card: SavedCard;
+  card: Card;
 };
 
 export function createParameter(

--- a/frontend/src/metabase/writeback/utils.ts
+++ b/frontend/src/metabase/writeback/utils.ts
@@ -1,11 +1,10 @@
 import type {
   ActionDashboardCard,
   BaseDashboardOrderedCard,
-  ClickBehavior,
+  Card,
   Database as IDatabase,
   WritebackAction,
 } from "metabase-types/api";
-import type { SavedCard } from "metabase-types/types/Card";
 import { TYPE } from "metabase-lib/types/constants";
 import type Database from "metabase-lib/metadata/Database";
 import type Field from "metabase-lib/metadata/Field";
@@ -61,13 +60,13 @@ export const isEditableField = (field: Field) => {
   return true;
 };
 
-export const isActionCard = (card: SavedCard) => card?.display === "action";
+export const isActionCard = (card: Card) => card?.display === "action";
 
 export function isActionDashCard(
   dashCard: BaseDashboardOrderedCard,
 ): dashCard is ActionDashboardCard {
   const virtualCard = dashCard?.visualization_settings?.virtual_card;
-  return isActionCard(virtualCard as SavedCard);
+  return isActionCard(virtualCard as Card);
 }
 
 /**


### PR DESCRIPTION
Based on #26671

Converts refactored `DashCard` component to TypeScript. Had to add a few missing properties to the `Card` and `DashboardOrderedCard` types to make it happen.

Also, this PR makes `DashboardOrderedCard` from `metabase-types/api/dashboard` to use the `Card` type from `metabase-types/api` instead of deprecated `SavedCard` type from `metabase-types/api`. This required changing card types in a few more files