### PR TITLE
Disable Editing Implicit Actions

### DIFF
--- a/frontend/src/metabase/actions/containers/ActionPicker/ActionPicker.tsx
+++ b/frontend/src/metabase/actions/containers/ActionPicker/ActionPicker.tsx
@@ -13,7 +13,7 @@ import type { State } from "metabase-types/store";
 import Icon from "metabase/components/Icon";
 import Button from "metabase/core/components/Button";
 
-import { isImplicitAction } from "metabase/writeback/utils";
+import { isImplicitAction } from "metabase/actions/utils";
 import { ActionCreator } from "metabase/actions/components/ActionCreator";
 
 import {

--- a/frontend/src/metabase/actions/containers/ActionPicker/ActionPicker.tsx
+++ b/frontend/src/metabase/actions/containers/ActionPicker/ActionPicker.tsx
@@ -13,6 +13,7 @@ import type { State } from "metabase-types/store";
 import Icon from "metabase/components/Icon";
 import Button from "metabase/core/components/Button";
 
+import { isImplicitAction } from "metabase/writeback/utils";
 import { ActionCreator } from "metabase/actions/components/ActionCreator";
 
 import {
@@ -92,7 +93,7 @@ function ModelActionPicker({
                 <ActionName onClick={() => onClick(action)}>
                   {action.name}
                 </ActionName>
-                {!!action.id && (
+                {!isImplicitAction(action) && (
                   <EditButton
                     icon="pencil"
                     onlyIcon


### PR DESCRIPTION
## Description

https://github.com/metabase/metabase/pull/26717 made implicit actions first-class actions with their own action ids. This broke the check in the add action sidebar where we disallowed editing implicit actions (because there's no query to edit).  This updates the implicit action check to properly disable editing of implicit actions.


Before | After
--- | ---
![Screen Shot 2022-12-05 at 3 30 27 PM](https://user-images.githubusercontent.com/30528226/205756755-88122657-9674-454b-8076-d507a6436dca.png) | ![Screen Shot 2022-12-05 at 3 29 49 PM](https://user-images.githubusercontent.com/30528226/205756756-97e13124-2433-417b-a93c-45de03b303ea.png)

## Testing Steps
[Data Apps Setup/Testing Instructions](https://www.notion.so/metabase/Testing-Metabase-Data-Apps-33db729b76b84864937d751126ba8360)

In order to test this, you will need
1. A metabase instance spun up with the `MB_EXPERIMENTAL_ACTIONS` flag set to true
2. A writeable database connected to metabase (preferable postgres)
3. Actions enabled on that database ☝️ 
4. A data app created in your metabase instance
5. One or more custom actions created for models in your data app.
