### PR TITLE
Fix avoid updating dashboard cards unless filter changes

### DIFF
--- a/frontend/src/metabase-lib/queries/utils/card.js
+++ b/frontend/src/metabase-lib/queries/utils/card.js
@@ -1,5 +1,5 @@
 import _ from "underscore";
-import { updateIn } from "icepick";
+import { updateIn, assoc } from "icepick";
 
 import Utils from "metabase/lib/utils";
 import { normalizeParameterValue } from "metabase-lib/parameters/utils/parameter-values";
@@ -118,23 +118,31 @@ export function applyParameters(
       deriveFieldOperatorFromParameter(parameter)?.optionsDefaults;
 
     if (mapping) {
-      // mapped target, e.x. on a dashboard
-      datasetQuery.parameters.push({
+      const queryParameter = {
         type,
         value: normalizeParameterValue(type, value),
         target: mapping.target,
-        options,
         id: parameter.id,
-      });
+      };
+      // mapped target, e.x. on a dashboard
+      datasetQuery.parameters.push(
+        options === undefined
+          ? queryParameter
+          : assoc(queryParameter, "options", options),
+      );
     } else if (parameter.target) {
-      // inline target, e.x. on a card
-      datasetQuery.parameters.push({
+      const queryParameter = {
         type,
         value: normalizeParameterValue(type, value),
         target: parameter.target,
-        options,
         id: parameter.id,
-      });
+      };
+      // inline target, e.x. on a card
+      datasetQuery.parameters.push(
+        options === undefined
+          ? queryParameter
+          : assoc(queryParameter, "options", options),
+      );
     }
   }
 


### PR DESCRIPTION
fix: #25914
It's not equal below when options is undefined
https://github.com/metabase/metabase/blob/c6e41b75139205d8524c04ab33224c58d3591366/frontend/src/metabase/dashboard/actions/data-fetching.js#L254-L257

###### Before submitting the PR, please make sure you do the following

- [ ] If you're attempting to fix a translation issue, please submit your changes to our [POEditor project](https://poeditor.com/join/project/ynjQmwSsGh) instead of opening a PR.

### Tests

- [ ] Run the frontend and Cypress end-to-end tests with `yarn lint && yarn test`)
- [ ] If there are changes to the backend codebase, run the backend tests with `clojure -X:dev:test`
- [ ] Sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform)
      (unless it's a tiny documentation change).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/26783)
<!-- Reviewable:end -->
