### PR TITLE
CI: Fix snowplow schema check

### DIFF
--- a/.github/workflows/snowplow.yml
+++ b/.github/workflows/snowplow.yml
@@ -11,9 +11,8 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-20.04
-    container: snowplow/igluctl:0.6.0
     steps:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Lint
-        run: igluctl lint snowplow
+        run: docker run -v $(pwd):/snowplow snowplow/igluctl:0.6.0 lint snowplow


### PR DESCRIPTION
For some reasons, snowplow/igluctl as the service container in GitHub Action workflow does not work anymore. Therefore, just invoke it directly with `docker run`.

### Before this PR

Checking those Snowplow schemas is busted (e.g. see [this failed CI log](https://github.com/metabase/metabase/actions/runs/4009346303/jobs/6884679578)), with the message `Error relocating /__e/node16_alpine/bin/node: getentropy: symbol not found`:

![image](https://user-images.githubusercontent.com/7288/214745565-cc9541d1-4465-4955-896a-80c8c0b27762.png)

### After this PR

It works again, as expected:

```
OK: com.metabase/account/jsonschema/1-0-0
OK: com.metabase/dashboard/jsonschema/1-0-0
OK: com.metabase/database/jsonschema/1-0-0
OK: com.metabase/instance/jsonschema/1-0-0
OK: com.metabase/instance/jsonschema/1-1-0
OK: com.metabase/instance/jsonschema/1-1-1
OK: com.metabase/invite/jsonschema/1-0-0
OK: com.metabase/invite/jsonschema/1-0-1
OK: com.metabase/question/jsonschema/1-0-0
OK: com.metabase/question/jsonschema/1-0-1
OK: com.metabase/settings/jsonschema/1-0-0
OK: com.metabase/settings/jsonschema/1-0-1
OK: com.metabase/setup/jsonschema/1-0-0
OK: com.metabase/setup/jsonschema/1-0-1
OK: com.metabase/task/jsonschema/1-0-0
OK: com.metabase/timeline/jsonschema/1-0-0
TOTAL: 16 valid schemas
TOTAL: 0 schemas didn't pass validation
```
