### PR TITLE
Make default values picker respect custom parameter source 

### DIFF
--- a/frontend/src/metabase/parameters/components/ParameterValueWidget.jsx
+++ b/frontend/src/metabase/parameters/components/ParameterValueWidget.jsx
@@ -307,17 +307,15 @@ function getWidgetDefinition(parameter) {
 }
 
 function isTextWidget(parameter) {
-  if (parameter.hasVariableTemplateTagTarget) {
-    return getQueryType(parameter) === "none";
-  } else {
-    return false;
-  }
+  const canQuery = getQueryType(parameter) !== "none";
+  return parameter.hasVariableTemplateTagTarget && !canQuery;
 }
 
 function isFieldWidget(parameter) {
-  if (parameter.hasVariableTemplateTagTarget) {
-    return getQueryType(parameter) !== "none";
-  } else {
-    return getFields(parameter).length > 0;
-  }
+  const canQuery = getQueryType(parameter) !== "none";
+  const hasFields = getFields(parameter).length > 0;
+
+  return parameter.hasVariableTemplateTagTarget
+    ? canQuery
+    : canQuery || hasFields;
 }

--- a/frontend/src/metabase/parameters/components/ParameterWidget.css
+++ b/frontend/src/metabase/parameters/components/ParameterWidget.css
@@ -71,11 +71,11 @@
 }
 
 :local(.parameter.noPopover.isEditing) input {
-  width: 138px;
+  width: 142px;
 }
 
 :local(.parameter.noPopover.selected) input {
-  width: 127px;
+  width: 142px;
   font-weight: bold;
   color: var(--color-brand);
 }
@@ -83,7 +83,7 @@
 :local(.parameter.noPopover) input:focus {
   outline: none;
   color: var(--color-text-dark);
-  width: 127px;
+  width: 142px;
 }
 :local(.parameter.noPopover) input::-webkit-input-placeholder {
   color: var(--color-text-medium);
@@ -155,5 +155,6 @@
   :local(.parameter.noPopover) input {
     /* NOTE: Fixed with to circumvent issues with flexbox with container having a min-width */
     width: 115px;
+    padding: 0;
   }
 }

--- a/frontend/src/metabase/parameters/components/ValuesSourceModal/ValuesSourceModal.tsx
+++ b/frontend/src/metabase/parameters/components/ValuesSourceModal/ValuesSourceModal.tsx
@@ -69,9 +69,11 @@ const ValuesSourceModal = ({
 };
 
 const getInitialSourceType = (parameter: ParameterWithTemplateTagTarget) => {
-  return parameter.hasVariableTemplateTagTarget
+  const sourceType = getSourceType(parameter);
+
+  return sourceType === null && parameter.hasVariableTemplateTagTarget
     ? "card"
-    : getSourceType(parameter);
+    : sourceType;
 };
 
 export default ValuesSourceModal;

--- a/frontend/src/metabase/parameters/components/ValuesSourceModal/ValuesSourceModal.unit.spec.tsx
+++ b/frontend/src/metabase/parameters/components/ValuesSourceModal/ValuesSourceModal.unit.spec.tsx
@@ -82,6 +82,17 @@ describe("ValuesSourceModal", () => {
         screen.getByRole("radio", { name: "From another model or question" }),
       ).toBeChecked();
     });
