### PR TITLE
Fix static gauge chart that segments has their min and max swapped

### DIFF
--- a/frontend/src/metabase/static-viz/components/Gauge/GaugeContainer.tsx
+++ b/frontend/src/metabase/static-viz/components/Gauge/GaugeContainer.tsx
@@ -22,6 +22,7 @@ import {
   calculateSegmentLabelPosition,
   calculateSegmentLabelTextAnchor,
   gaugeSorter,
+  fixSwappedMinMax,
 } from "./utils";
 
 import type { Card, Data, GaugeLabelData, Position } from "./types";
@@ -42,7 +43,9 @@ export default function GaugeContainer({
   const columnSettings =
     settings.column_settings &&
     populateDefaultColumnSettings(Object.values(settings.column_settings)[0]);
-  const segments = [...settings["gauge.segments"]].sort(gaugeSorter);
+  const segments = [...settings["gauge.segments"]]
+    .sort(gaugeSorter)
+    .map(fixSwappedMinMax);
 
   const segmentMinValue = segments[0].min;
   const segmentMaxValue = segments[segments.length - 1].max;

--- a/frontend/src/metabase/static-viz/components/Gauge/utils.tsx
+++ b/frontend/src/metabase/static-viz/components/Gauge/utils.tsx
@@ -141,6 +141,18 @@ export function gaugeSorter(
   return thisSegment.min - thatSegment.min;
 }
 
+export function fixSwappedMinMax(segment: GaugeSegment): GaugeSegment {
+  if (segment.min > segment.max) {
+    return {
+      ...segment,
+      min: segment.max,
+      max: segment.min,
+    };
+  }
+
+  return segment;
+}
+
 export function colorGetter(pieArcDatum: PieArcDatum<GaugeSegment>) {
   return pieArcDatum.data.color;
 }


### PR DESCRIPTION
Reported by: https://www.notion.so/Gauge-chart-0dad277863ad42ff8edf7dbeac07604b?d=8120be8e95a2495fabfe8395e9bc5934
Epic: #24759
[Product doc](https://www.notion.so/metabase/Further-polish-static-viz-and-add-support-for-new-charts-29e3a1d2c55a4bf39dc0b1e5a0b2d67f#0f6b8f3981b64682aa72be0bb87a61a2)
Original PR: https://github.com/metabase/metabase/pull/25651

This PR fixes the gauge chart that their segments have min and max values swapped. e.g.
![image](https://user-images.githubusercontent.com/1937582/203514174-eb6522d3-3059-466e-93a9-193bba89b1c5.png)

#### After
![image](https://user-images.githubusercontent.com/1937582/203514233-e34f8d8d-7447-461f-9646-1549eff5c224.png)

#### Before
![image](https://user-images.githubusercontent.com/1937582/203514259-f43091b9-aca8-4722-ae60-93e19a51e529.png)
