### PR TITLE
Allow setting values config for "search box" parameters

### DIFF
--- a/frontend/src/metabase-lib/parameters/utils/template-tags.ts
+++ b/frontend/src/metabase-lib/parameters/utils/template-tags.ts
@@ -1,6 +1,6 @@
 import _ from "underscore";
 
-import { Parameter, ParameterConfig } from "metabase-types/api";
+import { Parameter, ValuesConfig } from "metabase-types/api";
 import type { ParameterTarget } from "metabase-types/types/Parameter";
 import type { Card } from "metabase-types/types/Card";
 import type { TemplateTag } from "metabase-types/types/Query";
@@ -32,7 +32,7 @@ export function getTemplateTagParameterTarget(
 
 export function getTemplateTagParameter(
   tag: TemplateTag,
-  config?: ParameterConfig,
+  config?: ValuesConfig,
 ): ParameterWithTarget {
   return {
     id: tag.id,

--- a/frontend/src/metabase-lib/queries/NativeQuery.ts
+++ b/frontend/src/metabase-lib/queries/NativeQuery.ts
@@ -6,7 +6,7 @@ import _ from "underscore";
 import slugg from "slugg";
 import { humanize } from "metabase/lib/formatting";
 import Utils from "metabase/lib/utils";
-import { ParameterConfig } from "metabase-types/api";
+import { ValuesConfig } from "metabase-types/api";
 import {
   Card,
   DatasetQuery,
@@ -389,7 +389,7 @@ export default class NativeQuery extends AtomicQuery {
     return tagErrors.length === 0;
   }
 
-  setTemplateTag(name: string, tag: TemplateTag, config?: ParameterConfig) {
+  setTemplateTag(name: string, tag: TemplateTag, config?: ValuesConfig) {
     const newQuery = this.setDatasetQuery(
       updateIn(this.datasetQuery(), ["native", "template-tags"], tags => ({
         ...tags,

--- a/frontend/src/metabase-types/api/parameters.ts
+++ b/frontend/src/metabase-types/api/parameters.ts
@@ -32,7 +32,7 @@ export type ParameterId = string;
 
 export type ActionParameterValue = string | number;
 
-export interface Parameter extends ParameterConfig {
+export interface Parameter extends ValuesConfig {
   id: ParameterId;
   name: string;
   "display-name"?: string;
@@ -46,7 +46,7 @@ export interface Parameter extends ParameterConfig {
   value?: any;
 }
 
-export interface ParameterConfig {
+export interface ValuesConfig {
   values_query_type?: ValuesQueryType;
   values_source_type?: ValuesSourceType;
   values_source_config?: ValuesSourceConfig;

--- a/frontend/src/metabase/parameters/components/ValuesSourceSettings/ValuesSourceSettings.tsx
+++ b/frontend/src/metabase/parameters/components/ValuesSourceSettings/ValuesSourceSettings.tsx
@@ -99,7 +99,13 @@ const getRadioOptions = (
       value: "list",
     },
     {
-      name: <RadioLabel title={t`Search box`} />,
+      name: (
+        <RadioLabel
+          title={t`Search box`}
+          isSelected={queryType === "search"}
+          onEditClick={onEditClick}
+        />
+      ),
       value: "search",
     },
     {

--- a/frontend/src/metabase/parameters/components/ValuesSourceSettings/ValuesSourceSettings.unit.spec.tsx
+++ b/frontend/src/metabase/parameters/components/ValuesSourceSettings/ValuesSourceSettings.unit.spec.tsx
@@ -1,0 +1,47 @@
+import React from "react";
+import userEvent from "@testing-library/user-event";
+import { Parameter, ValuesQueryType } from "metabase-types/api";
+import { createMockParameter } from "metabase-types/api/mocks";
+import { renderWithProviders, screen } from "__support__/ui";
+import ValuesSourceSettings from "./ValuesSourceSettings";
+
+interface SetupOpts {
+  parameter: Parameter;
+}
+
+const setup = ({ parameter }: SetupOpts) => {
+  const onChangeQueryType = jest.fn();
+  const onChangeSourceSettings = jest.fn();
+
+  renderWithProviders(
+    <ValuesSourceSettings
+      parameter={parameter}
+      onChangeQueryType={onChangeQueryType}
+      onChangeSourceSettings={onChangeSourceSettings}
+    />,
+  );
+
+  return { onChangeQueryType, onChangeSourceSettings };
+};
+
+describe("ValuesSourceSettings", () => {
+  it.each<ValuesQueryType>(["list", "search"])(
+    "should allow changing values settings for %i",
+    (type: ValuesQueryType) => {
+      const { onChangeSourceSettings } = setup({
+        parameter: createMockParameter({
+          values_query_type: type,
+        }),
+      });
+
+      userEvent.click(screen.getByRole("button", { name: "Edit" }));
+      userEvent.click(screen.getByRole("radio", { name: "Custom list" }));
+      userEvent.type(screen.getByRole("textbox"), "A");
+      userEvent.click(screen.getByRole("button", { name: "Done" }));
+
+      expect(onChangeSourceSettings).toHaveBeenCalledWith("static-list", {
+        values: ["A"],
+      });
+    },
+  );
+});


### PR DESCRIPTION
Epic: https://github.com/metabase/metabase/issues/26898
Milestone: https://github.com/metabase/metabase/pull/27765

How to test:
- New -> SQL Query -> `SELECT {{tag}}`
- Type -> Field Filter -> Product -> Category, then change the search type from "Dropdown list" to "Search box".
- It should be possible to click `Edit` and edit values for the search

<img width="353" alt="Screenshot 2023-01-26 at 21 04 00" src="https://user-images.githubusercontent.com/8542534/214926382-8c864a0c-fa4f-4f22-a84d-fdd3c6ff97ea.png">

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/27904)
<!-- Reviewable:end -->
