### PR TITLE
Unsaved questions param values

### DIFF
--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -4,7 +4,6 @@
    [cheshire.core :as json]
    [clojure.core.async :as a]
    [clojure.data :as data]
-   [clojure.string :as str]
    [clojure.tools.logging :as log]
    [clojure.walk :as walk]
    [compojure.core :refer [DELETE GET POST PUT]]
@@ -25,7 +24,6 @@
             CardBookmark
             Collection
             Database
-            Field
             PersistedInfo
             Pulse
             Table
@@ -915,27 +913,13 @@ saved later when it is ready."
       (persisted-info/mark-for-pruning! {:id (:id persisted-info)} "off")
       api/generic-204-no-content)))
 
-(defn field-id->values
-  "Fetch values for field id. If query is present, uses `api.field/search-values`, otherwise delegates to
-  `api.field/check-parms-and-return-field-values`."
-  [field-id query]
-  (if (str/blank? query)
-    (api.field/check-perms-and-return-field-values field-id)
-    (let [field (api/check-404 (db/select-one Field :id field-id))]
-      ;; matching the output of the other params. [["Foo" "Foo"] ["Bar" "Bar"]] -> [["Foo"] ["Bar"]]. This shape
-      ;; is what the return-field-values returns above
-      {:values (map (comp vector first) (api.field/search-values field field query))
-       ;; assume there are more
-       :has_more_values true
-       :field_id field-id})))
-
 (defn mapping->field-values
   "Get param values for the \"old style\" parameters. This mimic's the api/dashboard version except we don't have
   chain-filter issues or dashcards to worry about."
   [card param query]
   (when-let [field-clause (params/param-target->field-clause (:target param) card)]
     (when-let [field-id (mbql.u/match-one field-clause [:field (id :guard integer?) _] id)]
-      (field-id->values field-id query))))
+      (api.field/field-id->values field-id query))))
 
 (s/defn param-values
   "Fetch values for a parameter.

--- a/src/metabase/api/dataset.clj
+++ b/src/metabase/api/dataset.clj
@@ -209,6 +209,7 @@
                     {:status-code 400
                      :parameter parameter}))))
 
+#_{:clj-kondo/ignore [:deprecated-var]}
 (api/defendpoint-schema POST "/parameter/values"
   "Return parameter values for cards or dashboards that are being edited."
   [:as {{:keys [parameter field_ids]} :body}]
@@ -217,6 +218,7 @@
   (let [nil-query nil]
     (parameter-values parameter field_ids nil-query)))
 
+#_{:clj-kondo/ignore [:deprecated-var]}
 (api/defendpoint-schema POST "/parameter/search"
   "Return parameter values for cards or dashboards that are being edited. Expects a query string at `?query=foo`."
   [:as {{:keys [parameter field_ids]} :body} query]

--- a/src/metabase/api/dataset.clj
+++ b/src/metabase/api/dataset.clj
@@ -176,11 +176,11 @@
       (qp.pivot/run-pivot-query (assoc query :async? true) info context))))
 
 
-(def Parameter
+(def ^:private Parameter
   (su/open-schema
    {:values_source_type (s/enum nil "static-list" "card")}))
 
-(def FieldIds (s/maybe [s/Int]))
+(def ^:private FieldIds (s/maybe [s/Int]))
 
 (defn- parameter-field-values
   [field-ids query]

--- a/src/metabase/api/dataset.clj
+++ b/src/metabase/api/dataset.clj
@@ -219,9 +219,9 @@
     (parameter-values parameter field_ids nil-query)))
 
 #_{:clj-kondo/ignore [:deprecated-var]}
