### PR TITLE
Fix custom columns lose their definition in embeddings

### DIFF
--- a/frontend/src/metabase-lib/parameters/utils/parameter-type.ts
+++ b/frontend/src/metabase-lib/parameters/utils/parameter-type.ts
@@ -22,6 +22,11 @@ function splitType(parameterOrType: Parameter | string) {
   return parameterType.split("/");
 }
 
+export function isIdParameter(parameter: Parameter | string) {
+  const type = getParameterType(parameter);
+  return type === "id";
+}
+
 export function isDateParameter(parameter: Parameter | string) {
   const type = getParameterType(parameter);
   return type === "date";

--- a/frontend/src/metabase/components/FieldValuesWidget.jsx
+++ b/frontend/src/metabase/components/FieldValuesWidget.jsx
@@ -694,12 +694,6 @@ export function getValuesMode(
   return "none";
 }
 
-/**
- *
- * @param {import("metabase-types/types/Field").Field} field
- * @param {import("metabase-types/types/Parameter").Parameter} parameter
- * @returns {boolean}
- */
 function isNumeric(field, parameter) {
   if (parameter) {
     return isNumberParameter(parameter);

--- a/frontend/src/metabase/components/FieldValuesWidget.jsx
+++ b/frontend/src/metabase/components/FieldValuesWidget.jsx
@@ -23,6 +23,11 @@ import { stripId } from "metabase/lib/formatting";
 import { fetchDashboardParameterValues } from "metabase/dashboard/actions";
 
 import Fields from "metabase/entities/fields";
+import {
+  isIdParameter,
+  isNumberParameter,
+  isStringParameter,
+} from "metabase-lib/parameters/utils/parameter-type";
 
 const MAX_SEARCH_RESULTS = 100;
 
@@ -291,6 +296,7 @@ class FieldValuesWidgetInner extends Component {
 
     const tokenFieldPlaceholder = getTokenFieldPlaceholder({
       fields,
+      parameter,
       disableSearch,
       placeholder,
       disablePKRemappingForSearch,
@@ -306,6 +312,12 @@ class FieldValuesWidgetInner extends Component {
       !forceTokenField;
     const isLoading = loadingState === "LOADING";
     const hasListValues = hasList({ fields, disableSearch, options });
+
+    const parseFreeformValue = value => {
+      return isNumeric(fields[0], parameter)
+        ? parseNumberValue(value)
+        : parseStringValue(value);
+    };
 
     return (
       <div
@@ -368,11 +380,7 @@ class FieldValuesWidgetInner extends Component {
               );
             }}
             onInputChange={this.onInputChange}
-            parseFreeformValue={value => {
-              return fields[0].isNumeric()
-                ? parseNumberValue(value)
-                : parseStringValue(value);
-            }}
+            parseFreeformValue={parseFreeformValue}
           />
         )}
       </div>
@@ -446,17 +454,30 @@ function shouldList(fields, disableSearch) {
   );
 }
 
-function getNonSearchableTokenFieldPlaceholder(firstField) {
-  if (firstField.isID()) {
-    return t`Enter an ID`;
-  } else if (firstField.isString()) {
-    return t`Enter some text`;
-  } else if (firstField.isNumeric()) {
-    return t`Enter a number`;
-  }
+function getNonSearchableTokenFieldPlaceholder(firstField, parameter) {
+  if (parameter) {
+    if (isIdParameter(parameter)) {
+      return t`Enter an ID`;
+    } else if (isStringParameter(parameter)) {
+      return t`Enter some text`;
+    } else if (isNumberParameter(parameter)) {
+      return t`Enter a number`;
+    }
 
-  // fallback
-  return t`Enter some text`;
+    // fallback
+    return t`Enter some text`;
+  } else {
+    if (firstField.isID()) {
+      return t`Enter an ID`;
+    } else if (firstField.isString()) {
+      return t`Enter some text`;
+    } else if (firstField.isNumeric()) {
+      return t`Enter a number`;
+    }
+
+    // fallback
+    return t`Enter some text`;
+  }
 }
 
 export function searchField(field, disablePKRemappingForSearch) {
@@ -544,6 +565,7 @@ export function isSearchable({
 
 function getTokenFieldPlaceholder({
   fields,
+  parameter,
   disableSearch,
   placeholder,
   disablePKRemappingForSearch,
@@ -578,7 +600,7 @@ function getTokenFieldPlaceholder({
       disablePKRemappingForSearch,
     );
   } else {
-    return getNonSearchableTokenFieldPlaceholder(firstField);
+    return getNonSearchableTokenFieldPlaceholder(firstField, parameter);
   }
 }
 
@@ -670,4 +692,18 @@ export function getValuesMode(
   }
 
   return "none";
+}
+
+/**
+ *
+ * @param {import("metabase-types/types/Field").Field} field
+ * @param {import("metabase-types/types/Parameter").Parameter} parameter
+ * @returns {boolean}
+ */
+function isNumeric(field, parameter) {
+  if (parameter) {
+    return isNumberParameter(parameter);
+  }
+
+  return field.isNumeric();
 }

--- a/frontend/test/metabase/scenarios/filters/view.cy.spec.js
+++ b/frontend/test/metabase/scenarios/filters/view.cy.spec.js
@@ -37,7 +37,7 @@ describe("scenarios > question > view", () => {
               "display-name": "CATEGORY",
               type: "dimension",
               dimension: ["field", PRODUCTS.CATEGORY, null],
-              "widget-type": "id",
+              "widget-type": "string/=",
             },
             vendor: {
               id: "6b8b10ef-0104-1047-1e5v-2492d5964545",
@@ -45,7 +45,7 @@ describe("scenarios > question > view", () => {
               "display-name": "VENDOR",
               type: "dimension",
               dimension: ["field", PRODUCTS.VENDOR, null],
-              "widget-type": "id",
+              "widget-type": "string/=",
             },
           },
         },

--- a/frontend/test/metabase/scenarios/sharing/public.cy.spec.js
+++ b/frontend/test/metabase/scenarios/sharing/public.cy.spec.js
@@ -9,7 +9,7 @@ import {
 
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
-const { PRODUCTS } = SAMPLE_DATABASE;
+const { PRODUCTS, PEOPLE, PEOPLE_ID } = SAMPLE_DATABASE;
 
 const COUNT_ALL = "200";
 const COUNT_DOOHICKEY = "42";
@@ -201,4 +201,106 @@ describe("scenarios > public", () => {
       }),
     );
   });
+
+  describe("public dashboard with parameters linked to a custom field (metabase#25473)", () => {
+    it("should show text parameter in public dashboards", () => {
+      // Setup
+      const customField = {
+        name: "email_name",
+        definition: [
+          "concat",
+          ["field", PEOPLE.EMAIL, null],
+          ["field", PEOPLE.NAME, null],
+        ],
+      };
+      const questionDetails = {
+        name: "Question",
+        query: {
+          "source-table": PEOPLE_ID,
+          expressions: {
+            [customField.name]: customField.definition,
+          },
+        },
+      };
+      const textContainsFilter = {
+        id: "890abcde",
+        name: "Text contains",
+        slug: "text_contains",
+        type: "string/contains",
+      };
+      const dashboardDetails = {
+        parameters: [textContainsFilter],
+      };
+
+      cy.createQuestionAndDashboard({
+        questionDetails,
+        dashboardDetails,
+      }).then(({ body: { id, card_id, dashboard_id } }) => {
+        cy.wrap(dashboard_id).as("dashboardId");
+
+        mapParameters({
+          id,
+          card_id,
+          dashboard_id,
+          parameter: textContainsFilter,
+          customFieldName: customField.name,
+        });
+      });
+
+      cy.get("@dashboardId").then(dashboardId => {
+        visitDashboard(dashboardId);
+      });
+
+      // Enable public sharing
+      cy.icon("share").click();
+
+      cy.contains("Enable sharing")
+        .parent()
+        .find("input[type=checkbox]")
+        .check();
+
+      cy.contains("Public link")
+        .parent()
+        .find("input")
+        .then($input => {
+          const dashboardPublicLink = $input[0].value;
+          cy.visit(dashboardPublicLink);
+        });
+
+      // Public dashboard
+      cy.findByText(textContainsFilter.name).click();
+
+      cy.findByPlaceholderText("Enter some text").should("be.visible");
+    });
+  });
 });
+
+function mapParameters({
+  id,
+  card_id,
+  dashboard_id,
+  parameter,
+  customFieldName,
+} = {}) {
+  return cy.request("PUT", `/api/dashboard/${dashboard_id}/cards`, {
+    cards: [
+      {
+        id,
+        card_id,
+        row: 0,
+        col: 0,
+        size_x: 18,
+        size_y: 6,
+        series: [],
+        visualization_settings: {},
+        parameter_mappings: [
+          {
+            card_id,
+            parameter_id: parameter.id,
+            target: ["dimension", ["expression", customFieldName]],
+          },
+        ],
+      },
+    ],
+  });
+}

--- a/frontend/test/metabase/scenarios/sharing/public.cy.spec.js
+++ b/frontend/test/metabase/scenarios/sharing/public.cy.spec.js
@@ -207,6 +207,7 @@ describe("scenarios > public", () => {
       // Setup
       const customField = {
         name: "email_name",
+        // Custom field is `concat([Email], [Name])`
         definition: [
           "concat",
           ["field", PEOPLE.EMAIL, null],
@@ -254,7 +255,7 @@ describe("scenarios > public", () => {
       // Enable public sharing
       cy.icon("share").click();
 
-      cy.contains("Enable sharing")
+      cy.findByText("Enable sharing")
         .parent()
         .find("input[type=checkbox]")
         .check();
@@ -267,10 +268,19 @@ describe("scenarios > public", () => {
           cy.visit(dashboardPublicLink);
         });
 
-      // Public dashboard
-      cy.findByText(textContainsFilter.name).click();
+      // Assert public dashboard
+      setFilter(textContainsFilter, "khalid-pouros@yahoo.com");
+      cy.findAllByText("khalid-pouros@yahoo.com").should("have.length", 2); // 1 for the filter and 1 for the result in the card
 
-      cy.findByPlaceholderText("Enter some text").should("be.visible");
+      clearFilter();
+      setFilter(textContainsFilter, "Edgardo Hackett");
+      cy.findAllByText("Edgardo Hackett").should("have.length", 2); // 1 for the filter and 1 for the result in the card
+
+      // search by the full value of the custom field which is email + name
+      clearFilter();
+      setFilter(textContainsFilter, "walsh-desiree@gmail.comDesiree Walsh");
+      cy.findByText("walsh-desiree@gmail.com").should("be.visible");
+      cy.findByText("Desiree Walsh").should("be.visible");
     });
   });
 });
@@ -303,4 +313,18 @@ function mapParameters({
       },
     ],
   });
+}
+
+function clearFilter() {
+  cy.icon("close").click();
+}
+
+function setFilter(filter, value) {
+  cy.findByText(filter.name).click();
+
+  cy.findByPlaceholderText("Enter some text").should("be.visible").type(value);
+
+  cy.findByRole("button", {
+    name: "Add filter",
+  }).click();
 }


### PR DESCRIPTION
Fixes: #25473
[Notion summary](https://www.notion.so/metabase/Question-about-custom-field-definition-in-parameters-on-public-dashboards-641c1603918548a2a1bc18fd430fd901)

## PR Summary
In `<FieldValuesWidget />`, there could be the `parameter` prop passed to it which indicates the widget is connected to a dashboard filter.

In such case, if we need to perform any logic to determine the widget type e.g. showing the placeholder as `Enter a number` we should use `parameter`'s type instead of field types.

## Todos
- [x] Add tests
- [x] Troubleshoot `ExpressionDimension.parseMBQL`
- [x] Draft questions about new public table metadata endpoint

<details>
<summary><h2>Old details</h2></summary>

## Problems
When populating parameters we use this selector:
https://github.com/metabase/metabase/blob/00ce5700e31a98124b034e0586456e9ce261505c/frontend/src/metabase/dashboard/selectors.js#L171-L179

Which down the line, uses the `Field` selector:
https://github.com/metabase/metabase/blob/00ce5700e31a98124b034e0586456e9ce261505c/frontend/src/metabase/selectors/metadata.js#L32

The problem is that we don't populate `state.entities.fields` in embedding.

In the app we call `/api/table/:tableId/query_metadata` here:
https://github.com/metabase/metabase/blob/00ce5700e31a98124b034e0586456e9ce261505c/frontend/src/metabase/entities/tables.js#L95-L98
which will populate `state.entities.fields` as expected, but in embedding we only call either `/api/public/dashboard/:uuid/dashcard/:dashcardId/card/:cardId` or `/api/embed/dashboard/:token/dashcard/:dashcardId/card/:cardId`:
https://github.com/metabase/metabase/blob/00ce5700e31a98124b034e0586456e9ce261505c/frontend/src/metabase/dashboard/actions/data-fetching.js#L378
which only populate `dashboard.dashcards.[cardId]`

I think of a couple solutions
1. Modify the selector so that it pulls fields from `dashboard.dashcards.[cardId]`
2. Kind of what this PR does, is to implement the reducer to populate `state.entities.fields`, but I found some problems which are laid out in the comments.
</details>
