### PR TITLE
Always use real reducers when using `renderWithProviders` utility

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/moderation/components/QuestionModerationButton/QuestionModerationButton.unit.spec.js
+++ b/enterprise/frontend/src/metabase-enterprise/moderation/components/QuestionModerationButton/QuestionModerationButton.unit.spec.js
@@ -1,10 +1,14 @@
 import React from "react";
+
 import { renderWithProviders, screen } from "__support__/ui";
 import {
   SAMPLE_DATABASE,
   ORDERS,
   metadata,
 } from "__support__/sample_database_fixture";
+
+import { createMockQueryBuilderState } from "metabase-types/store/mocks";
+
 import Question from "metabase-lib/Question";
 import QuestionModerationButton from "./QuestionModerationButton";
 
@@ -65,15 +69,12 @@ function getUnverifiedDataset() {
 }
 
 function setup({ question } = {}) {
-  const qbState = {
-    card: getVerifiedDataset(),
-  };
+  const card = getVerifiedDataset();
+  const state = { qb: createMockQueryBuilderState({ card }) };
 
   return renderWithProviders(<QuestionModerationButton question={question} />, {
     withSampleDatabase: true,
-    initialState: {
-      qb: qbState,
-    },
+    initialState: state,
   });
 }
 

--- a/enterprise/frontend/src/metabase-enterprise/moderation/components/QuestionModerationButton/QuestionModerationButton.unit.spec.js
+++ b/enterprise/frontend/src/metabase-enterprise/moderation/components/QuestionModerationButton/QuestionModerationButton.unit.spec.js
@@ -7,6 +7,7 @@ import {
   metadata,
 } from "__support__/sample_database_fixture";
 
+import { createMockUser } from "metabase-types/api/mocks";
 import { createMockQueryBuilderState } from "metabase-types/store/mocks";
 
 import Question from "metabase-lib/Question";
