### PR TITLE
Fix native query editor mock in `ActionCreator` tests

### DIFF
--- a/frontend/src/metabase/actions/containers/ActionCreator/ActionCreator.unit.spec.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/ActionCreator.unit.spec.tsx
@@ -19,11 +19,6 @@ import type Table from "metabase-lib/metadata/Table";
 
 import ActionCreator from "./ActionCreator";
 
-// eslint-disable-next-line react/display-name
-jest.mock("metabase/query_builder/components/NativeQueryEditor", () => () => (
-  <span data-testid="native-query-editor">Mock Native Query Editor</span>
-));
-
 function getDatabaseObject(database: Database) {
   return {
     ...database.getPlainObject(),
@@ -79,7 +74,9 @@ describe("ActionCreator", () => {
 
       expect(screen.getByText(/New action/i)).toBeInTheDocument();
       expect(screen.getByText(SAMPLE_DATABASE.name)).toBeInTheDocument();
-      expect(screen.getByTestId("native-query-editor")).toBeInTheDocument();
+      expect(
+        screen.getByTestId("mock-native-query-editor"),
+      ).toBeInTheDocument();
       expect(screen.getByRole("button", { name: "Save" })).toBeInTheDocument();
       expect(
         screen.queryByRole("button", { name: "Update" }),
@@ -103,7 +100,9 @@ describe("ActionCreator", () => {
       expect(screen.getByText(action.name)).toBeInTheDocument();
       expect(screen.queryByText(/New action/i)).not.toBeInTheDocument();
       expect(screen.getByText(SAMPLE_DATABASE.name)).toBeInTheDocument();
-      expect(screen.getByTestId("native-query-editor")).toBeInTheDocument();
+      expect(
+        screen.getByTestId("mock-native-query-editor"),
+      ).toBeInTheDocument();
       expect(
         screen.getByRole("button", { name: "Update" }),
       ).toBeInTheDocument();

--- a/frontend/src/metabase/query_builder/components/__mocks__/NativeQueryEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/__mocks__/NativeQueryEditor.jsx
@@ -3,12 +3,15 @@ import React from "react";
 
 import SyncedParametersList from "metabase/parameters/components/SyncedParametersList/SyncedParametersList";
 
-const MockNativeQueryEditor = ({ location, query, setParameterValue }) => (
-  <SyncedParametersList
-    className="mt1"
-    parameters={query.question().parameters()}
-    setParameterValue={setParameterValue}
-    commitImmediately
-  />
+const MockNativeQueryEditor = ({ query, setParameterValue }) => (
+  <div data-testid="mock-native-query-editor">
+    <SyncedParametersList
+      className="mt1"
+      parameters={query.question().parameters()}
+      setParameterValue={setParameterValue}
+      commitImmediately
+    />
+  </div>
 );
+
 export default MockNativeQueryEditor;

--- a/frontend/test/register-visualizations.js
+++ b/frontend/test/register-visualizations.js
@@ -1,7 +1,13 @@
 import "metabase/plugins/builtin";
+
 // We need to mock this *before* registering the visualizations. Otherwise
 // `ChartWithLegend` with already load the real one.
 jest.mock("metabase/components/ExplicitSize");
+
+// We need to mock this *before* registering the visualizations.
+// Otherwise ActionViz loads the NativeQueryEditor (via ActionCreator)
+// and tests fail because ace is not properly mocked
+jest.mock("metabase/query_builder/components/NativeQueryEditor");
 
 import registerVisualizations from "metabase/visualizations/register";
 registerVisualizations();


### PR DESCRIPTION
Fixes the `NativeQueryEditor` mocked stopped working for `ActionCreator` tests in #27756

### Root Cause

The mock stopped working because the real `NativeQueryEditor` was now loaded before we tried to mock it. #27756 cherry-picks the `ActionViz` component, that imports `ActionCreator` [inside one of its subcomponents](https://github.com/metabase/metabase/blob/afdecb2de6f31c0229e4113f0dcb401987fb9bd3/frontend/src/metabase/actions/components/ActionViz/ActionOptions.tsx#L13). Every Metabase viz component has to be registered [here](https://github.com/metabase/metabase/blob/master/frontend/src/metabase/visualizations/register.js). The problem is that we register visualizations as a part of our Jest setup (take a look at the [Jest config](https://github.com/metabase/metabase/blob/2553505eb8775a8a90273b993fcdfbd194bd4bed/jest.unit.conf.json#L28), the script itself is [here](https://github.com/metabase/metabase/blob/master/frontend/test/register-visualizations.js)). So now our `ActionViz` was imported before any test mock has been applied. The real `NativeQueryEditor` component gets imported as well, and apparently, Jest doesn't let us mock it after that.

### Solution and Alternatives

Fixed by moving `NativeQueryEditor` mocking to `test/register-visualization`. That means every Jest test will use a mocked version of the editor. Doesn't seem like it'd bring any inconvenience — I doubt the editor can work correctly inside Jest at all.

**Alternatives**

1. Move out the `ActionCreator` import from `ActionViz` to somewhere else
2. Find a way to mock the `ace` window object (I've tried, but failed)
3. Maybe migrate the editor to `react-ace`