### PR TITLE
docs - update jwt

### DIFF
--- a/docs/people-and-groups/authenticating-with-jwt.md
+++ b/docs/people-and-groups/authenticating-with-jwt.md
@@ -10,14 +10,14 @@ redirect_from:
 
 You can connect Metabase to your identity provider using JSON Web Tokens (JWT) to authenticate people.
 
-## Types of authentication Metabase supports with JWT
+## Types of authentication
 
-Metabase supports two types of OAuth 2 authentication with JWT:
+Metabase supports two types of authentication with JWT:
 
 - Authorization Code Flow
 - Authorization Code Flow with PKCE
 
-PKCE stands for Proof-Key for Code Exchange, and it's a way to extend the Authorization Code Flow to incorporate random keys generated on demand. For more on these flows, see the [Wikipedia entry on OAuth](https://en.wikipedia.org/wiki/OAuth).
+Metabase's auth flows are custom workflows modelled after OAuth 2.0. You can use the auth flow with PKCE to incorporate random keys generated on demand.
 
 Currently, the only algorithm Metabase supports is [HS256](https://en.wikipedia.org/wiki/JSON_Web_Token) ([HMAC](https://en.wikipedia.org/wiki/HMAC) + [SHA-256](https://en.wikipedia.org/wiki/SHA-2).
 

--- a/docs/people-and-groups/authenticating-with-jwt.md
+++ b/docs/people-and-groups/authenticating-with-jwt.md
@@ -10,9 +10,9 @@ redirect_from:
 
 You can connect Metabase to your identity provider using JSON Web Tokens (JWT) to authenticate people.
 
-## Types of authentication
+## Authentication flows
 
-Metabase supports two types of authentication with JWT:
+Metabase supports two auth flows that can be used with JWT:
 
 - Authorization Code Flow
 - Authorization Code Flow with PKCE


### PR DESCRIPTION
Customer pointed out that Metabase's JWT auth isn't the same as OAuth 2.0.