### PR TITLE
Action Forms Refactor 3: Move Option Editor to Popover

### DIFF
--- a/frontend/src/metabase/actions/components/ActionCreator/FormCreator/FormCreator.styled.tsx
+++ b/frontend/src/metabase/actions/components/ActionCreator/FormCreator/FormCreator.styled.tsx
@@ -26,7 +26,7 @@ export const FormSettings = styled.div`
   display: flex;
   gap: ${space(2)};
   align-items: center;
-  justify-content: space-between;
+  justify-content: flex-end;
 `;
 
 export const FormItemName = styled.div`
@@ -48,21 +48,6 @@ export const EmptyFormPlaceholderWrapper = styled.div`
   height: 100%;
   text-align: center;
   padding: 5rem;
-`;
-
-export const EditButton = styled(Button)`
-  color: ${color("brand")};
-  background-opacity: 0;
-  &:hover {
-    color: ${color("accent0-light")};
-  }
-`;
-
-export const FormSettingsPreviewContainer = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: ${space(1)};
-  min-width: 12rem;
 `;
 
 export const ExplainerText = styled.p`

--- a/frontend/src/metabase/actions/components/ActionCreator/FormCreator/FormCreator.tsx
+++ b/frontend/src/metabase/actions/components/ActionCreator/FormCreator/FormCreator.tsx
@@ -20,7 +20,7 @@ import {
   hasNewParams,
 } from "./utils";
 import { FormField } from "./FormField";
-import { OptionEditor } from "./OptionEditor";
+import { OptionPopover } from "./OptionEditor";
 
 import { EmptyFormPlaceholder } from "./EmptyFormPlaceholder";
 
@@ -29,8 +29,6 @@ import {
   FormCreatorWrapper,
   FormItemName,
   FormSettings,
-  FormSettingsPreviewContainer,
-  EditButton,
 } from "./FormCreator.styled";
 
 export function FormCreator({
@@ -146,7 +144,6 @@ function FormItem({
   fieldSettings: FieldSettings;
   onChange: (fieldSettings: FieldSettings) => void;
 }) {
-  const [isEditingOptions, setIsEditingOptions] = useState(false);
   const name = param["display-name"] ?? param.name;
 
   const updateOptions = (newOptions: (string | number)[]) => {
@@ -154,7 +151,6 @@ function FormItem({
       ...fieldSettings,
       valueOptions: newOptions,
     });
-    setIsEditingOptions(false);
   };
 
   const hasOptions =
@@ -167,26 +163,14 @@ function FormItem({
         {name}
         {!!fieldSettings.required && " *"}
       </FormItemName>
+      <FormField param={param} fieldSettings={fieldSettings} />
       <FormSettings>
-        <FormSettingsPreviewContainer>
-          {isEditingOptions && hasOptions ? (
-            <OptionEditor
-              options={fieldSettings.valueOptions ?? []}
-              onChange={updateOptions}
-            />
-          ) : (
-            <FormField param={param} fieldSettings={fieldSettings} />
-          )}
-          {!isEditingOptions && hasOptions && (
-            <EditButton
-              onClick={() => setIsEditingOptions(true)}
-              borderless
-              small
-            >
-              {t`Edit options`}
-            </EditButton>
-          )}
-        </FormSettingsPreviewContainer>
+        {hasOptions && (
+          <OptionPopover
+            options={fieldSettings.valueOptions ?? []}
+            onChange={updateOptions}
+          />
+        )}
         <FieldSettingsPopover
           fieldSettings={fieldSettings}
           onChange={onChange}

--- a/frontend/src/metabase/actions/components/ActionCreator/FormCreator/OptionEditor.styled.tsx
+++ b/frontend/src/metabase/actions/components/ActionCreator/FormCreator/OptionEditor.styled.tsx
@@ -7,6 +7,7 @@ import { space } from "metabase/styled-components/theme";
 export const OptionEditorContainer = styled.div`
   display: flex;
   flex-direction: column;
