### PR TITLE
Fix flaky tests `field-values-test.sync-recreate-field-values-test `

### DIFF
--- a/test/metabase/sync/field_values_test.clj
+++ b/test/metabase/sync/field_values_test.clj
@@ -24,6 +24,8 @@
 (deftest sync-recreate-field-values-test
   (testing "Test that when we delete FieldValues syncing the Table again will cause them to be re-created"
     (testing "Check that we have expected field values to start with"
+      ;; sync to make sure the field values are filled
+      (sync-database!' "update-field-values" (data/db))
       (is (= [1 2 3 4]
              (venues-price-field-values))))
     (testing "Delete the Field values, make sure they're gone"
@@ -41,6 +43,8 @@
 (deftest sync-should-update-test
   (testing "Test that syncing will cause FieldValues to be updated"
     (testing "Check that we have expected field values to start with"
+      ;; sync to make sure the field values are filled
+      (sync-database!' "update-field-values" (data/db))
       (is (= [1 2 3 4]
              (venues-price-field-values))))
     (testing "Update the FieldValues, remove one of the values that should be there"


### PR DESCRIPTION
First found in https://github.com/metabase/metabase/pull/27033/checks?check_run_id=9964429201

I think this failed because there are tests that clear the FieldValues of the same Field run before this test got executed.

So when these tests run there are no FieldValues for it to check.

A fix is to sync the db before executing the test to ensure FieldValues got filled.