### PR TITLE
fix row chart bugs

### DIFF
--- a/frontend/src/metabase/visualizations/shared/components/RowChart/types.ts
+++ b/frontend/src/metabase/visualizations/shared/components/RowChart/types.ts
@@ -13,8 +13,8 @@ export type Series<TDatum, TSeriesInfo = unknown> = {
 };
 
 export type BarData<TDatum, TSeriesInfo = unknown> = {
-  xStartValue: number;
-  xEndValue: number;
+  xStartValue: number | null;
+  xEndValue: number | null;
   yValue: StringLike;
   isNegative: boolean;
   isBorderValue?: boolean;

--- a/frontend/src/metabase/visualizations/shared/components/RowChart/utils/data.ts
+++ b/frontend/src/metabase/visualizations/shared/components/RowChart/utils/data.ts
@@ -3,7 +3,6 @@ import { stack, stackOffsetDiverging, stackOffsetExpand } from "d3-shape";
 import type { Series as D3Series } from "d3-shape";
 import d3 from "d3";
 import { ContinuousScaleType } from "metabase/visualizations/shared/types/scale";
-import { isNotNull } from "metabase/core/utils/types";
 import { formatNullable } from "metabase/lib/formatting/nullable";
 import { BarData, Series, SeriesData, StackOffset } from "../types";
 
@@ -20,27 +19,25 @@ export const calculateNonStackedBars = <TDatum>(
 ): SeriesData<TDatum>[] => {
   const defaultXValue = xScaleType === "log" ? 1 : 0;
   return multipleSeries.map((series, seriesIndex) => {
-    const bars: BarData<TDatum>[] = data
-      .map((datum, datumIndex) => {
-        const yValue = formatNullable(series.yAccessor(datum));
-        const xValue = series.xAccessor(datum);
-        const isNegative = xValue != null && xValue < 0;
+    const bars: BarData<TDatum>[] = data.map((datum, datumIndex) => {
+      const yValue = formatNullable(series.yAccessor(datum));
+      const xValue = series.xAccessor(datum);
+      const isNegative = xValue != null && xValue < 0;
 
-        const xStartValue = isNegative ? xValue : defaultXValue;
-        const xEndValue = isNegative ? defaultXValue : xValue;
+      const xStartValue = isNegative ? xValue : defaultXValue;
+      const xEndValue = isNegative ? defaultXValue : xValue;
 
-        return {
-          isNegative,
-          xStartValue,
-          xEndValue,
-          yValue,
-          datum,
-          datumIndex,
-          series,
-          seriesIndex,
-        };
-      })
-      .filter(isNotNull);
+      return {
+        isNegative,
+        xStartValue,
+        xEndValue,
+        yValue,
+        datum,
+        datumIndex,
+        series,
+        seriesIndex,
+      };
+    });
 
     return {
       bars,

--- a/frontend/src/metabase/visualizations/shared/components/RowChartView/RowChartView.tsx
+++ b/frontend/src/metabase/visualizations/shared/components/RowChartView/RowChartView.tsx
@@ -2,14 +2,14 @@ import React from "react";
 import { Group } from "@visx/group";
 import { AxisBottom, AxisLeft, AxisScale } from "@visx/axis";
 import { Bar } from "@visx/shape";
-import type { NumberValue, ScaleBand, ScaleContinuousNumeric } from "d3-scale";
+import type { ScaleBand, ScaleContinuousNumeric } from "d3-scale";
 import { Text } from "@visx/text";
 import { GridColumns } from "@visx/grid";
 import { scaleBand, StringLike, NumberLike } from "@visx/scale";
 import { HoveredData } from "metabase/visualizations/shared/types/events";
 import { Margin } from "metabase/visualizations/shared/types/layout";
 import { VerticalGoalLine } from "../VerticalGoalLine/VerticalGoalLine";
-import { BarData, RowChartTheme, SeriesData, YValue } from "../RowChart/types";
+import { BarData, RowChartTheme, SeriesData } from "../RowChart/types";
 import { DATA_LABEL_OFFSET } from "./constants";
 import { getDataLabel } from "./utils/data-labels";
 
@@ -94,7 +94,7 @@ const RowChartView = <TDatum,>({
               bar;
             let y = yScale(yValue);
 
-            if (y == null) {
+            if (y == null || xStartValue == null || xEndValue == null) {
               return null;
             }
 

--- a/frontend/src/metabase/visualizations/shared/components/RowChartView/utils/data-labels.ts
+++ b/frontend/src/metabase/visualizations/shared/components/RowChartView/utils/data-labels.ts
@@ -11,6 +11,10 @@ export const getDataLabel = <TDatum>(
   const { xStartValue, xEndValue, isNegative } = bar;
   const value = isNegative ? xStartValue : xEndValue;
 
+  if (value == null) {
+    return null;
+  }
+
   const [xDomainStart, xDomainEnd] = xScale.domain();
   const isOutOfDomain = value <= xDomainStart || value >= xDomainEnd;
 

--- a/frontend/src/metabase/visualizations/shared/utils/data.ts
+++ b/frontend/src/metabase/visualizations/shared/utils/data.ts
@@ -164,13 +164,21 @@ const getBreakoutDistinctValues = (
   breakout: ColumnDescriptor,
   columnFormatter: ColumnFormatter,
 ) => {
-  return Array.from(
-    new Set(
-      data.rows.map(row =>
-        columnFormatter(row[breakout.index], breakout.column),
-      ),
-    ),
-  );
+  const formattedDistinctValues: string[] = [];
+  const usedRawValues = new Set<RowValue>();
+
+  data.rows.forEach(row => {
+    const rawValue = row[breakout.index];
+
+    if (usedRawValues.has(rawValue)) {
+      return;
+    }
+
+    usedRawValues.add(rawValue);
+    formattedDistinctValues.push(columnFormatter(rawValue, breakout.column));
+  });
+
+  return formattedDistinctValues;
 };
 
 const getBreakoutSeries = (


### PR DESCRIPTION
[Bug bash doc](https://www.notion.so/metabase/Revamped-Row-Chart-03524a8f906c449cbb93a3dc7f30a20f)

## Changes

#### 1) Eliminate lags on certain datasets

Formatting each value of a breakout dimension turned out to be slow so I rewrote it to format unique values only once.

Before:
<img width="814" alt="Screen Shot 2022-11-23 at 12 23 19 AM" src="https://user-images.githubusercontent.com/14301985/203430547-00cdcba5-bed9-48e9-8ece-22c9fe200744.png">

After:
<img width="359" alt="Screen Shot 2022-11-23 at 12 26 05 AM" src="https://user-images.githubusercontent.com/14301985/203431447-d4d48540-117c-4e1a-80d5-ee5ff2fff2c8.png">

#### 2) Fix stacked row charts with log scales with breakouts and missing values

D3 stack calculates stacks from zero which is a problem on log scales. It also led to broken static viz for such charts because the rendering library is intolerant to invalid svg attribute values such as negative width.

```
select 1 y, 'a' breakout, 10 x
union all select 2 y, 'b' breakout, 10 x
```

Before:
<img width="400" alt="Screen Shot 2022-11-23 at 1 13 56 AM" src="https://user-images.githubusercontent.com/14301985/203432413-7521bc5b-67cc-4115-9cf9-cebe26a7bc9f.png">

After:
<img width="400" alt="Screen Shot 2022-11-23 at 1 13 22 AM" src="https://user-images.githubusercontent.com/14301985/203432394-691652ba-8bef-4845-96b5-8317ae369bae.png">


#### 3) Fixes not rendering `null` values which led to having too few values grouped

Before:
<img width="400" alt="Screen Shot 2022-11-23 at 1 14 53 AM" src="https://user-images.githubusercontent.com/14301985/203434277-d16900bf-bcf0-4efa-b491-89e2adc6ccdf.png">

After:
<img width="400" alt="Screen Shot 2022-11-23 at 1 15 10 AM" src="https://user-images.githubusercontent.com/14301985/203434309-6fff83b1-7001-429e-810b-13f0a1068995.png">
