### PR TITLE
Add `clojure -M:ee:drivers:check` to CI

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -112,3 +112,19 @@ jobs:
       with:
         report_paths: 'target/junit/**/*_test.xml'
         check_name: JUnit Test Report be-tests-java-${{ matrix.java-version }}-${{ matrix.edition }}
+
+  # checks that all the namespaces we actually ship can be compiled, without any dependencies that we don't ship (such
+  # as `:dev` dependencies). See #27009 for more context.
+  be-check:
+    runs-on: ubuntu-20.04
+    name: be-check-java-${{ matrix.java-version }}
+    timeout-minutes: 10
+    strategy:
+      matrix:
+        java-version: [11, 17, 19]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Prepare backend
+        uses: ./.github/actions/prepare-backend
+      - name: Check namespaces
+        run: clojure -M:ee:drivers:check

--- a/deps.edn
+++ b/deps.edn
@@ -306,11 +306,33 @@
 
 ;;; Linters
 
-  ;; clojure -M:dev:ee:ee-dev:drivers:drivers-dev:check
+  ;; clojure -M:ee:drivers:check
+  ;;
+  ;; checks that all the namespaces we actually ship can be compiled, without any dependencies that we don't
+  ;; ship (such as `:dev` dependencies). See #27009 for more context.
   :check
   {:extra-deps {athos/clj-check {:git/url "https://github.com/athos/clj-check.git"
                                  :sha     "518d5a1cbfcd7c952f548e6dbfcb9a4a5faf9062"}}
-   :main-opts  ["-m" "clj-check.check"]}
+   :main-opts  ["-m" "clj-check.check"
+                "src"
+                "shared/src"
+                "enterprise/backend/src"
+                "modules/drivers/athena/src"
+                "modules/drivers/bigquery-cloud-sdk/src"
+                "modules/drivers/druid/src"
+                "modules/drivers/googleanalytics/src"
+                "modules/drivers/mongo/src"
+                "modules/drivers/oracle/src"
+                "modules/drivers/presto/src"
+                "modules/drivers/presto-common/src"
+                "modules/drivers/presto-jdbc/src"
+                "modules/drivers/redshift/src"
+                "modules/drivers/snowflake/src"
+                "modules/drivers/sparksql/src"
+                "modules/drivers/sqlite/src"
+                "modules/drivers/sqlserver/src"
+                "modules/drivers/vertica/src"]
+   :jvm-opts   ["-Dclojure.main.report=stderr"]}
 
   ;; clojure -X:dev:ee:ee-dev:drivers:drivers-dev:test:eastwood
   :eastwood


### PR DESCRIPTION
Resolves #27009

I decided to have this run against Java 11 and 17, our two supported LTS releases, as well as Java 19, the currently supported LTS release. So we're getting a little something extra from this check besides just the missing dependency check we would have gotten.