### PR TITLE
Fix FieldValues does not get updated if the source question updated

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/sandbox/models/params/field_values.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/models/params/field_values.clj
@@ -38,9 +38,11 @@
 (defn- field->gtap-attributes-for-current-user
   "Returns the gtap attributes for current user that applied to `field`.
 
-  The gtap-attributes is a list with 2 elements:
+  The gtap-attributes is a list with 3 elements:
   1. card-id - for GTAP that use a saved question
-  2. a map:
+  2. card.updated_at -- for GTAP that use a saved question, this is to make sure
+     when update the card we recompute the FieldValues
+  3. a map:
     if query is mbql query:
       - with key is the user-attribute that applied to the table that `field` is in
       - value is the user-attribute of current user corresponding to the key
@@ -60,6 +62,7 @@
           attribute_remappings (:attribute_remappings gtap)
           field-ids            (db/select-field :id Field :table_id table_id)]
       [(:card_id gtap)
+       (get-in gtap [:card :updated_at])
        (if (= :native (get-in gtap [:card :query_type]))
          ;; For sandbox that uses native query, we can't narrow down to the exact attribute
          ;; that affect the current table. So we just hash the whole login-attributes of users.

--- a/enterprise/backend/test/metabase_enterprise/sandbox/models/params/field_values_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/models/params/field_values_test.clj
@@ -2,7 +2,7 @@
   (:require [clojure.test :refer :all]
             [metabase-enterprise.sandbox.models.group-table-access-policy :refer [GroupTableAccessPolicy]]
             [metabase-enterprise.sandbox.models.params.field-values :as ee-params.field-values]
-            [metabase.models :refer [Card Collection Field FieldValues PermissionsGroup PermissionsGroupMembership User]]
+            [metabase.models :refer [Card Field FieldValues PermissionsGroup PermissionsGroupMembership User]]
             [metabase.models.field-values :as field-values]
             [metabase.models.params.field-values :as params.field-values]
             [metabase.public-settings.premium-features-test :as premium-features-test]

--- a/enterprise/backend/test/metabase_enterprise/sandbox/models/params/field_values_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/models/params/field_values_test.clj
@@ -75,15 +75,15 @@
               (is (= (hash-for-user-id user-id-1 {"State" "CA"} (mt/id :categories :name))
                      (hash-for-user-id user-id-2 {"State" "CA"} (mt/id :categories :name)))))
 
-           (testing "same users but the login_attributes change should have different hash"
-             (is (not= (hash-for-user-id user-id-1 {"State" "CA"} (mt/id :categories :name))
-                       (hash-for-user-id user-id-1 {"State" "NY"} (mt/id :categories :name)))))
+            (testing "same users but the login_attributes change should have different hash"
+              (is (not= (hash-for-user-id user-id-1 {"State" "CA"} (mt/id :categories :name))
+                        (hash-for-user-id user-id-1 {"State" "NY"} (mt/id :categories :name)))))
 
-           (testing "2 users with different login_attributes should have different hash"
-             (is (not= (hash-for-user-id user-id-1 {"State" "CA"} (mt/id :categories :name))
-                       (hash-for-user-id user-id-2 {"State" "NY"} (mt/id :categories :name))))
-             (is (not= (hash-for-user-id user-id-1 {} (mt/id :categories :name))
-                       (hash-for-user-id user-id-2 {"State" "NY"} (mt/id :categories :name)))))))))
+            (testing "2 users with different login_attributes should have different hash"
+              (is (not= (hash-for-user-id user-id-1 {"State" "CA"} (mt/id :categories :name))
+                        (hash-for-user-id user-id-2 {"State" "NY"} (mt/id :categories :name))))
+              (is (not= (hash-for-user-id user-id-1 {} (mt/id :categories :name))
+                        (hash-for-user-id user-id-2 {"State" "NY"} (mt/id :categories :name)))))))))
 
     (testing "gtap with card and remappings"
       ;; hack so that we don't have to setup all the sandbox permissions the table
@@ -115,69 +115,69 @@
                 (is (not= (hash-for-user-id-with-attributes user-id-1 {"State" "CA"} (mt/id :categories :name))
                           (hash-for-user-id-with-attributes user-id-2 {"State" "CA"} (mt/id :categories :id)))))
 
