### PR TITLE
Repro #25374: Comma-separated dashboard filter values not passed down to the question

### DIFF
--- a/frontend/test/metabase/scenarios/dashboard-filters/reproductions/25374-comma-separated-values-not-passed-to-question.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters/reproductions/25374-comma-separated-values-not-passed-to-question.cy.spec.js
@@ -1,0 +1,111 @@
+import { restore, visitDashboard, filterWidget } from "__support__/e2e/helpers";
+
+const questionDetails = {
+  name: "25374",
+  native: {
+    "template-tags": {
+      num: {
+        id: "f7672b4d-1e84-1fa8-bf02-b5e584cd4535",
+        name: "num",
+        "display-name": "Num",
+        type: "number",
+        default: null,
+      },
+    },
+    query: "select count(*) from orders where id in ({{num}})",
+  },
+  parameters: [
+    {
+      id: "f7672b4d-1e84-1fa8-bf02-b5e584cd4535",
+      type: "number/=",
+      target: ["variable", ["template-tag", "num"]],
+      name: "Num",
+      slug: "num",
+      default: null,
+    },
+  ],
+};
+
+const filterDetails = {
+  name: "Equal to",
+  slug: "equal_to",
+  id: "10c0d4ba",
+  type: "number/=",
+  sectionId: "number",
+};
+
+const dashboardDetails = {
+  name: "25374D",
+  parameters: [filterDetails],
+};
+
+describe.skip("issue 25374", () => {
+  beforeEach(() => {
+    cy.intercept("POST", `/api/card/*/query`).as("cardQuery");
+
+    restore();
+    cy.signInAsAdmin();
+
+    cy.createNativeQuestionAndDashboard({
+      questionDetails,
+      dashboardDetails,
+    }).then(({ body: { id, card_id, dashboard_id } }) => {
+      // Connect filter to the card
+      cy.request("PUT", `/api/dashboard/${dashboard_id}/cards`, {
+        cards: [
+          {
+            id,
+            card_id,
+            row: 0,
+            col: 0,
+            size_x: 8,
+            size_y: 6,
+            parameter_mappings: [
+              {
+                parameter_id: filterDetails.id,
+                card_id,
+                target: ["variable", ["template-tag", "num"]],
+              },
+            ],
+          },
+        ],
+      });
+
+      visitDashboard(dashboard_id);
+
+      filterWidget().type("1,2,3{enter}");
+      cy.findByDisplayValue("1,2,3");
+
+      cy.get(".CardVisualization")
+        .should("contain", "COUNT(*)")
+        .and("contain", "3");
+
+      cy.location("search").should("eq", "?equal_to=1%2C2%2C3");
+    });
+  });
+
+  it("should pass comma-separated values down to the connected question (metabase#25374-1)", () => {
+    // Drill-through and go to the question
+    cy.findByText(questionDetails.name).click();
+    cy.wait("@cardQuery");
+
+    cy.get(".cellData").should("contain", "COUNT(*)").and("contain", "3");
+
+    cy.location("search").should("eq", "?num=1%2C2%2C3");
+  });
+
+  it("should retain comma-separated values on refresh (metabase#25374-2)", () => {
+    cy.reload();
+
+    // Make sure filter widget still has all the values
+    cy.findByDisplayValue("1,2,3");
+
+    // Make sure the result in the card is correct
+    cy.get(".CardVisualization")
+      .should("contain", "COUNT(*)")
+      .and("contain", "3");
+
+    // Make sure URL search params are correct
+    cy.location("search").should("eq", "?equal_to=1%2C2%2C3");
+  });
+});


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #25374 

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/dashboard-filters/reproductions/25374-comma-separated-values-not-passed-to-question.cy.spec.js`
- Unskip repro
- Tests should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip tests completely)
- Make sure tests are passing and
- Merge it together with the fix

### Screenshots:
Scenario 1 (drill-through and pass params to question)
![image](https://user-images.githubusercontent.com/31325167/209167453-3fb30884-e7ab-4d72-b985-8abe7443c253.png)

Scenario 2
Refresh dashboard
![image](https://user-images.githubusercontent.com/31325167/209167680-e95956fe-29e2-4102-91cc-6abd76f3b78a.png)

