### PR TITLE
Custom Table e2e Tests 5: Simple actions testing

### DIFF
--- a/docs/developers-guide/e2e-tests.md
+++ b/docs/developers-guide/e2e-tests.md
@@ -116,5 +116,14 @@ If you navigate to the `/admin/settings/license` page, the license input field s
 
 
 - If tests under `describeEE` block are greyed out and not running, make sure you entered the environment variables correctly.
-- If tests start running but the enterprise features are missing: make sure that the token is still valid. 
+- If tests start running but the enterprise features are missing: make sure that the token is still valid.
 - If everything with the token seems to be okay, go nuclear and destroy all Java processes: run `killall java` and restart Cypress.
+
+## Tags
+
+Cypress allows us to [tag](https://github.com/cypress-io/cypress/tree/develop/npm/grep#tags-in-the-test-config-object) tests, to easily find certain categories of tags. For example, we can tag all tests that require an external database with `@external` and then run only those tests with `yarn test-cypress-open --env grepTags="@external"`. Tags should start with `@` just to make it easier to distinguish them from other strings in searches.
+
+These are the tags currently in use:
+
+- `@external` - tests that require an external docker container to run
+- `@actions` - tests that use metabase actions and mutate data in a data source

--- a/frontend/test/__support__/e2e/helpers/e2e-action-helpers.js
+++ b/frontend/test/__support__/e2e/helpers/e2e-action-helpers.js
@@ -8,6 +8,9 @@ export function enableActionsForDB(dbId = SAMPLE_DB_ID) {
   });
 }
 
