### PR TITLE
Remove `sql.qp` stuff deprecated in 41 and 42

### DIFF
--- a/src/metabase/driver/sql/query_processor.clj
+++ b/src/metabase/driver/sql/query_processor.clj
@@ -11,7 +11,6 @@
    [metabase.driver.common :as driver.common]
    [metabase.mbql.schema :as mbql.s]
    [metabase.mbql.util :as mbql.u]
-   [metabase.models.field :as field]
    [metabase.models.table :refer [Table]]
    [metabase.query-processor.error-type :as qp.error-type]
    [metabase.query-processor.middleware.annotate :as annotate]
@@ -27,7 +26,6 @@
    [pretty.core :refer [PrettyPrintable]]
    [schema.core :as s])
   (:import
-   (metabase.models.field FieldInstance)
    (metabase.util.honeysql_extensions Identifier TypedHoneySQLForm)))
 
 (def source-query-alias

--- a/src/metabase/driver/sql/query_processor.clj
+++ b/src/metabase/driver/sql/query_processor.clj
@@ -1,32 +1,34 @@
 (ns metabase.driver.sql.query-processor
   "The Query Processor is responsible for translating the Metabase Query Language into HoneySQL SQL forms."
-  (:require [clojure.core.match :refer [match]]
-            [clojure.string :as str]
-            [clojure.tools.logging :as log]
-            [honeysql.core :as hsql]
-            [honeysql.format :as hformat]
-            [honeysql.helpers :as hh]
-            [metabase.driver :as driver]
-            [metabase.driver.common :as driver.common]
-            [metabase.driver.sql.query-processor.deprecated :as deprecated]
-            [metabase.mbql.schema :as mbql.s]
-            [metabase.mbql.util :as mbql.u]
-            [metabase.models.field :as field :refer [Field]]
-            [metabase.models.table :refer [Table]]
-            [metabase.query-processor.error-type :as qp.error-type]
-            [metabase.query-processor.middleware.annotate :as annotate]
-            [metabase.query-processor.middleware.wrap-value-literals :as qp.wrap-value-literals]
-            [metabase.query-processor.store :as qp.store]
-            [metabase.query-processor.util.add-alias-info :as add]
-            [metabase.query-processor.util.nest-query :as nest-query]
-            [metabase.util :as u]
-            [metabase.util.honeysql-extensions :as hx]
-            [metabase.util.i18n :refer [deferred-tru tru]]
-            [potemkin :as p]
-            [pretty.core :refer [PrettyPrintable]]
-            [schema.core :as s])
-  (:import metabase.models.field.FieldInstance
-           [metabase.util.honeysql_extensions Identifier TypedHoneySQLForm]))
+  (:require
+   [clojure.core.match :refer [match]]
+   [clojure.string :as str]
+   [clojure.tools.logging :as log]
+   [honeysql.core :as hsql]
+   [honeysql.format :as hformat]
+   [honeysql.helpers :as hh]
+   [metabase.driver :as driver]
+   [metabase.driver.common :as driver.common]
+   [metabase.mbql.schema :as mbql.s]
+   [metabase.mbql.util :as mbql.u]
+   [metabase.models.field :as field]
+   [metabase.models.table :refer [Table]]
+   [metabase.query-processor.error-type :as qp.error-type]
+   [metabase.query-processor.middleware.annotate :as annotate]
+   [metabase.query-processor.middleware.wrap-value-literals
+    :as qp.wrap-value-literals]
+   [metabase.query-processor.store :as qp.store]
+   [metabase.query-processor.util.add-alias-info :as add]
+   [metabase.query-processor.util.nest-query :as nest-query]
+   [metabase.util :as u]
+   [metabase.util.honeysql-extensions :as hx]
+   [metabase.util.i18n :refer [deferred-tru tru]]
+   [potemkin :as p]
+   [pretty.core :refer [PrettyPrintable]]
+   [schema.core :as s])
+  (:import
+   (metabase.models.field FieldInstance)
+   (metabase.util.honeysql_extensions Identifier TypedHoneySQLForm)))
 
 (def source-query-alias
   "Alias to use for source queries, e.g.:
@@ -1088,28 +1090,3 @@
   (let [honeysql-form (mbql->honeysql driver outer-query)
         [sql & args]  (format-honeysql driver honeysql-form)]
     {:query sql, :params args}))
