### PR TITLE
Rework sandboxing QP middleware to use `sandboxes` table as source of truth

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/sandbox/api/util.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/api/util.clj
@@ -13,9 +13,9 @@
 
 (defn- enforce-sandbox?
   "Takes the permission set for each group a user is in, and a sandbox, and determines whether the sandbox should be
-  enforced for the current user. This is done by checking whether the set of permissions in all *other* groups provides
-  full data access to the sandboxed table. If so, we don't enforce the sandbox, because the other groups' permissions
-  supercede it."
+  enforced for the current user. This is done by checking whether the union of permissions in all *other* groups
+  provides full data access to the sandboxed table. If so, we don't enforce the sandbox, because the other groups'
+  permissions supercede it."
   [group-id->perms-set {group-id :group_id, table-id :table_id}]
   (let [perms-set (->> (dissoc group-id->perms-set group-id)
                        (vals)
@@ -30,7 +30,7 @@
         perms               (when (seq group-ids)
                              (db/select Permissions {:where [:in :group_id group-ids]}))
         group-id->perms-set (-> (group-by :group_id perms)
-                                (update-vals (fn [perms] (into #{} (map :object perms)))))]
+                                (update-vals (fn [perms] (into #{} (map :object) perms))))]
     (filter (partial enforce-sandbox? group-id->perms-set)
             sandboxes)))
 

--- a/enterprise/backend/src/metabase_enterprise/sandbox/api/util.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/api/util.clj
@@ -1,19 +1,49 @@
 (ns metabase-enterprise.sandbox.api.util
   "Enterprise specific API utility functions"
   (:require
-   [metabase.api.common :refer [*current-user-permissions-set* *is-superuser?*]]
-   [metabase.models.permissions :as perms]
-   [metabase.util.i18n :refer [tru]]))
+   [clojure.set :as set]
+   [metabase-enterprise.sandbox.models.group-table-access-policy
+    :refer [GroupTableAccessPolicy]]
+   [metabase.api.common :refer [*current-user-id* *is-superuser?*]]
+   [metabase.models.permissions :as perms :refer [Permissions]]
+   [metabase.models.permissions-group-membership
+    :refer [PermissionsGroupMembership]]
+   [metabase.util.i18n :refer [tru]]
+   [toucan.db :as db]))
+
+(defn- enforce-sandbox?
+  "Takes the permission set for each group a user is in, and a sandbox, and determines whether the sandbox should be
+  enforced for the current user. This is done by checking whether the set of permissions in all *other* groups provides
+  full data access to the sandboxed table. If so, we don't enforce the sandbox, because the other groups' permissions
+  supercede it."
+  [group-id->perms-set {group-id :group_id, table-id :table_id}]
+  (let [perms-set (->> (dissoc group-id->perms-set group-id)
+                       (vals)
+                       (apply set/union))]
+    (not (perms/set-has-full-permissions? perms-set (perms/table-query-path table-id)))))
+
+(defn enforced-sandboxes
+  "Given a list of sandboxes, filters it to only include sandboxes that should be enforced for the current user.
+  A sandbox is not enforced if the user is in a different permissions group that grants full access to the table."
+  [sandboxes]
+  (let [group-ids           (dedupe (map :group_id sandboxes))
+        perms               (db/select Permissions {:where [:in :group_id group-ids]})
+        group-id->perms-set (-> (group-by :group_id perms)
+                                (update-vals (fn [perms] (into #{} (map :object perms)))))]
+    (filter (partial enforce-sandbox? group-id->perms-set)
+            sandboxes)))
 
 (defn segmented-user?
   "Returns true if the currently logged in user has segmented permissions"
   []
   (boolean
    (when-not *is-superuser?*
-     (if-let [current-user-perms @*current-user-permissions-set*]
-       (boolean (some #(re-matches perms/segmented-perm-regex %) current-user-perms))
-       ;; If the current permissions are nil, then we would return false which could give a potentially segmented user
-       ;; access they shouldn't have. If we don't have permissions, we can't determine whether they are segmented, so
-       ;; throw.
-       (throw (ex-info (str (tru "No permissions found for current user"))
+     (if *current-user-id*
+       (let [group-ids          (db/select-field :group_id PermissionsGroupMembership :user_id *current-user-id*)
+             sandboxes          (when (seq group-ids)
+                                  (db/select GroupTableAccessPolicy :group_id [:in group-ids]))]
+           (seq (enforced-sandboxes sandboxes)))
+       ;; If no *current-user-id* is bound we can't check for sandboxes, so we should throw in this case to avoid
+       ;; returning `false` for users who should actually be sandboxes.
+       (throw (ex-info (str (tru "No current user found"))
                        {:status-code 403}))))))

--- a/enterprise/backend/src/metabase_enterprise/sandbox/query_processor/middleware/row_level_restrictions.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/query_processor/middleware/row_level_restrictions.clj
@@ -66,7 +66,8 @@
 (defn- enforce-sandbox?
   "Takes the permission set for each group a user is in, and a sandbox, and determines whether the sandbox should be
   enforced for the current user. This is done by checking whether the set of permissions in all *other* groups provides
-  full data access to the sandboxed table. If so, we don't enforce the sandbox."
+  full data access to the sandboxed table. If so, we don't enforce the sandbox, because the other groups' permissions
+  supercede it."
   [group-id->perms-set {group-id :group_id, table-id :table_id}]
   (let [perms-set (->> (dissoc group-id->perms-set group-id)
                        (vals)

--- a/enterprise/backend/src/metabase_enterprise/sandbox/query_processor/middleware/row_level_restrictions.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/query_processor/middleware/row_level_restrictions.clj
@@ -7,7 +7,10 @@
    [clojure.set :as set]
    [clojure.tools.logging :as log]
    [medley.core :as m]
-   [metabase-enterprise.sandbox.models.group-table-access-policy :as gtap :refer [GroupTableAccessPolicy]]
+   [metabase-enterprise.sandbox.api.util :as mt.api.u]
+   [metabase-enterprise.sandbox.models.group-table-access-policy
+    :as gtap
+    :refer [GroupTableAccessPolicy]]
    [metabase.api.common :as api :refer [*current-user* *current-user-id*]]
    [metabase.db.connection :as mdb.connection]
    [metabase.mbql.schema :as mbql.s]
@@ -15,12 +18,14 @@
    [metabase.models.card :refer [Card]]
    [metabase.models.field :refer [Field]]
    [metabase.models.permissions :as perms]
-   [metabase.models.permissions-group-membership :refer [PermissionsGroupMembership]]
+   [metabase.models.permissions-group-membership
+    :refer [PermissionsGroupMembership]]
    [metabase.models.query.permissions :as query-perms]
    [metabase.models.table :refer [Table]]
    [metabase.plugins.classloader :as classloader]
    [metabase.query-processor.error-type :as qp.error-type]
-   [metabase.query-processor.middleware.fetch-source-query :as fetch-source-query]
+   [metabase.query-processor.middleware.fetch-source-query
+    :as fetch-source-query]
    [metabase.query-processor.middleware.permissions :as qp.perms]
    [metabase.query-processor.store :as qp.store]
    [metabase.util :as u]
@@ -87,10 +92,9 @@
     (let [group-ids           (qp.store/cached *current-user-id*
                                   (db/select-field :group_id PermissionsGroupMembership :user_id *current-user-id*))
           sandboxes           (when (seq group-ids)
-                               (db/select GroupTableAccessPolicy
-                                 :group_id [:in group-ids]
+                               (db/select GroupTableAccessPolicy :group_id [:in group-ids]
                                  :table_id [:in table-ids]))
-          enforced-sandboxes (enforced-sandboxes sandboxes group-ids)]
+          enforced-sandboxes (mt.api.u/enforced-sandboxes sandboxes)]
        (when (seq enforced-sandboxes)
          (assert-one-gtap-per-table enforced-sandboxes)
          enforced-sandboxes))))

--- a/enterprise/backend/test/metabase_enterprise/sandbox/models/params/chain_filter_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/models/params/chain_filter_test.clj
@@ -28,7 +28,8 @@
         (testing "When chain-filter with constraints"
           (testing "creates a linked-filter FieldValues if not sandboxed"
             ;; HACK to run this outside of sandboxing
-            (binding [api/*current-user-permissions-set* (atom #{"/"})]
+            (binding [api/*current-user-id*              nil
+                      api/*current-user-permissions-set* (atom #{"/"})]
               (is (= {:values          ["Artisan"]
                       :has_more_values false}
                      (mt/$ids (chain-filter/chain-filter %categories.name {%categories.id 3})))))

--- a/enterprise/backend/test/metabase_enterprise/sandbox/query_processor/middleware/row_level_restrictions_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/query_processor/middleware/row_level_restrictions_test.clj
@@ -251,13 +251,6 @@
   (mt/test-drivers (into #{}
                          (filter #(isa? driver/hierarchy % :sql))
                          (mt/normal-drivers-with-feature :nested-queries))
-    (testing "When querying with full permissions, no changes should be made"
-      (met/with-gtaps {:gtaps      {:venues (venues-category-mbql-gtap-def)}
-                       :attributes {"cat" 50}}
-        (perms/grant-permissions! &group (perms/table-query-path (db/select-one Table :id (mt/id :venues))))
-        (is (= [[100]]
-               (run-venues-count-query)))))
-
     (testing (str "Basic test around querying a table by a user with segmented only permissions and a GTAP question that "
                   "is a native query")
       (met/with-gtaps {:gtaps      {:venues (venues-category-native-gtap-def)}

--- a/src/metabase/query_processor/util/persisted_cache.clj
+++ b/src/metabase/query_processor/util/persisted_cache.clj
@@ -11,7 +11,9 @@
 (defn- segmented-user?
   []
   (if-let [segmented? (resolve 'metabase-enterprise.sandbox.api.util/segmented-user?)]
-    (segmented?)
+    (try (segmented?)
+      ;; Fail closed (i.e. default to true) if `segmented-user` throws an exception due to no current user being bound
+      (catch Throwable _ true))
     false))
 
 (defn can-substitute?

--- a/test/metabase/driver/common/parameters/values_test.clj
+++ b/test/metabase/driver/common/parameters/values_test.clj
@@ -288,131 +288,132 @@
 
 
 (deftest card-query-test
-  (testing "Card query template tag gets card's native query"
-    (let [test-query "SELECT 1"]
-      (mt/with-temp Card [card {:dataset_query {:database (mt/id)
-                                                :type     "native"
-                                                :native   {:query test-query}}}]
-        (is (= {:card-id (u/the-id card), :query test-query, :params nil}
-               (value-for-tag
-                {:name         "card-template-tag-test"
-                 :display-name "Card template tag test"
-                 :type         :card
-                 :card-id      (:id card)}
-                []))))))
+  (mt/with-test-user :rasta
+    (testing "Card query template tag gets card's native query"
+      (let [test-query "SELECT 1"]
+        (mt/with-temp Card [card {:dataset_query {:database (mt/id)
+                                                  :type     "native"
+                                                  :native   {:query test-query}}}]
+          (is (= {:card-id (u/the-id card), :query test-query, :params nil}
+                 (value-for-tag
+                  {:name         "card-template-tag-test"
+                   :display-name "Card template tag test"
+                   :type         :card
+                   :card-id      (:id card)}
+                  []))))))
 
-  (testing "Card query template tag generates native query for MBQL query"
-    (mt/with-everything-store
-      (driver/with-driver :h2
-        (let [mbql-query   (mt/mbql-query venues
-                             {:database (mt/id)
-                              :filter   [:< [:field $price nil] 3]})
-              expected-sql (str "SELECT "
-                                "\"PUBLIC\".\"VENUES\".\"ID\" AS \"ID\", "
-                                "\"PUBLIC\".\"VENUES\".\"NAME\" AS \"NAME\", "
-                                "\"PUBLIC\".\"VENUES\".\"CATEGORY_ID\" AS \"CATEGORY_ID\", "
-                                "\"PUBLIC\".\"VENUES\".\"LATITUDE\" AS \"LATITUDE\", "
-                                "\"PUBLIC\".\"VENUES\".\"LONGITUDE\" AS \"LONGITUDE\", "
-                                "\"PUBLIC\".\"VENUES\".\"PRICE\" AS \"PRICE\" "
-                                "FROM \"PUBLIC\".\"VENUES\" "
-                                "WHERE \"PUBLIC\".\"VENUES\".\"PRICE\" < 3 "
-                                "LIMIT 1048575")]
-          (mt/with-temp Card [card {:dataset_query mbql-query}]
-            (is (= {:card-id (u/the-id card), :query expected-sql, :params nil}
-                   (value-for-tag
-                    {:name         "card-template-tag-test"
-                     :display-name "Card template tag test"
-                     :type         :card
-                     :card-id      (:id card)}
-                    []))))))))
+    (testing "Card query template tag generates native query for MBQL query"
+      (mt/with-everything-store
+        (driver/with-driver :h2
+          (let [mbql-query   (mt/mbql-query venues
+                               {:database (mt/id)
+                                :filter   [:< [:field $price nil] 3]})
+                expected-sql (str "SELECT "
+                                  "\"PUBLIC\".\"VENUES\".\"ID\" AS \"ID\", "
+                                  "\"PUBLIC\".\"VENUES\".\"NAME\" AS \"NAME\", "
+                                  "\"PUBLIC\".\"VENUES\".\"CATEGORY_ID\" AS \"CATEGORY_ID\", "
+                                  "\"PUBLIC\".\"VENUES\".\"LATITUDE\" AS \"LATITUDE\", "
+                                  "\"PUBLIC\".\"VENUES\".\"LONGITUDE\" AS \"LONGITUDE\", "
+                                  "\"PUBLIC\".\"VENUES\".\"PRICE\" AS \"PRICE\" "
+                                  "FROM \"PUBLIC\".\"VENUES\" "
+                                  "WHERE \"PUBLIC\".\"VENUES\".\"PRICE\" < 3 "
+                                  "LIMIT 1048575")]
+            (mt/with-temp Card [card {:dataset_query mbql-query}]
+              (is (= {:card-id (u/the-id card), :query expected-sql, :params nil}
+                     (value-for-tag
+                      {:name         "card-template-tag-test"
+                       :display-name "Card template tag test"
+                       :type         :card
+                       :card-id      (:id card)}
+                      []))))))))
 
-  (testing "Persisted Models are substituted"
-    (mt/test-driver :postgres
-      (mt/dataset test-data
-        (mt/with-persistence-enabled [persist-models!]
-          (let [mbql-query (mt/mbql-query categories)]
-            (mt/with-temp* [Card [model {:name "model"
-                                         :dataset true
-                                         :dataset_query mbql-query
-                                         :database_id (mt/id)}]]
-              (persist-models!)
-              (testing "tag uses persisted table"
-                (let [pi (db/select-one 'PersistedInfo :card_id (u/the-id model))]
-                  (is (= "persisted" (:state pi)))
-                  (is (re-matches #"select \"id\", \"name\" from \"metabase_cache_[a-z0-9]+_[0-9]+\".\"model_[0-9]+_model\""
-                                  (:query
-                                   (value-for-tag
-                                    {:name         "card-template-tag-test"
-                                     :display-name "Card template tag test"
-                                     :type         :card
-                                     :card-id      (:id model)}
-                                    []))))
-                  (testing "query hits persisted table"
-                    (let [persisted-schema (ddl.i/schema-name {:id (mt/id)}
-                                                              (public-settings/site-uuid))
-                          update-query     (format "update %s.%s set name = name || ' from cached table'"
-                                                   persisted-schema (:table_name pi))
-                          model-query (format "select c_orig.name, c_cached.name
+    (testing "Persisted Models are substituted"
+      (mt/test-driver :postgres
+        (mt/dataset test-data
+          (mt/with-persistence-enabled [persist-models!]
+            (let [mbql-query (mt/mbql-query categories)]
+              (mt/with-temp* [Card [model {:name "model"
+                                           :dataset true
+                                           :dataset_query mbql-query
+                                           :database_id (mt/id)}]]
+                (persist-models!)
+                (testing "tag uses persisted table"
+                  (let [pi (db/select-one 'PersistedInfo :card_id (u/the-id model))]
+                    (is (= "persisted" (:state pi)))
+                    (is (re-matches #"select \"id\", \"name\" from \"metabase_cache_[a-z0-9]+_[0-9]+\".\"model_[0-9]+_model\""
+                                    (:query
+                                     (value-for-tag
+                                      {:name         "card-template-tag-test"
+                                       :display-name "Card template tag test"
+                                       :type         :card
+                                       :card-id      (:id model)}
+                                      []))))
+                    (testing "query hits persisted table"
+                      (let [persisted-schema (ddl.i/schema-name {:id (mt/id)}
+                                                                (public-settings/site-uuid))
+                            update-query     (format "update %s.%s set name = name || ' from cached table'"
+                                                     persisted-schema (:table_name pi))
+                            model-query (format "select c_orig.name, c_cached.name
                                                from categories c_orig
                                                left join {{#%d}} c_cached
                                                on c_orig.id = c_cached.id
                                                order by c_orig.id desc limit 3"
-                                              (u/the-id model))
-                          tag-name    (format "#%d" (u/the-id model))]
-                      (jdbc/execute! (sql-jdbc.conn/db->pooled-connection-spec (mt/db))
-                                     [update-query])
-                      (is (= [["Winery" "Winery from cached table"]
-                              ["Wine Bar" "Wine Bar from cached table"]
-                              ["Vegetarian / Vegan" "Vegetarian / Vegan from cached table"]]
-                             (mt/rows (qp/process-query
-                                       {:database (mt/id)
-                                        :type :native
-                                        :native {:query model-query
-                                                 :template-tags
-                                                 {(keyword tag-name)
-                                                  {:id "c6558da4-95b0-d829-edb6-45be1ee10d3c"
-                                                   :name tag-name
-                                                   :display-name tag-name
-                                                   :type "card"
-                                                   :card-id (u/the-id model)}}}}))))))))))))))
+                                                (u/the-id model))
+                            tag-name    (format "#%d" (u/the-id model))]
+                        (jdbc/execute! (sql-jdbc.conn/db->pooled-connection-spec (mt/db))
+                                       [update-query])
+                        (is (= [["Winery" "Winery from cached table"]
+                                ["Wine Bar" "Wine Bar from cached table"]
+                                ["Vegetarian / Vegan" "Vegetarian / Vegan from cached table"]]
+                               (mt/rows (qp/process-query
+                                         {:database (mt/id)
+                                          :type :native
+                                          :native {:query model-query
+                                                   :template-tags
+                                                   {(keyword tag-name)
+                                                    {:id "c6558da4-95b0-d829-edb6-45be1ee10d3c"
+                                                     :name tag-name
+                                                     :display-name tag-name
+                                                     :type "card"
+                                                     :card-id (u/the-id model)}}}}))))))))))))))
 
-  (testing "Card query template tag wraps error in tag details"
-    (mt/with-temp Card [param-card {:dataset_query
+    (testing "Card query template tag wraps error in tag details"
+      (mt/with-temp Card [param-card {:dataset_query
+                                      (mt/native-query
+                                        {:query "SELECT {{x}}"
+                                         :template-tags
+                                         {"x"
+                                          {:id   "x-tag", :name     "x", :display-name "Number x",
+                                           :type :number, :required false}}})}]
+        (let [param-card-id  (:id param-card)
+              param-card-tag (str "#" param-card-id)]
+          (mt/with-temp Card [card {:dataset_query
                                     (mt/native-query
-                                      {:query "SELECT {{x}}"
+                                      {:query (str "SELECT * FROM {{#" param-card-id "}} AS y")
                                        :template-tags
-                                       {"x"
-                                        {:id   "x-tag", :name     "x", :display-name "Number x",
-                                         :type :number, :required false}}})}]
-      (let [param-card-id  (:id param-card)
-            param-card-tag (str "#" param-card-id)]
-        (mt/with-temp Card [card {:dataset_query
-                                  (mt/native-query
-                                    {:query (str "SELECT * FROM {{#" param-card-id "}} AS y")
-                                     :template-tags
-                                     {param-card-tag
-                                      {:id   param-card-tag, :name    param-card-tag, :display-name param-card-tag
-                                       :type "card",         :card-id param-card-id}}})}]
-          (let [card-id  (:id card)
-                tag      {:name "card-template-tag-test", :display-name "Card template tag test",
-                          :type :card,                    :card-id      card-id}
-                e        (try
-                           (value-for-tag tag [])
-                           (catch ExceptionInfo e
-                             e))
-                exc-data (some (fn [e]
-                                 (when (:card-query-error? (ex-data e))
-                                   (ex-data e)))
-                               (take-while some? (iterate ex-cause e)))]
-            (testing "should be a card Query error"
-              (is (= true
-                     (boolean (:card-query-error? exc-data)))))
-            (testing "card-id"
-              (is (= card-id
-                     (:card-id exc-data))))
-            (testing "tag"
-              (is (= tag
-                     (:tag exc-data))))))))))
+                                       {param-card-tag
+                                        {:id   param-card-tag, :name    param-card-tag, :display-name param-card-tag
+                                         :type "card",         :card-id param-card-id}}})}]
+            (let [card-id  (:id card)
+                  tag      {:name "card-template-tag-test", :display-name "Card template tag test",
+                            :type :card,                    :card-id      card-id}
+                  e        (try
+                             (value-for-tag tag [])
+                             (catch ExceptionInfo e
+                               e))
+                  exc-data (some (fn [e]
+                                   (when (:card-query-error? (ex-data e))
+                                     (ex-data e)))
+                                 (take-while some? (iterate ex-cause e)))]
+              (testing "should be a card Query error"
+                (is (= true
+                       (boolean (:card-query-error? exc-data)))))
+              (testing "card-id"
+                (is (= card-id
+                       (:card-id exc-data))))
+              (testing "tag"
+                (is (= tag
+                       (:tag exc-data)))))))))))
 
 (deftest card-query-permissions-test
   (testing "We should be able to run a query referenced via a template tag if we have perms for the Card in question (#12354)"


### PR DESCRIPTION
Closes [#27299](https://github.com/metabase/metabase/issues/27299)

This PR reworks the `row-level-restrictions` middleware to use the `sandboxes` table directly (formerly the `group_table_access_policy` table) to determine what sandboxes should be applied to a given query. It also updates the `segmented-user?` helper function accordingly.

There's some tricky logic related to figuring out whether any _other_ groups supersede a sandbox for the current user. I've done my best to explain these in the relevant doc strings.

Since this should be a no-op, I couldn't think of any new tests that would be necessary (but happy to write some if anyone has ideas). The main validation of this change though is that existing sandboxing tests continue to pass.