### PR TITLE
User Resizable Pivot Table Columns

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTable.styled.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTable.styled.tsx
@@ -2,7 +2,11 @@ import { css } from "@emotion/react";
 import styled from "@emotion/styled";
 import { color, alpha, darken } from "metabase/lib/colors";
 
-import { CELL_HEIGHT, PIVOT_TABLE_FONT_SIZE } from "./constants";
+import {
+  CELL_HEIGHT,
+  PIVOT_TABLE_FONT_SIZE,
+  RESIZE_HANDLE_WIDTH,
+} from "./constants";
 
 export const RowToggleIconRoot = styled.div`
   display: flex;
@@ -55,6 +59,7 @@ const getBorderColor = ({ isNightMode }: PivotTableCellProps) => {
 
 export const PivotTableCell = styled.div<PivotTableCellProps>`
   flex: 1 0 auto;
+  position: relative;
   flex-basis: 0;
   line-height: ${CELL_HEIGHT}px;
   min-width: 0;
@@ -115,4 +120,23 @@ export const PivotTableRoot = styled.div<PivotTableRootProps>`
 export const PivotTableSettingLabel = styled.span`
   font-weight: 700;
   color: ${color("text-dark")};
+`;
+
+export const ResizeHandle = styled.div`
+  z-index: 99;
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: -${RESIZE_HANDLE_WIDTH - 1}px;
+  width: ${RESIZE_HANDLE_WIDTH}px;
+
+  cursor: ew-resize;
+
+  &:active {
+    background-color: ${color("brand")};
+  }
+
+  &:hover {
+    background-color: ${color("brand")};
+  }
 `;

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTable.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTable.tsx
@@ -167,6 +167,7 @@ function PivotTable({
   useEffect(() => {
     if (!pivoted?.rowIndexes) {
       setHeaderWidths({ leftHeaderWidths: null, totalHeaderWidths: null });
+      return;
     }
 
     if (!pivoted?.rowIndexes || columnsChanged) {

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTable.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTable.tsx
@@ -170,7 +170,7 @@ function PivotTable({
       return;
     }
 
-    if (!pivoted?.rowIndexes || columnsChanged) {
+    if (columnsChanged) {
       setHeaderWidths(
         getLeftHeaderWidths({
           rowIndexes: pivoted?.rowIndexes,
@@ -338,9 +338,7 @@ function PivotTable({
                       cellRenderer={({ index, style, key }) => (
                         <LeftHeaderCell
                           key={key}
-                          style={{
-                            ...style,
-                          }}
+                          style={style}
                           item={leftHeaderItems[index]}
                           rowIndex={rowIndex}
                           onUpdateVisualizationSettings={

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTable.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTable.tsx
@@ -26,7 +26,7 @@ import type { DatasetData } from "metabase-types/types/Dataset";
 import type { VisualizationSettings } from "metabase-types/api";
 import type { State } from "metabase-types/store";
 
-import type { PivotTableClicked } from "./types";
+import type { PivotTableClicked, HeaderWidthType } from "./types";
 
 import { RowToggleIcon } from "./RowToggleIcon";
 
@@ -51,7 +51,12 @@ import {
   topHeaderCellSizeAndPositionGetter,
 } from "./utils";
 
-import { CELL_WIDTH, CELL_HEIGHT, LEFT_HEADER_LEFT_SPACING } from "./constants";
+import {
+  CELL_WIDTH,
+  CELL_HEIGHT,
+  LEFT_HEADER_LEFT_SPACING,
+  MIN_HEADER_CELL_WIDTH,
+} from "./constants";
 import { settings, _columnSettings as columnSettings } from "./settings";
 
 const mapStateToProps = (state: State) => ({
@@ -80,6 +85,12 @@ function PivotTable({
   onVisualizationClick,
 }: PivotTableProps) {
   const [gridElement, setGridElement] = useState<HTMLElement | null>(null);
+  const [{ leftHeaderWidths, totalHeaderWidths }, setHeaderWidths] =
+    useState<HeaderWidthType>({
+      leftHeaderWidths: null,
+      totalHeaderWidths: null,
+    });
+
   const bodyRef = useRef(null);
   const leftHeaderRef = useRef(null);
   const topHeaderRef = useRef(null);
@@ -148,17 +159,19 @@ function PivotTable({
     }
   }
 
-  const { leftHeaderWidths, totalHeaderWidths } = useMemo(() => {
+  useEffect(() => {
     if (!pivoted?.rowIndexes) {
-      return { leftHeaderWidths: null, totalHeaderWidths: null };
+      setHeaderWidths({ leftHeaderWidths: null, totalHeaderWidths: null });
     }
 
-    return getLeftHeaderWidths({
-      rowIndexes: pivoted?.rowIndexes,
-      getColumnTitle: idx => getColumnTitle(idx),
-      leftHeaderItems: pivoted?.leftHeaderItems,
-      fontFamily: fontFamily,
-    });
+    setHeaderWidths(
+      getLeftHeaderWidths({
+        rowIndexes: pivoted?.rowIndexes,
+        getColumnTitle: idx => getColumnTitle(idx),
+        leftHeaderItems: pivoted?.leftHeaderItems,
+        fontFamily: fontFamily,
+      }),
+    );
   }, [
     pivoted?.rowIndexes,
     pivoted?.leftHeaderItems,
@@ -166,7 +179,7 @@ function PivotTable({
     getColumnTitle,
   ]);
 
-  if (pivoted === null) {
+  if (pivoted === null || !leftHeaderWidths) {
     return null;
   }
 

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTable.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTable.tsx
@@ -144,6 +144,7 @@ function PivotTable({
   }, [data, settings]);
 
   const previousRowIndexes = usePrevious(pivoted?.rowIndexes);
+  const columnsChanged = !_.isEqual(pivoted?.rowIndexes, previousRowIndexes);
 
   // In cases where there are horizontal scrollbars are visible AND the data grid has to scroll vertically as well,
   // the left sidebar and the main grid can get out of ScrollSync due to slightly differing heights
@@ -168,10 +169,7 @@ function PivotTable({
       setHeaderWidths({ leftHeaderWidths: null, totalHeaderWidths: null });
     }
 
-    if (
-      !pivoted?.rowIndexes ||
-      !_.isEqual(pivoted?.rowIndexes, previousRowIndexes)
-    ) {
+    if (!pivoted?.rowIndexes || columnsChanged) {
       setHeaderWidths(
         getLeftHeaderWidths({
           rowIndexes: pivoted?.rowIndexes,
@@ -186,7 +184,7 @@ function PivotTable({
     pivoted?.leftHeaderItems,
     fontFamily,
     getColumnTitle,
-    previousRowIndexes,
+    columnsChanged,
   ]);
 
   const handleColumnResize = (columnIndex: number, newWidth: number) => {
@@ -204,7 +202,7 @@ function PivotTable({
     });
   };
 
-  if (pivoted === null || !leftHeaderWidths) {
+  if (pivoted === null || !leftHeaderWidths || columnsChanged) {
     return null;
   }
 

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/RowToggleIcon.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/RowToggleIcon.tsx
@@ -42,8 +42,6 @@ export function RowToggleIcon({
     !isColumn && settingValue.includes(columnRef as string);
   const isCollapsed = settingValue.includes(ref) || isColumnCollapsed;
 
-  console.log(setting);
-
   if (hideUnlessCollapsed && !isCollapsed) {
     // subtotal rows shouldn't have an icon unless the section is collapsed
     return null;

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/constants.ts
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/constants.ts
@@ -18,3 +18,5 @@ export const MAX_HEADER_CELL_WIDTH =
 export const LEFT_HEADER_LEFT_SPACING = 24;
 
 export const MAX_ROWS_TO_MEASURE = 100;
+
+export const RESIZE_HANDLE_WIDTH = 5;

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/types.ts
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/types.ts
@@ -32,3 +32,8 @@ export interface HeaderItem {
 export type BodyItem = HeaderItem & {
   backgroundColor?: string;
 };
+
+export type HeaderWidthType = {
+  leftHeaderWidths: number[] | null;
+  totalHeaderWidths: number | null;
+};


### PR DESCRIPTION
resolves #27597

## Description

This makes the left header columns in pivot tables user-resizable by dragging, just like our standard table component.

## Implementation
- adds internal state for the pivot table column header widths, which is initially set based on the cell contents, but can be overridden by the user
- only resets cell widths when the columns change (e.g. a user changes a pivot row to a column)

## Screenshots
![pivotAdjustments](https://user-images.githubusercontent.com/30528226/212432253-a139da8d-e335-4c14-9240-dad0c1b4f945.gif)
![columnChanging](https://user-images.githubusercontent.com/30528226/212432260-bc8b968d-43da-4e40-93d2-75a5c36fa87b.gif)

## Further planned work

Allow Value columns to be resized https://github.com/metabase/metabase/issues/27691
Persist column widths for saved questions https://github.com/metabase/metabase/issues/27598


