### PR TITLE
Fix weird static viz data point value rounding

### DIFF
--- a/frontend/src/metabase/lib/formatting/numbers.tsx
+++ b/frontend/src/metabase/lib/formatting/numbers.tsx
@@ -24,7 +24,7 @@ interface FormatNumberOptionsType {
   negativeInParentheses?: boolean;
   number_separators?: string;
   number_style?: string;
-  scale?: string;
+  scale?: number;
   type?: string;
 }
 

--- a/frontend/src/metabase/lib/formatting/numbers.tsx
+++ b/frontend/src/metabase/lib/formatting/numbers.tsx
@@ -83,7 +83,12 @@ export function formatNumber(
   } else {
     try {
       let nf;
-      if (number < 1 && number > -1 && options.decimals == null) {
+      if (
+        number < 1 &&
+        number > -1 &&
+        options.decimals == null &&
+        options.number_style !== "percent"
+      ) {
         // NOTE: special case to match existing behavior for small numbers, use
         // max significant digits instead of max fraction digits
         nf = numberFormatterForOptions({

--- a/frontend/src/metabase/static-viz/components/XYChart/XYChart.tsx
+++ b/frontend/src/metabase/static-viz/components/XYChart/XYChart.tsx
@@ -5,7 +5,7 @@ import { GridRows } from "@visx/grid";
 import { Group } from "@visx/group";
 import { assoc } from "icepick";
 
-import { formatNumber } from "metabase/static-viz/lib/numbers";
+import { formatNumber } from "metabase/lib/formatting/numbers";
 import { LineSeries } from "metabase/static-viz/components/XYChart/shapes/LineSeries";
 import { BarSeries } from "metabase/static-viz/components/XYChart/shapes/BarSeries";
 import { AreaSeries } from "metabase/static-viz/components/XYChart/shapes/AreaSeries";

--- a/frontend/src/metabase/static-viz/components/XYChart/XYChart.tsx
+++ b/frontend/src/metabase/static-viz/components/XYChart/XYChart.tsx
@@ -5,7 +5,7 @@ import { GridRows } from "@visx/grid";
 import { Group } from "@visx/group";
 import { assoc } from "icepick";
 
-import { formatNumber } from "metabase/lib/formatting/numbers";
+import { formatNumber } from "metabase/static-viz/lib/numbers";
 import { LineSeries } from "metabase/static-viz/components/XYChart/shapes/LineSeries";
 import { BarSeries } from "metabase/static-viz/components/XYChart/shapes/BarSeries";
 import { AreaSeries } from "metabase/static-viz/components/XYChart/shapes/AreaSeries";

--- a/frontend/src/metabase/static-viz/lib/numbers.ts
+++ b/frontend/src/metabase/static-viz/lib/numbers.ts
@@ -1,4 +1,5 @@
 import { merge } from "icepick";
+import { formatNumber as appFormatNumber } from "metabase/lib/formatting/numbers";
 
 export type NumberFormatOptions = {
   number_style?: "currency" | "decimal" | "scientific" | "percentage";
@@ -24,74 +25,9 @@ const DEFAULT_OPTIONS = {
 };
 
 export const formatNumber = (number: number, options?: NumberFormatOptions) => {
-  const {
-    number_style,
-    currency,
-    currency_style,
-    number_separators: [decimal_separator, grouping_separator],
-    decimals,
-    scale,
-    prefix,
-    suffix,
-    compact,
-  } = handleSmallNumberFormat(number, { ...DEFAULT_OPTIONS, ...options });
+  const { prefix, suffix } = { ...DEFAULT_OPTIONS, ...options };
 
-  function createFormat(compact?: boolean) {
-    if (compact) {
-      return new Intl.NumberFormat("en", {
-        style: number_style !== "scientific" ? number_style : "decimal",
-        notation: "compact",
-        compactDisplay: "short",
-        currency: currency,
-        currencyDisplay: currency_style,
-        useGrouping: true,
-        maximumFractionDigits: decimals != null ? decimals : 2,
-      });
-    }
-
-    return new Intl.NumberFormat("en", {
-      style: number_style !== "scientific" ? number_style : "decimal",
-      notation: number_style !== "scientific" ? "standard" : "scientific",
-      currency: currency,
-      currencyDisplay: currency_style,
-      useGrouping: true,
-      minimumFractionDigits: decimals,
-      maximumFractionDigits: decimals != null ? decimals : 2,
-    });
-  }
-
-  const format = createFormat(compact);
-
-  const separatorMap = {
-    ",": grouping_separator || "",
-    ".": decimal_separator,
-  };
-  const formattedNumber = format
-    .format(number * scale)
-    .replace(/,|\./g, separator => separatorMap[separator as "." | ","]);
-
-  return `${prefix}${formattedNumber}${suffix}`;
-};
-
-// Simple hack to handle small decimal numbers (0-1)
-function handleSmallNumberFormat<T>(value: number, options: T): T {
-  const hasAtLeastThreeDecimalPoints = Math.abs(value) < 0.01;
-  if (hasAtLeastThreeDecimalPoints && Math.abs(value) > 0) {
-    options = maybeMerge(options, {
-      compact: true,
-      decimals: 4,
-    });
-  }
-
-  return options;
-}
-
-const maybeMerge = <T, S1>(collection: T, object: S1) => {
-  if (collection == null) {
-    return collection;
-  }
-
-  return merge(collection, object);
+  return `${prefix}${appFormatNumber(number, options)}${suffix}`;
 };
 
 export const formatPercent = (percent: number) =>

--- a/frontend/src/metabase/static-viz/lib/numbers.ts
+++ b/frontend/src/metabase/static-viz/lib/numbers.ts
@@ -25,9 +25,13 @@ const DEFAULT_OPTIONS = {
 };
 
 export const formatNumber = (number: number, options?: NumberFormatOptions) => {
-  const { prefix, suffix } = { ...DEFAULT_OPTIONS, ...options };
+  const optionsWithDefault = {
+    ...DEFAULT_OPTIONS,
+    ...options,
+  };
+  const { prefix, suffix } = optionsWithDefault;
 
-  return `${prefix}${appFormatNumber(number, options)}${suffix}`;
+  return `${prefix}${appFormatNumber(number, optionsWithDefault)}${suffix}`;
 };
 
 export const formatPercent = (percent: number) =>

--- a/frontend/src/metabase/static-viz/lib/numbers.unit.spec.js
+++ b/frontend/src/metabase/static-viz/lib/numbers.unit.spec.js
@@ -46,7 +46,7 @@ describe("formatNumber", () => {
       number_style: "scientific",
     });
 
-    expect(text).toEqual("1.2E3");
+    expect(text).toEqual("1.2e+3");
   });
 
   it("should format a number with custom number separators", () => {

--- a/frontend/test/metabase/lib/formatting.unit.spec.js
+++ b/frontend/test/metabase/lib/formatting.unit.spec.js
@@ -103,6 +103,12 @@ describe("formatting", () => {
       });
       it("should format percentages", () => {
         const options = { compact: true, number_style: "percent" };
+        expect(formatNumber(0.867, { number_style: "percent" })).toEqual(
+          "86.7%",
+        );
+        expect(formatNumber(1.2345, { number_style: "percent" })).toEqual(
+          "123.45%",
+        );
         expect(formatNumber(0, options)).toEqual("0%");
         expect(formatNumber(0.001, options)).toEqual("0.1%");
         expect(formatNumber(0.0001, options)).toEqual("0.01%");


### PR DESCRIPTION
Another attempt at https://github.com/metabase/metabase/pull/26704

# Original PR description

Epic: #24759
Fixes:
- https://metaboat.slack.com/archives/C078VCLF3/p1669060237434759?thread_ts=1669047144.131399&cid=C078VCLF3
- https://metaboat.slack.com/archives/C078VLFKM/p1669047580884579?thread_ts=1669047244.386359&cid=C078VLFKM

## Results

### After
<img width="650" alt="Screen Shot 2022-11-23 at 7 01 56 PM" src="https://user-images.githubusercontent.com/14301985/203594188-ac3933b1-90a8-4dbf-95a3-550082d5f964.png">

### Before
<img width="647" alt="Screen Shot 2022-11-23 at 7 05 58 PM" src="https://user-images.githubusercontent.com/14301985/203594244-492f3771-a011-4259-9a27-c19725a91aed.png">

## How to test

```
select 1 x, 1000000 y
union all select 2 x, 2000000 y
union all select 3 x, 2200000 y
union all select 4 x, 3900000 y
union all select 5 x, 4000000 y
union all select 6 x, 4100000 y
union all select 7 x, 5600000 y
```

- create a question with the query above
- change the Y-axis formatting co currency
- set `Minimum number of decimal places` to 0
- add the question on a dashboard and send a test subscription
