### PR TITLE
Convert timezone accept "Instance" as parameter

### DIFF
--- a/shared/src/metabase/mbql/schema.cljc
+++ b/shared/src/metabase/mbql/schema.cljc
@@ -6,6 +6,7 @@
    [(:require
      [clojure.core :as core]
      [clojure.set :as set]
+     [clojure.string :as str]
      [metabase.mbql.schema.helpers :as helpers :refer [is-clause?]]
      [metabase.mbql.schema.macros :refer [defclause one-of]]
      [schema.core :as s])
@@ -17,6 +18,7 @@
      ["moment-timezone" :as mtz]
      [clojure.core :as core]
      [clojure.set :as set]
+     [clojure.string :as str]
      [metabase.mbql.schema.helpers :as helpers :refer [is-clause?]]
      [metabase.mbql.schema.macros :refer [defclause one-of]]
      [schema.core :as s])]))
@@ -718,10 +720,14 @@
 (defclause ^{:requires-features #{:temporal-extract}} ^:sugar get-second
   datetime DateTimeExpressionArg)
 
+(def ^:private convertTimezoneArg
+  (s/cond-pre TimezoneId
+              (s/pred #(#{"instance"} (str/lower-case %)))))
+
 (defclause ^{:requires-features #{:convert-timezone}} convert-timezone
   datetime DateTimeExpressionArg
-  to       TimezoneId
-  from     (optional TimezoneId))
+  to       convertTimezoneArg
+  from     (optional convertTimezoneArg))
 
 (def ^:private ArithmeticDateTimeUnit
   (s/named
@@ -922,7 +928,6 @@
 
 (def ^:private StringExpression*
   (one-of substring trim ltrim rtrim replace lower upper concat regex-match-first coalesce case))
-
 
 (def FieldOrExpressionDef
   "Schema for anything that is accepted as a top-level expression definition, either an arithmetic expression such as a

--- a/shared/src/metabase/mbql/schema.cljc
+++ b/shared/src/metabase/mbql/schema.cljc
@@ -720,14 +720,14 @@
 (defclause ^{:requires-features #{:temporal-extract}} ^:sugar get-second
   datetime DateTimeExpressionArg)
 
-(def ^:private convertTimezoneArg
+(def ^:private ConvertTimezoneArg
   (s/cond-pre TimezoneId
               (s/pred #(#{"instance"} (str/lower-case %)))))
 
 (defclause ^{:requires-features #{:convert-timezone}} convert-timezone
   datetime DateTimeExpressionArg
-  to       convertTimezoneArg
-  from     (optional convertTimezoneArg))
+  to       ConvertTimezoneArg
+  from     (optional ConvertTimezoneArg))
 
 (def ^:private ArithmeticDateTimeUnit
   (s/named

--- a/shared/src/metabase/mbql/util.cljc
+++ b/shared/src/metabase/mbql/util.cljc
@@ -278,6 +278,17 @@
     [(op :guard temporal-extract-ops) field & args]
     [:temporal-extract field (temporal-extract-ops->unit [op (first args)])]))
 
+(defn desugar-convert-timezone
+  "Replace datetime extractions clauses like `[:get-year field]` with `[:temporal-extract field :year]`."
+  [m results-timezone-id]
+  (mbql.match/replace m
+    [(op :guard #{:convert-timezone}) field & args]
+    (into [:convert-timezone field ] (map (fn [arg]
+                                            (if (= (str/lower-case arg) "instance")
+                                             results-timezone-id
+                                             arg))
+                                          args))))
+
 (s/defn desugar-filter-clause :- mbql.s/Filter
   "Rewrite various 'syntatic sugar' filter clauses like `:time-interval` and `:inside` as simpler, logically
   equivalent clauses. This can be used to simplify the number of filter clauses that need to be supported by anything

--- a/shared/src/metabase/mbql/util.cljc
+++ b/shared/src/metabase/mbql/util.cljc
@@ -281,7 +281,11 @@
 (defn desugar-convert-timezone
   "Replace the magic argument of convert-timezone expression.
 
-  Currently only replace \"Instance\" with `results-timezone-id`."
+  Currently only replace \"Instance\" with `results-timezone-id`.
+
+  We need to handle this magic value in desugar but not in the driver itself because with convertTimezone
+  we need to annotate the column with the exact timezone id, so that the column will be formatted with the correct offset
+  in `format-rows` middleware."
   [m results-timezone-id]
   (mbql.match/replace m
     [(op :guard #{:convert-timezone}) field & args]

--- a/shared/src/metabase/mbql/util.cljc
+++ b/shared/src/metabase/mbql/util.cljc
@@ -279,7 +279,9 @@
     [:temporal-extract field (temporal-extract-ops->unit [op (first args)])]))
 
 (defn desugar-convert-timezone
-  "Replace datetime extractions clauses like `[:get-year field]` with `[:temporal-extract field :year]`."
+  "Replace the magic argument of convert-timezone expression.
+
+  Currently only replace \"Instance\" with `results-timezone-id`."
   [m results-timezone-id]
   (mbql.match/replace m
     [(op :guard #{:convert-timezone}) field & args]

--- a/shared/src/metabase/mbql/util.cljc
+++ b/shared/src/metabase/mbql/util.cljc
@@ -296,7 +296,7 @@
   equivalent clauses. This can be used to simplify the number of filter clauses that need to be supported by anything
   that needs to enumerate all the possible filter types (such as driver query processor implementations, or the
   implementation `negate-filter-clause` below.)"
-  [filter-clause :- mbql.s/Filter]
+  [filter-clause :- mbql.s/Filter results-timezone-id :- (s/maybe schema.helpers/NonBlankString)]
   (-> filter-clause
       desugar-current-relative-datetime
       desugar-equals-and-not-equals-with-extra-args
@@ -306,7 +306,8 @@
       desugar-is-empty-and-not-empty
       desugar-inside
       simplify-compound-filter
-      desugar-temporal-extract))
+      desugar-temporal-extract
+      (desugar-convert-timezone results-timezone-id)))
 
 (defmulti ^:private negate* first)
 

--- a/shared/test/metabase/mbql/util_test.cljc
+++ b/shared/test/metabase/mbql/util_test.cljc
@@ -364,6 +364,23 @@
 
 (t/deftest ^:parallel desugar-temporal-extract-test
   (t/testing "desugaring :get-year, :get-month, etc"
+    (t/is (= [:convert-timezone [:field 1 nil] "Asia/Ho_Chi_Minh" "UTC"]
+             (mbql.u/desugar-convert-timezone
+               [:convert-timezone [:field 1 nil] "instance" "UTC"]
+               "Asia/Ho_Chi_Minh")))
+
+   (t/is (= [:convert-timezone [:field 1 nil] "Asia/Ho_Chi_Minh" "UTC"]
+            (mbql.u/desugar-convert-timezone
+              [:convert-timezone [:field 1 nil] "InstAnce" "UTC"]
+              "Asia/Ho_Chi_Minh")))
+
+   (t/is (= [:convert-timezone [:field 1 nil] "Asia/Ho_Chi_Minh"]
+            (mbql.u/desugar-convert-timezone
+              [:convert-timezone [:field 1 nil] "Instance"]
+              "Asia/Ho_Chi_Minh")))))
+
+(t/deftest ^:parallel desugar-convert-timezone-test
+  (t/testing "desugaring :get-year, :get-month, etc"
     (doseq [[[op mode] unit] mbql.u/temporal-extract-ops->unit]
       (t/is (= [:temporal-extract [:field 1 nil] unit]
                (mbql.u/desugar-temporal-extract [op [:field 1 nil] mode])))

--- a/src/metabase/driver/sql/parameters/substitution.clj
+++ b/src/metabase/driver/sql/parameters/substitution.clj
@@ -265,7 +265,7 @@
       (let [[snippet & args]
             (as-> (assoc params :target [:template-tag (field->clause driver field param-type)]) form
               (params.ops/to-clause form)
-              (mbql.u/desugar-filter-clause form)
+              (mbql.u/desugar-filter-clause form (qp.timezone/results-timezone-id))
               (qp.wrap-value-literals/wrap-value-literals-in-mbql form)
               (sql.qp/->honeysql driver form)
               (hsql/format-predicate form :quoting (sql.qp/quote-style driver)))]

--- a/src/metabase/query_processor/middleware/desugar.clj
+++ b/src/metabase/query_processor/middleware/desugar.clj
@@ -3,6 +3,7 @@
             [metabase.mbql.predicates :as mbql.preds]
             [metabase.mbql.schema :as mbql.s]
             [metabase.mbql.util :as mbql.u]
+            [metabase.query-processor.timezone :as qp.timezone]
             [schema.core :as s]))
 
 (s/defn desugar :- mbql.s/Query
@@ -12,8 +13,11 @@
   [query]
   (m/update-existing query :query (fn [query]
                                     (mbql.u/replace query
-                                      (filter-clause :guard mbql.preds/Filter?)
-                                      (mbql.u/desugar-filter-clause filter-clause)
+                                     [:convert-timezone & args]
+                                     (mbql.u/desugar-convert-timezone &match (qp.timezone/results-timezone-id))
 
-                                      (temporal-extract-clause :guard mbql.preds/DatetimeExpression?)
-                                      (mbql.u/desugar-temporal-extract temporal-extract-clause)))))
+                                     (filter-clause :guard mbql.preds/Filter?)
+                                     (mbql.u/desugar-filter-clause filter-clause)
+
+                                     (temporal-extract-clause :guard mbql.preds/DatetimeExpression?)
+                                     (mbql.u/desugar-temporal-extract temporal-extract-clause)))))

--- a/src/metabase/query_processor/middleware/desugar.clj
+++ b/src/metabase/query_processor/middleware/desugar.clj
@@ -17,7 +17,7 @@
                                      (mbql.u/desugar-convert-timezone &match (qp.timezone/results-timezone-id))
 
                                      (filter-clause :guard mbql.preds/Filter?)
-                                     (mbql.u/desugar-filter-clause filter-clause)
+                                     (mbql.u/desugar-filter-clause filter-clause (qp.timezone/results-timezone-id))
 
                                      (temporal-extract-clause :guard mbql.preds/DatetimeExpression?)
                                      (mbql.u/desugar-temporal-extract temporal-extract-clause)))))

--- a/test/metabase/query_processor/middleware/desugar_test.clj
+++ b/test/metabase/query_processor/middleware/desugar_test.clj
@@ -11,6 +11,7 @@
             :query    {:source-table 1
                        :filter       [:and
                                       [:= [:field 1 nil] "Run Query"]
+                                      [:= [:field 4 nil] [:convert-timezone [:field 4 nil] "Asia/Ho_Chi_Minh" "UTC"]]
                                       [:between
                                        [:field 2 {:temporal-unit :day}]
                                        [:relative-datetime -30 :day]
@@ -34,6 +35,7 @@
              :query    {:source-table 1
                         :filter       [:and
                                        [:= [:field 1 nil] "Run Query"]
+                                       [:= [:field 4 nil] [:convert-timezone [:field 4 nil] "instance" "UTC"]]
                                        [:time-interval [:field 2 nil] -30 :day]
                                        [:!= [:field 3 nil] "(not set)" "url"]
                                        [:> [:get-year [:field 4 nil]] 2004]]

--- a/test/metabase/query_processor/middleware/desugar_test.clj
+++ b/test/metabase/query_processor/middleware/desugar_test.clj
@@ -1,41 +1,45 @@
 (ns metabase.query-processor.middleware.desugar-test
   (:require [clojure.test :refer :all]
-            [metabase.query-processor.middleware.desugar :as desugar]))
+            [metabase.query-processor.middleware.desugar :as desugar]
+            [metabase.query-processor.timezone :as qp.timezone]))
 
 ;; actual desugaring logic and tests are in [[metabase.mbql.util-test]]
 (deftest ^:parallel e2e-test
-  (is (= {:database 1
-          :type     :query
-          :query    {:source-table 1
-                     :filter       [:and
-                                    [:= [:field 1 nil] "Run Query"]
-                                    [:between
-                                     [:field 2 {:temporal-unit :day}]
-                                     [:relative-datetime -30 :day]
-                                     [:relative-datetime -1 :day]]
-                                    [:!= [:field 3 nil] "(not set)"]
-                                    [:!= [:field 3 nil] "url"]
-                                    [:> [:temporal-extract [:field 4 nil] :year-of-era] 2004]]
-                     :expressions  {"year" [:temporal-extract [:field 4 nil] :year-of-era]}
-                     :aggregation  [[:share [:and
-                                             [:= [:field 1 nil] "Run Query"]
-                                             [:between
-                                              [:field 2 {:temporal-unit :day}]
-                                              [:relative-datetime -30 :day]
-                                              [:relative-datetime -1 :day]]
-                                             [:!= [:field 3 nil] "(not set)"]
-                                             [:!= [:field 3 nil] "url"]]]]}}
-         (desugar/desugar
-          {:database 1
-           :type     :query
-           :query    {:source-table 1
-                      :filter       [:and
-                                     [:= [:field 1 nil] "Run Query"]
-                                     [:time-interval [:field 2 nil] -30 :day]
-                                     [:!= [:field 3 nil] "(not set)" "url"]
-                                     [:> [:get-year [:field 4 nil]] 2004]]
-                      :expressions  {"year" [:get-year [:field 4 nil]]}
-                      :aggregation  [[:share [:and
-                                              [:= [:field 1 nil] "Run Query"]
-                                              [:time-interval [:field 2 nil] -30 :day]
-                                              [:!= [:field 3 nil] "(not set)" "url"]]]]}}))))
+  (binding [qp.timezone/*results-timezone-id-override* "Asia/Ho_Chi_Minh"]
+    (is (= {:database 1
+            :type     :query
+            :query    {:source-table 1
+                       :filter       [:and
+                                      [:= [:field 1 nil] "Run Query"]
+                                      [:between
+                                       [:field 2 {:temporal-unit :day}]
+                                       [:relative-datetime -30 :day]
+                                       [:relative-datetime -1 :day]]
+                                      [:!= [:field 3 nil] "(not set)"]
+                                      [:!= [:field 3 nil] "url"]
+                                      [:> [:temporal-extract [:field 4 nil] :year-of-era] 2004]]
+                       :expressions  {"year" [:temporal-extract [:field 4 nil] :year-of-era]
+                                      "zoned" [:convert-timezone [:field 4 nil] "Asia/Ho_Chi_Minh" "UTC"]}
+                       :aggregation  [[:share [:and
+                                               [:= [:field 1 nil] "Run Query"]
+                                               [:between
+                                                [:field 2 {:temporal-unit :day}]
+                                                [:relative-datetime -30 :day]
+                                                [:relative-datetime -1 :day]]
+                                               [:!= [:field 3 nil] "(not set)"]
+                                               [:!= [:field 3 nil] "url"]]]]}}
+           (desugar/desugar
+            {:database 1
+             :type     :query
+             :query    {:source-table 1
+                        :filter       [:and
+                                       [:= [:field 1 nil] "Run Query"]
+                                       [:time-interval [:field 2 nil] -30 :day]
+                                       [:!= [:field 3 nil] "(not set)" "url"]
+                                       [:> [:get-year [:field 4 nil]] 2004]]
+                        :expressions  {"year" [:get-year [:field 4 nil]]
+                                       "zoned" [:convert-timezone [:field 4 nil] "instance" "UTC"]}
+                        :aggregation  [[:share [:and
+                                                [:= [:field 1 nil] "Run Query"]
+                                                [:time-interval [:field 2 nil] -30 :day]
+                                                [:!= [:field 3 nil] "(not set)" "url"]]]]}})))))


### PR DESCRIPTION
Pursuant to #25698

This PR adds the ability to use `"instance"` as an argument for `convertTimezone`. The `"instance"` will be replaced with the report-tz setting.

```
report-tz = "Asia/Ho_Chi_Minh"
convertTimezone([Created At], "instance") => convertTimezone([Created At], "Asia/Ho_Chi_Minh")
```

[Product doc](https://www.notion.so/metabase/Convert-Timezones-063e2c35bbc94b85923f6bc705325045)
