### PR TITLE
Support "quarter" unit for datetimeDiff

### DIFF
--- a/docs/questions/query-builder/expressions/datetimediff.md
+++ b/docs/questions/query-builder/expressions/datetimediff.md
@@ -22,6 +22,7 @@ title: DatetimeDiff
 `unit` can be any of:
 
 - "year"
+- "quarter"
 - "month"
 - "day"
 - "hour"

--- a/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk/query_processor.clj
+++ b/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk/query_processor.clj
@@ -589,11 +589,24 @@
                                 (hsql/call :> (extract :day a) (extract :day b)))))))]
         (hsql/call :case (hsql/call :<= x y) (positive-diff x y) :else (hx/* -1 (positive-diff y x))))
 
+      :quarter
+      (let [positive-diff (fn [a b] ; precondition: a <= b
+                            (hx/cast
+                             :integer
+                             (hx/floor
+                               (hx//
+                                (hx/-
+                                 ;; timestamp_diff doesn't support months, so convert to datetime to use datetime_diff
+                                 (hsql/call :datetime_diff (hx/->datetime b) (hx/->datetime a) (hsql/raw "month"))
+                                 (hx/cast :integer (hsql/call :> (extract :day a) (extract :day b))))
+                                3))))]
+        (hsql/call :case (hsql/call :<= x y) (positive-diff x y) :else (hx/* -1 (positive-diff y x))))
+
       :month
       (let [positive-diff (fn [a b] ; precondition: a <= b
                             (hx/-
                              ;; timestamp_diff doesn't support months, so convert to datetime to use datetime_diff
-                             (hsql/call :datetime_diff (hx/->datetime b) (hx/->datetime a) (hsql/raw (name unit)))
+                             (hsql/call :datetime_diff (hx/->datetime b) (hx/->datetime a) (hsql/raw "month"))
                              (hx/cast :integer (hsql/call :> (extract :day a) (extract :day b)))))]
         (hsql/call :case (hsql/call :<= x y) (positive-diff x y) :else (hx/* -1 (positive-diff y x))))
 

--- a/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
+++ b/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
@@ -252,10 +252,21 @@
                                 (hsql/call :> (extract :day a) (extract :day b)))))))]
         (hsql/call :case (hsql/call :<= x y) (positive-diff x y) :else (hx/* -1 (positive-diff y x))))
 
+      :quarter
+      (let [positive-diff (fn [a b]
+                            (hx/cast
+                             :integer
+                             (hx/floor
+                              (hx/-
+                               (hsql/call :datediff (hsql/raw "month") a b)
+                               (hx/cast :integer (hsql/call :> (extract :day a) (extract :day b))))
+                              3)))]
+        (hsql/call :case (hsql/call :<= x y) (positive-diff x y) :else (hx/* -1 (positive-diff y x))))
+
       :month
       (let [positive-diff (fn [a b]
                             (hx/-
-                             (hsql/call :datediff (hsql/raw (name unit)) a b)
+                             (hsql/call :datediff (hsql/raw "month") a b)
                              (hx/cast :integer (hsql/call :> (extract :day a) (extract :day b)))))]
         (hsql/call :case (hsql/call :<= x y) (positive-diff x y) :else (hx/* -1 (positive-diff y x))))
 

--- a/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
+++ b/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
@@ -257,10 +257,11 @@
                             (hx/cast
                              :integer
                              (hx/floor
-                              (hx/-
-                               (hsql/call :datediff (hsql/raw "month") a b)
-                               (hx/cast :integer (hsql/call :> (extract :day a) (extract :day b))))
-                              3)))]
+                              (hx//
+                               (hx/-
+                                (hsql/call :datediff (hsql/raw "month") a b)
+                                (hx/cast :integer (hsql/call :> (extract :day a) (extract :day b))))
+                               3))))]
         (hsql/call :case (hsql/call :<= x y) (positive-diff x y) :else (hx/* -1 (positive-diff y x))))
 
       :month

--- a/modules/drivers/sqlserver/src/metabase/driver/sqlserver.clj
+++ b/modules/drivers/sqlserver/src/metabase/driver/sqlserver.clj
@@ -326,6 +326,20 @@
                    :else
                    (hx/* -1 (positive-diff y x))))
 
+      :quarter
+      (let [positive-diff
+            (fn [a b]
+              (hx/cast
+               :integer
+               (hx/floor (hx// (hx/- (date-diff :month a b)
+                                     (hsql/call :case (hsql/call :> (date-part :day a) (date-part :day b)) 1 :else 0))
+                               3))))]
+        (hsql/call :case
+                   (hsql/call :<= (hx/->datetime x) (hx/->datetime y))
+                   (positive-diff x y)
+                   :else
+                   (hx/* -1 (positive-diff y x))))
+
       :month
       (let [positive-diff (fn [a b]
                             (hx/-

--- a/modules/drivers/vertica/src/metabase/driver/vertica.clj
+++ b/modules/drivers/vertica/src/metabase/driver/vertica.clj
@@ -176,6 +176,20 @@
                    :else
                    (hx/* -1 (positive-diff y x))))
 
+      :quarter
+      (let [positive-diff
+            (fn [a b]
+              (hx/cast
+               :integer
+               (hx/floor (hx// (hx/- (datediff :month a b)
+                                     (hx/cast :integer (hsql/call :> (extract :day a) (extract :day b))))
+                               3))))]
+        (hsql/call :case
+                   (hsql/call :<= (cast-timestamp x) (cast-timestamp y))
+                   (positive-diff x y)
+                   :else
+                   (hx/* -1 (positive-diff y x))))
+
       :month
       (let [positive-diff (fn [a b]
                             (hx/-

--- a/shared/src/metabase/mbql/schema.cljc
+++ b/shared/src/metabase/mbql/schema.cljc
@@ -112,7 +112,7 @@
 (def DatetimeDiffUnits
   "Valid units for a datetime-diff clause."
   (s/named
-    (apply s/enum #{:second :minute :hour :day :week :month :year})
+    (apply s/enum #{:second :minute :hour :day :week :month :quarter :year})
     "datetime-diff-units"))
 
 (def ExtractWeekModes

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -334,8 +334,8 @@
        (date-trunc :day y)
        (date-trunc :day x))))
 
-    :week
-    (hx// (datetime-diff-helper x y :day) 7)
+    :quarter
+    (hx// (datetime-diff-helper x y :month) 3)
 
     :month
     (hx/cast
@@ -349,6 +349,9 @@
         :age
         (date-trunc :day y)
         (date-trunc :day x)))))
+
+    :week
+    (hx// (datetime-diff-helper x y :day) 7)
 
     (:hour :minute :second)
     (let [ex            (extract :epoch x)

--- a/test/metabase/query_processor_test/date_time_zone_functions_test.clj
+++ b/test/metabase/query_processor_test/date_time_zone_functions_test.clj
@@ -761,54 +761,37 @@
                       (mt/formatted-rows [int int int])
                       first))))))))
 
-(mt/defdataset diff-time-zone-cases
+(mt/defdataset diff-time-zones-cases
   [["times"
-    [{:field-name "a_dt",            :base-type :type/DateTime}
-     {:field-name "a_dt_ltz",        :base-type :type/DateTimeWithLocalTZ}
-     {:field-name "a_dt_tz",         :base-type :type/DateTimeWithTZ}
-     {:field-name "a_dt_tz_offset",  :base-type :type/DateTimeWithZoneOffset}
-     {:field-name "a_dt_tz_id",      :base-type :type/DateTimeWithZoneID}
-     {:field-name "a_dt_tz_text",    :base-type :type/Text}
-     {:field-name "a_dt_tz_id_text", :base-type :type/Text}
-     {:field-name "b_dt",            :base-type :type/DateTime}
-     {:field-name "b_dt_ltz",        :base-type :type/DateTimeWithLocalTZ}
-     {:field-name "b_dt_tz",         :base-type :type/DateTimeWithTZ}
-     {:field-name "b_dt_tz_offset",  :base-type :type/DateTimeWithZoneOffset}
-     {:field-name "b_dt_tz_id",      :base-type :type/DateTimeWithZoneID}
-     {:field-name "b_dt_tz_text",    :base-type :type/Text}
-     {:field-name "b_dt_tz_id_text", :base-type :type/Text}]
-    (let [times ["2022-10-02T01:00:00+01:00[Africa/Lagos]"
-                 "2022-10-02T00:00:00Z[UTC]"
-                 "2022-10-02T01:00:00+01:00[Africa/Lagos]"
-                 "2022-10-03T00:00:00Z[UTC]"
-                 "2022-10-03T00:00:00+01:00[Africa/Lagos]"
-                 "2022-10-09T00:00:00Z[UTC]"
-                 "2022-10-09T00:00:00+01:00[Africa/Lagos]"
-                 "2022-11-02T00:00:00Z[UTC]"
-                 "2022-11-02T00:00:00+01:00[Africa/Lagos]"
-                 "2023-01-02T00:00:00Z[UTC]"
-                 "2023-01-02T00:00:00+01:00[Africa/Lagos]"
-                 "2023-10-02T00:00:00Z[UTC]"
-                 "2023-10-02T00:00:00+01:00[Africa/Lagos]"]]
-      (for [a times b times]
-        [(t/local-date-time (u.date/parse a))              ; a_dt
-         (t/offset-date-time (u.date/parse a))             ; a_dt_ltz
-         (u.date/parse a)                                  ; a_dt_tz
-         (t/offset-date-time (u.date/parse a))             ; a_dt_tz_offset
-         (u.date/parse a)                                  ; a_dt_tz_id
-         (t/format :iso-offset-date-time (u.date/parse a)) ; a_dt_tz_text
-         a                                                 ; a_dt_tz_id_text
-         (t/local-date-time (u.date/parse b))              ; b_dt
-         (t/offset-date-time (u.date/parse b))             ; b_dt_ltz
-         (u.date/parse b)                                  ; b_dt_tz
-         (t/offset-date-time (u.date/parse b))             ; b_dt_tz_offset
-         (u.date/parse b)                                  ; b_dt_tz_id
-         (t/format :iso-offset-date-time (u.date/parse b)) ; b_dt_tz_text
-         b]))]])                                           ; b_dt_tz_id_text
+    [{:field-name "a_dt_tz",      :base-type :type/DateTimeWithTZ}
+     {:field-name "b_dt_tz",      :base-type :type/DateTimeWithTZ}
+     {:field-name "a_dt_tz_text", :base-type :type/Text}
+     {:field-name "b_dt_tz_text", :base-type :type/Text}]
+    (let [times [#t "2022-10-02T01:00:00+01:00[Africa/Lagos]"
+                 #t "2022-10-02T00:00:00Z[UTC]"
+                 #t "2022-10-02T01:00:00+01:00[Africa/Lagos]"
+                 #t "2022-10-03T00:00:00Z[UTC]"
+                 #t "2022-10-03T00:00:00+01:00[Africa/Lagos]"
+                 #t "2022-10-09T00:00:00Z[UTC]"
+                 #t "2022-10-09T00:00:00+01:00[Africa/Lagos]"
+                 #t "2022-11-02T00:00:00Z[UTC]"
+                 #t "2022-11-02T00:00:00+01:00[Africa/Lagos]"
+                 #t "2023-01-02T00:00:00Z[UTC]"
+                 #t "2023-01-02T00:00:00+01:00[Africa/Lagos]"
+                 #t "2023-10-02T00:00:00Z[UTC]"
+                 #t "2023-10-02T00:00:00+01:00[Africa/Lagos]"]]
+      (for [a times
+            b times
+            :when (and (t/before? a b)
+                       (not= (t/zone-id a) (t/zone-id b)))]
+        [a                                        ; a_dt_tz
+         b                                        ; b_dt_tz
+         (t/format :iso-offset-date-time a)       ; a_dt_tz_text
+         (t/format :iso-offset-date-time b)]))]]) ; b_dt_tz_text
 
 (deftest datetime-diff-time-zones-test
   (mt/test-drivers (mt/normal-drivers-with-feature :datetime-diff)
-    (mt/dataset diff-time-zone-cases
+    (mt/dataset diff-time-zones-cases
       (let [diffs (fn [x y]
                     (let [units [:second :minute :hour :day :week :month :quarter :year]]
                       (->> (mt/run-mbql-query times

--- a/test/metabase/query_processor_test/date_time_zone_functions_test.clj
+++ b/test/metabase/query_processor_test/date_time_zone_functions_test.clj
@@ -865,7 +865,9 @@
                                  "2022-11-02T00:00:00Z")))))      ; 2022-11-02T00:00:00Z
         (testing "hour under a quarter"
           (mt/with-temporary-setting-values [driver/report-timezone "Atlantic/Cape_Verde"]
-            (is (partial= {:month 3 :quarter 1}
+            (is (partial= (if (driver/supports? driver/*driver* :set-timezone)
+                            {:month 3 :quarter 1}
+                            {:month 2 :quarter 0})
                           (diffs "2022-10-02T00:00:00Z"          ; 2022-10-01T23:00:00-01:00
                                  "2023-01-02T00:00:00+01:00")))) ; 2023-01-01T22:00:00-01:00
           (mt/with-temporary-setting-values [driver/report-timezone "UTC"]

--- a/test/metabase/query_processor_test/date_time_zone_functions_test.clj
+++ b/test/metabase/query_processor_test/date_time_zone_functions_test.clj
@@ -761,37 +761,54 @@
                       (mt/formatted-rows [int int int])
                       first))))))))
 
-(mt/defdataset diff-time-zones-cases
+(mt/defdataset diff-time-zone-cases
   [["times"
-    [{:field-name "a_dt_tz",      :base-type :type/DateTimeWithTZ}
-     {:field-name "b_dt_tz",      :base-type :type/DateTimeWithTZ}
-     {:field-name "a_dt_tz_text", :base-type :type/Text}
-     {:field-name "b_dt_tz_text", :base-type :type/Text}]
-    (let [times [#t "2022-10-02T01:00:00+01:00[Africa/Lagos]"
-                 #t "2022-10-02T00:00:00Z[UTC]"
-                 #t "2022-10-02T01:00:00+01:00[Africa/Lagos]"
-                 #t "2022-10-03T00:00:00Z[UTC]"
-                 #t "2022-10-03T00:00:00+01:00[Africa/Lagos]"
-                 #t "2022-10-09T00:00:00Z[UTC]"
-                 #t "2022-10-09T00:00:00+01:00[Africa/Lagos]"
-                 #t "2022-11-02T00:00:00Z[UTC]"
-                 #t "2022-11-02T00:00:00+01:00[Africa/Lagos]"
-                 #t "2023-01-02T00:00:00Z[UTC]"
-                 #t "2023-01-02T00:00:00+01:00[Africa/Lagos]"
-                 #t "2023-10-02T00:00:00Z[UTC]"
-                 #t "2023-10-02T00:00:00+01:00[Africa/Lagos]"]]
-      (for [a times
-            b times
-            :when (and (t/before? a b)
-                       (not= (t/zone-id a) (t/zone-id b)))]
-        [a                                        ; a_dt_tz
-         b                                        ; b_dt_tz
-         (t/format :iso-offset-date-time a)       ; a_dt_tz_text
-         (t/format :iso-offset-date-time b)]))]]) ; b_dt_tz_text
+    [{:field-name "a_dt",            :base-type :type/DateTime}
+     {:field-name "a_dt_ltz",        :base-type :type/DateTimeWithLocalTZ}
+     {:field-name "a_dt_tz",         :base-type :type/DateTimeWithTZ}
+     {:field-name "a_dt_tz_offset",  :base-type :type/DateTimeWithZoneOffset}
+     {:field-name "a_dt_tz_id",      :base-type :type/DateTimeWithZoneID}
+     {:field-name "a_dt_tz_text",    :base-type :type/Text}
+     {:field-name "a_dt_tz_id_text", :base-type :type/Text}
+     {:field-name "b_dt",            :base-type :type/DateTime}
+     {:field-name "b_dt_ltz",        :base-type :type/DateTimeWithLocalTZ}
+     {:field-name "b_dt_tz",         :base-type :type/DateTimeWithTZ}
+     {:field-name "b_dt_tz_offset",  :base-type :type/DateTimeWithZoneOffset}
+     {:field-name "b_dt_tz_id",      :base-type :type/DateTimeWithZoneID}
+     {:field-name "b_dt_tz_text",    :base-type :type/Text}
+     {:field-name "b_dt_tz_id_text", :base-type :type/Text}]
+    (let [times ["2022-10-02T01:00:00+01:00[Africa/Lagos]"
+                 "2022-10-02T00:00:00Z[UTC]"
+                 "2022-10-02T01:00:00+01:00[Africa/Lagos]"
+                 "2022-10-03T00:00:00Z[UTC]"
+                 "2022-10-03T00:00:00+01:00[Africa/Lagos]"
+                 "2022-10-09T00:00:00Z[UTC]"
+                 "2022-10-09T00:00:00+01:00[Africa/Lagos]"
+                 "2022-11-02T00:00:00Z[UTC]"
+                 "2022-11-02T00:00:00+01:00[Africa/Lagos]"
+                 "2023-01-02T00:00:00Z[UTC]"
+                 "2023-01-02T00:00:00+01:00[Africa/Lagos]"
+                 "2023-10-02T00:00:00Z[UTC]"
+                 "2023-10-02T00:00:00+01:00[Africa/Lagos]"]]
+      (for [a times b times]
+        [(t/local-date-time (u.date/parse a))              ; a_dt
+         (t/offset-date-time (u.date/parse a))             ; a_dt_ltz
+         (u.date/parse a)                                  ; a_dt_tz
+         (t/offset-date-time (u.date/parse a))             ; a_dt_tz_offset
+         (u.date/parse a)                                  ; a_dt_tz_id
+         (t/format :iso-offset-date-time (u.date/parse a)) ; a_dt_tz_text
+         a                                                 ; a_dt_tz_id_text
+         (t/local-date-time (u.date/parse b))              ; b_dt
+         (t/offset-date-time (u.date/parse b))             ; b_dt_ltz
+         (u.date/parse b)                                  ; b_dt_tz
+         (t/offset-date-time (u.date/parse b))             ; b_dt_tz_offset
+         (u.date/parse b)                                  ; b_dt_tz_id
+         (t/format :iso-offset-date-time (u.date/parse b)) ; b_dt_tz_text
+         b]))]])                                           ; b_dt_tz_id_text
 
 (deftest datetime-diff-time-zones-test
   (mt/test-drivers (mt/normal-drivers-with-feature :datetime-diff)
-    (mt/dataset diff-time-zones-cases
+    (mt/dataset diff-time-zone-cases
       (let [diffs (fn [x y]
                     (let [units [:second :minute :hour :day :week :month :quarter :year]]
                       (->> (mt/run-mbql-query times

--- a/test/metabase/query_processor_test/date_time_zone_functions_test.clj
+++ b/test/metabase/query_processor_test/date_time_zone_functions_test.clj
@@ -715,6 +715,9 @@
                                       ["2016-02-03T09:19:09" "2017-02-02T09:19:09" 0 "starts in leap year before leap day"]
                                       ["2016-10-03T09:19:09" "2017-10-03T09:19:09" 1 "starts in leap year after leap day"]
                                       ["2017-06-10T08:30:00" "2019-07-10T08:30:00" 2 "multiple years"]]]
+                              [:quarter [["2021-10-03T09:18:09" "2022-01-02T09:18:09" 0 "day under a quarter"]
+                                         ["2021-10-03T09:19:09" "2022-01-03T09:18:09" 1 "ignores time"]
+                                         ["2017-06-10T08:30:00" "2019-07-10T08:30:00" 8 "multiple years"]]]
                               [:month [["2022-10-03T09:18:09" "2022-11-02T09:18:09" 0  "day under a month"]
                                        ["2022-10-02T09:19:09" "2022-11-02T09:18:09" 1  "minute under a month"]
                                        ["2022-10-02T09:18:09" "2023-10-03T09:18:09" 12 "over a year"]]]
@@ -783,6 +786,8 @@
                  "2022-10-09T00:00:00+01:00[Africa/Lagos]"
                  "2022-11-02T00:00:00Z[UTC]"
                  "2022-11-02T00:00:00+01:00[Africa/Lagos]"
+                 "2023-01-02T00:00:00Z[UTC]"
+                 "2023-01-02T00:00:00+01:00[Africa/Lagos]"
                  "2023-10-02T00:00:00Z[UTC]"
                  "2023-10-02T00:00:00+01:00[Africa/Lagos]"]]
       (for [a times b times]
@@ -805,7 +810,7 @@
   (mt/test-drivers (mt/normal-drivers-with-feature :datetime-diff)
     (mt/dataset diff-time-zone-cases
       (let [diffs (fn [x y]
-                    (let [units [:second :minute :hour :day :week :month :year]]
+                    (let [units [:second :minute :hour :day :week :month :quarter :year]]
                       (->> (mt/run-mbql-query times
                              {:filter [:and [:= x $a_dt_tz_text] [:= y $b_dt_tz_text]]
                               :expressions (into {} (for [unit units]
@@ -875,6 +880,24 @@
             (is (partial= {:hour 744 :day 31 :month 1 :year 0}
                           (diffs "2022-10-02T01:00:00+01:00"      ; 2022-10-02T00:00:00Z
                                  "2022-11-02T00:00:00Z")))))      ; 2022-11-02T00:00:00Z
+        (testing "hour under a quarter"
+          (mt/with-temporary-setting-values [driver/report-timezone "Atlantic/Cape_Verde"]
+            (is (partial= {:month 3 :quarter 1}
+                          (diffs "2022-10-02T00:00:00Z"          ; 2022-10-01T23:00:00-01:00
+                                 "2023-01-02T00:00:00+01:00")))) ; 2023-01-01T22:00:00-01:00
+          (mt/with-temporary-setting-values [driver/report-timezone "UTC"]
+            (is (partial= {:month 2 :quarter 0}
+                          (diffs "2022-10-02T00:00:00Z"           ; 2022-10-02T00:00:00Z
+                                 "2023-01-02T00:00:00+01:00"))))) ; 2023-01-01T23:00:00Z
+        (testing "quarter"
+          (mt/with-temporary-setting-values [driver/report-timezone "Atlantic/Cape_Verde"]
+            (is (partial= {:month 3 :quarter 1}
+                          (diffs "2022-10-02T01:00:00+01:00"      ; 2022-10-01T23:00:00-01:00
+                                 "2023-01-02T00:00:00Z"))))       ; 2023-01-01T23:00:00-01:00
+          (mt/with-temporary-setting-values [driver/report-timezone "UTC"]
+            (is (partial= {:month 3 :quarter 1}
+                          (diffs "2022-10-02T01:00:00+01:00"      ; 2022-10-02T00:00:00Z
+                                 "2023-01-02T00:00:00Z")))))      ; 2023-01-02T00:00:00Z
         (testing "year"
           (mt/with-temporary-setting-values [driver/report-timezone "Atlantic/Cape_Verde"]
             (is (partial= {:day 365, :week 52, :month 12, :year 1}
@@ -901,7 +924,7 @@
     (mt/dataset sample-dataset
       (testing "Args can be expressions that return datetime values"
         (let [diffs (fn [x y]
-                      (let [units [:second :minute :hour :day :week :month :year]]
+                      (let [units [:second :minute :hour :day :week :month :quarter :year]]
                         (->> (mt/run-mbql-query orders
                                {:limit 1
                                 :expressions (into {} (for [unit units]
@@ -911,7 +934,7 @@
                              (mt/formatted-rows (repeat (count units) int))
                              first
                              (zipmap units))))]
-          (is (= {:second 31795200, :minute 529920, :hour 8832, :day 368, :week 52, :month 12, :year 1}
+          (is (= {:second 31795200, :minute 529920, :hour 8832, :day 368, :week 52, :month 12, :quarter 4, :year 1}
                  (diffs [:datetime-add #t "2022-10-03T00:00:00" 1 "day"] [:datetime-add #t "2023-10-03T00:00:00" 4 "day"])))))
       (testing "Result works in arithmetic expressions"
         (let [start "2021-10-03T09:19:09"


### PR DESCRIPTION
This adds the ability to use the "quarter" unit in the datetimeDiff custom expression function.

example behaviour:
`datetimeDiff("2021-02-01", "2021-05-01", "quarter")` => 1
`datetimeDiff("2021-02-20", "2021-05-01", "quarter")` => 0

Epic: https://github.com/metabase/metabase/issues/26999

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/27015)
<!-- Reviewable:end -->
