### PR TITLE
Preselect models data bucket in DataSelector for joins in Notebook

### DIFF
--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelector.jsx
@@ -248,7 +248,7 @@ export class UnconnectedDataSelector extends Component {
   }
 
   static propTypes = {
-    selectedDataBucketId: PropTypes.number,
+    selectedDataBucketId: PropTypes.string,
     selectedDatabaseId: PropTypes.number,
     selectedSchemaId: PropTypes.string,
     selectedTableId: PropTypes.number,
@@ -436,6 +436,10 @@ export class UnconnectedDataSelector extends Component {
       await this.hydrateActiveStep();
     }
 
+    if (this.props.selectedDataBucketId === DATA_BUCKET.DATASETS) {
+      this.showSavedQuestionPicker();
+    }
+
     if (this.props.selectedTableId) {
       await this.props.fetchFields(this.props.selectedTableId);
       if (this.isSavedQuestionSelected()) {
@@ -534,7 +538,11 @@ export class UnconnectedDataSelector extends Component {
 
   async hydrateActiveStep() {
     const { steps } = this.props;
-    if (this.isSavedQuestionSelected()) {
+    if (
+      this.isSavedQuestionSelected() ||
+      this.state.selectedDataBucketId === DATA_BUCKET.DATASETS ||
+      this.state.selectedDataBucketId === DATA_BUCKET.SAVED_QUESTIONS
+    ) {
       await this.switchToStep(DATABASE_STEP);
     } else if (this.state.selectedTableId && steps.includes(FIELD_STEP)) {
       await this.switchToStep(FIELD_STEP);

--- a/frontend/src/metabase/query_builder/components/notebook/Notebook.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/Notebook.tsx
@@ -1,23 +1,32 @@
-/* eslint-disable react/prop-types */
 import React from "react";
-
 import { t } from "ttag";
-
 import Button from "metabase/core/components/Button";
-
+import Question from "metabase-lib/Question";
 import NotebookSteps from "./NotebookSteps";
 import { NotebookRoot } from "./Notebook.styled";
 
-export default function Notebook({ className, ...props }) {
+interface NotebookProps {
+  className?: string;
+  question: Question;
+  isDirty: boolean;
+  isRunnable: boolean;
+  isResultDirty: boolean;
+  hasVisualizeButton?: boolean;
+  updateQuestion: (question: Question) => void;
+  runQuestionQuery: () => void;
+  setQueryBuilderMode: (mode: string) => void;
+}
+
+const Notebook = ({ className, ...props }: NotebookProps) => {
   const {
     question,
     isDirty,
     isRunnable,
     isResultDirty,
+    hasVisualizeButton = true,
+    updateQuestion,
     runQuestionQuery,
     setQueryBuilderMode,
-    updateQuestion,
-    hasVisualizeButton = true,
   } = props;
 
   // When switching out of the notebook editor, cleanupQuestion accounts for
@@ -55,4 +64,6 @@ export default function Notebook({ className, ...props }) {
       )}
     </NotebookRoot>
   );
-}
+};
+
+export default Notebook;

--- a/frontend/src/metabase/query_builder/components/notebook/Notebook.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/Notebook.tsx
@@ -4,10 +4,8 @@ import { t } from "ttag";
 import _ from "underscore";
 import Button from "metabase/core/components/Button";
 import Questions from "metabase/entities/questions";
-import Collections from "metabase/entities/collections";
 import { getMetadata } from "metabase/selectors/metadata";
-import { coerceCollectionId } from "metabase/collections/utils";
-import { Card, Collection } from "metabase-types/api";
+import { Card } from "metabase-types/api";
 import { State } from "metabase-types/store";
 import Question from "metabase-lib/Question";
 import StructuredQuery from "metabase-lib/queries/StructuredQuery";
@@ -34,18 +32,11 @@ interface NotebookCardProps {
   sourceCard?: Card;
 }
 
-interface NotebookCollectionProps {
-  sourceCollection?: Collection;
-}
-
 interface NotebookStateProps {
   sourceQuestion?: Question;
 }
 
-type NotebookProps = NotebookOwnProps &
-  NotebookCardProps &
-  NotebookCollectionProps &
-  NotebookStateProps;
+type NotebookProps = NotebookOwnProps & NotebookCardProps & NotebookStateProps;
 
 const Notebook = ({ className, ...props }: NotebookProps) => {
   const {
@@ -106,10 +97,6 @@ function getSourceCardId(question: Question) {
   }
 }
 
-function getSourceCollectionId(sourceCard?: Card) {
-  return coerceCollectionId(sourceCard?.collection_id);
-}
-
 function mapStateToProps(
   state: State,
   { sourceCard }: NotebookCardProps,
@@ -124,12 +111,6 @@ export default _.compose(
     id: (state: State, { question }: NotebookOwnProps) =>
       getSourceCardId(question),
     entityAlias: "sourceCard",
-    loadingAndErrorWrapper: false,
-  }),
-  Collections.load({
-    id: (state: State, { sourceCard }: NotebookCardProps) =>
-      getSourceCollectionId(sourceCard),
-    entityAlias: "sourceCollection",
     loadingAndErrorWrapper: false,
   }),
   connect(mapStateToProps),

--- a/frontend/src/metabase/query_builder/components/notebook/Notebook.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/Notebook.tsx
@@ -1,11 +1,25 @@
 import React from "react";
+import { connect } from "react-redux";
 import { t } from "ttag";
+import _ from "underscore";
 import Button from "metabase/core/components/Button";
+import Questions from "metabase/entities/questions";
+import Collections from "metabase/entities/collections";
+import { coerceCollectionId } from "metabase/collections/utils";
+import { DATA_BUCKET } from "metabase/query_builder/components/DataSelector/constants";
+import { Card, Collection } from "metabase-types/api";
+import { State } from "metabase-types/store";
 import Question from "metabase-lib/Question";
+import StructuredQuery from "metabase-lib/queries/StructuredQuery";
+import {
+  getCollectionVirtualSchemaId,
+  getQuestionIdFromVirtualTableId,
+  isVirtualCardId,
+} from "metabase-lib/metadata/utils/saved-questions";
 import NotebookSteps from "./NotebookSteps";
 import { NotebookRoot } from "./Notebook.styled";
 
-interface NotebookProps {
+interface NotebookOwnProps {
   className?: string;
   question: Question;
   isDirty: boolean;
@@ -16,6 +30,24 @@ interface NotebookProps {
   runQuestionQuery: () => void;
   setQueryBuilderMode: (mode: string) => void;
 }
+
+interface NotebookCardProps {
+  card?: Card;
+}
+
+interface NotebookCollectionProps {
+  collection?: Collection;
+}
+
+interface NotebookStateProps {
+  sourceDataBucketId?: string;
+  sourceSchemaId?: string;
+}
+
+type NotebookProps = NotebookOwnProps &
+  NotebookCardProps &
+  NotebookCollectionProps &
+  NotebookStateProps;
 
 const Notebook = ({ className, ...props }: NotebookProps) => {
   const {
@@ -66,4 +98,39 @@ const Notebook = ({ className, ...props }: NotebookProps) => {
   );
 };
 
-export default Notebook;
+const getSourceCardId = (question: Question) => {
+  const query = question.query();
+  if (query instanceof StructuredQuery) {
+    const sourceTableId = query.sourceTableId();
+    if (isVirtualCardId(sourceTableId)) {
+      return getQuestionIdFromVirtualTableId(sourceTableId);
+    }
+  }
+};
+
+const getSourceCollectionId = (card?: Card) => {
+  return coerceCollectionId(card?.collection_id);
+};
+
+const mapStateToProps = (
+  state: State,
+  { card, collection }: NotebookCardProps & NotebookCollectionProps,
+): NotebookStateProps => ({
+  sourceDataBucketId: card?.dataset ? DATA_BUCKET.DATASETS : undefined,
+  sourceSchemaId: collection && getCollectionVirtualSchemaId(collection),
+});
+
+export default _.compose(
+  Questions.load({
+    id: (state: State, { question }: NotebookOwnProps) =>
+      getSourceCardId(question),
+    loadingAndErrorWrapper: false,
+    entityAlias: "card",
+  }),
+  Collections.load({
+    id: (state: State, { card }: NotebookCardProps) =>
+      getSourceCollectionId(card),
+    loadingAndErrorWrapper: false,
+  }),
+  connect(mapStateToProps),
+)(Notebook);

--- a/frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx
@@ -119,7 +119,6 @@ export default class NotebookStep extends React.Component {
       updateQuery,
       reportTimezone,
       sourceQuestion,
-      sourceCollection,
     } = this.props;
     const { showPreview } = this.state;
 
@@ -187,7 +186,6 @@ export default class NotebookStep extends React.Component {
                   step={step}
                   query={step.query}
                   sourceQuestion={sourceQuestion}
-                  sourceCollection={sourceCollection}
                   updateQuery={updateQuery}
                   isLastOpened={isLastOpened}
                   reportTimezone={reportTimezone}

--- a/frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx
@@ -186,7 +186,6 @@ export default class NotebookStep extends React.Component {
                   color={color}
                   step={step}
                   query={step.query}
-                  source
                   sourceQuestion={sourceQuestion}
                   sourceCollection={sourceCollection}
                   updateQuery={updateQuery}

--- a/frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx
@@ -118,6 +118,8 @@ export default class NotebookStep extends React.Component {
       isLastOpened,
       updateQuery,
       reportTimezone,
+      sourceDataBucketId,
+      sourceSchemaId,
     } = this.props;
     const { showPreview } = this.state;
 
@@ -184,6 +186,9 @@ export default class NotebookStep extends React.Component {
                   color={color}
                   step={step}
                   query={step.query}
+                  source
+                  sourceDataBucketId={sourceDataBucketId}
+                  sourceSchemaId={sourceSchemaId}
                   updateQuery={updateQuery}
                   isLastOpened={isLastOpened}
                   reportTimezone={reportTimezone}

--- a/frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/NotebookStep.jsx
@@ -118,8 +118,8 @@ export default class NotebookStep extends React.Component {
       isLastOpened,
       updateQuery,
       reportTimezone,
-      sourceDataBucketId,
-      sourceSchemaId,
+      sourceQuestion,
+      sourceCollection,
     } = this.props;
     const { showPreview } = this.state;
 
@@ -187,8 +187,8 @@ export default class NotebookStep extends React.Component {
                   step={step}
                   query={step.query}
                   source
-                  sourceDataBucketId={sourceDataBucketId}
-                  sourceSchemaId={sourceSchemaId}
+                  sourceQuestion={sourceQuestion}
+                  sourceCollection={sourceCollection}
                   updateQuery={updateQuery}
                   isLastOpened={isLastOpened}
                   reportTimezone={reportTimezone}

--- a/frontend/src/metabase/query_builder/components/notebook/NotebookSteps.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/NotebookSteps.jsx
@@ -42,8 +42,8 @@ export default class NotebookSteps extends React.Component {
       question,
       className,
       reportTimezone,
-      sourceDataBucketId,
-      sourceSchemaId,
+      sourceQuestion,
+      sourceCollection,
       updateQuestion,
     } = this.props;
     const { openSteps, lastOpenedStep } = this.state;
@@ -69,8 +69,8 @@ export default class NotebookSteps extends React.Component {
             <NotebookStep
               key={step.id}
               step={step}
-              sourceDataBucketId={sourceDataBucketId}
-              sourceSchemaId={sourceSchemaId}
+              sourceQuestion={sourceQuestion}
+              sourceCollection={sourceCollection}
               updateQuery={updateQuery}
               openStep={this.openStep}
               closeStep={this.closeStep}

--- a/frontend/src/metabase/query_builder/components/notebook/NotebookSteps.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/NotebookSteps.jsx
@@ -38,7 +38,14 @@ export default class NotebookSteps extends React.Component {
   };
 
   render() {
-    const { question, className, reportTimezone, updateQuestion } = this.props;
+    const {
+      question,
+      className,
+      reportTimezone,
+      sourceDataBucketId,
+      sourceSchemaId,
+      updateQuestion,
+    } = this.props;
     const { openSteps, lastOpenedStep } = this.state;
 
     if (!question) {
@@ -62,6 +69,8 @@ export default class NotebookSteps extends React.Component {
             <NotebookStep
               key={step.id}
               step={step}
+              sourceDataBucketId={sourceDataBucketId}
+              sourceSchemaId={sourceSchemaId}
               updateQuery={updateQuery}
               openStep={this.openStep}
               closeStep={this.closeStep}

--- a/frontend/src/metabase/query_builder/components/notebook/NotebookSteps.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/NotebookSteps.jsx
@@ -43,7 +43,6 @@ export default class NotebookSteps extends React.Component {
       className,
       reportTimezone,
       sourceQuestion,
-      sourceCollection,
       updateQuestion,
     } = this.props;
     const { openSteps, lastOpenedStep } = this.state;
@@ -70,7 +69,6 @@ export default class NotebookSteps extends React.Component {
               key={step.id}
               step={step}
               sourceQuestion={sourceQuestion}
-              sourceCollection={sourceCollection}
               updateQuery={updateQuery}
               openStep={this.openStep}
               closeStep={this.closeStep}

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
@@ -64,6 +64,8 @@ const joinStepPropTypes = {
   color: PropTypes.string,
   isLastOpened: PropTypes.bool,
   updateQuery: PropTypes.func.isRequired,
+  sourceDataBucketId: PropTypes.string,
+  sourceSchemaId: PropTypes.string,
 };
 
 const JOIN_OPERATOR_OPTIONS = [
@@ -81,6 +83,8 @@ export default function JoinStep({
   step,
   updateQuery,
   isLastOpened,
+  sourceDataBucketId,
+  sourceSchemaId,
 }) {
   const isSingleJoinStep = step.itemIndex != null;
   let joins = query.joins();
@@ -110,6 +114,8 @@ export default function JoinStep({
                 showRemove={joins.length > 1}
                 updateQuery={updateQuery}
                 isLastOpened={isLastOpened && isLast}
+                sourceDataBucketId={sourceDataBucketId}
+                sourceSchemaId={sourceSchemaId}
               />
             </JoinClauseContainer>
           );
@@ -131,11 +137,20 @@ JoinStep.propTypes = joinStepPropTypes;
 const joinClausePropTypes = {
   color: PropTypes.string,
   join: PropTypes.object,
-  updateQuery: PropTypes.func,
+  sourceSchemaId: PropTypes.string,
+  sourceDataBucketId: PropTypes.string,
   showRemove: PropTypes.bool,
+  updateQuery: PropTypes.func,
 };
 
-function JoinClause({ color, join, updateQuery, showRemove }) {
+function JoinClause({
+  color,
+  join,
+  sourceDataBucketId,
+  sourceSchemaId,
+  updateQuery,
+  showRemove,
+}) {
   const joinDimensionPickersRef = useRef([]);
   const parentDimensionPickersRef = useRef([]);
 
@@ -230,6 +245,8 @@ function JoinClause({ color, join, updateQuery, showRemove }) {
           query={query}
           joinedTable={joinedTable}
           color={color}
+          sourceDataBucketId={sourceDataBucketId}
+          sourceSchemaId={sourceSchemaId}
           updateQuery={updateQuery}
           onSourceTableSet={onSourceTableSet}
         />
@@ -394,6 +411,8 @@ const joinTablePickerPropTypes = {
   query: PropTypes.object,
   joinedTable: PropTypes.object,
   color: PropTypes.string,
+  sourceDataBucketId: PropTypes.string,
+  sourceSchemaId: PropTypes.string,
   updateQuery: PropTypes.func,
   onSourceTableSet: PropTypes.func.isRequired,
 };
@@ -403,6 +422,8 @@ function JoinTablePicker({
   query,
   joinedTable,
   color,
+  sourceDataBucketId,
+  sourceSchemaId,
   updateQuery,
   onSourceTableSet,
 }) {
@@ -410,6 +431,8 @@ function JoinTablePicker({
     query.database(),
     query.database().savedQuestionsDatabase(),
   ].filter(Boolean);
+
+  const hasSourceTable = join.joinSourceTableId() != null;
 
   function onChange(tableId) {
     const newJoin = join
@@ -442,10 +465,12 @@ function JoinTablePicker({
         canChangeDatabase={false}
         databases={databases}
         tableFilter={table => table.db_id === query.database().id}
+        selectedDataBucketId={hasSourceTable ? undefined : sourceDataBucketId}
         selectedDatabaseId={query.databaseId()}
+        selectedSchemaId={hasSourceTable ? undefined : sourceSchemaId}
         selectedTableId={join.joinSourceTableId()}
         setSourceTableFn={onChange}
-        isInitiallyOpen={join.joinSourceTableId() == null}
+        isInitiallyOpen={!hasSourceTable}
         triggerElement={
           <FieldPickerContentContainer>
             {joinedTable ? joinedTable.displayName() : t`Pick a table...`}

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
@@ -486,19 +486,14 @@ function JoinTablePicker({
 }
 
 function getDataBucketId(question) {
-  if (!question) {
-    return DATA_BUCKET.RAW_DATA;
-  } else if (question.isDataset()) {
+  if (question && question.isDataset()) {
     return DATA_BUCKET.DATASETS;
-  } else {
-    return DATA_BUCKET.SAVED_QUESTIONS;
   }
 }
 
 function getSchemaId(question, collection) {
-  if (question && collection) {
-    const isDatasets = question.isDataset();
-    return getCollectionVirtualSchemaId(collection, { isDatasets });
+  if (question && question.isDataset() && collection) {
+    return getCollectionVirtualSchemaId(collection, { isDatasets: true });
   }
 }
 

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
@@ -12,34 +12,34 @@ import Select from "metabase/core/components/Select";
 import { isDateTimeField } from "metabase-lib/queries/utils/field-ref";
 import Join from "metabase-lib/queries/structured/Join";
 
-import { NotebookCellItem, NotebookCellAdd } from "../NotebookCell";
+import { NotebookCellAdd, NotebookCellItem } from "../NotebookCell";
 import {
-  FieldsPickerIcon,
   FieldPickerContentContainer,
   FIELDS_PICKER_STYLES,
+  FieldsPickerIcon,
 } from "../FieldsPickerIcon";
 import FieldsPicker from "./FieldsPicker";
 import {
   DimensionContainer,
   DimensionSourceName,
-  JoinStepRoot,
-  JoinClausesContainer,
-  JoinClauseRoot,
   JoinClauseContainer,
-  JoinStrategyIcon,
-  JoinTypeSelectRoot,
-  JoinTypeOptionRoot,
-  JoinTypeIcon,
-  JoinDimensionControlsContainer,
-  JoinWhereConditionLabelContainer,
-  JoinWhereConditionLabel,
+  JoinClauseRoot,
+  JoinClausesContainer,
   JoinConditionLabel,
+  JoinDimensionControlsContainer,
+  JoinOperatorButton,
+  JoinStepRoot,
+  JoinStrategyIcon,
+  JoinTypeIcon,
+  JoinTypeOptionRoot,
+  JoinTypeSelectRoot,
+  JoinWhereConditionLabel,
+  JoinWhereConditionLabelContainer,
+  PrimaryJoinCell,
   RemoveDimensionIcon,
   RemoveJoinIcon,
   Row,
-  PrimaryJoinCell,
   SecondaryJoinCell,
-  JoinOperatorButton,
 } from "./JoinStep.styled";
 
 const stepShape = {
@@ -419,7 +419,10 @@ function JoinTablePicker({
     query.database().savedQuestionsDatabase(),
   ].filter(Boolean);
 
-  const sourceDataBucketId = getDataBucketId(sourceQuestion);
+  const sourceDataBucketId =
+    sourceQuestion != null && sourceQuestion.isDataset()
+      ? DATA_BUCKET.DATASETS
+      : undefined;
   const hasSourceTable = join.joinSourceTableId() != null;
 
   function onChange(tableId) {
@@ -466,16 +469,6 @@ function JoinTablePicker({
       />
     </NotebookCellItem>
   );
-}
-
-function getDataBucketId(question) {
-  if (!question) {
-    return undefined;
-  } else if (question.isDataset()) {
-    return DATA_BUCKET.DATASETS;
-  } else {
-    return DATA_BUCKET.SAVED_QUESTIONS;
-  }
 }
 
 JoinTablePicker.propTypes = joinTablePickerPropTypes;

--- a/frontend/test/__support__/e2e/helpers/e2e-bi-basics-helpers.js
+++ b/frontend/test/__support__/e2e/helpers/e2e-bi-basics-helpers.js
@@ -8,6 +8,10 @@ export function filter({ mode } = {}) {
   initiateAction("Filter", mode);
 }
 
+export function join() {
+  initiateAction("Join", "notebook");
+}
+
 export function filterField(
   fieldName,
   { operator, value, placeholder, order } = {},
@@ -95,6 +99,10 @@ function getIcon(actionType) {
 
     case "Summarize":
       icon = "sum";
+      break;
+
+    case "Join":
+      icon = "join_left_outer";
       break;
 
     default:

--- a/frontend/test/metabase/scenarios/models/models.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/models.cy.spec.js
@@ -257,7 +257,9 @@ describe("scenarios > models", () => {
       });
 
       cy.icon("join_left_outer").click();
-      cy.wait("@schema");
+      selectFromDropdown("Models");
+      selectFromDropdown("Raw Data");
+      selectFromDropdown("Sample Database");
       cy.findAllByRole("option").should("have.length", 4);
       selectFromDropdown("Products");
 

--- a/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
@@ -1,16 +1,17 @@
 import {
   enterCustomColumnDetails,
+  filter,
+  filterField,
   getNotebookStep,
+  join,
   openOrdersTable,
   openProductsTable,
   popover,
   restore,
+  startNewQuestion,
+  summarize,
   visitQuestionAdhoc,
   visualize,
-  summarize,
-  filter,
-  filterField,
-  startNewQuestion,
 } from "__support__/e2e/helpers";
 
 import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
@@ -372,6 +373,32 @@ describe("scenarios > question > notebook", () => {
     filterField("Min of Vendor", {
       operator: "ends with",
     });
+  });
+
+  it("should prompt to join with a model if the question is based on a model", () => {
+    cy.createQuestion({
+      name: "Products model",
+      query: { "source-table": PRODUCTS_ID },
+      dataset: true,
+      display: "table",
+    });
+
+    cy.createQuestion({
+      name: "Orders model",
+      query: { "source-table": ORDERS_ID },
+      dataset: true,
+      display: "table",
+    });
+
+    startNewQuestion();
+    popover().findByText("Models").click();
+    popover().findByText("Products model").click();
+    join();
+    popover().findByText("Orders model").click();
+    popover().findByText("ID").click();
+    popover().findByText("Product ID").click();
+
+    visualize();
   });
 
   // flaky test


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/27101

How to verify:
- New -> Question
- Pick a model
- Join -> You should be prompted to select another model instantly 
- It only preselects the bucket (e.g. Models) and not the collection currently

<img width="870" alt="Screenshot 2023-02-06 at 14 22 48" src="https://user-images.githubusercontent.com/8542534/216970344-7c1890bc-e85b-464c-a544-cf39408b5c60.png">

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/28089)
<!-- Reviewable:end -->
