### PR TITLE
Start-of-cycle 46 basic dependency version bump

### DIFF
--- a/bin/build-drivers/deps.edn
+++ b/bin/build-drivers/deps.edn
@@ -23,7 +23,9 @@
  ;; https://ask.clojure.org/index.php/10726/deps-manifest-dependencies-respect-repos-dependent-project
  :mvn/repos
  {"athena"   {:url "https://s3.amazonaws.com/maven-athena"}
-  "redshift" {:url "https://s3.amazonaws.com/redshift-maven-repository/release"}}
+  "redshift" {:url "https://s3.amazonaws.com/redshift-maven-repository/release"}
+  ;; for metabase/saml20-clj
+  "opensaml" {:url "https://build.shibboleth.net/nexus/content/repositories/releases/"}}
 
  :jvm-opts
  ["-XX:-OmitStackTraceInFastThrow"]

--- a/bin/build-mb/deps.edn
+++ b/bin/build-mb/deps.edn
@@ -5,16 +5,18 @@
   build-drivers/build-drivers     {:local/root "../build-drivers"}
   i18n/i18n                       {:local/root "../i18n"}
   org.flatland/ordered            {:mvn/version "1.15.10"}
-  io.github.clojure/tools.build   {:git/tag "v0.7.5" :git/sha "2526f58"}
+  io.github.clojure/tools.build   {:git/tag "v0.8.5" :git/sha "9c738da"}
   ;; value currently used in tools.build but top level since we directly depend on it
