### PR TITLE
Upgrade clj-kondo to version 2023.01.20

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -643,9 +643,6 @@
    metabase.test/with-temp-env-var-value                                        macros.metabase.test.util/with-temp-env-var-value
    metabase.test/with-temporary-raw-setting-values                              macros.metabase.test.util/with-temporary-raw-setting-values}}
 
- :config-in-call
- {metabase.util.honey-sql-2-extensions/with-database-type-info {:linters {:type-mismatch {:level :off}}}}
-
  :config-in-comment
  {:linters {:unresolved-symbol {:level :off}}}
 

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -52,7 +52,7 @@ jobs:
         docker run
         --volume $PWD:/work
         --rm
-        cljkondo/clj-kondo:2023.01.16
+        cljkondo/clj-kondo:2023.01.20
         clj-kondo
         --config /work/.clj-kondo/config.edn
         --config-dir /work/.clj-kondo


### PR DESCRIPTION
This version fixes a bug where Malli was generating types unknown to Kondo and Kondo was flagging an erroneous type mismatch. See the changelog for more details:

https://github.com/clj-kondo/clj-kondo/blob/master/CHANGELOG.md#20230120

What it means for us is we can get rid of the gross `:config-in-call` hack.