### PR TITLE
Remove panning logic from map boundary calculation

### DIFF
--- a/frontend/src/metabase/admin/settings/components/SettingsSetting.jsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsSetting.jsx
@@ -63,7 +63,7 @@ export default class SettingsSetting extends Component {
 
     return (
       // TODO - this formatting needs to be moved outside this component
-      <SettingRoot>
+      <SettingRoot data-testid={`${setting.key}-setting`}>
         {!setting.noHeader && (
           <SettingHeader id={settingId} setting={setting} />
         )}

--- a/frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/CustomGeoJSONWidget.jsx
@@ -317,7 +317,7 @@ const EditMap = ({
   onCancel,
   onSave,
 }) => (
-  <div>
+  <div data-testid="edit-map-modal">
     <div className="flex">
       <div className="flex-no-shrink">
         <h2>{!originalMap ? t`Add a new map` : t`Edit map`}</h2>

--- a/frontend/src/metabase/visualizations/components/LeafletChoropleth.jsx
+++ b/frontend/src/metabase/visualizations/components/LeafletChoropleth.jsx
@@ -81,22 +81,6 @@ const LeafletChoropleth = ({
         }),
       ]).addTo(map);
 
-      // // left and right duplicates so we can pan a bit
-      // L.featureGroup([
-      //   L.geoJson(geoJson, {
-      //     style,
-      //     onEachFeature,
-      //     coordsToLatLng: ([longitude, latitude]) =>
-      //       L.latLng(latitude, longitude - 360),
-      //   }),
-      //   L.geoJson(geoJson, {
-      //     style,
-      //     onEachFeature,
-      //     coordsToLatLng: ([longitude, latitude]) =>
-      //       L.latLng(latitude, longitude + 360),
-      //   }),
-      // ]).addTo(map);
-
       map.fitBounds(minimalBounds);
 
       return () => {

--- a/frontend/src/metabase/visualizations/lib/mapping.js
+++ b/frontend/src/metabase/visualizations/lib/mapping.js
@@ -3,55 +3,13 @@ import d3 from "d3";
 
 export function computeMinimalBounds(features) {
   const points = getAllFeaturesPoints(features);
-  const gap = computeLargestGap(points, d => d[0]);
   const [west, east] = d3.extent(points, d => d[0]);
   const [north, south] = d3.extent(points, d => d[1]);
 
-  const normalGapSize = gap[1] - gap[0];
-  const antemeridianGapSize = 180 + west + (180 - east);
-
-  if (antemeridianGapSize > normalGapSize) {
-    return L.latLngBounds(
-      L.latLng(south, west), // SW
-      L.latLng(north, east), // NE
-    );
-  } else {
-    return L.latLngBounds(
-      L.latLng(south, -360 + gap[1]), // SW
-      L.latLng(north, gap[0]), // NE
-    );
-  }
-}
-
-export function computeLargestGap(items, valueAccessor = d => d) {
-  const [xMin, xMax] = d3.extent(items, valueAccessor);
-  if (xMin === xMax) {
-    return [xMin, xMax];
-  }
-
-  const buckets = [];
-  const bucketSize = (xMax - xMin) / items.length;
-  for (const item of items) {
-    const x = valueAccessor(item);
-    const k = Math.floor((x - xMin) / bucketSize);
-    if (buckets[k] === undefined) {
-      buckets[k] = [x, x];
-    } else {
-      buckets[k] = [Math.min(x, buckets[k][0]), Math.max(x, buckets[k][1])];
-    }
-  }
-  let largestGap = [0, 0];
-  for (let i = 0; i < items.length; i++) {
-    if (buckets[i + 1] === undefined) {
-      buckets[i + 1] = buckets[i];
-    } else if (
-      buckets[i + 1][0] - buckets[i][1] >
-      largestGap[1] - largestGap[0]
-    ) {
-      largestGap = [buckets[i][1], buckets[i + 1][0]];
-    }
-  }
-  return largestGap;
+  return L.latLngBounds(
+    L.latLng(south, west), // SW
+    L.latLng(north, east), // NE
+  );
 }
 
 export function getAllFeaturesPoints(features) {

--- a/frontend/test/metabase-visual/visualizations/map.cy.spec.js
+++ b/frontend/test/metabase-visual/visualizations/map.cy.spec.js
@@ -1,0 +1,66 @@
+import { restore, visitQuestionAdhoc } from "__support__/e2e/helpers";
+import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
+
+describe("visual tests > visualizations > map", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+  });
+
+  const customGeoJsonUrl =
+    "https://raw.githubusercontent.com/metabase/metabase/master/resources/frontend_client/app/assets/geojson/world.json";
+  const testMapName = "My Test Map";
+
+  const saveCustomMap = () => {
+    cy.request("PUT", "/api/setting/custom-geojson", {
+      value: {
+        "my-test-map-id": {
+          name: testMapName,
+          url: customGeoJsonUrl,
+          region_key: "NAME",
+          region_name: "NAME",
+        },
+      },
+    });
+  };
+
+  it("properly displays custom maps in settings", () => {
+    cy.visit("/admin/settings/maps");
+
+    cy.findByTestId("custom-geojson-setting").within(() => {
+      cy.findByText("Add a map").click();
+    });
+
+    cy.findByTestId("edit-map-modal").within(() => {
+      cy.findByPlaceholderText(/e.g. United Kingdom/i).type(testMapName);
+      cy.findByPlaceholderText(/my-map.json/i).type(customGeoJsonUrl);
+      cy.findByText("Load").click();
+    });
+
+    cy.createPercySnapshot();
+  });
+
+  it("properly displays custom map in query builder", () => {
+    saveCustomMap();
+
+    const testQuery = {
+      type: "native",
+      native: {
+        query:
+          "SELECT 'Brazil' region, 23 val UNION " +
+          "SELECT 'Algeria' region, 42 val;",
+      },
+      database: SAMPLE_DB_ID,
+    };
+
+    visitQuestionAdhoc({
+      dataset_query: testQuery,
+      display: "map",
+      visualization_settings: {
+        "map.region": "my-test-map-id",
+      },
+    });
+
+    cy.createPercySnapshot();
+  });
+});

