### PR TITLE
Migrate Mongo 4.0 and 5.0 driver tests to GitHub Actions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,15 +27,6 @@ executors:
     docker:
       - image: metabase/ci:java-17-clj-1.11.0.1100.04-2022-build
 
-  mongo-4-0-ssl:
-     working_directory: /home/circleci/metabase/metabase/
-     docker:
-       - image: metabase/ci:java-11-clj-1.11.0.1100.04-2022-build
-         environment:
-           MB_TEST_MONGO_REQUIRES_SSL: true
-       - image: metabase/qa-databases:mongo-sample-4.0
-         command: mongod --dbpath /data/db2/ --sslMode requireSSL --sslPEMKeyFile /etc/mongo/metamongo.pem --sslCAFile /etc/mongo/metaca.crt
-
 ########################################################################################################################
 #                                             MAP FRAGMENTS AND CACHE KEYS                                             #
 ########################################################################################################################
@@ -515,43 +506,6 @@ workflows:
                 command: bash <(curl -s https://codecov.io/bash) -F back-end
 
           skip-when-no-change: true
-
-      - test-driver:
-          matrix:
-            parameters:
-<<<<<<< HEAD
-              version: ["mongo-4-0-ssl", "mongo-5-0-ssl"]
-=======
-              driver: ["bigquery-cloud-sdk"]
-          name: be-tests-<< matrix.driver >>-ee
-          requires:
-            - be-deps
-          driver: << matrix.driver >>
-          timeout: 30m
-
-      - test-driver:
-          name: be-google-related-drivers-classpath-test
-          requires:
-            - be-deps
-          driver: googleanalytics,bigquery-cloud-sdk
-          test-args: >-
-            :only "[metabase.query-processor-test.expressions-test metabase.driver.google-test
-                    metabase.driver.googleanalytics-test]"
-
-      - test-driver:
-          matrix:
-            parameters:
-              version: ["mongo-4-0-ssl"]
->>>>>>> 75c5f579ea (Migrate Mongo 5 ssl driver test to GitHub Actions)
-          name: be-tests-<< matrix.version >>-ee
-          description: "(<< matrix.version >>)"
-          requires:
-            - be-deps
-          e: << matrix.version >>
-          driver: mongo
-          extra-env: >-
-            MB_MONGO_TEST_USER=metabase
-            MB_MONGO_TEST_PASSWORD=metasample123
 
       - test-driver:
           name: be-tests-oracle-ee

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,15 +36,6 @@ executors:
        - image: metabase/qa-databases:mongo-sample-4.0
          command: mongod --dbpath /data/db2/ --sslMode requireSSL --sslPEMKeyFile /etc/mongo/metamongo.pem --sslCAFile /etc/mongo/metaca.crt
 
-  mongo-5-0-ssl:
-     working_directory: /home/circleci/metabase/metabase/
-     docker:
-       - image: metabase/ci:java-11-clj-1.11.0.1100.04-2022-build
-         environment:
-           MB_TEST_MONGO_REQUIRES_SSL: true
-       - image: metabase/qa-databases:mongo-sample-5.0
-         command: mongod --dbpath /data/db2/ --tlsMode requireTLS --tlsCertificateKeyFile /etc/mongo/metamongo.pem --tlsCAFile /etc/mongo/metaca.crt
-
 ########################################################################################################################
 #                                             MAP FRAGMENTS AND CACHE KEYS                                             #
 ########################################################################################################################
@@ -528,7 +519,30 @@ workflows:
       - test-driver:
           matrix:
             parameters:
+<<<<<<< HEAD
               version: ["mongo-4-0-ssl", "mongo-5-0-ssl"]
+=======
+              driver: ["bigquery-cloud-sdk"]
+          name: be-tests-<< matrix.driver >>-ee
+          requires:
+            - be-deps
+          driver: << matrix.driver >>
+          timeout: 30m
+
+      - test-driver:
+          name: be-google-related-drivers-classpath-test
+          requires:
+            - be-deps
+          driver: googleanalytics,bigquery-cloud-sdk
+          test-args: >-
+            :only "[metabase.query-processor-test.expressions-test metabase.driver.google-test
+                    metabase.driver.googleanalytics-test]"
+
+      - test-driver:
+          matrix:
+            parameters:
+              version: ["mongo-4-0-ssl"]
+>>>>>>> 75c5f579ea (Migrate Mongo 5 ssl driver test to GitHub Actions)
           name: be-tests-<< matrix.version >>-ee
           description: "(<< matrix.version >>)"
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -314,15 +314,6 @@ jobs:
               echo 'This is a release or master branch; using cache-busting prefix'
               echo '<< pipeline.id >>' > .CACHE-PREFIX
             fi
