### PR TITLE
Handle cards that do not have parameters but rely on template-tags

### DIFF
--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -30,6 +30,7 @@
             Pulse
             Table
             ViewLog]]
+   [metabase.models.card :as card]
    [metabase.models.collection :as collection]
    [metabase.models.interface :as mi]
    [metabase.models.moderation-review :as moderation-review]
@@ -943,7 +944,11 @@ saved later when it is ready."
   ([card      :- su/Map
     param-key :- su/NonBlankString
     query     :- (s/maybe su/NonBlankString)]
-   (let [param       (get (m/index-by :id (:parameters card)) param-key)
+   (let [param       (get (m/index-by :id (or (seq (:parameters card))
+                                              ;; some older cards or cards in e2e just use the template tags on native
+                                              ;; queries
+                                              (card/template-tag-parameters card)))
+                          param-key)
          source-type (:values_source_type param)]
      (when-not param
        (throw (ex-info (tru "Card does not have a parameter with the ID {0}" (pr-str param-key))

--- a/src/metabase/api/public.clj
+++ b/src/metabase/api/public.clj
@@ -477,7 +477,8 @@
   [uuid param-key]
   (validation/check-public-sharing-enabled)
   (let [card (db/select-one Card :public_uuid uuid, :archived false)]
-    (api.card/param-values card param-key)))
+    (binding [api/*current-user-permissions-set* (atom #{"/"})]
+      (api.card/param-values card param-key))))
 
 #_{:clj-kondo/ignore [:deprecated-var]}
 (api/defendpoint-schema GET "/card/:uuid/params/:param-key/search/:query"
@@ -485,7 +486,8 @@
   [uuid param-key query]
   (validation/check-public-sharing-enabled)
   (let [card (db/select-one Card :public_uuid uuid, :archived false)]
-    (api.card/param-values card param-key query)))
+    (binding [api/*current-user-permissions-set* (atom #{"/"})]
+      (api.card/param-values card param-key query))))
 
 #_{:clj-kondo/ignore [:deprecated-var]}
 (api/defendpoint-schema GET "/dashboard/:uuid/params/:param-key/values"

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -2389,7 +2389,26 @@
                                                                "bar"))]
           (is (set/subset? #{["Barney's Beanery"] ["bigmista's barbecue"]}
                            (-> response :values set)))
-          (is (not ((into #{} (mapcat identity) (:values response)) "The Virgil"))))))))
+          (is (not ((into #{} (mapcat identity) (:values response)) "The Virgil")))))))
+  (testing "Old style, inferred parameters from native template-tags"
+    (with-card-param-values-fixtures [{:keys [param-keys field-filter-card]}]
+      ;; e2e tests and some older cards don't have an explicit parameter and infer them from the native template tags
+      (db/update! Card (:id field-filter-card) :parameters [])
+      (testing "GET /api/card/:card-id/params/:param-key/values for field-filter based params"
+        (testing "without search query"
+          (let [response (mt/user-http-request :rasta :get 200
+                                               (param-values-url field-filter-card (:field-values param-keys)))]
+            (is (false? (:has_more_values response)))
+            (is (set/subset? #{["20th Century Cafe"] ["33 Taps"]}
+                             (-> response :values set)))))
+        (testing "with search query"
+          (let [response (mt/user-http-request :rasta :get 200
+                                               (param-values-url field-filter-card
+                                                                 (:field-values param-keys)
+                                                                 "bar"))]
+            (is (set/subset? #{["Barney's Beanery"] ["bigmista's barbecue"]}
+                             (-> response :values set)))
+            (is (not ((into #{} (mapcat identity) (:values response)) "The Virgil")))))))))
 
 (deftest parameters-with-source-is-card-test
   (with-card-param-values-fixtures [{:keys [card param-keys]}]

--- a/test/metabase/api/public_test.clj
+++ b/test/metabase/api/public_test.clj
@@ -2,6 +2,7 @@
   "Tests for `api/public/` (public links) endpoints."
   (:require
    [cheshire.core :as json]
+   [clojure.set :as set]
    [clojure.string :as str]
    [clojure.test :refer :all]
    [dk.ative.docjure.spreadsheet :as spreadsheet]
@@ -1064,15 +1065,20 @@
                           (chain-filter-test/take-n-values 3)))))))))
 
     (testing "with card"
-      (api.card-test/with-card-param-values-fixtures [{:keys [card param-keys]}]
-        (let [uuid (str (UUID/randomUUID))]
+      (api.card-test/with-card-param-values-fixtures [{:keys [card field-filter-card param-keys]}]
+        (let [card-uuid (str (random-uuid))
+              field-filter-uuid (str (random-uuid))]
           (is (= true
-                 (db/update! Card (u/the-id card) :public_uuid uuid)))
+                 (db/update! Card (u/the-id card) :public_uuid card-uuid))
+              "Enabled public setting on card")
+          (is (= true
+                 (db/update! Card (u/the-id field-filter-card) :public_uuid field-filter-uuid))
+              "Enabled public setting on field-filter-card")
           (testing "GET /api/public/card/:uuid/params/:param-key/values"
             (testing "parameter with source is a static list"
               (is (= {:values          ["African" "American" "Asian"]
                       :has_more_values false}
-                     (client/client :get 200 (param-values-url :card uuid (:static-list param-keys))))))
+                     (client/client :get 200 (param-values-url :card card-uuid (:static-list param-keys))))))
 
             (testing "parameter with source is a card"
               (is (= {:values          ["Red Medicine"
@@ -1081,18 +1087,42 @@
                                         "Wurstküche"
                                         "Brite Spot Family Restaurant"]
                       :has_more_values false}
-                     (client/client :get 200 (param-values-url :card uuid (:card param-keys)))))))
+                     (client/client :get 200 (param-values-url :card card-uuid (:card param-keys))))))
+
+            (testing "parameter with source is a field filter"
+              (testing "parameter with source is a card"
+                (let [resp (client/client
+                            :get 200
+                            (param-values-url :card field-filter-uuid
+                                              (:field-values param-keys)))]
+                  (is (false? (:has_more_values resp)))
+                  (is (set/subset? #{["20th Century Cafe"] ["33 Taps"]}
+                                   (-> resp :values set)))))))
 
           (testing "GET /api/public/card/:uuid/params/:param-key/search/:query"
             (testing "parameter with source is a static list"
               (is (= {:values          ["African"]
                       :has_more_values false}
-                     (client/client :get 200 (param-values-url :card uuid (:static-list param-keys) "af")))))
+                     (client/client :get 200 (param-values-url :card card-uuid (:static-list param-keys) "af")))))
 
             (testing "parameter with source is a card"
               (is (= {:values          ["Red Medicine"]
                       :has_more_values false}
-                     (client/client :get 200 (param-values-url :card uuid (:card param-keys) "red")))))))))))
+                     (client/client :get 200 (param-values-url :card card-uuid (:card param-keys) "red")))))
+
+            (testing "parameter with source is a field-filter"
+              (is (partial= {:values
+                             [["Barney's Beanery"]
+                              ["My Brother's Bar-B-Q"]
+                              ["Tanoshi Sushi & Sake Bar"]
+                              ["The Misfit Restaurant + Bar"]
+                              ["Two Sisters Bar & Books"]
+                              ["bigmista's barbecue"]]
+                             :has_more_values true}
+                            (client/client
+                             :get 200
+                             (param-values-url :card field-filter-uuid
+                                               (:field-values param-keys) "bar")))))))))))
 
 (deftest param-values-ignore-current-user-permissions-test
   (testing "Should not fail if request is authenticated but current user does not have data permissions"


### PR DESCRIPTION
Ideally a card looks like:

```clojure
 :dataset_query {:type :native,
                 :native {:query "select * from products where {{CATEGORY}}",
                          :template-tags {"CATEGORY" {:id "f8196be2-3af0-8527-fa72-f45abbb09d35",
                                                      :name "CATEGORY",
                                                      :display-name "Category",
                                                      :type :dimension,
                                                      :dimension [:field
                                                                  58
                                                                  nil],
                                                      :widget-type :string/=,
                                                      :default nil}}},
                 :database 1}
 :parameters [{:id "f8196be2-3af0-8527-fa72-f45abbb09d35",
               :type :string/=,
               :target [:dimension [:template-tag "CATEGORY"]],
               :name "Category",
               :slug "CATEGORY"}]
```

And we just ask for the values for
`f8196be2-3af0-8527-fa72-f45abbb09d35` and all of the information needed is in :parameters.

Unfortunately a lot of e2e tests and perhaps some older cards don't both with parameters if they have native template-tags. This requires more places to know about these hacks and makes everyone's life worse.

This change will look at the parameters on the card and fall back to any inferred parameters based on native template tags. Note the fallback doesn't happen if there are parameters on the card. Assuming that if we're doing it correctly it should be correct.
