### PR TITLE
docs - update signed embedding

### DIFF
--- a/docs/embedding/signed-embedding-parameters.md
+++ b/docs/embedding/signed-embedding-parameters.md
@@ -111,6 +111,10 @@ You can change the appearance of an embedded item by adding parameters with the 
 | font¹                  | [font name](../configuring-metabase/fonts.md) |
 | hide_download_button²  | true, false                                   |
 
+¹ Available on [paid plans](https://www.metabase.com/pricing).
+
+² Available on [paid plans](https://www.metabase.com/pricing) and works on questions only (not dashboards).
+
 You can preview the changes from your question or dashboard's [embedded appearance settings](./signed-embedding.md#customizing-the-appearance-of-signed-embeds).
 
 For example, the following embedding URL will display an embedded item in dark mode, with its original title, and without a border:
@@ -118,10 +122,6 @@ For example, the following embedding URL will display an embedded item in dark m
 ```
 your_embedding_url#theme=night&titled=true&bordered=false
 ```
-
-¹ Available on paid plans.
-
-² Available on paid plans and works on questions only (not dashboards).
 
 ## Further reading
 

--- a/docs/embedding/signed-embedding-parameters.md
+++ b/docs/embedding/signed-embedding-parameters.md
@@ -111,7 +111,7 @@ You can change the appearance of an embedded item by adding parameters with the 
 | font¹                  | [font name](../configuring-metabase/fonts.md) |
 | hide_download_button²  | true, false                                   |
 
-You can preview the changes from your question or dashboard's [embedded appearance settings](./signed-embedding#customizing-the-appearance-of-signed-embeds.md).
+You can preview the changes from your question or dashboard's [embedded appearance settings](./signed-embedding.md#customizing-the-appearance-of-signed-embeds).
 
 For example, the following embedding URL will display an embedded item in dark mode, with its original title, and without a border:
 

--- a/docs/embedding/signed-embedding-parameters.md
+++ b/docs/embedding/signed-embedding-parameters.md
@@ -121,7 +121,7 @@ your_embedding_url#theme=night&titled=true&bordered=false
 
 ¹ Available on paid plans.
 
-² Available on paid plans and works on questions only (not dashboards). To completely disable downloads, use the [Download results permission](../permissions/data.md#download-results).
+² Available on paid plans and works on questions only (not dashboards).
 
 ## Further reading
 

--- a/docs/embedding/signed-embedding-parameters.md
+++ b/docs/embedding/signed-embedding-parameters.md
@@ -111,7 +111,7 @@ You can change the appearance of an embedded item by adding parameters with the 
 | font¹                  | [font name](../configuring-metabase/fonts.md) |
 | hide_download_button²  | true, false                                   |
 
-You can preview the changes from your question or dashboard's [embedded appearance settings](./signed-embedding#customizing-the-appearance-of-signed-embeds).
+You can preview the changes from your question or dashboard's [embedded appearance settings](./signed-embedding#customizing-the-appearance-of-signed-embeds.md).
 
 For example, the following embedding URL will display an embedded item in dark mode, with its original title, and without a border:
 

--- a/docs/embedding/signed-embedding-parameters.md
+++ b/docs/embedding/signed-embedding-parameters.md
@@ -108,18 +108,20 @@ You can change the appearance of an embedded item by adding parameters with the 
 | bordered               | true, false                                   |
 | titled                 | true, false                                   |
 | theme                  | null, transparent, night                      |
-| font\*                 | [font name](../configuring-metabase/fonts.md) |
-| hide_download_button\* | true, false                                   |
+| font¹                  | [font name](../configuring-metabase/fonts.md) |
+| hide_download_button²  | true, false                                   |
 
-\* Available on paid plans.
-
-You can preview the changes from your question or dashboard's [embedded appearance settings](./signed-embedding.md#customizing-the-appearance-of-signed-embeds).
+You can preview the changes from your question or dashboard's [embedded appearance settings](./signed-embedding#customizing-the-appearance-of-signed-embeds).
 
 For example, the following embedding URL will display an embedded item in dark mode, with its original title, and without a border:
 
 ```
 your_embedding_url#theme=night&titled=true&bordered=false
 ```
+
+¹ Available on paid plans.
+
+² Available on paid plans and works on questions only (not dashboards). To completely disable downloads, use the [Download results permission](../permissions/data.md#download-results).
 
 ## Further reading
 

--- a/docs/embedding/signed-embedding.md
+++ b/docs/embedding/signed-embedding.md
@@ -111,6 +111,10 @@ You can change the way an embedded question or dashboard looks in an iframe (whi
 - Font¹
 - Download data²
 
+¹ Available on [paid plans](https://www.metabase.com/pricing).
+
+² Available on [paid plans](https://www.metabase.com/pricing) and hides the download button on questions only (not dashboards).
+
 To update the appearance of a signed embed:
 
 1. Optional: Preview the appearance changes from your question or dashboard's embedding settings (**sharing icon** > **Embed this item in an application**).
@@ -118,10 +122,6 @@ To update the appearance of a signed embed:
 3. Change the [parameters](./signed-embedding-parameters.md#customizing-the-appearance-of-a-signed-embed) in your actual server code.
 
 For global appearance settings, such as the colors and fonts used across your entire Metabase instance, see [Customizing Metabase's appearance](../configuring-metabase/appearance.md).
-
-¹ Available on paid plans.
-
-² Available on paid plans and hides the download button on questions only (not dashboards).
 
 ## Removing the "Powered by Metabase" banner
 

--- a/docs/embedding/signed-embedding.md
+++ b/docs/embedding/signed-embedding.md
@@ -115,13 +115,13 @@ To update the appearance of a signed embed:
 
 1. Optional: Preview the appearance changes from your question or dashboard's embedding settings (**sharing icon** > **Embed this item in an application**).
 2. Optional: Click **Code** to find the updated server code snippet in the top code block.
-3. Change the [parameters](./signed-embedding-parameters#customizing-the-appearance-of-a-signed-embed) in your actual server code.
+3. Change the [parameters](./signed-embedding-parameters#customizing-the-appearance-of-a-signed-embed.md) in your actual server code.
 
-For global appearance settings, such as the colors and fonts used across your entire Metabase instance, see [Customizing Metabase's appearance](../configuring-metabase/appearance).
+For global appearance settings, such as the colors and fonts used across your entire Metabase instance, see [Customizing Metabase's appearance](../configuring-metabase/appearance.md).
 
 ¹ Available on paid plans.
 
-² Available on paid plans and hides the download button on questions only (not dashboards). To completely disable downloads, use the [Download results permission](../permissions/data.md#download-results).
+² Available on paid plans and hides the download button on questions only (not dashboards). To completely disable downloads, use the [Download results permission](../permissions/data.md#download-results.md).
 
 ## Removing the "Powered by Metabase" banner
 

--- a/docs/embedding/signed-embedding.md
+++ b/docs/embedding/signed-embedding.md
@@ -108,18 +108,20 @@ You can change the way an embedded question or dashboard looks in an iframe (whi
 - Border
 - Title
 - Theme (light, dark, transparent)
-- Font\*
-- Download data\* (Note: This setting only hides the download button. To disable the feature entirely, use the [Download results permission](../permissions/data.md#download-results).)
-
-\* Available on paid plans.
+- Font¹
+- Download data²
 
 To update the appearance of a signed embed:
 
 1. Optional: Preview the appearance changes from your question or dashboard's embedding settings (**sharing icon** > **Embed this item in an application**).
-2. Optional: Click **Code** to find the updated server code snippet in the top block.
-3. Change the [parameters](./signed-embedding-parameters.md#customizing-the-appearance-of-a-signed-embed) in your actual server code.
+2. Optional: Click **Code** to find the updated server code snippet in the top code block.
+3. Change the [parameters](./signed-embedding-parameters#customizing-the-appearance-of-a-signed-embed) in your actual server code.
 
-For global appearance settings, such as the colors and fonts used across your entire Metabase instance, see [Customizing Metabase's appearance](../configuring-metabase/appearance.md).
+For global appearance settings, such as the colors and fonts used across your entire Metabase instance, see [Customizing Metabase's appearance](../configuring-metabase/appearance).
+
+¹ Available on paid plans.
+
+² Available on paid plans and hides the download button on questions only (not dashboards). To completely disable downloads, use the [Download results permission](../permissions/data.md#download-results).
 
 ## Removing the "Powered by Metabase" banner
 

--- a/docs/embedding/signed-embedding.md
+++ b/docs/embedding/signed-embedding.md
@@ -115,7 +115,7 @@ To update the appearance of a signed embed:
 
 1. Optional: Preview the appearance changes from your question or dashboard's embedding settings (**sharing icon** > **Embed this item in an application**).
 2. Optional: Click **Code** to find the updated server code snippet in the top code block.
-3. Change the [parameters](./signed-embedding-parameters#customizing-the-appearance-of-a-signed-embed.md) in your actual server code.
+3. Change the [parameters](./signed-embedding-parameters.md#customizing-the-appearance-of-a-signed-embed) in your actual server code.
 
 For global appearance settings, such as the colors and fonts used across your entire Metabase instance, see [Customizing Metabase's appearance](../configuring-metabase/appearance.md).
 

--- a/docs/embedding/signed-embedding.md
+++ b/docs/embedding/signed-embedding.md
@@ -121,7 +121,7 @@ For global appearance settings, such as the colors and fonts used across your en
 
 ¹ Available on paid plans.
 
-² Available on paid plans and hides the download button on questions only (not dashboards). To completely disable downloads, use the [Download results permission](../permissions/data.md#download-results.md).
+² Available on paid plans and hides the download button on questions only (not dashboards).
 
 ## Removing the "Powered by Metabase" banner
 


### PR DESCRIPTION
Download data only hides the button on questions, not dashboards.

And updated the footnotes so it's easier to add and read these kinds of caveats.