### PR TITLE
small reproduction for mu/defn linting issue

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -421,7 +421,7 @@
   metabase.test/with-temp-file                                                         clojure.core/let
   metabase.test/with-user-in-groups                                                    clojure.core/let
   metabase.util.files/with-open-path-to-resource                                       clojure.core/let
-  metabase.util.malli/defn                                                             clj-kondo.lint-as/def-catch-all
+  metabase.util.malli/defn                                                             schema.core/defn
   metabase.util.ssh/with-ssh-tunnel                                                    clojure.core/let
   monger.operators/defoperator                                                         clojure.core/def
   potemkin.types/defprotocol+                                                          clojure.core/defprotocol
@@ -644,8 +644,8 @@
    metabase.test/with-temp-env-var-value                                        macros.metabase.test.util/with-temp-env-var-value
    metabase.test/with-temporary-raw-setting-values                              macros.metabase.test.util/with-temporary-raw-setting-values}}
 
- :config-in-call
- {metabase.util.honey-sql-2-extensions/with-database-type-info {:linters {:type-mismatch {:level :off}}}}
+ ;; :config-in-call
+ ;; {metabase.util.honey-sql-2-extensions/with-database-type-info {:linters {:type-mismatch {:level :off}}}}
 
  :config-in-comment
  {:linters {:unresolved-symbol {:level :off}}}


### PR DESCRIPTION
Running

```
clj-kondo --config .clj-kondo/config.edn --config-dir .clj-kondo/ --lint src/metabase/util/malli.clj src/metabase/util/honey_sql_2_extensions.clj test/metabase/util/honey_sql_2_extensions_test.clj
```

results in linting errors for functions defined by `mu/defn`. I think it's related to them being `:linted-as` `schema.core/defn` but still: It would be nice to have a clj-kondo hook for `mu/defn`. 

`malli.experimental/defn` would also benefit from this.

---

clj-kondo version: `clj-kondo v2023.01.16`