### PR TITLE
Fix auth pages having app and navigation bars

### DIFF
--- a/frontend/src/metabase/routes.jsx
+++ b/frontend/src/metabase/routes.jsx
@@ -164,6 +164,18 @@ export const getRoutes = store => (
       }}
     />
 
+    {/* AUTH */}
+    <Route path="/auth">
+      <IndexRedirect to="/auth/login" />
+      <Route component={IsNotAuthenticated}>
+        <Route path="login" title={t`Login`} component={LoginApp} />
+        <Route path="login/:provider" title={t`Login`} component={LoginApp} />
+      </Route>
+      <Route path="logout" component={LogoutApp} />
+      <Route path="forgot_password" component={ForgotPasswordApp} />
+      <Route path="reset_password/:token" component={ResetPasswordApp} />
+    </Route>
+
     {/* PUBLICLY SHARED LINKS */}
     <Route path="public">
       <Route path="question/:uuid" component={PublicQuestion} />
@@ -181,18 +193,6 @@ export const getRoutes = store => (
         trackPageView(nextState.location.pathname);
       }}
     >
-      {/* AUTH */}
-      <Route path="/auth">
-        <IndexRedirect to="/auth/login" />
-        <Route component={IsNotAuthenticated}>
-          <Route path="login" title={t`Login`} component={LoginApp} />
-          <Route path="login/:provider" title={t`Login`} component={LoginApp} />
-        </Route>
-        <Route path="logout" component={LogoutApp} />
-        <Route path="forgot_password" component={ForgotPasswordApp} />
-        <Route path="reset_password/:token" component={ResetPasswordApp} />
-      </Route>
-
       {/* MAIN */}
       <Route component={IsAuthenticated}>
         {/* The global all hands routes, things in here are for all the folks */}

--- a/frontend/src/metabase/routes.jsx
+++ b/frontend/src/metabase/routes.jsx
@@ -164,18 +164,6 @@ export const getRoutes = store => (
       }}
     />
 
-    {/* AUTH */}
-    <Route path="/auth">
-      <IndexRedirect to="/auth/login" />
-      <Route component={IsNotAuthenticated}>
-        <Route path="login" title={t`Login`} component={LoginApp} />
-        <Route path="login/:provider" title={t`Login`} component={LoginApp} />
-      </Route>
-      <Route path="logout" component={LogoutApp} />
-      <Route path="forgot_password" component={ForgotPasswordApp} />
-      <Route path="reset_password/:token" component={ResetPasswordApp} />
-    </Route>
-
     {/* PUBLICLY SHARED LINKS */}
     <Route path="public">
       <Route path="question/:uuid" component={PublicQuestion} />
@@ -193,6 +181,18 @@ export const getRoutes = store => (
         trackPageView(nextState.location.pathname);
       }}
     >
+      {/* AUTH */}
+      <Route path="/auth">
+        <IndexRedirect to="/auth/login" />
+        <Route component={IsNotAuthenticated}>
+          <Route path="login" title={t`Login`} component={LoginApp} />
+          <Route path="login/:provider" title={t`Login`} component={LoginApp} />
+        </Route>
+        <Route path="logout" component={LogoutApp} />
+        <Route path="forgot_password" component={ForgotPasswordApp} />
+        <Route path="reset_password/:token" component={ResetPasswordApp} />
+      </Route>
+
       {/* MAIN */}
       <Route component={IsAuthenticated}>
         {/* The global all hands routes, things in here are for all the folks */}

--- a/frontend/src/metabase/selectors/app.ts
+++ b/frontend/src/metabase/selectors/app.ts
@@ -18,9 +18,8 @@ export interface RouterProps {
 }
 
 const HOMEPAGE_PATH = /^\/$/;
-const AUTH_PATH = /^\/auth/;
 const PATHS_WITHOUT_NAVBAR = [
-  AUTH_PATH,
+  /^\/auth/,
   /\/model\/.*\/query/,
   /\/model\/.*\/metadata/,
   /\/model\/query/,
@@ -28,7 +27,6 @@ const PATHS_WITHOUT_NAVBAR = [
 ];
 const EMBEDDED_PATHS_WITH_NAVBAR = [
   HOMEPAGE_PATH,
-  AUTH_PATH,
   /^\/collection\/.*/,
   /^\/archive/,
 ];

--- a/frontend/src/metabase/selectors/app.ts
+++ b/frontend/src/metabase/selectors/app.ts
@@ -18,7 +18,9 @@ export interface RouterProps {
 }
 
 const HOMEPAGE_PATH = /^\/$/;
+const AUTH_PATH = /^\/auth/;
 const PATHS_WITHOUT_NAVBAR = [
+  AUTH_PATH,
   /\/model\/.*\/query/,
   /\/model\/.*\/metadata/,
   /\/model\/query/,
@@ -26,6 +28,7 @@ const PATHS_WITHOUT_NAVBAR = [
 ];
 const EMBEDDED_PATHS_WITH_NAVBAR = [
   HOMEPAGE_PATH,
+  AUTH_PATH,
   /^\/collection\/.*/,
   /^\/archive/,
 ];

--- a/frontend/test/metabase/scenarios/onboarding/auth/forgot_password.cy.spec.js
+++ b/frontend/test/metabase/scenarios/onboarding/auth/forgot_password.cy.spec.js
@@ -29,6 +29,16 @@ describe("scenarios > auth > password", { tags: "@external" }, () => {
       cy.findByText("You've updated your password.");
     });
   });
+
+  it("should not show the app bar when previously logged in", () => {
+    cy.signInAsAdmin();
+    cy.intercept("GET", "/api/user/current").as("getUser");
+
+    cy.visit("/auth/forgot_password");
+
+    cy.get("@getUser.all").should("have.length", 0);
+    cy.icon("gear").should("not.exist");
+  });
 });
 
 const getResetLink = html => {

--- a/frontend/test/metabase/scenarios/onboarding/auth/signin.cy.spec.js
+++ b/frontend/test/metabase/scenarios/onboarding/auth/signin.cy.spec.js
@@ -14,9 +14,16 @@ describe("scenarios > auth > signin", () => {
     cy.intercept("POST", "/api/dataset").as("dataset");
   });
 
-  it("should redirect to  /auth/login", () => {
+  it("should redirect to /auth/login", () => {
     cy.visit("/");
     cy.url().should("contain", "auth/login");
+  });
+
+  it("should redirect to / when logged in", () => {
+    cy.signInAsAdmin();
+    cy.visit("/auth/login");
+    cy.url().should("not.contain", "auth/login");
+    cy.icon("gear").should("exist");
   });
 
   it("should display an error for incorrect passwords", () => {


### PR DESCRIPTION
How to test:
- Login into Metabase
- Go to `/auth/forgot_password`

You should not see the app and navigation bars anymore, e.g. not like this:
<img width="1447" alt="image" src="https://user-images.githubusercontent.com/8542534/216041417-4f6ce449-faf2-4975-9800-99fdaad38992.png">

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/27992)
<!-- Reviewable:end -->