@@ -70,11 +71,14 @@ function getUnverifiedDataset() {
 
 function setup({ question } = {}) {
   const card = getVerifiedDataset();
-  const state = { qb: createMockQueryBuilderState({ card }) };
+  const state = {
+    currentUser: createMockUser({ is_superuser: true }),
+    qb: createMockQueryBuilderState({ card }),
+  };
 
   return renderWithProviders(<QuestionModerationButton question={question} />, {
     withSampleDatabase: true,
-    initialState: state,
+    storeInitialState: state,
   });
 }
 

--- a/enterprise/frontend/src/metabase-enterprise/moderation/components/QuestionModerationSection/QuestionModerationSection.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/moderation/components/QuestionModerationSection/QuestionModerationSection.jsx
@@ -57,7 +57,7 @@ function QuestionModerationSection({
         <ModerationReviewBanner
           className={reviewBannerClassName}
           moderationReview={latestModerationReview}
-          onRemove={isModerator && onRemoveModerationReview}
+          onRemove={isModerator ? onRemoveModerationReview : undefined}
         />
       )}
     </React.Fragment>

--- a/enterprise/frontend/src/metabase-enterprise/snippets/components/SnippetCollectionFormModal.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/snippets/components/SnippetCollectionFormModal.unit.spec.tsx
@@ -152,8 +152,6 @@ describe("SnippetCollectionFormModal", () => {
       const folder = createMockCollection({ description: "has description" });
       await setupEditing({ folder });
 
-      screen.debug();
-
       expect(screen.getByLabelText(LABEL.NAME)).toBeInTheDocument();
       expect(screen.getByLabelText(LABEL.NAME)).toHaveValue(folder.name);
 

--- a/frontend/src/metabase-types/store/app.ts
+++ b/frontend/src/metabase-types/store/app.ts
@@ -17,5 +17,4 @@ export interface AppBreadCrumbs {
 export interface AppState {
   errorPage: AppErrorDescriptor | null;
   isNavbarOpen: boolean;
-  breadcrumbs: AppBreadCrumbs;
 }

--- a/frontend/src/metabase-types/store/dashboard.ts
+++ b/frontend/src/metabase-types/store/dashboard.ts
@@ -53,6 +53,4 @@ export interface DashboardState {
     name?: DashboardSidebarName;
     props: Record<string, unknown>;
   };
-
-  titleTemplateChange: string | null;
 }

--- a/frontend/src/metabase-types/store/mocks/app.ts
+++ b/frontend/src/metabase-types/store/mocks/app.ts
@@ -3,9 +3,5 @@ import { AppState } from "metabase-types/store";
 export const createMockAppState = (opts?: Partial<AppState>): AppState => ({
   isNavbarOpen: true,
   errorPage: null,
-  breadcrumbs: {
-    collectionId: "root",
-    show: false,
-  },
   ...opts,
 });

--- a/frontend/src/metabase-types/store/mocks/dashboard.ts
+++ b/frontend/src/metabase-types/store/mocks/dashboard.ts
@@ -23,6 +23,5 @@ export const createMockDashboardState = (
   sidebar: {
     props: {},
   },
-  titleTemplateChange: null,
   ...opts,
 });

--- a/frontend/src/metabase/admin/databases/containers/DatabaseEditApp.unit.spec.js
+++ b/frontend/src/metabase/admin/databases/containers/DatabaseEditApp.unit.spec.js
@@ -8,7 +8,7 @@ import {
 import { setupEnterpriseTest } from "__support__/enterprise";
 import { mockSettings } from "__support__/settings";
 
-import admin from "metabase/admin/admin";
+import { createMockTokenFeatures } from "metabase-types/api/mocks";
 
 import DatabaseEditApp from "./DatabaseEditApp";
 
@@ -40,13 +40,15 @@ jest.mock(
 async function setup({ cachingEnabled = false } = {}) {
   const settings = mockSettings({
     engines: ENGINES_MOCK,
+    "token-features": createMockTokenFeatures({ advanced_config: true }),
     "enable-query-caching": cachingEnabled,
-    "persisted-models-enabled": false,
   });
 
   renderWithProviders(<DatabaseEditApp />, {
     withRouter: true,
-    reducers: { admin, settings: () => settings },
+    storeInitialState: {
+      settings,
+    },
   });
 
   await waitForElementToBeRemoved(() => screen.queryByText("Loading..."));

--- a/frontend/src/metabase/collections/containers/CreateCollectionForm.unit.spec.tsx
+++ b/frontend/src/metabase/collections/containers/CreateCollectionForm.unit.spec.tsx
@@ -22,7 +22,10 @@ type SetupOpts = {
   onCancel?: (() => void) | null;
 };
 
-function setup({ user, onCancel = jest.fn() }: SetupOpts = {}) {
+function setup({
+  user = createMockUser({ is_superuser: true }),
+  onCancel = jest.fn(),
+}: SetupOpts = {}) {
   nock(location.origin)
     .post("/api/collection")
     .reply(200, (url, body) => {
@@ -32,8 +35,8 @@ function setup({ user, onCancel = jest.fn() }: SetupOpts = {}) {
     });
 
   renderWithProviders(<CreateCollectionForm onCancel={onCancel} />, {
-    currentUser: user,
     storeInitialState: {
+      currentUser: user,
       entities: createMockEntitiesState({
         collections: {
           root: ROOT_COLLECTION,

--- a/frontend/src/metabase/containers/ItemPicker/ItemPicker.unit.spec.js
+++ b/frontend/src/metabase/containers/ItemPicker/ItemPicker.unit.spec.js
@@ -7,6 +7,7 @@ import {
   waitForElementToBeRemoved,
   within,
 } from "__support__/ui";
+import { createMockUser } from "metabase-types/api/mocks";
 import ItemPicker from "./ItemPicker";
 
 function collection({
@@ -36,11 +37,11 @@ function dashboard({ id, name, collection_id = null }) {
   };
 }
 
-const CURRENT_USER = {
+const CURRENT_USER = createMockUser({
   id: 1,
   personal_collection_id: 100,
   is_superuser: true,
-};
+});
 
 const COLLECTION = {
   ROOT: collection({ id: "root", name: "Our analytics", location: null }),
@@ -136,7 +137,9 @@ async function setup({
   renderWithProviders(
     <ItemPicker models={models} onChange={onChange} {...props} />,
     {
-      currentUser: CURRENT_USER,
+      storeInitialState: {
+        currentUser: CURRENT_USER,
+      },
     },
   );
 

--- a/frontend/src/metabase/public/components/widgets/EmbedModalContent.unit.spec.tsx
+++ b/frontend/src/metabase/public/components/widgets/EmbedModalContent.unit.spec.tsx
@@ -3,6 +3,7 @@ import { screen, waitFor } from "@testing-library/react";
 import _ from "underscore";
 
 import { renderWithProviders } from "__support__/ui";
+import { createMockUser } from "metabase-types/api/mocks";
 import { createMockSettingsState } from "metabase-types/store/mocks";
 
 import EmbedModalContent from "./EmbedModalContent";
@@ -143,6 +144,7 @@ describe("EmbedModalContent", () => {
 function renderWithConfiguredProviders(element: JSX.Element) {
   renderWithProviders(element, {
     storeInitialState: {
+      currentUser: createMockUser({ is_superuser: true }),
       settings: createMockSettingsState({
         "enable-embedding": true,
         "embedding-secret-key": "my_super_secret_key",

--- a/frontend/src/metabase/query_builder/components/QueryValidationError/QueryValidationError.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/QueryValidationError/QueryValidationError.unit.spec.tsx
@@ -7,17 +7,11 @@ import ValidationError, {
 
 import QueryValidationError from "./QueryValidationError";
 
-const providers = {
-  reducers: {
-    qb: () => ({}),
-  },
-};
-
 describe("QueryValidationError", () => {
   describe("when using an Error", () => {
     const error = new Error("oof");
     beforeEach(() => {
-      renderWithProviders(<QueryValidationError error={error} />, providers);
+      renderWithProviders(<QueryValidationError error={error} />);
     });
 
     it("should render the error message", () => {
@@ -35,10 +29,7 @@ describe("QueryValidationError", () => {
       VALIDATION_ERROR_TYPES.MISSING_TAG_DIMENSION,
     );
     beforeEach(() => {
-      renderWithProviders(
-        <QueryValidationError error={validationError} />,
-        providers,
-      );
+      renderWithProviders(<QueryValidationError error={validationError} />);
     });
 
     it("should render the error message", () => {

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader.unit.spec.js
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader.unit.spec.js
@@ -11,6 +11,8 @@ import MetabaseSettings from "metabase/lib/settings";
 import Question from "metabase-lib/Question";
 import { ViewTitleHeader } from "./ViewHeader";
 
+console.warn = jest.fn();
+
 const BASE_GUI_QUESTION = {
   display: "table",
   visualization_settings: {},
@@ -94,32 +96,37 @@ function mockSettings({ enableNestedQueries = true } = {}) {
 function setup({
   question,
   settings,
-  isRunnable = true,
   isActionListVisible = true,
   isAdditionalInfoVisible = true,
+  isDirty = false,
+  isRunnable = true,
   ...props
 } = {}) {
   mockSettings(settings);
 
   const callbacks = {
     runQuestionQuery: jest.fn(),
+    updateQuestion: jest.fn(),
     setQueryBuilderMode: jest.fn(),
     onOpenModal: jest.fn(),
     onAddFilter: jest.fn(),
     onCloseFilter: jest.fn(),
     onEditSummary: jest.fn(),
+    onOpenQuestionInfo: jest.fn(),
     onCloseSummary: jest.fn(),
     onSave: jest.fn(),
   };
 
   renderWithProviders(
     <ViewTitleHeader
+      isRunning={false}
       {...callbacks}
       {...props}
       question={question}
-      isRunnable={isRunnable}
       isActionListVisible={isActionListVisible}
       isAdditionalInfoVisible={isAdditionalInfoVisible}
+      isDirty={isDirty}
+      isRunnable={isRunnable}
     />,
     {
       withRouter: true,

--- a/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar.unit.spec.js
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar.unit.spec.js
@@ -91,7 +91,6 @@ async function setup({ question, cachingEnabled = true } = {}) {
   renderWithProviders(
     <QuestionInfoSidebar question={question} onSave={onSave} />,
     {
-      currentUser: user,
       withSampleDatabase: true,
       storeInitialState: {
         settings: settings,

--- a/frontend/src/metabase/search/components/InfoText.unit.spec.js
+++ b/frontend/src/metabase/search/components/InfoText.unit.spec.js
@@ -26,7 +26,7 @@ describe("InfoText", () => {
       model: "card",
       getCollection: () => collection,
     });
-    expect(screen.queryByText("Saved question in")).toHaveTextContent(
+    expect(screen.getByText("Saved question in")).toHaveTextContent(
       "Saved question in Collection Name",
     );
   });
@@ -37,14 +37,14 @@ describe("InfoText", () => {
       model: "collection",
       collection,
     });
-    expect(screen.queryByText("Collection")).toBeInTheDocument();
+    expect(screen.getByText("Collection")).toBeInTheDocument();
   });
 
   it("shows Database for databases", async () => {
     await setup({
       model: "database",
     });
-    expect(screen.queryByText("Database")).toBeInTheDocument();
+    expect(screen.getByText("Database")).toBeInTheDocument();
   });
 
   it("shows segment's table name", async () => {
@@ -92,7 +92,7 @@ describe("InfoText", () => {
       getCollection: () => collection,
     });
 
-    expect(screen.queryByText("Pulse in")).toHaveTextContent(
+    expect(screen.getByText("Pulse in")).toHaveTextContent(
       "Pulse in Collection Name",
     );
   });
@@ -103,7 +103,7 @@ describe("InfoText", () => {
       getCollection: () => collection,
     });
 
-    expect(screen.queryByText("Dashboard in")).toHaveTextContent(
+    expect(screen.getByText("Dashboard in")).toHaveTextContent(
       "Dashboard in Collection Name",
     );
   });

--- a/frontend/test/__support__/ui.tsx
+++ b/frontend/test/__support__/ui.tsx
@@ -10,7 +10,6 @@ import HTML5Backend from "react-dnd-html5-backend";
 
 import { state as sampleDatabaseReduxState } from "__support__/sample_database_fixture";
 
-import type { User } from "metabase-types/api";
 import type { State } from "metabase-types/store";
 
 import { createMockState } from "metabase-types/store/mocks";
@@ -21,7 +20,6 @@ import publicReducers from "metabase/reducers-public";
 import { getStore } from "./entities-store";
 
 export interface RenderWithProvidersOptions {
-  currentUser?: User;
   mode?: "default" | "public";
   storeInitialState?: Partial<State>;
   withSampleDatabase?: boolean;

--- a/frontend/test/__support__/ui.tsx
+++ b/frontend/test/__support__/ui.tsx
@@ -16,11 +16,14 @@ import type { State } from "metabase-types/store";
 import { createMockUser } from "metabase-types/api/mocks";
 import { createMockState } from "metabase-types/store/mocks";
 
+import mainReducers from "metabase/reducers-main";
+import publicReducers from "metabase/reducers-public";
+
 import { getStore } from "./entities-store";
 
 export interface RenderWithProvidersOptions {
   currentUser?: User;
-  reducers?: Record<string, (state: any) => any>;
+  mode?: "default" | "public";
   storeInitialState?: Partial<State>;
   withSampleDatabase?: boolean;
   withRouter?: boolean;
@@ -44,7 +47,7 @@ export function renderWithProviders(
   ui: React.ReactElement,
   {
     currentUser = DEFAULT_USER,
-    reducers = {},
+    mode = "default",
     storeInitialState = {},
     withSampleDatabase,
     withRouter = false,
@@ -61,17 +64,7 @@ export function renderWithProviders(
   const initialReduxState = createMockState(customStateParams);
 
   const store = getStore(
-    {
-      admin: (state = initialReduxState.admin) => state,
-      app: (state = initialReduxState.app) => state,
-      currentUser: (state = initialReduxState.currentUser) => state,
-      dashboard: (state = initialReduxState.dashboard) => state,
-      embed: (state = initialReduxState.embed) => state,
-      settings: (state = initialReduxState.settings) => state,
-      setup: (state = initialReduxState.setup) => state,
-      qb: (state = initialReduxState.qb) => state,
-      ...reducers,
-    },
+    mode === "default" ? mainReducers : publicReducers,
     initialReduxState,
   );
 

--- a/frontend/test/__support__/ui.tsx
+++ b/frontend/test/__support__/ui.tsx
@@ -13,7 +13,6 @@ import { state as sampleDatabaseReduxState } from "__support__/sample_database_f
 import type { User } from "metabase-types/api";
 import type { State } from "metabase-types/store";
 
-import { createMockUser } from "metabase-types/api/mocks";
 import { createMockState } from "metabase-types/store/mocks";
 
 import mainReducers from "metabase/reducers-main";
@@ -30,14 +29,6 @@ export interface RenderWithProvidersOptions {
   withDND?: boolean;
 }
 
-const DEFAULT_USER = createMockUser({
-  id: 1,
-  first_name: "Bobby",
-  last_name: "Tables",
-  email: "bobby@metabase.test",
-  is_superuser: true,
-});
-
 /**
  * Custom wrapper of react testing library's render function,
  * helping to setup common wrappers and provider components
@@ -46,7 +37,6 @@ const DEFAULT_USER = createMockUser({
 export function renderWithProviders(
   ui: React.ReactElement,
   {
-    currentUser = DEFAULT_USER,
     mode = "default",
     storeInitialState = {},
     withSampleDatabase,
@@ -55,13 +45,11 @@ export function renderWithProviders(
     ...options
   }: RenderWithProvidersOptions = {},
 ) {
-  let customStateParams = merge({ currentUser }, storeInitialState);
-
-  customStateParams = withSampleDatabase
-    ? merge(sampleDatabaseReduxState, customStateParams)
-    : customStateParams;
-
-  const initialReduxState = createMockState(customStateParams);
+  const initialReduxState = createMockState(
+    withSampleDatabase
+      ? merge(sampleDatabaseReduxState, storeInitialState)
+      : storeInitialState,
+  );
 
   const store = getStore(
     mode === "default" ? mainReducers : publicReducers,

--- a/frontend/test/metabase/components/LastEditInfoLabel.unit.spec.js
+++ b/frontend/test/metabase/components/LastEditInfoLabel.unit.spec.js
@@ -2,6 +2,7 @@ import React from "react";
 import mockDate from "mockdate";
 import moment from "moment-timezone";
 import { renderWithProviders } from "__support__/ui";
+import { createMockUser } from "metabase-types/api/mocks";
 import LastEditInfoLabel from "metabase/components/LastEditInfoLabel";
 
 describe("LastEditInfoLabel", () => {
@@ -11,12 +12,12 @@ describe("LastEditInfoLabel", () => {
 
   const NOW_REAL = moment().toISOString();
 
-  const TEST_USER = {
+  const TEST_USER = createMockUser({
     id: 2,
     first_name: "John",
     last_name: "Doe",
     email: "john@metabase.test",
-  };
+  });
 
   function setup({ isLastEditedByCurrentUser = false } = {}) {
     const testItem = {
@@ -26,13 +27,14 @@ describe("LastEditInfoLabel", () => {
       },
     };
 
-    function userReducer() {
-      return isLastEditedByCurrentUser ? TEST_USER : { id: TEST_USER.id + 1 };
-    }
+    const currentUser = isLastEditedByCurrentUser
+      ? TEST_USER
+      : { ...TEST_USER, id: TEST_USER.id + 1 };
 
     return renderWithProviders(<LastEditInfoLabel item={testItem} />, {
-      reducers: {
-        currentUser: userReducer,
+      currentUser,
+      storeInitialState: {
+        currentUser,
       },
     });
   }

--- a/frontend/test/metabase/components/LastEditInfoLabel.unit.spec.js
+++ b/frontend/test/metabase/components/LastEditInfoLabel.unit.spec.js
@@ -32,7 +32,6 @@ describe("LastEditInfoLabel", () => {
       : { ...TEST_USER, id: TEST_USER.id + 1 };
 
     return renderWithProviders(<LastEditInfoLabel item={testItem} />, {
-      currentUser,
       storeInitialState: {
         currentUser,
       },

--- a/frontend/test/metabase/nav/ProfileLink.unit.spec.js
+++ b/frontend/test/metabase/nav/ProfileLink.unit.spec.js
@@ -33,9 +33,6 @@ const setupState = hasAdminNavItems => {
     storeInitialState: {
       admin,
     },
-    reducers: {
-      admin: () => admin,
-    },
   };
 };
 

--- a/frontend/test/metabase/visualizations/components/Visualization-table.unit.spec.js
+++ b/frontend/test/metabase/visualizations/components/Visualization-table.unit.spec.js
@@ -1,7 +1,5 @@
 import React from "react";
-import { renderWithProviders } from "__support__/ui";
-
-import { createMockQueryBuilderState } from "metabase-types/store/mocks/qb";
+import { renderWithProviders, screen } from "__support__/ui";
 
 import Visualization from "metabase/visualizations/components/Visualization";
 import { NumberColumn } from "../__support__/visualizations";
@@ -38,22 +36,13 @@ describe("Table", () => {
         },
       ],
     };
-    const qbState = createMockQueryBuilderState();
-    const { getByText } = renderWithProviders(
-      <Visualization rawSeries={series(rows, settings)} />,
-      {
-        storeInitialState: {
-          qb: qbState,
-        },
-        reducers: {
-          qb: () => qbState,
-        },
-      },
-    );
+
+    renderWithProviders(<Visualization rawSeries={series(rows, settings)} />);
     jest.runAllTimers();
-    const bgColors = rows.map(
-      ([v]) => getByText(String(v)).parentNode.style["background-color"],
-    );
+
+    const bgColors = rows
+      .map(([value]) => screen.getByText(String(value)))
+      .map(element => element.parentNode.style["background-color"]);
     expect(bgColors).toEqual([
       "",
       "",


### PR DESCRIPTION
Epic #26960

Our wrapper around the testing library `render` method uses just a subset of reducers. So we test our code in an environment that's pretty far away from a real one. This PR makes `renderWithProviders` always use the full set of reducers with the ability to switch between default and public Metabase modes. Also, it removes the `currentUser` option in favor of setting it via `storeInitialState`.

Other small changes:

* removed the `titleTemplateChange` key from dashboard reducers to avoid errors about unknown state property. It's a leftover from data apps we forgot to remove
* removed the `breadcrumbs` key from app reducers to avoid errors about unknown state property. It doesn't seem like we actually have them in there

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/27552)
<!-- Reviewable:end -->
