### PR TITLE
Statically checked unused var in TypeScript files

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -4,42 +4,58 @@
     "no-undef": 2,
     "no-var": 1,
     "no-unused-vars": [
-      1,
-      { "vars": "all", "args": "none", "varsIgnorePattern": "^_.+" }
+      "error",
+      {
+        "vars": "all",
+        "args": "none",
+        "varsIgnorePattern": "^_.+",
+        "ignoreRestSiblings": true
+      }
     ],
     "no-empty": [1, { "allowEmptyCatch": true }],
     "curly": [1, "all"],
     "eqeqeq": [1, "smart"],
     "import/no-commonjs": 1,
-    "import/order": ["error", {
-      "pathGroups": [
-        {
-          "pattern": "react",
-          "group": "builtin",
-          "position": "before"
-        },
-        {
-          "pattern": "metabase/**",
-          "group": "internal"
-        },
-        {
-          "pattern": "metabase/**/components",
-          "group": "internal",
-          "position": "before"
-        },
-        {
-          "pattern": "__**",
-          "group": "internal",
-          "position": "before"
-        },
-        {
-          "pattern": "metabase-lib/**",
-          "group": "internal",
-          "position": "after"
-        }
-      ],
-      "groups": ["builtin", "external", "internal", "parent", "sibling", "index", "object"]
-    }],
+    "import/order": [
+      "error",
+      {
+        "pathGroups": [
+          {
+            "pattern": "react",
+            "group": "builtin",
+            "position": "before"
+          },
+          {
+            "pattern": "metabase/**",
+            "group": "internal"
+          },
+          {
+            "pattern": "metabase/**/components",
+            "group": "internal",
+            "position": "before"
+          },
+          {
+            "pattern": "__**",
+            "group": "internal",
+            "position": "before"
+          },
+          {
+            "pattern": "metabase-lib/**",
+            "group": "internal",
+            "position": "after"
+          }
+        ],
+        "groups": [
+          "builtin",
+          "external",
+          "internal",
+          "parent",
+          "sibling",
+          "index",
+          "object"
+        ]
+      }
+    ],
     "no-console": 0,
     "react/no-is-mounted": 2,
     "react/prefer-es6-class": 2,
@@ -112,7 +128,17 @@
         "@typescript-eslint/no-inferrable-types": "off",
         "@typescript-eslint/no-explicit-any": "off",
         "@typescript-eslint/no-this-alias": "off",
