### PR TITLE
Repro #25189: CC referencing a base column dropped in nested question

### DIFF
--- a/frontend/test/metabase/scenarios/custom-column/reproductions/25189-cc-column-reference-only.cy.spec.js
+++ b/frontend/test/metabase/scenarios/custom-column/reproductions/25189-cc-column-reference-only.cy.spec.js
@@ -1,0 +1,75 @@
+import { restore, filter, summarize } from "__support__/e2e/helpers";
+import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
+
+const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
+
+const ccTable = "Custom Created";
+const ccFunction = "Custom Total";
+
+const questionDetails = {
+  name: "25189",
+  query: {
+    "source-table": ORDERS_ID,
+    limit: 5,
+    expressions: {
+      [ccTable]: ["field", ORDERS.CREATED_AT, null],
+      [ccFunction]: [
+        "case",
+        [[[">", ["field", ORDERS.TOTAL, null], 100], "Yay"]],
+        {
+          default: "Nay",
+        },
+      ],
+    },
+  },
+};
+
+describe.skip("issue 25189", () => {
+  beforeEach(() => {
+    cy.intercept("POST", "/api/dataset").as("dataset");
+
+    restore();
+    cy.signInAsAdmin();
+
+    cy.createQuestion(questionDetails).then(
+      ({ body: { id: baseQuestionId } }) => {
+        cy.createQuestion(
+          {
+            name: "Nested 25189",
+            query: { "source-table": `card__${baseQuestionId}` },
+          },
+          { visitQuestion: true },
+        );
+      },
+    );
+  });
+
+  it("custom column referencing only a single column should not be dropped in a nested question (metabase#25189)", () => {
+    // 1. Column should not be dropped
+    cy.findAllByTestId("header-cell")
+      .should("contain", ccFunction)
+      .and("contain", ccTable);
+
+    // 2. We shouldn't see duplication in the bulk filter modal
+    filter();
+    cy.get(".Modal").within(() => {
+      // Implicit assertion - will fail if more than one element is found
+      cy.findByText(ccFunction);
+      cy.findByText(ccTable);
+
+      cy.findByText("Today").click();
+      cy.button("Apply Filters").click();
+    });
+
+    cy.wait("@dataset");
+    cy.findByText("No results!");
+
+    // 3. We shouldn't see duplication in the breakout fields
+    summarize();
+    cy.findByTestId("sidebar-content").within(() => {
+      // Another implicit assertion
+      cy.findByText(ccFunction);
+      cy.findByText(ccTable);
+    });
+  });
+});


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #25189

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/custom-column/reproductions/25189-cc-column-reference-only.cy.spec.js`
- Unskip repro
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/213748165-4bac249d-31c4-4797-b468-bf1e982d451b.png)

