### PR TITLE
Notify api key not set hints

### DIFF
--- a/src/metabase/api/routes.clj
+++ b/src/metabase/api/routes.clj
@@ -65,7 +65,7 @@
 
 (defroutes ^{:doc "Ring routes for API endpoints."} routes
   ee-routes
-  (context "/action"              [] (+auth api.action/routes))
+  (context "/action"               [] (+auth api.action/routes))
   (context "/activity"             [] (+auth api.activity/routes))
   (context "/alert"                [] (+auth api.alert/routes))
   (context "/automagic-dashboards" [] (+auth api.magic/routes))

--- a/src/metabase/api/routes/common.clj
+++ b/src/metabase/api/routes/common.clj
@@ -8,17 +8,17 @@
 (def +generic-exceptions
   "Wrap `routes` so any Exception thrown is just returned as a generic 400, to prevent details from leaking in public
   endpoints."
-  mw.exceptions/genericize-exceptions)
+  #'mw.exceptions/genericize-exceptions)
 
 (def +message-only-exceptions
   "Wrap `routes` so any Exception thrown is just returned as a 400 with only the message from the original
   Exception (i.e., remove the original stacktrace), to prevent details from leaking in public endpoints."
-  mw.exceptions/message-only-exceptions)
+  #'mw.exceptions/message-only-exceptions)
 
 (def +apikey
   "Wrap `routes` so they may only be accessed with a correct API key header."
-  mw.auth/enforce-api-key)
+  #'mw.auth/enforce-api-key)
 
 (def +auth
   "Wrap `routes` so they may only be accessed with proper authentication credentials."
-  mw.auth/enforce-authentication)
+  #'mw.auth/enforce-authentication)

--- a/src/metabase/models/setting.clj
+++ b/src/metabase/models/setting.clj
@@ -398,6 +398,11 @@
                  (str/replace "-" "_")
                  str/upper-case)))
 
+(defn setting-env-map-name
+  "Correctly translate a setting to the keyword it will be found at in [[env/env]]."
+  [setting-definition-or-name]
+  (keyword (str "mb-" (munge-setting-name (setting-name setting-definition-or-name)))))
+
 (defn env-var-value
   "Get the value of `setting-definition-or-name` from the corresponding env var, if any.
    The name of the Setting is converted to uppercase and dashes to underscores; for example, a setting named
@@ -407,7 +412,7 @@
   ^String [setting-definition-or-name]
   (let [setting (resolve-setting setting-definition-or-name)]
     (when (allows-site-wide-values? setting)
-      (let [v (env/env (keyword (str "mb-" (munge-setting-name (setting-name setting)))))]
+      (let [v (env/env (setting-env-map-name setting))]
         (when (seq v)
           v)))))
 

--- a/src/metabase/server/middleware/auth.clj
+++ b/src/metabase/server/middleware/auth.clj
@@ -4,7 +4,8 @@
   (:require
    [clojure.string :as str]
    [metabase.models.setting :refer [defsetting]]
-   [metabase.server.middleware.util :as mw.util]))
+   [metabase.server.middleware.util :as mw.util]
+   [metabase.util.i18n :refer [deferred-trs]]))
 
 (def ^:private ^:const ^String metabase-api-key-header "x-metabase-apikey")
 
@@ -38,7 +39,7 @@
 
 (def api-key-not-set-message
   "Message sent if an endpoint protected by this middleware is hit but MB_API_KEY is not set."
-  (format "MB_API_KEY is not set. See %s for details" mb-api-key-doc-url))
+  (deferred-trs "MB_API_KEY is not set. See {0} for details" mb-api-key-doc-url))
 
 (defn enforce-api-key
   "Middleware that enforces validation of the client via API Key, canceling the request processing if the check fails.

--- a/src/metabase/server/middleware/auth.clj
+++ b/src/metabase/server/middleware/auth.clj
@@ -2,6 +2,7 @@
   "Middleware related to enforcing authentication/API keys (when applicable). Unlike most other middleware most of this
   is not used as part of the normal `app`; it is instead added selectively to appropriate routes."
   (:require
+   [clojure.string :as str]
    [metabase.models.setting :refer [defsetting]]
    [metabase.server.middleware.util :as mw.util]))
 
@@ -31,6 +32,14 @@
   "When set, this API key is required for all API requests."
   :visibility :internal)
 
