### PR TITLE
Store DBMS version in Database

### DIFF
--- a/modules/drivers/druid/src/metabase/driver/druid.clj
+++ b/modules/drivers/druid/src/metabase/driver/druid.clj
@@ -22,6 +22,10 @@
   [_ database table]
   (druid.sync/describe-table database table))
 
+(defmethod driver/dbms-version :druid
+  [_ database]
+  (druid.sync/dbms-version database))
+
 (defmethod driver/describe-database :druid
   [_ database]
   (druid.sync/describe-database database))

--- a/modules/drivers/druid/src/metabase/driver/druid/sync.clj
+++ b/modules/drivers/druid/src/metabase/driver/druid/sync.clj
@@ -53,3 +53,11 @@
     (let [druid-datasources (druid.client/GET (druid.client/details->url details-with-tunnel "/druid/v2/datasources"))]
       {:tables (set (for [table-name druid-datasources]
                       {:schema nil, :name table-name}))})))
+
+(defn dbms-version
+  "Impl of `driver/dbms-version` for Druid."
+  [database]
+  {:pre [(map? (:details database))]}
+  (ssh/with-ssh-tunnel [details-with-tunnel (:details database)]
+    (-> (druid.client/GET (druid.client/details->url details-with-tunnel "/status"))
+        (select-keys [:version]))))

--- a/modules/drivers/druid/test/metabase/driver/druid/sync_test.clj
+++ b/modules/drivers/druid/test/metabase/driver/druid/sync_test.clj
@@ -1,8 +1,13 @@
 (ns metabase.driver.druid.sync-test
   (:require [clojure.test :refer :all]
             [metabase.driver :as driver]
+            [metabase.models.database :refer [Database]]
+            [metabase.sync.sync-metadata.dbms-version :as sync-dbms-ver]
             [metabase.test :as mt]
-            [metabase.timeseries-query-processor-test.util :as tqpt]))
+            [metabase.timeseries-query-processor-test.util :as tqpt]
+            [metabase.util :as u]
+            [schema.core :as s]
+            [toucan.db :as db]))
 
 (deftest sync-test
   (mt/test-driver :druid
@@ -28,3 +33,28 @@
                          {:name "user_last_login",     :base-type :type/Text,             :database-type "STRING",               :database-position 11}]}
                (-> (driver/describe-table :druid (mt/db) {:name "checkins"})
                    (update :fields (partial sort-by :database-position)))))))))
+
+(defn- db-dbms-version [db-or-id]
+  (db/select-one-field :dbms_version Database :id (u/the-id db-or-id)))
+
+(defn- check-dbms-version [dbms-version]
+  (s/check sync-dbms-ver/DBMSVersion dbms-version))
+
+(deftest dbms-version-test
+  (mt/test-driver :druid
+    (testing (str "This tests populating the dbms_version field for a given database."
+                  " The sync happens automatically, so this test removes it first"
+                  " to ensure that it gets set when missing.")
+      (tqpt/with-flattened-dbdef
+        (let [db                   (mt/db)
+              version-on-load      (db-dbms-version db)
+              _                    (db/update! Database (u/the-id db) :dbms_version nil)
+              db                   (db/select-one Database :id (u/the-id db))
+              version-after-update (db-dbms-version db)
+              _                    (sync-dbms-ver/sync-dbms-version! db)]
+          (testing "On startup is the dbms-version specified?"
+            (is (nil? (check-dbms-version version-on-load))))
+          (testing "Check to make sure the test removed the timezone"
+            (is (nil? version-after-update)))
+          (testing "Check that the value was set again after sync"
+            (is (nil? (check-dbms-version (db-dbms-version db))))))))))

--- a/modules/drivers/mongo/src/metabase/driver/mongo.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo.clj
@@ -176,12 +176,18 @@
                                                              first))
        (:nested-fields field-info) (assoc :nested-fields nested-fields)) idx-next]))
 
