### PR TITLE
Repro #27427: Static viz fails for unused returned column

### DIFF
--- a/frontend/test/metabase/scenarios/visualizations/reproductions/27427-static-viz-divide-by-zero.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/reproductions/27427-static-viz-divide-by-zero.cy.spec.js
@@ -22,7 +22,7 @@ describe.skip("issue 27427", () => {
     cy.signInAsAdmin();
   });
 
-  it("divide by zero (metabase#27427)", () => {
+  it("static-viz should not fail if there is unused returned column: 'divide by zero' (metabase#27427)", () => {
     assertStaticVizRender(questionDetails, ({ status, body }) => {
       expect(status).to.eq(200);
       expect(body).to.not.include(

--- a/frontend/test/metabase/scenarios/visualizations/reproductions/27427-static-viz-divide-by-zero.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/reproductions/27427-static-viz-divide-by-zero.cy.spec.js
@@ -1,0 +1,45 @@
+import { restore } from "__support__/e2e/helpers";
+
+const questionDetails = {
+  name: "27427",
+  native: {
+    query:
+      "select 1 as sortorder, year(current_timestamp), 1 v1, 2 v2\nunion all select 1, year(current_timestamp)-1, 1, 2",
+    "template-tags": {},
+  },
+  display: "bar",
+  visualization_settings: {
+    "graph.dimensions": ["EXTRACT(YEAR FROM CURRENT_TIMESTAMP)"],
+    "graph.metrics": ["V1", "V2"],
+    "graph.series_order_dimension": null,
+    "graph.series_order": null,
+  },
+};
+
+describe.skip("issue 27427", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+  });
+
+  it("divide by zero (metabase#27427)", () => {
+    assertStaticVizRender(questionDetails, ({ status, body }) => {
+      expect(status).to.eq(200);
+      expect(body).to.not.include(
+        "An error occurred while displaying this card.",
+      );
+    });
+  });
+});
+
+function assertStaticVizRender(questionDetails, callback) {
+  cy.createNativeQuestion(questionDetails).then(({ body: { id } }) => {
+    cy.request({
+      method: "GET",
+      url: `/api/pulse/preview_card/${id}`,
+      failOnStatusCode: false,
+    }).then(response => {
+      callback(response);
+    });
+  });
+}


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #27427 

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/visualizations/reproductions/27427-static-viz-divide-by-zero.cy.spec.js`
- Unskip repro
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/209810877-7fec18eb-b75c-4486-8c6f-0a6a1d30110c.png)