-      - run:
-          name: Make SSL certificates for Mongo available
-          command: >-
-            curl https://raw.githubusercontent.com/metabase/metabase-qa/master/dbs/mongo/certificates/metabase.crt
-            -o /home/circleci/metabase/metabase/test_resources/ssl/mongo/metabase.crt
-            https://raw.githubusercontent.com/metabase/metabase-qa/master/dbs/mongo/certificates/metabase.key
-            -o /home/circleci/metabase/metabase/test_resources/ssl/mongo/metabase.key
-            https://raw.githubusercontent.com/metabase/metabase-qa/master/dbs/mongo/certificates/metaca.crt
-            -o /home/circleci/metabase/metabase/test_resources/ssl/mongo/metaca.crt
       - persist_to_workspace:
           root: /home/circleci/
           paths:

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -207,7 +207,17 @@ jobs:
           - "27017:27017"
     steps:
     - uses: actions/checkout@v3
-    - run: mongod --dbpath /data/db2/ --sslMode requireSSL --sslPEMKeyFile /etc/mongo/metamongo.pem --sslCAFile /etc/mongo/metaca.crt
+    - run: |
+        curl https://raw.githubusercontent.com/metabase/metabase-qa/master/dbs/mongo/certificates/metabase.crt \
+        -o ./test_resources/ssl/mongo/metabase.crt
+
+        curl https://raw.githubusercontent.com/metabase/metabase-qa/master/dbs/mongo/certificates/metabase.key \
+        -o ./test_resources/ssl/mongo/metabase.key
+
+        curl https://raw.githubusercontent.com/metabase/metabase-qa/master/dbs/mongo/certificates/metaca.crt \
+        -o ./test_resources/ssl/mongo/metaca.crt
+
+        mongod --dbpath /data/db2/ --sslMode requireSSL --sslPEMKeyFile /etc/mongo/metamongo.pem --sslCAFile /etc/mongo/metaca.crt
     - name: Test MongoDB driver (4.0)
       uses: ./.github/actions/test-driver
       with:
@@ -251,7 +261,17 @@ jobs:
           - "27017:27017"
     steps:
     - uses: actions/checkout@v3
-    - run: mongod --dbpath /data/db2/ --tlsMode requireTLS --tlsCertificateKeyFile /etc/mongo/metamongo.pem --tlsCAFile /etc/mongo/metaca.crt
+    - run: |
+        curl https://raw.githubusercontent.com/metabase/metabase-qa/master/dbs/mongo/certificates/metabase.crt \
+        -o ./test_resources/ssl/mongo/metabase.crt
+
+        curl https://raw.githubusercontent.com/metabase/metabase-qa/master/dbs/mongo/certificates/metabase.key \
+        -o ./test_resources/ssl/mongo/metabase.key
+
+        curl https://raw.githubusercontent.com/metabase/metabase-qa/master/dbs/mongo/certificates/metaca.crt \
+        -o ./test_resources/ssl/mongo/metaca.crt
+
+        mongod --dbpath /data/db2/ --tlsMode requireTLS --tlsCertificateKeyFile /etc/mongo/metamongo.pem --tlsCAFile /etc/mongo/metaca.crt
     - name: Test MongoDB driver (5.0)
       uses: ./.github/actions/test-driver
       with:

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -205,8 +205,8 @@ jobs:
       - name: Spin up Mongo docker container
         run: docker run -d -p 27017:27017 --name metamongo metabase/qa-databases:mongo-sample-4.0 mongod --dbpath /data/db2/ --sslMode requireSSL --sslPEMKeyFile /etc/mongo/metamongo.pem --sslCAFile /etc/mongo/metaca.crt
       - name: Wait until the port 27017 is ready
-        run: while ! nc -z localhost 27017; do sleep 0.1; done
-        timeout-minutes: 15
+        run: while ! nc -z localhost 27017; do sleep 1; done
+        timeout-minutes: 5
       - name: Make SSL certificates for Mongo available
         run: |
           curl https://raw.githubusercontent.com/metabase/metabase-qa/master/dbs/mongo/certificates/metabase.crt \
