### PR TITLE
Fix incorrect casing in data-testids

### DIFF
--- a/frontend/src/metabase/core/components/Ellipsified/Ellipsified.styled.tsx
+++ b/frontend/src/metabase/core/components/Ellipsified/Ellipsified.styled.tsx
@@ -16,7 +16,7 @@ const clampCss = (props: EllipsifiedRootProps) => css`
 
 interface EllipsifiedRootProps {
   lines?: number;
-  "data-testId"?: string;
+  "data-testid"?: string;
 }
 
 export const EllipsifiedRoot = styled.div<EllipsifiedRootProps>`

--- a/frontend/src/metabase/query_builder/components/QuestionActions.tsx
+++ b/frontend/src/metabase/query_builder/components/QuestionActions.tsx
@@ -219,7 +219,7 @@ const QuestionActions = ({
             iconSize={HEADER_ICON_SIZE}
             onClick={onInfoClick}
             color={infoButtonColor}
-            data-testId="qb-header-info-button"
+            data-testid="qb-header-info-button"
           />
         </ViewHeaderIconButtonContainer>
       </Tooltip>

--- a/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetail.tsx
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetail.tsx
@@ -387,7 +387,7 @@ export function ObjectDetailHeader({
             )}
             <CloseButton>
               <Button
-                data-testId="object-detail-close-button"
+                data-testid="object-detail-close-button"
                 onlyIcon
                 borderless
                 onClick={closeObjectDetail}

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable.jsx
@@ -44,21 +44,21 @@ const partitions = [
     name: "rows",
     columnFilter: isDimension,
     title: (
-      <PivotTableSettingLabel data-testId="pivot-table-setting">{t`Rows`}</PivotTableSettingLabel>
+      <PivotTableSettingLabel data-testid="pivot-table-setting">{t`Rows`}</PivotTableSettingLabel>
     ),
   },
   {
     name: "columns",
     columnFilter: isDimension,
     title: (
-      <PivotTableSettingLabel data-testId="pivot-table-setting">{t`Columns`}</PivotTableSettingLabel>
+      <PivotTableSettingLabel data-testid="pivot-table-setting">{t`Columns`}</PivotTableSettingLabel>
     ),
   },
   {
     name: "values",
     columnFilter: col => !isDimension(col),
     title: (
-      <PivotTableSettingLabel data-testId="pivot-table-setting">{t`Measures`}</PivotTableSettingLabel>
+      <PivotTableSettingLabel data-testid="pivot-table-setting">{t`Measures`}</PivotTableSettingLabel>
     ),
   },
 ];


### PR DESCRIPTION
## Description
The console was throwing errors due to the use of `data-testId` instead of `data-testid` in a few places.

![Screen Shot 2022-12-16 at 1 58 50 PM](https://user-images.githubusercontent.com/30528226/208187911-1e70cd1d-a4d6-4a08-81e6-c06ae65975da.png)

## Testing steps
- On `master`, open a saved question, it will spit out the console error above
- on this branch, no console error!