### PR TITLE
Fixing two double thens

### DIFF
--- a/src/metabase/server/middleware/auth.clj
+++ b/src/metabase/server/middleware/auth.clj
@@ -21,7 +21,7 @@
 
 (defn wrap-api-key
   "Middleware that sets the `:metabase-api-key` keyword on the request if a valid API Key can be found. We check the
-  request headers for `X-METABASE-APIKEY` and if it's not found then then no keyword is bound to the request."
+  request headers for `X-METABASE-APIKEY` and if it's not found then no keyword is bound to the request."
   [handler]
   (fn [request respond raise]
     (handler (wrap-api-key* request) respond raise)))

--- a/src/metabase/server/middleware/session.clj
+++ b/src/metabase/server/middleware/session.clj
@@ -205,7 +205,7 @@
 (defn wrap-session-id
   "Middleware that sets the `:metabase-session-id` keyword on the request if a session id can be found.
   We first check the request :cookies for `metabase.SESSION`, then if no cookie is found we look in the http headers
-  for `X-METABASE-SESSION`. If neither is found then then no keyword is bound to the request."
+  for `X-METABASE-SESSION`. If neither is found then no keyword is bound to the request."
   [handler]
   (fn [request respond raise]
     (let [request (or (wrap-session-id-with-strategy :best request)


### PR DESCRIPTION
Only minor documentation fixes to fix two double-thens.