### PR TITLE
Add error boundary to dashcards and visualizations

### DIFF
--- a/frontend/src/metabase/App.tsx
+++ b/frontend/src/metabase/App.tsx
@@ -1,4 +1,4 @@
-import React, { ErrorInfo, ReactNode, useState } from "react";
+import React, { ReactNode, useState } from "react";
 import { connect } from "react-redux";
 import { Location } from "history";
 
@@ -30,6 +30,7 @@ import { ContentViewportContext } from "metabase/core/context/ContentViewportCon
 import { AppErrorDescriptor, State } from "metabase-types/store";
 
 import { AppContainer, AppContent, AppContentContainer } from "./App.styled";
+import ErrorBoundary from "./ErrorBoundary";
 
 const getErrorComponent = ({ status, data, context }: AppErrorDescriptor) => {
   if (status === 403 || data?.error_code === "unauthorized") {
@@ -79,18 +80,6 @@ const mapStateToProps = (
 const mapDispatchToProps: AppDispatchProps = {
   onError: setErrorPage,
 };
-
-class ErrorBoundary extends React.Component<{
-  onError: (errorInfo: ErrorInfo) => void;
-}> {
-  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
-    this.props.onError(errorInfo);
-  }
-
-  render() {
-    return this.props.children;
-  }
-}
 
 function App({
   errorPage,

--- a/frontend/src/metabase/ErrorBoundary.tsx
+++ b/frontend/src/metabase/ErrorBoundary.tsx
@@ -1,0 +1,40 @@
+import React, { ErrorInfo } from "react";
+
+import { SmallGenericError } from "metabase/containers/ErrorPages";
+
+export default class ErrorBoundary extends React.Component<
+  {
+    onError: (errorInfo: ErrorInfo) => void;
+  },
+  {
+    hasError: boolean;
+    errorDetails: string;
+  }
+> {
+  constructor(props: any) {
+    super(props);
+    this.state = {
+      hasError: false,
+      errorDetails: "",
+    };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    // if we don't provide a specific onError action, the component will display a generic error message
+    if (this.props.onError) {
+      this.props.onError(errorInfo);
+    } else {
+      this.setState({
+        hasError: true,
+        errorDetails: errorInfo.componentStack,
+      });
+    }
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return <SmallGenericError details={this.state.errorDetails} />;
+    }
+    return this.props.children;
+  }
+}

--- a/frontend/src/metabase/ErrorBoundary.tsx
+++ b/frontend/src/metabase/ErrorBoundary.tsx
@@ -5,6 +5,7 @@ import { SmallGenericError } from "metabase/containers/ErrorPages";
 export default class ErrorBoundary extends React.Component<
   {
     onError?: (errorInfo: ErrorInfo) => void;
+    errorComponent?: Element;
   },
   {
     hasError: boolean;
@@ -17,6 +18,11 @@ export default class ErrorBoundary extends React.Component<
       hasError: false,
       errorDetails: "",
     };
+  }
+
+  static getDerivedStateFromError() {
+    // Update state so the next render will show the fallback UI.
+    return { hasError: true };
   }
 
   componentDidCatch(error: Error, errorInfo: ErrorInfo) {
@@ -32,8 +38,14 @@ export default class ErrorBoundary extends React.Component<
   }
 
   render() {
-    if (this.state.hasError) {
-      return <SmallGenericError details={this.state.errorDetails} />;
+    if (this.state.hasError && !this.props.onError) {
+      const ErrorComponent = this.props.errorComponent;
+
+      if (!ErrorComponent) {
+        return <SmallGenericError />;
+      }
+
+      return ErrorComponent;
     }
     return this.props.children;
   }

--- a/frontend/src/metabase/ErrorBoundary.tsx
+++ b/frontend/src/metabase/ErrorBoundary.tsx
@@ -4,7 +4,7 @@ import { SmallGenericError } from "metabase/containers/ErrorPages";
 
 export default class ErrorBoundary extends React.Component<
   {
-    onError: (errorInfo: ErrorInfo) => void;
+    onError?: (errorInfo: ErrorInfo) => void;
   },
   {
     hasError: boolean;

--- a/frontend/src/metabase/containers/ErrorPages.jsx
+++ b/frontend/src/metabase/containers/ErrorPages.jsx
@@ -56,13 +56,13 @@ export const Archived = ({ entityName, linkTo }) => (
   </ErrorPageRoot>
 );
 
-export const SmallGenericError = ({
-  title = t`Something's gone wrong`,
-  message = t`We've run into an error. You can try refreshing the page, or just go back.`,
-  details,
-}) => (
+export const SmallGenericError = ({ message = t`Something's gone wrong` }) => (
   <ErrorPageRoot>
-    <Icon name="warning" color={color("text-medium")} tooltip={title} />
-    <ErrorDetails className="pt2" details={details} centered />
+    <Icon
+      name="warning"
+      size={32}
+      color={color("text-light")}
+      tooltip={message}
+    />
   </ErrorPageRoot>
 );

--- a/frontend/src/metabase/containers/ErrorPages.jsx
+++ b/frontend/src/metabase/containers/ErrorPages.jsx
@@ -1,6 +1,7 @@
 /* eslint-disable react/prop-types */
 import React from "react";
 import { t } from "ttag";
+import { color } from "metabase/lib/colors";
 
 import Icon from "metabase/components/Icon";
 import EmptyState from "metabase/components/EmptyState";
@@ -52,5 +53,16 @@ export const Archived = ({ entityName, linkTo }) => (
       illustrationElement={<Icon name="view_archive" size={100} />}
       link={linkTo}
     />
+  </ErrorPageRoot>
+);
+
+export const SmallGenericError = ({
+  title = t`Something's gone wrong`,
+  message = t`We've run into an error. You can try refreshing the page, or just go back.`,
+  details,
+}) => (
+  <ErrorPageRoot>
+    <Icon name="warning" color={color("text-medium")} tooltip={title} />
+    <ErrorDetails className="pt2" details={details} centered />
   </ErrorPageRoot>
 );

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCard.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCard.tsx
@@ -20,6 +20,8 @@ import { isVirtualDashCard } from "metabase/dashboard/utils";
 
 import { isActionCard } from "metabase/actions/utils";
 
+import ErrorBoundary from "metabase/ErrorBoundary";
+
 import type {
   Card,
   CardId,
@@ -311,46 +313,48 @@ function DashCard({
   ]);
 
   return (
-    <DashCardRoot
-      className="Card rounded flex flex-column hover-parent hover--visibility"
-      hasHiddenBackground={hasHiddenBackground}
-      isNightMode={isNightMode}
-      isUsuallySlow={isSlow === "usually-slow"}
-      ref={cardRootRef}
-    >
-      {renderDashCardActions()}
-      <DashCardVisualization
-        dashboard={dashboard}
-        dashcard={dashcard}
-        series={series}
-        parameterValues={parameterValues}
-        parameterValuesBySlug={parameterValuesBySlug}
-        metadata={metadata}
-        mode={mode}
-        gridSize={gridSize}
-        gridItemWidth={gridItemWidth}
-        totalNumGridCols={totalNumGridCols}
-        headerIcon={headerIcon}
-        expectedDuration={expectedDuration}
-        error={error}
-        isAction={isAction}
-        isEmbed={isEmbed}
-        isEditing={isEditing}
-        isEditingDashCardClickBehavior={isEditingDashCardClickBehavior}
-        isEditingDashboardLayout={isEditingDashboardLayout}
-        isEditingParameter={isEditingParameter}
-        isClickBehaviorSidebarOpen={isClickBehaviorSidebarOpen}
-        isSlow={isSlow}
-        isPreviewing={isPreviewingCard}
-        isFullscreen={isFullscreen}
+    <ErrorBoundary>
+      <DashCardRoot
+        className="Card rounded flex flex-column hover-parent hover--visibility"
+        hasHiddenBackground={hasHiddenBackground}
         isNightMode={isNightMode}
-        isMobile={isMobile}
-        showClickBehaviorSidebar={showClickBehaviorSidebar}
-        onUpdateVisualizationSettings={onUpdateVisualizationSettings}
-        onChangeCardAndRun={changeCardAndRunHandler}
-        onChangeLocation={onChangeLocation}
-      />
-    </DashCardRoot>
+        isUsuallySlow={isSlow === "usually-slow"}
+        ref={cardRootRef}
+      >
+        {renderDashCardActions()}
+        <DashCardVisualization
+          dashboard={dashboard}
+          dashcard={dashcard}
+          series={series}
+          parameterValues={parameterValues}
+          parameterValuesBySlug={parameterValuesBySlug}
+          metadata={metadata}
+          mode={mode}
+          gridSize={gridSize}
+          gridItemWidth={gridItemWidth}
+          totalNumGridCols={totalNumGridCols}
+          headerIcon={headerIcon}
+          expectedDuration={expectedDuration}
+          error={error}
+          isAction={isAction}
+          isEmbed={isEmbed}
+          isEditing={isEditing}
+          isEditingDashCardClickBehavior={isEditingDashCardClickBehavior}
+          isEditingDashboardLayout={isEditingDashboardLayout}
+          isEditingParameter={isEditingParameter}
+          isClickBehaviorSidebarOpen={isClickBehaviorSidebarOpen}
+          isSlow={isSlow}
+          isPreviewing={isPreviewingCard}
+          isFullscreen={isFullscreen}
+          isNightMode={isNightMode}
+          isMobile={isMobile}
+          showClickBehaviorSidebar={showClickBehaviorSidebar}
+          onUpdateVisualizationSettings={onUpdateVisualizationSettings}
+          onChangeCardAndRun={changeCardAndRunHandler}
+          onChangeLocation={onChangeLocation}
+        />
+      </DashCardRoot>
+    </ErrorBoundary>
   );
 }
 

--- a/frontend/src/metabase/visualizations/components/Visualization/Visualization.jsx
+++ b/frontend/src/metabase/visualizations/components/Visualization/Visualization.jsx
@@ -30,6 +30,7 @@ import { isSameSeries } from "metabase/visualizations/lib/utils";
 import { getMode } from "metabase/modes/lib/modes";
 import { getFont } from "metabase/styled-components/selectors";
 
+import ErrorBoundary from "metabase/ErrorBoundary";
 import Question from "metabase-lib/Question";
 import Mode from "metabase-lib/Mode";
 import { datasetContainsNoResults } from "metabase-lib/queries/utils/dataset";
@@ -448,74 +449,76 @@ class Visualization extends React.PureComponent {
       (replacementContent && (dashcard.size_y !== 1 || isMobile));
 
     return (
-      <VisualizationRoot className={className} style={style}>
-        {!!hasHeader && (
-          <VisualizationHeader>
-            <ChartCaption
+      <ErrorBoundary>
+        <VisualizationRoot className={className} style={style}>
+          {!!hasHeader && (
+            <VisualizationHeader>
+              <ChartCaption
+                series={series}
+                settings={settings}
+                icon={headerIcon}
+                actionButtons={extra}
+                onChangeCardAndRun={
+                  this.props.onChangeCardAndRun && !replacementContent
+                    ? this.handleOnChangeCardAndRun
+                    : null
+                }
+              />
+            </VisualizationHeader>
+          )}
+          {replacementContent ? (
+            replacementContent
+          ) : isDashboard && noResults ? (
+            <NoResultsView isSmall={small} />
+          ) : error ? (
+            <ErrorView
+              error={error}
+              icon={errorIcon}
+              isSmall={small}
+              isDashboard={isDashboard}
+            />
+          ) : loading ? (
+            <LoadingView expectedDuration={expectedDuration} isSlow={isSlow} />
+          ) : (
+            <CardVisualization
+              {...this.props}
+              // NOTE: CardVisualization class used to target ExplicitSize HOC
+              className="CardVisualization flex-full flex-basis-none"
+              isPlaceholder={isPlaceholder}
               series={series}
               settings={settings}
-              icon={headerIcon}
-              actionButtons={extra}
+              card={series[0].card} // convenience for single-series visualizations
+              data={series[0].data} // convenience for single-series visualizations
+              hovered={hovered}
+              clicked={clicked}
+              headerIcon={hasHeader ? null : headerIcon}
+              onHoverChange={this.handleHoverChange}
+              onVisualizationClick={this.handleVisualizationClick}
+              visualizationIsClickable={this.visualizationIsClickable}
+              onRenderError={this.onRenderError}
+              onRender={this.onRender}
+              onActionDismissal={this.hideActions}
+              gridSize={gridSize}
               onChangeCardAndRun={
-                this.props.onChangeCardAndRun && !replacementContent
+                this.props.onChangeCardAndRun
                   ? this.handleOnChangeCardAndRun
                   : null
               }
             />
-          </VisualizationHeader>
-        )}
-        {replacementContent ? (
-          replacementContent
-        ) : isDashboard && noResults ? (
-          <NoResultsView isSmall={small} />
-        ) : error ? (
-          <ErrorView
-            error={error}
-            icon={errorIcon}
-            isSmall={small}
-            isDashboard={isDashboard}
-          />
-        ) : loading ? (
-          <LoadingView expectedDuration={expectedDuration} isSlow={isSlow} />
-        ) : (
-          <CardVisualization
-            {...this.props}
-            // NOTE: CardVisualization class used to target ExplicitSize HOC
-            className="CardVisualization flex-full flex-basis-none"
-            isPlaceholder={isPlaceholder}
-            series={series}
-            settings={settings}
-            card={series[0].card} // convenience for single-series visualizations
-            data={series[0].data} // convenience for single-series visualizations
-            hovered={hovered}
-            clicked={clicked}
-            headerIcon={hasHeader ? null : headerIcon}
-            onHoverChange={this.handleHoverChange}
-            onVisualizationClick={this.handleVisualizationClick}
-            visualizationIsClickable={this.visualizationIsClickable}
-            onRenderError={this.onRenderError}
-            onRender={this.onRender}
-            onActionDismissal={this.hideActions}
-            gridSize={gridSize}
-            onChangeCardAndRun={
-              this.props.onChangeCardAndRun
-                ? this.handleOnChangeCardAndRun
-                : null
-            }
-          />
-        )}
-        <ChartTooltip series={series} hovered={hovered} settings={settings} />
-        {this.props.onChangeCardAndRun && (
-          <ChartClickActions
-            clicked={clicked}
-            clickActions={clickActions}
-            onChangeCardAndRun={this.handleOnChangeCardAndRun}
-            onClose={this.hideActions}
-            series={series}
-            onUpdateVisualizationSettings={onUpdateVisualizationSettings}
-          />
-        )}
-      </VisualizationRoot>
+          )}
+          <ChartTooltip series={series} hovered={hovered} settings={settings} />
+          {this.props.onChangeCardAndRun && (
+            <ChartClickActions
+              clicked={clicked}
+              clickActions={clickActions}
+              onChangeCardAndRun={this.handleOnChangeCardAndRun}
+              onClose={this.hideActions}
+              series={series}
+              onUpdateVisualizationSettings={onUpdateVisualizationSettings}
+            />
+          )}
+        </VisualizationRoot>
+      </ErrorBoundary>
     );
   }
 }


### PR DESCRIPTION
## Description

- Extracts our top-level ErrorBoundary component to be more reusable
- Adds some basic default behavior to the ErrorBoundary component to make it easier to use
- Allows the default error component to be overidden for each error boundary
- Adds an ErrorBoundary to the dashcard  and visualizations components so that one erroring visualization won't crash a whole dashboard or the query builder

Before | After
--- | ---
one broken visualization breaks the whole app | one broken visualization breaks just that visualization!
![Screen Shot 2023-01-27 at 3 46 10 PM](https://user-images.githubusercontent.com/30528226/215220696-756d2ff8-d78f-460d-9b4f-ea45827e560f.png) |  ![Screen Shot 2023-01-30 at 1 16 21 PM](https://user-images.githubusercontent.com/30528226/215587026-72a64f27-6229-41a3-ad13-c66a63164c2a.png)
![Screen Shot 2023-01-30 at 1 25 27 PM](https://user-images.githubusercontent.com/30528226/215587306-961fd087-4d63-47dd-a825-b668266a8fae.png) | ![Screen Shot 2023-01-30 at 1 15 11 PM](https://user-images.githubusercontent.com/30528226/215587143-7a01c590-a548-40a1-8ad9-3a27f992ab52.png)
![Screen Shot 2023-01-30 at 1 29 28 PM](https://user-images.githubusercontent.com/30528226/215588095-846079b6-3b72-42d3-9b75-504399281037.png) | ![Screen Shot 2023-01-30 at 1 28 46 PM](https://user-images.githubusercontent.com/30528226/215588100-bf1da504-371b-4c5e-abbb-d65f8d50ecad.png)






## How to Test

- add a couple of questions to a dashboard with different visualizations
- pick your favorite visualization (we know it's LineAreaBarChart 😉 ), and add a `throw new Error('foo')` to the render() method.
- see that instead of the whole dashboard crashing, you get a little error message for just the broken visualization.
- open the query builder and select your broken visualization type 
- see that only the viz preview breaks! not the whole query builder!
- open the collections view and pin a broken viz
- see that only the viz preview for that item breaks! not the whole collection browser!