### PR TITLE
Add e2e tests for parameter values with sandboxed users

### DIFF
--- a/frontend/src/metabase/parameters/components/ParameterValueWidget.jsx
+++ b/frontend/src/metabase/parameters/components/ParameterValueWidget.jsx
@@ -307,17 +307,15 @@ function getWidgetDefinition(parameter) {
 }
 
 function isTextWidget(parameter) {
-  if (parameter.hasVariableTemplateTagTarget) {
-    return getQueryType(parameter) === "none";
-  } else {
-    return false;
-  }
+  const canQuery = getQueryType(parameter) !== "none";
+  return parameter.hasVariableTemplateTagTarget && !canQuery;
 }
 
 function isFieldWidget(parameter) {
-  if (parameter.hasVariableTemplateTagTarget) {
-    return getQueryType(parameter) !== "none";
-  } else {
-    return getFields(parameter).length > 0;
-  }
+  const canQuery = getQueryType(parameter) !== "none";
+  const hasFields = getFields(parameter).length > 0;
+
+  return parameter.hasVariableTemplateTagTarget
+    ? canQuery
+    : canQuery || hasFields;
 }

--- a/frontend/src/metabase/parameters/components/ParameterValueWidget.jsx
+++ b/frontend/src/metabase/parameters/components/ParameterValueWidget.jsx
@@ -307,15 +307,17 @@ function getWidgetDefinition(parameter) {
 }
 
 function isTextWidget(parameter) {
-  const canQuery = getQueryType(parameter) !== "none";
-  return parameter.hasVariableTemplateTagTarget && !canQuery;
+  if (parameter.hasVariableTemplateTagTarget) {
+    return getQueryType(parameter) === "none";
+  } else {
+    return false;
+  }
 }
 
 function isFieldWidget(parameter) {
-  const canQuery = getQueryType(parameter) !== "none";
-  const hasFields = getFields(parameter).length > 0;
-
-  return parameter.hasVariableTemplateTagTarget
-    ? canQuery
-    : canQuery || hasFields;
+  if (parameter.hasVariableTemplateTagTarget) {
+    return getQueryType(parameter) !== "none";
+  } else {
+    return getFields(parameter).length > 0;
+  }
 }

--- a/frontend/test/metabase/scenarios/dashboard-filters/dashboard-filters-source.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters/dashboard-filters-source.cy.spec.js
@@ -23,14 +23,14 @@ const structuredSourceQuestion = {
     "source-table": PRODUCTS_ID,
     aggregation: [["count"]],
     breakout: [["field", PRODUCTS.CATEGORY, null]],
-    filter: ["!=", ["field", PRODUCTS.CATEGORY, null], "Gizmo"],
+    filter: ["!=", ["field", PRODUCTS.CATEGORY, null], "Doohickey"],
   },
 };
 
 const nativeSourceQuestion = {
   name: "SQL source",
   native: {
-    query: "select distinct CATEGORY from PRODUCTS order by CATEGORY limit 2",
+    query: "select CATEGORY from PRODUCTS WHERE CATEGORY != 'Doohickey'",
   },
 };
 
@@ -174,7 +174,7 @@ describe("scenarios > dashboard > filters", () => {
       editDashboard();
       setFilter("Text or Category", "Is");
       mapFilterToQuestion();
-      setFilterListSource({ values: ["Doohickey", "Gadget"] });
+      setFilterListSource({ values: ["Gadget", "Gizmo", "Widget"] });
       saveDashboard();
       filterDashboard();
     });
@@ -205,7 +205,7 @@ describe("scenarios > dashboard > filters", () => {
   });
 });
 
