### PR TITLE
Add cache time field to the db form

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/caching/components/CacheTimeInput/CacheTimeInput.styled.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/caching/components/CacheTimeInput/CacheTimeInput.styled.tsx
@@ -13,10 +13,6 @@ export const TimeInput = styled(NumericInput)`
   text-align: center;
 `;
 
-interface TimeInputMessageProps {
-  error?: boolean;
-}
-
-export const TimeInputMessage = styled.div<TimeInputMessageProps>`
-  color: ${props => color(props.error ? "error" : "text-dark")};
+export const TimeInputMessage = styled.div`
+  color: ${color("text-dark")};
 `;

--- a/enterprise/frontend/src/metabase-enterprise/caching/components/CacheTimeInput/CacheTimeInput.styled.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/caching/components/CacheTimeInput/CacheTimeInput.styled.tsx
@@ -1,0 +1,22 @@
+import styled from "@emotion/styled";
+import { color } from "metabase/lib/colors";
+import NumericInput from "metabase/core/components/NumericInput";
+
+export const CacheInputRoot = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+`;
+
+interface CacheInputMessageProps {
+  error?: boolean;
+}
+
+export const CacheInputMessage = styled.div<CacheInputMessageProps>`
+  color: ${props => color(props.error ? "error" : "text-dark")};
+`;
+
+export const CacheInput = styled(NumericInput)`
+  width: 3.125rem;
+  text-align: center;
+`;

--- a/enterprise/frontend/src/metabase-enterprise/caching/components/CacheTimeInput/CacheTimeInput.styled.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/caching/components/CacheTimeInput/CacheTimeInput.styled.tsx
@@ -2,21 +2,21 @@ import styled from "@emotion/styled";
 import { color } from "metabase/lib/colors";
 import NumericInput from "metabase/core/components/NumericInput";
 
-export const CacheInputRoot = styled.div`
+export const TimeInputRoot = styled.div`
   display: flex;
   align-items: center;
   gap: 0.625rem;
 `;
 
-interface CacheInputMessageProps {
+export const TimeInput = styled(NumericInput)`
+  width: 3.125rem;
+  text-align: center;
+`;
+
+interface TimeInputMessageProps {
   error?: boolean;
 }
 
-export const CacheInputMessage = styled.div<CacheInputMessageProps>`
+export const TimeInputMessage = styled.div<TimeInputMessageProps>`
   color: ${props => color(props.error ? "error" : "text-dark")};
-`;
-
-export const CacheInput = styled(NumericInput)`
-  width: 3.125rem;
-  text-align: center;
 `;

--- a/enterprise/frontend/src/metabase-enterprise/caching/components/CacheTimeInput/CacheTimeInput.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/caching/components/CacheTimeInput/CacheTimeInput.tsx
@@ -1,29 +1,35 @@
 import React from "react";
 import { t } from "ttag";
-import { NumericInputProps } from "metabase/core/components/NumericInput";
 import {
-  CacheInputMessage,
-  CacheInputRoot,
-  CacheInput,
+  TimeInputMessage,
+  TimeInputRoot,
+  TimeInput,
 } from "./CacheTimeInput.styled";
 
