### PR TITLE
Fix whitelabel initialization

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/caching/components/CacheTTLField/CacheTTLField.styled.js
+++ b/enterprise/frontend/src/metabase-enterprise/caching/components/CacheTTLField/CacheTTLField.styled.js
@@ -27,7 +27,7 @@ export const Input = styled(NumericInput)`
 
   :focus,
   :hover {
-    border-color: ${() => color("brand")};
+    border-color: ${color("brand")};
   }
 
   transition: border 300ms ease-in-out;

--- a/enterprise/frontend/src/metabase-enterprise/overrides.js
+++ b/enterprise/frontend/src/metabase-enterprise/overrides.js
@@ -1,0 +1,1 @@
+import "./whitelabel/overrides";

--- a/enterprise/frontend/src/metabase-enterprise/plugins.js
+++ b/enterprise/frontend/src/metabase-enterprise/plugins.js
@@ -8,7 +8,6 @@ MetabaseSettings.isEnterprise = () => true;
 
 // PLUGINS:
 
-import "./whitelabel/overrides";
 import "./tools";
 import "./sandboxes";
 import "./auth";

--- a/enterprise/frontend/src/metabase-enterprise/plugins.js
+++ b/enterprise/frontend/src/metabase-enterprise/plugins.js
@@ -8,6 +8,7 @@ MetabaseSettings.isEnterprise = () => true;
 
 // PLUGINS:
 
+import "./whitelabel/overrides";
 import "./tools";
 import "./sandboxes";
 import "./auth";

--- a/enterprise/frontend/src/metabase-enterprise/whitelabel/overrides.js
+++ b/enterprise/frontend/src/metabase-enterprise/whitelabel/overrides.js
@@ -1,0 +1,10 @@
+import { hasPremiumFeature } from "metabase-enterprise/settings";
+import {
+  enabledApplicationNameReplacement,
+  updateColors,
+} from "metabase-enterprise/whitelabel/lib/whitelabel";
+
+if (hasPremiumFeature("whitelabel")) {
+  updateColors();
+  enabledApplicationNameReplacement();
+}

--- a/frontend/src/metabase/app.js
+++ b/frontend/src/metabase/app.js
@@ -6,6 +6,11 @@ import "classlist-polyfill";
 
 import "number-to-locale-string";
 
+// This is conditionally aliased in the webpack config.
+// If EE isn't enabled, it loads an empty file.
+// Should be imported before any other metabase import
+import "ee-overrides"; // eslint-disable-line import/no-unresolved, import/no-duplicates
+
 // If enabled this monkeypatches `t` and `jt` to return blacked out
 // strings/elements to assist in finding untranslated strings.
 import "metabase/lib/i18n-debug";
@@ -21,7 +26,7 @@ import "metabase/plugins/builtin";
 
 // This is conditionally aliased in the webpack config.
 // If EE isn't enabled, it loads an empty file.
-import "ee-plugins"; // eslint-disable-line import/no-unresolved
+import "ee-plugins"; // eslint-disable-line import/no-unresolved, import/no-duplicates
 
 import React from "react";
 import ReactDOM from "react-dom";

--- a/frontend/src/metabase/auth/components/AuthButton/AuthButton.styled.tsx
+++ b/frontend/src/metabase/auth/components/AuthButton/AuthButton.styled.tsx
@@ -8,7 +8,7 @@ export const TextLink = styled(Link)`
   color: ${color("text-dark")};
 
   &:hover {
-    color: ${() => color("brand")};
+    color: ${color("brand")};
   }
 `;
 

--- a/frontend/src/metabase/auth/components/GoogleButton/GoogleButton.styled.tsx
+++ b/frontend/src/metabase/auth/components/GoogleButton/GoogleButton.styled.tsx
@@ -21,6 +21,6 @@ export const TextLink = styled(Link)`
   color: ${color("text-dark")};
 
   &:hover {
-    color: ${() => color("brand")};
+    color: ${color("brand")};
   }
 `;

--- a/frontend/src/metabase/components/MetadataInfo/FieldFingerprintInfo/CategoryFingerprint.styled.jsx
+++ b/frontend/src/metabase/components/MetadataInfo/FieldFingerprintInfo/CategoryFingerprint.styled.jsx
@@ -30,7 +30,7 @@ export const LoadingSpinner = styled(_LoadingSpinner)`
   flex-grow: 1;
   align-self: center;
   justify-content: center;
