### PR TITLE
Fix cannot select fields for double aggregations

### DIFF
--- a/frontend/src/metabase-lib/queries/utils/structured-query-table.ts
+++ b/frontend/src/metabase-lib/queries/utils/structured-query-table.ts
@@ -50,6 +50,7 @@ function getFieldsForSourceQueryTable(
     const virtualField = createVirtualField({
       ...column,
       id,
+      source: "fields",
       query: originalQuery,
       metadata,
     });

--- a/frontend/src/metabase/core/components/AccordionList/AccordionListCell.jsx
+++ b/frontend/src/metabase/core/components/AccordionList/AccordionListCell.jsx
@@ -120,6 +120,7 @@ export const AccordionListCell = ({
     content = (
       <ListCellItem
         data-testid={itemTestId}
+        aria-label={name}
         role="option"
         aria-selected={isSelected}
         isClickable={isClickable}

--- a/frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx
@@ -245,6 +245,7 @@ const ActionButton = ({
   onClick,
   ...props
 }) => {
+  const label = large ? title : null;
   const button = (
     <ColorButton
       icon={icon}
@@ -254,9 +255,10 @@ const ActionButton = ({
       iconVertical={large}
       iconSize={large ? 18 : 14}
       onClick={onClick}
+      aria-label={label}
       {...props}
     >
-      {large ? title : null}
+      {label}
     </ColorButton>
   );
 

--- a/frontend/test/metabase/scenarios/question/reproductions/27462-no-field-options-for-double-aggregations.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/reproductions/27462-no-field-options-for-double-aggregations.cy.spec.js
@@ -1,0 +1,43 @@
+import { visitQuestionAdhoc, restore, popover } from "__support__/e2e/helpers";
+
+import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
+import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
+
+const { PRODUCTS_ID, PRODUCTS } = SAMPLE_DATABASE;
+
+describe("issue 27462", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+  });
+
+  it("should be able to select field when double aggregating metabase#27462", () => {
+    const questionDetails = {
+      dataset_query: {
+        database: SAMPLE_DB_ID,
+        type: "query",
+        query: {
+          "source-table": PRODUCTS_ID,
+          aggregation: [["count"]],
+          breakout: [["field", PRODUCTS.CATEGORY, null]],
+        },
+      },
+      display: "table",
+      visualization_settings: {},
+    };
+
+    visitQuestionAdhoc(questionDetails, { mode: "notebook" });
+
+    cy.findByRole("button", { name: "Summarize" }).click();
+
+    cy.findByRole("option", { name: "Sum of ..." }).click();
+
+    popover().within(() => {
+      cy.findByRole("option", { name: "Count" }).click();
+    });
+
+    cy.findByRole("button", { name: "Visualize" }).click();
+
+    cy.findByText("200").should("be.visible");
+  });
+});

--- a/frontend/test/metabase/scenarios/question/reproductions/27462-no-field-options-for-double-aggregations.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/reproductions/27462-no-field-options-for-double-aggregations.cy.spec.js
@@ -28,7 +28,7 @@ describe("issue 27462", () => {
 
     visitQuestionAdhoc(questionDetails, { mode: "notebook" });
 
-    cy.findByRole("button", { name: "Summarize" }).click();
+    cy.button("Summarize").click();
 
     cy.findByRole("option", { name: "Sum of ..." }).click();
 
@@ -36,7 +36,7 @@ describe("issue 27462", () => {
       cy.findByRole("option", { name: "Count" }).click();
     });
 
-    cy.findByRole("button", { name: "Visualize" }).click();
+    cy.button("Visualize").click();
 
     cy.findByText("200").should("be.visible");
   });


### PR DESCRIPTION
Fixes #27462

The fix follows the behavior before we change it accidentally in #25267, I assume.

#### The problem
The problem is that there’s no field options showing for double aggregation. <img src="https://user-images.githubusercontent.com/1937582/211103045-c156e023-2d1e-4917-ad7e-4d933f046285.png" width="300" />
 I tracked down to this line of code.
https://github.com/metabase/metabase/blob/f1d355d4f8d907ec7d0851743fac3f07461597b9/frontend/src/metabase/query_builder/components/AggregationPopover/AggregationPopover.jsx#L379

From here the `query.aggregationFieldOptions` will call `this.fieldOptions` which calls `this.dimensionOptions` under the hood. However, on both version (44.6 vs master or 45) `this.dimensionOptions` will return different **count** dimension (which is the first aggregation from “products -> count by category”).

On master we the dimension's field source would be `aggregation` (which cause the bug). But on 44.6 the field source would be `fields` which make **count** appear when being populated in `query.aggregationFieldOptions`
- ![image](https://user-images.githubusercontent.com/1937582/211103404-0a8a37fe-e273-49f0-9cde-699ef20a8140.png)
- 
![image](https://user-images.githubusercontent.com/1937582/211103419-2a13f4dd-1302-4d83-b87b-7354a711c1d3.png)


#### How to test
Follow the repro steps in https://github.com/metabase/metabase/issues/27462