### PR TITLE
docs - update public links

### DIFF
--- a/docs/configuring-metabase/appearance.md
+++ b/docs/configuring-metabase/appearance.md
@@ -13,7 +13,7 @@ redirect_from:
 
 {% include plans-blockquote.html feature="Custom appearance" %}
 
-Appearance setttings give you the option to white label Metabase to match your company’s branding.
+Appearance settings give you the option to white label Metabase to match your company’s branding.
 
 ## Changing Metabase's appearance
 

--- a/docs/embedding/signed-embedding-parameters.md
+++ b/docs/embedding/signed-embedding-parameters.md
@@ -101,7 +101,15 @@ your_embedding_url?breakfast=Scrambled_eggs#hide_parameters=breakfast
 
 ## Customizing the appearance of a signed embed
 
-You can change the appearance of an embedded item by adding parameters with the following values:
+You can change the appearance of an embedded item by adding hash parameters to the end of the URL in your iframe's `src` attribute.
+
+For example, the following embedding URL will display an embedded item in dark mode, without a border, and with its original title:
+
+```
+your_embedding_url#theme=night&bordered=false&titled=true
+```
+
+You can preview appearance settings from your question or dashboard's [embedded appearance settings](./signed-embedding.md#customizing-the-appearance-of-signed-embeds).
 
 | Parameter name         | Possible values                               |
 | ---------------------- | --------------------------------------------- |
