### PR TITLE
Custom migrations

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -399,6 +399,8 @@
   metabase.api.search-test/do-test-users                                               clojure.core/let
   metabase.async.api-response-test/with-response                                       clojure.core/let
   metabase.dashboard-subscription-test/with-dashboard-sub-for-card                     clojure.core/let
+  metabase.db.custom-migrations/defmigration                                           clj-kondo.lint-as/def-catch-all
+  metabase.db.custom-migrations/def-reversible-migration                               clj-kondo.lint-as/def-catch-all
   metabase.db.data-migrations/defmigration                                             clojure.core/def
   metabase.db.liquibase/with-liquibase                                                 clojure.core/let
   metabase.db.schema-migrations-test.impl/with-temp-empty-app-db                       clojure.core/let

--- a/bin/lint-migrations-file/src/change/strict.clj
+++ b/bin/lint-migrations-file/src/change/strict.clj
@@ -38,8 +38,13 @@
 (s/def ::createIndex
   (s/keys :req-un [::indexName]))
 
+(s/def :custom-change/class (every-pred string? (complement str/blank?)))
+
+(s/def ::customChange
+  (s/keys :req-un [:custom-change/class]))
+
 (s/def ::change
-  (s/keys :opt-un [::addColumn ::createTable ::createIndex]))
+  (s/keys :opt-un [::addColumn ::createTable ::createIndex ::customChange]))
 
 (s/def :change.strict.dbms-qualified-sql-change.sql/dbms
   string?)

--- a/bin/lint-migrations-file/src/change_set/strict.clj
+++ b/bin/lint-migrations-file/src/change_set/strict.clj
@@ -55,7 +55,10 @@
     :renameSequence
     :renameTable
     :renameTrigger
