### PR TITLE
Serdes v2: Fix flaky e2e test

### DIFF
--- a/src/metabase/models/field.clj
+++ b/src/metabase/models/field.clj
@@ -410,14 +410,16 @@
 (defmethod serdes.base/serdes-dependencies "Field" [field]
   ;; Fields depend on their parent Table, plus any foreign Fields referenced by their Dimensions.
   ;; Take the path, but drop the Field section to get the parent Table's path instead.
-  (let [table (pop (serdes.base/serdes-path field))
+  (let [this  (serdes.base/serdes-path field)
+        table (pop this)
         fks   (some->> field :fk_target_field_id serdes.util/field->path)
         human (->> (:dimensions field)
                    (keep :human_readable_field_id)
                    (map serdes.util/field->path)
                    set)]
     (cond-> (set/union #{table} human)
-      fks   (set/union #{fks}))))
+      fks   (set/union #{fks})
+      true  (disj this))))
 
 (defn- extract-dimensions [dimensions]
   (->> (for [dim dimensions]


### PR DESCRIPTION
It could generate Dimensions which depend on their own parent Fields, which
causes the Fields to have circular deps and fail to load.
This prevents Fields from allowing dependencies on themselves.

