### PR TITLE
Migrate BigQuery and classpath driver tests to GitHub actions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -556,16 +556,6 @@ workflows:
           skip-when-no-change: true
 
       - test-driver:
-          matrix:
-            parameters:
-              driver: ["bigquery-cloud-sdk"]
-          name: be-tests-<< matrix.driver >>-ee
-          requires:
-            - be-deps
-          driver: << matrix.driver >>
-          timeout: 30m
-
-      - test-driver:
           name: be-google-related-drivers-classpath-test
           requires:
             - be-deps

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -556,15 +556,6 @@ workflows:
           skip-when-no-change: true
 
       - test-driver:
-          name: be-google-related-drivers-classpath-test
-          requires:
-            - be-deps
-          driver: googleanalytics,bigquery-cloud-sdk
-          test-args: >-
-            :only "[metabase.query-processor-test.expressions-test metabase.driver.google-test
-                    metabase.driver.googleanalytics-test]"
-
-      - test-driver:
           matrix:
             parameters:
               version: ["mongo-4-0-ssl", "mongo-5-0-ssl"]

--- a/.github/actions/test-driver/action.yml
+++ b/.github/actions/test-driver/action.yml
@@ -3,6 +3,8 @@ inputs:
   junit-name:
     required: true
     default: 'driver'
+  test-args:
+    required: false
 
 runs:
   using: "composite"
@@ -15,7 +17,7 @@ runs:
       run: yarn build-static-viz
       shell: bash
     - name: Test database driver
-      run: clojure -X:dev:ci:ee:ee-dev:drivers:drivers-dev:test
+      run: clojure -X:dev:ci:ee:ee-dev:drivers:drivers-dev:test ${{ inputs.test-args }}
       shell: bash
     - name: Publish Test Report (JUnit)
       uses: mikepenz/action-junit-report@v3

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -105,12 +105,18 @@ jobs:
     env:
       CI: 'true'
       DRIVERS: ${{ matrix.driver }}
+      MB_BIGQUERY_TEST_PROJECT_ID: ${{ secrets.BIGQUERY_TEST_PROJECT_ID }}
+      MB_BIGQUERY_TEST_CLIENT_ID: ${{ secrets.MB_BIGQUERY_TEST_CLIENT_ID }}
+      MB_BIGQUERY_TEST_CLIENT_SECRET: ${{ secrets.MB_BIGQUERY_TEST_CLIENT_SECRET }}
+      MB_BIGQUERY_TEST_ACCESS_TOKEN: ${{ secrets.MB_BIGQUERY_TEST_ACCESS_TOKEN }}
+      MB_BIGQUERY_TEST_REFRESH_TOKEN: ${{ secrets.MB_BIGQUERY_TEST_REFRESH_TOKEN }}
+      MB_BIGQUERY_CLOUD_SDK_TEST_SERVICE_ACCOUNT_JSON: ${{ secrets.MB_BIGQUERY_CLOUD_SDK_TEST_SERVICE_ACCOUNT_JSON }}
     steps:
     - uses: actions/checkout@v3
     - name: Test Google Related Classpath drivers
       uses: ./.github/actions/test-driver
       with:
-        junit-name: 'be-tests-googleanalytics-ee'
+        junit-name: 'be-tests-${{ matrix.driver }}-classpath-ee'
         test-args: ':only "[metabase.query-processor-test.expressions-test metabase.driver.google-test metabase.driver.googleanalytics-test]"'
 
   be-tests-mariadb-10-2-ee:

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -111,9 +111,7 @@ jobs:
       uses: ./.github/actions/test-driver
       with:
         junit-name: 'be-tests-googleanalytics-ee'
-        test-args: >-
-          ':only "[metabase.query-processor-test.expressions-test metabase.driver.google-test
-                   metabase.driver.googleanalytics-test]"'
+        test-args: ':only "[metabase.query-processor-test.expressions-test metabase.driver.google-test metabase.driver.googleanalytics-test]"'
 
   be-tests-mariadb-10-2-ee:
     if: github.event.pull_request.draft == false

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -95,6 +95,26 @@ jobs:
       with:
         junit-name: 'be-tests-googleanalytics-ee'
 
+  be-tests-google-related-classpath-ee:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-20.04
+    timeout-minutes: 60
+    strategy:
+      matrix:
+        driver: ['googleanalytics', 'bigquery-cloud-sdk']
+    env:
+      CI: 'true'
+      DRIVERS: ${{ matrix.driver }}
+    steps:
+    - uses: actions/checkout@v3
+    - name: Test Google Related Classpath drivers
+      uses: ./.github/actions/test-driver
+      with:
+        junit-name: 'be-tests-googleanalytics-ee'
+        test-args: >-
+          ':only "[metabase.query-processor-test.expressions-test metabase.driver.google-test
+                   metabase.driver.googleanalytics-test]"'
+
   be-tests-mariadb-10-2-ee:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-20.04

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -40,6 +40,26 @@ jobs:
       with:
         junit-name: 'be-tests-athena-ee'
 
+  be-tests-bigquery-cloud-sdk-ee:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-20.04
+    timeout-minutes: 60
+    env:
+      CI: 'true'
+      DRIVERS: bigquery-cloud-sdk
+      MB_BIGQUERY_TEST_PROJECT_ID: ${{ secrets.BIGQUERY_TEST_PROJECT_ID }}
+      MB_BIGQUERY_TEST_CLIENT_ID: ${{ secrets.MB_BIGQUERY_TEST_CLIENT_ID }}
+      MB_BIGQUERY_TEST_CLIENT_SECRET: ${{ secrets.MB_BIGQUERY_TEST_CLIENT_SECRET }}
+      MB_BIGQUERY_TEST_ACCESS_TOKEN: ${{ secrets.MB_BIGQUERY_TEST_ACCESS_TOKEN }}
+      MB_BIGQUERY_TEST_REFRESH_TOKEN: ${{ secrets.MB_BIGQUERY_TEST_REFRESH_TOKEN }}
+      MB_BIGQUERY_CLOUD_SDK_TEST_SERVICE_ACCOUNT_JSON: ${{ secrets.MB_BIGQUERY_CLOUD_SDK_TEST_SERVICE_ACCOUNT_JSON }}
+    steps:
+    - uses: actions/checkout@v3
+    - name: Test BigQuery Cloud SDK driver
+      uses: ./.github/actions/test-driver
+      with:
+        junit-name: 'be-tests-bigquery-cloud-sdk-ee'
+
   be-tests-druid-ee:
     if: github.event.pull_request.draft == false
     runs-on: buildjet-2vcpu-ubuntu-2004


### PR DESCRIPTION
Note:
Code can probably be a bit dry-er, but let's worry about that later when we move all tests and when we have a good overview of all tests.