### PR TITLE
Fix the date/day_of_birth/birthday classifiers ignoring columns with …

### DIFF
--- a/src/metabase/sync/analyze/classifiers/name.clj
+++ b/src/metabase/sync/analyze/classifiers/name.clj
@@ -109,7 +109,9 @@
    [#"description"                 text-type        :type/Description]
    [#"title"                       text-type        :type/Title]
    [#"comment"                     text-type        :type/Comment]
+   [#"birthda(?:te|y)"             date-type        :type/Birthdate]
    [#"birthda(?:te|y)"             timestamp-type   :type/Birthdate]
+   [#"(?:te|y)(?:_?)of(?:_?)birth" date-type        :type/Birthdate]
    [#"(?:te|y)(?:_?)of(?:_?)birth" timestamp-type   :type/Birthdate]])
 
 ;; Check that all the pattern tuples are valid


### PR DESCRIPTION
…date-type

copies over the commits from https://github.com/metabase/metabase/pull/28084 and runs them first party