### PR TITLE
Change hasBreakout check

### DIFF
--- a/frontend/src/metabase/query_builder/components/view/sidebars/ChartSettingsSidebar.jsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/ChartSettingsSidebar.jsx
@@ -21,6 +21,7 @@ export default class ChartSettingsSidebar extends React.Component {
       onReplaceAllVisualizationSettings,
       onClose,
       onOpenChartType,
+      visualizationSettings,
     } = this.props;
     const { sidebarPropsOverride } = this.state;
     return (
@@ -46,6 +47,7 @@ export default class ChartSettingsSidebar extends React.Component {
             noPreview
             initial={initialChartSetting}
             setSidebarPropsOverride={this.setSidebarPropsOverride}
+            computedSettings={visualizationSettings}
           />
         </SidebarContent>
       )

--- a/frontend/src/metabase/visualizations/components/ChartSettings.jsx
+++ b/frontend/src/metabase/visualizations/components/ChartSettings.jsx
@@ -206,10 +206,11 @@ class ChartSettings extends Component {
         },
       };
     } else if (currentWidget.props?.initialKey) {
-      const settings = this._getSettings();
-      const isBreakout = settings?.["graph.dimensions"]?.length > 1;
+      const hasBreakouts = series.some(
+        singleSeries => singleSeries.card?._breakoutColumn,
+      );
 
-      if (isBreakout) {
+      if (hasBreakouts) {
         return null;
       }
 

--- a/frontend/src/metabase/visualizations/components/ChartSettings.jsx
+++ b/frontend/src/metabase/visualizations/components/ChartSettings.jsx
@@ -133,6 +133,10 @@ class ChartSettings extends Component {
     );
   }
 
+  _getComputedSettings() {
+    return this.props.computedSettings || {};
+  }
+
   _getWidgets() {
     if (this.props.widgets) {
       return this.props.widgets;
@@ -188,6 +192,7 @@ class ChartSettings extends Component {
   getStyleWidget = () => {
     const widgets = this._getWidgets();
     const series = this._getTransformedSeries();
+    const settings = this._getComputedSettings();
     const { currentWidget } = this.state;
     const seriesSettingsWidget =
       currentWidget && widgets.find(widget => widget.id === "series_settings");
@@ -206,9 +211,7 @@ class ChartSettings extends Component {
         },
       };
     } else if (currentWidget.props?.initialKey) {
-      const hasBreakouts = series.some(
-        singleSeries => singleSeries.card?._breakoutColumn,
-      );
+      const hasBreakouts = settings["graph.dimensions"]?.length > 1;
 
       if (hasBreakouts) {
         return null;


### PR DESCRIPTION
Small change to how we check to see if a series is a "breakout series" for purposes of rendering the ChartSettings popover. Previously, if you were working with a new question with 2 dimensions and never explicitly reordered them, then our previous check of "are there 2 dimensions in viz settings" would fail because that check would only look at stored settings, which would lead to you clicking on the metric and being shown series settings. This change checks for the presence of the `_breakoutColumn` key in a `series.card`.

Before:
![image](https://user-images.githubusercontent.com/1328979/204812890-f5510731-3b71-4d85-89ee-82eeb4463edf.png)

After:
![image](https://user-images.githubusercontent.com/1328979/204812725-23348760-d167-4a7b-87ec-be011c0eb405.png)
