### PR TITLE
Use fn instead of constantly for malli schema error message

### DIFF
--- a/src/metabase/util/malli/schema.clj
+++ b/src/metabase/util/malli/schema.clj
@@ -25,35 +25,35 @@
   "Schema representing an integer than must also be greater than zero."
   (mc/schema
     [:int {:min      1
-           :error/fn (constantly (deferred-tru "value must be an integer greater than zero."))}]))
+           :error/fn (fn [] (deferred-tru "value must be an integer greater than zero."))}]))
 
 (def PositiveNum
   "Schema representing a numeric value greater than zero. This allows floating point numbers and integers."
   (mc/schema
-    [pos? {:error/fn (constantly (deferred-tru "value must be a number greater than zero."))}]))
+    [pos? {:error/fn (fn [] (deferred-tru "value must be a number greater than zero."))}]))
 
 (def KeywordOrString
   "Schema for something that can be either a `Keyword` or a `String`."
   (mc/schema
-    [:or {:error/fn (constantly (deferred-tru "value must be a keyword or string."))}
+    [:or {:error/fn (fn [] (deferred-tru "value must be a keyword or string."))}
      :string :keyword]))
 
 (def FieldType
   "Schema for a valid Field base or effective (data) type (does it derive from `:type/*`)?"
   (mc/schema
-    [:fn {:error/fn (constantly (deferred-tru "value must be a valid field type."))}
+    [:fn {:error/fn (fn [] (deferred-tru "value must be a valid field type."))}
      #(isa? % :type/*)]))
 
 (def FieldSemanticType
   "Schema for a valid Field semantic type deriving from `:Semantic/*`."
   (mc/schema
-    [:fn {:error/fn (constantly (deferred-tru "value must be a valid field semantic type."))}
+    [:fn {:error/fn (fn [] (deferred-tru "value must be a valid field semantic type."))}
      #(isa? % :Semantic/*)]))
 
 (def FieldRelationType
   "Schema for a valid Field relation type deriving from `:Relation/*`"
   (mc/schema
-    [:fn {:error/fn (constantly (deferred-tru "value must be a valid field relation type."))}
+    [:fn {:error/fn (fn [] (deferred-tru "value must be a valid field relation type."))}
      #(isa? % :Relation/*)]))
 
 (def FieldSemanticOrRelationType
@@ -61,13 +61,13 @@
   to store either the semantic type or relation type info. When this is changed in the future we can get rid of this
   schema. See #15486."
   (mc/schema
-    [:fn {:error/fn (constantly (deferred-tru "value must be a valid field semantic or relation type."))}
+    [:fn {:error/fn (fn [] (deferred-tru "value must be a valid field semantic or relation type."))}
      (fn [k] (or (isa? k :Semantic/*) (isa? k :Relation/*)))]))
 
 (def CoercionStrategy
   "Schema for a valid Field coercion strategy (does it derive from `:Coercion/*`)?"
   (mc/schema
-    [:fn {:error/fn (constantly (deferred-tru "value must be a valid coercion strategy."))}
+    [:fn {:error/fn (fn [] (deferred-tru "value must be a valid coercion strategy."))}
      #(isa? % :Coercion/*)]))
 
 (def FieldTypeKeywordOrString
@@ -75,25 +75,25 @@
    This is useful especially for validating API input or objects coming out of the DB as it is unlikely
    those values will be encoded as keywords at that point."
   (mc/schema
-    [:fn {:error/fn (constantly (deferred-tru "value must be a valid field data type (keyword or string)."))}
+    [:fn {:error/fn (fn [] (deferred-tru "value must be a valid field data type (keyword or string)."))}
      #(isa? (keyword %) :type/*)]))
 
 (def FieldSemanticTypeKeywordOrString
   "Like `FieldSemanticType` but accepts either a keyword or string."
   (mc/schema
-    [:fn {:error/fn (constantly (deferred-tru "value must be a valid field semantic type (keyword or string)."))}
+    [:fn {:error/fn (fn [] (deferred-tru "value must be a valid field semantic type (keyword or string)."))}
      #(isa? (keyword %) :Semantic/*)]))
 
 (def FieldRelationTypeKeywordOrString
   "Like `FieldRelationType` but accepts either a keyword or string."
   (mc/schema
-    [:fn {:error/fn (constantly (deferred-tru "value must be a valid field relation type (keyword or string)."))}
+    [:fn {:error/fn (fn [] (deferred-tru "value must be a valid field relation type (keyword or string)."))}
      #(isa? (keyword %) :Relation/*)]))
 
 (def FieldSemanticOrRelationTypeKeywordOrString
   "Like `FieldSemanticOrRelationType` but accepts either a keyword or string."
   (mc/schema
-    [:fn {:error/fn (constantly (deferred-tru "value must be a valid field semantic or relation type (keyword or string)."))}
+    [:fn {:error/fn (fn [] (deferred-tru "value must be a valid field semantic or relation type (keyword or string)."))}
      (fn [k]
        (let [k (keyword k)]
          (or (isa? k :Semantic/*)
@@ -102,7 +102,7 @@
 (def Field
   "Schema for a valid Field for API usage."
   (mc/schema
-    [:fn {:error/fn (constantly (deferred-tru "value must an array with :field id-or-name and an options map"))}
+    [:fn {:error/fn (fn [] (deferred-tru "value must an array with :field id-or-name and an options map"))}
      (fn [k]
        ((comp (complement (s/checker mbql.s/Field))
               mbql.normalize/normalize-tokens) k))]))
@@ -110,26 +110,26 @@
 (def CoercionStrategyKeywordOrString
   "Like `CoercionStrategy` but accepts either a keyword or string."
   (mc/schema
-    [:fn {:error/fn (constantly (deferred-tru "value must be a valid coercion strategy (keyword or string)."))}
+    [:fn {:error/fn (fn [] (deferred-tru "value must be a valid coercion strategy (keyword or string)."))}
      #(isa? (keyword %) :Coercion/*)]))
 
 (def EntityTypeKeywordOrString
   "Validates entity type derivatives of `:entity/*`. Allows strings or keywords"
   (mc/schema
-    [:fn {:error/fn (constantly (deferred-tru "value must be a valid entity type (keyword or string)."))}
+    [:fn {:error/fn (fn [] (deferred-tru "value must be a valid entity type (keyword or string)."))}
      #(isa? (keyword %) :entity/*)]))
 
 (def Map
   "Schema for a valid map."
   (mc/schema
-    [:map {:error/fn (constantly (deferred-tru "Value must be a map."))}]))
+    [:map {:error/fn (fn [] (deferred-tru "Value must be a map."))}]))
 
 (def Email
   "Schema for a valid email string."
   (mc/schema
     [:and
      :string
-     [:fn {:error/fn (constantly (deferred-tru "value must be a valid email address."))}
+     [:fn {:error/fn (fn [] (deferred-tru "value must be a valid email address."))}
       u/email?]]))
 
 (def ValidPassword
@@ -137,7 +137,7 @@
   (mc/schema
     [:and
      :string
-     [:fn {:error/fn (constantly (fn [_ _] (deferred-tru "password is too common.")))}
+     [:fn {:error/fn (fn [] (deferred-tru "password is too common."))}
       u.password/is-valid?]]))
 
 (def IntString
@@ -146,7 +146,7 @@
   (mc/schema
     [:and
      :string
-     [:fn {:error/fn (constantly (deferred-tru "value must be a valid integer."))}
+     [:fn {:error/fn (fn [] (deferred-tru "value must be a valid integer."))}
       #(u/ignore-exceptions (Integer/parseInt %))]]))
 
 (def IntStringGreaterThanZero
@@ -155,7 +155,7 @@
   (mc/schema
     [:and
      :string
-     [:fn {:error/fn (constantly (deferred-tru "value must be a valid integer greater than zero."))}
+     [:fn {:error/fn (fn [] (deferred-tru "value must be a valid integer greater than zero."))}
       #(u/ignore-exceptions (< 0 (Integer/parseInt %)))]]))
 
 (def IntStringGreaterThanOrEqualToZero
@@ -164,7 +164,7 @@
   (mc/schema
     [:and
      :string
-     [:fn {:error/fn (constantly (deferred-tru "value must be a valid integer greater than or equal to zero."))}
+     [:fn {:error/fn (fn [] (deferred-tru "value must be a valid integer greater than or equal to zero."))}
       #(u/ignore-exceptions (<= 0 (Integer/parseInt %)))]]))
 
 (def BooleanString
@@ -178,7 +178,7 @@
   (mc/schema
     [:and
      :string
-     [:fn {:error/fn (constantly (deferred-tru "value must be a valid date string"))}
+     [:fn {:error/fn (fn [] (deferred-tru "value must be a valid date string"))}
       #(u/ignore-exceptions (boolean (u.date/parse %)))]]))
 
 (def JSONString
@@ -186,7 +186,7 @@
   (mc/schema
     [:and
      :string
-     [:fn {:error/fn (constantly (deferred-tru "value must be a valid JSON string."))}
+     [:fn {:error/fn (fn [] (deferred-tru "value must be a valid JSON string."))}
       #(try
          (json/parse-string %)
          true
@@ -229,7 +229,7 @@
   Parameters we store on dashboard/card, and it has some difference with Parameter in MBQL."
   ;; TODO we could use :multi to dispatch values_source_type to the correct values_source_config
   (mc/schema
-    [:map {:error/fn (constantly (deferred-tru "parameter must be a map with :id and :type keys"))}
+    [:map {:error/fn (fn [] (deferred-tru "parameter must be a map with :id and :type keys"))}
      [:id NonBlankString]
      [:type keyword-or-non-blank-str-malli]
      ;; TODO how to merge this with ParameterSource above?
@@ -243,7 +243,7 @@
 (def ParameterMapping
   "Schema for a valid Parameter Mapping"
   (mc/schema
-    [:map {:error/fn (constantly (deferred-tru "parameter_mapping must be a map with :parameter_id and :target keys"))}
+    [:map {:error/fn (fn [] (deferred-tru "parameter_mapping must be a map with :parameter_id and :target keys"))}
      [:parameter_id NonBlankString]
      [:target :any]
      [:card_id {:optional true} IntGreaterThanZero]]))
@@ -251,7 +251,7 @@
 (def EmbeddingParams
   "Schema for a valid map of embedding params."
   (mc/schema
-    [:map-of {:error/fn (constantly (deferred-tru "value must be a valid embedding params map."))}
+    [:map-of {:error/fn (fn [] (deferred-tru "value must be a valid embedding params map."))}
      :keyword
      [:enum "disabled" "enabled" "locked"]]))
 
@@ -260,11 +260,11 @@
   (mc/schema
     [:and
      NonBlankString
-     [:fn {:error/fn (constantly (deferred-tru "String must be a valid two-letter ISO language or language-country code e.g. 'en' or 'en_US'."))}
+     [:fn {:error/fn (fn [] (deferred-tru "String must be a valid two-letter ISO language or language-country code e.g. 'en' or 'en_US'."))}
       i18n/available-locale?]]))
 
 (def NanoIdString
   "Schema for a 21-character NanoID string, like \"FReCLx5hSWTBU7kjCWfuu\"."
   (mc/schema
-    [:re {:error/fn (constantly (deferred-tru "String must be a valid 21-character NanoID string."))}
+    [:re {:error/fn (fn [] (deferred-tru "String must be a valid 21-character NanoID string."))}
      #"^[A-Za-z0-9_\-]{21}$"]))


### PR DESCRIPTION
`constantly` evaluates its argument at compile time so when we do `(constantly (deferred-tru))` the user's locale is undefined.

Change to `(fn [] (deferred-tru))` so the error message can be returned in the user's locale.