@@ -114,14 +122,6 @@ You can change the appearance of an embedded item by adding parameters with the 
 ¹ Available on [paid plans](https://www.metabase.com/pricing).
 
 ² Available on [paid plans](https://www.metabase.com/pricing) and works on questions only (not dashboards).
-
-You can preview the changes from your question or dashboard's [embedded appearance settings](./signed-embedding.md#customizing-the-appearance-of-signed-embeds).
-
-For example, the following embedding URL will display an embedded item in dark mode, with its original title, and without a border:
-
-```
-your_embedding_url#theme=night&titled=true&bordered=false
-```
 
 ## Further reading
 

--- a/docs/questions/sharing/public-links.md
+++ b/docs/questions/sharing/public-links.md
@@ -8,21 +8,21 @@ redirect_from:
 
 # Public sharing
 
-Sometimes you'll want to share a dashboard or question you've saved with someone that isn't a part of your organization or company, or someone who doesn't need access to your full Metabase instance. Metabase lets administrators create public links and [public embeds](#public-embed) to let you do just that.
+Sometimes you'll want to share a dashboard or question with someone who isn't a part of your organization or company. To share your work with people who don't need access to your full Metabase instance, you can create public links and [public embeds](#public-embed).
 
-## Enable public sharing on Metabase
+## Enable public sharing in Metabase
 
 ![Enable public sharing](../images/enable-public-sharing.png)
 
 In order to share Metabase items like questions and dashboards via a public link or an embedded iframe, an admin needs to enable public sharing for that Metabase instance by going to **Settings gear icon** > **Admin settings** > **Public sharing**.
 
-Once toggled on, the **Public sharing** section will display Metabase dashboards and questions with active public links. To make a public link inactive, click **Revoke link**.
+Once toggled on, the **Public sharing** section will display Metabase questions and dashboards with active public links. To deactivate a public link, click **Revoke link**.
 
 ## Enable sharing on your saved question or dashboard
 
-If [public sharing](#enable-sharing-on-your-saved-question-or-dashboard) is enabled for your Metabase, you'll find the **Sharing and Embedding** icon on saved questions and dashboards (it looks like an arrow pointing up and to the right). The sharing button is located on the bottom right corner of a question, or the top right corner of a dashboard.
+Once [public sharing](#enable-sharing-on-your-saved-question-or-dashboard) is enabled for your Metabase, you'll find the **Sharing icon** on saved questions and dashboards (it looks like an arrow pointing up and to the right). The sharing icon is located on the bottom right corner of a question, or the top right corner of a dashboard.
 
-To generate the sharing link for that question or dashboard, click on the sharing icon to bring up the sharing settings modal, then click the toggle.
+To generate the sharing link for a question or dashboard, click on the sharing icon to bring up the sharing settings modal, then click on the toggle.
 
 ![Enable sharing](../images/enable-links.png)
 
@@ -30,38 +30,53 @@ For more information about the option to **Embed this item in an application**, 
 
 ## Public links
 
-Once you've [enabled sharing on your question or dashboard](#enable-sharing-on-your-saved-question-or-dashboard), you can copy and share the public link URL with whomever you please. The public link URL will display static results of your question or dashboard, so visitors won't be able to drill-down into the underlying data on their own.
+If you've [enabled sharing on your question or dashboard](#enable-sharing-on-your-saved-question-or-dashboard), you can copy and share the public link URL with whomever you please. The public link URL will display static (view-only) results of your question or dashboard, so visitors won't be able to drill-down into the underlying data on their own.
 
-However, public URLs preserve [custom click behavior](../../dashboards/interactive.md) to external URLs. If you want to create a custom drill-down pathway, you can link to the public links of other questions or dashboards.
+If you want to create a drill-down pathway on your question or dashboard, you can set up a [custom destination](../../dashboards/interactive.md) that goes to the public link of another question or dashboard.
 
 ### Public link to export question results in CSV, XLSX, JSON
 
+The export option is only available for questions, not dashboards.
+
 To create a public link that people can use to download the results of a question:
 
-1. Click on the **Sharing and embedding** icon for the question,
-2. [Enable sharing](#enable-sharing-on-your-saved-question-or-dashboard).
-3. Click on the format you want (CSV, XLSX, or JSON) below the **Public link** option (the link gets updated based on your selection).
-4. Copy the public link and test it out to confirm that the link downloads the expected format.
+1. Click on the **Sharing and embedding** icon for the question.
+2. Click the toggle to [enable sharing](#enable-sharing-on-your-saved-question-or-dashboard).
+3. Click on the file format you want (below the **Public link** URL).
+4. Open the public link in a new tab to test the download.
 
 ![Public export](../images/public-export.png)
 
-This public link export option is only available for questions, not dashboards.
+## Public embeds
 
-## Public embed
+If you want to embed your question or dashboard in a simple web page or blog post:
 
-If you want to embed the link to your dashboard or question in a simple web page or blog post, copy and paste the iframe snippet to your destination of choice.
+1. Click on the **Sharing and embedding** icon for your question or dashboard.
+2. Click the toggle to [enable sharing](#enable-sharing-on-your-saved-question-or-dashboard).
+3. Copy the **Public embed** iframe snippet.
+4. Paste the iframe snippet in your destination of choice.
 
 To customize the appearance of your question or dashboard, you can update the link in the `src` attribute with [public embed parameters](#public-embed-parameters).
 
 ## Public embed parameters
 
-To toggle appearance settings or set filter values, you can add parameters to the end of the public link in your iframe's `src` attribute.
+To apply appearance or filter settings to your public embed, you can add parameters to the end of the link in your iframe's `src` attribute.
 
-Note that it's possible to find the a public link URL behind a public embed. If someone gets access to the public link URL, they can remove the hash parameters from the URL to view the original question or dashboard (without any appearance or filter settings).
+Note that it's possible to find the public link URL behind a public embed. If someone gets access to the public link URL, they can remove the parameters from the URL to view the original question or dashboard (that is, without any appearance or filter settings).
 
 If you'd like to create a secure embed that prevents people from changing filter names or values, check out [signed embedding](../../embedding/signed-embedding.md).
 
 ### Appearance parameters
+
+To toggle appearance settings, add _hash_ parameters to the end of the public link in your iframe's `src` attribute.
+
+For example, to embed a dashboard with a border, title, and night (dark) theme:
+
+```
+/dashboard/42#bordered=true&titled=true&theme=night
+```
+
+For more info about `hide_parameters`, see the next section on [Filter parameters](#filter-parameters).
 
 | Parameter name          | Possible values                                  |
 | ----------------------- | ------------------------------------------------ |
@@ -76,22 +91,14 @@ If you'd like to create a secure embed that prevents people from changing filter
 
 ² Available on [paid plans](https://www.metabase.com/pricing) and hides the download button on questions only (not dashboards).
 
-To toggle appearance settings, add _hash_ parameters to the end of the public link in your iframe's `src` attribute. For example, to embed a dashboard with a border, title, and night (dark) theme:
-
-```
-https://yourcompany.metabaseapp.com/dashboard/42#bordered=true&titled=true&theme=night
-```
-
-For info about `hide_parameters`, see the next section on [Filter parameters](#filter-parameters)
-
 ### Filter parameters
 
 You can display a filtered view of your question or dashboard in a public embed. Make sure you've set up a [question filter](../query-builder/introduction.md#filtering) or [dashboard filter](../../dashboards/filters.md) first.
 
-To apply filter settings, add _query_ parameters to the end of the public link in your iframe's `src` attribute:
+To apply a filter to your embedded question or dashboard, add a _query_ parameter to the end of the link in your iframe's `src` attribute, like this:
 
 ```
-?filter_name=value
+/dashboard/42?filter_name=value
 ```
 
 For example, say that we have a dashboard with an "ID" filter. We can give this filter a value of 7:
@@ -100,28 +107,28 @@ For example, say that we have a dashboard with an "ID" filter. We can give this 
 /dashboard/42?id=7
 ```
 
-To specify multiple values for filters, separate the values with ampersands (&), like this:
-
-```
-/dashboard/42?id=7&customer_name=janet
-```
-
-Note that the name of the filter in the URL should be specified in lower case, and with underscores instead of spaces. If your filter is called "Filter for User ZIP Code", you'd write:
-
-```
-/dashboard/42#hide_parameters=filter_for_user_zip_code
-```
-
 To set the ID filter to a value of 7 _and_ hide the ID filter from the public embed:
 
 ```
 /dashboard/42?id=7#hide_parameters=id
 ```
 
+To specify multiple values for filters, separate the values with ampersands (&), like this:
+
+```
+/dashboard/42?id=7&name=janet
+```
+
 You can hide multiple filters by separating them with commas, like this:
 
 ```
 /dashboard/42#hide_parameters=id,customer_name
+```
+
+Note that the name of the filter in the URL should be specified in lower case, and with underscores instead of spaces. If your filter is called "Filter for User ZIP Code", you'd write:
+
+```
+/dashboard/42?filter_for_user_zip_code=02116
 ```
 
 ## Further reading

--- a/docs/questions/sharing/public-links.md
+++ b/docs/questions/sharing/public-links.md
@@ -8,7 +8,7 @@ redirect_from:
 
 # Public sharing
 
-Sometimes you'll want to share a dashboard or question with someone who isn't a part of your organization or company. To share your work with people who don't need access to your full Metabase instance, you can create public links and [public embeds](#public-embed).
+Sometimes you'll want to share a dashboard or question with someone who isn't a part of your organization or company. To share your work with people who don't need access to your full Metabase instance, you can create public links and public embeds.
 
 ## Enable public sharing in Metabase
 
@@ -70,26 +70,26 @@ If you'd like to create a secure embed that prevents people from changing filter
 
 To toggle appearance settings, add _hash_ parameters to the end of the public link in your iframe's `src` attribute.
 
-For example, to embed a dashboard with a border, title, and night (dark) theme:
+For example, to embed a dashboard with a dark theme, original title, and no border:
 
 ```
-/dashboard/42#bordered=true&titled=true&theme=night
+/dashboard/42#theme=night&titled=true&bordered=false
 ```
-
-For more info about `hide_parameters`, see the next section on [Filter parameters](#filter-parameters).
 
 | Parameter name          | Possible values                                  |
 | ----------------------- | ------------------------------------------------ |
 | bordered                | true, false                                      |
 | titled                  | true, false                                      |
 | theme                   | null, transparent, night                         |
-| hide_parameters         | true, false                                      |
+| hide_parameters         | true, false                                      |      
 | font¹                   | [font name](../../configuring-metabase/fonts.md) |
 | hide_download_button²   | true, false                                      |
 
 ¹ Available on [paid plans](https://www.metabase.com/pricing).
 
 ² Available on [paid plans](https://www.metabase.com/pricing) and hides the download button on questions only (not dashboards).
+
+For more info about `hide_parameters`, see the next section on [Filter parameters](#filter-parameters).
 
 ### Filter parameters
 
@@ -107,7 +107,7 @@ For example, say that we have a dashboard with an "ID" filter. We can give this 
 /dashboard/42?id=7
 ```
 
-To set the ID filter to a value of 7 _and_ hide the ID filter from the public embed:
+To set the "ID" filter to a value of 7 _and_ hide the "ID" filter widget from the public embed:
 
 ```
 /dashboard/42?id=7#hide_parameters=id
@@ -119,7 +119,7 @@ To specify multiple values for filters, separate the values with ampersands (&),
 /dashboard/42?id=7&name=janet
 ```
 
-You can hide multiple filters by separating them with commas, like this:
+You can hide multiple filter widgets by separating the filter names with commas, like this:
 
 ```
 /dashboard/42#hide_parameters=id,customer_name

--- a/docs/questions/sharing/public-links.md
+++ b/docs/questions/sharing/public-links.md
@@ -14,15 +14,15 @@ Sometimes you'll want to share a dashboard or question you've saved with someone
 
 ![Enable public sharing](../images/enable-public-sharing.png)
 
-An admin needs to enable public sharing from **Settings** > **Admin settings** > **Public sharing** before you'll see the [sharing icon](#enable-sharing-on-your-saved-question-or-dashboard) option on questions and dashboards.
+In order to share Metabase items like questions and dashboards via a public link or an embedded iframe, an admin needs to enable public sharing for that Metabase instance by going to **Settings gear icon** > **Admin settings** > **Public sharing**.
 
 Once toggled on, the **Public sharing** section will display Metabase dashboards and questions with active public links. To make a public link inactive, click **Revoke link**.
 
 ## Enable sharing on your saved question or dashboard
 
-If [public sharing](#enable-sharing-on-your-saved-question-or-dashboard) is enabled for your Metabase, you'll find the `Sharing and Embedding` icon on saved questions and dashboards (it looks like an arrow pointing up and to the right). The sharing button is located on the bottom right corner of a question, or the top right corner of a dashboard.
+If [public sharing](#enable-sharing-on-your-saved-question-or-dashboard) is enabled for your Metabase, you'll find the **Sharing and Embedding** icon on saved questions and dashboards (it looks like an arrow pointing up and to the right). The sharing button is located on the bottom right corner of a question, or the top right corner of a dashboard.
 
-Click on the sharing icon to bring up the sharing settings modal, then click the toggle to generate the sharing link for that question or dashboard.
+To generate the sharing link for that question or dashboard, click on the sharing icon to bring up the sharing settings modal, then click the toggle.
 
 ![Enable sharing](../images/enable-links.png)
 
@@ -51,11 +51,11 @@ This public link export option is only available for questions, not dashboards.
 
 If you want to embed the link to your dashboard or question in a simple web page or blog post, copy and paste the iframe snippet to your destination of choice.
 
-You can update the link in the `src` attribute with [public embed parameters](#public-embed-parameters) to customize the appearance of your question or dashboard.
+To customize the appearance of your question or dashboard, you can update the link in the `src` attribute with [public embed parameters](#public-embed-parameters).
 
 ## Public embed parameters
 
-You can add hash parameters at the end of the public link in your iframe's `src` attribute to toggle appearance settings or set filter values. 
+To toggle appearance settings or set filter values, you can add hash parameters at the end of the public link in your iframe's `src` attribute.
 
 Note that it's possible to find the a public link URL behind a public embed. If someone gets access to the public link URL, they can remove the hash parameters from the URL to view the original question or dashboard (without any appearance or filter settings).
 
@@ -63,13 +63,17 @@ If you'd like to create a secure embed that prevents people from changing filter
 
 ### Appearance
 
-| Parameter name         | Possible values                                  |
-| ---------------------- | ------------------------------------------------ |
-| bordered               | true, false                                      |
-| titled                 | true, false                                      |
-| theme                  | null, transparent, night                         |
-| font                   | [font name](../../configuring-metabase/fonts.md) |
-| hide_download_button   | true, false                                      |
+| Parameter name          | Possible values                                  |
+| ----------------------- | ------------------------------------------------ |
+| bordered                | true, false                                      |
+| titled                  | true, false                                      |
+| theme                   | null, transparent, night                         |
+| font¹                   | [font name](../../configuring-metabase/fonts.md) |
+| hide_download_button²   | true, false                                      |
+
+¹ Available on [paid plans](https://www.metabase.com/pricing).
+
+² Available on [paid plans](https://www.metabase.com/pricing) and hides the download button on questions only (not dashboards).
 
 ### Filters
 

--- a/docs/questions/sharing/public-links.md
+++ b/docs/questions/sharing/public-links.md
@@ -55,19 +55,20 @@ To customize the appearance of your question or dashboard, you can update the li
 
 ## Public embed parameters
 
-To toggle appearance settings or set filter values, you can add hash parameters at the end of the public link in your iframe's `src` attribute.
+To toggle appearance settings or set filter values, you can add parameters to the end of the public link in your iframe's `src` attribute.
 
 Note that it's possible to find the a public link URL behind a public embed. If someone gets access to the public link URL, they can remove the hash parameters from the URL to view the original question or dashboard (without any appearance or filter settings).
 
 If you'd like to create a secure embed that prevents people from changing filter names or values, check out [signed embedding](../../embedding/signed-embedding.md).
 
-### Appearance
+### Appearance parameters
 
 | Parameter name          | Possible values                                  |
 | ----------------------- | ------------------------------------------------ |
 | bordered                | true, false                                      |
 | titled                  | true, false                                      |
 | theme                   | null, transparent, night                         |
+| hide_parameters         | true, false                                      |
 | font¹                   | [font name](../../configuring-metabase/fonts.md) |
 | hide_download_button²   | true, false                                      |
 
@@ -75,44 +76,52 @@ If you'd like to create a secure embed that prevents people from changing filter
 
 ² Available on [paid plans](https://www.metabase.com/pricing) and hides the download button on questions only (not dashboards).
 
-### Filters
+To toggle appearance settings, add _hash_ parameters to the end of the public link in your iframe's `src` attribute. For example, to embed a dashboard with a border, title, and night (dark) theme:
+
+```
+https://yourcompany.metabaseapp.com/dashboard/42#bordered=true&titled=true&theme=night
+```
+
+For info about `hide_parameters`, see the next section on [Filter parameters](#filter-parameters)
+
+### Filter parameters
 
 You can display a filtered view of your question or dashboard in a public embed. Make sure you've set up a [question filter](../query-builder/introduction.md#filtering) or [dashboard filter](../../dashboards/filters.md) first.
 
-To display the filtered results in a public embed, add a query parameter at the end of the public link in your `src` attribute:
+To apply filter settings, add _query_ parameters to the end of the public link in your iframe's `src` attribute:
 
 ```
 ?filter_name=value
 ```
 
-For example, say that we have a dashboard with an "ID" filter. We can give this filter a value of 7 and simultaneously prevent the filter widget from showing up on the embedded dashboard:
+For example, say that we have a dashboard with an "ID" filter. We can give this filter a value of 7:
 
 ```
-/dashboard/42?id=7#hide_parameters=id
+/dashboard/42?id=7
 ```
 
-You don't _have_ to assign a filter a value, though — if you only want to hide the filter, you can do this:
+To specify multiple values for filters, separate the values with ampersands (&), like this:
 
 ```
-/dashboard/42#hide_parameters=id
+/dashboard/42?id=7&customer_name=janet
 ```
 
-Note that the name of the filter in the URL should be specified in lower case, and with underscores instead of spaces. So if your filter was called "Filter for User ZIP Code," you'd write:
+Note that the name of the filter in the URL should be specified in lower case, and with underscores instead of spaces. If your filter is called "Filter for User ZIP Code", you'd write:
 
 ```
 /dashboard/42#hide_parameters=filter_for_user_zip_code
 ```
 
-You can specify multiple filters to hide by separating them with commas, like this:
+To set the ID filter to a value of 7 _and_ hide the ID filter from the public embed:
+
+```
+/dashboard/42?id=7#hide_parameters=id
+```
+
+You can hide multiple filters by separating them with commas, like this:
 
 ```
 /dashboard/42#hide_parameters=id,customer_name
-```
-
-To specify multiple values for filters, though, you'll need to separate them with ampersands (&), like this:
-
-```
-/dashboard/42?id=7&customer_name=janet
 ```
 
 ## Further reading

--- a/docs/questions/sharing/public-links.md
+++ b/docs/questions/sharing/public-links.md
@@ -20,9 +20,11 @@ Once toggled on, the **Public sharing** section will display Metabase questions 
 
 ## Enable sharing on your saved question or dashboard
 
-Once [public sharing](#enable-sharing-on-your-saved-question-or-dashboard) is enabled for your Metabase, you'll find the **Sharing icon** on saved questions and dashboards (it looks like an arrow pointing up and to the right). The sharing icon is located on the bottom right corner of a question, or the top right corner of a dashboard.
+Once [public sharing](#enable-sharing-on-your-saved-question-or-dashboard) is enabled for your Metabase, you'll find the **Sharing and embedding icon** on saved questions and dashboards (it looks like a box with an arrow pointing to the upper right). 
 
-To generate the sharing link for a question or dashboard, click on the sharing icon to bring up the sharing settings modal, then click on the toggle.
+You can find the **Sharing and embedding icon** icon at the bottom right corner of a question, or the top right corner of a dashboard.
+
+To enable public sharing on a question or dashboard, click on the **Sharing and embedding icon** icon to bring up the sharing settings modal, then click on the toggle.
 
 ![Enable sharing](../images/enable-links.png)
 
@@ -30,7 +32,7 @@ For more information about the option to **Embed this item in an application**, 
 
 ## Public links
 
-If you've [enabled sharing on your question or dashboard](#enable-sharing-on-your-saved-question-or-dashboard), you can copy and share the public link URL with whomever you please. The public link URL will display static (view-only) results of your question or dashboard, so visitors won't be able to drill-down into the underlying data on their own.
+Once you've [enabled sharing on your question or dashboard](#enable-sharing-on-your-saved-question-or-dashboard), you can copy and share the public link URL with whomever you please. The public link URL will display static (view-only) results of your question or dashboard, so visitors won't be able to drill-down into the underlying data on their own.
 
 If you want to create a drill-down pathway on your question or dashboard, you can set up a [custom destination](../../dashboards/interactive.md) that goes to the public link of another question or dashboard.
 

--- a/docs/questions/sharing/public-links.md
+++ b/docs/questions/sharing/public-links.md
@@ -34,8 +34,6 @@ Once you've [enabled sharing on your question or dashboard](#enable-sharing-on-y
 
 However, public URLs preserve [custom click behavior](../../dashboards/interactive.md) to external URLs. If you want to create a custom drill-down pathway, you can link to the public links of other questions or dashboards.
 
-If you want to restrict what people can see in a public link based on a filter value, see [Public link parameters](#public-link-parameters).
-
 ### Public link to export question results in CSV, XLSX, JSON
 
 To create a public link that people can use to download the results of a question:
@@ -53,7 +51,7 @@ This public link export option is only available for questions, not dashboards.
 
 If you want to embed the link to your dashboard or question in a simple web page or blog post, copy and paste the iframe snippet to your destination of choice.
 
-You can update the link in the `src` attribute with [public embed parameters](#public-link-parameters) to customize the appearance of your question or dashboard.
+You can update the link in the `src` attribute with [public embed parameters](#public-embed-parameters) to customize the appearance of your question or dashboard.
 
 ## Public embed parameters
 

--- a/docs/questions/sharing/public-links.md
+++ b/docs/questions/sharing/public-links.md
@@ -1,43 +1,49 @@
 ---
-title: Public links
+title: Public sharing
 redirect_from:
   - /docs/latest/administration-guide/12-public-links
   - /docs/latest/embedding/12-public-links
+  - /docs/latest/questions/sharing/public-links
 ---
 
-# Public links
+# Public sharing
 
 Sometimes you'll want to share a dashboard or question you've saved with someone that isn't a part of your organization or company, or someone who doesn't need access to your full Metabase instance. Metabase lets administrators create public links and [public embeds](#public-embed) to let you do just that.
 
-## Turning public links on
+## Enable public sharing on Metabase
 
 ![Enable public sharing](../images/enable-public-sharing.png)
-First things first, you'll need to go to the Admin Panel and enable public sharing. In the future, you'll see dashboards and questions you've shared listed here, and you'll be able to revoke any public links that you no longer want to be used.
+
+An admin needs to enable public sharing from **Settings** > **Admin settings** > **Public sharing** before you'll see the [sharing icon](#enable-sharing-on-your-saved-question-or-dashboard) option on questions and dashboards.
+
+Once toggled on, the **Public sharing** section will display Metabase dashboards and questions with active public links. To make a public link inactive, click **Revoke link**.
 
 ## Enable sharing on your saved question or dashboard
 
+If [public sharing](#enable-sharing-on-your-saved-question-or-dashboard) is enabled for your Metabase, you'll find the `Sharing and Embedding` icon on saved questions and dashboards (it looks like an arrow pointing up and to the right).
+
+Click on the sharing icon to bring up the sharing settings modal, then click the toggle to generate the sharing link for that question or dashboard.
+
 ![Enable sharing](../images/enable-links.png)
 
-Next, exit the Admin Panel and go to question that you want to share, then click on the `Sharing and Embedding` icon in the bottom-right of the screen (it looks like an arrow pointing up and to the right). Then click on the toggle to enable public sharing for this question.
+The sharing button is located on the bottom right corner of a question, or the top right corner of a dashboard.
 
-In the case of a dashboard, the button is located on the top right of the page.
+## Public links
 
-## Copy, paste, and share!
+Once you've [enabled sharing on your question or dashboard](#enable-sharing-on-your-saved-question-or-dashboard), you can copy and share the public link URL with whomever you please. The public link URL will display static results of your question or dashboard, so visitors won't be able to drill-down into the underlying data on their own.
 
-Copy and share the public link URL with whomever you please. The public link URL will display static results of your question or dashboard, so visitors won't be able to drill-down into the underlying data on their own.
+However, public URLs preserve [custom click behavior](../../dashboards/interactive.md) to external URLs. If you want to create a custom drill-down pathway, you can link to the public links of other questions or dashboards.
 
-However, public URLs preserve [custom click behavior](../../dashboards/interactive.md) to custom URLs. If you like, you can share specific drill-down views by linking to the public links of other questions or dashboards.
+If you want to restrict what people can see in a public link based on a filter value, see [Public link parameters](#public-link-parameters).
 
-If you want to restrict what people can see in a public link based on a filter value, check out [signed embedding](../../embedding/signed-embedding.md).
+### Public link to export question results in CSV, XLSX, JSON
 
-## Public exports for question results in CSV, XLSX, JSON
+To create a public link that people can use to download the results of a question:
 
-To create a public link to download the results of a question:
-
-- Click on the **Sharing and embedding** icon for the question,
-- Enable sharing,
-- Then, below the **Public link** option, click on the format you want (CSV, XLSX, or JSON). Metabase will update the link based on your selection.
-- Copy the link and test it out to confirm that the link downloads the expected format.
+1. Click on the **Sharing and embedding** icon for the question,
+2. [Enable sharing](#enable-sharing-on-your-saved-question-or-dashboard).
+3. Click on the format you want (CSV, XLSX, or JSON) below the **Public link** option (the link gets updated based on your selection).
+4. Copy the public link and test it out to confirm that the link downloads the expected format.
 
 ![Public export](../images/public-export.png)
 
@@ -47,17 +53,43 @@ This public link export option is only available for questions, not dashboards.
 
 If you want to embed the link to your dashboard or question in a simple web page or blog post, copy and paste the iframe snippet to your destination of choice.
 
-## Assigning values to filters or hiding them via the URL
+You can update the link in the `src` attribute with [public embed parameters](#public-link-parameters) to customize the appearance of your question or dashboard.
 
-This is a bit more advanced, but if you're embedding a dashboard or question in an iframe and it has one or more filter widgets on it, you can give those filters values and even hide one or more filters by adding some options to the end of the URL. (You could also do this when just sharing a link, but note that if you do that, the person you're sharing the link with could of course directly edit the URL to change the filters' values, or to change which filters are hidden or not.)
+## Public embed parameters
 
-Here's an example where we have a dashboard that has a couple filters on it, one of which is called "ID." We can give this filter a value of 7 and simultaneously prevent the filter widget from showing up by constructing our URL like this:
+You can add hash parameters at the end of the public link in your iframe's `src` attribute to toggle appearance settings or set filter values. 
+
+Note that it's possible to find the a public link URL behind a public embed. If someone gets access to the public link URL, they can remove the hash parameters from the URL to view the original question or dashboard (without any appearance or filter settings).
+
+If you'd like to create a secure embed that prevents people from changing filter names or values, check out [signed embedding](../../embedding/signed-embedding.md).
+
+### Appearance
+
+| Parameter name         | Possible values                                  |
+| ---------------------- | ------------------------------------------------ |
+| bordered               | true, false                                      |
+| titled                 | true, false                                      |
+| theme                  | null, transparent, night                         |
+| font                   | [font name](../../configuring-metabase/fonts.md) |
+| hide_download_button   | true, false                                      |
+
+### Filters
+
+You can display a filtered view of your question or dashboard in a public embed. Make sure you've set up a [question filter](../query-builder/introduction.md#filtering) or [dashboard filter](../../dashboards/filters.md) first.
+
+To display the filtered results in a public embed, add a query parameter at the end of the public link in your `src` attribute:
+
+```
+?filter_name=value
+```
+
+For example, say that we have a dashboard with an "ID" filter. We can give this filter a value of 7 and simultaneously prevent the filter widget from showing up on the embedded dashboard:
 
 ```
 /dashboard/42?id=7#hide_parameters=id
 ```
 
-You don't _have_ to assign a filter a value, though — if you only want to hide it, so that it isn't usable in this context, you can do this:
+You don't _have_ to assign a filter a value, though — if you only want to hide the filter, you can do this:
 
 ```
 /dashboard/42#hide_parameters=id

--- a/docs/questions/sharing/public-links.md
+++ b/docs/questions/sharing/public-links.md
@@ -20,13 +20,13 @@ Once toggled on, the **Public sharing** section will display Metabase dashboards
 
 ## Enable sharing on your saved question or dashboard
 
-If [public sharing](#enable-sharing-on-your-saved-question-or-dashboard) is enabled for your Metabase, you'll find the `Sharing and Embedding` icon on saved questions and dashboards (it looks like an arrow pointing up and to the right).
+If [public sharing](#enable-sharing-on-your-saved-question-or-dashboard) is enabled for your Metabase, you'll find the `Sharing and Embedding` icon on saved questions and dashboards (it looks like an arrow pointing up and to the right). The sharing button is located on the bottom right corner of a question, or the top right corner of a dashboard.
 
 Click on the sharing icon to bring up the sharing settings modal, then click the toggle to generate the sharing link for that question or dashboard.
 
 ![Enable sharing](../images/enable-links.png)
 
-The sharing button is located on the bottom right corner of a question, or the top right corner of a dashboard.
+For more information about the option to **Embed this item in an application**, see the docs on [signed embedding](../../embedding/signed-embedding.md).
 
 ## Public links
 

--- a/docs/questions/start.md
+++ b/docs/questions/start.md
@@ -56,6 +56,6 @@ Choose from a variety of visualization types.
 
 Get results via email or Slack, either on a schedule, or only when something interesting happens.
 
-### [Public links](./sharing/public-links.md)
+### [Public sharing](./sharing/public-links.md)
 
-Share your data with the good people of the internet.
+Create links or embeds for the good people of the internet.


### PR DESCRIPTION
Changed the topic to "public sharing" and updated the sections accordingly, since this doc covers:
  - The public sharing section in Admin
  - The sharing settings modal (where you access the signed embed settings as well),
  - Public links, public embeds, and public embed parameters (appearance and filters).
  
  Markdown check is failing on some external links.