### PR TITLE
Release workflow: handle the auto-adjustment of latest tag on Docker Hub

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,6 +100,8 @@ jobs:
           - 5000:5000
     steps:
     - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0  # IMPORTANT! to get all the tags
     - uses: actions/download-artifact@v3
       name: Retrieve previously downloaded Uberjar
       with:
@@ -148,6 +150,92 @@ jobs:
         echo "Pushing ${{ github.ref_name }} to ${{ env.DOCKERHUB_REPO }} ..."
         docker tag localhost:5000/local-metabase:${{ github.ref_name }} ${{ env.DOCKERHUB_REPO }}:${{ github.ref_name }}
         docker push ${{ env.DOCKERHUB_REPO }}:${{ github.ref_name }}
+        echo "Finished!"
+
+    - name: Check if the container image should be tagged as latest
+      uses: actions/github-script@v6
+      id: latest_version_check
+      with:
+        result-encoding: string
+        script: |
+          const currentTag = context.payload.ref.replace("refs/tags/", "");
+
+          const { execSync } = require("child_process");
+
+          const isNumber = s => s.match(/\d+/) && s.match(/\d+/).shift() == s;
+
+          const parseVersion = version => {
+            const parts = version.split(".");
+            const prefix = parts[0];
+            const isOSS = prefix === "v0";
+            const isEE = prefix === "v1";
+            const feature = parseInt(parts[1], 10);
+            const maintenance = parseInt(parts[2], 10);
+            const build = parseInt(parts[3], 10);
+            const prerelease = parts[2] ? !isNumber(parts[2]) : false;
+            return { prefix, feature, maintenance, build, isOSS, isEE, prerelease };
+          }
+
+          const byVersions = (tag1, tag2) => {
+            const v1 = parseVersion(tag1);
+            const v2 = parseVersion(tag2);
+            const order1 = v1.feature * 1e6 + v1.maintenance * 1e3 + (v1.build || 0);
+            const order2 = v2.feature * 1e6 + v2.maintenance * 1e3 + (v2.build || 0);
+            return order2 - order1;
+          }
+
+          const currentVersion = parseVersion(currentTag);
+          console.log("Current version for", currentTag, "is", currentVersion);
+          if (currentVersion.prerelease) {
+            console.log("This is a pre-release!");
+            console.log("There is no need to tag the container image as latest.");
+            return "not-latest";
+          }
+
+          console.log();
+          console.log("Enumerating all git tag...");
+          const allTags = execSync("git tag -l").toString("utf-8").split("\n");
+          console.log("Found total", allTags.length, "tags");
+
+          console.log();
+          console.log("Filtering for", currentVersion.isOSS ? "OSS" : "EE");
+          const relevantTags = allTags.filter(tag => {
+            const { prefix } = parseVersion(tag);
+            return prefix === currentVersion.prefix;
+          });
+          console.log("Found total", relevantTags.length, "filtered tags");
+          if (relevantTags.length < 10) {
+            console.error("Something is NOT RIGHT! Please check all git tags!!!");
+            return "not-latest";
+          }
+
+          console.log();
+          console.log("Sorting tags to find the highest version numbers...");
+          const sortedTags = relevantTags.sort(byVersions)
+          console.log("Showing 20 tags with the highest versions...");
+          const topTags = sortedTags.slice(0, 20);
+          topTags.map(tag => {
+            const marker = tag === currentTag ? "--->" : "    ";
+            console.log(marker, tag);
+          });
+
+          const latestTag = topTags[0];
+          const isLatest = latestTag === currentTag;
+          console.log();
+          if (isLatest) {
+            console.log("Thus, the container image for ", currentTag, "must be marked as latest.");
+          } else {
+            console.log("The latest container image stays as", latestTag);
+            console.log("There is no need to tag the", currentTag, "container image as latest.");
+          }
+          return isLatest ? "latest" : "not-latest";
+
+    - name: Tag the container image as latest
+      if: ${{ steps.latest_version_check.outputs.result == 'latest' }}
+      run: |
+        echo "Pushing ${{ env.DOCKERHUB_REPO }}:latest ..."
+        docker tag localhost:5000/local-metabase:${{ github.ref_name }} ${{ env.DOCKERHUB_REPO }}:latest
+        docker push ${{ env.DOCKERHUB_REPO }}:latest
         echo "Finished!"
 
   verify-docker-pull:


### PR DESCRIPTION
## Before this PR

The `latest` tag on Docker Hub, for both the OSS and EE, is **not** automatically adjusted by the release workflow to point to the version with the highest version number.

## After this PR

If the release workflow kicks in with the tag that resembles the highest version number, then there will be an additional step to ensure that `latest` points to that highest version number.

