### PR TITLE
Group tooltips rows

### DIFF
--- a/frontend/src/metabase/visualizations/components/ChartTooltip/StackedDataTooltip/StackedDataTooltip.tsx
+++ b/frontend/src/metabase/visualizations/components/ChartTooltip/StackedDataTooltip/StackedDataTooltip.tsx
@@ -1,4 +1,5 @@
 import React, { useMemo } from "react";
+import { color } from "metabase/lib/colors";
 import { TooltipRow, TooltipTotalRow } from "../TooltipRow";
 import type { StackedTooltipModel } from "../types";
 import {
@@ -9,7 +10,9 @@ import {
   DataPointTable,
   DataPointTableFooter,
 } from "./StackedDataTooltip.styled";
-import { getPercent, getTotalValue } from "./utils";
+import { getPercent, getTotalValue, groupExcessiveTooltipRows } from "./utils";
+
+const MAX_BODY_ROWS = 8;
 
 type StackedDataTooltipProps = StackedTooltipModel;
 
@@ -36,6 +39,12 @@ const StackedDataTooltip = ({
   // In order to calculate percentages correctly we provide the grand total value
   const percentCalculationTotal = grandTotal ?? rowsTotal;
 
+  const trimmedBodyRows = groupExcessiveTooltipRows(
+    bodyRows,
+    MAX_BODY_ROWS,
+    hasColorIndicators ? color("text-light") : undefined,
+  );
+
   return (
     <DataPointRoot>
       {headerTitle && (
@@ -57,9 +66,9 @@ const StackedDataTooltip = ({
           ))}
         </DataPointTableHeader>
 
-        {bodyRows.length > 0 && (
+        {trimmedBodyRows.length > 0 && (
           <DataPointTableBody>
-            {bodyRows.map((row, index) => (
+            {trimmedBodyRows.map((row, index) => (
               <TooltipRow
                 key={index}
                 percent={

--- a/frontend/src/metabase/visualizations/components/ChartTooltip/StackedDataTooltip/StackedDataTooltip.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/components/ChartTooltip/StackedDataTooltip/StackedDataTooltip.unit.spec.tsx
@@ -1,5 +1,7 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
+import _ from "underscore";
+import { t } from "ttag";
 
 import type { StackedTooltipModel } from "../types";
 import StackedDataTooltip from "./StackedDataTooltip";
@@ -82,5 +84,43 @@ describe("StackedDataTooltip", () => {
     const { rowNames, rowValues } = setup({ showTotal: true });
     expect(rowNames[rowNames.length - 1]).toBe("Total");
     expect(rowValues[rowValues.length - 1]).toBe("600");
+  });
+
+  it("groups excessive tooltip rows", () => {
+    const bodyRows = _.range(10).map(rowNumber => ({
+      color: "red",
+      name: t`body row ${rowNumber}`,
+      value: rowNumber * 100,
+    }));
+
+    const { rowNames, rowValues } = setup({
+      showTotal: true,
+      headerRows: [],
+      bodyRows,
+    });
+
+    expect(rowNames).toStrictEqual([
+      "body row 0",
+      "body row 1",
+      "body row 2",
+      "body row 3",
+      "body row 4",
+      "body row 5",
+      "body row 6",
+      "Other",
+      "Total",
+    ]);
+
+    expect(rowValues).toStrictEqual([
+      "0",
+      "100",
+      "200",
+      "300",
+      "400",
+      "500",
+      "600",
+      "2400",
+      "4500",
+    ]);
   });
 });

--- a/frontend/src/metabase/visualizations/components/ChartTooltip/StackedDataTooltip/utils.ts
+++ b/frontend/src/metabase/visualizations/components/ChartTooltip/StackedDataTooltip/utils.ts
@@ -1,3 +1,4 @@
+import { t } from "ttag";
 import { TooltipRowModel } from "../types";
 
 export const getTotalValue = (
@@ -28,8 +29,8 @@ export const groupExcessiveTooltipRows = (
   }
 
   const groupStartingFromIndex = maxRows - 1;
-  const result = rows.slice();
-  const rowsToGroup = result.splice(groupStartingFromIndex);
+  const rowsToKeep = rows.slice(0, groupStartingFromIndex);
+  const rowsToGroup = rows.slice(groupStartingFromIndex);
 
   const groupedRow = rowsToGroup.reduce(
     (grouped, current) => {
@@ -43,11 +44,11 @@ export const groupExcessiveTooltipRows = (
     },
     {
       color: groupedColor,
-      name: `Other`,
+      name: t`Other`,
       value: 0,
       formatter: rowsToGroup[0].formatter,
     },
   );
 
-  return [...result, groupedRow];
+  return [...rowsToKeep, groupedRow];
 };

--- a/frontend/src/metabase/visualizations/components/ChartTooltip/StackedDataTooltip/utils.ts
+++ b/frontend/src/metabase/visualizations/components/ChartTooltip/StackedDataTooltip/utils.ts
@@ -17,3 +17,37 @@ export const getPercent = (total: number, value: unknown) => {
 
   return value / total;
 };
+
+export const groupExcessiveTooltipRows = (
+  rows: TooltipRowModel[],
+  maxRows: number,
+  groupedColor?: string,
+) => {
+  if (rows.length <= maxRows) {
+    return rows;
+  }
+
+  const groupStartingFromIndex = maxRows - 1;
+  const result = rows.slice();
+  const rowsToGroup = result.splice(groupStartingFromIndex);
+
+  const groupedRow = rowsToGroup.reduce(
+    (grouped, current) => {
+      if (
+        typeof current.value === "number" &&
+        typeof grouped.value === "number"
+      ) {
+        grouped.value += current.value;
+      }
+      return grouped;
+    },
+    {
+      color: groupedColor,
+      name: `Other`,
+      value: 0,
+      formatter: rowsToGroup[0].formatter,
+    },
+  );
+
+  return [...result, groupedRow];
+};

--- a/frontend/src/metabase/visualizations/components/ChartTooltip/utils.ts
+++ b/frontend/src/metabase/visualizations/components/ChartTooltip/utils.ts
@@ -34,7 +34,10 @@ export const groupExcessiveTooltipRows = (
 
   rowsToGroup.reduce(
     (grouped, current) => {
-      if (typeof current.value === "number") {
+      if (
+        typeof current.value === "number" &&
+        typeof grouped.value === "number"
+      ) {
         grouped.value += current.value;
       }
       return grouped;

--- a/frontend/src/metabase/visualizations/components/ChartTooltip/utils.ts
+++ b/frontend/src/metabase/visualizations/components/ChartTooltip/utils.ts
@@ -1,7 +1,6 @@
-import { color } from "metabase/lib/colors";
 import { formatValue } from "metabase/lib/formatting";
 import { RemappingHydratedDatasetColumn } from "metabase/visualizations/shared/types/data";
-import { TooltipRowModel, VisualizationSettings } from "./types";
+import { VisualizationSettings } from "./types";
 
 export const formatValueForTooltip = ({
   value,
@@ -19,34 +18,3 @@ export const formatValueForTooltip = ({
     type: "tooltip",
     majorWidth: 0,
   });
-
-export const groupExcessiveTooltipRows = (
-  rows: TooltipRowModel[],
-  maxRows: number,
-) => {
-  if (rows.length <= maxRows) {
-    return rows;
-  }
-
-  const groupStartingFromIndex = maxRows - 1;
-  const result = rows.slice();
-  const rowsToGroup = result.splice(groupStartingFromIndex);
-
-  rowsToGroup.reduce(
-    (grouped, current) => {
-      if (
-        typeof current.value === "number" &&
-        typeof grouped.value === "number"
-      ) {
-        grouped.value += current.value;
-      }
-      return grouped;
-    },
-    {
-      color: color("text-light"),
-      name: `Other`,
-      value: 0,
-      formatter: rowsToGroup[0].formatter,
-    },
-  );
-};

--- a/frontend/src/metabase/visualizations/components/ChartTooltip/utils.ts
+++ b/frontend/src/metabase/visualizations/components/ChartTooltip/utils.ts
@@ -1,6 +1,7 @@
+import { color } from "metabase/lib/colors";
 import { formatValue } from "metabase/lib/formatting";
 import { RemappingHydratedDatasetColumn } from "metabase/visualizations/shared/types/data";
-import { VisualizationSettings } from "./types";
+import { TooltipRowModel, VisualizationSettings } from "./types";
 
 export const formatValueForTooltip = ({
   value,
@@ -18,3 +19,31 @@ export const formatValueForTooltip = ({
     type: "tooltip",
     majorWidth: 0,
   });
+
+export const groupExcessiveTooltipRows = (
+  rows: TooltipRowModel[],
+  maxRows: number,
+) => {
+  if (rows.length <= maxRows) {
+    return rows;
+  }
+
+  const groupStartingFromIndex = maxRows - 1;
+  const result = rows.slice();
+  const rowsToGroup = result.splice(groupStartingFromIndex);
+
+  rowsToGroup.reduce(
+    (grouped, current) => {
+      if (typeof current.value === "number") {
+        grouped.value += current.value;
+      }
+      return grouped;
+    },
+    {
+      color: color("text-light"),
+      name: `Other`,
+      value: 0,
+      formatter: rowsToGroup[0].formatter,
+    },
+  );
+};

--- a/frontend/src/metabase/visualizations/lib/tooltip.ts
+++ b/frontend/src/metabase/visualizations/lib/tooltip.ts
@@ -1,5 +1,6 @@
 import { DatasetColumn, VisualizationSettings } from "metabase-types/api";
 import { formatValue } from "metabase/lib/formatting";
+import { formatNullable } from "metabase/lib/formatting/nullable";
 
 function getElementIndex(e: HTMLElement | null) {
   return (
@@ -47,7 +48,8 @@ export const formatValueForTooltip = ({
   column?: DatasetColumn;
   settings?: VisualizationSettings;
 }) => {
-  return formatValue(value, {
+  const nullableValue = formatNullable(value);
+  return formatValue(nullableValue, {
     ...(settings && settings.column && column
       ? settings.column(column)
       : { column }),


### PR DESCRIPTION
## Changes

Group rows of the new tooltip to have 8 body rows at maximum to avoid huge tooltips that go out of the screen.

<img width="1259" alt="Screen Shot 2023-01-19 at 8 10 35 PM" src="https://user-images.githubusercontent.com/14301985/213582841-c91ad172-da5b-42c7-b56b-90d6b7878cc5.png">

## How to verify

- Create a pie chart: Orders -> Count grouped by Total (50 bins) 
- Hover pie chart slices and ensure the tooltip shows grouped rows