### PR TITLE
Handle no saved questions in the data picker

### DIFF
--- a/frontend/src/metabase-lib/metadata/Database.ts
+++ b/frontend/src/metabase-lib/metadata/Database.ts
@@ -27,6 +27,7 @@ class DatabaseInner extends Base {
   name: string;
   engine: string;
   description: string;
+  is_saved_questions: boolean;
   tables: Table[];
   schemas: Schema[];
   metadata: Metadata;

--- a/frontend/src/metabase/containers/DataPicker/DataPickerContainer.tsx
+++ b/frontend/src/metabase/containers/DataPicker/DataPickerContainer.tsx
@@ -55,7 +55,7 @@ function mapStateToProps(state: State) {
 
 function DataPicker({
   value,
-  databases,
+  databases: allDatabases,
   search: modelLookupResult,
   filters: customFilters = {},
   hasNestedQueriesEnabled,
@@ -74,13 +74,21 @@ function DataPicker({
     [customFilters],
   );
 
+  const databases = useMemo(
+    () => allDatabases.filter(database => !database.is_saved_questions),
+    [allDatabases],
+  );
+
   const dataTypes = useMemo(
     () =>
       getDataTypes({
         hasModels: modelLookupResult.length > 0,
+        hasSavedQuestions: allDatabases.some(
+          database => database.is_saved_questions,
+        ),
         hasNestedQueriesEnabled,
       }).filter(type => filters.types(type.id)),
-    [filters, modelLookupResult, hasNestedQueriesEnabled],
+    [allDatabases, filters, modelLookupResult, hasNestedQueriesEnabled],
   );
 
   const handleDataTypeChange = useCallback(
@@ -146,7 +154,9 @@ function DataPicker({
 
 const DataPickerContainer = _.compose(
   // Required for `hasDataAccess` check
-  Databases.loadList(),
+  Databases.loadList({
+    query: { saved: true },
+  }),
 
   // Lets the picker check there is
   // at least one model, to offer for selection

--- a/frontend/src/metabase/containers/DataPicker/RawDataPicker/RawDataPickerContainer.tsx
+++ b/frontend/src/metabase/containers/DataPicker/RawDataPicker/RawDataPickerContainer.tsx
@@ -36,7 +36,7 @@ type RawDataPickerProps = RawDataPickerOwnProps & DatabaseListLoaderProps;
 
 function RawDataPicker({
   value,
-  databases,
+  databases: allDatabases,
   isMultiSelect,
   allLoading,
   onChange,
@@ -48,6 +48,11 @@ function RawDataPicker({
     initialValues: value.tableIds,
     isMultiSelect,
   });
+
+  const databases = useMemo(
+    () => allDatabases.filter(database => !database.is_saved_questions),
+    [allDatabases],
+  );
 
   const selectedDatabase = useMemo(() => {
     if (!selectedDatabaseId) {
@@ -193,6 +198,9 @@ function RawDataPicker({
   return renderPicker({ isLoading: allLoading });
 }
 
-export default Databases.loadList({ loadingAndErrorWrapper: false })(
-  RawDataPicker,
-);
+export default Databases.loadList({
+  loadingAndErrorWrapper: false,
+  // We don't actually need the saved questions database here,
+  // but that'd let us reuse DataPickerContainer's DB list loader result
+  query: { saved: true },
+})(RawDataPicker);

--- a/frontend/src/metabase/containers/DataPicker/tests/DataPicker-Questions.unit.spec.ts
+++ b/frontend/src/metabase/containers/DataPicker/tests/DataPicker-Questions.unit.spec.ts
@@ -52,6 +52,11 @@ describe("DataPicker — picking questions", () => {
     expect(screen.getByText(/Nothing here/i)).toBeInTheDocument();
   });
 
+  it("doesn't show section when there are no saved questions", async () => {
+    await setup({ hasSavedQuestions: false });
+    expect(screen.queryByText(/Saved Questions/i)).not.toBeInTheDocument();
+  });
+
   it("respects initial value", async () => {
     await setup({
       initialValue: {

--- a/frontend/src/metabase/containers/DataPicker/tests/DataPicker-RawData.unit.spec.ts
+++ b/frontend/src/metabase/containers/DataPicker/tests/DataPicker-RawData.unit.spec.ts
@@ -50,6 +50,12 @@ describe("DataPicker — picking raw data", () => {
     expect(await screen.findByText(/Nothing here/i)).toBeInTheDocument();
   });
 
+  it("doesn't show saved questions database", async () => {
+    await setup();
+    userEvent.click(screen.getByText("Raw Data"));
+    expect(screen.queryByText(/Saved Questions/i)).not.toBeInTheDocument();
+  });
+
   it("allows to pick multiple tables", async () => {
     const { onChange } = await setup({ isMultiSelect: true });
 

--- a/frontend/src/metabase/containers/DataPicker/tests/common.tsx
+++ b/frontend/src/metabase/containers/DataPicker/tests/common.tsx
@@ -149,6 +149,7 @@ interface SetupOpts {
   hasDataAccess?: boolean;
   hasEmptyDatabase?: boolean;
   hasMultiSchemaDatabase?: boolean;
+  hasSavedQuestions?: boolean;
   hasModels?: boolean;
   hasNestedQueriesEnabled?: boolean;
 }
@@ -160,6 +161,7 @@ export async function setup({
   hasDataAccess = true,
   hasEmptyDatabase = false,
   hasMultiSchemaDatabase = false,
+  hasSavedQuestions = true,
   hasModels = true,
   hasNestedQueriesEnabled = true,
 }: SetupOpts = {}) {
@@ -178,9 +180,9 @@ export async function setup({
       databases.push(EMPTY_DATABASE);
     }
 
-    setupDatabasesEndpoints(scope, databases);
+    setupDatabasesEndpoints(scope, databases, { hasSavedQuestions });
   } else {
-    setupDatabasesEndpoints(scope, []);
+    setupDatabasesEndpoints(scope, [], { hasSavedQuestions: false });
   }
 
   scope

--- a/frontend/src/metabase/containers/DataPicker/utils.ts
+++ b/frontend/src/metabase/containers/DataPicker/utils.ts
@@ -11,9 +11,11 @@ export type DataTypeInfoItem = {
 
 export function getDataTypes({
   hasNestedQueriesEnabled,
+  hasSavedQuestions,
   hasModels,
 }: {
   hasNestedQueriesEnabled: boolean;
+  hasSavedQuestions: boolean;
   hasModels: boolean;
 }): DataTypeInfoItem[] {
   const dataTypes: DataTypeInfoItem[] = [
@@ -35,12 +37,14 @@ export function getDataTypes({
       });
     }
 
-    dataTypes.push({
-      id: "questions",
-      name: t`Saved Questions`,
-      icon: "folder",
-      description: t`Use any question’s results to start a new question.`,
-    });
+    if (hasSavedQuestions) {
+      dataTypes.push({
+        id: "questions",
+        name: t`Saved Questions`,
+        icon: "folder",
+        description: t`Use any question’s results to start a new question.`,
+      });
+    }
   }
 
   return dataTypes;

--- a/frontend/src/metabase/databases/constants.tsx
+++ b/frontend/src/metabase/databases/constants.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { t } from "ttag";
+import { SAVED_QUESTIONS_VIRTUAL_DB_ID } from "metabase-lib/metadata/utils/saved-questions";
 import DatabaseAuthCodeDescription from "./components/DatabaseAuthCodeDescription";
 import DatabaseCacheScheduleField from "./components/DatabaseCacheScheduleField";
 import DatabaseClientIdDescription from "./components/DatabaseClientIdDescription";
@@ -9,6 +10,13 @@ import DatabaseSshDescription from "./components/DatabaseSshDescription";
 import DatabaseSslKeyDescription from "./components/DatabaseSslKeyDescription";
 import DatabaseSyncScheduleField from "./components/DatabaseSyncScheduleField";
 import { EngineFieldOverride } from "./types";
+
+export const SAVED_QUESTIONS_DATABASE = {
+  id: SAVED_QUESTIONS_VIRTUAL_DB_ID,
+  name: t`Saved Questions`,
+  is_saved_questions: true,
+  features: ["basic-aggregations"],
+};
 
 export const ELEVATED_ENGINES = [
   "mysql",

--- a/frontend/test/__support__/server-mocks/database.ts
+++ b/frontend/test/__support__/server-mocks/database.ts
@@ -1,14 +1,8 @@
 import { Scope } from "nock";
 import _ from "underscore";
+import { SAVED_QUESTIONS_DATABASE } from "metabase/databases/constants";
 import { Database } from "metabase-types/api";
-import { SAVED_QUESTIONS_VIRTUAL_DB_ID } from "metabase-lib/metadata/utils/saved-questions";
 import { setupTableEndpoints } from "./table";
-
-const SAVED_QUESTIONS_DB = {
-  id: SAVED_QUESTIONS_VIRTUAL_DB_ID,
-  name: "Saved Questions",
-  is_saved_questions: true,
-};
 
 export function setupDatabaseEndpoints(scope: Scope, db: Database) {
   scope.get(`/api/database/${db.id}`).reply(200, db);
@@ -24,7 +18,7 @@ export function setupDatabasesEndpoints(
   scope.get("/api/database").reply(200, dbs);
   scope
     .get("/api/database?saved=true")
-    .reply(200, hasSavedQuestions ? [...dbs, SAVED_QUESTIONS_DB] : dbs);
+    .reply(200, hasSavedQuestions ? [...dbs, SAVED_QUESTIONS_DATABASE] : dbs);
 
   dbs.forEach(db => setupDatabaseEndpoints(scope, db));
 }

--- a/frontend/test/__support__/server-mocks/database.ts
+++ b/frontend/test/__support__/server-mocks/database.ts
@@ -1,7 +1,14 @@
 import { Scope } from "nock";
 import _ from "underscore";
 import { Database } from "metabase-types/api";
+import { SAVED_QUESTIONS_VIRTUAL_DB_ID } from "metabase-lib/metadata/utils/saved-questions";
 import { setupTableEndpoints } from "./table";
+
+const SAVED_QUESTIONS_DB = {
+  id: SAVED_QUESTIONS_VIRTUAL_DB_ID,
+  name: "Saved Questions",
+  is_saved_questions: true,
+};
 
 export function setupDatabaseEndpoints(scope: Scope, db: Database) {
   scope.get(`/api/database/${db.id}`).reply(200, db);
@@ -9,8 +16,16 @@ export function setupDatabaseEndpoints(scope: Scope, db: Database) {
   db.tables?.forEach(table => setupTableEndpoints(scope, table));
 }
 
-export function setupDatabasesEndpoints(scope: Scope, dbs: Database[]) {
+export function setupDatabasesEndpoints(
+  scope: Scope,
+  dbs: Database[],
+  { hasSavedQuestions = true } = {},
+) {
   scope.get("/api/database").reply(200, dbs);
+  scope
+    .get("/api/database?saved=true")
+    .reply(200, hasSavedQuestions ? [...dbs, SAVED_QUESTIONS_DB] : dbs);
+
   dbs.forEach(db => setupDatabaseEndpoints(scope, db));
 }
 


### PR DESCRIPTION
Epic #27160

Makes the `DataPicker` omit the "Saved Questions" section if there are actually no saved questions. Relies on the presence of a saved questions database in the `GET /api/database?saved=true` response (mirrors the behavior in the existing `DataSelector`)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/28099)
<!-- Reviewable:end -->