@@ -259,8 +259,8 @@ jobs:
     - name: Spin up Mongo docker container
       run: docker run -d -p 27017:27017 --name metamongo metabase/qa-databases:mongo-sample-5.0 mongod --dbpath /data/db2/ --tlsMode requireTLS --tlsCertificateKeyFile /etc/mongo/metamongo.pem --tlsCAFile /etc/mongo/metaca.crt
     - name: Wait until the port 27017 is ready
-      run: while ! nc -z localhost 27017; do sleep 0.1; done
-      timeout-minutes: 15
+      run: while ! nc -z localhost 27017; do sleep 1; done
+      timeout-minutes: 5
     - name: Make SSL certificates for Mongo available
       run: |
         curl https://raw.githubusercontent.com/metabase/metabase-qa/master/dbs/mongo/certificates/metabase.crt \

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -221,7 +221,7 @@ jobs:
 
     - name: Prepare the Docker image
       run: |
-          docker exec -it mongo-qa bash \
+          docker exec -i mongo-qa bash \
           && mongod --dbpath /data/db2/ \
                     --sslMode requireSSL \
                     --sslPEMKeyFile /etc/mongo/metamongo.pem \

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -205,7 +205,7 @@ jobs:
         image: metabase/qa-databases:mongo-sample-4.0
         ports:
           - "27017:27017"
-        options: "--entrypoint mongod --dbpath /data/db2/ --sslMode requireSSL --sslPEMKeyFile /etc/mongo/metamongo.pem --sslCAFile /etc/mongo/metaca.crt"
+        options: "--entrypoint 'mongod --dbpath /data/db2/ --sslMode requireSSL --sslPEMKeyFile /etc/mongo/metamongo.pem --sslCAFile /etc/mongo/metaca.crt'"
     steps:
       - uses: actions/checkout@v3
       - name: Make SSL certificates for Mongo available

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -203,7 +203,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Spin up Mongo docker container
-        run: docker run --rm -p 27017:27017 --name metamongo metabase/qa-databases:mongo-sample-4.0 mongod --dbpath /data/db2/ --sslMode requireSSL --sslPEMKeyFile /etc/mongo/metamongo.pem --sslCAFile /etc/mongo/metaca.crt
+        run: docker run -d -p 27017:27017 --name metamongo metabase/qa-databases:mongo-sample-4.0 mongod --dbpath /data/db2/ --sslMode requireSSL --sslPEMKeyFile /etc/mongo/metamongo.pem --sslCAFile /etc/mongo/metaca.crt
       - name: Wait until the port 27017 is ready
         run: while ! nc -z localhost 27017; do sleep 0.1; done
         timeout-minutes: 15
@@ -257,7 +257,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Spin up Mongo docker container
-      run: docker run --rm -p 27017:27017 --name metamongo metabase/qa-databases:mongo-sample-5.0 mongod --dbpath /data/db2/ --tlsMode requireTLS --tlsCertificateKeyFile /etc/mongo/metamongo.pem --tlsCAFile /etc/mongo/metaca.crt
+      run: docker run -d -p 27017:27017 --name metamongo metabase/qa-databases:mongo-sample-5.0 mongod --dbpath /data/db2/ --tlsMode requireTLS --tlsCertificateKeyFile /etc/mongo/metamongo.pem --tlsCAFile /etc/mongo/metaca.crt
     - name: Wait until the port 27017 is ready
       run: while ! nc -z localhost 27017; do sleep 0.1; done
       timeout-minutes: 15

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -205,32 +205,24 @@ jobs:
         image: metabase/qa-databases:mongo-sample-4.0
         ports:
           - "27017:27017"
-        options: '--name mongo-qa'
+        options: "--entrypoint --dbpath /data/db2/ --sslMode requireSSL --sslPEMKeyFile /etc/mongo/metamongo.pem --sslCAFile /etc/mongo/metaca.crt"
     steps:
-    - uses: actions/checkout@v3
-    - name: Make SSL certificates for Mongo available
-      run: |
-        curl https://raw.githubusercontent.com/metabase/metabase-qa/master/dbs/mongo/certificates/metabase.crt \
-        -o ./test_resources/ssl/mongo/metabase.crt
+      - uses: actions/checkout@v3
+      - name: Make SSL certificates for Mongo available
+        run: |
+          curl https://raw.githubusercontent.com/metabase/metabase-qa/master/dbs/mongo/certificates/metabase.crt \
+          -o ./test_resources/ssl/mongo/metabase.crt
 