-  org.apache.maven/maven-model    {:mvn/version "3.8.4"}}
+  org.apache.maven/maven-model    {:mvn/version "3.8.6"}}
 
  ;; These are needed for the Athena and Redshift drivers in order to build them. Maven repos from subprojects do not
  ;; get copied over -- see
  ;; https://ask.clojure.org/index.php/10726/deps-manifest-dependencies-respect-repos-dependent-project
  :mvn/repos
  {"athena"   {:url "https://s3.amazonaws.com/maven-athena"}
-  "redshift" {:url "https://s3.amazonaws.com/redshift-maven-repository/release"}}
+  "redshift" {:url "https://s3.amazonaws.com/redshift-maven-repository/release"}
+  ;; for metabase/saml20-clj
+  "opensaml" {:url "https://build.shibboleth.net/nexus/content/repositories/releases/"}}
 
  :aliases
  {:test {:extra-paths ["test"]

--- a/bin/common/deps.edn
+++ b/bin/common/deps.edn
@@ -4,7 +4,7 @@
  {commons-io/commons-io {:mvn/version "2.11.0"}
   colorize/colorize     {:mvn/version "0.1.1"}
   environ/environ       {:mvn/version "1.2.0"}
-  potemkin/potemkin     {:mvn/version "0.4.5"}}
+  potemkin/potemkin     {:mvn/version "0.4.6"}}
 
  :aliases
  {:test {:extra-paths ["test"]

--- a/bin/release/deps.edn
+++ b/bin/release/deps.edn
@@ -14,7 +14,9 @@
  ;; https://ask.clojure.org/index.php/10726/deps-manifest-dependencies-respect-repos-dependent-project
  :mvn/repos
  {"athena"   {:url "https://s3.amazonaws.com/maven-athena"}
-  "redshift" {:url "https://s3.amazonaws.com/redshift-maven-repository/release"}}
+  "redshift" {:url "https://s3.amazonaws.com/redshift-maven-repository/release"}
+  ;; for metabase/saml20-clj
+  "opensaml" {:url "https://build.shibboleth.net/nexus/content/repositories/releases/"}}
 
  :aliases
  {:test {:extra-paths ["test"]

--- a/deps.edn
+++ b/deps.edn
@@ -200,12 +200,12 @@
     clj-kondo/clj-kondo          {:mvn/version "2022.08.03"}                ; this is not for RUNNING kondo, but so we can hack on custom hooks code from the REPL.
     cloverage/cloverage          {:mvn/version "1.2.4"}
     com.gfredericks/test.chuck   {:mvn/version "0.2.13"}                    ; generating strings from regexes (useful with malli)
-    djblue/portal                {:mvn/version "0.35.0"}
+    djblue/portal                {:mvn/version "0.35.0"}                    ; ui for inspecting values
     eftest/eftest                {:mvn/version "0.6.0"}
     io.github.camsaul/humane-are {:mvn/version "1.0.2"}
-    jonase/eastwood              {:mvn/version "1.3.0"}
+    jonase/eastwood              {:mvn/version "1.3.0"}                     ; inspects namespaces and reports possible problems using tools.analyzer
     lambdaisland/deep-diff2      {:mvn/version "2.7.169"}                   ; way better diffs
-    methodical/methodical        {:mvn/version "0.15.0.1"}
+    methodical/methodical        {:mvn/version "0.15.0.1"}                  ; drop-in replacements for Clojure multimethods and adds several advanced features
     org.clojure/algo.generic     {:mvn/version "0.1.3"}
     pjstadig/humane-test-output  {:mvn/version "0.11.0"}
     reifyhealth/specmonstah      {:mvn/version "2.1.0"

--- a/deps.edn
+++ b/deps.edn
@@ -15,8 +15,8 @@
                                                            org.bouncycastle/bcprov-jdk15on]}
   buddy/buddy-sign                          {:mvn/version "3.4.333"}            ; JSON Web Tokens; High-Level message signing library
   camel-snake-kebab/camel-snake-kebab       {:mvn/version "0.4.3"}              ; util functions for converting between camel, snake, and kebob case
-  cheshire/cheshire                         {:mvn/version "5.10.2"}             ; fast JSON encoding (used by Ring JSON middleware)
-  clj-commons/iapetos                       {:mvn/version "0.1.12"}             ; prometheus metrics
+  cheshire/cheshire                         {:mvn/version "5.11.0"}             ; fast JSON encoding (used by Ring JSON middleware)
+  clj-commons/iapetos                       {:mvn/version "0.1.13"}             ; prometheus metrics
   clj-http/clj-http                         {:mvn/version "3.12.3"              ; HTTP client
                                              :exclusions  [commons-codec/commons-codec
                                                            commons-io/commons-io
@@ -30,15 +30,16 @@
                                              :exclusions  [it.unimi.dsi/fastutil
                                                            org.slf4j/slf4j-api]}
   com.draines/postal                        {:mvn/version "2.0.5"}              ; SMTP library
-  com.google.guava/guava                    {:mvn/version "31.0.1-jre"}         ; dep for BigQuery, Spark, and GA. Require here rather than letting different dep versions stomp on each other — see comments on #9697
+  com.google.guava/guava                    {:mvn/version "31.1-jre"}           ; dep for BigQuery, Spark, and GA. Require here rather than letting different dep versions stomp on each other — see comments on #9697
   com.fasterxml.jackson.core/jackson-databind
-                                            {:mvn/version "2.13.4.2"}           ; JSON processor used by snowplow-java-tracker
+                                            {:mvn/version "2.14.1"}             ; JSON processor used by snowplow-java-tracker
   com.fasterxml.woodstox/woodstox-core      {:mvn/version "6.4.0"}              ; trans dep of commons-codec (pinned version due to CVE-2022-40151)
   com.h2database/h2                         {:mvn/version "2.1.212"}            ; embedded SQL database
+  com.gfredericks/test.chuck                {:mvn/version "0.2.13"}             ; generating strings from regex
   com.snowplowanalytics/snowplow-java-tracker
                                             {:mvn/version "0.12.0"              ; Snowplow analytics
                                              :exclusions [com.fasterxml.jackson.core/jackson-databind]}
-  com.taoensso/nippy                        {:mvn/version "3.1.1"}              ; Fast serialization (i.e., GZIP) library for Clojure
+  com.taoensso/nippy                        {:mvn/version "3.2.0"}              ; Fast serialization (i.e., GZIP) library for Clojure
   com.vladsch.flexmark/flexmark             {:mvn/version "0.64.0"}             ; Markdown parsing
   com.vladsch.flexmark/flexmark-ext-autolink
                                             {:mvn/version "0.64.0"}             ; Flexmark extension for auto-linking bare URLs
@@ -48,7 +49,7 @@
                                              :exclusions  [commons-beanutils/commons-beanutils
                                                            commons-digester/commons-digester
                                                            commons-logging/commons-logging]}
-  compojure/compojure                       {:mvn/version "1.6.2"               ; HTTP Routing library built on Ring
+  compojure/compojure                       {:mvn/version "1.7.0"               ; HTTP Routing library built on Ring
                                              :exclusions  [ring/ring-codec]}
   crypto-random/crypto-random               {:mvn/version "1.2.1"}              ; library for generating cryptographically secure random bytes and strings
   dk.ative/docjure                          {:mvn/version "1.19.0"              ; excel export
@@ -66,14 +67,14 @@
   io.github.resilience4j/resilience4j-retry {:mvn/version "1.7.1"}              ; Support for retrying operations
   io.prometheus/simpleclient_hotspot        {:mvn/version "0.16.0"}             ; prometheus jvm collector
   io.prometheus/simpleclient_jetty          {:mvn/version "0.16.0"}             ; prometheus jetty collector
-  joda-time/joda-time                       {:mvn/version "2.10.13"}
+  joda-time/joda-time                       {:mvn/version "2.12.2"}
   kixi/stats                                {:mvn/version "0.4.4"               ; Various statistic measures implemented as transducers
                                              :exclusions  [org.clojure/data.avl]}
   me.raynes/fs                              {:mvn/version "1.4.6"               ; Filesystem tools
                                              :exclusions  [org.apache.commons/commons-compress]}
   medley/medley                             {:mvn/version "1.4.0"}              ; lightweight lib of useful functions
   metabase/connection-pool                  {:mvn/version "1.2.0"}              ; simple wrapper around C3P0. JDBC connection pools
-  metabase/saml20-clj                       {:mvn/version "2.0.2"}              ; EE SAML integration
+  metabase/saml20-clj                       {:mvn/version "2.1.0"}              ; EE SAML integration
   metabase/throttle                         {:mvn/version "1.0.2"}              ; Tools for throttling access to API endpoints and other code pathways
   metosin/malli                             {:mvn/version "0.9.2"}              ; Data-driven Schemas for Clojure/Script and babashka
   nano-id/nano-id                           {:mvn/version "1.0.0"}              ; NanoID generator for generating entity_ids
@@ -84,15 +85,15 @@
                                                            org.slf4j/slf4j-api]}
   net.sf.cssbox/cssbox                      {:mvn/version "5.0.0"               ; HTML / CSS rendering
                                              :exclusions  [org.slf4j/slf4j-api]}
-  net.thisptr/jackson-jq                    {:mvn/version "1.0.0-preview.20210928"} ; Java implementation of the JQ json query language
-  org.apache.commons/commons-compress       {:mvn/version "1.21"}               ; compression utils
+  net.thisptr/jackson-jq                    {:mvn/version "1.0.0-preview.20220705"} ; Java implementation of the JQ json query language
+  org.apache.commons/commons-compress       {:mvn/version "1.22"}               ; compression utils
   org.apache.commons/commons-lang3          {:mvn/version "3.12.0"}             ; helper methods for working with java.lang stuff
-  org.apache.logging.log4j/log4j-1.2-api    {:mvn/version "2.18.0"}             ; apache logging framework
-  org.apache.logging.log4j/log4j-api        {:mvn/version "2.18.0"}             ; add compatibility with log4j 1.2
-  org.apache.logging.log4j/log4j-core       {:mvn/version "2.18.0"}             ; apache logging framework
-  org.apache.logging.log4j/log4j-jcl        {:mvn/version "2.18.0"}             ; allows the commons-logging API to work with log4j 2
-  org.apache.logging.log4j/log4j-jul        {:mvn/version "2.18.0"}             ; java.util.logging (JUL) -> Log4j2 adapter
-  org.apache.logging.log4j/log4j-slf4j-impl {:mvn/version "2.18.0"}             ; allows the slf4j API to work with log4j 2
+  org.apache.logging.log4j/log4j-1.2-api    {:mvn/version "2.19.0"}             ; apache logging framework
+  org.apache.logging.log4j/log4j-api        {:mvn/version "2.19.0"}             ; add compatibility with log4j 1.2
+  org.apache.logging.log4j/log4j-core       {:mvn/version "2.19.0"}             ; apache logging framework
+  org.apache.logging.log4j/log4j-jcl        {:mvn/version "2.19.0"}             ; allows the commons-logging API to work with log4j 2
+  org.apache.logging.log4j/log4j-jul        {:mvn/version "2.19.0"}             ; java.util.logging (JUL) -> Log4j2 adapter
+  org.apache.logging.log4j/log4j-slf4j-impl {:mvn/version "2.19.0"}             ; allows the slf4j API to work with log4j 2
   org.apache.poi/poi                        {:mvn/version "5.2.3"}              ; Work with Office documents (e.g. Excel spreadsheets) -- newer version than one specified by Docjure
   org.apache.poi/poi-ooxml                  {:mvn/version "5.2.3"
                                              :exclusions  [org.bouncycastle/bcpkix-jdk15on
@@ -103,7 +104,7 @@
   org.bouncycastle/bcpkix-jdk15on           {:mvn/version "1.70"}               ; Bouncy Castle crypto library -- explicit version of BC specified to resolve illegal reflective access errors
   org.bouncycastle/bcprov-jdk15on           {:mvn/version "1.70"}
   org.clojure/clojure                       {:mvn/version "1.11.1"}
-  org.clojure/core.async                    {:mvn/version "1.5.648"
+  org.clojure/core.async                    {:mvn/version "1.6.673"
                                              :exclusions  [org.clojure/tools.reader]}
   org.clojure/core.logic                    {:mvn/version "1.0.1"}              ; optimized pattern matching library for Clojure
   org.clojure/core.match                    {:mvn/version "1.0.0"}
@@ -120,27 +121,27 @@
   org.clojure/tools.namespace               {:mvn/version "1.3.0"}
   org.clojure/tools.reader                  {:mvn/version "1.3.6"}
   org.clojure/tools.trace                   {:mvn/version "0.7.11"}             ; function tracing
-  org.eclipse.jetty/jetty-server            {:mvn/version "9.4.48.v20220622"}   ; web server
+  org.eclipse.jetty/jetty-server            {:mvn/version "9.4.50.v20221201"}   ; web server
   org.flatland/ordered                      {:mvn/version "1.15.10"}            ; ordered maps & sets
-  org.graalvm.js/js                         {:mvn/version "22.1.0"}             ; JavaScript engine
-  org.liquibase/liquibase-core              {:mvn/version "4.10.0"              ; migration management (Java lib)
+  org.graalvm.js/js                         {:mvn/version "22.3.0"}             ; JavaScript engine
+  org.liquibase/liquibase-core              {:mvn/version "4.11.0"              ; migration management (Java lib)
                                              :exclusions  [ch.qos.logback/logback-classic]}
   org.mariadb.jdbc/mariadb-java-client      {:mvn/version "2.7.6"}              ; MySQL/MariaDB driver
   org.mindrot/jbcrypt                       {:mvn/version "0.4"}                ; Crypto library
-  org.postgresql/postgresql                 {:mvn/version "42.5.0"}             ; Postgres driver
+  org.postgresql/postgresql                 {:mvn/version "42.5.1"}             ; Postgres driver
   org.quartz-scheduler/quartz               {:mvn/version "2.3.2"}              ; Quartz job scheduler, provided by quartzite but this is a newer version.
   org.slf4j/slf4j-api                       {:mvn/version "1.7.36"}             ; abstraction for logging frameworks -- allows end user to plug in desired logging framework at deployment time
   org.tcrawley/dynapath                     {:mvn/version "1.1.0"}              ; Dynamically add Jars (e.g. Oracle or Vertica) to classpath
-  org.threeten/threeten-extra               {:mvn/version "1.7.0"}              ; extra Java 8 java.time classes like DayOfMonth and Quarter
+  org.threeten/threeten-extra               {:mvn/version "1.7.2"}              ; extra Java 8 java.time classes like DayOfMonth and Quarter
   org.yaml/snakeyaml                        {:mvn/version "1.33"}               ; YAML parser
-  potemkin/potemkin                         {:mvn/version "0.4.5"               ; utility macros & fns
+  potemkin/potemkin                         {:mvn/version "0.4.6"               ; utility macros & fns
                                              :exclusions  [riddley/riddley]}
   pretty/pretty                             {:mvn/version "1.0.5"}              ; protocol for defining how custom types should be pretty printed
-  prismatic/schema                          {:mvn/version "1.2.1"}              ; Data schema declaration and validation library
+  prismatic/schema                          {:mvn/version "1.4.1"}              ; Data schema declaration and validation library
   redux/redux                               {:mvn/version "0.1.4"}              ; Utility functions for building and composing transducers
   riddley/riddley                           {:mvn/version "0.2.0"}              ; code walking lib -- used interally by Potemkin, manifold, etc.
-  ring/ring-core                            {:mvn/version "1.9.5"}              ; web server (Jetty wrapper)
-  ring/ring-jetty-adapter                   {:mvn/version "1.9.5"}              ; Ring adapter using Jetty webserver
+  ring/ring-core                            {:mvn/version "1.9.6"}              ; web server (Jetty wrapper)
+  ring/ring-jetty-adapter                   {:mvn/version "1.9.6"}              ; Ring adapter using Jetty webserver
   ring/ring-json                            {:mvn/version "0.5.1"}              ; Ring middleware for reading/writing JSON automatically
   robdaemon/clojure.java-time               {:mvn/version "0.3.3-SNAPSHOT"}     ; Java 8 java.time wrapper. Use this fork until https://github.com/dm3/clojure.java-time/issues/77 is fixed upstream
   slingshot/slingshot                       {:mvn/version "0.12.2"}             ; enhanced throw/catch, used by other deps
@@ -174,7 +175,9 @@
  ;; `:drivers` alias instead.
  :mvn/repos
  {"athena"   {:url "https://s3.amazonaws.com/maven-athena"}
-  "redshift" {:url "https://s3.amazonaws.com/redshift-maven-repository/release"}}
+  "redshift" {:url "https://s3.amazonaws.com/redshift-maven-repository/release"}
+  ;; for metabase/saml20-clj
+  "opensaml" {:url "https://build.shibboleth.net/nexus/content/repositories/releases/"}}
 
  :aliases
  {
@@ -195,22 +198,21 @@
    {clj-http-fake/clj-http-fake  {:mvn/version "1.0.3"
                                   :exclusions  [slingshot/slingshot]}
     clj-kondo/clj-kondo          {:mvn/version "2022.08.03"}                ; this is not for RUNNING kondo, but so we can hack on custom hooks code from the REPL.
-    cloverage/cloverage          {:mvn/version "1.2.2"}
+    cloverage/cloverage          {:mvn/version "1.2.4"}
     com.gfredericks/test.chuck   {:mvn/version "0.2.13"}                    ; generating strings from regexes (useful with malli)
-    djblue/portal                {:mvn/version "0.30.0"}                    ; ui for inspecting values
-    eftest/eftest                {:mvn/version "0.5.9"}
+    djblue/portal                {:mvn/version "0.35.0"}
+    eftest/eftest                {:mvn/version "0.6.0"}
     io.github.camsaul/humane-are {:mvn/version "1.0.2"}
-    jonase/eastwood              {:mvn/version "1.2.2"}                     ; inspects namespaces and reports possible problems using tools.analyzer
-    lambdaisland/deep-diff2      {:mvn/version "2.3.127"}                   ; way better diffs
-    methodical/methodical        {:mvn/version "0.15.0.1"}                  ; drop-in replacements for Clojure multimethods and adds several advanced features
+    jonase/eastwood              {:mvn/version "1.3.0"}
+    lambdaisland/deep-diff2      {:mvn/version "2.7.169"}                   ; way better diffs
+    methodical/methodical        {:mvn/version "0.15.0.1"}
     org.clojure/algo.generic     {:mvn/version "0.1.3"}
     pjstadig/humane-test-output  {:mvn/version "0.11.0"}
-    reifyhealth/specmonstah      {:mvn/version "2.0.0"
+    reifyhealth/specmonstah      {:mvn/version "2.1.0"
                                   :exclusions  [org.clojure/clojure
                                                 org.clojure/clojurescript]} ; lets you write test fixtures that are clear, concise, and easy to maintain (clojure.spec)
     ring/ring-mock               {:mvn/version "0.4.0"}                     ; creating Ring request maps for testing purposes
-    talltale/talltale            {:mvn/version "0.5.8"}}                    ; generates fake data, useful for prototyping or load testing
-
+    talltale/talltale            {:mvn/version "0.5.13"}}                   ; generates fake data, useful for prototyping or load testing
 
    :extra-paths ["dev/src" "local/src" "test" "shared/test" "test_resources"]
    :jvm-opts    ["-Dmb.run.mode=dev"
@@ -385,7 +387,7 @@
 
   ;; clojure -T:whitespace-linter
   :whitespace-linter
-  {:deps       {com.github.camsaul/whitespace-linter {:sha "912644a2b9cc91edcce31a6fa997c46479341a1d"}}
+  {:deps       {com.github.camsaul/whitespace-linter {:sha "e35bc252ccf5cc74f7d543ef95ad8a3e5131f25b"}}
    :ns-default whitespace-linter
    :exec-fn    whitespace-linter/lint
    :exec-args  {:paths            ["./.dir-locals.el"
@@ -495,7 +497,7 @@
   ;;
   ;;    clojure -M:liquibase dbDoc target/liquibase
   :liquibase
-  {:extra-deps  {ch.qos.logback/logback-classic {:mvn/version "1.2.10"}}
+  {:extra-deps  {ch.qos.logback/logback-classic {:mvn/version "1.4.5"}}
    :extra-paths ["dev/src"]
    :main-opts   ["-m" "dev.liquibase"]}}}
 

--- a/modules/drivers/bigquery-cloud-sdk/deps.edn
+++ b/modules/drivers/bigquery-cloud-sdk/deps.edn
@@ -5,5 +5,5 @@
  ;; TODO: figure out how to be able to leave off this version string and use the version from the BOM
  {com.google.cloud/google-cloud-bigquery      {:mvn/version "1.135.4"}
   ;; CVE on 2.8.7 from bigquery (NB: also in googleanalytics)
-  com.google.code.gson/gson                   {:mvn/version "2.8.9"}
-  com.google.oauth-client/google-oauth-client {:mvn/version "1.33.3"}}}
+  com.google.code.gson/gson                   {:mvn/version "2.10"}
+  com.google.oauth-client/google-oauth-client {:mvn/version "1.34.1"}}}

--- a/modules/drivers/googleanalytics/deps.edn
+++ b/modules/drivers/googleanalytics/deps.edn
@@ -3,8 +3,8 @@
  :deps
  {com.google.apis/google-api-services-analytics      {:mvn/version "v3-rev20190807-1.32.1"}
   ;; CVE on 2.8.7 from google api services (NB: also in bigquery-cloud-sdk)
-  com.google.code.gson/gson                          {:mvn/version "2.8.9"}
-  com.google.oauth-client/google-oauth-client        {:mvn/version "1.33.3"}
+  com.google.code.gson/gson                          {:mvn/version "2.10"}
+  com.google.oauth-client/google-oauth-client        {:mvn/version "1.34.1"}
   ;; for some reason, Google stopped depending on google-http-client-jackson2 from google-api-client somewhere between
   ;; 1.30.7 and 1.32.1, so we must explicitly bring it in because the google driver uses it directly
-  com.google.http-client/google-http-client-jackson2 {:mvn/version "1.39.2-sp.1"}}}
+  com.google.http-client/google-http-client-jackson2 {:mvn/version "1.42.3"}}}

--- a/modules/drivers/mongo/deps.edn
+++ b/modules/drivers/mongo/deps.edn
@@ -2,4 +2,4 @@
  ["src" "resources"]
 
  :deps
- {com.novemberain/monger {:mvn/version "3.5.0"}}}
+ {com.novemberain/monger {:mvn/version "3.6.0"}}}

--- a/modules/drivers/mongo/test/metabase/driver/mongo/util_test.clj
+++ b/modules/drivers/mongo/test/metabase/driver/mongo/util_test.clj
@@ -79,72 +79,19 @@
                (connect-mongo opts)))))))
 
 (deftest srv-connection-properties-test
-  (testing "test that connection properties when using srv"
-    (is (= "No SRV record available for host fake.fqdn.com"
-           (try
-             (let [host                            "fake.fqdn.com"
-                   opts                            {:host               host
-                                                    :port               1015
-                                                    :user               "test-user"
-                                                    :authdb             "test-authdb"
-                                                    :pass               "test-passwd"
-                                                    :dbname             "test-dbname"
-                                                    :ssl                true
-                                                    :additional-options ""
-                                                    :use-srv            true}
-                   [^MongoClient mongo-client _db] (connect-mongo opts)
-                   ^ServerAddress mongo-addr       (-> mongo-client
-                                                       (.getAllAddress)
-                                                       first)
-                   mongo-host                      (-> mongo-addr .getHost)
-                   mongo-port                      (-> mongo-addr .getPort)]
-               [mongo-host mongo-port])
-             (catch MongoClientException e
-               (.getMessage e)))))
-
-    (is (= "Using DNS SRV requires a FQDN for host"
-           (try
-             (let [host                            "host1"
-                   opts                            {:host               host
-                                                    :port               1015
-                                                    :user               "test-user"
-                                                    :authdb             "test-authdb"
-                                                    :pass               "test-passwd"
-                                                    :dbname             "test-dbname"
-                                                    :ssl                true
-                                                    :additional-options ""
-                                                    :use-srv            true}
-                   [^MongoClient mongo-client _db] (connect-mongo opts)
-                   ^ServerAddress mongo-addr       (-> mongo-client
-                                                       (.getAllAddress)
-                                                       first)
-                   mongo-host                      (-> mongo-addr .getHost)
-                   mongo-port                      (-> mongo-addr .getPort)]
-               [mongo-host mongo-port])
-             (catch Exception e
-               (.getMessage e)))))
-
-    (is (= "Unable to look up SRV record for host fake.fqdn.org"
-           (try
-             (let [host                            "fake.fqdn.org"
-                   opts                            {:host               host
-                                                    :port               1015
-                                                    :user               "test-user"
-                                                    :authdb             "test-authdb"
-                                                    :pass               "test-passwd"
-                                                    :dbname             "test-dbname"
-                                                    :ssl                true
-                                                    :additional-options ""
-                                                    :use-srv            true}
-                   [^MongoClient mongo-client _db] (connect-mongo opts)
-                   ^ServerAddress mongo-addr       (-> mongo-client
-                                                       (.getAllAddress)
-                                                       first)
-                   mongo-host                      (-> mongo-addr .getHost)
-                   mongo-port                      (-> mongo-addr .getPort)]
-               [mongo-host mongo-port])
-             (catch MongoClientException e
-               (.getMessage e)))))
+  (testing "connection properties when using SRV"
+    (are [host msg] (thrown-with-msg? Throwable msg
+                      (connect-mongo {:host host
+                                      :port               1015
+                                      :user               "test-user"
+                                      :authdb             "test-authdb"
+                                      :pass               "test-passwd"
+                                      :dbname             "test-dbname"
+                                      :ssl                true
+                                      :additional-options ""
+                                      :use-srv            true}))
+      "db.fqdn.test" #"Unable to look up TXT record for host db.fqdn.test"
+      "local.test" #"Using DNS SRV requires a FQDN for host")
 
     (testing "test host and port are correct for both srv and normal"
       (let [host                            "localhost"

--- a/modules/drivers/mongo/test/metabase/driver/mongo/util_test.clj
+++ b/modules/drivers/mongo/test/metabase/driver/mongo/util_test.clj
@@ -91,7 +91,7 @@
                                       :additional-options ""
                                       :use-srv            true}))
       "db.fqdn.test" #"Unable to look up TXT record for host db.fqdn.test"
-      "local.test" #"Using DNS SRV requires a FQDN for host")
+      "local.test"   #"Using DNS SRV requires a FQDN for host")
 
     (testing "test host and port are correct for both srv and normal"
       (let [host                            "localhost"

--- a/modules/drivers/mongo/test/metabase/driver/mongo/util_test.clj
+++ b/modules/drivers/mongo/test/metabase/driver/mongo/util_test.clj
@@ -3,7 +3,7 @@
             [metabase.driver.mongo.util :as mongo.util]
             [metabase.driver.util :as driver.u]
             [metabase.test :as mt])
-  (:import [com.mongodb MongoClient MongoClientException MongoClientOptions$Builder ReadPreference ServerAddress]))
+  (:import [com.mongodb MongoClient MongoClientOptions$Builder ReadPreference ServerAddress]))
 
 (defn- connect-mongo ^MongoClient [opts]
   (let [connection-info (#'mongo.util/details->mongo-connection-info

--- a/modules/drivers/presto-jdbc/deps.edn
+++ b/modules/drivers/presto-jdbc/deps.edn
@@ -2,7 +2,7 @@
  ["src" "resources"]
 
  :deps
- {com.facebook.presto/presto-jdbc {:mvn/version "0.269"}}
+ {com.facebook.presto/presto-jdbc {:mvn/version "0.278.1"}}
 
  :metabase.driver/parents
  #{:presto-common}}

--- a/modules/drivers/redshift/deps.edn
+++ b/modules/drivers/redshift/deps.edn
@@ -5,4 +5,4 @@
  {"redshift" {:url "https://s3.amazonaws.com/redshift-maven-repository/release"}}
 
  :deps
- {com.amazon.redshift/redshift-jdbc42 {:mvn/version "2.1.0.9"}}}
+ {com.amazon.redshift/redshift-jdbc42 {:mvn/version "2.1.0.10"}}}

--- a/modules/drivers/snowflake/deps.edn
+++ b/modules/drivers/snowflake/deps.edn
@@ -2,4 +2,4 @@
  ["src" "resources"]
 
  :deps
- {net.snowflake/snowflake-jdbc {:mvn/version "3.13.21"}}}
+ {net.snowflake/snowflake-jdbc {:mvn/version "3.13.26"}}}

--- a/modules/drivers/sparksql/deps.edn
+++ b/modules/drivers/sparksql/deps.edn
@@ -56,7 +56,6 @@
                  commons-daemon/commons-daemon
                  commons-dbcp/commons-dbcp
                  commons-io/commons-io
-                 commons-lang/commons-lang
                  commons-logging/commons-logging
                  commons-net/commons-net
                  commons-pool/commons-pool

--- a/modules/drivers/sqlite/deps.edn
+++ b/modules/drivers/sqlite/deps.edn
@@ -2,4 +2,4 @@
  ["src" "resources"]
 
  :deps
- {org.xerial/sqlite-jdbc {:mvn/version "3.36.0.3"}}}
+ {org.xerial/sqlite-jdbc {:mvn/version "3.40.0.0"}}}

--- a/modules/drivers/sqlite/deps.edn
+++ b/modules/drivers/sqlite/deps.edn
@@ -2,4 +2,4 @@
  ["src" "resources"]
 
  :deps
- {org.xerial/sqlite-jdbc {:mvn/version "3.39.4.1"}}}
+ {org.xerial/sqlite-jdbc {:mvn/version "3.40.0.0"}}}

