### PR TITLE
Remove special handling for mongo db in the database form

### DIFF
--- a/bin/build-drivers/src/build_drivers/lint_manifest_file.clj
+++ b/bin/build-drivers/src/build_drivers/lint_manifest_file.clj
@@ -23,7 +23,7 @@
 (s/def ::contact-info (spell/keys :req-un [::name]
                                   :opt-un [::address]))
 
-(def ^:private property-types #{"string" "text" "textFile" "boolean" "secret" "info" "schema-filters"})
+(def ^:private property-types #{"string" "text" "textFile" "boolean" "secret" "info" "schema-filters" "section"})
 
 (s/def ::display-name string?)
 (s/def ::default any?)

--- a/frontend/src/metabase/databases/components/DatabaseConnectionSectionField/DatabaseConnectionSectionField.styled.tsx
+++ b/frontend/src/metabase/databases/components/DatabaseConnectionSectionField/DatabaseConnectionSectionField.styled.tsx
@@ -1,0 +1,14 @@
+import styled from "@emotion/styled";
+import { color } from "metabase/lib/colors";
+import Button from "metabase/core/components/Button";
+
+export const SectionButton = styled(Button)`
+  color: ${color("brand")};
+  padding: 0;
+  border: none;
+  border-radius: 0;
+
+  &:hover {
+    background-color: transparent;
+  }
+`;

--- a/frontend/src/metabase/databases/components/DatabaseConnectionSectionField/DatabaseConnectionSectionField.tsx
+++ b/frontend/src/metabase/databases/components/DatabaseConnectionSectionField/DatabaseConnectionSectionField.tsx
@@ -1,0 +1,29 @@
+import React, { useCallback } from "react";
+import { useField } from "formik";
+import { t } from "ttag";
+import FormField from "metabase/core/components/FormField";
+import { SectionButton } from "./DatabaseConnectionSectionField.styled";
+
+export interface DatabaseConnectionSectionFieldProps {
+  name: string;
+}
+
+const DatabaseConnectionSectionField = ({
+  name,
+}: DatabaseConnectionSectionFieldProps): JSX.Element => {
+  const [{ value }, , { setValue }] = useField(name);
+
+  const handleClick = useCallback(() => {
+    setValue(!value);
+  }, [value, setValue]);
+
+  return (
+    <FormField>
+      <SectionButton type="button" onClick={handleClick}>
+        {value ? t`Fill out individual fields` : t`Paste a connection string`}
+      </SectionButton>
+    </FormField>
+  );
+};
+
+export default DatabaseConnectionSectionField;

--- a/frontend/src/metabase/databases/components/DatabaseConnectionSectionField/index.ts
+++ b/frontend/src/metabase/databases/components/DatabaseConnectionSectionField/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./DatabaseConnectionSectionField";

--- a/frontend/src/metabase/databases/constants.tsx
+++ b/frontend/src/metabase/databases/constants.tsx
@@ -89,7 +89,7 @@ export const FIELD_OVERRIDES: Record<string, EngineFieldOverride> = {
   "ssl-key-options": {
     description: <DatabaseSslKeyDescription />,
   },
-  "use-connection-string": {
+  "use-conn-uri": {
     type: DatabaseConnectionSectionField,
   },
   auto_run_queries: {

--- a/frontend/src/metabase/databases/constants.tsx
+++ b/frontend/src/metabase/databases/constants.tsx
@@ -1,8 +1,9 @@
 import React from "react";
 import { t } from "ttag";
-import DatabaseSshDescription from "./components/DatabaseSshDescription";
-import DatabaseClientIdDescription from "./components/DatabaseClientIdDescription";
 import DatabaseAuthCodeDescription from "./components/DatabaseAuthCodeDescription";
+import DatabaseClientIdDescription from "./components/DatabaseClientIdDescription";
+import DatabaseConnectionSectionField from "./components/DatabaseConnectionSectionField";
+import DatabaseSshDescription from "./components/DatabaseSshDescription";
 import DatabaseSslKeyDescription from "./components/DatabaseSslKeyDescription";
 import { EngineFieldOverride } from "./types";
 
@@ -87,6 +88,9 @@ export const FIELD_OVERRIDES: Record<string, EngineFieldOverride> = {
   },
   "ssl-key-options": {
     description: <DatabaseSslKeyDescription />,
+  },
+  "use-connection-string": {
+    type: DatabaseConnectionSectionField,
   },
   auto_run_queries: {
     name: "auto_run_queries",

--- a/frontend/src/metabase/entities/databases/mongo-fields.js
+++ b/frontend/src/metabase/entities/databases/mongo-fields.js
@@ -18,7 +18,7 @@ function MongoConnectionStringToggle({ field: { value, onChange } }) {
 
 export default function getFieldsForMongo(details, defaults, id) {
   const useConnectionString =
-    details["use-connection-uri"] == null || details["use-connection-uri"];
+    details["use-conn-uri"] == null || details["use-conn-uri"];
 
   const manualFields = [
     "host",
@@ -36,6 +36,7 @@ export default function getFieldsForMongo(details, defaults, id) {
     .filter(
       field =>
         !(
+          field["name"] === "use-conn-uri" ||
           (useConnectionString && manualFields.includes(field["name"])) ||
           (!useConnectionString && field["name"] === "conn-uri")
         ),
@@ -50,7 +51,7 @@ export default function getFieldsForMongo(details, defaults, id) {
   return {
     "details-fields": [
       {
-        name: "use-connection-uri",
+        name: "use-conn-uri",
         type: MongoConnectionStringToggle,
         hidden: true,
         default: false,

--- a/modules/drivers/mongo/resources/metabase-plugin.yaml
+++ b/modules/drivers/mongo/resources/metabase-plugin.yaml
@@ -15,13 +15,21 @@ driver:
       display-name: Paste your connection string
       placeholder: 'mongodb://[username:password@]host1[:port1][,...hostN[:portN]][/[dbname][?options]]'
       required: true
+      visible-if:
+        use-conn-uri: true
+    - merge:
+        - host
+        - visible-if:
+            use-conn-uri: false
+    - merge:
+        - dbname
+        - visible-if:
+            use-conn-uri: false
     - merge:
         - port
         - default: 27017
           visible-if:
             use-conn-uri: false
-    - host
-    - dbname
     - merge:
         - user
         - required: false

--- a/modules/drivers/mongo/resources/metabase-plugin.yaml
+++ b/modules/drivers/mongo/resources/metabase-plugin.yaml
@@ -7,8 +7,9 @@ driver:
   display-name: MongoDB
   lazy-load: true
   connection-properties:
-    - host
-    - dbname
+    - name: use-conn-uri
+      type: section
+      default: false
     - name: conn-uri
       type: string
       display-name: Paste your connection string
@@ -17,17 +18,30 @@ driver:
     - merge:
         - port
         - default: 27017
+          visible-if:
+            use-conn-uri: false
+    - host
+    - dbname
     - merge:
         - user
         - required: false
+          visible-if:
+            use-conn-uri: false
     - merge:
         - password
         - name: pass
+          visible-if:
+            use-conn-uri: false
     - name: authdb
       display-name: Authentication database (optional)
       placeholder: admin
+      visible-if:
+        use-conn-uri: false
     - cloud-ip-address-info
-    - ssl
+    - merge:
+        - ssl
+        - visible-if:
+            use-conn-uri: false
     - name: ssl-cert
       type: string
       display-name: Server SSL certificate chain (PEM)
@@ -56,10 +70,13 @@ driver:
         - additional-options
         - display-name: Additional connection string options (optional)
           placeholder: 'retryWrites=true&w=majority&authSource=admin&readPreference=nearest&replicaSet=test'
+          visible-if:
+            use-conn-uri: false
     - name: use-srv
       type: boolean
       default: false
       visible-if:
+        use-conn-uri: false
         advanced-options: true
     - default-advanced-options
 init:


### PR DESCRIPTION
Epic https://github.com/metabase/metabase/issues/26178

MongoDB form has its special connection string uri / fields toggle that was implemented in a very special way for the old db form. To avoid complexity, let's tweak the driver configuration to make it work like other drivers do:
- Add `use-conn-uri` section field for toggling field sections, like `advanced-options`
- Add `visible-if` rules to toggle fields in the form

How to test:
- `./bin/build-driver.sh mongo`
- `yarn dev`
- Copy `engines` setting field and paste it to `DatabaseForm.stories.tsx`
- Make sure the mongo db form works in the same way it does in the main app during setup

<img width="1492" alt="Screenshot 2022-11-30 at 15 02 36" src="https://user-images.githubusercontent.com/8542534/204803519-c028b3ba-55d9-4b0d-8e97-326a548f5719.png">
<img width="1488" alt="Screenshot 2022-11-30 at 15 02 49" src="https://user-images.githubusercontent.com/8542534/204803538-4142d72e-ada5-4a96-9db5-b5a03ea5d93d.png">
