### PR TITLE
[Ignore] Render object details card with wrong content

### DIFF
--- a/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetail.tsx
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetail.tsx
@@ -358,7 +358,9 @@ export function ObjectDetailHeader({
       <div className="Grid-cell">
         <h2 className="p3">
           {objectName}
-          {objectId !== null && <ObjectIdLabel> {objectId}</ObjectIdLabel>}
+          {objectId !== null && (
+            <ObjectIdLabel>Wrong header on purpose</ObjectIdLabel>
+          )}
         </h2>
       </div>
       {showActions && (

--- a/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetailsTable.tsx
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetailsTable.tsx
@@ -94,7 +94,7 @@ export function DetailsTableCell({
             : undefined
         }
       >
-        {cellValue}
+        {cellValue} with breaking text
       </span>
     </div>
   );


### PR DESCRIPTION
It's hard to manually find all e2e tests that check into object details.

This temporary PR will make that component render wrong data so we can bring forth breaking e2e tests.

Related: https://github.com/metabase/metabase/pull/27934

