### PR TITLE
Extract sample DB to plugins directory on startup

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -572,7 +572,7 @@
    metabase.query-processor-test.expressions-test/calculate-bird-scarcity                                                    hooks.metabase.query-processor-test.expressions-test/calculate-bird-scarcity
    metabase.query-processor-test.filter-test/count-with-filter-clause                                                        hooks.metabase.test.data/$ids
    metabase.query-processor.middleware.cache-test/with-mock-cache                                                            hooks.common/with-two-bindings
-   metabase.sample-database-test/with-temp-sample-database-db                                                                hooks.common/with-one-binding
+   metabase.sample-data-test/with-temp-sample-database-db                                                                hooks.common/with-one-binding
    metabase.test.data.datasets/test-drivers                                                                                  hooks.common/do*
    metabase.test.data.users/with-group                                                                                       hooks.common/let-one-with-optional-value
    metabase.test.data/$ids                                                                                                   hooks.metabase.test.data/$ids

--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -572,7 +572,7 @@
    metabase.query-processor-test.expressions-test/calculate-bird-scarcity                                                    hooks.metabase.query-processor-test.expressions-test/calculate-bird-scarcity
    metabase.query-processor-test.filter-test/count-with-filter-clause                                                        hooks.metabase.test.data/$ids
    metabase.query-processor.middleware.cache-test/with-mock-cache                                                            hooks.common/with-two-bindings
-   metabase.sample-data-test/with-temp-sample-database-db                                                                hooks.common/with-one-binding
+   metabase.sample-data-test/with-temp-sample-database-db                                                                    hooks.common/with-one-binding
    metabase.test.data.datasets/test-drivers                                                                                  hooks.common/do*
    metabase.test.data.users/with-group                                                                                       hooks.common/let-one-with-optional-value
    metabase.test.data/$ids                                                                                                   hooks.metabase.test.data/$ids

