### PR TITLE
Make it possible to autocomplete `color()` function

### DIFF
--- a/frontend/src/metabase/lib/colors/palette.ts
+++ b/frontend/src/metabase/lib/colors/palette.ts
@@ -6,7 +6,7 @@ export const ACCENT_COUNT = 8;
 // NOTE: DO NOT ADD COLORS WITHOUT EXTREMELY GOOD REASON AND DESIGN REVIEW
 // NOTE: KEEP SYNCRONIZED WITH COLORS.CSS
 /* eslint-disable no-color-literals */
-export const colors: ColorPalette = {
+export const colors = {
   brand: "#509EE3",
   summarize: "#88BF4D",
   filter: "#7172AD",
@@ -80,9 +80,19 @@ const aliases: Record<string, (palette: ColorPalette) => string> = {
   "accent7-dark": palette => shade(color(`accent7`, palette)),
 };
 
-export const color = (color: string, palette = colors) => {
+export function color(
+  colorName: keyof ColorPalette,
+  palette?: ColorPalette,
+): string;
+export function color(color: string, palette?: ColorPalette): string;
+export function color(color: any, palette: ColorPalette = colors) {
+  const fullPalette = {
+    ...colors,
+    ...palette,
+  };
+
   if (color in palette) {
-    return palette[color];
+    return fullPalette[color as keyof ColorPalette];
   }
 
   if (color in aliases) {
@@ -90,7 +100,7 @@ export const color = (color: string, palette = colors) => {
   }
 
   return color;
-};
+}
 
 export const alpha = (c: string, a: number) => {
   return Color(color(c)).alpha(a).string();

--- a/frontend/src/metabase/lib/colors/types.ts
+++ b/frontend/src/metabase/lib/colors/types.ts
@@ -1,4 +1,6 @@
-export type ColorPalette = Record<string, string>;
+import { colors } from "./palette";
+
+export type ColorPalette = Partial<Record<keyof typeof colors, string>>;
 
 export interface AccentColorOptions {
   main?: boolean;


### PR DESCRIPTION
While working on [Match static combo chart colors and legends with app viz colors](https://github.com/metabase/metabase/pull/26211#top). Specifically, in this commit https://github.com/metabase/metabase/pull/26211/commits/987acfa950f95ba3f212ef6f6585fc005bdb6a95, I want to make it so that `color()` function accepts partial `palette`, but most importantly, I want to make it possible to autocomplete the color name.

### Before this PR
Color name autocompletion doesn't work and it's prone to human error.
![Screenshot 2022-11-24 at 8 37 44 PM](https://user-images.githubusercontent.com/1937582/203798959-97f8618e-d805-4c56-b8d9-69106d3c80f4.png)

### After this PR
Color name autocompletion works! It also works when color is just a string, since we also accepts hex and rgb and other representation of colors as input.
- ![Screenshot 2022-11-24 at 8 38 11 PM](https://user-images.githubusercontent.com/1937582/203799182-c4faeffb-80dd-4540-957f-88ea707fd1e9.png)
- ![Screenshot 2022-11-24 at 8 38 24 PM](https://user-images.githubusercontent.com/1937582/203799194-f1342bed-1add-4646-8103-07ad9cfe70ce.png)
