### PR TITLE
Backport "no native drill fallback when embedded"

### DIFF
--- a/frontend/src/metabase/modes/components/drill/NativeDrillFallback/NativeDrillFallback.styled.tsx
+++ b/frontend/src/metabase/modes/components/drill/NativeDrillFallback/NativeDrillFallback.styled.tsx
@@ -1,7 +1,5 @@
 import styled from "@emotion/styled";
 import { color } from "metabase/lib/colors";
-import Icon from "metabase/components/Icon";
-import ExternalLink from "metabase/core/components/ExternalLink";
 
 export const DrillRoot = styled.div`
   max-width: 10.75rem;
@@ -11,12 +9,4 @@ export const DrillMessage = styled.div`
   color: ${color("text-dark")};
   font-weight: bold;
   line-height: 1.5rem;
-  margin-bottom: 0.5rem;
-`;
-
-export const DrillLearnLink = styled(ExternalLink)`
-  display: inline-flex;
-  align-items: center;
-  gap: 0.5rem;
-  color: ${color("brand")};
 `;

--- a/frontend/src/metabase/modes/components/drill/NativeDrillFallback/NativeDrillFallback.tsx
+++ b/frontend/src/metabase/modes/components/drill/NativeDrillFallback/NativeDrillFallback.tsx
@@ -1,15 +1,11 @@
 import React from "react";
 import { t } from "ttag";
-import MetabaseSettings from "metabase/lib/settings";
+import { IFRAMED } from "metabase/lib/dom";
 import { getEngineNativeType } from "metabase/lib/engine";
-import Icon from "metabase/components/Icon";
 import Question from "metabase-lib/Question";
 import { nativeDrillFallback } from "metabase-lib/queries/drills/native-drill-fallback";
-import {
-  DrillLearnLink,
-  DrillMessage,
-  DrillRoot,
-} from "./NativeDrillFallback.styled";
+
+import { DrillMessage, DrillRoot } from "./NativeDrillFallback.styled";
 
 interface NativeDrillFallbackProps {
   question: Question;
@@ -23,7 +19,10 @@ const NativeDrillFallback = ({ question }: NativeDrillFallbackProps) => {
 
   const { database } = drill;
   const isSql = getEngineNativeType(database.engine) === "sql";
-  const learnUrl = MetabaseSettings.learnUrl("questions/drill-through");
+
+  if (IFRAMED) {
+    return [];
+  }
 
   return [
     {
@@ -37,10 +36,6 @@ const NativeDrillFallback = ({ question }: NativeDrillFallbackProps) => {
               ? t`Drill-through doesn’t work on SQL questions.`
               : t`Drill-through doesn’t work on native questions.`}
           </DrillMessage>
-          <DrillLearnLink href={learnUrl}>
-            <Icon name="reference" />
-            {t`Learn more`}
-          </DrillLearnLink>
         </DrillRoot>
       ),
     },

--- a/frontend/src/metabase/modes/components/drill/NativeDrillFallback/NativeDrillFallback.unit.spec.tsx
+++ b/frontend/src/metabase/modes/components/drill/NativeDrillFallback/NativeDrillFallback.unit.spec.tsx
@@ -1,0 +1,35 @@
+jest.doMock("metabase/lib/dom");
+import * as dom from "metabase/lib/dom";
+import { getCleanNativeQuestion } from "metabase-lib/mocks";
+import NativeDrillFallback from "./NativeDrillFallback";
+
+describe("NativeDrillFallback", () => {
+  let isWithinIframeSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    isWithinIframeSpy = jest.spyOn(dom, "isWithinIframe");
+  });
+
+  afterEach(() => {
+    isWithinIframeSpy.mockRestore();
+  });
+
+  it("should return native drill fallback element on native questions", async () => {
+    isWithinIframeSpy.mockReturnValue(false);
+
+    const question = getCleanNativeQuestion();
+    const result = NativeDrillFallback({ question });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe("fallback-native");
+  });
+
+  it("should not return native drill fallback element on native questions when the app is in iframe", async () => {
+    isWithinIframeSpy.mockReturnValue(true);
+
+    const question = getCleanNativeQuestion();
+    const result = NativeDrillFallback({ question });
+
+    expect(result).toHaveLength(0);
+  });
+});

--- a/frontend/src/metabase/modes/components/drill/NativeDrillFallback/NativeDrillFallback.unit.spec.tsx
+++ b/frontend/src/metabase/modes/components/drill/NativeDrillFallback/NativeDrillFallback.unit.spec.tsx
@@ -1,35 +1,45 @@
-jest.doMock("metabase/lib/dom");
 import * as dom from "metabase/lib/dom";
+
 import { getCleanNativeQuestion } from "metabase-lib/mocks";
 import NativeDrillFallback from "./NativeDrillFallback";
 
+const mockIframed = (value: boolean) => {
+  const previous = dom.IFRAMED;
+  Object.defineProperty(dom, "IFRAMED", {
+    configurable: true,
+    get() {
+      return value;
+    },
+  });
+
+  return () => {
+    Object.defineProperty(dom, "IFRAMED", {
+      configurable: true,
+      get() {
+        return previous;
+      },
+    });
+  };
+};
+
 describe("NativeDrillFallback", () => {
-  let isWithinIframeSpy: jest.SpyInstance;
-
-  beforeEach(() => {
-    isWithinIframeSpy = jest.spyOn(dom, "isWithinIframe");
-  });
-
-  afterEach(() => {
-    isWithinIframeSpy.mockRestore();
-  });
-
-  it("should return native drill fallback element on native questions", async () => {
-    isWithinIframeSpy.mockReturnValue(false);
-
+  it("should return native drill fallback element on native questions", () => {
+    const unmock = mockIframed(false);
     const question = getCleanNativeQuestion();
     const result = NativeDrillFallback({ question });
 
     expect(result).toHaveLength(1);
     expect(result[0].name).toBe("fallback-native");
+    unmock();
   });
 
-  it("should not return native drill fallback element on native questions when the app is in iframe", async () => {
-    isWithinIframeSpy.mockReturnValue(true);
+  it("should not return native drill fallback element on native questions when the app is in iframe", () => {
+    const unmock = mockIframed(true);
 
     const question = getCleanNativeQuestion();
     const result = NativeDrillFallback({ question });
 
     expect(result).toHaveLength(0);
+    unmock();
   });
 });


### PR DESCRIPTION
Manual backport of https://github.com/metabase/metabase/pull/28243