### PR TITLE
update specs and ensure users need to wait until stats are loaded

### DIFF
--- a/frontend/src/metabase/admin/databases/components/DeleteDatabaseModel/DeleteDatabaseModal.tsx
+++ b/frontend/src/metabase/admin/databases/components/DeleteDatabaseModel/DeleteDatabaseModal.tsx
@@ -51,7 +51,7 @@ const DeleteDatabaseModal = ({
   onClose,
   onDelete,
 }: DeleteDatabaseModalProps) => {
-  const { data: usageInfo } = useFetch<DatabaseUsageInfo>(
+  const { data: usageInfo, isLoading } = useFetch<DatabaseUsageInfo>(
     `/api/database/${database.id}/usage_info`,
   );
 
@@ -85,7 +85,9 @@ const DeleteDatabaseModal = ({
   const shouldShowDbNameInputConfirmation =
     isContentRemovalConfirmed || !hasContent;
   const canDelete =
-    (isContentRemovalConfirmed || !hasContent) && isDatabaseNameConfirmed;
+    !isLoading &&
+    (isContentRemovalConfirmed || !hasContent) &&
+    isDatabaseNameConfirmed;
 
   const deleteButtonLabel = hasContent
     ? t`Delete this content and the DB connection`

--- a/frontend/src/metabase/admin/databases/components/DeleteDatabaseModel/DeleteDatabaseModal.unit.spec.tsx
+++ b/frontend/src/metabase/admin/databases/components/DeleteDatabaseModel/DeleteDatabaseModal.unit.spec.tsx
@@ -48,7 +48,10 @@ describe("DeleteDatabaseModal", () => {
   });
 
   it("should allow deleting database without content after confirming its name", () => {
-    useFetchMock.mockReturnValue({ data: getUsageInfo(false) } as any);
+    useFetchMock.mockReturnValue({
+      data: getUsageInfo(false),
+      isLoading: false,
+    } as any);
 
     const { onDelete } = setup();
 
@@ -73,7 +76,10 @@ describe("DeleteDatabaseModal", () => {
   });
 
   it("should allow deleting database with content after confirming its name and its content removal", () => {
-    useFetchMock.mockReturnValue({ data: getUsageInfo(true) } as any);
+    useFetchMock.mockReturnValue({
+      data: getUsageInfo(true),
+      isLoading: false,
+    } as any);
 
     const { onDelete } = setup();
 
@@ -103,9 +109,12 @@ describe("DeleteDatabaseModal", () => {
   });
 
   it("shows an error if removal failed", () => {
-    useFetchMock.mockReturnValue({ data: getUsageInfo(false) } as any);
+    useFetchMock.mockReturnValue({
+      data: getUsageInfo(false),
+      isLoading: false,
+    } as any);
 
-    const { onDelete } = setup({
+    setup({
       onDelete: () => {
         throw new Error("Something went wrong");
       },

--- a/frontend/test/metabase/scenarios/admin/databases/edit.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/databases/edit.cy.spec.js
@@ -249,7 +249,7 @@ describe("scenarios > admin > databases > edit", () => {
       cy.wait("@usage_info");
 
       modal().within(() => {
-        cy.findByLabelText("Delete 3 saved questions").click();
+        cy.findByLabelText(/Delete [0-9]* saved questions/).click();
         cy.findByPlaceholderText("Are you completely sure?").type(
           "Sample Database",
         );

--- a/frontend/test/metabase/scenarios/admin/databases/edit.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/databases/edit.cy.spec.js
@@ -240,11 +240,19 @@ describe("scenarios > admin > databases > edit", () => {
 
     it("lets you remove the Sample Database", () => {
       cy.intercept("DELETE", `/api/database/${SAMPLE_DB_ID}`).as("delete");
+      cy.intercept("GET", `/api/database/${SAMPLE_DB_ID}/usage_info`).as(
+        `usage_info`,
+      );
 
       cy.visit(`/admin/databases/${SAMPLE_DB_ID}`);
       cy.findByText("Remove this database").click();
+      cy.wait("@usage_info");
+
       modal().within(() => {
-        cy.get("input").type("Sample Database");
+        cy.findByLabelText("Delete 3 saved questions").click();
+        cy.findByPlaceholderText("Are you completely sure?").type(
+          "Sample Database",
+        );
         cy.get(".Button.Button--danger").click();
       });
 


### PR DESCRIPTION
[Slack convo](https://metaboat.slack.com/archives/C5XHN8GLW/p1675253877724579)

## Changes

Don't enable the delete button while stats are loaded even if users entered the db name confirmation. Update specs to prevent flakiness.

## How to verify

Ensure CI is green