### PR TITLE
Bump clj-kondo to 2023.01.16

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -423,7 +423,7 @@
   metabase.test/with-temp-file                                                         clojure.core/let
   metabase.test/with-user-in-groups                                                    clojure.core/let
   metabase.util.files/with-open-path-to-resource                                       clojure.core/let
-  metabase.util.malli/defn                                                             schema.core/defn
+  metabase.util.malli/defn                                                             clj-kondo.lint-as/def-catch-all
   metabase.util.ssh/with-ssh-tunnel                                                    clojure.core/let
   monger.operators/defoperator                                                         clojure.core/def
   potemkin.types/defprotocol+                                                          clojure.core/defprotocol
@@ -644,6 +644,9 @@
    metabase.test/with-temp-env-var-value                                        macros.metabase.test.util/with-temp-env-var-value
    metabase.test/with-temporary-raw-setting-values                              macros.metabase.test.util/with-temporary-raw-setting-values
    toucan.models/defmodel                                                       macros.toucan.models/defmodel}}
+
+ :config-in-call
+ {metabase.util.honey-sql-2-extensions/with-database-type-info {:linters {:type-mismatch {:level :off}}}}
 
  :config-in-comment
  {:linters {:unresolved-symbol {:level :off}}}

--- a/.clj-kondo/hooks/common.clj
+++ b/.clj-kondo/hooks/common.clj
@@ -41,11 +41,14 @@
 ;;;; Common hook definitions
 
 (defn do*
-  "This is basically the same as [[clojure.core/do]] but doesn't cause Kondo to complain about redundant dos."
+  "This is the same idea as [[clojure.core/do]] but doesn't cause Kondo to complain about redundant dos."
+  ;; This used to use `do` as the token-node, but as of version 2022.10.14 that resulted in warnings about
+  ;; unused variables since Kondo was smart enough to realize that we sometimes were calling pure functions early in
+  ;; the `do` and the value was getting thrown away. `print` tricks Kondo into thinking everything is used.
   [{{[_ & args] :children} :node}]
   (let [node* (hooks/list-node
                (list*
-                (hooks/token-node 'do)
+                (hooks/token-node 'print)
                 args))]
     {:node node*}))
 

--- a/.clj-kondo/hooks/metabase/test/data.clj
+++ b/.clj-kondo/hooks/metabase/test/data.clj
@@ -60,11 +60,14 @@
                       body)
 
                ;; for ones that came from the dataset defs namespace or ones whose origin is unknown, just ignore them
-               ;; and generate a `do` form:
+               ;; and generate a `print` form:
                ;;
-               ;;    (do ...)
+               ;;    (print ...)
+               ;;
+               ;; (this used to be a `do` form (which makes a lot more semantic sense), but that resulted in warnings
+               ;; about unused values
                (:unqualified/from-dataset-defs-namespace :unqualified/unknown)
-               (list* (hooks/token-node 'do)
+               (list* (hooks/token-node 'print)
                       body))]
     {:node (with-meta (hooks/list-node (with-meta body
                                                   (meta dataset)))

--- a/.clj-kondo/macros/metabase/test/util.clj
+++ b/.clj-kondo/macros/metabase/test/util.clj
@@ -1,11 +1,11 @@
 (ns macros.metabase.test.util)
 
 (defmacro with-temp-env-var-value [bindings & body]
-  `(do
-     ~@(map second (partition-all 2 bindings))
-     ~@body))
+  `(print
+    ~@(map second (partition-all 2 bindings))
+    ~@body))
 
 (defmacro with-temporary-raw-setting-values [bindings & body]
-  `(do
+  `(print
      ~@(map second (partition-all 2 bindings))
      ~@body))

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -51,7 +51,8 @@ jobs:
       run: >-
         docker run
         --volume $PWD:/work
-        --rm cljkondo/clj-kondo:2022.08.03
+        --rm
+        cljkondo/clj-kondo:2023.01.16
         clj-kondo
         --config /work/.clj-kondo/config.edn
         --config-dir /work/.clj-kondo

--- a/deps.edn
+++ b/deps.edn
@@ -199,7 +199,7 @@
   {:extra-deps
    {clj-http-fake/clj-http-fake  {:mvn/version "1.0.3"
                                   :exclusions  [slingshot/slingshot]}
-    clj-kondo/clj-kondo          {:mvn/version "2022.08.03"}                ; this is not for RUNNING kondo, but so we can hack on custom hooks code from the REPL.
+    clj-kondo/clj-kondo          {:mvn/version "2023.01.16"}                ; this is not for RUNNING kondo, but so we can hack on custom hooks code from the REPL.
     cloverage/cloverage          {:mvn/version "1.2.4"}
     com.gfredericks/test.chuck   {:mvn/version "0.2.13"}                    ; generating strings from regexes (useful with malli)
     djblue/portal                {:mvn/version "0.35.0"}                    ; ui for inspecting values

--- a/src/metabase/models/pulse.clj
+++ b/src/metabase/models/pulse.clj
@@ -259,7 +259,7 @@
   "Fetch an Alert or Pulse, and do the 'standard' hydrations, adding `:channels` with `:recipients`, `:creator`, and
   `:cards`."
   [notification-or-id & additional-conditions]
-  (some-> (apply Pulse :id (u/the-id notification-or-id), additional-conditions)
+  (some-> (apply db/select-one Pulse :id (u/the-id notification-or-id), additional-conditions)
           hydrate-notification))
 
 (s/defn ^:private notification->alert :- (mi/InstanceOf Pulse)

--- a/src/metabase/related.clj
+++ b/src/metabase/related.clj
@@ -133,7 +133,7 @@
     (->> (db/select-field :table_id Field
            :fk_target_field_id [:in fields]
            :active             true)
-         (map Table)
+         (map (partial db/select-one Table :id))
          filter-visible
          (take max-matches))
     []))
@@ -145,7 +145,7 @@
     (->> (db/select-field :card_id DashboardCard
            :dashboard_id [:in dashboards]
            :card_id      [:not= (:id card)])
-         (map Card)
+         (map (partial db/select-one Card :id))
          filter-visible
          (take max-matches))
     []))
@@ -175,7 +175,7 @@
          :model     "Dashboard"
          :user_id   api/*current-user-id*
          {:order-by [[:timestamp :desc]]})
-       (map Dashboard)
+       (map (partial db/select-one Dashboard :id))
        filter-visible
        (take max-serendipity-matches)))
 
@@ -193,7 +193,7 @@
         best             (->> cards
                               (mapcat (comp card->dashboards :id))
                               distinct
-                              (map Dashboard)
+                              (map (partial db/select-one Dashboard :id))
                               filter-visible
                               (take max-best-matches))]
     (concat best recent)))
@@ -302,8 +302,8 @@
 
 (defmethod related Dashboard
   [dashboard]
-  (let [cards (map Card (db/select-field :card_id DashboardCard
-                          :dashboard_id (:id dashboard)))]
+  (let [cards (map (partial db/select-one Card :id) (db/select-field :card_id DashboardCard
+                                                      :dashboard_id (:id dashboard)))]
     {:cards (->> cards
                  (mapcat (comp similar-questions))
                  (remove (set cards))

--- a/test/metabase/test_runner/assert_exprs/approximately_equal.clj
+++ b/test/metabase/test_runner/assert_exprs/approximately_equal.clj
@@ -100,6 +100,7 @@
 
 (set! *warn-on-reflection* true)
 
+#_{:clj-kondo/ignore [:dynamic-var-not-earmuffed]}
 (methodical/defmulti ^:dynamic =?-diff
   "Multimethod to use to diff two things with `=?`. Despite not having earmuffs, this is dynamic so it can be rebound at
   runtime."

--- a/test/metabase/util/honey_sql_2_extensions_test.clj
+++ b/test/metabase/util/honey_sql_2_extensions_test.clj
@@ -8,6 +8,14 @@
    [metabase.util.honey-sql-2-extensions :as h2x]
    [metabase.util.honeysql-extensions :as hx]))
 
+;; HACK: Workaround for Kondo incorrectly type-checking the original function. (It's a mu/defn-ed function, which
+;; we're linting as if it were defined with schema.core/defn. So Kondo is treating the Malli types as Schema types and
+;; getting confused. Adding this indirection is enough to subvert it. See discussion at
+;; https://metaboat.slack.com/archives/CKZEMT1MJ/p1673966596589579
+(defn- with-database-type-info
+  [hsql type-string]
+  (h2x/with-database-type-info hsql type-string))
+
 (deftest ^:parallel custom-functions-test
   (testing `::h2x/extract
     (is (= ["extract(a from b)"]
@@ -193,14 +201,14 @@
 (deftest ^:parallel with-database-type-info-test
   (testing "should be the same as calling `with-type-info` with `::hx/database-type`"
     (is (= (h2x/with-type-info :field {::hx/database-type "date"})
-           (h2x/with-database-type-info :field "date"))))
+           (with-database-type-info :field "date"))))
   (testing "Passing `nil` should"
     (testing "return untyped clause as-is"
       (is (= :field
-             (h2x/with-database-type-info :field nil))))
+             (with-database-type-info :field nil))))
     (testing "unwrap a typed clause"
       (is (= :field
-             (h2x/with-database-type-info (h2x/with-database-type-info :field "date") nil))))))
+             (with-database-type-info (with-database-type-info :field "date") nil))))))
 
 (deftest ^:parallel is-of-type?-test
   (are [expr tyype expected] (= expected (h2x/is-of-type? expr tyype))
@@ -232,8 +240,8 @@
   (testing "Math operators like `+` should propagate the type info of their args\n"
     ;; just pass along type info of the first arg with type info.
     (doseq [f [#'h2x/+ #'h2x/- #'h2x/* #'h2x// #'h2x/mod]
-            x [(h2x/with-database-type-info 1 "int") 1]
-            y [(h2x/with-database-type-info 2 "INT") 2]]
+            x [(with-database-type-info 1 "int") 1]
+            y [(with-database-type-info 2 "INT") 2]]
       (testing (str (pr-str (list f x y)) \newline)
         (let [expr (f x y)]
           (testing (pr-str expr)


### PR DESCRIPTION
Due to a bug in Kondo we were reloading our hook code on every usage. That's fixed as of yesterday, so in theory the new version will be more performant for us.

The `mu/defn` situation is unfortunate; see discussion [here](https://metaboat.slack.com/archives/CKZEMT1MJ/p1673966596589579). Everything else is explained in in-line comments.