### PR TITLE
Repro #25715: Blank admin panel page for `null` database details

### DIFF
--- a/frontend/test/metabase/scenarios/admin/databases/list.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/databases/list.cy.spec.js
@@ -131,4 +131,29 @@ describe("scenarios > admin > databases > list", () => {
 
     cy.findByRole("status").should("not.exist");
   });
+
+  it.skip("should handle malformed (null) database details (metabase#25715)", () => {
+    cy.request("GET", "/api/database/1").then(({ body }) => {
+      const stubbedResponse = {
+        ...body,
+        details: null,
+      };
+
+      cy.intercept("GET", "/api/database/1", req => {
+        req.reply({ body: stubbedResponse });
+      }).as("loadDatabase");
+    });
+
+    cy.visit("/admin/databases/1");
+    cy.wait("@loadDatabase");
+
+    // It is unclear how this issue will be handled,
+    // but at the very least it shouldn't render the blank page.
+    cy.get("nav").should("contain", "Metabase Admin");
+    // The response still contains the database name,
+    // so there's no reason we can't display it.
+    cy.contains(/Sample Database/i);
+    // This seems like a reasonable CTA if the database is beyond repair.
+    cy.button("Remove this database");
+  });
 });


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #25715

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/admin/databases/list.cy.spec.js`
- Replace `it.skip()` with `it.only()` to run the test in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/217393053-218e25b5-c980-49dc-bb0d-f34f343ca34f.png)