-(api/defendpoint-schema POST "/parameter/search"
+(api/defendpoint-schema POST "/parameter/search/:query"
   "Return parameter values for cards or dashboards that are being edited. Expects a query string at `?query=foo`."
-  [:as {{:keys [parameter field_ids]} :body} query]
+  [query :as {{:keys [parameter field_ids]} :body}]
   {parameter Parameter
    field_ids FieldIds
    query     s/Str}

--- a/src/metabase/api/dataset.clj
+++ b/src/metabase/api/dataset.clj
@@ -215,14 +215,16 @@
                      :parameter parameter}))))
 
 (api/defendpoint-schema POST "/parameter/values"
-  [:as {{:keys [parameter field_ids] :as body} :body}]
+  "Return parameter values for cards or dashboards that are being edited."
+  [:as {{:keys [parameter field_ids]} :body}]
   {parameter Parameter
    field_ids  FieldIds}
   (let [nil-query nil]
     (parameter-values parameter field_ids nil-query)))
 
 (api/defendpoint-schema POST "/parameter/search"
-  [:as {{:keys [parameter field_ids] :as body} :body} query]
+  "Return parameter values for cards or dashboards that are being edited. Expects a query string at `?query=foo`."
+  [:as {{:keys [parameter field_ids]} :body} query]
   {parameter Parameter
    field_ids FieldIds
    query     s/Str}

--- a/src/metabase/api/dataset.clj
+++ b/src/metabase/api/dataset.clj
@@ -5,8 +5,8 @@
    [clojure.string :as str]
    [clojure.tools.logging :as log]
    [compojure.core :refer [POST]]
-   [metabase.api.card :as api.card]
    [metabase.api.common :as api]
+   [metabase.api.field :as api.field]
    [metabase.events :as events]
    [metabase.mbql.normalize :as mbql.normalize]
    [metabase.mbql.schema :as mbql.s]
@@ -185,7 +185,7 @@
 (defn- parameter-field-values
   [field-ids query]
   (reduce (fn [resp id]
-            (let [{values :values more? :has_more_values} (api.card/field-id->values id query)]
+            (let [{values :values more? :has_more_values} (api.field/field-id->values id query)]
               (-> resp
                   (update :values concat values)
                   (update :has_more_values #(or % more?)))))

--- a/src/metabase/api/field.clj
+++ b/src/metabase/api/field.clj
@@ -1,5 +1,6 @@
 (ns metabase.api.field
   (:require
+   [clojure.string :as str]
    [clojure.tools.logging :as log]
    [compojure.core :refer [DELETE GET POST PUT]]
    [metabase.api.common :as api]
@@ -226,6 +227,21 @@
   (let [field (api/check-404 (db/select-one Field :id field-id))]
     (api/check-403 (params.field-values/current-user-can-fetch-field-values? field))
     (field->values field)))
+
+;; todo: we need to unify and untangle this stuff
+(defn field-id->values
+  "Fetch values for field id. If query is present, uses `api.field/search-values`, otherwise delegates to
+  `api.field/check-parms-and-return-field-values`."
+  [field-id query]
+  (if (str/blank? query)
+    (check-perms-and-return-field-values field-id)
+    (let [field (api/check-404 (db/select-one Field :id field-id))]
+      ;; matching the output of the other params. [["Foo" "Foo"] ["Bar" "Bar"]] -> [["Foo"] ["Bar"]]. This shape
+      ;; is what the return-field-values returns above
+      {:values (map (comp vector first) (search-values field field query))
+       ;; assume there are more
+       :has_more_values true
+       :field_id field-id})))
 
 ;; TODO -- not sure `has_field_values` actually has to be `:list` -- see code above.
 #_{:clj-kondo/ignore [:deprecated-var]}

--- a/test/metabase/api/dataset_test.clj
+++ b/test/metabase/api/dataset_test.clj
@@ -417,7 +417,7 @@
         (testing "search"
           (is (partial= {:values ["foo1" "foo2"]}
                         (mt/user-http-request :rasta :post 200
-                                              "dataset/parameter/search?query=fo"
+                                              "dataset/parameter/search/fo"
                                               {:parameter parameter}))))))
     (mt/with-temp* [Card [{card-id :id} {:database_id (mt/id)
                                          :dataset_query (mt/mbql-query products)}]]
@@ -440,7 +440,7 @@
               (is (= #{"Gizmo" "Widget" "Gadget" "Doohickey"} values))))
           (testing "search"
             (let [values (-> (mt/user-http-request :rasta :post 200
-                                                   "dataset/parameter/search?query=g"
+                                                   "dataset/parameter/search/g"
                                                    {:parameter parameter})
                              :values set)]
               (is (= #{"Gizmo" "Widget" "Gadget"} values)))))))
@@ -463,7 +463,7 @@
             (is (set/subset? #{["Doohickey"] ["Facebook"]} values))))
         (testing "search"
           (let [values (-> (mt/user-http-request :rasta :post 200
-                                                 "dataset/parameter/search?query=g"
+                                                 "dataset/parameter/search/g"
                                                  {:parameter parameter
                                                   :field_ids [(mt/id :products :category)
                                                               (mt/id :people :source)]})

--- a/test/metabase/api/dataset_test.clj
+++ b/test/metabase/api/dataset_test.clj
@@ -5,6 +5,7 @@
   (:require
    [cheshire.core :as json]
    [clojure.data.csv :as csv]
+   [clojure.set :as set]
    [clojure.string :as str]
    [clojure.test :refer :all]
    [medley.core :as m]
@@ -396,3 +397,77 @@
             (is (= ["AK" "Organic" 0 25] (second rows)))
             (is (= ["VA" nil 2 29] (nth rows 130)))
             (is (= [nil nil 3 2009] (last rows)))))))))
+
+(deftest parameter-values-test
+  (mt/dataset sample-dataset
+    (testing "static-list"
+      (let [parameter {:values_query_type "list",
+                       :values_source_type "static-list",
+                       :values_source_config {:values ["foo1" "foo2" "bar"]},
+                       :name "Text",
+                       :slug "text",
+                       :id "89e8bb5f",
+                       :type :string/=,
+                       :sectionId "string"}]
+        (testing "values"
+          (is (partial= {:values ["foo1" "foo2" "bar"]}
+                        (mt/user-http-request :rasta :post 200
+                                              "dataset/parameter/values"
+                                              {:parameter parameter}))))
+        (testing "search"
+          (is (partial= {:values ["foo1" "foo2"]}
+                        (mt/user-http-request :rasta :post 200
+                                              "dataset/parameter/search?query=fo"
+                                              {:parameter parameter}))))))
+    (mt/with-temp* [Card [{card-id :id} {:database_id (mt/id)
+                                         :dataset_query (mt/mbql-query products)}]]
+      (let [parameter {:values_query_type "list",
+                       :values_source_type "card",
+                       :values_source_config {:card_id card-id,
+                                              :value_field
+                                              [:field (mt/id :products :category) nil]},
+                       :name "Text 1",
+                       :slug "text_1",
+                       :id "2487b568",
+                       :type :string/=,
+                       :sectionId "string"}]
+        (testing "card"
+          (testing "values"
+            (let [values (-> (mt/user-http-request :rasta :post 200
+                                                   "dataset/parameter/values"
+                                                   {:parameter parameter})
+                             :values set)]
+              (is (= #{"Gizmo" "Widget" "Gadget" "Doohickey"} values))))
+          (testing "search"
+            (let [values (-> (mt/user-http-request :rasta :post 200
+                                                   "dataset/parameter/search?query=g"
+                                                   {:parameter parameter})
+                             :values set)]
+              (is (= #{"Gizmo" "Widget" "Gadget"} values)))))))
+    (testing "nil value (current behavior of field values)"
+      (let [parameter {:values_query_type "list",
+                       :values_source_type nil,
+                       :values_source_config {},
+                       :name "Text 2",
+                       :slug "text_2",
+                       :id "707f4bbf",
+                       :type :string/=,
+                       :sectionId "string"}]
+        (testing "values"
+          (let [values (-> (mt/user-http-request :rasta :post 200
+                                                 "dataset/parameter/values"
+                                                 {:parameter parameter
+                                                  :field_ids [(mt/id :products :category)
+                                                              (mt/id :people :source)]})
+                           :values set)]
+            (is (set/subset? #{["Doohickey"] ["Facebook"]} values))))
+        (testing "search"
+          (let [values (-> (mt/user-http-request :rasta :post 200
+                                                 "dataset/parameter/search?query=g"
+                                                 {:parameter parameter
+                                                  :field_ids [(mt/id :products :category)
+                                                              (mt/id :people :source)]})
+                           :values set)]
+            ;; results matched on g, does not include Doohickey (which is in above results)
+            (is (set/subset? #{["Widget"] ["Google"]} values))
+            (is (not (contains? values ["Doohickey"])))))))))

--- a/test/metabase/query_processor_test/date_time_zone_functions_test.clj
+++ b/test/metabase/query_processor_test/date_time_zone_functions_test.clj
@@ -408,7 +408,7 @@
     (testing "should work as an argument to datetime-add and datetime-subtract"
       (is (= true
              (-> (mt/run-mbql-query venues
-                   {:expressions {"1" [:datetime-subtract [:datetime-add [:now] 1 :month] 1 :month]}
+                   {:expressions {"1" [:datetime-subtract [:datetime-add [:now] 1 :day] 1 :day]}
                     :fields [[:expression "1"]]
                     :limit  1})
                  mt/rows
@@ -437,9 +437,9 @@
     (testing "should work in combination with datetime-diff and date-arithmetics"
       (is (= [1 1]
              (->> (mt/run-mbql-query venues
-                    {:expressions {"1" [:datetime-diff [:now] [:datetime-add [:now] 1 :month] :month]
+                    {:expressions {"1" [:datetime-diff [:now] [:datetime-add [:now] 1 :day] :day]
                                    "2" [:now]
-                                   "3" [:datetime-diff [:expression "2"] [:datetime-add [:expression "2"] 1 :month] :month]}
+                                   "3" [:datetime-diff [:expression "2"] [:datetime-add [:expression "2"] 1 :day] :day]}
                      :fields [[:expression "1"]
                               [:expression "3"]]
                      :limit  1})


### PR DESCRIPTION
Allow for two endpoints to service parameter values for use during dashboard and card creation. The key distinguisher here is that these cards or dashboards do not yet exist. There is no check to do against the the parameters saved on the card.

- `POST api/dataset/parameter/values`
- `POST api/dataset/parameter/search/foo`

> :warning:
> The api response does not currently deduplicate values from these queries. We will solve that in a follow up PR to do it comprehensively and in the correct location.

#### STATIC LIST VALUES

```
❯ http post "localhost:3000/api/dataset/parameter/values" \
   parameter:='{"values_source_type": "static-list", "values_source_config": {"values": ["foo", "bar"]}}' \
   Cookie:$SESSION -pb
{
    "has_more_values": false,
    "values": [
        "foo",
        "bar"
    ]
}
```

#### STATIC LIST SEARCH

```
❯ http post "localhost:3000/api/dataset/parameter/search/fo" \
   parameter:='{"values_source_type": "static-list", "values_source_config": {"values": ["foo", "bar"]}}' \
   Cookie:$SESSION -pb
{
    "has_more_values": false,
    "values": [
        "foo"
    ]
}
```

#### CARD VALUES

```
❯ http post "localhost:3000/api/dataset/parameter/values" \
   parameter:='{"values_source_type": "card", "values_source_config": {"card_id": 4, "value_field": ["field",58,null]}}' \
   Cookie:$SESSION -pb
{
    "has_more_values": false,
    "values": [
        "Gizmo",
        "Doohickey",
        "Doohickey",
        ...
        "Gizmo",
        "Widget",
        "Gadget"
    ]
}
```

#### CARD SEARCH

```
❯ http post "localhost:3000/api/dataset/parameter/search/ga" \
   parameter:='{"values_source_type": "card", "values_source_config": {"card_id": 4, "value_field": ["field",58,null]}}' \
   Cookie:$SESSION -pb
{
    "has_more_values": false,
    "values": [
        "Gadget",
        "Gadget",
        "Gadget",
        "Gadget",
        "Gadget",
        ...
        "Gadget",
        "Gadget",
        "Gadget"
    ]
}
```

#### FIELD VALUES

```
❯ http post "localhost:3000/api/dataset/parameter/values" \
   parameter:='{"values_source_type": null}' \
   field_ids:='[58, 3]' \
   Cookie:$SESSION -pb
{
    "has_more_values": false,
    "values": [
        [
            "Doohickey"
        ],
        [
            "Gadget"
        ],
        [
            "Gizmo"
        ],
        [
            "Widget"
        ],
        [
            null
        ],
        [
            "Facebook"
        ],
        [
            "Google"
        ],
        [
            "Invite"
        ],
        [
            "Twitter"
        ]
    ]
}
```

#### FIELD SEARCH

```
❯ http post "localhost:3000/api/dataset/parameter/search/g" \
   parameter:='{"values_source_type": null}' \
   field_ids:='[58, 3]' \
   Cookie:$SESSION -pb
{
    "has_more_values": true,
    "values": [
        [
            "Gadget"
        ],
        [
            "Gizmo"
        ],
        [
            "Widget"
        ],
        [
            "Google"
        ]
    ]
}
```
