### PR TITLE
Let the token features sanity check get memoized

### DIFF
--- a/src/metabase/public_settings/premium_features.clj
+++ b/src/metabase/public_settings/premium_features.clj
@@ -119,14 +119,19 @@
   ;; the first request to finish
   (let [lock (Object.)
         f    (memoize/ttl
-              fetch-token-status*
+              (fn [token]
+                ;; this is a sanity check to make sure we can actually get the active user count BEFORE we try to
+                ;; call [[fetch-token-status*]], because `fetch-token-status*` catches Exceptions and caches even failed
+                ;; results. We were running into issues in the e2e tests where `active-user-count` was timing out realed
+                ;; to weird timeouts after restoring the app DB from a snapshot, which would cause other tests to fail
+                ;; because a timed-out token check would get cached as a result.
+                (assert ((requiring-resolve 'metabase.db/db-is-set-up?)) "Metabase DB is not yet set up")
+                (u/with-timeout (u/seconds->ms 5)
+                  (active-user-count))
+                (fetch-token-status* token))
               :ttl/threshold (u/minutes->ms 5))]
     (fn [token]
-      (assert ((requiring-resolve 'metabase.db/db-is-set-up?)) "Metabase DB is not yet set up")
       (locking lock
-        ;; SANITY CHECK!
-        (u/with-timeout (u/seconds->ms 5)
-          (active-user-count))
         (f token)))))
 
 (schema/defn ^:private valid-token->features* :- #{su/NonBlankString}


### PR DESCRIPTION
I put a sanity check in there last week to fix weird issues where e2e tests were broken

But we don't need to do this sanity check every time we look up token features. If we have cached features we don't need to do the check again, so put that inside the stuff that gets memoized. Removes a lot of unneeded app DB hits