### PR TITLE
Update Orders.ID description in fixture

### DIFF
--- a/frontend/test/__support__/sample_database_fixture.json
+++ b/frontend/test/__support__/sample_database_fixture.json
@@ -484,7 +484,7 @@
         "values": []
       },
       "2": {
-        "description": "This is a unique ID for the product. It is also called the “Invoice number” or “Confirmation number” in customer facing emails and screens.",
+        "description": "This is a unique ID for an order. It is also called the “Invoice number” or “Confirmation number” in customer facing emails and screens.",
         "table_id": 1,
         "semantic_type": "type/PK",
         "name": "ID",


### PR DESCRIPTION
Orders.id field was described as being about a product.

Sometimes you're deep in query results land debugging something, and you look at the column description and this will throw you.