### PR TITLE
Handle MultipleValues parameter

### DIFF
--- a/modules/drivers/mongo/src/metabase/driver/mongo/parameters.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo/parameters.clj
@@ -18,7 +18,7 @@
             [metabase.util.date-2 :as u.date]
             [metabase.util.i18n :refer [tru]])
   (:import java.time.temporal.Temporal
-           [metabase.driver.common.parameters CommaSeparatedNumbers Date]))
+           [metabase.driver.common.parameters CommaSeparatedNumbers Date MultipleValues]))
 
 (defn- ->utc-instant [t]
   (t/instant
@@ -34,10 +34,14 @@
     (sequential? x)
     (format "{$in: [%s]}" (str/join ", " (map (partial param-value->str field) x)))
 
+    ;; MultipleValues get converted as sequences
+    (instance? MultipleValues x)
+    (recur field (:values x))
+
     ;; Date = the Parameters Date type, not an java.util.Date or java.sql.Date type
     ;; convert to a `Temporal` instance and recur
     (instance? Date x)
-    (param-value->str field (u.date/parse (:s x)))
+    (recur field (u.date/parse (:s x)))
 
     (and (instance? Temporal x)
          (isa? coercion :Coercion/UNIXSeconds->DateTime))
@@ -53,7 +57,7 @@
 
     ;; there's a special record type for sequences of numbers; pull the sequence it wraps out and recur
     (instance? CommaSeparatedNumbers x)
-    (param-value->str field (:numbers x))
+    (recur field (:numbers x))
 
     ;; for everything else, splice it in as its string representation
     :else

--- a/modules/drivers/mongo/test/metabase/driver/mongo/parameters_test.clj
+++ b/modules/drivers/mongo/test/metabase/driver/mongo/parameters_test.clj
@@ -42,6 +42,9 @@
 (defn- comma-separated-numbers [nums]
   (params/->CommaSeparatedNumbers nums))
 
+(defn- multiple-values [& values]
+  (params/->MultipleValues values))
+
 (deftest substitute-test
   (testing "non-parameterized strings should not be substituted"
     (is (= "wow"
@@ -93,6 +96,14 @@
   (testing "comma-separated numbers"
     (is (= "{$in: [1, 2, 3]}"
            (substitute {:id (comma-separated-numbers [1 2 3])}
+                       [(param :id)]))))
+  (testing "multiple-values single (#22486)"
+    (is (= "{$in: [\"33 Taps\"]}"
+           (substitute {:id (multiple-values "33 Taps")}
+                       [(param :id)]))))
+  (testing "multiple-values multi (#22486)"
+    (is (= "{$in: [\"33 Taps\", \"Cha Cha Chicken\"]}"
+           (substitute {:id (multiple-values "33 Taps" "Cha Cha Chicken")}
                        [(param :id)])))))
 
 (defprotocol ^:private ToBSON


### PR DESCRIPTION
Fixes #22486.

Even if the frontend allows a single value to be selected for a single variable, it sends a singleton array as the value which is converted into a `MultipleValues` parameter. This PR treats such parameters as sequences, i.e., it wraps them in an `$in` operation. This fixes the problem reported in #22486 and should be a strict improvement. For a complete fix FE changes might be needed.