### PR TITLE
Repro #18770: Post-aggregation filter disrupts drill-through

### DIFF
--- a/frontend/test/metabase/scenarios/filters/reproductions/18770-post-aggregation-filter-disrupts-drillthrough.cy.spec.js
+++ b/frontend/test/metabase/scenarios/filters/reproductions/18770-post-aggregation-filter-disrupts-drillthrough.cy.spec.js
@@ -1,0 +1,48 @@
+import { restore, popover, visualize } from "__support__/e2e/helpers";
+import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
+
+const { ORDERS_ID, PRODUCTS, ORDERS } = SAMPLE_DATABASE;
+
+const questionDetails = {
+  name: "18770",
+  query: {
+    "source-query": {
+      aggregation: [["count"]],
+      "source-table": ORDERS_ID,
+      breakout: [
+        ["field", PRODUCTS.TITLE, { "source-field": ORDERS.PRODUCT_ID }],
+      ],
+    },
+    filter: [">", ["field", "count", { "base-type": "type/Integer" }], 0],
+  },
+};
+
+describe.skip("issue 18770", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+
+    cy.createQuestion(questionDetails, { visitQuestion: true });
+  });
+
+  it("post-aggregation filter shouldn't affect the drill-through options (metabase#18770)", () => {
+    cy.icon("notebook").click();
+    // It is important to manually triger "visualize" in order to generate `result_metadata`
+    // Otherwise, we might get false negative even when this issue gets resolved.
+    // In order to do that, we have to change the breakout field first or it will never generate and send POST /api/dataset request.
+    cy.findAllByTestId("notebook-cell-item")
+      .contains(/Products? → Title/)
+      .click();
+    popover().findByText("Category").click();
+    cy.findAllByTestId("notebook-cell-item").contains(/Products? → Category/);
+
+    visualize();
+
+    cy.findByText("4,784").click();
+    popover()
+      .should("contain", "View these Orders")
+      .and("contain", "Break out by a…")
+      .and("contain", "Filter by this value")
+      .and("contain", "Automatic explorations");
+  });
+});


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #18770

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/filters/reproductions/18770-post-aggregation-filter-disrupts-drillthrough.cy.spec.js`
- Unskip repro
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
Sanity check without the post-aggregation filter. This gives us peace of mind, knowing that we'll not see false-negatives.
![image](https://user-images.githubusercontent.com/31325167/209942756-7aa436c9-88df-4963-ba45-c59b30ba6140.png)

The actual reproduction (with the post-aggregation filter)
![image](https://user-images.githubusercontent.com/31325167/209942784-2f2a691b-54ee-4b41-a016-bb7c66c64d82.png)
