### PR TITLE
Relieve db pressure on api/health check

### DIFF
--- a/src/metabase/db/connection_pool_setup.clj
+++ b/src/metabase/db/connection_pool_setup.clj
@@ -3,7 +3,6 @@
   (:require [java-time :as t]
             [metabase.config :as config]
             [metabase.connection-pool :as connection-pool]
-            [metabase.plugins.classloader :as classloader]
             [schema.core :as s])
   (:import [com.mchange.v2.c3p0 ConnectionCustomizer PoolBackedDataSource]))
 
@@ -30,7 +29,7 @@
 (let [field (doto (.getDeclaredField com.mchange.v2.c3p0.C3P0Registry "classNamesToConnectionCustomizers")
               (.setAccessible true))]
 
-  (.put (.get field com.mchange.v2.c3p0.C3P0Registry)
+  (.put ^java.util.HashMap (.get field com.mchange.v2.c3p0.C3P0Registry)
         (.getName CheckinTracker) (->CheckinTracker)))
 
 (def ^:private application-db-connection-pool-props
@@ -55,7 +54,6 @@
     data-source
     (let [ds-name    (format "metabase-%s-app-db" (name db-type))
           pool-props (assoc application-db-connection-pool-props "dataSourceName" ds-name)]
-      (classloader/the-classloader)
       (com.mchange.v2.c3p0.DataSources/pooledDataSource
        data-source
        (connection-pool/map->properties pool-props)))))

--- a/src/metabase/db/connection_pool_setup.clj
+++ b/src/metabase/db/connection_pool_setup.clj
@@ -8,14 +8,14 @@
 
 (def ^:private latest-checkin (atom nil))
 
