### PR TITLE
Parse comma-separated list of numbers as URL filter params

### DIFF
--- a/frontend/src/metabase/parameters/utils/parameter-values.js
+++ b/frontend/src/metabase/parameters/utils/parameter-values.js
@@ -29,10 +29,27 @@ export function parseParameterValue(value, parameter) {
 
   const type = getParameterType(parameter);
   if (type === "number") {
-    return parseFloat(value);
+    return parseParameterValueForNumber(value);
   }
 
   return value;
+}
+
+function parseParameterValueForNumber(value) {
+  // something like "1,2,3" or even "1, 2,  3"
+  const isCommaSeparatedListOfIntegers = value
+    .split(",")
+    .every(item => Number.isInteger(parseFloat(item)));
+
+  if (isCommaSeparatedListOfIntegers) {
+    // "1, 2,    3" will be tranformed into "1,2,3" for later use
+    return value
+      .split(",")
+      .map(item => parseFloat(item))
+      .join(",");
+  }
+
+  return parseFloat(value);
 }
 
 function parseParameterValueForFields(value, fields) {

--- a/frontend/src/metabase/parameters/utils/parameter-values.js
+++ b/frontend/src/metabase/parameters/utils/parameter-values.js
@@ -36,18 +36,22 @@ export function parseParameterValue(value, parameter) {
 }
 
 function parseParameterValueForNumber(value) {
-  // something like "1,2,3" or even "1, 2,  3"
-  const valueSplitByCommas = value.split(",");
+  // something like "1,2,3",  "1, 2,  3", ",,,1,2, 3"
+  const valueSplitByCommas = value
+    .split(",")
+    .filter(item => item.trim() !== "");
+
+  if (valueSplitByCommas.length === 0) {
+    return;
+  }
+
   const isCommaSeparatedListOfNumbers =
     valueSplitByCommas.length > 1 &&
     valueSplitByCommas.every(item => !isNaN(parseFloat(item)));
 
   if (isCommaSeparatedListOfNumbers) {
     // "1, 2,    3" will be tranformed into "1,2,3" for later use
-    return value
-      .split(",")
-      .map(item => parseFloat(item))
-      .join(",");
+    return valueSplitByCommas.map(item => parseFloat(item)).join(",");
   }
 
   return parseFloat(value);

--- a/frontend/src/metabase/parameters/utils/parameter-values.js
+++ b/frontend/src/metabase/parameters/utils/parameter-values.js
@@ -37,11 +37,12 @@ export function parseParameterValue(value, parameter) {
 
 function parseParameterValueForNumber(value) {
   // something like "1,2,3" or even "1, 2,  3"
-  const isCommaSeparatedListOfIntegers = value
-    .split(",")
-    .every(item => Number.isInteger(parseFloat(item)));
+  const valueSplitByCommas = value.split(",");
+  const isCommaSeparatedListOfNumbers =
+    valueSplitByCommas.length > 1 &&
+    valueSplitByCommas.every(item => !isNaN(parseFloat(item)));
 
-  if (isCommaSeparatedListOfIntegers) {
+  if (isCommaSeparatedListOfNumbers) {
     // "1, 2,    3" will be tranformed into "1,2,3" for later use
     return value
       .split(",")

--- a/frontend/src/metabase/parameters/utils/parameter-values.unit.spec.js
+++ b/frontend/src/metabase/parameters/utils/parameter-values.unit.spec.js
@@ -371,24 +371,27 @@ describe("parameters/utils/parameter-values", () => {
 
       describe("when parsing parameter value that is a comma-separated list of numbers", () => {
         it("should return list when every item is a number", () => {
-          expect(runGetParameterValueFromQueryParams("1, 2 ,   3")).toEqual([
+          expect(runGetParameterValueFromQueryParams("1,,2,3,4")).toEqual([
+            "1,2,3,4",
+          ]);
+          expect(runGetParameterValueFromQueryParams("1, ,2,3,4")).toEqual([
+            "1,2,3,4",
+          ]);
+          expect(runGetParameterValueFromQueryParams(",1,2,3,")).toEqual([
             "1,2,3",
-          ]);
-          expect(runGetParameterValueFromQueryParams("1,2.5,3.4")).toEqual([
-            "1,2.5,3.4",
-          ]);
-          expect(runGetParameterValueFromQueryParams("1,0,0000,2")).toEqual([
-            "1,0,0,2",
           ]);
         });
 
-        it("should return first float or NaN when list is not formatted properly", () => {
-          expect(runGetParameterValueFromQueryParams("1,,2,3,4")).toEqual([1]);
-          expect(runGetParameterValueFromQueryParams("1, ,2,3,4")).toEqual([1]);
-          expect(runGetParameterValueFromQueryParams("1,2,3,")).toEqual([1]);
-          expect(runGetParameterValueFromQueryParams(",,,")).toEqual([NaN]);
-          expect(runGetParameterValueFromQueryParams(" ")).toEqual([NaN]);
-          expect(runGetParameterValueFromQueryParams(",1,2,3")).toEqual([NaN]);
+        it("should return undefined when list is not formatted properly", () => {
+          expect(runGetParameterValueFromQueryParams(",,,")).toEqual([
+            undefined,
+          ]);
+          expect(runGetParameterValueFromQueryParams(" ")).toEqual([undefined]);
+        });
+
+        it("should return first parseable float if value includes non-numeric characters", () => {
+          expect(runGetParameterValueFromQueryParams("1,a,3,")).toEqual([1]);
+          expect(runGetParameterValueFromQueryParams("1a,b,3,")).toEqual([1]);
         });
       });
     });

--- a/frontend/src/metabase/parameters/utils/parameter-values.unit.spec.js
+++ b/frontend/src/metabase/parameters/utils/parameter-values.unit.spec.js
@@ -186,6 +186,23 @@ describe("parameters/utils/parameter-values", () => {
       ).toEqual([123.456]);
     });
 
+    it("should parse parameter value that is a comma-separated string of integers", () => {
+      const numberParameter = {
+        id: 111,
+        slug: "numberParameter",
+        type: "number/=",
+      };
+      expect(
+        getParameterValueFromQueryParams(
+          numberParameter,
+          {
+            [numberParameter.slug]: "1, 2,   3",
+          },
+          metadata,
+        ),
+      ).toEqual(["1,2,3"]);
+    });
+
     it("should not parse numeric values that are dates as floats", () => {
       field1.isNumeric = () => true;
       field1.isDate = () => true;

--- a/frontend/src/metabase/parameters/utils/parameter-values.unit.spec.js
+++ b/frontend/src/metabase/parameters/utils/parameter-values.unit.spec.js
@@ -186,7 +186,7 @@ describe("parameters/utils/parameter-values", () => {
       ).toEqual([123.456]);
     });
 
-    it("should parse parameter value that is a comma-separated string of integers", () => {
+    it("should parse parameter value that is a comma-separated list of numbers", () => {
       const numberParameter = {
         id: 111,
         slug: "numberParameter",

--- a/frontend/test/metabase/scenarios/dashboard-filters/reproductions/25374-comma-separated-values-not-passed-to-question.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters/reproductions/25374-comma-separated-values-not-passed-to-question.cy.spec.js
@@ -39,7 +39,7 @@ const dashboardDetails = {
   parameters: [filterDetails],
 };
 
-describe.skip("issue 25374", () => {
+describe("issue 25374", () => {
   beforeEach(() => {
     cy.intercept("POST", `/api/card/*/query`).as("cardQuery");
 


### PR DESCRIPTION
Fixes #25374 

### How to test

1. Create question: Native › Sample dataset › `select count(*) from orders where id in ({{number}})`
2. Set variable type as "Number" for variable "number".
3. Save
4. In the question url, add get params `?number=1%2C2%2C3` or `?number=1,2,3`

Filter should display: `1,2,3`
URL should show URL-encoded params, looking like `?number=1%2C2%2C3` 

Visualization count should show: `3`
🎗️There are other reproductions you can try in issue https://github.com/metabase/metabase/issues/25374. Worthwhile testing them too.