-
-
-
-;;; DEPRECATED STUFF
-
-(p/import-vars
- [deprecated
-  *field-options*
-  *source-query*
-  *table-alias*
-  escape-alias
-  field->alias
-  field->identifier
-  prefix-field-alias])
-
-;; deprecated, but we'll keep it here for now for backwards compatibility.
-(defmethod ->honeysql [:sql Field]
-  [driver field]
-  (deprecated/log-deprecation-warning driver "->honeysql [:sql (class Field)]" "0.42.0")
-  (->honeysql driver [:field (:id field) nil]))
-
-(defmethod field->identifier :sql
-  [driver field]
-  (deprecated/log-deprecation-warning driver `field->identifier "v0.42.0")
-  (->honeysql driver field))

--- a/src/metabase/driver/sql/query_processor.clj
+++ b/src/metabase/driver/sql/query_processor.clj
@@ -11,6 +11,7 @@
    [metabase.driver.common :as driver.common]
    [metabase.mbql.schema :as mbql.s]
    [metabase.mbql.util :as mbql.u]
+   [metabase.models.field]
    [metabase.models.table :refer [Table]]
    [metabase.query-processor.error-type :as qp.error-type]
    [metabase.query-processor.middleware.annotate :as annotate]
@@ -26,7 +27,10 @@
    [pretty.core :refer [PrettyPrintable]]
    [schema.core :as s])
   (:import
+   (metabase.models.field FieldInstance)
    (metabase.util.honeysql_extensions Identifier TypedHoneySQLForm)))
+
+(comment metabase.models.field/keep-me) ; for FieldInstance
 
 (def source-query-alias
   "Alias to use for source queries, e.g.:

--- a/src/metabase/driver/sql/query_processor/deprecated.clj
+++ b/src/metabase/driver/sql/query_processor/deprecated.clj
@@ -5,12 +5,14 @@
 
   Deprecated method impls should call [[log-deprecation-warning]] to gently nudge driver authors to stop using this
   method."
-  (:require [clojure.tools.logging :as log]
-            [metabase.driver :as driver]
-            [metabase.query-processor.store :as qp.store]
-            [metabase.query-processor.util.add-alias-info :as add]
-            [metabase.util :as u]
-            [metabase.util.i18n :refer [trs]]))
+  (:require
+   [clojure.tools.logging :as log]
+   [metabase.query-processor.store :as qp.store]
+   [metabase.util :as u]
+   [metabase.util.i18n :refer [trs]]))
+
+;;; This is unused at this moment in time but we can leave it around in case we want to use it again in the
+;;; future (likely). See the code at `v0.45.0` for example where we were using this a lot
 
 ;; TODO -- this is actually pretty handy and I think we ought to use it for all the deprecated driver methods.
 (defn log-deprecation-warning
@@ -21,8 +23,8 @@
   (letfn [(thunk []
             (log/warn
              (u/colorize 'red
-               (trs "Warning: Driver {0} is using {1}. This method was deprecated in {2} and will be removed in a future release."
-                    driver method-name deprecated-version))))]
+                         (trs "Warning: Driver {0} is using {1}. This method was deprecated in {2} and will be removed in a future release."
+                              driver method-name deprecated-version))))]
     ;; only log each individual message once for the current QP store; by 'caching' the value with the key it is
     ;; effectively memoized for the rest of the QP run for the current query. The goal here is to avoid blasting the
     ;; logs with warnings about deprecated method calls, but still remind people regularly enough that it gets fixed
@@ -31,100 +33,3 @@
       (qp.store/cached [driver method-name deprecated-version]
         (thunk))
       (thunk))))
-
-;;; DEPRECATED in 41
-
-(defmulti ^String field->alias
-  "Returns an escaped alias for a Field instance `field`.
-
-  DEPRECATED as of x.41. This method is no longer used by the SQL QP itself, but is still available for existing code
-  already using it. This multimethod will be removed in a future release.
-
-  Drivers that need to access this information can look at the
-  `:metabase.query-processor.util.add-alias-info/desired-alias` information in the
-  `:field`/`:expression`/`:aggregation` options map. See [[metabase.query-processor.util.add-alias]] for more
-  information.
-
-  Drivers that need to customize the aliases used can override the [[metabase.driver/escape-alias]] multimethod, or
-  change the values of `:metabase.query-processor.util.add-alias-info/desired-alias` or
-  `:metabase.query-processor.util.add-alias-info/source-alias` in the appropriate [[->honeysql]] methods."
-  {:arglists '([driver field]), :deprecated "0.41.0"}
-  driver/dispatch-on-initialized-driver
-  :hierarchy #'driver/hierarchy)
-
-(defmethod field->alias :sql
-  [driver [_ _ {::add/keys [desired-alias]} :as field]]
-  (log-deprecation-warning driver 'metabase.driver.sql.query-processor/field->alias "v0.41.0")
-  (or desired-alias
-      (driver/escape-alias driver (:name field))))
-
-
-;;; DEPRECATED IN 42
-
-(def ^:dynamic ^{:deprecated "0.42.0"} *field-options*
-  "DEPRECATED (unused) in 0.42.0. Binding this var has no effect.
-
-  If you need to track `:field` options for one reason or another, you can create and bind your own dynamic variable
-  for doing so. See [[metabase.driver.sqlserver]] for an example.
-
-  This var will be removed in a future release."
-  nil)
-
-(def ^:dynamic ^{:deprecated "0.42.0"} *table-alias*
-  "The alias, if any, that should be used to qualify Fields when building the HoneySQL form, instead of defaulting to
-  schema + Table name. Used to implement things like joined `:field`s.
-
-  DEPRECATED (unused) in 0.42.0+. Instead of using this, use or override `::add/source-table` in the
-  `:field`/`:expression`/`:aggregation` options."
-  nil)
-
-(def ^:dynamic ^{:deprecated "0.42.0"} *source-query*
-  "The source-query in effect.  Used when the query processor might need to distinguish between the type of the source
-  query (ex: to provide different behavior depending on whether the source query is from a table versus a subquery).
-
-  DEPRECATED -- use [[metabase.driver.sql.query-processor/*inner-query*]] instead, which does the same thing but it
-  always bound even if we are not in a source query."
-  nil)
-
-(defmulti field->identifier
-  "DEPRECATED: Unused in 0.42.0+; this functionality is now handled
-  by [[metabase.driver.sql.query-processor/->honeysql]]. Implementing this method has no effect. This method will be
-  removed in a future release."
-  {:arglists '([driver field]), :deprecated "0.42.0"}
-  driver/dispatch-on-initialized-driver
-  :hierarchy #'driver/hierarchy)
-
-(defmulti escape-alias
-  "DEPRECATED -- this has been moved to [[metabase.driver/escape-alias]]."
-  {:added "0.41.0", :deprecated "0.42.0", :arglists '([driver column-alias-name])}
-  driver/dispatch-on-initialized-driver
-  :hierarchy #'driver/hierarchy)
-
-(defmethod escape-alias :sql
-  [driver column-alias-name]
-  ((get-method driver/escape-alias ::driver/driver) driver column-alias-name))
-
-;; this method impl is only here to add a little bit of magic so we use the deprecated [[escape-alias]] method above, if
-;; an impl for it exists. This method impl can be removed entirely when we get rid of [[escape-alias]].
-(defmethod driver/escape-alias :sql
-  [driver column-alias-name]
-  (when-not (= (get-method escape-alias driver)
-               (get-method escape-alias :sql))
-    (log-deprecation-warning driver 'metabase.driver.sql.query-processor/escape-alias "0.42.0"))
-  (escape-alias driver column-alias-name))
-
-(defmulti prefix-field-alias
-  "DEPRECATED and no longer used in 0.42.0. Previously, this method was used to tell the SQL QP how to combine to
-  strings in order to generate aliases for columns coming from joins. Its primary use was to escape the resulting
-  identifier if needed.
-
-  In Metabase 0.42.0+ you can implement [[metabase.driver/escape-alias]] instead, which is now called when such an
-  alias is generated."
-  {:arglists '([driver prefix column-alias]), :added "0.38.1", :deprecated "0.42.0"}
-  driver/dispatch-on-initialized-driver
-  :hierarchy #'driver/hierarchy)
-
-(defmethod prefix-field-alias :sql
-  [driver prefix column-alias]
-  (log-deprecation-warning driver 'metabase.driver.sql.query-processor/prefix-field-alias "0.42.0")
-  (add/prefix-field-alias prefix column-alias))

--- a/test/metabase/driver/sql/query_processor_test.clj
+++ b/test/metabase/driver/sql/query_processor_test.clj
@@ -1,18 +1,18 @@
 (ns metabase.driver.sql.query-processor-test
-  (:require [clojure.test :refer :all]
-            [honeysql.core :as hsql]
-            [metabase.driver :as driver]
-            [metabase.driver.sql.query-processor :as sql.qp]
-            [metabase.driver.sql.query-processor-test-util :as sql.qp-test-util]
-            [metabase.models.field :refer [Field]]
-            [metabase.models.setting :as setting]
-            [metabase.query-processor :as qp]
-            [metabase.query-processor.interface :as qp.i]
-            [metabase.query-processor.util.add-alias-info :as add]
-            [metabase.test :as mt]
-            [metabase.util.honeysql-extensions :as hx]
-            [schema.core :as s]
-            [toucan.db :as db]))
+  (:require
+   [clojure.test :refer :all]
+   [honeysql.core :as hsql]
+   [metabase.driver :as driver]
+   [metabase.driver.sql.query-processor :as sql.qp]
+   [metabase.driver.sql.query-processor-test-util :as sql.qp-test-util]
+   [metabase.models.field :refer [Field]]
+   [metabase.models.setting :as setting]
+   [metabase.query-processor :as qp]
+   [metabase.query-processor.interface :as qp.i]
+   [metabase.query-processor.util.add-alias-info :as add]
+   [metabase.test :as mt]
+   [metabase.util.honeysql-extensions :as hx]
+   [schema.core :as s]))
 
 (deftest sql-source-query-validation-test
   (testing "[[sql.qp/sql-source-query]] should throw Exceptions if you pass in invalid nonsense"
@@ -46,17 +46,6 @@
       (-> (sql.qp/mbql->native :h2 (qp/preprocess query))
           :query
           sql.qp-test-util/pretty-sql))))
-
-(deftest compile-FieldInstance-test
-  (testing "For legacy compatibility, we should still be able to compile Field instances (for now)"
-    (driver/with-driver :h2
-      (mt/with-everything-store
-        (is (= "SELECT VENUES.PRICE AS PRICE WHERE VENUES.PRICE = 4"
-               (->> {:query {:fields [[:field (mt/id :venues :price)]]
-                             :filter [:= (db/select-one Field :id (mt/id :venues :price)) [:value 4 {:base-type :type/Integer}]]}}
-                    (sql.qp/mbql->native :h2)
-                    :query
-                    sql.qp-test-util/pretty-sql)))))))
 
 (deftest not-null-test
   (is (= '{:select [count (*) AS count]


### PR DESCRIPTION
We announced that these methods would be removed in 44 and 45 respectively, so removing them is overdue. 