### PR TITLE
Doing isBreakout check sooner, removing column formatting from 2nd dimension

### DIFF
--- a/frontend/src/metabase/visualizations/components/ChartSettings.jsx
+++ b/frontend/src/metabase/visualizations/components/ChartSettings.jsx
@@ -207,14 +207,20 @@ class ChartSettings extends Component {
       };
     } else if (currentWidget.props?.initialKey) {
       const settings = this._getSettings();
-      const singleSeriesForColumn = series.find(single => {
-        const metricColumn = single.data.cols[1];
-        return getColumnKey(metricColumn) === currentWidget.props.initialKey;
-      });
-
       const isBreakout = settings?.["graph.dimensions"]?.length > 1;
 
-      if (singleSeriesForColumn && !isBreakout) {
+      if (isBreakout) {
+        return null;
+      }
+
+      const singleSeriesForColumn = series.find(single => {
+        const metricColumn = single.data.cols[1];
+        if (metricColumn) {
+          return getColumnKey(metricColumn) === currentWidget.props.initialKey;
+        }
+      });
+
+      if (singleSeriesForColumn) {
         return {
           ...seriesSettingsWidget,
           props: {

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPicker.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPicker.jsx
@@ -1,7 +1,6 @@
 /* eslint-disable react/prop-types */
 import React from "react";
 import { t } from "ttag";
-import _ from "underscore";
 import { DragDropContext, Droppable, Draggable } from "react-beautiful-dnd";
 
 import { moveElement } from "metabase/visualizations/lib/utils";
@@ -15,6 +14,7 @@ const ChartSettingFieldsPicker = ({
   onChange,
   addAnother,
   showColumnSetting,
+  showColumnSettingForIndicies,
   ...props
 }) => {
   const handleDragEnd = ({ source, destination }) => {
@@ -54,9 +54,8 @@ const ChartSettingFieldsPicker = ({
                           <ChartSettingFieldPicker
                             {...props}
                             showColumnSetting={
-                              _.isArray(showColumnSetting)
-                                ? showColumnSetting.includes(fieldIndex)
-                                : showColumnSetting
+                              showColumnSetting ||
+                              showColumnSettingForIndicies?.includes(fieldIndex)
                             }
                             key={fieldIndex}
                             value={field}

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPicker.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPicker.jsx
@@ -37,12 +37,12 @@ const ChartSettingFieldsPicker = ({
           <Droppable droppableId="droppable">
             {provided => (
               <div {...provided.droppableProps} ref={provided.innerRef}>
-                {fields.map((field, index) => {
+                {fields.map((field, fieldIndex) => {
                   return (
                     <Draggable
                       key={`draggable-${field}`}
                       draggableId={`draggable-${field}`}
-                      index={index}
+                      index={fieldIndex}
                     >
                       {provided => (
                         <div
@@ -55,10 +55,10 @@ const ChartSettingFieldsPicker = ({
                             {...props}
                             showColumnSetting={
                               _.isArray(showColumnSetting)
-                                ? showColumnSetting.includes(index)
+                                ? showColumnSetting.includes(fieldIndex)
                                 : showColumnSetting
                             }
-                            key={index}
+                            key={fieldIndex}
                             value={field}
                             options={calculateOptions(field)}
                             onChange={updatedField => {
@@ -70,11 +70,11 @@ const ChartSettingFieldsPicker = ({
                                 fieldsCopy.splice(
                                   existingIndex,
                                   1,
-                                  fields[index],
+                                  fields[fieldIndex],
                                 );
                               }
                               // replace with the new value
-                              fieldsCopy.splice(index, 1, updatedField);
+                              fieldsCopy.splice(fieldIndex, 1, updatedField);
                               onChange(fieldsCopy);
                             }}
                             onRemove={
@@ -83,8 +83,8 @@ const ChartSettingFieldsPicker = ({
                               (fields.length > 1 && field == null)
                                 ? () =>
                                     onChange([
-                                      ...fields.slice(0, index),
-                                      ...fields.slice(index + 1),
+                                      ...fields.slice(0, fieldIndex),
+                                      ...fields.slice(fieldIndex + 1),
                                     ])
                                 : null
                             }

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPicker.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPicker.jsx
@@ -1,6 +1,7 @@
 /* eslint-disable react/prop-types */
 import React from "react";
 import { t } from "ttag";
+import _ from "underscore";
 import { DragDropContext, Droppable, Draggable } from "react-beautiful-dnd";
 
 import { moveElement } from "metabase/visualizations/lib/utils";
@@ -13,6 +14,7 @@ const ChartSettingFieldsPicker = ({
   options,
   onChange,
   addAnother,
+  showColumnSetting,
   ...props
 }) => {
   const handleDragEnd = ({ source, destination }) => {
@@ -51,6 +53,11 @@ const ChartSettingFieldsPicker = ({
                         >
                           <ChartSettingFieldPicker
                             {...props}
+                            showColumnSetting={
+                              _.isArray(showColumnSetting)
+                                ? showColumnSetting.includes(index)
+                                : showColumnSetting
+                            }
                             key={index}
                             value={field}
                             options={calculateOptions(field)}

--- a/frontend/src/metabase/visualizations/lib/settings/graph.js
+++ b/frontend/src/metabase/visualizations/lib/settings/graph.js
@@ -146,6 +146,8 @@ export const GRAPH_DATA_SETTINGS = {
             ? t`Add series breakout`
             : null,
         columns: data.cols,
+        // When this prop is passed an array, it will only show the
+        // column settings for any index that is included in the array
         showColumnSetting: [0],
       };
     },

--- a/frontend/src/metabase/visualizations/lib/settings/graph.js
+++ b/frontend/src/metabase/visualizations/lib/settings/graph.js
@@ -146,9 +146,9 @@ export const GRAPH_DATA_SETTINGS = {
             ? t`Add series breakout`
             : null,
         columns: data.cols,
-        // When this prop is passed an array, it will only show the
+        // When this prop is passed it will only show the
         // column settings for any index that is included in the array
-        showColumnSetting: [0],
+        showColumnSettingForIndicies: [0],
       };
     },
     readDependencies: ["graph._dimension_filter", "graph._metric_filter"],

--- a/frontend/src/metabase/visualizations/lib/settings/graph.js
+++ b/frontend/src/metabase/visualizations/lib/settings/graph.js
@@ -146,7 +146,7 @@ export const GRAPH_DATA_SETTINGS = {
             ? t`Add series breakout`
             : null,
         columns: data.cols,
-        showColumnSetting: true,
+        showColumnSetting: [0],
       };
     },
     readDependencies: ["graph._dimension_filter", "graph._metric_filter"],


### PR DESCRIPTION
Fixes #26765 

Change to `getSeriesSettings` function where we detect if the series is a breakout series sooner, because if no metric has been set, than `series.data.cols` will not have a second element. We also hide the column settings on any dimension that isn't the first one, since making changes to the breakout dimension will have no impact on the visualization at that point in time, it ends up looking like something is broken because nothing is changing.

Adding a filter, we can see that we get a legitimate (if maybe not very useful 😅) graph:
![image](https://user-images.githubusercontent.com/1328979/204383192-9f0d45ab-53ed-48ca-ad5c-46763fcbc450.png)

And moving `Tax` to be the first dimension of the graph then gives us the opportunity to format the colum as we see fit
![image](https://user-images.githubusercontent.com/1328979/204383322-39a6fbf7-dec1-4168-a432-46db5f8e2479.png)
