### PR TITLE
Fix datetimeDiff helper text

### DIFF
--- a/frontend/src/metabase-lib/expressions/helper-text-strings.ts
+++ b/frontend/src/metabase-lib/expressions/helper-text-strings.ts
@@ -384,7 +384,7 @@ const helperTextStrings: HelpText[] = [
   {
     name: "datetime-diff",
     structure:
-      "datetime-diff(" +
+      "datetimeDiff(" +
       t`datetime1` +
       ", " +
       t`datetime2` +
@@ -393,12 +393,12 @@ const helperTextStrings: HelpText[] = [
       ")",
     description: t`Get the difference between two datetime values (datetime2 minus datetime1) using the specified unit of time.`,
     example:
-      "datetime-diff([" +
+      "datetimeDiff([" +
       t`created_at` +
       "], [" +
       t`shipped_at` +
       "], " +
-      t`month` +
+      t`"month"` +
       ")",
     args: [
       {


### PR DESCRIPTION
Fixes two issues with the datetimeDiff custom expression function: 
1. datetimeDiff helper text uses the wrong case. It should read `datetimeDiff` not `datetime-diff`. 
2. the unit needs to be a string. `"month"` not `month`