### PR TITLE
docs - dash sub update

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -78,7 +78,7 @@ Metabase's reference documentation.
 #### Sharing
 
 - [Sharing answers](./questions/sharing/answers.md)
-- [Setting and getting alerts](./questions/sharing/alerts.md)
+- [Alerts](./questions/sharing/alerts.md)
 - [Public sharing](./questions/sharing/public-links.md)
 
 ### Dashboards
@@ -195,10 +195,6 @@ Metabase's reference documentation.
 [Learn Metabase](https://www.metabase.com/learn) has a ton of articles on how to use Metabase, data best practices, and more.
 
 ## More resources
-
-### [Learn Metabase](https://www.metabase.com/learn)
-
-Guides on working with data.
 
 ### [Discussion](https://discourse.metabase.com)
 

--- a/docs/configuring-metabase/email.md
+++ b/docs/configuring-metabase/email.md
@@ -62,3 +62,12 @@ Check if [email quotas](https://docs.aws.amazon.com/ses/latest/dg/quotas.html) a
 
 * SSL is strongly recommended because it’s more secure and gives your account extra protection from threats.
 * If your email service has a whitelist of email addresses that are allowed to send email, be sure to whitelist the email address that you put in the **From Address** field to ensure you and your teammates receive all emails from Metabase.
+
+## Further reading
+
+- [Alerts](../questions/sharing/alerts.md)
+- [Dashboard subscriptions](../dashboards/subscriptions.md)
+- [Notification permissions](../permissions/notifications.md)
+- [Setting up Slack](./slack.md)
+- [Auditing Metabase](../usage-and-performance-tools/audit.md)
+

--- a/docs/configuring-metabase/slack.md
+++ b/docs/configuring-metabase/slack.md
@@ -75,3 +75,11 @@ In your Slack workspace, create a public channel named whatever you want — we 
 
 In Metabase, click on the **Save changes** button and that’s it! Metabase will automatically run a quick test to check that the API token and your dedicated Slack channel are working properly. If something goes wrong, it'll give you an error message.
 
+## Further reading
+
+- [Alerts](../questions/sharing/alerts.md)
+- [Dashboard subscriptions](../dashboards/subscriptions.md)
+- [Notification permissions](../permissions/notifications.md)
+- [Setting up email](./email.md)
+- [Auditing Metabase](../usage-and-performance-tools/audit.md)
+

--- a/docs/configuring-metabase/slack.md
+++ b/docs/configuring-metabase/slack.md
@@ -6,7 +6,7 @@ redirect_from:
 
 # Slack
 
-If you want to have your [Dashboard subscriptions][dashboard-subscriptions] sent to Slack channels (or people on Slack), an admin must first integrate your Metabase with Slack.
+If you want to have your [Dashboard subscriptions](../dashboards/subscriptions.md) or [alerts](../questions/sharing/alerts.md) sent to Slack channels (or people on Slack), an admin must first integrate your Metabase with Slack.
 
 ## Create your Slack App
 
@@ -75,4 +75,3 @@ In your Slack workspace, create a public channel named whatever you want — we 
 
 In Metabase, click on the **Save changes** button and that’s it! Metabase will automatically run a quick test to check that the API token and your dedicated Slack channel are working properly. If something goes wrong, it'll give you an error message.
 
-[dashboard-subscriptions]: ../dashboards/subscriptions.md

--- a/docs/dashboards/subscriptions.md
+++ b/docs/dashboards/subscriptions.md
@@ -27,13 +27,6 @@ Let's say we want to email a dashboard. We'll click on the **Email it** option i
 
 ![Dashboard subscription email options](./images/email-options.png)
 
-## How permissions work with dashboard subscriptions
-
-- **Recipients of dashboard subscriptions will be able to see whatever the creator of the dashboard subscription can see.** That is, people will get to see charts in their email or Slack _as if_ they had the subscription creator's permissions to view those charts, _regardless of whether their groups have permission to view those charts_.
-- **Admins can see and edit all subscriptions.** Admins can modify recipients, filters, or delete the subscription without affecting the subscription's permissions; the subscription will continue to send data based on the subscription's creator's permissions. 
-- **Non-admins only see their subscriptions, not subscriptions created by others.** People who are 1) not in the Admin group, and 2) not sandboxed, can only see the subscriptions they've created. They can add anyone in their Metabase to their subscriptions using the dropdown menu.
-- **People in data sandboxes can only send dashboard results to themselves.** People who are sandboxed will only see themselves in the list of recipients for dashboard subscriptions.
-
 ## Email subscription options
 
 For emails, we can:
