### PR TITLE
Adds network=metabase-dev to devcontainer, git config on startup

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,5 +13,9 @@
 	"forwardPorts": [3000],
 
 	// Comment out the next line to run as root instead.
-	"remoteUser": "vscode"
+	"remoteUser": "vscode",
+
+	"runArgs": ["--network=metabase-dev"],
+
+	"postStartCommand": "git config --global --add safe.directory /workspaces/metabase"
 }


### PR DESCRIPTION
This PR adds the Metabase VS Code dev container to the `metabase-dev` network to enable communication with containers, e.g. database servers, and configures Git options to avoid problems when performing operations initially.

Currently, `dev-scripts` containers do not attach to a network, but they can be added to a network with `docker network connect` so that the dev container can reach them.