### PR TITLE
Backport #24523 to 43 release branch

### DIFF
--- a/test/metabase/api/geojson_test.clj
+++ b/test/metabase/api/geojson_test.clj
@@ -66,7 +66,8 @@
                     "https://example.com/"                     true
                     "http://example.com/rivendell.json"        true
                     "http://192.0.2.0"                         true
-                    "http://0xc0000200"                        true
+                    ;; this following test flakes in CI for unknown reasons
+                    ;;"http://0xc0000200"                        true
                     ;; Resources (files on classpath) are valid
                     "c3p0.properties"                          true
                     ;; Other files are not


### PR DESCRIPTION
A specific test case in our GeoJSON validation tests was flaky and was commented out by @dpsutton in https://github.com/metabase/metabase/pull/24523. That PR was never backported to the 43 release branch so it still fails there; this PR just performs that backport manually.

The TL;DR about the change itself is that it's a niche case of a hex-encoded IP address which should be valid in theory but causes an exception to be thrown in `InetAddress/getByName`. But it's not really a problem that this case fails since it would be very strange for someone to try to refer to a custom GeoJSON location via a hex-encoded IP address in the first place. (What's important is that disallowed IPs _are_ rejected even if they're hex-encoded, which we do have a test for)