### PR TITLE
Define browser in the main Cypress config

### DIFF
--- a/frontend/test/__runner__/cypress-runner-generate-snapshots.js
+++ b/frontend/test/__runner__/cypress-runner-generate-snapshots.js
@@ -2,7 +2,6 @@ const cypress = require("cypress");
 
 const getConfig = baseUrl => {
   return {
-    browser: "chrome",
     configFile: "frontend/test/__support__/e2e/cypress-snapshots.config.js",
     config: {
       baseUrl,

--- a/frontend/test/__runner__/cypress-runner-run-tests.js
+++ b/frontend/test/__runner__/cypress-runner-run-tests.js
@@ -42,7 +42,6 @@ const runCypress = async (baseUrl, exitFunction) => {
   });
 
   const defaultConfig = {
-    browser: "chrome",
     configFile: "frontend/test/__support__/e2e/cypress.config.js",
     config: {
       baseUrl,

--- a/frontend/test/__support__/e2e/config.js
+++ b/frontend/test/__support__/e2e/config.js
@@ -87,6 +87,7 @@ const defaultConfig = {
   },
   supportFile: "frontend/test/__support__/e2e/cypress.js",
   videoUploadOnPasses: false,
+  browser: "chrome",
   chromeWebSecurity: false,
   modifyObstructiveCode: false,
 };


### PR DESCRIPTION
Before this change

If you run `yarn test-cypress-run --browser electron` it would fail if you didn't have Chrome installed on your OS.
```
Can't run because you've entered an invalid browser name.

Browser: chrome was not found on your system or is not supported by Cypress.

Cypress supports the following browsers:
 - electron
 - chrome
 - chromium
 - chrome:canary
 - edge
 - firefox

You can also use a custom browser: https://on.cypress.io/customize-browsers

Available browsers found on your system are:
 - firefox
 - electron
```

After this change:
CLI overrides the default config and you can run Cypress with whatever browser you provided.