### PR TITLE
remove console polluting error

### DIFF
--- a/frontend/src/metabase-lib/queries/utils/get-column-key.ts
+++ b/frontend/src/metabase-lib/queries/utils/get-column-key.ts
@@ -17,7 +17,6 @@ export const getColumnKey = (
   let fieldRef = column.field_ref;
 
   if (!fieldRef) {
-    console.error("column is missing field_ref", column);
     fieldRef = createFieldReference(column.name);
   }
 


### PR DESCRIPTION
## Changes

Remove `column is missing field_ref` console error which pollutes our log. `field_ref` is not always present on columns and we handle this case by creating a field reference from a column name. Considering the case is handled and the error is unactionable, making DX a bit worse, I'd like to remove it.

<img width="1727" alt="Screen Shot 2022-11-28 at 11 01 36 AM" src="https://user-images.githubusercontent.com/14301985/204296925-6148a38e-2129-48cb-b189-20fc6f4671f5.png">

<img width="1728" alt="Screen Shot 2022-11-28 at 11 02 05 AM" src="https://user-images.githubusercontent.com/14301985/204297277-9f5e16d1-8696-4fa8-9c94-90ed9b67f244.png">

