### PR TITLE
Bump batik 1.14 -> 1.16 : CVE-2022-41704 

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -97,7 +97,7 @@
                                              :exclusions  [org.bouncycastle/bcpkix-jdk15on
                                                            org.bouncycastle/bcprov-jdk15on]}
   org.apache.sshd/sshd-core                 {:mvn/version "2.9.1"}              ; ssh tunneling and test server
-  org.apache.xmlgraphics/batik-all          {:mvn/version "1.14"}               ; SVG -> image
+  org.apache.xmlgraphics/batik-all          {:mvn/version "1.16"}               ; SVG -> image
   org.clojars.pntblnk/clj-ldap              {:mvn/version "0.0.17"}             ; LDAP client
   org.bouncycastle/bcpkix-jdk15on           {:mvn/version "1.70"}               ; Bouncy Castle crypto library -- explicit version of BC specified to resolve illegal reflective access errors
   org.bouncycastle/bcprov-jdk15on           {:mvn/version "1.70"}


### PR DESCRIPTION
First seen in trivy reportt:
https://github.com/metabase/metabase/pull/26763/checks?check_run_id=9738619831

We're on 1.14, the fixed version is 1.16.

the Vulnerability is found in `org.apache.xmlgraphics:batik-dom`, `org.apache.xmlgraphics:batik-rasterizer` and `org.apache.xmlgraphics:batik-svgbrowser` which all are transitive deps of `org.apache.xmlgraphics/batik-all`

Batik changes log : https://svn.apache.org/repos/asf/xmlgraphics/batik/trunk/CHANGES

### Subscription tests

I created 3 dashboards and manually check the rendered charts:
These email includes:
- [x] line
- [x] bar
- [x] combo
- [x] area
- [x] row
- [x] waterfall
- [x] scatter
- [x] pie
- [x] funnel
- [x] trend
- [x] progress
- [x] gauge
- [x] number
- [ ] table -- ignore since this is not SVG graph
- [ ] pivot table -- ignore since this is not SVG graph
- [ ] map -- ignroed since looks like we don't support map for subscription

Feel free to check out yourself: in each of these zip files there are 3 eml files that were generated for 3 dashboards:
- x-ray for orders table
- x-ray for reviews table
- custom dashboard I made that include many charts

[1.14.zip](https://github.com/metabase/metabase/files/10109655/1.14.zip)
[1.16.zip](https://github.com/metabase/metabase/files/10109656/1.16.zip)

Closes https://github.com/metabase/metabase/issues/26491