### PR TITLE
Repro #27873: Missing group by column from the joined table

### DIFF
--- a/frontend/test/metabase/scenarios/joins/reproductions/27873-missing-joined-group-by.cy.spec.js
+++ b/frontend/test/metabase/scenarios/joins/reproductions/27873-missing-joined-group-by.cy.spec.js
@@ -1,0 +1,54 @@
+import {
+  restore,
+  visitQuestionAdhoc,
+  summarize,
+} from "__support__/e2e/helpers";
+import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
+import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
+
+const { ORDERS, ORDERS_ID, PEOPLE, PEOPLE_ID } = SAMPLE_DATABASE;
+
+const questionDetails = {
+  dataset_query: {
+    type: "query",
+    query: {
+      "source-table": ORDERS_ID,
+      joins: [
+        {
+          fields: "all",
+          "source-table": PEOPLE_ID,
+          condition: [
+            "=",
+            ["field", ORDERS.USER_ID, null],
+            ["field", PEOPLE.ID, { "join-alias": "People - User" }],
+          ],
+          alias: "People - User",
+        },
+      ],
+      aggregation: [["count"]],
+      breakout: [
+        ["field", ORDERS.TOTAL, { binning: { strategy: "default" } }],
+        ["field", PEOPLE.SOURCE, { "join-alias": "People - User" }],
+      ],
+    },
+    database: SAMPLE_DB_ID,
+  },
+  display: "table",
+};
+
+describe.skip("issue 27873", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+  });
+
+  it("should show a group by column from the joined field in the summarize sidebar (metabase#27873)", () => {
+    visitQuestionAdhoc(questionDetails);
+    summarize();
+
+    cy.findByTestId("aggregation-item").should("have.text", "Count");
+    cy.findByTestId("pinned-dimensions")
+      .should("contain", "Total")
+      .and("contain", "People - User → Source");
+  });
+});


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #27873 

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/joins/reproductions/27873-missing-joined-group-by.cy.spec.js`
- Unskip repro
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/218462686-16ea5d72-fe18-4e56-9dbb-242fb63f2f50.png)