-  color: ${() => color("brand")};
+  color: ${color("brand")};
 `;
 
 LoadingSpinner.defaultProps = {

--- a/frontend/src/metabase/components/MetadataInfo/MetadataInfo.styled.tsx
+++ b/frontend/src/metabase/components/MetadataInfo/MetadataInfo.styled.tsx
@@ -61,7 +61,7 @@ export const RelativeSizeIcon = styled(Icon)`
 `;
 
 export const InvertedColorRelativeSizeIcon = styled(RelativeSizeIcon)`
-  background-color: ${() => color("brand")};
+  background-color: ${color("brand")};
   color: ${color("white")};
   border-radius: 0.3em;
   padding: 0.3em;
@@ -87,7 +87,7 @@ export const LoadingSpinner = styled(_LoadingSpinner)`
   flex-grow: 1;
   align-self: center;
   justify-content: center;
-  color: ${() => color("brand")};
+  color: ${color("brand")};
 `;
 
 export const Table = styled.table`

--- a/frontend/src/metabase/components/form/FormikFormField/FormField.styled.tsx
+++ b/frontend/src/metabase/components/form/FormikFormField/FormField.styled.tsx
@@ -33,7 +33,7 @@ export const InfoIcon = styled(Icon)`
   color: ${color("bg-dark")};
 
   &:hover {
-    color: ${() => color("brand")};
+    color: ${color("brand")};
   }
 `;
 

--- a/frontend/src/metabase/components/form/widgets/FormSectionWidget/FormSectionWidget.styled.tsx
+++ b/frontend/src/metabase/components/form/widgets/FormSectionWidget/FormSectionWidget.styled.tsx
@@ -3,7 +3,7 @@ import { color } from "metabase/lib/colors";
 import Button from "metabase/core/components/Button";
 
 export const WidgetButton = styled(Button)`
-  color: ${() => color("brand")};
+  color: ${color("brand")};
   padding: 0;
   border: none;
   border-radius: 0;

