### PR TITLE
fix audit dashboards click behavior

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/audit_app/lib/mode.js
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/lib/mode.js
@@ -88,5 +88,5 @@ const AuditDrill = ({ question, clicked }) => {
 
 export const AuditMode = {
   name: "audit",
-  drills: () => [AuditDrill],
+  drills: [AuditDrill],
 };

--- a/enterprise/frontend/src/metabase-enterprise/tools/mode.js
+++ b/enterprise/frontend/src/metabase-enterprise/tools/mode.js
@@ -24,5 +24,5 @@ const ErrorDrill = ({ clicked }) => {
 
 export const ErrorMode = {
   name: "error",
-  drills: () => [ErrorDrill],
+  drills: [ErrorDrill],
 };

--- a/frontend/src/metabase/visualizations/visualizations/RowChart/RowChart.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/RowChart/RowChart.tsx
@@ -177,11 +177,6 @@ const RowChartVisualization = ({
     }
 
     const clickData = getClickData(bar, settings, chartColumns, data.cols);
-
-    if (!visualizationIsClickable(clickData)) {
-      return;
-    }
-
     onVisualizationClick({ ...clickData, element: event.target });
   };
 


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/26847

## Changes

**Metabase EE features**

Drilling into charts stopped working on the audit dashboards for two reasons:
1) Recent refactoring of `Mode.drills` made code expecting an array instead of a function, but two places related to the Audit and Tools -> Error were missed.
2) In the old row chart (and existing line/area/bar charts) visualizationIsClickable was not executed when a click happened inside a chart to determine if visualization is clickable.

### How to verify

- Run Metabase EE
- Create a broken question, run it
- Open Admin -> Tools -> Errors, ensure the broken question is clickable in the table
- Open Audit, go to [All Questions](http://localhost:3000/admin/audit/questions/all) and ensure questions are clickable
- Change the tab to [Overview](http://localhost:3000/admin/audit/questions/overview) and click on any bar that represents a question — they should be clickable too