### PR TITLE
Add actions to public sharing admin settings

### DIFF
--- a/frontend/src/metabase-types/api/actions.ts
+++ b/frontend/src/metabase-types/api/actions.ts
@@ -7,6 +7,7 @@ import type {
   DashboardParameterMapping,
 } from "./dashboard";
 import type { Card, CardId } from "./card";
+import type { DatabaseId } from "./database";
 import type { UserId, UserInfo } from "./user";
 
 export interface WritebackParameter extends Parameter {
@@ -19,7 +20,7 @@ export type WritebackActionId = number;
 
 export interface WritebackActionBase {
   id: WritebackActionId;
-  model_id: number;
+  model_id: CardId;
   name: string;
   description: string | null;
   parameters: WritebackParameter[];
@@ -29,6 +30,7 @@ export interface WritebackActionBase {
   updated_at: string;
   created_at: string;
   public_uuid: string | null;
+  database_id?: DatabaseId;
 }
 
 export type PublicWritebackAction = Pick<

--- a/frontend/src/metabase-types/api/query.ts
+++ b/frontend/src/metabase-types/api/query.ts
@@ -1,6 +1,7 @@
-import { DatabaseId } from "./database";
-import { FieldId } from "./field";
-import { TableId } from "./table";
+import type { TemplateTags } from "../types/Query";
+import type { DatabaseId } from "./database";
+import type { FieldId } from "./field";
+import type { TableId } from "./table";
 
 export interface StructuredQuery {
   "source-table"?: TableId;
@@ -8,6 +9,7 @@ export interface StructuredQuery {
 
 export interface NativeQuery {
   query: string;
+  "template-tags"?: TemplateTags;
 }
 
 export interface StructuredDatasetQuery {

--- a/frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing/PublicLinksListing.jsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing/PublicLinksListing.jsx
@@ -1,16 +1,19 @@
 /* eslint-disable react/prop-types */
 import React, { Component } from "react";
+import { connect } from "react-redux";
 
 import { t } from "ttag";
 import Icon from "metabase/components/Icon";
+import { getSetting } from "metabase/selectors/settings";
 import Link from "metabase/core/components/Link";
 import ExternalLink from "metabase/core/components/ExternalLink";
 import Confirm from "metabase/components/Confirm";
 import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
-import { CardApi, DashboardApi } from "metabase/services";
+import { ActionsApi, CardApi, DashboardApi } from "metabase/services";
 import * as Urls from "metabase/lib/urls";
 
 import * as MetabaseAnalytics from "metabase/lib/analytics";
+import { RevokeIconWrapper } from "./PublicLinksListing.styled";
 
 export default class PublicLinksListing extends Component {
   constructor(props) {
@@ -74,13 +77,17 @@ export default class PublicLinksListing extends Component {
                 list.map(link => (
                   <tr key={link.id}>
                     <td>
-                      <Link
-                        to={getUrl(link)}
-                        onClick={() => this.trackEvent("Entity Link Clicked")}
-                        className="text-wrap"
-                      >
-                        {link.name}
-                      </Link>
+                      {getUrl ? (
+                        <Link
+                          to={getUrl(link)}
+                          onClick={() => this.trackEvent("Entity Link Clicked")}
+                          className="text-wrap"
+                        >
+                          {link.name}
+                        </Link>
+                      ) : (
+                        link.name
+                      )}
                     </td>
                     {getPublicUrl && (
                       <td>
@@ -103,10 +110,12 @@ export default class PublicLinksListing extends Component {
                             this.trackEvent("Revoked link");
                           }}
                         >
-                          <Icon
+                          <RevokeIconWrapper
                             name="close"
-                            className="text-light text-medium-hover cursor-pointer"
-                          />
+                            aria-label={t`Revoke link`}
+                          >
+                            <Icon name="close" />
+                          </RevokeIconWrapper>
                         </Confirm>
                       </td>
                     )}
@@ -140,6 +149,26 @@ export const PublicLinksQuestionListing = () => (
     getPublicUrl={({ public_uuid }) => Urls.publicQuestion(public_uuid)}
     noLinksMessage={t`No questions have been publicly shared yet.`}
   />
+);
+
+const mapStateToProps = state => ({
+  siteUrl: getSetting(state, "site-url"),
+});
+
+export const PublicLinksActionListing = connect(mapStateToProps)(
+  function PublicLinksActionListing({ siteUrl }) {
+    return (
+      <PublicLinksListing
+        load={ActionsApi.listPublic}
+        revoke={ActionsApi.deletePublicLink}
+        type={t`Public Action Listing`}
+        getPublicUrl={({ public_uuid }) =>
+          Urls.publicAction(siteUrl, public_uuid)
+        }
+        noLinksMessage={t`No actions have been publicly shared yet.`}
+      />
+    );
+  },
 );
 
 export const EmbeddedDashboardListing = () => (

--- a/frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing/PublicLinksListing.styled.ts
+++ b/frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing/PublicLinksListing.styled.ts
@@ -1,0 +1,12 @@
+import styled from "@emotion/styled";
+import IconButtonWrapper from "metabase/components/IconButtonWrapper";
+import { color } from "metabase/lib/colors";
+
+export const RevokeIconWrapper = styled(IconButtonWrapper)`
+  color: ${color("text-light")};
+  padding: 0;
+
+  &:hover {
+    color: ${color("text-medium")};
+  }
+`;

--- a/frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing/index.js
+++ b/frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing/index.js
@@ -1,0 +1,2 @@
+export { default } from "./PublicLinksListing";
+export * from "./PublicLinksListing";

--- a/frontend/src/metabase/admin/settings/components/widgets/SettingToggle.jsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/SettingToggle.jsx
@@ -4,13 +4,18 @@ import { t } from "ttag";
 import Toggle from "metabase/core/components/Toggle";
 import Tooltip from "metabase/core/components/Tooltip";
 
-const SettingToggle = ({ setting, onChange, disabled, tooltip }) => {
+const SettingToggle = ({ id, setting, onChange, disabled, tooltip }) => {
   const value = setting.value == null ? setting.default : setting.value;
   const on = value === true || value === "true";
   return (
     <div className="flex align-center pt1">
       <Tooltip tooltip={tooltip} isEnabled={!!tooltip}>
-        <Toggle value={on} onChange={!disabled ? () => onChange(!on) : null} />
+        <Toggle
+          id={id}
+          value={on}
+          onChange={!disabled ? () => onChange(!on) : null}
+          disabled={disabled}
+        />
       </Tooltip>
       <span className="text-bold mx1">{on ? t`Enabled` : t`Disabled`}</span>
     </div>

--- a/frontend/src/metabase/admin/settings/selectors.js
+++ b/frontend/src/metabase/admin/settings/selectors.js
@@ -18,6 +18,7 @@ import { EmbeddingCustomizationInfo } from "./components/widgets/EmbeddingCustom
 import {
   PublicLinksDashboardListing,
   PublicLinksQuestionListing,
+  PublicLinksActionListing,
   EmbeddedQuestionListing,
   EmbeddedDashboardListing,
 } from "./components/widgets/PublicLinksListing";
@@ -324,6 +325,12 @@ const SECTIONS = updateSectionsWithPlugins({
         key: "-public-sharing-questions",
         display_name: t`Shared Questions`,
         widget: PublicLinksQuestionListing,
+        getHidden: settings => !settings["enable-public-sharing"],
+      },
+      {
+        key: "-public-sharing-actions",
+        display_name: t`Shared Actions`,
+        widget: PublicLinksActionListing,
         getHidden: settings => !settings["enable-public-sharing"],
       },
     ],

--- a/frontend/src/metabase/lib/urls/actions.ts
+++ b/frontend/src/metabase/lib/urls/actions.ts
@@ -1,3 +1,9 @@
+import type { WritebackAction } from "metabase-types/api";
+
+export function action(action: WritebackAction) {
+  return `/model/${action.model_id}/detail/actions/${action.id}`;
+}
+
 export function publicAction(siteUrl: string, uuid: string) {
   return `${siteUrl}/public/action/${uuid}`;
 }

--- a/frontend/src/metabase/services.js
+++ b/frontend/src/metabase/services.js
@@ -504,4 +504,5 @@ export const ActionsApi = {
   execute: POST("/api/dashboard/:dashboardId/dashcard/:dashcardId/execute"),
   createPublicLink: POST("/api/action/:id/public_link"),
   deletePublicLink: DELETE("/api/action/:id/public_link"),
+  listPublic: GET("/api/action/public"),
 };

--- a/frontend/test/metabase/scenarios/admin/settings/public-sharing.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/public-sharing.cy.spec.js
@@ -1,0 +1,243 @@
+import { restore, modal, enableActionsForDB } from "__support__/e2e/helpers";
+import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
+import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
+
+const { ORDERS_ID } = SAMPLE_DATABASE;
+
+describe("scenarios > admin > settings > public sharing", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+  });
+
+  it("should be able to toggle public sharing", () => {
+    cy.visit("/admin/settings/public-sharing");
+    cy.findByLabelText("Enable Public Sharing")
+      .should("be.checked")
+      .click()
+      .should("not.be.checked");
+  });
+
+  it("should see public dashboards", () => {
+    const expectedDashboardName = "Public dashboard";
+    const expectedDashboardSlug = "public-dashboard";
+    cy.createQuestionAndDashboard({
+      dashboardDetails: {
+        name: expectedDashboardName,
+      },
+      questionDetails: {
+        name: "Question",
+        query: {
+          "source-table": ORDERS_ID,
+        },
+      },
+    })
+      .then(({ body }) => {
+        const dashboardId = body.dashboard_id;
+        cy.wrap(dashboardId).as("dashboardId");
+        cy.request("POST", `/api/dashboard/${dashboardId}/public_link`, {});
+      })
+      .then(response => {
+        cy.wrap(response.body.uuid).as("dashboardUuid");
+      });
+
+    cy.visit("/admin/settings/public-sharing");
+
+    cy.findByText("Shared Dashboards").should("be.visible");
+    cy.findByText(expectedDashboardName).should("be.visible");
+    cy.get("@dashboardUuid").then(dashboardUuid => {
+      cy.findByText(
+        `${location.origin}/public/dashboard/${dashboardUuid}`,
+      ).click();
+      cy.findByRole("heading", { name: expectedDashboardName }).should(
+        "be.visible",
+      );
+      cy.visit("/admin/settings/public-sharing");
+    });
+
+    cy.get("@dashboardId").then(dashboardId => {
+      cy.findByText(expectedDashboardName).click();
+      cy.url().should(
+        "eq",
+        `${location.origin}/dashboard/${dashboardId}-${expectedDashboardSlug}`,
+      );
+      cy.visit("/admin/settings/public-sharing");
+    });
+
+    cy.button("Revoke link").click();
+    modal().within(() => {
+      cy.findByText("Disable this link?").should("be.visible");
+      cy.button("Yes").click();
+    });
+    cy.findByText("No dashboards have been publicly shared yet.").should(
+      "be.visible",
+    );
+  });
+
+  it("should see public questions", () => {
+    const expectedQuestionName = "Public question";
+    const expectedQuestionSlug = "public-question";
+    cy.createQuestion({
+      name: expectedQuestionName,
+      query: {
+        "source-table": ORDERS_ID,
+      },
+    })
+      .then(({ body }) => {
+        const questionId = body.id;
+        cy.wrap(questionId).as("questionId");
+        cy.request("POST", `/api/card/${questionId}/public_link`, {});
+      })
+      .then(response => {
+        cy.wrap(response.body.uuid).as("questionUuid");
+      });
+
+    cy.visit("/admin/settings/public-sharing");
+
+    cy.findByText("Shared Questions").should("be.visible");
+    cy.findByText(expectedQuestionName).should("be.visible");
+    cy.get("@questionUuid").then(questionUuid => {
+      cy.findByText(
+        `${location.origin}/public/question/${questionUuid}`,
+      ).click();
+      cy.findByRole("heading", { name: expectedQuestionName }).should(
+        "be.visible",
+      );
+      cy.visit("/admin/settings/public-sharing");
+    });
+
+    cy.get("@questionId").then(questionId => {
+      cy.findByText(expectedQuestionName).click();
+      cy.url().should(
+        "eq",
+        `${location.origin}/question/${questionId}-${expectedQuestionSlug}`,
+      );
+      cy.visit("/admin/settings/public-sharing");
+    });
+
+    cy.button("Revoke link").click();
+    modal().within(() => {
+      cy.findByText("Disable this link?").should("be.visible");
+      cy.button("Yes").click();
+    });
+    cy.findByText("No questions have been publicly shared yet.").should(
+      "be.visible",
+    );
+  });
+
+  it("should see public actions", () => {
+    enableActionsForDB();
+    const expectedActionName = "Public action";
+
+    cy.createQuestion({
+      name: "Model",
+      query: {
+        "source-table": ORDERS_ID,
+      },
+      dataset: true,
+    }).then(({ body }) => {
+      const modelId = body.id;
+      cy.wrap(modelId).as("modelId");
+    });
+
+    cy.get("@modelId").then(modelId => {
+      createAction({
+        name: expectedActionName,
+        model_id: modelId,
+      }).then(({ body }) => {
+        const actionId = body.id;
+        cy.wrap(actionId).as("actionId");
+      });
+    });
+
+    cy.get("@actionId")
+      .then(actionId => {
+        cy.request("POST", `/api/action/${actionId}/public_link`, {});
+      })
+      .then(({ body }) => {
+        cy.wrap(body.uuid).as("actionUuid");
+      });
+
+    cy.visit("/admin/settings/public-sharing");
+
+    cy.findByText("Shared Actions").should("be.visible");
+    cy.findByText(expectedActionName).should("be.visible");
+    cy.get("@actionUuid").then(actionUuid => {
+      cy.findByText(`${location.origin}/public/action/${actionUuid}`).click();
+      cy.findByRole("heading", { name: expectedActionName }).should(
+        "be.visible",
+      );
+      cy.visit("/admin/settings/public-sharing");
+    });
+
+    cy.findByText(expectedActionName).should("not.have.attr", "href");
+
+    cy.button("Revoke link").click();
+    modal().within(() => {
+      cy.findByText("Disable this link?").should("be.visible");
+      cy.button("Yes").click();
+    });
+    cy.findByText("No actions have been publicly shared yet.").should(
+      "be.visible",
+    );
+  });
+});
+
+/**
+ *
+ * @param {import("metabase/entities/actions/actions").CreateQueryActionParams} actionDetails
+ */
+function createAction(actionDetails) {
+  const defaultActionDetails = {
+    database_id: SAMPLE_DB_ID,
+    dataset_query: {
+      database: SAMPLE_DB_ID,
+      native: {
+        query: "UPDATE orders SET quantity = 0 WHERE id = {{order_id}}",
+        "template-tags": {
+          order_id: {
+            "display-name": "Order ID",
+            id: "fake-uuid",
+            name: "order_id",
+            type: "text",
+          },
+        },
+      },
+      type: "native",
+    },
+    name: "Reset order quantity",
+    description: "Set order quantity to 0",
+    type: "query",
+    parameters: [
+      {
+        id: "fake-uuid",
+        hasVariableTemplateTagTarget: true,
+        name: "Order ID",
+        slug: "order_id",
+        type: "string/=",
+        target: ["variable", ["template-tag", "fake-uuid"]],
+      },
+    ],
+    visualization_settings: {
+      fields: {
+        "fake-uuid": {
+          id: "fake-uuid",
+          fieldType: "string",
+          inputType: "string",
+          hidden: false,
+          order: 999,
+          required: true,
+          name: "",
+          title: "",
+          placeholder: "",
+          description: "",
+        },
+      },
+      type: "button",
+    },
+  };
+  return cy.request("POST", "/api/action", {
+    ...defaultActionDetails,
+    ...actionDetails,
+  });
+}


### PR DESCRIPTION
- **Epic**: #27626
- **Integration PR**: https://github.com/metabase/metabase/pull/27845

## Demo
<img width="1448" alt="image" src="https://user-images.githubusercontent.com/1937582/217960509-8e574b20-a712-49e2-9226-26314801383a.png">

## How to test
1. Create an action
2. Make it public
3. Go to **Admin settings** > **Public Sharing**
4. Should see the new **SHARED ACTIONS** section
5. Clicking the action should lead to the action page (no page is up yet, so you'll be redirected to the model detail page instead)
6. Should see the public URL and clicking it should show the public action page
7. Should see the revoke icon and after clicking it and click to confirm, that action should disappear from the page.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/27675)
<!-- Reviewable:end -->
