### PR TITLE
Cleanup webpack console build messages

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,6 @@
 /* eslint-env node */
 /* eslint-disable import/no-commonjs */
+/* eslint-disable import/order */
 const NodePolyfillPlugin = require("node-polyfill-webpack-plugin");
 
 const webpack = require("webpack");
@@ -250,7 +251,7 @@ if (WEBPACK_BUNDLE === "hot") {
     allowedHosts: "auto",
     hot: true,
     client: {
-      progress: true,
+      progress: false,
       overlay: false,
     },
     headers: {


### PR DESCRIPTION
## Description

Doesn't print webpack build messages to the browser console anymore. Every HMR would cause several screens of build messages to appear, which, if you were looking for some application output in the console, made the console output hard to parse.

Before | After
--- | ---
![Screen Shot 2022-12-16 at 2 22 34 PM](https://user-images.githubusercontent.com/30528226/208191506-8fc71f0c-9292-41b1-9a30-4600437de025.png) | ![Screen Shot 2022-12-16 at 2 21 34 PM](https://user-images.githubusercontent.com/30528226/208191509-72c09fda-e7de-48f2-a659-362bf567f52a.png)
