### PR TITLE
CI for release: verify that the downloaded Uberjar is a valid JAR file

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,10 @@ jobs:
         curl -OL $JAR_DOWNLOAD_URL
         stat ./metabase.jar
         date | tee timestamp
+    - name: Verify that this is a valid JAR file
+      run: file ./metabase.jar | grep "Zip archive data"
+    - name: Reveal its version.properties
+      run: jar xf metabase.jar version.properties && cat version.properties
     - name: Calculate SHA256 checksum
       run: sha256sum ./metabase.jar | tee SHA256.sum
     - name: Upload Uberjar as artifact

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
         stat ./metabase.jar
         date | tee timestamp
     - name: Verify that this is a valid JAR file
-      run: file ./metabase.jar | grep "Zip archive data"
+      run: file --mime-type ./metabase.jar | grep "application/zip"
     - name: Reveal its version.properties
       run: jar xf metabase.jar version.properties && cat version.properties
     - name: Calculate SHA256 checksum


### PR DESCRIPTION
If the URL is invalid, what gets downloaded is actually an HTML file (e.g. for the 404 page). In that case, do not proceed.

### Before this PR

Given an invalid ref, the job sadly continues to download the Uberjar (which is actually an 404 HTML file) and save it.

![image](https://user-images.githubusercontent.com/7288/206270757-f488514e-16c1-487b-acf3-6aeda4a46ac4.png)

### After this PR

_Thou shall not pass!!!_

![image](https://user-images.githubusercontent.com/7288/206272421-efdcad92-e600-4250-a319-7e85bad65a7f.png)