### PR TITLE
Changing border color for fill-background Segmented Control

### DIFF
--- a/frontend/src/metabase/components/SegmentedControl.styled.jsx
+++ b/frontend/src/metabase/components/SegmentedControl.styled.jsx
@@ -19,8 +19,7 @@ const COLORS = {
   "fill-background": {
     background: ({ isSelected, selectedColor }) =>
       isSelected ? color(selectedColor) : "transparent",
-    border: ({ isSelected, selectedColor }) =>
-      isSelected ? color(selectedColor) : getDefaultBorderColor(),
+    border: ({ selectedColor }) => color(selectedColor),
     text: ({ isSelected, inactiveColor }) =>
       color(isSelected ? "text-white" : inactiveColor),
   },


### PR DESCRIPTION
[Notion Doc](https://www.notion.so/metabase/Viz-fixes-d667bd245a0047b180da43f708f54a9d#28578c55c45840d692a073875d819f80)

Small CSS adjustment to change the style of fill-background segmented controls to use the brand color for the border.

After:
![image](https://user-images.githubusercontent.com/1328979/204052656-d0f28e54-f9c6-4ab5-9f09-0118e1cf7f1c.png)
