### PR TITLE
Allowing users to hide logo on embedding

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/auth/containers/SSOButton/SSOButton.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/auth/containers/SSOButton/SSOButton.tsx
@@ -1,10 +1,10 @@
 import { connect } from "react-redux";
-import { isIframe } from "metabase/lib/dom";
+import { isWithinIframe } from "metabase/lib/dom";
 import SSOButton from "../../components/SSOButton";
 import { loginSSO } from "../../actions";
 
 const mapStateToProps = () => ({
-  isEmbedded: isIframe(),
+  isEmbedded: isWithinIframe(),
 });
 
 const mapDispatchToProps = {

--- a/enterprise/frontend/src/metabase-enterprise/auth/containers/SSOButton/SSOButton.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/auth/containers/SSOButton/SSOButton.tsx
@@ -1,10 +1,10 @@
 import { connect } from "react-redux";
-import { IFRAMED } from "metabase/lib/dom";
+import { isIframe } from "metabase/lib/dom";
 import SSOButton from "../../components/SSOButton";
 import { loginSSO } from "../../actions";
 
 const mapStateToProps = () => ({
-  isEmbedded: IFRAMED,
+  isEmbedded: isIframe(),
 });
 
 const mapDispatchToProps = {

--- a/frontend/src/metabase-types/api/mocks/query.ts
+++ b/frontend/src/metabase-types/api/mocks/query.ts
@@ -15,7 +15,6 @@ export const createMockNativeQuery = (
   opts?: Partial<NativeQuery>,
 ): NativeQuery => ({
   query: "SELECT 1",
-  "template-tags": {},
   ...opts,
 });
 

--- a/frontend/src/metabase-types/api/query.ts
+++ b/frontend/src/metabase-types/api/query.ts
@@ -1,4 +1,3 @@
-import { TemplateTags } from "metabase-types/types/Query";
 import { DatabaseId } from "./database";
 import { FieldId } from "./field";
 import { TableId } from "./table";
@@ -9,7 +8,6 @@ export interface StructuredQuery {
 
 export interface NativeQuery {
   query: string;
-  "template-tags": TemplateTags;
 }
 
 export interface StructuredDatasetQuery {

--- a/frontend/src/metabase-types/store/embed.ts
+++ b/frontend/src/metabase-types/store/embed.ts
@@ -4,6 +4,7 @@ export interface EmbedOptions {
   search?: boolean;
   new_button?: boolean;
   breadcrumbs?: boolean;
+  logo?: boolean;
   side_nav?: boolean | "default";
   header?: boolean;
   additional_info?: boolean;

--- a/frontend/src/metabase-types/store/mocks/embed.ts
+++ b/frontend/src/metabase-types/store/mocks/embed.ts
@@ -1,8 +1,6 @@
 import { EmbedOptions, EmbedState } from "metabase-types/store";
-import { DEFAULT_EMBED_OPTIONS } from "metabase/redux/embed";
 
 const createMockEmbedOptions = (opts?: Partial<EmbedOptions>) => ({
-  ...DEFAULT_EMBED_OPTIONS,
   ...opts,
 });
 

--- a/frontend/src/metabase-types/store/mocks/embed.ts
+++ b/frontend/src/metabase-types/store/mocks/embed.ts
@@ -2,7 +2,7 @@ import { EmbedOptions, EmbedState } from "metabase-types/store";
 import { DEFAULT_EMBED_OPTIONS } from "metabase/redux/embed";
 
 const createMockEmbedOptions = (opts?: Partial<EmbedOptions>) => ({
-  ...(DEFAULT_EMBED_OPTIONS as EmbedOptions),
+  ...DEFAULT_EMBED_OPTIONS,
   ...opts,
 });
 

--- a/frontend/src/metabase-types/store/mocks/embed.ts
+++ b/frontend/src/metabase-types/store/mocks/embed.ts
@@ -1,12 +1,13 @@
 import { EmbedOptions, EmbedState } from "metabase-types/store";
+import { DEFAULT_EMBED_OPTIONS } from "metabase/redux/embed";
 
-export const createMockEmbedOptions = (opts?: Partial<EmbedOptions>) => ({
+const createMockEmbedOptions = (opts?: Partial<EmbedOptions>) => ({
+  ...(DEFAULT_EMBED_OPTIONS as EmbedOptions),
   ...opts,
 });
 
 export const createMockEmbedState = (
-  opts?: Partial<EmbedState>,
+  opts?: Partial<EmbedOptions>,
 ): EmbedState => ({
-  options: createMockEmbedOptions(),
-  ...opts,
+  options: createMockEmbedOptions(opts),
 });

--- a/frontend/src/metabase-types/types/Query.ts
+++ b/frontend/src/metabase-types/types/Query.ts
@@ -66,7 +66,7 @@ export type TemplateTags = { [key: TemplateTagName]: TemplateTag };
 
 export type NativeQuery = {
   query: string;
-  "template-tags": TemplateTags;
+  "template-tags"?: TemplateTags;
 };
 
 // "card__4" like syntax meaning a query is using card 4 as a data source

--- a/frontend/src/metabase/App.tsx
+++ b/frontend/src/metabase/App.tsx
@@ -111,7 +111,7 @@ function App({
       <ScrollToTop>
         <AppContainer className="spread">
           <AppBanner />
-          {isAppBarVisible && <AppBar isNavBarEnabled={isNavBarEnabled} />}
+          {isAppBarVisible && <AppBar />}
           <AppContentContainer isAdminApp={isAdminApp}>
             {isNavBarEnabled && <Navbar />}
             <AppContent ref={setViewportElement}>

--- a/frontend/src/metabase/app-embed.js
+++ b/frontend/src/metabase/app-embed.js
@@ -3,14 +3,14 @@
  * file 'LICENSE-EMBEDDING.txt', which is part of this source code package.
  */
 
-import { IFRAMED } from "metabase/lib/dom";
+import { isIframe } from "metabase/lib/dom";
 import { init } from "./app";
 
 import { getRoutes } from "./routes-embed";
 import reducers from "./reducers-public";
 
 init(reducers, getRoutes, () => {
-  if (IFRAMED) {
+  if (isIframe()) {
     document.body.style.backgroundColor = "transparent";
   }
 });

--- a/frontend/src/metabase/app-embed.js
+++ b/frontend/src/metabase/app-embed.js
@@ -3,14 +3,14 @@
  * file 'LICENSE-EMBEDDING.txt', which is part of this source code package.
  */
 
-import { isIframe } from "metabase/lib/dom";
+import { isWithinIframe } from "metabase/lib/dom";
 import { init } from "./app";
 
 import { getRoutes } from "./routes-embed";
 import reducers from "./reducers-public";
 
 init(reducers, getRoutes, () => {
-  if (isIframe()) {
+  if (isWithinIframe()) {
     document.body.style.backgroundColor = "transparent";
   }
 });

--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.styled.jsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.styled.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import cx from "classnames";
 import styled from "@emotion/styled";
 import { css } from "@emotion/react";
-import { isIframe } from "metabase/lib/dom";
+import { isWithinIframe } from "metabase/lib/dom";
 import { color } from "metabase/lib/colors";
 import { breakpointMaxSmall, space } from "metabase/styled-components/theme";
 
@@ -109,7 +109,7 @@ export const ParametersWidgetContainer = styled(FullWidthContainer)`
     isSticky &&
     css`
       position: fixed;
-      top: ${isIframe() && !topNav ? "0" : APP_BAR_HEIGHT};
+      top: ${isWithinIframe() && !topNav ? "0" : APP_BAR_HEIGHT};
       left: 0;
       border-bottom: 1px solid ${color("border")};
     `}

--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.styled.jsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.styled.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import cx from "classnames";
 import styled from "@emotion/styled";
 import { css } from "@emotion/react";
-import { IFRAMED } from "metabase/lib/dom";
+import { isIframe } from "metabase/lib/dom";
 import { color } from "metabase/lib/colors";
 import { breakpointMaxSmall, space } from "metabase/styled-components/theme";
 
@@ -109,7 +109,7 @@ export const ParametersWidgetContainer = styled(FullWidthContainer)`
     isSticky &&
     css`
       position: fixed;
-      top: ${IFRAMED && !topNav ? "0" : APP_BAR_HEIGHT};
+      top: ${isIframe() && !topNav ? "0" : APP_BAR_HEIGHT};
       left: 0;
       border-bottom: 1px solid ${color("border")};
     `}

--- a/frontend/src/metabase/entities/actions/utils.unit.spec.ts
+++ b/frontend/src/metabase/entities/actions/utils.unit.spec.ts
@@ -184,8 +184,8 @@ describe("entities > actions > utils", () => {
       const tags = (newQuestion.card().dataset_query as NativeDatasetQuery)
         .native["template-tags"];
 
-      expect(tags.name.type).toEqual("text");
-      expect(tags.price.type).toEqual("number");
+      expect(tags?.name.type).toEqual("text");
+      expect(tags?.price.type).toEqual("number");
     });
 
     it("should set date template tag types", () => {
@@ -207,8 +207,8 @@ describe("entities > actions > utils", () => {
       const tags = (newQuestion.card().dataset_query as NativeDatasetQuery)
         .native["template-tags"];
 
-      expect(tags.name.type).toEqual("date");
-      expect(tags.price.type).toEqual("date");
+      expect(tags?.name.type).toEqual("date");
+      expect(tags?.price.type).toEqual("date");
     });
   });
 });

--- a/frontend/src/metabase/lib/api.js
+++ b/frontend/src/metabase/lib/api.js
@@ -3,7 +3,7 @@ import querystring from "querystring";
 import EventEmitter from "events";
 
 import { delay } from "metabase/lib/promise";
-import { isIframe } from "metabase/lib/dom";
+import { isWithinIframe } from "metabase/lib/dom";
 
 const ONE_SECOND = 1000;
 const MAX_RETRIES = 10;
@@ -84,7 +84,7 @@ export class Api extends EventEmitter {
           ? { Accept: "application/json", "Content-Type": "application/json" }
           : {};
 
-        if (isIframe()) {
+        if (isWithinIframe()) {
           headers["X-Metabase-Embedded"] = "true";
         }
 

--- a/frontend/src/metabase/lib/api.js
+++ b/frontend/src/metabase/lib/api.js
@@ -3,7 +3,7 @@ import querystring from "querystring";
 import EventEmitter from "events";
 
 import { delay } from "metabase/lib/promise";
-import { IFRAMED } from "metabase/lib/dom";
+import { isIframe } from "metabase/lib/dom";
 
 const ONE_SECOND = 1000;
 const MAX_RETRIES = 10;
@@ -84,7 +84,7 @@ export class Api extends EventEmitter {
           ? { Accept: "application/json", "Content-Type": "application/json" }
           : {};
 
-        if (IFRAMED) {
+        if (isIframe()) {
           headers["X-Metabase-Embedded"] = "true";
         }
 

--- a/frontend/src/metabase/lib/dom.js
+++ b/frontend/src/metabase/lib/dom.js
@@ -11,7 +11,7 @@ export const getScrollY = () =>
 
 // denotes whether the current page is loaded in an iframe or not
 // Cypress renders the whole app within an iframe, but we want to exlude it from this check to avoid certain components (like Nav bar) not rendering
-export const isIframe = function () {
+export const isWithinIframe = function () {
   try {
     return !isCypressActive && window.self !== window.top;
   } catch (e) {
@@ -440,7 +440,7 @@ export function clipPathReference(id) {
 }
 
 export function initializeIframeResizer(readyCallback = () => {}) {
-  if (!isIframe()) {
+  if (!isWithinIframe()) {
     return;
   }
 

--- a/frontend/src/metabase/lib/dom.js
+++ b/frontend/src/metabase/lib/dom.js
@@ -11,13 +11,13 @@ export const getScrollY = () =>
 
 // denotes whether the current page is loaded in an iframe or not
 // Cypress renders the whole app within an iframe, but we want to exlude it from this check to avoid certain components (like Nav bar) not rendering
-export const IFRAMED = (function () {
+export const isIframe = function () {
   try {
     return !isCypressActive && window.self !== window.top;
   } catch (e) {
     return true;
   }
-})();
+};
 
 // add a global so we can check if the parent iframe is Metabase
 window.METABASE = true;
@@ -440,7 +440,7 @@ export function clipPathReference(id) {
 }
 
 export function initializeIframeResizer(readyCallback = () => {}) {
-  if (!IFRAMED) {
+  if (!isIframe()) {
     return;
   }
 

--- a/frontend/src/metabase/lib/embed.js
+++ b/frontend/src/metabase/lib/embed.js
@@ -1,7 +1,7 @@
 import { push } from "react-router-redux";
 import _ from "underscore";
 import { parseSearchOptions, parseHashOptions } from "metabase/lib/browser";
-import { IFRAMED, IFRAMED_IN_SELF } from "metabase/lib/dom";
+import { isIframe, IFRAMED_IN_SELF } from "metabase/lib/dom";
 import { setOptions } from "metabase/redux/embed";
 import { isFitViewportMode } from "metabase/hoc/FitViewPort";
 
@@ -10,7 +10,7 @@ import { isFitViewportMode } from "metabase/hoc/FitViewPort";
 export const IS_EMBED_PREVIEW = IFRAMED_IN_SELF;
 
 export function initializeEmbedding(store) {
-  if (IFRAMED) {
+  if (isIframe()) {
     let currentHref;
     let currentFrame;
     // NOTE: history.listen and window's onhashchange + popstate events were not

--- a/frontend/src/metabase/lib/embed.js
+++ b/frontend/src/metabase/lib/embed.js
@@ -1,7 +1,7 @@
 import { push } from "react-router-redux";
 import _ from "underscore";
 import { parseSearchOptions, parseHashOptions } from "metabase/lib/browser";
-import { isIframe, IFRAMED_IN_SELF } from "metabase/lib/dom";
+import { isWithinIframe, IFRAMED_IN_SELF } from "metabase/lib/dom";
 import { setOptions } from "metabase/redux/embed";
 import { isFitViewportMode } from "metabase/hoc/FitViewPort";
 
@@ -10,7 +10,7 @@ import { isFitViewportMode } from "metabase/hoc/FitViewPort";
 export const IS_EMBED_PREVIEW = IFRAMED_IN_SELF;
 
 export function initializeEmbedding(store) {
-  if (isIframe()) {
+  if (isWithinIframe()) {
     let currentHref;
     let currentFrame;
     // NOTE: history.listen and window's onhashchange + popstate events were not

--- a/frontend/src/metabase/nav/components/AppBar/AppBar.tsx
+++ b/frontend/src/metabase/nav/components/AppBar/AppBar.tsx
@@ -10,6 +10,7 @@ export interface AppBarProps {
   collectionId?: CollectionId;
   isNavBarOpen?: boolean;
   isNavBarEnabled?: boolean;
+  isLogoVisible?: boolean;
   isSearchVisible?: boolean;
   isNewButtonVisible?: boolean;
   isProfileLinkVisible?: boolean;

--- a/frontend/src/metabase/nav/components/AppBar/AppBar.unit.spec.tsx
+++ b/frontend/src/metabase/nav/components/AppBar/AppBar.unit.spec.tsx
@@ -35,6 +35,7 @@ describe("AppBar", () => {
         isCollectionPathVisible: true,
         isSearchVisible: true,
         isNewButtonVisible: true,
+        isLogoVisible: true,
       });
 
       render(<AppBar {...props} />);
@@ -80,6 +81,7 @@ describe("AppBar", () => {
         isCollectionPathVisible: true,
         isSearchVisible: true,
         isNewButtonVisible: true,
+        isLogoVisible: true,
       });
 
       render(<AppBar {...props} />);

--- a/frontend/src/metabase/nav/components/AppBar/AppBarLarge.styled.tsx
+++ b/frontend/src/metabase/nav/components/AppBar/AppBarLarge.styled.tsx
@@ -1,3 +1,4 @@
+import { css } from "@emotion/react";
 import styled from "@emotion/styled";
 import { color } from "metabase/lib/colors";
 import { APP_BAR_HEIGHT } from "metabase/nav/constants";
@@ -22,6 +23,7 @@ export const AppBarRoot = styled.div<AppBarRootProps>`
 
 export interface AppBarLeftContainerProps {
   isNavBarEnabled?: boolean;
+  isLogoVisible?: boolean;
 }
 
 export const AppBarLeftContainer = styled.div<AppBarLeftContainerProps>`
@@ -44,6 +46,22 @@ export const AppBarLeftContainer = styled.div<AppBarLeftContainerProps>`
       opacity: ${props => (props.isNavBarEnabled ? 1 : 0)};
     }
   }
+
+  ${props =>
+    !props.isLogoVisible &&
+    css`
+      ${SidebarButton} {
+        opacity: 1;
+      }
+
+      padding-left: ${!props.isNavBarEnabled && "1rem"};
+
+      &:hover ${LogoLink}, ${LogoLink} {
+        display: ${!props.isNavBarEnabled && "none"};
+        opacity: 0;
+        pointer-events: none;
+      }
+    `}
 `;
 
 export const AppBarRightContainer = styled.div`

--- a/frontend/src/metabase/nav/components/AppBar/AppBarLarge.styled.tsx
+++ b/frontend/src/metabase/nav/components/AppBar/AppBarLarge.styled.tsx
@@ -2,7 +2,7 @@ import { css } from "@emotion/react";
 import styled from "@emotion/styled";
 import { color } from "metabase/lib/colors";
 import { APP_BAR_HEIGHT } from "metabase/nav/constants";
-import { LogoLink } from "./AppBarLogo.styled";
+// import { LogoLink } from "./AppBarLogo.styled";
 
 interface AppBarRootProps {
   isNavBarOpen?: boolean;
@@ -30,13 +30,6 @@ export const AppBarLeftContainer = styled.div<AppBarLeftContainerProps>`
   flex: 1 1 auto;
   align-items: center;
   min-width: 5rem;
-
-  &:hover {
-    ${LogoLink} {
-      opacity: ${props => (props.isNavBarEnabled ? 0 : 1)};
-      pointer-events: ${props => (props.isNavBarEnabled ? "none" : "")};
-    }
-  }
 
   padding-left: ${({ isLogoVisible, isNavBarEnabled }) =>
     !isLogoVisible && !isNavBarEnabled && "1rem"};

--- a/frontend/src/metabase/nav/components/AppBar/AppBarLarge.styled.tsx
+++ b/frontend/src/metabase/nav/components/AppBar/AppBarLarge.styled.tsx
@@ -47,29 +47,8 @@ export const AppBarLeftContainer = styled.div<AppBarLeftContainerProps>`
     }
   }
 
-  ${props =>
-    !props.isLogoVisible &&
-    css`
-      ${SidebarButton} {
-        opacity: 1;
-      }
-
-      ${SidebarIcon} {
-        color: ${color("text-medium")};
-
-        &:hover {
-          color: ${color("brand")};
-        }
-      }
-
-      padding-left: ${!props.isNavBarEnabled && "1rem"};
-
-      &:hover ${LogoLink}, ${LogoLink} {
-        display: ${!props.isNavBarEnabled && "none"};
-        opacity: 0;
-        pointer-events: none;
-      }
-    `}
+  padding-left: ${({ isLogoVisible, isNavBarEnabled }) =>
+    !isLogoVisible && !isNavBarEnabled && "1rem"};
 `;
 
 export const AppBarRightContainer = styled.div`

--- a/frontend/src/metabase/nav/components/AppBar/AppBarLarge.styled.tsx
+++ b/frontend/src/metabase/nav/components/AppBar/AppBarLarge.styled.tsx
@@ -3,7 +3,7 @@ import styled from "@emotion/styled";
 import { color } from "metabase/lib/colors";
 import { APP_BAR_HEIGHT } from "metabase/nav/constants";
 import { LogoLink } from "./AppBarLogo.styled";
-import { SidebarButton } from "./AppBarToggle.styled";
+import { SidebarButton, SidebarIcon } from "./AppBarToggle.styled";
 
 interface AppBarRootProps {
   isNavBarOpen?: boolean;
@@ -52,6 +52,14 @@ export const AppBarLeftContainer = styled.div<AppBarLeftContainerProps>`
     css`
       ${SidebarButton} {
         opacity: 1;
+      }
+
+      ${SidebarIcon} {
+        color: ${color("text-medium")};
+
+        &:hover {
+          color: ${color("brand")};
+        }
       }
 
       padding-left: ${!props.isNavBarEnabled && "1rem"};

--- a/frontend/src/metabase/nav/components/AppBar/AppBarLarge.styled.tsx
+++ b/frontend/src/metabase/nav/components/AppBar/AppBarLarge.styled.tsx
@@ -1,8 +1,6 @@
-import { css } from "@emotion/react";
 import styled from "@emotion/styled";
 import { color } from "metabase/lib/colors";
 import { APP_BAR_HEIGHT } from "metabase/nav/constants";
-// import { LogoLink } from "./AppBarLogo.styled";
 
 interface AppBarRootProps {
   isNavBarOpen?: boolean;

--- a/frontend/src/metabase/nav/components/AppBar/AppBarLarge.styled.tsx
+++ b/frontend/src/metabase/nav/components/AppBar/AppBarLarge.styled.tsx
@@ -3,7 +3,6 @@ import styled from "@emotion/styled";
 import { color } from "metabase/lib/colors";
 import { APP_BAR_HEIGHT } from "metabase/nav/constants";
 import { LogoLink } from "./AppBarLogo.styled";
-import { SidebarButton, SidebarIcon } from "./AppBarToggle.styled";
 
 interface AppBarRootProps {
   isNavBarOpen?: boolean;
@@ -32,18 +31,10 @@ export const AppBarLeftContainer = styled.div<AppBarLeftContainerProps>`
   align-items: center;
   min-width: 5rem;
 
-  ${SidebarButton} {
-    opacity: ${props => (props.isNavBarEnabled ? 0 : 1)};
-  }
-
   &:hover {
     ${LogoLink} {
       opacity: ${props => (props.isNavBarEnabled ? 0 : 1)};
       pointer-events: ${props => (props.isNavBarEnabled ? "none" : "")};
-    }
-
-    ${SidebarButton} {
-      opacity: ${props => (props.isNavBarEnabled ? 1 : 0)};
     }
   }
 

--- a/frontend/src/metabase/nav/components/AppBar/AppBarLarge.tsx
+++ b/frontend/src/metabase/nav/components/AppBar/AppBarLarge.tsx
@@ -52,6 +52,7 @@ const AppBarLarge = ({
         isLogoVisible={isLogoVisible}
       >
         <AppBarLogo
+          isLogoVisible={isLogoVisible}
           isNavBarOpen={isNavBarVisible}
           isNavBarEnabled={isNavBarEnabled}
           onToggleClick={onToggleNavbar}

--- a/frontend/src/metabase/nav/components/AppBar/AppBarLarge.tsx
+++ b/frontend/src/metabase/nav/components/AppBar/AppBarLarge.tsx
@@ -19,6 +19,7 @@ export interface AppBarLargeProps {
   collectionId?: CollectionId;
   isNavBarOpen?: boolean;
   isNavBarEnabled?: boolean;
+  isLogoVisible?: boolean;
   isSearchVisible?: boolean;
   isNewButtonVisible?: boolean;
   isProfileLinkVisible?: boolean;
@@ -33,6 +34,7 @@ const AppBarLarge = ({
   collectionId,
   isNavBarOpen,
   isNavBarEnabled,
+  isLogoVisible,
   isSearchVisible,
   isNewButtonVisible,
   isProfileLinkVisible,
@@ -45,7 +47,10 @@ const AppBarLarge = ({
 
   return (
     <AppBarRoot isNavBarOpen={isNavBarVisible}>
-      <AppBarLeftContainer isNavBarEnabled={isNavBarEnabled}>
+      <AppBarLeftContainer
+        isNavBarEnabled={isNavBarEnabled}
+        isLogoVisible={isLogoVisible}
+      >
         <AppBarLogo
           isNavBarOpen={isNavBarVisible}
           isNavBarEnabled={isNavBarEnabled}

--- a/frontend/src/metabase/nav/components/AppBar/AppBarLogo.styled.tsx
+++ b/frontend/src/metabase/nav/components/AppBar/AppBarLogo.styled.tsx
@@ -1,6 +1,8 @@
 import styled from "@emotion/styled";
+import { css } from "@emotion/react";
 import { color } from "metabase/lib/colors";
 import Link from "metabase/core/components/Link";
+import { space } from "metabase/styled-components/theme";
 
 export const LogoRoot = styled.div`
   position: relative;
@@ -20,9 +22,20 @@ export const LogoLink = styled(Link)`
   }
 `;
 
-export const ToggleContainer = styled.div`
-  position: absolute;
-  top: 0.625rem;
-  left: 0.9375rem;
+interface ToggleContainerProps {
+  isAbsolute?: boolean;
+}
+
+export const ToggleContainer = styled.div<ToggleContainerProps>`
+  ${props =>
+    props.isAbsolute
+      ? css`
+          position: absolute;
+          top: 0.625rem;
+          left: 0.9375rem;
+        `
+      : css`
+          padding: ${space(1)} ${space(2)};
+        `}
   transition: opacity 0.3s;
 `;

--- a/frontend/src/metabase/nav/components/AppBar/AppBarLogo.styled.tsx
+++ b/frontend/src/metabase/nav/components/AppBar/AppBarLogo.styled.tsx
@@ -23,12 +23,12 @@ export const LogoLink = styled(Link)`
 `;
 
 interface ToggleContainerProps {
-  isAbsolute?: boolean;
+  isLogoVisible?: boolean;
 }
 
 export const ToggleContainer = styled.div<ToggleContainerProps>`
   ${props =>
-    props.isAbsolute
+    props.isLogoVisible
       ? css`
           position: absolute;
           top: 0.625rem;

--- a/frontend/src/metabase/nav/components/AppBar/AppBarLogo.styled.tsx
+++ b/frontend/src/metabase/nav/components/AppBar/AppBarLogo.styled.tsx
@@ -3,12 +3,18 @@ import { css } from "@emotion/react";
 import { color } from "metabase/lib/colors";
 import Link from "metabase/core/components/Link";
 import { space } from "metabase/styled-components/theme";
+import { AppBarLeftContainer } from "./AppBarLarge.styled";
 
 export const LogoRoot = styled.div`
   position: relative;
 `;
 
-export const LogoLink = styled(Link)`
+interface LogoLinkProps {
+  isSmallAppBar?: boolean;
+  isNavBarEnabled?: boolean;
+}
+
+export const LogoLink = styled(Link)<LogoLinkProps>`
   cursor: pointer;
   display: flex;
   align-items: center;
@@ -20,6 +26,15 @@ export const LogoLink = styled(Link)`
   &:hover {
     background-color: ${color("bg-light")};
   }
+
+  ${props =>
+    !props.isSmallAppBar &&
+    css`
+      ${AppBarLeftContainer}:hover & {
+        opacity: ${props.isNavBarEnabled ? 0 : 1};
+        pointer-events: ${props.isNavBarEnabled ? "none" : ""};
+      }
+    `}
 `;
 
 interface ToggleContainerProps {

--- a/frontend/src/metabase/nav/components/AppBar/AppBarLogo.tsx
+++ b/frontend/src/metabase/nav/components/AppBar/AppBarLogo.tsx
@@ -30,7 +30,7 @@ const AppBarLogo = ({
         </LogoLink>
       )}
       {isNavBarEnabled && (
-        <ToggleContainer isAbsolute={isLogoVisible}>
+        <ToggleContainer isLogoVisible={isLogoVisible}>
           <AppBarToggle
             isLogoVisible={isLogoVisible}
             isNavBarOpen={isNavBarOpen}

--- a/frontend/src/metabase/nav/components/AppBar/AppBarLogo.tsx
+++ b/frontend/src/metabase/nav/components/AppBar/AppBarLogo.tsx
@@ -4,6 +4,7 @@ import AppBarToggle from "./AppBarToggle";
 import { LogoLink, LogoRoot, ToggleContainer } from "./AppBarLogo.styled";
 
 export interface AppBarLogoProps {
+  isLogoVisible?: boolean;
   isNavBarOpen?: boolean;
   isNavBarEnabled?: boolean;
   onLogoClick?: () => void;
@@ -11,6 +12,7 @@ export interface AppBarLogoProps {
 }
 
 const AppBarLogo = ({
+  isLogoVisible,
   isNavBarOpen,
   isNavBarEnabled,
   onLogoClick,
@@ -18,12 +20,19 @@ const AppBarLogo = ({
 }: AppBarLogoProps): JSX.Element => {
   return (
     <LogoRoot>
-      <LogoLink to="/" onClick={onLogoClick} data-metabase-event="Navbar;Logo">
-        <LogoIcon height={32} />
-      </LogoLink>
+      {isLogoVisible && (
+        <LogoLink
+          to="/"
+          onClick={onLogoClick}
+          data-metabase-event="Navbar;Logo"
+        >
+          <LogoIcon height={32} />
+        </LogoLink>
+      )}
       {isNavBarEnabled && (
-        <ToggleContainer>
+        <ToggleContainer isAbsolute={isLogoVisible}>
           <AppBarToggle
+            isLogoVisible={isLogoVisible}
             isNavBarOpen={isNavBarOpen}
             onToggleClick={onToggleClick}
           />

--- a/frontend/src/metabase/nav/components/AppBar/AppBarLogo.tsx
+++ b/frontend/src/metabase/nav/components/AppBar/AppBarLogo.tsx
@@ -24,6 +24,7 @@ const AppBarLogo = ({
     <LogoRoot>
       {isLogoVisible && (
         <LogoLink
+          isNavBarEnabled={isNavBarEnabled}
           to="/"
           onClick={onLogoClick}
           data-metabase-event="Navbar;Logo"

--- a/frontend/src/metabase/nav/components/AppBar/AppBarLogo.tsx
+++ b/frontend/src/metabase/nav/components/AppBar/AppBarLogo.tsx
@@ -4,6 +4,7 @@ import AppBarToggle from "./AppBarToggle";
 import { LogoLink, LogoRoot, ToggleContainer } from "./AppBarLogo.styled";
 
 export interface AppBarLogoProps {
+  isSmallAppBar?: boolean;
   isLogoVisible?: boolean;
   isNavBarOpen?: boolean;
   isNavBarEnabled?: boolean;
@@ -12,6 +13,7 @@ export interface AppBarLogoProps {
 }
 
 const AppBarLogo = ({
+  isSmallAppBar,
   isLogoVisible,
   isNavBarOpen,
   isNavBarEnabled,
@@ -32,6 +34,8 @@ const AppBarLogo = ({
       {isNavBarEnabled && (
         <ToggleContainer isLogoVisible={isLogoVisible}>
           <AppBarToggle
+            isSmallAppBar={isSmallAppBar}
+            isNavBarEnabled={isNavBarEnabled}
             isLogoVisible={isLogoVisible}
             isNavBarOpen={isNavBarOpen}
             onToggleClick={onToggleClick}

--- a/frontend/src/metabase/nav/components/AppBar/AppBarSmall.styled.tsx
+++ b/frontend/src/metabase/nav/components/AppBar/AppBarSmall.styled.tsx
@@ -8,11 +8,9 @@ export const AppBarRoot = styled.div`
 
 export interface AppBarHeaderProps {
   isSubheaderVisible?: boolean;
-  isHeaderVisible?: boolean;
 }
 
 export const AppBarHeader = styled.div<AppBarHeaderProps>`
-  display: ${props => !props.isHeaderVisible && "none"};
   position: relative;
   height: ${APP_BAR_HEIGHT};
   padding: 0 1rem;

--- a/frontend/src/metabase/nav/components/AppBar/AppBarSmall.styled.tsx
+++ b/frontend/src/metabase/nav/components/AppBar/AppBarSmall.styled.tsx
@@ -8,9 +8,11 @@ export const AppBarRoot = styled.div`
 
 export interface AppBarHeaderProps {
   isSubheaderVisible?: boolean;
+  isHeaderVisible?: boolean;
 }
 
 export const AppBarHeader = styled.div<AppBarHeaderProps>`
+  display: ${props => !props.isHeaderVisible && "none"};
   position: relative;
   height: ${APP_BAR_HEIGHT};
   padding: 0 1rem;

--- a/frontend/src/metabase/nav/components/AppBar/AppBarSmall.tsx
+++ b/frontend/src/metabase/nav/components/AppBar/AppBarSmall.tsx
@@ -95,7 +95,10 @@ const AppBarSmall = ({
           )}
         </AppBarMainContainer>
         <AppBarLogoContainer isVisible={isLogoVisible && !isSearchActive}>
-          <AppBarLogo onLogoClick={handleLogoClick} />
+          <AppBarLogo
+            isLogoVisible={isLogoVisible}
+            onLogoClick={handleLogoClick}
+          />
         </AppBarLogoContainer>
       </AppBarHeader>
       {isSubheaderVisible && (

--- a/frontend/src/metabase/nav/components/AppBar/AppBarSmall.tsx
+++ b/frontend/src/metabase/nav/components/AppBar/AppBarSmall.tsx
@@ -21,6 +21,7 @@ export interface AppBarSmallProps {
   currentUser: User;
   isNavBarOpen?: boolean;
   isNavBarEnabled?: boolean;
+  isLogoVisible?: boolean;
   isSearchVisible?: boolean;
   isProfileLinkVisible?: boolean;
   isCollectionPathVisible?: boolean;
@@ -34,6 +35,7 @@ const AppBarSmall = ({
   currentUser,
   isNavBarOpen,
   isNavBarEnabled,
+  isLogoVisible,
   isSearchVisible,
   isProfileLinkVisible,
   isCollectionPathVisible,
@@ -46,6 +48,8 @@ const AppBarSmall = ({
 
   const [isSearchActive, setSearchActive] = useState(false);
   const isInfoVisible = isQuestionLineageVisible || isCollectionPathVisible;
+  const isHeaderVisible =
+    isLogoVisible || isNavBarEnabled || isSearchVisible || isProfileLinkVisible;
   const isSubheaderVisible = !isNavBarVisible && isInfoVisible;
 
   const handleLogoClick = useCallback(() => {
@@ -63,7 +67,10 @@ const AppBarSmall = ({
 
   return (
     <AppBarRoot>
-      <AppBarHeader isSubheaderVisible={isSubheaderVisible}>
+      <AppBarHeader
+        isSubheaderVisible={isSubheaderVisible}
+        isHeaderVisible={isHeaderVisible}
+      >
         <AppBarMainContainer>
           <AppBarToggleContainer>
             {isNavBarEnabled && (
@@ -87,7 +94,7 @@ const AppBarSmall = ({
             </AppBarProfileLinkContainer>
           )}
         </AppBarMainContainer>
-        <AppBarLogoContainer isVisible={!isSearchActive}>
+        <AppBarLogoContainer isVisible={isLogoVisible && !isSearchActive}>
           <AppBarLogo onLogoClick={handleLogoClick} />
         </AppBarLogoContainer>
       </AppBarHeader>

--- a/frontend/src/metabase/nav/components/AppBar/AppBarSmall.tsx
+++ b/frontend/src/metabase/nav/components/AppBar/AppBarSmall.tsx
@@ -67,40 +67,39 @@ const AppBarSmall = ({
 
   return (
     <AppBarRoot>
-      <AppBarHeader
-        isSubheaderVisible={isSubheaderVisible}
-        isHeaderVisible={isHeaderVisible}
-      >
-        <AppBarMainContainer>
-          <AppBarToggleContainer>
-            {isNavBarEnabled && (
-              <AppBarToggle
-                isNavBarOpen={isNavBarVisible}
-                onToggleClick={onToggleNavbar}
-              />
+      {isHeaderVisible && (
+        <AppBarHeader isSubheaderVisible={isSubheaderVisible}>
+          <AppBarMainContainer>
+            <AppBarToggleContainer>
+              {isNavBarEnabled && (
+                <AppBarToggle
+                  isNavBarOpen={isNavBarVisible}
+                  onToggleClick={onToggleNavbar}
+                />
+              )}
+            </AppBarToggleContainer>
+            <AppBarSearchContainer>
+              {isSearchVisible && (
+                <SearchBar
+                  onSearchActive={handleSearchActive}
+                  onSearchInactive={handleSearchInactive}
+                />
+              )}
+            </AppBarSearchContainer>
+            {isProfileLinkVisible && (
+              <AppBarProfileLinkContainer>
+                <ProfileLink user={currentUser} onLogout={onLogout} />
+              </AppBarProfileLinkContainer>
             )}
-          </AppBarToggleContainer>
-          <AppBarSearchContainer>
-            {isSearchVisible && (
-              <SearchBar
-                onSearchActive={handleSearchActive}
-                onSearchInactive={handleSearchInactive}
-              />
-            )}
-          </AppBarSearchContainer>
-          {isProfileLinkVisible && (
-            <AppBarProfileLinkContainer>
-              <ProfileLink user={currentUser} onLogout={onLogout} />
-            </AppBarProfileLinkContainer>
-          )}
-        </AppBarMainContainer>
-        <AppBarLogoContainer isVisible={isLogoVisible && !isSearchActive}>
-          <AppBarLogo
-            isLogoVisible={isLogoVisible}
-            onLogoClick={handleLogoClick}
-          />
-        </AppBarLogoContainer>
-      </AppBarHeader>
+          </AppBarMainContainer>
+          <AppBarLogoContainer isVisible={isLogoVisible && !isSearchActive}>
+            <AppBarLogo
+              isLogoVisible={isLogoVisible}
+              onLogoClick={handleLogoClick}
+            />
+          </AppBarLogoContainer>
+        </AppBarHeader>
+      )}
       {isSubheaderVisible && (
         <AppBarSubheader isNavBarOpen={isNavBarVisible}>
           {isQuestionLineageVisible ? (

--- a/frontend/src/metabase/nav/components/AppBar/AppBarSmall.tsx
+++ b/frontend/src/metabase/nav/components/AppBar/AppBarSmall.tsx
@@ -73,6 +73,7 @@ const AppBarSmall = ({
             <AppBarToggleContainer>
               {isNavBarEnabled && (
                 <AppBarToggle
+                  isSmallAppBar
                   isNavBarOpen={isNavBarVisible}
                   onToggleClick={onToggleNavbar}
                 />
@@ -94,6 +95,7 @@ const AppBarSmall = ({
           </AppBarMainContainer>
           <AppBarLogoContainer isVisible={isLogoVisible && !isSearchActive}>
             <AppBarLogo
+              isSmallAppBar
               isLogoVisible={isLogoVisible}
               onLogoClick={handleLogoClick}
             />

--- a/frontend/src/metabase/nav/components/AppBar/AppBarToggle.styled.tsx
+++ b/frontend/src/metabase/nav/components/AppBar/AppBarToggle.styled.tsx
@@ -1,13 +1,36 @@
 import styled from "@emotion/styled";
+import { css } from "@emotion/react";
 import { color } from "metabase/lib/colors";
 import Icon from "metabase/components/Icon";
 
-export const SidebarButton = styled.button`
+interface SidebarButtonProps {
+  isLogoVisible: boolean;
+}
+
+export const SidebarButton = styled.button<SidebarButtonProps>`
   cursor: pointer;
   display: block;
+
+  && {
+    opacity: ${props => !props.isLogoVisible && 1};
+  }
 `;
 
-export const SidebarIcon = styled(Icon)`
+interface SidebarIconProps {
+  isLogoVisible: boolean;
+}
+
+export const SidebarIcon = styled(Icon)<SidebarIconProps>`
   color: ${color("brand")};
   display: block;
+
+  ${props =>
+    !props.isLogoVisible &&
+    css`
+      color: ${color("text-medium")};
+
+      &:hover {
+        color: ${color("brand")};
+      }
+    `}
 `;

--- a/frontend/src/metabase/nav/components/AppBar/AppBarToggle.styled.tsx
+++ b/frontend/src/metabase/nav/components/AppBar/AppBarToggle.styled.tsx
@@ -2,22 +2,34 @@ import styled from "@emotion/styled";
 import { css } from "@emotion/react";
 import { color } from "metabase/lib/colors";
 import Icon from "metabase/components/Icon";
+import { AppBarLeftContainer } from "./AppBarLarge.styled";
 
 interface SidebarButtonProps {
-  isLogoVisible: boolean;
+  isSmallAppBar?: boolean;
+  isNavBarEnabled?: boolean;
+  isLogoVisible?: boolean;
 }
 
 export const SidebarButton = styled.button<SidebarButtonProps>`
   cursor: pointer;
   display: block;
 
-  && {
-    opacity: ${props => !props.isLogoVisible && 1};
-  }
+  ${({ isNavBarEnabled, isLogoVisible, isSmallAppBar }) =>
+    isLogoVisible && !isSmallAppBar
+      ? css`
+          opacity: ${isNavBarEnabled ? 0 : 1};
+
+          ${AppBarLeftContainer}:hover & {
+            opacity: ${isNavBarEnabled ? 1 : 0};
+          }
+        `
+      : css`
+          opacity: 1;
+        `}
 `;
 
 interface SidebarIconProps {
-  isLogoVisible: boolean;
+  isLogoVisible?: boolean;
 }
 
 export const SidebarIcon = styled(Icon)<SidebarIconProps>`

--- a/frontend/src/metabase/nav/components/AppBar/AppBarToggle.tsx
+++ b/frontend/src/metabase/nav/components/AppBar/AppBarToggle.tsx
@@ -5,19 +5,25 @@ import Tooltip from "metabase/core/components/Tooltip";
 import { SidebarButton, SidebarIcon } from "./AppBarToggle.styled";
 
 export interface AppBarToggleProps {
+  isSmallAppBar?: boolean;
+  isNavBarEnabled?: boolean;
   isLogoVisible?: boolean;
   isNavBarOpen?: boolean;
   onToggleClick?: () => void;
 }
 
 const AppBarToggle = ({
-  isLogoVisible = true,
+  isSmallAppBar,
+  isNavBarEnabled,
+  isLogoVisible,
   isNavBarOpen,
   onToggleClick,
 }: AppBarToggleProps): JSX.Element => {
   return (
     <Tooltip tooltip={getSidebarTooltip(isNavBarOpen)}>
       <SidebarButton
+        isSmallAppBar={isSmallAppBar}
+        isNavBarEnabled={isNavBarEnabled}
         isLogoVisible={isLogoVisible}
         onClick={onToggleClick}
         data-testid="sidebar-toggle"

--- a/frontend/src/metabase/nav/components/AppBar/AppBarToggle.tsx
+++ b/frontend/src/metabase/nav/components/AppBar/AppBarToggle.tsx
@@ -5,22 +5,26 @@ import Tooltip from "metabase/core/components/Tooltip";
 import { SidebarButton, SidebarIcon } from "./AppBarToggle.styled";
 
 export interface AppBarToggleProps {
+  isLogoVisible?: boolean;
   isNavBarOpen?: boolean;
   onToggleClick?: () => void;
 }
 
 const AppBarToggle = ({
+  isLogoVisible = true,
   isNavBarOpen,
   onToggleClick,
 }: AppBarToggleProps): JSX.Element => {
   return (
     <Tooltip tooltip={getSidebarTooltip(isNavBarOpen)}>
       <SidebarButton
+        isLogoVisible={isLogoVisible}
         onClick={onToggleClick}
         data-testid="sidebar-toggle"
         aria-label="sidebar-toggle"
       >
         <SidebarIcon
+          isLogoVisible={isLogoVisible}
           size={28}
           name={isNavBarOpen ? "sidebar_open" : "sidebar_closed"}
         />

--- a/frontend/src/metabase/nav/components/AppBar/AppBarToggle.tsx
+++ b/frontend/src/metabase/nav/components/AppBar/AppBarToggle.tsx
@@ -27,7 +27,7 @@ const AppBarToggle = ({
         isLogoVisible={isLogoVisible}
         onClick={onToggleClick}
         data-testid="sidebar-toggle"
-        aria-label="sidebar-toggle"
+        aria-label={t`Toggle sidebar`}
       >
         <SidebarIcon
           isLogoVisible={isLogoVisible}

--- a/frontend/src/metabase/nav/components/AppBar/AppBarToggle.tsx
+++ b/frontend/src/metabase/nav/components/AppBar/AppBarToggle.tsx
@@ -15,7 +15,11 @@ const AppBarToggle = ({
 }: AppBarToggleProps): JSX.Element => {
   return (
     <Tooltip tooltip={getSidebarTooltip(isNavBarOpen)}>
-      <SidebarButton onClick={onToggleClick} data-testid="sidebar-toggle">
+      <SidebarButton
+        onClick={onToggleClick}
+        data-testid="sidebar-toggle"
+        aria-label="sidebar-toggle"
+      >
         <SidebarIcon
           size={28}
           name={isNavBarOpen ? "sidebar_open" : "sidebar_closed"}

--- a/frontend/src/metabase/nav/containers/AppBar/AppBar.tsx
+++ b/frontend/src/metabase/nav/containers/AppBar/AppBar.tsx
@@ -7,6 +7,7 @@ import { closeNavbar, getIsNavbarOpen, toggleNavbar } from "metabase/redux/app";
 import {
   getIsCollectionPathVisible,
   getIsLogoVisible,
+  getIsNavBarEnabled,
   getIsNewButtonVisible,
   getIsProfileLinkVisible,
   getIsQuestionLineageVisible,
@@ -21,6 +22,7 @@ const mapStateToProps = (state: State, props: RouterProps) => ({
   currentUser: getUser(state),
   collectionId: Collections.selectors.getInitialCollectionId(state, props),
   isNavBarOpen: getIsNavbarOpen(state),
+  isNavBarEnabled: getIsNavBarEnabled(state, props),
   isLogoVisible: getIsLogoVisible(state),
   isSearchVisible: getIsSearchVisible(state),
   isNewButtonVisible: getIsNewButtonVisible(state),

--- a/frontend/src/metabase/nav/containers/AppBar/AppBar.tsx
+++ b/frontend/src/metabase/nav/containers/AppBar/AppBar.tsx
@@ -6,6 +6,7 @@ import { logout } from "metabase/auth/actions";
 import { closeNavbar, getIsNavbarOpen, toggleNavbar } from "metabase/redux/app";
 import {
   getIsCollectionPathVisible,
+  getIsLogoVisible,
   getIsNewButtonVisible,
   getIsProfileLinkVisible,
   getIsQuestionLineageVisible,
@@ -20,6 +21,7 @@ const mapStateToProps = (state: State, props: RouterProps) => ({
   currentUser: getUser(state),
   collectionId: Collections.selectors.getInitialCollectionId(state, props),
   isNavBarOpen: getIsNavbarOpen(state),
+  isLogoVisible: getIsLogoVisible(state),
   isSearchVisible: getIsSearchVisible(state),
   isNewButtonVisible: getIsNewButtonVisible(state),
   isProfileLinkVisible: getIsProfileLinkVisible(state),

--- a/frontend/src/metabase/nav/containers/AppBar/AppBar.unit.spec.tsx
+++ b/frontend/src/metabase/nav/containers/AppBar/AppBar.unit.spec.tsx
@@ -14,6 +14,7 @@ import {
 } from "metabase-types/store/mocks";
 import { setupCollectionsEndpoints } from "__support__/server-mocks";
 import { EmbedOptions } from "metabase-types/store";
+import { DEFAULT_EMBED_OPTIONS } from "metabase/redux/embed";
 import AppBar from "./AppBar";
 
 describe("AppBar", () => {
@@ -152,7 +153,10 @@ function renderAppBar(embedOptions: Partial<EmbedOptions>) {
     initialRouterPath: "/question/1",
     storeInitialState: {
       app: createMockAppState({ isNavbarOpen: false }),
-      embed: createMockEmbedState(embedOptions),
+      embed: createMockEmbedState({
+        ...DEFAULT_EMBED_OPTIONS,
+        ...embedOptions,
+      }),
       qb: createMockQueryBuilderState({
         card: createMockCard(),
       }),
@@ -174,6 +178,7 @@ function getMediaQuery(opts?: Partial<MediaQueryList>): MediaQueryList {
   };
 }
 
+// TODO: Removed unused function
 function setupMock() {
   nock(location.origin)
     .get(`/api/collection/root`)

--- a/frontend/src/metabase/nav/containers/AppBar/AppBar.unit.spec.tsx
+++ b/frontend/src/metabase/nav/containers/AppBar/AppBar.unit.spec.tsx
@@ -13,6 +13,7 @@ import {
   createMockQueryBuilderState,
 } from "metabase-types/store/mocks";
 import { setupCollectionsEndpoints } from "__support__/server-mocks";
+import { EmbedOptions } from "metabase-types/store";
 import AppBar from "./AppBar";
 
 describe("AppBar", () => {
@@ -37,12 +38,15 @@ describe("AppBar", () => {
       });
 
       it("should be able to toggle side nav", async () => {
+        const embedOptions: Partial<EmbedOptions> = {
+          side_nav: true,
+        };
         renderWithProviders(<AppBar />, {
           withRouter: true,
           initialPath: "/question/1",
           storeInitialState: {
             app: createMockAppState({ isNavbarOpen: false }),
-            embed: createMockEmbedState({ side_nav: true }),
+            embed: createMockEmbedState(embedOptions),
             qb: createMockQueryBuilderState({
               card: createMockCard(),
             }),
@@ -50,8 +54,30 @@ describe("AppBar", () => {
         });
 
         expect(await screen.findByText(/Our analytics/)).toBeVisible();
-        expect(screen.getByTestId("main-logo")).toBeInTheDocument();
+        expect(screen.getByTestId("main-logo")).toBeVisible();
+        screen.getByTestId("sidebar-toggle").click();
         expect(screen.getByText(/Our analytics/)).not.toBeVisible();
+      });
+
+      it("should hide side nav toggle icon", async () => {
+        const embedOptions: Partial<EmbedOptions> = {
+          side_nav: false,
+        };
+        renderWithProviders(<AppBar />, {
+          withRouter: true,
+          initialPath: "/question/1",
+          storeInitialState: {
+            app: createMockAppState({ isNavbarOpen: false }),
+            embed: createMockEmbedState(embedOptions),
+            qb: createMockQueryBuilderState({
+              card: createMockCard(),
+            }),
+          },
+        });
+
+        expect(await screen.findByText(/Our analytics/)).toBeVisible();
+        expect(screen.getByTestId("main-logo")).toBeVisible();
+        expect(screen.queryByTestId("sidebar-toggle")).not.toBeInTheDocument();
       });
     });
   });

--- a/frontend/src/metabase/nav/containers/AppBar/AppBar.unit.spec.tsx
+++ b/frontend/src/metabase/nav/containers/AppBar/AppBar.unit.spec.tsx
@@ -44,8 +44,10 @@ describe("AppBar", () => {
 
         expect(await screen.findByText(/Our analytics/)).toBeVisible();
         expect(screen.getByTestId("main-logo")).toBeVisible();
+
         screen.getByTestId("sidebar-toggle").click();
         expect(screen.getByText(/Our analytics/)).not.toBeVisible();
+        expect(screen.getByTestId("main-logo")).toBeVisible();
       });
 
       it("should hide side nav toggle icon", async () => {
@@ -70,6 +72,62 @@ describe("AppBar", () => {
 
         screen.getByTestId("sidebar-toggle").click();
         expect(screen.getByText(/Our analytics/)).not.toBeVisible();
+        expect(screen.queryByTestId("main-logo")).not.toBeInTheDocument();
+        expect(screen.getByTestId("sidebar-toggle")).toBeVisible();
+      });
+
+      it("should not show either logo or side nav toggle button at all", async () => {
+        renderAppBar({
+          side_nav: false,
+          logo: false,
+        });
+
+        expect(await screen.findByText(/Our analytics/)).toBeVisible();
+        expect(screen.queryByTestId("main-logo")).not.toBeInTheDocument();
+        expect(screen.queryByTestId("sidebar-toggle")).not.toBeInTheDocument();
+      });
+    });
+
+    describe("small screens", () => {
+      beforeEach(() => {
+        matchMediaSpy.mockReturnValue(getMediaQuery({ matches: true }));
+      });
+
+      it("should be able to toggle side nav", async () => {
+        renderAppBar({
+          side_nav: true,
+        });
+
+        expect(await screen.findByText(/Our analytics/)).toBeVisible();
+        expect(screen.getByTestId("main-logo")).toBeVisible();
+
+        screen.getByTestId("sidebar-toggle").click();
+        expect(screen.queryByText(/Our analytics/)).not.toBeInTheDocument();
+        expect(screen.getByTestId("main-logo")).toBeVisible();
+      });
+
+      it("should hide side nav toggle icon", async () => {
+        renderAppBar({
+          side_nav: false,
+        });
+
+        expect(await screen.findByText(/Our analytics/)).toBeVisible();
+        expect(screen.getByTestId("main-logo")).toBeVisible();
+        expect(screen.queryByTestId("sidebar-toggle")).not.toBeInTheDocument();
+      });
+
+      it("should always show side nav toggle icon when logo is hidden", async () => {
+        renderAppBar({
+          side_nav: true,
+          logo: false,
+        });
+
+        expect(await screen.findByText(/Our analytics/)).toBeVisible();
+        expect(screen.queryByTestId("main-logo")).not.toBeInTheDocument();
+        expect(screen.getByTestId("sidebar-toggle")).toBeVisible();
+
+        screen.getByTestId("sidebar-toggle").click();
+        expect(screen.queryByText(/Our analytics/)).not.toBeInTheDocument();
         expect(screen.queryByTestId("main-logo")).not.toBeInTheDocument();
         expect(screen.getByTestId("sidebar-toggle")).toBeVisible();
       });

--- a/frontend/src/metabase/nav/containers/AppBar/AppBar.unit.spec.tsx
+++ b/frontend/src/metabase/nav/containers/AppBar/AppBar.unit.spec.tsx
@@ -28,8 +28,8 @@ describe("AppBar", () => {
 
     afterEach(() => {
       jest.clearAllMocks();
-      reStoreMockEmbedding();
       nock.cleanAll();
+      reStoreMockEmbedding();
     });
 
     describe("large screens", () => {
@@ -38,19 +38,8 @@ describe("AppBar", () => {
       });
 
       it("should be able to toggle side nav", async () => {
-        const embedOptions: Partial<EmbedOptions> = {
+        renderAppBar({
           side_nav: true,
-        };
-        renderWithProviders(<AppBar />, {
-          withRouter: true,
-          initialPath: "/question/1",
-          storeInitialState: {
-            app: createMockAppState({ isNavbarOpen: false }),
-            embed: createMockEmbedState(embedOptions),
-            qb: createMockQueryBuilderState({
-              card: createMockCard(),
-            }),
-          },
         });
 
         expect(await screen.findByText(/Our analytics/)).toBeVisible();
@@ -60,28 +49,58 @@ describe("AppBar", () => {
       });
 
       it("should hide side nav toggle icon", async () => {
-        const embedOptions: Partial<EmbedOptions> = {
+        renderAppBar({
           side_nav: false,
-        };
-        renderWithProviders(<AppBar />, {
-          withRouter: true,
-          initialPath: "/question/1",
-          storeInitialState: {
-            app: createMockAppState({ isNavbarOpen: false }),
-            embed: createMockEmbedState(embedOptions),
-            qb: createMockQueryBuilderState({
-              card: createMockCard(),
-            }),
-          },
         });
 
         expect(await screen.findByText(/Our analytics/)).toBeVisible();
         expect(screen.getByTestId("main-logo")).toBeVisible();
         expect(screen.queryByTestId("sidebar-toggle")).not.toBeInTheDocument();
       });
+
+      it("should always show side nav toggle icon when logo is hidden", async () => {
+        renderAppBar({
+          side_nav: true,
+          logo: false,
+        });
+
+        expect(await screen.findByText(/Our analytics/)).toBeVisible();
+        expect(screen.queryByTestId("main-logo")).not.toBeInTheDocument();
+        expect(screen.getByTestId("sidebar-toggle")).toBeVisible();
+
+        screen.getByTestId("sidebar-toggle").click();
+        expect(screen.getByText(/Our analytics/)).not.toBeVisible();
+        expect(screen.queryByTestId("main-logo")).not.toBeInTheDocument();
+        expect(screen.getByTestId("sidebar-toggle")).toBeVisible();
+      });
+
+      it("should not show either logo or side nav toggle button at all", async () => {
+        renderAppBar({
+          side_nav: false,
+          logo: false,
+        });
+
+        expect(await screen.findByText(/Our analytics/)).toBeVisible();
+        expect(screen.queryByTestId("main-logo")).not.toBeInTheDocument();
+        expect(screen.queryByTestId("sidebar-toggle")).not.toBeInTheDocument();
+      });
     });
   });
 });
+
+function renderAppBar(embedOptions: Partial<EmbedOptions>) {
+  renderWithProviders(<AppBar />, {
+    withRouter: true,
+    initialRouterPath: "/question/1",
+    storeInitialState: {
+      app: createMockAppState({ isNavbarOpen: false }),
+      embed: createMockEmbedState(embedOptions),
+      qb: createMockQueryBuilderState({
+        card: createMockCard(),
+      }),
+    },
+  });
+}
 
 function getMediaQuery(opts?: Partial<MediaQueryList>): MediaQueryList {
   return {

--- a/frontend/src/metabase/nav/containers/AppBar/AppBar.unit.spec.tsx
+++ b/frontend/src/metabase/nav/containers/AppBar/AppBar.unit.spec.tsx
@@ -24,7 +24,7 @@ describe("AppBar", () => {
     afterEach(() => {
       jest.clearAllMocks();
       nock.cleanAll();
-      reStoreMockEmbedding();
+      restoreMockEmbedding();
     });
 
     describe("large screens", () => {
@@ -143,7 +143,7 @@ describe("AppBar", () => {
 
 function setup(embedOptions: Partial<EmbedOptions>) {
   const scope = nock(location.origin);
-  setupCollectionsEndpoints(scope);
+  setupCollectionsEndpoints(scope, []);
 
   renderWithProviders(<AppBar />, {
     withRouter: true,
@@ -182,7 +182,7 @@ function mockEmbedding() {
   });
 }
 
-function reStoreMockEmbedding() {
+function restoreMockEmbedding() {
   Object.defineProperty(window, "self", {
     value: windowSelf,
   });

--- a/frontend/src/metabase/nav/containers/AppBar/AppBar.unit.spec.tsx
+++ b/frontend/src/metabase/nav/containers/AppBar/AppBar.unit.spec.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import nock from "nock";
-import { screen } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
 import {
   createMockCard,
   createMockCollection,
@@ -8,6 +8,7 @@ import {
 } from "metabase-types/api/mocks";
 import { renderWithProviders } from "__support__/ui";
 import {
+  createMockAppState,
   createMockEmbedState,
   createMockQueryBuilderState,
 } from "metabase-types/store/mocks";
@@ -40,6 +41,7 @@ describe("AppBar", () => {
           withRouter: true,
           initialPath: "/question/1",
           storeInitialState: {
+            app: createMockAppState({ isNavbarOpen: false }),
             embed: createMockEmbedState({ side_nav: true }),
             qb: createMockQueryBuilderState({
               card: createMockCard(),
@@ -47,11 +49,9 @@ describe("AppBar", () => {
           },
         });
 
-        expect(
-          screen.getByRole("button", { name: "sidebar-toggle" }),
-        ).toBeInTheDocument();
-        expect(await screen.findByText(/Our analytics/)).toBeInTheDocument();
+        expect(await screen.findByText(/Our analytics/)).toBeVisible();
         expect(screen.getByTestId("main-logo")).toBeInTheDocument();
+        expect(screen.getByText(/Our analytics/)).not.toBeVisible();
       });
     });
   });

--- a/frontend/src/metabase/nav/containers/AppBar/AppBar.unit.spec.tsx
+++ b/frontend/src/metabase/nav/containers/AppBar/AppBar.unit.spec.tsx
@@ -1,11 +1,7 @@
 import React from "react";
 import nock from "nock";
-import { screen, waitFor } from "@testing-library/react";
-import {
-  createMockCard,
-  createMockCollection,
-  createMockUnsavedCard,
-} from "metabase-types/api/mocks";
+import { screen } from "@testing-library/react";
+import { createMockCard } from "metabase-types/api/mocks";
 import { renderWithProviders } from "__support__/ui";
 import {
   createMockAppState,
@@ -22,8 +18,6 @@ describe("AppBar", () => {
 
   describe("full-app embedding", () => {
     beforeEach(async () => {
-      const scope = nock(location.origin);
-      setupCollectionsEndpoints(scope);
       mockEmbedding();
     });
 
@@ -39,7 +33,7 @@ describe("AppBar", () => {
       });
 
       it("should be able to toggle side nav", async () => {
-        renderAppBar({
+        setup({
           side_nav: true,
         });
 
@@ -52,7 +46,7 @@ describe("AppBar", () => {
       });
 
       it("should hide side nav toggle icon", async () => {
-        renderAppBar({
+        setup({
           side_nav: false,
         });
 
@@ -62,7 +56,7 @@ describe("AppBar", () => {
       });
 
       it("should always show side nav toggle icon when logo is hidden", async () => {
-        renderAppBar({
+        setup({
           side_nav: true,
           logo: false,
         });
@@ -78,7 +72,7 @@ describe("AppBar", () => {
       });
 
       it("should not show either logo or side nav toggle button at all", async () => {
-        renderAppBar({
+        setup({
           side_nav: false,
           logo: false,
         });
@@ -95,7 +89,7 @@ describe("AppBar", () => {
       });
 
       it("should be able to toggle side nav", async () => {
-        renderAppBar({
+        setup({
           side_nav: true,
         });
 
@@ -108,7 +102,7 @@ describe("AppBar", () => {
       });
 
       it("should hide side nav toggle icon", async () => {
-        renderAppBar({
+        setup({
           side_nav: false,
         });
 
@@ -118,7 +112,7 @@ describe("AppBar", () => {
       });
 
       it("should always show side nav toggle icon when logo is hidden", async () => {
-        renderAppBar({
+        setup({
           side_nav: true,
           logo: false,
         });
@@ -134,7 +128,7 @@ describe("AppBar", () => {
       });
 
       it("should not show either logo or side nav toggle button at all", async () => {
-        renderAppBar({
+        setup({
           side_nav: false,
           logo: false,
         });
@@ -147,7 +141,10 @@ describe("AppBar", () => {
   });
 });
 
-function renderAppBar(embedOptions: Partial<EmbedOptions>) {
+function setup(embedOptions: Partial<EmbedOptions>) {
+  const scope = nock(location.origin);
+  setupCollectionsEndpoints(scope);
+
   renderWithProviders(<AppBar />, {
     withRouter: true,
     initialRouterPath: "/question/1",
@@ -176,19 +173,6 @@ function getMediaQuery(opts?: Partial<MediaQueryList>): MediaQueryList {
     removeEventListener: jest.fn(),
     ...opts,
   };
-}
-
-// TODO: Removed unused function
-function setupMock() {
-  nock(location.origin)
-    .get(`/api/collection/root`)
-    .reply(
-      200,
-      createMockCollection({
-        id: "root",
-        name: "Our analytics",
-      }),
-    );
 }
 
 const windowSelf = window.self;

--- a/frontend/src/metabase/nav/containers/AppBar/AppBar.unit.spec.tsx
+++ b/frontend/src/metabase/nav/containers/AppBar/AppBar.unit.spec.tsx
@@ -1,0 +1,81 @@
+import React from "react";
+import nock from "nock";
+import { render, screen } from "@testing-library/react";
+import { createMockCollection, createMockUser } from "metabase-types/api/mocks";
+import { renderWithProviders } from "__support__/ui";
+import { createMockEmbedState } from "metabase-types/store/mocks";
+import AppBar from "./AppBar";
+
+jest.mock("metabase/selectors/embed", () => {
+  return {
+    ...jest.requireActual("metabase/selectors/embed"),
+    getIsEmbedded: jest.fn().mockReturnValue(true),
+  };
+});
+jest.mock("metabase/selectors/app", () => {
+  return {
+    ...jest.requireActual("metabase/selectors/app"),
+    getIsCollectionPathVisible: jest.fn().mockReturnValue(true),
+  };
+});
+
+describe("AppBar", () => {
+  const matchMediaSpy = jest.spyOn(window, "matchMedia");
+
+  describe("full-app embedding", () => {
+    beforeEach(async () => {
+      setupMock();
+    });
+
+    afterEach(() => {
+      jest.clearAllMocks();
+      nock.cleanAll();
+    });
+
+    describe("large screens", () => {
+      beforeEach(() => {
+        matchMediaSpy.mockReturnValue(getMediaQuery({ matches: false }));
+      });
+
+      it("should be able to toggle side nav", async () => {
+        // setupMock();
+        renderWithProviders(<AppBar />, {
+          withRouter: true,
+          storeInitialState: {
+            embed: createMockEmbedState({ side_nav: true }),
+          },
+        });
+
+        expect(
+          screen.getByRole("button", { name: "sidebar-toggle" }),
+        ).toBeInTheDocument();
+        expect(await screen.findByText(/Our analytics/)).toBeInTheDocument();
+        expect(screen.getByTestId("main-logo")).toBeInTheDocument();
+      });
+    });
+  });
+
+  const getMediaQuery = (opts?: Partial<MediaQueryList>): MediaQueryList => ({
+    media: "",
+    matches: false,
+    onchange: jest.fn(),
+    dispatchEvent: jest.fn(),
+    addListener: jest.fn(),
+    addEventListener: jest.fn(),
+    removeListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    ...opts,
+  });
+});
+
+function setupMock() {
+  nock(location.origin)
+    .get(`/api/collection/root`)
+    .reply(
+      200,
+      createMockCollection({
+        id: "root",
+        name: "Our analytics",
+      }),
+    );
+}

--- a/frontend/src/metabase/public/components/EmbedFrame.jsx
+++ b/frontend/src/metabase/public/components/EmbedFrame.jsx
@@ -3,7 +3,7 @@ import React, { Component } from "react";
 import { withRouter } from "react-router";
 
 import cx from "classnames";
-import { IFRAMED, initializeIframeResizer } from "metabase/lib/dom";
+import { isIframe, initializeIframeResizer } from "metabase/lib/dom";
 import { parseHashOptions } from "metabase/lib/browser";
 
 import MetabaseSettings from "metabase/lib/settings";
@@ -16,7 +16,7 @@ import LogoBadge from "./LogoBadge";
 import "./EmbedFrame.css";
 
 const DEFAULT_OPTIONS = {
-  bordered: IFRAMED,
+  bordered: isIframe(),
   titled: true,
 };
 

--- a/frontend/src/metabase/public/components/EmbedFrame.jsx
+++ b/frontend/src/metabase/public/components/EmbedFrame.jsx
@@ -3,7 +3,7 @@ import React, { Component } from "react";
 import { withRouter } from "react-router";
 
 import cx from "classnames";
-import { isIframe, initializeIframeResizer } from "metabase/lib/dom";
+import { isWithinIframe, initializeIframeResizer } from "metabase/lib/dom";
 import { parseHashOptions } from "metabase/lib/browser";
 
 import MetabaseSettings from "metabase/lib/settings";
@@ -16,7 +16,7 @@ import LogoBadge from "./LogoBadge";
 import "./EmbedFrame.css";
 
 const DEFAULT_OPTIONS = {
-  bordered: isIframe(),
+  bordered: isWithinIframe(),
   titled: true,
 };
 

--- a/frontend/src/metabase/public/containers/PublicDashboard.jsx
+++ b/frontend/src/metabase/public/containers/PublicDashboard.jsx
@@ -5,7 +5,7 @@ import { push } from "react-router-redux";
 import cx from "classnames";
 
 import _ from "underscore";
-import { isIframe } from "metabase/lib/dom";
+import { isWithinIframe } from "metabase/lib/dom";
 
 import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
 import DashboardGrid from "metabase/dashboard/components/DashboardGrid";
@@ -109,7 +109,7 @@ class PublicDashboard extends Component {
       isFullscreen,
       isNightMode,
     } = this.props;
-    const buttons = !isIframe()
+    const buttons = !isWithinIframe()
       ? getDashboardActions(this, { ...this.props, isPublic: true })
       : [];
 

--- a/frontend/src/metabase/public/containers/PublicDashboard.jsx
+++ b/frontend/src/metabase/public/containers/PublicDashboard.jsx
@@ -5,7 +5,7 @@ import { push } from "react-router-redux";
 import cx from "classnames";
 
 import _ from "underscore";
-import { IFRAMED } from "metabase/lib/dom";
+import { isIframe } from "metabase/lib/dom";
 
 import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
 import DashboardGrid from "metabase/dashboard/components/DashboardGrid";
@@ -109,7 +109,7 @@ class PublicDashboard extends Component {
       isFullscreen,
       isNightMode,
     } = this.props;
-    const buttons = !IFRAMED
+    const buttons = !isIframe()
       ? getDashboardActions(this, { ...this.props, isPublic: true })
       : [];
 

--- a/frontend/src/metabase/redux/embed.js
+++ b/frontend/src/metabase/redux/embed.js
@@ -10,6 +10,7 @@ const DEFAULT_OPTIONS = {
   search: false,
   new_button: false,
   breadcrumbs: true,
+  logo: true,
   header: true,
   additional_info: true,
   action_buttons: true,

--- a/frontend/src/metabase/redux/embed.js
+++ b/frontend/src/metabase/redux/embed.js
@@ -4,7 +4,7 @@ import {
   handleActions,
 } from "metabase/lib/redux";
 
-const DEFAULT_OPTIONS = {
+export const DEFAULT_EMBED_OPTIONS = {
   top_nav: true,
   side_nav: "default",
   search: false,
@@ -21,7 +21,10 @@ export const setOptions = createAction(SET_OPTIONS);
 
 const options = handleActions(
   {
-    [SET_OPTIONS]: (state, { payload }) => ({ ...DEFAULT_OPTIONS, ...payload }),
+    [SET_OPTIONS]: (state, { payload }) => ({
+      ...DEFAULT_EMBED_OPTIONS,
+      ...payload,
+    }),
   },
   {},
 );

--- a/frontend/src/metabase/redux/embed.ts
+++ b/frontend/src/metabase/redux/embed.ts
@@ -14,7 +14,7 @@ export const DEFAULT_EMBED_OPTIONS = {
   header: true,
   additional_info: true,
   action_buttons: true,
-};
+} as const;
 
 export const SET_OPTIONS = "metabase/embed/SET_OPTIONS";
 export const setOptions = createAction(SET_OPTIONS);

--- a/frontend/src/metabase/selectors/app.ts
+++ b/frontend/src/metabase/selectors/app.ts
@@ -72,7 +72,8 @@ export const getIsAppBarVisible = createSelector(
     const allEmbeddedAppBarElementsHidden =
       !embedOptions.search &&
       !embedOptions.new_button &&
-      !embedOptions.breadcrumbs;
+      !embedOptions.breadcrumbs &&
+      !embedOptions.logo;
     const isEmbeddedAppBarHidden =
       !embedOptions.top_nav || allEmbeddedAppBarElementsHidden;
     if (
@@ -107,6 +108,13 @@ export const getIsNavBarEnabled = createSelector(
       return EMBEDDED_PATHS_WITH_NAVBAR.some(pattern => pattern.test(path));
     }
     return !PATHS_WITHOUT_NAVBAR.some(pattern => pattern.test(path));
+  },
+);
+
+export const getIsLogoVisible = createSelector(
+  [getIsEmbedded, getEmbedOptions],
+  (isEmbedded, embedOptions) => {
+    return !isEmbedded || embedOptions.logo;
   },
 );
 

--- a/frontend/src/metabase/selectors/app.ts
+++ b/frontend/src/metabase/selectors/app.ts
@@ -1,7 +1,6 @@
 import { Location } from "history";
 import { createSelector } from "reselect";
-import { t } from "ttag";
-import { getUser, getUserIsAdmin } from "metabase/selectors/user";
+import { getUser } from "metabase/selectors/user";
 import {
   getIsEditing as getIsEditingDashboard,
   getDashboard,

--- a/frontend/src/metabase/selectors/app.ts
+++ b/frontend/src/metabase/selectors/app.ts
@@ -73,10 +73,43 @@ export const getIsQuestionLineageVisible = createSelector(
     PATHS_WITH_QUESTION_LINEAGE.some(pattern => pattern.test(path)),
 );
 
+export const getIsNavBarEnabled = createSelector(
+  [
+    getUser,
+    getRouterPath,
+    getIsEditingDashboard,
+    getIsEmbedded,
+    getEmbedOptions,
+  ],
+  (currentUser, path, isEditingDashboard, isEmbedded, embedOptions) => {
+    if (!currentUser || isEditingDashboard) {
+      return false;
+    }
+    if (isEmbedded && !embedOptions.side_nav) {
+      return false;
+    }
+    if (isEmbedded && embedOptions.side_nav === "default") {
+      return EMBEDDED_PATHS_WITH_NAVBAR.some(pattern => pattern.test(path));
+    }
+    return !PATHS_WITHOUT_NAVBAR.some(pattern => pattern.test(path));
+  },
+);
+
 const getIsEmbeddedAppBarVisible = createSelector(
-  [getEmbedOptions, getIsQuestionLineageVisible, getIsCollectionPathVisible],
-  (embedOptions, isQuestionLineageVisible, isCollectionPathVisible) => {
+  [
+    getEmbedOptions,
+    getIsQuestionLineageVisible,
+    getIsCollectionPathVisible,
+    getIsNavBarEnabled,
+  ],
+  (
+    embedOptions,
+    isQuestionLineageVisible,
+    isCollectionPathVisible,
+    isNavBarEnabled,
+  ) => {
     const anyEmbeddedAppBarElementVisible =
+      isNavBarEnabled ||
       embedOptions.search ||
       embedOptions.new_button ||
       embedOptions.logo ||
@@ -115,28 +148,6 @@ export const getIsAppBarVisible = createSelector(
       isFullscreen
     ) {
       return false;
-    }
-    return !PATHS_WITHOUT_NAVBAR.some(pattern => pattern.test(path));
-  },
-);
-
-export const getIsNavBarEnabled = createSelector(
-  [
-    getUser,
-    getRouterPath,
-    getIsEditingDashboard,
-    getIsEmbedded,
-    getEmbedOptions,
-  ],
-  (currentUser, path, isEditingDashboard, isEmbedded, embedOptions) => {
-    if (!currentUser || isEditingDashboard) {
-      return false;
-    }
-    if (isEmbedded && !embedOptions.side_nav) {
-      return false;
-    }
-    if (isEmbedded && embedOptions.side_nav === "default") {
-      return EMBEDDED_PATHS_WITH_NAVBAR.some(pattern => pattern.test(path));
     }
     return !PATHS_WITHOUT_NAVBAR.some(pattern => pattern.test(path));
   },

--- a/frontend/src/metabase/selectors/embed.ts
+++ b/frontend/src/metabase/selectors/embed.ts
@@ -1,8 +1,8 @@
-import { IFRAMED } from "metabase/lib/dom";
+import { isIframe } from "metabase/lib/dom";
 import { State } from "metabase-types/store";
 
 export const getIsEmbedded = () => {
-  return IFRAMED;
+  return isIframe();
 };
 
 export const getEmbedOptions = (state: State) => {

--- a/frontend/src/metabase/selectors/embed.ts
+++ b/frontend/src/metabase/selectors/embed.ts
@@ -1,8 +1,8 @@
-import { isIframe } from "metabase/lib/dom";
+import { isWithinIframe } from "metabase/lib/dom";
 import { State } from "metabase-types/store";
 
 export const getIsEmbedded = () => {
-  return isIframe();
+  return isWithinIframe();
 };
 
 export const getEmbedOptions = (state: State) => {

--- a/frontend/test/__support__/server-mocks/collection.ts
+++ b/frontend/test/__support__/server-mocks/collection.ts
@@ -10,7 +10,7 @@ import {
 
 export function setupCollectionsEndpoints(
   scope: Scope,
-  collections: Collection[],
+  collections: (typeof ROOT_COLLECTION | Collection)[] = [ROOT_COLLECTION],
 ) {
   scope.get("/api/collection").reply(200, collections);
   scope.get("/api/collection/tree?tree=true").reply(200, collections);

--- a/frontend/test/__support__/server-mocks/collection.ts
+++ b/frontend/test/__support__/server-mocks/collection.ts
@@ -10,11 +10,8 @@ import {
 
 export function setupCollectionsEndpoints(
   scope: Scope,
-  collections?: Collection[] | undefined,
+  collections: Collection[],
 ) {
-  if (collections == null) {
-    collections = [ROOT_COLLECTION as unknown as Collection];
-  }
   scope.get("/api/collection").reply(200, collections);
   scope.get("/api/collection/tree?tree=true").reply(200, collections);
   scope.get("/api/collection/root").reply(200, ROOT_COLLECTION);

--- a/frontend/test/__support__/server-mocks/collection.ts
+++ b/frontend/test/__support__/server-mocks/collection.ts
@@ -10,8 +10,11 @@ import {
 
 export function setupCollectionsEndpoints(
   scope: Scope,
-  collections: (typeof ROOT_COLLECTION | Collection)[] = [ROOT_COLLECTION],
+  collections?: Collection[] | undefined,
 ) {
+  if (collections == null) {
+    collections = [ROOT_COLLECTION as unknown as Collection];
+  }
   scope.get("/api/collection").reply(200, collections);
   scope.get("/api/collection/tree?tree=true").reply(200, collections);
   scope.get("/api/collection/root").reply(200, ROOT_COLLECTION);

--- a/frontend/test/__support__/ui.tsx
+++ b/frontend/test/__support__/ui.tsx
@@ -25,6 +25,7 @@ export interface RenderWithProvidersOptions {
   storeInitialState?: Partial<State>;
   withSampleDatabase?: boolean;
   withRouter?: boolean;
+  initialRouterPath?: string;
   withDND?: boolean;
 }
 
@@ -40,6 +41,7 @@ export function renderWithProviders(
     storeInitialState = {},
     withSampleDatabase,
     withRouter = false,
+    initialRouterPath,
     withDND = false,
     ...options
   }: RenderWithProvidersOptions = {},
@@ -63,6 +65,7 @@ export function renderWithProviders(
       {...props}
       store={store}
       withRouter={withRouter}
+      initialRouterPath={initialRouterPath}
       withDND={withDND}
     />
   );
@@ -82,18 +85,25 @@ function Wrapper({
   children,
   store,
   withRouter,
+  initialRouterPath,
   withDND,
 }: {
   children: React.ReactElement;
   store: any;
   withRouter: boolean;
+  initialRouterPath?: string;
   withDND: boolean;
 }): JSX.Element {
   return (
     <Provider store={store}>
       <MaybeDNDProvider hasDND={withDND}>
         <ThemeProvider theme={{}}>
-          <MaybeRouter hasRouter={withRouter}>{children}</MaybeRouter>
+          <MaybeRouter
+            hasRouter={withRouter}
+            initialRouterPath={initialRouterPath}
+          >
+            {children}
+          </MaybeRouter>
         </ThemeProvider>
       </MaybeDNDProvider>
     </Provider>
@@ -103,15 +113,16 @@ function Wrapper({
 function MaybeRouter({
   children,
   hasRouter,
+  initialRouterPath = "/",
 }: {
   children: React.ReactElement;
   hasRouter: boolean;
+  initialRouterPath?: string;
 }): JSX.Element {
   if (!hasRouter) {
     return children;
   }
-
-  const history = createMemoryHistory({ entries: ["/"] });
+  const history = createMemoryHistory({ entries: [initialRouterPath] });
 
   function Page(props: any) {
     return React.cloneElement(children, _.omit(props, "children"));
@@ -119,7 +130,7 @@ function MaybeRouter({
 
   return (
     <Router history={history}>
-      <Route path="/" component={Page} />
+      <Route path={initialRouterPath} component={Page} />
     </Router>
   );
 }

--- a/frontend/test/metabase/scenarios/embedding/embedding-full-app.cy.spec.js
+++ b/frontend/test/metabase/scenarios/embedding/embedding-full-app.cy.spec.js
@@ -1,4 +1,6 @@
+import Color from "color";
 import { restore } from "__support__/e2e/helpers";
+import { color } from "metabase/lib/colors";
 
 describe("scenarios > embedding > full app", () => {
   beforeEach(() => {
@@ -152,6 +154,15 @@ describe("scenarios > embedding > full app", () => {
           cy.findByTestId("main-logo").should("not.be.visible");
           cy.icon("sidebar_closed").should("be.visible");
         });
+        // Non-hovered color
+        cy.findByTestId("sidebar-toggle")
+          .children()
+          .should("have.css", "color", toRgbString(color("text-medium")));
+        // hovered color
+        cy.findByTestId("sidebar-toggle")
+          .realHover()
+          .children()
+          .should("have.css", "color", toRgbString(color("brand")));
 
         cy.findByTestId("sidebar-toggle").click();
         cy.findByText(/Add your own data/i).should("be.visible");
@@ -232,6 +243,16 @@ describe("scenarios > embedding > full app", () => {
           cy.findByTestId("main-logo").should("not.be.visible");
           cy.icon("sidebar_closed").should("be.visible");
         });
+
+        // non-hovered color
+        cy.findByTestId("sidebar-toggle")
+          .children()
+          .should("have.css", "color", toRgbString(color("brand")));
+        // hovered color
+        cy.findByTestId("sidebar-toggle")
+          .realHover()
+          .children()
+          .should("have.css", "color", toRgbString(color("brand")));
 
         cy.findByTestId("sidebar-toggle").click();
         cy.findByText(/Add your own data/i).should("be.visible");
@@ -373,3 +394,7 @@ const addLinkClickBehavior = ({ dashboardId, linkTemplate }) => {
     });
   });
 };
+
+function toRgbString(color) {
+  return Color(color).rgb().string();
+}

--- a/frontend/test/metabase/scenarios/embedding/embedding-full-app.cy.spec.js
+++ b/frontend/test/metabase/scenarios/embedding/embedding-full-app.cy.spec.js
@@ -327,6 +327,13 @@ describe("scenarios > embedding > full app", () => {
 
       cy.findAllByRole("cell").first().click();
       cy.wait("@getCardQuery");
+
+      // I don't know why this test starts to fail, but this command
+      // will force the cursor to move away from the app bar, if
+      // the cursor is still on the app bar, the logo will not be
+      // be visible, since we'll only see the side bar toggle button.
+      cy.findByRole("button", { name: /Filter/i }).realHover();
+
       cy.findByTestId("main-logo").should("be.visible");
     });
   });

--- a/frontend/test/metabase/scenarios/embedding/embedding-full-app.cy.spec.js
+++ b/frontend/test/metabase/scenarios/embedding/embedding-full-app.cy.spec.js
@@ -130,7 +130,6 @@ describe("scenarios > embedding > full app", () => {
       cy.button("Filter").should("not.exist");
     });
 
-    // TODO: move the whole suite to unit tests
     describe("desktop logo", () => {
       // This can't be unit test in AppBar since the logic to hide the AppBar is in its parent component
       it("should hide main header when there's nothing to display there", () => {
@@ -150,69 +149,7 @@ describe("scenarios > embedding > full app", () => {
         cy.viewport("iphone-x");
       });
 
-      it("should be able to toggle side nav", () => {
-        // default logo: true
-        visitQuestionUrl({ url: "/question/1", qs: { side_nav: true } });
-        cy.findByRole("banner").within(() => {
-          cy.findByText(/Our analytics/i).should("be.visible");
-          cy.findByTestId("main-logo").should("be.visible");
-        });
-
-        cy.findByTestId("sidebar-toggle").click();
-        cy.findByText(/Add your own data/i).should("be.visible");
-
-        cy.findByRole("banner").within(() => {
-          cy.findByText(/Our analytics/i).should("not.exist");
-          cy.findByTestId("main-logo").should("be.visible");
-        });
-      });
-
-      it("should hide side nav toggle icon on hover", () => {
-        // default logo: true
-        visitQuestionUrl({ url: "/question/1", qs: { side_nav: false } });
-        cy.findByRole("banner").within(() => {
-          cy.findByText(/Our analytics/i).should("be.visible");
-          cy.findByTestId("main-logo").should("be.visible");
-        });
-
-        cy.findByTestId("sidebar-toggle").should("not.exist");
-      });
-
-      it("should always show side nav toggle icon when logo is hidden", () => {
-        visitQuestionUrl({
-          url: "/question/1",
-          qs: { side_nav: true, logo: false },
-        });
-        cy.findByRole("banner").within(() => {
-          cy.findByText(/Our analytics/i).should("be.visible");
-          cy.findByTestId("main-logo").should("not.exist");
-          cy.icon("sidebar_closed").should("be.visible");
-        });
-
-        cy.findByTestId("sidebar-toggle").click();
-        cy.findByText(/Add your own data/i).should("be.visible");
-
-        cy.findByRole("banner").within(() => {
-          cy.findByText(/Our analytics/i).should("not.exist");
-          cy.findByTestId("main-logo").should("not.exist");
-          cy.icon("sidebar_open").should("be.visible");
-        });
-      });
-
-      it("should not show either logo or side nav toggle button at all", () => {
-        visitQuestionUrl({
-          url: "/question/1",
-          qs: { side_nav: false, logo: false },
-        });
-        cy.findByRole("banner").within(() => {
-          cy.findByText(/Our analytics/i).should("be.visible");
-          cy.findByTestId("main-logo").should("not.exist");
-          cy.icon("sidebar_closed").should("not.exist");
-        });
-
-        cy.findByTestId("sidebar-toggle").should("not.exist");
-      });
-
+      // This can't be unit test in AppBar since the logic to hide the AppBar is in its parent component
       it("should hide main header when there's nothing to display there", () => {
         visitQuestionUrl({
           url: "/question/1",

--- a/frontend/test/metabase/scenarios/embedding/embedding-full-app.cy.spec.js
+++ b/frontend/test/metabase/scenarios/embedding/embedding-full-app.cy.spec.js
@@ -132,17 +132,6 @@ describe("scenarios > embedding > full app", () => {
 
     // TODO: move the whole suite to unit tests
     describe("desktop logo", () => {
-      it("should hide side nav toggle icon on hover", () => {
-        // default logo: true
-        visitQuestionUrl({ url: "/question/1", qs: { side_nav: false } });
-        cy.findByRole("banner").within(() => {
-          cy.findByText(/Our analytics/i).should("be.visible");
-          cy.findByTestId("main-logo").should("be.visible");
-        });
-
-        cy.findByTestId("sidebar-toggle").should("not.exist");
-      });
-
       it("should always show side nav toggle icon when logo is hidden", () => {
         visitQuestionUrl({
           url: "/question/1",

--- a/frontend/test/metabase/scenarios/embedding/embedding-full-app.cy.spec.js
+++ b/frontend/test/metabase/scenarios/embedding/embedding-full-app.cy.spec.js
@@ -43,7 +43,7 @@ describe("scenarios > embedding > full app", () => {
       visitUrl({ url: "/", qs: { logo: false } });
       cy.findByText(/Bobby/).should("be.visible");
       cy.findByText("Our analytics").should("not.exist");
-      cy.button("sidebar-toggle").should("be.visible");
+      cy.button("Toggle sidebar").should("be.visible");
       cy.findByTestId("main-logo").should("not.exist");
     });
 
@@ -140,7 +140,7 @@ describe("scenarios > embedding > full app", () => {
         cy.findByRole("banner").should("not.exist");
         cy.findByTestId("main-logo").should("not.exist");
         cy.icon("sidebar_closed").should("not.exist");
-        cy.findByTestId("sidebar-toggle").should("not.exist");
+        cy.button("Toggle sidebar").should("not.exist");
       });
     });
 
@@ -158,7 +158,7 @@ describe("scenarios > embedding > full app", () => {
         cy.findByRole("banner").should("not.exist");
         cy.findByTestId("main-logo").should("not.exist");
         cy.icon("sidebar_closed").should("not.exist");
-        cy.findByTestId("sidebar-toggle").should("not.exist");
+        cy.button("Toggle sidebar").should("not.exist");
       });
     });
   });

--- a/frontend/test/metabase/scenarios/embedding/embedding-full-app.cy.spec.js
+++ b/frontend/test/metabase/scenarios/embedding/embedding-full-app.cy.spec.js
@@ -168,7 +168,7 @@ describe("scenarios > embedding > full app", () => {
         });
         cy.findByRole("banner").within(() => {
           cy.findByText(/Our analytics/i).should("be.visible");
-          cy.findByTestId("main-logo").should("not.be.visible");
+          cy.findByTestId("main-logo").should("not.exist");
           cy.icon("sidebar_closed").should("be.visible");
         });
         // Non-hovered color
@@ -186,7 +186,7 @@ describe("scenarios > embedding > full app", () => {
 
         cy.findByRole("banner").within(() => {
           cy.findByText(/Our analytics/i).should("not.be.visible");
-          cy.findByTestId("main-logo").should("not.be.visible");
+          cy.findByTestId("main-logo").should("not.exist");
           cy.icon("sidebar_open").should("be.visible");
         });
       });
@@ -198,7 +198,7 @@ describe("scenarios > embedding > full app", () => {
         });
         cy.findByRole("banner").within(() => {
           cy.findByText(/Our analytics/i).should("be.visible");
-          cy.findByTestId("main-logo").should("not.be.visible");
+          cy.findByTestId("main-logo").should("not.exist");
           cy.icon("sidebar_closed").should("not.exist");
         });
 
@@ -257,7 +257,7 @@ describe("scenarios > embedding > full app", () => {
         });
         cy.findByRole("banner").within(() => {
           cy.findByText(/Our analytics/i).should("be.visible");
-          cy.findByTestId("main-logo").should("not.be.visible");
+          cy.findByTestId("main-logo").should("not.exist");
           cy.icon("sidebar_closed").should("be.visible");
         });
 
@@ -276,7 +276,7 @@ describe("scenarios > embedding > full app", () => {
 
         cy.findByRole("banner").within(() => {
           cy.findByText(/Our analytics/i).should("not.exist");
-          cy.findByTestId("main-logo").should("not.be.visible");
+          cy.findByTestId("main-logo").should("not.exist");
           cy.icon("sidebar_open").should("be.visible");
         });
       });
@@ -288,7 +288,7 @@ describe("scenarios > embedding > full app", () => {
         });
         cy.findByRole("banner").within(() => {
           cy.findByText(/Our analytics/i).should("be.visible");
-          cy.findByTestId("main-logo").should("not.be.visible");
+          cy.findByTestId("main-logo").should("not.exist");
           cy.icon("sidebar_closed").should("not.exist");
         });
 

--- a/frontend/test/metabase/scenarios/embedding/embedding-full-app.cy.spec.js
+++ b/frontend/test/metabase/scenarios/embedding/embedding-full-app.cy.spec.js
@@ -13,24 +13,35 @@ describe("scenarios > embedding > full app", () => {
   describe("navigation", () => {
     it("should show the top nav and breadcrumbs by default", () => {
       visitUrl({ url: "/" });
+      cy.findByText(/Bobby/).should("be.visible");
       cy.findByText("Our analytics").should("be.visible");
       cy.findByTestId("main-logo").should("be.visible");
     });
 
     it("should hide the top nav by a param", () => {
       visitUrl({ url: "/", qs: { top_nav: false } });
+      cy.findByText(/Bobby/).should("be.visible");
       cy.findByText("Our analytics").should("not.exist");
       cy.findByTestId("main-logo").should("not.exist");
     });
 
-    it("should hide the top nav when all nav elements are hidden", () => {
+    it("should not hide the top nav when the logo is still visible", () => {
       visitUrl({ url: "/", qs: { breadcrumbs: false } });
+      cy.findByText(/Bobby/).should("be.visible");
+      cy.findByText("Our analytics").should("be.visible");
+      cy.findByTestId("main-logo").should("be.visible");
+    });
+
+    it("should hide the top nav when all nav elements are hidden", () => {
+      visitUrl({ url: "/", qs: { breadcrumbs: false, logo: false } });
+      cy.findByText(/Bobby/).should("be.visible");
       cy.findByText("Our analytics").should("not.exist");
       cy.findByTestId("main-logo").should("not.exist");
     });
 
     it("should show the top nav by a param", () => {
       visitUrl({ url: "/" });
+      cy.findByText(/Bobby/).should("be.visible");
       cy.findByTestId("main-logo").should("be.visible");
       cy.button(/New/).should("not.exist");
       cy.findByPlaceholderText("Search").should("not.exist");
@@ -38,22 +49,26 @@ describe("scenarios > embedding > full app", () => {
 
     it("should hide the side nav by a param", () => {
       visitUrl({ url: "/", qs: { side_nav: false } });
+      cy.findByText(/Bobby/).should("be.visible");
       cy.findByTestId("main-logo").should("be.visible");
       cy.findByText("Our analytics").should("not.exist");
     });
 
     it("should show question creation controls by a param", () => {
       visitUrl({ url: "/", qs: { new_button: true } });
+      cy.findByText(/Bobby/).should("be.visible");
       cy.button(/New/).should("be.visible");
     });
 
     it("should show search controls by a param", () => {
       visitUrl({ url: "/", qs: { search: true } });
+      cy.findByText(/Bobby/).should("be.visible");
       cy.findByPlaceholderText("Search…").should("be.visible");
     });
 
     it("should preserve params when navigating", () => {
       visitUrl({ url: "/" });
+      cy.findByText(/Bobby/).should("be.visible");
       cy.findByTestId("main-logo").should("be.visible");
 
       cy.findByText("Our analytics").click();
@@ -96,6 +111,162 @@ describe("scenarios > embedding > full app", () => {
       cy.icon("notebook").should("not.exist");
       cy.button("Summarize").should("not.exist");
       cy.button("Filter").should("not.exist");
+    });
+
+    describe("desktop logo", () => {
+      it("should be able to toggle side nav", () => {
+        // default logo: true
+        visitQuestionUrl({ url: "/question/1", qs: { side_nav: true } });
+        cy.findByRole("banner").within(() => {
+          cy.findByText(/Our analytics/i).should("be.visible");
+          cy.findByTestId("main-logo").should("be.visible");
+        });
+
+        cy.findByTestId("sidebar-toggle").click();
+        cy.findByText(/Add your own data/i).should("be.visible");
+
+        cy.findByRole("banner").within(() => {
+          cy.findByText(/Our analytics/i).should("not.be.visible");
+          cy.findByTestId("main-logo").should("be.visible");
+        });
+      });
+
+      it("should hide side nav toggle icon on hover", () => {
+        // default logo: true
+        visitQuestionUrl({ url: "/question/1", qs: { side_nav: false } });
+        cy.findByRole("banner").within(() => {
+          cy.findByText(/Our analytics/i).should("be.visible");
+          cy.findByTestId("main-logo").should("be.visible");
+        });
+
+        cy.findByTestId("sidebar-toggle").should("not.exist");
+      });
+
+      it("should always show side nav toggle icon when logo is hidden", () => {
+        visitQuestionUrl({
+          url: "/question/1",
+          qs: { side_nav: true, logo: false },
+        });
+        cy.findByRole("banner").within(() => {
+          cy.findByText(/Our analytics/i).should("be.visible");
+          cy.findByTestId("main-logo").should("not.be.visible");
+          cy.icon("sidebar_closed").should("be.visible");
+        });
+
+        cy.findByTestId("sidebar-toggle").click();
+        cy.findByText(/Add your own data/i).should("be.visible");
+
+        cy.findByRole("banner").within(() => {
+          cy.findByText(/Our analytics/i).should("not.be.visible");
+          cy.findByTestId("main-logo").should("not.be.visible");
+          cy.icon("sidebar_open").should("be.visible");
+        });
+      });
+
+      it("should not show either logo or side nav toggle button at all", () => {
+        visitQuestionUrl({
+          url: "/question/1",
+          qs: { side_nav: false, logo: false },
+        });
+        cy.findByRole("banner").within(() => {
+          cy.findByText(/Our analytics/i).should("be.visible");
+          cy.findByTestId("main-logo").should("not.be.visible");
+          cy.icon("sidebar_closed").should("not.exist");
+        });
+
+        cy.findByTestId("sidebar-toggle").should("not.exist");
+      });
+
+      it("should hide main header when there's nothing to display there", () => {
+        visitQuestionUrl({
+          url: "/question/1",
+          qs: { side_nav: false, logo: false, breadcrumbs: false },
+        });
+        cy.findByRole("banner").should("not.exist");
+        cy.findByTestId("main-logo").should("not.exist");
+        cy.icon("sidebar_closed").should("not.exist");
+        cy.findByTestId("sidebar-toggle").should("not.exist");
+      });
+    });
+
+    describe("mobile logo", () => {
+      beforeEach(() => {
+        cy.viewport("iphone-x");
+      });
+
+      it("should be able to toggle side nav", () => {
+        // default logo: true
+        visitQuestionUrl({ url: "/question/1", qs: { side_nav: true } });
+        cy.findByRole("banner").within(() => {
+          cy.findByText(/Our analytics/i).should("be.visible");
+          cy.findByTestId("main-logo").should("be.visible");
+        });
+
+        cy.findByTestId("sidebar-toggle").click();
+        cy.findByText(/Add your own data/i).should("be.visible");
+
+        cy.findByRole("banner").within(() => {
+          cy.findByText(/Our analytics/i).should("not.exist");
+          cy.findByTestId("main-logo").should("be.visible");
+        });
+      });
+
+      it("should hide side nav toggle icon on hover", () => {
+        // default logo: true
+        visitQuestionUrl({ url: "/question/1", qs: { side_nav: false } });
+        cy.findByRole("banner").within(() => {
+          cy.findByText(/Our analytics/i).should("be.visible");
+          cy.findByTestId("main-logo").should("be.visible");
+        });
+
+        cy.findByTestId("sidebar-toggle").should("not.exist");
+      });
+
+      it("should always show side nav toggle icon when logo is hidden", () => {
+        visitQuestionUrl({
+          url: "/question/1",
+          qs: { side_nav: true, logo: false },
+        });
+        cy.findByRole("banner").within(() => {
+          cy.findByText(/Our analytics/i).should("be.visible");
+          cy.findByTestId("main-logo").should("not.be.visible");
+          cy.icon("sidebar_closed").should("be.visible");
+        });
+
+        cy.findByTestId("sidebar-toggle").click();
+        cy.findByText(/Add your own data/i).should("be.visible");
+
+        cy.findByRole("banner").within(() => {
+          cy.findByText(/Our analytics/i).should("not.exist");
+          cy.findByTestId("main-logo").should("not.be.visible");
+          cy.icon("sidebar_open").should("be.visible");
+        });
+      });
+
+      it("should not show either logo or side nav toggle button at all", () => {
+        visitQuestionUrl({
+          url: "/question/1",
+          qs: { side_nav: false, logo: false },
+        });
+        cy.findByRole("banner").within(() => {
+          cy.findByText(/Our analytics/i).should("be.visible");
+          cy.findByTestId("main-logo").should("not.be.visible");
+          cy.icon("sidebar_closed").should("not.exist");
+        });
+
+        cy.findByTestId("sidebar-toggle").should("not.exist");
+      });
+
+      it("should hide main header when there's nothing to display there", () => {
+        visitQuestionUrl({
+          url: "/question/1",
+          qs: { side_nav: false, logo: false, breadcrumbs: false },
+        });
+        cy.findByRole("banner").should("not.exist");
+        cy.findByTestId("main-logo").should("not.exist");
+        cy.icon("sidebar_closed").should("not.exist");
+        cy.findByTestId("sidebar-toggle").should("not.exist");
+      });
     });
   });
 

--- a/frontend/test/metabase/scenarios/embedding/embedding-full-app.cy.spec.js
+++ b/frontend/test/metabase/scenarios/embedding/embedding-full-app.cy.spec.js
@@ -132,23 +132,6 @@ describe("scenarios > embedding > full app", () => {
 
     // TODO: move the whole suite to unit tests
     describe("desktop logo", () => {
-      it("should be able to toggle side nav", () => {
-        // default logo: true
-        visitQuestionUrl({ url: "/question/1", qs: { side_nav: true } });
-        cy.findByRole("banner").within(() => {
-          cy.findByText(/Our analytics/i).should("be.visible");
-          cy.findByTestId("main-logo").should("be.visible");
-        });
-
-        cy.findByTestId("sidebar-toggle").click();
-        cy.findByText(/Add your own data/i).should("be.visible");
-
-        cy.findByRole("banner").within(() => {
-          cy.findByText(/Our analytics/i).should("not.be.visible");
-          cy.findByTestId("main-logo").should("be.visible");
-        });
-      });
-
       it("should hide side nav toggle icon on hover", () => {
         // default logo: true
         visitQuestionUrl({ url: "/question/1", qs: { side_nav: false } });

--- a/frontend/test/metabase/scenarios/embedding/embedding-full-app.cy.spec.js
+++ b/frontend/test/metabase/scenarios/embedding/embedding-full-app.cy.spec.js
@@ -1,6 +1,4 @@
-import Color from "color";
 import { restore } from "__support__/e2e/helpers";
-import { color } from "metabase/lib/colors";
 
 describe("scenarios > embedding > full app", () => {
   beforeEach(() => {
@@ -171,15 +169,6 @@ describe("scenarios > embedding > full app", () => {
           cy.findByTestId("main-logo").should("not.exist");
           cy.icon("sidebar_closed").should("be.visible");
         });
-        // Non-hovered color
-        cy.findByTestId("sidebar-toggle")
-          .children()
-          .should("have.css", "color", toRgbString(color("text-medium")));
-        // hovered color
-        cy.findByTestId("sidebar-toggle")
-          .realHover()
-          .children()
-          .should("have.css", "color", toRgbString(color("brand")));
 
         cy.findByTestId("sidebar-toggle").click();
         cy.findByText(/Add your own data/i).should("be.visible");
@@ -260,16 +249,6 @@ describe("scenarios > embedding > full app", () => {
           cy.findByTestId("main-logo").should("not.exist");
           cy.icon("sidebar_closed").should("be.visible");
         });
-
-        // non-hovered color
-        cy.findByTestId("sidebar-toggle")
-          .children()
-          .should("have.css", "color", toRgbString(color("brand")));
-        // hovered color
-        cy.findByTestId("sidebar-toggle")
-          .realHover()
-          .children()
-          .should("have.css", "color", toRgbString(color("brand")));
 
         cy.findByTestId("sidebar-toggle").click();
         cy.findByText(/Add your own data/i).should("be.visible");
@@ -418,7 +397,3 @@ const addLinkClickBehavior = ({ dashboardId, linkTemplate }) => {
     });
   });
 };
-
-function toRgbString(color) {
-  return Color(color).rgb().string();
-}

--- a/frontend/test/metabase/scenarios/embedding/embedding-full-app.cy.spec.js
+++ b/frontend/test/metabase/scenarios/embedding/embedding-full-app.cy.spec.js
@@ -12,7 +12,14 @@ describe("scenarios > embedding > full app", () => {
     cy.intercept("GET", "/api/automagic-dashboards/**").as("getXrayDashboard");
   });
 
-  describe("navigation", () => {
+  describe("home page navigation", () => {
+    it("should hide the top nav when nothing is shown", () => {
+      visitUrl({ url: "/", qs: { side_nav: false, logo: false } });
+      cy.findByText(/Bobby/).should("be.visible");
+      cy.findByText("Our analytics").should("not.exist");
+      cy.findByTestId("main-logo").should("not.exist");
+    });
+
     it("should show the top nav and breadcrumbs by default", () => {
       visitUrl({ url: "/" });
       cy.findByText(/Bobby/).should("be.visible");
@@ -76,6 +83,15 @@ describe("scenarios > embedding > full app", () => {
       cy.findByText("Our analytics").click();
       cy.findByText("Orders in a dashboard").should("be.visible");
       cy.findByTestId("main-logo").should("be.visible");
+    });
+  });
+
+  describe("browse data", () => {
+    it("should hide the top nav when nothing is shown", () => {
+      visitUrl({ url: "/browse", qs: { side_nav: false, logo: false } });
+      cy.findByText("Our data").should("be.visible");
+      cy.findByText("Our analytics").should("not.exist");
+      cy.findByTestId("main-logo").should("not.exist");
     });
   });
 

--- a/frontend/test/metabase/scenarios/embedding/embedding-full-app.cy.spec.js
+++ b/frontend/test/metabase/scenarios/embedding/embedding-full-app.cy.spec.js
@@ -130,6 +130,7 @@ describe("scenarios > embedding > full app", () => {
       cy.button("Filter").should("not.exist");
     });
 
+    // TODO: move the whole suite to unit tests
     describe("desktop logo", () => {
       it("should be able to toggle side nav", () => {
         // default logo: true

--- a/frontend/test/metabase/scenarios/embedding/embedding-full-app.cy.spec.js
+++ b/frontend/test/metabase/scenarios/embedding/embedding-full-app.cy.spec.js
@@ -42,9 +42,10 @@ describe("scenarios > embedding > full app", () => {
     });
 
     it("should hide the top nav when all nav elements are hidden", () => {
-      visitUrl({ url: "/", qs: { breadcrumbs: false, logo: false } });
+      visitUrl({ url: "/", qs: { logo: false } });
       cy.findByText(/Bobby/).should("be.visible");
       cy.findByText("Our analytics").should("not.exist");
+      cy.button("sidebar-toggle").should("be.visible");
       cy.findByTestId("main-logo").should("not.exist");
     });
 

--- a/frontend/test/metabase/scenarios/embedding/embedding-full-app.cy.spec.js
+++ b/frontend/test/metabase/scenarios/embedding/embedding-full-app.cy.spec.js
@@ -132,41 +132,7 @@ describe("scenarios > embedding > full app", () => {
 
     // TODO: move the whole suite to unit tests
     describe("desktop logo", () => {
-      it("should always show side nav toggle icon when logo is hidden", () => {
-        visitQuestionUrl({
-          url: "/question/1",
-          qs: { side_nav: true, logo: false },
-        });
-        cy.findByRole("banner").within(() => {
-          cy.findByText(/Our analytics/i).should("be.visible");
-          cy.findByTestId("main-logo").should("not.exist");
-          cy.icon("sidebar_closed").should("be.visible");
-        });
-
-        cy.findByTestId("sidebar-toggle").click();
-        cy.findByText(/Add your own data/i).should("be.visible");
-
-        cy.findByRole("banner").within(() => {
-          cy.findByText(/Our analytics/i).should("not.be.visible");
-          cy.findByTestId("main-logo").should("not.exist");
-          cy.icon("sidebar_open").should("be.visible");
-        });
-      });
-
-      it("should not show either logo or side nav toggle button at all", () => {
-        visitQuestionUrl({
-          url: "/question/1",
-          qs: { side_nav: false, logo: false },
-        });
-        cy.findByRole("banner").within(() => {
-          cy.findByText(/Our analytics/i).should("be.visible");
-          cy.findByTestId("main-logo").should("not.exist");
-          cy.icon("sidebar_closed").should("not.exist");
-        });
-
-        cy.findByTestId("sidebar-toggle").should("not.exist");
-      });
-
+      // This can't be unit test in AppBar since the logic to hide the AppBar is in its parent component
       it("should hide main header when there's nothing to display there", () => {
         visitQuestionUrl({
           url: "/question/1",


### PR DESCRIPTION
Issue: #27293

Allow users to disable/hide logo in embedding by the param `logo` (defaults to `true`)

#### How to test
1. Run Metabase with this branch as an enterprise user (port 3000)
1. Configure enterprise token
1. Enable JWT authentication and make sure you set the secret to `ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff` https://github.com/metabase/sso-examples/blob/master/app-embed-example/server.js#L9-L10
1. Clone https://github.com/metabase/sso-examples
1. Go to `/app-embed-example/`
1. Run `yarn dev` (it will start port 3001 and 3002)
1. Go to http://localhost:3001/analytics and test if embedding shows breadcrumbs as desired.
1. You could try append different parameters to see it in action e.g.
    1. `?logo=false`
    2. `?logo=false&side_nav=true`
    3. `?logo=false&breadcrumbs=false`
    4. `?breadcrumbs=false` 
1. Test mobile view.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/27391)
<!-- Reviewable:end -->
