### PR TITLE
Fix weird static viz data point values rounding

### DIFF
--- a/frontend/src/metabase/lib/formatting/numbers.tsx
+++ b/frontend/src/metabase/lib/formatting/numbers.tsx
@@ -24,7 +24,7 @@ interface FormatNumberOptionsType {
   negativeInParentheses?: boolean;
   number_separators?: string;
   number_style?: string;
-  scale?: string;
+  scale?: number;
   type?: string;
 }
 

--- a/frontend/src/metabase/static-viz/components/XYChart/XYChart.tsx
+++ b/frontend/src/metabase/static-viz/components/XYChart/XYChart.tsx
@@ -5,7 +5,7 @@ import { GridRows } from "@visx/grid";
 import { Group } from "@visx/group";
 import { assoc } from "icepick";
 
-import { formatNumber } from "metabase/static-viz/lib/numbers";
+import { formatNumber } from "metabase/lib/formatting/numbers";
 import { LineSeries } from "metabase/static-viz/components/XYChart/shapes/LineSeries";
 import { BarSeries } from "metabase/static-viz/components/XYChart/shapes/BarSeries";
 import { AreaSeries } from "metabase/static-viz/components/XYChart/shapes/AreaSeries";


### PR DESCRIPTION
Epic: #24759
Fixes:
- https://metaboat.slack.com/archives/C078VCLF3/p1669060237434759?thread_ts=1669047144.131399&cid=C078VCLF3
- https://metaboat.slack.com/archives/C078VLFKM/p1669047580884579?thread_ts=1669047244.386359&cid=C078VLFKM

## Results

### After
<img width="650" alt="Screen Shot 2022-11-23 at 7 01 56 PM" src="https://user-images.githubusercontent.com/14301985/203594188-ac3933b1-90a8-4dbf-95a3-550082d5f964.png">

### Before
<img width="647" alt="Screen Shot 2022-11-23 at 7 05 58 PM" src="https://user-images.githubusercontent.com/14301985/203594244-492f3771-a011-4259-9a27-c19725a91aed.png">

## How to test

```
select 1 x, 1000000 y
union all select 2 x, 2000000 y
union all select 3 x, 2200000 y
union all select 4 x, 3900000 y
union all select 5 x, 4000000 y
union all select 6 x, 4100000 y
union all select 7 x, 5600000 y
```

- create a question with the query above
- change the Y-axis formatting co currency
- set `Minimum number of decimal places` to 0
- add the question on a dashboard and send a test subscription