### PR TITLE
Open absolute urls not relatively to a metabase instance

### DIFF
--- a/frontend/src/metabase/lib/dom.js
+++ b/frontend/src/metabase/lib/dom.js
@@ -247,6 +247,8 @@ export function constrainToScreen(element, direction, padding) {
   return false;
 }
 
+const isAbsoluteUrl = url => url.startsWith("/");
+
 function getWithSiteUrl(url) {
   const siteUrl = MetabaseSettings.get("site-url");
   return url.startsWith("/") ? siteUrl + url : url;
@@ -302,12 +304,17 @@ export function open(
     ...options
   } = {},
 ) {
+  const isOriginalUrlAbsolute = isAbsoluteUrl(url);
   url = ignoreSiteUrl ? url : getWithSiteUrl(url);
 
   if (shouldOpenInBlankWindow(url, options)) {
     openInBlankWindow(url);
   } else if (isSameOrigin(url)) {
-    openInSameOrigin(url, getLocation(url));
+    if (isOriginalUrlAbsolute) {
+      clickLink(url, false);
+    } else {
+      openInSameOrigin(url, getLocation(url));
+    }
   } else {
     openInSameWindow(url);
   }


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/25953

## Changes

When a click behavior URL is absolute, open it bypassing the router to handle cases when Metabase is on a non-root path and a click behavior links to another URL segment on the same level as where Metabase at.

For instance, if Metabase is on `/metabase-app/` and there is another app on `/admin/`, the click behavior with `/admin` URL should open another app, but if the click behavior has URL `admin`, then it should open the admin panel.

## How to verify

Check the original issue repro steps.

@flamber do you think this fixes the original issue in the right way?