### PR TITLE
Migrate to card viz-settings v.2

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -401,6 +401,7 @@
   metabase.integrations.ldap/with-ldap-connection                                      clojure.core/fn
   metabase.mbql.schema.macros/defclause                                                clj-kondo.lint-as/def-catch-all
   metabase.models.collection-test/with-collection-in-location                          clojure.core/let
+  metabase.models.json-migration/def-json-migration                                    clj-kondo.lint-as/def-catch-all
   metabase.models.setting.multi-setting/define-multi-setting                           clojure.core/def
   metabase.models.setting/defsetting                                                   clj-kondo.lint-as/def-catch-all
   metabase.public-settings.premium-features/defenterprise                              clj-kondo.lint-as/def-catch-all

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -31,6 +31,8 @@
 ;;; You can read/write a Card if you can read/write its parent Collection
 (derive Card ::perms/use-parent-collection-perms)
 
+(def ^:private viz-settings-version 2)
+
 
 ;;; -------------------------------------------------- Hydration --------------------------------------------------
 
@@ -237,6 +239,49 @@
       (field-values/update-field-values-for-on-demand-dbs! field-ids))
     (create-actions-when-is-writable! card)))
 
+(defn- assoc-viz-setting
+  [card key val]
+  (assoc-in card [:visualization_settings key] val))
+
+(defmulti ^:private migrate-viz-settings*
+  "Migration visualization_settings to the appropriate version"
+  {:arglists '([card desired-version])}
+  (fn [card desired-version]
+    (let [current-version (or (get-in card [:visualization_settings :version])
+                              1)]
+      (if (= current-version desired-version)
+        ::identity
+        [current-version desired-version]))))
+
+(defmethod ^:private migrate-viz-settings* ::identity [card _]
+  card)
+
+(defmethod ^:private migrate-viz-settings* [1 2] [{:keys [visualization_settings] :as card} _]
+  (let [{percent? :pie.show_legend_perecent ;; [sic]
+         legend?  :pie.show_legend} visualization_settings]
+    (assoc-viz-setting card :pie.percent_visibility
+                       (cond
+                         legend?  "inside"
+                         percent? "legend"
+                         :else    "off"))))
+
+;; migrate-viz settings was introduced with v. 2, so we'll never be in a situation where we can downgrade from 2 to 1.
+;; See sample code in SHA d597b445333f681ddd7e52b2e30a431668d35da8
+
+(defn- migrate-viz-settings
+  "Updates the card to the current `viz-settings-version`."
+  [card]
+  (if (:visualization_settings card)
+    (-> card
+        (migrate-viz-settings* viz-settings-version)
+        (assoc-viz-setting :version viz-settings-version))
+    card))
+
+(defn- post-select [card]
+  (-> card
+      public-settings/remove-public-uuid-if-public-sharing-is-disabled
+      migrate-viz-settings))
+
 (defonce
   ^{:doc "Atom containing a function used to check additional sandboxing constraints for Metabase Enterprise Edition.
   This is called as part of the `pre-update` method for a Card.
@@ -321,11 +366,11 @@
                                        :entity_id    true})
           ;; Make sure we normalize the query before calling `pre-update` or `pre-insert` because some of the
           ;; functions those fns call assume normalized queries
-          :pre-update     (comp populate-query-fields pre-update populate-result-metadata maybe-normalize-query)
-          :pre-insert     (comp populate-query-fields pre-insert populate-result-metadata maybe-normalize-query)
+          :pre-update     (comp migrate-viz-settings populate-query-fields pre-update populate-result-metadata maybe-normalize-query)
+          :pre-insert     (comp migrate-viz-settings populate-query-fields pre-insert populate-result-metadata maybe-normalize-query)
           :post-insert    post-insert
           :pre-delete     pre-delete
-          :post-select    public-settings/remove-public-uuid-if-public-sharing-is-disabled}))
+          :post-select    post-select}))
 
 (defmethod serdes.hash/identity-hash-fields Card
   [_card]

--- a/src/metabase/models/interface.clj
+++ b/src/metabase/models/interface.clj
@@ -8,6 +8,7 @@
             [metabase.mbql.normalize :as mbql.normalize]
             [metabase.mbql.schema :as mbql.s]
             [metabase.models.dispatch :as models.dispatch]
+            [metabase.models.json-migration :as jm]
             [metabase.plugins.classloader :as classloader]
             [metabase.util :as u]
             [metabase.util.cron :as u.cron]
@@ -157,9 +158,31 @@
       ;; the word "expression" but it is not MBQL (metabase#15882)
       (get viz-settings "graph.metrics")   (assoc :graph.metrics (get viz-settings "graph.metrics")))))
 
