### PR TITLE
Update docs on supported DBs for datetimeDiff

### DIFF
--- a/docs/questions/query-builder/expressions/datetimediff.md
+++ b/docs/questions/query-builder/expressions/datetimediff.md
@@ -33,18 +33,8 @@ title: DatetimeDiff
 
 `datetimeDiff` is currently unavailable for the following databases:
 
-- Amazon Athena
 - Druid
 - Google Analytics
-- H2
-- MongoDB
-- Oracle
-- Presto
-- Redshift
-- SparkSQL
-- SQLite
-- SQL Server
-- Vertica
 
 ## Calculating age
 


### PR DESCRIPTION
This PR updates the list of supported DBs for the datetimeDiff custom expression function, which have now been implemented.

This epic tracked the additional support for DBs: https://github.com/metabase/metabase/issues/26999