### PR TITLE
Restoring active item colors

### DIFF
--- a/frontend/src/metabase/components/SelectList/SelectListItem.styled.jsx
+++ b/frontend/src/metabase/components/SelectList/SelectListItem.styled.jsx
@@ -2,7 +2,7 @@ import styled from "@emotion/styled";
 import { css } from "@emotion/react";
 
 import Label from "metabase/components/type/Label";
-import { color, lighten } from "metabase/lib/colors";
+import { color } from "metabase/lib/colors";
 import Icon from "metabase/components/Icon";
 
 export const ItemTitle = styled(Label)`
@@ -16,11 +16,11 @@ export const ItemIcon = styled(Icon)`
 `;
 
 const activeItemCss = css`
-  background-color: ${lighten("brand")};
+  background-color: ${color("brand")};
 
   ${ItemIcon},
   ${ItemTitle} {
-    color: ${color("brand")};
+    color: ${color("white")};
   }
 `;
 


### PR DESCRIPTION
Fixes #27449

Reverts the color of active item in select lists back to it's original color.