### PR TITLE
Only update dashboard cards if their own filter changes

### DIFF
--- a/frontend/src/metabase-lib/queries/utils/card.js
+++ b/frontend/src/metabase-lib/queries/utils/card.js
@@ -1,5 +1,5 @@
 import _ from "underscore";
-import { updateIn, assoc } from "icepick";
+import { updateIn } from "icepick";
 
 import Utils from "metabase/lib/utils";
 import { normalizeParameterValue } from "metabase-lib/parameters/utils/parameter-values";
@@ -117,34 +117,24 @@ export function applyParameters(
     const options =
       deriveFieldOperatorFromParameter(parameter)?.optionsDefaults;
 
+    const queryParameter = {
+      type,
+      value: normalizeParameterValue(type, value),
+      id: parameter.id,
+    };
+
+    if (options) {
+      queryParameter.options = options;
+    }
+
     if (mapping) {
       // mapped target, e.x. on a dashboard
-      const parameter = {
-        type,
-        value: normalizeParameterValue(type, value),
-        target: mapping.target,
-        id: parameter.id,
-      };
-
-      if (options) {
-        parameter.options = options;
-      }
-
-      datasetQuery.parameters.push(parameter);
+      queryParameter.target = mapping.target;
+      datasetQuery.parameters.push(queryParameter);
     } else if (parameter.target) {
       // inline target, e.x. on a card
-      const parameter = {
-        type,
-        value: normalizeParameterValue(type, value),
-        target: parameter.target,
-        id: parameter.id,
-      };
-
-      if (options) {
-        parameter.options = options;
-      }
-
-      datasetQuery.parameters.push(parameter);
+      queryParameter.target = parameter.target;
+      datasetQuery.parameters.push(queryParameter);
     }
   }
 

--- a/frontend/src/metabase-lib/queries/utils/card.js
+++ b/frontend/src/metabase-lib/queries/utils/card.js
@@ -1,5 +1,5 @@
 import _ from "underscore";
-import { updateIn } from "icepick";
+import { updateIn, assoc } from "icepick";
 
 import Utils from "metabase/lib/utils";
 import { normalizeParameterValue } from "metabase-lib/parameters/utils/parameter-values";
@@ -119,22 +119,32 @@ export function applyParameters(
 
     if (mapping) {
       // mapped target, e.x. on a dashboard
-      datasetQuery.parameters.push({
+      const parameter = {
         type,
         value: normalizeParameterValue(type, value),
         target: mapping.target,
-        options,
         id: parameter.id,
-      });
+      };
+
+      if (options) {
+        parameter.options = options;
+      }
+
+      datasetQuery.parameters.push(parameter);
     } else if (parameter.target) {
       // inline target, e.x. on a card
-      datasetQuery.parameters.push({
+      const parameter = {
         type,
         value: normalizeParameterValue(type, value),
         target: parameter.target,
-        options,
         id: parameter.id,
-      });
+      };
+
+      if (options) {
+        parameter.options = options;
+      }
+
+      datasetQuery.parameters.push(parameter);
     }
   }
 


### PR DESCRIPTION
Fixes: https://github.com/metabase/metabase/issues/25914

Fixes cards reloading when we change a filter that has not been connected to them.

99.9% of the kudos should go to @swk777 who wrote this PR: https://github.com/metabase/metabase/pull/26783
If there's a way he can be added as a contributor, I'm all in.

### How to Test

1. Question > Sample > Orders - summarize by Count - save as "Q1"
2. Add "Q1" three times to a dashboard, then add two filters and connect first filter to first card, second filter to second card
![image](https://user-images.githubusercontent.com/1447303/195640061-04984906-6f0d-4bec-ad00-7ffb067e184d.png)
3. Set a value in first filter, only first card is updated - as expected
4. Set a value in second filter (while there's a value in first filter)

Only the second filter should be reloaded.

