### PR TITLE
[CI] Fix flag type in `codecov` workflow

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,6 @@
 codecov:
     bot: "codecov-io"
-    require_ci_to_pass: no
+    require_ci_to_pass: false
 
 coverage:
   status:


### PR DESCRIPTION
According to the [codecov schema](https://json.schemastore.org/codecov.json), `require_ci_to_pass` needs a Boolean flag type.

**Before**
VSCode compains
![image](https://user-images.githubusercontent.com/31325167/209653707-7440e13b-6887-4c12-985c-7f7418a5b788.png)

**Now**
There should be no warnings
![image](https://user-images.githubusercontent.com/31325167/209653756-79f34ed0-8a8c-4d4a-a403-9278388df3d7.png)
