### PR TITLE
[CI] Add `resources/` dir to the default paths

### DIFF
--- a/.github/file-paths.yaml
+++ b/.github/file-paths.yaml
@@ -1,6 +1,7 @@
 default: &default
-  - "locales/**"
   - "bin/**"
+  - "locales/**"
+  - "resources/**"
 
 ci: &ci
   - ".github/**"


### PR DESCRIPTION
This PR is the follow-up on #28048.

The bottom-line (Edit) of this comment was easy to overlook.
I don't think we can ignore `resources/` directory.