### PR TITLE
[Add ability to hide individual events in viz] Variation: eye buttons

### DIFF
--- a/frontend/src/metabase/timelines/questions/components/EventCard/EventCard.styled.tsx
+++ b/frontend/src/metabase/timelines/questions/components/EventCard/EventCard.styled.tsx
@@ -9,7 +9,7 @@ export interface CardRootProps {
 
 export const CardRoot = styled.div<CardRootProps>`
   display: flex;
-  padding: 0.25rem 0.75rem;
+  padding: 0.25rem 1rem 0.25rem 1.25rem;
   border-left: 0.25rem solid
     ${props => (props.isSelected ? color("brand") : "transparent")};
   background-color: ${props =>

--- a/frontend/src/metabase/timelines/questions/components/EventCard/EventCard.tsx
+++ b/frontend/src/metabase/timelines/questions/components/EventCard/EventCard.tsx
@@ -6,6 +6,9 @@ import { parseTimestamp } from "metabase/lib/time";
 import { formatDateTimeWithUnit } from "metabase/lib/formatting";
 import EntityMenu from "metabase/components/EntityMenu";
 import Checkbox from "metabase/core/components/CheckBox/CheckBox";
+import IconButtonWrapper from "metabase/components/IconButtonWrapper";
+import Icon from "metabase/components/Icon";
+
 import { useScrollOnMount } from "metabase/hooks/use-scroll-on-mount";
 import {
   CardAside,
@@ -76,11 +79,16 @@ const EventCard = ({
       onClick={handleToggleSelected}
     >
       <CardCheckboxContainer>
-        <Checkbox
-          checked={isTimelineVisible && isVisible}
-          disabled={!isTimelineVisible}
+        <IconButtonWrapper
           onClick={handleChangeVisibility}
-        />
+          style={{ opacity: isTimelineVisible && isVisible ? 0.6 : 0.3 }}
+        >
+          <Icon
+            name={
+              isTimelineVisible && isVisible ? "eye_outline" : "eye_crossed_out"
+            }
+          />
+        </IconButtonWrapper>
       </CardCheckboxContainer>
       <CardBody>
         <CardIconAndDateContainer>

--- a/frontend/src/metabase/timelines/questions/components/TimelineCard/TimelineCard.tsx
+++ b/frontend/src/metabase/timelines/questions/components/TimelineCard/TimelineCard.tsx
@@ -51,6 +51,9 @@ const TimelineCard = ({
   const events = getEvents(timeline.events);
   const isEventSelected = events.some(e => selectedEventIds.includes(e.id));
   const [isExpanded, setIsExpanded] = useState(isDefault || isEventSelected);
+  const allEventsVisible = events.every(event =>
+    visibleEventIds.includes(event.id),
+  );
 
   const handleHeaderClick = useCallback(() => {
     setIsExpanded(isExpanded => !isExpanded);
@@ -81,6 +84,7 @@ const TimelineCard = ({
       >
         <CardCheckbox
           checked={isVisible}
+          indeterminate={isVisible && !allEventsVisible}
           onClick={handleCheckboxClick}
           onChange={handleToggleTimeline}
         />

--- a/frontend/src/metabase/timelines/questions/components/TimelineCard/TimelineCard.tsx
+++ b/frontend/src/metabase/timelines/questions/components/TimelineCard/TimelineCard.tsx
@@ -11,6 +11,8 @@ import _ from "underscore";
 import { Timeline, TimelineEvent } from "metabase-types/api";
 import { getTimelineName } from "metabase/lib/timelines";
 import Ellipsified from "metabase/core/components/Ellipsified";
+import IconButtonWrapper from "metabase/components/IconButtonWrapper";
+import Icon from "metabase/components/Icon";
 import EventCard from "../EventCard";
 import {
   CardHeader,
@@ -59,9 +61,13 @@ const TimelineCard = ({
     setIsExpanded(isExpanded => !isExpanded);
   }, []);
 
-  const handleCheckboxClick = useCallback((event: MouseEvent) => {
-    event.stopPropagation();
-  }, []);
+  const handleCheckboxClick = useCallback(
+    (event: MouseEvent) => {
+      event.stopPropagation();
+      onToggleTimeline?.(timeline, !isVisible);
+    },
+    [timeline, isVisible, onToggleTimeline],
+  );
 
   const handleToggleTimeline = useCallback(
     (event: ChangeEvent<HTMLInputElement>) => {
@@ -82,12 +88,13 @@ const TimelineCard = ({
         onClick={handleHeaderClick}
         aria-label={t`Timeline card header`}
       >
-        <CardCheckbox
-          checked={isVisible}
-          indeterminate={isVisible && !allEventsVisible}
+        <IconButtonWrapper
           onClick={handleCheckboxClick}
-          onChange={handleToggleTimeline}
-        />
+          style={{ opacity: isVisible ? 0.6 : 0.3 }}
+        >
+          <Icon name={isVisible ? "eye_outline" : "eye_crossed_out"} />
+        </IconButtonWrapper>
+
         <CardLabel>
           <Ellipsified tooltipMaxWidth="100%">
             {getTimelineName(timeline)}


### PR DESCRIPTION
This variation uses eye icons instead of checkboxes to toggle timeline and event visibility.

This is a rough direction.
We could think about placing the eye button to the right, so that events' icons show up a bit more...and other small ideas.

<img width="800" alt="image" src="https://user-images.githubusercontent.com/380816/208793087-dcb8b6df-a446-47c1-97bf-d1884667c061.png">
