### PR TITLE
Add links to reach the model detail page

### DIFF
--- a/frontend/src/metabase-types/api/collection.ts
+++ b/frontend/src/metabase-types/api/collection.ts
@@ -38,9 +38,11 @@ export interface Collection {
   path?: CollectionId[];
 }
 
-export interface CollectionItem {
+type CollectionItemModel = "card" | "dataset" | "dashboard" | "pulse";
+
+export interface CollectionItem<T = CollectionItemModel> {
   id: number;
-  model: string;
+  model: T;
   name: string;
   description: string | null;
   copy?: boolean;

--- a/frontend/src/metabase/collections/components/ActionMenu/ActionMenu.unit.spec.tsx
+++ b/frontend/src/metabase/collections/components/ActionMenu/ActionMenu.unit.spec.tsx
@@ -51,7 +51,7 @@ describe("ActionMenu", () => {
   it("should not show an option to hide preview for a pinned model", () => {
     const props = getProps({
       item: createMockCollectionItem({
-        model: "model",
+        model: "dataset",
         collection_position: 1,
         setCollectionPreview: jest.fn(),
       }),

--- a/frontend/src/metabase/collections/components/BaseItemsTable.styled.jsx
+++ b/frontend/src/metabase/collections/components/BaseItemsTable.styled.jsx
@@ -101,7 +101,7 @@ export const SortingControlContainer = styled.div`
 
 export const RowActionsContainer = styled.div`
   display: flex;
-  gap: 8px;
+  gap: 0.5rem;
 `;
 
 export const TableItemSecondaryField = styled.span`

--- a/frontend/src/metabase/collections/components/BaseItemsTable.styled.jsx
+++ b/frontend/src/metabase/collections/components/BaseItemsTable.styled.jsx
@@ -9,6 +9,7 @@ import {
 import EntityItem from "metabase/components/EntityItem";
 import Icon from "metabase/components/Icon";
 import Link from "metabase/core/components/Link";
+import BaseModelDetailLink from "metabase/models/components/ModelDetailLink";
 
 const LAST_EDITED_BY_INDEX = 3;
 const LAST_EDITED_AT_INDEX = 4;
@@ -76,6 +77,11 @@ SortingIcon.defaultProps = {
   size: 8,
 };
 
+export const ModelDetailLink = styled(BaseModelDetailLink)`
+  color: ${color("text-medium")};
+  visibility: hidden;
+`;
+
 export const SortingControlContainer = styled.div`
   display: flex;
   align-items: center;
@@ -91,6 +97,11 @@ export const SortingControlContainer = styled.div`
       visibility: visible;
     }
   }
+`;
+
+export const RowActionsContainer = styled.div`
+  display: flex;
+  gap: 8px;
 `;
 
 export const TableItemSecondaryField = styled.span`
@@ -141,6 +152,12 @@ export const TBody = styled.tbody`
       &:first-of-type {
         border-bottom-left-radius: 8px;
       }
+    }
+  }
+
+  tr:hover {
+    ${ModelDetailLink} {
+      visibility: visible;
     }
   }
 `;

--- a/frontend/src/metabase/collections/components/BaseTableItem.jsx
+++ b/frontend/src/metabase/collections/components/BaseTableItem.jsx
@@ -21,6 +21,8 @@ import {
   ItemLink,
   TableItemSecondaryField,
   DescriptionIcon,
+  ModelDetailLink,
+  RowActionsContainer,
 } from "./BaseItemsTable.styled";
 
 BaseTableItem.propTypes = {
@@ -141,15 +143,18 @@ export function BaseTableItem({
           )}
         </ItemCell>
         <ItemCell>
-          <ActionMenu
-            createBookmark={createBookmark}
-            deleteBookmark={deleteBookmark}
-            bookmarks={bookmarks}
-            item={item}
-            collection={collection}
-            onCopy={onCopy}
-            onMove={onMove}
-          />
+          <RowActionsContainer>
+            <ActionMenu
+              createBookmark={createBookmark}
+              deleteBookmark={deleteBookmark}
+              bookmarks={bookmarks}
+              item={item}
+              collection={collection}
+              onCopy={onCopy}
+              onMove={onMove}
+            />
+            {item.model === "dataset" && <ModelDetailLink model={item} />}
+          </RowActionsContainer>
         </ItemCell>
       </tr>
     );

--- a/frontend/src/metabase/collections/components/PinnedItemCard/PinnedItemCard.tsx
+++ b/frontend/src/metabase/collections/components/PinnedItemCard/PinnedItemCard.tsx
@@ -4,6 +4,7 @@ import { t } from "ttag";
 import Tooltip from "metabase/core/components/Tooltip";
 
 import ActionMenu from "metabase/collections/components/ActionMenu";
+import ModelDetailLink from "metabase/models/components/ModelDetailLink";
 
 import type { Bookmark, Collection, CollectionItem } from "metabase-types/api";
 
@@ -74,6 +75,9 @@ function PinnedItemCard({
           <Header>
             <ItemIcon name={icon} />
             <ActionsContainer>
+              {item.model === "dataset" && (
+                <ModelDetailLink model={item as CollectionItem<"dataset">} />
+              )}
               <ActionMenu
                 bookmarks={bookmarks}
                 createBookmark={createBookmark}

--- a/frontend/src/metabase/collections/components/PinnedItemCard/PinnedItemCard.unit.spec.js
+++ b/frontend/src/metabase/collections/components/PinnedItemCard/PinnedItemCard.unit.spec.js
@@ -4,6 +4,11 @@ import { render, screen, getIcon } from "__support__/ui";
 
 import PinnedItemCard from "./PinnedItemCard";
 
+// eslint-disable-next-line react/display-name, react/prop-types
+jest.mock("metabase/core/components/Link", () => ({ to, ...props }) => (
+  <a {...props} href={to} />
+));
+
 const mockOnCopy = jest.fn();
 const mockOnMove = jest.fn();
 

--- a/frontend/src/metabase/collections/components/PinnedItemCard/PinnedItemCard.unit.spec.js
+++ b/frontend/src/metabase/collections/components/PinnedItemCard/PinnedItemCard.unit.spec.js
@@ -14,27 +14,37 @@ const defaultCollection = {
   archived: false,
 };
 
-const defaultItem = {
-  id: 1,
-  model: "dashboard",
-  collection_position: 1,
-  name: "Dashboard Foo",
-  description: "description foo foo foo",
-  getIcon: () => ({ name: "dashboard" }),
-  getUrl: () => "/dashboard/1",
-  setArchived: jest.fn(),
-  setPinned: jest.fn(),
-};
+function getCollectionItem({
+  id = 1,
+  model = "dashboard",
+  name = "My Item",
+  description = "description foo foo foo",
+  collection_position = 1,
+  icon = "dashboard",
+  url = "/dashboard/1",
+  setArchived = jest.fn(),
+  setPinned = jest.fn(),
+  ...rest
+} = {}) {
+  return {
+    ...rest,
+    id,
+    model,
+    name,
+    description,
+    collection_position,
+    getIcon: () => ({ name: icon }),
+    getUrl: () => url,
+    setArchived,
+    setPinned,
+  };
+}
 
-function setup({ item, collection } = {}) {
-  item = item || defaultItem;
-  collection = collection || defaultCollection;
+const defaultItem = getCollectionItem();
 
+function setup({ item = defaultItem, collection = defaultCollection } = {}) {
   mockOnCopy.mockReset();
   mockOnMove.mockReset();
-  item.setArchived.mockReset();
-  item.setPinned.mockReset();
-
   return render(
     <PinnedItemCard
       item={item}
@@ -62,12 +72,7 @@ describe("PinnedItemCard", () => {
   });
 
   it("should show a default description if there is no item description", () => {
-    const item = {
-      ...defaultItem,
-      description: null,
-    };
-    setup({ item });
-
+    setup({ item: getCollectionItem({ description: null }) });
     expect(screen.getByText("A dashboard")).toBeInTheDocument();
   });
 

--- a/frontend/src/metabase/collections/components/PinnedItemCard/PinnedItemCard.unit.spec.js
+++ b/frontend/src/metabase/collections/components/PinnedItemCard/PinnedItemCard.unit.spec.js
@@ -81,4 +81,27 @@ describe("PinnedItemCard", () => {
     userEvent.click(getIcon("ellipsis"));
     expect(screen.getByText("Unpin")).toBeInTheDocument();
   });
+
+  it("doesn't show model detail page link", () => {
+    setup();
+    expect(screen.queryByTestId("model-detail-link")).not.toBeInTheDocument();
+  });
+
+  describe("models", () => {
+    const model = getCollectionItem({
+      id: 1,
+      name: "Order",
+      model: "dataset",
+      url: "/model/1",
+    });
+
+    it("should show a model detail page link", () => {
+      setup({ item: model });
+      expect(screen.getByTestId("model-detail-link")).toBeInTheDocument();
+      expect(screen.getByTestId("model-detail-link")).toHaveAttribute(
+        "href",
+        "/model/1-order/detail",
+      );
+    });
+  });
 });

--- a/frontend/src/metabase/lib/urls/models.ts
+++ b/frontend/src/metabase/lib/urls/models.ts
@@ -17,6 +17,11 @@ export function model(
   return question(card as LegacyCard, opts);
 }
 
+export function modelDetail(card: CardOrSearchResult) {
+  const baseUrl = model(card);
+  return `${baseUrl}/detail`;
+}
+
 type ModelEditorUrlBuilderOpts = {
   type?: "query" | "metadata";
 };

--- a/frontend/src/metabase/models/components/ModelDetailLink.tsx
+++ b/frontend/src/metabase/models/components/ModelDetailLink.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { t } from "ttag";
+
+import Button, { ButtonProps } from "metabase/core/components/Button";
+import Link from "metabase/core/components/Link";
+
+import * as Urls from "metabase/lib/urls";
+
+import type { Card, CollectionItem } from "metabase-types/api";
+
+type ModelCard = Card & { dataset: true };
+
+interface Props extends ButtonProps {
+  model: ModelCard | CollectionItem<"dataset">;
+}
+
+function ModelDetailLink({ model, ...props }: Props) {
+  return (
+    <Button
+      aria-label={t`Model details`}
+      {...props}
+      as={Link}
+      to={Urls.modelDetail(model)}
+      icon="reference"
+      onlyIcon
+      role="link"
+      data-testid="model-detail-link"
+    />
+  );
+}
+
+export default ModelDetailLink;

--- a/frontend/src/metabase/models/components/ModelDetailLink.tsx
+++ b/frontend/src/metabase/models/components/ModelDetailLink.tsx
@@ -18,6 +18,7 @@ function ModelDetailLink({ model, ...props }: Props) {
   return (
     <Button
       aria-label={t`Model details`}
+      tooltip={t`Model details`}
       {...props}
       as={Link}
       to={Urls.modelDetail(model)}

--- a/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar.styled.tsx
@@ -1,6 +1,9 @@
 import styled from "@emotion/styled";
-import { color } from "metabase/lib/colors";
+
 import EditableText from "metabase/core/components/EditableText";
+import Link from "metabase/core/components/Link";
+
+import { color } from "metabase/lib/colors";
 
 export const Root = styled.div`
   padding: 1rem 1.5rem 0;
@@ -36,6 +39,13 @@ export const ContentSection = styled.div<ContentSectionProps>`
   }
 `;
 
-export const Header = styled.h3`
+export const HeaderContainer = styled.div`
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
   margin-top: 0.5rem;
+`;
+
+export const HeaderLink = styled(Link)`
+  color: ${color("brand")};
 `;

--- a/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar.tsx
@@ -1,19 +1,26 @@
 import React from "react";
 import { t } from "ttag";
 
+import EditableText from "metabase/core/components/EditableText";
+
 import { PLUGIN_MODERATION, PLUGIN_CACHING } from "metabase/plugins";
 
 import MetabaseSettings from "metabase/lib/settings";
+import * as Urls from "metabase/lib/urls";
 
 import QuestionActivityTimeline from "metabase/query_builder/components/QuestionActivityTimeline";
 
-import { Card } from "metabase-types/types/Card";
+import type { Card } from "metabase-types/types/Card";
 
-import EditableText from "metabase/core/components/EditableText";
 import Question from "metabase-lib/Question";
 
 import ModelCacheManagementSection from "./ModelCacheManagementSection";
-import { Root, ContentSection, Header } from "./QuestionInfoSidebar.styled";
+import {
+  Root,
+  ContentSection,
+  HeaderContainer,
+  HeaderLink,
+} from "./QuestionInfoSidebar.styled";
 
 interface QuestionInfoSidebarProps {
   question: Question;
@@ -48,7 +55,14 @@ export const QuestionInfoSidebar = ({
   return (
     <Root>
       <ContentSection>
-        <Header>{t`About`}</Header>
+        <HeaderContainer>
+          <h3>{t`About`}</h3>
+          {question.isDataset() && (
+            <HeaderLink
+              to={Urls.modelDetail(question.card())}
+            >{t`Model details`}</HeaderLink>
+          )}
+        </HeaderContainer>
         <EditableText
           initialValue={description}
           placeholder={

--- a/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar.unit.spec.js
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar.unit.spec.js
@@ -20,6 +20,11 @@ import Question from "metabase-lib/Question";
 
 import { QuestionInfoSidebar } from "./QuestionInfoSidebar";
 
+// eslint-disable-next-line react/display-name, react/prop-types
+jest.mock("metabase/core/components/Link", () => ({ to, ...props }) => (
+  <a {...props} href={to} />
+));
+
 const BASE_QUESTION = {
   id: 1,
   name: "Q1",
@@ -165,6 +170,23 @@ describe("QuestionInfoSidebar", () => {
     it("should show verification badge if verified", async () => {
       await setup({ question: getQuestion() });
       expect(screen.getByText(/verified this/)).toBeInTheDocument();
+    });
+  });
+
+  describe("model detail link", () => {
+    it("is shown for models", async () => {
+      const model = getDataset();
+      await setup({ question: model });
+
+      const link = screen.getByText("Model details");
+
+      expect(link).toBeInTheDocument();
+      expect(link).toHaveAttribute("href", `${model.getUrl()}/detail`);
+    });
+
+    it("isn't shown for questions", async () => {
+      await setup({ question: getQuestion() });
+      expect(screen.queryByText("Model details")).not.toBeInTheDocument();
     });
   });
 

--- a/frontend/test/metabase/collections/BaseItemsTable.unit.spec.js
+++ b/frontend/test/metabase/collections/BaseItemsTable.unit.spec.js
@@ -75,4 +75,27 @@ describe("Collections BaseItemsTable", () => {
       moment(timestamp).format(`${DEFAULT_DATE_STYLE}, ${DEFAULT_TIME_STYLE}`),
     );
   });
+
+  it("doesn't show model detail page link", () => {
+    setup();
+    expect(screen.queryByTestId("model-detail-link")).not.toBeInTheDocument();
+  });
+
+  describe("models", () => {
+    const model = getCollectionItem({
+      id: 1,
+      name: "Order",
+      model: "dataset",
+      url: "/model/1",
+    });
+
+    it("shows model detail page link", () => {
+      setup({ items: [model] });
+      expect(screen.getByTestId("model-detail-link")).toBeInTheDocument();
+      expect(screen.getByTestId("model-detail-link")).toHaveAttribute(
+        "href",
+        "/model/1-order/detail",
+      );
+    });
+  });
 });

--- a/frontend/test/metabase/collections/BaseItemsTable.unit.spec.js
+++ b/frontend/test/metabase/collections/BaseItemsTable.unit.spec.js
@@ -10,22 +10,39 @@ import {
 
 import BaseItemsTable from "metabase/collections/components/BaseItemsTable";
 
-describe("Collections BaseItemsTable", () => {
-  const timestamp = "2021-06-03T19:46:52.128";
+// eslint-disable-next-line react/display-name, react/prop-types
+jest.mock("metabase/core/components/Link", () => ({ to, ...props }) => (
+  <a {...props} href={to} />
+));
 
-  const ITEM = {
-    id: 1,
-    model: "dashboard",
-    name: "Test Dashboard",
+const timestamp = "2021-06-03T19:46:52.128";
+
+function getCollectionItem({
+  id = 1,
+  model = "dashboard",
+  name = "My Item",
+  icon = "dashboard",
+  url = "/dashboard/1",
+  ...rest
+} = {}) {
+  return {
     "last-edit-info": {
       id: 1,
       first_name: "John",
       last_name: "Doe",
-      timestamp: timestamp,
+      timestamp,
     },
-    getIcon: () => ({ name: "dashboard" }),
-    getUrl: () => "/dashboard/1",
+    ...rest,
+    id,
+    model,
+    name,
+    getIcon: () => icon,
+    getUrl: () => url,
   };
+}
+
+describe("Collections BaseItemsTable", () => {
+  const ITEM = getCollectionItem();
 
   function setup({ items = [ITEM], ...props } = {}) {
     return renderWithProviders(

--- a/frontend/test/metabase/lib/urls.unit.spec.js
+++ b/frontend/test/metabase/lib/urls.unit.spec.js
@@ -5,6 +5,7 @@ import {
   dashboard,
   question,
   model,
+  modelDetail,
   modelEditor,
   extractQueryParams,
   extractEntityId,
@@ -163,6 +164,14 @@ describe("urls", () => {
       expect(
         model({ id: 1, dataset: true, name: "Foo" }, { objectId: 4 }),
       ).toBe("/model/1-foo/4");
+    });
+
+    describe("detail page", () => {
+      it("should return correct URL", () => {
+        expect(modelDetail({ id: 1, dataset: true, name: "Foo" })).toBe(
+          "/model/1-foo/detail",
+        );
+      });
     });
 
     describe("editor", () => {


### PR DESCRIPTION
Epic #27581, milestone 1

Adds links around models leading people to the model detail page.

### To Verify

1. Pin a model inside a collection
2. Hover the pinned item card, and ensure you can see a "reference" (book) icon that leads to the model detail
3. Unpin the model
4. Hover its table row, to ensure you can see a "reference" (book) icon that leads to the model detail
5. Open the model in chill mode, and click the "info" icon at the top right to open the info sidebar. Ensure there's a link to the model detail page right next to the "About" next

### Demo

https://user-images.githubusercontent.com/17258145/211818977-c5452bd9-ab2d-43cd-8ed0-f192b9eb8178.mp4

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/27628)
<!-- Reviewable:end -->
