### PR TITLE
Make Action Picker models list collapsible

### DIFF
--- a/frontend/src/metabase/actions/containers/ActionPicker/ActionPicker.styled.tsx
+++ b/frontend/src/metabase/actions/containers/ActionPicker/ActionPicker.styled.tsx
@@ -9,17 +9,10 @@ import Button from "metabase/core/components/Button";
 
 export const ModelActionList = styled.div`
   margin-bottom: ${space(2)};
-  &:not(:last-child) {
-    border-bottom: 1px solid ${color("border")};
-  }
 `;
 
 export const ModelTitle = styled.h4`
-  color: ${color("text-dark")};
   margin-bottom: ${space(2)};
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
 `;
 
 export const ActionItem = styled.li`
@@ -27,15 +20,6 @@ export const ActionItem = styled.li`
   justify-content: space-between;
   padding-left: ${space(3)};
   margin-bottom: ${space(2)};
-`;
-
-export const ActionName = styled.span`
-  color: ${color("brand")};
-  font-weight: bold;
-  cursor: pointer;
-  &:hover: {
-    color: ${lighten("brand", 0.1)};
-  }
 `;
 
 export const EmptyState = styled(UnstyledEmptyState)`

--- a/frontend/src/metabase/actions/containers/ActionPicker/ActionPicker.styled.tsx
+++ b/frontend/src/metabase/actions/containers/ActionPicker/ActionPicker.styled.tsx
@@ -1,25 +1,21 @@
 import _ from "underscore";
 import styled from "@emotion/styled";
 
-import { color, lighten } from "metabase/lib/colors";
+import { color } from "metabase/lib/colors";
 import { space } from "metabase/styled-components/theme";
 
 import UnstyledEmptyState from "metabase/components/EmptyState";
 import Button from "metabase/core/components/Button";
+import CollapseSection from "metabase/components/CollapseSection";
 
-export const ModelActionList = styled.div`
-  margin-bottom: ${space(2)};
-`;
-
-export const ModelTitle = styled.h4`
-  margin-bottom: ${space(2)};
+export const ModelCollapseSection = styled(CollapseSection)`
+  margin-bottom: ${space(1)};
 `;
 
 export const ActionItem = styled.li`
   display: flex;
   justify-content: space-between;
-  padding-left: ${space(3)};
-  margin-bottom: ${space(2)};
+  margin: 1rem 1.5rem;
 `;
 
 export const EmptyState = styled(UnstyledEmptyState)`
@@ -27,7 +23,7 @@ export const EmptyState = styled(UnstyledEmptyState)`
 `;
 
 export const EmptyModelStateContainer = styled.div`
-  padding-bottom: ${space(2)};
+  padding: ${space(2)};
   color: ${color("text-medium")};
   text-align: center;
 `;

--- a/frontend/src/metabase/actions/containers/ActionPicker/ActionPicker.tsx
+++ b/frontend/src/metabase/actions/containers/ActionPicker/ActionPicker.tsx
@@ -10,7 +10,6 @@ import Questions from "metabase/entities/questions";
 import type { Card, WritebackAction } from "metabase-types/api";
 import type { State } from "metabase-types/store";
 
-import Icon from "metabase/components/Icon";
 import Button from "metabase/core/components/Button";
 
 import { isImplicitAction } from "metabase/actions/utils";
