### PR TITLE
Break down root `Visualization` component

### DIFF
--- a/frontend/src/metabase/visualizations/components/Visualization/ChartSettingsErrorButton/ChartSettingsErrorButton.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/Visualization/ChartSettingsErrorButton/ChartSettingsErrorButton.styled.tsx
@@ -1,0 +1,5 @@
+import styled from "@emotion/styled";
+
+export const ButtonContainer = styled.div`
+  margin-top: 1rem;
+`;

--- a/frontend/src/metabase/visualizations/components/Visualization/ChartSettingsErrorButton/ChartSettingsErrorButton.tsx
+++ b/frontend/src/metabase/visualizations/components/Visualization/ChartSettingsErrorButton/ChartSettingsErrorButton.tsx
@@ -6,13 +6,17 @@ import type { VisualizationSettings } from "metabase-types/api";
 
 import { ButtonContainer } from "./ChartSettingsErrorButton.styled";
 
-interface Props {
+interface ChartSettingsErrorButtonProps {
   message: string;
   buttonLabel: string;
   onClick: (initial: VisualizationSettings) => void;
 }
 
-function ChartSettingsErrorButton({ message, buttonLabel, onClick }: Props) {
+function ChartSettingsErrorButton({
+  message,
+  buttonLabel,
+  onClick,
+}: ChartSettingsErrorButtonProps) {
   return (
     <div>
       <div>{message}</div>

--- a/frontend/src/metabase/visualizations/components/Visualization/ChartSettingsErrorButton/ChartSettingsErrorButton.tsx
+++ b/frontend/src/metabase/visualizations/components/Visualization/ChartSettingsErrorButton/ChartSettingsErrorButton.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+
+import Button from "metabase/core/components/Button";
+
+import type { VisualizationSettings } from "metabase-types/api";
+
+import { ButtonContainer } from "./ChartSettingsErrorButton.styled";
+
+interface Props {
+  message: string;
+  buttonLabel: string;
+  onClick: (initial: VisualizationSettings) => void;
+}
+
+function ChartSettingsErrorButton({ message, buttonLabel, onClick }: Props) {
+  return (
+    <div>
+      <div>{message}</div>
+      <ButtonContainer>
+        <Button primary medium onClick={onClick}>
+          {buttonLabel}
+        </Button>
+      </ButtonContainer>
+    </div>
+  );
+}
+
+export default ChartSettingsErrorButton;

--- a/frontend/src/metabase/visualizations/components/Visualization/ChartSettingsErrorButton/index.ts
+++ b/frontend/src/metabase/visualizations/components/Visualization/ChartSettingsErrorButton/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ChartSettingsErrorButton";

--- a/frontend/src/metabase/visualizations/components/Visualization/ErrorView/ErrorView.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/Visualization/ErrorView/ErrorView.styled.tsx
@@ -1,0 +1,28 @@
+import styled from "@emotion/styled";
+import Icon from "metabase/components/Icon";
+import { color } from "metabase/lib/colors";
+
+export const Root = styled.div<{ isDashboard: boolean }>`
+  display: flex;
+  flex: 1 0 auto;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+  padding-bottom: 0.5rem;
+
+  color: ${({ isDashboard }) =>
+    isDashboard ? color("text-medium") : color("text-light")};
+`;
+
+export const StyledIcon = styled(Icon)`
+  margin-bottom: 1rem;
+`;
+
+export const ShortMessage = styled.span`
+  font-weight: bold;
+  font-size: 1.12em;
+`;

--- a/frontend/src/metabase/visualizations/components/Visualization/ErrorView/ErrorView.tsx
+++ b/frontend/src/metabase/visualizations/components/Visualization/ErrorView/ErrorView.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+
+import Tooltip from "metabase/components/Tooltip";
+
+import { Root, ShortMessage, StyledIcon } from "./ErrorView.styled";
+
+interface Props {
+  error: string;
+  icon: string;
+  isDashboard: boolean;
+  isSmall: boolean;
+}
+
+function ErrorView({ error, icon = "warning", isDashboard, isSmall }: Props) {
+  return (
+    <Root isDashboard={isDashboard}>
+      <Tooltip tooltip={error} isEnabled={isSmall}>
+        <StyledIcon name={icon} size={50} />
+      </Tooltip>
+      {!isSmall && <ShortMessage>{error}</ShortMessage>}
+    </Root>
+  );
+}
+
+export default ErrorView;

--- a/frontend/src/metabase/visualizations/components/Visualization/ErrorView/ErrorView.tsx
+++ b/frontend/src/metabase/visualizations/components/Visualization/ErrorView/ErrorView.tsx
@@ -4,14 +4,19 @@ import Tooltip from "metabase/components/Tooltip";
 
 import { Root, ShortMessage, StyledIcon } from "./ErrorView.styled";
 
-interface Props {
+interface ErrorViewProps {
   error: string;
   icon: string;
   isDashboard: boolean;
   isSmall: boolean;
 }
 
-function ErrorView({ error, icon = "warning", isDashboard, isSmall }: Props) {
+function ErrorView({
+  error,
+  icon = "warning",
+  isDashboard,
+  isSmall,
+}: ErrorViewProps) {
   return (
     <Root isDashboard={isDashboard}>
       <Tooltip tooltip={error} isEnabled={isSmall}>

--- a/frontend/src/metabase/visualizations/components/Visualization/ErrorView/index.ts
+++ b/frontend/src/metabase/visualizations/components/Visualization/ErrorView/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ErrorView";

--- a/frontend/src/metabase/visualizations/components/Visualization/LoadingView/LoadingView.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/Visualization/LoadingView/LoadingView.styled.tsx
@@ -1,0 +1,34 @@
+import styled from "@emotion/styled";
+import LoadingSpinner from "metabase/components/LoadingSpinner";
+import { color } from "metabase/lib/colors";
+
+export const Root = styled.div`
+  display: flex;
+  flex: 1 0 auto;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+
+  padding: 0.5rem;
+
+  color: ${color("brand")};
+`;
+
+export const SlowQueryMessageContainer = styled.div`
+  color: ${color("text-medium")};
+`;
+
+export const ShortMessage = styled.span`
+  font-weight: bold;
+  font-size: 1.12em;
+  margin-bottom: 0.5rem;
+`;
+
+export const Duration = styled.span`
+  white-space: nowrap;
+`;
+
+export const StyledLoadingSpinner = styled(LoadingSpinner)`
+  color: ${color("text-medium")};
+`;

--- a/frontend/src/metabase/visualizations/components/Visualization/LoadingView/LoadingView.tsx
+++ b/frontend/src/metabase/visualizations/components/Visualization/LoadingView/LoadingView.tsx
@@ -1,0 +1,52 @@
+import React from "react";
+import { t, jt } from "ttag";
+
+import { duration } from "metabase/lib/formatting";
+
+import {
+  Root,
+  ShortMessage,
+  Duration,
+  SlowQueryMessageContainer,
+  StyledLoadingSpinner,
+} from "./LoadingView.styled";
+
+interface Props {
+  isSlow: "usually-slow" | boolean;
+  expectedDuration: number;
+}
+
+function SlowQueryView({ expectedDuration, isSlow }: Props) {
+  return (
+    <SlowQueryMessageContainer>
+      <ShortMessage>{t`Still Waiting…`}</ShortMessage>
+      {isSlow === "usually-slow" ? (
+        <div>
+          {jt`This usually takes an average of ${(
+            <Duration>{duration(expectedDuration)}</Duration>
+          )}.`}
+          <br />
+          {t`(This is a bit long for a dashboard)`}
+        </div>
+      ) : (
+        <div>
+          {t`This is usually pretty fast but seems to be taking a while right now.`}
+        </div>
+      )}
+    </SlowQueryMessageContainer>
+  );
+}
+
+function LoadingView({ expectedDuration, isSlow }: Props) {
+  return (
+    <Root>
+      {isSlow ? (
+        <SlowQueryView expectedDuration={expectedDuration} isSlow={isSlow} />
+      ) : (
+        <StyledLoadingSpinner />
+      )}
+    </Root>
+  );
+}
+
+export default LoadingView;

--- a/frontend/src/metabase/visualizations/components/Visualization/LoadingView/LoadingView.tsx
+++ b/frontend/src/metabase/visualizations/components/Visualization/LoadingView/LoadingView.tsx
@@ -11,12 +11,12 @@ import {
   StyledLoadingSpinner,
 } from "./LoadingView.styled";
 
-interface Props {
+interface LoadingViewProps {
   isSlow: "usually-slow" | boolean;
   expectedDuration: number;
 }
 
-function SlowQueryView({ expectedDuration, isSlow }: Props) {
+function SlowQueryView({ expectedDuration, isSlow }: LoadingViewProps) {
   return (
     <SlowQueryMessageContainer>
       <ShortMessage>{t`Still Waiting…`}</ShortMessage>
@@ -37,7 +37,7 @@ function SlowQueryView({ expectedDuration, isSlow }: Props) {
   );
 }
 
-function LoadingView({ expectedDuration, isSlow }: Props) {
+function LoadingView({ expectedDuration, isSlow }: LoadingViewProps) {
   return (
     <Root>
       {isSlow ? (

--- a/frontend/src/metabase/visualizations/components/Visualization/LoadingView/index.ts
+++ b/frontend/src/metabase/visualizations/components/Visualization/LoadingView/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./LoadingView";

--- a/frontend/src/metabase/visualizations/components/Visualization/NoResultsView/NoResultsView.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/Visualization/NoResultsView/NoResultsView.styled.tsx
@@ -1,0 +1,22 @@
+import styled from "@emotion/styled";
+import { color } from "metabase/lib/colors";
+
+export const Root = styled.div`
+  display: flex;
+  flex: 1 0 auto;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+  padding-bottom: 0.5rem;
+
+  color: ${color("text-light")};
+`;
+
+export const ShortMessage = styled.span`
+  font-weight: bold;
+  font-size: 1.12em;
+`;

--- a/frontend/src/metabase/visualizations/components/Visualization/NoResultsView/NoResultsView.tsx
+++ b/frontend/src/metabase/visualizations/components/Visualization/NoResultsView/NoResultsView.tsx
@@ -6,11 +6,11 @@ import Tooltip from "metabase/components/Tooltip";
 import NoResults from "assets/img/no_results.svg";
 import { Root, ShortMessage } from "./NoResultsView.styled";
 
-interface Props {
+interface NoResultsViewProps {
   isSmall?: boolean;
 }
 
-function NoResultsView({ isSmall }: Props) {
+function NoResultsView({ isSmall }: NoResultsViewProps) {
   return (
     <Root>
       <Tooltip tooltip={t`No results!`} isEnabled={isSmall}>

--- a/frontend/src/metabase/visualizations/components/Visualization/NoResultsView/NoResultsView.tsx
+++ b/frontend/src/metabase/visualizations/components/Visualization/NoResultsView/NoResultsView.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import { t } from "ttag";
+
+import Tooltip from "metabase/components/Tooltip";
+
+import NoResults from "assets/img/no_results.svg";
+import { Root, ShortMessage } from "./NoResultsView.styled";
+
+interface Props {
+  isSmall?: boolean;
+}
+
+function NoResultsView({ isSmall }: Props) {
+  return (
+    <Root>
+      <Tooltip tooltip={t`No results!`} isEnabled={isSmall}>
+        <img data-testid="no-results-image" src={NoResults} />
+      </Tooltip>
+      {!isSmall && <ShortMessage>{t`No results!`}</ShortMessage>}
+    </Root>
+  );
+}
+
+export default NoResultsView;

--- a/frontend/src/metabase/visualizations/components/Visualization/NoResultsView/index.ts
+++ b/frontend/src/metabase/visualizations/components/Visualization/NoResultsView/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./NoResultsView";

--- a/frontend/src/metabase/visualizations/components/Visualization/Visualization.jsx
+++ b/frontend/src/metabase/visualizations/components/Visualization/Visualization.jsx
@@ -4,7 +4,6 @@ import { connect } from "react-redux";
 import { t } from "ttag";
 import { assoc } from "icepick";
 import _ from "underscore";
-import cx from "classnames";
 
 import ExplicitSize from "metabase/components/ExplicitSize";
 
@@ -41,6 +40,8 @@ import ErrorView from "./ErrorView";
 import LoadingView from "./LoadingView";
 import NoResultsView from "./NoResultsView";
 import {
+  Root,
+  Header,
   VisualizationActionButtonsContainer,
   VisualizationSlowSpinner,
 } from "./Visualization.styled";
@@ -447,12 +448,9 @@ class Visualization extends React.PureComponent {
       (replacementContent && (dashcard.size_y !== 1 || isMobile));
 
     return (
-      <div
-        className={cx(className, "flex flex-column full-height")}
-        style={style}
-      >
+      <Root className={className} style={style}>
         {!!hasHeader && (
-          <div className="p1 flex-no-shrink">
+          <Header>
             <ChartCaption
               series={series}
               settings={settings}
@@ -464,7 +462,7 @@ class Visualization extends React.PureComponent {
                   : null
               }
             />
-          </div>
+          </Header>
         )}
         {replacementContent ? (
           replacementContent
@@ -517,7 +515,7 @@ class Visualization extends React.PureComponent {
             onUpdateVisualizationSettings={onUpdateVisualizationSettings}
           />
         )}
-      </div>
+      </Root>
     );
   }
 }

--- a/frontend/src/metabase/visualizations/components/Visualization/Visualization.jsx
+++ b/frontend/src/metabase/visualizations/components/Visualization/Visualization.jsx
@@ -8,8 +8,6 @@ import cx from "classnames";
 
 import ExplicitSize from "metabase/components/ExplicitSize";
 import LoadingSpinner from "metabase/components/LoadingSpinner";
-import Icon from "metabase/components/Icon";
-import Tooltip from "metabase/components/Tooltip";
 
 import * as MetabaseAnalytics from "metabase/lib/analytics";
 import { duration, formatNumber } from "metabase/lib/formatting";
@@ -40,6 +38,7 @@ import { datasetContainsNoResults } from "metabase-lib/queries/utils/dataset";
 import { memoizeClass } from "metabase-lib/utils";
 
 import ChartSettingsErrorButton from "./ChartSettingsErrorButton";
+import ErrorView from "./ErrorView";
 import NoResultsView from "./NoResultsView";
 import {
   VisualizationActionButtonsContainer,
@@ -472,17 +471,12 @@ class Visualization extends React.PureComponent {
         ) : isDashboard && noResults ? (
           <NoResultsView isSmall={small} />
         ) : error ? (
-          <div
-            className={
-              "flex-full px1 pb1 text-centered flex flex-column layout-centered " +
-              (isDashboard ? "text-slate-light" : "text-slate")
-            }
-          >
-            <Tooltip tooltip={error} isEnabled={small}>
-              <Icon className="mb2" name={errorIcon || "warning"} size={50} />
-            </Tooltip>
-            {!small && <span className="h4 text-bold">{error}</span>}
-          </div>
+          <ErrorView
+            error={error}
+            icon={errorIcon}
+            isSmall={small}
+            isDashboard={isDashboard}
+          />
         ) : loading ? (
           <div className="flex-full p1 text-centered text-brand flex flex-column layout-centered">
             {isSlow ? (

--- a/frontend/src/metabase/visualizations/components/Visualization/Visualization.jsx
+++ b/frontend/src/metabase/visualizations/components/Visualization/Visualization.jsx
@@ -40,8 +40,8 @@ import ErrorView from "./ErrorView";
 import LoadingView from "./LoadingView";
 import NoResultsView from "./NoResultsView";
 import {
-  Root,
-  Header,
+  VisualizationRoot,
+  VisualizationHeader,
   VisualizationActionButtonsContainer,
   VisualizationSlowSpinner,
 } from "./Visualization.styled";
@@ -448,9 +448,9 @@ class Visualization extends React.PureComponent {
       (replacementContent && (dashcard.size_y !== 1 || isMobile));
 
     return (
-      <Root className={className} style={style}>
+      <VisualizationRoot className={className} style={style}>
         {!!hasHeader && (
-          <Header>
+          <VisualizationHeader>
             <ChartCaption
               series={series}
               settings={settings}
@@ -462,7 +462,7 @@ class Visualization extends React.PureComponent {
                   : null
               }
             />
-          </Header>
+          </VisualizationHeader>
         )}
         {replacementContent ? (
           replacementContent
@@ -515,7 +515,7 @@ class Visualization extends React.PureComponent {
             onUpdateVisualizationSettings={onUpdateVisualizationSettings}
           />
         )}
-      </Root>
+      </VisualizationRoot>
     );
   }
 }

--- a/frontend/src/metabase/visualizations/components/Visualization/Visualization.jsx
+++ b/frontend/src/metabase/visualizations/components/Visualization/Visualization.jsx
@@ -42,7 +42,10 @@ import { datasetContainsNoResults } from "metabase-lib/queries/utils/dataset";
 import { memoizeClass } from "metabase-lib/utils";
 
 import ChartSettingsErrorButton from "./ChartSettingsErrorButton";
-import { VisualizationSlowSpinner } from "./Visualization.styled";
+import {
+  VisualizationActionButtonsContainer,
+  VisualizationSlowSpinner,
+} from "./Visualization.styled";
 
 const defaultProps = {
   showTitle: false,
@@ -396,7 +399,7 @@ class Visualization extends React.PureComponent {
     }
 
     const extra = (
-      <span className="flex align-center">
+      <VisualizationActionButtonsContainer>
         {isSlow && !loading && (
           <VisualizationSlowSpinner
             className="Visualization-slow-spinner"
@@ -405,7 +408,7 @@ class Visualization extends React.PureComponent {
           />
         )}
         {actionButtons}
-      </span>
+      </VisualizationActionButtonsContainer>
     );
 
     let { gridSize, gridUnit } = this.props;

--- a/frontend/src/metabase/visualizations/components/Visualization/Visualization.jsx
+++ b/frontend/src/metabase/visualizations/components/Visualization/Visualization.jsx
@@ -34,14 +34,13 @@ import { isSameSeries } from "metabase/visualizations/lib/utils";
 import { getMode } from "metabase/modes/lib/modes";
 import { getFont } from "metabase/styled-components/selectors";
 
-import NoResults from "assets/img/no_results.svg";
-
 import Question from "metabase-lib/Question";
 import Mode from "metabase-lib/Mode";
 import { datasetContainsNoResults } from "metabase-lib/queries/utils/dataset";
 import { memoizeClass } from "metabase-lib/utils";
 
 import ChartSettingsErrorButton from "./ChartSettingsErrorButton";
+import NoResultsView from "./NoResultsView";
 import {
   VisualizationActionButtonsContainer,
   VisualizationSlowSpinner,
@@ -471,17 +470,7 @@ class Visualization extends React.PureComponent {
         {replacementContent ? (
           replacementContent
         ) : isDashboard && noResults ? (
-          <div
-            className={
-              "flex-full px1 pb1 text-centered flex flex-column layout-centered " +
-              (isDashboard ? "text-slate-light" : "text-slate")
-            }
-          >
-            <Tooltip tooltip={t`No results!`} isEnabled={small}>
-              <img data-testid="no-results-image" src={NoResults} />
-            </Tooltip>
-            {!small && <span className="h4 text-bold">{t`No results!`}</span>}
-          </div>
+          <NoResultsView isSmall={small} />
         ) : error ? (
           <div
             className={

--- a/frontend/src/metabase/visualizations/components/Visualization/Visualization.jsx
+++ b/frontend/src/metabase/visualizations/components/Visualization/Visualization.jsx
@@ -1,16 +1,15 @@
 /* eslint-disable react/prop-types */
 import React from "react";
 import { connect } from "react-redux";
-import { t, jt } from "ttag";
+import { t } from "ttag";
 import { assoc } from "icepick";
 import _ from "underscore";
 import cx from "classnames";
 
 import ExplicitSize from "metabase/components/ExplicitSize";
-import LoadingSpinner from "metabase/components/LoadingSpinner";
 
 import * as MetabaseAnalytics from "metabase/lib/analytics";
-import { duration, formatNumber } from "metabase/lib/formatting";
+import { formatNumber } from "metabase/lib/formatting";
 import Utils from "metabase/lib/utils";
 
 import {
@@ -39,6 +38,7 @@ import { memoizeClass } from "metabase-lib/utils";
 
 import ChartSettingsErrorButton from "./ChartSettingsErrorButton";
 import ErrorView from "./ErrorView";
+import LoadingView from "./LoadingView";
 import NoResultsView from "./NoResultsView";
 import {
   VisualizationActionButtonsContainer,
@@ -478,30 +478,7 @@ class Visualization extends React.PureComponent {
             isDashboard={isDashboard}
           />
         ) : loading ? (
-          <div className="flex-full p1 text-centered text-brand flex flex-column layout-centered">
-            {isSlow ? (
-              <div className="text-slate">
-                <div className="h4 text-bold mb1">{t`Still Waiting...`}</div>
-                {isSlow === "usually-slow" ? (
-                  <div>
-                    {jt`This usually takes an average of ${(
-                      <span style={{ whiteSpace: "nowrap" }}>
-                        {duration(expectedDuration)}
-                      </span>
-                    )}.`}
-                    <br />
-                    {t`(This is a bit long for a dashboard)`}
-                  </div>
-                ) : (
-                  <div>
-                    {t`This is usually pretty fast but seems to be taking a while right now.`}
-                  </div>
-                )}
-              </div>
-            ) : (
-              <LoadingSpinner className="text-slate" />
-            )}
-          </div>
+          <LoadingView expectedDuration={expectedDuration} isSlow={isSlow} />
         ) : (
           <CardVisualization
             {...this.props}

--- a/frontend/src/metabase/visualizations/components/Visualization/Visualization.jsx
+++ b/frontend/src/metabase/visualizations/components/Visualization/Visualization.jsx
@@ -41,6 +41,7 @@ import Mode from "metabase-lib/Mode";
 import { datasetContainsNoResults } from "metabase-lib/queries/utils/dataset";
 import { memoizeClass } from "metabase-lib/utils";
 
+import ChartSettingsErrorButton from "./ChartSettingsErrorButton";
 import { VisualizationSlowSpinner } from "./Visualization.styled";
 
 const defaultProps = {
@@ -374,17 +375,11 @@ class Visualization extends React.PureComponent {
             isPlaceholder = true;
           } else if (e instanceof ChartSettingsError && onOpenChartSettings) {
             error = (
-              <div>
-                <div>{error}</div>
-                <div className="mt2">
-                  <button
-                    className="Button Button--primary Button--medium"
-                    onClick={() => this.props.onOpenChartSettings(e.initial)}
-                  >
-                    {e.buttonText}
-                  </button>
-                </div>
-              </div>
+              <ChartSettingsErrorButton
+                message={error}
+                buttonLabel={e.buttonText}
+                onClick={() => onOpenChartSettings(e.initial)}
+              />
             );
           } else if (e instanceof MinRowsError) {
             noResults = true;

--- a/frontend/src/metabase/visualizations/components/Visualization/Visualization.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/Visualization/Visualization.styled.tsx
@@ -2,6 +2,17 @@ import styled from "@emotion/styled";
 import LoadingSpinner from "metabase/components/LoadingSpinner";
 import { color } from "metabase/lib/colors";
 
+export const Root = styled.div`
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+`;
+
+export const Header = styled.div`
+  padding: 0.5rem;
+  flex-shrink: 0;
+`;
+
 export interface VisualizationSlowSpinnerProps {
   isUsuallySlow: boolean;
 }

--- a/frontend/src/metabase/visualizations/components/Visualization/Visualization.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/Visualization/Visualization.styled.tsx
@@ -2,13 +2,13 @@ import styled from "@emotion/styled";
 import LoadingSpinner from "metabase/components/LoadingSpinner";
 import { color } from "metabase/lib/colors";
 
-export const Root = styled.div`
+export const VisualizationRoot = styled.div`
   display: flex;
   flex-direction: column;
   height: 100%;
 `;
 
-export const Header = styled.div`
+export const VisualizationHeader = styled.div`
   padding: 0.5rem;
   flex-shrink: 0;
 `;

--- a/frontend/src/metabase/visualizations/components/Visualization/Visualization.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/Visualization/Visualization.styled.tsx
@@ -6,6 +6,11 @@ export interface VisualizationSlowSpinnerProps {
   isUsuallySlow: boolean;
 }
 
+export const VisualizationActionButtonsContainer = styled.span`
+  display: flex;
+  align-items: center;
+`;
+
 export const VisualizationSlowSpinner = styled(
   LoadingSpinner,
 )<VisualizationSlowSpinnerProps>`


### PR DESCRIPTION
The root `Visualization` component handles loading, empty, and error states for every visualization in Metabase. Also, it provides a few props to extend visualization looks: e.g., add action buttons on top of it.

This PR extracts and cleans up these components, so it's a bit easier to reason about the `Visualization`. For every extracted component, we also extract styled components, convert them to TypeScript and align them with the current FE code guidelines.