### PR TITLE
BE: Enforce parameter's name to be required and unique

### DIFF
--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -38,6 +38,7 @@
    [metabase.related :as related]
    [metabase.util :as u]
    [metabase.util.i18n :refer [tru]]
+   [metabase.util.malli.schema :as ms]
    [metabase.util.schema :as su]
    [schema.core :as s]
    [toucan.db :as db]
@@ -72,16 +73,15 @@
                    dashboard)))
           dashboards)))
 
-#_{:clj-kondo/ignore [:deprecated-var]}
-(api/defendpoint-schema POST "/"
+(api/defendpoint POST "/"
   "Create a new Dashboard."
   [:as {{:keys [name description parameters cache_ttl collection_id collection_position], :as _dashboard} :body}]
-  {name                su/NonBlankString
-   parameters          (s/maybe [su/Parameter])
-   description         (s/maybe s/Str)
-   cache_ttl           (s/maybe su/IntGreaterThanZero)
-   collection_id       (s/maybe su/IntGreaterThanZero)
-   collection_position (s/maybe su/IntGreaterThanZero)}
+  {name                ms/NonBlankString
+   parameters          [:maybe ms/Parameters]
+   description         [:maybe :string]
+   cache_ttl           [:maybe ms/IntGreaterThanZero]
+   collection_id       [:maybe ms/IntGreaterThanZero]
+   collection_position [:maybe ms/IntGreaterThanZero]}
   ;; if we're trying to save the new dashboard in a Collection make sure we have permissions to do that
   (collection/check-write-perms-for-collection collection_id)
   (let [dashboard-data {:name                name
@@ -374,8 +374,7 @@
     (validation/check-embedding-enabled)
     (api/check-superuser)))
 
-#_{:clj-kondo/ignore [:deprecated-var]}
-(api/defendpoint-schema PUT "/:id"
+(api/defendpoint PUT "/:id"
   "Update a Dashboard.
 
   Usually, you just need write permissions for this Dashboard to do this (which means you have appropriate
@@ -384,19 +383,19 @@
   [id :as {{:keys [description name parameters caveats points_of_interest show_in_getting_started enable_embedding
                    embedding_params position archived collection_id collection_position cache_ttl]
             :as dash-updates} :body}]
-  {name                    (s/maybe su/NonBlankString)
-   description             (s/maybe s/Str)
-   caveats                 (s/maybe s/Str)
-   points_of_interest      (s/maybe s/Str)
-   show_in_getting_started (s/maybe s/Bool)
-   enable_embedding        (s/maybe s/Bool)
-   embedding_params        (s/maybe su/EmbeddingParams)
-   parameters              (s/maybe [su/Parameter])
-   position                (s/maybe su/IntGreaterThanZero)
-   archived                (s/maybe s/Bool)
-   collection_id           (s/maybe su/IntGreaterThanZero)
-   collection_position     (s/maybe su/IntGreaterThanZero)
-   cache_ttl               (s/maybe su/IntGreaterThanZero)}
+  {name                    [:maybe ms/NonBlankString]
+   description             [:maybe :string]
+   caveats                 [:maybe :string]
+   points_of_interest      [:maybe :string]
+   show_in_getting_started [:maybe :boolean]
+   enable_embedding        [:maybe :boolean]
+   embedding_params        [:maybe ms/EmbeddingParams]
+   parameters              [:maybe ms/Parameters]
+   position                [:maybe ms/IntGreaterThanZero]
+   archived                [:maybe :boolean]
+   collection_id           [:maybe ms/IntGreaterThanZero]
+   collection_position     [:maybe ms/IntGreaterThanZero]
+   cache_ttl               [:maybe ms/IntGreaterThanZero]}
   (let [dash-before-update (api/write-check Dashboard id)]
     ;; Do various permissions checks as needed
     (collection/check-allowed-to-change-collection dash-before-update dash-updates)

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -250,7 +250,6 @@
       (check-field-filter-fields-are-from-correct-database card)
       ;; TODO: add a check to see if all id in :parameter_mappings are in :parameters
       (assert-valid-model card)
-      (params/assert-valid-parameters card)
       (params/assert-valid-parameter-mappings card)
       (collection/check-collection-namespace Card (:collection_id card)))))
 
@@ -311,7 +310,6 @@
       (check-field-filter-fields-are-from-correct-database changes)
       ;; Make sure the Collection is in the default Collection namespace (e.g. as opposed to the Snippets Collection namespace)
       (collection/check-collection-namespace Card (:collection_id changes))
-      (params/assert-valid-parameters changes)
       (params/assert-valid-parameter-mappings changes)
       (parameter-card/upsert-or-delete-from-parameters! "card" id (:parameters changes))
       ;; additional checks (Enterprise Edition only)

--- a/src/metabase/models/dashboard.clj
+++ b/src/metabase/models/dashboard.clj
@@ -85,7 +85,6 @@
   (let [defaults  {:parameters []}
         dashboard (merge defaults dashboard)]
     (u/prog1 dashboard
-      (params/assert-valid-parameters dashboard)
       (collection/check-collection-namespace Dashboard (:collection_id dashboard)))))
 
 (defn- post-insert
@@ -95,7 +94,6 @@
 
 (defn- pre-update [dashboard]
   (u/prog1 dashboard
-    (params/assert-valid-parameters dashboard)
     (parameter-card/upsert-or-delete-from-parameters! "dashboard" (:id dashboard) (:parameters dashboard))
     (collection/check-collection-namespace Dashboard (:collection_id dashboard))))
 

--- a/src/metabase/models/parameter_card.clj
+++ b/src/metabase/models/parameter_card.clj
@@ -5,8 +5,6 @@
    [metabase.models.serialization.util :as serdes.util]
    [metabase.util :as u]
    [metabase.util.i18n :refer [tru]]
-   [metabase.util.malli :as mu]
-   [metabase.util.malli.schema :as ms]
    [toucan.db :as db]
    [toucan.models :as models]))
 
@@ -64,12 +62,12 @@
       (or (db/update-where! ParameterCard conditions :card_id card-id)
           (db/insert! ParameterCard (merge conditions {:card_id card-id}))))))
 
