### PR TITLE
Migrate MySQL latest driver test to GitHub Actions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,19 +27,6 @@ executors:
     docker:
       - image: metabase/ci:java-17-clj-1.11.0.1100.04-2022-build
 
-  mysql-latest:
-    working_directory: /home/circleci/metabase/metabase/
-    docker:
-      - image: metabase/ci:java-11-clj-1.11.0.1100.04-2022-build
-        environment:
-          MB_DB_TYPE: mysql
-          MB_DB_HOST: localhost
-          MB_DB_PORT: 3306
-          MB_DB_DBNAME: circle_test
-          MB_DB_USER: root
-          MB_MYSQL_TEST_USER: root
-      - image: circleci/mysql:latest
-
   mongo-4-0-ssl:
      working_directory: /home/circleci/metabase/metabase/
      docker:
@@ -615,28 +602,6 @@ workflows:
             - be-deps
           e: << matrix.version >>
           driver: mongo
-
-      - test-driver:
-          name: be-tests-mysql-latest-ee
-          description: "(MySQL latest)"
-          requires:
-            - be-deps
-          e:
-            name: mysql-latest
-          driver: mysql
-          # set up env vars for something named "MYSQL_SSL" to run MySQL SSL tests verifying connectivity with PEM cert
-          # they are deliberately given a different name to prevent them from affecting the regular test run against
-          # the configured MySQL instance, but there is one particular test (mysql-connect-with-ssl-and-pem-cert-test)
-          # that overrides the MB_MYSQL_TEST_* values with them
-          # the MYSQL_RDS_SSL_INSTANCE vars are secret and/or changeable, so they are defined in the CircleCI settings
-          timeout: 30m
-          extra-env: >-
-            MB_MYSQL_SSL_TEST_HOST=$MYSQL_RDS_SSL_INSTANCE_HOST
-            MB_MYSQL_SSL_TEST_SSL=true
-            MB_MYSQL_SSL_TEST_ADDITIONAL_OPTIONS='verifyServerCertificate=true'
-            MB_MYSQL_SSL_TEST_SSL_CERT="$(cat /home/circleci/metabase/metabase/resources/certificates/rds-combined-ca-bundle.pem)"
-            MB_MYSQL_SSL_TEST_USER=metabase
-            MB_MYSQL_SSL_TEST_PASSWORD=$MYSQL_RDS_SSL_INSTANCE_PASSWORD
 
       - test-driver:
           name: be-tests-oracle-ee

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -24,7 +24,7 @@ jobs:
 
   be-tests-druid-ee:
     runs-on: buildjet-2vcpu-ubuntu-2004
-    timeout-minutes: 30
+    timeout-minutes: 60
     env:
       CI: 'true'
       DRIVERS: druid
@@ -44,7 +44,7 @@ jobs:
 
   be-tests-mariadb-10-2-ee:
     runs-on: ubuntu-20.04
-    timeout-minutes: 30
+    timeout-minutes: 60
     env:
       CI: 'true'
       DRIVERS: mysql
@@ -68,7 +68,7 @@ jobs:
 
   be-tests-mariadb-latest-ee:
     runs-on: ubuntu-20.04
-    timeout-minutes: 30
+    timeout-minutes: 60
     env:
       CI: 'true'
       DRIVERS: mysql
@@ -92,7 +92,7 @@ jobs:
 
   be-tests-mongo-4-0-ee:
     runs-on: ubuntu-20.04
-    timeout-minutes: 30
+    timeout-minutes: 60
     env:
       CI: 'true'
       DRIVERS: mongo
@@ -110,7 +110,7 @@ jobs:
 
   be-tests-mongo-5-0-ee:
     runs-on: ubuntu-20.04
-    timeout-minutes: 30
+    timeout-minutes: 60
     env:
       CI: 'true'
       DRIVERS: mongo
@@ -128,7 +128,7 @@ jobs:
 
   be-tests-mongo-latest-ee:
     runs-on: ubuntu-20.04
-    timeout-minutes: 30
+    timeout-minutes: 60
     env:
       CI: 'true'
       DRIVERS: mongo
@@ -149,7 +149,7 @@ jobs:
 
   be-tests-mysql-5-7-ee:
     runs-on: ubuntu-20.04
-    timeout-minutes: 30
+    timeout-minutes: 60
     env:
       CI: 'true'
       DRIVERS: mysql
