### PR TITLE
fix core input icons tooltips

### DIFF
--- a/frontend/src/metabase/core/components/Input/Input.tsx
+++ b/frontend/src/metabase/core/components/Input/Input.tsx
@@ -93,9 +93,10 @@ const Input = forwardRef(function Input(
       {leftIcon && (
         <Tooltip tooltip={leftIconTooltip} placement="left">
           <InputLeftButton
+            data-testid="input-left-icon-button"
             size={size}
             onClick={onLeftIconClick}
-            disabled={!leftIconTooltip || !onLeftIconClick}
+            disabled={!leftIconTooltip && !onLeftIconClick}
           >
             <Icon name={leftIcon} />
           </InputLeftButton>
@@ -104,9 +105,10 @@ const Input = forwardRef(function Input(
       {rightIcon && (
         <Tooltip tooltip={rightIconTooltip} placement="right">
           <InputRightButton
+            data-testid="input-right-icon-button"
             size={size}
             onClick={onRightIconClick}
-            disabled={!rightIconTooltip || !onRightIconClick}
+            disabled={!rightIconTooltip && !onRightIconClick}
           >
             <Icon name={rightIcon} />
           </InputRightButton>

--- a/frontend/src/metabase/core/components/Input/Input.unit.spec.tsx
+++ b/frontend/src/metabase/core/components/Input/Input.unit.spec.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import Input from "./Input";
+
+describe("Input", () => {
+  it("should render icon tooltips when hover them", () => {
+    const { getByTestId, getByText } = render(
+      <Input
+        leftIconTooltip="left tooltip"
+        rightIconTooltip="right tooltip"
+        leftIcon="search"
+        rightIcon="check"
+      />,
+    );
+
+    const leftIcon = getByTestId("input-left-icon-button");
+    userEvent.hover(leftIcon);
+    expect(getByText("left tooltip")).toBeInTheDocument();
+
+    const rightIcon = getByTestId("input-right-icon-button");
+    userEvent.hover(rightIcon);
+    expect(getByText("right tooltip")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/27083

## Changes

Fixes input icons do not show hover tooltips.

## How to verify

- As an admin go to settings -> databases -> add
- Select Postgres
- Ensure the info icon inside the "Display name" input shows a tooltip on hover