### PR TITLE
Fix partial palette not working

### DIFF
--- a/frontend/src/metabase/lib/colors/palette.ts
+++ b/frontend/src/metabase/lib/colors/palette.ts
@@ -91,7 +91,7 @@ export function color(color: any, palette: ColorPalette = colors) {
     ...palette,
   };
 
-  if (color in palette) {
+  if (color in fullPalette) {
     return fullPalette[color as keyof ColorPalette];
   }
 


### PR DESCRIPTION
Follow up from https://github.com/metabase/metabase/pull/26732

That PR missed one key part which would make partial `palette` work.

Testing with [Match static combo chart colors and legends with app viz colors](https://github.com/metabase/metabase/pull/26211#top) when having custom appearance settings (enterprise feature)

#### Before this PR
![image](https://user-images.githubusercontent.com/1937582/204012592-cd814f77-6863-4533-bc21-edcaa07dbe9f.png)

#### After this PR
![image](https://user-images.githubusercontent.com/1937582/204012617-2c7c6c81-a489-428c-844d-d18e23566dc3.png)
