### PR TITLE
Package (Docker) image automatically on a tagged release (OSS and EE)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,159 @@
+name: Release [WIP]
+
+on:
+  push:
+    tags:
+    - 'v*'
+
+jobs:
+
+  download-uberjar:
+    runs-on: ubuntu-20.04
+    timeout-minutes: 10
+    steps:
+    - name: Download Uberjar for ${{ github.ref_name }}
+      run: |
+        JAR_DOWNLOAD_URL=https://downloads.metabase.com/${{ github.ref_name }}/metabase.jar
+        if [[ ${{ github.ref_name }} == v1* ]]; then
+          JAR_DOWNLOAD_URL=https://downloads.metabase.com/enterprise/${{ github.ref_name }}/metabase.jar
+        fi
+        echo $JAR_DOWNLOAD_URL > url.txt
+        echo "----- Downloading Uberjar from $JAR_DOWNLOAD_URL -----"
+        curl -OL $JAR_DOWNLOAD_URL
+        stat ./metabase.jar
+        date | tee timestamp
+    - name: Calculate SHA256 checksum
+      run: sha256sum ./metabase.jar | tee SHA256.sum
+    - name: Upload Uberjar as artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: metabase-uberjar-${{ github.ref_name }}
+        path: |
+          ./metabase.jar
+          ./url.txt
+          ./timestamp
+          ./SHA256.sum
+
+  check-uberjar:
+    runs-on: ubuntu-20.04
+    needs: download-uberjar
+    timeout-minutes: 10
+    strategy:
+      matrix:
+        java-version: [11, 17]
+    steps:
+    - name: Prepare JRE (Java Run-time Environment)
+      uses: actions/setup-java@v3
+      with:
+        java-package: jre
+        java-version: ${{ matrix.java-version }}
+        distribution: 'temurin'
+    - uses: actions/download-artifact@v2
+      name: Retrieve previously downloaded Uberjar
+      with:
+        name: metabase-uberjar-${{ github.ref_name }}
+    - name: Reveal its version.properties
+      run: jar xf metabase.jar version.properties && cat version.properties
+    - name: Display when and where it was downloaded
+      run: |
+        cat timestamp
+        cat url.txt
+    - name: Show the checksum
+      run: cat SHA256.sum
+    - name: Launch Metabase Uberjar (and keep it running)
+      run: java -jar ./metabase.jar &
+    - name: Wait for Metabase to start
+      run: while ! curl -s localhost:3000/api/health; do sleep 1; done
+      timeout-minutes: 3
+    - name: Check API health
+      run: curl -s localhost:3000/api/health
+
+  containerize:
+    runs-on: ubuntu-20.04
+    needs: check-uberjar
+    timeout-minutes: 15
+    services:
+      registry:
+        image: registry:2
+        ports:
+          - 5000:5000
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/download-artifact@v3
+      name: Retrieve previously downloaded Uberjar
+      with:
+        name: metabase-uberjar-${{ github.ref_name }}
+    - name: Move the Uberjar to the context dir
+      run: mv ./metabase.jar bin/docker/.
+    - name: Set up Docker Buildx
+      id: buildx
+      uses: docker/setup-buildx-action@v2
+      with:
+        driver-opts: network=host
+    - name: Build ${{ matrix.edition }} container
+      uses: docker/build-push-action@v3
+      with:
+        context: bin/docker/.
+        platforms: linux/amd64
+        network: host
+        tags: localhost:5000/local-metabase:${{ github.ref_name }}
+        no-cache: true
+        push: true
+
+    - name: Launch container
+      run: docker run --rm -dp 3000:3000 localhost:5000/local-metabase:${{ github.ref_name }}
+      timeout-minutes: 5
+    - name: Wait for Metabase to start
+      run: while ! curl -s 'http://localhost:3000/api/health' | grep '{"status":"ok"}'; do sleep 1; done
+      timeout-minutes: 3
+
+    - name: Determine the target Docker Hub repository
+      run: |
+        if [[ ${{ github.ref_name }} == v1* ]]; then
+          echo "Metabase EE: image is going to be pushed to ${{ github.repository_owner }}/metabase-enterprise"
+          echo "DOCKERHUB_REPO=${{ github.repository_owner }}/metabase-enterprise" >> $GITHUB_ENV
+        else
+          echo "Metabase OSS: image is going to be pushed to ${{ github.repository_owner }}/metabase"
+          echo "DOCKERHUB_REPO=${{ github.repository_owner }}/metabase" >> $GITHUB_ENV
+        fi
+
+    - name: Login to Docker Hub
+      uses: docker/login-action@v2
+      with:
+        username: ${{ secrets.DOCKERHUB_RELEASE_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_RELEASE_TOKEN }}
+    - name: Retag and push container image to Docker Hub
+      run: |
+        echo "Pushing ${{ github.ref_name }} to ${{ env.DOCKERHUB_REPO }} ..."
+        docker tag localhost:5000/local-metabase:${{ github.ref_name }} ${{ env.DOCKERHUB_REPO }}:${{ github.ref_name }}
+        docker push ${{ env.DOCKERHUB_REPO }}:${{ github.ref_name }}
+        echo "Finished!"
+
+  verify-docker-pull:
+    runs-on: ubuntu-20.04
+    needs: containerize
+    timeout-minutes: 15
+    steps:
+    - name: Login to Docker Hub # authenticated, to avoid being rate-throttled
+      uses: docker/login-action@v2
+      with:
+        username: ${{ secrets.DOCKERHUB_RELEASE_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_RELEASE_TOKEN }}
+    - name: Determine the container image to pull
+      run: |
+        if [[ ${{ github.ref_name }} == v1* ]]; then
+          echo "DOCKERHUB_REPO=${{ github.repository_owner }}/metabase-enterprise" >> $GITHUB_ENV
+        else
+          echo "DOCKERHUB_REPO=${{ github.repository_owner }}/metabase" >> $GITHUB_ENV
+        fi
+    - name: Pull the container image
+      run: |
+        echo "Pulling container image ${{ env.DOCKERHUB_REPO }}:${{ github.ref_name }} ..."
+        docker pull ${{ env.DOCKERHUB_REPO }}:${{ github.ref_name }}
+        echo "Successful!"
+    - name: Launch container
+      run: docker run --rm -dp 3000:3000 ${{ env.DOCKERHUB_REPO }}:${{ github.ref_name }}
+      timeout-minutes: 5
+    - name: Wait for Metabase to start
+      run: while ! curl -s 'http://localhost:3000/api/health' | grep '{"status":"ok"}'; do sleep 1; done
+      timeout-minutes: 3


### PR DESCRIPTION
When the release manager runs the release script manually, one of the step is to tag the commit and push the tag to GitHub. When that happens, this workflow is triggered, and the workflow will automatically containerize the Uberjar and push the image to the official Metabase Dockerhub.

The way I test it:

1. Prepare it in a fork (e.g. `github.com/ariya/metabase` in my case)
2. Merge this PR into `master` (or cherry-pick this commit)
3. Tag it with a past release of Metabase, e.g. `git tag v0.44.6`
4. Push the tag to the said fork
5. Watch the action gets triggered

![image](https://user-images.githubusercontent.com/7288/203665643-7c02a3b7-46c3-4c7e-9c3d-f45a82b08a6d.png)

6. Check [hub.docker.com/r/ariya/metabase/tags](https://hub.docker.com/r/ariya/metabase/tags)

![image](https://user-images.githubusercontent.com/7288/203665769-6904617f-2e8c-4451-8e68-f96ca4193270.png)

*Note*: The reason for Step 3 is because the workflow will download an existing Uberjar from the official place (e.g. `https://downloads.metabase.com/v0.44.6` in the above example), hence we ought use the tag of any past releases.

At some point, **once** this workflow is verified to work correctly, **then** we can remove the Docker build step from the release script. See PR #26726.