### PR TITLE
Hide archived cards from the model details page "Used by" tab

### DIFF
--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -133,7 +133,7 @@
                                                    [:or
                                                     [:like :c.dataset_query (format "%%card__%s%%" model-id)]
                                                     [:like :c.dataset_query (format "%%#%s%%" model-id)]]]]
-                         :where [:= :m.id model-id]})
+                         :where [:and [:= :m.id model-id] [:not :c.archived]]})
        (db/do-post-select Card)
        ;; now check if model-id really occurs as a card ID
        (filter (fn [card] (some #{model-id} (-> card :dataset_query query/collect-card-ids))))))

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -376,8 +376,12 @@
                     Database [{other-database-id :id}]
                     ;; database doesn't quite match
                     Card [card-6 {:name "Card 6", :database_id other-database-id
-                                   :dataset_query {:query {:source-table (str "card__" model-id)}}}]]
-      (with-cards-in-readable-collection [model card-1 card-2 card-3 card-4 card-5 card-6]
+                                   :dataset_query {:query {:source-table (str "card__" model-id)}}}]
+                    ;; same as matching question, but archived
+                    Card [card-7 {:name "Card 7"
+                                  :archived true
+                                  :dataset_query {:query {:source-table (str "card__" model-id)}}}]]
+      (with-cards-in-readable-collection [model card-1 card-2 card-3 card-4 card-5 card-6 card-7]
         (is (= #{"Card 1" "Card 3" "Card 4"}
                (into #{} (map :name) (mt/user-http-request :rasta :get 200 "card"
                                                            :f :using_model :model_id model-id))))))))


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/27762

This PR modifies the BE query to filter for cards where `[:not :c.archived]` is true.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/27763)
<!-- Reviewable:end -->
