### PR TITLE
Manage App Button at Top Level of App Nav

### DIFF
--- a/frontend/src/metabase/core/components/Button/Button.tsx
+++ b/frontend/src/metabase/core/components/Button/Button.tsx
@@ -37,6 +37,7 @@ export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   as?: ElementType;
   className?: string;
   to?: string;
+  tooltip?: string; // available when using as={Link}
   href?: string;
 
   icon?: string | ReactNode;

--- a/frontend/src/metabase/nav/containers/MainNavbar/DataAppNavbar/DataAppActionPanel/DataAppActionPanel.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/DataAppNavbar/DataAppActionPanel/DataAppActionPanel.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo } from "react";
 import { t } from "ttag";
 
+import Link from "metabase/core/components/Link";
 import Button from "metabase/core/components/Button";
 import EntityMenu from "metabase/components/EntityMenu";
 import Tooltip from "metabase/components/Tooltip";
@@ -56,14 +57,6 @@ function DataAppActionPanel({
       },
     ];
 
-    if (hasManageContentAction) {
-      items.push({
-        title: t`Manage content`,
-        icon: "list",
-        link: Urls.dataApp(dataApp, { mode: "preview" }),
-      });
-    }
-
     if (hasArchivePageAction) {
       items.push({
         title: t`Archive this page`,
@@ -79,14 +72,7 @@ function DataAppActionPanel({
     });
 
     return items;
-  }, [
-    dataApp,
-    hasArchivePageAction,
-    hasManageContentAction,
-    onEditAppSettings,
-    onArchiveApp,
-    onArchivePage,
-  ]);
+  }, [hasArchivePageAction, onEditAppSettings, onArchiveApp, onArchivePage]);
 
   return (
     <Root>
@@ -100,10 +86,19 @@ function DataAppActionPanel({
           </Tooltip>
         )}
         {page && <DataAppPageSharingControl page={page} />}
+        {hasManageContentAction && (
+          <Button
+            icon="list"
+            onlyIcon
+            as={Link}
+            to={Urls.dataApp(dataApp, { mode: "preview" })}
+            tooltip={t`Manage app content`}
+          />
+        )}
         <EntityMenu
           items={menuItems}
           triggerIcon="ellipsis"
-          tooltip={t`Manage content, settings and more…`}
+          tooltip={t`Manage settings and more…`}
         />
       </ActionsContainer>
     </Root>


### PR DESCRIPTION
closes #26455 

## Description

Moves manage app button to the top level off the app nav.

![manageAppButton](https://user-images.githubusercontent.com/30528226/203441394-3cbad07a-df36-445f-801c-1efd0246fe43.gif)
