### PR TITLE
POC to use clojure for liquibase migrations

### DIFF
--- a/bin/prep.sh
+++ b/bin/prep.sh
@@ -1,0 +1,39 @@
+#! /usr/bin/env bash
+
+# functions for running prep steps to compile Java and AOT source files, needed before running other stuff.
+
+script_directory=`dirname "${BASH_SOURCE[0]}"`
+cd "$script_directory/.."
+project_root=`pwd`
+
+clear_cpcaches() {
+    cd "$project_root"
+    for file in `find . -type d -name .cpcache`; do
+        rm -rf "$file"
+    done
+}
+
+compile_java_sources() {
+    cd "$project_root"
+
+    echo "Compile Java source files in $project_root/java if needed..."
+    if [ ! -d "$project_root/java/target/classes" ]; then
+        echo 'Compile Java source files'
+        cd "$project_root"
+        clojure -Sforce -X:deps prep
+    else
+        echo 'Java source files are already compiled'
+    fi
+}
+
+prep_deps() {
+    if compile_java_sources; then
+        echo "Java sources => OK"
+    else
+        echo 'Compilation failed (WHY?!); clearing classpath caches and trying again...'
+        clear_cpcaches
+        compile_java_sources
+    fi
+
+    cd "$project_root"
+}

--- a/deps.edn
+++ b/deps.edn
@@ -154,7 +154,8 @@
                                                            org.clojure/tools.logging
                                                            org.clojure/tools.namespace]}
   user-agent/user-agent                     {:mvn/version "0.1.0"}              ; User-Agent string parser, for Login History page & elsewhere
-  weavejester/dependency                    {:mvn/version "0.2.1"}}             ; Dependency graphs and topological sorting
+  weavejester/dependency                    {:mvn/version "0.2.1"}              ; Dependency graphs and topological sorting
+  metabase/java-deps                        {:local/root "java"}}
 
  ;; !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
  ;; !!         PLEASE KEEP NEW DEPENDENCIES ABOVE ALPHABETICALLY ORGANIZED AND ADD COMMENTS EXPLAINING THEM.         !!
@@ -163,7 +164,7 @@
 
 
  :paths
