### PR TITLE
Fix URL custom destination modal bug

### DIFF
--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/LinkOptions/CustomURLPicker.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/LinkOptions/CustomURLPicker.tsx
@@ -45,7 +45,11 @@ function CustomURLPicker({
     linkTemplate: url,
   });
 
-  const handleLinkTemplateChange = useCallback(() => {
+  const handleLinkTemplateChange = useCallback(e => {
+    setUrl(e.currentTarget.value);
+  }, []);
+
+  const handleSubmit = useCallback(() => {
     updateSettings({
       ...clickBehavior,
       linkTemplate: url,
@@ -103,7 +107,7 @@ function CustomURLPicker({
             primary
             type="button"
             onClick={() => {
-              handleLinkTemplateChange();
+              handleSubmit();
               onClose();
             }}
             disabled={!canSelect}


### PR DESCRIPTION
Fixes an issue with custom URL click behavior when it was impossible to save a link template.

In #26201 we've tweaked `CustomURLPicker` to keep the link template in a local state before the "Done" button is clicked. Once "Done" is clicked, the component would call `handleLinkTemplateChange` which calls `updateSettings` under the hood. After merging `master` into `data-apps-main`, we've replaced that piece of code with the old implementation that made it impossible to change the URL.

### To Verify

1. Open a dashboard with at least one card
2. Click the pencil icon to open the editing mode
3. Open click behavior editing for any card (hover the card and click the "click behavior" icon)
4. Pick custom destination > Custom URL
5. Ensure you can fill in and save a link

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/27334)
<!-- Reviewable:end -->
