### PR TITLE
Make `parameter_card.parameter_id` long enough for a uuid

### DIFF
--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -13933,6 +13933,17 @@ databaseChangeLog:
                   name: context
             indexName: idx_query_execution_context
 
+  - changeSet:
+      id: v46.00-057
+      author: dpsutton
+      comment: Added 0.46.0 -- parameter_card.parameter_id long enough to hold a uuid
+      changes:
+        - modifyDataType:
+            tableName: parameter_card
+            columnName: parameter_id
+            newDataType: char(36)
+      rollback: #nothing to do, char(32) or char(36) are equivalent
+
 # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -13941,7 +13941,7 @@ databaseChangeLog:
         - modifyDataType:
             tableName: parameter_card
             columnName: parameter_id
-            newDataType: char(36)
+            newDataType: varchar(36)
       rollback: #nothing to do, char(32) or char(36) are equivalent
 
 # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<


### PR DESCRIPTION
was char(32). This is a common type for identifiers in our migrations file, but unfortunately not great for ids.

```clojure
user=> (count (str (random-uuid)))
36
```