-        curl https://raw.githubusercontent.com/metabase/metabase-qa/master/dbs/mongo/certificates/metabase.key \
-        -o ./test_resources/ssl/mongo/metabase.key
+          curl https://raw.githubusercontent.com/metabase/metabase-qa/master/dbs/mongo/certificates/metabase.key \
+          -o ./test_resources/ssl/mongo/metabase.key
 
-        curl https://raw.githubusercontent.com/metabase/metabase-qa/master/dbs/mongo/certificates/metaca.crt \
-        -o ./test_resources/ssl/mongo/metaca.crt
+          curl https://raw.githubusercontent.com/metabase/metabase-qa/master/dbs/mongo/certificates/metaca.crt \
+          -o ./test_resources/ssl/mongo/metaca.crt
 
-    - name: Prepare the Docker image
-      run: |
-          docker exec -i mongo-qa bash \
-          && mongod --dbpath /data/db2/ \
-                    --sslMode requireSSL \
-                    --sslPEMKeyFile /etc/mongo/metamongo.pem \
-                    --sslCAFile /etc/mongo/metaca.crt
-
-    - name: Test MongoDB driver (4.0)
-      uses: ./.github/actions/test-driver
-      with:
-        junit-name: 'be-tests-mongo-4-0-ee'
+      - name: Test MongoDB driver (4.0)
+        uses: ./.github/actions/test-driver
+        with:
+          junit-name: 'be-tests-mongo-4-0-ee'
 
   be-tests-mongo-5-0-ee:
     if: github.event.pull_request.draft == false

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -200,14 +200,13 @@ jobs:
       MB_MONGO_TEST_USER: metabase
       MB_MONGO_TEST_PASSWORD: metasample123
       MB_TEST_MONGO_REQUIRES_SSL: true
-    services:
-      mongodb:
-        image: metabase/qa-databases:mongo-sample-4.0
-        ports:
-          - "27017:27017"
-        options: --entrypoint 'mongod --sslMode requireSSL --sslPEMKeyFile /etc/mongo/metamongo.pem --sslCAFile /etc/mongo/metaca.crt'
     steps:
       - uses: actions/checkout@v3
+      - name: Spin up Mongo docker container
+        run: docker run --rm -p 27017:27017 --name metamongo metabase/qa-databases:mongo-sample-4.0 mongod --dbpath /data/db2/ --sslMode requireSSL --sslPEMKeyFile /etc/mongo/metamongo.pem --sslCAFile /etc/mongo/metaca.crt
+      - name: Wait until the port 27017 is ready
+        run: while ! nc -z localhost 27017; do sleep 0.1; done
+        timeout-minutes: 15
       - name: Make SSL certificates for Mongo available
         run: |
           curl https://raw.githubusercontent.com/metabase/metabase-qa/master/dbs/mongo/certificates/metabase.crt \
@@ -219,7 +218,7 @@ jobs:
           curl https://raw.githubusercontent.com/metabase/metabase-qa/master/dbs/mongo/certificates/metaca.crt \
           -o ./test_resources/ssl/mongo/metaca.crt
 
-      - name: Test MongoDB driver (4.0)
+      - name: Test MongoDB SSL driver (4.0)
         uses: ./.github/actions/test-driver
         with:
           junit-name: 'be-tests-mongo-4-0-ee'
@@ -255,14 +254,15 @@ jobs:
       MB_MONGO_TEST_USER: metabase
       MB_MONGO_TEST_PASSWORD: metasample123
       MB_TEST_MONGO_REQUIRES_SSL: true
-    services:
-      mongodb:
-        image: metabase/qa-databases:mongo-sample-5.0
-        ports:
-          - "27017:27017"
     steps:
     - uses: actions/checkout@v3
-    - run: |
+    - name: Spin up Mongo docker container
+      run: docker run --rm -p 27017:27017 --name metamongo metabase/qa-databases:mongo-sample-5.0 mongod --dbpath /data/db2/ --tlsMode requireTLS --tlsCertificateKeyFile /etc/mongo/metamongo.pem --tlsCAFile /etc/mongo/metaca.crt
+    - name: Wait until the port 27017 is ready
+      run: while ! nc -z localhost 27017; do sleep 0.1; done
+      timeout-minutes: 15
+    - name: Make SSL certificates for Mongo available
+      run: |
         curl https://raw.githubusercontent.com/metabase/metabase-qa/master/dbs/mongo/certificates/metabase.crt \
         -o ./test_resources/ssl/mongo/metabase.crt
 
