### PR TITLE
Run all tests on mysql/h2/postgres app-db tests

### DIFF
--- a/.github/actions/test-driver/action.yml
+++ b/.github/actions/test-driver/action.yml
@@ -17,7 +17,7 @@ runs:
       run: yarn build-static-viz
       shell: bash
     - name: Test database driver
-      run: clojure -X:dev:ci:ee:ee-dev:drivers:drivers-dev:test ${{ inputs.test-args }} :exclude-tags '[:mb/once]'
+      run: clojure -X:dev:ci:ee:ee-dev:drivers:drivers-dev:test ${{ inputs.test-args }}
       shell: bash
     - name: Publish Test Report (JUnit)
       uses: dorny/test-reporter@v1

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -43,6 +43,7 @@ jobs:
       uses: ./.github/actions/test-driver
       with:
         junit-name: 'be-tests-athena-ee'
+        test-args: ":exclude-tags '[:mb/once]'"
 
   be-tests-bigquery-cloud-sdk-ee:
     if: github.event.pull_request.draft == false
@@ -63,6 +64,7 @@ jobs:
       uses: ./.github/actions/test-driver
       with:
         junit-name: 'be-tests-bigquery-cloud-sdk-ee'
+        test-args: ":exclude-tags '[:mb/once]'"
 
   be-tests-druid-ee:
     if: github.event.pull_request.draft == false
@@ -84,6 +86,7 @@ jobs:
       uses: ./.github/actions/test-driver
       with:
         junit-name: 'be-tests-druid-ee'
+        test-args: ":exclude-tags '[:mb/once]'"
 
   be-tests-googleanalytics-ee:
     if: github.event.pull_request.draft == false
@@ -98,6 +101,7 @@ jobs:
       uses: ./.github/actions/test-driver
       with:
         junit-name: 'be-tests-googleanalytics-ee'
+        test-args: ":exclude-tags '[:mb/once]'"
 
   be-tests-google-related-classpath-ee:
     if: github.event.pull_request.draft == false
@@ -193,6 +197,7 @@ jobs:
       uses: ./.github/actions/test-driver
       with:
         junit-name: 'be-tests-mongo-4-2-ee'
+        test-args: ":exclude-tags '[:mb/once]'"
 
   be-tests-mongo-4-2-ssl-ee:
     if: github.event.pull_request.draft == false
@@ -226,6 +231,7 @@ jobs:
         uses: ./.github/actions/test-driver
         with:
           junit-name: 'be-tests-mongo-4-2-ee'
+          test-args: ":exclude-tags '[:mb/once]'"
 
   be-tests-mongo-5-0-ee:
     if: github.event.pull_request.draft == false
@@ -247,6 +253,7 @@ jobs:
       uses: ./.github/actions/test-driver
       with:
         junit-name: 'be-tests-mongo-5-0-ee'
+        test-args: ":exclude-tags '[:mb/once]'"
 
   be-tests-mongo-5-0-ssl-ee:
     if: github.event.pull_request.draft == false
@@ -280,6 +287,7 @@ jobs:
       uses: ./.github/actions/test-driver
       with:
         junit-name: 'be-tests-mongo-5-0-ee'
+        test-args: ":exclude-tags '[:mb/once]'"
 
   be-tests-mongo-latest-ee:
     if: github.event.pull_request.draft == false
@@ -304,6 +312,7 @@ jobs:
       uses: ./.github/actions/test-driver
       with:
         junit-name: 'be-tests-mongo-latest-ee'
+        test-args: ":exclude-tags '[:mb/once]'"
 
   be-tests-mysql-5-7-ee:
     if: github.event.pull_request.draft == false
@@ -391,6 +400,7 @@ jobs:
       uses: ./.github/actions/test-driver
       with:
         junit-name: 'be-tests-oracle-18-4-ee'
+        test-args: ":exclude-tags '[:mb/once]'"
 
   be-tests-oracle-21-3-ee:
     if: github.event.pull_request.draft == false
@@ -425,6 +435,7 @@ jobs:
       uses: ./.github/actions/test-driver
       with:
         junit-name: 'be-tests-oracle-21-3-ee'
+        test-args: ":exclude-tags '[:mb/once]'"
 
   be-tests-postgres-ee:
     if: github.event.pull_request.draft == false
@@ -506,6 +517,7 @@ jobs:
       uses: ./.github/actions/test-driver
       with:
         junit-name: 'be-tests-presto-186-ee'
+        test-args: ":exclude-tags '[:mb/once]'"
 
   be-tests-presto-jdbc-ee:
     if: github.event.pull_request.draft == false
@@ -554,6 +566,7 @@ jobs:
       uses: ./.github/actions/test-driver
       with:
         junit-name: 'be-tests-presto-jdbc-ee'
