### PR TITLE
Update snowflake datetime-diff to throw on time argument

### DIFF
--- a/test/metabase/query_processor_test/date_time_zone_functions_test.clj
+++ b/test/metabase/query_processor_test/date_time_zone_functions_test.clj
@@ -930,26 +930,14 @@
                       (mt/formatted-rows [int int int int])
                       first))))))))
 
-(mt/defdataset diff-type-test-cases
-  [["times"
-    [{:field-name "a_text",      :base-type :type/Text}
-     {:field-name "a_datetime",  :base-type :type/DateTime}
-     {:field-name "b_text",      :base-type :type/Text}
-     {:field-name "b_time",      :base-type :type/Time}]
-    [["2022-10-02T01:00:00"    ; a_text
-      #t "2022-10-02T01:00:00" ; a_datetime
-      "05:00:00"               ; b_text
-      #t "05:00:00"]]]])       ; b_time
-
 (deftest datetime-diff-type-test
   (mt/test-drivers (filter mt/supports-time-type? (mt/normal-drivers-with-feature :datetime-diff))
     (testing "Cannot datetime-diff against time column"
-      (mt/dataset diff-type-test-cases
+      (mt/dataset test-data-with-time
         (is (thrown-with-msg?
              clojure.lang.ExceptionInfo
              #"Only datetime, timestamp, or date types allowed. Found .*"
-             (mt/rows
-              (mt/run-mbql-query times
-                {:limit 1
-                 :fields      [[:expression "diff-day"]]
-                 :expressions {"diff-day" [:datetime-diff $a_datetime $b_time :day]}}))))))))
+             (mt/run-mbql-query users
+               {:limit 1
+                :fields      [[:expression "diff-day"]]
+                :expressions {"diff-day" [:datetime-diff $last_login_time $last_login_date :day]}})))))))

--- a/test/metabase/query_processor_test/date_time_zone_functions_test.clj
+++ b/test/metabase/query_processor_test/date_time_zone_functions_test.clj
@@ -922,15 +922,26 @@
                       (mt/formatted-rows [int int int int])
                       first))))))))
 
+(mt/defdataset diff-type-test-cases
+  [["times"
+    [{:field-name "a_text",      :base-type :type/Text}
+     {:field-name "a_datetime",  :base-type :type/DateTime}
+     {:field-name "b_text",      :base-type :type/Text}
+     {:field-name "b_time",      :base-type :type/Time}]
+    [["2022-10-02T01:00:00"    ; a_text
+      #t "2022-10-02T01:00:00" ; a_datetime
+      "05:00:00"               ; b_text
+      #t "05:00:00"]]]])       ; b_time
+
 (deftest datetime-diff-type-test
   (mt/test-drivers (filter mt/supports-time-type? (mt/normal-drivers-with-feature :datetime-diff))
     (testing "Cannot datetime-diff against time column"
-      (mt/dataset attempted-murders
+      (mt/dataset diff-type-test-cases
         (is (thrown-with-msg?
              clojure.lang.ExceptionInfo
              #"Only datetime, timestamp, or date types allowed. Found .*"
              (mt/rows
-              (mt/run-mbql-query attempts
+              (mt/run-mbql-query times
                 {:limit 1
                  :fields      [[:expression "diff-day"]]
-                 :expressions {"diff-day" [:datetime-diff $time_tz $datetime_tz :day]}}))))))))
+                 :expressions {"diff-day" [:datetime-diff $a_datetime $b_time :day]}}))))))))

--- a/test/metabase/query_processor_test/date_time_zone_functions_test.clj
+++ b/test/metabase/query_processor_test/date_time_zone_functions_test.clj
@@ -923,9 +923,7 @@
                       first))))))))
 
 (deftest datetime-diff-type-test
-  ;; FIXME — The excluded drivers below don't have TIME types. These shouldn't be hard-coded with #26807
-  (mt/test-drivers (disj (mt/normal-drivers-with-feature :datetime-diff)
-                         :oracle :presto :redshift :sparksql :snowflake)
+  (mt/test-drivers (filter mt/supports-time-type? (mt/normal-drivers-with-feature :datetime-diff))
     (testing "Cannot datetime-diff against time column"
       (mt/dataset attempted-murders
         (is (thrown-with-msg?


### PR DESCRIPTION
Previously snowflake didn't throw an error if an argument to datetimeDiff was of type `:type/Time`, unlike other drivers.

A complication is that this is tested in `datetime-diff-type-test`. However, `attempted-murders` is currently used in the test but it requires that the driver supports `:type/TimeWithTZ`. Snowflake is an example of a driver that supports columns of type `:type/Time`, but not `:type/TimeWithTZ`. To work around this, I've created a new dataset specifically that only includes a `:type/Time` and `:type/DateTime` column, and no `:type/TimeWithTZ`.