### PR TITLE
Fix navigating from dashboard to card with string filters

### DIFF
--- a/frontend/src/metabase-lib/parameters/utils/mbql.js
+++ b/frontend/src/metabase-lib/parameters/utils/mbql.js
@@ -13,7 +13,10 @@ import {
   isDateParameter,
 } from "metabase-lib/parameters/utils/parameter-type";
 import { isTemplateTagReference } from "metabase-lib/references";
-import { getParameterOperatorName } from "metabase-lib/parameters/utils/operators";
+import {
+  deriveFieldOperatorFromParameter,
+  getParameterOperatorName,
+} from "metabase-lib/parameters/utils/operators";
 import { hasParameterValue } from "metabase-lib/parameters/utils/parameter-values";
 
 const withTemporalUnit = (fieldRef, unit) => {
@@ -144,11 +147,15 @@ export function dateParameterValueToMBQL(parameterValue, fieldRef) {
 }
 
 export function stringParameterValueToMBQL(parameter, fieldRef) {
+  const operator = deriveFieldOperatorFromParameter(parameter);
   const parameterValue = parameter.value;
-  const subtype = getParameterSubType(parameter);
-  const operatorName = getParameterOperatorName(subtype);
 
-  return [operatorName, fieldRef].concat(parameterValue);
+  const filter = [operator.name, fieldRef].concat(parameterValue);
+  if (operator.optionsDefaults) {
+    filter.push(operator.optionsDefaults);
+  }
+
+  return filter;
 }
 
 export function numberParameterValueToMBQL(parameter, fieldRef) {

--- a/frontend/src/metabase-lib/parameters/utils/mbql.js
+++ b/frontend/src/metabase-lib/parameters/utils/mbql.js
@@ -147,15 +147,14 @@ export function dateParameterValueToMBQL(parameterValue, fieldRef) {
 }
 
 export function stringParameterValueToMBQL(parameter, fieldRef) {
-  const operator = deriveFieldOperatorFromParameter(parameter);
   const parameterValue = parameter.value;
+  const operator = deriveFieldOperatorFromParameter(parameter);
+  const subtype = getParameterSubType(parameter);
+  const operatorName = getParameterOperatorName(subtype);
 
-  const filter = [operator.name, fieldRef].concat(parameterValue);
-  if (operator.optionsDefaults) {
-    filter.push(operator.optionsDefaults);
-  }
-
-  return filter;
+  return [operatorName, fieldRef]
+    .concat(parameterValue)
+    .concat(operator?.optionsDefaults ?? []);
 }
 
 export function numberParameterValueToMBQL(parameter, fieldRef) {

--- a/frontend/src/metabase-lib/parameters/utils/mbql.unit.spec.js
+++ b/frontend/src/metabase-lib/parameters/utils/mbql.unit.spec.js
@@ -183,7 +183,14 @@ describe("parameters/utils/mbql", () => {
             { type: "string/starts-with", value: "1" },
             null,
           ),
-        ).toEqual(["starts-with", null, "1"]);
+        ).toEqual([
+          "starts-with",
+          null,
+          "1",
+          {
+            "case-sensitive": false,
+          },
+        ]);
       });
     });
 
@@ -278,12 +285,19 @@ describe("parameters/utils/mbql", () => {
         fieldFilterParameterToMBQLFilter(
           {
             target: ["dimension", ["field", PRODUCTS.CATEGORY.id, null]],
-            type: "string/starts-with",
+            type: "string/contains",
             value: "foo",
           },
           metadata,
         ),
-      ).toEqual(["starts-with", ["field", PRODUCTS.CATEGORY.id, null], "foo"]);
+      ).toEqual([
+        "contains",
+        ["field", PRODUCTS.CATEGORY.id, null],
+        "foo",
+        {
+          "case-sensitive": false,
+        },
+      ]);
 
       expect(
         fieldFilterParameterToMBQLFilter(
@@ -294,7 +308,12 @@ describe("parameters/utils/mbql", () => {
           },
           metadata,
         ),
-      ).toEqual(["starts-with", ["field", PRODUCTS.CATEGORY.id, null], "foo"]);
+      ).toEqual([
+        "starts-with",
+        ["field", PRODUCTS.CATEGORY.id, null],
+        "foo",
+        { "case-sensitive": false },
+      ]);
     });
 
     it("should return mbql filter for category parameter", () => {

--- a/frontend/src/metabase-lib/parameters/utils/operators.ts
+++ b/frontend/src/metabase-lib/parameters/utils/operators.ts
@@ -57,7 +57,7 @@ function getParameterOperatorType(parameterType?: string) {
       // id can technically be a FK but doesn't matter as both use default filter operators
       return PRIMARY_KEY;
     default:
-      return undefined;
+      return STRING;
   }
 }
 

--- a/frontend/src/metabase-lib/parameters/utils/operators.ts
+++ b/frontend/src/metabase-lib/parameters/utils/operators.ts
@@ -57,7 +57,7 @@ function getParameterOperatorType(parameterType?: string) {
       // id can technically be a FK but doesn't matter as both use default filter operators
       return PRIMARY_KEY;
     default:
-      return STRING;
+      return undefined;
   }
 }
 

--- a/frontend/test/metabase-lib/lib/Question.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/Question.unit.spec.js
@@ -1227,6 +1227,7 @@ describe("Question", () => {
         "starts-with",
         ["field", PRODUCTS.CATEGORY.id, null],
         "abc",
+        { "case-sensitive": false },
       ]);
     });
   });

--- a/frontend/test/metabase/scenarios/dashboard-filters/reproductions/25908-contains-filter-case-sensitivity.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters/reproductions/25908-contains-filter-case-sensitivity.cy.spec.js
@@ -24,7 +24,7 @@ const dashboardDetails = {
 
 const CASE_INSENSITIVE_ROWS = 30;
 
-describe.skip("issue 25908", () => {
+describe("issue 25908", () => {
   beforeEach(() => {
     cy.intercept("POST", "/api/dataset").as("dataset");
 


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/25908

When navigating to a question from a dashboard with some string filters (e.g. `contains`), we'll add make the corresponding question filters case-insensitive to match the dashboard behavior.

How to test:
- Follow the steps from the original issue or
- Run the unskipped cypress test

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/27687)
<!-- Reviewable:end -->
