### PR TITLE
Repro #27356: Moving between dashboards with/without filter triggers an error

### DIFF
--- a/frontend/test/metabase/scenarios/dashboard-filters/reproductions/27356-navigation-between-two-dashboards.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters/reproductions/27356-navigation-between-two-dashboards.cy.spec.js
@@ -1,0 +1,52 @@
+import {
+  restore,
+  openNavigationSidebar,
+  visitDashboard,
+} from "__support__/e2e/helpers";
+
+const ratingFilter = {
+  name: "Text",
+  slug: "text",
+  id: "5dfco74e",
+  type: "string/=",
+  sectionId: "string",
+};
+
+const paramDashboard = {
+  name: "Dashboard With Params",
+  parameters: [ratingFilter],
+};
+
+const regularDashboard = {
+  name: "Dashboard Without Params",
+};
+
+describe.skip("issue 27356", () => {
+  beforeEach(() => {
+    cy.intercept("GET", "/api/dashboard/*").as("getDashboard");
+    restore();
+    cy.signInAsAdmin();
+
+    cy.createDashboard(paramDashboard).then(({ body: { id } }) => {
+      cy.request("POST", `/api/bookmark/dashboard/${id}`);
+    });
+
+    cy.createDashboard(regularDashboard).then(({ body: { id } }) => {
+      cy.request("POST", `/api/bookmark/dashboard/${id}`);
+      visitDashboard(id);
+    });
+  });
+
+  it("should seamlessly move between dashboards with or without filters without triggering an error (metabase#27356)", () => {
+    openNavigationSidebar();
+
+    cy.findByText(paramDashboard.name).click();
+    cy.findByText("This dashboard is looking empty.");
+
+    cy.findByText(regularDashboard.name).click();
+    cy.findByText("This dashboard is looking empty.");
+
+    cy.findByText(paramDashboard.name).click();
+    cy.findByText("This dashboard is looking empty.");
+  });
+});


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #27356 

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/dashboard-filters/reproductions/27356-navigation-between-two-dashboards.cy.spec.js`
- Unskip repro
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/209676501-cd000f1c-2c8d-4396-9b59-310a76a7ea9a.png)

