### PR TITLE
Prevent admin group from being cleared by `PUT /membership/:group-id/clear`

### DIFF
--- a/src/metabase/api/permissions.clj
+++ b/src/metabase/api/permissions.clj
@@ -243,7 +243,7 @@
   [group-id]
   (validation/check-manager-of-group group-id)
   (api/check-404 (db/exists? PermissionsGroup :id group-id))
-  (api/check-400 (= group-id (u/the-id (perms-group/admin))))
+  (api/check-400 (not= group-id (u/the-id (perms-group/admin))))
   (db/delete! PermissionsGroupMembership :group_id group-id)
   api/generic-204-no-content)
 

--- a/src/metabase/api/permissions.clj
+++ b/src/metabase/api/permissions.clj
@@ -239,10 +239,11 @@
 
 #_{:clj-kondo/ignore [:deprecated-var]}
 (api/defendpoint-schema PUT "/membership/:group-id/clear"
-  "Remove all members from a `PermissionsGroup`."
+  "Remove all members from a `PermissionsGroup`. Returns a 400 (Bad Request) if the group ID is for the admin group."
   [group-id]
   (validation/check-manager-of-group group-id)
   (api/check-404 (db/exists? PermissionsGroup :id group-id))
+  (api/check-400 (= group-id (u/the-id (perms-group/admin))))
   (db/delete! PermissionsGroupMembership :group_id group-id)
   api/generic-204-no-content)
 

--- a/test/metabase/api/permissions_test.clj
+++ b/test/metabase/api/permissions_test.clj
@@ -297,7 +297,10 @@
         (is (= 1 (db/count PermissionsGroupMembership :group_id group-id)))
         (mt/user-http-request :crowberto :put 204 (format "permissions/membership/%d/clear" group-id))
         (is (true? (db/exists? PermissionsGroup :id group-id)))
-        (is (= 0 (db/count PermissionsGroupMembership :group_id group-id)))))))
+        (is (= 0 (db/count PermissionsGroupMembership :group_id group-id))))
+
+      (testing "The admin group cannot be cleared using this endpoint"
+        (mt/user-http-request :crowberto :put 400 (format "permissions/membership/%d/clear" (u/the-id (perms-group/admin))))))))
 
 (deftest delete-group-membership-test
   (testing "DELETE /api/permissions/membership/:id"


### PR DESCRIPTION
This endpoint was added in https://github.com/metabase/metabase/pull/26555 to support a new UX for SSO group mapping management. But we don't ever want to clear the admin group via this UX, so I've made it error with a 400 if it is called this way.