### PR TITLE
Mark required form fields

### DIFF
--- a/frontend/src/metabase-types/forms/index.ts
+++ b/frontend/src/metabase-types/forms/index.ts
@@ -96,6 +96,7 @@ export type FormField<Values, Value = DefaultFieldValue> = {
   touched: boolean;
   valid: boolean;
   visited: boolean;
+  required?: boolean;
 
   onBlur: () => void;
   onFocus: () => void;

--- a/frontend/src/metabase/components/form/FormikFormField/FormField.tsx
+++ b/frontend/src/metabase/components/form/FormikFormField/FormField.tsx
@@ -121,6 +121,7 @@ function FormField<Values>({
       align={align}
       standAloneLabel={standAloneLabel}
       horizontal={horizontal}
+      required={!!formField?.required}
     >
       {children}
     </FormFieldView>

--- a/frontend/src/metabase/components/form/FormikFormField/FormFieldView.tsx
+++ b/frontend/src/metabase/components/form/FormikFormField/FormFieldView.tsx
@@ -21,6 +21,7 @@ interface FormFieldViewProps extends BaseFieldDefinition {
   className?: string;
   standAloneLabel?: boolean;
   children: React.ReactNode;
+  required: boolean;
 }
 
 function FormFieldView({
@@ -38,6 +39,7 @@ function FormFieldView({
   horizontal,
   standAloneLabel,
   children,
+  required,
 }: FormFieldViewProps) {
   const rootClassNames = cx("Form-field", className, {
     "Form--fieldError": !!error,
@@ -58,6 +60,7 @@ function FormFieldView({
                 standAlone={standAloneLabel}
               >
                 {title}
+                {required && " *"}
                 {error && <span className="text-error">: {error}</span>}
               </Label>
             )}

--- a/frontend/src/metabase/writeback/components/ActionCreator/FormCreator/FormCreator.tsx
+++ b/frontend/src/metabase/writeback/components/ActionCreator/FormCreator/FormCreator.tsx
@@ -99,7 +99,10 @@ function FormItem({
 
   return (
     <FormItemWrapper>
-      <FormItemName>{name}</FormItemName>
+      <FormItemName>
+        {name}
+        {!!fieldSettings.required && " *"}
+      </FormItemName>
       <FormSettings>
         <FormSettingsPreviewContainer>
           {isEditingOptions && hasOptions ? (

--- a/frontend/src/metabase/writeback/components/ActionCreator/FormCreator/utils.ts
+++ b/frontend/src/metabase/writeback/components/ActionCreator/FormCreator/utils.ts
@@ -105,6 +105,7 @@ export const getFormField = (
       parameter.id,
     description: fieldSettings.description ?? "",
     placeholder: fieldSettings?.placeholder,
+    required: fieldSettings.required,
     validate: fieldSettings.required ? validate.required() : _.noop,
     fieldInstance: fieldSettings.fieldInstance,
   };


### PR DESCRIPTION
closes #26581

## Description

Marks required form fields with a `*` in the form creator and in action forms. Just a simple QoL improvement until we port action forms to the new forms framework.

![asterisks](https://user-images.githubusercontent.com/30528226/203433910-0f0d8b19-2c76-4bbb-9cc4-e613f95dc308.gif)
