### PR TITLE
Custom list rename source -> values_source

### DIFF
--- a/frontend/src/metabase-types/api/mocks/parameters.ts
+++ b/frontend/src/metabase-types/api/mocks/parameters.ts
@@ -1,4 +1,4 @@
-import { Parameter, ParameterSourceOptions } from "metabase-types/api";
+import { Parameter, ParameterSourceConfig } from "metabase-types/api";
 
 export const createMockParameter = (opts?: Partial<Parameter>): Parameter => ({
   id: "1",
@@ -9,7 +9,7 @@ export const createMockParameter = (opts?: Partial<Parameter>): Parameter => ({
 });
 
 export const createMockParameterSourceOptions = (
-  opts?: Partial<ParameterSourceOptions>,
-): ParameterSourceOptions => ({
+  opts?: Partial<ParameterSourceConfig>,
+): ParameterSourceConfig => ({
   ...opts,
 });

--- a/frontend/src/metabase-types/api/parameters.ts
+++ b/frontend/src/metabase-types/api/parameters.ts
@@ -40,8 +40,8 @@ export interface Parameter {
   filteringParameters?: ParameterId[];
   isMultiSelect?: boolean;
   value?: any;
-  source_type?: ParameterSourceType;
-  source_options?: ParameterSourceOptions;
+  values_source_type?: ParameterSourceType;
+  values_source_options?: ParameterSourceOptions;
 }
 
 export type ParameterSourceType = null | "static-list";

--- a/frontend/src/metabase-types/api/parameters.ts
+++ b/frontend/src/metabase-types/api/parameters.ts
@@ -41,11 +41,11 @@ export interface Parameter {
   isMultiSelect?: boolean;
   value?: any;
   values_source_type?: ParameterSourceType;
-  values_source_options?: ParameterSourceOptions;
+  values_source_config?: ParameterSourceConfig;
 }
 
 export type ParameterSourceType = null | "static-list";
 
-export interface ParameterSourceOptions {
+export interface ParameterSourceConfig {
   values?: string[];
 }

--- a/frontend/src/metabase/dashboard/actions/parameters.js
+++ b/frontend/src/metabase/dashboard/actions/parameters.js
@@ -214,7 +214,7 @@ export const setParameterSourceOptions = createThunkAction(
   (parameterId, sourceOptions) => (dispatch, getState) => {
     updateParameter(dispatch, getState, parameterId, parameter => ({
       ...parameter,
-      values_source_options: sourceOptions,
+      values_source_config: sourceOptions,
     }));
     return { id: parameterId, sourceOptions };
   },

--- a/frontend/src/metabase/dashboard/actions/parameters.js
+++ b/frontend/src/metabase/dashboard/actions/parameters.js
@@ -201,7 +201,7 @@ export const setParameterSourceType = createThunkAction(
   (parameterId, sourceType) => (dispatch, getState) => {
     updateParameter(dispatch, getState, parameterId, parameter => ({
       ...parameter,
-      source_type: sourceType,
+      values_source_type: sourceType,
     }));
     return { id: parameterId, sourceType };
   },
@@ -214,7 +214,7 @@ export const setParameterSourceOptions = createThunkAction(
   (parameterId, sourceOptions) => (dispatch, getState) => {
     updateParameter(dispatch, getState, parameterId, parameter => ({
       ...parameter,
-      source_options: sourceOptions,
+      values_source_options: sourceOptions,
     }));
     return { id: parameterId, sourceOptions };
   },

--- a/frontend/src/metabase/parameters/components/ParameterListSourceModal/ParameterListSourceModal.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterListSourceModal/ParameterListSourceModal.tsx
@@ -3,10 +3,7 @@ import { t } from "ttag";
 import Button from "metabase/core/components/Button";
 import ModalContent from "metabase/components/ModalContent";
 import { getSourceOptions } from "metabase/parameters/utils/dashboards";
-import {
-  ParameterSourceOptions,
-  ParameterSourceType,
-} from "metabase-types/api";
+import { ParameterSourceConfig, ParameterSourceType } from "metabase-types/api";
 import { UiParameter } from "metabase-lib/parameters/types";
 import { ModalMessage, ModalTextArea } from "./ParameterListSourceModal.styled";
 
@@ -15,7 +12,7 @@ const PLACEHOLDER = [t`banana`, t`orange`].join(NEW_LINE);
 
 export interface ParameterListSourceModalProps {
   parameter: UiParameter;
-  onChangeSourceOptions: (sourceOptions: ParameterSourceOptions) => void;
+  onChangeSourceOptions: (sourceOptions: ParameterSourceConfig) => void;
   onClose?: () => void;
 }
 

--- a/frontend/src/metabase/parameters/components/ParameterListSourceModal/ParameterListSourceModal.unit.spec.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterListSourceModal/ParameterListSourceModal.unit.spec.tsx
@@ -26,7 +26,7 @@ describe("ParameterListSourceModal", () => {
   it("should clear source values", () => {
     const props = getProps({
       parameter: createMockUiParameter({
-        source_options: createMockParameterSourceOptions({
+        values_source_options: createMockParameterSourceOptions({
           values: ["Gadget", "Gizmo"],
         }),
       }),

--- a/frontend/src/metabase/parameters/components/ParameterListSourceModal/ParameterListSourceModal.unit.spec.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterListSourceModal/ParameterListSourceModal.unit.spec.tsx
@@ -26,7 +26,7 @@ describe("ParameterListSourceModal", () => {
   it("should clear source values", () => {
     const props = getProps({
       parameter: createMockUiParameter({
-        values_source_options: createMockParameterSourceOptions({
+        values_source_config: createMockParameterSourceOptions({
           values: ["Gadget", "Gizmo"],
         }),
       }),

--- a/frontend/src/metabase/parameters/components/ParameterSettings/ParameterSettings.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterSettings/ParameterSettings.tsx
@@ -8,10 +8,7 @@ import React, {
 import { t } from "ttag";
 import Input from "metabase/core/components/Input";
 import Radio from "metabase/core/components/Radio";
-import {
-  ParameterSourceOptions,
-  ParameterSourceType,
-} from "metabase-types/api";
+import { ParameterSourceConfig, ParameterSourceType } from "metabase-types/api";
 import { UiParameter } from "metabase-lib/parameters/types";
 import { getIsMultiSelect } from "../../utils/dashboards";
 import {
@@ -38,7 +35,7 @@ export interface ParameterSettingsProps {
   onChangeDefaultValue: (value: unknown) => void;
   onChangeIsMultiSelect: (isMultiSelect: boolean) => void;
   onChangeSourceType: (sourceType: ParameterSourceType) => void;
-  onChangeSourceOptions: (sourceOptions: ParameterSourceOptions) => void;
+  onChangeSourceOptions: (sourceOptions: ParameterSourceConfig) => void;
   onRemoveParameter: () => void;
 }
 

--- a/frontend/src/metabase/parameters/components/ParameterSidebar/ParameterSidebar.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterSidebar/ParameterSidebar.tsx
@@ -4,7 +4,7 @@ import Radio from "metabase/core/components/Radio";
 import Sidebar from "metabase/dashboard/components/Sidebar";
 import {
   ParameterId,
-  ParameterSourceOptions,
+  ParameterSourceConfig,
   ParameterSourceType,
 } from "metabase-types/api";
 import { UiParameter } from "metabase-lib/parameters/types";
@@ -28,7 +28,7 @@ export interface ParameterSidebarProps {
   ) => void;
   onChangeSourceOptions: (
     parameterId: ParameterId,
-    sourceOptions: ParameterSourceOptions,
+    sourceOptions: ParameterSourceConfig,
   ) => void;
   onChangeFilteringParameters: (
     parameterId: ParameterId,
@@ -85,7 +85,7 @@ const ParameterSidebar = ({
   );
 
   const handleSourceOptionsChange = useCallback(
-    (sourceOptions: ParameterSourceOptions) => {
+    (sourceOptions: ParameterSourceConfig) => {
       onChangeSourceOptions(parameterId, sourceOptions);
     },
     [parameterId, onChangeSourceOptions],

--- a/frontend/src/metabase/parameters/components/ParameterSourceSettings/ParameterSourceSettings.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterSourceSettings/ParameterSourceSettings.tsx
@@ -7,10 +7,7 @@ import {
   getSourceType,
   hasValidSourceOptions,
 } from "metabase/parameters/utils/dashboards";
-import {
-  ParameterSourceOptions,
-  ParameterSourceType,
-} from "metabase-types/api";
+import { ParameterSourceConfig, ParameterSourceType } from "metabase-types/api";
 import { UiParameter } from "metabase-lib/parameters/types";
 import ParameterListSourceModal from "../ParameterListSourceModal";
 import {
@@ -22,7 +19,7 @@ import {
 export interface ParameterSourceSettingsProps {
   parameter: UiParameter;
   onChangeSourceType: (sourceType: ParameterSourceType) => void;
-  onChangeSourceOptions: (sourceOptions: ParameterSourceOptions) => void;
+  onChangeSourceOptions: (sourceOptions: ParameterSourceConfig) => void;
 }
 
 const ParameterSourceSettings = ({
@@ -51,7 +48,7 @@ const ParameterSourceSettings = ({
   );
 
   const handleSourceOptionsChange = useCallback(
-    (sourceOptions: ParameterSourceOptions) => {
+    (sourceOptions: ParameterSourceConfig) => {
       if (editingType && hasValidSourceOptions(editingType, sourceOptions)) {
         onChangeSourceType(editingType);
       } else {

--- a/frontend/src/metabase/parameters/components/ParameterSourceSettings/ParameterSourceSettings.unit.spec.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterSourceSettings/ParameterSourceSettings.unit.spec.tsx
@@ -38,7 +38,7 @@ describe("ParameterSourceSettings", () => {
     const props = getProps({
       parameter: createMockUiParameter({
         values_source_type: "static-list",
-        values_source_options: { values: ["Gadget"] },
+        values_source_config: { values: ["Gadget"] },
       }),
     });
 
@@ -69,7 +69,7 @@ describe("ParameterSourceSettings", () => {
     const props = getProps({
       parameter: createMockUiParameter({
         values_source_type: "static-list",
-        values_source_options: { values: ["Gadget"] },
+        values_source_config: { values: ["Gadget"] },
       }),
     });
 

--- a/frontend/src/metabase/parameters/components/ParameterSourceSettings/ParameterSourceSettings.unit.spec.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterSourceSettings/ParameterSourceSettings.unit.spec.tsx
@@ -10,7 +10,7 @@ describe("ParameterSourceSettings", () => {
   it("should set the default source type", () => {
     const props = getProps({
       parameter: createMockUiParameter({
-        source_type: "static-list",
+        values_source_type: "static-list",
       }),
     });
 
@@ -37,8 +37,8 @@ describe("ParameterSourceSettings", () => {
   it("should edit the static list source via the modal", () => {
     const props = getProps({
       parameter: createMockUiParameter({
-        source_type: "static-list",
-        source_options: { values: ["Gadget"] },
+        values_source_type: "static-list",
+        values_source_options: { values: ["Gadget"] },
       }),
     });
 
@@ -68,8 +68,8 @@ describe("ParameterSourceSettings", () => {
   it("should set the default source type if the static list is empty", () => {
     const props = getProps({
       parameter: createMockUiParameter({
-        source_type: "static-list",
-        source_options: { values: ["Gadget"] },
+        values_source_type: "static-list",
+        values_source_options: { values: ["Gadget"] },
       }),
     });
 

--- a/frontend/src/metabase/parameters/utils/dashboards.ts
+++ b/frontend/src/metabase/parameters/utils/dashboards.ts
@@ -9,7 +9,7 @@ import type {
   DashboardParameterMapping,
   DashboardOrderedCard,
   ParameterSourceType,
-  ParameterSourceOptions,
+  ParameterSourceConfig,
   Parameter,
 } from "metabase-types/api";
 import { isFieldFilterParameter } from "metabase-lib/parameters/utils/parameter-type";
@@ -70,13 +70,13 @@ export function getSourceType(parameter: Parameter): ParameterSourceType {
   return parameter.values_source_type ?? null;
 }
 
-export function getSourceOptions(parameter: Parameter): ParameterSourceOptions {
-  return parameter.values_source_options ?? {};
+export function getSourceOptions(parameter: Parameter): ParameterSourceConfig {
+  return parameter.values_source_config ?? {};
 }
 
 export function hasValidSourceOptions(
   sourceType: ParameterSourceType,
-  sourceOptions: ParameterSourceOptions,
+  sourceOptions: ParameterSourceConfig,
 ): boolean {
   switch (sourceType) {
     case "static-list":

--- a/frontend/src/metabase/parameters/utils/dashboards.ts
+++ b/frontend/src/metabase/parameters/utils/dashboards.ts
@@ -67,11 +67,11 @@ export function setParameterName(
 }
 
 export function getSourceType(parameter: Parameter): ParameterSourceType {
-  return parameter.source_type ?? null;
+  return parameter.values_source_type ?? null;
 }
 
 export function getSourceOptions(parameter: Parameter): ParameterSourceOptions {
-  return parameter.source_options ?? {};
+  return parameter.values_source_options ?? {};
 }
 
 export function hasValidSourceOptions(

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -735,11 +735,11 @@
            (throw e)))))))
 
 (defn- static-parameter-values
-  [{source-options :source_options :as _param} query]
-  (when-let [values (:values source-options)]
-    {:values (if query
-               (parameter-card/query-matches query values)
-               values)
+  [{values-source-options :values_source_options :as _param} query]
+  (when-let [values (:values values-source-options)]
+    {:values          (if query
+                        (parameter-card/query-matches query values)
+                        values)
      :has_more_values false}))
 
 (s/defn param-values
@@ -762,7 +762,7 @@
        (throw (ex-info (tru "Dashboard does not have a parameter with the ID {0}" (pr-str param-key))
                        {:resolved-params (keys (:resolved-params dashboard))
                         :status-code     400})))
-     (case (:source_type param)
+     (case (:values_source_type param)
        "static-list" (static-parameter-values param query)
        "card"        (parameter-card/values-for-dashboard dashboard param-key query)
        (chain-filter dashboard param-key constraint-param-key->value query)))))

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -735,7 +735,7 @@
            (throw e)))))))
 
 (defn- static-parameter-values
-  [{values-source-options :values_source_options :as _param} query]
+  [{values-source-options :values_source_config :as _param} query]
   (when-let [values (:values values-source-options)]
     {:values          (if query
                         (parameter-card/query-matches query values)

--- a/src/metabase/models/dashboard.clj
+++ b/src/metabase/models/dashboard.clj
@@ -153,9 +153,9 @@
   [{dashboard-id :id parameters :parameters :as dashboard}]
   (assoc dashboard :parameters
          (let [param-id->card-id (card-ids-by-param-id dashboard-id)]
-           (for [{:keys [id values_source_type values_source_options] :as param} parameters]
+           (for [{:keys [id values_source_type values_source_config] :as param} parameters]
              (if (= values_source_type "card")
-               (assoc-in param [:values_source_options :card_id] (get param-id->card-id id (:card_id values_source_options)))
+               (assoc-in param [:values_source_config :card_id] (get param-id->card-id id (:card_id values_source_config)))
                param)))))
 
 (u/strict-extend #_{:clj-kondo/ignore [:metabase/disallow-class-or-type-on-model]} (class Dashboard)

--- a/src/metabase/models/dashboard.clj
+++ b/src/metabase/models/dashboard.clj
@@ -153,9 +153,9 @@
   [{dashboard-id :id parameters :parameters :as dashboard}]
   (assoc dashboard :parameters
          (let [param-id->card-id (card-ids-by-param-id dashboard-id)]
-           (for [{:keys [id source_type source_options] :as param} parameters]
-             (if (= source_type "card")
-               (assoc-in param [:source_options :card_id] (get param-id->card-id id (:card_id source_options)))
+           (for [{:keys [id values_source_type values_source_options] :as param} parameters]
+             (if (= values_source_type "card")
+               (assoc-in param [:values_source_options :card_id] (get param-id->card-id id (:card_id values_source_options)))
                param)))))
 
 (u/strict-extend #_{:clj-kondo/ignore [:metabase/disallow-class-or-type-on-model]} (class Dashboard)

--- a/src/metabase/models/parameter_card.clj
+++ b/src/metabase/models/parameter_card.clj
@@ -55,8 +55,8 @@
 
 (defn- upsert-for-dashboard!
   [dashboard-id parameters]
-  (doseq [{:keys [values_source_options id]} parameters]
-    (let [card-id    (:card_id values_source_options)
+  (doseq [{:keys [values_source_config id]} parameters]
+    (let [card-id    (:card_id values_source_config)
           conditions {:parameterized_object_id   dashboard-id
                       :parameterized_object_type "dashboard"
                       :parameter_id              id}]
@@ -66,8 +66,8 @@
 (defn upsert-or-delete-for-dashboard!
   "Create, update, or delete appropriate ParameterCards for each parameter in the dashboard"
   [{dashboard-id :id parameters :parameters}]
-  (let [upsertable?           (fn [{:keys [values_source_type values_source_options id]}]
-                                (and values_source_type id (:card_id values_source_options)
+  (let [upsertable?           (fn [{:keys [values_source_type values_source_config id]}]
+                                (and values_source_type id (:card_id values_source_config)
                                      (= values_source_type "card")))
         upsertable-parameters (filter upsertable? parameters)]
     (upsert-for-dashboard! dashboard-id upsertable-parameters)

--- a/src/metabase/models/parameter_card.clj
+++ b/src/metabase/models/parameter_card.clj
@@ -55,8 +55,8 @@
 
 (defn- upsert-for-dashboard!
   [dashboard-id parameters]
-  (doseq [{:keys [source_options id]} parameters]
-    (let [card-id    (:card_id source_options)
+  (doseq [{:keys [values_source_options id]} parameters]
+    (let [card-id    (:card_id values_source_options)
           conditions {:parameterized_object_id   dashboard-id
                       :parameterized_object_type "dashboard"
                       :parameter_id              id}]
@@ -66,10 +66,10 @@
 (defn upsert-or-delete-for-dashboard!
   "Create, update, or delete appropriate ParameterCards for each parameter in the dashboard"
   [{dashboard-id :id parameters :parameters}]
-  (let [upsertable?           (fn [{:keys [source_type source_options id]}] (and source_type id (:card_id source_options)
-                                                                                 (= source_type "card")))
+  (let [upsertable?           (fn [{:keys [values_source_type values_source_options id]}]
+                                (and values_source_type id (:card_id values_source_options)
+                                     (= values_source_type "card")))
         upsertable-parameters (filter upsertable? parameters)]
-
     (upsert-for-dashboard! dashboard-id upsertable-parameters)
     (delete-all-for-parameterized-object! "dashboard" dashboard-id (map :id upsertable-parameters))))
 

--- a/src/metabase/util/schema.clj
+++ b/src/metabase/util/schema.clj
@@ -374,7 +374,7 @@
   (with-api-error-message {:id                                     NonBlankString
                            :type                                   keyword-or-non-blank-str
                            (s/optional-key :values_source_type)    (s/enum "static-list" "card" nil)
-                           (s/optional-key :values_source_options) ParameterSourceOptions
+                           (s/optional-key :values_source_config) ParameterSourceOptions
                            ;; Allow blank name and slug #15279
                            (s/optional-key :name)                  s/Str
                            (s/optional-key :slug)                  s/Str

--- a/src/metabase/util/schema.clj
+++ b/src/metabase/util/schema.clj
@@ -361,7 +361,7 @@
     string?  NonBlankString
     keyword? s/Keyword))
 
-(def ParameterSourceOptions
+(def ValuesSourceConfig
   "Schema for valid source_options within a Parameter"
   ;; TODO: This should be tighter
   {(s/optional-key :values) (s/cond-pre [s/Any])
@@ -371,16 +371,16 @@
   "Schema for a valid Parameter.
   We're not using [metabase.mbql.schema/Parameter] here because this Parameter is meant to be used for
   Parameters we store on dashboard/card, and it has some difference with Parameter in MBQL."
-  (with-api-error-message {:id                                     NonBlankString
-                           :type                                   keyword-or-non-blank-str
-                           (s/optional-key :values_source_type)    (s/enum "static-list" "card" nil)
-                           (s/optional-key :values_source_config) ParameterSourceOptions
+  (with-api-error-message {:id                                    NonBlankString
+                           :type                                  keyword-or-non-blank-str
+                           (s/optional-key :values_source_type)   (s/enum "static-list" "card" nil)
+                           (s/optional-key :values_source_config) ValuesSourceConfig
                            ;; Allow blank name and slug #15279
-                           (s/optional-key :name)                  s/Str
-                           (s/optional-key :slug)                  s/Str
-                           (s/optional-key :default)               s/Any
-                           (s/optional-key :sectionId)             NonBlankString
-                           s/Keyword                               s/Any}
+                           (s/optional-key :slug)                 s/Str
+                           (s/optional-key :name)                 s/Str
+                           (s/optional-key :default)              s/Any
+                           (s/optional-key :sectionId)            NonBlankString
+                           s/Keyword                              s/Any}
     (deferred-tru "parameter must be a map with :id and :type keys")))
 
 (def ParameterMapping

--- a/src/metabase/util/schema.clj
+++ b/src/metabase/util/schema.clj
@@ -371,16 +371,16 @@
   "Schema for a valid Parameter.
   We're not using [metabase.mbql.schema/Parameter] here because this Parameter is meant to be used for
   Parameters we store on dashboard/card, and it has some difference with Parameter in MBQL."
-  (with-api-error-message {:id                              NonBlankString
-                           :type                            keyword-or-non-blank-str
-                           (s/optional-key :source_type)    (s/enum "static-list" "card" nil)
-                           (s/optional-key :source_options) ParameterSourceOptions
+  (with-api-error-message {:id                                     NonBlankString
+                           :type                                   keyword-or-non-blank-str
+                           (s/optional-key :values_source_type)    (s/enum "static-list" "card" nil)
+                           (s/optional-key :values_source_options) ParameterSourceOptions
                            ;; Allow blank name and slug #15279
-                           (s/optional-key :name)           s/Str
-                           (s/optional-key :slug)           s/Str
-                           (s/optional-key :default)        s/Any
-                           (s/optional-key :sectionId)      NonBlankString
-                           s/Keyword                        s/Any}
+                           (s/optional-key :name)                  s/Str
+                           (s/optional-key :slug)                  s/Str
+                           (s/optional-key :default)               s/Any
+                           (s/optional-key :sectionId)             NonBlankString
+                           s/Keyword                               s/Any}
     (deferred-tru "parameter must be a map with :id and :type keys")))
 
 (def ParameterMapping

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -1725,18 +1725,18 @@
                                                                   :slug "id"
                                                                   :id   "_ID_"
                                                                   :type "category"}
-                                                                 {:name           "Static Category",
-                                                                  :slug           "static_category"
-                                                                  :id             "_STATIC_CATEGORY_",
-                                                                  :type           "category",
-                                                                  :source_type    "static-list"
-                                                                  :source_options {:values ["African" "American" "Asian"]}}
-                                                                 {:name           "Static Category label",
-                                                                  :slug           "static_category_label"
-                                                                  :id             "_STATIC_CATEGORY_LABEL_",
-                                                                  :type           "category",
-                                                                  :source_type    "static-list"
-                                                                  :source_options {:values [["African" "Af"] ["American" "Am"] ["Asian" "As"]]}}]}
+                                                                 {:name                  "Static Category",
+                                                                  :slug                  "static_category"
+                                                                  :id                    "_STATIC_CATEGORY_",
+                                                                  :type                  "category",
+                                                                  :values_source_type    "static-list"
+                                                                  :values_source_options {:values ["African" "American" "Asian"]}}
+                                                                 {:name                  "Static Category label",
+                                                                  :slug                  "static_category_label"
+                                                                  :id                    "_STATIC_CATEGORY_LABEL_",
+                                                                  :type                  "category",
+                                                                  :values_source_type    "static-list"
+                                                                  :values_source_options {:values [["African" "Af"] ["American" "Am"] ["Asian" "As"]]}}]}
                                                    dashboard-values)]
                    Card          [card {:database_id   (mt/id)
                                         :table_id      (mt/id :venues)
@@ -1886,38 +1886,38 @@
       (testing "we could edit the values list"
         ;; TODO add tests for schema check
         (let [dashboard (mt/user-http-request :rasta :put 200 (str "dashboard/" (:id dashboard))
-                                              {:parameters [{:name           "Static Category",
-                                                             :slug           "static_category"
-                                                             :id             "_STATIC_CATEGORY_",
-                                                             :type           "category",
-                                                             :source_type    "static-list"
-                                                             :source_options {"values" ["BBQ" "Bakery" "Bar"]}}]})]
-          (is (= [{:name           "Static Category",
-                   :slug           "static_category"
-                   :id             "_STATIC_CATEGORY_",
-                   :type           "category",
-                   :source_type    "static-list"
-                   :source_options {:values ["BBQ" "Bakery" "Bar"]}}]
+                                              {:parameters [{:name                  "Static Category",
+                                                             :slug                  "static_category"
+                                                             :id                    "_STATIC_CATEGORY_",
+                                                             :type                  "category",
+                                                             :values_source_type    "static-list"
+                                                             :values_source_options {"values" ["BBQ" "Bakery" "Bar"]}}]})]
+          (is (= [{:name                  "Static Category",
+                   :slug                  "static_category"
+                   :id                    "_STATIC_CATEGORY_",
+                   :type                  "category",
+                   :values_source_type    "static-list"
+                   :values_source_options {:values ["BBQ" "Bakery" "Bar"]}}]
                  (:parameters dashboard))))))
 
     (testing "source-options must be a map and sourcetype must be `card` or `static-list` must be a string"
       (is (= "value may be nil, or if non-nil, value must be an array. Each parameter must be a map with :id and :type keys"
              (get-in (mt/user-http-request :rasta :post 400 "dashboard"
                                            {:name       "a dashboard"
-                                            :parameters [{:id             "_value_",
-                                                          :name           "value",
-                                                          :type           "category",
-                                                          :source_type    "random-type"
-                                                          :source_options {"values" [1 2 3]}}]})
+                                            :parameters [{:id                    "_value_",
+                                                          :name                  "value",
+                                                          :type                  "category",
+                                                          :values_source_type    "random-type"
+                                                          :values_source_options {"values" [1 2 3]}}]})
                      [:errors :parameters])))
       (is (= "value may be nil, or if non-nil, value must be an array. Each parameter must be a map with :id and :type keys"
              (get-in (mt/user-http-request :rasta :post 400 "dashboard"
                                            {:name       "a dashboard"
-                                            :parameters [{:id             "_value_",
-                                                          :name           "value",
-                                                          :type           "category",
-                                                          :source_type    "static-list"
-                                                          :source_options []}]})
+                                            :parameters [{:id                    "_value_",
+                                                          :name                  "value",
+                                                          :type                  "category",
+                                                          :values_source_type    "static-list"
+                                                          :values_source_options []}]})
                      [:errors :parameters]))))))
 
 (deftest chain-filter-search-test
@@ -2064,11 +2064,11 @@
   (mt/with-temp* [Card      [{card-id :id}      {:database_id   (mt/id)
                                                  :table_id      (mt/id :venues)
                                                  :dataset_query (mt/native-query {:query "SELECT name FROM venues WHERE name LIKE '%Bar%'"})}]
-                  Dashboard [{dashboard-id :id} {:parameters [{:id             "abc"
-                                                               :type           "category"
-                                                               :name           "CATEGORY"
-                                                               :source_type    "card"
-                                                               :source_options {:card_id card-id}}]}]]
+                  Dashboard [{dashboard-id :id} {:parameters [{:id                    "abc"
+                                                               :type                  "category"
+                                                               :name                  "CATEGORY"
+                                                               :values_source_type    "card"
+                                                               :values_source_options {:card_id card-id}}]}]]
     (testing "It uses the results of the card's query execution"
       (let-url [url (chain-filter-values-url dashboard-id "abc")]
         (is (= {:values          ["The Misfit Restaurant + Bar"

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -1730,13 +1730,13 @@
                                                                   :id                    "_STATIC_CATEGORY_",
                                                                   :type                  "category",
                                                                   :values_source_type    "static-list"
-                                                                  :values_source_options {:values ["African" "American" "Asian"]}}
+                                                                  :values_source_config {:values ["African" "American" "Asian"]}}
                                                                  {:name                  "Static Category label",
                                                                   :slug                  "static_category_label"
                                                                   :id                    "_STATIC_CATEGORY_LABEL_",
                                                                   :type                  "category",
                                                                   :values_source_type    "static-list"
-                                                                  :values_source_options {:values [["African" "Af"] ["American" "Am"] ["Asian" "As"]]}}]}
+                                                                  :values_source_config {:values [["African" "Af"] ["American" "Am"] ["Asian" "As"]]}}]}
                                                    dashboard-values)]
                    Card          [card {:database_id   (mt/id)
                                         :table_id      (mt/id :venues)
@@ -1891,13 +1891,13 @@
                                                              :id                    "_STATIC_CATEGORY_",
                                                              :type                  "category",
                                                              :values_source_type    "static-list"
-                                                             :values_source_options {"values" ["BBQ" "Bakery" "Bar"]}}]})]
+                                                             :values_source_config {"values" ["BBQ" "Bakery" "Bar"]}}]})]
           (is (= [{:name                  "Static Category",
                    :slug                  "static_category"
                    :id                    "_STATIC_CATEGORY_",
                    :type                  "category",
                    :values_source_type    "static-list"
-                   :values_source_options {:values ["BBQ" "Bakery" "Bar"]}}]
+                   :values_source_config {:values ["BBQ" "Bakery" "Bar"]}}]
                  (:parameters dashboard))))))
 
     (testing "source-options must be a map and sourcetype must be `card` or `static-list` must be a string"
@@ -1908,7 +1908,7 @@
                                                           :name                  "value",
                                                           :type                  "category",
                                                           :values_source_type    "random-type"
-                                                          :values_source_options {"values" [1 2 3]}}]})
+                                                          :values_source_config {"values" [1 2 3]}}]})
                      [:errors :parameters])))
       (is (= "value may be nil, or if non-nil, value must be an array. Each parameter must be a map with :id and :type keys"
              (get-in (mt/user-http-request :rasta :post 400 "dashboard"
@@ -1917,7 +1917,7 @@
                                                           :name                  "value",
                                                           :type                  "category",
                                                           :values_source_type    "static-list"
-                                                          :values_source_options []}]})
+                                                          :values_source_config []}]})
                      [:errors :parameters]))))))
 
 (deftest chain-filter-search-test
@@ -2068,7 +2068,7 @@
                                                                :type                  "category"
                                                                :name                  "CATEGORY"
                                                                :values_source_type    "card"
-                                                               :values_source_options {:card_id card-id}}]}]]
+                                                               :values_source_config {:card_id card-id}}]}]]
     (testing "It uses the results of the card's query execution"
       (let-url [url (chain-filter-values-url dashboard-id "abc")]
         (is (= {:values          ["The Misfit Restaurant + Bar"

--- a/test/metabase/models/dashboard_test.clj
+++ b/test/metabase/models/dashboard_test.clj
@@ -219,7 +219,7 @@
                       Dashboard [{dashboard-id :id}
                                  {:parameters [(merge default-params
                                                       {:values_source_type    "card"
-                                                       :values_source_options {:card_id card-id}})]}]]
+                                                       :values_source_config {:card_id card-id}})]}]]
         (is (=? {:card_id                   card-id
                  :parameterized_object_type :dashboard
                  :parameterized_object_id   dashboard-id
@@ -233,7 +233,7 @@
         (is (nil? (db/select-one 'ParameterCard :card_id card-id)))
         (db/update! Dashboard dashboard-id :parameters [(merge default-params
                                                                {:values_source_type    "card"
-                                                                :values_source_options {:card_id card-id}})])
+                                                                :values_source_config {:card_id card-id}})])
         (is (=? {:card_id                   card-id
                  :parameterized_object_type :dashboard
                  :parameterized_object_id   dashboard-id
@@ -245,7 +245,7 @@
                       Dashboard [{dashboard-id :id}
                                  {:parameters [(merge default-params
                                                       {:values_source_type    "card"
-                                                       :values_source_options {:card_id card-id}})]}]]
+                                                       :values_source_config {:card_id card-id}})]}]]
         ;; same setup as earlier test, we know the ParameterCard exists right now
         (db/delete! Dashboard :id dashboard-id)
         (is (nil? (db/select-one 'ParameterCard :card_id card-id)))))))

--- a/test/metabase/models/dashboard_test.clj
+++ b/test/metabase/models/dashboard_test.clj
@@ -217,7 +217,9 @@
     (testing "A new dashboard creates a new ParameterCard"
       (tt/with-temp* [Card      [{card-id :id}]
                       Dashboard [{dashboard-id :id}
-                                 {:parameters [(assoc default-params :source_type "card" :source_options {:card_id card-id})]}]]
+                                 {:parameters [(merge default-params
+                                                      {:values_source_type    "card"
+                                                       :values_source_options {:card_id card-id}})]}]]
         (is (=? {:card_id                   card-id
                  :parameterized_object_type :dashboard
                  :parameterized_object_id   dashboard-id
@@ -229,7 +231,9 @@
                       Dashboard [{dashboard-id :id}
                                  {:parameters [default-params]}]]
         (is (nil? (db/select-one 'ParameterCard :card_id card-id)))
-        (db/update! Dashboard dashboard-id :parameters [(assoc default-params :source_type "card" :source_options {:card_id card-id})])
+        (db/update! Dashboard dashboard-id :parameters [(merge default-params
+                                                               {:values_source_type    "card"
+                                                                :values_source_options {:card_id card-id}})])
         (is (=? {:card_id                   card-id
                  :parameterized_object_type :dashboard
                  :parameterized_object_id   dashboard-id
@@ -239,7 +243,9 @@
     (testing "Removing a card_id deletes old ParameterCards"
       (tt/with-temp* [Card      [{card-id :id}]
                       Dashboard [{dashboard-id :id}
-                                 {:parameters [(assoc default-params :source_type "card" :source_options {:card_id card-id})]}]]
+                                 {:parameters [(merge default-params
+                                                      {:values_source_type    "card"
+                                                       :values_source_options {:card_id card-id}})]}]]
         ;; same setup as earlier test, we know the ParameterCard exists right now
         (db/delete! Dashboard :id dashboard-id)
         (is (nil? (db/select-one 'ParameterCard :card_id card-id)))))))


### PR DESCRIPTION
We added 2 keys to parameter `[:source_type, :source_options]` in https://github.com/metabase/metabase/pull/27008.

The name `source` is quite ambiguous, so renaming to `[:values_source_type, :values_source_options]`