### PR TITLE
Add utility to set instance settings in Jest

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/caching/components/QuestionCacheTTLField/QuestionCacheTTLField.unit.spec.js
+++ b/enterprise/frontend/src/metabase-enterprise/caching/components/QuestionCacheTTLField/QuestionCacheTTLField.unit.spec.js
@@ -1,8 +1,8 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { mockSettings } from "__support__/settings";
 import { msToMinutes, msToHours } from "metabase/lib/time";
-import MetabaseSettings from "metabase/lib/settings";
 import QuestionCacheTTLField from "./QuestionCacheTTLField";
 
 const TEN_MINUTES = 10 * 60 * 1000;
@@ -16,17 +16,10 @@ function setup({
 } = {}) {
   const onChange = jest.fn();
 
-  const spy = jest.spyOn(MetabaseSettings, "get");
-  spy.mockImplementation(key => {
-    if (key === "enable-query-caching") {
-      return true;
-    }
-    if (key === "query-caching-ttl-ratio") {
-      return cacheTTLMultiplier;
-    }
-    if (key === "query-caching-min-ttl") {
-      return minCacheThreshold;
-    }
+  mockSettings({
+    "enable-query-caching": true,
+    "query-caching-ttl-ratio": cacheTTLMultiplier,
+    "query-caching-min-ttl": minCacheThreshold,
   });
 
   const question = {

--- a/enterprise/frontend/src/metabase-enterprise/caching/utils.unit.spec.js
+++ b/enterprise/frontend/src/metabase-enterprise/caching/utils.unit.spec.js
@@ -1,5 +1,5 @@
+import { mockSettings } from "__support__/settings";
 import { msToSeconds, hoursToSeconds } from "metabase/lib/time";
-import MetabaseSettings from "metabase/lib/settings";
 import { getQuestionsImplicitCacheTTL, validateCacheTTL } from "./utils";
 
 describe("validateCacheTTL", () => {
@@ -30,17 +30,10 @@ describe("getQuestionsImplicitCacheTTL", () => {
     cacheTTLMultiplier = DEFAULT_CACHE_TTL_MULTIPLIER,
     minCacheThreshold = 60,
   } = {}) {
-    const spy = jest.spyOn(MetabaseSettings, "get");
-    spy.mockImplementation(key => {
-      if (key === "enable-query-caching") {
-        return cachingEnabled;
-      }
-      if (key === "query-caching-ttl-ratio") {
-        return cachingEnabled ? cacheTTLMultiplier : null;
-      }
-      if (key === "query-caching-min-ttl") {
-        return cachingEnabled ? minCacheThreshold : null;
-      }
+    mockSettings({
+      "enable-query-caching": cachingEnabled,
+      "query-caching-ttl-ratio": cachingEnabled ? cacheTTLMultiplier : null,
+      "query-caching-min-ttl": cachingEnabled ? minCacheThreshold : null,
     });
 
     return {

--- a/frontend/src/metabase/admin/databases/components/DatabaseEditApp/Sidebar/Sidebar.unit.spec.tsx
+++ b/frontend/src/metabase/admin/databases/components/DatabaseEditApp/Sidebar/Sidebar.unit.spec.tsx
@@ -9,9 +9,6 @@ import {
 } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
-import MetabaseSettings from "metabase/lib/settings";
-import Utils from "metabase/lib/utils";
-
 import type { InitialSyncStatus } from "metabase-types/api";
 
 import {
@@ -68,22 +65,7 @@ function setup({
   };
 }
 
-function mockMetabaseSettings() {
-  const original = MetabaseSettings.get.bind(MetabaseSettings);
-  const spy = jest.spyOn(MetabaseSettings, "get");
-  spy.mockImplementation(key => {
-    if (key === "site-uuid") {
-      return Utils.uuid();
-    }
-    return original(key);
-  });
-}
-
 describe("DatabaseEditApp/Sidebar", () => {
-  beforeAll(() => {
-    mockMetabaseSettings();
-  });
-
   it("syncs database schema", () => {
     const { database, syncDatabaseSchema } = setup();
     userEvent.click(screen.getByText(/Sync database schema now/i));

--- a/frontend/src/metabase/admin/databases/containers/DatabaseEditApp.unit.spec.js
+++ b/frontend/src/metabase/admin/databases/containers/DatabaseEditApp.unit.spec.js
@@ -1,12 +1,15 @@
 import React from "react";
+
 import {
   renderWithProviders,
   screen,
   waitForElementToBeRemoved,
 } from "__support__/ui";
-import admin from "metabase/admin/admin";
-import MetabaseSettings from "metabase/lib/settings";
 import { setupEnterpriseTest } from "__support__/enterprise";
+import { mockSettings } from "__support__/settings";
+
+import admin from "metabase/admin/admin";
+
 import DatabaseEditApp from "./DatabaseEditApp";
 
 const ENGINES_MOCK = {
@@ -34,46 +37,16 @@ jest.mock(
   () => ComponentMock,
 );
 
-function mockSettings({ cachingEnabled = false }) {
-  const original = MetabaseSettings.get.bind(MetabaseSettings);
-  const spy = jest.spyOn(MetabaseSettings, "get");
-  spy.mockImplementation(key => {
-    if (key === "engines") {
-      return ENGINES_MOCK;
-    }
-    if (key === "enable-query-caching") {
-      return cachingEnabled;
-    }
-    if (key === "site-url") {
-      return "http://localhost:3333";
-    }
-    if (key === "application-name") {
-      return "Metabase Test";
-    }
-    if (key === "is-hosted?") {
-      return false;
-    }
-    if (key === "cloud-gateway-ips") {
-      return [];
-    }
-    return original(key);
-  });
-}
-
 async function setup({ cachingEnabled = false } = {}) {
-  mockSettings({ cachingEnabled });
-
-  const settingsReducer = () => ({
-    values: {
-      engines: ENGINES_MOCK,
-      "enable-query-caching": cachingEnabled,
-      "persisted-models-enabled": false,
-    },
+  const settings = mockSettings({
+    engines: ENGINES_MOCK,
+    "enable-query-caching": cachingEnabled,
+    "persisted-models-enabled": false,
   });
 
   renderWithProviders(<DatabaseEditApp />, {
     withRouter: true,
-    reducers: { admin, settings: settingsReducer },
+    reducers: { admin, settings: () => settings.state },
   });
 
   await waitForElementToBeRemoved(() => screen.queryByText("Loading..."));

--- a/frontend/src/metabase/admin/databases/containers/DatabaseEditApp.unit.spec.js
+++ b/frontend/src/metabase/admin/databases/containers/DatabaseEditApp.unit.spec.js
@@ -46,7 +46,7 @@ async function setup({ cachingEnabled = false } = {}) {
 
   renderWithProviders(<DatabaseEditApp />, {
     withRouter: true,
-    reducers: { admin, settings: () => settings.state },
+    reducers: { admin, settings },
   });
 
   await waitForElementToBeRemoved(() => screen.queryByText("Loading..."));

--- a/frontend/src/metabase/admin/databases/containers/DatabaseEditApp.unit.spec.js
+++ b/frontend/src/metabase/admin/databases/containers/DatabaseEditApp.unit.spec.js
@@ -46,7 +46,7 @@ async function setup({ cachingEnabled = false } = {}) {
 
   renderWithProviders(<DatabaseEditApp />, {
     withRouter: true,
-    reducers: { admin, settings },
+    reducers: { admin, settings: () => settings },
   });
 
   await waitForElementToBeRemoved(() => screen.queryByText("Loading..."));

--- a/frontend/src/metabase/admin/settings/components/SettingsUpdatesForm/SettingsUpdatesForm.unit.spec.js
+++ b/frontend/src/metabase/admin/settings/components/SettingsUpdatesForm/SettingsUpdatesForm.unit.spec.js
@@ -1,7 +1,12 @@
 import React from "react";
 import { render as renderRTL, screen } from "@testing-library/react";
-
-import MetabaseSettings from "metabase/lib/settings";
+import { setupEnterpriseTest } from "__support__/enterprise";
+import { mockSettings } from "__support__/settings";
+import {
+  createMockVersion,
+  createMockVersionInfo,
+  createMockVersionInfoRecord,
+} from "metabase-types/api/mocks";
 import SettingsUpdatesForm from "./SettingsUpdatesForm";
 
 const elements = [
@@ -17,47 +22,56 @@ const render = () => {
 
 describe("SettingsUpdatesForm", () => {
   it("shows custom message for Cloud installations", () => {
-    const isHostedSpy = jest.spyOn(MetabaseSettings, "isHosted");
-    isHostedSpy.mockImplementation(() => true);
+    mockSettings({ "is-hosted?": true });
 
     render();
     screen.getByText(/Metabase Cloud keeps your instance up-to-date/);
-
-    isHostedSpy.mockRestore();
   });
 
   it("shows correct message when latest version is installed", () => {
-    const versionIsLatestSpy = jest.spyOn(MetabaseSettings, "versionIsLatest");
-    versionIsLatestSpy.mockImplementation(() => true);
+    mockSettings({
+      version: createMockVersion({ tag: "v1.0.0" }),
+      "version-info": createMockVersionInfo({
+        latest: createMockVersionInfoRecord({ version: "v1.0.0" }),
+      }),
+    });
 
     render();
     screen.getByText(/which is the latest and greatest/);
-
-    versionIsLatestSpy.mockRestore();
   });
 
   it("shows correct message when no version checks have been run", () => {
+    mockSettings({
+      version: null,
+      "version-info": null,
+    });
     render();
     screen.getByText("No successful checks yet.");
   });
 
   it("shows upgrade call-to-action if not in Enterprise plan", () => {
-    const versionIsLatestSpy = jest.spyOn(MetabaseSettings, "versionIsLatest");
-    versionIsLatestSpy.mockImplementation(() => true);
+    mockSettings({
+      version: createMockVersion({ tag: "v1.0.0" }),
+      "version-info": createMockVersionInfo({
+        latest: createMockVersionInfoRecord({ version: "v1.0.0" }),
+      }),
+    });
 
     render();
     screen.getByText("Migrate to Metabase Cloud.");
-
-    versionIsLatestSpy.mockRestore();
   });
 
   it("does not show upgrade call-to-action if in Enterprise plan", () => {
-    const versionIsLatestSpy = jest.spyOn(MetabaseSettings, "versionIsLatest");
-    versionIsLatestSpy.mockImplementation(() => false);
+    setupEnterpriseTest();
+
+    mockSettings({
+      version: createMockVersion({ tag: "v1.0.0" }),
+      "version-info": createMockVersionInfo({
+        latest: createMockVersionInfoRecord({ version: "v2.0.0" }),
+      }),
+    });
 
     render();
     expect(screen.queryByText("Migrate to Metabase Cloud.")).toBeNull();
-
-    versionIsLatestSpy.mockRestore();
   });
 });

--- a/frontend/src/metabase/dashboard/containers/CreateDashboardModal.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/containers/CreateDashboardModal.unit.spec.tsx
@@ -4,8 +4,8 @@ import nock from "nock";
 
 import { renderWithProviders, screen, waitFor } from "__support__/ui";
 import { setupEnterpriseTest } from "__support__/enterprise";
+import { mockSettings } from "__support__/settings";
 
-import MetabaseSettings from "metabase/lib/settings";
 import type { Collection } from "metabase-types/api";
 import { createMockEntitiesState } from "metabase-types/store/mocks";
 
@@ -16,29 +16,6 @@ const ROOT_COLLECTION = {
   name: "Our analytics",
   can_write: true,
 } as Collection;
-
-function mockCachingEnabled(enabled = true) {
-  const original = MetabaseSettings.get.bind(MetabaseSettings);
-  const spy = jest.spyOn(MetabaseSettings, "get");
-  spy.mockImplementation(key => {
-    if (key === "enable-query-caching") {
-      return enabled;
-    }
-    if (key === "application-name") {
-      return "Metabase Test";
-    }
-    if (key === "version") {
-      return { tag: "" };
-    }
-    if (key === "is-hosted?") {
-      return false;
-    }
-    if (key === "enable-enhancements?") {
-      return false;
-    }
-    return original(key);
-  });
-}
 
 function setup({ mockCreateDashboardResponse = true } = {}) {
   const onClose = jest.fn();
@@ -104,7 +81,9 @@ describe("CreateDashboardModal", () => {
 
   describe("Cache TTL field", () => {
     beforeEach(() => {
-      mockCachingEnabled();
+      mockSettings({
+        "enable-query-caching": true,
+      });
     });
 
     describe("OSS", () => {

--- a/frontend/src/metabase/dashboard/containers/CreateDashboardModal.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/containers/CreateDashboardModal.unit.spec.tsx
@@ -17,8 +17,13 @@ const ROOT_COLLECTION = {
   can_write: true,
 } as Collection;
 
-function setup({ mockCreateDashboardResponse = true } = {}) {
+function setup({
+  isCachingEnabled = false,
+  mockCreateDashboardResponse = true,
+} = {}) {
   const onClose = jest.fn();
+
+  const settings = mockSettings({ "enable-query-caching": isCachingEnabled });
 
   if (mockCreateDashboardResponse) {
     nock(location.origin)
@@ -33,6 +38,7 @@ function setup({ mockCreateDashboardResponse = true } = {}) {
           root: ROOT_COLLECTION,
         },
       }),
+      settings: settings.state,
     },
   });
 
@@ -80,15 +86,9 @@ describe("CreateDashboardModal", () => {
   });
 
   describe("Cache TTL field", () => {
-    beforeEach(() => {
-      mockSettings({
-        "enable-query-caching": true,
-      });
-    });
-
     describe("OSS", () => {
       it("is not shown", () => {
-        setup();
+        setup({ isCachingEnabled: true });
         expect(screen.queryByText("More options")).not.toBeInTheDocument();
         expect(
           screen.queryByText("Cache all question results for"),
@@ -102,7 +102,7 @@ describe("CreateDashboardModal", () => {
       });
 
       it("is not shown", () => {
-        setup();
+        setup({ isCachingEnabled: true });
         expect(screen.queryByText("More options")).not.toBeInTheDocument();
         expect(
           screen.queryByText("Cache all question results for"),

--- a/frontend/src/metabase/dashboard/containers/CreateDashboardModal.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/containers/CreateDashboardModal.unit.spec.tsx
@@ -38,7 +38,7 @@ function setup({
           root: ROOT_COLLECTION,
         },
       }),
-      settings: settings.state,
+      settings,
     },
   });
 

--- a/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar.unit.spec.js
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar.unit.spec.js
@@ -1,4 +1,5 @@
 import React from "react";
+
 import { renderWithProviders, screen } from "__support__/ui";
 import {
   SAMPLE_DATABASE,
@@ -6,8 +7,10 @@ import {
   metadata,
 } from "__support__/sample_database_fixture";
 import { setupEnterpriseTest } from "__support__/enterprise";
-import MetabaseSettings from "metabase/lib/settings";
+import { mockSettings } from "__support__/settings";
+
 import Question from "metabase-lib/Question";
+
 import { QuestionInfoSidebar } from "./QuestionInfoSidebar";
 
 const BASE_QUESTION = {
@@ -36,22 +39,6 @@ const BASE_QUESTION = {
   ],
 };
 
-function mockCachingSettings({ enabled = true } = {}) {
-  const original = MetabaseSettings.get.bind(MetabaseSettings);
-  const spy = jest.spyOn(MetabaseSettings, "get");
-  spy.mockImplementation(key => {
-    const settings = {
-      "enable-query-caching": enabled,
-      "query-caching-min-ttl": 10000,
-      "application-name": "Metabase Test",
-      version: { tag: "" },
-      "is-hosted?": false,
-      "enable-enhancements?": false,
-    };
-    return settings[key] ?? original(key);
-  });
-}
-
 function getQuestion(card) {
   return new Question(
     {
@@ -74,8 +61,9 @@ function getDataset(card) {
 }
 
 function setup({ question, cachingEnabled = true } = {}) {
-  mockCachingSettings({
-    enabled: cachingEnabled,
+  mockSettings({
+    "enable-query-caching": cachingEnabled,
+    "query-caching-min-ttl": 10000,
   });
 
   const onSave = jest.fn();

--- a/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar.unit.spec.js
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar.unit.spec.js
@@ -73,7 +73,7 @@ function setup({ question, cachingEnabled = true } = {}) {
     {
       withSampleDatabase: true,
       storeInitialState: {
-        settings: settings.state,
+        settings,
       },
     },
   );

--- a/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar.unit.spec.js
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar.unit.spec.js
@@ -61,7 +61,7 @@ function getDataset(card) {
 }
 
 function setup({ question, cachingEnabled = true } = {}) {
-  mockSettings({
+  const settings = mockSettings({
     "enable-query-caching": cachingEnabled,
     "query-caching-min-ttl": 10000,
   });
@@ -72,6 +72,9 @@ function setup({ question, cachingEnabled = true } = {}) {
     <QuestionInfoSidebar question={question} onSave={onSave} />,
     {
       withSampleDatabase: true,
+      storeInitialState: {
+        settings: settings.state,
+      },
     },
   );
 }

--- a/frontend/test/__support__/settings.ts
+++ b/frontend/test/__support__/settings.ts
@@ -9,5 +9,5 @@ export function mockSettings(params: Partial<Settings> = {}) {
 
   MetabaseSettings.setAll(settings);
 
-  return { state };
+  return state;
 }

--- a/frontend/test/__support__/settings.ts
+++ b/frontend/test/__support__/settings.ts
@@ -1,0 +1,13 @@
+import MetabaseSettings from "metabase/lib/settings";
+import { createMockSettings } from "metabase-types/api/mocks";
+import { createMockSettingsState } from "metabase-types/store/mocks";
+import type { Settings } from "metabase-types/api";
+
+export function mockSettings(params: Partial<Settings> = {}) {
+  const settings = createMockSettings(params);
+  const state = createMockSettingsState({ values: settings });
+
+  MetabaseSettings.setAll(settings);
+
+  return { state };
+}

--- a/frontend/test/metabase/containers/SaveQuestionModal.unit.spec.js
+++ b/frontend/test/metabase/containers/SaveQuestionModal.unit.spec.js
@@ -15,10 +15,17 @@ import SaveQuestionModal from "metabase/containers/SaveQuestionModal";
 
 import Question from "metabase-lib/Question";
 
-const setup = async (question, originalQuestion) => {
+const setup = async (
+  question,
+  originalQuestion,
+  { isCachingEnabled = false } = {},
+) => {
   const onCreateMock = jest.fn(() => Promise.resolve());
   const onSaveMock = jest.fn(() => Promise.resolve());
   const onCloseMock = jest.fn();
+
+  const settings = mockSettings({ "enable-query-caching": isCachingEnabled });
+
   renderWithProviders(
     <SaveQuestionModal
       card={question.card()}
@@ -28,8 +35,14 @@ const setup = async (question, originalQuestion) => {
       onSave={onSaveMock}
       onClose={onCloseMock}
     />,
+    {
+      storeInitialState: {
+        settings: settings.state,
+      },
+    },
   );
   await waitFor(() => screen.getByRole("button", { name: "Save" }));
+
   return { onSaveMock, onCreateMock, onCloseMock };
 };
 
@@ -523,10 +536,6 @@ describe("SaveQuestionModal", () => {
   });
 
   describe("Cache TTL field", () => {
-    beforeEach(() => {
-      mockSettings({ "enable-query-caching": true });
-    });
-
     const question = Question.create({
       databaseId: SAMPLE_DATABASE.id,
       tableId: ORDERS.id,
@@ -538,7 +547,7 @@ describe("SaveQuestionModal", () => {
 
     describe("OSS", () => {
       it("is not shown", async () => {
-        await setup(question);
+        await setup(question, null, { isCachingEnabled: true });
         expect(screen.queryByText("More options")).not.toBeInTheDocument();
         expect(
           screen.queryByText("Cache all question results for"),
@@ -552,7 +561,7 @@ describe("SaveQuestionModal", () => {
       });
 
       it("is not shown", async () => {
-        await setup(question);
+        await setup(question, null, { isCachingEnabled: true });
         expect(screen.queryByText("More options")).not.toBeInTheDocument();
         expect(
           screen.queryByText("Cache all question results for"),

--- a/frontend/test/metabase/containers/SaveQuestionModal.unit.spec.js
+++ b/frontend/test/metabase/containers/SaveQuestionModal.unit.spec.js
@@ -1,41 +1,19 @@
 import React from "react";
 import userEvent from "@testing-library/user-event";
 import nock from "nock";
+
 import { act, renderWithProviders, screen, waitFor } from "__support__/ui";
-
-import SaveQuestionModal from "metabase/containers/SaveQuestionModal";
-import MetabaseSettings from "metabase/lib/settings";
-
 import {
   SAMPLE_DATABASE,
   ORDERS,
   metadata,
 } from "__support__/sample_database_fixture";
 import { setupEnterpriseTest } from "__support__/enterprise";
-import Question from "metabase-lib/Question";
+import { mockSettings } from "__support__/settings";
 
-function mockCachingEnabled(enabled = true) {
-  const original = MetabaseSettings.get.bind(MetabaseSettings);
-  const spy = jest.spyOn(MetabaseSettings, "get");
-  spy.mockImplementation(key => {
-    if (key === "enable-query-caching") {
-      return enabled;
-    }
-    if (key === "application-name") {
-      return "Metabase Test";
-    }
-    if (key === "version") {
-      return { tag: "" };
-    }
-    if (key === "is-hosted?") {
-      return false;
-    }
-    if (key === "enable-enhancements?") {
-      return false;
-    }
-    return original(key);
-  });
-}
+import SaveQuestionModal from "metabase/containers/SaveQuestionModal";
+
+import Question from "metabase-lib/Question";
 
 const setup = async (question, originalQuestion) => {
   const onCreateMock = jest.fn(() => Promise.resolve());
@@ -546,7 +524,7 @@ describe("SaveQuestionModal", () => {
 
   describe("Cache TTL field", () => {
     beforeEach(() => {
-      mockCachingEnabled();
+      mockSettings({ "enable-query-caching": true });
     });
 
     const question = Question.create({

--- a/frontend/test/metabase/containers/SaveQuestionModal.unit.spec.js
+++ b/frontend/test/metabase/containers/SaveQuestionModal.unit.spec.js
@@ -37,7 +37,7 @@ const setup = async (
     />,
     {
       storeInitialState: {
-        settings: settings.state,
+        settings,
       },
     },
   );

--- a/frontend/test/metabase/nav/ProfileLink.unit.spec.js
+++ b/frontend/test/metabase/nav/ProfileLink.unit.spec.js
@@ -1,8 +1,9 @@
 import React from "react";
 import { screen, fireEvent } from "@testing-library/react";
-import { renderWithProviders } from "__support__/ui";
 
-import MetabaseSettings from "metabase/lib/settings";
+import { renderWithProviders } from "__support__/ui";
+import { mockSettings } from "__support__/settings";
+
 import ProfileLink from "metabase/nav/components/ProfileLink";
 
 const REGULAR_ITEMS = [
@@ -43,17 +44,12 @@ describe("ProfileLink", () => {
     ["regular", "hosted"].forEach(testCase => {
       describe(`${testCase} instance`, () => {
         beforeEach(() => {
-          jest.spyOn(MetabaseSettings, "isHosted");
-          MetabaseSettings.isHosted = jest.fn(() => false);
-        });
-
-        afterEach(() => {
-          MetabaseSettings.isHosted.mockRestore();
+          mockSettings({ "is-hosted?": false });
         });
 
         if (testCase === "hosted") {
           beforeEach(() => {
-            MetabaseSettings.isHosted = jest.fn(() => true);
+            mockSettings({ "is-hosted?": true });
           });
         }
 


### PR DESCRIPTION
Epic #26960

### Problem

When testing code using Metabase instance settings, we often need to put them in a proper shape. We already have [`createMockSettings`](https://github.com/metabase/metabase/blob/73b6ee7d890cfea97ec68de957e0ab1b58698f47/frontend/src/metabase-types/api/mocks/settings.ts#L130) and [`createMockSettingsState`](https://github.com/metabase/metabase/blob/73b6ee7d890cfea97ec68de957e0ab1b58698f47/frontend/src/metabase-types/store/mocks/settings.ts#L4) for Redux. Some components are still using deprecated `MetabaseSettings` singleton, and in this case, we often need to do weird stuff like:

```js
import MetabaseSettings from "metabase/lib/settings"

beforeEach(() => {
  const original = MetabaseSettings.get;
  const spy = jest.spyOn(MetabaseSettings, "get");
  spy.mockImplementation(key => {
    if ("enable-query-caching") {
      return false;
    }
    return original(key);
  });
});
```

Sometimes some child component deep down in the tree needs a setting that doesn't really matter in tests. In this case, we need to extend this already bloated piece of code with mocks that don't help to understand the test better.

### Solution

This PR introduces a simple `mockSettings` test utility that'd generate a complete settings object and overwrite whatever is in `MetabaseSettings` as a side effect to guarantee settings are consistent

**Example usage**

```js
import { renderWithProviders } from "__support__/ui"
import { mockSettings } from "__support__/settings"

function setup() {
   const { state: settings } = mockSettings({ "enable-query-caching": true });
   renderWithProviders(<Component />, {
     storeInitialState: { settings }
   })
}
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/27532)
<!-- Reviewable:end -->
