### PR TITLE
Simplify `createMockSettingsState` utility

### DIFF
--- a/frontend/src/metabase-types/store/mocks/settings.ts
+++ b/frontend/src/metabase-types/store/mocks/settings.ts
@@ -1,9 +1,9 @@
-import { SettingsState } from "metabase-types/store";
+import type { Settings } from "metabase-types/api";
+import type { SettingsState } from "metabase-types/store";
 import { createMockSettings } from "metabase-types/api/mocks";
 
 export const createMockSettingsState = (
-  opts?: Partial<SettingsState>,
+  opts?: Partial<Settings>,
 ): SettingsState => ({
-  values: createMockSettings(),
-  ...opts,
+  values: createMockSettings(opts),
 });

--- a/frontend/src/metabase/public/components/widgets/EmbedModalContent.unit.spec.tsx
+++ b/frontend/src/metabase/public/components/widgets/EmbedModalContent.unit.spec.tsx
@@ -3,7 +3,6 @@ import { screen, waitFor } from "@testing-library/react";
 import _ from "underscore";
 
 import { renderWithProviders } from "__support__/ui";
-import { createMockSettings } from "metabase-types/api/mocks";
 import { createMockSettingsState } from "metabase-types/store/mocks";
 
 import EmbedModalContent from "./EmbedModalContent";
@@ -145,10 +144,8 @@ function renderWithConfiguredProviders(element: JSX.Element) {
   renderWithProviders(element, {
     storeInitialState: {
       settings: createMockSettingsState({
-        values: createMockSettings({
-          "enable-embedding": true,
-          "embedding-secret-key": "my_super_secret_key",
-        }),
+        "enable-embedding": true,
+        "embedding-secret-key": "my_super_secret_key",
       }),
     },
   });

--- a/frontend/test/__support__/settings.ts
+++ b/frontend/test/__support__/settings.ts
@@ -5,7 +5,7 @@ import type { Settings } from "metabase-types/api";
 
 export function mockSettings(params: Partial<Settings> = {}) {
   const settings = createMockSettings(params);
-  const state = createMockSettingsState({ values: settings });
+  const state = createMockSettingsState(settings);
 
   MetabaseSettings.setAll(settings);
 


### PR DESCRIPTION
Epic #26960

We store Metabase instance settings in Redux like that:

```js
{
  settings: {
    values: hugeSettingsObject
  },
  ...otherReducers
}
```

If we need to provide a default settings state in unit tests, we needed to use two different utilities:

```js
import { createMockSettings } from "metabase-types/api/mocks";
import { createMockSettingsState } from "metabase-types/store/mocks";

const settings = createMockSettings({ 'enable-query-caching': true });
const settingsState = createMockSettingsState(settings);

renderWithProviders(<Component />, { storeInitialState: { settings: settingsState  } });
```

This PR simplifies the `createMockSettingsState` utility, so we can avoid using `createMockSettings`:

```js
import { createMockSettingsState } from "metabase-types/store/mocks";

const settingsState = createMockSettingsState({ 'enable-query-caching': true });

renderWithProviders(<Component />, { storeInitialState: { settings: settingsState  } });
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/27546)
<!-- Reviewable:end -->
