### PR TITLE
Fix flaky `remap-human-readable-string-column-test`

### DIFF
--- a/test/metabase/query_processor/middleware/add_dimension_projections_test.clj
+++ b/test/metabase/query_processor/middleware/add_dimension_projections_test.clj
@@ -214,15 +214,6 @@
       (mt/with-column-remappings [venues.name {"apple"  "Appletini"
                                                "banana" "Bananasplit"
                                                "kiwi"   "Kiwi-flavored Thing"}]
-        ;; todo: logging code for if this errors in CI
-        (let [remappings (db/select 'FieldValues :field_id (mt/id :venues :name))
-              dimensions (db/select 'Dimension :field_id (mt/id :venues :name))]
-          (when (> (count remappings) 1)
-            (throw (ex-info "Too many remappings"
-                            {:remappings (map #(update % :values (fn [vs] (take 5 vs))) remappings)})))
-          (when (> (count dimensions) 1)
-            (ex-info "Too many dimensions"
-                            {:dimensions dimensions})))
         (is (partial= {:status    :completed
                        :row_count 3
                        :data      {:rows [[1 "apple"   4 3 "Appletini"]

--- a/test/metabase/query_processor/middleware/add_dimension_projections_test.clj
+++ b/test/metabase/query_processor/middleware/add_dimension_projections_test.clj
@@ -214,6 +214,15 @@
       (mt/with-column-remappings [venues.name {"apple"  "Appletini"
                                                "banana" "Bananasplit"
                                                "kiwi"   "Kiwi-flavored Thing"}]
+        ;; todo: logging code for if this errors in CI
+        (let [remappings (db/select 'FieldValues :field_id (mt/id :venues :name))
+              dimensions (db/select 'Dimension :field_id (mt/id :venues :name))]
+          (when (> (count remappings) 1)
+            (throw (ex-info "Too many remappings"
+                            {:remappings (map #(update % :values (fn [vs] (take 5 vs))) remappings)})))
+          (when (> (count dimensions) 1)
+            (ex-info "Too many dimensions"
+                            {:dimensions dimensions})))
         (is (partial= {:status    :completed
                        :row_count 3
                        :data      {:rows [[1 "apple"   4 3 "Appletini"]

--- a/test/metabase/test/util.clj
+++ b/test/metabase/test/util.clj
@@ -52,6 +52,7 @@
    [metabase.test.data :as data]
    [metabase.test.fixtures :as fixtures]
    [metabase.test.initialize :as initialize]
+   [metabase.test.util :as tu]
    [metabase.test.util.log :as tu.log]
    [metabase.util :as u]
    [metabase.util.files :as u.files]
@@ -889,15 +890,22 @@
                                      remap)
                              remap)]
             (fn []
-              (tt/with-temp* [Dimension   [_ {:field_id (:id original)
-                                              :name     (format "%s [internal remap]" (:display_name original))
-                                              :type     :internal}]
-                              FieldValues [_ {:field_id              (:id original)
-                                              :values                (keys values-map)
-                                              :human_readable_values (vals values-map)}]]
-                (testing (format "With human readable values remapping %s -> %s\n"
-                                 (describe-field original) (pr-str values-map))
-                  (thunk)))))))))
+              (let [preexisting-id (db/select-one-id FieldValues :field_id (:id original))
+                    testing-thunk (fn []
+                                    (testing (format "With human readable values remapping %s -> %s\n"
+                                                     (describe-field original) (pr-str values-map))
+                                      (thunk)))]
+                (tt/with-temp* [Dimension   [_ {:field_id (:id original)
+                                                :name     (format "%s [internal remap]" (:display_name original))
+                                                :type     :internal}]]
+                  (if preexisting-id
+                    (tu/with-temp-vals-in-db FieldValues preexisting-id {:values (keys values-map)
+                                                                         :human_readable_values (vals values-map)}
+                      (testing-thunk))
+                    (tt/with-temp* [FieldValues [_ {:field_id              (:id original)
+                                                    :values                (keys values-map)
+                                                    :human_readable_values (vals values-map)}]]
+                      (testing-thunk)))))))))))
    orig->remapped))
 
 (defn- col-remappings-arg [x]

--- a/test/metabase/test/util.clj
+++ b/test/metabase/test/util.clj
@@ -890,7 +890,9 @@
                                      remap)
                              remap)]
             (fn []
-              (let [preexisting-id (db/select-one-id FieldValues :field_id (:id original))
+              (let [preexisting-id (db/select-one-id FieldValues
+                                                     :field_id (:id original)
+                                                     :type :full)
                     testing-thunk (fn []
                                     (testing (format "With human readable values remapping %s -> %s\n"
                                                      (describe-field original) (pr-str values-map))


### PR DESCRIPTION
Quite annoying test that would flake quite a bit in CI.

the problem is that the mechanism for `mt/with-column-remappings` wasn't aware of the case when there were pre-existing mappings. It just blindly added a new mapping. But when the middleware fetching the remappings, it found the preexisting ones.

For the venue.name field in this test, that was ("20th Century Cafe","25°","33 Taps","800 Degrees Neapolitan Pizzeria", ...). We were passing in fake names like "apple", "banana", "kiwi" and it found no remappings for those in the db.

So the fix is to check for pre-existing ones, and if found, use `tu/with-temp-vals-in-db` to temporarily set them to the desired values, otherwise use some new ones with `tt/with-temp*` as it was doing previously.


If you are running these tests locally, run them and see if they pass or fail.

Before this patch:
To reliably make them pass, run 
`(db/delete! 'FieldValues :field_id (mt/id :venues :name))`

To reliably make them fail, run
`(metabase.sync.field-values/update-field-values! (db/select-one 'Database :id <temp-data-id>))` (for me is 241, find with `(db/select-one 'Database :name "test-data" :engine "h2")`).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/27050)
<!-- Reviewable:end -->