+(defmethod driver/dbms-version :mongo
+  [_ database]
+  (with-mongo-connection [^com.mongodb.DB conn database]
+    (let [build-info (mg/command conn {:buildInfo 1})]
+      {:version (get build-info "version")
+       :semantic-version (get build-info "versionArray")})))
+
 (defmethod driver/describe-database :mongo
   [_ database]
   (with-mongo-connection [^com.mongodb.DB conn database]
     {:tables  (set (for [collection (disj (mdb/get-collection-names conn) "system.indexes")]
-                    {:schema nil, :name collection}))
-     :version (get (mg/command conn {:buildInfo 1}) "version")}))
+                    {:schema nil, :name collection}))}))
 
 (defn- table-sample-column-info
   "Sample the rows (i.e., documents) in `table` and return a map of information about the column keys we found in that

--- a/modules/drivers/mongo/test/metabase/driver/mongo/query_processor_test.clj
+++ b/modules/drivers/mongo/test/metabase/driver/mongo/query_processor_test.clj
@@ -330,7 +330,7 @@
 
 (deftest temporal-arithmetic-test
   (testing "Mixed integer and date arithmetic works with Mongo 5+"
-    (with-redefs [mongo.qp/get-mongo-version (constantly "5.2.13")]
+    (with-redefs [mongo.qp/get-mongo-version (constantly {:version "5.2.13", :semantic-version [5 2 13]})]
       (mt/with-clock #t "2022-06-21T15:36:00+02:00[Europe/Berlin]"
         (is (= {:$expr
                 {"$lt"
@@ -357,7 +357,7 @@
                                           [:interval -1 :week]
                                           86400000]]))))))
   (testing "Date arithmetic fails with Mongo 4-"
-    (with-redefs [mongo.qp/get-mongo-version (constantly "4")]
+    (with-redefs [mongo.qp/get-mongo-version (constantly {:version "4", :semantic-version [4]})]
       (is (thrown-with-msg? clojure.lang.ExceptionInfo  #"Date arithmetic not supported in versions before 5"
                             (mongo.qp/compile-filter [:<
                                                       [:+

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -13006,6 +13006,19 @@ databaseChangeLog:
             type: mysql,mariadb
 
   - changeSet:
+      id: v46.00-026
+      author: metamben
+      comment: Added 0.46.0 -- add field for tracking DBMS versions
+      changes:
+        - addColumn:
+            tableName: metabase_database
+            columns:
+              - column:
+                  name: dbms_version
+                  type: ${text.type}
+                  remarks: 'A JSON object describing the flavor and version of the DBMS.'
+
+  - changeSet:
       id: v46.00-027
       author: snoe
       comment: Added 0.46.0 -- add last_used_at to FieldValues

--- a/src/metabase/analytics/stats.clj
+++ b/src/metabase/analytics/stats.clj
@@ -274,9 +274,11 @@
 (defn- database-metrics
   "Get metrics based on Databases."
   []
-  {:databases (merge-count-maps (for [{is-full-sync? :is_full_sync} (db/select [Database :is_full_sync])]
-                                  {:total    1
-                                   :analyzed is-full-sync?}))})
+  (let [databases (db/select [Database :is_full_sync :engine :dbms_version])]
+    {:databases (merge-count-maps (for [{is-full-sync? :is_full_sync} databases]
+                                    {:total    1
+                                     :analyzed is-full-sync?}))
+     :dbms_versions (frequencies (map #(assoc (:dbms_version %) :engine (:engine %)) databases))}))
 
 
 (defn- table-metrics

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -254,6 +254,19 @@
   dispatch-on-initialized-driver
   :hierarchy #'hierarchy)
 
+(defmulti dbms-version
+  "Return a map containing information that describes the version of the DBMS. This typically includes a
+  `:version` containing the (semantic) version of the DBMS as a string and potentially a `:flavor`
+  specifying the flavor like `MySQL` or `MariaDB`."
+  {:arglists '([driver database])}
+  dispatch-on-initialized-driver
+  :hierarchy #'hierarchy)
+
+;; Some drivers like BigQuery or Snowflake cannot provide a meaningful stable version.
+(defmethod dbms-version :default
+  [_ _]
+  nil)
+
 (defmulti describe-database
   "Return a map containing information that describes all of the tables in a `database`, an instance of the `Database`
   model. It is expected that this function will be peformant and avoid draining meaningful resources of the database.

--- a/src/metabase/driver/sql_jdbc.clj
+++ b/src/metabase/driver/sql_jdbc.clj
@@ -61,6 +61,10 @@
   [_ database]
   (sql-jdbc.conn/notify-database-updated database))
 
+(defmethod driver/dbms-version :sql-jdbc
+  [driver database]
+  (sql-jdbc.sync/dbms-version driver (sql-jdbc.conn/db->pooled-connection-spec database)))
+
 (defmethod driver/describe-database :sql-jdbc
   [driver database]
   (sql-jdbc.sync/describe-database driver database))

--- a/src/metabase/driver/sql_jdbc/sync.clj
+++ b/src/metabase/driver/sql_jdbc/sync.clj
@@ -1,6 +1,7 @@
 (ns metabase.driver.sql-jdbc.sync
   "Implementations for sync-related driver multimethods for SQL JDBC drivers, using JDBC DatabaseMetaData."
-  (:require [metabase.driver.sql-jdbc.sync.describe-database :as sql-jdbc.describe-database]
+  (:require [metabase.driver.sql-jdbc.sync.dbms-version :as sql-jdbc.dbms-version]
+            [metabase.driver.sql-jdbc.sync.describe-database :as sql-jdbc.describe-database]
             [metabase.driver.sql-jdbc.sync.describe-table :as sql-jdbc.describe-table]
             [metabase.driver.sql-jdbc.sync.interface :as sql-jdbc.sync.interface]
             [potemkin :as p]))
@@ -31,4 +32,7 @@
  [sql-jdbc.describe-database
   describe-database
   fast-active-tables
-  post-filtered-active-tables])
+  post-filtered-active-tables]
+
+ [sql-jdbc.dbms-version
+  dbms-version])

--- a/src/metabase/driver/sql_jdbc/sync/dbms_version.clj
+++ b/src/metabase/driver/sql_jdbc/sync/dbms_version.clj
@@ -1,0 +1,13 @@
+(ns metabase.driver.sql-jdbc.sync.dbms-version
+  (:require [clojure.java.jdbc :as jdbc]))
+
+(defn dbms-version
+  "Default implementation of `driver/dbms-version` for SQL JDBC drivers. Uses JDBC DatabaseMetaData."
+  [_driver jdbc-spec]
+  (jdbc/with-db-metadata [metadata jdbc-spec]
+    {:flavor (.getDatabaseProductName metadata)
+     :version (.getDatabaseProductVersion metadata)
+     :semantic-version [(.getDriverMajorVersion metadata)
+                        (.getDriverMinorVersion metadata)]
+     :driver-name (.getDriverName metadata)
+     :driver-version (.getDriverVersion metadata)}))

--- a/src/metabase/driver/sql_jdbc/sync/dbms_version.clj
+++ b/src/metabase/driver/sql_jdbc/sync/dbms_version.clj
@@ -7,7 +7,5 @@
   (jdbc/with-db-metadata [metadata jdbc-spec]
     {:flavor (.getDatabaseProductName metadata)
      :version (.getDatabaseProductVersion metadata)
-     :semantic-version [(.getDriverMajorVersion metadata)
-                        (.getDriverMinorVersion metadata)]
-     :driver-name (.getDriverName metadata)
-     :driver-version (.getDriverVersion metadata)}))
+     :semantic-version [(.getDatabaseMajorVersion metadata)
+                        (.getDatabaseMinorVersion metadata)]}))

--- a/src/metabase/models/database.clj
+++ b/src/metabase/models/database.clj
@@ -207,7 +207,8 @@
                                        :metadata_sync_schedule      :cron-string
                                        :cache_field_values_schedule :cron-string
                                        :start_of_week               :keyword
-                                       :settings                    :encrypted-json})
+                                       :settings                    :encrypted-json
+                                       :dbms_version                :json})
           :post-insert    post-insert
           :post-select    post-select
           :pre-insert     pre-insert

--- a/src/metabase/sync/sync_metadata.clj
+++ b/src/metabase/sync/sync_metadata.clj
@@ -8,6 +8,7 @@
    4.  Sync Metabase Metadata table (`metabase.sync.sync-metadata.metabase-metadata`)"
   (:require [metabase.sync.fetch-metadata :as fetch-metadata]
             [metabase.sync.interface :as i]
+            [metabase.sync.sync-metadata.dbms-version :as sync-dbms-ver]
             [metabase.sync.sync-metadata.fields :as sync-fields]
             [metabase.sync.sync-metadata.fks :as sync-fks]
             [metabase.sync.sync-metadata.metabase-metadata :as metabase-metadata]
@@ -17,6 +18,11 @@
             [metabase.util :as u]
             [metabase.util.i18n :refer [trs]]
             [schema.core :as s]))
+
+(defn- sync-dbms-version-summary [{:keys [version] :as _step-info}]
+  (if version
+    (trs "Found DBMS version {0}" version)
+    (trs "Could not determine DBMS version")))
 
 (defn- sync-fields-summary [{:keys [total-fields updated-fields] :as _step-info}]
   (trs "Total number of fields sync''d {0}, number of fields updated {1}"
@@ -34,7 +40,8 @@
        total-fks updated-fks total-failed))
 
 (defn- make-sync-steps [db-metadata]
-  [(sync-util/create-sync-step "sync-timezone" sync-tz/sync-timezone! sync-timezone-summary)
+  [(sync-util/create-sync-step "sync-dbms-version" sync-dbms-ver/sync-dbms-version! sync-dbms-version-summary)
+   (sync-util/create-sync-step "sync-timezone" sync-tz/sync-timezone! sync-timezone-summary)
    ;; Make sure the relevant table models are up-to-date
    (sync-util/create-sync-step "sync-tables" #(sync-tables/sync-tables-and-database! % db-metadata) sync-tables-summary)
    ;; Now for each table, sync the fields

--- a/src/metabase/sync/sync_metadata/dbms_version.clj
+++ b/src/metabase/sync/sync_metadata/dbms_version.clj
@@ -1,0 +1,16 @@
+(ns metabase.sync.sync-metadata.dbms-version
+  (:require [metabase.driver :as driver]
+            [metabase.driver.util :as driver.u]
+            [metabase.models.database :refer [Database]]
+            [metabase.sync.interface :as i]
+            [schema.core :as s]
+            [toucan.db :as db]))
+
+(s/defn sync-dbms-version!
+  "Get the DBMS version as provided by the driver and save it in the Database."
+  [database :- i/DatabaseInstance]
+  (let [driver  (driver.u/database->driver database)
+        version (driver/dbms-version driver database)]
+    (when (not= version (:dbms_version database))
+      (db/update! Database (:id database) {:dbms_version version}))
+    version))

--- a/src/metabase/sync/sync_metadata/dbms_version.clj
+++ b/src/metabase/sync/sync_metadata/dbms_version.clj
@@ -3,12 +3,18 @@
             [metabase.driver.util :as driver.u]
             [metabase.models.database :refer [Database]]
             [metabase.sync.interface :as i]
+            [metabase.util.schema :as su]
             [schema.core :as s]
             [toucan.db :as db]))
 
+(def DBMSVersion
+  "Schema for the expected output of `describe-table-fks`."
+  {:version  su/NonBlankString
+   s/Keyword s/Any})
+
 (s/defn sync-dbms-version!
   "Get the DBMS version as provided by the driver and save it in the Database."
-  [database :- i/DatabaseInstance]
+  [database :- i/DatabaseInstance] :- (s/maybe DBMSVersion)
   (let [driver  (driver.u/database->driver database)
         version (driver/dbms-version driver database)]
     (when (not= version (:dbms_version database))

--- a/test/metabase/analytics/stats_test.clj
+++ b/test/metabase/analytics/stats_test.clj
@@ -8,7 +8,6 @@
             [metabase.models.pulse-card :refer [PulseCard]]
             [metabase.models.pulse-channel :refer [PulseChannel]]
             [metabase.models.query-execution :refer [QueryExecution]]
-            [metabase.sync.sync-metadata.dbms-version :as sync-dbms-ver]
             [metabase.test :as mt]
             [metabase.test.fixtures :as fixtures]
             [metabase.util :as u]
@@ -69,7 +68,9 @@
     "10000+"     100000))
 
 (def DBMSVersionStats
-  {sync-dbms-ver/DBMSVersion su/NonNegativeInt})
+  {{:engine                   s/Keyword
+    (s/optional-key :version) (s/maybe su/NonBlankString)
+    s/Keyword                 s/Any}                      su/NonNegativeInt})
 
 (deftest anonymous-usage-stats-test
   (with-redefs [email/email-configured? (constantly false)

--- a/test/metabase/analytics/stats_test.clj
+++ b/test/metabase/analytics/stats_test.clj
@@ -8,9 +8,11 @@
             [metabase.models.pulse-card :refer [PulseCard]]
             [metabase.models.pulse-channel :refer [PulseChannel]]
             [metabase.models.query-execution :refer [QueryExecution]]
+            [metabase.sync.sync-metadata.dbms-version :as sync-dbms-ver]
             [metabase.test :as mt]
             [metabase.test.fixtures :as fixtures]
             [metabase.util :as u]
+            [metabase.util.schema :as su]
             [schema.core :as s]
             [toucan.db :as db]
             [toucan.util.test :as tt]))
@@ -66,6 +68,9 @@
     "10000+"     10001
     "10000+"     100000))
 
+(def DBMSVersionStats
+  {sync-dbms-ver/DBMSVersion su/NonNegativeInt})
+
 (deftest anonymous-usage-stats-test
   (with-redefs [email/email-configured? (constantly false)
                 slack/slack-configured? (constantly false)]
@@ -82,7 +87,9 @@
                        :slack_configured    false
                        :sso_configured      false
                        :has_sample_data     false}
-                      stats))))))
+                      stats))
+        (is (schema= DBMSVersionStats
+                     (-> stats :stats :database :dbms_versions)))))))
 
 (deftest conversion-test
   (is (= #{true}

--- a/test/metabase/api/database_test.clj
+++ b/test/metabase/api/database_test.clj
@@ -52,7 +52,7 @@
   ([{driver :engine, :as db}]
    (merge
     (mt/object-defaults Database)
-    (select-keys db [:created_at :id :details :updated_at :timezone :name])
+    (select-keys db [:created_at :id :details :updated_at :timezone :name :dbms_version])
     {:engine (u/qualified-name (:engine db))
      :features (map u/qualified-name (driver.u/features driver db))
      :initial_sync_status "complete"})))
@@ -294,7 +294,7 @@
 (deftest fetch-database-metadata-test
   (testing "GET /api/database/:id/metadata"
     (is (= (merge (dissoc (mt/object-defaults Database) :details :settings)
-                  (select-keys (mt/db) [:created_at :id :updated_at :timezone :initial_sync_status])
+                  (select-keys (mt/db) [:created_at :id :updated_at :timezone :initial_sync_status :dbms_version])
                   {:engine        "h2"
                    :name          "test-data"
                    :features      (map u/qualified-name (driver.u/features :h2 (mt/db)))

--- a/test/metabase/api/field_test.clj
+++ b/test/metabase/api/field_test.clj
@@ -22,7 +22,7 @@
 (defn- db-details []
   (merge
    (select-keys (mt/db) [:id :timezone :initial_sync_status])
-   (dissoc (mt/object-defaults Database) :details :initial_sync_status)
+   (dissoc (mt/object-defaults Database) :details :initial_sync_status :dbms_version)
    {:engine        "h2"
     :name          "test-data"
     :features      (mapv u/qualified-name (driver.u/features :h2 (mt/db)))
@@ -66,7 +66,7 @@
                  :name_field       nil})
                (m/dissoc-in [:table :db :updated_at] [:table :db :created_at] [:table :db :timezone] [:table :db :settings]))
            (-> (mt/user-http-request :rasta :get 200 (format "field/%d" (mt/id :users :name)))
-               (m/dissoc-in [:table :db :updated_at] [:table :db :created_at] [:table :db :timezone]))))))
+               (update-in [:table :db] dissoc :updated_at :created_at :timezone :dbms_version))))))
 
 (deftest get-field-summary-test
   (testing "GET /api/field/:id/summary"

--- a/test/metabase/api/table_test.clj
+++ b/test/metabase/api/table_test.clj
@@ -29,7 +29,7 @@
 
 (defn- db-details []
   (merge
-   (select-keys (mt/db) [:id :created_at :updated_at :timezone :creator_id :initial_sync_status])
+   (select-keys (mt/db) [:id :created_at :updated_at :timezone :creator_id :initial_sync_status :dbms_version])
    {:engine                      "h2"
     :name                        "test-data"
     :is_sample                   false

--- a/test/metabase/query_processor_test/filter_test.clj
+++ b/test/metabase/query_processor_test/filter_test.clj
@@ -114,8 +114,7 @@
 
 (defn- mongo-major-version [db]
   (when (= driver/*driver* :mongo)
-    (-> (driver/describe-database :mongo db)
-        :version (str/split #"\.") first parse-long)))
+    (-> (driver/dbms-version :mongo db) :semantic-version first)))
 
 (defn- timezone-arithmetic-drivers []
   (set/intersection

--- a/test/metabase/query_processor_test/filter_test.clj
+++ b/test/metabase/query_processor_test/filter_test.clj
@@ -1,7 +1,6 @@
 (ns metabase.query-processor-test.filter-test
   "Tests for the `:filter` clause."
   (:require [clojure.set :as set]
-            [clojure.string :as str]
             [clojure.test :refer :all]
             [metabase.driver :as driver]
             [metabase.query-processor :as qp]

--- a/test/metabase/sync/sync_metadata/dbms_version_test.clj
+++ b/test/metabase/sync/sync_metadata/dbms_version_test.clj
@@ -1,0 +1,33 @@
+(ns metabase.sync.sync-metadata.dbms-version-test
+  (:require [clojure.test :refer :all]
+            [metabase.models.database :refer [Database]]
+            [metabase.sync.sync-metadata.dbms-version :as sync-dbms-ver]
+            [metabase.test :as mt]
+            [metabase.util :as u]
+            [schema.core :as s]
+            [toucan.db :as db]))
+
+(defn- db-dbms-version [db-or-id]
+  (db/select-one-field :dbms_version Database :id (u/the-id db-or-id)))
+
+(defn- check-dbms-version [dbms-version]
+  (s/check (s/maybe sync-dbms-ver/DBMSVersion) dbms-version))
+
+(deftest dbms-version-test
+  (mt/test-drivers (mt/normal-drivers)
+    (testing (str "This tests populating the dbms_version field for a given database."
+                  " The sync happens automatically, so this test removes it first"
+                  " to ensure that it gets set when missing.")
+      (mt/dataset test-data
+        (let [db                   (mt/db)
+              version-on-load      (db-dbms-version db)
+              _                    (db/update! Database (u/the-id db) :dbms_version nil)
+              db                   (db/select-one Database :id (u/the-id db))
+              version-after-update (db-dbms-version db)
+              _                    (sync-dbms-ver/sync-dbms-version! db)]
+          (testing "On startup is the dbms-version specified?"
+            (is (nil? (check-dbms-version version-on-load))))
+          (testing "Check to make sure the test removed the timezone"
+            (is (nil? version-after-update)))
+          (testing "Check that the value was set again after sync"
+            (is (nil? (check-dbms-version (db-dbms-version db))))))))))


### PR DESCRIPTION
Fixes #13444.

This PR adds the JSON column `dbms_version` to `metabase_database` and stores the database version information in it. The column is `null` for cloud databases like BigQuery. For non-cloud databases it contains at least the property `:version`, a string. Where available, the property `:semantic-version`, a vector of integers is added too. For cases like MySQL/MariaDB, the property `:flavor`, a string is included.

Statistics about the database versions used by the instance are included in the anonymous stats the following way:
```edn
{,,,
 :stats
 {,,,
  :database
  {:databases {:total 16, :analyzed 16},
   :dbms_versions
   {{:engine :bigquery-cloud-sdk} 1,
    {:engine :h2} 5,
    {:flavor "PostgreSQL", :version "14.5", :semantic-version [14 5], :engine :postgres} 1,
    {:flavor "H2", :version "1.4.197 (2018-03-18)", :semantic-version [1 4], :engine :h2} 6,
    {:version "5.0.9", :semantic-version [5 0 9 0], :engine :mongo} 1,
    {:flavor "MariaDB", :version "10.8.3-MariaDB-1:10.8.3+maria~jammy", :semantic-version [10 8], :engine :mysql} 1,
    {:flavor "MySQL", :version "8.0.30", :semantic-version [8 0], :engine :mysql} 1}},
  ,,,}}
```
The property `:engine` comes from the `engine` field in `metabase_database` and is merged with `dbms_version`.