### PR TITLE
Fix Google SSO button overflowing on small screens

### DIFF
--- a/frontend/src/metabase/auth/components/GoogleButton/GoogleButton.tsx
+++ b/frontend/src/metabase/auth/components/GoogleButton/GoogleButton.tsx
@@ -53,7 +53,6 @@ const GoogleButton = ({
             onSuccess={handleLogin}
             onError={handleError}
             locale={locale}
-            width="366"
           />
         </GoogleOAuthProvider>
       ) : (


### PR DESCRIPTION
Fixes #27431

This PR removes hard coded `min-width` CSS property set on the GoogleLogin button.
It was first added [in this PR](https://github.com/metabase/metabase/pull/22868/files#diff-e1888d8af8301f423f898d9d6bb24b456face8148af9cb549378f3b1ca569883R51) by @gusaiani, which is the reason I'm adding him to the reviewers. There was probably a very good reason why that minimal width was added back then.

## Further reading
We're using [@react-oauth/google](https://www.npmjs.com/package/@react-oauth/google) library.

The `width` prop indeed corresponds to the `min-width` and is marked as optional. The `max-width` is hard-coded to 400px by this library:
https://developers.google.com/identity/gsi/web/reference/js-reference#width

## Testing

Although I tried many different screen sizes to check that this button renders correctly, I'd still be much more confident with @gusaiani 's review.

_(simulated iPhone 12 pro size in dev tools)_
**Before**
![image](https://user-images.githubusercontent.com/31325167/209800741-b9a9e476-57c0-4975-8352-884adb2901fb.png)

**After**
![image](https://user-images.githubusercontent.com/31325167/209800649-f9cb6f6b-a124-42e2-90fa-f01746bf3462.png)
