### PR TITLE
Fix ObjectDrill on queries with joined tables

### DIFF
--- a/frontend/src/metabase-lib/types/utils/isa.js
+++ b/frontend/src/metabase-lib/types/utils/isa.js
@@ -1,4 +1,5 @@
 import { isa as cljs_isa } from "cljs/metabase.types";
+import { isVirtualCardId } from "metabase-lib/metadata/utils/saved-questions";
 
 import {
   TYPE,
@@ -208,3 +209,13 @@ export function hasLatitudeAndLongitudeColumns(cols) {
   }
   return hasLatitude && hasLongitude;
 }
+
+export const getIsPKFromTablePredicate = tableId => column => {
+  const isPrimaryKey = isPK(column);
+
+  // FIXME: columns of nested questions at this moment miss table_id value
+  // which makes it impossible to match them with their tables that are nested cards
+  return isVirtualCardId(tableId)
+    ? isPrimaryKey
+    : isPrimaryKey && column.table_id === tableId;
+};

--- a/frontend/src/metabase/query_builder/selectors.js
+++ b/frontend/src/metabase/query_builder/selectors.js
@@ -37,7 +37,7 @@ import {
   normalizeParameters,
   normalizeParameterValue,
 } from "metabase-lib/parameters/utils/parameter-values";
-import { isPK } from "metabase-lib/types/utils/isa";
+import { getIsPKFromTablePredicate } from "metabase-lib/types/utils/isa";
 import Mode from "metabase-lib/Mode";
 import NativeQuery from "metabase-lib/queries/NativeQuery";
 import Question from "metabase-lib/Question";
@@ -139,18 +139,25 @@ export const getFirstQueryResult = createSelector([getQueryResults], results =>
   Array.isArray(results) ? results[0] : null,
 );
 
