### PR TITLE
Show public action label on model detail page

### DIFF
--- a/frontend/src/metabase/models/components/ModelDetailPage/ModelActionDetails/ModelActionListItem.styled.tsx
+++ b/frontend/src/metabase/models/components/ModelDetailPage/ModelActionDetails/ModelActionListItem.styled.tsx
@@ -17,6 +17,14 @@ export const ActionSubtitle = styled.span`
   margin-top: 4px;
 `;
 
+export const ActionSubtitlePart = styled.span`
+  &:not(:last-child)::after {
+    content: "·";
+    margin-left: 6px;
+    margin-right: 6px;
+  }
+`;
+
 export const Card = styled.div`
   display: block;
   position: relative;

--- a/frontend/src/metabase/models/components/ModelDetailPage/ModelActionDetails/ModelActionListItem.tsx
+++ b/frontend/src/metabase/models/components/ModelDetailPage/ModelActionDetails/ModelActionListItem.tsx
@@ -3,6 +3,7 @@ import { t } from "ttag";
 
 import type { WritebackAction, WritebackQueryAction } from "metabase-types/api";
 
+import { isNotNull } from "metabase/core/utils/types";
 import StackedInsightIcon from "./StackedInsightIcon";
 import {
   ActionTitle,
@@ -12,6 +13,7 @@ import {
   EditButton,
   ImplicitActionCardContentRoot,
   ImplicitActionMessage,
+  ActionSubtitlePart,
 } from "./ModelActionListItem.styled";
 
 interface Props {
@@ -42,11 +44,21 @@ function ModelActionListItem({ action, onEdit }: Props) {
       <ImplicitActionCardContent />
     ) : null;
 
+  const subtitleParts = [
+    action.public_uuid && t`Public Action`,
+    // Remove this optional chaining after removed all the existing actions without creators
+    action.creator?.common_name && t`Created by ${action.creator.common_name}`,
+  ].filter(isNotNull);
+
   return (
     <>
       <ActionTitle>{action.name}</ActionTitle>
-      {action?.creator?.common_name && (
-        <ActionSubtitle>{t`Created by ${action.creator.common_name}`}</ActionSubtitle>
+      {subtitleParts.length > 0 && (
+        <ActionSubtitle>
+          {subtitleParts.map((subtitlePart, index) => (
+            <ActionSubtitlePart key={index}>{subtitlePart}</ActionSubtitlePart>
+          ))}
+        </ActionSubtitle>
       )}
       <Card>
         {renderCardContent()}

--- a/frontend/src/metabase/models/containers/ModelDetailPage/ModelDetailPage.unit.spec.tsx
+++ b/frontend/src/metabase/models/containers/ModelDetailPage/ModelDetailPage.unit.spec.tsx
@@ -465,6 +465,22 @@ describe("ModelDetailPage", () => {
           ).toBeInTheDocument();
         });
 
+        it("lists existing public query actions with public label", async () => {
+          const model = getModel();
+          const action = createMockQueryAction({
+            model_id: model.id(),
+            public_uuid: "mock-uuid",
+          });
+          await setupActions({ model, actions: [action] });
+
+          expect(screen.getByText(action.name)).toBeInTheDocument();
+          expect(screen.getByText(TEST_QUERY)).toBeInTheDocument();
+          expect(screen.getByText("Public Action")).toBeInTheDocument();
+          expect(
+            screen.getByText(`Created by ${action.creator.common_name}`),
+          ).toBeInTheDocument();
+        });
+
         it("lists existing implicit actions", async () => {
           const model = getModel();
           await setupActions({


### PR DESCRIPTION
Epic: #27626
[Product doc](https://www.notion.so/metabase/Allow-actions-to-be-shared-via-public-link-7970b901caa2476586c1454762195c55#0527c8c482d44344947b0192db845c26)


### Screenshots
#### Before
<img width="835" alt="Screenshot 2023-02-02 at 7 47 59 PM" src="https://user-images.githubusercontent.com/1937582/216434782-12111e36-9853-40cc-95d8-76c9e76c1492.png">

#### After
<img width="810" alt="Screenshot 2023-02-02 at 7 47 32 PM" src="https://user-images.githubusercontent.com/1937582/216434851-1076a24f-3432-48a1-9347-e248ae4360ca.png">

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/28039)
<!-- Reviewable:end -->
