### PR TITLE
specify a default font family for storybook

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,0 +1,5 @@
+<style type="text/css">
+  :root {
+    --default-font-family: "Lato";
+  }
+</style>


### PR DESCRIPTION
As part of our support for different fonts as part of embedding, we end up specifying `--default-font-family` in the app dynamically [over here.](https://github.com/metabase/metabase/blob/master/frontend/src/metabase/styled-components/components/GlobalStyles/GlobalStyles.tsx#L13)

Well our pal storybook doesn't know so much about that and shouldn't have to, so by adding `.storybook/preview-head.html` and adding a default-font-family var there, we're able to see the components as intended.