### PR TITLE
Cache and deps fixes

### DIFF
--- a/.github/actions/prepare-backend/action.yml
+++ b/.github/actions/prepare-backend/action.yml
@@ -5,7 +5,7 @@ inputs:
     default: '11'
   clojure-version:
     required: true
-    default: '1.11.0.1100'
+    default: '1.11.1.1208'
   m2-cache-key:
     description: 'Key to cache M2 packages from Maven Central'
     required: true

--- a/.github/actions/prepare-backend/action.yml
+++ b/.github/actions/prepare-backend/action.yml
@@ -41,4 +41,4 @@ runs:
     - name: List contents of cache
       shell: bash
       run: |
-        ls /home/runner/.m2/repository
+        echo "found directories: $(find /home/runner/.m2/repository -d | wc -l)"

--- a/.github/actions/prepare-backend/action.yml
+++ b/.github/actions/prepare-backend/action.yml
@@ -38,3 +38,7 @@ runs:
         key: ${{ runner.os }}-${{ inputs.m2-cache-key }}-${{ hashFiles('**/deps.edn') }}
         restore-keys: |
           ${{ runner.os }}-${{ inputs.m2-cache-key }}-
+    - name: List contents of cache
+      shell: bash
+      run: |
+        echo "found directories: $(find /home/runner/.m2/repository -d | wc -l)"

--- a/.github/actions/prepare-backend/action.yml
+++ b/.github/actions/prepare-backend/action.yml
@@ -41,4 +41,4 @@ runs:
     - name: List contents of cache
       shell: bash
       run: |
-        ls /home/runner/.m2
+        ls /home/runner/.m2/repository

--- a/.github/actions/prepare-backend/action.yml
+++ b/.github/actions/prepare-backend/action.yml
@@ -38,3 +38,7 @@ runs:
         key: ${{ runner.os }}-${{ inputs.m2-cache-key }}-${{ hashFiles('**/deps.edn') }}
         restore-keys: |
           ${{ runner.os }}-${{ inputs.m2-cache-key }}-
+    - name: List contents of cache
+      shell: bash
+      run: |
+        ls /home/runner/.m2

--- a/.github/actions/prepare-backend/action.yml
+++ b/.github/actions/prepare-backend/action.yml
@@ -33,7 +33,7 @@ runs:
       if: ${{ !contains(github.event.head_commit.message, '[ci nocache]') }}
       with:
         path: |
-          ~/.m2/
+          ~/.m2
           ~/.gitlibs
         key: ${{ runner.os }}-${{ inputs.m2-cache-key }}-${{ hashFiles('**/deps.edn') }}
         restore-keys: |

--- a/.github/actions/prepare-backend/action.yml
+++ b/.github/actions/prepare-backend/action.yml
@@ -33,8 +33,8 @@ runs:
       if: ${{ !contains(github.event.head_commit.message, '[ci nocache]') }}
       with:
         path: |
-          ~/.m2
-          ~/.gitlibs
+          /home/runner/.m2/
+          /home/runner/.gitlibs
         key: ${{ runner.os }}-${{ inputs.m2-cache-key }}-${{ hashFiles('**/deps.edn') }}
         restore-keys: |
           ${{ runner.os }}-${{ inputs.m2-cache-key }}-

--- a/.github/actions/prepare-backend/action.yml
+++ b/.github/actions/prepare-backend/action.yml
@@ -38,7 +38,3 @@ runs:
         key: ${{ runner.os }}-${{ inputs.m2-cache-key }}-${{ hashFiles('**/deps.edn') }}
         restore-keys: |
           ${{ runner.os }}-${{ inputs.m2-cache-key }}-
-    - name: List contents of cache
-      shell: bash
-      run: |
-        echo "found directories: $(find /home/runner/.m2/repository -d | wc -l)"

--- a/.github/actions/prepare-backend/action.yml
+++ b/.github/actions/prepare-backend/action.yml
@@ -33,8 +33,8 @@ runs:
       if: ${{ !contains(github.event.head_commit.message, '[ci nocache]') }}
       with:
         path: |
-          /home/runner/.m2/
-          /home/runner/.gitlibs
+          ~/.m2/
+          ~/.gitlibs
         key: ${{ runner.os }}-${{ inputs.m2-cache-key }}-${{ hashFiles('**/deps.edn') }}
         restore-keys: |
           ${{ runner.os }}-${{ inputs.m2-cache-key }}-

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,9 +9,9 @@ ARG MB_EDITION=oss
 WORKDIR /home/node
 
 RUN apt-get update && apt-get upgrade -y && apt-get install openjdk-11-jdk curl git -y \
-    && curl -O https://download.clojure.org/install/linux-install-1.11.0.1100.sh \
-    && chmod +x linux-install-1.11.0.1100.sh \
-    && ./linux-install-1.11.0.1100.sh
+    && curl -O https://download.clojure.org/install/linux-install-1.11.1.1280.sh \
+    && chmod +x linux-install-1.11.1.1208.sh \
+    && ./linux-install-1.11.1.1208.sh
 
 COPY . .
 RUN INTERACTIVE=false CI=true MB_EDITION=$MB_EDITION bin/build


### PR DESCRIPTION
Want to resolve a few issues:

#### Errors creating a classpath

