### PR TITLE
Update react-virtualized to v9.22.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "react-sortable-hoc": "^1.11.0",
     "react-textarea-autosize": "^5.2.1",
     "react-transition-group": "1",
-    "react-virtualized": "^9.7.2",
+    "react-virtualized": "^9.22.3",
     "redux": "^4.2.0",
     "redux-actions": "^2.0.1",
     "redux-auth-wrapper": "^1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -18045,10 +18045,10 @@ react-use-measure@^2.0.4:
   dependencies:
     debounce "^1.2.1"
 
-react-virtualized@^9.7.2:
-  version "9.22.2"
-  resolved "https://registry.yarnpkg.com/react-virtualized/-/react-virtualized-9.22.2.tgz#217a870bad91e5438f46f01a009e1d8ce1060a5a"
-  integrity sha512-5j4h4FhxTdOpBKtePSs1yk6LDNT4oGtUwjT7Nkh61Z8vv3fTG/XeOf8J4li1AYaexOwTXnw0HFVxsV0GBUqwRw==
+react-virtualized@^9.22.3:
+  version "9.22.3"
+  resolved "https://registry.yarnpkg.com/react-virtualized/-/react-virtualized-9.22.3.tgz#f430f16beb0a42db420dbd4d340403c0de334421"
+  integrity sha512-MKovKMxWTcwPSxE1kK1HcheQTWfuCxAuBoSTf2gwyMM21NdX/PXUhnoP8Uc5dRKd+nKm8v41R36OellhdCpkrw==
   dependencies:
     "@babel/runtime" "^7.7.2"
     clsx "^1.0.4"


### PR DESCRIPTION
In working with `react-virtualized`, I discovered that we're on a ~6 year old version. The issue I was looking into wasn't actually solved by a version upgrade, but I've been using it locally and it doesn't seem to have broken anything.

https://www.npmjs.com/package/react-virtualized?activeTab=versions

The latest version is still two years old, but it seems like we might as well bump to the current one.