-describeEE.only("scenarios > dashboard > filters", () => {
+describeEE("scenarios > dashboard > filters", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();
@@ -246,17 +246,17 @@ const filterDashboard = ({ isSandboxed } = {}) => {
   cy.findByText("Text").click();
 
   popover().within(() => {
-    cy.findByText("Gadget").should("be.visible");
-    cy.findByText("Gizmo").should("not.exist");
+    cy.findByText("Gizmo").should("be.visible");
+    cy.findByText("Doohickey").should("not.exist");
+    cy.findByText("Gadget").should(isSandboxed ? "not.exist" : "be.visible");
     cy.findByText("Widget").should(isSandboxed ? "not.exist" : "be.visible");
-    cy.findByText("Doohickey").should(isSandboxed ? "not.exist" : "be.visible");
 
-    cy.findByPlaceholderText("Search the list").type("et");
+    cy.findByPlaceholderText("Search the list").type("i");
+    cy.findByText("Gadget").should("not.exist");
     cy.findByText("Widget").should(isSandboxed ? "not.exist" : "be.visible");
     cy.findByText("Doohickey").should("not.exist");
-    cy.findByText("Gizmo").should("not.exist");
 
-    cy.findByText("Gadget").click();
+    cy.findByText("Gizmo").click();
     cy.button("Add filter").click();
   });
 };
@@ -311,7 +311,7 @@ const getListDashboard = () => {
   return getTargetDashboard({
     values_source_type: "static-list",
     values_source_config: {
-      values: ["Doohickey", "Gadget"],
+      values: ["Gadget", "Gizmo", "Widget"],
     },
   });
 };

--- a/frontend/test/metabase/scenarios/dashboard-filters/dashboard-filters-source.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters/dashboard-filters-source.cy.spec.js
@@ -211,7 +211,7 @@ describeEE("scenarios > dashboard > filters", () => {
     cy.signInAsAdmin();
   });
 
-  it("should sandbox parameter values based on cards", () => {
+  it("should sandbox parameter values in dashboards", () => {
     cy.sandboxTable({
       table_id: PRODUCTS_ID,
       attribute_remappings: {

--- a/frontend/test/metabase/scenarios/native-filters/sql-filters-source.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native-filters/sql-filters-source.cy.spec.js
@@ -21,7 +21,7 @@ const structuredSourceQuestion = {
     "source-table": PRODUCTS_ID,
     aggregation: [["count"]],
     breakout: [["field", PRODUCTS.CATEGORY, null]],
-    filter: ["!=", ["field", PRODUCTS.CATEGORY, null], "Gizmo"],
+    filter: ["!=", ["field", PRODUCTS.CATEGORY, null], "Doohickey"],
   },
 };
 
@@ -60,8 +60,8 @@ describe("scenarios > filters > sql filters > values source", () => {
       saveQuestion("SQL filter");
 
       FieldFilter.openEntryForm();
-      checkFilterValueNotInList("Gizmo");
-      FieldFilter.selectFilterValueFromList("Gadget");
+      checkFilterValueNotInList("Doohickey");
+      FieldFilter.selectFilterValueFromList("Gizmo");
       SQLFilter.runQuery("cardQuery");
     });
 
@@ -76,8 +76,8 @@ describe("scenarios > filters > sql filters > values source", () => {
       saveQuestion("SQL filter");
 
       FieldFilter.openEntryForm();
-      checkFilterValueNotInList("Gizmo");
-      FieldFilter.selectFilterValueFromList("Gadget");
+      checkFilterValueNotInList("Doohickey");
+      FieldFilter.selectFilterValueFromList("Gizmo");
       SQLFilter.runQuery("cardQuery");
     });
 
@@ -91,10 +91,10 @@ describe("scenarios > filters > sql filters > values source", () => {
       setFilterQuestionSource({ question: "MBQL source", field: "Category" });
 
       FieldFilter.openEntryForm();
-      checkFilterValueNotInList("Gizmo");
-      FieldFilter.setWidgetStringFilter("Gadget");
+      checkFilterValueNotInList("Doohickey");
+      FieldFilter.setWidgetStringFilter("Gizmo");
       checkFilterValueNotInList("Widget");
-      FieldFilter.selectFilterValueFromList("Gadget");
+      FieldFilter.selectFilterValueFromList("Gizmo");
       SQLFilter.runQuery("dataset");
     });
 
@@ -108,10 +108,10 @@ describe("scenarios > filters > sql filters > values source", () => {
       setFilterQuestionSource({ question: "MBQL source", field: "Category" });
       FieldFilter.openEntryForm();
       cy.wait("@parameterValues");
-      checkFilterValueInList("Gadget");
+      checkFilterValueInList("Gizmo");
       FieldFilter.closeEntryForm();
       FieldFilter.openEntryForm();
-      checkFilterValueInList("Gadget");
+      checkFilterValueInList("Gizmo");
       cy.get("@parameterValues.all").should("have.length", 1);
       setFilterListSource({ values: ["A", "B"] });
       FieldFilter.openEntryForm();
@@ -130,7 +130,7 @@ describe("scenarios > filters > sql filters > values source", () => {
       updateQuestion();
       FieldFilter.openEntryForm();
       cy.wait("@cardParameterValues");
-      checkFilterValueInList("Gadget");
+      checkFilterValueInList("Gizmo");
     });
 
     it("should be able to use a structured question source when embedded", () => {
@@ -145,8 +145,8 @@ describe("scenarios > filters > sql filters > values source", () => {
       );
 
       FieldFilter.openEntryForm();
-      checkFilterValueNotInList("Gizmo");
-      FieldFilter.selectFilterValueFromList("Gadget");
+      checkFilterValueNotInList("Doohickey");
+      FieldFilter.selectFilterValueFromList("Gizmo");
     });
 
     it("should be able to use a structured question source when public", () => {
@@ -161,8 +161,8 @@ describe("scenarios > filters > sql filters > values source", () => {
       );
 
       FieldFilter.openEntryForm();
-      checkFilterValueNotInList("Gizmo");
-      FieldFilter.selectFilterValueFromList("Gadget");
+      checkFilterValueNotInList("Doohickey");
+      FieldFilter.selectFilterValueFromList("Gizmo");
     });
   });
 

--- a/frontend/test/metabase/scenarios/native-filters/sql-filters-source.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native-filters/sql-filters-source.cy.spec.js
@@ -309,6 +309,8 @@ describeEE("scenarios > filters > sql filters > values source", () => {
     cy.icon("variable").click();
     FieldFilter.openEntryForm(true);
     cy.wait("@parameterValues");
+    checkFilterValueNotInList("Gadget");
+    checkFilterValueNotInList("Doohickey");
     FieldFilter.selectFilterValueFromList("Gizmo");
   });
 });


### PR DESCRIPTION
Epic https://github.com/metabase/metabase/issues/26898

Adds e2e tests for sandboxed users and parameter values. All 3 different ways of obtaining values are tested:
- params in dashboards
- params in saved cards
- params without the card context (e.g. default values)

I also had to change values in tests to make them work with our sandboxing setup.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/28058)
<!-- Reviewable:end -->