--- a/frontend/src/metabase/core/components/CheckBox/CheckBox.styled.tsx
+++ b/frontend/src/metabase/core/components/CheckBox/CheckBox.styled.tsx
@@ -39,7 +39,7 @@ export const CheckBoxContainer = styled.span<CheckBoxContainerProps>`
   opacity: ${props => (props.disabled ? "0.4" : "")};
 
   ${CheckBoxInput}:focus + & {
-    outline: 2px solid ${() => color("focus")};
+    outline: 2px solid ${color("focus")};
   }
 
   ${CheckBoxInput}:focus:not(:focus-visible) + & {

--- a/frontend/src/metabase/core/components/FileInput/FileInput.styled.tsx
+++ b/frontend/src/metabase/core/components/FileInput/FileInput.styled.tsx
@@ -43,7 +43,7 @@ export const InputButton = styled.span`
   user-select: none;
 
   ${InputField}:focus + & {
-    outline: 2px solid ${() => color("focus")};
+    outline: 2px solid ${color("focus")};
   }
 
   ${InputField}:not(:focus-visible) + & {

--- a/frontend/src/metabase/core/components/FormField/FormField.styled.tsx
+++ b/frontend/src/metabase/core/components/FormField/FormField.styled.tsx
@@ -59,7 +59,7 @@ export const FieldInfoIcon = styled(Icon)`
   height: 0.75rem;
 
   &:hover {
-    color: ${() => color("brand")};
+    color: ${color("brand")};
   }
 `;
 

--- a/frontend/src/metabase/core/components/Radio/Radio.styled.tsx
+++ b/frontend/src/metabase/core/components/Radio/Radio.styled.tsx
@@ -71,7 +71,7 @@ export const RadioContainer = styled.div<RadioContainerProps>`
   }
 
   ${RadioInput}:focus + & {
-    outline: 2px solid ${() => color("focus")};
+    outline: 2px solid ${color("focus")};
   }
 
   ${RadioInput}:focus:not(:focus-visible) + & {

--- a/frontend/src/metabase/core/components/SelectButton/SelectButton.styled.tsx
+++ b/frontend/src/metabase/core/components/SelectButton/SelectButton.styled.tsx
@@ -35,8 +35,8 @@ export const SelectButtonRoot = styled.button<SelectButtonRootProps>`
   color: ${getColor};
 
   &:focus {
-    border-color: ${() => color("brand")};
-    outline: 2px solid ${() => color("focus")};
+    border-color: ${color("brand")};
+    outline: 2px solid ${color("focus")};
   }
 
   &:not(:focus-visible) {

--- a/frontend/src/metabase/core/components/TextArea/TextArea.styled.tsx
+++ b/frontend/src/metabase/core/components/TextArea/TextArea.styled.tsx
@@ -23,7 +23,7 @@ export const TextAreaRoot = styled.textarea<TextAreaRootProps>`
 
   &:focus,
   &:hover {
-    border-color: ${() => color("brand")};
+    border-color: ${color("brand")};
     transition: border 300ms ease-in-out;
   }
   ${css`

--- a/frontend/src/metabase/databases/components/DatabaseEngineField/DatabaseEngineWidget.styled.tsx
+++ b/frontend/src/metabase/databases/components/DatabaseEngineField/DatabaseEngineWidget.styled.tsx
@@ -39,8 +39,8 @@ export const EngineCardRoot = styled.li<EngineCardRootProps>`
   outline: ${props => (props.isActive ? `2px solid ${color("focus")}` : "")};
 
   &:hover {
-    border-color: ${() => color("brand")};
-    background-color: ${() => lighten("brand", 0.6)};
+    border-color: ${color("brand")};
+    background-color: ${lighten("brand", 0.6)};
   }
 `;
 

--- a/frontend/src/metabase/plugins/components/SettingsCloudStoreLink/SettingsCloudStoreLink.styled.jsx
+++ b/frontend/src/metabase/plugins/components/SettingsCloudStoreLink/SettingsCloudStoreLink.styled.jsx
@@ -13,7 +13,7 @@ export const Link = styled(ExternalLink)`
   align-items: center;
   color: ${color("text-white")};
   font-weight: bold;
-  background-color: ${() => color("brand")};
+  background-color: ${color("brand")};
   padding: 12px 18px;
   border-radius: 6px;
 

--- a/frontend/src/metabase/query_builder/components/SidebarHeader/SidebarHeader.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/SidebarHeader/SidebarHeader.styled.tsx
@@ -65,6 +65,6 @@ export const CloseButton = styled.a`
   margin-left: auto;
 
   &:hover {
-    color: ${() => color("brand")};
+    color: ${color("brand")};
   }
 `;

--- a/frontend/src/metabase/visualizations/components/ChartSettingsWidget.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/ChartSettingsWidget.styled.tsx
@@ -67,7 +67,7 @@ export const Root = styled.div<{
 
     &:hover {
       transition: border 0.3s;
-      border-color: ${() => color("brand")};
+      border-color: ${color("brand")};
     }
   }
 `;

--- a/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.styled.tsx
@@ -24,12 +24,12 @@ export const ExpandButton = styled(Button)`
   border: 1px solid ${() => lighten("brand", 0.3)};
   padding: 0.125rem 0.25rem;
   border-radius: 0.25rem;
-  color: ${() => color("brand")};
+  color: ${color("brand")};
   margin-right: 0.5rem;
   margin-left: auto;
 
   &:hover {
-    color: ${() => color("text-white")};
-    background-color: ${() => color("brand")};
+    color: ${color("text-white")};
+    background-color: ${color("brand")};
   }
 `;

--- a/frontend/src/metabase/visualizations/components/TableSimple/TableSimple.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/TableSimple/TableSimple.styled.tsx
@@ -87,7 +87,7 @@ export const TableHeaderCellContent = styled.button<{
   }
 
   &:hover {
-    color: ${() => color("brand")};
+    color: ${color("brand")};
   }
 `;
 
@@ -113,7 +113,7 @@ export const PaginationButton = styled.button<{
   cursor: pointer;
 
   &:hover {
-    color: ${() => color("brand")};
+    color: ${color("brand")};
   }
 
   ${props =>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -143,6 +143,10 @@ const config = (module.exports = {
         process.env.MB_EDITION === "ee"
           ? ENTERPRISE_SRC_PATH + "/plugins"
           : SRC_PATH + "/lib/noop",
+      "ee-overrides":
+        process.env.MB_EDITION === "ee"
+          ? ENTERPRISE_SRC_PATH + "/overrides"
+          : SRC_PATH + "/lib/noop",
     },
   },
   cache: useFilesystemCache


### PR DESCRIPTION
Previously there were issues with `colors` constant being overwritten after some other files were imported. These files used the constant without whitelabel settings applied. This PR fixes the issue by moving whitelabel overrides to a separate file, which is imported before others.

How to test:
- Run Metabase EE
- Go to Admin -> Settings -> Appearance
- Change the brand color to something else
- Go to the root collection
- Refresh the page
- Try to create a new collection

Before
<img width="671" alt="Screenshot 2023-02-08 at 16 32 51" src="https://user-images.githubusercontent.com/8542534/217559730-c8e6f9e7-8571-43af-abb1-c35f5149e3c7.png">

After
<img width="710" alt="Screenshot 2023-02-08 at 16 38 35" src="https://user-images.githubusercontent.com/8542534/217562568-d0332823-6bf3-4677-9415-0303a945076d.png">

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/28148)
<!-- Reviewable:end -->
