### PR TITLE
Settings refactor [WIP]

### DIFF
--- a/src/metabase/models/setting/definition.clj
+++ b/src/metabase/models/setting/definition.clj
@@ -1,0 +1,52 @@
+(ns metabase.models.setting.definition
+  "Common code related to dealing with Setting definitions."
+  (:require
+   [clojure.string :as str]))
+
+(defprotocol ^:private SettingName
+  (setting-name ^String [setting-definition-or-name]
+    "String name of a Setting, e.g. `\"site-url\"`. Works with strings, keywords, or Setting definition maps."))
+
+(extend-protocol SettingName
+  clojure.lang.IPersistentMap
+  (setting-name [this]
+    (name (:name this)))
+
+  String
+  (setting-name [this]
+    this)
+
+  clojure.lang.Keyword
+  (setting-name [this]
+    (name this)))
+
+(defn allows-site-wide-values?
+  "Whether this is a 'normal' Setting that allows site-wide values, as opposed to a database-local-only Setting or a
+  user-local-only Setting."
+  [setting-def]
+  (and
+   (not= (:database-local setting-def) :only)
+   (not= (:user-local setting-def) :only)))
+
+(defn allows-database-local-values?
+  "Whether this Setting allows setting values for individual data warehouse databases."
+  [setting-def]
+  (#{:only :allowed} (:database-local setting-def)))
+
+(defn allows-user-local-values?
+  "Whether this Setting allows setting values for individual Users."
+  [setting-def]
+  (#{:only :allowed} (:user-local setting-def)))
+
+(defn munge-setting-name
+  "Munge names so that they are legal for bash. Only allows for alphanumeric characters,  underscores, and hyphens."
+  [setting-nm]
+  (str/replace (name setting-nm) #"[^a-zA-Z0-9_-]*" ""))
+
+(defn env-var-name
+  "Get the env var corresponding to `setting-definition-or-name`. (This is used primarily for documentation purposes)."
+  ^String [setting-definition-or-name]
+  (str "MB_" (-> (setting-name setting-definition-or-name)
+                 munge-setting-name
+                 (str/replace "-" "_")
+                 str/upper-case)))

--- a/src/metabase/models/setting/interface.clj
+++ b/src/metabase/models/setting/interface.clj
@@ -1,0 +1,24 @@
+(ns metabase.models.setting.interface
+  "Multimethod definitions for getting and setting Settings of different types. Actual implementations live
+  in [[metabase.models.setting]].")
+
+(defmulti get-value-of-type
+  "Get the value of `setting-definition-or-name` as a value of type `setting-type`. This is used as the default getter
+  for Settings with `setting-type`.
+
+  Impls should call [[get-raw-value]] to get the underlying possibly-serialized value and parse it appropriately if it
+  comes back as a String; impls should only return values that are of the correct type (e.g. the `:boolean` impl
+  should only return [[Boolean]] values)."
+  {:arglists '([setting-type setting-definition-or-name])}
+  (fn [setting-type _]
+    (keyword setting-type)))
+
+(defmulti set-value-of-type!
+  "Set the value of a `setting-type` `setting-definition-or-name`. A `nil` value deletes the current value of the
+  Setting (when set in the application database). Returns `new-value`.
+
+  Impls of this method should ultimately call the implementation for `:string`, which handles the low-level logic of
+  updating the cache and application database."
+  {:arglists '([setting-type setting-definition-or-name new-value])}
+  (fn [setting-type _ _]
+    (keyword setting-type)))

--- a/src/metabase/models/setting/macros.clj
+++ b/src/metabase/models/setting/macros.clj
@@ -1,0 +1,188 @@
+(ns metabase.models.setting.macros
+  "The [[defendpoint]] macro and its implementation."
+  (:require
+   [clojure.core :as core]
+   [clojure.string :as str]
+   [metabase.models.setting.definition :as setting.def]
+   [metabase.models.setting.interface :as setting.i]
+   [metabase.models.setting.registry :as setting.registry]))
+
+(defn- setting-fn-docstring [{:keys [default description], setting-type :type, :as setting}]
+  ;; indentation below is intentional to make it clearer what shape the generated documentation is going to take.
+  (str
+   description \newline
+   \newline
+   (format "`%s` is a `%s` Setting. You can get its value by calling:\n" (setting.def/setting-name setting) setting-type)
+   \newline
+   (format "    (%s)\n"                                                  (setting.def/setting-name setting))
+   \newline
+   "and set its value by calling:\n"
+   \newline
+   (format "    (%s! <new-value>)\n"                                     (setting.def/setting-name setting))
+   \newline
+   (format "You can also set its value with the env var `%s`.\n"         (setting.def/env-var-name setting))
+   \newline
+   "Clear its value by calling:\n"
+   \newline
+   (format "    (%s! nil)\n"                                             (setting.def/setting-name setting))
+   \newline
+   (format "Its default value is `%s`."                                  (pr-str default))))
+
+(defn setting-fn-metadata
+  "Impl for [[defsetting]]. Create metadata for [[setting-fn]]."
+  [getter-or-setter {:keys [tag deprecated], :as setting}]
+  {:arglists   (case getter-or-setter
+                 :getter (list (with-meta [] {:tag tag}))
+                 :setter (list (with-meta '[new-value] {:tag tag})))
+   :deprecated deprecated
+   :doc        (setting-fn-docstring setting)})
+
+(defn setting-fn
+  "Impl for [[defsetting]]. Create the automatically defined `getter-or-setter` function for Settings defined
+  by [[defsetting]]."
+  [getter-or-setter setting]
+  (case getter-or-setter
+    :getter (fn setting-getter* []
+              (setting.i/get-value-of-type (:type setting) setting))
+    :setter (fn setting-setter* [new-value]
+              ;; need to qualify this or otherwise the reader gets this confused with the set! used for things like
+              ;; (set! *warn-on-reflection* true)
+              ;; :refer-clojure :exclude doesn't seem to work in this case
+              (setting.i/set-value-of-type! (:type setting) setting new-value))))
+
+;;; The next few functions are for validating the Setting description (i.e., docstring) at macroexpansion time. They
+;;; check that the docstring is a valid deferred i18n form (e.g. [[metabase.util.i18n/deferred-tru]]) so the Setting
+;;; description will be localized properly when it shows up in the FE admin interface.
+
+(def ^:private allowed-deferred-i18n-forms
+  '#{metabase.util.i18n/deferred-trs metabase.util.i18n/deferred-tru})
+
+(defn- is-form?
+  "Whether `form` is a function call/macro call form starting with a symbol in `symbols`.
+
+    (is-form? #{`deferred-tru} `(deferred-tru \"wow\")) ; -> true"
+  [symbols form]
+  (when (and (list? form)
+             (symbol? (first form)))
+    ;; resolve the symbol to a var and convert back to a symbol so we can get the actual name rather than whatever
+    ;; alias the current namespace happens to be using
+    (let [symb (symbol (resolve (first form)))]
+      ((set symbols) symb))))
+
+(defn- valid-trs-or-tru? [desc]
+  (is-form? allowed-deferred-i18n-forms desc))
+
+(defn- validate-description-form
+  "Check that `description-form` is a i18n form (e.g. [[metabase.util.i18n/deferred-tru]]). Returns `description-form`
+  as-is."
+  [description-form]
+  (when-not (valid-trs-or-tru? description-form)
+    ;; this doesn't need to be i18n'ed because it's a compile-time error.
+    (throw (ex-info (str "defsetting docstrings must be an *deferred* i18n form unless the Setting has"
+                         " `:visibilty` `:internal` or `:setter` `:none`."
+                         (format " Got: ^%s %s"
+                                 (some-> description-form class (.getCanonicalName))
+                                 (pr-str description-form)))
+                    {:description-form description-form})))
+  description-form)
+
+(defmacro defsetting
+  "Defines a new Setting that will be added to the DB at some point in the future.
+  Conveniently can be used as a getter/setter as well
+
+    (defsetting mandrill-api-key (trs \"API key for Mandrill.\"))
+    (mandrill-api-key)            ; get the value
+    (mandrill-api-key! new-value) ; update the value
+    (mandrill-api-key! nil)       ; delete the value
+
+  A setting can be set from the Admin Panel or via the corresponding env var, eg. `MB_MANDRILL_API_KEY` for the
+  example above.
+
+  You may optionally pass any of the `options` below:
+
+  ###### `:default`
+
+  The default value of the setting. This must be of the same type as the Setting type, e.g. the default for an
+  `:integer` setting must be some sort of integer. (default: `nil`)
+
+  ###### `:type`
+
+  `:string` (default) or one of the other types that implement [[get-value-of-type]] and [[set-value-of-type]].
+  Non-`:string` Settings have special default getters and setters that automatically coerce values to the correct
+  types.
+
+  ###### `:visibility`
+
+  `:public`, `:authenticated`, `:admin` (default), or `:internal`. Controls where this setting is visible
+
+  ###### `:getter`
+
+  A custom getter fn, which takes no arguments. Overrides the default implementation. (This can in turn call functions
+  in this namespace like methods of [[get-value-of-type]] to invoke the 'parent' getter behavior.)
+
+  ###### `:setter`
+
+  A custom setter fn, which takes a single argument, or `:none` for read-only settings. Overrides the default
+  implementation. (This can in turn call methods of [[set-value-of-type!]] to invoke 'parent' setter behavior. Keep in
+  mind that the custom setter may be passed `nil`, which should clear the values of the Setting.)
+
+  ###### `:cache?`
+
+  Should this Setting be cached? (default `true`)? Be careful when disabling this, because it could have a very
+  negative performance impact.
+
+  ###### `:sensitive?`
+
+  Is this a sensitive setting, such as a password, that we should never return in plaintext? (Default: `false`).
+  Obfuscation is not done by getter functions, but instead by functions that ultimately return these values via the
+  API, such as [[admin-writable-settings]] below. (In other words, code in the backend can continute to consume
+  sensitive Settings normally; sensitivity is a purely user-facing option.)
+
+  ###### `:database-local`
+
+  The ability of this Setting to be /Database-local/. Valid values are `:only`, `:allowed`, and `:never`. Default:
+  `:never`. See docstring for [[metabase.models.setting]] for more information.
+
+  ###### `:user-local`
+
+  Whether this Setting is /User-local/. Valid values are `:only`, `:allowed`, and `:never`. Default: `:never`. See
+  docstring for [[metabase.models.setting]] for more info.
+
+  ###### `:deprecated`
+
+  If this setting is deprecated, this should contain a string of the Metabase version in which the setting was
+  deprecated. A deprecation notice will be logged whenever the setting is written. (Default: `nil`).
+
+  ###### `:on-change`
+
+  Do you want to update something else when this setting changes? Takes a function which takes 2 arguments, `old`, and
+  `new` and calls it with the old and new settings values. By default, the :on-change will be missing, and nothing
+  will happen, in [[call-on-change]] below."
+  {:style/indent 1}
+  [setting-symbol description & {:as options}]
+  {:pre [(symbol? setting-symbol)
+         (not (namespace setting-symbol))
+         ;; don't put exclamation points in your Setting names. We don't want functions like `exciting!` for the getter
+         ;; and `exciting!!` for the setter.
+         (not (str/includes? (name setting-symbol) "!"))]}
+  (let [description               (if (or (= (:visibility options) :internal)
+                                          (= (:setter options) :none))
+                                    description
+                                    (validate-description-form description))
+        definition-form           (assoc options
+                                         :name (keyword setting-symbol)
+                                         :description description
+                                         :namespace (list 'quote (ns-name *ns*)))
+        ;; create symbols for the getter and setter functions e.g. `my-setting` and `my-setting!` respectively.
+        ;; preserve metadata from the `setting-symbol` passed to `defsetting`.
+        setting-getter-fn-symbol  setting-symbol
+        setting-setter-fn-symbol  (-> (symbol (str (name setting-symbol) \!))
+                                      (with-meta (meta setting-symbol)))
+        ;; create a symbol for the Setting definition from [[register-setting!]]
+        setting-definition-symbol (gensym "setting-")]
+    `(let [~setting-definition-symbol (setting.registry/register-setting! ~definition-form)]
+       (-> (def ~setting-getter-fn-symbol (setting-fn :getter ~setting-definition-symbol))
+           (alter-meta! merge (setting-fn-metadata :getter ~setting-definition-symbol)))
+       ~(when-not (= (:setter options) :none)
+          `(-> (def ~setting-setter-fn-symbol (setting-fn :setter ~setting-definition-symbol))
+               (alter-meta! merge (setting-fn-metadata :setter ~setting-definition-symbol)))))))

--- a/src/metabase/models/setting/registry.clj
+++ b/src/metabase/models/setting/registry.clj
@@ -1,0 +1,193 @@
+(ns metabase.models.setting.registry
+  "Registry of all know Settings and [[register-setting!]] to validate and register a Setting."
+  (:require
+   [clojure.core :as core]
+   [metabase.models.setting.definition :as setting.def]
+   [metabase.models.setting.interface :as i]
+   [schema.core :as s])
+  (:import
+   (clojure.lang Keyword Symbol)
+   (java.time.temporal Temporal)))
+
+(def ^:private retired-setting-names
+  "A set of setting names which existed in previous versions of Metabase, but are no longer used. New settings may not use
+  these names to avoid unintended side-effects if an application database still stores values for these settings."
+  #{"-site-url"
+    "enable-advanced-humanization"
+    "metabot-enabled"
+    "ldap-sync-admin-group"})
+
+(def ^:dynamic *allow-retired-setting-names*
+  "A dynamic val that controls whether it's allowed to use retired settings.
+  Primarily used in test to disable retired setting check."
+  false)
+
+(defonce ^{:doc "Map of loaded defsettings"}
+  registered-settings
+  (atom {}))
+
+(defprotocol ^:private Resolvable
+  (resolve-setting [setting-definition-or-name]
+    "Resolve the definition map for a Setting. `setting-definition-or-name` map be a map, keyword, or string."))
+
+(extend-protocol Resolvable
+  clojure.lang.IPersistentMap
+  (resolve-setting [this] this)
+
+  String
+  (resolve-setting [s]
+    (resolve-setting (keyword s)))
+
+  clojure.lang.Keyword
+  (resolve-setting [k]
+    (or (@registered-settings k)
+        ;; not i18n'ed to avoid circular refs. Hopefully dev-facing-only anyway
+        (throw (ex-info (format "Unknown setting: %s" (pr-str k))
+                        {:registered-settings
+                         (sort (keys @registered-settings))})))))
+
+(defmulti default-tag-for-type
+  "Type tag that will be included in the Setting's metadata, so that the getter function will not cause reflection
+  warnings."
+  {:arglists '([setting-type])}
+  keyword)
+
+(defmethod default-tag-for-type :default   [_] `Object)
+(defmethod default-tag-for-type :string    [_] `String)
+(defmethod default-tag-for-type :boolean   [_] `Boolean)
+(defmethod default-tag-for-type :integer   [_] `Long)
+(defmethod default-tag-for-type :double    [_] `Double)
+(defmethod default-tag-for-type :timestamp [_] `Temporal)
+(defmethod default-tag-for-type :keyword   [_] `Keyword)
+
+(def ^:private Type
+  (s/pred (fn [a-type]
+            (contains? (set (keys (methods default-tag-for-type))) a-type))
+          "Valid Setting :type"))
+
+(def ^:private Visibility
+  (s/enum :public :authenticated :admin :internal))
+
+;; This is called `LocalOption` rather than `DatabaseLocalOption` or something like that because we intend to also add
+;; User-Local Settings at some point in the future. The will use the same options
+(def ^:private LocalOption
+  "Schema for valid values of `:database-local`. See [[metabase.models.setting]] docstring for description of what these
+  options mean."
+  (s/enum :only :allowed :never))
+
+(def ^:private SettingDefinition
+  {:name        s/Keyword
+   :munged-name s/Str
+   :namespace   s/Symbol
+   :description s/Any            ; description is validated via the macro, not schema
+   ;; Use `:doc` to include a map with additional documentation, for use when generating the environment variable docs
+   ;; from source. To exclude a setting from documenation, set to `false`. See metabase.cmd.env-var-dox.
+   :doc         s/Any
+   :default     s/Any
+   :type        Type             ; all values are stored in DB as Strings,
+   :getter      clojure.lang.IFn ; different getters/setters take care of parsing/unparsing
+   :setter      clojure.lang.IFn
+   :tag         (s/maybe Symbol) ; type annotation, e.g. ^String, to be applied. Defaults to tag based on :type
+   :sensitive?  s/Bool           ; is this sensitive (never show in plaintext), like a password? (default: false)
+   :visibility  Visibility       ; where this setting should be visible (default: :admin)
+   :cache?      s/Bool           ; should the getter always fetch this value "fresh" from the DB? (default: false)
+   :deprecated  (s/maybe s/Str)            ; if non-nil, contains the Metabase version in which this setting was deprecated
+
+   ;; whether this Setting can be Database-local or User-local. See [[metabase.models.setting]] docstring for more info.
+   :database-local LocalOption
+   :user-local     LocalOption
+
+   ;; called whenever setting value changes, whether from update-setting! or a cache refresh. used to handle cases
+   ;; where a change to the cache necessitates a change to some value outside the cache, like when a change the
+   ;; `:site-locale` setting requires a call to `java.util.Locale/setDefault`
+   :on-change   (s/maybe clojure.lang.IFn)
+
+   ;; optional fn called whether to allow the getter to return a value. Useful for ensuring premium settings are not available to
+   :enabled?    (s/maybe clojure.lang.IFn)})
+
+(defn- default-getter-for-type [setting-type]
+  (partial i/get-value-of-type (keyword setting-type)))
+
+(defn- default-setter-for-type [setting-type]
+  (partial i/set-value-of-type! (keyword setting-type)))
+
+(defn- validate-default-value-for-type
+  "Check whether the `:default` value of a Setting (if provided) agrees with the Setting's `:type` and its `:tag` (which
+  usually comes from [[default-tag-for-type]])."
+  [{:keys [tag default] :as _setting-definition}]
+  ;; the errors below don't need to be i18n'ed since they're definition-time errors rather than user-facing
+  (when (some? tag)
+    (assert ((some-fn symbol? string?) tag) (format "Setting :tag should be a symbol or string, got: ^%s %s"
+                                                    (.getCanonicalName (class tag))
+                                                    (pr-str tag))))
+  (when (and (some? default)
+             (some? tag))
+    (let [klass (if (string? tag)
+                  (try
+                    (Class/forName tag)
+                    (catch Throwable e
+                      e))
+                  (resolve tag))]
+      (when-not (class? klass)
+        (throw (ex-info (format "Cannot resolve :tag %s to a class. Is it fully qualified?" (pr-str tag))
+                        {:tag klass}
+                        (when (instance? Throwable klass) klass))))
+      (when-not (instance? klass default)
+        (throw (ex-info (format "Wrong :default type: got ^%s %s, but expected a %s"
+                                (.getCanonicalName (class default))
+                                (pr-str default)
+                                (.getCanonicalName ^Class klass))
+                        {:tag klass}))))))
+
+(defn register-setting!
+  "Register a new Setting with a map of [[SettingDefinition]] attributes. Returns the map it was passed. This is used
+  internally by [[defsetting]]; you shouldn't need to use it yourself."
+  [{setting-name :name, setting-ns :namespace, setting-type :type, default :default, :as setting}]
+  (let [munged-name (setting.def/munge-setting-name (name setting-name))
+        setting-type (s/validate Type (or setting-type :string))
+        setting-def (merge
+                     {:name           setting-name
+                      :munged-name    munged-name
+                      :namespace      setting-ns
+                      :description    nil
+                      :doc            nil
+                      :type           setting-type
+                      :default        default
+                      :on-change      nil
+                      :getter         (partial (default-getter-for-type setting-type) setting-name)
+                      :setter         (partial (default-setter-for-type setting-type) setting-name)
+                      :tag            (default-tag-for-type setting-type)
+                      :visibility     :admin
+                      :sensitive?     false
+                      :cache?         true
+                      :database-local :never
+                      :user-local     :never
+                      :deprecated     nil
+                      :enabled?       nil}
+                     (dissoc setting :name :type :default))]
+    (s/validate SettingDefinition setting-def)
+    (validate-default-value-for-type setting-def)
+    ;; The errors below are not i18n'ed because they're dev-facing-only
+    ;;
+    ;; eastwood complains about (setting-name @registered-settings) for shadowing the function `setting-name`
+    (when-let [registered-setting (get @registered-settings setting-name)]
+      (when (not= setting-ns (:namespace registered-setting))
+        (throw (ex-info (format "Setting %s already registered in %s" setting-name (:namespace registered-setting))
+                        {:existing-setting (dissoc registered-setting :on-change :getter :setter)}))))
+    (when-let [same-munge (first (filter (comp #{munged-name} :munged-name)
+                                         (vals @registered-settings)))]
+      (when (not= setting-name (:name same-munge)) ;; redefinitions are fine
+        (throw (ex-info (format "Setting names in would collide: %s and %s"
+                                setting-name (:name same-munge))
+                        {:existing-setting (dissoc same-munge :on-change :getter :setter)
+                         :new-setting      (dissoc setting-def :on-change :getter :setter)}))))
+    (when (and (retired-setting-names (name setting-name)) (not *allow-retired-setting-names*))
+      (throw (ex-info (format "Setting name %s is retired; use a different name instead" (name setting-name))
+                      {:retired-setting-name (name setting-name)
+                       :new-setting          (dissoc setting-def :on-change :getter :setter)})))
+    (when (and (setting.def/allows-user-local-values? setting) (setting.def/allows-database-local-values? setting))
+      (throw (ex-info (format "Setting %s allows both user-local and database-local values; this is not supported"
+                              setting-name)
+                      {:setting setting})))
+    (swap! registered-settings assoc setting-name setting-def)
+    setting-def))


### PR DESCRIPTION
Experiment with making the `defsetting` macro dependency-free so it can be used everywhere and we can remove the weird stuff in `metabase.config` and rework it to use `defsetting`. This will make it easier to document all of our env vars automatically. Still need to do a bit more work to make these settings stop trying to do DB access tho

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/27044)
<!-- Reviewable:end -->
