### PR TITLE
Allow Form Fields to be marked as optional

### DIFF
--- a/frontend/src/metabase/collections/containers/CreateCollectionForm.tsx
+++ b/frontend/src/metabase/collections/containers/CreateCollectionForm.tsx
@@ -127,6 +127,7 @@ function CreateCollectionForm({
             title={t`Description`}
             placeholder={t`It's optional but oh, so helpful`}
             nullable
+            optional
           />
           <FormCollectionPicker
             name="parent_id"

--- a/frontend/src/metabase/core/components/FormCheckBox/FormCheckBox.tsx
+++ b/frontend/src/metabase/core/components/FormCheckBox/FormCheckBox.tsx
@@ -9,10 +9,19 @@ export interface FormCheckBoxProps
   name: string;
   title?: string;
   description?: ReactNode;
+  optional?: boolean;
 }
 
 const FormCheckBox = forwardRef(function FormCheckBox(
-  { name, className, style, title, description, ...props }: FormCheckBoxProps,
+  {
+    name,
+    className,
+    style,
+    title,
+    description,
+    optional,
+    ...props
+  }: FormCheckBoxProps,
   ref: Ref<HTMLDivElement>,
 ) {
   const id = useUniqueId();
@@ -29,6 +38,7 @@ const FormCheckBox = forwardRef(function FormCheckBox(
       orientation="horizontal"
       htmlFor={id}
       error={touched ? error : undefined}
+      optional={optional}
     >
       <CheckBox
         {...props}

--- a/frontend/src/metabase/core/components/FormDateInput/FormDateInput.tsx
+++ b/frontend/src/metabase/core/components/FormDateInput/FormDateInput.tsx
@@ -16,6 +16,7 @@ export interface FormDateInputProps
   title?: string;
   description?: ReactNode;
   nullable?: boolean;
+  optional?: boolean;
 }
 
 const FormDateInput = forwardRef(function FormDateInput(
@@ -26,6 +27,7 @@ const FormDateInput = forwardRef(function FormDateInput(
     title,
     description,
     nullable,
+    optional,
     ...props
   }: FormDateInputProps,
   ref: Ref<HTMLDivElement>,
@@ -57,6 +59,7 @@ const FormDateInput = forwardRef(function FormDateInput(
       description={description}
       htmlFor={id}
       error={touched ? error : undefined}
+      optional={optional}
     >
       <DateWidget
         {...props}

--- a/frontend/src/metabase/core/components/FormField/FormField.styled.tsx
+++ b/frontend/src/metabase/core/components/FormField/FormField.styled.tsx
@@ -30,6 +30,13 @@ export const FieldLabel = styled.label<FieldLabelProps>`
   font-weight: 900;
 `;
 
+export const OptionalTag = styled.span`
+  color: ${color("text-medium")};
+  font-size: 0.77rem;
+  font-weight: 900;
+  margin-left: 0.25rem;
+`;
+
 export const FieldLabelContainer = styled.div`
   display: flex;
   align-items: center;

--- a/frontend/src/metabase/core/components/FormField/FormField.tsx
+++ b/frontend/src/metabase/core/components/FormField/FormField.tsx
@@ -11,6 +11,7 @@ import {
   FieldLabelContainer,
   FieldLabelError,
   FieldRoot,
+  OptionalTag,
 } from "./FormField.styled";
 
 export interface FormFieldProps extends HTMLAttributes<HTMLDivElement> {
@@ -52,9 +53,11 @@ const FormField = forwardRef(function FormField(
             {title && (
               <FieldLabel hasError={hasError} htmlFor={htmlFor}>
                 {title}
-                {!!optional && !hasError && t` (optional)`}
                 {hasError && <FieldLabelError>: {error}</FieldLabelError>}
               </FieldLabel>
+            )}
+            {!!optional && !hasError && (
+              <OptionalTag>{t`(optional)`}</OptionalTag>
             )}
             {(infoLabel || infoTooltip) && (
               <Tooltip tooltip={infoTooltip} maxWidth="100%">

--- a/frontend/src/metabase/core/components/FormField/FormField.tsx
+++ b/frontend/src/metabase/core/components/FormField/FormField.tsx
@@ -1,4 +1,5 @@
 import React, { forwardRef, HTMLAttributes, ReactNode, Ref } from "react";
+import { t } from "ttag";
 import Tooltip from "metabase/components/Tooltip";
 import { FieldAlignment, FieldOrientation } from "./types";
 import {
@@ -17,6 +18,7 @@ export interface FormFieldProps extends HTMLAttributes<HTMLDivElement> {
   description?: ReactNode;
   alignment?: FieldAlignment;
   orientation?: FieldOrientation;
+  optional?: boolean;
   error?: string;
   htmlFor?: string;
   infoLabel?: string;
@@ -34,6 +36,7 @@ const FormField = forwardRef(function FormField(
     infoLabel,
     infoTooltip,
     children,
+    optional,
     ...props
   }: FormFieldProps,
   ref: Ref<HTMLDivElement>,
@@ -49,6 +52,7 @@ const FormField = forwardRef(function FormField(
             {title && (
               <FieldLabel hasError={hasError} htmlFor={htmlFor}>
                 {title}
+                {!!optional && !hasError && t` (optional)`}
                 {hasError && <FieldLabelError>: {error}</FieldLabelError>}
               </FieldLabel>
             )}

--- a/frontend/src/metabase/core/components/FormFileInput/FormFileInput.tsx
+++ b/frontend/src/metabase/core/components/FormFileInput/FormFileInput.tsx
@@ -18,6 +18,7 @@ export interface FormFileInputProps
   encoding?: FormFileInputEncoding;
   title?: string;
   description?: ReactNode;
+  optional?: boolean;
 }
 
 const FormFileInput = forwardRef(function FormFileInput(
@@ -28,6 +29,7 @@ const FormFileInput = forwardRef(function FormFileInput(
     style,
     title,
     description,
+    optional,
     ...props
   }: FormFileInputProps,
   ref: Ref<HTMLDivElement>,
@@ -51,6 +53,7 @@ const FormFileInput = forwardRef(function FormFileInput(
       description={description}
       htmlFor={id}
       error={touched ? error : undefined}
+      optional={optional}
     >
       <FileInput
         {...props}

--- a/frontend/src/metabase/core/components/FormInput/FormInput.tsx
+++ b/frontend/src/metabase/core/components/FormInput/FormInput.tsx
@@ -19,6 +19,7 @@ export interface FormInputProps
   title?: string;
   description?: ReactNode;
   nullable?: boolean;
+  optional?: boolean;
 }
 
 const FormInput = forwardRef(function FormInput(
@@ -29,6 +30,7 @@ const FormInput = forwardRef(function FormInput(
     title,
     description,
     nullable,
+    optional,
     ...props
   }: FormInputProps,
   ref: Ref<HTMLDivElement>,
@@ -52,6 +54,7 @@ const FormInput = forwardRef(function FormInput(
       description={description}
       htmlFor={id}
       error={touched ? error : undefined}
+      optional={optional}
     >
       <Input
         size="large"

--- a/frontend/src/metabase/core/components/FormInput/FormInput.unit.spec.tsx
+++ b/frontend/src/metabase/core/components/FormInput/FormInput.unit.spec.tsx
@@ -11,10 +11,15 @@ const TEST_SCHEMA = Yup.object({
 
 interface TestFormInputProps {
   initialValue?: string;
+  optional?: boolean;
   onSubmit: () => void;
 }
 
-const TestFormInput = ({ initialValue = "", onSubmit }: TestFormInputProps) => {
+const TestFormInput = ({
+  initialValue = "",
+  optional,
+  onSubmit,
+}: TestFormInputProps) => {
   return (
     <Formik
       initialValues={{ value: initialValue }}
@@ -22,7 +27,7 @@ const TestFormInput = ({ initialValue = "", onSubmit }: TestFormInputProps) => {
       onSubmit={onSubmit}
     >
       <Form>
-        <FormInput name="value" title="Label" />
+        <FormInput name="value" title="Label" optional={optional} />
         <button type="submit">Submit</button>
       </Form>
     </Formik>
@@ -67,5 +72,31 @@ describe("FormInput", () => {
     userEvent.tab();
 
     expect(await screen.findByText(": error")).toBeInTheDocument();
+  });
+
+  it("should mark the field as optional", () => {
+    const onSubmit = jest.fn();
+
+    render(<TestFormInput initialValue="" onSubmit={onSubmit} optional />);
+
+    expect(screen.getByText(/optional/i)).toBeInTheDocument();
+  });
+
+  it("should not mark the field as optional (undefined)", () => {
+    const onSubmit = jest.fn();
+
+    render(<TestFormInput initialValue="" onSubmit={onSubmit} />);
+
+    expect(screen.queryByText(/optional/i)).not.toBeInTheDocument();
+  });
+
+  it("should not mark the field as optional (false)", () => {
+    const onSubmit = jest.fn();
+
+    render(
+      <TestFormInput initialValue="" onSubmit={onSubmit} optional={false} />,
+    );
+
+    expect(screen.queryByText(/optional/i)).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/metabase/core/components/FormInput/FormInput.unit.spec.tsx
+++ b/frontend/src/metabase/core/components/FormInput/FormInput.unit.spec.tsx
@@ -99,4 +99,12 @@ describe("FormInput", () => {
 
     expect(screen.queryByText(/optional/i)).not.toBeInTheDocument();
   });
+
+  it("should be selectable by label text", () => {
+    const onSubmit = jest.fn();
+
+    render(<TestFormInput initialValue="" onSubmit={onSubmit} optional />);
+
+    expect(screen.getByLabelText("Label")).toBeInTheDocument();
+  });
 });

--- a/frontend/src/metabase/core/components/FormNumericInput/FormNumericInput.tsx
+++ b/frontend/src/metabase/core/components/FormNumericInput/FormNumericInput.tsx
@@ -21,6 +21,7 @@ export interface FormNumericInputProps
   title?: string;
   description?: ReactNode;
   nullable?: boolean;
+  optional?: boolean;
 }
 
 const FormNumericInput = forwardRef(function FormNumericInput(
@@ -31,6 +32,7 @@ const FormNumericInput = forwardRef(function FormNumericInput(
     title,
     description,
     nullable,
+    optional,
     ...props
   }: FormNumericInputProps,
   ref: Ref<HTMLDivElement>,
@@ -54,6 +56,7 @@ const FormNumericInput = forwardRef(function FormNumericInput(
       description={description}
       htmlFor={id}
       error={touched ? error : undefined}
+      optional={optional}
     >
       <NumericInput
         {...props}

--- a/frontend/src/metabase/core/components/FormRadio/FormRadio.tsx
+++ b/frontend/src/metabase/core/components/FormRadio/FormRadio.tsx
@@ -13,6 +13,7 @@ export interface FormRadioProps<
   name: string;
   title?: string;
   description?: ReactNode;
+  optional?: boolean;
 }
 
 const FormRadio = forwardRef(function FormRadio<
@@ -25,6 +26,7 @@ const FormRadio = forwardRef(function FormRadio<
     style,
     title,
     description,
+    optional,
     ...props
   }: FormRadioProps<TValue, TOption>,
   ref: Ref<HTMLDivElement>,
@@ -39,6 +41,7 @@ const FormRadio = forwardRef(function FormRadio<
       title={title}
       description={description}
       error={touched ? error : undefined}
+      optional={optional}
     >
       <Radio
         {...props}

--- a/frontend/src/metabase/core/components/FormSelect/FormSelect.tsx
+++ b/frontend/src/metabase/core/components/FormSelect/FormSelect.tsx
@@ -13,6 +13,7 @@ export interface FormSelectProps<TValue, TOption = SelectOption<TValue>>
   name: string;
   title?: string;
   description?: ReactNode;
+  optional?: boolean;
 }
 
 const FormSelect = forwardRef(function FormSelect<
@@ -25,6 +26,7 @@ const FormSelect = forwardRef(function FormSelect<
     title,
     description,
     onChange,
+    optional,
     ...props
   }: FormSelectProps<TValue, TOption>,
   ref: Ref<HTMLDivElement>,
@@ -49,6 +51,7 @@ const FormSelect = forwardRef(function FormSelect<
       description={description}
       htmlFor={id}
       error={touched ? error : undefined}
+      optional={optional}
     >
       <Select
         {...props}

--- a/frontend/src/metabase/core/components/FormTextArea/FormTextArea.tsx
+++ b/frontend/src/metabase/core/components/FormTextArea/FormTextArea.tsx
@@ -21,6 +21,7 @@ export interface FormTextAreaProps
   nullable?: boolean;
   infoLabel?: string;
   infoTooltip?: string;
+  optional?: boolean;
 }
 
 const FormTextArea = forwardRef(function FormTextArea(
@@ -33,6 +34,7 @@ const FormTextArea = forwardRef(function FormTextArea(
     nullable,
     infoLabel,
     infoTooltip,
+    optional,
     ...props
   }: FormTextAreaProps,
   ref: Ref<HTMLDivElement>,
@@ -58,6 +60,7 @@ const FormTextArea = forwardRef(function FormTextArea(
       error={touched ? error : undefined}
       infoLabel={infoLabel}
       infoTooltip={infoTooltip}
+      optional={optional}
     >
       <TextArea
         {...props}

--- a/frontend/src/metabase/core/components/FormToggle/FormToggle.tsx
+++ b/frontend/src/metabase/core/components/FormToggle/FormToggle.tsx
@@ -8,6 +8,7 @@ export interface FormToggleProps extends Omit<ToggleProps, "value" | "onBlur"> {
   name: string;
   title?: string;
   description?: ReactNode;
+  optional?: boolean;
 }
 
 const FormToggle = forwardRef(function FormToggle(
@@ -18,6 +19,7 @@ const FormToggle = forwardRef(function FormToggle(
     title,
     description,
     onChange,
+    optional,
     ...props
   }: FormToggleProps,
   ref: Ref<HTMLDivElement>,
@@ -43,6 +45,7 @@ const FormToggle = forwardRef(function FormToggle(
       orientation="horizontal"
       htmlFor={id}
       error={touched ? error : undefined}
+      optional={optional}
     >
       <Toggle
         {...props}


### PR DESCRIPTION
## Description
Adds an `optional` prop to our new form field components to allow them to be marked as `(optional)` in a consistent way.

example:

![Screen Shot 2022-12-14 at 2 10 10 PM](https://user-images.githubusercontent.com/30528226/207714960-e6f67b09-e723-42e3-ae4c-d46d38479ed8.png)
