### PR TITLE
Docs - Updating Okta link

### DIFF
--- a/docs/people-and-groups/saml-okta.md
+++ b/docs/people-and-groups/saml-okta.md
@@ -107,7 +107,7 @@ For common issues, go to [Troubleshooting SAML][troubleshooting-saml].
 
 [enabling-saml-in-metabase]: ./authenticating-with-saml.md#enabling-saml-authentication-in-metabase
 [okta-saml-docs]: https://help.okta.com/en-us/Content/Topics/Apps/Apps_App_Integration_Wizard_SAML.htm
-[okta-create-attribute-statement]: https://support.okta.com/help/s/article/How-to-define-and-configure-a-custom-SAML-attribute-statement
+[okta-create-attribute-statement]: https://support.okta.com/help/s/article/How-to-define-and-configure-a-custom-SAML-attribute-statement?language=en_US
 [saml-doc]: ./authenticating-with-saml.md
 [site-url]: ../configuring-metabase/settings.md#site-url
 [troubleshooting-saml]: ../troubleshooting-guide/saml.md


### PR DESCRIPTION
Seems like the linter is detecting this link as dead (?) [here](https://github.com/metabase/metabase/actions/runs/4069902668/jobs/7017913743)