-    :renameView})
+    :renameView
+    ;; assumes all custom changes use the `def-migration` or `def-reversible-migration` in
+    ;; metabase.db.custom-migrations
+    :customChange})
 
 (defn- major-version
   "Returns major version from id string, e.g. 44 from \"v44.00-034\""

--- a/src/metabase/db/custom_migrations.clj
+++ b/src/metabase/db/custom_migrations.clj
@@ -1,16 +1,31 @@
 (ns metabase.db.custom-migrations
   (:require [metabase.util.log :as log]
-            [toucan.db :as db])
+            [toucan2.connection :as t2.conn])
   (:import [liquibase.change.custom CustomTaskChange CustomTaskRollback]
            liquibase.exception.ValidationErrors))
 
 (defmacro def-reversible-migration
-  "Define a reversible custom migration."
-  [name migration-body reverse-migration-body]
+  "Define a reversible custom migration. Both the forward and reverse migrations are defined using the same structure,
+  similar to the bodies of multi-arity Clojure functions. The first thing in each migration body must be a one-element
+  vector containing a binding to use for the database object provided by Liquibase, so that migrations have access to
+  it if needed. It is also set automatically as the current connection for Toucan 2.
+
+  Example:
+
+  ```clj
+  (def-reversible-migration ExampleMigrationName
+    ([_database]
+     (migration-body))
+
+    ([_database]
+     (migration-body)))"
+  [name [[db-binding-1] & migration-body] [[db-binding-2] reverse-migration-body]]
   `(defrecord ~name []
      CustomTaskChange
-     (execute [_# _database#]
-       ~migration-body)
+     (execute [_# database#]
+       (binding [toucan2.connection/*current-connectable* (.getWrappedConnection (.getConnection database#))]
+        (let [~db-binding-1 database#]
+          ~@migration-body)))
      (getConfirmationMessage [_#]
        (str "Custom migration: " ~name))
      (setUp [_#])
@@ -19,8 +34,10 @@
      (setFileOpener [_# _resourceAccessor#])
 
      CustomTaskRollback
-     (rollback [_# _database#]
-       ~reverse-migration-body)))
+     (rollback [_# database#]
+       (binding [toucan2.connection/*current-connectable* (.getWrappedConnection (.getConnection database#))]
+         (let [~db-binding-2 database#]
+           ~@reverse-migration-body)))))
 
 (defn no-op
   "No-op logging rollback function"
@@ -28,6 +45,6 @@
   (log/info "No rollback for: " n))
 
 (defmacro defmigration
-  "define a custom migration"
+  "Define a custom migration."
   [name migration-body]
-  `(def-reversible-migration ~name ~migration-body (no-op ~(str name))))
+  `(def-reversible-migration ~name ~migration-body ([~'_] (no-op ~(str name)))))

--- a/src/metabase/db/custom_migrations.clj
+++ b/src/metabase/db/custom_migrations.clj
@@ -4,6 +4,8 @@
   (:import [liquibase.change.custom CustomTaskChange CustomTaskRollback]
            liquibase.exception.ValidationErrors))
 
+(set! *warn-on-reflection* true)
+
 (defmacro def-reversible-migration
   "Define a reversible custom migration. Both the forward and reverse migrations are defined using the same structure,
   similar to the bodies of multi-arity Clojure functions.

--- a/src/metabase/db/custom_migrations.clj
+++ b/src/metabase/db/custom_migrations.clj
@@ -1,0 +1,33 @@
+(ns metabase.db.custom-migrations
+  (:require [metabase.util.log :as log]
+            [toucan.db :as db])
+  (:import [liquibase.change.custom CustomTaskChange CustomTaskRollback]
+           liquibase.exception.ValidationErrors))
+
+(defmacro def-reversible-migration
+  "Define a reversible custom migration."
+  [name migration-body reverse-migration-body]
+  `(defrecord ~name []
+     CustomTaskChange
+     (execute [_# _database#]
+       ~migration-body)
+     (getConfirmationMessage [_#]
+       (str "Custom migration: " ~name))
+     (setUp [_#])
+     (validate [_# _database#]
+       (ValidationErrors.))
+     (setFileOpener [_# _resourceAccessor#])
+
+     CustomTaskRollback
+     (rollback [_# _database#]
+       ~reverse-migration-body)))
+
+(defn no-op
+  "No-op logging rollback function"
+  [n]
+  (log/info "No rollback for: " n))
+
+(defmacro defmigration
+  "define a custom migration"
+  [name migration-body]
+  `(def-reversible-migration ~name ~migration-body (no-op ~(str name))))

--- a/src/metabase/db/custom_migrations.clj
+++ b/src/metabase/db/custom_migrations.clj
@@ -6,26 +6,28 @@
 
 (defmacro def-reversible-migration
   "Define a reversible custom migration. Both the forward and reverse migrations are defined using the same structure,
-  similar to the bodies of multi-arity Clojure functions. The first thing in each migration body must be a one-element
-  vector containing a binding to use for the database object provided by Liquibase, so that migrations have access to
-  it if needed. It is also set automatically as the current connection for Toucan 2.
+  similar to the bodies of multi-arity Clojure functions.
+
+  The first thing in each migration body must be a one-element vector containing a binding to use for the database
+  object provided by Liquibase, so that migrations have access to it if needed. This should typically not be used
+  directly, however, because is also set automatically as the current connection for Toucan 2.
 
   Example:
 
   ```clj
   (def-reversible-migration ExampleMigrationName
-    ([_database]
-     (migration-body))
+   ([_database]
+    (migration-body))
 
-    ([_database]
-     (migration-body)))"
+   ([_database]
+    (migration-body)))"
   [name [[db-binding-1] & migration-body] [[db-binding-2] reverse-migration-body]]
   `(defrecord ~name []
      CustomTaskChange
      (execute [_# database#]
        (binding [toucan2.connection/*current-connectable* (.getWrappedConnection (.getConnection database#))]
-        (let [~db-binding-1 database#]
-          ~@migration-body)))
+         (let [~db-binding-1 database#]
+           ~@migration-body)))
      (getConfirmationMessage [_#]
        (str "Custom migration: " ~name))
      (setUp [_#])

--- a/src/metabase/db/setup.clj
+++ b/src/metabase/db/setup.clj
@@ -9,6 +9,7 @@
   (:require
    [honey.sql :as sql]
    [metabase.db.connection :as mdb.connection]
+   metabase.db.custom-migrations ;; load our custom migrations
    [metabase.db.jdbc-protocols :as mdb.jdbc-protocols]
    [metabase.db.liquibase :as liquibase]
    [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]


### PR DESCRIPTION
Current syntax:

specify the migration with
```
  - changeSet:
      id: v46.00-080
      author: dpsutton
      comment: Uppercases all Card names
      changes:
        - customChange:
            class: "metabase.db.custom_migrations.ReversibleUppercaseCards"
```

and in the new namespace metabase.db.custom-migrations:

```clojure
(defmigration UppercaseCards
  (db/execute! {:update :report_card
                :set    {:name :%upper.name}}))

(def-reversible-migration ReversibleUppercaseCards
  (db/execute! {:update :report_card
                :set    {:name :%upper.name}})
  (db/execute! {:update :report_card
                :set    {:name :%lower.name}}))
```

While testing, I've found the below helpful in the custom migrations namespace:

```clojure
(comment

  (dev/migrate!)
  (dev/migrate! :down 45)
  (db/execute! {:delete-from :databasechangelog
                :where  [:= :id "v46.00-080"]})

  (db/select-field :name 'Card)



  (db/execute! {:update :report_card
                :set    {:name :%lower.name}})
  (db/execute! {:delete-from :databasechangelog
                :where  [:= :id "v46.00-080"]})

  )
```