### PR TITLE
Dynamic pivot table cell size

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTable.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTable.jsx
@@ -360,6 +360,7 @@ class PivotTable extends Component {
     const { leftHeaderWidths, totalHeaderWidths } = getLeftHeaderWidths({
       rowIndexes: rowIndexes ?? [],
       getColumnTitle: idx => this.getColumnTitle(idx),
+      leftHeaderItems,
       fontFamily: fontFamily,
     });
 

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTable.unit.spec.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTable.unit.spec.jsx
@@ -194,7 +194,7 @@ describe("Visualizations > PivotTable > PivotTable", () => {
     );
 
     rows.forEach(rowData => {
-      expect(screen.queryByText(rowData[0].toString())).toBeInTheDocument();
+      expect(screen.getByText(rowData[0].toString())).toBeInTheDocument();
 
       [1, 2, 4, 5].forEach(colIndex => {
         expect(

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTable.unit.spec.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTable.unit.spec.jsx
@@ -194,7 +194,7 @@ describe("Visualizations > PivotTable > PivotTable", () => {
     );
 
     rows.forEach(rowData => {
-      expect(screen.getByText(rowData[0].toString())).toBeInTheDocument();
+      expect(screen.queryByText(rowData[0].toString())).toBeInTheDocument();
 
       [1, 2, 4, 5].forEach(colIndex => {
         expect(

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/constants.ts
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/constants.ts
@@ -16,3 +16,5 @@ export const MAX_HEADER_CELL_WIDTH =
 
 // the left header has some additional padding on the left to align with the title
 export const LEFT_HEADER_LEFT_SPACING = 24;
+
+export const MAX_ROWS_TO_MEASURE = 100;

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/types.ts
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/types.ts
@@ -1,4 +1,5 @@
 import type { FieldReference, AggregationReference } from "metabase-types/api";
+import type { Column } from "metabase-types/types/Dataset";
 
 export type FieldOrAggregationReference = FieldReference | AggregationReference;
 
@@ -7,3 +8,22 @@ export type PivotSetting = {
   rows: FieldReference[];
   values: AggregationReference[];
 };
+
+export interface LeftHeaderItem {
+  clicked: { value: string; column: Column };
+
+  isCollapsed: boolean;
+  hasChildren: boolean;
+  hasSubtotal?: boolean;
+  isSubtotal?: boolean;
+  isGrandTotal?: boolean;
+
+  depth: number;
+  maxDepthBelow: number;
+  offset: number;
+  span: number; // rows to span
+
+  path: string[];
+  rawValue: string;
+  value: string;
+}

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/utils.ts
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/utils.ts
@@ -6,7 +6,11 @@ import { measureText } from "metabase/lib/measure-text";
 
 import type { Column } from "metabase-types/types/Dataset";
 import type { Card } from "metabase-types/types/Card";
-import type { PivotSetting, FieldOrAggregationReference } from "./types";
+import type {
+  PivotSetting,
+  FieldOrAggregationReference,
+  LeftHeaderItem,
+} from "./types";
 import { partitions } from "./partitions";
 
 import {
@@ -15,6 +19,7 @@ import {
   MIN_HEADER_CELL_WIDTH,
   MAX_HEADER_CELL_WIDTH,
   PIVOT_TABLE_FONT_SIZE,
+  MAX_ROWS_TO_MEASURE,
 } from "./constants";
 
 // adds or removes columns from the pivot settings based on the current query
@@ -88,25 +93,43 @@ export function isFormattablePivotColumn(column: Column) {
 interface GetLeftHeaderWidthsProps {
   rowIndexes: number[];
   getColumnTitle: (columnIndex: number) => string;
+  leftHeaderItems: LeftHeaderItem[];
   fontFamily?: string;
 }
 
 export function getLeftHeaderWidths({
   rowIndexes,
   getColumnTitle,
+  leftHeaderItems,
   fontFamily = "Lato",
 }: GetLeftHeaderWidthsProps) {
-  const widths = rowIndexes.map(rowIndex => {
+  const cellValues = getColumnValues(leftHeaderItems, rowIndexes);
+
+  const widths = rowIndexes.map((rowIndex, depthIndex) => {
+    const computedHeaderWidth = Math.ceil(
+      measureText(getColumnTitle(rowIndex), {
+        weight: "bold",
+        family: fontFamily,
+        size: PIVOT_TABLE_FONT_SIZE,
+      }) + ROW_TOGGLE_ICON_WIDTH,
+    );
+
+    const computedCellWidth = Math.ceil(
+      Math.max(
+        // we need to use the depth index because the data is in depth order, not row index order
+        ...cellValues[depthIndex].values.map(
+          value =>
+            measureText(value, {
+              weight: "normal",
+              family: fontFamily,
+              size: PIVOT_TABLE_FONT_SIZE,
+            }) + (cellValues[rowIndex].hasSubtotal ? ROW_TOGGLE_ICON_WIDTH : 0),
+        ),
+      ),
+    );
+
     const computedWidth =
-      Math.ceil(
-        measureText(getColumnTitle(rowIndex), {
-          weight: "bold",
-          family: fontFamily,
-          size: PIVOT_TABLE_FONT_SIZE,
-        }),
-      ) +
-      ROW_TOGGLE_ICON_WIDTH +
-      CELL_PADDING;
+      Math.max(computedHeaderWidth, computedCellWidth) + CELL_PADDING;
 
     if (computedWidth > MAX_HEADER_CELL_WIDTH) {
       return MAX_HEADER_CELL_WIDTH;
@@ -122,4 +145,42 @@ export function getLeftHeaderWidths({
   const total = widths.reduce((acc, width) => acc + width, 0);
 
   return { leftHeaderWidths: widths, totalHeaderWidths: total };
+}
+
+type ColumnValueInfo = {
+  values: string[];
+  hasSubtotal: boolean;
+};
+
+function getColumnValues(
+  leftHeaderItems: LeftHeaderItem[],
+  rowIndexes: number[],
+) {
+  const columnValues: ColumnValueInfo[] = [];
+
+  leftHeaderItems
+    .slice(0, MAX_ROWS_TO_MEASURE)
+    .forEach((leftHeaderItem: LeftHeaderItem) => {
+      const { value, depth, isSubtotal, isGrandTotal, hasSubtotal } =
+        leftHeaderItem;
+
+      // don't size based on subtotals or grand totals
+      if (!isSubtotal && !isGrandTotal && value !== null) {
+        if (!columnValues[depth]) {
+          columnValues[depth] = {
+            values: [value],
+            hasSubtotal: false,
+          };
+        } else {
+          columnValues[depth].values.push(value);
+        }
+
+        // we need to track whether the column has a subtotal to size for the row expand icon
+        if (hasSubtotal) {
+          columnValues[depth].hasSubtotal = true;
+        }
+      }
+    });
+
+  return columnValues;
 }

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/utils.ts
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/utils.ts
@@ -93,17 +93,17 @@ export function isFormattablePivotColumn(column: Column) {
 interface GetLeftHeaderWidthsProps {
   rowIndexes: number[];
   getColumnTitle: (columnIndex: number) => string;
-  leftHeaderItems: LeftHeaderItem[];
+  leftHeaderItems?: LeftHeaderItem[];
   fontFamily?: string;
 }
 
 export function getLeftHeaderWidths({
   rowIndexes,
   getColumnTitle,
-  leftHeaderItems,
+  leftHeaderItems = [],
   fontFamily = "Lato",
 }: GetLeftHeaderWidthsProps) {
-  const cellValues = getColumnValues(leftHeaderItems, rowIndexes);
+  const cellValues = getColumnValues(leftHeaderItems);
 
   const widths = rowIndexes.map((rowIndex, depthIndex) => {
     const computedHeaderWidth = Math.ceil(
@@ -117,14 +117,15 @@ export function getLeftHeaderWidths({
     const computedCellWidth = Math.ceil(
       Math.max(
         // we need to use the depth index because the data is in depth order, not row index order
-        ...cellValues[depthIndex].values.map(
+        ...(cellValues[depthIndex]?.values?.map(
           value =>
             measureText(value, {
               weight: "normal",
               family: fontFamily,
               size: PIVOT_TABLE_FONT_SIZE,
-            }) + (cellValues[rowIndex].hasSubtotal ? ROW_TOGGLE_ICON_WIDTH : 0),
-        ),
+            }) +
+            (cellValues[rowIndex]?.hasSubtotal ? ROW_TOGGLE_ICON_WIDTH : 0),
+        ) ?? [0]),
       ),
     );
 
@@ -152,10 +153,7 @@ type ColumnValueInfo = {
   hasSubtotal: boolean;
 };
 
-function getColumnValues(
-  leftHeaderItems: LeftHeaderItem[],
-  rowIndexes: number[],
-) {
+export function getColumnValues(leftHeaderItems: LeftHeaderItem[]) {
   const columnValues: ColumnValueInfo[] = [];
 
   leftHeaderItems
@@ -165,7 +163,7 @@ function getColumnValues(
         leftHeaderItem;
 
       // don't size based on subtotals or grand totals
-      if (!isSubtotal && !isGrandTotal && value !== null) {
+      if (!isSubtotal && !isGrandTotal) {
         if (!columnValues[depth]) {
           columnValues[depth] = {
             values: [value],

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/utils.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/utils.unit.spec.ts
@@ -1,6 +1,7 @@
 import type { Column } from "metabase-types/types/Dataset";
 import type { Card } from "metabase-types/types/Card";
-import type { PivotSetting } from "./types";
+
+import type { PivotSetting, LeftHeaderItem } from "./types";
 
 import {
   isColumnValid,
@@ -8,9 +9,15 @@ import {
   updateValueWithCurrentColumns,
   addMissingCardBreakouts,
   getLeftHeaderWidths,
+  getColumnValues,
 } from "./utils";
 
-import { MAX_HEADER_CELL_WIDTH, MIN_HEADER_CELL_WIDTH } from "./constants";
+import {
+  MAX_HEADER_CELL_WIDTH,
+  MIN_HEADER_CELL_WIDTH,
+  CELL_PADDING,
+  ROW_TOGGLE_ICON_WIDTH,
+} from "./constants";
 
 describe("Visualizations > Visualizations > PivotTable > utils", () => {
   const cols = [
@@ -264,6 +271,115 @@ describe("Visualizations > Visualizations > PivotTable > utils", () => {
         MAX_HEADER_CELL_WIDTH,
         MAX_HEADER_CELL_WIDTH,
         MAX_HEADER_CELL_WIDTH,
+      ]);
+    });
+
+    it("should return the wider of the column header or data width", () => {
+      const data = [
+        { depth: 0, value: "x".repeat(150) },
+        { depth: 0, value: "foo2" },
+        { depth: 1, value: "bar1" },
+        { depth: 1, value: "bar2" },
+        { depth: 2, value: "baz1" },
+        { depth: 4, value: "boo1" },
+      ] as LeftHeaderItem[];
+
+      const { leftHeaderWidths } = getLeftHeaderWidths({
+        rowIndexes: [0, 1, 2, 3, 4],
+        leftHeaderItems: data,
+        getColumnTitle: () => "x".repeat(70),
+      });
+
+      expect(leftHeaderWidths).toEqual([
+        150 + CELL_PADDING,
+        70 + CELL_PADDING + ROW_TOGGLE_ICON_WIDTH,
+        70 + CELL_PADDING + ROW_TOGGLE_ICON_WIDTH,
+        70 + CELL_PADDING + ROW_TOGGLE_ICON_WIDTH,
+        70 + CELL_PADDING + ROW_TOGGLE_ICON_WIDTH,
+      ]);
+    });
+
+    it("should factor in the toggle icon width for columns with subtotals", () => {
+      const data = [
+        { depth: 0, value: "x".repeat(100), hasSubtotal: true },
+        { depth: 0, value: "foo2" },
+        { depth: 1, value: "bar1" },
+        { depth: 1, value: "bar2" },
+        { depth: 2, value: "baz1" },
+        { depth: 4, value: "boo1" },
+      ] as LeftHeaderItem[];
+
+      const { leftHeaderWidths } = getLeftHeaderWidths({
+        rowIndexes: [0, 1, 2, 3, 4],
+        leftHeaderItems: data,
+        getColumnTitle: () => "test-123",
+      });
+
+      expect(leftHeaderWidths).toEqual([
+        100 + CELL_PADDING + ROW_TOGGLE_ICON_WIDTH,
+        MIN_HEADER_CELL_WIDTH,
+        MIN_HEADER_CELL_WIDTH,
+        MIN_HEADER_CELL_WIDTH,
+        MIN_HEADER_CELL_WIDTH,
+      ]);
+    });
+  });
+
+  describe("getColumnValues", () => {
+    it("can collect column values from left header data", () => {
+      const data = [
+        { depth: 0, value: "foo1" },
+        { depth: 0, value: "foo2" },
+        { depth: 1, value: "bar1" },
+        { depth: 1, value: "bar2" },
+        { depth: 2, value: "baz1" },
+        { depth: 4, value: "boo1" },
+      ] as LeftHeaderItem[];
+
+      const result = getColumnValues(data);
+
+      expect(result).toEqual([
+        { values: ["foo1", "foo2"], hasSubtotal: false },
+        { values: ["bar1", "bar2"], hasSubtotal: false },
+        { values: ["baz1"], hasSubtotal: false },
+        undefined, // no depth of 3
+        { values: ["boo1"], hasSubtotal: false },
+      ]);
+    });
+
+    it("detects columns with subtotals", () => {
+      const data = [
+        { depth: 0, value: "foo1", hasSubtotal: false },
+        { depth: 0, value: "foo2", hasSubtotal: true },
+        { depth: 1, value: "bar1", hasSubtotal: false },
+        { depth: 1, value: "bar2", hasSubtotal: false },
+        { depth: 2, value: "baz1", hasSubtotal: true },
+      ] as LeftHeaderItem[];
+
+      const result = getColumnValues(data);
+
+      expect(result).toEqual([
+        { values: ["foo1", "foo2"], hasSubtotal: true },
+        { values: ["bar1", "bar2"], hasSubtotal: false },
+        { values: ["baz1"], hasSubtotal: true },
+      ]);
+    });
+
+    it("handles null values ", () => {
+      const data = [
+        { depth: 0, value: "foo1", hasSubtotal: false },
+        { depth: 0, value: null, hasSubtotal: true },
+        { depth: 1, value: "bar1", hasSubtotal: false },
+        { depth: 1, value: "bar2", hasSubtotal: false },
+        { depth: 2, value: "baz1", hasSubtotal: true },
+      ] as LeftHeaderItem[];
+
+      const result = getColumnValues(data);
+
+      expect(result).toEqual([
+        { values: ["foo1", null], hasSubtotal: true },
+        { values: ["bar1", "bar2"], hasSubtotal: false },
+        { values: ["baz1"], hasSubtotal: true },
       ]);
     });
   });

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/utils.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/utils.unit.spec.ts
@@ -365,7 +365,7 @@ describe("Visualizations > Visualizations > PivotTable > utils", () => {
       ]);
     });
 
-    it("handles null values ", () => {
+    it("handles null values", () => {
       const data = [
         { depth: 0, value: "foo1", hasSubtotal: false },
         { depth: 0, value: null, hasSubtotal: true },


### PR DESCRIPTION
resolves #27596 

## Description

In order to make pivot tables look nicer out of the box, we want to also try to fit column widths to cell data (within constraints).

This scans the first 100 (a totally arbitrary value) data left header data items in a pivot table, and sizes the pivot columns based on this data if it is wider than the size calculated for the column header.

Before | After
--- | ---
![Screen Shot 2023-01-10 at 11 31 04 AM](https://user-images.githubusercontent.com/30528226/211633899-c75111d3-eb01-440b-8c86-d094b0bec8ea.png) | ![Screen Shot 2023-01-10 at 11 30 50 AM](https://user-images.githubusercontent.com/30528226/211633904-40295ade-50f4-497b-b4d1-fc4f7f8a469f.png)


## Testing Steps
- open a complicated pivot table like this one:
```
http://localhost:3000/question#eyJkYXRhc2V0X3F1ZXJ5Ijp7ImRhdGFiYXNlIjoxLCJxdWVyeSI6eyJzb3VyY2UtdGFibGUiOjIsImFnZ3JlZ2F0aW9uIjpbWyJzdW0iLFsiZmllbGQiLDEzLG51bGxdXV0sImJyZWFrb3V0IjpbWyJmaWVsZCIsMTQseyJ0ZW1wb3JhbC11bml0IjoicXVhcnRlciJ9XSxbImZpZWxkIiw4LHsic291cmNlLWZpZWxkIjo5fV0sWyJmaWVsZCIsMTIseyJiaW5uaW5nIjp7InN0cmF0ZWd5IjoiZGVmYXVsdCJ9fV0sWyJmaWVsZCIsMTcseyJiaW5uaW5nIjp7InN0cmF0ZWd5IjoiZGVmYXVsdCJ9fV0sWyJmaWVsZCIsMTUsbnVsbF1dfSwidHlwZSI6InF1ZXJ5In0sImRpc3BsYXkiOiJwaXZvdCIsImRpc3BsYXlJc0xvY2tlZCI6dHJ1ZSwicGFyYW1ldGVycyI6W10sInZpc3VhbGl6YXRpb25fc2V0dGluZ3MiOnsicGl2b3RfdGFibGUuY29sdW1uX3NwbGl0Ijp7InJvd3MiOltbImZpZWxkIiw4LHsic291cmNlLWZpZWxkIjo5fV0sWyJmaWVsZCIsMTQseyJ0ZW1wb3JhbC11bml0IjoicXVhcnRlciJ9XSxbImZpZWxkIiwxMix7ImJpbm5pbmciOnsic3RyYXRlZ3kiOiJkZWZhdWx0In19XSxbImZpZWxkIiwxNyx7ImJpbm5pbmciOnsic3RyYXRlZ3kiOiJkZWZhdWx0In19XSxbImZpZWxkIiwxNSxudWxsXV0sImNvbHVtbnMiOltdLCJ2YWx1ZXMiOltbImFnZ3JlZ2F0aW9uIiwwXV19fSwib3JpZ2luYWxfY2FyZF9pZCI6MTZ9
```
- see that column headers are appropriately sized for the header and cell content, including the row expand button
- on metabase enterprise, change your font to something wacky and see that columns size properly for that font too

## Further work not done here
- #27597
- #27598
