### PR TITLE
Add test for temporal extract and now function

### DIFF
--- a/test/metabase/query_processor_test/date_time_zone_functions_test.clj
+++ b/test/metabase/query_processor_test/date_time_zone_functions_test.clj
@@ -406,8 +406,8 @@
 
 (deftest now-with-extract-test
   (mt/test-drivers (mt/normal-drivers-with-feature :now :temporal-extract)
-    (testing "now should work with temporal extract functions according to the results timezone"
-      (let [timezone "Asia/Kathmandu"] ; UTC+5:45 all year
+    (testing "now should work with temporal extract functions according to the report timezone"
+      (doseq [timezone ["UTC" "Asia/Kathmandu"]] ; UTC+5:45 all year
         (mt/with-temporary-setting-values [report-timezone timezone]
           (is (= true
                  (let [[minute hour] (->> (mt/run-mbql-query venues
@@ -422,7 +422,6 @@
                        now              (t/local-date-time (t/zone-id results-timezone))]
                    (and (close-minute? minute (.getMinute now))
                         (close-hour? hour (.getHour now)))))))))))
-
 
 (deftest datetime-math-with-extract-test
   (mt/test-drivers (mt/normal-drivers-with-feature :date-arithmetics)

--- a/test/metabase/query_processor_test/date_time_zone_functions_test.clj
+++ b/test/metabase/query_processor_test/date_time_zone_functions_test.clj
@@ -409,19 +409,18 @@
     (testing "now should work with temporal extract functions according to the report timezone"
       (doseq [timezone ["UTC" "Asia/Kathmandu"]] ; UTC+5:45 all year
         (mt/with-temporary-setting-values [report-timezone timezone]
-          (is (= true
-                 (let [[minute hour] (->> (mt/run-mbql-query venues
-                                            {:expressions {"minute" [:get-minute [:now]]
-                                                           "hour" [:get-hour [:now]]}
-                                             :fields [[:expression "minute"]
-                                                      [:expression "hour"]]
-                                             :limit  1})
-                                          (mt/formatted-rows [int int])
-                                          first)
-                       results-timezone (mt/with-everything-store (qp.timezone/results-timezone-id))
-                       now              (t/local-date-time (t/zone-id results-timezone))]
-                   (and (close-minute? minute (.getMinute now))
-                        (close-hour? hour (.getHour now)))))))))))
+          (let [[minute hour] (->> (mt/run-mbql-query venues
+                                     {:expressions {"minute" [:get-minute [:now]]
+                                                    "hour" [:get-hour [:now]]}
+                                      :fields [[:expression "minute"]
+                                               [:expression "hour"]]
+                                      :limit  1})
+                                   (mt/formatted-rows [int int])
+                                   first)
+                results-timezone (mt/with-everything-store (qp.timezone/results-timezone-id))
+                now              (t/local-date-time (t/zone-id results-timezone))]
+            (is (true? (close-minute? minute (.getMinute now)))
+            (is (true? (close-hour? hour (.getHour now)))))))))))
 
 (deftest datetime-math-with-extract-test
   (mt/test-drivers (mt/normal-drivers-with-feature :date-arithmetics)


### PR DESCRIPTION
This PR adds a test for combining temporal extract functions and the now function in custom expressions.

This should have been tested when the now function was created.

Original now function PR: https://github.com/metabase/metabase/pull/26548/files