### PR TITLE
Support standard deviation aggregations for MongoDB

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -615,6 +615,9 @@ workflows:
             - be-deps
           e: << matrix.version >>
           driver: mongo
+          extra-env: >-
+            MB_MONGO_TEST_USER=metabase
+            MB_MONGO_TEST_PASSWORD=metasample123
 
       - test-driver:
           name: be-tests-mysql-latest-ee

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -96,6 +96,8 @@ jobs:
     env:
       CI: 'true'
       DRIVERS: mongo
+      MB_MONGO_TEST_USER: metabase
+      MB_MONGO_TEST_PASSWORD: metasample123
     services:
       mongodb:
         image: metabase/qa-databases:mongo-sample-4.0
@@ -114,6 +116,8 @@ jobs:
     env:
       CI: 'true'
       DRIVERS: mongo
+      MB_MONGO_TEST_USER: metabase
+      MB_MONGO_TEST_PASSWORD: metasample123
     services:
       mongodb:
         image: metabase/qa-databases:mongo-sample-5.0
@@ -132,6 +136,8 @@ jobs:
     env:
       CI: 'true'
       DRIVERS: mongo
+      MB_MONGO_TEST_USER: metabase
+      MB_MONGO_TEST_PASSWORD: metasample123
     services:
       mongodb:
         image: circleci/mongo:latest

--- a/modules/drivers/mongo/src/metabase/driver/mongo.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo.clj
@@ -218,8 +218,9 @@
 
 (doseq [feature [:basic-aggregations
                  :nested-fields
-                 :native-parameters]]
-  (defmethod driver/supports? [:mongo feature] [_ _] true))
+                 :native-parameters
+                 :standard-deviation-aggregations]]
+  (defmethod driver/supports? [:mongo feature] [_driver _feature] true))
 
 (defn- db-version [db]
   (get-in db [:details :version]))

--- a/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
@@ -748,14 +748,14 @@
   {:arglists '([mbql-clause])}
   (comp first unwrap-named-ag))
 
-;;; TODO -- these won't work inside expressions since we don't handle stuff like `$divide` correctly inside expressions.
-;;; See https://github.com/metabase/metabase/issues/23422 for more information.
-
 ;;; * `:group` = stuff to do in the `$group` stage
 ;;;
 ;;; * `:post` = stuff to do in the `$addFields` stage immediately following it
 ;;;
 ;;; both of these are maps of LHS column name => RHS definition
+;;;
+;;; Note that this code doesn't handle expression aggregations, but that's ok because we do not support
+;;; `:expression-aggregations` for Mongo DB.
 
 (defmethod expand-aggregation :share
   [[_ pred :as ag]]

--- a/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
@@ -372,6 +372,7 @@
 
 (defmethod ->lvalue :avg       [[_ inp]] (->lvalue inp))
 (defmethod ->lvalue :stddev    [[_ inp]] (->lvalue inp))
+(defmethod ->lvalue :var       [[_ inp]] (->lvalue inp))
 (defmethod ->lvalue :sum       [[_ inp]] (->lvalue inp))
 (defmethod ->lvalue :min       [[_ inp]] (->lvalue inp))
 (defmethod ->lvalue :max       [[_ inp]] (->lvalue inp))
@@ -404,11 +405,11 @@
 
 (defmethod ->lvalue :coalesce [[_ & args]] (->lvalue (first args)))
 
-(defmethod ->rvalue :avg       [[_ inp]] {"$avg" (->rvalue inp)})
-(defmethod ->rvalue :stddev    [[_ inp]] {"$stdDevPop" (->rvalue inp)})
+(defmethod ->rvalue :avg       [[_ inp]] {$avg (->rvalue inp)})
+(defmethod ->rvalue :stddev    [[_ inp]] {"$stdDevSamp" (->rvalue inp)})
 (defmethod ->rvalue :sum       [[_ inp]] {"$sum" (->rvalue inp)})
-(defmethod ->rvalue :min       [[_ inp]] {"$min" (->rvalue inp)})
-(defmethod ->rvalue :max       [[_ inp]] {"$max" (->rvalue inp)})
+(defmethod ->rvalue :min       [[_ inp]] {$min (->rvalue inp)})
+(defmethod ->rvalue :max       [[_ inp]] {$max (->rvalue inp)})
 
 (defmethod ->rvalue :floor     [[_ inp]] {"$floor" (->rvalue inp)})
 (defmethod ->rvalue :ceil      [[_ inp]] {"$ceil" (->rvalue inp)})
@@ -507,16 +508,18 @@
     (throw (ex-info (tru "now is not supported for MongoDB versions before 4.2")
                     {:database-version (get-mongo-version)}))))
 
