### PR TITLE
fix add series modal

### DIFF
--- a/frontend/src/metabase/dashboard/components/AddSeriesModal/QuestionList.jsx
+++ b/frontend/src/metabase/dashboard/components/AddSeriesModal/QuestionList.jsx
@@ -83,17 +83,38 @@ export const QuestionList = React.memo(function QuestionList({
 
   const compatibleQuestions = useMemo(
     () =>
-      filteredQuestions?.filter(question =>
-        isQuestionCompatible(visualization, dashcard, dashcardData, question),
-      ),
+      filteredQuestions?.filter(question => {
+        try {
+          return isQuestionCompatible(
+            visualization,
+            dashcard,
+            dashcardData,
+            question,
+          );
+        } catch (e) {
+          console.warn(
+            `Could not check question compatibility for a question with id=${question?.id?.()}`,
+            e,
+          );
+          return false;
+        }
+      }),
     [dashcard, dashcardData, filteredQuestions, visualization],
   );
 
   const questionsWithoutMetadata = useMemo(
     () =>
-      filteredQuestions.filter(
-        question => question.isStructured() && !question.query().hasMetadata(),
-      ),
+      filteredQuestions.filter(question => {
+        try {
+          return question.isStructured() && !question.query().hasMetadata();
+        } catch (e) {
+          console.warn(
+            `Could not check question metadata existence for a question with id=${question?.id?.()}`,
+            e,
+          );
+          return false;
+        }
+      }),
     [filteredQuestions],
   );
 


### PR DESCRIPTION
Add a couple of try-catch blocks to the AddSeries modal to avoid the app crashing when anything is wrong with questions' queries or their metadata.