### PR TITLE
Remove unnecessary ParameterCard function

### DIFF
--- a/src/metabase/models/dashboard.clj
+++ b/src/metabase/models/dashboard.clj
@@ -5,7 +5,6 @@
    [clojure.set :as set]
    [clojure.string :as str]
    [clojure.tools.logging :as log]
-   [medley.core :as m]
    [metabase.automagic-dashboards.populate :as populate]
    [metabase.events :as events]
    [metabase.models.card :as card :refer [Card]]
@@ -15,9 +14,7 @@
     :refer [DashboardCard]]
    [metabase.models.field-values :as field-values]
    [metabase.models.interface :as mi]
-   [metabase.models.parameter-card
-    :as parameter-card
-    :refer [ParameterCard]]
+   [metabase.models.parameter-card :as parameter-card]
    [metabase.models.params :as params]
    [metabase.models.permissions :as perms]
    [metabase.models.pulse :as pulse :refer [Pulse]]
@@ -147,23 +144,6 @@
   [dashboard]
   (update-dashboard-subscription-pulses! dashboard))
 
-(defn- card-ids-by-param-id
-  "Returns a map from parameter IDs to card IDs for the given dashboard (for parameters whose filter values come from a
-  card via a ParameterCard)."
-  [dashboard-id]
-  (->> (db/select ParameterCard :parameterized_object_id dashboard-id :parameterized_object_type "dashboard")
-       (group-by :parameter_id)
-       (m/map-vals (comp :card_id first))))
-
-(defn- populate-card-id-for-parameters
-  [{dashboard-id :id parameters :parameters :as dashboard}]
-  (assoc dashboard :parameters
-         (let [param-id->card-id (card-ids-by-param-id dashboard-id)]
-           (for [{:keys [id values_source_type values_source_config] :as param} parameters]
-             (if (= values_source_type "card")
-               (assoc-in param [:values_source_config :card_id] (get param-id->card-id id (:card_id values_source_config)))
-               param)))))
-
 (mi/define-methods
  Dashboard
  {:properties  (constantly {::mi/timestamped? true
@@ -174,7 +154,7 @@
   :post-insert post-insert
   :pre-update  pre-update
   :post-update post-update
-  :post-select (comp populate-card-id-for-parameters public-settings/remove-public-uuid-if-public-sharing-is-disabled)})
+  :post-select public-settings/remove-public-uuid-if-public-sharing-is-disabled})
 
 (defmethod serdes.hash/identity-hash-fields Dashboard
   [_dashboard]

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -197,7 +197,7 @@
               (mt/user-http-request :rasta :post 200 "dashboard" {:name                dashboard-name
                                                                   :collection_id       (u/the-id collection)
                                                                   :collection_position 1000})
-              (is (= #metabase.models.dashboard.DashboardInstance{:collection_id true, :collection_position 1000, :parameters []}
+              (is (= #metabase.models.dashboard.DashboardInstance{:collection_id true, :collection_position 1000}
                      (some-> (db/select-one [Dashboard :collection_id :collection_position] :name dashboard-name)
                              (update :collection_id (partial = (u/the-id collection))))))
               (finally

--- a/test/metabase/events/activity_feed_test.clj
+++ b/test/metabase/events/activity_feed_test.clj
@@ -134,7 +134,6 @@
                 :table_id    nil
                 :details     {:name        "My Cool Dashboard"
                               :description nil
-                              :parameters  []
                               :dashcards   [{:description (:description card)
                                              :name        (:name card)
                                              :id          (:id dashcard)
@@ -159,7 +158,6 @@
                 :table_id    nil
                 :details     {:name        "My Cool Dashboard"
                               :description nil
-                              :parameters  []
                               :dashcards   [{:description (:description card)
                                              :name        (:name card)
                                              :id          (:id dashcard)

--- a/test/metabase/events/revision_test.clj
+++ b/test/metabase/events/revision_test.clj
@@ -46,7 +46,6 @@
 (defn- dashboard->revision-object [dashboard]
   {:description  nil
    :cache_ttl    nil
-   :parameters   []
    :name         (:name dashboard)})
 
 (deftest card-create-test


### PR DESCRIPTION
We were explicitly keeping ParameterCards and dashboard.parameters in sync, but that's not necessary

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/27493)
<!-- Reviewable:end -->
