### PR TITLE
Improve datetimeDiff type error message

### DIFF
--- a/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk/query_processor.clj
+++ b/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk/query_processor.clj
@@ -567,7 +567,7 @@
         y                (hx/->timestamp y)]
     (when (seq disallowed-types)
       (throw
-       (ex-info (tru "Only datetime, timestamp, or date types allowed. Found {0}"
+       (ex-info (tru "datetimeDiff only allows datetime, timestamp, or date types. Found {0}"
                      (pr-str disallowed-types))
                 {:allowed #{:timestamp :datetime :date}
                  :found   disallowed-types

--- a/modules/drivers/sqlserver/src/metabase/driver/sqlserver.clj
+++ b/modules/drivers/sqlserver/src/metabase/driver/sqlserver.clj
@@ -291,7 +291,7 @@
                                     #{"time"}))
                           [x y])
         _ (when (seq disallowed-types)
-            (throw (ex-info (tru "Only datetime, timestamp, or date types allowed. Found {0}"
+            (throw (ex-info (tru "datetimeDiff only allows datetime, timestamp, or date types. Found {0}"
                                  (pr-str disallowed-types))
                             {:found disallowed-types
                              :type  qp.error-type/invalid-query})))

--- a/modules/drivers/vertica/src/metabase/driver/vertica.clj
+++ b/modules/drivers/vertica/src/metabase/driver/vertica.clj
@@ -152,7 +152,7 @@
                                     #{"time" "timetz"}))
                           [x y])]
     (when (seq disallowed-types)
-      (throw (ex-info (tru "Only datetime, timestamp, or date types allowed. Found {0}"
+      (throw (ex-info (tru "datetimeDiff only allows datetime, timestamp, or date types. Found {0}"
                            (pr-str disallowed-types))
                       {:found disallowed-types
                        :type  qp.error-type/invalid-query})))

--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -399,7 +399,7 @@
                                   (name db-type)))))
                           [x y])]
     (when (seq disallowed-types)
-      (throw (ex-info (tru "Only datetime, timestamp, or date types allowed. Found {0}"
+      (throw (ex-info (tru "datetimeDiff only allows datetime, timestamp, or date types. Found {0}"
                            (pr-str disallowed-types))
                       {:found disallowed-types
                        :type  qp.error-type/invalid-query})))

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -377,7 +377,7 @@
                                   (name db-type)))))
                           [x y])]
     (when (seq disallowed-types)
-      (throw (ex-info (tru "Only datetime, timestamp, or date types allowed. Found {0}"
+      (throw (ex-info (tru "datetimeDiff only allows datetime, timestamp, or date types. Found {0}"
                            (pr-str disallowed-types))
                       {:found disallowed-types
                        :type  qp.error-type/invalid-query})))

--- a/test/metabase/query_processor_test/date_time_zone_functions_test.clj
+++ b/test/metabase/query_processor_test/date_time_zone_functions_test.clj
@@ -946,7 +946,7 @@
       (mt/dataset attempted-murders
         (is (thrown-with-msg?
              clojure.lang.ExceptionInfo
-             #"Only datetime, timestamp, or date types allowed. Found .*"
+             #"datetimeDiff only allows datetime, timestamp, or date types. Found .*"
              (mt/rows
               (mt/run-mbql-query attempts
                 {:limit 1


### PR DESCRIPTION
Updates the error message displayed if an argument to datetimeDiff is the wrong type. Before it didn't have any reference to datetimeDiff, which made it hard to understand for users.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/27225)
<!-- Reviewable:end -->
