### PR TITLE
Do not suggest to connect a variable template tag to fields in the values source modal

### DIFF
--- a/frontend/src/metabase/parameters/components/ValuesSourceModal/ValuesSourceModal.tsx
+++ b/frontend/src/metabase/parameters/components/ValuesSourceModal/ValuesSourceModal.tsx
@@ -9,6 +9,7 @@ import {
   getSourceConfigForType,
   getSourceType,
 } from "metabase-lib/parameters/utils/parameter-source";
+import { ParameterWithTemplateTagTarget } from "metabase-lib/parameters/types";
 import ValuesSourceTypeModal from "./ValuesSourceTypeModal";
 import ValuesSourceCardModal from "./ValuesSourceCardModal";
 
@@ -29,7 +30,7 @@ const ValuesSourceModal = ({
   onClose,
 }: ModalProps): JSX.Element => {
   const [step, setStep] = useState<ModalStep>("main");
-  const [sourceType, setSourceType] = useState(getSourceType(parameter));
+  const [sourceType, setSourceType] = useState(getInitialSourceType(parameter));
   const [sourceConfig, setSourceConfig] = useState(getSourceConfig(parameter));
 
   const handlePickerOpen = useCallback(() => {
@@ -65,6 +66,12 @@ const ValuesSourceModal = ({
       onClose={onClose}
     />
   );
+};
+
+const getInitialSourceType = (parameter: ParameterWithTemplateTagTarget) => {
+  return parameter.hasVariableTemplateTagTarget
+    ? "card"
+    : getSourceType(parameter);
 };
 
 export default ValuesSourceModal;

--- a/frontend/src/metabase/parameters/components/ValuesSourceModal/ValuesSourceModal.unit.spec.tsx
+++ b/frontend/src/metabase/parameters/components/ValuesSourceModal/ValuesSourceModal.unit.spec.tsx
@@ -67,6 +67,21 @@ describe("ValuesSourceModal", () => {
         expect(screen.getByRole("textbox")).toHaveValue("A\nB\nC");
       });
     });
+
+    it("should not show the fields option for variable template tags", () => {
+      setup({
+        parameter: createMockUiParameter({
+          hasVariableTemplateTagTarget: true,
+        }),
+      });
+
+      expect(
+        screen.queryByRole("radio", { name: "From connected fields" }),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.getByRole("radio", { name: "From another model or question" }),
+      ).toBeChecked();
+    });
   });
 
   describe("card source", () => {


### PR DESCRIPTION
Epic https://github.com/metabase/metabase/issues/26898

This PR removes the invalid option for variable template tags (i.e. not field filters). 

How to test:
- New -> SQL Query -> `SELECT {{tag}}`
- How should users filter on this variable? -> Dropdown list -> Edit
- There should be no option to select connected fields

<img width="1725" alt="Screenshot 2023-02-01 at 16 34 55" src="https://user-images.githubusercontent.com/8542534/216072876-87a82dca-2a9c-47b6-ae0a-b221654d8aca.png">
