### PR TITLE
Refactor datetime-diff implementations: sqlserver, mysql, bigquery, redshift, snowflake, vertica, postgres

### DIFF
--- a/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk/query_processor.clj
+++ b/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk/query_processor.clj
@@ -554,8 +554,9 @@
       t (->temporal-type t))))
 
 (defn- datetime-diff-check-args
-  "Validates the types of the datetime args to a `datetime-diff` clause. Bigquery's type handling
-   differs from other drivers, which means we can't use [[sql.qp/datetime-diff-check-args]]."
+  "Validates the types of the datetime args to a `datetime-diff` clause.
+   This is exactly the same as [[sql.qp/datetime-diff-check-args]] except it uses [[temporal-type]]`
+   to get the type of each arg, not [[hx/database-type]], which is needed for bigquery."
   [x y]
   (doseq [arg [x y]
           :let [db-type (some-> (temporal-type arg) name)]

--- a/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk/query_processor.clj
+++ b/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk/query_processor.clj
@@ -553,80 +553,69 @@
     (cond->> ((get-method sql.qp/->honeysql [:sql :relative-datetime]) driver clause)
       t (->temporal-type t))))
 
+(defn- datetime-diff-check-args
+  "Validates the types of the datetime args to a `datetime-diff` clause. Bigquery's type handling
+   differs from other drivers, which means we can't use [[sql.qp/datetime-diff-check-args]]."
+  [x y]
+  (doseq [arg [x y]
+          :let [db-type (some-> (temporal-type arg) name)]
+          :when (and db-type (not (re-find #"^(?i)(timestamp|date)" db-type)))]
+    (throw (ex-info (tru "datetimeDiff only allows datetime, timestamp, or date types. Found {0}"
+                         (pr-str db-type))
+                    {:found db-type
+                     :type  qp.error-type/invalid-query}))))
+
 (defmethod sql.qp/->honeysql [:bigquery-cloud-sdk :datetime-diff]
   [driver [_ x y unit]]
-  (let [x               (sql.qp/->honeysql driver x)
-        y               (sql.qp/->honeysql driver y)
-        disallowed-types (keep
-                          (fn [x]
-                            (when-not (contains? #{:timestamp :date :datetime} (temporal-type x))
-                              (or (some-> (temporal-type x) name)
-                                  (hx/type-info->db-type (hx/type-info x)))))
-                          [x y])
-        x                (hx/->timestamp x)
-        y                (hx/->timestamp y)]
-    (when (seq disallowed-types)
-      (throw
-       (ex-info (tru "datetimeDiff only allows datetime, timestamp, or date types. Found {0}"
-                     (pr-str disallowed-types))
-                {:allowed #{:timestamp :datetime :date}
-                 :found   disallowed-types
-                 :type    qp.error-type/invalid-query})))
-    (case unit
-      :year
-      (let [positive-diff (fn [a b] ; precondition: a <= b
-                            (hx/-
-                             (hx/- (extract :year b) (extract :year a))
-                             ;; decrement if a is later than b in the year calendar
-                             (hx/cast
-                              :integer
-                              (hsql/call
-                               :or
-                               (hsql/call :> (extract :month a) (extract :month b))
-                               (hsql/call
-                                :and
-                                (hsql/call := (extract :month a) (extract :month b))
-                                (hsql/call :> (extract :day a) (extract :day b)))))))]
-        (hsql/call :case (hsql/call :<= x y) (positive-diff x y) :else (hx/* -1 (positive-diff y x))))
+  (let [x (sql.qp/->honeysql driver x)
+        y (sql.qp/->honeysql driver y)
+        _ (datetime-diff-check-args x y)]
+    (sql.qp/datetime-diff driver unit x y)))
 
-      :quarter
-      (let [positive-diff (fn [a b] ; precondition: a <= b
-                            (hx/cast
-                             :integer
-                             (hx/floor
-                               (hx//
-                                (hx/-
-                                 ;; timestamp_diff doesn't support months, so convert to datetime to use datetime_diff
-                                 (hsql/call :datetime_diff (hx/->datetime b) (hx/->datetime a) (hsql/raw "month"))
-                                 (hx/cast :integer (hsql/call :> (extract :day a) (extract :day b))))
-                                3))))]
-        (hsql/call :case (hsql/call :<= x y) (positive-diff x y) :else (hx/* -1 (positive-diff y x))))
+(defn- timestamp-diff [unit x y]
+  (hsql/call :timestamp_diff y x (hsql/raw (name unit))))
 
-      :month
-      (let [positive-diff (fn [a b] ; precondition: a <= b
-                            (hx/-
-                             ;; timestamp_diff doesn't support months, so convert to datetime to use datetime_diff
-                             (hsql/call :datetime_diff (hx/->datetime b) (hx/->datetime a) (hsql/raw "month"))
-                             (hx/cast :integer (hsql/call :> (extract :day a) (extract :day b)))))]
-        (hsql/call :case (hsql/call :<= x y) (positive-diff x y) :else (hx/* -1 (positive-diff y x))))
+(defmethod sql.qp/datetime-diff [:bigquery-cloud-sdk :year]
+  [driver _unit x y]
+  (hx// (sql.qp/datetime-diff driver :month x y) 12))
 
-      :week
-      (let [x (trunc :day x)
-            y (trunc :day y)
-            positive-diff (fn [a b]
-                            (hx/cast
-                             :integer
-                             (hx/floor
-                              (hx// (hsql/call :timestamp_diff b a (hsql/raw "day")) 7))))]
-        (hsql/call :case (hsql/call :<= x y) (positive-diff x y) :else (hx/* -1 (positive-diff y x))))
+(defmethod sql.qp/datetime-diff [:bigquery-cloud-sdk :quarter]
+  [driver _unit x y]
+  (hx// (sql.qp/datetime-diff driver :month x y) 3))
 
-      :day
-      (let [x (trunc :day x)
-            y (trunc :day y)]
-        (hsql/call :timestamp_diff y x (hsql/raw (name unit))))
+(defmethod sql.qp/datetime-diff [:bigquery-cloud-sdk :month]
+  [_driver _unit x y]
+  ;; Only bigquery's `datetime_diff` supports months. We need to convert args to datetime to use it.
+  ;; Also `<` and `>` comparisons can only be made on the same type.
+  (let [x' (hx/->datetime x)
+        y' (hx/->datetime y)]
+    (hx/+ (hsql/call :datetime_diff y' x' (hsql/raw "month"))
+          ;; datetime_diff counts month boundaries not whole months, so we need to adjust
+          ;; if x<y but x>y in the month calendar then subtract one month
+          ;; if x>y but x<y in the month calendar then add one month
+          (hsql/call
+           :case
+           (hsql/call :and (hsql/call :< x' y') (hsql/call :> (extract :day x) (extract :day y)))
+           -1
+           (hsql/call :and (hsql/call :> x' y') (hsql/call :< (extract :day x) (extract :day y)))
+           1
+           :else 0))))
 
-      (:hour :minute :second)
-      (hsql/call :timestamp_diff y x (hsql/raw (name unit))))))
+(defmethod sql.qp/datetime-diff [:bigquery-cloud-sdk :week]
+  [driver _unit x y]
+  (hx// (sql.qp/datetime-diff driver :day x y) 7))
+
+(defmethod sql.qp/datetime-diff [:bigquery-cloud-sdk :day]
+  [_driver _unit x y]
+  (timestamp-diff :day (trunc :day x) (trunc :day y)))
+
+(defmethod sql.qp/datetime-diff [:bigquery-cloud-sdk :hour]
+  [_driver _unit x y]
+  ;; timestamp_diff with hours only has millisecond precision if the args are cast to a timestamp
+  (timestamp-diff :hour (hx/->timestamp x) (hx/->timestamp y)))
+
+(defmethod sql.qp/datetime-diff [:bigquery-cloud-sdk :minute] [_driver _unit x y] (timestamp-diff :minute x y))
+(defmethod sql.qp/datetime-diff [:bigquery-cloud-sdk :second] [_driver _unit x y] (timestamp-diff :second x y))
 
 (defmethod driver/escape-alias :bigquery-cloud-sdk
   [driver s]

--- a/modules/drivers/redshift/src/metabase/driver/redshift.clj
+++ b/modules/drivers/redshift/src/metabase/driver/redshift.clj
@@ -241,11 +241,11 @@
 
 (defmethod sql.qp/datetime-diff [:redshift :hour]
   [driver _unit x y]
-  (hx// (sql.qp/datetime-diff driver :seconds x y) 3600))
+  (hx// (sql.qp/datetime-diff driver :second x y) 3600))
 
 (defmethod sql.qp/datetime-diff [:redshift :minute]
   [driver _unit x y]
-  (hx// (sql.qp/datetime-diff driver :seconds x y) 60))
+  (hx// (sql.qp/datetime-diff driver :second x y) 60))
 
 (defmethod sql.qp/datetime-diff [:redshift :second]
   [_driver _unit x y]

--- a/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
+++ b/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
@@ -251,8 +251,8 @@
 (defn- sub-day-datediff
   "Same as snowflake's `datediff`, but accurate to the millisecond for sub-day units."
   [unit x y]
-  (let [milliseconds (hx/cast :float (hsql/call :datediff (hsql/raw "milliseconds") x y))]
-    ; millseconds needs to be cast to float because division rounds incorrectly with large integers
+  (let [milliseconds (hsql/call :datediff (hsql/raw "milliseconds") x y)]
+    ;; millseconds needs to be cast to float because division rounds incorrectly with large integers
     (hsql/call :trunc (hx// (hx/cast :float milliseconds)
                             (case unit :hour 3600000 :minute 60000 :second 1000)))))
 

--- a/modules/drivers/sqlserver/src/metabase/driver/sqlserver.clj
+++ b/modules/drivers/sqlserver/src/metabase/driver/sqlserver.clj
@@ -19,12 +19,10 @@
             [metabase.driver.sql.util :as sql.u]
             [metabase.driver.sql.util.unprepare :as unprepare]
             [metabase.mbql.util :as mbql.u]
-            [metabase.query-processor.error-type :as qp.error-type]
             [metabase.query-processor.interface :as qp.i]
             [metabase.query-processor.timezone :as qp.timezone]
-            [metabase.util :as u]
             [metabase.util.honeysql-extensions :as hx]
-            [metabase.util.i18n :refer [trs tru]])
+            [metabase.util.i18n :refer [trs]])
   (:import [java.sql Connection ResultSet Time]
            [java.time LocalDate LocalDateTime LocalTime OffsetDateTime OffsetTime ZonedDateTime]))
 
@@ -282,20 +280,7 @@
   [driver [_ x y unit]]
   (let [x (sql.qp/->honeysql driver x)
         y (sql.qp/->honeysql driver y)
-        disallowed-types (keep
-                          (fn [v]
-                            (some-> v
-                                    hx/type-info
-                                    hx/type-info->db-type
-                                    name
-                                    u/lower-case-en
-                                    #{"time"}))
-                          [x y])
-        _ (when (seq disallowed-types)
-            (throw (ex-info (tru "datetimeDiff only allows datetime, timestamp, or date types. Found {0}"
-                                 (pr-str disallowed-types))
-                            {:found disallowed-types
-                             :type  qp.error-type/invalid-query})))
+        _ (sql.qp/datetime-diff-check-args x y (partial re-find #"(?i)^(timestamp|date)"))
         x (if (hx/is-of-type? x "datetimeoffset")
             (hx/->AtTimeZone x (zone-id->windows-zone (qp.timezone/results-timezone-id)))
             x)
@@ -304,84 +289,33 @@
             (hx/->AtTimeZone y (zone-id->windows-zone (qp.timezone/results-timezone-id)))
             y)
         y (hx/cast "datetime2" y)]
-    (case unit
-      :year
-      (let [positive-diff (fn [a b] ; precondition: a <= b
-                            (hx/-
-                             (date-diff :year a b)
-                             (hsql/call
-                              :case
-                              (hsql/call
-                               :or
-                               (hsql/call :> (date-part :month a) (date-part :month b))
-                               (hsql/call
-                                :and
-                                (hsql/call := (date-part :month a) (date-part :month b))
-                                (hsql/call :> (date-part :day a) (date-part :day b))))
-                              1
-                              :else
-                              0)))]
-        (hsql/call :case
-                   (hsql/call :<= (hx/->datetime x) (hx/->datetime y))
-                   (positive-diff x y)
-                   :else
-                   (hx/* -1 (positive-diff y x))))
+    (sql.qp/datetime-diff driver unit x y)))
 
-      :quarter
-      (let [positive-diff
-            (fn [a b]
-              (hx/cast
-               :integer
-               (hx/floor (hx// (hx/- (date-diff :month a b)
-                                     (hsql/call :case (hsql/call :> (date-part :day a) (date-part :day b)) 1 :else 0))
-                               3))))]
-        (hsql/call :case
-                   (hsql/call :<= (hx/->datetime x) (hx/->datetime y))
-                   (positive-diff x y)
-                   :else
-                   (hx/* -1 (positive-diff y x))))
+(defmethod sql.qp/datetime-diff [:sqlserver :year]
+  [driver _unit x y]
+  (hx// (sql.qp/datetime-diff driver :month x y) 12))
 
-      :month
-      (let [positive-diff (fn [a b]
-                            (hx/-
-                             (date-diff :month a b)
-                             (hsql/call
-                              :case
-                              (hsql/call :> (date-part :day a) (date-part :day b))
-                              1
-                              :else
-                              0)))]
-        (hsql/call :case
-                   (hsql/call :<= (hx/->datetime x) (hx/->datetime y))
-                   (positive-diff x y)
-                   :else
-                   (hx/* -1 (positive-diff y x))))
+(defmethod sql.qp/datetime-diff [:sqlserver :quarter]
+  [driver _unit x y]
+  (hx// (sql.qp/datetime-diff driver :month x y) 3))
 
-      :week
-      (let [positive-diff (fn [a b]
-                            (hx/cast
-                             :integer
-                             (hx/floor
-                              (hx// (date-diff :day a b) 7))))]
-        (hsql/call :case
-                   (hsql/call :<= (hx/->datetime x) (hx/->datetime y))
-                   (positive-diff x y)
-                   :else
-                   (hx/* -1 (positive-diff y x))))
+(defmethod sql.qp/datetime-diff [:sqlserver :month]
+  [_driver _unit x y]
+  (hx/+ (date-diff :month x y)
+        ;; datediff counts month boundaries not whole months, so we need to adjust
+        ;; if x<y but x>y in the month calendar then subtract one month
+        ;; if x>y but x<y in the month calendar then add one month
+        (hsql/call
+         :case
+         (hsql/call :and (hsql/call :< x y) (hsql/call :> (date-part :day x) (date-part :day y))) -1
+         (hsql/call :and (hsql/call :> x y) (hsql/call :< (date-part :day x) (date-part :day y))) 1
+         :else 0)))
 
-      :day
-      (date-diff :day x y)
-
-      (:hour :minute :second)
-      (let [positive-diff (fn [a b]
-                            (hx/floor
-                             (hx// (date-diff :millisecond a b)
-                                   (case unit :hour 3600000 :minute 60000 :second 1000))))]
-        (hsql/call :case
-                   (hsql/call :<= (hx/->datetime x) (hx/->datetime y))
-                   (positive-diff x y)
-                   :else
-                   (hx/* -1 (positive-diff y x)))))))
+(defmethod sql.qp/datetime-diff [:sqlserver :week] [_driver _unit x y] (hx// (date-diff :day x y) 7))
+(defmethod sql.qp/datetime-diff [:sqlserver :day] [_driver _unit x y] (date-diff :day x y))
+(defmethod sql.qp/datetime-diff [:sqlserver :hour] [_driver _unit x y] (hx// (date-diff :millisecond x y) 3600000))
+(defmethod sql.qp/datetime-diff [:sqlserver :minute] [_driver _unit x y] (date-diff :minute x y))
+(defmethod sql.qp/datetime-diff [:sqlserver :second] [_driver _unit x y] (date-diff :second x y))
 
 (defmethod sql.qp/cast-temporal-string [:sqlserver :Coercion/ISO8601->DateTime]
   [_driver _semantic_type expr]

--- a/modules/drivers/vertica/src/metabase/driver/vertica.clj
+++ b/modules/drivers/vertica/src/metabase/driver/vertica.clj
@@ -138,88 +138,52 @@
        (reduce (partial hsql/call :concat))))
 
 (defmethod sql.qp/datetime-diff [:vertica :year]
-  [_driver _unit x y]
-  (let [positive-diff (fn [a b] ; precondition: a <= b
-                        (hx/-
-                         (datediff :year a b)
-                         (hx/cast
-                          :integer
-                          (hsql/call
-                           :or
-                           (hsql/call :> (extract :month a) (extract :month b))
-                           (hsql/call
-                            :and
-                            (hsql/call := (extract :month a) (extract :month b))
-                            (hsql/call :> (extract :day a) (extract :day b)))))))]
-    (hsql/call :case
-               (hsql/call :<= (cast-timestamp x) (cast-timestamp y))
-               (positive-diff x y)
-               :else
-               (hx/* -1 (positive-diff y x)))))
+  [driver _unit x y]
+  (let [months (sql.qp/datetime-diff driver :month x y)]
+    (hx/->integer (hsql/call :trunc (hx// months 12)))))
 
 (defmethod sql.qp/datetime-diff [:vertica :quarter]
-  [_driver _unit x y]
-  (let [positive-diff
-        (fn [a b]
-          (hx/cast
-           :integer
-           (hx/floor (hx// (hx/- (datediff :month a b)
-                                 (hx/cast :integer (hsql/call :> (extract :day a) (extract :day b))))
-                           3))))]
-    (hsql/call :case
-               (hsql/call :<= (cast-timestamp x) (cast-timestamp y))
-               (positive-diff x y)
-               :else
-               (hx/* -1 (positive-diff y x)))))
+  [driver _unit x y]
+  (let [months (sql.qp/datetime-diff driver :month x y)]
+    (hx/->integer (hsql/call :trunc (hx// months 3)))))
 
 (defmethod sql.qp/datetime-diff [:vertica :month]
   [_driver _unit x y]
-  (let [positive-diff (fn [a b]
-                        (hx/-
-                         (datediff :month a b)
-                         (hx/cast
-                          :integer
-                          (hsql/call :> (extract :day a) (extract :day b)))))]
-    (hsql/call :case
-               (hsql/call :<= (cast-timestamp x) (cast-timestamp y))
-               (positive-diff x y)
-               :else
-               (hx/* -1 (positive-diff y x)))))
+  (hx/+ (datediff :month x y)
+        ;; datediff counts month boundaries not whole months, so we need to adjust
+        ;; if x<y but x>y in the month calendar then subtract one month
+        ;; if x>y but x<y in the month calendar then add one month
+        (hsql/call
+         :case
+         (hsql/call :and
+                    (hsql/call :< (cast-timestamp x) (cast-timestamp y))
+                    (hsql/call :> (extract :day x) (extract :day y))) -1
+         (hsql/call :and
+                    (hsql/call :> (cast-timestamp x) (cast-timestamp y))
+                    (hsql/call :< (extract :day x) (extract :day y))) 1
+         :else 0)))
 
 (defmethod sql.qp/datetime-diff [:vertica :week]
   [_driver _unit x y]
-  (let [positive-diff
-        (fn [a b]
-          (hx/cast :integer (hx/floor (hx// (datediff :day a b) 7))))]
-    (hsql/call :case
-               (hsql/call :<= (cast-timestamp x) (cast-timestamp y))
-               (positive-diff x y)
-               :else
-               (hx/* -1 (positive-diff y x)))))
+  (hx/->integer (hsql/call :trunc (hx// (datediff :day x y) 7))))
 
 (defmethod sql.qp/datetime-diff [:vertica :day]
   [_driver _unit x y]
   (datediff :day x y))
 
-(defn- sub-day-diff-helper
-  [unit x y]
-  (let [positive-diff
-        (fn [a b]
-          (hx/cast
-           :integer
-           (hx/floor
-            (cond-> (hsql/call :- (extract :epoch b) (extract :epoch a))
-              (not= unit :second)
-              (hx// (case unit :hour 3600 :minute 60))))))]
-    (hsql/call :case
-               (hsql/call :<= (cast-timestamp x) (cast-timestamp y))
-               (positive-diff x y)
-               :else
-               (hx/* -1 (positive-diff y x)))))
+(defmethod sql.qp/datetime-diff [:vertica :hour]
+  [_driver _unit x y]
+  (let [seconds (hx/- (extract :epoch y) (extract :epoch x))]
+    (hx/->integer (hsql/call :trunc (hx// seconds 3600)))))
 
-(defmethod sql.qp/datetime-diff [:vertica :hour] [_driver _unit x y] (sub-day-diff-helper :hour x y))
-(defmethod sql.qp/datetime-diff [:vertica :minute] [_driver _unit x y] (sub-day-diff-helper :minute x y))
-(defmethod sql.qp/datetime-diff [:vertica :second] [_driver _unit x y] (sub-day-diff-helper :second x y))
+(defmethod sql.qp/datetime-diff [:vertica :minute]
+  [_driver _unit x y]
+  (let [seconds (hx/- (extract :epoch y) (extract :epoch x))]
+    (hx/->integer (hsql/call :trunc (hx// seconds 60)))))
+
+(defmethod sql.qp/datetime-diff [:vertica :second]
+  [_driver _unit x y]
+  (hx/->integer (hsql/call :trunc (hx/- (extract :epoch y) (extract :epoch x)))))
 
 (defmethod sql.qp/->honeysql [:vertica :regex-match-first]
   [driver [_ arg pattern]]

--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -22,13 +22,12 @@
             [metabase.driver.sql.util :as sql.u]
             [metabase.driver.sql.util.unprepare :as unprepare]
             [metabase.models.field :as field]
-            [metabase.query-processor.error-type :as qp.error-type]
             [metabase.query-processor.store :as qp.store]
             [metabase.query-processor.timezone :as qp.timezone]
             [metabase.query-processor.util.add-alias-info :as add]
             [metabase.util :as u]
             [metabase.util.honeysql-extensions :as hx]
-            [metabase.util.i18n :refer [deferred-tru trs tru]])
+            [metabase.util.i18n :refer [deferred-tru trs]])
   (:import [java.sql DatabaseMetaData ResultSet ResultSetMetaData Types]
            [java.time LocalDateTime OffsetDateTime OffsetTime ZonedDateTime]
            metabase.util.honeysql_extensions.Identifier))
@@ -368,42 +367,20 @@
       (hsql/call :convert_tz expr (or source-timezone (qp.timezone/results-timezone-id)) target-timezone)
       "datetime")))
 
-(defn- datetime-diff-helper [x y unit]
-  (case unit
-    (:year :month)
-    (hsql/call :timestampdiff (hsql/raw (name unit)) (hsql/call :date x) (hsql/call :date y))
+(defn- timestampdiff-dates [unit x y]
+  (hsql/call :timestampdiff (hsql/raw (name unit)) (hx/->date x) (hx/->date y)))
 
-    :week
-    (let [positive-diff (fn [a b] (hx/floor (hx// (hsql/call :datediff b a) 7)))]
-      (hsql/call :case (hsql/call :<= x y) (positive-diff x y) :else (hx/* -1 (positive-diff y x))))
+(defn- timestampdiff [unit x y]
+  (hsql/call :timestampdiff (hsql/raw (name unit)) x y))
 
-    :quarter
-    (let [positive-diff (fn [a b] (hx/floor (hx// (datetime-diff-helper a b :month) 3)))]
-      (hsql/call :case (hsql/call :<= x y) (positive-diff x y) :else (hx/* -1 (positive-diff y x))))
-
-    :day
-    (hsql/call :datediff y x)
-
-    (:hour :minute :second)
-    (hsql/call :timestampdiff (hsql/raw (name unit)) x y)))
-
-(defmethod sql.qp/->honeysql [:mysql :datetime-diff]
-  [driver [_ x y unit]]
-  (let [x (sql.qp/->honeysql driver x)
-        y (sql.qp/->honeysql driver y)
-        disallowed-types (keep
-                          (fn [v]
-                            (when-let [db-type (some-> v hx/type-info hx/type-info->db-type u/upper-case-en keyword)]
-                              (let [base-type (sql-jdbc.sync/database-type->base-type driver db-type)]
-                                (when-not (some #(isa? base-type %) [:type/Date :type/DateTime])
-                                  (name db-type)))))
-                          [x y])]
-    (when (seq disallowed-types)
-      (throw (ex-info (tru "datetimeDiff only allows datetime, timestamp, or date types. Found {0}"
-                           (pr-str disallowed-types))
-                      {:found disallowed-types
-                       :type  qp.error-type/invalid-query})))
-    (datetime-diff-helper x y unit)))
+(defmethod sql.qp/datetime-diff [:mysql :year]    [_driver _unit x y] (timestampdiff-dates :year x y))
+(defmethod sql.qp/datetime-diff [:mysql :quarter] [_driver _unit x y] (timestampdiff-dates :quarter x y))
+(defmethod sql.qp/datetime-diff [:mysql :month]   [_driver _unit x y] (timestampdiff-dates :month x y))
+(defmethod sql.qp/datetime-diff [:mysql :week]    [_driver _unit x y] (timestampdiff-dates :week x y))
+(defmethod sql.qp/datetime-diff [:mysql :day]     [_driver _unit x y] (hsql/call :datediff y x))
+(defmethod sql.qp/datetime-diff [:mysql :hour]    [_driver _unit x y] (timestampdiff :hour x y))
+(defmethod sql.qp/datetime-diff [:mysql :minute]  [_driver _unit x y] (timestampdiff :minute x y))
+(defmethod sql.qp/datetime-diff [:mysql :second]  [_driver _unit x y] (timestampdiff :second x y))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                         metabase.driver.sql-jdbc impls                                         |


### PR DESCRIPTION
This PR refactors the existing datetime-diff implementations on the master branch to be tidier.
- changes several datetime-diff implementations to use a multimethod instead of a case statement
- simplifies implementations after I discovered the `trunc` SQL function and how integer division works for most databases.
- adds comments and names where the logic behind the implementation is obscure

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/27262)
<!-- Reviewable:end -->
