### PR TITLE
Action Forms Refactor 2: Rename ActionForm -> ActionVizForm

### DIFF
--- a/frontend/src/metabase/actions/components/ActionCreator/FormCreator/FormCreator.styled.tsx
+++ b/frontend/src/metabase/actions/components/ActionCreator/FormCreator/FormCreator.styled.tsx
@@ -26,7 +26,7 @@ export const FormSettings = styled.div`
   display: flex;
   gap: ${space(2)};
   align-items: center;
-  justify-content: space-between;
+  justify-content: flex-end;
 `;
 
 export const FormItemName = styled.div`
@@ -48,21 +48,6 @@ export const EmptyFormPlaceholderWrapper = styled.div`
   height: 100%;
   text-align: center;
   padding: 5rem;
-`;
-
-export const EditButton = styled(Button)`
-  color: ${color("brand")};
-  background-opacity: 0;
-  &:hover {
-    color: ${color("accent0-light")};
-  }
-`;
-
-export const FormSettingsPreviewContainer = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: ${space(1)};
-  min-width: 12rem;
 `;
 
 export const ExplainerText = styled.p`

--- a/frontend/src/metabase/actions/components/ActionCreator/FormCreator/FormCreator.tsx
+++ b/frontend/src/metabase/actions/components/ActionCreator/FormCreator/FormCreator.tsx
@@ -20,7 +20,7 @@ import {
   hasNewParams,
 } from "./utils";
 import { FormField } from "./FormField";
-import { OptionEditor } from "./OptionEditor";
+import { OptionPopover } from "./OptionEditor";
 
 import { EmptyFormPlaceholder } from "./EmptyFormPlaceholder";
 
@@ -29,8 +29,6 @@ import {
   FormCreatorWrapper,
   FormItemName,
   FormSettings,
-  FormSettingsPreviewContainer,
-  EditButton,
 } from "./FormCreator.styled";
 
 export function FormCreator({
@@ -146,7 +144,6 @@ function FormItem({
   fieldSettings: FieldSettings;
   onChange: (fieldSettings: FieldSettings) => void;
 }) {
-  const [isEditingOptions, setIsEditingOptions] = useState(false);
   const name = param["display-name"] ?? param.name;
 
   const updateOptions = (newOptions: (string | number)[]) => {
@@ -154,7 +151,6 @@ function FormItem({
       ...fieldSettings,
       valueOptions: newOptions,
     });
-    setIsEditingOptions(false);
   };
 
   const hasOptions =
@@ -167,26 +163,14 @@ function FormItem({
         {name}
         {!!fieldSettings.required && " *"}
       </FormItemName>
+      <FormField param={param} fieldSettings={fieldSettings} />
       <FormSettings>
-        <FormSettingsPreviewContainer>
-          {isEditingOptions && hasOptions ? (
-            <OptionEditor
-              options={fieldSettings.valueOptions ?? []}
-              onChange={updateOptions}
-            />
-          ) : (
-            <FormField param={param} fieldSettings={fieldSettings} />
-          )}
-          {!isEditingOptions && hasOptions && (
-            <EditButton
-              onClick={() => setIsEditingOptions(true)}
-              borderless
-              small
-            >
-              {t`Edit options`}
-            </EditButton>
-          )}
-        </FormSettingsPreviewContainer>
+        {hasOptions && (
+          <OptionPopover
+            options={fieldSettings.valueOptions ?? []}
+            onChange={updateOptions}
+          />
+        )}
         <FieldSettingsPopover
           fieldSettings={fieldSettings}
           onChange={onChange}

--- a/frontend/src/metabase/actions/components/ActionCreator/FormCreator/OptionEditor.styled.tsx
+++ b/frontend/src/metabase/actions/components/ActionCreator/FormCreator/OptionEditor.styled.tsx
@@ -7,6 +7,7 @@ import { space } from "metabase/styled-components/theme";
 export const OptionEditorContainer = styled.div`
   display: flex;
   flex-direction: column;
+  padding: ${space(2)};
 `;
 
 export const AddMorePrompt = styled.div`

--- a/frontend/src/metabase/actions/components/ActionCreator/FormCreator/OptionEditor.tsx
+++ b/frontend/src/metabase/actions/components/ActionCreator/FormCreator/OptionEditor.tsx
@@ -1,7 +1,9 @@
 import React, { useState } from "react";
 import { t } from "ttag";
 
+import TippyPopoverWithTrigger from "metabase/components/PopoverWithTrigger/TippyPopoverWithTrigger";
 import Button from "metabase/core/components/Button";
