### PR TITLE
Fix sticky filters in embed mode

### DIFF
--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.jsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.jsx
@@ -130,6 +130,7 @@ class Dashboard extends Component {
   componentDidUpdate(prevProps) {
     if (prevProps.dashboardId !== this.props.dashboardId) {
       this.loadDashboard(this.props.dashboardId);
+      this.throttleParameterWidgetStickiness();
     } else if (
       !_.isEqual(prevProps.parameterValues, this.props.parameterValues) ||
       (!prevProps.dashboard && this.props.dashboard)

--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.styled.jsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.styled.jsx
@@ -130,7 +130,6 @@ export const ParametersWidgetContainer = styled(FullWidthContainer)`
   ${({ isSticky, isNavbarOpen }) =>
     isSticky &&
     isNavbarOpen &&
-    !IFRAMED &&
     css`
       left: ${parseInt(NAV_SIDEBAR_WIDTH) + 1 + "px"};
       width: calc(100% - ${NAV_SIDEBAR_WIDTH});


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/26229
Fixes https://github.com/metabase/metabase/issues/26230

How to test:
- Set `IFRAMED` to `true` in `dom.js` for #26229
- Follow the steps from the issue