### PR TITLE
Handle permission errors in the param modal

### DIFF
--- a/frontend/src/metabase/entities/containers/EntityObjectLoader.jsx
+++ b/frontend/src/metabase/entities/containers/EntityObjectLoader.jsx
@@ -58,7 +58,8 @@ class EntityObjectLoaderInner extends React.Component {
 
   fetch = (query, options) => {
     const fetch = this.props[this.props.requestType];
-    return fetch(query, options);
+    // errors are handled in redux actions
+    return fetch(query, options).catch(() => {});
   };
 
   UNSAFE_componentWillMount() {

--- a/frontend/src/metabase/parameters/components/ValuesSourceModal/ValuesSourceCardModal.tsx
+++ b/frontend/src/metabase/parameters/components/ValuesSourceModal/ValuesSourceCardModal.tsx
@@ -28,6 +28,7 @@ import {
   getQuestionIdFromVirtualTableId,
   getQuestionVirtualTableId,
 } from "metabase-lib/metadata/utils/saved-questions";
+import { ModalLoadingAndErrorWrapper } from "./ValuesSourceModal.styled";
 import {
   DataPickerContainer,
   ModalBodyWithSearch,
@@ -195,10 +196,12 @@ export default _.compose(
   Questions.load({
     id: (state: State, { sourceConfig: { card_id } }: ModalOwnProps) => card_id,
     entityAlias: "card",
+    LoadingAndErrorWrapper: ModalLoadingAndErrorWrapper,
   }),
   Collections.load({
     id: (state: State, { card }: ModalCardProps) =>
       card?.collection_id ?? "root",
+    LoadingAndErrorWrapper: ModalLoadingAndErrorWrapper,
   }),
   connect(mapStateToProps, mapDispatchToProps),
 )(ValuesSourceCardModal);

--- a/frontend/src/metabase/parameters/components/ValuesSourceModal/ValuesSourceModal.styled.tsx
+++ b/frontend/src/metabase/parameters/components/ValuesSourceModal/ValuesSourceModal.styled.tsx
@@ -1,5 +1,13 @@
 import styled from "@emotion/styled";
+import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
 
 export const ModalBody = styled.div`
   height: 50vh;
+`;
+
+export const ModalLoadingAndErrorWrapper = styled(LoadingAndErrorWrapper)`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: calc(50vh + 11.25rem);
 `;

--- a/frontend/src/metabase/parameters/components/ValuesSourceModal/ValuesSourceTypeModal.tsx
+++ b/frontend/src/metabase/parameters/components/ValuesSourceModal/ValuesSourceTypeModal.tsx
@@ -30,6 +30,7 @@ import {
   getFieldSourceValues,
   isValidSourceConfig,
 } from "metabase-lib/parameters/utils/parameter-source";
+import { ModalLoadingAndErrorWrapper } from "./ValuesSourceModal.styled";
 import {
   ModalHelpMessage,
   ModalLabel,
@@ -409,10 +410,12 @@ export default _.compose(
     id: (state: State, { sourceConfig: { card_id } }: ModalOwnProps) =>
       card_id ? getQuestionVirtualTableId(card_id) : undefined,
     requestType: "fetchMetadata",
+    LoadingAndErrorWrapper: ModalLoadingAndErrorWrapper,
   }),
   Questions.load({
     id: (state: State, { sourceConfig: { card_id } }: ModalOwnProps) => card_id,
     entityAlias: "card",
+    LoadingAndErrorWrapper: ModalLoadingAndErrorWrapper,
   }),
   connect(mapStateToProps, mapDispatchToProps),
 )(ValuesSourceTypeModal);

--- a/frontend/test/__support__/server-mocks/card.ts
+++ b/frontend/test/__support__/server-mocks/card.ts
@@ -5,6 +5,7 @@ import {
   getQuestionVirtualTableId,
   convertSavedQuestionToVirtualTable,
 } from "metabase-lib/metadata/utils/saved-questions";
+import { PERMISSION_ERROR } from "./constants";
 
 export function setupCardEndpoints(scope: Scope, card: Card) {
   scope.get(`/api/card/${card.id}`).reply(200, card);
@@ -26,4 +27,17 @@ export function setupCardEndpoints(scope: Scope, card: Card) {
 export function setupCardsEndpoints(scope: Scope, cards: Card[]) {
   scope.get("/api/card").reply(200, cards);
   cards.forEach(card => setupCardEndpoints(scope, card));
+}
+
+export function setupUnauthorizedCardEndpoints(scope: Scope, card: Card) {
+  scope.get(`/api/card/${card.id}`).reply(403, PERMISSION_ERROR);
+
+  const virtualTableId = getQuestionVirtualTableId(card.id);
+  scope
+    .get(`/api/table/${virtualTableId}/query_metadata`)
+    .reply(403, PERMISSION_ERROR);
+}
+
+export function setupUnauthorizedCardsEndpoints(scope: Scope, cards: Card[]) {
+  cards.forEach(card => setupUnauthorizedCardEndpoints(scope, card));
 }

--- a/frontend/test/__support__/server-mocks/constants.ts
+++ b/frontend/test/__support__/server-mocks/constants.ts
@@ -1,0 +1,1 @@
+export const PERMISSION_ERROR = "You don't have permissions to do that.";


### PR DESCRIPTION
Epic https://github.com/metabase/metabase/issues/26898

Modifies the values source modal to not emit the global permission error event. Instead the permission error will be displayed in the modal. Also sets a custom `LoadingAndErrorWrapper` to set the height matching the modal when loaded.

<img width="1728" alt="Screenshot 2023-01-16 at 17 36 25" src="https://user-images.githubusercontent.com/8542534/212715904-3b28d88c-26a8-4d0a-93fd-1aa619cba30f.png">

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/27704)
<!-- Reviewable:end -->
