### PR TITLE
CI for release: use up-to-date actions/download-artifact@v3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
         java-package: jre
         java-version: ${{ matrix.java-version }}
         distribution: 'temurin'
-    - uses: actions/download-artifact@v2
+    - uses: actions/download-artifact@v3
       name: Retrieve previously downloaded Uberjar
       with:
         name: metabase-uberjar-${{ github.ref_name }}


### PR DESCRIPTION
This gets rid of the following GitHub Action warning message:

```
check-uberjar (17)
Node.js 12 actions are deprecated. For more information see:
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
Please update the following actions to use Node.js 16:
actions/download-artifact@v2
```
