### PR TITLE
Migrate Presto JDBC driver test to GitHub Actions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,25 +45,6 @@ executors:
        - image: metabase/qa-databases:mongo-sample-5.0
          command: mongod --dbpath /data/db2/ --tlsMode requireTLS --tlsCertificateKeyFile /etc/mongo/metamongo.pem --tlsCAFile /etc/mongo/metaca.crt
 
-  presto-jdbc-env:
-    working_directory: /home/circleci/metabase/metabase/
-    docker:
-      - image: metabase/ci:java-11-clj-1.11.0.1100.04-2022-build
-      - image: metabase/presto-mb-ci:latest # version 0.254
-        environment:
-          JAVA_TOOL_OPTIONS: "-Xmx2g"
-          MB_PRESTO_JDBC_TEST_CATALOG: test_data
-          MB_PRESTO_JDBC_TEST_HOST: localhost
-          MB_PRESTO_JDBC_TEST_PORT: 8443
-          MB_PRESTO_JDBC_TEST_SSL: true
-          MB_PRESTO_JDBC_TEST_USER: metabase
-          MB_PRESTO_JDBC_TEST_PASSWORD: metabase
-          MB_ENABLE_PRESTO_JDBC_DRIVER: true
-          MB_PRESTO_JDBC_TEST_ADDITIONAL_OPTIONS: >
-            SSLTrustStorePath=/tmp/cacerts-with-presto-ssl.jks&SSLTrustStorePassword=changeit
-    # (see above)
-    resource_class: large
-
 ########################################################################################################################
 #                                             MAP FRAGMENTS AND CACHE KEYS                                             #
 ########################################################################################################################
@@ -577,39 +558,3 @@ workflows:
             MB_ORACLE_SSL_TEST_SSL_TRUSTSTORE_PATH=/home/circleci/metabase/metabase/resources/certificates/rds_root_ca_truststore.jks
             MB_ORACLE_SSL_TEST_SSL_TRUSTSTORE_OPTIONS=local
             MB_ORACLE_SSL_TEST_SSL_TRUSTSTORE_PASSWORD_VALUE=metabase
-
-      - test-driver:
-          name: be-tests-presto-jdbc-ee
-          requires:
-            - be-deps
-          e: presto-jdbc-env # specific env for running Presto JDBC tests (newer Presto version, SSL, etc.)
-          before-steps:
-            - wait-for-port:
-                port: 8443
-            - run:
-                name: Create temp cacerts file based on bundled JDK one
-                command: cp $JAVA_HOME/lib/security/cacerts /tmp/cacerts-with-presto-ssl.jks
-            - run:
-                name: Capture Presto server self signed CA
-                command: |
-                  while [[ ! -s /tmp/presto-ssl-ca.pem ]];
-                    do echo "Waiting to capture SSL CA" \
-                      && openssl s_client -connect localhost:8443 2>/dev/null </dev/null | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' > /tmp/presto-ssl-ca.pem \
-                      && sleep 1; done
-            - run:
-                name: Convert Presto CA from PEM to DER
-                command: openssl x509 -outform der -in /tmp/presto-ssl-ca.pem -out /tmp/presto-ssl-ca.der
-            - run:
-                name: Add write permission on cacerts file
-                command: chmod u+w /tmp/cacerts-with-presto-ssl.jks
-            - run:
-                name: Import Presto CA into temp cacerts file
-                command: |
-                  keytool -noprompt -import -alias presto -keystore /tmp/cacerts-with-presto-ssl.jks \
-                   -storepass changeit -file /tmp/presto-ssl-ca.der -trustcacerts
-          after-steps:
-            - run:
-                name: Capture max memory usage
-                command: cat /sys/fs/cgroup/memory/memory.max_usage_in_bytes
-                when: always
-          driver: presto-jdbc

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,17 +45,6 @@ executors:
        - image: metabase/qa-databases:mongo-sample-5.0
          command: mongod --dbpath /data/db2/ --tlsMode requireTLS --tlsCertificateKeyFile /etc/mongo/metamongo.pem --tlsCAFile /etc/mongo/metaca.crt
 
-  presto-186:
-    working_directory: /home/circleci/metabase/metabase/
-    docker:
-      - image: metabase/ci:java-11-clj-1.11.0.1100.04-2022-build
-      - image: metabase/presto-mb-ci:0.186
-        environment:
-          JAVA_TOOL_OPTIONS: "-Xmx2g"
-    # Run instance with 8GB or RAM instead of the default 4GB for medium instances. The Presto Docker image runs
-    # OOM sometimes with the default medium size.
-    resource_class: large
-
   presto-jdbc-env:
     working_directory: /home/circleci/metabase/metabase/
     docker:

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -401,6 +401,9 @@ jobs:
           JAVA_TOOL_OPTIONS: "-Xmx2g"
     steps:
     - uses: actions/checkout@v3
+    - name: Wait for port ${{ env.MB_PRESTO_JDBC_TEST_PORT }} to be ready
+      run: while ! nc -z localhost ${{ env.MB_PRESTO_JDBC_TEST_PORT }}; do sleep 0.1; done
+      timeout-minutes: 15
     - name: Create temp cacerts file based on bundled JDK one
       run: cp $JAVA_HOME/lib/security/cacerts /tmp/cacerts-with-presto-ssl.jks
     - name: Capture Presto server self signed CA

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -383,7 +383,7 @@ jobs:
     timeout-minutes: 60
     env:
       CI: 'true'