- ["src" "shared/src" "resources"]
+ ["src" "shared/src" "resources" "java/target/classes"]
 
  ;; These are needed for the Athena and Redshift drivers if you are developing against them locally. If those drivers'
  ;; dependencies are not included (i.e., if we don't have the `:drivers` profile), these repos are effectively

--- a/java/build.clj
+++ b/java/build.clj
@@ -1,0 +1,19 @@
+(ns build
+  (:require [clojure.pprint :as pprint]
+            [clojure.tools.build.api :as b]))
+
+(def target-dir "target/classes")
+
+(defn compile-java [_]
+  (b/delete {:path target-dir})
+  (try
+    (b/javac
+     {:src-dirs   ["."]
+      :class-dir  target-dir
+      :basis      (b/create-basis {:aliases #{:compilation-basis}})
+      :javac-opts ["-source" "8", "-target" "8"]})
+    (catch Throwable e
+      (println "Error compiling Java sources:" (ex-message e))
+      (pprint/pprint (Throwable->map e))
+      (b/delete {:path target-dir})
+      (throw e))))

--- a/java/deps.edn
+++ b/java/deps.edn
@@ -1,0 +1,15 @@
+{:deps/prep-lib
+ {:ensure "target/classes"
+  :alias  :build
+  :fn     compile-java}
+
+ :paths ["target/classes"]
+
+ :aliases
+ {:build
+  {:deps       {io.github.clojure/tools.build {:git/tag "v0.7.5" :git/sha "2526f58"}}
+   :ns-default build}
+
+  ;; dependencies needed for compiling the Java files.
+  :compilation-basis
+  {:extra-deps {org.liquibase/liquibase-core {:mvn/version "3.6.3"}}}}}

--- a/java/metabase/db/liquibase/MetabaseExecuteClojureMigration.java
+++ b/java/metabase/db/liquibase/MetabaseExecuteClojureMigration.java
@@ -1,0 +1,88 @@
+package liquibase.change.custom;
+
+import liquibase.database.Database;
+import liquibase.exception.CustomChangeException;
+import liquibase.exception.RollbackImpossibleException;
+import liquibase.exception.SetupException;
+import liquibase.exception.ValidationErrors;
+import liquibase.resource.ResourceAccessor;
+import clojure.lang.RT;
+import clojure.lang.Var;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+
+public class MetabaseExecuteClojureMigration implements CustomTaskChange, CustomTaskRollback {
+
+    private String migrationName;
+
+    @SuppressWarnings({"UnusedDeclaration", "FieldCanBeLocal"})
+    private ResourceAccessor resourceAccessor;
+
+
+    public String getMigrationName() {
+        return migrationName;
+    }
+
+    public void setMigrationName(String migrationName) {
+        this.migrationName = migrationName;
+    }
+
+    @Override
+    public void execute(Database database) throws CustomChangeException {
+        try {
+            RT.loadResourceScript("migrations/001_clojure_migration.clj");
+            Var execute = RT.var("migrations.001-clojure-migration", getMigrationName()+"-execute");
+            // invoke and print out the result
+            Object result = execute.invoke(database);
+        } catch (Exception e) {
+            throw new CustomChangeException("Error executing Clojure migration"+getMigrationName(), e);
+        }
+    }
+
+    @Override
+    public void rollback(Database database) throws CustomChangeException, RollbackImpossibleException {
+        try {
+            RT.loadResourceScript("migrations/001_clojure_migration.clj");
+            Var rollback  = RT.var("migrations.001-clojure-migration", getMigrationName()+"-rollback");
+            // if exists execute
+            if (rollback.isBound()) {
+                Object result = rollback.invoke(database);
+            } else {
+                System.out.println("Rollback not found for migration: "+getMigrationName());
+            }
+        } catch (Exception e) {
+            throw new CustomChangeException("Error rollback Clojure migration"+getMigrationName(), e);
+        }
+
+    }
+
+    @Override
+    public String getConfirmationMessage() {
+        return null;
+    }
+
+    @Override
+    public void setUp() throws SetupException {
+        try {
+            RT.loadResourceScript("migrations/001_clojure_migration.clj");
+            Var execute = RT.var("migrations.001-clojure-migration", getMigrationName()+"-execute");
+            if (!execute.isBound()) {
+                throw new SetupException("Error loading Clojure migration"+getMigrationName());
+            }
+        } catch (Exception e) {
+            throw new SetupException("Error loading Clojure migration"+getMigrationName(), e);
+        }
+    }
+
+    @Override
+    public void setFileOpener(ResourceAccessor resourceAccessor) {
+        this.resourceAccessor = resourceAccessor;
+    }
+
+    @Override
+    public ValidationErrors validate(Database database) {
+        //validate if the file exists
+        return null;
+    }
+}

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -13990,6 +13990,15 @@ databaseChangeLog:
             constraintName: fk_action_creator_id
             nullable: false
 
+  - changeSet:
+      id: v46.00-047
+      author: qnkhuat
+      changes:
+        - customChange: {
+              "class": "liquibase.change.custom.MetabaseExecuteClojureMigration",
+              "migrationName": "append-name-to-all-questions"
+        }
+
 # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################

--- a/resources/migrations/001_clojure_migration.clj
+++ b/resources/migrations/001_clojure_migration.clj
@@ -1,0 +1,31 @@
+(ns migrations.001-clojure-migration)
+
+(defmacro defmigration
+  ([name execute-thunk]
+   `(defmigration ~name ~execute-thunk nil))
+  ([name execute-thunk rollback-thunk]
+   `(do
+      (defn ~(symbol (str name "-execute")) [~'database] (~execute-thunk ~'database))
+      ~(when (seq rollback-thunk)
+         `(defn ~(symbol (str name "-rollback")) [~'database] (~rollback-thunk ~'database))))))
+
+(defmigration append-name-to-all-questions
+  (fn execute [database]
+    (let [conn  (.getConnection database)
+           stmt (.createStatement conn)]
+      (try
+        (let [rs    (.executeQuery stmt "select * from report_card")
+              names (loop [acc []]
+                      (if (.next rs)
+                        (recur (conj acc (.getString rs "name")))
+                        acc))]
+          ;; update all card's name with a postfix "liquibase migration 2.0"
+          (doseq [name names]
+            (let [update-stmt (.createStatement conn)]
+              (.execute update-stmt (format "update report_card set name = '%s - liquibase migration 2.0' where name = '%s'" name name)))))
+        (catch Exception e
+          (println "Error creating table: " (.getMessage e))
+          (throw e)))))
+
+  (fn rollback [_database]
+    (println "DO NOTHING")))


### PR DESCRIPTION
This PR demonstrates how we could use Clojure with liquibase migration via creating a customChange.

How to try this:
- `clj -X:deps prep` -- build the java class path that implements `CustomTaskChange`
- Starts your REPL like normal

Note: I have a demo migration where I add a postfix `liquibase 2.0` to all the existing questions, so if you don't want it to mess with your local db, I suggest create a new db before trying this.