+export const getTableId = createSelector([getCard], card =>
+  getIn(card, ["dataset_query", "query", "source-table"]),
+);
+
 export const getPKColumnIndex = createSelector(
-  [getFirstQueryResult],
-  result => {
+  [getFirstQueryResult, getTableId],
+  (result, tableId) => {
     if (!result) {
       return;
     }
     const { cols } = result.data;
-    const hasMultiplePks = cols.filter(isPK).length > 1;
+
+    const hasMultiplePks =
+      cols.filter(getIsPKFromTablePredicate(tableId)).length > 1;
+
     if (hasMultiplePks) {
       return -1;
     }
-    return cols.findIndex(isPK);
+    return cols.findIndex(getIsPKFromTablePredicate(tableId));
   },
 );
 
@@ -180,10 +187,6 @@ export const getQueryStartTime = state => state.qb.queryStartTime;
 export const getDatabaseId = createSelector(
   [getCard],
   card => card && card.dataset_query && card.dataset_query.database,
-);
-
-export const getTableId = createSelector([getCard], card =>
-  getIn(card, ["dataset_query", "query", "source-table"]),
 );
 
 export const getTableForeignKeyReferences = state =>

--- a/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetail.tsx
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetail.tsx
@@ -55,11 +55,12 @@ import {
 } from "./ObjectDetail.styled";
 
 const mapStateToProps = (state: State, { data }: ObjectDetailProps) => {
+  const table = getTableMetadata(state);
   let zoomedRowID = getZoomedObjectId(state);
   const isZooming = zoomedRowID != null;
 
   if (!isZooming) {
-    zoomedRowID = getIdValue({ data });
+    zoomedRowID = getIdValue({ data, tableId: table?.id });
   }
 
   const zoomedRow = isZooming ? getZoomRow(state) : getSingleResultsRow(data);
@@ -70,7 +71,7 @@ const mapStateToProps = (state: State, { data }: ObjectDetailProps) => {
     // FIXME: remove the non-null assertion operator
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     question: getQuestion(state)!,
-    table: getTableMetadata(state),
+    table,
     // FIXME: remove the type cast
     tableForeignKeys: getTableForeignKeys(state) as ForeignKey[],
     tableForeignKeyReferences: getTableForeignKeyReferences(state),
@@ -243,7 +244,12 @@ export function ObjectDetailFn({
     zoomedRow,
   });
 
-  const displayId = getDisplayId({ cols: data.cols, zoomedRow });
+  const displayId = getDisplayId({
+    cols: data.cols,
+    zoomedRow,
+    tableId: table?.id,
+  });
+
   const hasPk = !!data.cols.find(isPK);
   const hasRelationships =
     showRelations && !!(tableForeignKeys && !!tableForeignKeys.length && hasPk);

--- a/frontend/src/metabase/visualizations/components/ObjectDetail/utils.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/utils.unit.spec.ts
@@ -2,6 +2,7 @@ import {
   metadata,
   SAMPLE_DATABASE,
   ORDERS,
+  PRODUCTS,
 } from "__support__/sample_database_fixture";
 
 import { Card } from "metabase-types/types/Card";
@@ -25,12 +26,21 @@ const card = {
 } as Card;
 
 describe("ObjectDetail utils", () => {
+  const productIdCol = {
+    name: "product_id",
+    display_name: "Product ID",
+    base_type: "int",
+    effective_type: "int",
+    semantic_type: "type/PK",
+    table_id: PRODUCTS.id,
+  };
   const idCol = {
     name: "id",
     display_name: "ID",
     base_type: "int",
     effective_type: "int",
     semantic_type: "type/PK",
+    table_id: ORDERS.id,
   };
   const qtyCol = {
     name: "qty",
@@ -38,6 +48,7 @@ describe("ObjectDetail utils", () => {
     base_type: "int",
     effective_type: "int",
     semantic_type: "type/int",
+    table_id: ORDERS.id,
   };
   const nameCol = {
     name: "id",
@@ -45,6 +56,7 @@ describe("ObjectDetail utils", () => {
     base_type: "string",
     effective_type: "string",
     semantic_type: "type/Name",
+    table_id: ORDERS.id,
   };
 
   describe("getObjectName", () => {
@@ -103,10 +115,11 @@ describe("ObjectDetail utils", () => {
   });
 
   describe("getDisplayId", () => {
-    it("should get a display id when there is a single primary key column", () => {
+    it("should get a display id when there is a single primary key column in the table", () => {
       const id = getDisplayId({
-        cols: [idCol, qtyCol, nameCol],
-        zoomedRow: [22, 33, "Giant Sprocket"],
+        cols: [productIdCol, idCol, qtyCol, nameCol],
+        zoomedRow: [11, 22, 33, "Giant Sprocket"],
+        tableId: ORDERS.id,
       });
 
       expect(id).toBe(22);
@@ -136,12 +149,13 @@ describe("ObjectDetail utils", () => {
     it("should return the primary key of the first row if now zoomed row id exists", () => {
       const id = getIdValue({
         data: {
-          cols: [idCol, qtyCol, nameCol],
+          cols: [productIdCol, idCol, qtyCol, nameCol],
           rows: [
-            [22, 33, "Giant Sprocket"],
-            [44, 55, "Tiny Sprocket"],
+            [11, 22, 33, "Giant Sprocket"],
+            [33, 44, 55, "Tiny Sprocket"],
           ],
         },
+        tableId: ORDERS.id,
       });
 
       expect(id).toBe(22);

--- a/frontend/src/metabase/visualizations/components/ObjectDetail/utils.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/utils.unit.spec.ts
@@ -132,21 +132,6 @@ describe("ObjectDetail utils", () => {
   });
 
   describe("getIdValue", () => {
-    it("should return the zoomed Row id if present", () => {
-      const id = getIdValue({
-        data: {
-          cols: [idCol, qtyCol, nameCol],
-          rows: [
-            [22, 33, "Giant Sprocket"],
-            [44, 55, "Tiny Sprocket"],
-          ],
-        },
-        zoomedRowID: 1,
-      });
-
-      expect(id).toBe(1);
-    });
-
     // this code should no longer be reachable now that we always reach object detail by zooming
     it("should return the primary key of the first row if now zoomed row id exists", () => {
       const id = getIdValue({


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/27094
Reproduces https://github.com/metabase/metabase/issues/27094

### Description

Joined questions with 1 PK from the source table and >0 PK from the joined table did show the correct ObjectDetail view when the PK from the source table got clicked. The previous logic ignored to which tables PKs belong so it considered that the row cannot be identified by a single value since there are multiple PKs even though there is only a single PK in the source table.

This PR adds consideration of table columns when searching for primary keys.
- https://github.com/metabase/metabase/pull/28076/files#diff-2fc40467e8370b516c4ce51320cd4d159278808493231640527a65f51d06e65aR154
- https://github.com/metabase/metabase/pull/28076/files#diff-d398b83ed4884463296bff30877810bde5f8c222529606d995616d088918dcd2R58

#### Related but not fixed here issues

The following issues did exist before and this PR does not fix them:

- Columns from nested queries do not have table_id set which should be `card__*number*` in this case so joining nested questions still hasn't been fixed
- Clicking on PK of a joined table does not work correctly. On `master` it uses the joined table PK value for the source table PK which was completely wrong

### How to verify

1. New question -> Sample Dataset -> Orders join Products
2. Click visualize
3. Click on the `ID` column of the Orders table and ensure the object detail is correct
4. You can try doing so with UUID columns as it is described in the original issue but is no different

### Checklist

- [x] Tests have been added/updated to cover changes in this PR

### Demo

<video src="https://user-images.githubusercontent.com/14301985/216737640-9b4db8d8-d8fd-4ab3-9e31-b75e55e89e8e.mov" />
