### PR TITLE
Fix model detail page's tab colors

### DIFF
--- a/frontend/src/metabase/core/components/Tab/Tab.styled.tsx
+++ b/frontend/src/metabase/core/components/Tab/Tab.styled.tsx
@@ -14,7 +14,7 @@ export const TabRoot = styled.button<TabProps>`
   flex: 1;
   text-align: left;
 
-  color: ${props => (props.isSelected ? color("brand") : color("text-light"))};
+  color: ${props => (props.isSelected ? color("brand") : color("text-dark"))};
   background-color: ${props =>
     props.isSelected ? alpha("brand", 0.1) : "transparent"};
   cursor: pointer;

--- a/frontend/src/metabase/core/components/TabLink/TabLink.styled.tsx
+++ b/frontend/src/metabase/core/components/TabLink/TabLink.styled.tsx
@@ -16,7 +16,7 @@ export const TabLabel = styled.div`
 export const TabLinkRoot = styled(Link)<TabLinkProps>`
   padding: 1rem 0;
 
-  color: ${props => (props.isSelected ? color("brand") : color("text-medium"))};
+  color: ${props => (props.isSelected ? color("brand") : color("text-dark"))};
   font-size: 0.875rem;
   font-weight: 700;
 


### PR DESCRIPTION
Epic #27581

Fixes a visual regression on the model detail page introduced in #27959. Tab colors should be `text-dark`, but they became `text-medium` after we switched the tab components.

### Demo

**Before**
![tab-colors-before](https://user-images.githubusercontent.com/17258145/216638721-9e57b014-436e-43f9-a258-3f6ad48fd764.png)

**After**
![tab-colors-after](https://user-images.githubusercontent.com/17258145/216638776-346f607b-00b6-4925-9f0c-2ad805d39d82.png)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/28056)
<!-- Reviewable:end -->