-      DRIVERS: presto
+      DRIVERS: presto-jdbc
       MB_PRESTO_JDBC_TEST_CATALOG: test_data
       MB_PRESTO_JDBC_TEST_HOST: localhost
       MB_PRESTO_JDBC_TEST_PORT: 8443
@@ -417,9 +417,6 @@ jobs:
       run: |
           keytool -noprompt -import -alias presto -keystore /tmp/cacerts-with-presto-ssl.jks \
                   -storepass changeit -file /tmp/presto-ssl-ca.der -trustcacerts
-    - name: Wait for port ${{ env.MB_PRESTO_JDBC_TEST_PORT }} to be ready
-      run: while ! nc -z localhost ${{ env.MB_PRESTO_JDBC_TEST_PORT }}; do sleep 0.1; done
-      timeout-minutes: 15
     - name: Test Presto JDBC driver
       uses: ./.github/actions/test-driver
       with:

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -377,6 +377,53 @@ jobs:
       with:
         junit-name: 'be-tests-presto-186-ee'
 
+  be-tests-presto-jdbc-ee:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-20.04
+    timeout-minutes: 60
+    env:
+      CI: 'true'
+      DRIVERS: presto
+      MB_PRESTO_JDBC_TEST_CATALOG: test_data
+      MB_PRESTO_JDBC_TEST_HOST: localhost
+      MB_PRESTO_JDBC_TEST_PORT: 8443
+      MB_PRESTO_JDBC_TEST_SSL: true
+      MB_PRESTO_JDBC_TEST_USER: metabase
+      MB_PRESTO_JDBC_TEST_PASSWORD: metabase
+      MB_ENABLE_PRESTO_JDBC_DRIVER: true
+      MB_PRESTO_JDBC_TEST_ADDITIONAL_OPTIONS: 'SSLTrustStorePath=/tmp/cacerts-with-presto-ssl.jks&SSLTrustStorePassword=changeit'
+    services:
+      presto:
+        image: metabase/presto-mb-ci:latest # version 0.254
+        ports:
+          - "8443:8443"
+        env:
+          JAVA_TOOL_OPTIONS: "-Xmx2g"
+    steps:
+    - uses: actions/checkout@v3
+    - name: Create temp cacerts file based on bundled JDK one
+      run: cp $JAVA_HOME/lib/security/cacerts /tmp/cacerts-with-presto-ssl.jks
+    - name: Capture Presto server self signed CA
+      run: |
+          while [[ ! -s /tmp/presto-ssl-ca.pem ]];
+            do echo "Waiting to capture SSL CA" \
+              && openssl s_client -connect localhost:8443 2>/dev/null </dev/null | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' > /tmp/presto-ssl-ca.pem \
+              && sleep 1; done
+    - name: Convert Presto CA from PEM to DER
+      run: openssl x509 -outform der -in /tmp/presto-ssl-ca.pem -out /tmp/presto-ssl-ca.der
+    - name: Add write permission on cacerts file
+      run: chmod u+w /tmp/cacerts-with-presto-ssl.jks
+    - name: Import Presto CA into temp cacerts file
+      run: |
+          keytool -noprompt -import -alias presto -keystore /tmp/cacerts-with-presto-ssl.jks \
+                  -storepass changeit -file /tmp/presto-ssl-ca.der -trustcacerts
+    - name: Test Presto JDBC driver
+      uses: ./.github/actions/test-driver
+      with:
+        junit-name: 'be-tests-presto-jdbc-ee'
+    - name: Capture max memory usage
+      run: cat /sys/fs/cgroup/memory/memory.max_usage_in_bytes
+
   be-tests-redshift-ee:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-20.04

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -417,6 +417,9 @@ jobs:
       run: |
           keytool -noprompt -import -alias presto -keystore /tmp/cacerts-with-presto-ssl.jks \
                   -storepass changeit -file /tmp/presto-ssl-ca.der -trustcacerts
+    - name: Wait for port ${{ env.MB_PRESTO_JDBC_TEST_PORT }} to be ready
+      run: while ! nc -z localhost ${{ env.MB_PRESTO_JDBC_TEST_PORT }}; do sleep 0.1; done
+      timeout-minutes: 15
     - name: Test Presto JDBC driver
       uses: ./.github/actions/test-driver
       with:


### PR DESCRIPTION
```clj
;; GitHub Actions (regular potato runner)
;;
;; Ran 3069 tests in 754.153 seconds
;; 19337 assertions, 0 failures, 0 errors.
{:test 3069,
 :pass 19337,
 :fail 0,
 :error 0,
 :type :summary,
 :duration 754152.61644,
 :single-threaded 2842,
 :parallel 227}
;; Ran 227 tests in parallel, 2842 single-threaded.
;; Finding and running tests took 13.9 mins.
```

```clj
;; CircleCI (large resource class)
;;
;; Ran 3069 tests in 495.280 seconds
;; 19337 assertions, 0 failures, 0 errors.
{:test 3069,
 :pass 19337,
 :fail 0,
 :error 0,
 :type :summary,
 :duration 495279.537714,
 :single-threaded 2842,
 :parallel 227}
;; Ran 227 tests in parallel, 2842 single-threaded.
;; Finding and running tests took 9.3 mins.
```