### PR TITLE
[CI] Fix Trivy scans timing out

### DIFF
--- a/.github/workflows/uberjar.yml
+++ b/.github/workflows/uberjar.yml
@@ -140,6 +140,8 @@ jobs:
     - name: Run Trivy vulnerability scanner if master (ee)
       if: ${{ (github.ref_name == 'master') && matrix.edition == 'ee' }}
       uses: aquasecurity/trivy-action@master
+      env:
+        TRIVY_OFFLINE_SCAN: true
       with:
         image-ref: docker.io/metabase/metabase-enterprise-head:latest
         format: sarif
@@ -148,6 +150,8 @@ jobs:
     - name: Run Trivy vulnerability scanner if master (oss)
       if: ${{ (github.ref_name == 'master') && matrix.edition == 'oss' }}
       uses: aquasecurity/trivy-action@master
+      env:
+        TRIVY_OFFLINE_SCAN: true
       with:
         image-ref: docker.io/metabase/metabase-head:latest
         format: sarif
@@ -156,6 +160,8 @@ jobs:
     - name: Run Trivy vulnerability scanner if dev branch
       if: ${{ !(startsWith(github.ref_name,'master') || startsWith(github.ref_name,'backport')) && matrix.edition == 'ee' }}
       uses: aquasecurity/trivy-action@master
+      env:
+        TRIVY_OFFLINE_SCAN: true
       with:
         image-ref: docker.io/metabase/metabase-dev:${{ steps.extract_branch.outputs.branch }}
         format: sarif


### PR DESCRIPTION
Our `master` branch is riddled with failed tests since yesterday.
The culprit is a Trivy scan in the `uberjar.yml` workflow.

Here's the [example of a failed run](https://github.com/metabase/metabase/actions/runs/3907601835/jobs/6677133688).

According to https://github.com/aquasecurity/trivy-action/issues/190, the solution could be to do the offline scan. That is what I'm trying in this PR.

I've triggered the workflow manually.
If it passes, this is good to go.