@@ -84,7 +77,14 @@ Here's the sidebar where you can set the filter values:
 
 The section to call out here is the **Set filter values for when this gets sent**. Here we've set "VT" as the value for the dashboard's State filter to scope results to records from Vermont. We didn't set a value for the Created_At filter, so the subscription will send the results without a filter applied. If you've set a default value for the filter, the subscription will list the value here.
 
-## Related reading
+## How permissions work with dashboard subscriptions
 
+See [Notification permissions](../permissions/notifications.md).
+
+## Further reading
+
+- [Alerts](../questions/sharing/alerts.md)
+- [Notification permissions](../permissions/notifications.md)
 - [Setting up email](../configuring-metabase/email.md)
 - [Setting up Slack](../configuring-metabase/slack.md)
+- [Auditing Metabase](../../usage-and-performance-tools/audit.md)

--- a/docs/dashboards/subscriptions.md
+++ b/docs/dashboards/subscriptions.md
@@ -87,4 +87,4 @@ See [Notification permissions](../permissions/notifications.md).
 - [Notification permissions](../permissions/notifications.md)
 - [Setting up email](../configuring-metabase/email.md)
 - [Setting up Slack](../configuring-metabase/slack.md)
-- [Auditing Metabase](../../usage-and-performance-tools/audit.md)
+- [Auditing Metabase](../usage-and-performance-tools/audit.md)