-export interface CacheTimeInputProps extends NumericInputProps {
+export interface CacheTimeInputProps {
+  value?: number;
   message?: string;
+  error?: boolean;
+  onChange?: (value?: number) => void;
 }
 
 const CacheTimeInput = ({
+  value,
   message,
   error,
-  ...props
+  onChange,
 }: CacheTimeInputProps): JSX.Element => {
   return (
-    <CacheInputRoot>
-      {message && (
-        <CacheInputMessage error={error}>{message}</CacheInputMessage>
-      )}
-      <CacheInput {...props} error={error} placeholder="24" />
-      <CacheInputMessage error={error}>{t`hours`}</CacheInputMessage>
-    </CacheInputRoot>
+    <TimeInputRoot>
+      {message && <TimeInputMessage error={error}>{message}</TimeInputMessage>}
+      <TimeInput
+        value={value}
+        error={error}
+        placeholder="24"
+        onChange={onChange}
+      />
+      <TimeInputMessage error={error}>{t`hours`}</TimeInputMessage>
+    </TimeInputRoot>
   );
 };
 

--- a/enterprise/frontend/src/metabase-enterprise/caching/components/CacheTimeInput/CacheTimeInput.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/caching/components/CacheTimeInput/CacheTimeInput.tsx
@@ -1,4 +1,4 @@
-import React, { FocusEvent } from "react";
+import React, { FocusEvent, useCallback } from "react";
 import { t } from "ttag";
 import {
   TimeInputMessage,
@@ -25,6 +25,13 @@ const CacheTimeInput = ({
   onChange,
   onBlur,
 }: CacheTimeInputProps): JSX.Element => {
+  const handleChange = useCallback(
+    (value?: number) => {
+      onChange?.(value !== 0 ? value : undefined);
+    },
+    [onChange],
+  );
+
   return (
     <TimeInputRoot>
       {message && <TimeInputMessage>{message}</TimeInputMessage>}
@@ -35,7 +42,7 @@ const CacheTimeInput = ({
         placeholder="24"
         error={error}
         fullWidth
-        onChange={onChange}
+        onChange={handleChange}
         onBlur={onBlur}
       />
       <TimeInputMessage>{t`hours`}</TimeInputMessage>

--- a/enterprise/frontend/src/metabase-enterprise/caching/components/CacheTimeInput/CacheTimeInput.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/caching/components/CacheTimeInput/CacheTimeInput.tsx
@@ -1,4 +1,4 @@
-import React, { FocusEvent, useCallback } from "react";
+import React, { FocusEvent } from "react";
 import { t } from "ttag";
 import {
   TimeInputMessage,
@@ -7,42 +7,38 @@ import {
 } from "./CacheTimeInput.styled";
 
 export interface CacheTimeInputProps {
+  id?: string;
+  name?: string;
   value?: number;
   message?: string;
   error?: boolean;
-  inputId?: string;
   onChange?: (value?: number) => void;
   onBlur?: (event: FocusEvent<HTMLInputElement>) => void;
 }
 
 const CacheTimeInput = ({
+  id,
+  name,
   value,
   message,
   error,
-  inputId,
   onChange,
   onBlur,
 }: CacheTimeInputProps): JSX.Element => {
-  const handleBlur = useCallback(
-    (event: FocusEvent<HTMLInputElement>) => {
-      onChange?.(value !== 0 ? value : undefined);
-      onBlur?.(event);
-    },
-    [value, onChange, onBlur],
-  );
-
   return (
     <TimeInputRoot>
-      {message && <TimeInputMessage error={error}>{message}</TimeInputMessage>}
+      {message && <TimeInputMessage>{message}</TimeInputMessage>}
       <TimeInput
-        id={inputId}
+        id={id}
+        name={name}
         value={value}
-        error={error}
         placeholder="24"
+        error={error}
+        fullWidth
         onChange={onChange}
-        onBlur={handleBlur}
+        onBlur={onBlur}
       />
-      <TimeInputMessage error={error}>{t`hours`}</TimeInputMessage>
+      <TimeInputMessage>{t`hours`}</TimeInputMessage>
     </TimeInputRoot>
   );
 };

--- a/enterprise/frontend/src/metabase-enterprise/caching/components/CacheTimeInput/CacheTimeInput.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/caching/components/CacheTimeInput/CacheTimeInput.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { FocusEvent } from "react";
 import { t } from "ttag";
 import {
   TimeInputMessage,
@@ -10,23 +10,29 @@ export interface CacheTimeInputProps {
   value?: number;
   message?: string;
   error?: boolean;
+  inputId?: string;
   onChange?: (value?: number) => void;
+  onBlur?: (event: FocusEvent<HTMLInputElement>) => void;
 }
 
 const CacheTimeInput = ({
   value,
   message,
   error,
+  inputId,
   onChange,
+  onBlur,
 }: CacheTimeInputProps): JSX.Element => {
   return (
     <TimeInputRoot>
       {message && <TimeInputMessage error={error}>{message}</TimeInputMessage>}
       <TimeInput
+        id={inputId}
         value={value}
         error={error}
         placeholder="24"
         onChange={onChange}
+        onBlur={onBlur}
       />
       <TimeInputMessage error={error}>{t`hours`}</TimeInputMessage>
     </TimeInputRoot>

--- a/enterprise/frontend/src/metabase-enterprise/caching/components/CacheTimeInput/CacheTimeInput.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/caching/components/CacheTimeInput/CacheTimeInput.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+import { t } from "ttag";
+import { NumericInputProps } from "metabase/core/components/NumericInput";
+import {
+  CacheInputMessage,
+  CacheInputRoot,
+  CacheInput,
+} from "./CacheTimeInput.styled";
+
+export interface CacheTimeInputProps extends NumericInputProps {
+  message?: string;
+}
+
+const CacheTimeInput = ({
+  message,
+  error,
+  ...props
+}: CacheTimeInputProps): JSX.Element => {
+  return (
+    <CacheInputRoot>
+      {message && (
+        <CacheInputMessage error={error}>{message}</CacheInputMessage>
+      )}
+      <CacheInput {...props} error={error} placeholder="24" />
+      <CacheInputMessage error={error}>{t`hours`}</CacheInputMessage>
+    </CacheInputRoot>
+  );
+};
+
+export default CacheTimeInput;

--- a/enterprise/frontend/src/metabase-enterprise/caching/components/CacheTimeInput/CacheTimeInput.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/caching/components/CacheTimeInput/CacheTimeInput.tsx
@@ -1,4 +1,4 @@
-import React, { FocusEvent } from "react";
+import React, { FocusEvent, useCallback } from "react";
 import { t } from "ttag";
 import {
   TimeInputMessage,
@@ -23,6 +23,14 @@ const CacheTimeInput = ({
   onChange,
   onBlur,
 }: CacheTimeInputProps): JSX.Element => {
+  const handleBlur = useCallback(
+    (event: FocusEvent<HTMLInputElement>) => {
+      onChange?.(value !== 0 ? value : undefined);
+      onBlur?.(event);
+    },
+    [value, onChange, onBlur],
+  );
+
   return (
     <TimeInputRoot>
       {message && <TimeInputMessage error={error}>{message}</TimeInputMessage>}
@@ -32,7 +40,7 @@ const CacheTimeInput = ({
         error={error}
         placeholder="24"
         onChange={onChange}
-        onBlur={onBlur}
+        onBlur={handleBlur}
       />
       <TimeInputMessage error={error}>{t`hours`}</TimeInputMessage>
     </TimeInputRoot>

--- a/enterprise/frontend/src/metabase-enterprise/caching/components/CacheTimeInput/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/caching/components/CacheTimeInput/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./CacheTimeInput";

--- a/enterprise/frontend/src/metabase-enterprise/caching/components/DatabaseCacheTimeField/DatabaseCacheTimeField.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/caching/components/DatabaseCacheTimeField/DatabaseCacheTimeField.tsx
@@ -1,25 +1,28 @@
 import React, { useCallback } from "react";
-import { useField } from "formik";
+import { useField, useFormikContext } from "formik";
 import { jt, t } from "ttag";
 import { useUniqueId } from "metabase/hooks/use-unique-id";
 import Link from "metabase/core/components/Link/Link";
 import FormField from "metabase/core/components/FormField";
+import { DatabaseValues } from "metabase/databases/types";
 import DatabaseCacheTimeInput from "../DatabaseCacheTimeInput";
 
-export interface DatabaseCacheTimeFieldProps {
-  name: string;
-}
+const FIELD = "cache_ttl";
+const SECTION = "advanced-options";
 
-const DatabaseCacheTimeField = ({ name }: DatabaseCacheTimeFieldProps) => {
+const DatabaseCacheTimeField = () => {
   const id = useUniqueId();
-  const [{ value, onBlur }, { error, touched }, { setValue }] = useField(name);
+  const [{ value, onBlur }, { error, touched }, { setValue }] = useField(FIELD);
+  const { values } = useFormikContext<DatabaseValues>();
 
   const handleChange = useCallback(
-    (value?: number) => {
-      setValue(value != null ? value : null);
-    },
+    (value?: number) => setValue(value != null ? value : null),
     [setValue],
   );
+
+  if (!values.details[SECTION]) {
+    return null;
+  }
 
   return (
     <FormField

--- a/enterprise/frontend/src/metabase-enterprise/caching/components/DatabaseCacheTimeField/DatabaseCacheTimeField.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/caching/components/DatabaseCacheTimeField/DatabaseCacheTimeField.tsx
@@ -32,9 +32,10 @@ const DatabaseCacheTimeField = () => {
       error={touched ? error : undefined}
     >
       <DatabaseCacheTimeInput
+        id={id}
+        name={FIELD}
         value={value ?? undefined}
         error={touched && error != null}
-        inputId={id}
         onChange={handleChange}
         onBlur={onBlur}
       />
@@ -44,13 +45,13 @@ const DatabaseCacheTimeField = () => {
 
 const DatabaseCacheTimeDescription = (): JSX.Element => {
   return (
-    <span>
+    <div>
       {jt`How long to keep question results. By default, Metabase will use the value you supply on the ${(
         <Link key="link" to="/admin/settings/caching">
           {t`cache settings page`}
         </Link>
       )}, but if this database has other factors that influence the freshness of data, it could make sense to set a custom duration. You can also choose custom durations on individual questions or dashboards to help improve performance.`}
-    </span>
+    </div>
   );
 };
 

--- a/enterprise/frontend/src/metabase-enterprise/caching/components/DatabaseCacheTimeField/DatabaseCacheTimeField.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/caching/components/DatabaseCacheTimeField/DatabaseCacheTimeField.tsx
@@ -1,0 +1,54 @@
+import React, { useCallback } from "react";
+import { useField } from "formik";
+import { jt, t } from "ttag";
+import { useUniqueId } from "metabase/hooks/use-unique-id";
+import Link from "metabase/core/components/Link/Link";
+import FormField from "metabase/core/components/FormField";
+import DatabaseCacheTimeInput from "../DatabaseCacheTimeInput";
+
+export interface DatabaseCacheTimeFieldProps {
+  name: string;
+}
+
+const DatabaseCacheTimeField = ({ name }: DatabaseCacheTimeFieldProps) => {
+  const id = useUniqueId();
+  const [{ value, onBlur }, { error, touched }, { setValue }] = useField(name);
+
+  const handleChange = useCallback(
+    (value?: number) => {
+      setValue(value != null ? value : null);
+    },
+    [setValue],
+  );
+
+  return (
+    <FormField
+      title={t`Default result cache duration`}
+      description={<DatabaseCacheTimeDescription />}
+      htmlFor={id}
+      error={touched ? error : undefined}
+    >
+      <DatabaseCacheTimeInput
+        value={value ?? undefined}
+        error={touched && error != null}
+        inputId={id}
+        onChange={handleChange}
+        onBlur={onBlur}
+      />
+    </FormField>
+  );
+};
+
+const DatabaseCacheTimeDescription = (): JSX.Element => {
+  return (
+    <span>
+      {jt`How long to keep question results. By default, Metabase will use the value you supply on the ${(
+        <Link key="link" to="/admin/settings/caching">
+          {t`cache settings page`}
+        </Link>
+      )}, but if this database has other factors that influence the freshness of data, it could make sense to set a custom duration. You can also choose custom durations on individual questions or dashboards to help improve performance.`}
+    </span>
+  );
+};
+
+export default DatabaseCacheTimeField;

--- a/enterprise/frontend/src/metabase-enterprise/caching/components/DatabaseCacheTimeField/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/caching/components/DatabaseCacheTimeField/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./DatabaseCacheTimeField";

--- a/enterprise/frontend/src/metabase-enterprise/caching/components/DatabaseCacheTimeInput/DatabaseCacheTimeInput.styled.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/caching/components/DatabaseCacheTimeInput/DatabaseCacheTimeInput.styled.tsx
@@ -1,0 +1,7 @@
+import styled from "@emotion/styled";
+
+export const TimeInputRoot = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+`;

--- a/enterprise/frontend/src/metabase-enterprise/caching/components/DatabaseCacheTimeInput/DatabaseCacheTimeInput.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/caching/components/DatabaseCacheTimeInput/DatabaseCacheTimeInput.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from "react";
+import React, { FocusEvent, useCallback, useState } from "react";
 import { t } from "ttag";
 import Select, { SelectChangeEvent } from "metabase/core/components/Select";
 import CacheTimeInput from "../CacheTimeInput";
@@ -14,13 +14,17 @@ const DEFAULT_CACHE_TIME = 24;
 export interface DatabaseCacheTimeInputProps {
   value?: number;
   error?: boolean;
+  inputId?: string;
   onChange?: (value?: number) => void;
+  onBlur?: (event: FocusEvent<HTMLInputElement>) => void;
 }
 
 const DatabaseCacheTimeInput = ({
   value,
   error,
+  inputId,
   onChange,
+  onBlur,
 }: DatabaseCacheTimeInputProps): JSX.Element => {
   const [isCustom, setIsCustom] = useState(value != null);
 
@@ -40,7 +44,13 @@ const DatabaseCacheTimeInput = ({
         onChange={handleChange}
       />
       {isCustom && (
-        <CacheTimeInput value={value} error={error} onChange={onChange} />
+        <CacheTimeInput
+          value={value}
+          error={error}
+          inputId={inputId}
+          onChange={onChange}
+          onBlur={onBlur}
+        />
       )}
     </TimeInputRoot>
   );

--- a/enterprise/frontend/src/metabase-enterprise/caching/components/DatabaseCacheTimeInput/DatabaseCacheTimeInput.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/caching/components/DatabaseCacheTimeInput/DatabaseCacheTimeInput.tsx
@@ -12,17 +12,19 @@ const CACHE_OPTIONS = [
 const DEFAULT_CACHE_TIME = 24;
 
 export interface DatabaseCacheTimeInputProps {
+  id?: string;
+  name?: string;
   value?: number;
   error?: boolean;
-  inputId?: string;
   onChange?: (value?: number) => void;
   onBlur?: (event: FocusEvent<HTMLInputElement>) => void;
 }
 
 const DatabaseCacheTimeInput = ({
+  id,
+  name,
   value,
   error,
-  inputId,
   onChange,
   onBlur,
 }: DatabaseCacheTimeInputProps): JSX.Element => {
@@ -45,9 +47,10 @@ const DatabaseCacheTimeInput = ({
       />
       {isCustom && (
         <CacheTimeInput
+          id={id}
+          name={name}
           value={value}
           error={error}
-          inputId={inputId}
           onChange={onChange}
           onBlur={onBlur}
         />

--- a/enterprise/frontend/src/metabase-enterprise/caching/components/DatabaseCacheTimeInput/DatabaseCacheTimeInput.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/caching/components/DatabaseCacheTimeInput/DatabaseCacheTimeInput.tsx
@@ -1,0 +1,49 @@
+import React, { useCallback, useState } from "react";
+import { t } from "ttag";
+import Select, { SelectChangeEvent } from "metabase/core/components/Select";
+import CacheTimeInput from "../CacheTimeInput";
+import { TimeInputRoot } from "./DatabaseCacheTimeInput.styled";
+
+const CACHE_OPTIONS = [
+  { name: t`Use instance default (TTL)`, value: false },
+  { name: t`Custom`, value: true },
+];
+
+const DEFAULT_CACHE_TIME = 24;
+
+export interface DatabaseCacheTimeInputProps {
+  value?: number;
+  error?: boolean;
+  onChange?: (value?: number) => void;
+}
+
+const DatabaseCacheTimeInput = ({
+  value,
+  error,
+  onChange,
+}: DatabaseCacheTimeInputProps): JSX.Element => {
+  const [isCustom, setIsCustom] = useState(value != null);
+
+  const handleChange = useCallback(
+    ({ target: { value: isCustom } }: SelectChangeEvent<boolean>) => {
+      setIsCustom(isCustom);
+      onChange?.(isCustom ? DEFAULT_CACHE_TIME : undefined);
+    },
+    [onChange],
+  );
+
+  return (
+    <TimeInputRoot>
+      <Select
+        value={isCustom}
+        options={CACHE_OPTIONS}
+        onChange={handleChange}
+      />
+      {isCustom && (
+        <CacheTimeInput value={value} error={error} onChange={onChange} />
+      )}
+    </TimeInputRoot>
+  );
+};
+
+export default DatabaseCacheTimeInput;

--- a/enterprise/frontend/src/metabase-enterprise/caching/components/DatabaseCacheTimeInput/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/caching/components/DatabaseCacheTimeInput/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./DatabaseCacheTimeInput";

--- a/enterprise/frontend/src/metabase-enterprise/caching/index.js
+++ b/enterprise/frontend/src/metabase-enterprise/caching/index.js
@@ -5,6 +5,7 @@ import { PLUGIN_CACHING, PLUGIN_FORM_WIDGETS } from "metabase/plugins";
 import Link from "metabase/core/components/Link";
 import CacheTTLField from "./components/CacheTTLField";
 import DatabaseCacheTTLField from "./components/DatabaseCacheTTLField";
+import DatabaseCacheTimeField from "./components/DatabaseCacheTimeField";
 import QuestionCacheTTLField from "./components/QuestionCacheTTLField";
 import QuestionCacheSection from "./components/QuestionCacheSection";
 import DashboardCacheSection from "./components/DashboardCacheSection";
@@ -52,7 +53,8 @@ if (hasPremiumFeature("advanced_config")) {
   PLUGIN_FORM_WIDGETS.questionCacheTTL = QuestionCacheTTLField;
 
   PLUGIN_CACHING.getQuestionsImplicitCacheTTL = getQuestionsImplicitCacheTTL;
-  PLUGIN_CACHING.QuestionCacheSection = QuestionCacheSection;
+  PLUGIN_CACHING.DatabaseCacheTimeField = DatabaseCacheTimeField;
   PLUGIN_CACHING.DashboardCacheSection = DashboardCacheSection;
+  PLUGIN_CACHING.QuestionCacheSection = QuestionCacheSection;
   PLUGIN_CACHING.isEnabled = () => true;
 }

--- a/enterprise/frontend/src/metabase-enterprise/caching/index.js
+++ b/enterprise/frontend/src/metabase-enterprise/caching/index.js
@@ -58,5 +58,3 @@ if (hasPremiumFeature("advanced_config")) {
   PLUGIN_CACHING.QuestionCacheSection = QuestionCacheSection;
   PLUGIN_CACHING.isEnabled = () => true;
 }
-
-PLUGIN_CACHING.DatabaseCacheTimeField = DatabaseCacheTimeField;

--- a/enterprise/frontend/src/metabase-enterprise/caching/index.js
+++ b/enterprise/frontend/src/metabase-enterprise/caching/index.js
@@ -58,3 +58,5 @@ if (hasPremiumFeature("advanced_config")) {
   PLUGIN_CACHING.QuestionCacheSection = QuestionCacheSection;
   PLUGIN_CACHING.isEnabled = () => true;
 }
+
+PLUGIN_CACHING.DatabaseCacheTimeField = DatabaseCacheTimeField;

--- a/frontend/src/metabase-types/api/mocks/settings.ts
+++ b/frontend/src/metabase-types/api/mocks/settings.ts
@@ -116,7 +116,7 @@ export const createMockSettings = (opts?: Partial<Settings>): Settings => ({
   "email-configured?": false,
   "enable-embedding": false,
   "enable-nested-queries": true,
-  "enable-query-caching": false,
+  "enable-query-caching": undefined,
   "enable-public-sharing": false,
   "enable-xrays": false,
   "experimental-enable-actions": false,

--- a/frontend/src/metabase-types/api/mocks/settings.ts
+++ b/frontend/src/metabase-types/api/mocks/settings.ts
@@ -116,6 +116,7 @@ export const createMockSettings = (opts?: Partial<Settings>): Settings => ({
   "email-configured?": false,
   "enable-embedding": false,
   "enable-nested-queries": true,
+  "enable-query-caching": false,
   "enable-public-sharing": false,
   "enable-xrays": false,
   "experimental-enable-actions": false,

--- a/frontend/src/metabase-types/api/settings.ts
+++ b/frontend/src/metabase-types/api/settings.ts
@@ -145,7 +145,7 @@ export interface Settings {
   "embedding-secret-key"?: string;
   "enable-embedding": boolean;
   "enable-nested-queries": boolean;
-  "enable-query-caching": boolean;
+  "enable-query-caching"?: boolean;
   "enable-public-sharing": boolean;
   "enable-xrays": boolean;
   "experimental-enable-actions": boolean;

--- a/frontend/src/metabase-types/api/settings.ts
+++ b/frontend/src/metabase-types/api/settings.ts
@@ -145,6 +145,7 @@ export interface Settings {
   "embedding-secret-key"?: string;
   "enable-embedding": boolean;
   "enable-nested-queries": boolean;
+  "enable-query-caching": boolean;
   "enable-public-sharing": boolean;
   "enable-xrays": boolean;
   "experimental-enable-actions": boolean;

--- a/frontend/src/metabase-types/store/mocks/setup.ts
+++ b/frontend/src/metabase-types/store/mocks/setup.ts
@@ -41,6 +41,7 @@ export const createMockDatabaseInfo = (
   schedules: {},
   auto_run_queries: false,
   refingerprint: false,
+  cache_ttl: null,
   is_sample: false,
   is_full_sync: false,
   is_on_demand: false,

--- a/frontend/src/metabase-types/store/setup.ts
+++ b/frontend/src/metabase-types/store/setup.ts
@@ -27,6 +27,7 @@ export interface DatabaseInfo {
   schedules: DatabaseSchedules;
   auto_run_queries: boolean;
   refingerprint: boolean;
+  cache_ttl: number | null;
   is_sample: boolean;
   is_full_sync: boolean;
   is_on_demand: boolean;

--- a/frontend/src/metabase/core/components/FormField/FormField.styled.tsx
+++ b/frontend/src/metabase/core/components/FormField/FormField.styled.tsx
@@ -3,31 +3,6 @@ import { color } from "metabase/lib/colors";
 import Icon from "metabase/components/Icon";
 import { FieldAlignment, FieldOrientation } from "./types";
 
-export const FieldLabelError = styled.span`
-  color: ${color("error")};
-`;
-
-export interface FieldRootProps {
-  orientation: FieldOrientation;
-  hasError: boolean;
-}
-
-export const FieldRoot = styled.div<FieldRootProps>`
-  display: ${props => props.orientation === "horizontal" && "flex"};
-  justify-content: ${props =>
-    props.orientation === "horizontal" && "space-between"};
-  color: ${props => (props.hasError ? color("error") : color("text-medium"))};
-  margin-bottom: 1.25rem;
-
-  &:focus-within {
-    color: ${color("text-medium")};
-
-    ${FieldLabelError} {
-      display: none;
-    }
-  }
-`;
-
 export interface FormCaptionProps {
   alignment: FieldAlignment;
   orientation: FieldOrientation;
@@ -44,8 +19,13 @@ export const FieldCaption = styled.div<FormCaptionProps>`
     "0.5rem"};
 `;
 
-export const FieldLabel = styled.label`
+export interface FieldLabelProps {
+  hasError: boolean;
+}
+
+export const FieldLabel = styled.label<FieldLabelProps>`
   display: block;
+  color: ${props => (props.hasError ? color("error") : color("text-medium"))};
   font-size: 0.77rem;
   font-weight: 900;
 `;
@@ -56,7 +36,12 @@ export const FieldLabelContainer = styled.div`
   margin-bottom: 0.5em;
 `;
 
+export const FieldLabelError = styled.span`
+  color: ${color("error")};
+`;
+
 export const FieldDescription = styled.div`
+  color: ${color("text-medium")};
   margin-bottom: 0.5rem;
 `;
 
@@ -76,4 +61,25 @@ export const FieldInfoLabel = styled.div`
   font-size: 0.75rem;
   margin-left: auto;
   cursor: default;
+`;
+
+export interface FieldRootProps {
+  orientation: FieldOrientation;
+}
+
+export const FieldRoot = styled.div<FieldRootProps>`
+  display: ${props => props.orientation === "horizontal" && "flex"};
+  justify-content: ${props =>
+    props.orientation === "horizontal" && "space-between"};
+  margin-bottom: 1.25rem;
+
+  &:focus-within {
+    ${FieldLabel} {
+      color: ${color("text-medium")};
+    }
+
+    ${FieldLabelError} {
+      display: none;
+    }
+  }
 `;

--- a/frontend/src/metabase/core/components/FormField/FormField.tsx
+++ b/frontend/src/metabase/core/components/FormField/FormField.tsx
@@ -41,18 +41,13 @@ const FormField = forwardRef(function FormField(
   const hasError = Boolean(error);
 
   return (
-    <FieldRoot
-      {...props}
-      ref={ref}
-      orientation={orientation}
-      hasError={hasError}
-    >
+    <FieldRoot {...props} ref={ref} orientation={orientation}>
       {alignment === "start" && children}
       {(title || description) && (
         <FieldCaption alignment={alignment} orientation={orientation}>
           <FieldLabelContainer>
             {title && (
-              <FieldLabel htmlFor={htmlFor}>
+              <FieldLabel hasError={hasError} htmlFor={htmlFor}>
                 {title}
                 {hasError && <FieldLabelError>: {error}</FieldLabelError>}
               </FieldLabel>

--- a/frontend/src/metabase/core/utils/errors/errors.ts
+++ b/frontend/src/metabase/core/utils/errors/errors.ts
@@ -7,3 +7,5 @@ export const email = () => t`must be a valid email address`;
 
 export const maxLength = ({ max }: MaxLengthParams) =>
   t`must be ${max} characters or less`;
+
+export const positive = () => t`must be a positive integer value`;

--- a/frontend/src/metabase/core/utils/errors/index.ts
+++ b/frontend/src/metabase/core/utils/errors/index.ts
@@ -1,1 +1,1 @@
-export { required, email, maxLength } from "./errors";
+export { required, email, maxLength, positive } from "./errors";

--- a/frontend/src/metabase/databases/components/DatabaseForm/DatabaseForm.tsx
+++ b/frontend/src/metabase/databases/components/DatabaseForm/DatabaseForm.tsx
@@ -7,6 +7,7 @@ import FormProvider from "metabase/core/components/FormProvider";
 import FormFooter from "metabase/core/components/FormFooter";
 import FormSubmitButton from "metabase/core/components/FormSubmitButton";
 import FormErrorMessage from "metabase/core/components/FormErrorMessage";
+import { PLUGIN_CACHING } from "metabase/plugins";
 import { Engine } from "metabase-types/api";
 import { DatabaseValues } from "../../types";
 import { getDefaultEngineKey } from "../../utils/engine";
@@ -22,6 +23,7 @@ export interface DatabaseFormProps {
   initialValues?: DatabaseValues;
   isHosted?: boolean;
   isAdvanced?: boolean;
+  isQueryCachingEnabled?: boolean;
   onSubmit: (values: DatabaseValues) => void;
   onEngineChange?: (engineKey: string | undefined) => void;
   onCancel?: () => void;
@@ -32,6 +34,7 @@ const DatabaseForm = ({
   initialValues: initialData,
   isHosted = false,
   isAdvanced = false,
+  isQueryCachingEnabled = false,
   onSubmit,
   onCancel,
   onEngineChange,
@@ -72,6 +75,7 @@ const DatabaseForm = ({
         engines={engines}
         isHosted={isHosted}
         isAdvanced={isAdvanced}
+        isQueryCachingEnabled={isQueryCachingEnabled}
         onEngineChange={handleEngineChange}
         onCancel={onCancel}
       />
@@ -85,6 +89,7 @@ interface DatabaseFormBodyProps {
   engines: Record<string, Engine>;
   isHosted: boolean;
   isAdvanced: boolean;
+  isQueryCachingEnabled: boolean;
   onEngineChange: (engineKey: string | undefined) => void;
   onCancel?: () => void;
 }
@@ -95,6 +100,7 @@ const DatabaseFormBody = ({
   engines,
   isHosted,
   isAdvanced,
+  isQueryCachingEnabled,
   onEngineChange,
   onCancel,
 }: DatabaseFormBodyProps): JSX.Element => {
@@ -122,6 +128,7 @@ const DatabaseFormBody = ({
       {fields.map(field => (
         <DatabaseDetailField key={field.name} field={field} />
       ))}
+      {isQueryCachingEnabled && <PLUGIN_CACHING.DatabaseCacheField />}
       <DatabaseFormFooter isAdvanced={isAdvanced} onCancel={onCancel} />
     </Form>
   );

--- a/frontend/src/metabase/databases/components/DatabaseForm/DatabaseForm.tsx
+++ b/frontend/src/metabase/databases/components/DatabaseForm/DatabaseForm.tsx
@@ -23,7 +23,7 @@ export interface DatabaseFormProps {
   initialValues?: DatabaseValues;
   isHosted?: boolean;
   isAdvanced?: boolean;
-  isQueryCachingEnabled?: boolean;
+  isCachingEnabled?: boolean;
   onSubmit: (values: DatabaseValues) => void;
   onEngineChange?: (engineKey: string | undefined) => void;
   onCancel?: () => void;
@@ -34,7 +34,7 @@ const DatabaseForm = ({
   initialValues: initialData,
   isHosted = false,
   isAdvanced = false,
-  isQueryCachingEnabled = false,
+  isCachingEnabled = false,
   onSubmit,
   onCancel,
   onEngineChange,
@@ -75,7 +75,7 @@ const DatabaseForm = ({
         engines={engines}
         isHosted={isHosted}
         isAdvanced={isAdvanced}
-        isQueryCachingEnabled={isQueryCachingEnabled}
+        isCachingEnabled={isCachingEnabled}
         onEngineChange={handleEngineChange}
         onCancel={onCancel}
       />
@@ -89,7 +89,7 @@ interface DatabaseFormBodyProps {
   engines: Record<string, Engine>;
   isHosted: boolean;
   isAdvanced: boolean;
-  isQueryCachingEnabled: boolean;
+  isCachingEnabled: boolean;
   onEngineChange: (engineKey: string | undefined) => void;
   onCancel?: () => void;
 }
@@ -100,7 +100,7 @@ const DatabaseFormBody = ({
   engines,
   isHosted,
   isAdvanced,
-  isQueryCachingEnabled,
+  isCachingEnabled,
   onEngineChange,
   onCancel,
 }: DatabaseFormBodyProps): JSX.Element => {
@@ -128,7 +128,7 @@ const DatabaseFormBody = ({
       {fields.map(field => (
         <DatabaseDetailField key={field.name} field={field} />
       ))}
-      {isQueryCachingEnabled && <PLUGIN_CACHING.DatabaseCacheTimeField />}
+      {isCachingEnabled && <PLUGIN_CACHING.DatabaseCacheTimeField />}
       <DatabaseFormFooter isAdvanced={isAdvanced} onCancel={onCancel} />
     </Form>
   );

--- a/frontend/src/metabase/databases/components/DatabaseForm/DatabaseForm.tsx
+++ b/frontend/src/metabase/databases/components/DatabaseForm/DatabaseForm.tsx
@@ -128,7 +128,7 @@ const DatabaseFormBody = ({
       {fields.map(field => (
         <DatabaseDetailField key={field.name} field={field} />
       ))}
-      {isQueryCachingEnabled && <PLUGIN_CACHING.DatabaseCacheField />}
+      {isQueryCachingEnabled && <PLUGIN_CACHING.DatabaseCacheTimeField />}
       <DatabaseFormFooter isAdvanced={isAdvanced} onCancel={onCancel} />
     </Form>
   );

--- a/frontend/src/metabase/databases/containers/DatabaseForm/DatabaseForm.tsx
+++ b/frontend/src/metabase/databases/containers/DatabaseForm/DatabaseForm.tsx
@@ -3,14 +3,14 @@ import { getSetting } from "metabase/selectors/settings";
 import { State } from "metabase-types/store";
 import DatabaseForm, { DatabaseFormProps } from "../../components/DatabaseForm";
 
-type DatabaseFormStateKeys = "engines" | "isHosted" | "isQueryCachingEnabled";
+type DatabaseFormStateKeys = "engines" | "isHosted" | "isCachingEnabled";
 type DatabaseFormOwnProps = Omit<DatabaseFormProps, DatabaseFormStateKeys>;
 type DatabaseFormStateProps = Pick<DatabaseFormProps, DatabaseFormStateKeys>;
 
 const mapStateToProps = (state: State) => ({
   engines: getSetting(state, "engines"),
   isHosted: getSetting(state, "is-hosted?"),
-  isQueryCachingEnabled: getSetting(state, "enable-query-caching"),
+  isCachingEnabled: getSetting(state, "enable-query-caching"),
 });
 
 export default connect<

--- a/frontend/src/metabase/databases/containers/DatabaseForm/DatabaseForm.tsx
+++ b/frontend/src/metabase/databases/containers/DatabaseForm/DatabaseForm.tsx
@@ -3,13 +3,14 @@ import { getSetting } from "metabase/selectors/settings";
 import { State } from "metabase-types/store";
 import DatabaseForm, { DatabaseFormProps } from "../../components/DatabaseForm";
 
-type DatabaseFormStateKeys = "engines" | "isHosted";
+type DatabaseFormStateKeys = "engines" | "isHosted" | "isQueryCachingEnabled";
 type DatabaseFormOwnProps = Omit<DatabaseFormProps, DatabaseFormStateKeys>;
 type DatabaseFormStateProps = Pick<DatabaseFormProps, DatabaseFormStateKeys>;
 
 const mapStateToProps = (state: State) => ({
   engines: getSetting(state, "engines"),
   isHosted: getSetting(state, "is-hosted?"),
+  isQueryCachingEnabled: getSetting(state, "enable-query-caching"),
 });
 
 export default connect<

--- a/frontend/src/metabase/databases/types.ts
+++ b/frontend/src/metabase/databases/types.ts
@@ -14,6 +14,7 @@ export interface DatabaseValues {
   schedules: DatabaseSchedules;
   auto_run_queries: boolean;
   refingerprint: boolean;
+  cache_ttl: number | null;
   is_sample: boolean;
   is_full_sync: boolean;
   is_on_demand: boolean;

--- a/frontend/src/metabase/databases/utils/schema.ts
+++ b/frontend/src/metabase/databases/utils/schema.ts
@@ -23,6 +23,7 @@ export const getValidationSchema = (
     }),
     auto_run_queries: Yup.boolean().default(true),
     refingerprint: Yup.boolean().default(false),
+    cache_ttl: Yup.number().nullable().default(null).positive(Errors.positive),
     is_sample: Yup.boolean().default(false),
     is_full_sync: Yup.boolean().default(true),
     is_on_demand: Yup.boolean().default(false),

--- a/frontend/src/metabase/plugins/index.ts
+++ b/frontend/src/metabase/plugins/index.ts
@@ -163,7 +163,7 @@ export const PLUGIN_CACHING = {
   getQuestionsImplicitCacheTTL: (question?: any) => null,
   QuestionCacheSection: PluginPlaceholder,
   DashboardCacheSection: PluginPlaceholder,
-  DatabaseCacheField: PluginPlaceholder,
+  DatabaseCacheTimeField: PluginPlaceholder,
   isEnabled: () => false,
 };
 

--- a/frontend/src/metabase/plugins/index.ts
+++ b/frontend/src/metabase/plugins/index.ts
@@ -163,6 +163,7 @@ export const PLUGIN_CACHING = {
   getQuestionsImplicitCacheTTL: (question?: any) => null,
   QuestionCacheSection: PluginPlaceholder,
   DashboardCacheSection: PluginPlaceholder,
+  DatabaseCacheField: PluginPlaceholder,
   isEnabled: () => false,
 };
 


### PR DESCRIPTION
Epic https://github.com/metabase/metabase/issues/26178

How to test:
- Modify https://github.com/metabase/metabase/blob/1f5d8abac569318c922c69c3a2c06d6edb340506/enterprise/frontend/src/metabase-enterprise/caching/index.js#L56 - set this component unconditionally outside of `if`
- Modify https://github.com/metabase/metabase/blob/1f5d8abac569318c922c69c3a2c06d6edb340506/frontend/src/metabase/databases/containers/DatabaseForm/DatabaseForm.tsx#L13 - set to `true`
- Run a fresh Metabase instance in EE mode
- Go to the db form, select a database, open advanced settings and the caching field should be available
- Make sure validation works

<img width="749" alt="Screenshot 2022-12-02 at 17 18 37" src="https://user-images.githubusercontent.com/8542534/205325727-32a6e020-8950-40cd-84ee-d4846e986fff.png">
