### PR TITLE
Mind = blown :exploding_head:

### DIFF
--- a/dev/src/dev.clj
+++ b/dev/src/dev.clj
@@ -183,7 +183,7 @@
 
     ;; Run a query against a Data warehouse DB
     (t2/query (t2/select-one Database :name \"test-data\")
-              (mt/mbql-query venues) {:type :mbql})
+              (mt/mbql-query venues))
 
     ;; Run MBQL queries against the application database
     (t2/query (dev/with-app-db (mt/mbql-query core_user {:aggregation [[:min [:get-year $date_joined]]]})))

--- a/dev/src/dev.clj
+++ b/dev/src/dev.clj
@@ -157,15 +157,15 @@
   right now!
 
     ;; use Honey SQL
-    (t2/query (t2/select-one 'Database :engine :postgres, :name \"test-data\")
+    (t2/query (t2/select-one Database :engine :postgres, :name \"test-data\")
               {:select [:*], :from [:venues]})
 
     ;; use it with `select`
-    (t2/select :conn (t2/select-one 'Database :engine :postgres, :name \"test-data\")
+    (t2/select :conn (t2/select-one Database :engine :postgres, :name \"test-data\")
                \"venues\")
 
     ;; use it with raw SQL
-    (t2/query (t2/select-one 'Database :engine :postgres, :name \"test-data\")
+    (t2/query (t2/select-one Database :engine :postgres, :name \"test-data\")
               \"SELECT * FROM venues;\")"
   [database f]
   (t2.connection/do-with-connection (sql-jdbc.conn/db->pooled-connection-spec database) f))

--- a/test/metabase/test/data.clj
+++ b/test/metabase/test/data.clj
@@ -141,7 +141,8 @@
    (as-> inner-query <>
      (mbql-query-impl/parse-tokens table-name <>)
      (mbql-query-impl/maybe-add-source-table <> table-name)
-     (mbql-query-impl/wrap-inner-query <>))))
+     (mbql-query-impl/wrap-inner-query <>)
+     (vary-meta <> assoc :type :mbql))))
 
 (defmacro query
   "Like `mbql-query`, but operates on an entire 'outer' query rather than the 'inner' MBQL query. Like `mbql-query`,


### PR DESCRIPTION
## New dev-only REPL utils.

These are here to make our lives a little easier when developing in the REPL.

Teach Toucan 2 how to get a connection from a `Database`, and how to compile an MBQL query to `[sql & args]`.

### Run arbitrary SQL or Honey SQL against connected data warehouse DBs

```clj
(t2/query (t2/select-one Database :engine :postgres, :name "test-data")
          {:select [:*], :from [:venues]})
=>
[{:id 1, :name "Red Medicine", :category_id 4, :latitude 10.0646, :longitude -165.374, :price 3}
 ...]

(t2/query (t2/select-one Database :engine :postgres, :name "test-data")
          "SELECT * FROM venues;")
=>
[{:id 1, :name "Red Medicine", :category_id 4, :latitude 10.0646, :longitude -165.374, :price 3}
 ...]

(t2/select :conn (t2/select-one Database :engine :postgres, :name "test-data")
           "venues")
=>
[{:id 1, :name "Red Medicine", :category_id 4, :latitude 10.0646, :longitude -165.374, :price 3}
 ...]
```

### Run MBQL Queries against data warehouse Databases

It's just like the query processor!

```clj
(t2/query (t2/select-one Database :name "test-data")
          (mt/mbql-query venues))
=>
[{:id 1, :name "Red Medicine", :category_id 4, :latitude 10.0646, :longitude -165.374, :price 3}
 ...]
```
### Run MBQL Queries AGAINST THE APPLICATION DATABASE (!)

```clj
(t2/query (dev/with-app-db (mt/mbql-query core_user {:aggregation [[:min [:get-year $date_joined]]]})))
=>
[{:min 2023}]
```

