### PR TITLE
26890 viz picker behavior

### DIFF
--- a/frontend/src/metabase/core/components/ButtonGroup/ButtonGroup.styled.tsx
+++ b/frontend/src/metabase/core/components/ButtonGroup/ButtonGroup.styled.tsx
@@ -3,8 +3,7 @@ import Button from "metabase/core/components/Button";
 import { color } from "metabase/lib/colors";
 
 export const ButtonGroupRoot = styled.div`
-  display: inline-flex;
-  align-items: center;
+  display: inline-block;
 
   ${Button.Root} {
     border: 1px solid ${color("border")};

--- a/frontend/src/metabase/core/components/ButtonGroup/ButtonGroup.styled.tsx
+++ b/frontend/src/metabase/core/components/ButtonGroup/ButtonGroup.styled.tsx
@@ -3,7 +3,8 @@ import Button from "metabase/core/components/Button";
 import { color } from "metabase/lib/colors";
 
 export const ButtonGroupRoot = styled.div`
-  display: inline-block;
+  display: inline-flex;
+  align-items: center;
 
   ${Button.Root} {
     border: 1px solid ${color("border")};

--- a/frontend/src/metabase/query_builder/components/view/ViewFooter.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewFooter.jsx
@@ -14,10 +14,7 @@ import QueryDownloadWidget from "metabase/query_builder/components/QueryDownload
 import QuestionEmbedWidget, {
   QuestionEmbedWidgetTrigger,
 } from "metabase/query_builder/containers/QuestionEmbedWidget";
-import {
-  getVisualizationRaw,
-  getIconForVisualizationType,
-} from "metabase/visualizations";
+import { getIconForVisualizationType } from "metabase/visualizations";
 import ViewButton from "./ViewButton";
 
 import QuestionAlertWidget from "./QuestionAlertWidget";
@@ -25,7 +22,7 @@ import QuestionTimelineWidget from "./QuestionTimelineWidget";
 
 import QuestionRowCount from "./QuestionRowCount";
 import QuestionLastUpdated from "./QuestionLastUpdated";
-import { ViewFooterRoot } from "./ViewFooter.styled";
+import { ViewFooterRoot, FooterButtonGroup } from "./ViewFooter.styled";
 
 const ViewFooter = ({
   question,
@@ -77,30 +74,35 @@ const ViewFooter = ({
         className="flex-full"
         left={[
           !hideChartSettings && (
-            <VizTypeButton
-              key="viz-type"
-              question={question}
-              result={result}
-              active={isShowingChartTypeSidebar}
-              onClick={
-                isShowingChartTypeSidebar
-                  ? () => onCloseChartType()
-                  : () => onOpenChartType()
-              }
-            />
-          ),
-          !hideChartSettings && (
-            <VizSettingsButton
-              key="viz-settings"
-              ml={1}
-              mr={[3, 0]}
-              active={isShowingChartSettingsSidebar}
-              onClick={
-                isShowingChartSettingsSidebar
-                  ? () => onCloseChartSettings()
-                  : () => onOpenChartSettings()
-              }
-            />
+            <FooterButtonGroup>
+              <ViewButton
+                medium
+                labelBreakpoint="sm"
+                data-testid="viz-type-button"
+                active={isShowingChartTypeSidebar}
+                onClick={
+                  isShowingChartTypeSidebar
+                    ? () => onCloseChartType()
+                    : () => onOpenChartType()
+                }
+              >
+                {t`Visualization`}
+              </ViewButton>
+              <ViewButton
+                active={isShowingChartSettingsSidebar}
+                icon="gear"
+                iconSize={16}
+                medium
+                onlyIcon
+                labelBreakpoint="sm"
+                data-testid="viz-settings-button"
+                onClick={
+                  isShowingChartSettingsSidebar
+                    ? () => onCloseChartSettings()
+                    : () => onOpenChartSettings()
+                }
+              />
+            </FooterButtonGroup>
           ),
         ]}
         center={
@@ -188,40 +190,6 @@ const ViewFooter = ({
     </ViewFooterRoot>
   );
 };
-
-const VizTypeButton = ({ question, result, ...props }) => {
-  // TODO: move this to QuestionResult or something
-  const { visualization } = getVisualizationRaw([
-    { card: question.card(), data: result.data },
-  ]);
-  const icon = visualization && visualization.iconName;
-
-  return (
-    <ViewButton
-      medium
-      p={[2, 1]}
-      icon={icon}
-      labelBreakpoint="sm"
-      data-testid="viz-type-button"
-      {...props}
-    >
-      {t`Visualization`}
-    </ViewButton>
-  );
-};
-
-const VizSettingsButton = ({ ...props }) => (
-  <ViewButton
-    medium
-    p={[2, 1]}
-    icon="gear"
-    labelBreakpoint="sm"
-    data-testid="viz-settings-button"
-    {...props}
-  >
-    {t`Settings`}
-  </ViewButton>
-);
 
 const Well = styled.div`
   display: flex;

--- a/frontend/src/metabase/query_builder/components/view/ViewFooter.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewFooter.styled.tsx
@@ -10,7 +10,7 @@ export const ViewFooterRoot = styled(ViewSection)`
 
 export const FooterButtonGroup = styled(ButtonGroup)`
   display: inline-flex;
-  align-items: center;
+  align-items: stretch;
 
   ${Button.Root} {
     border: 1px solid ${"white"};

--- a/frontend/src/metabase/query_builder/components/view/ViewFooter.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewFooter.styled.tsx
@@ -1,7 +1,18 @@
 import styled from "@emotion/styled";
+import ButtonGroup from "metabase/core/components/ButtonGroup";
+import Button from "metabase/core/components/Button";
 import ViewSection from "./ViewSection";
 
 export const ViewFooterRoot = styled(ViewSection)`
   padding-top: 0.5rem;
   padding-bottom: 0.5rem;
+`;
+
+export const FooterButtonGroup = styled(ButtonGroup)`
+  display: inline-flex;
+  align-items: center;
+
+  ${Button.Root} {
+    border: 1px solid ${"white"};
+  }
 `;

--- a/frontend/src/metabase/query_builder/components/view/sidebars/ChartSettingsSidebar.jsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/ChartSettingsSidebar.jsx
@@ -23,15 +23,21 @@ export default class ChartSettingsSidebar extends React.Component {
       onOpenChartType,
       visualizationSettings,
       isRunning,
+      showSidebarTitle = false,
     } = this.props;
     const { sidebarPropsOverride } = this.state;
+    const sidebarContentProps = showSidebarTitle
+      ? {
+          title: t`${visualizations.get(question.display()).uiName} options`,
+          onBack: () => onOpenChartType(),
+        }
+      : {};
     return (
       result && (
         <SidebarContent
           className="full-height"
-          title={t`${visualizations.get(question.display()).uiName} options`}
-          onDone={onClose}
-          onBack={onOpenChartType}
+          onDone={() => onClose()}
+          {...sidebarContentProps}
           {...sidebarPropsOverride}
         >
           <ChartSettings
@@ -44,7 +50,7 @@ export default class ChartSettingsSidebar extends React.Component {
               },
             ]}
             onChange={onReplaceAllVisualizationSettings}
-            onClose={onClose}
+            onClose={() => onClose()}
             noPreview
             initial={initialChartSetting}
             setSidebarPropsOverride={this.setSidebarPropsOverride}

--- a/frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.styled.tsx
@@ -1,5 +1,6 @@
 import styled from "@emotion/styled";
-import { color, tint, isDark } from "metabase/lib/colors";
+import { color, tint, isDark, lighten } from "metabase/lib/colors";
+import Button from "metabase/core/components/Button";
 
 export interface OptionRootProps {
   isSelected?: boolean;
@@ -24,9 +25,11 @@ export const OptionRoot = styled.div<OptionRootProps>`
     props.isSelected &&
     `
     ${OptionIconContainer} {
+      &, &:hover { 
       background-color: ${color("brand")};
       color: ${getOptionIconColor(props)};
       border: 1px solid transparent;
+      }
     }
 
     ${OptionText} {
@@ -46,7 +49,20 @@ export const OptionText = styled.div`
   font-size: 0.75rem;
 `;
 
+export const SettingsButton = styled(Button)`
+  position: absolute;
+  top: -0.5rem;
+  right: -0.75rem;
+  padding: 0.375rem;
+  border: 1px solid ${color("border")};
+
+  border-radius: 50px;
+  background-color: ${color("white")};
+  opacity: 0;
+`;
+
 export const OptionIconContainer = styled.div<OptionIconContainerProps>`
+  position: relative;
   display: inline-flex;
   flex-direction: column;
   justify-content: center;
@@ -58,9 +74,13 @@ export const OptionIconContainer = styled.div<OptionIconContainerProps>`
   cursor: pointer;
   padding: 0.875rem;
   &:hover {
-    color: ${color("white")};
-    background-color: ${color("brand")};
+    color: ${color("brand")};
+    background-color: ${lighten("brand", 0.55)};
     border: 1px solid transparent;
+
+    ${SettingsButton} {
+      opacity: 1;
+    }
   }
 `;
 

--- a/frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.tsx
@@ -68,10 +68,8 @@ const ChartTypeSidebar = ({
     return _.partition(
       _.union(
         DEFAULT_ORDER,
-        Array.from(visualizations)
-          .filter(([_type, visualization]) => !visualization.hidden)
-          .map(([vizType]) => vizType),
-      ),
+        Array.from(visualizations).map(([vizType]) => vizType),
+      ).filter(vizType => !visualizations.get(vizType).hidden),
       vizType => {
         const visualization = visualizations.get(vizType);
         return (
@@ -93,7 +91,6 @@ const ChartTypeSidebar = ({
         shouldUpdateUrl: question.query().isEditable(),
       });
       setUIControls({ isShowingRawTable: false });
-      console.log("clicky clicky");
     },
     [question, updateQuestion, setUIControls],
   );

--- a/frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.tsx
@@ -16,6 +16,7 @@ import {
   OptionRoot,
   OptionText,
   OptionLabel,
+  SettingsButton,
 } from "./ChartTypeSidebar.styled";
 
 const DEFAULT_ORDER = [
@@ -41,7 +42,10 @@ const DEFAULT_ORDER = [
 interface ChartTypeSidebarProps {
   question: Question;
   result: any;
-  onOpenChartSettings: (props: { section: string }) => void;
+  onOpenChartSettings: (props: {
+    initialChartSettings: { section: string };
+    showSidebarTitle: boolean;
+  }) => void;
   onCloseChartType: () => void;
   updateQuestion: (
     question: Question,
@@ -88,14 +92,29 @@ const ChartTypeSidebar = ({
         reload: false,
         shouldUpdateUrl: question.query().isEditable(),
       });
-      onOpenChartSettings({ section: t`Data` });
       setUIControls({ isShowingRawTable: false });
+      console.log("clicky clicky");
     },
-    [question, updateQuestion, onOpenChartSettings, setUIControls],
+    [question, updateQuestion, setUIControls],
+  );
+
+  const handleSettingsClick = useCallback(
+    (e: React.MouseEvent<HTMLButtonElement>) => {
+      e.stopPropagation();
+
+      onOpenChartSettings({
+        initialChartSettings: { section: t`Data` },
+        showSidebarTitle: true,
+      });
+    },
+    [onOpenChartSettings],
   );
 
   return (
-    <SidebarContent className="full-height px1" onDone={onCloseChartType}>
+    <SidebarContent
+      className="full-height px1"
+      onDone={() => onCloseChartType()}
+    >
       <OptionList data-testid="display-options-sensible">
         {makesSense.map(type => {
           const visualization = visualizations.get(type);
@@ -107,6 +126,7 @@ const ChartTypeSidebar = ({
                 isSelected={type === question.display()}
                 isSensible
                 onClick={() => handleClick(type)}
+                onSettingsClick={handleSettingsClick}
               />
             )
           );
@@ -124,6 +144,7 @@ const ChartTypeSidebar = ({
                 isSelected={type === question.display()}
                 isSensible={false}
                 onClick={() => handleClick(type)}
+                onSettingsClick={handleSettingsClick}
               />
             )
           );
@@ -137,6 +158,7 @@ interface ChartTypeOptionProps {
   isSelected: boolean;
   isSensible: boolean;
   onClick: () => void;
+  onSettingsClick: (e: React.MouseEvent<HTMLButtonElement>) => void;
   visualization: Visualization;
 }
 
@@ -145,6 +167,7 @@ const ChartTypeOption = ({
   isSelected,
   isSensible,
   onClick,
+  onSettingsClick,
 }: ChartTypeOptionProps) => (
   <OptionRoot
     isSelected={isSelected}
@@ -158,6 +181,14 @@ const ChartTypeOption = ({
       data-testid={`${visualization.uiName}-button`}
     >
       <Icon name={visualization.iconName} size={20} />
+      {isSelected && (
+        <SettingsButton
+          onlyIcon
+          icon="gear"
+          iconSize={12}
+          onClick={onSettingsClick}
+        />
+      )}
     </OptionIconContainer>
     <OptionText>{visualization.uiName}</OptionText>
   </OptionRoot>

--- a/frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.tsx
@@ -5,6 +5,7 @@ import Icon from "metabase/components/Icon";
 import SidebarContent from "metabase/query_builder/components/SidebarContent";
 
 import visualizations from "metabase/visualizations";
+import { sanatizeResultData } from "metabase/visualizations/shared/utils/data";
 import { Visualization } from "metabase/visualizations/shared/types/visualization";
 
 import Question from "metabase-lib/Question";
@@ -76,7 +77,7 @@ const ChartTypeSidebar = ({
           result &&
           result.data &&
           visualization.isSensible &&
-          visualization.isSensible(result.data, query)
+          visualization.isSensible(sanatizeResultData(result.data), query)
         );
       },
     );

--- a/frontend/src/metabase/query_builder/reducers.js
+++ b/frontend/src/metabase/query_builder/reducers.js
@@ -251,11 +251,15 @@ export const uiControls = handleActions(
       ...state,
       ...UI_CONTROLS_SIDEBAR_DEFAULTS,
     }),
-    [onOpenChartSettings]: (state, { payload: initial }) => ({
+    [onOpenChartSettings]: (
+      state,
+      { payload: { initialChartSettings, showSidebarTitle = false } = {} },
+    ) => ({
       ...state,
       ...UI_CONTROLS_SIDEBAR_DEFAULTS,
       isShowingChartSettingsSidebar: true,
-      initialChartSetting: initial,
+      initialChartSetting: initialChartSettings,
+      showSidebarTitle: showSidebarTitle,
     }),
     [onCloseChartSettings]: state => ({
       ...state,

--- a/frontend/src/metabase/visualizations/components/ChartSettings.jsx
+++ b/frontend/src/metabase/visualizations/components/ChartSettings.jsx
@@ -373,7 +373,7 @@ class ChartSettings extends Component {
           optionNameFn={v => v}
           optionValueFn={v => v}
           optionKeyFn={v => v}
-          variant="bubble"
+          variant="underlined"
         />
       </SectionContainer>
     );
@@ -400,7 +400,7 @@ class ChartSettings extends Component {
       <div className={cx(className, "flex flex-column")}>
         {showSectionPicker && (
           <div
-            className={cx("flex flex-no-shrink pl4 pb1", {
+            className={cx("flex flex-no-shrink pt1 pb1", {
               pt3: isDashboard,
             })}
           >

--- a/frontend/src/metabase/visualizations/components/ChartSettings.jsx
+++ b/frontend/src/metabase/visualizations/components/ChartSettings.jsx
@@ -1,6 +1,5 @@
 /* eslint-disable react/prop-types */
 import React, { Component } from "react";
-import cx from "classnames";
 import { assocIn } from "icepick";
 import _ from "underscore";
 import { t } from "ttag";
@@ -34,6 +33,12 @@ import {
   SectionContainer,
   SectionWarnings,
   TitleButton,
+  ChartSettingsRoot,
+  ChartSettingsMenu,
+  ChartSettingsPreview,
+  ChartSettingsListContainer,
+  ChartSettingsVisualizationContainer,
+  ChartSettingsFooterRoot,
 } from "./ChartSettings.styled";
 
 // section names are localized
@@ -365,7 +370,7 @@ class ChartSettings extends Component {
     };
 
     const sectionPicker = (
-      <SectionContainer>
+      <SectionContainer isDashboard={isDashboard}>
         <Radio
           value={currentSection}
           onChange={this.handleShowSection}
@@ -397,69 +402,45 @@ class ChartSettings extends Component {
 
     // default layout with visualization
     return (
-      <div className={cx(className, "flex flex-column")}>
-        {showSectionPicker && (
-          <div
-            className={cx("flex flex-no-shrink pt1 pb1", {
-              pt3: isDashboard,
-            })}
-          >
-            {sectionPicker}
-          </div>
-        )}
-        {noPreview ? (
-          <div className="full-height relative scroll-y scroll-show pt2 pb4">
+      <ChartSettingsRoot className={className}>
+        <ChartSettingsMenu data-testid="chartsettings-sidebar">
+          {showSectionPicker && sectionPicker}
+          {title && (
+            <TitleButton onClick={onBack} icon="chevronleft" onlyText>
+              {title}
+            </TitleButton>
+          )}
+          <ChartSettingsListContainer className="scroll-show">
             <ChartSettingsWidgetList
               widgets={visibleWidgets}
               extraWidgetProps={extraWidgetProps}
             />
-          </div>
-        ) : (
-          <div className="Grid flex-full">
-            <div
-              className="Grid-cell Cell--1of3 scroll-y scroll-show border-right py4"
-              data-testid="chartsettings-sidebar"
-            >
-              {title && (
-                <TitleButton onClick={onBack} icon="chevronleft" onlyText>
-                  {title}
-                </TitleButton>
-              )}
-              <ChartSettingsWidgetList
-                widgets={visibleWidgets}
-                extraWidgetProps={extraWidgetProps}
+          </ChartSettingsListContainer>
+        </ChartSettingsMenu>
+        {!noPreview && (
+          <ChartSettingsPreview>
+            <SectionWarnings warnings={this.state.warnings} size={20} />
+            <ChartSettingsVisualizationContainer>
+              <Visualization
+                className="spread"
+                rawSeries={rawSeries}
+                showTitle
+                isEditing
+                isDashboard
+                dashboard={dashboard}
+                dashcard={dashcard}
+                isSettings
+                showWarnings
+                onUpdateVisualizationSettings={this.handleChangeSettings}
+                onUpdateWarnings={warnings => this.setState({ warnings })}
               />
-            </div>
-            <div className="Grid-cell flex flex-column pt2">
-              <div className="mx4 flex flex-column">
-                <SectionWarnings
-                  className="mx2 align-self-end"
-                  warnings={this.state.warnings}
-                  size={20}
-                />
-              </div>
-              <div className="mx4 flex-full relative">
-                <Visualization
-                  className="spread"
-                  rawSeries={rawSeries}
-                  showTitle
-                  isEditing
-                  isDashboard
-                  dashboard={dashboard}
-                  dashcard={dashcard}
-                  isSettings
-                  showWarnings
-                  onUpdateVisualizationSettings={this.handleChangeSettings}
-                  onUpdateWarnings={warnings => this.setState({ warnings })}
-                />
-              </div>
-              <ChartSettingsFooter
-                onDone={this.handleDone}
-                onCancel={this.handleCancel}
-                onReset={onReset}
-              />
-            </div>
-          </div>
+            </ChartSettingsVisualizationContainer>
+            <ChartSettingsFooter
+              onDone={this.handleDone}
+              onCancel={this.handleCancel}
+              onReset={onReset}
+            />
+          </ChartSettingsPreview>
         )}
         <ChartSettingsWidgetPopover
           currentWidgetKey={
@@ -471,37 +452,31 @@ class ChartSettings extends Component {
           )}
           handleEndShowWidget={this.handleEndShowWidget}
         />
-      </div>
+      </ChartSettingsRoot>
     );
   }
 }
 
-const ChartSettingsFooter = ({ className, onDone, onCancel, onReset }) => (
-  <div className={cx("py2 px4", className)}>
-    <div className="float-right">
-      <Button
-        className="ml2"
-        onClick={onCancel}
-        data-metabase-event="Chart Settings;Cancel"
-      >{t`Cancel`}</Button>
-      <Button
-        primary
-        className="ml2"
-        onClick={onDone}
-        data-metabase-event="Chart Settings;Done"
-      >{t`Done`}</Button>
-    </div>
-
+const ChartSettingsFooter = ({ onDone, onCancel, onReset }) => (
+  <ChartSettingsFooterRoot>
     {onReset && (
       <Button
         borderless
         icon="refresh"
-        className="float-right ml2"
         data-metabase-event="Chart Settings;Reset"
         onClick={onReset}
       >{t`Reset to defaults`}</Button>
     )}
-  </div>
+    <Button
+      onClick={onCancel}
+      data-metabase-event="Chart Settings;Cancel"
+    >{t`Cancel`}</Button>
+    <Button
+      primary
+      onClick={onDone}
+      data-metabase-event="Chart Settings;Done"
+    >{t`Done`}</Button>
+  </ChartSettingsFooterRoot>
 );
 
 export default ChartSettings;

--- a/frontend/src/metabase/visualizations/components/ChartSettings.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/ChartSettings.styled.tsx
@@ -1,10 +1,14 @@
 import styled from "@emotion/styled";
+import { css } from "@emotion/react";
 import { color } from "metabase/lib/colors";
 import Radio from "metabase/core/components/Radio";
 import Button from "metabase/core/components/Button";
 import Warnings from "metabase/query_builder/components/Warnings";
 
-export const SectionContainer = styled.div`
+interface SectionContainerProps {
+  isDashboard: boolean;
+}
+export const SectionContainer = styled.div<SectionContainerProps>`
   ${({ isDashboard }) =>
     isDashboard &&
     css`
@@ -31,12 +35,57 @@ export const SectionContainer = styled.div`
 
 export const SectionWarnings = styled(Warnings)`
   color: ${color("accent4")};
+  position: absolute;
+  top: 2rem;
+  right: 2rem;
+  z-index: 2;
+`;
+
+export const ChartSettingsRoot = styled.div`
+  display: flex;
+  flex-grow: 1;
+  overflow-y: auto;
+`;
+
+export const ChartSettingsMenu = styled.div`
+  flex: 1 0 0;
+  display: flex;
+  flex-direction: column;
+`;
+
+export const ChartSettingsListContainer = styled.div`
+  position: relative;
+  overflow-y: auto;
+  padding: 2rem 0;
+`;
+
+export const ChartSettingsPreview = styled.div`
+  flex: 2 0 0;
+  display: flex;
+  flex-direction: column;
+  border-left: 1px solid ${color("border")};
+  padding-top: 1.5rem;
+`;
+
+export const ChartSettingsVisualizationContainer = styled.div`
+  position: relative;
+  margin: 0 2rem;
+  flex-grow: 1;
+`;
+
+export const ChartSettingsFooterRoot = styled.div`
+  display: flex;
+  justify-content: end;
+  padding: 1rem 2rem;
+  ${Button} {
+    margin-left: 1rem;
+  }
 `;
 
 export const TitleButton = styled(Button)`
-  margin-left: 1.5rem;
-  margin-bottom: 0.5rem;
+  margin: 2rem 2rem 0;
   ${Button.Content} {
+    justify-content: start;
     color: ${color("text-dark")};
     &:hover {
       color: ${color("brand")};

--- a/frontend/src/metabase/visualizations/components/ChartSettings.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/ChartSettings.styled.tsx
@@ -5,12 +5,27 @@ import Button from "metabase/core/components/Button";
 import Warnings from "metabase/query_builder/components/Warnings";
 
 export const SectionContainer = styled.div`
+  ${({ isDashboard }) =>
+    isDashboard &&
+    css`
+      margin-top: 1rem;
+    `}
+  width: 100%;
   ${Radio.RadioGroupVariants.join(", ")} {
-    flex-wrap: wrap;
+    border-bottom: 1px solid ${color("border")};
   }
-
   ${Radio.RadioContainerVariants.join(", ")} {
-    margin-bottom: 0.5rem;
+    padding-left: 0.5rem;
+    padding-right: 0.5rem;
+  }
+  ${Radio.RadioLabelVariants.join(", ")} {
+    flex-grow: 1;
+    margin-right: 0;
+    display: flex;
+    justify-content: center;
+    &:not(:last-child) {
+      margin-right: 0;
+    }
   }
 `;
 

--- a/frontend/src/metabase/visualizations/components/ChartSettingsWidgetPopover.tsx
+++ b/frontend/src/metabase/visualizations/components/ChartSettingsWidgetPopover.tsx
@@ -49,7 +49,6 @@ const ChartSettingsWidgetPopover = ({
 
   return (
     <TippyPopover
-      hideOnClick
       reference={anchor}
       content={
         widgets.length > 0 ? (

--- a/frontend/src/metabase/visualizations/components/Visualization/Visualization.jsx
+++ b/frontend/src/metabase/visualizations/components/Visualization/Visualization.jsx
@@ -381,7 +381,9 @@ class Visualization extends React.PureComponent {
               <ChartSettingsErrorButton
                 message={error}
                 buttonLabel={e.buttonText}
-                onClick={() => onOpenChartSettings(e.initial)}
+                onClick={() =>
+                  onOpenChartSettings({ initialChartSettings: e.initial })
+                }
               />
             );
           } else if (e instanceof MinRowsError) {

--- a/frontend/src/metabase/visualizations/shared/utils/data.ts
+++ b/frontend/src/metabase/visualizations/shared/utils/data.ts
@@ -1,5 +1,10 @@
 import { t } from "ttag";
-import { RowValue, RowValues, SeriesOrderSetting } from "metabase-types/api";
+import {
+  RowValue,
+  RowValues,
+  SeriesOrderSetting,
+  DatasetData,
+} from "metabase-types/api";
 
 import {
   ChartColumns,
@@ -262,4 +267,11 @@ export const getOrderedSeries = (
       }
       return foundSeries;
     });
+};
+
+export const sanatizeResultData = (data: DatasetData) => {
+  return {
+    ...data,
+    cols: data.cols.filter(col => col.expression_name !== "pivot-grouping"),
+  };
 };

--- a/frontend/test/metabase/query_builder/components/view/sidebars/ChartSettingsSidebar.unit.spec.js
+++ b/frontend/test/metabase/query_builder/components/view/sidebars/ChartSettingsSidebar.unit.spec.js
@@ -11,16 +11,17 @@ describe("ChartSettingsSidebar", () => {
     cols: [{ base_type: "type/Integer", name: "foo", display_name: "foo" }],
   };
 
-  it("should not hide the title for gauge charts", () => {
+  it("should hide the title when showSidebarTitle is false", () => {
     render(
       <ChartSettingsSidebar
         question={SAMPLE_DATABASE.question().setDisplay("gauge")}
         result={{ data }}
+        showSidebarTitle={false}
       />,
     );
 
     // see options header with sections
-    expect(screen.getByText("Gauge options")).toBeInTheDocument();
+    expect(screen.queryByText("Gauge options")).not.toBeInTheDocument();
     expect(screen.getByText("Formatting")).toBeInTheDocument();
     expect(screen.getByText("Display")).toBeInTheDocument();
 
@@ -31,16 +32,17 @@ describe("ChartSettingsSidebar", () => {
     expect(screen.getByText("Style")).toBeInTheDocument();
 
     // but the sections and back title are unchanged
-    expect(screen.getByText("Gauge options")).toBeInTheDocument();
+    expect(screen.queryByText("Gauge options")).not.toBeInTheDocument();
     expect(screen.getByText("Formatting")).toBeInTheDocument();
     expect(screen.getByText("Display")).toBeInTheDocument();
   });
 
-  it("should not hide the title for scalar charts", () => {
+  it("should not hide the title when showSidebarTitle is false", () => {
     render(
       <ChartSettingsSidebar
         question={SAMPLE_DATABASE.question().setDisplay("scalar")}
         result={{ data }}
+        showSidebarTitle={true}
       />,
     );
 

--- a/frontend/test/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.unit.spec.js
+++ b/frontend/test/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.unit.spec.js
@@ -33,23 +33,37 @@ describe("ChartSettingsSidebar", () => {
   });
 
   it("should call correct functions when display type is selected", () => {
-    const onOpenChartSettings = jest.fn();
     const updateQuestion = jest.fn();
     const setUIControls = jest.fn();
 
     setup({
-      onOpenChartSettings,
       updateQuestion,
       setUIControls,
     });
 
-    fireEvent.click(
-      within(screen.getByTestId("Progress-button")).getByRole("img"),
-    );
+    fireEvent.click(screen.getByTestId("Progress-button"));
 
-    expect(onOpenChartSettings).toHaveBeenCalledWith({ section: "Data" });
     expect(setUIControls).toHaveBeenCalledWith({ isShowingRawTable: false });
     expect(updateQuestion).toHaveBeenCalled();
+  });
+
+  it("should display a gear icon when hovering selected display type", () => {
+    const onOpenChartSettings = jest.fn();
+    setup({
+      onOpenChartSettings,
+    });
+
+    expect(
+      within(screen.getByTestId("Gauge-button")).getByRole("img", {
+        name: /gear/i,
+      }),
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("img", { name: /gear/i }));
+    expect(onOpenChartSettings).toHaveBeenCalledWith({
+      initialChartSettings: { section: "Data" },
+      showSidebarTitle: true,
+    });
   });
 
   it("should group sensible and nonsensible options separately and in the correct order", () => {
@@ -62,10 +76,7 @@ describe("ChartSettingsSidebar", () => {
       screen.getByTestId("display-options-not-sensible"),
     ).getAllByTestId(/container/i);
 
-    expect(sensible).toHaveLength(5);
-    expect(nonSensible).toHaveLength(12);
-
-    const sensibleOrder = ["Table", "Number", "Gauge", "Progress", "Detail"];
+    const sensibleOrder = ["Table", "Number", "Gauge", "Progress"];
     const nonSensibleOrder = [
       "Bar",
       "Line",
@@ -80,6 +91,9 @@ describe("ChartSettingsSidebar", () => {
       "Scatter",
       "Waterfall",
     ];
+
+    expect(sensible).toHaveLength(sensibleOrder.length);
+    expect(nonSensible).toHaveLength(nonSensibleOrder.length);
 
     sensible.forEach((node, index) => {
       expect(node).toHaveTextContent(sensibleOrder[index]);

--- a/frontend/test/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.unit.spec.js
+++ b/frontend/test/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.unit.spec.js
@@ -76,7 +76,7 @@ describe("ChartSettingsSidebar", () => {
       screen.getByTestId("display-options-not-sensible"),
     ).getAllByTestId(/container/i);
 
-    const sensibleOrder = ["Table", "Number", "Gauge", "Progress"];
+    const sensibleOrder = ["Table", "Number", "Gauge", "Progress", "Detail"];
     const nonSensibleOrder = [
       "Bar",
       "Line",

--- a/frontend/test/metabase/scenarios/binning/binning-reproductions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/binning/binning-reproductions.cy.spec.js
@@ -202,10 +202,9 @@ describe("binning related reproductions", () => {
 
     cy.createQuestion(questionDetails, { visitQuestion: true });
 
-    cy.findByText("Settings").click();
+    cy.findByTestId("viz-settings-button").click();
 
     cy.findByTestId("sidebar-left").within(() => {
-      cy.findByTextEnsureVisible("Table options");
       cy.findByText("Add or remove columns").click();
       cy.findByText("Created At").click();
       cy.button("Done").click();

--- a/frontend/test/metabase/scenarios/cross-version/source/03-questions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/cross-version/source/03-questions.cy.spec.js
@@ -28,7 +28,7 @@ it("should create questions", () => {
 
   cy.get(".bar").should("have.length", 4);
 
-  cy.findByText("Settings").click();
+  cy.findByTestId("viz-settings-button").click();
   cy.contains("Show values on data points").next().click();
   cy.contains("3.71");
 
@@ -61,7 +61,7 @@ it("should create questions", () => {
   visualize();
   cy.get("circle");
 
-  cy.findByText("Settings").click();
+  cy.findByTestId("viz-settings-button").click();
   cy.icon("area").click();
   cy.findByText("Goal line").next().click();
   cy.findByDisplayValue("0").type("100000").blur();

--- a/frontend/test/metabase/scenarios/native/native.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native/native.cy.spec.js
@@ -162,7 +162,7 @@ describe("scenarios > question > native", () => {
   it("should be able to add new columns after hiding some (metabase#15393)", () => {
     openNativeEditor().type("select 1 as visible, 2 as hidden");
     cy.get(".NativeQueryEditor .Icon-play").as("runQuery").click();
-    cy.findByText("Settings").click();
+    cy.findByTestId("viz-settings-button").click();
     cy.findByTestId("sidebar-left").as("sidebar");
     cy.findByText("Add or remove columns").click();
     sidebar().within(() => {

--- a/frontend/test/metabase/scenarios/native/reproductions/12439-click-on-legend-breaks-ui.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native/reproductions/12439-click-on-legend-breaks-ui.cy.spec.js
@@ -48,6 +48,7 @@ describe("issue 12439", () => {
     // Make sure buttons are clickable
     cy.findByTestId("viz-settings-button").click();
 
-    sidebar().contains("Line options");
+    sidebar().contains("X-axis");
+    sidebar().contains("Y-axis");
   });
 });

--- a/frontend/test/metabase/scenarios/permissions/admin-permissions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/permissions/admin-permissions.cy.spec.js
@@ -624,7 +624,7 @@ describeEE("scenarios > admin > permissions", () => {
     visitQuestion(1);
 
     cy.findByText("There was a problem with your question");
-    cy.findByText("Settings").should("not.exist");
+    cy.findByTestId("viz-settings-button").should("not.exist");
     cy.findByText("Visualization").should("not.exist");
   });
 

--- a/frontend/test/metabase/scenarios/permissions/reproductions/22447-illogical-UI-elements-for-nodata.cy.spec.js
+++ b/frontend/test/metabase/scenarios/permissions/reproductions/22447-illogical-UI-elements-for-nodata.cy.spec.js
@@ -13,11 +13,15 @@ describe("UI elements that make no sense for users without data permissions (met
 
     visitQuestion("1");
 
-    cy.findByText("Settings");
+    cy.findByTestId("viz-settings-button");
     cy.findByText("Visualization").click();
 
     cy.findByTestId("display-options-sensible");
     cy.icon("line").click();
+    cy.findByTestId("Line-button").realHover();
+    cy.findByTestId("Line-button").within(() => {
+      cy.icon("gear").click();
+    });
 
     cy.findByTextEnsureVisible("Line options");
     cy.findByText("Save")

--- a/frontend/test/metabase/scenarios/permissions/reproductions/22447-illogical-UI-elements-for-nodata.cy.spec.js
+++ b/frontend/test/metabase/scenarios/permissions/reproductions/22447-illogical-UI-elements-for-nodata.cy.spec.js
@@ -64,7 +64,7 @@ describe("UI elements that make no sense for users without data permissions (met
 
     cy.findByTextEnsureVisible("There was a problem with your question");
 
-    cy.findByText("Settings").should("not.exist");
+    cy.findByTestId("viz-settings-button").should("not.exist");
     cy.findByText("Visualization").should("not.exist");
 
     cy.findByTestId("qb-header-action-panel").within(() => {

--- a/frontend/test/metabase/scenarios/permissions/sandboxes.cy.spec.js
+++ b/frontend/test/metabase/scenarios/permissions/sandboxes.cy.spec.js
@@ -780,7 +780,7 @@ describeEE("formatting > sandboxes", () => {
       cy.signInAsSandboxedUser();
       createJoinedQuestion("14841", { visitQuestion: true });
 
-      cy.findByText("Settings").click();
+      cy.findByTestId("viz-settings-button").click();
       cy.findByTestId("sidebar-left")
         .should("be.visible")
         .within(() => {

--- a/frontend/test/metabase/scenarios/question/reproductions/18207-string-min-max.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/reproductions/18207-string-min-max.cy.spec.js
@@ -5,6 +5,7 @@ import {
   visualize,
   openProductsTable,
   summarize,
+  sidebar,
 } from "__support__/e2e/helpers";
 
 describe("issue 18207", () => {
@@ -64,9 +65,12 @@ describe("issue 18207", () => {
     visualize();
 
     // Why is it not a table?
-    cy.contains("Settings").click();
-    cy.contains("Bar options").click();
-    cy.get("[data-testid=Table-button]").click();
+    cy.contains("Visualization").click();
+    sidebar().within(() => {
+      cy.icon("table").click();
+      cy.findByTestId("Table-button").realHover();
+      cy.icon("gear").click();
+    });
     cy.contains("Done").click();
 
     cy.findByText("Zemlak-Wiegand");

--- a/frontend/test/metabase/scenarios/question/reproductions/18978-18977-nested-question-nodata-user.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/reproductions/18978-18977-nested-question-nodata-user.cy.spec.js
@@ -77,6 +77,8 @@ function setVisualizationTo(vizName) {
 
   sidebar().within(() => {
     cy.icon(vizName).click();
+    cy.icon(vizName).realHover();
+    cy.icon("gear").click();
     cy.findByText("X-axis").parent().findByText("Select a field").click();
   });
   selectFromDropdown("Created At");

--- a/frontend/test/metabase/scenarios/question/settings.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/settings.cy.spec.js
@@ -27,7 +27,7 @@ describe("scenarios > question > settings", () => {
       cy.viewport(1600, 800);
 
       openOrdersTable();
-      cy.contains("Settings").click();
+      cy.findByTestId("viz-settings-button").click();
 
       // wait for settings sidebar to open
       cy.findByTestId("sidebar-left").invoke("width").should("be.gt", 350);
@@ -72,7 +72,7 @@ describe("scenarios > question > settings", () => {
         },
         display: "table",
       });
-      cy.findByText("Settings").click();
+      cy.findByTestId("viz-settings-button").click();
 
       cy.findByText("Add or remove columns").click();
 
@@ -121,7 +121,7 @@ describe("scenarios > question > settings", () => {
         display: "table",
       });
 
-      cy.findByText("Settings").click();
+      cy.findByTestId("viz-settings-button").click();
 
       getSidebarColumns()
         .eq("12")
@@ -203,8 +203,9 @@ describe("scenarios > question > settings", () => {
         },
       });
 
-      cy.findByText("Settings").click(); // open settings sidebar
-      cy.findByText("Table options"); // confirm it's open
+      cy.findByTestId("viz-settings-button").click(); // open settings sidebar
+      cy.findByText("Conditional Formatting"); // confirm it's open
+      cy.findByText("Add or remove columns"); // confirm it's open
       cy.get(".TableInteractive").findByText("Subtotal").click(); // open subtotal column header actions
       popover().within(() => cy.icon("gear").click()); // open subtotal column settings
 
@@ -246,7 +247,7 @@ describe("scenarios > question > settings", () => {
 
     it("should respect symbol settings for all currencies", () => {
       openOrdersTable();
-      cy.contains("Settings").click();
+      cy.findByTestId("viz-settings-button").click();
 
       getSidebarColumns()
         .eq("4")

--- a/frontend/test/metabase/scenarios/sharing/alert/alert-types.cy.spec.js
+++ b/frontend/test/metabase/scenarios/sharing/alert/alert-types.cy.spec.js
@@ -1,4 +1,9 @@
-import { restore, setupSMTP, visitQuestion } from "__support__/e2e/helpers";
+import {
+  restore,
+  setupSMTP,
+  visitQuestion,
+  sidebar,
+} from "__support__/e2e/helpers";
 
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
@@ -67,7 +72,11 @@ describe("scenarios > alert > types", { tags: "@external" }, () => {
       // Set goal on timeseries question
       visitQuestion(timeSeriesQuestionId);
 
-      cy.findByText("Settings").click();
+      cy.findByText("Visualization").click();
+      sidebar().within(() => {
+        cy.icon("line").realHover();
+        cy.icon("gear").click();
+      });
       cy.findByText("Line options");
       cy.findByText("Display").click();
 

--- a/frontend/test/metabase/scenarios/visualizations/bar_chart.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/bar_chart.cy.spec.js
@@ -133,7 +133,7 @@ describe("scenarios > visualizations > bar chart", () => {
         },
       });
 
-      cy.findByText("Settings").click();
+      cy.findByTestId("viz-settings-button").click();
       sidebar().findByText("Data").click();
     });
 

--- a/frontend/test/metabase/scenarios/visualizations/funnel.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/funnel.cy.spec.js
@@ -29,7 +29,7 @@ describe("scenarios > visualizations > funnel chart", () => {
       },
       display: "funnel",
     });
-    cy.findByText("Settings").click();
+    cy.findByTestId("viz-settings-button").click();
     sidebar().findByText("Data").click();
   });
 

--- a/frontend/test/metabase/scenarios/visualizations/line_chart.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/line_chart.cy.spec.js
@@ -35,7 +35,7 @@ describe("scenarios > visualizations > line chart", () => {
       display: "line",
     });
 
-    cy.findByText("Settings").click();
+    cy.findByTestId("viz-settings-button").click();
     openSeriesSettings("Count");
     cy.findByText("Right").click();
     cy.get(Y_AXIS_RIGHT_SELECTOR);
@@ -155,7 +155,7 @@ describe("scenarios > visualizations > line chart", () => {
       },
     });
 
-    cy.findByText("Settings").click();
+    cy.findByTestId("viz-settings-button").click();
 
     // Make sure we can update input with some existing value
     openSeriesSettings("cat1", true);

--- a/frontend/test/metabase/scenarios/visualizations/maps.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/maps.cy.spec.js
@@ -27,6 +27,9 @@ describe("scenarios > visualizations > maps", () => {
     // switch to a pin map visualization
     cy.contains("Visualization").click();
     cy.icon("pinmap").click();
+    cy.findByTestId("Map-button").within(() => {
+      cy.icon("gear").click();
+    });
 
     cy.contains("Map type").next().click();
     popover().contains("Pin map").click();
@@ -69,14 +72,11 @@ describe("scenarios > visualizations > maps", () => {
     );
 
     cy.findByText("Visualization").closest(".Button").as("vizButton");
-    cy.get("@vizButton").find(".Icon-pinmap");
     cy.get("@vizButton").click();
-    cy.findByTestId("display-options-sensible");
+    cy.findByTestId("display-options-sensible").as("sensibleOptions");
 
-    cy.findByTestId("sidebar-left").as("vizSidebar");
-
-    cy.get("@vizSidebar").within(() => {
-      cy.findByText("Map").parent().should("have.css", "opacity", "1");
+    cy.get("@sensibleOptions").within(() => {
+      cy.findByText("Map").should("be.visible");
     });
   });
 

--- a/frontend/test/metabase/scenarios/visualizations/pivot_tables.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/pivot_tables.cy.spec.js
@@ -40,7 +40,7 @@ describe("scenarios > visualizations > pivot tables", () => {
 
     cy.findByText(/Count by Users? → Source and Products? → Category/); // ad-hoc title
 
-    cy.findByText("Settings").click();
+    cy.findByTestId("viz-settings-button").click();
     assertOnPivotSettings();
     cy.get(".Visualization").within(() => {
       assertOnPivotFields();
@@ -54,7 +54,7 @@ describe("scenarios > visualizations > pivot tables", () => {
     });
 
     // Open Pivot table side-bar
-    cy.findByText("Settings").click();
+    cy.findByTestId("viz-settings-button").click();
 
     assertOnPivotSettings();
   });
@@ -114,10 +114,10 @@ describe("scenarios > visualizations > pivot tables", () => {
     createAndVisitTestQuestion();
 
     // Open Pivot table side-bar
-    cy.findByText("Settings").click();
+    cy.findByTestId("viz-settings-button").click();
 
     // Give it some time to open the side-bar fully before we start dragging
-    cy.findByText(/Pivot Table options/i);
+    assertOnPivotSettings();
 
     // Drag the second aggregate (Product category) from table columns to table rows
     dragField(1, 0);
@@ -232,7 +232,7 @@ describe("scenarios > visualizations > pivot tables", () => {
     cy.findByText("3,520"); // check for one of the subtotals
 
     // open settings
-    cy.findByText("Settings").click();
+    cy.findByTestId("viz-settings-button").click();
     assertOnPivotSettings();
 
     // Confirm that Product -> Category doesn't have the option to hide subtotals
@@ -261,7 +261,7 @@ describe("scenarios > visualizations > pivot tables", () => {
     cy.findByText("3,520"); // affiliate subtotal is visible
 
     // open settings
-    cy.findByText("Settings").click();
+    cy.findByTestId("viz-settings-button").click();
 
     // turn off subtotals for User -> Source
     openColumnSettings(/Users? → Source/);
@@ -276,7 +276,7 @@ describe("scenarios > visualizations > pivot tables", () => {
 
     cy.findByText(/Count by Users? → Source and Products? → Category/); // ad-hoc title
 
-    cy.findByText("Settings").click();
+    cy.findByTestId("viz-settings-button").click();
     assertOnPivotSettings();
     openColumnSettings(/Users? → Source/);
 
@@ -296,7 +296,7 @@ describe("scenarios > visualizations > pivot tables", () => {
 
     cy.findByText(/Count by Users? → Source and Products? → Category/); // ad-hoc title
 
-    cy.findByText("Settings").click();
+    cy.findByTestId("viz-settings-button").click();
     assertOnPivotSettings();
     openColumnSettings(/Count/);
 
@@ -319,7 +319,7 @@ describe("scenarios > visualizations > pivot tables", () => {
 
     cy.findByText(/Count by Users? → Source and Products? → Category/); // ad-hoc title
 
-    cy.findByText("Settings").click();
+    cy.findByTestId("viz-settings-button").click();
     assertOnPivotSettings();
     openColumnSettings(/Count/);
 
@@ -350,7 +350,7 @@ describe("scenarios > visualizations > pivot tables", () => {
     });
 
     // open settings and expand Total column settings
-    cy.findByText("Settings").click();
+    cy.findByTestId("viz-settings-button").click();
     openColumnSettings(/Total/);
 
     // sort descending
@@ -822,7 +822,7 @@ describe("scenarios > visualizations > pivot tables", () => {
       },
     });
 
-    cy.findByText("Settings").click();
+    cy.findByTestId("viz-settings-button").click();
     cy.findByText("Conditional Formatting").click();
 
     cy.findByText("Add a rule").click();
@@ -957,7 +957,6 @@ function assertOnPivotSettings() {
   cy.findAllByTestId(/draggable-item/).as("fieldOption");
 
   cy.log("Implicit side-bar assertions");
-  cy.findByText(/Pivot Table options/i);
 
   cy.findAllByTestId("pivot-table-setting").eq(0);
   cy.get("@fieldOption")

--- a/frontend/test/metabase/scenarios/visualizations/reproductions/11249-add-more-series-no-columns.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/reproductions/11249-add-more-series-no-columns.cy.spec.js
@@ -30,7 +30,7 @@ describe("issue 11249", () => {
   it("should not allow adding more series when all columns are used (metabase#11249)", () => {
     visitQuestionAdhoc(questionDetails);
 
-    cy.findByText("Settings").click();
+    cy.findByTestId("viz-settings-button").click();
 
     cy.findByTestId("sidebar-left").within(() => {
       cy.findByText("Data").click();

--- a/frontend/test/metabase/scenarios/visualizations/reproductions/21452-xhr-on-every-char-for-rename.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/reproductions/21452-xhr-on-every-char-for-rename.cy.spec.js
@@ -28,7 +28,7 @@ describe("issue 21452", () => {
 
     visitQuestionAdhoc(questionDetails);
 
-    cy.findByText("Settings").click();
+    cy.findByTestId("viz-settings-button").click();
   });
 
   it("should not fire POST request after every character during display name change (metabase#21452)", () => {

--- a/frontend/test/metabase/scenarios/visualizations/reproductions/21504-pie-settings-formatting.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/reproductions/21504-pie-settings-formatting.cy.spec.js
@@ -26,7 +26,7 @@ describe("issue 21504", () => {
       display: "pie",
     });
 
-    cy.findByText("Settings").click();
+    cy.findByTestId("viz-settings-button").click();
     cy.findByText("Display").click();
     cy.findByText("April, 2016").should("be.visible");
   });

--- a/frontend/test/metabase/scenarios/visualizations/reproductions/22206-add-remove-column.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/reproductions/22206-add-remove-column.cy.spec.js
@@ -10,7 +10,7 @@ describe("#22206 adding and removing columns doesn't duplicate columns", () => {
   });
 
   it("should not duplicate column in settings when removing and adding it back", () => {
-    cy.findByText("Settings").click();
+    cy.findByTestId("viz-settings-button").click();
 
     cy.findByTestId("sidebar-content")
       .findByText("Add or remove columns")

--- a/frontend/test/metabase/scenarios/visualizations/reproductions/22527-scatter-negative-values-not-rendered.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/reproductions/22527-scatter-negative-values-not-rendered.cy.spec.js
@@ -23,7 +23,7 @@ describe.skip("issue 22527", () => {
   it("should render negative values in a scatter visualziation (metabase#22527)", () => {
     assertion();
 
-    cy.findByText("Settings").click();
+    cy.findByTestId("viz-settings-button").click();
     cy.findByTestId("sidebar-left").within(() => {
       cy.findByTextEnsureVisible("Data").click();
     });

--- a/frontend/test/metabase/scenarios/visualizations/scalar.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/scalar.cy.spec.js
@@ -81,7 +81,7 @@ describe("scenarios > visualizations > scalar", () => {
     });
 
     cy.findByText("April 30, 2018");
-    cy.findByText("Settings").click();
+    cy.findByTestId("viz-settings-button").click();
 
     cy.findByText("Show the time").should("be.hidden");
     cy.findByText("Time style").should("be.hidden");

--- a/frontend/test/metabase/scenarios/visualizations/trendline.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/trendline.cy.spec.js
@@ -30,6 +30,9 @@ describe("scenarios > question > trendline", () => {
     sidebar().within(() => {
       cy.icon("line").click();
     });
+    cy.findByTestId("Line-button").within(() => {
+      cy.icon("gear").click();
+    });
     cy.findByText("Display").click();
     cy.findByText("Trend line").parent().children().last().click();
 

--- a/frontend/test/metabase/scenarios/visualizations/waterfall.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/waterfall.cy.spec.js
@@ -61,7 +61,7 @@ describe("scenarios > visualizations > waterfall", () => {
 
     cy.get(".NativeQueryEditor .Icon-play").click();
     cy.contains("Visualization").click();
-    cy.icon("waterfall").click();
+    switchToWaterfallDisplay();
 
     cy.contains("Select a field").click();
     cy.get(".List-item").contains("X").click();
@@ -83,7 +83,7 @@ describe("scenarios > visualizations > waterfall", () => {
     );
     cy.get(".NativeQueryEditor .Icon-play").click();
     cy.contains("Visualization").click();
-    cy.icon("waterfall").click();
+    switchToWaterfallDisplay();
 
     cy.contains("Select a field").click();
     cy.get(".List-item").contains("X").click();
@@ -109,7 +109,7 @@ describe("scenarios > visualizations > waterfall", () => {
     visualize();
 
     cy.contains("Visualization").click();
-    cy.icon("waterfall").click();
+    switchToWaterfallDisplay();
 
     verifyWaterfallRendering("Created At", "Count");
   });
@@ -124,7 +124,7 @@ describe("scenarios > visualizations > waterfall", () => {
     visualize();
 
     cy.contains("Visualization").click();
-    cy.icon("waterfall").click();
+    switchToWaterfallDisplay();
 
     cy.get(".Visualization .axis.x").within(() => {
       cy.findByText("Total").should("not.exist");
@@ -146,7 +146,7 @@ describe("scenarios > visualizations > waterfall", () => {
     });
 
     cy.findByText("Visualization").click();
-    cy.findByTestId("Waterfall-button").click();
+    switchToWaterfallDisplay();
     cy.findByText("Waterfall chart does not support multiple series");
 
     cy.findByTestId("remove-count").click();
@@ -173,7 +173,7 @@ describe("scenarios > visualizations > waterfall", () => {
     });
 
     cy.findByText("Visualization").click();
-    cy.findByTestId("Waterfall-button").click();
+    switchToWaterfallDisplay();
 
     cy.contains("Select a field").click();
     cy.get(".List-item").contains("Created At").click();
@@ -253,7 +253,7 @@ describe("scenarios > visualizations > waterfall", () => {
       openNativeEditor().type("select 'A' as X, -4.56 as Y");
       cy.get(".NativeQueryEditor .Icon-play").click();
       cy.contains("Visualization").click();
-      cy.icon("waterfall").click();
+      switchToWaterfallDisplay();
     });
 
     it("should have increase, decrease, and total color options", () => {
@@ -290,3 +290,10 @@ describe("scenarios > visualizations > waterfall", () => {
     });
   });
 });
+
+const switchToWaterfallDisplay = () => {
+  cy.icon("waterfall").click();
+  cy.findByTestId("Waterfall-button").within(() => {
+    cy.icon("gear").click();
+  });
+};


### PR DESCRIPTION
EPIC #26890 

Update to change the behavior of selecting a viz type. Selecting a viz type no longer automatically opens up the viz settings, but will now only change the viz type. Hovering over the currently selected viz type will show you a gear button that can be pressed, which will take you to the viz settings, and render with a back button at the top of the viz settings. 

The old settings button now only has an icon, no text, and opening viz settings with this button shows you the viz settings without a back button.

`ChartSettings` was also updated to have simpler (in my opinion) HTML structure with less duplication. No real changes should be noticable to the user unless you are looking at dashcard viz settings, where we should no longer have the whole modal scroll if you have a lot of viz settings.

![chrome_3oJ7BcWQZm](https://user-images.githubusercontent.com/1328979/218199680-070a4c41-1b17-4fb0-aaf3-ef2d2a26dc67.gif)
