### PR TITLE
Switch back to main fork of `clojure.java-time` and bump version to latest

### DIFF
--- a/.github/workflows/e2e-main.yml
+++ b/.github/workflows/e2e-main.yml
@@ -30,12 +30,9 @@ jobs:
     - name: Prepare back-end environment
       uses: ./.github/actions/prepare-backend
 
-    - run: ./bin/build version
-    - run: ./bin/build translations
-    - run: ./bin/build frontend
-    - run: ./bin/build licenses
-    - run: ./bin/build drivers
-    - run: ./bin/build uberjar
+    - name: Build uberjar with ./bin/build
+      run: >-
+        ./bin/build version translations frontend licenses drivers uberjar
 
     - name: Prepare uberjar artifact
       uses: ./.github/actions/prepare-uberjar-artifact

--- a/deps.edn
+++ b/deps.edn
@@ -21,6 +21,7 @@
                                              :exclusions  [commons-codec/commons-codec
                                                            commons-io/commons-io
                                                            slingshot/slingshot]}
+  clojure.java-time/clojure.java-time       {:mvn/version "1.1.0"}              ; java.time utilities
   clojurewerkz/quartzite                    {:mvn/version "2.1.0"               ; scheduling library
                                              :exclusions  [c3p0/c3p0
                                                            org.quartz-scheduler/quartz]}
@@ -143,7 +144,6 @@
   ring/ring-core                            {:mvn/version "1.9.6"}              ; web server (Jetty wrapper)
   ring/ring-jetty-adapter                   {:mvn/version "1.9.6"}              ; Ring adapter using Jetty webserver
   ring/ring-json                            {:mvn/version "0.5.1"}              ; Ring middleware for reading/writing JSON automatically
-  robdaemon/clojure.java-time               {:mvn/version "0.3.3-SNAPSHOT"}     ; Java 8 java.time wrapper. Use this fork until https://github.com/dm3/clojure.java-time/issues/77 is fixed upstream
   slingshot/slingshot                       {:mvn/version "0.12.2"}             ; enhanced throw/catch, used by other deps
   stencil/stencil                           {:mvn/version "0.5.0"}              ; Mustache templates for Clojure
   toucan/toucan                             {:mvn/version "1.18.0"              ; Model layer, hydration, and DB utilities

--- a/src/metabase/util/date_2.clj
+++ b/src/metabase/util/date_2.clj
@@ -297,7 +297,12 @@
       :hours   t
       :days    t)))
 
-(def truncate-units  "Valid date trucation units"
+;;; See https://github.com/dm3/clojure.java-time/issues/95. We need to update the `java-time/truncate-to` copy of the
+;;; actual underlying method since `extend-protocol` mutates the var
+(alter-var-root #'t/truncate-to (constantly t.core/truncate-to))
+
+(def truncate-units
+  "Valid date trucation units"
   #{:millisecond :second :minute :hour :day :week :month :quarter :year})
 
 (s/defn truncate :- Temporal


### PR DESCRIPTION
We had been using a fork of `clojure.java-time` while waiting for the library author to cut a new release with the fix for https://github.com/dm3/clojure.java-time/issues/77 included. Now that they have cut a new release, we don't need to be using the fork anymore.

We're pulling in `clojure.java-time` as a transient dependency of some of other other libraries, and some of these have updated to a newer version of `clojure.java-time`. The new version is not completely compatible with the old version.

Because we had both our fork and the newer version of the lib (as a transient dependency) present, builds could sometimes break with errors like 

```
      Syntax error compiling at (java_time/temporal.clj:323:1).
      No such var: jt.u/when-class
```

I think this was a race condition, which is why we didn't catch it in CI. So far, I only know of this being triggered locally.