### PR TITLE
Support action execution in public dashboards

### DIFF
--- a/frontend/src/metabase/actions/containers/ActionParametersInputForm/ActionParametersInputForm.tsx
+++ b/frontend/src/metabase/actions/containers/ActionParametersInputForm/ActionParametersInputForm.tsx
@@ -18,11 +18,12 @@ import type {
   ActionFormSettings,
 } from "metabase-types/api";
 
-import { ActionsApi } from "metabase/services";
+import { ActionsApi, PublicApi } from "metabase/services";
 import {
   shouldPrefetchValues,
   generateFieldSettingsFromParameters,
 } from "metabase/actions/utils";
+import { getDashboardType } from "metabase/dashboard/utils";
 
 import type Field from "metabase-lib/metadata/Field";
 
@@ -56,8 +57,13 @@ function ActionParametersInputForm({
 
   const shouldPrefetch = useMemo(() => shouldPrefetchValues(action), [action]);
 
+  const prefetchEndpoint =
+    getDashboardType(dashboard?.id) === "public"
+      ? PublicApi.prefetchValues
+      : ActionsApi.prefetchValues;
+
   const fetchInitialValues = useCallback(async () => {
-    const fetchedValues = await ActionsApi.prefetchValues({
+    const fetchedValues = await prefetchEndpoint({
       dashboardId: dashboard?.id,
       dashcardId: dashcard?.id,
       parameters: JSON.stringify(dashcardParamValues),
@@ -66,7 +72,7 @@ function ActionParametersInputForm({
     if (fetchedValues) {
       setPrefetchValues(fetchedValues);
     }
-  }, [dashboard?.id, dashcard?.id, dashcardParamValues]);
+  }, [dashboard?.id, dashcard?.id, dashcardParamValues, prefetchEndpoint]);
 
   useEffect(() => {
     const hasValueFromDashboard = Object.keys(dashcardParamValues).length > 0;

--- a/frontend/src/metabase/dashboard/actions/actions.ts
+++ b/frontend/src/metabase/dashboard/actions/actions.ts
@@ -7,7 +7,7 @@ import {
 
 import { addUndo } from "metabase/redux/undo";
 
-import { ActionsApi } from "metabase/services";
+import { ActionsApi, PublicApi } from "metabase/services";
 
 import type {
   ActionDashboardCard,
@@ -21,6 +21,7 @@ import type {
 } from "metabase-types/api";
 import type { Dispatch } from "metabase-types/store";
 
+import { getDashboardType } from "../utils";
 import { setDashCardAttributes } from "./core";
 import { reloadDashboardCards } from "./data-fetching";
 
@@ -91,7 +92,10 @@ export const executeRowAction = async ({
   dispatch,
   shouldToast = true,
 }: ExecuteRowActionPayload): Promise<ActionFormSubmitResult> => {
-  const executeAction = ActionsApi.execute;
+  const executeAction =
+    getDashboardType(dashboard.id) === "public"
+      ? PublicApi.executeAction
+      : ActionsApi.execute;
 
   try {
     const result = await executeAction({

--- a/frontend/src/metabase/dashboard/actions/actions.ts
+++ b/frontend/src/metabase/dashboard/actions/actions.ts
@@ -94,7 +94,7 @@ export const executeRowAction = async ({
 }: ExecuteRowActionPayload): Promise<ActionFormSubmitResult> => {
   const executeAction =
     getDashboardType(dashboard.id) === "public"
-      ? PublicApi.executeAction
+      ? PublicApi.executeDashcardAction
       : ActionsApi.execute;
 
   try {

--- a/frontend/src/metabase/services.js
+++ b/frontend/src/metabase/services.js
@@ -162,6 +162,9 @@ const PIVOT_PUBLIC_PREFIX = "/api/public/pivot/";
 
 export const PublicApi = {
   action: GET("/api/public/action/:uuid"),
+  executeDashcardAction: POST(
+    "/api/public/dashboard/:dashboardId/dashcard/:dashcardId/execute",
+  ),
   executeAction: POST("/api/public/action/:uuid/execute"),
   card: GET("/api/public/card/:uuid"),
   cardQuery: GET("/api/public/card/:uuid/query"),
@@ -174,9 +177,6 @@ export const PublicApi = {
     PIVOT_PUBLIC_PREFIX + "dashboard/:uuid/dashcard/:dashcardId/card/:cardId",
   ),
   prefetchValues: GET(
-    "/api/public/dashboard/:dashboardId/dashcard/:dashcardId/execute",
-  ),
-  executeAction: POST(
     "/api/public/dashboard/:dashboardId/dashcard/:dashcardId/execute",
   ),
 };

--- a/frontend/src/metabase/services.js
+++ b/frontend/src/metabase/services.js
@@ -173,6 +173,12 @@ export const PublicApi = {
   dashboardCardQueryPivot: GET(
     PIVOT_PUBLIC_PREFIX + "dashboard/:uuid/dashcard/:dashcardId/card/:cardId",
   ),
+  prefetchValues: GET(
+    "/api/public/dashboard/:dashboardId/dashcard/:dashcardId/execute",
+  ),
+  executeAction: POST(
+    "/api/public/dashboard/:dashboardId/dashcard/:dashcardId/execute",
+  ),
 };
 
 export const EmbedApi = {


### PR DESCRIPTION
resolves #27899 

## Description
Enables action execution (and update/prefetch values) endpoints in public dashboards.

## Testing Steps
- enable sharing in your metabase admin settings
- add one or more actions to a dashboard
- enable sharing on that dashboard
- visit the public version of a dashboard in incognito mode
- see that execution works

I also used https://github.com/metabase/embedding-demo to test that it works as a public embedded dashboard.

## Open Questions
- should we add additional warnings when sharing dashboards with actions? the potential consequences for "oops" are more serious here.