### PR TITLE
Extract `DashCardVisualization` component

### DIFF
--- a/frontend/src/metabase/dashboard/components/DashCard/DashCard.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCard.tsx
@@ -1,7 +1,4 @@
 import React, { useCallback, useMemo, useRef, useState } from "react";
-import cx from "classnames";
-import { t } from "ttag";
-import { connect } from "react-redux";
 import { getIn } from "icepick";
 import type { LocationDescriptor } from "history";
 
@@ -13,14 +10,11 @@ import Utils from "metabase/lib/utils";
 
 import { useOnMount } from "metabase/hooks/use-on-mount";
 
-import Visualization, {
+import {
   ERROR_MESSAGE_GENERIC,
   ERROR_MESSAGE_PERMISSION,
 } from "metabase/visualizations/components/Visualization";
-import WithVizSettingsData from "metabase/visualizations/hoc/WithVizSettingsData";
 import { mergeSettings } from "metabase/visualizations/lib/settings";
-
-import QueryDownloadWidget from "metabase/query_builder/components/QueryDownloadWidget";
 
 import { isVirtualDashCard } from "metabase/dashboard/utils";
 
@@ -40,30 +34,22 @@ import type {
   ParameterValueOrArray,
 } from "metabase-types/types/Parameter";
 import type { Series } from "metabase-types/types/Visualization";
-import type { Dispatch } from "metabase-types/store";
 
 import { getParameterValuesBySlug } from "metabase-lib/parameters/utils/parameter-values";
 
 import type Mode from "metabase-lib/Mode";
 import type Metadata from "metabase-lib/metadata/Metadata";
 
-import ClickBehaviorSidebarOverlay from "./ClickBehaviorSidebarOverlay";
-import DashCardActionButtons from "./DashCardActionButtons";
-import DashCardParameterMapper from "./DashCardParameterMapper";
 import {
-  DashCardRoot,
-  DashboardCardActionsPanel,
-  VirtualDashCardOverlayRoot,
-  VirtualDashCardOverlayText,
-} from "./DashCard.styled";
+  CardSlownessStatus,
+  NavigateToNewCardFromDashboardOpts,
+  DashCardOnChangeCardAndRunHandler,
+} from "./types";
+import DashCardActionButtons from "./DashCardActionButtons";
+import DashCardVisualization from "./DashCardVisualization";
+import { DashCardRoot, DashboardCardActionsPanel } from "./DashCard.styled";
 
 const DATASET_USUALLY_FAST_THRESHOLD = 15 * 1000;
