### PR TITLE
mongo: calculate now during query execution, not processing, for versions >=4.2

### DIFF
--- a/modules/drivers/mongo/src/metabase/driver/mongo.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo.clj
@@ -218,16 +218,17 @@
 
 (doseq [feature [:basic-aggregations
                  :nested-fields
-                 :native-parameters
-                 :now]]
+                 :native-parameters]]
   (defmethod driver/supports? [:mongo feature] [_ _] true))
 
-(defn- db-major-version
-  [db]
-  (some-> (get-in db [:details :version])
-          (str/split #"\.")
-          first
-          Integer/parseInt))
+(defn- db-version [db]
+  (get-in db [:details :version]))
+
+(defn- parse-version [version]
+  (map #(Integer/parseInt %) (str/split version #"\.")))
+
+(defn- db-major-version [db]
+  (some-> (db-version db) parse-version first))
 
 (defmethod driver/database-supports? [:mongo :expressions] [_ _ db]
   (let [version (db-major-version db)]
@@ -236,6 +237,12 @@
 (defmethod driver/database-supports? [:mongo :date-arithmetics] [_ _ db]
   (let [version (db-major-version db)]
     (and (some? version) (>= version 5))))
+
+(defmethod driver/database-supports? [:mongo :now]
+  ;; The $$NOW aggregation expression was introduced in version 4.2.
+  [_ _ db]
+  (let [version (some-> (db-version db) parse-version)]
+    (and (some? version) (>= (first version) 4) (>= (second version) 2))))
 
 (defmethod driver/mbql->native :mongo
   [_ query]

--- a/modules/drivers/mongo/src/metabase/driver/mongo.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo.clj
@@ -225,7 +225,9 @@
   (get-in db [:details :version]))
 
 (defn- parse-version [version]
-  (map #(Integer/parseInt %) (str/split version #"\.")))
+  (->> (str/split version #"\.")
+       (take 2)
+       (map #(Integer/parseInt %))))
 
 (defn- db-major-version [db]
   (some-> (db-version db) parse-version first))

--- a/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
@@ -455,6 +455,11 @@
       (throw (ex-info "Date arithmetic not supported in versions before 5"
                       {:database-version mongo-version})))))
 
+(defn- check-now-aggregation-expression-supported
+  "$$NOW is introduced in version 4.2"
+  []
+  (not (neg? (compare "4.2" (get-mongo-version)))))
+
 (defn- interval? [expr]
   (and (vector? expr) (= (first expr) :interval)))
 
@@ -501,7 +506,14 @@
 
 (defmethod ->rvalue :coalesce [[_ & args]] {"$ifNull" (mapv ->rvalue args)})
 
-(defmethod ->rvalue :now [[_]] "$$NOW")
+(defmethod ->rvalue :now
+  ;; $$NOW is introduced in version 4.2. If the version is less than 4.2, we return a hard-coded
+  ;; string with the current datetime based on the time when the query was processed.
+  ;; In this case, the compiled native query will not be accurate if the query is run at a different time.
+  [[_]]
+  (if (check-now-aggregation-expression-supported)
+    "$$NOW"
+    ($date-from-string (t/offset-date-time (t/zone-id (qp.timezone/results-timezone-id))))))
 
 (defmethod ->rvalue :datetime-add        [[_ inp amount unit]] (do
                                                                  (check-date-operations-supported)

--- a/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
@@ -504,7 +504,7 @@
 (defmethod ->rvalue :now [[_]]
   (if (driver/database-supports? :mongo :now (qp.store/database))
     "$$NOW"
-    (throw (ex-info "now is not supported for MongoDB versions before 4.2"
+    (throw (ex-info (tru "now is not supported for MongoDB versions before 4.2")
                     {:database-version (get-mongo-version)}))))
 
 (defmethod ->rvalue :datetime-add        [[_ inp amount unit]] (do

--- a/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
@@ -20,7 +20,6 @@
             [metabase.util.date-2 :as u.date]
             [metabase.util.i18n :refer [tru]]
             [metabase.util.schema :as su]
-            [monger.conversion :as m.conversion]
             [monger.operators :refer [$add $addToSet $and $avg $cond $dayOfMonth $dayOfWeek $dayOfYear $divide $eq
                                       $group $gt $gte $hour $limit $lt $lte $match $max $min $minute $mod $month
                                       $multiply $ne $not $or $project $regex $second $size $skip $sort $strcasecmp $subtract

--- a/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
@@ -20,6 +20,7 @@
             [metabase.util.date-2 :as u.date]
             [metabase.util.i18n :refer [tru]]
             [metabase.util.schema :as su]
+            [monger.conversion :as m.conversion]
             [monger.operators :refer [$add $addToSet $and $avg $cond $dayOfMonth $dayOfWeek $dayOfYear $divide $eq
                                       $group $gt $gte $hour $limit $lt $lte $match $max $min $minute $mod $month
                                       $multiply $ne $not $or $project $regex $second $size $skip $sort $strcasecmp $subtract
@@ -501,9 +502,7 @@
 
 (defmethod ->rvalue :coalesce [[_ & args]] {"$ifNull" (mapv ->rvalue args)})
 
-(defmethod ->rvalue :now
-  [[_]]
-  ($date-from-string (t/offset-date-time (t/zone-id (qp.timezone/results-timezone-id)))))
+(defmethod ->rvalue :now [[_]] "$$NOW")
 
 (defmethod ->rvalue :datetime-add        [[_ inp amount unit]] (do
                                                                  (check-date-operations-supported)


### PR DESCRIPTION
I'm aiming to merge this into the now-function PR: https://github.com/metabase/metabase/pull/26548

Previously I had implemented the now function for all versions of mongo by calculating the current timestamp in clojure during query processing, and converting that from a date string literal into a date type. A custom expression with `now` will compile to something like this in the native query:

Before:
```JSON
      "now_before_4.2": {
        "$dateFromString": {
          "dateString": "2022-11-30T17:18:44.541794Z" 
         }
       }
```

This isn't ideal because the “convert to native query” feature will hard-code the now time as the time when the query was converted.

But for versions from 4.2, we can use the [$$NOW aggregation expression](https://www.mongodb.com/docs/manual/reference/aggregation-variables/#mongodb-variable-variable.NOW) to calculate now at query execution time, rather than query processing time.

After this PR, a custom expression with `now` will compile to:
```JSON
      "now_from_4.2": "$$NOW"
```

**Update: we're not going to support `now` for versions <4.2, to avoid the problem mentioned above.** 