### PR TITLE
Fix question and dashboard cache settings

### DIFF
--- a/frontend/test/metabase/scenarios/dashboard/caching.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/caching.cy.spec.js
@@ -1,7 +1,6 @@
 import {
   restore,
   describeEE,
-  mockSessionProperty,
   popover,
   visitDashboard,
   rightSidebar,
@@ -10,8 +9,8 @@ import {
 describeEE("scenarios > dashboard > caching", () => {
   beforeEach(() => {
     restore();
-    mockSessionProperty("enable-query-caching", true);
     cy.signInAsAdmin();
+    cy.request("PUT", "/api/setting/enable-query-caching", { value: true });
   });
 
   it("can set cache ttl for a saved question", () => {

--- a/frontend/test/metabase/scenarios/question/caching.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/caching.cy.spec.js
@@ -1,7 +1,6 @@
 import {
   restore,
   describeEE,
-  mockSessionProperty,
   visitQuestion,
   questionInfoButton,
   rightSidebar,
@@ -11,8 +10,8 @@ import {
 describeEE("scenarios > question > caching", () => {
   beforeEach(() => {
     restore();
-    mockSessionProperty("enable-query-caching", true);
     cy.signInAsAdmin();
+    cy.request("PUT", "/api/setting/enable-query-caching", { value: true });
   });
 
   it("can set cache ttl for a saved question", () => {

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -224,7 +224,8 @@
 (defsetting enable-query-caching
   (deferred-tru "Enabling caching will save the results of queries that take a long time to run.")
   :type    :boolean
-  :default false)
+  :default    :false
+  :visibility :authenticated)
 
 (defsetting persisted-models-enabled
   (deferred-tru "Allow persisting models into the source database.")

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -224,8 +224,7 @@
 (defsetting enable-query-caching
   (deferred-tru "Enabling caching will save the results of queries that take a long time to run.")
   :type    :boolean
-  :default false
-  :visibility :settings-manager)
+  :default false)
 
 (defsetting persisted-models-enabled
   (deferred-tru "Allow persisting models into the source database.")

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -223,8 +223,8 @@
 
 (defsetting enable-query-caching
   (deferred-tru "Enabling caching will save the results of queries that take a long time to run.")
-  :type    :boolean
-  :default    :false
+  :type       :boolean
+  :default    false
   :visibility :authenticated)
 
 (defsetting persisted-models-enabled


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/27806

Fixes caching settings disappear in master after recent settings changes. There was an issue with how the corresponding e2e tests were written and that's why we didn't catch the issue automatically.

How to test:
- Run Metabase EE
- Admin -> Settings -> Caching -> Enable
- Go to a saved question and click the info button
- There should be a section for caching settings
- Same for dashboards

<img width="309" alt="Screenshot 2023-01-24 at 13 29 16" src="https://user-images.githubusercontent.com/8542534/214280466-91feb2f0-304c-4c2f-9747-583ed5c0fde9.png">

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/27831)
<!-- Reviewable:end -->
