### PR TITLE
Pass source settings via parameter for template tags

### DIFF
--- a/frontend/src/metabase-types/types/Query.ts
+++ b/frontend/src/metabase-types/types/Query.ts
@@ -3,11 +3,6 @@
  * @deprecated use existing types from, or add to metabase-types/api/*
  */
 
-import {
-  ValuesQueryType,
-  ValuesSourceConfig,
-  ValuesSourceType,
-} from "metabase-types/api";
 import { DatetimeUnit } from "metabase-types/api/query";
 import { TableId } from "./Table";
 import { FieldId, BaseType } from "./Field";
@@ -65,11 +60,6 @@ export type TemplateTag = {
   // Snippet specific
   "snippet-id"?: number;
   "snippet-name"?: string;
-
-  // Values source
-  values_query_type?: ValuesQueryType;
-  values_source_type?: ValuesSourceType;
-  values_source_config?: ValuesSourceConfig;
 };
 
 export type TemplateTags = { [key: TemplateTagName]: TemplateTag };

--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx
@@ -84,19 +84,19 @@ export class TagEditorParam extends Component {
   }
 
   setQueryType = queryType => {
-    const { tag, setTemplateTag } = this.props;
+    const { tag, parameter, setTemplateTag } = this.props;
 
-    setTemplateTag({
-      ...tag,
+    setTemplateTag(tag, {
+      ...parameter,
       values_query_type: queryType,
     });
   };
 
   setSourceSettings = (sourceType, sourceConfig) => {
-    const { tag, setTemplateTag } = this.props;
+    const { tag, parameter, setTemplateTag } = this.props;
 
-    setTemplateTag({
-      ...tag,
+    setTemplateTag(tag, {
+      ...parameter,
       values_source_type: sourceType,
       values_source_config: sourceConfig,
     });

--- a/frontend/test/metabase/scenarios/native-filters/sql-filters-source.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native-filters/sql-filters-source.cy.spec.js
@@ -191,7 +191,7 @@ const getQuestionResource = questionId => ({
   params: {},
 });
 
-const getTargetQuestion = tag => ({
+const getTargetQuestion = ({ tag, parameter }) => ({
   name: "Embedded",
   native: {
     query: "SELECT * FROM PRODUCTS WHERE {{tag}}",
@@ -206,6 +206,16 @@ const getTargetQuestion = tag => ({
       },
     },
   },
+  parameters: [
+    {
+      id: "93961154-c3d5-7c93-7b59-f4e494fda499",
+      name: "Tag",
+      slug: "tag",
+      type: "string/=",
+      target: ["dimension", ["template-tag", "tag"]],
+      ...parameter,
+    },
+  ],
   enable_embedding: true,
   embedding_params: {
     tag: "enabled",
@@ -214,32 +224,44 @@ const getTargetQuestion = tag => ({
 
 const getStructuredTargetQuestion = questionId => {
   return getTargetQuestion({
-    dimension: ["field", PRODUCTS.CATEGORY, null],
-    values_source_type: "card",
-    values_source_config: {
-      card_id: questionId,
-      value_field: ["field", PRODUCTS.CATEGORY, null],
+    tag: {
+      dimension: ["field", PRODUCTS.CATEGORY, null],
+    },
+    parameter: {
+      values_source_type: "card",
+      values_source_config: {
+        card_id: questionId,
+        value_field: ["field", PRODUCTS.CATEGORY, null],
+      },
     },
   });
 };
 
 const getNativeTargetQuestion = questionId => {
   return getTargetQuestion({
-    dimension: ["field", PRODUCTS.EAN, null],
-    values_source_type: "card",
-    values_source_config: {
-      card_id: questionId,
-      value_field: ["field", "EAN", { "base-type": "type/Text" }],
+    tag: {
+      dimension: ["field", PRODUCTS.EAN, null],
+    },
+    parameter: {
+      values_source_type: "card",
+      values_source_config: {
+        card_id: questionId,
+        value_field: ["field", "EAN", { "base-type": "type/Text" }],
+      },
     },
   });
 };
 
 const getListTargetQuestion = () => {
   return getTargetQuestion({
-    dimension: ["field", PRODUCTS.EAN, null],
-    values_source_type: "static-list",
-    values_source_config: {
-      values: ["1018947080336", "7663515285824"],
+    tag: {
+      dimension: ["field", PRODUCTS.EAN, null],
+    },
+    parameter: {
+      values_source_type: "static-list",
+      values_source_config: {
+        values: ["1018947080336", "7663515285824"],
+      },
     },
   });
 };


### PR DESCRIPTION
Epic https://github.com/metabase/metabase/issues/26898

This PR uses new `parameter` argument from https://github.com/metabase/metabase/pull/27863 to set source settings.

How to test:
- New -> SQL Query -> `SELECT * FROM PRODUCTS WHERE {{x}}` -> Field Filter -> Dropdown -> Edit
- Making sure it is possible to change options in the modal and get them saved in the question

<img width="1086" alt="Screenshot 2023-01-26 at 16 44 27" src="https://user-images.githubusercontent.com/8542534/214865610-2fa0fd0d-2d31-4899-bcb1-65c1a7c4b975.png">

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/27894)
<!-- Reviewable:end -->
