### PR TITLE
Ensuring _raw prop is present on transformed series in line/area/bar …

### DIFF
--- a/frontend/src/metabase-types/api/mocks/card.ts
+++ b/frontend/src/metabase-types/api/mocks/card.ts
@@ -3,6 +3,7 @@ import {
   Card,
   UnsavedCard,
   VisualizationSettings,
+  SeriesOrderSetting,
 } from "metabase-types/api";
 import { createMockStructuredDatasetQuery } from "./query";
 
@@ -34,6 +35,18 @@ export const createMockUnsavedCard = (
 export const createMockVisualizationSettings = (
   opts?: Partial<VisualizationSettings>,
 ): VisualizationSettings => ({
+  ...opts,
+});
+
+export const createMockSeriesOrderSetting = ({
+  name = "",
+  key,
+  enabled = true,
+  ...opts
+}: Partial<SeriesOrderSetting>): SeriesOrderSetting => ({
+  name,
+  key: key || name,
+  enabled,
   ...opts,
 });
 

--- a/frontend/src/metabase-types/api/mocks/dataset.ts
+++ b/frontend/src/metabase-types/api/mocks/dataset.ts
@@ -13,7 +13,7 @@ export const createMockColumn = (data: Partial<DatasetColumn>) => {
   };
 };
 