-
-// This is done to add the `getExtraDataForClick` prop.
-// We need that to pass relevant data along with the clicked object.
-const WrappedVisualization = WithVizSettingsData(
-  connect(null, dispatch => ({ dispatch }))(Visualization),
-);
 
 function preventDragging(event: React.SyntheticEvent) {
   event.stopPropagation();
@@ -98,21 +84,6 @@ function getSeriesError(series: Series) {
   return;
 }
 
-type FetchCardDataOpts = {
-  reload?: boolean;
-  clear?: boolean;
-  ignoreCache?: boolean;
-};
-
-type NavigateToNewCardFromDashboardOpts = {
-  nextCard: Card;
-  previousCard: Card;
-  dashcard: DashboardOrderedCard;
-  objectId?: unknown;
-};
-
-type CardIsSlow = "usually-fast" | "usually-slow" | false;
-
 interface DashCardProps {
   dashboard: Dashboard;
   dashcard: DashboardOrderedCard & { justAdded?: boolean };
@@ -134,15 +105,9 @@ interface DashCardProps {
 
   headerIcon?: IconProps;
 
-  dispatch: Dispatch;
   onAddSeries: () => void;
   onRemove: () => void;
   markNewCardSeen: (dashcardId: DashCardId) => void;
-  fetchCardData: (
-    card: Card,
-    dashCard: DashboardOrderedCard,
-    opts?: FetchCardDataOpts,
-  ) => void;
   navigateToNewCardFromDashboard?: (
     opts: NavigateToNewCardFromDashboardOpts,
   ) => void;
@@ -177,7 +142,6 @@ function DashCard({
   onChangeLocation,
   onUpdateVisualizationSettings,
   onReplaceAllVisualizationSettings,
-  dispatch,
 }: DashCardProps) {
   const [isPreviewingCard, setIsPreviewingCard] = useState(false);
   const cardRootRef = useRef<HTMLDivElement>(null);
@@ -240,7 +204,7 @@ function DashCard({
       ...series.map(s => s.card.query_average_duration || 0),
     );
     const isUsuallyFast = series.every(s => s.isUsuallyFast);
-    let isSlow: CardIsSlow = false;
+    let isSlow: CardSlownessStatus = false;
     if (isLoading && series.some(s => s.isSlow)) {
       isSlow = isUsuallyFast ? "usually-fast" : "usually-slow";
     }
@@ -288,8 +252,11 @@ function DashCard({
       return null;
     }
 
-    type Args = Omit<NavigateToNewCardFromDashboardOpts, "dashcard">;
-    return ({ nextCard, previousCard, objectId }: Args) => {
+    const handler: DashCardOnChangeCardAndRunHandler = ({
+      nextCard,
+      previousCard,
+      objectId,
+    }) => {
       navigateToNewCardFromDashboard({
         nextCard,
         previousCard,
@@ -297,48 +264,9 @@ function DashCard({
         objectId,
       });
     };
+
+    return handler;
   }, [dashcard, navigateToNewCardFromDashboard]);
-
-  const renderVisualizationOverlay = useCallback(() => {
-    if (isClickBehaviorSidebarOpen) {
-      if (isVirtualDashCard(dashcard)) {
-        const isTextCard =
-          dashcard?.visualization_settings?.virtual_card?.display === "text";
-        return (
-          <VirtualDashCardOverlayRoot>
-            <VirtualDashCardOverlayText>
-              {isTextCard ? t`Text card` : t`Action button`}
-            </VirtualDashCardOverlayText>
-          </VirtualDashCardOverlayRoot>
-        );
-      }
-      return (
-        <ClickBehaviorSidebarOverlay
-          dashcard={dashcard}
-          dashcardWidth={gridItemWidth}
-          showClickBehaviorSidebar={showClickBehaviorSidebar}
-          isShowingThisClickBehaviorSidebar={isEditingDashCardClickBehavior}
-        />
-      );
-    }
-
-    if (isEditingParameter && !isAction) {
-      return (
-        <DashCardParameterMapper dashcard={dashcard} isMobile={isMobile} />
-      );
-    }
-
-    return null;
-  }, [
-    dashcard,
-    gridItemWidth,
-    isAction,
-    isMobile,
-    isEditingParameter,
-    isClickBehaviorSidebarOpen,
-    isEditingDashCardClickBehavior,
-    showClickBehaviorSidebar,
-  ]);
 
   const renderDashCardActions = useCallback(() => {
     if (isEditingDashboardLayout) {
@@ -362,7 +290,6 @@ function DashCard({
         </DashboardCardActionsPanel>
       );
     }
-
     return null;
   }, [
     dashcard,
@@ -379,25 +306,6 @@ function DashCard({
     handleShowClickBehaviorSidebar,
   ]);
 
-  const renderActionButtons = useCallback(() => {
-    if (isEmbed) {
-      return (
-        <QueryDownloadWidget
-          className="m1 text-brand-hover text-light"
-          classNameClose="hover-child"
-          card={dashcard.card}
-          params={parameterValuesBySlug}
-          dashcardId={dashcard.id}
-          token={dashcard.dashboard_id}
-          icon="download"
-          // Can be removed once QueryDownloadWidget is converted to Typescript
-          visualizationSettings={undefined}
-        />
-      );
-    }
-    return null;
-  }, [dashcard, parameterValuesBySlug, isEmbed]);
-
   return (
     <DashCardRoot
       className="Card rounded flex flex-column hover-parent hover--visibility"
@@ -407,45 +315,36 @@ function DashCard({
       ref={cardRootRef}
     >
       {renderDashCardActions()}
-      <WrappedVisualization
-        // Visualization has to be converted to TypeScript before we can remove the ts-ignore
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore
-        className={cx("flex-full overflow-hidden", {
-          "pointer-events-none": isEditingDashboardLayout,
-        })}
-        classNameWidgets={cx({
-          "text-light text-medium-hover": isEmbed,
-        })}
+      <DashCardVisualization
         dashboard={dashboard}
         dashcard={dashcard}
+        series={series}
         parameterValues={parameterValues}
         parameterValuesBySlug={parameterValuesBySlug}
-        rawSeries={series}
-        headerIcon={headerIcon}
-        error={error?.message}
-        errorIcon={error?.icon}
-        gridSize={gridSize}
         metadata={metadata}
         mode={mode}
+        gridSize={gridSize}
+        gridItemWidth={gridItemWidth}
         totalNumGridCols={totalNumGridCols}
+        headerIcon={headerIcon}
         expectedDuration={expectedDuration}
-        showTitle
-        replacementContent={renderVisualizationOverlay()}
-        actionButtons={renderActionButtons()}
+        error={error}
+        isAction={isAction}
+        isEmbed={isEmbed}
+        isEditing={isEditing}
+        isEditingDashCardClickBehavior={isEditingDashCardClickBehavior}
+        isEditingDashboardLayout={isEditingDashboardLayout}
+        isEditingParameter={isEditingParameter}
+        isClickBehaviorSidebarOpen={isClickBehaviorSidebarOpen}
         isSlow={isSlow}
-        isDataApp={false}
+        isPreviewing={isPreviewingCard}
         isFullscreen={isFullscreen}
         isNightMode={isNightMode}
-        isDashboard
-        isEditing={isEditing}
-        isPreviewing={isPreviewingCard}
-        isEditingParameter={isEditingParameter}
         isMobile={isMobile}
+        showClickBehaviorSidebar={showClickBehaviorSidebar}
         onUpdateVisualizationSettings={onUpdateVisualizationSettings}
         onChangeCardAndRun={changeCardAndRunHandler}
         onChangeLocation={onChangeLocation}
-        dispatch={dispatch}
       />
     </DashCardRoot>
   );

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx
@@ -77,6 +77,16 @@ interface DashCardVisualizationProps {
   onChangeLocation: (location: LocationDescriptor) => void;
 }
 
+function mapDispatchToProps(dispatch: Dispatch) {
+  return { dispatch };
+}
+
+// This is done to add the `getExtraDataForClick` prop.
+// We need that to pass relevant data along with the clicked object.
+const WrappedVisualization = WithVizSettingsData(
+  connect(null, mapDispatchToProps)(Visualization),
+);
+
 function DashCardVisualization({
   dashcard,
   dashboard,
@@ -170,7 +180,7 @@ function DashCardVisualization({
   }, [dashcard, parameterValuesBySlug, isEmbed]);
 
   return (
-    <Visualization
+    <WrappedVisualization
       // Visualization has to be converted to TypeScript before we can remove the ts-ignore
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
@@ -213,8 +223,4 @@ function DashCardVisualization({
   );
 }
 
-// This is done to add the `getExtraDataForClick` prop.
-// We need that to pass relevant data along with the clicked object.
-export default WithVizSettingsData(
-  connect(null, dispatch => ({ dispatch }))(DashCardVisualization),
-) as unknown as React.ComponentType<DashCardVisualizationProps>;
+export default DashCardVisualization;

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx
@@ -1,0 +1,220 @@
+import React, { useCallback } from "react";
+import cx from "classnames";
+import { t } from "ttag";
+import { connect } from "react-redux";
+import type { LocationDescriptor } from "history";
+
+import { IconProps } from "metabase/components/Icon";
+
+import Visualization from "metabase/visualizations/components/Visualization";
+import WithVizSettingsData from "metabase/visualizations/hoc/WithVizSettingsData";
+
+import QueryDownloadWidget from "metabase/query_builder/components/QueryDownloadWidget";
+
+import { isVirtualDashCard } from "metabase/dashboard/utils";
+
+import type {
+  Dashboard,
+  DashboardOrderedCard,
+  DashCardId,
+  VisualizationSettings,
+} from "metabase-types/api";
+import type {
+  ParameterId,
+  ParameterValueOrArray,
+} from "metabase-types/types/Parameter";
+import type { Series } from "metabase-types/types/Visualization";
+import type { Dispatch } from "metabase-types/store";
+
+import type Mode from "metabase-lib/Mode";
+import type Metadata from "metabase-lib/metadata/Metadata";
+
+import { CardSlownessStatus, DashCardOnChangeCardAndRunHandler } from "./types";
+import ClickBehaviorSidebarOverlay from "./ClickBehaviorSidebarOverlay";
+import DashCardParameterMapper from "./DashCardParameterMapper";
+import {
+  VirtualDashCardOverlayRoot,
+  VirtualDashCardOverlayText,
+} from "./DashCard.styled";
+
+interface DashCardVisualizationProps {
+  dashboard: Dashboard;
+  dashcard: DashboardOrderedCard;
+  series: Series;
+  parameterValues: Record<ParameterId, ParameterValueOrArray>;
+  parameterValuesBySlug: Record<string, ParameterValueOrArray>;
+  metadata: Metadata;
+  mode?: Mode;
+
+  gridSize: {
+    width: number;
+    height: number;
+  };
+  gridItemWidth: number;
+  totalNumGridCols: number;
+
+  expectedDuration: number;
+  isSlow: CardSlownessStatus;
+
+  isAction: boolean;
+  isPreviewing: boolean;
+  isEmbed: boolean;
+  isClickBehaviorSidebarOpen: boolean;
+  isEditingDashCardClickBehavior: boolean;
+  isEditingDashboardLayout: boolean;
+  isEditing?: boolean;
+  isEditingParameter?: boolean;
+  isFullscreen?: boolean;
+  isMobile?: boolean;
+  isNightMode?: boolean;
+
+  error?: { message?: string; icon?: IconProps["name"] };
+  headerIcon?: IconProps;
+
+  onUpdateVisualizationSettings: (settings: VisualizationSettings) => void;
+  onChangeCardAndRun: DashCardOnChangeCardAndRunHandler | null;
+  showClickBehaviorSidebar: (dashCardId: DashCardId | null) => void;
+  onChangeLocation: (location: LocationDescriptor) => void;
+}
+
+function DashCardVisualization({
+  dashcard,
+  dashboard,
+  series,
+  parameterValues,
+  parameterValuesBySlug,
+  mode,
+  metadata,
+  gridSize,
+  gridItemWidth,
+  totalNumGridCols,
+  expectedDuration,
+  error,
+  headerIcon,
+  isSlow,
+  isAction,
+  isPreviewing,
+  isEmbed,
+  isEditingDashboardLayout,
+  isClickBehaviorSidebarOpen,
+  isEditingDashCardClickBehavior,
+  isEditing = false,
+  isNightMode = false,
+  isFullscreen = false,
+  isMobile = false,
+  isEditingParameter,
+  onChangeCardAndRun,
+  showClickBehaviorSidebar,
+  onChangeLocation,
+  onUpdateVisualizationSettings,
+  dispatch,
+}: DashCardVisualizationProps & { dispatch: Dispatch }) {
+  const renderVisualizationOverlay = useCallback(() => {
+    if (isClickBehaviorSidebarOpen) {
+      if (isVirtualDashCard(dashcard)) {
+        const isTextCard =
+          dashcard?.visualization_settings?.virtual_card?.display === "text";
+        return (
+          <VirtualDashCardOverlayRoot>
+            <VirtualDashCardOverlayText>
+              {isTextCard ? t`Text card` : t`Action button`}
+            </VirtualDashCardOverlayText>
+          </VirtualDashCardOverlayRoot>
+        );
+      }
+      return (
+        <ClickBehaviorSidebarOverlay
+          dashcard={dashcard}
+          dashcardWidth={gridItemWidth}
+          showClickBehaviorSidebar={showClickBehaviorSidebar}
+          isShowingThisClickBehaviorSidebar={isEditingDashCardClickBehavior}
+        />
+      );
+    }
+
+    if (isEditingParameter && !isAction) {
+      return (
+        <DashCardParameterMapper dashcard={dashcard} isMobile={isMobile} />
+      );
+    }
+
+    return null;
+  }, [
+    dashcard,
+    gridItemWidth,
+    isAction,
+    isMobile,
+    isEditingParameter,
+    isClickBehaviorSidebarOpen,
+    isEditingDashCardClickBehavior,
+    showClickBehaviorSidebar,
+  ]);
+
+  const renderActionButtons = useCallback(() => {
+    if (isEmbed) {
+      return (
+        <QueryDownloadWidget
+          className="m1 text-brand-hover text-light"
+          classNameClose="hover-child"
+          card={dashcard.card}
+          params={parameterValuesBySlug}
+          dashcardId={dashcard.id}
+          token={dashcard.dashboard_id}
+          icon="download"
+          // Can be removed once QueryDownloadWidget is converted to Typescript
+          visualizationSettings={undefined}
+        />
+      );
+    }
+    return null;
+  }, [dashcard, parameterValuesBySlug, isEmbed]);
+
+  return (
+    <Visualization
+      // Visualization has to be converted to TypeScript before we can remove the ts-ignore
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      className={cx("flex-full overflow-hidden", {
+        "pointer-events-none": isEditingDashboardLayout,
+      })}
+      classNameWidgets={cx({
+        "text-light text-medium-hover": isEmbed,
+      })}
+      dashboard={dashboard}
+      dashcard={dashcard}
+      rawSeries={series}
+      parameterValues={parameterValues}
+      parameterValuesBySlug={parameterValuesBySlug}
+      metadata={metadata}
+      mode={mode}
+      gridSize={gridSize}
+      totalNumGridCols={totalNumGridCols}
+      headerIcon={headerIcon}
+      expectedDuration={expectedDuration}
+      error={error?.message}
+      errorIcon={error?.icon}
+      showTitle
+      isDashboard
+      isDataApp={false}
+      isSlow={isSlow}
+      isFullscreen={isFullscreen}
+      isNightMode={isNightMode}
+      isEditing={isEditing}
+      isPreviewing={isPreviewing}
+      isEditingParameter={isEditingParameter}
+      isMobile={isMobile}
+      actionButtons={renderActionButtons()}
+      replacementContent={renderVisualizationOverlay()}
+      onUpdateVisualizationSettings={onUpdateVisualizationSettings}
+      onChangeCardAndRun={onChangeCardAndRun}
+      onChangeLocation={onChangeLocation}
+      dispatch={dispatch}
+    />
+  );
+}
+
+// This is done to add the `getExtraDataForClick` prop.
+// We need that to pass relevant data along with the clicked object.
+export default WithVizSettingsData(
+  connect(null, dispatch => ({ dispatch }))(DashCardVisualization),
+) as unknown as React.ComponentType<DashCardVisualizationProps>;

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx
@@ -117,8 +117,7 @@ function DashCardVisualization({
   showClickBehaviorSidebar,
   onChangeLocation,
   onUpdateVisualizationSettings,
-  dispatch,
-}: DashCardVisualizationProps & { dispatch: Dispatch }) {
+}: DashCardVisualizationProps) {
   const renderVisualizationOverlay = useCallback(() => {
     if (isClickBehaviorSidebarOpen) {
       if (isVirtualDashCard(dashcard)) {
@@ -218,7 +217,6 @@ function DashCardVisualization({
       onUpdateVisualizationSettings={onUpdateVisualizationSettings}
       onChangeCardAndRun={onChangeCardAndRun}
       onChangeLocation={onChangeLocation}
-      dispatch={dispatch}
     />
   );
 }

--- a/frontend/src/metabase/dashboard/components/DashCard/types.ts
+++ b/frontend/src/metabase/dashboard/components/DashCard/types.ts
@@ -1,0 +1,14 @@
+import type { Card, DashboardOrderedCard } from "metabase-types/api";
+
+export type CardSlownessStatus = "usually-fast" | "usually-slow" | boolean;
+
+export type NavigateToNewCardFromDashboardOpts = {
+  nextCard: Card;
+  previousCard: Card;
+  dashcard: DashboardOrderedCard;
+  objectId?: unknown;
+};
+
+export type DashCardOnChangeCardAndRunHandler = (
+  opts: Omit<NavigateToNewCardFromDashboardOpts, "dashcard">,
+) => void;


### PR DESCRIPTION
Based on #26672

> **Note**
> This is controversial, so I'd appreciate high-level feedback about the whole idea

The PR extracts visualization rendering concerns from the `DashCard` and moves them to a new `DashCardVisualization` component. Hopefully, that should make it easier to reason about the component