### PR TITLE
Repro #24839: Can't aggregate if source is the aggregated question

### DIFF
--- a/frontend/test/metabase/scenarios/question/reproductions/24839-summarize-source-question-with-summarization.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/reproductions/24839-summarize-source-question-with-summarization.cy.spec.js
@@ -1,0 +1,57 @@
+import { restore, visitQuestionAdhoc, popover } from "__support__/e2e/helpers";
+import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
+import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
+
+const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
+
+const questionDetails = {
+  name: "24839",
+  query: {
+    "source-table": ORDERS_ID,
+    aggregation: [
+      ["sum", ["field", ORDERS.QUANTITY, null]],
+      ["avg", ["field", ORDERS.TOTAL, null]],
+    ],
+    breakout: [["field", ORDERS.CREATED_AT, { "temporal-unit": "month" }]],
+  },
+  display: "line",
+};
+
+describe("issue 24839: should be able to summarize a nested question based on the source question with aggregations (metabase#24839)", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+
+    cy.createQuestion(questionDetails).then(({ body: { id } }) => {
+      // Start ad-hoc nested question based on the saved one
+      visitQuestionAdhoc({
+        dataset_query: {
+          database: SAMPLE_DB_ID,
+          query: { "source-table": `card__${id}` },
+          type: "query",
+        },
+      });
+    });
+  });
+
+  it.skip("from the notebook GUI (metabase#24839-1)", () => {
+    cy.icon("notebook").click();
+    cy.findByText("Summarize").click();
+    cy.findByText("Sum of ...").click();
+    popover()
+      .should("contain", "Sum of Quantity")
+      .and("contain", "Average of Total");
+  });
+
+  it("from a table header cell (metabase#24839-2)", () => {
+    cy.findAllByTestId("header-cell").contains("Average of Total").click();
+
+    popover().contains("Distinct values").click();
+
+    cy.get(".ScalarValue").invoke("text").should("eq", "49");
+
+    cy.findByTestId("aggregation-item")
+      .invoke("text")
+      .should("eq", "Distinct values of Average of Total");
+  });
+});


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #24839

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/question/reproductions/24839-summarize-source-question-with-summarization.cy.spec.js`
- Replace `it.skip()` with `it.only()` to run the test in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
Scenario 1: Direct repro of the issue (trying to summarize from the notebook editor)
![image](https://user-images.githubusercontent.com/31325167/209332354-fa6ce0f9-2e8d-4d17-ba67-8a6ccdc7e4a2.png)

Scenario 2: Trying to summarize from the header cell
![image](https://user-images.githubusercontent.com/31325167/209332380-ca019f95-c00a-4602-b0ca-087e33d2a538.png)