### PR TITLE
Refactor router usage in tests

### DIFF
--- a/frontend/src/metabase/admin/databases/containers/DatabaseEditApp.unit.spec.js
+++ b/frontend/src/metabase/admin/databases/containers/DatabaseEditApp.unit.spec.js
@@ -1,4 +1,5 @@
 import React from "react";
+import { Route } from "react-router";
 
 import {
   renderWithProviders,
@@ -44,7 +45,7 @@ async function setup({ cachingEnabled = false } = {}) {
     "enable-query-caching": cachingEnabled,
   });
 
-  renderWithProviders(<DatabaseEditApp />, {
+  renderWithProviders(<Route path="/" component={DatabaseEditApp} />, {
     withRouter: true,
     storeInitialState: {
       settings,

--- a/frontend/src/metabase/collections/components/PinnedItemCard/PinnedItemCard.unit.spec.js
+++ b/frontend/src/metabase/collections/components/PinnedItemCard/PinnedItemCard.unit.spec.js
@@ -1,13 +1,9 @@
 import React from "react";
+import { Route } from "react-router";
 import userEvent from "@testing-library/user-event";
-import { render, screen, getIcon } from "__support__/ui";
+import { renderWithProviders, screen, getIcon } from "__support__/ui";
 
 import PinnedItemCard from "./PinnedItemCard";
-
-// eslint-disable-next-line react/display-name, react/prop-types
-jest.mock("metabase/core/components/Link", () => ({ to, ...props }) => (
-  <a {...props} href={to} />
-));
 
 const mockOnCopy = jest.fn();
 const mockOnMove = jest.fn();
@@ -50,13 +46,19 @@ const defaultItem = getCollectionItem();
 function setup({ item = defaultItem, collection = defaultCollection } = {}) {
   mockOnCopy.mockReset();
   mockOnMove.mockReset();
-  return render(
-    <PinnedItemCard
-      item={item}
-      collection={collection}
-      onCopy={mockOnCopy}
-      onMove={mockOnMove}
+  return renderWithProviders(
+    <Route
+      path="/"
+      component={() => (
+        <PinnedItemCard
+          item={item}
+          collection={collection}
+          onCopy={mockOnCopy}
+          onMove={mockOnMove}
+        />
+      )}
     />,
+    { withRouter: true },
   );
 }
 

--- a/frontend/src/metabase/nav/containers/AppBar/AppBar.unit.spec.tsx
+++ b/frontend/src/metabase/nav/containers/AppBar/AppBar.unit.spec.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { Route } from "react-router";
 import nock from "nock";
 import { screen } from "@testing-library/react";
 import { createMockCard } from "metabase-types/api/mocks";
@@ -145,12 +146,9 @@ function setup(embedOptions: Partial<EmbedOptions>) {
   const scope = nock(location.origin);
   setupCollectionsEndpoints(scope, []);
 
-  renderWithProviders(<AppBar />, {
+  renderWithProviders(<Route path="/question/:slug" component={AppBar} />, {
     withRouter: true,
-    initialRouterState: {
-      location: "/question/1",
-      route: "/question/:slug",
-    },
+    initialRoute: "/question/1",
     storeInitialState: {
       app: createMockAppState({ isNavbarOpen: false }),
       embed: createMockEmbedState({

--- a/frontend/src/metabase/public/containers/PublicApp/PublicApp.unit.spec.tsx
+++ b/frontend/src/metabase/public/containers/PublicApp/PublicApp.unit.spec.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { Route } from "react-router";
 import userEvent from "@testing-library/user-event";
 
 import { getIcon, renderWithProviders, screen } from "__support__/ui";
@@ -29,18 +30,20 @@ function setup({
   const settings = mockSettings({ "hide-embed-branding?": !hasEmbedBranding });
 
   renderWithProviders(
-    <PublicApp>
-      <EmbedFrame {...embedFrameProps}>
-        <h1 data-testid="test-content">Test</h1>
-      </EmbedFrame>
-    </PublicApp>,
+    <Route
+      path="/public/dashboard/:id"
+      component={props => (
+        <PublicApp {...props}>
+          <EmbedFrame {...embedFrameProps}>
+            <h1 data-testid="test-content">Test</h1>
+          </EmbedFrame>
+        </PublicApp>
+      )}
+    />,
     {
       mode: "public",
+      initialRoute: `/public/dashboard/UUID${hash}`,
       storeInitialState: { app, settings },
-      initialRouterState: {
-        route: "/public/dashboard/:id",
-        location: `/public/dashboard/UUID${hash}`,
-      },
       withRouter: true,
     },
   );

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader.unit.spec.js
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader.unit.spec.js
@@ -1,4 +1,5 @@
 import React from "react";
+import { Route } from "react-router";
 import nock from "nock";
 import userEvent from "@testing-library/user-event";
 import { fireEvent, renderWithProviders, screen } from "__support__/ui";
@@ -118,15 +119,20 @@ function setup({
   };
 
   renderWithProviders(
-    <ViewTitleHeader
-      isRunning={false}
-      {...callbacks}
-      {...props}
-      question={question}
-      isActionListVisible={isActionListVisible}
-      isAdditionalInfoVisible={isAdditionalInfoVisible}
-      isDirty={isDirty}
-      isRunnable={isRunnable}
+    <Route
+      path="/"
+      component={() => (
+        <ViewTitleHeader
+          isRunning={false}
+          {...callbacks}
+          {...props}
+          question={question}
+          isActionListVisible={isActionListVisible}
+          isAdditionalInfoVisible={isAdditionalInfoVisible}
+          isDirty={isDirty}
+          isRunnable={isRunnable}
+        />
+      )}
     />,
     {
       withRouter: true,

--- a/frontend/test/__support__/entities-store.js
+++ b/frontend/test/__support__/entities-store.js
@@ -5,7 +5,7 @@ import requestsReducer from "metabase/redux/requests";
 import { thunkWithDispatchAction } from "metabase/store";
 import * as entities from "metabase/redux/entities";
 
-export function getStore(reducers = {}, initialState = {}) {
+export function getStore(reducers = {}, initialState = {}, middleware = []) {
   const reducer = combineReducers({
     entities: entities.reducer,
     requests: (state, action) =>
@@ -16,6 +16,8 @@ export function getStore(reducers = {}, initialState = {}) {
   return createStore(
     reducer,
     initialState,
-    compose(applyMiddleware(thunkWithDispatchAction, promise)),
+    compose(
+      applyMiddleware(...[thunkWithDispatchAction, promise, ...middleware]),
+    ),
   );
 }

--- a/frontend/test/__support__/ui.tsx
+++ b/frontend/test/__support__/ui.tsx
@@ -3,7 +3,7 @@ import { render, screen } from "@testing-library/react";
 import { merge } from "icepick";
 import _ from "underscore";
 import { createMemoryHistory } from "history";
-import { Router, Route } from "react-router";
+import { Router } from "react-router";
 import { Provider } from "react-redux";
 import { ThemeProvider } from "@emotion/react";
 import { DragDropContextProvider } from "react-dnd";
@@ -20,11 +20,9 @@ import publicReducers from "metabase/reducers-public";
 
 import { getStore } from "./entities-store";
 
-type RouterStateOpts = { route: string; location: string };
-
 export interface RenderWithProvidersOptions {
   mode?: "default" | "public";
-  initialRouterState?: RouterStateOpts;
+  initialRoute?: string;
   storeInitialState?: Partial<State>;
   withSampleDatabase?: boolean;
   withRouter?: boolean;
@@ -40,8 +38,8 @@ export function renderWithProviders(
   ui: React.ReactElement,
   {
     mode = "default",
+    initialRoute,
     storeInitialState = {},
-    initialRouterState,
     withSampleDatabase,
     withRouter = false,
     withDND = false,
@@ -66,7 +64,7 @@ export function renderWithProviders(
     <Wrapper
       {...props}
       store={store}
-      initialRouterState={initialRouterState}
+      initialRoute={initialRoute}
       withRouter={withRouter}
       withDND={withDND}
     />
@@ -86,13 +84,13 @@ export function renderWithProviders(
 function Wrapper({
   children,
   store,
-  initialRouterState,
+  initialRoute,
   withRouter,
   withDND,
 }: {
   children: React.ReactElement;
   store: any;
-  initialRouterState?: RouterStateOpts;
+  initialRoute?: string;
   withRouter: boolean;
   withDND: boolean;
 }): JSX.Element {
@@ -100,7 +98,7 @@ function Wrapper({
     <Provider store={store}>
       <MaybeDNDProvider hasDND={withDND}>
         <ThemeProvider theme={{}}>
-          <MaybeRouter hasRouter={withRouter} initialState={initialRouterState}>
+          <MaybeRouter hasRouter={withRouter} initialRoute={initialRoute}>
             {children}
           </MaybeRouter>
         </ThemeProvider>
@@ -112,29 +110,17 @@ function Wrapper({
 function MaybeRouter({
   children,
   hasRouter,
-  initialState,
+  initialRoute = "/",
 }: {
   children: React.ReactElement;
   hasRouter: boolean;
-  initialState?: RouterStateOpts;
+  initialRoute?: string;
 }): JSX.Element {
   if (!hasRouter) {
     return children;
   }
-  const location = initialState?.location || "/";
-  const route = initialState?.route || "/";
-
-  const history = createMemoryHistory({ entries: [location] });
-
-  function Page(props: any) {
-    return React.cloneElement(children, _.omit(props, "children"));
-  }
-
-  return (
-    <Router history={history}>
-      <Route path={route} component={Page} />
-    </Router>
-  );
+  const history = createMemoryHistory({ entries: [initialRoute] });
+  return <Router history={history}>{children}</Router>;
 }
 
 function MaybeDNDProvider({

--- a/frontend/test/__support__/ui.tsx
+++ b/frontend/test/__support__/ui.tsx
@@ -65,9 +65,7 @@ export function renderWithProviders(
   const reducers = mode === "default" ? mainReducers : publicReducers;
 
   if (withRouter) {
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    reducers.routing = routerReducer;
+    Object.assign(reducers, { routing: routerReducer });
   }
 
   const store = getStore(

--- a/frontend/test/__support__/ui.tsx
+++ b/frontend/test/__support__/ui.tsx
@@ -4,6 +4,7 @@ import { merge } from "icepick";
 import _ from "underscore";
 import { createMemoryHistory, History } from "history";
 import { Router } from "react-router";
+import { routerReducer, routerMiddleware } from "react-router-redux";
 import { Provider } from "react-redux";
 import { ThemeProvider } from "@emotion/react";
 import { DragDropContextProvider } from "react-dnd";
@@ -57,11 +58,23 @@ export function renderWithProviders(
     initialState = _.pick(initialState, ...publicReducerNames) as State;
   }
 
-  const reducers = mode === "default" ? mainReducers : publicReducers;
-  const store = getStore(reducers, initialState);
   const history = withRouter
     ? createMemoryHistory({ entries: [initialRoute] })
     : undefined;
+
+  const reducers = mode === "default" ? mainReducers : publicReducers;
+
+  if (withRouter) {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    reducers.routing = routerReducer;
+  }
+
+  const store = getStore(
+    reducers,
+    initialState,
+    history ? [routerMiddleware(history)] : [],
+  );
 
   const wrapper = (props: any) => (
     <Wrapper

--- a/frontend/test/__support__/ui.tsx
+++ b/frontend/test/__support__/ui.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { render, screen } from "@testing-library/react";
 import { merge } from "icepick";
 import _ from "underscore";
-import { createMemoryHistory } from "history";
+import { createMemoryHistory, History } from "history";
 import { Router } from "react-router";
 import { Provider } from "react-redux";
 import { ThemeProvider } from "@emotion/react";
@@ -38,7 +38,7 @@ export function renderWithProviders(
   ui: React.ReactElement,
   {
     mode = "default",
-    initialRoute,
+    initialRoute = "/",
     storeInitialState = {},
     withSampleDatabase,
     withRouter = false,
@@ -59,11 +59,15 @@ export function renderWithProviders(
 
   const reducers = mode === "default" ? mainReducers : publicReducers;
   const store = getStore(reducers, initialState);
+  const history = withRouter
+    ? createMemoryHistory({ entries: [initialRoute] })
+    : undefined;
 
   const wrapper = (props: any) => (
     <Wrapper
       {...props}
       store={store}
+      history={history}
       initialRoute={initialRoute}
       withRouter={withRouter}
       withDND={withDND}
@@ -78,19 +82,20 @@ export function renderWithProviders(
   return {
     ...utils,
     store,
+    history,
   };
 }
 
 function Wrapper({
   children,
   store,
-  initialRoute,
+  history,
   withRouter,
   withDND,
 }: {
   children: React.ReactElement;
   store: any;
-  initialRoute?: string;
+  history?: History;
   withRouter: boolean;
   withDND: boolean;
 }): JSX.Element {
@@ -98,7 +103,7 @@ function Wrapper({
     <Provider store={store}>
       <MaybeDNDProvider hasDND={withDND}>
         <ThemeProvider theme={{}}>
-          <MaybeRouter hasRouter={withRouter} initialRoute={initialRoute}>
+          <MaybeRouter hasRouter={withRouter} history={history}>
             {children}
           </MaybeRouter>
         </ThemeProvider>
@@ -110,16 +115,15 @@ function Wrapper({
 function MaybeRouter({
   children,
   hasRouter,
-  initialRoute = "/",
+  history,
 }: {
   children: React.ReactElement;
   hasRouter: boolean;
-  initialRoute?: string;
+  history?: History;
 }): JSX.Element {
   if (!hasRouter) {
     return children;
   }
-  const history = createMemoryHistory({ entries: [initialRoute] });
   return <Router history={history}>{children}</Router>;
 }
 

--- a/frontend/test/__support__/ui.tsx
+++ b/frontend/test/__support__/ui.tsx
@@ -81,7 +81,6 @@ export function renderWithProviders(
       {...props}
       store={store}
       history={history}
-      initialRoute={initialRoute}
       withRouter={withRouter}
       withDND={withDND}
     />

--- a/frontend/test/metabase/collections/BaseItemsTable.unit.spec.js
+++ b/frontend/test/metabase/collections/BaseItemsTable.unit.spec.js
@@ -1,4 +1,5 @@
 import React from "react";
+import { Route } from "react-router";
 import userEvent from "@testing-library/user-event";
 import moment from "moment-timezone";
 import { renderWithProviders, screen } from "__support__/ui";
@@ -9,11 +10,6 @@ import {
 } from "cljs/metabase.shared.formatting.constants";
 
 import BaseItemsTable from "metabase/collections/components/BaseItemsTable";
-
-// eslint-disable-next-line react/display-name, react/prop-types
-jest.mock("metabase/core/components/Link", () => ({ to, ...props }) => (
-  <a {...props} href={to} />
-));
 
 const timestamp = "2021-06-03T19:46:52.128";
 
@@ -46,13 +42,18 @@ describe("Collections BaseItemsTable", () => {
 
   function setup({ items = [ITEM], ...props } = {}) {
     return renderWithProviders(
-      <BaseItemsTable
-        items={items}
-        sortingOptions={{ sort_column: "name", sort_direction: "asc" }}
-        onSortingOptionsChange={jest.fn()}
-        {...props}
+      <Route
+        path="/"
+        component={() => (
+          <BaseItemsTable
+            items={items}
+            sortingOptions={{ sort_column: "name", sort_direction: "asc" }}
+            onSortingOptionsChange={jest.fn()}
+            {...props}
+          />
+        )}
       />,
-      { withDND: true },
+      { withDND: true, withRouter: true },
     );
   }
 


### PR DESCRIPTION
Epic #26960.

Changes how `renderWithProviders` deals with router setup to allow rendering multiple routes. 

`renderWithProviders` has a boolean `withRouter` option that'd wrap the rendered JSX into `Router` and `Route`. We also added the `initialRouterState` parameter to configure initial location and route pattern. Still, it didn't let us render more than one route in a single test.

**Changes**

* `renderWithProviders` no longer wraps the passed JSX into `Route` (only top-level `Router` with `history`)
* when `withRouter` is enabled, `renderWithProviders` will also add `react-router-redux` reducer and middleware to the store, so actions like `push` and `replace` should work
* `initialRouterState` is removed in favor of `Route's` `path` prop and the new `initialRoute` parameter
* `renderWithProviders` now returns the `history` object to assert the current location

**Example usage**


```tsx
import { Route } from "react-router"
import { renderWithProviders } from "__support__/ui"

const initialRoute = "/page/1"

const { history } = renderWithProviders(
  <>
    <Route path="/page/:id" component={Page} />
    <Route path="/page/:id/info" component={PageInfo} />
  </>,
  { withRouter: true, initialRoute }
)

userEvent.click(screen.getByText("Next Page"))
expect(history?.getCurrentLocation().pathname).toBe("/page/2")

userEvent.click(screen.getByText("Page info"))
expect(history?.getCurrentLocation().pathname).toBe("/page/2/info")
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/27957)
<!-- Reviewable:end -->
