### PR TITLE
Rename toggleEvent functions

### DIFF
--- a/frontend/src/metabase/query_builder/components/view/sidebars/TimelineSidebar/TimelineSidebar.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/TimelineSidebar/TimelineSidebar.tsx
@@ -52,7 +52,7 @@ const TimelineSidebar = ({
     [onOpenModal],
   );
 
-  const handleToggleEvent = useCallback(
+  const handleToggleEventSelected = useCallback(
     (event: TimelineEvent, isSelected: boolean) => {
       if (isSelected) {
         onSelectTimelineEvents?.([event]);
@@ -84,7 +84,7 @@ const TimelineSidebar = ({
         onNewEvent={handleNewEvent}
         onEditEvent={handleEditEvent}
         onMoveEvent={handleMoveEvent}
-        onToggleEvent={handleToggleEvent}
+        onToggleEventSelected={handleToggleEventSelected}
         onToggleTimeline={handleToggleTimeline}
       />
     </SidebarContent>

--- a/frontend/src/metabase/timelines/questions/components/EventCard/EventCard.tsx
+++ b/frontend/src/metabase/timelines/questions/components/EventCard/EventCard.tsx
@@ -25,7 +25,7 @@ export interface EventCardProps {
   onEdit?: (event: TimelineEvent) => void;
   onMove?: (event: TimelineEvent) => void;
   onArchive?: (event: TimelineEvent) => void;
-  onToggle?: (event: TimelineEvent, isSelected: boolean) => void;
+  onToggleSelected?: (event: TimelineEvent, isSelected: boolean) => void;
 }
 
 const EventCard = ({
@@ -35,7 +35,7 @@ const EventCard = ({
   onEdit,
   onMove,
   onArchive,
-  onToggle,
+  onToggleSelected,
 }: EventCardProps): JSX.Element => {
   const selectedRef = useScrollOnMount();
   const menuItems = getMenuItems(event, timeline, onEdit, onMove, onArchive);
@@ -43,8 +43,8 @@ const EventCard = ({
   const creatorMessage = getCreatorMessage(event);
 
   const handleEventClick = useCallback(() => {
-    onToggle?.(event, !isSelected);
-  }, [event, isSelected, onToggle]);
+    onToggleSelected?.(event, !isSelected);
+  }, [event, isSelected, onToggleSelected]);
 
   const handleAsideClick = useCallback((event: SyntheticEvent) => {
     event.stopPropagation();

--- a/frontend/src/metabase/timelines/questions/components/TimelineCard/TimelineCard.tsx
+++ b/frontend/src/metabase/timelines/questions/components/TimelineCard/TimelineCard.tsx
@@ -28,7 +28,7 @@ export interface TimelineCardProps {
   onEditEvent?: (event: TimelineEvent) => void;
   onMoveEvent?: (event: TimelineEvent) => void;
   onArchiveEvent?: (event: TimelineEvent) => void;
-  onToggleEvent?: (event: TimelineEvent, isSelected: boolean) => void;
+  onToggleEventSelected?: (event: TimelineEvent, isSelected: boolean) => void;
   onToggleTimeline?: (timeline: Timeline, isVisible: boolean) => void;
 }
 
@@ -40,7 +40,7 @@ const TimelineCard = ({
   onEditEvent,
   onMoveEvent,
   onArchiveEvent,
-  onToggleEvent,
+  onToggleEventSelected,
   onToggleTimeline,
 }: TimelineCardProps): JSX.Element => {
   const events = getEvents(timeline.events);
@@ -62,15 +62,15 @@ const TimelineCard = ({
     [timeline, onToggleTimeline],
   );
 
-  const handleToggleEvent = useCallback(
+  const handleToggleEventSelected = useCallback(
     (event: TimelineEvent, isSelected: boolean) => {
-      onToggleEvent?.(event, isSelected);
+      onToggleEventSelected?.(event, isSelected);
 
       if (isSelected && !isVisible) {
         onToggleTimeline?.(timeline, true);
       }
     },
-    [timeline, isVisible, onToggleTimeline, onToggleEvent],
+    [timeline, isVisible, onToggleTimeline, onToggleEventSelected],
   );
 
   useEffect(() => {
@@ -105,7 +105,7 @@ const TimelineCard = ({
               onEdit={onEditEvent}
               onMove={onMoveEvent}
               onArchive={onArchiveEvent}
-              onToggle={handleToggleEvent}
+              onToggleSelected={handleToggleEventSelected}
             />
           ))}
         </CardContent>

--- a/frontend/src/metabase/timelines/questions/components/TimelineCard/TimelineCard.unit.spec.tsx
+++ b/frontend/src/metabase/timelines/questions/components/TimelineCard/TimelineCard.unit.spec.tsx
@@ -40,7 +40,7 @@ describe("TimelineCard", () => {
     expect(props.onToggleTimeline).toHaveBeenCalled();
   });
 
-  it("should make a timeline visible when its even is selected", () => {
+  it("should make a timeline visible when its event is selected", () => {
     const props = getProps({
       timeline: createMockTimeline({
         name: "Releases",

--- a/frontend/src/metabase/timelines/questions/components/TimelineList/TimelineList.tsx
+++ b/frontend/src/metabase/timelines/questions/components/TimelineList/TimelineList.tsx
@@ -9,7 +9,7 @@ export interface TimelineListProps {
   onEditEvent?: (event: TimelineEvent) => void;
   onMoveEvent?: (event: TimelineEvent) => void;
   onArchiveEvent?: (event: TimelineEvent) => void;
-  onToggleEvent?: (event: TimelineEvent, isSelected: boolean) => void;
+  onToggleEventSelected?: (event: TimelineEvent, isSelected: boolean) => void;
   onToggleTimeline?: (timeline: Timeline, isVisible: boolean) => void;
 }
 
@@ -20,7 +20,7 @@ const TimelineList = ({
   onEditEvent,
   onMoveEvent,
   onArchiveEvent,
-  onToggleEvent,
+  onToggleEventSelected,
   onToggleTimeline,
 }: TimelineListProps): JSX.Element => {
   return (
@@ -35,7 +35,7 @@ const TimelineList = ({
           onToggleTimeline={onToggleTimeline}
           onEditEvent={onEditEvent}
           onMoveEvent={onMoveEvent}
-          onToggleEvent={onToggleEvent}
+          onToggleEventSelected={onToggleEventSelected}
           onArchiveEvent={onArchiveEvent}
         />
       ))}

--- a/frontend/src/metabase/timelines/questions/components/TimelinePanel/TimelinePanel.tsx
+++ b/frontend/src/metabase/timelines/questions/components/TimelinePanel/TimelinePanel.tsx
@@ -15,7 +15,7 @@ export interface TimelinePanelProps {
   onEditEvent?: (event: TimelineEvent) => void;
   onMoveEvent?: (event: TimelineEvent) => void;
   onArchiveEvent?: (event: TimelineEvent) => void;
-  onToggleEvent?: (event: TimelineEvent, isSelected: boolean) => void;
+  onToggleEventSelected?: (event: TimelineEvent, isSelected: boolean) => void;
   onToggleTimeline?: (timeline: Timeline, isVisible: boolean) => void;
 }
 
@@ -28,7 +28,7 @@ const TimelinePanel = ({
   onEditEvent,
   onMoveEvent,
   onArchiveEvent,
-  onToggleEvent,
+  onToggleEventSelected,
   onToggleTimeline,
 }: TimelinePanelProps): JSX.Element => {
   const isEmpty = timelines.length === 0;
@@ -49,7 +49,7 @@ const TimelinePanel = ({
           onToggleTimeline={onToggleTimeline}
           onEditEvent={onEditEvent}
           onMoveEvent={onMoveEvent}
-          onToggleEvent={onToggleEvent}
+          onToggleEventSelected={onToggleEventSelected}
           onArchiveEvent={onArchiveEvent}
         />
       ) : (


### PR DESCRIPTION
This PR is in preparation to implement [Allow individual events to be toggled on / off](https://www.notion.so/metabase/Allow-individual-events-to-be-toggled-on-off-eedd91cf28cc450f8106d51437f92a76)

We currently have `onToggle` and variations namespaced to handle toggling if an event is _selected_ or not in a timeline sidebar.

Here we make the related function names specific to the "Selected" state so we open space to add functions about toggling visibility.

9-second Loom for context
https://www.loom.com/share/b43c9ba96eaa4b16b266db9e7055b6ee