### PR TITLE
Fix card parameter values endpoints

### DIFF
--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -934,7 +934,7 @@ saved later when it is ready."
 (defn template-tag-parameters
   "Transforms native query's `template-tags` into `parameters`."
   [card]
-  ;; NOTE: this should mirror `getTemplateTagParameters` in frontend/src/metabase/parameters/utils/cards.js
+  ;; NOTE: this should mirror `getTemplateTagParameters` in frontend/src/metabase-lib/parameters/utils/template-tags.ts
   (for [[_ {tag-type :type, widget-type :widget-type, :as tag}] (get-in card [:dataset_query :native :template-tags])
         :when                         (and tag-type
                                            (or widget-type (not= tag-type :dimension)))]
@@ -951,7 +951,8 @@ saved later when it is ready."
      :default (:default tag)}))
 
 (defn parameters
-  "Mirrors `getParametersFromCard` in frontend/src/metabase/parameters/utils/cards.js."
+  "Gets parameters from a card.
+   Should mirror `getParametersFromCard` in frontend/src/metabase-lib/parameters/utils/template-tags.ts"
   [card]
   (or (seq (:parameters card))
       (template-tag-parameters card)))

--- a/src/metabase/api/embed.clj
+++ b/src/metabase/api/embed.clj
@@ -155,29 +155,10 @@
                 card))
             ordered-cards))))
 
-(defn- template-tag-parameters
-  "Transforms native query's `template-tags` into `parameters`."
-  [card]
-  ;; NOTE: this should mirror `getTemplateTagParameters` in frontend/src/metabase/parameters/utils/cards.js
-  (for [[_ {tag-type :type, widget-type :widget-type, :as tag}] (get-in card [:dataset_query :native :template-tags])
-        :when                         (and tag-type
-                                           (or widget-type (not= tag-type :dimension)))]
-    {:id      (:id tag)
-     :type    (or widget-type (cond (= tag-type :date)   :date/single
-                                    (= tag-type :string) :string/=
-                                    (= tag-type :number) :number/=
-                                    :else                :category))
-     :target  (if (= tag-type :dimension)
-                [:dimension [:template-tag (:name tag)]]
-                [:variable  [:template-tag (:name tag)]])
-     :name    (:display-name tag)
-     :slug    (:name tag)
-     :default (:default tag)}))
-
 (defn- add-implicit-card-parameters
   "Add template tag parameter information to `card`'s `:parameters`."
   [card]
-  (update card :parameters concat (template-tag-parameters card)))
+  (update card :parameters concat (api.card/template-tag-parameters card)))
 
 (s/defn ^:private apply-slug->value :- (s/maybe [{:slug   su/NonBlankString
                                                   :type   s/Keyword
@@ -558,8 +539,8 @@
   values according to [[api.card/param-values]]."
   [{:keys [unsigned-token card param-key search-prefix]}]
   (let [slug-token-params   (embed/get-in-unsigned-token-or-throw unsigned-token [:params])
-        id->slug            (into {} (map (juxt :id :slug) (:parameters card)))
-        slug->id            (into {} (map (juxt :slug :id) (:parameters card)))
+        id->slug            (into {} (map (juxt :id :slug) (api.card/parameters card)))
+        slug->id            (into {} (map (juxt :slug :id) (api.card/parameters card)))
         searched-param-slug (get id->slug param-key)
         embedding-params    (:embedding_params card)]
     (try

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -2331,11 +2331,7 @@
                                                                     :dimension    [:field (mt/id :venues :name) nil]
                                                                     :required     true}}}}
                                 :name       "native card with field filter"
-                                :parameters [{:id     "name_param_id",
-                                              :type   :string/=,
-                                              :target [:dimension [:template-tag "NAME"]],
-                                              :name   "Name",
-                                              :slug   "NAME"}]}]
+                                :parameters []}]
       Card [card        (merge
                          {:database_id   (mt/id)
                           :dataset_query (mt/mbql-query venues)

--- a/test/metabase/api/embed_test.clj
+++ b/test/metabase/api/embed_test.clj
@@ -10,6 +10,7 @@
    [clojure.test :refer :all]
    [crypto.random :as crypto-random]
    [dk.ative.docjure.spreadsheet :as spreadsheet]
+   [metabase.api.card :as api.card]
    [metabase.api.card-test :as api.card-test]
    [metabase.api.dashboard-test :as api.dashboard-test]
    [metabase.api.embed :as api.embed]
@@ -658,11 +659,11 @@
         (api.card-test/with-card-param-values-fixtures [{:keys [card field-filter-card param-keys]}]
           (db/update! Card (:id field-filter-card)
                       {:enable_embedding true
-                       :embedding_params (zipmap (map :slug (:parameters field-filter-card))
+                       :embedding_params (zipmap (map :slug (api.card/parameters field-filter-card))
                                                  (repeat "enabled"))})
           (db/update! Card (:id card)
                       {:enable_embedding true
-                       :embedding_params (zipmap (map :slug (:parameters card))
+                       :embedding_params (zipmap (map :slug (api.card/parameters card))
                                                  (repeat "enabled"))})
           (testing "field filter based param"
             (let [response (dropdown field-filter-card (:field-values param-keys))]


### PR DESCRIPTION
This PR makes changes to two functions:
- `api.embed/card-param-values`: which is called by two endpoints:
  - `GET /card/:token/params/:param-key/search/:prefix`
  - `GET /card/:token/params/:param-key/values"`
- `api.embed/param-values`, which is called by two endpoints:
  - `GET /:card-id/params/:param-key/values`
  - `GET /:card-id/params/:param-key/search/:query`

In all cases, instead of getting the parameters from card.parameters, we mirror the logic on the frontend in `getCardParameters`.