+        test-args: ":exclude-tags '[:mb/once]'"
     - name: Capture max memory usage
       run: cat /sys/fs/cgroup/memory/memory.max_usage_in_bytes
 
@@ -574,6 +587,7 @@ jobs:
       uses: ./.github/actions/test-driver
       with:
         junit-name: 'be-tests-redshift-ee'
+        test-args: ":exclude-tags '[:mb/once]'"
 
   be-tests-snowflake-ee:
     if: github.event.pull_request.draft == false
@@ -594,6 +608,7 @@ jobs:
       uses: ./.github/actions/test-driver
       with:
         junit-name: 'be-tests-snowflake-ee'
+        test-args: ":exclude-tags '[:mb/once]'"
 
   be-tests-sparksql-ee:
     if: github.event.pull_request.draft == false
@@ -613,6 +628,7 @@ jobs:
       uses: ./.github/actions/test-driver
       with:
         junit-name: 'be-tests-sparksql-ee'
+        test-args: ":exclude-tags '[:mb/once]'"
 
   be-tests-sqlite-ee:
     if: github.event.pull_request.draft == false
@@ -627,6 +643,7 @@ jobs:
       uses: ./.github/actions/test-driver
       with:
         junit-name: 'be-tests-sqlite-ee'
+        test-args: ":exclude-tags '[:mb/once]'"
 
   be-tests-sqlserver-ee:
     if: github.event.pull_request.draft == false
@@ -653,6 +670,7 @@ jobs:
       uses: ./.github/actions/test-driver
       with:
         junit-name: 'be-tests-sqlserver-ee'
+        test-args: ":exclude-tags '[:mb/once]'"
 
   be-tests-vertica-ee:
     if: github.event.pull_request.draft == false
@@ -674,3 +692,4 @@ jobs:
       uses: ./.github/actions/test-driver
       with:
         junit-name: 'be-tests-vertica-ee'
+        test-args: ":exclude-tags '[:mb/once]'"


### PR DESCRIPTION
Originally made all "drivers" tests skip the :mb/once test selected test namespaces. But we use the drivers matrix to test the different app-db types (mysql, postgres). So this moves the `:exclude-tags [:mb/once]` selector off of the drivers job and into particular driver jobs.

```clojure
user=> (letfn [(uses-exclude? [[job-name job]]
                 (let [steps (:steps job)]
                   (reduce (fn [uses? step]
                             (if-let [with (:with step)]
                               (if (= ":exclude-tags '[:mb/once]'" (:test-args with))
                                 (reduced true)
                                 uses?)
                               uses?))
                           false
                           steps)))]
         (-> (group-by uses-exclude? (:jobs (yaml/from-file ".github/workflows/drivers.yml")))
             (update-vals (fn [jobs] (map key jobs)))))
{true (:be-tests-athena-ee
       :be-tests-bigquery-cloud-sdk-ee
       :be-tests-druid-ee
       :be-tests-googleanalytics-ee
       :be-tests-mongo-4-2-ee
       :be-tests-mongo-4-2-ssl-ee
       :be-tests-mongo-5-0-ee
       :be-tests-mongo-5-0-ssl-ee
       :be-tests-mongo-latest-ee
       :be-tests-oracle-18-4-ee
       :be-tests-oracle-21-3-ee
       :be-tests-presto-186-ee
       :be-tests-presto-jdbc-ee
       :be-tests-redshift-ee
       :be-tests-snowflake-ee
       :be-tests-sparksql-ee
       :be-tests-sqlite-ee
       :be-tests-sqlserver-ee
       :be-tests-vertica-ee),
 false (:be-tests-google-related-classpath-ee ;; includes an :only selector
        :be-tests-mariadb-10-2-ee
        :be-tests-mariadb-latest-ee
        :be-tests-mysql-5-7-ee
        :be-tests-mysql-latest-ee
        :be-tests-postgres-ee
        :be-tests-postgres-latest-ee)}
```

These maria/mysql/postgres tests all specify `MB_DB_TYPE` so we omit the `exclude-tags` selector to run all tests. The only strange one here is the `:be-tests-google-related-classpath-ee` job which includes an :only selector:

```yaml
    steps:
    - uses: actions/checkout@v3
    - name: Test Google Related Classpath drivers
      uses: ./.github/actions/test-driver
      with:
        junit-name: 'be-tests-${{ matrix.driver }}-classpath-ee'
        test-args: ':only "[metabase.query-processor-test.expressions-test metabase.driver.google-test metabase.driver.googleanalytics-test]"'
```

#### Future work
I think it could make sense to pull the tests against the three different app-dbs into a different workflow and restore the previous behavior. But need to make a decision on how  big the matrix should be of `app-db x java-version x ee|oss`. 