### PR TITLE
Test snowflake throws on datetime-diff with time arg

### DIFF
--- a/test/metabase/query_processor_test/date_time_zone_functions_test.clj
+++ b/test/metabase/query_processor_test/date_time_zone_functions_test.clj
@@ -959,8 +959,7 @@
                       first))))))))
 
 (deftest datetime-diff-type-test
-  (mt/test-drivers (->> (disj (mt/normal-drivers-with-feature :datetime-diff) :snowflake)
-                        (filter mt/supports-time-type?))
+  (mt/test-drivers (filter mt/supports-time-type? (mt/normal-drivers-with-feature :datetime-diff))
     (testing "Cannot datetime-diff against time column"
       (mt/dataset test-data-with-time
         (is (thrown-with-msg?


### PR DESCRIPTION
Previously snowflake didn't throw an error if an argument to datetimeDiff was of type :type/Time, unlike other drivers.

This was fixed in https://github.com/metabase/metabase/pull/27262.

This PR adds snowflake to the relevant test.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/27277)
<!-- Reviewable:end -->
