### PR TITLE
Display action creator info

### DIFF
--- a/frontend/src/metabase-types/api/actions.ts
+++ b/frontend/src/metabase-types/api/actions.ts
@@ -7,6 +7,7 @@ import type {
   DashboardParameterMapping,
 } from "./dashboard";
 import type { Card, CardId } from "./card";
+import type { UserId, UserInfo } from "./user";
 
 export interface WritebackParameter extends Parameter {
   target: ParameterTarget;
@@ -23,6 +24,8 @@ export interface WritebackActionBase {
   description: string | null;
   parameters: WritebackParameter[];
   visualization_settings?: ActionFormSettings;
+  creator_id: UserId;
+  creator: UserInfo;
   updated_at: string;
   created_at: string;
 }

--- a/frontend/src/metabase-types/api/mocks/actions.ts
+++ b/frontend/src/metabase-types/api/mocks/actions.ts
@@ -6,6 +6,7 @@ import {
 } from "metabase-types/api";
 import { createMockNativeDatasetQuery } from "./query";
 import { createMockParameter } from "./parameters";
+import { createMockUserInfo } from "./user";
 
 export const createMockActionParameter = (
   opts?: Partial<WritebackParameter>,
@@ -22,6 +23,7 @@ export const createMockActionParameter = (
 
 export const createMockQueryAction = ({
   dataset_query = createMockNativeDatasetQuery(),
+  creator = createMockUserInfo(),
   ...opts
 }: Partial<WritebackQueryAction> = {}): WritebackQueryAction => {
   return {
@@ -31,6 +33,8 @@ export const createMockQueryAction = ({
     description: null,
     model_id: 1,
     parameters: [],
+    creator_id: creator.id,
+    creator,
     created_at: new Date().toISOString(),
     updated_at: new Date().toISOString(),
     ...opts,
@@ -38,9 +42,10 @@ export const createMockQueryAction = ({
   };
 };
 
-export const createMockImplicitQueryAction = (
-  options: Partial<WritebackImplicitQueryAction>,
-): WritebackImplicitQueryAction => ({
+export const createMockImplicitQueryAction = ({
+  creator = createMockUserInfo(),
+  ...opts
+}: Partial<WritebackImplicitQueryAction>): WritebackImplicitQueryAction => ({
   id: 1,
   kind: "row/create",
   name: "",
@@ -48,9 +53,11 @@ export const createMockImplicitQueryAction = (
   model_id: 1,
   parameters: [],
   visualization_settings: undefined,
+  creator_id: creator.id,
+  creator,
   created_at: new Date().toISOString(),
   updated_at: new Date().toISOString(),
-  ...options,
+  ...opts,
   type: "implicit",
 });
 

--- a/frontend/src/metabase-types/api/mocks/timeline.ts
+++ b/frontend/src/metabase-types/api/mocks/timeline.ts
@@ -4,7 +4,7 @@ import {
   TimelineData,
   TimelineEventData,
 } from "../timeline";
-import { createMockUser } from "./user";
+import { createMockUserInfo } from "./user";
 
 export const createMockTimeline = (opts?: Partial<Timeline>): Timeline => ({
   ...createMockTimelineData(opts),
@@ -31,7 +31,7 @@ export const createMockTimelineEvent = (
   ...createMockTimelineEventData(opts),
   id: 1,
   timeline_id: 1,
-  creator: createMockUser(),
+  creator: createMockUserInfo(),
   created_at: "2021-12-01",
   ...opts,
 });

--- a/frontend/src/metabase-types/api/mocks/user.ts
+++ b/frontend/src/metabase-types/api/mocks/user.ts
@@ -1,4 +1,4 @@
-import { User } from "metabase-types/api";
+import { User, UserInfo } from "metabase-types/api";
 
 export const createMockUser = (opts?: Partial<User>): User => ({
   id: 1,
@@ -18,6 +18,19 @@ export const createMockUser = (opts?: Partial<User>): User => ({
   personal_collection_id: 1,
   date_joined: new Date().toISOString(),
   first_login: new Date().toISOString(),
+  last_login: new Date().toISOString(),
+  ...opts,
+});
+
+export const createMockUserInfo = (opts?: Partial<UserInfo>): UserInfo => ({
+  id: 1,
+  first_name: "Testy",
+  last_name: "Tableton",
+  common_name: `Testy Tableton`,
+  email: "user@metabase.test",
+  is_qbnewb: false,
+  is_superuser: false,
+  date_joined: new Date().toISOString(),
   last_login: new Date().toISOString(),
   ...opts,
 });

--- a/frontend/src/metabase-types/api/snippets.ts
+++ b/frontend/src/metabase-types/api/snippets.ts
@@ -1,5 +1,5 @@
 import { RegularCollectionId } from "./collection";
-import { User, UserId } from "./user";
+import { UserId, UserInfo } from "./user";
 
 export type NativeQuerySnippetId = number;
 
@@ -10,7 +10,7 @@ export interface NativeQuerySnippet {
   content: string;
   collection_id: RegularCollectionId | null;
   creator_id: UserId;
-  creator: User;
+  creator: UserInfo;
   archived: boolean;
   entity_id: string;
   created_at: string;

--- a/frontend/src/metabase-types/api/timeline.ts
+++ b/frontend/src/metabase-types/api/timeline.ts
@@ -1,6 +1,6 @@
 import { CardId } from "./card";
 import { Collection, RegularCollectionId } from "./collection";
-import { User } from "./user";
+import { UserInfo } from "./user";
 
 export type TimelineId = number;
 export type TimelineEventId = number;
@@ -25,7 +25,7 @@ export interface TimelineData {
 export interface TimelineEvent extends TimelineEventData {
   id: TimelineEventId;
   timeline_id: TimelineId;
-  creator: User;
+  creator: UserInfo;
   created_at: string;
 }
 

--- a/frontend/src/metabase-types/api/user.ts
+++ b/frontend/src/metabase-types/api/user.ts
@@ -25,3 +25,17 @@ export interface User extends BaseUser {
   has_question_and_dashboard: boolean;
   personal_collection_id: number;
 }
+
+// Used when hydrating `creator` property
+export type UserInfo = Pick<
+  BaseUser,
+  | "id"
+  | "common_name"
+  | "first_name"
+  | "last_name"
+  | "email"
+  | "date_joined"
+  | "last_login"
+  | "is_superuser"
+  | "is_qbnewb"
+>;

--- a/frontend/src/metabase/models/components/ModelDetailPage/ModelActionDetails/ModelActionDetails.styled.tsx
+++ b/frontend/src/metabase/models/components/ModelDetailPage/ModelActionDetails/ModelActionDetails.styled.tsx
@@ -22,7 +22,7 @@ export const ActionList = styled.ul`
   margin-top: 1rem;
 
   li:not(:first-of-type) {
-    margin-top: 1rem;
+    margin-top: 2.25rem;
   }
 
   ${breakpointMaxMedium} {

--- a/frontend/src/metabase/models/components/ModelDetailPage/ModelActionDetails/ModelActionListItem.styled.tsx
+++ b/frontend/src/metabase/models/components/ModelDetailPage/ModelActionDetails/ModelActionListItem.styled.tsx
@@ -8,12 +8,21 @@ export const ActionTitle = styled.h4`
   color: ${color("text-dark")};
 `;
 
+export const ActionSubtitle = styled.span`
+  display: block;
+  font-size: 0.75rem;
+  font-weight: 700;
+  line-height: 0.875rem;
+  color: ${color("text-medium")};
+  margin-top: 4px;
+`;
+
 export const Card = styled.div`
   display: block;
   position: relative;
 
   padding: 1rem;
-  margin-top: 0.5rem;
+  margin-top: 0.75rem;
   border-radius: 6px;
 
   color: ${color("text-white")};

--- a/frontend/src/metabase/models/components/ModelDetailPage/ModelActionDetails/ModelActionListItem.tsx
+++ b/frontend/src/metabase/models/components/ModelDetailPage/ModelActionDetails/ModelActionListItem.tsx
@@ -6,6 +6,7 @@ import type { WritebackAction, WritebackQueryAction } from "metabase-types/api";
 import StackedInsightIcon from "./StackedInsightIcon";
 import {
   ActionTitle,
+  ActionSubtitle,
   Card,
   CodeBlock,
   EditButton,
@@ -44,6 +45,9 @@ function ModelActionListItem({ action, onEdit }: Props) {
   return (
     <>
       <ActionTitle>{action.name}</ActionTitle>
+      {action?.creator?.common_name && (
+        <ActionSubtitle>{t`Created by ${action.creator.common_name}`}</ActionSubtitle>
+      )}
       <Card>
         {renderCardContent()}
         {canEdit && <EditButton onClick={onEdit} />}

--- a/frontend/src/metabase/models/containers/ModelDetailPage/ModelDetailPage.unit.spec.tsx
+++ b/frontend/src/metabase/models/containers/ModelDetailPage/ModelDetailPage.unit.spec.tsx
@@ -442,6 +442,9 @@ describe("ModelDetailPage", () => {
 
           expect(screen.getByText(action.name)).toBeInTheDocument();
           expect(screen.getByText(TEST_QUERY)).toBeInTheDocument();
+          expect(
+            screen.getByText(`Created by ${action.creator.common_name}`),
+          ).toBeInTheDocument();
         });
 
         it("lists existing implicit actions", async () => {


### PR DESCRIPTION
Epic #27581, based on #27772. Adds action creator info to the action list on the model detail page

![CleanShot 2023-01-24 at 15 11 48@2x](https://user-images.githubusercontent.com/17258145/214332418-0d7e8328-4531-4b33-8179-431c7508e7bc.png)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/27851)
<!-- Reviewable:end -->
