### PR TITLE
Fix sanity check test constantly failing

### DIFF
--- a/frontend/test/metabase-visual/onboarding/urls.cy.spec.js
+++ b/frontend/test/metabase-visual/onboarding/urls.cy.spec.js
@@ -35,7 +35,7 @@ describe("visual tests > onboarding > URLs", () => {
     cy.wait("@collection-items");
     cy.wait("@collection-items");
 
-    cy.findByText("First collection");
+    cy.findAllByText("First collection");
     cy.findByText("Your personal collection");
     cy.findByText("Orders");
 

--- a/frontend/test/metabase-visual/onboarding/urls.cy.spec.js
+++ b/frontend/test/metabase-visual/onboarding/urls.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore } from "__support__/e2e/helpers";
+import { restore, navigationSidebar } from "__support__/e2e/helpers";
 import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
 
 describe("visual tests > onboarding > URLs", () => {
@@ -35,9 +35,14 @@ describe("visual tests > onboarding > URLs", () => {
     cy.wait("@collection-items");
     cy.wait("@collection-items");
 
-    cy.findAllByText("First collection");
-    cy.findByText("Your personal collection");
-    cy.findByText("Orders");
+    navigationSidebar().within(() => {
+      cy.findByText("First collection");
+      cy.findByText("Your personal collection");
+    });
+    cy.get("main").within(() => {
+      cy.findByText("Orders");
+      cy.findByText("First collection");
+    });
 
     cy.createPercySnapshot();
   });


### PR DESCRIPTION
Fixes a failing test caused by #28023. After we started listing subcollections in collections, we had to instances of "First collection" on the page, but the test was using a `findBy` query instead of `findAllBy`

### Problem

![CleanShot 2023-02-06 at 18 35 47@2x](https://user-images.githubusercontent.com/17258145/217057288-043f219c-86fd-4d61-8d3a-ee07c7e6c4a1.png)

### Works now ✅ 

<img width="767" alt="CleanShot 2023-02-06 at 18 41 46@2x" src="https://user-images.githubusercontent.com/17258145/217057551-126e62d2-7d79-4d0f-af3f-21863bbf9bc3.png">

