### PR TITLE
[CI] Add `concurrency` to the `drivers` workflow

### DIFF
--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -21,8 +21,8 @@ on:
       - "**/frontend/**.unit.*"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ !(startsWith(github.ref_name,'master') || startsWith(github.ref_name,'release-x')) }}
+  group: ${{ github.head_ref || github.run_id}}
+  cancel-in-progress: true
 
 jobs:
 

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -20,6 +20,10 @@ on:
       - "**/frontend/test/**"
       - "**/frontend/**.unit.*"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ !(startsWith(github.ref_name,'master') || startsWith(github.ref_name,'release-x')) }}
+
 jobs:
 
   be-tests-athena-ee:


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Adds concurrency to the drivers workflow in such a way that it doesn't obstruct (cancel) runs in progress on master, but it cancels subsequent runs for PRs (scoped to a branch). This is exactly what we've been trying to achieve.

**Before**
Two commits have been pushed within 2 minutes. Both will run the full `drivers` workflow that takes 45 minutes to finish, even though only the latest report matters.
![image](https://user-images.githubusercontent.com/31325167/207591823-c18b48e7-1c74-432f-a619-6d6e262067bf.png)

**After (now)**
Only the latest commit in a branch will trigger a workflow run. Older runs are automatically cancelled.
![image](https://user-images.githubusercontent.com/31325167/207578955-67129610-0a08-44f7-bdc2-8344816381f4.png)

## Background
https://docs.github.com/en/actions/using-jobs/using-concurrency

As the team grows, we're putting CI under more load and we often end up having to wait for the feedback because jobs are stuck in a queue. At the same time, "expensive" and heavy workflows, such as `drivers`, did not have `concurrency` set which was extremely wasteful.
In practice that meant that a single developer could submit 3-4 commits in a row (rapid fire) within their PR and GitHub would run every single one of them. But we only care about the latest one so it's desirable to cancel all others.

That's where `concurrency` shines and that's what it's made for.

But the problem was how to cancel old jobs **only** for PRs, while keeping them running on `master` or on `release` branches?

Up until now, that seemed impossible, but the solution was there all along in the official documentation.

### Explanation
https://docs.github.com/en/actions/using-jobs/using-concurrency#example-using-a-fallback-value

**tl;dr
If the concurrency `group` key matches for a particular workflow, cancel the older run in progress and run the latest one**

- `${{ github.head_ref }}` environment variable exists **only** in the scope of a pull request (it resolves to a name of the branch; in this case, it will be `gha-drivers-concurrency`
- `${{ github.run_id }}` is always unique

We can use this to our advantage.

1. `master` or `release` branches
    - `concurrency` "key" will resolve to the run id which is unique
    - therefore, it's never possible to have two runs with the same key and we're avoiding cancelled runs
2. pull requests
    - `concurency` "key" will resolve to the branch name
    - every subsequent commit push to the pull request counts as a `synchronize` workflow trigger
    - there will be a new `drivers` workflow run and it will cancel the previous one because the `concurrency` key matches (as you can see from the screenshot)

### Next steps
Once we determine that this works as we expect, we can apply this same mechanism to all other workflows, or at least to the "heavy" ones.