### PR TITLE
Renaming funnel order settings names

### DIFF
--- a/frontend/src/metabase/visualizations/components/FunnelNormal.jsx
+++ b/frontend/src/metabase/visualizations/components/FunnelNormal.jsx
@@ -27,8 +27,8 @@ export default class FunnelNormal extends Component {
     const dimensionIndex = 0;
     const metricIndex = 1;
     const cols = series[0].data.cols;
-    const rows = settings["funnel.rows"]
-      ? settings["funnel.rows"]
+    const rows = settings["funnel.series_order"]
+      ? settings["funnel.series_order"]
           .filter(fr => fr.enabled)
           .map(fr => findSeriesByKey(series, fr.key).data.rows[0])
       : series.map(s => s.data.rows[0]);

--- a/frontend/src/metabase/visualizations/components/FunnelNormal.jsx
+++ b/frontend/src/metabase/visualizations/components/FunnelNormal.jsx
@@ -27,8 +27,8 @@ export default class FunnelNormal extends Component {
     const dimensionIndex = 0;
     const metricIndex = 1;
     const cols = series[0].data.cols;
-    const rows = settings["funnel.series_order"]
-      ? settings["funnel.series_order"]
+    const rows = settings["funnel.rows_order"]
+      ? settings["funnel.rows_order"]
           .filter(fr => fr.enabled)
           .map(fr => findSeriesByKey(series, fr.key).data.rows[0])
       : series.map(s => s.data.rows[0]);

--- a/frontend/src/metabase/visualizations/visualizations/Funnel.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Funnel.jsx
@@ -111,18 +111,18 @@ export default class Funnel extends Component {
       showColumnSetting: true,
       marginBottom: "0.625rem",
     }),
-    "funnel.order_dimension": {
+    "funnel.series_order_dimension": {
       getValue: (_series, settings) => settings["funnel.dimension"],
-      readDependencies: ["funnel.rows"],
+      readDependencies: ["funnel.series_order"],
     },
-    "funnel.rows": {
+    "funnel.series_order": {
       section: t`Data`,
       widget: ChartSettingOrderedSimple,
 
       getValue: (series, settings) => {
-        const seriesOrder = settings["funnel.rows"];
+        const seriesOrder = settings["funnel.series_order"];
         const seriesKeys = series.map(s => keyForSingleSeries(s));
-        const orderDimension = settings["funnel.order_dimension"];
+        const orderDimension = settings["funnel.series_order_dimension"];
         const dimension = settings["funnel.dimension"];
 
         const getDefault = keys =>
@@ -156,7 +156,7 @@ export default class Funnel extends Component {
       getHidden: (series, settings) =>
         settings["funnel.dimension"] === null ||
         settings["funnel.metric"] === null,
-      writeDependencies: ["funnel.order_dimension"],
+      writeDependencies: ["funnel.series_order_dimension"],
       dataTestId: "funnel-row-sort",
     },
     ...metricSetting("funnel.metric", {

--- a/frontend/src/metabase/visualizations/visualizations/Funnel.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Funnel.jsx
@@ -111,18 +111,18 @@ export default class Funnel extends Component {
       showColumnSetting: true,
       marginBottom: "0.625rem",
     }),
-    "funnel.series_order_dimension": {
+    "funnel.rows_order_dimension": {
       getValue: (_series, settings) => settings["funnel.dimension"],
-      readDependencies: ["funnel.series_order"],
+      readDependencies: ["funnel.rows_order"],
     },
-    "funnel.series_order": {
+    "funnel.rows_order": {
       section: t`Data`,
       widget: ChartSettingOrderedSimple,
 
       getValue: (series, settings) => {
-        const seriesOrder = settings["funnel.series_order"];
+        const seriesOrder = settings["funnel.rows_order"];
         const seriesKeys = series.map(s => keyForSingleSeries(s));
-        const orderDimension = settings["funnel.series_order_dimension"];
+        const orderDimension = settings["funnel.rows_order_dimension"];
         const dimension = settings["funnel.dimension"];
 
         const getDefault = keys =>
@@ -156,7 +156,7 @@ export default class Funnel extends Component {
       getHidden: (series, settings) =>
         settings["funnel.dimension"] === null ||
         settings["funnel.metric"] === null,
-      writeDependencies: ["funnel.series_order_dimension"],
+      writeDependencies: ["funnel.rows_order_dimension"],
       dataTestId: "funnel-row-sort",
     },
     ...metricSetting("funnel.metric", {


### PR DESCRIPTION
PR to change the names of the viz settings used for computing series order in funnel visualizations to match what we use for Line/Area/Bar charts.