### PR TITLE
Fix broken jar after #28133

### DIFF
--- a/src/metabase/util.cljc
+++ b/src/metabase/util.cljc
@@ -8,7 +8,7 @@
    [clojure.walk :as walk]
    [flatland.ordered.map :refer [ordered-map]]
    [medley.core :as m]
-   [metabase.shared.util.i18n :refer [tru] :as i18n]
+   [metabase.shared.util.i18n :refer [tru] :as shared.i18n]
    [metabase.shared.util.namespaces :as u.ns]
    [metabase.util.format :as u.format]
    [metabase.util.log :as log]
@@ -18,6 +18,7 @@
               [metabase.config :as config]
               #_{:clj-kondo/ignore [:discouraged-namespace]}
               [metabase.util.jvm :as u.jvm]
+              [metabase.util.i18n :as i18n]
               [potemkin :as p]
               [ring.util.codec :as codec]]))
   #?(:clj (:import
@@ -320,8 +321,8 @@
                ;; next, remove the combining diacritical marks -- this SO answer explains what's going on here best:
                ;; http://stackoverflow.com/a/5697575/1198455 The closest thing to a relevant JavaDoc I could find was
                ;; http://docs.oracle.com/javase/7/docs/api/java/lang/Character.UnicodeBlock.html#COMBINING_DIACRITICAL_MARKS
-               #"\p{Block=CombiningDiacriticalMarks}+"
-               "")
+              #"\p{Block=CombiningDiacriticalMarks}+"
+              "")
        :cljs (-> s
                  (.normalize "NFKD")  ;; Renders accented characters as base + accent.
                  (.replace (js/RegExp. "[\u0300-\u036f]" "gu") ""))))) ;; Drops all the accents.


### PR DESCRIPTION
The jar was broken after #28133 is merged.
Failed health check job: https://github.com/metabase/metabase/actions/runs/4141809666/jobs/7164042392

I don't fully understand why using `shared.i18n` broke it, but switching to `clojure i18n` seems to work.