### PR TITLE
Remove the backend unit tests w/ Java 11 job from CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -562,18 +562,6 @@ workflows:
             - checkout
 
       - clojure:
-          matrix:
-            parameters:
-              edition: ["ee"]
-              java-version: ["java-11"]
-          name: be-tests-<< matrix.java-version >>-<< matrix.edition >>
-          requires:
-            - be-deps
-          e: << matrix.java-version >>
-          clojure-args: -X:dev:ci:test
-          skip-when-no-change: true
-
-      - clojure:
           name: be-linter-cloverage
           requires:
             - be-deps


### PR DESCRIPTION
Related to the work in #25781

We don't need it anymore since we have an equivalent job in GH Actions now