### PR TITLE
mu/defn auto docstrings

### DIFF
--- a/src/metabase/util/malli.clj
+++ b/src/metabase/util/malli.clj
@@ -66,14 +66,14 @@ explain-fn-fail!
                     (->> arities val :arities (map parse)))
         raw-arglists (map :raw-arglist parglists)
         schema (as-> (map ->schema parglists) $ (if single (first $) (into [:function] $)))
-        annotated-doc (str "Inputs: " (if single
-                                        (pr-str (first (mapv :raw-arglist parglists)))
-                                        (str "("
-                                             (str/join "\n           "
-                                                       (map (comp pr-str :raw-arglist) parglists))
-                                             ")"))
-                           "\n  Returns: " (pr-str (:schema return))
-                           (when (not-empty doc) (str "\n\n  " doc)))
+        annotated-doc (str/trim
+                       (str "Inputs: " (if single
+                                         (pr-str (first (mapv :raw-arglist parglists)))
+                                         (str "(" (str/join "\n           " (map (comp pr-str :raw-arglist) parglists)) ")"))
+                            "\n  Return: " (str/replace (u/pprint-to-str (:schema return))
+                                                        "\n"
+                                                        (str "\n          "))
+                            (when (not-empty doc) (str "\n\n  " doc))))
         id (str (gensym "id"))]
     `(let [defn# (core/defn
                    ~name

--- a/src/metabase/util/malli.clj
+++ b/src/metabase/util/malli.clj
@@ -34,7 +34,7 @@
        :else url))))
 
 (core/defn- humanize-include-value
-  "Pass into mu/humanize to include the value recieved in the error message."
+  "Pass into mu/humanize to include the value received in the error message."
   [{:keys [value message]}] (str message ", received: " (pr-str value)))
 
 (core/defn- explain-fn-fail!

--- a/test/metabase/util/malli_test.clj
+++ b/test/metabase/util/malli_test.clj
@@ -9,8 +9,8 @@
 (deftest mu-defn-test
   (testing "invalid input"
     (mu/defn bar [x :- [:map [:x int?] [:y int?]]] (str x))
-    (is (= [{:x ["missing required key"]
-             :y ["missing required key"]}]
+    (is (= [{:x ["missing required key, received: nil"]
+             :y ["missing required key, received: nil"]}]
            (:humanized
             (try (bar {})
                  (catch Exception e (ex-data e)))))
@@ -19,8 +19,8 @@
 
   (testing "invalid output"
     (mu/defn baz :- [:map [:x int?] [:y int?]] [] {:x "3"})
-    (is (= {:x ["should be an int"]
-            :y ["missing required key"]}
+    (is (= {:x ["should be an int, received: \"3\""]
+            :y ["missing required key, received: nil"]}
            (:humanized
             (try (baz)
                  (catch Exception e (ex-data e)))))
@@ -40,6 +40,9 @@
 
         (is (= ["Special Number that has to be less than four"]
                (me/humanize (mc/explain special-lt-4-schema 8))))
+
+        (is (= ["Special Number that has to be less than four, received: 8"]
+               (me/humanize (mc/explain special-lt-4-schema 8) {:wrap #'mu/humanize-include-value})))
 
         (is (= "Special Number that has to be less than four"
                (umd/describe special-lt-4-schema)))))


### PR DESCRIPTION
mu/defn now prepends docstrings onto functions, the way prismatic schema does.

```
(mu/defn ^:private foo :- [:multi {:dispatch :type}
                               [:sized [:map [:type [:= :sized]]
                                        [:size int?]]]
                               [:human [:map
                                        [:type [:= :human]]
                                        [:name string?]
                                        [:address [:map [:street string?]]]]]]
      ([] {:type :sized :size 3})
      ([a :- :int] {:type :sized :size a})
      ([a :- :int b :- :int] {:type :sized :size (+ a b)})
      ([a b & c :- [:* :int]] {:type :human
                               :name "Jim"
                               :address {:street (str  (+ a b (apply + c)) " ln")}}))
```

docstring: https://github.com/metabase/metabase/pull/28042/files#diff-a7d821ed8b964b37cde01d71bbeb006ffde582fee2030e84be57a27166b46870R53-R60

cider doc output:

```
metabase.util.malli-test/foo
 []
 [a]
 [a b]
 [a b & c]
  Inputs: ([]
           [a :- :int]
           [a :- :int b :- :int]
           [a b & c :- [:* :int]])
  Return: [:multi
           {:dispatch :type}
           [:sized [:map [:type [:= :sized]] [:size int?]]]
           [:human [:map [:type [:= :human]] [:name string?] [:address [:map [:street string?]]]]]]
```