<details>
<summary>org.apache.maven.model.resolution.UnresolvableModelException: Could not transfer artifact io.dropwizard.metrics:metrics-parent:pom:4.2.9 from/to central (https://repo1.maven.org/maven2): /home/runner/.m2/repository/io/dropwizard/metrics/metrics-parent/4.2.9/metrics-parent-4.2.9.pom.part (No such file or directory)</summary>

```
Error building classpath. Failed to read artifact descriptor for org.opensaml:opensaml-xmlsec-api:jar:4.2.0
org.eclipse.aether.resolution.ArtifactDescriptorException: Failed to read artifact descriptor for org.opensaml:opensaml-xmlsec-api:jar:4.2.0
	at org.apache.maven.repository.internal.DefaultArtifactDescriptorReader.loadPom(DefaultArtifactDescriptorReader.java:306)
	at org.apache.maven.repository.internal.DefaultArtifactDescriptorReader.readArtifactDescriptor(DefaultArtifactDescriptorReader.java:175)
	at org.eclipse.aether.internal.impl.DefaultRepositorySystem.readArtifactDescriptor(DefaultRepositorySystem.java:255)
	at clojure.tools.deps.alpha.extensions.maven$read_descriptor.invokeStatic(maven.clj:115)
	at clojure.tools.deps.alpha.extensions.maven$fn__1128.invokeStatic(maven.clj:143)
	at clojure.tools.deps.alpha.extensions.maven$fn__1128.invoke(maven.clj:143)
	at clojure.lang.MultiFn.invoke(MultiFn.java:244)
	at clojure.tools.deps.alpha$expand_deps$children_task__771$fn__773$fn__774.invoke(alpha.clj:405)
	at clojure.tools.deps.alpha.util.concurrent$submit_task$task__479.invoke(concurrent.clj:35)
	at clojure.lang.AFn.call(AFn.java:18)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)
Caused by: org.apache.maven.model.resolution.UnresolvableModelException: Could not transfer artifact io.dropwizard.metrics:metrics-parent:pom:4.2.9 from/to central (https://repo1.maven.org/maven2): /home/runner/.m2/repository/io/dropwizard/metrics/metrics-parent/4.2.9/metrics-parent-4.2.9.pom.part (No such file or directory)
	at org.apache.maven.repository.internal.DefaultModelResolver.resolveModel(DefaultModelResolver.java:176)
	at org.apache.maven.repository.internal.DefaultModelResolver.resolveModel(DefaultModelResolver.java:222)
	at org.apache.maven.model.building.DefaultModelBuilder.readParentExternally(DefaultModelBuilder.java:1077)
	at org.apache.maven.model.building.DefaultModelBuilder.readParent(DefaultModelBuilder.java:853)
	at org.apache.maven.model.building.DefaultModelBuilder.build(DefaultModelBuilder.java:344)
	at org.apache.maven.model.building.DefaultModelBuilder.importDependencyManagement(DefaultModelBuilder.java:1306)
	at org.apache.maven.model.building.DefaultModelBuilder.build(DefaultModelBuilder.java:481)
	at org.apache.maven.model.building.DefaultModelBuilder.build(DefaultModelBuilder.java:437)
	at org.apache.maven.model.building.DefaultModelBuilder.build(DefaultModelBuilder.java:252)
	at org.apache.maven.repository.internal.DefaultArtifactDescriptorReader.loadPom(DefaultArtifactDescriptorReader.java:297)
```

</details>

I'm hoping this is some internal maven state and we can bump the clojure cli version. This will bump from 1.11.0.1100 -> 1.11.1.1208 in the hopes this works

#### cache is not working correctly
<details>
<summary>cache restored but then deps downloaded</summary>

```
Cache restored successfully
Cache restored from key: node-cache-Linux-yarn-c77c62695c03098590f800495109656553dd12cbcd8ed2c2cf9b4c143a2a8057
Run actions/cache@v3
  with:
    path: ~/.m2
    key: Linux-cljs-7698eacf6e8da21fd96476b49bdc46ace72b116af22652b04798fbbe5c5aa703
```

and then later:

```
Run clojure -X:dev:ci:ee:ee-dev:drivers:drivers-dev:test 
Downloading: org/bouncycastle/bcprov-jdk15on/1.70/bcprov-jdk15on-1.70.pom from central
Downloading: org/clojure/java.jmx/1.0.0/java.jmx-1.0.0.pom from central
Downloading: buddy/buddy-core/1.10.413/buddy-core-1.10.413.pom from clojars
Downloading: org/apache/logging/log4j/log4j-slf4j-impl/2.19.0/log4j-slf4j-impl-2.19.0.pom from central
Downloading: lambdaisland/deep-diff2/2.7.169/deep-diff2-2.7.169.pom from clojars
Downloading: com/fasterxml/woodstox/woodstox-core/6.4.0/woodstox-core-6.4.0.pom from central
Downloading: org/apache/logging/log4j/log4j/2.19.0/log4j-2.19.0.pom from central
Downloading: com/fasterxml/oss-parent/45/oss-parent-45.pom from central
```

</details>

Which seems to indicate that the cache was not correctly restored (or was empty, put into wrong place, etc)

I'm going to switch to using an expanded directory of `/home/runner/.m2/` instead of `~/.m2`