### PR TITLE
Revert "[CI] Add concurrency to BE and FE workflows (#27235)"

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -20,10 +20,6 @@ on:
       - "**/frontend/test/**"
       - "**/frontend/**.unit.*"
 
-concurrency:
-  group: ${{ github.head_ref && github.workflow || github.run_id }}
-  cancel-in-progress: true
-
 jobs:
 
   be-linter-cloverage:

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -21,7 +21,7 @@ on:
       - "**/frontend/**.unit.*"
 
 concurrency:
-  group: ${{ github.head_ref && github.workflow || github.run_id }}
+  group: ${{ github.head_ref || github.run_id}}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -34,10 +34,6 @@ on:
       - "frontend/test/__support__/e2e/**"
       - "frontend/test/__runner__/*cypress*"
 
-concurrency:
-  group: ${{ github.head_ref && github.workflow || github.run_id }}
-  cancel-in-progress: true
-
 jobs:
   fe-linter-prettier:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
This reverts commit a63f9bd14425ec04266c9df7f758c1a490b9420a.

This solution once again didn't achieve the conditional concurrency and once again, it was apparent only when the PR has already been merged.