+
+    it("should preserve custom list option for variable template tags", () => {
+      setup({
+        parameter: createMockUiParameter({
+          values_source_type: "static-list",
+          hasVariableTemplateTagTarget: true,
+        }),
+      });
+
+      expect(screen.getByRole("radio", { name: "Custom list" })).toBeChecked();
+    });
   });
 
   describe("card source", () => {

--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx
@@ -315,7 +315,7 @@ export class TagEditorParam extends Component {
             <ContainerLabel>{t`Default filter widget value`}</ContainerLabel>
             <DefaultParameterValueWidget
               parameter={
-                tag.type === "dimension"
+                tag.type === "text" || tag.type === "dimension"
                   ? parameter || {
                       fields: [],
                       ...tag,

--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx
@@ -289,14 +289,6 @@ export class TagEditorParam extends Component {
           </InputContainer>
         )}
 
-        <InputContainer lessBottomPadding>
-          <ContainerLabel>{t`Required?`}</ContainerLabel>
-          <Toggle
-            value={tag.required}
-            onChange={value => this.setRequired(value)}
-          />
-        </InputContainer>
-
         {parameter && canUseCustomSource(parameter) && (
           <InputContainer>
             <ContainerLabel>{t`How should users filter on this variable?`}</ContainerLabel>
@@ -307,6 +299,14 @@ export class TagEditorParam extends Component {
             />
           </InputContainer>
         )}
+
+        <InputContainer lessBottomPadding>
+          <ContainerLabel>{t`Required?`}</ContainerLabel>
+          <Toggle
+            value={tag.required}
+            onChange={value => this.setRequired(value)}
+          />
+        </InputContainer>
 
         {((tag.type !== "dimension" && tag.required) ||
           tag.type === "dimension" ||

--- a/frontend/test/__support__/e2e/helpers/e2e-misc-helpers.js
+++ b/frontend/test/__support__/e2e/helpers/e2e-misc-helpers.js
@@ -247,6 +247,7 @@ export function saveQuestion(
 export function visitPublicQuestion(id) {
   cy.request("POST", `/api/card/${id}/public_link`).then(
     ({ body: { uuid } }) => {
+      cy.signOut();
       cy.visit(`/public/question/${uuid}`);
     },
   );
@@ -255,6 +256,7 @@ export function visitPublicQuestion(id) {
 export function visitPublicDashboard(id) {
   cy.request("POST", `/api/dashboard/${id}/public_link`).then(
     ({ body: { uuid } }) => {
+      cy.signOut();
       cy.visit(`/public/dashboard/${uuid}`);
     },
   );

--- a/frontend/test/metabase/scenarios/native-filters/sql-filters-source.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native-filters/sql-filters-source.cy.spec.js
@@ -12,6 +12,7 @@ import {
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 import * as SQLFilter from "./helpers/e2e-sql-filter-helpers";
 import * as FieldFilter from "./helpers/e2e-field-filter-helpers";
+import { toggleRequired } from "./helpers/e2e-sql-filter-helpers";
 
 const { PRODUCTS_ID, PRODUCTS } = SAMPLE_DATABASE;
 
@@ -63,6 +64,10 @@ describe("scenarios > filters > sql filters > values source", () => {
       checkFilterValueNotInList("Gizmo");
       FieldFilter.selectFilterValueFromList("Gadget");
       SQLFilter.runQuery("cardQuery");
+
+      toggleRequired();
+      FieldFilter.openEntryForm(true);
+      FieldFilter.selectFilterValueFromList("Gadget");
     });
 
     it("should be able to use a structured question source with a text tag", () => {
@@ -79,6 +84,10 @@ describe("scenarios > filters > sql filters > values source", () => {
       checkFilterValueNotInList("Gizmo");
       FieldFilter.selectFilterValueFromList("Gadget");
       SQLFilter.runQuery("cardQuery");
+
+      toggleRequired();
+      FieldFilter.openEntryForm(true);
+      FieldFilter.selectFilterValueFromList("Gadget");
     });
 
     it("should be able to use a structured question source without saving the question", () => {


### PR DESCRIPTION
Epic https://github.com/metabase/metabase/issues/26898

Changes:
- When choosing the default value for a text template tag, it will use your custom values config and show the dropdown with the list of values (there is a e2e test for this change)
- Fixes an issue where `sourceType` was ignored text tags (there is a unit test for the fix)
- Moves `Required` option at the bottom because the default value picker appears at the bottom, too
- Fixes an issue where the placeholder for the default parameter value was cut off

How to verify:
- New -> SQL Query -> `SELECT * FROM PRODUCTS WHERE CATEGORY = {{category}}`
- How should users filter on this variable? -> Dropdown list -> Custom list -> Enter some values -> Done
- Required -> Enter default value
- You should see the dropdown with your values

<img width="363" alt="Screenshot 2023-02-03 at 15 18 04" src="https://user-images.githubusercontent.com/8542534/216613912-6e1c9bd7-d09e-4882-99c5-3c765c925392.png">

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/28054)
<!-- Reviewable:end -->
