### PR TITLE
Repro #25250: Pivot Table doesn't show stand-alone values on collapsed sub-level grouping

### DIFF
--- a/frontend/test/metabase/scenarios/visualizations/reproductions/25250-pivot-no-standalone-values-when-collapsed.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/reproductions/25250-pivot-no-standalone-values-when-collapsed.cy.spec.js
@@ -1,0 +1,59 @@
+import { restore, visitQuestionAdhoc } from "__support__/e2e/helpers";
+import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
+import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
+
+const { ORDERS_ID, ORDERS } = SAMPLE_DATABASE;
+
+const questionDetails = {
+  name: "25250",
+  dataset_query: {
+    type: "query",
+    query: {
+      "source-table": ORDERS_ID,
+      filter: ["<", ["field", ORDERS.CREATED_AT, null], "2016-06-01"],
+      aggregation: [["count"]],
+      breakout: [
+        ["field", ORDERS.CREATED_AT, { "temporal-unit": "month" }],
+        ["field", ORDERS.USER_ID, null],
+        ["field", ORDERS.PRODUCT_ID, null],
+      ],
+    },
+    database: SAMPLE_DB_ID,
+  },
+  display: "pivot",
+  visualization_settings: {
+    "pivot_table.column_split": {
+      rows: [
+        ["field", ORDERS.CREATED_AT, { "temporal-unit": "month" }],
+        ["field", ORDERS.USER_ID, null],
+        ["field", ORDERS.PRODUCT_ID, null],
+      ],
+      columns: [],
+      values: [["aggregation", 0]],
+    },
+    "pivot_table.collapsed_rows": {
+      value: [],
+      rows: [
+        ["field", ORDERS.CREATED_AT, { "temporal-unit": "month" }],
+        ["field", ORDERS.USER_ID, null],
+        ["field", ORDERS.PRODUCT_ID, null],
+      ],
+    },
+  },
+};
+
+describe.skip("issue 25250", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+
+    visitQuestionAdhoc(questionDetails);
+  });
+
+  it("pivot table should show standalone values when collapsed to the sub-level grouping (metabase#25250)", () => {
+    cy.findByText("1162").should("be.visible");
+    // Collapse "User ID" column
+    cy.findByText("User ID").parent().find(".Icon-dash").click();
+    cy.findByText("1162").should("be.visible");
+  });
+});


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #25250

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/visualizations/reproductions/25250-pivot-no-standalone-values-when-collapsed.cy.spec.js`
- Unskip repro
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
Before collapsing:
![image](https://user-images.githubusercontent.com/31325167/209947742-3227d8b7-5288-4b42-870a-395077a9831b.png)

After collapsing
![image](https://user-images.githubusercontent.com/31325167/209947573-3e5eb222-7cf1-4735-aa38-12435301024d.png)

