### PR TITLE
Remove api call check

### DIFF
--- a/frontend/test/metabase/scenarios/onboarding/auth/forgot_password.cy.spec.js
+++ b/frontend/test/metabase/scenarios/onboarding/auth/forgot_password.cy.spec.js
@@ -32,11 +32,9 @@ describe("scenarios > auth > password", { tags: "@external" }, () => {
 
   it("should not show the app bar when previously logged in", () => {
     cy.signInAsAdmin();
-    cy.intercept("GET", "/api/user/current").as("getUser");
 
     cy.visit("/auth/forgot_password");
 
-    cy.get("@getUser.all").should("have.length", 0);
     cy.icon("gear").should("not.exist");
   });
 });


### PR DESCRIPTION
As we haven't moved `ForgotPasswordApp` from the main route, it still calls the endpoint to fetch user data.