### PR TITLE
Use Oxford comma for formatting parameter values in text cards with more than 2 items

### DIFF
--- a/shared/src/metabase/shared/parameters/parameters.cljc
+++ b/shared/src/metabase/shared/parameters/parameters.cljc
@@ -115,9 +115,10 @@
   "Given a seq of parameter values, returns them as a single comma-separated string. Does not do additional formatting
   on the values."
   [values]
-  (if (= (count values) 1)
-    (str (first values))
-    (trs "{0} and {1}" (str/join ", " (butlast values)) (last values))))
+  (condp = (count values)
+    1 (str (first values))
+    2 (trs "{0} and {1}" (first values) (second values))
+    (trs "{0}, and {1}" (str/join ", " (butlast values)) (last values))))
 
 (defmethod formatted-value :default
   [_ value _]

--- a/shared/src/metabase/shared/parameters/parameters.cljc
+++ b/shared/src/metabase/shared/parameters/parameters.cljc
@@ -118,7 +118,10 @@
   (condp = (count values)
     1 (str (first values))
     2 (trs "{0} and {1}" (first values) (second values))
-    (trs "{0}, and {1}" (str/join ", " (butlast values)) (last values))))
+    (trs "{0}, {1}, and {2}"
+         (str/join ", " (drop-last 2 values))
+         (nth values (- (count values) 2))
+         (last values))))
 
 (defmethod formatted-value :default
   [_ value _]

--- a/shared/test/metabase/shared/parameters/parameters_test.cljc
+++ b/shared/test/metabase/shared/parameters/parameters_test.cljc
@@ -85,6 +85,10 @@
       "1\\, 2\\, and 3"
 
       "{{foo}}"
+      {"foo" {:type :number/= :value [1 2 3 4]}}
+      "1\\, 2\\, 3\\, and 4"
+
+      "{{foo}}"
       {"foo" {:type :number/between :value [1 5]}}
       "1 and 5"
 

--- a/shared/test/metabase/shared/parameters/parameters_test.cljc
+++ b/shared/test/metabase/shared/parameters/parameters_test.cljc
@@ -53,6 +53,10 @@
       {"foo" {:type :string/= :value ["bar", "baz"]}}
       "bar and baz"
 
+      "{{foo}}"
+      {"foo" {:type :string/= :value ["bar", "baz", "qux"]}}
+      "bar\\, baz\\, and qux"
+
       "{{foo}} and {{bar}}"
       {"foo" {:type :string/= :value "A"}
        "bar" {:type :string/= :value "B"}}
@@ -78,7 +82,7 @@
 
       "{{foo}}"
       {"foo" {:type :number/= :value [1 2 3]}}
-      "1\\, 2 and 3"
+      "1\\, 2\\, and 3"
 
       "{{foo}}"
       {"foo" {:type :number/between :value [1 5]}}

--- a/test/metabase/pulse/parameters_test.clj
+++ b/test/metabase/pulse/parameters_test.clj
@@ -7,7 +7,7 @@
 
 (deftest value-string-test
   (testing "If a filter has multiple values, they are concatenated into a comma-separated string"
-    (is (= "CA, NY and NJ"
+    (is (= "CA, NY, and NJ"
            (params/value-string (-> test-dashboard :parameters first)))))
 
   (testing "If a filter has a single default value, it is formatted appropriately"


### PR DESCRIPTION
Resolves #27584