### PR TITLE
[metabase-lib] Port date and time parsing and formatting to CLJC

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -634,6 +634,7 @@
    metabase.models.user-test/with-groups                                        macros.metabase.models.user-test/with-groups
    metabase.query-processor.streaming/streaming-response                        macros.metabase.query-processor.streaming/streaming-response
    metabase.related-test/with-world                                             macros.metabase.related-test/with-world
+   metabase.shared.util.namespaces/import-fn                                    macros.metabase.shared.util.namespaces/import-fn
    metabase.test.data.users/with-group-for-user                                 macros.metabase.test.data.users/with-group-for-user
    metabase.test.util/with-temp-env-var-value                                   macros.metabase.test.util/with-temp-env-var-value
    metabase.test.util/with-temporary-raw-setting-values                         macros.metabase.test.util/with-temporary-raw-setting-values

--- a/.clj-kondo/macros/metabase/shared/util/namespaces.clj
+++ b/.clj-kondo/macros/metabase/shared/util/namespaces.clj
@@ -1,0 +1,7 @@
+(ns macros.metabase.shared.util.namespaces)
+
+(defmacro import-fn
+  ([sym]
+   `(def ~(-> sym name symbol) "docstring" ~sym))
+  ([sym name]
+   `(def ~name "docstring" ~sym)))

--- a/frontend/src/metabase/lib/formatting/date.tsx
+++ b/frontend/src/metabase/lib/formatting/date.tsx
@@ -1,129 +1,21 @@
 import React from "react";
-import moment, { Moment } from "moment-timezone";
 
-import { parseTimestamp } from "metabase/lib/time";
+import { MomentInput } from "moment-timezone";
+
+import {
+  format_datetime_with_unit,
+  format_for_parameter,
+  format_range_with_unit,
+} from "cljs/metabase.shared.formatting.date";
 import type { DatetimeUnit } from "metabase-types/api/query";
 import { isDateWithoutTime } from "metabase-lib/types/utils/isa";
-import {
-  DEFAULT_DATE_STYLE,
-  DEFAULT_TIME_STYLE,
-  getTimeFormatFromStyle,
-  hasDay,
-  hasHour,
-} from "./datetime-utils";
 
 import type { OptionsType } from "./types";
 
