### PR TITLE
Basic link dashboard cards

### DIFF
--- a/frontend/src/metabase-types/api/actions.ts
+++ b/frontend/src/metabase-types/api/actions.ts
@@ -173,7 +173,7 @@ export type ActionParametersMapping = Pick<
 export interface ActionDashboardCard
   extends Omit<BaseDashboardOrderedCard, "parameter_mappings"> {
   action?: WritebackAction;
-  card_id?: CardId; // model card id for the associated action
+  card_id?: CardId | null; // model card id for the associated action
   card?: Card;
 
   parameter_mappings?: ActionParametersMapping[] | null;

--- a/frontend/src/metabase-types/api/dashboard.ts
+++ b/frontend/src/metabase-types/api/dashboard.ts
@@ -42,11 +42,17 @@ export type BaseDashboardOrderedCard = {
   entity_id: string;
   visualization_settings?: {
     [key: string]: unknown;
-    virtual_card?: Card;
+    virtual_card?: VirtualCard;
   };
   justAdded?: boolean;
   created_at: string;
   updated_at: string;
+};
+
+export type VirtualCardDisplay = "text" | "action" | "link";
+
+export type VirtualCard = Partial<Card> & {
+  display: VirtualCardDisplay;
 };
 
 export type DashboardOrderedCard = BaseDashboardOrderedCard & {

--- a/frontend/src/metabase-types/api/dashboard.ts
+++ b/frontend/src/metabase-types/api/dashboard.ts
@@ -37,15 +37,20 @@ export type BaseDashboardOrderedCard = {
   dashboard_id: DashboardId;
   size_x: number;
   size_y: number;
+  col: number;
+  row: number;
+  entity_id: string;
   visualization_settings?: {
     [key: string]: unknown;
     virtual_card?: Card;
   };
   justAdded?: boolean;
+  created_at: string;
+  updated_at: string;
 };
 
 export type DashboardOrderedCard = BaseDashboardOrderedCard & {
-  card_id: CardId;
+  card_id: CardId | null;
   card: Card;
   parameter_mappings?: DashboardParameterMapping[] | null;
   series?: Card[];

--- a/frontend/src/metabase-types/api/mocks/dashboard.ts
+++ b/frontend/src/metabase-types/api/mocks/dashboard.ts
@@ -1,4 +1,5 @@
 import {
+  Card,
   Dashboard,
   DashboardOrderedCard,
   ActionDashboardCard,
@@ -28,27 +29,37 @@ export const createMockDashboardOrderedCard = (
 ): DashboardOrderedCard => ({
   id: 1,
   dashboard_id: 1,
+  col: 0,
+  row: 0,
+  card_id: 1,
   size_x: 1,
   size_y: 1,
+  entity_id: "abc_123",
   visualization_settings: {},
-  justAdded: false,
-  card_id: 1,
   card: createMockCard(),
+  created_at: "2020-01-01T12:30:30.000000",
+  updated_at: "2020-01-01T12:30:30.000000",
+  justAdded: false,
   parameter_mappings: [],
   ...opts,
 });
 
-export const createMockActionDashboardCard = (
-  opts?: Partial<ActionDashboardCard>,
-): ActionDashboardCard => ({
+export const createMockDashboardCardWithVirtualCard = (
+  opts?: Partial<DashboardOrderedCard>,
+): DashboardOrderedCard => ({
   ...createMockDashboardOrderedCard(),
-  action: undefined,
-  card: createMockCard(),
+  card: {
+    query_average_duration: null,
+  } as Card,
+  card_id: null,
   visualization_settings: {
-    "button.label": "Please click me",
-    "button.variant": "primary",
-    actionDisplayType: "button",
-    virtual_card: createMockCard({ display: "action" }),
+    virtual_card: {
+      archived: false,
+      dataset_query: {},
+      display: "text",
+      name: null,
+      visualization_settings: {},
+    } as unknown as Card,
   },
   ...opts,
 });

--- a/frontend/src/metabase-types/api/mocks/dashboard.ts
+++ b/frontend/src/metabase-types/api/mocks/dashboard.ts
@@ -2,6 +2,7 @@ import {
   Card,
   Dashboard,
   DashboardOrderedCard,
+  VirtualCard,
   ActionDashboardCard,
 } from "metabase-types/api";
 import { createMockCard } from "./card";
@@ -44,6 +45,21 @@ export const createMockDashboardOrderedCard = (
   ...opts,
 });
 
+export const createMockActionDashboardCard = (
+  opts?: Partial<ActionDashboardCard>,
+): ActionDashboardCard => ({
+  ...createMockDashboardOrderedCard(),
+  action: undefined,
+  card: createMockCard(),
+  visualization_settings: {
+    "button.label": "Please click me",
+    "button.variant": "primary",
+    actionDisplayType: "button",
+    virtual_card: createMockCard({ display: "action" }),
+  },
+  ...opts,
+});
+
 export const createMockDashboardCardWithVirtualCard = (
   opts?: Partial<DashboardOrderedCard>,
 ): DashboardOrderedCard => ({
@@ -57,9 +73,9 @@ export const createMockDashboardCardWithVirtualCard = (
       archived: false,
       dataset_query: {},
       display: "text",
-      name: null,
+      name: "",
       visualization_settings: {},
-    } as unknown as Card,
+    } as VirtualCard,
   },
   ...opts,
 });

--- a/frontend/src/metabase/core/components/FormField/FormField.styled.tsx
+++ b/frontend/src/metabase/core/components/FormField/FormField.styled.tsx
@@ -1,4 +1,5 @@
 import styled from "@emotion/styled";
+import React from "react";
 import { color } from "metabase/lib/colors";
 import Icon from "metabase/components/Icon";
 import { FieldAlignment, FieldOrientation } from "./types";
@@ -90,3 +91,13 @@ export const FieldRoot = styled.div<FieldRootProps>`
     }
   }
 `;
+
+export const FieldLabelWithContainer = ({
+  children,
+}: {
+  children: React.ReactNode;
+}) => (
+  <FieldLabelContainer>
+    <FieldLabel hasError={false}>{children}</FieldLabel>
+  </FieldLabelContainer>
+);

--- a/frontend/src/metabase/core/components/Link/Link.tsx
+++ b/frontend/src/metabase/core/components/Link/Link.tsx
@@ -1,9 +1,9 @@
-import React, { CSSProperties, HTMLAttributes, ReactNode } from "react";
+import React, { AnchorHTMLAttributes, CSSProperties, ReactNode } from "react";
 import Tooltip from "metabase/core/components/Tooltip";
 import { TooltipProps } from "metabase/core/components/Tooltip/Tooltip";
 import { LinkRoot } from "./Link.styled";
 
-export interface LinkProps extends HTMLAttributes<HTMLAnchorElement> {
+export interface LinkProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
   to: string;
   disabled?: boolean;
   className?: string;

--- a/frontend/src/metabase/dashboard/actions/cards.js
+++ b/frontend/src/metabase/dashboard/actions/cards.js
@@ -97,8 +97,8 @@ export const addTextDashCardToDashboard = function ({ dashId }) {
 };
 
 export const addLinkDashCardToDashboard = function ({ dashId }) {
-  const DEFAULT_HEIGHT = 2;
-  const DEFAULT_WIDTH = 4;
+  const DEFAULT_HEIGHT = 1;
+  const DEFAULT_WIDTH = 3;
 
   const virtualLinkCard = {
     ...createCard(),

--- a/frontend/src/metabase/dashboard/actions/cards.js
+++ b/frontend/src/metabase/dashboard/actions/cards.js
@@ -96,6 +96,30 @@ export const addTextDashCardToDashboard = function ({ dashId }) {
   });
 };
 
+export const addLinkDashCardToDashboard = function ({ dashId }) {
+  const DEFAULT_HEIGHT = 2;
+  const DEFAULT_WIDTH = 4;
+
+  const virtualLinkCard = {
+    ...createCard(),
+    display: "link",
+    archived: false,
+  };
+
+  const dashcardOverrides = {
+    card: virtualLinkCard,
+    size_x: DEFAULT_WIDTH,
+    size_y: DEFAULT_HEIGHT,
+    visualization_settings: {
+      virtual_card: virtualLinkCard,
+    },
+  };
+  return addDashCardToDashboard({
+    dashId: dashId,
+    dashcardOverrides: dashcardOverrides,
+  });
+};
+
 const estimateCardSize = (displayType, action, buttonLabel) => {
   const BASE_HEIGHT = 3;
   const HEIGHT_PER_FIELD = 1.5;

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebarContent.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebarContent.tsx
@@ -51,7 +51,7 @@ function ClickBehaviorSidebar({
     return { type: "actionMenu" };
   }, [clickBehavior]);
 
-  if (isTableDisplay(dashcard) && !hasSelectedColumn) {
+  if (isTableDisplay(dashcard) && !hasSelectedColumn && dashcard.card_id) {
     const columns = getIn(dashcardData, [dashcard.card_id, "data", "cols"]);
     return (
       <TableClickBehaviorView

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardCardParameterMapper.jsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardCardParameterMapper.jsx
@@ -16,6 +16,7 @@ import {
   getNativeDashCardEmptyMappingText,
   isNativeDashCard,
   isVirtualDashCard,
+  getVirtualCardType,
   showVirtualDashCardInfoText,
 } from "metabase/dashboard/utils";
 
@@ -105,6 +106,7 @@ function DashCardCardParameterMapper({
   );
 
   const isVirtual = isVirtualDashCard(dashcard);
+  const virtualCardType = getVirtualCardType(dashcard);
   const isNative = isNativeDashCard(dashcard);
 
   const hasPermissionsToMap = useMemo(() => {
@@ -176,7 +178,12 @@ function DashCardCardParameterMapper({
     }
   }, [dashcard, isVirtual, isNative, isDisabled, isMobile]);
 
-  const mappingInfoText = t`You can connect widgets to {{variables}} in text cards.`;
+  const mappingInfoText =
+    {
+      text: t`You can connect widgets to {{variables}} in text cards.`,
+      link: t`You cannot connect variables to link cards.`,
+      action: t`Open this card's action settings to connect variables`,
+    }[virtualCardType] ?? "";
 
   return (
     <Container>

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx
@@ -11,12 +11,16 @@ import WithVizSettingsData from "metabase/visualizations/hoc/WithVizSettingsData
 
 import QueryDownloadWidget from "metabase/query_builder/components/QueryDownloadWidget";
 
-import { isVirtualDashCard } from "metabase/dashboard/utils";
+import {
+  getVirtualCardType,
+  isVirtualDashCard,
+} from "metabase/dashboard/utils";
 
 import type {
   Dashboard,
   DashboardOrderedCard,
   DashCardId,
+  VirtualCardDisplay,
   VisualizationSettings,
 } from "metabase-types/api";
 import type {
@@ -121,12 +125,19 @@ function DashCardVisualization({
   const renderVisualizationOverlay = useCallback(() => {
     if (isClickBehaviorSidebarOpen) {
       if (isVirtualDashCard(dashcard)) {
-        const isTextCard =
-          dashcard?.visualization_settings?.virtual_card?.display === "text";
+        const virtualDashcardType = getVirtualCardType(
+          dashcard,
+        ) as VirtualCardDisplay;
+        const placeholderText = {
+          link: t`Link`,
+          action: t`Action Button`,
+          text: t`Text Card`,
+        }[virtualDashcardType];
+
         return (
           <VirtualDashCardOverlayRoot>
             <VirtualDashCardOverlayText>
-              {isTextCard ? t`Text card` : t`Action button`}
+              {placeholderText}
             </VirtualDashCardOverlayText>
           </VirtualDashCardOverlayRoot>
         );

--- a/frontend/src/metabase/dashboard/containers/DashboardHeader.jsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardHeader.jsx
@@ -82,6 +82,7 @@ class DashboardHeader extends Component {
 
     addCardToDashboard: PropTypes.func.isRequired,
     addTextDashCardToDashboard: PropTypes.func.isRequired,
+    addLinkDashCardToDashboard: PropTypes.func.isRequired,
     fetchDashboard: PropTypes.func.isRequired,
     saveDashboardAndCards: PropTypes.func.isRequired,
     setDashboardAttribute: PropTypes.func.isRequired,
@@ -116,6 +117,10 @@ class DashboardHeader extends Component {
 
   onAddTextBox() {
     this.props.addTextDashCardToDashboard({ dashId: this.props.dashboard.id });
+  }
+
+  onAddLinkCard() {
+    this.props.addLinkDashCardToDashboard({ dashId: this.props.dashboard.id });
   }
 
   onAddAction() {
@@ -246,6 +251,14 @@ class DashboardHeader extends Component {
               <Icon name="string" size={18} />
             </DashboardHeaderButton>
           </a>
+        </Tooltip>,
+        <Tooltip key="add-link-card" tooltip={t`Add link card`}>
+          <DashboardHeaderButton
+            onClick={() => this.onAddLinkCard()}
+            data-metabase-event={`Dashboard;Add Link Card`}
+          >
+            <Icon name="link" size={18} />
+          </DashboardHeaderButton>
         </Tooltip>,
       );
 

--- a/frontend/src/metabase/dashboard/utils.js
+++ b/frontend/src/metabase/dashboard/utils.js
@@ -58,6 +58,10 @@ export function isVirtualDashCard(dashcard) {
   return _.isObject(dashcard.visualization_settings.virtual_card);
 }
 
+export function getVirtualCardType(dashcard) {
+  return dashcard?.visualization_settings?.virtual_card?.display;
+}
+
 export function isNativeDashCard(dashcard) {
   return isNative(dashcard.card?.dataset_query);
 }

--- a/frontend/src/metabase/dashboard/utils.js
+++ b/frontend/src/metabase/dashboard/utils.js
@@ -55,7 +55,7 @@ export function expandInlineCard(card) {
 }
 
 export function isVirtualDashCard(dashcard) {
-  return _.isObject(dashcard.visualization_settings.virtual_card);
+  return _.isObject(dashcard?.visualization_settings?.virtual_card);
 }
 
 export function getVirtualCardType(dashcard) {

--- a/frontend/src/metabase/parameters/utils/mapping-options.js
+++ b/frontend/src/metabase/parameters/utils/mapping-options.js
@@ -1,5 +1,6 @@
 import { tag_names } from "cljs/metabase.shared.parameters.parameters";
 import { isActionDashCard } from "metabase/actions/utils";
+import { isVirtualDashCard } from "metabase/dashboard/utils";
 import Question from "metabase-lib/Question";
 import { ExpressionDimension } from "metabase-lib/Dimension";
 import {
@@ -75,7 +76,7 @@ export function getParameterMappingOptions(
     return actionParams || [];
   }
 
-  if (!card.dataset_query) {
+  if (!card.dataset_query || isVirtualDashCard(dashcard)) {
     return [];
   }
 

--- a/frontend/src/metabase/visualizations/register.js
+++ b/frontend/src/metabase/visualizations/register.js
@@ -10,6 +10,7 @@ import SmartScalar from "./visualizations/SmartScalar";
 import Progress from "./visualizations/Progress";
 import Table from "./visualizations/Table";
 import Text from "./visualizations/Text";
+import LinkViz from "./visualizations/LinkViz";
 import LineChart from "./visualizations/LineChart";
 import BarChart from "./visualizations/BarChart";
 import WaterfallChart from "./visualizations/WaterfallChart";
@@ -31,6 +32,7 @@ export default function () {
   registerVisualization(Gauge);
   registerVisualization(Table);
   registerVisualization(Text);
+  registerVisualization(LinkViz);
   registerVisualization(LineChart);
   registerVisualization(AreaChart);
   registerVisualization(BarChart);

--- a/frontend/src/metabase/visualizations/visualizations/LinkViz/LinkViz.styled.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/LinkViz/LinkViz.styled.tsx
@@ -1,0 +1,28 @@
+import styled from "@emotion/styled";
+import Link from "metabase/core/components/Link";
+import { color } from "metabase/lib/colors";
+
+export const DisplayLinkCardWrapper = styled.div<{ alignmentSettings: string }>`
+  padding: 0.5rem;
+  display: flex;
+  width: 100%;
+  height: 100%;
+  pointer-events: all;
+  ${props => props.alignmentSettings ?? ""}
+`;
+
+export const EditLinkCardWrapper = styled.div`
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  pointer-events: all;
+`;
+
+export const CardLink = styled(Link)`
+  padding: 0.5rem;
+  font-weight: bold;
+  color: ${color("brand")};
+`;

--- a/frontend/src/metabase/visualizations/visualizations/LinkViz/LinkViz.styled.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/LinkViz/LinkViz.styled.tsx
@@ -24,6 +24,8 @@ export const EditLinkCardWrapper = styled.div`
 export const CardLink = styled(Link)`
   padding: 0.5rem;
   display: flex;
+  width: 100%;
+  height: 100%;
   min-width: 0;
   gap: 0.5rem;
   align-items: center;

--- a/frontend/src/metabase/visualizations/visualizations/LinkViz/LinkViz.styled.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/LinkViz/LinkViz.styled.tsx
@@ -2,13 +2,13 @@ import styled from "@emotion/styled";
 import Link from "metabase/core/components/Link";
 import { color } from "metabase/lib/colors";
 
-export const DisplayLinkCardWrapper = styled.div<{ alignmentSettings: string }>`
+export const DisplayLinkCardWrapper = styled.div`
   padding: 0.5rem;
   display: flex;
   width: 100%;
   height: 100%;
   pointer-events: all;
-  ${props => props.alignmentSettings ?? ""}
+  align-items: center;
 `;
 
 export const EditLinkCardWrapper = styled.div`

--- a/frontend/src/metabase/visualizations/visualizations/LinkViz/LinkViz.styled.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/LinkViz/LinkViz.styled.tsx
@@ -12,7 +12,7 @@ export const DisplayLinkCardWrapper = styled.div<{ alignmentSettings: string }>`
 `;
 
 export const EditLinkCardWrapper = styled.div`
-  padding: 1.5rem;
+  padding: 0.5rem;
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -23,6 +23,12 @@ export const EditLinkCardWrapper = styled.div`
 
 export const CardLink = styled(Link)`
   padding: 0.5rem;
-  font-weight: bold;
-  color: ${color("brand")};
+  display: flex;
+  min-width: 0;
+  gap: 0.5rem;
+  align-items: center;
+  &:hover {
+    color: ${color("brand")};
+    text-decoration: underline;
+  }
 `;

--- a/frontend/src/metabase/visualizations/visualizations/LinkViz/LinkViz.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/LinkViz/LinkViz.tsx
@@ -1,0 +1,71 @@
+import React from "react";
+import { t } from "ttag";
+
+import Input from "metabase/core/components/Input";
+import Ellipsified from "metabase/core/components/Ellipsified";
+import { FieldLabelWithContainer } from "metabase/core/components/FormField/FormField.styled";
+import {
+  settings,
+  getSettingsStyle,
+  LinkCardSettings,
+} from "./LinkVizSettings";
+
+import {
+  EditLinkCardWrapper,
+  DisplayLinkCardWrapper,
+  CardLink,
+} from "./LinkViz.styled";
+
+interface LinkVizProps {
+  isEditing: boolean;
+  isPreviewing: boolean;
+  isSettings: boolean;
+  onUpdateVisualizationSettings: (
+    newSettings: Partial<LinkCardSettings>,
+  ) => void;
+  settings: LinkCardSettings;
+}
+
+function LinkViz({
+  isEditing,
+  isPreviewing,
+  isSettings,
+  onUpdateVisualizationSettings,
+  settings,
+}: LinkVizProps) {
+  const {
+    link: { url },
+  } = settings;
+
+  const handleLinkChange = (e: React.ChangeEvent<HTMLInputElement>) =>
+    onUpdateVisualizationSettings({ link: { url: e.currentTarget.value } });
+
+  const showEditBox = isEditing && !isPreviewing && !isSettings;
+
+  if (showEditBox) {
+    return (
+      <EditLinkCardWrapper>
+        <FieldLabelWithContainer>{t`Link url`}</FieldLabelWithContainer>
+        <Input
+          value={url ?? ""}
+          onChange={handleLinkChange}
+          fullWidth
+          // the dashcard really wants to turn all mouse events into drag events
+          onMouseDown={e => e.stopPropagation()}
+        />
+      </EditLinkCardWrapper>
+    );
+  }
+
+  return (
+    <DisplayLinkCardWrapper alignmentSettings={getSettingsStyle(settings)}>
+      <Ellipsified>
+        <CardLink to={url ?? ""} target="_blank" rel="noreferrer">
+          {url ?? t`Choose a link`}
+        </CardLink>
+      </Ellipsified>
+    </DisplayLinkCardWrapper>
+  );
+}
+
+export default Object.assign(LinkViz, settings);

--- a/frontend/src/metabase/visualizations/visualizations/LinkViz/LinkViz.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/LinkViz/LinkViz.tsx
@@ -8,11 +8,7 @@ import Icon from "metabase/components/Icon";
 import type { DashboardOrderedCard } from "metabase-types/api";
 import { isEmpty } from "metabase/lib/validate";
 
-import {
-  settings,
-  getSettingsStyle,
-  LinkCardSettings,
-} from "./LinkVizSettings";
+import { settings, LinkCardSettings } from "./LinkVizSettings";
 
 import {
   EditLinkCardWrapper,
@@ -20,7 +16,7 @@ import {
   CardLink,
 } from "./LinkViz.styled";
 
-interface LinkVizProps {
+export interface LinkVizProps {
   dashcard: DashboardOrderedCard;
   isEditing: boolean;
   isPreviewing: boolean;
@@ -55,7 +51,7 @@ function LinkViz({
       <EditLinkCardWrapper>
         <Input
           autoFocus={isNew}
-          placeholder={t`https://metabase.com`}
+          placeholder={"https://example.com"}
           value={url ?? ""}
           onChange={handleLinkChange}
           fullWidth
@@ -69,7 +65,7 @@ function LinkViz({
   const displayIcon = isEmpty(url) ? "question" : "link";
 
   return (
-    <DisplayLinkCardWrapper alignmentSettings={getSettingsStyle(settings)}>
+    <DisplayLinkCardWrapper>
       <CardLink to={url ?? ""} target="_blank" rel="noreferrer">
         <Icon name={displayIcon} />
         <Ellipsified style={{ minWidth: 0 }}>

--- a/frontend/src/metabase/visualizations/visualizations/LinkViz/LinkViz.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/LinkViz/LinkViz.tsx
@@ -3,7 +3,11 @@ import { t } from "ttag";
 
 import Input from "metabase/core/components/Input";
 import Ellipsified from "metabase/core/components/Ellipsified";
-import { FieldLabelWithContainer } from "metabase/core/components/FormField/FormField.styled";
+import Icon from "metabase/components/Icon";
+
+import type { DashboardOrderedCard } from "metabase-types/api";
+import { isEmpty } from "metabase/lib/validate";
+
 import {
   settings,
   getSettingsStyle,
@@ -17,6 +21,7 @@ import {
 } from "./LinkViz.styled";
 
 interface LinkVizProps {
+  dashcard: DashboardOrderedCard;
   isEditing: boolean;
   isPreviewing: boolean;
   isSettings: boolean;
@@ -27,6 +32,7 @@ interface LinkVizProps {
 }
 
 function LinkViz({
+  dashcard,
   isEditing,
   isPreviewing,
   isSettings,
@@ -37,6 +43,8 @@ function LinkViz({
     link: { url },
   } = settings;
 
+  const isNew = !!dashcard?.justAdded;
+
   const handleLinkChange = (e: React.ChangeEvent<HTMLInputElement>) =>
     onUpdateVisualizationSettings({ link: { url: e.currentTarget.value } });
 
@@ -45,8 +53,9 @@ function LinkViz({
   if (showEditBox) {
     return (
       <EditLinkCardWrapper>
-        <FieldLabelWithContainer>{t`Link url`}</FieldLabelWithContainer>
         <Input
+          autoFocus={isNew}
+          placeholder={t`https://metabase.com`}
           value={url ?? ""}
           onChange={handleLinkChange}
           fullWidth
@@ -57,13 +66,16 @@ function LinkViz({
     );
   }
 
+  const displayIcon = isEmpty(url) ? "question" : "link";
+
   return (
     <DisplayLinkCardWrapper alignmentSettings={getSettingsStyle(settings)}>
-      <Ellipsified>
-        <CardLink to={url ?? ""} target="_blank" rel="noreferrer">
-          {url ?? t`Choose a link`}
-        </CardLink>
-      </Ellipsified>
+      <CardLink to={url ?? ""} target="_blank" rel="noreferrer">
+        <Icon name={displayIcon} />
+        <Ellipsified style={{ minWidth: 0 }}>
+          {isEmpty(url) ? t`Choose a link` : url}
+        </Ellipsified>
+      </CardLink>
     </DisplayLinkCardWrapper>
   );
 }

--- a/frontend/src/metabase/visualizations/visualizations/LinkViz/LinkViz.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/LinkViz/LinkViz.unit.spec.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { renderWithProviders, screen, fireEvent } from "__support__/ui";
 
-import type { Card } from "metabase-types/api";
 import { createMockDashboardCardWithVirtualCard } from "metabase-types/api/mocks";
 
 import LinkViz, { LinkVizProps } from "./LinkViz";
@@ -14,7 +13,7 @@ const linkDashcard = createMockDashboardCardWithVirtualCard({
     },
     virtual_card: {
       display: "link",
-    } as unknown as Card,
+    },
   },
 });
 
@@ -25,7 +24,7 @@ const emptyLinkDashcard = createMockDashboardCardWithVirtualCard({
     },
     virtual_card: {
       display: "link",
-    } as unknown as Card,
+    },
   },
 });
 

--- a/frontend/src/metabase/visualizations/visualizations/LinkViz/LinkViz.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/LinkViz/LinkViz.unit.spec.tsx
@@ -1,0 +1,96 @@
+import React from "react";
+import { renderWithProviders, screen, fireEvent } from "__support__/ui";
+
+import type { Card } from "metabase-types/api";
+import { createMockDashboardCardWithVirtualCard } from "metabase-types/api/mocks";
+
+import LinkViz, { LinkVizProps } from "./LinkViz";
+import type { LinkCardSettings } from "./LinkVizSettings";
+
+const linkDashcard = createMockDashboardCardWithVirtualCard({
+  visualization_settings: {
+    link: {
+      url: "https://example23.com",
+    },
+    virtual_card: {
+      display: "link",
+    } as unknown as Card,
+  },
+});
+
+const emptyLinkDashcard = createMockDashboardCardWithVirtualCard({
+  visualization_settings: {
+    link: {
+      url: "",
+    },
+    virtual_card: {
+      display: "link",
+    } as unknown as Card,
+  },
+});
+
+const setup = (options?: Partial<LinkVizProps>) => {
+  const changeSpy = jest.fn();
+
+  renderWithProviders(
+    <LinkViz
+      dashcard={linkDashcard}
+      isEditing={true}
+      isPreviewing={false}
+      isSettings={false}
+      onUpdateVisualizationSettings={changeSpy}
+      settings={
+        linkDashcard.visualization_settings as unknown as LinkCardSettings
+      }
+      {...options}
+    />,
+  );
+
+  return { changeSpy };
+};
+
+describe("LinkViz", () => {
+  it("should render link input settings view", () => {
+    setup({ isEditing: true });
+
+    expect(screen.getByPlaceholderText("https://example.com")).toHaveValue(
+      "https://example23.com",
+    );
+  });
+
+  it("updates visualization settings with input value", () => {
+    const { changeSpy } = setup({ isEditing: true });
+
+    const linkInput = screen.getByPlaceholderText("https://example.com");
+    fireEvent.change(linkInput, {
+      target: { value: "https://example.com/123" },
+    });
+
+    expect(changeSpy).toHaveBeenCalledWith({
+      link: {
+        url: "https://example.com/123",
+      },
+    });
+  });
+
+  it("should render link display view", () => {
+    setup({ isEditing: false });
+
+    expect(screen.getByLabelText("link icon")).toBeInTheDocument();
+    expect(screen.getByText("https://example23.com")).toBeInTheDocument();
+  });
+
+  it("should render empty state", () => {
+    setup({
+      isEditing: false,
+      dashcard: emptyLinkDashcard,
+      settings:
+        emptyLinkDashcard.visualization_settings as unknown as LinkCardSettings,
+    });
+
+    expect(screen.queryByLabelText("link icon")).not.toBeInTheDocument();
+    expect(screen.getByLabelText("question icon")).toBeInTheDocument();
+
+    expect(screen.getByText("Choose a link")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/metabase/visualizations/visualizations/LinkViz/LinkVizSettings.ts
+++ b/frontend/src/metabase/visualizations/visualizations/LinkViz/LinkVizSettings.ts
@@ -1,8 +1,6 @@
 import { t } from "ttag";
 
 export interface LinkCardSettings {
-  "card.title": string;
-  "card.description": string;
   link: {
     url?: string;
     entity?: {
@@ -16,19 +14,17 @@ export interface LinkCardSettings {
       id: number;
     };
   };
-  "link.align_vertical": "top" | "middle" | "bottom";
-  "link.align_horizontal": "left" | "center" | "right";
 }
 
 export const settings = {
   uiName: "Link",
   identifier: "link",
   iconName: "link",
-  disableSettingsConfig: false,
+  disableSettingsConfig: true,
   noHeader: true,
   supportsSeries: false,
   hidden: true,
-  supportPreviewing: true,
+  supportPreviewing: false,
   minSize: { width: 1, height: 1 },
   checkRenderable: () => undefined,
   settings: {
@@ -42,60 +38,11 @@ export const settings = {
     link: {
       value: {
         url: "",
-        entity: {
-          type: "",
-          id: "",
-        },
       },
       default: {
         url: "",
       },
     },
-    "link.align_vertical": {
-      section: t`Display`,
-      title: t`Vertical Alignment`,
-      widget: "select",
-      props: {
-        options: [
-          { name: t`Top`, value: "top" },
-          { name: t`Middle`, value: "middle" },
-          { name: t`Bottom`, value: "bottom" },
-        ],
-      },
-      default: "middle",
-    },
-    "link.align_horizontal": {
-      section: t`Display`,
-      title: t`Horizontal Alignment`,
-      widget: "select",
-      props: {
-        options: [
-          { name: t`Left`, value: "left" },
-          { name: t`Center`, value: "center" },
-          { name: t`Right`, value: "right" },
-        ],
-      },
-      default: "left",
-    },
   },
   preventDragging: (e: React.SyntheticEvent) => e.stopPropagation(),
-};
-
-export const getSettingsStyle = (settings: LinkCardSettings) => {
-  const flexProps = {
-    left: "flex-start",
-    right: "flex-end",
-    center: "center",
-    middle: "center",
-    top: "flex-start",
-    bottom: "flex-end",
-  };
-
-  const horizontalSetting = settings["link.align_horizontal"];
-  const verticalSetting = settings["link.align_vertical"];
-
-  return /* css */ `
-    justify-content: ${flexProps[horizontalSetting] ?? "center"};
-    align-items: ${flexProps[verticalSetting] ?? "center"};
-  `;
 };

--- a/frontend/src/metabase/visualizations/visualizations/LinkViz/LinkVizSettings.ts
+++ b/frontend/src/metabase/visualizations/visualizations/LinkViz/LinkVizSettings.ts
@@ -1,0 +1,101 @@
+import { t } from "ttag";
+
+export interface LinkCardSettings {
+  "card.title": string;
+  "card.description": string;
+  link: {
+    url?: string;
+    entity?: {
+      type:
+        | "dashboard"
+        | "card"
+        | "dataset"
+        | "collection"
+        | "table"
+        | "database";
+      id: number;
+    };
+  };
+  "link.align_vertical": "top" | "middle" | "bottom";
+  "link.align_horizontal": "left" | "center" | "right";
+}
+
+export const settings = {
+  uiName: "Link",
+  identifier: "link",
+  iconName: "link",
+  disableSettingsConfig: false,
+  noHeader: true,
+  supportsSeries: false,
+  hidden: true,
+  supportPreviewing: true,
+  minSize: { width: 1, height: 1 },
+  checkRenderable: () => undefined,
+  settings: {
+    "card.title": {
+      dashboard: false,
+      default: t`Link card`,
+    },
+    "card.description": {
+      dashboard: false,
+    },
+    link: {
+      value: {
+        url: "",
+        entity: {
+          type: "",
+          id: "",
+        },
+      },
+      default: {
+        url: "https://metabase.com",
+      },
+    },
+    "link.align_vertical": {
+      section: t`Display`,
+      title: t`Vertical Alignment`,
+      widget: "select",
+      props: {
+        options: [
+          { name: t`Top`, value: "top" },
+          { name: t`Middle`, value: "middle" },
+          { name: t`Bottom`, value: "bottom" },
+        ],
+      },
+      default: "middle",
+    },
+    "link.align_horizontal": {
+      section: t`Display`,
+      title: t`Horizontal Alignment`,
+      widget: "select",
+      props: {
+        options: [
+          { name: t`Left`, value: "left" },
+          { name: t`Center`, value: "center" },
+          { name: t`Right`, value: "right" },
+        ],
+      },
+      default: "center",
+    },
+  },
+  preventDragging: (e: React.SyntheticEvent) => e.stopPropagation(),
+};
+
+export const getSettingsStyle = (settings: LinkCardSettings) => {
+  const flexProps = {
+    left: "flex-start",
+    right: "flex-end",
+    center: "center",
+    middle: "center",
+    top: "flex-start",
+    bottom: "flex-end",
+  };
+
+  const horizontalSetting = settings["link.align_horizontal"];
+  const verticalSetting = settings["link.align_vertical"];
+
+  return /* css */ `
+    justify-content: ${flexProps[horizontalSetting] ?? "center"};
+    align-items: ${flexProps[verticalSetting] ?? "center"};
+  `;
+};

--- a/frontend/src/metabase/visualizations/visualizations/LinkViz/LinkVizSettings.ts
+++ b/frontend/src/metabase/visualizations/visualizations/LinkViz/LinkVizSettings.ts
@@ -48,7 +48,7 @@ export const settings = {
         },
       },
       default: {
-        url: "https://metabase.com",
+        url: "",
       },
     },
     "link.align_vertical": {
@@ -75,7 +75,7 @@ export const settings = {
           { name: t`Right`, value: "right" },
         ],
       },
-      default: "center",
+      default: "left",
     },
   },
   preventDragging: (e: React.SyntheticEvent) => e.stopPropagation(),

--- a/frontend/src/metabase/visualizations/visualizations/LinkViz/index.ts
+++ b/frontend/src/metabase/visualizations/visualizations/LinkViz/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./LinkViz";


### PR DESCRIPTION
Resolves #28245 

### Description

- adds basic url-linking dashboard cards
- uses the same `virtual_card` structure that we use for text cards and actions, and requires no backend changes

![Screen Shot 2023-02-14 at 12 42 28 PM](https://user-images.githubusercontent.com/30528226/218841435-2a3cd526-ea60-4dbb-a22c-f217b1dbafea.png)


### How to verify

- Open a dashboard and click `edit`
- click the new "add a link" button
- add any valid url
- see that when you save the dashboard, you get a link, that should open links in a new tab

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
