### PR TITLE
Custom Table e2e Tests 4: Allow reusable multi-dialect schema reset

### DIFF
--- a/frontend/test/__support__/e2e/db_tasks.js
+++ b/frontend/test/__support__/e2e/db_tasks.js
@@ -1,5 +1,5 @@
 import Knex from "knex";
-import { TESTING_DB_CONFIG } from "./cypress_data";
+import { WRITABLE_DB_CONFIG } from "./cypress_data";
 import * as testTables from "./test_tables";
 
 const dbClients = {};
@@ -31,7 +31,7 @@ export async function connectAndQueryDB({ connectionConfig, query }) {
   }
 }
 export async function resetTable({ type = "postgres", table = "testTable1" }) {
-  const dbClient = getDbClient(TESTING_DB_CONFIG[type]);
+  const dbClient = getDbClient(WRITABLE_DB_CONFIG[type]);
 
   // eslint-disable-next-line import/namespace
   return testTables?.[table]?.(dbClient);

--- a/frontend/test/__support__/e2e/db_tasks.js
+++ b/frontend/test/__support__/e2e/db_tasks.js
@@ -1,4 +1,6 @@
 import Knex from "knex";
+import { TESTING_DB_CONFIG } from "./cypress_data";
+import * as testTables from "./test_tables";
 
 const dbClients = {};
 
@@ -27,4 +29,10 @@ export async function connectAndQueryDB({ connectionConfig, query }) {
   if (connectionConfig.client === "pg") {
     return result;
   }
+}
+export async function resetTable({ type = "postgres", table = "testTable1" }) {
+  const dbClient = getDbClient(TESTING_DB_CONFIG[type]);
+
+  // eslint-disable-next-line import/namespace
+  return testTables?.[table]?.(dbClient);
 }

--- a/frontend/test/__support__/e2e/helpers/e2e-qa-databases-helpers.js
+++ b/frontend/test/__support__/e2e/helpers/e2e-qa-databases-helpers.js
@@ -172,6 +172,10 @@ export function queryWritableDB(query, type = "postgres") {
   });
 }
 
+export function resetTestTable({ type, table }) {
+  cy.task("resetTable", { type, table });
+}
+
 // will this work for multiple schemas?
 export function getTableId({ databaseId = WRITABLE_DB_ID, name }) {
   return cy

--- a/frontend/test/__support__/e2e/test_tables.js
+++ b/frontend/test/__support__/e2e/test_tables.js
@@ -1,0 +1,6 @@
+// define test schema such that they can be used in multiple SQL dialects using
+// knex's schema builder https://knexjs.org/guide/schema-builder.html
+
+// we cannot use knex to define multi-dialect schemas because we can only pass
+// json-serializable data to cypress tasks (which run in node)
+// https://docs.cypress.io/api/commands/task#Arguments

--- a/frontend/test/__support__/e2e/test_tables.js
+++ b/frontend/test/__support__/e2e/test_tables.js
@@ -4,3 +4,21 @@
 // we cannot use knex to define multi-dialect schemas because we can only pass
 // json-serializable data to cypress tasks (which run in node)
 // https://docs.cypress.io/api/commands/task#Arguments
+
+export const colors27745 = async dbClient => {
+  const tableName = "colors27745";
+
+  await dbClient.schema.dropTableIfExists(tableName);
+  await dbClient.schema.createTable(tableName, table => {
+    table.increments("id").primary();
+    table.string("name").unique().notNullable();
+  });
+
+  await dbClient(tableName).insert([
+    { name: "red" },
+    { name: "green" },
+    { name: "blue" },
+  ]);
+
+  return true;
+};

--- a/frontend/test/metabase/scenarios/custom-column/reproductions/27745-cc-numeric-missing-summarize.cy.spec.js
+++ b/frontend/test/metabase/scenarios/custom-column/reproductions/27745-cc-numeric-missing-summarize.cy.spec.js
@@ -4,52 +4,25 @@ import {
   enterCustomColumnDetails,
   visualize,
   popover,
-  queryQADB,
+  resetTestTable,
 } from "__support__/e2e/helpers";
-
-const createTableQueries = {
-  postgres: `
-    DROP TABLE IF EXISTS colors;
-
-    CREATE TABLE colors (
-      id INTEGER PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
-      color VARCHAR ( 255 ) UNIQUE NOT NULL
-    );
-
-    INSERT INTO colors (color) VALUES ('red'), ('green'), ('blue');
-  `,
-  mysql: `
-    DROP TABLE IF EXISTS colors;
-
-    CREATE TABLE colors (
-      id INTEGER PRIMARY KEY AUTO_INCREMENT,
-      color VARCHAR ( 255 ) UNIQUE NOT NULL
-    );
-
-    INSERT INTO colors (color) VALUES ('red'), ('green'), ('blue');
-  `,
-};
-
-const snapshotMap = {
-  postgres: "postgres-12",
-  mysql: "mysql-8",
-};
 
 ["postgres", "mysql"].forEach(dialect => {
   describe.skip(`issue 27745 (${dialect})`, { tags: "@external" }, () => {
+    const tableName = "colors27745";
+
     beforeEach(() => {
-      restore(snapshotMap[dialect]);
+      restore(`${dialect}-writable`);
       cy.signInAsAdmin();
 
-      queryQADB(createTableQueries[dialect], dialect);
-
+      resetTestTable({ type: dialect, table: tableName });
       cy.request("POST", "/api/database/2/sync_schema");
     });
 
     it("should display all summarize options if the only numeric field is a custom column (metabase#27745)", () => {
       startNewQuestion();
-      cy.findByText(/QA/i).click();
-      cy.findByText("Colors").click();
+      cy.findByText(/Writable/i).click();
+      cy.findByText(/colors/i).click();
       cy.icon("add_data").click();
       enterCustomColumnDetails({
         formula: "case([ID] > 1, 25, 5)",


### PR DESCRIPTION
## Description

- Adds a `resetTestTable()` helper function that will reset the schema and all data in the given table for the given SQL dialect
- Adds a `test_tables` file for the test table schema definitions to live
- Converts the repro for #27745 to use a single knex schema definition

Again, the reproduction fails, as it should

![Screen Shot 2023-01-31 at 3 46 50 PM](https://user-images.githubusercontent.com/30528226/215901318-f4855546-cf8c-4bb0-9771-5b0e73a8273b.png)

But again, the tables seed correctly

![Screen Shot 2023-01-31 at 3 47 22 PM](https://user-images.githubusercontent.com/30528226/215901320-6210589b-5c51-4bb8-a386-f4f71d03b595.png)
![Screen Shot 2023-01-31 at 3 47 05 PM](https://user-images.githubusercontent.com/30528226/215901321-ffbe9c68-975d-4eb2-9fab-6c33c647b75a.png)