@@ -19,7 +18,6 @@ import ActionCreator from "metabase/actions/containers/ActionCreator";
 import {
   ModelTitle,
   ActionItem,
-  ActionName,
   EditButton,
   ModelActionList,
   EmptyState,
@@ -62,6 +60,7 @@ function ModelActionPicker({
   model: Card;
   actions: WritebackAction[];
 }) {
+  const [isCollapsed, { toggle: toggleIsCollapsed }] = useToggle(true);
   const [editingActionId, setEditingActionId] = useState<number | undefined>(
     undefined,
   );
@@ -80,40 +79,48 @@ function ModelActionPicker({
     <>
       <ModelActionList>
         <ModelTitle>
-          <div>
-            <Icon name="model" size={16} className="mr2" />
+          <Button
+            onlyText
+            onClick={toggleIsCollapsed}
+            icon={isCollapsed ? "chevronright" : "chevrondown"}
+          >
             {model.name}
-          </div>
-          <Button onlyIcon icon="add" onClick={toggleIsActionCreatorVisible} />
+          </Button>
         </ModelTitle>
-        {actions?.length ? (
-          <ul>
-            {actions?.map(action => (
-              <ActionItem key={action.id}>
-                <ActionName onClick={() => onClick(action)}>
-                  {action.name}
-                </ActionName>
-                {!isImplicitAction(action) && (
-                  <EditButton
-                    icon="pencil"
-                    onlyIcon
-                    onClick={() => {
-                      setEditingActionId(action.id);
-                      toggleIsActionCreatorVisible();
-                    }}
-                  />
-                )}
+        {!isCollapsed &&
+          (actions?.length ? (
+            <ul>
+              {actions?.map(action => (
+                <ActionItem key={action.id}>
+                  <Button onlyText onClick={() => onClick(action)}>
+                    <span>{action.name}</span>
+                  </Button>
+                  {!isImplicitAction(action) && (
+                    <EditButton
+                      icon="pencil"
+                      onlyIcon
+                      onClick={() => {
+                        setEditingActionId(action.id);
+                        toggleIsActionCreatorVisible();
+                      }}
+                    />
+                  )}
+                </ActionItem>
+              ))}
+              <ActionItem>
+                <Button onlyText onClick={toggleIsActionCreatorVisible}>
+                  {t`Create new action`}
+                </Button>
               </ActionItem>
-            ))}
-          </ul>
-        ) : (
-          <EmptyModelStateContainer>
-            <div>{t`There are no actions for this model`}</div>
-            <Button onClick={toggleIsActionCreatorVisible} borderless>
-              {t`Create new action`}
-            </Button>
-          </EmptyModelStateContainer>
-        )}
+            </ul>
+          ) : (
+            <EmptyModelStateContainer>
+              <div>{t`There are no actions for this model`}</div>
+              <Button onClick={toggleIsActionCreatorVisible} borderless>
+                {t`Create new action`}
+              </Button>
+            </EmptyModelStateContainer>
+          ))}
       </ModelActionList>
       {isActionCreatorOpen && (
         <ActionCreator

--- a/frontend/src/metabase/actions/containers/ActionPicker/ActionPicker.tsx
+++ b/frontend/src/metabase/actions/containers/ActionPicker/ActionPicker.tsx
@@ -16,11 +16,10 @@ import { isImplicitAction } from "metabase/actions/utils";
 import ActionCreator from "metabase/actions/containers/ActionCreator";
 
 import {
-  ModelTitle,
   ActionItem,
   EditButton,
-  ModelActionList,
   EmptyState,
+  ModelCollapseSection,
   EmptyModelStateContainer,
 } from "./ActionPicker.styled";
 
@@ -60,7 +59,6 @@ function ModelActionPicker({
   model: Card;
   actions: WritebackAction[];
 }) {
-  const [isCollapsed, { toggle: toggleIsCollapsed }] = useToggle(true);
   const [editingActionId, setEditingActionId] = useState<number | undefined>(
     undefined,
   );
@@ -77,51 +75,41 @@ function ModelActionPicker({
 
   return (
     <>
-      <ModelActionList>
-        <ModelTitle>
-          <Button
-            onlyText
-            onClick={toggleIsCollapsed}
-            icon={isCollapsed ? "chevronright" : "chevrondown"}
-          >
-            {model.name}
-          </Button>
-        </ModelTitle>
-        {!isCollapsed &&
-          (actions?.length ? (
-            <ul>
-              {actions?.map(action => (
-                <ActionItem key={action.id}>
-                  <Button onlyText onClick={() => onClick(action)}>
-                    <span>{action.name}</span>
-                  </Button>
-                  {!isImplicitAction(action) && (
-                    <EditButton
-                      icon="pencil"
-                      onlyIcon
-                      onClick={() => {
-                        setEditingActionId(action.id);
-                        toggleIsActionCreatorVisible();
-                      }}
-                    />
-                  )}
-                </ActionItem>
-              ))}
-              <ActionItem>
-                <Button onlyText onClick={toggleIsActionCreatorVisible}>
-                  {t`Create new action`}
+      <ModelCollapseSection header={<h4>{model.name}</h4>}>
+        {actions?.length ? (
+          <ul>
+            {actions?.map(action => (
+              <ActionItem key={action.id}>
+                <Button onlyText onClick={() => onClick(action)}>
+                  <span>{action.name}</span>
                 </Button>
+                {!isImplicitAction(action) && (
+                  <EditButton
+                    icon="pencil"
+                    onlyIcon
+                    onClick={() => {
+                      setEditingActionId(action.id);
+                      toggleIsActionCreatorVisible();
+                    }}
+                  />
+                )}
               </ActionItem>
-            </ul>
-          ) : (
-            <EmptyModelStateContainer>
-              <div>{t`There are no actions for this model`}</div>
-              <Button onClick={toggleIsActionCreatorVisible} borderless>
+            ))}
+            <ActionItem>
+              <Button onlyText onClick={toggleIsActionCreatorVisible}>
                 {t`Create new action`}
               </Button>
-            </EmptyModelStateContainer>
-          ))}
-      </ModelActionList>
+            </ActionItem>
+          </ul>
+        ) : (
+          <EmptyModelStateContainer>
+            <div>{t`There are no actions for this model`}</div>
+            <Button onClick={toggleIsActionCreatorVisible} borderless>
+              {t`Create new action`}
+            </Button>
+          </EmptyModelStateContainer>
+        )}
+      </ModelCollapseSection>
       {isActionCreatorOpen && (
         <ActionCreator
           modelId={model.id}


### PR DESCRIPTION
resolves https://github.com/metabase/metabase/issues/27823

## Description

This should make the action picker sidebar feel less overwhelming by collapsing actions within their models.

I also took this opportunity to implement the new `onlyText` variant of the button component here.

![Screen Shot 2023-01-27 at 8 46 53 AM](https://user-images.githubusercontent.com/30528226/215128213-9833a84c-f80e-4a65-bb5c-8a889d896e1a.png)


## Testing Steps

- You can follow these [testing steps for actions](https://www.notion.so/metabase/How-To-Use-Metabase-Actions-9c23b4b9a7b847018944bc740002ccf0) to set up a basic set of actions.
- when you open the actions list, you should not longer see actions immediately, but model names that you can expand to add their actions.
