### PR TITLE
Remove `parameterValuesSearchCache`

### DIFF
--- a/frontend/src/metabase-types/store/dashboard.ts
+++ b/frontend/src/metabase-types/store/dashboard.ts
@@ -25,13 +25,6 @@ export interface DashboardState {
   dashcardData: DashCardDataMap;
 
   parameterValues: Record<ParameterId, ParameterValueOrArray>;
-  parameterValuesSearchCache: Record<
-    ParameterValueCacheKey,
-    {
-      has_more_values: boolean;
-      results: ParameterValueOrArray[];
-    }
-  >;
 
   loadingDashCards: {
     dashcardIds: DashCardId[];

--- a/frontend/src/metabase-types/store/mocks/dashboard.ts
+++ b/frontend/src/metabase-types/store/mocks/dashboard.ts
@@ -9,7 +9,6 @@ export const createMockDashboardState = (
   dashcards: {},
   dashcardData: {},
   parameterValues: {},
-  parameterValuesSearchCache: {},
   loadingDashCards: {
     dashcardIds: [],
     loadingIds: [],


### PR DESCRIPTION
Removes `parameterValuesSearchCache` from the `dashboard` state definition as it no longer exists in the real state