### PR TITLE
Add model actions section to database admin page sidebar

### DIFF
--- a/frontend/src/metabase-lib/metadata/Database.ts
+++ b/frontend/src/metabase-lib/metadata/Database.ts
@@ -1,6 +1,6 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
-import { NativePermissions } from "metabase-types/api";
+import { Database as IDatabase, NativePermissions } from "metabase-types/api";
 import { generateSchemaId } from "metabase-lib/metadata/utils/schema";
 import { createLookupByProperty, memoizeClass } from "metabase-lib/utils";
 import Question from "../Question";
@@ -30,6 +30,10 @@ class DatabaseInner extends Base {
 
   // Only appears in  GET /api/database/:id
   "can-manage"?: boolean;
+
+  getPlainObject(): IDatabase {
+    return this._plainObject;
+  }
 
   // TODO Atte Keinänen 6/11/17: List all fields here (currently only in types/Database)
   displayName() {

--- a/frontend/src/metabase-types/api/database.ts
+++ b/frontend/src/metabase-types/api/database.ts
@@ -7,9 +7,11 @@ export type InitialSyncStatus = "incomplete" | "complete" | "aborted";
 
 export type DatabaseSettings = {
   [key: string]: any;
+  "database-enable-actions"?: boolean;
 };
 
 export type DatabaseFeature =
+  | "actions"
   | "basic-aggregations"
   | "binning"
   | "case-sensitivity-string-filter-options"

--- a/frontend/src/metabase-types/api/mocks/database.ts
+++ b/frontend/src/metabase-types/api/mocks/database.ts
@@ -1,6 +1,7 @@
 import { Database, DatabaseData, DatabaseFeature } from "metabase-types/api";
 
 export const COMMON_DATABASE_FEATURES: DatabaseFeature[] = [
+  "actions",
   "basic-aggregations",
   "binning",
   "case-sensitivity-string-filter-options",

--- a/frontend/src/metabase/actions/utils.ts
+++ b/frontend/src/metabase/actions/utils.ts
@@ -1,0 +1,8 @@
+import type { Database as IDatabase } from "metabase-types/api";
+import type Database from "metabase-lib/metadata/Database";
+
+export const checkDatabaseSupportsActions = (database: Database) =>
+  database.hasFeature("actions");
+
+export const checkDatabaseActionsEnabled = (database: IDatabase) =>
+  !!database.settings?.["database-enable-actions"];

--- a/frontend/src/metabase/actions/utils.ts
+++ b/frontend/src/metabase/actions/utils.ts
@@ -1,8 +1,7 @@
-import type { Database as IDatabase } from "metabase-types/api";
-import type Database from "metabase-lib/metadata/Database";
+import type { Database } from "metabase-types/api";
 
 export const checkDatabaseSupportsActions = (database: Database) =>
-  database.hasFeature("actions");
+  database.features.includes("actions");
 
-export const checkDatabaseActionsEnabled = (database: IDatabase) =>
+export const checkDatabaseActionsEnabled = (database: Database) =>
   !!database.settings?.["database-enable-actions"];

--- a/frontend/src/metabase/admin/databases/components/DatabaseEditApp/Sidebar/ModelActionsSection/ModelActionsSection.styled.tsx
+++ b/frontend/src/metabase/admin/databases/components/DatabaseEditApp/Sidebar/ModelActionsSection/ModelActionsSection.styled.tsx
@@ -1,0 +1,24 @@
+import styled from "@emotion/styled";
+import { color } from "metabase/lib/colors";
+
+export const ToggleContainer = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+`;
+
+export const Label = styled.label`
+  width: 100%;
+  cursor: pointer;
+
+  color: ${color("text-medium")};
+  font-weight: 700;
+`;
+
+export const Description = styled.p`
+  margin-top: 24px;
+
+  color: ${color("text-medium")};
+  line-height: 22px;
+`;

--- a/frontend/src/metabase/admin/databases/components/DatabaseEditApp/Sidebar/ModelActionsSection/ModelActionsSection.tsx
+++ b/frontend/src/metabase/admin/databases/components/DatabaseEditApp/Sidebar/ModelActionsSection/ModelActionsSection.tsx
@@ -10,13 +10,13 @@ import {
 } from "./ModelActionsSection.styled";
 
 interface ModelActionsSectionProps {
-  hasActionsEnabled: boolean;
-  onToggleActionsEnabled: (enabled: boolean) => void;
+  hasModelActionsEnabled: boolean;
+  onToggleModelActionsEnabled: (enabled: boolean) => void;
 }
 
 function ModelActionsSection({
-  hasActionsEnabled,
-  onToggleActionsEnabled,
+  hasModelActionsEnabled,
+  onToggleModelActionsEnabled,
 }: ModelActionsSectionProps) {
   return (
     <div>
@@ -24,8 +24,8 @@ function ModelActionsSection({
         <Label htmlFor="model-actions-toggle">{t`Model actions`}</Label>
         <Toggle
           id="model-actions-toggle"
-          value={hasActionsEnabled}
-          onChange={onToggleActionsEnabled}
+          value={hasModelActionsEnabled}
+          onChange={onToggleModelActionsEnabled}
         />
       </ToggleContainer>
       <Description>{t`Allow actions from models created from this data to be run. Actions are able to read, write, and possibly delete data.`}</Description>

--- a/frontend/src/metabase/admin/databases/components/DatabaseEditApp/Sidebar/ModelActionsSection/ModelActionsSection.tsx
+++ b/frontend/src/metabase/admin/databases/components/DatabaseEditApp/Sidebar/ModelActionsSection/ModelActionsSection.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+import { t } from "ttag";
+
+import Toggle from "metabase/core/components/Toggle";
+
+import {
+  ToggleContainer,
+  Label,
+  Description,
+} from "./ModelActionsSection.styled";
+
+interface ModelActionsSectionProps {
+  hasActionsEnabled: boolean;
+  onToggleActionsEnabled: (enabled: boolean) => void;
+}
+
+function ModelActionsSection({
+  hasActionsEnabled,
+  onToggleActionsEnabled,
+}: ModelActionsSectionProps) {
+  return (
+    <div>
+      <ToggleContainer>
+        <Label htmlFor="model-actions-toggle">{t`Model actions`}</Label>
+        <Toggle
+          id="model-actions-toggle"
+          value={hasActionsEnabled}
+          onChange={onToggleActionsEnabled}
+        />
+      </ToggleContainer>
+      <Description>{t`Allow actions from models created from this data to be run. Actions are able to read, write, and possibly delete data.`}</Description>
+      <Description>{t`Note: Your database user will need write permissions.`}</Description>
+    </div>
+  );
+}
+
+export default ModelActionsSection;

--- a/frontend/src/metabase/admin/databases/components/DatabaseEditApp/Sidebar/ModelActionsSection/index.ts
+++ b/frontend/src/metabase/admin/databases/components/DatabaseEditApp/Sidebar/ModelActionsSection/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ModelActionsSection";

--- a/frontend/src/metabase/admin/databases/components/DatabaseEditApp/Sidebar/Sidebar.styled.tsx
+++ b/frontend/src/metabase/admin/databases/components/DatabaseEditApp/Sidebar/Sidebar.styled.tsx
@@ -46,3 +46,7 @@ export const SidebarContent = styled.div`
     margin-bottom: 0;
   }
 `;
+
+export const ModelActionsSidebarContent = styled(SidebarContent)`
+  margin-top: 32px;
+`;

--- a/frontend/src/metabase/admin/databases/components/DatabaseEditApp/Sidebar/Sidebar.tsx
+++ b/frontend/src/metabase/admin/databases/components/DatabaseEditApp/Sidebar/Sidebar.tsx
@@ -51,28 +51,28 @@ const DatabaseEditAppSidebar = ({
   const discardSavedFieldValuesModal = useRef<any>();
   const deleteDatabaseModal = useRef<any>();
 
-  const databaseObject = database.getPlainObject();
-  const isNewDatabase = !databaseObject.id;
+  const isEditingDatabase = !!database.id;
 
   const isSynced = isSyncCompleted(database);
   const hasModelActionsSection =
-    !isNewDatabase && checkDatabaseSupportsActions(database);
+    isEditingDatabase &&
+    checkDatabaseSupportsActions(database.getPlainObject());
   const hasModelCachingSection =
     isModelPersistenceEnabled && database.supportsPersistence();
 
   const handleSyncDatabaseSchema = useCallback(
     () => syncDatabaseSchema(database.id),
-    [database, syncDatabaseSchema],
+    [database.id, syncDatabaseSchema],
   );
 
   const handleReScanFieldValues = useCallback(
     () => rescanDatabaseFields(database.id),
-    [database, rescanDatabaseFields],
+    [database.id, rescanDatabaseFields],
   );
 
   const handleDismissSyncSpinner = useCallback(
     () => dismissSyncSpinner(database.id),
-    [database, dismissSyncSpinner],
+    [database.id, dismissSyncSpinner],
   );
 
   const handleToggleModelActionsEnabled = useCallback(
@@ -81,17 +81,17 @@ const DatabaseEditAppSidebar = ({
         id: database.id,
         settings: { "database-enable-actions": nextValue },
       }),
-    [database, updateDatabase],
+    [database.id, updateDatabase],
   );
 
   const handleDiscardSavedFieldValues = useCallback(
     () => discardSavedFieldValues(database.id),
-    [database, discardSavedFieldValues],
+    [database.id, discardSavedFieldValues],
   );
 
   const handleDeleteDatabase = useCallback(
     () => deleteDatabase(database.id, true),
-    [database, deleteDatabase],
+    [database.id, deleteDatabase],
   );
 
   const handleSavedFieldsModalClose = useCallback(() => {
@@ -190,8 +190,10 @@ const DatabaseEditAppSidebar = ({
       {hasModelActionsSection && (
         <ModelActionsSidebarContent>
           <ModelActionsSection
-            hasActionsEnabled={checkDatabaseActionsEnabled(databaseObject)}
-            onToggleActionsEnabled={handleToggleModelActionsEnabled}
+            hasModelActionsEnabled={checkDatabaseActionsEnabled(
+              database.getPlainObject(),
+            )}
+            onToggleModelActionsEnabled={handleToggleModelActionsEnabled}
           />
         </ModelActionsSidebarContent>
       )}

--- a/frontend/src/metabase/admin/databases/components/DatabaseEditApp/Sidebar/Sidebar.unit.spec.tsx
+++ b/frontend/src/metabase/admin/databases/components/DatabaseEditApp/Sidebar/Sidebar.unit.spec.tsx
@@ -163,6 +163,75 @@ describe("DatabaseEditApp/Sidebar", () => {
     });
   });
 
+  describe("model actions control", () => {
+    it("is shown if database supports actions", () => {
+      setup();
+      expect(screen.getByLabelText(/Model actions/i)).toBeInTheDocument();
+    });
+
+    it("is shown for non-admin users", () => {
+      setup({ isAdmin: false });
+      expect(screen.getByLabelText(/Model actions/i)).toBeInTheDocument();
+    });
+
+    it("shows if actions are enabled", () => {
+      setup({
+        database: createMockDatabase({
+          settings: { "database-enable-actions": true },
+        }),
+      });
+
+      expect(screen.getByLabelText(/Model actions/i)).toBeChecked();
+    });
+
+    it("shows if actions are disabled", () => {
+      setup({
+        database: createMockDatabase({
+          settings: { "database-enable-actions": false },
+        }),
+      });
+
+      expect(screen.getByLabelText(/Model actions/i)).not.toBeChecked();
+    });
+
+    it("isn't shown if database doesn't support actions", () => {
+      const features = _.without(COMMON_DATABASE_FEATURES, "actions");
+      setup({ database: createMockDatabase({ features }) });
+
+      expect(screen.queryByText(/Model actions/i)).not.toBeInTheDocument();
+    });
+
+    it("isn't shown when adding a new database", () => {
+      setup({ database: createMockDatabase({ id: undefined }) });
+      expect(screen.queryByText(/Model actions/i)).not.toBeInTheDocument();
+    });
+
+    it("enables actions", () => {
+      const { database, updateDatabase } = setup();
+
+      userEvent.click(screen.getByLabelText(/Model actions/i));
+
+      expect(updateDatabase).toBeCalledWith({
+        id: database.id,
+        settings: { "database-enable-actions": true },
+      });
+    });
+
+    it("disables actions", () => {
+      const database = createMockDatabase({
+        settings: { "database-enable-actions": true },
+      });
+      const { updateDatabase } = setup({ database });
+
+      userEvent.click(screen.getByLabelText(/Model actions/i));
+
+      expect(updateDatabase).toBeCalledWith({
+        id: database.id,
+        settings: { "database-enable-actions": false },
+      });
+    });
+  });
+
   describe("model caching control", () => {
     it("isn't shown if model caching is turned off globally", () => {
       setup({ isModelPersistenceEnabled: false });


### PR DESCRIPTION
Epic #27281

Partially cherry-picks FE code letting people enable/disable actions per database. It's not just a cherry-pick though — the PR introduces a different UI and adds unit tests.

### To Verify

1. Sign in as admin and go to `/admin/databases`
2. Open your sample database and ensure you can see the "Model actions" section below the actions sidebar
3. Ensure you can turn actions on/off
4. Try adding a new Postgres/MySQL database
5. Ensure you don't see the "Model actions" section until the database is connected
6. Once the database is added, ensure you can see the actions section and turn them on/off
7. Ensure you can't see the section for databases that don't support actions (anything except H2, Postgres and MySQL for now)

### Demo

https://user-images.githubusercontent.com/17258145/208928494-ec84dc82-77f7-4227-85a4-4b5d7ed6af35.mp4

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/27367)
<!-- Reviewable:end -->
