### PR TITLE
Fix `metabase.util.log/infof` et al which are not formatting

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -28,12 +28,12 @@ jobs:
     timeout-minutes: 60
     steps:
     - uses: actions/checkout@v3
-    - name: Build static viz frontend
-      run: yarn build-static-viz
     - name: Prepare back-end environment
       uses: ./.github/actions/prepare-backend
       with:
         m2-cache-key: 'cloverage'
+    - name: Build static viz frontend
+      run: yarn build-static-viz
     - name: Collect the test coverage
       run: clojure -X:dev:ee:ee-dev:test:cloverage
     - name: Upload coverage to codecov.io

--- a/.github/workflows/cljs.yml
+++ b/.github/workflows/cljs.yml
@@ -16,5 +16,9 @@ jobs:
     - uses: actions/checkout@v3
     - name: Prepare front-end environment
       uses: ./.github/actions/prepare-frontend
+    - name: Prepare back-end environment
+      uses: ./.github/actions/prepare-backend
+      with:
+        m2-cache-key: 'cljs'
     - name: Run Cljs tests for shared/ code
       run: yarn run test-cljs

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -52,6 +52,10 @@ jobs:
     - uses: actions/checkout@v3
     - name: Prepare front-end environment
       uses: ./.github/actions/prepare-frontend
+    - name: Prepare back-end environment
+      uses: ./.github/actions/prepare-backend
+      with:
+        m2-cache-key: 'cljs'
     - run: yarn run lint-eslint
       name: Run ESLint linter
 
@@ -62,6 +66,10 @@ jobs:
     - uses: actions/checkout@v3
     - name: Prepare front-end environment
       uses: ./.github/actions/prepare-frontend
+    - name: Prepare back-end environment
+      uses: ./.github/actions/prepare-backend
+      with:
+        m2-cache-key: 'cljs'
     - run: yarn build-quick:cljs
       name: Compile CLJS
     - run: yarn type-check
@@ -75,6 +83,10 @@ jobs:
     - uses: actions/checkout@v3
     - name: Prepare front-end environment
       uses: ./.github/actions/prepare-frontend
+    - name: Prepare back-end environment
+      uses: ./.github/actions/prepare-backend
+      with:
+        m2-cache-key: 'cljs'
     - run: yarn run test-unit --coverage --silent
       name: Run frontend unit tests
     - name: Upload coverage to codecov.io
@@ -91,6 +103,10 @@ jobs:
     - uses: actions/checkout@v3
     - name: Prepare front-end environment
       uses: ./.github/actions/prepare-frontend
+    - name: Prepare back-end environment
+      uses: ./.github/actions/prepare-backend
+      with:
+        m2-cache-key: 'cljs'
     - run: yarn run test-timezones
       name: Run frontend timezones tests
 
@@ -104,6 +120,10 @@ jobs:
           fetch-depth: 0
       - name: Prepare front-end environment
         uses: ./.github/actions/prepare-frontend
+      - name: Prepare back-end environment
+        uses: ./.github/actions/prepare-backend
+        with:
+          m2-cache-key: 'cljs'
       - name: Publish to Chromatic
         uses: chromaui/action@v1
         env:

--- a/deps.edn
+++ b/deps.edn
@@ -280,6 +280,13 @@
   :oss-dev
   {}
 
+  :cljs
+  {:extra-paths ["test" "shared/test"]
+   :extra-deps
+   {com.lambdaisland/glogi  {:mvn/version "1.2.164"}
+    io.github.metabase/hawk {:sha "45ed36008014f9ac1ea66beb56fb1c4c39f8342b"}
+    thheller/shadow-cljs    {:mvn/version "2.19.6"}}}
+
   ;; for local dev -- include the drivers locally with :dev:drivers
   :drivers
   {:extra-deps

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -1,21 +1,6 @@
 ;; shadow-cljs configuration
-{:source-paths
- ["src"
-  "test"
-  "shared/src"
-  "shared/test"]
+{:deps {:aliases [:cljs]}
 
- ;; TODO -- share deps with deps.edn -- see https://shadow-cljs.github.io/docs/UsersGuide.html#deps-edn
- :dependencies
- [[org.clojure/core.match "1.0.0"]
-  [medley "1.4.0"]
-  [net.cgrand/macrovich "0.2.1"]
-  [prismatic/schema "1.2.0"]
-
-  ;; new stuff
-  [camel-snake-kebab "0.4.3"]
-  [org.clojure/tools.logging "1.2.4"] ; required at macro time by metabase.util.log
-  [com.lambdaisland/glogi "1.2.164"]]
  :nrepl
  {:middleware
   [cider.nrepl/cider-middleware

--- a/src/metabase/util/log.cljs
+++ b/src/metabase/util/log.cljs
@@ -18,10 +18,17 @@
 (defn is-loggable?
   "Part of the internals of [[glogi-logp]] etc."
   [logger-name level]
-  (glog/isLoggable (log/logger logger-name) (log/levels level)))
+  (glog/isLoggable (log/logger logger-name) (log/level level)))
 
 #_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
 (defn format-msg
   "Part of the internals of [[logf]]."
   [fmt & args]
   (apply gstring/format fmt args))
+
+(defn glogi-level
+  "Converts our standard `metabase.util.log` levels to those understood by glogi."
+  [level]
+  (if (= level :fatal)
+    :shout
+    level))

--- a/test/metabase/api/common/internal_test.clj
+++ b/test/metabase/api/common/internal_test.clj
@@ -98,7 +98,9 @@
                                       :zip    2999
                                       :lonlat [0.0 0.0]}}))))
       (is (some (fn [{message :msg, :as entry}]
-                  (when (str/includes? (str message) "Unexpected parameters")
+                  (when (str/includes? (str message)
+                                       (str "Unexpected parameters at [:post \"/post/test-address\"]: [:tags :address :id]\n"
+                                            "Please add them to the schema or remove them from the API client"))
                     entry))
                 (mb.logger/messages))))
 

