### PR TITLE
Disable field value scanning for inactive fields

### DIFF
--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -13005,6 +13005,22 @@ databaseChangeLog:
         - dbms:
             type: mysql,mariadb
 
+  - changeSet:
+      id: v46.00-027
+      author: snoe
+      comment: Added 0.46.0 -- add last_used_at to FieldValues
+      changes:
+        - addColumn:
+            tableName: metabase_fieldvalues
+            columns:
+              - column:
+                  name: last_used_at
+                  type: ${timestamp_type}
+                  remarks: Timestamp of when these FieldValues were last used.
+                  constraints:
+                    nullable: false
+                  defaultValueComputed: current_timestamp
+
 # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################

--- a/src/metabase/sync/field_values.clj
+++ b/src/metabase/sync/field_values.clj
@@ -23,7 +23,11 @@
 
 (s/defn ^:private update-field-values-for-field! [field :- i/FieldInstance]
   (log/debug (u/format-color 'green "Looking into updating FieldValues for %s" (sync-util/name-for-logging field)))
-  (field-values/create-or-update-full-field-values! field))
+  (let [field-values (db/select-one FieldValues :field_id (u/the-id field) :type :full)]
+    (if (field-values/inactive? field-values)
+      (log/debug (trs "Field {0} has not been used since {1}. Skipping..."
+                      (sync-util/name-for-logging field) (t/format "yyyy-MM-dd" (t/local-date-time (:last_used_at field-values)))))
+      (field-values/create-or-update-full-field-values! field))))
 
 (defn- update-field-value-stats-count [counts-map result]
   (if (instance? Exception result)

--- a/test/metabase/sync/field_values_test.clj
+++ b/test/metabase/sync/field_values_test.clj
@@ -58,8 +58,8 @@
   (testing "Test that syncing will skip updating inactive FieldValues"
     (db/update! FieldValues
                 (db/select-one-id FieldValues :field_id (mt/id :venues :price) :type :full)
-                :last_used_at (t/minus (t/offset-date-time) (t/days 20)))
-    (db/update! FieldValues (db/select-one-id FieldValues :field_id (mt/id :venues :price) :type :full) :values [1 2 3])
+                :last_used_at (t/minus (t/offset-date-time) (t/days 20))
+                :values [1 2 3])
     (is (= (repeat 2 {:errors 0, :created 0, :updated 0, :deleted 0})
            (sync-database!' "update-field-values" (data/db))))
     (is (= [1 2 3] (venues-price-field-values)))

--- a/test/metabase/sync/field_values_test.clj
+++ b/test/metabase/sync/field_values_test.clj
@@ -69,6 +69,7 @@
       (let [last-used-at (db/select-one-field :last_used_at FieldValues :field_id (mt/id :venues :price) :type :full)]
         (is (t/after? last-used-at (t/minus (t/offset-date-time) (t/hours 2))))
         (testing "Fetching again updates last-used-at"
+          (Thread/sleep 500) ;; Let clock advance to make sure last-used-at is different
           (mt/user-http-request :rasta :get 200 (format "field/%d/values" (mt/id :venues :price)))
           (is (t/after?
                 (db/select-one-field :last_used_at FieldValues :field_id (mt/id :venues :price) :type :full)

--- a/test/metabase/sync/field_values_test.clj
+++ b/test/metabase/sync/field_values_test.clj
@@ -54,6 +54,26 @@
       (is (= [1 2 3 4]
              (venues-price-field-values))))))
 
+(deftest sync-should-properly-handle-last-used-at
+  (testing "Test that syncing will skip updating inactive FieldValues"
+    (db/update! FieldValues
+                (db/select-one-id FieldValues :field_id (mt/id :venues :price) :type :full)
+                :last_used_at (t/minus (t/offset-date-time) (t/days 20)))
+    (db/update! FieldValues (db/select-one-id FieldValues :field_id (mt/id :venues :price) :type :full) :values [1 2 3])
+    (is (= (repeat 2 {:errors 0, :created 0, :updated 0, :deleted 0})
+           (sync-database!' "update-field-values" (data/db))))
+    (is (= [1 2 3] (venues-price-field-values)))
+    (testing "Fetching field values causes an on-demand update and marks Field Values as active"
+      (is (partial= {:values [[1] [2] [3] [4]]}
+                    (mt/user-http-request :rasta :get 200 (format "field/%d/values" (mt/id :venues :price)))))
+      (let [last-used-at (db/select-one-field :last_used_at FieldValues :field_id (mt/id :venues :price) :type :full)]
+        (is (t/after? last-used-at (t/minus (t/offset-date-time) (t/hours 2))))
+        (testing "Fetching again updates last-used-at"
+          (mt/user-http-request :rasta :get 200 (format "field/%d/values" (mt/id :venues :price)))
+          (is (t/after?
+                (db/select-one-field :last_used_at FieldValues :field_id (mt/id :venues :price) :type :full)
+                last-used-at)))))))
+
 (deftest sync-should-delete-expired-advanced-field-values-test
   (testing "Test that the expired Advanced FieldValues should be removed"
     (let [field-id                  (mt/id :venues :price)

--- a/test/metabase/sync/field_values_test.clj
+++ b/test/metabase/sync/field_values_test.clj
@@ -66,14 +66,16 @@
     (testing "Fetching field values causes an on-demand update and marks Field Values as active"
       (is (partial= {:values [[1] [2] [3] [4]]}
                     (mt/user-http-request :rasta :get 200 (format "field/%d/values" (mt/id :venues :price)))))
-      (let [last-used-at (db/select-one-field :last_used_at FieldValues :field_id (mt/id :venues :price) :type :full)]
-        (is (t/after? last-used-at (t/minus (t/offset-date-time) (t/hours 2))))
-        (testing "Fetching again updates last-used-at"
-          (Thread/sleep 500) ;; Let clock advance to make sure last-used-at is different
-          (mt/user-http-request :rasta :get 200 (format "field/%d/values" (mt/id :venues :price)))
-          (is (t/after?
-                (db/select-one-field :last_used_at FieldValues :field_id (mt/id :venues :price) :type :full)
-                last-used-at)))))))
+      (is (t/after? (db/select-one-field :last_used_at FieldValues :field_id (mt/id :venues :price) :type :full)
+                    (t/minus (t/offset-date-time) (t/hours 2))))
+      (testing "Field is syncing after usage"
+        (db/update! FieldValues
+                    (db/select-one-id FieldValues :field_id (mt/id :venues :price) :type :full)
+                    :values [1 2 3])
+        (is (= (repeat 2 {:errors 0, :created 0, :updated 1, :deleted 0})
+               (sync-database!' "update-field-values" (data/db))))
+        (is (partial= {:values [[1] [2] [3] [4]]}
+                      (mt/user-http-request :rasta :get 200 (format "field/%d/values" (mt/id :venues :price)))))))))
 
 (deftest sync-should-delete-expired-advanced-field-values-test
   (testing "Test that the expired Advanced FieldValues should be removed"


### PR DESCRIPTION
Fixes #26863

Adds `last-used-at` to `metabase_fieldvalues` table.

This is used to track when full FieldValues are fetched, which should always happen through `get-or-create-full-field-values!` If an inactive FieldValues is queried, they will be updated immediately
 to be returned to the user and a new last-used-at will be set so that
 sync will start picking it up.

During field values sync, if `last-used-at` occurred more than 14 days ago, then we will no longer query and synchronize this field until it is queried for again.