### PR TITLE
Make all toggles inline

### DIFF
--- a/frontend/src/metabase/visualizations/lib/settings/series.js
+++ b/frontend/src/metabase/visualizations/lib/settings/series.js
@@ -141,6 +141,7 @@ export function seriesSetting({
     show_series_values: {
       title: t`Show values for this series`,
       widget: "toggle",
+      inline: true,
       getHidden: (single, seriesSettings, { settings, series }) =>
         series.length <= 1 || // no need to show series-level control if there's only one series
         !Object.prototype.hasOwnProperty.call(settings, "graph.show_values") || // don't show it unless this chart has a global setting

--- a/frontend/src/metabase/visualizations/visualizations/PieChart/PieChart.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/PieChart/PieChart.jsx
@@ -122,18 +122,21 @@ export default class PieChart extends Component {
       title: t`Show legend`,
       widget: "toggle",
       default: true,
+      inline: true,
     },
     "pie.show_legend_perecent": {
       section: t`Display`,
       title: t`Show percentages in legend`,
       widget: "toggle",
       default: true,
+      inline: true,
     },
     "pie.show_data_labels": {
       section: t`Display`,
       title: t`Show data labels`,
       widget: "toggle",
       default: false,
+      inline: true,
     },
     "pie.slice_threshold": {
       section: t`Display`,

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx
@@ -55,6 +55,7 @@ export default class Smart extends React.Component {
     "scalar.switch_positive_negative": {
       title: t`Switch positive / negative colors?`,
       widget: "toggle",
+      inline: true,
     },
     click_behavior: {},
   };

--- a/frontend/src/metabase/visualizations/visualizations/Table.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Table.jsx
@@ -249,6 +249,7 @@ export default class Table extends Component {
       settings["show_mini_bar"] = {
         title: t`Show a mini bar chart`,
         widget: "toggle",
+        inline: true,
       };
     }
 

--- a/frontend/src/metabase/visualizations/visualizations/Text/Text.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Text/Text.jsx
@@ -88,6 +88,7 @@ export default class Text extends Component {
       section: t`Display`,
       title: t`Show background`,
       dashboard: true,
+      inline: true,
       widget: "toggle",
       default: true,
     },

--- a/frontend/src/metabase/visualizations/visualizations/WaterfallChart.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/WaterfallChart.jsx
@@ -38,6 +38,7 @@ export default class WaterfallChart extends LineAreaBarChart {
       title: t`Show total`,
       widget: "toggle",
       default: true,
+      inline: true,
     },
     "waterfall.total_color": {
       section: t`Display`,


### PR DESCRIPTION
[Notion Doc](https://www.notion.so/metabase/Viz-Pod-Rest-of-the-Cycle-Outlook-c0456a67b5754647937bdc1def78e04c#bfd362e005d8419a9981fdc42a7f2d8e)

Small PR to add the inline prop to all toggles in Viz Settings (excluding the list component. I'll follow up with data-apps team). Checked each setting after changing, and all render okay.

Example: 
![image](https://user-images.githubusercontent.com/1328979/203858556-fb1ea98f-8c45-4463-ae9e-a3e75667e6f0.png)
