### PR TITLE
Athena Driver: change auth method description and helper text

### DIFF
--- a/modules/drivers/athena/resources/metabase-plugin.yaml
+++ b/modules/drivers/athena/resources/metabase-plugin.yaml
@@ -26,11 +26,11 @@ driver:
         helper-text: Use a different data catalog (if you have federated queries, for example)
         required: false
     - name: access_key
-      display-name: Access Key
+      display-name: Access key
       helper-text: Leave this empty to authorize using AWS Credentials Provider Chain (Instance Profiles or IAM Roles for Tasks)
     - merge:
         - password
-        - display-name: Secret Key
+        - display-name: Secret key
           name: secret_key
     - advanced-options-start
     - merge:

--- a/modules/drivers/athena/resources/metabase-plugin.yaml
+++ b/modules/drivers/athena/resources/metabase-plugin.yaml
@@ -16,7 +16,7 @@ driver:
       display-name: Workgroup
       default: "primary"
     - name: s3_staging_dir
-      display-name: S3 Staging Directory
+      display-name: S3 staging directory
       default: s3://your_bucket
     - merge:
       - dbname
@@ -27,6 +27,7 @@ driver:
         required: false
     - name: access_key
       display-name: Access Key
+      helper-text: Leave this empty to authorize using Instance Profiles or IAM Roles for Tasks
     - merge:
         - password
         - display-name: Secret Key

--- a/modules/drivers/athena/resources/metabase-plugin.yaml
+++ b/modules/drivers/athena/resources/metabase-plugin.yaml
@@ -2,7 +2,7 @@
 info:
   name: Metabase Athena Driver
   version: 1.0.0-athena-jdbc-2.0.13
-  description: Allows Metabase to connect to AWS Athena databases. Community Supported driver.
+  description: Allows Metabase to connect to AWS Athena databases.
 driver:
   name: athena
   display-name: Amazon Athena
@@ -16,7 +16,7 @@ driver:
       display-name: Workgroup
       default: "primary"
     - name: s3_staging_dir
-      display-name: S3 Staging dir
+      display-name: S3 Staging Directory
       default: s3://your_bucket
     - merge:
       - dbname
@@ -25,20 +25,12 @@ driver:
         display-name: Catalog
         helper-text: Use a different data catalog (if you have federated queries, for example)
         required: false
-    - name: iam_keys
-      type: boolean
-      display-name: "Use hard-coded IAM credentials (not recommended)"
-      default: false
     - name: access_key
       display-name: Access Key
-      visible-if:
-        iam_keys: true
     - merge:
         - password
         - display-name: Secret Key
           name: secret_key
-          visible-if:
-            iam_keys: true
     - advanced-options-start
     - merge:
         - additional-options

--- a/modules/drivers/athena/resources/metabase-plugin.yaml
+++ b/modules/drivers/athena/resources/metabase-plugin.yaml
@@ -27,7 +27,7 @@ driver:
         required: false
     - name: access_key
       display-name: Access Key
-      helper-text: Leave this empty to authorize using Instance Profiles or IAM Roles for Tasks
+      helper-text: Leave this empty to authorize using AWS Credentials Provider Chain (Instance Profiles or IAM Roles for Tasks)
     - merge:
         - password
         - display-name: Secret Key

--- a/modules/drivers/athena/resources/metabase-plugin.yaml
+++ b/modules/drivers/athena/resources/metabase-plugin.yaml
@@ -30,8 +30,9 @@ driver:
       helper-text: Leave this empty to authorize using AWS Credentials Provider Chain (Instance Profiles or IAM Roles for Tasks)
     - merge:
         - password
-        - display-name: Secret key
-          name: secret_key
+        - name: secret_key
+          display-name: Secret key
+          helper-text: Leave this empty to authorize using AWS Credentials Provider Chain (Instance Profiles or IAM Roles for Tasks)
     - advanced-options-start
     - merge:
         - additional-options

--- a/modules/drivers/athena/resources/metabase-plugin.yaml
+++ b/modules/drivers/athena/resources/metabase-plugin.yaml
@@ -17,6 +17,7 @@ driver:
       default: "primary"
     - name: s3_staging_dir
       display-name: S3 staging directory
+      helper-text: This S3 staging directory must be in the same region you specify above.
       default: s3://your_bucket
     - merge:
       - dbname


### PR DESCRIPTION
Following [this discussion on Slack](https://metaboat.slack.com/archives/C010ZSXQY87/p1670332507088409)

- Removed the toggle to use hardcoded credentials.
- If the user wants to use [AWS Default Credentials Chain](https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html#credentials-default) they can leave the Access key and Secret key blank.

In a following PR: we disable `(when (str/blank? access_key)
         {:AwsCredentialsProviderClass "com.simba.athena.amazonaws.auth.DefaultAWSCredentialsProviderChain"})` if the instance is hosted on our Cloud.