### PR TITLE
Fixes remapped columns support for the row chart type

### DIFF
--- a/frontend/src/metabase-types/api/dataset.ts
+++ b/frontend/src/metabase-types/api/dataset.ts
@@ -13,12 +13,15 @@ export interface DatasetColumn {
   display_name: string;
   source: string;
   name: string;
+  // FIXME: this prop does not come from API
   remapped_to_column?: DatasetColumn;
   unit?: DatetimeUnit;
   field_ref?: DimensionReference;
   expression_name?: any;
   base_type?: string;
   semantic_type?: string;
+  remapped_from?: string;
+  remapped_to?: string;
   binning_info?: {
     bin_width?: number;
   };

--- a/frontend/src/metabase/static-viz/components/RowChart/RowChart.tsx
+++ b/frontend/src/metabase/static-viz/components/RowChart/RowChart.tsx
@@ -26,6 +26,7 @@ import {
   getLabelsStaticFormatter,
   getStaticFormatters,
 } from "metabase/static-viz/lib/format";
+import { extractRemappedColumns } from "metabase/visualizations";
 import { calculateLegendRows } from "../Legend/utils";
 import { Legend } from "../Legend";
 
@@ -56,15 +57,16 @@ const staticTextMeasurer: TextMeasurer = (text: string, style: FontStyle) =>
   );
 
 const StaticRowChart = ({ data, settings, getColor }: StaticRowChartProps) => {
+  const remappedColumnsData = extractRemappedColumns(data);
   const columnValueFormatter = getColumnValueStaticFormatter();
 
   const { chartColumns, series, seriesColors } = getTwoDimensionalChartSeries(
-    data,
+    remappedColumnsData,
     settings,
     columnValueFormatter,
   );
   const groupedData = getGroupedDataset(
-    data.rows,
+    remappedColumnsData.rows,
     chartColumns,
     columnValueFormatter,
   );

--- a/frontend/src/metabase/static-viz/components/RowChart/RowChart.tsx
+++ b/frontend/src/metabase/static-viz/components/RowChart/RowChart.tsx
@@ -14,7 +14,10 @@ import {
 import { getChartGoal } from "metabase/visualizations/lib/settings/goal";
 import { VisualizationSettings } from "metabase-types/api";
 import { ColorGetter } from "metabase/static-viz/lib/colors";
-import { TwoDimensionalChartData } from "metabase/visualizations/shared/types/data";
+import {
+  RemappingHydratedChartData,
+  TwoDimensionalChartData,
+} from "metabase/visualizations/shared/types/data";
 import { getTwoDimensionalChartSeries } from "metabase/visualizations/shared/utils/series";
 import {
   getAxesVisibility,
@@ -57,7 +60,9 @@ const staticTextMeasurer: TextMeasurer = (text: string, style: FontStyle) =>
   );
 
 const StaticRowChart = ({ data, settings, getColor }: StaticRowChartProps) => {
-  const remappedColumnsData = extractRemappedColumns(data);
+  const remappedColumnsData = extractRemappedColumns(
+    data,
+  ) as RemappingHydratedChartData;
   const columnValueFormatter = getColumnValueStaticFormatter();
 
   const { chartColumns, series, seriesColors } = getTwoDimensionalChartSeries(

--- a/frontend/src/metabase/static-viz/lib/format.ts
+++ b/frontend/src/metabase/static-viz/lib/format.ts
@@ -20,6 +20,7 @@ import {
 import { ChartColumns } from "metabase/visualizations/lib/graph/columns";
 import { getStackOffset } from "metabase/visualizations/lib/settings/stacking";
 import { getLabelsMetricColumn } from "metabase/visualizations/shared/utils/series";
+import { RemappingHydratedDatasetColumn } from "metabase/visualizations/shared/types/data";
 import {
   isCoordinate,
   isDate,
@@ -29,6 +30,17 @@ import {
 } from "metabase-lib/types/utils/isa";
 import { rangeForValue } from "metabase-lib/queries/utils/range-for-value";
 import { getColumnKey } from "metabase-lib/queries/utils/get-column-key";
+
+const getRemappedValue = (
+  value: unknown,
+  column: RemappingHydratedDatasetColumn,
+) => {
+  if (column.remapping instanceof Map && column.remapping.has(value)) {
+    return column.remapping.get(value);
+  }
+
+  return value;
+};
 
 type StaticFormattingOptions = {
   column: DatasetColumn;
@@ -109,9 +121,10 @@ export const getStaticFormatters = (
   const yTickFormatter = (value: StringLike) => {
     const column = chartColumns.dimension.column;
     const columnSettings = settings.column_settings?.[getColumnKey(column)];
+    const valueToFormat = getRemappedValue(value, column);
 
     return String(
-      formatStaticValue(value, {
+      formatStaticValue(valueToFormat, {
         column,
         ...columnSettings,
         jsx: false,
@@ -140,9 +153,10 @@ export const getStaticFormatters = (
   const xTickFormatter = (value: NumberLike) => {
     const column = metricColumn.column;
     const columnSettings = settings.column_settings?.[getColumnKey(column)];
+    const valueToFormat = getRemappedValue(value, column);
 
     return String(
-      formatStaticValue(value, {
+      formatStaticValue(valueToFormat, {
         column,
         ...columnSettings,
         jsx: false,
@@ -181,6 +195,8 @@ export const getLabelsStaticFormatter = (
 };
 
 export const getColumnValueStaticFormatter = () => {
-  return (value: RowValue, column: DatasetColumn) =>
-    String(formatStaticValue(value, { column }));
+  return (value: RowValue, column: DatasetColumn) => {
+    const valueToFormat = getRemappedValue(value, column);
+    return String(formatStaticValue(valueToFormat, { column }));
+  };
 };

--- a/frontend/src/metabase/visualizations/index.js
+++ b/frontend/src/metabase/visualizations/index.js
@@ -106,7 +106,7 @@ export function getMaxDimensionsSupported(display) {
 }
 
 // removes columns with `remapped_from` property and adds a `remapping` to the appropriate column
-const extractRemappedColumns = data => {
+export const extractRemappedColumns = data => {
   const cols = data.cols.map(col => ({
     ...col,
     remapped_from_index:

--- a/frontend/src/metabase/visualizations/lib/graph/columns.ts
+++ b/frontend/src/metabase/visualizations/lib/graph/columns.ts
@@ -1,19 +1,18 @@
-import {
-  DatasetColumn,
-  DatasetData,
-  VisualizationSettings,
-} from "metabase-types/api";
+import { DatasetData, VisualizationSettings } from "metabase-types/api";
 import { isNotNull } from "metabase/core/utils/types";
-import { TwoDimensionalChartData } from "metabase/visualizations/shared/types/data";
+import {
+  RemappingHydratedChartData,
+  RemappingHydratedDatasetColumn,
+} from "metabase/visualizations/shared/types/data";
 
 export type ColumnDescriptor = {
   index: number;
-  column: DatasetColumn;
+  column: RemappingHydratedDatasetColumn;
 };
 
 export const getColumnDescriptors = (
   columnNames: string[],
-  columns: DatasetColumn[],
+  columns: RemappingHydratedDatasetColumn[],
 ): ColumnDescriptor[] => {
   return columnNames.map(columnName => {
     const index = columns.findIndex(column => column.name === columnName);
@@ -58,7 +57,7 @@ export type MultipleMetricsChartColumns = {
 export type ChartColumns = BreakoutChartColumns | MultipleMetricsChartColumns;
 
 export const getChartColumns = (
-  data: TwoDimensionalChartData,
+  data: RemappingHydratedChartData,
   visualizationSettings: VisualizationSettings,
 ): ChartColumns => {
   const [dimension, breakout] = getColumnDescriptors(

--- a/frontend/src/metabase/visualizations/shared/types/data.ts
+++ b/frontend/src/metabase/visualizations/shared/types/data.ts
@@ -7,6 +7,17 @@ import {
 
 export type TwoDimensionalChartData = Pick<DatasetData, "rows" | "cols">;
 
+export type RemappingHydratedDatasetColumn = DatasetColumn & {
+  remapped_from_index?: number;
+  remapped_to_column?: DatasetColumn;
+  remapping?: Map<any, any>;
+};
+
+export type RemappingHydratedChartData = {
+  rows: DatasetData["rows"];
+  cols: RemappingHydratedDatasetColumn[];
+};
+
 export type SeriesInfo = {
   metricColumn: DatasetColumn;
   dimensionColumn: DatasetColumn;

--- a/frontend/src/metabase/visualizations/visualizations/RowChart/RowChart.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/RowChart/RowChart.tsx
@@ -33,6 +33,7 @@ import { getTwoDimensionalChartSeries } from "metabase/visualizations/shared/uti
 import { getStackOffset } from "metabase/visualizations/lib/settings/stacking";
 import {
   GroupedDatum,
+  RemappingHydratedChartData,
   SeriesInfo,
 } from "metabase/visualizations/shared/types/data";
 import { IconProps } from "metabase/components/Icon";
@@ -125,8 +126,10 @@ const RowChartVisualization = ({
   const [chartSeries] = useMemo(() => {
     return isPlaceholder ? multipleSeries : rawMultipleSeries;
   }, [isPlaceholder, multipleSeries, rawMultipleSeries]);
+
   const data = useMemo(
-    () => extractRemappedColumns(chartSeries.data),
+    () =>
+      extractRemappedColumns(chartSeries.data) as RemappingHydratedChartData,
     [chartSeries.data],
   );
 

--- a/frontend/src/metabase/visualizations/visualizations/RowChart/RowChart.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/RowChart/RowChart.tsx
@@ -43,6 +43,7 @@ import {
 } from "metabase/visualizations/lib/settings/validation";
 import { BarData } from "metabase/visualizations/shared/components/RowChart/types";
 import { FontStyle } from "metabase/visualizations/shared/types/measure-text";
+import { extractRemappedColumns } from "metabase/visualizations";
 import { isDimension, isMetric } from "metabase-lib/types/utils/isa";
 import { getChartWarnings } from "./utils/warnings";
 import {
@@ -124,7 +125,10 @@ const RowChartVisualization = ({
   const [chartSeries] = useMemo(() => {
     return isPlaceholder ? multipleSeries : rawMultipleSeries;
   }, [isPlaceholder, multipleSeries, rawMultipleSeries]);
-  const data = chartSeries.data;
+  const data = useMemo(
+    () => extractRemappedColumns(chartSeries.data),
+    [chartSeries.data],
+  );
 
   const { chartColumns, series, seriesColors } = useMemo(
     () => getTwoDimensionalChartSeries(data, settings, formatColumnValue),


### PR DESCRIPTION
## Changes

Fixes row chart did not use remapped column values.

## How to verify

1) Go to Admin -> Data model -> Orders
2) Find the "Product Id" column, click on a cog icon, and set Display values: Use foreign key -> Title
3) New -> Question -> Orders
4) Summarize by Product Id under the Orders table
5) Select the Row chart viz type, with Y-axis: Product Id, and X-axis: Count
    5.1) Ensure it Y-axis values show product titles instead of product ids
6) Save the question, add it on a dashboard, save the dashboard
7) Send a test email subscription and open the static chart you've received
    7.1) Ensure it Y-axis values show product titles instead of product ids

## Screenshots

#### Before

<img width="621" alt="Screen Shot 2022-11-30 at 9 31 15 PM" src="https://user-images.githubusercontent.com/14301985/204937796-cbf4a824-f7cb-421e-8f40-304ee9b88100.png">

#### After

<img width="636" alt="Screen Shot 2022-11-30 at 9 31 03 PM" src="https://user-images.githubusercontent.com/14301985/204937801-6d0d6012-4c44-455e-b161-82638ce99ae9.png">