### PR TITLE
Fix missing keys in Account settings > Login history

### DIFF
--- a/frontend/src/metabase/account/login-history/components/LoginHistory/LoginHistory.jsx
+++ b/frontend/src/metabase/account/login-history/components/LoginHistory/LoginHistory.jsx
@@ -30,7 +30,7 @@ const LoginHistoryItem = ({ item }) => (
         </Text>
       </div>
       <LoginItemInfo>
-        {item.active && <LoginActiveLabel pr={2}>Active</LoginActiveLabel>}
+        {item.active && <LoginActiveLabel pr={2}>{t`Active`}</LoginActiveLabel>}
         <Label>{item.time}</Label>
       </LoginItemInfo>
     </LoginItemContent>

--- a/frontend/src/metabase/account/login-history/components/LoginHistory/LoginHistory.jsx
+++ b/frontend/src/metabase/account/login-history/components/LoginHistory/LoginHistory.jsx
@@ -18,7 +18,7 @@ import {
 } from "./LoginHistory.styled";
 
 const LoginHistoryItem = item => (
-  <Card py={1} px="20px" my={2}>
+  <Card py={1} px="20px" my={2} key={item.timestamp}>
     <LoginItemContent>
       <div>
         <Label mb="0">
@@ -38,7 +38,7 @@ const LoginHistoryItem = item => (
 );
 
 const LoginHistoryGroup = (items, date) => (
-  <LoginGroup>
+  <LoginGroup key={date}>
     <Label>{date}</Label>
     <div>{items.map(LoginHistoryItem)}</div>
   </LoginGroup>

--- a/frontend/src/metabase/account/login-history/components/LoginHistory/LoginHistory.jsx
+++ b/frontend/src/metabase/account/login-history/components/LoginHistory/LoginHistory.jsx
@@ -37,8 +37,8 @@ const LoginHistoryItem = ({ item }) => (
   </Card>
 );
 
-const LoginHistoryGroup = (items, date) => (
-  <LoginGroup key={date}>
+const LoginHistoryGroup = ({ items, date }) => (
+  <LoginGroup>
     <Label>{date}</Label>
     <div>
       {items.map(item => (
@@ -73,7 +73,13 @@ function LoginHistoryList({ loginHistory }) {
     );
   }
 
-  return <div>{_.map(groups, LoginHistoryGroup)}</div>;
+  return (
+    <div>
+      {_.map(groups, (items, date) => (
+        <LoginHistoryGroup items={items} date={date} key={date} />
+      ))}
+    </div>
+  );
 }
 
 export default LoginHistoryList;

--- a/frontend/src/metabase/account/login-history/components/LoginHistory/LoginHistory.jsx
+++ b/frontend/src/metabase/account/login-history/components/LoginHistory/LoginHistory.jsx
@@ -17,8 +17,8 @@ import {
   LoginItemInfo,
 } from "./LoginHistory.styled";
 
-const LoginHistoryItem = item => (
-  <Card py={1} px="20px" my={2} key={item.timestamp}>
+const LoginHistoryItem = ({ item }) => (
+  <Card py={1} px="20px" my={2}>
     <LoginItemContent>
       <div>
         <Label mb="0">
@@ -40,7 +40,11 @@ const LoginHistoryItem = item => (
 const LoginHistoryGroup = (items, date) => (
   <LoginGroup key={date}>
     <Label>{date}</Label>
-    <div>{items.map(LoginHistoryItem)}</div>
+    <div>
+      {items.map(item => (
+        <LoginHistoryItem key={item.timestamp} item={item} />
+      ))}
+    </div>
   </LoginGroup>
 );
 


### PR DESCRIPTION
Before:
Console printed warnings for missing keys in both `Card` and `LoginHistoryGroup`

Now:
No warnings 🎉 