### PR TITLE
Add e2e test for public action page

### DIFF
--- a/frontend/src/metabase-types/api/mocks/actions.ts
+++ b/frontend/src/metabase-types/api/mocks/actions.ts
@@ -8,18 +8,20 @@ import {
 import { createMockNativeDatasetQuery } from "./query";
 import { createMockParameter } from "./parameters";
 
-export const createMockActionParameter = (
-  opts?: Partial<WritebackParameter>,
-): WritebackParameter => ({
-  target: opts?.target || ["variable", ["template-tag", "id"]],
-  ...createMockParameter({
-    id: "id",
+export const createMockActionParameter = ({
+  id = "id",
+  target = ["variable", ["template-tag", id]],
+  ...opts
+}: Partial<WritebackParameter> = {}): WritebackParameter => {
+  const parameter = createMockParameter({
+    id,
     name: "ID",
     type: "type/Integer",
     slug: "id",
     ...opts,
-  }),
-});
+  });
+  return { ...parameter, target };
+};
 
 export const createMockQueryAction = ({
   dataset_query = createMockNativeDatasetQuery(),

--- a/frontend/src/metabase/actions/containers/ActionCreator/InlineActionSettings.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/InlineActionSettings.tsx
@@ -57,7 +57,13 @@ export const ActionSettingsTriggerButton = ({
   onClick: () => void;
 }) => (
   <Tooltip tooltip={t`Action settings`}>
-    <Button onlyIcon onClick={onClick} icon="gear" iconSize={16} />
+    <Button
+      onlyIcon
+      onClick={onClick}
+      icon="gear"
+      iconSize={16}
+      aria-label={t`Action settings`}
+    />
   </Tooltip>
 );
 

--- a/frontend/test/metabase/scenarios/models/model-actions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/model-actions.cy.spec.js
@@ -1,0 +1,201 @@
+import {
+  enableActionsForDB,
+  modal,
+  popover,
+  restore,
+} from "__support__/e2e/helpers";
+import { SAMPLE_DB_TABLES } from "__support__/e2e/cypress_data";
+import { createMockActionParameter } from "metabase-types/api/mocks";
+
+const PG_DB_ID = 2;
+
+const SAMPLE_ORDERS_MODEL = {
+  name: "Order",
+  dataset: true,
+  display: "table",
+  query: {
+    "source-table": SAMPLE_DB_TABLES.STATIC_ORDERS_ID,
+  },
+};
+
+const TEST_PARAMETER = createMockActionParameter({
+  id: "49596bcb-62bb-49d6-a92d-bf5dbfddf43b",
+  name: "Total",
+  slug: "total",
+  type: "number/=",
+  target: ["variable", ["template-tag", "total"]],
+});
+
+const TEST_TEMPLATE_TAG = {
+  id: TEST_PARAMETER.id,
+  type: "number",
+  name: TEST_PARAMETER.slug,
+  "display-name": "Total",
+  slug: TEST_PARAMETER.slug,
+};
+
+const SAMPLE_QUERY_ACTION = {
+  name: "Demo Action",
+  type: "query",
+  parameters: [TEST_PARAMETER],
+  database_id: PG_DB_ID,
+  dataset_query: {
+    type: "native",
+    native: {
+      query: `DELETE FROM orders WHERE total < {{ ${TEST_TEMPLATE_TAG.name} }}`,
+      "template-tags": {
+        [TEST_TEMPLATE_TAG.name]: TEST_TEMPLATE_TAG,
+      },
+    },
+    database: PG_DB_ID,
+  },
+  visualization_settings: {
+    fields: {
+      [TEST_PARAMETER.id]: {
+        id: TEST_PARAMETER.id,
+        required: true,
+        fieldType: "number",
+        inputType: "number",
+      },
+    },
+  },
+};
+
+describe("scenarios > models > actions", () => {
+  beforeEach(() => {
+    restore("postgres-12");
+    cy.signInAsAdmin();
+
+    enableActionsForDB();
+    enableActionsForDB(PG_DB_ID);
+
+    cy.createQuestion(SAMPLE_ORDERS_MODEL, {
+      wrapId: true,
+      idAlias: "modelId",
+    });
+
+    cy.intercept("/api/card/*").as("getModel");
+  });
+
+  it("should allow to view, create and edit model actions", () => {
+    cy.get("@modelId").then(id => {
+      cy.visit(`/model/${id}/detail`);
+      cy.wait("@getModel");
+    });
+
+    cy.findByText("Actions").click();
+
+    cy.findByRole("button", { name: /Create basic actions/i }).click();
+    cy.findByLabelText("Action list").within(() => {
+      cy.findByText("Create").should("be.visible");
+      cy.findByText("Update").should("be.visible");
+      cy.findByText("Delete").should("be.visible");
+    });
+
+    cy.findByRole("button", { name: "New action" }).click();
+    fillQuery("DELETE FROM orders WHERE id = {{ id }}");
+    fieldSettings()
+      .findByText(/Number/i)
+      .click();
+    cy.findByRole("button", { name: "Save" }).click();
+    modal().within(() => {
+      cy.findByLabelText("Name").type("Delete Order");
+      cy.findByRole("button", { name: "Create" }).click();
+    });
+    cy.findByLabelText("Action list")
+      .findByText("Delete Order")
+      .should("be.visible");
+
+    openActionEditorFor("Delete Order");
+    fillQuery(" AND status = 'pending'");
+    fieldSettings()
+      .findByRole("radiogroup", { name: /Field type/i })
+      .findByLabelText(/Number/i)
+      .should("be.checked");
+    cy.findByRole("button", { name: "Update" }).click();
+
+    cy.findByLabelText("Action list")
+      .findByText(
+        "DELETE FROM orders WHERE id = {{ id }} AND status = 'pending'",
+      )
+      .should("be.visible");
+  });
+
+  it("should allow to make actions public and execute them", () => {
+    cy.intercept("/api/public/action/*/execute", request => {
+      expect(request.body).to.deep.equal({
+        parameters: { [TEST_PARAMETER.id]: -2 },
+      });
+    });
+
+    cy.get("@modelId").then(modelId => {
+      cy.request("POST", "/api/action", {
+        ...SAMPLE_QUERY_ACTION,
+        model_id: modelId,
+      });
+      cy.visit(`/model/${modelId}/detail`);
+      cy.wait("@getModel");
+    });
+
+    cy.findByText("Actions").click();
+    openActionEditorFor(SAMPLE_QUERY_ACTION.name);
+
+    cy.findByRole("dialog").within(() => {
+      cy.findByRole("button", { name: "Action settings" }).click();
+      cy.findByLabelText("Make public").should("not.be.checked").click();
+      cy.findByLabelText("Public action link URL")
+        .invoke("val")
+        .then(url => {
+          cy.wrap(url).as("publicUrl");
+        });
+    });
+
+    cy.get("@publicUrl").then(url => {
+      cy.signOut();
+      cy.visit(url);
+    });
+
+    cy.findByLabelText(TEST_PARAMETER.name).type("-2");
+    cy.findByRole("button", { name: "Submit" }).click();
+    cy.findByText("Thanks for your submission.").should("be.visible");
+    cy.findByRole("form").should("not.exist");
+    cy.findByRole("button", { name: "Submit" }).should("not.exist");
+
+    cy.signInAsAdmin();
+    cy.get("@modelId").then(modelId => {
+      cy.visit(`/model/${modelId}/detail`);
+      cy.wait("@getModel");
+    });
+
+    cy.findByText("Actions").click();
+    openActionEditorFor(SAMPLE_QUERY_ACTION.name);
+
+    cy.findByRole("dialog").within(() => {
+      cy.findByRole("button", { name: "Action settings" }).click();
+      cy.findByLabelText("Make public").should("be.checked").click();
+    });
+    modal().findByRole("button", { name: "Yes" }).click();
+
+    cy.get("@publicUrl").then(url => {
+      cy.visit(url);
+      cy.findByRole("form").should("not.exist");
+      cy.findByRole("button", { name: "Submit" }).should("not.exist");
+      cy.findByText("An error occurred.").should("be.visible");
+    });
+  });
+});
+
+function openActionEditorFor(actionName) {
+  cy.findByRole("listitem", { name: actionName }).within(() => {
+    cy.icon("pencil").click();
+  });
+}
+
+function fillQuery(query) {
+  cy.get(".ace_content").type(query, { parseSpecialCharSequences: false });
+}
+
+function fieldSettings() {
+  cy.findByTestId("action-form-editor").within(() => cy.icon("gear").click());
+  return popover();
+}

--- a/frontend/test/metabase/scenarios/models/model-actions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/model-actions.cy.spec.js
@@ -174,7 +174,10 @@ describe("scenarios > models > actions", () => {
       cy.findByRole("button", { name: "Action settings" }).click();
       cy.findByLabelText("Make public").should("be.checked").click();
     });
-    modal().findByRole("button", { name: "Yes" }).click();
+    modal().within(() => {
+      cy.findByText("Disable this public link?").should("be.visible");
+      cy.findByRole("button", { name: "Yes" }).click();
+    });
 
     cy.get("@publicUrl").then(url => {
       cy.visit(url);

--- a/frontend/test/metabase/scenarios/models/model-actions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/model-actions.cy.spec.js
@@ -94,9 +94,7 @@ describe("scenarios > models > actions", () => {
 
     cy.findByRole("button", { name: "New action" }).click();
     fillQuery("DELETE FROM orders WHERE id = {{ id }}");
-    fieldSettings()
-      .findByText(/Number/i)
-      .click();
+    fieldSettings().findByText("number").click();
     cy.findByRole("button", { name: "Save" }).click();
     modal().within(() => {
       cy.findByLabelText("Name").type("Delete Order");
@@ -109,8 +107,8 @@ describe("scenarios > models > actions", () => {
     openActionEditorFor("Delete Order");
     fillQuery(" AND status = 'pending'");
     fieldSettings()
-      .findByRole("radiogroup", { name: /Field type/i })
-      .findByLabelText(/Number/i)
+      .findByRole("radiogroup", { name: "Field type" })
+      .findByLabelText("number")
       .should("be.checked");
     cy.findByRole("button", { name: "Update" }).click();
 


### PR DESCRIPTION
Adds an E2E test to #27747 (public action page)

A few tricky parts:

**Postgres**

Seems like it's not currently possible to run actions with the sample H2 database. I had to switch the tests to use Postgres (see `restore("postgres-12")` instead of normal `restore()`).

**Action query**

We don't have a toolchain to set up database data for actions yet (being able to restore DB state between tests or programmatically create/drop it, whatever). Also, the BE doesn't accept `SELECT` queries for actions — it'd throw an error for any action query returning something back.

The test is using a query like `DELETE FROM orders WHERE total < {{ total }}` and makes the `total` parameter a negative number. We don't have any orders with a negative total, so the `DELETE` doesn't affect any records, but we can still test what's happening.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/27922)
<!-- Reviewable:end -->
