### PR TITLE
Hide auth config pages from setting managers

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/api/setting_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/api/setting_test.clj
@@ -2,63 +2,16 @@
   "Permisisons tests for API that needs to be enforced by Application Permissions to access Admin/Setting pages."
   (:require [clojure.test :refer :all]
             [metabase.api.geojson-test :as geojson-test]
-            [metabase.api.ldap-test :as ldap-test]
             [metabase.email :as email]
             [metabase.integrations.slack :as slack]
             [metabase.models :refer [Card Dashboard]]
             [metabase.models.permissions :as perms]
-            [metabase.models.setting-test :as models.setting-test]
             [metabase.public-settings.premium-features-test :as premium-features-test]
             [metabase.test :as mt]
-            [metabase.test.fixtures :as fixtures]
-            [metabase.test.integrations.ldap :as ldap.test])
+            [metabase.test.fixtures :as fixtures])
   (:import java.util.UUID))
 
 (use-fixtures :once (fixtures/initialize :db))
-
-(deftest setting-api-test
-  (testing "/api/setting"
-    (mt/with-user-in-groups [group {:name "New Group"}
-                             user  [group]]
-      (letfn [(get-setting [user status]
-                (testing (format "get setting with %s user" (mt/user-descriptor user))
-                  (mt/user-http-request user :get status "setting")))
-
-              (update-setting [user status]
-                (testing (format "update single setting with %s user" (mt/user-descriptor user))
-                  (mt/user-http-request user :put status "setting/test-setting-1" {:value "ABC"})))
-
-              (update-settings [user status]
-                (testing (format "update multiple settings setting with %s user" (mt/user-descriptor user))
-                  (mt/user-http-request user :put status "setting" {:test-setting-1 "ABC", :test-setting-2 "DEF"})))]
-        ;; we focus on permissions in these tests, so set default value to make it easier to test
-        (models.setting-test/test-setting-1! "ABC")
-        (models.setting-test/test-setting-2! "DEF")
-
-        (testing "if `advanced-permissions` is disabled, require admins"
-          (premium-features-test/with-premium-features #{}
-            (get-setting user 403)
-            (update-setting user 403)
-            (update-settings user 403)
-            (get-setting :crowberto 200)
-            (update-setting :crowberto 204)
-            (update-settings :crowberto 204)))
-
-        (testing "if `advanced-permissions` is enabled"
-          (premium-features-test/with-premium-features #{:advanced-permissions}
-            (testing "still fail if user's group doesn't have `setting` permission"
-              (get-setting user 403)
-              (update-setting user 403)
-              (update-settings user 403)
-              (get-setting :crowberto 200)
-              (update-setting :crowberto 204)
-              (update-settings :crowberto 204))
-
-            (testing "succeed if user's group has `setting` permission"
-              (perms/grant-application-permissions! group :setting)
-              (get-setting user 200)
-              (update-setting user 204)
-              (update-settings user 204))))))))
 
 (deftest email-api-test
   (testing "/api/email"
@@ -151,59 +104,6 @@
               (get-manifest user 200)
               (set-slack-settings :crowberto 200)
               (get-manifest :crowberto 200))))))))
