### PR TITLE
Generalize product-triggered survey emails

### DIFF
--- a/src/metabase/email/messages.clj
+++ b/src/metabase/email/messages.clj
@@ -30,7 +30,7 @@
             [metabase.query-processor.timezone :as qp.timezone]
             [metabase.util :as u]
             [metabase.util.date-2 :as u.date]
-            [metabase.util.i18n :as i18n :refer [deferred-trs trs tru]]
+            [metabase.util.i18n :as i18n :refer [trs tru]]
             [metabase.util.urls :as urls]
             [stencil.core :as stencil]
             [stencil.loader :as stencil-loader]

--- a/src/metabase/email/messages.clj
+++ b/src/metabase/email/messages.clj
@@ -272,7 +272,7 @@
                        {:emailType    "notification"
                         :logoHeader   true
                         :heading      (trs "We hope you''ve been enjoying Metabase.")
-                        :callToAction (trs "Would you mind taking a fast 6 question survey to tell us how it’s going?")
+                        :callToAction (trs "Would you mind taking a quick 5 minute survey to tell us how it’s going?")
                         :link         "https://metabase.com/feedback/active"})
         email {:subject      (trs "[{0}] Tell us how things are going." (app-name-trs))
                :recipients   [email]

--- a/src/metabase/task/follow_up_emails.clj
+++ b/src/metabase/task/follow_up_emails.clj
@@ -41,7 +41,7 @@
     ;; TODO - Does it make to send to this user instead of `(public-settings/admin-email)`?
     (when-let [admin (db/select-one User :is_superuser true, :is_active true, {:order-by [:date_joined]})]
       (try
-        (messages/send-follow-up-email! (:email admin) "follow-up")
+        (messages/send-follow-up-email! (:email admin))
         (catch Throwable e
           (log/error "Problem sending follow-up email:" e))
         (finally
@@ -120,7 +120,7 @@
     (when (should-send-abandoment-email?)
       (log/info (trs "Sending abandonment email!"))
       (try
-        (messages/send-follow-up-email! admin-email "abandon")
+        (messages/send-follow-up-email! admin-email)
         (catch Throwable e
           (log/error e (trs "Problem sending abandonment email")))
         (finally

--- a/src/metabase/task/follow_up_emails.clj
+++ b/src/metabase/task/follow_up_emails.clj
@@ -7,17 +7,12 @@
             [java-time :as t]
             [metabase.email :as email]
             [metabase.email.messages :as messages]
-            [metabase.models.activity :refer [Activity]]
             [metabase.models.setting :as setting]
             [metabase.models.user :as user :refer [User]]
-            [metabase.models.view-log :refer [ViewLog]]
             [metabase.public-settings :as public-settings]
             [metabase.task :as task]
             [metabase.util.date-2 :as u.date]
-            [metabase.util.i18n :refer [trs]]
-            [schema.core :as s]
-            [toucan.db :as db])
-  (:import java.time.temporal.Temporal))
+            [toucan.db :as db]))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                             send follow-up emails                                              |
@@ -70,83 +65,6 @@
                  (jobs/with-identity (jobs/key follow-up-emails-job-key)))
         trigger (triggers/build
                  (triggers/with-identity (triggers/key follow-up-emails-trigger-key))
-                 (triggers/start-now)
-                 (triggers/with-schedule
-                   ;; run once a day
-                   (cron/cron-schedule "0 0 12 * * ? *")))]
-    (task/schedule-task! job trigger)))
-
-
-;;; +----------------------------------------------------------------------------------------------------------------+
-;;; |                                             send abandoment emails                                             |
-;;; +----------------------------------------------------------------------------------------------------------------+
-
-(setting/defsetting ^:private abandonment-email-sent
-  "Have we sent an abandonment email to the instance admin?"
-  :type       :boolean
-  :default    false
-  :visibility :internal)
-
-(s/defn ^:private should-send-abandoment-email?
-  ([]
-   (let [[last-user last-activity last-view]
-         (map :last (db/query
-                     {:union-all
-                      [{:select [[:%max.date_joined :last]], :from [User]}
-                       {:select [[:%max.timestamp :last]], :from [Activity]}
-                       {:select [[:%max.timestamp :last]], :from [ViewLog]}]}))]
-     (should-send-abandoment-email?
-      (instance-creation-timestamp)
-      last-user
-      last-activity
-      last-view)))
-
-  ([instance-creation :- (s/maybe Temporal)
-    last-user         :- (s/maybe Temporal)
-    last-activity     :- (s/maybe Temporal)
-    last-view         :- (s/maybe Temporal)]
-   (boolean
-    (and instance-creation
-         (u.date/older-than? instance-creation (t/weeks 4))
-         (or (not last-user)     (u.date/older-than? last-user     (t/weeks 2)))
-         (or (not last-activity) (u.date/older-than? last-activity (t/weeks 2)))
-         (or (not last-view)     (u.date/older-than? last-view     (t/weeks 2)))))))
-
-(defn- send-abandoment-email-if-needed!
-  "Send an email to the instance admin about why Metabase usage has died down."
-  []
-  ;; grab the oldest admins email address, that's who we'll send to
-  (when-let [admin-email (db/select-one-field :email User :is_superuser true, {:order-by [:date_joined]})]
-    (when (should-send-abandoment-email?)
-      (log/info (trs "Sending abandonment email!"))
-      (try
-        (messages/send-follow-up-email! admin-email)
-        (catch Throwable e
-          (log/error e (trs "Problem sending abandonment email")))
-        (finally
-          (abandonment-email-sent! true))))))
-
-
-(jobs/defjob
-  ^{:doc "Sends out an email any time after 30 days if the instance has stopped being used for 14 days"}
-  AbandonmentEmail
-  [_]
-  ;; if we've already sent the abandonment email then we are done
-  (when-not (abandonment-email-sent)
-    ;; we need access to email AND the instance must be opted into anonymous tracking
-    (when (and (email/email-configured?)
-               (public-settings/anon-tracking-enabled))
-      (send-abandoment-email-if-needed!))))
-
-(def ^:private abandonment-emails-job-key     "metabase.task.abandonment-emails.job")
-(def ^:private abandonment-emails-trigger-key "metabase.task.abandonment-emails.trigger")
-
-(defmethod task/init! ::SendAbandomentEmails [_]
-  (let [job     (jobs/build
-                 (jobs/of-type AbandonmentEmail)
-                 (jobs/with-identity (jobs/key abandonment-emails-job-key)))
-        trigger (triggers/build
-                 (triggers/with-identity (triggers/key abandonment-emails-trigger-key))
                  (triggers/start-now)
                  (triggers/with-schedule
                    ;; run once a day

--- a/test/metabase/cmd/env_var_dox_test.clj
+++ b/test/metabase/cmd/env_var_dox_test.clj
@@ -2,12 +2,12 @@
   (:require [clojure.test :refer :all]
             [metabase.cmd.env-var-dox :as sut]))
 
-(def settings '({:description "Have we sent an abandonment email to the instance admin?",
+(def settings '({:description "Have we sent a follow up email to the instance admin?",
                  :database-local :never,
                  :cache? true,
                  :user-local :never,
                  :default false,
-                 :name :abandonment-email-sent,
+                 :name :follow-up-email-sent,
                  :type :boolean,
                  :enabled? nil,
                  :deprecated nil,
@@ -16,7 +16,7 @@
                  :on-change nil,
                  :doc nil,
                  :namespace metabase.task.follow-up-emails,
-                 :munged-name "abandonment-email-sent",
+                 :munged-name "follow-up-email-sent",
                  :visibility :internal}
                 {:description "The email address users should be referred to if they encounter a problem.",
                  :database-local :never,
@@ -53,7 +53,7 @@
                  :munged-name "analytics-uuid",
                  :visibility :public}))
 
-(def expected-docs '("### `MB_ABANDONMENT_EMAIL_SENT`\n\nType: boolean\n\nDefault: `false`\n\nHave we sent an abandonment email to the instance admin?"
+(def expected-docs '("### `MB_FOLLOW_UP_EMAIL_SENT`\n\nType: boolean\n\nDefault: `false`\n\nHave we sent a follow up email to the instance admin?"
                      "### `MB_ADMIN_EMAIL`\n\nType: string\n\nDefault: `null`\n\nThe email address users should be referred to if they encounter a problem."))
 
 (deftest test-env-var-docs

--- a/test/metabase/task/follow_up_emails_test.clj
+++ b/test/metabase/task/follow_up_emails_test.clj
@@ -1,6 +1,5 @@
 (ns metabase.task.follow-up-emails-test
   (:require [clojure.test :refer :all]
-            [java-time :as t]
             [metabase.email-test :refer [inbox with-fake-inbox]]
             [metabase.task.follow-up-emails :as follow-up-emails]
             [metabase.test.fixtures :as fixtures]

--- a/test/metabase/task/follow_up_emails_test.clj
+++ b/test/metabase/task/follow_up_emails_test.clj
@@ -18,23 +18,3 @@
       (#'follow-up-emails/send-follow-up-email!)
       (is (= 1
              (-> @inbox vals first count))))))
-
-(deftest should-send-abandoment-email-test
-  (testing "Make sure zero-arity version works (#12068)"
-    (testing `(follow-up-emails/should-send-abandoment-email?)
-      (is (boolean? (#'follow-up-emails/should-send-abandoment-email?)))))
-  (testing "Conditions where abandonment emails should be sent"
-    (doseq [now               [(t/zoned-date-time) (t/offset-date-time) (t/instant)]
-            instance-creation [0 1 5 nil]
-            last-user         [0 1 3 nil]
-            last-activity     [0 1 3 nil]
-            last-view         [0 1 3 nil]]
-      (testing (format "classes = %s, instance creation = %d weeks ago, last-user = %d weeks ago, last-activity = %d weeks ago, last-view = %d weeks ago"
-                       (.getName (class now)) instance-creation last-user last-activity last-view)
-        (is (= (and (= instance-creation 5)
-                    (every? #(contains? #{nil 3} %) [last-user last-activity last-view]))
-               (#'follow-up-emails/should-send-abandoment-email?
-                (when instance-creation (t/minus now (t/weeks instance-creation)))
-                (when last-user         (t/minus now (t/weeks last-user)))
-                (when last-activity     (t/minus now (t/weeks last-activity)))
-                (when last-view         (t/minus now (t/weeks last-view))))))))))


### PR DESCRIPTION
Resolves epic: https://github.com/metabase/metabase/issues/27098

This PR ticks both boxes in the epic:
~~1. replaces the "abandonment" email content with the "follow-up" email content, and~~
1. Removing the abandonment email completely (https://github.com/metabase/metabase/issues/27098#issuecomment-1361627372)
2. updates the call to action in the general follow up

There are no relevant tests for the email content.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/27348)
<!-- Reviewable:end -->