-             (testing "with different attributes, the hash should be the different"
-               (is (not= (hash-for-user-id-with-attributes user-id-1 {"State" "CA"} (mt/id :categories :name))
-                         (hash-for-user-id-with-attributes user-id-2 {"State" "NY"} (mt/id :categories :name)))))))
+              (testing "with different attributes, the hash should be the different"
+                (is (not= (hash-for-user-id-with-attributes user-id-1 {"State" "CA"} (mt/id :categories :name))
+                          (hash-for-user-id-with-attributes user-id-2 {"State" "NY"} (mt/id :categories :name)))))))
 
           (testing "gtap with native question"
-           (mt/with-temp*
-             [Card                       [{card-id :id} {:query_type :native
-                                                         :name "A native query"
-                                                         :dataset_query
-                                                         {:type :native
-                                                          :database (mt/id)
-                                                          :native
-                                                          {:query "SELECT * FROM People WHERE state = {{STATE}}"
-                                                           :template-tags
-                                                           {"STATE" {:id "72461b3b-3877-4538-a5a3-7a3041924517"
-                                                                     :name "STATE"
-                                                                     :display-name "STATE"
-                                                                     :type "text"}}}}}]
-              PermissionsGroup           [{group-id :id}]
-              User                       [{user-id :id}]
-              PermissionsGroupMembership [_ {:group_id group-id
-                                             :user_id user-id}]
-              GroupTableAccessPolicy     [_ {:card_id card-id
-                                             :group_id group-id
-                                             :table_id (mt/id :categories)
-                                             :attribute_remappings {"State" [:variable [:template-tag "STATE"]]}}]]
-             (testing "same users but if the login_attributes change, they should have different hash (#24966)"
-               (is (not= (hash-for-user-id-with-attributes user-id {"State" "CA"} (mt/id :categories :name))
-                         (hash-for-user-id-with-attributes user-id {"State" "NY"} (mt/id :categories :name)))))))
+            (mt/with-temp*
+              [Card                       [{card-id :id} {:query_type :native
+                                                          :name "A native query"
+                                                          :dataset_query
+                                                          {:type :native
+                                                           :database (mt/id)
+                                                           :native
+                                                           {:query "SELECT * FROM People WHERE state = {{STATE}}"
+                                                            :template-tags
+                                                            {"STATE" {:id "72461b3b-3877-4538-a5a3-7a3041924517"
+                                                                      :name "STATE"
+                                                                      :display-name "STATE"
+                                                                      :type "text"}}}}}]
+               PermissionsGroup           [{group-id :id}]
+               User                       [{user-id :id}]
+               PermissionsGroupMembership [_ {:group_id group-id
+                                              :user_id user-id}]
+               GroupTableAccessPolicy     [_ {:card_id card-id
+                                              :group_id group-id
+                                              :table_id (mt/id :categories)
+                                              :attribute_remappings {"State" [:variable [:template-tag "STATE"]]}}]]
+              (testing "same users but if the login_attributes change, they should have different hash (#24966)"
+                (is (not= (hash-for-user-id-with-attributes user-id {"State" "CA"} (mt/id :categories :name))
+                          (hash-for-user-id-with-attributes user-id {"State" "NY"} (mt/id :categories :name)))))))
 
           (testing "2 users in different groups but gtaps use the same card"
-           (mt/with-temp*
-             [Card                       [{card-id :id}]
+            (mt/with-temp*
+              [Card                       [{card-id :id}]
 
-              ;; user 1 in group 1
-              User                       [{user-id-1 :id}]
-              PermissionsGroup           [{group-id-1 :id}]
-              PermissionsGroupMembership [_ {:group_id group-id-1
-                                             :user_id user-id-1}]
-              GroupTableAccessPolicy     [_ {:card_id card-id
-                                             :group_id group-id-1
-                                             :table_id (mt/id :categories)
-                                             :attribute_remappings {"State" [:dimension [:field (mt/id :categories :name) nil]]}}]
-              ;; user 2 in group 2 with gtap using the same card
-              User                       [{user-id-2 :id}]
-              PermissionsGroup           [{group-id-2 :id}]
-              PermissionsGroupMembership [_ {:group_id group-id-2
-                                             :user_id user-id-2}]
-              GroupTableAccessPolicy     [_ {:card_id card-id
-                                             :group_id group-id-2
-                                             :table_id (mt/id :categories)
-                                             :attribute_remappings {"State" [:dimension [:field (mt/id :categories :name) nil]]}}]]
-             (testing "with the same attributes, the hash should be the same"
-               (is (= (hash-for-user-id-with-attributes user-id-1 {"State" "CA"} (mt/id :categories :name))
-                      (hash-for-user-id-with-attributes user-id-2 {"State" "CA"} (mt/id :categories :name)))))
+               ;; user 1 in group 1
+               User                       [{user-id-1 :id}]
+               PermissionsGroup           [{group-id-1 :id}]
+               PermissionsGroupMembership [_ {:group_id group-id-1
+                                              :user_id user-id-1}]
+               GroupTableAccessPolicy     [_ {:card_id card-id
+                                              :group_id group-id-1
+                                              :table_id (mt/id :categories)
+                                              :attribute_remappings {"State" [:dimension [:field (mt/id :categories :name) nil]]}}]
+               ;; user 2 in group 2 with gtap using the same card
+               User                       [{user-id-2 :id}]
+               PermissionsGroup           [{group-id-2 :id}]
+               PermissionsGroupMembership [_ {:group_id group-id-2
+                                              :user_id user-id-2}]
+               GroupTableAccessPolicy     [_ {:card_id card-id
+                                              :group_id group-id-2
+                                              :table_id (mt/id :categories)
+                                              :attribute_remappings {"State" [:dimension [:field (mt/id :categories :name) nil]]}}]]
+              (testing "with the same attributes, the hash should be the same"
+                (is (= (hash-for-user-id-with-attributes user-id-1 {"State" "CA"} (mt/id :categories :name))
+                       (hash-for-user-id-with-attributes user-id-2 {"State" "CA"} (mt/id :categories :name)))))
 
-             (testing "with same attributes, the hash should different for different fields"
-               (is (not= (hash-for-user-id-with-attributes user-id-1 {"State" "CA"} (mt/id :categories :name))
-                         (hash-for-user-id-with-attributes user-id-2 {"State" "CA"} (mt/id :categories :id)))))
+              (testing "with same attributes, the hash should different for different fields"
+                (is (not= (hash-for-user-id-with-attributes user-id-1 {"State" "CA"} (mt/id :categories :name))
+                          (hash-for-user-id-with-attributes user-id-2 {"State" "CA"} (mt/id :categories :id)))))
 
-            (testing "with different attributes, the hash should be the different"
-              (is (not= (hash-for-user-id-with-attributes user-id-1 {"State" "CA"} (mt/id :categories :name))
-                        (hash-for-user-id-with-attributes user-id-2 {"State" "NY"} (mt/id :categories :name)))))))
+              (testing "with different attributes, the hash should be the different"
+                (is (not= (hash-for-user-id-with-attributes user-id-1 {"State" "CA"} (mt/id :categories :name))
+                          (hash-for-user-id-with-attributes user-id-2 {"State" "NY"} (mt/id :categories :name)))))))
 
           (testing "2 users in different groups and gtaps use 2 different cards"
             (mt/with-temp*
@@ -219,16 +219,21 @@
                                              :attribute_remappings {"State" [:dimension [:field (mt/id :categories :name) nil]]}}]]
              (let [current-user-hash (fn []
                                        (mw.session/with-current-user user-id
-                                        (ee-params.field-values/hash-key-for-sandbox (mt/id :categories :name))))]
+                                         (ee-params.field-values/hash-key-for-sandbox (mt/id :categories :name))))]
 
                (testing "update dataset_query should change the hash"
                  (let [old-hash (current-user-hash)
-                       _        (db/update! Card card-id {:dataset_query (mt/mbql-query categories)})
+                       ;; have to hard code the tests because updated_at in mysql has second precisions
+                       ;; and the hash use updated_at to check if the card is changed
+                       ;; so if the tests run to fast, this test will be flaky
+                       _        (db/update! Card card-id {:dataset_query (mt/mbql-query categories)
+                                                          :updated_at    #t "2022-01-01 03:04:05"})
                        new-hash (current-user-hash)]
-                  (is (not= old-hash new-hash))))
+                   (is (not= old-hash new-hash))))
 
                (testing "update collection_id should change the hash"
                  (let [old-hash (current-user-hash)
-                       _        (db/update! Card card-id {:collection_id (db/select-one-id Collection)})
-                       new-hash (current-user-hash)]
-                  (is (not= old-hash new-hash))))))))))))
+                       _        (db/update! Card card-id {:dataset_query (mt/mbql-query categories)
+                                                          :updated_at    #t "2022-01-01 03:04:06"})
+                                new-hash (current-user-hash)]
+                      (is (not= old-hash new-hash))))))))))))

