### PR TITLE
allow for 3rd party logger configs

### DIFF
--- a/src/metabase/bootstrap.clj
+++ b/src/metabase/bootstrap.clj
@@ -6,7 +6,9 @@
 ;; own log4j2.xml and dynamically reloads and kills useful logging. Should we move our log4j2.xml into
 ;; metabase/metabase/log4j2.xml and refer to it that way so presumably no jar could add another log4j2.xml that we
 ;; accidentally pick up?
-(System/setProperty "log4j2.configurationFile" "log4j2.xml")
+(when-not (or (System/getProperty "log4j2.configurationFile")
+              (System/getProperty "log4j.configurationFile"))
+  (System/setProperty "log4j2.configurationFile" "log4j2.xml"))
 
 ;; ensure we use a `BasicContextSelector` instead of a `ClassLoaderContextSelector` for log4j2. Ensures there is only
 ;; one LoggerContext instead of one per classpath root. Practical effect is that now `(LogManager/getContext true)`


### PR DESCRIPTION
Fix applied to master for https://github.com/metabase/metabase/issues/27497

I fixed on `release-x.45.x` first in https://github.com/metabase/metabase/pull/27536 so that the original reporter has the option to try out the jar in CI before merging. I'll merge once confirmed or tomorrow at some point if we don't hear back.


Grabbing a jar from this CI run or from the CI run of the other PR, 

```shell
❯ MB_JETTY_PORT=3006 java -Dlog4j.configurationFile=log4j2.xml -jar metabase.jar
2023-01-05 17:09:04,426 main DEBUG null null initializing configuration XmlConfiguration[location=/private/tmp/test/log4j2.xml]
2023-01-05 17:09:04,437 main DEBUG PluginManager 'Core' found 132 plugins
2023-01-05 17:09:04,437 main DEBUG PluginManager 'Level' found 0 plugins
2023-01-05 17:09:04,451 main DEBUG PluginManager 'Lookup' found 16 plugins
2023-01-05 17:09:04,454 main DEBUG Building Plugin[name=layout, class=org.apache.logging.log4j.core.layout.PatternLayout].
2023-01-05 17:09:04,474 main DEBUG PluginManager 'TypeConverter' found 26 plugins
...
```

```
docker run \
       -p 3000:3000 \
       -v $PWD/my_log4j2.xml:/tmp/my_log4j2.xml \
       -e JAVA_OPTS=-Dlog4j.configurationFile=/tmp/my_log4j2.xml \
       metabase/metabase:v0.45.1
```

From https://github.com/metabase/metabase/issues/27497

Note that this specifies `log4j.configurationFile` and not "log4j2.configurationFile" that we set in our bootstrap.clj.

I'm not sure if this is supposed to work or not but we'll give it a shot.

the Automatic Configuration section of
https://logging.apache.org/log4j/2.x/manual/configuration.html specifies that:
1. Log4j will inspect the "log4j2.configurationFile" system property and, if set, will attempt to load the configuration using the ConfigurationFactory that matches the file extension. Note that this is not restricted to a location on the local file system and may contain a URL.

I'm not sure if that other property will work due to some other mechanism or log4j2 has an undocumented back-compat mechanism.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/27541)
<!-- Reviewable:end -->