-(def ^:private recent-window-seconds 15)
+(def ^:private ^java.time.Duration recent-window-duration (t/seconds 15))
 
 (defn recent-activity?
   "Returns true if there has been recent activity. Define recent activity as an application db connection checked in
   within 15 seconds. Check-in means a query succeeded and the db connection is no longer needed."
   []
   (when-let [activity @latest-checkin]
-    (t/after? activity (t/minus (t/offset-date-time) (t/seconds recent-window-seconds)))))
+    (t/after? activity (t/minus (t/offset-date-time) recent-window-duration))))
 
 (defrecord CheckinTracker []
   ConnectionCustomizer

--- a/src/metabase/db/connection_pool_setup.clj
+++ b/src/metabase/db/connection_pool_setup.clj
@@ -35,7 +35,7 @@
   Clojure defined code is in memory in a dynamic class loader not available to c3p0's use of Class/forName. Luckily it
   looks up the instances in a cache which I pre-seed with out impl here. Issue for better access here:
   https://github.com/swaldman/c3p0/issues/166"
-  [klass]
+  [^Class klass]
   (let [field (doto (.getDeclaredField com.mchange.v2.c3p0.C3P0Registry "classNamesToConnectionCustomizers")
                 (.setAccessible true))]
 

--- a/src/metabase/db/connection_pool_setup.clj
+++ b/src/metabase/db/connection_pool_setup.clj
@@ -22,10 +22,14 @@
   (onAcquire [_ _connection _identity-token])
   (onCheckIn [_ _connection _identity-token]
     (reset! latest-checkin (t/offset-date-time)))
-  (onCheckOut [_ _connection _identity-token]
-    (reset! latest-checkin (t/offset-date-time)))
+  (onCheckOut [_ _connection _identity-token])
   (onDestroy [_ _connection _identity-token]))
 
+;; c3p0 allows for hooking into lifecycles with its interface
+;; ConnectionCustomizer. https://www.mchange.com/projects/c3p0/apidocs/com/mchange/v2/c3p0/ConnectionCustomizer.html. But
+;; Clojure defined code is in memory in a dynamic class loader not available to c3p0's use of Class/forName. Luckily
+;; it looks up the instances in a cache which I pre-seed with out impl here. Issue for better access here:
+;; https://github.com/swaldman/c3p0/issues/166
 (let [field (doto (.getDeclaredField com.mchange.v2.c3p0.C3P0Registry "classNamesToConnectionCustomizers")
               (.setAccessible true))]
 

--- a/src/metabase/server/routes.clj
+++ b/src/metabase/server/routes.clj
@@ -8,6 +8,7 @@
             [metabase.api.routes :as api]
             [metabase.core.initialization-status :as init-status]
             [metabase.db.connection :as mdb.connection]
+            [metabase.db.connection-pool-setup :as mdb.connection-pool-setup]
             [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
             [metabase.plugins.classloader :as classloader]
             [metabase.public-settings :as public-settings]
@@ -49,7 +50,8 @@
   ;; ^/api/health -> Health Check Endpoint
   (GET "/api/health" []
        (if (init-status/complete?)
-         (try (if (sql-jdbc.conn/can-connect-with-spec? {:datasource (mdb.connection/data-source)})
+         (try (if (or (mdb.connection-pool-setup/recent-activity?)
+                      (sql-jdbc.conn/can-connect-with-spec? {:datasource (mdb.connection/data-source)}))
                 {:status 200, :body {:status "ok"}}
                 {:status 503 :body {:status "Unable to get app-db connection"}})
               (catch Exception e

--- a/test/metabase/db/connection_pool_setup_test.clj
+++ b/test/metabase/db/connection_pool_setup_test.clj
@@ -44,6 +44,7 @@
   (testing "db activity resets counter"
     (reset! (var-get #'mdb.connection-pool-setup/latest-checkin) nil)
     (db/count Database) ;; trigger db access which should reset the latest checkin
+    (db/count Database) ;; twice just to play nice if the customizer happens off thread
     (let [recent-checkin (deref (var-get #'mdb.connection-pool-setup/latest-checkin))]
       (is (some? recent-checkin)
           "Database activity did not reset latest-checkin")


### PR DESCRIPTION
https://github.com/metabase/metabase/issues/26266

Servers under heavy load can be slow to respond to the api/health check. This can lead to k8s killing healthy instances happily humming along serving requests.

One idea floated was to use QoSFilters
https://www.eclipse.org/jetty/javadoc/jetty-9/org/eclipse/jetty/servlets/QoSFilter.html to prioritize those requests in front of others. But I suspect this might not be our bottleneck.

Our health endpoint was updated to see if it could acquire an endpoint when we were dealing with connection pool issues. We were reporting the instance was healthy once it has finished the init process, but would report healthy if 60/15 app-db connections were used and no actual queries could complete.

The remedy was adding
`(sql-jdbc.conn/can-connect-with-spec? {:datasource (mdb.connection/data-source)})` to the endpoint. But now to get information about the health of the system we have to wait in the queue to get a db connection.

The hope is that this change which monitors for recent db checkins (query success) and checkouts (query begun) can be a proxy for db activity without having to wait for a connection and hit the db ourselves.

Some simple and crude benchmarking:
- use `siege` to hit `api/database/<app-db>/sync_schema`
- in a separate tab, use `siege` to hit `api/health`

Three trials with unconditional db access and conditional db access (look for recent activity set by the new `ConnectionCustomizer`).

One siege client is synching the app-db's schema with 80 clients each sending 60 requests. the other has 1 client sending 60 requests to api/health.

```
Run             |  Elapsed Time | max tx  | tx rate
 before change  |    7.16s      |  0.79s  |  8.38 tx/s
 before change  |   23.91s      |  1.44s  |  2.51 tx/s
 before change  |   13.00s      |  0.50s  |  4.62 tx/s
----------------------------------------------------
 after change   |    4.46s      |  0.27s  |  13.45 tx/s
 after change   |    5.81s      |  0.61s  |  10.33 tx/s
 after change   |    4.54s      |  0.44s  |  13.22 tx/s
```

Full(er) results below:

```
Unconditional db access
=======================

siege -c80 -r 40 "http://localhost:3000/api/database/2/sync_schema POST" -H "Cookie: $SESSION"

siege -c 1 -r 60 "http://localhost:3000/api/health"

Elapsed time:		        7.16 secs
Response time:		        0.12 secs
Transaction rate:	        8.38 trans/sec
Longest transaction:	        0.79
Shortest transaction:	        0.01

Elapsed time:		       23.91 secs
Response time:		        0.40 secs
Transaction rate:	        2.51 trans/sec
Longest transaction:	        1.44
Shortest transaction:	        0.02

Elapsed time:		       13.00 secs
Response time:		        0.22 secs
Transaction rate:	        4.62 trans/sec
Longest transaction:	        0.50
Shortest transaction:	        0.06

Conditional db access
==============================================================

Elapsed time:		        4.46 secs
Response time:		        0.07 secs
Transaction rate:	       13.45 trans/sec
Longest transaction:	        0.27
Shortest transaction:	        0.01

Elapsed time:		        5.81 secs
Response time:		        0.10 secs
Transaction rate:	       10.33 trans/sec
Longest transaction:	        0.61
Shortest transaction:	        0.00

Elapsed time:		        4.54 secs
Response time:		        0.08 secs
Transaction rate:	       13.22 trans/sec
Longest transaction:	        0.44
Shortest transaction:	        0.01
```


I'm not wild that we have to use reflection to add our connection customizer to c3p0. I've got an issue open at https://github.com/swaldman/c3p0/issues/166 to see if that can be made better.

I tried several ways to get our class on c3p0's classpath.
- `(classloader/the-classloader)` doesn't work because the class is looked up from a thread launched by c3p0 which has the application classloader and not clojure's dynamic one. We are not in control of the creation of this thread so i'm not sure how we could swap out its classloader
- we could make a java class and compile it and put it on our classpath. presumably c3p0 would see this. but this would bring us back to the world of having a prep step and we don't want to deal with that if we don't have to
- trying to figure out other classloader shenanigans but ultimately to no avail.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/27192)
<!-- Reviewable:end -->
