### PR TITLE
Augment `GET /api/mt/gtap` to allow fetching a single GTAP by group and table ID

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/sandbox/api/gtap.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/api/gtap.clj
@@ -11,12 +11,14 @@
    [schema.core :as s]
    [toucan.db :as db]))
 
-#_{:clj-kondo/ignore [:deprecated-var]}
-(api/defendpoint-schema GET "/"
-  "Fetch a list of all the GTAPs currently in use."
-  []
-  ;; TODO - do we need to hydrate anything here?
-  (db/select GroupTableAccessPolicy))
+(api/defendpoint GET "/"
+  "Fetch a list of all GTAPs currently in use, or a single GTAP if both `group_id` and `table_id` are provided."
+  [group_id table_id]
+  {group_id [:maybe pos-int?]
+   table_id [:maybe pos-int?]}
+  (if (and group_id table_id)
+    (db/select-one GroupTableAccessPolicy :group_id group_id :table_id table_id)
+    (db/select GroupTableAccessPolicy)))
 
 #_{:clj-kondo/ignore [:deprecated-var]}
 (api/defendpoint-schema GET "/:id"

--- a/enterprise/backend/src/metabase_enterprise/sandbox/api/gtap.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/api/gtap.clj
@@ -18,7 +18,7 @@
    table_id [:maybe pos-int?]}
   (if (and group_id table_id)
     (db/select-one GroupTableAccessPolicy :group_id group_id :table_id table_id)
-    (db/select GroupTableAccessPolicy)))
+    (db/select GroupTableAccessPolicy {:order-by [[:id :asc]]})))
 
 #_{:clj-kondo/ignore [:deprecated-var]}
 (api/defendpoint-schema GET "/:id"

--- a/enterprise/backend/test/metabase_enterprise/sandbox/api/gtap_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/api/gtap_test.clj
@@ -54,6 +54,33 @@
                                         :group_id             group-id
                                         :card_id              card-id
                                         :attribute_remappings {"foo" 1}}))))))))
+
+(deftest fetch-gtap-test
+  (testing "GET /api/mt/gtap/"
+    (with-gtap-cleanup
+      (mt/with-temp* [Table                  [{table-id-1 :id}]
+                      Table                  [{table-id-2 :id}]
+                      PermissionsGroup       [{group-id-1 :id}]
+                      PermissionsGroup       [{group-id-2 :id}]
+                      Card                   [{card-id :id}]
+                      GroupTableAccessPolicy [{gtap-id-1 :id} {:table_id table-id-1
+                                                               :group_id group-id-1
+                                                               :card_id  card-id}]
+                      GroupTableAccessPolicy [{gtap-id-2 :id} {:table_id table-id-2
+                                                               :group_id group-id-2
+                                                               :card_id  card-id}]]
+        (testing "Test that we can fetch the list of all GTAPs"
+          (is (partial=
+               [{:id gtap-id-1 :table_id table-id-1 :group_id group-id-1}
+                {:id gtap-id-2 :table_id table-id-2 :group_id group-id-2}]
+               (mt/user-http-request :crowberto :get 200 "mt/gtap/"))))
+
+        (testing "Test that we can fetch the list of GTAPs for a specific table and group"
+          (is (partial=
+               {:id gtap-id-1 :table_id table-id-1 :group_id group-id-1}
+               (mt/user-http-request :crowberto :get 200 "mt/gtap/"
+                                     :group_id group-id-1 :table_id table-id-1))))))))
+
 (deftest create-gtap-test
   (testing "POST /api/mt/gtap"
     (mt/with-temp* [Table            [{table-id :id}]

--- a/enterprise/backend/test/metabase_enterprise/sandbox/api/gtap_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/api/gtap_test.clj
@@ -45,15 +45,16 @@
   (testing "POST /api/mt/gtap"
     (testing "Must have a valid token to use GTAPs"
       (with-redefs [premium-features/enable-sandboxes? (constantly false)]
-        (mt/with-temp* [Table            [{table-id :id}]
-                        PermissionsGroup [{group-id :id}]
-                        Card             [{card-id :id}]]
-          (is (= "This API endpoint is only enabled if you have a premium token with the :sandboxes feature."
-                 (mt/user-http-request :crowberto :post 402 "mt/gtap"
-                                       {:table_id             table-id
-                                        :group_id             group-id
-                                        :card_id              card-id
-                                        :attribute_remappings {"foo" 1}}))))))))
+        (mt/with-temporary-setting-values [premium-embedding-token nil]
+          (mt/with-temp* [Table            [{table-id :id}]
+                          PermissionsGroup [{group-id :id}]
+                          Card             [{card-id :id}]]
+            (is (= "This API endpoint is only enabled if you have a premium token with the :sandboxes feature."
+                   (mt/user-http-request :crowberto :post 402 "mt/gtap"
+                                         {:table_id             table-id
+                                          :group_id             group-id
+                                          :card_id              card-id
+                                          :attribute_remappings {"foo" 1}})))))))))
 
 (deftest fetch-gtap-test
   (testing "GET /api/mt/gtap/"
@@ -73,7 +74,9 @@
           (is (partial=
                [{:id gtap-id-1 :table_id table-id-1 :group_id group-id-1}
                 {:id gtap-id-2 :table_id table-id-2 :group_id group-id-2}]
-               (mt/user-http-request :crowberto :get 200 "mt/gtap/"))))
+               (filter
+                #(#{gtap-id-1 gtap-id-2} (:id %))
+                (mt/user-http-request :crowberto :get 200 "mt/gtap/")))))
 
         (testing "Test that we can fetch the list of GTAPs for a specific table and group"
           (is (partial=
@@ -260,6 +263,8 @@
   (testing "PUT /api/permissions/graph"
     (testing "make sure an error is thrown if the :sandboxes key is included in the request, but the :sandboxes feature
              is not enabled"
-      (is (= "Sandboxes are an Enterprise feature. Please upgrade to a paid plan to use this feature."
-             (mt/user-http-request :crowberto :put 402 "permissions/graph"
-                                   (assoc (perms/data-perms-graph) :sandboxes [{:card_id 1}])))))))
+      (with-redefs [premium-features/enable-sandboxes? (constantly false)]
+        (mt/with-temporary-setting-values [premium-embedding-token nil]
+          (is (= "Sandboxes are an Enterprise feature. Please upgrade to a paid plan to use this feature."
+                 (mt/user-http-request :crowberto :put 402 "permissions/graph"
+                                       (assoc (perms/data-perms-graph) :sandboxes [{:card_id 1}])))))))))


### PR DESCRIPTION
Simple change to allow a single GTAP to be fetched by the frontend without already knowing its ID. Pursuent to #27053.