### PR TITLE
Action Forms Refactor 5: Good Housekeeping

### DIFF
--- a/frontend/src/metabase-types/api/action-form-settings.ts
+++ b/frontend/src/metabase-types/api/action-form-settings.ts
@@ -1,27 +1,34 @@
-import type { Validator, FormFieldDefinition } from "metabase-types/forms";
 import type Field from "metabase-lib/metadata/Field";
 import type { ParameterId } from "./parameters";
 
 export type ActionDisplayType = "form" | "button";
 export type FieldType = "string" | "number" | "date" | "category";
 
-export type DateInputType =
-  | "date"
-  | "time"
-  | "datetime"
-  | "monthyear"
-  | "quarteryear";
+export type DateInputType = "date" | "time" | "datetime";
 
-export type InputType =
+// these types are saved in visualization_settings
+export type InputSettingType =
   | DateInputType
   | "string"
   | "text"
   | "number"
-  | "dropdown"
+  | "select"
   | "radio"
-  | "email"
-  | "password"
   | "boolean"
+  | "category";
+
+// these types get passed to the input components
+export type InputComponentType =
+  | "text"
+  | "input" // this will be removed
+  | "textarea"
+  | "number"
+  | "boolean"
+  | "select"
+  | "radio"
+  | "date"
+  | "time"
+  | "datetime-local"
   | "category";
 
 export type Size = "small" | "medium" | "large";
