### PR TITLE
Fix failing bigquery test

### DIFF
--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
@@ -262,33 +262,33 @@
               ;; make sure all the fields for taxi_tips were synced
               (is (= 23 (db/count Field :table_id (u/the-id tbl))))))
           (testing " for querying"
-            (is (= ["67794e631648a002f88d4b7f3ab0bcb6a9ed306a"
-                    "1d7ade2f592e1c98f5d34e9e1ef452fae2c76a65e1002a04d1f5262bb47aeb2060332673825208955ed5e35dab5a07b7f69ec1745fe209d4b9ad60560a9e9896"
-                    "2014-01-12T00:45:00Z"
-                    "2014-01-12T00:45:00Z"
-                    0
-                    0.0
-                    17031062300
+            (is (= ["ff0b96c0cada768361b1c9341e11905254644afb"
+                    "c7fd753040e0170e38049465089bca99c750f5ed8b3f6c547b303057ec23be36b9b86790fe417bb5949d980892460a2732a28a515bb805cf967bf4cf4b44b074"
+                    "2016-09-20T07:15:00Z"
+                    "2016-09-20T07:30:00Z"
+                    1265
+                    7.2
                     nil
-                    6
                     nil
-                    0.07
+                    nil
+                    nil
+                    0.01
                     0.0
+                    nil
                     0.0
-                    0.0
-                    0.07
+                    0.01
                     "Cash"
-                    "Top Cab Affiliation"
-                    41.9416281
-                    -87.661443368
-                    "POINT (-87.6614433685 41.9416281)"
+                    "303 Taxi"
+                    nil
+                    nil
+                    nil
                     nil
                     nil
                     nil]
                    (mt/first-row
                      (mt/run-mbql-query taxi_trips
                        {:filter [:= [:field (mt/id :taxi_trips :unique_key) nil]
-                                    "67794e631648a002f88d4b7f3ab0bcb6a9ed306a"]})))))
+                                    "ff0b96c0cada768361b1c9341e11905254644afb"]})))))
           (testing " has project-id-from-credentials set correctly"
             (is (= (bigquery-project-id) (get-in temp-db [:details :project-id-from-credentials])))))))))
 


### PR DESCRIPTION
Bigquery was checking that we can set a project-id in the db details of a bigquery database. Normally this comes from the json token:

```
export MB_BIGQUERY_CLOUD_SDK_TEST_SERVICE_ACCOUNT_JSON='{
  "type": "service_account",
  "project_id": "metabase-bigquery-driver", // <- ordinarily source of truth
  "private_key_id": "keykeykeykeykeykeykeykey",
  "private_key": "-----BEGIN PRIVATE KEY----- ...."
```

The db details normally connects to project-id
"metabase-bigquery-driver" and this test swaps out to "bigquery-public-data" with a schema filter on chicago_taxi_trips.

to prove it works it selects from that dataset:

```clojure
(mt/first-row
  (mt/run-mbql-query taxi_trips
    {:filter [:= [:field (mt/id :taxi_trips :unique_key) nil]
                 "67794e631648a002f88d4b7f3ab0bcb6a9ed306a"]}))
```

The test fails because this row seems to no longer be in the results. The query isn't failing, it's just returning no rows (and presumably because the row with this id from 2014 is no longer in the dataset.)

I ran the same with with a limit 4, see it's working and grab one of those rows and use the id as in the filter clause.

old: "67794e631648a002f88d4b7f3ab0bcb6a9ed306a" ("2014-01-12T00:45:00Z")
new: "ff0b96c0cada768361b1c9341e11905254644afb" ("2016-09-20T07:15:00Z")
