### PR TITLE
Add public action page

### DIFF
--- a/frontend/src/metabase-types/api/actions.ts
+++ b/frontend/src/metabase-types/api/actions.ts
@@ -31,6 +31,11 @@ export interface WritebackActionBase {
   public_uuid: string | null;
 }
 
+export type PublicWritebackAction = Pick<
+  WritebackActionBase,
+  "id" | "name" | "parameters" | "visualization_settings"
+>;
+
 export interface QueryAction {
   type: "query";
   dataset_query: NativeDatasetQuery;

--- a/frontend/src/metabase-types/api/mocks/actions.ts
+++ b/frontend/src/metabase-types/api/mocks/actions.ts
@@ -1,5 +1,6 @@
 import {
   CardId,
+  PublicWritebackAction,
   WritebackParameter,
   WritebackQueryAction,
   WritebackImplicitQueryAction,
@@ -85,3 +86,12 @@ export const createMockImplicitCUDActions = (
     model_id: modelId,
   }),
 ];
+
+export const createMockPublicAction = (
+  opts?: Partial<PublicWritebackAction>,
+): PublicWritebackAction => ({
+  id: 1,
+  name: "Public Action",
+  parameters: [],
+  ...opts,
+});

--- a/frontend/src/metabase/actions/components/ActionForm/ActionForm.tsx
+++ b/frontend/src/metabase/actions/components/ActionForm/ActionForm.tsx
@@ -190,7 +190,7 @@ export const ActionForm = ({
             {onClose && <Button onClick={onClose}>{t`Cancel`}</Button>}
             <FormSubmitButton
               disabled={!dirty && hasFormFields}
-              title={submitTitle ?? t`Save`}
+              title={submitTitle ?? t`Submit`}
               {...submitButtonVariant}
             />
           </ActionFormButtonContainer>

--- a/frontend/src/metabase/actions/components/ActionForm/ActionForm.unit.spec.tsx
+++ b/frontend/src/metabase/actions/components/ActionForm/ActionForm.unit.spec.tsx
@@ -60,6 +60,7 @@ const setup = ({
     <ActionForm
       initialValues={initialValues}
       parameters={parameters}
+      submitTitle="Save"
       formSettings={formSettings}
       setFormSettings={isSettings ? setFormSettings : undefined}
       onSubmit={onSubmit}

--- a/frontend/src/metabase/core/components/FormSubmitButton/FormSubmitButton.tsx
+++ b/frontend/src/metabase/core/components/FormSubmitButton/FormSubmitButton.tsx
@@ -54,4 +54,6 @@ const getSubmitButtonTitle = (
   }
 };
 
-export default FormSubmitButton;
+export default Object.assign(FormSubmitButton, {
+  Button: Button.Root,
+});

--- a/frontend/src/metabase/public/components/EmbedFrame/EmbedFrame.styled.tsx
+++ b/frontend/src/metabase/public/components/EmbedFrame/EmbedFrame.styled.tsx
@@ -73,7 +73,7 @@ const footerVariantStyles = {
   default: css`
     border-top: 1px solid ${color("border")};
   `,
-  big: css`
+  large: css`
     justify-content: center;
     align-items: center;
     margin-bottom: 2rem;
@@ -84,7 +84,7 @@ const footerVariantStyles = {
   `,
 };
 
-export const Footer = styled.footer<{ variant: "default" | "big" }>`
+export const Footer = styled.footer<{ variant: "default" | "large" }>`
   display: flex;
   flex-shrink: 0;
   align-items: center;

--- a/frontend/src/metabase/public/components/EmbedFrame/EmbedFrame.styled.tsx
+++ b/frontend/src/metabase/public/components/EmbedFrame/EmbedFrame.styled.tsx
@@ -69,6 +69,8 @@ export const ActionButtonsContainer = styled.div`
   margin-left: auto;
 `;
 
+export type FooterVariant = "default" | "large";
+
 const footerVariantStyles = {
   default: css`
     border-top: 1px solid ${color("border")};
@@ -84,7 +86,7 @@ const footerVariantStyles = {
   `,
 };
 
-export const Footer = styled.footer<{ variant: "default" | "large" }>`
+export const Footer = styled.footer<{ variant: FooterVariant }>`
   display: flex;
   flex-shrink: 0;
   align-items: center;

--- a/frontend/src/metabase/public/components/EmbedFrame/EmbedFrame.styled.tsx
+++ b/frontend/src/metabase/public/components/EmbedFrame/EmbedFrame.styled.tsx
@@ -64,12 +64,33 @@ export const Body = styled.main`
   position: relative;
 `;
 
-export const Footer = styled.footer`
+export const ActionButtonsContainer = styled.div`
+  color: ${color("text-medium")};
+  margin-left: auto;
+`;
+
+const footerVariantStyles = {
+  default: css`
+    border-top: 1px solid ${color("border")};
+  `,
+  big: css`
+    justify-content: center;
+    align-items: center;
+    margin-bottom: 2rem;
+
+    ${ActionButtonsContainer} {
+      display: none;
+    }
+  `,
+};
+
+export const Footer = styled.footer<{ variant: "default" | "big" }>`
   display: flex;
   flex-shrink: 0;
   align-items: center;
 
-  border-top: 1px solid ${color("border")};
+  ${props => footerVariantStyles[props.variant]}
+
   padding: 0.5rem;
 
   ${breakpointMinMedium} {
@@ -79,9 +100,4 @@ export const Footer = styled.footer`
   ${breakpointMinLarge} {
     padding: 1.5rem;
   }
-`;
-
-export const ActionButtonsContainer = styled.div`
-  color: ${color("text-medium")};
-  margin-left: auto;
 `;

--- a/frontend/src/metabase/public/components/EmbedFrame/EmbedFrame.tsx
+++ b/frontend/src/metabase/public/components/EmbedFrame/EmbedFrame.tsx
@@ -22,6 +22,7 @@ import Question from "metabase-lib/Question";
 import { getValuePopulatedParameters } from "metabase-lib/parameters/utils/parameter-values";
 
 import LogoBadge from "./LogoBadge";
+import type { FooterVariant } from "./EmbedFrame.styled";
 import {
   Root,
   ContentContainer,
@@ -39,7 +40,7 @@ interface OwnProps {
   question?: Question;
   dashboard?: Dashboard;
   actionButtons?: JSX.Element[];
-  footerVariant?: "default" | "large";
+  footerVariant?: FooterVariant;
   parameters?: Parameter[];
   parameterValues?: Record<ParameterId, ParameterValueOrArray>;
   setParameterValue?: (parameterId: ParameterId, value: any) => void;

--- a/frontend/src/metabase/public/components/EmbedFrame/EmbedFrame.tsx
+++ b/frontend/src/metabase/public/components/EmbedFrame/EmbedFrame.tsx
@@ -39,6 +39,7 @@ interface OwnProps {
   question?: Question;
   dashboard?: Dashboard;
   actionButtons?: JSX.Element[];
+  footerVariant?: "default" | "big";
   parameters?: Parameter[];
   parameterValues?: Record<ParameterId, ParameterValueOrArray>;
   setParameterValue?: (parameterId: ParameterId, value: any) => void;
@@ -76,6 +77,7 @@ function EmbedFrame({
   question,
   dashboard,
   actionButtons,
+  footerVariant = "default",
   location,
   hasEmbedBranding,
   parameters,
@@ -144,8 +146,10 @@ function EmbedFrame({
         <Body>{children}</Body>
       </ContentContainer>
       {showFooter && (
-        <Footer className="EmbedFrame-footer">
-          {hasEmbedBranding && <LogoBadge dark={theme === "night"} />}
+        <Footer className="EmbedFrame-footer" variant={footerVariant}>
+          {hasEmbedBranding && (
+            <LogoBadge variant={footerVariant} dark={theme === "night"} />
+          )}
           {actionButtons && (
             <ActionButtonsContainer>{actionButtons}</ActionButtonsContainer>
           )}

--- a/frontend/src/metabase/public/components/EmbedFrame/EmbedFrame.tsx
+++ b/frontend/src/metabase/public/components/EmbedFrame/EmbedFrame.tsx
@@ -39,7 +39,7 @@ interface OwnProps {
   question?: Question;
   dashboard?: Dashboard;
   actionButtons?: JSX.Element[];
-  footerVariant?: "default" | "big";
+  footerVariant?: "default" | "large";
   parameters?: Parameter[];
   parameterValues?: Record<ParameterId, ParameterValueOrArray>;
   setParameterValue?: (parameterId: ParameterId, value: any) => void;

--- a/frontend/src/metabase/public/components/EmbedFrame/LogoBadge.styled.tsx
+++ b/frontend/src/metabase/public/components/EmbedFrame/LogoBadge.styled.tsx
@@ -1,26 +1,50 @@
 import styled from "@emotion/styled";
+import { css } from "@emotion/react";
 import ExternalLink from "metabase/core/components/ExternalLink";
 import { color } from "metabase/lib/colors";
 import { breakpointMinMedium } from "metabase/styled-components/theme";
 
-export const MetabaseLink = styled(ExternalLink)`
+export type Variant = "default" | "big";
+
+export const MetabaseLink = styled(ExternalLink)<{ variant: Variant }>`
   display: flex;
   align-items: center;
 
   font-size: 0.85rem;
   font-weight: bold;
   text-decoration: none;
+
+  ${props =>
+    props.variant === "big" &&
+    css`
+      flex-direction: column;
+    `}
 `;
 
-export const Message = styled.span`
-  color: ${color("text-medium")};
+const messageVariantStyles = {
+  default: css`
+    color: ${color("text-medium")};
 
-  margin-left: 0.5rem;
-  ${breakpointMinMedium} {
-    margin-left: 1rem;
-  }
+    margin-left: 0.5rem;
+    ${breakpointMinMedium} {
+      margin-left: 1rem;
+    }
+  `,
+  big: css`
+    color: ${color("text-dark")};
+    margin-top: 1rem;
+  `,
+};
+
+export const Message = styled.span<{ variant: Variant }>`
+  ${props => messageVariantStyles[props.variant]}
 `;
 
-export const MetabaseName = styled.span<{ isDark: boolean }>`
-  color: ${props => color(props.isDark ? "white" : "brand")};
+export const MetabaseName = styled.span<{ isDark: boolean; variant: Variant }>`
+  color: ${props => {
+    if (props.isDark) {
+      return color("white");
+    }
+    return color(props.variant === "big" ? "text-dark" : "brand");
+  }};
 `;

--- a/frontend/src/metabase/public/components/EmbedFrame/LogoBadge.styled.tsx
+++ b/frontend/src/metabase/public/components/EmbedFrame/LogoBadge.styled.tsx
@@ -4,7 +4,7 @@ import ExternalLink from "metabase/core/components/ExternalLink";
 import { color } from "metabase/lib/colors";
 import { breakpointMinMedium } from "metabase/styled-components/theme";
 
-export type Variant = "default" | "big";
+export type Variant = "default" | "large";
 
 export const MetabaseLink = styled(ExternalLink)<{ variant: Variant }>`
   display: flex;
@@ -15,7 +15,7 @@ export const MetabaseLink = styled(ExternalLink)<{ variant: Variant }>`
   text-decoration: none;
 
   ${props =>
-    props.variant === "big" &&
+    props.variant === "large" &&
     css`
       flex-direction: column;
     `}
@@ -30,7 +30,7 @@ const messageVariantStyles = {
       margin-left: 1rem;
     }
   `,
-  big: css`
+  large: css`
     color: ${color("text-dark")};
     margin-top: 1rem;
   `,
@@ -45,6 +45,6 @@ export const MetabaseName = styled.span<{ isDark: boolean; variant: Variant }>`
     if (props.isDark) {
       return color("white");
     }
-    return color(props.variant === "big" ? "text-dark" : "brand");
+    return color(props.variant === "large" ? "text-dark" : "brand");
   }};
 `;

--- a/frontend/src/metabase/public/components/EmbedFrame/LogoBadge.tsx
+++ b/frontend/src/metabase/public/components/EmbedFrame/LogoBadge.tsx
@@ -1,18 +1,34 @@
 import React from "react";
 import { t, jt } from "ttag";
 import LogoIcon from "metabase/components/LogoIcon";
-import { MetabaseLink, MetabaseName, Message } from "./LogoBadge.styled";
+import {
+  MetabaseLink,
+  MetabaseName,
+  Message,
+  Variant,
+} from "./LogoBadge.styled";
 
-function LogoBadge({ dark }: { dark: boolean }) {
+function LogoBadge({
+  dark,
+  variant = "default",
+}: {
+  dark: boolean;
+  variant?: Variant;
+}) {
+  const logoSize = variant === "big" ? 42 : 28;
   const Metabase = (
-    <MetabaseName key="metabase" isDark={dark}>
+    <MetabaseName key="metabase" isDark={dark} variant={variant}>
       {t`Metabase`}
     </MetabaseName>
   );
   return (
-    <MetabaseLink href="https://metabase.com/" target="_blank">
-      <LogoIcon height={28} dark={dark} />
-      <Message>{jt`Powered by ${Metabase}`}</Message>
+    <MetabaseLink
+      href="https://metabase.com/"
+      target="_blank"
+      variant={variant}
+    >
+      <LogoIcon height={logoSize} dark={dark} />
+      <Message variant={variant}>{jt`Powered by ${Metabase}`}</Message>
     </MetabaseLink>
   );
 }

--- a/frontend/src/metabase/public/components/EmbedFrame/LogoBadge.tsx
+++ b/frontend/src/metabase/public/components/EmbedFrame/LogoBadge.tsx
@@ -15,7 +15,7 @@ function LogoBadge({
   dark: boolean;
   variant?: Variant;
 }) {
-  const logoSize = variant === "big" ? 42 : 28;
+  const logoSize = variant === "large" ? 42 : 28;
   const Metabase = (
     <MetabaseName key="metabase" isDark={dark} variant={variant}>
       {t`Metabase`}

--- a/frontend/src/metabase/public/containers/PublicAction/PublicAction.styled.tsx
+++ b/frontend/src/metabase/public/containers/PublicAction/PublicAction.styled.tsx
@@ -1,0 +1,31 @@
+import styled from "@emotion/styled";
+import FormSubmitButton from "metabase/core/components/FormSubmitButton";
+import BaseLoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
+import { color } from "metabase/lib/colors";
+
+export const LoadingAndErrorWrapper = styled(BaseLoadingAndErrorWrapper)`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  min-height: 100vh;
+`;
+
+export const ContentContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 430px;
+
+  ${FormSubmitButton.Button} {
+    width: 100%;
+  }
+`;
+
+export const FormTitle = styled.h1`
+  font-weight: 700;
+  font-size: 18px;
+  line-height: 22px;
+  color: ${color("text-dark")};
+
+  margin-bottom: 21px;
+`;

--- a/frontend/src/metabase/public/containers/PublicAction/PublicAction.styled.tsx
+++ b/frontend/src/metabase/public/containers/PublicAction/PublicAction.styled.tsx
@@ -8,8 +8,7 @@ export const LoadingAndErrorWrapper = styled(BaseLoadingAndErrorWrapper)`
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 100%;
-  min-height: 100vh;
+  flex: 1 0 auto;
 `;
 
 export const ContentContainer = styled.div`

--- a/frontend/src/metabase/public/containers/PublicAction/PublicAction.styled.tsx
+++ b/frontend/src/metabase/public/containers/PublicAction/PublicAction.styled.tsx
@@ -1,4 +1,5 @@
 import styled from "@emotion/styled";
+import { css } from "@emotion/react";
 import FormSubmitButton from "metabase/core/components/FormSubmitButton";
 import BaseLoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
 import { color } from "metabase/lib/colors";
@@ -21,11 +22,19 @@ export const ContentContainer = styled.div`
   }
 `;
 
-export const FormTitle = styled.h1`
+const titleStyle = css`
   font-weight: 700;
-  font-size: 18px;
-  line-height: 22px;
+  font-size: 1.125rem;
+  line-height: 1.375rem;
   color: ${color("text-dark")};
+`;
 
+export const FormTitle = styled.h1`
+  ${titleStyle}
   margin-bottom: 21px;
+`;
+
+export const FormResultMessage = styled.h1`
+  ${titleStyle}
+  text-align: center;
 `;

--- a/frontend/src/metabase/public/containers/PublicAction/PublicAction.styled.tsx
+++ b/frontend/src/metabase/public/containers/PublicAction/PublicAction.styled.tsx
@@ -6,12 +6,18 @@ import { color } from "metabase/lib/colors";
 
 export const LoadingAndErrorWrapper = styled(BaseLoadingAndErrorWrapper)`
   display: flex;
-  align-items: center;
-  justify-content: center;
   flex: 1 0 auto;
 `;
 
 export const ContentContainer = styled.div`
+  display: flex;
+  flex: 1 0 auto;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+`;
+
+export const FormContainer = styled.div`
   display: flex;
   flex-direction: column;
   width: 430px;

--- a/frontend/src/metabase/public/containers/PublicAction/PublicAction.tsx
+++ b/frontend/src/metabase/public/containers/PublicAction/PublicAction.tsx
@@ -1,11 +1,7 @@
 import React, { useCallback, useState } from "react";
-import { connect } from "react-redux";
 import { t } from "ttag";
 
-import { useOnMount } from "metabase/hooks/use-on-mount";
-import { useSafeAsyncFunction } from "metabase/hooks/use-safe-async-function";
-import { setErrorPage } from "metabase/redux/app";
-import { ActionsApi } from "metabase/services";
+import title from "metabase/hoc/Title";
 
 import { ActionForm } from "metabase/actions/components/ActionForm";
 
@@ -15,84 +11,45 @@ import type {
 } from "metabase-types/api";
 import type { AppErrorDescriptor } from "metabase-types/store";
 
-import EmbedFrame from "metabase/public/components/EmbedFrame";
-import {
-  LoadingAndErrorWrapper,
-  ContentContainer,
-  FormTitle,
-  FormResultMessage,
-} from "./PublicAction.styled";
+import { FormTitle, FormResultMessage } from "./PublicAction.styled";
 
-interface OwnProps {
-  params: { actionId: string };
+interface Props {
+  action: WritebackAction;
+  onError: (error: AppErrorDescriptor) => void;
 }
 
-interface DispatchProps {
-  setErrorPage: (error: AppErrorDescriptor) => void;
-}
-
-type Props = OwnProps & DispatchProps;
-
-const mapDispatchToProps = {
-  setErrorPage,
-};
-
-function PublicAction({ params, setErrorPage }: Props) {
-  const [action, setAction] = useState<WritebackAction | null>(null);
+function PublicAction({ action, onError }: Props) {
   const [isSubmitted, setSubmitted] = useState(false);
-  const fetchAction = useSafeAsyncFunction(ActionsApi.get);
-
-  useOnMount(() => {
-    async function loadAction() {
-      try {
-        const action = await fetchAction({ id: params.actionId });
-        setAction(action);
-      } catch (error) {
-        setErrorPage(error as AppErrorDescriptor);
-      }
-    }
-    loadAction();
-  });
 
   const handleSubmit = useCallback(
     (values: ParametersForActionExecution) => {
       try {
         setSubmitted(true);
       } catch (error) {
-        setErrorPage(error as AppErrorDescriptor);
+        onError(error as AppErrorDescriptor);
       }
     },
-    [setErrorPage],
+    [onError],
   );
 
-  const renderContent = useCallback(() => {
-    if (!action) {
-      return null;
-    }
-    if (isSubmitted) {
-      return (
-        <FormResultMessage>{t`Thanks for your submission.`}</FormResultMessage>
-      );
-    }
+  if (isSubmitted) {
     return (
-      <>
-        <FormTitle>{action.name}</FormTitle>
-        <ActionForm
-          parameters={action.parameters}
-          formSettings={action.visualization_settings}
-          onSubmit={handleSubmit}
-        />
-      </>
+      <FormResultMessage>{t`Thanks for your submission.`}</FormResultMessage>
     );
-  }, [action, isSubmitted, handleSubmit]);
+  }
 
   return (
-    <EmbedFrame footerVariant="big">
-      <LoadingAndErrorWrapper loading={!action}>
-        {() => <ContentContainer>{renderContent()}</ContentContainer>}
-      </LoadingAndErrorWrapper>
-    </EmbedFrame>
+    <>
+      <FormTitle>{action.name}</FormTitle>
+      <ActionForm
+        parameters={action.parameters}
+        formSettings={action.visualization_settings}
+        onSubmit={handleSubmit}
+      />
+    </>
   );
 }
 
-export default connect(null, mapDispatchToProps)(PublicAction);
+const getPageTitle = ({ action }: Props) => action.name;
+
+export default title(getPageTitle)(PublicAction);

--- a/frontend/src/metabase/public/containers/PublicAction/PublicAction.tsx
+++ b/frontend/src/metabase/public/containers/PublicAction/PublicAction.tsx
@@ -11,7 +11,11 @@ import type {
 } from "metabase-types/api";
 import type { AppErrorDescriptor } from "metabase-types/store";
 
-import { FormTitle, FormResultMessage } from "./PublicAction.styled";
+import {
+  FormContainer,
+  FormTitle,
+  FormResultMessage,
+} from "./PublicAction.styled";
 
 interface Props {
   action: WritebackAction;
@@ -39,14 +43,14 @@ function PublicAction({ action, onError }: Props) {
   }
 
   return (
-    <>
+    <FormContainer>
       <FormTitle>{action.name}</FormTitle>
       <ActionForm
         parameters={action.parameters}
         formSettings={action.visualization_settings}
         onSubmit={handleSubmit}
       />
-    </>
+    </FormContainer>
   );
 }
 

--- a/frontend/src/metabase/public/containers/PublicAction/PublicAction.tsx
+++ b/frontend/src/metabase/public/containers/PublicAction/PublicAction.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useState } from "react";
 import { t } from "ttag";
 
 import title from "metabase/hoc/Title";
+import { PublicApi } from "metabase/services";
 
 import { ActionForm } from "metabase/actions/components/ActionForm";
 
@@ -19,21 +20,23 @@ import {
 
 interface Props {
   action: WritebackAction;
+  publicId: string;
   onError: (error: AppErrorDescriptor) => void;
 }
 
-function PublicAction({ action, onError }: Props) {
+function PublicAction({ action, publicId, onError }: Props) {
   const [isSubmitted, setSubmitted] = useState(false);
 
   const handleSubmit = useCallback(
-    (values: ParametersForActionExecution) => {
+    async (values: ParametersForActionExecution) => {
       try {
+        await PublicApi.executeAction({ uuid: publicId, parameters: values });
         setSubmitted(true);
       } catch (error) {
         onError(error as AppErrorDescriptor);
       }
     },
-    [onError],
+    [publicId, onError],
   );
 
   if (isSubmitted) {

--- a/frontend/src/metabase/public/containers/PublicAction/PublicAction.tsx
+++ b/frontend/src/metabase/public/containers/PublicAction/PublicAction.tsx
@@ -1,0 +1,72 @@
+import React, { useCallback } from "react";
+import { connect } from "react-redux";
+
+import { useOnMount } from "metabase/hooks/use-on-mount";
+import { useSafeAsyncFunction } from "metabase/hooks/use-safe-async-function";
+import { setErrorPage } from "metabase/redux/app";
+import { ActionsApi } from "metabase/services";
+
+import { ActionForm } from "metabase/actions/components/ActionForm";
+
+import type { WritebackAction } from "metabase-types/api";
+import type { AppErrorDescriptor } from "metabase-types/store";
+
+import {
+  LoadingAndErrorWrapper,
+  ContentContainer,
+  FormTitle,
+} from "./PublicAction.styled";
+
+interface OwnProps {
+  params: { actionId: string };
+}
+
+interface DispatchProps {
+  setErrorPage: (error: AppErrorDescriptor) => void;
+}
+
+type Props = OwnProps & DispatchProps;
+
+const mapDispatchToProps = {
+  setErrorPage,
+};
+
+function PublicAction({ params, setErrorPage }: Props) {
+  const [action, setAction] = React.useState<WritebackAction | null>(null);
+  const fetchAction = useSafeAsyncFunction(ActionsApi.get);
+
+  useOnMount(() => {
+    async function loadAction() {
+      try {
+        const action = await fetchAction({ id: params.actionId });
+        setAction(action);
+      } catch (error) {
+        setErrorPage(error as AppErrorDescriptor);
+      }
+    }
+    loadAction();
+  });
+
+  const renderContent = useCallback(() => {
+    if (!action) {
+      return null;
+    }
+    return (
+      <ContentContainer>
+        <FormTitle>{action.name}</FormTitle>
+        <ActionForm
+          parameters={action.parameters}
+          formSettings={action.visualization_settings}
+        />
+      </ContentContainer>
+    );
+  }, [action]);
+
+  return (
+    <LoadingAndErrorWrapper loading={!action}>
+      {renderContent}
+    </LoadingAndErrorWrapper>
+  );
+}
+
+export default connect(null, mapDispatchToProps)(PublicAction);

--- a/frontend/src/metabase/public/containers/PublicAction/PublicAction.tsx
+++ b/frontend/src/metabase/public/containers/PublicAction/PublicAction.tsx
@@ -15,6 +15,7 @@ import type {
 } from "metabase-types/api";
 import type { AppErrorDescriptor } from "metabase-types/store";
 
+import EmbedFrame from "metabase/public/components/EmbedFrame";
 import {
   LoadingAndErrorWrapper,
   ContentContainer,
@@ -86,9 +87,11 @@ function PublicAction({ params, setErrorPage }: Props) {
   }, [action, isSubmitted, handleSubmit]);
 
   return (
-    <LoadingAndErrorWrapper loading={!action}>
-      {() => <ContentContainer>{renderContent()}</ContentContainer>}
-    </LoadingAndErrorWrapper>
+    <EmbedFrame footerVariant="big">
+      <LoadingAndErrorWrapper loading={!action}>
+        {() => <ContentContainer>{renderContent()}</ContentContainer>}
+      </LoadingAndErrorWrapper>
+    </EmbedFrame>
   );
 }
 

--- a/frontend/src/metabase/public/containers/PublicAction/PublicAction.tsx
+++ b/frontend/src/metabase/public/containers/PublicAction/PublicAction.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useState } from "react";
 import { t } from "ttag";
 
 import title from "metabase/hoc/Title";
+import { useOnMount } from "metabase/hooks/use-on-mount";
 import { PublicApi } from "metabase/services";
 
 import { ActionForm } from "metabase/actions/components/ActionForm";
@@ -27,6 +28,8 @@ interface Props {
 function PublicAction({ action, publicId, onError }: Props) {
   const [isSubmitted, setSubmitted] = useState(false);
 
+  const hasParameters = action.parameters.length > 0;
+
   const handleSubmit = useCallback(
     async (values: ParametersForActionExecution) => {
       try {
@@ -39,10 +42,20 @@ function PublicAction({ action, publicId, onError }: Props) {
     [publicId, onError],
   );
 
+  useOnMount(() => {
+    if (!hasParameters) {
+      handleSubmit({});
+    }
+  });
+
   if (isSubmitted) {
     return (
       <FormResultMessage>{t`Thanks for your submission.`}</FormResultMessage>
     );
+  }
+
+  if (!hasParameters) {
+    return null;
   }
 
   return (

--- a/frontend/src/metabase/public/containers/PublicAction/PublicAction.unit.spec.tsx
+++ b/frontend/src/metabase/public/containers/PublicAction/PublicAction.unit.spec.tsx
@@ -168,4 +168,18 @@ describe("PublicAction", () => {
     expect(screen.getByText("Not found")).toBeInTheDocument();
     expect(screen.queryByRole("form")).not.toBeInTheDocument();
   });
+
+  it("immediately executes an action without parameters", async () => {
+    const { executeActionEndpointSpy } = await setup({
+      action: { ...TEST_ACTION, parameters: [] },
+      expectedRequestBody: { parameters: {} },
+    });
+
+    expect(
+      await screen.findByText("Thanks for your submission."),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(TEST_ACTION.name)).not.toBeInTheDocument();
+    expect(screen.queryByRole("form")).not.toBeInTheDocument();
+    expect(executeActionEndpointSpy.isDone()).toBe(true);
+  });
 });

--- a/frontend/src/metabase/public/containers/PublicAction/PublicAction.unit.spec.tsx
+++ b/frontend/src/metabase/public/containers/PublicAction/PublicAction.unit.spec.tsx
@@ -1,0 +1,171 @@
+import React from "react";
+import nock from "nock";
+import userEvent from "@testing-library/user-event";
+
+import {
+  renderWithProviders,
+  screen,
+  waitFor,
+  waitForElementToBeRemoved,
+} from "__support__/ui";
+
+import type {
+  ParametersForActionExecution,
+  PublicWritebackAction,
+} from "metabase-types/api";
+import {
+  createMockActionParameter,
+  createMockPublicAction,
+} from "metabase-types/api/mocks";
+
+import PublicApp from "../PublicApp";
+import PublicAction from "./PublicActionLoader";
+
+const TEST_PUBLIC_ID = "test-public-id";
+
+const SIZE_PARAMETER = createMockActionParameter({
+  id: "size",
+  name: "Size",
+  type: "number/=",
+  slug: "size",
+  target: ["variable", ["template-tag", "size"]],
+});
+
+const COLOR_PARAMETER = createMockActionParameter({
+  id: "color",
+  name: "Color",
+  type: "string/=",
+  slug: "color",
+  target: ["variable", ["template-tag", "color"]],
+});
+
+const TEST_ACTION = createMockPublicAction({
+  name: "Giving out t-shirts",
+  parameters: [SIZE_PARAMETER, COLOR_PARAMETER],
+});
+
+type ExecuteActionRequestBody = {
+  parameters: ParametersForActionExecution;
+};
+
+async function setup({
+  action = TEST_ACTION,
+  expectedRequestBody,
+  shouldFetchFail = false,
+  shouldExecutionFail = false,
+}: {
+  action?: PublicWritebackAction;
+  expectedRequestBody?: ExecuteActionRequestBody;
+  shouldFetchFail?: boolean;
+  shouldExecutionFail?: boolean;
+} = {}) {
+  const scope = nock(location.origin);
+
+  scope
+    .get(`/api/public/action/${TEST_PUBLIC_ID}`)
+    .reply(
+      shouldFetchFail ? 404 : 200,
+      shouldFetchFail ? { message: "Not found" } : action,
+    );
+
+  const executionResponse = shouldExecutionFail
+    ? { message: "Something's off" }
+    : { "rows-affected": [1] };
+
+  const executeActionEndpointSpy = scope
+    .post(`/api/public/action/${TEST_PUBLIC_ID}/execute`, expectedRequestBody)
+    .reply(shouldExecutionFail ? 400 : 200, executionResponse);
+
+  renderWithProviders(
+    <PublicApp>
+      <PublicAction params={{ uuid: TEST_PUBLIC_ID }} />
+    </PublicApp>,
+    {
+      mode: "public",
+      initialRouterState: {
+        route: "/public/action/:uuid",
+        location: `/public/action/${TEST_PUBLIC_ID}`,
+      },
+      withRouter: true,
+    },
+  );
+
+  await waitForElementToBeRemoved(() =>
+    screen.queryByTestId("loading-spinner"),
+  );
+
+  return { executeActionEndpointSpy };
+}
+
+describe("PublicAction", () => {
+  beforeEach(() => {
+    nock.cleanAll();
+  });
+
+  it("shows acton form", async () => {
+    await setup();
+
+    expect(screen.getByText(TEST_ACTION.name)).toBeInTheDocument();
+    expect(screen.getByLabelText(SIZE_PARAMETER.name)).toBeInTheDocument();
+    expect(screen.getByLabelText(COLOR_PARAMETER.name)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Submit" })).toBeInTheDocument();
+  });
+
+  it("doesn't let to submit a clean form", async () => {
+    await setup();
+    expect(screen.getByRole("button", { name: "Submit" })).toBeDisabled();
+  });
+
+  it("submits form correctly", async () => {
+    const { executeActionEndpointSpy } = await setup({
+      expectedRequestBody: {
+        parameters: {
+          [SIZE_PARAMETER.id]: "42",
+          [COLOR_PARAMETER.id]: "metablue",
+        },
+      },
+    });
+
+    userEvent.type(screen.getByLabelText("Size"), "42");
+    userEvent.type(screen.getByLabelText("Color"), "metablue");
+    userEvent.click(screen.getByRole("button", { name: "Submit" }));
+
+    await waitFor(() => {
+      expect(executeActionEndpointSpy.isDone()).toBe(true);
+    });
+  });
+
+  it("shows a message on successful submit", async () => {
+    await setup();
+
+    userEvent.type(screen.getByLabelText("Size"), "42");
+    userEvent.type(screen.getByLabelText("Color"), "metablue");
+    userEvent.click(screen.getByRole("button", { name: "Submit" }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Thanks for your submission."),
+      ).toBeInTheDocument();
+    });
+    expect(screen.queryByText(TEST_ACTION.name)).not.toBeInTheDocument();
+    expect(screen.queryByRole("form")).not.toBeInTheDocument();
+  });
+
+  it("shows error if can't fetch action", async () => {
+    await setup({ shouldExecutionFail: true });
+
+    userEvent.type(screen.getByLabelText("Size"), "42");
+    userEvent.type(screen.getByLabelText("Color"), "metablue");
+    userEvent.click(screen.getByRole("button", { name: "Submit" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Something's off")).toBeInTheDocument();
+    });
+  });
+
+  it("shows error if action fails", async () => {
+    await setup({ shouldFetchFail: true });
+    expect(screen.getByText("Not found")).toBeInTheDocument();
+    expect(screen.queryByRole("form")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/metabase/public/containers/PublicAction/PublicAction.unit.spec.tsx
+++ b/frontend/src/metabase/public/containers/PublicAction/PublicAction.unit.spec.tsx
@@ -142,11 +142,9 @@ describe("PublicAction", () => {
     userEvent.type(screen.getByLabelText("Color"), "metablue");
     userEvent.click(screen.getByRole("button", { name: "Submit" }));
 
-    await waitFor(() => {
-      expect(
-        screen.getByText("Thanks for your submission."),
-      ).toBeInTheDocument();
-    });
+    expect(
+      await screen.findByText("Thanks for your submission."),
+    ).toBeInTheDocument();
     expect(screen.queryByText(TEST_ACTION.name)).not.toBeInTheDocument();
     expect(screen.queryByRole("form")).not.toBeInTheDocument();
   });
@@ -158,9 +156,7 @@ describe("PublicAction", () => {
     userEvent.type(screen.getByLabelText("Color"), "metablue");
     userEvent.click(screen.getByRole("button", { name: "Submit" }));
 
-    await waitFor(() => {
-      expect(screen.getByText("Something's off")).toBeInTheDocument();
-    });
+    expect(await screen.findByText("Something's off")).toBeInTheDocument();
   });
 
   it("shows error if action fails", async () => {

--- a/frontend/src/metabase/public/containers/PublicAction/PublicAction.unit.spec.tsx
+++ b/frontend/src/metabase/public/containers/PublicAction/PublicAction.unit.spec.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { Route } from "react-router";
 import nock from "nock";
 import userEvent from "@testing-library/user-event";
 
@@ -77,15 +78,17 @@ async function setup({
     .reply(shouldExecutionFail ? 400 : 200, executionResponse);
 
   renderWithProviders(
-    <PublicApp>
-      <PublicAction params={{ uuid: TEST_PUBLIC_ID }} />
-    </PublicApp>,
+    <Route
+      path="/public/action/:uuid"
+      component={props => (
+        <PublicApp {...props}>
+          <PublicAction {...props} />
+        </PublicApp>
+      )}
+    />,
     {
       mode: "public",
-      initialRouterState: {
-        route: "/public/action/:uuid",
-        location: `/public/action/${TEST_PUBLIC_ID}`,
-      },
+      initialRoute: `/public/action/${TEST_PUBLIC_ID}`,
       withRouter: true,
     },
   );

--- a/frontend/src/metabase/public/containers/PublicAction/PublicActionLoader.tsx
+++ b/frontend/src/metabase/public/containers/PublicAction/PublicActionLoader.tsx
@@ -4,7 +4,7 @@ import { connect } from "react-redux";
 import { useOnMount } from "metabase/hooks/use-on-mount";
 import { useSafeAsyncFunction } from "metabase/hooks/use-safe-async-function";
 import { setErrorPage } from "metabase/redux/app";
-import { ActionsApi } from "metabase/services";
+import { PublicApi } from "metabase/services";
 
 import type { WritebackAction } from "metabase-types/api";
 import type { AppErrorDescriptor } from "metabase-types/store";
@@ -17,7 +17,7 @@ import {
 } from "./PublicAction.styled";
 
 interface OwnProps {
-  params: { actionId: string };
+  params: { uuid: string };
 }
 
 interface DispatchProps {
@@ -32,12 +32,12 @@ const mapDispatchToProps = {
 
 function PublicActionLoader({ params, setErrorPage }: Props) {
   const [action, setAction] = useState<WritebackAction | null>(null);
-  const fetchAction = useSafeAsyncFunction(ActionsApi.get);
+  const fetchAction = useSafeAsyncFunction(PublicApi.action);
 
   useOnMount(() => {
     async function loadAction() {
       try {
-        const action = await fetchAction({ id: params.actionId });
+        const action = await fetchAction({ uuid: params.uuid });
         setAction(action);
       } catch (error) {
         setErrorPage(error as AppErrorDescriptor);

--- a/frontend/src/metabase/public/containers/PublicAction/PublicActionLoader.tsx
+++ b/frontend/src/metabase/public/containers/PublicAction/PublicActionLoader.tsx
@@ -52,10 +52,14 @@ function PublicActionLoader({ params, setErrorPage }: Props) {
     }
     return (
       <ContentContainer>
-        <PublicAction action={action} onError={setErrorPage} />
+        <PublicAction
+          action={action}
+          publicId={params.uuid}
+          onError={setErrorPage}
+        />
       </ContentContainer>
     );
-  }, [action, setErrorPage]);
+  }, [action, params.uuid, setErrorPage]);
 
   return (
     <EmbedFrame footerVariant="big">

--- a/frontend/src/metabase/public/containers/PublicAction/PublicActionLoader.tsx
+++ b/frontend/src/metabase/public/containers/PublicAction/PublicActionLoader.tsx
@@ -1,0 +1,69 @@
+import React, { useCallback, useState } from "react";
+import { connect } from "react-redux";
+
+import { useOnMount } from "metabase/hooks/use-on-mount";
+import { useSafeAsyncFunction } from "metabase/hooks/use-safe-async-function";
+import { setErrorPage } from "metabase/redux/app";
+import { ActionsApi } from "metabase/services";
+
+import type { WritebackAction } from "metabase-types/api";
+import type { AppErrorDescriptor } from "metabase-types/store";
+
+import EmbedFrame from "../../components/EmbedFrame";
+import PublicAction from "./PublicAction";
+import {
+  LoadingAndErrorWrapper,
+  ContentContainer,
+} from "./PublicAction.styled";
+
+interface OwnProps {
+  params: { actionId: string };
+}
+
+interface DispatchProps {
+  setErrorPage: (error: AppErrorDescriptor) => void;
+}
+
+type Props = OwnProps & DispatchProps;
+
+const mapDispatchToProps = {
+  setErrorPage,
+};
+
+function PublicActionLoader({ params, setErrorPage }: Props) {
+  const [action, setAction] = useState<WritebackAction | null>(null);
+  const fetchAction = useSafeAsyncFunction(ActionsApi.get);
+
+  useOnMount(() => {
+    async function loadAction() {
+      try {
+        const action = await fetchAction({ id: params.actionId });
+        setAction(action);
+      } catch (error) {
+        setErrorPage(error as AppErrorDescriptor);
+      }
+    }
+    loadAction();
+  });
+
+  const renderContent = useCallback(() => {
+    if (!action) {
+      return null;
+    }
+    return (
+      <ContentContainer>
+        <PublicAction action={action} onError={setErrorPage} />
+      </ContentContainer>
+    );
+  }, [action, setErrorPage]);
+
+  return (
+    <EmbedFrame footerVariant="big">
+      <LoadingAndErrorWrapper loading={!action}>
+        {renderContent}
+      </LoadingAndErrorWrapper>
+    </EmbedFrame>
+  );
+}
+
+export default connect(null, mapDispatchToProps)(PublicActionLoader);

--- a/frontend/src/metabase/public/containers/PublicAction/index.ts
+++ b/frontend/src/metabase/public/containers/PublicAction/index.ts
@@ -1,1 +1,1 @@
-export { default } from "./PublicAction";
+export { default } from "./PublicActionLoader";

--- a/frontend/src/metabase/public/containers/PublicAction/index.ts
+++ b/frontend/src/metabase/public/containers/PublicAction/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./PublicAction";

--- a/frontend/src/metabase/routes-public.jsx
+++ b/frontend/src/metabase/routes-public.jsx
@@ -6,12 +6,14 @@ import { Route } from "metabase/hoc/Title";
 import PublicNotFound from "metabase/public/components/PublicNotFound";
 
 import PublicApp from "metabase/public/containers/PublicApp";
+import PublicAction from "metabase/public/containers/PublicAction";
 import PublicQuestion from "metabase/public/containers/PublicQuestion";
 import PublicDashboard from "metabase/public/containers/PublicDashboard";
 
 export const getRoutes = store => (
   <Route title={t`Metabase`}>
     <Route path="public" component={PublicApp}>
+      <Route path="action/:actionId" component={PublicAction} />
       <Route path="question/:uuid" component={PublicQuestion} />
       <Route path="dashboard/:uuid" component={PublicDashboard} />
       <Route path="*" component={PublicNotFound} />

--- a/frontend/src/metabase/routes-public.jsx
+++ b/frontend/src/metabase/routes-public.jsx
@@ -13,7 +13,7 @@ import PublicDashboard from "metabase/public/containers/PublicDashboard";
 export const getRoutes = store => (
   <Route title={t`Metabase`}>
     <Route path="public" component={PublicApp}>
-      <Route path="action/:actionId" component={PublicAction} />
+      <Route path="action/:uuid" component={PublicAction} />
       <Route path="question/:uuid" component={PublicQuestion} />
       <Route path="dashboard/:uuid" component={PublicDashboard} />
       <Route path="*" component={PublicNotFound} />

--- a/frontend/src/metabase/services.js
+++ b/frontend/src/metabase/services.js
@@ -162,6 +162,7 @@ const PIVOT_PUBLIC_PREFIX = "/api/public/pivot/";
 
 export const PublicApi = {
   action: GET("/api/public/action/:uuid"),
+  executeAction: POST("/api/public/action/:uuid/execute"),
   card: GET("/api/public/card/:uuid"),
   cardQuery: GET("/api/public/card/:uuid/query"),
   cardQueryPivot: GET(PIVOT_PUBLIC_PREFIX + "card/:uuid/query"),

--- a/frontend/src/metabase/services.js
+++ b/frontend/src/metabase/services.js
@@ -161,6 +161,7 @@ export const CollectionsApi = {
 const PIVOT_PUBLIC_PREFIX = "/api/public/pivot/";
 
 export const PublicApi = {
+  action: GET("/api/public/action/:uuid"),
   card: GET("/api/public/card/:uuid"),
   cardQuery: GET("/api/public/card/:uuid/query"),
   cardQueryPivot: GET(PIVOT_PUBLIC_PREFIX + "card/:uuid/query"),


### PR DESCRIPTION
Epic #27626

Adds a public action page available at `/public/action/:uuid` that should be publicly accessible after an action is made public. The page should display an action form, and have simple submit success and error states.

### To Verify

1. Sign in as admin
2. Go to `/admin/settings/public-sharing` and enable public sharing
3. Create a structured model (e.g. from the sample Orders table)
4. Go to `/model/:id/detail` and click the "Actions" tab
5. Create a new action (not a basic/implicit one) with a few parameters (e.g. `UPDATE orders SET discount = {{ discount }} WHERE id = {{ order_id }}`). Important: use the parameters form on the right to specify parameter types. E.g. for an example query, both `discount` and `order_id` should be numbers
6. After creating an action, click the pencil icon on the model actions tab. Click the gear icon in the modal editor topbar and make the action public using the control on the right
7. Copy the public action URL and open it in a different browser or an incognito tab
8. Ensure you can see the action form listing parameters, and ensure the "Submit" button is disabled
9. Fill in the form, click Submit, ensure you can see the "Thank you" message
10. Use the query builder to ensure that your action had a desired effect

### Demo

https://user-images.githubusercontent.com/17258145/214897324-e3696879-1d52-4ffe-a72b-9cb53d0bf470.mp4

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/27747)
<!-- Reviewable:end -->
