### PR TITLE
Remove confusing "actions" header in DB settings

### DIFF
--- a/frontend/src/metabase/admin/databases/components/DatabaseEditApp/Sidebar/Sidebar.tsx
+++ b/frontend/src/metabase/admin/databases/components/DatabaseEditApp/Sidebar/Sidebar.tsx
@@ -106,7 +106,6 @@ const DatabaseEditAppSidebar = ({
     <SidebarRoot>
       <SidebarContent data-testid="database-actions-panel">
         <SidebarGroup>
-          <SidebarGroup.Name>{t`Actions`}</SidebarGroup.Name>
           <SidebarGroup.List>
             {!isSynced && (
               <SidebarGroup.ListItem hasMarginTop={false}>


### PR DESCRIPTION
Having the word "Actions" used twice in different senses is confusing.

context: https://metaboat.slack.com/archives/C01MS7DQKR6/p1674581070813289

Before | After
--- | ---
![Screen Shot 2023-01-24 at 10 36 28 AM](https://user-images.githubusercontent.com/30528226/214366854-1ad62780-259b-49b5-8a4d-3ed720345e61.png) | ![Screen Shot 2023-01-24 at 10 36 17 AM](https://user-images.githubusercontent.com/30528226/214366851-eda183cb-9415-412f-95be-8cf548f54d74.png)
