### PR TITLE
[CI] Add path filtering to the yaml linter workflow

### DIFF
--- a/.github/file-paths.yaml
+++ b/.github/file-paths.yaml
@@ -86,3 +86,7 @@ snowplow:
 documentation:
   - "docs/**"
   - "**.md"
+
+yaml:
+  - "**.yml"
+  - "**.yaml"

--- a/.github/workflows/yaml.yml
+++ b/.github/workflows/yaml.yml
@@ -8,9 +8,24 @@ on:
   pull_request:
 
 jobs:
+  files-changed:
+    name: Check which files changed
+    runs-on: ubuntu-20.04
+    timeout-minutes: 3
+    outputs:
+      yaml: ${{ steps.changes.outputs.yaml }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Test which files changed
+        uses: dorny/paths-filter@v2.11.1
+        id: changes
+        with:
+          token: ${{ github.token }}
+          filters: .github/file-paths.yaml
 
   yaml-linter:
     runs-on: ubuntu-20.04
+    if: needs.files-changed.outputs.yaml == 'true'
     timeout-minutes: 10
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
Adds better path filtering to the `yaml` linter workflow.

Math behind this decision:

~33600 runs * 1.3 min = 46600 min = 727h = **1 month!**

Blind guess is that more than 80% of all these runs didn't even touch any yaml file.