### PR TITLE
Fix incorrect static viz formatting

### DIFF
--- a/frontend/src/metabase/lib/formatting/numbers.tsx
+++ b/frontend/src/metabase/lib/formatting/numbers.tsx
@@ -83,7 +83,12 @@ export function formatNumber(
   } else {
     try {
       let nf;
-      if (number < 1 && number > -1 && options.decimals == null) {
+      if (
+        number < 1 &&
+        number > -1 &&
+        options.decimals == null &&
+        options.number_style !== "percent"
+      ) {
         // NOTE: special case to match existing behavior for small numbers, use
         // max significant digits instead of max fraction digits
         nf = numberFormatterForOptions({

--- a/frontend/src/metabase/static-viz/components/XYChart/XYChart.tsx
+++ b/frontend/src/metabase/static-viz/components/XYChart/XYChart.tsx
@@ -5,7 +5,7 @@ import { GridRows } from "@visx/grid";
 import { Group } from "@visx/group";
 import { assoc } from "icepick";
 
-import { formatNumber } from "metabase/lib/formatting/numbers";
+import { formatNumber } from "metabase/static-viz/lib/numbers";
 import { LineSeries } from "metabase/static-viz/components/XYChart/shapes/LineSeries";
 import { BarSeries } from "metabase/static-viz/components/XYChart/shapes/BarSeries";
 import { AreaSeries } from "metabase/static-viz/components/XYChart/shapes/AreaSeries";

--- a/frontend/src/metabase/static-viz/lib/numbers.ts
+++ b/frontend/src/metabase/static-viz/lib/numbers.ts
@@ -1,4 +1,5 @@
 import { merge } from "icepick";
+import { formatNumber as appFormatNumber } from "metabase/lib/formatting/numbers";
 
 export type NumberFormatOptions = {
   number_style?: "currency" | "decimal" | "scientific" | "percentage";
@@ -24,74 +25,9 @@ const DEFAULT_OPTIONS = {
 };
 
 export const formatNumber = (number: number, options?: NumberFormatOptions) => {
-  const {
-    number_style,
-    currency,
-    currency_style,
-    number_separators: [decimal_separator, grouping_separator],
-    decimals,
-    scale,
-    prefix,
-    suffix,
-    compact,
-  } = handleSmallNumberFormat(number, { ...DEFAULT_OPTIONS, ...options });
+  const { prefix, suffix } = { ...DEFAULT_OPTIONS, ...options };
 
-  function createFormat(compact?: boolean) {
-    if (compact) {
-      return new Intl.NumberFormat("en", {
-        style: number_style !== "scientific" ? number_style : "decimal",
-        notation: "compact",
-        compactDisplay: "short",
-        currency: currency,
-        currencyDisplay: currency_style,
-        useGrouping: true,
-        maximumFractionDigits: decimals != null ? decimals : 2,
-      });
-    }
-
-    return new Intl.NumberFormat("en", {
-      style: number_style !== "scientific" ? number_style : "decimal",
-      notation: number_style !== "scientific" ? "standard" : "scientific",
-      currency: currency,
-      currencyDisplay: currency_style,
-      useGrouping: true,
-      minimumFractionDigits: decimals,
-      maximumFractionDigits: decimals != null ? decimals : 2,
-    });
-  }
-
-  const format = createFormat(compact);
-
-  const separatorMap = {
-    ",": grouping_separator || "",
-    ".": decimal_separator,
-  };
-  const formattedNumber = format
-    .format(number * scale)
-    .replace(/,|\./g, separator => separatorMap[separator as "." | ","]);
-
-  return `${prefix}${formattedNumber}${suffix}`;
-};
-
-// Simple hack to handle small decimal numbers (0-1)
-function handleSmallNumberFormat<T>(value: number, options: T): T {
-  const hasAtLeastThreeDecimalPoints = Math.abs(value) < 0.01;
-  if (hasAtLeastThreeDecimalPoints && Math.abs(value) > 0) {
-    options = maybeMerge(options, {
-      compact: true,
-      decimals: 4,
-    });
-  }
-
-  return options;
-}
-
-const maybeMerge = <T, S1>(collection: T, object: S1) => {
-  if (collection == null) {
-    return collection;
-  }
-
-  return merge(collection, object);
+  return `${prefix}${appFormatNumber(number, options)}${suffix}`;
 };
 
 export const formatPercent = (percent: number) =>

--- a/frontend/src/metabase/static-viz/lib/numbers.unit.spec.js
+++ b/frontend/src/metabase/static-viz/lib/numbers.unit.spec.js
@@ -46,7 +46,7 @@ describe("formatNumber", () => {
       number_style: "scientific",
     });
 
-    expect(text).toEqual("1.2E3");
+    expect(text).toEqual("1.2e+3");
   });
 
   it("should format a number with custom number separators", () => {

--- a/frontend/test/metabase/lib/formatting.unit.spec.js
+++ b/frontend/test/metabase/lib/formatting.unit.spec.js
@@ -103,6 +103,12 @@ describe("formatting", () => {
       });
       it("should format percentages", () => {
         const options = { compact: true, number_style: "percent" };
+        expect(formatNumber(0.867, { number_style: "percent" })).toEqual(
+          "86.7%",
+        );
+        expect(formatNumber(1.2345, { number_style: "percent" })).toEqual(
+          "123.45%",
+        );
         expect(formatNumber(0, options)).toEqual("0%");
         expect(formatNumber(0.001, options)).toEqual("0.1%");
         expect(formatNumber(0.0001, options)).toEqual("0.01%");


### PR DESCRIPTION
This fixes the error caused by https://github.com/metabase/metabase/pull/26704. The reason is that we currently don't run BE tests when only FE is changed on a PR. But static viz is setup a bit differently. The failed tests rely on a static viz bundle which means BE static viz tests should run when FE static viz changes to ensure integrity of the static viz.

Example of an error: https://github.com/metabase/metabase/actions/runs/3540217641

I tested `test/metabase/pulse/render/js_svg_test.clj` manually and this change pass it 💪 

This PR should be manually backported to include the change from https://github.com/metabase/metabase/pull/26704 too.