### PR TITLE
Extend router mocking and test public page theming

### DIFF
--- a/frontend/src/metabase/nav/containers/AppBar/AppBar.unit.spec.tsx
+++ b/frontend/src/metabase/nav/containers/AppBar/AppBar.unit.spec.tsx
@@ -147,7 +147,7 @@ function setup(embedOptions: Partial<EmbedOptions>) {
 
   renderWithProviders(<AppBar />, {
     withRouter: true,
-    router: {
+    initialRouterState: {
       currentLocation: "/question/1",
       currentRoute: "/question/:slug",
     },

--- a/frontend/src/metabase/nav/containers/AppBar/AppBar.unit.spec.tsx
+++ b/frontend/src/metabase/nav/containers/AppBar/AppBar.unit.spec.tsx
@@ -147,7 +147,10 @@ function setup(embedOptions: Partial<EmbedOptions>) {
 
   renderWithProviders(<AppBar />, {
     withRouter: true,
-    initialRouterPath: "/question/1",
+    router: {
+      currentLocation: "/question/1",
+      currentRoute: "/question/:slug",
+    },
     storeInitialState: {
       app: createMockAppState({ isNavbarOpen: false }),
       embed: createMockEmbedState({

--- a/frontend/src/metabase/nav/containers/AppBar/AppBar.unit.spec.tsx
+++ b/frontend/src/metabase/nav/containers/AppBar/AppBar.unit.spec.tsx
@@ -148,8 +148,8 @@ function setup(embedOptions: Partial<EmbedOptions>) {
   renderWithProviders(<AppBar />, {
     withRouter: true,
     initialRouterState: {
-      currentLocation: "/question/1",
-      currentRoute: "/question/:slug",
+      location: "/question/1",
+      route: "/question/:slug",
     },
     storeInitialState: {
       app: createMockAppState({ isNavbarOpen: false }),

--- a/frontend/src/metabase/public/components/EmbedFrame/EmbedFrame.tsx
+++ b/frontend/src/metabase/public/components/EmbedFrame/EmbedFrame.tsx
@@ -109,6 +109,7 @@ function EmbedFrame({
       className={cx("EmbedFrame", className, {
         [`Theme--${theme}`]: !!theme,
       })}
+      data-testid="embed-frame"
     >
       <ContentContainer hasScroll={hasInnerScroll}>
         {hasHeader && (

--- a/frontend/src/metabase/public/containers/PublicApp/PublicApp.unit.spec.tsx
+++ b/frontend/src/metabase/public/containers/PublicApp/PublicApp.unit.spec.tsx
@@ -16,11 +16,13 @@ type SetupOpts = {
   actionButtons?: JSX.Element[];
   error?: AppErrorDescriptor;
   hasEmbedBranding?: boolean;
+  hash?: string;
 };
 
 function setup({
   error,
   hasEmbedBranding = true,
+  hash = "",
   ...embedFrameProps
 }: SetupOpts = {}) {
   const app = createMockAppState({ errorPage: error });
@@ -32,7 +34,15 @@ function setup({
         <h1 data-testid="test-content">Test</h1>
       </EmbedFrame>
     </PublicApp>,
-    { mode: "public", storeInitialState: { app, settings }, withRouter: true },
+    {
+      mode: "public",
+      storeInitialState: { app, settings },
+      router: {
+        currentRoute: "/public/dashboard/:id",
+        currentLocation: `/public/dashboard/UUID${hash}`,
+      },
+      withRouter: true,
+    },
   );
 }
 
@@ -100,5 +110,26 @@ describe("PublicApp", () => {
     setup({ error: { status: 404 }, hasEmbedBranding: false });
     expect(screen.queryByText(/Powered by/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/Metabase/)).not.toBeInTheDocument();
+  });
+
+  describe("theming", () => {
+    it("renders correctly without a theme parameter", () => {
+      setup();
+
+      const embedFrame = screen.getByTestId("embed-frame");
+
+      // eslint-disable-next-line jest-dom/prefer-to-have-class
+      expect(embedFrame.className).not.toEqual(
+        expect.stringContaining("Theme--"),
+      );
+    });
+
+    test.each([
+      ["night", "Theme--night"],
+      ["transparent", "Theme--transparent"],
+    ])("correctly handles %s theme", (theme, expectedClass) => {
+      setup({ hash: `#theme=${theme}` });
+      expect(screen.getByTestId("embed-frame")).toHaveClass(expectedClass);
+    });
   });
 });

--- a/frontend/src/metabase/public/containers/PublicApp/PublicApp.unit.spec.tsx
+++ b/frontend/src/metabase/public/containers/PublicApp/PublicApp.unit.spec.tsx
@@ -37,7 +37,7 @@ function setup({
     {
       mode: "public",
       storeInitialState: { app, settings },
-      router: {
+      initialRouterState: {
         currentRoute: "/public/dashboard/:id",
         currentLocation: `/public/dashboard/UUID${hash}`,
       },

--- a/frontend/src/metabase/public/containers/PublicApp/PublicApp.unit.spec.tsx
+++ b/frontend/src/metabase/public/containers/PublicApp/PublicApp.unit.spec.tsx
@@ -38,8 +38,8 @@ function setup({
       mode: "public",
       storeInitialState: { app, settings },
       initialRouterState: {
-        currentRoute: "/public/dashboard/:id",
-        currentLocation: `/public/dashboard/UUID${hash}`,
+        route: "/public/dashboard/:id",
+        location: `/public/dashboard/UUID${hash}`,
       },
       withRouter: true,
     },

--- a/frontend/test/__support__/ui.tsx
+++ b/frontend/test/__support__/ui.tsx
@@ -20,11 +20,11 @@ import publicReducers from "metabase/reducers-public";
 
 import { getStore } from "./entities-store";
 
-type RouterOpts = { currentRoute: string; currentLocation: string };
+type RouterStateOpts = { currentRoute: string; currentLocation: string };
 
 export interface RenderWithProvidersOptions {
   mode?: "default" | "public";
-  router?: RouterOpts;
+  initialRouterState?: RouterStateOpts;
   storeInitialState?: Partial<State>;
   withSampleDatabase?: boolean;
   withRouter?: boolean;
@@ -41,7 +41,7 @@ export function renderWithProviders(
   {
     mode = "default",
     storeInitialState = {},
-    router,
+    initialRouterState,
     withSampleDatabase,
     withRouter = false,
     withDND = false,
@@ -66,7 +66,7 @@ export function renderWithProviders(
     <Wrapper
       {...props}
       store={store}
-      router={router}
+      initialRouterState={initialRouterState}
       withRouter={withRouter}
       withDND={withDND}
     />
@@ -86,13 +86,13 @@ export function renderWithProviders(
 function Wrapper({
   children,
   store,
-  router,
+  initialRouterState,
   withRouter,
   withDND,
 }: {
   children: React.ReactElement;
   store: any;
-  router?: RouterOpts;
+  initialRouterState?: RouterStateOpts;
   withRouter: boolean;
   withDND: boolean;
 }): JSX.Element {
@@ -100,7 +100,7 @@ function Wrapper({
     <Provider store={store}>
       <MaybeDNDProvider hasDND={withDND}>
         <ThemeProvider theme={{}}>
-          <MaybeRouter hasRouter={withRouter} router={router}>
+          <MaybeRouter hasRouter={withRouter} initialState={initialRouterState}>
             {children}
           </MaybeRouter>
         </ThemeProvider>
@@ -112,19 +112,19 @@ function Wrapper({
 function MaybeRouter({
   children,
   hasRouter,
-  router,
+  initialState,
 }: {
   children: React.ReactElement;
   hasRouter: boolean;
-  router?: RouterOpts;
+  initialState?: RouterStateOpts;
 }): JSX.Element {
   if (!hasRouter) {
     return children;
   }
-  const pathname = router?.currentLocation || "/";
-  const route = router?.currentRoute || "/";
+  const location = initialState?.currentLocation || "/";
+  const route = initialState?.currentRoute || "/";
 
-  const history = createMemoryHistory({ entries: [pathname] });
+  const history = createMemoryHistory({ entries: [location] });
 
   function Page(props: any) {
     return React.cloneElement(children, _.omit(props, "children"));

--- a/frontend/test/__support__/ui.tsx
+++ b/frontend/test/__support__/ui.tsx
@@ -20,7 +20,7 @@ import publicReducers from "metabase/reducers-public";
 
 import { getStore } from "./entities-store";
 
-type RouterStateOpts = { currentRoute: string; currentLocation: string };
+type RouterStateOpts = { route: string; location: string };
 
 export interface RenderWithProvidersOptions {
   mode?: "default" | "public";
@@ -121,8 +121,8 @@ function MaybeRouter({
   if (!hasRouter) {
     return children;
   }
-  const location = initialState?.currentLocation || "/";
-  const route = initialState?.currentRoute || "/";
+  const location = initialState?.location || "/";
+  const route = initialState?.route || "/";
 
   const history = createMemoryHistory({ entries: [location] });
 


### PR DESCRIPTION
Further improvement on top of #27796 and #27746

While cleaning up the `EmbedFrame` component in #27746, we discovered the "Powered by Metabase" badge was partially invisible when using the transparent theme. This was caused by an incorrect `isDark` prop being passed to the component; the fix was extracted into #27796 (so it can be backported).

We had a discussion about adding a test that'd guarantee this never happens again. I'm not sure there's anything better we can do apart from asserting the `isDark` prop directly which feels off. IMO, we should be safe after `EmbedFrame` is ported to TypeScript. This PR adds some additional theming coverage though (on top of other tests added in #27746). We're now going to test that the `EmbedFrame` child components have expected CSS classes implementing various theming options.

You'd notice updates to `renderWithProviders` testing utility. I've tried to re-use the existing `initialRouterPath` option but seems like `react-router` wants both the route (e.g. `/question/:slug`) and the location (e.g. `/question/1-orders`). This PR replaces `initialRouterPath` with a `router` object prop