### PR TITLE
Only call onChange on blur

### DIFF
--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingInputNumeric.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingInputNumeric.tsx
@@ -23,9 +23,6 @@ const ChartSettingInputNumeric = ({
       value={internalValue}
       onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
         const num = parseFloat(e.target.value);
-        if (!isNaN(num) && num !== value) {
-          onChange(num);
-        }
         setInternalValue(num);
       }}
       onBlur={(e: React.ChangeEvent<HTMLInputElement>) => {


### PR DESCRIPTION
Small change to avoid calling onChange in `ChartSettingNumericInput` unless there is a blur event. When dealing with a large series these changes can be relatively slow causing typing to hang.

![h9kzuZnXBF](https://user-images.githubusercontent.com/1328979/204621862-29b0ce28-0708-41b1-a585-b09b15e2583e.gif)