--- a/docs/databases/connecting.md
+++ b/docs/databases/connecting.md
@@ -166,7 +166,7 @@ To forget the data that Metabase has stored from previous [database scans](#sync
 
 Metabase syncs and scans regularly, but if the database administrator has just changed the database schema, or if a lot of data is added automatically at specific times, you may want to write a script that uses the [Metabase API](https://www.metabase.com/learn/administration/metabase-api) to force a sync or scan. [Our API](../api-documentation.md) provides two ways to initiate a sync or scan of a database:
 
-1. Using a a session token:  the `/api/database/:id/sync_schema` or `api/database/:id/rescan_values` endpoints. These endpoints do the same things as going to the database in the Admin Panel and choosing **Sync database schema now** or **Re-scan field values now** respectively. To use these endpoints, you have to authenticate with a user ID and pass a session token in the header of your request.
+1. Using a session token:  the `/api/database/:id/sync_schema` or `api/database/:id/rescan_values` endpoints. These endpoints do the same things as going to the database in the Admin Panel and choosing **Sync database schema now** or **Re-scan field values now** respectively. To use these endpoints, you have to authenticate with a user ID and pass a session token in the header of your request.
 
 2. Using an API key: `/api/notify/db/:id`. We created this endpoint so that people could notify their Metabase to sync after an [ETL operation](https://www.metabase.com/learn/analytics/etl-landscape) finishes. To use this endpoint, you must pass an API key by defining the `MB_API_KEY` environment variable.
 

--- a/docs/people-and-groups/account-settings.md
+++ b/docs/people-and-groups/account-settings.md
@@ -6,7 +6,7 @@ redirect_from:
 
 # Account settings
 
-You can view your account settings by going to the top right of the screen and clicking on the **gear** icon > **Account settings**. 
+You can view your account settings by going to the top right of the screen and clicking on the **gear** icon > **Account settings**.
 
 ## Account profile
 
@@ -30,3 +30,7 @@ Whenever you log in from a new device, Metabase will send you an email just to l
 ## Disable animations in Metabase
 
 This isn't an in-Metabase setting, but just so you know: you can disable UI animations in Metabase (like sidebars sliding around, or rotating spinners) by changing the settings for your operating system so it respects the `prefers-reduced-motion` CSS media feature. This change will also affect other applications, not just Metabase. Check out the instructions for how to set the user preferences for your operating system in the [MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion#user_preferences).
+
+## Notifications
+
+If you subscribe or are added to dashboard subscriptions or alerts, you’ll be able to manage those notifications here (as well as on the relevant question or dashboard themselves).

--- a/docs/permissions/notifications.md
+++ b/docs/permissions/notifications.md
@@ -4,13 +4,15 @@ title: Notification permissions
 
 # Notification permissions
 
-How permissions work with dashboard subscriptions and alerts:
+Some notes on how permissions work with dashboard subscriptions and alerts:
 
-- **Recipients of the notification will be able to see whatever the creator of the notification can see.** That is, people will get to see charts in their email or Slack _as if_ they had the alert or subscription creator's permissions to view those charts, _regardless of whether their groups have permission to view those charts_.
-- **Admins can see and edit all notifications.** Admins can modify recipients, filters, or delete the subscription without affecting the subscription's permissions; the subscription will continue to send data based on the subscription's creator's permissions. Admins can edit alerts and subscriptions on the items themselves, or, if they have a paid plan, in the Admin panel under **Audit** > **Subscriptions and alerts**. 
-- **Non-admins only view and edit their subscriptions and alerts, not subscriptions created by others.** People who are 1) not in the Admin group, and 2) not sandboxed, can only see the subscriptions they've created. They can add anyone in their Metabase to their subscriptions using the dropdown menu.
-- **People in data sandboxes can only send notifications to themselves.** People who are sandboxed will only see themselves in the list of recipients for dashboard subscriptions and alerts.
-- **Everyone can view and manage their own notifications**. People can click on the **gear** icon and go to **Account settings** > **Notifications** to view and unsubscribe from any or all of their dashboard subscriptions and alerts.
+- **Recipients of notifications can see whatever the creator of the notification can see.** That is, people will get to see charts in their email or Slack _as if_ they had the alert or subscription creator's permissions to view those charts, _regardless of whether their groups have permission to view those charts_.
+- **Anyone can create and manage their own notifications**. In addition to the alert and subscription menus on questions and dashboards, people can click on the **gear** icon and go to **Account settings** > **Notifications** to view and unsubscribe from any or all of their dashboard subscriptions and alerts.
+- **Anyone can add people via email or Slack to a subscription or alert that they created**. Again, the data Metabase sends to the added recipients depends on the person who created the notification, not the recipient.
+- **Some paid plans can restrict which domains Metabase can email.** See [approved domains](../configuring-metabase/settings.md#approved-domains-for-notification). 
+- **Admins can see and edit all notifications.** Admins can modify recipients, filters, or delete the subscription without affecting the subscription's permissions; the subscription will continue to send data based on whoever originally created the subscription. Admins can edit alerts and subscriptions on the items themselves, or, if they have a paid plan, in the Admin panel under **Audit** > **Subscriptions and alerts**. See [Auditing Metabase](../usage-and-performance-tools/audit.md). 
+- **Non-admins can only view and edit notifications they created, not notifications created by others.**
+- **Provided the non-admin account isn't sandboxed, non-admins can add anyone in their Metabase to their subscriptions using the dropdown menu.** People who are sandboxed will only see themselves in the list of recipients for dashboard subscriptions and alerts that they create; they won't be able to see other Metabase accounts.
 
 ## Further reading
 

--- a/docs/permissions/notifications.md
+++ b/docs/permissions/notifications.md
@@ -1,0 +1,21 @@
+---
+title: Notification permissions
+---
+
+# Notification permissions
+
+How permissions work with dashboard subscriptions and alerts:
+
+- **Recipients of the notification will be able to see whatever the creator of the notification can see.** That is, people will get to see charts in their email or Slack _as if_ they had the alert or subscription creator's permissions to view those charts, _regardless of whether their groups have permission to view those charts_.
+- **Admins can see and edit all notifications.** Admins can modify recipients, filters, or delete the subscription without affecting the subscription's permissions; the subscription will continue to send data based on the subscription's creator's permissions. Admins can edit alerts and subscriptions on the items themselves, or, if they have a paid plan, in the Admin panel under **Audit** > **Subscriptions and alerts**. 
+- **Non-admins only view and edit their subscriptions and alerts, not subscriptions created by others.** People who are 1) not in the Admin group, and 2) not sandboxed, can only see the subscriptions they've created. They can add anyone in their Metabase to their subscriptions using the dropdown menu.
+- **People in data sandboxes can only send notifications to themselves.** People who are sandboxed will only see themselves in the list of recipients for dashboard subscriptions and alerts.
+- **Everyone can view and manage their own notifications**. People can click on the **gear** icon and go to **Account settings** > **Notifications** to view and unsubscribe from any or all of their dashboard subscriptions and alerts.
+
+## Further reading
+
+- [Dashboard subscriptions](../dashboards/subscriptions.md)
+- [Alerts](../questions/sharing/alerts.md)
+- [Auditing](../usage-and-performance-tools/audit.md)
+- 
+

--- a/docs/permissions/start.md
+++ b/docs/permissions/start.md
@@ -29,3 +29,7 @@ Granting group access to different Metabase features.
 ## [Data sandboxing](./data-sandboxes.md)
 
 Creating data sandboxes to restrict access to rows and columns in tables.
+
+## [Notification permissions](./notifications.md)
+
+Notes on how permissions interact with dashboard subscriptions and alerts.

--- a/docs/questions/sharing/alerts.md
+++ b/docs/questions/sharing/alerts.md
@@ -1,10 +1,10 @@
 ---
-title: Setting and getting alerts
+title: Alerts
 redirect_from:
   - /docs/latest/users-guide/15-alerts
 ---
 