-(defmethod ->rvalue :datetime-add        [[_ inp amount unit]] (do
-                                                                 (check-date-operations-supported)
-                                                                 {"$dateAdd" {:startDate (->rvalue inp)
-                                                                              :unit      unit
-                                                                              :amount    amount}}))
-(defmethod ->rvalue :datetime-subtract   [[_ inp amount unit]] (do
-                                                                 (check-date-operations-supported)
-                                                                 {"$dateSubtract" {:startDate (->rvalue inp)
-                                                                                   :unit      unit
-                                                                                   :amount    amount}}))
+(defmethod ->rvalue :datetime-add [[_ inp amount unit]]
+  (check-date-operations-supported)
+  {"$dateAdd" {:startDate (->rvalue inp)
+               :unit      unit
+               :amount    amount}})
+
+(defmethod ->rvalue :datetime-subtract
+  [[_ inp amount unit]]
+  (check-date-operations-supported)
+  {"$dateSubtract" {:startDate (->rvalue inp)
+                    :unit      unit
+                    :amount    amount}})
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                               CLAUSE APPLICATION                                               |
@@ -696,21 +699,14 @@
     {$sum {$cond {:if   (->rvalue arg)
                   :then 1
                   :else 0}}}
-    [:avg arg]
-    {$avg (->rvalue arg)}
 
+    ;; these aggregation types can all be used in expressions as well so their implementations live above in the
+    ;; general [[->rvalue]] implementations
+    #{:avg :stddev :sum :min :max}
+    (->rvalue &match)
 
     [:distinct arg]
     {$addToSet (->rvalue arg)}
-
-    [:sum arg]
-    {$sum (->rvalue arg)}
-
-    [:min arg]
-    {$min (->rvalue arg)}
-
-    [:max arg]
-    {$max (->rvalue arg)}
 
     [:sum-where arg pred]
     {$sum {$cond {:if   (compile-cond pred)
@@ -744,22 +740,46 @@
                 {$size (str \$ ag-name)}
                 true)])))
 
-(defmulti ^:private expand-aggregation (comp first unwrap-named-ag))
+(defmulti ^:private expand-aggregation
+  "Expand aggregations like `:share` and `:var` that can't be done as top-level aggregations in the `$group` stage
+  alone. See [[group-and-post-aggregations]] for more info. See also
+  https://www.mongodb.com/docs/manual/reference/operator/aggregation/group/#accumulator-operator for a list of what
+  aggregation operators are allowed inside `$group` (vs the ones that have to be done in a later stage)."
+  {:arglists '([mbql-clause])}
+  (comp first unwrap-named-ag))
+
+;;; TODO -- these won't work inside expressions since we don't handle stuff like `$divide` correctly inside expressions.
+;;; See https://github.com/metabase/metabase/issues/23422 for more information.
+
+;;; * `:group` = stuff to do in the `$group` stage
+;;;
+;;; * `:post` = stuff to do in the `$addFields` stage immediately following it
+;;;
+;;; both of these are maps of LHS column name => RHS definition
 
 (defmethod expand-aggregation :share
   [[_ pred :as ag]]
-  (let [count-where-name (name (gensym "count-where"))
+  (let [count-where-name (name (gensym "count-where-"))
         count-name       (name (gensym "count-"))
         pred             (if (= (first pred) :share)
                            (second pred)
                            pred)]
-    [[[count-where-name (aggregation->rvalue [:count-where pred])]
-      [count-name (aggregation->rvalue [:count])]]
-     [[(annotate/aggregation-name ag) {$divide [(str "$" count-where-name) (str "$" count-name)]}]]]))
+    {:group {count-where-name (aggregation->rvalue [:count-where pred])
+             count-name       (aggregation->rvalue [:count])}
+     :post  {(annotate/aggregation-name ag) {$divide [(str "$" count-where-name) (str "$" count-name)]}}}))
+
+;; MongoDB doesn't have a variance operator, but you calculate it by taking the square of the standard deviation.
+;; However, `$pow` is not allowed in the `$group` stage. So calculate standard deviation in the
+(defmethod expand-aggregation :var
+  [ag]
+  (let [[_ expr]    (unwrap-named-ag ag)
+        stddev-name (name (gensym "stddev-"))]
+    {:group {stddev-name (aggregation->rvalue [:stddev expr])}
+     :post  {(annotate/aggregation-name ag) {:$pow [(str \$ stddev-name) 2]}}}))
 
 (defmethod expand-aggregation :default
   [ag]
-  [[[(annotate/aggregation-name ag) (aggregation->rvalue ag)]]])
+  {:group {(annotate/aggregation-name ag) (aggregation->rvalue ag)}})
 
 (defn- group-and-post-aggregations
   "Mongo is picky about which top-level aggregations it allows with groups. Eg. even
@@ -769,8 +789,8 @@
    accrued in `$group` stage are discarded in the final `$project` stage."
   [id aggregations]
   (let [expanded-ags (map expand-aggregation aggregations)
-        group-ags    (mapcat first expanded-ags)
-        post-ags     (mapcat second expanded-ags)]
+        group-ags    (mapcat :group expanded-ags)
+        post-ags     (mapcat :post expanded-ags)]
     [{$group (into (ordered-map/ordered-map "_id" id) group-ags)}
      (when (not-empty post-ags)
        {:$addFields (into (ordered-map/ordered-map) post-ags)})]))

