### PR TITLE
Remove changes to `metabase/lib/errors`

### DIFF
--- a/frontend/src/metabase/dashboard/actions/writeback.ts
+++ b/frontend/src/metabase/dashboard/actions/writeback.ts
@@ -3,7 +3,7 @@ import { t } from "ttag";
 import {
   getResponseErrorMessage,
   GenericErrorResponse,
-} from "metabase/lib/errors";
+} from "metabase/core/utils/errors";
 import { createAction } from "metabase/lib/redux";
 import Utils from "metabase/lib/utils";
 import { addUndo } from "metabase/redux/undo";
@@ -130,10 +130,9 @@ export const executeRowAction = async ({
     return { success: true, message };
   } catch (err) {
     const response = err as GenericErrorResponse;
-    const message = getResponseErrorMessage(
-      response,
-      t`Something went wrong while executing the action`,
-    );
+    const message =
+      getResponseErrorMessage(response) ??
+      t`Something went wrong while executing the action`;
 
     if (shouldToast) {
       dispatch(

--- a/frontend/src/metabase/data-apps/containers/CreateDataAppModal/DataAppScaffoldingModal.tsx
+++ b/frontend/src/metabase/data-apps/containers/CreateDataAppModal/DataAppScaffoldingModal.tsx
@@ -5,11 +5,11 @@ import { push } from "react-router-redux";
 import type { LocationDescriptor } from "history";
 
 import Button from "metabase/core/components/Button";
-
 import {
   getResponseErrorMessage,
   GenericErrorResponse,
-} from "metabase/lib/errors";
+} from "metabase/core/utils/errors";
+
 import * as Urls from "metabase/lib/urls";
 
 import DataPicker, {
@@ -112,7 +112,7 @@ function DataAppScaffoldingModal({
       onChangeLocation(Urls.dataApp(dataApp));
     } catch (error) {
       const response = error as GenericErrorResponse;
-      setError(getResponseErrorMessage(response));
+      setError(getResponseErrorMessage(response) ?? t`An error occurred`);
     }
   }, [tableIds, onCreate, onChangeLocation, onClose]);
 

--- a/frontend/src/metabase/data-apps/containers/ScaffoldDataAppPagesModal/ScaffoldDataAppPagesModal.tsx
+++ b/frontend/src/metabase/data-apps/containers/ScaffoldDataAppPagesModal/ScaffoldDataAppPagesModal.tsx
@@ -3,13 +3,12 @@ import { t } from "ttag";
 import { connect } from "react-redux";
 
 import Button from "metabase/core/components/Button";
-
-import { useDataPickerValue } from "metabase/containers/DataPicker";
-
 import {
   getResponseErrorMessage,
   GenericErrorResponse,
-} from "metabase/lib/errors";
+} from "metabase/core/utils/errors";
+
+import { useDataPickerValue } from "metabase/containers/DataPicker";
 
 import {
   scaffoldDataAppPages,
@@ -78,7 +77,7 @@ function ScaffoldDataAppPagesModal({
       onAdd(dataApp);
     } catch (error) {
       const response = error as GenericErrorResponse;
-      setError(getResponseErrorMessage(response));
+      setError(getResponseErrorMessage(response) ?? t`An error occurred`);
     }
   }, [dataAppId, tableIds, onAdd, onScaffold, onClose]);
 

--- a/frontend/src/metabase/lib/errors.ts
+++ b/frontend/src/metabase/lib/errors.ts
@@ -1,37 +1,3 @@
-import { t } from "ttag";
-
-export type GenericErrorResponse = {
-  data?:
-    | {
-        message?: string;
-        errors?: Record<string, string>;
-      }
-    | string;
-  errors?: Record<string, string>;
-  message?: string;
-};
-
 export const SERVER_ERROR_TYPES = {
   missingPermissions: "missing-required-permissions",
 };
-
-export function getResponseErrorMessage(
-  error: GenericErrorResponse,
-  fallback = t`An error occurred`,
-) {
-  if (typeof error.data === "object") {
-    if (error.data.message) {
-      return error.data.message;
-    }
-    if (error.data?.errors?._error) {
-      return error.data.errors._error;
-    }
-  }
-  if (error.message) {
-    return error.message;
-  }
-  if (typeof error.data === "string") {
-    return error.data;
-  }
-  return fallback;
-}


### PR DESCRIPTION
Epic https://github.com/metabase/metabase/issues/27281

In `data-apps-main`, we've extracted the `getResponseErrorMessage` helper from `FormikForm` so it can be re-used outside of forms. For data apps, we wanted to reuse it for displaying app scaffolding error messages in the "+ New" > App modal. While cherry-picking changes to shared FE code, we decided to move it to `metabase/core/utils` (see [here](https://github.com/metabase/metabase/blob/master/frontend/src/metabase/core/utils/errors/messages.ts)). 

This PR makes data app code use the `getResponseErrorMessage` from `metabase/core/utils/errors` and removes changes to `metabase/lib/errors`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/27327)
<!-- Reviewable:end -->
