### PR TITLE
Avoid second counting for MongoDB 5+

### DIFF
--- a/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
@@ -13,6 +13,7 @@
    [metabase.mbql.schema :as mbql.s]
    [metabase.mbql.util :as mbql.u]
    [metabase.models.field :refer [Field]]
+   [metabase.models.setting :as setting]
    [metabase.query-processor.error-type :as qp.error-type]
    [metabase.query-processor.interface :as qp.i]
    [metabase.query-processor.middleware.annotate :as annotate]
@@ -253,9 +254,17 @@
   [field unit]
   (if (= unit :default)
     field
-    (let [column field]
+    (let [date-trunc? (-> (get-mongo-version)
+                          :semantic-version
+                          (driver.u/semantic-version-gte [5]))
+          column field]
       (letfn [(truncate [unit]
-                (truncate-to-resolution column unit))]
+                (if date-trunc?
+                  {:$dateTrunc {:date column
+                                :unit (name unit)
+                                :timezone (qp.timezone/results-timezone-id)
+                                :startOfWeek (name (setting/get-value-of-type :keyword :start-of-week))}}
+                  (truncate-to-resolution column unit)))]
         (case unit
           :default          column
           :second-of-minute {$second column}
@@ -267,9 +276,14 @@
           :day-of-week      (day-of-week column)
           :day-of-month     {$dayOfMonth column}
           :day-of-year      {$dayOfYear column}
-          :week             (truncate-to-resolution (week column) :day)
-          :week-of-year     {:$ceil {$divide [{$dayOfYear (week column)}
-                                              7.0]}}
+          :week             (if date-trunc?
+                              (truncate :week)
+                              (truncate-to-resolution (week column) :day))
+          :week-of-year     (let [week-start (if date-trunc?
+                                               (truncate :week)
+                                               (week column))]
+                              {:$ceil {$divide [{$dayOfYear week-start}
+                                                7.0]}})
           :week-of-year-iso {:$isoWeek column}
           :week-of-year-us  (week-of-year column :us)
           :week-of-year-instance  (week-of-year column :instance)
@@ -279,19 +293,16 @@
           ;; stringify it as yyyy-MM Subtracting (($dayOfYear(column) % 91) - 3) days will put you in correct month.
           ;; Trust me.
           :quarter
-          (mongo-let [#_:clj-kondo/ignore parts {:$dateToParts {:date column}}]
-            {:$dateFromParts {:year  :$$parts.year
-                              :month {$subtract [:$$parts.month
-                                                 {$mod [{$add [:$$parts.month 2]}
-                                                        3]}]}}})
+          (if date-trunc?
+            (truncate :quarter)
+            (mongo-let [#_:clj-kondo/ignore parts {:$dateToParts {:date column}}]
+                       {:$dateFromParts {:year  :$$parts.year
+                                         :month {$subtract [:$$parts.month
+                                                            {$mod [{$add [:$$parts.month 2]}
+                                                                   3]}]}}}))
 
           :quarter-of-year
-          (mongo-let [month {$month column}]
-            ;; TODO -- $floor ?
-            {$divide [{$subtract [{$add [month 2]}
-                                  {$mod [{$add [month 2]}
-                                         3]}]}
-                      3]})
+          {:$ceil {$divide [{$month column} 3.0]}}
 
           :year
           (truncate :year)

--- a/modules/drivers/mongo/test/metabase/driver/mongo/query_processor_test.clj
+++ b/modules/drivers/mongo/test/metabase/driver/mongo/query_processor_test.clj
@@ -89,8 +89,8 @@
                     :mbql?       true}
                    (qp/compile
                     (mt/mbql-query attempts
-                                   {:aggregation [[:count]]
-                                    :filter      [:time-interval $datetime :last :month]}))))
+                      {:aggregation [[:count]]
+                       :filter      [:time-interval $datetime :last :month]}))))
 
             (testing "should still work even with bucketing bucketing"
               (let [tz (qp.timezone/results-timezone-id :mongo mt/db)

--- a/modules/drivers/mongo/test/metabase/driver/mongo/query_processor_test.clj
+++ b/modules/drivers/mongo/test/metabase/driver/mongo/query_processor_test.clj
@@ -68,6 +68,9 @@
                                            [:field "date-field"]
                                            [:absolute-datetime date]]))))))))
 