-
-(deftest ldap-api-test
-  (testing "/api/ldap"
-    (mt/with-user-in-groups
-      [group {:name "New Group"}
-       user  [group]]
-      (letfn [(update-ldap-settings [user status]
-                (testing (format "update ldap settings with %s user" (mt/user-descriptor user))
-                  (ldap.test/with-ldap-server
-                    (mt/user-http-request user :put status "ldap/settings"
-                                          (ldap-test/ldap-test-details)))))]
-
-        (testing "if `advanced-permissions` is disabled, require admins"
-          (premium-features-test/with-premium-features #{}
-            (update-ldap-settings user 403)
-            (update-ldap-settings :crowberto 200)))
-
-        (testing "if `advanced-permissions` is enabled"
-          (premium-features-test/with-premium-features #{:advanced-permissions}
-            (testing "still fail if user's group doesn't have `setting` permission"
-              (update-ldap-settings user 403)
-              (update-ldap-settings :crowberto 200))
-
-            (testing "succeed if user's group has `setting` permission"
-              (perms/grant-application-permissions! group :setting)
-              (update-ldap-settings user 200)
-              (update-ldap-settings :crowberto 200))))))))
-
-(deftest google-api-test
-  (testing "/api/google"
-    (mt/with-user-in-groups
-      [group {:name "New Group"}
-       user  [group]]
-      (letfn [(update-google-settings [user status]
-                (testing (format "update google settings with %s user" (mt/user-descriptor user))
-                  (mt/user-http-request user :put status "google/settings"
-                                        {:google-auth-client-id "test-client-id.apps.googleusercontent.com"
-                                         :google-auth-enabled true})))]
-        (testing "if `advanced-permissions` is disabled, require admin status"
-          (premium-features-test/with-premium-features #{}
-            (update-google-settings user 403)
-            (update-google-settings :crowberto 200)))
-
-        (testing "if `advanced-permissions` is enabled"
-          (premium-features-test/with-premium-features #{:advanced-permissions}
-            (testing "still fail if user's group doesn't have `setting` permission"
-              (update-google-settings user 403)
-              (update-google-settings :crowberto 200))
-
-            (testing "succeed if user's group has `setting` permission"
-              (perms/grant-application-permissions! group :setting)
-              (update-google-settings user 200)
-              (update-google-settings :crowberto 200))))))))
 
 (deftest geojson-api-test
   (testing "/api/geojson"

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
@@ -30,7 +30,7 @@
            (@#'perms/update-group-permissions! all-users-group-id current-graph)))))))
 
 (defmacro ^:private with-all-users-data-perms
-  "Runs `f` with perms for the All Users group temporarily set to the values in `graph`. Also enables the advanced
+  "Runs `body` with perms for the All Users group temporarily set to the values in `graph`. Also enables the advanced
   permissions feature flag, and clears the (5 second TTL) cache used for Field permissions, for convenience."
   [graph & body]
   `(do-with-all-user-data-perms ~graph (fn [] ~@body)))

--- a/frontend/src/metabase/admin/settings/selectors.js
+++ b/frontend/src/metabase/admin/settings/selectors.js
@@ -228,6 +228,7 @@ const SECTIONS = updateSectionsWithPlugins({
     name: t`Authentication`,
     order: 6,
     settings: [], // added by plugins
+    adminOnly: true,
   },
   maps: {
     name: t`Maps`,

--- a/src/metabase/api/google.clj
+++ b/src/metabase/api/google.clj
@@ -2,7 +2,6 @@
   "/api/google endpoints"
   (:require [compojure.core :refer [PUT]]
             [metabase.api.common :as api]
-            [metabase.api.common.validation :as validation]
             [metabase.integrations.google :as google]
             [metabase.models.setting :as setting]
             [schema.core :as s]
@@ -14,7 +13,7 @@
   {google-auth-client-id                   (s/maybe s/Str)
    google-auth-enabled                     (s/maybe s/Bool)
    google-auth-auto-create-accounts-domain (s/maybe s/Str)}
-  (validation/check-has-application-permission :setting)
+  (api/check-superuser)
   ;; Set google-auth-enabled in a separate step because it requires the client ID to be set first
   (db/transaction
    (setting/set-many! {:google-auth-client-id                   google-auth-client-id

--- a/src/metabase/api/ldap.clj
+++ b/src/metabase/api/ldap.clj
@@ -4,7 +4,6 @@
             [clojure.tools.logging :as log]
             [compojure.core :refer [PUT]]
             [metabase.api.common :as api]
-            [metabase.api.common.validation :as validation]
             [metabase.integrations.ldap :as ldap]
             [metabase.models.setting :as setting :refer [defsetting]]
             [metabase.util.i18n :refer [deferred-tru tru]]
@@ -100,7 +99,7 @@
   "Update LDAP related settings. You must be a superuser or have `setting` permission to do this."
   [:as {settings :body}]
   {settings su/Map}
-  (validation/check-has-application-permission :setting)
+  (api/check-superuser)
   (let [ldap-settings (-> settings
                           (select-keys (keys ldap/mb-settings->ldap-details))
                           (assoc :ldap-port (when-let [^String ldap-port (not-empty (str (:ldap-port settings)))]

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -45,6 +45,7 @@
 
 (defsetting report-timezone
   (deferred-tru "Connection timezone to use when executing queries. Defaults to system timezone.")
+  :visibility :settings-manager
   :setter
   (fn [new-value]
     (setting/set-value-of-type! :string :report-timezone new-value)

--- a/src/metabase/email.clj
+++ b/src/metabase/email.clj
@@ -17,10 +17,12 @@
 
 (defsetting email-from-address
   (deferred-tru "The email address you want to use for the sender of emails.")
-  :default "notifications@metabase.com")
+  :default    "notifications@metabase.com"
+  :visibility :settings-manager)
 
 (defsetting email-from-name
-  (deferred-tru "The name you want to use for the sender of emails."))
+  (deferred-tru "The name you want to use for the sender of emails.")
+  :visibility :settings-manager)
 
 (def ^:private ReplyToAddresses
   (s/maybe [su/Email]))
@@ -31,29 +33,35 @@
 (defsetting email-reply-to
   (deferred-tru "The email address you want the replies to go to, if different from the from address.")
   :type :json
+  :visibility :settings-manager
   :setter (fn [new-value]
             (->> new-value
                  validate-reply-to-addresses
                  (setting/set-value-of-type! :json :email-reply-to))))
 
 (defsetting email-smtp-host
-  (deferred-tru "The address of the SMTP server that handles your emails."))
+  (deferred-tru "The address of the SMTP server that handles your emails.")
+  :visibility :settings-manager)
 
 (defsetting email-smtp-username
-  (deferred-tru "SMTP username."))
+  (deferred-tru "SMTP username.")
+  :visibility :settings-manager)
 
 (defsetting email-smtp-password
   (deferred-tru "SMTP password.")
+  :visibility :settings-manager
   :sensitive? true)
 
 (defsetting email-smtp-port
   (deferred-tru "The port your SMTP server uses for outgoing emails.")
-  :type :integer)
+  :type       :integer
+  :visibility :settings-manager)
 
 (defsetting email-smtp-security
   (deferred-tru "SMTP secure connection protocol. (tls, ssl, starttls, or none)")
-  :type    :keyword
-  :default :none
+  :type       :keyword
+  :default    :none
+  :visibility :settings-manager
   :setter  (fn [new-value]
              (when (some? new-value)
                (assert (#{:tls :ssl :none :starttls} (keyword new-value))))

--- a/src/metabase/integrations/slack.clj
+++ b/src/metabase/integrations/slack.clj
@@ -19,6 +19,7 @@
     (str "Deprecated Slack API token for connecting the Metabase Slack bot. "
          "Please use a new Slack app integration instead."))
   :deprecated "0.42.0"
+  :visibility :settings-manager
   :doc        false)
 
 (defsetting slack-app-token
@@ -30,8 +31,9 @@
   (deferred-tru
     (str "Whether the current Slack app token, if set, is valid. "
          "Set to 'false' if a Slack API request returns an auth error."))
-  :type :boolean
-  :doc  false)
+  :type       :boolean
+  :visibility :settings-manager
+  :doc        false)
 
 (defn process-files-channel-name
   "Converts empty strings to `nil`, and removes leading `#` from the channel name if present."
@@ -58,6 +60,7 @@
 (defsetting slack-files-channel
   (deferred-tru "The name of the channel to which Metabase files should be initially uploaded")
   :default "metabase_files"
+  :visibility :settings-manager
   :setter (fn [channel-name]
             (setting/set-value-of-type! :string :slack-files-channel (process-files-channel-name channel-name))))
 

--- a/src/metabase/models/humanization.clj
+++ b/src/metabase/models/humanization.clj
@@ -110,6 +110,7 @@
   (deferred-tru
     (str "To make table and field names more human-friendly, Metabase will replace dashes and underscores in them "
          "with spaces. We’ll capitalize each word while at it, so ‘last_visited_at’ will become ‘Last Visited At’."))
-  :type    :keyword
-  :default :simple
-  :setter  set-humanization-strategy!)
+  :type       :keyword
+  :default    :simple
+  :visibility :settings-manager
+  :setter     set-humanization-strategy!)

--- a/src/metabase/models/setting.clj
+++ b/src/metabase/models/setting.clj
@@ -373,16 +373,15 @@
   (or (not *enforce-setting-access-checks*)
       (nil? api/*current-user-id*)
       api/*is-superuser?*
-      (not= (:visibility setting) :admin)
-      #_(and
-         ;; Non-admin setting managers can only access settings that are not marked as admin-only
-         (not api/*is-superuser?*)
-         (has-advanced-setting-access?)
-         (not= (:visibility setting) :admin))
-      #_(and
-         ;; Non-admins can only access user-local settings not marked as admin-only
-         (allows-user-local-values? setting)
-         (not= (:visibility setting) :admin))))
+      (and
+       ;; Non-admin setting managers can only access settings that are not marked as admin-only
+       (not api/*is-superuser?*)
+       (has-advanced-setting-access?)
+       (not= (:visibility setting) :admin))
+      (and
+       ;; Non-admins can only access user-local settings not marked as admin-only
+       (allows-user-local-values? setting)
+       (not= (:visibility setting) :admin))))
 
 (defn- munge-setting-name
   "Munge names so that they are legal for bash. Only allows for alphanumeric characters,  underscores, and hyphens."

--- a/src/metabase/models/setting.clj
+++ b/src/metabase/models/setting.clj
@@ -168,7 +168,7 @@
           "Valid Setting :type"))
 
 (def ^:private Visibility
-  (s/enum :public :authenticated :admin :internal))
+  (s/enum :public :authenticated :settings-manager :admin :internal))
 
 (defmulti default-tag-for-type
   "Type tag that will be included in the Setting's metadata, so that the getter function will not cause reflection
@@ -235,7 +235,7 @@
    :sensitive?  s/Bool           ; is this sensitive (never show in plaintext), like a password? (default: false)
    :visibility  Visibility       ; where this setting should be visible (default: :admin)
    :cache?      s/Bool           ; should the getter always fetch this value "fresh" from the DB? (default: false)
-   :deprecated  (s/maybe s/Str)            ; if non-nil, contains the Metabase version in which this setting was deprecated
+   :deprecated  (s/maybe s/Str)  ; if non-nil, contains the Metabase version in which this setting was deprecated
 
    ;; whether this Setting can be Database-local or User-local. See [[metabase.models.setting]] docstring for more info.
    :database-local LocalOption
@@ -373,10 +373,16 @@
   (or (not *enforce-setting-access-checks*)
       (nil? api/*current-user-id*)
       api/*is-superuser?*
-      (has-advanced-setting-access?)
-      (and
-       (allows-user-local-values? setting)
-       (not= (:visibility setting) :admin))))
+      (not= (:visibility setting) :admin)
+      #_(and
+         ;; Non-admin setting managers can only access settings that are not marked as admin-only
+         (not api/*is-superuser?*)
+         (has-advanced-setting-access?)
+         (not= (:visibility setting) :admin))
+      #_(and
+         ;; Non-admins can only access user-local settings not marked as admin-only
+         (allows-user-local-values? setting)
+         (not= (:visibility setting) :admin))))
 
 (defn- munge-setting-name
   "Munge names so that they are legal for bash. Only allows for alphanumeric characters,  underscores, and hyphens."
@@ -905,7 +911,8 @@
 
   ###### `:visibility`
 
-  `:public`, `:authenticated`, `:admin` (default), or `:internal`. Controls where this setting is visible
+  `:public`, `:authenticated`, `:settings-manager`, `:admin` (default), or `:internal`. Controls where this setting is
+  visible. `:settings-manager` refers to non-admins with the 'settings' permission.
 
   ###### `:getter`
 
@@ -1068,7 +1075,10 @@
 
   This is currently used by `GET /api/setting` ([[metabase.api.setting/GET_]]; admin-only; powers the Admin Settings
   page) so all admin-visible Settings should be included. We *do not* want to return env var values, since admins
-  are not allowed to modify them."
+  are not allowed to modify them.
+
+  For settings managers who are not admins, only the subset of settings with the :settings-manager visibility level
+  are returned."
   [& {:as options}]
   ;; ignore Database-local values, but not User-local values
   (binding [*database-local-values* nil]
@@ -1076,6 +1086,8 @@
      []
      (comp (filter (fn [setting]
                      (and (not= (:visibility setting) :internal)
+                          (or api/*is-superuser?*
+                              (not= (:visibility setting) :admin))
                           (not= (:database-local setting) :only))))
            (map #(m/mapply user-facing-info % options)))
      (sort-by :name (vals @registered-settings)))))

--- a/src/metabase/models/setting.clj
+++ b/src/metabase/models/setting.clj
@@ -910,8 +910,18 @@
 
   ###### `:visibility`
 
-  `:public`, `:authenticated`, `:settings-manager`, `:admin` (default), or `:internal`. Controls where this setting is
-  visible. `:settings-manager` refers to non-admins with the 'settings' permission.
+  Controls where this setting is visibile, and who can update it. Possible values are:
+
+    Visibility       | Who Can See It?              | Who Can Update It?
+    ---------------- | ---------------------------- | --------------------
+    :public          | The entire world             | Admins and Settings Managers
+    :authenticated   | Logged-in Users              | Admins and Settings Managers
+    :settings-manager| Admins and Settings Managers | Admins and Settings Managers
+    :admin           | Admins                       | Admins
+    :internal        | Nobody                       | No one (usually for env-var-only settings)
+
+  'Settings Managers' are non-admin users with the 'settings' permission, which gives them access to the Settings page
+  in the Admin Panel.
 
   ###### `:getter`
 

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -213,9 +213,9 @@
 
 (defsetting enable-nested-queries
   (deferred-tru "Allow using a saved question or Model as the source for other queries?")
-  :type    :boolean
-  :default true
-  :visibility :settings-manager)
+  :type       :boolean
+  :default    true
+  :visibility :authenticated)
 
 (defsetting enable-query-caching
   (deferred-tru "Enabling caching will save the results of queries that take a long time to run.")
@@ -409,7 +409,7 @@
   (deferred-tru "Allow users to explore data using X-rays")
   :type       :boolean
   :default    true
-  :visibility :settings-manager)
+  :visibility :authenticated)
 
 (defsetting show-homepage-data
   (deferred-tru

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -66,7 +66,8 @@
 
 (defsetting site-name
   (deferred-tru "The name used for this instance of Metabase.")
-  :default "Metabase")
+  :default    "Metabase"
+  :visibility :settings-manager)
 
 ;; `::uuid-nonce` is a Setting that sets a site-wide random UUID value the first time it is fetched.
 (defmethod setting/get-value-of-type ::uuid-nonce
@@ -214,12 +215,13 @@
   (deferred-tru "Allow using a saved question or Model as the source for other queries?")
   :type    :boolean
   :default true
-  :visibility :authenticated)
+  :visibility :settings-manager)
 
 (defsetting enable-query-caching
   (deferred-tru "Enabling caching will save the results of queries that take a long time to run.")
   :type    :boolean
-  :default false)
+  :default false
+  :visibility :settings-manager)
 
 (defsetting persisted-models-enabled
   (deferred-tru "Allow persisting models into the source database.")
@@ -407,7 +409,7 @@
   (deferred-tru "Allow users to explore data using X-rays")
   :type       :boolean
   :default    true
-  :visibility :authenticated)
+  :visibility :settings-manager)
 
 (defsetting show-homepage-data
   (deferred-tru

--- a/test/metabase/api/setting_test.clj
+++ b/test/metabase/api/setting_test.clj
@@ -1,5 +1,6 @@
 (ns metabase.api.setting-test
   (:require [clojure.test :refer :all]
+            [metabase.api.common.validation :as validation]
             [metabase.models.setting :as setting :refer [defsetting]]
             [metabase.models.setting-test :as models.setting-test]
             [metabase.public-settings.premium-features-test :as premium-features-test]
@@ -25,13 +26,20 @@
   :visibility :public
   :type :integer)
 
+(defsetting test-settings-manager-visibility
+  (deferred-tru "Setting to test the `:settings-manager` visibility level. This only shows up in dev.")
+  :visibility :settings-manager)
+
 ;; ## Helper Fns
 (defn- fetch-test-settings
-  "Fetch all test settings."
-  []
-  (for [setting (mt/user-http-request :crowberto :get 200 "setting")
-        :when   (re-find #"^test-setting-\d$" (name (:key setting)))]
-    setting))
+  "Fetch the provided settings using the API. Settings not present in the response are ignored."
+  ([setting-names]
+   (fetch-test-settings :crowberto setting-names))
+
+  ([user setting-names]
+   (for [setting (mt/user-http-request user :get 200 "setting")
+         :when   (.contains setting-names (keyword (:key setting)))]
+     setting)))
 
 (defn- fetch-setting
   "Fetch a single setting."
@@ -41,9 +49,20 @@
   ([user setting-name status]
    (mt/user-http-request user :get status (format "setting/%s" (name setting-name)))))
 
+(defn- do-with-mocked-settings-manager-access
+  [f]
+  (with-redefs [setting/has-advanced-setting-access?        (constantly true)
+                validation/check-has-application-permission (constantly true)]
+    (f)))
+
+(defmacro ^:private with-mocked-settings-manager-access
+  "Runs `body` with the approrpiate functions redefined to give the current user settings manager permissions."
+  [& body]
+  `(do-with-mocked-settings-manager-access (fn [] ~@body)))
+
 (deftest fetch-setting-test
   (testing "GET /api/setting"
-    (testing "Check that we can fetch all Settings, except `:visiblity :internal` ones"
+    (testing "Check that we can fetch all Settings as an admin, except `:visiblity :internal` ones"
       (models.setting-test/test-setting-1! nil)
       (models.setting-test/test-setting-2! "FANCY")
       (models.setting-test/test-setting-3! "oh hai") ; internal setting that should not be returned
@@ -59,19 +78,35 @@
                :env_name       "MB_TEST_SETTING_2"
                :description    "Test setting - this only shows up in dev (2)"
                :default        "[Default Value]"}]
-             (fetch-test-settings))))
+             (fetch-test-settings [:test-setting-1 :test-setting-2 :test-setting-3]))))
 
-    (testing "Check that non-superusers are denied access"
+    (testing "Check that non-admin setting managers can fetch Settings with `:visibility :settings-manager`"
+      (test-settings-manager-visibility! nil)
+      (with-mocked-settings-manager-access
+        (is (= [{:key "test-settings-manager-visibility",
+                 :value nil,
+                 :is_env_setting false,
+                 :env_name "MB_TEST_SETTINGS_MANAGER_VISIBILITY",
+                 :description "Setting to test the `:settings-manager` visibility level. This only shows up in dev.",
+                 :default nil}]
+               (fetch-test-settings :rasta [:test-setting-1 :test-settings-manager-visibility])))))
+
+    (testing "Check that non-admins are denied access"
       (is (= "You don't have permissions to do that."
              (mt/user-http-request :rasta :get 403 "setting")))))
 
   (testing "GET /api/setting/:key"
-    (testing "Test that we can fetch a single setting"
+    (testing "Test that admins can fetch a single Setting"
       (models.setting-test/test-setting-2! "OK!")
       (is (= "OK!"
              (fetch-setting :test-setting-2 200))))
 
-    (testing "Check that non-superusers cannot fetch a single setting if it is not user-local"
+    (testing "Test that non-admin setting managers can fetch a single Setting if it has `:visibility :settings-manager`."
+      (test-settings-manager-visibility! "OK!")
+      (with-mocked-settings-manager-access
+        (is (= "OK!" (fetch-setting :test-settings-manager-visibility 200)))))
+
+    (testing "Check that non-superusers cannot fetch a single Setting if it is not user-local"
       (is (= "You don't have permissions to do that."
              (fetch-setting :rasta :test-setting-2 403))))
     (testing "non-string values work over the api (#20735)"
@@ -117,6 +152,13 @@
     (is (= "NICE!"
            (fetch-setting :test-setting-1 200))
         "Updated setting should be visible from API endpoint")
+
+    (testing "Check that non-admin setting managers can only update Settings with `:visibility :settings-manager`."
+      (with-mocked-settings-manager-access
+        (mt/user-http-request :rasta :put 204 "setting/test-settings-manager-visibility" {:value "NICE!"})
+        (is (= "NICE!" (fetch-setting :test-settings-manager-visibility 200)))
+
+        (mt/user-http-request :rasta :put 403 "setting/test-setting-1" {:value "Not nice :("})))
 
     (testing "Check non-superuser can't set a Setting that is not user-local"
       (is (= "You don't have permissions to do that."
@@ -179,6 +221,19 @@
              (models.setting-test/test-setting-1)))
       (is (= "DEF"
              (models.setting-test/test-setting-2))))
+
+    (testing "non-admin setting managers should only be able to update multiple settings at once if they have `:visibility :settings-manager`"
+      (with-mocked-settings-manager-access
+       (is (= nil
+              (mt/user-http-request :rasta :put 204 "setting" {:test-settings-manager-visibility "ABC"})))
+       (is (= "ABC"
+              (test-settings-manager-visibility)))
+       (is (= "You don't have permissions to do that."
+              (mt/user-http-request :rasta :put 403 "setting" {:test-settings-manager-visibility "GHI", :test-setting-1 "JKL"})))
+       (is (= "ABC"
+              (test-settings-manager-visibility)))
+       (is (= "ABC"
+              (models.setting-test/test-setting-1)))))
 
     (testing "non-admin should not be able to update multiple settings at once if any of them are not user-local"
       (is (= "You don't have permissions to do that."

--- a/test/metabase/models/setting_test.clj
+++ b/test/metabase/models/setting_test.clj
@@ -578,119 +578,8 @@
     (is (= "Banana Beak"
            (toucan-name)))))
 
-(deftest duplicated-setting-name
-  (testing "can re-register a setting in the same ns (redefining or reloading ns)"
-    (is (defsetting foo (deferred-tru "A testing setting") :visibility :public))
-    (is (defsetting foo (deferred-tru "A testing setting") :visibility :public)))
-  (testing "if attempt to register in a different ns throws an error"
-    (let [current-ns (ns-name *ns*)]
-      (try
-        (ns nested-setting-test
-          (:require [metabase.models.setting :refer [defsetting]]
-                    [metabase.util.i18n :as i18n :refer [deferred-tru]]))
-        (defsetting foo (deferred-tru "A testing setting") :visibility :public)
-        (catch Exception e
-          (is (schema= {:existing-setting
-                        {:description (s/eq (deferred-tru "A testing setting"))
-                         :name        (s/eq :foo)
-                         :munged-name (s/eq "foo")
-                         :type        (s/eq :string)
-                         :sensitive?  (s/eq false)
-                         :tag         (s/eq 'java.lang.String)
-                         :namespace   (s/eq current-ns)
-                         :visibility  (s/eq :public)
-                         s/Keyword s/Any}}
-                       (ex-data e)))
-          (is (= (str "Setting :foo already registered in " current-ns)
-                 (ex-message e))))
-        (finally (in-ns current-ns))))))
 
-(defsetting test-setting-with-question-mark?
-  "Test setting - this only shows up in dev (6)"
-  :visibility :internal)
-
-(deftest munged-setting-name-test
-  (testing "Only valid characters used for environment lookup"
-    (is (nil? (test-setting-with-question-mark?)))
-    ;; note now question mark on the environmental setting
-    (with-redefs [env/env {:mb-test-setting-with-question-mark "resolved"}]
-      (binding [setting/*disable-cache* false]
-        (is (= "resolved" (test-setting-with-question-mark?))))))
-  (testing "Setting a setting that would munge the same throws an error"
-    (is (= {:existing-setting
-            {:name :test-setting-with-question-mark?
-             :munged-name "test-setting-with-question-mark"}
-            :new-setting
-            {:name :test-setting-with-question-mark????
-             :munged-name "test-setting-with-question-mark"}}
-           (m/map-vals #(select-keys % [:name :munged-name])
-                       (try (defsetting test-setting-with-question-mark????
-                              "Test setting - this only shows up in dev (6)"
-                              :visibility :internal)
-                            (catch Exception e (ex-data e)))))))
-  (testing "Munge collision on first definition"
-    (defsetting test-setting-normal
-      "Test setting - this only shows up in dev (6)"
-      :visibility :internal)
-    (is (= {:existing-setting {:name :test-setting-normal, :munged-name "test-setting-normal"},
-            :new-setting {:name :test-setting-normal??, :munged-name "test-setting-normal"}}
-           (m/map-vals #(select-keys % [:name :munged-name])
-                       (try (defsetting test-setting-normal??
-                              "Test setting - this only shows up in dev (6)"
-                              :visibility :internal)
-                            (catch Exception e (ex-data e)))))))
-  (testing "Munge collision on second definition"
-    (defsetting test-setting-normal-1??
-      "Test setting - this only shows up in dev (6)"
-      :visibility :internal)
-    (is (= {:new-setting {:munged-name "test-setting-normal-1", :name :test-setting-normal-1},
-             :existing-setting {:munged-name "test-setting-normal-1", :name :test-setting-normal-1??}}
-           (m/map-vals #(select-keys % [:name :munged-name])
-                       (try (defsetting test-setting-normal-1
-                              "Test setting - this only shows up in dev (6)"
-                              :visibility :internal)
-                            (catch Exception e (ex-data e)))))))
-  (testing "Removes characters not-compliant with shells"
-    (is (= "aa1aa-b2b_cc3c"
-           (#'setting/munge-setting-name "aa1'aa@#?-b2@b_cc'3?c?")))))
-
-(deftest validate-default-value-for-type-test
-  (letfn [(validate [tag default]
-            (@#'setting/validate-default-value-for-type
-             {:tag tag, :default default, :name :a-setting, :type :fake-type}))]
-    (testing "No default value"
-      (is (nil? (validate `String nil))))
-    (testing "No tag"
-      (is (nil? (validate nil "abc"))))
-    (testing "tag is not a symbol or string"
-      (is (thrown-with-msg?
-           AssertionError
-           #"Setting :tag should be a symbol or string, got: \^clojure\.lang\.Keyword :string"
-           (validate :string "Green Friend"))))
-    (doseq [[tag valid-tag?]     {"String"           false
-                                  "java.lang.String" true
-                                  'STRING            false
-                                  `str               false
-                                  `String            true}
-            [value valid-value?] {"Green Friend" true
-                                  :green-friend  false}]
-      (testing (format "Tag = %s (valid = %b)" (pr-str tag) valid-tag?)
-        (testing (format "Value = %s (valid = %b)" (pr-str value) valid-value?)
-          (cond
-            (and valid-tag? valid-value?)
-            (is (nil? (validate tag value)))
-
-            (not valid-tag?)
-            (is (thrown-with-msg?
-                 Exception
-                 #"Cannot resolve :tag .+ to a class"
-                 (validate tag value)))
-
-            (not valid-value?)
-            (is (thrown-with-msg?
-                 Exception
-                 #"Wrong :default type: got \^clojure\.lang\.Keyword :green-friend, but expected a java\.lang\.String"
-                 (validate tag value)))))))))
+;;; ------------------------------------------------- DB-local Settings ------------------------------------------------
 
 (defsetting ^:private test-database-local-only-setting
   "test Setting"
@@ -833,29 +722,8 @@
         (is (= ::not-present
                (f :test-database-local-only-setting-with-default)))))))
 
-(defsetting ^:private test-integer-setting
-  "test Setting"
-  :visibility :internal
-  :type       :integer)
 
-(deftest integer-setting-test
-  (testing "Should be able to set integer setting with a string"
-    (test-integer-setting! "100")
-    (is (= 100
-           (test-integer-setting)))
-    (testing "should be able to set to a negative number (thanks Howon for spotting this)"
-      (test-integer-setting! "-2")
-      (is (= -2
-             (test-integer-setting))))))
-
-(deftest retired-settings-test
-  (testing "Should not be able to define a setting with a retired name"
-    (with-redefs [setting/retired-setting-names #{"retired-setting"}]
-      (try
-        (defsetting retired-setting (deferred-tru "A retired setting name"))
-        (catch Exception e
-          (is (= "Setting name 'retired-setting' is retired; use a different name instead"
-                 (ex-message e))))))))
+;;; ------------------------------------------------- User-local Settings ----------------------------------------------
 
 (defsetting test-user-local-only-setting
   (deferred-tru  "test Setting")
@@ -951,3 +819,144 @@
     (binding [*enabled?* true]
       (is (= "custom" (test-enabled-setting-default)))
       (is (= "custom" (test-enabled-setting-no-default))))))
+
+
+;;; ------------------------------------------------- Misc tests -------------------------------------------------------
+
+(defsetting ^:private test-integer-setting
+  "test Setting"
+  :visibility :internal
+  :type       :integer)
+
+(deftest integer-setting-test
+  (testing "Should be able to set integer setting with a string"
+    (test-integer-setting! "100")
+    (is (= 100
+           (test-integer-setting)))
+    (testing "should be able to set to a negative number (thanks Howon for spotting this)"
+      (test-integer-setting! "-2")
+      (is (= -2
+             (test-integer-setting))))))
+
+(deftest retired-settings-test
+  (testing "Should not be able to define a setting with a retired name"
+    (with-redefs [setting/retired-setting-names #{"retired-setting"}]
+      (try
+        (defsetting retired-setting (deferred-tru "A retired setting name"))
+        (catch Exception e
+          (is (= "Setting name 'retired-setting' is retired; use a different name instead"
+                 (ex-message e))))))))
+
+(deftest duplicated-setting-name
+  (testing "can re-register a setting in the same ns (redefining or reloading ns)"
+    (is (defsetting foo (deferred-tru "A testing setting") :visibility :public))
+    (is (defsetting foo (deferred-tru "A testing setting") :visibility :public)))
+  (testing "if attempt to register in a different ns throws an error"
+    (let [current-ns (ns-name *ns*)]
+      (try
+        (ns nested-setting-test
+          (:require [metabase.models.setting :refer [defsetting]]
+                    [metabase.util.i18n :as i18n :refer [deferred-tru]]))
+        (defsetting foo (deferred-tru "A testing setting") :visibility :public)
+        (catch Exception e
+          (is (schema= {:existing-setting
+                        {:description (s/eq (deferred-tru "A testing setting"))
+                         :name        (s/eq :foo)
+                         :munged-name (s/eq "foo")
+                         :type        (s/eq :string)
+                         :sensitive?  (s/eq false)
+                         :tag         (s/eq 'java.lang.String)
+                         :namespace   (s/eq current-ns)
+                         :visibility  (s/eq :public)
+                         s/Keyword s/Any}}
+                       (ex-data e)))
+          (is (= (str "Setting :foo already registered in " current-ns)
+                 (ex-message e))))
+        (finally (in-ns current-ns))))))
+
+(defsetting test-setting-with-question-mark?
+  "Test setting - this only shows up in dev (6)"
+  :visibility :internal)
+
+(deftest munged-setting-name-test
+  (testing "Only valid characters used for environment lookup"
+    (is (nil? (test-setting-with-question-mark?)))
+    ;; note now question mark on the environmental setting
+    (with-redefs [env/env {:mb-test-setting-with-question-mark "resolved"}]
+      (binding [setting/*disable-cache* false]
+        (is (= "resolved" (test-setting-with-question-mark?))))))
+  (testing "Setting a setting that would munge the same throws an error"
+    (is (= {:existing-setting
+            {:name :test-setting-with-question-mark?
+             :munged-name "test-setting-with-question-mark"}
+            :new-setting
+            {:name :test-setting-with-question-mark????
+             :munged-name "test-setting-with-question-mark"}}
+           (m/map-vals #(select-keys % [:name :munged-name])
+                       (try (defsetting test-setting-with-question-mark????
+                              "Test setting - this only shows up in dev (6)"
+                              :visibility :internal)
+                            (catch Exception e (ex-data e)))))))
+  (testing "Munge collision on first definition"
+    (defsetting test-setting-normal
+      "Test setting - this only shows up in dev (6)"
+      :visibility :internal)
+    (is (= {:existing-setting {:name :test-setting-normal, :munged-name "test-setting-normal"},
+            :new-setting {:name :test-setting-normal??, :munged-name "test-setting-normal"}}
+           (m/map-vals #(select-keys % [:name :munged-name])
+                       (try (defsetting test-setting-normal??
+                              "Test setting - this only shows up in dev (6)"
+                              :visibility :internal)
+                            (catch Exception e (ex-data e)))))))
+  (testing "Munge collision on second definition"
+    (defsetting test-setting-normal-1??
+      "Test setting - this only shows up in dev (6)"
+      :visibility :internal)
+    (is (= {:new-setting {:munged-name "test-setting-normal-1", :name :test-setting-normal-1},
+             :existing-setting {:munged-name "test-setting-normal-1", :name :test-setting-normal-1??}}
+           (m/map-vals #(select-keys % [:name :munged-name])
+                       (try (defsetting test-setting-normal-1
+                              "Test setting - this only shows up in dev (6)"
+                              :visibility :internal)
+                            (catch Exception e (ex-data e)))))))
+  (testing "Removes characters not-compliant with shells"
+    (is (= "aa1aa-b2b_cc3c"
+           (#'setting/munge-setting-name "aa1'aa@#?-b2@b_cc'3?c?")))))
+
+(deftest validate-default-value-for-type-test
+  (letfn [(validate [tag default]
+            (@#'setting/validate-default-value-for-type
+             {:tag tag, :default default, :name :a-setting, :type :fake-type}))]
+    (testing "No default value"
+      (is (nil? (validate `String nil))))
+    (testing "No tag"
+      (is (nil? (validate nil "abc"))))
+    (testing "tag is not a symbol or string"
+      (is (thrown-with-msg?
+           AssertionError
+           #"Setting :tag should be a symbol or string, got: \^clojure\.lang\.Keyword :string"
+           (validate :string "Green Friend"))))
+    (doseq [[tag valid-tag?]     {"String"           false
+                                  "java.lang.String" true
+                                  'STRING            false
+                                  `str               false
+                                  `String            true}
+            [value valid-value?] {"Green Friend" true
+                                  :green-friend  false}]
+      (testing (format "Tag = %s (valid = %b)" (pr-str tag) valid-tag?)
+        (testing (format "Value = %s (valid = %b)" (pr-str value) valid-value?)
+          (cond
+            (and valid-tag? valid-value?)
+            (is (nil? (validate tag value)))
+
+            (not valid-tag?)
+            (is (thrown-with-msg?
+                 Exception
+                 #"Cannot resolve :tag .+ to a class"
+                 (validate tag value)))
+
+            (not valid-value?)
+            (is (thrown-with-msg?
+                 Exception
+                 #"Wrong :default type: got \^clojure\.lang\.Keyword :green-friend, but expected a java\.lang\.String"
+                 (validate tag value)))))))))


### PR DESCRIPTION
Fixes #27089, and by extension https://github.com/metabase/metabase/issues/27056 and https://github.com/metabase/metabase/issues/27055

* Hides the auth settings page from non-admin setting managers
* Adds a `:settings-manager` visibility level to settings, which should be used specifically for settings that non-admin setting managers _should_ have access to read and write. The default will stay `:admin` so that we fail closed, just in case.
* Updates all the necessary settings (at least, that I could find) to have `:settings-manager` visibility.
* New tests and a fair bit of settings test reorganization that felt prudent. Sorry for bloating the PR but I've called those areas out in comments so hopefully it's obvious what's going on.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/27187)
<!-- Reviewable:end -->
