### PR TITLE
fix hover behavior on collection item table names

### DIFF
--- a/frontend/src/metabase/collections/components/BaseItemsTable.styled.jsx
+++ b/frontend/src/metabase/collections/components/BaseItemsTable.styled.jsx
@@ -55,15 +55,6 @@ export const EntityIconCheckBox = styled(EntityItem.IconCheckBox)`
   height: 3em;
 `;
 
-export const ItemNameCell = styled(ItemCell)`
-  &:hover {
-    ${ItemLink} {
-      color: ${color("brand")};
-    }
-    cursor: pointer;
-  }
-`;
-
 export const ItemLink = styled(Link)`
   display: flex;
   grid-gap: 0.5rem;
@@ -71,6 +62,20 @@ export const ItemLink = styled(Link)`
 
   &:hover {
     color: ${color("brand")};
+  }
+`;
+
+export const ItemNameCell = styled.td`
+  padding: 0 !important;
+
+  ${ItemLink} {
+    padding: 1em;
+  }
+  &:hover {
+    ${ItemLink} {
+      color: ${color("brand")};
+    }
+    cursor: pointer;
   }
 `;
 

--- a/frontend/src/metabase/collections/components/BaseItemsTable.styled.jsx
+++ b/frontend/src/metabase/collections/components/BaseItemsTable.styled.jsx
@@ -55,6 +55,15 @@ export const EntityIconCheckBox = styled(EntityItem.IconCheckBox)`
   height: 3em;
 `;
 
+export const ItemNameCell = styled(ItemCell)`
+  &:hover {
+    ${ItemLink} {
+      color: ${color("brand")};
+    }
+    cursor: pointer;
+  }
+`;
+
 export const ItemLink = styled(Link)`
   display: flex;
   grid-gap: 0.5rem;

--- a/frontend/src/metabase/collections/components/BaseTableItem.jsx
+++ b/frontend/src/metabase/collections/components/BaseTableItem.jsx
@@ -17,6 +17,7 @@ import { getFullName } from "metabase/lib/user";
 
 import {
   ItemCell,
+  ItemNameCell,
   EntityIconCheckBox,
   ItemLink,
   TableItemSecondaryField,
@@ -116,7 +117,7 @@ export function BaseTableItem({
             showCheckbox={isHoveringOverRow}
           />
         </ItemCell>
-        <ItemCell data-testid={`${testId}-name`}>
+        <ItemNameCell data-testid={`${testId}-name`}>
           <ItemLink {...linkProps} to={item.getUrl()}>
             <EntityItem.Name name={item.name} variant="list" />
             <PLUGIN_MODERATION.ModerationStatusIcon
@@ -131,7 +132,7 @@ export function BaseTableItem({
               />
             )}
           </ItemLink>
-        </ItemCell>
+        </ItemNameCell>
         <ItemCell data-testid={`${testId}-last-edited-by`}>
           <Ellipsified>{lastEditedBy}</Ellipsified>
         </ItemCell>


### PR DESCRIPTION
Fixes an issue found by @vbenedetti where item names in the collection list didn't have a full click target and associated text color hover to indicate it when hovering on that part of the table row.

## Before
<img width="1280" alt="Screen Shot 2023-02-07 at 12 55 07 PM" src="https://user-images.githubusercontent.com/5248953/217326979-d8068e07-4496-49cf-88ec-a7cf5e7c2a2f.png">
The cursor has entered the cell, but there's no indication of "clickability".


## After
<img width="1280" alt="Screen Shot 2023-02-07 at 12 52 54 PM" src="https://user-images.githubusercontent.com/5248953/217326791-fbe2979d-d21c-45f3-a7b8-2ee7b48891f6.png">
Note how the cursor becomes a pointer and the text becomes blue the moment the cursor enters the cell.


Here's [a quick loom](https://www.loom.com/share/c6fa5b3dc39346a0aa54d839fbef4d48) of being able to click on any part of the name cell and having it navigate.
