### PR TITLE
Switch to Honey SQL 2 and Toucan 2, part 1

### DIFF
--- a/.clj-kondo/better-cond/better-cond/better_cond/core.clj
+++ b/.clj-kondo/better-cond/better-cond/better_cond/core.clj
@@ -1,0 +1,145 @@
+(ns better-cond.core
+  "A clj-kondo hook to allow linting of better-cond `cond` macro.
+  This supports better-cond version 2.0.0+.
+
+  To use in a project, change the namespace to hooks.better-cond,
+  put this code in file .clj-kondo/hooks/better_cond.clj, and include
+  a config.edn entry in the :hooks key like:
+
+    :hooks {:analyze-call {better-cond.core/cond hooks.better-cond/cond}}
+
+  Note that the expansion of :when-let and :when-some forms currently
+  takes a shortcut that *would* lead to incorrect values in some
+  cases of restructuring during actual expansion/evaluation, e.g.,
+  :when-let [[x y] nil] would not abort the cond, though :when-let
+  [[x y] [nil nil]] would. However, for linting purposes, the current
+  expansion approach works just fine. It seems unnecessary to do the
+  full expansion in these cases for linting purposes, though that could
+  be done if needed."
+  (:refer-clojure :exclude [cond])
+  (:require
+   [clj-kondo.hooks-api :as api]
+   [clojure.string :as str]))
+
+(def better-cond-simple-keys
+  "Special constructs in better cond, either as keywords or symbols.
+  This includes those keys that are simply transformed. Note that
+  :when-let and :when-some are *not* included as better-cond allows
+  multiple bindings but clojure does not. These two must be handled
+  separately."
+  #{:let :when :do
+    'let 'when 'do})
+
+(def better-cond-complex-keys
+  "Special constructs in better cond, either as keywords or symbols.
+  This includes those keys that require a multi-step transformation.
+  For example, :when-let and :when-some get converted to a let
+  wrapping a when, wrapping the continuing cond. Note that clojure
+  does not support multiple bindings in the standard when-let and
+  when-some macros."
+  {:when-let  'identity
+   'when-let  'identity
+   :when-some 'some?
+   'when-some 'some?})
+
+(defn extract-binding-forms
+  [bindings]
+  (keep-indexed #(when (even? %1) %2) bindings))
+
+(defn process-pairs
+  "Transforms a `cond` with the clauses given as a collection of explicit pairs.
+  Handles all the special better-cond constructs as keywords or symbols.
+  Returns a rewrite-clj list-node representing the transformed code."
+  [node-pairs]
+  (loop [[[lhs rhs :as pair] & pairs] node-pairs
+         new-body [(api/token-node 'clojure.core/cond)]] ; Avoid reprocessing the cond with ns here
+    (if pair
+      (let [lhs-sexpr (api/sexpr lhs)]
+        (clojure.core/cond
+          (= 1 (count pair)) ;; better-cond allows single clause for default
+          , (api/list-node (conj new-body (api/keyword-node :else) lhs))
+          (better-cond-simple-keys lhs-sexpr) ;; Handle special better-cond constructs
+          , (api/list-node
+             (conj new-body
+                   (api/keyword-node :else)
+                   (api/list-node [(api/token-node (symbol #_"clojure.core" (name lhs-sexpr)))
+                                   rhs
+                                   (process-pairs pairs)])))
+          (better-cond-complex-keys lhs-sexpr)  ;; Multi stage constructs
+          , (api/list-node
+             (conj new-body
+                   (api/keyword-node :else)
+                   (api/list-node [(api/token-node 'let)
+                                   rhs
+                                   (api/list-node [(api/token-node 'when)
+                                                   (api/list-node    ;; ATTN: shortcut here; fine for linting
+                                                    [(api/token-node 'every?)
+                                                     (api/token-node (better-cond-complex-keys lhs-sexpr))
+                                                     (api/vector-node (->> rhs
+                                                                           api/sexpr
+                                                                           extract-binding-forms
+                                                                           (map api/token-node)))])
+                                                   (process-pairs pairs)])])))
+          :else
+          , (recur pairs (conj new-body lhs rhs))))
+      (api/list-node new-body))))
+
+(defn cond-hook
+  [{:keys [node]}]
+  (let [expr (let [args (rest (:children node))
+                   pairs (partition-all 2 args)]
+               (process-pairs pairs))]
+    {:node (with-meta expr
+             (meta node))}))
+
+(defn process-if-let-pairs [pairs then else]
+  (if (seq pairs)
+    (let [[lhs rhs] (first pairs)]
+      (if (and (api/keyword-node? lhs)
+               (= :let (api/sexpr lhs)))
+        (api/list-node (conj [(api/token-node 'clojure.core/let) rhs
+                              (process-if-let-pairs (next pairs) then else)]))
+        (let [test (api/token-node (gensym "test"))]
+          (api/list-node
+           (conj [(api/token-node 'clojure.core/let) (api/vector-node [test rhs])
+                  (api/list-node [(api/token-node 'if) test
+                                  (api/list-node
+                                   [(api/token-node 'clojure.core/let)
+                                    (api/vector-node [lhs test])
+                                    (process-if-let-pairs (next pairs) then else)])
+                                  else])])))))
+    then))
+
+(defn if-let-hook
+  [{:keys [node]}]
+  (let [expr (let [[binding-vec then else] (rest (:children node))
+                   pairs (partition-all 2 (:children binding-vec))
+                   node (process-if-let-pairs pairs then else)]
+               node)]
+    {:node (with-meta expr
+             (meta node))}))
+
+(defn when-let-hook
+  [{:keys [node]}]
+  (let [expr (let [[binding-vec & body] (rest (:children node))]
+               (api/list-node
+                [(api/token-node 'better-cond.core/if-let)
+                 binding-vec
+                 (api/list-node (list* (api/token-node 'do)
+                                       body))]))]
+    {:node (with-meta expr
+             (meta node))}))
+
+(defn defnc-hook [{:keys [node]}]
+  (let [[defnc-node name-node arg-node & body]
+        (:children node)
+        new-node (api/list-node [(api/token-node (if (str/ends-with? (str defnc-node)
+                                                                     "defnc-")
+                                                   'clojure.core/defn-
+                                                   'clojure.core/defn))
+                                 name-node
+                                 arg-node
+                                 (api/list-node
+                                  (list* (api/token-node 'better-cond.core/cond)
+                                         body))])]
+    {:node new-node}))

--- a/.clj-kondo/better-cond/better-cond/config.edn
+++ b/.clj-kondo/better-cond/better-cond/config.edn
@@ -1,0 +1,9 @@
+{:hooks
+ {:analyze-call
+  {better-cond.core/cond better-cond.core/cond-hook
+   better-cond.core/defnc better-cond.core/defnc-hook
+   better-cond.core/defnc- better-cond.core/defnc-hook
+   better-cond.core/if-let better-cond.core/if-let-hook
+   better-cond.core/if-some better-cond.core/if-let-hook
+   better-cond.core/when-let better-cond.core/when-let-hook
+   better-cond.core/when-some better-cond.core/when-let-hook}}}

--- a/.clj-kondo/com.github.camsaul/toucan2/config.edn
+++ b/.clj-kondo/com.github.camsaul/toucan2/config.edn
@@ -1,0 +1,39 @@
+{:config-paths
+ ["macros"]
+
+ :lint-as
+ {toucan2.core/build             clojure.core/identity
+  toucan2.core/compile           clojure.core/identity
+  toucan2.query/with-built-query clojure.core/let
+  toucan2.tools.compile/build    clojure.core/identity
+  toucan2.tools.compile/compile  clojure.core/identity}
+
+ :hooks
+ {:analyze-call
+  {toucan2.connection/with-connection                      hooks.toucan2.connection/with-connection
+   toucan2.connection/with-transaction                     hooks.toucan2.connection/with-transaction
+   toucan2.core/with-connection                            hooks.toucan2.connection/with-connection
+   toucan2.core/with-transaction                           hooks.toucan2.connection/with-transaction
+   toucan2.tools.simple-out-transform/define-out-transform hooks.toucan2.tools.simple-out-transform/define-out-transform
+   toucan2.tools.with-temp/with-temp                       hooks.toucan2.tools.with-temp/with-temp}
+
+  :macroexpand
+  {toucan.db/with-call-counting                       macros.toucan2.execute/with-call-count
+   toucan.models/defmodel                             macros.toucan.models/defmodel
+   toucan2.core/define-after-insert                   macros.toucan2.tools.after-insert/define-after-insert
+   toucan2.core/define-after-select                   macros.toucan2.tools.helpers/define-after-select
+   toucan2.core/define-after-update                   macros.toucan2.tools.after-update/define-after-update
+   toucan2.core/define-before-delete                  macros.toucan2.tools.helpers/define-before-delete
+   toucan2.core/define-before-insert                  macros.toucan2.tools.before-insert/define-before-insert
+   toucan2.core/define-before-select                  macros.toucan2.tools.helpers/define-before-select
+   toucan2.core/define-before-update                  macros.toucan2.tools.before-update/define-before-update
+   toucan2.execute/with-call-count                    macros.toucan2.execute/with-call-count
+   toucan2.tools.after-insert/define-after-insert     macros.toucan2.tools.after-insert/define-after-insert
+   toucan2.tools.after-select/define-after-select     macros.toucan2.tools.helpers/define-after-select
+   toucan2.tools.after-update/define-after-update     macros.toucan2.tools.after-update/define-after-update
+   toucan2.tools.before-delete/define-before-delete   macros.toucan2.tools.helpers/define-before-delete
+   toucan2.tools.before-insert/define-before-insert   macros.toucan2.tools.before-insert/define-before-insert
+   toucan2.tools.before-select/define-before-select   macros.toucan2.tools.helpers/define-before-select
+   toucan2.tools.before-update/define-before-update   macros.toucan2.tools.before-update/define-before-update
+   toucan2.tools.default-fields/define-default-fields macros.toucan2.tools.default-fields/define-default-fields
+   toucan2.tools.named-query/define-named-query       macros.toucan2.tools.named-query/define-named-query}}}

--- a/.clj-kondo/com.github.camsaul/toucan2/hooks/toucan2/connection.clj
+++ b/.clj-kondo/com.github.camsaul/toucan2/hooks/toucan2/connection.clj
@@ -1,0 +1,14 @@
+(ns hooks.toucan2.connection
+  (:require [clj-kondo.hooks-api :as hooks]))
+
+(defn with-connection [{{[_ bindings & body] :children} :node}]
+  (let [[conn-binding connectable] (:children bindings)]
+    {:node (hooks/list-node
+            (list*
+             (hooks/token-node 'let)
+             (hooks/vector-node [conn-binding (or connectable
+                                                  (hooks/token-node 'nil))])
+             body))}))
+
+(defn with-transaction [node]
+  (with-connection node))

--- a/.clj-kondo/com.github.camsaul/toucan2/hooks/toucan2/tools/simple_out_transform.clj
+++ b/.clj-kondo/com.github.camsaul/toucan2/hooks/toucan2/tools/simple_out_transform.clj
@@ -1,0 +1,37 @@
+(ns hooks.toucan2.tools.simple-out-transform
+  (:require [clj-kondo.hooks-api :as hooks]))
+
+(defn- ignore-unused-binding [x]
+  (vary-meta x assoc :clj-kondo/ignore [:unused-binding]))
+
+(defn define-out-transform
+  [{{[_define-out-transform dispatch-value {[instance-binding] :children, :as bindings} & body] :children, :as node} :node}]
+  {:node (-> (hooks/list-node
+              [(hooks/token-node 'do)
+               dispatch-value
+               (hooks/list-node
+                (list*
+                 (hooks/token-node 'fn)
+                 (-> (hooks/vector-node
+                      [(ignore-unused-binding (with-meta (hooks/token-node '&query-type)  (meta bindings)))
+                       (ignore-unused-binding (with-meta (hooks/token-node '&model)       (meta bindings)))
+                       instance-binding])
+                     (with-meta (meta bindings)))
+                 body))])
+             (with-meta (meta node)))})
+
+(comment
+  (defn test-define-out-transform []
+    (as-> '(tools.simple-out-transform/define-out-transform [:toucan.query-type/select.instances ::after-select]
+             [instance]
+             (let [wow 1000]
+               ;; don't do after-select if this select is a result of doing something like insert-returning instances
+               (if (isa? &query-type :toucan2.pipeline/select.instances-from-pks)
+                 instance
+                 (after-select instance)))) <>
+        (hooks/parse-string (pr-str <>))
+        (define-out-transform {:node <>})
+        (:node <>)
+        (hooks/sexpr <>)
+        (binding [*print-meta* false #_true]
+          (clojure.pprint/pprint <>)))))

--- a/.clj-kondo/com.github.camsaul/toucan2/hooks/toucan2/tools/with_temp.clj
+++ b/.clj-kondo/com.github.camsaul/toucan2/hooks/toucan2/tools/with_temp.clj
@@ -1,0 +1,22 @@
+(ns hooks.toucan2.tools.with-temp
+  (:require [clj-kondo.hooks-api :as hooks]))
+
+(defn with-temp [{{[_with-temp {bindings :children} & body] :children} :node}]
+  (let [bindings* (into
+                   []
+                   (comp (partition-all 3)
+                         (mapcat (fn [[model binding attributes]]
+                                   (let [binding    (or binding (hooks/token-node '_))
+                                         attributes (or attributes (hooks/token-node 'nil))]
+                                     [binding (hooks/list-node
+                                               (list
+                                                (hooks/token-node 'do)
+                                                model
+                                                attributes))]))))
+                   bindings)
+        node*         (hooks/list-node
+                       (list*
+                        (hooks/token-node 'let)
+                        (hooks/vector-node bindings*)
+                        body))]
+    {:node node*}))

--- a/.clj-kondo/com.github.camsaul/toucan2/macros/toucan/models.clj
+++ b/.clj-kondo/com.github.camsaul/toucan2/macros/toucan/models.clj
@@ -1,0 +1,5 @@
+(ns macros.toucan.models)
+
+(defmacro defmodel
+  [model _table-name]
+  `(def ~model "Docstring." ~(keyword (name model))))

--- a/.clj-kondo/com.github.camsaul/toucan2/macros/toucan2/common.clj
+++ b/.clj-kondo/com.github.camsaul/toucan2/macros/toucan2/common.clj
@@ -1,0 +1,4 @@
+(ns macros.toucan2.common)
+
+(defn ignore-unused [symb]
+  (vary-meta symb assoc :clj-kondo/ignore [:unused-binding]))

--- a/.clj-kondo/com.github.camsaul/toucan2/macros/toucan2/execute.clj
+++ b/.clj-kondo/com.github.camsaul/toucan2/macros/toucan2/execute.clj
@@ -1,0 +1,6 @@
+(ns macros.toucan2.execute)
+
+(defmacro with-call-count
+  [[call-count-fn-binding] & body]
+  `(let [~call-count-fn-binding (fn [])]
+     ~@body))

--- a/.clj-kondo/com.github.camsaul/toucan2/macros/toucan2/tools/after_insert.clj
+++ b/.clj-kondo/com.github.camsaul/toucan2/macros/toucan2/tools/after_insert.clj
@@ -1,0 +1,10 @@
+(ns macros.toucan2.tools.after-insert
+  (:require [macros.toucan2.common :as common]))
+
+(defmacro define-after-insert
+  [model [instance-binding] & body]
+  `(do
+     ~model
+     (fn [~(common/ignore-unused '&model)
+          ~instance-binding]
+       ~@body)))

--- a/.clj-kondo/com.github.camsaul/toucan2/macros/toucan2/tools/after_update.clj
+++ b/.clj-kondo/com.github.camsaul/toucan2/macros/toucan2/tools/after_update.clj
@@ -1,0 +1,10 @@
+(ns macros.toucan2.tools.after-update
+  (:require [macros.toucan2.common :as common]))
+
+(defmacro define-after-update
+  [model [instance-binding] & body]
+  `(do
+     ~model
+     (fn [~(common/ignore-unused '&model)
+          ~instance-binding]
+       ~@body)))

--- a/.clj-kondo/com.github.camsaul/toucan2/macros/toucan2/tools/before_insert.clj
+++ b/.clj-kondo/com.github.camsaul/toucan2/macros/toucan2/tools/before_insert.clj
@@ -1,0 +1,10 @@
+(ns macros.toucan2.tools.before-insert
+  (:require [macros.toucan2.common :as common]))
+
+(defmacro define-before-insert
+  [model [instance-binding] & body]
+  `(do
+     ~model
+     (fn [~(common/ignore-unused '&model)
+          ~instance-binding]
+       ~@body)))

--- a/.clj-kondo/com.github.camsaul/toucan2/macros/toucan2/tools/before_update.clj
+++ b/.clj-kondo/com.github.camsaul/toucan2/macros/toucan2/tools/before_update.clj
@@ -1,0 +1,10 @@
+(ns macros.toucan2.tools.before-update
+  (:require [macros.toucan2.common :as common]))
+
+(defmacro define-before-update
+  [model [instance-binding] & body]
+  `(do
+     ~model
+     (fn [~(common/ignore-unused '&model)
+          ~instance-binding]
+       ~@body)))

--- a/.clj-kondo/com.github.camsaul/toucan2/macros/toucan2/tools/default_fields.clj
+++ b/.clj-kondo/com.github.camsaul/toucan2/macros/toucan2/tools/default_fields.clj
@@ -1,0 +1,6 @@
+(ns macros.toucan2.tools.default-fields
+  (:require [macros.toucan2.common :as common]))
+
+(defmacro define-default-fields [model & body]
+  `(let [~(common/ignore-unused '&model) ~model]
+     ~@body))

--- a/.clj-kondo/com.github.camsaul/toucan2/macros/toucan2/tools/helpers.clj
+++ b/.clj-kondo/com.github.camsaul/toucan2/macros/toucan2/tools/helpers.clj
@@ -1,0 +1,27 @@
+(ns macros.toucan2.tools.helpers
+  (:require [macros.toucan2.common :as common]))
+
+(defmacro define-before-select [dispatch-value [args-binding] & body]
+  `(do
+     ~dispatch-value
+     (fn [~(common/ignore-unused '&query-type)
+          ~(common/ignore-unused '&model)
+          ~args-binding]
+       ~@body)))
+
+(defmacro define-after-select [model [instance-binding] & body]
+  `(do
+     ~model
+     (fn [~(common/ignore-unused '&query-type)
+          ~(common/ignore-unused '&model)
+          ~(common/ignore-unused '&parsed-args)
+          ~instance-binding]
+       ~@body)))
+
+(defmacro define-before-delete
+  [model [instance-binding] & body]
+  `(do
+     ~model
+     (fn [~(common/ignore-unused '&model)
+          ~instance-binding]
+       ~@body)))

--- a/.clj-kondo/com.github.camsaul/toucan2/macros/toucan2/tools/named_query.clj
+++ b/.clj-kondo/com.github.camsaul/toucan2/macros/toucan2/tools/named_query.clj
@@ -1,0 +1,22 @@
+(ns macros.toucan2.tools.named-query
+  (:require [macros.toucan2.common :as common]))
+
+;;; separate function because recursive macroexpansion doesn't seem to work.
+(defn- define-named-query*
+  [query-name query-type model resolved-query]
+  `(do
+     ~query-name
+     ~query-type
+     ~model
+     (fn [~(common/ignore-unused '&query-type)
+          ~(common/ignore-unused '&model)
+          ~(common/ignore-unused '&parsed-args)
+          ~(common/ignore-unused '&unresolved-query)]
+       ~resolved-query)))
+
+(defmacro define-named-query
+  ([query-name resolved-query]
+   (define-named-query* query-name :default :default resolved-query))
+
+  ([query-name query-type model resolved-query]
+   (define-named-query* query-name query-type model resolved-query)))

--- a/.clj-kondo/com.github.seancorfield/next.jdbc/config.edn
+++ b/.clj-kondo/com.github.seancorfield/next.jdbc/config.edn
@@ -1,0 +1,5 @@
+{:hooks
+ {:analyze-call
+  {next.jdbc/with-transaction
+   hooks.com.github.seancorfield.next-jdbc/with-transaction}}
+ :lint-as {next.jdbc/on-connection clojure.core/with-open}}

--- a/.clj-kondo/com.github.seancorfield/next.jdbc/hooks/com/github/seancorfield/next_jdbc.clj
+++ b/.clj-kondo/com.github.seancorfield/next.jdbc/hooks/com/github/seancorfield/next_jdbc.clj
@@ -1,0 +1,18 @@
+(ns hooks.com.github.seancorfield.next-jdbc
+  (:require [clj-kondo.hooks-api :as api]))
+
+(defn with-transaction
+  "Expands (with-transaction [tx expr opts] body)
+  to (let [tx expr] opts body) pre clj-kondo examples."
+  [{:keys [:node]}]
+  (let [[binding-vec & body] (rest (:children node))
+        [sym val opts] (:children binding-vec)]
+    (when-not (and sym val)
+      (throw (ex-info "No sym and val provided" {})))
+    (let [new-node (api/list-node
+                    (list*
+                     (api/token-node 'let)
+                     (api/vector-node [sym val])
+                     opts
+                     body))]
+      {:node new-node})))

--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -30,6 +30,7 @@
   (eval . (put 'setting/defsetting 'clojure-doc-string-elt 2))
   (eval . (put 's/defn 'clojure-doc-string-elt 2))
   (eval . (put 'p.types/defprotocol+ 'clojure-doc-string-elt 2))
+  (eval . (put 'methodical/defmethod 'clojure-doc-string-elt 3))
   (eval . (put 'methodical/defmulti 'clojure-doc-string-elt 2))
   (eval . (put 'mi/define-simple-hydration-method 'clojure-doc-string-elt 3))
   (eval . (put 'mi/define-batched-hydration-method 'clojure-doc-string-elt 3))

--- a/deps.edn
+++ b/deps.edn
@@ -403,7 +403,9 @@
                                    "\\.sh$"
                                    "\\.yaml$"
                                    "\\.yml$"]
-                :exclude-patterns ["resources/i18n/.*\\.edn$"
+                :exclude-patterns [".clj-kondo/better-cond/.*"
+                                   ".clj-kondo/com.github.seancorfield/.*"
+                                   "resources/i18n/.*\\.edn$"
                                    "resources/frontend_client"
                                    "resources/frontend_shared"
                                    "resources/html-entities.edn"

--- a/resources/log4j2.xml
+++ b/resources/log4j2.xml
@@ -30,6 +30,7 @@
     <Logger name="com.mchange" level="ERROR"/>
     <Logger name="org.quartz" level="INFO"/>
     <Logger name="liquibase" level="ERROR"/>
+    <Logger name="net.snowflake.client.jdbc.SnowflakeConnectString" level="ERROR"/>
 
     <Root level="WARN">
       <AppenderRef ref="STDOUT"/>

--- a/src/metabase/models/setting.clj
+++ b/src/metabase/models/setting.clj
@@ -138,9 +138,7 @@
 
 (declare admin-writable-site-wide-settings get-value-of-type set-value-of-type!)
 
-(models/defmodel Setting
-  "The model that underlies [[defsetting]]."
-  :setting)
+(models/defmodel Setting :setting)
 
 (mi/define-methods
  Setting

--- a/test/metabase/test.clj
+++ b/test/metabase/test.clj
@@ -11,6 +11,7 @@
    [humane-are.core :as humane-are]
    [java-time :as t]
    [medley.core :as m]
+   [metabase.config :as config]
    [metabase.driver :as driver]
    [metabase.driver.sql-jdbc.test-util :as sql-jdbc.tu]
    [metabase.driver.sql.query-processor-test-util :as sql.qp-test-util]
@@ -50,7 +51,10 @@
    [toucan.util.test :as tt]))
 
 (humane-are/install!)
-(humane-test-output/activate!)
+
+;; don't enable humane-test-output when running tests from the CLI, it breaks diffs.
+(when-not config/is-test?
+  (humane-test-output/activate!))
 
 ;; Fool the linters into thinking these namespaces are used! See discussion on
 ;; https://github.com/clojure-emacs/refactor-nrepl/pull/270

--- a/test/metabase/test_runner.clj
+++ b/test/metabase/test_runner.clj
@@ -24,8 +24,11 @@
    [metabase.util.i18n.impl :as i18n.impl]
    [pjstadig.humane-test-output :as humane-test-output]))
 
-;; initialize Humane Test Output if it's not already initialized.
-(humane-test-output/activate!)
+;; Initialize Humane Test Output if it's not already initialized. Don't enable humane-test-output when running tests
+;; from the CLI, it breaks diffs.
+(when-not config/is-test?
+  (humane-test-output/activate!))
+
 ;;; Same for https://github.com/camsaul/humane-are
 (humane-are/install!)
 


### PR DESCRIPTION
Part 1 of 3.

- Part 1: #27742
- Part 2: #27743 
- Part 3: #27688

I have a green PR to switch to Toucan 2 (#27688), but it is about 2500 lines, which is too much! So I will break it out into a series of smaller PRs. This is easy because half of that PR is unrelated stuff like formatting fixes anyway.

This PR

- Import Kondo config for Honey SQL 2, Toucan 2, and [`better-cond`](https://github.com/Engelberg/better-cond) (used by Toucan 2)
- Disable annoying Snowflake connection warnings
- Fix diffs not appearing when running tests locally via the CLI. Apparently `humane-test-output` conflicts with the pretty diff logic in eftest, so don't enable it when running tests via the CLI.