### PR TITLE
fix calendar input

### DIFF
--- a/frontend/src/metabase/core/components/Input/Input.styled.tsx
+++ b/frontend/src/metabase/core/components/Input/Input.styled.tsx
@@ -93,7 +93,7 @@ export const InputField = styled.input<InputProps>`
   padding-right: ${props =>
     getHorizontalPadding(
       props.fieldSize,
-      props.hasLeftIcon,
+      props.hasRightIcon,
       props.hasClearButton,
     )};
 
@@ -110,7 +110,7 @@ type InputButtonProps = {
 
 export const InputButton = styled(IconButtonWrapper)<InputButtonProps>`
   position: absolute;
-  color: ${color("text-light")};
+  color: ${props => color(props.onClick != null ? "text-dark" : "text-light")};
   padding: ${props => (props.size === "small" ? "0.5rem" : "0.75rem")};
   border-radius: 50%;
   bottom: ${props => (props.size === "large" ? "0.125rem" : 0)};

--- a/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/SpecificDatePicker.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/SpecificDatePicker.styled.tsx
@@ -1,16 +1,5 @@
 import styled from "@emotion/styled";
 import { color } from "metabase/lib/colors";
-import Icon from "metabase/components/Icon";
-
-export const CalendarIcon = styled(Icon)`
-  margin-right: 0.5rem;
-  margin-left: 0.5rem;
-  cursor: pointer;
-
-  &:hover {
-    color: ${color("filter")};
-  }
-`;
 
 interface DateInputContainerProps {
   isActive?: boolean;

--- a/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/SpecificDatePicker.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/SpecificDatePicker.tsx
@@ -12,7 +12,7 @@ import {
 } from "metabase-lib/queries/utils/query-time";
 import HoursMinutesInput from "./HoursMinutesInput";
 
-import { CalendarIcon, DateInputContainer } from "./SpecificDatePicker.styled";
+import { DateInputContainer } from "./SpecificDatePicker.styled";
 
 interface SpecificDatePickerProps {
   className?: string;
@@ -74,15 +74,10 @@ const SpecificDatePicker = ({
               handleChange();
             }
           }}
+          rightIcon={hasCalendar ? "calendar" : undefined}
+          onRightIconClick={() => setShowCalendar(!showCalendar)}
+          rightIconTooltip={showCalendar ? t`Hide calendar` : t`Show calendar`}
         />
-
-        {hasCalendar && (
-          <CalendarIcon
-            name="calendar"
-            onClick={() => setShowCalendar(!showCalendar)}
-            tooltip={showCalendar ? t`Hide calendar` : t`Show calendar`}
-          />
-        )}
       </DateInputContainer>
 
       {showTimeSelectors && (

--- a/frontend/src/metabase/query_builder/components/filters/pickers/LegacyDatePicker/SpecificDatePicker.jsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/LegacyDatePicker/SpecificDatePicker.jsx
@@ -12,7 +12,7 @@ import Icon from "metabase/components/Icon";
 import ExpandingContent from "metabase/components/ExpandingContent";
 import HoursMinutesInput from "../DatePicker/HoursMinutesInput";
 
-import { CalendarIcon, TimeLabel } from "./SpecificDatePicker.styled";
+import { TimeLabel } from "./SpecificDatePicker.styled";
 
 const DATE_FORMAT = "YYYY-MM-DD";
 const DATE_TIME_FORMAT = "YYYY-MM-DDTHH:mm:ss";
@@ -91,17 +91,14 @@ export default class SpecificDatePicker extends Component {
                 this.onChange(null);
               }
             }}
+            rightIcon={calendar ? "calendar" : undefined}
+            onRightIconClick={() =>
+              this.setState({ showCalendar: !this.state.showCalendar })
+            }
+            rightIconTooltip={
+              showCalendar ? t`Hide calendar` : t`Show calendar`
+            }
           />
-
-          {calendar && (
-            <CalendarIcon
-              name="calendar"
-              onClick={() =>
-                this.setState({ showCalendar: !this.state.showCalendar })
-              }
-              tooltip={showCalendar ? t`Hide calendar` : t`Show calendar`}
-            />
-          )}
         </div>
 
         {calendar && (

--- a/frontend/src/metabase/query_builder/components/filters/pickers/LegacyDatePicker/SpecificDatePicker.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/LegacyDatePicker/SpecificDatePicker.styled.tsx
@@ -1,15 +1,5 @@
 import styled from "@emotion/styled";
 import { color } from "metabase/lib/colors";
-import Icon from "metabase/components/Icon";
-
-export const CalendarIcon = styled(Icon)`
-  margin-right: 0.5rem;
-  cursor: pointer;
-
-  &:hover {
-    color: ${color("filter")};
-  }
-`;
 
 export const TimeLabel = styled.div`
   display: flex;


### PR DESCRIPTION
## Changes

Fixes the date filter input: moves the calendar show/hide button back into the input.

## How to verify

- New -> Orders
- In column header: Filter by Created at -> Specific dates -> "On" filter
- Ensure the calendar toggle button is inside the input and it is aligned correctly

## Screenshots

### Before
<img width="358" alt="Screen Shot 2022-12-14 at 4 52 20 PM" src="https://user-images.githubusercontent.com/14301985/207700817-2f402d02-6d5b-45fd-b812-225f32c73b9e.png">

### After
<img width="369" alt="Screen Shot 2022-12-14 at 4 51 50 PM" src="https://user-images.githubusercontent.com/14301985/207700822-517f4e56-db21-49b9-9240-ad77ffbf987a.png">


