### PR TITLE
Repro #27768: CC dashboard filter appears disconnected

### DIFF
--- a/frontend/test/metabase/scenarios/dashboard-filters/reproductions/27768-cc-filter-appears-disconnected.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters/reproductions/27768-cc-filter-appears-disconnected.cy.spec.js
@@ -1,0 +1,73 @@
+import {
+  restore,
+  popover,
+  visitDashboard,
+  editDashboard,
+  saveDashboard,
+  filterWidget,
+} from "__support__/e2e/helpers";
+import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
+
+const { PRODUCTS_ID, PRODUCTS } = SAMPLE_DATABASE;
+
+const questionDetails = {
+  name: "27768",
+  query: {
+    "source-table": PRODUCTS_ID,
+    limit: 5,
+    expressions: { CCategory: ["field", PRODUCTS.CATEGORY, null] },
+  },
+};
+
+const filter = {
+  name: "Cat",
+  slug: "cat",
+  id: "b3b436dd",
+  type: "string/=",
+  sectionId: "string",
+};
+
+describe.skip("issue 27768", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+
+    cy.createQuestionAndDashboard({ questionDetails }).then(
+      ({ body: { dashboard_id } }) => {
+        cy.request("PUT", `/api/dashboard/${dashboard_id}`, {
+          parameters: [filter],
+        });
+
+        visitDashboard(dashboard_id, { queryParams: { cat: "Gizmo" } });
+      },
+    );
+  });
+
+  it("filter connected to custom column should visually indicate it is connected (metabase#27768)", () => {
+    // We need to manually connect the filter to the custom column using the UI,
+    // but when we fix the issue, it should be safe to do this via API
+    editDashboard();
+    getFilterOptions(filter.name);
+
+    cy.findByText("Select…").click();
+    popover().contains("CCategory").click();
+    saveDashboard();
+
+    filterWidget().click();
+    cy.findByPlaceholderText("Enter some text").type("Gizmo").blur();
+    cy.button("Add filter").click();
+
+    cy.findAllByText("Doohickey").should("not.exist");
+
+    // Make sure the filter is still connected to the custom column
+    editDashboard();
+    getFilterOptions(filter.name);
+
+    cy.findByText("Select…").should("not.exist");
+    cy.findByText("Column to filter on").parent().contains("Product.CCategory");
+  });
+});
+
+function getFilterOptions(filterName) {
+  cy.findByText(filterName).find(".Icon-gear").click();
+}


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #27768 

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/dashboard-filters/reproductions/27768-cc-filter-appears-disconnected.cy.spec.js`
- Unskip repro
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/213683020-7d3b09ed-08d2-4008-b18b-59ce381c5170.png)