@@ -173,7 +173,7 @@ jobs:
 
   be-tests-mysql-latest-ee:
     runs-on: ubuntu-20.04
-    timeout-minutes: 40
+    timeout-minutes: 60
     env:
       CI: 'true'
       DRIVERS: mysql
@@ -209,7 +209,7 @@ jobs:
 
   be-tests-postgres-ee:
     runs-on: ubuntu-20.04
-    timeout-minutes: 30
+    timeout-minutes: 60
     env:
       CI: 'true'
       DRIVERS: postgres
@@ -236,7 +236,7 @@ jobs:
 
   be-tests-postgres-latest-ee:
     runs-on: ubuntu-20.04
-    timeout-minutes: 30
+    timeout-minutes: 60
     env:
       CI: 'true'
       DRIVERS: postgres
@@ -267,7 +267,7 @@ jobs:
 
   be-tests-presto-186-ee:
     runs-on: ubuntu-20.04
-    timeout-minutes: 30
+    timeout-minutes: 60
     env:
       CI: 'true'
       DRIVERS: presto
@@ -287,7 +287,7 @@ jobs:
 
   be-tests-sparksql-ee:
     runs-on: buildjet-2vcpu-ubuntu-2004
-    timeout-minutes: 30
+    timeout-minutes: 60
     env:
       CI: 'true'
       DRIVERS: sparksql
@@ -305,7 +305,7 @@ jobs:
 
   be-tests-sqlite-ee:
     runs-on: ubuntu-20.04
-    timeout-minutes: 30
+    timeout-minutes: 60
     env:
       CI: 'true'
       DRIVERS: sqlite
@@ -318,7 +318,7 @@ jobs:
 
   be-tests-sqlserver-ee:
     runs-on: ubuntu-20.04
-    timeout-minutes: 30
+    timeout-minutes: 60
     env:
       CI: 'true'
       DRIVERS: sqlserver

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -173,7 +173,7 @@ jobs:
 
   be-tests-mysql-latest-ee:
     runs-on: ubuntu-20.04
-    timeout-minutes: 30
+    timeout-minutes: 35
     env:
       CI: 'true'
       DRIVERS: mysql

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -171,6 +171,43 @@ jobs:
       with:
         junit-name: 'be-tests-mysql-5-7-ee'
 
+  be-tests-mysql-latest-ee:
+    runs-on: ubuntu-20.04
+    timeout-minutes: 30
+    env:
+      CI: 'true'
+      DRIVERS: mysql
+      MB_DB_TYPE: mysql
+      MB_DB_HOST: localhost
+      MB_DB_PORT: 3306
+      MB_DB_DBNAME: circle_test
+      MB_DB_USER: root
+      MB_MYSQL_TEST_USER: root
+    services:
+      mysql:
+        image: circleci/mysql:latest
+        ports:
+        - "3306:3306"
+        # set up env vars for something named "MYSQL_SSL" to run MySQL SSL tests verifying connectivity with PEM cert
+        # they are deliberately given a different name to prevent them from affecting the regular test run against
+        # the configured MySQL instance, but there is one particular test (mysql-connect-with-ssl-and-pem-cert-test)
+        # that overrides the MB_MYSQL_TEST_* values with them
+        # the MYSQL_RDS_SSL_INSTANCE vars are defined as secrets and can be altered
+        env:
+          MB_MYSQL_SSL_TEST_HOST: ${{ secrets.MYSQL_RDS_SSL_INSTANCE_HOST }}
+          MB_MYSQL_SSL_TEST_SSL: true
+          MB_MYSQL_SSL_TEST_ADDITIONAL_OPTIONS: 'verifyServerCertificate=true'
+          # the contents of the ./resources/certificates/rds-combined-ca-bundle.pem file
+          MB_MYSQL_SSL_TEST_SSL_CERT: ${{ secrets.MB_MYSQL_SSL_TEST_SSL_CERT }}
+          MB_MYSQL_SSL_TEST_USER: metabase
+          MB_MYSQL_SSL_TEST_PASSWORD: ${{ secrets.MYSQL_RDS_SSL_INSTANCE_PASSWORD }}
+    steps:
+    - uses: actions/checkout@v3
+    - name: Test MySQL driver (latest)
+      uses: ./.github/actions/test-driver
+      with:
+        junit-name: 'be-tests-mysql-latest-ee'
+
   be-tests-postgres-ee:
     runs-on: ubuntu-20.04
     timeout-minutes: 30

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -183,24 +183,23 @@ jobs:
       MB_DB_DBNAME: circle_test
       MB_DB_USER: root
       MB_MYSQL_TEST_USER: root
