### PR TITLE
Add empty and loading states to data picker

### DIFF
--- a/frontend/src/metabase/containers/DataPicker/CardPicker/CardPickerContainer.tsx
+++ b/frontend/src/metabase/containers/DataPicker/CardPicker/CardPickerContainer.tsx
@@ -38,6 +38,7 @@ interface CollectionsLoaderProps {
   collectionTree: Collection[];
   collections: Collection[];
   rootCollection: Collection;
+  allLoading: boolean;
 }
 
 interface SchemaLoaderProps {
@@ -63,6 +64,7 @@ function CardPickerContainer({
   schema: selectedSchema,
   currentUser,
   targetModel,
+  allLoading,
   onChange,
   onBack,
 }: CardPickerProps) {
@@ -133,6 +135,7 @@ function CardPickerContainer({
       virtualTables={selectedSchema?.tables}
       selectedItems={selectedItems}
       targetModel={targetModel}
+      isLoading={allLoading}
       onSelectCollection={handleSelectedCollectionChange}
       onSelectedVirtualTable={handleSelectedTablesChange}
       onBack={onBack}

--- a/frontend/src/metabase/containers/DataPicker/CardPicker/CardPickerView.tsx
+++ b/frontend/src/metabase/containers/DataPicker/CardPicker/CardPickerView.tsx
@@ -10,6 +10,9 @@ import type { Collection } from "metabase-types/api";
 import type Table from "metabase-lib/metadata/Table";
 
 import type { DataPickerSelectedItem, VirtualTable } from "../types";
+
+import EmptyState from "../EmptyState";
+import LoadingState from "../LoadingState";
 import PanePicker from "../PanePicker";
 
 import { StyledSelectList } from "./CardPicker.styled";
@@ -21,6 +24,7 @@ interface CardPickerViewProps {
   virtualTables?: VirtualTable[];
   selectedItems: DataPickerSelectedItem[];
   targetModel: TargetModel;
+  isLoading: boolean;
   onSelectCollection: (id: Collection["id"]) => void;
   onSelectedVirtualTable: (id: Table["id"]) => void;
   onBack?: () => void;
@@ -73,6 +77,7 @@ function CardPickerView({
   virtualTables,
   selectedItems,
   targetModel,
+  isLoading,
   onSelectCollection,
   onSelectedVirtualTable,
   onBack,
@@ -111,6 +116,8 @@ function CardPickerView({
     [selectedVirtualTableIds, targetModel, onSelectedVirtualTable],
   );
 
+  const isEmpty = _.isEmpty(virtualTables);
+
   return (
     <PanePicker
       data={collectionTree}
@@ -118,9 +125,15 @@ function CardPickerView({
       onSelect={handlePanePickerSelect}
       onBack={onBack}
     >
-      <StyledSelectList>
-        {virtualTables?.map?.(renderVirtualTable)}
-      </StyledSelectList>
+      {isLoading ? (
+        <LoadingState />
+      ) : isEmpty ? (
+        <EmptyState />
+      ) : (
+        <StyledSelectList>
+          {virtualTables?.map?.(renderVirtualTable)}
+        </StyledSelectList>
+      )}
     </PanePicker>
   );
 }

--- a/frontend/src/metabase/containers/DataPicker/DataPickerView.styled.tsx
+++ b/frontend/src/metabase/containers/DataPicker/DataPickerView.styled.tsx
@@ -4,10 +4,3 @@ export const Root = styled.div`
   display: flex;
   flex: 1;
 `;
-
-export const EmptyStateContainer = styled.div`
-  display: flex;
-  flex: 1;
-  align-items: center;
-  justify-content: center;
-`;

--- a/frontend/src/metabase/containers/DataPicker/DataPickerView.tsx
+++ b/frontend/src/metabase/containers/DataPicker/DataPickerView.tsx
@@ -1,8 +1,6 @@
 import React, { useMemo } from "react";
 import { t } from "ttag";
 
-import EmptyState from "metabase/components/EmptyState";
-
 import { MIN_SEARCH_LENGTH } from "./constants";
 
 import type { DataPickerProps, DataPickerDataType } from "./types";
@@ -13,7 +11,8 @@ import DataTypePicker from "./DataTypePicker";
 import DataSearch from "./DataSearch";
 import RawDataPicker from "./RawDataPicker";
 
-import { Root, EmptyStateContainer } from "./DataPickerView.styled";
+import EmptyState from "./EmptyState";
+import { Root } from "./DataPickerView.styled";
 
 interface DataPickerViewProps extends DataPickerProps {
   dataTypes: DataTypeInfoItem[];
@@ -39,12 +38,10 @@ function DataPickerViewContent({
 
   if (!hasDataAccess) {
     return (
-      <EmptyStateContainer>
-        <EmptyState
-          message={t`To pick some data, you'll need to add some first`}
-          icon="database"
-        />
-      </EmptyStateContainer>
+      <EmptyState
+        message={t`To pick some data, you'll need to add some first`}
+        icon="database"
+      />
     );
   }
 

--- a/frontend/src/metabase/containers/DataPicker/EmptyState/EmptyState.styled.tsx
+++ b/frontend/src/metabase/containers/DataPicker/EmptyState/EmptyState.styled.tsx
@@ -1,0 +1,8 @@
+import styled from "@emotion/styled";
+
+export const EmptyStateContainer = styled.div`
+  display: flex;
+  flex: 1;
+  align-items: center;
+  justify-content: center;
+`;

--- a/frontend/src/metabase/containers/DataPicker/EmptyState/EmptyState.tsx
+++ b/frontend/src/metabase/containers/DataPicker/EmptyState/EmptyState.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+import { t } from "ttag";
+import DefaultEmptyState from "metabase/components/EmptyState";
+import { EmptyStateContainer } from "./EmptyState.styled";
+
+interface Props {
+  message?: string;
+  icon?: string;
+}
+
+function EmptyState({ message = t`Nothing here`, icon = "all" }: Props) {
+  return (
+    <EmptyStateContainer>
+      <DefaultEmptyState message={message} icon={icon} />
+    </EmptyStateContainer>
+  );
+}
+
+export default EmptyState;

--- a/frontend/src/metabase/containers/DataPicker/EmptyState/index.ts
+++ b/frontend/src/metabase/containers/DataPicker/EmptyState/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./EmptyState";

--- a/frontend/src/metabase/containers/DataPicker/LoadingState/LoadingState.styled.tsx
+++ b/frontend/src/metabase/containers/DataPicker/LoadingState/LoadingState.styled.tsx
@@ -1,0 +1,10 @@
+import styled from "@emotion/styled";
+import { color } from "metabase/lib/colors";
+
+export const LoadingStateContainer = styled.div`
+  display: flex;
+  flex: 1;
+  align-items: center;
+  justify-content: center;
+  color: ${color("brand")};
+`;

--- a/frontend/src/metabase/containers/DataPicker/LoadingState/LoadingState.tsx
+++ b/frontend/src/metabase/containers/DataPicker/LoadingState/LoadingState.tsx
@@ -1,0 +1,13 @@
+import React from "react";
+import LoadingSpinner from "metabase/components/LoadingSpinner";
+import { LoadingStateContainer } from "./LoadingState.styled";
+
+function LoadingState() {
+  return (
+    <LoadingStateContainer>
+      <LoadingSpinner />
+    </LoadingStateContainer>
+  );
+}
+
+export default LoadingState;

--- a/frontend/src/metabase/containers/DataPicker/LoadingState/index.ts
+++ b/frontend/src/metabase/containers/DataPicker/LoadingState/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./LoadingState";

--- a/frontend/src/metabase/containers/DataPicker/PanePicker/PanePicker.styled.tsx
+++ b/frontend/src/metabase/containers/DataPicker/PanePicker/PanePicker.styled.tsx
@@ -1,4 +1,5 @@
 import styled from "@emotion/styled";
+import { css } from "@emotion/react";
 
 import { Tree } from "metabase/components/tree";
 
@@ -17,13 +18,17 @@ export const Root = styled.div`
   }
 `;
 
-export const LeftPaneContainer = styled.div`
+export const LeftPaneContainer = styled.div<{ hasContent?: boolean }>`
   display: flex;
-  flex: 1;
   flex-direction: column;
   overflow: auto;
 
-  border-right: 1px solid ${color("border")};
+  ${({ hasContent }) =>
+    hasContent &&
+    css`
+      flex: 1;
+      border-right: 1px solid ${color("border")};
+    `}
 
   ${Tree.Node.Root} {
     border-radius: 6px;

--- a/frontend/src/metabase/containers/DataPicker/PanePicker/PanePicker.tsx
+++ b/frontend/src/metabase/containers/DataPicker/PanePicker/PanePicker.tsx
@@ -29,9 +29,10 @@ function PanePicker({
   onBack,
   children,
 }: PanePickerProps) {
+  const hasContent = data.length > 0;
   return (
     <Root>
-      <LeftPaneContainer>
+      <LeftPaneContainer hasContent={hasContent}>
         {onBack && (
           <BackButton onClick={onBack}>
             <Icon name="chevronleft" className="mr1" />

--- a/frontend/src/metabase/containers/DataPicker/RawDataPicker/RawDataPickerContainer.tsx
+++ b/frontend/src/metabase/containers/DataPicker/RawDataPicker/RawDataPickerContainer.tsx
@@ -16,10 +16,16 @@ import RawDataPickerView from "./RawDataPickerView";
 
 interface DatabaseListLoaderProps {
   databases: Database[];
+  allLoading: boolean;
+}
+
+interface SchemasListLoaderProps {
+  allLoading: boolean;
 }
 
 interface TableListLoaderProps {
   tables: Table[];
+  allLoading: boolean;
 }
 
 interface RawDataPickerOwnProps extends DataPickerProps {
@@ -31,6 +37,7 @@ type RawDataPickerProps = RawDataPickerOwnProps & DatabaseListLoaderProps;
 function RawDataPicker({
   value,
   databases,
+  allLoading,
   onChange,
   onBack,
 }: RawDataPickerProps) {
@@ -122,12 +129,19 @@ function RawDataPicker({
   }, [selectedDatabase, selectedSchemaId, handleSelectedSchemaIdChange]);
 
   const renderPicker = useCallback(
-    ({ tables }: { tables?: Table[] } = {}) => {
+    ({
+      tables,
+      isLoading = allLoading,
+    }: {
+      tables?: Table[];
+      isLoading?: boolean;
+    } = {}) => {
       return (
         <RawDataPickerView
           databases={databases}
           tables={tables}
           selectedItems={selectedItems}
+          isLoading={isLoading}
           onSelectDatabase={handleSelectedDatabaseIdChange}
           onSelectSchema={handleSelectedSchemaIdChange}
           onSelectedTable={handleSelectedTablesChange}
@@ -138,6 +152,7 @@ function RawDataPicker({
     [
       databases,
       selectedItems,
+      allLoading,
       handleSelectedDatabaseIdChange,
       handleSelectedSchemaIdChange,
       handleSelectedTablesChange,
@@ -152,9 +167,9 @@ function RawDataPicker({
         loadingAndErrorWrapper={false}
         onLoaded={onDatabaseSchemasLoaded}
       >
-        {() => {
+        {({ allLoading }: SchemasListLoaderProps) => {
           if (!selectedSchema) {
-            return renderPicker();
+            return renderPicker({ isLoading: allLoading });
           }
           return (
             <Tables.ListLoader
@@ -164,7 +179,9 @@ function RawDataPicker({
               }}
               loadingAndErrorWrapper={false}
             >
-              {({ tables }: TableListLoaderProps) => renderPicker({ tables })}
+              {({ tables, allLoading }: TableListLoaderProps) =>
+                renderPicker({ tables, isLoading: allLoading })
+              }
             </Tables.ListLoader>
           );
         }}
@@ -172,7 +189,7 @@ function RawDataPicker({
     );
   }
 
-  return renderPicker();
+  return renderPicker({ isLoading: allLoading });
 }
 
 export default Databases.loadList({ loadingAndErrorWrapper: false })(

--- a/frontend/src/metabase/containers/DataPicker/RawDataPicker/RawDataPickerView.tsx
+++ b/frontend/src/metabase/containers/DataPicker/RawDataPicker/RawDataPickerView.tsx
@@ -11,6 +11,8 @@ import type Schema from "metabase-lib/metadata/Schema";
 
 import type { DataPickerSelectedItem } from "../types";
 
+import EmptyState from "../EmptyState";
+import LoadingState from "../LoadingState";
 import PanePicker from "../PanePicker";
 import { StyledSelectList } from "./RawDataPicker.styled";
 
@@ -18,6 +20,7 @@ interface RawDataPickerViewProps {
   databases: Database[];
   tables?: Table[];
   selectedItems: DataPickerSelectedItem[];
+  isLoading: boolean;
   onSelectDatabase: (id: Database["id"]) => void;
   onSelectSchema: (id: Schema["id"]) => void;
   onSelectedTable: (id: Table["id"]) => void;
@@ -74,6 +77,7 @@ function RawDataPickerView({
   databases,
   tables,
   selectedItems,
+  isLoading,
   onSelectDatabase,
   onSelectSchema,
   onSelectedTable,
@@ -142,6 +146,10 @@ function RawDataPickerView({
     [selectedTableIds, onSelectedTable],
   );
 
+  const hasDatabases = databases.length > 0;
+  const hasTables = !_.isEmpty(tables);
+  const isEmpty = !hasDatabases || (selectedDatabaseId && !hasTables);
+
   return (
     <PanePicker
       data={treeData}
@@ -149,7 +157,13 @@ function RawDataPickerView({
       onSelect={handlePanePickerSelect}
       onBack={onBack}
     >
-      <StyledSelectList>{tables?.map?.(renderTable)}</StyledSelectList>
+      {isLoading ? (
+        <LoadingState />
+      ) : isEmpty ? (
+        <EmptyState />
+      ) : (
+        <StyledSelectList>{tables?.map?.(renderTable)}</StyledSelectList>
+      )}
     </PanePicker>
   );
 }

--- a/frontend/src/metabase/containers/DataPicker/tests/DataPicker-Models.unit.spec.ts
+++ b/frontend/src/metabase/containers/DataPicker/tests/DataPicker-Models.unit.spec.ts
@@ -13,6 +13,7 @@ import {
 
 import {
   setup,
+  EMPTY_COLLECTION,
   SAMPLE_COLLECTION,
   SAMPLE_MODEL,
   SAMPLE_MODEL_2,
@@ -43,6 +44,15 @@ describe("DataPicker — picking models", () => {
     expect(screen.getByText(SAMPLE_MODEL.name)).toBeInTheDocument();
     expect(screen.queryByText(/Raw Data/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/Saved Questions/i)).not.toBeInTheDocument();
+  });
+
+  it("has empty state", async () => {
+    await setup();
+
+    userEvent.click(screen.getByText(/Saved Questions/i));
+    userEvent.click(await screen.findByText(EMPTY_COLLECTION.name));
+
+    expect(screen.getByText(/Nothing here/i)).toBeInTheDocument();
   });
 
   it("respects initial value", async () => {

--- a/frontend/src/metabase/containers/DataPicker/tests/DataPicker-Questions.unit.spec.ts
+++ b/frontend/src/metabase/containers/DataPicker/tests/DataPicker-Questions.unit.spec.ts
@@ -13,6 +13,7 @@ import {
 
 import {
   setup,
+  EMPTY_COLLECTION,
   SAMPLE_COLLECTION,
   SAMPLE_QUESTION,
   SAMPLE_QUESTION_2,
@@ -42,6 +43,15 @@ describe("DataPicker — picking questions", () => {
       expect(screen.getByText(SAMPLE_QUESTION.name)).toBeInTheDocument();
       expect(screen.queryByText(/Models/i)).not.toBeInTheDocument();
       expect(screen.queryByText(/Raw Data/i)).not.toBeInTheDocument();
+    });
+
+    it("has empty state", async () => {
+      await setup();
+
+      userEvent.click(screen.getByText(/Saved Questions/i));
+      userEvent.click(await screen.findByText(EMPTY_COLLECTION.name));
+
+      expect(screen.getByText(/Nothing here/i)).toBeInTheDocument();
     });
 
     it("respects initial value", async () => {

--- a/frontend/src/metabase/containers/DataPicker/tests/DataPicker-RawData.unit.spec.ts
+++ b/frontend/src/metabase/containers/DataPicker/tests/DataPicker-RawData.unit.spec.ts
@@ -4,6 +4,7 @@ import nock from "nock";
 import { screen, waitFor } from "__support__/ui";
 import {
   SAMPLE_DATABASE,
+  ANOTHER_DATABASE,
   MULTI_SCHEMA_DATABASE,
 } from "__support__/sample_database_fixture";
 
@@ -32,6 +33,15 @@ describe("DataPicker — picking raw data", () => {
     });
     expect(screen.queryByText(/Models/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/Saved Questions/i)).not.toBeInTheDocument();
+  });
+
+  it("has empty state", async () => {
+    await setup({ hasEmptyDatabase: true });
+
+    userEvent.click(screen.getByText(/Raw Data/i));
+    userEvent.click(screen.getByText(ANOTHER_DATABASE.name));
+
+    expect(await screen.findByText(/Nothing here/i)).toBeInTheDocument();
   });
 
   it("allows to pick multiple tables", async () => {

--- a/frontend/src/metabase/containers/DataPicker/tests/common.tsx
+++ b/frontend/src/metabase/containers/DataPicker/tests/common.tsx
@@ -14,6 +14,7 @@ import {
 } from "__support__/server-mocks";
 import {
   SAMPLE_DATABASE,
+  ANOTHER_DATABASE,
   MULTI_SCHEMA_DATABASE,
 } from "__support__/sample_database_fixture";
 
@@ -31,9 +32,18 @@ import useDataPickerValue from "../useDataPickerValue";
 import DataPicker from "../DataPickerContainer";
 
 export const SAMPLE_COLLECTION = createMockCollection({
+  id: 1,
   name: "Sample Collection",
   location: "/",
   here: ["card", "dataset"],
+});
+
+export const EMPTY_COLLECTION = createMockCollection({
+  id: 2,
+  name: "Empty Collection",
+  location: "/",
+  here: [],
+  below: ["card", "dataset"],
 });
 
 export const SAMPLE_MODEL = createMockCard({
@@ -95,6 +105,7 @@ interface SetupOpts {
   initialValue?: DataPickerValue;
   filters?: DataPickerFiltersProp;
   hasDataAccess?: boolean;
+  hasEmptyDatabase?: boolean;
   hasMultiSchemaDatabase?: boolean;
   hasModels?: boolean;
   hasNestedQueriesEnabled?: boolean;
@@ -104,6 +115,7 @@ export async function setup({
   initialValue = { tableIds: [] },
   filters,
   hasDataAccess = true,
+  hasEmptyDatabase = false,
   hasMultiSchemaDatabase = false,
   hasModels = true,
   hasNestedQueriesEnabled = true,
@@ -119,6 +131,10 @@ export async function setup({
       databases.push(MULTI_SCHEMA_DATABASE);
     }
 
+    if (hasEmptyDatabase) {
+      databases.push(ANOTHER_DATABASE);
+    }
+
     setupDatabasesEndpoints(scope, databases);
   } else {
     scope.get("/api/database").reply(200, []);
@@ -128,7 +144,7 @@ export async function setup({
     .get("/api/search?models=dataset&limit=1")
     .reply(200, { data: hasModels ? [SAMPLE_MODEL] : [] });
 
-  setupCollectionEndpoints(scope, [SAMPLE_COLLECTION]);
+  setupCollectionEndpoints(scope, [SAMPLE_COLLECTION, EMPTY_COLLECTION]);
 
   setupCollectionVirtualSchemaEndpoints(
     scope,
@@ -147,6 +163,8 @@ export async function setup({
     SAMPLE_QUESTION,
     SAMPLE_MODEL,
   ]);
+
+  setupCollectionVirtualSchemaEndpoints(scope, EMPTY_COLLECTION, []);
 
   const settings = createMockSettingsState({
     "enable-nested-queries": hasNestedQueriesEnabled,


### PR DESCRIPTION
Epic #27160; closes #27259, partially #27258 too (still need a loading state for schemas)

1. Shows a loading spinner on the right side of the picker while loading database tables or collection models/questions
2. Shows a "Nothing here" empty state when a schema doesn't have any tables (e.g. all hidden) or if a collection doesn't have models/questions inside
3. Adds an empty state when there are no available databases

### To Verify

The picker isn't used anywhere in the app at the moment, and it's difficult to put in Storybook, so for the setup, we need to actually put it somewhere. I'm currently using the `HomeContent` component for this to put the picker right on the homepage. Here's the code snippet:

<details>
<summary>Data Picker Usage</summary>

```tsx
import React from "react";
import DataPicker, { useDataPickerValue } from "metabase/containers/DataPicker";

const HomeContent = (): JSX.Element | null => {
  const [value, onChange] = useDataPickerValue();

  return (
    <div
      style={{
        display: "flex",
        background: "white",
        height: 500,
        padding: 32,
        borderRadius: 16,
      }}
    >
      <DataPicker value={value} onChange={onChange} />
    </div>
  );
};

export default HomeContent;

```

</details>

1. Picker: Raw Data > Database > Table
2. Ensure you've seen a loading spinner
3. Admin > Data Model > Database > Hide all tables
4. Picker: Raw Data > Database
5. Ensure you can see the "Nothing here" message 

### Demo

https://user-images.githubusercontent.com/17258145/207842934-5297fea2-db54-4a24-8c49-60d1297efe1a.mp4

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/27260)
<!-- Reviewable:end -->
