### PR TITLE
Clean up parameter on card update

### DIFF
--- a/src/metabase/models/params/custom_values.clj
+++ b/src/metabase/models/params/custom_values.clj
@@ -7,7 +7,7 @@
   "
   (:require
    [clojure.string :as str]
-
+   [metabase.models.card :refer [Card]]
    [metabase.models.interface :as mi]
    [metabase.query-processor :as qp]
    [metabase.query-processor.util :as qp.util]
@@ -87,7 +87,7 @@
   ([card value-field]
    (values-from-card card value-field nil))
 
-  ([card            :- (ms/InstanceOf 'Card)
+  ([card            :- (ms/InstanceOf Card)
     value-field     :- ms/Field
     query           :- [:any]]
    (let [mbql-query   (values-from-card-query card value-field query)
@@ -102,7 +102,7 @@
   "Given a param and query returns the values."
   [{config :values_source_config :as _param} query]
   (let [card-id (:card_id config)
-        card    (db/select-one 'Card :id card-id)]
+        card    (db/select-one Card :id card-id)]
     (values-from-card card (:value_field config) query)))
 
 (defn- can-get-card-values?
@@ -122,7 +122,7 @@
   [parameter query default-case-fn]
   (case (:values_source_type parameter)
     "static-list" (static-list-values parameter query)
-    "card"        (let [card (db/select-one 'Card :id (get-in parameter [:values_source_config :card_id]))]
+    "card"        (let [card (db/select-one Card :id (get-in parameter [:values_source_config :card_id]))]
                     (when-not (mi/can-read? card)
                       (throw (ex-info "You don't have permissions to do that." {:status-code 403})))
                     (if (can-get-card-values? card (get-in parameter [:values_source_config :value_field]))

--- a/src/metabase/query_processor/util.clj
+++ b/src/metabase/query_processor/util.clj
@@ -118,6 +118,7 @@
     [type id-or-name (select-keys options field-options-for-identification)]))
 
 (defn field->field-info
+  "Given a field and result_metadata, return a map of information about the field if result_metadata contains a matched field. "
   [field result-metadata]
   (let [[_ttype id-or-name options :as field] (field-normalizer field)]
     (or

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -2460,6 +2460,7 @@
         (testing "success if has read permission to the source card's collection"
           (is (some? (mt/user-http-request :rasta :get 200 (param-values-url card-id "abc"))))
           (is (some? (mt/user-http-request :rasta :get 200 (param-values-url card-id "abc" "search-query")))))))))
+
 (deftest paramters-using-old-style-field-values
   (with-card-param-values-fixtures [{:keys [param-keys field-filter-card]}]
     (testing "GET /api/card/:card-id/params/:param-key/values for field-filter based params"


### PR DESCRIPTION
Follow up of https://github.com/metabase/metabase/pull/28055

This PR makes changes so that when:
- a card is archived, update parameter.values_source_type = nil for any parameter that uses this card as the source
- fields are removed from a card, update parameter.values_source_type = nil for any parameter that uses that field as value_field.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/28142)
<!-- Reviewable:end -->
