### PR TITLE
Rename GTAP table and clean up orphans

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/sandbox/api/table.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/api/table.clj
@@ -22,11 +22,11 @@
   [table-or-table-id user-or-user-id]
   (some->> (mdb.query/query
             {:select [:c.id :c.dataset_query]
-             :from   [[:group_table_access_policy :gtap]]
-             :join   [[:permissions_group_membership :pgm] [:= :gtap.group_id :pgm.group_id]
-                      [:report_card :c] [:= :c.id :gtap.card_id]]
+             :from   [[:sandboxes]]
+             :join   [[:permissions_group_membership :pgm] [:= :sandboxes.group_id :pgm.group_id]
+                      [:report_card :c] [:= :c.id :sandboxes.card_id]]
              :where  [:and
-                      [:= :gtap.table_id (u/the-id table-or-table-id)]
+                      [:= :sandboxes.table_id (u/the-id table-or-table-id)]
                       [:= :pgm.user_id (u/the-id user-or-user-id)]]})
            first
            (models/do-post-select Card)))

--- a/enterprise/backend/src/metabase_enterprise/sandbox/models/group_table_access_policy.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/models/group_table_access_policy.clj
@@ -134,10 +134,11 @@
     (if-let [id (:id sandbox)]
       ;; Only update `card_id` and/or `attribute_remappings` if the values are present in the body of the request.
       ;; This allows existing values to be "cleared" by being set to nil
-      (when (some #(contains? sandbox %) [:card_id :attribute_remappings])
-        (db/update! GroupTableAccessPolicy
-                    id
-                    (u/select-keys-when sandbox :present #{:card_id :attribute_remappings}))
+      (do
+        (when (some #(contains? sandbox %) [:card_id :attribute_remappings])
+          (db/update! GroupTableAccessPolicy
+                      id
+                      (u/select-keys-when sandbox :present #{:card_id :attribute_remappings})))
         (db/select-one GroupTableAccessPolicy :id id))
       (let [expected-permission-path (perms/table-segmented-query-path (:table_id sandbox))]
         (when-let [permission-path-id (db/select-one-field :id Permissions :object expected-permission-path)]

--- a/enterprise/backend/src/metabase_enterprise/sandbox/models/group_table_access_policy.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/models/group_table_access_policy.clj
@@ -10,6 +10,7 @@
    [metabase.mbql.normalize :as mbql.normalize]
    [metabase.models.card :as card :refer [Card]]
    [metabase.models.interface :as mi]
+   [metabase.models.permissions :as perms :refer [Permissions]]
    [metabase.models.table :as table]
    [metabase.plugins.classloader :as classloader]
    [metabase.public-settings.premium-features :refer [defenterprise]]
@@ -20,10 +21,9 @@
    [metabase.util.schema :as su]
    [schema.core :as s]
    [toucan.db :as db]
-   [toucan.models :as models]
-   [metabase.models.permissions :as perms :refer [Permissions]]))
+   [toucan.models :as models]))
 
-(models/defmodel GroupTableAccessPolicy :group_table_access_policy)
+(models/defmodel GroupTableAccessPolicy :sandboxes)
 
 ;;; only admins can work with GTAPs
 (derive GroupTableAccessPolicy ::mi/read-policy.superuser)

--- a/enterprise/backend/src/metabase_enterprise/sandbox/models/group_table_access_policy.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/models/group_table_access_policy.clj
@@ -132,16 +132,16 @@
   [sandboxes]
   (for [sandbox sandboxes]
     (if-let [id (:id sandbox)]
+      ;; Only update `card_id` and/or `attribute_remappings` if the values are present in the body of the request.
+      ;; This allows existing values to be "cleared" by being set to nil
+      (when (some #(contains? sandbox %) [:card_id :attribute_remappings])
+        (db/update! GroupTableAccessPolicy
+                    id
+                    (u/select-keys-when sandbox :present #{:card_id :attribute_remappings}))
+        (db/select-one GroupTableAccessPolicy :id id))
       (let [expected-permission-path (perms/table-segmented-query-path (:table_id sandbox))]
         (when-let [permission-path-id (db/select-one-field :id Permissions :object expected-permission-path)]
-          ;; Only update `card_id` and/or `attribute_remappings` if the values are present in the body of the request.
-          ;; This allows existing values to be "cleared" by being set to nil
-          (when (some #(contains? sandbox %) [:card_id :attribute_remappings])
-            (db/update! GroupTableAccessPolicy
-                        id
-                        (u/select-keys-when sandbox :present #{:card_id :attribute_remappings})))
-          (db/select-one GroupTableAccessPolicy :id id)))
-      (db/insert! GroupTableAccessPolicy sandbox))))
+          (db/insert! GroupTableAccessPolicy (assoc sandbox :permission_id permission-path-id)))))))
 
 (defn- pre-insert [gtap]
   (u/prog1 gtap

--- a/enterprise/backend/src/metabase_enterprise/sandbox/models/permissions/delete_sandboxes.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/models/permissions/delete_sandboxes.clj
@@ -18,10 +18,10 @@
       (log/debugf "Deleting GTAPs for Group %d with conditions %s" (u/the-id group-or-id) (pr-str conditions))
       (try
         (if-let [gtap-ids (not-empty (set (map :id (mdb.query/query
-                                                    {:select    [[:gtap.id :id]]
-                                                     :from      [[:group_table_access_policy :gtap]]
+                                                    {:select    [[:sandboxes.id :id]]
+                                                     :from      [[:sandboxes]]
                                                      :left-join [[:metabase_table :table]
-                                                                 [:= :gtap.table_id :table.id]]
+                                                                 [:= :sandboxes.table_id :table.id]]
                                                      :where     conditions}))))]
           (do
             (log/debugf "Deleting %d matching GTAPs: %s" (count gtap-ids) (pr-str gtap-ids))

--- a/enterprise/backend/src/metabase_enterprise/sandbox/models/permissions/delete_sandboxes.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/models/permissions/delete_sandboxes.clj
@@ -13,7 +13,7 @@
   (when (seq condition)
     (let [conditions (into
                       [:and
-                       [:= :gtap.group_id (u/the-id group-or-id)]]
+                       [:= :sandboxes.group_id (u/the-id group-or-id)]]
                       [condition])]
       (log/debugf "Deleting GTAPs for Group %d with conditions %s" (u/the-id group-or-id) (pr-str conditions))
       (try

--- a/enterprise/backend/test/metabase_enterprise/sandbox/api/gtap_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/api/gtap_test.clj
@@ -203,7 +203,6 @@
       (premium-features-test/with-premium-features #{:sandboxes}
         (with-gtap-cleanup
           (testing "Test that we can create a new sandbox using the permission graph API"
-            ;; TODO: add sandbox to graph itself
             (let [graph  (assoc (assoc-in (perms/data-perms-graph)
                                           [:groups group-id (mt/id) :data :schemas "PUBLIC" table-id-1 :query]
                                           :segmented)
@@ -231,7 +230,6 @@
                                     :sandboxes [{:id                   sandbox-id
                                                  :card_id              card-id-2
                                                  :attribute_remappings {"foo" 2}}])
-
                   result     (mt/user-http-request :crowberto :put 200 "permissions/graph" graph)]
               (is (partial= [{:table_id table-id-1 :group_id group-id}]
                             (:sandboxes result)))

--- a/enterprise/backend/test/metabase_enterprise/sandbox/api/gtap_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/api/gtap_test.clj
@@ -26,6 +26,7 @@
    :card_id              true
    :table_id             true
    :group_id             true
+   :permission_id        false
    :attribute_remappings {:foo 1}})
 
 (defmacro ^:private with-gtap-cleanup
@@ -194,26 +195,33 @@
 
 (deftest bulk-upsert-sandboxes-test
   (testing "PUT /api/permissions/graph"
-    (mt/with-temp* [Table                  [{table-id-1 :id}]
-                    Table                  [{table-id-2 :id}]
+    (mt/with-temp* [Table                  [{table-id-1 :id} {:db_id (mt/id), :schema "PUBLIC"}]
+                    Table                  [{table-id-2 :id} {:db_id (mt/id), :schema "PUBLIC"}]
                     PermissionsGroup       [{group-id :id}]
                     Card                   [{card-id-1 :id}]
                     Card                   [{card-id-2 :id}]]
       (premium-features-test/with-premium-features #{:sandboxes}
         (with-gtap-cleanup
           (testing "Test that we can create a new sandbox using the permission graph API"
-            (let [graph  (assoc (perms/data-perms-graph)
-                                :sandboxes [{:table_id             table-id-1
-                                             :group_id             group-id
-                                             :card_id              card-id-1
-                                             :attribute_remappings {"foo" 1}}])
+            ;; TODO: add sandbox to graph itself
+            (let [graph  (assoc (assoc-in (perms/data-perms-graph)
+                                          [:groups group-id (mt/id) :data :schemas "PUBLIC" table-id-1 :query]
+                                          :segmented)
+                                :sandboxes
+                                [{:table_id             table-id-1
+                                  :group_id             group-id
+                                  :card_id              card-id-1
+                                  :attribute_remappings {"foo" 1}}])
                   result (mt/user-http-request :crowberto :put 200 "permissions/graph" graph)]
-              (is (partial= [{:table_id table-id-1 :group_id group-id}]
-                            (:sandboxes result)))
-              (is (db/exists? GroupTableAccessPolicy
-                              :table_id table-id-1
-                              :group_id group-id
-                              :card_id  card-id-1))))
+              (is (schema=
+                   [{:id                   s/Int
+                     :table_id             (s/eq table-id-1)
+                     :group_id             (s/eq group-id)
+                     :card_id              (s/eq card-id-1)
+                     :attribute_remappings (s/eq {:foo 1})
+                     :permission_id        s/Int}]
+                   (:sandboxes result)))
+              (is (db/exists? GroupTableAccessPolicy :table_id table-id-1 :group_id group-id))))
 
           (testing "Test that we can update a sandbox using the permission graph API"
             (let [sandbox-id (db/select-one-field :id GroupTableAccessPolicy
@@ -223,6 +231,7 @@
                                     :sandboxes [{:id                   sandbox-id
                                                  :card_id              card-id-2
                                                  :attribute_remappings {"foo" 2}}])
+
                   result     (mt/user-http-request :crowberto :put 200 "permissions/graph" graph)]
               (is (partial= [{:table_id table-id-1 :group_id group-id}]
                             (:sandboxes result)))
@@ -236,7 +245,9 @@
             (let [sandbox-id (db/select-one-field :id GroupTableAccessPolicy
                                                   :table_id table-id-1
                                                   :group_id group-id)
-                  graph      (assoc (perms/data-perms-graph)
+                  graph      (assoc (assoc-in (perms/data-perms-graph)
+                                              [:groups group-id (mt/id) :data :schemas "PUBLIC" table-id-2 :query]
+                                              :segmented)
                                     :sandboxes [{:id                   sandbox-id
                                                  :card_id              card-id-1
                                                  :attribute_remappings {"foo" 3}}

--- a/enterprise/backend/test/metabase_enterprise/sandbox/api/permissions_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/api/permissions_test.clj
@@ -107,6 +107,7 @@
                                         :group_id             (s/eq (u/the-id &group))
                                         :table_id             (s/eq (u/the-id db-2-table))
                                         :card_id              (s/eq nil)
+                                        :permission_id        (s/eq nil)
                                         :attribute_remappings (s/eq nil)}
                                        "GTAP")]
                                (db/select GroupTableAccessPolicy
@@ -117,6 +118,7 @@
                                         :group_id             (s/eq (u/the-id other-group))
                                         :table_id             (s/eq (mt/id :venues))
                                         :card_id              (s/eq nil)
+                                        :permission_id        (s/eq nil)
                                         :attribute_remappings (s/eq nil)}
                                        "GTAP")]
                                (db/select GroupTableAccessPolicy :group_id (u/the-id other-group)))))))))))))

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -14066,6 +14066,7 @@ databaseChangeLog:
           - column:
               name: permission_id
               type: int
+              remarks: The ID of the corresponding permissions path for this sandbox
               constraints:
                 foreignKeyName: fk_sandboxes_ref_permissions
                 nullable: true
@@ -14086,6 +14087,8 @@ databaseChangeLog:
                 p.object LIKE '%/table/' || s.table_id || '/query/segmented/'
                 AND p.group_id = s.group_id
             );
+      rollback:
+        # not required, new values added here are dropped in the rollback of v46.00-065
 
   - changeSet:
       id: v46.00-067
@@ -14095,6 +14098,8 @@ databaseChangeLog:
         - sql: >-
             DELETE FROM sandboxes
             WHERE permission_id IS NULL;
+      rollback:
+        # not required, orphaned sandboxes should not be re-added to the DB
 
 # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -14067,11 +14067,6 @@ databaseChangeLog:
               name: permission_id
               type: int
               remarks: The ID of the corresponding permissions path for this sandbox
-              constraints:
-                foreignKeyName: fk_sandboxes_ref_permissions
-                nullable: true
-                referencedTableName: permissions
-                referencedColumnNames: id
 
   - changeSet:
       id: v46.00-066
@@ -14100,6 +14095,19 @@ databaseChangeLog:
             WHERE permission_id IS NULL;
       rollback:
         # not required, orphaned sandboxes should not be re-added to the DB
+
+  - changeSet:
+      id: v46.00-075
+      author: noahmoss
+      comment: Add foreign key constraint on sandboxes.permission_id
+      changes:
+        - addForeignKeyConstraint:
+            baseTableName: sandboxes
+            baseColumnNames: permission_id
+            referencedTableName: permissions
+            referencedColumnNames: id
+            constraintName: fk_sandboxes_ref_permissions
+            nullable: true
 
 # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -14046,6 +14046,55 @@ databaseChangeLog:
             constraintName: fk_action_creator_id
             nullable: false
 
+  - changeSet:
+      id: v46.00-064
+      author: noahmoss
+      comment: Added 0.46.0 -- rename `group_table_access_policy` to `sandboxes`
+      changes:
+        - renameTable:
+            newTableName: sandboxes
+            oldTableName: group_table_access_policy
+
+  - changeSet:
+      id: v46.00-065
+      author: noahmoss
+      comment: Added 0.46.0 -- add `permission_id` to `sandboxes`
+      changes:
+      - addColumn:
+          tableName: sandboxes
+          columns:
+          - column:
+              name: permission_id
+              type: int
+              constraints:
+                foreignKeyName: fk_sandboxes_ref_permissions
+                nullable: true
+                referencedTableName: permissions
+                referencedColumnNames: id
+
+  - changeSet:
+      id: v46.00-066
+      author: noahmoss
+      comment: Added 0.46.0 -- backfill `permission_id` values in `sandboxes`
+      changes:
+        - sql: >-
+            UPDATE sandboxes s
+            SET permission_id = (
+              SELECT id
+              FROM permissions p
+              WHERE
+                p.object LIKE '%/table/' || s.table_id || '/query/segmented/'
+                AND p.group_id = s.group_id
+            );
+
+  - changeSet:
+      id: v46.00-067
+      author: noahmoss
+      comment: Added 0.46.0 -- remove orphaned entries in `sandboxes`
+      changes:
+        - sql: >-
+            DELETE FROM sandboxes
+            WHERE permission_id IS NULL;
 
 # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -14084,7 +14084,7 @@ databaseChangeLog:
               SELECT id
               FROM permissions p
               WHERE
-                p.object LIKE '%/table/' || s.table_id || '/query/segmented/'
+                p.object LIKE CONCAT('%/table/', s.table_id, '/query/segmented/')
                 AND p.group_id = s.group_id
             );
       rollback:

--- a/src/metabase/api/permissions.clj
+++ b/src/metabase/api/permissions.clj
@@ -79,8 +79,8 @@
                          :error explained
                          :humanized (me/humanize explained)}))))
     (db/transaction
-      (perms/update-data-perms-graph! (dissoc graph :sandboxes))
-      (if-let [sandboxes (:sandboxes body)]
+     (perms/update-data-perms-graph! (dissoc graph :sandboxes))
+     (if-let [sandboxes (:sandboxes body)]
        (let [new-sandboxes (upsert-sandboxes! sandboxes)]
          (assoc (perms/data-perms-graph) :sandboxes new-sandboxes))
        (perms/data-perms-graph)))))

--- a/test/metabase/db/schema_migrations_test.clj
+++ b/test/metabase/db/schema_migrations_test.clj
@@ -26,6 +26,7 @@
             Database
             Dimension
             Field
+            Permissions
             Pulse
             Setting
             Table
@@ -833,3 +834,35 @@
           (is (= #{"F1 D2"
                    "F2 D1"}
                  (db/select-field :name Dimension {:order-by [[:id :asc]]}))))))))
+
+(deftest clean-up-gtap-table-test
+  (testing "Migrations v46.00-064 to v46.00-067: rename `group_table_access_policy` table, add `permission_id` FK,
+           and clean up orphaned rows"
+    (impl/test-migrations ["v46.00-064" "v46.00-067"] [migrate!]
+      (let [db-id    (db/simple-insert! Database {:name       "DB"
+                                                  :engine     "h2"
+                                                  :created_at :%now
+                                                  :updated_at :%now
+                                                  :details    "{}"})
+            table-id (db/simple-insert! Table {:db_id      db-id
+                                               :name       "Table"
+                                               :created_at :%now
+                                               :updated_at :%now
+                                               :active     true})
+            _        (db/execute! {:insert-into :group_table_access_policy
+                                   :values      [{:group_id             1
+                                                  :table_id             table-id
+                                                  :attribute_remappings "{\"foo\", 1}"}
+                                                 {:group_id             2
+                                                  :table_id             table-id
+                                                  :attribute_remappings "{\"foo\", 1}"}]})
+            perm-id  (db/simple-insert! Permissions {:group_id 1
+                                                     :object   "/db/1/schema/PUBLIC/table/1/query/segmented/"})]
+          ;; Two rows are present in `group_table_access_policy`
+          (is (= [{:id 1, :group_id 1, :table_id table-id, :card_id nil, :attribute_remappings "{\"foo\", 1}"}
+                  {:id 2, :group_id 2, :table_id table-id, :card_id nil, :attribute_remappings "{\"foo\", 1}"}]
+                 (mdb.query/query {:select [:*] :from [:group_table_access_policy]})))
+          (migrate!)
+          ;; Only the sandbox with a corresponding `Permissions` row is present, and the table is renamed to `sandboxes`
+          (is (= [{:id 1, :group_id 1, :table_id table-id, :card_id nil, :attribute_remappings "{\"foo\", 1}", :permission_id perm-id}]
+                 (mdb.query/query {:select [:*] :from [:sandboxes]})))))))


### PR DESCRIPTION
Pursuant to https://github.com/metabase/metabase/issues/27053

Adds four new migrations concerning the `group_table_access_policy` (GTAP) table:
1. Renames it to `sandboxes`
2. Adds a `permission_id` foreign key column
3. For each existing sandbox, looks for the corresponding row in the `permissions` table (i.e. the one with a `/segmented/` path for that group and table), and backfills the `permission_id` value
4. Deletes sandboxes that don't have a backfilled `permission_id`

The end state should be a `sandboxes` table that only contains sandboxes actively reflected by the current permissions graph.

I've also
* Modified `upsert-sandboxes!` to add the corresponding permission path ID when writing a new sandbox.
* Updated a couple pieces of honeysql in the codebase that to use the new `:sandboxes` table name
* Added a test for the migration, and modified the test for `upsert-sandboxes!` to reflect the new behavior

Note, I'm not modifying most places in the code that use the term `group_table_access_policy` or `GTAP` quite yet. That'll come in a separate PR.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/27880)
<!-- Reviewable:end -->
