### PR TITLE
Ignore only FE and E2E test changes in backend workflows

### DIFF
--- a/.github/workflows/backend-skipped-checks.yml
+++ b/.github/workflows/backend-skipped-checks.yml
@@ -11,12 +11,12 @@ on:
     paths:
       - "docs/**"
       - "**.md"
-      - "**/frontend/**"
+      - "**/frontend/**.unit.*"
   pull_request:
     paths:
       - "docs/**"
       - "**.md"
-      - "**/frontend/**"
+      - "**/frontend/**.unit.*"
 
 jobs:
 

--- a/.github/workflows/backend-skipped-checks.yml
+++ b/.github/workflows/backend-skipped-checks.yml
@@ -11,11 +11,15 @@ on:
     paths:
       - "docs/**"
       - "**.md"
+      # frontend and E2E tests
+      - "**/frontend/test/**"
       - "**/frontend/**.unit.*"
   pull_request:
     paths:
       - "docs/**"
       - "**.md"
+      # frontend and E2E tests
+      - "**/frontend/test/**"
       - "**/frontend/**.unit.*"
 
 jobs:

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -8,12 +8,12 @@ on:
     paths-ignore:
       - "docs/**"
       - "**.md"
-      - "**/frontend/**"
+      - "**/frontend/**.unit.*"
   pull_request:
     paths-ignore:
       - "docs/**"
       - "**.md"
-      - "**/frontend/**"
+      - "**/frontend/**.unit.*"
 
 jobs:
 

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -8,11 +8,15 @@ on:
     paths-ignore:
       - "docs/**"
       - "**.md"
+      # frontend and E2E tests
+      - "**/frontend/test/**"
       - "**/frontend/**.unit.*"
   pull_request:
     paths-ignore:
       - "docs/**"
       - "**.md"
+      # frontend and E2E tests
+      - "**/frontend/test/**"
       - "**/frontend/**.unit.*"
 
 jobs:

--- a/.github/workflows/drivers-skipped-checks.yml
+++ b/.github/workflows/drivers-skipped-checks.yml
@@ -11,12 +11,12 @@ on:
     paths:
       - "docs/**"
       - "**.md"
-      - "**/frontend/**"
+      - "**/frontend/**.unit.*"
   pull_request:
     paths:
       - "docs/**"
       - "**.md"
-      - "**/frontend/**"
+      - "**/frontend/**.unit.*"
 
 jobs:
 

--- a/.github/workflows/drivers-skipped-checks.yml
+++ b/.github/workflows/drivers-skipped-checks.yml
@@ -11,11 +11,15 @@ on:
     paths:
       - "docs/**"
       - "**.md"
+      # frontend and E2E tests
+      - "**/frontend/test/**"
       - "**/frontend/**.unit.*"
   pull_request:
     paths:
       - "docs/**"
       - "**.md"
+      # frontend and E2E tests
+      - "**/frontend/test/**"
       - "**/frontend/**.unit.*"
 
 jobs:

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -8,13 +8,13 @@ on:
     paths-ignore:
       - "docs/**"
       - "**.md"
-      - "**/frontend/**"
+      - "**/frontend/**.unit.*"
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     paths-ignore:
       - "docs/**"
       - "**.md"
-      - "**/frontend/**"
+      - "**/frontend/**.unit.*"
 
 jobs:
 

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -8,12 +8,16 @@ on:
     paths-ignore:
       - "docs/**"
       - "**.md"
+      # frontend and E2E tests
+      - "**/frontend/test/**"
       - "**/frontend/**.unit.*"
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     paths-ignore:
       - "docs/**"
       - "**.md"
+      # frontend and E2E tests
+      - "**/frontend/test/**"
       - "**/frontend/**.unit.*"
 
 jobs:


### PR DESCRIPTION
As it turned out[^1], we cannot ignore all frontend (source) code changes in backend workflows.
There is a subset of backend tests related to static-viz that relies on FE code.

Instead of completely reverting #26539, this PR adds another glob pattern that matches unit tests outside of the `/frontend/test/` folder.

[^1]: https://github.com/metabase/metabase/pull/26704 passed all tests (because backend tests were skipped), but then broke `master`