### PR TITLE
Remove `compareVersions`

### DIFF
--- a/frontend/src/metabase/lib/utils.js
+++ b/frontend/src/metabase/lib/utils.js
@@ -134,48 +134,6 @@ const MetabaseUtils = {
     // FIXME: ugghhhhhhhhh
     return JSON.parse(JSON.stringify(a));
   },
-
-  // this should correctly compare all version formats Metabase uses, e.x.
-  // 0.0.9, 0.0.10-snapshot, 0.0.10-alpha1, 0.0.10-rc1, 0.0.10-rc2, 0.0.10-rc10
-  // 0.0.10, 0.1.0, 0.2.0, 0.10.0, 1.1.0
-  compareVersions(aVersion, bVersion) {
-    if (!aVersion || !bVersion) {
-      return null;
-    }
-
-    const SPECIAL_COMPONENTS = {
-      snapshot: -4,
-      alpha: -3,
-      beta: -2,
-      rc: -1,
-    };
-
-    const getComponents = x =>
-      // v1.2.3-BETA1
-      x
-        .toLowerCase()
-        // v1.2.3-beta1
-        .replace(/^v/, "")
-        // 1.2.3-beta1
-        .split(/[.-]*([0-9]+)[.-]*/)
-        .filter(c => c)
-        // ["1", "2", "3", "beta", "1"]
-        .map(c => SPECIAL_COMPONENTS[c] || parseInt(c, 10));
-    // [1, 2, 3, -2, 1]
-
-    const aComponents = getComponents(aVersion);
-    const bComponents = getComponents(bVersion);
-    for (let i = 0; i < Math.max(aComponents.length, bComponents.length); i++) {
-      const a = aComponents[i];
-      const b = bComponents[i];
-      if (b == null || a < b) {
-        return -1;
-      } else if (a == null || b < a) {
-        return 1;
-      }
-    }
-    return 0;
-  },
 };
 
 export default MetabaseUtils;

--- a/frontend/test/metabase/lib/utils.unit.spec.js
+++ b/frontend/test/metabase/lib/utils.unit.spec.js
@@ -1,28 +1,6 @@
 import MetabaseUtils from "metabase/lib/utils";
 
 describe("utils", () => {
-  describe("compareVersions", () => {
-    it("should compare versions correctly", () => {
-      const expected = [
-        "0.0.9",
-        "0.0.10-snapshot",
-        "0.0.10-alpha1",
-        "0.0.10-rc1",
-        "0.0.10-rc2",
-        "0.0.10-rc10",
-        "0.0.10",
-        "0.1.0",
-        "0.2.0",
-        "0.10.0",
-        "1.1.0",
-      ];
-      const shuffled = expected.slice();
-      shuffle(shuffled);
-      shuffled.sort(MetabaseUtils.compareVersions);
-      expect(shuffled).toEqual(expected);
-    });
-  });
-
   describe("isEmpty", () => {
     it("should not allow all-blank strings", () => {
       expect(MetabaseUtils.isEmpty(" ")).toEqual(true);
@@ -39,10 +17,3 @@ describe("utils", () => {
     });
   });
 });
-
-function shuffle(a) {
-  for (let i = a.length; i; i--) {
-    const j = Math.floor(Math.random() * i);
-    [a[i - 1], a[j]] = [a[j], a[i - 1]];
-  }
-}


### PR DESCRIPTION
It's not being used anywhere in the FE codebase outside of its own tests.