--- a/src/metabase/plugins.clj
+++ b/src/metabase/plugins.clj
@@ -1,5 +1,6 @@
 (ns metabase.plugins
-  (:require [clojure.java.classpath :as classpath]
+  (:require [clojure.core.memoize :as memoize]
+            [clojure.java.classpath :as classpath]
             [clojure.java.io :as io]
             [clojure.string :as str]
             [clojure.tools.logging :as log]
@@ -17,33 +18,32 @@
   (or (env/env :mb-plugins-dir)
       (.getAbsolutePath (io/file "plugins"))))
 
-;; logic for determining plugins dir -- see below
-(defonce ^:private plugins-dir*
-  (delay
-    (let [filename (plugins-dir-filename)]
-      (try
-        ;; attempt to create <current-dir>/plugins if it doesn't already exist. Check that the directory is readable.
-        (let [path (u.files/get-path filename)]
-          (u.files/create-dir-if-not-exists! path)
+(def ^:private plugins-dir*
+  (memoize/memo
+   (fn [filename]
+    (try
+      ;; attempt to create <current-dir>/plugins if it doesn't already exist. Check that the directory is readable.
+      (let [path (u.files/get-path filename)]
+        (u.files/create-dir-if-not-exists! path)
+        (assert (Files/isWritable path)
+          (trs "Metabase does not have permissions to write to plugins directory {0}" filename))
+        {:path  path, :temp false})
+      ;; If we couldn't create the directory, or the directory is not writable, fall back to a temporary directory
+      ;; rather than failing to launch entirely. Log instructions for what should be done to fix the problem.
+      (catch Throwable e
+        (log/warn
+         e
+         (trs "Metabase cannot use the plugins directory {0}" filename)
+         "\n"
+         (trs "Please make sure the directory exists and that Metabase has permission to write to it.")
+         (trs "You can change the directory Metabase uses for modules by setting the environment variable MB_PLUGINS_DIR.")
+         (trs "Falling back to a temporary directory for now."))
+        ;; Check whether the fallback temporary directory is writable. If it's not, there's no way for us to
+        ;; gracefully proceed here. Throw an Exception detailing the critical issues.
+        (let [path (u.files/get-path (System/getProperty "java.io.tmpdir"))]
           (assert (Files/isWritable path)
-            (trs "Metabase does not have permissions to write to plugins directory {0}" filename))
-          {:path  path, :temp false})
-        ;; If we couldn't create the directory, or the directory is not writable, fall back to a temporary directory
-        ;; rather than failing to launch entirely. Log instructions for what should be done to fix the problem.
-        (catch Throwable e
-          (log/warn
-           e
-           (trs "Metabase cannot use the plugins directory {0}" filename)
-           "\n"
-           (trs "Please make sure the directory exists and that Metabase has permission to write to it.")
-           (trs "You can change the directory Metabase uses for modules by setting the environment variable MB_PLUGINS_DIR.")
-           (trs "Falling back to a temporary directory for now."))
-          ;; Check whether the fallback temporary directory is writable. If it's not, there's no way for us to
-          ;; gracefully proceed here. Throw an Exception detailing the critical issues.
-          (let [path (u.files/get-path (System/getProperty "java.io.tmpdir"))]
-            (assert (Files/isWritable path)
-              (trs "Metabase cannot write to temporary directory. Please set MB_PLUGINS_DIR to a writable directory and restart Metabase."))
-            {:path path, :temp true}))))))
+            (trs "Metabase cannot write to temporary directory. Please set MB_PLUGINS_DIR to a writable directory and restart Metabase."))
+          {:path path, :temp true}))))))
 
 ;; Actual logic is wrapped in a delay rather than a normal function so we don't log the error messages more than once
 ;; in cases where we have to fall back to the system temporary directory
@@ -51,7 +51,7 @@
   "Map with a :path key containing the `Path` to the Metabase plugins directory, and a :temp key indicating whether a
   temporary directory was used."
   ^Path []
-  @plugins-dir*)
+  (plugins-dir* (plugins-dir-filename)))
 
 (defn plugins-dir
   "Get a `Path` to the Metabase plugins directory, creating it if needed. If it cannot be created for one reason or

--- a/src/metabase/plugins.clj
+++ b/src/metabase/plugins.clj
@@ -21,29 +21,29 @@
 (def ^:private plugins-dir*
   (memoize/memo
    (fn [filename]
-    (try
-      ;; attempt to create <current-dir>/plugins if it doesn't already exist. Check that the directory is readable.
-      (let [path (u.files/get-path filename)]
-        (u.files/create-dir-if-not-exists! path)
-        (assert (Files/isWritable path)
-          (trs "Metabase does not have permissions to write to plugins directory {0}" filename))
-        {:path  path, :temp false})
-      ;; If we couldn't create the directory, or the directory is not writable, fall back to a temporary directory
-      ;; rather than failing to launch entirely. Log instructions for what should be done to fix the problem.
-      (catch Throwable e
-        (log/warn
-         e
-         (trs "Metabase cannot use the plugins directory {0}" filename)
-         "\n"
-         (trs "Please make sure the directory exists and that Metabase has permission to write to it.")
-         (trs "You can change the directory Metabase uses for modules by setting the environment variable MB_PLUGINS_DIR.")
-         (trs "Falling back to a temporary directory for now."))
-        ;; Check whether the fallback temporary directory is writable. If it's not, there's no way for us to
-        ;; gracefully proceed here. Throw an Exception detailing the critical issues.
-        (let [path (u.files/get-path (System/getProperty "java.io.tmpdir"))]
-          (assert (Files/isWritable path)
-            (trs "Metabase cannot write to temporary directory. Please set MB_PLUGINS_DIR to a writable directory and restart Metabase."))
-          {:path path, :temp true}))))))
+     (try
+       ;; attempt to create <current-dir>/plugins if it doesn't already exist. Check that the directory is readable.
+       (let [path (u.files/get-path filename)]
+         (u.files/create-dir-if-not-exists! path)
+         (assert (Files/isWritable path)
+           (trs "Metabase does not have permissions to write to plugins directory {0}" filename))
+         {:path  path, :temp false})
+       ;; If we couldn't create the directory, or the directory is not writable, fall back to a temporary directory
+       ;; rather than failing to launch entirely. Log instructions for what should be done to fix the problem.
+       (catch Throwable e
+         (log/warn
+          e
+          (trs "Metabase cannot use the plugins directory {0}" filename)
+          "\n"
+          (trs "Please make sure the directory exists and that Metabase has permission to write to it.")
+          (trs "You can change the directory Metabase uses for modules by setting the environment variable MB_PLUGINS_DIR.")
+          (trs "Falling back to a temporary directory for now."))
+         ;; Check whether the fallback temporary directory is writable. If it's not, there's no way for us to
+         ;; gracefully proceed here. Throw an Exception detailing the critical issues.
+         (let [path (u.files/get-path (System/getProperty "java.io.tmpdir"))]
+           (assert (Files/isWritable path)
+             (trs "Metabase cannot write to temporary directory. Please set MB_PLUGINS_DIR to a writable directory and restart Metabase."))
+           {:path path, :temp true}))))))
 
 ;; Actual logic is wrapped in a delay rather than a normal function so we don't log the error messages more than once
 ;; in cases where we have to fall back to the system temporary directory