--- a/modules/drivers/mongo/test/metabase/test/data/mongo.clj
+++ b/modules/drivers/mongo/test/metabase/test/data/mongo.clj
@@ -36,11 +36,15 @@
     (ssl-required?) (merge (ssl-params))))
 
 (defmethod tx/dbdef->connection-details :mongo
-  [_ _ dbdef]
-  (conn-details {:dbname (tx/escaped-database-name dbdef)
-                 :user   "metabase"
-                 :pass   "metasample123"
-                 :host   "localhost"}))
+  [_driver _db-or-server dbdef]
+  (conn-details (merge
+                 {:dbname (tx/escaped-database-name dbdef)
+                  :host   (tx/db-test-env-var :mongo :host "localhost")
+                  :post   (Integer/parseUnsignedInt (tx/db-test-env-var :mongo :post "27017"))}
+                 (when-let [user (tx/db-test-env-var :mongo :user)]
+                   {:user user})
+                 (when-let [password (tx/db-test-env-var :mongo :password)]
+                   {:pass password}))))
 
 (defn- destroy-db! [driver dbdef]
   (with-mongo-connection [mongo-connection (tx/dbdef->connection-details driver :server dbdef)]

--- a/modules/drivers/mongo/test/metabase/test/data/mongo.clj
+++ b/modules/drivers/mongo/test/metabase/test/data/mongo.clj
@@ -36,7 +36,7 @@
     (ssl-required?) (merge (ssl-params))))
 
 (defmethod tx/dbdef->connection-details :mongo
-  [_driver _db-or-server dbdef]
+  [_driver _connection-type dbdef]
   (conn-details (merge
                  {:dbname (tx/escaped-database-name dbdef)
                   :host   (tx/db-test-env-var :mongo :host "localhost")

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -386,7 +386,9 @@
     ;; DEFAULTS TO TRUE.
     :basic-aggregations
 
-    ;; Does this driver support standard deviation and variance aggregations?
+    ;; Does this driver support standard deviation and variance aggregations? Note that if variance is not supported
+    ;; directly, you can calculate it manually by taking the square of the standard deviation. See the MongoDB driver
+    ;; for example.
     :standard-deviation-aggregations
 
     ;; Does this driver support expressions (e.g. adding the values of 2 columns together)?

--- a/test/metabase/query_processor_test/advanced_math_test.clj
+++ b/test/metabase/query_processor_test/advanced_math_test.clj
@@ -1,7 +1,9 @@
 (ns metabase.query-processor-test.advanced-math-test
-  (:require [clojure.test :refer :all]
-            [metabase.test :as mt]
-            [metabase.util :as u]))
+  (:require
+   [clojure.test :refer :all]
+   [metabase.driver :as driver]
+   [metabase.test :as mt]
+   [metabase.util :as u]))
 
 (defn- test-math-expression
   [expr]
@@ -63,28 +65,50 @@
                    int)))))
 
 
