### PR TITLE
convert timezone requires source timezone

### DIFF
--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -298,10 +298,10 @@
         timestamptz? (hx/is-of-type? expr "timestamptz")
         _            (sql.u/validate-convert-timezone-args timestamptz? target-timezone source-timezone)
         expr         (cond->> expr
-                      (not timestamptz?)
-                      (hsql/call :timezone source-timezone)
-                      true
-                      (hsql/call :timezone target-timezone))]
+                       (not timestamptz?)
+                       (hsql/call :timezone source-timezone)
+                       :always
+                       (hsql/call :timezone target-timezone))]
     (hx/with-database-type-info expr "timestamp")))
 
 (defmethod sql.qp/->honeysql [:postgres :value]

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -21,12 +21,12 @@
             [metabase.driver.sql-jdbc.sync :as sql-jdbc.sync]
             [metabase.driver.sql-jdbc.sync.describe-table :as sql-jdbc.describe-table]
             [metabase.driver.sql.query-processor :as sql.qp]
+            [metabase.driver.sql.util :as sql.u]
             [metabase.driver.sql.util.unprepare :as unprepare]
             [metabase.models.field :as field]
             [metabase.models.secret :as secret]
             [metabase.query-processor.error-type :as qp.error-type]
             [metabase.query-processor.store :as qp.store]
-            [metabase.query-processor.timezone :as qp.timezone]
             [metabase.query-processor.util.add-alias-info :as add]
             [metabase.util :as u]
             [metabase.util.date-2 :as u.date]
@@ -295,19 +295,14 @@
   [driver [_ arg target-timezone source-timezone]]
   (let [expr         (sql.qp/->honeysql driver (cond-> arg
                                                  (string? arg) u.date/parse))
-        timestamptz? (hx/is-of-type? expr "timestamptz")]
-    (when (and timestamptz? source-timezone)
-      (throw (ex-info (tru "`timestamp with time zone` columns shouldn''t have a `source timezone`")
-                      {:type            qp.error-type/invalid-query
-                       :target-timezone target-timezone
-                       :source-timezone source-timezone})))
-    (let [source-timezone (or source-timezone (qp.timezone/results-timezone-id))
-          expr            (cond->> expr
-                            (not timestamptz?)
-                            (hsql/call :timezone source-timezone)
-                            true
-                            (hsql/call :timezone target-timezone))]
-      (hx/with-database-type-info expr "timestamp"))))
+        timestamptz? (hx/is-of-type? expr "timestamptz")
+        _            (sql.u/validate-convert-timezone-args timestamptz? target-timezone source-timezone)
+        expr         (cond->> expr
+                      (not timestamptz?)
+                      (hsql/call :timezone source-timezone)
+                      true
+                      (hsql/call :timezone target-timezone))]
+    (hx/with-database-type-info expr "timestamp")))
 
 (defmethod sql.qp/->honeysql [:postgres :value]
   [driver value]

--- a/test/metabase/query_processor_test/date_time_zone_functions_test.clj
+++ b/test/metabase/query_processor_test/date_time_zone_functions_test.clj
@@ -350,24 +350,27 @@
                      (mt/$ids (test-convert-tz
                                 $times.dt
                                 [:convert-timezone $times.dt "Asia/Tokyo" "Asia/Shanghai"])))))
-            (testing "convert to +09:00, from_tz should have default is system-tz (UTC)"
-              (is (= ["2004-03-19T09:19:09Z" "2004-03-19T18:19:09+09:00"]
-                     (mt/$ids (test-convert-tz
-                                $times.dt
-                                [:convert-timezone [:field (mt/id :times :dt) nil] "Asia/Tokyo"]))))))
+            (testing "source-timezone is required"
+              (is (thrown-with-msg?
+                    clojure.lang.ExceptionInfo
+                    #"input column doesnt have a set timezone. Please set the source parameter in convertTimezone to convert it."
+                    (mt/$ids (test-convert-tz
+                               $times.dt
+                               [:convert-timezone [:field (mt/id :times :dt) nil] "Asia/Tokyo"]))))))
 
           (mt/with-report-timezone-id "Europe/Rome"
-            (testing "from_tz should default to report_tz"
-              (is (= ["2004-03-19T09:19:09+01:00" "2004-03-19T17:19:09+09:00"]
-                     (mt/$ids (test-convert-tz
-                                $times.dt
-                                [:convert-timezone [:field (mt/id :times :dt) nil] "Asia/Tokyo"])))))
-
-            (testing "if from_tz is provided, ignore report_tz"
+            (testing "convert from UTC to Asia/Tokyo(+09:00)"
               (is (= ["2004-03-19T09:19:09+01:00" "2004-03-19T18:19:09+09:00"]
                      (mt/$ids (test-convert-tz
                                 $times.dt
-                                [:convert-timezone [:field (mt/id :times :dt) nil] "Asia/Tokyo" "UTC"])))))))
+                                [:convert-timezone [:field (mt/id :times :dt) nil] "Asia/Tokyo" "UTC"])))))
+            (testing "source-timezone is required"
+             (is (thrown-with-msg?
+                   clojure.lang.ExceptionInfo
+                   #"input column doesnt have a set timezone. Please set the source parameter in convertTimezone to convert it."
+                   (mt/$ids (test-convert-tz
+                               $times.dt
+                               [:convert-timezone [:field (mt/id :times :dt) nil] "Asia/Tokyo"])))))))
 
         (testing "timestamp with time zone columns"
           (mt/with-report-timezone-id "UTC"
@@ -376,10 +379,10 @@
                      (mt/$ids (test-convert-tz
                                 $times.dt_tz
                                 [:convert-timezone [:field (mt/id :times :dt_tz) nil] "Asia/Tokyo"])))))
