### PR TITLE
Use u/lower-case-en and u/upper-case-en for type normalization

### DIFF
--- a/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk/query_processor.clj
+++ b/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk/query_processor.clj
@@ -168,7 +168,7 @@
     nil))
 
 (defn- database-type->temporal-type [database-type]
-  (condp = (some-> database-type str/upper-case)
+  (condp = (some-> database-type u/upper-case-en)
     "TIMESTAMP" :timestamp
     "DATETIME"  :datetime
     "DATE"      :date

--- a/modules/drivers/sqlserver/src/metabase/driver/sqlserver.clj
+++ b/modules/drivers/sqlserver/src/metabase/driver/sqlserver.clj
@@ -22,6 +22,7 @@
             [metabase.query-processor.error-type :as qp.error-type]
             [metabase.query-processor.interface :as qp.i]
             [metabase.query-processor.timezone :as qp.timezone]
+            [metabase.util :as u]
             [metabase.util.honeysql-extensions :as hx]
             [metabase.util.i18n :refer [trs tru]])
   (:import [java.sql Connection ResultSet Time]
@@ -287,7 +288,7 @@
                                     hx/type-info
                                     hx/type-info->db-type
                                     name
-                                    str/lower-case
+                                    u/lower-case-en
                                     #{"time"}))
                           [x y])
         _ (when (seq disallowed-types)

--- a/modules/drivers/vertica/src/metabase/driver/vertica.clj
+++ b/modules/drivers/vertica/src/metabase/driver/vertica.clj
@@ -17,6 +17,7 @@
             [metabase.driver.sql.util :as sql.u]
             [metabase.query-processor.error-type :as qp.error-type]
             [metabase.query-processor.timezone :as qp.timezone]
+            [metabase.util :as u]
             [metabase.util.date-2 :as u.date]
             [metabase.util.honeysql-extensions :as hx]
             [metabase.util.i18n :refer [trs tru]])
@@ -148,7 +149,7 @@
                                     hx/type-info
                                     hx/type-info->db-type
                                     name
-                                    str/lower-case
+                                    u/lower-case-en
                                     #{"time" "timetz"}))
                           [x y])]
     (when (seq disallowed-types)

--- a/src/metabase/db/jdbc_protocols.clj
+++ b/src/metabase/db/jdbc_protocols.clj
@@ -7,6 +7,7 @@
             [clojure.tools.logging :as log]
             [java-time :as t]
             [metabase.db.connection :as mdb.connection]
+            [metabase.util :as u]
             [metabase.util.date-2 :as u.date])
   (:import java.io.BufferedReader
            [java.sql PreparedStatement ResultSet ResultSetMetaData Types]
@@ -104,7 +105,7 @@
     :postgres
     ;; for some reason postgres `TIMESTAMP WITH TIME ZONE` columns still come back as `Type/TIMESTAMP`, which seems
     ;; like a bug with the JDBC driver?
-    (let [^Class klass (if (= (str/lower-case (.getColumnTypeName rsmeta i)) "timestamptz")
+    (let [^Class klass (if (= (u/lower-case-en (.getColumnTypeName rsmeta i)) "timestamptz")
                          OffsetDateTime
                          LocalDateTime)]
       (.getObject rs i klass))

--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -279,7 +279,7 @@
 
         "boolean" json-extract+jsonpath
 
-        (hsql/call :convert json-extract+jsonpath (hsql/raw (str/upper-case field-type)))))))
+        (hsql/call :convert json-extract+jsonpath (hsql/raw (u/upper-case-en field-type)))))))
 
 (defmethod sql.qp/->honeysql [:mysql :field]
   [driver [_ id-or-name opts :as clause]]
@@ -393,7 +393,7 @@
         y (sql.qp/->honeysql driver y)
         disallowed-types (keep
                           (fn [v]
-                            (when-let [db-type (some-> v hx/type-info hx/type-info->db-type str/upper-case keyword)]
+                            (when-let [db-type (some-> v hx/type-info hx/type-info->db-type u/upper-case-en keyword)]
                               (let [base-type (sql-jdbc.sync/database-type->base-type driver db-type)]
                                 (when-not (some #(isa? base-type %) [:type/Date :type/DateTime])
                                   (name db-type)))))

--- a/src/metabase/util/honeysql_extensions.clj
+++ b/src/metabase/util/honeysql_extensions.clj
@@ -173,7 +173,7 @@
   {(s/optional-key ::database-type) (s/constrained
                                      su/NonBlankString
                                      (fn [s]
-                                       (= s (str/lower-case s)))
+                                       (= s (u/lower-case-en s)))
                                      "lowercased string")})
 
 (s/defn ^:private normalize-type-info :- NormalizedTypeInfo
@@ -181,7 +181,7 @@
   `::database-type` to a lower-case string)."
   [type-info]
   (cond-> type-info
-    (::database-type type-info) (update ::database-type (comp str/lower-case name))))
+    (::database-type type-info) (update ::database-type (comp u/lower-case-en name))))
 
 (extend-protocol TypedHoneySQL
   Object
@@ -222,11 +222,11 @@
     (is-of-type? expr #\"int*\") ; -> true"
 
   [honeysql-form database-type]
-  (let [form-type (some-> honeysql-form type-info type-info->db-type str/lower-case)]
+  (let [form-type (some-> honeysql-form type-info type-info->db-type u/lower-case-en)]
     (if (instance? java.util.regex.Pattern database-type)
       (and (some? form-type) (some? (re-find database-type form-type)))
       (= form-type
-         (some-> database-type name str/lower-case)))))
+         (some-> database-type name u/lower-case-en)))))
 
 (s/defn with-database-type-info
   "Convenience for adding only database type information to a `honeysql-form`. Wraps `honeysql-form` and returns a


### PR DESCRIPTION
This PR replaces uses of `str/lower-case` and `str/upper-case` with `metabase.util/lower-case-en` and `metabase.util/upper-case-en` for converting the case of database types.

We currently use `str/lower-case` and `str/upper-case` in a few places to convert the case of database types. This is problematic for reasons pointed out by Cam [here](https://github.com/metabase/metabase/pull/27068#discussion_r1047775173), and is probably causing bugs if running Metabase with a locale like Turkey where lowercase i is different to the English i.

e.g. 
```
(= (str/lower-case "TIMESTAMP")
   "timestamp")
;; => true

(= (mt/with-locale "tr" (str/lower-case "TIMESTAMP"))
   "timestamp")
;; => false
```

Note there are probably other places we use these functions mistakenly too, but this PR focuses only on the normalization of database types.