![image](https://user-images.githubusercontent.com/7288/213824219-13d1ebe2-d6db-448a-9c42-ba886e203aaf.png)

Behind the scene:

1. Enumerate all the tags via `git tags`
2. Filter based on the intended edition, OSS or EE
3. Sort the tags based on the feature number first and then the maintenance update (and build number, if exist).
Examples:
* `v0.45.0` is more recent than `v0.44.6`
* `v0.44.3` is more recent than `v0.44.1`
* `v0.41.3.2` is more recent than `v0.41.3`
4. Exclude pre-releases such as `0.44.0-RC3`
 
### Example 1a
Let's assume the release manager is preparing `v0.45.3`. Then the output of the workflow will look like this:

```
Current version for v0.45.3 is {
  prefix: 'v0',
  feature: 45,
  maintenance: 3,
  build: NaN,
  isOSS: true,
  isEE: false,
  prerelease: false
}

Enumerating all git tag...
Found total 370 tags

Filtering for OSS
Found total 265 filtered tags

Sorting tags to find the highest version numbers...
Showing 20 tags with the highest versions...
---> v0.45.3
     v0.45.2
     v0.45.1
     v0.45.0
     v0.45.0-RC1
     v0.45.0-RC2
     v0.45.0-RC3
     v0.44.6
     v0.44.5
     v0.44.4
     v0.44.3
     v0.44.2
     v0.44.1
     v0.44.0
     v0.44.0-RC1
     v0.44.0-RC2
     v0.44.0-RC3
     v0.43.7
     v0.43.6
     v0.43.5

Thus, the container image for  v0.45.3 must be marked as latest.

```

This is the expected behavior. Hitherto, only `v0.45.2` is available and hence `latest` on  Docker Hub's container image of `metabase/metabase` points to `v0.45.2`. However, once `v0.45.3` is available, the `latest` tag must be point to `v0.45.3` instead.

### Example 1b

This the EE variant of the previous example. Similar output, same behavior.
```
Current version for v1.45.3 is {
  prefix: 'v1',
  feature: 45,
  maintenance: 3,
  build: NaN,
  isOSS: false,
  isEE: true,
  prerelease: false
}

Enumerating all git tag...
Found total 370 tags

Filtering for EE
Found total 95 filtered tags

Sorting tags to find the highest version numbers...
Showing 20 tags with the highest versions...
---> v1.45.3
     v1.45.2
     v1.45.1
     v1.45.0
     v1.45.0-RC1
     v1.45.0-RC2
     v1.45.0-RC3
     v1.44.6
     v1.44.5
     v1.44.4
     v1.44.3
     v1.44.2
     v1.44.1
     v1.44.0
     v1.44.0-RC1
     v1.44.0-RC2
     v1.44.0-RC3
     v1.43.7
     v1.43.6
     v1.43.5

Thus, the container image for  v1.45.3 must be marked as latest.
```

### Example 2
Let's assume the release manager is preparing `v0.44.7`. Then the output of the workflow will look like this:

```
Current version for v0.44.7 is {
  prefix: 'v0',
  feature: 44,
  maintenance: 7,
  build: NaN,
  isOSS: true,
  isEE: false,
  prerelease: false
}

Enumerating all git tag...
Found total 370 tags

Filtering for OSS
Found total 265 filtered tags

Sorting tags to find the highest version numbers...
Showing 20 tags with the highest versions...
     v0.45.2
     v0.45.1
     v0.45.0
     v0.45.0-RC1
     v0.45.0-RC2
     v0.45.0-RC3
---> v0.44.7
     v0.44.6
     v0.44.5
     v0.44.4
     v0.44.3
     v0.44.2
     v0.44.1
     v0.44.0
     v0.44.0-RC1
     v0.44.0-RC2
     v0.44.0-RC3
     v0.43.7
     v0.43.6
     v0.43.5

The latest container image stays as v0.45.2
There is no need to tag the v0.44.7 container image as latest.
```

This is the correct behavior, since `latest` container image must continue from the `v0.45.x` series instead of going back to `v0.44.7`.

### Example 3
Let's assume the release manager is preparing `v0.50.0-rc3`. Then the output of the workflow will look like this:

```
Current version for v0.50.0-rc3 is {
  prefix: 'v0',
  feature: 50,
  maintenance: 0,
  build: NaN,
  isOSS: true,
  isEE: false,
  prerelease: true
}
This is a pre-release!
There is no need to tag the container image as latest.
```

Since this is a pre-release, as denoted by the `-rc3` suffix, no need to do anything else. The `latest` container image must **not** be modified.