### PR TITLE
allow for 3rd party logger configs

### DIFF
--- a/src/metabase/bootstrap.clj
+++ b/src/metabase/bootstrap.clj
@@ -6,7 +6,9 @@
 ;; own log4j2.xml and dynamically reloads and kills useful logging. Should we move our log4j2.xml into
 ;; metabase/metabase/log4j2.xml and refer to it that way so presumably no jar could add another log4j2.xml that we
 ;; accidentally pick up?
-(System/setProperty "log4j2.configurationFile" "log4j2.xml")
+(when-not (or (System/getProperty "log4j2.configurationFile")
+              (System/getProperty "log4j.configurationFile"))
+  (System/setProperty "log4j2.configurationFile" "log4j2.xml"))
 
 ;; ensure we use a `BasicContextSelector` instead of a `ClassLoaderContextSelector` for log4j2. Ensures there is only
 ;; one LoggerContext instead of one per classpath root. Practical effect is that now `(LogManager/getContext true)`


### PR DESCRIPTION
Fixes #27497 

allow for 3rd party logger configs

```
docker run \
       -p 3000:3000 \
       -v $PWD/my_log4j2.xml:/tmp/my_log4j2.xml \
       -e JAVA_OPTS=-Dlog4j.configurationFile=/tmp/my_log4j2.xml \
       metabase/metabase:v0.45.1
```

From https://github.com/metabase/metabase/issues/27497

Note that this specifies `log4j.configurationFile` and not
"log4j2.configurationFile" that we set in our bootstrap.clj.

I'm not sure if this is supposed to work or not but we'll give it a
shot.

the Automatic Configuration section of
https://logging.apache.org/log4j/2.x/manual/configuration.html specifies
that:
1. Log4j will inspect the "log4j2.configurationFile" system property
and, if set, will attempt to load the configuration using the
ConfigurationFactory that matches the file extension. Note that this is
not restricted to a location on the local file system and may contain a
URL.

I'm not sure if that other property will work due to some other
mechanism or log4j2 has an undocumented back-compat mechanism.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/27536)
<!-- Reviewable:end -->
