### PR TITLE
Fix error on implicit create

### DIFF
--- a/frontend/src/metabase/actions/containers/ActionParametersInputForm/utils.ts
+++ b/frontend/src/metabase/actions/containers/ActionParametersInputForm/utils.ts
@@ -38,14 +38,15 @@ export function setNumericValues(
 
 export const getChangedValues = (
   newValues: ParametersForActionExecution,
-  oldValues: ParametersForActionExecution,
+  oldValues: Partial<ParametersForActionExecution>,
 ) => {
   const changedValues = Object.entries(newValues).filter(
     ([newKey, newValue]) => {
       const oldValue = oldValues[newKey];
+      const hadUnsetValue = oldValue === null || oldValue === undefined;
 
       // don't flag a change when the input changes itself to an empty string
-      if (oldValue === null && newValue === "") {
+      if (hadUnsetValue && newValue === "") {
         return false;
       }
       return newValue !== oldValue;

--- a/frontend/src/metabase/actions/containers/ActionParametersInputForm/utils.unit.spec.ts
+++ b/frontend/src/metabase/actions/containers/ActionParametersInputForm/utils.unit.spec.ts
@@ -192,9 +192,23 @@ describe("actions > containers > ActionParametersInputForm > utils", () => {
   });
 
   describe("getChangedValues", () => {
-    it("should flag changed fields", () => {
+    it("should flag changed fields from null to a value", () => {
       const oldValues = {
         "abc-def": null,
+      };
+
+      const newValues = {
+        "abc-def": "abc",
+      };
+
+      const result = getChangedValues(newValues, oldValues);
+
+      expect(result).toEqual(newValues);
+    });
+
+    it("should flag changed fields from undefined to a value", () => {
+      const oldValues = {
+        "abc-def": undefined,
       };
 
       const newValues = {


### PR DESCRIPTION
Epic #27281

Fixes a regression (I suppose) caused by a recent action forms migration to `formik` without using the `FormikForm` adapter.

We were submitting untouched form fields when doing an implicit create. The FE was replacing `undefined` with empty strings no matter what's the actually expected column type and the insert was failing.

### To Verify

1. New > App > Sample Database > Products > Create
2. On the products list page, click "Create"
3. Only fill in required fields (like ID)
4. Ensure the insert works

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/27326)
<!-- Reviewable:end -->
