### PR TITLE
Attempt to fix model editor sidebar

### DIFF
--- a/frontend/src/metabase-lib/Question.ts
+++ b/frontend/src/metabase-lib/Question.ts
@@ -713,7 +713,7 @@ class QuestionInner {
             const dimension = query.columnDimensionWithName(name);
             return {
               name: name,
-              field_ref: getBaseDimensionReference(dimension.mbql()),
+              fieldRef: getBaseDimensionReference(dimension.mbql()),
               enabled: true,
             };
           }),

--- a/frontend/src/metabase-lib/metadata/utils/models.ts
+++ b/frontend/src/metabase-lib/metadata/utils/models.ts
@@ -1,5 +1,11 @@
 import { TemplateTag } from "metabase-types/types/Query";
-import { ModelCacheRefreshStatus } from "metabase-types/api";
+import {
+  DatasetColumn,
+  Field,
+  FieldReference,
+  ModelCacheRefreshStatus,
+  TableColumnOrderSetting,
+} from "metabase-types/api";
 import {
   Card as CardObject,
   CardId,
@@ -9,6 +15,7 @@ import { getQuestionVirtualTableId } from "metabase-lib/metadata/utils/saved-que
 import Database from "metabase-lib/metadata/Database";
 import Question from "metabase-lib/Question";
 import NativeQuery from "metabase-lib/queries/NativeQuery";
+import { isSameField } from "metabase-lib/queries/utils/field-ref";
 import { isStructured } from "metabase-lib/queries/utils";
 
 export type FieldMetadata = {
@@ -155,4 +162,51 @@ export function getModelCacheSchemaName(databaseId: number, siteUUID: string) {
   const uuidParts = siteUUID.split("-");
   const firstLetters = uuidParts.map(part => part.charAt(0)).join("");
   return `metabase_cache_${firstLetters}_${databaseId}`;
+}
+
+type QueryField = Field & { field_ref: FieldReference };
+
+function getFieldFromColumnVizSetting(
+  columnVizSetting: TableColumnOrderSetting,
+  columns: DatasetColumn[],
+  columnMetadata: QueryField[],
+) {
+  // We have some corrupted visualization settings where both names are mixed
+  // We should settle on `fieldRef`, make it required and remove `field_ref`
+  const fieldRef = columnVizSetting.fieldRef || columnVizSetting.field_ref;
+  return (
+    columns.find(column => isSameField(column.field_ref, fieldRef)) ||
+    columnMetadata.find(column => isSameField(column.field_ref, fieldRef))
+  );
+}
+
+export function getSortedModelFields(model: Question) {
+  // Columns in resultsMetadata contain all the necessary metadata
+  // orderedColumns contain properly sorted columns, but they only contain field names and refs.
+  // Normally, columns in resultsMetadata are ordered too,
+  // but they only get updated after running a query (which is not triggered after reordering columns).
+  // This ensures metadata rich columns are sorted correctly not to break the "Tab" key navigation behavior.
+  const columnMetadata = model.getResultMetadata();
+
+  if (!Array.isArray(columnMetadata)) {
+    return [];
+  }
+
+  const orderedColumns = model.setting("table.columns");
+
+  if (!Array.isArray(orderedColumns)) {
+    return columnMetadata;
+  }
+
+  const table = model.table();
+  const tableFields = table?.fields ?? [];
+  const tableColumns = tableFields.map(field => field.column());
+
+  return orderedColumns.map(columnVizSetting =>
+    getFieldFromColumnVizSetting(
+      columnVizSetting,
+      tableColumns,
+      columnMetadata,
+    ),
+  );
 }

--- a/frontend/src/metabase-types/api/card.ts
+++ b/frontend/src/metabase-types/api/card.ts
@@ -64,9 +64,19 @@ export type PivotTableCollapsedRowsSetting = {
   value: string[]; // identifiers for collapsed rows
 };
 
+export type TableColumnOrderSetting = {
+  name: string;
+  enabled: boolean;
+  fieldRef?: FieldReference;
+  field_ref?: FieldReference;
+};
+
 export type VisualizationSettings = {
   "graph.show_values"?: boolean;
   "stackable.stack_type"?: "stacked" | "normalized" | null;
+
+  // Table
+  "table.columns"?: TableColumnOrderSetting[];
 
   // X-axis
   "graph.x_axis.title_text"?: string;

--- a/frontend/src/metabase-types/api/card.ts
+++ b/frontend/src/metabase-types/api/card.ts
@@ -67,6 +67,9 @@ export type PivotTableCollapsedRowsSetting = {
 export type TableColumnOrderSetting = {
   name: string;
   enabled: boolean;
+
+  // We have some corrupted visualization settings where both names are mixed
+  // We should settle on `fieldRef`, make it required and remove `field_ref`
   fieldRef?: FieldReference;
   field_ref?: FieldReference;
 };

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.jsx
@@ -30,7 +30,10 @@ import { useToggle } from "metabase/hooks/use-toggle";
 
 import { MODAL_TYPES } from "metabase/query_builder/constants";
 import { isSameField } from "metabase-lib/queries/utils/field-ref";
-import { checkCanBeModel } from "metabase-lib/metadata/utils/models";
+import {
+  checkCanBeModel,
+  getSortedModelFields,
+} from "metabase-lib/metadata/utils/models";
 import { EDITOR_TAB_INDEXES } from "./constants";
 import DatasetFieldMetadataSidebar from "./DatasetFieldMetadataSidebar";
 import DatasetQueryEditor from "./DatasetQueryEditor";
@@ -187,42 +190,8 @@ function DatasetEditor(props) {
     handleResize,
     onOpenModal,
   } = props;
-  const orderedColumns = useMemo(
-    () => dataset.setting("table.columns"),
-    [dataset],
-  );
 
-  const fields = useMemo(() => {
-    const virtualCardTable = dataset.table();
-    const virtualCardColumns = (virtualCardTable?.fields ?? []).map(field =>
-      field.column(),
-    );
-    // Columns in resultsMetadata contain all the necessary metadata
-    // orderedColumns contain properly sorted columns, but they only contain field names and refs.
-    // Normally, columns in resultsMetadata are ordered too,
-    // but they only get updated after running a query (which is not triggered after reordering columns).
-    // This ensures metadata rich columns are sorted correctly not to break the "Tab" key navigation behavior.
-    const columns = resultsMetadata?.columns;
-
-    if (!Array.isArray(columns)) {
-      return [];
-    }
-    if (!Array.isArray(orderedColumns)) {
-      return columns;
-    }
-
-    function getFieldFromColumnVizSetting(columnVizSetting) {
-      const fieldRef = columnVizSetting.fieldRef || columnVizSetting.field_ref;
-      return (
-        columns.find(column => isSameField(column.field_ref, fieldRef)) ||
-        virtualCardColumns.find(column =>
-          isSameField(column.field_ref, fieldRef),
-        )
-      );
-    }
-
-    return orderedColumns.map(getFieldFromColumnVizSetting).filter(Boolean);
-  }, [dataset, orderedColumns, resultsMetadata]);
+  const fields = useMemo(() => getSortedModelFields(dataset), [dataset]);
 
   const isEditingQuery = datasetEditorTab === "query";
   const isEditingMetadata = datasetEditorTab === "metadata";

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.jsx
@@ -210,13 +210,18 @@ function DatasetEditor(props) {
     if (!Array.isArray(orderedColumns)) {
       return columns;
     }
-    return orderedColumns
-      .map(
-        col =>
-          columns.find(c => isSameField(c.field_ref, col.fieldRef)) ||
-          virtualCardColumns.find(c => isSameField(c.field_ref, col.fieldRef)),
-      )
-      .filter(Boolean);
+
+    function getFieldFromColumnVizSetting(columnVizSetting) {
+      const fieldRef = columnVizSetting.fieldRef || columnVizSetting.field_ref;
+      return (
+        columns.find(column => isSameField(column.field_ref, fieldRef)) ||
+        virtualCardColumns.find(column =>
+          isSameField(column.field_ref, fieldRef),
+        )
+      );
+    }
+
+    return orderedColumns.map(getFieldFromColumnVizSetting).filter(Boolean);
   }, [dataset, orderedColumns, resultsMetadata]);
 
   const isEditingQuery = datasetEditorTab === "query";


### PR DESCRIPTION
Fixes an issue we encountered on our internal instance. There's a single model for which the metadata editor sidebar doesn't show up.

As far as I know, the only case when it happens is when there's no focused field. [Here's the check](https://github.com/metabase/metabase/blob/1f16ac8374cfc7ba5e701ce56a0a7ba2d4364f26/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.jsx#L118) and [we keep the focused field reference in model editor state](https://github.com/metabase/metabase/blob/1f16ac8374cfc7ba5e701ce56a0a7ba2d4364f26/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.jsx#L239). Usually, it's `undefined` by default and [is set to the first available field once the query completes](https://github.com/metabase/metabase/blob/1f16ac8374cfc7ba5e701ce56a0a7ba2d4364f26/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.jsx#L273). What was odd about the problematic model is that clicking on the column header didn't focus the field either. Turns out, this model's `visualization_settings["table.columns"]` have used `field_ref` instead of expected `fieldRef`. So it made the checks [here](https://github.com/metabase/metabase/blob/1f16ac8374cfc7ba5e701ce56a0a7ba2d4364f26/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.jsx#L216) return nothing, however, we have all the column data.

Fixed by checking for both `fieldRef` and `field_ref` inside the editor 🥴 I'm open to a more global solution for existing questions with mixed naming tho :/ Also fixed what we believe was making some questions end up having incorrectly named `fieldRef` parameters. There's code inside the `Question's` method that is called to sync `visualization_settings["table.columns"]` values with actual columns in query results to ensure they're consistent.