### PR TITLE
Display subcollections in collection views

### DIFF
--- a/frontend/src/metabase/collections/components/ActionMenu/ActionMenu.tsx
+++ b/frontend/src/metabase/collections/components/ActionMenu/ActionMenu.tsx
@@ -88,7 +88,7 @@ function ActionMenu({
         isBookmarked={isBookmarked}
         isPreviewShown={isPreviewShown(item)}
         isPreviewAvailable={isFullyParametrized(item)}
-        onPin={collection.can_write ? handlePin : null}
+        onPin={collection.can_write && item.setPinned ? handlePin : null}
         onMove={collection.can_write && item.setCollection ? handleMove : null}
         onCopy={item.copy ? handleCopy : null}
         onArchive={collection.can_write ? handleArchive : null}

--- a/frontend/src/metabase/collections/containers/CollectionContent.jsx
+++ b/frontend/src/metabase/collections/containers/CollectionContent.jsx
@@ -36,7 +36,14 @@ import {
 
 const PAGE_SIZE = 25;
 
-const ALL_MODELS = ["dashboard", "dataset", "card", "snippet", "pulse"];
+const ALL_MODELS = [
+  "dashboard",
+  "dataset",
+  "card",
+  "snippet",
+  "pulse",
+  "collection",
+];
 
 const itemKeyFn = item => `${item.id}:${item.model}`;
 

--- a/frontend/test/metabase/scenarios/collections/collection-items-listing.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/collection-items-listing.cy.spec.js
@@ -25,10 +25,11 @@ describe("scenarios > collection items listing", () => {
   const PAGE_SIZE = 25;
 
   describe("pagination", () => {
+    const SUBCOLLECTIONS = 2;
     const ADDED_QUESTIONS = 15;
     const ADDED_DASHBOARDS = 14;
 
-    const TOTAL_ITEMS = ADDED_DASHBOARDS + ADDED_QUESTIONS;
+    const TOTAL_ITEMS = SUBCOLLECTIONS + ADDED_DASHBOARDS + ADDED_QUESTIONS;
 
     beforeEach(() => {
       // Removes questions and dashboards included in the default database,
@@ -142,9 +143,10 @@ describe("scenarios > collection items listing", () => {
       toggleSortingFor(/Type/i);
       cy.wait("@getCollectionItems");
       getAllCollectionItemNames().then(({ actualNames, sortedNames }) => {
-        const dashboardsFirst = _.sortBy(sortedNames, name =>
-          name.toLowerCase().includes("question"),
-        );
+        const dashboardsFirst = _.chain(sortedNames)
+          .sortBy(name => name.toLowerCase().includes("question"))
+          .sortBy(name => name.toLowerCase().includes("collection"))
+          .value();
         expect(actualNames, "sorted dashboards first").to.deep.equal(
           dashboardsFirst,
         );
@@ -153,9 +155,10 @@ describe("scenarios > collection items listing", () => {
       toggleSortingFor(/Type/i);
       cy.wait("@getCollectionItems");
       getAllCollectionItemNames().then(({ actualNames, sortedNames }) => {
-        const questionsFirst = _.sortBy(sortedNames, name =>
-          name.toLowerCase().includes("dashboard"),
-        );
+        const questionsFirst = _.chain(sortedNames)
+          .sortBy(name => name.toLowerCase().includes("question"))
+          .sortBy(name => name.toLowerCase().includes("dashboard"))
+          .value();
         expect(actualNames, "sorted questions first").to.deep.equal(
           questionsFirst,
         );
@@ -168,7 +171,10 @@ describe("scenarios > collection items listing", () => {
 
       cy.findAllByTestId(lastEditedByColumnTestId).then(nodes => {
         const actualNames = _.map(nodes, "innerText");
-        const sortedNames = _.sortBy(actualNames);
+        const sortedNames = _.chain(actualNames)
+          .sortBy(actualNames)
+          .sortBy(name => !name)
+          .value();
         expect(
           actualNames,
           "sorted by last editor name alphabetically",
@@ -198,9 +204,12 @@ describe("scenarios > collection items listing", () => {
       cy.wait("@getCollectionItems");
 
       getAllCollectionItemNames().then(({ actualNames, sortedNames }) => {
-        expect(actualNames, "sorted newest first").to.deep.equal(
-          sortedNames.reverse(),
-        );
+        const newestFirst = _.chain(sortedNames)
+          .reverse()
+          .sortBy(name => name.toLowerCase().includes("collection"))
+          .sortBy(name => name.toLowerCase().includes("personal"))
+          .value();
+        expect(actualNames, "sorted newest first").to.deep.equal(newestFirst);
       });
     });
 

--- a/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
@@ -27,14 +27,13 @@ describe("scenarios > collection defaults", () => {
     it("should navigate effortlessly through collections tree", () => {
       visitRootCollection();
 
-      cy.log(
-        "should allow a user to expand a collection without navigating to it",
-      );
-
-      // 1. click on the chevron to expand the sub collection
-      displaySidebarChildOf("First collection");
-
       navigationSidebar().within(() => {
+        cy.log(
+          "should allow a user to expand a collection without navigating to it",
+        );
+
+        // 1. click on the chevron to expand the sub collection
+        displaySidebarChildOf("First collection");
         // 2. I should see the nested collection name
         cy.findByText("Second collection");
         cy.findByText("Third collection").should("not.exist");
@@ -98,7 +97,9 @@ describe("scenarios > collection defaults", () => {
       });
 
       // 1. Expand so that deeply nested collection is showing
-      displaySidebarChildOf("Fourth collection");
+      navigationSidebar().within(() => {
+        displaySidebarChildOf("Fourth collection");
+      });
 
       // 2. Ensure we show the helpful tooltip with the full (long) collection name
       cy.findByText("Fifth collection with a very long name").realHover();

--- a/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/collections.cy.spec.js
@@ -27,13 +27,14 @@ describe("scenarios > collection defaults", () => {
     it("should navigate effortlessly through collections tree", () => {
       visitRootCollection();
 
-      navigationSidebar().within(() => {
-        cy.log(
-          "should allow a user to expand a collection without navigating to it",
-        );
+      cy.log(
+        "should allow a user to expand a collection without navigating to it",
+      );
 
-        // 1. click on the chevron to expand the sub collection
-        displaySidebarChildOf("First collection");
+      // 1. click on the chevron to expand the sub collection
+      displaySidebarChildOf("First collection");
+
+      navigationSidebar().within(() => {
         // 2. I should see the nested collection name
         cy.findByText("Second collection");
         cy.findByText("Third collection").should("not.exist");
@@ -402,7 +403,7 @@ describe("scenarios > collection defaults", () => {
             cy.findByRole("checkbox");
             cy.icon("dash").click({ force: true });
             cy.icon("dash").should("not.exist");
-            cy.findByText("4 items selected");
+            cy.findByText("6 items selected");
 
             // Deselect all
             cy.icon("check").click({ force: true });
@@ -537,9 +538,11 @@ function moveOpenedCollectionTo(newParent) {
 
   cy.findAllByTestId("item-picker-item").contains(newParent).click();
 
-  cy.button("Move").click();
+  modal().within(() => {
+    cy.button("Move").click();
+  });
   // Make sure modal closed
-  cy.button("Move").should("not.exist");
+  modal().should("not.exist");
 }
 
 function dragAndDrop(subjectAlias, targetAlias) {

--- a/frontend/test/metabase/scenarios/collections/helpers/e2e-collections-sidebar.js
+++ b/frontend/test/metabase/scenarios/collections/helpers/e2e-collections-sidebar.js
@@ -1,5 +1,8 @@
+import { navigationSidebar } from "__support__/e2e/helpers";
+
 export function displaySidebarChildOf(collectionName) {
-  cy.findByText(collectionName)
+  navigationSidebar()
+    .findByText(collectionName)
     .parentsUntil("[data-testid=sidebar-collection-link-root]")
     .find(".Icon-chevronright")
     .eq(0) // there may be more nested icons, but we need the top level one

--- a/frontend/test/metabase/scenarios/collections/helpers/e2e-collections-sidebar.js
+++ b/frontend/test/metabase/scenarios/collections/helpers/e2e-collections-sidebar.js
@@ -1,8 +1,5 @@
-import { navigationSidebar } from "__support__/e2e/helpers";
-
 export function displaySidebarChildOf(collectionName) {
-  navigationSidebar()
-    .findByText(collectionName)
+  cy.findByText(collectionName)
     .parentsUntil("[data-testid=sidebar-collection-link-root]")
     .find(".Icon-chevronright")
     .eq(0) // there may be more nested icons, but we need the top level one

--- a/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/permissions.cy.spec.js
@@ -7,6 +7,7 @@ import {
   navigationSidebar,
   openNativeEditor,
   openCollectionMenu,
+  modal,
 } from "__support__/e2e/helpers";
 
 import { USERS } from "__support__/e2e/cypress_data";
@@ -71,10 +72,10 @@ describe("collection permissions", () => {
                   cy.findByTestId("pinned-items").should("not.exist");
 
                   pinItem("Orders in a dashboard");
-                  unpinnedItemsLeft(3);
+                  unpinnedItemsLeft(5);
 
                   pinItem("Orders, Count");
-                  unpinnedItemsLeft(2);
+                  unpinnedItemsLeft(4);
 
                   // Should see "pinned items" and items should be in that section
                   cy.findByTestId("pinned-items").within(() => {
@@ -386,9 +387,12 @@ describe("collection permissions", () => {
                 cy.findByText("Dashboard").click();
 
                 // Coming from the root collection, the initial offered collection will be "Our analytics" (read-only access)
-                cy.findByText(
-                  `${first_name} ${last_name}'s Personal Collection`,
-                ).click();
+                modal().within(() => {
+                  cy.findByText(
+                    `${first_name} ${last_name}'s Personal Collection`,
+                  ).click();
+                });
+
                 popover().within(() => {
                   cy.findByText("My personal collection");
                   // Test will fail on this step first
@@ -435,7 +439,8 @@ function pinItem(item) {
 }
 
 function exposeChildrenFor(collectionName) {
-  cy.findByText(collectionName)
+  navigationSidebar()
+    .findByText(collectionName)
     .parentsUntil("[data-testid=sidebar-collection-link-root]")
     .find(".Icon-chevronright")
     .eq(0) // there may be more nested icons, but we need the top level one

--- a/frontend/test/metabase/scenarios/collections/personal-collections.cy.spec.js
+++ b/frontend/test/metabase/scenarios/collections/personal-collections.cy.spec.js
@@ -10,7 +10,8 @@ import {
 
 import { USERS } from "__support__/e2e/cypress_data";
 
-const adminPersonalCollectionId = 1;
+const ADMIN_PERSONAL_COLLECTION_ID = 1;
+const NODATA_PERSONAL_COLLECTION_ID = 5;
 
 describe("personal collections", () => {
   beforeEach(() => {
@@ -77,7 +78,7 @@ describe("personal collections", () => {
       cy.request("POST", "/api/collection", {
         name: "Foo",
         color: "#ff9a9a",
-        parent_id: adminPersonalCollectionId,
+        parent_id: ADMIN_PERSONAL_COLLECTION_ID,
       });
 
       // Go to admin's personal collection
@@ -123,13 +124,14 @@ describe("personal collections", () => {
       });
     });
 
-    it.skip("should be able view other users' personal sub-collections (metabase#15339)", () => {
-      cy.visit("/collection/5");
-      openNewCollectionItemFlowFor("collection");
-      cy.findByLabelText("Name").type("Foo");
-      cy.button("Create").click();
-      // This repro could possibly change depending on the design decision for this feature implementation
-      navigationSidebar().findByText("Foo");
+    it("should be able view other users' personal sub-collections (metabase#15339)", () => {
+      cy.createCollection({
+        name: "Foo",
+        parent_id: NODATA_PERSONAL_COLLECTION_ID,
+      });
+
+      cy.visit(`/collection/${NODATA_PERSONAL_COLLECTION_ID}`);
+      cy.findByText("Foo");
     });
   });
 

--- a/frontend/test/metabase/scenarios/models/reproductions/19737-data-picker-not-showing-moved-model.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/reproductions/19737-data-picker-not-showing-moved-model.cy.spec.js
@@ -1,4 +1,9 @@
-import { restore, modal, popover } from "__support__/e2e/helpers";
+import {
+  restore,
+  modal,
+  popover,
+  navigationSidebar,
+} from "__support__/e2e/helpers";
 
 const modelName = "Orders Model";
 
@@ -51,7 +56,7 @@ describe("issue 19737", () => {
     cy.go("back");
 
     // move "Orders Model" from a custom collection ("First collection") to another collection
-    cy.findByText("First collection").click();
+    navigationSidebar().findByText("First collection").click();
 
     moveModel(modelName, "My personal collection");
 


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/15339

Currently subcollections aren't displayed in the collection view. This becomes an issue for other users' personal collections because they are not displayed in the sidebar. This PR fixes the original issue by displaying subcollections in the collection view in all cases.

<img width="1682" alt="Screenshot 2023-02-02 at 16 15 46" src="https://user-images.githubusercontent.com/8542534/216348993-116053f0-4bde-421d-abea-79456a8d5212.png">

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/28023)
<!-- Reviewable:end -->
