### PR TITLE
Persist Pivot Table Column Widths

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTable.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTable.tsx
@@ -16,7 +16,6 @@ import { usePrevious } from "metabase/hooks/use-previous";
 import { getScrollBarSize } from "metabase/lib/dom";
 import { getSetting } from "metabase/selectors/settings";
 import { useOnMount } from "metabase/hooks/use-on-mount";
-import { PLUGIN_SELECTORS } from "metabase/plugins";
 
 import { sumArray } from "metabase/core/utils/arrays";
 

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTable.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTable.tsx
@@ -377,7 +377,9 @@ function PivotTable({
                       cellRenderer={({ index, style, key }) => (
                         <LeftHeaderCell
                           key={key}
-                          style={style}
+                          style={{
+                            ...style,
+                          }}
                           item={leftHeaderItems[index]}
                           rowIndex={rowIndex}
                           onUpdateVisualizationSettings={

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTable.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTable.tsx
@@ -218,7 +218,7 @@ function PivotTable({
           fontFamily: fontFamily,
         }),
         valueHeaderWidths: {},
-      }));
+      });
     }
   }, [pivoted, fontFamily, getColumnTitle, columnsChanged, setHeaderWidths]);
 

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTable.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTable.tsx
@@ -16,6 +16,7 @@ import { usePrevious } from "metabase/hooks/use-previous";
 import { getScrollBarSize } from "metabase/lib/dom";
 import { getSetting } from "metabase/selectors/settings";
 import { useOnMount } from "metabase/hooks/use-on-mount";
