### PR TITLE
Upgrade Mongo to 4.2 in workflow to skip driver checks

### DIFF
--- a/.github/workflows/drivers-skipped-checks.yml
+++ b/.github/workflows/drivers-skipped-checks.yml
@@ -66,13 +66,13 @@ jobs:
       - run: |
           echo "Didn't run due to conditional filtering"
 
-  be-tests-mongo-4-0-ee:
+  be-tests-mongo-4-2-ee:
     runs-on: ubuntu-20.04
     steps:
       - run: |
           echo "Didn't run due to conditional filtering"
 
-  be-tests-mongo-4-0-ssl-ee:
+  be-tests-mongo-4-2-ssl-ee:
     runs-on: ubuntu-20.04
     steps:
       - run: |


### PR DESCRIPTION
(Should have been part of [#27176])
