### PR TITLE
Add endpoint for executing a public action

### DIFF
--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -13974,6 +13974,17 @@ databaseChangeLog:
                 name: public_uuid
 
   - changeSet:
+      id: v46.00-057
+      author: dpsutton
+      comment: Added 0.46.0 -- parameter_card.parameter_id long enough to hold a uuid
+      changes:
+        - modifyDataType:
+            tableName: parameter_card
+            columnName: parameter_id
+            newDataType: varchar(36)
+      rollback: #nothing to do, char(32) or char(36) are equivalent
+
+  - changeSet:
       id: v46.00-058
       author: calherries
       comment: Added 0.46.0 -- add FK constraint for action.made_public_by_id with core_user.id
@@ -13985,17 +13996,6 @@ databaseChangeLog:
             referencedColumnNames: id
             constraintName: fk_action_made_public_by_id
             onDelete: CASCADE
-
-  - changeSet:
-      id: v46.00-057
-      author: dpsutton
-      comment: Added 0.46.0 -- parameter_card.parameter_id long enough to hold a uuid
-      changes:
-        - modifyDataType:
-            tableName: parameter_card
-            columnName: parameter_id
-            newDataType: varchar(36)
-      rollback: #nothing to do, char(32) or char(36) are equivalent
 
 
 # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<

--- a/src/metabase/actions/execution.clj
+++ b/src/metabase/actions/execution.clj
@@ -72,8 +72,6 @@
                          :type qp.error-type/invalid-parameter
                          :parameters request-parameters
                          :destination-parameters (:parameters action)}))))
-    (when-not (contains? #{:query :http} action-type)
-      (throw (ex-info (tru "Unknown action type {0}." (name action-type)) action)))
     (try
       (case action-type
         :query
@@ -162,9 +160,12 @@
 (defn execute-action!
   "Execute the given action with the given parameters of shape `{<parameter-id> <value>}."
   [action request-parameters]
-  (if (= :implicit (:type action))
+  (case (:type action)
+    :implicit
     (execute-implicit-action action request-parameters)
-    (execute-custom-action action request-parameters)))
+    (:query :http)
+    (execute-custom-action action request-parameters)
+    (throw (ex-info (tru "Unknown action type {0}." (name (:type action))) action))))
 
 (defn execute-dashcard!
   "Execute the given action in the dashboard/dashcard context with the given parameters

--- a/src/metabase/actions/execution.clj
+++ b/src/metabase/actions/execution.clj
@@ -159,6 +159,13 @@
       (catch Exception e
         (handle-action-execution-error e)))))
 
