### PR TITLE
Fix `shared.util.i18n`

### DIFF
--- a/shared/src/metabase/shared/util/i18n.clj
+++ b/shared/src/metabase/shared/util/i18n.clj
@@ -1,12 +1,7 @@
 (ns metabase.shared.util.i18n
   (:require
-   [metabase.util.i18n]
+   [metabase.util.i18n :as i18n]
    [net.cgrand.macrovich :as macros]))
-
-;; Needs to be loaded in CLOJURE LAND so people using this stuff will have access to things like
-;; [[metabase.util.i18n/tru]]. For ClojureScript compilation there is nothing of value in this namespace, but it doesn't
-;; really hurt anything to load it.
-(comment metabase.util.i18n/keep-me)
 
 (defmacro tru
   "i18n a string with the user's locale. Format string will be translated to the user's locale when the form is eval'ed.
@@ -16,7 +11,7 @@
   [format-string & args]
   (macros/case
     :clj
-    `(metabase.util.i18n/tru ~format-string ~@args)
+    `(i18n/tru ~format-string ~@args)
 
     :cljs
     `(js-i18n ~format-string ~@args)))
@@ -34,7 +29,7 @@
     :clj
     (do
       (require 'metabase.util.i18n)
-      `(metabase.util.i18n/trs ~format-string ~@args))
+      `(i18n/trs ~format-string ~@args))
 
     :cljs
     `(js-i18n ~format-string ~@args)))
@@ -46,7 +41,7 @@
   [format-string format-string-pl n]
   (macros/case
     :clj
-    `(metabase.util.i18n/trsn ~format-string ~format-string-pl ~n)
+    `(i18n/trsn ~format-string ~format-string-pl ~n)
 
     :cljs
     `(js-i18n-n ~format-string ~format-string-pl ~n)))

--- a/shared/src/metabase/shared/util/i18n.clj
+++ b/shared/src/metabase/shared/util/i18n.clj
@@ -1,6 +1,12 @@
 (ns metabase.shared.util.i18n
   (:require
+   [metabase.util.i18n]
    [net.cgrand.macrovich :as macros]))
+
+;; Needs to be loaded in CLOJURE LAND so people using this stuff will have access to things like
+;; [[metabase.util.i18n/tru]]. For ClojureScript compilation there is nothing of value in this namespace, but it doesn't
+;; really hurt anything to load it.
+(comment metabase.util.i18n/keep-me)
 
 (defmacro tru
   "i18n a string with the user's locale. Format string will be translated to the user's locale when the form is eval'ed.
@@ -10,9 +16,7 @@
   [format-string & args]
   (macros/case
     :clj
-    (do
-      (require 'metabase.util.i18n)
-      `(metabase.util.i18n/tru ~format-string ~@args))
+    `(metabase.util.i18n/tru ~format-string ~@args)
 
     :cljs
     `(js-i18n ~format-string ~@args)))
@@ -42,9 +46,7 @@
   [format-string format-string-pl n]
   (macros/case
     :clj
-    (do
-      (require 'metabase.util.i18n)
-      `(metabase.util.i18n/trsn ~format-string ~format-string-pl ~n))
+    `(metabase.util.i18n/trsn ~format-string ~format-string-pl ~n)
 
     :cljs
     `(js-i18n-n ~format-string ~format-string-pl ~n)))

--- a/src/metabase/util.cljc
+++ b/src/metabase/util.cljc
@@ -8,7 +8,7 @@
    [clojure.walk :as walk]
    [flatland.ordered.map :refer [ordered-map]]
    [medley.core :as m]
-   [metabase.shared.util.i18n :refer [tru] :as shared.i18n]
+   [metabase.shared.util.i18n :refer [tru] :as i18n]
    [metabase.shared.util.namespaces :as u.ns]
    [metabase.util.format :as u.format]
    [metabase.util.log :as log]
@@ -18,7 +18,6 @@
               [metabase.config :as config]
               #_{:clj-kondo/ignore [:discouraged-namespace]}
               [metabase.util.jvm :as u.jvm]
-              [metabase.util.i18n :as i18n]
               [potemkin :as p]
               [ring.util.codec :as codec]]))
   #?(:clj (:import


### PR DESCRIPTION
`metabase.shared.util.i18n/tru` was macroexpanding to something like

```clj
(metabase.util.i18n/str* (metabase.util.i18n.UserLocalizedString. "Number of cans: {0}" [2] {}))
```

which didn't work because `metabase.util.i18n` was not necessarily loaded yet. Fix is to have `metabase.shared.util.i18n` load `metabase.util.i18n` so anyone using macros like `metabase.shared.util.i18n` in Clojure-land will get `metabase.util.i18n` loaded as well. Won't affect the macroexpansion in ClojureScript, since there's a separate `.cljs` version of this namespace, and the `.clj` version is only used for its macros

Reverted the changes in #28209 because that only fixed stuff that happened to get loaded _after_ `metabase.util` -- it could still break if some other namespace was loaded _before_ `metabase.util` in the future.