### PR TITLE
Repro #27123: Exclude filter always ends up showing "Days of the week"

### DIFF
--- a/frontend/test/metabase/scenarios/filters/reproductions/27123-exclude-always-shows-days-of-week.cy.spec.js
+++ b/frontend/test/metabase/scenarios/filters/reproductions/27123-exclude-always-shows-days-of-week.cy.spec.js
@@ -1,0 +1,31 @@
+import { restore, popover } from "__support__/e2e/helpers";
+import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
+
+const { ORDERS_ID } = SAMPLE_DATABASE;
+
+const questionDetails = {
+  query: {
+    "source-table": ORDERS_ID,
+    limit: 100,
+  },
+};
+
+describe.skip("issue 27123", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+
+    cy.createQuestion(questionDetails, { visitQuestion: true });
+  });
+
+  it("exclude filter should not resolve to 'Days of the week' regardless of the chosen granularity  (metabase#27123)", () => {
+    cy.findAllByTestId("header-cell").contains("Created At").click();
+    cy.findByText("Filter by this column").click();
+    cy.findByText("Exclude...").click();
+    cy.findByText("Months of the year...").click();
+
+    popover()
+      .should("contain", "Months of the year...")
+      .and("contain", "January");
+  });
+});


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #27123 

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/filters/reproductions/27123-exclude-always-shows-days-of-week.cy.spec.js`
- Unskip the test
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/209220808-bfec67fb-3bb5-4da1-be72-8d8330ce1b4c.png)

