### PR TITLE
Fixes to static-viz datetime formatter, in particular, issues #27020 …

### DIFF
--- a/frontend/test/metabase/scenarios/dashboard/reproductions/27020-27105-static-viz-date-formatting-failures.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/reproductions/27020-27105-static-viz-date-formatting-failures.cy.spec.js
@@ -28,7 +28,7 @@ const questionDetails27020 = {
   },
 };
 
-describe.skip("issues 27020 and 27105: static-viz fails to render for certain date formatting options", () => {
+describe("issues 27020 and 27105: static-viz fails to render for certain date formatting options", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();

--- a/src/metabase/pulse/render/datetime.clj
+++ b/src/metabase/pulse/render/datetime.clj
@@ -70,48 +70,60 @@
   ([timezone-id s col] (format-temporal-str timezone-id s col {}))
   ([timezone-id s col viz-settings]
    (Locale/setDefault (Locale. (public-settings/site-locale)))
-   (let [col-viz-settings (viz-settings-for-col col viz-settings)
-         {date-style     :date-style
-          abbreviate     :date-abbreviate
-          date-separator :date-separator
-          time-style     :time-style} (if (seq col-viz-settings)
-                                        (-> col-viz-settings
-                                            (update-keys (comp keyword name)))
-                                        (-> (:type/Temporal (public-settings/custom-formatting))
-                                            (update-keys (fn [k] (-> k name (str/replace #"_" "-") keyword)))))
-         date-style (cond-> date-style
-                      date-separator (str/replace #"/" date-separator)
-                      abbreviate (-> (str/replace #"MMMM" "MMM") (str/replace #"DDD" "D")))]
-     (cond (str/blank? s) ""
+   (cond
+     (str/blank? s) ""
 
-           (isa? (or (:effective_type col) (:base_type col)) :type/Time)
-           (t/format DateTimeFormatter/ISO_LOCAL_TIME (u.date/parse s timezone-id))
+     (isa? (or (:effective_type col) (:base_type col)) :type/Time)
+     (t/format DateTimeFormatter/ISO_LOCAL_TIME (u.date/parse s timezone-id))
 
-           :else
-           (case (:unit col)
-             ;; these types have special formatting
-             :minute  (reformat-temporal-str timezone-id s
-                                             (str (or date-style "MMMM, yyyy") ", "
-                                                  (str/replace (or time-style "h:mm a") #"A" "a")))
-             :hour    (reformat-temporal-str timezone-id s
-                                             (str (or date-style "MMMM, yyyy") ", "
-                                                  (str/replace (or time-style "h a") #"A" "a")))
-             :day     (reformat-temporal-str timezone-id s (or date-style "EEEE, MMMM d, YYYY"))
-             :week    (str (tru "Week ") (reformat-temporal-str timezone-id s "w - YYYY"))
-             :month   (reformat-temporal-str timezone-id s (or date-style "MMMM, yyyy"))
-             :quarter (reformat-temporal-str timezone-id s "QQQ - yyyy")
-             :year    (reformat-temporal-str timezone-id s "YYYY")
+     :else
+     (let [col-viz-settings             (viz-settings-for-col col viz-settings)
+           {date-style     :date-style
+            abbreviate     :date-abbreviate
+            date-separator :date-separator
+            time-style     :time-style} (if (seq col-viz-settings)
+                                          (-> col-viz-settings
+                                              (update-keys (comp keyword name)))
+                                          (-> (:type/Temporal (public-settings/custom-formatting))
+                                              (update-keys (fn [k] (-> k name (str/replace #"_" "-") keyword)))))
+           post-process-date-style      (fn [date-style]
+                                          (cond-> (-> date-style (str/replace #"dddd" "EEEE"))
+                                            date-separator (str/replace #"/" date-separator)
+                                            abbreviate     (-> (str/replace #"MMMM" "MMM")
+                                                               (str/replace #"EEEE" "EEE")
+                                                               (str/replace #"DDD" "D"))))]
+       (case (:unit col)
+         ;; these types have special formatting
+         :minute  (reformat-temporal-str timezone-id s
+                                         (-> (or date-style "MMMM, yyyy")
+                                             (str ", " (str/replace (or time-style "h:mm a") #"A" "a"))
+                                             post-process-date-style))
+         :hour    (reformat-temporal-str timezone-id s
+                                         (-> (or date-style "MMMM, yyyy")
+                                             (str ", " (str/replace (or time-style "h a") #"A" "a"))
+                                             post-process-date-style))
+         :day     (reformat-temporal-str timezone-id s
+                                         (-> (or date-style "EEEE, MMMM d, YYYY")
+                                             post-process-date-style))
+         :week    (str (tru "Week ") (reformat-temporal-str timezone-id s "w - YYYY"))
+         :month   (reformat-temporal-str timezone-id s
+                                         (-> (or date-style "MMMM, yyyy")
+                                             post-process-date-style))
+         :quarter (reformat-temporal-str timezone-id s "QQQ - yyyy")
+         :year    (reformat-temporal-str timezone-id s "YYYY")
 
-             ;; s is just a number as a string here
-             :day-of-week     (day-of-week (parse-long s) abbreviate)
-             :month-of-year   (month-of-year (parse-long s) abbreviate)
-             :quarter-of-year (format "Q%s" s)
-             :hour-of-day     (hour-of-day s (str/replace (or time-style "h a") #"A" "a"))
+         ;; s is just a number as a string here
+         :day-of-week     (day-of-week (parse-long s) abbreviate)
+         :month-of-year   (month-of-year (parse-long s) abbreviate)
+         :quarter-of-year (format "Q%s" s)
+         :hour-of-day     (hour-of-day s (str/replace (or time-style "h a") #"A" "a"))
 
-             (:week-of-year :minute-of-hour :day-of-month :day-of-year) (x-of-y (parse-long s))
+         (:week-of-year :minute-of-hour :day-of-month :day-of-year) (x-of-y (parse-long s))
 
-             ;; for everything else return in this format
-             (reformat-temporal-str timezone-id s (str/replace (or date-style "MMM d, yyyy") #"D" "d")))))))
+         ;; for everything else return in this format
+         (reformat-temporal-str timezone-id s (-> (or date-style "MMMM d, yyyy")
+                                                  (str/replace #"D" "d")
+                                                  post-process-date-style)))))))
 
 (def ^:private RenderableInterval
   {:interval-start     Temporal

--- a/test/metabase/pulse/render/body_test.clj
+++ b/test/metabase/pulse/render/body_test.clj
@@ -157,16 +157,16 @@
 
 ;; Basic test that result rows are formatted correctly (dates, floating point numbers etc)
 (deftest format-result-rows
-  (is (= [{:bar-width nil, :row [(number "1") (number "34.1") "Apr 1, 2014" "Stout Burgers & Beers"]}
-          {:bar-width nil, :row [(number "2") (number "34.04") "Dec 5, 2014" "The Apple Pan"]}
-          {:bar-width nil, :row [(number "3") (number "34.05") "Aug 1, 2014" "The Gorbals"]}]
+  (is (= [{:bar-width nil, :row [(number "1") (number "34.1") "April 1, 2014" "Stout Burgers & Beers"]}
+          {:bar-width nil, :row [(number "2") (number "34.04") "December 5, 2014" "The Apple Pan"]}
+          {:bar-width nil, :row [(number "3") (number "34.05") "August 1, 2014" "The Gorbals"]}]
          (rest (#'body/prep-for-html-rendering pacific-tz {} {:cols test-columns :rows test-data})))))
 
 ;; Testing the bar-column, which is the % of this row relative to the max of that column
 (deftest bar-column
-  (is (= [{:bar-width (float 85.249),  :row [(number "1") (number "34.1") "Apr 1, 2014" "Stout Burgers & Beers"]}
-          {:bar-width (float 85.1015), :row [(number "2") (number "34.04") "Dec 5, 2014" "The Apple Pan"]}
-          {:bar-width (float 85.1185), :row [(number "3") (number "34.05") "Aug 1, 2014" "The Gorbals"]}]
+  (is (= [{:bar-width (float 85.249),  :row [(number "1") (number "34.1") "April 1, 2014" "Stout Burgers & Beers"]}
+          {:bar-width (float 85.1015), :row [(number "2") (number "34.04") "December 5, 2014" "The Apple Pan"]}
+          {:bar-width (float 85.1185), :row [(number "3") (number "34.05") "August 1, 2014" "The Gorbals"]}]
          (rest (#'body/prep-for-html-rendering pacific-tz {} {:cols test-columns :rows test-data}
                                                {:bar-column second, :min-value 0, :max-value 40})))))
 
@@ -207,9 +207,9 @@
 
 ;; Result rows should include only the remapped column value, not the original
 (deftest include-only-remapped-column-name
-  (is (= [[(number "1") (number "34.1") "Bad" "Apr 1, 2014" "Stout Burgers & Beers"]
-          [(number "2") (number "34.04") "Ok" "Dec 5, 2014" "The Apple Pan"]
-          [(number "3") (number "34.05") "Good" "Aug 1, 2014" "The Gorbals"]]
+  (is (= [[(number "1") (number "34.1") "Bad" "April 1, 2014" "Stout Burgers & Beers"]
+          [(number "2") (number "34.04") "Ok" "December 5, 2014" "The Apple Pan"]
+          [(number "3") (number "34.05") "Good" "August 1, 2014" "The Gorbals"]]
          (map :row (rest (#'body/prep-for-html-rendering  pacific-tz
                                                           {}
                                                           {:cols test-columns-with-remapping :rows test-data-with-remapping}))))))
@@ -231,9 +231,9 @@
                                 :coercion_strategy :Coercion/ISO8601->DateTime}))
 
 (deftest cols-with-semantic-types
-  (is (= [{:bar-width nil, :row [(number "1") (number "34.1") "Apr 1, 2014" "Stout Burgers & Beers"]}
-          {:bar-width nil, :row [(number "2") (number "34.04") "Dec 5, 2014" "The Apple Pan"]}
-          {:bar-width nil, :row [(number "3") (number "34.05") "Aug 1, 2014" "The Gorbals"]}]
+  (is (= [{:bar-width nil, :row [(number "1") (number "34.1") "April 1, 2014" "Stout Burgers & Beers"]}
+          {:bar-width nil, :row [(number "2") (number "34.04") "December 5, 2014" "The Apple Pan"]}
+          {:bar-width nil, :row [(number "3") (number "34.05") "August 1, 2014" "The Gorbals"]}]
          (rest (#'body/prep-for-html-rendering pacific-tz
                                                {}
                                                {:cols test-columns-with-date-semantic-type :rows test-data})))))
@@ -274,7 +274,7 @@
                                          :semantic_type nil}]
                                  :rows [["foo"]]}))))
   (testing "renders date"
-    (is (= "Apr 1, 2014"
+    (is (= "April 1, 2014"
            (render-scalar-value {:cols [{:name         "date",
                                          :display_name "DATE",
                                          :base_type    :type/DateTime

--- a/test/metabase/pulse/render/datetime_test.clj
+++ b/test/metabase/pulse/render/datetime_test.clj
@@ -1,7 +1,9 @@
 (ns metabase.pulse.render.datetime-test
   (:require [clojure.test :refer :all]
             [java-time :as t]
-            [metabase.pulse.render.datetime :as datetime]))
+            [metabase.pulse.render.datetime :as datetime]
+            [metabase.shared.models.visualization-settings :as mb.viz]
+            [metabase.test :as mt]))
 
 (def ^:private now "2020-07-16T18:04:00Z[UTC]")
 
@@ -99,3 +101,53 @@
     (is (= "08:05:06"
            (datetime/format-temporal-str "UTC" "08:05:06Z"
                                          {:effective_type :type/Time})))))
+
+(deftest format-temporal-str-column-viz-settings-test
+  (testing "Written Date Formatting"
+    (let [fmt (fn [col-viz]
+                (datetime/format-temporal-str "UTC" now {:field_ref      [:column_name "created_at"]
+                                                         :effective_type :type/Date}
+                                              {::mb.viz/column-settings
+                                               {{::mb.viz/column-name "created_at"} col-viz}}))]
+      (doseq [[ date-style normal-result abbreviated-result]
+              [["MMMM D, YYYY" "July 16, 2020" "Jul 16, 2020"]
+               ["D MMMM, YYYY" "16 July, 2020" "16 Jul, 2020"]
+               ["dddd, MMMM D, YYYY" "Thursday, July 16, 2020" "Thu, Jul 16, 2020"] ;; Render datetimes with Day of Week option. (#27105)
+               [nil "July 16, 2020" "Jul 16, 2020"]]] ;; Render abbreviated date styles when no other style data is explicitly set. (#27020)
+        (testing (str "Date style: " date-style " correctly formats.")
+          (is (= normal-result
+                 (fmt (when date-style {::mb.viz/date-style date-style})))))
+        (testing (str "Date style: " date-style " with abbreviation correctly formats.")
+          (is (= abbreviated-result
+                 (fmt (merge {::mb.viz/date-abbreviate true}
+                             (when date-style {::mb.viz/date-style date-style})))))))))
+  (testing "Numerical Date Formatting"
+    (let [fmt (fn [col-viz]
+                (datetime/format-temporal-str "UTC" now {:field_ref      [:column_name "created_at"]
+                                                         :effective_type :type/Date}
+                                              {::mb.viz/column-settings
+                                               {{::mb.viz/column-name "created_at"} col-viz}}))]
+      (doseq [[ date-style slash-result dash-result dot-result]
+              [["M/D/YYYY" "7/16/2020" "7-16-2020" "7.16.2020"]
+               ["D/M/YYYY" "16/7/2020" "16-7-2020" "16.7.2020"]
+               ["YYYY/M/D" "2020/7/16" "2020-7-16" "2020.7.16"]
+               [nil "July 16, 2020" "July 16, 2020" "July 16, 2020"]] ;; nil date-style does not blow up when date-separator exists
+              date-separator ["/" "-" "."]]
+        (testing (str "Date style: " date-style " with '" date-separator "' correctly formats.")
+          (is (= (get {"/" slash-result
+                       "-" dash-result
+                       "." dot-result} date-separator)
+                 (fmt (merge {::mb.viz/date-separator date-separator}
+                             (when date-style {::mb.viz/date-style date-style})))))))
+      (testing "Default date separator is '/'"
+        (is (= "7/16/2020"
+               (fmt {::mb.viz/date-style "M/D/YYYY"}))))))
+  (testing "Custom Formatting options are respected as defaults."
+    (mt/with-temporary-setting-values [custom-formatting {:type/Temporal {:date_style "MMMM D, YYYY"
+                                                                                  :date_abbreviate true}}]
+      (is (= "Jul 16, 2020"
+             (datetime/format-temporal-str "UTC" now nil nil))))
+    (mt/with-temporary-setting-values [custom-formatting {:type/Temporal {:date_style "M/DD/YYYY"
+                                                                                    :date_separator "-"}}]
+      (is (= "7-16-2020"
+             (datetime/format-temporal-str "UTC" now nil nil))))))


### PR DESCRIPTION
…and #27105  (#27339)

* Handle abbreviation and date-separator in a fn, where defaults are passed in in any place where nil COULD exist

Moving abbreviation and date-separator string changes into a post-processing fn allows each unit case to handle the date-style default formatting, and eliminates the problem of date-style being `nil` in the let statement. It was this scenario where `abbreviate` was `true`, but `date-style` was `nil`.

In many cases, if `date-style` is nil, then so is `abbreviate` and `date-separator`, in fact, the default from the frontend sends nil for all of these keys. In such a case, none of the branches run and nil is safely passed through. It is then handled appropriately with `(or ...)` expressions in each entry for the case statement.

But, it is indeed possible to have a nil `date-style` with non-nil `abbreviate` or `date-separator` keys. Now, the post-process-date-style function is only ever called AFTER the default date-style is set in whatever case branch is needed.

* Turn frontend day format 'dddd' into backend format 'EEEE'

The frontend sends a datetime format string to the backend and some elements are not equivalent to the expectations the java datetime formatter has.

* Unskip e2e reproductions

* Add a test for all 'written date' combos

* These tests fail b/c I fixed the 'default' from Abbreviated to non-abbreviated

* Add test 'matrix' for numerically formatted dates, and each separator

* Finally, add tests to confirm that custom-formatting is applied