+import Icon from "metabase/components/Icon";
 
 import {
   OptionEditorContainer,
@@ -15,7 +17,7 @@ const optionsToText = (options: ValueOptions) => options.join("\n");
 const textToOptions = (text: string): ValueOptions =>
   text.split("\n").map(option => option.trim());
 
-export const OptionEditor = ({
+export const OptionPopover = ({
   options,
   onChange,
 }: {
@@ -23,23 +25,33 @@ export const OptionEditor = ({
   onChange: (options: ValueOptions) => void;
 }) => {
   const [text, setText] = useState(optionsToText(options));
-  const save = () => {
+  const save = (closePopover: () => void) => {
     onChange(textToOptions(text));
+    closePopover();
   };
 
   return (
-    <OptionEditorContainer>
-      <StyledTextArea
-        value={text}
-        onChange={e => setText(e.target.value)}
-        placeholder={t`Enter one option per line`}
-      />
-      <AddMorePrompt style={{ opacity: text.length ? 1 : 0 }}>
-        {t`Press enter to add another option`}
-      </AddMorePrompt>
-      <Button onClick={save} small>
-        {t`Save`}
-      </Button>
-    </OptionEditorContainer>
+    <TippyPopoverWithTrigger
+      placement="bottom-end"
+      triggerContent={
+        <Icon name="list" size={14} tooltip={t`change options`} />
+      }
+      maxWidth={400}
+      popoverContent={({ closePopover }) => (
+        <OptionEditorContainer>
+          <StyledTextArea
+            value={text}
+            onChange={e => setText(e.target.value)}
+            placeholder={t`Enter one option per line`}
+          />
+          <AddMorePrompt style={{ opacity: text.length ? 1 : 0 }}>
+            {t`Press enter to add another option`}
+          </AddMorePrompt>
+          <Button onClick={() => save(closePopover)} small>
+            {t`Save`}
+          </Button>
+        </OptionEditorContainer>
+      )}
+    />
   );
 };

--- a/frontend/src/metabase/actions/components/ActionViz/Action.tsx
+++ b/frontend/src/metabase/actions/components/ActionViz/Action.tsx
@@ -21,7 +21,7 @@ import type { ParameterValueOrArray } from "metabase-types/types/Parameter";
 
 import { generateFieldSettingsFromParameters } from "../ActionCreator/FormCreator";
 import LinkButton from "./LinkButton";
-import ActionForm from "./ActionForm";
+import ActionVizForm from "./ActionVizForm";
 import { ActionParameterOptions } from "./ActionOptions";
 import { shouldShowConfirmation } from "./utils";
 import { StyledButton } from "./ActionButton.styled";
@@ -101,7 +101,7 @@ function ActionComponent({
         {showParameterMapper && (
           <ActionParameterOptions dashcard={dashcard} page={page} />
         )}
-        <ActionForm
+        <ActionVizForm
           onSubmit={onSubmit}
           dashcard={dashcard}
           page={page}

--- a/frontend/src/metabase/actions/components/ActionViz/ActionOptions.tsx
+++ b/frontend/src/metabase/actions/components/ActionViz/ActionOptions.tsx
@@ -156,7 +156,6 @@ export const ActionParameterMappingForm = ({
   showEditModal,
 }: ActionParameterMapperProps &
   DispatchProps & { showEditModal?: () => void }) => {
-  console.log({ passedAction });
   const action = passedAction ?? dashcard?.action;
   const actionParameters = action?.parameters ?? [];
   const dashboardParameters = page.parameters ?? [];

--- a/frontend/src/metabase/actions/components/ActionViz/ActionVizForm.tsx
+++ b/frontend/src/metabase/actions/components/ActionViz/ActionVizForm.tsx
@@ -34,7 +34,7 @@ interface ActionFormProps {
   shouldDisplayButton: boolean;
 }
 
-function ActionForm({
+function ActionVizForm({
   onSubmit,
   dashcard,
   settings,
@@ -122,4 +122,4 @@ const ConfirmMessage = ({ message }: { message?: string | null }) => (
   <div>{message ?? t`This action cannot be undone.`}</div>
 );
 
-export default ActionForm;
+export default ActionVizForm;


### PR DESCRIPTION
partly resolves https://github.com/metabase/metabase/issues/26724

## Description

We will be creating a new component called `ActionForm` that actually renders all action forms. The existing ActionForm component is really just a logic layer that determines whether, in an action vizualization we should display the form as a button or an inline form. This renames the component to `ActionVizForm` to avoid a collision later.