### PR TITLE
Try `dorny/test-reporter`

### DIFF
--- a/.github/actions/test-driver/action.yml
+++ b/.github/actions/test-driver/action.yml
@@ -25,3 +25,4 @@ runs:
       with:
         path: 'target/junit/**/*_test.xml'
         name: JUnit Test Report ${{ inputs.junit-name }}
+        reporter: java-junit

--- a/.github/actions/test-driver/action.yml
+++ b/.github/actions/test-driver/action.yml
@@ -20,8 +20,8 @@ runs:
       run: clojure -X:dev:ci:ee:ee-dev:drivers:drivers-dev:test ${{ inputs.test-args }}
       shell: bash
     - name: Publish Test Report (JUnit)
-      uses: mikepenz/action-junit-report@v3
+      uses: dorny/test-reporter@v1
       if: always()
       with:
-        report_paths: 'target/junit/**/*_test.xml'
-        check_name: JUnit Test Report ${{ inputs.junit-name }}
+        path: 'target/junit/**/*_test.xml'
+        name: JUnit Test Report ${{ inputs.junit-name }}

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -107,11 +107,12 @@ jobs:
       run: clojure -X:dev:ci:test:${{ matrix.edition }}:${{ matrix.edition }}-dev
 
     - name: Publish Test Report (JUnit)
-      uses: mikepenz/action-junit-report@v3
+      uses: dorny/test-reporter@v1
       if: always()
       with:
-        report_paths: 'target/junit/**/*_test.xml'
-        check_name: JUnit Test Report be-tests-java-${{ matrix.java-version }}-${{ matrix.edition }}
+        path: 'target/junit/**/*_test.xml'
+        name: JUnit Test Report be-tests-java-${{ matrix.java-version }}-${{ matrix.edition }}
+        reporter: java-junit
 
   # checks that all the namespaces we actually ship can be compiled, without any dependencies that we don't ship (such
   # as `:dev` dependencies). See #27009 for more context.


### PR DESCRIPTION
This PR replaces `mikepenz/action-junit-report@v3` with `dorny/test-reporter@v1` that provides more legible HTML report.

Example of the HTML report with passing tests: https://github.com/metabase/metabase/runs/10061123088
Example of the HTML report with failing tests: https://github.com/metabase/metabase/runs/10061574245