-# Setting and getting alerts
+# Alerts
 
 Whether you're keeping track of revenue, users, or negative reviews, there are often times when you want to be alerted about something. Metabase has a few different kinds of alerts you can set up, and you can choose to be notified via email or Slack.
 
@@ -74,13 +74,26 @@ Here's more information about [setting up email integration](../../configuring-m
 
 There are a few ways alerts can be stopped:
 
-- Regular users can unsubscribe from any alert that they're a recipient of.
-- Admins can edit any alert and delete it entirely. This can't be undone, so be careful!
-- If a saved question that has an alert on it gets edited in such a way that the alert doesn't make sense anymore, the alert will get deleted. For example, if a saved question with a goal line alert on it gets edited, and the goal line is removed entirely, that alert will get deleted.
+- Non-admins can unsubscribe from any alert that they're a recipient of.
+- Admins can edit and delete any alert. This can't be undone, so be careful!
+- Admins on some paid plans can view, edit, and delete all dashboard subscriptions and alerts in the [Audit tab](../../usage-and-performance-tools/audit.md#subscriptions-and-alerts).
+- If a saved question that has an alert gets edited in such a way that the alert doesn't make sense anymore, the alert will get deleted. For example, if a saved question with a goal line alert on it gets edited, and the goal line is removed entirely, that alert will get deleted.
 - If a question gets archived, any alerts on it will be deleted.
 
 ## Viewing existing alerts
 
 {% include plans-blockquote.html feature="Audit logs" %}
 
-To view a list of all alerts and dashboard subscriptions that people have set up in your Metabase, click on the **gear** icon in the upper right and select **Admin settings** > **Audit** > **Subscriptions & Alerts**. See [Audit logs](../../usage-and-performance-tools/audit.md).
+To view a list of all alerts and dashboard subscriptions that people have set up in your Metabase, click on the **gear** icon in the upper right and select **Admin settings** > **Audit** > **Subscriptions & Alerts**. See [Audit](../../usage-and-performance-tools/audit.md#subscriptions-and-alerts).
+
+## How permissions work with alerts
+
+See [Notification permissions](../../permissions/notifications.md).
+
+## Further reading
+
+- [Dashboard subscriptions](../..dashboards/subscriptions.md)
+- [Notification permissions](../../permissions/notifications.md)
+- [Setting up email](../../configuring-metabase/email.md)
+- [Setting up Slack](../../configuring-metabase/slack.md)
+- [Auditing Metabase](../../usage-and-performance-tools/audit.md)

--- a/docs/questions/sharing/alerts.md
+++ b/docs/questions/sharing/alerts.md
@@ -92,7 +92,7 @@ See [Notification permissions](../../permissions/notifications.md).
 
 ## Further reading
 
-- [Dashboard subscriptions](../..dashboards/subscriptions.md)
+- [Dashboard subscriptions](../../dashboards/subscriptions.md)
 - [Notification permissions](../../permissions/notifications.md)
 - [Setting up email](../../configuring-metabase/email.md)
 - [Setting up Slack](../../configuring-metabase/slack.md)

--- a/docs/usage-and-performance-tools/audit.md
+++ b/docs/usage-and-performance-tools/audit.md
@@ -91,7 +91,7 @@ Use the __Downloads__ section to understand which people are downloading (or exp
 
 ### Subscriptions & Alerts
 
-Here Admins can get an overview of all of the [Dashboard subscriptions][dashboard-subscriptions] and [Alerts][alerts] that are currently active for that Metabase.
+Here admins can get an overview of all of the [dashboard subscriptions][dashboard-subscriptions] and [alerts][alerts] that are currently active for that Metabase.
 
 - Dashboard name (or Question name for Alerts)
 - Recipients
@@ -102,7 +102,11 @@ Here Admins can get an overview of all of the [Dashboard subscriptions][dashboar
 - Created At
 - Filters
 
-Admins can add and remove people from a subscription or alert by clicking on the item's __Recipients__. Admins can also delete the subscription or alert entirely by clicking on the **X** on the relevant line.
+Admins can add and remove people from a subscription or alert by clicking on the item's __Recipients__ number. Admins can also delete the subscription or alert entirely by clicking on the **X** on the relevant line.
+
+Everyone can view all of their subscriptions and alerts by clicking on the **gear** icon in the upper right and navigating to **Account settings** > **Notifications**.
+
+For more, see [how permissions work with dashboard subscriptions and alerts](../dashboards/subscriptions.md#how-permissions-work-with-dashboard-subscriptions.md).
 
 [alerts]: ../questions/sharing/alerts.md
 [dashboard-subscriptions]: ../dashboards/subscriptions.md


### PR DESCRIPTION
Adds a notifications permissions page to clarify how permissions interact with dashboard subscriptions and alerts.