### PR TITLE
Preserve join `:alias/original`

### DIFF
--- a/src/metabase/query_processor/middleware/escape_join_aliases.clj
+++ b/src/metabase/query_processor/middleware/escape_join_aliases.clj
@@ -25,7 +25,8 @@
                     (merge
                      ;; recursively update stuff inside the join
                      (rename-join-aliases* (dissoc join :alias))
-                     {:alias (original->new (:alias join))})))]
+                     {:alias          (original->new (:alias join))
+                      :alias/original (:alias join)})))]
           (rename-join-aliases* query))))))
 
 (defn- all-join-aliases [query]

--- a/test/metabase/query_processor/middleware/annotate_test.clj
+++ b/test/metabase/query_processor/middleware/annotate_test.clj
@@ -795,3 +795,32 @@
           (is (= "alias → B Column" (-> results :data :results_metadata
                                         :columns second :display_name))
               "Results metadata cols has wrong display name"))))))
+
+(deftest preserve-original-join-alias-test
+  (testing "The join alias for the `:field_ref` in results metadata should match the one originally specified (#27464)"
+    (mt/test-drivers (mt/normal-drivers-with-feature :left-join)
+      (mt/dataset sample-dataset
+        (let [join-alias "Products with a very long name - Product ID with a very long name"
+              results    (mt/run-mbql-query orders
+                           {:joins  [{:source-table $$products
+                                      :condition    [:= $product_id [:field %products.id {:join-alias join-alias}]]
+                                      :alias        join-alias
+                                      :fields       [[:field %products.title {:join-alias join-alias}]]}]
+                            :fields [$orders.id
+                                     [:field %products.title {:join-alias join-alias}]]
+                            :limit  4})]
+          (doseq [[location metadata] {"data.cols"                     (mt/cols results)
+                                       "data.results_metadata.columns" (get-in results [:data :results_metadata :columns])}]
+            (testing location
+              (is (= (mt/$ids
+                       [{:display_name "ID"
+                         :field_ref    $orders.id}
+                        (merge
+                         {:display_name (str join-alias " → Title")
+                          :field_ref    [:field %products.title {:join-alias join-alias}]}
+                         ;; `source_alias` is only included in `data.cols`, but not in `results_metadata`
+                         (when (= location "data.cols")
+                           {:source_alias join-alias}))])
+                     (map
+                      #(select-keys % [:display_name :field_ref :source_alias])
+                      metadata))))))))))

--- a/test/metabase/query_processor_test.clj
+++ b/test/metabase/query_processor_test.clj
@@ -191,10 +191,8 @@
         (update :display_name (partial format "%s → %s" (str/replace (:display_name source-col) #"(?i)\sid$" "")))
         (assoc :field_ref    [:field (:id dest-col) {:source-field (:id source-col)}]
                :fk_field_id  (:id source-col)
-               :source_alias (driver/escape-alias
-                              driver/*driver*
-                              (#'qp.add-implicit-joins/join-alias (db/select-one-field :name Table :id (data/id dest-table-kw))
-                                                                  (:name source-col)))))))
+               :source_alias (#'qp.add-implicit-joins/join-alias (db/select-one-field :name Table :id (data/id dest-table-kw))
+                                                                 (:name source-col))))))
 
 (declare cols)
 


### PR DESCRIPTION
Fixes #27464

In #19384 or one of its follow-ons I added logic to escape/deduplicate/truncate join aliases if needed (most databases have some sort of identifier length limit, and several only allow certain characters).

These new escaped/shortened join aliases were getting returned with results metadata, rather than the original aliases; this ended up resulting in the issues described in #27464. 

Fixed by having the `metabase.query-processor.middleware.escape-join-aliases` middleware that does the shortening keep `:alias/original` in the join itself, and by updating the `annotate` middleware that generates results metadata to use this preferentially when generating `:field_ref`, `:display_name`, and the like.