### PR TITLE
Improve bin/kondo.sh script

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -46,49 +46,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Run clj-kondo
-      run: >-
-        docker run
-        --volume $PWD:/work
-        --rm cljkondo/clj-kondo:2022.08.03
-        clj-kondo
-        --config /work/.clj-kondo/config.edn
-        --config-dir /work/.clj-kondo
-        --parallel
-        --lint
-        /work/src
-        /work/test
-        /work/enterprise/backend/src
-        /work/enterprise/backend/test
-        /work/shared/src
-        /work/shared/test
-        /work/modules/drivers/sparksql/src
-        /work/modules/drivers/sparksql/test
-        /work/modules/drivers/vertica/src
-        /work/modules/drivers/vertica/test
-        /work/modules/drivers/presto-common/src
-        /work/modules/drivers/presto-common/test
-        /work/modules/drivers/presto/src
-        /work/modules/drivers/presto/test
-        /work/modules/drivers/mongo/src
-        /work/modules/drivers/mongo/test
-        /work/modules/drivers/oracle/src
-        /work/modules/drivers/oracle/test
-        /work/modules/drivers/sqlite/src
-        /work/modules/drivers/sqlite/test
-        /work/modules/drivers/bigquery-cloud-sdk/src
-        /work/modules/drivers/bigquery-cloud-sdk/test
-        /work/modules/drivers/redshift/src
-        /work/modules/drivers/redshift/test
-        /work/modules/drivers/snowflake/src
-        /work/modules/drivers/snowflake/test
-        /work/modules/drivers/googleanalytics/src
-        /work/modules/drivers/googleanalytics/test
-        /work/modules/drivers/druid/src
-        /work/modules/drivers/druid/test
-        /work/modules/drivers/sqlserver/src
-        /work/modules/drivers/sqlserver/test
-        /work/modules/drivers/presto-jdbc/src
-        /work/modules/drivers/presto-jdbc/test
+      run: bin/kondo.sh
 
   be-linter-eastwood:
     runs-on: ubuntu-20.04

--- a/bin/kondo.sh
+++ b/bin/kondo.sh
@@ -1,18 +1,10 @@
 #! /usr/bin/env bash
 
-set -euxo pipefail
+# Convenience/CI script for running clj-kondo against all source and test directories using Docker
 
-# Convenience for running clj-kondo against all the appropriate directories.
+set -ex
 
-# Copy over Kondo configs from libraries we use.
-
-clj-kondo --copy-configs --dependencies --lint "$(clojure -A:dev -Spath)" --skip-lint --parallel
-
-# Run Kondo against all of our Clojure files in the various directories they might live.
-find modules/drivers shared enterprise/backend \
-     -maxdepth 2 \
-     -type d \
-     -name src -or -name test \
-    | xargs clj-kondo \
-            --parallel \
-            --lint src test
+docker run --rm --volume $PWD:/work --workdir /work cljkondo/clj-kondo:2022.08.03 \
+    clj-kondo --config .clj-kondo/config.edn --config-dir .clj-kondo \
+    --parallel --lint src test \
+    $(find shared modules/drivers enterprise/backend -maxdepth 2 -type d \( -name src -o -name test \))

--- a/bin/kondo.sh
+++ b/bin/kondo.sh
@@ -2,9 +2,13 @@
 
 # Convenience/CI script for running clj-kondo against all source and test directories using Docker
 
+# To use a local clj-kondo installation instead of Docker, set KONDO_CMD=clj-kondo
+
 set -ex
 
-docker run --rm --volume $PWD:/work --workdir /work cljkondo/clj-kondo:2022.08.03 \
-    clj-kondo --config .clj-kondo/config.edn --config-dir .clj-kondo \
-    --parallel --lint src test \
+kondoCmd="${KONDO_CMD:-docker run --rm --volume $PWD:/work --workdir /work cljkondo/clj-kondo:2022.08.03 clj-kondo}"
+
+$kondoCmd --copy-configs --dependencies --lint "$(clojure -A:dev -Spath)" --skip-lint --parallel
+
+$kondoCmd --config .clj-kondo/config.edn --config-dir .clj-kondo --parallel --lint src test \
     $(find shared modules/drivers enterprise/backend -maxdepth 2 -type d \( -name src -o -name test \))

--- a/bin/kondo.sh
+++ b/bin/kondo.sh
@@ -8,7 +8,9 @@ set -ex
 
 kondoCmd="${KONDO_CMD:-docker run --rm --volume $PWD:/work --workdir /work cljkondo/clj-kondo:2022.08.03 clj-kondo}"
 
+# Copy over Kondo configs from libraries we use.
 $kondoCmd --copy-configs --dependencies --lint "$(clojure -A:dev -Spath)" --skip-lint --parallel
 
+# Run Kondo against all of our Clojure files in the various directories they might live.
 $kondoCmd --config .clj-kondo/config.edn --config-dir .clj-kondo --parallel --lint src test \
     $(find shared modules/drivers enterprise/backend -maxdepth 2 -type d \( -name src -o -name test \))

--- a/docs/developers-guide/devenv.md
+++ b/docs/developers-guide/devenv.md
@@ -208,8 +208,6 @@ Some drivers require additional environment variables when testing since they ar
 
 ### Running the linters
 
-`clj-kondo` must be [installed separately](https://github.com/clj-kondo/clj-kondo/blob/master/doc/install.md).
-
 ```
 # Run Eastwood
 clojure -X:dev:ee:ee-dev:drivers:drivers-dev:eastwood
@@ -217,8 +215,8 @@ clojure -X:dev:ee:ee-dev:drivers:drivers-dev:eastwood
 # Run the namespace checker
 clojure -X:dev:ee:ee-dev:drivers:drivers-dev:test:namespace-checker
 
-# Run clj-kondo
-clj-kondo --parallel --lint src shared/src enterprise/backend/src --config .clj-kondo/config.edn
+# Run clj-kondo (uses Docker)
+bin/kondo.sh
 ```
 
 ## Continuous integration


### PR DESCRIPTION
This PR simplifies running `clj-kondo` for developers and updates the backend CI workflow to use `bin/kondo.sh`. The script is updated to use the same Docker-image-based approach as CI. Developers with Docker can run `bin/kondo.sh` whether `clj-kondo` is installed locally or not.

~To use a local executable instead of Docker, set the `KONDO_CMD` env var~

If `clj-kondo` is available on the path, the script will use it, otherwise it will use Docker.