-type MockDatasetOpts = Partial<Omit<Dataset, "data">> & {
+export type MockDatasetOpts = Partial<Omit<Dataset, "data">> & {
   data?: Partial<DatasetData>;
 };
 

--- a/frontend/src/metabase-types/api/mocks/series.ts
+++ b/frontend/src/metabase-types/api/mocks/series.ts
@@ -1,0 +1,18 @@
+import { SingleSeries, Series } from "../dataset";
+import { Card } from "../card";
+import { createMockCard } from "./card";
+import { createMockDataset, MockDatasetOpts } from "./dataset";
+
+export const createMockSingleSeries = (
+  cardOpts: Partial<Card>,
+  dataOpts: MockDatasetOpts = {},
+): SingleSeries => {
+  return {
+    card: createMockCard(cardOpts),
+    data: createMockDataset(dataOpts).data,
+  };
+};
+
+export const createMockSeries = (opts: { name: string }[]): Series => {
+  return opts.map(opt => createMockSingleSeries({ name: opt.name }));
+};

--- a/frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx
+++ b/frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx
@@ -20,7 +20,7 @@ import {
   validateDatasetRows,
   validateStacking,
 } from "metabase/visualizations/lib/settings/validation";
-import { findSeriesByKey } from "metabase/visualizations/lib/series";
+import { getOrderedSeries } from "metabase/visualizations/lib/series";
 import { getAccentColors } from "metabase/lib/colors/groups";
 import {
   isNumeric,
@@ -349,12 +349,7 @@ export default class LineAreaBarChart extends Component {
       settings,
     } = this.props;
 
-    const orderedSeries =
-      (settings["graph.dimensions"]?.length > 1 &&
-        settings["graph.series_order"]
-          ?.filter(orderedItem => orderedItem.enabled)
-          .map(orderedItem => findSeriesByKey(series, orderedItem.key))) ||
-      series;
+    const orderedSeries = getOrderedSeries(series, settings);
 
     const {
       title,

--- a/frontend/src/metabase/visualizations/lib/series.ts
+++ b/frontend/src/metabase/visualizations/lib/series.ts
@@ -1,6 +1,7 @@
 import { assocIn } from "icepick";
 import { VisualizationSettings } from "metabase-types/api/card";
-import { Series } from "metabase-types/types/Visualization";
+import { Series, TransformedSeries } from "metabase-types/api/dataset";
+import { isNotNull } from "metabase/core/utils/types";
 import { SETTING_ID, keyForSingleSeries } from "./settings/series";
 
 export const updateSeriesColor = (
@@ -13,4 +14,30 @@ export const updateSeriesColor = (
 
 export const findSeriesByKey = (series: Series, key: string) => {
   return series.find(singleSeries => keyForSingleSeries(singleSeries) === key);
+};
+
+export const getOrderedSeries = (
+  series: Series,
+  settings: VisualizationSettings,
+) => {
+  if (
+    (settings["graph.dimensions"] &&
+      settings["graph.dimensions"].length <= 1) ||
+    !settings["graph.series_order"]
+  ) {
+    return series;
+  }
+
+  const orderedSeries = settings["graph.series_order"]
+    ?.filter(orderedItem => orderedItem.enabled)
+    .map(orderedItem => findSeriesByKey(series, orderedItem.key))
+    .filter(isNotNull);
+
+  if ("_raw" in series) {
+    const transformedOrderedSeries = [...orderedSeries] as TransformedSeries;
+    transformedOrderedSeries._raw = series._raw;
+    return transformedOrderedSeries;
+  }
+
+  return orderedSeries;
 };

--- a/frontend/src/metabase/visualizations/lib/series.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/lib/series.unit.spec.ts
@@ -1,0 +1,66 @@
+import _ from "underscore";
+
+import { createMockSeries } from "metabase-types/api/mocks/series";
+import {
+  createMockSeriesOrderSetting,
+  createMockVisualizationSettings,
+} from "metabase-types/api/mocks/card";
+import { TransformedSeries } from "metabase-types/api";
+import { getOrderedSeries } from "./series";
+
+type setupSeriesOpts = { name: string; enabled?: boolean }[];
+
+const setupSeries = (opts: setupSeriesOpts) => ({
+  series: createMockSeries(opts),
+  settings: createMockVisualizationSettings({
+    "graph.dimensions": ["one", "two"],
+    "graph.series_order": opts.map(opt => createMockSeriesOrderSetting(opt)),
+  }),
+});
+
+describe("series utils", () => {
+  describe("getOrderedSeries", () => {
+    it("should reorder the series", () => {
+      const { series, settings } = setupSeries([
+        { name: "foo" },
+        { name: "bar" },
+      ]);
+
+      const sortedSettings = {
+        ...settings,
+        "graph.series_order":
+          settings["graph.series_order"] &&
+          _.sortBy(settings["graph.series_order"], "name"),
+      };
+
+      const orderedSeries = getOrderedSeries(series, sortedSettings);
+      expect(orderedSeries).toHaveLength(2);
+
+      expect(orderedSeries[0].card.name).toBe("bar");
+      expect(orderedSeries[1].card.name).toBe("foo");
+    });
+
+    it("should filter hidden series", () => {
+      const { series, settings } = setupSeries([
+        { name: "foo" },
+        { name: "bar", enabled: false },
+      ]);
+
+      const orderedSeries = getOrderedSeries(series, settings);
+      expect(orderedSeries).toHaveLength(1);
+    });
+
+    it("should preserve _raw prop if present", () => {
+      const { series, settings } = setupSeries([
+        { name: "foo" },
+        { name: "bar", enabled: false },
+      ]);
+
+      const transformedSeries = [...series] as TransformedSeries;
+      transformedSeries._raw = createMockSeries([{ name: "foobar" }]);
+
+      const orderedSeries = getOrderedSeries(transformedSeries, settings);
+      expect(orderedSeries).toHaveProperty("_raw");
+    });
+  });
+});

--- a/frontend/test/metabase/scenarios/visualizations/reproductions/27279-sorting-does-not-apply-to-x-axis.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/reproductions/27279-sorting-does-not-apply-to-x-axis.cy.spec.js
@@ -14,7 +14,7 @@ const questionDetails = {
   },
 };
 
-describe.skip("issue 27279", () => {
+describe("issue 27279", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();


### PR DESCRIPTION
…charts

Fixes #27063 
Fixes #27279 

Small fix (and accompanying tests) to ensure that the `_raw` prop is included after ordering a series. Stripping it causes some functions that are passed a series to assume the series *is* the raw series, which can lead to things like not being able to find the `result_timezone` (issue with 27063) and not properly ordering data (issue with 27279).
