### PR TITLE
adding onlyText button variant

### DIFF
--- a/frontend/src/metabase/core/components/Button/Button.stories.tsx
+++ b/frontend/src/metabase/core/components/Button/Button.stories.tsx
@@ -26,3 +26,9 @@ export const WithIcon = Template.bind({});
 WithIcon.args = {
   icon: "chevrondown",
 };
+
+export const OnlyText = Template.bind({});
+OnlyText.args = {
+  onlyText: true,
+  children: "Click Me",
+};

--- a/frontend/src/metabase/core/components/Button/Button.styled.tsx
+++ b/frontend/src/metabase/core/components/Button/Button.styled.tsx
@@ -4,6 +4,7 @@ import { alpha, color } from "metabase/lib/colors";
 
 export interface ButtonRootProps {
   purple?: boolean;
+  onlyText?: boolean;
 }
 
 export const ButtonRoot = styled.button<ButtonRootProps>`
@@ -21,6 +22,21 @@ export const ButtonRoot = styled.button<ButtonRootProps>`
         color: ${color("white")};
         background-color: ${alpha("filter", 0.88)};
         border-color: ${alpha("filter", 0.88)};
+      }
+    `}
+
+  ${({ onlyText }) =>
+    onlyText &&
+    css`
+      border: none;
+      padding: 0;
+
+      ${ButtonContent} {
+        color: ${color("brand")};
+      }
+
+      &:hover {
+        background-color: unset;
       }
     `}
 `;

--- a/frontend/src/metabase/core/components/Button/Button.styled.tsx
+++ b/frontend/src/metabase/core/components/Button/Button.styled.tsx
@@ -31,10 +31,7 @@ export const ButtonRoot = styled.button<ButtonRootProps>`
       border: none;
       padding: 0;
 
-      ${ButtonContent} {
-        color: ${color("brand")};
-      }
-
+      color: ${color("brand")};
       &:hover {
         background-color: unset;
       }

--- a/frontend/src/metabase/core/components/Button/Button.tsx
+++ b/frontend/src/metabase/core/components/Button/Button.tsx
@@ -65,6 +65,7 @@ export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   borderless?: boolean;
   onlyIcon?: boolean;
   fullWidth?: boolean;
+  onlyText?: boolean;
 }
 
 const BaseButton = forwardRef(function BaseButton(


### PR DESCRIPTION
Adding text only button variant. No borders or padding around the button content, and color defaults to brand.

![image](https://user-images.githubusercontent.com/1328979/212901205-d3caa983-ec00-40ab-ab69-2a6cccbfffb0.png)
