### PR TITLE
Fix Node FE builder?

### DIFF
--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -74,7 +74,7 @@ services:
 #       Hopefully one of our node geniuses can figure it out.
   # Just build the frontend. Mounts local dev so nothing else needed
   fe-builder:
-    image: node:18.14
+    image: node:16
     container_name: fe-builder
     working_dir: /dev/metabase
     volumes:


### PR DESCRIPTION
We use Node 16 for building the FE. I think that's the reason why it doesn't build

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/28228)
<!-- Reviewable:end -->
