### PR TITLE
Add Clickhouse as a partner driver

### DIFF
--- a/src/metabase/driver/util.clj
+++ b/src/metabase/driver/util.clj
@@ -466,7 +466,7 @@
 
 (def partner-drivers
   "The set of other drivers in the partnership program"
-  #{"exasol" "firebolt" "starburst"})
+  #{"clickhouse" "exasol" "firebolt" "starburst"})
 
 (defn driver-source
   "Return the source type of the driver: official, partner, or community"


### PR DESCRIPTION
Adding Clickhouse in the partner driver list

![image](https://user-images.githubusercontent.com/32561114/218481602-4caec43e-f94e-493e-8417-7cdc969346c9.png)
