### PR TITLE
Fix jest error about import after teardown phase

### DIFF
--- a/frontend/src/metabase/entities/revisions.js
+++ b/frontend/src/metabase/entities/revisions.js
@@ -2,9 +2,10 @@ import { createEntity } from "metabase/lib/entities";
 
 import { GET, POST } from "metabase/lib/api";
 
-const listRevisions = GET("/api/revision");
+import Dashboards from "./dashboards";
+import Questions from "./questions";
 
-const ASSOCIATED_ENTITY_TYPES = ["questions", "dashboards"];
+const listRevisions = GET("/api/revision");
 
 const Revision = createEntity({
   name: "revisions",
@@ -35,14 +36,11 @@ const Revision = createEntity({
   },
 
   actionShouldInvalidateLists(action) {
-    const entities = require("metabase/entities");
-    for (const type of ASSOCIATED_ENTITY_TYPES) {
-      if (entities[type].actionShouldInvalidateLists(action)) {
-        return true;
-      }
-    }
-
-    return action.type === this.actionTypes.INVALIDATE_LISTS_ACTION;
+    return (
+      action.type === this.actionTypes.INVALIDATE_LISTS_ACTION ||
+      Dashboards.actionShouldInvalidateLists(action) ||
+      Questions.actionShouldInvalidateLists(action)
+    );
   },
 });
 

--- a/frontend/src/metabase/entities/search.js
+++ b/frontend/src/metabase/entities/search.js
@@ -3,11 +3,19 @@ import { createEntity } from "metabase/lib/entities";
 import { GET } from "metabase/lib/api";
 import { entityTypeForObject } from "metabase/lib/schema";
 
-import { ObjectUnionSchema, ENTITIES_SCHEMA_MAP } from "metabase/schema";
+import { ObjectUnionSchema } from "metabase/schema";
 
 import { canonicalCollectionId } from "metabase/collections/utils";
 
-const ENTITIES_TYPES = Object.keys(ENTITIES_SCHEMA_MAP);
+import Bookmarks from "./bookmarks";
+import Collections from "./collections";
+import Dashboards from "./dashboards";
+import Metrics from "./metrics";
+import Pulses from "./pulses";
+import Questions from "./questions";
+import Segments from "./segments";
+import Snippets from "./snippets";
+import SnippetCollections from "./snippet-collections";
 
 const searchList = GET("/api/search");
 const collectionList = GET("/api/collection/:collection/items");
@@ -82,12 +90,16 @@ export default createEntity({
 
   // delegate to each entity's actionShouldInvalidateLists
   actionShouldInvalidateLists(action) {
-    const entities = require("metabase/entities");
-    for (const type of ENTITIES_TYPES) {
-      if (entities[type].actionShouldInvalidateLists(action)) {
-        return true;
-      }
-    }
-    return false;
+    return (
+      Bookmarks.actionShouldInvalidateLists(action) ||
+      Collections.actionShouldInvalidateLists(action) ||
+      Dashboards.actionShouldInvalidateLists(action) ||
+      Metrics.actionShouldInvalidateLists(action) ||
+      Pulses.actionShouldInvalidateLists(action) ||
+      Questions.actionShouldInvalidateLists(action) ||
+      Segments.actionShouldInvalidateLists(action) ||
+      Snippets.actionShouldInvalidateLists(action) ||
+      SnippetCollections.actionShouldInvalidateLists(action)
+    );
   },
 });


### PR DESCRIPTION
Fixes an annoying Jest error that shows up in certain tests:

```
ReferenceError: You are trying to 'import' a file after the Jest environment has been torn down
```

The issue was a dynamic `require` happening at revisions and search entities' `actionShouldInvalidateList` check. They used to access entities via `require("metabase/entities")` (we can't just import `metabase/entities` from an entity file because it'd be a circular import). Something in a test would dispatch an action, we'd run all the necessary assertions, but the handler won't finish running and that would cause an error.

Fixed by importing the entities we need directly

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/27780)
<!-- Reviewable:end -->
