### PR TITLE
Revert "Manual backport for datetime-diff function for vertica #26816"

### DIFF
--- a/modules/drivers/vertica/src/metabase/driver/vertica.clj
+++ b/modules/drivers/vertica/src/metabase/driver/vertica.clj
@@ -15,11 +15,10 @@
             [metabase.driver.sql.query-processor :as sql.qp]
             [metabase.driver.sql.query-processor.empty-string-is-null :as sql.qp.empty-string-is-null]
             [metabase.driver.sql.util :as sql.u]
-            [metabase.query-processor.error-type :as qp.error-type]
             [metabase.query-processor.timezone :as qp.timezone]
             [metabase.util.date-2 :as u.date]
             [metabase.util.honeysql-extensions :as hx]
-            [metabase.util.i18n :refer [trs tru]])
+            [metabase.util.i18n :refer [trs]])
   (:import [java.sql ResultSet ResultSetMetaData Types]))
 
 (driver/register! :vertica, :parent #{:sql-jdbc
@@ -31,8 +30,6 @@
 (defmethod driver/database-supports? [:vertica :convert-timezone]
   [_driver _feature _database]
   true)
-
-(defmethod driver/database-supports? [:vertica :datetime-diff] [_ _ _] true)
 
 (defmethod driver/db-start-of-week :vertica
   [_]
@@ -86,7 +83,6 @@
 
 (defn- date-trunc [unit expr] (hsql/call :date_trunc (hx/literal unit) (cast-timestamp expr)))
 (defn- extract    [unit expr] (hsql/call :extract    unit              (cast-timestamp expr)))
-(defn- datediff   [unit a b]  (hsql/call :datediff   (hx/literal unit) (cast-timestamp a) (cast-timestamp b)))
 
 (def ^:private extract-integer (comp hx/->integer extract))
 
@@ -131,86 +127,6 @@
   (->> args
        (map (partial sql.qp/->honeysql driver))
        (reduce (partial hsql/call :concat))))
-
-(defmethod sql.qp/->honeysql [:vertica :datetime-diff]
-  [driver [_ x y unit]]
-  (let [x (sql.qp/->honeysql driver x)
-        y (sql.qp/->honeysql driver y)
-        disallowed-types (keep
-                          (fn [v]
-                            (some-> v
-                                    hx/type-info
-                                    hx/type-info->db-type
-                                    name
-                                    str/lower-case
-                                    #{"time" "timetz"}))
-                          [x y])]
-    (when (seq disallowed-types)
-      (throw (ex-info (tru "Only datetime, timestamp, or date types allowed. Found {0}"
-                           (pr-str disallowed-types))
-                      {:found disallowed-types
-                       :type  qp.error-type/invalid-query})))
-    (case unit
-      :year
-      (let [positive-diff (fn [a b] ; precondition: a <= b
-                            (hx/-
-                             (datediff :year a b)
-                             (hx/cast
-                              :integer
-                              (hsql/call
-                               :or
-                               (hsql/call :> (extract :month a) (extract :month b))
-                               (hsql/call
-                                :and
-                                (hsql/call := (extract :month a) (extract :month b))
-                                (hsql/call :> (extract :day a) (extract :day b)))))))]
-        (hsql/call :case
-                   (hsql/call :<= (cast-timestamp x) (cast-timestamp y))
-                   (positive-diff x y)
-                   :else
-                   (hx/* -1 (positive-diff y x))))
-
-      :month
-      (let [positive-diff (fn [a b]
-                            (hx/-
-                             (datediff :month a b)
-                             (hx/cast
-                              :integer
-                              (hsql/call :> (extract :day a) (extract :day b)))))]
-        (hsql/call :case
-                   (hsql/call :<= (cast-timestamp x) (cast-timestamp y))
-                   (positive-diff x y)
-                   :else
-                   (hx/* -1 (positive-diff y x))))
-
-      :week
-      (let [positive-diff (fn [a b]
-                            (hx/cast
-                             :integer
-                             (hx/floor
-                              (hx// (datediff :day a b) 7))))]
-        (hsql/call :case
-                   (hsql/call :<= (cast-timestamp x) (cast-timestamp y))
-                   (positive-diff x y)
-                   :else
-                   (hx/* -1 (positive-diff y x))))
-
-      :day
-      (datediff :day x y)
-
-      (:hour :minute :second)
-      (let [positive-diff (fn [a b]
-                            (hx/cast
-                             :integer
-                             (hx/floor
-                              (cond-> (hsql/call :- (extract :epoch b) (extract :epoch a))
-                                (not= unit :second)
-                                (hx// (case unit :hour 3600 :minute 60))))))]
-        (hsql/call :case
-                   (hsql/call :<= (cast-timestamp x) (cast-timestamp y))
-                   (positive-diff x y)
-                   :else
-                   (hx/* -1 (positive-diff y x)))))))
 
 (defmethod sql.qp/->honeysql [:vertica :regex-match-first]
   [driver [_ arg pattern]]


### PR DESCRIPTION
Reverts metabase/metabase#27066. Backporting this was my mistake. Point releases are for bug and security fixes.
See this comment for more context https://github.com/metabase/metabase/pull/27074#pullrequestreview-1216551945