### PR TITLE
Highlight model's collection on model detail page

### DIFF
--- a/frontend/src/metabase-types/store/entities.ts
+++ b/frontend/src/metabase-types/store/entities.ts
@@ -1,6 +1,10 @@
 import {
+  Card,
+  CardId,
   Collection,
   CollectionId,
+  Dashboard,
+  DashboardId,
   Database,
   Field,
   FieldId,
@@ -16,9 +20,11 @@ import {
 export interface EntitiesState {
   actions?: Record<WritebackActionId, WritebackAction>;
   collections?: Record<CollectionId, Collection>;
+  dashboards?: Record<DashboardId, Dashboard>;
   databases?: Record<number, Database>;
   fields?: Record<FieldId, Field>;
   tables?: Record<number | string, Table>;
   snippets?: Record<NativeQuerySnippetId, NativeQuerySnippet>;
   users?: Record<UserId, User>;
+  questions?: Record<CardId, Card>;
 }

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbar.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbar.tsx
@@ -87,7 +87,12 @@ function MainNavbar({
   );
 
   return (
-    <Sidebar className="Nav" isOpen={isOpen} aria-hidden={!isOpen}>
+    <Sidebar
+      className="Nav"
+      isOpen={isOpen}
+      aria-hidden={!isOpen}
+      data-testid="main-navbar-root"
+    >
       <NavRoot isOpen={isOpen}>
         <MainNavbarContainer
           isOpen={isOpen}

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbar.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbar.tsx
@@ -22,7 +22,7 @@ import {
   MainNavbarDispatchProps,
   SelectedItem,
 } from "./types";
-import getSelectedItems, { isModelDetailPathname } from "./getSelectedItems";
+import getSelectedItems, { isModelDetailPath } from "./getSelectedItems";
 import { NavRoot, Sidebar } from "./MainNavbar.styled";
 
 interface StateProps {
@@ -45,7 +45,7 @@ function mapStateToProps(
   state: State,
   { location, params }: MainNavbarOwnProps,
 ) {
-  const isModelDetailPage = isModelDetailPathname(location.pathname);
+  const isModelDetailPage = isModelDetailPath(location.pathname);
   return {
     card: isModelDetailPage
       ? getModelDetailPageCard(state, params)

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbar.unit.spec.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbar.unit.spec.tsx
@@ -10,7 +10,6 @@ import {
 import {
   setupCardsEndpoints,
   setupCollectionsEndpoints,
-  setupDashboardsEndpoints,
   setupDatabasesEndpoints,
 } from "__support__/server-mocks";
 
@@ -28,6 +27,7 @@ import {
 import {
   createMockState,
   createMockDashboardState,
+  createMockEntitiesState,
   createMockQueryBuilderState,
 } from "metabase-types/store/mocks";
 
@@ -107,9 +107,6 @@ async function setup({
   if (openQuestionCard) {
     setupCardsEndpoints(scope, [openQuestionCard]);
   }
-  if (openDashboard) {
-    setupDashboardsEndpoints(scope, [openDashboard]);
-  }
 
   const dashboards = openDashboard ? { [openDashboard.id]: openDashboard } : {};
   const dashboardId = openDashboard ? openDashboard.id : null;
@@ -117,6 +114,7 @@ async function setup({
     currentUser: user,
     dashboard: createMockDashboardState({ dashboardId, dashboards }),
     qb: createMockQueryBuilderState({ card: openQuestionCard }),
+    entities: createMockEntitiesState({ dashboards }),
   });
 
   renderWithProviders(

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbar.unit.spec.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbar.unit.spec.tsx
@@ -1,0 +1,413 @@
+import React from "react";
+import nock from "nock";
+import { Route } from "react-router";
+
+import {
+  renderWithProviders,
+  screen,
+  waitForElementToBeRemoved,
+} from "__support__/ui";
+import {
+  setupCollectionsEndpoints,
+  setupDatabasesEndpoints,
+} from "__support__/server-mocks";
+
+import * as Urls from "metabase/lib/urls";
+import { ROOT_COLLECTION } from "metabase/entities/collections";
+
+import type { Card, Dashboard, User } from "metabase-types/api";
+import {
+  createMockCard,
+  createMockCollection,
+  createMockDatabase,
+  createMockDashboard,
+  createMockUser,
+} from "metabase-types/api/mocks";
+import {
+  createMockState,
+  createMockDashboardState,
+  createMockEntitiesState,
+  createMockQueryBuilderState,
+} from "metabase-types/store/mocks";
+
+import MainNavbar from "./MainNavbar";
+
+type SetupOpts = {
+  pathname?: string;
+  route?: string;
+  user?: User | null;
+  hasDataAccess?: boolean;
+  hasOwnDatabase?: boolean;
+  openQuestionCard?: Card;
+  openDashboard?: Dashboard;
+};
+
+const PERSONAL_COLLECTION_BASE = createMockCollection({
+  id: 1,
+  name: "'Your personal collection",
+  originalName: "John's Personal Collection",
+});
+
+const TEST_COLLECTION = createMockCollection({
+  id: 2,
+  name: "Test collection",
+});
+
+const SAMPLE_DATABASE = createMockDatabase({
+  id: 1,
+  name: "Sample Database",
+  is_sample: true,
+});
+
+const USER_DATABASE = createMockDatabase({
+  id: 2,
+  name: "User Database",
+  is_sample: false,
+});
+
+function getInitialState({
+  card,
+  dashboard,
+  user,
+}: {
+  card?: Card;
+  dashboard?: Dashboard;
+  user?: User | null;
+} = {}) {
+  const cards = card ? { [card.id]: card } : {};
+  const dashboards = dashboard ? { [dashboard.id]: dashboard } : {};
+
+  return createMockState({
+    currentUser: user,
+    dashboard: createMockDashboardState({
+      dashboardId: dashboard ? dashboard.id : null,
+      dashboards,
+    }),
+    qb: createMockQueryBuilderState({ card }),
+    entities: createMockEntitiesState({
+      dashboards,
+      questions: cards,
+    }),
+  });
+}
+
+async function setup({
+  pathname = "/",
+  route = pathname,
+  user = createMockUser(),
+  hasDataAccess = true,
+  hasOwnDatabase = true,
+  openDashboard,
+  openQuestionCard,
+}: SetupOpts = {}) {
+  const scope = nock(location.origin);
+
+  const databases = [];
+  const collections = [TEST_COLLECTION];
+
+  if (hasDataAccess) {
+    databases.push(SAMPLE_DATABASE);
+
+    if (hasOwnDatabase) {
+      databases.push(USER_DATABASE);
+    }
+  }
+
+  const personalCollection = user
+    ? createMockCollection({
+        ...PERSONAL_COLLECTION_BASE,
+        personal_owner_id: user.id,
+      })
+    : null;
+
+  if (personalCollection && user) {
+    user.personal_collection_id = 1;
+    collections.push(personalCollection);
+  }
+
+  setupCollectionsEndpoints(scope, collections);
+  setupDatabasesEndpoints(scope, databases);
+  scope.get("/api/bookmark").reply(200, []);
+
+  const storeInitialState = getInitialState({
+    card: openQuestionCard,
+    dashboard: openDashboard,
+    user,
+  });
+
+  renderWithProviders(
+    <Route
+      path={route}
+      component={props => <MainNavbar {...props} isOpen />}
+    />,
+    {
+      storeInitialState,
+      initialRoute: pathname,
+      withRouter: true,
+      withDND: true,
+    },
+  );
+
+  await waitForElementToBeRemoved(() =>
+    screen.queryAllByTestId("loading-spinner"),
+  );
+}
+
+async function setupCollectionPage({
+  pathname = "/",
+  route = "/collection/:slug",
+}: Pick<SetupOpts, "pathname" | "route"> = {}) {
+  await setup({ pathname, route });
+
+  const rootCollectionElements = {
+    link: screen.getByRole("link", { name: /Our analytics/i }),
+    listItem: screen.getByRole("treeitem", { name: /Our analytics/i }),
+  };
+
+  const personalCollectionElements = {
+    link: screen.getByRole("link", { name: /Your personal collection/i }),
+    listItem: screen.getByRole("treeitem", {
+      name: /Your personal collection/i,
+    }),
+  };
+
+  const regularCollectionElements = {
+    link: screen.getByRole("link", { name: /Test collection/i }),
+    listItem: screen.getByRole("treeitem", { name: /Test collection/i }),
+  };
+
+  return {
+    rootCollectionElements,
+    personalCollectionElements,
+    regularCollectionElements,
+  };
+}
+
+describe("nav > containers > MainNavbar", () => {
+  describe("homepage link", () => {
+    it("should render", async () => {
+      await setup();
+      const link = screen.getByRole("link", { name: /Home/i });
+      expect(link).toBeInTheDocument();
+      expect(link).toHaveAttribute("href", "/");
+    });
+
+    it("should be highlighted if selected", async () => {
+      await setup({ pathname: "/" });
+      const link = screen.getByRole("listitem", { name: /Home/i });
+      expect(link).toHaveAttribute("aria-selected", "true");
+    });
+  });
+
+  describe("browse data link", () => {
+    it("should render", async () => {
+      await setup();
+      const link = screen.getByRole("link", { name: /Browse data/i });
+      expect(link).toBeInTheDocument();
+      expect(link).toHaveAttribute("href", "/browse");
+    });
+
+    it("should not render when a user has no data access", async () => {
+      await setup({ hasDataAccess: false });
+      expect(
+        screen.queryByRole("link", { name: /Browse data/i }),
+      ).not.toBeInTheDocument();
+    });
+
+    it("should be highlighted if selected", async () => {
+      await setup({ pathname: "/browse" });
+      const link = screen.getByRole("listitem", { name: /Browse data/i });
+      expect(link).toHaveAttribute("aria-selected", "true");
+    });
+
+    it("should be highlighted if child route selected", async () => {
+      await setup({ pathname: "/browse/1" });
+      const link = screen.getByRole("listitem", { name: /Browse data/i });
+      expect(link).toHaveAttribute("aria-selected", "true");
+    });
+  });
+
+  describe("setup database link", () => {
+    it("should render when there are no databases connected", async () => {
+      await setup({
+        hasOwnDatabase: false,
+        user: createMockUser({ is_superuser: true }),
+      });
+      const link = screen.getByRole("link", { name: /Add your own data/i });
+      expect(link).toBeInTheDocument();
+      expect(link).toHaveAttribute("href", "/admin/databases/create");
+    });
+
+    it("should not render when there is a database connected", async () => {
+      await setup({
+        hasOwnDatabase: true,
+        user: createMockUser({ is_superuser: true }),
+      });
+      expect(
+        screen.queryByRole("link", { name: /Add your own data/i }),
+      ).not.toBeInTheDocument();
+    });
+
+    it("should not render to non-admin users", async () => {
+      await setup({
+        hasOwnDatabase: false,
+        user: createMockUser({ is_superuser: false }),
+      });
+      expect(
+        screen.queryByRole("link", { name: /Add your own data/i }),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe("collection tree", () => {
+    it("should show collections", async () => {
+      const {
+        rootCollectionElements,
+        personalCollectionElements,
+        regularCollectionElements,
+      } = await setupCollectionPage({ pathname: "/", route: "/" });
+
+      expect(rootCollectionElements.link).toBeInTheDocument();
+      expect(rootCollectionElements.link).toHaveAttribute(
+        "href",
+        Urls.collection(ROOT_COLLECTION),
+      );
+      expect(personalCollectionElements.link).toBeInTheDocument();
+      expect(personalCollectionElements.link).toHaveAttribute(
+        "href",
+        Urls.collection(PERSONAL_COLLECTION_BASE),
+      );
+      expect(regularCollectionElements.link).toBeInTheDocument();
+      expect(regularCollectionElements.link).toHaveAttribute(
+        "href",
+        Urls.collection(TEST_COLLECTION),
+      );
+    });
+
+    it("should not highlight collections when not selected", async () => {
+      const {
+        rootCollectionElements,
+        personalCollectionElements,
+        regularCollectionElements,
+      } = await setupCollectionPage({ pathname: "/", route: "/" });
+
+      expect(rootCollectionElements.listItem).toHaveAttribute(
+        "aria-selected",
+        "false",
+      );
+      expect(personalCollectionElements.listItem).toHaveAttribute(
+        "aria-selected",
+        "false",
+      );
+      expect(regularCollectionElements.listItem).toHaveAttribute(
+        "aria-selected",
+        "false",
+      );
+    });
+
+    it("should highlight regular collection if selected", async () => {
+      const {
+        rootCollectionElements,
+        personalCollectionElements,
+        regularCollectionElements,
+      } = await setupCollectionPage({
+        pathname: Urls.collection(TEST_COLLECTION),
+      });
+
+      expect(regularCollectionElements.listItem).toHaveAttribute(
+        "aria-selected",
+        "true",
+      );
+      expect(rootCollectionElements.listItem).toHaveAttribute(
+        "aria-selected",
+        "false",
+      );
+      expect(personalCollectionElements.listItem).toHaveAttribute(
+        "aria-selected",
+        "false",
+      );
+    });
+
+    it("should highlight root if selected", async () => {
+      const {
+        rootCollectionElements,
+        personalCollectionElements,
+        regularCollectionElements,
+      } = await setupCollectionPage({
+        pathname: Urls.collection(ROOT_COLLECTION),
+      });
+
+      expect(rootCollectionElements.listItem).toHaveAttribute(
+        "aria-selected",
+        "true",
+      );
+      expect(regularCollectionElements.listItem).toHaveAttribute(
+        "aria-selected",
+        "false",
+      );
+      expect(personalCollectionElements.listItem).toHaveAttribute(
+        "aria-selected",
+        "false",
+      );
+    });
+
+    it("should highlight personal collection if selected", async () => {
+      const {
+        rootCollectionElements,
+        personalCollectionElements,
+        regularCollectionElements,
+      } = await setupCollectionPage({
+        pathname: Urls.collection(PERSONAL_COLLECTION_BASE),
+      });
+
+      expect(personalCollectionElements.listItem).toHaveAttribute(
+        "aria-selected",
+        "true",
+      );
+      expect(rootCollectionElements.listItem).toHaveAttribute(
+        "aria-selected",
+        "false",
+      );
+      expect(regularCollectionElements.listItem).toHaveAttribute(
+        "aria-selected",
+        "false",
+      );
+    });
+
+    it("should highlight question's collection if selected", async () => {
+      const card = createMockCard({
+        collection_id: TEST_COLLECTION.id as number,
+      });
+      await setup({
+        openQuestionCard: card,
+        route: "/question/:slug",
+        pathname: `/question/${card.id}`,
+      });
+
+      expect(
+        screen.getByRole("treeitem", { name: /Test collection/i }),
+      ).toHaveAttribute("aria-selected", "true");
+      expect(
+        screen.getByRole("treeitem", { name: /Our analytics/i }),
+      ).toHaveAttribute("aria-selected", "false");
+    });
+
+    it("should highlight dashboard's collection if selected", async () => {
+      const dashboard = createMockDashboard({
+        collection_id: TEST_COLLECTION.id as number,
+      });
+      await setup({
+        openDashboard: dashboard,
+        route: "/dashboard/:slug",
+        pathname: `/dashboard/${dashboard.id}`,
+      });
+
+      expect(
+        screen.getByRole("treeitem", { name: /Test collection/i }),
+      ).toHaveAttribute("aria-selected", "true");
+      expect(
+        screen.getByRole("treeitem", { name: /Our analytics/i }),
+      ).toHaveAttribute("aria-selected", "false");
+    });
+  });
+});

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbar.unit.spec.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbar.unit.spec.tsx
@@ -409,5 +409,24 @@ describe("nav > containers > MainNavbar", () => {
         screen.getByRole("treeitem", { name: /Our analytics/i }),
       ).toHaveAttribute("aria-selected", "false");
     });
+
+    it("should highlight model's collection when on model detail page", async () => {
+      const model = createMockCard({
+        collection_id: TEST_COLLECTION.id as number,
+        dataset: true,
+      });
+      await setup({
+        route: "/model/:slug/detail",
+        pathname: `/model/${model.id}/detail`,
+        openQuestionCard: model,
+      });
+
+      expect(
+        screen.getByRole("treeitem", { name: /Test collection/i }),
+      ).toHaveAttribute("aria-selected", "true");
+      expect(
+        screen.getByRole("treeitem", { name: /Our analytics/i }),
+      ).toHaveAttribute("aria-selected", "false");
+    });
   });
 });

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/MainNavbarContainer.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/MainNavbarContainer.tsx
@@ -17,6 +17,7 @@ import Collections, {
   ROOT_COLLECTION,
   CollectionTreeItem,
 } from "metabase/entities/collections";
+import Databases from "metabase/entities/databases";
 import { logout } from "metabase/auth/actions";
 import { getUser, getUserIsAdmin } from "metabase/selectors/user";
 import { getHasDataAccess, getHasOwnDatabase } from "metabase/selectors/data";
@@ -185,6 +186,9 @@ export default _.compose(
   }),
   Collections.loadList({
     query: () => ({ tree: true, "exclude-archived": true }),
+    loadingAndErrorWrapper: false,
+  }),
+  Databases.loadList({
     loadingAndErrorWrapper: false,
   }),
   connect(mapStateToProps, mapDispatchToProps),

--- a/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarLink.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarLink.tsx
@@ -82,6 +82,8 @@ function SidebarLink({
       depth={0}
       isSelected={isSelected}
       hasDefaultIconStyle={hasDefaultIconStyle}
+      aria-label={children}
+      aria-selected={isSelected}
       onMouseDown={disableImageDragging}
       {...props}
     >

--- a/frontend/src/metabase/nav/containers/MainNavbar/getSelectedItems.ts
+++ b/frontend/src/metabase/nav/containers/MainNavbar/getSelectedItems.ts
@@ -2,7 +2,7 @@ import * as Urls from "metabase/lib/urls";
 
 import { coerceCollectionId } from "metabase/collections/utils";
 
-import type { Dashboard } from "metabase-types/api";
+import type { Card, Dashboard } from "metabase-types/api";
 import type Question from "metabase-lib/Question";
 
 import { SelectedItem } from "./types";
@@ -13,14 +13,20 @@ type Opts = {
     slug?: string;
     pageId?: string;
   };
-  question?: Question;
+  card?: Card;
   dashboard?: Dashboard;
 };
+
+const MODEL_DETAIL_PAGE_PATTERN = /\/model\/.*\/detail.*/;
+
+export function isModelDetailPathname(pathname: string): boolean {
+  return MODEL_DETAIL_PAGE_PATTERN.test(pathname);
+}
 
 function getSelectedItems({
   pathname,
   params,
-  question,
+  card,
   dashboard,
 }: Opts): SelectedItem[] {
   const { slug } = params;
@@ -29,7 +35,7 @@ function getSelectedItems({
   const isUsersCollectionPath = pathname.startsWith("/collection/users");
   const isQuestionPath = pathname.startsWith("/question");
   const isModelPath = pathname.startsWith("/model");
-  const isModelDetailPath = isModelPath && pathname.endsWith("/detail");
+  const isModelDetailPath = isModelDetailPathname(pathname);
   const isDashboardPath = pathname.startsWith("/dashboard");
 
   if (isCollectionPath) {
@@ -52,14 +58,14 @@ function getSelectedItems({
       },
     ];
   }
-  if ((isQuestionPath || isModelPath) && question) {
+  if ((isQuestionPath || isModelPath) && card) {
     return [
       {
-        id: question.id(),
+        id: card.id,
         type: "card",
       },
       {
-        id: coerceCollectionId(question.collectionId()),
+        id: coerceCollectionId(card.collection_id),
         type: "collection",
       },
     ];

--- a/frontend/src/metabase/nav/containers/MainNavbar/getSelectedItems.ts
+++ b/frontend/src/metabase/nav/containers/MainNavbar/getSelectedItems.ts
@@ -16,8 +16,6 @@ type Opts = {
   dashboard?: Dashboard;
 };
 
-const MODEL_DETAIL_PAGE_PATTERN = /\/model\/.*\/detail.*/;
-
 function isCollectionPath(pathname: string): boolean {
   return pathname.startsWith("/collection");
 }
@@ -26,19 +24,15 @@ function isUsersCollectionPath(pathname: string): boolean {
   return pathname.startsWith("/collection/users");
 }
 
-function isQuestionPath(pathname: string): boolean {
+export function isQuestionPath(pathname: string): boolean {
   return pathname.startsWith("/question");
 }
 
-function isModelPath(pathname: string): boolean {
+export function isModelPath(pathname: string): boolean {
   return pathname.startsWith("/model");
 }
 
-export function isModelDetailPath(pathname: string): boolean {
-  return MODEL_DETAIL_PAGE_PATTERN.test(pathname);
-}
-
-function isDashboardPath(pathname: string): boolean {
+export function isDashboardPath(pathname: string): boolean {
   return pathname.startsWith("/dashboard");
 }
 
@@ -81,14 +75,6 @@ function getSelectedItems({
       {
         id: coerceCollectionId(card.collection_id),
         type: "collection",
-      },
-    ];
-  }
-  if (isModelDetailPath(pathname)) {
-    return [
-      {
-        id: Urls.extractEntityId(slug),
-        type: "card",
       },
     ];
   }

--- a/frontend/src/metabase/nav/containers/MainNavbar/getSelectedItems.ts
+++ b/frontend/src/metabase/nav/containers/MainNavbar/getSelectedItems.ts
@@ -3,7 +3,6 @@ import * as Urls from "metabase/lib/urls";
 import { coerceCollectionId } from "metabase/collections/utils";
 
 import type { Card, Dashboard } from "metabase-types/api";
-import type Question from "metabase-lib/Question";
 
 import { SelectedItem } from "./types";
 
@@ -19,8 +18,28 @@ type Opts = {
 
 const MODEL_DETAIL_PAGE_PATTERN = /\/model\/.*\/detail.*/;
 
-export function isModelDetailPathname(pathname: string): boolean {
+function isCollectionPath(pathname: string): boolean {
+  return pathname.startsWith("/collection");
+}
+
+function isUsersCollectionPath(pathname: string): boolean {
+  return pathname.startsWith("/collection/users");
+}
+
+function isQuestionPath(pathname: string): boolean {
+  return pathname.startsWith("/question");
+}
+
+function isModelPath(pathname: string): boolean {
+  return pathname.startsWith("/model");
+}
+
+export function isModelDetailPath(pathname: string): boolean {
   return MODEL_DETAIL_PAGE_PATTERN.test(pathname);
+}
+
+function isDashboardPath(pathname: string): boolean {
+  return pathname.startsWith("/dashboard");
 }
 
 function getSelectedItems({
@@ -31,22 +50,17 @@ function getSelectedItems({
 }: Opts): SelectedItem[] {
   const { slug } = params;
 
-  const isCollectionPath = pathname.startsWith("/collection");
-  const isUsersCollectionPath = pathname.startsWith("/collection/users");
-  const isQuestionPath = pathname.startsWith("/question");
-  const isModelPath = pathname.startsWith("/model");
-  const isModelDetailPath = isModelDetailPathname(pathname);
-  const isDashboardPath = pathname.startsWith("/dashboard");
-
-  if (isCollectionPath) {
+  if (isCollectionPath(pathname)) {
     return [
       {
-        id: isUsersCollectionPath ? "users" : Urls.extractCollectionId(slug),
+        id: isUsersCollectionPath(pathname)
+          ? "users"
+          : Urls.extractCollectionId(slug),
         type: "collection",
       },
     ];
   }
-  if (isDashboardPath && dashboard) {
+  if (isDashboardPath(pathname) && dashboard) {
     return [
       {
         id: dashboard.id,
@@ -58,7 +72,7 @@ function getSelectedItems({
       },
     ];
   }
-  if ((isQuestionPath || isModelPath) && card) {
+  if ((isQuestionPath(pathname) || isModelPath(pathname)) && card) {
     return [
       {
         id: card.id,
@@ -70,7 +84,7 @@ function getSelectedItems({
       },
     ];
   }
-  if (isModelDetailPath) {
+  if (isModelDetailPath(pathname)) {
     return [
       {
         id: Urls.extractEntityId(slug),

--- a/frontend/src/metabase/nav/containers/MainNavbar/getSelectedItems.ts
+++ b/frontend/src/metabase/nav/containers/MainNavbar/getSelectedItems.ts
@@ -32,7 +32,7 @@ export function isModelPath(pathname: string): boolean {
   return pathname.startsWith("/model");
 }
 
-export function isDashboardPath(pathname: string): boolean {
+function isDashboardPath(pathname: string): boolean {
   return pathname.startsWith("/dashboard");
 }
 

--- a/frontend/src/metabase/nav/containers/Navbar.unit.spec.tsx
+++ b/frontend/src/metabase/nav/containers/Navbar.unit.spec.tsx
@@ -1,0 +1,89 @@
+import React from "react";
+import { Route } from "react-router";
+import nock from "nock";
+
+import {
+  renderWithProviders,
+  screen,
+  waitForElementToBeRemoved,
+} from "__support__/ui";
+import {
+  setupCollectionsEndpoints,
+  setupDatabasesEndpoints,
+} from "__support__/server-mocks";
+
+import type { User } from "metabase-types/api";
+import { createMockDatabase, createMockUser } from "metabase-types/api/mocks";
+import {
+  createMockAppState,
+  createMockState,
+} from "metabase-types/store/mocks";
+
+import Navbar from "./Navbar";
+
+type SetupOpts = {
+  isOpen?: boolean;
+  route?: string;
+  pathname?: string;
+  user?: User | null;
+};
+
+async function setup({
+  isOpen = true,
+  pathname = "/",
+  route = pathname,
+  user = createMockUser(),
+}: SetupOpts = {}) {
+  const scope = nock(location.origin);
+  const hasContentToFetch = !!user;
+  const isAdminApp = pathname.startsWith("/admin");
+
+  if (hasContentToFetch) {
+    setupCollectionsEndpoints(scope, []);
+    setupDatabasesEndpoints(scope, [createMockDatabase()]);
+    scope.get("/api/bookmark").reply(200, []);
+  }
+
+  const storeInitialState = createMockState({
+    app: createMockAppState({ isNavbarOpen: isOpen }),
+    currentUser: user,
+  });
+
+  renderWithProviders(<Route path={route} component={Navbar} />, {
+    storeInitialState,
+    initialRoute: pathname,
+    withRouter: true,
+    withDND: true,
+  });
+
+  // Admin navbar component doesn't have a loading state
+  if (hasContentToFetch && !isAdminApp) {
+    await waitForElementToBeRemoved(() =>
+      screen.queryAllByTestId("loading-spinner"),
+    );
+  }
+}
+
+describe("nav > containers > Navbar > Core App", () => {
+  it("should be open when isOpen is true", async () => {
+    await setup({ isOpen: true });
+    const navbar = screen.getByTestId("main-navbar-root");
+    expect(navbar).toHaveAttribute("aria-hidden", "false");
+  });
+
+  it("should be hidden when isOpen is false", async () => {
+    await setup({ isOpen: false });
+    const navbar = screen.getByTestId("main-navbar-root");
+    expect(navbar).toHaveAttribute("aria-hidden", "true");
+  });
+
+  it("should not render when signed out", async () => {
+    await setup({ user: null });
+    expect(screen.queryByTestId("main-navbar-root")).not.toBeInTheDocument();
+  });
+
+  it("should not render when in the admin app", async () => {
+    await setup({ pathname: "/admin/" });
+    expect(screen.queryByTestId("main-navbar-root")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/test/__support__/server-mocks/collection.ts
+++ b/frontend/test/__support__/server-mocks/collection.ts
@@ -14,6 +14,10 @@ export function setupCollectionsEndpoints(
 ) {
   scope.get("/api/collection").reply(200, collections);
   scope.get("/api/collection/tree?tree=true").reply(200, collections);
+  scope.get("/api/collection/tree?tree=true&exclude-archived=true").reply(
+    200,
+    collections.filter(collection => !collection.archived),
+  );
   scope.get("/api/collection/root").reply(200, ROOT_COLLECTION);
 }
 

--- a/frontend/test/__support__/server-mocks/dashboard.ts
+++ b/frontend/test/__support__/server-mocks/dashboard.ts
@@ -1,0 +1,18 @@
+import { Scope } from "nock";
+import { Dashboard } from "metabase-types/api";
+import { createMockDashboard } from "metabase-types/api/mocks";
+
+export function setupDashboardEndpoints(scope: Scope, dashboard: Dashboard) {
+  scope.get(`/api/dashboard/${dashboard.id}`).reply(200, dashboard);
+  scope
+    .put(`/api/dashboard/${dashboard.id}`)
+    .reply(200, (uri, body) => createMockDashboard(body as Dashboard));
+}
+
+export function setupDashboardsEndpoints(
+  scope: Scope,
+  dashboards: Dashboard[],
+) {
+  scope.get("/api/dashboard").reply(200, dashboards);
+  dashboards.forEach(dashboard => setupDashboardEndpoints(scope, dashboard));
+}

--- a/frontend/test/__support__/server-mocks/index.ts
+++ b/frontend/test/__support__/server-mocks/index.ts
@@ -1,6 +1,7 @@
 export * from "./action";
 export * from "./card";
 export * from "./collection";
+export * from "./dashboard";
 export * from "./database";
 export * from "./dataset";
 export * from "./field";


### PR DESCRIPTION
Epic #27581

Highlights model's collection in the navigation sidebar. Also adds unit test coverage to the `Navbar` and `MainNavbar` components to ensure selected items are highlighted.

### To Verify

1. Open `/model/:id/detail`
2. Ensure the model's collection is highlighted in the sidebar
3. Repeat against Our analytics, personal collection, and regular collection

### Demo

**Before**
![sidebar-highlighting-before](https://user-images.githubusercontent.com/17258145/216639301-34fff183-f172-421a-8e4a-03f8ddcdc1ea.png)

**After**

![sidebar-highlighting-after](https://user-images.githubusercontent.com/17258145/216639424-40d4315a-00e7-434a-b41c-a07002a39a4a.png)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/28057)
<!-- Reviewable:end -->
