### PR TITLE
Allow wider dashboardHeader buttons

### DIFF
--- a/frontend/src/metabase/dashboard/containers/DashboardHeader.styled.jsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardHeader.styled.jsx
@@ -14,7 +14,7 @@ export const DashboardHeaderActionDivider = styled.div`
 export const DashboardHeaderButton = styled(Button)`
   padding: 0.25rem 0.5rem;
   height: 2rem;
-  width: 2rem;
+  min-width: 2rem;
   color: ${props => (props.isActive ? color("brand") : color("text-dark"))};
   font-size: 1rem;
 


### PR DESCRIPTION
## Description

We were setting a fixed width on dashboard header buttons, which caused any icons that were wider than they were tall to get clipped. This allows rectangular icons to fit properly (note, both the text card and click icons are affected).

Before | After
--- | ---
![Screen Shot 2023-01-23 at 3 18 53 PM](https://user-images.githubusercontent.com/30528226/214164166-02b291f2-ff47-4428-adb6-680d90d5003e.png) | ![Screen Shot 2023-01-23 at 3 25 34 PM](https://user-images.githubusercontent.com/30528226/214164191-13cd429a-76ce-4193-b342-c7fac6d3232d.png)


Other dashboard buttons still look fine

![Screen Shot 2023-01-23 at 3 25 45 PM](https://user-images.githubusercontent.com/30528226/214164234-041466fe-cebd-4d29-9242-6663db8e179d.png)

