### PR TITLE
Removing / fixing warnings when updating a dashboard filter and with incorrect link templates

### DIFF
--- a/frontend/src/metabase/lib/formatting/link.ts
+++ b/frontend/src/metabase/lib/formatting/link.ts
@@ -61,7 +61,6 @@ function renderTemplateForClick(
       if (valueAndColumn) {
         return formatFunction(valueAndColumn);
       }
-      console.warn("Missing value for " + name);
       return "";
     },
   );

--- a/frontend/src/metabase/visualizations/components/Visualization/Visualization.jsx
+++ b/frontend/src/metabase/visualizations/components/Visualization/Visualization.jsx
@@ -140,9 +140,9 @@ class Visualization extends React.PureComponent {
       : null;
     const series = transformed && transformed.series;
     const visualization = transformed && transformed.visualization;
-    const computedSettings = series
+    const computedSettings = !this.isLoading(series)
       ? getComputedSettingsForSeries(series)
-      : null;
+      : {};
     this.setState({
       hovered: null,
       error: null,


### PR DESCRIPTION
Small adjustments to limit the amount of console warnings that are generated in dashboards. 

**First thing to test:** 
- Open any dashboard and observe logs. XRays are a great test case because they have multiple types of visualizations

*Before*: we likely see a number of warnings like the one below:
![image](https://user-images.githubusercontent.com/1328979/217652458-9dc28045-9395-47ef-bade-a04bb0d36274.png)
These would also come up when filtering. This is happening because we are attempting to compute viz settings before the visualization has loaded, so `series` is empty.

*After*: we should not see any warnings like the one above

**Second thing to test:**
- Create a dashboard with a table
- Add click behavior to the table where a column will go to a url
- in the URL template, use a column that doesn't exist. eg: `http://{SAMPLE}.com`
- save the changes to the dashboard

*Before*: We would see a large number of warnings that looked like this: 
![image](https://user-images.githubusercontent.com/1328979/217657439-2dcebcb0-c84f-4a7d-9b6f-b981214b10c2.png)
*After*: We should not get any warnings in the console logs around missing columns
