### PR TITLE
Fix BigQuery parsing of `bigdecimal` results

### DIFF
--- a/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk/query_processor.clj
+++ b/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk/query_processor.clj
@@ -1,36 +1,34 @@
 (ns metabase.driver.bigquery-cloud-sdk.query-processor
-  (:require
-   [clojure.string :as str]
-   [clojure.tools.logging :as log]
-   [honeysql.core :as hsql]
-   [honeysql.format :as hformat]
-   [java-time :as t]
-   [metabase.driver :as driver]
-   [metabase.driver.bigquery-cloud-sdk.common :as bigquery.common]
-   [metabase.driver.common :as driver.common]
-   [metabase.driver.sql :as sql]
-   [metabase.driver.sql.parameters.substitution :as sql.params.substitution]
-   [metabase.driver.sql.query-processor :as sql.qp]
-   [metabase.driver.sql.util :as sql.u]
-   [metabase.driver.sql.util.unprepare :as unprepare]
-   [metabase.mbql.util :as mbql.u]
-   [metabase.models.field :refer [Field]]
-   [metabase.models.setting :as setting]
-   [metabase.query-processor.error-type :as qp.error-type]
-   [metabase.query-processor.store :as qp.store]
-   [metabase.query-processor.timezone :as qp.timezone]
-   [metabase.query-processor.util.add-alias-info :as add]
-   [metabase.util :as u]
-   [metabase.util.date-2 :as u.date]
-   [metabase.util.honeysql-extensions :as hx]
-   [metabase.util.i18n :refer [trs tru]]
-   [pretty.core :refer [PrettyPrintable]]
-   [schema.core :as s])
-  (:import
-   (com.google.cloud.bigquery Field$Mode FieldValue)
-   (java.time LocalDate LocalDateTime LocalTime OffsetDateTime OffsetTime ZonedDateTime)
-   (metabase.driver.common.parameters FieldFilter)
-   (metabase.util.honeysql_extensions Identifier TypedHoneySQLForm)))
+  (:require [clojure.string :as str]
+            [clojure.tools.logging :as log]
+            [honeysql.core :as hsql]
+            [honeysql.format :as hformat]
+            [java-time :as t]
+            [metabase.driver :as driver]
+            [metabase.driver.bigquery-cloud-sdk.common :as bigquery.common]
+            [metabase.driver.common :as driver.common]
+            [metabase.driver.sql :as sql]
+            [metabase.driver.sql.parameters.substitution :as sql.params.substitution]
+            [metabase.driver.sql.query-processor :as sql.qp]
+            [metabase.driver.sql.util :as sql.u]
+            [metabase.driver.sql.util.unprepare :as unprepare]
+            [metabase.mbql.util :as mbql.u]
+            [metabase.models.field :refer [Field]]
+            [metabase.models.setting :as setting]
+            [metabase.query-processor.error-type :as qp.error-type]
+            [metabase.query-processor.store :as qp.store]
+            [metabase.query-processor.timezone :as qp.timezone]
+            [metabase.query-processor.util.add-alias-info :as add]
+            [metabase.util :as u]
+            [metabase.util.date-2 :as u.date]
+            [metabase.util.honeysql-extensions :as hx]
+            [metabase.util.i18n :refer [trs tru]]
+            [pretty.core :refer [PrettyPrintable]]
+            [schema.core :as s])
+  (:import [com.google.cloud.bigquery Field$Mode FieldValue]
+           [java.time LocalDate LocalDateTime LocalTime OffsetDateTime OffsetTime ZonedDateTime]
+           metabase.driver.common.parameters.FieldFilter
+           [metabase.util.honeysql_extensions Identifier TypedHoneySQLForm]))
 
 (defn- valid-project-identifier?
   "Is String `s` a valid BigQuery project identifier (a.k.a. project-id)? Identifiers are only allowed to contain

--- a/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk/query_processor.clj
+++ b/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk/query_processor.clj
@@ -1,34 +1,36 @@
 (ns metabase.driver.bigquery-cloud-sdk.query-processor
-  (:require [clojure.string :as str]
-            [clojure.tools.logging :as log]
-            [honeysql.core :as hsql]
-            [honeysql.format :as hformat]
-            [java-time :as t]
-            [metabase.driver :as driver]
-            [metabase.driver.bigquery-cloud-sdk.common :as bigquery.common]
-            [metabase.driver.common :as driver.common]
-            [metabase.driver.sql :as sql]
-            [metabase.driver.sql.parameters.substitution :as sql.params.substitution]
-            [metabase.driver.sql.query-processor :as sql.qp]
-            [metabase.driver.sql.util :as sql.u]
-            [metabase.driver.sql.util.unprepare :as unprepare]
-            [metabase.mbql.util :as mbql.u]
-            [metabase.models.field :refer [Field]]
-            [metabase.models.setting :as setting]
-            [metabase.query-processor.error-type :as qp.error-type]
-            [metabase.query-processor.store :as qp.store]
-            [metabase.query-processor.timezone :as qp.timezone]
-            [metabase.query-processor.util.add-alias-info :as add]
-            [metabase.util :as u]
-            [metabase.util.date-2 :as u.date]
-            [metabase.util.honeysql-extensions :as hx]
-            [metabase.util.i18n :refer [tru]]
-            [pretty.core :refer [PrettyPrintable]]
-            [schema.core :as s])
-  (:import [com.google.cloud.bigquery Field$Mode FieldValue]
-           [java.time LocalDate LocalDateTime LocalTime OffsetDateTime OffsetTime ZonedDateTime]
-           metabase.driver.common.parameters.FieldFilter
-           [metabase.util.honeysql_extensions Identifier TypedHoneySQLForm]))
+  (:require
+   [clojure.string :as str]
+   [clojure.tools.logging :as log]
+   [honeysql.core :as hsql]
+   [honeysql.format :as hformat]
+   [java-time :as t]
+   [metabase.driver :as driver]
+   [metabase.driver.bigquery-cloud-sdk.common :as bigquery.common]
+   [metabase.driver.common :as driver.common]
+   [metabase.driver.sql :as sql]
+   [metabase.driver.sql.parameters.substitution :as sql.params.substitution]
+   [metabase.driver.sql.query-processor :as sql.qp]
+   [metabase.driver.sql.util :as sql.u]
+   [metabase.driver.sql.util.unprepare :as unprepare]
+   [metabase.mbql.util :as mbql.u]
+   [metabase.models.field :refer [Field]]
+   [metabase.models.setting :as setting]
+   [metabase.query-processor.error-type :as qp.error-type]
+   [metabase.query-processor.store :as qp.store]
+   [metabase.query-processor.timezone :as qp.timezone]
+   [metabase.query-processor.util.add-alias-info :as add]
+   [metabase.util :as u]
+   [metabase.util.date-2 :as u.date]
+   [metabase.util.honeysql-extensions :as hx]
+   [metabase.util.i18n :refer [trs tru]]
+   [pretty.core :refer [PrettyPrintable]]
+   [schema.core :as s])
+  (:import
+   (com.google.cloud.bigquery Field$Mode FieldValue)
+   (java.time LocalDate LocalDateTime LocalTime OffsetDateTime OffsetTime ZonedDateTime)
+   (metabase.driver.common.parameters FieldFilter)
+   (metabase.util.honeysql_extensions Identifier TypedHoneySQLForm)))
 
 (defn- valid-project-identifier?
   "Is String `s` a valid BigQuery project identifier (a.k.a. project-id)? Identifiers are only allowed to contain
@@ -88,7 +90,8 @@
     (parse-fn v)))
 
 (defmethod parse-result-of-type :default
-  [_ column-mode _ v]
+  [column-type column-mode _ v]
+  (log/warn (trs "Warning: missing type mapping for parsing BigQuery results of type {0}." column-type))
   (parse-value column-mode v identity))
 
 (defmethod parse-result-of-type "BOOLEAN"
@@ -105,6 +108,10 @@
 
 (defmethod parse-result-of-type "NUMERIC"
   [_ column-mode _ v]
+  (parse-value column-mode v bigdec))
+
+(defmethod parse-result-of-type "BIGNUMERIC"
+  [_column-type column-mode _timezone-id v]
   (parse-value column-mode v bigdec))
 
 (defn- parse-timestamp-str [timezone-id s]

--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk/params_test.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk/params_test.clj
@@ -3,7 +3,7 @@
             [metabase.query-processor :as qp]
             [metabase.test :as mt]))
 
