### PR TITLE
Fix removed 'all' icon is still used

### DIFF
--- a/frontend/src/metabase/admin/permissions/components/FilterableTree/FilterableTree.tsx
+++ b/frontend/src/metabase/admin/permissions/components/FilterableTree/FilterableTree.tsx
@@ -76,7 +76,7 @@ export const FilterableTree = ({
                 {/* @ts-ignore */}
                 <EmptyState
                   message={emptyState?.text ?? t`Nothing here`}
-                  icon={emptyState?.icon ?? "all"}
+                  icon={emptyState?.icon ?? "folder"}
                 />
               </EmptyStateContainer>
             }

--- a/frontend/src/metabase/admin/permissions/components/PermissionsEditor/PermissionsEditorContent.jsx
+++ b/frontend/src/metabase/admin/permissions/components/PermissionsEditor/PermissionsEditorContent.jsx
@@ -94,7 +94,7 @@ export function PermissionsEditorContent({
           onAction={onAction}
           emptyState={
             <EditorEmptyStateContainer>
-              <EmptyState message={t`Nothing here`} icon="all" />
+              <EmptyState message={t`Nothing here`} icon="folder" />
             </EditorEmptyStateContainer>
           }
         />

--- a/frontend/src/metabase/containers/DataPicker/EmptyState/EmptyState.tsx
+++ b/frontend/src/metabase/containers/DataPicker/EmptyState/EmptyState.tsx
@@ -8,7 +8,7 @@ interface Props {
   icon?: string;
 }
 
-function EmptyState({ message = t`Nothing here`, icon = "all" }: Props) {
+function EmptyState({ message = t`Nothing here`, icon = "folder" }: Props) {
   return (
     <EmptyStateContainer>
       <DefaultEmptyState message={message} icon={icon} />

--- a/frontend/src/metabase/dashboard/components/AddSeriesModal/QuestionList.jsx
+++ b/frontend/src/metabase/dashboard/components/AddSeriesModal/QuestionList.jsx
@@ -205,7 +205,7 @@ export const QuestionList = React.memo(function QuestionList({
           </AutoSizer>
           {!hasQuestionsToShow && (
             <EmptyStateContainer>
-              <EmptyState message={t`Nothing here`} icon="all" />
+              <EmptyState message={t`Nothing here`} icon="folder" />
             </EmptyStateContainer>
           )}
         </QuestionListContainer>

--- a/frontend/src/metabase/nav/components/RecentsList.jsx
+++ b/frontend/src/metabase/nav/components/RecentsList.jsx
@@ -123,7 +123,7 @@ function RecentsList({ list, loading, onChangeLocation }) {
 
           {!hasRecents && (
             <EmptyStateContainer>
-              <EmptyState message={t`Nothing here`} icon="all" />
+              <EmptyState message={t`Nothing here`} icon="folder" />
             </EmptyStateContainer>
           )}
         </React.Fragment>

--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorDatabaseSchemaPicker/DataSelectorDatabaseSchemaPicker.tsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorDatabaseSchemaPicker/DataSelectorDatabaseSchemaPicker.tsx
@@ -65,7 +65,7 @@ const DataSelectorDatabaseSchemaPicker = ({
           }))
         : [],
     className: database.is_saved_questions ? "bg-light" : null,
-    icon: database.is_saved_questions ? "all" : "database",
+    icon: database.is_saved_questions ? "collection" : "database",
     loading:
       selectedDatabase?.id === database.id &&
       database.schemas.length === 0 &&

--- a/frontend/src/metabase/reference/databases/TableQuestions.jsx
+++ b/frontend/src/metabase/reference/databases/TableQuestions.jsx
@@ -30,7 +30,7 @@ import {
 const emptyStateData = table => {
   return {
     message: t`Questions about this table will appear here as they're added`,
-    icon: "all",
+    icon: "folder",
     action: t`Ask a question`,
     link: getQuestionUrl({
       dbId: table.db_id,

--- a/frontend/src/metabase/reference/databases/TableSidebar.jsx
+++ b/frontend/src/metabase/reference/databases/TableSidebar.jsx
@@ -41,7 +41,7 @@ const TableSidebar = ({ database, table, style, className }) => (
       <SidebarItem
         key={`/reference/databases/${database.id}/tables/${table.id}/questions`}
         href={`/reference/databases/${database.id}/tables/${table.id}/questions`}
-        icon="all"
+        icon="folder"
         name={t`Questions about this table`}
       />
       {MetabaseSettings.get("enable-xrays") && (

--- a/frontend/src/metabase/reference/metrics/MetricSidebar.jsx
+++ b/frontend/src/metabase/reference/metrics/MetricSidebar.jsx
@@ -32,7 +32,7 @@ const MetricSidebar = ({ metric, user, style, className }) => (
         <SidebarItem
           key={`/reference/metrics/${metric.id}/questions`}
           href={`/reference/metrics/${metric.id}/questions`}
-          icon="all"
+          icon="folder"
           name={t`Questions about ${metric.name}`}
         />
         {MetabaseSettings.get("enable-xrays") && (

--- a/frontend/src/metabase/reference/segments/SegmentQuestions.jsx
+++ b/frontend/src/metabase/reference/segments/SegmentQuestions.jsx
@@ -31,7 +31,7 @@ import {
 const emptyStateData = (table, segment) => {
   return {
     message: t`Questions about this segment will appear here as they're added`,
-    icon: "all",
+    icon: "folder",
     action: t`Ask a question`,
     link: getQuestionUrl({
       dbId: table && table.db_id,

--- a/frontend/src/metabase/reference/segments/SegmentSidebar.jsx
+++ b/frontend/src/metabase/reference/segments/SegmentSidebar.jsx
@@ -38,7 +38,7 @@ const SegmentSidebar = ({ segment, user, style, className }) => (
         <SidebarItem
           key={`/reference/segments/${segment.id}/questions`}
           href={`/reference/segments/${segment.id}/questions`}
-          icon="all"
+          icon="folder"
           name={t`Questions about this segment`}
         />
         {MetabaseSettings.get("enable-xrays") && (


### PR DESCRIPTION
#27929 removed the "all" icon in favor of "folder" / "collection", but we've missed a few spots where it's used. This PR should fix it 🎉 