### PR TITLE
`#schema` -> `#hawk/schema`

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/sandbox/api/gtap_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/api/gtap_test.clj
@@ -210,12 +210,12 @@
                                                  :card_id              card-id-1
                                                  :attribute_remappings {"foo" 1}}]))
                   result (mt/user-http-request :crowberto :put 200 "permissions/graph" graph)]
-              (is (=? [{:id                   #schema s/Int
+              (is (=? [{:id                   #hawk/schema s/Int
                         :table_id             table-id-1
                         :group_id             group-id
                         :card_id              card-id-1
                         :attribute_remappings {:foo 1}
-                        :permission_id        #schema s/Int}]
+                        :permission_id        #hawk/schema s/Int}]
                       (:sandboxes result)))
               (is (db/exists? GroupTableAccessPolicy :table_id table-id-1 :group_id group-id))))
 


### PR DESCRIPTION
fixes failures of

```
 {:via
  [{:type clojure.lang.Compiler$CompilerException,
    :message "Syntax error reading source at (metabase_enterprise/sandbox/api/gtap_test.clj:214:0).",
    :data
    {:clojure.error/phase :read-source,
     :clojure.error/line 214,
     :clojure.error/column 0,
     :clojure.error/source "metabase_enterprise/sandbox/api/gtap_test.clj"},
    :at [clojure.lang.Compiler load "Compiler.java" 7660]}
   {:type java.lang.RuntimeException,
    :message "No reader function for tag schema",
    :at [clojure.lang.LispReader$CtorReader readTagged "LispReader.java" 1444]}],
```

https://github.com/metabase/metabase/actions/runs/4066623275/jobs/7002952009