### PR TITLE
Report DBMS versions as a JSON string

### DIFF
--- a/src/metabase/analytics/stats.clj
+++ b/src/metabase/analytics/stats.clj
@@ -1,6 +1,7 @@
 (ns metabase.analytics.stats
   "Functions which summarize the usage of an instance"
-  (:require [clj-http.client :as http]
+  (:require [cheshire.core :as json]
+            [clj-http.client :as http]
             [clojure.string :as str]
             [clojure.tools.logging :as log]
             [java-time :as t]
@@ -278,7 +279,12 @@
     {:databases (merge-count-maps (for [{is-full-sync? :is_full_sync} databases]
                                     {:total    1
                                      :analyzed is-full-sync?}))
-     :dbms_versions (frequencies (map #(assoc (:dbms_version %) :engine (:engine %)) databases))}))
+     :dbms_versions (frequencies (map (fn [db]
+                                        (-> db
+                                            :dbms_version
+                                            (assoc :engine (:engine db))
+                                            json/generate-string))
+                                      databases))}))
 
 
 (defn- table-metrics

--- a/test/metabase/analytics/stats_test.clj
+++ b/test/metabase/analytics/stats_test.clj
@@ -68,9 +68,7 @@
     "10000+"     100000))
 
 (def DBMSVersionStats
-  {{:engine                   s/Keyword
-    (s/optional-key :version) (s/maybe su/NonBlankString)
-    s/Keyword                 s/Any}                      su/NonNegativeInt})
+  {s/Str su/NonNegativeInt})
 
 (deftest anonymous-usage-stats-test
   (with-redefs [email/email-configured? (constantly false)


### PR DESCRIPTION
Related to #13444. Without this conversion the data ends up as an EDN string in the `usage_stats` table and that's not easily accessible in PostgreSQL.