+export function fillActionQuery(query) {
+  cy.get(".ace_content").type(query, { parseSpecialCharSequences: false });
+
 /**
  *
  * @param {import("metabase/entities/actions/actions").CreateQueryActionParams} actionDetails

--- a/frontend/test/__support__/e2e/helpers/e2e-action-helpers.js
+++ b/frontend/test/__support__/e2e/helpers/e2e-action-helpers.js
@@ -10,7 +10,7 @@ export function enableActionsForDB(dbId = SAMPLE_DB_ID) {
 
 export function fillActionQuery(query) {
   cy.get(".ace_content").type(query, { parseSpecialCharSequences: false });
-
+}
 /**
  *
  * @param {import("metabase/entities/actions/actions").CreateQueryActionParams} actionDetails

--- a/frontend/test/__support__/e2e/helpers/e2e-qa-databases-helpers.js
+++ b/frontend/test/__support__/e2e/helpers/e2e-qa-databases-helpers.js
@@ -200,3 +200,10 @@ export function waitForSyncToFinish(iteration = 0, databaseId = 2) {
     return;
   });
 }
+
+export function resyncDatabase(DB_ID = 2) {
+  // must be signed in as admin to sync
+  cy.request("POST", `/api/database/${DB_ID}/sync_schema`);
+  cy.request("POST", `/api/database/${DB_ID}/rescan_values`);
+  waitForSyncToFinish(0, DB_ID);
+}

--- a/frontend/test/__support__/e2e/helpers/e2e-qa-databases-helpers.js
+++ b/frontend/test/__support__/e2e/helpers/e2e-qa-databases-helpers.js
@@ -184,3 +184,19 @@ export function getTableId({ databaseId = WRITABLE_DB_ID, name }) {
       return body.tables.find(table => table.name === name).id;
     });
 }
+
+export function waitForSyncToFinish(iteration = 0, databaseId = 2) {
+  // 100 x 100ms should be plenty of time for the sync to finish.
+  if (iteration === 100) {
+    return;
+  }
+
+  cy.request("GET", `/api/database/${databaseId}/metadata`).then(({ body }) => {
+    if (!body.tables.length) {
+      cy.wait(100);
+      waitForSyncToFinish(++iteration, databaseId);
+    }
+
+    return;
+  });
+}

--- a/frontend/test/__support__/e2e/helpers/e2e-qa-databases-helpers.js
+++ b/frontend/test/__support__/e2e/helpers/e2e-qa-databases-helpers.js
@@ -181,7 +181,7 @@ export function getTableId({ databaseId = WRITABLE_DB_ID, name }) {
   return cy
     .request("GET", `/api/database/${databaseId}/metadata`)
     .then(({ body }) => {
-      return body.tables.find(table => table.name === name).id;
+      return body?.tables?.find(table => table.name === name)?.id;
     });
 }
 

--- a/frontend/test/__support__/e2e/test_tables.js
+++ b/frontend/test/__support__/e2e/test_tables.js
@@ -22,3 +22,35 @@ export const colors27745 = async dbClient => {
 
   return true;
 };
+
+export const scoreboard_actions = async dbClient => {
+  const tableName = "scoreboard_actions";
+
+  await dbClient.schema.dropTableIfExists(tableName);
+  await dbClient.schema.createTable(tableName, table => {
+    table.increments("id").primary();
+    table.string("team_name").unique().notNullable();
+    table.integer("score").notNullable().defaultTo(0);
+    table.string("status").notNullable().defaultTo("active");
+    table.timestamps(false, true);
+  });
+
+  await dbClient(tableName).insert([
+    { team_name: "Amorous Aardvarks", score: 0 },
+    { team_name: "Bouncy Bears", score: 10 },
+    { team_name: "Cuddly Cats", score: 20 },
+    { team_name: "Dusty Ducks", score: 25 },
+    { team_name: "Energetic Elephants", score: 30 },
+    { team_name: "Funky Flamingos", score: 30, status: "suspended" },
+    { team_name: "Generous Giraffes", score: 30 },
+    { team_name: "Hilarious Hippos", score: 40 },
+    { team_name: "Incredible Iguanas", score: 50, status: "retired" },
+    { team_name: "Jolly Jellyfish", score: 60 },
+    { team_name: "Kind Koalas", score: 70 },
+    { team_name: "Lively Lemurs", score: 80 },
+    { team_name: "Mighty Monkeys", score: 90, status: "inactive" },
+    { team_name: "Nifty Narwhals", score: 100 },
+  ]);
+
+  return true;
+};

--- a/frontend/test/metabase/scenarios/dashboard/actions-on-dashboards.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/actions-on-dashboards.cy.spec.js
@@ -11,100 +11,104 @@ const DB_ID = 2;
 const TEST_TABLE = "scoreboard_actions";
 
 ["mysql", "postgres"].forEach(dialect => {
-  describe(`Write Actions on Dashboards (${dialect})`, () => {
-    beforeEach(() => {
-      cy.intercept("/api/card/*").as("getModel");
+  describe(
+    `Write Actions on Dashboards (${dialect})`,
+    { tags: ["@external", "@actions"] },
+    () => {
+      beforeEach(() => {
+        cy.intercept("/api/card/*").as("getModel");
 
-      cy.intercept("POST", "/api/dashboard/*/dashcard/*/execute").as(
-        "executeAPI",
-      );
-
-      cy.intercept("GET", "/api/dashboard/*").as("dashboardLoad");
-
-      resetTestTable({ type: dialect, table: TEST_TABLE });
-      restore(`${dialect}-writable`);
-      cy.signInAsAdmin();
-      resyncDatabase(DB_ID);
-    });
-
-    it("should show testing_db with actions enabled", () => {
-      cy.visit("/admin/databases/2");
-      cy.get("#model-actions-toggle").should("be.checked");
-    });
-
-    // this test is mostly to prove that we're actually reading from freshly reset data
-    it("can read from the test table", () => {
-      cy.visit("/browse/2");
-      cy.findByText("Scoreboard Actions").click();
-
-      cy.findByText("Generous Giraffes").should("be.visible");
-      cy.findByText("Dusty Ducks").should("be.visible");
-      cy.findByText("Lively Lemurs").should("be.visible");
-      cy.findByText("Zany Zebras").should("not.exist");
-    });
-
-    it("adds a custom query action to a dashboard and runs it", () => {
-      queryTestDB(
-        `SELECT * FROM ${TEST_TABLE} WHERE team_name = 'Zany Zebras'`,
-        dialect,
-      ).then(result => {
-        expect(result.rows.length).to.equal(0);
-      });
-
-      createModelFromTable(TEST_TABLE);
-
-      cy.get("@modelId").then(id => {
-        cy.visit(`/model/${id}/detail`);
-        cy.wait("@getModel");
-      });
-
-      cy.visit("/model/4-test-model/detail");
-      cy.findByText("Actions").click();
-      cy.findByText("New action").click();
-
-      cy.findByRole("dialog").within(() => {
-        fillActionQuery(
-          `INSERT INTO ${TEST_TABLE} (team_name) VALUES ('Zany Zebras')`,
+        cy.intercept("POST", "/api/dashboard/*/dashcard/*/execute").as(
+          "executeAPI",
         );
+
+        cy.intercept("GET", "/api/dashboard/*").as("dashboardLoad");
+
+        resetTestTable({ type: dialect, table: TEST_TABLE });
+        restore(`${dialect}-writable`);
+        cy.signInAsAdmin();
+        resyncDatabase(DB_ID);
+      });
+
+      it("should show testing_db with actions enabled", () => {
+        cy.visit("/admin/databases/2");
+        cy.get("#model-actions-toggle").should("be.checked");
+      });
+
+      // this test is mostly to prove that we're actually reading from freshly reset data
+      it("can read from the test table", () => {
+        cy.visit("/browse/2");
+        cy.findByText("Scoreboard Actions").click();
+
+        cy.findByText("Generous Giraffes").should("be.visible");
+        cy.findByText("Dusty Ducks").should("be.visible");
+        cy.findByText("Lively Lemurs").should("be.visible");
+        cy.findByText("Zany Zebras").should("not.exist");
+      });
+
+      it("adds a custom query action to a dashboard and runs it", () => {
+        queryTestDB(
+          `SELECT * FROM ${TEST_TABLE} WHERE team_name = 'Zany Zebras'`,
+          dialect,
+        ).then(result => {
+          expect(result.rows.length).to.equal(0);
+        });
+
+        createModelFromTable(TEST_TABLE);
+
+        cy.get("@modelId").then(id => {
+          cy.visit(`/model/${id}/detail`);
+          cy.wait("@getModel");
+        });
+
+        cy.visit("/model/4-test-model/detail");
+        cy.findByText("Actions").click();
+        cy.findByText("New action").click();
+
+        cy.findByRole("dialog").within(() => {
+          fillActionQuery(
+            `INSERT INTO ${TEST_TABLE} (team_name) VALUES ('Zany Zebras')`,
+          );
+          cy.findByText("Save").click();
+        });
+
+        cy.findByPlaceholderText("My new fantastic action").type("Add Zebras");
+        cy.findByText("Create").click();
+
+        cy.createDashboard({ name: `action packed dash` }).then(
+          ({ body: { id: dashboardId } }) => {
+            cy.visit(`/dashboard/${dashboardId}`);
+          },
+        );
+
+        cy.findByLabelText("pencil icon").click();
+        cy.findByLabelText("click icon").click();
+        cy.get("aside").within(() => {
+          cy.findByText("Test Model").click();
+          cy.findByText("Add Zebras").click();
+        });
+        cy.findByLabelText("click icon").click();
+
+        cy.findByText("Add Zebras").should("be.visible");
         cy.findByText("Save").click();
-      });
 
-      cy.findByPlaceholderText("My new fantastic action").type("Add Zebras");
-      cy.findByText("Create").click();
+        // this keeps the test from flaking because it's confused about the detached
+        // edit-mode button
+        cy.reload();
 
-      cy.createDashboard({ name: `action packed dash` }).then(
-        ({ body: { id: dashboardId } }) => {
-          cy.visit(`/dashboard/${dashboardId}`);
-        },
-      );
-
-      cy.findByLabelText("pencil icon").click();
-      cy.findByLabelText("click icon").click();
-      cy.get("aside").within(() => {
-        cy.findByText("Test Model").click();
         cy.findByText("Add Zebras").click();
+
+        cy.wait("@executeAPI");
+
+        queryTestDB(
+          `SELECT * FROM ${TEST_TABLE} WHERE team_name = 'Zany Zebras'`,
+          dialect,
+        ).then(result => {
+          expect(result.rows.length).to.equal(1);
+        });
       });
-      cy.findByLabelText("click icon").click();
-
-      cy.findByText("Add Zebras").should("be.visible");
-      cy.findByText("Save").click();
-
-      // this keeps the test from flaking because it's confused about the detached
-      // edit-mode button
-      cy.reload();
-
-      cy.findByText("Add Zebras").click();
-
-      cy.wait("@executeAPI");
-
-      queryTestDB(
-        `SELECT * FROM ${TEST_TABLE} WHERE team_name = 'Zany Zebras'`,
-        dialect,
-      ).then(result => {
-        expect(result.rows.length).to.equal(1);
-      });
-    });
-  });
+    },
+  );
 });
 
 const createModelFromTable = tableName => {

--- a/frontend/test/metabase/scenarios/dashboard/actions-on-dashboards.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/actions-on-dashboards.cy.spec.js
@@ -1,13 +1,14 @@
 import {
   restore,
-  queryTestDB,
+  queryWritableDB,
   resetTestTable,
   getTableId,
   fillActionQuery,
   resyncDatabase,
 } from "__support__/e2e/helpers";
 
-const DB_ID = 2;
+import { WRITABLE_DB_ID } from "__support__/e2e/cypress_data";
+
 const TEST_TABLE = "scoreboard_actions";
 
 ["mysql", "postgres"].forEach(dialect => {
@@ -27,17 +28,17 @@ const TEST_TABLE = "scoreboard_actions";
         resetTestTable({ type: dialect, table: TEST_TABLE });
         restore(`${dialect}-writable`);
         cy.signInAsAdmin();
-        resyncDatabase(DB_ID);
+        resyncDatabase(WRITABLE_DB_ID);
       });
 
-      it("should show testing_db with actions enabled", () => {
-        cy.visit("/admin/databases/2");
+      it("should show writable_db with actions enabled", () => {
+        cy.visit(`/admin/databases/${WRITABLE_DB_ID}`);
         cy.get("#model-actions-toggle").should("be.checked");
       });
 
       // this test is mostly to prove that we're actually reading from freshly reset data
       it("can read from the test table", () => {
-        cy.visit("/browse/2");
+        cy.visit(`/browse/${WRITABLE_DB_ID}`);
         cy.findByText("Scoreboard Actions").click();
 
         cy.findByText("Generous Giraffes").should("be.visible");
@@ -47,12 +48,13 @@ const TEST_TABLE = "scoreboard_actions";
       });
 
       it("adds a custom query action to a dashboard and runs it", () => {
-        queryTestDB(
+        queryWritableDB(
           `SELECT * FROM ${TEST_TABLE} WHERE team_name = 'Zany Zebras'`,
           dialect,
         ).then(result => {
           expect(result.rows.length).to.equal(0);
         });
+        cy.visit("/");
 
         createModelFromTable(TEST_TABLE);
 
@@ -84,23 +86,26 @@ const TEST_TABLE = "scoreboard_actions";
         cy.findByLabelText("pencil icon").click();
         cy.findByLabelText("click icon").click();
         cy.get("aside").within(() => {
+          cy.findByText("Pick an action").click();
+        });
+
+        cy.findByRole("dialog").within(() => {
           cy.findByText("Test Model").click();
           cy.findByText("Add Zebras").click();
+          cy.findByRole("button", { name: "Done" }).click();
         });
-        cy.findByLabelText("click icon").click();
 
-        cy.findByText("Add Zebras").should("be.visible");
         cy.findByText("Save").click();
 
         // this keeps the test from flaking because it's confused about the detached
         // edit-mode button
         cy.reload();
 
-        cy.findByText("Add Zebras").click();
+        cy.findByText("Click Me").click();
 
         cy.wait("@executeAPI");
 
-        queryTestDB(
+        queryWritableDB(
           `SELECT * FROM ${TEST_TABLE} WHERE team_name = 'Zany Zebras'`,
           dialect,
         ).then(result => {
@@ -115,7 +120,7 @@ const createModelFromTable = tableName => {
   getTableId({ name: tableName }).then(tableId => {
     cy.createQuestion(
       {
-        database: 2,
+        database: WRITABLE_DB_ID,
         name: "Test Model",
         query: {
           "source-table": tableId,

--- a/frontend/test/metabase/scenarios/dashboard/actions-on-dashboards.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/actions-on-dashboards.cy.spec.js
@@ -1,0 +1,128 @@
+import {
+  restore,
+  queryTestDB,
+  resetTestTable,
+  getTableId,
+  waitForSyncToFinish,
+  fillActionQuery,
+} from "__support__/e2e/helpers";
+
+const DB_ID = 2;
+const TEST_TABLE = "scoreboard_actions";
+
+["mysql", "postgres"].forEach(dialect => {
+  describe(`Write Actions on Dashboards (${dialect})`, () => {
+    beforeEach(() => {
+      cy.intercept("/api/card/*").as("getModel");
+
+      cy.intercept("POST", "/api/dashboard/*/dashcard/*/execute").as(
+        "executeAPI",
+      );
+
+      cy.intercept("GET", "/api/dashboard/*").as("dashboardLoad");
+
+      resetTestTable({ type: dialect, table: TEST_TABLE });
+      restore(`${dialect}-writable`);
+      cy.signInAsAdmin();
+      cy.request("POST", `/api/database/${DB_ID}/sync_schema`);
+      cy.request("POST", `/api/database/${DB_ID}/rescan_values`);
+      waitForSyncToFinish(0, DB_ID);
+    });
+
+    it("should show testing_db with actions enabled", () => {
+      cy.visit("/admin/databases/2");
+      cy.get("#model-actions-toggle").should("be.checked");
+    });
+
+    // this test is mostly to prove that we're actually reading from freshly reset data
+    it("can read from the test table", () => {
+      cy.visit("/browse/2");
+      cy.findByText("Scoreboard Actions").click();
+
+      cy.findByText("Generous Giraffes").should("be.visible");
+      cy.findByText("Dusty Ducks").should("be.visible");
+      cy.findByText("Lively Lemurs").should("be.visible");
+      cy.findByText("Zany Zebras").should("not.exist");
+    });
+
+    it("adds a custom query action to a dashboard and runs it", () => {
+      queryTestDB(
+        `SELECT * FROM ${TEST_TABLE} WHERE team_name = 'Zany Zebras'`,
+        dialect,
+      ).then(result => {
+        expect(result.rows.length).to.equal(0);
+      });
+
+      createModelFromTable(TEST_TABLE);
+
+      cy.get("@modelId").then(id => {
+        cy.visit(`/model/${id}/detail`);
+        cy.wait("@getModel");
+      });
+
+      cy.visit("/model/4-test-model/detail");
+      cy.findByText("Actions").click();
+      cy.findByText("New action").click();
+
+      cy.findByRole("dialog").within(() => {
+        fillActionQuery(
+          `INSERT INTO ${TEST_TABLE} (team_name) VALUES ('Zany Zebras')`,
+        );
+        cy.findByText("Save").click();
+      });
+
+      cy.findByPlaceholderText("My new fantastic action").type("Add Zebras");
+      cy.findByText("Create").click();
+
+      cy.createDashboard({ name: `action packed dash` }).then(
+        ({ body: { id: dashboardId } }) => {
+          cy.visit(`/dashboard/${dashboardId}`);
+        },
+      );
+
+      cy.findByLabelText("pencil icon").click();
+      cy.findByLabelText("click icon").click();
+      cy.get("aside").within(() => {
+        cy.findByText("Add Zebras").click();
+      });
+      cy.findByLabelText("click icon").click();
+
+      cy.findByText("Add Zebras").should("be.visible");
+      cy.findByText("Save").click();
+
+      // this keeps the test from flaking because it's confused about the detached
+      // edit-mode button
+      cy.reload();
+
+      cy.findByText("Add Zebras").click();
+
+      cy.wait("@executeAPI");
+
+      queryTestDB(
+        `SELECT * FROM ${TEST_TABLE} WHERE team_name = 'Zany Zebras'`,
+        dialect,
+      ).then(result => {
+        expect(result.rows.length).to.equal(1);
+      });
+    });
+  });
+});
+
+const createModelFromTable = tableName => {
+  getTableId({ name: tableName }).then(tableId => {
+    cy.createQuestion(
+      {
+        database: 2,
+        name: "Test Model",
+        query: {
+          "source-table": tableId,
+        },
+        dataset: true,
+      },
+      {
+        wrapId: true,
+        idAlias: "modelId",
+      },
+    );
+  });
+};

--- a/frontend/test/metabase/scenarios/dashboard/actions-on-dashboards.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/actions-on-dashboards.cy.spec.js
@@ -3,8 +3,8 @@ import {
   queryTestDB,
   resetTestTable,
   getTableId,
-  waitForSyncToFinish,
   fillActionQuery,
+  resyncDatabase,
 } from "__support__/e2e/helpers";
 
 const DB_ID = 2;
@@ -24,9 +24,7 @@ const TEST_TABLE = "scoreboard_actions";
       resetTestTable({ type: dialect, table: TEST_TABLE });
       restore(`${dialect}-writable`);
       cy.signInAsAdmin();
-      cy.request("POST", `/api/database/${DB_ID}/sync_schema`);
-      cy.request("POST", `/api/database/${DB_ID}/rescan_values`);
-      waitForSyncToFinish(0, DB_ID);
+      resyncDatabase(DB_ID);
     });
 
     it("should show testing_db with actions enabled", () => {
@@ -83,6 +81,7 @@ const TEST_TABLE = "scoreboard_actions";
       cy.findByLabelText("pencil icon").click();
       cy.findByLabelText("click icon").click();
       cy.get("aside").within(() => {
+        cy.findByText("Test Model").click();
         cy.findByText("Add Zebras").click();
       });
       cy.findByLabelText("click icon").click();

--- a/frontend/test/metabase/scenarios/models/model-actions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/model-actions.cy.spec.js
@@ -69,216 +69,217 @@ describe(
   "scenarios > models > actions",
   { tags: ["@external", "@actions"] },
   () => {
-  beforeEach(() => {
-    restore("postgres-12");
-    cy.signInAsAdmin();
-    enableActionsForDB(PG_DB_ID);
+    beforeEach(() => {
+      restore("postgres-12");
+      cy.signInAsAdmin();
+      enableActionsForDB(PG_DB_ID);
 
-    cy.createQuestion(SAMPLE_ORDERS_MODEL, {
-      wrapId: true,
-      idAlias: "modelId",
-    });
-
-    cy.intercept("GET", "/api/card/*").as("getModel");
-    cy.intercept("PUT", "/api/action/*").as("updateAction");
-  });
-
-  it("should allow to view, create, edit, and archive model actions", () => {
-    cy.get("@modelId").then(id => {
-      cy.visit(`/model/${id}/detail`);
-      cy.wait("@getModel");
-    });
-
-    cy.findByText("Actions").click();
-
-    cy.findByRole("button", { name: /Create basic actions/i }).click();
-    cy.findByLabelText("Action list").within(() => {
-      cy.findByText("Create").should("be.visible");
-      cy.findByText("Update").should("be.visible");
-      cy.findByText("Delete").should("be.visible");
-    });
-
-    cy.findByRole("link", { name: "New action" }).click();
-    fillActionQuery("DELETE FROM orders WHERE id = {{ id }}");
-    fieldSettings().findByText("Number").click();
-    cy.findByRole("button", { name: "Save" }).click();
-    modal().within(() => {
-      cy.findByLabelText("Name").type("Delete Order");
-      cy.findByRole("button", { name: "Create" }).click();
-    });
-    cy.findByLabelText("Action list")
-      .findByText("Delete Order")
-      .should("be.visible");
-
-    openActionEditorFor("Delete Order");
-    fillActionQuery(" AND status = 'pending'");
-    fieldSettings()
-      .findByRole("radiogroup", { name: "Field type" })
-      .findByLabelText("Number")
-      .should("be.checked");
-    cy.findByRole("button", { name: "Update" }).click();
-
-    cy.findByLabelText("Action list")
-      .findByText(
-        "DELETE FROM orders WHERE id = {{ id }} AND status = 'pending'",
-      )
-      .should("be.visible");
-
-    openActionMenuFor("Delete Order");
-    popover().findByText("Archive").click();
-
-    modal().within(() => {
-      cy.findByText("Archive Delete Order?").should("be.visible");
-      cy.findByRole("button", { name: "Archive" }).click();
-    });
-
-    cy.findByRole("listitem", { name: "Delete Order" }).should("not.exist");
-
-    cy.findByLabelText("Actions menu").click();
-    popover().findByText("Disable basic actions").click();
-    modal().within(() => {
-      cy.findByText("Disable basic actions?").should("be.visible");
-      cy.button("Disable").click();
-    });
-    cy.findByLabelText("Action list").should("not.exist");
-    cy.findByText("Create").should("not.exist");
-    cy.findByText("Update").should("not.exist");
-    cy.findByText("Delete").should("not.exist");
-  });
-
-  it("should allow to execute actions from the model page", () => {
-    cy.get("@modelId").then(modelId => {
-      createAction({
-        ...SAMPLE_QUERY_ACTION,
-        model_id: modelId,
+      cy.createQuestion(SAMPLE_ORDERS_MODEL, {
+        wrapId: true,
+        idAlias: "modelId",
       });
-      cy.visit(`/model/${modelId}/detail/actions`);
-      cy.wait("@getModel");
+
+      cy.intercept("GET", "/api/card/*").as("getModel");
+      cy.intercept("PUT", "/api/action/*").as("updateAction");
     });
 
-    runActionFor(SAMPLE_QUERY_ACTION.name);
-
-    modal().within(() => {
-      cy.findByLabelText(TEST_PARAMETER.name).type("1");
-      cy.button("Run").click();
-    });
-
-    cy.findByText(`${SAMPLE_QUERY_ACTION.name} ran successfully`).should(
-      "be.visible",
-    );
-  });
-
-  it("should allow to make actions public and execute them", () => {
-    const IMPLICIT_ACTION_NAME = "Update order";
-
-    cy.get("@modelId").then(modelId => {
-      createAction({
-        ...SAMPLE_QUERY_ACTION,
-        model_id: modelId,
+    it("should allow to view, create, edit, and archive model actions", () => {
+      cy.get("@modelId").then(id => {
+        cy.visit(`/model/${id}/detail`);
+        cy.wait("@getModel");
       });
-      createAction({
-        type: "implicit",
-        kind: "row/update",
-        name: IMPLICIT_ACTION_NAME,
-        model_id: modelId,
+
+      cy.findByText("Actions").click();
+
+      cy.findByRole("button", { name: /Create basic actions/i }).click();
+      cy.findByLabelText("Action list").within(() => {
+        cy.findByText("Create").should("be.visible");
+        cy.findByText("Update").should("be.visible");
+        cy.findByText("Delete").should("be.visible");
       });
-      cy.visit(`/model/${modelId}/detail/actions`);
-      cy.wait("@getModel");
+
+      cy.findByRole("link", { name: "New action" }).click();
+      fillActionQuery("DELETE FROM orders WHERE id = {{ id }}");
+      fieldSettings().findByText("Number").click();
+      cy.findByRole("button", { name: "Save" }).click();
+      modal().within(() => {
+        cy.findByLabelText("Name").type("Delete Order");
+        cy.findByRole("button", { name: "Create" }).click();
+      });
+      cy.findByLabelText("Action list")
+        .findByText("Delete Order")
+        .should("be.visible");
+
+      openActionEditorFor("Delete Order");
+      fillActionQuery(" AND status = 'pending'");
+      fieldSettings()
+        .findByRole("radiogroup", { name: "Field type" })
+        .findByLabelText("Number")
+        .should("be.checked");
+      cy.findByRole("button", { name: "Update" }).click();
+
+      cy.findByLabelText("Action list")
+        .findByText(
+          "DELETE FROM orders WHERE id = {{ id }} AND status = 'pending'",
+        )
+        .should("be.visible");
+
+      openActionMenuFor("Delete Order");
+      popover().findByText("Archive").click();
+
+      modal().within(() => {
+        cy.findByText("Archive Delete Order?").should("be.visible");
+        cy.findByRole("button", { name: "Archive" }).click();
+      });
+
+      cy.findByRole("listitem", { name: "Delete Order" }).should("not.exist");
+
+      cy.findByLabelText("Actions menu").click();
+      popover().findByText("Disable basic actions").click();
+      modal().within(() => {
+        cy.findByText("Disable basic actions?").should("be.visible");
+        cy.button("Disable").click();
+      });
+      cy.findByLabelText("Action list").should("not.exist");
+      cy.findByText("Create").should("not.exist");
+      cy.findByText("Update").should("not.exist");
+      cy.findByText("Delete").should("not.exist");
     });
 
-    enableSharingFor(SAMPLE_QUERY_ACTION.name, {
-      publicUrlAlias: "queryActionPublicUrl",
-    });
-    enableSharingFor(IMPLICIT_ACTION_NAME, {
-      publicUrlAlias: "implicitActionPublicUrl",
-    });
+    it("should allow to execute actions from the model page", () => {
+      cy.get("@modelId").then(modelId => {
+        createAction({
+          ...SAMPLE_QUERY_ACTION,
+          model_id: modelId,
+        });
+        cy.visit(`/model/${modelId}/detail/actions`);
+        cy.wait("@getModel");
+      });
 
-    cy.signOut();
+      runActionFor(SAMPLE_QUERY_ACTION.name);
 
-    cy.get("@queryActionPublicUrl").then(url => {
-      cy.visit(url);
-      cy.findByLabelText(TEST_PARAMETER.name).type("1");
-      cy.findByRole("button", { name: "Submit" }).click();
+      modal().within(() => {
+        cy.findByLabelText(TEST_PARAMETER.name).type("1");
+        cy.button("Run").click();
+      });
+
       cy.findByText(`${SAMPLE_QUERY_ACTION.name} ran successfully`).should(
         "be.visible",
       );
-      cy.findByRole("form").should("not.exist");
-      cy.findByRole("button", { name: "Submit" }).should("not.exist");
     });
 
-    cy.get("@implicitActionPublicUrl").then(url => {
-      cy.visit(url);
+    it("should allow to make actions public and execute them", () => {
+      const IMPLICIT_ACTION_NAME = "Update order";
 
-      // Order 1 has quantity 2 by default, so we're not actually mutating data
-      cy.findByLabelText("id").type("1");
-      cy.findByLabelText(/quantity/i).type("2");
-
-      cy.findByRole("button", { name: "Submit" }).click();
-      cy.findByText(`${IMPLICIT_ACTION_NAME} ran successfully`).should(
-        "be.visible",
-      );
-      cy.findByRole("form").should("not.exist");
-      cy.findByRole("button", { name: "Submit" }).should("not.exist");
-    });
-
-    cy.signInAsAdmin();
-    cy.get("@modelId").then(modelId => {
-      cy.visit(`/model/${modelId}/detail/actions`);
-      cy.wait("@getModel");
-    });
-
-    disableSharingFor(SAMPLE_QUERY_ACTION.name);
-    disableSharingFor(IMPLICIT_ACTION_NAME);
-
-    cy.get("@queryActionPublicUrl").then(url => {
-      cy.visit(url);
-      cy.findByRole("form").should("not.exist");
-      cy.findByRole("button", { name: "Submit" }).should("not.exist");
-      cy.findByText("An error occurred.").should("be.visible");
-    });
-
-    cy.get("@implicitActionPublicUrl").then(url => {
-      cy.visit(url);
-      cy.findByRole("form").should("not.exist");
-      cy.findByRole("button", { name: "Submit" }).should("not.exist");
-      cy.findByText("An error occurred.").should("be.visible");
-    });
-  });
-
-  it("should respect permissions", () => {
-    cy.get("@modelId").then(modelId => {
-      cy.request("POST", "/api/action", {
-        ...SAMPLE_QUERY_ACTION,
-        model_id: modelId,
-      });
-      cy.signIn("readonly");
-      cy.visit(`/model/${modelId}/detail/actions`);
-      cy.wait("@getModel");
-    });
-
-    openActionMenuFor(SAMPLE_QUERY_ACTION.name);
-    popover().within(() => {
-      cy.findByText("Archive").should("not.exist");
-      cy.findByText("View").click();
-    });
-
-    cy.findByRole("dialog").within(() => {
-      cy.findByDisplayValue(SAMPLE_QUERY_ACTION.name).should("be.disabled");
-
-      cy.button("Save").should("not.exist");
-      cy.button("Update").should("not.exist");
-
-      assertQueryEditorDisabled();
-
-      cy.findByRole("form").within(() => {
-        cy.icon("gear").should("not.exist");
+      cy.get("@modelId").then(modelId => {
+        createAction({
+          ...SAMPLE_QUERY_ACTION,
+          model_id: modelId,
+        });
+        createAction({
+          type: "implicit",
+          kind: "row/update",
+          name: IMPLICIT_ACTION_NAME,
+          model_id: modelId,
+        });
+        cy.visit(`/model/${modelId}/detail/actions`);
+        cy.wait("@getModel");
       });
 
-      cy.findByLabelText("Action settings").click();
-      cy.findByLabelText("Success message").should("be.disabled");
+      enableSharingFor(SAMPLE_QUERY_ACTION.name, {
+        publicUrlAlias: "queryActionPublicUrl",
+      });
+      enableSharingFor(IMPLICIT_ACTION_NAME, {
+        publicUrlAlias: "implicitActionPublicUrl",
+      });
+
+      cy.signOut();
+
+      cy.get("@queryActionPublicUrl").then(url => {
+        cy.visit(url);
+        cy.findByLabelText(TEST_PARAMETER.name).type("1");
+        cy.findByRole("button", { name: "Submit" }).click();
+        cy.findByText(`${SAMPLE_QUERY_ACTION.name} ran successfully`).should(
+          "be.visible",
+        );
+        cy.findByRole("form").should("not.exist");
+        cy.findByRole("button", { name: "Submit" }).should("not.exist");
+      });
+
+      cy.get("@implicitActionPublicUrl").then(url => {
+        cy.visit(url);
+
+        // Order 1 has quantity 2 by default, so we're not actually mutating data
+        cy.findByLabelText("id").type("1");
+        cy.findByLabelText(/quantity/i).type("2");
+
+        cy.findByRole("button", { name: "Submit" }).click();
+        cy.findByText(`${IMPLICIT_ACTION_NAME} ran successfully`).should(
+          "be.visible",
+        );
+        cy.findByRole("form").should("not.exist");
+        cy.findByRole("button", { name: "Submit" }).should("not.exist");
+      });
+
+      cy.signInAsAdmin();
+      cy.get("@modelId").then(modelId => {
+        cy.visit(`/model/${modelId}/detail/actions`);
+        cy.wait("@getModel");
+      });
+
+      disableSharingFor(SAMPLE_QUERY_ACTION.name);
+      disableSharingFor(IMPLICIT_ACTION_NAME);
+
+      cy.get("@queryActionPublicUrl").then(url => {
+        cy.visit(url);
+        cy.findByRole("form").should("not.exist");
+        cy.findByRole("button", { name: "Submit" }).should("not.exist");
+        cy.findByText("An error occurred.").should("be.visible");
+      });
+
+      cy.get("@implicitActionPublicUrl").then(url => {
+        cy.visit(url);
+        cy.findByRole("form").should("not.exist");
+        cy.findByRole("button", { name: "Submit" }).should("not.exist");
+        cy.findByText("An error occurred.").should("be.visible");
+      });
     });
-  });
-});
+
+    it("should respect permissions", () => {
+      cy.get("@modelId").then(modelId => {
+        cy.request("POST", "/api/action", {
+          ...SAMPLE_QUERY_ACTION,
+          model_id: modelId,
+        });
+        cy.signIn("readonly");
+        cy.visit(`/model/${modelId}/detail/actions`);
+        cy.wait("@getModel");
+      });
+
+      openActionMenuFor(SAMPLE_QUERY_ACTION.name);
+      popover().within(() => {
+        cy.findByText("Archive").should("not.exist");
+        cy.findByText("View").click();
+      });
+
+      cy.findByRole("dialog").within(() => {
+        cy.findByDisplayValue(SAMPLE_QUERY_ACTION.name).should("be.disabled");
+
+        cy.button("Save").should("not.exist");
+        cy.button("Update").should("not.exist");
+
+        assertQueryEditorDisabled();
+
+        cy.findByRole("form").within(() => {
+          cy.icon("gear").should("not.exist");
+        });
+
+        cy.findByLabelText("Action settings").click();
+        cy.findByLabelText("Success message").should("be.disabled");
+      });
+    });
+  },
+);
 
 function runActionFor(actionName) {
   cy.findByRole("listitem", { name: actionName }).within(() => {

--- a/frontend/test/metabase/scenarios/models/model-actions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/model-actions.cy.spec.js
@@ -3,6 +3,7 @@ import {
   modal,
   popover,
   restore,
+  fillActionQuery,
   createAction,
 } from "__support__/e2e/helpers";
 

--- a/frontend/test/metabase/scenarios/models/model-actions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/model-actions.cy.spec.js
@@ -97,7 +97,7 @@ describe("scenarios > models > actions", () => {
     });
 
     cy.findByRole("link", { name: "New action" }).click();
-    fillQuery("DELETE FROM orders WHERE id = {{ id }}");
+    fillActionQuery("DELETE FROM orders WHERE id = {{ id }}");
     fieldSettings().findByText("Number").click();
     cy.findByRole("button", { name: "Save" }).click();
     modal().within(() => {
@@ -109,7 +109,7 @@ describe("scenarios > models > actions", () => {
       .should("be.visible");
 
     openActionEditorFor("Delete Order");
-    fillQuery(" AND status = 'pending'");
+    fillActionQuery(" AND status = 'pending'");
     fieldSettings()
       .findByRole("radiogroup", { name: "Field type" })
       .findByLabelText("Number")

--- a/frontend/test/metabase/scenarios/models/model-actions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/model-actions.cy.spec.js
@@ -69,10 +69,10 @@ describe(
   "scenarios > models > actions",
   { tags: ["@external", "@actions"] },
   () => {
-    beforeEach(() => {
-      restore("postgres-12");
-      cy.signInAsAdmin();
-      enableActionsForDB(PG_DB_ID);
+  beforeEach(() => {
+    restore("postgres-12");
+    cy.signInAsAdmin();
+    enableActionsForDB(PG_DB_ID);
 
     cy.createQuestion(SAMPLE_ORDERS_MODEL, {
       wrapId: true,
@@ -193,16 +193,7 @@ describe(
         cy.wait("@getModel");
       });
 
-    cy.get("@queryActionPublicUrl").then(url => {
-      cy.visit(url);
-      cy.findByLabelText(TEST_PARAMETER.name).type("1");
-      cy.findByRole("button", { name: "Submit" }).click();
-      cy.findByText(`${SAMPLE_QUERY_ACTION.name} ran successfully`).should(
-        "be.visible",
-      );
-      cy.findByRole("form").should("not.exist");
-      cy.findByRole("button", { name: "Submit" }).should("not.exist");
-    });
+      cy.findByText("Actions").click();
 
       cy.findByRole("button", { name: /Create basic actions/i }).click();
       cy.findByLabelText("Action list").within(() => {
@@ -223,6 +214,28 @@ describe(
       cy.findByRole("listitem", { name: "Delete Order" }).should("not.exist");
     });
 
+    it("should allow to execute actions from the model page", () => {
+      cy.get("@modelId").then(modelId => {
+        createAction({
+          ...SAMPLE_QUERY_ACTION,
+          model_id: modelId,
+        });
+        cy.visit(`/model/${modelId}/detail/actions`);
+        cy.wait("@getModel");
+      });
+
+      runActionFor(SAMPLE_QUERY_ACTION.name);
+
+      modal().within(() => {
+        cy.findByLabelText(TEST_PARAMETER.name).type("1");
+        cy.button("Run").click();
+      });
+
+      cy.findByText(`${SAMPLE_QUERY_ACTION.name} ran successfully`).should(
+        "be.visible",
+      );
+    });
+
     it("should allow to make actions public and execute them", () => {
       const IMPLICIT_ACTION_NAME = "Update order";
 
@@ -237,109 +250,138 @@ describe(
           name: IMPLICIT_ACTION_NAME,
           model_id: modelId,
         });
-        cy.visit(`/model/${modelId}/detail/actions`);
-        cy.wait("@getModel");
+
+        cy.intercept("GET", "/api/card/*").as("getModel");
+        cy.intercept("PUT", "/api/action/*").as("updateAction");
       });
 
-      enableSharingFor(SAMPLE_QUERY_ACTION.name, {
-        publicUrlAlias: "queryActionPublicUrl",
-      });
-      enableSharingFor(IMPLICIT_ACTION_NAME, {
-        publicUrlAlias: "implicitActionPublicUrl",
-      });
-
-    openActionMenuFor(SAMPLE_QUERY_ACTION.name);
-    popover().within(() => {
-      cy.findByText("Archive").should("not.exist");
-      cy.findByText("View").click();
-    });
-
-    cy.findByRole("dialog").within(() => {
-      cy.findByDisplayValue(SAMPLE_QUERY_ACTION.name).should("be.disabled");
-
-        // Order 1 has quantity 2 by default, so we're not actually mutating data
-        cy.findByLabelText(/^id/i).type("1");
-        cy.findByLabelText(/quantity/i).type("2");
-
-        cy.findByRole("button", { name: "Submit" }).click();
-        cy.findByText(`${IMPLICIT_ACTION_NAME} ran successfully`).should(
-          "be.visible",
-        );
-        cy.findByRole("form").should("not.exist");
-        cy.findByRole("button", { name: "Submit" }).should("not.exist");
-      });
-
-      cy.signInAsAdmin();
-      cy.get("@modelId").then(modelId => {
-        cy.visit(`/model/${modelId}/detail/actions`);
-        cy.wait("@getModel");
-      });
-
-      disableSharingFor(SAMPLE_QUERY_ACTION.name);
-      disableSharingFor(IMPLICIT_ACTION_NAME);
-
-      cy.get("@queryActionPublicUrl").then(url => {
-        cy.visit(url);
-        cy.findByRole("form").should("not.exist");
-        cy.findByRole("button", { name: "Submit" }).should("not.exist");
-        cy.findByText("An error occurred.").should("be.visible");
-      });
-
-      cy.get("@implicitActionPublicUrl").then(url => {
-        cy.visit(url);
-        cy.findByRole("form").should("not.exist");
-        cy.findByRole("button", { name: "Submit" }).should("not.exist");
-      });
-    });
-
-    it("should respect permissions", () => {
-      cy.get("@modelId").then(modelId => {
-        cy.request("POST", "/api/action", {
-          ...SAMPLE_QUERY_ACTION,
-          model_id: modelId,
-        });
-        cy.signIn("readonly");
-        cy.visit(`/model/${modelId}/detail/actions`);
-        cy.wait("@getModel");
-      });
-
-      cy.findByRole("listitem", { name: SAMPLE_QUERY_ACTION.name }).within(
-        () => {
-          cy.icon("ellipsis").should("not.exist");
-        },
-      );
-
-      openActionEditorFor(SAMPLE_QUERY_ACTION.name, { isReadOnly: true });
-
-      cy.findByRole("dialog").within(() => {
-        cy.findByDisplayValue(SAMPLE_QUERY_ACTION.name).should("be.disabled");
-
-        cy.button("Save").should("not.exist");
-        cy.button("Update").should("not.exist");
-
-        assertQueryEditorDisabled();
-
-        cy.findByRole("form").within(() => {
-          cy.icon("gear").should("not.exist");
+      it("should allow to view, create, edit, and archive model actions", () => {
+        cy.get("@modelId").then(id => {
+          cy.visit(`/model/${id}/detail`);
+          cy.wait("@getModel");
         });
 
-        cy.findByText("Actions").click();
-        openActionEditorFor(SAMPLE_QUERY_ACTION.name);
+        cy.get("@queryActionPublicUrl").then(url => {
+          cy.visit(url);
+          cy.findByLabelText(TEST_PARAMETER.name).type("1");
+          cy.findByRole("button", { name: "Submit" }).click();
+          cy.findByText(`${SAMPLE_QUERY_ACTION.name} ran successfully`).should(
+            "be.visible",
+          );
+          cy.findByRole("form").should("not.exist");
+          cy.findByRole("button", { name: "Submit" }).should("not.exist");
+        });
+
+        cy.findByRole("button", { name: /Create basic actions/i }).click();
+        cy.findByLabelText("Action list").within(() => {
+          cy.findByText("Create").should("be.visible");
+          cy.findByText("Update").should("be.visible");
+          cy.findByText("Delete").should("be.visible");
+        });
+
+        cy.findByRole("link", { name: "New action" }).click();
+        fillActionQuery("DELETE FROM orders WHERE id = {{ id }}");
+        fieldSettings().findByText("number").click();
+        cy.findByRole("button", { name: "Save" }).click();
+        modal().within(() => {
+          cy.findByLabelText("Name").type("Delete Order");
+          cy.findByRole("button", { name: "Create" }).click();
+        });
+        cy.findByLabelText("Action list")
+          .findByText("Delete Order")
+          .should("be.visible");
+
+        openActionEditorFor("Delete Order");
+        fillActionQuery(" AND status = 'pending'");
+        fieldSettings()
+          .findByRole("radiogroup", { name: "Field type" })
+          .findByLabelText("number")
+          .should("be.checked");
+        cy.findByRole("button", { name: "Update" }).click();
+
+        cy.findByLabelText("Action list")
+          .findByText(
+            "DELETE FROM orders WHERE id = {{ id }} AND status = 'pending'",
+          )
+          .should("be.visible");
+
+        openActionMenuFor("Delete Order");
+        popover().findByText("Archive").click();
+
+        modal().within(() => {
+          cy.findByText("Archive Delete Order?").should("be.visible");
+          cy.findByRole("button", { name: "Archive" }).click();
+        });
+
+        cy.findByRole("listitem", { name: "Delete Order" }).should("not.exist");
+      });
+
+      it("should allow to make actions public and execute them", () => {
+        const IMPLICIT_ACTION_NAME = "Update order";
+
+        cy.get("@modelId").then(modelId => {
+          createAction({
+            ...SAMPLE_QUERY_ACTION,
+            model_id: modelId,
+          });
+          createAction({
+            type: "implicit",
+            kind: "row/update",
+            name: IMPLICIT_ACTION_NAME,
+            model_id: modelId,
+          });
+          cy.visit(`/model/${modelId}/detail/actions`);
+          cy.wait("@getModel");
+        });
+
+        enableSharingFor(SAMPLE_QUERY_ACTION.name, {
+          publicUrlAlias: "queryActionPublicUrl",
+        });
+        enableSharingFor(IMPLICIT_ACTION_NAME, {
+          publicUrlAlias: "implicitActionPublicUrl",
+        });
+
+        openActionMenuFor(SAMPLE_QUERY_ACTION.name);
+        popover().within(() => {
+          cy.findByText("Archive").should("not.exist");
+          cy.findByText("View").click();
+        });
 
         cy.findByRole("dialog").within(() => {
-          cy.findByRole("button", { name: "Action settings" }).click();
-          cy.findByLabelText("Make public").should("be.checked").click();
-        });
-        modal().within(() => {
-          cy.findByText("Disable this public link?").should("be.visible");
-          cy.findByRole("button", { name: "Yes" }).click();
+          cy.findByDisplayValue(SAMPLE_QUERY_ACTION.name).should("be.disabled");
+
+          // Order 1 has quantity 2 by default, so we're not actually mutating data
+          cy.findByLabelText(/^id/i).type("1");
+          cy.findByLabelText(/quantity/i).type("2");
+
+          cy.findByRole("button", { name: "Submit" }).click();
+          cy.findByText(`${IMPLICIT_ACTION_NAME} ran successfully`).should(
+            "be.visible",
+          );
+          cy.findByRole("form").should("not.exist");
+          cy.findByRole("button", { name: "Submit" }).should("not.exist");
         });
 
-        cy.get("@publicUrl").then(url => {
+        cy.signInAsAdmin();
+        cy.get("@modelId").then(modelId => {
+          cy.visit(`/model/${modelId}/detail/actions`);
+          cy.wait("@getModel");
+        });
+
+        disableSharingFor(SAMPLE_QUERY_ACTION.name);
+        disableSharingFor(IMPLICIT_ACTION_NAME);
+
+        cy.get("@queryActionPublicUrl").then(url => {
           cy.visit(url);
           cy.findByRole("form").should("not.exist");
           cy.findByRole("button", { name: "Submit" }).should("not.exist");
           cy.findByText("An error occurred.").should("be.visible");
+        });
+
+        cy.get("@implicitActionPublicUrl").then(url => {
+          cy.visit(url);
+          cy.findByRole("form").should("not.exist");
+          cy.findByRole("button", { name: "Submit" }).should("not.exist");
         });
       });
 
@@ -353,6 +395,12 @@ describe(
           cy.visit(`/model/${modelId}/detail/actions`);
           cy.wait("@getModel");
         });
+
+        cy.findByRole("listitem", { name: SAMPLE_QUERY_ACTION.name }).within(
+          () => {
+            cy.icon("ellipsis").should("not.exist");
+          },
+        );
 
         openActionEditorFor(SAMPLE_QUERY_ACTION.name, { isReadOnly: true });
 
@@ -368,13 +416,61 @@ describe(
             cy.icon("gear").should("not.exist");
           });
 
-          cy.findByLabelText("Action settings").click();
-          cy.findByLabelText("Success message").should("be.disabled");
+          cy.findByText("Actions").click();
+          openActionEditorFor(SAMPLE_QUERY_ACTION.name);
+
+          cy.findByRole("dialog").within(() => {
+            cy.findByRole("button", { name: "Action settings" }).click();
+            cy.findByLabelText("Make public").should("be.checked").click();
+          });
+          modal().within(() => {
+            cy.findByText("Disable this public link?").should("be.visible");
+            cy.findByRole("button", { name: "Yes" }).click();
+          });
+
+          cy.get("@publicUrl").then(url => {
+            cy.visit(url);
+            cy.findByRole("form").should("not.exist");
+            cy.findByRole("button", { name: "Submit" }).should("not.exist");
+            cy.findByText("An error occurred.").should("be.visible");
+          });
+        });
+
+        it("should respect permissions", () => {
+          cy.get("@modelId").then(modelId => {
+            cy.request("POST", "/api/action", {
+              ...SAMPLE_QUERY_ACTION,
+              model_id: modelId,
+            });
+            cy.signIn("readonly");
+            cy.visit(`/model/${modelId}/detail/actions`);
+            cy.wait("@getModel");
+          });
+
+          openActionEditorFor(SAMPLE_QUERY_ACTION.name, { isReadOnly: true });
+
+          cy.findByRole("dialog").within(() => {
+            cy.findByDisplayValue(SAMPLE_QUERY_ACTION.name).should(
+              "be.disabled",
+            );
+
+            cy.button("Save").should("not.exist");
+            cy.button("Update").should("not.exist");
+
+            assertQueryEditorDisabled();
+
+            cy.findByRole("form").within(() => {
+              cy.icon("gear").should("not.exist");
+            });
+
+            cy.findByLabelText("Action settings").click();
+            cy.findByLabelText("Success message").should("be.disabled");
+          });
         });
       });
     });
-  },
-);
+  });
+});
 
 function runActionFor(actionName) {
   cy.findByRole("listitem", { name: actionName }).within(() => {
@@ -393,10 +489,6 @@ function openActionEditorFor(actionName, { isReadOnly = false } = {}) {
   popover()
     .findByText(isReadOnly ? "View" : "Edit")
     .click();
-}
-
-function fillQuery(query) {
-  cy.get(".ace_content").type(query, { parseSpecialCharSequences: false });
 }
 
 function assertQueryEditorDisabled() {

--- a/frontend/test/metabase/scenarios/models/model-actions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/model-actions.cy.spec.js
@@ -72,7 +72,6 @@ describe(
     beforeEach(() => {
       restore("postgres-12");
       cy.signInAsAdmin();
-
       enableActionsForDB(PG_DB_ID);
 
     cy.createQuestion(SAMPLE_ORDERS_MODEL, {
@@ -183,18 +182,16 @@ describe(
         name: IMPLICIT_ACTION_NAME,
         model_id: modelId,
       });
-      cy.visit(`/model/${modelId}/detail/actions`);
-      cy.wait("@getModel");
+
+      cy.intercept("GET", "/api/card/*").as("getModel");
+      cy.intercept("PUT", "/api/action/*").as("updateAction");
     });
 
-    enableSharingFor(SAMPLE_QUERY_ACTION.name, {
-      publicUrlAlias: "queryActionPublicUrl",
-    });
-    enableSharingFor(IMPLICIT_ACTION_NAME, {
-      publicUrlAlias: "implicitActionPublicUrl",
-    });
-
-    cy.signOut();
+    it("should allow to view, create, edit, and archive model actions", () => {
+      cy.get("@modelId").then(id => {
+        cy.visit(`/model/${id}/detail`);
+        cy.wait("@getModel");
+      });
 
     cy.get("@queryActionPublicUrl").then(url => {
       cy.visit(url);
@@ -207,52 +204,49 @@ describe(
       cy.findByRole("button", { name: "Submit" }).should("not.exist");
     });
 
-    cy.get("@implicitActionPublicUrl").then(url => {
-      cy.visit(url);
+      cy.findByRole("button", { name: /Create basic actions/i }).click();
+      cy.findByLabelText("Action list").within(() => {
+        cy.findByText("Create").should("be.visible");
+        cy.findByText("Update").should("be.visible");
+        cy.findByText("Delete").should("be.visible");
+      });
 
       // Order 1 has quantity 2 by default, so we're not actually mutating data
       cy.findByLabelText("id").type("1");
       cy.findByLabelText(/quantity/i).type("2");
 
-      cy.findByRole("button", { name: "Submit" }).click();
-      cy.findByText(`${IMPLICIT_ACTION_NAME} ran successfully`).should(
-        "be.visible",
-      );
-      cy.findByRole("form").should("not.exist");
-      cy.findByRole("button", { name: "Submit" }).should("not.exist");
-    });
-
-    cy.signInAsAdmin();
-    cy.get("@modelId").then(modelId => {
-      cy.visit(`/model/${modelId}/detail/actions`);
-      cy.wait("@getModel");
-    });
-
-    disableSharingFor(SAMPLE_QUERY_ACTION.name);
-    disableSharingFor(IMPLICIT_ACTION_NAME);
-
-    cy.get("@queryActionPublicUrl").then(url => {
-      cy.visit(url);
-      cy.findByRole("form").should("not.exist");
-      cy.findByRole("button", { name: "Submit" }).should("not.exist");
-      cy.findByText("An error occurred.").should("be.visible");
-    });
-
-    cy.get("@implicitActionPublicUrl").then(url => {
-      cy.visit(url);
-      cy.findByRole("form").should("not.exist");
-      cy.findByRole("button", { name: "Submit" }).should("not.exist");
-
-  it("should respect permissions", () => {
-    cy.get("@modelId").then(modelId => {
-      cy.request("POST", "/api/action", {
-        ...SAMPLE_QUERY_ACTION,
-        model_id: modelId,
+      modal().within(() => {
+        cy.findByText("Archive Delete Order?").should("be.visible");
+        cy.findByRole("button", { name: "Archive" }).click();
       });
-      cy.signIn("readonly");
-      cy.visit(`/model/${modelId}/detail/actions`);
-      cy.wait("@getModel");
+
+      cy.findByRole("listitem", { name: "Delete Order" }).should("not.exist");
     });
+
+    it("should allow to make actions public and execute them", () => {
+      const IMPLICIT_ACTION_NAME = "Update order";
+
+      cy.get("@modelId").then(modelId => {
+        createAction({
+          ...SAMPLE_QUERY_ACTION,
+          model_id: modelId,
+        });
+        createAction({
+          type: "implicit",
+          kind: "row/update",
+          name: IMPLICIT_ACTION_NAME,
+          model_id: modelId,
+        });
+        cy.visit(`/model/${modelId}/detail/actions`);
+        cy.wait("@getModel");
+      });
+
+      enableSharingFor(SAMPLE_QUERY_ACTION.name, {
+        publicUrlAlias: "queryActionPublicUrl",
+      });
+      enableSharingFor(IMPLICIT_ACTION_NAME, {
+        publicUrlAlias: "implicitActionPublicUrl",
+      });
 
     openActionMenuFor(SAMPLE_QUERY_ACTION.name);
     popover().within(() => {
@@ -263,32 +257,38 @@ describe(
     cy.findByRole("dialog").within(() => {
       cy.findByDisplayValue(SAMPLE_QUERY_ACTION.name).should("be.disabled");
 
-      cy.button("Save").should("not.exist");
-      cy.button("Update").should("not.exist");
+        // Order 1 has quantity 2 by default, so we're not actually mutating data
+        cy.findByLabelText(/^id/i).type("1");
+        cy.findByLabelText(/quantity/i).type("2");
 
-      assertQueryEditorDisabled();
-
-      cy.findByRole("form").within(() => {
-        cy.icon("gear").should("not.exist");
+        cy.findByRole("button", { name: "Submit" }).click();
+        cy.findByText(`${IMPLICIT_ACTION_NAME} ran successfully`).should(
+          "be.visible",
+        );
+        cy.findByRole("form").should("not.exist");
+        cy.findByRole("button", { name: "Submit" }).should("not.exist");
       });
 
-      cy.findByText("Actions").click();
-      openActionEditorFor(SAMPLE_QUERY_ACTION.name);
-
-      cy.findByRole("dialog").within(() => {
-        cy.findByRole("button", { name: "Action settings" }).click();
-        cy.findByLabelText("Make public").should("be.checked").click();
-      });
-      modal().within(() => {
-        cy.findByText("Disable this public link?").should("be.visible");
-        cy.findByRole("button", { name: "Yes" }).click();
+      cy.signInAsAdmin();
+      cy.get("@modelId").then(modelId => {
+        cy.visit(`/model/${modelId}/detail/actions`);
+        cy.wait("@getModel");
       });
 
-      cy.get("@publicUrl").then(url => {
+      disableSharingFor(SAMPLE_QUERY_ACTION.name);
+      disableSharingFor(IMPLICIT_ACTION_NAME);
+
+      cy.get("@queryActionPublicUrl").then(url => {
         cy.visit(url);
         cy.findByRole("form").should("not.exist");
         cy.findByRole("button", { name: "Submit" }).should("not.exist");
         cy.findByText("An error occurred.").should("be.visible");
+      });
+
+      cy.get("@implicitActionPublicUrl").then(url => {
+        cy.visit(url);
+        cy.findByRole("form").should("not.exist");
+        cy.findByRole("button", { name: "Submit" }).should("not.exist");
       });
     });
 
@@ -302,6 +302,12 @@ describe(
         cy.visit(`/model/${modelId}/detail/actions`);
         cy.wait("@getModel");
       });
+
+      cy.findByRole("listitem", { name: SAMPLE_QUERY_ACTION.name }).within(
+        () => {
+          cy.icon("ellipsis").should("not.exist");
+        },
+      );
 
       openActionEditorFor(SAMPLE_QUERY_ACTION.name, { isReadOnly: true });
 
@@ -317,8 +323,54 @@ describe(
           cy.icon("gear").should("not.exist");
         });
 
-        cy.findByLabelText("Action settings").click();
-        cy.findByLabelText("Success message").should("be.disabled");
+        cy.findByText("Actions").click();
+        openActionEditorFor(SAMPLE_QUERY_ACTION.name);
+
+        cy.findByRole("dialog").within(() => {
+          cy.findByRole("button", { name: "Action settings" }).click();
+          cy.findByLabelText("Make public").should("be.checked").click();
+        });
+        modal().within(() => {
+          cy.findByText("Disable this public link?").should("be.visible");
+          cy.findByRole("button", { name: "Yes" }).click();
+        });
+
+        cy.get("@publicUrl").then(url => {
+          cy.visit(url);
+          cy.findByRole("form").should("not.exist");
+          cy.findByRole("button", { name: "Submit" }).should("not.exist");
+          cy.findByText("An error occurred.").should("be.visible");
+        });
+      });
+
+      it("should respect permissions", () => {
+        cy.get("@modelId").then(modelId => {
+          cy.request("POST", "/api/action", {
+            ...SAMPLE_QUERY_ACTION,
+            model_id: modelId,
+          });
+          cy.signIn("readonly");
+          cy.visit(`/model/${modelId}/detail/actions`);
+          cy.wait("@getModel");
+        });
+
+        openActionEditorFor(SAMPLE_QUERY_ACTION.name, { isReadOnly: true });
+
+        cy.findByRole("dialog").within(() => {
+          cy.findByDisplayValue(SAMPLE_QUERY_ACTION.name).should("be.disabled");
+
+          cy.button("Save").should("not.exist");
+          cy.button("Update").should("not.exist");
+
+          assertQueryEditorDisabled();
+
+          cy.findByRole("form").within(() => {
+            cy.icon("gear").should("not.exist");
+          });
+
+          cy.findByLabelText("Action settings").click();
+          cy.findByLabelText("Success message").should("be.disabled");
+        });
       });
     });
   },
@@ -350,7 +402,7 @@ function fillQuery(query) {
 function assertQueryEditorDisabled() {
   // Ace doesn't act as a normal input, so we can't use `should("be.disabled")`
   // Instead we'd assert that a user can't type in the editor
-  fillQuery("QWERTY");
+  fillActionQuery("QWERTY");
   cy.findByText("QWERTY").should("not.exist");
 }
 


### PR DESCRIPTION
## Description

- creates a custom `scoreboard_actions` test table that gets reset between each test
- creates a custom action, adds it to a dashboard, executes it, and verifies with a direct db query that the action mutated data as expected in both MySQL and postgres

![Screen Shot 2023-01-31 at 5 06 13 PM](https://user-images.githubusercontent.com/30528226/215913028-3b8a172a-020b-4efe-b1d2-e0f607fa63c8.png)

![Screen Shot 2023-01-31 at 5 10 30 PM](https://user-images.githubusercontent.com/30528226/215913030-8bb0d8cc-41d0-4365-86df-ab4033e7ebca.png)

passes in CI: 🥳 

![Screen Shot 2023-02-01 at 11 22 25 AM](https://user-images.githubusercontent.com/30528226/216129581-44a636cc-68b3-4690-a23d-6cebab5d5d58.png)




