### PR TITLE
Fix "Powered by Metabase" badge partially invisible with transparent theme

### DIFF
--- a/frontend/src/metabase/public/components/EmbedFrame.jsx
+++ b/frontend/src/metabase/public/components/EmbedFrame.jsx
@@ -97,7 +97,7 @@ class EmbedFrame extends Component {
         {showFooter && (
           <div className="EmbedFrame-footer p1 md-p2 lg-p3 border-top flex-no-shrink flex align-center">
             {!MetabaseSettings.hideEmbedBranding() && (
-              <LogoBadge dark={theme} />
+              <LogoBadge dark={theme === "night"} />
             )}
             {actionButtons && (
               <div className="flex-align-right text-medium">


### PR DESCRIPTION
Fixes the "Powered by Metabase" badge shown at the bottom of public/embedded views is partially invisible when a theme is set to transparent. 

### To Verify

1. Sign in as admin
2. Go to `/admin/settings/public-sharing` and enable public sharing
3. Open a dashboard, click the sharing icon at the top right
4. Enable sharing and copy the public link
5. Try out to add `#theme=night` and `#theme=transparent` and ensure the "Powered by Metabase" badge looks good.

### Demo

**Before (with transparent theme)**

<img width="275" alt="213729804-0cd8998b-3217-40d0-9711-52239414ad66" src="https://user-images.githubusercontent.com/17258145/213731764-249d73aa-8054-4329-b245-415da83c08c5.png">

**After (with transparent theme)**

<img width="283" alt="CleanShot 2023-01-20 at 15 03 06@2x" src="https://user-images.githubusercontent.com/17258145/213731797-5ff1330d-a0a2-4081-874c-740c8072f6f3.png">
