### PR TITLE
Remove curl and certs from dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,14 +24,9 @@ FROM --platform=linux/amd64 eclipse-temurin:11-jre-alpine as runner
 ENV FC_LANG en-US LC_CTYPE en_US.UTF-8
 
 # dependencies
-RUN apk add -U bash ttf-dejavu fontconfig curl java-cacerts && \
+RUN apk add -U bash ttf-dejavu fontconfig java-cacerts && \
     apk upgrade && \
     rm -rf /var/cache/apk/* && \
-    mkdir -p /app/certs && \
-    curl https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem -o /app/certs/rds-combined-ca-bundle.pem  && \
-    /opt/java/openjdk/bin/keytool -noprompt -import -trustcacerts -alias aws-rds -file /app/certs/rds-combined-ca-bundle.pem -keystore /etc/ssl/certs/java/cacerts -keypass changeit -storepass changeit && \
-    curl https://cacerts.digicert.com/DigiCertGlobalRootG2.crt.pem -o /app/certs/DigiCertGlobalRootG2.crt.pem  && \
-    /opt/java/openjdk/bin/keytool -noprompt -import -trustcacerts -alias azure-cert -file /app/certs/DigiCertGlobalRootG2.crt.pem -keystore /etc/ssl/certs/java/cacerts -keypass changeit -storepass changeit && \
     mkdir -p /plugins && chmod a+rwx /plugins
 
 # add Metabase script and uberjar

--- a/bin/docker/Dockerfile
+++ b/bin/docker/Dockerfile
@@ -3,14 +3,9 @@ FROM --platform=linux/amd64 eclipse-temurin:11-jre-alpine
 ENV FC_LANG=en-US LC_CTYPE=en_US.UTF-8
 
 # dependencies
-RUN apk add -U bash ttf-dejavu fontconfig curl java-cacerts && \
+RUN apk add -U bash ttf-dejavu fontconfig java-cacerts && \
     apk upgrade && \
     rm -rf /var/cache/apk/* && \
-    mkdir -p /app/certs && \
-    curl https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem -o /app/certs/rds-combined-ca-bundle.pem  && \
-    /opt/java/openjdk/bin/keytool -noprompt -import -trustcacerts -alias aws-rds -file /app/certs/rds-combined-ca-bundle.pem -keystore /etc/ssl/certs/java/cacerts -keypass changeit -storepass changeit && \
-    curl https://cacerts.digicert.com/DigiCertGlobalRootG2.crt.pem -o /app/certs/DigiCertGlobalRootG2.crt.pem  && \
-    /opt/java/openjdk/bin/keytool -noprompt -import -trustcacerts -alias azure-cert -file /app/certs/DigiCertGlobalRootG2.crt.pem -keystore /etc/ssl/certs/java/cacerts -keypass changeit -storepass changeit && \
     mkdir -p /plugins && chmod a+rwx /plugins
 
 # add Metabase jar & add our run script to the image


### PR DESCRIPTION
As we can now upload the certs in Metabase, there’s no need to pull them in the dockerfile and even install curl

This will make the image a bit slimmer