### PR TITLE
add sandbox tests for api/dataset/parameter

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/sandbox/api/card_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/api/card_test.clj
@@ -66,11 +66,22 @@
                 :table_id        (mt/id :venues)}]]
 
         (testing "when getting values"
-          (is (=? {:values          ["African" "American" "Artisan"]
-                   :has_more_values false}
-                  (mt/user-http-request :rasta :get 200 (api.card-test/param-values-url card-id "abc")))))
+          (let [get-values (fn [user]
+                             (mt/user-http-request user :get 200 (api.card-test/param-values-url card-id "abc")))]
+            ;; returns much more if not sandboxed
+            (is (> (-> (get-values :crowberto) :values count) 3))
+            (is (=? {:values          ["African" "American" "Artisan"]
+                     :has_more_values false}
+                    (get-values :rasta)))))
 
         (testing "when searching values"
-          (is (= {:values          []
-                  :has_more_values false}
-                 (mt/user-http-request :rasta :get 200 (api.card-test/param-values-url card-id "abc" "red")))))))))
+          ;; return BBQ if not sandboxed
+          (let [search (fn [user]
+                         (mt/user-http-request user :get 200 (api.card-test/param-values-url card-id "abc" "bbq")))]
+            (is (=? {:values          ["BBQ"]
+                     :has_more_values false}
+                    (search :crowberto)))
+
+            (is (=? {:values          []
+                     :has_more_values false}
+                    (search :rasta)))))))))

--- a/enterprise/backend/test/metabase_enterprise/sandbox/api/dashboard_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/api/dashboard_test.clj
@@ -81,13 +81,22 @@
                                                           :value_field (mt/$ids $categories.name)}}]}]]
 
         (testing "when getting values"
-          (api.dashboard-test/let-url [url (api.dashboard-test/chain-filter-values-url dashboard-id "abc")]
+          (let [get-values (fn [user]
+                             (mt/user-http-request user :get 200 (api.dashboard-test/chain-filter-values-url dashboard-id "abc")))]
+
+            (is (> (-> (get-values :crowberto) :values count) 3))
             (is (= {:values          ["African" "American" "Artisan"]
                     :has_more_values false}
-                   (mt/user-http-request :rasta :get 200 url)))))
+                   (get-values :rasta)))))
+
 
         (testing "when search values"
-          (api.dashboard-test/let-url [url (api.dashboard-test/chain-filter-search-url dashboard-id "abc" "red")]
+          (let [search (fn [user]
+                         (mt/user-http-request user :get 200 (api.dashboard-test/chain-filter-search-url dashboard-id "abc" "bbq")))]
+            (is (= {:values          ["BBQ"]
+                    :has_more_values false}
+                   (search :crowberto)))
+
             (is (= {:values          []
                     :has_more_values false}
-                   (mt/user-http-request :rasta :get 200 url)))))))))
+                   (search :rasta)))))))))

--- a/enterprise/backend/test/metabase_enterprise/sandbox/api/dataset_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/api/dataset_test.clj
@@ -1,0 +1,83 @@
+(ns metabase-enterprise.sandbox.api.dataset-test
+  (:require
+    [clojure.test :refer :all]
+    [metabase-enterprise.test :as met]
+    [metabase.models :refer [Card]]
+    [metabase.test :as mt]))
+
+(deftest dataset-parameter-test
+  (testing "POST /api/dataset/parameter/values should follow sandbox rules"
+    (met/with-gtaps {:gtaps {:categories {:query (mt/mbql-query categories {:filter [:<= $id 3]})}}}
+      (testing "with values_source_type=card"
+        (mt/with-temp*
+          [Card [{source-card-id :id}
+                 {:database_id   (mt/id)
+                  :table_id      (mt/id :categories)
+                  :dataset_query (mt/mbql-query categories)}]]
+
+          (testing "when getting values"
+            (let [get-values (fn [user]
+                               (mt/user-http-request user :post 200 "/dataset/parameter/values"
+                                 {:parameter {:id                   "abc"
+                                              :type                 "category"
+                                              :name                 "CATEGORY"
+                                              :values_source_type   "card"
+                                              :values_source_config {:card_id     source-card-id
+                                                                     :value_field (mt/$ids $categories.name)}}}))]
+
+              ;; returns much more if not sandboxed
+              (is (> (-> (get-values :crowberto) :values count) 3))
+              (is (=? {:values          ["African" "American" "Artisan"]
+                       :has_more_values false}
+                      (get-values :rasta)))))
+
+          (testing "when searching values"
+            (let [search (fn [user]
+                           (mt/user-http-request user :post 200 "/dataset/parameter/search/BBQ"
+                                                 {:parameter {:id                   "abc"
+                                                              :type                 "category"
+                                                              :name                 "CATEGORY"
+                                                              :values_source_type   "card"
+                                                              :values_source_config {:card_id     source-card-id
+                                                                                     :value_field (mt/$ids $categories.name)}}}))]
+
+              ;; returns `BBQ` if not sandboxed
+              (is (=? {:values          ["BBQ"]
+                       :has_more_values false}
+                      (search :crowberto)))
+
+              (is (=? {:values          []
+                        :has_more_values false}
+                      (search :rasta)))))))
+
+      (testing "values_source_type=nil (values from fields)"
+        (testing "when getting values"
+          (let [get-values (fn [user]
+                             (mt/user-http-request user :post 200 "/dataset/parameter/values"
+                                                   {:parameter {:id                 "abc"
+                                                                :type               "category"
+                                                                :name               "CATEGORY"
+                                                                :values_source_type nil}
+                                                    :field_ids [(mt/id :categories :name)]}))]
+
+            ;; returns much more if not sandboxed
+            (is (> (-> (get-values :crowberto) :values count) 3))
+            (is (=? {:values          [["Artisan"] ["African"] ["American"]]
+                     :has_more_values false}
+                    (get-values :rasta)))))
+
+        (testing "when searching values"
+          (let [search (fn [user]
+                         (mt/user-http-request user :post 200 "/dataset/parameter/search/BBQ"
+                                               {:parameter {:id                 "abc"
+                                                            :type               "category"
+                                                            :name               "CATEGORY"
+                                                            :values_source_type nil}
+                                                :field_ids [(mt/id :categories :name)]}))]
+
+            ;; returns `BBQ` if not sandboxed
+            (is (=? {:values [["BBQ"]]}
+                    (search :crowberto)))
+
+            (is (=? {:values          []}
+                    (search :rasta)))))))))


### PR DESCRIPTION
The APIs `api/dataset/parameter` and `api/dataset/parameter/search` was added in https://github.com/metabase/metabase/pull/27938, but we didn't have tests for sandbox if the source is a card and getting field values.

This PR adds tests for those cases

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/28088)
<!-- Reviewable:end -->
