### PR TITLE
Use origin instead of regex for nock

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/license/components/LicenseAndBillingSettings/LicenseAndBillingSettings.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/license/components/LicenseAndBillingSettings/LicenseAndBillingSettings.unit.spec.tsx
@@ -45,7 +45,7 @@ const setupState = ({
 };
 
 const mockTokenStatus = (valid: boolean, features: string[] = []) => {
-  nock(/.*/).get("/api/premium-features/token/status").reply(200, {
+  nock(location.origin).get("/api/premium-features/token/status").reply(200, {
     valid,
     "valid-thru": "2099-12-31T12:00:00",
     features,
@@ -53,11 +53,11 @@ const mockTokenStatus = (valid: boolean, features: string[] = []) => {
 };
 
 const mockTokenNotExist = () => {
-  nock(/.*/).get("/api/premium-features/token/status").reply(404);
+  nock(location.origin).get("/api/premium-features/token/status").reply(404);
 };
 
 const mockUpdateToken = (valid: boolean) => {
-  nock(/.*/)
+  nock(location.origin)
     .put("/api/setting/premium-embedding-token")
     .reply(valid ? 200 : 400);
 };

--- a/enterprise/frontend/src/metabase-enterprise/snippets/components/SnippetCollectionFormModal.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/snippets/components/SnippetCollectionFormModal.unit.spec.tsx
@@ -27,11 +27,11 @@ type SetupOpts = {
 
 async function setup({ folder = {}, onClose = jest.fn() }: SetupOpts = {}) {
   if (folder.id) {
-    nock(/.*/)
+    nock(location.origin)
       .get(`/api/collection/${folder.id}?namespace=snippets`)
       .reply(200, folder);
 
-    nock(/.*/)
+    nock(location.origin)
       .put(`/api/collection/${folder.id}`)
       .reply(200, (uri, body) => {
         if (typeof body === "object") {
@@ -44,11 +44,11 @@ async function setup({ folder = {}, onClose = jest.fn() }: SetupOpts = {}) {
     .get("/api/collection/root?namespace=snippets")
     .reply(200, TOP_SNIPPETS_FOLDER);
 
-  nock(/.*/)
+  nock(location.origin)
     .get("/api/collection?namespace=snippets")
     .reply(200, [TOP_SNIPPETS_FOLDER]);
 
-  nock(/.*/)
+  nock(location.origin)
     .post("/api/collection")
     .reply(200, (uri, body) => {
       if (typeof body === "object") {

--- a/frontend/src/metabase/collections/containers/CreateCollectionForm.unit.spec.tsx
+++ b/frontend/src/metabase/collections/containers/CreateCollectionForm.unit.spec.tsx
@@ -16,7 +16,7 @@ type SetupOpts = {
 };
 
 function setup({ user, onCancel = jest.fn() }: SetupOpts = {}) {
-  nock(/.*/)
+  nock(location.origin)
     .post("/api/collection")
     .reply(200, (url, body) => {
       if (typeof body === "object") {
@@ -33,7 +33,7 @@ function setup({ user, onCancel = jest.fn() }: SetupOpts = {}) {
 
 describe("CreateCollectionForm", () => {
   beforeEach(() => {
-    nock(/.*/)
+    nock(location.origin)
       .get("/api/collection")
       .reply(200, [
         {

--- a/frontend/src/metabase/components/FormCategoryInput/CategoryFieldPicker.unit.spec.tsx
+++ b/frontend/src/metabase/components/FormCategoryInput/CategoryFieldPicker.unit.spec.tsx
@@ -45,7 +45,7 @@ describe("CategoryFieldPicker", () => {
 
   describe("given a few distinct values", () => {
     beforeEach(() => {
-      nock(/.*/)
+      nock(location.origin)
         .get(`/api/field/${productCategoryField.id}/values`)
         .reply(200, productCategoryField.fieldValues());
     });

--- a/frontend/src/metabase/containers/ItemPicker/ItemPicker.unit.spec.js
+++ b/frontend/src/metabase/containers/ItemPicker/ItemPicker.unit.spec.js
@@ -86,11 +86,11 @@ const DASHBOARD = {
 
 function mockCollectionEndpoint({ extraCollections = [] } = {}) {
   const collections = [...Object.values(COLLECTION), ...extraCollections];
-  nock(/.*/).get("/api/collection").reply(200, collections);
+  nock(location.origin).get("/api/collection").reply(200, collections);
 }
 
 function mockCollectionItemsEndpoint() {
-  nock(/.*/)
+  nock(location.origin)
     .persist()
     .get(/\/api\/collection\/(root|[1-9]\d*)\/items.*/)
     .reply(200, url => {
@@ -106,7 +106,7 @@ function mockCollectionItemsEndpoint() {
       };
     });
 
-  nock(/.*/)
+  nock(location.origin)
     .get("/api/collection/root/items")
     .reply(200, () => {
       const dashboards = Object.values(DASHBOARD).filter(

--- a/frontend/src/metabase/dashboard/containers/CreateDashboardModal.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/containers/CreateDashboardModal.unit.spec.tsx
@@ -33,7 +33,7 @@ function setup({ mockCreateDashboardResponse = true } = {}) {
   const onClose = jest.fn();
 
   if (mockCreateDashboardResponse) {
-    nock(/.*/)
+    nock(location.origin)
       .post(`/api/dashboard`)
       .reply(200, (url, body) => body);
   }
@@ -47,7 +47,7 @@ function setup({ mockCreateDashboardResponse = true } = {}) {
 
 describe("CreateDashboardModal", () => {
   beforeEach(() => {
-    nock(/.*/)
+    nock(location.origin)
       .get("/api/collection")
       .reply(200, [
         {

--- a/frontend/src/metabase/nav/components/RecentsList.unit.spec.js
+++ b/frontend/src/metabase/nav/components/RecentsList.unit.spec.js
@@ -42,7 +42,7 @@ const recentsData = [
 ];
 
 function mockRecentsEndpoint(recents) {
-  nock(/.*/).get("/api/activity/recent_views").reply(200, recents);
+  nock(location.origin).get("/api/activity/recent_views").reply(200, recents);
 }
 
 async function setup(recents = recentsData) {

--- a/frontend/src/metabase/query_builder/actions/core/initializeQB.unit.spec.ts
+++ b/frontend/src/metabase/query_builder/actions/core/initializeQB.unit.spec.ts
@@ -113,7 +113,7 @@ async function setup({
   const card = question.card();
 
   if ("id" in card) {
-    nock(/.*/).get(`/api/card/${card.id}`).reply(200, card);
+    nock(location.origin).get(`/api/card/${card.id}`).reply(200, card);
   }
 
   jest.spyOn(CardLib, "loadCard").mockReturnValue(Promise.resolve({ ...card }));
@@ -425,7 +425,7 @@ describe("QB Actions > initializeQB", () => {
           original_card_id: ORIGINAL_CARD_ID,
         });
 
-        nock(/.*/)
+        nock(location.origin)
           .get(`/api/card/${originalQuestion.id()}`)
           .reply(200, originalQuestion.card());
 

--- a/frontend/src/metabase/query_builder/actions/core/initializeQB.unit.spec.ts
+++ b/frontend/src/metabase/query_builder/actions/core/initializeQB.unit.spec.ts
@@ -113,7 +113,7 @@ async function setup({
   const card = question.card();
 
   if ("id" in card) {
-    nock(location.origin).get(`/api/card/${card.id}`).reply(200, card);
+    nock(global.location.origin).get(`/api/card/${card.id}`).reply(200, card);
   }
 
   jest.spyOn(CardLib, "loadCard").mockReturnValue(Promise.resolve({ ...card }));

--- a/frontend/src/metabase/query_builder/components/DataSelector/saved-question-picker/SavedQuestionPicker.unit.spec.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/saved-question-picker/SavedQuestionPicker.unit.spec.jsx
@@ -27,18 +27,18 @@ const COLLECTIONS = {
 };
 
 function mockCollectionTreeEndpoint() {
-  nock(/.*/)
+  nock(location.origin)
     .get("/api/collection/tree?tree=true")
     .reply(200, Object.values(COLLECTIONS));
 }
 
 function mockRootCollectionEndpoint(hasAccess) {
   if (hasAccess) {
-    nock(/.*/)
+    nock(location.origin)
       .get("/api/collection/root")
       .reply(200, createMockCollection({ id: "root", name: "Our analytics" }));
   } else {
-    nock(/.*/)
+    nock(location.origin)
       .get("/api/collection/root")
       .reply(200, "You don't have access to this collection");
   }
@@ -46,7 +46,7 @@ function mockRootCollectionEndpoint(hasAccess) {
 
 function mockCollectionEndpoint(requestedCollectionName) {
   const encodedName = encodeURIComponent(requestedCollectionName);
-  nock(/.*/)
+  nock(location.origin)
     .get(`/api/database/-1337/schema/${encodedName}`)
     .reply(200, [
       createMockTable({

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.unit.spec.js
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.unit.spec.js
@@ -171,20 +171,20 @@ describe.skip("Notebook Editor > Join Step", () => {
   }
 
   beforeEach(() => {
-    nock(/.*/)
+    nock(location.origin)
       .get("/api/database")
       .reply(200, {
         total: 1,
         data: [SAMPLE_DATABASE.getPlainObject()],
       });
-    nock(/.*/).get("/api/database/1/schemas").reply(200, ["PUBLIC"]);
-    nock(/.*/)
+    nock(location.origin).get("/api/database/1/schemas").reply(200, ["PUBLIC"]);
+    nock(location.origin)
       .get("/api/database/1/schema/PUBLIC")
       .reply(
         200,
         SAMPLE_DATABASE.tables.filter(table => table.schema === "PUBLIC"),
       );
-    nock(/.*/)
+    nock(location.origin)
       .get("/api/search?models=dataset&limit=1")
       .reply(200, {
         data: [],

--- a/frontend/src/metabase/query_builder/components/template_tags/SnippetFormModal/SnippetFormModal.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/SnippetFormModal/SnippetFormModal.unit.spec.tsx
@@ -35,17 +35,17 @@ async function setup({
   withDefaultFoldersList = true,
   onClose = jest.fn(),
 }: SetupOpts = {}) {
-  nock(/.*/)
+  nock(location.origin)
     .get("/api/collection/root?namespace=snippets")
     .reply(200, TOP_SNIPPETS_FOLDER);
 
   if (withDefaultFoldersList) {
-    nock(/.*/)
+    nock(location.origin)
       .get("/api/collection?namespace=snippets")
       .reply(200, [TOP_SNIPPETS_FOLDER]);
   }
 
-  nock(/.*/)
+  nock(location.origin)
     .post("/api/native-query-snippet")
     .reply(200, (uri, body) => {
       if (typeof body === "object") {
@@ -54,7 +54,7 @@ async function setup({
     });
 
   if (snippet.id) {
-    nock(/.*/)
+    nock(location.origin)
       .put(`/api/native-query-snippet/${snippet.id}`)
       .reply(200, (uri, body) => {
         if (typeof body === "object") {
@@ -118,7 +118,7 @@ describe("SnippetFormModal", () => {
     });
 
     it("shows folder picker if there are many folders", async () => {
-      nock(/.*/)
+      nock(location.origin)
         .get("/api/collection?namespace=snippets")
         .reply(200, [TOP_SNIPPETS_FOLDER, createMockCollection()]);
 
@@ -211,7 +211,7 @@ describe("SnippetFormModal", () => {
     });
 
     it("shows folder picker if there are many folders", async () => {
-      nock(/.*/)
+      nock(location.origin)
         .get("/api/collection?namespace=snippets")
         .reply(200, [TOP_SNIPPETS_FOLDER, createMockCollection()]);
 

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader.unit.spec.js
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader.unit.spec.js
@@ -144,7 +144,7 @@ function setupSavedNative(props = {}) {
     name: "Our analytics",
   };
 
-  nock(/.*/).get("/api/collection/root").reply(200, collection);
+  nock(location.origin).get("/api/collection/root").reply(200, collection);
 
   const utils = setup({ question: getSavedNativeQuestion(), ...props });
 
@@ -342,7 +342,7 @@ describe("ViewHeader", () => {
 
       describe(questionType, () => {
         beforeEach(() => {
-          nock(/.*/).get("/api/collection/root").reply(200, {
+          nock(location.origin).get("/api/collection/root").reply(200, {
             id: "root",
             name: "Our analytics",
           });

--- a/frontend/src/metabase/query_builder/components/view/sidebars/ModelCacheManagementSection/ModelCacheManagementSection.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/ModelCacheManagementSection/ModelCacheManagementSection.unit.spec.tsx
@@ -42,7 +42,9 @@ async function setup({
     .spyOn(PersistedModels.objectActions, "refreshCache")
     .mockReturnValue({ type: "__MOCK__" });
 
-  nock(/.*/).get(`/api/persist/card/${model.id()}`).reply(200, modelCacheInfo);
+  nock(location.origin)
+    .get(`/api/persist/card/${model.id()}`)
+    .reply(200, modelCacheInfo);
 
   if (!waitForSectionAppearance) {
     jest.spyOn(PersistedModels, "Loader").mockImplementation(props => {

--- a/frontend/src/metabase/search/components/InfoText.unit.spec.js
+++ b/frontend/src/metabase/search/components/InfoText.unit.spec.js
@@ -9,9 +9,9 @@ const table = { id: 1, display_name: "Table Name" };
 const database = { id: 1, name: "Database Name" };
 
 async function setup(result) {
-  nock(/.*/).get("/api/table/1").reply(200, table);
+  nock(location.origin).get("/api/table/1").reply(200, table);
 
-  nock(/.*/).get("/api/database/1").reply(200, database);
+  nock(location.origin).get("/api/database/1").reply(200, database);
 
   renderWithProviders(<InfoText result={result} />);
 }

--- a/frontend/test/metabase/admin/tasks/containers/Logs.unit.spec.js
+++ b/frontend/test/metabase/admin/tasks/containers/Logs.unit.spec.js
@@ -11,7 +11,7 @@ describe("Logs", () => {
 
     it("should call UtilApi.logs after 1 second", () => {
       jest.useFakeTimers();
-      nock(/.*/).get("/api/util/logs").reply(200, []);
+      nock(location.origin).get("/api/util/logs").reply(200, []);
       render(<Logs />);
       const utilSpy = jest.spyOn(UtilApi, "logs");
 

--- a/frontend/test/metabase/containers/SaveQuestionModal.unit.spec.js
+++ b/frontend/test/metabase/containers/SaveQuestionModal.unit.spec.js
@@ -150,8 +150,10 @@ describe("SaveQuestionModal", () => {
   ];
 
   beforeEach(() => {
-    nock(/.*/).get("/api/collection").reply(200, TEST_COLLECTIONS);
-    nock(/.*/).get("/api/collection/root").reply(200, TEST_COLLECTIONS);
+    nock(location.origin).get("/api/collection").reply(200, TEST_COLLECTIONS);
+    nock(location.origin)
+      .get("/api/collection/root")
+      .reply(200, TEST_COLLECTIONS);
   });
 
   afterEach(() => {

--- a/frontend/test/metabase/entities/databases.unit.spec.js
+++ b/frontend/test/metabase/entities/databases.unit.spec.js
@@ -15,7 +15,7 @@ describe("database entity", () => {
   });
 
   it("should save database metadata in redux", async () => {
-    nock(/.*/)
+    nock(location.origin)
       .get("/api/database/123/metadata")
       .reply(200, {
         id: 123,

--- a/frontend/test/metabase/entities/schemas.unit.spec.js
+++ b/frontend/test/metabase/entities/schemas.unit.spec.js
@@ -17,7 +17,7 @@ describe("schema entity", () => {
   });
 
   it("should save metadata from fetching a schema's tables", async () => {
-    nock(/.*/)
+    nock(location.origin)
       .get("/api/database/1/schema/public")
       .reply(200, [
         { id: 123, name: "foo" },
@@ -41,7 +41,9 @@ describe("schema entity", () => {
   });
 
   it("should save metadata from listing schemas", async () => {
-    nock(/.*/).get("/api/database/1/schemas").reply(200, ["foo", "bar"]);
+    nock(location.origin)
+      .get("/api/database/1/schemas")
+      .reply(200, ["foo", "bar"]);
 
     await store.dispatch(Schemas.actions.fetchList({ dbId: "1" }));
     const { schemas } = store.getState().entities;
@@ -52,7 +54,7 @@ describe("schema entity", () => {
   });
 
   it("should handle schema-less databases", async () => {
-    nock(/.*/).get("/api/database/1/schemas").reply(200, [""]);
+    nock(location.origin).get("/api/database/1/schemas").reply(200, [""]);
 
     await store.dispatch(Schemas.actions.fetchList({ dbId: "1" }));
     const { schemas } = store.getState().entities;
@@ -60,7 +62,7 @@ describe("schema entity", () => {
   });
 
   it("should fetch schema tables for a schema-less database", async () => {
-    nock(/.*/)
+    nock(location.origin)
       .get("/api/database/1/schema/")
       .reply(200, [
         { id: 123, name: "foo" },

--- a/frontend/test/metabase/lib/api.unit.spec.js
+++ b/frontend/test/metabase/lib/api.unit.spec.js
@@ -10,7 +10,7 @@ describe("api", () => {
   const successResponse = { status: "ok" };
 
   it("should GET", async () => {
-    nock(/.*/).get("/hello").reply(200, successResponse);
+    nock(location.origin).get("/hello").reply(200, successResponse);
     const hello = GET("/hello");
     const response = await hello();
     expect(response).toEqual({ status: "ok" });
@@ -18,7 +18,7 @@ describe("api", () => {
 
   it("GET should throw on 503 with no retry", async () => {
     expect.assertions(1);
-    nock(/.*/).get("/hello").reply(503);
+    nock(location.origin).get("/hello").reply(503);
     const hello = GET("/hello", { retry: false });
     try {
       await hello();
@@ -28,7 +28,7 @@ describe("api", () => {
   });
 
   it("should POST", async () => {
-    nock(/.*/).post("/hello").reply(200, successResponse);
+    nock(location.origin).post("/hello").reply(200, successResponse);
     const hello = POST("/hello");
     const response = await hello();
     expect(response).toEqual({ status: "ok" });
@@ -36,7 +36,7 @@ describe("api", () => {
 
   it("should PUT with remaining params as body", async () => {
     expect.assertions(1);
-    nock(/.*/)
+    nock(location.origin)
       .put("/hello/123")
       .reply(201, (uri, body) => {
         expect(body).toEqual({ other: "stuff" });
@@ -46,7 +46,7 @@ describe("api", () => {
 
   it("should PUT with a specific params as the body", async () => {
     expect.assertions(1);
-    nock(/.*/)
+    nock(location.origin)
       .put("/hello/123")
       .reply(201, (uri, body) => {
         expect(body).toEqual(["i", "am", "an", "array"]);
@@ -59,7 +59,7 @@ describe("api", () => {
 
   it("POST should throw on 503 with no retry", async () => {
     expect.assertions(1);
-    nock(/.*/).post("/hello").reply(503);
+    nock(location.origin).post("/hello").reply(503);
     const hello = POST("/hello", { retry: false });
     try {
       await hello({ data: "here" });
@@ -70,8 +70,8 @@ describe("api", () => {
 
   it("GET should retry and succeed if 503 then 200", async () => {
     expect.assertions(1);
-    nock(/.*/).get("/hello").reply(503);
-    nock(/.*/).get("/hello").reply(200, successResponse);
+    nock(location.origin).get("/hello").reply(503);
+    nock(location.origin).get("/hello").reply(200, successResponse);
     const hello = GET("/hello", { retry: true });
     const response = await hello();
     expect(response).toEqual({ status: "ok" });
@@ -84,10 +84,10 @@ describe("api", () => {
 
   it("GET should fail if after retryCount it still returns 503", async () => {
     expect.assertions(1);
-    nock(/.*/).get("/hello").reply(503);
-    nock(/.*/).get("/hello").reply(503);
-    nock(/.*/).get("/hello").reply(503);
-    nock(/.*/).get("/hello").reply(503);
+    nock(location.origin).get("/hello").reply(503);
+    nock(location.origin).get("/hello").reply(503);
+    nock(location.origin).get("/hello").reply(503);
+    nock(location.origin).get("/hello").reply(503);
     const limitedRetryGET = api._makeMethod("GET", RETRY_THREE_TIMES);
     const hello = limitedRetryGET("/hello", { retry: true });
     try {
@@ -99,10 +99,10 @@ describe("api", () => {
 
   it("GET should succeed if the last attempt succeeds", async () => {
     expect.assertions(1);
-    nock(/.*/).get("/hello").reply(503);
-    nock(/.*/).get("/hello").reply(503);
-    nock(/.*/).get("/hello").reply(503);
-    nock(/.*/).get("/hello").reply(200, successResponse);
+    nock(location.origin).get("/hello").reply(503);
+    nock(location.origin).get("/hello").reply(503);
+    nock(location.origin).get("/hello").reply(503);
+    nock(location.origin).get("/hello").reply(200, successResponse);
     const limitedRetryGET = api._makeMethod("GET", RETRY_THREE_TIMES);
     const hello = limitedRetryGET("/hello", { retry: true });
     const response = await hello();
@@ -111,7 +111,7 @@ describe("api", () => {
 
   it("should use _status from body when HTTP status is 202", async () => {
     expect.assertions(2);
-    nock(/.*/)
+    nock(location.origin)
       .get("/async-status")
       .reply(202, { _status: 400, message: "error message" });
     const asyncStatus = GET("/async-status");

--- a/frontend/test/metabase/query_builder/components/DataSelector.unit.spec.js
+++ b/frontend/test/metabase/query_builder/components/DataSelector.unit.spec.js
@@ -20,7 +20,7 @@ import { UnconnectedDataSelector as DataSelector } from "metabase/query_builder/
 
 describe("DataSelector", () => {
   beforeEach(() => {
-    nock(/.*/)
+    nock(location.origin)
       .get("/api/search?models=dataset&limit=1")
       .reply(200, {
         data: [],


### PR DESCRIPTION
Epic https://github.com/metabase/metabase/issues/26960
Follow up on https://github.com/metabase/metabase/pull/27337

Cleans up `nock` usage. Instead of passing a regex to match arbitrary location, let's make it more clear that we are working with the current origin.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/27352)
<!-- Reviewable:end -->