+  padding: ${space(2)};
 `;
 
 export const AddMorePrompt = styled.div`

--- a/frontend/src/metabase/actions/components/ActionCreator/FormCreator/OptionEditor.tsx
+++ b/frontend/src/metabase/actions/components/ActionCreator/FormCreator/OptionEditor.tsx
@@ -1,7 +1,9 @@
 import React, { useState } from "react";
 import { t } from "ttag";
 
+import TippyPopoverWithTrigger from "metabase/components/PopoverWithTrigger/TippyPopoverWithTrigger";
 import Button from "metabase/core/components/Button";
+import Icon from "metabase/components/Icon";
 
 import {
   OptionEditorContainer,
@@ -15,7 +17,7 @@ const optionsToText = (options: ValueOptions) => options.join("\n");
 const textToOptions = (text: string): ValueOptions =>
   text.split("\n").map(option => option.trim());
 
-export const OptionEditor = ({
+export const OptionPopover = ({
   options,
   onChange,
 }: {
@@ -23,23 +25,33 @@ export const OptionEditor = ({
   onChange: (options: ValueOptions) => void;
 }) => {
   const [text, setText] = useState(optionsToText(options));
-  const save = () => {
+  const save = (closePopover: () => void) => {
     onChange(textToOptions(text));
+    closePopover();
   };
 
   return (
-    <OptionEditorContainer>
-      <StyledTextArea
-        value={text}
-        onChange={e => setText(e.target.value)}
-        placeholder={t`Enter one option per line`}
-      />
-      <AddMorePrompt style={{ opacity: text.length ? 1 : 0 }}>
-        {t`Press enter to add another option`}
-      </AddMorePrompt>
-      <Button onClick={save} small>
-        {t`Save`}
-      </Button>
-    </OptionEditorContainer>
+    <TippyPopoverWithTrigger
+      placement="bottom-end"
+      triggerContent={
+        <Icon name="list" size={14} tooltip={t`change options`} />
+      }
+      maxWidth={400}
+      popoverContent={({ closePopover }) => (
+        <OptionEditorContainer>
+          <StyledTextArea
+            value={text}
+            onChange={e => setText(e.target.value)}
+            placeholder={t`Enter one option per line`}
+          />
+          <AddMorePrompt style={{ opacity: text.length ? 1 : 0 }}>
+            {t`Press enter to add another option`}
+          </AddMorePrompt>
+          <Button onClick={() => save(closePopover)} small>
+            {t`Save`}
+          </Button>
+        </OptionEditorContainer>
+      )}
+    />
   );
 };


### PR DESCRIPTION
partly resolves https://github.com/metabase/metabase/issues/26724

## Description

One of the main goals of this project is to unify the form display component and the form creation component, largely to allow execution from the creation component. There was a pretty... rough ... UI for editing select/radio options inline that would replace the form component altogether, this doesn't work in a world where we want the form to be executable. This moves the option-definition UI to a popover for now. This is certainly not the final/ideal UX, but @kdoh is working on designing a much more [robust solution](https://www.notion.so/metabase/Custom-value-list-for-dashboard-filters-and-template-tags-parameters-8ddbdfa87b9e4d1c97e77d8b8c16c4ea) to this problem, but for now, moving this to a popover enables us to keep moving this component's features forward without losing any existing functionality.

. | .
--- | ---
Before | ![beforeOptionedit](https://user-images.githubusercontent.com/30528226/207115124-30c3769e-9697-4151-bebc-d32666c88f73.gif) 
After | ![popoveroptions](https://user-images.githubusercontent.com/30528226/207115130-707f8f01-e05b-4188-bec1-bdb0bae59476.gif)

## Testing steps

- In an app page, edit the page and go to edit a custom action.
- Change a parameter type to category (either radio or select), and see that a new button appears allowing you to edit options
- see that editing the options in the popover saves
