### PR TITLE
datetime-diff function for SQLite

### DIFF
--- a/modules/drivers/sqlite/src/metabase/driver/sqlite.clj
+++ b/modules/drivers/sqlite/src/metabase/driver/sqlite.clj
@@ -31,6 +31,7 @@
                               :percentile-aggregations                false
                               :advanced-math-expressions              false
                               :standard-deviation-aggregations        false
+                              :datetime-diff                          true
                               :now                                    true}]
   (defmethod driver/supports? [:sqlite feature] [_ _] supported?))
 
@@ -359,6 +360,97 @@
 (defmethod sql.qp/current-datetime-honeysql-form :sqlite
   [_]
   (hsql/call :datetime (hx/literal :now)))
+
+(defmethod sql.qp/->honeysql [:sqlite :datetime-diff]
+  [driver [_ x y unit]]
+  (let [x                (sql.qp/->honeysql driver x)
+        y                (sql.qp/->honeysql driver y)
+        extract          (fn [unit x] (sql.qp/date :sqlite unit x))
+        disallowed-types (keep
+                          (fn [v]
+                            (some->> v
+                                     hx/type-info
+                                     hx/type-info->db-type
+                                     name
+                                     (re-find #"(?i)^time")))
+                          [x y])]
+    (when (seq disallowed-types)
+      (throw (ex-info (tru "Only datetime, timestamp, or date types allowed. Found {0}"
+                           (pr-str disallowed-types))
+                      {:found disallowed-types
+                       :type  qp.error-type/invalid-query})))
+    (case unit
+      :year
+      (let [positive-diff
+            (fn [a b] ; precondition: a <= b
+              (hx/-
+               (hx/- (extract :year b) (extract :year a))
+               ;; decrement if a is later than b in the year calendar
+               (hx/cast
+                :integer
+                (hsql/call
+                 :or
+                 (hsql/call :> (extract :month-of-year a) (extract :month-of-year b))
+                 (hsql/call
+                  :and
+                  (hsql/call := (extract :month-of-year a) (extract :month-of-year b))
+                  (hsql/call :> (extract :day-of-month a) (extract :day-of-month b)))))))]
+        (hsql/call :case (hsql/call :<= x y) (positive-diff x y) :else (hx/* -1 (positive-diff y x))))
+
+      :quarter
+      (let [positive-diff
+            (fn [a b]
+              (hx/cast
+               :integer
+               (hx/floor (hx// (hx/- (hx/+ (hx/* (hx/- (extract :year b)
+                                                       (extract :year a))
+                                                 12)
+                                           (hx/- (extract :month-of-year b)
+                                                 (extract :month-of-year a)))
+                                     (hx/cast
+                                      :integer
+                                      (hsql/call :> (extract :day-of-month a) (extract :day-of-month b))))
+                               3))))]
+        (hsql/call :case (hsql/call :<= x y) (positive-diff x y) :else (hx/* -1 (positive-diff y x))))
+
+      :month
+      (let [positive-diff
+            (fn [a b]
+              (hx/- (hx/+ (hx/* (hx/- (extract :year b)
+                                      (extract :year a))
+                                12)
+                          (hx/- (extract :month-of-year b)
+                                (extract :month-of-year a)))
+                    (hx/cast :integer (hsql/call :> (extract :day-of-month a) (extract :day-of-month b)))))]
+        (hsql/call :case (hsql/call :<= x y) (positive-diff x y) :else (hx/* -1 (positive-diff y x))))
+
+      :week
+      (let [positive-diff
+            (fn [a b]
+              (hx/cast :integer (hx// (hsql/call :-
+                                                 (hsql/call :julianday (->date b))
+                                                 (hsql/call :julianday (->date a)))
+                                      7)))]
+        (hsql/call :case (hsql/call :<= x y) (positive-diff x y) :else (hx/* -1 (positive-diff y x))))
+
+      :day
+      (let [positive-diff
+            (fn [a b]
+              (hx/cast :integer (hsql/call :-
+                                           (hsql/call :julianday (->date b))
+                                           (hsql/call :julianday (->date a)))))]
+        (hsql/call :case (hsql/call :<= x y) (positive-diff x y) :else (hx/* -1 (positive-diff y x))))
+
+      (:hour :minute :second)
+      (let [positive-diff
+            (fn [a b]
+              (-> (hsql/call :-
+                             (hsql/call :julianday b)
+                             (hsql/call :julianday a))
+                  (hx/* (case unit :hour 24 :minute 1440 :second 86400))
+                  hx/floor
+                  hx/->integer))]
+        (hsql/call :case (hsql/call :<= x y) (positive-diff x y) :else (hx/* -1 (positive-diff y x)))))))
 
 ;; SQLite's JDBC driver is fussy and won't let you change connections to read-only after you create them. So skip that
 ;; step. SQLite doesn't have a notion of session timezones so don't do that either. The only thing we're doing here from

--- a/modules/drivers/sqlite/src/metabase/driver/sqlite.clj
+++ b/modules/drivers/sqlite/src/metabase/driver/sqlite.clj
@@ -361,96 +361,54 @@
   [_]
   (hsql/call :datetime (hx/literal :now)))
 
-(defmethod sql.qp/->honeysql [:sqlite :datetime-diff]
-  [driver [_ x y unit]]
-  (let [x                (sql.qp/->honeysql driver x)
-        y                (sql.qp/->honeysql driver y)
-        extract          (fn [unit x] (sql.qp/date :sqlite unit x))
-        disallowed-types (keep
-                          (fn [v]
-                            (some->> v
-                                     hx/type-info
-                                     hx/type-info->db-type
-                                     name
-                                     (re-find #"(?i)^time")))
-                          [x y])]
-    (when (seq disallowed-types)
-      (throw (ex-info (tru "Only datetime, timestamp, or date types allowed. Found {0}"
-                           (pr-str disallowed-types))
-                      {:found disallowed-types
-                       :type  qp.error-type/invalid-query})))
-    (case unit
-      :year
-      (let [positive-diff
-            (fn [a b] ; precondition: a <= b
-              (hx/-
-               (hx/- (extract :year b) (extract :year a))
-               ;; decrement if a is later than b in the year calendar
-               (hx/cast
-                :integer
-                (hsql/call
-                 :or
-                 (hsql/call :> (extract :month-of-year a) (extract :month-of-year b))
-                 (hsql/call
-                  :and
-                  (hsql/call := (extract :month-of-year a) (extract :month-of-year b))
-                  (hsql/call :> (extract :day-of-month a) (extract :day-of-month b)))))))]
-        (hsql/call :case (hsql/call :<= x y) (positive-diff x y) :else (hx/* -1 (positive-diff y x))))
+(defmethod sql.qp/datetime-diff [:sqlite :year]
+  [driver _unit x y]
+  (hx// (sql.qp/datetime-diff driver :month x y) 12))
 
-      :quarter
-      (let [positive-diff
-            (fn [a b]
-              (hx/cast
-               :integer
-               (hx/floor (hx// (hx/- (hx/+ (hx/* (hx/- (extract :year b)
-                                                       (extract :year a))
-                                                 12)
-                                           (hx/- (extract :month-of-year b)
-                                                 (extract :month-of-year a)))
-                                     (hx/cast
-                                      :integer
-                                      (hsql/call :> (extract :day-of-month a) (extract :day-of-month b))))
-                               3))))]
-        (hsql/call :case (hsql/call :<= x y) (positive-diff x y) :else (hx/* -1 (positive-diff y x))))
+(defmethod sql.qp/datetime-diff [:sqlite :quarter]
+  [driver _unit x y]
+  (hx// (sql.qp/datetime-diff driver :month x y) 3))
 
-      :month
-      (let [positive-diff
-            (fn [a b]
-              (hx/- (hx/+ (hx/* (hx/- (extract :year b)
-                                      (extract :year a))
-                                12)
-                          (hx/- (extract :month-of-year b)
-                                (extract :month-of-year a)))
-                    (hx/cast :integer (hsql/call :> (extract :day-of-month a) (extract :day-of-month b)))))]
-        (hsql/call :case (hsql/call :<= x y) (positive-diff x y) :else (hx/* -1 (positive-diff y x))))
+(defmethod sql.qp/datetime-diff [:sqlite :month]
+  [driver _unit x y]
+  (let [extract            (fn [unit x] (sql.qp/date driver unit x))
+        year-diff          (hx/- (extract :year y) (extract :year x))
+        month-of-year-diff (hx/- (extract :month-of-year y) (extract :month-of-year x))
+        total-month-diff   (hx/+ month-of-year-diff (hx/* year-diff 12))]
+    (hx/+ total-month-diff
+          ;; total-month-diff counts month boundaries not whole months, so we need to adjust
+          ;; if x<y but x>y in the month calendar then subtract one month
+          ;; if x>y but x<y in the month calendar then add one month
+          (hsql/call
+           :case
+           (hsql/call :and (hsql/call :< x y) (hsql/call :> (extract :day-of-month x) (extract :day-of-month y)))
+           -1
+           (hsql/call :and (hsql/call :> x y) (hsql/call :< (extract :day-of-month x) (extract :day-of-month y)))
+           1
+           :else 0))))
 
-      :week
-      (let [positive-diff
-            (fn [a b]
-              (hx/cast :integer (hx// (hsql/call :-
-                                                 (hsql/call :julianday (->date b))
-                                                 (hsql/call :julianday (->date a)))
-                                      7)))]
-        (hsql/call :case (hsql/call :<= x y) (positive-diff x y) :else (hx/* -1 (positive-diff y x))))
+(defmethod sql.qp/datetime-diff [:sqlite :week]
+  [driver _unit x y]
+  (hx// (sql.qp/datetime-diff driver :day x y) 7))
 
-      :day
-      (let [positive-diff
-            (fn [a b]
-              (hx/cast :integer (hsql/call :-
-                                           (hsql/call :julianday (->date b))
-                                           (hsql/call :julianday (->date a)))))]
-        (hsql/call :case (hsql/call :<= x y) (positive-diff x y) :else (hx/* -1 (positive-diff y x))))
+(defmethod sql.qp/datetime-diff [:sqlite :day]
+  [_driver _unit x y]
+  (hx/->integer
+   (hx/- (hsql/call :julianday y (hx/literal "start of day"))
+         (hsql/call :julianday x (hx/literal "start of day")))))
 
-      (:hour :minute :second)
-      (let [positive-diff
-            (fn [a b]
-              (-> (hsql/call :-
-                             (hsql/call :julianday b)
-                             (hsql/call :julianday a))
-                  (hx/* (case unit :hour 24 :minute 1440 :second 86400))
-                  hx/floor
-                  hx/->integer))]
-        (hsql/call :case (hsql/call :<= x y) (positive-diff x y) :else (hx/* -1 (positive-diff y x)))))))
+(defmethod sql.qp/datetime-diff [:sqlite :hour]
+  [driver _unit x y]
+  (hx// (sql.qp/datetime-diff driver :second x y) 3600))
+
+(defmethod sql.qp/datetime-diff [:sqlite :minute]
+  [driver _unit x y]
+  (hx// (sql.qp/datetime-diff driver :second x y) 60))
+
+(defmethod sql.qp/datetime-diff [:sqlite :second]
+  [_driver _unit x y]
+  ;; strftime strftime('%s', <timestring>) returns the unix time as an integer.
+  (hx/- (strftime "%s" y) (strftime "%s" x)))
 
 ;; SQLite's JDBC driver is fussy and won't let you change connections to read-only after you create them. So skip that
 ;; step. SQLite doesn't have a notion of session timezones so don't do that either. The only thing we're doing here from

--- a/modules/drivers/sqlite/src/metabase/driver/sqlite.clj
+++ b/modules/drivers/sqlite/src/metabase/driver/sqlite.clj
@@ -124,10 +124,6 @@
 
 ;; See also the [SQLite Date and Time Functions Reference](http://www.sqlite.org/lang_datefunc.html).
 
-(defmethod sql.qp/date [:sqlite :default]
-  [driver _ expr]
-  (sql.qp/->honeysql driver expr))
-
 (defmethod sql.qp/date [:sqlite :second]
   [driver _ expr]
   (->datetime (strftime "%Y-%m-%d %H:%M:%S" (sql.qp/->honeysql driver expr))))

--- a/modules/drivers/sqlite/src/metabase/driver/sqlite.clj
+++ b/modules/drivers/sqlite/src/metabase/driver/sqlite.clj
@@ -124,6 +124,8 @@
 
 ;; See also the [SQLite Date and Time Functions Reference](http://www.sqlite.org/lang_datefunc.html).
 
+(defmethod sql.qp/date [:sqlite :default] [_driver _unit expr] expr)
+
 (defmethod sql.qp/date [:sqlite :second]
   [driver _ expr]
   (->datetime (strftime "%Y-%m-%d %H:%M:%S" (sql.qp/->honeysql driver expr))))

--- a/test/metabase/query_processor_test/date_time_zone_functions_test.clj
+++ b/test/metabase/query_processor_test/date_time_zone_functions_test.clj
@@ -959,7 +959,8 @@
                       first))))))))
 
 (deftest datetime-diff-type-test
-  (mt/test-drivers (->> (disj (mt/normal-drivers-with-feature :datetime-diff) :snowflake)
+  ;; FIXME: time fields in sqlite aren't wrapped with a TypedHoneySQLForm, this test fails
+  (mt/test-drivers (->> (disj (mt/normal-drivers-with-feature :datetime-diff) :sqlite)
                         (filter mt/supports-time-type?))
     (testing "Cannot datetime-diff against time column"
       (mt/dataset test-data-with-time

--- a/test/metabase/query_processor_test/date_time_zone_functions_test.clj
+++ b/test/metabase/query_processor_test/date_time_zone_functions_test.clj
@@ -959,9 +959,7 @@
                       first))))))))
 
 (deftest datetime-diff-type-test
-  ;; FIXME: time fields in sqlite aren't wrapped with a TypedHoneySQLForm, this test fails
-  (mt/test-drivers (->> (disj (mt/normal-drivers-with-feature :datetime-diff) :sqlite)
-                        (filter mt/supports-time-type?))
+  (mt/test-drivers (filter mt/supports-time-type? (mt/normal-drivers-with-feature :datetime-diff))
     (testing "Cannot datetime-diff against time column"
       (mt/dataset test-data-with-time
         (is (thrown-with-msg?


### PR DESCRIPTION
Adds support for the datetime-diff function for SQLite.

Epic: https://github.com/metabase/metabase/issues/26999

Original datetime-diff PR: https://github.com/metabase/metabase/pull/25722

The tests are in the "Datetime diff tests" block here: https://github.com/metabase/metabase/blob/6e5cce4bc0e8bc177820182a8ea45fc1f44eee06/test/metabase/query_processor_test/date_time_zone_functions_test.clj#L701

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/27076)
<!-- Reviewable:end -->
