### PR TITLE
Adjusting style of Column Title label in Table Viz

### DIFF
--- a/frontend/src/metabase/visualizations/lib/settings/column.js
+++ b/frontend/src/metabase/visualizations/lib/settings/column.js
@@ -181,7 +181,6 @@ export const DATE_COLUMN_SETTINGS = {
   date_style: {
     title: t`Date style`,
     widget: "select",
-    variant: "form-field",
     getDefault: ({ unit }) => {
       // Grab the first option's value. If there were no options (for
       // hour-of-day probably), use an empty format string instead.
@@ -205,7 +204,6 @@ export const DATE_COLUMN_SETTINGS = {
     title: t`Date separators`,
     widget: "radio",
     default: "/",
-    variant: "form-field",
     getProps: (column, settings) => {
       const style = /\//.test(settings["date_style"])
         ? settings["date_style"]
@@ -234,7 +232,6 @@ export const DATE_COLUMN_SETTINGS = {
   time_enabled: {
     title: t`Show the time`,
     widget: "radio",
-    variant: "form-field",
     isValid: ({ unit }, settings) => {
       const options = getTimeEnabledOptionsForUnit(unit);
       return !!_.findWhere(options, { value: settings["time_enabled"] });
@@ -251,7 +248,6 @@ export const DATE_COLUMN_SETTINGS = {
     title: t`Time style`,
     widget: "radio",
     default: "h:mm A",
-    variant: "form-field",
     getProps: (column, settings) => ({
       options: [
         timeStyleOption("h:mm A", t`12-hour clock`),
@@ -282,7 +278,6 @@ export const NUMBER_COLUMN_SETTINGS = {
   number_style: {
     title: t`Style`,
     widget: "select",
-    variant: "form-field",
     props: {
       options: [
         { name: "Normal", value: "decimal" },
@@ -301,7 +296,6 @@ export const NUMBER_COLUMN_SETTINGS = {
   currency: {
     title: t`Unit of currency`,
     widget: "select",
-    variant: "form-field",
     props: {
       // FIXME: rest of these options
       options: currency.map(([_, currency]) => ({
@@ -317,7 +311,6 @@ export const NUMBER_COLUMN_SETTINGS = {
   currency_style: {
     title: t`Currency label style`,
     widget: "radio",
-    variant: "form-field",
     getProps: (column, settings) => {
       const c = settings["currency"] || "USD";
       const symbol = getCurrencySymbol(c);
@@ -356,7 +349,6 @@ export const NUMBER_COLUMN_SETTINGS = {
   currency_in_header: {
     title: t`Where to display the unit of currency`,
     widget: "radio",
-    variant: "form-field",
     props: {
       options: [
         { name: t`In the column heading`, value: true },
@@ -373,7 +365,6 @@ export const NUMBER_COLUMN_SETTINGS = {
     // uses 1-2 character string to represent decimal and thousands separators
     title: t`Separator style`,
     widget: "select",
-    variant: "form-field",
     props: {
       options: [
         { name: "100,000.00", value: ".," },
@@ -388,7 +379,6 @@ export const NUMBER_COLUMN_SETTINGS = {
   decimals: {
     title: t`Minimum number of decimal places`,
     widget: "number",
-    variant: "form-field",
     props: {
       placeholder: "1",
     },
@@ -396,7 +386,6 @@ export const NUMBER_COLUMN_SETTINGS = {
   scale: {
     title: t`Multiply by a number`,
     widget: "number",
-    variant: "form-field",
     props: {
       placeholder: "1",
     },
@@ -404,7 +393,6 @@ export const NUMBER_COLUMN_SETTINGS = {
   prefix: {
     title: t`Add a prefix`,
     widget: "input",
-    variant: "form-field",
     props: {
       placeholder: "$",
     },
@@ -412,7 +400,6 @@ export const NUMBER_COLUMN_SETTINGS = {
   suffix: {
     title: t`Add a suffix`,
     widget: "input",
-    variant: "form-field",
     props: {
       placeholder: t`dollars`,
     },

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
@@ -275,7 +275,6 @@ class PivotTable extends Component {
       title: t`Column title`,
       widget: "input",
       getDefault: column => formatColumn(column),
-      variant: "form-field",
     },
   };
 

--- a/frontend/src/metabase/visualizations/visualizations/Table.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Table.jsx
@@ -242,7 +242,6 @@ export default class Table extends Component {
         title: t`Column title`,
         widget: "input",
         getDefault: column => formatColumn(column),
-        variant: "form-field",
       },
       click_behavior: {},
     };

--- a/frontend/src/metabase/visualizations/visualizations/Table.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Table.jsx
@@ -242,6 +242,7 @@ export default class Table extends Component {
         title: t`Column title`,
         widget: "input",
         getDefault: column => formatColumn(column),
+        variant: "form-field",
       },
       click_behavior: {},
     };


### PR DESCRIPTION
[Notion Doc](https://www.notion.so/metabase/Maz-notes-on-viz-settings-67aed0e4ddcc4d4a83028992c4301820#30166395d0814c83bba503dc8474c612)

Adding `form-field` variant to Column Title setting in Table Viz.

After:
![image](https://user-images.githubusercontent.com/1328979/204054834-bc713273-6387-4e6a-a051-619d8c55afef.png)
