### PR TITLE
adding border to pivot table sort buttons

### DIFF
--- a/frontend/src/metabase/visualizations/components/ChartSettings.jsx
+++ b/frontend/src/metabase/visualizations/components/ChartSettings.jsx
@@ -93,8 +93,7 @@ class ChartSettings extends Component {
 
   // allows a widget to temporarily replace itself with a different widget
   handleShowWidget = (widget, ref) => {
-    this.setState({ popoverRef: ref });
-    this.setState({ currentWidget: widget });
+    this.setState({ popoverRef: ref, currentWidget: widget });
   };
 
   // go back to previously selected section

--- a/frontend/src/metabase/visualizations/components/ChartSettingsWidget.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/ChartSettingsWidget.styled.tsx
@@ -12,6 +12,7 @@ export const Root = styled.div<{
   noPadding?: boolean;
   inline?: boolean;
   marginBottom?: string;
+  borderBottom?: boolean;
 }>`
   ${props =>
     !props.noPadding &&
@@ -51,6 +52,13 @@ export const Root = styled.div<{
         display: inline-flex;
         margin-bottom: 0;
       }
+    `}
+
+    ${props =>
+    props.borderBottom &&
+    css`
+      padding-bottom: 1rem;
+      border-bottom: 1px solid ${color("border")};
     `}
 
   input, .AdminSelect {

--- a/frontend/src/metabase/visualizations/components/ChartSettingsWidget.tsx
+++ b/frontend/src/metabase/visualizations/components/ChartSettingsWidget.tsx
@@ -21,6 +21,7 @@ type Props = {
   props?: Record<string, unknown>;
   noPadding?: boolean;
   variant?: "default" | "form-field";
+  borderBottom?: boolean;
   dataTestId?: string;
 };
 
@@ -38,6 +39,7 @@ const ChartSettingsWidget = ({
   props,
   // disables X padding for certain widgets so divider line extends to edge
   noPadding,
+  borderBottom,
   // NOTE: pass along special props to support:
   // * adding additional fields
   // * substituting widgets
@@ -53,6 +55,7 @@ const ChartSettingsWidget = ({
       inline={inline}
       marginBottom={marginBottom}
       data-testid={dataTestId}
+      borderBottom={borderBottom}
     >
       {title && (
         <Title variant={variant} className={cx({ "Form-label": isFormField })}>

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingIconRadio.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingIconRadio.styled.tsx
@@ -8,9 +8,16 @@ interface RadioIconProps {
 }
 
 export const RadioIcon = styled(Icon)<RadioIconProps>`
-  margin-left: 1rem;
+  margin-left: 0.5rem;
   cursor: pointer;
   user-select: none;
+  border: 1px solid ${color("border")};
+  border-radius: 0.5rem;
+  padding: 0.5rem;
+
+  &:hover {
+    color: ${color("brand")};
+  }
 
   ${props => props.isSelected && `color: ${color("brand")}`}
 `;

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingIconRadio.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingIconRadio.styled.tsx
@@ -1,23 +1,6 @@
 import styled from "@emotion/styled";
-import Icon from "metabase/components/Icon";
+import Button from "metabase/core/components/Button";
 
-import { color } from "metabase/lib/colors";
-
-interface RadioIconProps {
-  isSelected: boolean;
-}
-
-export const RadioIcon = styled(Icon)<RadioIconProps>`
+export const IconButton = styled(Button)`
   margin-left: 0.5rem;
-  cursor: pointer;
-  user-select: none;
-  border: 1px solid ${color("border")};
-  border-radius: 0.5rem;
-  padding: 0.5rem;
-
-  &:hover {
-    color: ${color("brand")};
-  }
-
-  ${props => props.isSelected && `color: ${color("brand")}`}
 `;

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingIconRadio.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingIconRadio.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { RadioIcon } from "./ChartSettingIconRadio.styled";
+import { IconButton } from "./ChartSettingIconRadio.styled";
 
 interface ChartSettingIconRadioProps {
   value: string;
@@ -23,10 +23,10 @@ export const ChartSettingIconRadio = ({
   return (
     <div>
       {options.map(option => (
-        <RadioIcon
-          name={option.iconName}
+        <IconButton
+          icon={option.iconName}
           onClick={() => handleClick(option.value)}
-          isSelected={option.value === value}
+          primary={option.value === value}
           key={`radio-icon-${option.iconName}`}
         />
       ))}

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
@@ -240,6 +240,7 @@ class PivotTable extends Component {
       title: t`Sort Order`,
       widget: ChartSettingIconRadio,
       inline: true,
+      borderBottom: true,
       props: {
         options: [
           {


### PR DESCRIPTION
Notion Doc: https://www.notion.so/metabase/Maz-notes-on-viz-settings-67aed0e4ddcc4d4a83028992c4301820#0009a0ca07a3475692061cd5ffda78de

Small PR to add borders to the Pivot table sort buttons, add a hover state, and create a border to separate the sort action from the rest of the column settings.

![image](https://user-images.githubusercontent.com/1328979/203803301-45571cd8-8cf7-45a8-a396-af1b2eb0d0a6.png)

