### PR TITLE
TextArea polish + story

### DIFF
--- a/frontend/src/metabase/core/components/TextArea/TextArea.stories.tsx
+++ b/frontend/src/metabase/core/components/TextArea/TextArea.stories.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+import type { ComponentStory } from "@storybook/react";
+import TextArea from "./TextArea";
+
+export default {
+  title: "Core/Text Area",
+  component: TextArea,
+};
+
+const Template: ComponentStory<typeof TextArea> = args => {
+  return <TextArea {...args} />;
+};
+
+export const Default = Template.bind({});

--- a/frontend/src/metabase/core/components/TextArea/TextArea.styled.tsx
+++ b/frontend/src/metabase/core/components/TextArea/TextArea.styled.tsx
@@ -1,6 +1,7 @@
 import styled from "@emotion/styled";
 import { css } from "@emotion/react";
 import { color } from "metabase/lib/colors";
+import { focusOutlineStyle } from "metabase/core/style/input";
 
 export interface TextAreaRootProps {
   readOnly?: boolean;
@@ -25,6 +26,9 @@ export const TextAreaRoot = styled.textarea<TextAreaRootProps>`
     border-color: ${() => color("brand")};
     transition: border 300ms ease-in-out;
   }
+  ${css`
+    ${focusOutlineStyle("brand")}
+  `};
 
   ${props =>
     props.hasError &&


### PR DESCRIPTION
Noticed that our TextArea component didn't have the same outline style when focused that our other inputs have.
<img width="691" alt="Screen Shot 2023-02-02 at 3 15 39 PM" src="https://user-images.githubusercontent.com/5248953/216439898-dd71b38a-d07c-4d52-ac0b-3f3ca8a5fb49.png">

Before
<img width="696" alt="Screen Shot 2023-02-02 at 3 15 34 PM" src="https://user-images.githubusercontent.com/5248953/216439916-33b87f21-364b-4f21-8bc6-0c877f8353f6.png">

After
<img width="714" alt="Screen Shot 2023-02-02 at 3 14 51 PM" src="https://user-images.githubusercontent.com/5248953/216439936-d70c47f6-2b7a-43be-8b85-e6e9baa9182b.png">


Fixed that by using the handy dandy util function that our main input was using, and while I was in there, decided we might as well have a story to document the component exists.

