### PR TITLE
Enable deleting groups and members with authentication mapping group deletion

### DIFF
--- a/frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx
@@ -126,11 +126,17 @@ export default class GroupMappingsWidget extends React.Component {
 
   updateGroupsListsForCallbacksAfterDeletingMappings = (
     whatToDoAboutGroups,
-    groups,
+    groupIds,
   ) => {
+    const { groups } = this.state;
+
     if (whatToDoAboutGroups === "nothing") {
       return;
     }
+
+    const allGroupIdsExceptAdmin = groupIds.filter(
+      groupId => !isAdminGroup(_.find(groups, group => group.id === groupId)),
+    );
 
     const stateKey = {
       clear: "groupsToClearAllPermissions",
@@ -140,7 +146,9 @@ export default class GroupMappingsWidget extends React.Component {
     this.setState(({ whenDeletingMappingGroups }) => ({
       whenDeletingMappingGroups: {
         ...whenDeletingMappingGroups,
-        [stateKey]: _.uniq(whenDeletingMappingGroups[stateKey].concat(groups)),
+        [stateKey]: _.uniq(
+          whenDeletingMappingGroups[stateKey].concat(allGroupIdsExceptAdmin),
+        ),
       },
     }));
   };

--- a/frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx
@@ -26,6 +26,7 @@ export default class GroupMappingsWidget extends React.Component {
       showAddRow: false,
       groups: null,
       mappings: {},
+      savedMappings: {},
       saveError: null,
       dnForVisibleDeleteMappingModal: null,
       groupIdsForVisibleDeleteMappingModal: null,
@@ -45,7 +46,8 @@ export default class GroupMappingsWidget extends React.Component {
     });
 
     this.setState({
-      mappings: (setting && setting.value) || {},
+      mappings: setting?.value || {},
+      savedMappings: setting?.value || {},
       showEditModal: true,
     });
 
@@ -216,6 +218,7 @@ export default class GroupMappingsWidget extends React.Component {
       groups,
       mappings,
       saveError,
+      savedMappings,
       dnForVisibleDeleteMappingModal,
       groupIdsForVisibleDeleteMappingModal,
     } = this.state;
@@ -266,8 +269,13 @@ export default class GroupMappingsWidget extends React.Component {
                         _.find(groups, group => group.id === ids[0]),
                       );
 
+                    const isSavedMapping =
+                      Object.keys(savedMappings).includes(dn);
+
                     const shouldUseDeleteMappingModal =
-                      ids.length > 0 && !isMappingLinkedOnlyToAdminGroup;
+                      ids.length > 0 &&
+                      !isMappingLinkedOnlyToAdminGroup &&
+                      isSavedMapping;
 
                     const onDelete = shouldUseDeleteMappingModal
                       ? () => this.handleShowDeleteMappingModal(ids, dn)

--- a/frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx
@@ -265,8 +265,10 @@ export default class GroupMappingsWidget extends React.Component {
                       groups={groups || []}
                       selectedGroups={ids}
                       onChange={this._changeMapping(dn)}
-                      onDelete={() =>
-                        this.handleShowDeleteMappingModal(ids, dn)
+                      onDelete={
+                        ids.length > 0
+                          ? () => this.handleShowDeleteMappingModal(ids, dn)
+                          : () => this._deleteMapping(dn)
                       }
                     />
                   ))}

--- a/frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx
@@ -174,7 +174,9 @@ export default class GroupMappingsWidget extends React.Component {
     SettingsApi.put({ key: mappingSetting, value: mappings }).then(
       () => {
         onChangeSetting(mappingSetting, mappings);
+
         this.updateGroupsFromDeletedMappings();
+
         this.setState({
           showEditModal: false,
           showAddRow: false,
@@ -186,13 +188,23 @@ export default class GroupMappingsWidget extends React.Component {
   };
 
   updateGroupsFromDeletedMappings = () => {
-    const { groupsToClearAllPermissions, groupsToDelete } =
-      this.state.whenDeletingMappingGroups;
+    const { groupsToDelete } = this.state.whenDeletingMappingGroups;
 
     groupsToDelete.forEach(id => PermissionsApi.deleteGroup({ id }));
 
-    groupsToClearAllPermissions.forEach(id =>
-      PermissionsApi.clearGroupMembership({ id }),
+    // Avoid calling the API for groups that have just been deleted
+    this.getGroupsToClearAllPermissionsThatAreNotAlsoGroupsToDelete().forEach(
+      id => PermissionsApi.clearGroupMembership({ id }),
+    );
+  };
+
+  getGroupsToClearAllPermissionsThatAreNotAlsoGroupsToDelete = () => {
+    const { groupsToClearAllPermissions, groupsToDelete } =
+      this.state.whenDeletingMappingGroups;
+
+    return groupsToClearAllPermissions.filter(
+      groupToClearAllPermission =>
+        !groupsToDelete.includes(groupToClearAllPermission),
     );
   };
 

--- a/frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx
@@ -10,7 +10,7 @@ import GroupSelect from "metabase/admin/people/components/GroupSelect";
 import LoadingSpinner from "metabase/components/LoadingSpinner";
 import Modal from "metabase/components/Modal";
 import { PermissionsApi, SettingsApi } from "metabase/services";
-import { isDefaultGroup } from "metabase/lib/groups";
+import { isDefaultGroup, isAdminGroup } from "metabase/lib/groups";
 
 import SettingToggle from "./SettingToggle";
 import DeleteGroupMappingModal from "./GroupMappingsWidget/DeleteGroupMappingModal";
@@ -258,20 +258,32 @@ export default class GroupMappingsWidget extends React.Component {
                       placeholder={this.props.groupPlaceholder}
                     />
                   ) : null}
-                  {Object.entries(mappings).map(([dn, ids]) => (
-                    <MappingRow
-                      key={dn}
-                      dn={dn}
-                      groups={groups || []}
-                      selectedGroups={ids}
-                      onChange={this._changeMapping(dn)}
-                      onDelete={
-                        ids.length > 0
-                          ? () => this.handleShowDeleteMappingModal(ids, dn)
-                          : () => this._deleteMapping(dn)
-                      }
-                    />
-                  ))}
+                  {Object.entries(mappings).map(([dn, ids]) => {
+                    const isMappingLinkedOnlyToAdminGroup =
+                      groups &&
+                      ids.length === 1 &&
+                      isAdminGroup(
+                        _.find(groups, group => group.id === ids[0]),
+                      );
+
+                    const shouldUseDeleteMappingModal =
+                      ids.length > 0 && !isMappingLinkedOnlyToAdminGroup;
+
+                    const onDelete = shouldUseDeleteMappingModal
+                      ? () => this.handleShowDeleteMappingModal(ids, dn)
+                      : () => this._deleteMapping(dn);
+
+                    return (
+                      <MappingRow
+                        key={dn}
+                        dn={dn}
+                        groups={groups || []}
+                        selectedGroups={ids}
+                        onChange={this._changeMapping(dn)}
+                        onDelete={onDelete}
+                      />
+                    );
+                  })}
                 </AdminContentTable>
               </div>
               <ModalFooter>

--- a/frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx
@@ -131,7 +131,7 @@ export default class GroupMappingsWidget extends React.Component {
     }
 
     const stateKey = {
-      clearAllPermissions: "groupsToClearAllPermissions",
+      clear: "groupsToClearAllPermissions",
       delete: "groupsToDelete",
     }[whatToDoAboutGroups];
 

--- a/frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx
@@ -13,6 +13,7 @@ import { PermissionsApi, SettingsApi } from "metabase/services";
 import { isDefaultGroup } from "metabase/lib/groups";
 
 import SettingToggle from "./SettingToggle";
+import DeleteGroupMappingModal from "./GroupMappingsWidget/DeleteGroupMappingModal";
 
 const groupIsMappable = group => !isDefaultGroup(group);
 
@@ -77,8 +78,17 @@ export default class GroupMappingsWidget extends React.Component {
     }
   };
 
+  handleShowDeleteMappingModal = () => {
+    this.setState({ showDeleteMappingModal: true, showEditModal: false });
+  };
+
+  handleHideDeleteMappingModal = () => {
+    this.setState({ showDeleteMappingModal: false, showEditModal: true });
+  };
+
   _deleteMapping = dn => e => {
     e.preventDefault();
+
     this.setState(prevState => ({
       mappings: _.omit(prevState.mappings, dn),
     }));
@@ -93,11 +103,11 @@ export default class GroupMappingsWidget extends React.Component {
     e.preventDefault();
     const {
       state: { mappings },
-      props: { onChangeSetting },
+      props: { mappingSetting, onChangeSetting },
     } = this;
-    SettingsApi.put({ key: this.props.mappingSetting, value: mappings }).then(
+    SettingsApi.put({ key: mappingSetting, value: mappings }).then(
       () => {
-        onChangeSetting(this.props.mappingSetting, mappings);
+        onChangeSetting(mappingSetting, mappings);
         this.setState({
           showEditModal: false,
           showAddRow: false,
@@ -109,8 +119,14 @@ export default class GroupMappingsWidget extends React.Component {
   };
 
   render() {
-    const { showEditModal, showAddRow, groups, mappings, saveError } =
-      this.state;
+    const {
+      showDeleteMappingModal,
+      showEditModal,
+      showAddRow,
+      groups,
+      mappings,
+      saveError,
+    } = this.state;
 
     return (
       <div className="flex align-center">
@@ -157,7 +173,10 @@ export default class GroupMappingsWidget extends React.Component {
                       groups={groups || []}
                       selectedGroups={ids}
                       onChange={this._changeMapping(dn)}
-                      onDelete={this._deleteMapping(dn)}
+                      onDelete={
+                        this
+                          .handleShowDeleteMappingModal /*this._deleteMapping(dn)*/
+                      }
                     />
                   ))}
                 </AdminContentTable>
@@ -176,6 +195,9 @@ export default class GroupMappingsWidget extends React.Component {
               </ModalFooter>
             </div>
           </Modal>
+        ) : null}
+        {showDeleteMappingModal ? (
+          <DeleteGroupMappingModal onHide={this.handleHideDeleteMappingModal} />
         ) : null}
       </div>
     );

--- a/frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget.jsx
@@ -135,7 +135,7 @@ export default class GroupMappingsWidget extends React.Component {
     }
 
     const allGroupIdsExceptAdmin = groupIds.filter(
-      groupId => !isAdminGroup(_.find(groups, group => group.id === groupId)),
+      groupId => !isAdminGroup(groups.find(group => group.id === groupId)),
     );
 
     const stateKey = {
@@ -273,9 +273,7 @@ export default class GroupMappingsWidget extends React.Component {
                     const isMappingLinkedOnlyToAdminGroup =
                       groups &&
                       ids.length === 1 &&
-                      isAdminGroup(
-                        _.find(groups, group => group.id === ids[0]),
-                      );
+                      isAdminGroup(groups.find(group => group.id === ids[0]));
 
                     const isSavedMapping =
                       Object.keys(savedMappings).includes(dn);

--- a/frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget/DeleteGroupMappingModal/DeleteGroupMappingModal.styled.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget/DeleteGroupMappingModal/DeleteGroupMappingModal.styled.tsx
@@ -1,0 +1,14 @@
+import styled from "@emotion/styled";
+import { space } from "metabase/styled-components/theme";
+
+export const ModalHeader = styled.h2`
+  padding: ${space(3)};
+`;
+
+export const ModalSubtitle = styled.p`
+  padding: 0 ${space(3)};
+`;
+
+export const ModalRadioRoot = styled.div`
+  padding: ${space(0)} ${space(3)};
+`;

--- a/frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget/DeleteGroupMappingModal/DeleteGroupMappingModal.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget/DeleteGroupMappingModal/DeleteGroupMappingModal.tsx
@@ -1,0 +1,64 @@
+import React, { useState } from "react";
+import { t } from "ttag";
+
+import Modal from "metabase/components/Modal";
+import Radio from "metabase/core/components/Radio";
+import Button from "metabase/core/components/Button";
+
+type DeleteGroupMappingModalProps = {
+  onHide: () => void;
+};
+
+const DeleteGroupMappingModal = ({ onHide }: DeleteGroupMappingModalProps) => {
+  const [value, setValue] = useState("nothing");
+
+  const handleChange = (newValue: string) => {
+    setValue(newValue);
+  };
+
+  return (
+    <Modal>
+      <div className="px4">
+        <div className="pt4">
+          <h2>{t`Remove this group mapping?`}</h2>
+        </div>
+        <div className="pt4">
+          <p className="text-measure">
+            {t`This group's user membership will no longer be synced with the directory server.`}
+          </p>
+        </div>
+        <div className="pt4">
+          <p className="text-measure">
+            {t`What should happen with the group itself in ⚠️fill in dynamic application name?`}
+          </p>
+          <Radio
+            className="ml2"
+            vertical
+            value={value}
+            options={[
+              {
+                name: t`Nothing, just remove the mapping.`,
+                value: "nothing",
+              },
+              {
+                name: t`Also remove all group members`,
+                value: "remove-all-members",
+              },
+              {
+                name: t`Also delete the group`,
+                value: "delete-group",
+              },
+            ]}
+            showButtons
+            onChange={handleChange}
+          />
+        </div>
+        <div className="pt4">
+          <Button onClick={onHide}>{t`Cancel`}</Button>
+        </div>
+      </div>
+    </Modal>
+  );
+};
+
+export default DeleteGroupMappingModal;

--- a/frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget/DeleteGroupMappingModal/DeleteGroupMappingModal.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget/DeleteGroupMappingModal/DeleteGroupMappingModal.tsx
@@ -2,8 +2,15 @@ import React, { useState } from "react";
 import { t } from "ttag";
 
 import Modal from "metabase/components/Modal";
+import { ModalFooter } from "metabase/components/ModalContent";
 import Radio from "metabase/core/components/Radio";
 import Button from "metabase/core/components/Button";
+
+import {
+  ModalHeader,
+  ModalSubtitle,
+  ModalRadioRoot,
+} from "./DeleteGroupMappingModal.styled";
 
 type DeleteGroupMappingModalProps = {
   onHide: () => void;
@@ -16,21 +23,22 @@ const DeleteGroupMappingModal = ({ onHide }: DeleteGroupMappingModalProps) => {
     setValue(newValue);
   };
 
+  const submitButtonLabels: Record<string, string> = {
+    nothing: t`Remove mapping`,
+    removeAllMembers: t`Remove mapping and members`,
+    deleteGroup: t`Remove mapping and delete group`,
+  };
+
   return (
     <Modal>
-      <div className="px4">
-        <div className="pt4">
-          <h2>{t`Remove this group mapping?`}</h2>
-        </div>
-        <div className="pt4">
-          <p className="text-measure">
-            {t`This group's user membership will no longer be synced with the directory server.`}
-          </p>
-        </div>
-        <div className="pt4">
-          <p className="text-measure">
-            {t`What should happen with the group itself in ⚠️fill in dynamic application name?`}
-          </p>
+      <div>
+        <ModalHeader>{t`Remove this group mapping?`}</ModalHeader>
+        <ModalSubtitle>
+          {t`This group's user membership will no longer be synced with the directory server.`}
+        </ModalSubtitle>
+        <ModalRadioRoot>
+          <p>{t`What should happen with the group itself in Metabase?`}</p>
+
           <Radio
             className="ml2"
             vertical
@@ -42,20 +50,23 @@ const DeleteGroupMappingModal = ({ onHide }: DeleteGroupMappingModalProps) => {
               },
               {
                 name: t`Also remove all group members`,
-                value: "remove-all-members",
+                value: "removeAllMembers",
               },
               {
                 name: t`Also delete the group`,
-                value: "delete-group",
+                value: "deleteGroup",
               },
             ]}
             showButtons
             onChange={handleChange}
           />
-        </div>
-        <div className="pt4">
+        </ModalRadioRoot>
+        <ModalFooter>
           <Button onClick={onHide}>{t`Cancel`}</Button>
-        </div>
+          <Button danger onClick={onHide}>
+            {submitButtonLabels[value]}
+          </Button>
+        </ModalFooter>
       </div>
     </Modal>
   );

--- a/frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget/DeleteGroupMappingModal/DeleteGroupMappingModal.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget/DeleteGroupMappingModal/DeleteGroupMappingModal.tsx
@@ -16,7 +16,7 @@ export type GroupIds = number[];
 export type DNType = string;
 export type ValueType = "nothing" | "clear" | "delete";
 
-type DeleteGroupMappingModalProps = {
+export type DeleteGroupMappingModalProps = {
   dn: DNType;
   groupIds: GroupIds;
   onConfirm: (value: ValueType, groupIds: GroupIds, dn: DNType) => void;

--- a/frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget/DeleteGroupMappingModal/DeleteGroupMappingModal.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget/DeleteGroupMappingModal/DeleteGroupMappingModal.tsx
@@ -14,7 +14,7 @@ import {
 
 type GroupIds = number[];
 type DNType = string;
-type ValueType = "nothing" | "clearAllPermissions" | "delete";
+type ValueType = "nothing" | "clear" | "delete";
 
 type DeleteGroupMappingModalProps = {
   dn: DNType;
@@ -41,7 +41,7 @@ const DeleteGroupMappingModal = ({
 
   const submitButtonLabels: Record<ValueType, string> = {
     nothing: t`Remove mapping`,
-    clearAllPermissions: t`Remove mapping and members`,
+    clear: t`Remove mapping and members`,
     delete: t`Remove mapping and delete group`,
   };
 
@@ -66,7 +66,7 @@ const DeleteGroupMappingModal = ({
               },
               {
                 name: t`Also remove all group members`,
-                value: "clearAllPermissions",
+                value: "clear",
               },
               {
                 name: t`Also delete the group`,

--- a/frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget/DeleteGroupMappingModal/DeleteGroupMappingModal.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget/DeleteGroupMappingModal/DeleteGroupMappingModal.tsx
@@ -42,18 +42,29 @@ const DeleteGroupMappingModal = ({
   const submitButtonLabels: Record<ValueType, string> = {
     nothing: t`Remove mapping`,
     clear: t`Remove mapping and members`,
-    delete: t`Remove mapping and delete group`,
+    delete:
+      groupIds.length > 1
+        ? t`Remove mapping and delete groups`
+        : t`Remove mapping and delete group`,
   };
+
+  const subtitle =
+    groupIds.length > 1
+      ? t`These groups' user memberships will no longer be synced with the directory server.`
+      : t`This group's user membership will no longer be synced with the directory server.`;
+
+  const whatShouldHappenText =
+    groupIds.length > 1
+      ? t`What should happen with the groups themselves in Metabase?`
+      : t`What should happen with the group itself in Metabase?`;
 
   return (
     <Modal>
       <div>
         <ModalHeader>{t`Remove this group mapping?`}</ModalHeader>
-        <ModalSubtitle>
-          {t`This group's user membership will no longer be synced with the directory server.`}
-        </ModalSubtitle>
+        <ModalSubtitle>{subtitle}</ModalSubtitle>
         <ModalRadioRoot>
-          <p>{t`What should happen with the group itself in Metabase?`}</p>
+          <p>{whatShouldHappenText}</p>
 
           <Radio
             className="ml2"
@@ -61,7 +72,7 @@ const DeleteGroupMappingModal = ({
             value={value as ValueType | undefined}
             options={[
               {
-                name: t`Nothing, just remove the mapping.`,
+                name: t`Nothing, just remove the mapping`,
                 value: "nothing",
               },
               {
@@ -69,7 +80,10 @@ const DeleteGroupMappingModal = ({
                 value: "clear",
               },
               {
-                name: t`Also delete the group`,
+                name:
+                  groupIds.length > 1
+                    ? t`Also delete the groups`
+                    : t`Also delete the group`,
                 value: "delete",
               },
             ]}

--- a/frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget/DeleteGroupMappingModal/DeleteGroupMappingModal.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget/DeleteGroupMappingModal/DeleteGroupMappingModal.tsx
@@ -16,7 +16,7 @@ type GroupIds = number[];
 type DNType = string;
 type ValueType = "nothing" | "clear" | "delete";
 
-type DeleteGroupMappingModalProps = {
+export type DeleteGroupMappingModalProps = {
   dn: DNType;
   groupIds: GroupIds;
   onConfirm: (value: ValueType, groups: number[], dn: DNType) => void;

--- a/frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget/DeleteGroupMappingModal/DeleteGroupMappingModal.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget/DeleteGroupMappingModal/DeleteGroupMappingModal.tsx
@@ -19,7 +19,7 @@ export type ValueType = "nothing" | "clear" | "delete";
 type DeleteGroupMappingModalProps = {
   dn: DNType;
   groupIds: GroupIds;
-  onConfirm: (value: ValueType, groups: number[], dn: DNType) => void;
+  onConfirm: (value: ValueType, groupIds: GroupIds, dn: DNType) => void;
   onHide: () => void;
 };
 
@@ -29,14 +29,14 @@ const DeleteGroupMappingModal = ({
   onConfirm,
   onHide,
 }: DeleteGroupMappingModalProps) => {
-  const [value, setValue] = useState("nothing");
+  const [value, setValue] = useState<ValueType>("nothing");
 
   const handleChange = (newValue: ValueType) => {
     setValue(newValue);
   };
 
   const handleConfirm = () => {
-    onConfirm(value as ValueType, groupIds, dn);
+    onConfirm(value, groupIds, dn);
   };
 
   const submitButtonLabels: Record<ValueType, string> = {

--- a/frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget/DeleteGroupMappingModal/DeleteGroupMappingModal.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget/DeleteGroupMappingModal/DeleteGroupMappingModal.tsx
@@ -76,7 +76,7 @@ const DeleteGroupMappingModal = ({
                 value: "nothing",
               },
               {
-                name: t`Also remove all group members`,
+                name: t`Also remove all group members (except from Admin)`,
                 value: "clear",
               },
               {

--- a/frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget/DeleteGroupMappingModal/DeleteGroupMappingModal.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget/DeleteGroupMappingModal/DeleteGroupMappingModal.tsx
@@ -77,7 +77,7 @@ const DeleteGroupMappingModal = ({
             onChange={handleChange}
           />
         </ModalRadioRoot>
-        <ModalFooter>
+        <ModalFooter fullPageModal={false} formModal={true}>
           <Button onClick={onHide}>{t`Cancel`}</Button>
           <Button danger onClick={handleConfirm}>
             {submitButtonLabels[value as ValueType]}

--- a/frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget/DeleteGroupMappingModal/DeleteGroupMappingModal.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget/DeleteGroupMappingModal/DeleteGroupMappingModal.tsx
@@ -12,11 +12,11 @@ import {
   ModalRadioRoot,
 } from "./DeleteGroupMappingModal.styled";
 
-type GroupIds = number[];
-type DNType = string;
-type ValueType = "nothing" | "clear" | "delete";
+export type GroupIds = number[];
+export type DNType = string;
+export type ValueType = "nothing" | "clear" | "delete";
 
-export type DeleteGroupMappingModalProps = {
+type DeleteGroupMappingModalProps = {
   dn: DNType;
   groupIds: GroupIds;
   onConfirm: (value: ValueType, groups: number[], dn: DNType) => void;
@@ -82,7 +82,7 @@ const DeleteGroupMappingModal = ({
               {
                 name:
                   groupIds.length > 1
-                    ? t`Also delete the groups`
+                    ? t`Also delete the groups (except Admin)`
                     : t`Also delete the group`,
                 value: "delete",
               },

--- a/frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget/DeleteGroupMappingModal/DeleteGroupMappingModal.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget/DeleteGroupMappingModal/DeleteGroupMappingModal.tsx
@@ -12,22 +12,36 @@ import {
   ModalRadioRoot,
 } from "./DeleteGroupMappingModal.styled";
 
+type ValueType = "nothing" | "clearAllPermissions" | "delete";
+
 type DeleteGroupMappingModalProps = {
+  dn: any;
+  onConfirm: () => void;
   onHide: () => void;
 };
 
-const DeleteGroupMappingModal = ({ onHide }: DeleteGroupMappingModalProps) => {
+const DeleteGroupMappingModal = ({
+  dn,
+  onConfirm,
+  onHide,
+}: DeleteGroupMappingModalProps) => {
   const [value, setValue] = useState("nothing");
 
-  const handleChange = (newValue: string) => {
+  const handleChange = (newValue: ValueType) => {
     setValue(newValue);
   };
 
-  const submitButtonLabels: Record<string, string> = {
-    nothing: t`Remove mapping`,
-    removeAllMembers: t`Remove mapping and members`,
-    deleteGroup: t`Remove mapping and delete group`,
+  const handleConfirm = () => {
+    onConfirm(value, dn);
   };
+
+  const submitButtonLabels: Record<ValueType, string> = {
+    nothing: t`Remove mapping`,
+    clearAllPermissions: t`Remove mapping and members`,
+    delete: t`Remove mapping and delete group`,
+  };
+
+  console.log("🚀", { dn });
 
   return (
     <Modal>
@@ -42,7 +56,7 @@ const DeleteGroupMappingModal = ({ onHide }: DeleteGroupMappingModalProps) => {
           <Radio
             className="ml2"
             vertical
-            value={value}
+            value={value as ValueType | undefined}
             options={[
               {
                 name: t`Nothing, just remove the mapping.`,
@@ -50,11 +64,11 @@ const DeleteGroupMappingModal = ({ onHide }: DeleteGroupMappingModalProps) => {
               },
               {
                 name: t`Also remove all group members`,
-                value: "removeAllMembers",
+                value: "clearAllPermissions",
               },
               {
                 name: t`Also delete the group`,
-                value: "deleteGroup",
+                value: "delete",
               },
             ]}
             showButtons
@@ -63,8 +77,8 @@ const DeleteGroupMappingModal = ({ onHide }: DeleteGroupMappingModalProps) => {
         </ModalRadioRoot>
         <ModalFooter>
           <Button onClick={onHide}>{t`Cancel`}</Button>
-          <Button danger onClick={onHide}>
-            {submitButtonLabels[value]}
+          <Button danger onClick={handleConfirm}>
+            {submitButtonLabels[value as ValueType]}
           </Button>
         </ModalFooter>
       </div>

--- a/frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget/DeleteGroupMappingModal/DeleteGroupMappingModal.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget/DeleteGroupMappingModal/DeleteGroupMappingModal.tsx
@@ -12,16 +12,20 @@ import {
   ModalRadioRoot,
 } from "./DeleteGroupMappingModal.styled";
 
+type GroupIds = number[];
+type DNType = string;
 type ValueType = "nothing" | "clearAllPermissions" | "delete";
 
 type DeleteGroupMappingModalProps = {
-  dn: any;
-  onConfirm: () => void;
+  dn: DNType;
+  groupIds: GroupIds;
+  onConfirm: (value: ValueType, groups: number[], dn: DNType) => void;
   onHide: () => void;
 };
 
 const DeleteGroupMappingModal = ({
   dn,
+  groupIds,
   onConfirm,
   onHide,
 }: DeleteGroupMappingModalProps) => {
@@ -32,7 +36,7 @@ const DeleteGroupMappingModal = ({
   };
 
   const handleConfirm = () => {
-    onConfirm(value, dn);
+    onConfirm(value as ValueType, groupIds, dn);
   };
 
   const submitButtonLabels: Record<ValueType, string> = {
@@ -40,8 +44,6 @@ const DeleteGroupMappingModal = ({
     clearAllPermissions: t`Remove mapping and members`,
     delete: t`Remove mapping and delete group`,
   };
-
-  console.log("🚀", { dn });
 
   return (
     <Modal>

--- a/frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget/DeleteGroupMappingModal/DeleteGroupMappingModal.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget/DeleteGroupMappingModal/DeleteGroupMappingModal.unit.spec.tsx
@@ -1,8 +1,17 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import type { GroupIds, DNType, ValueType } from ".";
 
 import DeleteGroupMappingModal from ".";
-import type { DeleteGroupMappingModalProps } from ".";
+
+type PropTypes = {
+  dn?: DNType;
+  groupIds?: GroupIds;
+  onConfirm?: (value: ValueType, groups: number[], dn: DNType) => void;
+  onHide?: () => void;
+};
 
 const DEFAULT_PROPS = {
   dn: "cn=People",
@@ -11,16 +20,82 @@ const DEFAULT_PROPS = {
   onHide: jest.fn(),
 };
 
-const setup = (props?: DeleteGroupMappingModalProps) => {
-  render(<DeleteGroupMappingModal {...DEFAULT_PROPS} />);
+const setup = (props?: PropTypes) => {
+  render(<DeleteGroupMappingModal {...DEFAULT_PROPS} {...props} />);
 };
 
 describe("DeleteGroupMappingModal", () => {
-  it("something", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("shows options for when mapping is linked to just one group", () => {
     setup();
 
     expect(
       screen.getByText("Nothing, just remove the mapping"),
     ).toBeInTheDocument();
+
+    expect(
+      screen.getByText("Also remove all group members"),
+    ).toBeInTheDocument();
+
+    expect(screen.getByText("Also delete the group")).toBeInTheDocument();
+  });
+
+  it("shows options for when mapping is linked to more than one group", () => {
+    setup({ groupIds: [1, 2] });
+
+    expect(
+      screen.getByText("Nothing, just remove the mapping"),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByText("Also remove all group members"),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByText("Also delete the groups (except Admin)"),
+    ).toBeInTheDocument();
+  });
+
+  it("starts with 'Nothing' option checked", () => {
+    setup();
+
+    expect(
+      screen.getByLabelText("Nothing, just remove the mapping"),
+    ).toBeChecked();
+  });
+
+  it("confirms when clearing members", () => {
+    setup();
+
+    userEvent.click(screen.getByLabelText("Also remove all group members"));
+
+    userEvent.click(
+      screen.getByRole("button", { name: "Remove mapping and members" }),
+    );
+
+    expect(DEFAULT_PROPS.onConfirm).toHaveBeenCalledWith(
+      "clear",
+      DEFAULT_PROPS.groupIds,
+      DEFAULT_PROPS.dn,
+    );
+  });
+
+  it("confirms when deleting groups", () => {
+    setup();
+
+    userEvent.click(screen.getByLabelText("Also delete the group"));
+
+    userEvent.click(
+      screen.getByRole("button", { name: "Remove mapping and delete group" }),
+    );
+
+    expect(DEFAULT_PROPS.onConfirm).toHaveBeenCalledWith(
+      "delete",
+      DEFAULT_PROPS.groupIds,
+      DEFAULT_PROPS.dn,
+    );
   });
 });

--- a/frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget/DeleteGroupMappingModal/DeleteGroupMappingModal.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget/DeleteGroupMappingModal/DeleteGroupMappingModal.unit.spec.tsx
@@ -37,7 +37,7 @@ describe("DeleteGroupMappingModal", () => {
     ).toBeInTheDocument();
 
     expect(
-      screen.getByText("Also remove all group members"),
+      screen.getByText("Also remove all group members (except from Admin)"),
     ).toBeInTheDocument();
 
     expect(screen.getByText("Also delete the group")).toBeInTheDocument();
@@ -51,7 +51,7 @@ describe("DeleteGroupMappingModal", () => {
     ).toBeInTheDocument();
 
     expect(
-      screen.getByText("Also remove all group members"),
+      screen.getByText("Also remove all group members (except from Admin)"),
     ).toBeInTheDocument();
 
     expect(
@@ -70,7 +70,11 @@ describe("DeleteGroupMappingModal", () => {
   it("confirms when clearing members", () => {
     setup();
 
-    userEvent.click(screen.getByLabelText("Also remove all group members"));
+    userEvent.click(
+      screen.getByLabelText(
+        "Also remove all group members (except from Admin)",
+      ),
+    );
 
     userEvent.click(
       screen.getByRole("button", { name: "Remove mapping and members" }),

--- a/frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget/DeleteGroupMappingModal/DeleteGroupMappingModal.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget/DeleteGroupMappingModal/DeleteGroupMappingModal.unit.spec.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+
+import DeleteGroupMappingModal from ".";
+import type { DeleteGroupMappingModalProps } from ".";
+
+const DEFAULT_PROPS = {
+  dn: "cn=People",
+  groupIds: [1],
+  onConfirm: jest.fn(),
+  onHide: jest.fn(),
+};
+
+const setup = (props?: DeleteGroupMappingModalProps) => {
+  render(<DeleteGroupMappingModal {...DEFAULT_PROPS} />);
+};
+
+describe("DeleteGroupMappingModal", () => {
+  it("something", () => {
+    setup();
+
+    expect(
+      screen.getByText("Nothing, just remove the mapping"),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget/DeleteGroupMappingModal/DeleteGroupMappingModal.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget/DeleteGroupMappingModal/DeleteGroupMappingModal.unit.spec.tsx
@@ -4,14 +4,11 @@ import userEvent from "@testing-library/user-event";
 
 import type { GroupIds, DNType, ValueType } from "./DeleteGroupMappingModal";
 
-import DeleteGroupMappingModal from "./DeleteGroupMappingModal";
+import DeleteGroupMappingModal, {
+  DeleteGroupMappingModalProps,
+} from "./DeleteGroupMappingModal";
 
-type PropTypes = {
-  dn?: DNType;
-  groupIds?: GroupIds;
-  onConfirm?: (value: ValueType, groups: number[], dn: DNType) => void;
-  onHide?: () => void;
-};
+type SetupOpts = Partial<DeleteGroupMappingModalProps>;
 
 const DEFAULT_PROPS = {
   dn: "cn=People",
@@ -20,7 +17,7 @@ const DEFAULT_PROPS = {
   onHide: jest.fn(),
 };
 
-const setup = (props?: PropTypes) => {
+const setup = (props?: SetupOpts) => {
   render(<DeleteGroupMappingModal {...DEFAULT_PROPS} {...props} />);
 };
 

--- a/frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget/DeleteGroupMappingModal/DeleteGroupMappingModal.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget/DeleteGroupMappingModal/DeleteGroupMappingModal.unit.spec.tsx
@@ -2,9 +2,9 @@ import React from "react";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
-import type { GroupIds, DNType, ValueType } from ".";
+import type { GroupIds, DNType, ValueType } from "./DeleteGroupMappingModal";
 
-import DeleteGroupMappingModal from ".";
+import DeleteGroupMappingModal from "./DeleteGroupMappingModal";
 
 type PropTypes = {
   dn?: DNType;

--- a/frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget/DeleteGroupMappingModal/index.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget/DeleteGroupMappingModal/index.tsx
@@ -1,0 +1,1 @@
+export { default } from "./DeleteGroupMappingModal";

--- a/frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget/DeleteGroupMappingModal/index.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget/DeleteGroupMappingModal/index.tsx
@@ -1,1 +1,2 @@
 export { default } from "./DeleteGroupMappingModal";
+export type { DeleteGroupMappingModalProps } from "./DeleteGroupMappingModal";

--- a/frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget/DeleteGroupMappingModal/index.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget/DeleteGroupMappingModal/index.tsx
@@ -1,2 +1,2 @@
 export { default } from "./DeleteGroupMappingModal";
-export type { DeleteGroupMappingModalProps } from "./DeleteGroupMappingModal";
+export type { GroupIds, DNType, ValueType } from "./DeleteGroupMappingModal";

--- a/frontend/src/metabase/services.js
+++ b/frontend/src/metabase/services.js
@@ -376,7 +376,7 @@ export const PermissionsApi = {
   createMembership: POST("/api/permissions/membership"),
   deleteMembership: DELETE("/api/permissions/membership/:id"),
   updateMembership: PUT("/api/permissions/membership/:id"),
-  clearGroupMembership: PUT("/api/permissions/membership/:group-id/clear"),
+  clearGroupMembership: PUT("/api/permissions/membership/:id/clear"),
   updateGroup: PUT("/api/permissions/group/:id"),
   deleteGroup: DELETE("/api/permissions/group/:id"),
 };

--- a/frontend/src/metabase/services.js
+++ b/frontend/src/metabase/services.js
@@ -376,6 +376,7 @@ export const PermissionsApi = {
   createMembership: POST("/api/permissions/membership"),
   deleteMembership: DELETE("/api/permissions/membership/:id"),
   updateMembership: PUT("/api/permissions/membership/:id"),
+  clearGroupMembership: PUT("/api/permissions/membership/:group-id/clear"),
   updateGroup: PUT("/api/permissions/group/:id"),
   deleteGroup: DELETE("/api/permissions/group/:id"),
 };


### PR DESCRIPTION
Partially resolves https://github.com/metabase/metabase/issues/27212

### How to Test

📺 **Loom Demo**: https://www.loom.com/share/d90a32af70114d07bbf37b946e3b009b

1. In http://localhost:3000/admin/people/groups, create a few groups, and populate them with users
2. In http://localhost:3000/admin/settings/authentication/ldap, scroll all the way down and click on `Edit Mappings`
3. Create mappings, and populate them with zero to several groups each.
4. Save
5. Remove mappings
6. If a mapping is not linked to any groups, the mapping will simply disappear from the list. 
7. If a mapping is linked to one group, a modal will be displayed, with options on what to do about the groups in the mappings and copy using "group" in the singular from whenever appropriate.
8. If a mapping is linked to more than one group, a modal will be displayed, with options on what to do about the groups in the mappings and copy using "group" in the plural from whenever appropriate.

9. Save

Back in http://localhost:3000/admin/people/groups, you should:
1. no longer see the groups you had marked for deletion (Admin should still be there)
2. no longer see users in groups you had marked for emptying of users (Admin should still have the same users as before)

#### Corner cases 

1. If you create a mapping and click to Remove it before saving, no modal will appear. The groups mapped will not be affected.

### What will follow in upcoming PRs

1. The Mapping interaction will be inlined, removed from the Modal.
2. Unit tests for GroupMappingsWidget will be added.
3. Break-down GroupMappingsWidget.

