### PR TITLE
Add the Deprecated Driver flag to the GA driver

### DIFF
--- a/modules/drivers/googleanalytics/resources/metabase-plugin.yaml
+++ b/modules/drivers/googleanalytics/resources/metabase-plugin.yaml
@@ -4,7 +4,7 @@ info:
   description: Allows Metabase to connect to Google Analytics accounts.
 driver:
   name: googleanalytics
-  display-name: Google Analytics
+  display-name: Google Analytics (Deprecated driver)
   lazy-load: true
   connection-properties:
     - name: account-id


### PR DESCRIPTION
I'm adding the deprecation flag to the Google Analytics driver. It will be removed from the codebase on 47.

GA3 EOL is near and we won't build a new driver for GA4.