### PR TITLE
Custom Table e2e Tests 3: Create and add writable DBs

### DIFF
--- a/frontend/test/__support__/e2e/cypress_data.js
+++ b/frontend/test/__support__/e2e/cypress_data.js
@@ -173,6 +173,27 @@ export const QA_DB_CONFIG = {
   },
 };
 
+export const TESTING_DB_CONFIG = {
+  mysql: {
+    client: "mysql2",
+    connection: {
+      ...QA_DB_CREDENTIALS,
+      user: "root", // only the root user has create database privileges
+      database: "testing_db",
+      port: QA_MYSQL_PORT,
+      multipleStatements: true,
+    },
+  },
+  postgres: {
+    client: "pg",
+    connection: {
+      ...QA_DB_CREDENTIALS,
+      database: "testing_db",
+      port: QA_POSTGRES_PORT,
+    },
+  },
+};
+
 export const WEBMAIL_CONFIG = {
   WEB_PORT: 1080,
   SMTP_PORT: 1025,

--- a/frontend/test/__support__/e2e/cypress_data.js
+++ b/frontend/test/__support__/e2e/cypress_data.js
@@ -173,13 +173,15 @@ export const QA_DB_CONFIG = {
   },
 };
 
-export const TESTING_DB_CONFIG = {
+export const WRITABLE_DB_ID = 2;
+
+export const WRITABLE_DB_CONFIG = {
   mysql: {
     client: "mysql2",
     connection: {
       ...QA_DB_CREDENTIALS,
       user: "root", // only the root user has create database privileges
-      database: "testing_db",
+      database: "writable_db",
       port: QA_MYSQL_PORT,
       multipleStatements: true,
     },
@@ -188,7 +190,7 @@ export const TESTING_DB_CONFIG = {
     client: "pg",
     connection: {
       ...QA_DB_CREDENTIALS,
-      database: "testing_db",
+      database: "writable_db",
       port: QA_POSTGRES_PORT,
     },
   },

--- a/frontend/test/__support__/e2e/helpers/e2e-qa-databases-helpers.js
+++ b/frontend/test/__support__/e2e/helpers/e2e-qa-databases-helpers.js
@@ -150,7 +150,7 @@ export const setupTestDB = (type = "postgres") => {
     if (!results.rows.length) {
       cy.log(`**-- Adding ${type} DB for actions --**`);
       cy.task("connectAndQueryDB", {
-        connectionConfig,
+        connectionConfig: connectionConfig[type],
         query: `CREATE DATABASE testing_db;`,
       });
     }

--- a/frontend/test/__support__/e2e/helpers/e2e-qa-databases-helpers.js
+++ b/frontend/test/__support__/e2e/helpers/e2e-qa-databases-helpers.js
@@ -3,6 +3,7 @@ import {
   QA_MONGO_PORT,
   QA_MYSQL_PORT,
   QA_DB_CREDENTIALS,
+  TESTING_DB_CONFIG,
   QA_DB_CONFIG,
 } from "__support__/e2e/cypress_data";
 
@@ -15,30 +16,38 @@ export function addMongoDatabase(name = "QA Mongo4") {
   addQADatabase("mongo", name, QA_MONGO_PORT);
 }
 
-export function addPostgresDatabase(name = "QA Postgres12") {
+export function addPostgresDatabase(name = "QA Postgres12", writable = false) {
   // https://hub.docker.com/layers/metabase/qa-databases/postgres-sample-12/images/sha256-80bbef27dc52552d6dc64b52796ba356d7541e7bba172740336d7b8a64859cf8
-  addQADatabase("postgres", name, QA_POSTGRES_PORT);
+  addQADatabase("postgres", name, QA_POSTGRES_PORT, writable);
 }
 
-export function addMySQLDatabase(name = "QA MySQL8") {
+export function addMySQLDatabase(name = "QA MySQL8", writable = false) {
   // https://hub.docker.com/layers/metabase/qa-databases/mysql-sample-8/images/sha256-df67db50379ec59ac3a437b5205871f85ab519ce8d2cdc526e9313354d00f9d4
-  addQADatabase("mysql", name, QA_MYSQL_PORT);
+  addQADatabase("mysql", name, QA_MYSQL_PORT, writable);
 }
 
-function addQADatabase(engine, db_display_name, port) {
+function addQADatabase(engine, db_display_name, port, enable_actions = false) {
   const PASS_KEY = engine === "mongo" ? "pass" : "password";
   const AUTH_DB = engine === "mongo" ? "admin" : null;
   const OPTIONS = engine === "mysql" ? "allowPublicKeyRetrieval=true" : null;
+
+  const db_name = enable_actions
+    ? TESTING_DB_CONFIG[engine].connection.database
+    : QA_DB_CREDENTIALS.database;
+
+  const credentials = enable_actions
+    ? TESTING_DB_CONFIG[engine].connection
+    : QA_DB_CREDENTIALS;
 
   cy.log(`**-- Adding ${engine.toUpperCase()} DB --**`);
   cy.request("POST", "/api/database", {
     engine: engine,
     name: db_display_name,
     details: {
-      dbname: QA_DB_CREDENTIALS.database,
-      host: QA_DB_CREDENTIALS.host,
+      dbname: db_name,
+      host: credentials.host,
       port: port,
-      user: QA_DB_CREDENTIALS.user,
+      user: credentials.user,
       [PASS_KEY]: QA_DB_CREDENTIALS.password, // NOTE: we're inconsistent in where we use `pass` vs `password` as a key
       authdb: AUTH_DB,
       "additional-options": OPTIONS,
@@ -61,13 +70,25 @@ function addQADatabase(engine, db_display_name, port) {
         schedule_type: "hourly",
       },
     },
-  }).then(({ status, body }) => {
-    expect(status).to.equal(200);
-    cy.wrap(body.id).as(`${engine}ID`);
-  });
+  })
+    .then(({ status, body }) => {
+      expect(status).to.equal(200);
+      cy.wrap(body.id).as(`${engine}ID`);
+    })
+    .then(dbId => {
+      // Make sure we have all the metadata because we'll need to use it in tests
+      assertOnDatabaseMetadata(engine);
 
-  // Make sure we have all the metadata because we'll need to use it in tests
-  assertOnDatabaseMetadata(engine);
+      // it's important that we don't enable actions until sync is complete
+      if (dbId && enable_actions) {
+        cy.log(`**-- Enabling actions --**`);
+        cy.request("PUT", `/api/database/${dbId}`, {
+          settings: { "database-enable-actions": true },
+        }).then(({ status }) => {
+          expect(status).to.equal(200);
+        });
+      }
+    });
 }
 
 function assertOnDatabaseMetadata(engine) {
@@ -95,9 +116,57 @@ function recursiveCheck(id, i = 0) {
   });
 }
 
+export const setupTestDB = (type = "postgres") => {
+  const connectionConfig = {
+    postgres: {
+      client: "pg",
+      connection: {
+        ...QA_DB_CREDENTIALS,
+        port: QA_POSTGRES_PORT,
+      },
+    },
+    mysql: {
+      client: "mysql2",
+      connection: {
+        ...QA_DB_CREDENTIALS,
+        user: "root",
+        port: QA_MYSQL_PORT,
+      },
+    },
+  };
+
+  const dbName = TESTING_DB_CONFIG[type].connection.database;
+
+  const dbCheckQuery = {
+    postgres: `SELECT FROM pg_database WHERE datname = '${dbName}';`,
+    mysql: `SELECT SCHEMA_NAME FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME='${dbName}'`,
+  };
+
+  // we need to initially connect to the db we know exists to create the testing_db
+  cy.task("connectAndQueryDB", {
+    connectionConfig: connectionConfig[type],
+    query: dbCheckQuery[type],
+  }).then(results => {
+    if (!results.rows.length) {
+      cy.log(`**-- Adding ${type} DB for actions --**`);
+      cy.task("connectAndQueryDB", {
+        connectionConfig,
+        query: `CREATE DATABASE testing_db;`,
+      });
+    }
+  });
+};
+
 export function queryQADB(query, type = "postgres") {
   return cy.task("connectAndQueryDB", {
     connectionConfig: QA_DB_CONFIG[type],
+    query,
+  });
+}
+
+export function queryTestDB(query, type = "postgres") {
+  return cy.task("connectAndQueryDB", {
+    connectionConfig: TESTING_DB_CONFIG[type],
     query,
   });
 }

--- a/frontend/test/metabase/scenarios/admin/databases/actions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/databases/actions.cy.spec.js
@@ -1,0 +1,22 @@
+import { restore } from "__support__/e2e/helpers";
+
+describe(
+  "admin > database > external databases > enable actions",
+  { tags: "@external" },
+  () => {
+    ["mysql", "postgres"].forEach(dialect => {
+      it(`should show ${dialect} testing_db with actions enabled`, () => {
+        restore(`${dialect}-writable`);
+        cy.signInAsAdmin();
+
+        cy.request("/api/database/2").then(({ body }) => {
+          expect(body.name).to.include("Writable");
+          expect(body.name.toLowerCase()).to.include(dialect);
+
+          expect(body.details.dbname).to.equal("testing_db");
+          expect(body.settings["database-enable-actions"]).to.eq(true);
+        });
+      });
+    });
+  },
+);

--- a/frontend/test/metabase/scenarios/admin/databases/actions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/databases/actions.cy.spec.js
@@ -1,21 +1,34 @@
 import { restore } from "__support__/e2e/helpers";
+import {
+  WRITABLE_DB_ID,
+  WRITABLE_DB_CONFIG,
+} from "__support__/e2e/cypress_data";
 
 describe(
   "admin > database > external databases > enable actions",
-  { tags: "@external" },
+  { tags: ["@external", "@actions"] },
   () => {
     ["mysql", "postgres"].forEach(dialect => {
-      it(`should show ${dialect} testing_db with actions enabled`, () => {
+      it(`should show ${dialect} writable_db with actions enabled`, () => {
         restore(`${dialect}-writable`);
         cy.signInAsAdmin();
 
-        cy.request("/api/database/2").then(({ body }) => {
+        cy.request(`/api/database/${WRITABLE_DB_ID}`).then(({ body }) => {
           expect(body.name).to.include("Writable");
           expect(body.name.toLowerCase()).to.include(dialect);
 
-          expect(body.details.dbname).to.equal("testing_db");
+          expect(body.details.dbname).to.equal(
+            WRITABLE_DB_CONFIG[dialect].connection.database,
+          );
           expect(body.settings["database-enable-actions"]).to.eq(true);
         });
+
+        cy.visit(`/admin/databases/${WRITABLE_DB_ID}`);
+        cy.get("#model-actions-toggle").should(
+          "have.attr",
+          "aria-checked",
+          "true",
+        );
       });
     });
   },

--- a/frontend/test/snapshot-creators/qa-db.cy.snap.js
+++ b/frontend/test/snapshot-creators/qa-db.cy.snap.js
@@ -4,6 +4,7 @@ import {
   addPostgresDatabase,
   addMongoDatabase,
   addMySQLDatabase,
+  setupTestDB,
 } from "__support__/e2e/helpers";
 
 describe("qa databases snapshots", { tags: "@external" }, () => {
@@ -27,6 +28,20 @@ describe("qa databases snapshots", { tags: "@external" }, () => {
     addMongoDatabase();
     snapshot("mongo-4");
     deleteDatabase("mongoID");
+
+    restoreAndAuthenticate();
+
+    setupTestDB("mysql");
+    addMySQLDatabase("Writable MySQL8", true);
+    snapshot("mysql-writable");
+    deleteDatabase("mysqlID");
+
+    restoreAndAuthenticate();
+
+    setupTestDB("postgres");
+    addPostgresDatabase("Writable Postgres12", true);
+    snapshot("postgres-writable");
+    deleteDatabase("postgresID");
 
     restore("blank");
   });

--- a/frontend/test/snapshot-creators/qa-db.cy.snap.js
+++ b/frontend/test/snapshot-creators/qa-db.cy.snap.js
@@ -4,7 +4,7 @@ import {
   addPostgresDatabase,
   addMongoDatabase,
   addMySQLDatabase,
-  setupTestDB,
+  setupWritableDB,
 } from "__support__/e2e/helpers";
 
 describe("qa databases snapshots", { tags: "@external" }, () => {
@@ -31,14 +31,14 @@ describe("qa databases snapshots", { tags: "@external" }, () => {
 
     restoreAndAuthenticate();
 
-    setupTestDB("mysql");
+    setupWritableDB("mysql");
     addMySQLDatabase("Writable MySQL8", true);
     snapshot("mysql-writable");
     deleteDatabase("mysqlID");
 
     restoreAndAuthenticate();
 
-    setupTestDB("postgres");
+    setupWritableDB("postgres");
     addPostgresDatabase("Writable Postgres12", true);
     snapshot("postgres-writable");
     deleteDatabase("postgresID");


### PR DESCRIPTION
## Description
- as we add more tables, many of which we will want to test write actions against, we should make separate databases on the same DB servers for this purpose - so as not to dirty up datasets that we rely on remaining stable.
- Additions
  - adds a  `setupTestDB()` function that can create `testing_db` ephemeral databases in either our postgres or mysql containers.
  - adds an `is_writable` parameter to our `addQADatabase()` helper function to allow it to have conditional logic to use the correct credentials for writable DBs, and enables write actions in metabase on those DBs
  - uses the above to create writable snapshots for both postgres and mysql that we can use throughout our test suite.
  - adds a `queryTestDB()` function to easily run queries against the writable test DBs


Also adds tests that assert that the metabase API recognizes these DBs have actions enabled

![Screen Shot 2023-01-31 at 3 02 06 PM](https://user-images.githubusercontent.com/30528226/215898906-33a9308d-fe0a-4dd5-9a1a-a9eee2399830.png)

