### PR TITLE
Revert "🤖 backported "datetime-diff function for redshift ""

### DIFF
--- a/modules/drivers/redshift/src/metabase/driver/redshift.clj
+++ b/modules/drivers/redshift/src/metabase/driver/redshift.clj
@@ -101,6 +101,15 @@
   (or (database-type->base-type column-type)
       ((get-method sql-jdbc.sync/database-type->base-type :postgres) driver column-type)))
 
+(defmethod driver/database-supports? [:redshift :datetime-diff]
+  [_driver _feat _db]
+  ;; postgres uses `date_part` on an interval or a call to `age` to get datediffs. It seems redshift does not have
+  ;; this and errors with:
+  ;; > ERROR: function pg_catalog.pgdate_part("unknown", interval) does not exist
+  ;; It offers a datediff function that tracks number of boundaries, which could be used to implement the correct behaviour,
+  ;; similar to bigquery.
+  false)
+
 (defmethod sql.qp/add-interval-honeysql-form :redshift
   [_ hsql-form amount unit]
   (let [hsql-form (hx/->timestamp hsql-form)]
@@ -192,59 +201,6 @@
   (->> args
        (map (partial sql.qp/->honeysql driver))
        (reduce (partial hsql/call :concat))))
-
-(defn- extract [unit temporal]
-  (hsql/call :extract (format "'%s'" (name unit)) temporal))
-
-(defmethod sql.qp/->honeysql [:redshift :datetime-diff]
-  ;; postgres uses `extract` around a call to `age` to calculate datediffs. 
-  ;; redshift doesn't have `age`, so we have to use `extract` instead.
-  [driver [_ x y unit]]
-  (let [x (hx/->timestamp (sql.qp/->honeysql driver x))
-        y (hx/->timestamp (sql.qp/->honeysql driver y))]
-    (case unit
-      :year
-      (let [positive-diff (fn [a b] ; precondition: a <= b
-                            (hx/-
-                             (hx/- (extract :year b) (extract :year a))
-                             ;; decrement if a is later than b in the year calendar
-                             (hx/cast
-                              :integer
-                              (hsql/call
-                               :or
-                               (hsql/call :> (extract :month a) (extract :month b))
-                               (hsql/call
-                                :and
-                                (hsql/call := (extract :month a) (extract :month b))
-                                (hsql/call :> (extract :day a) (extract :day b)))))))]
-        (hsql/call :case (hsql/call :<= x y) (positive-diff x y) :else (hx/* -1 (positive-diff y x))))
-
-      :month
-      (let [positive-diff (fn [a b] ; precondition: a <= b
-                            (hx/-
-                             (hsql/call :datediff (hsql/raw (name unit)) a b)
-                             (hx/cast :integer (hsql/call :> (extract :day a) (extract :day b)))))]
-        (hsql/call :case (hsql/call :<= x y) (positive-diff x y) :else (hx/* -1 (positive-diff y x))))
-
-      :week
-      (let [positive-diff (fn [a b]
-                            (hx/cast
-                             :integer
-                             (hx/floor
-                              (hx// (hsql/call :datediff (hsql/raw "day") a b) 7))))]
-        (hsql/call :case (hsql/call :<= x y) (positive-diff x y) :else (hx/* -1 (positive-diff y x))))
-
-      :day
-      (hsql/call :datediff (hsql/raw (name unit)) x y)
-
-      (:hour :minute :second)
-      (let [positive-diff (fn [a b]
-                            (hx/cast
-                             :integer
-                             (hx/floor
-                              (hx// (hx/cast :float (hsql/call :datediff (hsql/raw "millisecond") a b)) ; datediff returns integer, so cast to float
-                                    (case unit :hour 3600000 :minute 60000 :second 1000)))))]
-        (hsql/call :case (hsql/call :<= x y) (positive-diff x y) :else (hx/* -1 (positive-diff y x)))))))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                         metabase.driver.sql-jdbc impls                                         |


### PR DESCRIPTION
Reverts metabase/metabase#27067. Backporting this was my mistake. Point releases are for bug and security fixes.
See this comment for more context https://github.com/metabase/metabase/pull/27074#pullrequestreview-1216551945