### PR TITLE
Fix Data Apps Crash on Pages With Hidden Filters

### DIFF
--- a/frontend/src/metabase/dashboard/components/Dashboard/stickyParameters.js
+++ b/frontend/src/metabase/dashboard/components/Dashboard/stickyParameters.js
@@ -3,6 +3,9 @@ import { isSmallScreen, getMainElement } from "metabase/lib/dom";
 export const MAXIMUM_PARAMETERS_FOR_STICKINESS = 6;
 
 export const updateParametersWidgetStickiness = dashboard => {
+  if (!dashboard.parametersWidgetRef) {
+    return;
+  }
   initializeWidgetOffsetTop(dashboard);
 
   const shouldBeSticky = checkIfParametersWidgetShouldBeSticky(dashboard);


### PR DESCRIPTION
## Description

Clicking around too fast in data apps would cause the dashboard to crash.

![stickyCrash](https://user-images.githubusercontent.com/30528226/206771364-52fa8f0e-89fa-404b-a567-a2a65abfb5f2.gif)

The console produced these errors:

![Screen Shot 2022-12-09 at 11 43 28 AM](https://user-images.githubusercontent.com/30528226/206771446-1a5e55fa-fa45-499d-9f31-6fbdf94b411b.png)
![Screen Shot 2022-12-09 at 11 40 40 AM](https://user-images.githubusercontent.com/30528226/206771448-3a81c53d-9e9d-4621-a57b-7804c777fbdc.png)

## Solution 

It seems that if you move too fast, we don't pass the expected ref. This simply adds a check for the ref to the stickyParameters components so we don't hit any errors as a result. It's possible that this may be related to the fact that we have some hidden parameters filters in data apps.