--- a/src/metabase/plugins.clj
+++ b/src/metabase/plugins.clj
@@ -19,6 +19,7 @@
       (.getAbsolutePath (io/file "plugins"))))
 
 (def ^:private plugins-dir*
+  ;; Memoized so we don't log the error messages multiple times if the plugins directory doesn't change
   (memoize/memo
    (fn [filename]
      (try
@@ -45,8 +46,6 @@
              (trs "Metabase cannot write to temporary directory. Please set MB_PLUGINS_DIR to a writable directory and restart Metabase."))
            {:path path, :temp true}))))))
 
-;; Actual logic is wrapped in a delay rather than a normal function so we don't log the error messages more than once
-;; in cases where we have to fall back to the system temporary directory
 (defn plugins-dir-info
   "Map with a :path key containing the `Path` to the Metabase plugins directory, and a :temp key indicating whether a
   temporary directory was used."

--- a/src/metabase/plugins.clj
+++ b/src/metabase/plugins.clj
@@ -47,7 +47,7 @@
 
 ;; Actual logic is wrapped in a delay rather than a normal function so we don't log the error messages more than once
 ;; in cases where we have to fall back to the system temporary directory
-(defn- plugins-dir
+(defn plugins-dir
   "Get a `Path` to the Metabase plugins directory, creating it if needed. If it cannot be created for one reason or
   another, or if we do not have write permissions for it, use a temporary directory instead."
   ^Path []

--- a/src/metabase/sample_data.clj
+++ b/src/metabase/sample_data.clj
@@ -45,20 +45,20 @@
 
 (defn- db-details
   "Tries to extract the sample database out of the JAR (for performance) and then returns a db-details map
-   containing a connection string."
+   containing a path to the copied database."
   []
   (let [resource (io/resource sample-database-filename)]
     (when-not resource
       (throw (Exception. (trs "Sample database DB file ''{0}'' cannot be found."
                               sample-database-filename))))
     {:db
-      (if-not (:temp plugins/plugins-dir-info)
-        (do
-         (extract-sample-database!)
-         (extracted-db-details))
-        (do
-         (log/warn (trs (str "Sample database could not be extracted to the plugins directory; this may result in slow startup times.")))
-         (jar-db-details resource)))}))
+     (if-not (:temp (plugins/plugins-dir-info))
+       (do
+        (extract-sample-database!)
+        (extracted-db-details))
+       (do
+        (log/warn (trs (str "Sample database could not be extracted to the plugins directory; this may result in slow startup times.")))
+        (jar-db-details resource)))}))
 
 (defn add-sample-database!
   "Add the sample database as a Metabase DB if it doesn't already exist."

--- a/src/metabase/sample_data.clj
+++ b/src/metabase/sample_data.clj
@@ -35,7 +35,8 @@
 (defn- jar-db-details
   [resource]
   (-> (.getPath ^URL resource)
-      (str/replace #"^file:" "zip:") ; to connect to an H2 DB inside a JAR just replace file: with zip: (this doesn't do anything when running from the Clojure CLI, which has no `file:` prefix)
+      (str/replace #"^file:" "zip:") ; to connect to an H2 DB inside a JAR just replace file: with zip: (this doesn't
+                                     ;   do anything when running from the Clojure CLI, which has no `file:` prefix
       process-sample-db-path))
 
 (defn- extracted-db-details
@@ -57,7 +58,11 @@
         (extract-sample-database!)
         (extracted-db-details))
        (do
-        (log/warn (trs (str "Sample database could not be extracted to the plugins directory; this may result in slow startup times.")))
+         ;; If the plugins directory is a temp directory, fall back to reading the DB directly from the JAR until a
+         ;; working plugins directory is available. (We want to ensure the sample DB is in a stable location.)
+         (log/warn (trs (str "Sample database could not be extracted to the plugins directory,"
+                             "which may result in slow startup times. "
+                             "Please set MB_PLUGINS_DIR to a writable directory and restart Metabase.")))
         (jar-db-details resource)))}))
 
 (defn add-sample-database!

--- a/src/metabase/sample_data.clj
+++ b/src/metabase/sample_data.clj
@@ -3,23 +3,46 @@
             [clojure.string :as str]
             [clojure.tools.logging :as log]
             [metabase.models.database :refer [Database]]
+            [metabase.plugins :as plugins]
             [metabase.sync :as sync]
+            [metabase.util.files :as u.files]
             [metabase.util.i18n :refer [trs]]
             [toucan.db :as db]))
 
 (def ^:private ^String sample-database-name     "Sample Database")
 (def ^:private ^String sample-database-filename "sample-database.db.mv.db")
 
