### PR TITLE
Minor UI fixes for data picker

### DIFF
--- a/frontend/src/metabase/components/SelectList/BaseSelectListItem.jsx
+++ b/frontend/src/metabase/components/SelectList/BaseSelectListItem.jsx
@@ -46,3 +46,4 @@ export function BaseSelectListItem({
 }
 
 BaseSelectListItem.propTypes = propTypes;
+BaseSelectListItem.Root = BaseItemRoot;

--- a/frontend/src/metabase/containers/DataPicker/DataTypePicker/DataTypePicker.styled.tsx
+++ b/frontend/src/metabase/containers/DataPicker/DataTypePicker/DataTypePicker.styled.tsx
@@ -8,6 +8,12 @@ import { space } from "metabase/styled-components/theme";
 
 export const List = styled(SelectList)`
   padding: ${space(0)} ${space(1)} 12px ${space(1)};
+
+  ${SelectList.BaseItem.Root} {
+    &:hover {
+      background-color: ${color("brand")};
+    }
+  }
 `;
 
 export const ItemIcon = styled(Icon)`

--- a/frontend/src/metabase/containers/DataPicker/PanePicker/PanePicker.styled.tsx
+++ b/frontend/src/metabase/containers/DataPicker/PanePicker/PanePicker.styled.tsx
@@ -54,4 +54,5 @@ export const TreeContainer = styled.div``;
 export const RightPaneContainer = styled.div`
   display: flex;
   flex: 1;
+  overflow-y: auto;
 `;

--- a/frontend/src/metabase/containers/DataPicker/PanePicker/PanePicker.styled.tsx
+++ b/frontend/src/metabase/containers/DataPicker/PanePicker/PanePicker.styled.tsx
@@ -28,10 +28,6 @@ export const LeftPaneContainer = styled.div`
   ${Tree.Node.Root} {
     border-radius: 6px;
   }
-
-  ${Tree.NodeList.Root} {
-    padding: 0 1rem;
-  }
 `;
 
 export const BackButton = styled.a`
@@ -49,7 +45,9 @@ export const BackButton = styled.a`
   }
 `;
 
-export const TreeContainer = styled.div``;
+export const TreeContainer = styled.div`
+  margin-right: 1rem;
+`;
 
 export const RightPaneContainer = styled.div`
   display: flex;


### PR DESCRIPTION
Epic #27160

1. Fixes data type list item color on hover to be "brand" (meaning Models / Raw Data / Saved Questions picker)
2. Adds `overflow-y` to picker right pane to handle long lists of models/tables/questions
3. Fixes tree view sizing and paddings

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/27232)
<!-- Reviewable:end -->
