### PR TITLE
Migrate Vertica driver test to GitHub Actions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,12 +75,6 @@ executors:
     # (see above)
     resource_class: large
 
-  vertica:
-    working_directory: /home/circleci/metabase/metabase/
-    docker:
-      - image: metabase/ci:java-11-clj-1.11.0.1100.04-2022-build
-      - image: sumitchawla/vertica
-
 ########################################################################################################################
 #                                             MAP FRAGMENTS AND CACHE KEYS                                             #
 ########################################################################################################################
@@ -656,14 +650,3 @@ workflows:
             - be-deps
           driver: snowflake
           timeout: 115m # whut
-
-      - test-driver:
-          name: be-tests-vertica-ee
-          requires:
-            - be-deps
-          e: vertica
-          before-steps:
-            - fetch-jdbc-driver:
-                source: VERTICA_JDBC_JAR
-                dest: vertica-jdbc-7.1.2-0.jar
-          driver: vertica

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -370,6 +370,8 @@ jobs:
     services:
       vertica:
         image: sumitchawla/vertica
+        ports:
+          - "5433:5433"
     steps:
     - uses: actions/checkout@v3
     - name: Make plugins directory

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -364,9 +364,6 @@ jobs:
     if: github.event.pull_request.draft == false
     runs-on: buildjet-2vcpu-ubuntu-2004
     timeout-minutes: 60
-    strategy:
-      matrix:
-        version: ['vertica-jdbc-7.1.2-0.jar']
     env:
       CI: 'true'
       DRIVERS: vertica
@@ -378,7 +375,7 @@ jobs:
     - name: Make plugins directory
       run: mkdir plugins
     - name: Fetch JDBC driver
-      run: wget --output-document=plugins/${{ matrix.version }} ${{ secrets.VERTICA_JDBC_JAR }}
+      run: wget --output-document=plugins/vertica-jdbc-7.1.2-0.jar ${{ secrets.VERTICA_JDBC_JAR }}
     - name: Test Vertica driver
       uses: ./.github/actions/test-driver
       with:

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -362,7 +362,7 @@ jobs:
 
   be-tests-vertica-ee:
     if: github.event.pull_request.draft == false
-    runs-on: buildjet-2vcpu-ubuntu-2004
+    runs-on: ubuntu-20.04
     timeout-minutes: 60
     env:
       CI: 'true'

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -359,3 +359,27 @@ jobs:
       uses: ./.github/actions/test-driver
       with:
         junit-name: 'be-tests-sqlserver-ee'
+
+  be-tests-vertica-ee:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-20.04
+    timeout-minutes: 60
+    strategy:
+      matrix:
+        version: ['vertica-jdbc-7.1.2-0.jar']
+    env:
+      CI: 'true'
+      DRIVERS: vertica
+    services:
+      vertica:
+        image: sumitchawla/vertica
+    steps:
+    - uses: actions/checkout@v3
+    - name: Make plugins directory
+      run: mkdir plugins
+    - name: Fetch JDBC driver
+      run: wget --output-document=plugins/${{ matrix.version }} ${{ secrets.VERTICA_JDBC_JAR }}
+    - name: Test Vertica driver
+      uses: ./.github/actions/test-driver
+      with:
+        junit-name: 'be-tests-vertica-ee'

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -362,7 +362,7 @@ jobs:
 
   be-tests-vertica-ee:
     if: github.event.pull_request.draft == false
-    runs-on: ubuntu-20.04
+    runs-on: buildjet-2vcpu-ubuntu-2004
     timeout-minutes: 60
     strategy:
       matrix:


### PR DESCRIPTION
```clj
;; GitHub
;;
;; Ran 3061 tests in 621.346 seconds
;; 19487 assertions, 0 failures, 0 errors.
{:test 3061,
 :pass 19487,
 :fail 0,
 :error 0,
 :type :summary,
 :duration 621346.429205,
 :single-threaded 2834,
 :parallel 227}
;; Ran 227 tests in parallel, 2834 single-threaded.
;; Finding and running tests took 11.7 mins.
;; All tests passed.
```

```clj
;; CircleCI
;;
;; Ran 3061 tests in 608.557 seconds
;; 19487 assertions, 0 failures, 0 errors.
{:test 3061,
 :pass 19487,
 :fail 0,
 :error 0,
 :type :summary,
 :duration 608556.988431,
 :single-threaded 2834,
 :parallel 227}
;; Ran 227 tests in parallel, 2834 single-threaded.
;; Finding and running tests took 11.3 mins.
;; All tests passed.
```