### PR TITLE
Adds migration linter check to disallow deleteCascade in addColumn

### DIFF
--- a/bin/lint-migrations-file/test/lint_migrations_file_test.clj
+++ b/bin/lint-migrations-file/test/lint_migrations_file_test.clj
@@ -205,3 +205,12 @@
                                             :rollback {:sql {:sql "select 1"}}))))))
   (testing "change types with automatic rollback support are allowed"
     (is (= :ok (validate (mock-change-set :id "v45.12-345" :changes [(mock-add-column-changes)]))))))
+
+(deftest disallow-deletecascade-in-addcolumn-test
+  (testing "addColumn with deleteCascade fails"
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo
+         #"disallow-delete-cascade"
+         (validate (mock-change-set :id "v45.12-345"
+                                    :changes [(mock-add-column-changes
+                                               :columns [(mock-column :constraints {:deleteCascade true})])]))))))

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -6892,7 +6892,6 @@ databaseChangeLog:
                     referencedTableName: collection
                     referencedColumnNames: id
                     foreignKeyName: fk_snippet_collection_id
-                    deleteCascade: true
         - createIndex:
             tableName: native_query_snippet
             indexName: idx_snippet_collection_id


### PR DESCRIPTION
Resolves #14321

This adds a check to prevent usage of `deleteCascade` in `addColumn` changes, which is currently broken in Liquibase (https://liquibase.jira.com/browse/CORE-3058).