### PR TITLE
Reproductions #27020 and #27105: static-viz failing for certain date formatting options

### DIFF
--- a/frontend/test/metabase/scenarios/dashboard/reproductions/27020-27105-static-viz-date-formatting-failures.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/reproductions/27020-27105-static-viz-date-formatting-failures.cy.spec.js
@@ -1,0 +1,68 @@
+import { restore } from "__support__/e2e/helpers";
+
+const questionDetails27105 = {
+  name: "27105",
+  native: { query: "select current_date::date, 1", "template-tags": {} },
+  display: "table",
+  visualization_settings: {
+    column_settings: {
+      '["name","CAST(CURRENT_DATE AS DATE)"]': {
+        date_style: "dddd, MMMM D, YYYY",
+      },
+    },
+    "table.pivot_column": "CAST(CURRENT_DATE AS DATE)",
+    "table.cell_column": "1",
+  },
+};
+
+const questionDetails27020 = {
+  name: "27020",
+  native: {
+    query: 'select current_date as "created_at", 1 "val"',
+    "template-tags": {},
+  },
+  visualization_settings: {
+    column_settings: { '["name","created_at"]': { date_abbreviate: true } },
+    "table.pivot_column": "created_at",
+    "table.cell_column": "val",
+  },
+};
+
+describe.skip("issues 27020 and 27105: static-viz fails to render for certain date formatting options", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+  });
+
+  it("should render static-viz when date formatting is abbreviated (metabase#27020)", () => {
+    // This is currently the default setting, anyway.
+    // But we want to explicitly set it in case something changes in the future,
+    // because it is a crucial step for this reproduction.
+    cy.request("PUT", "/api/setting/custom-formatting", {
+      value: {
+        "type/Temporal": {
+          date_style: "MMMM D, YYYY",
+        },
+      },
+    });
+
+    assertStaticVizRenders(questionDetails27020);
+  });
+
+  it("should render static-viz when date formatting contains day (metabase#27105)", () => {
+    assertStaticVizRenders(questionDetails27105);
+  });
+});
+
+function assertStaticVizRenders(questionDetails) {
+  cy.createNativeQuestion(questionDetails).then(({ body: { id } }) => {
+    cy.request({
+      method: "GET",
+      url: `/api/pulse/preview_card_png/${id}`,
+      failOnStatusCode: false,
+    }).then(({ status, body }) => {
+      expect(status).to.eq(200);
+      expect(body).to.contain("PNG");
+    });
+  });
+}


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #27020 and #27105 

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/dashboard/reproductions/27020-27105-static-viz-date-formatting-failures.cy.spec.js`
- Unskip reproductions
- Tests should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip tests completely)
- Make sure tests are passing and
- Merge this together with the fix

### Screenshots:
_Please note: This is not a classic Cypress test that has a visual output. We're really testing just the API here_
![image](https://user-images.githubusercontent.com/31325167/208480350-e56d88ae-9075-458b-9c86-78cc61788da0.png)