--- a/enterprise/backend/test/metabase_enterprise/sandbox/models/params/field_values_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/models/params/field_values_test.clj
@@ -2,7 +2,7 @@
   (:require [clojure.test :refer :all]
             [metabase-enterprise.sandbox.models.group-table-access-policy :refer [GroupTableAccessPolicy]]
             [metabase-enterprise.sandbox.models.params.field-values :as ee-params.field-values]
-            [metabase.models :refer [Card Field FieldValues PermissionsGroup PermissionsGroupMembership User]]
+            [metabase.models :refer [Card Collection Field FieldValues PermissionsGroup PermissionsGroupMembership User]]
             [metabase.models.field-values :as field-values]
             [metabase.models.params.field-values :as params.field-values]
             [metabase.public-settings.premium-features-test :as premium-features-test]
@@ -120,64 +120,64 @@
                          (hash-for-user-id-with-attributes user-id-2 {"State" "NY"} (mt/id :categories :name)))))))
 
           (testing "gtap with native question"
-            (mt/with-temp*
-              [Card                       [{card-id :id} {:query_type :native
-                                                          :name "A native query"
-                                                          :dataset_query
-                                                          {:type :native
-                                                           :database (mt/id)
-                                                           :native
-                                                           {:query "SELECT * FROM People WHERE state = {{STATE}}"
-                                                            :template-tags
-                                                            {"STATE" {:id "72461b3b-3877-4538-a5a3-7a3041924517"
-                                                                      :name "STATE"
-                                                                      :display-name "STATE"
-                                                                      :type "text"}}}}}]
-               PermissionsGroup           [{group-id :id}]
-               User                       [{user-id :id}]
-               PermissionsGroupMembership [_ {:group_id group-id
-                                              :user_id user-id}]
-               GroupTableAccessPolicy     [_ {:card_id card-id
-                                              :group_id group-id
-                                              :table_id (mt/id :categories)
-                                              :attribute_remappings {"State" [:variable [:template-tag "STATE"]]}}]]
-              (testing "same users but if the login_attributes change, they should have different hash (#24966)"
-                (is (not= (hash-for-user-id-with-attributes user-id {"State" "CA"} (mt/id :categories :name))
-                          (hash-for-user-id-with-attributes user-id {"State" "NY"} (mt/id :categories :name)))))))
+           (mt/with-temp*
+             [Card                       [{card-id :id} {:query_type :native
+                                                         :name "A native query"
+                                                         :dataset_query
+                                                         {:type :native
+                                                          :database (mt/id)
+                                                          :native
+                                                          {:query "SELECT * FROM People WHERE state = {{STATE}}"
+                                                           :template-tags
+                                                           {"STATE" {:id "72461b3b-3877-4538-a5a3-7a3041924517"
+                                                                     :name "STATE"
+                                                                     :display-name "STATE"
+                                                                     :type "text"}}}}}]
+              PermissionsGroup           [{group-id :id}]
+              User                       [{user-id :id}]
+              PermissionsGroupMembership [_ {:group_id group-id
+                                             :user_id user-id}]
+              GroupTableAccessPolicy     [_ {:card_id card-id
+                                             :group_id group-id
+                                             :table_id (mt/id :categories)
+                                             :attribute_remappings {"State" [:variable [:template-tag "STATE"]]}}]]
+             (testing "same users but if the login_attributes change, they should have different hash (#24966)"
+               (is (not= (hash-for-user-id-with-attributes user-id {"State" "CA"} (mt/id :categories :name))
+                         (hash-for-user-id-with-attributes user-id {"State" "NY"} (mt/id :categories :name)))))))
 
           (testing "2 users in different groups but gtaps use the same card"
-            (mt/with-temp*
-              [Card                       [{card-id :id}]
+           (mt/with-temp*
+             [Card                       [{card-id :id}]
 
-               ;; user 1 in group 1
-               User                       [{user-id-1 :id}]
-               PermissionsGroup           [{group-id-1 :id}]
-               PermissionsGroupMembership [_ {:group_id group-id-1
-                                              :user_id user-id-1}]
-               GroupTableAccessPolicy     [_ {:card_id card-id
-                                              :group_id group-id-1
-                                              :table_id (mt/id :categories)
-                                              :attribute_remappings {"State" [:dimension [:field (mt/id :categories :name) nil]]}}]
-               ;; user 2 in group 2 with gtap using the same card
-               User                       [{user-id-2 :id}]
-               PermissionsGroup           [{group-id-2 :id}]
-               PermissionsGroupMembership [_ {:group_id group-id-2
-                                              :user_id user-id-2}]
-               GroupTableAccessPolicy     [_ {:card_id card-id
-                                              :group_id group-id-2
-                                              :table_id (mt/id :categories)
-                                              :attribute_remappings {"State" [:dimension [:field (mt/id :categories :name) nil]]}}]]
-              (testing "with the same attributes, the hash should be the same"
-                (is (= (hash-for-user-id-with-attributes user-id-1 {"State" "CA"} (mt/id :categories :name))
-                       (hash-for-user-id-with-attributes user-id-2 {"State" "CA"} (mt/id :categories :name)))))
+              ;; user 1 in group 1
+              User                       [{user-id-1 :id}]
+              PermissionsGroup           [{group-id-1 :id}]
+              PermissionsGroupMembership [_ {:group_id group-id-1
+                                             :user_id user-id-1}]
+              GroupTableAccessPolicy     [_ {:card_id card-id
+                                             :group_id group-id-1
+                                             :table_id (mt/id :categories)
+                                             :attribute_remappings {"State" [:dimension [:field (mt/id :categories :name) nil]]}}]
+              ;; user 2 in group 2 with gtap using the same card
+              User                       [{user-id-2 :id}]
+              PermissionsGroup           [{group-id-2 :id}]
+              PermissionsGroupMembership [_ {:group_id group-id-2
+                                             :user_id user-id-2}]
+              GroupTableAccessPolicy     [_ {:card_id card-id
+                                             :group_id group-id-2
+                                             :table_id (mt/id :categories)
+                                             :attribute_remappings {"State" [:dimension [:field (mt/id :categories :name) nil]]}}]]
+             (testing "with the same attributes, the hash should be the same"
+               (is (= (hash-for-user-id-with-attributes user-id-1 {"State" "CA"} (mt/id :categories :name))
+                      (hash-for-user-id-with-attributes user-id-2 {"State" "CA"} (mt/id :categories :name)))))
 
-              (testing "with same attributes, the hash should different for different fields"
-                (is (not= (hash-for-user-id-with-attributes user-id-1 {"State" "CA"} (mt/id :categories :name))
-                          (hash-for-user-id-with-attributes user-id-2 {"State" "CA"} (mt/id :categories :id)))))
-
-             (testing "with different attributes, the hash should be the different"
+             (testing "with same attributes, the hash should different for different fields"
                (is (not= (hash-for-user-id-with-attributes user-id-1 {"State" "CA"} (mt/id :categories :name))
-                         (hash-for-user-id-with-attributes user-id-2 {"State" "NY"} (mt/id :categories :name)))))))
+                         (hash-for-user-id-with-attributes user-id-2 {"State" "CA"} (mt/id :categories :id)))))
+
+            (testing "with different attributes, the hash should be the different"
+              (is (not= (hash-for-user-id-with-attributes user-id-1 {"State" "CA"} (mt/id :categories :name))
+                        (hash-for-user-id-with-attributes user-id-2 {"State" "NY"} (mt/id :categories :name)))))))
 
           (testing "2 users in different groups and gtaps use 2 different cards"
             (mt/with-temp*
@@ -204,4 +204,31 @@
                 (is (not= (hash-for-user-id-with-attributes user-id-1 {"State" "CA"} (mt/id :categories :name))
                           (hash-for-user-id-with-attributes user-id-2 {"State" "CA"} (mt/id :categories :name))))
                 (is (not= (hash-for-user-id-with-attributes user-id-1 {"State" "CA"} (mt/id :categories :name))
-                          (hash-for-user-id-with-attributes user-id-2 {"State" "NY"} (mt/id :categories :name))))))))))))
+                          (hash-for-user-id-with-attributes user-id-2 {"State" "NY"} (mt/id :categories :name)))))))
+
+         (testing "hash should change if the card got updated #25411"
+           (mt/with-temp*
+             [Card                       [{card-id :id}]
+              User                       [{user-id :id}]
+              PermissionsGroup           [{group-id :id}]
+              PermissionsGroupMembership [_ {:group_id group-id
+                                             :user_id user-id}]
+              GroupTableAccessPolicy     [_ {:card_id              card-id
+                                             :group_id             group-id
+                                             :table_id             (mt/id :categories)
+                                             :attribute_remappings {"State" [:dimension [:field (mt/id :categories :name) nil]]}}]]
+             (let [current-user-hash (fn []
+                                       (mw.session/with-current-user user-id
+                                        (ee-params.field-values/hash-key-for-sandbox (mt/id :categories :name))))]
+
+               (testing "update dataset_query should change the hash"
+                 (let [old-hash (current-user-hash)
+                       _        (db/update! Card card-id {:dataset_query (mt/mbql-query categories)})
+                       new-hash (current-user-hash)]
+                  (is (not= old-hash new-hash))))
+
+               (testing "update collection_id should change the hash"
+                 (let [old-hash (current-user-hash)
+                       _        (db/update! Card card-id {:collection_id (db/select-one-id Collection)})
+                       new-hash (current-user-hash)]
+                  (is (not= old-hash new-hash))))))))))))


### PR DESCRIPTION
Fixes #25411

In https://github.com/metabase/metabase/pull/23435 we introduced the Advanced FieldValues where we cache the field values for sandboxing and identify it using a hash.

We have the 25411 bug because the list we used to compute the hash didn't consider the case when the card is updated. 

So when the card changes but the hash are still the same => we return the old values.

The fix is quite simple, adding `updated_at` when computing the hash, I didn't use `dataset_query` because I think it's okay to be generous here. It also takes care of cases when the card is moved between collections as well.