### PR TITLE
Add Codespell linter

### DIFF
--- a/.codespellignore
+++ b/.codespellignore
@@ -1,0 +1,3 @@
+edn
+juxt
+methodd

--- a/.codespellignore
+++ b/.codespellignore
@@ -1,3 +1,4 @@
+altho
 datas
 edn
 juxt

--- a/.codespellignore
+++ b/.codespellignore
@@ -1,3 +1,7 @@
+datas
 edn
 juxt
 methodd
+pass-thru
+ser
+trun

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,3 @@
+[codespell]
+skip = ./.git,./target,./.clj-kondo/.cache
+ignore-words = .codespellignore

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,3 +1,3 @@
 [codespell]
-skip = ./.git,./target,./.clj-kondo/.cache,./locales,./resources/common_passwords.txt,./resources/i18n,./resources/frontend_client,./node_modules,./.shadow-cljs,./yarn.lock
+skip = ./.git,target,./.clj-kondo/.cache,./locales,./resources/common_passwords.txt,./resources/i18n,./resources/frontend_client,./node_modules,./.shadow-cljs,./yarn.lock,./modules/drivers/sqlserver/resources/timezones/windowsZones.xml,#*#,./test/metabase/test/data/dataset_definitions/*.edn,./frontend/test/snapshots/*.sql
 ignore-words = .codespellignore

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,3 +1,3 @@
 [codespell]
-skip = ./.git,target,./.clj-kondo/.cache,./locales,./resources/common_passwords.txt,./resources/i18n,./resources/frontend_client,./node_modules,./.shadow-cljs,./yarn.lock,./modules/drivers/sqlserver/resources/timezones/windowsZones.xml,#*#,./test/metabase/test/data/dataset_definitions/*.edn,./frontend/test/snapshots/*.sql
+skip = ./.git,target,./.clj-kondo/.cache,./locales,./resources/common_passwords.txt,./resources/i18n,./resources/frontend_client,./node_modules,./.shadow-cljs,./yarn.lock,./modules/drivers/sqlserver/resources/timezones/windowsZones.xml,#*#,./test/metabase/test/data/dataset_definitions/*.edn,./frontend/test/snapshots/*.sql,./frontend/src/cljs
 ignore-words = .codespellignore

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,3 +1,3 @@
 [codespell]
-skip = ./.git,./target,./.clj-kondo/.cache
+skip = ./.git,./target,./.clj-kondo/.cache,./locales,./resources/common_passwords.txt,./resources/i18n,./resources/frontend_client,./node_modules,./.shadow-cljs,./yarn.lock
 ignore-words = .codespellignore

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,18 @@
+name: Codespell
+
+on:
+  push:
+    branches:
+      - 'master'
+      - 'release-**'
+  pull_request:
+
+jobs:
+
+  codespell:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+      - uses: codespell-project/actions-codespell@v1
+        with:
+          ignore_words_file: .codespellignore


### PR DESCRIPTION
I talked about doing this a million years ago, here it is.

Misspellings are a bad look, especially in our dox. Codespell can help us with a lot of that stuff.

I don't really have any intention of fixing all the errors here myself. Maybe someone else can help with this.

Run locally with `codespell` if you have it installed. `codespell -w -i 1` can interactively fix stuff for you.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/28233)
<!-- Reviewable:end -->
