### PR TITLE
Polish tooltips

### DIFF
--- a/frontend/src/metabase/visualizations/components/ChartTooltip/KeyValuePairChartTooltip/KeyValuePairChartTooltip.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/ChartTooltip/KeyValuePairChartTooltip/KeyValuePairChartTooltip.styled.tsx
@@ -1,0 +1,8 @@
+import styled from "@emotion/styled";
+
+export const TooltipTableCell = styled.td`
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 240px;
+`;

--- a/frontend/src/metabase/visualizations/components/ChartTooltip/KeyValuePairChartTooltip/KeyValuePairChartTooltip.tsx
+++ b/frontend/src/metabase/visualizations/components/ChartTooltip/KeyValuePairChartTooltip/KeyValuePairChartTooltip.tsx
@@ -6,8 +6,9 @@ import {
   HoveredDimension,
   HoveredObject,
   VisualizationSettings,
-} from "./types";
-import { formatValueForTooltip } from "./utils";
+} from "../types";
+import { formatValueForTooltip } from "../utils";
+import { TooltipTableCell } from "./KeyValuePairChartTooltip.styled";
 
 export interface StackedDataTooltipProps {
   hovered: HoveredObject;
@@ -46,12 +47,18 @@ export interface TooltipRowProps {
 
 const TooltipRow = ({ name, value, column, settings }: TooltipRowProps) => (
   <tr>
-    {name ? <td className="text-light text-right pr1">{name}:</td> : <td />}
-    <td className="text-bold text-left">
+    {name ? (
+      <TooltipTableCell className="text-light text-right pr1">
+        {name}:
+      </TooltipTableCell>
+    ) : (
+      <TooltipTableCell />
+    )}
+    <TooltipTableCell className="text-bold text-left">
       {React.isValidElement(value)
         ? value
         : formatValueForTooltip({ value, column, settings })}
-    </td>
+    </TooltipTableCell>
   </tr>
 );
 

--- a/frontend/src/metabase/visualizations/components/ChartTooltip/KeyValuePairChartTooltip/index.ts
+++ b/frontend/src/metabase/visualizations/components/ChartTooltip/KeyValuePairChartTooltip/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./KeyValuePairChartTooltip";

--- a/frontend/src/metabase/visualizations/components/ChartTooltip/TooltipRow/TooltipRow.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/ChartTooltip/TooltipRow/TooltipRow.styled.tsx
@@ -27,6 +27,10 @@ export const Cell = styled.td`
   vertical-align: middle;
   padding: 0.375rem 0.5rem;
   font-weight: 700;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 220px;
 
   & + & {
     padding-left: 0.5rem;
@@ -45,6 +49,15 @@ export const Cell = styled.td`
   &:last-of-type {
     border-bottom-right-radius: 4px;
     border-top-right-radius: 4px;
+  }
+`;
+
+export const ColorIndicatorCell = styled(Cell)`
+  width: 1%;
+  text-align: center;
+
+  && {
+    padding-right: 0.25rem;
   }
 `;
 

--- a/frontend/src/metabase/visualizations/components/ChartTooltip/TooltipRow/TooltipRow.tsx
+++ b/frontend/src/metabase/visualizations/components/ChartTooltip/TooltipRow/TooltipRow.tsx
@@ -5,6 +5,7 @@ import { TooltipRowModel } from "../types";
 import {
   Cell,
   ColorIndicator,
+  ColorIndicatorCell,
   PercentCell,
   TooltipRowRoot,
   TotalRowRoot,
@@ -26,9 +27,9 @@ export const TooltipRow = ({
 }: TooltipRowProps) => (
   <TooltipRowRoot isHeader={isHeader}>
     {color && (
-      <Cell>
+      <ColorIndicatorCell>
         <ColorIndicator size={isHeader ? 12 : 8} color={color} />
-      </Cell>
+      </ColorIndicatorCell>
     )}
     <Cell data-testid="row-name">{name}</Cell>
     <ValueCell data-testid="row-value">{formatter(value)}</ValueCell>
@@ -52,7 +53,7 @@ export const TooltipTotalRow = ({
   hasIcon,
 }: TotalTooltipRow) => (
   <TotalRowRoot>
-    {hasIcon && <Cell>=</Cell>}
+    {hasIcon && <ColorIndicatorCell>=</ColorIndicatorCell>}
     <Cell data-testid="row-name">{t`Total`}</Cell>
     <ValueCell data-testid="row-value">{value}</ValueCell>
     {percent != null && (

--- a/frontend/src/metabase/visualizations/visualizations/RowChart/utils/events.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/visualizations/RowChart/utils/events.unit.spec.ts
@@ -69,7 +69,7 @@ const barData: BarData<GroupedDatum> = {
 
 describe("events utils", () => {
   describe("getHoverData", () => {
-    it("returns key-value pairs based on series_settings for charts without breaekouts", () => {
+    it("returns key-value pairs based on series_settings for charts without a breakout", () => {
       const keyValueData = getHoverData(
         barData,
         {

--- a/frontend/src/metabase/visualizations/visualizations/RowChart/utils/events.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/visualizations/RowChart/utils/events.unit.spec.ts
@@ -1,4 +1,4 @@
-import { VisualizationSettings } from "metabase-types/api";
+import { SeriesSettings, VisualizationSettings } from "metabase-types/api";
 import { MultipleMetricsChartColumns } from "metabase/visualizations/lib/graph/columns";
 import { BarData } from "metabase/visualizations/shared/components/RowChart/types";
 import {
@@ -8,9 +8,9 @@ import {
 import { getHoverData } from "./events";
 
 const datasetColumns = [
-  { name: "y" } as RemappingHydratedDatasetColumn,
-  { name: "x" } as RemappingHydratedDatasetColumn,
-  { name: "x1" } as RemappingHydratedDatasetColumn,
+  { name: "y", display_name: "Y" } as RemappingHydratedDatasetColumn,
+  { name: "x", display_name: "X" } as RemappingHydratedDatasetColumn,
+  { name: "x1", display_name: "X1" } as RemappingHydratedDatasetColumn,
 ];
 
 const chartColumns: MultipleMetricsChartColumns = {
@@ -69,6 +69,36 @@ const barData: BarData<GroupedDatum> = {
 
 describe("events utils", () => {
   describe("getHoverData", () => {
+    it("returns key-value pairs based on series_settings for charts without breaekouts", () => {
+      const keyValueData = getHoverData(
+        barData,
+        {
+          series_settings: {
+            [chartColumns.metrics[0].column.name]: {
+              title: "my custom label",
+            } as SeriesSettings,
+          },
+        },
+        {
+          dimension: chartColumns.dimension,
+          metrics: [chartColumns.metrics[0]],
+        },
+        datasetColumns,
+        [series1],
+        seriesColors,
+      ).data;
+
+      expect(keyValueData).toStrictEqual([
+        { col: chartColumns.dimension.column, key: "Y", value: "foo" },
+        {
+          col: chartColumns.metrics[0].column,
+          key: "my custom label",
+          value: 100,
+        },
+        { col: chartColumns.metrics[1].column, key: "X1", value: 200 },
+      ]);
+    });
+
     it.each(["stacked", "normalized"])(
       "returns stacked tooltip model for stacked charts",
       stackType => {


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/27944

## Changes

Fixes a few small tooltips issues:

1) Tweak the spacing of the [stacked charts' tooltip](https://metaboat.slack.com/archives/C04D0E4837E/p1674768446708369?thread_ts=1674686901.499709&cid=C04D0E4837E) 

2) Limit the width of [long key-pairs](https://metaboat.slack.com/archives/C04D0E4837E/p1675073919719979) in tooltips:
<img width="462" alt="Screen Shot 2023-01-30 at 6 43 47 PM" src="https://user-images.githubusercontent.com/14301985/215612234-28a0f65d-b174-4c18-9b17-972db1d5700e.png">

3) Render user-defined metric names from settings in tooltips https://github.com/metabase/metabase/issues/27944

## How to verify

1. New question -> Orders -> Summarize by [Created At] and [Product -> Category]
2. Make it a bar chart and enable stacking
3. Hover the chart and ensure the spacing between color indicators looks good
4. Open viz settings and remove the breakout [Product -> Category]
5. Go to Y-axis [Count] settings -> Style -> change the name to `Super long count count count count count count count count count count count `
6. Hover the chart and ensure it gets ellipsified
7. Switch viz type to Row
8. Hover the chart and ensure it looks the same with the correct custom name