-            (testing "timestamp with time zone columns shouldn't have `from_tz`"
+            (testing "timestamp with time zone columns shouldn't have `source-timezone`"
               (is (thrown-with-msg?
                     clojure.lang.ExceptionInfo
-                    #"`timestamp with time zone` columns shouldn't have a `source timezone`"
+                    #"input column already has a set timezone. Please remove the source parameter in convertTimezone."
                     (mt/$ids (test-convert-tz
                                $times.dt_tz
                                [:convert-timezone [:field (mt/id :times :dt_tz) nil]
@@ -419,8 +422,8 @@
                   20]                          ;; hour
                  (->> (mt/run-mbql-query
                         times
-                        {:expressions {"converted"  [:convert-timezone $times.dt "Asia/Tokyo"]
-                                       "date-added" [:datetime-add [:convert-timezone $times.dt "Asia/Tokyo"] 2 :hour]
+                        {:expressions {"converted"  [:convert-timezone $times.dt "Asia/Tokyo" "UTC"]
+                                       "date-added" [:datetime-add [:convert-timezone $times.dt "Asia/Tokyo" "UTC"] 2 :hour]
                                        "hour"       [:get-hour [:expression "date-added"]]}
                          :filter      [:= $times.index 1]
                          :fields      [$times.dt
@@ -449,7 +452,7 @@
                   "2004-03-19T18:19:09+09:00"];; at +09
                  (->> (mt/run-mbql-query
                         times
-                        {:expressions {"to-07"       [:convert-timezone $times.dt "Asia/Ho_Chi_Minh"]
+                        {:expressions {"to-07"       [:convert-timezone $times.dt "Asia/Ho_Chi_Minh" "UTC"]
                                        "to-07-to-09" [:convert-timezone [:expression "to-07"] "Asia/Tokyo"
                                                       "Asia/Ho_Chi_Minh"]}
                          :filter      [:= $times.index 1]
@@ -463,7 +466,7 @@
           (is (= ["2004-03-19T18:19:09+09:00"]
                  (->> (mt/run-mbql-query
                         times
-                        {:expressions {"converted" [:convert-timezone $times.dt "Asia/Tokyo"]
+                        {:expressions {"converted" [:convert-timezone $times.dt "Asia/Tokyo" "UTC"]
                                        "hour"       [:get-hour [:expression "converted"]]}
                          :filter      [:between [:expression "hour"] 17 18]
                          :fields      [[:expression "converted"]]})
@@ -473,7 +476,7 @@
           (is (= ["2004-03-19T18:19:09+09:00"]
                  (->> (mt/run-mbql-query
                         times
-                        {:expressions {"converted" [:convert-timezone $times.dt "Asia/Tokyo"]
+                        {:expressions {"converted" [:convert-timezone $times.dt "Asia/Tokyo" "UTC"]
                                        "hour"      [:get-hour [:expression "converted"]]}
                          :filter      [:= [:expression "hour"] 18]
                          :fields      [[:expression "converted"]]})
@@ -485,7 +488,7 @@
                               {:dataset_query
                                (mt/mbql-query
                                  times
-                                 {:expressions {"to-07"       [:convert-timezone $times.dt "Asia/Ho_Chi_Minh"]
+                                 {:expressions {"to-07"       [:convert-timezone $times.dt "Asia/Ho_Chi_Minh" "UTC"]
                                                 "to-07-to-09" [:convert-timezone [:expression "to-07"] "Asia/Tokyo"
                                                                "Asia/Ho_Chi_Minh"]}
                                   :filter      [:= $times.index 1]


### PR DESCRIPTION
In https://github.com/metabase/metabase/pull/25698 we allow convert-timezone to have a default value for `source-timezone = report-tz` if the input column is `timestamp without time zone` column. 

But that might cause confusion for users that don't really know what is done behind the scene.
To avoid confusion, this PR removes the default value and makes `source-timezone` requires if the input column doesn't have a timezone.

In-depth on why: check this slack [thread](https://metaboat.slack.com/archives/C03SHMZ266R/p1669373484566159).