### PR TITLE
Build the CLJS before type checking the frontend code

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -61,6 +61,8 @@ jobs:
     - uses: actions/checkout@v3
     - name: Prepare front-end environment
       uses: ./.github/actions/prepare-frontend
+    - run: yarn build-quick:cljs
+      name: Compile CLJS
     - run: yarn type-check
       name: Check types
 


### PR DESCRIPTION
This was using the CLJS code at master, so type-checking fails if you
add new CLJS functions and use them from CLJS in the same PR.

