### PR TITLE
Fix flakyness in native filter e2e test 

### DIFF
--- a/frontend/test/metabase/scenarios/native-filters/helpers/e2e-field-filter-helpers.js
+++ b/frontend/test/metabase/scenarios/native-filters/helpers/e2e-field-filter-helpers.js
@@ -161,7 +161,13 @@ function enterDefaultValue(value) {
 export function pickDefaultValue(searchTerm, result) {
   cy.findByText("Enter a default value…").click();
   cy.findByPlaceholderText("Enter a default value…").type(searchTerm);
-  popover().findByText(result).click();
+
+  // We could search for only one result inside popover()
+  // instead of `all` then `last`,
+  // but it flakes out as sometimes the popover
+  // is detached from the DOM.
+  //
+  cy.findAllByText(result).last().click();
 
   cy.button("Add filter").click();
 }


### PR DESCRIPTION
Fixes #27958

### To test

1. `yarn test-cypress-open`
2. `frontend/test/metabase/scenarios/native-filters/helpers/e2e-field-filter-helpers.js`

#### Details

This popover is sometimes found in Cypress before it's attached to the DOM.

Considered using a wait for an API call, but this popover is not fed by an async API call.

Tried using checks for attached, like

```
  popover().should($el => {
    expect(Cypress.dom.isDetached($el)).to.eq(false)…
```

but flake still happened.

So went for the simple solution.

![image](https://user-images.githubusercontent.com/380816/215576378-41368c9d-40a4-445a-aa8d-fa57fe92eef0.png)