-        "@typescript-eslint/no-unused-vars": "off"
+        "no-unused-vars": "off",
+        "@typescript-eslint/no-unused-vars": [
+          "error",
+          {
+            "vars": "all",
+            "args": "none",
+            "varsIgnorePattern": "^_.+",
+            "ignoreRestSiblings": true,
+            "destructuredArrayIgnorePattern": "^_"
+          }
+        ]
       }
     },
     {

--- a/enterprise/frontend/src/metabase-enterprise/auth/components/SessionTimeoutSetting/SessionTimeoutSetting.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/auth/components/SessionTimeoutSetting/SessionTimeoutSetting.unit.spec.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, cleanup, screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import SessionTimeoutSetting from "metabase-enterprise/auth/components/SessionTimeoutSetting";
 
 describe("SessionTimeoutSetting", () => {

--- a/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/data-model-permission.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/data-model-permission.unit.spec.ts
@@ -178,8 +178,7 @@ describe("buildDataModelPermission", () => {
         "schemas",
       );
 
-      const [downgradePermissionConfirmation] =
-        permissionModel.confirmations("all");
+      permissionModel.confirmations("all");
 
       expect(permissionModel.warning).toBe(null);
     });

--- a/frontend/src/metabase-lib/expressions/pratt/syntax.ts
+++ b/frontend/src/metabase-lib/expressions/pratt/syntax.ts
@@ -1,4 +1,4 @@
-import { assert, NodeType, Node } from "./types";
+import { NodeType, Node } from "./types";
 
 /*
  * This file specifies most of the syntax for the Metabase handwritten custom

--- a/frontend/src/metabase-lib/queries/Query.ts
+++ b/frontend/src/metabase-lib/queries/Query.ts
@@ -1,7 +1,7 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 import { DatasetQuery } from "metabase-types/types/Card";
-import { DependentMetadataItem, Field } from "metabase-types/types/Query";
+import { DependentMetadataItem } from "metabase-types/types/Query";
 import Metadata from "metabase-lib/metadata/Metadata";
 import Question from "metabase-lib/Question";
 import Dimension from "metabase-lib/Dimension";

--- a/frontend/src/metabase-lib/queries/utils/dimension.ts
+++ b/frontend/src/metabase-lib/queries/utils/dimension.ts
@@ -1,4 +1,4 @@
-import type { ConcreteField, FilterClause } from "metabase-types/types/Query";
+import type { ConcreteField } from "metabase-types/types/Query";
 import type { VariableTarget } from "metabase-types/types/Parameter";
 import type Metadata from "metabase-lib/metadata/Metadata";
 import type StructuredQuery from "metabase-lib/queries/StructuredQuery";

--- a/frontend/src/metabase-types/api/parameters.ts
+++ b/frontend/src/metabase-types/api/parameters.ts
@@ -1,7 +1,5 @@
-import { DashboardId } from "./dashboard";
 import { RowValue } from "./dataset";
 import { CardId } from "./card";
-import { FieldId } from "./field";
 
 export type StringParameterType =
   | "string/="

--- a/frontend/src/metabase-types/store/dashboard.ts
+++ b/frontend/src/metabase-types/store/dashboard.ts
@@ -15,8 +15,6 @@ export type DashboardSidebarName =
   | "sharing"
   | "info";
 
-type ParameterValueCacheKey = string;
-
 export interface DashboardState {
   dashboardId: DashboardId | null;
   dashboards: Record<DashboardId, Dashboard>;

--- a/frontend/src/metabase-types/store/mocks/dashboard.ts
+++ b/frontend/src/metabase-types/store/mocks/dashboard.ts
@@ -1,4 +1,3 @@
-import { createMockDashboard } from "metabase-types/api/mocks";
 import type { DashboardState } from "metabase-types/store";
 
 export const createMockDashboardState = (

--- a/frontend/src/metabase/actions/components/ActionForm/ActionForm.tsx
+++ b/frontend/src/metabase/actions/components/ActionForm/ActionForm.tsx
@@ -1,6 +1,5 @@
 import React, { useMemo } from "react";
 import { t } from "ttag";
-import _ from "underscore";
 import { DragDropContext, Droppable, Draggable } from "react-beautiful-dnd";
 
 import type {

--- a/frontend/src/metabase/actions/components/ActionForm/ActionForm.unit.spec.tsx
+++ b/frontend/src/metabase/actions/components/ActionForm/ActionForm.unit.spec.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import _ from "underscore";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 

--- a/frontend/src/metabase/actions/components/ActionForm/ActionFormFieldWidget.tsx
+++ b/frontend/src/metabase/actions/components/ActionForm/ActionFormFieldWidget.tsx
@@ -1,5 +1,4 @@
 import React, { forwardRef } from "react";
-import _ from "underscore";
 
 import FormInputWidget from "metabase/core/components/FormInput";
 import FormTextAreaWidget from "metabase/core/components/FormTextArea";

--- a/frontend/src/metabase/actions/components/ActionForm/utils.ts
+++ b/frontend/src/metabase/actions/components/ActionForm/utils.ts
@@ -1,5 +1,4 @@
 import { t } from "ttag";
-import _ from "underscore";
 import * as Yup from "yup";
 
 import type {

--- a/frontend/src/metabase/actions/components/ActionViz/ActionVizForm.tsx
+++ b/frontend/src/metabase/actions/components/ActionViz/ActionVizForm.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from "react";
-import { t } from "ttag";
 
 import type {
   WritebackQueryAction,

--- a/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/FieldSettingsPopover.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/FieldSettingsPopover.tsx
@@ -176,8 +176,6 @@ function PlaceholderInput({
   value: string;
   onChange: (newPlaceholder: string) => void;
 }) {
-  const inputTypes = useMemo(getInputTypes, []);
-
   return (
     <div>
       <SectionLabel>{t`Placeholder text`}</SectionLabel>

--- a/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/FormCreator.styled.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/FormCreator.styled.tsx
@@ -1,5 +1,4 @@
 import styled from "@emotion/styled";
-import InputBase from "metabase/core/components/Input";
 import Icon from "metabase/components/Icon";
 
 import { color, lighten } from "metabase/lib/colors";

--- a/frontend/src/metabase/actions/containers/ActionParametersInputForm/utils.unit.spec.ts
+++ b/frontend/src/metabase/actions/containers/ActionParametersInputForm/utils.unit.spec.ts
@@ -1,4 +1,3 @@
-import type { FieldSettingsMap } from "metabase-types/api";
 import { getChangedValues, formatValue } from "./utils";
 
 describe("actions > containers > ActionParametersInputForm > utils", () => {

--- a/frontend/src/metabase/actions/containers/ActionPicker/ActionOptionItem.styled.tsx
+++ b/frontend/src/metabase/actions/containers/ActionPicker/ActionOptionItem.styled.tsx
@@ -1,4 +1,3 @@
-import _ from "underscore";
 import styled from "@emotion/styled";
 
 import { color, lighten } from "metabase/lib/colors";

--- a/frontend/src/metabase/actions/containers/ActionPicker/ActionPicker.styled.tsx
+++ b/frontend/src/metabase/actions/containers/ActionPicker/ActionPicker.styled.tsx
@@ -1,4 +1,3 @@
-import _ from "underscore";
 import styled from "@emotion/styled";
 
 import { color } from "metabase/lib/colors";

--- a/frontend/src/metabase/actions/utils.unit.spec.ts
+++ b/frontend/src/metabase/actions/utils.unit.spec.ts
@@ -65,7 +65,7 @@ describe("sortActionParams", () => {
     it("should generate settings for a string field", () => {
       const fields = [createField({ name: "test-field" })];
       const params = [createParameter({ id: "test-field" })];
-      const [id, settings] = getFirstEntry(
+      const [_id, settings] = getFirstEntry(
         generateFieldSettingsFromParameters(params, fields),
       );
 
@@ -84,7 +84,7 @@ describe("sortActionParams", () => {
       const params = [
         createParameter({ id: "test-field", type: "type/Integer" }),
       ];
-      const [id, settings] = getFirstEntry(
+      const [_id, settings] = getFirstEntry(
         generateFieldSettingsFromParameters(params, fields),
       );
 
@@ -103,7 +103,7 @@ describe("sortActionParams", () => {
       const params = [
         createParameter({ id: "test-field", type: "type/Float" }),
       ];
-      const [id, settings] = getFirstEntry(
+      const [_id, settings] = getFirstEntry(
         generateFieldSettingsFromParameters(params, fields),
       );
 
@@ -116,7 +116,7 @@ describe("sortActionParams", () => {
         createField({ name: "test-field", semantic_type: "type/Category" }),
       ];
       const params = [createParameter({ id: "test-field", type: "type/Text" })];
-      const [id, settings] = getFirstEntry(
+      const [_id, settings] = getFirstEntry(
         generateFieldSettingsFromParameters(params, fields),
       );
 
@@ -127,7 +127,7 @@ describe("sortActionParams", () => {
     it("should set the parameter id as the object key", () => {
       const fields = [createField({ name: "test-field" })];
       const params = [createParameter({ id: "test-field" })];
-      const [id, settings] = getFirstEntry(
+      const [id, _settings] = getFirstEntry(
         generateFieldSettingsFromParameters(params, fields),
       );
 
@@ -137,7 +137,7 @@ describe("sortActionParams", () => {
     it("should get display name from field metadata", () => {
       const fields = [createField({ name: "test-field" })];
       const params = [createParameter({ id: "test-field" })];
-      const [id, settings] = getFirstEntry(
+      const [_id, settings] = getFirstEntry(
         generateFieldSettingsFromParameters(params, fields),
       );
 
@@ -161,7 +161,7 @@ describe("sortActionParams", () => {
     it("sets settings from parameter if there is no corresponding field", () => {
       const fields = [createField({ name: "xyz", description: "foo bar baz" })];
       const params = [createParameter({ id: "test-field", name: null })];
-      const [id, settings] = getFirstEntry(
+      const [_id, settings] = getFirstEntry(
         generateFieldSettingsFromParameters(params, fields),
       );
 
@@ -173,7 +173,7 @@ describe("sortActionParams", () => {
     it("sets required prop to true", () => {
       const fields = [createField({ name: "test-field" })];
       const params = [createParameter({ id: "test-field", required: true })];
-      const [id, settings] = getFirstEntry(
+      const [_id, settings] = getFirstEntry(
         generateFieldSettingsFromParameters(params, fields),
       );
 
@@ -183,7 +183,7 @@ describe("sortActionParams", () => {
     it("sets required prop to false", () => {
       const fields = [createField({ name: "test-field" })];
       const params = [createParameter({ id: "test-field", required: false })];
-      const [id, settings] = getFirstEntry(
+      const [_id, settings] = getFirstEntry(
         generateFieldSettingsFromParameters(params, fields),
       );
 
@@ -195,7 +195,7 @@ describe("sortActionParams", () => {
         createField({ name: "test-field", description: "foo bar baz" }),
       ];
       const params = [createParameter({ id: "test-field" })];
-      const [id, settings] = getFirstEntry(
+      const [_id, settings] = getFirstEntry(
         generateFieldSettingsFromParameters(params, fields),
       );
 

--- a/frontend/src/metabase/admin/app/reducers.ts
+++ b/frontend/src/metabase/admin/app/reducers.ts
@@ -1,7 +1,6 @@
 import { t } from "ttag";
 import { combineReducers, handleActions } from "metabase/lib/redux";
 import Settings from "metabase/lib/settings";
-import { User } from "metabase-types/api";
 import {
   PLUGIN_ADMIN_ALLOWED_PATH_GETTERS,
   PLUGIN_ADMIN_NAV_ITEMS,

--- a/frontend/src/metabase/admin/databases/components/ContentRemovalConfirmation/ContentRemovalConfirmation.tsx
+++ b/frontend/src/metabase/admin/databases/components/ContentRemovalConfirmation/ContentRemovalConfirmation.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { msgid, ngettext, t } from "ttag";
+import { msgid, ngettext } from "ttag";
 import { DatabaseUsageInfo } from "metabase-types/api";
 import { color } from "metabase/lib/colors";
 import { ConfirmationCheckbox } from "./ContentRemovalConfirmation.styled";

--- a/frontend/src/metabase/admin/datamodel/components/FormLabel/FormLabel.tsx
+++ b/frontend/src/metabase/admin/datamodel/components/FormLabel/FormLabel.tsx
@@ -1,10 +1,4 @@
-import React, {
-  forwardRef,
-  HTMLAttributes,
-  LabelHTMLAttributes,
-  ReactNode,
-  Ref,
-} from "react";
+import React, { forwardRef, HTMLAttributes, ReactNode, Ref } from "react";
 import {
   FormLabelContent,
   FormLabelDescription,

--- a/frontend/src/metabase/admin/datamodel/components/database/MetadataTable/MetadataTable.styled.tsx
+++ b/frontend/src/metabase/admin/datamodel/components/database/MetadataTable/MetadataTable.styled.tsx
@@ -1,8 +1,6 @@
 import styled from "@emotion/styled";
-import { css } from "@emotion/react";
 import { color } from "metabase/lib/colors";
 import InputBlurChange from "metabase/components/InputBlurChange";
-import { focusOutlineStyle } from "metabase/core/style/input";
 import Input from "metabase/core/components/Input";
 
 interface VisibilityTypeProps {

--- a/frontend/src/metabase/admin/datamodel/components/database/TableSyncWarning/TableSyncWarning.tsx
+++ b/frontend/src/metabase/admin/datamodel/components/database/TableSyncWarning/TableSyncWarning.tsx
@@ -1,7 +1,7 @@
-import React, { useCallback } from "react";
+import React from "react";
 import { t } from "ttag";
 import Button from "metabase/core/components/Button/Button";
-import { Table, TableVisibilityType } from "metabase-types/api";
+import { TableVisibilityType } from "metabase-types/api";
 import {
   SyncWarningRoot,
   SyncWarningDescription,

--- a/frontend/src/metabase/admin/permissions/components/PermissionsSidebar/PermissionsSidebar.tsx
+++ b/frontend/src/metabase/admin/permissions/components/PermissionsSidebar/PermissionsSidebar.tsx
@@ -7,7 +7,7 @@ import {
 } from "./PermissionsSidebarContent";
 import { SidebarRoot } from "./PermissionsSidebar.styled";
 
-interface PermissionsSidebar extends PermissionsSidebarContentProps {
+interface PermissionsSidebarProps extends PermissionsSidebarContentProps {
   isLoading?: boolean;
   error: string;
 }
@@ -16,7 +16,7 @@ export const PermissionsSidebar = ({
   isLoading,
   error,
   ...contentProps
-}: PermissionsSidebar) => {
+}: PermissionsSidebarProps) => {
   return (
     <SidebarRoot>
       <LoadingAndErrorWrapper loading={isLoading} error={error} noWrapper>

--- a/frontend/src/metabase/admin/permissions/components/ToolbarUpsell/ToolbarUpsell.tsx
+++ b/frontend/src/metabase/admin/permissions/components/ToolbarUpsell/ToolbarUpsell.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import _ from "underscore";
 import { jt, t } from "ttag";
 
 import PopoverWithTrigger from "metabase/components/PopoverWithTrigger";

--- a/frontend/src/metabase/admin/settings/components/widgets/SecretKeyWidget/SecretKeyWidget.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/SecretKeyWidget/SecretKeyWidget.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 
 import { t } from "ttag";
-import Button from "metabase/core/components/Button";
 import Confirm from "metabase/components/Confirm";
 import { UtilApi } from "metabase/services";
 import SettingInput from "../SettingInput";

--- a/frontend/src/metabase/admin/settings/slack/components/SlackForm/SlackForm.tsx
+++ b/frontend/src/metabase/admin/settings/slack/components/SlackForm/SlackForm.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo } from "react";
+import React, { useCallback } from "react";
 import { t } from "ttag";
 import * as Yup from "yup";
 import Form from "metabase/core/components/Form";

--- a/frontend/src/metabase/auth/components/ForgotPassword/ForgotPassword.tsx
+++ b/frontend/src/metabase/auth/components/ForgotPassword/ForgotPassword.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useState } from "react";
+import React, { useCallback, useState } from "react";
 import { t } from "ttag";
 import Button from "metabase/core/components/Button";
 import AuthLayout from "../../containers/AuthLayout";

--- a/frontend/src/metabase/auth/components/Logout/Logout.tsx
+++ b/frontend/src/metabase/auth/components/Logout/Logout.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import { useEffect } from "react";
 
 interface LogoutProps {
   onLogout: () => void;

--- a/frontend/src/metabase/collections/components/CollectionHeader/CollectionMenu.tsx
+++ b/frontend/src/metabase/collections/components/CollectionHeader/CollectionMenu.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { t } from "ttag";
-import _ from "underscore";
 
 import { PLUGIN_COLLECTIONS } from "metabase/plugins";
 import * as Urls from "metabase/lib/urls";

--- a/frontend/src/metabase/collections/components/PinnedItemCard/PinnedItemCard.stories.tsx
+++ b/frontend/src/metabase/collections/components/PinnedItemCard/PinnedItemCard.stories.tsx
@@ -17,7 +17,6 @@ const collection = {
   archived: false,
 };
 
-const onToggleSelected = action("onToggleSelected");
 const onCopy = action("onCopy");
 const onMove = action("onMove");
 

--- a/frontend/src/metabase/components/Calendar.tsx
+++ b/frontend/src/metabase/components/Calendar.tsx
@@ -7,7 +7,6 @@ import cx from "classnames";
 import moment, { Moment } from "moment-timezone";
 import { t } from "ttag";
 import Icon from "metabase/components/Icon";
-import { color } from "metabase/lib/colors";
 import { CalendarDay } from "./Calendar.styled";
 
 export type SelectAll = "after" | "before";
@@ -216,15 +215,8 @@ type WeekProps = {
 class Week extends Component<WeekProps> {
   render() {
     const days = [];
-    let {
-      date,
-      month,
-      selected,
-      selectedEnd,
-      primaryColor = color("brand"),
-      selectAll,
-      isRangePicker,
-    } = this.props;
+    let { date, month, selected, selectedEnd, selectAll, isRangePicker } =
+      this.props;
 
     for (let i = 0; i < 7; i++) {
       const isSelected =

--- a/frontend/src/metabase/components/ListField/utils.unit.spec.ts
+++ b/frontend/src/metabase/components/ListField/utils.unit.spec.ts
@@ -1,4 +1,3 @@
-import moment from "moment-timezone";
 import { isValidOptionItem } from "./utils";
 
 describe("ListField - utils", () => {

--- a/frontend/src/metabase/components/Popover/TippyPopover.tsx
+++ b/frontend/src/metabase/components/Popover/TippyPopover.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo, useCallback, useRef } from "react";
+import React, { useState, useMemo, useCallback } from "react";
 import PropTypes from "prop-types";
 import * as TippyReact from "@tippyjs/react";
 import * as tippy from "tippy.js";

--- a/frontend/src/metabase/components/SelectList/SelectListItem.styled.tsx
+++ b/frontend/src/metabase/components/SelectList/SelectListItem.styled.tsx
@@ -3,7 +3,7 @@ import { css } from "@emotion/react";
 
 import Label from "metabase/components/type/Label";
 import { color } from "metabase/lib/colors";
-import Icon, { IconProps } from "metabase/components/Icon";
+import Icon from "metabase/components/Icon";
 
 export const ItemTitle = styled(Label)`
   margin: 0;

--- a/frontend/src/metabase/components/TextWidget/TextWidget.unit.spec.tsx
+++ b/frontend/src/metabase/components/TextWidget/TextWidget.unit.spec.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from "react";
 import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { act } from "react-dom/test-utils";
 import TextWidget from "./TextWidget";
 
 const TextInputWithStateWrapper = ({ value }: { value?: number | string }) => {

--- a/frontend/src/metabase/components/form/FormikCustomForm/CustomForm.tsx
+++ b/frontend/src/metabase/components/form/FormikCustomForm/CustomForm.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import _ from "underscore";
 import { Form } from "formik";
 
 import {
@@ -8,11 +7,7 @@ import {
   PopulatedFormObject,
 } from "metabase-types/forms";
 
-import {
-  BaseFormProps,
-  OptionalFormViewProps,
-  FormLegacyContext,
-} from "./types";
+import { BaseFormProps, OptionalFormViewProps } from "./types";
 
 import CustomFormField, { CustomFormFieldProps } from "./CustomFormField";
 import CustomFormFooter, { CustomFormFooterProps } from "./CustomFormFooter";

--- a/frontend/src/metabase/components/form/FormikCustomForm/CustomFormMessage.tsx
+++ b/frontend/src/metabase/components/form/FormikCustomForm/CustomFormMessage.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import _ from "underscore";
 
 import FormMessage from "metabase/components/form/FormMessage";
 

--- a/frontend/src/metabase/components/form/FormikCustomForm/CustomFormSubmit.tsx
+++ b/frontend/src/metabase/components/form/FormikCustomForm/CustomFormSubmit.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { t } from "ttag";
-import _ from "underscore";
 
 import ActionButton from "metabase/components/ActionButton";
 

--- a/frontend/src/metabase/containers/DataPicker/CardPicker/utils.ts
+++ b/frontend/src/metabase/containers/DataPicker/CardPicker/utils.ts
@@ -1,5 +1,3 @@
-import _ from "underscore";
-
 import {
   PERSONAL_COLLECTIONS,
   buildCollectionTree as _buildCollectionTree,

--- a/frontend/src/metabase/containers/DataPicker/RawDataPicker/RawDataPickerContainer.tsx
+++ b/frontend/src/metabase/containers/DataPicker/RawDataPicker/RawDataPickerContainer.tsx
@@ -1,5 +1,4 @@
 import React, { useCallback, useMemo } from "react";
-import _ from "underscore";
 
 import Databases from "metabase/entities/databases";
 import Schemas from "metabase/entities/schemas";

--- a/frontend/src/metabase/containers/FormikForm/FormView.tsx
+++ b/frontend/src/metabase/containers/FormikForm/FormView.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import _ from "underscore";
 
 import CustomForm, {
   CustomFormProps,

--- a/frontend/src/metabase/core/components/ColorInput/ColorInput.stories.tsx
+++ b/frontend/src/metabase/core/components/ColorInput/ColorInput.stories.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React from "react";
 import type { ComponentStory } from "@storybook/react";
 import { useArgs } from "@storybook/client-api";
 import ColorInput from "./ColorInput";

--- a/frontend/src/metabase/core/components/DateSelector/DateSelector.stories.tsx
+++ b/frontend/src/metabase/core/components/DateSelector/DateSelector.stories.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import moment, { Moment } from "moment-timezone";
+import moment from "moment-timezone";
 import type { ComponentStory } from "@storybook/react";
 import DateSelector from "./DateSelector";
 

--- a/frontend/src/metabase/core/components/DateSelector/DateSelector.tsx
+++ b/frontend/src/metabase/core/components/DateSelector/DateSelector.tsx
@@ -4,7 +4,6 @@ import React, {
   Ref,
   useCallback,
   useMemo,
-  useState,
 } from "react";
 import moment, { Moment } from "moment-timezone";
 import { t } from "ttag";

--- a/frontend/src/metabase/core/components/FormNumericInput/FormNumericInput.tsx
+++ b/frontend/src/metabase/core/components/FormNumericInput/FormNumericInput.tsx
@@ -1,10 +1,4 @@
-import React, {
-  ChangeEvent,
-  forwardRef,
-  ReactNode,
-  Ref,
-  useCallback,
-} from "react";
+import React, { forwardRef, ReactNode, Ref, useCallback } from "react";
 import { useField } from "formik";
 import { useUniqueId } from "metabase/hooks/use-unique-id";
 import NumericInput, {

--- a/frontend/src/metabase/core/components/Radio/Radio.tsx
+++ b/frontend/src/metabase/core/components/Radio/Radio.tsx
@@ -133,7 +133,7 @@ interface RadioItemProps<TValue> {
   onOptionClick?: (value: TValue) => void;
 }
 
-const RadioItem = <TValue, TOption>({
+const RadioItem = <TValue,>({
   checked,
   name,
   label,
@@ -191,7 +191,7 @@ const getDefaultOptionKey = <TValue, TOption>(option: TOption): Key => {
 };
 
 const getDefaultOptionName = <TValue, TOption>(option: TOption): ReactNode => {
-  if (isDefaultOption(option)) {
+  if (isDefaultOption<TValue>(option)) {
     return option.name;
   } else {
     throw new TypeError();

--- a/frontend/src/metabase/core/components/Select/Select.stories.tsx
+++ b/frontend/src/metabase/core/components/Select/Select.stories.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import type { ComponentStory } from "@storybook/react";
-import { field_semantic_types } from "metabase/lib/core";
 import Select from "./Select";
 
 export default {

--- a/frontend/src/metabase/dashboard/components/AddActionSidebar/AddActionSidebar.tsx
+++ b/frontend/src/metabase/dashboard/components/AddActionSidebar/AddActionSidebar.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React from "react";
 import _ from "underscore";
 import { t } from "ttag";
 import { connect } from "react-redux";

--- a/frontend/src/metabase/dashboard/components/DashCard/ClickBehaviorSidebarOverlay/ClickBehaviorSidebarOverlay.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/ClickBehaviorSidebarOverlay/ClickBehaviorSidebarOverlay.tsx
@@ -1,5 +1,4 @@
 import React, { useCallback } from "react";
-import _ from "underscore";
 import { t } from "ttag";
 
 import { getClickBehaviorDescription } from "metabase/lib/click-behavior";

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardActionButtons/AddSeriesButton/AddSeriesButton.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardActionButtons/AddSeriesButton/AddSeriesButton.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import _ from "underscore";
 import { t } from "ttag";
 
 import Icon from "metabase/components/Icon";

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardActionButtons/ChartSettingsButton.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardActionButtons/ChartSettingsButton.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import _ from "underscore";
 import { t } from "ttag";
 
 import ModalWithTrigger from "metabase/components/ModalWithTrigger";

--- a/frontend/src/metabase/dashboard/components/DashboardHeader.styled.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHeader.styled.tsx
@@ -3,7 +3,7 @@ import { css } from "@emotion/react";
 
 import LastEditInfoLabel from "metabase/components/LastEditInfoLabel";
 
-import { alpha, color } from "metabase/lib/colors";
+import { color } from "metabase/lib/colors";
 import {
   breakpointMaxSmall,
   breakpointMinSmall,

--- a/frontend/src/metabase/databases/components/DatabaseForm/DatabaseForm.stories.tsx
+++ b/frontend/src/metabase/databases/components/DatabaseForm/DatabaseForm.stories.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import type { ComponentStory } from "@storybook/react";
-import { createMockEngine } from "metabase-types/api/mocks";
 import DatabaseForm from "./DatabaseForm";
 
 export default {

--- a/frontend/src/metabase/databases/components/DatabaseSyncModal/DatabaseSyncModal.styled.tsx
+++ b/frontend/src/metabase/databases/components/DatabaseSyncModal/DatabaseSyncModal.styled.tsx
@@ -1,5 +1,4 @@
 import styled from "@emotion/styled";
-import React from "react";
 import { color } from "metabase/lib/colors";
 import Icon from "metabase/components/Icon";
 

--- a/frontend/src/metabase/entities/containers/EntityName.unit.spec.tsx
+++ b/frontend/src/metabase/entities/containers/EntityName.unit.spec.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { screen, waitFor } from "@testing-library/react";
+import { screen } from "@testing-library/react";
 
 import { renderWithProviders } from "__support__/ui";
 import { createMockUser } from "metabase-types/api/mocks";

--- a/frontend/src/metabase/home/homepage/components/HomePage/HomePage.unit.spec.tsx
+++ b/frontend/src/metabase/home/homepage/components/HomePage/HomePage.unit.spec.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { render } from "@testing-library/react";
 import * as dom from "metabase/lib/dom";
 import HomePage from "./HomePage";
 

--- a/frontend/src/metabase/hooks/use-loading-timer.ts
+++ b/frontend/src/metabase/hooks/use-loading-timer.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 
 interface LoadingTimerProps {
   timer: number;

--- a/frontend/src/metabase/hooks/use-media-query.ts
+++ b/frontend/src/metabase/hooks/use-media-query.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
 const useMediaQuery = (query: string) => {
   const queryList = useMemo(() => window.matchMedia(query), [query]);

--- a/frontend/src/metabase/lib/colors/scales.ts
+++ b/frontend/src/metabase/lib/colors/scales.ts
@@ -1,5 +1,4 @@
 import d3 from "d3";
-import Color from "color";
 
 export const getColorScale = (
   extent: [number, number],

--- a/frontend/src/metabase/lib/formatting/numbers.tsx
+++ b/frontend/src/metabase/lib/formatting/numbers.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 
 import { format_number } from "cljs/metabase.shared.formatting.numbers";
-import { getCurrencySymbol } from "./currency";
 
 interface FormatNumberOptionsType {
   compact?: boolean;

--- a/frontend/src/metabase/lib/formatting/strings.ts
+++ b/frontend/src/metabase/lib/formatting/strings.ts
@@ -1,11 +1,5 @@
 import inflection from "inflection";
 
-import { formatUrl } from "./url";
-import { formatEmail } from "./email";
-import { formatImage } from "./image";
-
-import type { OptionsType } from "./types";
-
 export function singularize(str: string, singular?: string) {
   return inflection.singularize(str, singular);
 }

--- a/frontend/src/metabase/lib/urls/collections.ts
+++ b/frontend/src/metabase/lib/urls/collections.ts
@@ -1,9 +1,6 @@
 import slugg from "slugg";
 
-import {
-  Collection as BaseCollection,
-  RegularCollectionId,
-} from "metabase-types/api";
+import { Collection as BaseCollection } from "metabase-types/api";
 
 import { appendSlug, extractEntityId } from "./utils";
 

--- a/frontend/src/metabase/models/components/ModelDetailPage/ModelInfoSidePanel/ModelRelationships.styled.tsx
+++ b/frontend/src/metabase/models/components/ModelDetailPage/ModelInfoSidePanel/ModelRelationships.styled.tsx
@@ -1,7 +1,6 @@
 import styled from "@emotion/styled";
 
 import Link from "metabase/core/components/Link";
-import Icon from "metabase/components/Icon";
 
 import { color, darken } from "metabase/lib/colors";
 

--- a/frontend/src/metabase/modes/components/drill/DashboardClickDrill.tsx
+++ b/frontend/src/metabase/modes/components/drill/DashboardClickDrill.tsx
@@ -1,10 +1,8 @@
-import { push } from "react-router-redux";
 import {
   setOrUnsetParameterValues,
   setParameterValue,
 } from "metabase/dashboard/actions";
 
-import type { ReduxAction } from "metabase-types/store";
 import type Question from "metabase-lib/Question";
 
 import {

--- a/frontend/src/metabase/nav/components/AdminNavbar/AdminNavItem.tsx
+++ b/frontend/src/metabase/nav/components/AdminNavbar/AdminNavItem.tsx
@@ -1,15 +1,17 @@
 import React from "react";
-import cx from "classnames";
-import Link from "metabase/core/components/Link";
 import { AdminNavLink } from "./AdminNavItem.styled";
 
-interface AdminNavItem {
+interface AdminNavItemProps {
   name: string;
   path: string;
   currentPath: string;
 }
 
-export const AdminNavItem = ({ name, path, currentPath }: AdminNavItem) => (
+export const AdminNavItem = ({
+  name,
+  path,
+  currentPath,
+}: AdminNavItemProps) => (
   <li>
     <AdminNavLink
       to={path}

--- a/frontend/src/metabase/nav/containers/MainNavbar/types.ts
+++ b/frontend/src/metabase/nav/containers/MainNavbar/types.ts
@@ -1,4 +1,4 @@
-import type { Location, LocationDescriptor } from "history";
+import type { Location } from "history";
 
 export interface MainNavbarOwnProps {
   isOpen: boolean;

--- a/frontend/src/metabase/parameters/components/ParameterLinkedFilters/ParameterLinkedFilters.styled.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterLinkedFilters/ParameterLinkedFilters.styled.tsx
@@ -1,6 +1,5 @@
 import styled from "@emotion/styled";
 import { color } from "metabase/lib/colors";
-import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
 
 export const SectionRoot = styled.div`
   padding: 1.5rem 1rem;

--- a/frontend/src/metabase/parameters/components/ValuesSourceModal/ValuesSourceTypeModal.styled.tsx
+++ b/frontend/src/metabase/parameters/components/ValuesSourceModal/ValuesSourceTypeModal.styled.tsx
@@ -1,7 +1,6 @@
 import styled from "@emotion/styled";
 import { color } from "metabase/lib/colors";
 import TextArea from "metabase/core/components/TextArea";
-import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
 import { ModalBody } from "metabase/parameters/components/ValuesSourceModal/ValuesSourceModal.styled";
 
 export const ModalBodyWithPane = styled(ModalBody)`

--- a/frontend/src/metabase/public/components/widgets/EmbedModalContent.unit.spec.tsx
+++ b/frontend/src/metabase/public/components/widgets/EmbedModalContent.unit.spec.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { screen, waitFor } from "@testing-library/react";
-import _ from "underscore";
 
 import { renderWithProviders } from "__support__/ui";
 import { createMockUser } from "metabase-types/api/mocks";

--- a/frontend/src/metabase/query_builder/actions/core/parameterUtils.ts
+++ b/frontend/src/metabase/query_builder/actions/core/parameterUtils.ts
@@ -1,15 +1,12 @@
-import _ from "underscore";
-
 import { DashboardApi } from "metabase/services";
 
 import { setErrorPage } from "metabase/redux/app";
-import { getMetadata } from "metabase/selectors/metadata";
 
 import { hasMatchingParameters } from "metabase/parameters/utils/dashboards";
 import { getParameterValuesByIdFromQueryParams } from "metabase/parameters/utils/parameter-values";
 
 import { Parameter } from "metabase-types/api";
-import { Dispatch, GetState } from "metabase-types/store";
+import { Dispatch } from "metabase-types/store";
 
 import { Card, SavedCard } from "metabase-types/types/Card";
 import { getCardUiParameters } from "metabase-lib/parameters/utils/cards";

--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorDataBucketPicker/DataSelectorDataBucketPicker.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorDataBucketPicker/DataSelectorDataBucketPicker.styled.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import styled from "@emotion/styled";
 
 import SelectList from "metabase/components/SelectList";

--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorTablePicker/DataSelectorTablePicker.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorTablePicker/DataSelectorTablePicker.unit.spec.tsx
@@ -1,14 +1,12 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
 
-import { createMockTable } from "metabase-types/api/mocks/table";
 import { createMockDatabase } from "metabase-types/api/mocks/database";
 
 import type Table from "metabase-lib/metadata/Table";
 import DataSelectorTablePicker from "./DataSelectorTablePicker";
 
 const database = createMockDatabase();
-const table = createMockTable();
 
 const props = {
   schemas: [],

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/EditorTabs/EditorTabs.tsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/EditorTabs/EditorTabs.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import _ from "underscore";
 
 import Icon from "metabase/components/Icon";
 import { TabBar, Tab, RadioInput } from "./EditorTabs.styled";

--- a/frontend/src/metabase/query_builder/components/QuestionActions.tsx
+++ b/frontend/src/metabase/query_builder/components/QuestionActions.tsx
@@ -85,7 +85,6 @@ const QuestionActions = ({
   const isDataset = question.isDataset();
   const canWrite = question.canWrite();
   const isSaved = question.isSaved();
-  const isNative = question.isNative();
 
   const canPersistDataset =
     PLUGIN_MODEL_PERSISTENCE.isModelLevelPersistenceEnabled() &&

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield/helper-text-strings.ts
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield/helper-text-strings.ts
@@ -1,7 +1,6 @@
 import { t } from "ttag";
 import moment from "moment-timezone";
 
-import { formatTime } from "metabase/lib/formatting";
 import type { Database } from "metabase-types/api/database";
 import { HelpText, HelpTextConfig } from "metabase-lib/expressions/types";
 

--- a/frontend/src/metabase/query_builder/components/filters/FilterPopover/FilterPopover.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/FilterPopover/FilterPopover.tsx
@@ -48,12 +48,6 @@ type Props = {
   checkedColor?: string;
 };
 
-type State = {
-  filter: Filter | null;
-  choosingField: boolean;
-  editingFilter: boolean;
-};
-
 export default function FilterPopover({
   isNew: isNewProp,
   filter: filterProp,

--- a/frontend/src/metabase/query_builder/components/filters/FilterPopover/FilterPopoverPicker.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/FilterPopover/FilterPopoverPicker.tsx
@@ -40,7 +40,6 @@ export default class FilterPopoverPicker extends React.Component<Props> {
       onCommit,
       minWidth,
       maxWidth,
-      primaryColor,
       checkedColor,
     } = this.props;
 

--- a/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterModal/utils.ts
+++ b/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterModal/utils.ts
@@ -5,7 +5,6 @@ import StructuredQuery, {
   isDimensionOption,
 } from "metabase-lib/queries/StructuredQuery";
 import type Filter from "metabase-lib/queries/structured/Filter";
-import type Dimension from "metabase-lib/Dimension";
 
 // fix between filters with missing or misordered arguments
 export function fixBetweens(query: StructuredQuery): StructuredQuery {

--- a/frontend/src/metabase/query_builder/components/filters/modals/InlineCategoryPicker/InlineCategoryPicker.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/modals/InlineCategoryPicker/InlineCategoryPicker.tsx
@@ -6,7 +6,6 @@ import Fields from "metabase/entities/fields";
 import { useSafeAsyncFunction } from "metabase/hooks/use-safe-async-function";
 import Warnings from "metabase/query_builder/components/Warnings";
 import type Filter from "metabase-lib/queries/structured/Filter";
-import StructuredQuery from "metabase-lib/queries/StructuredQuery";
 import Dimension from "metabase-lib/Dimension";
 
 import { InlineValuePicker } from "../InlineValuePicker";

--- a/frontend/src/metabase/query_builder/components/filters/modals/InlineOperatorSelector/InlineOperatorSelector.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/modals/InlineOperatorSelector/InlineOperatorSelector.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useCallback } from "react";
+import React from "react";
 import TippyPopoverWithTrigger from "metabase/components/PopoverWithTrigger/TippyPopoverWithTrigger";
 import Icon from "metabase/components/Icon";
 

--- a/frontend/src/metabase/query_builder/components/filters/modals/InlineOperatorSelector/InlineOperatorSelector.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/modals/InlineOperatorSelector/InlineOperatorSelector.unit.spec.tsx
@@ -1,10 +1,6 @@
 import React from "react";
 
-import {
-  render,
-  screen,
-  waitForElementToBeRemoved,
-} from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import { InlineOperatorSelector } from "./InlineOperatorSelector";

--- a/frontend/src/metabase/query_builder/components/filters/modals/InlineValuePicker/InlineValuePicker.styled.ts
+++ b/frontend/src/metabase/query_builder/components/filters/modals/InlineValuePicker/InlineValuePicker.styled.ts
@@ -1,8 +1,5 @@
 import styled from "@emotion/styled";
-import {
-  space,
-  breakpointMinHeightMedium,
-} from "metabase/styled-components/theme";
+import { space } from "metabase/styled-components/theme";
 import { color } from "metabase/lib/colors";
 
 import NumericInput from "metabase/core/components/NumericInput";

--- a/frontend/src/metabase/query_builder/components/filters/modals/InlineValuePicker/InlineValuePicker.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/modals/InlineValuePicker/InlineValuePicker.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo } from "react";
+import React, { useCallback } from "react";
 import { t } from "ttag";
 
 import FieldValuesWidget from "metabase/components/FieldValuesWidget";

--- a/frontend/src/metabase/query_builder/components/filters/pickers/BooleanPicker/constants.ts
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/BooleanPicker/constants.ts
@@ -1,5 +1,4 @@
 import { t } from "ttag";
-import { RadioOption } from "metabase/core/components/Radio/Radio";
 
 export const OPTIONS = [
   { name: t`True`, value: true },

--- a/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/RelativeDatePicker.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/RelativeDatePicker.styled.tsx
@@ -1,5 +1,5 @@
 import styled from "@emotion/styled";
-import { alpha, color } from "metabase/lib/colors";
+import { color } from "metabase/lib/colors";
 import { space } from "metabase/styled-components/theme";
 
 import Button from "metabase/core/components/Button";

--- a/frontend/src/metabase/query_builder/components/filters/pickers/DefaultPicker.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DefaultPicker.styled.tsx
@@ -1,5 +1,4 @@
 import styled from "@emotion/styled";
-import { css } from "@emotion/react";
 import { color } from "metabase/lib/colors";
 
 export const BetweenLayoutContainer = styled.div`

--- a/frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.styled.tsx
@@ -1,5 +1,5 @@
 import styled from "@emotion/styled";
-import { color, lighten, tint, isDark } from "metabase/lib/colors";
+import { color, tint, isDark } from "metabase/lib/colors";
 
 export interface OptionRootProps {
   isSelected?: boolean;

--- a/frontend/src/metabase/questions/actions.ts
+++ b/frontend/src/metabase/questions/actions.ts
@@ -1,5 +1,3 @@
-import _ from "underscore";
-
 import { loadMetadataForQueries } from "metabase/redux/metadata";
 import { getMetadata } from "metabase/selectors/metadata";
 

--- a/frontend/src/metabase/selectors/data.unit.spec.ts
+++ b/frontend/src/metabase/selectors/data.unit.spec.ts
@@ -1,4 +1,3 @@
-import { State } from "metabase-types/store";
 import { createMockState } from "metabase-types/store/mocks";
 import { createMockDatabase } from "metabase-types/api/mocks";
 import {

--- a/frontend/src/metabase/sharing/components/AddEditSidebar/CaveatMessage.styled.tsx
+++ b/frontend/src/metabase/sharing/components/AddEditSidebar/CaveatMessage.styled.tsx
@@ -1,5 +1,4 @@
 import styled from "@emotion/styled";
-import { css } from "@emotion/react";
 import { color, alpha } from "metabase/lib/colors";
 import Text from "metabase/components/type/Text";
 

--- a/frontend/src/metabase/static-viz/components/Gauge/GaugeContainer.tsx
+++ b/frontend/src/metabase/static-viz/components/Gauge/GaugeContainer.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment } from "react";
+import React from "react";
 
 import { formatNumber } from "metabase/static-viz/lib/numbers";
 import { truncateText } from "metabase/static-viz/lib/text";

--- a/frontend/src/metabase/static-viz/components/LineAreaBarChart/utils/settings.unit.spec.ts
+++ b/frontend/src/metabase/static-viz/components/LineAreaBarChart/utils/settings.unit.spec.ts
@@ -1,4 +1,3 @@
-import _ from "underscore";
 import { ChartSettings } from "../../XYChart/types";
 import { adjustSettings } from "./settings";
 

--- a/frontend/src/metabase/static-viz/components/XYChart/shapes/LineArea.tsx
+++ b/frontend/src/metabase/static-viz/components/XYChart/shapes/LineArea.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { Area, LinePath } from "@visx/shape";
 import { AccessorForArrayItem, PositionScale } from "@visx/shape/lib/types";
-import { StackedDatum } from "../types";
 
 interface AreaProps<Datum> {
   x: AccessorForArrayItem<Datum, number>;

--- a/frontend/src/metabase/timelines/collections/containers/TimelineDetailsModal/TimelineDetailsModal.tsx
+++ b/frontend/src/metabase/timelines/collections/containers/TimelineDetailsModal/TimelineDetailsModal.tsx
@@ -4,7 +4,7 @@ import _ from "underscore";
 import * as Urls from "metabase/lib/urls";
 import Timelines from "metabase/entities/timelines";
 import TimelineEvents from "metabase/entities/timeline-events";
-import { Collection, Timeline, TimelineEvent } from "metabase-types/api";
+import { Timeline, TimelineEvent } from "metabase-types/api";
 import { State } from "metabase-types/store";
 import TimelineDetailsModal from "../../components/TimelineDetailsModal";
 import LoadingAndErrorWrapper from "../../components/LoadingAndErrorWrapper";

--- a/frontend/src/metabase/timelines/questions/components/TimelinePanel/TimelinePanel.styled.tsx
+++ b/frontend/src/metabase/timelines/questions/components/TimelinePanel/TimelinePanel.styled.tsx
@@ -1,5 +1,4 @@
 import styled from "@emotion/styled";
-import { color } from "metabase/lib/colors";
 
 export const PanelRoot = styled.div`
   margin: 0 1.5rem;

--- a/frontend/src/metabase/visualizations/components/ChartSettingsWidgetList.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/ChartSettingsWidgetList.styled.tsx
@@ -2,8 +2,6 @@ import styled from "@emotion/styled";
 
 import { color } from "metabase/lib/colors";
 
-import ChartSettingsWidget from "./ChartSettingsWidget";
-
 export const ChartSettingsWidgetListHeader = styled.h4`
   margin-left: 2rem;
   margin-bottom: 1rem;

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.styled.tsx
@@ -3,7 +3,6 @@ import { color } from "metabase/lib/colors";
 import Icon from "metabase/components/Icon";
 import SelectButton from "metabase/core/components/SelectButton";
 import Triggerable from "metabase/components/Triggerable";
-import ColorPill from "metabase/core/components/ColorPill";
 import ChartSettingColorPicker from "./ChartSettingColorPicker";
 
 interface ChartSettingFieldPickerRootProps {

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPartition.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPartition.styled.tsx
@@ -1,5 +1,5 @@
 import styled from "@emotion/styled";
-import { color, lighten } from "metabase/lib/colors";
+import { color } from "metabase/lib/colors";
 import ColumnItem from "./ColumnItem";
 
 interface FieldPartitionColumnProps {

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPicker.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPicker.styled.tsx
@@ -1,5 +1,4 @@
 import styled from "@emotion/styled";
-import { color } from "metabase/lib/colors";
 
 export const AddAnotherContainer = styled.div`
   margin-top: 1rem;

--- a/frontend/src/metabase/visualizations/components/settings/ColumnItem.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ColumnItem.styled.tsx
@@ -2,7 +2,6 @@ import styled from "@emotion/styled";
 import { color } from "metabase/lib/colors";
 
 import Icon from "metabase/components/Icon";
-import ColorPill from "metabase/core/components/ColorPill";
 import ChartSettingColorPicker from "./ChartSettingColorPicker";
 
 interface ColumnItemRootProps {

--- a/frontend/src/metabase/visualizations/components/skeletons/SmartScalarSkeleton/SmartScalarSkeleton.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/skeletons/SmartScalarSkeleton/SmartScalarSkeleton.styled.tsx
@@ -1,5 +1,4 @@
 import styled from "@emotion/styled";
-import { color } from "metabase/lib/colors";
 import SkeletonCaption from "metabase/visualizations/components/skeletons/SkeletonCaption/SkeletonCaption";
 import { containerStyles, animationStyles } from "../Skeleton";
 

--- a/frontend/src/metabase/visualizations/shared/components/RowChart/RowChart.tsx
+++ b/frontend/src/metabase/visualizations/shared/components/RowChart/RowChart.tsx
@@ -1,6 +1,5 @@
 import React, { useMemo } from "react";
 
-import _ from "underscore";
 import type { NumberValue } from "d3-scale";
 
 import { TextMeasurer } from "metabase/visualizations/shared/types/measure-text";

--- a/frontend/src/metabase/visualizations/shared/components/RowChart/utils/layout.ts
+++ b/frontend/src/metabase/visualizations/shared/components/RowChart/utils/layout.ts
@@ -1,5 +1,3 @@
-import _ from "underscore";
-
 import type { ScaleContinuousNumeric } from "d3-scale";
 import { TextMeasurer } from "metabase/visualizations/shared/types/measure-text";
 import { Margin } from "metabase/visualizations/shared/types/layout";
@@ -9,7 +7,7 @@ import {
 } from "metabase/visualizations/shared/types/style";
 import { ChartGoal } from "metabase/visualizations/shared/types/settings";
 import { LABEL_PADDING } from "../constants";
-import { Series, SeriesData } from "../types";
+import { SeriesData } from "../types";
 
 const CHART_PADDING = 10;
 const TICKS_OFFSET = 10;

--- a/frontend/src/metabase/visualizations/shared/components/RowChart/utils/scale.ts
+++ b/frontend/src/metabase/visualizations/shared/components/RowChart/utils/scale.ts
@@ -14,7 +14,7 @@ import {
 } from "metabase/visualizations/shared/types/scale";
 import { ChartFont } from "metabase/visualizations/shared/types/style";
 import { DATA_LABEL_OFFSET } from "../../RowChartView";
-import { SeriesData, StackOffset, YValue } from "../types";
+import { SeriesData, StackOffset } from "../types";
 import { createXDomain, createYDomain } from "./domain";
 
 export const createXScale = (

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTable.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTable.tsx
@@ -54,7 +54,6 @@ import {
   leftHeaderCellSizeAndPositionGetter,
   topHeaderCellSizeAndPositionGetter,
   getCellWidthsForSection,
-  getWidthForRange,
 } from "./utils";
 
 import {
@@ -92,7 +91,6 @@ function PivotTable({
 }: PivotTableProps) {
   const [gridElement, setGridElement] = useState<HTMLElement | null>(null);
   const columnWidthSettings = settings["pivot_table.column_widths"];
-  const previousColumnWidthSettings = usePrevious(columnWidthSettings);
 
   const [
     { leftHeaderWidths, totalLeftHeaderWidths, valueHeaderWidths },

--- a/package.json
+++ b/package.json
@@ -301,7 +301,7 @@
     "precommit": "lint-staged",
     "preinstall": "echo $npm_execpath | grep -q yarn || echo '\\033[0;33mSorry, npm is not supported. Please use Yarn (https://yarnpkg.com/).\\033[0m'",
     "prettier": "prettier --write '{enterprise/,}frontend/**/*.{js,jsx,ts,tsx,css}'",
-    "eslint-fix": "yarn && eslint --fix --ext .js,.jsx,.ts,.tsx --rulesdir frontend/lint/eslint-rules {enterprise/,}frontend/{src,test}",
+    "eslint-fix": "yarn lint-eslint --fix",
     "ci": "yarn ci-frontend && yarn ci-backend",
     "ci-frontend": "yarn lint && yarn test",
     "ci-backend": "clojure -X:dev:ee:ee-dev:drivers:drivers-dev:eastwood && clojure -X:dev:test",


### PR DESCRIPTION
## Motivation
There have been too many occurrences where we forgot to remove unused imports and variables in TypeScript files. I'm not totally sure why we haven't set this up earlier. We already have this set up for JavaScript but never TypeScript for some reason.

## How to verify
1. Run Metabase locally and everything should work the same.