+;; Reuse the plugins directory for the destination to extract the sample database because it's pretty much guaranteed
+;; to exist and be writable.
+(def ^:private target-path (u.files/append-to-path (plugins/plugins-dir) sample-database-filename))
+
+(defn- extract-sample-database!
+  []
+  (u.files/with-open-path-to-resource [sample-db-path sample-database-filename]
+    (u.files/copy-file! sample-db-path target-path)))
+
+(defn- jar-db-details
+  [resource]
+  (-> (.getPath resource)
+      (str/replace #"^file:" "zip:") ; to connect to an H2 DB inside a JAR just replace file: with zip: (this doesn't do anything when running from the Clojure CLI, which has no `file:` prefix)
+      (str/replace #"\.mv\.db$" "")  ; strip the .mv.db suffix from the path
+      (str/replace #"%20" " ") ; for some reason the path can get URL-encoded and replace spaces with `%20`; this breaks things so switch them back to spaces
+      (str ";USER=GUEST;PASSWORD=guest")))
+
 (defn- db-details []
   (let [resource (io/resource sample-database-filename)]
     (when-not resource
       (throw (Exception. (trs "Sample database DB file ''{0}'' cannot be found."
                               sample-database-filename))))
-    {:db (-> (.getPath resource)
-             (str/replace #"^file:" "zip:") ; to connect to an H2 DB inside a JAR just replace file: with zip: (this doesn't do anything when running from the Clojure CLI, which has no `file:` prefix)
-             (str/replace #"\.mv\.db$" "")  ; strip the .mv.db suffix from the path
-             (str/replace #"%20" " ") ; for some reason the path can get URL-encoded and replace spaces with `%20`; this breaks things so switch them back to spaces
-             (str ";USER=GUEST;PASSWORD=guest"))})) ; specify the GUEST user account created for the DB
+    {:db
+     (try
+       (extract-sample-database!)
+       (-> (str "file:" (u.files/append-to-path (plugins/plugins-dir) sample-database-filename))
+           (str/replace #"\.mv\.db$" "")  ; strip the .mv.db suffix from the path
+           (str/replace #"%20" " ") ; for some reason the path can get URL-encoded and replace spaces with `%20`; this breaks things so switch them back to spaces
+           (str ";USER=GUEST;PASSWORD=guest"))
+       (catch Exception _
+        (jar-db-details resource)))})) ; specify the GUEST user account created for the DB
 
 (defn add-sample-database!
   "Add the sample database as a Metabase DB if it doesn't already exist."

--- a/src/metabase/sample_data.clj
+++ b/src/metabase/sample_data.clj
@@ -7,7 +7,8 @@
             [metabase.sync :as sync]
             [metabase.util.files :as u.files]
             [metabase.util.i18n :refer [trs]]
-            [toucan.db :as db]))
+            [toucan.db :as db])
+  (:import java.net.URL))
 
 (def ^:private ^String sample-database-name     "Sample Database")
 (def ^:private ^String sample-database-filename "sample-database.db.mv.db")
@@ -33,7 +34,7 @@
 
 (defn- jar-db-details
   [resource]
-  (-> (.getPath resource)
+  (-> (.getPath ^URL resource)
       (str/replace #"^file:" "zip:") ; to connect to an H2 DB inside a JAR just replace file: with zip: (this doesn't do anything when running from the Clojure CLI, which has no `file:` prefix)
       process-sample-db-path))
 

--- a/src/metabase/sample_data.clj
+++ b/src/metabase/sample_data.clj
@@ -76,8 +76,11 @@
 
 (defn update-sample-database-if-needed!
   "Update the path to the sample database DB if it exists in case the JAR has moved."
-  []
-  (when-let [sample-db (db/select-one Database :is_sample true)]
-    (let [intended (db-details)]
-      (when (not= (:details sample-db) intended)
-        (db/update! Database (:id sample-db) :details intended)))))
+  ([]
+   (update-sample-database-if-needed! (db/select-one Database :is_sample true)))
+
+  ([sample-db]
+   (when sample-db
+     (let [intended (db-details)]
+       (when (not= (:details sample-db) intended)
+         (db/update! Database (:id sample-db) :details intended))))))

--- a/src/metabase/sample_data.clj
+++ b/src/metabase/sample_data.clj
@@ -7,6 +7,7 @@
             [metabase.sync :as sync]
             [metabase.util.files :as u.files]
             [metabase.util.i18n :refer [trs]]
+            [ring.util.codec :as codec]
             [toucan.db :as db])
   (:import java.net.URL))
 
@@ -19,30 +20,27 @@
   []
   (u.files/append-to-path (plugins/plugins-dir) sample-database-filename))
 
-(defn- extract-sample-database!
-  []
-  (u.files/with-open-path-to-resource [sample-db-path sample-database-filename]
-    (u.files/copy-file! sample-db-path (target-path))))
-
 (defn- process-sample-db-path
   [base-path]
   (-> base-path
       (str/replace #"\.mv\.db$" "")        ; strip the .mv.db suffix from the path
-      (str/replace #"%20" " ")             ; for some reason the path can get URL-encoded and replace spaces with `%20`;
-                                           ;   this breaks things so switch them back to spaces
+      codec/url-decode                     ; for some reason the path can get URL-encoded so we decode it here
       (str ";USER=GUEST;PASSWORD=guest"))) ; specify the GUEST user account created for the DB
 
 (defn- jar-db-details
-  [resource]
-  (-> (.getPath ^URL resource)
+  [^URL resource]
+  (-> (.getPath resource)
       (str/replace #"^file:" "zip:") ; to connect to an H2 DB inside a JAR just replace file: with zip: (this doesn't
-                                     ;   do anything when running from the Clojure CLI, which has no `file:` prefix
+                                     ;   do anything when running from the Clojure CLI, which has no `file:` prefix)
       process-sample-db-path))
 
-(defn- extracted-db-details
+(defn- extract-sample-database!
   []
-  (-> (str "file:" (plugins/plugins-dir) "/" sample-database-filename)
-      process-sample-db-path))
+  (u.files/with-open-path-to-resource [sample-db-path sample-database-filename]
+    (let [dest-path (target-path)]
+      (u.files/copy-file! sample-db-path dest-path)
+      (-> (str "file:" dest-path)
+          process-sample-db-path))))
 
 (defn- try-to-extract-sample-database!
   "Tries to extract the sample database out of the JAR (for performance) and then returns a db-details map
@@ -54,16 +52,14 @@
                               sample-database-filename))))
     {:db
      (if-not (:temp (plugins/plugins-dir-info))
-       (do
-        (extract-sample-database!)
-        (extracted-db-details))
+       (extract-sample-database!)
        (do
          ;; If the plugins directory is a temp directory, fall back to reading the DB directly from the JAR until a
          ;; working plugins directory is available. (We want to ensure the sample DB is in a stable location.)
          (log/warn (trs (str "Sample database could not be extracted to the plugins directory,"
                              "which may result in slow startup times. "
                              "Please set MB_PLUGINS_DIR to a writable directory and restart Metabase.")))
-        (jar-db-details resource)))}))
+         (jar-db-details resource)))}))
 
 (defn add-sample-database!
   "Add the sample database as a Metabase DB if it doesn't already exist."

--- a/src/metabase/util/files.clj
+++ b/src/metabase/util/files.clj
@@ -29,7 +29,9 @@
   ^Path [& path-components]
   (apply get-path-in-filesystem (FileSystems/getDefault) path-components))
 
