### PR TITLE
no native drill fallback when embedded

### DIFF
--- a/frontend/src/metabase/modes/components/drill/NativeDrillFallback/NativeDrillFallback.styled.tsx
+++ b/frontend/src/metabase/modes/components/drill/NativeDrillFallback/NativeDrillFallback.styled.tsx
@@ -1,6 +1,5 @@
 import styled from "@emotion/styled";
 import { color } from "metabase/lib/colors";
-import ExternalLink from "metabase/core/components/ExternalLink";
 
 export const DrillRoot = styled.div`
   max-width: 10.75rem;
@@ -10,12 +9,4 @@ export const DrillMessage = styled.div`
   color: ${color("text-dark")};
   font-weight: bold;
   line-height: 1.5rem;
-  margin-bottom: 0.5rem;
-`;
-
-export const DrillLearnLink = styled(ExternalLink)`
-  display: inline-flex;
-  align-items: center;
-  gap: 0.5rem;
-  color: ${color("brand")};
 `;

--- a/frontend/src/metabase/modes/components/drill/NativeDrillFallback/NativeDrillFallback.tsx
+++ b/frontend/src/metabase/modes/components/drill/NativeDrillFallback/NativeDrillFallback.tsx
@@ -1,16 +1,11 @@
 import React from "react";
 import { t } from "ttag";
-import Icon from "metabase/components/Icon";
-import MetabaseSettings from "metabase/lib/settings";
+import { isWithinIframe } from "metabase/lib/dom";
 import { getEngineNativeType } from "metabase/lib/engine";
 import { nativeDrillFallback } from "metabase-lib/queries/drills/native-drill-fallback";
 
 import type { ClickAction, Drill } from "../../../types";
-import {
-  DrillLearnLink,
-  DrillMessage,
-  DrillRoot,
-} from "./NativeDrillFallback.styled";
+import { DrillMessage, DrillRoot } from "./NativeDrillFallback.styled";
 
 const NativeDrillFallback: Drill = ({ question }) => {
   const drill = nativeDrillFallback({ question });
@@ -20,7 +15,10 @@ const NativeDrillFallback: Drill = ({ question }) => {
 
   const { database } = drill;
   const isSql = getEngineNativeType(database.engine) === "sql";
-  const learnUrl = MetabaseSettings.learnUrl("questions/drill-through");
+
+  if (isWithinIframe()) {
+    return [];
+  }
 
   return [
     {
@@ -34,10 +32,6 @@ const NativeDrillFallback: Drill = ({ question }) => {
               ? t`Drill-through doesn’t work on SQL questions.`
               : t`Drill-through doesn’t work on native questions.`}
           </DrillMessage>
-          <DrillLearnLink href={learnUrl}>
-            <Icon name="reference" />
-            {t`Learn more`}
-          </DrillLearnLink>
         </DrillRoot>
       ),
     } as ClickAction,

--- a/frontend/src/metabase/modes/components/drill/NativeDrillFallback/NativeDrillFallback.unit.spec.tsx
+++ b/frontend/src/metabase/modes/components/drill/NativeDrillFallback/NativeDrillFallback.unit.spec.tsx
@@ -1,0 +1,35 @@
+jest.doMock("metabase/lib/dom");
+import * as dom from "metabase/lib/dom";
+import { getCleanNativeQuestion } from "metabase-lib/mocks";
+import NativeDrillFallback from "./NativeDrillFallback";
+
+describe("NativeDrillFallback", () => {
+  let isWithinIframeSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    isWithinIframeSpy = jest.spyOn(dom, "isWithinIframe");
+  });
+
+  afterEach(() => {
+    isWithinIframeSpy.mockRestore();
+  });
+
+  it("should return native drill fallback element on native questions", async () => {
+    isWithinIframeSpy.mockReturnValue(false);
+
+    const question = getCleanNativeQuestion();
+    const result = NativeDrillFallback({ question });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe("fallback-native");
+  });
+
+  it("should not return native drill fallback element on native questions when the app is in iframe", async () => {
+    isWithinIframeSpy.mockReturnValue(true);
+
+    const question = getCleanNativeQuestion();
+    const result = NativeDrillFallback({ question });
+
+    expect(result).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/27797

### Description

1. Drop the "Learn more" link from educational messaging in native question drill-through
2. When embedded, drop educational messaging in native question drill-through altogether. Revert back to previous behavior when simply nothing happens.

### How to verify

```
SELECT date_trunc('month', "PUBLIC"."ORDERS"."CREATED_AT") AS "CREATED_AT", count(*) AS "count"
FROM "PUBLIC"."ORDERS"
GROUP BY date_trunc('month', "PUBLIC"."ORDERS"."CREATED_AT")
ORDER BY date_trunc('month', "PUBLIC"."ORDERS"."CREATED_AT") ASC
```

1. Create a question from the SQL above and make it a line chart
2. Try to drill through, ensure it does not show "Learn more" link anymore
3. In `frontend/src/metabase/lib/dom.js` make `isWithinIframe` returning "true"
4. Try to drill through, ensure it does not do anything

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
