### PR TITLE
mu/defn fix: no return schema docstring generation

### DIFF
--- a/src/metabase/util/malli.clj
+++ b/src/metabase/util/malli.clj
@@ -70,7 +70,7 @@ explain-fn-fail!
                        (str "Inputs: " (if single
                                          (pr-str (first (mapv :raw-arglist parglists)))
                                          (str "(" (str/join "\n           " (map (comp pr-str :raw-arglist) parglists)) ")"))
-                            "\n  Return: " (str/replace (u/pprint-to-str (:schema return))
+                            "\n  Return: " (str/replace (u/pprint-to-str (:schema return :any))
                                                         "\n"
                                                         (str "\n          "))
                             (when (not-empty doc) (str "\n\n  " doc))))

--- a/test/metabase/util/malli_test.clj
+++ b/test/metabase/util/malli_test.clj
@@ -35,6 +35,21 @@
     (is (str/ends-with? (:doc (meta #'boo)) "something very important to remember goes here"))
     (ns-unmap *ns* 'boo))
 
+  (testing "no schemas given should work"
+    (mu/defn qux [])
+    (is (= "Inputs: []\n  Return: :any"
+           (:doc (meta #'qux))))
+    (ns-unmap *ns* 'qux)
+    (mu/defn qux "Original docstring." [])
+    (is (= (str/join "\n"
+                     [  "Inputs: []"
+                      "  Return: :any"
+                      "          "
+                      ""
+                      "  Original docstring."])
+           (:doc (meta #'qux))))
+    (ns-unmap *ns* 'qux))
+
   (testing "multi-arity, and varargs doc strings should work"
     (mu/defn ^:private foo :- [:multi {:dispatch :type}
                                [:sized [:map [:type [:= :sized]]

--- a/test/metabase/util/malli_test.clj
+++ b/test/metabase/util/malli_test.clj
@@ -50,6 +50,40 @@
            (:doc (meta #'qux))))
     (ns-unmap *ns* 'qux))
 
+  (testing "no return schemas given should work"
+    (mu/defn qux [x :- :int])
+    (is (= "Inputs: [x :- :int]\n  Return: :any"
+           (:doc (meta #'qux))))
+    (ns-unmap *ns* 'qux)
+    (mu/defn qux "Original docstring." [x :- :int])
+    (is (= (str/join "\n"
+                     [  "Inputs: [x :- :int]"
+                      "  Return: :any"
+                      "          "
+                      ""
+                      "  Original docstring."])
+           (:doc (meta #'qux))))
+    (ns-unmap *ns* 'qux))
+
+  (testing "no input schemas given should work"
+    (mu/defn qux :- :int [])
+    (is (= "Inputs: []\n  Return: :int"
+           (:doc (meta #'qux))))
+    (ns-unmap *ns* 'qux)
+    (mu/defn qux :- :int
+      "Original docstring."
+      [x :- :int])
+    (is (= (str/join "\n"
+                     [  "Inputs: [x :- :int]"
+                      "  Return: :int"
+                      "          "
+                      ""
+                      "  Original docstring."])
+           (:doc (meta #'qux))))
+    (ns-unmap *ns* 'qux))
+
+
+
   (testing "multi-arity, and varargs doc strings should work"
     (mu/defn ^:private foo :- [:multi {:dispatch :type}
                                [:sized [:map [:type [:= :sized]]


### PR DESCRIPTION
The macro was not handling the absence of a return schema properly. Now it will resort to `:any` when no return annotation is given.

The fix is on this line:
https://github.com/metabase/metabase/pull/28121/files#diff-e29756aed1e2e2cbce8a26a8e4b2e1cbedfb83cd4d853cf6942455e49516e4d8R73