--- a/test/metabase/test/util/log.cljs
+++ b/test/metabase/test/util/log.cljs
@@ -1,0 +1,32 @@
+(ns metabase.test.util.log
+  (:require
+    [lambdaisland.glogi :as glogi]
+    [metabase.util.log :as log])
+  (:require-macros [metabase.test.util.log]))
+
+(def ^:private level-overrides
+  {:warning :warn
+   :severe  :error
+   :shout   :fatal
+   :fine    :debug
+   :finer   :trace})
+
+(defn- extract-log [{:keys [exception level message]}]
+  [(get level-overrides level level) exception message])
+
+;; TODO This does not suppress the logs from actually reaching the console.
+;; Perhaps https://github.com/lambdaisland/glogi/issues/24 to add a `clear-handlers!` or similar.
+#_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
+(defn do-with-glogi-logs
+  "Used internally by the CLJS flavour of [[with-log-messages-for-level]]. Don't call this directly."
+  [log-ns level body-fn]
+  (let [captured     (atom [])
+        handler      (fn [record] (swap! captured conj record))]
+    (glogi/add-handler log-ns handler)
+    (glogi/set-levels {log-ns (log/glogi-level level)
+                       ""     :off})
+    (body-fn)
+    (glogi/remove-handler log-ns handler)
+    (glogi/set-levels {log-ns :info
+                       ""     :info})
+    (mapv extract-log @captured)))

--- a/test/metabase/util/log_test.cljc
+++ b/test/metabase/util/log_test.cljc
@@ -1,0 +1,47 @@
+(ns metabase.util.log-test
+  (:require
+    [clojure.test :refer [are deftest is]]
+    [metabase.test.util.log :as tlog]
+    [metabase.util.log :as log]))
+
+(deftest basic-logp-test
+  (is (= [[:warn nil "a message"]]
+         (tlog/with-log-messages-for-level :warn
+           (log/info "not this one")
+           (log/warn "a message"))))
+  (is (= [[:info nil "here's one"]
+          [:warn nil "a message"]]
+         (tlog/with-log-messages-for-level :info
+           (log/info "here's one")
+           (log/warn "a message"))))
+  (is (= [[:info nil ":keyword 78"]]
+         (tlog/with-log-messages-for-level :info
+           (log/info :keyword 78)))))
+
+(deftest logp-levels-test
+  (let [spam (fn []
+               (log/fatal "fatal")
+               (log/error "error")
+               (log/warn  "warn")
+               (log/info  "info")
+               (log/debug "debug")
+               (log/trace "trace"))
+        logs [[:fatal nil "fatal"]
+              [:error nil "error"]
+              [:warn  nil "warn"]
+              [:info  nil "info"]
+              [:debug nil "debug"]
+              [:trace nil "trace"]]]
+    (are [prefix level] (= (take prefix logs) (tlog/with-log-messages-for-level level (spam)))
+         ;0 :off - this doesn't work in CLJ and perhaps should?
+         1 :fatal
+         2 :error
+         3 :warn
+         4 :info
+         5 :debug
+         6 :trace)))
+
+(deftest logf-formatting-test
+  (is (= [[:info nil "input: 8, 3; output: ignored"]]
+         (tlog/with-log-messages-for-level :info
+           (log/infof "input: %d, %d; %s: ignored" 8 3 "output")))))


### PR DESCRIPTION
Includes much-improved testing for the logger in CLJ and CLJS.

**This moves us from explicit `shadow-cljs.edn` dependencies to relying
on deps.edn for everything.** It seems to be working nicely, and we
avoid deps drift.

