### PR TITLE
Fix numeric parameter values in jwt

### DIFF
--- a/src/metabase/query_processor/dashboard.clj
+++ b/src/metabase/query_processor/dashboard.clj
@@ -74,12 +74,13 @@
        request-param
        ;; if value comes in as a lone value for an operator filter type (as will be the case for embedding) wrap it in a
        ;; vector so the parameter handling code doesn't explode.
-       (when (and (params.ops/operator? (:type matching-param))
-                  (if (string? (:value request-param))
-                    (not (str/blank? (:value request-param)))
-                    (some? (:value request-param)))
-                  (not (sequential? (:value request-param))))
-         {:value [(:value request-param)]})
+       (let [value (:value request-param)]
+         (when (and (params.ops/operator? (:type matching-param))
+                    (if (string? value)
+                      (not (str/blank? value))
+                      (some? value))
+                    (not (sequential? value)))
+           {:value [value]}))
        {:id     param-id
         :target (:target matching-mapping)}))))
 

--- a/src/metabase/query_processor/dashboard.clj
+++ b/src/metabase/query_processor/dashboard.clj
@@ -1,6 +1,7 @@
 (ns metabase.query-processor.dashboard
   "Code for running a query in the context of a specific DashboardCard."
-  (:require [clojure.tools.logging :as log]
+  (:require [clojure.string :as str]
+            [clojure.tools.logging :as log]
             [medley.core :as m]
             [metabase.api.common :as api]
             [metabase.driver.common.parameters.operators :as params.ops]
@@ -74,7 +75,9 @@
        ;; if value comes in as a lone value for an operator filter type (as will be the case for embedding) wrap it in a
        ;; vector so the parameter handling code doesn't explode.
        (when (and (params.ops/operator? (:type matching-param))
-                  (seq (:value request-param))
+                  (if (string? (:value request-param))
+                    (not (str/blank? (:value request-param)))
+                    (some? (:value request-param)))
                   (not (sequential? (:value request-param))))
          {:value [(:value request-param)]})
        {:id     param-id


### PR DESCRIPTION
Fixes #25031 

#### Before
<img width="945" alt="image" src="https://user-images.githubusercontent.com/6377293/205748508-912371ef-7f8d-4958-937e-410ab8ecd389.png">


#### After
<img width="984" alt="image" src="https://user-images.githubusercontent.com/6377293/205748001-b1a208c1-1b72-4211-a078-8350ee067a25.png">


Don't call `seq` on numbers. If its a string, assert it isn't blank, otherwise check that it is non-null.

Linked issue has repro steps. Sending a payload of `{... :value 4}` was failing. We added the new operators like `:string/=` and `:number/=`. The code checks that there is a value with `(seq value)` which fails on numeric inputs.

If you need help on the repro steps, check out https://github.com/metabase/embedding-reference-apps which has a node app that can run embedding. This app is a bit more heavy weight than we need (it has login, sessions, many routes, etc) so you can use the following:

Replace `index.js` with the following:

```javascript
const express = require("express");
const jwt = require("jsonwebtoken");

const PORT = process.env["PORT"] ? parseInt(process.env["PORT"]) : 4000;

var METABASE_SITE_URL = "http://localhost:3000";
var METABASE_SECRET_KEY = "<your-key from the UI>"

const app = express();

app.set("view engine", "pug");

app.get("/foo", (req, res) => {
    var payload = {   // this is the payload from the embedding settings. use your own
      resource: { dashboard: 683 },
      params: {
        "equal_to": 3
      },
      exp: Math.round(Date.now() / 1000) + (100 * 60) // I made this much longer
    };
    var token = jwt.sign(payload, METABASE_SECRET_KEY);

    var iframeUrl = METABASE_SITE_URL + "/embed/dashboard/" + token + "#bordered=true&titled=true";
    res.render("foo", {iframeUrl: iframeUrl });

});

app.listen(PORT, () => {
  console.log("Example app listening on port " + PORT + "!");
});
```

and `views/foo.pug`:
```

extends layout.pug

block content
    h1 Embedding charts with signed parameters

    p This is an example of an embedded chart with a signed parameter. Signed parameters are question parameters that must be signed by the embedding application.

    a(href="/") Go back to a global view
    p
        This results in the below when put together

    iframe(
        src=iframeUrl
        frameborder="0"
        width="800"
        height="600"
        allowtransparency)
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/26969)
<!-- Reviewable:end -->
