### PR TITLE
Refactor PivotTable Visualization into a functional typescript component

### DIFF
--- a/frontend/src/metabase-types/api/card.ts
+++ b/frontend/src/metabase-types/api/card.ts
@@ -46,6 +46,15 @@ export type SeriesOrderSetting = {
   color?: string;
 };
 
+export type ColumnFormattingSetting = {
+  columns: string[]; // column names
+  color?: string;
+  type?: string;
+  operator?: string;
+  value?: string | number;
+  highlight_row?: boolean;
+};
+
 export type VisualizationSettings = {
   "graph.show_values"?: boolean;
   "stackable.stack_type"?: "stacked" | "normalized" | null;
@@ -76,6 +85,8 @@ export type VisualizationSettings = {
 
   // Funnel settings
   "funnel.rows"?: SeriesOrderSetting[];
+
+  "table.column_formatting": ColumnFormattingSetting[];
 
   [key: string]: any;
 };

--- a/frontend/src/metabase-types/api/card.ts
+++ b/frontend/src/metabase-types/api/card.ts
@@ -55,6 +55,11 @@ export type ColumnFormattingSetting = {
   highlight_row?: boolean;
 };
 
+export type PivotTableCollapsedRowsSetting = {
+  rows: FieldOrAggregationReference[];
+  value: string[]; // identifiers for collapsed rows
+};
+
 export type VisualizationSettings = {
   "graph.show_values"?: boolean;
   "stackable.stack_type"?: "stacked" | "normalized" | null;
@@ -86,7 +91,8 @@ export type VisualizationSettings = {
   // Funnel settings
   "funnel.rows"?: SeriesOrderSetting[];
 
-  "table.column_formatting": ColumnFormattingSetting[];
+  "table.column_formatting"?: ColumnFormattingSetting[];
+  "pivot_table.collapsed_rows"?: PivotTableCollapsedRowsSetting;
 
   [key: string]: any;
 };

--- a/frontend/src/metabase-types/api/card.ts
+++ b/frontend/src/metabase-types/api/card.ts
@@ -1,6 +1,10 @@
 import type { DatabaseId } from "./database";
 import type { Field } from "./field";
-import type { DatasetQuery } from "./query";
+import type {
+  DatasetQuery,
+  FieldReference,
+  AggregationReference,
+} from "./query";
 
 export interface Card extends UnsavedCard {
   id: CardId;
@@ -56,7 +60,7 @@ export type ColumnFormattingSetting = {
 };
 
 export type PivotTableCollapsedRowsSetting = {
-  rows: FieldOrAggregationReference[];
+  rows: (FieldReference | AggregationReference)[];
   value: string[]; // identifiers for collapsed rows
 };
 

--- a/frontend/src/metabase/visualizations/lib/settings/column.js
+++ b/frontend/src/metabase/visualizations/lib/settings/column.js
@@ -26,6 +26,7 @@ const DEFAULT_GET_COLUMNS = (series, vizSettings) =>
 
 export function columnSettings({
   getColumns = DEFAULT_GET_COLUMNS,
+  hidden,
   ...def
 } = {}) {
   return nestedSettings("column_settings", {
@@ -37,6 +38,7 @@ export function columnSettings({
     component: ChartNestedSettingColumns,
     getInheritedSettingsForObject: getInhertiedSettingsForColumn,
     useRawSeries: true,
+    hidden,
     ...def,
   });
 }

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTable.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTable.jsx
@@ -152,9 +152,10 @@ function PivotTable({
     return getLeftHeaderWidths({
       rowIndexes: rowIndexes,
       getColumnTitle: idx => getColumnTitle(idx),
+      leftHeaderItems: pivoted.leftHeaderItems,
       fontFamily: fontFamily,
     });
-  }, [rowIndexes, fontFamily, getColumnTitle]);
+  }, [rowIndexes, fontFamily, pivoted.leftHeaderItems, getColumnTitle]);
 
   if (pivoted === null) {
     return null;

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTable.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTable.jsx
@@ -1,5 +1,11 @@
 /* eslint-disable react/prop-types */
-import React, { useEffect, useMemo, useCallback } from "react";
+import React, {
+  useEffect,
+  useMemo,
+  useCallback,
+  useRef,
+  useState,
+} from "react";
 import { t } from "ttag";
 import { Grid, Collection, ScrollSync, AutoSizer } from "react-virtualized";
 import { findDOMNode } from "react-dom";
@@ -52,15 +58,10 @@ function PivotTable({
   fontFamily,
   onVisualizationClick,
 }) {
-  console.log("render");
-  let grid;
-  let bodyRef;
-  let topHeaderRef;
-  let leftHeaderRef;
-
-  // const setBodyRef = element => {
-  //   bodyRef = element;
-  // };
+  const [gridElement, setGridElement] = useState(null);
+  const bodyRef = useRef(null);
+  const leftHeaderRef = useRef(null);
+  const topHeaderRef = useRef(null);
 
   const getColumnTitle = useCallback(
     function (columnIndex) {
@@ -83,12 +84,14 @@ function PivotTable({
 
   useEffect(() => {
     // This is needed in case the cell counts didn't change, but the data did
-    leftHeaderRef && leftHeaderRef.recomputeCellSizesAndPositions();
-    topHeaderRef && topHeaderRef.recomputeCellSizesAndPositions();
+    leftHeaderRef.current &&
+      leftHeaderRef.current.recomputeCellSizesAndPositions();
+    topHeaderRef.current &&
+      topHeaderRef.current.recomputeCellSizesAndPositions();
   }, [data, leftHeaderRef, topHeaderRef]);
 
   useOnMount(() => {
-    grid = bodyRef && findDOMNode(bodyRef);
+    setGridElement(bodyRef.current && findDOMNode(bodyRef.current));
   });
 
   const pivoted = useMemo(() => {
@@ -107,12 +110,13 @@ function PivotTable({
   // In cases where there are horizontal scrollbars are visible AND the data grid has to scroll vertically as well,
   // the left sidebar and the main grid can get out of ScrollSync due to slightly differing heights
   function scrollBarOffsetSize() {
-    if (!grid) {
+    if (!gridElement) {
       return 0;
     }
     // get the size of the scrollbars
     const scrollBarSize = getScrollBarSize();
-    const scrollsHorizontally = grid.scrollWidth > parseInt(grid.style.width);
+    const scrollsHorizontally =
+      gridElement.scrollWidth > parseInt(gridElement.style.width);
 
     if (scrollsHorizontally && scrollBarSize > 0) {
       return scrollBarSize;
@@ -181,6 +185,7 @@ function PivotTable({
       // </div>
     );
   };
+
   const leftHeaderCellSizeAndPositionGetter = ({ index }) => {
     const { offset, span, depth, maxDepthBelow } = leftHeaderItems[index];
 
@@ -407,4 +412,5 @@ export default Object.assign(connect(mapStateToProps)(PivotTable), {
   isLiveResizable: () => false,
   seriesAreCompatible: () => false,
 });
+
 export { PivotTable };

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTable.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTable.jsx
@@ -42,6 +42,8 @@ import {
   databaseSupportsPivotTables,
   isSensible,
   checkRenderable,
+  leftHeaderCellSizeAndPositionGetter,
+  topHeaderCellSizeAndPositionGetter,
 } from "./utils";
 
 import { CELL_WIDTH, CELL_HEIGHT, LEFT_HEADER_LEFT_SPACING } from "./constants";
@@ -158,43 +160,10 @@ function PivotTable({
     return null;
   }
 
-  const leftHeaderCellSizeAndPositionGetter = ({ index }) => {
-    const { offset, span, depth, maxDepthBelow } = leftHeaderItems[index];
-
-    const columnsToSpan = rowIndexes.length - depth - maxDepthBelow;
-
-    // add up all the widths of the columns, other than itself, that this cell spans
-    const spanWidth = leftHeaderWidths
-      .slice(depth + 1, depth + columnsToSpan)
-      .reduce((acc, cellWidth) => acc + cellWidth, 0);
-    const columnPadding = depth === 0 ? LEFT_HEADER_LEFT_SPACING : 0;
-    const columnWidth = leftHeaderWidths[depth];
-
-    return {
-      height: span * CELL_HEIGHT,
-      width: columnWidth + spanWidth + columnPadding,
-      x:
-        leftHeaderWidths
-          .slice(0, depth)
-          .reduce((acc, cellWidth) => acc + cellWidth, 0) +
-        (depth > 0 ? LEFT_HEADER_LEFT_SPACING : 0),
-      y: offset * CELL_HEIGHT,
-    };
-  };
-
   const topHeaderRows =
     columnIndexes.length + (valueIndexes.length > 1 ? 1 : 0) || 1;
-  const topHeaderHeight = topHeaderRows * CELL_HEIGHT;
 
-  const topHeaderCellSizeAndPositionGetter = ({ index }) => {
-    const { offset, span, maxDepthBelow } = topHeaderItems[index];
-    return {
-      height: CELL_HEIGHT,
-      width: span * CELL_WIDTH,
-      x: offset * CELL_WIDTH,
-      y: (topHeaderRows - maxDepthBelow - 1) * CELL_HEIGHT,
-    };
-  };
+  const topHeaderHeight = topHeaderRows * CELL_HEIGHT;
 
   const leftHeaderWidth =
     rowIndexes.length > 0 ? LEFT_HEADER_LEFT_SPACING + totalHeaderWidths : 0;
@@ -283,7 +252,12 @@ function PivotTable({
                     isNightMode={isNightMode}
                   />
                 )}
-                cellSizeAndPositionGetter={topHeaderCellSizeAndPositionGetter}
+                cellSizeAndPositionGetter={({ index }) =>
+                  topHeaderCellSizeAndPositionGetter(
+                    topHeaderItems[index],
+                    topHeaderRows,
+                  )
+                }
                 onScroll={({ scrollLeft }) => onScroll({ scrollLeft })}
                 scrollLeft={scrollLeft}
               />
@@ -311,8 +285,12 @@ function PivotTable({
                           getCellClickHandler={getCellClickHandler}
                         />
                       )}
-                      cellSizeAndPositionGetter={
-                        leftHeaderCellSizeAndPositionGetter
+                      cellSizeAndPositionGetter={({ index }) =>
+                        leftHeaderCellSizeAndPositionGetter(
+                          leftHeaderItems[index],
+                          leftHeaderWidths,
+                          rowIndexes,
+                        )
                       }
                       width={leftHeaderWidth}
                       height={height - scrollBarOffsetSize()}

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTable.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTable.jsx
@@ -1,12 +1,13 @@
 /* eslint-disable react/prop-types */
-import React, { Component } from "react";
+import React, { useEffect, useMemo, useCallback } from "react";
 import { t } from "ttag";
 import { Grid, Collection, ScrollSync, AutoSizer } from "react-virtualized";
-
 import { findDOMNode } from "react-dom";
 import { connect } from "react-redux";
+
 import { getScrollBarSize } from "metabase/lib/dom";
 import { getSetting } from "metabase/selectors/settings";
+import { useOnMount } from "metabase/hooks/use-on-mount";
 
 import {
   COLUMN_SHOW_TOTALS,
@@ -33,7 +34,6 @@ import {
 } from "./utils";
 
 import { CELL_WIDTH, CELL_HEIGHT, LEFT_HEADER_LEFT_SPACING } from "./constants";
-
 import { settings, _columnSettings as columnSettings } from "./settings";
 
 const mapStateToProps = state => ({
@@ -41,22 +41,39 @@ const mapStateToProps = state => ({
   fontFamily: getSetting(state, "application-font"),
 });
 
-class PivotTable extends Component {
-  setBodyRef = element => {
-    this.bodyRef = element;
-  };
+function PivotTable({
+  data,
+  settings,
+  width,
+  hasCustomColors,
+  onUpdateVisualizationSettings,
+  isNightMode,
+  isDashboard,
+  fontFamily,
+  onVisualizationClick,
+}) {
+  console.log("render");
+  let grid;
+  let bodyRef;
+  let topHeaderRef;
+  let leftHeaderRef;
 
-  getColumnTitle(columnIndex) {
-    const { data, settings } = this.props;
-    const columns = data.cols.filter(col => !isPivotGroupColumn(col));
-    const { column, column_title: columnTitle } = settings.column(
-      columns[columnIndex],
-    );
-    return columnTitle || formatColumn(column);
-  }
+  // const setBodyRef = element => {
+  //   bodyRef = element;
+  // };
 
-  isColumnCollapsible(columnIndex) {
-    const { data, settings } = this.props;
+  const getColumnTitle = useCallback(
+    function (columnIndex) {
+      const columns = data.cols.filter(col => !isPivotGroupColumn(col));
+      const { column, column_title: columnTitle } = settings.column(
+        columns[columnIndex],
+      );
+      return columnTitle || formatColumn(column);
+    },
+    [data, settings],
+  );
+
+  function isColumnCollapsible(columnIndex) {
     const columns = data.cols.filter(col => !isPivotGroupColumn(col));
     const { [COLUMN_SHOW_TOTALS]: showTotals } = settings.column(
       columns[columnIndex],
@@ -64,319 +81,318 @@ class PivotTable extends Component {
     return showTotals;
   }
 
-  componentDidUpdate() {
+  useEffect(() => {
     // This is needed in case the cell counts didn't change, but the data did
-    this.leftHeaderRef && this.leftHeaderRef.recomputeCellSizesAndPositions();
-    this.topHeaderRef && this.topHeaderRef.recomputeCellSizesAndPositions();
-  }
+    leftHeaderRef && leftHeaderRef.recomputeCellSizesAndPositions();
+    topHeaderRef && topHeaderRef.recomputeCellSizesAndPositions();
+  }, [data, leftHeaderRef, topHeaderRef]);
 
-  componentDidMount() {
-    this.grid = this.bodyRef && findDOMNode(this.bodyRef);
-  }
+  useOnMount(() => {
+    grid = bodyRef && findDOMNode(bodyRef);
+  });
 
-  render() {
-    const {
-      settings,
-      data,
-      width,
-      hasCustomColors,
-      onUpdateVisualizationSettings,
-      isNightMode,
-      isDashboard,
-      fontFamily,
-    } = this.props;
+  const pivoted = useMemo(() => {
     if (data == null || !data.cols.some(isPivotGroupColumn)) {
       return null;
     }
 
-    const grid = this.grid;
-
-    // In cases where there are horizontal scrollbars are visible AND the data grid has to scroll vertically as well,
-    // the left sidebar and the main grid can get out of ScrollSync due to slightly differing heights
-    function scrollBarOffsetSize() {
-      if (!grid) {
-        return 0;
-      }
-      // get the size of the scrollbars
-      const scrollBarSize = getScrollBarSize();
-      const scrollsHorizontally = grid.scrollWidth > parseInt(grid.style.width);
-
-      if (scrollsHorizontally && scrollBarSize > 0) {
-        return scrollBarSize;
-      } else {
-        return 0;
-      }
-    }
-
-    let pivoted;
     try {
-      pivoted = multiLevelPivot(data, settings);
+      return multiLevelPivot(data, settings);
     } catch (e) {
       console.warn(e);
     }
-    const {
-      leftHeaderItems,
-      topHeaderItems,
-      rowCount,
-      columnCount,
-      rowIndex,
-      getRowSection,
-      rowIndexes,
-      columnIndexes,
-      valueIndexes,
-    } = pivoted;
+    return {};
+  }, [data, settings]);
 
-    const { leftHeaderWidths, totalHeaderWidths } = getLeftHeaderWidths({
-      rowIndexes: rowIndexes ?? [],
-      getColumnTitle: idx => this.getColumnTitle(idx),
-      leftHeaderItems,
-      fontFamily: fontFamily,
-    });
+  // In cases where there are horizontal scrollbars are visible AND the data grid has to scroll vertically as well,
+  // the left sidebar and the main grid can get out of ScrollSync due to slightly differing heights
+  function scrollBarOffsetSize() {
+    if (!grid) {
+      return 0;
+    }
+    // get the size of the scrollbars
+    const scrollBarSize = getScrollBarSize();
+    const scrollsHorizontally = grid.scrollWidth > parseInt(grid.style.width);
 
-    const leftHeaderCellRenderer = ({ index, key, style }) => {
-      const { value, isSubtotal, hasSubtotal, depth, path, clicked } =
-        leftHeaderItems[index];
-
-      return (
-        <Cell
-          key={key}
-          style={{
-            ...style,
-            ...(depth === 0 ? { paddingLeft: LEFT_HEADER_LEFT_SPACING } : {}),
-          }}
-          isNightMode={isNightMode}
-          value={value}
-          isEmphasized={isSubtotal}
-          isBold={isSubtotal}
-          onClick={this.getCellClickHander(clicked)}
-          icon={
-            (isSubtotal || hasSubtotal) && (
-              <RowToggleIcon
-                value={path}
-                settings={settings}
-                updateSettings={onUpdateVisualizationSettings}
-                hideUnlessCollapsed={isSubtotal}
-                rowIndex={rowIndex} // used to get a list of "other" paths when open one item in a collapsed column
-                isNightMode={isNightMode}
-              />
-            )
-          }
-        />
-        // </div>
-      );
-    };
-    const leftHeaderCellSizeAndPositionGetter = ({ index }) => {
-      const { offset, span, depth, maxDepthBelow } = leftHeaderItems[index];
-
-      const columnsToSpan = rowIndexes.length - depth - maxDepthBelow;
-
-      // add up all the widths of the columns, other than itself, that this cell spans
-      const spanWidth = leftHeaderWidths
-        .slice(depth + 1, depth + columnsToSpan)
-        .reduce((acc, cellWidth) => acc + cellWidth, 0);
-      const columnPadding = depth === 0 ? LEFT_HEADER_LEFT_SPACING : 0;
-      const columnWidth = leftHeaderWidths[depth];
-
-      return {
-        height: span * CELL_HEIGHT,
-        width: columnWidth + spanWidth + columnPadding,
-        x:
-          leftHeaderWidths
-            .slice(0, depth)
-            .reduce((acc, cellWidth) => acc + cellWidth, 0) +
-          (depth > 0 ? LEFT_HEADER_LEFT_SPACING : 0),
-        y: offset * CELL_HEIGHT,
-      };
-    };
-
-    const topHeaderRows =
-      columnIndexes.length + (valueIndexes.length > 1 ? 1 : 0) || 1;
-    const topHeaderHeight = topHeaderRows * CELL_HEIGHT;
-
-    const topHeaderCellRenderer = ({ index, key, style }) => {
-      const { value, hasChildren, clicked, isSubtotal, maxDepthBelow } =
-        topHeaderItems[index];
-      return (
-        <Cell
-          key={key}
-          style={{
-            ...style,
-          }}
-          value={value}
-          isNightMode={isNightMode}
-          isBorderedHeader={maxDepthBelow === 0}
-          isEmphasized={hasChildren}
-          isBold={isSubtotal}
-          onClick={this.getCellClickHander(clicked)}
-        />
-      );
-    };
-    const topHeaderCellSizeAndPositionGetter = ({ index }) => {
-      const { offset, span, maxDepthBelow } = topHeaderItems[index];
-      return {
-        height: CELL_HEIGHT,
-        width: span * CELL_WIDTH,
-        x: offset * CELL_WIDTH,
-        y: (topHeaderRows - maxDepthBelow - 1) * CELL_HEIGHT,
-      };
-    };
-
-    const leftHeaderWidth =
-      rowIndexes.length > 0 ? LEFT_HEADER_LEFT_SPACING + totalHeaderWidths : 0;
-
-    // These are tied to the `multiLevelPivot` call, so they're awkwardly shoved in render for now
-
-    const bodyRenderer = ({ key, style, rowIndex, columnIndex }) => (
-      <div key={key} style={style} className="flex">
-        {getRowSection(columnIndex, rowIndex).map(
-          ({ value, isSubtotal, clicked, backgroundColor }, index) => (
-            <Cell
-              isNightMode={isNightMode}
-              key={index}
-              value={value}
-              isEmphasized={isSubtotal}
-              isBold={isSubtotal}
-              isBody
-              onClick={this.getCellClickHander(clicked)}
-              backgroundColor={backgroundColor}
-            />
-          ),
-        )}
-      </div>
-    );
-
-    return (
-      <PivotTableRoot
-        isDashboard={isDashboard}
-        isNightMode={isNightMode}
-        data-testid="pivot-table"
-      >
-        <ScrollSync>
-          {({ onScroll, scrollLeft, scrollTop }) => (
-            <div className="full-height flex flex-column">
-              <div className="flex" style={{ height: topHeaderHeight }}>
-                {/* top left corner - displays left header columns */}
-                <PivotTableTopLeftCellsContainer
-                  isNightMode={isNightMode}
-                  style={{
-                    width: leftHeaderWidth,
-                  }}
-                >
-                  {rowIndexes.map((rowIndex, index) => (
-                    <Cell
-                      key={rowIndex}
-                      isEmphasized
-                      isBold
-                      isBorderedHeader
-                      isTransparent
-                      hasTopBorder={topHeaderRows > 1}
-                      isNightMode={isNightMode}
-                      value={this.getColumnTitle(rowIndex)}
-                      style={{
-                        flex: "0 0 auto",
-                        width:
-                          leftHeaderWidths?.[index] +
-                          (index === 0 ? LEFT_HEADER_LEFT_SPACING : 0),
-                        ...(index === 0
-                          ? { paddingLeft: LEFT_HEADER_LEFT_SPACING }
-                          : {}),
-                        ...(index === rowIndexes.length - 1
-                          ? { borderRight: "none" }
-                          : {}),
-                      }}
-                      icon={
-                        // you can only collapse before the last column
-                        index < rowIndexes.length - 1 &&
-                        this.isColumnCollapsible(rowIndex) && (
-                          <RowToggleIcon
-                            value={index + 1}
-                            settings={settings}
-                            updateSettings={onUpdateVisualizationSettings}
-                            hasCustomColors={hasCustomColors}
-                            isNightMode={isNightMode}
-                          />
-                        )
-                      }
-                    />
-                  ))}
-                </PivotTableTopLeftCellsContainer>
-                {/* top header */}
-                <Collection
-                  ref={e => (this.topHeaderRef = e)}
-                  className="scroll-hide-all"
-                  isNightMode={isNightMode}
-                  width={width - leftHeaderWidth}
-                  height={topHeaderHeight}
-                  cellCount={topHeaderItems.length}
-                  cellRenderer={topHeaderCellRenderer}
-                  cellSizeAndPositionGetter={topHeaderCellSizeAndPositionGetter}
-                  onScroll={({ scrollLeft }) => onScroll({ scrollLeft })}
-                  scrollLeft={scrollLeft}
-                />
-              </div>
-              <div className="flex flex-full">
-                {/* left header */}
-                <div style={{ width: leftHeaderWidth }}>
-                  <AutoSizer disableWidth>
-                    {({ height }) => (
-                      <Collection
-                        ref={e => (this.leftHeaderRef = e)}
-                        className="scroll-hide-all"
-                        cellCount={leftHeaderItems.length}
-                        cellRenderer={leftHeaderCellRenderer}
-                        cellSizeAndPositionGetter={
-                          leftHeaderCellSizeAndPositionGetter
-                        }
-                        width={leftHeaderWidth}
-                        height={height - scrollBarOffsetSize()}
-                        scrollTop={scrollTop}
-                        onScroll={({ scrollTop }) => onScroll({ scrollTop })}
-                      />
-                    )}
-                  </AutoSizer>
-                </div>
-                {/* pivot table body */}
-                <div>
-                  <AutoSizer disableWidth>
-                    {({ height }) => (
-                      <Grid
-                        width={width - leftHeaderWidth}
-                        height={height}
-                        className="text-dark"
-                        rowCount={rowCount}
-                        columnCount={columnCount}
-                        rowHeight={CELL_HEIGHT}
-                        columnWidth={valueIndexes.length * CELL_WIDTH}
-                        cellRenderer={bodyRenderer}
-                        onScroll={({ scrollLeft, scrollTop }) =>
-                          onScroll({ scrollLeft, scrollTop })
-                        }
-                        ref={this.setBodyRef}
-                        scrollTop={scrollTop}
-                        scrollLeft={scrollLeft}
-                      />
-                    )}
-                  </AutoSizer>
-                </div>
-              </div>
-            </div>
-          )}
-        </ScrollSync>
-      </PivotTableRoot>
-    );
+    if (scrollsHorizontally && scrollBarSize > 0) {
+      return scrollBarSize;
+    } else {
+      return 0;
+    }
   }
 
-  getCellClickHander(clicked) {
+  const {
+    leftHeaderItems,
+    topHeaderItems,
+    rowCount,
+    columnCount,
+    rowIndex,
+    getRowSection,
+    rowIndexes,
+    columnIndexes,
+    valueIndexes,
+  } = pivoted ?? {};
+
+  const { leftHeaderWidths, totalHeaderWidths } = useMemo(() => {
+    if (!rowIndexes) {
+      return {};
+    }
+
+    return getLeftHeaderWidths({
+      rowIndexes: rowIndexes,
+      getColumnTitle: idx => getColumnTitle(idx),
+      fontFamily: fontFamily,
+    });
+  }, [rowIndexes, fontFamily, getColumnTitle]);
+
+  if (pivoted === null) {
+    return null;
+  }
+
+  const leftHeaderCellRenderer = ({ index, key, style }) => {
+    const { value, isSubtotal, hasSubtotal, depth, path, clicked } =
+      leftHeaderItems[index];
+
+    return (
+      <Cell
+        key={key}
+        style={{
+          ...style,
+          ...(depth === 0 ? { paddingLeft: LEFT_HEADER_LEFT_SPACING } : {}),
+        }}
+        isNightMode={isNightMode}
+        value={value}
+        isEmphasized={isSubtotal}
+        isBold={isSubtotal}
+        onClick={getCellClickHander(clicked)}
+        icon={
+          (isSubtotal || hasSubtotal) && (
+            <RowToggleIcon
+              value={path}
+              settings={settings}
+              updateSettings={onUpdateVisualizationSettings}
+              hideUnlessCollapsed={isSubtotal}
+              rowIndex={rowIndex} // used to get a list of "other" paths when open one item in a collapsed column
+              isNightMode={isNightMode}
+            />
+          )
+        }
+      />
+      // </div>
+    );
+  };
+  const leftHeaderCellSizeAndPositionGetter = ({ index }) => {
+    const { offset, span, depth, maxDepthBelow } = leftHeaderItems[index];
+
+    const columnsToSpan = rowIndexes.length - depth - maxDepthBelow;
+
+    // add up all the widths of the columns, other than itself, that this cell spans
+    const spanWidth = leftHeaderWidths
+      .slice(depth + 1, depth + columnsToSpan)
+      .reduce((acc, cellWidth) => acc + cellWidth, 0);
+    const columnPadding = depth === 0 ? LEFT_HEADER_LEFT_SPACING : 0;
+    const columnWidth = leftHeaderWidths[depth];
+
+    return {
+      height: span * CELL_HEIGHT,
+      width: columnWidth + spanWidth + columnPadding,
+      x:
+        leftHeaderWidths
+          .slice(0, depth)
+          .reduce((acc, cellWidth) => acc + cellWidth, 0) +
+        (depth > 0 ? LEFT_HEADER_LEFT_SPACING : 0),
+      y: offset * CELL_HEIGHT,
+    };
+  };
+
+  const topHeaderRows =
+    columnIndexes.length + (valueIndexes.length > 1 ? 1 : 0) || 1;
+  const topHeaderHeight = topHeaderRows * CELL_HEIGHT;
+
+  const topHeaderCellRenderer = ({ index, key, style }) => {
+    const { value, hasChildren, clicked, isSubtotal, maxDepthBelow } =
+      topHeaderItems[index];
+    return (
+      <Cell
+        key={key}
+        style={{
+          ...style,
+        }}
+        value={value}
+        isNightMode={isNightMode}
+        isBorderedHeader={maxDepthBelow === 0}
+        isEmphasized={hasChildren}
+        isBold={isSubtotal}
+        onClick={getCellClickHander(clicked)}
+      />
+    );
+  };
+
+  const topHeaderCellSizeAndPositionGetter = ({ index }) => {
+    const { offset, span, maxDepthBelow } = topHeaderItems[index];
+    return {
+      height: CELL_HEIGHT,
+      width: span * CELL_WIDTH,
+      x: offset * CELL_WIDTH,
+      y: (topHeaderRows - maxDepthBelow - 1) * CELL_HEIGHT,
+    };
+  };
+
+  const leftHeaderWidth =
+    rowIndexes.length > 0 ? LEFT_HEADER_LEFT_SPACING + totalHeaderWidths : 0;
+
+  // These are tied to the `multiLevelPivot` call, so they're awkwardly shoved in render for now
+
+  const bodyRenderer = ({ key, style, rowIndex, columnIndex }) => (
+    <div key={key} style={style} className="flex">
+      {getRowSection(columnIndex, rowIndex).map(
+        ({ value, isSubtotal, clicked, backgroundColor }, index) => (
+          <Cell
+            isNightMode={isNightMode}
+            key={index}
+            value={value}
+            isEmphasized={isSubtotal}
+            isBold={isSubtotal}
+            isBody
+            onClick={getCellClickHander(clicked)}
+            backgroundColor={backgroundColor}
+          />
+        ),
+      )}
+    </div>
+  );
+
+  function getCellClickHander(clicked) {
     if (!clicked) {
       return null;
     }
     return e =>
-      this.props.onVisualizationClick({
+      onVisualizationClick({
         ...clicked,
         event: e.nativeEvent,
-        settings: this.props.settings,
+        settings,
       });
   }
+
+  return (
+    <PivotTableRoot
+      isDashboard={isDashboard}
+      isNightMode={isNightMode}
+      data-testid="pivot-table"
+    >
+      <ScrollSync>
+        {({ onScroll, scrollLeft, scrollTop }) => (
+          <div className="full-height flex flex-column">
+            <div className="flex" style={{ height: topHeaderHeight }}>
+              {/* top left corner - displays left header columns */}
+              <PivotTableTopLeftCellsContainer
+                isNightMode={isNightMode}
+                style={{
+                  width: leftHeaderWidth,
+                }}
+              >
+                {rowIndexes.map((rowIndex, index) => (
+                  <Cell
+                    key={rowIndex}
+                    isEmphasized
+                    isBold
+                    isBorderedHeader
+                    isTransparent
+                    hasTopBorder={topHeaderRows > 1}
+                    isNightMode={isNightMode}
+                    value={getColumnTitle(rowIndex)}
+                    style={{
+                      flex: "0 0 auto",
+                      width:
+                        leftHeaderWidths?.[index] +
+                        (index === 0 ? LEFT_HEADER_LEFT_SPACING : 0),
+                      ...(index === 0
+                        ? { paddingLeft: LEFT_HEADER_LEFT_SPACING }
+                        : {}),
+                      ...(index === rowIndexes.length - 1
+                        ? { borderRight: "none" }
+                        : {}),
+                    }}
+                    icon={
+                      // you can only collapse before the last column
+                      index < rowIndexes.length - 1 &&
+                      isColumnCollapsible(rowIndex) && (
+                        <RowToggleIcon
+                          value={index + 1}
+                          settings={settings}
+                          updateSettings={onUpdateVisualizationSettings}
+                          hasCustomColors={hasCustomColors}
+                          isNightMode={isNightMode}
+                        />
+                      )
+                    }
+                  />
+                ))}
+              </PivotTableTopLeftCellsContainer>
+              {/* top header */}
+              <Collection
+                ref={topHeaderRef}
+                className="scroll-hide-all"
+                isNightMode={isNightMode}
+                width={width - leftHeaderWidth}
+                height={topHeaderHeight}
+                cellCount={topHeaderItems.length}
+                cellRenderer={topHeaderCellRenderer}
+                cellSizeAndPositionGetter={topHeaderCellSizeAndPositionGetter}
+                onScroll={({ scrollLeft }) => onScroll({ scrollLeft })}
+                scrollLeft={scrollLeft}
+              />
+            </div>
+            <div className="flex flex-full">
+              {/* left header */}
+              <div style={{ width: leftHeaderWidth }}>
+                <AutoSizer disableWidth>
+                  {({ height }) => (
+                    <Collection
+                      ref={leftHeaderRef}
+                      className="scroll-hide-all"
+                      cellCount={leftHeaderItems.length}
+                      cellRenderer={leftHeaderCellRenderer}
+                      cellSizeAndPositionGetter={
+                        leftHeaderCellSizeAndPositionGetter
+                      }
+                      width={leftHeaderWidth}
+                      height={height - scrollBarOffsetSize()}
+                      scrollTop={scrollTop}
+                      onScroll={({ scrollTop }) => onScroll({ scrollTop })}
+                    />
+                  )}
+                </AutoSizer>
+              </div>
+              {/* pivot table body */}
+              <div>
+                <AutoSizer disableWidth>
+                  {({ height }) => (
+                    <Grid
+                      width={width - leftHeaderWidth}
+                      height={height}
+                      className="text-dark"
+                      rowCount={rowCount}
+                      columnCount={columnCount}
+                      rowHeight={CELL_HEIGHT}
+                      columnWidth={valueIndexes.length * CELL_WIDTH}
+                      cellRenderer={bodyRenderer}
+                      onScroll={({ scrollLeft, scrollTop }) =>
+                        onScroll({ scrollLeft, scrollTop })
+                      }
+                      ref={bodyRef}
+                      scrollTop={scrollTop}
+                      scrollLeft={scrollLeft}
+                    />
+                  )}
+                </AutoSizer>
+              </div>
+            </div>
+          </div>
+        )}
+      </ScrollSync>
+    </PivotTableRoot>
+  );
 }
 
 export default Object.assign(connect(mapStateToProps)(PivotTable), {

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTable.styled.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTable.styled.tsx
@@ -2,7 +2,11 @@ import { css } from "@emotion/react";
 import styled from "@emotion/styled";
 import { color, alpha, darken } from "metabase/lib/colors";
 
-import { CELL_HEIGHT, PIVOT_TABLE_FONT_SIZE } from "./constants";
+import {
+  CELL_HEIGHT,
+  PIVOT_TABLE_FONT_SIZE,
+  RESIZE_HANDLE_WIDTH,
+} from "./constants";
 
 export const RowToggleIconRoot = styled.div`
   display: flex;
@@ -55,6 +59,7 @@ const getBorderColor = ({ isNightMode }: PivotTableCellProps) => {
 
 export const PivotTableCell = styled.div<PivotTableCellProps>`
   flex: 1 0 auto;
+  position: relative;
   flex-basis: 0;
   line-height: ${CELL_HEIGHT}px;
   min-width: 0;
@@ -115,4 +120,23 @@ export const PivotTableRoot = styled.div<PivotTableRootProps>`
 export const PivotTableSettingLabel = styled.span`
   font-weight: 700;
   color: ${color("text-dark")};
+`;
+
+export const ResizeHandle = styled.div`
+  z-index: 99;
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: -${RESIZE_HANDLE_WIDTH - 1}px;
+  width: ${RESIZE_HANDLE_WIDTH}px;
+
+  cursor: ew-resize;
+
+  &:active {
+    background-color: ${color("brand")};
+  }
+
+  &:hover {
+    background-color: ${color("brand")};
+  }
 `;

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTable.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTable.tsx
@@ -65,7 +65,7 @@ interface PivotTableProps {
   onUpdateVisualizationSettings: (settings: VisualizationSettings) => void;
   isNightMode: boolean;
   isDashboard: boolean;
-  fontFamily: string;
+  fontFamily?: string;
   onVisualizationClick: (options: any) => void;
 }
 

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTable.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTable.tsx
@@ -14,7 +14,6 @@ import { connect } from "react-redux";
 import { getScrollBarSize } from "metabase/lib/dom";
 import { getSetting } from "metabase/selectors/settings";
 import { useOnMount } from "metabase/hooks/use-on-mount";
-import { PLUGIN_SELECTORS } from "metabase/plugins";
 
 import {
   COLUMN_SHOW_TOTALS,
@@ -56,7 +55,6 @@ import { CELL_WIDTH, CELL_HEIGHT, LEFT_HEADER_LEFT_SPACING } from "./constants";
 import { settings, _columnSettings as columnSettings } from "./settings";
 
 const mapStateToProps = (state: State) => ({
-  hasCustomColors: PLUGIN_SELECTORS.getHasCustomColors(state),
   fontFamily: getSetting(state, "application-font"),
 });
 
@@ -64,7 +62,6 @@ interface PivotTableProps {
   data: DatasetData;
   settings: VisualizationSettings;
   width: number;
-  hasCustomColors: boolean;
   onUpdateVisualizationSettings: (settings: VisualizationSettings) => void;
   isNightMode: boolean;
   isDashboard: boolean;
@@ -76,7 +73,6 @@ function PivotTable({
   data,
   settings,
   width,
-  hasCustomColors,
   onUpdateVisualizationSettings,
   isNightMode,
   isDashboard,

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTable.unit.spec.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTable.unit.spec.jsx
@@ -194,7 +194,7 @@ describe("Visualizations > PivotTable > PivotTable", () => {
     );
 
     rows.forEach(rowData => {
-      expect(screen.queryByText(rowData[0].toString())).toBeInTheDocument();
+      expect(screen.getByText(rowData[0].toString())).toBeInTheDocument();
 
       [1, 2, 4, 5].forEach(colIndex => {
         expect(

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTable.unit.spec.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTable.unit.spec.jsx
@@ -194,7 +194,7 @@ describe("Visualizations > PivotTable > PivotTable", () => {
     );
 
     rows.forEach(rowData => {
-      expect(screen.getByText(rowData[0].toString())).toBeInTheDocument();
+      expect(screen.queryByText(rowData[0].toString())).toBeInTheDocument();
 
       [1, 2, 4, 5].forEach(colIndex => {
         expect(

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTable.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTable.unit.spec.tsx
@@ -1,5 +1,8 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
+import _ from "underscore";
+import type { VisualizationSettings } from "metabase-types/api";
+import type { Column } from "metabase-types/types/Dataset";
 
 import { PivotTable } from "./PivotTable";
 
@@ -38,7 +41,7 @@ const cols = [
     field_ref: ["aggregation", 2],
     display_name: "aggregation-2",
   },
-];
+] as Column[];
 
 const rows = [
   ["foo1", "bar1", "baz1", 0, 111, 222],
@@ -64,12 +67,12 @@ const pivotSettings = {
 
 const settings = {
   ...pivotSettings,
-  column: c => ({
+  column: (c: any) => ({
     ...pivotSettings,
     column: c,
     column_title: c.display_name,
   }),
-};
+} as unknown as VisualizationSettings;
 
 // 3 isn't a real column, it's a pivot-grouping
 const columnIndexes = [0, 1, 2, 4, 5];
@@ -80,11 +83,11 @@ describe("Visualizations > PivotTable > PivotTable", () => {
   const originalOffsetHeight = Object.getOwnPropertyDescriptor(
     HTMLElement.prototype,
     "offsetHeight",
-  );
+  ) as number;
   const originalOffsetWidth = Object.getOwnPropertyDescriptor(
     HTMLElement.prototype,
     "offsetWidth",
-  );
+  ) as number;
 
   beforeAll(() => {
     Object.defineProperty(HTMLElement.prototype, "offsetHeight", {
@@ -116,8 +119,8 @@ describe("Visualizations > PivotTable > PivotTable", () => {
         settings={settings}
         data={{ rows, cols }}
         width={600}
-        hasCustomColors={false}
-        onUpdateVisualizationSettings={() => {}}
+        onVisualizationClick={_.noop}
+        onUpdateVisualizationSettings={_.noop}
         isNightMode={false}
         isDashboard={false}
       />,
@@ -132,8 +135,8 @@ describe("Visualizations > PivotTable > PivotTable", () => {
           settings={settings}
           data={{ rows, cols }}
           width={600}
-          hasCustomColors={false}
-          onUpdateVisualizationSettings={() => {}}
+          onVisualizationClick={_.noop}
+          onUpdateVisualizationSettings={_.noop}
           isNightMode={false}
           isDashboard={false}
         />
@@ -153,8 +156,8 @@ describe("Visualizations > PivotTable > PivotTable", () => {
           settings={settings}
           data={{ rows, cols }}
           width={900}
-          hasCustomColors={false}
-          onUpdateVisualizationSettings={() => {}}
+          onVisualizationClick={_.noop}
+          onUpdateVisualizationSettings={_.noop}
           isNightMode={false}
           isDashboard={false}
         />
@@ -177,7 +180,7 @@ describe("Visualizations > PivotTable > PivotTable", () => {
         rows: [cols[0].field_ref, cols[1].field_ref, cols[2].field_ref],
         value: ["2"],
       },
-    };
+    } as unknown as VisualizationSettings;
 
     render(
       <div style={{ height: 800 }}>
@@ -185,8 +188,8 @@ describe("Visualizations > PivotTable > PivotTable", () => {
           settings={hiddenSettings}
           data={{ rows, cols }}
           width={900}
-          hasCustomColors={false}
-          onUpdateVisualizationSettings={() => {}}
+          onVisualizationClick={_.noop}
+          onUpdateVisualizationSettings={_.noop}
           isNightMode={false}
           isDashboard={false}
         />

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTableCell.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTableCell.jsx
@@ -4,7 +4,10 @@ import cx from "classnames";
 
 import Ellipsified from "metabase/core/components/Ellipsified";
 
+import { RowToggleIcon } from "./RowToggleIcon";
 import { PivotTableCell } from "./PivotTable.styled";
+
+import { LEFT_HEADER_LEFT_SPACING } from "./constants";
 
 export function Cell({
   value,
@@ -46,3 +49,90 @@ export function Cell({
     </PivotTableCell>
   );
 }
+
+export const TopHeaderCell = ({
+  style,
+  item,
+  getCellClickHandler,
+  isNightMode,
+}) => {
+  const { value, hasChildren, clicked, isSubtotal, maxDepthBelow } = item;
+
+  return (
+    <Cell
+      style={{
+        ...style,
+      }}
+      value={value}
+      isNightMode={isNightMode}
+      isBorderedHeader={maxDepthBelow === 0}
+      isEmphasized={hasChildren}
+      isBold={isSubtotal}
+      onClick={getCellClickHandler(clicked)}
+    />
+  );
+};
+
+export const LeftHeaderCell = ({
+  item,
+  style,
+  isNightMode,
+  rowIndex,
+  settings,
+  onUpdateVisualizationSettings,
+  getCellClickHandler,
+}) => {
+  const { value, isSubtotal, hasSubtotal, depth, path, clicked } = item;
+
+  return (
+    <Cell
+      style={{
+        ...style,
+        ...(depth === 0 ? { paddingLeft: LEFT_HEADER_LEFT_SPACING } : {}),
+      }}
+      isNightMode={isNightMode}
+      value={value}
+      isEmphasized={isSubtotal}
+      isBold={isSubtotal}
+      onClick={getCellClickHandler(clicked)}
+      icon={
+        (isSubtotal || hasSubtotal) && (
+          <RowToggleIcon
+            value={path}
+            settings={settings}
+            updateSettings={onUpdateVisualizationSettings}
+            hideUnlessCollapsed={isSubtotal}
+            rowIndex={rowIndex} // used to get a list of "other" paths when open one item in a collapsed column
+            isNightMode={isNightMode}
+          />
+        )
+      }
+    />
+  );
+};
+
+export const BodyCell = ({
+  style,
+  rowSection,
+  isNightMode,
+  getCellClickHandler,
+}) => {
+  return (
+    <div style={style} className="flex">
+      {rowSection.map(
+        ({ value, isSubtotal, clicked, backgroundColor }, index) => (
+          <Cell
+            isNightMode={isNightMode}
+            key={index}
+            value={value}
+            isEmphasized={isSubtotal}
+            isBold={isSubtotal}
+            isBody
+            onClick={getCellClickHandler(clicked)}
+            backgroundColor={backgroundColor}
+          />
+        ),
+      )}
+    </div>
+  );
+};

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTableCell.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTableCell.tsx
@@ -1,13 +1,30 @@
-/* eslint-disable react/prop-types */
 import React from "react";
 import cx from "classnames";
 
 import Ellipsified from "metabase/core/components/Ellipsified";
 
+import type { VisualizationSettings } from "metabase-types/api";
+
 import { RowToggleIcon } from "./RowToggleIcon";
 import { PivotTableCell } from "./PivotTable.styled";
 
+import type { HeaderItem, BodyItem, PivotTableClicked } from "./types";
 import { LEFT_HEADER_LEFT_SPACING } from "./constants";
+
+interface CellProps {
+  value: React.ReactNode;
+  style?: React.CSSProperties;
+  icon?: React.ReactNode;
+  backgroundColor?: string;
+  isBody?: boolean;
+  isBold?: boolean;
+  isEmphasized?: boolean;
+  isNightMode?: boolean;
+  isBorderedHeader?: boolean;
+  isTransparent?: boolean;
+  hasTopBorder?: boolean;
+  onClick?: ((e: React.SyntheticEvent) => void) | undefined;
+}
 
 export function Cell({
   value,
@@ -22,7 +39,7 @@ export function Cell({
   isTransparent,
   hasTopBorder,
   onClick,
-}) {
+}: CellProps) {
   return (
     <PivotTableCell
       data-testid="pivot-table-cell"
@@ -50,12 +67,23 @@ export function Cell({
   );
 }
 
+type CellClickHandler = (
+  clicked: PivotTableClicked,
+) => ((e: React.SyntheticEvent) => void) | undefined;
+
+interface TopHeaderCellProps {
+  item: HeaderItem;
+  style: React.CSSProperties;
+  isNightMode: boolean;
+  getCellClickHandler: CellClickHandler;
+}
+
 export const TopHeaderCell = ({
-  style,
   item,
-  getCellClickHandler,
+  style,
   isNightMode,
-}) => {
+  getCellClickHandler,
+}: TopHeaderCellProps) => {
   const { value, hasChildren, clicked, isSubtotal, maxDepthBelow } = item;
 
   return (
@@ -73,15 +101,21 @@ export const TopHeaderCell = ({
   );
 };
 
+type LeftHeaderCellProps = TopHeaderCellProps & {
+  rowIndex: string[];
+  settings: VisualizationSettings;
+  onUpdateVisualizationSettings: (settings: VisualizationSettings) => void;
+};
+
 export const LeftHeaderCell = ({
   item,
   style,
   isNightMode,
+  getCellClickHandler,
   rowIndex,
   settings,
   onUpdateVisualizationSettings,
-  getCellClickHandler,
-}) => {
+}: LeftHeaderCellProps) => {
   const { value, isSubtotal, hasSubtotal, depth, path, clicked } = item;
 
   return (
@@ -103,7 +137,6 @@ export const LeftHeaderCell = ({
             updateSettings={onUpdateVisualizationSettings}
             hideUnlessCollapsed={isSubtotal}
             rowIndex={rowIndex} // used to get a list of "other" paths when open one item in a collapsed column
-            isNightMode={isNightMode}
           />
         )
       }
@@ -111,12 +144,19 @@ export const LeftHeaderCell = ({
   );
 };
 
+interface BodyCellProps {
+  style: React.CSSProperties;
+  rowSection: BodyItem[];
+  isNightMode: boolean;
+  getCellClickHandler: CellClickHandler;
+}
+
 export const BodyCell = ({
   style,
   rowSection,
   isNightMode,
   getCellClickHandler,
-}) => {
+}: BodyCellProps) => {
   return (
     <div style={style} className="flex">
       {rowSection.map(

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/RowToggleIcon.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/RowToggleIcon.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/prop-types */
 import React from "react";
 import { updateIn } from "icepick";
 import _ from "underscore";
@@ -7,27 +6,44 @@ import Icon from "metabase/components/Icon";
 
 import { COLLAPSED_ROWS_SETTING } from "metabase/lib/data_grid";
 
+import {
+  VisualizationSettings,
+  PivotTableCollapsedRowsSetting,
+} from "metabase-types/api";
 import { RowToggleIconRoot } from "./PivotTable.styled";
+
+interface RowToggleIconProps {
+  value: number | string[];
+  settings: VisualizationSettings;
+  updateSettings: (settings: VisualizationSettings) => void;
+  hideUnlessCollapsed?: boolean;
+  rowIndex?: string[];
+}
 
 export function RowToggleIcon({
   value,
   settings,
   updateSettings,
   hideUnlessCollapsed,
-  rowIndex,
-  hasCustomColors,
-  isNightMode,
-}) {
+  rowIndex = [],
+}: RowToggleIconProps) {
   if (value == null) {
     return null;
   }
-  const setting = settings[COLLAPSED_ROWS_SETTING];
+  const setting = settings[
+    COLLAPSED_ROWS_SETTING
+  ] as PivotTableCollapsedRowsSetting;
   const ref = JSON.stringify(value);
   const isColumn = !Array.isArray(value);
   const columnRef = isColumn ? null : JSON.stringify(value.length);
-  const settingValue = setting.value || [];
-  const isColumnCollapsed = !isColumn && settingValue.includes(columnRef);
+  const settingValue: PivotTableCollapsedRowsSetting["value"] =
+    setting.value || [];
+  const isColumnCollapsed =
+    !isColumn && settingValue.includes(columnRef as string);
   const isCollapsed = settingValue.includes(ref) || isColumnCollapsed;
+
+  console.log(setting);
+
   if (hideUnlessCollapsed && !isCollapsed) {
     // subtotal rows shouldn't have an icon unless the section is collapsed
     return null;
@@ -37,7 +53,7 @@ export function RowToggleIcon({
   // That depends on whether we're a row or column header and whether we're open or closed.
   const toggle =
     isColumn && !isCollapsed // click on open column
-      ? settingValue =>
+      ? (settingValue: PivotTableCollapsedRowsSetting["value"]) =>
           settingValue
             .filter(v => {
               const parsed = JSON.parse(v);
@@ -45,7 +61,7 @@ export function RowToggleIcon({
             }) // remove any already collapsed items in this column
             .concat(ref) // add column to list
       : !isColumn && isColumnCollapsed // single row in collapsed column
-      ? settingValue =>
+      ? (settingValue: PivotTableCollapsedRowsSetting["value"]) =>
           settingValue
             .filter(v => v !== columnRef) // remove column from list
             .concat(
@@ -62,9 +78,11 @@ export function RowToggleIcon({
                 .map(item => JSON.stringify(item)),
             )
       : isCollapsed // closed row or column
-      ? settingValue => settingValue.filter(v => v !== ref)
+      ? (settingValue: PivotTableCollapsedRowsSetting["value"]) =>
+          settingValue.filter(v => v !== ref)
       : // open row or column
-        settingValue => settingValue.concat(ref);
+        (settingValue: PivotTableCollapsedRowsSetting["value"]) =>
+          settingValue.concat(ref);
 
   return (
     <RowToggleIconRoot

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/RowToggleIcon.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/RowToggleIcon.tsx
@@ -42,8 +42,6 @@ export function RowToggleIcon({
     !isColumn && settingValue.includes(columnRef as string);
   const isCollapsed = settingValue.includes(ref) || isColumnCollapsed;
 
-  console.log(setting);
-
   if (hideUnlessCollapsed && !isCollapsed) {
     // subtotal rows shouldn't have an icon unless the section is collapsed
     return null;

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/constants.ts
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/constants.ts
@@ -18,3 +18,5 @@ export const MAX_HEADER_CELL_WIDTH =
 export const LEFT_HEADER_LEFT_SPACING = 24;
 
 export const MAX_ROWS_TO_MEASURE = 100;
+
+export const RESIZE_HANDLE_WIDTH = 5;

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/settings.ts
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/settings.ts
@@ -1,0 +1,253 @@
+import { getIn } from "icepick";
+import { t } from "ttag";
+import _ from "underscore";
+
+import {
+  COLLAPSED_ROWS_SETTING,
+  COLUMN_SPLIT_SETTING,
+  COLUMN_SORT_ORDER,
+  COLUMN_SORT_ORDER_ASC,
+  COLUMN_SORT_ORDER_DESC,
+  COLUMN_SHOW_TOTALS,
+  COLUMN_FORMATTING_SETTING,
+  isPivotGroupColumn,
+} from "metabase/lib/data_grid";
+import { formatColumn } from "metabase/lib/formatting";
+
+import { columnSettings } from "metabase/visualizations/lib/settings/column";
+import ChartSettingsTableFormatting from "metabase/visualizations/components/settings/ChartSettingsTableFormatting";
+import { ChartSettingIconRadio } from "metabase/visualizations/components/settings/ChartSettingIconRadio";
+
+import type { Series, VisualizationSettings } from "metabase-types/api";
+import type { Card } from "metabase-types/types/Card";
+import type {
+  DatasetData,
+  Column,
+  Row,
+  ColumnSettings,
+} from "metabase-types/types/Dataset";
+
+import { isDimension } from "metabase-lib/types/utils/isa";
+
+import { partitions } from "./partitions";
+
+import {
+  addMissingCardBreakouts,
+  isColumnValid,
+  isFormattablePivotColumn,
+  updateValueWithCurrentColumns,
+} from "./utils";
+import { PivotSetting } from "./types";
+
+export const settings = {
+  ...columnSettings({ hidden: true }),
+  [COLLAPSED_ROWS_SETTING]: {
+    hidden: true,
+    readDependencies: [COLUMN_SPLIT_SETTING],
+    getValue: (
+      series: Series,
+      settings: Partial<VisualizationSettings> = {},
+    ) => {
+      // This is hack. Collapsed rows depend on the current column split setting.
+      // If the query changes or the rows are reordered, we ignore the current collapsed row setting.
+      // This is accomplished by snapshotting part of the column split setting *inside* this setting.
+      // `value` the is the actual data for this setting
+      // `rows` is value we check against the current setting to see if we should use `value`
+      const { rows, value } = settings[COLLAPSED_ROWS_SETTING] || {};
+      const { rows: currentRows } = settings[COLUMN_SPLIT_SETTING] || {};
+      if (!_.isEqual(rows, currentRows)) {
+        return { value: [], rows: currentRows };
+      }
+      return { rows, value };
+    },
+  },
+  [COLUMN_SPLIT_SETTING]: {
+    section: t`Columns`,
+    widget: "fieldsPartition",
+    persistDefault: true,
+    getHidden: ([{ data }]: [{ data: DatasetData }]) =>
+      // hide the setting widget if there are invalid columns
+      !data || data.cols.some(col => !isColumnValid(col)),
+    getProps: (
+      [{ data }]: [{ data: DatasetData }],
+      settings: VisualizationSettings,
+    ) => ({
+      partitions,
+      columns: data == null ? [] : data.cols,
+      settings,
+    }),
+    getValue: (
+      [{ data, card }]: [{ data: DatasetData; card: Card }],
+      settings: Partial<VisualizationSettings> = {},
+    ) => {
+      const storedValue = settings[COLUMN_SPLIT_SETTING];
+      if (data == null) {
+        return undefined;
+      }
+      const columnsToPartition = data.cols.filter(
+        col => !isPivotGroupColumn(col),
+      );
+      let setting;
+      if (storedValue == null) {
+        const [dimensions, values] = _.partition(
+          columnsToPartition,
+          isDimension,
+        );
+        const [first, second, ...rest] = _.sortBy(dimensions, col =>
+          getIn(col, ["fingerprint", "global", "distinct-count"]),
+        );
+
+        let rows;
+        let columns: Column[];
+
+        if (dimensions.length < 2) {
+          columns = [];
+          rows = [first];
+        } else if (dimensions.length <= 3) {
+          columns = [first];
+          rows = [second, ...rest];
+        } else {
+          columns = [first, second];
+          rows = rest;
+        }
+        setting = _.mapObject({ rows, columns, values }, cols =>
+          cols.map(col => col.field_ref),
+        );
+      } else {
+        setting = updateValueWithCurrentColumns(
+          storedValue,
+          columnsToPartition,
+        );
+      }
+
+      return addMissingCardBreakouts(setting as PivotSetting, card);
+    },
+  },
+  "pivot.show_row_totals": {
+    section: t`Columns`,
+    title: t`Show row totals`,
+    widget: "toggle",
+    default: true,
+    inline: true,
+  },
+  "pivot.show_column_totals": {
+    section: t`Columns`,
+    title: t`Show column totals`,
+    widget: "toggle",
+    default: true,
+    inline: true,
+  },
+  [COLUMN_FORMATTING_SETTING]: {
+    section: t`Conditional Formatting`,
+    widget: ChartSettingsTableFormatting,
+    default: [],
+    getDefault: (
+      [{ data }]: [{ data: DatasetData }],
+      settings: VisualizationSettings,
+    ) => {
+      const columnFormats = settings[COLUMN_FORMATTING_SETTING] ?? [];
+
+      return columnFormats
+        .map(columnFormat => {
+          const hasOnlyFormattableColumns =
+            columnFormat.columns
+              .map((columnName: string) =>
+                data.cols.find(column => column.name === columnName),
+              )
+              .filter(Boolean) ?? [].every(isFormattablePivotColumn);
+
+          if (!hasOnlyFormattableColumns) {
+            return null;
+          }
+
+          return {
+            ...columnFormat,
+            highlight_row: false,
+          };
+        })
+        .filter(Boolean);
+    },
+    isValid: (
+      [{ data }]: [{ data: DatasetData }],
+      settings: VisualizationSettings,
+    ): boolean => {
+      const columnFormats = settings[COLUMN_FORMATTING_SETTING] ?? [];
+
+      return columnFormats.every(columnFormat => {
+        const hasOnlyFormattableColumns =
+          columnFormat.columns
+            .map(columnName =>
+              (data.cols as Column[]).find(
+                column => column.name === columnName,
+              ),
+            )
+            .filter(Boolean) ?? [].every(isFormattablePivotColumn);
+
+        return hasOnlyFormattableColumns && !columnFormat.highlight_row;
+      });
+    },
+    getProps: (series: Series) => ({
+      canHighlightRow: false,
+      cols: (series[0].data.cols as Column[]).filter(isFormattablePivotColumn),
+    }),
+    getHidden: ([{ data }]: [{ data: DatasetData }]) =>
+      !data?.cols.some(col => isFormattablePivotColumn(col)),
+  },
+};
+
+export const _columnSettings = {
+  [COLUMN_SORT_ORDER]: {
+    title: t`Sort order`,
+    widget: ChartSettingIconRadio,
+    inline: true,
+    borderBottom: true,
+    props: {
+      options: [
+        {
+          iconName: "arrow_up",
+          value: COLUMN_SORT_ORDER_ASC,
+        },
+        {
+          iconName: "arrow_down",
+          value: COLUMN_SORT_ORDER_DESC,
+        },
+      ],
+    },
+    getHidden: ({ source }: { source: Column["source"] }) =>
+      source === "aggregation",
+  },
+  [COLUMN_SHOW_TOTALS]: {
+    title: t`Show totals`,
+    widget: "toggle",
+    inline: true,
+    getDefault: (
+      column: Column,
+      columnSettings: ColumnSettings,
+      { settings }: { settings: VisualizationSettings },
+    ) => {
+      //Default to showing totals if appropriate
+      const rows = settings[COLUMN_SPLIT_SETTING].rows || [];
+      return rows
+        .slice(0, -1)
+        .some((row: Row) => _.isEqual(row, column.field_ref));
+    },
+    getHidden: (
+      column: Column,
+      columnSettings: ColumnSettings,
+      { settings }: { settings: VisualizationSettings },
+    ) => {
+      const rows = settings[COLUMN_SPLIT_SETTING].rows || [];
+      // to show totals a column needs to be:
+      //  - in the left header ("rows" in COLUMN_SPLIT_SETTING)
+      //  - not the last column
+      return !rows
+        .slice(0, -1)
+        .some((row: Row) => _.isEqual(row, column.field_ref));
+    },
+  },
+  column_title: {
+    title: t`Column title`,
+    widget: "input",
+    getDefault: formatColumn,
+  },
+};

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/types.ts
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/types.ts
@@ -32,3 +32,8 @@ export interface HeaderItem {
 export type BodyItem = HeaderItem & {
   backgroundColor?: string;
 };
+
+export type HeaderWidthType = {
+  leftHeaderWidths: number[] | null;
+  totalHeaderWidths: number | null;
+};

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/types.ts
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/types.ts
@@ -9,8 +9,9 @@ export type PivotSetting = {
   values: AggregationReference[];
 };
 
+export type PivotTableClicked = { value: string; column: Column };
 export interface HeaderItem {
-  clicked: { value: string; column: Column };
+  clicked: PivotTableClicked;
 
   isCollapsed?: boolean;
   hasChildren: boolean;
@@ -27,3 +28,7 @@ export interface HeaderItem {
   rawValue: string;
   value: string;
 }
+
+export type BodyItem = HeaderItem & {
+  backgroundColor?: string;
+};

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/types.ts
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/types.ts
@@ -9,10 +9,10 @@ export type PivotSetting = {
   values: AggregationReference[];
 };
 
-export interface LeftHeaderItem {
+export interface HeaderItem {
   clicked: { value: string; column: Column };
 
-  isCollapsed: boolean;
+  isCollapsed?: boolean;
   hasChildren: boolean;
   hasSubtotal?: boolean;
   isSubtotal?: boolean;

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/utils.ts
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/utils.ts
@@ -93,17 +93,17 @@ export function isFormattablePivotColumn(column: Column) {
 interface GetLeftHeaderWidthsProps {
   rowIndexes: number[];
   getColumnTitle: (columnIndex: number) => string;
-  leftHeaderItems: LeftHeaderItem[];
+  leftHeaderItems?: LeftHeaderItem[];
   fontFamily?: string;
 }
 
 export function getLeftHeaderWidths({
   rowIndexes,
   getColumnTitle,
-  leftHeaderItems,
+  leftHeaderItems = [],
   fontFamily = "Lato",
 }: GetLeftHeaderWidthsProps) {
-  const cellValues = getColumnValues(leftHeaderItems, rowIndexes);
+  const cellValues = getColumnValues(leftHeaderItems);
 
   const widths = rowIndexes.map((rowIndex, depthIndex) => {
     const computedHeaderWidth = Math.ceil(
@@ -117,14 +117,15 @@ export function getLeftHeaderWidths({
     const computedCellWidth = Math.ceil(
       Math.max(
         // we need to use the depth index because the data is in depth order, not row index order
-        ...cellValues[depthIndex].values.map(
+        ...(cellValues[depthIndex]?.values?.map(
           value =>
             measureText(value, {
               weight: "normal",
               family: fontFamily,
               size: PIVOT_TABLE_FONT_SIZE,
-            }) + (cellValues[rowIndex].hasSubtotal ? ROW_TOGGLE_ICON_WIDTH : 0),
-        ),
+            }) +
+            (cellValues[rowIndex]?.hasSubtotal ? ROW_TOGGLE_ICON_WIDTH : 0),
+        ) ?? [0]),
       ),
     );
 
@@ -152,10 +153,7 @@ type ColumnValueInfo = {
   hasSubtotal: boolean;
 };
 
-function getColumnValues(
-  leftHeaderItems: LeftHeaderItem[],
-  rowIndexes: number[],
-) {
+export function getColumnValues(leftHeaderItems: LeftHeaderItem[]) {
   const columnValues: ColumnValueInfo[] = [];
 
   leftHeaderItems
@@ -165,7 +163,7 @@ function getColumnValues(
         leftHeaderItem;
 
       // don't size based on subtotals or grand totals
-      if (!isSubtotal && !isGrandTotal && value !== null) {
+      if (!isSubtotal && !isGrandTotal) {
         if (!columnValues[depth]) {
           columnValues[depth] = {
             values: [value],

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/utils.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/utils.unit.spec.ts
@@ -1,7 +1,7 @@
 import type { Column } from "metabase-types/types/Dataset";
 import type { Card } from "metabase-types/types/Card";
 
-import type { PivotSetting, LeftHeaderItem } from "./types";
+import type { PivotSetting, HeaderItem } from "./types";
 
 import {
   isColumnValid,
@@ -282,7 +282,7 @@ describe("Visualizations > Visualizations > PivotTable > utils", () => {
         { depth: 1, value: "bar2" },
         { depth: 2, value: "baz1" },
         { depth: 4, value: "boo1" },
-      ] as LeftHeaderItem[];
+      ] as HeaderItem[];
 
       const { leftHeaderWidths } = getLeftHeaderWidths({
         rowIndexes: [0, 1, 2, 3, 4],
@@ -334,7 +334,7 @@ describe("Visualizations > Visualizations > PivotTable > utils", () => {
         { depth: 1, value: "bar2" },
         { depth: 2, value: "baz1" },
         { depth: 4, value: "boo1" },
-      ] as LeftHeaderItem[];
+      ] as HeaderItem[];
 
       const result = getColumnValues(data);
 
@@ -354,7 +354,7 @@ describe("Visualizations > Visualizations > PivotTable > utils", () => {
         { depth: 1, value: "bar1", hasSubtotal: false },
         { depth: 1, value: "bar2", hasSubtotal: false },
         { depth: 2, value: "baz1", hasSubtotal: true },
-      ] as LeftHeaderItem[];
+      ] as HeaderItem[];
 
       const result = getColumnValues(data);
 
@@ -372,7 +372,7 @@ describe("Visualizations > Visualizations > PivotTable > utils", () => {
         { depth: 1, value: "bar1", hasSubtotal: false },
         { depth: 1, value: "bar2", hasSubtotal: false },
         { depth: 2, value: "baz1", hasSubtotal: true },
-      ] as LeftHeaderItem[];
+      ] as HeaderItem[];
 
       const result = getColumnValues(data);
 

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/utils.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/utils.unit.spec.ts
@@ -307,7 +307,7 @@ describe("Visualizations > Visualizations > PivotTable > utils", () => {
         { depth: 1, value: "bar2" },
         { depth: 2, value: "baz1" },
         { depth: 4, value: "boo1" },
-      ] as LeftHeaderItem[];
+      ] as HeaderItem[];
 
       const { leftHeaderWidths } = getLeftHeaderWidths({
         rowIndexes: [0, 1, 2, 3, 4],


### PR DESCRIPTION
resolves https://github.com/metabase/metabase/issues/27649

## Why Refactor this component?

With the upcoming work to [make pivot table columns user-resizable](https://github.com/metabase/metabase/issues/27597), we'll need to introduce internal state to this component which will cause a large number of re-renders. To keep this performant, we'd already need to do a good bit of refactoring to memoize a bunch of calculations.  Access to the `useMemo` hook will be highly valuable.

In addition, this component is pretty big, and includes several subcomponents and calculation functions, and will be easier to understand when those are extracted.

Also, we want more stuff in typescript, and I think the work typing the internal settings for pivot tables here is really helpful in making the logic more comprehensible.

## Summary

There should be no changes to the visualization's behavior, it should just now be a functional component and properly typed.

## Testing Steps

open a big gnarly pivot table like this one:
```
http://localhost:3000/question#eyJkYXRhc2V0X3F1ZXJ5Ijp7ImRhdGFiYXNlIjoxLCJxdWVyeSI6eyJzb3VyY2UtdGFibGUiOjIsImFnZ3JlZ2F0aW9uIjpbWyJzdW0iLFsiZmllbGQiLDEzLG51bGxdXV0sImJyZWFrb3V0IjpbWyJmaWVsZCIsMTQseyJ0ZW1wb3JhbC11bml0IjoicXVhcnRlciJ9XSxbImZpZWxkIiw4LHsic291cmNlLWZpZWxkIjo5fV0sWyJmaWVsZCIsMTIseyJiaW5uaW5nIjp7InN0cmF0ZWd5IjoiZGVmYXVsdCJ9fV0sWyJmaWVsZCIsMTcseyJiaW5uaW5nIjp7InN0cmF0ZWd5IjoiZGVmYXVsdCJ9fV1dfSwidHlwZSI6InF1ZXJ5In0sImRpc3BsYXkiOiJwaXZvdCIsImRpc3BsYXlJc0xvY2tlZCI6dHJ1ZSwicGFyYW1ldGVycyI6W10sInZpc3VhbGl6YXRpb25fc2V0dGluZ3MiOnsicGl2b3RfdGFibGUuY29sdW1uX3NwbGl0Ijp7InJvd3MiOltbImZpZWxkIiwxNCx7InRlbXBvcmFsLXVuaXQiOiJxdWFydGVyIn1dLFsiZmllbGQiLDEyLHsiYmlubmluZyI6eyJzdHJhdGVneSI6Im51bS1iaW5zIiwibWluLXZhbHVlIjowLCJtYXgtdmFsdWUiOjEwMCwibnVtLWJpbnMiOjgsImJpbi13aWR0aCI6MTIuNX19XSxbImZpZWxkIiwxNyx7ImJpbm5pbmciOnsic3RyYXRlZ3kiOiJudW0tYmlucyIsIm1pbi12YWx1ZSI6MCwibWF4LXZhbHVlIjo3MCwibnVtLWJpbnMiOjgsImJpbi13aWR0aCI6MTB9fV1dLCJjb2x1bW5zIjpbWyJmaWVsZCIsOCx7InNvdXJjZS1maWVsZCI6OX1dXSwidmFsdWVzIjpbWyJhZ2dyZWdhdGlvbiIsMF1dfX19
```
- see that the pivot table displays properly
- see that click actions work properly
- see that collapsing/expanding works properly
- open the viz settings and change stuff and see that it updates correctly
- see that performance isn't any worse than on `master` (which is pretty bad, scrollsync is slow)

