### PR TITLE
Update normal-drivers-with-feature to use driver test db

### DIFF
--- a/test/metabase/query_processor_test.clj
+++ b/test/metabase/query_processor_test.clj
@@ -45,7 +45,8 @@
   (let [features (set (cons feature more-features))]
     (set (for [driver (normal-drivers)
                :let   [driver (tx/the-driver-with-test-extensions driver)]
-               :when  (set/subset? features (driver.u/features driver (data/db)))]
+               :when  (driver/with-driver driver
+                        (set/subset? features (driver.u/features driver (data/db))))]
            driver))))
 
 (alter-meta! #'normal-drivers-with-feature assoc :arglists (list (into ['&] (sort driver/driver-features))))

--- a/test/metabase/query_processor_test.clj
+++ b/test/metabase/query_processor_test.clj
@@ -8,7 +8,6 @@
             [medley.core :as m]
             [metabase.db.connection :as mdb.connection]
             [metabase.driver :as driver]
-            [metabase.driver.util :as driver.u]
             [metabase.models.field :refer [Field]]
             [metabase.models.table :refer [Table]]
             [metabase.query-processor :as qp]

--- a/test/metabase/query_processor_test.clj
+++ b/test/metabase/query_processor_test.clj
@@ -46,7 +46,8 @@
     (set (for [driver (normal-drivers)
                :let   [driver (tx/the-driver-with-test-extensions driver)]
                :when  (driver/with-driver driver
-                        (set/subset? features (driver.u/features driver (data/db))))]
+                        (let [db (data/db)]
+                          (every? #(driver/database-supports? driver % db) features)))]
            driver))))
 
 (alter-meta! #'normal-drivers-with-feature assoc :arglists (list (into ['&] (sort driver/driver-features))))

--- a/test/metabase/query_processor_test/date_time_zone_functions_test.clj
+++ b/test/metabase/query_processor_test/date_time_zone_functions_test.clj
@@ -470,7 +470,8 @@
             (is (true? (close-hour? hour (.getHour now))))))))))
 
 (deftest datetime-math-with-extract-test
-  (mt/test-drivers (mt/normal-drivers-with-feature :date-arithmetics)
+  ;; FIXME: mongo doesn't supports parsing strings as dates so we exclude it from this test temporarily (#27111)
+  (mt/test-drivers (disj (mt/normal-drivers-with-feature :date-arithmetics) :mongo)
     (mt/dataset times-mixed
       (doseq [{:keys [title expected query]}
               [{:title    "Nested date math then extract"


### PR DESCRIPTION
This PR updates `normal-features-with-driver` so that the driver's test db is used to test whether a driver supports a feature or not.

Previously we were using the current test db to see whether a feature was supported or not in `normal-features-with-driver`

This meant that, for example, `(mt/normal-drivers-with-feature :date-arithmetics)` would always exclude Mongo, if the current test db wasn't Mongo, since database-supports? is defined like this for mongo and `:date-arithmetics`:

```
(defmethod driver/database-supports? [:mongo :date-arithmetics] [_ _ db]
  (let [version (db-major-version db)]
    (and (some? version) (>= version 5))))
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/27112)
<!-- Reviewable:end -->