+(jm/def-json-migration migrate-viz-settings*)
+
+(def ^:private viz-settings-current-version 2)
+
+(defmethod ^:private migrate-viz-settings* [1 2] [viz-settings _]
+  (let [{percent? :pie.show_legend_perecent ;; [sic]
+         legend?  :pie.show_legend} viz-settings]
+    (assoc viz-settings :pie.percent_visibility
+           (cond
+             legend?  "inside"
+             percent? "legend"
+             :else    "off"))))
+
+(defn- migrate-viz-settings
+  [viz-settings]
+  (-> viz-settings
+      (migrate-viz-settings* viz-settings-current-version)
+      (jm/update-version viz-settings-current-version)))
+
+;; migrate-viz settings was introduced with v. 2, so we'll never be in a situation where we can downgrade from 2 to 1.
+;; See sample code in SHA d597b445333f681ddd7e52b2e30a431668d35da8
+
 (models/add-type! :visualization-settings
-  :in  json-in
-  :out (comp normalize-visualization-settings json-out-without-keywordization))
+  :in  (comp json-in migrate-viz-settings)
+  :out (comp migrate-viz-settings normalize-visualization-settings json-out-without-keywordization))
 
 ;; json-set is just like json but calls `set` on it when coming out of the DB. Intended for storing things like a
 ;; permissions set

