### PR TITLE
Adding Subtitle to Series Name Input

### DIFF
--- a/frontend/src/metabase/core/components/Input/Input.tsx
+++ b/frontend/src/metabase/core/components/Input/Input.tsx
@@ -134,4 +134,5 @@ const Input = forwardRef(function Input(
 export default Object.assign(Input, {
   Root: InputRoot,
   Field: InputField,
+  Subtitle: InputSubtitle,
 });

--- a/frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeries.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeries.styled.tsx
@@ -2,6 +2,7 @@ import styled from "@emotion/styled";
 import { color } from "metabase/lib/colors";
 import Icon from "metabase/components/Icon";
 import InputBlurChange from "metabase/components/InputBlurChange";
+import Input from "metabase/core/components/Input";
 
 export const OptionsIcon = styled(Icon)`
   color: ${color("text-medium")};
@@ -14,4 +15,18 @@ export const OptionsIcon = styled(Icon)`
 
 export const SeriesNameInput = styled(InputBlurChange)`
   width: auto;
+
+  ${({ subtitle }) =>
+    subtitle &&
+    `
+    ${Input.Field} {
+      padding-top: 1rem;
+      padding-bottom: 0.375rem;
+    }
+
+    ${Input.Subtitle} {
+      top: 0.375rem;
+      left: 0.875rem;
+    }  
+  `}
 `;

--- a/frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeries.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeries.styled.tsx
@@ -26,7 +26,7 @@ export const SeriesNameInput = styled(InputBlurChange)`
 
     ${Input.Subtitle} {
       top: 0.375rem;
-      left: 0.875rem;
+      left: 0.8rem;
     }  
   `}
 `;

--- a/frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.jsx
@@ -20,21 +20,18 @@ export default class ChartNestedSettingSeriesMultiple extends React.Component {
       objectSettingsWidgets,
       object,
       allComputedSettings,
+      seriesCardNames,
     } = this.props;
     const objectKey = object && getObjectKey(object);
     const isSelected = single => objectKey === getObjectKey(single);
 
-    const display = object && object.card.display;
-    const isLineAreaBar = ["line", "area", "bar", "combo"].includes(display);
-
-    console.log(isLineAreaBar);
-
     return (
-      <div>
+      <div data-testid="series-settings">
         {objects.length < 100 &&
           objects.map(single => {
             const key = getObjectKey(single);
             const settings = allComputedSettings[key] || {};
+            const seriesCardName = seriesCardNames?.[key];
             return (
               <div
                 key={key}
@@ -52,7 +49,11 @@ export default class ChartNestedSettingSeriesMultiple extends React.Component {
                     className="flex-full ml1 align-self-stretch"
                     // set vertical padding to 0 and use align-self-stretch to match siblings
                     style={{ paddingTop: 0, paddingBottom: 0 }}
+                    data-testid="series-name-input"
                     value={settings.title}
+                    subtitle={
+                      seriesCardName !== settings.title ? seriesCardName : ""
+                    }
                     onBlurChange={e =>
                       onChangeObjectSettings(single, { title: e.target.value })
                     }

--- a/frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesMultiple.jsx
@@ -49,10 +49,10 @@ export default class ChartNestedSettingSeriesMultiple extends React.Component {
                     className="flex-full ml1 align-self-stretch"
                     // set vertical padding to 0 and use align-self-stretch to match siblings
                     style={{ paddingTop: 0, paddingBottom: 0 }}
-                    data-testid="series-name-input"
+                    aria-label="series-name-input"
                     value={settings.title}
                     subtitle={
-                      seriesCardName !== settings.title ? seriesCardName : ""
+                      seriesCardName === settings.title ? "" : seriesCardName
                     }
                     onBlurChange={e =>
                       onChangeObjectSettings(single, { title: e.target.value })

--- a/frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesSingle.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesSingle.tsx
@@ -3,17 +3,21 @@ import React from "react";
 
 import { getAccentColors } from "metabase/lib/colors/groups";
 import ColorSelector from "metabase/core/components/ColorSelector";
-import { Series } from "metabase-types/types/Visualization";
+import { SingleSeries } from "metabase-types/types/Visualization";
 import { VisualizationSettings } from "metabase-types/api/card";
 
 import { SeriesNameInput } from "./ChartNestedSettingSeries.styled";
 
 export interface ChartNestedSettingsSeriesSingleProps {
-  object: Series;
-  getObjectKey: (object: Series) => string;
-  onChangeObjectSettings: (object: Series, value: Record<string, any>) => void;
+  object: SingleSeries;
+  getObjectKey: (object: SingleSeries) => string;
+  onChangeObjectSettings: (
+    object: SingleSeries,
+    value: Record<string, any>,
+  ) => void;
   objectSettingsWidgets: React.ReactNode[];
   allComputedSettings: VisualizationSettings;
+  seriesCardNames: Record<string, string>;
 }
 
 // various props injected by chartSettingNestedSettings HOC
@@ -23,12 +27,18 @@ const ChartNestedSettingsSeriesSingle = ({
   objectSettingsWidgets,
   object,
   allComputedSettings,
+  seriesCardNames,
 }: ChartNestedSettingsSeriesSingleProps) => {
   const objectKey = object && getObjectKey(object);
   const computedSettings = allComputedSettings[objectKey] || {};
+  const seriesCardName = seriesCardNames?.[objectKey];
 
   return (
-    <div key={objectKey} className="px4 align-self-stretch">
+    <div
+      key={objectKey}
+      className="px4 align-self-stretch"
+      data-testid="series-settings"
+    >
       <div className="flex align-center border-bottom pb2">
         <ColorSelector
           value={computedSettings.color}
@@ -39,6 +49,9 @@ const ChartNestedSettingsSeriesSingle = ({
           className="flex-full ml1 align-self-stretch"
           value={computedSettings.title}
           data-testid="series-name-input"
+          subtitle={
+            seriesCardName !== computedSettings.title ? seriesCardName : ""
+          }
           onBlurChange={(e: React.ChangeEvent<HTMLInputElement>) =>
             onChangeObjectSettings(object, { title: e.target.value })
           }

--- a/frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesSingle.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartNestedSettingSeriesSingle.tsx
@@ -48,9 +48,9 @@ const ChartNestedSettingsSeriesSingle = ({
         <SeriesNameInput
           className="flex-full ml1 align-self-stretch"
           value={computedSettings.title}
-          data-testid="series-name-input"
+          aria-label="series-name-input"
           subtitle={
-            seriesCardName !== computedSettings.title ? seriesCardName : ""
+            seriesCardName === computedSettings.title ? "" : seriesCardName
           }
           onBlurChange={(e: React.ChangeEvent<HTMLInputElement>) =>
             onChangeObjectSettings(object, { title: e.target.value })

--- a/frontend/src/metabase/visualizations/lib/series.ts
+++ b/frontend/src/metabase/visualizations/lib/series.ts
@@ -1,5 +1,5 @@
 import { assocIn } from "icepick";
-import { VisualizationSettings } from "metabase-types/api/card";
+import { VisualizationSettings, Card } from "metabase-types/api/card";
 import { Series, TransformedSeries } from "metabase-types/api/dataset";
 import { isNotNull } from "metabase/core/utils/types";
 import { SETTING_ID, keyForSingleSeries } from "./settings/series";
@@ -40,4 +40,8 @@ export const getOrderedSeries = (
   }
 
   return orderedSeries;
+};
+
+export const getNameForCard = (card: Card) => {
+  return card?.name || "";
 };

--- a/frontend/src/metabase/visualizations/lib/settings/nested.js
+++ b/frontend/src/metabase/visualizations/lib/settings/nested.js
@@ -98,6 +98,7 @@ export function nestedSettings(
           objects,
           allComputedSettings,
           extra: { series, settings },
+          ...def.getExtraProps?.(series, settings, onChange, extra),
           ...extra,
         };
       },

--- a/frontend/src/metabase/visualizations/lib/settings/series.js
+++ b/frontend/src/metabase/visualizations/lib/settings/series.js
@@ -5,6 +5,7 @@ import { getIn } from "icepick";
 
 import ChartNestedSettingSeries from "metabase/visualizations/components/settings/ChartNestedSettingSeries";
 import { getColorsForValues } from "metabase/lib/colors/charts";
+import { getNameForCard } from "../series";
 import { nestedSettings } from "./nested";
 
 export function keyForSingleSeries(single) {
@@ -169,6 +170,14 @@ export function seriesSetting({
       component: ChartNestedSettingSeries,
       readDependencies: [COLOR_SETTING_ID, ...readDependencies],
       noPadding: true,
+      getExtraProps: series => ({
+        seriesCardNames: series.reduce((memo, singleSeries) => {
+          memo[keyForSingleSeries(singleSeries)] = getNameForCard(
+            singleSeries.card,
+          );
+          return memo;
+        }, {}),
+      }),
       ...def,
     }),
     // colors must be computed as a whole rather than individually

--- a/frontend/test/metabase/scenarios/visualizations/line_chart.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/line_chart.cy.spec.js
@@ -167,7 +167,7 @@ describe("scenarios > visualizations > line chart", () => {
     // Now do the same for the input with no value
     openSeriesSettings("Unknown", true);
     popover().within(() => {
-      cy.findAllByTestId("series-name-input").type("cat2").blur();
+      cy.findAllByLabelText("series-name-input").type("cat2").blur();
       cy.findByDisplayValue("cat2");
     });
     cy.button("Done").click();

--- a/frontend/test/metabase/visualizations/components/settings/ChartNestedSettingsSeriesMultiple.unit.spec.js
+++ b/frontend/test/metabase/visualizations/components/settings/ChartNestedSettingsSeriesMultiple.unit.spec.js
@@ -98,18 +98,18 @@ describe("ChartNestedSettingSeries", () => {
   });
 
   it("should show original series title in subtitle if it's changed", () => {
-    const { getByTestId } = setup("line", 1, true);
+    const { getByTestId, getByLabelText } = setup("line", 1, true);
 
     const seriesSettings = getByTestId("series-settings");
     expect(queryByText(seriesSettings, "Test 0")).toBeInTheDocument();
-    expect(getByTestId("series-name-input")).toHaveValue("Test 0 updated");
+    expect(getByLabelText("series-name-input")).toHaveValue("Test 0 updated");
   });
 
   it("should not show a series subtitle if the series name has not changed", () => {
-    const { getByTestId } = setup("line", 1);
+    const { getByTestId, getByLabelText } = setup("line", 1);
 
     const seriesSettings = getByTestId("series-settings");
     expect(queryByText(seriesSettings, "Test 0")).not.toBeInTheDocument();
-    expect(getByTestId("series-name-input")).toHaveValue("Test 0");
+    expect(getByLabelText("series-name-input")).toHaveValue("Test 0");
   });
 });


### PR DESCRIPTION
Epic #26887 

Adding the card's name to the subtitle of the series name input when it's been changed.

![chrome_Tfw5xUctjN](https://user-images.githubusercontent.com/1328979/208187048-1feb1dd6-0b1a-4659-9c35-e0da07c88b7f.gif)
