### PR TITLE
Add basic model detail page

### DIFF
--- a/frontend/src/metabase-lib/metadata/Table.ts
+++ b/frontend/src/metabase-lib/metadata/Table.ts
@@ -4,7 +4,7 @@
 // NOTE: this needs to be imported first due to some cyclical dependency nonsense
 import Question from "../Question"; // eslint-disable-line import/order
 import { singularize } from "metabase/lib/formatting";
-import type { TableId } from "metabase-types/types/Table";
+import type { Table as ITable, TableId } from "metabase-types/api";
 import { isVirtualCardId } from "metabase-lib/metadata/utils/saved-questions";
 import { getAggregationOperators } from "metabase-lib/operators/utils";
 import { createLookupByProperty, memoizeClass } from "metabase-lib/utils";
@@ -34,6 +34,10 @@ class TableInner extends Base {
   fields: Field[];
   metadata?: Metadata;
   db?: Database | undefined | null;
+
+  getPlainObject(): ITable {
+    return this._plainObject;
+  }
 
   isVirtualCard() {
     return isVirtualCardId(this.id);

--- a/frontend/src/metabase-lib/mocks.ts
+++ b/frontend/src/metabase-lib/mocks.ts
@@ -53,6 +53,8 @@ const SAVED_QUESTION = {
   name: "Q1",
   description: "",
   collection_id: null,
+  can_write: true,
+  result_metadata: ORDERS.fields.map(field => field.getPlainObject()),
 };
 
 export function getQuestion(card: Partial<Card>) {

--- a/frontend/src/metabase-lib/mocks.ts
+++ b/frontend/src/metabase-lib/mocks.ts
@@ -54,7 +54,7 @@ const SAVED_QUESTION = {
   description: "",
   collection_id: null,
   can_write: true,
-  result_metadata: ORDERS.fields.map(field => field.getPlainObject()),
+  result_metadata: [],
 };
 
 export function getQuestion(card: Partial<Card>) {

--- a/frontend/src/metabase-lib/mocks.ts
+++ b/frontend/src/metabase-lib/mocks.ts
@@ -18,10 +18,10 @@ import StructuredQuery from "metabase-lib/queries/StructuredQuery";
 import Query from "metabase-lib/queries/Query";
 import { UiParameter } from "metabase-lib/parameters/types";
 
-type NativeSavedCard = SavedCard<NativeDatasetQuery>;
-type NativeUnsavedCard = UnsavedCard<NativeDatasetQuery>;
-type StructuredSavedCard = SavedCard<StructuredDatasetQuery>;
-type StructuredUnsavedCard = UnsavedCard<StructuredDatasetQuery>;
+export type NativeSavedCard = SavedCard<NativeDatasetQuery>;
+export type NativeUnsavedCard = UnsavedCard<NativeDatasetQuery>;
+export type StructuredSavedCard = SavedCard<StructuredDatasetQuery>;
+export type StructuredUnsavedCard = UnsavedCard<StructuredDatasetQuery>;
 
 const BASE_GUI_QUESTION: StructuredUnsavedCard = {
   display: "table",

--- a/frontend/src/metabase-types/api/card.ts
+++ b/frontend/src/metabase-types/api/card.ts
@@ -1,4 +1,5 @@
-import { DatasetQuery } from "./query";
+import type { Field } from "./field";
+import type { DatasetQuery } from "./query";
 
 export interface Card extends UnsavedCard {
   id: CardId;
@@ -10,13 +11,14 @@ export interface Card extends UnsavedCard {
   cache_ttl: number | null;
   query_average_duration?: number | null;
   last_query_start: string | null;
+  result_metadata: Field[];
   archived: boolean;
 
   creator?: {
     id: number;
     common_name: string;
-    first_name: string;
-    last_name: string;
+    first_name: string | null;
+    last_name: string | null;
     email: string;
     last_login: string;
     date_joined: string;

--- a/frontend/src/metabase-types/api/collection.ts
+++ b/frontend/src/metabase-types/api/collection.ts
@@ -38,9 +38,11 @@ export interface Collection {
   path?: CollectionId[];
 }
 
-export interface CollectionItem {
+type CollectionItemModel = "card" | "dataset" | "dashboard" | "pulse";
+
+export interface CollectionItem<T = CollectionItemModel> {
   id: number;
-  model: string;
+  model: T;
   name: string;
   description: string | null;
   copy?: boolean;

--- a/frontend/src/metabase-types/api/mocks/card.ts
+++ b/frontend/src/metabase-types/api/mocks/card.ts
@@ -14,6 +14,7 @@ export const createMockCard = (opts?: Partial<Card>): Card => ({
   display: "table",
   dataset_query: createMockStructuredDatasetQuery(),
   visualization_settings: createMockVisualizationSettings(),
+  result_metadata: [],
   dataset: false,
   can_write: false,
   cache_ttl: null,

--- a/frontend/src/metabase-types/api/mocks/collection.ts
+++ b/frontend/src/metabase-types/api/mocks/collection.ts
@@ -6,6 +6,7 @@ export const createMockCollection = (
   id: 1,
   name: "Collection",
   description: null,
+  location: "/",
   can_write: false,
   archived: false,
   ...opts,

--- a/frontend/src/metabase-types/types/Card.ts
+++ b/frontend/src/metabase-types/types/Card.ts
@@ -35,6 +35,16 @@ export type SavedCard<Query = DatasetQuery> = UnsavedCard<Query> & {
   archived?: boolean;
   collection_id?: number | null;
 
+  creator?: {
+    id: number;
+    common_name: string;
+    first_name: string | null;
+    last_name: string | null;
+    email: string;
+    last_login: string;
+    date_joined: string;
+  };
+
   // Only for native queries
   is_write?: boolean;
   action_id?: number;

--- a/frontend/src/metabase-types/types/Card.ts
+++ b/frontend/src/metabase-types/types/Card.ts
@@ -3,7 +3,7 @@
  * @deprecated use existing types from, or add to metabase-types/api/*
  */
 
-import { Parameter, VisualizationSettings } from "metabase-types/api";
+import { Field, Parameter, VisualizationSettings } from "metabase-types/api";
 import { DatabaseId } from "./Database";
 import { StructuredQuery, NativeQuery } from "./Query";
 import { ParameterQueryObject } from "./Parameter";
@@ -34,6 +34,7 @@ export type SavedCard<Query = DatasetQuery> = UnsavedCard<Query> & {
   cache_ttl?: number | null;
   archived?: boolean;
   collection_id?: number | null;
+  result_metadata: Field[];
 
   creator?: {
     id: number;
@@ -44,10 +45,6 @@ export type SavedCard<Query = DatasetQuery> = UnsavedCard<Query> & {
     last_login: string;
     date_joined: string;
   };
-
-  // Only for native queries
-  is_write?: boolean;
-  action_id?: number;
 };
 
 export type Card<Query = DatasetQuery> = SavedCard<Query> | UnsavedCard<Query>;

--- a/frontend/src/metabase/admin/tasks/containers/ModelCacheRefreshJobs/ModelCacheRefreshJobs.tsx
+++ b/frontend/src/metabase/admin/tasks/containers/ModelCacheRefreshJobs/ModelCacheRefreshJobs.tsx
@@ -34,7 +34,7 @@ type JobTableItemProps = {
 };
 
 function JobTableItem({ job, onRefresh }: JobTableItemProps) {
-  const modelUrl = Urls.dataset({ id: job.card_id, name: job.card_name });
+  const modelUrl = Urls.model({ id: job.card_id, name: job.card_name });
   const collectionUrl = Urls.collection({
     id: job.collection_id,
     name: job.collection_name,

--- a/frontend/src/metabase/collections/components/ActionMenu/ActionMenu.unit.spec.tsx
+++ b/frontend/src/metabase/collections/components/ActionMenu/ActionMenu.unit.spec.tsx
@@ -51,7 +51,7 @@ describe("ActionMenu", () => {
   it("should not show an option to hide preview for a pinned model", () => {
     const props = getProps({
       item: createMockCollectionItem({
-        model: "model",
+        model: "dataset",
         collection_position: 1,
         setCollectionPreview: jest.fn(),
       }),

--- a/frontend/src/metabase/collections/components/BaseItemsTable.styled.jsx
+++ b/frontend/src/metabase/collections/components/BaseItemsTable.styled.jsx
@@ -9,6 +9,7 @@ import {
 import EntityItem from "metabase/components/EntityItem";
 import Icon from "metabase/components/Icon";
 import Link from "metabase/core/components/Link";
+import BaseModelDetailLink from "metabase/models/components/ModelDetailLink";
 
 const LAST_EDITED_BY_INDEX = 3;
 const LAST_EDITED_AT_INDEX = 4;
@@ -76,6 +77,11 @@ SortingIcon.defaultProps = {
   size: 8,
 };
 
+export const ModelDetailLink = styled(BaseModelDetailLink)`
+  color: ${color("text-medium")};
+  visibility: hidden;
+`;
+
 export const SortingControlContainer = styled.div`
   display: flex;
   align-items: center;
@@ -91,6 +97,11 @@ export const SortingControlContainer = styled.div`
       visibility: visible;
     }
   }
+`;
+
+export const RowActionsContainer = styled.div`
+  display: flex;
+  gap: 0.5rem;
 `;
 
 export const TableItemSecondaryField = styled.span`
@@ -141,6 +152,12 @@ export const TBody = styled.tbody`
       &:first-of-type {
         border-bottom-left-radius: 8px;
       }
+    }
+  }
+
+  tr:hover {
+    ${ModelDetailLink} {
+      visibility: visible;
     }
   }
 `;

--- a/frontend/src/metabase/collections/components/BaseTableItem.jsx
+++ b/frontend/src/metabase/collections/components/BaseTableItem.jsx
@@ -115,7 +115,7 @@ export function BaseTableItem({
           />
         </ItemCell>
         <ItemCell data-testid={`${testId}-name`}>
-          <ItemLink {...linkProps} to={item.getUrl({ isModelDetail: true })}>
+          <ItemLink {...linkProps} to={item.getUrl()}>
             <EntityItem.Name name={item.name} variant="list" />
             <PLUGIN_MODERATION.ModerationStatusIcon
               size={16}

--- a/frontend/src/metabase/collections/components/BaseTableItem.jsx
+++ b/frontend/src/metabase/collections/components/BaseTableItem.jsx
@@ -21,6 +21,8 @@ import {
   ItemLink,
   TableItemSecondaryField,
   DescriptionIcon,
+  ModelDetailLink,
+  RowActionsContainer,
 } from "./BaseItemsTable.styled";
 
 BaseTableItem.propTypes = {
@@ -141,15 +143,18 @@ export function BaseTableItem({
           )}
         </ItemCell>
         <ItemCell>
-          <ActionMenu
-            createBookmark={createBookmark}
-            deleteBookmark={deleteBookmark}
-            bookmarks={bookmarks}
-            item={item}
-            collection={collection}
-            onCopy={onCopy}
-            onMove={onMove}
-          />
+          <RowActionsContainer>
+            <ActionMenu
+              createBookmark={createBookmark}
+              deleteBookmark={deleteBookmark}
+              bookmarks={bookmarks}
+              item={item}
+              collection={collection}
+              onCopy={onCopy}
+              onMove={onMove}
+            />
+            {item.model === "dataset" && <ModelDetailLink model={item} />}
+          </RowActionsContainer>
         </ItemCell>
       </tr>
     );

--- a/frontend/src/metabase/collections/components/PinnedItemCard/PinnedItemCard.styled.tsx
+++ b/frontend/src/metabase/collections/components/PinnedItemCard/PinnedItemCard.styled.tsx
@@ -4,7 +4,6 @@ import { color } from "metabase/lib/colors";
 import Icon from "metabase/components/Icon";
 import Link from "metabase/core/components/Link";
 import Card from "metabase/components/Card";
-import ActionMenu from "metabase/collections/components/ActionMenu";
 
 export const ItemCard = styled(Card)``;
 
@@ -19,7 +18,11 @@ export const ItemIcon = styled(Icon)`
   width: 1.5rem;
 `;
 
-export const HoverMenu = styled(ActionMenu)`
+export const ActionsContainer = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+
   visibility: hidden;
 `;
 
@@ -52,7 +55,7 @@ export const Body = styled.div`
       color: ${color("brand")};
     }
 
-    ${HoverMenu} {
+    ${ActionsContainer} {
       visibility: visible;
     }
   }

--- a/frontend/src/metabase/collections/components/PinnedItemCard/PinnedItemCard.styled.tsx
+++ b/frontend/src/metabase/collections/components/PinnedItemCard/PinnedItemCard.styled.tsx
@@ -21,7 +21,7 @@ export const ItemIcon = styled(Icon)`
 export const ActionsContainer = styled.div`
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 0.5rem;
 
   visibility: hidden;
 `;

--- a/frontend/src/metabase/collections/components/PinnedItemCard/PinnedItemCard.tsx
+++ b/frontend/src/metabase/collections/components/PinnedItemCard/PinnedItemCard.tsx
@@ -65,7 +65,7 @@ function PinnedItemCard({
   };
 
   return (
-    <ItemLink className={className} to={item.getUrl({ isModelDetail: true })}>
+    <ItemLink className={className} to={item.getUrl()}>
       <ItemCard flat>
         <Body>
           <Header>

--- a/frontend/src/metabase/collections/components/PinnedItemCard/PinnedItemCard.tsx
+++ b/frontend/src/metabase/collections/components/PinnedItemCard/PinnedItemCard.tsx
@@ -4,6 +4,7 @@ import { t } from "ttag";
 import Tooltip from "metabase/core/components/Tooltip";
 
 import ActionMenu from "metabase/collections/components/ActionMenu";
+import ModelDetailLink from "metabase/models/components/ModelDetailLink";
 
 import type { Bookmark, Collection, CollectionItem } from "metabase-types/api";
 
@@ -74,6 +75,9 @@ function PinnedItemCard({
           <Header>
             <ItemIcon name={icon} />
             <ActionsContainer>
+              {item.model === "dataset" && (
+                <ModelDetailLink model={item as CollectionItem<"dataset">} />
+              )}
               <ActionMenu
                 bookmarks={bookmarks}
                 createBookmark={createBookmark}

--- a/frontend/src/metabase/collections/components/PinnedItemCard/PinnedItemCard.tsx
+++ b/frontend/src/metabase/collections/components/PinnedItemCard/PinnedItemCard.tsx
@@ -2,13 +2,16 @@ import React, { useState } from "react";
 import { t } from "ttag";
 
 import Tooltip from "metabase/core/components/Tooltip";
-import { Bookmark, Collection, CollectionItem } from "metabase-types/api";
+
+import ActionMenu from "metabase/collections/components/ActionMenu";
+
+import type { Bookmark, Collection, CollectionItem } from "metabase-types/api";
 
 import {
   Body,
   Description,
   Header,
-  HoverMenu,
+  ActionsContainer,
   ItemCard,
   ItemIcon,
   ItemLink,
@@ -70,15 +73,17 @@ function PinnedItemCard({
         <Body>
           <Header>
             <ItemIcon name={icon} />
-            <HoverMenu
-              bookmarks={bookmarks}
-              createBookmark={createBookmark}
-              deleteBookmark={deleteBookmark}
-              item={item}
-              collection={collection}
-              onCopy={onCopy}
-              onMove={onMove}
-            />
+            <ActionsContainer>
+              <ActionMenu
+                bookmarks={bookmarks}
+                createBookmark={createBookmark}
+                deleteBookmark={deleteBookmark}
+                item={item}
+                collection={collection}
+                onCopy={onCopy}
+                onMove={onMove}
+              />
+            </ActionsContainer>
           </Header>
           <Tooltip
             tooltip={name}

--- a/frontend/src/metabase/collections/components/PinnedItemCard/PinnedItemCard.unit.spec.js
+++ b/frontend/src/metabase/collections/components/PinnedItemCard/PinnedItemCard.unit.spec.js
@@ -4,6 +4,11 @@ import { render, screen, getIcon } from "__support__/ui";
 
 import PinnedItemCard from "./PinnedItemCard";
 
+// eslint-disable-next-line react/display-name, react/prop-types
+jest.mock("metabase/core/components/Link", () => ({ to, ...props }) => (
+  <a {...props} href={to} />
+));
+
 const mockOnCopy = jest.fn();
 const mockOnMove = jest.fn();
 
@@ -14,27 +19,37 @@ const defaultCollection = {
   archived: false,
 };
 
-const defaultItem = {
-  id: 1,
-  model: "dashboard",
-  collection_position: 1,
-  name: "Dashboard Foo",
-  description: "description foo foo foo",
-  getIcon: () => ({ name: "dashboard" }),
-  getUrl: () => "/dashboard/1",
-  setArchived: jest.fn(),
-  setPinned: jest.fn(),
-};
+function getCollectionItem({
+  id = 1,
+  model = "dashboard",
+  name = "My Item",
+  description = "description foo foo foo",
+  collection_position = 1,
+  icon = "dashboard",
+  url = "/dashboard/1",
+  setArchived = jest.fn(),
+  setPinned = jest.fn(),
+  ...rest
+} = {}) {
+  return {
+    ...rest,
+    id,
+    model,
+    name,
+    description,
+    collection_position,
+    getIcon: () => ({ name: icon }),
+    getUrl: () => url,
+    setArchived,
+    setPinned,
+  };
+}
 
-function setup({ item, collection } = {}) {
-  item = item || defaultItem;
-  collection = collection || defaultCollection;
+const defaultItem = getCollectionItem();
 
+function setup({ item = defaultItem, collection = defaultCollection } = {}) {
   mockOnCopy.mockReset();
   mockOnMove.mockReset();
-  item.setArchived.mockReset();
-  item.setPinned.mockReset();
-
   return render(
     <PinnedItemCard
       item={item}
@@ -62,12 +77,7 @@ describe("PinnedItemCard", () => {
   });
 
   it("should show a default description if there is no item description", () => {
-    const item = {
-      ...defaultItem,
-      description: null,
-    };
-    setup({ item });
-
+    setup({ item: getCollectionItem({ description: null }) });
     expect(screen.getByText("A dashboard")).toBeInTheDocument();
   });
 
@@ -75,5 +85,28 @@ describe("PinnedItemCard", () => {
     setup();
     userEvent.click(getIcon("ellipsis"));
     expect(screen.getByText("Unpin")).toBeInTheDocument();
+  });
+
+  it("doesn't show model detail page link", () => {
+    setup();
+    expect(screen.queryByTestId("model-detail-link")).not.toBeInTheDocument();
+  });
+
+  describe("models", () => {
+    const model = getCollectionItem({
+      id: 1,
+      name: "Order",
+      model: "dataset",
+      url: "/model/1",
+    });
+
+    it("should show a model detail page link", () => {
+      setup({ item: model });
+      expect(screen.getByTestId("model-detail-link")).toBeInTheDocument();
+      expect(screen.getByTestId("model-detail-link")).toHaveAttribute(
+        "href",
+        "/model/1-order/detail",
+      );
+    });
   });
 });

--- a/frontend/src/metabase/components/ArchiveModal.jsx
+++ b/frontend/src/metabase/components/ArchiveModal.jsx
@@ -33,7 +33,7 @@ class ArchiveModal extends React.Component {
       <ModalContent
         title={title || t`Archive this?`}
         footer={[
-          error ? <FormMessage formError={error} /> : null,
+          error ? <FormMessage key="message" formError={error} /> : null,
           <Button key="cancel" onClick={onClose}>
             {t`Cancel`}
           </Button>,

--- a/frontend/src/metabase/components/Modal.jsx
+++ b/frontend/src/metabase/components/Modal.jsx
@@ -68,7 +68,10 @@ export class WindowModal extends Component {
         backdropElement={this._modalElement}
         handleDismissal={this.handleDismissal}
       >
-        <div className={cx(className, "relative bg-white rounded")}>
+        <div
+          className={cx(className, "relative bg-white rounded")}
+          role="dialog"
+        >
           {getModalContent({
             ...this.props,
             fullPageModal: false,

--- a/frontend/src/metabase/components/Popover/Popover.jsx
+++ b/frontend/src/metabase/components/Popover/Popover.jsx
@@ -63,7 +63,7 @@ export default class Popover extends Component {
       PropTypes.func,
       PropTypes.array,
     ]),
-    target: PropTypes.oneOfType([PropTypes.func, PropTypes.node]),
+    target: PropTypes.any,
     targetEvent: PropTypes.object,
     role: PropTypes.string,
     ignoreTrigger: PropTypes.bool,

--- a/frontend/src/metabase/entities/containers/EntityListLoader.jsx
+++ b/frontend/src/metabase/entities/containers/EntityListLoader.jsx
@@ -12,7 +12,7 @@ import { capitalize } from "metabase/lib/formatting";
 import entityType from "./EntityType";
 
 const propTypes = {
-  entityType: PropTypes.string,
+  entityType: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
   entityQuery: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
   // We generally expect booleans here,
   // but a parent entity loader may pass `reload` as a function.

--- a/frontend/src/metabase/entities/questions.js
+++ b/frontend/src/metabase/entities/questions.js
@@ -1,17 +1,19 @@
+import { t } from "ttag";
 import { updateIn } from "icepick";
+
 import { createEntity, undo } from "metabase/lib/entities";
 import * as Urls from "metabase/lib/urls";
 import { color } from "metabase/lib/colors";
-
-import {
-  API_UPDATE_QUESTION,
-  SOFT_RELOAD_CARD,
-} from "metabase/query_builder/actions";
 
 import Collections, {
   getCollectionType,
   normalizedCollection,
 } from "metabase/entities/collections";
+
+import {
+  API_UPDATE_QUESTION,
+  SOFT_RELOAD_CARD,
+} from "metabase/query_builder/actions";
 import { canonicalCollectionId } from "metabase/collections/utils";
 
 import forms from "./questions/forms";
@@ -28,8 +30,8 @@ const Questions = createEntity({
         { archived },
         undo(
           opts,
-          dataset || model === "dataset" ? "model" : "question",
-          archived ? "archived" : "unarchived",
+          dataset || model === "dataset" ? t`model` : t`question`,
+          archived ? t`archived` : t`unarchived`,
         ),
       ),
 
@@ -43,8 +45,8 @@ const Questions = createEntity({
             },
             undo(
               opts,
-              dataset || model === "dataset" ? "model" : "question",
-              "moved",
+              dataset || model === "dataset" ? t`model` : t`question`,
+              t`moved`,
             ),
           ),
         );

--- a/frontend/src/metabase/entities/questions.js
+++ b/frontend/src/metabase/entities/questions.js
@@ -22,18 +22,18 @@ const Questions = createEntity({
   path: "/api/card",
 
   objectActions: {
-    setArchived: ({ id, model }, archived, opts) =>
+    setArchived: ({ id, dataset, model }, archived, opts) =>
       Questions.actions.update(
         { id },
         { archived },
         undo(
           opts,
-          model === "dataset" ? "model" : "question",
+          dataset || model === "dataset" ? "model" : "question",
           archived ? "archived" : "unarchived",
         ),
       ),
 
-    setCollection: ({ id, model }, collection, opts) => {
+    setCollection: ({ id, dataset, model }, collection, opts) => {
       return async dispatch => {
         const result = await dispatch(
           Questions.actions.update(
@@ -41,7 +41,11 @@ const Questions = createEntity({
             {
               collection_id: canonicalCollectionId(collection && collection.id),
             },
-            undo(opts, model === "dataset" ? "model" : "question", "moved"),
+            undo(
+              opts,
+              dataset || model === "dataset" ? "model" : "question",
+              "moved",
+            ),
           ),
         );
         dispatch(

--- a/frontend/src/metabase/home/containers/SearchApp.jsx
+++ b/frontend/src/metabase/home/containers/SearchApp.jsx
@@ -64,11 +64,6 @@ const SEARCH_FILTERS = [
     icon: "bar",
   },
   {
-    name: t`Pages`,
-    filter: "page",
-    icon: "document",
-  },
-  {
     name: t`Pulses`,
     filter: "pulse",
     icon: "pulse",

--- a/frontend/src/metabase/lib/urls/index.ts
+++ b/frontend/src/metabase/lib/urls/index.ts
@@ -5,6 +5,7 @@ export * from "./browse";
 export * from "./collections";
 export * from "./dashboards";
 export * from "./misc";
+export * from "./models";
 export * from "./pulses";
 export * from "./questions";
 export * from "./timelines";

--- a/frontend/src/metabase/lib/urls/misc.js
+++ b/frontend/src/metabase/lib/urls/misc.js
@@ -1,5 +1,5 @@
 import { dashboard } from "./dashboards";
-import { question, dataset, tableRowsQuery } from "./questions";
+import { question, model, tableRowsQuery } from "./questions";
 import { pulse } from "./pulses";
 
 export const exportFormats = ["csv", "xlsx", "json"];
@@ -25,7 +25,7 @@ export function modelToUrl(item) {
     case "card":
       return question(modelData);
     case "dataset":
-      return dataset(modelData);
+      return model(modelData);
     case "dashboard":
       return dashboard(modelData);
     case "page":

--- a/frontend/src/metabase/lib/urls/misc.js
+++ b/frontend/src/metabase/lib/urls/misc.js
@@ -1,5 +1,6 @@
 import { dashboard } from "./dashboards";
-import { question, model, tableRowsQuery } from "./questions";
+import { model } from "./models";
+import { question, tableRowsQuery } from "./questions";
 import { pulse } from "./pulses";
 
 export const exportFormats = ["csv", "xlsx", "json"];

--- a/frontend/src/metabase/lib/urls/misc.js
+++ b/frontend/src/metabase/lib/urls/misc.js
@@ -25,7 +25,7 @@ export function modelToUrl(item) {
     case "card":
       return question(modelData);
     case "dataset":
-      return dataset(modelData, { isModelDetail: true });
+      return dataset(modelData);
     case "dashboard":
       return dashboard(modelData);
     case "page":

--- a/frontend/src/metabase/lib/urls/misc.js
+++ b/frontend/src/metabase/lib/urls/misc.js
@@ -28,8 +28,6 @@ export function modelToUrl(item) {
       return model(modelData);
     case "dashboard":
       return dashboard(modelData);
-    case "page":
-      return dashboard(modelData);
     case "pulse":
       return pulse(modelData.id);
     case "table":

--- a/frontend/src/metabase/lib/urls/models.ts
+++ b/frontend/src/metabase/lib/urls/models.ts
@@ -1,0 +1,6 @@
+import { Card } from "metabase-types/types/Card";
+import { question, QuestionUrlBuilderParams } from "./questions";
+
+export function model(card: Card, opts: QuestionUrlBuilderParams) {
+  return question(card, opts);
+}

--- a/frontend/src/metabase/lib/urls/models.ts
+++ b/frontend/src/metabase/lib/urls/models.ts
@@ -17,6 +17,11 @@ export function model(
   return question(card as LegacyCard, opts);
 }
 
+export function modelDetail(card: CardOrSearchResult) {
+  const baseUrl = model(card);
+  return `${baseUrl}/detail`;
+}
+
 type ModelEditorUrlBuilderOpts = {
   type?: "query" | "metadata";
 };

--- a/frontend/src/metabase/lib/urls/models.ts
+++ b/frontend/src/metabase/lib/urls/models.ts
@@ -1,6 +1,36 @@
-import { Card } from "metabase-types/types/Card";
+import slugg from "slugg";
+import type { Card } from "metabase-types/api";
+import type { Card as LegacyCard } from "metabase-types/types/Card";
 import { question, QuestionUrlBuilderParams } from "./questions";
+import { appendSlug } from "./utils";
 
-export function model(card: Card, opts: QuestionUrlBuilderParams) {
-  return question(card, opts);
+type CardOrSearchResult = (Partial<Card> | Partial<LegacyCard>) & {
+  id?: number | string;
+  card_id?: number | string;
+  name?: string;
+};
+
+export function model(
+  card: CardOrSearchResult,
+  opts?: QuestionUrlBuilderParams,
+) {
+  return question(card as LegacyCard, opts);
+}
+
+type ModelEditorUrlBuilderOpts = {
+  type?: "query" | "metadata";
+};
+
+export function modelEditor(
+  model: CardOrSearchResult,
+  { type = "query" }: ModelEditorUrlBuilderOpts = {},
+) {
+  const id = model.card_id ?? model.id;
+
+  let basePath = `/model/${id}`;
+  if (model.name) {
+    basePath = appendSlug(basePath, slugg(model.name));
+  }
+
+  return `${basePath}/${type}`;
 }

--- a/frontend/src/metabase/lib/urls/questions.ts
+++ b/frontend/src/metabase/lib/urls/questions.ts
@@ -18,7 +18,7 @@ type Card = Partial<BaseCard> & {
 
 export const newQuestionFlow = () => "/question/new";
 
-type QuestionUrlBuilderParams = {
+export type QuestionUrlBuilderParams = {
   hash?: Card | string;
   query?: Record<string, unknown> | string;
   objectId?: number | string;
@@ -109,10 +109,6 @@ export function newQuestion({
   } else {
     return url;
   }
-}
-
-export function model(...args: Parameters<typeof question>) {
-  return question(...args);
 }
 
 export function publicQuestion(

--- a/frontend/src/metabase/lib/urls/questions.ts
+++ b/frontend/src/metabase/lib/urls/questions.ts
@@ -22,17 +22,11 @@ type QuestionUrlBuilderParams = {
   hash?: Card | string;
   query?: Record<string, unknown> | string;
   objectId?: number | string;
-  isModelDetail?: boolean;
 };
 
 export function question(
   card: Card | null,
-  {
-    hash = "",
-    query = "",
-    objectId,
-    isModelDetail = false,
-  }: QuestionUrlBuilderParams = {},
+  { hash = "", query = "", objectId }: QuestionUrlBuilderParams = {},
 ) {
   if (hash && typeof hash === "object") {
     hash = serializeCardForUrl(hash);

--- a/frontend/src/metabase/lib/urls/questions.ts
+++ b/frontend/src/metabase/lib/urls/questions.ts
@@ -111,7 +111,7 @@ export function newQuestion({
   }
 }
 
-export function dataset(...args: Parameters<typeof question>) {
+export function model(...args: Parameters<typeof question>) {
   return question(...args);
 }
 

--- a/frontend/src/metabase/models/components/ModelDetailLink.tsx
+++ b/frontend/src/metabase/models/components/ModelDetailLink.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+import { t } from "ttag";
+
+import Button, { ButtonProps } from "metabase/core/components/Button";
+import Link from "metabase/core/components/Link";
+
+import * as Urls from "metabase/lib/urls";
+
+import type { Card, CollectionItem } from "metabase-types/api";
+
+type ModelCard = Card & { dataset: true };
+
+interface Props extends ButtonProps {
+  model: ModelCard | CollectionItem<"dataset">;
+}
+
+function ModelDetailLink({ model, ...props }: Props) {
+  return (
+    <Button
+      aria-label={t`Model details`}
+      tooltip={t`Model details`}
+      {...props}
+      as={Link}
+      to={Urls.modelDetail(model)}
+      icon="reference"
+      onlyIcon
+      role="link"
+      data-testid="model-detail-link"
+    />
+  );
+}
+
+export default ModelDetailLink;

--- a/frontend/src/metabase/models/components/ModelDetailPage/ModelDetailHeader/ModelDetailHeader.styled.tsx
+++ b/frontend/src/metabase/models/components/ModelDetailPage/ModelDetailHeader/ModelDetailHeader.styled.tsx
@@ -1,0 +1,30 @@
+import styled from "@emotion/styled";
+
+import EditableText from "metabase/core/components/EditableText";
+
+import { color } from "metabase/lib/colors";
+
+export const ModelTitle = styled(EditableText)`
+  color: ${color("text-dark")};
+  font-weight: 700;
+  font-size: 1.25rem;
+`;
+
+export const ModelFootnote = styled.p`
+  color: ${color("text-medium")};
+  margin: 4px 0 0 4px;
+`;
+
+export const ModelHeader = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: flex-start;
+  width: 100%;
+`;
+
+export const ModelHeaderButtonsContainer = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+`;

--- a/frontend/src/metabase/models/components/ModelDetailPage/ModelDetailHeader/ModelDetailHeader.tsx
+++ b/frontend/src/metabase/models/components/ModelDetailPage/ModelDetailHeader/ModelDetailHeader.tsx
@@ -93,9 +93,13 @@ function ModelDetailHeader({ model, onChangeName, onChangeCollection }: Props) {
           <ModelFootnote>{t`Model`}</ModelFootnote>
         </div>
         <ModelHeaderButtonsContainer>
-          <Button as={Link} to={queryEditorLink}>{t`Edit definition`}</Button>
+          {canWrite && (
+            <Button as={Link} to={queryEditorLink}>{t`Edit definition`}</Button>
+          )}
           <Button primary as={Link} to={exploreDataLink}>{t`Explore`}</Button>
-          <EntityMenu items={extraActions} triggerIcon="ellipsis" />
+          {canWrite && (
+            <EntityMenu items={extraActions} triggerIcon="ellipsis" />
+          )}
         </ModelHeaderButtonsContainer>
       </ModelHeader>
       {modal && <Modal onClose={handleCloseModal}>{renderModal()}</Modal>}

--- a/frontend/src/metabase/models/components/ModelDetailPage/ModelDetailHeader/ModelDetailHeader.tsx
+++ b/frontend/src/metabase/models/components/ModelDetailPage/ModelDetailHeader/ModelDetailHeader.tsx
@@ -1,0 +1,48 @@
+import React from "react";
+import { t } from "ttag";
+
+import Button from "metabase/core/components/Button";
+import Link from "metabase/core/components/Link";
+
+import * as Urls from "metabase/lib/urls";
+
+import type Question from "metabase-lib/Question";
+
+import {
+  ModelHeader,
+  ModelHeaderButtonsContainer,
+  ModelTitle,
+  ModelFootnote,
+} from "./ModelDetailHeader.styled";
+
+interface Props {
+  model: Question;
+  onChangeName: (name?: string) => void;
+}
+
+function ModelDetailHeader({ model, onChangeName }: Props) {
+  const modelCard = model.card();
+  const canWrite = model.canWrite();
+
+  const queryEditorLink = Urls.modelEditor(modelCard, { type: "query" });
+  const exploreDataLink = Urls.model(modelCard);
+
+  return (
+    <ModelHeader>
+      <div>
+        <ModelTitle
+          initialValue={model.displayName()}
+          isDisabled={!canWrite}
+          onChange={onChangeName}
+        />
+        <ModelFootnote>{t`Model`}</ModelFootnote>
+      </div>
+      <ModelHeaderButtonsContainer>
+        <Button as={Link} to={queryEditorLink}>{t`Edit definition`}</Button>
+        <Button primary as={Link} to={exploreDataLink}>{t`Explore`}</Button>
+      </ModelHeaderButtonsContainer>
+    </ModelHeader>
+  );
+}
+
+export default ModelDetailHeader;

--- a/frontend/src/metabase/models/components/ModelDetailPage/ModelDetailHeader/ModelDetailHeader.tsx
+++ b/frontend/src/metabase/models/components/ModelDetailPage/ModelDetailHeader/ModelDetailHeader.tsx
@@ -1,10 +1,17 @@
-import React from "react";
+import React, { useCallback, useMemo, useState } from "react";
 import { t } from "ttag";
 
 import Button from "metabase/core/components/Button";
+import EntityMenu from "metabase/components/EntityMenu";
 import Link from "metabase/core/components/Link";
+import Modal from "metabase/components/Modal";
 
 import * as Urls from "metabase/lib/urls";
+
+import ArchiveModelModal from "metabase/questions/containers/ArchiveQuestionModal";
+import CollectionMoveModal from "metabase/containers/CollectionMoveModal";
+
+import type { Collection } from "metabase-types/api";
 
 import type Question from "metabase-lib/Question";
 
@@ -18,30 +25,81 @@ import {
 interface Props {
   model: Question;
   onChangeName: (name?: string) => void;
+  onChangeCollection: (collection: Collection) => void;
 }
 
-function ModelDetailHeader({ model, onChangeName }: Props) {
+type HeaderModal = "move" | "archive";
+
+function ModelDetailHeader({ model, onChangeName, onChangeCollection }: Props) {
+  const [modal, setModal] = useState<HeaderModal | null>(null);
+
   const modelCard = model.card();
   const canWrite = model.canWrite();
 
   const queryEditorLink = Urls.modelEditor(modelCard, { type: "query" });
   const exploreDataLink = Urls.model(modelCard);
 
-  return (
-    <ModelHeader>
-      <div>
-        <ModelTitle
-          initialValue={model.displayName()}
-          isDisabled={!canWrite}
-          onChange={onChangeName}
+  const extraActions = useMemo(() => {
+    return [
+      {
+        title: t`Move`,
+        icon: "move",
+        action: () => setModal("move"),
+      },
+      {
+        title: t`Archive`,
+        icon: "archive",
+        action: () => setModal("archive"),
+      },
+    ];
+  }, []);
+
+  const handleCloseModal = useCallback(() => setModal(null), []);
+
+  const handleCollectionChange = useCallback(
+    (collection: Collection) => {
+      onChangeCollection(collection);
+      handleCloseModal();
+    },
+    [onChangeCollection, handleCloseModal],
+  );
+
+  const renderModal = useCallback(() => {
+    if (modal === "move") {
+      return (
+        <CollectionMoveModal
+          title={t`Which collection should this be in?`}
+          initialCollectionId={model.collectionId() || "root"}
+          onMove={handleCollectionChange}
+          onClose={handleCloseModal}
         />
-        <ModelFootnote>{t`Model`}</ModelFootnote>
-      </div>
-      <ModelHeaderButtonsContainer>
-        <Button as={Link} to={queryEditorLink}>{t`Edit definition`}</Button>
-        <Button primary as={Link} to={exploreDataLink}>{t`Explore`}</Button>
-      </ModelHeaderButtonsContainer>
-    </ModelHeader>
+      );
+    }
+    if (modal === "archive") {
+      return <ArchiveModelModal question={model} onClose={handleCloseModal} />;
+    }
+    return null;
+  }, [modal, model, handleCollectionChange, handleCloseModal]);
+
+  return (
+    <>
+      <ModelHeader>
+        <div>
+          <ModelTitle
+            initialValue={model.displayName()}
+            isDisabled={!canWrite}
+            onChange={onChangeName}
+          />
+          <ModelFootnote>{t`Model`}</ModelFootnote>
+        </div>
+        <ModelHeaderButtonsContainer>
+          <Button as={Link} to={queryEditorLink}>{t`Edit definition`}</Button>
+          <Button primary as={Link} to={exploreDataLink}>{t`Explore`}</Button>
+          <EntityMenu items={extraActions} triggerIcon="ellipsis" />
+        </ModelHeaderButtonsContainer>
+      </ModelHeader>
+      {modal && <Modal onClose={handleCloseModal}>{renderModal()}</Modal>}
+    </>
   );
 }
 

--- a/frontend/src/metabase/models/components/ModelDetailPage/ModelDetailHeader/index.ts
+++ b/frontend/src/metabase/models/components/ModelDetailPage/ModelDetailHeader/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ModelDetailHeader";

--- a/frontend/src/metabase/models/components/ModelDetailPage/ModelDetailPage.styled.tsx
+++ b/frontend/src/metabase/models/components/ModelDetailPage/ModelDetailPage.styled.tsx
@@ -1,0 +1,73 @@
+import styled from "@emotion/styled";
+
+import EditableText from "metabase/core/components/EditableText";
+import Radio from "metabase/core/components/Radio";
+import BaseTabPanel from "metabase/core/components/TabPanel";
+
+import { color } from "metabase/lib/colors";
+
+export const RootLayout = styled.div`
+  display: flex;
+  flex: 1;
+  flex-direction: row;
+
+  padding: 3rem 4rem;
+  min-height: 90vh;
+`;
+
+export const ModelMain = styled.div`
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+
+  padding-right: 3rem;
+`;
+
+export const ModelTitle = styled(EditableText)`
+  color: ${color("text-dark")};
+  font-weight: 700;
+  font-size: 1.25rem;
+`;
+
+export const ModelFootnote = styled.p`
+  color: ${color("text-medium")};
+  margin: 4px 0 0 4px;
+`;
+
+export const ModelHeader = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: flex-start;
+  width: 100%;
+`;
+
+export const TabList = styled(Radio)`
+  margin: 1rem 0;
+`;
+
+TabList.defaultProps = { variant: "underlined" };
+
+export const TabPanel = styled(BaseTabPanel)`
+  display: flex;
+  flex-direction: column;
+`;
+
+export const EmptyStateContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 1rem;
+
+  margin: 3rem 0;
+`;
+
+export const EmptyStateTitle = styled.span`
+  display: block;
+  color: ${color("text-medium")};
+  font-size: 1rem;
+  line-height: 1.5rem;
+  margin-bottom: 1rem;
+  text-align: center;
+`;

--- a/frontend/src/metabase/models/components/ModelDetailPage/ModelDetailPage.styled.tsx
+++ b/frontend/src/metabase/models/components/ModelDetailPage/ModelDetailPage.styled.tsx
@@ -1,6 +1,5 @@
 import styled from "@emotion/styled";
 
-import EditableText from "metabase/core/components/EditableText";
 import Radio from "metabase/core/components/Radio";
 import BaseTabPanel from "metabase/core/components/TabPanel";
 
@@ -21,31 +20,6 @@ export const ModelMain = styled.div`
   flex-direction: column;
 
   padding-right: 3rem;
-`;
-
-export const ModelTitle = styled(EditableText)`
-  color: ${color("text-dark")};
-  font-weight: 700;
-  font-size: 1.25rem;
-`;
-
-export const ModelFootnote = styled.p`
-  color: ${color("text-medium")};
-  margin: 4px 0 0 4px;
-`;
-
-export const ModelHeader = styled.div`
-  display: flex;
-  flex-direction: row;
-  justify-content: space-between;
-  align-items: flex-start;
-  width: 100%;
-`;
-
-export const ModelHeaderButtonsContainer = styled.div`
-  display: flex;
-  align-items: center;
-  gap: 1rem;
 `;
 
 export const TabList = styled(Radio)`

--- a/frontend/src/metabase/models/components/ModelDetailPage/ModelDetailPage.styled.tsx
+++ b/frontend/src/metabase/models/components/ModelDetailPage/ModelDetailPage.styled.tsx
@@ -42,6 +42,12 @@ export const ModelHeader = styled.div`
   width: 100%;
 `;
 
+export const ModelHeaderButtonsContainer = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+`;
+
 export const TabList = styled(Radio)`
   margin: 1rem 0;
 `;

--- a/frontend/src/metabase/models/components/ModelDetailPage/ModelDetailPage.styled.tsx
+++ b/frontend/src/metabase/models/components/ModelDetailPage/ModelDetailPage.styled.tsx
@@ -24,6 +24,7 @@ export const ModelMain = styled.div`
 
 export const TabList = styled(Radio)`
   margin: 1rem 0;
+  border-bottom: 1px solid ${color("border")};
 `;
 
 TabList.defaultProps = { variant: "underlined" };

--- a/frontend/src/metabase/models/components/ModelDetailPage/ModelDetailPage.tsx
+++ b/frontend/src/metabase/models/components/ModelDetailPage/ModelDetailPage.tsx
@@ -1,26 +1,19 @@
 import React, { useCallback, useState } from "react";
 import { t } from "ttag";
 
-import Button from "metabase/core/components/Button";
-import Link from "metabase/core/components/Link";
 import TabContent from "metabase/core/components/TabContent";
-
-import * as Urls from "metabase/lib/urls";
 
 import type { Card } from "metabase-types/api";
 import type Question from "metabase-lib/Question";
 import type Table from "metabase-lib/metadata/Table";
 
+import ModelDetailHeader from "./ModelDetailHeader";
 import ModelInfoSidePanel from "./ModelInfoSidePanel";
 import ModelSchemaDetails from "./ModelSchemaDetails";
 import ModelUsageDetails from "./ModelUsageDetails";
 import {
   RootLayout,
   ModelMain,
-  ModelHeader,
-  ModelHeaderButtonsContainer,
-  ModelTitle,
-  ModelFootnote,
   TabList,
   TabPanel,
 } from "./ModelDetailPage.styled";
@@ -36,11 +29,6 @@ type ModelTab = "schema" | "usage";
 function ModelDetailPage({ model, mainTable, onChangeModel }: Props) {
   const [tab, setTab] = useState<ModelTab>("usage");
 
-  const modelCard = model.card();
-
-  const queryEditorLink = Urls.modelEditor(modelCard, { type: "query" });
-  const exploreDataLink = Urls.model(modelCard);
-
   const handleNameChange = useCallback(
     name => {
       if (name && name !== model.displayName()) {
@@ -50,7 +38,7 @@ function ModelDetailPage({ model, mainTable, onChangeModel }: Props) {
     [model, onChangeModel],
   );
 
-  const handleChangeDescription = useCallback(
+  const handleDescriptionChange = useCallback(
     description => {
       if (model.description() !== description) {
         onChangeModel(model.setDescription(description).card() as Card);
@@ -62,20 +50,7 @@ function ModelDetailPage({ model, mainTable, onChangeModel }: Props) {
   return (
     <RootLayout>
       <ModelMain>
-        <ModelHeader>
-          <div>
-            <ModelTitle
-              initialValue={model.displayName()}
-              isDisabled={!model.canWrite()}
-              onChange={handleNameChange}
-            />
-            <ModelFootnote>{t`Model`}</ModelFootnote>
-          </div>
-          <ModelHeaderButtonsContainer>
-            <Button as={Link} to={queryEditorLink}>{t`Edit definition`}</Button>
-            <Button primary as={Link} to={exploreDataLink}>{t`Explore`}</Button>
-          </ModelHeaderButtonsContainer>
-        </ModelHeader>
+        <ModelDetailHeader model={model} onChangeName={handleNameChange} />
         <TabContent value={tab} onChange={setTab}>
           <TabList
             value={tab}
@@ -96,7 +71,7 @@ function ModelDetailPage({ model, mainTable, onChangeModel }: Props) {
       <ModelInfoSidePanel
         model={model}
         mainTable={mainTable}
-        onChangeDescription={handleChangeDescription}
+        onChangeDescription={handleDescriptionChange}
       />
     </RootLayout>
   );

--- a/frontend/src/metabase/models/components/ModelDetailPage/ModelDetailPage.tsx
+++ b/frontend/src/metabase/models/components/ModelDetailPage/ModelDetailPage.tsx
@@ -1,0 +1,100 @@
+import React, { useCallback, useState } from "react";
+import { t } from "ttag";
+
+import Button from "metabase/core/components/Button";
+import Link from "metabase/core/components/Link";
+import TabContent from "metabase/core/components/TabContent";
+
+import * as Urls from "metabase/lib/urls";
+
+import type { Card } from "metabase-types/api";
+import type Question from "metabase-lib/Question";
+import type Table from "metabase-lib/metadata/Table";
+
+import ModelInfoSidePanel from "./ModelInfoSidePanel";
+import ModelSchemaDetails from "./ModelSchemaDetails";
+import ModelUsageDetails from "./ModelUsageDetails";
+import {
+  RootLayout,
+  ModelMain,
+  ModelHeader,
+  ModelTitle,
+  ModelFootnote,
+  TabList,
+  TabPanel,
+} from "./ModelDetailPage.styled";
+
+interface Props {
+  model: Question;
+  mainTable?: Table | null;
+  onChangeModel: (model: Card) => void;
+}
+
+type ModelTab = "schema" | "usage";
+
+function ModelDetailPage({ model, mainTable, onChangeModel }: Props) {
+  const [tab, setTab] = useState<ModelTab>("usage");
+
+  const modelCard = model.card();
+
+  const exploreDataLink = Urls.question(modelCard);
+
+  const handleNameChange = useCallback(
+    name => {
+      if (name && name !== model.displayName()) {
+        onChangeModel(model.setDisplayName(name).card() as Card);
+      }
+    },
+    [model, onChangeModel],
+  );
+
+  const handleChangeDescription = useCallback(
+    description => {
+      if (model.description() !== description) {
+        onChangeModel(model.setDescription(description).card() as Card);
+      }
+    },
+    [model, onChangeModel],
+  );
+
+  return (
+    <RootLayout>
+      <ModelMain>
+        <ModelHeader>
+          <div>
+            <ModelTitle
+              initialValue={model.displayName()}
+              isDisabled={!model.canWrite()}
+              onChange={handleNameChange}
+            />
+            <ModelFootnote>{t`Model`}</ModelFootnote>
+          </div>
+          <Button primary as={Link} to={exploreDataLink}>{t`Explore`}</Button>
+        </ModelHeader>
+        <TabContent value={tab} onChange={setTab}>
+          <TabList
+            value={tab}
+            options={[
+              { value: "usage", name: t`Used by` },
+              { value: "schema", name: t`Schema` },
+            ]}
+            onChange={tab => setTab(tab as ModelTab)}
+          />
+          <TabPanel value="usage">
+            <ModelUsageDetails model={model} />
+          </TabPanel>
+          <TabPanel value="schema">
+            <ModelSchemaDetails model={model} />
+          </TabPanel>
+        </TabContent>
+      </ModelMain>
+      <ModelInfoSidePanel
+        model={model}
+        mainTable={mainTable}
+        onChangeDescription={handleChangeDescription}
+      />
+    </RootLayout>
+  );
+}
+
+export default ModelDetailPage;

--- a/frontend/src/metabase/models/components/ModelDetailPage/ModelDetailPage.tsx
+++ b/frontend/src/metabase/models/components/ModelDetailPage/ModelDetailPage.tsx
@@ -3,7 +3,7 @@ import { t } from "ttag";
 
 import TabContent from "metabase/core/components/TabContent";
 
-import type { Card } from "metabase-types/api";
+import type { Card, Collection } from "metabase-types/api";
 import type Question from "metabase-lib/Question";
 import type Table from "metabase-lib/metadata/Table";
 
@@ -22,11 +22,17 @@ interface Props {
   model: Question;
   mainTable?: Table | null;
   onChangeModel: (model: Card) => void;
+  onChangeCollection: (collection: Collection) => void;
 }
 
 type ModelTab = "schema" | "usage";
 
-function ModelDetailPage({ model, mainTable, onChangeModel }: Props) {
+function ModelDetailPage({
+  model,
+  mainTable,
+  onChangeModel,
+  onChangeCollection,
+}: Props) {
   const [tab, setTab] = useState<ModelTab>("usage");
 
   const handleNameChange = useCallback(
@@ -52,7 +58,11 @@ function ModelDetailPage({ model, mainTable, onChangeModel }: Props) {
   return (
     <RootLayout>
       <ModelMain>
-        <ModelDetailHeader model={model} onChangeName={handleNameChange} />
+        <ModelDetailHeader
+          model={model}
+          onChangeName={handleNameChange}
+          onChangeCollection={onChangeCollection}
+        />
         <TabContent value={tab} onChange={setTab}>
           <TabList
             value={tab}

--- a/frontend/src/metabase/models/components/ModelDetailPage/ModelDetailPage.tsx
+++ b/frontend/src/metabase/models/components/ModelDetailPage/ModelDetailPage.tsx
@@ -18,6 +18,7 @@ import {
   RootLayout,
   ModelMain,
   ModelHeader,
+  ModelHeaderButtonsContainer,
   ModelTitle,
   ModelFootnote,
   TabList,
@@ -37,6 +38,7 @@ function ModelDetailPage({ model, mainTable, onChangeModel }: Props) {
 
   const modelCard = model.card();
 
+  const queryEditorLink = Urls.modelEditor(modelCard, { type: "query" });
   const exploreDataLink = Urls.model(modelCard);
 
   const handleNameChange = useCallback(
@@ -69,7 +71,10 @@ function ModelDetailPage({ model, mainTable, onChangeModel }: Props) {
             />
             <ModelFootnote>{t`Model`}</ModelFootnote>
           </div>
-          <Button primary as={Link} to={exploreDataLink}>{t`Explore`}</Button>
+          <ModelHeaderButtonsContainer>
+            <Button as={Link} to={queryEditorLink}>{t`Edit definition`}</Button>
+            <Button primary as={Link} to={exploreDataLink}>{t`Explore`}</Button>
+          </ModelHeaderButtonsContainer>
         </ModelHeader>
         <TabContent value={tab} onChange={setTab}>
           <TabList

--- a/frontend/src/metabase/models/components/ModelDetailPage/ModelDetailPage.tsx
+++ b/frontend/src/metabase/models/components/ModelDetailPage/ModelDetailPage.tsx
@@ -37,7 +37,7 @@ function ModelDetailPage({ model, mainTable, onChangeModel }: Props) {
 
   const modelCard = model.card();
 
-  const exploreDataLink = Urls.question(modelCard);
+  const exploreDataLink = Urls.model(modelCard);
 
   const handleNameChange = useCallback(
     name => {

--- a/frontend/src/metabase/models/components/ModelDetailPage/ModelDetailPage.tsx
+++ b/frontend/src/metabase/models/components/ModelDetailPage/ModelDetailPage.tsx
@@ -32,7 +32,8 @@ function ModelDetailPage({ model, mainTable, onChangeModel }: Props) {
   const handleNameChange = useCallback(
     name => {
       if (name && name !== model.displayName()) {
-        onChangeModel(model.setDisplayName(name).card() as Card);
+        const nextCard = model.setDisplayName(name).card();
+        onChangeModel(nextCard as Card);
       }
     },
     [model, onChangeModel],
@@ -41,7 +42,8 @@ function ModelDetailPage({ model, mainTable, onChangeModel }: Props) {
   const handleDescriptionChange = useCallback(
     description => {
       if (model.description() !== description) {
-        onChangeModel(model.setDescription(description).card() as Card);
+        const nextCard = model.setDescription(description).card();
+        onChangeModel(nextCard as Card);
       }
     },
     [model, onChangeModel],

--- a/frontend/src/metabase/models/components/ModelDetailPage/ModelInfoSidePanel/ModelInfoSidePanel.styled.tsx
+++ b/frontend/src/metabase/models/components/ModelDetailPage/ModelInfoSidePanel/ModelInfoSidePanel.styled.tsx
@@ -1,0 +1,51 @@
+import styled from "@emotion/styled";
+import { css } from "@emotion/react";
+
+import EditableText from "metabase/core/components/EditableText";
+import Link from "metabase/core/components/Link";
+
+import { color } from "metabase/lib/colors";
+
+export const ModelInfoSection = styled.div``;
+
+export const ModelInfoPanel = styled.div`
+  padding-left: 2rem;
+  border-left: 1px solid ${color("border")};
+  width: 15rem;
+
+  ${ModelInfoSection}:not(:first-of-type) {
+    margin-top: 1rem;
+  }
+`;
+
+export const ModelInfoTitle = styled.span`
+  display: block;
+  color: ${color("text-dark")};
+  font-weight: 600;
+
+  padding-left: 4px;
+`;
+
+export const valueBlockStyle = css`
+  display: block;
+  margin-top: 0.5rem;
+  padding-left: 4px;
+`;
+
+const commonInfoTextStyle = css`
+  ${valueBlockStyle}
+  color: ${color("text-medium")};
+`;
+
+export const ModelInfoText = styled.span`
+  ${commonInfoTextStyle}
+`;
+
+export const ModelDescription = styled(EditableText)`
+  ${commonInfoTextStyle}
+`;
+
+export const ModelInfoLink = styled(Link)`
+  ${commonInfoTextStyle}
+  color: ${color("brand")};
+`;

--- a/frontend/src/metabase/models/components/ModelDetailPage/ModelInfoSidePanel/ModelInfoSidePanel.tsx
+++ b/frontend/src/metabase/models/components/ModelDetailPage/ModelInfoSidePanel/ModelInfoSidePanel.tsx
@@ -39,20 +39,28 @@ function ModelInfoSidePanel({ model, mainTable, onChangeDescription }: Props) {
           isOptional
           isMultiline
           isDisabled={!canWrite}
+          aria-label={t`Description`}
           onChange={onChangeDescription}
         />
       </ModelInfoSection>
-      <ModelRelationships model={model} mainTable={mainTable} />
+      {!model.isNative() && (
+        <ModelRelationships model={model} mainTable={mainTable} />
+      )}
       {modelCard.creator && (
         <ModelInfoSection>
           <ModelInfoTitle>{t`Contact`}</ModelInfoTitle>
-          <ModelInfoText>{modelCard.creator.common_name}</ModelInfoText>
+          <ModelInfoText aria-label={t`Contact`}>
+            {modelCard.creator.common_name}
+          </ModelInfoText>
         </ModelInfoSection>
       )}
       {mainTable && (
         <ModelInfoSection>
           <ModelInfoTitle>{t`Backing table`}</ModelInfoTitle>
-          <ModelInfoLink to={mainTable.newQuestion().getUrl({ clean: false })}>
+          <ModelInfoLink
+            to={mainTable.newQuestion().getUrl({ clean: false })}
+            aria-label={t`Backing table`}
+          >
             {mainTable.displayName()}
           </ModelInfoLink>
         </ModelInfoSection>

--- a/frontend/src/metabase/models/components/ModelDetailPage/ModelInfoSidePanel/ModelInfoSidePanel.tsx
+++ b/frontend/src/metabase/models/components/ModelDetailPage/ModelInfoSidePanel/ModelInfoSidePanel.tsx
@@ -1,0 +1,64 @@
+import React from "react";
+import { t } from "ttag";
+
+import type { Card } from "metabase-types/api";
+import type Question from "metabase-lib/Question";
+import type Table from "metabase-lib/metadata/Table";
+
+import ModelRelationships from "./ModelRelationships";
+import {
+  ModelInfoPanel,
+  ModelInfoTitle,
+  ModelInfoText,
+  ModelInfoSection,
+  ModelDescription,
+  ModelInfoLink,
+} from "./ModelInfoSidePanel.styled";
+
+interface Props {
+  model: Question;
+  mainTable?: Table | null;
+  onChangeDescription: (description: string | null) => void;
+}
+
+function ModelInfoSidePanel({ model, mainTable, onChangeDescription }: Props) {
+  const modelCard = model.card() as Card;
+
+  const canWrite = model.canWrite();
+  const description = model.description();
+
+  return (
+    <ModelInfoPanel>
+      <ModelInfoSection>
+        <ModelInfoTitle>{t`Description`}</ModelInfoTitle>
+        <ModelDescription
+          initialValue={description}
+          placeholder={
+            !description && !canWrite ? t`No description` : t`Add description`
+          }
+          isOptional
+          isMultiline
+          isDisabled={!canWrite}
+          onChange={onChangeDescription}
+        />
+      </ModelInfoSection>
+      <ModelRelationships model={model} mainTable={mainTable} />
+      {modelCard.creator && (
+        <ModelInfoSection>
+          <ModelInfoTitle>{t`Contact`}</ModelInfoTitle>
+          <ModelInfoText>{modelCard.creator.common_name}</ModelInfoText>
+        </ModelInfoSection>
+      )}
+      {mainTable && (
+        <ModelInfoSection>
+          <ModelInfoTitle>{t`Backing table`}</ModelInfoTitle>
+          <ModelInfoLink to={mainTable.newQuestion().getUrl({ clean: false })}>
+            {mainTable.displayName()}
+          </ModelInfoLink>
+        </ModelInfoSection>
+      )}
+    </ModelInfoPanel>
+  );
+}
+
+export default ModelInfoSidePanel;

--- a/frontend/src/metabase/models/components/ModelDetailPage/ModelInfoSidePanel/ModelRelationships.styled.tsx
+++ b/frontend/src/metabase/models/components/ModelDetailPage/ModelInfoSidePanel/ModelRelationships.styled.tsx
@@ -1,0 +1,35 @@
+import styled from "@emotion/styled";
+
+import Link from "metabase/core/components/Link";
+import Icon from "metabase/components/Icon";
+
+import { color, darken } from "metabase/lib/colors";
+
+import { valueBlockStyle } from "./ModelInfoSidePanel.styled";
+
+export const List = styled.ul`
+  ${valueBlockStyle}
+
+  li:not(:first-of-type) {
+    margin-top: 6px;
+  }
+`;
+
+export const ListItemName = styled.span`
+  display: block;
+`;
+
+export const ListItemLink = styled(Link)`
+  display: flex;
+  align-items: center;
+
+  color: ${color("brand")};
+
+  ${ListItemName} {
+    margin-left: 4px;
+  }
+
+  &:hover {
+    color: ${darken("brand")};
+  }
+`;

--- a/frontend/src/metabase/models/components/ModelDetailPage/ModelInfoSidePanel/ModelRelationships.tsx
+++ b/frontend/src/metabase/models/components/ModelDetailPage/ModelInfoSidePanel/ModelRelationships.tsx
@@ -1,0 +1,49 @@
+import React, { useMemo } from "react";
+import { t } from "ttag";
+import _ from "underscore";
+
+import Icon from "metabase/components/Icon";
+
+import type Question from "metabase-lib/Question";
+import type Table from "metabase-lib/metadata/Table";
+
+import { ModelInfoTitle, ModelInfoSection } from "./ModelInfoSidePanel.styled";
+import { List, ListItemLink, ListItemName } from "./ModelRelationships.styled";
+
+interface Props {
+  model: Question;
+  mainTable?: Table | null;
+}
+
+function ModelRelationships({ model, mainTable }: Props) {
+  const relatedTables = useMemo(() => {
+    const tablesMainTablePointsTo = model.table()?.foreignTables() || [];
+    const tablesPointingToMainTable = mainTable?.connectedTables() || [];
+    return _.uniq(
+      [...tablesMainTablePointsTo, ...tablesPointingToMainTable],
+      table => table.id,
+    );
+  }, [model, mainTable]);
+
+  if (relatedTables.length <= 0) {
+    return null;
+  }
+
+  return (
+    <ModelInfoSection>
+      <ModelInfoTitle>{t`Relationships`}</ModelInfoTitle>
+      <List>
+        {relatedTables.map(table => (
+          <li key={table.id}>
+            <ListItemLink to={table.newQuestion().getUrl()}>
+              <Icon name="table" />
+              <ListItemName>{table.displayName()}</ListItemName>
+            </ListItemLink>
+          </li>
+        ))}
+      </List>
+    </ModelInfoSection>
+  );
+}
+
+export default ModelRelationships;

--- a/frontend/src/metabase/models/components/ModelDetailPage/ModelInfoSidePanel/ModelRelationships.tsx
+++ b/frontend/src/metabase/models/components/ModelDetailPage/ModelInfoSidePanel/ModelRelationships.tsx
@@ -32,10 +32,13 @@ function ModelRelationships({ model, mainTable }: Props) {
   return (
     <ModelInfoSection>
       <ModelInfoTitle>{t`Relationships`}</ModelInfoTitle>
-      <List>
+      <List data-testid="model-relationships">
         {relatedTables.map(table => (
           <li key={table.id}>
-            <ListItemLink to={table.newQuestion().getUrl()}>
+            <ListItemLink
+              to={table.newQuestion().getUrl()}
+              aria-label={table.displayName()}
+            >
               <Icon name="table" />
               <ListItemName>{table.displayName()}</ListItemName>
             </ListItemLink>

--- a/frontend/src/metabase/models/components/ModelDetailPage/ModelInfoSidePanel/index.ts
+++ b/frontend/src/metabase/models/components/ModelDetailPage/ModelInfoSidePanel/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ModelInfoSidePanel";

--- a/frontend/src/metabase/models/components/ModelDetailPage/ModelSchemaDetails/ModelSchemaDetails.styled.tsx
+++ b/frontend/src/metabase/models/components/ModelDetailPage/ModelSchemaDetails/ModelSchemaDetails.styled.tsx
@@ -1,0 +1,40 @@
+import styled from "@emotion/styled";
+
+import Icon from "metabase/components/Icon";
+
+import { color } from "metabase/lib/colors";
+
+export const SchemaHeader = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+`;
+
+export const FieldList = styled.ul`
+  padding-top: 1rem;
+`;
+
+export const FieldTitle = styled.span`
+  font-weight: 700;
+`;
+
+export const FieldIcon = styled(Icon)``;
+
+export const FieldListItem = styled.li`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+
+  width: 100%;
+  border-radius: 8px;
+  padding: 1rem 0.5rem;
+
+  ${FieldTitle} {
+    margin-left: 1rem;
+  }
+
+  &:hover {
+    background-color: ${color("brand-light")};
+  }
+`;

--- a/frontend/src/metabase/models/components/ModelDetailPage/ModelSchemaDetails/ModelSchemaDetails.tsx
+++ b/frontend/src/metabase/models/components/ModelDetailPage/ModelSchemaDetails/ModelSchemaDetails.tsx
@@ -1,0 +1,58 @@
+import React, { useCallback, useMemo } from "react";
+import { t, ngettext, msgid } from "ttag";
+
+import Button from "metabase/core/components/Button";
+import Link from "metabase/core/components/Link";
+
+import * as Urls from "metabase/lib/urls";
+import { getSemanticTypeIcon } from "metabase/lib/schema_metadata";
+
+import type Field from "metabase-lib/metadata/Field";
+import type Question from "metabase-lib/Question";
+
+import {
+  SchemaHeader,
+  FieldList,
+  FieldListItem,
+  FieldTitle,
+  FieldIcon,
+} from "./ModelSchemaDetails.styled";
+
+interface Props {
+  model: Question;
+}
+
+function ModelSchemaDetails({ model }: Props) {
+  const baseModelUrl = Urls.question(model.card());
+  const metadataEditorUrl = `${baseModelUrl}/metadata`;
+
+  const fields = useMemo(() => model.table()?.fields || [], [model]);
+
+  const fieldsCount = useMemo(() => {
+    return ((count: number) =>
+      ngettext(msgid`${count} field`, `${count} fields`, count))(fields.length);
+  }, [fields]);
+
+  const renderField = useCallback((field: Field) => {
+    const icon = getSemanticTypeIcon(field.semantic_type, "warning");
+    const tooltip = field.semantic_type ? null : t`Unknown type`;
+    return (
+      <FieldListItem key={field.getUniqueId()}>
+        <FieldIcon name={icon} tooltip={tooltip} />
+        <FieldTitle>{field.displayName()}</FieldTitle>
+      </FieldListItem>
+    );
+  }, []);
+
+  return (
+    <>
+      <SchemaHeader>
+        <span>{fieldsCount}</span>
+        <Button as={Link} to={metadataEditorUrl}>{t`Edit metadata`}</Button>
+      </SchemaHeader>
+      <FieldList>{fields.map(renderField)}</FieldList>
+    </>
+  );
+}
+
+export default ModelSchemaDetails;

--- a/frontend/src/metabase/models/components/ModelDetailPage/ModelSchemaDetails/ModelSchemaDetails.tsx
+++ b/frontend/src/metabase/models/components/ModelDetailPage/ModelSchemaDetails/ModelSchemaDetails.tsx
@@ -23,8 +23,9 @@ interface Props {
 }
 
 function ModelSchemaDetails({ model }: Props) {
-  const baseModelUrl = Urls.question(model.card());
-  const metadataEditorUrl = `${baseModelUrl}/metadata`;
+  const metadataEditorUrl = Urls.modelEditor(model.card(), {
+    type: "metadata",
+  });
 
   const fields = useMemo(() => model.table()?.fields || [], [model]);
 

--- a/frontend/src/metabase/models/components/ModelDetailPage/ModelSchemaDetails/ModelSchemaDetails.tsx
+++ b/frontend/src/metabase/models/components/ModelDetailPage/ModelSchemaDetails/ModelSchemaDetails.tsx
@@ -23,6 +23,8 @@ interface Props {
 }
 
 function ModelSchemaDetails({ model }: Props) {
+  const canWrite = model.canWrite();
+
   const metadataEditorUrl = Urls.modelEditor(model.card(), {
     type: "metadata",
   });
@@ -49,7 +51,9 @@ function ModelSchemaDetails({ model }: Props) {
     <>
       <SchemaHeader>
         <span>{fieldsCount}</span>
-        <Button as={Link} to={metadataEditorUrl}>{t`Edit metadata`}</Button>
+        {canWrite && (
+          <Button as={Link} to={metadataEditorUrl}>{t`Edit metadata`}</Button>
+        )}
       </SchemaHeader>
       <FieldList>{fields.map(renderField)}</FieldList>
     </>

--- a/frontend/src/metabase/models/components/ModelDetailPage/ModelSchemaDetails/index.ts
+++ b/frontend/src/metabase/models/components/ModelDetailPage/ModelSchemaDetails/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ModelSchemaDetails";

--- a/frontend/src/metabase/models/components/ModelDetailPage/ModelUsageDetails/ModelUsageDetails.styled.tsx
+++ b/frontend/src/metabase/models/components/ModelDetailPage/ModelUsageDetails/ModelUsageDetails.styled.tsx
@@ -1,0 +1,27 @@
+import styled from "@emotion/styled";
+
+import Link from "metabase/core/components/Link";
+
+import { color } from "metabase/lib/colors";
+
+export const CardTitle = styled.span`
+  font-weight: 700;
+`;
+
+export const CardListItem = styled(Link)`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+
+  width: 100%;
+  border-radius: 8px;
+  padding: 1rem 0.5rem;
+
+  ${CardTitle} {
+    margin-left: 1rem;
+  }
+
+  &:hover {
+    background-color: ${color("brand-light")};
+  }
+`;

--- a/frontend/src/metabase/models/components/ModelDetailPage/ModelUsageDetails/ModelUsageDetails.tsx
+++ b/frontend/src/metabase/models/components/ModelDetailPage/ModelUsageDetails/ModelUsageDetails.tsx
@@ -1,0 +1,73 @@
+import React from "react";
+import { t } from "ttag";
+
+import Button from "metabase/core/components/Button";
+import Link from "metabase/core/components/Link";
+import Icon from "metabase/components/Icon";
+
+import * as Urls from "metabase/lib/urls";
+import Questions, {
+  getIcon as getQuestionIcon,
+} from "metabase/entities/questions";
+
+import type { Card } from "metabase-types/api";
+import type { State } from "metabase-types/store";
+import type { Card as LegacyCardType } from "metabase-types/types/Card";
+import type Question from "metabase-lib/Question";
+
+import {
+  EmptyStateContainer,
+  EmptyStateTitle,
+} from "../ModelDetailPage.styled";
+
+import { CardListItem, CardTitle } from "./ModelUsageDetails.styled";
+
+interface OwnProps {
+  model: Question;
+}
+
+interface EntityLoaderProps {
+  cards: Card[];
+}
+
+type Props = OwnProps & EntityLoaderProps;
+
+function ModelUsageDetails({ model, cards }: Props) {
+  if (cards.length === 0) {
+    return (
+      <EmptyStateContainer>
+        <EmptyStateTitle>{t`This model is not used by any questions yet.`}</EmptyStateTitle>
+        <Button
+          as={Link}
+          to={model.composeDataset().getUrl()}
+          icon="add"
+        >{t`Create a new question`}</Button>
+      </EmptyStateContainer>
+    );
+  }
+
+  return (
+    <ul>
+      {cards.map(card => (
+        <li key={card.id}>
+          <CardListItem to={Urls.question(card as LegacyCardType)}>
+            <Icon name={getQuestionIcon(card).name} />
+            <CardTitle>{card.name}</CardTitle>
+          </CardListItem>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function getCardListingQuery(state: State, { model }: OwnProps) {
+  return {
+    f: "using_model",
+    model_id: model.id(),
+  };
+}
+
+export default Questions.loadList({
+  listName: "cards",
+  query: getCardListingQuery,
+})(ModelUsageDetails);

--- a/frontend/src/metabase/models/components/ModelDetailPage/ModelUsageDetails/ModelUsageDetails.tsx
+++ b/frontend/src/metabase/models/components/ModelDetailPage/ModelUsageDetails/ModelUsageDetails.tsx
@@ -50,7 +50,10 @@ function ModelUsageDetails({ model, cards }: Props) {
     <ul>
       {cards.map(card => (
         <li key={card.id}>
-          <CardListItem to={Urls.question(card as LegacyCardType)}>
+          <CardListItem
+            to={Urls.question(card as LegacyCardType)}
+            aria-label={card.name}
+          >
             <Icon name={getQuestionIcon(card).name} />
             <CardTitle>{card.name}</CardTitle>
           </CardListItem>

--- a/frontend/src/metabase/models/components/ModelDetailPage/ModelUsageDetails/index.ts
+++ b/frontend/src/metabase/models/components/ModelDetailPage/ModelUsageDetails/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ModelUsageDetails";

--- a/frontend/src/metabase/models/components/ModelDetailPage/index.ts
+++ b/frontend/src/metabase/models/components/ModelDetailPage/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ModelDetailPage";

--- a/frontend/src/metabase/models/containers/ModelDetailPage/ModelDetailPage.tsx
+++ b/frontend/src/metabase/models/containers/ModelDetailPage/ModelDetailPage.tsx
@@ -1,0 +1,100 @@
+import React, { useEffect, useMemo, useState } from "react";
+import _ from "underscore";
+import { connect } from "react-redux";
+
+import * as Urls from "metabase/lib/urls";
+import { useOnMount } from "metabase/hooks/use-on-mount";
+
+import { getMetadata } from "metabase/selectors/metadata";
+import Questions from "metabase/entities/questions";
+import Tables from "metabase/entities/tables";
+
+import { loadMetadataForCard } from "metabase/query_builder/actions";
+
+import ModelDetailPageView from "metabase/models/components/ModelDetailPage";
+
+import type { Card } from "metabase-types/api";
+import type { Card as LegacyCardType } from "metabase-types/types/Card";
+import type { State } from "metabase-types/store";
+
+import Question from "metabase-lib/Question";
+import Table from "metabase-lib/metadata/Table";
+
+type OwnProps = {
+  params: {
+    slug: string;
+  };
+};
+
+type EntityLoaderProps = {
+  modelCard: Card;
+};
+
+type StateProps = {
+  model: Question;
+};
+
+type DispatchProps = {
+  loadMetadataForCard: (card: LegacyCardType) => void;
+  fetchTableForeignKeys: (params: { id: Table["id"] }) => void;
+  onChangeModel: (card: Card) => void;
+};
+
+type Props = OwnProps & EntityLoaderProps & StateProps & DispatchProps;
+
+function mapStateToProps(state: State, props: OwnProps & EntityLoaderProps) {
+  const metadata = getMetadata(state);
+  const model = new Question(props.modelCard, metadata);
+  return { model };
+}
+
+const mapDispatchToProps = {
+  loadMetadataForCard,
+  fetchTableForeignKeys: Tables.actions.fetchForeignKeys,
+  onChangeModel: Questions.actions.update,
+};
+
+function ModelDetailPage({
+  model,
+  loadMetadataForCard,
+  fetchTableForeignKeys,
+  onChangeModel,
+}: Props) {
+  const [hasFetchedTableMetadata, setHasFetchedTableMetadata] = useState(false);
+
+  const mainTable = useMemo(
+    () => (model.isStructured() ? model.query().sourceTable() : null),
+    [model],
+  );
+
+  useOnMount(() => {
+    loadMetadataForCard(model.card());
+  });
+
+  useEffect(() => {
+    if (mainTable && !hasFetchedTableMetadata) {
+      setHasFetchedTableMetadata(true);
+      fetchTableForeignKeys({ id: mainTable.id });
+    }
+  }, [mainTable, hasFetchedTableMetadata, fetchTableForeignKeys]);
+
+  return (
+    <ModelDetailPageView
+      model={model}
+      mainTable={mainTable}
+      onChangeModel={onChangeModel}
+    />
+  );
+}
+
+export default _.compose(
+  Questions.load({
+    id: (state: State, props: OwnProps) =>
+      Urls.extractEntityId(props.params.slug),
+    entityAlias: "modelCard",
+  }),
+  connect<StateProps, DispatchProps, OwnProps & EntityLoaderProps, State>(
+    mapStateToProps,
+    mapDispatchToProps,
+  ),
+)(ModelDetailPage);

--- a/frontend/src/metabase/models/containers/ModelDetailPage/ModelDetailPage.tsx
+++ b/frontend/src/metabase/models/containers/ModelDetailPage/ModelDetailPage.tsx
@@ -65,7 +65,7 @@ function mapStateToProps(state: State, props: OwnProps & EntityLoaderProps) {
 const mapDispatchToProps = {
   loadMetadataForCard,
   fetchTableForeignKeys: Tables.actions.fetchForeignKeys,
-  onChangeModel: Questions.actions.update,
+  onChangeModel: (card: Card) => Questions.actions.update(card),
   onChangeCollection: Questions.objectActions.setCollection,
 };
 

--- a/frontend/src/metabase/models/containers/ModelDetailPage/ModelDetailPage.tsx
+++ b/frontend/src/metabase/models/containers/ModelDetailPage/ModelDetailPage.tsx
@@ -9,7 +9,7 @@ import { getMetadata } from "metabase/selectors/metadata";
 import Questions from "metabase/entities/questions";
 import Tables from "metabase/entities/tables";
 
-import { loadMetadataForCard } from "metabase/query_builder/actions";
+import { loadMetadataForCard } from "metabase/questions/actions";
 
 import ModelDetailPageView from "metabase/models/components/ModelDetailPage";
 import QuestionMoveToast from "metabase/questions/components/QuestionMoveToast";

--- a/frontend/src/metabase/models/containers/ModelDetailPage/ModelDetailPage.tsx
+++ b/frontend/src/metabase/models/containers/ModelDetailPage/ModelDetailPage.tsx
@@ -8,6 +8,7 @@ import { useOnMount } from "metabase/hooks/use-on-mount";
 import { getMetadata } from "metabase/selectors/metadata";
 import Questions from "metabase/entities/questions";
 import Tables from "metabase/entities/tables";
+import title from "metabase/hoc/Title";
 
 import { loadMetadataForCard } from "metabase/questions/actions";
 
@@ -115,6 +116,10 @@ function ModelDetailPage({
   );
 }
 
+function getPageTitle({ modelCard }: Props) {
+  return modelCard?.name;
+}
+
 export default _.compose(
   Questions.load({
     id: (state: State, props: OwnProps) =>
@@ -125,4 +130,5 @@ export default _.compose(
     mapStateToProps,
     mapDispatchToProps,
   ),
+  title(getPageTitle),
 )(ModelDetailPage);

--- a/frontend/src/metabase/models/containers/ModelDetailPage/ModelDetailPage.unit.spec.tsx
+++ b/frontend/src/metabase/models/containers/ModelDetailPage/ModelDetailPage.unit.spec.tsx
@@ -31,6 +31,8 @@ import {
   getNativeModel as _getNativeModel,
   getSavedStructuredQuestion,
   getSavedNativeQuestion,
+  StructuredSavedCard,
+  NativeSavedCard,
 } from "metabase-lib/mocks";
 
 import ModelDetailPage from "./ModelDetailPage";
@@ -42,12 +44,12 @@ jest.mock("metabase/core/components/Link", () => ({ to, ...props }: any) => (
 
 const resultMetadata = ORDERS.fields.map(field => field.getPlainObject());
 
-function getStructuredModel(opts: Parameters<typeof _getStructuredModel>) {
-  return _getStructuredModel({ result_metadata: resultMetadata, ...opts });
+function getStructuredModel(card?: Partial<StructuredSavedCard>) {
+  return _getStructuredModel({ ...card, result_metadata: resultMetadata });
 }
 
-function getNativeModel(opts: Parameters<typeof _getNativeModel>) {
-  return _getNativeModel({ result_metadata: resultMetadata, ...opts });
+function getNativeModel(card?: Partial<NativeSavedCard>) {
+  return _getNativeModel({ ...card, result_metadata: resultMetadata });
 }
 
 const COLLECTION_1 = createMockCollection({

--- a/frontend/src/metabase/models/containers/ModelDetailPage/ModelDetailPage.unit.spec.tsx
+++ b/frontend/src/metabase/models/containers/ModelDetailPage/ModelDetailPage.unit.spec.tsx
@@ -6,6 +6,7 @@ import {
   fireEvent,
   renderWithProviders,
   getIcon,
+  queryIcon,
   screen,
   waitFor,
   waitForElementToBeRemoved,
@@ -267,6 +268,40 @@ describe("ModelDetailPage", () => {
           fields.forEach((field: Field) => {
             expect(screen.getByText(field.display_name)).toBeInTheDocument();
           });
+        });
+      });
+
+      describe("read-only permissions", () => {
+        const model = getModel({ can_write: false });
+
+        it("doesn't allow to rename a model", async () => {
+          await setup({ model });
+          expect(
+            screen.getByDisplayValue(model.displayName() as string),
+          ).toBeDisabled();
+        });
+
+        it("doesn't allow to change description", async () => {
+          await setup({ model });
+          expect(screen.getByPlaceholderText("No description")).toBeDisabled();
+        });
+
+        it("doesn't show model management actions", async () => {
+          await setup({ model });
+          expect(queryIcon("ellipsis")).not.toBeInTheDocument();
+          expect(screen.queryByText("Archive")).not.toBeInTheDocument();
+          expect(screen.queryByText("Move")).not.toBeInTheDocument();
+        });
+
+        it("doesn't show a link to the query editor", async () => {
+          await setup({ model });
+          expect(screen.queryByText("Edit definition")).not.toBeInTheDocument();
+        });
+
+        it("doesn't show a link to the metadata editor", async () => {
+          await setup({ model });
+          userEvent.click(screen.getByText("Schema"));
+          expect(screen.queryByText("Edit metadata")).not.toBeInTheDocument();
         });
       });
     });

--- a/frontend/src/metabase/models/containers/ModelDetailPage/ModelDetailPage.unit.spec.tsx
+++ b/frontend/src/metabase/models/containers/ModelDetailPage/ModelDetailPage.unit.spec.tsx
@@ -35,8 +35,6 @@ import {
 
 import ModelDetailPage from "./ModelDetailPage";
 
-console.warn = jest.fn();
-
 // eslint-disable-next-line react/display-name
 jest.mock("metabase/core/components/Link", () => ({ to, ...props }: any) => (
   <a {...props} href={to} />

--- a/frontend/src/metabase/models/containers/ModelDetailPage/ModelDetailPage.unit.spec.tsx
+++ b/frontend/src/metabase/models/containers/ModelDetailPage/ModelDetailPage.unit.spec.tsx
@@ -1,0 +1,317 @@
+import React from "react";
+import nock from "nock";
+import userEvent from "@testing-library/user-event";
+
+import {
+  fireEvent,
+  renderWithProviders,
+  getIcon,
+  screen,
+  waitFor,
+  waitForElementToBeRemoved,
+  within,
+} from "__support__/ui";
+import { PRODUCTS, PEOPLE } from "__support__/sample_database_fixture";
+import {
+  setupCardEndpoints,
+  setupCollectionEndpoints,
+  setupDatabasesEndpoints,
+  setupTableEndpoints,
+} from "__support__/server-mocks";
+
+import Models from "metabase/entities/questions";
+
+import type { Card, Collection, Field } from "metabase-types/api";
+import { createMockCollection, createMockUser } from "metabase-types/api/mocks";
+
+import type Question from "metabase-lib/Question";
+import {
+  getStructuredModel,
+  getNativeModel,
+  getSavedStructuredQuestion,
+  getSavedNativeQuestion,
+} from "metabase-lib/mocks";
+
+import ModelDetailPage from "./ModelDetailPage";
+
+console.warn = jest.fn();
+
+// eslint-disable-next-line react/display-name
+jest.mock("metabase/core/components/Link", () => ({ to, ...props }: any) => (
+  <a {...props} href={to} />
+));
+
+const COLLECTION_1 = createMockCollection({
+  id: 5,
+  name: "C1",
+  can_write: true,
+});
+
+const COLLECTION_2 = createMockCollection({
+  id: 10,
+  name: "C2",
+  can_write: true,
+});
+
+type SetupOpts = {
+  model: Question;
+  collections?: Collection[];
+  usedBy?: Question[];
+};
+
+async function setup({ model, collections = [], usedBy = [] }: SetupOpts) {
+  const scope = nock(location.origin).persist();
+
+  const modelUpdateSpy = jest.spyOn(Models.actions, "update");
+
+  const database = model.database();
+  const tables = database?.tables || [];
+  const card = model.card() as Card;
+  const slug = `${card.id}-model-name`;
+
+  if (database) {
+    setupDatabasesEndpoints(scope, [database]);
+    setupTableEndpoints(scope, tables);
+  }
+
+  scope
+    .get("/api/card")
+    .query({ f: "using_model", model_id: card.id })
+    .reply(
+      200,
+      usedBy.map(question => question.card()),
+    );
+
+  setupCardEndpoints(scope, [card]);
+
+  setupCollectionEndpoints(scope, collections);
+
+  renderWithProviders(<ModelDetailPage params={{ slug }} />, {
+    withSampleDatabase: true,
+  });
+
+  await waitForElementToBeRemoved(() =>
+    screen.queryByTestId("loading-spinner"),
+  );
+
+  return { modelUpdateSpy };
+}
+
+describe("ModelDetailPage", () => {
+  afterEach(() => {
+    nock.cleanAll();
+  });
+
+  [
+    { type: "structured", getModel: getStructuredModel },
+    { type: "native", getModel: getNativeModel },
+  ].forEach(testCase => {
+    const { type, getModel } = testCase;
+
+    describe(`${type} model`, () => {
+      it("renders and shows general info", async () => {
+        await setup({
+          model: getModel({ name: "My Model", description: "Foo Bar" }),
+        });
+
+        expect(screen.getByText("My Model")).toBeInTheDocument();
+        expect(screen.getByLabelText("Description")).toHaveTextContent(
+          "Foo Bar",
+        );
+      });
+
+      it("displays model contact", async () => {
+        const creator = createMockUser();
+        await setup({ model: getModel({ creator }) });
+
+        expect(screen.getByLabelText("Contact")).toHaveTextContent(
+          creator.common_name,
+        );
+      });
+
+      describe("management", () => {
+        it("allows to rename modal", async () => {
+          const model = getModel();
+          const { modelUpdateSpy } = await setup({ model });
+
+          const input = screen.getByDisplayValue(model.displayName() as string);
+          userEvent.clear(input);
+          userEvent.type(input, "New model name");
+          fireEvent.blur(input);
+
+          await waitFor(() => {
+            expect(modelUpdateSpy).toHaveBeenCalledWith({
+              ...model.card(),
+              name: "New model name",
+            });
+          });
+        });
+
+        it("allows to change description", async () => {
+          const model = getModel();
+          const { modelUpdateSpy } = await setup({ model });
+
+          const input = screen.getByPlaceholderText("Add description");
+          userEvent.type(input, "Foo bar");
+          fireEvent.blur(input);
+
+          await waitFor(() => {
+            expect(modelUpdateSpy).toHaveBeenCalledWith({
+              ...model.card(),
+              description: "Foo bar",
+            });
+          });
+          expect(screen.getByLabelText("Description")).toHaveTextContent(
+            "Foo bar",
+          );
+        });
+
+        it("can be archived", async () => {
+          const model = getModel();
+          const { modelUpdateSpy } = await setup({ model });
+
+          userEvent.click(getIcon("ellipsis"));
+          userEvent.click(screen.getByText("Archive"));
+
+          expect(screen.getByRole("dialog")).toBeInTheDocument();
+          userEvent.click(screen.getByRole("button", { name: "Archive" }));
+
+          await waitFor(() => {
+            expect(modelUpdateSpy).toHaveBeenCalledWith(
+              { id: model.id() },
+              { archived: true },
+              expect.anything(),
+            );
+          });
+        });
+
+        it("can be moved to another collection", async () => {
+          const model = getModel({ collection_id: 1 });
+          const { modelUpdateSpy } = await setup({
+            model,
+            collections: [COLLECTION_1, COLLECTION_2],
+          });
+
+          userEvent.click(getIcon("ellipsis"));
+          userEvent.click(screen.getByText("Move"));
+
+          expect(screen.getByRole("dialog")).toBeInTheDocument();
+          userEvent.click(await screen.findByText(COLLECTION_2.name));
+          userEvent.click(screen.getByRole("button", { name: "Move" }));
+
+          expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+
+          await waitFor(() => {
+            expect(modelUpdateSpy).toHaveBeenCalledWith(
+              { id: model.id() },
+              { collection_id: COLLECTION_2.id },
+              expect.anything(),
+            );
+          });
+        });
+      });
+
+      describe("used by section", () => {
+        it("has an empty state", async () => {
+          const model = getModel();
+          await setup({ model });
+
+          expect(
+            screen.getByRole("link", { name: /Create a new question/i }),
+          ).toHaveAttribute("href", model.getUrl());
+          expect(
+            screen.getByText(/This model is not used by any questions yet/i),
+          ).toBeInTheDocument();
+        });
+
+        it("lists questions based on the model", async () => {
+          const q1 = getSavedStructuredQuestion({ id: 5, name: "Q1" });
+          const q2 = getSavedNativeQuestion({ id: 6, name: "Q2" });
+
+          await setup({
+            model: getModel({ name: "My Model" }),
+            usedBy: [q1, q2],
+          });
+
+          expect(screen.getByRole("link", { name: "Q1" })).toHaveAttribute(
+            "href",
+            q1.getUrl(),
+          );
+          expect(screen.getByRole("link", { name: "Q2" })).toHaveAttribute(
+            "href",
+            q2.getUrl(),
+          );
+
+          expect(
+            screen.queryByText(/Create a new question/i),
+          ).not.toBeInTheDocument();
+          expect(
+            screen.queryByText(/This model is not used by any questions yet/i),
+          ).not.toBeInTheDocument();
+        });
+      });
+
+      describe("schema section", () => {
+        it("displays model schema", async () => {
+          const model = getModel();
+          const fields = model.getResultMetadata();
+          await setup({ model });
+
+          userEvent.click(screen.getByText("Schema"));
+
+          expect(fields.length).toBeGreaterThan(0);
+          expect(
+            screen.getByText(`${fields.length} fields`),
+          ).toBeInTheDocument();
+
+          fields.forEach((field: Field) => {
+            expect(screen.getByText(field.display_name)).toBeInTheDocument();
+          });
+        });
+      });
+    });
+  });
+
+  describe("structured model", () => {
+    const model = getStructuredModel();
+
+    it("displays backing table", async () => {
+      await setup({ model });
+      expect(screen.getByLabelText("Backing table")).toHaveTextContent(
+        "Orders",
+      );
+    });
+
+    it("displays related tables", async () => {
+      await setup({ model });
+
+      const list = within(screen.getByTestId("model-relationships"));
+
+      expect(list.getByRole("link", { name: "Products" })).toHaveAttribute(
+        "href",
+        PRODUCTS.newQuestion().getUrl(),
+      );
+      expect(list.getByRole("link", { name: "People" })).toHaveAttribute(
+        "href",
+        PEOPLE.newQuestion().getUrl(),
+      );
+      expect(list.queryByText("Reviews")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("native model", () => {
+    const model = getNativeModel();
+
+    it("doesn't show backing table", async () => {
+      await setup({ model });
+      expect(screen.queryByLabelText("Backing table")).not.toBeInTheDocument();
+    });
+
+    it("doesn't show related tables", async () => {
+      await setup({ model });
+      expect(
+        screen.queryByTestId("model-relationships"),
+      ).not.toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/metabase/models/containers/ModelDetailPage/ModelDetailPage.unit.spec.tsx
+++ b/frontend/src/metabase/models/containers/ModelDetailPage/ModelDetailPage.unit.spec.tsx
@@ -12,7 +12,7 @@ import {
   waitForElementToBeRemoved,
   within,
 } from "__support__/ui";
-import { PRODUCTS, PEOPLE } from "__support__/sample_database_fixture";
+import { ORDERS, PRODUCTS, PEOPLE } from "__support__/sample_database_fixture";
 import {
   setupCardEndpoints,
   setupCollectionEndpoints,
@@ -27,8 +27,8 @@ import { createMockCollection, createMockUser } from "metabase-types/api/mocks";
 
 import type Question from "metabase-lib/Question";
 import {
-  getStructuredModel,
-  getNativeModel,
+  getStructuredModel as _getStructuredModel,
+  getNativeModel as _getNativeModel,
   getSavedStructuredQuestion,
   getSavedNativeQuestion,
 } from "metabase-lib/mocks";
@@ -41,6 +41,16 @@ console.warn = jest.fn();
 jest.mock("metabase/core/components/Link", () => ({ to, ...props }: any) => (
   <a {...props} href={to} />
 ));
+
+const resultMetadata = ORDERS.fields.map(field => field.getPlainObject());
+
+function getStructuredModel(opts: Parameters<typeof _getStructuredModel>) {
+  return _getStructuredModel({ result_metadata: resultMetadata, ...opts });
+}
+
+function getNativeModel(opts: Parameters<typeof _getNativeModel>) {
+  return _getNativeModel({ result_metadata: resultMetadata, ...opts });
+}
 
 const COLLECTION_1 = createMockCollection({
   id: 5,

--- a/frontend/src/metabase/models/containers/ModelDetailPage/index.ts
+++ b/frontend/src/metabase/models/containers/ModelDetailPage/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ModelDetailPage";

--- a/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar.styled.tsx
@@ -1,6 +1,9 @@
 import styled from "@emotion/styled";
-import { color } from "metabase/lib/colors";
+
 import EditableText from "metabase/core/components/EditableText";
+import Link from "metabase/core/components/Link";
+
+import { color } from "metabase/lib/colors";
 
 export const Root = styled.div`
   padding: 1rem 1.5rem 0;
@@ -36,6 +39,13 @@ export const ContentSection = styled.div<ContentSectionProps>`
   }
 `;
 
-export const Header = styled.h3`
+export const HeaderContainer = styled.div`
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
   margin-top: 0.5rem;
+`;
+
+export const HeaderLink = styled(Link)`
+  color: ${color("brand")};
 `;

--- a/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar.tsx
@@ -1,19 +1,26 @@
 import React from "react";
 import { t } from "ttag";
 
+import EditableText from "metabase/core/components/EditableText";
+
 import { PLUGIN_MODERATION, PLUGIN_CACHING } from "metabase/plugins";
 
 import MetabaseSettings from "metabase/lib/settings";
+import * as Urls from "metabase/lib/urls";
 
 import QuestionActivityTimeline from "metabase/query_builder/components/QuestionActivityTimeline";
 
-import { Card } from "metabase-types/types/Card";
+import type { Card } from "metabase-types/types/Card";
 
-import EditableText from "metabase/core/components/EditableText";
 import Question from "metabase-lib/Question";
 
 import ModelCacheManagementSection from "./ModelCacheManagementSection";
-import { Root, ContentSection, Header } from "./QuestionInfoSidebar.styled";
+import {
+  Root,
+  ContentSection,
+  HeaderContainer,
+  HeaderLink,
+} from "./QuestionInfoSidebar.styled";
 
 interface QuestionInfoSidebarProps {
   question: Question;
@@ -48,7 +55,14 @@ export const QuestionInfoSidebar = ({
   return (
     <Root>
       <ContentSection>
-        <Header>{t`About`}</Header>
+        <HeaderContainer>
+          <h3>{t`About`}</h3>
+          {question.isDataset() && (
+            <HeaderLink
+              to={Urls.modelDetail(question.card())}
+            >{t`Model details`}</HeaderLink>
+          )}
+        </HeaderContainer>
         <EditableText
           initialValue={description}
           placeholder={

--- a/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar.unit.spec.js
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar.unit.spec.js
@@ -20,6 +20,11 @@ import Question from "metabase-lib/Question";
 
 import { QuestionInfoSidebar } from "./QuestionInfoSidebar";
 
+// eslint-disable-next-line react/display-name, react/prop-types
+jest.mock("metabase/core/components/Link", () => ({ to, ...props }) => (
+  <a {...props} href={to} />
+));
+
 const BASE_QUESTION = {
   id: 1,
   name: "Q1",
@@ -165,6 +170,23 @@ describe("QuestionInfoSidebar", () => {
     it("should show verification badge if verified", async () => {
       await setup({ question: getQuestion() });
       expect(screen.getByText(/verified this/)).toBeInTheDocument();
+    });
+  });
+
+  describe("model detail link", () => {
+    it("is shown for models", async () => {
+      const model = getDataset();
+      await setup({ question: model });
+
+      const link = screen.getByText("Model details");
+
+      expect(link).toBeInTheDocument();
+      expect(link).toHaveAttribute("href", `${model.getUrl()}/detail`);
+    });
+
+    it("isn't shown for questions", async () => {
+      await setup({ question: getQuestion() });
+      expect(screen.queryByText("Model details")).not.toBeInTheDocument();
     });
   });
 

--- a/frontend/src/metabase/questions/components/QuestionMoveToast/QuestionMoveToast.styled.tsx
+++ b/frontend/src/metabase/questions/components/QuestionMoveToast/QuestionMoveToast.styled.tsx
@@ -2,6 +2,8 @@ import styled from "@emotion/styled";
 import { space } from "metabase/styled-components/theme";
 
 import Icon from "metabase/components/Icon";
+import { color } from "metabase/lib/colors";
+import Collections from "metabase/entities/collections";
 
 export const ToastRoot = styled.div`
   display: flex;
@@ -9,5 +11,11 @@ export const ToastRoot = styled.div`
 `;
 
 export const StyledIcon = styled(Icon)`
+  color: ${color("text-white")};
   margin-right: ${space(1)};
+`;
+
+export const CollectionLink = styled(Collections.Link)`
+  color: ${color("brand")};
+  margin-left: ${space(0)};
 `;

--- a/frontend/src/metabase/questions/components/QuestionMoveToast/QuestionMoveToast.tsx
+++ b/frontend/src/metabase/questions/components/QuestionMoveToast/QuestionMoveToast.tsx
@@ -1,37 +1,30 @@
 import React from "react";
 import { jt } from "ttag";
 
-import Collections from "metabase/entities/collections";
-import { color } from "metabase/lib/colors";
+import { coerceCollectionId } from "metabase/collections/utils";
 
-import { StyledIcon, ToastRoot } from "./QuestionMoveToast.styled";
+import type { CollectionId } from "metabase-types/api";
+
+import {
+  CollectionLink,
+  StyledIcon,
+  ToastRoot,
+} from "./QuestionMoveToast.styled";
 
 interface QuestionMoveToastProps {
   isModel: boolean;
-  collectionId: number;
+  collectionId: CollectionId;
 }
 
 function QuestionMoveToast({ isModel, collectionId }: QuestionMoveToastProps) {
+  const id = coerceCollectionId(collectionId);
+  const collectionLink = <CollectionLink key="collection-link" id={id} />;
   return (
     <ToastRoot>
-      <StyledIcon name="all" color="white" />
+      <StyledIcon name="all" />
       {isModel
-        ? jt`Model moved to ${(
-            <Collections.Link
-              key="collection-link"
-              id={collectionId}
-              ml={1}
-              color={color("brand")}
-            />
-          )}`
-        : jt`Question moved to ${(
-            <Collections.Link
-              key="collection-link"
-              id={collectionId}
-              ml={1}
-              color={color("brand")}
-            />
-          )}`}
+        ? jt`Model moved to ${collectionLink}`
+        : jt`Question moved to ${collectionLink}`}
     </ToastRoot>
   );
 }

--- a/frontend/src/metabase/questions/containers/ArchiveQuestionModal.jsx
+++ b/frontend/src/metabase/questions/containers/ArchiveQuestionModal.jsx
@@ -11,7 +11,7 @@ import * as Urls from "metabase/lib/urls";
 import Questions from "metabase/entities/questions";
 
 const mapDispatchToProps = {
-  archive: id => Questions.actions.setArchived({ id }, true),
+  archive: card => Questions.actions.setArchived(card, true),
 };
 
 class ArchiveQuestionModal extends Component {
@@ -19,7 +19,7 @@ class ArchiveQuestionModal extends Component {
     const { question, archive, router } = this.props;
 
     const card = question.card();
-    archive(card.id);
+    archive(card);
     router.push(Urls.collection(card.collection));
   };
 

--- a/frontend/src/metabase/routes.jsx
+++ b/frontend/src/metabase/routes.jsx
@@ -87,6 +87,8 @@ import SearchApp from "metabase/home/containers/SearchApp";
 import { trackPageView } from "metabase/lib/analytics";
 import { getAdminPaths } from "metabase/admin/app/selectors";
 
+import ModelDetailPage from "metabase/models/containers/ModelDetailPage";
+
 const MetabaseIsSetup = UserAuthWrapper({
   predicate: authData => authData.hasUserSetup,
   failureRedirectPath: "/setup",
@@ -166,6 +168,7 @@ export const getRoutes = store => (
     <Route path="public">
       <Route path="question/:uuid" component={PublicQuestion} />
       <Route path="dashboard/:uuid" component={PublicDashboard} />
+      <Route path="page/:uuid" component={PublicDashboard} />
     </Route>
 
     {/* APP */}
@@ -238,6 +241,8 @@ export const getRoutes = store => (
           <Route path=":slug/notebook" component={QueryBuilder} />
           <Route path=":slug/:objectId" component={QueryBuilder} />
         </Route>
+
+        <Route path="/model/:slug/detail" component={ModelDetailPage} />
 
         <Route path="/model">
           <IndexRoute component={QueryBuilder} />

--- a/frontend/src/metabase/routes.jsx
+++ b/frontend/src/metabase/routes.jsx
@@ -168,7 +168,6 @@ export const getRoutes = store => (
     <Route path="public">
       <Route path="question/:uuid" component={PublicQuestion} />
       <Route path="dashboard/:uuid" component={PublicDashboard} />
-      <Route path="page/:uuid" component={PublicDashboard} />
     </Route>
 
     {/* APP */}

--- a/frontend/src/metabase/search/components/InfoText.jsx
+++ b/frontend/src/metabase/search/components/InfoText.jsx
@@ -29,8 +29,6 @@ const infoTextPropTypes = {
 
 export function InfoText({ result }) {
   switch (result.model) {
-    case "app":
-      return t`App`;
     case "card":
       return jt`Saved question in ${formatCollection(
         result,
@@ -42,8 +40,6 @@ export function InfoText({ result }) {
       return getCollectionInfoText(result.collection);
     case "database":
       return t`Database`;
-    case "page":
-      return t`Page`;
     case "table":
       return <TablePath result={result} />;
     case "segment":

--- a/frontend/src/metabase/search/components/SearchResult.jsx
+++ b/frontend/src/metabase/search/components/SearchResult.jsx
@@ -104,7 +104,7 @@ export default function SearchResult({
       isSelected={isSelected}
       active={active}
       compact={compact}
-      to={!onClick ? result.getUrl({ isModelDetail: true }) : ""}
+      to={!onClick ? result.getUrl() : ""}
       onClick={onClick ? () => onClick(result) : undefined}
       data-testid="search-result-item"
     >

--- a/frontend/test/__support__/server-mocks/card.ts
+++ b/frontend/test/__support__/server-mocks/card.ts
@@ -1,0 +1,32 @@
+import type { Scope } from "nock";
+
+import type { Card } from "metabase-types/api";
+import { createMockCard } from "metabase-types/api/mocks";
+import {
+  getQuestionVirtualTableId,
+  convertSavedQuestionToVirtualTable,
+} from "metabase-lib/metadata/utils/saved-questions";
+
+function setupForSingleCard(scope: Scope, card: Card) {
+  scope.get(`/api/card/${card.id}`).reply(200, card);
+  scope
+    .put(`/api/card/${card.id}`)
+    .reply(200, (uri, body) => createMockCard(body as Card));
+
+  if (card.dataset) {
+    const virtualTableId = getQuestionVirtualTableId(card.id);
+    scope.get(`/api/table/${virtualTableId}/query_metadata`).reply(200, {
+      ...convertSavedQuestionToVirtualTable(card),
+      dimension_options: {},
+      fields: card.result_metadata.map(field => ({
+        ...field,
+        table_id: virtualTableId,
+      })),
+    });
+  }
+}
+
+export function setupCardEndpoints(scope: Scope, cards: Card[]) {
+  scope.get("/api/card").reply(200, cards);
+  cards.forEach(card => setupForSingleCard(scope, card));
+}

--- a/frontend/test/__support__/server-mocks/database.ts
+++ b/frontend/test/__support__/server-mocks/database.ts
@@ -1,20 +1,7 @@
 import _ from "underscore";
 import type { Scope } from "nock";
-
-import type { Table as TableObject } from "metabase-types/api";
-
 import type Database from "metabase-lib/metadata/Database";
-import type Table from "metabase-lib/metadata/Table";
-
-function cleanTable(table: Table): TableObject {
-  const object = {
-    ..._.omit(table.getPlainObject(), "schema", "schema_name"),
-    // After table is built inside the metadata object,
-    // what is normally called "schema" is renamed to "schema_name"
-    schema: table.schema_name,
-  };
-  return object as TableObject;
-}
+import { cleanTable } from "./utils";
 
 function setupForSingleDatabase(scope: Scope, db: Database) {
   scope.get(`/api/database/${db.id}`).reply(200, db.getPlainObject());

--- a/frontend/test/__support__/server-mocks/field.ts
+++ b/frontend/test/__support__/server-mocks/field.ts
@@ -1,0 +1,6 @@
+import type { Scope } from "nock";
+import type Field from "metabase-lib/metadata/Field";
+
+export function setupFieldEndpoints(scope: Scope, field: Field) {
+  scope.get(`/api/field/${field.id}`).reply(200, field.getPlainObject());
+}

--- a/frontend/test/__support__/server-mocks/index.ts
+++ b/frontend/test/__support__/server-mocks/index.ts
@@ -1,2 +1,5 @@
+export * from "./card";
 export * from "./collection";
 export * from "./database";
+export * from "./field";
+export * from "./table";

--- a/frontend/test/__support__/server-mocks/table.ts
+++ b/frontend/test/__support__/server-mocks/table.ts
@@ -1,0 +1,23 @@
+import type { Scope } from "nock";
+import type Table from "metabase-lib/metadata/Table";
+import { setupFieldEndpoints } from "./field";
+import { cleanTable } from "./utils";
+
+function setupForSingleTable(scope: Scope, table: Table) {
+  scope.get(`/api/table/${table.id}`).reply(200, cleanTable(table));
+
+  scope.get(`/api/table/${table.id}/query_metadata`).reply(200, {
+    ...cleanTable(table),
+    db: table.database?.getPlainObject?.(),
+    fields: table.fields.map(field => field.getPlainObject()),
+  });
+
+  scope.get(`/api/table/${table.id}/fks`).reply(200, []);
+
+  table.fields.forEach(field => setupFieldEndpoints(scope, field));
+}
+
+export function setupTableEndpoints(scope: Scope, tables: Table[]) {
+  scope.get("/api/table").reply(200, tables.map(cleanTable));
+  tables.forEach(table => setupForSingleTable(scope, table));
+}

--- a/frontend/test/__support__/server-mocks/utils.ts
+++ b/frontend/test/__support__/server-mocks/utils.ts
@@ -1,0 +1,23 @@
+import _ from "underscore";
+import type { Table as TableObject } from "metabase-types/api";
+import type Table from "metabase-lib/metadata/Table";
+
+const TABLE_IGNORE_PROPERTIES = [
+  "fields",
+  "metrics",
+  "segments",
+  "schema",
+  "schema_name",
+];
+
+export function cleanTable(table: Table): TableObject {
+  const plainObject = table.getPlainObject();
+  const cleanObject = _.omit(plainObject, ...TABLE_IGNORE_PROPERTIES);
+  return {
+    dimension_options: {},
+    ...cleanObject,
+    // After table is built inside the metadata object,
+    // what is normally called "schema" is renamed to "schema_name"
+    schema: table.schema_name,
+  } as TableObject;
+}

--- a/frontend/test/metabase/collections/BaseItemsTable.unit.spec.js
+++ b/frontend/test/metabase/collections/BaseItemsTable.unit.spec.js
@@ -10,22 +10,39 @@ import {
 
 import BaseItemsTable from "metabase/collections/components/BaseItemsTable";
 
-describe("Collections BaseItemsTable", () => {
-  const timestamp = "2021-06-03T19:46:52.128";
+// eslint-disable-next-line react/display-name, react/prop-types
+jest.mock("metabase/core/components/Link", () => ({ to, ...props }) => (
+  <a {...props} href={to} />
+));
 
-  const ITEM = {
-    id: 1,
-    model: "dashboard",
-    name: "Test Dashboard",
+const timestamp = "2021-06-03T19:46:52.128";
+
+function getCollectionItem({
+  id = 1,
+  model = "dashboard",
+  name = "My Item",
+  icon = "dashboard",
+  url = "/dashboard/1",
+  ...rest
+} = {}) {
+  return {
     "last-edit-info": {
       id: 1,
       first_name: "John",
       last_name: "Doe",
-      timestamp: timestamp,
+      timestamp,
     },
-    getIcon: () => ({ name: "dashboard" }),
-    getUrl: () => "/dashboard/1",
+    ...rest,
+    id,
+    model,
+    name,
+    getIcon: () => icon,
+    getUrl: () => url,
   };
+}
+
+describe("Collections BaseItemsTable", () => {
+  const ITEM = getCollectionItem();
 
   function setup({ items = [ITEM], ...props } = {}) {
     return renderWithProviders(
@@ -57,5 +74,28 @@ describe("Collections BaseItemsTable", () => {
     expect(screen.getByRole("tooltip")).toHaveTextContent(
       moment(timestamp).format(`${DEFAULT_DATE_STYLE}, ${DEFAULT_TIME_STYLE}`),
     );
+  });
+
+  it("doesn't show model detail page link", () => {
+    setup();
+    expect(screen.queryByTestId("model-detail-link")).not.toBeInTheDocument();
+  });
+
+  describe("models", () => {
+    const model = getCollectionItem({
+      id: 1,
+      name: "Order",
+      model: "dataset",
+      url: "/model/1",
+    });
+
+    it("shows model detail page link", () => {
+      setup({ items: [model] });
+      expect(screen.getByTestId("model-detail-link")).toBeInTheDocument();
+      expect(screen.getByTestId("model-detail-link")).toHaveAttribute(
+        "href",
+        "/model/1-order/detail",
+      );
+    });
   });
 });

--- a/frontend/test/metabase/lib/urls.unit.spec.js
+++ b/frontend/test/metabase/lib/urls.unit.spec.js
@@ -4,6 +4,7 @@ import {
   collection,
   dashboard,
   question,
+  model,
   extractQueryParams,
   extractEntityId,
   extractCollectionId,
@@ -111,26 +112,6 @@ describe("urls", () => {
         expect(url).toBe("/question/1-foo/5?a=b#abc");
       });
     });
-
-    describe("model", () => {
-      it("returns /model URLS", () => {
-        expect(question({ id: 1, dataset: true, name: "Foo" })).toEqual(
-          "/model/1-foo",
-        );
-
-        expect(
-          question({ id: 1, card_id: 42, dataset: true, name: "Foo" }),
-        ).toEqual("/model/42-foo");
-
-        expect(
-          question({ id: 1, card_id: 42, model: "dataset", name: "Foo" }),
-        ).toEqual("/model/42-foo");
-
-        expect(
-          question({ id: 1, dataset: true, name: "Foo" }, { objectId: 4 }),
-        ).toEqual("/model/1-foo/4");
-      });
-    });
   });
 
   describe("query", () => {
@@ -157,6 +138,30 @@ describe("urls", () => {
       const extractedParams2 = extractQueryParams({ foo: ["1", "2"] });
       expect(extractedParams2).toContainEqual(["foo", "1"]);
       expect(extractedParams2).toContainEqual(["foo", "2"]);
+    });
+  });
+
+  describe("model", () => {
+    it("should return correct URL", () => {
+      expect(model({ id: 1, dataset: true, name: "Foo" })).toBe("/model/1-foo");
+    });
+
+    it("should prefer card_id when building a URL", () => {
+      expect(model({ id: 1, card_id: 42, dataset: true, name: "Foo" })).toBe(
+        "/model/42-foo",
+      );
+    });
+
+    it("should work with `model: dataset` property", () => {
+      expect(model({ id: 1, card_id: 42, model: "dataset", name: "Foo" })).toBe(
+        "/model/42-foo",
+      );
+    });
+
+    it("should handle object ID", () => {
+      expect(
+        model({ id: 1, dataset: true, name: "Foo" }, { objectId: 4 }),
+      ).toBe("/model/1-foo/4");
     });
   });
 

--- a/frontend/test/metabase/lib/urls.unit.spec.js
+++ b/frontend/test/metabase/lib/urls.unit.spec.js
@@ -5,6 +5,7 @@ import {
   dashboard,
   question,
   model,
+  modelEditor,
   extractQueryParams,
   extractEntityId,
   extractCollectionId,
@@ -162,6 +163,34 @@ describe("urls", () => {
       expect(
         model({ id: 1, dataset: true, name: "Foo" }, { objectId: 4 }),
       ).toBe("/model/1-foo/4");
+    });
+
+    describe("editor", () => {
+      it("should return correct query editor URL", () => {
+        expect(modelEditor({ id: 1, name: "Order" }, { type: "query" })).toBe(
+          "/model/1-order/query",
+        );
+      });
+
+      it("should return query editor URL if `type` isn't provided explicitly", () => {
+        expect(modelEditor({ id: 1, name: "Order" })).toBe(
+          "/model/1-order/query",
+        );
+      });
+
+      it("should return correct metadata editor URL", () => {
+        expect(
+          modelEditor({ id: 1, name: "Order" }, { type: "metadata" }),
+        ).toBe("/model/1-order/metadata");
+      });
+
+      it("should handle missing name", () => {
+        expect(modelEditor({ id: 1 })).toBe("/model/1/query");
+      });
+
+      it("should prefer card_id over id", () => {
+        expect(modelEditor({ id: 1, card_id: 2 })).toBe("/model/2/query");
+      });
     });
   });
 

--- a/frontend/test/metabase/lib/urls.unit.spec.js
+++ b/frontend/test/metabase/lib/urls.unit.spec.js
@@ -5,6 +5,7 @@ import {
   dashboard,
   question,
   model,
+  modelDetail,
   modelEditor,
   extractQueryParams,
   extractEntityId,
@@ -163,6 +164,14 @@ describe("urls", () => {
       expect(
         model({ id: 1, dataset: true, name: "Foo" }, { objectId: 4 }),
       ).toBe("/model/1-foo/4");
+    });
+
+    describe("detail page", () => {
+      it("should return correct URL", () => {
+        expect(modelDetail({ id: 1, dataset: true, name: "Foo" })).toBe(
+          "/model/1-foo/detail",
+        );
+      });
     });
 
     describe("editor", () => {


### PR DESCRIPTION
Epic #27581, milestone 1

Adds a basic model detail page showing model info, making it possible to manage the model, showing its schema and questions based on it. This PR doesn't include any UI to reach the page, it's going to be done in #27628.

### To Verify

1. For any existing model, open the `/model/:id/detail` URL
2. Ensure you can rename the model by clicking on its title
3. Ensure you can change the model description from the right panel
4. Ensure there are links to the chill mode (Explore), query editor (Edit definition), and metadata editor (Edit metadata, under the Schema tab)
5. Ensure you can see questions based on a model under the "Used By" section
6. Ensure you can see model schema under the "Schema" section
7. Ensure the model creator is shown in the right panel
8. Ensure the backing table is shown in the right panel (a table a model was started from, isn't available for native models)
9. Ensure related tables are shown in the right panel (tables linked with a backing table via foreign keys)

### Demo


https://user-images.githubusercontent.com/17258145/211818461-ed8b4db2-40d5-4852-9ec8-d0136acb0af0.mp4

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/27311)
<!-- Reviewable:end -->