@@ -272,8 +272,7 @@ jobs:
         curl https://raw.githubusercontent.com/metabase/metabase-qa/master/dbs/mongo/certificates/metaca.crt \
         -o ./test_resources/ssl/mongo/metaca.crt
 
-        mongod --dbpath /data/db2/ --tlsMode requireTLS --tlsCertificateKeyFile /etc/mongo/metamongo.pem --tlsCAFile /etc/mongo/metaca.crt
-    - name: Test MongoDB driver (5.0)
+    - name: Test MongoDB SSL driver (5.0)
       uses: ./.github/actions/test-driver
       with:
         junit-name: 'be-tests-mongo-5-0-ee'

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -211,6 +211,29 @@ jobs:
       with:
         junit-name: 'be-tests-mongo-5-0-ee'
 
+  be-tests-mongo-5-0-ssl-ee:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-20.04
+    timeout-minutes: 60
+    env:
+      CI: 'true'
+      DRIVERS: mongo
+      MB_MONGO_TEST_USER: metabase
+      MB_MONGO_TEST_PASSWORD: metasample123
+      MB_TEST_MONGO_REQUIRES_SSL: true
+    services:
+      mongodb:
+        image: metabase/qa-databases:mongo-sample-5.0
+        ports:
+          - "27017:27017"
+    steps:
+    - uses: actions/checkout@v3
+    - run: mongod --dbpath /data/db2/ --tlsMode requireTLS --tlsCertificateKeyFile /etc/mongo/metamongo.pem --tlsCAFile /etc/mongo/metaca.crt
+    - name: Test MongoDB driver (5.0)
+      uses: ./.github/actions/test-driver
+      with:
+        junit-name: 'be-tests-mongo-5-0-ee'
+
   be-tests-mongo-latest-ee:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-20.04
@@ -261,6 +284,7 @@ jobs:
         junit-name: 'be-tests-mysql-5-7-ee'
 
   be-tests-mysql-latest-ee:
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-20.04
     timeout-minutes: 60
     env:

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -205,7 +205,7 @@ jobs:
         image: metabase/qa-databases:mongo-sample-4.0
         ports:
           - "27017:27017"
-        options: --entrypoint 'mongod --dbpath /data/db2/ --sslMode requireSSL --sslPEMKeyFile /etc/mongo/metamongo.pem --sslCAFile /etc/mongo/metaca.crt'
+        options: --entrypoint 'mongod --sslMode requireSSL --sslPEMKeyFile /etc/mongo/metamongo.pem --sslCAFile /etc/mongo/metaca.crt'
     steps:
       - uses: actions/checkout@v3
       - name: Make SSL certificates for Mongo available

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -205,9 +205,11 @@ jobs:
         image: metabase/qa-databases:mongo-sample-4.0
         ports:
           - "27017:27017"
+        options: '--name mongo-qa'
     steps:
     - uses: actions/checkout@v3
-    - run: |
+    - name: Make SSL certificates for Mongo available
+      run: |
         curl https://raw.githubusercontent.com/metabase/metabase-qa/master/dbs/mongo/certificates/metabase.crt \
         -o ./test_resources/ssl/mongo/metabase.crt
 
@@ -217,7 +219,14 @@ jobs:
         curl https://raw.githubusercontent.com/metabase/metabase-qa/master/dbs/mongo/certificates/metaca.crt \
         -o ./test_resources/ssl/mongo/metaca.crt
 
-        mongod --dbpath /data/db2/ --sslMode requireSSL --sslPEMKeyFile /etc/mongo/metamongo.pem --sslCAFile /etc/mongo/metaca.crt
+    - name: Prepare the Docker image
+      run: |
+          docker exec -it mongo-qa bash \
+          && mongod --dbpath /data/db2/ \
+                    --sslMode requireSSL \
+                    --sslPEMKeyFile /etc/mongo/metamongo.pem \
+                    --sslCAFile /etc/mongo/metaca.crt
+
     - name: Test MongoDB driver (4.0)
       uses: ./.github/actions/test-driver
       with:

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -205,7 +205,7 @@ jobs:
         image: metabase/qa-databases:mongo-sample-4.0
         ports:
           - "27017:27017"
