### PR TITLE
Model sidebar fix followup

### DIFF
--- a/frontend/src/metabase-lib/metadata/utils/models.ts
+++ b/frontend/src/metabase-lib/metadata/utils/models.ts
@@ -180,14 +180,15 @@ function getFieldFromColumnVizSetting(
   );
 }
 
-export function getSortedModelFields(model: Question) {
-  // Columns in resultsMetadata contain all the necessary metadata
-  // orderedColumns contain properly sorted columns, but they only contain field names and refs.
-  // Normally, columns in resultsMetadata are ordered too,
-  // but they only get updated after running a query (which is not triggered after reordering columns).
-  // This ensures metadata rich columns are sorted correctly not to break the "Tab" key navigation behavior.
-  const columnMetadata = model.getResultMetadata();
-
+// Columns in resultsMetadata contain all the necessary metadata
+// orderedColumns contain properly sorted columns, but they only contain field names and refs.
+// Normally, columns in resultsMetadata are ordered too,
+// but they only get updated after running a query (which is not triggered after reordering columns).
+// This ensures metadata rich columns are sorted correctly not to break the "Tab" key navigation behavior.
+export function getSortedModelFields(
+  model: Question,
+  columnMetadata?: QueryField[],
+) {
   if (!Array.isArray(columnMetadata)) {
     return [];
   }

--- a/frontend/src/metabase-lib/metadata/utils/models.ts
+++ b/frontend/src/metabase-lib/metadata/utils/models.ts
@@ -203,11 +203,13 @@ export function getSortedModelFields(
   const tableFields = table?.fields ?? [];
   const tableColumns = tableFields.map(field => field.column());
 
-  return orderedColumns.map(columnVizSetting =>
-    getFieldFromColumnVizSetting(
-      columnVizSetting,
-      tableColumns,
-      columnMetadata,
-    ),
-  );
+  return orderedColumns
+    .map(columnVizSetting =>
+      getFieldFromColumnVizSetting(
+        columnVizSetting,
+        tableColumns,
+        columnMetadata,
+      ),
+    )
+    .filter(Boolean);
 }

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.jsx
@@ -191,7 +191,10 @@ function DatasetEditor(props) {
     onOpenModal,
   } = props;
 
-  const fields = useMemo(() => getSortedModelFields(dataset), [dataset]);
+  const fields = useMemo(
+    () => getSortedModelFields(dataset, resultsMetadata?.columns),
+    [dataset, resultsMetadata],
+  );
 
   const isEditingQuery = datasetEditorTab === "query";
   const isEditingMetadata = datasetEditorTab === "metadata";


### PR DESCRIPTION
Followup on #28197

The fix seems incomplete as the problematic model on our internal instance still has issues. I can't reproduce it locally though, so this PR tries to bring the current implementation a bit closer to how it used to be:

* switches to using `resultsMetadata` coming from QB redux instead of the one from `model.getResultMetadata()`
* adds `filter(Boolean)` to the final step of building model column metadata list

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/28261)
<!-- Reviewable:end -->
