### PR TITLE
datetime-diff function for Spark SQL

### DIFF
--- a/modules/drivers/sparksql/src/metabase/driver/hive_like.clj
+++ b/modules/drivers/sparksql/src/metabase/driver/hive_like.clj
@@ -165,7 +165,7 @@
 
 (defmethod sql.qp/datetime-diff [:hive-like :quarter]
   [driver _unit x y]
-  (hsql/call :div (sql.qp/datetime-diff driver :month x y) 3.0))
+  (hsql/call :div (sql.qp/datetime-diff driver :month x y) 3))
 
 (defmethod sql.qp/datetime-diff [:hive-like :month]
   [_driver _unit x y]

--- a/modules/drivers/sparksql/test/metabase/test/data/sparksql.clj
+++ b/modules/drivers/sparksql/test/metabase/test/data/sparksql.clj
@@ -23,6 +23,7 @@
 (defmethod driver/supports? [:sparksql :foreign-keys] [_ _] (not config/is-test?))
 
 (defmethod tx/supports-time-type? :sparksql [_driver] false)
+(defmethod tx/supports-timestamptz-type? :sparksql [_driver] false)
 
 (doseq [[base-type database-type] {:type/BigInteger "BIGINT"
                                    :type/Boolean    "BOOLEAN"


### PR DESCRIPTION
Adds support for the datetime-diff function for Spark SQL.

Epic: https://github.com/metabase/metabase/issues/26999

Original datetime-diff PR: https://github.com/metabase/metabase/pull/25722

The tests are in the "Datetime diff tests" block here https://github.com/metabase/metabase/blob/2eb0f03a10efd5a4a77260a85e3fa0ee06fdcf6b/test/metabase/query_processor_test/date_time_zone_functions_test.clj#L701

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/27197)
<!-- Reviewable:end -->
