### PR TITLE
Simplify setting config for tags

### DIFF
--- a/frontend/src/metabase-lib/Question.ts
+++ b/frontend/src/metabase-lib/Question.ts
@@ -1132,9 +1132,9 @@ class QuestionInner {
     }
   }
 
-  setParameter(newParameter) {
+  setParameter(id: string, parameter) {
     const newParameters = this.parameters().map(oldParameter =>
-      oldParameter.id === newParameter.id ? newParameter : oldParameter,
+      oldParameter.id === id ? parameter : oldParameter,
     );
 
     return this.setParameters(newParameters);

--- a/frontend/src/metabase-lib/queries/NativeQuery.ts
+++ b/frontend/src/metabase-lib/queries/NativeQuery.ts
@@ -389,7 +389,7 @@ export default class NativeQuery extends AtomicQuery {
     return tagErrors.length === 0;
   }
 
-  setTemplateTag(name: string, tag: TemplateTag) {
+  setTemplateTag(name: string, tag: TemplateTag): NativeQuery {
     return this.setDatasetQuery(
       updateIn(this.datasetQuery(), ["native", "template-tags"], tags => ({
         ...tags,
@@ -398,10 +398,12 @@ export default class NativeQuery extends AtomicQuery {
     );
   }
 
-  setTemplateTagConfig(tag: TemplateTag, config: ParameterValuesConfig) {
-    return this.question()
-      .setParameter(tag.id, getTemplateTagParameter(tag, config))
-      .query() as NativeQuery;
+  setTemplateTagConfig(
+    tag: TemplateTag,
+    config: ParameterValuesConfig,
+  ): NativeQuery {
+    const newParameter = getTemplateTagParameter(tag, config);
+    return this.question().setParameter(tag.id, newParameter).query();
   }
 
   setDatasetQuery(datasetQuery: DatasetQuery): NativeQuery {

--- a/frontend/src/metabase-lib/queries/NativeQuery.ts
+++ b/frontend/src/metabase-lib/queries/NativeQuery.ts
@@ -389,21 +389,18 @@ export default class NativeQuery extends AtomicQuery {
     return tagErrors.length === 0;
   }
 
-  setTemplateTag(
-    name: string,
-    tag: TemplateTag,
-    config?: ParameterValuesConfig,
-  ) {
-    const newQuery = this.setDatasetQuery(
+  setTemplateTag(name: string, tag: TemplateTag) {
+    return this.setDatasetQuery(
       updateIn(this.datasetQuery(), ["native", "template-tags"], tags => ({
         ...tags,
         [name]: tag,
       })),
     );
+  }
 
-    return newQuery
-      .question()
-      .setParameter(getTemplateTagParameter(tag, config))
+  setTemplateTagConfig(tag: TemplateTag, config: ParameterValuesConfig) {
+    return this.question()
+      .setParameter(tag.id, getTemplateTagParameter(tag, config))
       .query() as NativeQuery;
   }
 

--- a/frontend/src/metabase/query_builder/actions/native.js
+++ b/frontend/src/metabase/query_builder/actions/native.js
@@ -145,14 +145,27 @@ export const insertSnippet = snip => (dispatch, getState) => {
 };
 
 export const SET_TEMPLATE_TAG = "metabase/qb/SET_TEMPLATE_TAG";
-export const setTemplateTag = createThunkAction(
-  SET_TEMPLATE_TAG,
+export const setTemplateTag = createThunkAction(SET_TEMPLATE_TAG, tag => {
+  return (dispatch, getState) => {
+    const question = getQuestion(getState());
+    const newQuestion = question
+      .query()
+      .setTemplateTag(tag.name, tag)
+      .question();
+
+    dispatch(updateQuestion(newQuestion));
+  };
+});
+
+export const SET_TEMPLATE_TAG_CONFIG = "metabase/qb/SET_TEMPLATE_TAG_CONFIG";
+export const setTemplateTagConfig = createThunkAction(
+  SET_TEMPLATE_TAG_CONFIG,
   (tag, parameter) => {
     return (dispatch, getState) => {
       const question = getQuestion(getState());
       const newQuestion = question
         .query()
-        .setTemplateTag(tag.name, tag, parameter)
+        .setTemplateTagConfig(tag, parameter)
         .question();
 
       dispatch(updateQuestion(newQuestion));

--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx
@@ -84,18 +84,18 @@ export class TagEditorParam extends Component {
   }
 
   setQueryType = queryType => {
-    const { tag, parameter, setTemplateTag } = this.props;
+    const { tag, parameter, setTemplateTagConfig } = this.props;
 
-    setTemplateTag(tag, {
+    setTemplateTagConfig(tag, {
       ...parameter,
       values_query_type: queryType,
     });
   };
 
   setSourceSettings = (sourceType, sourceConfig) => {
-    const { tag, parameter, setTemplateTag } = this.props;
+    const { tag, parameter, setTemplateTagConfig } = this.props;
 
-    setTemplateTag(tag, {
+    setTemplateTagConfig(tag, {
       ...parameter,
       values_source_type: sourceType,
       values_source_config: sourceConfig,

--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.jsx
@@ -24,6 +24,7 @@ export default class TagEditorSidebar extends React.Component {
     sampleDatabaseId: PropTypes.number,
     setDatasetQuery: PropTypes.func.isRequired,
     setTemplateTag: PropTypes.func.isRequired,
+    setTemplateTagConfig: PropTypes.func.isRequired,
     setParameterValue: PropTypes.func.isRequired,
   };
 
@@ -44,6 +45,7 @@ export default class TagEditorSidebar extends React.Component {
       setDatasetQuery,
       query,
       setTemplateTag,
+      setTemplateTagConfig,
       setParameterValue,
       onClose,
     } = this.props;
@@ -85,6 +87,7 @@ export default class TagEditorSidebar extends React.Component {
               database={database}
               databases={databases}
               setTemplateTag={setTemplateTag}
+              setTemplateTagConfig={setTemplateTagConfig}
               setParameterValue={setParameterValue}
             />
           ) : (
@@ -108,6 +111,7 @@ const SettingsPane = ({
   database,
   databases,
   setTemplateTag,
+  setTemplateTagConfig,
   setParameterValue,
 }) => (
   <div>
@@ -121,6 +125,7 @@ const SettingsPane = ({
           database={database}
           databases={databases}
           setTemplateTag={setTemplateTag}
+          setTemplateTagConfig={setTemplateTagConfig}
           setParameterValue={setParameterValue}
         />
       </div>

--- a/frontend/test/metabase-lib/lib/queries/NativeQuery.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/queries/NativeQuery.unit.spec.js
@@ -285,8 +285,7 @@ describe("NativeQuery", () => {
       const oldQuery = makeQuery().setQueryText(
         "SELECT * FROM PRODUCTS WHERE {{t1}} AND {{t2}}",
       );
-      const newQuery = oldQuery.setTemplateTag(
-        "t1",
+      const newQuery = oldQuery.setTemplateTagConfig(
         oldQuery.templateTagsMap()["t1"],
         {
           values_query_type: "search",


### PR DESCRIPTION
Epic https://github.com/metabase/metabase/issues/26898

Removes `config` param from `setTemplateTag` and adds a separate method for it. This way we won't have to deal with missing `config` values when updating tags in other places. Shouldn't lead to any behavioural changes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/27947)
<!-- Reviewable:end -->
