### PR TITLE
Repro #25994: Between specific dates filter fails after aggregation

### DIFF
--- a/frontend/test/metabase/scenarios/filters/reproductions/25994-between-after-summarize-not-working.cy.spec.js
+++ b/frontend/test/metabase/scenarios/filters/reproductions/25994-between-after-summarize-not-working.cy.spec.js
@@ -4,6 +4,7 @@ import {
   popover,
   visualize,
 } from "__support__/e2e/helpers";
+import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
 const { PRODUCTS, PRODUCTS_ID } = SAMPLE_DATABASE;
@@ -18,7 +19,7 @@ const questionDetails = {
       ],
       breakout: [["field", PRODUCTS.CATEGORY, null]],
     },
-    database: 1,
+    database: SAMPLE_DB_ID,
   },
 };
 

--- a/frontend/test/metabase/scenarios/filters/reproductions/25994-between-after-summarize-not-working.cy.spec.js
+++ b/frontend/test/metabase/scenarios/filters/reproductions/25994-between-after-summarize-not-working.cy.spec.js
@@ -1,0 +1,46 @@
+import {
+  restore,
+  visitQuestionAdhoc,
+  popover,
+  visualize,
+} from "__support__/e2e/helpers";
+import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
+
+const { PRODUCTS, PRODUCTS_ID } = SAMPLE_DATABASE;
+
+const questionDetails = {
+  dataset_query: {
+    type: "query",
+    query: {
+      "source-table": PRODUCTS_ID,
+      aggregation: [
+        ["min", ["field", PRODUCTS.CREATED_AT, { "temporal-unit": "day" }]],
+      ],
+      breakout: [["field", PRODUCTS.CATEGORY, null]],
+    },
+    database: 1,
+  },
+};
+
+describe.skip("issue 25994", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+
+    visitQuestionAdhoc(questionDetails);
+    cy.icon("notebook").click();
+  });
+
+  it("should be possible to use 'between' dates filter after aggregation (metabase#25994)", () => {
+    cy.findByText("Filter").click();
+    popover().findByText("Min of Created At: Day").click();
+    cy.findByText("Specific dates...").click();
+
+    // It doesn't really matter which dates we select so let's go with whatever is offered
+    cy.button("Add filter").click();
+
+    visualize(response => {
+      expect(response.body.error).to.not.exist;
+    });
+  });
+});


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #25994

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/filters/reproductions/25994-between-after-summarize-not-working.cy.spec.js`
- Unskip repro
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/209363637-302026b9-22ef-4581-bdc4-38be7a2ecc6a.png)