-(deftest set-parameters-test
+(deftest ^:parallel set-parameters-test
   (mt/test-driver :bigquery-cloud-sdk
     (testing "Make sure we're setting various types of parameters correctly\n"
       (doseq [[v expected] [[nil                                        {:base-type :type/Text}]
@@ -19,10 +19,10 @@
                             [(double 100.0)                             {:base-type :type/Float}]
                             ;; one case for NUMERIC/DECIMAL
                             [(bigdec "-2.3E+16")                        {:base-type :type/Decimal
-                                                                         :v         "-23000000000000000"}]
+                                                                         :v         -23000000000000000M}]
                             ;; and one for BIGNUMERIC/BIGDECIMAL
                             [(bigdec "1.6E+31")                         {:base-type :type/Decimal
-                                                                         :v         "16000000000000000000000000000000"}]
+                                                                         :v         16000000000000000000000000000000M}]
                             ;; LocalDate
                             [#t "2020-05-26"                            {:base-type :type/Date
                                                                          :v         #t "2020-05-26"}]

--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk/query_processor_test.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk/query_processor_test.clj
@@ -960,3 +960,17 @@
                             :query)]
           (is (not (str/includes? sql-query name-with-spaces))
               (format "Query `%s' should not contain `%s'" sql-query name-with-spaces)))))))
+
+(deftest parse-bigquery-bignumeric-correctly-test
+  (mt/test-driver :bigquery-cloud-sdk
+    (let [query (mt/native-query {:query (str/join \newline
+                                                   ["select"
+                                                    "  1234.1234567890123456                     as extremely_long_undef"
+                                                    ", cast(1234.1234567890123456 as decimal)    as extremely_long_decimal"
+                                                    ", cast(1234.1234567890123456 as float64)    as extremely_long_float64"
+                                                    ",  cast(1234.1234567890123456 as bigdecimal) as extremely_long_BIGdecimal"])})]
+      (is (= [[1234.1234567890124
+               1234.123456789M
+               1234.1234567890124
+               1234.1234567890123456M]]
+             (mt/rows (mt/process-query query)))))))

--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk/query_processor_test.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk/query_processor_test.clj
@@ -961,7 +961,7 @@
           (is (not (str/includes? sql-query name-with-spaces))
               (format "Query `%s' should not contain `%s'" sql-query name-with-spaces)))))))
 
-(deftest parse-bigquery-bignumeric-correctly-test
+(deftest ^:parallel parse-bigquery-bignumeric-correctly-test
   (mt/test-driver :bigquery-cloud-sdk
     (let [query (mt/native-query {:query (str/join \newline
                                                    ["select"


### PR DESCRIPTION
We had no results parser type mapping for `bigdecimal`, so it fell back to getting parsed as a string.

Fixes #25508