### PR TITLE
[Chore] Upgrade Husky to the latest `v8.0.2`

### DIFF
--- a/package.json
+++ b/package.json
@@ -218,7 +218,7 @@
     "glob": "^7.1.1",
     "html-webpack-harddisk-plugin": "^2.0.0",
     "html-webpack-plugin": "5.5.0",
-    "husky": "^7.0.4",
+    "husky": "^8.0.2",
     "jest": "^29.3.1",
     "jest-canvas-mock": "^2.4.0",
     "jest-environment-jsdom": "^29.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12424,10 +12424,10 @@ humanize-plus@^1.8.1:
   resolved "https://registry.yarnpkg.com/humanize-plus/-/humanize-plus-1.8.2.tgz#a65b34459ad6367adbb3707a82a3c9f916167030"
   integrity sha1-pls0RZrWNnrbs3B6gqPJ+RYWcDA=
 
-husky@^7.0.4:
-  version "7.0.4"
-  resolved "https://registry.yarnpkg.com/husky/-/husky-7.0.4.tgz#242048245dc49c8fb1bf0cc7cfb98dd722531535"
-  integrity sha512-vbaCKN2QLtP/vD4yvs6iz6hBEo6wkSzs8HpRah1Z6aGmF2KW5PdYuAd7uX5a+OyBZHBhd+TFLqgjUgytQr4RvQ==
+husky@^8.0.2:
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-8.0.2.tgz#5816a60db02650f1f22c8b69b928fd6bcd77a236"
+  integrity sha512-Tkv80jtvbnkK3mYWxPZePGFpQ/tT3HNSs/sasF9P2YfkMezDl3ON37YN6jUUI4eTg5LcyVynlb6r4eyvOmspvg==
 
 icepick@2.4.0:
   version "2.4.0"


### PR DESCRIPTION
We were one major version behind.
Looking at the Husky changelog, there were no breaking changes.