+(defn execute-action!
+  "Execute the given action with the given parameters of shape `{<parameter-id> <value>}."
+  [action request-parameters]
+  (if (= :implicit (:type action))
+    (execute-implicit-action action request-parameters)
+    (execute-custom-action action request-parameters)))
+
 (defn execute-dashcard!
   "Execute the given action in the dashboard/dashcard context with the given parameters
    of shape `{<parameter-id> <value>}."
@@ -168,9 +175,7 @@
                                                :id dashcard-id
                                                :dashboard_id dashboard-id))
         action (api/check-404 (first (action/actions-with-implicit-params nil :id (:action_id dashcard))))]
-    (if (= :implicit (:type action))
-      (execute-implicit-action action request-parameters)
-      (execute-custom-action action request-parameters))))
+    (execute-action! action request-parameters)))
 
 (defn- fetch-implicit-action-values
   [dashboard-id action request-parameters]

--- a/src/metabase/api/public.clj
+++ b/src/metabase/api/public.clj
@@ -531,9 +531,10 @@
      :parameters    parameters :qp-runner qp.pivot/run-pivot-query)))
 
 (def ^:private action-execution-throttle
-  "Rate limit 1 action per second on a per action basis. The goal of rate limiting should be to prevent
-   very obvioius abuse, but it should be relatively lax so we don't annoy legitimate users."
-  (throttle/make-throttler :action-uuid :attempts-threshold 1000))
+  "Rate limit at 1 action per second on a per action basis.
+   The goal of rate limiting should be to prevent very obvioius abuse, but it should
+   be relatively lax so we don't annoy legitimate users."
+  (throttle/make-throttler :action-uuid :attempts-threshold 1 :initial-delay-ms 1000 :delay-exponent 1))
 
 #_{:clj-kondo/ignore [:deprecated-var]}
 (api/defendpoint-schema POST "/action/:uuid/execute"

--- a/src/metabase/api/public.clj
+++ b/src/metabase/api/public.clj
@@ -5,7 +5,6 @@
    [clojure.core.async :as a]
    [compojure.core :refer [GET]]
    [medley.core :as m]
-   [metabase.actions :as actions]
    [metabase.actions.execution :as actions.execution]
    [metabase.api.card :as api.card]
    [metabase.api.common :as api]

--- a/src/metabase/api/public.clj
+++ b/src/metabase/api/public.clj
@@ -557,7 +557,7 @@
                :body   throttle-message}
         throttle-time (assoc :headers {"Retry-After" throttle-time}))
       (do
-        (actions/check-actions-enabled)
+        ;; TODO: check-actions-enabled for the database
         (validation/check-public-sharing-enabled)
         ;; Run this query with full superuser perms. We don't want the various perms checks
         ;; failing because there are no current user perms; if this Dashcard is public

--- a/test/metabase/api/action_test.clj
+++ b/test/metabase/api/action_test.clj
@@ -227,10 +227,10 @@
 (deftest share-action-test
   (testing "POST /api/action/:id/public_link"
     (mt/with-temporary-setting-values [enable-public-sharing true]
-      (actions.test-util/with-actions-enabled
+      (mt/with-actions-enabled
         (mt/with-non-admin-groups-no-root-collection-perms
           (testing "We can share an action"
-            (actions.test-util/with-actions [{:keys [action-id]} unshared-action-opts]
+            (mt/with-actions [{:keys [action-id]} unshared-action-opts]
               (let [uuid (:uuid (mt/user-http-request :crowberto :post 200
                                                       (format "action/%d/public_link" action-id)))]
                 (is (db/exists? Action :id action-id, :public_uuid uuid))
@@ -239,7 +239,7 @@
                          (:uuid (mt/user-http-request :crowberto :post 200
                                                       (format "action/%d/public_link" action-id)))))))))
 
-          (actions.test-util/with-actions [{:keys [action-id]} {}]
+          (mt/with-actions [{:keys [action-id]} {}]
             (testing "We *cannot* share a Action if the setting is disabled"
               (mt/with-temporary-setting-values [enable-public-sharing false]
                 (is (= "Public sharing is not enabled."
@@ -250,29 +250,29 @@
                      (mt/user-http-request :crowberto :post 404 (format "action/%d/public_link" Integer/MAX_VALUE)))))))
 
         (testing "We *cannot* share an action if we aren't admins"
-          (actions.test-util/with-actions [{:keys [action-id]} unshared-action-opts]
+          (mt/with-actions [{:keys [action-id]} unshared-action-opts]
             (is (= "You don't have permissions to do that."
                    (mt/user-http-request :rasta :post 403 (format "action/%d/public_link" action-id))))))))))
 
 (deftest disable-sharing-action-test
   (testing "DELETE /api/action/:id/public_link"
     (mt/with-temporary-setting-values [enable-public-sharing true]
-      (actions.test-util/with-actions-enabled
+      (mt/with-actions-enabled
         (testing "Test that we can unshare an action"
           (let [action-opts (shared-action-opts)]
-            (actions.test-util/with-actions [{:keys [action-id]} action-opts]
+            (mt/with-actions [{:keys [action-id]} action-opts]
               (mt/user-http-request :crowberto :delete 204 (format "action/%d/public_link" action-id))
               (is (= false
                      (db/exists? Action :id action-id, :public_uuid (:public_uuid action-opts)))))))
 
         (testing "Test that we *cannot* unshare a action if we are not admins"
           (let [action-opts (shared-action-opts)]
-            (actions.test-util/with-actions [{:keys [action-id]} action-opts]
+            (mt/with-actions [{:keys [action-id]} action-opts]
               (is (= "You don't have permissions to do that."
                      (mt/user-http-request :rasta :delete 403 (format "action/%d/public_link" action-id)))))))
 
         (testing "Test that we get a 404 if Action isn't shared"
-          (actions.test-util/with-actions [{:keys [action-id]} unshared-action-opts]
+          (mt/with-actions [{:keys [action-id]} unshared-action-opts]
             (is (= "Not found."
                    (mt/user-http-request :crowberto :delete 404 (format "action/%d/public_link" action-id))))))
 

--- a/test/metabase/api/public_test.clj
+++ b/test/metabase/api/public_test.clj
@@ -1285,7 +1285,22 @@
   (mt/with-actions-test-data-and-actions-enabled
     (mt/with-temporary-setting-values [enable-public-sharing true]
       (let [{:keys [public_uuid] :as action-opts} (shared-obj)]
-        ;; Lift the throttle threshold to 1000 so we don't have to wait 1 second between requests
+        ;; Set the throttle delay high enough the throttle will definitely trigger
+        (with-redefs [api.public/action-execution-throttle (throttle/make-throttler :action-uuid :attempts-threshold 1 :initial-delay-ms 20000)]
+          (testing "Happy path - we can execute a public action"
+            (is (=? {:rows-affected 1}
+                    (client/client
+                     :post 200
+                     (format "public/action/%s/execute" public_uuid)
+                     {:parameters {:id 1 :name "European"}}))))
+          (testing "Test throttle"
+            (let [throttled-response (client/client-full-response
+                                      :post 429
+                                      (format "public/action/%s/execute" public_uuid)
+                                      {:parameters {:id 1 :name "European"}})]
+              (is (str/starts-with? (:body throttled-response) "Too many attempts!"))
+              (is (contains? (:headers throttled-response) "Retry-After")))))
+        ;; Lift the throttle attempts threshold so we don't have to wait between requests
         (with-redefs [api.public/action-execution-throttle (throttle/make-throttler :action-uuid :attempts-threshold 1000)]
           (mt/with-actions [{} action-opts]
             (testing "Check that we get a 400 if the action doesn't exist"
@@ -1310,17 +1325,4 @@
                           (format "public/action/%s/execute" public_uuid)
                           {:parameters {:id 1 :name "European"}})))))
             ;; Now decrease the throttle threshold to 1 so we can test the throttle
-            (with-redefs [api.public/action-execution-throttle (throttle/make-throttler :action-uuid :attempts-threshold 1)]
-              (testing "Happy path - we can execute a public action"
-                (is (=? {:rows-affected 1}
-                        (client/client
-                         :post 200
-                         (format "public/action/%s/execute" public_uuid)
-                         {:parameters {:id 1 :name "European"}}))))
-              (testing "Test throttle"
-                (let [throttled-response (client/client-full-response
-                                          :post 429
-                                          (format "public/action/%s/execute" public_uuid)
-                                          {:parameters {:id 1 :name "European"}})]
-                  (is (str/starts-with? (:body throttled-response) "Too many attempts!"))
-                  (is (contains? (:headers throttled-response) "Retry-After")))))))))))
+            ))))))

--- a/test/metabase/api/public_test.clj
+++ b/test/metabase/api/public_test.clj
@@ -1285,16 +1285,39 @@
   (mt/with-actions-test-data-and-actions-enabled
     (mt/with-temporary-setting-values [enable-public-sharing true]
       (let [{:keys [public_uuid] :as action-opts} (shared-obj)]
-        (mt/with-actions [{:keys [action-id model-id]} action-opts]
+        (mt/with-actions [{} action-opts]
+          (testing "Check that we get a 400 if the action doesn't exist"
+            (is (= "An error occurred."
+                   (client/client
+                    :post 400
+                    (format "public/action/%s/execute" (str (UUID/randomUUID)))
+                    {:parameters {:id 1 :name "European"}}))))
+          (testing "Check that we get a 400 if sharing is disabled."
+            (mt/with-temporary-setting-values [enable-public-sharing false]
+              (is (= "An error occurred."
+                     (client/client
+                      :post 400
+                      (format "public/action/%s/execute" public_uuid)
+                      {:parameters {:id 1 :name "European"}})))))
+          ;; TODO: this needs to pass when this PR is merged https://github.com/metabase/metabase/pull/27716
+          #_(testing "Check that we get a 400 if actions are disabled for the database."
+            (mt/with-temp-vals-in-db Database (mt/id) {:settings {:database-enable-actions false}}
+              (is (= "An error occurred."
+                     (client/client
+                      :post 400
+                      (format "public/action/%s/execute" public_uuid)
+                      {:parameters {:id 1 :name "European"}})))))
           (with-redefs [api.public/action-execution-throttle (throttle/make-throttler :action-uuid :attempts-threshold 1)]
-            (is (partial= {:rows-affected 1}
-                          (client/client
-                           :post 200
-                           (format "public/action/%s/execute" public_uuid)
-                           {:parameters {:id 1 :name "European"}})))
-            (let [throttled-response (client/client-full-response
-                                      :post 429
-                                      (format "public/action/%s/execute" public_uuid)
-                                      {:parameters {:id 1 :name "European"}})]
-              (is (str/starts-with? (:body throttled-response) "Too many attempts!"))
-              (is (contains? (:headers throttled-response) "Retry-After")))))))))
+            (testing "Happy path - we can execute a public action"
+              (is (=? {:rows-affected 1}
+                      (client/client
+                       :post 200
+                       (format "public/action/%s/execute" public_uuid)
+                       {:parameters {:id 1 :name "European"}}))))
+            (testing "Test throttle"
+              (let [throttled-response (client/client-full-response
+                                        :post 429
+                                        (format "public/action/%s/execute" public_uuid)
+                                        {:parameters {:id 1 :name "European"}})]
+                (is (str/starts-with? (:body throttled-response) "Too many attempts!"))
+                (is (contains? (:headers throttled-response) "Retry-After"))))))))))


### PR DESCRIPTION
Solves #27717 

This PR creates an endpoint `POST: /api/public/action/:action-uuid/execute` for executing a public action. 

The endpoint is rate limited per action, as [outlined in the product doc](https://www.notion.so/metabase/Allow-actions-to-be-shared-via-public-link-7970b901caa2476586c1454762195c55#ec95c866fb7a448bae3fc5a83d78843f). If there is more than one request to `POST: /api/public/action/:action-uuid/execute` within a second, only the first request will succeed.