--- a/frontend/test/metabase-visual/visualizations/map.cy.spec.js
+++ b/frontend/test/metabase-visual/visualizations/map.cy.spec.js
@@ -37,6 +37,10 @@ describe("visual tests > visualizations > map", () => {
       cy.findByText("Load").click();
     });
 
+    cy.findByTestId("loading-spinner").should("not.exist");
+    cy.findByLabelText("hourglass icon").should("not.exist");
+    cy.get(".leaflet-container").should("be.visible");
+
     cy.createPercySnapshot();
   });
 
@@ -60,6 +64,10 @@ describe("visual tests > visualizations > map", () => {
         "map.region": "my-test-map-id",
       },
     });
+
+    cy.findByTestId("loading-spinner").should("not.exist");
+    cy.findByLabelText("hourglass icon").should("not.exist");
+    cy.get(".leaflet-container").should("be.visible");
 
     cy.createPercySnapshot();
   });


### PR DESCRIPTION
Resolves #26213 

## Story Time

### Chapter 1

Once upon a time, some maps in metabase would repeat themselves, to make the left-right panning experience nicer: e.g. it would be easier to center a global map on Japan, even though most global maps center on Europe. This functionality was removed in https://github.com/metabase/metabase/pull/22427 because it looked a little funny and users reported it as a bug. In order to make maps appear correctly after repeating was removed, we added this code to center maps:

https://github.com/metabase/metabase/blob/ccac9d9af9addbc8eb689a802b5d5ccb92b1638a/frontend/src/metabase/visualizations/components/LeafletChoropleth.jsx#L103

And all was well. (spoiler: it was not all well).

### Chapter 2

Later on, we discovered an issue where users "couldn't load" new maps https://github.com/metabase/metabase/issues/23450 (spoiler: in fact, maps would load just fine, their previews just wouldn't appear for some reason)

It appeared that the panning code actually was pushing the maps out of the viewport, and [removing the panning code](https://github.com/metabase/metabase/pull/23454) fixed everything! (spoiler: it did not fix everything)

### Chapter 3

And it came to pass that again, we have a reported issue that certain maps seem to be squished to the side and cut off 🤔 

![199487692-6d131fbf-55db-400a-8ccf-aaaa4ed675e0](https://user-images.githubusercontent.com/30528226/209230552-a66ad1fe-f6ed-4838-8da9-93ae6b84552a.png)

But some maps are totally fine:
![Screen Shot 2022-12-22 at 2 50 01 PM](https://user-images.githubusercontent.com/30528226/209232068-cc0b8218-4b6f-4868-be2e-0cb5bb735f09.png)

What if we just stick the panning code back in?
![Screen Shot 2022-12-22 at 2 49 28 PM](https://user-images.githubusercontent.com/30528226/209232177-bc5745a7-0c43-46a3-ac60-24bb5771a586.png)

Hooray! we've saved the world, but it cost us California, the UK and the Pacific Islands. 😢 

Alright? what's really going on here? 

Well, it turns out that in the code that sets map boundaries, for certain large maps, it sets ridiculously large boundaries  (wait for it...) to allow you to pan side to side.

## Changes

Deleted the conditional and calculations that set map boundaries wide enough to allow side-to-side map panning.

![Screen Shot 2022-12-22 at 2 19 45 PM](https://user-images.githubusercontent.com/30528226/209232546-ab9aada1-36c1-4cd5-b31b-8a0b848f3a34.png)

And all the maps are happy now.

## Testing Steps

I used all of these test maps to make sure they appeared correctly, in the map loader (in admin settings), and in the query builder, and in dashboards.
```
https://raw.githubusercontent.com/metabase/metabase/master/resources/frontend_client/app/assets/geojson/world.json
https://raw.githubusercontent.com/johan/world.geo.json/master/countries.geo.json
https://raw.githubusercontent.com/datasets/geo-countries/master/data/countries.geojson
https://raw.githubusercontent.com/codeforgermany/click_that_hood/main/public/data/california-counties.geojson
https://pacificdata.org/data/dataset/964dbebf-2f42-414e-bf99-dd7125eedb16/resource/dad3f7b2-a8aa-4584-8bca-a77e16a391fe/download/country_boundary_eez.geojson
https://gist.githubusercontent.com/iethree/ec57ec72e12fb61d74a595a1e88a2826/raw/d02fb28577f76c41d07fb07131f4d0ec8067839c/uk_regions.geojson
https://raw.githubusercontent.com/codeforgermany/click_that_hood/main/public/data/africa.geojson
```

~Gonna poke around a bit and see if there's a way to unit test this. 🕵️‍♀️~
It appears that JSDOM doesn't really support svg rendering, so any meaningful unit tests are impossible with our current test setup.
https://stackoverflow.com/questions/54382414/fixing-react-leaflet-testing-error-cannot-read-property-layeradd-of-null/54384719#54384719