+import { PLUGIN_SELECTORS } from "metabase/plugins";
 
 import { sumArray } from "metabase/core/utils/arrays";
 

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTable.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTable.tsx
@@ -377,9 +377,7 @@ function PivotTable({
                       cellRenderer={({ index, style, key }) => (
                         <LeftHeaderCell
                           key={key}
-                          style={{
-                            ...style,
-                          }}
+                          style={style}
                           item={leftHeaderItems[index]}
                           rowIndex={rowIndex}
                           onUpdateVisualizationSettings={

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTable.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTable.unit.spec.tsx
@@ -77,6 +77,30 @@ const settings = {
 // 3 isn't a real column, it's a pivot-grouping
 const columnIndexes = [0, 1, 2, 4, 5];
 
+function setup(options?: any) {
+  render(<PivotTableWrapper {...options} />);
+}
+
+function PivotTableWrapper(props?: any) {
+  const [vizSettings, setVizSettings] = React.useState(
+    props.initialSettings ?? settings,
+  );
+  return (
+    <PivotTable
+      settings={vizSettings}
+      data={{ rows, cols }}
+      width={600}
+      onVisualizationClick={_.noop}
+      onUpdateVisualizationSettings={newSettings =>
+        setVizSettings({ ...vizSettings, ...newSettings })
+      }
+      isNightMode={false}
+      isDashboard={false}
+      {...props}
+    />
+  );
+}
+
 describe("Visualizations > PivotTable > PivotTable", () => {
   // we need to mock offsetHeight and offsetWidth to make react-virtualized work with react-dom
   // https://github.com/bvaughn/react-virtualized/issues/493#issuecomment-447014986
@@ -113,35 +137,13 @@ describe("Visualizations > PivotTable > PivotTable", () => {
     );
   });
 
-  it("should render pivot table wrapper", () => {
-    render(
-      <PivotTable
-        settings={settings}
-        data={{ rows, cols }}
-        width={600}
-        onVisualizationClick={_.noop}
-        onUpdateVisualizationSettings={_.noop}
-        isNightMode={false}
-        isDashboard={false}
-      />,
-    );
-    expect(screen.getByTestId("pivot-table")).toBeInTheDocument();
+  it("should render pivot table wrapper", async () => {
+    setup();
+    expect(await screen.findByTestId("pivot-table")).toBeInTheDocument();
   });
 
   it("should render column names", () => {
-    render(
-      <div style={{ height: 800 }}>
-        <PivotTable
-          settings={settings}
-          data={{ rows, cols }}
-          width={600}
-          onVisualizationClick={_.noop}
-          onUpdateVisualizationSettings={_.noop}
-          isNightMode={false}
-          isDashboard={false}
-        />
-      </div>,
-    );
+    setup();
 
     // all column names except 3, the pivot grouping, should be in the document
     columnIndexes.forEach(colIndex => {
@@ -150,19 +152,7 @@ describe("Visualizations > PivotTable > PivotTable", () => {
   });
 
   it("should render column values", () => {
-    render(
-      <div style={{ height: 800 }}>
-        <PivotTable
-          settings={settings}
-          data={{ rows, cols }}
-          width={900}
-          onVisualizationClick={_.noop}
-          onUpdateVisualizationSettings={_.noop}
-          isNightMode={false}
-          isDashboard={false}
-        />
-      </div>,
-    );
+    setup();
 
     rows.forEach(rowData => {
       columnIndexes.forEach(colIndex => {
@@ -182,19 +172,7 @@ describe("Visualizations > PivotTable > PivotTable", () => {
       },
     } as unknown as VisualizationSettings;
 
-    render(
-      <div style={{ height: 800 }}>
-        <PivotTable
-          settings={hiddenSettings}
-          data={{ rows, cols }}
-          width={900}
-          onVisualizationClick={_.noop}
-          onUpdateVisualizationSettings={_.noop}
-          isNightMode={false}
-          isDashboard={false}
-        />
-      </div>,
-    );
+    setup({ initialSettings: hiddenSettings });
 
     rows.forEach(rowData => {
       expect(screen.getByText(rowData[0].toString())).toBeInTheDocument();

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTable.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTable.unit.spec.tsx
@@ -197,7 +197,7 @@ describe("Visualizations > PivotTable > PivotTable", () => {
     );
 
     rows.forEach(rowData => {
-      expect(screen.getByText(rowData[0].toString())).toBeInTheDocument();
+      expect(screen.queryByText(rowData[0].toString())).toBeInTheDocument();
 
       [1, 2, 4, 5].forEach(colIndex => {
         expect(

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTable.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTable.unit.spec.tsx
@@ -197,7 +197,7 @@ describe("Visualizations > PivotTable > PivotTable", () => {
     );
 
     rows.forEach(rowData => {
-      expect(screen.queryByText(rowData[0].toString())).toBeInTheDocument();
+      expect(screen.getByText(rowData[0].toString())).toBeInTheDocument();
 
       [1, 2, 4, 5].forEach(colIndex => {
         expect(

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTableCell.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTableCell.tsx
@@ -28,6 +28,21 @@ interface CellProps {
   onResize?: (newWidth: number) => void;
 }
 
+interface CellProps {
+  value: React.ReactNode;
+  style?: React.CSSProperties;
+  icon?: React.ReactNode;
+  backgroundColor?: string;
+  isBody?: boolean;
+  isBold?: boolean;
+  isEmphasized?: boolean;
+  isNightMode?: boolean;
+  isBorderedHeader?: boolean;
+  isTransparent?: boolean;
+  hasTopBorder?: boolean;
+  onClick?: ((e: React.SyntheticEvent) => void) | undefined;
+}
+
 export function Cell({
   value,
   style,

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTableCell.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTableCell.tsx
@@ -41,6 +41,7 @@ interface CellProps {
   isTransparent?: boolean;
   hasTopBorder?: boolean;
   onClick?: ((e: React.SyntheticEvent) => void) | undefined;
+  onResize?: (newWidth: number) => void;
 }
 
 export function Cell({

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTableCell.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTableCell.tsx
@@ -98,7 +98,7 @@ export function Cell({
               onResize(x);
             }}
           >
-            <ResizeHandle />
+            <ResizeHandle data-testid="pivot-table-resize-handle" />
           </Draggable>
         )}
       </>

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/settings.ts
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/settings.ts
@@ -137,6 +137,7 @@ export const settings = {
     default: true,
     inline: true,
   },
+  "pivot_table.column_widths": {},
   [COLUMN_FORMATTING_SETTING]: {
     section: t`Conditional Formatting`,
     widget: ChartSettingsTableFormatting,

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/utils.ts
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/utils.ts
@@ -110,10 +110,10 @@ interface GetLeftHeaderWidthsProps {
 export function getLeftHeaderWidths({
   rowIndexes,
   getColumnTitle,
-  leftHeaderItems = [],
+  leftHeaderItems,
   fontFamily = "Lato",
 }: GetLeftHeaderWidthsProps) {
-  const cellValues = getColumnValues(leftHeaderItems);
+  const cellValues = getColumnValues(leftHeaderItems, rowIndexes);
 
   const widths = rowIndexes.map((rowIndex, depthIndex) => {
     const computedHeaderWidth = Math.ceil(
@@ -127,15 +127,14 @@ export function getLeftHeaderWidths({
     const computedCellWidth = Math.ceil(
       Math.max(
         // we need to use the depth index because the data is in depth order, not row index order
-        ...(cellValues[depthIndex]?.values?.map(
+        ...cellValues[depthIndex].values.map(
           value =>
             measureText(value, {
               weight: "normal",
               family: fontFamily,
               size: PIVOT_TABLE_FONT_SIZE,
-            }) +
-            (cellValues[rowIndex]?.hasSubtotal ? ROW_TOGGLE_ICON_WIDTH : 0),
-        ) ?? [0]),
+            }) + (cellValues[rowIndex].hasSubtotal ? ROW_TOGGLE_ICON_WIDTH : 0),
+        ),
       ),
     );
 
@@ -173,7 +172,7 @@ export function getColumnValues(leftHeaderItems: HeaderItem[]) {
         leftHeaderItem;
 
       // don't size based on subtotals or grand totals
-      if (!isSubtotal && !isGrandTotal) {
+      if (!isSubtotal && !isGrandTotal && value !== null) {
         if (!columnValues[depth]) {
           columnValues[depth] = {
             values: [value],

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/utils.ts
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/utils.ts
@@ -110,10 +110,10 @@ interface GetLeftHeaderWidthsProps {
 export function getLeftHeaderWidths({
   rowIndexes,
   getColumnTitle,
-  leftHeaderItems,
+  leftHeaderItems = [],
   fontFamily = "Lato",
 }: GetLeftHeaderWidthsProps) {
-  const cellValues = getColumnValues(leftHeaderItems, rowIndexes);
+  const cellValues = getColumnValues(leftHeaderItems);
 
   const widths = rowIndexes.map((rowIndex, depthIndex) => {
     const computedHeaderWidth = Math.ceil(
@@ -127,14 +127,15 @@ export function getLeftHeaderWidths({
     const computedCellWidth = Math.ceil(
       Math.max(
         // we need to use the depth index because the data is in depth order, not row index order
-        ...cellValues[depthIndex].values.map(
+        ...(cellValues[depthIndex]?.values?.map(
           value =>
             measureText(value, {
               weight: "normal",
               family: fontFamily,
               size: PIVOT_TABLE_FONT_SIZE,
-            }) + (cellValues[rowIndex].hasSubtotal ? ROW_TOGGLE_ICON_WIDTH : 0),
-        ),
+            }) +
+            (cellValues[rowIndex]?.hasSubtotal ? ROW_TOGGLE_ICON_WIDTH : 0),
+        ) ?? [0]),
       ),
     );
 
@@ -172,7 +173,7 @@ export function getColumnValues(leftHeaderItems: HeaderItem[]) {
         leftHeaderItem;
 
       // don't size based on subtotals or grand totals
-      if (!isSubtotal && !isGrandTotal && value !== null) {
+      if (!isSubtotal && !isGrandTotal) {
         if (!columnValues[depth]) {
           columnValues[depth] = {
             values: [value],

--- a/frontend/test/metabase/scenarios/visualizations/pivot_tables.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/pivot_tables.cy.spec.js
@@ -873,6 +873,56 @@ describe("scenarios > visualizations > pivot tables", () => {
       cy.get("[role=rowgroup] > div").eq(5).invoke("text").should("eq", value);
     }
   });
+
+  describe("column resizing", () => {
+    const getCellWidth = textEl =>
+      textEl.closest("[data-testid=pivot-table-cell]").width();
+
+    it("should persist column sizes in visualization settings", () => {
+      visitQuestionAdhoc({ dataset_query: testQuery, display: "pivot" });
+      const leftHeaderColHandle = cy
+        .findAllByTestId("pivot-table-resize-handle")
+        .first();
+      const totalHeaderColHandle = cy
+        .findAllByTestId("pivot-table-resize-handle")
+        .last();
+
+      dragColumnHeader(leftHeaderColHandle, -100);
+      dragColumnHeader(totalHeaderColHandle, 100);
+
+      cy.findByTestId("pivot-table").within(() => {
+        cy.findByText("User → Source").then($headerTextEl => {
+          expect(getCellWidth($headerTextEl)).equal(80); // min width is 80
+        });
+        cy.findByText("Row totals").then($headerTextEl => {
+          expect(getCellWidth($headerTextEl)).equal(200);
+        });
+      });
+
+      cy.findByTestId("qb-header-action-panel").within(() => {
+        cy.findByText("Save").click();
+      });
+
+      cy.get("#SaveQuestionModal").within(() => {
+        cy.findByText("Save").click();
+      });
+
+      cy.get("#QuestionSavedModal").within(() => {
+        cy.findByText("Not now").click();
+      });
+
+      cy.reload(); // reload to make sure the settings are persisted
+
+      cy.findByTestId("pivot-table").within(() => {
+        cy.findByText("User → Source").then($headerTextEl => {
+          expect(getCellWidth($headerTextEl)).equal(80);
+        });
+        cy.findByText("Row totals").then($headerTextEl => {
+          expect(getCellWidth($headerTextEl)).equal(200);
+        });
+      });
+    });
+  });
 });
 
 const testQuery = {
@@ -922,6 +972,18 @@ function assertOnPivotFields() {
   cy.findByText("3,520");
   cy.findByText("4,784");
   cy.findByText("18,760");
+}
+
+function dragColumnHeader(el, xDistance = 50) {
+  const HANDLE_WIDTH = xDistance > 0 ? 2 : -2;
+  el.then($el => {
+    const currentXPos = $el[0].getBoundingClientRect().x;
+    el.trigger("mousedown", { which: 1 })
+      .trigger("mousemove", {
+        clientX: currentXPos + (xDistance + HANDLE_WIDTH),
+      })
+      .trigger("mouseup");
+  });
 }
 
 // Rely on native drag events, rather than on the coordinates


### PR DESCRIPTION
resolves https://github.com/metabase/metabase/issues/27598

## Description

Adds a new `pivot_table.column_widths` visualization setting and uses it to persist column widths.

![persist resize](https://user-images.githubusercontent.com/30528226/213761518-f7f782c7-eded-425c-b67f-f5f3bc8ce17c.gif)


## Testing Steps
- open a gnarly pivot table with multiple aggregations
- resize some columns
- refresh the page, see that the settings persist via query serialization in the url
- save the query
- refresh the page again and see that the settings persist in the db

