### PR TITLE
Introduce driver feature for testing JVM timezone setting

### DIFF
--- a/modules/drivers/athena/src/metabase/driver/athena.clj
+++ b/modules/drivers/athena/src/metabase/driver/athena.clj
@@ -42,6 +42,10 @@
 (defmethod driver/supports? [:athena :nested-fields] [_ _] false #_true) ; huh? Not sure why this was `true`. Disabled
                                                                          ; for now.
 
+(defmethod driver/database-supports? [:athena :test/jvm-timezone-setting]
+  [_driver _feature _database]
+  false)
+
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                     metabase.driver.sql-jdbc method impls                                      |
 ;;; +----------------------------------------------------------------------------------------------------------------+

--- a/modules/drivers/mongo/src/metabase/driver/mongo.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo.clj
@@ -257,6 +257,10 @@
       :semantic-version
       (driver.u/semantic-version-gte [4 2])))
 
+(defmethod driver/database-supports? [:mongo :test/jvm-timezone-setting]
+  [_driver _feature _database]
+  false)
+
 (defmethod driver/mbql->native :mongo
   [_ query]
   (mongo.qp/mbql->native query))

--- a/modules/drivers/redshift/src/metabase/driver/redshift.clj
+++ b/modules/drivers/redshift/src/metabase/driver/redshift.clj
@@ -25,6 +25,10 @@
 
 (driver/register! :redshift, :parent #{:postgres ::sql-jdbc.legacy/use-legacy-classes-for-read-and-set})
 
+(defmethod driver/database-supports? [:redshift :test/jvm-timezone-setting]
+  [_driver _feature _database]
+  false)
+
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                             metabase.driver impls                                              |
 ;;; +----------------------------------------------------------------------------------------------------------------+

--- a/modules/drivers/sparksql/src/metabase/driver/sparksql.clj
+++ b/modules/drivers/sparksql/src/metabase/driver/sparksql.clj
@@ -193,4 +193,8 @@
 (when-not (get (methods driver/supports?) [:sparksql :foreign-keys])
   (defmethod driver/supports? [:sparksql :foreign-keys] [_ _] true))
 
+(defmethod driver/database-supports? [:sparksql :test/jvm-timezone-setting]
+  [_driver _feature _database]
+  false)
+
 (defmethod sql.qp/quote-style :sparksql [_] :mysql)

--- a/modules/drivers/sqlserver/src/metabase/driver/sqlserver.clj
+++ b/modules/drivers/sqlserver/src/metabase/driver/sqlserver.clj
@@ -40,6 +40,9 @@
 (defmethod driver/database-supports? [:sqlserver :convert-timezone]
   [_driver _feature _database]
   true)
+(defmethod driver/database-supports? [:sqlserver :test/jvm-timezone-setting]
+  [_driver _feature _database]
+  false)
 
 (defmethod driver/db-start-of-week :sqlserver
   [_]

--- a/modules/drivers/vertica/src/metabase/driver/vertica.clj
+++ b/modules/drivers/vertica/src/metabase/driver/vertica.clj
@@ -35,6 +35,10 @@
   [_driver _feature _database]
   true)
 
+(defmethod driver/database-supports? [:vertica :test/jvm-timezone-setting]
+  [_driver _feature _database]
+  false)
+
 (defmethod driver/db-start-of-week :vertica
   [_]
   :monday)

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -492,7 +492,7 @@
     ;; implement [[execute-write-query!]]
     :actions/custom
 
-    ;; Does changing the JVM timezone allow producing correct results?
+    ;; Does changing the JVM timezone allow producing correct results? (See #27876 for details.)
     :test/jvm-timezone-setting})
 
 (defmulti supports?

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -490,7 +490,10 @@
 
     ;; Does the driver support custom writeback actions. Drivers that support this must
     ;; implement [[execute-write-query!]]
-    :actions/custom})
+    :actions/custom
+
+    ;; Does changing the JVM timezone allow producing correct results?
+    :test/jvm-timezone-setting})
 
 (defmulti supports?
   "Does this driver support a certain `feature`? (A feature is a keyword, and can be any of the ones listed above in
@@ -514,6 +517,7 @@
 (defmethod supports? [::driver :date-arithmetics] [_ _] true)
 (defmethod supports? [::driver :temporal-extract] [_ _] true)
 (defmethod supports? [::driver :convert-timezone] [_ _] false)
+(defmethod supports? [::driver :test/jvm-timezone-setting] [_ _] true)
 
 (defmulti database-supports?
   "Does this driver and specific instance of a database support a certain `feature`?

--- a/src/metabase/driver/h2.clj
+++ b/src/metabase/driver/h2.clj
@@ -36,13 +36,14 @@
 ;;; |                                             metabase.driver impls                                              |
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
-(doseq [[feature supported?] {:full-join               false
-                              :regex                   true
-                              :percentile-aggregations false
-                              :actions                 true
-                              :actions/custom          true
-                              :datetime-diff           true
-                              :now                     true}]
+(doseq [[feature supported?] {:full-join                 false
+                              :regex                     true
+                              :percentile-aggregations   false
+                              :actions                   true
+                              :actions/custom            true
+                              :datetime-diff             true
+                              :now                       true
+                              :test/jvm-timezone-setting false}]
   (defmethod driver/database-supports? [:h2 feature]
     [_driver _feature _database]
     supported?))

--- a/test/metabase/query_processor_test/date_bucketing_test.clj
+++ b/test/metabase/query_processor_test/date_bucketing_test.clj
@@ -274,7 +274,7 @@
   ;; timezone
   ;;
   ;; TIMEZONE FIXME
-  (mt/test-drivers (mt/normal-drivers-except #{:h2 :sqlserver :redshift :sparksql :mongo :athena})
+  (mt/test-drivers (mt/normal-drivers-with-feature :test/jvm-timezone-setting)
     (testing "Change JVM timezone from UTC to Pacific"
       (is (= (cond
                (= :sqlite driver/*driver*)
@@ -526,7 +526,7 @@
     ;; timezone
     ;;
     ;; TIMEZONE FIXME
-    (mt/test-drivers (mt/normal-drivers-except #{:h2 :sqlserver :redshift :sparksql :mongo :vertica :athena})
+    (mt/test-drivers (mt/normal-drivers-with-feature :test/jvm-timezone-setting)
       (is (= (cond
                (= :sqlite driver/*driver*)
                (results-by-day u.date/parse date-without-time-format-fn [6 10 4 9 9 8 8 9 7 9])


### PR DESCRIPTION
Related to #27829.

This PR introduces the `:test/jvm-timezone-setting` feature flag so that third party drivers can easily opt out from testing with JVM timezone manipulation.