### PR TITLE
Add conditional concurrency to heavy-traffic workflows

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -8,6 +8,10 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref && github.ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   files-changed:
     name: Check which files changed

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -9,7 +9,7 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
 
 concurrency:
-  group: ${{ github.head_ref || github.run_id}}
+  group: ${{ github.workflow }}-${{ github.head_ref && github.ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -8,6 +8,10 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref && github.ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   files-changed:
     name: Check which files changed


### PR DESCRIPTION
Continuation of https://github.com/metabase/metabase/pull/28192

After this PR, the load on the CI queue should be lighter as each subsequent push to the PR would cancel long-running workflows.

In this example from the screenshot, all three runs were active before I manually cancelled the two oldest ones. You can imagine how much we're overloading the CI if one backend job takes about 30 minutes to finish.
![Screenshot 2023-02-10 at 15 44 25](https://user-images.githubusercontent.com/31325167/218120370-092513c9-e008-49ef-bb24-f2e491624156.png)

Once we merge this PR, nobody needs to be vigilant anymore and to manually cancel unneeded jobs. That will happen automatically.