### PR TITLE
adds malli= with tests

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -6,7 +6,7 @@
     (clojure.core.logic/fresh)
     (clojure.core.logic/matcha)
     (clojure.core.logic/run)
-    (clojure.test/is [partial= query= re= schema= sql= =?])
+    (clojure.test/is [partial= query= re= schema= malli= sql= =?])
     (clojure.tools.macro/macrolet)
     (metabase.async.streaming-response/streaming-response)
     (metabase.driver.druid.query-processor-test/druid-query-returning-rows)

--- a/test/metabase/test_runner/assert_exprs.clj
+++ b/test/metabase/test_runner/assert_exprs.clj
@@ -1,15 +1,15 @@
 (ns metabase.test-runner.assert-exprs
   "Custom implementations of [[clojure.test/is]] expressions (i.e., implementations of [[clojure.test/assert-expr]]).
-  `re=`, `schema=`, `query=`, `sql=`, `=?`, and more."
+  `re=`, `schema=`, `malli=`, `query=`, `sql=`, `=?`, and more."
   (:require
    [clojure.data :as data]
    [clojure.test :as t]
    [clojure.walk :as walk]
    [malli.core :as mc]
+   [malli.error :as me]
    [metabase.test-runner.assert-exprs.approximately-equal :as approximately-equal]
    [metabase.util.malli.describe :as umd]
-   [schema.core :as s]
-   [malli.error :as me]))
+   [schema.core :as s]))
 
 (defmethod t/assert-expr 're= [msg [_ pattern actual]]
   `(let [pattern#  ~pattern

--- a/test/metabase/test_runner/assert_exprs_test.clj
+++ b/test/metabase/test_runner/assert_exprs_test.clj
@@ -55,3 +55,23 @@
             {:a 1, :b [], :c [1]})))
     (is (partial= {:a 1, :b []}
                   {:a 1, :b []}))))
+
+(deftest malli=-test
+  (is (malli= [:maybe int?] 3))
+  (is (malli= [:maybe int?] nil))
+  (let [MyAddress [:map
+                   [:id :string]
+                   [:tags [:set :keyword]]
+                   [:address {:closed true}
+                    [:map {:closed true}
+                     [:street :string]
+                     [:city :string]
+                     [:zip :int]
+                     [:lonlat [:tuple :double :double]]]]]]
+    (is (malli= MyAddress {:id "home"
+                           :tags #{:sea-breeze :sunset :crowded}
+                           :address {:street "1234 46th St."
+                                     :city "Outer Phesantville"
+                                     :zip 12345
+                                     :lonlat [37.750109844302685
+                                              -122.50427012310526]}}))))


### PR DESCRIPTION
closes #27588

- behaves like `schema=` for reporting, diffs, and expected values.

I wasn't sure how to test the failure cases, so here are some screenshots:

---

### Very small failure case + report:

<img width="354" alt="Screen Shot 2023-01-09 at 1 05 20 PM" src="https://user-images.githubusercontent.com/343288/211398845-765c4552-ea2c-40a8-9a3f-0209b72da10e.png">

<img width="382" alt="Screen Shot 2023-01-09 at 1 05 16 PM" src="https://user-images.githubusercontent.com/343288/211398849-811085ce-4f09-4062-b688-5bc10196de2d.png">

---

### More realistic failure + report:

<img width="694" alt="Screen Shot 2023-01-09 at 1 13 48 PM" src="https://user-images.githubusercontent.com/343288/211399417-0413b710-2df9-47e0-8cc2-85ecbee0b29e.png">

<img width="1114" alt="Screen Shot 2023-01-09 at 1 13 56 PM" src="https://user-images.githubusercontent.com/343288/211399430-aa7435e5-a83c-44a5-a1b8-3efce48d57da.png">
