### PR TITLE
Fix exclude filter not working with other date time units

### DIFF
--- a/frontend/src/metabase-lib/queries/utils/date-filters.ts
+++ b/frontend/src/metabase-lib/queries/utils/date-filters.ts
@@ -377,15 +377,15 @@ export function getInitialDayOfWeekFilter(filter: Filter) {
 }
 
 export function getInitialMonthOfYearFilter(filter: Filter) {
-  return ["!=", getDateTimeFieldRef(filter[1], "day-of-week")];
+  return ["!=", getDateTimeFieldRef(filter[1], "month-of-year")];
 }
 
 export function getInitialQuarterOfYearFilter(filter: Filter) {
-  return ["!=", getDateTimeFieldRef(filter[1], "day-of-week")];
+  return ["!=", getDateTimeFieldRef(filter[1], "quarter-of-year")];
 }
 
 export function getInitialHourOfDayFilter(filter: Filter) {
-  return ["!=", getDateTimeFieldRef(filter[1], "day-of-week")];
+  return ["!=", getDateTimeFieldRef(filter[1], "hour-of-day")];
 }
 
 export const isDayOfWeekDateFilter = testTemporalUnit("day-of-week");

--- a/frontend/test/metabase/scenarios/filters/reproductions/27123-exclude-always-shows-days-of-week.cy.spec.js
+++ b/frontend/test/metabase/scenarios/filters/reproductions/27123-exclude-always-shows-days-of-week.cy.spec.js
@@ -10,7 +10,7 @@ const questionDetails = {
   },
 };
 
-describe.skip("issue 27123", () => {
+describe("issue 27123", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/27123

How to test:
1. New question > Sample Database > Orders
2. Filter on "Created At" and choose "Exclude" filter
3. Choose "Months of the year..." (or "Quarters of the year..." or "Hours of the day...") and "Add filter"
4. The filter popover should show options based on your choice 

<img width="348" alt="Screenshot 2023-01-23 at 17 34 42" src="https://user-images.githubusercontent.com/8542534/214080783-81bea54d-eda1-4f48-9ff8-2b33c88e81b7.png">

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/27825)
<!-- Reviewable:end -->
