### PR TITLE
return white text color more frequently

### DIFF
--- a/frontend/src/metabase/lib/colors/palette.ts
+++ b/frontend/src/metabase/lib/colors/palette.ts
@@ -154,14 +154,19 @@ const LIGHT_HSL_RANGES = [
   ],
 ];
 
+// We intentionally want to return white text color more frequently
+// https://www.notion.so/Maz-notes-on-viz-settings-67aed0e4ddcc4d4a83028992c4301820?d=513f4f7fa9c143cb874c7e4525dfb1e9#277d6b3eeb464eac86088abd144fde9e
+const whiteTextColorPriorityFactor = 1.8;
+
 export const getTextColorForBackground = (backgroundColor: string) => {
-  const whiteTextContrast = Color(color(backgroundColor)).contrast(
-    Color(color("white")),
-  );
+  const whiteTextContrast =
+    Color(color(backgroundColor)).contrast(Color(color("white"))) *
+    whiteTextColorPriorityFactor;
   const darkTextContrast = Color(color(backgroundColor)).contrast(
     Color(color("text-dark")),
   );
-  return whiteTextContrast > darkTextContrast
+
+  return whiteTextContrast * whiteTextColorPriorityFactor > darkTextContrast
     ? color("white")
     : color("text-dark");
 };

--- a/frontend/src/metabase/lib/colors/palette.ts
+++ b/frontend/src/metabase/lib/colors/palette.ts
@@ -156,7 +156,7 @@ const LIGHT_HSL_RANGES = [
 
 // We intentionally want to return white text color more frequently
 // https://www.notion.so/Maz-notes-on-viz-settings-67aed0e4ddcc4d4a83028992c4301820?d=513f4f7fa9c143cb874c7e4525dfb1e9#277d6b3eeb464eac86088abd144fde9e
-const whiteTextColorPriorityFactor = 1.8;
+const whiteTextColorPriorityFactor = 3;
 
 export const getTextColorForBackground = (backgroundColor: string) => {
   const whiteTextContrast =
@@ -166,7 +166,7 @@ export const getTextColorForBackground = (backgroundColor: string) => {
     Color(color("text-dark")),
   );
 
-  return whiteTextContrast * whiteTextColorPriorityFactor > darkTextContrast
+  return whiteTextContrast > darkTextContrast
     ? color("white")
     : color("text-dark");
 };


### PR DESCRIPTION
[Notion doc](https://www.notion.so/metabase/Maz-notes-on-viz-settings-67aed0e4ddcc4d4a83028992c4301820#277d6b3eeb464eac86088abd144fde9e)

## Changes

We [intentionally](https://www.notion.so/metabase/Maz-notes-on-viz-settings-67aed0e4ddcc4d4a83028992c4301820#277d6b3eeb464eac86088abd144fde9e) want to have white text on pie segment colors more frequently even though it gives worse contrast than the dark color

### Before
<img width="1172" alt="Screen Shot 2022-11-24 at 1 48 56 AM" src="https://user-images.githubusercontent.com/14301985/203659020-4680ca76-d337-466b-8c04-544a9ec1f647.png">

### After
<img width="1085" alt="Screen Shot 2022-11-24 at 1 48 28 AM" src="https://user-images.githubusercontent.com/14301985/203659039-dc2d5cf1-8990-49e4-8043-2eb36decb1b2.png">
