### PR TITLE
Allow additional parameter-specific settings to be set for template tags

### DIFF
--- a/frontend/src/metabase-lib/Question.ts
+++ b/frontend/src/metabase-lib/Question.ts
@@ -26,8 +26,8 @@ import { memoizeClass, sortObject } from "metabase-lib/utils";
 import * as Urls from "metabase/lib/urls";
 import { getCardUiParameters } from "metabase-lib/parameters/utils/cards";
 import {
-  DashboardApi,
   CardApi,
+  DashboardApi,
   maybeUsePivotEndpoint,
   MetabaseApi,
 } from "metabase/services";
@@ -50,8 +50,7 @@ import {
   normalizeParameters,
 } from "metabase-lib/parameters/utils/parameter-values";
 import {
-  getTemplateTagParameters,
-  getTemplateTagsForParameters,
+  getTemplateTagParametersFromCard,
   remapParameterValuesToTemplateTags,
 } from "metabase-lib/parameters/utils/template-tags";
 import { fieldFilterParameterToMBQLFilter } from "metabase-lib/parameters/utils/mbql";
@@ -153,8 +152,7 @@ class QuestionInner {
     q._card = card;
 
     if (card.dataset_query.type === "native") {
-      const tags = getTemplateTagsForParameters(card);
-      const parameters = getTemplateTagParameters(tags);
+      const parameters = getTemplateTagParametersFromCard(card);
       q._card = { ...card, parameters };
     } else {
       q._card = card;
@@ -1142,6 +1140,14 @@ class QuestionInner {
     }
   }
 
+  setParameter(newParameter) {
+    const newParameters = this.parameters().map(oldParameter =>
+      oldParameter.id === tag.id ? newParameter : oldParameter,
+    );
+
+    return this.setParameters(newParameters);
+  }
+
   setParameters(parameters) {
     return this.setCard(assoc(this.card(), "parameters", parameters));
   }
@@ -1186,12 +1192,10 @@ class QuestionInner {
     const [a, b] = [this, originalQuestion].map(q => {
       return (
         q &&
-        new Question(q.card(), this.metadata())
-          .setParameters([])
-          .setDashboardProps({
-            dashboardId: undefined,
-            dashcardId: undefined,
-          })
+        new Question(q.card(), this.metadata()).setDashboardProps({
+          dashboardId: undefined,
+          dashcardId: undefined,
+        })
       );
     });
     return a.isDirtyComparedTo(b);

--- a/frontend/src/metabase-lib/Question.ts
+++ b/frontend/src/metabase-lib/Question.ts
@@ -49,7 +49,10 @@ import {
   getParameterValuesBySlug,
   normalizeParameters,
 } from "metabase-lib/parameters/utils/parameter-values";
-import { remapParameterValuesToTemplateTags } from "metabase-lib/parameters/utils/template-tags";
+import {
+  getTemplateTagParametersFromCard,
+  remapParameterValuesToTemplateTags,
+} from "metabase-lib/parameters/utils/template-tags";
 import { fieldFilterParameterToMBQLFilter } from "metabase-lib/parameters/utils/mbql";
 import { getQuestionVirtualTableId } from "metabase-lib/metadata/utils/saved-questions";
 import {
@@ -1181,10 +1184,12 @@ class QuestionInner {
     const [a, b] = [this, originalQuestion].map(q => {
       return (
         q &&
-        new Question(q.card(), this.metadata()).setDashboardProps({
-          dashboardId: undefined,
-          dashcardId: undefined,
-        })
+        new Question(q.card(), this.metadata())
+          .setParameters(getTemplateTagParametersFromCard(q.card()))
+          .setDashboardProps({
+            dashboardId: undefined,
+            dashcardId: undefined,
+          })
       );
     });
     return a.isDirtyComparedTo(b);

--- a/frontend/src/metabase-lib/Question.ts
+++ b/frontend/src/metabase-lib/Question.ts
@@ -1142,7 +1142,7 @@ class QuestionInner {
 
   setParameter(newParameter) {
     const newParameters = this.parameters().map(oldParameter =>
-      oldParameter.id === tag.id ? newParameter : oldParameter,
+      oldParameter.id === newParameter.id ? newParameter : oldParameter,
     );
 
     return this.setParameters(newParameters);

--- a/frontend/src/metabase-lib/Question.ts
+++ b/frontend/src/metabase-lib/Question.ts
@@ -26,8 +26,8 @@ import { memoizeClass, sortObject } from "metabase-lib/utils";
 import * as Urls from "metabase/lib/urls";
 import { getCardUiParameters } from "metabase-lib/parameters/utils/cards";
 import {
-  CardApi,
   DashboardApi,
+  CardApi,
   maybeUsePivotEndpoint,
   MetabaseApi,
 } from "metabase/services";
@@ -49,10 +49,7 @@ import {
   getParameterValuesBySlug,
   normalizeParameters,
 } from "metabase-lib/parameters/utils/parameter-values";
-import {
-  getTemplateTagParametersFromCard,
-  remapParameterValuesToTemplateTags,
-} from "metabase-lib/parameters/utils/template-tags";
+import { remapParameterValuesToTemplateTags } from "metabase-lib/parameters/utils/template-tags";
 import { fieldFilterParameterToMBQLFilter } from "metabase-lib/parameters/utils/mbql";
 import { getQuestionVirtualTableId } from "metabase-lib/metadata/utils/saved-questions";
 import {
@@ -150,14 +147,6 @@ class QuestionInner {
   setCard(card: CardObject): Question {
     const q = this.clone();
     q._card = card;
-
-    if (card.dataset_query.type === "native") {
-      const parameters = getTemplateTagParametersFromCard(card);
-      q._card = { ...card, parameters };
-    } else {
-      q._card = card;
-    }
-
     return q;
   }
 

--- a/frontend/src/metabase-lib/Question.ts
+++ b/frontend/src/metabase-lib/Question.ts
@@ -49,7 +49,11 @@ import {
   getParameterValuesBySlug,
   normalizeParameters,
 } from "metabase-lib/parameters/utils/parameter-values";
-import { remapParameterValuesToTemplateTags } from "metabase-lib/parameters/utils/template-tags";
+import {
+  getTemplateTagParameters,
+  getTemplateTagsForParameters,
+  remapParameterValuesToTemplateTags,
+} from "metabase-lib/parameters/utils/template-tags";
 import { fieldFilterParameterToMBQLFilter } from "metabase-lib/parameters/utils/mbql";
 import { getQuestionVirtualTableId } from "metabase-lib/metadata/utils/saved-questions";
 import {
@@ -147,6 +151,15 @@ class QuestionInner {
   setCard(card: CardObject): Question {
     const q = this.clone();
     q._card = card;
+
+    if (card.dataset_query.type === "native") {
+      const tags = getTemplateTagsForParameters(card);
+      const parameters = getTemplateTagParameters(tags);
+      q._card = { ...card, parameters };
+    } else {
+      q._card = card;
+    }
+
     return q;
   }
 

--- a/frontend/src/metabase-lib/parameters/utils/template-tags.ts
+++ b/frontend/src/metabase-lib/parameters/utils/template-tags.ts
@@ -1,6 +1,6 @@
 import _ from "underscore";
 
-import { Parameter } from "metabase-types/api";
+import { Parameter, ParameterConfig } from "metabase-types/api";
 import type { ParameterTarget } from "metabase-types/types/Parameter";
 import type { Card } from "metabase-types/types/Card";
 import type { TemplateTag } from "metabase-types/types/Query";
@@ -32,7 +32,7 @@ export function getTemplateTagParameterTarget(
 
 export function getTemplateTagParameter(
   tag: TemplateTag,
-  parameter?: Parameter,
+  config?: ParameterConfig,
 ): ParameterWithTarget {
   return {
     id: tag.id,
@@ -41,9 +41,9 @@ export function getTemplateTagParameter(
     name: tag["display-name"],
     slug: tag.name,
     default: tag.default,
-    values_query_type: parameter?.values_query_type,
-    values_source_type: parameter?.values_source_type,
-    values_source_config: parameter?.values_source_config,
+    values_query_type: config?.values_query_type,
+    values_source_type: config?.values_source_type,
+    values_source_config: config?.values_source_config,
   };
 }
 

--- a/frontend/src/metabase-lib/parameters/utils/template-tags.ts
+++ b/frontend/src/metabase-lib/parameters/utils/template-tags.ts
@@ -30,7 +30,10 @@ export function getTemplateTagParameterTarget(
     : ["variable", ["template-tag", tag.name]];
 }
 
-export function getTemplateTagParameter(tag: TemplateTag): ParameterWithTarget {
+export function getTemplateTagParameter(
+  tag: TemplateTag,
+  parameter?: Parameter,
+): ParameterWithTarget {
   return {
     id: tag.id,
     type: tag["widget-type"] || getTemplateTagType(tag),
@@ -38,19 +41,25 @@ export function getTemplateTagParameter(tag: TemplateTag): ParameterWithTarget {
     name: tag["display-name"],
     slug: tag.name,
     default: tag.default,
+    values_query_type: parameter?.values_query_type,
+    values_source_type: parameter?.values_source_type,
+    values_source_config: parameter?.values_source_config,
   };
 }
 
 // NOTE: this should mirror `template-tag-parameters` in src/metabase/api/embed.clj
 export function getTemplateTagParameters(
   tags: TemplateTag[],
+  parameters: Parameter[] = [],
 ): ParameterWithTarget[] {
+  const parametersById = _.indexBy(parameters, "id");
+
   return tags
     .filter(
       tag =>
         tag.type != null && (tag["widget-type"] || tag.type !== "dimension"),
     )
-    .map(getTemplateTagParameter);
+    .map(tag => getTemplateTagParameter(tag, parametersById[tag.id]));
 }
 
 export function getTemplateTagsForParameters(card: Card) {
@@ -77,10 +86,14 @@ export function getParametersFromCard(
 
   if (card.parameters && !_.isEmpty(card.parameters)) {
     return card.parameters;
+  } else {
+    return getTemplateTagParametersFromCard(card);
   }
+}
 
+export function getTemplateTagParametersFromCard(card: Card) {
   const tags = getTemplateTagsForParameters(card);
-  return getTemplateTagParameters(tags);
+  return getTemplateTagParameters(tags, card.parameters);
 }
 
 // when navigating from dashboard --> saved native question,

--- a/frontend/src/metabase-lib/queries/NativeQuery.ts
+++ b/frontend/src/metabase-lib/queries/NativeQuery.ts
@@ -400,7 +400,7 @@ export default class NativeQuery extends AtomicQuery {
     return newQuery
       .question()
       .setParameter(getTemplateTagParameter(tag, parameter))
-      .query();
+      .query() as NativeQuery;
   }
 
   setDatasetQuery(datasetQuery: DatasetQuery): NativeQuery {

--- a/frontend/src/metabase-lib/queries/NativeQuery.ts
+++ b/frontend/src/metabase-lib/queries/NativeQuery.ts
@@ -6,6 +6,7 @@ import _ from "underscore";
 import slugg from "slugg";
 import { humanize } from "metabase/lib/formatting";
 import Utils from "metabase/lib/utils";
+import { Parameter } from "metabase-types/api";
 import {
   Card,
   DatasetQuery,
@@ -21,6 +22,7 @@ import Question from "metabase-lib/Question";
 import Table from "metabase-lib/metadata/Table";
 import Database from "metabase-lib/metadata/Database";
 import AtomicQuery from "metabase-lib/queries/AtomicQuery";
+import { getTemplateTagParameter } from "metabase-lib/parameters/utils/template-tags";
 import Variable from "metabase-lib/variables/Variable";
 import TemplateTagVariable from "metabase-lib/variables/TemplateTagVariable";
 import { createTemplateTag } from "metabase-lib/queries/TemplateTag";
@@ -387,10 +389,15 @@ export default class NativeQuery extends AtomicQuery {
     return tagErrors.length === 0;
   }
 
-  setTemplateTag(name: string, tag: TemplateTag) {
-    return this.setDatasetQuery(
+  setTemplateTag(name: string, tag: TemplateTag, parameter?: Parameter) {
+    const newQuery = this.setDatasetQuery(
       assocIn(this.datasetQuery(), ["native", "template-tags", name], tag),
     );
+
+    return newQuery
+      .question()
+      .setParameter(getTemplateTagParameter(tag, parameter))
+      .query();
   }
 
   setDatasetQuery(datasetQuery: DatasetQuery): NativeQuery {

--- a/frontend/src/metabase-lib/queries/NativeQuery.ts
+++ b/frontend/src/metabase-lib/queries/NativeQuery.ts
@@ -391,7 +391,10 @@ export default class NativeQuery extends AtomicQuery {
 
   setTemplateTag(name: string, tag: TemplateTag, parameter?: Parameter) {
     const newQuery = this.setDatasetQuery(
-      assocIn(this.datasetQuery(), ["native", "template-tags", name], tag),
+      updateIn(this.datasetQuery(), ["native", "template-tags"], tags => ({
+        ...tags,
+        [name]: tag,
+      })),
     );
 
     return newQuery

--- a/frontend/src/metabase-lib/queries/NativeQuery.ts
+++ b/frontend/src/metabase-lib/queries/NativeQuery.ts
@@ -6,7 +6,7 @@ import _ from "underscore";
 import slugg from "slugg";
 import { humanize } from "metabase/lib/formatting";
 import Utils from "metabase/lib/utils";
-import { Parameter } from "metabase-types/api";
+import { ParameterConfig } from "metabase-types/api";
 import {
   Card,
   DatasetQuery,
@@ -389,7 +389,7 @@ export default class NativeQuery extends AtomicQuery {
     return tagErrors.length === 0;
   }
 
-  setTemplateTag(name: string, tag: TemplateTag, parameter?: Parameter) {
+  setTemplateTag(name: string, tag: TemplateTag, config?: ParameterConfig) {
     const newQuery = this.setDatasetQuery(
       updateIn(this.datasetQuery(), ["native", "template-tags"], tags => ({
         ...tags,
@@ -399,7 +399,7 @@ export default class NativeQuery extends AtomicQuery {
 
     return newQuery
       .question()
-      .setParameter(getTemplateTagParameter(tag, parameter))
+      .setParameter(getTemplateTagParameter(tag, config))
       .query() as NativeQuery;
   }
 

--- a/frontend/src/metabase-types/api/parameters.ts
+++ b/frontend/src/metabase-types/api/parameters.ts
@@ -32,7 +32,7 @@ export type ParameterId = string;
 
 export type ActionParameterValue = string | number;
 
-export interface Parameter {
+export interface Parameter extends ParameterConfig {
   id: ParameterId;
   name: string;
   "display-name"?: string;
@@ -44,6 +44,9 @@ export interface Parameter {
   filteringParameters?: ParameterId[];
   isMultiSelect?: boolean;
   value?: any;
+}
+
+export interface ParameterConfig {
   values_query_type?: ValuesQueryType;
   values_source_type?: ValuesSourceType;
   values_source_config?: ValuesSourceConfig;

--- a/frontend/src/metabase/actions/containers/ActionCreator/QueryActionEditor.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/QueryActionEditor.tsx
@@ -4,6 +4,7 @@ import NativeQueryEditor from "metabase/query_builder/components/NativeQueryEdit
 
 import type NativeQuery from "metabase-lib/queries/NativeQuery";
 import type Question from "metabase-lib/Question";
+import { getTemplateTagParametersFromCard } from "metabase-lib/parameters/utils/template-tags";
 
 function QueryActionEditor({
   question,
@@ -14,9 +15,11 @@ function QueryActionEditor({
 }) {
   const handleChange = useCallback(
     (newQuery: NativeQuery) => {
-      setQuestion(question.setQuery(newQuery));
+      const newQuestion = newQuery.question();
+      const newParams = getTemplateTagParametersFromCard(newQuestion.card());
+      setQuestion(newQuestion.setQuery(newQuery).setParameters(newParams));
     },
-    [question, setQuestion],
+    [setQuestion],
   );
 
   return (

--- a/frontend/src/metabase/actions/containers/ActionCreator/QueryActionEditor.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/QueryActionEditor.tsx
@@ -5,8 +5,6 @@ import NativeQueryEditor from "metabase/query_builder/components/NativeQueryEdit
 import type NativeQuery from "metabase-lib/queries/NativeQuery";
 import type Question from "metabase-lib/Question";
 
-import { getTemplateTagParameters } from "metabase-lib/parameters/utils/template-tags";
-
 function QueryActionEditor({
   question,
   setQuestion,
@@ -16,10 +14,7 @@ function QueryActionEditor({
 }) {
   const handleChange = useCallback(
     (newQuery: NativeQuery) => {
-      const newParams = getTemplateTagParameters(
-        newQuery.templateTagsWithoutSnippets(),
-      );
-      setQuestion(question.setQuery(newQuery).setParameters(newParams));
+      setQuestion(question.setQuery(newQuery));
     },
     [question, setQuestion],
   );

--- a/frontend/src/metabase/query_builder/actions/core/updateQuestion.ts
+++ b/frontend/src/metabase/query_builder/actions/core/updateQuestion.ts
@@ -9,6 +9,7 @@ import { Dispatch, GetState, QueryBuilderMode } from "metabase-types/store";
 import Question from "metabase-lib/Question";
 import NativeQuery from "metabase-lib/queries/NativeQuery";
 import StructuredQuery from "metabase-lib/queries/StructuredQuery";
+import { getTemplateTagParametersFromCard } from "metabase-lib/parameters/utils/template-tags";
 
 import {
   getFirstQueryResult,
@@ -192,6 +193,13 @@ export const updateQuestion = (
           shouldUpdateUrl: false,
         }),
       );
+    }
+
+    const newDatasetQuery = newQuestion.query().datasetQuery();
+    // Sync card's parameters with the template tags;
+    if (newDatasetQuery.type === "native") {
+      const parameters = getTemplateTagParametersFromCard(newQuestion.card());
+      newQuestion = newQuestion.setParameters(parameters);
     }
 
     await dispatch({

--- a/frontend/src/metabase/query_builder/actions/core/updateQuestion.ts
+++ b/frontend/src/metabase/query_builder/actions/core/updateQuestion.ts
@@ -6,10 +6,6 @@ import { loadMetadataForCard } from "metabase/questions/actions";
 import { Dataset } from "metabase-types/api";
 import { Series } from "metabase-types/types/Visualization";
 import { Dispatch, GetState, QueryBuilderMode } from "metabase-types/store";
-import {
-  getTemplateTagsForParameters,
-  getTemplateTagParameters,
-} from "metabase-lib/parameters/utils/template-tags";
 import Question from "metabase-lib/Question";
 import NativeQuery from "metabase-lib/queries/NativeQuery";
 import StructuredQuery from "metabase-lib/queries/StructuredQuery";
@@ -196,14 +192,6 @@ export const updateQuestion = (
           shouldUpdateUrl: false,
         }),
       );
-    }
-
-    const newDatasetQuery = newQuestion.query().datasetQuery();
-    // Sync card's parameters with the template tags;
-    if (newDatasetQuery.type === "native") {
-      const templateTags = getTemplateTagsForParameters(newQuestion.card());
-      const parameters = getTemplateTagParameters(templateTags);
-      newQuestion = newQuestion.setParameters(parameters);
     }
 
     await dispatch({

--- a/frontend/src/metabase/query_builder/actions/native.js
+++ b/frontend/src/metabase/query_builder/actions/native.js
@@ -1,17 +1,10 @@
-import { assoc, updateIn } from "icepick";
-
 import { createAction } from "redux-actions";
 
 import * as MetabaseAnalytics from "metabase/lib/analytics";
 import { createThunkAction } from "metabase/lib/redux";
-import Utils from "metabase/lib/utils";
 
 import Questions from "metabase/entities/questions";
 import { getMetadata } from "metabase/selectors/metadata";
-import {
-  getTemplateTagsForParameters,
-  getTemplateTagParameters,
-} from "metabase-lib/parameters/utils/template-tags";
 import {
   getDataReferenceStack,
   getNativeEditorCursorOffset,
@@ -152,43 +145,14 @@ export const insertSnippet = snip => (dispatch, getState) => {
 };
 
 export const SET_TEMPLATE_TAG = "metabase/qb/SET_TEMPLATE_TAG";
-export const setTemplateTag = createThunkAction(
-  SET_TEMPLATE_TAG,
-  templateTag => {
-    return (dispatch, getState) => {
-      const {
-        qb: { card, uiControls },
-      } = getState();
+export const setTemplateTag = createThunkAction(SET_TEMPLATE_TAG, tag => {
+  return (dispatch, getState) => {
+    const question = getQuestion(getState());
+    const newQuestion = question
+      .query()
+      .setTemplateTag(tag.name, tag)
+      .question();
 
-      const updatedCard = Utils.copy(card);
-
-      // when the query changes on saved card we change this into a new query w/ a known starting point
-      if (uiControls.queryBuilderMode !== "dataset" && updatedCard.id) {
-        delete updatedCard.id;
-        delete updatedCard.name;
-        delete updatedCard.description;
-      }
-
-      // we need to preserve the order of the keys to avoid UI jumps
-      const updatedTagsCard = updateIn(
-        updatedCard,
-        ["dataset_query", "native", "template-tags"],
-        tags => {
-          const { name } = templateTag;
-          const newTag =
-            tags[name] && tags[name].type !== templateTag.type
-              ? // when we switch type, null out any default
-                { ...templateTag, default: null }
-              : templateTag;
-          return { ...tags, [name]: newTag };
-        },
-      );
-
-      return assoc(
-        updatedTagsCard,
-        "parameters",
-        getTemplateTagParameters(getTemplateTagsForParameters(updatedTagsCard)),
-      );
-    };
-  },
-);
+    dispatch(updateQuestion(newQuestion));
+  };
+});

--- a/frontend/src/metabase/query_builder/actions/native.js
+++ b/frontend/src/metabase/query_builder/actions/native.js
@@ -145,14 +145,17 @@ export const insertSnippet = snip => (dispatch, getState) => {
 };
 
 export const SET_TEMPLATE_TAG = "metabase/qb/SET_TEMPLATE_TAG";
-export const setTemplateTag = createThunkAction(SET_TEMPLATE_TAG, tag => {
-  return (dispatch, getState) => {
-    const question = getQuestion(getState());
-    const newQuestion = question
-      .query()
-      .setTemplateTag(tag.name, tag)
-      .question();
+export const setTemplateTag = createThunkAction(
+  SET_TEMPLATE_TAG,
+  (tag, parameter) => {
+    return (dispatch, getState) => {
+      const question = getQuestion(getState());
+      const newQuestion = question
+        .query()
+        .setTemplateTag(tag.name, tag, parameter)
+        .question();
 
-    dispatch(updateQuestion(newQuestion));
-  };
-});
+      dispatch(updateQuestion(newQuestion));
+    };
+  },
+);

--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx
@@ -56,7 +56,7 @@ export class TagEditorParam extends Component {
       setTemplateTag({
         ...tag,
         type: type,
-        default: null,
+        default: undefined,
         dimension: undefined,
         "widget-type": undefined,
       });

--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx
@@ -56,6 +56,7 @@ export class TagEditorParam extends Component {
       setTemplateTag({
         ...tag,
         type: type,
+        default: null,
         dimension: undefined,
         "widget-type": undefined,
       });

--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.unit.spec.jsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.unit.spec.jsx
@@ -95,6 +95,9 @@ describe("TagEditorParam", () => {
       expect(mockSetTemplateTag).toHaveBeenCalledWith({
         ...textTag,
         type: "number",
+        default: undefined,
+        dimension: undefined,
+        "widget-type": undefined,
       });
     });
 
@@ -111,9 +114,10 @@ describe("TagEditorParam", () => {
 
       expect(mockSetTemplateTag).toHaveBeenCalledWith({
         ...mappedDimensionTag,
-        "widget-type": undefined,
-        dimension: undefined,
         type: "text",
+        default: undefined,
+        dimension: undefined,
+        "widget-type": undefined,
       });
     });
   });

--- a/frontend/src/metabase/query_builder/reducers.js
+++ b/frontend/src/metabase/query_builder/reducers.js
@@ -23,7 +23,6 @@ import {
   API_CREATE_QUESTION,
   API_UPDATE_QUESTION,
   SET_CARD_AND_RUN,
-  SET_TEMPLATE_TAG,
   SET_PARAMETER_VALUE,
   UPDATE_QUESTION,
   RUN_QUERY,
@@ -354,8 +353,6 @@ export const card = handleActions(
     [API_UPDATE_QUESTION]: { next: (state, { payload }) => payload },
 
     [CANCEL_DATASET_CHANGES]: { next: (state, { payload }) => payload.card },
-
-    [SET_TEMPLATE_TAG]: { next: (state, { payload }) => payload },
 
     [UPDATE_QUESTION]: (state, { payload: { card } }) => card,
 

--- a/frontend/test/metabase-lib/lib/queries/NativeQuery.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/queries/NativeQuery.unit.spec.js
@@ -6,8 +6,6 @@ import {
   MONGO_DATABASE,
 } from "__support__/sample_database_fixture";
 
-import { createMockParameter } from "metabase-types/api/mocks";
-
 import NativeQuery, {
   recognizeTemplateTags,
   cardIdFromTagName,
@@ -290,11 +288,11 @@ describe("NativeQuery", () => {
       const newQuery = oldQuery.setTemplateTag(
         "t1",
         oldQuery.templateTagsMap()["t1"],
-        createMockParameter({
+        {
           values_query_type: "search",
           values_source_type: "static-list",
           values_source_config: { values: ["A"] },
-        }),
+        },
       );
 
       const newParameters = newQuery.question().parameters();

--- a/frontend/test/metabase-lib/lib/queries/NativeQuery.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/queries/NativeQuery.unit.spec.js
@@ -6,6 +6,8 @@ import {
   MONGO_DATABASE,
 } from "__support__/sample_database_fixture";
 
+import { createMockParameter } from "metabase-types/api/mocks";
+
 import NativeQuery, {
   recognizeTemplateTags,
   cardIdFromTagName,
@@ -266,6 +268,28 @@ describe("NativeQuery", () => {
         );
         expect(q.templateTags().map(v => v["card-id"])).toEqual([1, 2, 1]);
       });
+    });
+  });
+  describe("values source settings", () => {
+    it("should allow setting source settings for tags", () => {
+      const oldQuery = makeQuery().setQueryText(
+        "SELECT * FROM PRODUCTS WHERE {{t1}} AND {{t2}}",
+      );
+      const newQuery = oldQuery.setTemplateTag(
+        "t1",
+        oldQuery.templateTagsMap()["t1"],
+        createMockParameter({
+          values_query_type: "search",
+          values_source_type: "static-list",
+          values_source_config: { values: ["A"] },
+        }),
+      );
+
+      const newParameters = newQuery.question().parameters();
+      expect(newParameters).toHaveLength(2);
+      expect(newParameters[0].values_query_type).toEqual("search");
+      expect(newParameters[0].values_source_type).toEqual("static-list");
+      expect(newParameters[0].values_source_config).toEqual({ values: ["A"] });
     });
   });
   describe("variables", () => {

--- a/frontend/test/metabase-lib/lib/queries/NativeQuery.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/queries/NativeQuery.unit.spec.js
@@ -271,6 +271,18 @@ describe("NativeQuery", () => {
     });
   });
   describe("values source settings", () => {
+    it("should preserve the order of templates tags when updating", () => {
+      const oldQuery = makeQuery().setQueryText(
+        "SELECT * FROM PRODUCTS WHERE {{t1}} AND {{t2}}",
+      );
+      const newQuery = oldQuery.setTemplateTag(
+        "t1",
+        oldQuery.templateTagsMap()["t1"],
+      );
+
+      expect(oldQuery.templateTags()).toEqual(newQuery.templateTags());
+    });
+
     it("should allow setting source settings for tags", () => {
       const oldQuery = makeQuery().setQueryText(
         "SELECT * FROM PRODUCTS WHERE {{t1}} AND {{t2}}",


### PR DESCRIPTION
Epic https://github.com/metabase/metabase/issues/26898

This is some preparation work required by the epic that shouldn't change how the application works. The key thing here is that we make it possible to define additional properties for the parameter associated with a template tag, and they would be preserved when re-generating parameters based on template-tags.

Previously it was possible to generate `parameters` for a native card from `template-tags` in all cases. Now we want to specify some options for a parameter associated with a template tag without adding this information to the tag itself. New unit tests in `NativeQuery.unit.spec.ts` explain the new behavior.

How to test:
- CI should be green

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/27863)
<!-- Reviewable:end -->
