### PR TITLE
Repro #25378: Relative date filter on breakout after aggregation

### DIFF
--- a/frontend/test/metabase/scenarios/filters/reproductions/25378-relative-date-on-breakout.cy.spec.js
+++ b/frontend/test/metabase/scenarios/filters/reproductions/25378-relative-date-on-breakout.cy.spec.js
@@ -1,0 +1,57 @@
+import {
+  restore,
+  visitQuestionAdhoc,
+  popover,
+  visualize,
+} from "__support__/e2e/helpers";
+
+import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
+import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
+
+const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
+
+const questionDetails = {
+  name: "25378",
+  dataset_query: {
+    type: "query",
+    query: {
+      "source-table": ORDERS_ID,
+      aggregation: [["count"]],
+      breakout: [["field", ORDERS.CREATED_AT, { "temporal-unit": "month" }]],
+    },
+    database: SAMPLE_DB_ID,
+  },
+  display: "line",
+};
+
+describe.skip("issue 25378", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+
+    visitQuestionAdhoc(questionDetails);
+  });
+
+  it("should be able to use relative date filter on a breakout after the aggregation (metabase#25378)", () => {
+    cy.icon("notebook").click();
+
+    cy.findByText("Filter").click();
+    popover().contains("Created At").click();
+
+    cy.findByText(/^Relative dates/).click();
+    // Change `days` to `months`
+    cy.findAllByTestId("select-button-content").contains("days").click();
+    popover().last().contains("months").click();
+    // Add "Starting from..." but it doesn't matter how many months ago we select
+    popover().within(() => {
+      cy.icon("ellipsis").click();
+    });
+    cy.findByText(/^Starting from/).click();
+
+    cy.button("Add filter").click();
+
+    visualize(response => {
+      expect(response.body.error).to.not.exist;
+    });
+  });
+});


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #25378

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/filters/reproductions/25378-relative-date-on-breakout.cy.spec.js`
- Unskip repro
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/209687573-37783bb6-a917-4767-9f51-ceec3ff3440f.png)

