### PR TITLE
Repro #24330: Admin gets all users' personal collections on home page

### DIFF
--- a/frontend/test/metabase/scenarios/collections/personal-collections.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/personal-collections.cy.spec.js
@@ -29,11 +29,11 @@ describe("personal collections", () => {
      * Thus, test might not work as expected by that point.
      *
      * For example:
-     *  1. FE might devide to not fetch the full collection tree on the home page or
+     *  1. FE might decide not to fetch the full collection tree on the home page or
      *  2. BE might alter this endpoint
      *
      * TODO:
-     *  - When the solution for this problem is ready, either adjust this test or completely remove it!
+     *  - When the solution for this problem is ready, either adjust the test or completely remove it!
      */
 
     it.skip("shouldn't get API response containing all other personal collections when visiting the home page (metabase#24330)", () => {

--- a/frontend/test/metabase/scenarios/collections/personal-collections.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/personal-collections.cy.spec.js
@@ -22,6 +22,20 @@ describe("personal collections", () => {
       cy.signInAsAdmin();
     });
 
+    /**
+     * This reproduction is here only as a placeholder until a proper backend tests is added.
+     *
+     * Not entirely sure how this issue will be resolved!
+     * Thus, test might not work as expected by that point.
+     *
+     * For example:
+     *  1. FE might devide to not fetch the full collection tree on the home page or
+     *  2. BE might alter this endpoint
+     *
+     * TODO:
+     *  - When the solution for this problem is ready, either adjust this test or completely remove it!
+     */
+
     it.skip("shouldn't get API response containing all other personal collections when visiting the home page (metabase#24330)", () => {
       cy.intercept("GET", "/api/collection/tree*").as("getCollections");
 

--- a/frontend/test/metabase/scenarios/collections/personal-collections.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/personal-collections.cy.spec.js
@@ -22,6 +22,22 @@ describe("personal collections", () => {
       cy.signInAsAdmin();
     });
 
+    it.skip("shouldn't get API response containing all other personal collections when visiting the home page (metabase#24330)", () => {
+      cy.intercept("GET", "/api/collection/tree*").as("getCollections");
+
+      cy.visit("/");
+
+      cy.wait("@getCollections").then(({ response: { body } }) => {
+        const personalCollections = body.filter(({ personal_owner_id }) => {
+          return personal_owner_id !== null;
+        });
+
+        // Admin can only see their own personal collection, so this list should return only that
+        // Loading all other users' personal collections can lead to performance issues!
+        expect(personalCollections).to.have.lengthOf(1);
+      });
+    });
+
     it("should be able to view their own as well as other users' personal collections (including other admins)", () => {
       // Turn normal user into another admin
       cy.request("PUT", "/api/user/2", {


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #24330 

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/collections/personal-collections.cy.spec.js`
- Replace `it.skip()` with `it.only()` to run the test in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/213770914-da7b4169-fc13-4cd7-a260-486e1c3ed361.png)

