### PR TITLE
Add read-only mode to action editor

### DIFF
--- a/frontend/src/metabase/actions/components/ActionForm/ActionForm.tsx
+++ b/frontend/src/metabase/actions/components/ActionForm/ActionForm.tsx
@@ -40,6 +40,7 @@ import { getForm, getFormValidationSchema } from "./utils";
 export interface ActionFormComponentProps {
   parameters: WritebackParameter[] | Parameter[];
   initialValues?: ActionFormInitialValues;
+  isEditable?: boolean;
   onClose?: () => void;
   onSubmit?: (
     params: ParametersForActionExecution,
@@ -54,6 +55,7 @@ export interface ActionFormComponentProps {
 export const ActionForm = ({
   parameters,
   initialValues = {},
+  isEditable,
   onClose,
   onSubmit,
   submitTitle,
@@ -130,6 +132,7 @@ export const ActionForm = ({
                     <Draggable
                       key={`draggable-${field.name}`}
                       draggableId={field.name}
+                      isDragDisabled={!isEditable}
                       index={index}
                     >
                       {(provided: DraggableProvided) => (
@@ -139,20 +142,23 @@ export const ActionForm = ({
                           {...provided.dragHandleProps}
                           isSettings={isSettings}
                         >
-                          <SettingsContainer>
-                            <Icon name="grabber2" size={14} />
-                          </SettingsContainer>
-
+                          {isEditable && (
+                            <SettingsContainer>
+                              <Icon name="grabber2" size={14} />
+                            </SettingsContainer>
+                          )}
                           <InputContainer>
                             <FormFieldWidget
                               key={field.name}
                               formField={field}
                             />
                           </InputContainer>
-                          <FieldSettingsButtons
-                            fieldSettings={formSettings.fields[field.name]}
-                            onChange={handleChangeFieldSettings}
-                          />
+                          {isEditable && (
+                            <FieldSettingsButtons
+                              fieldSettings={formSettings.fields[field.name]}
+                              onChange={handleChangeFieldSettings}
+                            />
+                          )}
                         </FormFieldContainer>
                       )}
                     </Draggable>

--- a/frontend/src/metabase/actions/components/ActionForm/ActionForm.unit.spec.tsx
+++ b/frontend/src/metabase/actions/components/ActionForm/ActionForm.unit.spec.tsx
@@ -59,6 +59,7 @@ const setup = ({
     <ActionForm
       initialValues={initialValues}
       parameters={parameters}
+      isEditable
       submitTitle="Save"
       formSettings={formSettings}
       setFormSettings={isSettings ? setFormSettings : undefined}
@@ -612,7 +613,7 @@ describe("Actions > ActionForm", () => {
       });
 
       // click the settings cog then the number input type
-      userEvent.click(await screen.findByLabelText("gear icon"));
+      userEvent.click(await screen.findByLabelText("Field settings"));
       userEvent.click(await screen.findByText("number"));
 
       await waitFor(() => {
@@ -642,7 +643,7 @@ describe("Actions > ActionForm", () => {
       });
 
       // click the settings cog then the number input type
-      userEvent.click(await screen.findByLabelText("gear icon"));
+      userEvent.click(await screen.findByLabelText("Field settings"));
       userEvent.click(await screen.findByText("long text"));
 
       await waitFor(() => {
@@ -671,7 +672,7 @@ describe("Actions > ActionForm", () => {
         formSettings,
       });
 
-      userEvent.click(await screen.findByLabelText("gear icon"));
+      userEvent.click(await screen.findByLabelText("Field settings"));
       userEvent.click(await screen.findByText("date"));
 
       await waitFor(() => {
@@ -699,7 +700,7 @@ describe("Actions > ActionForm", () => {
         formSettings,
       });
 
-      userEvent.click(await screen.findByLabelText("gear icon"));
+      userEvent.click(await screen.findByLabelText("Field settings"));
       userEvent.click(await screen.findByText("category"));
 
       await waitFor(() => {
@@ -726,7 +727,7 @@ describe("Actions > ActionForm", () => {
         formSettings,
       });
 
-      userEvent.click(await screen.findByLabelText("gear icon"));
+      userEvent.click(await screen.findByLabelText("Field settings"));
       userEvent.click(await screen.findByRole("switch"));
 
       await waitFor(() => {

--- a/frontend/src/metabase/actions/containers/ActionCreator/ActionCreator.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/ActionCreator.tsx
@@ -93,6 +93,7 @@ function resolveQuestion(
 
 function ActionCreator({
   action,
+  model,
   modelId,
   databaseId,
   metadata,
@@ -112,6 +113,7 @@ function ActionCreator({
 
   const query = question.query() as NativeQuery;
   const isNew = !action && !question.isSaved();
+  const isEditable = isNew || Boolean(model?.can_write);
 
   useEffect(() => {
     setQuestion(resolveQuestion(action, { metadata, databaseId }));
@@ -171,6 +173,7 @@ function ActionCreator({
     <>
       <ActionCreatorView
         isNew={isNew}
+        isEditable={isEditable}
         canSave={query.isEmpty()}
         action={action}
         question={question}

--- a/frontend/src/metabase/actions/containers/ActionCreator/ActionCreator.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/ActionCreator.tsx
@@ -10,10 +10,12 @@ import Actions, {
   UpdateQueryActionParams,
 } from "metabase/entities/actions";
 import Database from "metabase/entities/databases";
+import Models from "metabase/entities/questions";
 import { getMetadata } from "metabase/selectors/metadata";
 
 import type {
   ActionFormSettings,
+  Card,
   DatabaseId,
   WritebackActionId,
   WritebackQueryAction,
@@ -47,6 +49,10 @@ interface ActionLoaderProps {
   action?: WritebackQueryAction;
 }
 
+interface ModelLoaderProps {
+  model?: Card;
+}
+
 interface StateProps {
   metadata: Metadata;
 }
@@ -58,7 +64,11 @@ interface DispatchProps {
 
 export type ActionCreatorProps = OwnProps;
 
-type Props = OwnProps & ActionLoaderProps & StateProps & DispatchProps;
+type Props = OwnProps &
+  ActionLoaderProps &
+  ModelLoaderProps &
+  StateProps &
+  DispatchProps;
 
 const mapStateToProps = (state: State) => ({
   metadata: getMetadata(state),
@@ -191,10 +201,26 @@ function ActionCreator({
   );
 }
 
+function maybeGetModelId(
+  state: State,
+  { action, actionId }: OwnProps & ActionLoaderProps,
+) {
+  const isNewAction = !actionId;
+  if (isNewAction) {
+    return null;
+  }
+  return action?.model_id;
+}
+
 export default _.compose(
   Actions.load({
     id: (state: State, props: OwnProps) => props.actionId,
     loadingAndErrorWrapper: false,
+  }),
+  Models.load({
+    id: maybeGetModelId,
+    loadingAndErrorWrapper: false,
+    entityAlias: "model",
   }),
   Database.loadList(),
   connect(mapStateToProps, mapDispatchToProps),

--- a/frontend/src/metabase/actions/containers/ActionCreator/ActionCreator.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/ActionCreator.tsx
@@ -10,7 +10,7 @@ import Actions, {
   UpdateQueryActionParams,
 } from "metabase/entities/actions";
 import Database from "metabase/entities/databases";
-import Models from "metabase/entities/questions";
+import Questions from "metabase/entities/questions";
 import { getMetadata } from "metabase/selectors/metadata";
 
 import type {
@@ -206,12 +206,8 @@ function ActionCreator({
 
 function maybeGetModelId(
   state: State,
-  { action, actionId }: OwnProps & ActionLoaderProps,
+  { action }: OwnProps & ActionLoaderProps,
 ) {
-  const isNewAction = !actionId;
-  if (isNewAction) {
-    return null;
-  }
   return action?.model_id;
 }
 
@@ -220,7 +216,7 @@ export default _.compose(
     id: (state: State, props: OwnProps) => props.actionId,
     loadingAndErrorWrapper: false,
   }),
-  Models.load({
+  Questions.load({
     id: maybeGetModelId,
     loadingAndErrorWrapper: false,
     entityAlias: "model",

--- a/frontend/src/metabase/actions/containers/ActionCreator/ActionCreator.unit.spec.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/ActionCreator.unit.spec.tsx
@@ -162,7 +162,7 @@ describe("ActionCreator", () => {
         screen.getByTestId("mock-native-query-editor"),
       ).toBeInTheDocument();
       expect(
-        screen.getByRole("button", { name: "Update" }),
+        await screen.findByRole("button", { name: "Update" }),
       ).toBeInTheDocument();
       expect(
         screen.queryByRole("button", { name: "Create" }),
@@ -281,17 +281,15 @@ describe("ActionCreator", () => {
         userEvent.click(
           screen.getByRole("button", { name: "Action settings" }),
         );
-        expect(
-          screen.getByRole("textbox", { name: "Success message" }),
-        ).toHaveValue("Thanks for your submission.");
 
-        userEvent.type(
-          screen.getByRole("textbox", { name: "Success message" }),
-          `${specialChars.selectAll}Thanks!`,
-        );
-        expect(
-          screen.getByRole("textbox", { name: "Success message" }),
-        ).toHaveValue("Thanks!");
+        const messageBox = screen.getByRole("textbox", {
+          name: "Success message",
+        });
+        expect(messageBox).toHaveValue("Thanks for your submission.");
+
+        await waitFor(() => expect(messageBox).toBeEnabled());
+        userEvent.type(messageBox, `${specialChars.selectAll}Thanks!`);
+        expect(messageBox).toHaveValue("Thanks!");
       });
     });
 

--- a/frontend/src/metabase/actions/containers/ActionCreator/ActionCreator.unit.spec.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/ActionCreator.unit.spec.tsx
@@ -193,6 +193,10 @@ describe("ActionCreator", () => {
       expect(
         screen.queryByRole("button", { name: "Update" }),
       ).not.toBeInTheDocument();
+
+      screen.getByLabelText("Action settings").click();
+
+      expect(screen.getByLabelText("Success message")).toBeDisabled();
     });
 
     describe("admin users and has public sharing enabled", () => {

--- a/frontend/src/metabase/actions/containers/ActionCreator/ActionCreatorHeader.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/ActionCreatorHeader.tsx
@@ -14,6 +14,7 @@ import {
 type Props = {
   name: string;
   type: WritebackActionType;
+  isEditable: boolean;
   onChangeName: (name: string) => void;
   onChangeType?: (type: WritebackActionType) => void;
   actionButtons: React.ReactElement[];
@@ -23,6 +24,7 @@ const OPTS = [{ value: "query", name: t`Query`, disabled: true }];
 
 const ActionCreatorHeader = ({
   name = t`New Action`,
+  isEditable,
   type,
   onChangeName,
   onChangeType,
@@ -31,7 +33,11 @@ const ActionCreatorHeader = ({
   return (
     <Container>
       <LeftHeader>
-        <EditableText initialValue={name} onChange={onChangeName} />
+        <EditableText
+          initialValue={name}
+          onChange={onChangeName}
+          isDisabled={!isEditable}
+        />
         {!!onChangeType && (
           <CompactSelect options={OPTS} value={type} onChange={onChangeType} />
         )}

--- a/frontend/src/metabase/actions/containers/ActionCreator/ActionCreatorView.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/ActionCreatorView.tsx
@@ -139,6 +139,7 @@ export default function ActionCreatorView({
           <InlineActionSettings
             action={action}
             formSettings={formSettings}
+            isEditable={isEditable}
             onChangeFormSettings={onChangeFormSettings}
             onClose={closeSideView}
           />

--- a/frontend/src/metabase/actions/containers/ActionCreator/ActionCreatorView.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/ActionCreatorView.tsx
@@ -30,6 +30,7 @@ import InlineActionSettings, {
 interface ActionCreatorProps {
   isNew: boolean;
   canSave: boolean;
+  isEditable: boolean;
 
   action?: WritebackAction;
   question: Question;
@@ -48,6 +49,7 @@ const DEFAULT_SIDE_VIEW: SideView = "actionForm";
 export default function ActionCreatorView({
   isNew,
   canSave,
+  isEditable,
   action,
   question,
   formSettings,
@@ -92,6 +94,7 @@ export default function ActionCreatorView({
           <ActionCreatorHeader
             type="query"
             name={question.displayName() ?? t`New Action`}
+            isEditable={isEditable}
             onChangeName={onChangeName}
             actionButtons={[
               <DataReferenceTriggerButton
@@ -107,6 +110,7 @@ export default function ActionCreatorView({
           <EditorContainer>
             <QueryActionEditor
               query={question.query() as NativeQuery}
+              isEditable={isEditable}
               onChangeQuestionQuery={onChangeQuestionQuery}
             />
           </EditorContainer>
@@ -114,15 +118,18 @@ export default function ActionCreatorView({
             <Button onClick={onCloseModal} borderless>
               {t`Cancel`}
             </Button>
-            <Button primary disabled={canSave} onClick={onClickSave}>
-              {isNew ? t`Save` : t`Update`}
-            </Button>
+            {isEditable && (
+              <Button primary disabled={canSave} onClick={onClickSave}>
+                {isNew ? t`Save` : t`Update`}
+              </Button>
+            )}
           </ModalActions>
         </ModalLeft>
         {activeSideView === "actionForm" ? (
           <FormCreator
             params={question.parameters() ?? []}
             formSettings={formSettings}
+            isEditable={isEditable}
             onChange={onChangeFormSettings}
             onExampleClick={onClickExample}
           />

--- a/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/FieldSettingsPopover.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/FieldSettingsPopover.tsx
@@ -36,6 +36,7 @@ export function FieldSettingsPopover({
           name="gear"
           size={14}
           tooltip={t`Change field settings`}
+          aria-label={t`Field settings`}
         />
       }
       maxWidth={400}

--- a/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/FieldSettingsPopover.unit.spec.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/FieldSettingsPopover.unit.spec.tsx
@@ -14,7 +14,7 @@ describe("actions > FormCreator > FieldSettingsPopover", () => {
       <FieldSettingsPopover fieldSettings={settings} onChange={changeSpy} />,
     );
 
-    await userEvent.click(screen.getByLabelText("gear icon"));
+    await userEvent.click(screen.getByLabelText("Field settings"));
 
     expect(
       await screen.findByTestId("field-settings-popover"),
@@ -29,7 +29,7 @@ describe("actions > FormCreator > FieldSettingsPopover", () => {
       <FieldSettingsPopover fieldSettings={settings} onChange={changeSpy} />,
     );
 
-    await userEvent.click(screen.getByLabelText("gear icon"));
+    await userEvent.click(screen.getByLabelText("Field settings"));
 
     expect(
       await screen.findByTestId("field-settings-popover"),
@@ -54,7 +54,7 @@ describe("actions > FormCreator > FieldSettingsPopover", () => {
       <FieldSettingsPopover fieldSettings={settings} onChange={changeSpy} />,
     );
 
-    await userEvent.click(screen.getByLabelText("gear icon"));
+    await userEvent.click(screen.getByLabelText("Field settings"));
 
     expect(
       await screen.findByTestId("field-settings-popover"),
@@ -78,7 +78,7 @@ describe("actions > FormCreator > FieldSettingsPopover", () => {
       <FieldSettingsPopover fieldSettings={settings} onChange={changeSpy} />,
     );
 
-    await userEvent.click(screen.getByLabelText("gear icon"));
+    await userEvent.click(screen.getByLabelText("Field settings"));
 
     expect(
       await screen.findByTestId("field-settings-popover"),

--- a/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/FormCreator.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/FormCreator.tsx
@@ -14,11 +14,13 @@ import { FormCreatorWrapper } from "./FormCreator.styled";
 
 function FormCreator({
   params,
+  isEditable,
   formSettings: passedFormSettings,
   onChange,
   onExampleClick,
 }: {
   params: Parameter[];
+  isEditable: boolean;
   formSettings?: ActionFormSettings;
   onChange: (formSettings: ActionFormSettings) => void;
   onExampleClick: () => void;
@@ -55,6 +57,7 @@ function FormCreator({
     <FormCreatorWrapper>
       <ActionForm
         parameters={sortedParams}
+        isEditable={isEditable}
         onClose={_.noop}
         onSubmit={_.noop}
         formSettings={formSettings}

--- a/frontend/src/metabase/actions/containers/ActionCreator/InlineActionSettings.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/InlineActionSettings.tsx
@@ -36,6 +36,7 @@ import {
 interface OwnProps {
   action?: WritebackAction;
   formSettings: ActionFormSettings;
+  isEditable: boolean;
   onChangeFormSettings: (formSettings: ActionFormSettings) => void;
   onClose: () => void;
 }
@@ -83,6 +84,7 @@ const mapDispatchToProps: DispatchProps = {
 const InlineActionSettings = ({
   action,
   formSettings,
+  isEditable,
   siteUrl,
   isAdmin,
   isPublicSharingEnabled,
@@ -157,6 +159,7 @@ const InlineActionSettings = ({
               id={`${id}-message`}
               value={formSettings.successMessage ?? ""}
               fullWidth
+              disabled={!isEditable}
               onChange={handleSuccessMessageChange}
             />
           </FormField>

--- a/frontend/src/metabase/actions/containers/ActionCreator/QueryActionEditor.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/QueryActionEditor.tsx
@@ -6,9 +6,11 @@ import type NativeQuery from "metabase-lib/queries/NativeQuery";
 
 function QueryActionEditor({
   query,
+  isEditable,
   onChangeQuestionQuery,
 }: {
   query: NativeQuery;
+  isEditable: boolean;
   onChangeQuestionQuery: (query: NativeQuery) => void;
 }) {
   return (
@@ -22,7 +24,7 @@ function QueryActionEditor({
         isNativeEditorOpen
         hasParametersList={false}
         resizable={false}
-        readOnly={false}
+        readOnly={!isEditable}
         requireWriteback
       />
     </>

--- a/frontend/src/metabase/core/components/TextArea/TextArea.styled.tsx
+++ b/frontend/src/metabase/core/components/TextArea/TextArea.styled.tsx
@@ -30,6 +30,11 @@ export const TextAreaRoot = styled.textarea<TextAreaRootProps>`
     ${focusOutlineStyle("brand")}
   `};
 
+  &:disabled {
+    pointer-events: none;
+    opacity: 0.4;
+  }
+
   ${props =>
     props.hasError &&
     css`

--- a/frontend/src/metabase/models/components/ModelDetailPage/ModelActionDetails/ModelActionListItem.styled.tsx
+++ b/frontend/src/metabase/models/components/ModelDetailPage/ModelActionDetails/ModelActionListItem.styled.tsx
@@ -56,7 +56,6 @@ export const EditorLink = styled(Button)`
 
 EditorLink.defaultProps = {
   as: Link,
-  icon: "pencil",
   onlyIcon: true,
 };
 

--- a/frontend/src/metabase/models/components/ModelDetailPage/ModelActionDetails/ModelActionListItem.tsx
+++ b/frontend/src/metabase/models/components/ModelDetailPage/ModelActionDetails/ModelActionListItem.tsx
@@ -36,7 +36,7 @@ function ImplicitActionCardContent() {
 }
 
 function ModelActionListItem({ action, editorUrl, canWrite }: Props) {
-  const canEdit = action.type !== "implicit" && canWrite;
+  const hasEditorLink = action.type !== "implicit";
 
   const renderCardContent = () =>
     action.type === "query" ? (
@@ -63,7 +63,9 @@ function ModelActionListItem({ action, editorUrl, canWrite }: Props) {
       )}
       <Card>
         {renderCardContent()}
-        {canEdit && <EditorLink to={editorUrl} />}
+        {hasEditorLink && (
+          <EditorLink icon={canWrite ? "pencil" : "eye"} to={editorUrl} />
+        )}
       </Card>
     </>
   );

--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelector.jsx
@@ -4,6 +4,7 @@ import { connect } from "react-redux";
 import PropTypes from "prop-types";
 import { t } from "ttag";
 import _ from "underscore";
+import cx from "classnames";
 
 import EmptyState from "metabase/components/EmptyState";
 import ListSearchField from "metabase/components/ListSearchField";
@@ -858,12 +859,13 @@ export class UnconnectedDataSelector extends Component {
   };
 
   getTriggerClasses() {
-    if (this.props.triggerClasses) {
-      return this.props.triggerClasses;
+    const { readOnly, triggerClasses, renderAsSelect } = this.props;
+    if (triggerClasses) {
+      return cx(triggerClasses, { disabled: readOnly });
     }
-    return this.props.renderAsSelect
-      ? "border-medium bg-white block no-decoration"
-      : "flex align-center";
+    return renderAsSelect
+      ? cx("border-medium bg-white block no-decoration", { disabled: readOnly })
+      : cx("flex align-center", { disabled: readOnly });
   }
 
   handleSavedQuestionPickerClose = () => {

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx
@@ -110,7 +110,7 @@ class NativeQueryEditor extends Component {
   };
 
   componentDidUpdate(prevProps) {
-    const { query } = this.props;
+    const { query, readOnly } = this.props;
     if (!query || !this._editor) {
       return;
     }
@@ -138,7 +138,7 @@ class NativeQueryEditor extends Component {
 
     const editorElement = this.editor.current;
 
-    if (query.hasWritePermission()) {
+    if (query.hasWritePermission() && !readOnly) {
       this._editor.setReadOnly(false);
       editorElement.classList.remove("read-only");
     } else {

--- a/frontend/test/metabase/scenarios/models/model-actions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/model-actions.cy.spec.js
@@ -4,17 +4,19 @@ import {
   popover,
   restore,
 } from "__support__/e2e/helpers";
-import { SAMPLE_DB_TABLES } from "__support__/e2e/cypress_data";
+
 import { createMockActionParameter } from "metabase-types/api/mocks";
 
 const PG_DB_ID = 2;
+const PG_ORDERS_TABLE_ID = 9;
 
 const SAMPLE_ORDERS_MODEL = {
   name: "Order",
   dataset: true,
   display: "table",
+  database: PG_DB_ID,
   query: {
-    "source-table": SAMPLE_DB_TABLES.STATIC_ORDERS_ID,
+    "source-table": PG_ORDERS_TABLE_ID,
   },
 };
 
@@ -66,7 +68,6 @@ describe("scenarios > models > actions", () => {
     restore("postgres-12");
     cy.signInAsAdmin();
 
-    enableActionsForDB();
     enableActionsForDB(PG_DB_ID);
 
     cy.createQuestion(SAMPLE_ORDERS_MODEL, {
@@ -188,16 +189,54 @@ describe("scenarios > models > actions", () => {
       cy.findByText("An error occurred.").should("be.visible");
     });
   });
+
+  it("should respect permissions", () => {
+    cy.get("@modelId").then(modelId => {
+      cy.request("POST", "/api/action", {
+        ...SAMPLE_QUERY_ACTION,
+        model_id: modelId,
+      });
+      cy.signIn("readonly");
+      cy.visit(`/model/${modelId}/detail/actions`);
+      cy.wait("@getModel");
+    });
+
+    openActionEditorFor(SAMPLE_QUERY_ACTION.name, { isReadOnly: true });
+
+    cy.findByRole("dialog").within(() => {
+      cy.findByDisplayValue(SAMPLE_QUERY_ACTION.name).should("be.disabled");
+
+      cy.button("Save").should("not.exist");
+      cy.button("Update").should("not.exist");
+
+      assertQueryEditorDisabled();
+
+      cy.findByRole("form").within(() => {
+        cy.icon("gear").should("not.exist");
+      });
+
+      cy.findByLabelText("Action settings").click();
+      cy.findByLabelText("Success message").should("be.disabled");
+    });
+  });
 });
 
-function openActionEditorFor(actionName) {
+function openActionEditorFor(actionName, { isReadOnly = false } = {}) {
   cy.findByRole("listitem", { name: actionName }).within(() => {
-    cy.icon("pencil").click();
+    const icon = isReadOnly ? "eye" : "pencil";
+    cy.icon(icon).click();
   });
 }
 
 function fillQuery(query) {
   cy.get(".ace_content").type(query, { parseSpecialCharSequences: false });
+}
+
+function assertQueryEditorDisabled() {
+  // Ace doesn't act as a normal input, so we can't use `should("be.disabled")`
+  // Instead we'd assert that a user can't type in the editor
+  fillQuery("QWERTY");
+  cy.findByText("QWERTY").should("not.exist");
 }
 
 function fieldSettings() {


### PR DESCRIPTION
Epic #27581

Adds read-only mode to the action editor. It should disable the query editor on the left, hide/disable controls for modifying an action, and hide the submit button. Also, users with read-only access to a model would now see a link to the action editor next to the model's actions (Metabase would show an "eye" icon instead of a "pencil" to indicate there's nothing to modify).

### To Verify

1. Sign in as admin
2. Go to `/admin/people` and create another non-admin user
3. Go to `/admin/permissions/collections`, pick a collection your model lives in, and set the access to "View" for "All users"
4. Ensure your model has at least one query action (not an implicit/basic one)
5. Sign in as a user created in step 2
6. Go to `/model/:modelId/actions`
7. Ensure you can see "eye" icons next to your actions (except for implicit/basic actions)
8. Click one of the icons to open the editor
9. Ensure you can't change the query, name, field settings, enable/disable public sharing, or modify the success message
10. Sign in as admin or any other user with "Curate" collection permission and ensure you can do everything from prev step

### Demo

https://user-images.githubusercontent.com/17258145/218816432-0ea323ab-cac4-45f9-8618-77c41235876f.mp4

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/28126)
<!-- Reviewable:end -->