-(defn- test-aggregation
-  [agg]
-  (->> {:aggregation [agg]}
-       (mt/run-mbql-query venues)
-       mt/rows
-       ffirst
-       double
-       (u/round-to-decimals 2)))
+(defn- aggregation=
+  [expected agg]
+  (testing "As a top-level aggregation"
+    (let [query (mt/mbql-query venues
+                  {:aggregation [agg]})]
+      (mt/with-native-query-testing-context query
+        (is (= expected
+               (ffirst
+                (mt/formatted-rows [1.0]
+                  (mt/process-query query))))))))
+  ;; TODO -- MongoDB expressions support is actually broken, since it tries to do stuff like `$divide` that
+  ;; is not allowed in the` $group` stage. See #23422 for more information. When we address that issue, we
+  ;; should re-enable these tests.
+  (when (and (driver/database-supports? driver/*driver* :expressions (mt/db))
+             (not= driver/*driver* :mongo))
+        (testing "Inside an expression"
+          (let [query (mt/mbql-query venues
+                        {:aggregation [[:+ agg 1]]})]
+            (mt/with-native-query-testing-context query
+              (is (= (+ expected 1.0)
+                     (ffirst
+                      (mt/formatted-rows [1.0]
+                        (mt/process-query query))))))))))
+
+;;; there is a test for standard deviation itself
+;;; in [[metabase.query-processor-test.aggregation-test/standard-deviation-test]]
 
 (deftest test-variance
   (mt/test-drivers (mt/normal-drivers-with-feature :standard-deviation-aggregations)
-    (is (= 0.59 (test-aggregation [:var [:field (mt/id :venues :price) nil]])))))
+    (aggregation= 0.6
+                  [:var [:field (mt/id :venues :price) nil]])))
 
 (deftest test-median
   (mt/test-drivers (mt/normal-drivers-with-feature :percentile-aggregations)
-    (is (= 2.0 (test-aggregation [:median [:field (mt/id :venues :price) nil]])))))
+    (aggregation= 2.0
+                  [:median [:field (mt/id :venues :price) nil]])))
 
 (deftest test-percentile
   (mt/test-drivers (mt/normal-drivers-with-feature :percentile-aggregations)
-    (is (= 3.0 (test-aggregation [:percentile [:field (mt/id :venues :price) nil] 0.9])))))
+    (aggregation= 3.0
+                  [:percentile [:field (mt/id :venues :price) nil] 0.9])))
 
 (deftest test-nesting
   (mt/test-drivers (mt/normal-drivers-with-feature :advanced-math-expressions)
     (is (= 2.0 (test-math-expression [:sqrt [:power 2.0 2]])))
-    (is (= 59.0 (test-aggregation [:count-where [:between [:- [:round [:power [:field (mt/id :venues :price) nil] 2]] 1] 1 5]])))))
+    (aggregation= 59.0
+                  [:count-where [:between [:- [:round [:power [:field (mt/id :venues :price) nil] 2]] 1] 1 5]])))

--- a/test/metabase/query_processor_test/advanced_math_test.clj
+++ b/test/metabase/query_processor_test/advanced_math_test.clj
@@ -75,19 +75,15 @@
                (ffirst
                 (mt/formatted-rows [1.0]
                   (mt/process-query query))))))))
-  ;; TODO -- MongoDB expressions support is actually broken, since it tries to do stuff like `$divide` that
-  ;; is not allowed in the` $group` stage. See #23422 for more information. When we address that issue, we
-  ;; should re-enable these tests.
-  (when (and (driver/database-supports? driver/*driver* :expressions (mt/db))
-             (not= driver/*driver* :mongo))
-        (testing "Inside an expression"
-          (let [query (mt/mbql-query venues
-                        {:aggregation [[:+ agg 1]]})]
-            (mt/with-native-query-testing-context query
-              (is (= (+ expected 1.0)
-                     (ffirst
-                      (mt/formatted-rows [1.0]
-                        (mt/process-query query))))))))))
+  (when (driver/database-supports? driver/*driver* :expression-aggregations (mt/db))
+    (testing "Inside an expression aggregation"
+      (let [query (mt/mbql-query venues
+                    {:aggregation [[:+ agg 1]]})]
+        (mt/with-native-query-testing-context query
+          (is (= (+ expected 1.0)
+                 (ffirst
+                  (mt/formatted-rows [1.0]
+                    (mt/process-query query))))))))))
 
 ;;; there is a test for standard deviation itself
 ;;; in [[metabase.query-processor-test.aggregation-test/standard-deviation-test]]

--- a/test/metabase/query_processor_test/order_by_test.clj
+++ b/test/metabase/query_processor_test/order_by_test.clj
@@ -1,8 +1,10 @@
 (ns metabase.query-processor-test.order-by-test
   "Tests for the `:order-by` clause."
-  (:require [clojure.test :refer :all]
-            [metabase.driver :as driver]
-            [metabase.test :as mt]))
+  (:require
+   [clojure.test :refer :all]
+   [metabase.driver :as driver]
+   [metabase.test :as mt]
+   [schema.core :as s]))
 
 (deftest order-by-test
   (mt/test-drivers (mt/normal-drivers)
@@ -74,14 +76,20 @@
 
   (testing :stddev
     (mt/test-drivers (mt/normal-drivers-with-feature :standard-deviation-aggregations)
-      ;; standard deviation calculations are always NOT EXACT (normal behavior) so round results to nearest whole
-      ;; number.
-      (is (= [[3 25.0]
-              [1 24.0]
-              [2 21.0]
-              [4 14.0]]
-             (mt/formatted-rows [int 0.0]
-               (mt/run-mbql-query venues
-                 {:aggregation [[:stddev $category_id]]
-                  :breakout    [$price]
-                  :order-by    [[:desc [:aggregation 0]]]})))))))
+      ;; standard deviation calculations are always NOT EXACT (normal behavior) so just test that the results are in a
+      ;; certain RANGE.
+      (letfn [(row-schema [price lower-bound upper-bound]
+                (s/one [(s/one (s/eq price)
+                               (format "price = %d" price))
+                        (s/one (s/pred #(< lower-bound % upper-bound))
+                               (format "%.1f < value < %.1f" lower-bound upper-bound))]
+                       "row"))]
+        (is (schema= [(row-schema 3 23.0 27.0)
+                      (row-schema 1 22.0 26.0)
+                      (row-schema 2 19.0 23.0)
+                      (row-schema 4 12.0 16.0)]
+                     (mt/formatted-rows [int 1.0]
+                       (mt/run-mbql-query venues
+                         {:aggregation [[:stddev $category_id]]
+                          :breakout    [$price]
+                          :order-by    [[:desc [:aggregation 0]]]}))))))))

--- a/test/metabase/test/data/interface.clj
+++ b/test/metabase/test/data/interface.clj
@@ -290,10 +290,12 @@
   "Return the connection details map that should be used to connect to the Database we will create for
   `database-definition`.
 
+  `db-or-server` is either:
+
   *  `:server` - Return details for making the connection in a way that isn't DB-specific (e.g., for
                  creating/destroying databases)
   *  `:db`     - Return details for connecting specifically to the DB."
-  {:arglists '([driver context database-definition])}
+  {:arglists '([driver db-or-server database-definition])}
   dispatch-on-driver-with-test-extensions
   :hierarchy #'driver/hierarchy)
 

--- a/test/metabase/test/data/interface.clj
+++ b/test/metabase/test/data/interface.clj
@@ -290,12 +290,12 @@
   "Return the connection details map that should be used to connect to the Database we will create for
   `database-definition`.
 
-  `db-or-server` is either:
+  `connection-type` is either:
 
   *  `:server` - Return details for making the connection in a way that isn't DB-specific (e.g., for
                  creating/destroying databases)
   *  `:db`     - Return details for connecting specifically to the DB."
-  {:arglists '([driver db-or-server database-definition])}
+  {:arglists '([driver connection-type database-definition])}
   dispatch-on-driver-with-test-extensions
   :hierarchy #'driver/hierarchy)
 


### PR DESCRIPTION
Resolves #2173

Apparently the `:standard-deviation-aggregations` feature flag is used for both `:stddev` and `:var`(iance) aggregations. MongoDB doesn't have a variance operator but you can calculate it by taking the square of the standard deviation. So I did that.