### PR TITLE
Remove `is_write` card property on the FE

### DIFF
--- a/frontend/src/metabase-lib/Question.ts
+++ b/frontend/src/metabase-lib/Question.ts
@@ -272,7 +272,7 @@ class QuestionInner {
   }
 
   isAction() {
-    return this._card && this._card.is_write;
+    return false;
   }
 
   setPersisted(isPersisted) {
@@ -290,7 +290,7 @@ class QuestionInner {
   }
 
   setIsAction(isAction) {
-    return this.setCard(assoc(this.card(), "is_write", isAction));
+    return this.card();
   }
 
   // locking the display prevents auto-selection

--- a/frontend/src/metabase/entities/questions.js
+++ b/frontend/src/metabase/entities/questions.js
@@ -113,7 +113,6 @@ const Questions = createEntity({
     "collection_position",
     "collection_preview",
     "result_metadata",
-    "is_write",
   ],
 
   getAnalyticsMetadata([object], { action }, getState) {

--- a/frontend/src/metabase/entities/questions/forms.js
+++ b/frontend/src/metabase/entities/questions/forms.js
@@ -13,12 +13,6 @@ const FORM_FIELDS = [
     type: "text",
     placeholder: t`It's optional but oh, so helpful`,
   },
-  {
-    name: "is_write",
-    title: t`Is Write`,
-    description: t`Write questions can be used for experimental actions.`,
-    type: "boolean",
-  },
 ];
 
 export default {

--- a/frontend/src/metabase/query_builder/components/QuestionActions.tsx
+++ b/frontend/src/metabase/query_builder/components/QuestionActions.tsx
@@ -73,8 +73,6 @@ const QuestionActions = ({
   question,
   setQueryBuilderMode,
   turnDatasetIntoQuestion,
-  turnQuestionIntoAction,
-  turnActionIntoQuestion,
   onInfoClick,
   onModelPersistenceChange,
   isModerator,
@@ -86,7 +84,6 @@ const QuestionActions = ({
     ? color("brand")
     : undefined;
 
-  const isAction = question.isAction();
   const isDataset = question.isDataset();
   const canWrite = question.canWrite();
   const isSaved = question.isSaved();
@@ -169,7 +166,7 @@ const QuestionActions = ({
       action: () => onOpenModal(MODAL_TYPES.MOVE),
       testId: MOVE_TESTID,
     });
-    if (!isDataset && !isAction) {
+    if (!isDataset) {
       extraButtons.push({
         title: t`Turn into a model`,
         icon: "model",
@@ -182,15 +179,6 @@ const QuestionActions = ({
         title: t`Turn back to saved question`,
         icon: "model_framed",
         action: turnDatasetIntoQuestion,
-      });
-    }
-    if (isSaved && isNative && !isDataset) {
-      extraButtons.push({
-        title: isAction
-          ? t`Turn back to saved question`
-          : t`Turn into an action`,
-        icon: "bolt",
-        action: isAction ? turnActionIntoQuestion : turnQuestionIntoAction,
       });
     }
   }


### PR DESCRIPTION
Removes a lost data app entry point that was supposed to be disabled. The native question could be converted into "actions" which shouldn't actually be possible on `master` now.

### To Verify

1. New > Native (SQL) Question
2. Fill in any query, e.g. `select 1`
3. Click "Save" at the top right, give the question a name and save
4. Click the "..." button at the top right
5. Make sure there's no "Turn into action" option
6. Click "Duplicate"
7. Make sure there's no "is write" form field