### PR TITLE
Refactor driver/database-supports? to driver/supports? for bigquery-cloud-sdk datetime-diff

### DIFF
--- a/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
+++ b/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
@@ -316,9 +316,7 @@
 
 (defmethod driver/supports? [:bigquery-cloud-sdk :foreign-keys] [_ _] true)
 
-(defmethod driver/database-supports? [:bigquery-cloud-sdk :datetime-diff]
-  [_driver _feat _db]
-  true)
+(defmethod driver/supports? [:bigquery-cloud-sdk :datetime-diff] [_ _] true)
 
 ;; BigQuery uses timezone operators and arguments on calls like extract() and timezone_trunc() rather than literally
 ;; using SET TIMEZONE, but we need to flag it as supporting set-timezone anyway so that reporting timezones are


### PR DESCRIPTION
Just tidier. Doesn't change runtime behaviour.