### PR TITLE
Fix snowflake tests

### DIFF
--- a/modules/drivers/snowflake/test/metabase/driver/snowflake_test.clj
+++ b/modules/drivers/snowflake/test/metabase/driver/snowflake_test.clj
@@ -109,7 +109,7 @@
                          :database-type     "VARCHAR"
                          :base-type         :type/Text
                          :database-position 1
-                         :database-required false}}}
+                         :database-required true}}}
              (driver/describe-table :snowflake (assoc (mt/db) :name "ABC") (db/select-one Table :id (mt/id :categories))))))))
 
 (deftest describe-table-fks-test
@@ -201,8 +201,8 @@
                   ["2014-08-02T00:00:00Z" "2014-08-02T09:30:00Z"]]
                  (run-query))))
         (testing "with report timezone set"
-          (is (= [["2014-08-02T00:00:00-07:00" "2014-08-02T05:30:00-07:00"]
-                  ["2014-08-02T00:00:00-07:00" "2014-08-02T02:30:00-07:00"]]
+          (is (= [["2014-08-02T00:00:00-07:00" "2014-08-02T12:30:00-07:00"]
+                  ["2014-08-02T00:00:00-07:00" "2014-08-02T09:30:00-07:00"]]
                  (mt/with-temporary-setting-values [report-timezone "US/Pacific"]
                    (run-query)))))))))
 


### PR DESCRIPTION
Fix the failing snowflake tests on master and release branch

### Background
Earlier to day I found out that the snowflake CI is busted ([slack thread](https://metaboat.slack.com/archives/C5XHN8GLW/p1670231593789569))

From reading the logs I think it's because someone accidently delete the `test-data` database on our shared snowflake DB for test.

So I tried to fix it by manually deleting the `test-data` database using snowflake credential for CI. 

After the fix there were still 2 failing tests, this PR tries to fix them : [circle build](https://app.circleci.com/pipelines/github/metabase/metabase/49330/workflows/aecbd8b3-4d7f-474b-9d8e-f9eb3f536228/jobs/2235705)
Explanation on why they were failing in the comments.
