### PR TITLE
[Add ability to hide individual events in viz] Variation: show and hide all events when toggling timeline visibility

### DIFF
--- a/frontend/src/metabase/query_builder/components/view/sidebars/TimelineSidebar/TimelineSidebar.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/TimelineSidebar/TimelineSidebar.tsx
@@ -16,7 +16,7 @@ export interface TimelineSidebarProps {
   xDomain?: [Moment, Moment];
   onShowTimelines?: (timelines: Timeline[]) => void;
   onHideTimelines?: (timelines: Timeline[]) => void;
-  onShowTimelineEvent: (timelineEvent: TimelineEvent) => void;
+  onShowTimelineEvent: (timelineEvent: TimelineEvent | TimelineEvent[]) => void;
   onHideTimelineEvent: (timelineEvent: TimelineEvent) => void;
   onSelectTimelineEvents?: (timelineEvents: TimelineEvent[]) => void;
   onDeselectTimelineEvents?: () => void;
@@ -84,11 +84,12 @@ const TimelineSidebar = ({
     (timeline: Timeline, isVisible: boolean) => {
       if (isVisible) {
         onShowTimelines?.([timeline]);
+        timeline.events && onShowTimelineEvent(timeline.events);
       } else {
         onHideTimelines?.([timeline]);
       }
     },
-    [onShowTimelines, onHideTimelines],
+    [onShowTimelines, onHideTimelines, onShowTimelineEvent],
   );
 
   return (

--- a/frontend/src/metabase/query_builder/reducers.js
+++ b/frontend/src/metabase/query_builder/reducers.js
@@ -576,7 +576,13 @@ export const visibleTimelineEventIds = handleActions(
         state.filter(item => item !== event.id),
     },
     [SHOW_TIMELINE_EVENT]: {
-      next: (state, { payload: event }) => [...state, event.id],
+      next: (state, { payload: events }) => {
+        if (Array.isArray(events)) {
+          return _.uniq([...state, ...events.map(event => event.id)]);
+        } else {
+          return [...state, event.id];
+        }
+      },
     },
     [RESET_QB]: { next: () => [] },
   },

--- a/frontend/src/metabase/timelines/questions/components/TimelineCard/TimelineCard.tsx
+++ b/frontend/src/metabase/timelines/questions/components/TimelineCard/TimelineCard.tsx
@@ -51,6 +51,9 @@ const TimelineCard = ({
   const events = getEvents(timeline.events);
   const isEventSelected = events.some(e => selectedEventIds.includes(e.id));
   const [isExpanded, setIsExpanded] = useState(isDefault || isEventSelected);
+  const allEventsVisible = events.every(event =>
+    visibleEventIds.includes(event.id),
+  );
 
   const handleHeaderClick = useCallback(() => {
     setIsExpanded(isExpanded => !isExpanded);
@@ -81,6 +84,7 @@ const TimelineCard = ({
       >
         <CardCheckbox
           checked={isVisible}
+          indeterminate={isVisible && !allEventsVisible}
           onClick={handleCheckboxClick}
           onChange={handleToggleTimeline}
         />


### PR DESCRIPTION
In https://github.com/metabase/metabase/pull/27254, atm the visible events in a timeline stay in memory.
Imagine a timeline with dozens of events, where a user has spent time selecting exactly which events should be visible.
Then she wants to quickly hide the entire timeline but not lose the choices when showing the timeline again.

In this variation, we show and hide all events when toggling their timeline's visibility.
It's simple but maybe more blunt for people who need the granularity of individual event visibility in the first place.