-(defn- append-to-path ^Path [^Path path & components]
+(defn append-to-path
+  "Appends string `components` to the end of a Path, returning a new Path."
+  ^Path [^Path path & components]
   (loop [^Path path path, [^String component & more] components]
     (let [path (.resolve path component)]
       (if-not (seq more)
@@ -106,7 +108,7 @@
 
 (defn do-with-open-path-to-resource
   "Impl for `with-open-path-to-resource`."
-  [^String resource, f]
+  [^String resource f]
   (let [url (io/resource resource)]
     (when-not url
       (throw (FileNotFoundException. (trs "Resource does not exist."))))

--- a/test/metabase/sample_data_test.clj
+++ b/test/metabase/sample_data_test.clj
@@ -44,7 +44,7 @@
 
 ;;; ----------------------------------------------------- Tests ------------------------------------------------------
 
-(def ^:private extracted-db-path-regex #"^file:[a-zA-z/]*plugins/sample-database.db;USER=GUEST;PASSWORD=guest$")
+(def ^:private extracted-db-path-regex #"^file:.*plugins/sample-database.db;USER=GUEST;PASSWORD=guest$")
 
 (deftest extract-sample-database-test
   (testing "The Sample Database is copied out of the JAR into the plugins directory before the DB details are saved."

--- a/test/metabase/sample_data_test.clj
+++ b/test/metabase/sample_data_test.clj
@@ -18,7 +18,7 @@
 ;; These tools are pretty sophisticated for the amount of tests we have!
 
 (defn- sample-database-db []
-  {:details (#'sample-data/db-details)
+  {:details (#'sample-data/try-to-extract-sample-database!)
    :engine  :h2
    :name    "Sample Database"})
 


### PR DESCRIPTION
Second go at fixing the slow startup times due to sample database sync. It seems that the slowdown has to do with reading directly from the database file in the JAR, so this PR copies it into the `plugins/` directory (which is supposed to be a stable, writable location) on startup.

Fixes https://github.com/metabase/metabase/issues/26648