### PR TITLE
Add values source settings to template tags

### DIFF
--- a/frontend/src/metabase-lib/parameters/constants.ts
+++ b/frontend/src/metabase-lib/parameters/constants.ts
@@ -148,11 +148,6 @@ export const LOCATION_OPTIONS = [
   },
 ];
 
-export const CUSTOM_SOURCE_PARAMETER_TYPES: Record<string, string[]> = {
-  string: ["="],
-  location: ["="],
-};
-
 export const TYPE_SUPPORTS_LINKED_FILTERS = [
   "string",
   "category",

--- a/frontend/src/metabase-lib/parameters/utils/parameter-source.ts
+++ b/frontend/src/metabase-lib/parameters/utils/parameter-source.ts
@@ -6,8 +6,10 @@ import {
   ValuesSourceConfig,
   ValuesSourceType,
 } from "metabase-types/api";
-import { getFields } from "metabase-lib/parameters/utils/parameter-fields";
 import Field from "metabase-lib/metadata/Field";
+import { CUSTOM_SOURCE_PARAMETER_TYPES } from "../constants";
+import { getFields } from "./parameter-fields";
+import { getParameterSubType, getParameterType } from "./parameter-type";
 
 export const getQueryType = (parameter: Parameter): ValuesQueryType => {
   return parameter.values_query_type ?? "list";
@@ -19,6 +21,16 @@ export const getSourceType = (parameter: Parameter): ValuesSourceType => {
 
 export const getSourceConfig = (parameter: Parameter): ValuesSourceConfig => {
   return parameter.values_source_config ?? {};
+};
+
+export const canUseCustomSource = (parameter: Parameter) => {
+  const type = getParameterType(parameter);
+  const subType = getParameterSubType(parameter);
+
+  return (
+    CUSTOM_SOURCE_PARAMETER_TYPES[type] != null &&
+    CUSTOM_SOURCE_PARAMETER_TYPES[type].includes(subType)
+  );
 };
 
 export const isValidSourceConfig = (

--- a/frontend/src/metabase-lib/parameters/utils/parameter-source.ts
+++ b/frontend/src/metabase-lib/parameters/utils/parameter-source.ts
@@ -7,7 +7,6 @@ import {
   ValuesSourceType,
 } from "metabase-types/api";
 import Field from "metabase-lib/metadata/Field";
-import { CUSTOM_SOURCE_PARAMETER_TYPES } from "../constants";
 import { getFields } from "./parameter-fields";
 import { getParameterSubType, getParameterType } from "./parameter-type";
 
@@ -27,10 +26,15 @@ export const canUseCustomSource = (parameter: Parameter) => {
   const type = getParameterType(parameter);
   const subType = getParameterSubType(parameter);
 
-  return (
-    CUSTOM_SOURCE_PARAMETER_TYPES[type] != null &&
-    CUSTOM_SOURCE_PARAMETER_TYPES[type].includes(subType)
-  );
+  switch (type) {
+    case "string":
+    case "location":
+      return subType === "=";
+    case "category":
+      return true;
+    default:
+      return false;
+  }
 };
 
 export const isValidSourceConfig = (

--- a/frontend/src/metabase-lib/parameters/utils/template-tags.ts
+++ b/frontend/src/metabase-lib/parameters/utils/template-tags.ts
@@ -38,6 +38,9 @@ export function getTemplateTagParameter(tag: TemplateTag): ParameterWithTarget {
     name: tag["display-name"],
     slug: tag.name,
     default: tag.default,
+    values_query_type: tag.values_query_type,
+    values_source_type: tag.values_source_type,
+    values_source_config: tag.values_source_config,
   };
 }
 

--- a/frontend/src/metabase-types/types/Query.ts
+++ b/frontend/src/metabase-types/types/Query.ts
@@ -3,6 +3,11 @@
  * @deprecated use existing types from, or add to metabase-types/api/*
  */
 
+import {
+  ValuesQueryType,
+  ValuesSourceConfig,
+  ValuesSourceType,
+} from "metabase-types/api";
 import { DatetimeUnit } from "metabase-types/api/query";
 import { TableId } from "./Table";
 import { FieldId, BaseType } from "./Field";
@@ -60,6 +65,11 @@ export type TemplateTag = {
   // Snippet specific
   "snippet-id"?: number;
   "snippet-name"?: string;
+
+  // Values source
+  values_query_type?: ValuesQueryType;
+  values_source_type?: ValuesSourceType;
+  values_source_config?: ValuesSourceConfig;
 };
 
 export type TemplateTags = { [key: TemplateTagName]: TemplateTag };

--- a/frontend/src/metabase/parameters/components/ParameterLinkedFilters/ParameterLinkedFilters.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterLinkedFilters/ParameterLinkedFilters.tsx
@@ -4,8 +4,13 @@ import Toggle from "metabase/core/components/Toggle";
 import Fields from "metabase/entities/fields";
 import Tables from "metabase/entities/tables";
 import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
-import { Field, FieldId, ParameterId, Table } from "metabase-types/api";
-import { UiParameter } from "metabase-lib/parameters/types";
+import {
+  Field,
+  FieldId,
+  Parameter,
+  ParameterId,
+  Table,
+} from "metabase-types/api";
 import { usableAsLinkedFilter } from "../../utils/linked-filters";
 import useFilterFields from "./use-filter-fields";
 import {
@@ -25,8 +30,8 @@ import {
 } from "./ParameterLinkedFilters.styled";
 
 export interface ParameterLinkedFiltersProps {
-  parameter: UiParameter;
-  otherParameters: UiParameter[];
+  parameter: Parameter;
+  otherParameters: Parameter[];
   onChangeFilteringParameters: (filteringParameters: ParameterId[]) => void;
   onShowAddParameterPopover: () => void;
 }
@@ -50,7 +55,7 @@ const ParameterLinkedFilters = ({
   );
 
   const handleFilterChange = useCallback(
-    (otherParameter: UiParameter, isFiltered: boolean) => {
+    (otherParameter: Parameter, isFiltered: boolean) => {
       const newParameters = isFiltered
         ? filteringParameters.concat(otherParameter.id)
         : filteringParameters.filter(id => id !== otherParameter.id);
@@ -61,7 +66,7 @@ const ParameterLinkedFilters = ({
   );
 
   const handleExpandedChange = useCallback(
-    (otherParameter: UiParameter, isExpanded: boolean) => {
+    (otherParameter: Parameter, isExpanded: boolean) => {
       setExpandedParameterId(isExpanded ? otherParameter.id : undefined);
     },
     [],
@@ -111,12 +116,12 @@ const ParameterLinkedFilters = ({
 };
 
 interface LinkedParameterProps {
-  parameter: UiParameter;
-  otherParameter: UiParameter;
+  parameter: Parameter;
+  otherParameter: Parameter;
   isFiltered: boolean;
   isExpanded: boolean;
-  onFilterChange: (otherParameter: UiParameter, isFiltered: boolean) => void;
-  onExpandedChange: (otherParameter: UiParameter, isExpanded: boolean) => void;
+  onFilterChange: (otherParameter: Parameter, isFiltered: boolean) => void;
+  onExpandedChange: (otherParameter: Parameter, isExpanded: boolean) => void;
 }
 
 const LinkedParameter = ({
@@ -157,8 +162,8 @@ const LinkedParameter = ({
 };
 
 interface LinkedFieldListProps {
-  parameter: UiParameter;
-  otherParameter: UiParameter;
+  parameter: Parameter;
+  otherParameter: Parameter;
 }
 
 const LinkedFieldList = ({

--- a/frontend/src/metabase/parameters/components/ParameterLinkedFilters/use-filter-fields.ts
+++ b/frontend/src/metabase/parameters/components/ParameterLinkedFilters/use-filter-fields.ts
@@ -2,8 +2,8 @@ import { useCallback, useState } from "react";
 import { t } from "ttag";
 import { DashboardApi } from "metabase/services";
 import { useOnMount } from "metabase/hooks/use-on-mount";
-import { FieldId } from "metabase-types/api";
-import { UiParameter } from "metabase-lib/parameters/types";
+import { FieldId, Parameter } from "metabase-types/api";
+import { getFields } from "metabase-lib/parameters/utils/parameter-fields";
 
 export interface UseFilterFieldsState {
   data?: FieldId[][];
@@ -12,14 +12,14 @@ export interface UseFilterFieldsState {
 }
 
 const useFilterFields = (
-  parameter: UiParameter,
-  otherParameter: UiParameter,
+  parameter: Parameter,
+  otherParameter: Parameter,
 ): UseFilterFieldsState => {
   const [state, setState] = useState<UseFilterFieldsState>({ loading: false });
 
   const handleLoad = useCallback(async () => {
-    const filtered = getParameterFieldIds(parameter);
-    const filtering = getParameterFieldIds(otherParameter);
+    const filtered = getFields(parameter).map(field => field.id);
+    const filtering = getFields(otherParameter).map(field => field.id);
 
     if (!filtered.length || !filtered.length) {
       const errorParameter = !filtered.length ? parameter : otherParameter;
@@ -40,16 +40,8 @@ const useFilterFields = (
   return state;
 };
 
-const getParameterError = ({ name }: UiParameter) => {
+const getParameterError = ({ name }: Parameter) => {
   return t`To view this, ${name} must be connected to at least one field.`;
-};
-
-const getParameterFieldIds = (parameter: UiParameter) => {
-  if ("fields" in parameter) {
-    return parameter.fields.map(field => field.id);
-  } else {
-    return [];
-  }
 };
 
 const getParameterMapping = (data: Record<FieldId, FieldId[]>) => {

--- a/frontend/src/metabase/parameters/components/ParameterSettings/ParameterSettings.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterSettings/ParameterSettings.tsx
@@ -3,11 +3,11 @@ import { t } from "ttag";
 import InputBlurChange from "metabase/components/InputBlurChange";
 import Radio from "metabase/core/components/Radio";
 import {
+  Parameter,
   ValuesQueryType,
   ValuesSourceConfig,
   ValuesSourceType,
 } from "metabase-types/api";
-import { UiParameter } from "metabase-lib/parameters/types";
 import { getIsMultiSelect } from "../../utils/dashboards";
 import {
   canUseCustomSource,
@@ -28,7 +28,7 @@ const MULTI_SELECT_OPTIONS = [
 ];
 
 export interface ParameterSettingsProps {
-  parameter: UiParameter;
+  parameter: Parameter;
   onChangeName: (name: string) => void;
   onChangeDefaultValue: (value: unknown) => void;
   onChangeIsMultiSelect: (isMultiSelect: boolean) => void;

--- a/frontend/src/metabase/parameters/components/ParameterSettings/ParameterSettings.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterSettings/ParameterSettings.tsx
@@ -8,11 +8,9 @@ import {
   ValuesSourceConfig,
   ValuesSourceType,
 } from "metabase-types/api";
+import { canUseCustomSource } from "metabase-lib/parameters/utils/parameter-source";
 import { getIsMultiSelect } from "../../utils/dashboards";
-import {
-  canUseCustomSource,
-  isSingleOrMultiSelectable,
-} from "../../utils/parameter-type";
+import { isSingleOrMultiSelectable } from "../../utils/parameter-type";
 import ValuesSourceSettings from "../ValuesSourceSettings";
 import {
   SettingLabel,

--- a/frontend/src/metabase/parameters/components/ParameterSidebar/ParameterSidebar.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterSidebar/ParameterSidebar.tsx
@@ -3,20 +3,20 @@ import { t } from "ttag";
 import Radio from "metabase/core/components/Radio";
 import Sidebar from "metabase/dashboard/components/Sidebar";
 import {
+  Parameter,
   ParameterId,
   ValuesQueryType,
   ValuesSourceConfig,
   ValuesSourceType,
 } from "metabase-types/api";
-import { UiParameter } from "metabase-lib/parameters/types";
 import { canUseLinkedFilters } from "../../utils/linked-filters";
 import ParameterSettings from "../ParameterSettings";
 import ParameterLinkedFilters from "../ParameterLinkedFilters";
 import { SidebarBody, SidebarHeader } from "./ParameterSidebar.styled";
 
 export interface ParameterSidebarProps {
-  parameter: UiParameter;
-  otherParameters: UiParameter[];
+  parameter: Parameter;
+  otherParameters: Parameter[];
   onChangeName: (parameterId: ParameterId, name: string) => void;
   onChangeDefaultValue: (parameterId: ParameterId, value: unknown) => void;
   onChangeIsMultiSelect: (
@@ -151,7 +151,7 @@ const ParameterSidebar = ({
   );
 };
 
-const getTabs = (parameter: UiParameter) => {
+const getTabs = (parameter: Parameter) => {
   const tabs = [{ value: "settings", name: t`Settings`, icon: "gear" }];
 
   if (canUseLinkedFilters(parameter)) {

--- a/frontend/src/metabase/parameters/components/ValuesSourceModal/ValuesSourceModal.tsx
+++ b/frontend/src/metabase/parameters/components/ValuesSourceModal/ValuesSourceModal.tsx
@@ -1,19 +1,22 @@
 import React, { useCallback, useMemo, useState } from "react";
-import { ValuesSourceConfig, ValuesSourceType } from "metabase-types/api";
+import {
+  Parameter,
+  ValuesSourceConfig,
+  ValuesSourceType,
+} from "metabase-types/api";
 import { getNonVirtualFields } from "metabase-lib/parameters/utils/parameter-fields";
 import {
   getSourceConfig,
   getSourceConfigForType,
   getSourceType,
 } from "metabase-lib/parameters/utils/parameter-source";
-import { UiParameter } from "metabase-lib/parameters/types";
 import ValuesSourceTypeModal from "./ValuesSourceTypeModal";
 import ValuesSourceCardModal from "./ValuesSourceCardModal";
 
 type ModalStep = "main" | "card";
 
 interface ModalProps {
-  parameter: UiParameter;
+  parameter: Parameter;
   onSubmit: (
     sourceType: ValuesSourceType,
     sourceConfig: ValuesSourceConfig,

--- a/frontend/src/metabase/parameters/components/ValuesSourceSettings/ValuesSourceSettings.tsx
+++ b/frontend/src/metabase/parameters/components/ValuesSourceSettings/ValuesSourceSettings.tsx
@@ -3,12 +3,12 @@ import { t } from "ttag";
 import Radio from "metabase/core/components/Radio/Radio";
 import Modal from "metabase/components/Modal";
 import {
+  Parameter,
   ValuesQueryType,
   ValuesSourceConfig,
   ValuesSourceType,
 } from "metabase-types/api";
 import { getQueryType } from "metabase-lib/parameters/utils/parameter-source";
-import { UiParameter } from "metabase-lib/parameters/types";
 import ValuesSourceModal from "../ValuesSourceModal";
 import {
   RadioLabelButton,
@@ -17,7 +17,7 @@ import {
 } from "./ValuesSourceSettings.styled";
 
 export interface ValuesSourceSettingsProps {
-  parameter: UiParameter;
+  parameter: Parameter;
   onChangeQueryType: (queryType: ValuesQueryType) => void;
   onChangeSourceType: (sourceType: ValuesSourceType) => void;
   onChangeSourceConfig: (sourceConfig: ValuesSourceConfig) => void;

--- a/frontend/src/metabase/parameters/utils/parameter-type.ts
+++ b/frontend/src/metabase/parameters/utils/parameter-type.ts
@@ -1,11 +1,8 @@
 import { Parameter } from "metabase-types/api";
+import { SINGLE_OR_MULTI_SELECTABLE_TYPES } from "metabase-lib/parameters/constants";
 import {
-  CUSTOM_SOURCE_PARAMETER_TYPES,
-  SINGLE_OR_MULTI_SELECTABLE_TYPES,
-} from "metabase-lib/parameters/constants";
-import {
-  getParameterType,
   getParameterSubType,
+  getParameterType,
 } from "metabase-lib/parameters/utils/parameter-type";
 
 export function isSingleOrMultiSelectable(parameter: Parameter): boolean {
@@ -20,13 +17,3 @@ export function isSingleOrMultiSelectable(parameter: Parameter): boolean {
   }
   return SINGLE_OR_MULTI_SELECTABLE_TYPES[type].includes(subType);
 }
-
-export const canUseCustomSource = (parameter: Parameter) => {
-  const type = getParameterType(parameter);
-  const subType = getParameterSubType(parameter);
-
-  return (
-    CUSTOM_SOURCE_PARAMETER_TYPES[type] != null &&
-    CUSTOM_SOURCE_PARAMETER_TYPES[type].includes(subType)
-  );
-};

--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx
@@ -12,13 +12,14 @@ import InputBlurChange from "metabase/components/InputBlurChange";
 import Select, { Option } from "metabase/core/components/Select";
 
 import ValuesSourceSettings from "metabase/parameters/components/ValuesSourceSettings";
-import { canUseCustomSource } from "metabase/parameters/utils/parameter-type";
 import { getParameterOptionsForField } from "metabase/parameters/utils/template-tag-options";
 
 import { fetchField } from "metabase/redux/metadata";
 import { getMetadata } from "metabase/selectors/metadata";
 import { SchemaTableAndFieldDataSelector } from "metabase/query_builder/components/DataSelector";
 import MetabaseSettings from "metabase/lib/settings";
+
+import { canUseCustomSource } from "metabase-lib/parameters/utils/parameter-source";
 
 import {
   ErrorSpan,

--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx
@@ -279,7 +279,7 @@ export class TagEditorParam extends Component {
 
         {parameter && canUseCustomSource(parameter) && (
           <InputContainer>
-            <ContainerLabel>{t`How should users filter on this column?`}</ContainerLabel>
+            <ContainerLabel>{t`How should users filter on this variable?`}</ContainerLabel>
             <ValuesSourceSettings
               parameter={parameter}
               onChangeQueryType={value =>

--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx
@@ -11,6 +11,8 @@ import Toggle from "metabase/core/components/Toggle";
 import InputBlurChange from "metabase/components/InputBlurChange";
 import Select, { Option } from "metabase/core/components/Select";
 
+import ValuesSourceSettings from "metabase/parameters/components/ValuesSourceSettings";
+import { canUseCustomSource } from "metabase/parameters/utils/parameter-type";
 import { getParameterOptionsForField } from "metabase/parameters/utils/template-tag-options";
 
 import { fetchField } from "metabase/redux/metadata";
@@ -273,6 +275,24 @@ export class TagEditorParam extends Component {
             onChange={value => this.setRequired(value)}
           />
         </InputContainer>
+
+        {parameter && canUseCustomSource(parameter) && (
+          <InputContainer>
+            <ContainerLabel>{t`How should users filter on this column?`}</ContainerLabel>
+            <ValuesSourceSettings
+              parameter={parameter}
+              onChangeQueryType={value =>
+                this.setParameterAttribute("values_query_type", value)
+              }
+              onChangeSourceType={value =>
+                this.setParameterAttribute("values_source_type", value)
+              }
+              onChangeSourceConfig={value =>
+                this.setParameterAttribute("values_source_config", value)
+              }
+            />
+          </InputContainer>
+        )}
 
         {((tag.type !== "dimension" && tag.required) ||
           tag.type === "dimension" ||

--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.unit.spec.jsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.unit.spec.jsx
@@ -23,6 +23,7 @@ jest.mock("metabase/query_builder/components/DataSelector", () => ({
 }));
 
 jest.mock("metabase/entities/schemas", () => ({
+  load: () => children => children,
   Loader: ({ children }) => children(),
 }));
 

--- a/frontend/test/__support__/e2e/helpers/e2e-filter-helpers.js
+++ b/frontend/test/__support__/e2e/helpers/e2e-filter-helpers.js
@@ -1,0 +1,43 @@
+import {
+  modal,
+  popover,
+} from "__support__/e2e/helpers/e2e-ui-elements-helpers";
+
+export function setFilterQuestionSource({ question, field }) {
+  cy.findByText("Dropdown list").click();
+  cy.findByText("Edit").click();
+
+  modal().within(() => {
+    cy.findByText("From another model or question").click();
+    cy.findByText("Pick a model or question…").click();
+  });
+
+  modal().within(() => {
+    cy.findByPlaceholderText(/Search for a question/).type(question);
+    cy.findByText(question).click();
+    cy.button("Done").click();
+  });
+
+  modal().within(() => {
+    cy.findByText("Pick a column…").click();
+  });
+
+  popover().within(() => {
+    cy.findByText(field).click();
+  });
+
+  modal().within(() => {
+    cy.button("Done").click();
+  });
+}
+
+export function setFilterListSource({ values }) {
+  cy.findByText("Dropdown list").click();
+  cy.findByText("Edit").click();
+
+  modal().within(() => {
+    cy.findByText("Custom list").click();
+    cy.findByRole("textbox").clear().type(values.join("\n"));
+    cy.button("Done").click();
+  });
+}

--- a/frontend/test/__support__/e2e/helpers/e2e-misc-helpers.js
+++ b/frontend/test/__support__/e2e/helpers/e2e-misc-helpers.js
@@ -1,5 +1,7 @@
 // Find a text field by label text, type it in, then blur the field.
 // Commonly used in our Admin section as we auto-save settings.
+import { modal } from "__support__/e2e/helpers/e2e-ui-elements-helpers";
+
 export function typeAndBlurUsingLabel(label, value) {
   cy.findByLabelText(label).clear().type(value).blur();
 }
@@ -217,4 +219,27 @@ export function interceptIfNotPreviouslyDefined({ method, url, alias } = {}) {
   if (!isAlreadyDefined) {
     cy.intercept(method, url).as(alias);
   }
+}
+
+export function saveQuestion(
+  name,
+  { wrapId = false, idAlias = "questionId" } = {},
+) {
+  cy.intercept("POST", "/api/card").as("saveQuestion");
+  cy.findByText("Save").click();
+
+  modal().within(() => {
+    cy.findByLabelText("Name").type(name);
+    cy.button("Save").click();
+  });
+
+  cy.wait("@saveQuestion").then(({ response: { body } }) => {
+    if (wrapId) {
+      cy.wrap(body.id).as(idAlias);
+    }
+  });
+
+  modal().within(() => {
+    cy.button("Not now").click();
+  });
 }

--- a/frontend/test/__support__/e2e/helpers/e2e-misc-helpers.js
+++ b/frontend/test/__support__/e2e/helpers/e2e-misc-helpers.js
@@ -1,7 +1,7 @@
-// Find a text field by label text, type it in, then blur the field.
-// Commonly used in our Admin section as we auto-save settings.
 import { modal } from "__support__/e2e/helpers/e2e-ui-elements-helpers";
 
+// Find a text field by label text, type it in, then blur the field.
+// Commonly used in our Admin section as we auto-save settings.
 export function typeAndBlurUsingLabel(label, value) {
   cy.findByLabelText(label).clear().type(value).blur();
 }

--- a/frontend/test/__support__/e2e/helpers/index.js
+++ b/frontend/test/__support__/e2e/helpers/index.js
@@ -5,6 +5,7 @@ export * from "./e2e-database-metadata-helpers";
 export * from "./e2e-qa-databases-helpers";
 export * from "./e2e-ad-hoc-question-helpers";
 export * from "./e2e-enterprise-helpers";
+export * from "./e2e-filter-helpers";
 export * from "./e2e-mock-app-settings-helpers";
 export * from "./e2e-notebook-helpers";
 export * from "./e2e-cloud-helpers";

--- a/frontend/test/metabase/scenarios/dashboard-filters/dashboard-filters-source.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters/dashboard-filters-source.cy.spec.js
@@ -1,6 +1,5 @@
 import {
   editDashboard,
-  modal,
   popover,
   restore,
   saveDashboard,
@@ -8,6 +7,8 @@ import {
   visitDashboard,
   openQuestionActions,
   visitQuestion,
+  setFilterQuestionSource,
+  setFilterListSource,
 } from "__support__/e2e/helpers";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
@@ -22,7 +23,7 @@ const dashboardQuestionDetails = {
 };
 
 const structuredQuestionDetails = {
-  name: "Categories",
+  name: "GUI source",
   query: {
     "source-table": PRODUCTS_ID,
     aggregation: [["count"]],
@@ -32,7 +33,7 @@ const structuredQuestionDetails = {
 };
 
 const nativeQuestionDetails = {
-  name: "Categories",
+  name: "SQL source",
   native: {
     query: "select distinct CATEGORY from PRODUCTS order by CATEGORY limit 2",
   },
@@ -57,8 +58,7 @@ describe("scenarios > dashboard > filters", () => {
     editDashboard();
     setFilter("Text or Category", "Is");
     mapFilterToQuestion();
-    editDropdown();
-    setupStructuredQuestionSource();
+    setFilterQuestionSource({ question: "GUI source", field: "Category" });
     saveDashboard();
     filterDashboard();
 
@@ -77,8 +77,7 @@ describe("scenarios > dashboard > filters", () => {
     editDashboard();
     setFilter("Text or Category", "Is");
     mapFilterToQuestion();
-    editDropdown();
-    setupNativeQuestionSource();
+    setFilterQuestionSource({ question: "SQL source", field: "CATEGORY" });
     saveDashboard();
     filterDashboard();
 
@@ -96,78 +95,11 @@ describe("scenarios > dashboard > filters", () => {
     editDashboard();
     setFilter("Text or Category", "Is");
     mapFilterToQuestion();
-    editDropdown();
-    setupCustomList();
+    setFilterListSource({ values: ["Doohickey", "Gadget"] });
     saveDashboard();
     filterDashboard();
   });
 });
-
-const editDropdown = () => {
-  cy.findByText("Dropdown list").click();
-  cy.findByText("Edit").click();
-};
-
-const setupStructuredQuestionSource = () => {
-  modal().within(() => {
-    cy.findByText("From another model or question").click();
-    cy.findByText("Pick a model or question…").click();
-  });
-
-  modal().within(() => {
-    cy.findByPlaceholderText(/Search for a question/).type("Categories");
-    cy.findByText("Categories").click();
-    cy.button("Done").click();
-  });
-
-  modal().within(() => {
-    cy.findByText("Pick a column…").click();
-  });
-
-  popover().within(() => {
-    cy.findByText("Category").click();
-  });
-
-  modal().within(() => {
-    cy.wait("@dataset");
-    cy.findByDisplayValue(/Gadget/).should("be.visible");
-    cy.button("Done").click();
-  });
-};
-
-const setupNativeQuestionSource = () => {
-  modal().within(() => {
-    cy.findByText("From another model or question").click();
-    cy.findByText("Pick a model or question…").click();
-  });
-
-  modal().within(() => {
-    cy.findByText("Categories").click();
-    cy.button("Done").click();
-  });
-
-  modal().within(() => {
-    cy.findByText("Pick a column…").click();
-  });
-
-  popover().within(() => {
-    cy.findByText("CATEGORY").click();
-  });
-
-  modal().within(() => {
-    cy.wait("@dataset");
-    cy.findByDisplayValue(/Gadget/).should("be.visible");
-    cy.button("Done").click();
-  });
-};
-
-const setupCustomList = () => {
-  modal().within(() => {
-    cy.findByText("Custom list").click();
-    cy.findByRole("textbox").clear().type("Doohickey\nGadget");
-    cy.button("Done").click();
-  });
-};
 
 const mapFilterToQuestion = () => {
   cy.findByText("Select…").click();

--- a/frontend/test/metabase/scenarios/native-filters/sql-filters-source.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native-filters/sql-filters-source.cy.spec.js
@@ -1,0 +1,57 @@
+import {
+  openNativeEditor,
+  restore,
+  setFilterQuestionSource,
+  saveQuestion,
+} from "__support__/e2e/helpers";
+import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
+import * as SQLFilter from "./helpers/e2e-sql-filter-helpers";
+import * as FieldFilter from "./helpers/e2e-field-filter-helpers";
+
+const { PRODUCTS_ID, PRODUCTS } = SAMPLE_DATABASE;
+
+const structuredQuestionDetails = {
+  name: "GUI source",
+  query: {
+    "source-table": PRODUCTS_ID,
+    aggregation: [["count"]],
+    breakout: [["field", PRODUCTS.CATEGORY, null]],
+    filter: ["!=", ["field", PRODUCTS.CATEGORY, null], "Gizmo"],
+  },
+};
+
+const nativeQuestionDetails = {
+  name: "SQL source",
+  native: {
+    query: "select distinct CATEGORY from PRODUCTS order by CATEGORY limit 2",
+  },
+};
+
+describe("scenarios > filters > sql filters > values source", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+  });
+
+  it("should be able to use a custom source for a text filter", () => {
+    cy.createQuestion(structuredQuestionDetails);
+    openNativeEditor();
+
+    SQLFilter.enterParameterizedQuery("SELECT * FROM products WHERE {{f}}");
+    SQLFilter.openTypePickerFromDefaultFilterType();
+    setFilterQuestionSource({ question: "GUI source", field: "Category" });
+    saveQuestion("SQL filter");
+  });
+
+  it("should be able to use a custom source for a field filter", () => {
+    cy.createNativeQuestion(nativeQuestionDetails);
+    openNativeEditor();
+
+    SQLFilter.enterParameterizedQuery("SELECT * FROM products WHERE {{f}}");
+    SQLFilter.openTypePickerFromDefaultFilterType();
+    SQLFilter.chooseType("Field Filter");
+    FieldFilter.mapTo({ table: "Products", field: "Category" });
+    setFilterQuestionSource({ question: "SQL source", field: "CATEGORY" });
+    saveQuestion("SQL filter");
+  });
+});


### PR DESCRIPTION
Epic https://github.com/metabase/metabase/issues/26898

Adds a way to set a custom source for string template tags. Currently has no effect on the filter wiget.

How to test:
- New -> SQL query
- `SELECT * FROM PRODUCTS WHERE {{f}}`
- The template sidebar should appear with `How should users filter on this variable?` section
- Make sure it is possible to set the dropdown source for the tag

<img width="360" alt="Screenshot 2023-01-17 at 15 44 24" src="https://user-images.githubusercontent.com/8542534/212914721-f2f75f65-6c3b-4270-9ffa-9371d9d07768.png">

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/27713)
<!-- Reviewable:end -->
