### PR TITLE
Fix e2e Repro which works in 46 with new H2 driver, not 45 (old H2)

### DIFF
--- a/frontend/test/metabase/scenarios/visualizations/reproductions/27427-static-viz-divide-by-zero.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/reproductions/27427-static-viz-divide-by-zero.cy.spec.js
@@ -9,7 +9,7 @@ const questionDetails = {
   },
   display: "bar",
   visualization_settings: {
-    "graph.dimensions": ["EXTRACT(YEAR FROM CURRENT_TIMESTAMP)"],
+    "graph.dimensions": ["YEAR(CURRENT_TIMESTAMP())"],
     "graph.metrics": ["V1", "V2"],
     "graph.series_order_dimension": null,
     "graph.series_order": null,


### PR DESCRIPTION
This e2e test failed in the 45 release branch because 46 (in progress on mater at time of writing) has an upgraded H2 driver, which was not backported.

This meant that the e2e test's expection of a graph.dimension of `EXTRACT(YEAR FROM CURRENT_TIMESTAMP)` would cause the static-viz render to fail because the actual dimension would be `YEAR(CURRENT_TIMESTAMP())`.

The fix to the underlying problem is still valid, and this reproduction, with the correct dimension, tests the fix and behaves correctly.