### PR TITLE
Update data perms graph API to accept sandboxes and save them transactionally with the permissions graph

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/sandbox/models/group_table_access_policy.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/models/group_table_access_policy.clj
@@ -12,6 +12,7 @@
    [metabase.models.interface :as mi]
    [metabase.models.table :as table]
    [metabase.plugins.classloader :as classloader]
+   [metabase.public-settings.premium-features :refer [defenterprise]]
    [metabase.query-processor.error-type :as qp.error-type]
    [metabase.server.middleware.session :as mw.session]
    [metabase.util :as u]
@@ -121,6 +122,22 @@
 
 (log/trace "Installing additional EE pre-update checks for Card")
 (reset! card/pre-update-check-sandbox-constraints update-card-check-gtaps)
+
+(defenterprise upsert-sandboxes!
+  "Create new `sandboxes` or update existing ones. If a sandbox has an `:id` it will be updated, otherwise it will be
+  created."
+  :feature :sandboxes
+  [sandboxes]
+  (doseq [sandbox sandboxes]
+    (if-let [id (:id sandbox)]
+      (do
+        ;; Only update `card_id` and/or `attribute_remappings` if the values are present in the body of the request.
+        ;; This allows existing values to be "cleared" by being set to nil
+        (when (some #(contains? sandbox %) [:card_id :attribute_remappings])
+          (db/update! GroupTableAccessPolicy
+                      id
+                      (u/select-keys-when sandbox :present #{:card_id :attribute_remappings}))))
+      (db/insert! GroupTableAccessPolicy sandbox))))
 
 (defn- pre-insert [gtap]
   (u/prog1 gtap

--- a/enterprise/backend/src/metabase_enterprise/sandbox/models/group_table_access_policy.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/models/group_table_access_policy.clj
@@ -128,7 +128,7 @@
   created."
   :feature :sandboxes
   [sandboxes]
-  (doseq [sandbox sandboxes]
+  (for [sandbox sandboxes]
     (if-let [id (:id sandbox)]
       (do
         ;; Only update `card_id` and/or `attribute_remappings` if the values are present in the body of the request.
@@ -136,7 +136,8 @@
         (when (some #(contains? sandbox %) [:card_id :attribute_remappings])
           (db/update! GroupTableAccessPolicy
                       id
-                      (u/select-keys-when sandbox :present #{:card_id :attribute_remappings}))))
+                      (u/select-keys-when sandbox :present #{:card_id :attribute_remappings})))
+        (db/select-one GroupTableAccessPolicy :id id))
       (db/insert! GroupTableAccessPolicy sandbox))))
 
 (defn- pre-insert [gtap]

--- a/src/metabase/models/permissions.clj
+++ b/src/metabase/models/permissions.clj
@@ -1038,8 +1038,8 @@
    table-id        :- su/IntGreaterThanZero
    new-query-perms :- (s/enum :all :segmented :none)]
   (case new-query-perms
-    :all       (grant-permissions!  group-id (table-query-path           db-id schema table-id))
-    :segmented (grant-permissions!  group-id (table-segmented-query-path db-id schema table-id))
+    :all       (grant-permissions! group-id (table-query-path           db-id schema table-id))
+    :segmented (grant-permissions! group-id (table-segmented-query-path db-id schema table-id))
     :none      (revoke-data-perms! group-id (table-query-path           db-id schema table-id))))
 
 (s/defn ^:private update-table-data-access-permissions!

--- a/test/metabase/api/permissions_test.clj
+++ b/test/metabase/api/permissions_test.clj
@@ -165,6 +165,13 @@
         (is (= :all
                (get-in (perms/data-perms-graph) [:groups (u/the-id group) db-id :data :schemas])))))))
 
+(deftest update-perms-graph-error-test
+  (testing "PUT /api/permissions/graph"
+    (testing "make sure an error is thrown if the :sandboxes key is included in an OSS request"
+      (is (= "Sandboxes are an Enterprise feature. Please upgrade to a paid plan to use this feature."
+             (mt/user-http-request :crowberto :put 402 "permissions/graph"
+                                   (assoc (perms/data-perms-graph) :sandboxes [{:card_id 1}])))))))
+
 
 ;;; +---------------------------------------------- permissions membership apis -----------------------------------------------------------+
 


### PR DESCRIPTION
This API updates the `PUT /api/permissions/graph` endpoint to accept an additional `sandboxes` key containing the sandboxes which should be created or updated as part of this graph update. This will replace the `POST` and `PUT /api/mt/gtap` endpoint once the frontend starts using this functionality.

Sandboxes no longer in use by the permissions graph are detected and deleted automatically so the frontend doesn't need to include this information (this behavior existed already in the `delete-gtaps-if-needed-after-permissions-change!` function).

This enables sandboxes to be saved transactionally with the permissions graph, avoiding orphaned sandboxes. The key should only be included on EE instances with the `:sandboxes` feature enabled; otherwise an error will be returned.

Part of Epic https://github.com/metabase/metabase/issues/27053