### PR TITLE
Fix flaky `input-chan-closed-unexpectedly-test`

### DIFF
--- a/test/metabase/async/api_response_test.clj
+++ b/test/metabase/async/api_response_test.clj
@@ -103,19 +103,18 @@
     (tu.async/with-chans [input-chan]
       (with-response [{:keys [os output-chan os-closed-chan]} input-chan]
         (a/close! input-chan)
-        (testing "output-channel should get closed"
-          ;; output-chan may or may not get the InterruptedException written to it -- it's a race condition -- we're just
-          ;; want to make sure it closes
-          (is (not= ::tu.async/timed-out (tu.async/wait-for-result output-chan)))
-          (testing "...as should the output stream"
-            (is (= true
-                   (wait-for-close os-closed-chan)))))
+        (testing "output stream should have gotten closed"
+          (is (= true
+                 (wait-for-close os-closed-chan))))
         (testing "An error should be written to the output stream"
           (is (schema= {:message (s/eq "Input channel unexpectedly closed.")
                         :_status (s/eq 500)
                         :trace   s/Any
                         s/Any    s/Any}
-                       (os->response os))))))))
+                       (os->response os))))
+        (testing "output-channel should be closed now as well"
+          (is (= nil
+                 (tu.async/wait-for-result output-chan))))))))
 
 
 ;;; ------------------------------ Output-chan closed early (i.e. API request canceled) ------------------------------

--- a/test/metabase/test/util/async.clj
+++ b/test/metabase/test/util/async.clj
@@ -50,7 +50,8 @@
         `(do ~@body))))
 
 (defn wait-for-result
-  "Wait up to `timeout-ms` (default 200) for a result from `chan`, or return a `::timed-out` message."
+  "Wait up to `timeout-ms` (default 200) for a result from `chan`, or return a `::timed-out` message. Closes the channel
+  when finished. Be careful when using this with non-promise channels, since it will consume the results!"
   ([chan]
    (wait-for-result chan 200))
   ([chan timeout-ms]


### PR DESCRIPTION
This test was supposed to test that when the input channel was closed, an error written to the output stream. The way this works is that when the input channel is closed, it writes an `Input channel unexpectedly closed` error to the output channel, and then asynchronously this is written to an OutputStream.

However we were using `(tu.async/wait-for-result output-chan)` here to make sure `output-chan` got closed, which caused a race condition where it would consume the `Input channel unexpectedly closed` error before the loop that wrote it to the output stream ever saw it, meaning no error message would be written to the output stream.

I was able to trigger this test failure pretty consistently. Not sure why it's never been a problem until now, since I don't think anything has changed here recently...

Either way the fix here was to move the `wait-for-result` check to the end of the test, and I cannot trigger it at all.

One a side note I'm trying to figure out why we even need a separate output channel at all here as opposed to writing to the output stream directly (or in an `a/thread`)... I might investigate this next. 