### PR TITLE
Triggers docs update upon a release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,23 @@ on:
 
 jobs:
 
+  trigger-docs-update:
+    runs-on: ubuntu-20.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.DOCS_UPDATE_TOKEN }}
+          script: |
+            github.rest.repos.createDispatchEvent({
+              owner: '${{ github.repository_owner }}',
+              repo: '${{ secrets.DOCS_REPO }}',
+              event_type: 'trigger-docs-update',
+              client_payload: {
+                version: '${{ github.ref_name }}'
+              }
+            });
+
   download-uberjar:
     runs-on: ubuntu-20.04
     timeout-minutes: 10


### PR DESCRIPTION
This PR facilitates triggering another repository when a tag is created. A major use case is to trigger docs update (which lives on a separate repo) when a release is prepared, i.e. a new `v*` tag is pushed to GitHub. This ensures that the docs get updated (semi)automatically after every release.

Prerequisites: two new GitHub Actions _secrets_ on this repo:

* `DOCS_REPO` points to the name of the docs git repo
* `DOCS_UPDATE_TOKEN` is a new [PAT](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) necessary to access the above repo

### How I tested it

I have two repos:

* github.com/ariya/metabase, this is my fork which already contains the commit in this PR
* github.com/ariya/sample-docs-site, this simulates the target docs repo

This fork of mine github.com/ariya/metabase has the abovementioned two secrets. Notionly, `DOCS_REPO` is `sample-docs-site` as it points to the simulated target docs repo.

The simulated docs repo does nothing at the point, other than printing out a message, once the workflow is triggered.


```
  ariya/metabase                  ariya/sample-docs-site
┌────────────────┐                ┌────────────────────┐
│ release.yml    ├───────────────►│ update-docs.yml    │
└───────▲────────┘  dispatch      └────────────────────┘
        │
        │

tag (e.g. v0.44.9)
```

Here are the steps I did to test whole mechanics:

1. Intentionally I create a (hypothetical) tag

```
git tag v0.44.9
git push myfork v0.44.9
```

2. Due to the above `git push`, the release workflow is triggered. Here is the partial output of the `trigger-docs-update` job.

![image](https://user-images.githubusercontent.com/7288/206058646-c4b01127-f5d6-48ea-8d53-8f34ded95cfe.png)


3. From the output above, clearly it did dispatch an event to the simulated target docs repo. And looking at that simulated target docs repo, indeed a workflow was executed.

![image](https://user-images.githubusercontent.com/7288/206058485-14caa8ee-54a3-49a8-9f8a-a048b8aeb926.png)

![image](https://user-images.githubusercontent.com/7288/206058551-80204da1-a014-4cdc-bc05-7eeed9caa959.png)

