### PR TITLE
Fix Avoid showing time granularity options for DATE columns

### DIFF
--- a/src/metabase/api/table.clj
+++ b/src/metabase/api/table.clj
@@ -139,15 +139,11 @@
                      :mbql [:field nil {:temporal-unit param}]
                      :type "type/DateTime"})
                   ;; note the order of these options corresponds to the order they will be shown to the user in the UI
-                  [[minute-str "minute"]
-                   [hour-str "hour"]
-                   [day-str "day"]
+                  [[day-str "day"]
                    [(deferred-tru "Week") "week"]
                    [(deferred-tru "Month") "month"]
                    [(deferred-tru "Quarter") "quarter"]
                    [(deferred-tru "Year") "year"]
-                   [(deferred-tru "Minute of Hour") "minute-of-hour"]
-                   [(deferred-tru "Hour of Day") "hour-of-day"]
                    [(deferred-tru "Day of Week") "day-of-week"]
                    [(deferred-tru "Day of Month") "day-of-month"]
                    [(deferred-tru "Day of Year") "day-of-year"]


### PR DESCRIPTION
### Description

The granularity/bucketing/binning options available for DATE (type/Date) fields incorrectly show time options as well because of dimension_options returned in /api/table/:id/query_metadata.
Follow-up on https://github.com/metabase/metabase/issues/27362

### How to verify

1. Question > Sample > People > group by Birth Date
2. The invalid options have been removed.

### Demo

<img width="1372" alt="image" src="https://user-images.githubusercontent.com/82889377/217707299-5b0fe51c-647c-49e1-9cf4-62c7d6ad9d53.png">

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