-(mu/defn upsert-or-delete-from-parameters!
+(defn upsert-or-delete-from-parameters!
   "From a parameters list on card or dashboard, create, update,
   or delete appropriate ParameterCards for each parameter in the dashboard"
-  [parameterized-object-type :- ms/NonBlankString
-   parameterized-object-id   :- ms/IntGreaterThanZero
-   parameters                :- [:maybe [:sequential ms/Parameter]]]
+  [parameterized-object-type
+   parameterized-object-id
+   parameters]
   (let [upsertable?           (fn [{:keys [values_source_type values_source_config id]}]
                                 (and values_source_type id (:card_id values_source_config)
                                      (= values_source_type "card")))

--- a/src/metabase/models/params.clj
+++ b/src/metabase/models/params.clj
@@ -20,13 +20,6 @@
 ;;; |                                                     SHARED                                                     |
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
-(defn assert-valid-parameters
-  "Receive a Paremeterized Object and check if its parameters is valid."
-  [{:keys [parameters]}]
-  (when (s/check (s/maybe [su/Parameter]) parameters)
-    (throw (ex-info (tru ":parameters must be a sequence of maps with :id and :type keys")
-                    {:parameters parameters}))))
-
 (defn assert-valid-parameter-mappings
   "Receive a Paremeterized Object and check if its parameters is valid."
   [{:keys [parameter_mappings]}]

--- a/src/metabase/util/malli/schema.clj
+++ b/src/metabase/util/malli/schema.clj
@@ -253,14 +253,25 @@
   (mu/with-api-error-message
     [:map [:id NonBlankString]
      [:type keyword-or-non-blank-str-malli]
+     [:name NonBlankString]
      ;; TODO how to merge this with ParameterSource above?
      [:values_source_type {:optional true} [:enum "static-list" "card" nil]]
      [:values_source_config {:optional true} ValuesSourceConfig]
      [:slug {:optional true} :string]
-     [:name {:optional true} :string]
      [:default {:optional true} :any]
      [:sectionId {:optional true} NonBlankString]]
     (deferred-tru "parameter must be a map with :id and :type keys")))
+
+(def Parameters
+  "Schema for a valid collection of Parameters.
+  Each parameter's name must be unique within the parameters list."
+  (mu/with-api-error-message
+    [:and
+     [:sequential Parameter]
+     #_[:fn (fn [parameters]
+              (= (-> (map :name parameters) set count)
+                 (count parameters)))]]
+    (deferred-tru "Parameters must be a list of Parameter with unique names")))
 
 (def ParameterMapping
   "Schema for a valid Parameter Mapping"

--- a/src/metabase/util/malli/schema.clj
+++ b/src/metabase/util/malli/schema.clj
@@ -260,7 +260,7 @@
      [:slug {:optional true} :string]
      [:default {:optional true} :any]
      [:sectionId {:optional true} NonBlankString]]
-    (deferred-tru "parameter must be a map with :id and :type keys")))
+    (deferred-tru "parameter must be a map with :id, :type, :name keys")))
 
 (def Parameters
   "Schema for a valid collection of Parameters.
@@ -268,9 +268,12 @@
   (mu/with-api-error-message
     [:and
      [:sequential Parameter]
-     #_[:fn (fn [parameters]
-              (= (-> (map :name parameters) set count)
-                 (count parameters)))]]
+     [:fn
+      {:error/fn (fn [_ _] (deferred-tru "parameter.name must be unique"))}
+      (fn [parameters]
+        (let [param-names (map :name parameters)]
+         (= (-> param-names set count)
+            (count param-names))))]]
     (deferred-tru "Parameters must be a list of Parameter with unique names")))
 
 (def ParameterMapping

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -448,11 +448,12 @@
 
 (deftest create-card-validation-test
   (testing "POST /api/card"
-    (is (= {:errors {:visualization_settings "value must be a map."}}
+    (is (= {:errors {:visualization_settings "Value must be a map."},
+            :specific-errors {:visualization_settings ["Value must be a map."]}}
            (mt/user-http-request :crowberto :post 400 "card" {:visualization_settings "ABC"})))
 
-    (is (= {:errors {:parameters (str "value may be nil, or if non-nil, value must be an array. "
-                                      "Each parameter must be a map with :id and :type keys")}}
+    (is (= {:errors {:parameters "nullable Parameters must be a list of Parameter with unique names"},
+            :specific-errors {:parameters ["invalid type"]}}
            (mt/user-http-request :crowberto :post 400 "card" {:visualization_settings {:global {:title nil}}
                                                               :parameters             "abc"})))
     (with-temp-native-card-with-params [db card]
@@ -901,15 +902,19 @@
     (mt/with-temp Card [card]
       (testing "successfully update with valid parameters"
         (is (partial= {:parameters [{:id   "random-id"
+                                     :name "random-name"
                                      :type "number"}]}
                       (mt/user-http-request :rasta :put 200 (str "card/" (u/the-id card))
                                             {:parameters [{:id   "random-id"
+                                                           :name "random-name"
                                                            :type "number"}]})))))
 
     (mt/with-temp Card [card {:parameters [{:id   "random-id"
+                                            :name "random-name"
                                             :type "number"}]}]
       (testing "nil parameters will no-op"
         (is (partial= {:parameters [{:id   "random-id"
+                                     :name "random-name"
                                      :type "number"}]}
                       (mt/user-http-request :rasta :put 200 (str "card/" (u/the-id card))
                                             {:parameters nil}))))

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -132,14 +132,14 @@
 
 (deftest create-dashboard-validation-test
   (testing "POST /api/dashboard"
-    (is (= {:errors {:name "value must be a non-blank string."}}
+    (is (=? {:errors {:name "value must be a non-blank string."},
+             :specific-errors {:name ["value must be a non-blank string."]}}
            (mt/user-http-request :rasta :post 400 "dashboard" {})))
 
-    (is (= {:errors {:parameters (str "value may be nil, or if non-nil, value must be an array. "
-                                      "Each parameter must be a map with :id and :type keys")}}
-           (mt/user-http-request :crowberto :post 400 "dashboard" {:name       "Test"
-                                                                   :parameters "abc"})))))
-
+    (is (=? {:errors {:parameters "nullable Parameters must be a list of Parameter with unique names"},
+             :specific-errors {:parameters ["invalid type"]}}
+            (mt/user-http-request :crowberto :post 400 "dashboard" {:name       "Test"
+                                                                    :parameters "abc"})))))
 (def ^:private dashboard-defaults
   {:archived                false
    :caveats                 nil
@@ -1903,7 +1903,7 @@
                  (:parameters dashboard))))))
 
     (testing "source-options must be a map and sourcetype must be `card` or `static-list` must be a string"
-      (is (= "value may be nil, or if non-nil, value must be an array. Each parameter must be a map with :id and :type keys"
+      (is (= "nullable Parameters must be a list of Parameter with unique names"
              (get-in (mt/user-http-request :rasta :post 400 "dashboard"
                                            {:name       "a dashboard"
                                             :parameters [{:id                    "_value_",
@@ -1912,13 +1912,13 @@
                                                           :values_source_type    "random-type"
                                                           :values_source_config {"values" [1 2 3]}}]})
                      [:errors :parameters])))
-      (is (= "value may be nil, or if non-nil, value must be an array. Each parameter must be a map with :id and :type keys"
+      (is (= "nullable Parameters must be a list of Parameter with unique names"
              (get-in (mt/user-http-request :rasta :post 400 "dashboard"
                                            {:name       "a dashboard"
-                                            :parameters [{:id                    "_value_",
-                                                          :name                  "value",
-                                                          :type                  "category",
-                                                          :values_source_type    "static-list"
+                                            :parameters [{:id                   "_value_",
+                                                          :name                 "value",
+                                                          :type                 "category",
+                                                          :values_source_type   "static-list"
                                                           :values_source_config []}]})
                      [:errors :parameters]))))))
 

--- a/test/metabase/models/card_test.clj
+++ b/test/metabase/models/card_test.clj
@@ -290,27 +290,6 @@
 
 ;;; ------------------------------------------ Parameters tests ------------------------------------------
 
-(deftest validate-parameters-test
-  (testing "Should validate Card :parameters when"
-    (testing "creating"
-      (is (thrown-with-msg?
-           clojure.lang.ExceptionInfo
-           #":parameters must be a sequence of maps with :id and :type keys"
-           (mt/with-temp Card [_ {:parameters {:a :b}}])))
-
-     (mt/with-temp Card [card {:parameters [{:id   "valid-id"
-                                             :type "id"}]}]
-       (is (some? card))))
-
-    (testing "updating"
-      (mt/with-temp Card [{:keys [id]} {:parameters []}]
-        (is (thrown-with-msg?
-             clojure.lang.ExceptionInfo
-             #":parameters must be a sequence of maps with :id and :type keys"
-             (db/update! Card id :parameters [{:id 100}])))
-        (is (some? (db/update! Card id :parameters [{:id   "new-valid-id"
-                                                     :type "id"}])))))))
-
 (deftest normalize-parameters-test
   (testing ":parameters should get normalized when coming out of the DB"
     (doseq [[target expected] {[:dimension [:field-id 1000]] [:dimension [:field 1000 nil]]
@@ -450,6 +429,7 @@
     (mt/with-temp* [Card [card1 {:name "base card"}]
                     Card [card2 {:name       "derived card"
                                  :parameters [{:id                   "valid-id"
+                                               :name                 "valid-name"
                                                :type                 "id"
                                                :values_source_type   "card"
                                                :values_source_config {:card_id (:id card1)}}]}]]

--- a/test/metabase/models/dashboard_test.clj
+++ b/test/metabase/models/dashboard_test.clj
@@ -325,20 +325,6 @@
              #"A Dashboard can only go in Collections in the \"default\" namespace"
              (db/update! Dashboard card-id {:collection_id collection-id})))))))
 
-(deftest validate-parameters-test
-  (testing "Should validate Dashboard :parameters when"
-    (testing "creating"
-      (is (thrown-with-msg?
-           clojure.lang.ExceptionInfo
-           #":parameters must be a sequence of maps with :id and :type keys"
-           (mt/with-temp Dashboard [_ {:parameters {:a :b}}]))))
-    (testing "updating"
-      (mt/with-temp Dashboard [{:keys [id]} {:parameters []}]
-        (is (thrown-with-msg?
-             clojure.lang.ExceptionInfo
-             #":parameters must be a sequence of maps with :id and :type keys"
-             (db/update! Dashboard id :parameters [{:id 100}])))))))
-
 (deftest normalize-parameters-test
   (testing ":parameters should get normalized when coming out of the DB"
     (doseq [[target expected] {[:dimension [:field-id 1000]] [:dimension [:field 1000 nil]]
@@ -410,6 +396,7 @@
                     Card      [card      {:name "A card"}]
                     Dashboard [dashboard {:name       "A dashboard"
                                           :parameters [{:id "abc"
+                                                        :name "valid-name"
                                                         :type "category"
                                                         :values_source_type "card"
                                                         :values_source_config {:card_id     (:id card)

--- a/test/metabase/test/generate.clj
+++ b/test/metabase/test/generate.clj
@@ -121,8 +121,9 @@
 (s/def ::content ::not-empty-string)
 
 (s/def :parameter/id   ::not-empty-string)
+(s/def :parameter/name ::not-empty-string)
 (s/def :parameter/type ::base_type)
-(s/def ::parameter  (s/keys :req-un [:parameter/id :parameter/type]))
+(s/def ::parameter  (s/keys :req-un [:parameter/id :parameter/type :parameter/name]))
 (s/def ::parameters (s/coll-of ::parameter))
 
 ;; * pulse

--- a/test/metabase/util/schema_test.clj
+++ b/test/metabase/util/schema_test.clj
@@ -237,21 +237,25 @@
             :failed-cases  [{:id   "param-id"
                              :name "param-name"}
                             {:id                   "param-id"
+                             :name                 "param-name"
                              :type                 "number"
                              :values_source_type   "invalid-type"
                              :values_source_config {:values [[1 2 3]]}}
                             {:id                   "param-id"
+                             :name                 "param-name"
                              :type                 "number"
                              :values_source_type   "card"
                              :values_source_config {:card_id     3
                                                     :value_field [:aggregation 0]}}]
             :success-cases [{:id                   "param-id"
+                             :name                 "param-name"
                              :type                 "number"
                              :values_source_type   "card"
                              :values_source_config {:card_id     3
                                                     :value_field [:field 3 nil]
                                                     :label_field [:field "name" {:base-type :type/Float}]}}
                             {:id                   "param-id"
+                             :name                 "param-name"
                              :type                 "number"
                              :values_source_type   "static-list"
                              :values_source_config {:values [[1 2 3]]}}]}


### PR DESCRIPTION
Resolves https://github.com/metabase/metabase/issues/27653 by enforce parameter.name to be required and unique in APIs.