### PR TITLE
Include numThreadsAwaitingCheckoutDefaultUser in conn pool stats

### DIFF
--- a/src/metabase/analytics/prometheus.clj
+++ b/src/metabase/analytics/prometheus.clj
@@ -116,7 +116,11 @@
    :numIdleConnections {:label       "c3p0_num_idle_connections"
                         :description (deferred-trs "C3P0 Number of idle connections")}
    :numBusyConnections {:label       "c3p0_num_busy_connections"
-                        :description (deferred-trs "C3P0 Number of busy connections")}})
+                        :description (deferred-trs "C3P0 Number of busy connections")}
+
+   :numThreadsAwaitingCheckoutDefaultUser
+                       {:label       "c3p0_num_threads_awaiting_checkout_default_user"
+                        :description (deferred-trs "C3P0 Number of threads awaiting checkout")}})
 
 (defn- stats->prometheus
   "Create an ArrayList of GaugeMetricFamily objects containing measurements from the c3p0 stats. Stats are grouped by

--- a/src/metabase/troubleshooting.clj
+++ b/src/metabase/troubleshooting.clj
@@ -46,7 +46,8 @@
 
 (defn- conn-pool-bean-diag-info [acc ^ObjectName jmx-bean]
   (let [bean-id   (.getCanonicalName jmx-bean)
-        props     [:numConnections :numIdleConnections :numBusyConnections :minPoolSize :maxPoolSize]]
+        props     [:numConnections :numIdleConnections :numBusyConnections
+                   :minPoolSize :maxPoolSize :numThreadsAwaitingCheckoutDefaultUser]]
       (assoc acc (jmx/read bean-id :dataSourceName) (jmx/read bean-id props))))
 
 (defn connection-pool-info


### PR DESCRIPTION
Closes #28014 

This includes the stats in

```clojure
prometheus=> (troubleshooting/connection-pool-info)
{:connection-pools {"metabase-postgres-app-db" {:numConnections 4,
                                                :numIdleConnections 4,
                                                :numBusyConnections 0,
                                                :minPoolSize 1,
                                                :maxPoolSize 15,
                                                :numThreadsAwaitingCheckoutDefaultUser 0},
                    "db-52-postgres-clean" {:numConnections 1,
                                            :numIdleConnections 1,
                                            :numBusyConnections 0,
                                            :minPoolSize 1,
                                            :maxPoolSize 15,
                                            :numThreadsAwaitingCheckoutDefaultUser 0}}}
```

And thus ultimately in c3p0 stats:

```
_# HELP c3p0_num_threads_awaiting_checkout_default_user C3P0 Number of threads awaiting checkout
_# TYPE c3p0_num_threads_awaiting_checkout_default_user gauge
c3p0_num_threads_awaiting_checkout_default_user{database="metabase-postgres-app-db",} 0.0
c3p0_num_threads_awaiting_checkout_default_user{database="db-52-postgres-clean",} 0.0
```

### Demo:

put some load on the system:

```
~ on ☁️  metabase-query took 18s
❯ siege -c80 -r 30 "http://localhost:3000/api/card/766/query POST" -H "Cookie: $SESSION"
** SIEGE 4.1.6
** Preparing 80 concurrent users for battle.
The server is now under siege...
HTTP/1.1 202     0.49 secs:    2300 bytes ==> POST http://localhost:3000/api/card/766/query
HTTP/1.1 202     0.49 secs:    2300 bytes ==> POST http://localhost:3000/api/card/766/query
<lots of these>
HTTP/1.1 202     0.04 secs:    2300 bytes ==> POST http://localhost:3000/api/card/766/query

Transactions:		        2400 hits
Availability:		      100.00 %
Elapsed time:		       13.53 secs
Data transferred:	        5.24 MB
Response time:		        0.43 secs
Transaction rate:	      177.38 trans/sec
Throughput:		        0.39 MB/sec
Concurrency:		       76.44
Successful transactions:        2400
Failed transactions:	           0
Longest transaction:	        1.35
Shortest transaction:	        0.04
```
<img width="1092" alt="image" src="https://user-images.githubusercontent.com/6377293/216196699-7dab00e5-4b9c-4906-92d1-47312d0d497a.png">

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/28015)
<!-- Reviewable:end -->
