### PR TITLE
Test that GET "/api/action?model-id=..." returns sharing info

### DIFF
--- a/test/metabase/api/action_test.clj
+++ b/test/metabase/api/action_test.clj
@@ -43,6 +43,8 @@
                                  :template {:method "GET"
                                             :url "https://example.com/{{x}}"}
                                  :parameters [{:id "x" :type "text"}]
+                                 :public_uuid (str (UUID/randomUUID))
+                                 :made_public_by_id 1
                                  :response_handle ".body"
                                  :error_handle ".status >= 400"}
                                 {:name "Query example"
@@ -227,10 +229,10 @@
 (deftest share-action-test
   (testing "POST /api/action/:id/public_link"
     (mt/with-temporary-setting-values [enable-public-sharing true]
-      (actions.test-util/with-actions-enabled
+      (mt/with-actions-enabled
         (mt/with-non-admin-groups-no-root-collection-perms
           (testing "We can share an action"
-            (actions.test-util/with-actions [{:keys [action-id]} unshared-action-opts]
+            (mt/with-actions [{:keys [action-id]} unshared-action-opts]
               (let [uuid (:uuid (mt/user-http-request :crowberto :post 200
                                                       (format "action/%d/public_link" action-id)))]
                 (is (db/exists? Action :id action-id, :public_uuid uuid))
@@ -239,7 +241,7 @@
                          (:uuid (mt/user-http-request :crowberto :post 200
                                                       (format "action/%d/public_link" action-id)))))))))
 
-          (actions.test-util/with-actions [{:keys [action-id]} {}]
+          (mt/with-actions [{:keys [action-id]} {}]
             (testing "We *cannot* share a Action if the setting is disabled"
               (mt/with-temporary-setting-values [enable-public-sharing false]
                 (is (= "Public sharing is not enabled."
@@ -250,29 +252,29 @@
                      (mt/user-http-request :crowberto :post 404 (format "action/%d/public_link" Integer/MAX_VALUE)))))))
 
         (testing "We *cannot* share an action if we aren't admins"
-          (actions.test-util/with-actions [{:keys [action-id]} unshared-action-opts]
+          (mt/with-actions [{:keys [action-id]} unshared-action-opts]
             (is (= "You don't have permissions to do that."
                    (mt/user-http-request :rasta :post 403 (format "action/%d/public_link" action-id))))))))))
 
 (deftest disable-sharing-action-test
   (testing "DELETE /api/action/:id/public_link"
     (mt/with-temporary-setting-values [enable-public-sharing true]
-      (actions.test-util/with-actions-enabled
+      (mt/with-actions-enabled
         (testing "Test that we can unshare an action"
           (let [action-opts (shared-action-opts)]
-            (actions.test-util/with-actions [{:keys [action-id]} action-opts]
+            (mt/with-actions [{:keys [action-id]} action-opts]
               (mt/user-http-request :crowberto :delete 204 (format "action/%d/public_link" action-id))
               (is (= false
                      (db/exists? Action :id action-id, :public_uuid (:public_uuid action-opts)))))))
 
         (testing "Test that we *cannot* unshare a action if we are not admins"
           (let [action-opts (shared-action-opts)]
-            (actions.test-util/with-actions [{:keys [action-id]} action-opts]
+            (mt/with-actions [{:keys [action-id]} action-opts]
               (is (= "You don't have permissions to do that."
                      (mt/user-http-request :rasta :delete 403 (format "action/%d/public_link" action-id)))))))
 
         (testing "Test that we get a 404 if Action isn't shared"
-          (actions.test-util/with-actions [{:keys [action-id]} unshared-action-opts]
+          (mt/with-actions [{:keys [action-id]} unshared-action-opts]
             (is (= "Not found."
                    (mt/user-http-request :crowberto :delete 404 (format "action/%d/public_link" action-id))))))
 


### PR DESCRIPTION
Resolves https://github.com/metabase/metabase/issues/27718

It already worked, I just needed to add test coverage.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/27802)
<!-- Reviewable:end -->
