### PR TITLE
Repro #27257: Number filter with 0 (zero) as default value shows as empty in the widget

### DIFF
--- a/frontend/test/metabase/scenarios/native-filters/reproductions/27257.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native-filters/reproductions/27257.cy.spec.js
@@ -1,0 +1,43 @@
+import {
+  restore,
+  openNativeEditor,
+  popover,
+  filterWidget,
+} from "__support__/e2e/helpers";
+
+import * as SQLFilter from "../helpers/e2e-sql-filter-helpers";
+
+describe.skip("issue 27257", () => {
+  beforeEach(() => {
+    cy.intercept("POST", "/api/dataset").as("dataset");
+
+    restore();
+    cy.signInAsAdmin();
+
+    openNativeEditor();
+    SQLFilter.enterParameterizedQuery("SELECT {{number}}");
+
+    filterWidget().within(() => {
+      cy.icon("string");
+    });
+
+    cy.findByText("Variable type").parent().findByText("Text").click();
+    popover().contains("Number").click();
+
+    filterWidget().within(() => {
+      cy.icon("number");
+      cy.findByPlaceholderText("Number").type("0").blur();
+      cy.findByDisplayValue("0");
+    });
+
+    SQLFilter.runQuery();
+
+    cy.get(".ScalarValue").invoke("text").should("eq", "0");
+  });
+
+  it("should not drop numeric filter widget value on refresh even if it's zero (metabase#27257)", () => {
+    cy.reload();
+    cy.findByText("Here's where your results will appear");
+    cy.findByDisplayValue("0");
+  });
+});


### PR DESCRIPTION
### Status
READY

### What does this PR accomplish?
- Reproduces #27257 

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/native-filters/reproductions/27257.cy.spec.js`
- Unskip repro
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/208468288-be98f26d-071b-4866-b28e-9ba095c06e4d.png)

