### PR TITLE
More tests for Parameters with source is a card.

### DIFF
--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -2047,36 +2047,82 @@
                     :has_more_values false}
                    (mt/user-http-request :rasta :get 200 url)))))))))
 
+(defn- card-fields-from-table-metadata
+  [card-id]
+  (:fields (mt/user-http-request :rasta :get 200 (format "/table/card__%d/query_metadata" card-id))))
+
 (deftest parameter-values-from-card-test
   ;; TODO add permissions tests
-  (mt/with-temp*
-    [Card      [{card-id         :id}
-                (merge (mt/card-with-source-metadata-for-query (mt/mbql-query venues {:limit 5}))
-                       {:database_id     (mt/id)
-                        :table_id        (mt/id :venues)})]
-     Dashboard [{dashboard-id :id}
-                {:parameters [{:id                   "abc"
-                               :type                 "category"
-                               :name                 "CATEGORY"
-                               :values_source_type   "card"
-                               :values_source_config {:card_id     card-id
-                                                      :value_field (mt/$ids $venues.name)}}]}]]
+  (testing "getting values"
+    (mt/with-temp*
+      [Card      [{card-id         :id}
+                  (merge (mt/card-with-source-metadata-for-query (mt/mbql-query venues {:limit 5}))
+                         {:database_id     (mt/id)
+                          :table_id        (mt/id :venues)})]
+       Dashboard [{dashboard-id :id}
+                  {:parameters [{:id                   "abc"
+                                 :type                 "category"
+                                 :name                 "CATEGORY"
+                                 :values_source_type   "card"
+                                 :values_source_config {:card_id     card-id
+                                                        :value_field (mt/$ids $venues.name)}}]}]]
 
-    (testing "It uses the results of the card's query execution"
-      (let-url [url (chain-filter-values-url dashboard-id "abc")]
-        (is (= {:values          ["Red Medicine"
-                                  "Stout Burgers & Beers"
-                                  "The Apple Pan"
-                                  "Wurstküche"
-                                  "Brite Spot Family Restaurant"]
-                :has_more_values false}
-               (mt/user-http-request :rasta :get 200 url)))))
+      (testing "It uses the results of the card's query execution"
+        (let-url [url (chain-filter-values-url dashboard-id "abc")]
+          (is (= {:values          ["Red Medicine"
+                                    "Stout Burgers & Beers"
+                                    "The Apple Pan"
+                                    "Wurstküche"
+                                    "Brite Spot Family Restaurant"]
+                  :has_more_values false}
+                 (mt/user-http-request :rasta :get 200 url)))))
 
-    (testing "it only returns search matches"
-      (let-url [url (chain-filter-search-url dashboard-id "abc" "red")]
-        (is (= {:values          ["Red Medicine"]
-                :has_more_values false}
-               (mt/user-http-request :rasta :get 200 url)))))))
+      (testing "it only returns search matches"
+        (let-url [url (chain-filter-search-url dashboard-id "abc" "red")]
+          (is (= {:values          ["Red Medicine"]
+                  :has_more_values false}
+                 (mt/user-http-request :rasta :get 200 url))))))
+
+    (testing "field selection should compatible with field-id from /api/table/:card__id/query_metadata"
+      ;; FE use the id returned by /api/table/:card__id/query_metadata
+      ;; for the `values_source_config.value_field`, so we need to test to make sure
+      ;; the id is a valid field that we could use to retrieve values.
+      (mt/with-temp*
+        [;; card with agggregation and binning columns
+         Card [{mbql-card-id :id}
+               (merge (mt/card-with-source-metadata-for-query
+                        (mt/mbql-query venues {:limit 5
+                                               :aggregation [:count]
+                                               :breakout [[:field %latitude {:binning {:strategy :num-bins :num-bins 10}}]]}))
+                      {:name        "MBQL question"
+                       :database_id (mt/id)
+                       :table_id    (mt/id :venues)})]
+         Card [{native-card-id :id}
+               (merge (mt/card-with-source-metadata-for-query
+                        (mt/native-query {:query "select name from venues;"}))
+                      {:name        "Native question"
+                       :database_id (mt/id)
+                       :table_id    (mt/id :venues)})]]
+
+        (let [mbql-card-fields   (card-fields-from-table-metadata mbql-card-id)
+              native-card-fields (card-fields-from-table-metadata native-card-id)
+              fields->parameter  (fn [fields card-id]
+                                   (for [{:keys [id field_ref name]} fields]
+                                     {:id                   (format "id_%s" name)
+                                      :type                 "category"
+                                      :name                 name
+                                      :values_source_type   "card"
+                                      :values_source_config {:card_id     card-id
+                                                             :value_field (if (number? id)
+                                                                            field_ref
+                                                                            id)}}))
+              parameters         (concat
+                                   (fields->parameter mbql-card-fields mbql-card-id)
+                                   (fields->parameter native-card-fields native-card-id))]
+          (mt/with-temp Dashboard [{dash-id :id} {:parameters parameters}]
+            (doseq [param parameters]
+              (let-url [url (chain-filter-values-url dash-id (:id param))]
+                (is (some? (mt/user-http-request :rasta :get 200 url)))))))))))
 
 (deftest valid-filter-fields-test
   (testing "GET /api/dashboard/params/valid-filter-fields"

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -2088,8 +2088,8 @@
       ;; for the `values_source_config.value_field`, so we need to test to make sure
       ;; the id is a valid field that we could use to retrieve values.
       (mt/with-temp*
-        [;; card with agggregation and binning columns
-         Card [{mbql-card-id :id}
+        ;; card with agggregation and binning columns
+        [Card [{mbql-card-id :id}
                (merge (mt/card-with-source-metadata-for-query
                         (mt/mbql-query venues {:limit 5
                                                :aggregation [:count]


### PR DESCRIPTION
Epic: https://github.com/metabase/metabase/issues/26873

FE gets `value_field` for `dashboard.parameters[0].values_source_config` 
by search the fields by calling `/api/table/card__id/query_metadata`.

if a field has id as a number, then use `field_ref`, else use `id`.

This PR adds to make sure we could use this method for all kinds of field (aggregation, breakout, field from native query)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/27667)
<!-- Reviewable:end -->
