### PR TITLE
Fix `GET /api/session` endpoint for settings managers

### DIFF
--- a/src/metabase/api/session.clj
+++ b/src/metabase/api/session.clj
@@ -286,6 +286,8 @@
    (setting/user-readable-values-map :public)
    (when @api/*current-user*
      (setting/user-readable-values-map :authenticated))
+   (when (setting/has-advanced-setting-access?)
+     (setting/user-readable-values-map :settings-manager))
    (when api/*is-superuser?*
      (setting/user-readable-values-map :admin))))
 

--- a/src/metabase/models/setting.clj
+++ b/src/metabase/models/setting.clj
@@ -350,7 +350,7 @@
   set to true when settings are being written directly via /api/setting endpoints."
   false)
 
-(defn- has-advanced-setting-access?
+(defn has-advanced-setting-access?
   "If `advanced-permissions` is enabled, check if current user has permissions to edit `setting`.
   Return `false` when `advanced-permissions` is disabled."
   []

--- a/test/metabase/api/session_test.clj
+++ b/test/metabase/api/session_test.clj
@@ -359,10 +359,19 @@
                          (setting/user-readable-values-map :authenticated))))
              (set (keys (mt/user-http-request :lucky :get 200 "session/properties"))))))
 
+    (testing "Authenticated settings manager"
+      (with-redefs [setting/has-advanced-setting-access? (constantly true)]
+        (is (= (set (keys (merge
+                           (setting/user-readable-values-map :public)
+                           (setting/user-readable-values-map :authenticated)
+                           (setting/user-readable-values-map :settings-manager))))
+               (set (keys (mt/user-http-request :lucky :get 200 "session/properties")))))))
+
     (testing "Authenticated super user"
       (is (= (set (keys (merge
                          (setting/user-readable-values-map :public)
                          (setting/user-readable-values-map :authenticated)
+                         (setting/user-readable-values-map :settings-manager)
                          (setting/user-readable-values-map :admin))))
              (set (keys (mt/user-http-request :crowberto :get 200 "session/properties"))))))))
 


### PR DESCRIPTION
Resolves https://github.com/metabase/metabase/issues/27951

I added a new `:settings-managers` visibility level for settings in https://github.com/metabase/metabase/pull/27187 but this inadvertently broke the `GET /api/session` endpoint. The endpoint reads the list of settings for each visibility level and merges them together depending on the current user's access level. So it's a quick fix to include `:settings-manager` in this logic.

This enables settings with `:settings-manager` visibility to be returned by this endpoint for both admins and non-admin settings managers.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/27952)
<!-- Reviewable:end -->
