### PR TITLE
Adds custom ->honeysql for :substring in MySQL

### DIFF
--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -245,6 +245,17 @@
   [_ value]
   (hx/maybe-cast :signed value))
 
+(defmethod sql.qp/->honeysql [:mysql :substring]
+  [driver [_ arg start length]]
+  ;; Unlike most databases, MySQL returns an empty string when start=0, so to make MBQL substring
+  ;; work consistently across all RDMBSs we turn a 0 start index into 1
+  (let [start (if (and (number? start) (zero? start))
+                1
+                start)]
+    (if length
+      (hsql/call :substring (sql.qp/->honeysql driver arg) (sql.qp/->honeysql driver start) (sql.qp/->honeysql driver length))
+      (hsql/call :substring (sql.qp/->honeysql driver arg) (sql.qp/->honeysql driver start)))))
+
 (defmethod sql.qp/->honeysql [:mysql :regex-match-first]
   [driver [_ arg pattern]]
   (hsql/call :regexp_substr (sql.qp/->honeysql driver arg) (sql.qp/->honeysql driver pattern)))

--- a/test/metabase/query_processor_test/string_extracts_test.clj
+++ b/test/metabase/query_processor_test/string_extracts_test.clj
@@ -43,6 +43,8 @@
 
 (deftest test-substring
   (mt/test-drivers (mt/normal-drivers-with-feature :expressions)
+    ;; start index 0 and 1 should behave the same across all drivers
+    (is (= "Red" (test-string-extract [:substring [:field (data/id :venues :name) nil] 0 3])))
     (is (= "Red" (test-string-extract [:substring [:field (data/id :venues :name) nil] 1 3])))
     (is (= "ed Medicine" (test-string-extract [:substring [:field (data/id :venues :name) nil] 2])))
     (is (= "Red Medicin" (test-string-extract [:substring [:field (data/id :venues :name) nil]


### PR DESCRIPTION
In MySQL, the SUBSTRING function returns an empty string when the start argument is 0, unlike most other DB drivers which generally treat 0 and 1 interchangeably. To make SUBSTRING consistent across DB drivers, we will convert a 0 start index in MBQL to 1 in MySQL.

Resolves #12445
