### PR TITLE
Revert default behavior on 45 for embedding `top_nav`

### DIFF
--- a/frontend/src/metabase/redux/embed.js
+++ b/frontend/src/metabase/redux/embed.js
@@ -5,7 +5,7 @@ import {
 } from "metabase/lib/redux";
 
 const DEFAULT_OPTIONS = {
-  top_nav: true,
+  top_nav: false,
   side_nav: "default",
   search: false,
   new_button: false,

--- a/frontend/test/metabase/scenarios/embedding/embedding-full-app.cy.spec.js
+++ b/frontend/test/metabase/scenarios/embedding/embedding-full-app.cy.spec.js
@@ -11,49 +11,43 @@ describe("scenarios > embedding > full app", () => {
   });
 
   describe("navigation", () => {
-    it("should show the top nav and breadcrumbs by default", () => {
+    it("should hide the top nav by default", () => {
       visitUrl({ url: "/" });
+      cy.findByText("Our analytics").should("be.visible");
+      cy.findByTestId("main-logo").should("not.exist");
+    });
+
+    it("should show breadcrumbs by default when top nav is enabled", () => {
+      visitUrl({ url: "/", qs: { top_nav: true } });
       cy.findByText("Our analytics").should("be.visible");
       cy.findByTestId("main-logo").should("be.visible");
     });
 
-    it("should hide the top nav by a param", () => {
-      visitUrl({ url: "/", qs: { top_nav: false } });
-      cy.findByText("Our analytics").should("not.exist");
-      cy.findByTestId("main-logo").should("not.exist");
-    });
-
-    it("should hide the top nav when all nav elements are hidden", () => {
-      visitUrl({ url: "/", qs: { breadcrumbs: false } });
-      cy.findByText("Our analytics").should("not.exist");
-      cy.findByTestId("main-logo").should("not.exist");
-    });
-
     it("should show the top nav by a param", () => {
-      visitUrl({ url: "/" });
+      visitUrl({ url: "/", qs: { top_nav: true } });
       cy.findByTestId("main-logo").should("be.visible");
       cy.button(/New/).should("not.exist");
       cy.findByPlaceholderText("Search").should("not.exist");
     });
 
     it("should hide the side nav by a param", () => {
-      visitUrl({ url: "/", qs: { side_nav: false } });
+      visitUrl({ url: "/", qs: { top_nav: true, side_nav: false } });
       cy.findByTestId("main-logo").should("be.visible");
       cy.findByText("Our analytics").should("not.exist");
     });
 
     it("should show question creation controls by a param", () => {
-      visitUrl({ url: "/", qs: { new_button: true } });
+      visitUrl({ url: "/", qs: { top_nav: true, new_button: true } });
       cy.button(/New/).should("be.visible");
     });
 
     it("should show search controls by a param", () => {
-      visitUrl({ url: "/", qs: { search: true } });
+      visitUrl({ url: "/", qs: { top_nav: true, search: true } });
       cy.findByPlaceholderText("Search…").should("be.visible");
     });
 
     it("should preserve params when navigating", () => {
-      visitUrl({ url: "/" });
+      visitUrl({ url: "/", qs: { top_nav: true } });
       cy.findByTestId("main-logo").should("be.visible");
 
       cy.findByText("Our analytics").click();
@@ -85,7 +79,7 @@ describe("scenarios > embedding > full app", () => {
     it("should hide the question's additional info by a param", () => {
       visitQuestionUrl({ url: "/question/1", qs: { additional_info: false } });
 
-      cy.findByText("Our analytics").should("be.visible");
+      cy.findByText("Our analytics").should("not.exist");
       cy.findByText(/Edited/).should("not.exist");
     });
 
@@ -121,7 +115,7 @@ describe("scenarios > embedding > full app", () => {
 
       cy.findByText("Orders in a dashboard").should("be.visible");
       cy.findByText(/Edited/).should("not.exist");
-      cy.findByText("Our analytics").should("be.visible");
+      cy.findByText("Our analytics").should("not.exist");
     });
 
     it("should preserve embedding options with click behavior (metabase#24756)", () => {
@@ -131,6 +125,7 @@ describe("scenarios > embedding > full app", () => {
       });
       visitDashboardUrl({
         url: "/dashboard/1",
+        qs: { top_nav: true },
       });
 
       cy.findAllByRole("cell").first().click();


### PR DESCRIPTION
This revert the behavior of the backport PR https://github.com/metabase/metabase/pull/27243 which introduced a change to the `top_nav` option in embedding.