+(def mb-api-key-doc-url
+  "Url for documentation on how to set MB_API_KEY."
+  "https://www.metabase.com/docs/latest/configuring-metabase/environment-variables#mb_api_key")
+
+(def api-key-not-set-message
+  "Message sent if an endpoint protected by this middleware is hit but MB_API_KEY is not set."
+  (format "MB_API_KEY is not set. See %s for details" mb-api-key-doc-url))
+
 (defn enforce-api-key
   "Middleware that enforces validation of the client via API Key, canceling the request processing if the check fails.
 
@@ -43,7 +52,10 @@
   This variable only works for /api/notify/db/:id endpoint"
   [handler]
   (fn [{:keys [metabase-api-key], :as request} respond raise]
-    (cond (not metabase-api-key)
+    (cond (str/blank? (api-key))
+          (respond {:status 403 :body api-key-not-set-message})
+
+          (not metabase-api-key)
           (respond mw.util/response-forbidden)
 
           (= (api-key) metabase-api-key)

--- a/src/metabase/server/middleware/auth.clj
+++ b/src/metabase/server/middleware/auth.clj
@@ -37,9 +37,10 @@
   "Url for documentation on how to set MB_API_KEY."
   "https://www.metabase.com/docs/latest/configuring-metabase/environment-variables#mb_api_key")
 
-(def api-key-not-set-message
-  "Message sent if an endpoint protected by this middleware is hit but MB_API_KEY is not set."
-  (deferred-trs "MB_API_KEY is not set. See {0} for details" mb-api-key-doc-url))
+(def key-not-set-response
+  "Response when the MB_API_KEY is not set."
+  {:status 403
+   :body (deferred-trs "MB_API_KEY is not set. See {0} for details" mb-api-key-doc-url)})
 
 (defn enforce-api-key
   "Middleware that enforces validation of the client via API Key, canceling the request processing if the check fails.
@@ -54,7 +55,7 @@
   [handler]
   (fn [{:keys [metabase-api-key], :as request} respond raise]
     (cond (str/blank? (api-key))
-          (respond {:status 403 :body api-key-not-set-message})
+          (respond key-not-set-response)
 
           (not metabase-api-key)
           (respond mw.util/response-forbidden)

--- a/test/metabase/api/notify_test.clj
+++ b/test/metabase/api/notify_test.clj
@@ -18,7 +18,7 @@
   (testing "POST /api/notify/db/:id"
     (testing "endpoint requires MB_API_KEY set"
       (mt/with-temporary-setting-values [api-key nil]
-        (is (= mw.auth/api-key-not-set-message
+        (is (= (str mw.auth/api-key-not-set-message)
                (client/client :post 403 "notify/db/100")))))
     (testing "endpoint requires authentication"
       (mt/with-temporary-setting-values [api-key "test-api-key"] ;; set in :test but not in :dev

--- a/test/metabase/api/notify_test.clj
+++ b/test/metabase/api/notify_test.clj
@@ -4,6 +4,7 @@
    [clojure.test :refer :all]
    [metabase.http-client :as client]
    [metabase.models.database :as database]
+   [metabase.server.middleware.auth :as mw.auth]
    [metabase.server.middleware.util :as mw.util]
    [metabase.sync]
    [metabase.sync.sync-metadata]
@@ -13,11 +14,16 @@
 
 (use-fixtures :once (fixtures/initialize :db :web-server))
 
-(deftest unauthenticated-test
+(deftest authentication-test
   (testing "POST /api/notify/db/:id"
-    (testing "endpoint should require authentication"
-      (is (= (get mw.util/response-forbidden :body)
-             (client/client :post 403 "notify/db/100"))))))
+    (testing "endpoint requires MB_API_KEY set"
+      (mt/with-temporary-setting-values [api-key nil]
+        (is (= mw.auth/api-key-not-set-message
+               (client/client :post 403 "notify/db/100")))))
+    (testing "endpoint requires authentication"
+      (mt/with-temporary-setting-values [api-key "test-api-key"] ;; set in :test but not in :dev
+        (is (= (get mw.util/response-forbidden :body)
+               (client/client :post 403 "notify/db/100")))))))
 
 (def api-headers {:headers {"X-METABASE-APIKEY" "test-api-key"
                             "Content-Type"      "application/json"}})

--- a/test/metabase/api/notify_test.clj
+++ b/test/metabase/api/notify_test.clj
@@ -18,7 +18,7 @@
   (testing "POST /api/notify/db/:id"
     (testing "endpoint requires MB_API_KEY set"
       (mt/with-temporary-setting-values [api-key nil]
-        (is (= (str mw.auth/api-key-not-set-message)
+        (is (= (-> mw.auth/key-not-set-response :body str)
                (client/client :post 403 "notify/db/100")))))
     (testing "endpoint requires authentication"
       (mt/with-temporary-setting-values [api-key "test-api-key"] ;; set in :test but not in :dev

--- a/test/metabase/models/setting_test.clj
+++ b/test/metabase/models/setting_test.clj
@@ -226,7 +226,7 @@
   (tu/do-with-temporary-setting-value setting db-value
     (fn []
       (tu/do-with-temp-env-var-value
-       (keyword (str "mb-" (name setting)))
+       (keyword setting)
        env-var-value
        (fn []
          (dissoc (#'setting/user-facing-info (#'setting/resolve-setting setting))
@@ -632,7 +632,7 @@
                                                (setting.cache/restore-cache!)))))
                                        (fn [thunk]
                                          (tu/do-with-temp-env-var-value
-                                          (keyword (str "mb-" (name setting-name)))
+                                          setting-name
                                           site-wide-value
                                           thunk))]]
         ;; clear out Setting if it was already set for some reason (except for `:only` where this is explicitly

--- a/test/metabase/models/setting_test.clj
+++ b/test/metabase/models/setting_test.clj
@@ -226,7 +226,7 @@
   (tu/do-with-temporary-setting-value setting db-value
     (fn []
       (tu/do-with-temp-env-var-value
-       (keyword setting)
+       (setting/setting-env-map-name (keyword setting))
        env-var-value
        (fn []
          (dissoc (#'setting/user-facing-info (#'setting/resolve-setting setting))
@@ -632,7 +632,7 @@
                                                (setting.cache/restore-cache!)))))
                                        (fn [thunk]
                                          (tu/do-with-temp-env-var-value
-                                          setting-name
+                                          (setting/setting-env-map-name setting-name)
                                           site-wide-value
                                           thunk))]]
         ;; clear out Setting if it was already set for some reason (except for `:only` where this is explicitly

--- a/test/metabase/public_settings_test.clj
+++ b/test/metabase/public_settings_test.clj
@@ -62,21 +62,19 @@
 (deftest site-url-settings-normalize
   (testing "We should normalize `site-url` when set via env var we should still normalize it (#9764)"
     (mt/with-temp-env-var-value [mb-site-url "localhost:3000/"]
-      (mt/with-temporary-setting-values [site-url nil]
-        (is (= "localhost:3000/"
-               (setting/get-value-of-type :string :site-url)))
-        (is (= "http://localhost:3000"
-               (public-settings/site-url)))))))
+      (is (= "localhost:3000/"
+             (setting/get-value-of-type :string :site-url)))
+      (is (= "http://localhost:3000"
+             (public-settings/site-url))))))
 
 (deftest invalid-site-url-env-var-test
   (testing (str "If `site-url` is set via an env var, and it's invalid, we should return `nil` rather than having the"
                 " whole instance break")
     (mt/with-temp-env-var-value [mb-site-url "asd_12w31%$;"]
-      (mt/with-temporary-setting-values [site-url nil]
-        (is (= "asd_12w31%$;"
-               (setting/get-value-of-type :string :site-url)))
-        (is (= nil
-               (public-settings/site-url)))))))
+      (is (= "asd_12w31%$;"
+             (setting/get-value-of-type :string :site-url)))
+      (is (= nil
+             (public-settings/site-url))))))
 
 (deftest site-url-should-update-https-redirect-test
   (testing "Changing `site-url` to non-HTTPS should disable forced HTTPS redirection"

--- a/test/metabase/server/middleware/auth_test.clj
+++ b/test/metabase/server/middleware/auth_test.clj
@@ -138,11 +138,9 @@
               (request-with-api-key "foobar"))))))
 
   (testing "no apikey is set, expect 403"
-    (mt/with-temporary-setting-values [api-key nil]
-      (is (= mw.util/response-forbidden
-             (api-key-enforced-handler
-              (ring.mock/request :get "/anyurl")))))
-    (mt/with-temporary-setting-values [api-key ""]
-      (is (= mw.util/response-forbidden
-             (api-key-enforced-handler
-              (ring.mock/request :get "/anyurl")))))))
+    (doseq [api-key-value [nil ""]]
+      (testing (str "when key is " ({nil "nil" "" "empty"} api-key-value))
+       (mt/with-temporary-setting-values [api-key api-key-value]
+         (is (= mw.auth/key-not-set-response
+                (api-key-enforced-handler
+                 (ring.mock/request :get "/anyurl")))))))))

--- a/test/metabase/test/util.clj
+++ b/test/metabase/test/util.clj
@@ -319,23 +319,6 @@
       str/lower-case
       keyword))
 
-(defn- safe-env-var-keyword
-  "Transform setting-k into the env/env lookup. [[do-with-temp-env-var-value]] is called from a few contexts.
-
-  One is [[mt/with-temp-env-var-value]] which seems to expect the env variable convention of `mb-email-smtp-port` or
-  `\"MB_DISABLE_SCHEDULER\"`. The point is you know the setting is an environmental setting and set it as such.
-
-  The other calling style is from `(mt/with-temporary-setting-values [api-key \"api-key\"]...)` when it is an
-  implementation detail that a particular setting was set in the environment. Here you use the convenient setting name
-  of :api-key not :mb-api-key.
-
-  Both pathways flow through this [[do-with-temp-env-var-value]]. So doing this check is not sloppy but handles the
-  two calling conventions through here."
-  [setting-k]
-  (if (str/starts-with? (name setting-k) "mb")
-    setting-k
-    (setting/setting-env-map-name setting-k)))
-
 (defn do-with-temp-env-var-value
   "Impl for [[with-temp-env-var-value]] macro."
   [env-var-keyword value thunk]
@@ -344,7 +327,7 @@
     (testing (colorize/blue (format "\nEnv var %s = %s\n" env-var-keyword (pr-str value)))
       (try
         ;; temporarily override the underlying environment variable value
-        (with-redefs [env/env (assoc env/env (safe-env-var-keyword env-var-keyword) value)]
+        (with-redefs [env/env (assoc env/env env-var-keyword value)]
           ;; flush the Setting cache so it picks up the env var value for the Setting (if applicable)
           (setting.cache/restore-cache!)
           (thunk))
@@ -396,10 +379,10 @@
     (with-temp-env-var-value [some-fake-env-var 123, "ANOTHER_FAKE_ENV_VAR" "def"]
       (testing "Should convert values to strings"
         (is (= "123"
-               (:mb-some-fake-env-var env/env))))
+               (:some-fake-env-var env/env))))
       (testing "should handle CAPITALS/SNAKE_CASE"
         (is (= "def"
-               (:mb-another-fake-env-var env/env))))))
+               (:another-fake-env-var env/env))))))
 
   (testing "validation"
     (are [form] (thrown?
@@ -442,7 +425,7 @@
                          (when-not raw-setting?
                            (throw e))))]
     (if (and (not raw-setting?) (#'setting/env-var-value setting-k))
-      (do-with-temp-env-var-value setting-k value thunk)
+      (do-with-temp-env-var-value (setting/setting-env-map-name setting-k) value thunk)
       (let [original-value (if raw-setting?
                              (db/select-one-field :value Setting :key setting-k)
                              (#'setting/get setting-k))]

--- a/test/metabase/test/util.clj
+++ b/test/metabase/test/util.clj
@@ -327,7 +327,7 @@
     (testing (colorize/blue (format "\nEnv var %s = %s\n" env-var-keyword (pr-str value)))
       (try
         ;; temporarily override the underlying environment variable value
-        (with-redefs [env/env (assoc env/env env-var-keyword value)]
+        (with-redefs [env/env (assoc env/env (setting/setting-env-map-name env-var-keyword) value)]
           ;; flush the Setting cache so it picks up the env var value for the Setting (if applicable)
           (setting.cache/restore-cache!)
           (thunk))
@@ -424,8 +424,8 @@
                        (catch Exception e
                          (when-not raw-setting?
                            (throw e))))]
-    (if-let [env-var-value (and (not raw-setting?) (#'setting/env-var-value setting-k))]
-      (do-with-temp-env-var-value setting env-var-value thunk)
+    (if (and (not raw-setting?) (#'setting/env-var-value setting-k))
+      (do-with-temp-env-var-value setting-k value thunk)
       (let [original-value (if raw-setting?
                              (db/select-one-field :value Setting :key setting-k)
                              (#'setting/get setting-k))]

--- a/test/metabase/test/util.clj
+++ b/test/metabase/test/util.clj
@@ -396,10 +396,10 @@
     (with-temp-env-var-value [some-fake-env-var 123, "ANOTHER_FAKE_ENV_VAR" "def"]
       (testing "Should convert values to strings"
         (is (= "123"
-               (:some-fake-env-var env/env))))
+               (:mb-some-fake-env-var env/env))))
       (testing "should handle CAPITALS/SNAKE_CASE"
         (is (= "def"
-               (:another-fake-env-var env/env))))))
+               (:mb-another-fake-env-var env/env))))))
 
   (testing "validation"
     (are [form] (thrown?


### PR DESCRIPTION
Fixes #15157

History: If you want to scan a database you can hit `api/notify/db/<db-id>?scan=schema` to do a quick schema scan. This is exposed to programatic users with the user of an api key. Previously, we had a bug where if a request failed to include the key, but the instance also hadn't set a key, the two keys were (vacuously) identical, and the request succeeded. That was fixed a while ago and we require the key being set.

This change gives a more informative error message if the key is not set. The behavior is still the same-- unauthenticated response, but now the body gives some insight:


#### Before
```
❯ http POST "localhost:3000/api/notify/db/1?scan=schema"
HTTP/1.1 403 Forbidden
<other headers removed>

Forbidden
```

#### With this change:

```
❯ http POST "localhost:3000/api/notify/db/1?scan=schema"
HTTP/1.1 403 Forbidden
<other headers removed>

MB_API_KEY is not set. See https://www.metabase.com/docs/latest/configuring-metabase/environment-variables#mb_api_key for details
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/27515)
<!-- Reviewable:end -->
