### PR TITLE
Simplify dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,3 @@ EXPOSE 3000
 
 # run it
 ENTRYPOINT ["/app/run_metabase.sh"]
-
-FROM scratch as export-stage
-
-COPY --from=builder /home/node/target/uberjar/metabase.jar /

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,13 +2,18 @@
 # STAGE 1: builder
 ###################
 
-FROM metabase/ci:java-11-clj-1.11.0.1100.04-2022-build as builder
+FROM node:16-slim as builder
 
 ARG MB_EDITION=oss
 
-WORKDIR /home/circleci
+WORKDIR /home/node
 
-COPY --chown=circleci . .
+RUN apt-get update && apt-get upgrade -y && apt-get install openjdk-11-jdk curl git -y \
+    && curl -O https://download.clojure.org/install/linux-install-1.11.0.1100.sh \
+    && chmod +x linux-install-1.11.0.1100.sh \
+    && ./linux-install-1.11.0.1100.sh
+
+COPY . .
 RUN INTERACTIVE=false CI=true MB_EDITION=$MB_EDITION bin/build
 
 # ###################
@@ -35,7 +40,7 @@ RUN apk add -U bash ttf-dejavu fontconfig curl java-cacerts && \
     mkdir -p /plugins && chmod a+rwx /plugins
 
 # add Metabase script and uberjar
-COPY --from=builder /home/circleci/target/uberjar/metabase.jar /app/
+COPY --from=builder /home/node/target/uberjar/metabase.jar /app/
 COPY bin/docker/run_metabase.sh /app/
 
 # expose our default runtime port
@@ -43,3 +48,7 @@ EXPOSE 3000
 
 # run it
 ENTRYPOINT ["/app/run_metabase.sh"]
+
+FROM scratch as export-stage
+
+COPY --from=builder /home/node/target/uberjar/metabase.jar /


### PR DESCRIPTION
Now that we don't run in CircleCI anymore and we have our CI on plain machines in GH actions, the base docker image customized for CircleCI is not needed anymore. 

I introduced that image in the Dockerfile to make the process as similar as our CI process, but now we can easily move to a node one, which is slimmer and does not have all the complications (users, scripts, overhead) as the CircleCI one