### PR TITLE
docs - notes on allowed domains

### DIFF
--- a/docs/configuring-metabase/settings.md
+++ b/docs/configuring-metabase/settings.md
@@ -38,9 +38,11 @@ This email address will be displayed in various messages throughout Metabase whe
 
 Allowed email address domain(s) for new [dashboard subscriptions](../dashboards/subscriptions.md) and [alerts](../questions/sharing/alerts.md). 
 
-Adding approved domains allows you to send alerts and subscriptions to email addresses that aren't associated with an account in your Metabase.
+Adding approved domains allows you to restrict which email addresses people can send alerts and subscriptions to.
 
-To specify multiple domains, separate each domain with a comma, with no space in between (e.g., "domain1,domain2"). To allow all domains, leave the field empty. 
+To allow all domains, leave the field empty (allowing all domains is the default).
+
+To specify multiple domains, separate each domain with a comma, with no space in between (e.g., "domain1,domain2"). 
 
 This setting doesn't affect existing subscriptions.
 

--- a/docs/configuring-metabase/settings.md
+++ b/docs/configuring-metabase/settings.md
@@ -34,7 +34,15 @@ This email address will be displayed in various messages throughout Metabase whe
 
 ## Approved domains for notifications
 
-Allowed email address domain(s) for new [dashboard subscriptions](../dashboards/subscriptions.md) and [alerts](../questions/sharing/alerts.md). To specify multiple domains, separate each domain with a comma, with no space in between (e.g., "domain1,domain2"). To allow all domains, leave the field empty. This setting doesn't affect existing subscriptions.
+{% include plans-blockquote.html feature="Approved domains for notifications" %}
+
+Allowed email address domain(s) for new [dashboard subscriptions](../dashboards/subscriptions.md) and [alerts](../questions/sharing/alerts.md). 
+
+Adding approved domains allows you to send alerts and subscriptions to email addresses that aren't associated with an account in your Metabase.
+
+To specify multiple domains, separate each domain with a comma, with no space in between (e.g., "domain1,domain2"). To allow all domains, leave the field empty. 
+
+This setting doesn't affect existing subscriptions.
 
 ## Anonymous tracking
 

--- a/docs/paid-features/overview.md
+++ b/docs/paid-features/overview.md
@@ -48,6 +48,12 @@ Send different groups of people the contents of the dashboard with different fil
 
 - [Customizing filter values for each dashboard subscription](../dashboards/subscriptions.md)
 
+## Email subscriptions and alerts to people without Metabase accounts
+
+You can whitelist domains, which allows you to send alerts and dashboard subscriptions to recipients that don't have accounts in your Metabase.
+
+- [Approved domains for notifications](../configuring-metabase/settings.md#approved-domains-for-notifications)
+
 ## Official collections
 
 You can mark certain collections as [official](../exploration-and-organization/collections.md#official-collections), which helps people find your most important questions, dashboards, and models.

--- a/docs/paid-features/overview.md
+++ b/docs/paid-features/overview.md
@@ -48,9 +48,9 @@ Send different groups of people the contents of the dashboard with different fil
 
 - [Customizing filter values for each dashboard subscription](../dashboards/subscriptions.md)
 
-## Email subscriptions and alerts to people without Metabase accounts
+## Restrict which domains people can send alerts and subscriptions to
 
-You can whitelist domains, which allows you to send alerts and dashboard subscriptions to recipients that don't have accounts in your Metabase.
+As an additional security layer, you can whitelist domains, which restricts people from sending alerts and subscriptions to email addresses that don't use an approved domain.
 
 - [Approved domains for notifications](../configuring-metabase/settings.md#approved-domains-for-notifications)
 


### PR DESCRIPTION
- Allowed domains is a pro/enterprise feature
- Clarifies why you'd want this feature: to restrict the domains as an extra security layer.