--- a/src/metabase/models/json_migration.clj
+++ b/src/metabase/models/json_migration.clj
@@ -1,9 +1,12 @@
 (ns metabase.models.json-migration)
 
 (defn update-version
-  "Set the updated version"
+  "Set the updated version if the column-value has data. Doesn't do anything if it's empty since empty values are
+  assumed to result in version-appropriate default behavior and don't need an explicit version key."
   [column-value desired-version]
-  (assoc column-value :version desired-version))
+  (if (seq column-value)
+    (assoc column-value :version desired-version)
+    column-value))
 
 (defmacro def-json-migration
   "Create a multi-method with the given name that will perform JSON migrations. Individual cases (with appropriate

--- a/src/metabase/models/json_migration.clj
+++ b/src/metabase/models/json_migration.clj
@@ -1,0 +1,50 @@
+(ns metabase.models.json-migration)
+
+(defn update-version
+  "Set the updated version"
+  [column-value desired-version]
+  (assoc column-value :version desired-version))
+
+(defmacro def-json-migration
+  "Create a multi-method with the given name that will perform JSON migrations. Individual cases (with appropriate
+  logic!) must be defined by the user. The resulting multi-method accepts two arguments: the value of the column and
+  the desired version. Versioning is assumed to start at 1 and be stored in the JSON blob under the `:version`
+  key (and no version at all is assumed to be 1 as well). Updating the version is *not* handled here; in practice you
+  should probably chain the migration method together with `update-version` (defined above). Non-upgrades (e.g.,
+  upgrading a value from version 2 to version 2) are handled and treated as a no-op.
+
+  For example, imagine a User model with a JSON column called `login_settings`. This originally contained a boolean
+  key `remember_me` that persisted a session for 30 days, but the number of days is now configurable per user. The
+  migration code would look like this:
+
+      (def login-settings-version 2)
+
+      (def-json-migration migrate-login-settings*)
+
+      (defmethod migrate-login-settings* [1 2] [login-settings _version]
+        (assoc login-settings :remember_me_days (if (:remember_me login-settings) 30 0)))
+
+      (defn migrate-login-settings
+        [login-settings] ;; note that this only takes the one argument, not two
+        (-> login-settings
+            (migrate-login-settings* login-settings-version)
+            (update-version login-settings-version)))
+
+      (migrate-login-settings {:remember_me true})                 ;; => {:remember_me_days 30, :version 2, :remember_me true}
+      (migrate-login-settings {:remember_me false})                ;; => {:remember_me_days 0,  :version 2, :remember_me false}
+      (migrate-login-settings {:remember_me true, :version 1})     ;; => {:remember_me_days 30, :version 2, :remember_me true}
+      (migrate-login-settings {:remember_me_days 15, :version 2})  ;; => {:remember_me_days 15, :version 2}"
+  [name]
+  (let [name* name]
+    `(do
+       (defmulti ^:private ~name*
+         "Migrate the column value to the appropriate version."
+         {:arglists '([~'column-value ~'desired-version])}
+         (fn [~'column-value ~'desired-version]
+           (let [~'current-version (or (get ~'column-value :version) 1)]
+             (if (= ~'current-version ~'desired-version)
+               ::identity
+               [~'current-version ~'desired-version]))))
+
+       (defmethod ^:private ~name* ::identity [~'column-value ~'_]
+         ~'column-value))))

--- a/test/metabase/models/card_test.clj
+++ b/test/metabase/models/card_test.clj
@@ -395,29 +395,3 @@
               :pie.show_legend true
               :pie.percent_visibility "inside"}
              (:visualization_settings (db/simple-select-one Card {:where [:= :id card-id]})))))))
-
-(deftest upgrade-to-v2-viz-settings-test
-  (let [migrate #(select-keys (:visualization_settings (#'card/migrate-viz-settings {:visualization_settings %}))
-                              [:version :pie.percent_visibility])]
-    (testing "show_legend -> inside"
-      (is (= {:version 2
-              :pie.percent_visibility "inside"}
-             (migrate {:pie.show_legend          true
-                       :pie.show_legend_perecent true
-                       :pie.show_data_labels     true}))))
-    (testing "show_legend_percent -> legend"
-      (is (= {:version 2
-              :pie.percent_visibility "legend"}
-             (migrate {:pie.show_legend          false
-                       :pie.show_legend_perecent true
-                       :pie.show_data_labels     true}))))
-    (testing "anything else -> off"
-      (doseq [legend  [false nil]
-              percent [false nil]
-              labels  [true false nil]
-              version [nil 1]]
-        (is (= {:version 2
-                :pie.percent_visibility "off"}
-               (migrate {:pie.show_legend          legend
-                         :pie.show_legend_perecent percent
-                         :pie.show_data_labels     labels})))))))

--- a/test/metabase/models/interface_test.clj
+++ b/test/metabase/models/interface_test.clj
@@ -6,6 +6,7 @@
    [metabase.db.connection :as mdb.connection]
    [metabase.mbql.normalize :as mbql.normalize]
    [metabase.models.field :refer [Field]]
+   [metabase.models.interface :as mi]
    [metabase.test :as mt]
    [schema.core :as s]
    [toucan.models :as models]))
@@ -98,3 +99,30 @@
                         :updated_at t-schema
                         s/Keyword   s/Any}
                        field)))))))
+
+(deftest upgrade-to-v2-viz-settings-test
+  (let [migrate #(select-keys (#'mi/migrate-viz-settings %)
+                              [:version :pie.percent_visibility])]
+    (testing "show_legend -> inside"
+      (is (= {:version 2
+              :pie.percent_visibility "inside"}
+             (migrate {:pie.show_legend          true
+                       :pie.show_legend_perecent true
+                       :pie.show_data_labels     true}))))
+    (testing "show_legend_percent -> legend"
+      (is (= {:version 2
+              :pie.percent_visibility "legend"}
+             (migrate {:pie.show_legend          false
+                       :pie.show_legend_perecent true
+                       :pie.show_data_labels     true}))))
+    (testing "anything else -> off"
+      (doseq [legend  [false nil]
+              percent [false nil]
+              labels  [true false nil]
+              version [nil 1]]
+        (is (= {:version 2
+                :pie.percent_visibility "off"}
+               (migrate {:pie.show_legend          legend
+                         :pie.show_legend_perecent percent
+                         :pie.show_data_labels     labels
+                         :version                  version})))))))

--- a/test/metabase/models/interface_test.clj
+++ b/test/metabase/models/interface_test.clj
@@ -115,14 +115,11 @@
              (migrate {:pie.show_legend          false
                        :pie.show_legend_perecent true
                        :pie.show_data_labels     true}))))
-    (testing "anything else -> off"
+    (testing "anything else -> nothing"
       (doseq [legend  [false nil]
               percent [false nil]
-              labels  [true false nil]
-              version [nil 1]]
-        (is (= {:version 2
-                :pie.percent_visibility "off"}
+              labels  [true false nil]]
+        (is (= {}
                (migrate {:pie.show_legend          legend
                          :pie.show_legend_perecent percent
-                         :pie.show_data_labels     labels
-                         :version                  version})))))))
+                         :pie.show_data_labels     labels})))))))

--- a/test/metabase/models/json_migration_test.clj
+++ b/test/metabase/models/json_migration_test.clj
@@ -1,0 +1,25 @@
+(ns metabase.models.json-migration-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase.models.json-migration :as jm]))
+
+(jm/def-json-migration migrate-birds)
+
+(defmethod migrate-birds [1 2] [bird-facts _]
+  (assoc bird-facts :favorite :toucan))
+
+(deftest basic-usage-test
+  (testing "No-ops with no version change"
+    (is (= {:favorite :pigeon, :version 1}
+           (migrate-birds {:favorite :pigeon, :version 1} 1))))
+  (testing "No-ops with no version change and no explicit version"
+    (is (= {:favorite :pigeon}
+           (migrate-birds {:favorite :pigeon} 1))))
+  (testing "Runs a user-defined migration for higher versions"
+    (is (= {:favorite :toucan, :version 1} ;; version is handled separately :(
+           (migrate-birds {:favorite :pigeon, :version 1} 2)))))
+
+(deftest version-updating-test
+  (testing "It updates the :version key"
+    (is (= {:favorite :toucan, :version 2}
+           (jm/update-version {:favorite :toucan, :version 1} 2)))))


### PR DESCRIPTION
This uses the new :pie.percent_visibility key (an enum) instead of a collection of booleans

Part of #26776, so going into Sasha's `pie-percent` branch