-const RANGE_SEPARATOR = ` – `;
-
-type DEFAULT_DATE_FORMATS_TYPE = { [key: string]: string };
-const DEFAULT_DATE_FORMATS: DEFAULT_DATE_FORMATS_TYPE = {
-  year: "YYYY",
-  quarter: "[Q]Q - YYYY",
-  "minute-of-hour": "m",
-  "day-of-week": "dddd",
-  "day-of-month": "D",
-  "day-of-year": "DDD",
-  "week-of-year": "wo",
-  "month-of-year": "MMMM",
-  "quarter-of-year": "[Q]Q",
-};
-
-// a "date style" is essentially a "day" format with overrides for larger units
-
-type DATE_STYLE_TO_FORMAT_TYPE = { [key: string]: { [key: string]: string } };
-
-const DATE_STYLE_TO_FORMAT: DATE_STYLE_TO_FORMAT_TYPE = {
-  "M/D/YYYY": {
-    month: "M/YYYY",
-  },
-  "D/M/YYYY": {
-    month: "M/YYYY",
-  },
-  "YYYY/M/D": {
-    month: "YYYY/M",
-    quarter: "YYYY - [Q]Q",
-  },
-  "MMMM D, YYYY": {
-    month: "MMMM, YYYY",
-  },
-  "D MMMM, YYYY": {
-    month: "MMMM, YYYY",
-  },
-  "dddd, MMMM D, YYYY": {
-    week: "MMMM D, YYYY",
-    month: "MMMM, YYYY",
-  },
-};
-
-const getDayFormat = (options: OptionsType) =>
-  options.compact || options.date_abbreviate ? "ddd" : "dddd";
-
-const getMonthFormat = (options: OptionsType) =>
-  options.compact || options.date_abbreviate ? "MMM" : "MMMM";
-
-export function getDateFormatFromStyle(
-  style: string,
-  unit: DatetimeUnit,
-  separator: string,
-  includeWeekday?: boolean,
-) {
-  const replaceSeparators = (format: string) =>
-    separator && format ? format.replace(/\//g, separator) : format;
-
-  if (!unit) {
-    unit = "default";
-  }
-
-  let format = null;
-
-  if (DATE_STYLE_TO_FORMAT[style]) {
-    if (DATE_STYLE_TO_FORMAT[style][unit]) {
-      format = replaceSeparators(DATE_STYLE_TO_FORMAT[style][unit]);
-    }
-  } else {
-    console.warn("Unknown date style", style);
-  }
-
-  if (format == null) {
-    format = DEFAULT_DATE_FORMATS[unit]
-      ? replaceSeparators(DEFAULT_DATE_FORMATS[unit])
-      : replaceSeparators(style);
-  }
-
-  if (includeWeekday && hasDay(unit)) {
-    format = `ddd, ${format}`;
-  }
-
-  return format;
-}
+const RANGE_SEPARATOR = ` \u2013 `;
 
 export function formatDateTimeForParameter(value: string, unit: DatetimeUnit) {
-  const m = parseTimestamp(value, unit);
-  if (!m.isValid()) {
-    return String(value);
-  }
-
-  if (unit === "month") {
-    return m.format("YYYY-MM");
-  } else if (unit === "quarter") {
-    return m.format("[Q]Q-YYYY");
-  } else if (unit === "day") {
-    return m.format("YYYY-MM-DD");
-  } else if (unit) {
-    const start = m.clone().startOf(unit);
-    const end = m.clone().endOf(unit);
-
-    if (!start.isValid() || !end.isValid()) {
-      return String(value);
-    }
-
-    const isSameDay = start.isSame(end, "day");
-
-    return isSameDay
-      ? start.format("YYYY-MM-DD")
-      : `${start.format("YYYY-MM-DD")}~${end.format("YYYY-MM-DD")}`;
-  }
+  return format_for_parameter(value, { unit });
 }
 
 /** This formats a time with unit as a date range */
@@ -132,52 +24,11 @@ export function formatDateTimeRangeWithUnit(
   unit: DatetimeUnit,
   options: OptionsType = {},
 ) {
-  const m = parseTimestamp(value, unit, options.local);
-  if (!m.isValid()) {
-    return String(value);
-  }
-
-  // Tooltips should show full month name, but condense "MMMM D, YYYY - MMMM D, YYYY" to "MMMM D - D, YYYY" etc
-  const monthFormat =
-    options.type === "tooltip" ? "MMMM" : getMonthFormat(options);
-  const condensed = options.compact || options.type === "tooltip";
-
-  // The client's unit boundaries might not line up with the data returned from the server.
-  // We shift the range so that the start lines up with the value.
-  const start = m.clone().startOf(unit);
-  const end = m.clone().endOf(unit);
-  const shift = m.diff(start, "days");
-  [start, end].forEach(d => d.add(shift, "days"));
-
-  if (start.isValid() && end.isValid()) {
-    if (!condensed || start.year() !== end.year()) {
-      // January 1, 2018 - January 2, 2019
-      return (
-        start.format(`${monthFormat} D, YYYY`) +
-        RANGE_SEPARATOR +
-        end.format(`${monthFormat} D, YYYY`)
-      );
-    } else if (start.month() !== end.month()) {
-      // January 1 - Feburary 2, 2018
-      return (
-        start.format(`${monthFormat} D`) +
-        RANGE_SEPARATOR +
-        end.format(`${monthFormat} D, YYYY`)
-      );
-    } else {
-      // January 1 - 2, 2018
-      return (
-        start.format(`${monthFormat} D`) +
-        RANGE_SEPARATOR +
-        end.format(`D, YYYY`)
-      );
-    }
-  } else {
-    // TODO: when is this used?
-    return formatWeek(m, options);
-  }
+  return format_range_with_unit(value, { ...options, unit });
 }
 
+// TODO This function has nothing to do with date formatting specifically and
+// should be moved to a more general library.
 export function formatRange(
   range: any[],
   formatter: any,
@@ -195,129 +46,22 @@ export function formatRange(
   }
 }
 
-function formatWeek(m: Moment, options: OptionsType = {}) {
-  return formatMajorMinor(m.format("wo"), m.format("gggg"), options);
-}
-
-function formatMajorMinor(
-  major: string,
-  minor: string,
-  options: OptionsType = {},
-) {
-  options = {
-    jsx: false,
-    majorWidth: 3,
-    ...options,
-  };
-  if (options.jsx) {
-    return (
-      <span>
-        <span
-          style={{ minWidth: options.majorWidth + "em" }}
-          className="inline-block text-right text-bold"
-        >
-          {major}
-        </span>
-        {" - "}
-        <span>{minor}</span>
-      </span>
-    );
-  } else {
-    return `${major} - ${minor}`;
-  }
-}
-
-function replaceDateFormatNames(format: string, options: OptionsType) {
-  return format
-    .replace(/\bMMMM\b/g, getMonthFormat(options))
-    .replace(/\bdddd\b/g, getDayFormat(options));
-}
-
-function formatDateTimeWithFormats(
-  value: number,
-  dateFormat: string,
-  timeFormat: string,
-  options: OptionsType,
-) {
-  const m = parseTimestamp(
-    value,
-    options.column && options.column.unit,
-    options.local,
-  );
-  if (!m.isValid()) {
-    return String(value);
-  }
-
-  const format = [];
-  if (dateFormat) {
-    format.push(replaceDateFormatNames(dateFormat, options));
-  }
-
-  const shouldIncludeTime =
-    timeFormat && options.time_enabled && !isDateWithoutTime(options.column);
-
-  if (shouldIncludeTime) {
-    format.push(timeFormat);
-  }
-  return m.format(format.join(", "));
-}
-
 export function formatDateTimeWithUnit(
-  value: number | string,
+  value: MomentInput,
   unit: DatetimeUnit,
   options: OptionsType = {},
 ) {
-  if (options.isExclude && unit === "hour-of-day") {
-    return moment.utc(value).format("h A");
-  } else if (options.isExclude && unit === "day-of-week") {
-    const date = moment.utc(value);
-    if (date.isValid()) {
-      return date.format("dddd");
-    }
-  }
-
-  const m = parseTimestamp(value, unit, options.local);
-  if (!m.isValid()) {
-    return String(value);
-  }
-
-  // expand "week" into a range in specific contexts
-  if (unit === "week") {
-    if (
-      (options.type === "tooltip" || options.type === "cell") &&
-      !options.noRange
-    ) {
-      // tooltip show range like "January 1 - 7, 2017"
-      return formatDateTimeRangeWithUnit(value, unit, options);
-    }
-  }
-
-  options = {
-    date_style: DEFAULT_DATE_STYLE,
-    time_style: DEFAULT_TIME_STYLE,
-    time_enabled: hasHour(unit) ? "minutes" : null,
+  const fullOptions = {
     ...options,
+    unit,
   };
 
-  let dateFormat = options.date_format;
-  let timeFormat = options.time_format;
-
-  if (!dateFormat) {
-    dateFormat = getDateFormatFromStyle(
-      options.date_style as string,
-      unit,
-      options.date_separator as string,
-      options.weekday_enabled,
-    );
+  // Handle one FE-only concern before handing off to the CLJC library:
+  // columns marked as date-only should disable including the time.
+  if (isDateWithoutTime(options.column)) {
+    // Explicitly setting time_enabled to null will ensure the time is ignored.
+    fullOptions.time_enabled = null;
   }
 
-  if (!timeFormat) {
-    timeFormat = getTimeFormatFromStyle(
-      options.time_style as string,
-      unit,
-      options.time_enabled,
-    );
-  }
-
-  return formatDateTimeWithFormats(m, dateFormat, timeFormat, options);
+  return format_datetime_with_unit(value, fullOptions);
 }

--- a/frontend/src/metabase/lib/formatting/datetime-utils.ts
+++ b/frontend/src/metabase/lib/formatting/datetime-utils.ts
@@ -1,8 +1,5 @@
 import type { DatetimeUnit } from "metabase-types/api/query";
 
-export const DEFAULT_TIME_STYLE = "h:mm A";
-export const DEFAULT_DATE_STYLE = "MMMM D, YYYY";
-
 const UNITS_WITH_HOUR = ["default", "minute", "hour", "hour-of-day"] as const;
 const UNITS_WITH_DAY = ["default", "minute", "hour", "day", "week"] as const;
 
@@ -17,18 +14,3 @@ export const hasDay = (unit: DatetimeUnit) =>
 
 export const hasHour = (unit: DatetimeUnit) =>
   unit == null || UNITS_WITH_HOUR_SET.has(unit as UNITS_WITH_HOUR_TYPE);
-
-export function getTimeFormatFromStyle(
-  style: string,
-  unit: DatetimeUnit,
-  timeEnabled?: "minutes" | "milliseconds" | "seconds" | null,
-) {
-  const format = style;
-  if (!timeEnabled || timeEnabled === "milliseconds") {
-    return format.replace(/mm/, "mm:ss.SSS");
-  } else if (timeEnabled === "seconds") {
-    return format.replace(/mm/, "mm:ss");
-  } else {
-    return format;
-  }
-}

--- a/frontend/src/metabase/lib/formatting/time.ts
+++ b/frontend/src/metabase/lib/formatting/time.ts
@@ -1,13 +1,10 @@
 import { msgid, ngettext } from "ttag";
 import { Moment } from "moment-timezone";
-import { parseTime, parseTimestamp } from "metabase/lib/time";
-
-import type { DatetimeUnit } from "metabase-types/api/query";
 import {
-  DEFAULT_TIME_STYLE,
-  getTimeFormatFromStyle,
-  hasHour,
-} from "./datetime-utils";
+  format_time,
+  format_time_with_unit,
+} from "cljs/metabase.shared.formatting.time";
+import type { DatetimeUnit } from "metabase-types/api/query";
 
 export function duration(milliseconds: number) {
   const SECOND = 1000;
@@ -28,15 +25,12 @@ export function duration(milliseconds: number) {
 }
 
 export function formatTime(time: Moment) {
-  const parsedTime = parseTime(time);
-
-  return parsedTime.isValid() ? parsedTime.format("LT") : String(time);
+  return format_time(time);
 }
 
 interface TimeWithUnitType {
   local?: boolean;
   time_enabled?: "minutes" | "milliseconds" | "seconds" | boolean;
-  time_format?: string;
   time_style?: string;
 }
 
@@ -45,24 +39,5 @@ export function formatTimeWithUnit(
   unit: DatetimeUnit,
   options: TimeWithUnitType = {},
 ) {
-  const m = parseTimestamp(value, unit, options.local);
-  if (!m.isValid()) {
-    return String(value);
-  }
-
-  const timeStyle = options.time_style
-    ? options.time_style
-    : DEFAULT_TIME_STYLE;
-
-  const timeEnabled = options.time_enabled
-    ? options.time_enabled
-    : hasHour(unit)
-    ? "minutes"
-    : null;
-
-  const timeFormat = options.time_format
-    ? options.time_format
-    : getTimeFormatFromStyle(timeStyle, unit, timeEnabled as any);
-
-  return m.format(timeFormat);
+  return format_time_with_unit(value, { ...options, unit });
 }

--- a/frontend/src/metabase/lib/formatting/types.ts
+++ b/frontend/src/metabase/lib/formatting/types.ts
@@ -1,12 +1,30 @@
+import {
+  format_strings_js,
+  known_date_styles_js,
+  known_datetime_styles_js,
+  known_time_styles_js,
+} from "cljs/metabase.shared.formatting.constants";
+
+// These correspond to the maps of known date-style and time-style values in
+// in metabase.shared.formatting.internal.date-formatting
+type KnownDateFormats = keyof typeof known_date_styles_js;
+type KnownDateTimeFormats = keyof typeof known_datetime_styles_js;
+type KnownTimeFormats = keyof typeof known_time_styles_js;
+
+// This corresponds to the map of format strings in metabase.shared.formatting.internal.date-builder
+type FormatKey = keyof typeof format_strings_js;
+
+type FormatList = [FormatKey | [string]];
+
 export interface OptionsType {
   click_behavior?: any;
   clicked?: any;
   column?: any;
   compact?: boolean;
   date_abbreviate?: boolean;
-  date_format?: string;
+  date_format?: KnownDateFormats | KnownDateTimeFormats | FormatList;
   date_separator?: string;
-  date_style?: string;
+  date_style?: KnownDateFormats | KnownDateTimeFormats | FormatList;
   decimals?: number;
   isExclude?: boolean;
   jsx?: boolean;
@@ -25,9 +43,9 @@ export interface OptionsType {
   rich?: boolean;
   suffix?: string;
   time_enabled?: "minutes" | "milliseconds" | "seconds" | null;
-  weekday_enabled?: boolean;
-  time_format?: string;
-  time_style?: string;
+  time_format?: KnownTimeFormats | FormatList;
+  time_style?: KnownTimeFormats;
   type?: string;
   view_as?: string | null;
+  weekday_enabled?: boolean;
 }

--- a/frontend/src/metabase/lib/time.ts
+++ b/frontend/src/metabase/lib/time.ts
@@ -5,40 +5,14 @@ import MetabaseSettings from "metabase/lib/settings";
 
 import type { DatetimeUnit } from "metabase-types/api/query";
 
+import {
+  coerce_to_time,
+  coerce_to_timestamp,
+} from "cljs/metabase.shared.util.time";
+
 addAbbreviatedLocale();
 
 const TIME_FORMAT_24_HOUR = "HH:mm";
-
-const TEXT_UNIT_FORMATS = {
-  "day-of-week": (value: string) =>
-    moment.parseZone(value, "ddd").startOf("day"),
-};
-
-const NUMERIC_UNIT_FORMATS = {
-  // workaround for https://github.com/metabase/metabase/issues/1992
-  "minute-of-hour": (value: number) => moment().minute(value).startOf("minute"),
-  "hour-of-day": (value: number) => moment().hour(value).startOf("hour"),
-  "day-of-week": (value: number) =>
-    moment()
-      .weekday(value - 1)
-      .startOf("day"),
-  "day-of-month": (value: number) =>
-    moment("2016-01-01") // initial date must be in month with 31 days to format properly
-      .date(value)
-      .startOf("day"),
-  "day-of-year": (value: number) =>
-    moment("2016-01-01") // initial date must be in leap year to format properly
-      .dayOfYear(value)
-      .startOf("day"),
-  "week-of-year": (value: number) => moment().week(value).startOf("week"),
-  "month-of-year": (value: number) =>
-    moment()
-      .month(value - 1)
-      .startOf("month"),
-  "quarter-of-year": (value: number) =>
-    moment().quarter(value).startOf("quarter"),
-  year: (value: number) => moment().year(value).startOf("year"),
-};
 
 // when you define a custom locale, moment automatically makes it the active global locale,
 // so we need to return to the user's initial locale.
@@ -156,52 +130,14 @@ export function msToSeconds(ms: number) {
   return ms / 1000;
 }
 
-export function parseTime(value: moment.Moment | string) {
-  if (moment.isMoment(value)) {
-    return value;
-  } else if (typeof value === "string") {
-    return moment(value, [
-      "HH:mm:ss.sss[Z]",
-      "HH:mm:SS.sss",
-      "HH:mm:SS",
-      "HH:mm",
-    ]);
-  }
-
-  return moment.utc(value);
+export function parseTime(value: moment.Moment | string): moment.Moment {
+  return coerce_to_time(value);
 }
 
-type NUMERIC_UNIT_FORMATS_KEY_TYPE =
-  | "minute-of-hour"
-  | "hour-of-day"
-  | "day-of-week"
-  | "day-of-month"
-  | "day-of-year"
-  | "week-of-year"
-  | "month-of-year"
-  | "quarter-of-year"
-  | "year";
-
-// only attempt to parse the timezone if we're sure we have one (either Z or ±hh:mm or +-hhmm)
-// moment normally interprets the DD in YYYY-MM-DD as an offset :-/
 export function parseTimestamp(
   value: MomentInput,
   unit: DatetimeUnit | null = null,
   local: unknown = false,
-) {
-  let m: any;
-  if (moment.isMoment(value)) {
-    m = value;
-  } else if (typeof value === "string" && /(Z|[+-]\d\d:?\d\d)$/.test(value)) {
-    m = moment.parseZone(value);
-  } else if (unit && unit in TEXT_UNIT_FORMATS && typeof value === "string") {
-    m = TEXT_UNIT_FORMATS[unit as "day-of-week"](value);
-  } else if (unit && unit in NUMERIC_UNIT_FORMATS && typeof value == "number") {
-    m = NUMERIC_UNIT_FORMATS[unit as NUMERIC_UNIT_FORMATS_KEY_TYPE](value);
-  } else if (typeof value === "number") {
-    m = moment.utc(value, moment.ISO_8601);
-  } else {
-    m = moment.utc(value);
-  }
-  return local ? m.local() : m;
+): moment.Moment {
+  return coerce_to_timestamp(value, { unit, local });
 }

--- a/frontend/src/metabase/visualizations/lib/chart_values.js
+++ b/frontend/src/metabase/visualizations/lib/chart_values.js
@@ -1,6 +1,5 @@
 import _ from "underscore";
 
-import { COMPACT_CURRENCY_OPTIONS } from "metabase/lib/formatting";
 import { moveToFront } from "metabase/lib/dom";
 import { isHistogramBar, xValueForWaterfallTotal } from "./renderer_utils";
 
@@ -182,7 +181,9 @@ export function onRenderValueLabels(
         // We include compact currency options here for both compact and
         // non-compact formatting. This prevents auto's logic from depending on
         // those settings.
-        ...COMPACT_CURRENCY_OPTIONS,
+        minimum_fraction_digits: 2,
+        maximum_fraction_digits: 2,
+        currency_style: "symbol",
       };
       const lengths = data.map(d => formatYValue(d.y, options).length);
       return lengths.reduce((sum, l) => sum + l, 0) / lengths.length;

--- a/frontend/test/metabase/collections/BaseItemsTable.unit.spec.js
+++ b/frontend/test/metabase/collections/BaseItemsTable.unit.spec.js
@@ -4,9 +4,9 @@ import moment from "moment-timezone";
 import { renderWithProviders, screen } from "__support__/ui";
 
 import {
-  DEFAULT_DATE_STYLE,
-  DEFAULT_TIME_STYLE,
-} from "metabase/lib/formatting/datetime-utils";
+  default_date_style,
+  default_time_style,
+} from "cljs/metabase.shared.formatting.constants";
 
 import BaseItemsTable from "metabase/collections/components/BaseItemsTable";
 
@@ -72,7 +72,7 @@ describe("Collections BaseItemsTable", () => {
     userEvent.hover(screen.getByText(lastEditedAt));
 
     expect(screen.getByRole("tooltip")).toHaveTextContent(
-      moment(timestamp).format(`${DEFAULT_DATE_STYLE}, ${DEFAULT_TIME_STYLE}`),
+      moment(timestamp).format(`${default_date_style}, ${default_time_style}`),
     );
   });
 

--- a/frontend/test/metabase/components/DateTime.unit.spec.js
+++ b/frontend/test/metabase/components/DateTime.unit.spec.js
@@ -3,9 +3,9 @@ import { render, screen } from "@testing-library/react";
 import moment from "moment-timezone";
 
 import {
-  DEFAULT_DATE_STYLE,
-  DEFAULT_TIME_STYLE,
-} from "metabase/lib/formatting/datetime-utils";
+  default_date_style,
+  default_time_style,
+} from "cljs/metabase.shared.formatting.constants";
 import MetabaseSettings from "metabase/lib/settings";
 
 import DateTime from "metabase/components/DateTime";
@@ -39,8 +39,8 @@ describe("DateTime", () => {
   }
 
   function getExpectedFormat({
-    date_style = DEFAULT_DATE_STYLE,
-    time_style = DEFAULT_TIME_STYLE,
+    date_style = default_date_style,
+    time_style = default_time_style,
   } = {}) {
     return moment(TEST_DATE).format(`${date_style}, ${time_style}`);
   }

--- a/frontend/test/metabase/lib/formatting.unit.spec.js
+++ b/frontend/test/metabase/lib/formatting.unit.spec.js
@@ -415,7 +415,7 @@ describe("formatting", () => {
           time_style: "HH:mm",
           column: {
             base_type: "type/Date",
-            unit: "hour-of-day",
+            unit: "minute",
           },
         }),
       ).toEqual("7/7/2019");
@@ -597,7 +597,7 @@ describe("formatting", () => {
   describe("formatDateTimeWithUnit", () => {
     it("should format week ranges", () => {
       expect(
-        formatDateTimeWithUnit("2019-07-07T00:00:00.000Z", "week", {
+        formatDateTimeWithUnit("2019-07-09T00:00:00.000Z", "week", {
           type: "cell",
         }),
       ).toEqual("July 7, 2019 – July 13, 2019");
@@ -605,13 +605,14 @@ describe("formatting", () => {
 
     it("should always format week ranges according to returned data", () => {
       try {
-        // globally set locale to es
+        // globally set locale to es. That moves the weeks to starting on Mondays, in the abstract unit testing world.
+        // In the full app the first day of the week is a setting.
         moment.locale("es");
         expect(
-          formatDateTimeWithUnit("2019-07-07T00:00:00.000Z", "week", {
+          formatDateTimeWithUnit("2019-07-09T00:00:00.000Z", "week", {
             type: "cell",
           }),
-        ).toEqual("julio 7, 2019 – julio 13, 2019");
+        ).toEqual("julio 8, 2019 – julio 14, 2019");
       } finally {
         // globally reset locale
         moment.locale("en");

--- a/package.json
+++ b/package.json
@@ -290,7 +290,7 @@
     "cljs-server-start": "yarn && shadow-cljs start",
     "cljs-server-stop": "yarn && shadow-cljs stop",
     "cljs-server-restart": "yarn && shadow-cljs restart",
-    "cljs-nrepl": "yarn && shadow-cljs node-repl -d cider/cider-nrepl:0.25.8 -d cider/piggieback:0.5.1 -d refactor-nrepl:2.5.1",
+    "cljs-nrepl": "yarn && shadow-cljs node-repl -d cider/cider-nrepl:0.28.5 -d cider/piggieback:0.5.3 -d refactor-nrepl:3.6.0",
     "test-cljs": "yarn && shadow-cljs compile test && node target/node-tests.js",
     "build": "yarn build:cljs && yarn build:js",
     "build-watch": "yarn concurrently -n 'cljs,js' 'yarn build-watch:cljs' 'yarn build-watch:js'",

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -25,11 +25,13 @@
    :output-dir "frontend/src/cljs/"
    :entries    [metabase.mbql.js
                 metabase.types
-                metabase.shared.formatting.internal.numbers-core
-                metabase.shared.formatting.internal.numbers
+                metabase.shared.formatting.constants
+                metabase.shared.formatting.date
                 metabase.shared.formatting.numbers
+                metabase.shared.formatting.time
                 metabase.shared.util
                 metabase.shared.util.currency
+                metabase.shared.util.time
                 metabase.shared.parameters.parameters]}
 
   :test

--- a/shared/src/metabase/shared/formatting/constants.cljc
+++ b/shared/src/metabase/shared/formatting/constants.cljc
@@ -1,0 +1,72 @@
+(ns metabase.shared.formatting.constants
+  #?(:cljs (:require
+            [metabase.shared.formatting.internal.date-builder :as builder])))
+
+(defn abbreviated?
+  "Months and weekdays should be abbreviated for `compact` output."
+  [{:keys [output-density]}]
+  (= output-density "compact"))
+
+(defn condense-ranges?
+  "For `compact` and `condensed` output, ranges should be shortened if they're in the same month or year.
+  Eg. `January 8 - 15, 2022`, or `January 28 - February 4, 2022`."
+  [{:keys [output-density]}]
+  (#{"compact" "condensed"} output-density))
+
+(def ^:export default-date-style
+  "The default date style, used in a few places in the JS code as well as by this formatting library."
+  "MMMM D, YYYY")
+
+(def ^:export default-time-style
+  "The default time style, used in a few places in the JS code as well as by this formatting library."
+  "h:mm A")
+
+(def ^:export known-date-styles
+  "A map of string patterns for dates, to functions from options to the data structures consumed by
+  [[metabase.shared.formatting.internal.date-builder]].
+
+  Prefer passing the data structure directly, or use `:date_style`."
+  {"M/D/YYYY"           [:month-d "/" :day-of-month-d "/" :year]
+   "D/M/YYYY"           [:day-of-month-d "/" :month-d "/" :year]
+   "YYYY/M/D"           [:year "/" :month-d "/" :day-of-month-d]
+   "MMMM D, YYYY"       [:month-full " " :day-of-month-d ", " :year]
+   "D MMMM, YYYY"       [:day-of-month-d " " :month-full ", " :year]
+   "dddd, MMMM D, YYYY" [:day-of-week-full ", " :month-full " " :day-of-month-d ", " :year]})
+
+(def ^:export known-time-styles
+  "A table of string patterns for dates to the data structures consumed by
+  [[metabase.shared.formatting.internal.date-builder]].
+
+  Don't rely on these - prefer passing the data structure directly, or use `:date_style`."
+  {"h:mm A" [:hour-12-d  ":" :minute-dd " " :am-pm]
+   "HH:mm"  [:hour-24-dd ":" :minute-dd]
+   "HH"     [:hour-24-dd]})
+
+(def ^:export known-datetime-styles
+  "A table of string patterns for datetimes to the data structures consumed by
+  [[metabase.shared.formatting.internal.date-builder]].
+
+  Don't rely on these - prefer passing the data structure directly, or use `:date_style`."
+  {"M/D/YYYY, h:mm A" {:date-format (get known-date-styles "M/D/YYYY")
+                       :time-format (get known-time-styles "h:mm A")}})
+
+#?(:cljs
+   (do
+     (defn- basic-map [m]
+       (-> m (update-vals (constantly 1)) clj->js))
+
+     (def ^:export known-date-styles-js
+       "Vanilla JS object version of [[known-date-styles]] that can be used with keyof in TS."
+       (basic-map known-date-styles))
+
+     (def ^:export known-datetime-styles-js
+       "Vanilla JS object version of [[known-datetime-formats]] that can be used with keyof in TS."
+       (basic-map known-datetime-styles))
+
+     (def ^:export known-time-styles-js
+       "Vanilla JS object version of [[known-time-formats]] that can be used with keyof in TS."
+       (basic-map known-time-styles))
+
+     (def ^:export format-strings-js
+       "Vanilla JS object version of [[builder/format-strings]] that can be used with keyof in TS."
+       (basic-map builder/format-strings))))

--- a/shared/src/metabase/shared/formatting/date.cljc
+++ b/shared/src/metabase/shared/formatting/date.cljc
@@ -1,0 +1,85 @@
+(ns metabase.shared.formatting.date
+  "Formatting for dates, times, and ranges."
+  (:require
+   [metabase.shared.formatting.constants :as constants]
+   [metabase.shared.formatting.internal.date-builder :as builder]
+   [metabase.shared.formatting.internal.date-formatters :as formatters]
+   [metabase.shared.formatting.internal.date-options :as options]
+   [metabase.shared.util.time :as shared.ut]))
+
+(def range-separator
+  "The range separator is a Unicode en-dash, not an ASCII hyphen."
+  " \u2013 ")
+
+;;; -------------------------------------------- Parameter Formatting ---------------------------------------------
+(def ^:private parameter-formatters
+  {:month   (builder/->formatter [:year "-" :month-dd])
+   :quarter (builder/->formatter ["Q" :quarter "-" :year])
+   :day     formatters/big-endian-day})
+
+(defn ^:export format-for-parameter
+  "Returns a formatting date string for a datetime used as a parameter to a Card."
+  [value options]
+  (let [options (options/prepare-options options)
+        t       (shared.ut/coerce-to-timestamp value options)]
+    (if (not (shared.ut/valid? t))
+      ;; Fall back to a basic string rendering if we couldn't parse it.
+      (str value)
+      (if-let [fmt (parameter-formatters (:unit options))]
+        ;; A few units have special formats.
+        (fmt t)
+        ;; Otherwise, render as a day or day range.
+        (let [[start end] (shared.ut/to-range t options)]
+          (if (shared.ut/same-day? start end)
+            (formatters/big-endian-day start)
+            (str (formatters/big-endian-day start) "~" (formatters/big-endian-day end))))))))
+
+;;; ------------------------------------------------ Format Range -------------------------------------------------
+(defn- format-range-with-unit-inner [[start end] options]
+  (cond
+    ;; Uncondensed, or in different years: January 1, 2018 - January 23, 2019
+    (or (not (constants/condense-ranges? options))
+        (not (shared.ut/same-year? start end)))
+    (let [fmt (formatters/month-day-year options)]
+      (str (fmt start) range-separator (fmt end)))
+
+    ;; Condensed, but different months: January 1 - February 2, 2018
+    (not (shared.ut/same-month? start end))
+    (str ((formatters/month-day options) start)
+         range-separator
+         ((formatters/month-day-year options) end))
+
+    ;; Condensed, and same month: January 1 - 14, 2018
+    :else (str ((formatters/month-day options) start)
+               range-separator
+               ((builder/->formatter [:day-of-month-d ", " :year]) end))))
+
+(defn ^:export format-range-with-unit
+  "Returns a string with this datetime formatted as a range, rounded to the given `:unit`."
+  [value options]
+  (let [options (options/prepare-options options)
+        t       (shared.ut/coerce-to-timestamp value options)]
+    (if (shared.ut/valid? t)
+      (format-range-with-unit-inner (shared.ut/to-range t options) options)
+      ;; Best-effort fallback if we failed to parse - .toString the input.
+      (str value))))
+
+;;; ---------------------------------------------- Format Single Date -----------------------------------------------
+(defn ^:export format-datetime-with-unit
+  "Returns a string with this datetime formatted as a single value, rounded to the given `:unit`."
+  [value options]
+  (let [{:keys [is-exclude no-range type unit]
+         :as options}                          (options/prepare-options options)
+        t                                      (shared.ut/coerce-to-timestamp value options)]
+    (cond
+      is-exclude (case unit
+                   :hour-of-day (formatters/hour-only t)
+                   :day-of-week (formatters/weekday t)
+                   (throw (ex-info "is-exclude option is only compatible with hour-of-day and day-of-week units"
+                                   {:options options})))
+
+      ;; Weeks in tooltips and cells get formatted specially.
+      (and (= unit :week) (#{"tooltip" "cell"} type) (not no-range))
+      (format-range-with-unit value options)
+
+      :else ((formatters/options->formatter options) t))))

--- a/shared/src/metabase/shared/formatting/internal/date_builder.cljc
+++ b/shared/src/metabase/shared/formatting/internal/date_builder.cljc
@@ -1,0 +1,67 @@
+(ns metabase.shared.formatting.internal.date-builder
+  "The formatting strings are not standardized.
+  Rather than wrangling with strings, this library defines a data structure for describing the format of
+  date/time strings.
+
+  A format is represented as a (JS or CLJS) list of keyword or string date fragments (`:year` or `\":day-of-month\"`).
+  Literal strings, eg. /, -, and the \"Q\" of \"Q4 - 2022\" are simply strings that don't start with : - except for the
+  literal string \":\" as a special case.
+
+  Examples:
+  - `[:year \"-\" :month-dd]` gives `\"2022-12\"`
+  - `[\"Q\" \":quarter\" \" - \" \":year\"]` gives `\"Q4 - 2022\"`
+  - `[:month-full-name]` gives `\"April\"`
+  - `[:month-name]` gives `\"Apr\"`
+  - `[:month-dd]` gives `\"04\"`"
+  (:require
+   [clojure.string :as str])
+  #?(:clj (:import
+           java.time.format.DateTimeFormatter)))
+
+(def format-strings
+  "This is the complete set of keys the formats can contain, mapped to the platform-specific magic string expected
+  by Moment.js or java.time.format.DateTimeFormatter. Many are the same, but not all."
+  {:year              #?(:cljs "YYYY" :clj "yyyy")  ; 2022
+   :quarter           "Q"                           ; 2 ("Q2" etc. is added by higher level formatting)
+   :month-full        "MMMM"                        ; April
+   :month-short       "MMM"                         ; Apr
+   :month-dd          "MM"                          ; 04
+   :month-d           "M"                           ; 4
+   :day-of-month-d    #?(:cljs "D"    :clj "d")     ; 6
+   :day-of-month-dd   #?(:cljs "DD"   :clj "dd")    ; 06
+   :day-of-week-full  #?(:cljs "dddd" :clj "EEEE")  ; Friday
+   :day-of-week-short #?(:cljs "ddd"  :clj "EEE")   ; Fri
+   :hour-24-dd        "HH"                          ; 17, 05
+   :hour-24-d         "H"                           ; 17, 5
+   :hour-12-dd        "hh"                          ; 05
+   :hour-12-d         "h"                           ; 5
+   :am-pm             #?(:cljs "A"    :clj "a")     ; AM
+   :minute-d          "m"                           ; 7, 39
+   :minute-dd         "mm"                          ; 07, 39
+   :second-dd         "ss"                          ; 08, 45
+   :millisecond-ddd   "SSS"                         ; 001, 423
+   :day-of-year       #?(:cljs "DDD"  :clj "D")     ; 235
+   :week-of-year      #?(:cljs "wo"   :clj "w")})   ; 34th in CLJS, 34 in CLJ. No ordinal numbers in Java.
+
+(defn- format-string-literal [lit]
+  #?(:cljs (str "[" lit "]")
+     :clj  (str "'" (str/replace lit "'" "''") "'")))
+
+(defn ->formatter
+  "Given a data structure describing the date format, as given in [[format-strings]], return a function that takes a
+  date object and formats it."
+  [format-list]
+  (let [js->clj   #?(:cljs js->clj :clj identity)
+        parts     (for [fmt (js->clj format-list)]
+                    (cond
+                      (keyword? fmt)             (get format-strings fmt)
+                      (= fmt ":")                (format-string-literal ":")
+                      (str/starts-with? fmt ":") (-> fmt (subs 1) keyword format-strings)
+                      (string? fmt)              (format-string-literal fmt)
+                      :else                      (throw (ex-info "Unknown element of date format"
+                                                                 {:bad-element fmt
+                                                                  :format      format-list}))))
+        fmt-str   (apply str parts)]
+    #?(:cljs #(.format % fmt-str)
+       :clj  (let [formatter (DateTimeFormatter/ofPattern fmt-str)]
+               #(.format formatter %)))))

--- a/shared/src/metabase/shared/formatting/internal/date_formatters.cljc
+++ b/shared/src/metabase/shared/formatting/internal/date_formatters.cljc
@@ -1,0 +1,226 @@
+(ns metabase.shared.formatting.internal.date-formatters
+  "The gory details of transforming date and time styles, with units and other options, into formatting functions.
+
+  This namespace deals with the options only, not with specific dates, and returns reusable formatter functions."
+  (:require
+   [clojure.string :as str]
+   [metabase.shared.formatting.constants :as constants]
+   [metabase.shared.formatting.internal.date-builder :as builder]
+   [metabase.shared.util.log :as log]))
+
+(defn- apply-date-separator [format-list date-separator]
+  (if date-separator
+    (for [fmt format-list]
+      (if (string? fmt)
+        (str/replace fmt #"/" date-separator)
+        fmt))
+    format-list))
+
+(defn- apply-date-abbreviation [format-list]
+  (for [k format-list]
+    (case k
+      :month-full         :month-short
+      ":month-full"       :month-short
+      :day-of-week-full   :day-of-week-short
+      ":day-of-week-full" :day-of-week-short
+      k)))
+
+(def ^:private default-date-formats-for-unit
+  "Maps each unit to the default way of formatting that unit.
+  This uses full month and weekday names; abbreviated output replaces these with the short forms later."
+  ;; TODO Do we have (in i18n or utils) helpers for getting localized ordinals?
+  {:year            [:year]                    ; 2022
+   :quarter         ["Q" :quarter " - " :year] ; Q4 - 2022
+   :minute-of-hour  [:minute-d]                ; 6, 24
+   :day-of-week     [:day-of-week-full]        ; Monday; Mon
+   :day-of-month    [:day-of-month-d]          ; 7, 23
+   :day-of-year     [:day-of-year]             ; 1, 24, 365
+   :week-of-year    [:week-of-year]            ; CLJS: 1st, 42nd; CLJ: 1, 42 (no ordinals)
+   :month-of-year   [:month-full]              ; October; Oct
+   :quarter-of-year ["Q" :quarter]})           ; Q4
+
+(def ^:private date-style-to-format-overrides
+  "Map of `{date_style {unit format}}`.
+  If given eg. the style `\"M/D/YYYY\"` but a unit of months, we don't want to use that directly for the format,
+  since it contains days.
+  This map transforms the `date_style + unit` pair to the format data structure."
+  (let [m-y     [:month-d "/" :year]
+        mmm-y   [:month-full ", " :year]]
+    {"M/D/YYYY"           {:month   m-y}
+     "D/M/YYYY"           {:month   m-y}
+     "YYYY/M/D"           {:month   [:year "/" :month-d]
+                           :quarter [:year " - Q" :quarter]}
+     "MMMM D, YYYY"       {:month   mmm-y}
+     "D MMMM, YYYY"       {:month   mmm-y}
+     "dddd, MMMM D, YYYY" {:week    [:month-full " " :day-of-month-d ", " :year]
+                           :month   mmm-y}}))
+
+(def ^:private fallback-iso-format
+  [:year "-" :month-dd "-" :day-of-month-dd "T" :hour-24-dd ":" :minute-dd ":" :second-dd])
+
+(defn- resolve-date-style
+  "The `:date-style` is transformed to a `:date-format` as follows:
+  0. If `:date-format` is set, just use that.
+  1. Check [[date-style-to-format-overrides]] for a style + unit override.
+  2. Check [[default-date-formats-for-unit]] for a unit-specific format.
+  3. Check [[constants/known-date-styles]] for a basic format.
+  4. Fall back to a standard ISO date string, emitting a warning."
+  [{:keys [date-format date-style unit]}]
+  (or date-format
+      (get-in date-style-to-format-overrides [date-style unit])
+      (get default-date-formats-for-unit unit)
+      (get constants/known-date-styles date-style)
+      (do
+        (log/warn "Unrecognized date style" {:date-style date-style
+                                             :unit       unit})
+        fallback-iso-format)))
+
+(defn- normalize-date-format [{:keys [date-format] :as options}]
+  (merge options (get constants/known-datetime-styles date-format)))
+
+(defn- prepend-weekday [date-format]
+  (concat [:day-of-week-short ", "] date-format))
+
+(defn- date-format-for-options
+  "Derives a date format data structure from an options map.
+
+  There are three possible sources of the final date format:
+  1. A directly provided `:date-format`, which is either a string or a
+     [[metabase.shared.formatting.internal.date-builder]] format structure.
+  2. `:date_style` as a provided string, a legacy Moment.js format string.
+  3. [[constants/default-date-style]]
+
+  A string `:date-format` is converted to a `date-builder` structure.
+  If `:date-format` is provided in either form, `:date-style` is ignored.
+  See [[resolve-date-style]] for the details of how the `:date-style` is transformed to a format structure.
+  "
+  [{:keys [date-separator weekday-enabled] :as options}]
+  (let [date-format (-> options normalize-date-format resolve-date-style)]
+    (cond-> date-format
+      date-separator                   (apply-date-separator date-separator)
+      weekday-enabled                  prepend-weekday
+      (constants/abbreviated? options) apply-date-abbreviation)))
+
+;;; ------------------------------------------ Standardized Formats ------------------------------------------------
+(def ^:private short-month-day
+  (builder/->formatter [:month-short " " :day-of-month-d]))
+(def ^:private full-month-day
+  (builder/->formatter [:month-full  " " :day-of-month-d]))
+
+(def ^:private short-month-day-year
+  (builder/->formatter [:month-short " " :day-of-month-d ", " :year]))
+(def ^:private full-month-day-year
+  (builder/->formatter [:month-full  " " :day-of-month-d ", " :year]))
+
+(defn- short-months? [{:keys [type] :as options}]
+  (and (constants/abbreviated? options) (not= type "tooltip")))
+
+(defn month-day-year
+  "Helper that gets the right month-day-year format based on the options: either full `\"April 6, 2022\"` or shortened
+  `\"Apr 6, 2022\"`."
+  [options]
+  (if (short-months? options)
+    short-month-day-year
+    full-month-day-year))
+
+(defn month-day
+  "Helper that gets the right month-day format based on the options: either full `\"April 6\"` or shortened
+  `\"Apr 6\"`."
+  [options]
+  (if (short-months? options)
+    short-month-day
+    full-month-day))
+
+(def ^:private big-endian-day-format
+  [:year "-" :month-dd "-" :day-of-month-dd])
+
+(def big-endian-day
+  "A cached, commonly used formatter for dates in `\"2022-04-22\"` form."
+  (builder/->formatter big-endian-day-format))
+
+(def hour-only
+  "A cached, commonly used formatter for times in 12-hour `\"7 PM\"` form."
+  (builder/->formatter [:hour-12-d " " :am-pm]))
+
+(def weekday
+  "A cached, commonly used formatter for full weekday names."
+  (builder/->formatter [:day-of-week-full]))
+
+;;; --------------------------------------------- Time formatters ----------------------------------------------------
+(defn- english-time-seconds [inner]
+  (vec (concat [:hour-12-d ":" :minute-dd ":" :second-dd]
+               inner
+               [" " :am-pm])))
+
+(def ^:private iso-time-seconds
+  [:hour-24-dd ":" :minute-dd ":" :second-dd])
+
+(def ^:private time-style-to-format
+  {"h:mm A" {nil            (english-time-seconds [])
+             "seconds"      (english-time-seconds [])
+             "milliseconds" (english-time-seconds ["." :millisecond-ddd])}
+   "HH:mm"  {nil            iso-time-seconds
+             "seconds"      iso-time-seconds
+             "milliseconds" (into iso-time-seconds ["." :millisecond-ddd])}})
+
+(def ^:private fallback-iso-time
+  [:hour-24-dd ":" :minute-dd ":" :second-dd])
+
+(defn- time-format-for-options
+  "The time format is resolved as follows:
+  1. If a `:time-format` is provided as a string, look it up in [[constants/known-time-styles]], throwing if not found.
+  2. If a `:time-format` is provided directly as a [[builder]] structure, use that.
+  3. Check [[time-style-to-format]] for a supported `:time-style + :time-enabled` resolution pair.
+  4. Look up `:time-style` in [[constants/known-time-styles]].
+  5. Throw an exception, since the time style is unknown."
+  [{:keys [time-enabled time-format time-style] :as options}]
+  (or (and (string? time-format)
+           (or (get constants/known-time-styles time-format)
+               (throw (ex-info "Unknown time format" options))))
+      time-format
+      (get-in time-style-to-format [time-style time-enabled])
+      (get constants/known-time-styles time-style)
+      (do
+        (log/warn "Unrecognized time style" {:time-style   time-style
+                                             :time-enabled time-enabled})
+        fallback-iso-time)))
+
+;;; ------------------------------------- Custom formatters from options ---------------------------------------------
+;; These are cached, since the formatter is always identical for the same options.
+
+(defn- options->formatter*
+  [{:keys [date-enabled time-enabled] :as options}]
+  ;; TODO The original emits a console warning if the date-style is not in the overrides map. Reproduce that?
+  (let [date-format (when date-enabled (date-format-for-options options))
+        time-format (when time-enabled (time-format-for-options options))
+        format-list (if (and date-format time-format)
+                      (concat date-format [", "] time-format)
+                      ;; At most one format is given; use that one.
+                      ;; If neither is set, emit a warning and use ISO standard format.
+                      (or date-format
+                          time-format
+                          (do
+                            (log/warn "Unrecognized date/time format" options)
+                            fallback-iso-format)))]
+    (builder/->formatter format-list)))
+
+(def ^:private options->formatter-cache (atom {}))
+
+(defn options->formatter
+  "Given the options map, this reduces it to a formatter function.
+  Expects `date-style` and `time-style`, if provided, to be in the known set.
+  If they're unknown, this logs a warning and defaults to a full ISO 8601 string format.
+  If `date-style` or `time-style` are set to nil, that part will not be included.
+
+  The options and corresponding formatters are cached indefinitely, since there are generally only a few dozen
+  different sets of options, and from hundreds to many thousands of dates will be formatted in a typical session."
+  [options]
+  {:pre [(map? options)]} ;; options must be a Clojure map from date-options/prepare-options
+  (if-let [fmt (get @options->formatter-cache options)]
+    fmt
+    (-> (swap! options->formatter-cache
+               (fn [cache]
+                 (if (contains? cache options)
+                   cache
+                   (assoc cache options (options->formatter* options)))))
+        (get options))))

--- a/shared/src/metabase/shared/formatting/internal/date_options.cljc
+++ b/shared/src/metabase/shared/formatting/internal/date_options.cljc
@@ -1,0 +1,47 @@
+(ns metabase.shared.formatting.internal.date-options
+  "Normalization and helper predicates for date formatting options maps."
+  (:require
+   [metabase.shared.formatting.constants :as constants]
+   [metabase.shared.util :as shared.u]))
+
+(def ^:private default-options
+  {:date-enabled   true
+   :date-style     constants/default-date-style
+   :time-style     constants/default-time-style
+   :output-density "default"
+   :unit           :default})
+
+(def ^:private units-with-hour
+  #{:default  :minute  :hour  :hour-of-day})
+
+(def ^:private units-with-day
+  #{nil :default :minute :hour :day :week})
+
+(def ^:private time-only?
+  #{:hour-of-day})
+
+(defn prepare-options
+  "Normalizes the options map. This returns a Clojure map with `:kebab-case-keys`, whatever the input object or
+  key spelling.
+
+  Mixes in the [[default-options]], plus:
+  - defaulting `:time-enabled` to `\"minutes\"` if the `:unit` is smaller than a day.
+  - transforming `:date-format` and `:time-format` to the corresponding styles.
+  - transforming `:type` of `\"cell\"` or `\"tooltip\"` to `condensed` output density
+  - transforming `:compact true` to `:output-density \"compact\"` (takes precedence over `\"condensed\"`).
+  - make `:unit` a keyword"
+  [options]
+  (let [options                               (-> (shared.u/normalize-map options)
+                                                  (update :unit keyword))
+        {:keys [compact date-abbreviate
+                type unit]
+         :as options}                         (merge default-options
+                                                     (when (units-with-hour (:unit options))
+                                                       {:time-enabled "minutes"})
+                                                     options)]
+    (cond-> options
+      true                         (dissoc :compact :date-abbreviate)
+      (time-only? unit)            (assoc :date-enabled false)
+      (= type "tooltip")           (assoc :output-density "condensed")
+      (or compact date-abbreviate) (assoc :output-density "compact")
+      (not (units-with-day unit))  (dissoc :weekday-enabled))))

--- a/shared/src/metabase/shared/formatting/time.cljc
+++ b/shared/src/metabase/shared/formatting/time.cljc
@@ -1,0 +1,29 @@
+(ns metabase.shared.formatting.time
+  "Formatters for time values without date information."
+  (:require
+   [metabase.shared.formatting.date :as date]
+   [metabase.shared.formatting.internal.date-options :as options]
+   [metabase.shared.util.time :as shared.ut])
+  #?(:clj
+     (:import
+      [java.time.format DateTimeFormatter FormatStyle])))
+
+;;; ------------------------------------------------- Format Time ---------------------------------------------------
+(defn ^:export format-time
+  "Formats a give time (an hour number, a local time string, or a platform-specific local time object) in the
+  idiomatic style for this locale.
+
+  For example, `\"7:45 PM\"` in English, `\"19h45\"` in French."
+  [value]
+  (let [t (shared.ut/coerce-to-time value)]
+    ;; Uses localized time formatting.
+    (when (shared.ut/valid? t)
+      #?(:cljs (.format t "LT")
+         :clj  (.format (DateTimeFormatter/ofLocalizedTime FormatStyle/SHORT) t)))))
+
+(defn ^:export format-time-with-unit
+  "Formats the given time (as a string or platform-specific local time or datetime object) based on the `:unit` and
+  other options, as is done for date formatting."
+  [value options]
+  (let [options (-> options options/prepare-options (assoc :date-enabled false))]
+    (date/format-datetime-with-unit value options)))

--- a/shared/src/metabase/shared/util/internal/time.clj
+++ b/shared/src/metabase/shared/util/internal/time.clj
@@ -1,0 +1,196 @@
+(ns metabase.shared.util.internal.time
+  (:require
+   [java-time :as t]
+   [metabase.public-settings :as public-settings]
+   [metabase.shared.util.internal.time-common :as common])
+  (:import
+   java.util.Locale))
+
+(defn- now [] (t/offset-date-time))
+
+;;; ----------------------------------------------- predicates -------------------------------------------------------
+(defn datetime?
+  "Given any value, check if it's a datetime object."
+  [value]
+  (or (t/offset-date-time? value)
+      (t/zoned-date-time? value)
+      (t/instant? value)))
+
+(defn time?
+  "checks if the provided value is a local time value."
+  [value]
+  (t/local-time? value))
+
+(defn valid?
+  "Given a datetime, check that it's valid."
+  [value]
+  (or (datetime?      value)
+      (t/offset-time? value)
+      (t/local-time?  value)))
+
+(defn normalize
+  "Does nothing. Just a placeholder in CLJS; the JVM implementation does some real work."
+  [value]
+  (t/offset-date-time value))
+
+(defn same-day?
+  "Given two platform-specific datetimes, checks if they fall within the same day."
+  [d1 d2]
+  (= (t/truncate-to d1 :days) (t/truncate-to d2 :days)))
+
+(defn same-year?
+  "True if these two datetimes fall in the same year."
+  [d1 d2]
+  (= (t/year d1) (t/year d2)))
+
+(defn same-month?
+  "True if these two datetimes fall in the same (year and) month."
+  [d1 d2]
+  (and (same-year? d1 d2)
+       (= (t/month d1) (t/month d2))))
+
+;;; ---------------------------------------------- information -------------------------------------------------------
+(defn first-day-of-week
+  "The first day of the week varies by locale, but Metabase has a setting that overrides it.
+  In JVM, we can just read the setting directly."
+  []
+  (public-settings/start-of-week))
+
+(def default-options
+  "The default map of options."
+  {:locale (Locale/getDefault)})
+
+;;; ------------------------------------------------ to-range --------------------------------------------------------
+(defn- minus-ms [value]
+  (t/minus value (t/millis 1)))
+
+(defmethod common/to-range :default [value _]
+  ;; Fallback: Just return a zero-width at the input time.
+  ;; This mimics Moment.js behavior if you `m.startOf("unknown unit")` - it doesn't change anything.
+  [value value])
+
+(defmethod common/to-range :minute [value _]
+  (let [start (t/truncate-to value :minutes)]
+    [start (minus-ms (t/plus start (t/minutes 1)))]))
+
+(defmethod common/to-range :hour [value _]
+  (let [start (t/truncate-to value :hours)]
+    [start (minus-ms (t/plus start (t/hours 1)))]))
+
+(defmethod common/to-range :day [value _]
+  (let [start (t/truncate-to value :days)]
+    [start (minus-ms (t/plus start (t/days 1)))]))
+
+(defmethod common/to-range :week [value _]
+  (let [first-day (first-day-of-week)
+        start (-> value
+                  (t/truncate-to :days)
+                  (t/adjust :previous-or-same-day-of-week first-day))]
+    [start (minus-ms (t/plus start (t/weeks 1)))]))
+
+(defmethod common/to-range :month [value _]
+  (let [value (t/truncate-to value :days)]
+    [(t/adjust value :first-day-of-month)
+     (minus-ms (t/adjust value :first-day-of-next-month))]))
+
+(defmethod common/to-range :year [value _]
+  (let [value (t/truncate-to value :days)]
+    [(t/adjust value :first-day-of-year)
+     (minus-ms (t/adjust value :first-day-of-next-year))]))
+
+;;; -------------------------------------------- string->timestamp ---------------------------------------------------
+(defmethod common/string->timestamp :default [value _]
+  ;; Best effort to parse this unknown string format, as a local zoneless datetime, then treating it as UTC.
+  (let [base (try (t/local-date-time value)
+                  (catch Exception _
+                    (try (t/local-date value)
+                         (catch Exception _
+                           nil))))]
+    (when base
+      (t/offset-date-time base (t/zone-id)))))
+
+(defmethod common/string->timestamp :day-of-week [value options]
+  ;; Try to parse as a regular timestamp; if that fails then try to treat it as a weekday name and adjust from
+  ;; the current time.
+  (let [as-default (try ((get-method common/string->timestamp :default) value options)
+                        (catch Exception _ nil))]
+    (if (valid? as-default)
+      as-default
+      (let [day (try (t/day-of-week "EEE" value)
+                     (catch Exception _
+                       (try (t/day-of-week "EEEE" value)
+                            (catch Exception _
+                              (throw (ex-info (str "Failed to coerce '" value "' to day-of-week")
+                                              {:value value}))))))]
+        (-> (now)
+            (t/truncate-to :days)
+            (t/adjust :previous-or-same-day-of-week :monday)  ; Move to ISO start of week.
+            (t/adjust :next-or-same-day-of-week day))))))    ; Then to the specified day.
+
+;;; -------------------------------------------- number->timestamp ---------------------------------------------------
+(def ^:private magic-base-date
+  "Some of the date coercions are relative, and not directly involved with any particular month.
+  To avoid errors we need to use a reference date that is (a) in a month with 31 days,(b) in a leap year.
+  This uses 2016-01-01 for the purpose."
+  (t/offset-date-time 2016 01 01))
+
+(defmethod common/number->timestamp :default [value _]
+  ;; If no unit is given, or the unit is not recognized, try to parse the number as year number, returning the timestamp
+  ;; for midnight UTC on January 1.
+  (t/offset-date-time value))
+
+(defmethod common/number->timestamp :minute-of-hour [value _]
+  (-> (now) (t/truncate-to :hours) (t/plus (t/minutes value))))
+
+(defmethod common/number->timestamp :hour-of-day [value _]
+  (-> (now) (t/truncate-to :days) (t/plus (t/hours value))))
+
+(defmethod common/number->timestamp :day-of-week [value _]
+  ;; Metabase uses 1 to mean the start of the week, based on the Metabase setting for the first day of the week.
+  ;; Moment uses 0 as the first day of the week in its configured locale.
+  ;; For Java, get the first day of the week from the setting, and offset by `(dec value)` for the current day.
+  (-> (now)
+      (t/adjust :previous-or-same-day-of-week (first-day-of-week))
+      (t/truncate-to :days)
+      (t/plus (t/days (dec value)))))
+
+(defmethod common/number->timestamp :day-of-month [value _]
+  ;; We force the initial date to be in a month with 31 days.
+  (t/plus magic-base-date (t/days (dec value))))
+
+(defmethod common/number->timestamp :day-of-year [value _]
+  ;; We force the initial date to be in a leap year (2016).
+  (t/plus magic-base-date (t/days (dec value))))
+
+(defmethod common/number->timestamp :week-of-year [value _]
+  (-> (now)
+      (t/truncate-to :days)
+      (t/adjust :first-day-of-year)
+      (t/adjust :previous-or-same-day-of-week (first-day-of-week))
+      (t/plus (t/weeks (dec value)))))
+
+(defmethod common/number->timestamp :month-of-year [value _]
+  (t/offset-date-time (t/year (now)) value 1))
+
+(defmethod common/number->timestamp :quarter-of-year [value _]
+  (let [month (inc (* 3 (dec value)))]
+    (t/offset-date-time (t/year (now)) month 1)))
+
+(defmethod common/number->timestamp :year [value _]
+  (t/offset-date-time value 1 1))
+
+;;; ---------------------------------------------- parsing helpers ---------------------------------------------------
+(defn parse-with-zone
+  "Parses a timestamp with Z or a timezone offset at the end."
+  [value]
+  (t/offset-date-time value))
+
+(defn localize
+  "Given a freshly parsed `OffsetDateTime`, convert it to a `LocalDateTime`."
+  [value]
+  (t/local-date-time value))
+
+(defn parse-time-string
+  "Parses a time string that has been stripped of any time zone."
+  [value]
+  (t/local-time value))

--- a/shared/src/metabase/shared/util/internal/time.cljs
+++ b/shared/src/metabase/shared/util/internal/time.cljs
@@ -1,0 +1,150 @@
+(ns metabase.shared.util.internal.time
+  "CLJS implementation of the time utilities on top of Moment.js.
+  See [[metabase.shared.util.time]] for the public interface."
+  (:require
+   ["moment" :as moment]
+   [metabase.shared.util.internal.time-common :as common]))
+
+(defn- now [] (moment))
+
+;;; ----------------------------------------------- predicates -------------------------------------------------------
+(defn datetime?
+  "Given any value, check if it's a (possibly invalid) Moment."
+  [value]
+  (and value (moment/isMoment value)))
+
+(defn time?
+  "checks if the provided value is a local time value."
+  [value]
+  (moment/isMoment value))
+
+(defn valid?
+  "Given a Moment, check that it's valid."
+  [value]
+  (and (datetime? value) (.isValid ^moment/Moment value)))
+
+(defn normalize
+  "Does nothing. Just a placeholder in CLJS; the JVM implementation does some real work."
+  [value]
+  value)
+
+(defn same-day?
+  "Given two platform-specific datetimes, checks if they fall within the same day."
+  [^moment/Moment d1 ^moment/Moment d2]
+  (.isSame d1 d2 "day"))
+
+(defn same-month?
+  "True if these two datetimes fall in the same (year and) month."
+  [^moment/Moment d1 ^moment/Moment d2]
+  (.isSame d1 d2 "month"))
+
+(defn same-year?
+  "True if these two datetimes fall in the same year."
+  [^moment/Moment d1 ^moment/Moment d2]
+  (.isSame d1 d2 "year"))
+
+;;; ---------------------------------------------- information -------------------------------------------------------
+(defn first-day-of-week
+  "The first day of the week varies by locale, but Metabase has a setting that overrides it.
+  In CLJS, Moment is already configured with that setting."
+  []
+  (-> (moment/weekdays 0)
+      (.toLowerCase)
+      keyword))
+
+(def default-options
+  "The default map of options - empty in CLJS."
+  {})
+
+;;; ------------------------------------------------ to-range --------------------------------------------------------
+(defmethod common/to-range :default [^moment/Moment value {:keys [unit]}]
+  (let [^moment/Moment c1 (.clone value)
+        ^moment/Moment c2 (.clone value)]
+    [(.startOf c1 (name unit))
+     (.endOf   c2 (name unit))]))
+
+;; NB: Only the :default for to-range is needed in CLJS, since Moment's startOf and endOf methods are doing the work.
+
+;;; -------------------------------------------- string->timestamp ---------------------------------------------------
+(defmethod common/string->timestamp :default [value _]
+  ;; Best effort to parse this unknown string format, as a local zoneless datetime, then treating it as UTC.
+  (moment/utc value moment/ISO_8601))
+
+(defmethod common/string->timestamp :day-of-week [value options]
+  ;; Try to parse as a regular timestamp; if that fails then try to treat it as a weekday name and adjust from
+  ;; the current time.
+  (let [as-default (try ((get-method common/string->timestamp :default) value options)
+                        (catch js/Error _ nil))]
+    (if (valid? as-default)
+      as-default
+      (-> (now)
+          (.isoWeekday value)
+          (.startOf "day")))))
+
+;;; -------------------------------------------- number->timestamp ---------------------------------------------------
+(defn- magic-base-date
+  "Some of the date coercions are relative, and not directly involved with any particular month.
+  To avoid errors we need to use a reference date that is (a) in a month with 31 days,(b) in a leap year.
+  This uses 2016-01-01 for the purpose.
+  This is a function that returns fresh values, since Moments are mutable."
+  []
+  (moment "2016-01-01"))
+
+(defmethod common/number->timestamp :default [value _]
+  ;; If no unit is given, or the unit is not recognized, try to parse the number as year number, returning the timestamp
+  ;; for midnight UTC on January 1.
+  (moment/utc value moment/ISO_8601))
+
+(defmethod common/number->timestamp :minute-of-hour [value _]
+  (.. (now) (minute value) (startOf "minute")))
+
+(defmethod common/number->timestamp :hour-of-day [value _]
+  (.. (now) (hour value) (startOf "hour")))
+
+(defmethod common/number->timestamp :day-of-week [value _]
+  ;; Metabase uses 1 to mean the start of the week, based on the Metabase setting for the first day of the week.
+  ;; Moment uses 0 as the first day of the week in its configured locale.
+  (.. (now) (weekday (dec value)) (startOf "day")))
+
+(defmethod common/number->timestamp :day-of-month [value _]
+  ;; We force the initial date to be in a month with 31 days.
+  (.. (magic-base-date) (date value) (startOf "day")))
+
+(defmethod common/number->timestamp :day-of-year [value _]
+  ;; We force the initial date to be in a leap year (2016).
+  (.. (magic-base-date) (dayOfYear value) (startOf "day")))
+
+(defmethod common/number->timestamp :week-of-year [value _]
+  (.. (now) (week value) (startOf "week")))
+
+(defmethod common/number->timestamp :month-of-year [value _]
+  (.. (now) (month (dec value)) (startOf "month")))
+
+(defmethod common/number->timestamp :quarter-of-year [value _]
+  (.. (now) (quarter value) (startOf "quarter")))
+
+(defmethod common/number->timestamp :year [value _]
+  (.. (now) (year value) (startOf "year")))
+
+;;; ---------------------------------------------- parsing helpers ---------------------------------------------------
+(defn parse-with-zone
+  "Parses a timestamp with Z or a timezone offset at the end.
+  This requires a different API call from timestamps without time zones in CLJS."
+  [value]
+  (moment/parseZone value))
+
+(defn localize
+  "Given a freshly parsed absolute Moment, convert it to a local one."
+  [value]
+  (.local value))
+
+(def ^:private parse-time-formats
+  #js ["HH:mm:ss.SSS[Z]"
+       "HH:mm:ss.SSS"
+       "HH:mm:ss"
+       "HH:mm"])
+
+(defn parse-time-string
+  "Parses a time string that has been stripped of any time zone."
+  [value]
+  (moment value parse-time-formats))

--- a/shared/src/metabase/shared/util/internal/time_common.cljc
+++ b/shared/src/metabase/shared/util/internal/time_common.cljc
@@ -1,0 +1,33 @@
+(ns metabase.shared.util.internal.time-common
+  "Shared core of time utils used by the internal CLJ and CLJS implementations.
+  See [[metabase.shared.util.time]] for the public interface.")
+
+(defn- by-unit [_ {:keys [unit]}] (keyword unit))
+
+(defmulti to-range
+  "Given a datetime and a unit (eg. \"hour\"), returns an *inclusive* datetime range as a pair of datetimes.
+  For a unit of an hour, and a datetime for 13:49:28, that means [13:00:00 13:59:59.999], ie. 1 ms before the end."
+  by-unit)
+
+(defmulti string->timestamp
+  "Given a string representation of a datetime and the `options` map, parses the string as a representation of the
+  `:unit` option (eg. \"hour\").
+  Returns a platform-specific datetime."
+  by-unit)
+
+(defmulti number->timestamp
+  "Given a numeric representation of a datetime and the `options` map, interprets the number based on the `:unit` option
+  (eg. \"day-of-week\").
+
+  Note that for two relative units - `day-of-month` and `day-of-year` - an arbitrary date is generated, not necessarily
+  one in the current month or year. When grouping user data by day-of-month, it doesn't matter whether the current month
+  has 31 days or not.
+
+  Returns a platform-specific datetime."
+  by-unit)
+
+(defn drop-trailing-time-zone
+  "Strips off a trailing +0500, -0430, or Z from a time string."
+  [time-str]
+  (or (second (re-matches #"(.*?)(?:Z|[+-][\d:]+)$" time-str))
+      time-str))

--- a/shared/src/metabase/shared/util/log.cljs
+++ b/shared/src/metabase/shared/util/log.cljs
@@ -1,5 +1,6 @@
 (ns metabase.shared.util.log
   (:require
+   [goog.log :as glog]
    [goog.string :as gstring]
    [goog.string.format :as gstring.format]
    [lambdaisland.glogi :as log]
@@ -37,4 +38,4 @@
 (defn is-loggable?
   "Part of the impl for [[metabase.shared.util.log/js-logp]] and [[metabase.shared.util.log/js-logf]]."
   [logger-name level]
-  (.isLoggable (log/logger logger-name) (log/levels level)))
+  (glog/isLoggable (log/logger logger-name) (log/levels level)))

--- a/shared/src/metabase/shared/util/namespaces.clj
+++ b/shared/src/metabase/shared/util/namespaces.clj
@@ -1,0 +1,14 @@
+(ns metabase.shared.util.namespaces
+  "Potemkin is Java-only, so here's a basic function-importing macro that works for both CLJS and CLJ.")
+
+(defmacro import-fn
+  "Imports a single defn from another namespace.
+  This creates a new local function that calls through to the original, so that it reloads nicely in the REPL.
+  `(import-fn ns b) => (defn b [& args] (apply ns/b args))`"
+  ;; Heavily inspired by Potemkin.
+  ([target]
+   `(import-fn ~target nil))
+  ([target sym]
+   (let [defn-name (or sym (symbol (name target)))
+         args      (gensym)]
+     `(def ~defn-name (fn [& ~args] (apply ~target ~args))))))

--- a/shared/src/metabase/shared/util/namespaces.cljs
+++ b/shared/src/metabase/shared/util/namespaces.cljs
@@ -1,0 +1,3 @@
+(ns metabase.shared.util.namespaces
+  (:require-macros
+   [metabase.shared.util.namespaces]))

--- a/shared/src/metabase/shared/util/time.cljc
+++ b/shared/src/metabase/shared/util/time.cljc
@@ -1,0 +1,50 @@
+(ns metabase.shared.util.time
+  "Time parsing helper functions.
+  In Java these return [[OffsetDateTime]], in JavaScript they return Moments.
+  Most of the implementations are in the split CLJ/CLJS files [[metabase.shared.util.internal.time]]."
+  (:require
+   [metabase.shared.util :as shared.u]
+   [metabase.shared.util.internal.time :as internal]
+   [metabase.shared.util.internal.time-common :as common]
+   [metabase.shared.util.namespaces :as shared.ns]))
+
+;; Importing and re-exporting some functions defined in each implementation.
+(shared.ns/import-fn common/to-range)
+(shared.ns/import-fn internal/valid?)
+(shared.ns/import-fn internal/same-day?)
+(shared.ns/import-fn internal/same-month?)
+(shared.ns/import-fn internal/same-year?)
+
+(defn- prep-options [options]
+  (merge internal/default-options (shared.u/normalize-map options)))
+
+(defn ^:export coerce-to-timestamp
+  "Parses a timestamp value into a date object. This can be a straightforward Unix timestamp or ISO format string.
+  But the `:unit` field can be used to alter the parsing to, for example, treat the input number as a day-of-week or
+  day-of-month number.
+  Returns Moments in JS and OffsetDateTimes in Java."
+  ([value] (coerce-to-timestamp value {}))
+  ([value options]
+   (let [options (prep-options options)
+         base (cond
+                ;; Just return an already-parsed value. (Moment in CLJS, DateTime classes in CLJ.)
+                (internal/datetime? value)                        (internal/normalize value)
+                ;; If there's a timezone offset, or Z for Zulu/UTC time, parse it directly.
+                (and (string? value)
+                     (re-matches #".*(Z|[+-]\d\d:?\d\d)$" value)) (internal/parse-with-zone value)
+                ;; Then we fall back to two multimethods for coercing strings and number to timestamps per the :unit.
+                (string? value)                                   (common/string->timestamp value options)
+                :else                                             (common/number->timestamp value options))]
+     (if (:local options)
+       (internal/localize base)
+       base))))
+
+(defn ^:export coerce-to-time
+  "Parses a standalone time, or the time portion of a timestamp.
+  Accepts a platform time value (eg. Moment, OffsetTime, LocalTime) or a string."
+  [value]
+  (cond
+    (internal/time? value) value
+    (string? value) (-> value common/drop-trailing-time-zone internal/parse-time-string)
+    :else           (throw (ex-info "Unknown input to coerce-to-time; expecting a string"
+                                    {:value value}))))

--- a/shared/test/metabase/shared/formatting/date_test.cljc
+++ b/shared/test/metabase/shared/formatting/date_test.cljc
@@ -1,0 +1,303 @@
+(ns metabase.shared.formatting.date-test
+  (:require
+   [clojure.test :refer [are deftest is testing]]
+   [metabase.shared.formatting.date :as date]
+   [metabase.shared.util.time :as shared.ut]
+   #?@(:clj [[metabase.shared.formatting.internal.date-formatters :as formatters]
+             [metabase.test :as mt]]))
+  #?(:clj (:import
+           java.util.Locale)))
+
+(def ^:private locale
+  #?(:cljs nil :clj (Locale. "en")))
+
+(deftest ^:parallel format-for-parameter-test
+  (testing "some units have custom formatting"
+    (are [exp date unit] (= exp (date/format-for-parameter (shared.ut/coerce-to-timestamp date) {:unit unit}))
+      ;; Years
+      "2022-01-01~2022-12-31" "2022-12-19T12:03:19" "year"
+      ;; Months
+      "2022-12"               "2022-12-19T12:03:19" "month"
+      "2022-01"               "2022-01-19T12:03:19" "month"
+      ;; Quarters
+      "Q4-2022"               "2022-12-19T12:03:19" "quarter"
+      "Q1-2022"               "2022-01-19T12:03:19" "quarter"
+      ;; Quarter-of-year formats as the same day. This is an odd case, but it's in the original unit tests.
+      ;; It actually isn't recognized as a ".startOf" by Moment, so it doesn't change the input. That means the
+      ;; "range" is the input time, so it renders as a single day reference.
+      "2022-01-19"            "2022-01-19T12:03:19" "quarter-of-year"
+      ;; Days
+      "2022-01-19"            "2022-01-19T12:03:19" "day"
+      "2022-12-19"            "2022-12-19T12:03:19" "day"))
+
+  (testing "other units are treated as days or day ranges"
+    (are [exp date unit] (= exp (date/format-for-parameter (shared.ut/coerce-to-timestamp date)
+                                                           {:unit   unit
+                                                            :locale locale}))
+      ;; Hour and minute are treated as days.
+      "2022-12-19" "2022-12-19T12:03:19" "hour"
+      "2022-12-19" "2022-12-19T00:03:19" "hour"
+      "2022-12-19" "2022-12-19T12:03:19" "minute"
+      "2022-12-19" "2022-12-19T00:03:19" "minute"
+
+      ;; Weeks are (previous/this) start of Sunday to end of Saturday
+      "2022-12-18~2022-12-24" "2022-12-18T00:03:19" "week"    ; Sunday
+      "2022-12-18~2022-12-24" "2022-12-19T00:03:19" "week"    ; Monday
+      "2022-12-18~2022-12-24" "2022-12-24T23:03:19" "week"))) ; Saturday
+
+(deftest ^:parallel format-range-with-unit-test
+  (letfn [(week-of [d]
+            (date/format-range-with-unit d {:unit    "week"
+                                            :compact true
+                                            :locale  locale}))]
+    (testing "full form (M d, Y - M d Y)"
+      (testing "when not abbreviated"
+        (is (= (str "November 1, 2022" date/range-separator "November 30, 2022")
+               (date/format-range-with-unit "2022-11-16T11:19:04" {:unit "month"}))))
+      (testing "in different years, even with :compact true"
+        (is (= (str "Dec 29, 2019" date/range-separator "Jan 4, 2020")
+               (week-of "2019-12-31T11:19:04")))))
+
+    (testing "split months, shared year (M d - M d, Y"
+      (is (= (str "Aug 28" date/range-separator "Sep 3, 2022")
+             (week-of "2022-08-31T11:19:04"))))
+
+    (testing "shared month and year (M d - d, Y)"
+      (is (= (str "Dec 11" date/range-separator "17, 2022")
+             (week-of "2022-12-14T11:19:04"))))))
+
+(deftest ^:parallel format-datetime-with-unit-test
+  (testing "special cases"
+    (testing "is-exclude"
+      (testing "for hour-of-day renders only the hour"
+        (are [exp date] (= exp (date/format-datetime-with-unit date {:unit "hour-of-day" :is-exclude true}))
+          "11 AM" "2022-11-20T11:19:04"
+          "3 PM"  "2022-11-20T15:19:04"
+          "12 AM" "2022-11-20T00:19:04"
+          "12 PM" "2022-11-20T12:19:04"))
+
+      (testing "for day-of-week renders eg. Monday"
+        (testing "from ISO date strings"
+          (are [exp date] (= exp (date/format-datetime-with-unit date {:unit "day-of-week" :is-exclude true}))
+            "Sunday"    "2022-12-18T11:19:04"
+            "Monday"    "2022-12-19T11:19:04"
+            "Tuesday"   "2022-12-20T11:19:04"
+            "Wednesday" "2022-12-21T11:19:04"
+            "Thursday"  "2022-12-22T11:19:04"
+            "Friday"    "2022-12-23T11:19:04"
+            "Saturday"  "2022-12-24T11:19:04"))
+
+        (testing "from weekday numbers"
+          (are [exp date] (= exp (date/format-datetime-with-unit date {:unit "day-of-week" :is-exclude true}))
+            "Saturday"  0
+            "Sunday"    1
+            "Monday"    2
+            "Tuesday"   3
+            "Wednesday" 4
+            "Thursday"  5
+            "Friday"    6
+            "Saturday"  7
+            "Sunday"    8))
+
+        (testing "from short weekday names"
+          (are [exp date] (= exp (date/format-datetime-with-unit date {:unit "day-of-week" :is-exclude true}))
+            "Sunday"    "Sun"
+            "Monday"    "Mon"
+            "Tuesday"   "Tue"
+            "Wednesday" "Wed"
+            "Thursday"  "Thu"
+            "Friday"    "Fri"
+            "Saturday"  "Sat"
+            "Sunday"    "Sun"))
+
+        (testing "from full weekday names"
+          (are [exp date] (= exp (date/format-datetime-with-unit date {:unit "day-of-week" :is-exclude true}))
+            "Sunday"    "Sunday"
+            "Monday"    "Monday"
+            "Tuesday"   "Tuesday"
+            "Wednesday" "Wednesday"
+            "Thursday"  "Thursday"
+            "Friday"    "Friday"
+            "Saturday"  "Saturday"
+            "Sunday"    "Sunday"))))
+
+    (testing "weeks in tooltips (condensed ranges, not abbreviated)"
+      (testing "that fit in one month are formatted December 18 - 24, 2022"
+        (is (= (str "December 18" date/range-separator "24, 2022")
+               (date/format-datetime-with-unit "2022-12-20T11:19:04" {:unit   "week"
+                                                                      :type   "tooltip"
+                                                                      :locale locale}))))
+      (testing "that span months are formatted November 27 - December 3, 2022"
+        (is (= (str "November 27" date/range-separator "December 3, 2022")
+               (date/format-datetime-with-unit "2022-11-30T11:19:04" {:unit   "week"
+                                                                      :type   "tooltip"
+                                                                      :locale locale}))))
+      (testing "that span years are formatted December 29, 2019 - January 4, 2020"
+        (is (= (str "December 29, 2019" date/range-separator "January 4, 2020")
+               (date/format-datetime-with-unit "2019-12-30T11:19:04" {:unit   "week"
+                                                                      :type   "tooltip"
+                                                                      :locale locale}))))))
+
+  (testing "general dates"
+    (testing "with default style, unit-based"
+      (are [exp unit] (= exp (date/format-datetime-with-unit "2022-12-07" {:unit unit}))
+        "2022"                     "year"
+        "Q4 - 2022"                "quarter"
+        "Q4"                       "quarter-of-year"
+        ;; Not just "month" because that's got overrides, tested below.
+        "December"                 "month-of-year"
+        "December 7, 2022"         "day"
+        "7"                        "day-of-month"
+        "Wednesday"                "day-of-week"
+        "341"                      "day-of-year"
+        #?(:clj "50" :cljs "50th") "week-of-year"))
+
+    (testing "default formats for each date style"
+      (are [exp style unit] (= exp (date/format-datetime-with-unit "2022-04-07T19:08:45.123" {:unit         unit
+                                                                                              :date-style   style
+                                                                                              :time-enabled false}))
+        "4/7/2022"                "M/D/YYYY"           "day"
+        "7/4/2022"                "D/M/YYYY"           "hour"
+        "2022/4/7"                "YYYY/M/D"           "day"
+        "April 7, 2022"           "MMMM D, YYYY"       "day"
+        "7 April, 2022"           "D MMMM, YYYY"       "day"
+        "Thursday, April 7, 2022" "dddd, MMMM D, YYYY" "day"))
+
+    (testing "unit overrides for various styles"
+      (are [exp style unit] (= exp (date/format-datetime-with-unit "2022-04-07T19:08:45.123" {:unit         unit
+                                                                                              :date-style   style
+                                                                                              :time-enabled false}))
+        "4/2022"        "M/D/YYYY"           "month"
+        "4/2022"        "D/M/YYYY"           "month"
+        "2022/4"        "YYYY/M/D"           "month"
+        "2022 - Q2"     "YYYY/M/D"           "quarter"
+        "April, 2022"   "MMMM D, YYYY"       "month"
+        "April, 2022"   "D MMMM, YYYY"       "month"
+        "April 7, 2022" "dddd, MMMM D, YYYY" "week"  ;; TODO is this actually right? check with existing code
+        "April, 2022"   "dddd, MMMM D, YYYY" "month")
+
+      (testing "use short forms in compact mode"
+        (are [exp style unit] (= exp (date/format-datetime-with-unit "2022-04-07T19:08:45.123" {:unit         unit
+                                                                                                :time-enabled false
+                                                                                                :compact      true}))
+          "Apr, 2022"   "MMMM D, YYYY"       "month"
+          "Apr, 2022"   "D MMMM, YYYY"       "month"
+          "Apr 7, 2022" "dddd, MMMM D, YYYY" "week"  ;; TODO is this actually right? check with existing code
+          "Apr, 2022"   "dddd, MMMM D, YYYY" "month")))
+
+    (testing "custom date separators"
+      (are [exp style separator unit]
+           (= exp (date/format-datetime-with-unit "2022-04-07T19:08:45.123" {:unit           unit
+                                                                             :time-enabled   false
+                                                                             :date-style     style
+                                                                             :date-separator separator
+                                                                             :compact        true}))
+        "Apr, 2022"    "MMMM D, YYYY" "/" "month"
+        "Apr 7, 2022"  "MMMM D, YYYY" "/" "day"
+        "Apr, 2022"    "MMMM D, YYYY" "-" "month"
+        "Apr 7, 2022"  "MMMM D, YYYY" "-" "day"
+        "4/2022"       "M/D/YYYY"     "/" "month"
+        "4/7/2022"     "M/D/YYYY"     "/" "day"
+        "4-2022"       "M/D/YYYY"     "-" "month"
+        "4-7-2022"     "M/D/YYYY"     "-" "day"
+        "4/2022"       "D/M/YYYY"     "/" "month"
+        "7/4/2022"     "D/M/YYYY"     "/" "day"
+        "4-2022"       "D/M/YYYY"     "-" "month"
+        "7-4-2022"     "D/M/YYYY"     "-" "day")))
+
+  (testing "general dates and times"
+    (testing "with both styles left as defaults and a sub-day :unit"
+      (is (= "April 7, 2022, 7:08 PM"
+             (date/format-datetime-with-unit "2022-04-07T19:08:45.123" {:unit "minute"}))))
+
+    (testing "setting the time style"
+      (are [exp style enabled]
+           (= exp (date/format-datetime-with-unit "2022-04-07T19:08:45.123" {:time-enabled enabled
+                                                                             :time-style   style}))
+        "April 7, 2022, 7:08 PM"        "h:mm A" "minutes"
+        "April 7, 2022, 19:08"          "HH:mm"  "minutes"
+        "April 7, 2022, 7:08:45 PM"     "h:mm A" "seconds"
+        "April 7, 2022, 19:08:45"       "HH:mm"  "seconds"
+        "April 7, 2022, 7:08:45.123 PM" "h:mm A" "milliseconds"
+        "April 7, 2022, 19:08:45.123"   "HH:mm"  "milliseconds"))
+
+    (testing "setting both styles"
+      (are [exp date-style time-style enabled]
+           (= exp (date/format-datetime-with-unit "2022-04-07T19:08:45.123" {:date-style   date-style
+                                                                             :time-style   time-style
+                                                                             :time-enabled enabled}))
+        "April 7, 2022, 7:08 PM" "MMMM D, YYYY" "h:mm A" "minutes"
+        "April 7, 2022, 19:08"   "MMMM D, YYYY" "HH:mm"  "minutes"
+        "4/7/2022, 7:08 PM"      "M/D/YYYY"     "h:mm A" "minutes"
+        "4/7/2022, 19:08"        "M/D/YYYY"     "HH:mm"  "minutes"
+        "4/7/2022, 19:08:45"     "M/D/YYYY"     "HH:mm"  "seconds"
+        "4/7/2022, 19:08:45.123" "M/D/YYYY"     "HH:mm"  "milliseconds"))
+
+    (testing "setting a date style and unit that overrides, plus a time"
+      ;; This is a weird thing to do, but it should work correctly.
+      (is (= "4/2022, 19:08:45.123"
+             (date/format-datetime-with-unit "2022-04-07T19:08:45.123" {:date-style   "M/D/YYYY"
+                                                                        :time-style   "HH:mm"
+                                                                        :time-enabled "milliseconds"
+                                                                        :unit         "month"})))))
+
+  (testing "bare times"
+    (are [exp arg unit time-style] (= exp (date/format-datetime-with-unit arg {:unit       unit
+                                                                               :time-style time-style}))
+      "7:00 AM"   7 "hour-of-day" "h:mm A"
+      "12:00 PM" 12 "hour-of-day" "h:mm A"
+      "7:00 PM"  19 "hour-of-day" "h:mm A"
+      "12:00 AM" 24 "hour-of-day" "h:mm A"
+      "07:00"     7 "hour-of-day" "HH:mm"
+      "12:00"    12 "hour-of-day" "HH:mm"
+      "19:00"    19 "hour-of-day" "HH:mm"
+      "00:00"    24 "hour-of-day" "HH:mm"))
+
+  (testing "prepending weekdays"
+    (testing "works on any date format with days"
+      (are [exp date-style time-style unit]
+           (= exp (date/format-datetime-with-unit "2022-04-07T19:08:45.123" {:date-style      date-style
+                                                                             :time-style      time-style
+                                                                             :time-enabled    (when time-style "minutes")
+                                                                             :unit            unit
+                                                                             :weekday-enabled true}))
+        "Thu, April 7, 2022, 7:08 PM" "MMMM D, YYYY" "h:mm A" "minute"
+        "Thu, April 7, 2022, 19:08"   "MMMM D, YYYY" "HH:mm"  "minute"
+        "Thu, 4/7/2022, 7:08 PM"      "M/D/YYYY"     "h:mm A" "minute"
+        "Thu, 4/7/2022, 19:08"        "M/D/YYYY"     "HH:mm"  "minute"
+        "Thu, 4/7/2022, 19:08"        "M/D/YYYY"     "HH:mm"  "hour"
+        "Thu, April 7, 2022"          "MMMM D, YYYY" nil      "day"
+        "Thu, April 7, 2022"          "MMMM D, YYYY" nil      "week"))
+
+    (testing "is skipped if the unit does not have day resolution"
+      (are [exp date-style unit]
+           (= exp (date/format-datetime-with-unit "2022-04-07T19:08:45.123" {:date-style      date-style
+                                                                             :unit            unit
+                                                                             :weekday-enabled true}))
+        "April, 2022" "MMMM D, YYYY" "month"
+        "Q2 - 2022"   "MMMM D, YYYY" "quarter"
+        "2022"        "MMMM D, YYYY" "year"))))
+
+;; This is a separate deftest because the [[mt/with-log-messages-for-level]] doesn't work in :parallel tests.
+;; TODO Capturing log messages and suppressing the output is Clojure-only. Port that to CLJS and test it here.
+(deftest fallback-test
+  (testing "fallback to ISO date string if neither the unit nor style map to a format"
+    #?(:clj  (let [result (atom nil)]
+               ;; Clear the cache, because it only generates the warning the first time this gets constructured.
+               (reset! @#'formatters/options->formatter-cache {})
+
+               (is (= [[:warn nil "Unrecognized date style {:date-style asdf, :unit :asdf}"]]
+                      (mt/with-log-messages-for-level :warn
+                        (reset! result
+                                (date/format-datetime-with-unit "2022-04-07T19:08:45.123" {:unit         :asdf
+                                                                                           :date-style   "asdf"
+                                                                                           :time-enabled false})))))
+               (is (= "2022-04-07T19:08:45" @result)))
+
+       :cljs (is (= "2022-04-07T19:08:45"
+                    (date/format-datetime-with-unit "2022-04-07T19:08:45.123" {:unit         "asdf"
+                                                                               :date-style   "asdf"
+                                                                               :time-enabled false}))))))
+
+;; TODO The originals theoretically support custom "date-format" and "time-format" options; are they ever
+;; actually used? What about non-standard styles?

--- a/shared/test/metabase/shared/formatting/internal/date_builder_test.cljc
+++ b/shared/test/metabase/shared/formatting/internal/date_builder_test.cljc
@@ -1,0 +1,78 @@
+(ns metabase.shared.formatting.internal.date-builder-test
+  (:require
+   [clojure.test :refer [are deftest testing]]
+   [metabase.shared.formatting.internal.date-builder :as builder]
+   [metabase.shared.util.time :as shared.ut]))
+
+;; This tests the underlying string formatter, not the public interface.
+(deftest string-formatting-test
+  (testing "string formatting"
+    (testing "works for keywords and vectors"
+      (are [exp t fmt] (= exp ((builder/->formatter fmt) (shared.ut/coerce-to-timestamp t)))
+        "2022"                "2022-06-08T09:06:19Z" [:year]
+        "202206"              "2022-06-08T09:06:19Z" [:year :month-dd]
+        "20226"               "2022-06-08T09:06:19Z" [:year :month-d]
+        "2022-06-08"          "2022-06-08T09:06:19Z" [:year "-" :month-dd "-" :day-of-month-dd]
+        "Q2 - 2022"           "2022-06-08T09:06:19Z" ["Q" :quarter " - " :year]
+
+        "6/8/2022"            "2022-06-08T09:06:19Z" [:month-d     "/" :day-of-month-d "/"  :year]
+        "June 8, 2022"        "2022-06-08T09:06:19Z" [:month-full  " " :day-of-month-d ", " :year]
+        "Jun 8, 2022"         "2022-06-08T09:06:19Z" [:month-short " " :day-of-month-d ", " :year]
+        "Monday June 6, 2022" "2022-06-06T09:06:19Z" [:day-of-week-full " " :month-full " "
+                                                      :day-of-month-d ", " :year]
+        "Mon June 6, 2022"    "2022-06-06T09:06:19Z" [:day-of-week-short " " :month-full " "
+                                                      :day-of-month-d ", " :year]
+
+        "19:06:19"            "2022-06-08T19:06:19Z" [:hour-24-dd ":" :minute-dd ":" :second-dd]
+        "07:06:19"            "2022-06-08T19:06:19Z" [:hour-12-dd ":" :minute-dd ":" :second-dd]
+        "7:06:19"             "2022-06-08T19:06:19Z" [:hour-12-d  ":" :minute-dd ":" :second-dd]
+        "9:06:19"             "2022-06-08T09:06:19Z" [:hour-24-d  ":" :minute-dd ":" :second-dd]
+        "7:06 PM"             "2022-06-08T19:06:19Z" [:hour-12-d  ":" :minute-dd " " :am-pm]
+        "6m19s"               "2022-06-08T19:06:19Z" [:minute-d "m" :second-dd "s"]))
+
+    (testing "works for strings in Clojure vectors"
+      (are [exp t fmt] (= exp ((builder/->formatter fmt) (shared.ut/coerce-to-timestamp t)))
+        "2022"                "2022-06-08T09:06:19Z" [":year"]
+        "202206"              "2022-06-08T09:06:19Z" [":year" ":month-dd"]
+        "20226"               "2022-06-08T09:06:19Z" [":year" ":month-d"]
+        "2022-06-08"          "2022-06-08T09:06:19Z" [":year" "-" ":month-dd" "-" ":day-of-month-dd"]
+        "Q2 - 2022"           "2022-06-08T09:06:19Z" ["Q" ":quarter" " - " ":year"]
+
+        "6/8/2022"            "2022-06-08T09:06:19Z" [":month-d"           "/"  ":day-of-month-d" "/"  ":year"]
+        "June 8, 2022"        "2022-06-08T09:06:19Z" [":month-full"        " "  ":day-of-month-d" ", " ":year"]
+        "Jun 8, 2022"         "2022-06-08T09:06:19Z" [":month-short"       " "  ":day-of-month-d" ", " ":year"]
+        "Monday June 6, 2022" "2022-06-06T09:06:19Z" [":day-of-week-full"  " "  ":month-full" " "
+                                                      ":day-of-month-d"    ", " ":year"]
+        "Mon June 6, 2022"    "2022-06-06T09:06:19Z" [":day-of-week-short" " "  ":month-full" " "
+                                                      ":day-of-month-d"    ", " ":year"]
+
+        "19:06:19"            "2022-06-08T19:06:19Z" [":hour-24-dd" ":" ":minute-dd" ":" ":second-dd"]
+        "07:06:19"            "2022-06-08T19:06:19Z" [":hour-12-dd" ":" ":minute-dd" ":" ":second-dd"]
+        "7:06:19"             "2022-06-08T19:06:19Z" [":hour-12-d"  ":" ":minute-dd" ":" ":second-dd"]
+        "9:06:19"             "2022-06-08T09:06:19Z" [":hour-24-d"  ":" ":minute-dd" ":" ":second-dd"]
+        "7:06 PM"             "2022-06-08T19:06:19Z" [":hour-12-d"  ":" ":minute-dd" " " ":am-pm"]
+        "6m19s"               "2022-06-08T19:06:19Z" [":minute-d"   "m" ":second-dd" "s"]))
+
+    #?(:cljs
+       (testing "works for strings in JS arrays"
+         (are [exp t fmt] (= exp ((builder/->formatter fmt) (shared.ut/coerce-to-timestamp t)))
+           "2022"                "2022-06-08T09:06:19Z" #js [":year"]
+           "202206"              "2022-06-08T09:06:19Z" #js [":year" ":month-dd"]
+           "20226"               "2022-06-08T09:06:19Z" #js [":year" ":month-d"]
+           "2022-06-08"          "2022-06-08T09:06:19Z" #js [":year" "-" ":month-dd" "-" ":day-of-month-dd"]
+           "Q2 - 2022"           "2022-06-08T09:06:19Z" #js ["Q" ":quarter" " - " ":year"]
+
+           "6/8/2022"            "2022-06-08T09:06:19Z" #js [":month-d"           "/"  ":day-of-month-d" "/"  ":year"]
+           "June 8, 2022"        "2022-06-08T09:06:19Z" #js [":month-full"        " "  ":day-of-month-d" ", " ":year"]
+           "Jun 8, 2022"         "2022-06-08T09:06:19Z" #js [":month-short"       " "  ":day-of-month-d" ", " ":year"]
+           "Monday June 6, 2022" "2022-06-06T09:06:19Z" #js [":day-of-week-full"  " "  ":month-full" " "
+                                                             ":day-of-month-d"    ", " ":year"]
+           "Mon June 6, 2022"    "2022-06-06T09:06:19Z" #js [":day-of-week-short" " "  ":month-full" " "
+                                                             ":day-of-month-d"    ", " ":year"]
+
+           "19:06:19"            "2022-06-08T19:06:19Z" #js [":hour-24-dd" ":" ":minute-dd" ":" ":second-dd"]
+           "07:06:19"            "2022-06-08T19:06:19Z" #js [":hour-12-dd" ":" ":minute-dd" ":" ":second-dd"]
+           "7:06:19"             "2022-06-08T19:06:19Z" #js [":hour-12-d"  ":" ":minute-dd" ":" ":second-dd"]
+           "9:06:19"             "2022-06-08T09:06:19Z" #js [":hour-24-d"  ":" ":minute-dd" ":" ":second-dd"]
+           "7:06 PM"             "2022-06-08T19:06:19Z" #js [":hour-12-d"  ":" ":minute-dd" " " ":am-pm"]
+           "6m19s"               "2022-06-08T19:06:19Z" #js [":minute-d"   "m" ":second-dd" "s"])))))

--- a/shared/test/metabase/shared/formatting/time_test.cljc
+++ b/shared/test/metabase/shared/formatting/time_test.cljc
@@ -1,0 +1,24 @@
+(ns metabase.shared.formatting.time-test
+  (:require
+   [clojure.test :refer [are deftest]]
+   [metabase.shared.formatting.time :as time]))
+
+(deftest format-time-test
+  (are [exp input] (= exp (time/format-time input))
+    "1:02 AM"  "01:02:03.456+07:00"
+    "1:02 AM"  "01:02"
+    "10:29 PM" "22:29:59.26816+01:00"
+    "10:29 PM" "22:29:59.412459+01:00"
+    "7:14 PM"  "19:14:42.926221+01:00"
+    "7:14 PM"  "19:14:42.13202+01:00"
+    "1:38 PM"  "13:38:58.987352+01:00"
+    "1:38 PM"  "13:38:58.001001+01:00"
+    "5:01 PM"  "17:01:23+01:00"))
+
+(deftest format-time-with-unit
+  (are [exp input opts] (= exp (time/format-time-with-unit input (merge {:unit "hour-of-day"} opts)))
+    "8:00 AM"  8  nil
+    ;; 24-hour
+    "08:00"    8  {:time-style "HH:mm"}
+    "18:00"    18 {:time-style "HH:mm"}
+    "18:00:00" 18 {:time-style "HH:mm" :time-enabled "seconds"}))

--- a/shared/test/metabase/shared/util/time_test.cljc
+++ b/shared/test/metabase/shared/util/time_test.cljc
@@ -1,0 +1,207 @@
+(ns metabase.shared.util.time-test
+  (:require
+   [clojure.test :refer [are deftest is testing]]
+   [metabase.shared.util.internal.time :as internal]
+   [metabase.shared.util.time :as shared.ut]
+   #?@(:cljs [["moment" :as moment]]
+       :clj  [[java-time :as t]]))
+  #?(:clj (:import java.util.Locale)))
+
+(defn- from [time-str]
+  #?(:cljs (moment time-str)
+     :clj  (t/offset-date-time (t/local-date-time time-str) (t/zone-offset))))
+(defn- from-zulu [time-str]
+  #?(:cljs (moment/utc time-str)
+     :clj  (t/offset-date-time time-str)))
+
+(defn- same?
+  "True if these two datetimes are equivalent.
+  JVM objects are [[=]] but Moment.js values are not, so use the Moment.isSame method in CLJS."
+  [t1 t2]
+  #?(:cljs (.isSame ^moment/Moment t1 t2)
+     :clj  (= t1 t2)))
+
+(defn- same-instant?
+  "The same point on the timeline of the universe, adjusting to the same time zone (UTC)."
+  [t1 t2]
+  #?(:cljs (.isSame ^moment/Moment t1 t2)
+     :clj  (= (t/instant t1) (t/instant t2))))
+
+(def test-epoch
+  "For consistency of testing we use an arbitrary time as \"now\"."
+  "2022-12-14T13:18:43")
+
+(deftest string->timestamp-test
+  (testing "numbers are parsed into datetimes based on the unit"
+    (with-redefs [internal/now (fn [] (from test-epoch))]
+      (are [exp-str input unit] (same? (from exp-str) (shared.ut/coerce-to-timestamp input {:unit unit}))
+        "2022-12-14T13:00:00"  0 "minute-of-hour"
+        "2022-12-14T13:12:00" 12 "minute-of-hour"
+        "2022-12-14T13:59:00" 59 "minute-of-hour"
+
+        "2022-12-14T00:00:00"  0 "hour-of-day"
+        "2022-12-14T06:00:00"  6 "hour-of-day"
+        "2022-12-14T12:00:00" 12 "hour-of-day"
+        "2022-12-14T23:00:00" 23 "hour-of-day"
+
+        ;; 2022-12-14 is a Wednesday (day 4, with a Sunday start)
+        "2022-12-11T00:00:00" 1 "day-of-week"
+        "2022-12-12T00:00:00" 2 "day-of-week"
+        "2022-12-13T00:00:00" 3 "day-of-week"
+        "2022-12-14T00:00:00" 4 "day-of-week"
+        "2022-12-15T00:00:00" 5 "day-of-week"
+        "2022-12-16T00:00:00" 6 "day-of-week"
+        "2022-12-17T00:00:00" 7 "day-of-week"
+
+        ;; day-of-year uses a specific (leap) year, 2016-01-01, for its reference.
+        "2016-01-01T00:00:00"   1 "day-of-year"
+        "2016-01-02T00:00:00"   2 "day-of-year"
+        "2016-02-01T00:00:00"  32 "day-of-year"
+        "2016-02-29T00:00:00"  60 "day-of-year"
+        "2016-03-01T00:00:00"  61 "day-of-year"
+        "2016-12-31T00:00:00" 366 "day-of-year"
+
+        ;; day-of-month uses a specific 31-day month (2016-01), as its reference.
+        "2016-01-01T00:00:00"   1 "day-of-month"
+        "2016-01-02T00:00:00"   2 "day-of-month"
+        "2016-01-31T00:00:00"  31 "day-of-month"
+
+        ;; week-of-year 1 means the first week, which is the week that contains Jan 1, even if it's in December.
+        ;; Note that the first day of the week differs by locale!
+        ;; But since we force "en" locale in our dev environment, Sunday is the start of the week.
+        ;; In 2022 the first week starts on Sunday, Dec. 26, 2021.
+        "2021-12-26T00:00:00"  1 "week-of-year"
+        "2022-01-02T00:00:00"  2 "week-of-year"
+        "2022-12-18T00:00:00" 52 "week-of-year"
+        "2022-12-25T00:00:00" 53 "week-of-year"
+
+        "2022-01-01T00:00:00"  1 "month-of-year"
+        "2022-02-01T00:00:00"  2 "month-of-year"
+        "2022-06-01T00:00:00"  6 "month-of-year"
+        "2022-12-01T00:00:00" 12 "month-of-year"
+
+        "2022-01-01T00:00:00" 1 "quarter-of-year"
+        "2022-04-01T00:00:00" 2 "quarter-of-year"
+        "2022-07-01T00:00:00" 3 "quarter-of-year"
+        "2022-10-01T00:00:00" 4 "quarter-of-year"
+
+        "2022-01-01T00:00:00" 2022 "year"
+        "1954-01-01T00:00:00" 1954 "year"
+        "2044-01-01T00:00:00" 2044 "year")))
+
+  (testing "numbers with no unit are parsed as year numbers"
+    (are [exp-str input] (same? (from-zulu exp-str) (shared.ut/coerce-to-timestamp input {}))
+      "1950-01-01T00:00:00Z" 1950
+      "2015-01-01T00:00:00Z" 2015))
+
+  (testing "strings"
+    (testing "with unit=day-of-week get parsed as eg. Mon"
+      (with-redefs [internal/now (fn [] (from test-epoch))]
+        (are [exp-str input] (same? (from exp-str) (shared.ut/coerce-to-timestamp input {:unit "day-of-week"}))
+          ;; 2022-12-14 (the test epoch) is a Wednesday.
+          "2022-12-12T00:00:00" "Mon"
+          "2022-12-13T00:00:00" "Tue"
+          "2022-12-14T00:00:00" "Wed"
+          "2022-12-15T00:00:00" "Thu"
+          "2022-12-16T00:00:00" "Fri"
+          "2022-12-17T00:00:00" "Sat"
+          "2022-12-18T00:00:00" "Sun")))
+
+    (testing "with unit != day-of-week"
+      (testing "and a time offset are parsed in that offset"
+        (are [exp-str input] (same-instant? (from-zulu exp-str) (shared.ut/coerce-to-timestamp input {}))
+          "2022-12-14T13:37:00Z" "2022-12-14T13:37:00Z"
+          "2022-12-14T09:37:00Z" "2022-12-14T13:37:00+04:00"
+          "2022-12-14T17:07:00Z" "2022-12-14T13:37:00-03:30"))
+      (testing "and no time offset are assumed to be UTC"
+        (is (same? (from-zulu "2022-12-14T13:37:45Z")
+                   (shared.ut/coerce-to-timestamp "2022-12-14T13:37:45" {}))))))
+
+  (testing "existing date-time values are simply returned"
+    (are [value] (let [t (shared.ut/coerce-to-timestamp value)] (same? t (shared.ut/coerce-to-timestamp t)))
+      "2022-12-12T00:00:00"
+      "2022-12-12T00:00:00Z"
+      1000)))
+
+(deftest same-day-month-year-test
+  (let [ref-date      (from "2022-12-19T08:12:45")  ; Base
+        same-day      (from "2022-12-19T14:06:00")  ; Later that day
+        same-month    (from "2022-12-02T06:44:18")  ; Earlier the same month
+        same-year     (from "2022-06-14T06:44:18")  ; Earlier the same year
+        previous-year (from "2021-12-19T08:12:45")] ; Exactly the same date/time - the year before!
+    (testing "same-day?"
+      (is (shared.ut/same-day? ref-date ref-date))
+      (is (shared.ut/same-day? ref-date same-day))
+      (is (shared.ut/same-day? same-day ref-date))
+      (is (not (shared.ut/same-day? ref-date same-month)))
+      (is (not (shared.ut/same-day? ref-date same-year)))
+      (is (not (shared.ut/same-day? ref-date previous-year))))
+    (testing "same-month?"
+      (is (shared.ut/same-month? ref-date ref-date))
+      (is (shared.ut/same-month? ref-date same-day))
+      (is (shared.ut/same-month? same-day ref-date))
+      (is (shared.ut/same-month? same-day same-month))
+      (is (not (shared.ut/same-month? same-day same-year)))
+      (is (not (shared.ut/same-month? same-day previous-year))))
+    (testing "same-year?"
+      (is (shared.ut/same-year? ref-date ref-date))
+      (is (shared.ut/same-year? ref-date same-day))
+      (is (shared.ut/same-year? same-day ref-date))
+      (is (shared.ut/same-year? same-day same-month))
+      (is (shared.ut/same-year? same-day same-year))
+      (is (not (shared.ut/same-year? same-day previous-year))))))
+
+(deftest to-range-test
+  (doseq [[exp-from exp-to date unit]
+          [["2022-01-01T00:00:00Z" "2022-12-31T23:59:59.999Z" "2022-08-19T00:00:00" "year"]
+
+           ["2022-08-01T00:00:00Z" "2022-08-31T23:59:59.999Z" "2022-08-19T00:00:00" "month"] ; 31 days in August
+           ["2022-02-01T00:00:00Z" "2022-02-28T23:59:59.999Z" "2022-02-19T00:00:00" "month"] ; 28 days in regular February
+           ["2020-02-01T00:00:00Z" "2020-02-29T23:59:59.999Z" "2020-02-19T00:00:00" "month"] ; 29 days in leap-year February
+
+           ;; Weeks are Sunday-Saturday
+           ["2022-08-21T00:00:00Z" "2022-08-27T23:59:59.999Z" "2022-08-21T00:00:00" "week"]  ; Input is Sunday
+           ["2022-08-21T00:00:00Z" "2022-08-27T23:59:59.999Z" "2022-08-24T00:00:00" "week"]  ; Input is Wednesday
+           ["2022-08-21T00:00:00Z" "2022-08-27T23:59:59.999Z" "2022-08-27T00:00:00" "week"]  ; Input is Saturday
+           ;; Week that crosses a month boundary.
+           ["2022-08-28T00:00:00Z" "2022-09-03T23:59:59.999Z" "2022-08-29T00:00:00" "week"]
+           ["2022-08-28T00:00:00Z" "2022-09-03T23:59:59.999Z" "2022-09-01T00:00:00" "week"]
+           ;; Week that crosses a year boundary.
+           ["2019-12-29T00:00:00Z" "2020-01-04T23:59:59.999Z" "2019-12-30T00:00:00" "week"]
+           ["2019-12-29T00:00:00Z" "2020-01-04T23:59:59.999Z" "2020-01-02T00:00:00" "week"]]
+          :let [[from to] (shared.ut/to-range (shared.ut/coerce-to-timestamp date nil)
+                                              {:unit   unit
+                                               :locale #?(:cljs nil :clj (Locale/getDefault))})]]
+    (is (same? (from-zulu exp-from) from) "start dates should be the same")
+    (is (same? (from-zulu exp-to)   to)   "end dates should be the same")))
+
+(defn- time-from [s]
+  #?(:cljs (moment s moment/HTML5_FMT.TIME_MS)
+     :clj  (t/local-time s)))
+
+(deftest coerce-to-time-test
+  (testing "parsing time strings"
+    (are [exp input] (same? (time-from exp) (shared.ut/coerce-to-time input))
+      "09:26:45.123" "09:26:45.123"
+      "09:26:45.000" "09:26:45"
+      "09:26:00.000" "09:26"
+      "19:26:00.000" "19:26"
+
+      "09:26:45.123" "09:26:45.123+08:00"
+      "09:26:45.000" "09:26:45+08:00"
+      "09:26:00.000" "09:26+08:00"
+      "19:26:00.000" "19:26+08:00"
+
+      "09:26:45.123" "09:26:45.123-08:00"
+      "09:26:45.000" "09:26:45-08:00"
+      "09:26:00.000" "09:26-08:00"
+      "19:26:00.000" "19:26-08:00"))
+
+  (testing "Moment and LocalTime values are simply returned"
+    (let [t (time-from "09:29")]
+      (is (= t (shared.ut/coerce-to-time t)))))
+
+  (testing "numbers are treated as Unix timestamps"
+    (is (thrown-with-msg? #?(:clj Exception :cljs js/Error)
+                          #"Unknown input to coerce-to-time; expecting a string"
+                          (shared.ut/coerce-to-time 12)))))


### PR DESCRIPTION
## Date and Time Parsing

This adds a cross-platform date/time formatting library in CLJC, with
(nearly) identical output in both JVM and JS environments.

**Please see the open question below under "cross-platform format specs"!**

### Known differences

The only known difference is week numbers.

CLJS (through Moment.js) has ordinal numbers, and renders the week
number as "34th". Neither the JVM nor Clojure has a handy library for
this (I'm sure it's out there somewhere, but it seems like a silly
dep to add) so it renders week numbers as simply "34".

### Cross-platform format specs

Both platforms have date formatters that use pattern strings (eg.
"YYYY-MM-dd") to turn date/time objects into strings. There's a strong
resemblance in how these work and what letters stand for what parts of
the date and time, but they are far from identical.

Rather than try to hackily convert one set of strings to another with
regexes or other manipulations, this PR defines a set of names for
fragments of dates (eg. `:year`, `:day-of-week-full`, `:hour-24-dd`)
and includes functions to transform a list of these keys into a
platform-specific format function.

This is portable and transparent, and can be written in Clojure or
JS code:

```clj
;; clojure
[:year ["-"] :month-dd ["-"] :day-of-month-dd]   ; 2022-04-08
[:month-full [" "] :day-of-month-d [", "] :year] ; April 8, 2022
```

```js
// JS
["year", ["-"], "month-dd", ["-"], "day-of-month-dd"]   // 2022-04-08
["month-full", [" "], "day-of-month-d", [", "], "year"] // April 8, 2022
```

#### Open question

In a purely Clojure world, I would drop the nested lists around literal strings and write

```clj
[:month-full " " :day-of-month-d ", " :year]
```
using the keywords vs. strings to give the two types.

With JS in play, though, we have two options:
```js
// nested
["month-full", [" "], "day-of-month-d", [", "], "year"]

// inline
["month-full", " ", "day-of-month-d", ", ", "year"]
```
in the inline style, we would either:

- treat any unrecognized key as a literal string, which is risky in case of an unnnoticed typo; or
- use a regex (probably) to make sure the literal makes sense. Something like `[ ,:hmsHMSqQ/\-]+`.
Both of those feel kind of hacky, so I went with the nesting, but it does make the JS lists harder to read and write.
WDYT?

### New date styles

Note that the original code would pass the :date-style string directly to Moment
as the formatting string. With the move to formatting data structures that no
longer works. Instead there is a fixed map of format strings to these format specs,
that contains all the currently used :date-style inputs.

If some caller needs a new format someday, we can either: (a) add the
style to the map; or (b) pass the data structure form directly to the
:date-format option, which is used directly if provided.

### API surface

Most of the existing functions in the TS library are unchanged.

The set of allowed `:date-style` and `:time-style` values is turned into
a type using `keyof`, so that we get precise type-checking of these
values rather than simply string.

One function has been dropped from the API: `getDateFormatFromStyle`.
There was no practical way to implement it using the new format data
structures. The only caller was the date format column settings, and it
has been rewritten to use the formatted string for its sample date as
its key instead.