### PR TITLE
Dynamically-sized pivot-table header cells

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTable.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTable.jsx
@@ -8,7 +8,7 @@ import { Grid, Collection, ScrollSync, AutoSizer } from "react-virtualized";
 import { findDOMNode } from "react-dom";
 import { connect } from "react-redux";
 import { getScrollBarSize } from "metabase/lib/dom";
-import MetabaseSettings from "metabase/lib/settings";
+import { getSetting } from "metabase/selectors/settings";
 import ChartSettingsTableFormatting from "metabase/visualizations/components/settings/ChartSettingsTableFormatting";
 
 import {
@@ -50,6 +50,7 @@ import { CELL_WIDTH, CELL_HEIGHT, LEFT_HEADER_LEFT_SPACING } from "./constants";
 
 const mapStateToProps = state => ({
   hasCustomColors: PLUGIN_SELECTORS.getHasCustomColors(state),
+  fontFamily: getSetting(state, "application-font"),
 });
 
 class PivotTable extends Component {
@@ -313,6 +314,7 @@ class PivotTable extends Component {
       onUpdateVisualizationSettings,
       isNightMode,
       isDashboard,
+      fontFamily,
     } = this.props;
     if (data == null || !data.cols.some(isPivotGroupColumn)) {
       return null;
@@ -358,7 +360,7 @@ class PivotTable extends Component {
     const { leftHeaderWidths, totalHeaderWidths } = getLeftHeaderWidths({
       rowIndexes: rowIndexes ?? [],
       getColumnTitle: idx => this.getColumnTitle(idx),
-      fontFamily: MetabaseSettings.get("application-font") ?? "Lato",
+      fontFamily: fontFamily,
     });
 
     const leftHeaderCellRenderer = ({ index, key, style }) => {

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTable.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTable.jsx
@@ -8,6 +8,7 @@ import { Grid, Collection, ScrollSync, AutoSizer } from "react-virtualized";
 import { findDOMNode } from "react-dom";
 import { connect } from "react-redux";
 import { getScrollBarSize } from "metabase/lib/dom";
+import MetabaseSettings from "metabase/lib/settings";
 import ChartSettingsTableFormatting from "metabase/visualizations/components/settings/ChartSettingsTableFormatting";
 
 import {
@@ -357,8 +358,7 @@ class PivotTable extends Component {
     const { leftHeaderWidths, totalHeaderWidths } = getLeftHeaderWidths({
       rowIndexes: rowIndexes ?? [],
       getColumnTitle: idx => this.getColumnTitle(idx),
-      fontFamily:
-        window?.Metabase?.settings?._settings?.["application-font"] ?? "Lato", // 😬
+      fontFamily: MetabaseSettings.get("application-font") ?? "Lato",
     });
 
     const leftHeaderCellRenderer = ({ index, key, style }) => {

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTable.styled.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTable.styled.tsx
@@ -2,7 +2,7 @@ import { css } from "@emotion/react";
 import styled from "@emotion/styled";
 import { color, alpha, darken } from "metabase/lib/colors";
 
-export const CELL_HEIGHT = 30;
+import { CELL_HEIGHT, PIVOT_TABLE_FONT_SIZE } from "./constants";
 
 export const RowToggleIconRoot = styled.div`
   display: flex;
@@ -102,7 +102,7 @@ interface PivotTableRootProps {
 
 export const PivotTableRoot = styled.div<PivotTableRootProps>`
   height: 100%;
-  font-size: 0.875em;
+  font-size: ${PIVOT_TABLE_FONT_SIZE};
 
   ${props =>
     props.isDashboard

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTable.unit.spec.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTable.unit.spec.jsx
@@ -194,7 +194,7 @@ describe("Visualizations > PivotTable > PivotTable", () => {
     );
 
     rows.forEach(rowData => {
-      expect(screen.queryByText(rowData[0].toString())).toBeInTheDocument();
+      expect(screen.getByText(rowData[0].toString())).toBeInTheDocument();
 
       [1, 2, 4, 5].forEach(colIndex => {
         expect(

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTable.unit.spec.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTable.unit.spec.jsx
@@ -194,7 +194,7 @@ describe("Visualizations > PivotTable > PivotTable", () => {
     );
 
     rows.forEach(rowData => {
-      expect(screen.getByText(rowData[0].toString())).toBeInTheDocument();
+      expect(screen.queryByText(rowData[0].toString())).toBeInTheDocument();
 
       [1, 2, 4, 5].forEach(colIndex => {
         expect(

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/constants.ts
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/constants.ts
@@ -1,0 +1,18 @@
+// cell width and height for normal body cells
+export const CELL_WIDTH = 100;
+export const CELL_HEIGHT = 30;
+
+// styling and cell text measurement depend on this font size
+export const PIVOT_TABLE_FONT_SIZE = "0.75rem";
+
+// values for computing header width
+export const ROW_TOGGLE_ICON_WIDTH = 24;
+export const CELL_PADDING = 16;
+
+export const MIN_HEADER_CELL_WIDTH = 80;
+const MAX_HEADER_CONTENT_WIDTH = 200;
+export const MAX_HEADER_CELL_WIDTH =
+  MAX_HEADER_CONTENT_WIDTH + CELL_PADDING + ROW_TOGGLE_ICON_WIDTH;
+
+// the left header has some additional padding on the left to align with the title
+export const LEFT_HEADER_LEFT_SPACING = 24;

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/utils.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/utils.unit.spec.ts
@@ -7,7 +7,10 @@ import {
   isFormattablePivotColumn,
   updateValueWithCurrentColumns,
   addMissingCardBreakouts,
+  getLeftHeaderWidths,
 } from "./utils";
+
+import { MAX_HEADER_CELL_WIDTH, MIN_HEADER_CELL_WIDTH } from "./constants";
 
 describe("Visualizations > Visualizations > PivotTable > utils", () => {
   const cols = [
@@ -225,6 +228,43 @@ describe("Visualizations > Visualizations > PivotTable > utils", () => {
       const result = addMissingCardBreakouts(oldPivotSettings, card);
 
       expect(result).toEqual(newPivotSettings);
+    });
+  });
+
+  describe("getLeftHeaderWidths", () => {
+    it("should return an array of widths", () => {
+      const { leftHeaderWidths } = getLeftHeaderWidths({
+        rowIndexes: [0, 1, 2],
+        getColumnTitle: () => "test-123",
+      });
+      // react-dom thinks all characters are 1px wide, so we get the minimum
+      expect(leftHeaderWidths).toEqual([
+        MIN_HEADER_CELL_WIDTH,
+        MIN_HEADER_CELL_WIDTH,
+        MIN_HEADER_CELL_WIDTH,
+      ]);
+    });
+
+    it("should return the total of all widths", () => {
+      const { totalHeaderWidths } = getLeftHeaderWidths({
+        rowIndexes: [0, 1, 2],
+        getColumnTitle: () => "test-123",
+      });
+      expect(totalHeaderWidths).toEqual(MIN_HEADER_CELL_WIDTH * 3);
+    });
+
+    it("should not exceed the max width", () => {
+      const { leftHeaderWidths } = getLeftHeaderWidths({
+        rowIndexes: [0, 1, 2],
+        // react dom thinks characters are 1px wide
+        getColumnTitle: () => "x".repeat(MAX_HEADER_CELL_WIDTH),
+      });
+
+      expect(leftHeaderWidths).toEqual([
+        MAX_HEADER_CELL_WIDTH,
+        MAX_HEADER_CELL_WIDTH,
+        MAX_HEADER_CELL_WIDTH,
+      ]);
     });
   });
 });

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/utils.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/utils.unit.spec.ts
@@ -237,7 +237,7 @@ describe("Visualizations > Visualizations > PivotTable > utils", () => {
         rowIndexes: [0, 1, 2],
         getColumnTitle: () => "test-123",
       });
-      // react-dom thinks all characters are 1px wide, so we get the minimum
+      // jest-dom thinks all characters are 1px wide, so we get the minimum
       expect(leftHeaderWidths).toEqual([
         MIN_HEADER_CELL_WIDTH,
         MIN_HEADER_CELL_WIDTH,
@@ -256,7 +256,7 @@ describe("Visualizations > Visualizations > PivotTable > utils", () => {
     it("should not exceed the max width", () => {
       const { leftHeaderWidths } = getLeftHeaderWidths({
         rowIndexes: [0, 1, 2],
-        // react dom thinks characters are 1px wide
+        // jest-dom thinks characters are 1px wide
         getColumnTitle: () => "x".repeat(MAX_HEADER_CELL_WIDTH),
       });
 


### PR DESCRIPTION
resolves #27514 

## Descriptions

Previously, all pivot table header cells were 145px wide, this allows them to grow or shrink, based on the text content between 80px and 200px.

Before | After
--- | ---
![Screen Shot 2023-01-09 at 2 50 38 PM](https://user-images.githubusercontent.com/30528226/211415514-ac6de60b-783b-4c6c-a0d3-ec03e4c96538.png) | ![Screen Shot 2023-01-09 at 2 41 45 PM](https://user-images.githubusercontent.com/30528226/211415516-66048090-23b8-4819-8459-0e3a4148cc90.png)


## Testing Steps
- open a complicated pivot table like this one:
```
http://localhost:3000/question#eyJkYXRhc2V0X3F1ZXJ5Ijp7ImRhdGFiYXNlIjoxLCJxdWVyeSI6eyJzb3VyY2UtdGFibGUiOjIsImFnZ3JlZ2F0aW9uIjpbWyJzdW0iLFsiZmllbGQiLDEzLG51bGxdXV0sImJyZWFrb3V0IjpbWyJmaWVsZCIsMTQseyJ0ZW1wb3JhbC11bml0IjoicXVhcnRlciJ9XSxbImZpZWxkIiw4LHsic291cmNlLWZpZWxkIjo5fV0sWyJmaWVsZCIsMTIseyJiaW5uaW5nIjp7InN0cmF0ZWd5IjoiZGVmYXVsdCJ9fV0sWyJmaWVsZCIsMTcseyJiaW5uaW5nIjp7InN0cmF0ZWd5IjoiZGVmYXVsdCJ9fV0sWyJmaWVsZCIsMTUsbnVsbF1dfSwidHlwZSI6InF1ZXJ5In0sImRpc3BsYXkiOiJwaXZvdCIsImRpc3BsYXlJc0xvY2tlZCI6dHJ1ZSwicGFyYW1ldGVycyI6W10sInZpc3VhbGl6YXRpb25fc2V0dGluZ3MiOnsicGl2b3RfdGFibGUuY29sdW1uX3NwbGl0Ijp7InJvd3MiOltbImZpZWxkIiw4LHsic291cmNlLWZpZWxkIjo5fV0sWyJmaWVsZCIsMTQseyJ0ZW1wb3JhbC11bml0IjoicXVhcnRlciJ9XSxbImZpZWxkIiwxMix7ImJpbm5pbmciOnsic3RyYXRlZ3kiOiJkZWZhdWx0In19XSxbImZpZWxkIiwxNyx7ImJpbm5pbmciOnsic3RyYXRlZ3kiOiJkZWZhdWx0In19XSxbImZpZWxkIiwxNSxudWxsXV0sImNvbHVtbnMiOltdLCJ2YWx1ZXMiOltbImFnZ3JlZ2F0aW9uIiwwXV19fSwib3JpZ2luYWxfY2FyZF9pZCI6MTZ9
```
- see that column headers are appropriately sized for the header content, including the row expand header
- on metabase enterprise, change your font to something wacky and see that columns size properly for that font too

## Further work not done here
- #27596
- #27597
- #27598