### PR TITLE
Refactor functions for selecting actions

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/e2e/yaml_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/e2e/yaml_test.clj
@@ -298,7 +298,8 @@
               (testing "for Actions"
                 (doseq [{:keys [entity_id] :as coll} (get @entities "Action")]
                   (is (= (clean-entity coll)
-                         (->> (action/select-action-without-implicit-params :entity_id entity_id)
+                         (->> (db/select-one 'Action :entity_id entity_id)
+                              action/hydrate-subtype
                               (serdes.base/extract-one "Action" {})
                               clean-entity)))))
 

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/e2e/yaml_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/e2e/yaml_test.clj
@@ -299,7 +299,7 @@
                 (doseq [{:keys [entity_id] :as coll} (get @entities "Action")]
                   (is (= (clean-entity coll)
                          (->> (db/select-one 'Action :entity_id entity_id)
-                              action/hydrate-subtype
+                              @#'action/hydrate-subtype
                               (serdes.base/extract-one "Action" {})
                               clean-entity)))))
 

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/e2e/yaml_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/e2e/yaml_test.clj
@@ -299,7 +299,7 @@
                 (doseq [{:keys [entity_id] :as coll} (get @entities "Action")]
                   (is (= (clean-entity coll)
                          (->> (db/select-one 'Action :entity_id entity_id)
-                              @#'action/hydrate-subtype
+                              (@#'action/hydrate-subtype)
                               (serdes.base/extract-one "Action" {})
                               clean-entity)))))
 

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/e2e/yaml_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/e2e/yaml_test.clj
@@ -298,7 +298,7 @@
               (testing "for Actions"
                 (doseq [{:keys [entity_id] :as coll} (get @entities "Action")]
                   (is (= (clean-entity coll)
-                         (->> (action/select-one :entity_id entity_id)
+                         (->> (action/select-action-without-implicit-params :entity_id entity_id)
                               (serdes.base/extract-one "Action" {})
                               clean-entity)))))
 

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
@@ -764,7 +764,7 @@
                                                :kind          "row/update"
                                                :creator_id    ann-id
                                                :model_id      card-id-1}]
-          (let [action (action/select-action-without-implicit-params :id action-id)]
+          (let [action (action/select-action :id action-id)]
             (testing "implicit action"
               (let [ser (serdes.base/extract-one "Action" {} action)]
                 (is (schema= {:serdes/meta (s/eq [{:model "Action" :id (:entity_id action) :label "my_action"}])
@@ -800,7 +800,7 @@
                                                :template      {}
                                                :creator_id    ann-id
                                                :model_id      card-id-1}]
-          (let [action (action/select-action-without-implicit-params :id action-id)]
+          (let [action (action/select-action :id action-id)]
             (testing "action"
               (let [ser (serdes.base/extract-one "Action" {} action)]
                 (is (schema= {:serdes/meta (s/eq [{:model "Action" :id (:entity_id action) :label "my_action"}])
@@ -836,7 +836,7 @@
                                                :database_id   db-id
                                                :creator_id    ann-id
                                                :model_id      card-id-1}]
-          (let [action (action/select-action-without-implicit-params :id action-id)]
+          (let [action (action/select-action :id action-id)]
             (testing "action"
               (let [ser (serdes.base/extract-one "Action" {} action)]
                 (is (schema= {:serdes/meta   (s/eq [{:model "Action"

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
@@ -764,7 +764,7 @@
                                                :kind          "row/update"
                                                :creator_id    ann-id
                                                :model_id      card-id-1}]
-          (let [action (action/select-one :id action-id)]
+          (let [action (action/select-action-without-implicit-params :id action-id)]
             (testing "implicit action"
               (let [ser (serdes.base/extract-one "Action" {} action)]
                 (is (schema= {:serdes/meta (s/eq [{:model "Action" :id (:entity_id action) :label "my_action"}])
@@ -800,7 +800,7 @@
                                                :template      {}
                                                :creator_id    ann-id
                                                :model_id      card-id-1}]
-          (let [action (action/select-one :id action-id)]
+          (let [action (action/select-action-without-implicit-params :id action-id)]
             (testing "action"
               (let [ser (serdes.base/extract-one "Action" {} action)]
                 (is (schema= {:serdes/meta (s/eq [{:model "Action" :id (:entity_id action) :label "my_action"}])
@@ -836,7 +836,7 @@
                                                :database_id   db-id
                                                :creator_id    ann-id
                                                :model_id      card-id-1}]
-          (let [action (action/select-one :id action-id)]
+          (let [action (action/select-action-without-implicit-params :id action-id)]
             (testing "action"
               (let [ser (serdes.base/extract-one "Action" {} action)]
                 (is (schema= {:serdes/meta   (s/eq [{:model "Action"

--- a/src/metabase/actions/execution.clj
+++ b/src/metabase/actions/execution.clj
@@ -211,7 +211,7 @@
   (let [dashcard (api/check-404 (db/select-one DashboardCard
                                                :id dashcard-id
                                                :dashboard_id dashboard-id))
-        action (api/check-404 (first (action/select-action :id (:action_id dashcard))))]
+        action (api/check-404 (action/select-action :id (:action_id dashcard)))]
     (if (= :implicit (:type action))
       (fetch-implicit-action-values dashboard-id action request-parameters)
       {})))

--- a/src/metabase/actions/execution.clj
+++ b/src/metabase/actions/execution.clj
@@ -178,7 +178,7 @@
   (let [dashcard (api/check-404 (db/select-one DashboardCard
                                                :id dashcard-id
                                                :dashboard_id dashboard-id))
-        action (api/check-404 (first (action/actions-with-implicit-params nil :id (:action_id dashcard))))]
+        action (api/check-404 (action/select-action :id (:action_id dashcard)))]
     (execute-action! action request-parameters)))
 
 (defn- fetch-implicit-action-values
@@ -211,7 +211,7 @@
   (let [dashcard (api/check-404 (db/select-one DashboardCard
                                                :id dashcard-id
                                                :dashboard_id dashboard-id))
-        action (api/check-404 (first (action/actions-with-implicit-params nil :id (:action_id dashcard))))]
+        action (api/check-404 (first (action/select-action :id (:action_id dashcard))))]
     (if (= :implicit (:type action))
       (fetch-implicit-action-values dashboard-id action request-parameters)
       {})))

--- a/src/metabase/api/action.clj
+++ b/src/metabase/api/action.clj
@@ -58,8 +58,7 @@
 
 (api/defendpoint GET "/:action-id"
   [action-id]
-  (-> (action/actions-with-implicit-params nil :id action-id)
-      first
+  (-> (action/select-action :id action-id)
       (hydrate :creator)
       api/read-check))
 
@@ -100,7 +99,7 @@
     (actions/check-actions-enabled! (db/select-one Database :id database_id)))
   (let [action-id (action/insert! (assoc action :creator_id api/*current-user-id*))]
     (if action-id
-      (first (action/actions-with-implicit-params nil :id action-id))
+      (action/select-action :id action-id)
       ;; db/insert! does not return a value when used with h2
       ;; so we return the most recently updated http action.
       (last (action/actions-with-implicit-params nil :type type)))))
@@ -125,7 +124,7 @@
    visualization_settings [:maybe map?]}
   (let [existing-action (api/write-check Action id)]
     (action/update! (assoc action :id id) existing-action))
-  (first (action/actions-with-implicit-params nil :id id)))
+  (action/select-one-with-implicit-params :id id))
 
 (api/defendpoint POST "/:id/public_link"
   "Generate publicly-accessible links for this Action. Returns UUID to be used in public links. (If this

--- a/src/metabase/api/action.clj
+++ b/src/metabase/api/action.clj
@@ -124,7 +124,7 @@
    visualization_settings [:maybe map?]}
   (let [existing-action (api/write-check Action id)]
     (action/update! (assoc action :id id) existing-action))
-  (action/select-one-with-implicit-params :id id))
+  (action/select-action :id id))
 
 (api/defendpoint POST "/:id/public_link"
   "Generate publicly-accessible links for this Action. Returns UUID to be used in public links. (If this

--- a/src/metabase/api/action.clj
+++ b/src/metabase/api/action.clj
@@ -53,7 +53,7 @@
     ;; We don't check the permissions on the actions, we assume they are
     ;; readable if the model is readable.
     (hydrate
-     (action/actions-with-implicit-params [model] :model_id model-id)
+     (action/select-actions [model] :model_id model-id)
      :creator)))
 
 (api/defendpoint GET "/:action-id"
@@ -102,7 +102,7 @@
       (action/select-action :id action-id)
       ;; db/insert! does not return a value when used with h2
       ;; so we return the most recently updated http action.
-      (last (action/actions-with-implicit-params nil :type type)))))
+      (last (action/select-actions nil :type type)))))
 
 (api/defendpoint PUT "/:id"
   [id :as

--- a/src/metabase/api/public.clj
+++ b/src/metabase/api/public.clj
@@ -320,7 +320,7 @@
   [uuid]
   {uuid ms/UUIDString}
   (validation/check-public-sharing-enabled)
-  (-> (action/actions-with-implicit-params nil :public_uuid uuid)
+  (-> (action/select-action :public_uuid uuid)
       first
       api/check-404
       (select-keys action-public-keys)))
@@ -584,7 +584,7 @@
         ;; failing because there are no current user perms; if this Dashcard is public
         ;; you're by definition allowed to run it without a perms check anyway
         (binding [api/*current-user-permissions-set* (delay #{"/"})]
-          (let [action (api/check-404 (first (action/actions-with-implicit-params nil :public_uuid uuid)))]
+          (let [action (api/check-404 (action/select-action :public_uuid uuid))]
             ;; Undo middleware string->keyword coercion
             (actions.execution/execute-action! action (update-keys parameters name))))))))
 

--- a/src/metabase/api/public.clj
+++ b/src/metabase/api/public.clj
@@ -321,7 +321,6 @@
   {uuid ms/UUIDString}
   (validation/check-public-sharing-enabled)
   (-> (action/select-action :public_uuid uuid)
-      first
       api/check-404
       (select-keys action-public-keys)))
 

--- a/src/metabase/models/action.clj
+++ b/src/metabase/models/action.clj
@@ -161,19 +161,19 @@
 (defn implicit-action-parameters
   "Return a set of parameters for the given models"
   [cards]
-  (let [card-by-table-id (into {}        ; table-id->card
+  (let [card-by-table-id (into {}
                                (for [card cards
                                      :let [{:keys [table-id]} (query/query->database-and-table-ids (:dataset_query card))]
                                      :when table-id]
                                  [table-id card]))
-        tables (when-let [table-ids (seq (keys card-by-table-id))] ; tables that are used in cards dataset query
+        tables (when-let [table-ids (seq (keys card-by-table-id))]
                  (hydrate (db/select 'Table :id [:in table-ids]) :fields))]
     (into {}
           (for [table tables
                 :let [fields (:fields table)]
                 ;; Skip tables for have conflicting slugified columns i.e. table has "name" and "NAME" columns.
                 :when (unique-field-slugs? fields)
-                :let [card (get card-by-table-id (:id table)) ; one card that uses the table. not sure what happens if multiple cards use the same table?
+                :let [card (get card-by-table-id (:id table))
                       exposed-fields (into #{} (keep :id) (:result_metadata card))
                       parameters (->> fields
                                       (filter #(contains? exposed-fields (:id %)))
@@ -190,7 +190,6 @@
   "Find actions with given options and generate implicit parameters for execution.
 
    Pass in known-models to save a second Card lookup."
-  ()
   ([known-models & options]
    (let [actions                         (apply select-actions-without-implicit-params options)
          implicit-action-model-ids       (set (map :model_id (filter (comp #(= :implicit %) :type) actions)))

--- a/test/metabase/models/action_test.clj
+++ b/test/metabase/models/action_test.clj
@@ -13,7 +13,7 @@
                        :name "Query Example"
                        :model_id model-id
                        :parameters [{:id "id" :type :number}]}
-                      (first (action/select-actions-without-implicit-params :id action-id))))
+                      (action/select-action-without-implicit-params :id action-id)))
         (is (partial= {:id action-id
                        :name "Query Example"
                        :model_id model-id
@@ -28,7 +28,7 @@
                        :name "Echo Example"
                        :parameters [{:id "id" :type :number}
                                     {:id "fail" :type :text}]}
-                      (first (action/select-actions-without-implicit-params :id action-id))))
+                      (action/select-action-without-implicit-params :id action-id)))
         (is (partial= {:id action-id
                        :name "Echo Example"
                        :parameters [{:id "id" :type :number}
@@ -45,7 +45,7 @@
                        :creator_id (mt/user->id :crowberto)
                        :creator {:common_name "Crowberto Corv"}
                        :parameters [{:id "id" :type :number}]}
-                      (hydrate (first (action/select-actions-without-implicit-params :id action-id)) :creator)))
+                      (hydrate (action/select-action-without-implicit-params :id action-id) :creator)))
         (is (partial= {:id action-id
                        :name "Query Example"
                        :model_id model-id

--- a/test/metabase/models/action_test.clj
+++ b/test/metabase/models/action_test.clj
@@ -13,7 +13,7 @@
                        :name "Query Example"
                        :model_id model-id
                        :parameters [{:id "id" :type :number}]}
-                      (first (action/select :id action-id))))
+                      (first (action/select-actions-without-implicit-params :id action-id))))
         (is (partial= {:id action-id
                        :name "Query Example"
                        :model_id model-id
@@ -28,7 +28,7 @@
                        :name "Echo Example"
                        :parameters [{:id "id" :type :number}
                                     {:id "fail" :type :text}]}
-                      (first (action/select :id action-id))))
+                      (first (action/select-actions-without-implicit-params :id action-id))))
         (is (partial= {:id action-id
                        :name "Echo Example"
                        :parameters [{:id "id" :type :number}
@@ -45,7 +45,7 @@
                        :creator_id (mt/user->id :crowberto)
                        :creator {:common_name "Crowberto Corv"}
                        :parameters [{:id "id" :type :number}]}
-                      (hydrate (first (action/select :id action-id)) :creator)))
+                      (hydrate (first (action/select-actions-without-implicit-params :id action-id)) :creator)))
         (is (partial= {:id action-id
                        :name "Query Example"
                        :model_id model-id

--- a/test/metabase/models/action_test.clj
+++ b/test/metabase/models/action_test.clj
@@ -13,12 +13,12 @@
                        :name "Query Example"
                        :model_id model-id
                        :parameters [{:id "id" :type :number}]}
-                      (first (action/select-actions :id action-id))))
+                      (first (action/select :id action-id))))
         (is (partial= {:id action-id
                        :name "Query Example"
                        :model_id model-id
                        :parameters [{:id "id" :type :number}]}
-                      (action/select-one :id action-id)))))))
+                      (action/select-action-without-implicit-params :id action-id)))))))
 
 (deftest hydrate-http-action-test
   (mt/test-drivers (mt/normal-drivers-with-feature :actions/custom)
@@ -28,12 +28,12 @@
                        :name "Echo Example"
                        :parameters [{:id "id" :type :number}
                                     {:id "fail" :type :text}]}
-                      (first (action/select-actions :id action-id))))
+                      (first (action/select :id action-id))))
         (is (partial= {:id action-id
                        :name "Echo Example"
                        :parameters [{:id "id" :type :number}
                                     {:id "fail" :type :text}]}
-                      (action/select-one :id action-id)))))))
+                      (action/select-action-without-implicit-params :id action-id)))))))
 
 (deftest hydrate-creator-test
   (mt/test-drivers (mt/normal-drivers-with-feature :actions/custom)
@@ -45,11 +45,11 @@
                        :creator_id (mt/user->id :crowberto)
                        :creator {:common_name "Crowberto Corv"}
                        :parameters [{:id "id" :type :number}]}
-                      (hydrate (first (action/select-actions :id action-id)) :creator)))
+                      (hydrate (first (action/select :id action-id)) :creator)))
         (is (partial= {:id action-id
                        :name "Query Example"
                        :model_id model-id
                        :creator_id (mt/user->id :crowberto)
                        :creator {:common_name "Crowberto Corv"}
                        :parameters [{:id "id" :type :number}]}
-                      (hydrate (action/select-one :id action-id) :creator)))))))
+                      (hydrate (action/select-action-without-implicit-params :id action-id) :creator)))))))

--- a/test/metabase/models/action_test.clj
+++ b/test/metabase/models/action_test.clj
@@ -13,12 +13,12 @@
                        :name "Query Example"
                        :model_id model-id
                        :parameters [{:id "id" :type :number}]}
-                      (action/select-action-without-implicit-params :id action-id)))
+                      (action/select-action :id action-id)))
         (is (partial= {:id action-id
                        :name "Query Example"
                        :model_id model-id
                        :parameters [{:id "id" :type :number}]}
-                      (action/select-action-without-implicit-params :id action-id)))))))
+                      (action/select-action :id action-id)))))))
 
 (deftest hydrate-http-action-test
   (mt/test-drivers (mt/normal-drivers-with-feature :actions/custom)
@@ -28,12 +28,12 @@
                        :name "Echo Example"
                        :parameters [{:id "id" :type :number}
                                     {:id "fail" :type :text}]}
-                      (action/select-action-without-implicit-params :id action-id)))
+                      (action/select-action :id action-id)))
         (is (partial= {:id action-id
                        :name "Echo Example"
                        :parameters [{:id "id" :type :number}
                                     {:id "fail" :type :text}]}
-                      (action/select-action-without-implicit-params :id action-id)))))))
+                      (action/select-action :id action-id)))))))
 
 (deftest hydrate-creator-test
   (mt/test-drivers (mt/normal-drivers-with-feature :actions/custom)
@@ -45,11 +45,11 @@
                        :creator_id (mt/user->id :crowberto)
                        :creator {:common_name "Crowberto Corv"}
                        :parameters [{:id "id" :type :number}]}
-                      (hydrate (action/select-action-without-implicit-params :id action-id) :creator)))
+                      (hydrate (action/select-action :id action-id) :creator)))
         (is (partial= {:id action-id
                        :name "Query Example"
                        :model_id model-id
                        :creator_id (mt/user->id :crowberto)
                        :creator {:common_name "Crowberto Corv"}
                        :parameters [{:id "id" :type :number}]}
-                      (hydrate (action/select-action-without-implicit-params :id action-id) :creator)))))))
+                      (hydrate (action/select-action :id action-id) :creator)))))))


### PR DESCRIPTION
This is a refactor that eases selecting actions and makes the function names more consistent.

Before:
```
;; selecting one action
(first (actions-with-implicit-params nil <options>))

;; selecting multiple actions
(actions-with-implicit-params nil <options>) 
```

After:
```
;; selecting one action
(select-action <options>)

;; selecting multiple actions
(select-actions nil <options>)
```

The name change from `actions-with-implicit-params` to `select-actions` is appropriate because selecting an action with generated implicit params should be the default. Selecting actions without implicit params needs the caller to know the parameters aren't going to be used, and this assumption should be called out explicitly.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/28187)
<!-- Reviewable:end -->