+(defn- date-arithmetic-supported? []
+  (driver/database-supports? :mongo :date-arithmetics (mt/db)))
+
 (deftest no-initial-projection-test
   (mt/test-driver :mongo
     (testing "Don't need to create initial projections anymore (#4216)"
@@ -86,33 +89,43 @@
                     :mbql?       true}
                    (qp/compile
                     (mt/mbql-query attempts
-                      {:aggregation [[:count]]
-                       :filter      [:time-interval $datetime :last :month]}))))
+                                   {:aggregation [[:count]]
+                                    :filter      [:time-interval $datetime :last :month]}))))
 
             (testing "should still work even with bucketing bucketing"
-              (let [query (mt/with-everything-store
+              (let [tz (qp.timezone/results-timezone-id :mongo mt/db)
+                    query (mt/with-everything-store
                             (qp/compile
                              (mt/mbql-query attempts
-                               {:aggregation [[:count]]
-                                :breakout    [[:field %datetime {:temporal-unit :month}]
-                                              [:field %datetime {:temporal-unit :day}]]
-                                :filter      [:= [:field %datetime {:temporal-unit :month}] [:relative-datetime -1 :month]]})))]
+                                            {:aggregation [[:count]]
+                                             :breakout    [[:field %datetime {:temporal-unit :month}]
+                                                           [:field %datetime {:temporal-unit :day}]]
+                                             :filter      [:= [:field %datetime {:temporal-unit :month}] [:relative-datetime -1 :month]]})))]
                 (is (= {:projections ["datetime~~~month" "datetime~~~day" "count"]
                         :query       [{"$match"
                                        {"$and"
                                         [{:$expr {"$gte" ["$datetime" {:$dateFromString {:dateString "2021-01-01T00:00Z"}}]}}
                                          {:$expr {"$lt" ["$datetime" {:$dateFromString {:dateString "2021-02-01T00:00Z"}}]}}]}}
-                                      {"$group" {"_id"   {"datetime~~~month" {:$let {:vars {:parts {:$dateToParts {:date "$datetime"
-                                                                                                                   :timezone (qp.timezone/results-timezone-id :mongo mt/db)}}}
-                                                                                     :in   {:$dateFromParts {:year  "$$parts.year"
-                                                                                                             :month "$$parts.month"
-                                                                                                             :timezone (qp.timezone/results-timezone-id :mongo mt/db)}}}},
-                                                          "datetime~~~day"   {:$let {:vars {:parts {:$dateToParts {:date "$datetime"
-                                                                                                                   :timezone (qp.timezone/results-timezone-id :mongo mt/db)}}}
-                                                                                     :in   {:$dateFromParts {:year  "$$parts.year"
-                                                                                                             :month "$$parts.month"
-                                                                                                             :day   "$$parts.day"
-                                                                                                             :timezone (qp.timezone/results-timezone-id :mongo mt/db)}}}}}
+                                      {"$group" {"_id"   (if (date-arithmetic-supported?)
+                                                           {"datetime~~~month" {:$dateTrunc {:date "$datetime"
+                                                                                             :startOfWeek "sunday"
+                                                                                             :timezone tz
+                                                                                             :unit "month"}}
+                                                            "datetime~~~day" {:$dateTrunc {:date "$datetime"
+                                                                                           :startOfWeek "sunday"
+                                                                                           :timezone tz
+                                                                                           :unit "day"}}}
+                                                           {"datetime~~~month" {:$let {:vars {:parts {:$dateToParts {:date "$datetime"
+                                                                                                                     :timezone tz}}}
+                                                                                       :in   {:$dateFromParts {:year  "$$parts.year"
+                                                                                                               :month "$$parts.month"
+                                                                                                               :timezone tz}}}}
+                                                            "datetime~~~day"   {:$let {:vars {:parts {:$dateToParts {:date "$datetime"
+                                                                                                                     :timezone tz}}}
+                                                                                       :in   {:$dateFromParts {:year  "$$parts.year"
+                                                                                                               :month "$$parts.month"
+                                                                                                               :day   "$$parts.day"
+                                                                                                               :timezone tz}}}}})
                                                  "count" {"$sum" 1}}}
                                       {"$sort" {"_id" 1}}
                                       {"$project" {"_id"              false
@@ -333,11 +346,19 @@
                   {"$group"
                    {"_id"
                     {"date~~~day"
-                     {:$let
-                      {:vars {:parts {:$dateToParts {:date "$date"
-                                                     :timezone (qp.timezone/results-timezone-id :mongo mt/db)}}},
-                       :in   {:$dateFromParts {:year "$$parts.year", :month "$$parts.month", :day "$$parts.day"
-                                               :timezone (qp.timezone/results-timezone-id :mongo mt/db)}}}}}}}
+                     (let [tz (qp.timezone/results-timezone-id :mongo mt/db)]
+                       (if (date-arithmetic-supported?)
+                         {:$dateTrunc {:date "$date"
+                                       :startOfWeek "sunday"
+                                       :timezone tz
+                                       :unit "day"}}
+                         {:$let
+                          {:vars {:parts {:$dateToParts {:date "$date"
+                                                         :timezone tz}}}
+                           :in   {:$dateFromParts {:year "$$parts.year"
+                                                   :month "$$parts.month"
+                                                   :day "$$parts.day"
+                                                   :timezone tz}}}}))}}}
                   {"$sort" {"_id" 1}}
                   {"$project" {"_id" false, "date~~~day" "$_id.date~~~day"}}
                   {"$sort" {"date~~~day" 1}}


### PR DESCRIPTION
Related to #13344.

This PR assumes that the problem we want to solve is wrong date arithmetic in the presence of leap seconds. The problem is not serious, there have been no leap seconds since 2017, there will be none on June 30, 2023 and probably none in December 2023.

There seems to be no clean way to avoid second calculations in MongoDB before version 5, so this PR checks the database version and uses the old way if `$dateTrunc` is not available. The PR simplifies a number of cases for version 5+.
