### PR TITLE
fix api/database/<id>/fields to include table's name

### DIFF
--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -565,16 +565,17 @@
   "Get a list of all `Fields` in `Database`."
   [id]
   (api/read-check Database id)
-  (let [fields (filter mi/can-read? (-> (db/select [Field :id :display_name :table_id :base_type :semantic_type]
+  (let [fields (filter mi/can-read? (-> (db/select [Field :id :name :display_name :table_id :base_type :semantic_type]
                                           :table_id        [:in (db/select-field :id Table, :db_id id)]
                                           :visibility_type [:not-in ["sensitive" "retired"]])
                                         (hydrate :table)))]
-    (for [{:keys [id display_name table base_type semantic_type]} fields]
+    (for [{:keys [id name display_name table base_type semantic_type]} fields]
       {:id            id
-       :name          display_name
+       :name          name
+       :display_name  display_name
        :base_type     base_type
        :semantic_type semantic_type
-       :table_name    (:display_name table)
+       :table_name    (:name table)
        :schema        (:schema table)})))
 
 

--- a/test/metabase/api/database_test.clj
+++ b/test/metabase/api/database_test.clj
@@ -340,6 +340,23 @@
            (let [resp (mt/derecordize (mt/user-http-request :rasta :get 200 (format "database/%d/metadata" (mt/id))))]
              (assoc resp :tables (filter #(= "CATEGORIES" (:name %)) (:tables resp))))))))
 
+(deftest fetch-database-fields-test
+  (letfn [(f [fields] (m/index-by #(str (:table_name %) "." (:name %)) fields))]
+    (testing "GET /api/database/:id/fields"
+      (is (partial= {"VENUES.ID"        {:name "ID" :display_name "ID"
+                                         :table_name "VENUES"}
+                     "CHECKINS.USER_ID" {:name "USER_ID" :display_name "User ID"
+                                         :table_name "CHECKINS"}}
+                    (f (mt/user-http-request :rasta :get 200 (format "database/%d/fields" (mt/id))))))
+      (testing "shows display names"
+        (mt/with-temp* [Table [{t-id :id} {:name "FOO_TABLE" :display_name "irrelevant"
+                                           :db_id (mt/id)}]
+                        Field [_ {:name "F_NAME" :display_name "user editable"
+                                  :table_id t-id}]]
+          (is (partial= {"FOO_TABLE.F_NAME" {:name "F_NAME" :display_name "user editable"
+                                             :table_name "FOO_TABLE"}}
+                        (f (mt/user-http-request :rasta :get 200 (format "database/%d/fields" (mt/id)))))))))))
+
 (deftest fetch-database-metadata-include-hidden-test
   ;; NOTE: test for the exclude_uneditable parameter lives in metabase-enterprise.advanced-permissions.common-test
   (mt/with-temp-vals-in-db Table (mt/id :categories) {:visibility_type "hidden"}


### PR DESCRIPTION
Fixes #12419

including name and display name for field, and table name (not display name) which was original complaint.

output of `api/database/<id>/fields:

#### before
```clojure
 {:id 40,
  :name "Total",
  :base_type :type/Float,
  :semantic_type nil,
  :table_name "Orders",
  :schema "PUBLIC"}
```

#### after
```clojure
 {:id 40,
  :name "TOTAL",
  :display_name "Total",
  :base_type :type/Float,
  :semantic_type nil,
  :table_name "ORDERS",
  :schema "PUBLIC"}
```

Differences:
- `:name` now refers to the proper field name, not display name (here `"TOTAL"`)
- `:display_name` is new and is the display name (titlecased here by default, but user editable in data admin section)
- `:table_name` is now the table's actual name and not display name (here `"ORDERS"` instead of `"Orders"`)

This api appears to be unused so the change is safe.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/27558)
<!-- Reviewable:end -->