+      # set up env vars for something named "MYSQL_SSL" to run MySQL SSL tests verifying connectivity with PEM cert
+      # they are deliberately given a different name to prevent them from affecting the regular test run against
+      # the configured MySQL instance, but there is one particular test (mysql-connect-with-ssl-and-pem-cert-test)
+      # that overrides the MB_MYSQL_TEST_* values with them
+      # the MYSQL_RDS_SSL_INSTANCE vars are defined as secrets and can be altered
+      MB_MYSQL_SSL_TEST_HOST: ${{ secrets.MYSQL_RDS_SSL_INSTANCE_HOST }}
+      MB_MYSQL_SSL_TEST_SSL: true
+      MB_MYSQL_SSL_TEST_ADDITIONAL_OPTIONS: 'verifyServerCertificate=true'
+      # the contents of the ./resources/certificates/rds-combined-ca-bundle.pem file
+      MB_MYSQL_SSL_TEST_SSL_CERT: ${{ secrets.MB_MYSQL_SSL_TEST_SSL_CERT }}
+      MB_MYSQL_SSL_TEST_USER: metabase
+      MB_MYSQL_SSL_TEST_PASSWORD: ${{ secrets.MYSQL_RDS_SSL_INSTANCE_PASSWORD }}
     services:
       mysql:
         image: circleci/mysql:latest
         ports:
         - "3306:3306"
-        # set up env vars for something named "MYSQL_SSL" to run MySQL SSL tests verifying connectivity with PEM cert
-        # they are deliberately given a different name to prevent them from affecting the regular test run against
-        # the configured MySQL instance, but there is one particular test (mysql-connect-with-ssl-and-pem-cert-test)
-        # that overrides the MB_MYSQL_TEST_* values with them
-        # the MYSQL_RDS_SSL_INSTANCE vars are defined as secrets and can be altered
-        env:
-          MB_MYSQL_SSL_TEST_HOST: ${{ secrets.MYSQL_RDS_SSL_INSTANCE_HOST }}
-          MB_MYSQL_SSL_TEST_SSL: true
-          MB_MYSQL_SSL_TEST_ADDITIONAL_OPTIONS: 'verifyServerCertificate=true'
-          # the contents of the ./resources/certificates/rds-combined-ca-bundle.pem file
-          MB_MYSQL_SSL_TEST_SSL_CERT: ${{ secrets.MB_MYSQL_SSL_TEST_SSL_CERT }}
-          MB_MYSQL_SSL_TEST_USER: metabase
-          MB_MYSQL_SSL_TEST_PASSWORD: ${{ secrets.MYSQL_RDS_SSL_INSTANCE_PASSWORD }}
     steps:
     - uses: actions/checkout@v3
     - name: Test MySQL driver (latest)

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -173,7 +173,7 @@ jobs:
 
   be-tests-mysql-latest-ee:
     runs-on: ubuntu-20.04
-    timeout-minutes: 35
+    timeout-minutes: 40
     env:
       CI: 'true'
       DRIVERS: mysql


### PR DESCRIPTION
One thing to keep in mind while reviewing this is the difference in the total number of tests reported by GH vs CCI:

```clj
;; GitHub Actions
;;
;; Ran 3058 tests in 1349.317 seconds
;; 19960 assertions, 0 failures, 0 errors.
{:test 3058,
 :pass 19960,
 :fail 0,
 :error 0,
 :type :summary,
 :duration 1349317.309391,
 :single-threaded 2838,
 :parallel 220}
;; Ran 220 tests in parallel, 2838 single-threaded.
;; Finding and running tests took 23.9 mins.
```

vs

```clj
;; CircleCI
;;
;; Ran 3064 tests in 1668.093 seconds
;; 19987 assertions, 0 failures, 0 errors.
{:test 3064,
 :pass 19987,
 :fail 0,
 :error 0,
 :type :summary,
 :duration 1668092.674047,
 :single-threaded 2843,
 :parallel 221}
;; Ran 221 tests in parallel, 2843 single-threaded.
;; Finding and running tests took 29.1 mins.
```