--- a/modules/drivers/sqlite/deps.edn
+++ b/modules/drivers/sqlite/deps.edn
@@ -2,4 +2,4 @@
  ["src" "resources"]
 
  :deps
- {org.xerial/sqlite-jdbc {:mvn/version "3.40.0.0"}}}
+ {org.xerial/sqlite-jdbc {:mvn/version "3.39.4.1"}}}

--- a/modules/drivers/sqlite/test/metabase/driver/sqlite_test.clj
+++ b/modules/drivers/sqlite/test/metabase/driver/sqlite_test.clj
@@ -182,14 +182,14 @@
                                        {:fields [$col_timestamp $col_date $col_datetime]
                                         :filter [:= $test_case "epoch"]})))))
           (testing "select datetime stored as string with milliseconds"
-            (is (= [["2021-08-25 04:18:24.111"    ; TIMESTAMP (raw string)
+            (is (= [["2021-08-25T04:18:24.111Z"   ; TIMESTAMP (raw string)
                      "2021-08-25T04:18:24.111Z"]] ; DATETIME
                    (qp.test/rows
                     (mt/run-mbql-query datetime_table
                                        {:fields [$col_timestamp $col_datetime]
                                         :filter [:= $test_case "iso8601-ms"]})))))
           (testing "select datetime stored as string without milliseconds"
-            (is (= [["2021-08-25 04:18:24"    ; TIMESTAMP (raw string)
+            (is (= [["2021-08-25T04:18:24Z"   ; TIMESTAMP (raw string)
                      "2021-08-25T04:18:24Z"]] ; DATETIME
                    (qp.test/rows
                     (mt/run-mbql-query datetime_table


### PR DESCRIPTION
This is a basic dependency bump. Some dependencies still have available major version updates, but since those would likely introduce breaking changes, they have been updated to only the most recent version available of the same major version (e.g. Jetty).

Some minor changes to MongoDB and SQLite tests were required.