@@ -30,13 +37,14 @@ export type DateRange = [string, string];
 export type NumberRange = [number, number];
 
 export interface FieldSettings {
+  id: string;
   name: string;
   title: string;
   order: number;
   description?: string | null;
   placeholder?: string;
   fieldType: FieldType;
-  inputType: InputType;
+  inputType: InputSettingType;
   required: boolean;
   defaultValue?: string | number;
   hidden: boolean;
@@ -66,9 +74,19 @@ export type ActionFormOption = {
   value: string | number;
 };
 
-export type ActionFormFieldProps = FormFieldDefinition & {
+export type Validator = (value: string) => undefined | string;
+
+export type ActionFormFieldProps = {
+  name: string;
+  title: string;
+  description?: string;
+  placeholder?: string;
+  type: InputComponentType;
+  required?: boolean;
+  validate?: Validator;
   validator?: Validator;
   fieldInstance?: Field;
+  options?: ActionFormOption[];
 };
 
 export type ActionFormProps = {

--- a/frontend/src/metabase/actions/components/ActionCreator/FormCreator/FieldSettingsButtons.tsx
+++ b/frontend/src/metabase/actions/components/ActionCreator/FormCreator/FieldSettingsButtons.tsx
@@ -26,8 +26,7 @@ export function FieldSettingsButtons({
   };
 
   const hasOptions =
-    fieldSettings.inputType === "dropdown" ||
-    fieldSettings.inputType === "radio";
+    fieldSettings.inputType === "select" || fieldSettings.inputType === "radio";
 
   return (
     <FieldSettingsButtonsContainer>

--- a/frontend/src/metabase/actions/components/ActionCreator/FormCreator/FieldSettingsPopover.tsx
+++ b/frontend/src/metabase/actions/components/ActionCreator/FormCreator/FieldSettingsPopover.tsx
@@ -1,7 +1,11 @@
 import React, { useMemo } from "react";
 import { t } from "ttag";
 
-import type { FieldSettings, FieldType, InputType } from "metabase-types/api";
+import type {
+  FieldSettings,
+  FieldType,
+  InputSettingType,
+} from "metabase-types/api";
 
 import Input from "metabase/core/components/Input";
 import Radio from "metabase/core/components/Radio";
@@ -61,7 +65,7 @@ export function FormCreatorPopoverBody({
       inputType: inputTypes[newFieldType][0].value,
     });
 
-  const handleUpdateInputType = (newInputType: InputType) =>
+  const handleUpdateInputType = (newInputType: InputSettingType) =>
     onChange({
       ...fieldSettings,
       inputType: newInputType,
@@ -148,9 +152,9 @@ function InputTypeSelect({
   value,
   onChange,
 }: {
-  value: InputType;
+  value: InputSettingType;
   fieldType: FieldType;
-  onChange: (newInputType: InputType) => void;
+  onChange: (newInputType: InputSettingType) => void;
 }) {
   const inputTypes = useMemo(getInputTypes, []);
 

--- a/frontend/src/metabase/actions/components/ActionCreator/FormCreator/FieldSettingsPopover.unit.spec.tsx
+++ b/frontend/src/metabase/actions/components/ActionCreator/FormCreator/FieldSettingsPopover.unit.spec.tsx
@@ -66,7 +66,7 @@ describe("actions > FormCreator > FieldSettingsPopover", () => {
 
     expect(changeSpy).toHaveBeenCalledWith({
       ...settings,
-      inputType: "dropdown",
+      inputType: "select",
     });
   });
 

--- a/frontend/src/metabase/actions/components/ActionCreator/FormCreator/FormCreator.tsx
+++ b/frontend/src/metabase/actions/components/ActionCreator/FormCreator/FormCreator.tsx
@@ -10,13 +10,13 @@ import type {
 import type { Parameter } from "metabase-types/types/Parameter";
 import type { ActionFormSettings, FieldSettings } from "metabase-types/api";
 
+import { sortActionParams } from "metabase/actions/utils";
 import { addMissingSettings } from "metabase/entities/actions/utils";
 
 import {
   getDefaultFormSettings,
   getDefaultFieldSettings,
   reorderFields,
-  sortActionParams,
   hasNewParams,
 } from "./utils";
 

--- a/frontend/src/metabase/actions/components/ActionCreator/FormCreator/constants.ts
+++ b/frontend/src/metabase/actions/components/ActionCreator/FormCreator/constants.ts
@@ -1,5 +1,5 @@
 import { t } from "ttag";
-import type { FieldType, InputType } from "metabase-types/api";
+import type { FieldType, InputSettingType } from "metabase-types/api";
 
 interface FieldOptionType {
   value: FieldType;
@@ -26,7 +26,7 @@ export const getFieldTypes = (): FieldOptionType[] => [
 ];
 
 interface InputOptionType {
-  value: InputType;
+  value: InputSettingType;
   name: string;
 }
 
@@ -50,7 +50,7 @@ const getTextInputs = (): InputOptionType[] => [
 
 const getSelectInputs = (): InputOptionType[] => [
   {
-    value: "dropdown",
+    value: "select",
     name: t`dropdown`,
   },
   {

--- a/frontend/src/metabase/actions/components/ActionCreator/FormCreator/utils.ts
+++ b/frontend/src/metabase/actions/components/ActionCreator/FormCreator/utils.ts
@@ -20,7 +20,7 @@ import type {
 
 import type { Parameter } from "metabase-types/types/Parameter";
 
-import { isEditableField } from "metabase/actions/utils";
+import { isEditableField, sortActionParams } from "metabase/actions/utils";
 import Field from "metabase-lib/metadata/Field";
 import { TYPE } from "metabase-lib/types/constants";
 
@@ -273,14 +273,6 @@ export const reorderFields = (
 
   return _.indexBy(fieldsWithUpdatedOrderProperty, "id");
 };
-
-export const sortActionParams =
-  (formSettings: ActionFormSettings) => (a: Parameter, b: Parameter) => {
-    const aOrder = formSettings.fields[a.id]?.order ?? 0;
-    const bOrder = formSettings.fields[b.id]?.order ?? 0;
-
-    return aOrder - bOrder;
-  };
 
 export const hasNewParams = (
   params: Parameter[],

--- a/frontend/src/metabase/actions/components/ActionCreator/FormCreator/utils.ts
+++ b/frontend/src/metabase/actions/components/ActionCreator/FormCreator/utils.ts
@@ -15,7 +15,8 @@ import type {
   ActionFormOption,
   ActionFormProps,
   ActionFormFieldProps,
-  InputType,
+  InputSettingType,
+  InputComponentType,
 } from "metabase-types/api";
 
 import type { Parameter } from "metabase-types/types/Parameter";
@@ -44,6 +45,7 @@ const getOptionsFromArray = (
 export const getDefaultFieldSettings = (
   overrides: Partial<FieldSettings> = {},
 ): FieldSettings => ({
+  id: "",
   name: "",
   title: "",
   description: "",
@@ -63,7 +65,7 @@ const getSampleOptions = () => [
   { name: t`Option Three`, value: 3 },
 ];
 
-type FieldPropTypeMap = Record<InputType, string>;
+type FieldPropTypeMap = Record<InputSettingType, InputComponentType>;
 
 const fieldPropsTypeMap: FieldPropTypeMap = {
   string: "input",
@@ -71,19 +73,15 @@ const fieldPropsTypeMap: FieldPropTypeMap = {
   date: "date",
   datetime: "datetime-local",
   time: "time",
-  monthyear: "date",
-  quarteryear: "date",
-  email: "email",
-  password: "password",
-  number: "integer", // this input type is badly named, it works for floats too
+  number: "number",
   boolean: "boolean",
-  category: "categoryPillOrSearch",
-  dropdown: "select",
+  category: "category",
+  select: "select",
   radio: "radio",
 };
 
 const inputTypeHasOptions = (fieldSettings: FieldSettings) =>
-  ["dropdown", "radio"].includes(fieldSettings.inputType);
+  ["select", "radio"].includes(fieldSettings.inputType);
 
 export const getFormField = (
   parameter: Parameter,
@@ -190,6 +188,7 @@ export const generateFieldSettingsFromParameters = (
     const displayName = field?.displayName?.() ?? name;
 
     fieldSettings[param.id] = getDefaultFieldSettings({
+      id: param.id,
       name,
       title: displayName,
       placeholder: displayName,
@@ -230,9 +229,6 @@ export const getInputType = (param: Parameter, field?: Field) => {
   }
   if (field.isDate()) {
     return field.isDateWithoutTime() ? "date" : "datetime";
-  }
-  if (field.semantic_type === TYPE.Email) {
-    return "email";
   }
   if (
     field.semantic_type === TYPE.Description ||

--- a/frontend/src/metabase/actions/components/ActionCreator/FormCreator/utils.unit.spec.ts
+++ b/frontend/src/metabase/actions/components/ActionCreator/FormCreator/utils.unit.spec.ts
@@ -253,13 +253,6 @@ describe("actions > ActionCreator > FormCreator > utils", () => {
       });
     });
 
-    it('should return "email" for email', () => {
-      const field = createField({
-        semantic_type: "type/Email",
-      });
-      expect(getInputType(createParameter(), field)).toEqual("email");
-    });
-
     it('should return "category" for categories', () => {
       const field = createField({
         semantic_type: "type/Category",

--- a/frontend/src/metabase/actions/components/ActionCreator/FormCreator/utils.unit.spec.ts
+++ b/frontend/src/metabase/actions/components/ActionCreator/FormCreator/utils.unit.spec.ts
@@ -4,7 +4,6 @@ import Field from "metabase-lib/metadata/Field";
 import {
   reorderFields,
   hasNewParams,
-  sortActionParams,
   getDefaultFieldSettings,
   getDefaultFormSettings,
   generateFieldSettingsFromParameters,
@@ -288,37 +287,6 @@ describe("actions > ActionCreator > FormCreator > utils", () => {
       expect(reorderedFields.a.order).toEqual(1);
       expect(reorderedFields.b.order).toEqual(0);
       expect(reorderedFields.c.order).toEqual(2);
-    });
-  });
-
-  describe("sortActionParams", () => {
-    const formSettings = getDefaultFormSettings({
-      fields: {
-        a: getDefaultFieldSettings({ order: 0 }),
-        b: getDefaultFieldSettings({ order: 1 }),
-        c: getDefaultFieldSettings({ order: 2 }),
-      },
-    });
-
-    it("should return a sorting function", () => {
-      const sortFn = sortActionParams(formSettings);
-      expect(typeof sortFn).toBe("function");
-    });
-
-    it("should sort params by the settings-defined field order", () => {
-      const sortFn = sortActionParams(formSettings);
-
-      const params = [
-        createParameter({ id: "c" }),
-        createParameter({ id: "a" }),
-        createParameter({ id: "b" }),
-      ];
-
-      const sortedParams = params.sort(sortFn);
-
-      expect(sortedParams[0].id).toEqual("a");
-      expect(sortedParams[1].id).toEqual("b");
-      expect(sortedParams[2].id).toEqual("c");
     });
   });
 

--- a/frontend/src/metabase/actions/containers/ActionParametersInputForm/ActionParametersInputForm.tsx
+++ b/frontend/src/metabase/actions/containers/ActionParametersInputForm/ActionParametersInputForm.tsx
@@ -96,8 +96,8 @@ function ActionParametersInputForm({
   );
 
   const initialValues = useMemo(
-    () => getInitialValues(form, prefetchValues),
-    [form, prefetchValues],
+    () => getInitialValues(fieldSettings, prefetchValues),
+    [fieldSettings, prefetchValues],
   );
 
   const handleSubmit = useCallback(

--- a/frontend/src/metabase/actions/containers/ActionParametersInputForm/utils.ts
+++ b/frontend/src/metabase/actions/containers/ActionParametersInputForm/utils.ts
@@ -3,8 +3,10 @@ import { isEmpty } from "metabase/lib/validate";
 
 import type {
   FieldSettings,
+  InputSettingType,
   ParametersForActionExecution,
   ActionFormProps,
+  FieldSettingsMap,
 } from "metabase-types/api";
 
 // set user-defined default values for any non-required empty parameters
@@ -55,13 +57,13 @@ export const getChangedValues = (
 
 export const formatValue = (
   value: string | number | null,
-  inputType?: string,
+  inputType?: InputSettingType,
 ) => {
   if (!isEmpty(value)) {
     if (inputType === "date" && moment(value).isValid()) {
       return moment(value).utc(false).format("YYYY-MM-DD");
     }
-    if (inputType === "datetime-local" && moment(value).isValid()) {
+    if (inputType === "datetime" && moment(value).isValid()) {
       return moment(value).utc(false).format("YYYY-MM-DDTHH:mm:ss");
     }
     if (inputType === "time") {
@@ -71,15 +73,15 @@ export const formatValue = (
   return value;
 };
 
-// maps intial values, if any, into an intialValues map
+// maps initial values, if any, into an initialValues map
 export const getInitialValues = (
-  form: ActionFormProps,
+  fieldSettings: FieldSettingsMap,
   prefetchValues: ParametersForActionExecution,
 ) => {
   return Object.fromEntries(
-    form.fields.map(field => [
-      field.name,
-      formatValue(prefetchValues[field.name], field.type),
+    Object.values(fieldSettings).map(field => [
+      field.id,
+      formatValue(prefetchValues[field.id], field.inputType),
     ]),
   );
 };

--- a/frontend/src/metabase/actions/containers/ActionParametersInputForm/utils.unit.spec.ts
+++ b/frontend/src/metabase/actions/containers/ActionParametersInputForm/utils.unit.spec.ts
@@ -137,7 +137,7 @@ describe("actions > containers > ActionParametersInputForm > utils", () => {
     });
 
     it("formats datetimes", () => {
-      const result = formatValue("2020-05-01T05:00:00Z", "datetime-local");
+      const result = formatValue("2020-05-01T05:00:00Z", "datetime");
       expect(result).toEqual("2020-05-01T05:00:00");
     });
   });

--- a/frontend/src/metabase/actions/utils.ts
+++ b/frontend/src/metabase/actions/utils.ts
@@ -1,6 +1,7 @@
 import type {
   Database as IDatabase,
   WritebackAction,
+  ActionFormSettings,
 } from "metabase-types/api";
 import type { Parameter } from "metabase-types/types/Parameter";
 
@@ -67,3 +68,11 @@ export const shouldPrefetchValues = (action: WritebackAction) => {
   // for custom actions
   return action.type === "implicit" && action.kind === "row/update";
 };
+
+export const sortActionParams =
+  (formSettings: ActionFormSettings) => (a: Parameter, b: Parameter) => {
+    const aOrder = formSettings.fields[a.id]?.order ?? 0;
+    const bOrder = formSettings.fields[b.id]?.order ?? 0;
+
+    return aOrder - bOrder;
+  };

--- a/frontend/src/metabase/actions/utils.unit.spec.ts
+++ b/frontend/src/metabase/actions/utils.unit.spec.ts
@@ -1,0 +1,45 @@
+import {
+  getDefaultFieldSettings,
+  getDefaultFormSettings,
+} from "metabase/actions/components/ActionCreator/FormCreator";
+import { sortActionParams } from "./utils";
+
+const createParameter = (options?: any) => {
+  return {
+    id: "test_parameter",
+    name: "Test Parameter",
+    type: "type/Text",
+    ...options,
+  };
+};
+
+describe("sortActionParams", () => {
+  const formSettings = getDefaultFormSettings({
+    fields: {
+      a: getDefaultFieldSettings({ order: 0 }),
+      b: getDefaultFieldSettings({ order: 1 }),
+      c: getDefaultFieldSettings({ order: 2 }),
+    },
+  });
+
+  it("should return a sorting function", () => {
+    const sortFn = sortActionParams(formSettings);
+    expect(typeof sortFn).toBe("function");
+  });
+
+  it("should sort params by the settings-defined field order", () => {
+    const sortFn = sortActionParams(formSettings);
+
+    const params = [
+      createParameter({ id: "c" }),
+      createParameter({ id: "a" }),
+      createParameter({ id: "b" }),
+    ];
+
+    const sortedParams = params.sort(sortFn);
+
+    expect(sortedParams[0].id).toEqual("a");
+    expect(sortedParams[1].id).toEqual("b");
+    expect(sortedParams[2].id).toEqual("c");
+  });
+});

--- a/frontend/src/metabase/components/form/FormWidget.jsx
+++ b/frontend/src/metabase/components/form/FormWidget.jsx
@@ -34,13 +34,14 @@ const WIDGETS = {
   section: FormSectionWidget,
   select: FormSelectWidget,
   integer: FormNumericInputWidget,
+  number: FormNumericInputWidget,
   boolean: FormBooleanWidget,
   collection: FormCollectionWidget,
   snippetCollection: FormSnippetCollectionWidget,
   hidden: FormHiddenWidget,
   textFile: FormTextFileWidget,
   model: FormModelWidget,
-  categoryPillOrSearch: CategoryFieldPicker,
+  category: CategoryFieldPicker,
 };
 
 export function getWidgetComponent(formField) {

--- a/frontend/src/metabase/entities/actions/utils.ts
+++ b/frontend/src/metabase/entities/actions/utils.ts
@@ -5,7 +5,7 @@ import { getDefaultFieldSettings } from "metabase/actions/components/ActionCreat
 import type {
   ActionFormSettings,
   FieldType,
-  InputType,
+  InputSettingType,
   ParameterType,
 } from "metabase-types/api";
 import type { Parameter as ParameterObject } from "metabase-types/types/Parameter";
@@ -50,7 +50,7 @@ export const addMissingSettings = (
     fields: {
       ...settings.fields,
       ...Object.fromEntries(
-        missingIds.map(id => [id, getDefaultFieldSettings()]),
+        missingIds.map(id => [id, getDefaultFieldSettings({ id })]),
       ),
     },
   };
@@ -58,7 +58,7 @@ export const addMissingSettings = (
 
 const getParameterTypeFromFieldSettings = (
   fieldType: FieldType,
-  inputType: InputType,
+  inputType: InputSettingType,
 ): ParameterType => {
   if (fieldType === "date") {
     return dateTypeToParameterTypeMap[inputType] ?? "date/single";


### PR DESCRIPTION
partly resolves https://github.com/metabase/metabase/issues/26724

## Description

- moves `sortActionParams` function (and its tests) from FormCreator utils to the top level actions utils file, since it is used by multiple components outside the FormCreator
- updates a few action forms types
  - updates input types to reflect those types that are currently supported by the action creator, rather than our forms framework (eg, removes email, password)
  - renames InputType to `InputSettingsType` and adds `InputComponentType` to make the difference between them explicit and enforceable by typescript
  - renames "dropdown" to "select" to make more sense
  - adds a parameter ID property to action form field settings that makes mapping easier
  - removes the deprecated `FormFieldDefinition` type as a dependency from the `ActionFormFieldProps` type

There should be no functional changes
