### PR TITLE
Respect chart orders in static viz

### DIFF
--- a/frontend/src/metabase-types/api/card.ts
+++ b/frontend/src/metabase-types/api/card.ts
@@ -70,6 +70,9 @@ export type VisualizationSettings = {
 
   "graph.series_order"?: SeriesOrderSetting[];
 
+  // Funnel settings
+  "funnel.rows"?: SeriesOrderSetting[];
+
   [key: string]: any;
 };
 

--- a/frontend/src/metabase/static-viz/components/FunnelChart/FunnelChart.tsx
+++ b/frontend/src/metabase/static-viz/components/FunnelChart/FunnelChart.tsx
@@ -12,6 +12,7 @@ import {
   calculateFunnelSteps,
   calculateStepOpacity,
   getFormattedStep,
+  reorderData,
 } from "metabase/static-viz/components/FunnelChart/utils/funnel";
 import { calculateMargin } from "./utils/margin";
 
@@ -43,8 +44,10 @@ type FunnelProps = {
 const Funnel = ({ data, settings }: FunnelProps) => {
   const palette = { ...layout.colors, ...settings.colors };
 
+  const reorderedData = reorderData(data, settings);
+
   const margin = calculateMargin(
-    data[0],
+    reorderedData[0],
     layout.stepFontSize,
     layout.percentFontSize,
     layout.measureFontSize,
@@ -59,7 +62,7 @@ const Funnel = ({ data, settings }: FunnelProps) => {
   const stepWidth = (layout.width - margin.left) / (data.length - 1);
   const maxStepTextWidth = stepWidth - layout.stepTextOffset * 2;
 
-  const steps = calculateFunnelSteps(data, stepWidth, funnelHeight);
+  const steps = calculateFunnelSteps(reorderedData, stepWidth, funnelHeight);
 
   const firstMeasureTop = margin.top + steps[0].top + steps[0].height / 2;
   const stepLabelTop = firstMeasureTop + measureTextHeight(layout.nameFontSize);

--- a/frontend/src/metabase/static-viz/components/FunnelChart/types.ts
+++ b/frontend/src/metabase/static-viz/components/FunnelChart/types.ts
@@ -1,3 +1,4 @@
+import { VisualizationSettings } from "metabase-types/api";
 import { NumberFormatOptions } from "metabase/static-viz/lib/numbers";
 
 export type Step = string | number;
@@ -18,6 +19,7 @@ export type FunnelSettings = {
     brand: string;
     border: string;
   };
+  visualization_settings: VisualizationSettings;
 };
 
 export type FunnelStep = {

--- a/frontend/src/metabase/static-viz/components/FunnelChart/utils/funnel.ts
+++ b/frontend/src/metabase/static-viz/components/FunnelChart/utils/funnel.ts
@@ -1,4 +1,5 @@
 import { PolygonProps } from "@visx/shape/lib/shapes/Polygon";
+import { isNotNull } from "metabase/core/utils/types";
 import { formatNumber, formatPercent } from "metabase/static-viz/lib/numbers";
 import { truncateText } from "metabase/static-viz/lib/text";
 import { FunnelDatum, FunnelSettings, FunnelStep } from "../types";
@@ -85,4 +86,25 @@ export const getFormattedStep = (
     measure,
     stepName,
   };
+};
+
+export const reorderData = (
+  data: FunnelDatum[],
+  settings: FunnelSettings,
+): FunnelDatum[] => {
+  const funnelOrder = settings.visualization_settings["funnel.rows"];
+  if (funnelOrder == null) {
+    return data;
+  }
+
+  const keys = data.map(datum => String(datum[0]));
+
+  return funnelOrder
+    .map(orderedItem => {
+      if (orderedItem.enabled) {
+        const dataIndex = keys.findIndex(key => key === orderedItem.key);
+        return data[dataIndex];
+      }
+    })
+    .filter(isNotNull);
 };

--- a/frontend/src/metabase/static-viz/components/FunnelChart/utils/funnel.unit.spec.ts
+++ b/frontend/src/metabase/static-viz/components/FunnelChart/utils/funnel.unit.spec.ts
@@ -1,4 +1,10 @@
-import { calculateFunnelPolygonPoints, calculateFunnelSteps } from "./funnel";
+import { merge } from "icepick";
+import { FunnelDatum, FunnelSettings } from "../types";
+import {
+  calculateFunnelPolygonPoints,
+  calculateFunnelSteps,
+  reorderData,
+} from "./funnel";
 
 describe("calculateFunnelSteps", () => {
   it("calculates funnel steps from data", () => {
@@ -66,6 +72,74 @@ describe("calculateFunnelPolygonPoints", () => {
       [100, 100], // right top
       [100, 150], // right bottom
       [0, 200], // left bottom
+    ]);
+  });
+});
+
+describe("reorderData", () => {
+  const data: FunnelDatum[] = [
+    ["funnel step 1", 100],
+    ["funnel step 2", 50],
+    ["funnel step 3", 0],
+  ];
+
+  const settings: FunnelSettings = {
+    colors: {
+      border: "#ffffff",
+      brand: "#ffffff",
+      textMedium: "#ffffff",
+    },
+    step: {
+      name: "Step",
+      format: {},
+    },
+    measure: {
+      format: {},
+    },
+    visualization_settings: {},
+  };
+
+  it("should not reorder data when `funnel.rows` isn't set", () => {
+    const reorderedData = reorderData(data, settings);
+    expect(reorderedData).toEqual(data);
+  });
+
+  it("reorders data given `funnel.rows` is set", () => {
+    const reorderedData = reorderData(
+      data,
+      merge(settings, {
+        visualization_settings: {
+          "funnel.rows": [
+            { enabled: true, key: "funnel step 1", name: "funnel step 1" },
+            { enabled: true, key: "funnel step 3", name: "funnel step 3" },
+            { enabled: true, key: "funnel step 2", name: "funnel step 2" },
+          ],
+        },
+      }),
+    );
+    expect(reorderedData).toEqual([
+      ["funnel step 1", 100],
+      ["funnel step 3", 0],
+      ["funnel step 2", 50],
+    ]);
+  });
+
+  it("reorders data for only enabled row in `funnel.rows`", () => {
+    const reorderedData = reorderData(
+      data,
+      merge(settings, {
+        visualization_settings: {
+          "funnel.rows": [
+            { enabled: true, key: "funnel step 1", name: "funnel step 1" },
+            { enabled: true, key: "funnel step 3", name: "funnel step 3" },
+            { enabled: false, key: "funnel step 2", name: "funnel step 2" },
+          ],
+        },
+      }),
+    );
+    expect(reorderedData).toEqual([
+      ["funnel step 1", 100],
+      ["funnel step 3", 0],
     ]);
   });
 });

--- a/frontend/src/metabase/static-viz/components/LineAreaBarChart/LineAreaBarChart.tsx
+++ b/frontend/src/metabase/static-viz/components/LineAreaBarChart/LineAreaBarChart.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import _ from "underscore";
 import { ColorGetter } from "metabase/static-viz/lib/colors";
 import { XYChart } from "../XYChart";
 import { CardSeries, ChartSettings, ChartStyle } from "../XYChart/types";
@@ -56,13 +57,12 @@ const LineAreaBarChart = ({
     goalColor: getColor("text-medium"),
   };
 
-  const seriesWithColors = getSeriesWithColors(
-    multipleSeries,
-    settings,
-    instanceColors,
-  );
-  const seriesWithLegends = getSeriesWithLegends(seriesWithColors, settings);
-  const series = removeNoneSeriesFields(seriesWithLegends);
+  const series = pipe(
+    _.partial(getSeriesWithColors, settings, instanceColors),
+    _.partial(getSeriesWithLegends, settings),
+    _.flatten,
+    removeNoneSeriesFields,
+  )(multipleSeries);
 
   const minTickSize = chartStyle.axes.ticks.fontSize * 1.5;
   const xValuesCount = getXValuesCount(series);
@@ -84,5 +84,9 @@ const LineAreaBarChart = ({
     />
   );
 };
+
+function pipe(...functions: ((arg: any) => any)[]) {
+  return _.compose(...functions.reverse());
+}
 
 export default LineAreaBarChart;

--- a/frontend/src/metabase/static-viz/components/LineAreaBarChart/LineAreaBarChart.tsx
+++ b/frontend/src/metabase/static-viz/components/LineAreaBarChart/LineAreaBarChart.tsx
@@ -13,6 +13,7 @@ import {
   getSeriesWithColors,
   getSeriesWithLegends,
   removeNoneSeriesFields,
+  reorderSeries,
 } from "./utils/series";
 
 interface LineAreaBarChartProps {
@@ -60,6 +61,7 @@ const LineAreaBarChart = ({
   const series = pipe(
     _.partial(getSeriesWithColors, settings, instanceColors),
     _.partial(getSeriesWithLegends, settings),
+    _.partial(reorderSeries, settings),
     _.flatten,
     removeNoneSeriesFields,
   )(multipleSeries);

--- a/frontend/src/metabase/static-viz/components/LineAreaBarChart/utils/series.tsx
+++ b/frontend/src/metabase/static-viz/components/LineAreaBarChart/utils/series.tsx
@@ -16,9 +16,8 @@ export function getSeriesWithColors(
   settings: ChartSettings,
   palette: ColorPalette,
   multipleCardSeries: CardSeries[],
-): (SeriesWithOneOrLessDimensions | SeriesWithTwoDimensions)[][] {
-  const isMultipleSeries = multipleCardSeries.length > 1;
-  const keys = getSeriesKeys(multipleCardSeries, isMultipleSeries);
+): CardSeries[] {
+  const keys = getSeriesKeys(multipleCardSeries);
 
   const seriesSettings = settings.visualization_settings.series_settings;
   const seriesColors = seriesSettings
@@ -47,8 +46,8 @@ export function getSeriesWithColors(
 export function getSeriesWithLegends(
   settings: ChartSettings,
   multipleCardSeries: CardSeries[],
-): (SeriesWithOneOrLessDimensions | SeriesWithTwoDimensions)[][] {
-  const keys = getSeriesKeys(multipleCardSeries, multipleCardSeries.length > 1);
+): CardSeries[] {
+  const keys = getSeriesKeys(multipleCardSeries);
   const isMultipleSeries = multipleCardSeries.length > 1;
 
   const seriesSettings = settings.visualization_settings.series_settings;
@@ -120,10 +119,7 @@ export function getSeriesWithLegends(
 
 export function reorderSeries(
   settings: ChartSettings,
-  multipleCardSeries: (
-    | SeriesWithOneOrLessDimensions
-    | SeriesWithTwoDimensions
-  )[][],
+  multipleCardSeries: CardSeries[],
 ) {
   const seriesOrder = settings.visualization_settings["graph.series_order"];
   // We don't sort series when there's is multiple questions on a dashcard
@@ -131,7 +127,7 @@ export function reorderSeries(
     return multipleCardSeries;
   }
 
-  const keys = getSeriesKeys(multipleCardSeries, multipleCardSeries.length > 1);
+  const keys = getSeriesKeys(multipleCardSeries);
 
   // visualization settings only applies to a dashcard's first question's series.
   const firstCardSeries = multipleCardSeries[0];
@@ -147,10 +143,9 @@ export function reorderSeries(
   ];
 }
 
-function getSeriesKeys(
-  multipleSeries: CardSeries[],
-  isMultipleSeries: boolean,
-) {
+function getSeriesKeys(multipleSeries: CardSeries[]) {
+  const hasMultipleCards = multipleSeries.length > 1;
+
   return multipleSeries
     .flatMap((questionSeries, seriesIndex) => {
       return questionSeries.map(series => {
@@ -166,7 +161,7 @@ function getSeriesKeys(
           }
 
           const hasOneMetric = questionSeries.length === 1;
-          if (!isMultipleSeries || hasOneMetric) {
+          if (!hasMultipleCards || hasOneMetric) {
             return series.cardName;
           }
 
@@ -178,7 +173,7 @@ function getSeriesKeys(
             column: series.column,
           });
 
-          if (!isMultipleSeries) {
+          if (!hasMultipleCards) {
             return columnKey;
           }
 

--- a/frontend/src/metabase/static-viz/components/LineAreaBarChart/utils/series.tsx
+++ b/frontend/src/metabase/static-viz/components/LineAreaBarChart/utils/series.tsx
@@ -5,6 +5,7 @@ import { getColorsForValues } from "metabase/lib/colors/charts";
 import { formatStaticValue } from "metabase/static-viz/lib/format";
 import { ColorPalette } from "metabase/lib/colors/types";
 import {
+  CardSeries,
   ChartSettings,
   Series,
   SeriesWithOneOrLessDimensions,
@@ -12,15 +13,16 @@ import {
 } from "../../XYChart/types";
 
 export function getSeriesWithColors(
-  multipleSeries: (SeriesWithOneOrLessDimensions | SeriesWithTwoDimensions)[][],
   settings: ChartSettings,
   palette: ColorPalette,
+  multipleSeries: CardSeries[],
 ): (SeriesWithOneOrLessDimensions | SeriesWithTwoDimensions)[][] {
   const isMultipleSeries = multipleSeries.length > 1;
   const keys = getSeriesKeys(multipleSeries, isMultipleSeries);
 
-  const seriesColors = settings.series_settings
-    ? _.mapObject(settings.series_settings, value => {
+  const seriesSettings = settings.visualization_settings.series_settings;
+  const seriesColors = seriesSettings
+    ? _.mapObject(seriesSettings, value => {
         return value.color;
       })
     : undefined;
@@ -43,14 +45,15 @@ export function getSeriesWithColors(
 }
 
 export function getSeriesWithLegends(
-  multipleSeries: (SeriesWithOneOrLessDimensions | SeriesWithTwoDimensions)[][],
   settings: ChartSettings,
+  multipleSeries: CardSeries[],
 ): (SeriesWithOneOrLessDimensions | SeriesWithTwoDimensions)[][] {
   const keys = getSeriesKeys(multipleSeries, multipleSeries.length > 1);
   const isMultipleSeries = multipleSeries.length > 1;
 
-  const seriesTitles = settings.series_settings
-    ? _.mapObject(settings.series_settings, value => {
+  const seriesSettings = settings.visualization_settings.series_settings;
+  const seriesTitles = seriesSettings
+    ? _.mapObject(seriesSettings, value => {
         return value.title;
       })
     : undefined;
@@ -120,7 +123,7 @@ export function getSeriesWithLegends(
 }
 
 function getSeriesKeys(
-  multipleSeries: (SeriesWithOneOrLessDimensions | SeriesWithTwoDimensions)[][],
+  multipleSeries: CardSeries[],
   isMultipleSeries: boolean,
 ) {
   return multipleSeries
@@ -168,14 +171,10 @@ function hasTwoDimensions(
   return "breakoutValue" in series;
 }
 
-export function removeNoneSeriesFields(
-  series: (SeriesWithOneOrLessDimensions | SeriesWithTwoDimensions)[][],
-): Series[] {
-  return series
-    .flat()
-    .map(
-      series => _.omit(series, "cardName", "column", "breakoutValue") as Series,
-    );
+export function removeNoneSeriesFields(series: CardSeries): Series[] {
+  return series.map(
+    series => _.omit(series, "cardName", "column", "breakoutValue") as Series,
+  );
 }
 
 function removeEmptyValues(

--- a/frontend/src/metabase/static-viz/components/LineAreaBarChart/utils/series.tsx
+++ b/frontend/src/metabase/static-viz/components/LineAreaBarChart/utils/series.tsx
@@ -15,10 +15,10 @@ import {
 export function getSeriesWithColors(
   settings: ChartSettings,
   palette: ColorPalette,
-  multipleSeries: CardSeries[],
+  multipleCardSeries: CardSeries[],
 ): (SeriesWithOneOrLessDimensions | SeriesWithTwoDimensions)[][] {
-  const isMultipleSeries = multipleSeries.length > 1;
-  const keys = getSeriesKeys(multipleSeries, isMultipleSeries);
+  const isMultipleSeries = multipleCardSeries.length > 1;
+  const keys = getSeriesKeys(multipleCardSeries, isMultipleSeries);
 
   const seriesSettings = settings.visualization_settings.series_settings;
   const seriesColors = seriesSettings
@@ -33,7 +33,7 @@ export function getSeriesWithColors(
   );
 
   let index = -1;
-  return multipleSeries.map(questionSeries =>
+  return multipleCardSeries.map(questionSeries =>
     questionSeries.map(series => {
       index++;
 
@@ -46,10 +46,10 @@ export function getSeriesWithColors(
 
 export function getSeriesWithLegends(
   settings: ChartSettings,
-  multipleSeries: CardSeries[],
+  multipleCardSeries: CardSeries[],
 ): (SeriesWithOneOrLessDimensions | SeriesWithTwoDimensions)[][] {
-  const keys = getSeriesKeys(multipleSeries, multipleSeries.length > 1);
-  const isMultipleSeries = multipleSeries.length > 1;
+  const keys = getSeriesKeys(multipleCardSeries, multipleCardSeries.length > 1);
+  const isMultipleSeries = multipleCardSeries.length > 1;
 
   const seriesSettings = settings.visualization_settings.series_settings;
   const seriesTitles = seriesSettings
@@ -59,7 +59,7 @@ export function getSeriesWithLegends(
     : undefined;
 
   let index = -1;
-  const legends = multipleSeries
+  const legends = multipleCardSeries
     .flatMap(questionSeries => {
       return questionSeries.map(series => {
         index++;
@@ -107,7 +107,7 @@ export function getSeriesWithLegends(
     .filter(isNotNull);
 
   index = -1;
-  return multipleSeries.map(questionSeries =>
+  return multipleCardSeries.map(questionSeries =>
     questionSeries.map(series => {
       index++;
 
@@ -116,6 +116,35 @@ export function getSeriesWithLegends(
       });
     }),
   );
+}
+
+export function reorderSeries(
+  settings: ChartSettings,
+  multipleCardSeries: (
+    | SeriesWithOneOrLessDimensions
+    | SeriesWithTwoDimensions
+  )[][],
+) {
+  const seriesOrder = settings.visualization_settings["graph.series_order"];
+  // We don't sort series when there's is multiple questions on a dashcard
+  if (multipleCardSeries.length > 1 || seriesOrder == null) {
+    return multipleCardSeries;
+  }
+
+  const keys = getSeriesKeys(multipleCardSeries, multipleCardSeries.length > 1);
+
+  // visualization settings only applies to a dashcard's first question's series.
+  const firstCardSeries = multipleCardSeries[0];
+  return [
+    seriesOrder
+      ?.map(orderedItem => {
+        if (orderedItem.enabled) {
+          const seriesIndex = keys.findIndex(key => key === orderedItem.key);
+          return firstCardSeries[seriesIndex];
+        }
+      })
+      .filter(isNotNull),
+  ];
 }
 
 function getSeriesKeys(

--- a/frontend/src/metabase/static-viz/components/LineAreaBarChart/utils/series.tsx
+++ b/frontend/src/metabase/static-viz/components/LineAreaBarChart/utils/series.tsx
@@ -60,7 +60,7 @@ export function getSeriesWithLegends(
 
   let index = -1;
   const legends = multipleSeries
-    .flatMap((questionSeries, seriesIndex) => {
+    .flatMap(questionSeries => {
       return questionSeries.map(series => {
         index++;
 
@@ -76,10 +76,6 @@ export function getSeriesWithLegends(
 
         if (!hasTwoDimensions(series)) {
           // One or zero dimensions
-
-          if (seriesIndex === 0 && series.name) {
-            return series.name;
-          }
 
           const hasOneMetric = questionSeries.length === 1;
           if (hasOneMetric) {

--- a/frontend/src/metabase/static-viz/components/LineAreaBarChart/utils/series.unit.spec.ts
+++ b/frontend/src/metabase/static-viz/components/LineAreaBarChart/utils/series.unit.spec.ts
@@ -18,16 +18,17 @@ const settings: ChartSettings = {
     left: "Count",
     bottom: "Date",
   },
+  visualization_settings: {},
 };
 
 describe("getSeriesWithColors", () => {
   it("should return an empty series given an empty series", () => {
-    const seriesWithColors = getSeriesWithColors([], settings, getPalette({}));
+    const seriesWithColors = getSeriesWithColors(settings, getPalette({}), []);
 
     expect(seriesWithColors).toEqual([]);
   });
 
-  describe("Series without ones or less dimensions", () => {
+  describe("Series without one or less dimensions", () => {
     const multipleSeries: SeriesWithOneOrLessDimensions[][] = [
       [
         {
@@ -93,9 +94,9 @@ describe("getSeriesWithColors", () => {
 
     it("should assign colors given series", () => {
       const seriesWithColors = getSeriesWithColors(
-        multipleSeries,
         settings,
         getPalette({}),
+        multipleSeries,
       );
 
       const expectedSeries = [
@@ -117,9 +118,9 @@ describe("getSeriesWithColors", () => {
 
     it("should assign colors from whitelabel colors", () => {
       const seriesWithColors = getSeriesWithColors(
-        multipleSeries,
         settings,
         getPalette({ brand: "#123456", summarize: "#ffffff" }),
+        multipleSeries,
       );
 
       const expectedSeries = [
@@ -141,15 +142,17 @@ describe("getSeriesWithColors", () => {
 
     it("it should assign colors from column colors", () => {
       const seriesWithColors = getSeriesWithColors(
-        multipleSeries,
         merge(settings, {
-          series_settings: {
-            count: {
-              color: "#987654",
+          visualization_settings: {
+            series_settings: {
+              count: {
+                color: "#987654",
+              },
             },
           },
         }),
         getPalette({ brand: "#123456", summarize: "#ffffff" }),
+        multipleSeries,
       );
 
       const expectedSeries = [
@@ -171,9 +174,9 @@ describe("getSeriesWithColors", () => {
 
     it("it should assign colors on multiple series dashcard", () => {
       const seriesWithColors = getSeriesWithColors(
-        multipleSeriesDashcard,
         settings,
         getPalette({}),
+        multipleSeriesDashcard,
       );
 
       const expectedSeries = [
@@ -225,9 +228,9 @@ describe("getSeriesWithColors", () => {
 
     it("should assign colors from preferred color", () => {
       const seriesWithColors = getSeriesWithColors(
-        multipleSeries,
         merge(settings, { x: { type: "timeseries" } }),
         getPalette({ brand: "#123456", summarize: "#ffffff" }),
+        multipleSeries,
       );
 
       const expectedSeries = [
@@ -249,11 +252,11 @@ describe("getSeriesWithColors", () => {
 
     it("should assign colors from whitelabel colors", () => {
       const seriesWithColors = getSeriesWithColors(
-        multipleSeries,
         merge(settings, {
           x: { type: "timeseries" },
         }),
         getPalette({ accent1: "#123456", summarize: "#ffffff" }),
+        multipleSeries,
       );
 
       const expectedSeries = [
@@ -275,16 +278,18 @@ describe("getSeriesWithColors", () => {
 
     it("should assign colors from column colors", () => {
       const seriesWithColors = getSeriesWithColors(
-        multipleSeries,
         merge(settings, {
           x: { type: "timeseries" },
-          series_settings: {
-            sum: {
-              color: "#987654",
+          visualization_settings: {
+            series_settings: {
+              sum: {
+                color: "#987654",
+              },
             },
           },
         }),
         getPalette({ brand: "#123456", summarize: "#ffffff" }),
+        multipleSeries,
       );
 
       const expectedSeries = [
@@ -441,11 +446,11 @@ describe("getSeriesWithColors", () => {
 
     it("should assign colors given series", () => {
       const seriesWithColors = getSeriesWithColors(
-        multipleSeries,
         merge(settings, {
           x: { type: "timeseries" },
         }),
         getPalette({}),
+        multipleSeries,
       );
 
       const expectedSeries = [
@@ -478,11 +483,11 @@ describe("getSeriesWithColors", () => {
 
     it("should assign colors from whitelabel colors", () => {
       const seriesWithColors = getSeriesWithColors(
-        multipleSeries,
         merge(settings, {
           x: { type: "timeseries" },
         }),
         getPalette({ accent3: "#123456" }),
+        multipleSeries,
       );
 
       const expectedSeries = [
@@ -515,16 +520,18 @@ describe("getSeriesWithColors", () => {
 
     it("should assign colors from column colors", () => {
       const seriesWithColors = getSeriesWithColors(
-        multipleSeries,
         merge(settings, {
           x: { type: "timeseries" },
-          series_settings: {
-            2017: {
-              color: "#987654",
+          visualization_settings: {
+            series_settings: {
+              2017: {
+                color: "#987654",
+              },
             },
           },
         }),
         getPalette({ accent3: "#123456" }),
+        multipleSeries,
       );
 
       const expectedSeries = [
@@ -557,9 +564,9 @@ describe("getSeriesWithColors", () => {
 
     it("it should assign colors on multiple series dashcard", () => {
       const seriesWithColors = getSeriesWithColors(
-        multipleSeriesDashcard,
         settings,
         getPalette({}),
+        multipleSeriesDashcard,
       );
 
       const expectedSeries = [
@@ -623,7 +630,7 @@ function getPalette(instanceColors: Record<string, string>) {
 
 describe("getSeriesWithLegends", () => {
   it("should return an empty series given an empty series", () => {
-    const seriesWithLegends = getSeriesWithLegends([], settings);
+    const seriesWithLegends = getSeriesWithLegends(settings, []);
 
     expect(seriesWithLegends).toEqual([]);
   });
@@ -693,7 +700,7 @@ describe("getSeriesWithLegends", () => {
     ];
 
     it("should assign legends given series", () => {
-      const seriesWithLegends = getSeriesWithLegends(multipleSeries, settings);
+      const seriesWithLegends = getSeriesWithLegends(settings, multipleSeries);
 
       const expectedSeries = [
         [
@@ -713,10 +720,10 @@ describe("getSeriesWithLegends", () => {
 
     it("it should assign legends from column custom name", () => {
       const seriesWithLegends = getSeriesWithLegends(
+        settings,
         // This might not be apparent, but series' `name` would be set to
         // custom metric name for series with one or less dimensions.
         setIn(multipleSeries, [0, 0, "name"], "Custom count"),
-        settings,
       );
 
       const expectedSeries = [
@@ -737,8 +744,8 @@ describe("getSeriesWithLegends", () => {
 
     it("it should assign legends on multiple series dashcard", () => {
       const seriesWithLegends = getSeriesWithLegends(
-        multipleSeriesDashcard,
         settings,
+        multipleSeriesDashcard,
       );
 
       const expectedSeries = [
@@ -904,10 +911,10 @@ describe("getSeriesWithLegends", () => {
 
     it("should assign legends given series", () => {
       const seriesWithLegends = getSeriesWithLegends(
-        multipleSeries,
         merge(settings, {
           x: { type: "timeseries" },
         }),
+        multipleSeries,
       );
 
       const expectedSeries = [
@@ -938,15 +945,17 @@ describe("getSeriesWithLegends", () => {
 
     it("should assign legends from column custom name", () => {
       const seriesWithLegends = getSeriesWithLegends(
-        multipleSeries,
         merge(settings, {
           x: { type: "timeseries" },
-          series_settings: {
-            2017: {
-              title: "custom 2017",
+          visualization_settings: {
+            series_settings: {
+              2017: {
+                title: "custom 2017",
+              },
             },
           },
         }),
+        multipleSeries,
       );
 
       const expectedSeries = [
@@ -977,8 +986,8 @@ describe("getSeriesWithLegends", () => {
 
     it("it should assign legends on multiple series dashcard", () => {
       const seriesWithLegends = getSeriesWithLegends(
-        multipleSeriesDashcard,
         settings,
+        multipleSeriesDashcard,
       );
 
       const expectedSeries = [

--- a/frontend/src/metabase/static-viz/components/LineAreaBarChart/utils/series.unit.spec.ts
+++ b/frontend/src/metabase/static-viz/components/LineAreaBarChart/utils/series.unit.spec.ts
@@ -32,7 +32,6 @@ describe("getSeriesWithColors", () => {
     const multipleSeries: SeriesWithOneOrLessDimensions[][] = [
       [
         {
-          name: "Count",
           cardName: "Bar chart",
           yAxisPosition: "left",
           type: "bar",
@@ -54,7 +53,6 @@ describe("getSeriesWithColors", () => {
     const multipleSeriesDashcard: SeriesWithOneOrLessDimensions[][] = [
       [
         {
-          name: "Count",
           cardName: "Bar chart",
           yAxisPosition: "left",
           type: "bar",
@@ -73,7 +71,6 @@ describe("getSeriesWithColors", () => {
       ],
       [
         {
-          name: "Count",
           cardName: "Area chart",
           yAxisPosition: "left",
           type: "area",
@@ -103,7 +100,6 @@ describe("getSeriesWithColors", () => {
         [
           {
             color: "#509EE3", // brand color
-            name: expect.anything(),
             cardName: expect.anything(),
             yAxisPosition: expect.anything(),
             type: expect.anything(),
@@ -127,7 +123,6 @@ describe("getSeriesWithColors", () => {
         [
           {
             color: "#123456", // whitelabel color
-            name: expect.anything(),
             cardName: expect.anything(),
             yAxisPosition: expect.anything(),
             type: expect.anything(),
@@ -159,7 +154,6 @@ describe("getSeriesWithColors", () => {
         [
           {
             color: "#987654", // column color
-            name: expect.anything(),
             cardName: expect.anything(),
             yAxisPosition: expect.anything(),
             type: expect.anything(),
@@ -183,7 +177,6 @@ describe("getSeriesWithColors", () => {
         [
           {
             color: "#509EE3", // brand color
-            name: expect.anything(),
             cardName: expect.anything(),
             yAxisPosition: expect.anything(),
             type: expect.anything(),
@@ -194,7 +187,6 @@ describe("getSeriesWithColors", () => {
         [
           {
             color: "#EF8C8C",
-            name: expect.anything(),
             cardName: expect.anything(),
             yAxisPosition: expect.anything(),
             type: expect.anything(),
@@ -212,7 +204,6 @@ describe("getSeriesWithColors", () => {
     const multipleSeries: SeriesWithOneOrLessDimensions[][] = [
       [
         {
-          name: "Sum of Total",
           cardName: "Bar chart",
           yAxisPosition: "left",
           type: "bar",
@@ -237,7 +228,6 @@ describe("getSeriesWithColors", () => {
         [
           {
             color: "#88BF4D", // accent1 color
-            name: expect.anything(),
             cardName: expect.anything(),
             yAxisPosition: expect.anything(),
             type: expect.anything(),
@@ -263,7 +253,6 @@ describe("getSeriesWithColors", () => {
         [
           {
             color: "#123456", // whitelabel color
-            name: expect.anything(),
             cardName: expect.anything(),
             yAxisPosition: expect.anything(),
             type: expect.anything(),
@@ -296,7 +285,6 @@ describe("getSeriesWithColors", () => {
         [
           {
             color: "#987654", // column color
-            name: expect.anything(),
             cardName: expect.anything(),
             yAxisPosition: expect.anything(),
             type: expect.anything(),
@@ -314,7 +302,6 @@ describe("getSeriesWithColors", () => {
     const multipleSeries: SeriesWithTwoDimensions[][] = [
       [
         {
-          name: null,
           cardName: "Area chart",
           type: "area",
           data: [
@@ -334,7 +321,6 @@ describe("getSeriesWithColors", () => {
           breakoutValue: "2016-01-01T00:00:00Z",
         },
         {
-          name: null,
           cardName: "Area chart",
           type: "area",
           data: [
@@ -359,7 +345,6 @@ describe("getSeriesWithColors", () => {
     const multipleSeriesDashcard: SeriesWithTwoDimensions[][] = [
       [
         {
-          name: null,
           cardName: "Area chart",
           type: "area",
           data: [
@@ -379,7 +364,6 @@ describe("getSeriesWithColors", () => {
           breakoutValue: "2016-01-01T00:00:00Z",
         },
         {
-          name: null,
           cardName: "Area chart",
           type: "area",
           data: [
@@ -402,7 +386,6 @@ describe("getSeriesWithColors", () => {
 
       [
         {
-          name: null,
           cardName: "Bar chart",
           type: "bar",
           data: [
@@ -422,7 +405,6 @@ describe("getSeriesWithColors", () => {
           breakoutValue: "2016-01-01T00:00:00Z",
         },
         {
-          name: null,
           cardName: "Bar chart",
           type: "bar",
           data: [
@@ -457,7 +439,6 @@ describe("getSeriesWithColors", () => {
         [
           {
             color: "#EF8C8C", // accent3 color
-            name: null,
             cardName: expect.anything(),
             yAxisPosition: expect.anything(),
             type: expect.anything(),
@@ -467,7 +448,6 @@ describe("getSeriesWithColors", () => {
           },
           {
             color: "#F9D45C", // accent4 color
-            name: null,
             cardName: expect.anything(),
             yAxisPosition: expect.anything(),
             type: expect.anything(),
@@ -494,7 +474,6 @@ describe("getSeriesWithColors", () => {
         [
           {
             color: "#123456", // whitelabel color
-            name: null,
             cardName: expect.anything(),
             yAxisPosition: expect.anything(),
             type: expect.anything(),
@@ -504,7 +483,6 @@ describe("getSeriesWithColors", () => {
           },
           {
             color: "#F9D45C", // accent4 color
-            name: null,
             cardName: expect.anything(),
             yAxisPosition: expect.anything(),
             type: expect.anything(),
@@ -538,7 +516,6 @@ describe("getSeriesWithColors", () => {
         [
           {
             color: "#123456", // whitelabel color
-            name: null,
             cardName: expect.anything(),
             yAxisPosition: expect.anything(),
             type: expect.anything(),
@@ -548,7 +525,6 @@ describe("getSeriesWithColors", () => {
           },
           {
             color: "#987654", // column color
-            name: null,
             cardName: expect.anything(),
             yAxisPosition: expect.anything(),
             type: expect.anything(),
@@ -573,7 +549,6 @@ describe("getSeriesWithColors", () => {
         [
           {
             color: "#F9D45C", // brand color
-            name: null,
             cardName: expect.anything(),
             yAxisPosition: expect.anything(),
             type: expect.anything(),
@@ -583,7 +558,6 @@ describe("getSeriesWithColors", () => {
           },
           {
             color: "#F2A86F", // column color
-            name: null,
             cardName: expect.anything(),
             yAxisPosition: expect.anything(),
             type: expect.anything(),
@@ -595,7 +569,6 @@ describe("getSeriesWithColors", () => {
         [
           {
             color: "#98D9D9",
-            name: null,
             cardName: expect.anything(),
             yAxisPosition: expect.anything(),
             type: expect.anything(),
@@ -605,7 +578,6 @@ describe("getSeriesWithColors", () => {
           },
           {
             color: "#7172AD", // column color
-            name: null,
             cardName: expect.anything(),
             yAxisPosition: expect.anything(),
             type: expect.anything(),
@@ -639,7 +611,6 @@ describe("getSeriesWithLegends", () => {
     const multipleSeries: SeriesWithOneOrLessDimensions[][] = [
       [
         {
-          name: "Count",
           cardName: "Bar chart",
           yAxisPosition: "left",
           type: "bar",
@@ -661,7 +632,6 @@ describe("getSeriesWithLegends", () => {
     const multipleSeriesDashcard: SeriesWithOneOrLessDimensions[][] = [
       [
         {
-          name: "Count",
           cardName: "Bar chart",
           yAxisPosition: "left",
           type: "bar",
@@ -680,7 +650,6 @@ describe("getSeriesWithLegends", () => {
       ],
       [
         {
-          name: "Count",
           cardName: "Area chart",
           yAxisPosition: "left",
           type: "area",
@@ -705,7 +674,7 @@ describe("getSeriesWithLegends", () => {
       const expectedSeries = [
         [
           {
-            name: "Count",
+            name: "Bar chart",
             cardName: expect.anything(),
             yAxisPosition: expect.anything(),
             type: expect.anything(),
@@ -720,10 +689,17 @@ describe("getSeriesWithLegends", () => {
 
     it("should assign legends from column custom name", () => {
       const seriesWithLegends = getSeriesWithLegends(
-        settings,
-        // This might not be apparent, but series' `name` would be set to
-        // custom metric name for series with one or less dimensions.
-        setIn(multipleSeries, [0, 0, "name"], "Custom count"),
+        merge(settings, {
+          x: { type: "timeseries" },
+          visualization_settings: {
+            series_settings: {
+              count: {
+                title: "Custom count",
+              },
+            },
+          },
+        }),
+        multipleSeries,
       );
 
       const expectedSeries = [
@@ -751,7 +727,7 @@ describe("getSeriesWithLegends", () => {
       const expectedSeries = [
         [
           {
-            name: "Count",
+            name: "Bar chart",
             cardName: expect.anything(),
             yAxisPosition: expect.anything(),
             type: expect.anything(),
@@ -779,7 +755,6 @@ describe("getSeriesWithLegends", () => {
     const multipleSeries: SeriesWithTwoDimensions[][] = [
       [
         {
-          name: null,
           cardName: "Area chart",
           type: "area",
           data: [
@@ -799,7 +774,6 @@ describe("getSeriesWithLegends", () => {
           breakoutValue: "2016-01-01T00:00:00Z",
         },
         {
-          name: null,
           cardName: "Area chart",
           type: "area",
           data: [
@@ -824,7 +798,6 @@ describe("getSeriesWithLegends", () => {
     const multipleSeriesDashcard: SeriesWithTwoDimensions[][] = [
       [
         {
-          name: null,
           cardName: "Area chart",
           type: "area",
           data: [
@@ -844,7 +817,6 @@ describe("getSeriesWithLegends", () => {
           breakoutValue: "2016-01-01T00:00:00Z",
         },
         {
-          name: null,
           cardName: "Area chart",
           type: "area",
           data: [
@@ -867,7 +839,6 @@ describe("getSeriesWithLegends", () => {
 
       [
         {
-          name: null,
           cardName: "Bar chart",
           type: "bar",
           data: [
@@ -887,7 +858,6 @@ describe("getSeriesWithLegends", () => {
           breakoutValue: "2016-01-01T00:00:00Z",
         },
         {
-          name: null,
           cardName: "Bar chart",
           type: "bar",
           data: [

--- a/frontend/src/metabase/static-viz/components/LineAreaBarChart/utils/series.unit.spec.ts
+++ b/frontend/src/metabase/static-viz/components/LineAreaBarChart/utils/series.unit.spec.ts
@@ -1,11 +1,15 @@
-import { merge, setIn } from "icepick";
+import { merge } from "icepick";
 import { colors } from "metabase/lib/colors";
 import type {
   ChartSettings,
   SeriesWithOneOrLessDimensions,
   SeriesWithTwoDimensions,
 } from "../../XYChart/types";
-import { getSeriesWithColors, getSeriesWithLegends } from "./series";
+import {
+  getSeriesWithColors,
+  getSeriesWithLegends,
+  reorderSeries,
+} from "./series";
 
 const settings: ChartSettings = {
   x: {
@@ -29,7 +33,7 @@ describe("getSeriesWithColors", () => {
   });
 
   describe("Series without one or less dimensions", () => {
-    const multipleSeries: SeriesWithOneOrLessDimensions[][] = [
+    const singleCardSeries: SeriesWithOneOrLessDimensions[][] = [
       [
         {
           cardName: "Bar chart",
@@ -50,7 +54,7 @@ describe("getSeriesWithColors", () => {
       ],
     ];
 
-    const multipleSeriesDashcard: SeriesWithOneOrLessDimensions[][] = [
+    const multipleCardSeries: SeriesWithOneOrLessDimensions[][] = [
       [
         {
           cardName: "Bar chart",
@@ -93,7 +97,7 @@ describe("getSeriesWithColors", () => {
       const seriesWithColors = getSeriesWithColors(
         settings,
         getPalette({}),
-        multipleSeries,
+        singleCardSeries,
       );
 
       const expectedSeries = [
@@ -116,7 +120,7 @@ describe("getSeriesWithColors", () => {
       const seriesWithColors = getSeriesWithColors(
         settings,
         getPalette({ brand: "#123456", summarize: "#ffffff" }),
-        multipleSeries,
+        singleCardSeries,
       );
 
       const expectedSeries = [
@@ -147,7 +151,7 @@ describe("getSeriesWithColors", () => {
           },
         }),
         getPalette({ brand: "#123456", summarize: "#ffffff" }),
-        multipleSeries,
+        singleCardSeries,
       );
 
       const expectedSeries = [
@@ -170,7 +174,7 @@ describe("getSeriesWithColors", () => {
       const seriesWithColors = getSeriesWithColors(
         settings,
         getPalette({}),
-        multipleSeriesDashcard,
+        multipleCardSeries,
       );
 
       const expectedSeries = [
@@ -201,7 +205,7 @@ describe("getSeriesWithColors", () => {
   });
 
   describe("Series with preferred colors", () => {
-    const multipleSeries: SeriesWithOneOrLessDimensions[][] = [
+    const singleCardSeries: SeriesWithOneOrLessDimensions[][] = [
       [
         {
           cardName: "Bar chart",
@@ -221,7 +225,7 @@ describe("getSeriesWithColors", () => {
       const seriesWithColors = getSeriesWithColors(
         merge(settings, { x: { type: "timeseries" } }),
         getPalette({ brand: "#123456", summarize: "#ffffff" }),
-        multipleSeries,
+        singleCardSeries,
       );
 
       const expectedSeries = [
@@ -246,7 +250,7 @@ describe("getSeriesWithColors", () => {
           x: { type: "timeseries" },
         }),
         getPalette({ accent1: "#123456", summarize: "#ffffff" }),
-        multipleSeries,
+        singleCardSeries,
       );
 
       const expectedSeries = [
@@ -278,7 +282,7 @@ describe("getSeriesWithColors", () => {
           },
         }),
         getPalette({ brand: "#123456", summarize: "#ffffff" }),
-        multipleSeries,
+        singleCardSeries,
       );
 
       const expectedSeries = [
@@ -299,7 +303,7 @@ describe("getSeriesWithColors", () => {
   });
 
   describe("Series with 2 dimension", () => {
-    const multipleSeries: SeriesWithTwoDimensions[][] = [
+    const singleCardSeries: SeriesWithTwoDimensions[][] = [
       [
         {
           cardName: "Area chart",
@@ -342,7 +346,7 @@ describe("getSeriesWithColors", () => {
       ],
     ];
 
-    const multipleSeriesDashcard: SeriesWithTwoDimensions[][] = [
+    const multipleCardSeries: SeriesWithTwoDimensions[][] = [
       [
         {
           cardName: "Area chart",
@@ -432,7 +436,7 @@ describe("getSeriesWithColors", () => {
           x: { type: "timeseries" },
         }),
         getPalette({}),
-        multipleSeries,
+        singleCardSeries,
       );
 
       const expectedSeries = [
@@ -467,7 +471,7 @@ describe("getSeriesWithColors", () => {
           x: { type: "timeseries" },
         }),
         getPalette({ accent3: "#123456" }),
-        multipleSeries,
+        singleCardSeries,
       );
 
       const expectedSeries = [
@@ -509,7 +513,7 @@ describe("getSeriesWithColors", () => {
           },
         }),
         getPalette({ accent3: "#123456" }),
-        multipleSeries,
+        singleCardSeries,
       );
 
       const expectedSeries = [
@@ -542,7 +546,7 @@ describe("getSeriesWithColors", () => {
       const seriesWithColors = getSeriesWithColors(
         settings,
         getPalette({}),
-        multipleSeriesDashcard,
+        multipleCardSeries,
       );
 
       const expectedSeries = [
@@ -608,7 +612,7 @@ describe("getSeriesWithLegends", () => {
   });
 
   describe("Series without ones or less dimensions", () => {
-    const multipleSeries: SeriesWithOneOrLessDimensions[][] = [
+    const singleCardSeries: SeriesWithOneOrLessDimensions[][] = [
       [
         {
           cardName: "Bar chart",
@@ -629,7 +633,7 @@ describe("getSeriesWithLegends", () => {
       ],
     ];
 
-    const multipleSeriesDashcard: SeriesWithOneOrLessDimensions[][] = [
+    const multipleCardSeries: SeriesWithOneOrLessDimensions[][] = [
       [
         {
           cardName: "Bar chart",
@@ -669,7 +673,10 @@ describe("getSeriesWithLegends", () => {
     ];
 
     it("should assign legends given series", () => {
-      const seriesWithLegends = getSeriesWithLegends(settings, multipleSeries);
+      const seriesWithLegends = getSeriesWithLegends(
+        settings,
+        singleCardSeries,
+      );
 
       const expectedSeries = [
         [
@@ -699,7 +706,7 @@ describe("getSeriesWithLegends", () => {
             },
           },
         }),
-        multipleSeries,
+        singleCardSeries,
       );
 
       const expectedSeries = [
@@ -721,7 +728,7 @@ describe("getSeriesWithLegends", () => {
     it("should assign legends on multiple series dashcard", () => {
       const seriesWithLegends = getSeriesWithLegends(
         settings,
-        multipleSeriesDashcard,
+        multipleCardSeries,
       );
 
       const expectedSeries = [
@@ -752,7 +759,7 @@ describe("getSeriesWithLegends", () => {
   });
 
   describe("Series with 2 dimension", () => {
-    const multipleSeries: SeriesWithTwoDimensions[][] = [
+    const singleCardSeries: SeriesWithTwoDimensions[][] = [
       [
         {
           cardName: "Area chart",
@@ -795,7 +802,7 @@ describe("getSeriesWithLegends", () => {
       ],
     ];
 
-    const multipleSeriesDashcard: SeriesWithTwoDimensions[][] = [
+    const multipleCardSeries: SeriesWithTwoDimensions[][] = [
       [
         {
           cardName: "Area chart",
@@ -884,7 +891,7 @@ describe("getSeriesWithLegends", () => {
         merge(settings, {
           x: { type: "timeseries" },
         }),
-        multipleSeries,
+        singleCardSeries,
       );
 
       const expectedSeries = [
@@ -925,7 +932,7 @@ describe("getSeriesWithLegends", () => {
             },
           },
         }),
-        multipleSeries,
+        singleCardSeries,
       );
 
       const expectedSeries = [
@@ -957,7 +964,7 @@ describe("getSeriesWithLegends", () => {
     it("should assign legends on multiple series dashcard", () => {
       const seriesWithLegends = getSeriesWithLegends(
         settings,
-        multipleSeriesDashcard,
+        multipleCardSeries,
       );
 
       const expectedSeries = [
@@ -1004,6 +1011,231 @@ describe("getSeriesWithLegends", () => {
       ];
 
       expect(seriesWithLegends).toEqual(expectedSeries);
+    });
+  });
+});
+
+describe("reorderSeries", () => {
+  it("should return an empty series given an empty series", () => {
+    const reorderedSeries = reorderSeries(settings, []);
+
+    expect(reorderedSeries).toEqual([]);
+  });
+
+  describe("Series with 2 dimension", () => {
+    const singleCardSeries: SeriesWithTwoDimensions[][] = [
+      [
+        {
+          cardName: "Area chart",
+          type: "area",
+          data: [
+            ["Doohickey", 177],
+            ["Gadget", 199],
+            ["Gizmo", 158],
+            ["Widget", 210],
+          ],
+          yAxisPosition: "left",
+          column: {
+            semantic_type: "type/CreationTimestamp",
+            unit: "year",
+            name: "CREATED_AT",
+            source: "breakout",
+            display_name: "Created At",
+          },
+          breakoutValue: "2016-01-01T00:00:00Z",
+        },
+        {
+          cardName: "Area chart",
+          type: "area",
+          data: [
+            ["Doohickey", 1206],
+            ["Gadget", 1505],
+            ["Gizmo", 1592],
+            ["Widget", 1531],
+          ],
+          yAxisPosition: "left",
+          column: {
+            semantic_type: "type/CreationTimestamp",
+            unit: "year",
+            name: "CREATED_AT",
+            source: "breakout",
+            display_name: "Created At",
+          },
+          breakoutValue: "2017-01-01T00:00:00Z",
+        },
+      ],
+    ];
+
+    const multipleCardSeries: SeriesWithTwoDimensions[][] = [
+      [
+        {
+          cardName: "Area chart",
+          type: "area",
+          data: [
+            ["Doohickey", 177],
+            ["Gadget", 199],
+            ["Gizmo", 158],
+            ["Widget", 210],
+          ],
+          yAxisPosition: "left",
+          column: {
+            semantic_type: "type/CreationTimestamp",
+            unit: "year",
+            name: "CREATED_AT",
+            source: "breakout",
+            display_name: "Created At",
+          },
+          breakoutValue: "2016-01-01T00:00:00Z",
+        },
+        {
+          cardName: "Area chart",
+          type: "area",
+          data: [
+            ["Doohickey", 1206],
+            ["Gadget", 1505],
+            ["Gizmo", 1592],
+            ["Widget", 1531],
+          ],
+          yAxisPosition: "left",
+          column: {
+            semantic_type: "type/CreationTimestamp",
+            unit: "year",
+            name: "CREATED_AT",
+            source: "breakout",
+            display_name: "Created At",
+          },
+          breakoutValue: "2017-01-01T00:00:00Z",
+        },
+      ],
+      [
+        {
+          cardName: "Bar chart",
+          type: "bar",
+          data: [
+            ["Doohickey", 177],
+            ["Gadget", 199],
+            ["Gizmo", 158],
+            ["Widget", 210],
+          ],
+          yAxisPosition: "left",
+          column: {
+            semantic_type: "type/CreationTimestamp",
+            unit: "year",
+            name: "CREATED_AT",
+            source: "breakout",
+            display_name: "Created At",
+          },
+          breakoutValue: "2016-01-01T00:00:00Z",
+        },
+        {
+          cardName: "Bar chart",
+          type: "bar",
+          data: [
+            ["Doohickey", 1206],
+            ["Gadget", 1505],
+            ["Gizmo", 1592],
+            ["Widget", 1531],
+          ],
+          yAxisPosition: "left",
+          column: {
+            semantic_type: "type/CreationTimestamp",
+            unit: "year",
+            name: "CREATED_AT",
+            source: "breakout",
+            display_name: "Created At",
+          },
+          breakoutValue: "2017-01-01T00:00:00Z",
+        },
+      ],
+    ];
+
+    it("should return the same series given no `graph.series_order` set", () => {
+      const reorderedSeries = reorderSeries(settings, singleCardSeries);
+
+      expect(reorderedSeries).toEqual(singleCardSeries);
+    });
+
+    it("should sort the series following `graph.series_order`", () => {
+      const reorderedSeries = reorderSeries(
+        merge(settings, {
+          visualization_settings: {
+            "graph.series_order": [
+              {
+                enabled: true,
+                key: "2017",
+                name: "2017",
+              },
+              {
+                enabled: true,
+                key: "2016",
+                name: "2016",
+              },
+            ],
+          },
+        }),
+        singleCardSeries,
+      );
+
+      const expectedSeries = [
+        [
+          expect.objectContaining({ breakoutValue: "2017-01-01T00:00:00Z" }),
+          expect.objectContaining({ breakoutValue: "2016-01-01T00:00:00Z" }),
+        ],
+      ];
+
+      expect(reorderedSeries).toEqual(expectedSeries);
+    });
+
+    it("should sort the series following `graph.series_order` on only enabled series", () => {
+      const reorderedSeries = reorderSeries(
+        merge(settings, {
+          visualization_settings: {
+            "graph.series_order": [
+              {
+                enabled: true,
+                key: "2017",
+                name: "2017",
+              },
+              {
+                enabled: false,
+                key: "2016",
+                name: "2016",
+              },
+            ],
+          },
+        }),
+        singleCardSeries,
+      );
+
+      const expectedSeries = [
+        [expect.objectContaining({ breakoutValue: "2017-01-01T00:00:00Z" })],
+      ];
+
+      expect(reorderedSeries).toEqual(expectedSeries);
+    });
+
+    it("should not reorder when there are multiple cards", () => {
+      const reorderedSeries = reorderSeries(
+        merge(settings, {
+          visualization_settings: {
+            "graph.series_order": [
+              {
+                enabled: true,
+                key: "2017",
+                name: "2017",
+              },
+              {
+                enabled: false,
+                key: "2016",
+                name: "2016",
+              },
+            ],
+          },
+        }),
+        multipleCardSeries,
+      );
+
+      expect(reorderedSeries).toEqual(multipleCardSeries);
     });
   });
 });

--- a/frontend/src/metabase/static-viz/components/LineAreaBarChart/utils/series.unit.spec.ts
+++ b/frontend/src/metabase/static-viz/components/LineAreaBarChart/utils/series.unit.spec.ts
@@ -140,7 +140,7 @@ describe("getSeriesWithColors", () => {
       expect(seriesWithColors).toEqual(expectedSeries);
     });
 
-    it("it should assign colors from column colors", () => {
+    it("should assign colors from column colors", () => {
       const seriesWithColors = getSeriesWithColors(
         merge(settings, {
           visualization_settings: {
@@ -172,7 +172,7 @@ describe("getSeriesWithColors", () => {
       expect(seriesWithColors).toEqual(expectedSeries);
     });
 
-    it("it should assign colors on multiple series dashcard", () => {
+    it("should assign colors on multiple series dashcard", () => {
       const seriesWithColors = getSeriesWithColors(
         settings,
         getPalette({}),
@@ -562,7 +562,7 @@ describe("getSeriesWithColors", () => {
       expect(seriesWithColors).toEqual(expectedSeries);
     });
 
-    it("it should assign colors on multiple series dashcard", () => {
+    it("should assign colors on multiple series dashcard", () => {
       const seriesWithColors = getSeriesWithColors(
         settings,
         getPalette({}),
@@ -718,7 +718,7 @@ describe("getSeriesWithLegends", () => {
       expect(seriesWithLegends).toEqual(expectedSeries);
     });
 
-    it("it should assign legends from column custom name", () => {
+    it("should assign legends from column custom name", () => {
       const seriesWithLegends = getSeriesWithLegends(
         settings,
         // This might not be apparent, but series' `name` would be set to
@@ -742,7 +742,7 @@ describe("getSeriesWithLegends", () => {
       expect(seriesWithLegends).toEqual(expectedSeries);
     });
 
-    it("it should assign legends on multiple series dashcard", () => {
+    it("should assign legends on multiple series dashcard", () => {
       const seriesWithLegends = getSeriesWithLegends(
         settings,
         multipleSeriesDashcard,
@@ -984,7 +984,7 @@ describe("getSeriesWithLegends", () => {
       expect(seriesWithLegends).toEqual(expectedSeries);
     });
 
-    it("it should assign legends on multiple series dashcard", () => {
+    it("should assign legends on multiple series dashcard", () => {
       const seriesWithLegends = getSeriesWithLegends(
         settings,
         multipleSeriesDashcard,

--- a/frontend/src/metabase/static-viz/components/LineAreaBarChart/utils/settings.unit.spec.ts
+++ b/frontend/src/metabase/static-viz/components/LineAreaBarChart/utils/settings.unit.spec.ts
@@ -1,5 +1,5 @@
 import _ from "underscore";
-import { ChartSettings, Series } from "../../XYChart/types";
+import { ChartSettings } from "../../XYChart/types";
 import { adjustSettings } from "./settings";
 
 const settings: ChartSettings = {
@@ -22,16 +22,6 @@ const chartSize = {
 };
 
 const minTickSize = 12;
-
-const getSeries = (length: number): Series[] => [
-  {
-    name: "series",
-    color: "black",
-    yAxisPosition: "left",
-    type: "line",
-    data: _.range(length).map(index => [`X:${index}`, index]),
-  },
-];
 
 describe("adjustSettings", () => {
   describe("ordinal x-axis", () => {

--- a/frontend/src/metabase/static-viz/components/LineAreaBarChart/utils/settings.unit.spec.ts
+++ b/frontend/src/metabase/static-viz/components/LineAreaBarChart/utils/settings.unit.spec.ts
@@ -13,6 +13,7 @@ const settings: ChartSettings = {
     left: "Count",
     bottom: "Date",
   },
+  visualization_settings: {},
 };
 
 const chartSize = {

--- a/frontend/src/metabase/static-viz/components/XYChart/XYChart.tsx
+++ b/frontend/src/metabase/static-viz/components/XYChart/XYChart.tsx
@@ -79,6 +79,8 @@ export const XYChart = ({
   const yLabelOffsetRight = LABEL_PADDING;
   const xTickVerticalMargins = style.axes.labels.fontSize * 2;
 
+  const showValues = settings.visualization_settings["graph.show_values"];
+
   const margin = calculateMargin(
     yTickWidths.left,
     yTickWidths.right,
@@ -86,7 +88,7 @@ export const XYChart = ({
     xTicksDimensions.width,
     settings.labels,
     style.axes.ticks.fontSize,
-    !!settings.goal || !!settings.show_values,
+    !!settings.goal || showValues,
   );
 
   const { xMin, xMax, yMin, innerHeight, innerWidth } = calculateBounds(
@@ -303,7 +305,7 @@ export const XYChart = ({
               />
             )}
 
-            {settings.show_values && (
+            {showValues && (
               <Values
                 series={series}
                 formatter={(value: number, compact: boolean): string =>
@@ -353,7 +355,10 @@ function getValuesLeftOffset(
   const maxSeriesLength = Math.max(
     ...multipleSeries.map(series => series.data.length),
   );
-  if (settings.show_values && maxSeriesLength > MAX_SERIES_LENGTH) {
+  if (
+    settings.visualization_settings["graph.show_values"] &&
+    maxSeriesLength > MAX_SERIES_LENGTH
+  ) {
     return valueCharSize * (APPROXIMATE_MAX_VALUE_CHAR_LENGTH / 2);
   }
 

--- a/frontend/src/metabase/static-viz/components/XYChart/types.ts
+++ b/frontend/src/metabase/static-viz/components/XYChart/types.ts
@@ -17,7 +17,6 @@ export type YAxisPosition = "left" | "right";
 export type VisualizationType = "line" | "area" | "bar" | "waterfall";
 
 interface BaseSeries {
-  name: string | null;
   data: SeriesData;
   type: VisualizationType;
   yAxisPosition: YAxisPosition;

--- a/frontend/src/metabase/static-viz/components/XYChart/types.ts
+++ b/frontend/src/metabase/static-viz/components/XYChart/types.ts
@@ -1,5 +1,5 @@
 import type { ScaleBand, ScaleLinear, ScaleTime } from "d3-scale";
-import { DatasetColumn } from "metabase-types/api";
+import { DatasetColumn, VisualizationSettings } from "metabase-types/api";
 import type { DateFormatOptions } from "metabase/static-viz/lib/dates";
 import type { NumberFormatOptions } from "metabase/static-viz/lib/numbers";
 import { ContinuousScaleType } from "metabase/visualizations/shared/types/scale";
@@ -69,13 +69,12 @@ export type ChartSettings = {
     value: number;
     label: string;
   };
-  show_values?: boolean;
   labels: {
     left?: string;
     bottom?: string;
     right?: string;
   };
-  series_settings?: Record<string, { color?: string; title?: string }>;
+  visualization_settings: VisualizationSettings;
 };
 
 export interface Dimensions {

--- a/frontend/src/metabase/visualizations/lib/settings.js
+++ b/frontend/src/metabase/visualizations/lib/settings.js
@@ -128,6 +128,9 @@ function getSettingWidget(
     for (const settingId of settingDef.writeDependencies || []) {
       newSettings[settingId] = computedSettings[settingId];
     }
+    for (const settingId of settingDef.eraseDependencies || []) {
+      newSettings[settingId] = null;
+    }
     onChangeSettings(newSettings);
   };
   if (settingDef.useRawSeries && object._raw) {

--- a/frontend/src/metabase/visualizations/lib/settings/graph.js
+++ b/frontend/src/metabase/visualizations/lib/settings/graph.js
@@ -153,6 +153,7 @@ export const GRAPH_DATA_SETTINGS = {
     },
     readDependencies: ["graph._dimension_filter", "graph._metric_filter"],
     writeDependencies: ["graph.metrics"],
+    eraseDependencies: ["graph.series_order_dimension", "graph.series_order"],
     dashboard: false,
     useRawSeries: true,
   },

--- a/src/metabase/pulse/render/body.clj
+++ b/src/metabase/pulse/render/body.clj
@@ -289,10 +289,11 @@
   - there are some date overrides done from lib/formatting.js
   - chop off and underscore the nasty keys in our map
   - backfill currency to the default of USD if not present"
-  [x-col y-col {::mb.viz/keys [column-settings] :as _viz-settings}]
+  [x-col y-col {::mb.viz/keys [column-settings] :as viz-settings}]
   (let [x-col-settings (settings-from-column x-col column-settings)
         y-col-settings (settings-from-column y-col column-settings)]
-    (cond-> {:colors (public-settings/application-colors)}
+    (cond-> {:colors (public-settings/application-colors)
+             :visualization_settings viz-settings}
       x-col-settings
       (assoc :x x-col-settings)
       y-col-settings

--- a/src/metabase/pulse/render/body.clj
+++ b/src/metabase/pulse/render/body.clj
@@ -325,19 +325,17 @@
                          "timeseries"
                          "ordinal")]
     (merge
-     {:colors      (public-settings/application-colors)
-      :stacking    (if (:stackable.stack_type viz-settings) "stack" "none")
-      :show_values (boolean (:graph.show_values viz-settings))
-      :x           {:type   (or (:graph.x_axis.scale viz-settings) default-x-type)
-                    :format x-format}
-      :y           {:type   (or (:graph.y_axis.scale viz-settings) "linear")
-                    :format y-format}
-      :labels      labels}
+     {:colors                 (public-settings/application-colors)
+      :stacking               (if (:stackable.stack_type viz-settings) "stack" "none")
+      :x                      {:type   (or (:graph.x_axis.scale viz-settings) default-x-type)
+                               :format x-format}
+      :y                      {:type   (or (:graph.y_axis.scale viz-settings) "linear")
+                               :format y-format}
+      :labels                 labels
+      :visualization_settings viz-settings}
      (when (:graph.show_goal viz-settings)
        {:goal {:value (:graph.goal_value viz-settings)
-               :label (or (:graph.goal_label viz-settings) (tru "Goal"))}})
-     (when (:series_settings viz-settings)
-       {:series_settings (:series_settings viz-settings)}))))
+               :label (or (:graph.goal_label viz-settings) (tru "Goal"))}}))))
 
 (defn- set-default-stacked
   "Default stack type is stacked for area chart with more than one metric.

--- a/src/metabase/pulse/render/body.clj
+++ b/src/metabase/pulse/render/body.clj
@@ -293,7 +293,7 @@
   (let [x-col-settings (settings-from-column x-col column-settings)
         y-col-settings (settings-from-column y-col column-settings)]
     (cond-> {:colors (public-settings/application-colors)
-             :visualization_settings viz-settings}
+             :visualization_settings (or viz-settings {})}
       x-col-settings
       (assoc :x x-col-settings)
       y-col-settings
@@ -333,7 +333,7 @@
       :y                      {:type   (or (:graph.y_axis.scale viz-settings) "linear")
                                :format y-format}
       :labels                 labels
-      :visualization_settings viz-settings}
+      :visualization_settings (or viz-settings {})}
      (when (:graph.show_goal viz-settings)
        {:goal {:value (:graph.goal_value viz-settings)
                :label (or (:graph.goal_label viz-settings) (tru "Goal"))}}))))

--- a/src/metabase/pulse/render/body.clj
+++ b/src/metabase/pulse/render/body.clj
@@ -608,8 +608,7 @@
 (defn- multiple-scalar-series
   [joined-rows _x-cols _y-cols _viz-settings]
   [(for [[row-val] (map vector joined-rows)]
-     {:name          nil
-      :cardName      (first row-val)
+     {:cardName      (first row-val)
       :type          :bar
       :data          [row-val]
       :yAxisPosition "left"
@@ -643,16 +642,13 @@
   [chart-type joined-rows _x-cols y-cols {:keys [viz-settings] :as data} card-name]
   (for [[idx y-col] (map-indexed vector y-cols)]
     (let [y-col-key     (keyword (:name y-col))
-          metric-name          (or (series-setting viz-settings y-col-key :name)
-                                   (series-setting viz-settings y-col-key :title))
           card-type     (or (series-setting viz-settings y-col-key :display)
                             chart-type
                             (nth default-combo-chart-types idx))
           selected-rows (mapv #(vector (ffirst %) (nth (second %) idx)) joined-rows)
           y-axis-pos    (or (series-setting viz-settings y-col-key :axis)
                             (nth (default-y-pos data axis-group-threshold) idx))]
-      {:name          metric-name
-       :cardName      card-name
+      {:cardName      card-name
        :type          card-type
        :data          selected-rows
        :yAxisPosition y-axis-pos
@@ -670,15 +666,12 @@
     (for [[idx group-key] (map-indexed vector groups)]
       (let [row-group          (get grouped-rows group-key)
             selected-row-group (mapv #(vector (ffirst %) (first (second %))) row-group)
-            column-name          (or (series-setting viz-settings group-key :name)
-                                   (series-setting viz-settings group-key :title))
             card-type          (or (series-setting viz-settings group-key :display)
                                    chart-type
                                    (nth default-combo-chart-types idx))
             y-axis-pos         (or (series-setting viz-settings group-key :axis)
                                    (nth (default-y-pos data axis-group-threshold) idx))]
-        {:name          column-name
-         :cardName      card-name
+        {:cardName      card-name
          :type          card-type
          :data          selected-row-group
          :yAxisPosition y-axis-pos

--- a/test/metabase/pulse/render/body_test.clj
+++ b/test/metabase/pulse/render/body_test.clj
@@ -410,25 +410,30 @@
 (deftest render-bar-graph-test
   (testing "Render a bar graph with non-nil values for the x and y axis"
     (is (has-inline-image?
-         (render-bar-graph {:cols default-columns
-                            :rows [[10.0 1] [5.0 10] [2.50 20] [1.25 30]]}))))
+         (render-bar-graph {:cols         default-columns
+                            :rows         [[10.0 1] [5.0 10] [2.50 20] [1.25 30]]
+                            :viz-settings {}}))))
   (testing "Check to make sure we allow nil values for the y-axis"
     (is (has-inline-image?
-         (render-bar-graph {:cols default-columns
-                            :rows [[10.0 1] [5.0 10] [2.50 20] [1.25 nil]]}))))
+         (render-bar-graph {:cols         default-columns
+                            :rows         [[10.0 1] [5.0 10] [2.50 20] [1.25 nil]]
+                            :viz-settings {}}))))
   (testing "Check to make sure we allow nil values for the y-axis"
     (is (has-inline-image?
-         (render-bar-graph {:cols default-columns
-                            :rows [[10.0 1] [5.0 10] [2.50 20] [nil 30]]}))))
+         (render-bar-graph {:cols         default-columns
+                            :rows         [[10.0 1] [5.0 10] [2.50 20] [nil 30]]
+                            :viz-settings {}}))))
   (testing "Check to make sure we allow nil values for both x and y on different rows"
     (is (has-inline-image?
-         (render-bar-graph {:cols default-columns
-                            :rows [[10.0 1] [5.0 10] [nil 20] [1.25 nil]]}))))
+         (render-bar-graph {:cols         default-columns
+                            :rows         [[10.0 1] [5.0 10] [nil 20] [1.25 nil]]
+                            :viz-settings {}}))))
   (testing "Check multiseries in one card but without explicit combo"
     (is (has-inline-image?
-          (render-multiseries-bar-graph
-            {:cols default-multi-columns
-             :rows [[10.0 1 1231 1] [5.0 10 nil 111] [2.50 20 11 1] [1.25 nil 1231 11]]})))))
+         (render-multiseries-bar-graph
+          {:cols         default-multi-columns
+           :rows         [[10.0 1 1231 1] [5.0 10 nil 111] [2.50 20 11 1] [1.25 nil 1231 11]]
+           :viz-settings {}})))))
 
 (defn- render-area-graph [results]
   (body/render :area :inline pacific-tz render.tu/test-card nil results))
@@ -442,29 +447,35 @@
 (deftest render-area-graph-test
   (testing "Render an area graph with non-nil values for the x and y axis"
     (is (has-inline-image?
-          (render-area-graph {:cols default-columns
-                              :rows [[10.0 1] [5.0 10] [2.50 20] [1.25 30]]}))))
+         (render-area-graph {:cols         default-columns
+                             :rows         [[10.0 1] [5.0 10] [2.50 20] [1.25 30]]
+                             :viz-settings {}}))))
   (testing "Render a stacked area graph"
     (is (has-inline-image?
-          (render-stack-area-graph {:cols default-multi-columns
-                                    :rows [[10.0 1 1231 1] [5.0 10 nil 111] [2.50 20 11 1] [1.25 nil 1231 11]]}))))
+         (render-stack-area-graph {:cols         default-multi-columns
+                                   :rows         [[10.0 1 1231 1] [5.0 10 nil 111] [2.50 20 11 1] [1.25 nil 1231 11]]
+                                   :viz-settings {}}))))
   (testing "Check to make sure we allow nil values for the y-axis"
     (is (has-inline-image?
-          (render-area-graph {:cols default-columns
-                              :rows [[10.0 1] [5.0 10] [2.50 20] [1.25 nil]]}))))
+         (render-area-graph {:cols         default-columns
+                             :rows         [[10.0 1] [5.0 10] [2.50 20] [1.25 nil]]
+                             :viz-settings {}}))))
   (testing "Check to make sure we allow nil values for the y-axis"
     (is (has-inline-image?
-          (render-area-graph {:cols default-columns
-                              :rows [[10.0 1] [5.0 10] [2.50 20] [nil 30]]}))))
+         (render-area-graph {:cols         default-columns
+                             :rows         [[10.0 1] [5.0 10] [2.50 20] [nil 30]]
+                             :viz-settings {}}))))
   (testing "Check to make sure we allow nil values for both x and y on different rows"
     (is (has-inline-image?
-          (render-area-graph {:cols default-columns
-                              :rows [[10.0 1] [5.0 10] [nil 20] [1.25 nil]]}))))
+         (render-area-graph {:cols         default-columns
+                             :rows         [[10.0 1] [5.0 10] [nil 20] [1.25 nil]]
+                             :viz-settings {}}))))
   (testing "Check multiseries in one card but without explicit combo"
     (is (has-inline-image?
-          (render-multiseries-area-graph
-            {:cols default-multi-columns
-             :rows [[10.0 1 1231 1] [5.0 10 nil 111] [2.50 20 11 1] [1.25 nil 1231 11]]})))))
+         (render-multiseries-area-graph
+          {:cols         default-multi-columns
+           :rows         [[10.0 1 1231 1] [5.0 10 nil 111] [2.50 20 11 1] [1.25 nil 1231 11]]
+           :viz-settings {}})))))
 
 (deftest series-with-custom-names-test
   (testing "Check if single x-axis combo series uses custom series names (#21503)"
@@ -503,23 +514,28 @@
   (testing "Render a waterfall graph with non-nil values for the x and y axis"
     (is (has-inline-image?
          (render-waterfall {:cols default-columns
-                            :rows [[10.0 1] [5.0 10] [2.50 20] [1.25 30]]}))))
+                            :rows         [[10.0 1] [5.0 10] [2.50 20] [1.25 30]]
+                            :viz-settings {}}))))
   (testing "Render a waterfall graph with bigdec, bigint values for the x and y axis"
     (is (has-inline-image?
-          (render-waterfall {:cols default-columns
-                             :rows [[10.0M 1M] [5.0 10N] [2.50 20N] [1.25M 30]]}))))
+         (render-waterfall {:cols         default-columns
+                            :rows         [[10.0M 1M] [5.0 10N] [2.50 20N] [1.25M 30]]
+                            :viz-settings {}}))))
   (testing "Check to make sure we allow nil values for the y-axis"
     (is (has-inline-image?
-         (render-waterfall {:cols default-columns
-                            :rows [[10.0 1] [5.0 10] [2.50 20] [1.25 nil]]}))))
+         (render-waterfall {:cols         default-columns
+                            :rows         [[10.0 1] [5.0 10] [2.50 20] [1.25 nil]]
+                            :viz-settings {}}))))
   (testing "Check to make sure we allow nil values for the x-axis"
     (is (has-inline-image?
-         (render-waterfall {:cols default-columns
-                            :rows [[10.0 1] [5.0 10] [2.50 20] [nil 30]]}))))
+         (render-waterfall {:cols         default-columns
+                            :rows         [[10.0 1] [5.0 10] [2.50 20] [nil 30]]
+                            :viz-settings {}}))))
   (testing "Check to make sure we allow nil values for both x and y on different rows"
     (is (has-inline-image?
-         (render-waterfall {:cols default-columns
-                            :rows [[10.0 1] [5.0 10] [nil 20] [1.25 nil]]})))))
+         (render-waterfall {:cols         default-columns
+                            :rows         [[10.0 1] [5.0 10] [nil 20] [1.25 nil]]
+                            :viz-settings {}})))))
 
 (defn- render-combo [results]
   (body/render :combo :inline pacific-tz render.tu/test-combo-card nil results))
@@ -530,16 +546,19 @@
 (deftest render-combo-test
   (testing "Render a combo graph with non-nil values for the x and y axis"
     (is (has-inline-image?
-          (render-combo {:cols default-multi-columns
-                         :rows [[10.0 1 123 111] [5.0 10 12 111] [2.50 20 1337 12312] [1.25 30 -22 123124]]}))))
+         (render-combo {:cols         default-multi-columns
+                        :rows         [[10.0 1 123 111] [5.0 10 12 111] [2.50 20 1337 12312] [1.25 30 -22 123124]]
+                        :viz-settings {}}))))
   (testing "Render a combo graph with multiple x axes"
     (is (has-inline-image?
-          (render-combo-multi-x {:cols default-multi-columns
-                                 :rows [[10.0 "Bob" 123 123124] [5.0 "Dobbs" 12 23423] [2.50 "Robbs" 1337 234234] [1.25 "Mobbs" -22 1234123]]}))))
+         (render-combo-multi-x {:cols         default-multi-columns
+                                :rows         [[10.0 "Bob" 123 123124] [5.0 "Dobbs" 12 23423] [2.50 "Robbs" 1337 234234] [1.25 "Mobbs" -22 1234123]]
+                                :viz-settings {}}))))
   (testing "Check to make sure we allow nil values for any axis"
     (is (has-inline-image?
-          (render-combo {:cols default-multi-columns
-                         :rows [[nil 1 1 23453] [10.0 1 nil nil] [5.0 10 22 1337] [2.50 nil 22 1231] [1.25 nil nil 1231232]]})))))
+         (render-combo {:cols         default-multi-columns
+                        :rows         [[nil 1 1 23453] [10.0 1 nil nil] [5.0 10 22 1337] [2.50 nil 22 1231] [1.25 nil nil 1231232]]
+                        :viz-settings {}})))))
 
 (defn- render-funnel [results]
   (body/render :funnel :inline pacific-tz render.tu/test-card nil results))
@@ -548,18 +567,21 @@
   (testing "Test that we can render a funnel with all valid values"
     (is (has-inline-image?
          (render-funnel
-          {:cols default-columns
-           :rows [[10.0 1] [5.0 10] [2.50 20] [1.25 30]]}))))
+          {:cols         default-columns
+           :rows         [[10.0 1] [5.0 10] [2.50 20] [1.25 30]]
+           :viz-settings {}}))))
   (testing "Test that we can render a funnel with extraneous columns and also weird strings stuck in places"
     (is (has-inline-image?
-          (render-funnel
-            {:cols default-multi-columns
-             :rows [[10.0 1 2 2] [5.0 10 "11.1" 1] ["2.50" 20 1337 0] [1.25 30 -2 "-2"]]}))))
+         (render-funnel
+          {:cols         default-multi-columns
+           :rows         [[10.0 1 2 2] [5.0 10 "11.1" 1] ["2.50" 20 1337 0] [1.25 30 -2 "-2"]]
+           :viz-settings {}}))))
   (testing "Test that we can have some nil values stuck everywhere"
     (is (has-inline-image?
          (render-funnel
-          {:cols default-columns
-           :rows [[nil 1] [11.0 nil] [nil nil] [2.50 20] [1.25 30]]})))))
+          {:cols         default-columns
+           :rows         [[nil 1] [11.0 nil] [nil nil] [2.50 20] [1.25 30]]
+           :viz-settings {}})))))
 
 (deftest render-categorical-donut-test
   (let [columns [{:name          "category",

--- a/test/metabase/pulse/render/body_test.clj
+++ b/test/metabase/pulse/render/body_test.clj
@@ -477,36 +477,6 @@
            :rows         [[10.0 1 1231 1] [5.0 10 nil 111] [2.50 20 11 1] [1.25 nil 1231 11]]
            :viz-settings {}})))))
 
-(deftest series-with-custom-names-test
-  (testing "Check if single x-axis combo series uses custom series names (#21503)"
-    (is (= #{"Bought" "Sold"}
-           (set (map :name
-                     (#'body/single-x-axis-combo-series
-                       :bar
-                       [[[10.0] [1 -1]] [[5.0] [10 -10]] [[1.25] [20 -20]]]
-                       [{:name "Price", :display_name "Price", :base_type :type/Number}]
-                       [{:name "NumPurchased", :display_name "NumPurchased", :base_type :type/Number}
-                        {:name "NumSold", :display_name "NumSold", :base_type :type/Number}]
-                       {:viz-settings
-                        {:series_settings {:NumPurchased {:color "#a7cf7b" :title "Bought"}
-                                           :NumSold      {:color "#a7cf7b" :title "Sold"}}}}
-                       "Card name"))))))
-  (testing "Check if double x-axis combo series uses custom series names (#21503)"
-    (is (= #{"Bobby" "Dobby" "Robby" "Mobby"}
-           (set (map :name
-                     (#'body/double-x-axis-combo-series
-                       nil
-                       [[[10.0 "Bob"] [123]] [[5.0 "Dobbs"] [12]] [[2.5 "Robbs"] [1337]] [[1.25 "Mobbs"] [-22]]]
-                       [{:base_type :type/BigInteger, :display_name "Price", :name "Price", :semantic_type nil}
-                        {:base_type :type/BigInteger, :display_name "NumPurchased", :name "NumPurchased", :semantic_type nil}]
-                       [{:base_type :type/BigInteger, :display_name "NumKazoos", :name "NumKazoos", :semantic_type nil}]
-                       {:viz-settings
-                        {:series_settings {:Bob   {:color "#c5a9cf" :title "Bobby"}
-                                           :Dobbs {:color "#a7cf7b" :title "Dobby"}
-                                           :Robbs {:color "#34517d" :title "Robby"}
-                                           :Mobbs {:color "#e0be40" :title "Mobby"}}}}
-                       "Card name")))))))
-
 (defn- render-waterfall [results]
   (body/render :waterfall :inline pacific-tz render.tu/test-card nil results))
 

--- a/test/metabase/pulse/render/js_svg_test.clj
+++ b/test/metabase/pulse/render/js_svg_test.clj
@@ -112,21 +112,21 @@
   (let [rows        [[#t "2020" 2]
                      [#t "2021" 3]]
         series-seqs [[{:type          :line
-                       :color         "#999AC4"
                        :data          rows
                        :yAxisPosition "left"
                        :column        {:name "count"}}]]
-        settings    {:colors {:brand     "#5E81AC"
-                              :filter    "#A3BE8C"
-                              :summarize "#B48EAD"},
-                     :x      {:type   "timeseries"
-                              :format {:date_style "YYYY/MM/DD"}}
-                     :y      {:type   "linear"
-                              :format {:prefix   "prefix"
-                                       :decimals 2}}
-                     :labels {:bottom ""
-                              :left   ""
-                              :right  ""}}
+        settings    {:colors                 {:brand     "#5E81AC"
+                                              :filter    "#A3BE8C"
+                                              :summarize "#B48EAD"},
+                     :x                      {:type   "timeseries"
+                                              :format {:date_style "YYYY/MM/DD"}}
+                     :y                      {:type   "linear"
+                                              :format {:prefix   "prefix"
+                                                       :decimals 2}}
+                     :labels                 {:bottom ""
+                                              :left   ""
+                                              :right  ""}
+                     :visualization_settings {}}
         svg-string  (combo-chart-string series-seqs settings)]
     (testing "It returns bytes"
       (let [svg-bytes (js-svg/combo-chart series-seqs settings)]
@@ -153,21 +153,21 @@
   (let [rows        [[#t "2020" 2]
                      [#t "2021" 3]]
         series-seqs [[{:type          :bar
-                       :color         "#999AC4"
                        :data          rows
                        :yAxisPosition "left"
                        :column        {:name "count"}}]]
-        settings    {:colors {:brand     "#5E81AC"
-                              :filter    "#A3BE8C"
-                              :summarize "#B48EAD"},
-                     :x      {:type   "timeseries"
-                              :format {:date_style "YYYY/MM/DD"}}
-                     :y      {:type   "linear"
-                              :format {:prefix   "prefix"
-                                       :decimals 4}}
-                     :labels {:bottom ""
-                              :left   ""
-                              :right  ""}}
+        settings    {:colors                 {:brand     "#5E81AC"
+                                              :filter    "#A3BE8C"
+                                              :summarize "#B48EAD"},
+                     :x                      {:type   "timeseries"
+                                              :format {:date_style "YYYY/MM/DD"}}
+                     :y                      {:type   "linear"
+                                              :format {:prefix   "prefix"
+                                                       :decimals 4}}
+                     :labels                 {:bottom ""
+                                              :left   ""
+                                              :right  ""}
+                     :visualization_settings {}}
         svg-string  (combo-chart-string series-seqs settings)]
     (testing "It returns bytes"
       (let [svg-bytes (js-svg/combo-chart series-seqs settings)]
@@ -194,20 +194,20 @@
   (let [rows        [["bob" 2]
                      ["dobbs" 3]]
         series-seqs [[{:type          :area
-                       :color         "#999AC4"
                        :data          rows
                        :yAxisPosition "left"
                        :column        {:name "count"}}]]
-        settings    {:colors {:brand     "#5E81AC"
-                              :filter    "#A3BE8C"
-                              :summarize "#B48EAD"},
-                     :x      {:type "ordinal"}
-                     :y      {:type   "linear"
-                              :format {:prefix   "prefix"
-                                       :decimals 4}}
-                     :labels {:bottom ""
-                              :left   ""
-                              :right  ""}}
+        settings    {:colors                 {:brand     "#5E81AC"
+                                              :filter    "#A3BE8C"
+                                              :summarize "#B48EAD"},
+                     :x                      {:type "ordinal"}
+                     :y                      {:type   "linear"
+                                              :format {:prefix   "prefix"
+                                                       :decimals 4}}
+                     :labels                 {:bottom ""
+                                              :left   ""
+                                              :right  ""}
+                     :visualization_settings {}}
         svg-string  (combo-chart-string series-seqs settings)]
     (testing "It returns bytes"
       (let [svg-bytes (js-svg/combo-chart series-seqs settings)]
@@ -234,11 +234,12 @@
                            :data          [["A" 1] ["B" 20] ["C" -4] ["D" 100]]
                            :yAxisPosition "left"
                            :column        {:name "count"}}]]
-        settings        {:x      {:type "ordinal"}
-                         :y      {:type "linear"}
-                         :labels {:bottom ""
-                                  :left   ""
-                                  :right  ""}}
+        settings        {:x                      {:type "ordinal"}
+                         :y                      {:type "linear"}
+                         :labels                 {:bottom ""
+                                                  :left   ""
+                                                  :right  ""}
+                         :visualization_settings {}}
         non-goal-hiccup (combo-chart-hiccup series-seqs settings)
         non-goal-node   (->> non-goal-hiccup (tree-seq vector? rest) (filter #(= goal-label (second %))) first)]
     (testing "No goal line exists when there are no goal settings."
@@ -285,28 +286,27 @@
         rows2       [[#t "2000-03-01T00:00:00Z" 3]
                      [#t "2002-03-01T00:00:00Z" 4]]
         ;; this one needs more stuff because of stricter ts types
-        series-seqs [[{:name          "bob"
-                       :color         "#cccccc"
+        series-seqs [[{:cardName      "bob"
                        :type          "area"
                        :data          rows1
                        :yAxisPosition "left"
-                       :column        {:name "count"}}
-                      {:name          "bob2"
-                       :color         "#cccccc"
+                       :column        {:name "count" :display_name "Count"}}
+                      {:cardName      "bob"
                        :type          "line"
                        :data          rows2
                        :yAxisPosition "right"
-                       :column        {:name "count"}}]]
+                       :column        {:name "count2" :display_name "Count 2"}}]]
         labels      {:left   "count"
                      :bottom "year"
                      :right  "something"}
-        settings    {:x      {:type   "timeseries"
-                              :format {:date_style "YYYY"}}
-                     :y      {:type   "linear"
-                              :format {:number_style "decimal"
-                                       :decimals     4}}
-                     :colors {}
-                     :labels labels}]
+        settings    {:x                      {:type   "timeseries"
+                                              :format {:date_style "YYYY"}}
+                     :y                      {:type   "linear"
+                                              :format {:number_style "decimal"
+                                                       :decimals     4}}
+                     :colors                 {}
+                     :labels                 labels
+                     :visualization_settings {}}]
     (testing "It returns bytes"
       (let [svg-bytes (js-svg/combo-chart series-seqs settings)]
         (is (bytes? svg-bytes))))


### PR DESCRIPTION
Epic: #24759
[Notion doc](https://www.notion.so/metabase/Viz-Pod-Rest-of-the-Cycle-Outlook-c0456a67b5754647937bdc1def78e04c#211dba1718754379a195916499158369)

## Changes
- Respect order settings in combo chart `graph.series_order`
- Respect order settings in funnel chart `funnel.rows`

## How to test
1. Create one or more questions with 2 dimensions, select bar, or area, or line as their visualization and reorder the breakout columns, then toggle their visibility as desired.
1. Create one or more funnel charts questions, reorder the step and toggle their visibility as desired.
1. Add those questions to a dashboard
1. Send a test subscription for that dashboard and see the result

#### App
- ![image](https://user-images.githubusercontent.com/1937582/204808753-de3d1c3e-6a31-40ca-8cc1-0a35e3fb8b14.png)
- ![image](https://user-images.githubusercontent.com/1937582/204808698-c0c274fc-5dc6-44d5-9907-c21018dd86e1.png)


#### After
- ![image](https://user-images.githubusercontent.com/1937582/204808609-3ccb80f8-3604-49d0-a714-5acc2537fa29.png)
- ![image](https://user-images.githubusercontent.com/1937582/204808485-69451803-6184-410b-8390-efd4816a5c7d.png)

#### Before
- ![image](https://user-images.githubusercontent.com/1937582/204808973-83a5b83f-e726-48fe-9552-34a8090ce2c1.png)
- ![image](https://user-images.githubusercontent.com/1937582/204809269-b3936fd3-cf70-4b53-93d5-a4006e613501.png)