### PR TITLE
Bump `node` to version 16

### DIFF
--- a/.github/actions/prepare-frontend/action.yml
+++ b/.github/actions/prepare-frontend/action.yml
@@ -5,6 +5,9 @@ runs:
     - name: Prepare Node.js
       uses: actions/setup-node@v3
       with:
+        # Please don't bump this version to anything higher.
+        # See https://github.com/facebook/jest/issues/11956 for more details,
+        # as a lot of people couldn't complete a jest run with any other versions.
         node-version: 16.10.0
         cache: 'yarn'
     - name: Check to see if dependencies should be cached

--- a/.github/actions/prepare-frontend/action.yml
+++ b/.github/actions/prepare-frontend/action.yml
@@ -5,7 +5,7 @@ runs:
     - name: Prepare Node.js
       uses: actions/setup-node@v3
       with:
-        node-version: 14.x
+        node-version: 16.10.0
         cache: 'yarn'
     - name: Check to see if dependencies should be cached
       if: ${{ contains(github.event.head_commit.message, '[ci nocache]') }}

--- a/frontend/test/jest-setup.js
+++ b/frontend/test/jest-setup.js
@@ -1,4 +1,3 @@
-import { XMLHttpRequest } from "xmlhttprequest";
 import "raf/polyfill";
 import "jest-localstorage-mock";
 import "jest-canvas-mock";
@@ -11,10 +10,6 @@ import "__support__/mocks";
 process.on("uncaughtException", err =>
   console.error("WARNING: UNCAUGHT EXCEPTION", err),
 );
-
-if (!global.XMLHttpRequest) {
-  global.XMLHttpRequest = XMLHttpRequest;
-}
 
 if (process.env["DISABLE_LOGGING"] || process.env["DISABLE_LOGGING_FRONTEND"]) {
   global.console = {

--- a/package.json
+++ b/package.json
@@ -256,7 +256,6 @@
     "webpack-dev-server": "4.11.1",
     "webpack-notifier": "1.15.0",
     "xlsx": "0.18.3",
-    "xmlhttprequest": "^1.8.0",
     "yaml-lint": "~1.6.0"
   },
   "resolutions": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "repository": "https://github.com/metabase/metabase",
   "license": "private",
   "engines": {
-    "node": ">=14.2",
+    "node": ">=16",
     "yarn": ">=1.12.3"
   },
   "dependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -21662,11 +21662,6 @@ xmlchars@^2.2.0:
   resolved "https://registry.yarnpkg.com/xmlchars/-/xmlchars-2.2.0.tgz#060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb"
   integrity sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==
 
-xmlhttprequest@^1.8.0:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz#67fe075c5c24fef39f9d65f5f7b7fe75171968fc"
-  integrity sha512-58Im/U0mlVBLM38NdZjHyhuMtCqa61469k2YP/AaPbvCoV9aQGUpbJBj1QRm2ytRiVQBD/fsw7L2bJGDVQswBA==
-
 xtend@^4.0.0, xtend@^4.0.1, xtend@^4.0.2, xtend@~4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"


### PR DESCRIPTION
## Why?
1. Fixes frontend test failures related to `nock` library
2. Enforces the same version for dev and production environments

---
Since the introduction of `nock` in https://github.com/metabase/metabase/pull/27337, we starts to see some inconsistency in the unit tests behavior run on Node v14 vs v16+. This leads to the conclusion that we should be using Node v16+ for both development + CI environment to make the tests more repeatable.

Also, please note that we're using exactly Node `16.10.0` on our CI since a lot of people reported here https://github.com/facebook/jest/issues/11956. Any other 16 or 18 versions don't seem to work at all.

#### Example failed runs
- https://github.com/metabase/metabase/actions/runs/4047552648/jobs/6961708453

Other runs are hard to find since the PR is amended, but there was at least a single commit that I reran the tests a few times and it failed consistently when this couldn't be reproduced on machines using node V16+