### PR TITLE
Add conditional concurrency to low risk workflows

### DIFF
--- a/.github/workflows/cljs.yml
+++ b/.github/workflows/cljs.yml
@@ -7,6 +7,10 @@ on:
       - 'release-**'
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref && github.ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
 
   shared-tests-cljs:

--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -7,6 +7,10 @@ on:
       - 'release-**'
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref && github.ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
 
   verify-i18n-files:


### PR DESCRIPTION
Is this a dream come true? Conditional concurrency on GitHub, third attempt.

> **Note**
> Because previous attempts were known to backfire, I'm playing it safe and adding the concurrency only to two of a very low-risk workflows. It will be enough to confirm everything works since they are triggered on every push without any filters.

```yml
concurrency:
  group: ${{ github.workflow }}-${{ github.head_ref && github.ref || github.run_id }}
  cancel-in-progress: true
```

Everything inside `${{ }}` is an [expression](https://docs.github.com/en/actions/learn-github-actions/expressions).

- `${{ github.head_ref && github.ref || github.run_id }}` acts as a fake ternary.
- `github.head_ref` exists only for pull requests and coerces to `false` on `master`

---
Requirements for our repo:
1. `group` should have a unique identifier on `master` because we **never** want to cancel any job in progress there
    - cancelling a job in progress on `master` leads to a failed run and it sends wrong message by printing ❌
2. `group` should be scoped to a workflow PLUS the branch for that PR to avoid cancelling others' workflows

### How to test?
If we have TWO workflows named "Foo" and "Bar" and we push two commits in a row, this is what we'd get for `group`:
1. on `master`:
    - comit A
        - **Foo-4135785169**
        - **Bar-4135785170**
    - commit B
        - **Foo-4135785171**
        - **Bar-4135785172**
2. in a PR:
    - commit A:
        - **Foo-refs/pull/14/merge**
        - **Bar-refs/pull/14/merge**
    - commit B:
        - **Foo-refs/pull/14/merge**
        - **Bar-refs/pull/14/merge**
        
        
It seems we've achieved the goal.
- `group` identifiers on `master` are always unique regardless of a workflow and will never be cancelled.
- `group` identifiers in PRs are unique among themselves, but are repeating in consecutive commits which ensures the previous run will be cancelled. Only the latest commit will run checks.
