### PR TITLE
Custom Table e2e Tests 2: Simple issue reproduction

### DIFF
--- a/frontend/test/metabase/scenarios/custom-column/reproductions/27745-cc-numeric-missing-summarize.cy.spec.js
+++ b/frontend/test/metabase/scenarios/custom-column/reproductions/27745-cc-numeric-missing-summarize.cy.spec.js
@@ -1,0 +1,78 @@
+import {
+  restore,
+  startNewQuestion,
+  enterCustomColumnDetails,
+  visualize,
+  popover,
+  queryQADB,
+} from "__support__/e2e/helpers";
+
+const createTableQueries = {
+  postgres: `
+    DROP TABLE IF EXISTS colors;
+
+    CREATE TABLE colors (
+      id INTEGER PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+      color VARCHAR ( 255 ) UNIQUE NOT NULL
+    );
+
+    INSERT INTO colors (color) VALUES ('red'), ('green'), ('blue');
+  `,
+  mysql: `
+    DROP TABLE IF EXISTS colors;
+
+    CREATE TABLE colors (
+      id INTEGER PRIMARY KEY AUTO_INCREMENT,
+      color VARCHAR ( 255 ) UNIQUE NOT NULL
+    );
+
+    INSERT INTO colors (color) VALUES ('red'), ('green'), ('blue');
+  `,
+};
+
+const snapshotMap = {
+  postgres: "postgres-12",
+  mysql: "mysql-8",
+};
+
+["postgres", "mysql"].forEach(dialect => {
+  describe.skip(`issue 27745 (${dialect})`, { tags: "@external" }, () => {
+    beforeEach(() => {
+      restore(snapshotMap[dialect]);
+      cy.signInAsAdmin();
+
+      queryQADB(createTableQueries[dialect], dialect);
+
+      cy.request("POST", "/api/database/2/sync_schema");
+    });
+
+    it("should display all summarize options if the only numeric field is a custom column (metabase#27745)", () => {
+      startNewQuestion();
+      cy.findByText(/QA/i).click();
+      cy.findByText("Colors").click();
+      cy.icon("add_data").click();
+      enterCustomColumnDetails({
+        formula: "case([ID] > 1, 25, 5)",
+        name: "Numeric",
+      });
+      cy.button("Done").click();
+
+      visualize();
+
+      cy.findAllByTestId("header-cell").contains("Numeric").click();
+      popover().findByText(/^Sum$/).click();
+
+      cy.wait("@dataset");
+      cy.get(".ScalarValue").invoke("text").should("eq", "55");
+
+      cy.findByTestId("sidebar-right")
+        .should("be.visible")
+        .within(() => {
+          cy.findByTestId("aggregation-item").should(
+            "contain",
+            "Sum of Numeric",
+          );
+        });
+    });
+  });
+});


### PR DESCRIPTION
## Description

- Uses the `queryQADB()` function to set up tables specifically to reproduce #27745 

The test fail! as expected.
![Screen Shot 2023-01-31 at 2 27 56 PM](https://user-images.githubusercontent.com/30528226/215887389-89665f33-44e5-47ed-a866-3ac76eecc149.png)

But more importantly, the db tasks complete correctly and create the necessary tables in their respective databases.

![Screen Shot 2023-01-31 at 2 28 17 PM](https://user-images.githubusercontent.com/30528226/215887392-9b633212-66d7-4a0c-9363-73c452d326e2.png)
![Screen Shot 2023-01-31 at 2 28 30 PM](https://user-images.githubusercontent.com/30528226/215887395-731d79a9-f3f6-4f5b-9ee1-14311b8d0683.png)
