### PR TITLE
Repro #27380: Doing "Zoom in" from dashboard drops fields from joined tables

### DIFF
--- a/frontend/test/metabase/scenarios/joins/reproductions/27380-dashboard-drops-joined-fields-on-zoom-in.cy.spec.js
+++ b/frontend/test/metabase/scenarios/joins/reproductions/27380-dashboard-drops-joined-fields-on-zoom-in.cy.spec.js
@@ -1,0 +1,49 @@
+import { restore, visitDashboard } from "__support__/e2e/helpers";
+import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
+
+const { ORDERS, ORDERS_ID, PRODUCTS } = SAMPLE_DATABASE;
+
+const questionDetails = {
+  query: {
+    "source-table": ORDERS_ID,
+    aggregation: [["count"]],
+    breakout: [
+      [
+        "field",
+        PRODUCTS.CREATED_AT,
+        { "source-field": ORDERS.PRODUCT_ID, "temporal-unit": "month" },
+      ],
+    ],
+  },
+  display: "line",
+};
+
+describe.skip("issue 27380", () => {
+  beforeEach(() => {
+    cy.intercept("POST", "/api/dataset").as("dataset");
+
+    restore();
+    cy.signInAsAdmin();
+
+    cy.createQuestionAndDashboard({ questionDetails }).then(
+      ({ body: { dashboard_id } }) => {
+        visitDashboard(dashboard_id);
+      },
+    );
+  });
+
+  it("should not drop fields from joined table on dashboard 'zoom-in' (metabase#27380)", () => {
+    // Doesn't really matter which 'circle" we click on the graph
+    cy.get("circle").last().realClick();
+    cy.findByText("Zoom in").click();
+    cy.wait("@dataset");
+
+    // Graph should still exist
+    // Let's check only the y-axis label
+    cy.get("y-axis-label").invoke("text").should("eq", "Count");
+
+    cy.icon("notebook").click();
+    cy.findByText("Pick a column to group by").should("not.exist");
+    cy.findByText(/Products? → Created At: Month/);
+  });
+});


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #27380 

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/joins/reproductions/27380-dashboard-drops-joined-fields-on-zoom-in.cy.spec.js`
- Unskip the test
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/209224012-31a0a8f1-be83-4f20-98c6-46e9ac3a686e.png)

