### PR TITLE
[CI] Do not run FE and BE tests when PRs are in a draft mode

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -105,7 +105,7 @@ jobs:
       name: Run Eastwood linter
 
   be-tests:
-    if: (matrix.edition == 'ee' && matrix.java-version == '11') || github.event.pull_request.draft == false
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-20.04
     name: be-tests-java-${{ matrix.java-version }}-${{ matrix.edition }}
     timeout-minutes: 25

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -111,7 +111,7 @@ jobs:
   be-tests-java-11-ee-pre-check:
     if: github.event.pull_request.draft == true
     runs-on: ubuntu-20.04
-    name: be-tests-java-11-ee
+    name: be-tests-java-11-ee-pre-check
     timeout-minutes: 25
     steps:
     - uses: actions/checkout@v3
@@ -132,7 +132,7 @@ jobs:
       if: always()
       with:
         path: 'target/junit/**/*_test.xml'
-        name: JUnit Test Report be-tests-java-11-ee
+        name: JUnit Test Report be-tests-java-11-ee-pre-check
         reporter: java-junit
 
   be-tests:

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -12,6 +12,7 @@ on:
       - "**/frontend/test/**"
       - "**/frontend/**.unit.*"
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     paths-ignore:
       - "docs/**"
       - "**.md"

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -105,7 +105,7 @@ jobs:
       name: Run Eastwood linter
 
   be-tests:
-    if: github.event.pull_request.draft == false
+    if: (matrix.edition == 'ee' && matrix.java-version == '11') || github.event.pull_request.draft == false
     runs-on: ubuntu-20.04
     name: be-tests-java-${{ matrix.java-version }}-${{ matrix.edition }}
     timeout-minutes: 25

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -42,7 +42,6 @@ jobs:
         flags: back-end
 
   be-linter-clj-kondo:
-    if: github.event.pull_request.draft == false
     runs-on: ubuntu-20.04
     timeout-minutes: 10
     steps:

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -22,6 +22,7 @@ on:
 jobs:
 
   be-linter-cloverage:
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-20.04
     timeout-minutes: 60
     steps:
@@ -41,6 +42,7 @@ jobs:
         flags: back-end
 
   be-linter-clj-kondo:
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-20.04
     timeout-minutes: 10
     steps:
@@ -91,6 +93,7 @@ jobs:
         /work/modules/drivers/presto-jdbc/test
 
   be-linter-eastwood:
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-20.04
     timeout-minutes: 20
     steps:
@@ -103,6 +106,7 @@ jobs:
       name: Run Eastwood linter
 
   be-tests:
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-20.04
     name: be-tests-java-${{ matrix.java-version }}-${{ matrix.edition }}
     timeout-minutes: 25
@@ -136,6 +140,7 @@ jobs:
   # checks that all the namespaces we actually ship can be compiled, without any dependencies that we don't ship (such
   # as `:dev` dependencies). See #27009 for more context.
   be-check:
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-20.04
     name: be-check-java-${{ matrix.java-version }}
     timeout-minutes: 10

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -104,6 +104,36 @@ jobs:
     - run: clojure -X:dev:ee:ee-dev:drivers:drivers-dev:test:eastwood
       name: Run Eastwood linter
 
+  # Because it's not possible to conditionally run only `java-11-ee` test in the draft mode,
+  # we have to extract that job manually here. Backend developers have requested that this
+  # test runs at all times to give them an early warning sign is something is broken.
+  be-tests-java-11-ee-pre-check:
+    if: github.event.pull_request.draft == true
+    runs-on: ubuntu-20.04
+    name: be-tests-java-11-ee
+    timeout-minutes: 25
+    steps:
+    - uses: actions/checkout@v3
+    - name: Prepare front-end environment
+      uses: ./.github/actions/prepare-frontend
+    - name: Prepare back-end environment
+      uses: ./.github/actions/prepare-backend
+
+    - run: yarn install --frozen-lockfile --prefer-offline
+    - name: Build static viz frontend
+      run: yarn build-static-viz
+
+    - name: Run tests
+      run: clojure -X:dev:ci:test:ee:ee-dev
+
+    - name: Publish Test Report (JUnit)
+      uses: dorny/test-reporter@v1
+      if: always()
+      with:
+        path: 'target/junit/**/*_test.xml'
+        name: JUnit Test Report be-tests-java-11-ee
+        reporter: java-junit
+
   be-tests:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-20.04

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -67,6 +67,7 @@ jobs:
       name: Check types
 
   fe-tests-unit:
+    if: github.event.pull_request.draft == false
     runs-on: buildjet-2vcpu-ubuntu-2004
     timeout-minutes: 20
     steps:
@@ -82,6 +83,7 @@ jobs:
         flags: front-end
 
   fe-tests-timezones:
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-20.04
     timeout-minutes: 14
     steps:
@@ -92,6 +94,7 @@ jobs:
       name: Run frontend timezones tests
 
   fe-chromatic:
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout repository

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -19,6 +19,7 @@ on:
       - "frontend/test/__support__/e2e/**"
       - "frontend/test/__runner__/*cypress*"
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     paths-ignore:
       # documentation
       - "docs/**"


### PR DESCRIPTION
Do not run FE and BE tests when PRs are in a draft mode.

## Note
If we're going to rely on the draft mode and want tests to run as soon as we make the PR "ready for review", `on: pill_request` needs to be instructed to do so explicitly.

As per the [documentation](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request):
> By default, a workflow only runs when a pull_request event's activity type is `opened`, `synchronize`, or `reopened`.

This PR adds `ready_for_review` type of trigger to pull request event.