### PR TITLE
Category filters should always be multi-selectable

### DIFF
--- a/frontend/src/metabase-lib/parameters/constants.ts
+++ b/frontend/src/metabase-lib/parameters/constants.ts
@@ -160,7 +160,7 @@ export const SINGLE_OR_MULTI_SELECTABLE_TYPES: Record<
   string | string[]
 > = {
   string: ["=", "!="],
-  category: ["=", "!="],
+  category: "any",
   id: "any",
   location: ["=", "!="],
 };

--- a/frontend/src/metabase/parameters/utils/parameter-type.unit.spec.ts
+++ b/frontend/src/metabase/parameters/utils/parameter-type.unit.spec.ts
@@ -24,4 +24,11 @@ describe("isSingleOrMultiSelectable", () => {
     });
     expect(isSingleOrMultiSelectable(parameter)).toBe(true);
   });
+
+  it("is true for parameters with acceptable types and wildcarded subTypes", () => {
+    const parameter = createMockParameter({
+      type: "category",
+    });
+    expect(isSingleOrMultiSelectable(parameter)).toBe(true);
+  });
 });

--- a/frontend/src/metabase/visualizations/components/ObjectDetail/utils.ts
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/utils.ts
@@ -1,5 +1,4 @@
 import { t } from "ttag";
-import _ from "underscore";
 
 import { singularize } from "metabase/lib/formatting";
 


### PR DESCRIPTION
[Fixes #27393]

### Description

Context on Slack: https://metaboat.slack.com/archives/C04DAKFDTCZ/p1675699779860499

### How to verify

See bug ticket

_Upload a demo video or before/after screenshots if sensible or remove the section_

![image](https://user-images.githubusercontent.com/784417/217025565-6e3f4b3e-f639-41c5-a551-6fc6099f53ab.png)

### Checklist

- [x] :grimacing:  Tests have been added/updated to cover changes in this PR

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/28096)
<!-- Reviewable:end -->
