### PR TITLE
Add meta to kondo hook tokens

### DIFF
--- a/.clj-kondo/hooks/common.clj
+++ b/.clj-kondo/hooks/common.clj
@@ -2,6 +2,12 @@
   (:require [clj-kondo.hooks-api :as hooks]
             [clojure.pprint]))
 
+(defn with-macro-meta
+  "When introducing internal nodes (let, defn, etc) it is important to provide a meta of an existing token
+   as the current version of kondo will use the whole form by default."
+  [new-node hook-node]
+  (with-meta new-node (meta (first (:children hook-node)))))
+
 ;;; This stuff is to help debug hooks. Trace a function and it will pretty-print the before & after sexprs.
 ;;;
 ;;;    (hooks.common/trace #'calculate-bird-scarcity)

--- a/.clj-kondo/hooks/metabase/api/common.clj
+++ b/.clj-kondo/hooks/metabase/api/common.clj
@@ -1,7 +1,8 @@
 (ns hooks.metabase.api.common
   (:require
-   [clj-kondo.hooks-api :as api]
-   [clojure.string :as str]))
+   [clj-kondo.hooks-api :as hooks]
+   [clojure.string :as str]
+   [hooks.common :as common]))
 
 (defn route-fn-name
   [method route]
@@ -13,11 +14,13 @@
 (defn defendpoint [{:keys [node]}]
   (let [[method route & body] (rest (:children node))]
     {:node
-     (api/list-node [(api/token-node 'do)
-                     ;; register usage of compojure core var
-                     (api/token-node (symbol (str "compojure.core")
-                                             (str method)))
-                     ;; define function with route-fn-name
-                     (api/list-node (list* (api/token-node 'clojure.core/defn)
-                                           (route-fn-name (api/sexpr method) (api/sexpr route))
-                                           body))])}))
+     (hooks/vector-node [;; register usage of compojure core var
+                         (common/with-macro-meta (hooks/token-node (symbol (str "compojure.core")
+                                                                           (str method)))
+                           node)
+                         ;; define function with route-fn-name
+                         (hooks/list-node
+                           (list* (common/with-macro-meta (hooks/token-node 'clojure.core/defn)
+                                    node)
+                                  (route-fn-name (hooks/sexpr method) (hooks/sexpr route))
+                                  body))])}))

--- a/.clj-kondo/hooks/metabase/models/setting.clj
+++ b/.clj-kondo/hooks/metabase/models/setting.clj
@@ -1,5 +1,6 @@
 (ns hooks.metabase.models.setting
-  (:require [clj-kondo.hooks-api :as hooks]))
+  (:require [clj-kondo.hooks-api :as hooks]
+            [hooks.common :as common]))
 
 (defn defsetting
   "Rewrite a [[metabase.models.defsetting]] form like
@@ -38,7 +39,7 @@
     {:node (-> (list
                 (hooks/token-node 'let)
                 ;; include description and the options map so they can get validated as well.
-                (hooks/vector-node (vec (interleave (repeat (hooks/token-node '_))
+                (hooks/vector-node (vec (interleave (repeat (common/with-macro-meta (hooks/token-node '_) node))
                                                     args)))
                 getter-node
                 setter-node)


### PR DESCRIPTION
Kondo made a recent change to try deriving positional information for introduced tokens, unfortunately it is rarely accurate and can make working with our macros difficult in lsp.

There's no hard and fast rule here, but in general, new internal tokens (like `_` used on the left side of a `let`) need to be given an existing token's meta. The easiest way to see if a macro is well annotated is to use clojure-lsp, and see if `hover` is properly giving information about each symbol inside the macro. Alternatively you can `clj-kondo --lint src/test.clj --config '{:output {:format :edn}, :analysis true}'` to look at the symbols emitted by your hook and ensure that the `name-row` and `name-row-end` keys are sane. 