-        options: "--entrypoint --dbpath /data/db2/ --sslMode requireSSL --sslPEMKeyFile /etc/mongo/metamongo.pem --sslCAFile /etc/mongo/metaca.crt"
+        options: "--entrypoint mongod --dbpath /data/db2/ --sslMode requireSSL --sslPEMKeyFile /etc/mongo/metamongo.pem --sslCAFile /etc/mongo/metaca.crt"
     steps:
       - uses: actions/checkout@v3
       - name: Make SSL certificates for Mongo available

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -205,7 +205,7 @@ jobs:
         image: metabase/qa-databases:mongo-sample-4.0
         ports:
           - "27017:27017"
-        options: "--entrypoint 'mongod --dbpath /data/db2/ --sslMode requireSSL --sslPEMKeyFile /etc/mongo/metamongo.pem --sslCAFile /etc/mongo/metaca.crt'"
+        options: --entrypoint 'mongod --dbpath /data/db2/ --sslMode requireSSL --sslPEMKeyFile /etc/mongo/metamongo.pem --sslCAFile /etc/mongo/metaca.crt'
     steps:
       - uses: actions/checkout@v3
       - name: Make SSL certificates for Mongo available

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -190,6 +190,29 @@ jobs:
       with:
         junit-name: 'be-tests-mongo-4-0-ee'
 
+  be-tests-mongo-4-0-ssl-ee:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-20.04
+    timeout-minutes: 60
+    env:
+      CI: 'true'
+      DRIVERS: mongo
+      MB_MONGO_TEST_USER: metabase
+      MB_MONGO_TEST_PASSWORD: metasample123
+      MB_TEST_MONGO_REQUIRES_SSL: true
+    services:
+      mongodb:
+        image: metabase/qa-databases:mongo-sample-4.0
+        ports:
+          - "27017:27017"
+    steps:
+    - uses: actions/checkout@v3
+    - run: mongod --dbpath /data/db2/ --sslMode requireSSL --sslPEMKeyFile /etc/mongo/metamongo.pem --sslCAFile /etc/mongo/metaca.crt
+    - name: Test MongoDB driver (4.0)
+      uses: ./.github/actions/test-driver
+      with:
+        junit-name: 'be-tests-mongo-4-0-ee'
+
   be-tests-mongo-5-0-ee:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-20.04


### PR DESCRIPTION
After a lot of struggle, finally the tests are green!

Running the Docker command manually instead using the `service` containers did the trick with overriding the `entrypoint`.

## Results

### Mongo 4.0

```clj
;; GitHub Actions
;;
;; Ran 3099 tests in 581.287 seconds
;; 19038 assertions, 0 failures, 0 errors.
{:test 3099,
 :pass 19038,
 :fail 0,
 :error 0,
 :type :summary,
 :duration 581286.997084,
 :single-threaded 2871,
 :parallel 228}
;; Ran 228 tests in parallel, 2871 single-threaded.
;; Finding and running tests took 11.1 mins.
;; All tests passed.
```

```clj
;; CircleCI
;;
;; Ran 3099 tests in 483.418 seconds
;; 19038 assertions, 0 failures, 0 errors.
{:test 3099,
 :pass 19038,
 :fail 0,
 :error 0,
 :type :summary,
 :duration 483418.193138,
 :single-threaded 2871,
 :parallel 228}
;; Ran 228 tests in parallel, 2871 single-threaded.
;; Finding and running tests took 9.2 mins.
;; All tests passed.
```

### Mongo 5.0

```clj
;; GitHub Actions
;;
;; Ran 3099 tests in 528.116 seconds
;; 19126 assertions, 0 failures, 0 errors.
{:test 3099,
 :pass 19126,
 :fail 0,
 :error 0,
 :type :summary,
 :duration 528116.180768,
 :single-threaded 2871,
 :parallel 228}
;; Ran 228 tests in parallel, 2871 single-threaded.
;; Finding and running tests took 10.1 mins.
;; All tests passed.
```

```clj
;; CircleCI
;;
;; Ran 3099 tests in 532.066 seconds
;; 19126 assertions, 0 failures, 0 errors.
{:test 3099,
 :pass 19126,
 :fail 0,
 :error 0,
 :type :summary,
 :duration 532066.413351,
 :single-threaded 2871,
 :parallel 228}
;; Ran 228 tests in parallel, 2871 single-threaded.
;; Finding and running tests took 10.1 mins.
;; All tests passed.
```