### PR TITLE
Move `loadMetadataForCard` to questions module

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/audit_app/pages/AuditQueryDetail.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/pages/AuditQueryDetail.jsx
@@ -54,7 +54,7 @@ const AuditQueryDetail = ({ params: { queryHash } }) => (
 import { getMetadata } from "metabase/selectors/metadata";
 
 import ExplicitSize from "metabase/components/ExplicitSize";
-import { loadMetadataForCard } from "metabase/query_builder/actions";
+import { loadMetadataForCard } from "metabase/questions/actions";
 import NativeQuery from "metabase-lib/queries/NativeQuery";
 import Question from "metabase-lib/Question";
 import * as QueryDetailCards from "../lib/cards/query_detail";

--- a/frontend/src/metabase/containers/AdHocQuestionLoader.jsx
+++ b/frontend/src/metabase/containers/AdHocQuestionLoader.jsx
@@ -4,7 +4,7 @@ import { connect } from "react-redux";
 
 // things that will eventually load the quetsion
 import { deserializeCardFromUrl } from "metabase/lib/card";
-import { loadMetadataForCard } from "metabase/query_builder/actions";
+import { loadMetadataForCard } from "metabase/questions/actions";
 import { getMetadata } from "metabase/selectors/metadata";
 
 import Question from "metabase-lib/Question";

--- a/frontend/src/metabase/containers/SavedQuestionLoader.jsx
+++ b/frontend/src/metabase/containers/SavedQuestionLoader.jsx
@@ -2,7 +2,7 @@
 import React from "react";
 import { connect } from "react-redux";
 
-import { loadMetadataForCard } from "metabase/query_builder/actions";
+import { loadMetadataForCard } from "metabase/questions/actions";
 import { getMetadata } from "metabase/selectors/metadata";
 
 import Questions from "metabase/entities/questions";

--- a/frontend/src/metabase/query_builder/actions/core/core.js
+++ b/frontend/src/metabase/query_builder/actions/core/core.js
@@ -8,6 +8,7 @@ import * as Urls from "metabase/lib/urls";
 import Utils from "metabase/lib/utils";
 import { createThunkAction } from "metabase/lib/redux";
 
+import { loadMetadataForCard } from "metabase/questions/actions";
 import { getCardAfterVisualizationClick } from "metabase/visualizations/lib/utils";
 
 import { openUrl } from "metabase/redux/app";
@@ -39,7 +40,6 @@ import { clearQueryResult, runQuestionQuery } from "../querying";
 import { onCloseSidebars } from "../ui";
 
 import { updateQuestion } from "./updateQuestion";
-import { loadMetadataForCard } from "./metadata";
 import { getQuestionWithDefaultVisualizationSettings } from "./utils";
 
 export const RESET_QB = "metabase/qb/RESET_QB";

--- a/frontend/src/metabase/query_builder/actions/core/index.ts
+++ b/frontend/src/metabase/query_builder/actions/core/index.ts
@@ -1,4 +1,3 @@
 export * from "./core";
 export * from "./initializeQB";
-export * from "./metadata";
 export * from "./updateQuestion";

--- a/frontend/src/metabase/query_builder/actions/core/initializeQB.ts
+++ b/frontend/src/metabase/query_builder/actions/core/initializeQB.ts
@@ -11,6 +11,7 @@ import { getUser } from "metabase/selectors/user";
 
 import Snippets from "metabase/entities/snippets";
 import Questions from "metabase/entities/questions";
+import { loadMetadataForCard } from "metabase/questions/actions";
 import { fetchAlertsForQuestion } from "metabase/alert/alert";
 
 import {
@@ -34,7 +35,6 @@ import { updateUrl } from "../navigation";
 import { cancelQuery, runQuestionQuery } from "../querying";
 
 import { resetQB } from "./core";
-import { loadMetadataForCard } from "./metadata";
 import {
   propagateDashboardParameters,
   getParameterValuesForQuestion,

--- a/frontend/src/metabase/query_builder/actions/core/initializeQB.unit.spec.ts
+++ b/frontend/src/metabase/query_builder/actions/core/initializeQB.unit.spec.ts
@@ -5,6 +5,7 @@ import * as CardLib from "metabase/lib/card";
 import * as Urls from "metabase/lib/urls";
 
 import * as alert from "metabase/alert/alert";
+import * as questionActions from "metabase/questions/actions";
 import Databases from "metabase/entities/databases";
 import Snippets from "metabase/entities/snippets";
 import { setErrorPage } from "metabase/redux/app";
@@ -36,7 +37,6 @@ import Question from "metabase-lib/Question";
 import * as querying from "../querying";
 
 import * as core from "./core";
-import * as metadataActions from "./metadata";
 import { initializeQB } from "./initializeQB";
 
 type BaseSetupOpts = {
@@ -228,7 +228,7 @@ describe("QB Actions > initializeQB", () => {
 
         it("fetches question metadata", async () => {
           const loadMetadataForCardSpy = jest.spyOn(
-            metadataActions,
+            questionActions,
             "loadMetadataForCard",
           );
 
@@ -772,7 +772,7 @@ describe("QB Actions > initializeQB", () => {
 
     it("fetches question metadata", async () => {
       const loadMetadataForCardSpy = jest.spyOn(
-        metadataActions,
+        questionActions,
         "loadMetadataForCard",
       );
 

--- a/frontend/src/metabase/query_builder/actions/core/updateQuestion.ts
+++ b/frontend/src/metabase/query_builder/actions/core/updateQuestion.ts
@@ -1,6 +1,8 @@
 import _ from "underscore";
 import { assocIn } from "icepick";
 
+import { loadMetadataForCard } from "metabase/questions/actions";
+
 import { Dataset } from "metabase-types/api";
 import { Series } from "metabase-types/types/Visualization";
 import { Dispatch, GetState, QueryBuilderMode } from "metabase-types/store";
@@ -12,7 +14,6 @@ import Question from "metabase-lib/Question";
 import NativeQuery from "metabase-lib/queries/NativeQuery";
 import StructuredQuery from "metabase-lib/queries/StructuredQuery";
 
-import { isSupportedTemplateTagForModel } from "metabase-lib/metadata/utils/models";
 import {
   getFirstQueryResult,
   getIsShowingTemplateTagsEditor,
@@ -26,7 +27,6 @@ import { setIsShowingTemplateTagsEditor } from "../native";
 import { runQuestionQuery } from "../querying";
 import { onCloseQuestionInfo, setQueryBuilderMode } from "../ui";
 
-import { loadMetadataForCard } from "./metadata";
 import { getQuestionWithDefaultVisualizationSettings } from "./utils";
 
 function hasNewColumns(question: Question, queryResult: Dataset) {

--- a/frontend/src/metabase/query_builder/actions/core/updateQuestion.unit.spec.ts
+++ b/frontend/src/metabase/query_builder/actions/core/updateQuestion.unit.spec.ts
@@ -1,3 +1,4 @@
+import * as questionActions from "metabase/questions/actions";
 import { createMockDataset } from "metabase-types/api/mocks";
 import { Card, StructuredDatasetQuery } from "metabase-types/types/Card";
 import { ConcreteField, TemplateTag } from "metabase-types/types/Query";
@@ -34,7 +35,6 @@ import * as native from "../native";
 import * as querying from "../querying";
 import * as ui from "../ui";
 
-import * as metadataActions from "./metadata";
 import { updateQuestion, UPDATE_QUESTION } from "./updateQuestion";
 
 type SetupOpts = {
@@ -451,7 +451,7 @@ describe("QB Actions > updateQuestion", () => {
       describe(questionType, () => {
         it("loads metadata for the model", async () => {
           const loadMetadataSpy = jest.spyOn(
-            metadataActions,
+            questionActions,
             "loadMetadataForCard",
           );
 
@@ -461,7 +461,7 @@ describe("QB Actions > updateQuestion", () => {
 
         it("refreshes question metadata if there's difference in dependent metadata", async () => {
           const loadMetadataSpy = jest.spyOn(
-            metadataActions,
+            questionActions,
             "loadMetadataForCard",
           );
           const join = new Join(PRODUCTS_JOIN_CLAUSE);
@@ -488,7 +488,7 @@ describe("QB Actions > updateQuestion", () => {
       describe(questionType, () => {
         it("doesn't refresh question metadata if dependent metadata doesn't change", async () => {
           const loadMetadataSpy = jest.spyOn(
-            metadataActions,
+            questionActions,
             "loadMetadataForCard",
           );
 
@@ -498,7 +498,7 @@ describe("QB Actions > updateQuestion", () => {
 
         it("refreshes question metadata if there's difference in dependent metadata", async () => {
           const loadMetadataSpy = jest.spyOn(
-            metadataActions,
+            questionActions,
             "loadMetadataForCard",
           );
           const join = new Join(PRODUCTS_JOIN_CLAUSE);

--- a/frontend/src/metabase/questions/actions.ts
+++ b/frontend/src/metabase/questions/actions.ts
@@ -3,8 +3,9 @@ import _ from "underscore";
 import { loadMetadataForQueries } from "metabase/redux/metadata";
 import { getMetadata } from "metabase/selectors/metadata";
 
-import { Card } from "metabase-types/types/Card";
-import { Dispatch, GetState } from "metabase-types/store";
+import type { Card } from "metabase-types/types/Card";
+import type { Dispatch, GetState } from "metabase-types/store";
+
 import Question from "metabase-lib/Question";
 
 export interface LoadMetadataOptions {


### PR DESCRIPTION
Moves out `loadMetadataForCard` action from `query_builder` to `questions`