### PR TITLE
[metabase-lib] PoC for wrapping JS objects with cljs-bean in CLJC

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -405,6 +405,7 @@
   metabase.db.data-migrations/defmigration                                             clojure.core/def
   metabase.db.liquibase/with-liquibase                                                 clojure.core/let
   metabase.db.schema-migrations-test.impl/with-temp-empty-app-db                       clojure.core/let
+  metabase.domain-entities.malli/defn                                                  schema.core/defn
   metabase.driver.mongo.query-processor/mongo-let                                      clojure.core/let
   metabase.driver.mongo.util/with-mongo-connection                                     clojure.core/let
   metabase.driver.sql-jdbc.actions/with-jdbc-transaction                               clojure.core/let

--- a/.clj-kondo/macros/metabase/shared/util/namespaces.clj
+++ b/.clj-kondo/macros/metabase/shared/util/namespaces.clj
@@ -6,12 +6,3 @@
    `(def ~(-> sym name symbol) "docstring" ~sym))
   ([sym name]
    `(def ~name "docstring" ~sym)))
-
-(defmacro import-fns
-  "Kondo macro replacement for [[metabase.shared.util.namespaces/import-fns]]."
-  [& pairs]
-  `(vector ~@(for [[from & syms] pairs
-               sym           syms
-               :let [args (gensym)]]
-           (symbol (name from) (name sym))
-           #_`(def ~sym "docstring" (fn [& ~args] (apply ~(symbol (name from) (name sym)) ~args))))))

--- a/deps.edn
+++ b/deps.edn
@@ -283,9 +283,10 @@
   :cljs
   {:extra-paths ["test" "shared/test"]
    :extra-deps
-   {com.lambdaisland/glogi  {:mvn/version "1.2.164"}
+   {cljs-bean/cljs-bean     {:mvn/version "1.9.0"}
+    com.lambdaisland/glogi  {:mvn/version "1.2.164"}
     io.github.metabase/hawk {:sha "45ed36008014f9ac1ea66beb56fb1c4c39f8342b"}
-    thheller/shadow-cljs    {:mvn/version "2.19.6"}}}
+    thheller/shadow-cljs    {:mvn/version "2.20.20"}}}
 
   ;; for local dev -- include the drivers locally with :dev:drivers
   :drivers

--- a/frontend/src/metabase-lib/queries/utils/expression.js
+++ b/frontend/src/metabase-lib/queries/utils/expression.js
@@ -1,14 +1,15 @@
 import _ from "underscore";
+import {
+  expressions_list,
+  unique_expression_name,
+} from "cljs/metabase.domain_entities.queries.util";
 
 export function getExpressions(expressions = {}) {
   return expressions;
 }
 
 export function getExpressionsList(expressions = {}) {
-  return Object.entries(expressions).map(([name, expression]) => ({
-    name,
-    expression,
-  }));
+  return expressions_list(expressions);
 }
 
 export function addExpression(expressions = {}, name, expression) {
@@ -42,23 +43,5 @@ export function clearExpressions(expressions) {
  * @returns {string}
  */
 export function getUniqueExpressionName(expressions, originalName) {
-  if (!expressions[originalName]) {
-    return originalName;
-  }
-  const expressionNames = Object.keys(expressions);
-  const handledDuplicateNamePattern = new RegExp(
-    `^${originalName} \\([0-9]+\\)$`,
-  );
-  const duplicateNames = expressionNames.filter(
-    name => name === originalName || handledDuplicateNamePattern.test(name),
-  );
-  return getUniqueName(duplicateNames, originalName, duplicateNames.length);
-}
-
-function getUniqueName(expressionNames, originalName, index) {
-  const nameWithIndexAppended = `${originalName} (${index})`;
-  const isUnique = !expressionNames.includes(nameWithIndexAppended);
-  return isUnique
-    ? nameWithIndexAppended
-    : getUniqueName(expressionNames, originalName, index + 1);
+  return unique_expression_name(expressions, originalName);
 }

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -11,7 +11,8 @@
  {:app
   {:target     :npm-module
    :output-dir "frontend/src/cljs/"
-   :entries    [metabase.mbql.js
+   :entries    [metabase.domain-entities.queries.util
+                metabase.mbql.js
                 metabase.types
                 metabase.shared.formatting.constants
                 metabase.shared.formatting.date

--- a/src/metabase/domain_entities/converters.cljs
+++ b/src/metabase/domain_entities/converters.cljs
@@ -1,0 +1,73 @@
+(ns metabase.domain-entities.converters
+  (:require
+    [camel-snake-kebab.core :as csk]
+    [cljs-bean.core :as bean]
+    ))
+
+(defn- ->entity
+  "Conversion of incoming vanilla JS objects and arrays to CLJS maps and vectors.
+
+  You should not need to call this directly; it's an implementation detail of [[defn]]."
+  [x]
+  (bean/->clj x
+              :prop->key csk/->kebab-case-keyword
+              :key->prop csk/->camelCaseString))
+
+(defn- entity->
+  "Conversion of cljs-bean wrapped CLJS maps and vectors back into vanilla JS objects and arrays.
+
+  You should not need to call this directly; it's an implementation detail of [[defn]]."
+  [x]
+  (bean/->js x :key->prop csk/->camelCaseString))
+
+(defn- opaque? [schema]
+  (-> schema :properties :bean/opaque boolean))
+
+(defmulti incoming
+  "Note that this works on the map syntax, the Malli AST, not the raw vectors.
+  It's easier to process that way."
+  (fn [schema]
+    (if (opaque? schema)
+      :bean/opaque
+      (:type schema))))
+
+(defmethod incoming :default [_]
+  identity)
+
+(defmethod incoming :bean/opaque [_]
+  identity)
+
+(defmethod incoming :vector [schema]
+  (let [kf (incoming (:child schema))]
+    #(mapv kf %)))
+
+(defmethod incoming :tuple [schema]
+  (let [inner (map incoming (:children schema))]
+    (fn [value]
+      (mapv #(%1 %2) inner value))))
+
+(def ^:private conversion-needed? #{:tuple :vector :map :map-of})
+
+(defmethod incoming :map-of [schema]
+  (let [vf          (incoming (:value schema))
+        keywordize? (-> schema :key :type (#{:keyword 'keyword?}))
+        recursive?  (-> schema :value :type conversion-needed?)
+        transform   (when (and (not (opaque? (:value schema)))
+                               (not= identity vf))
+                      vf)
+        opts        (cond-> {:recursive       (boolean recursive?)
+                             :keywordize-keys (boolean keywordize?)}
+                      keywordize? (assoc :prop->key csk/->kebab-case-keyword
+                                         :key->prop csk/->camelCaseString)
+                      transform   (assoc :transform transform))]
+    #(bean/bean % opts)))
+
+(defmethod incoming :map [_schema]
+  ->entity)
+
+;; TODO Does this handle cases where we didn't convert string keys to keywords? Does it need to be schema-smart too?
+#_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]} ;; This is used by macro-generated code.
+(defn outgoing
+  "Converts back to pure JS form."
+  [x]
+  (entity-> x))

--- a/src/metabase/domain_entities/malli.cljc
+++ b/src/metabase/domain_entities/malli.cljc
@@ -1,0 +1,65 @@
+(ns metabase.domain-entities.malli
+  (:refer-clojure :exclude [defn])
+  (:require
+    [malli.util :as mut]
+    #?@(:clj  ([malli.core :as mc]
+               [metabase.util.malli :as mu]
+               [net.cgrand.macrovich :as macros])
+        :cljs ([malli.instrument]
+               [metabase.domain-entities.converters])))
+  #?(:cljs (:require-macros [metabase.domain-entities.malli])))
+
+;; Experimental JS->CLJS bridge
+;; - Pass vanilla JS objects to functions written with a defn macro
+;; - It wraps mu/defn and uses the Malli schemas to determine which arguments need conversion with `cljs-bean`.
+;;   - Use recursive beaning, or something like it, for all Clojure-side access and usage.
+
+;; I think this is the most practical and TS-native approach. Clojure is a lot more flexible, with macros and dynamic
+;; typing, so it should be the one jumping through the hoops. Of course performance is a question but there's still
+;; hope. We can assume (deep) immutability so there's lots of room for caching of eg. key conversion.
+
+#?(:clj
+   (clojure.core/defn- argname [arg]
+     (cond
+       (symbol? arg)   arg
+       (and (map? arg)
+            (:as arg)) (:as arg)
+       :else           (gensym "arg"))))
+
+#?(:clj
+   (defmacro defn
+     "Specialized [[clojure.core/defn]] for writing domain objects CLJC code.
+
+     Malli schemas are *required* for the return type and arguments!
+
+     In JVM Clojure, this is transparently [[mu/defn]].
+
+     For CLJS, the argument schemas are used to determine how to wrap each vanilla JS
+     argument for idiomatic use in CLJS. This is powered by the `cljs-bean` library.
+
+     See `metabase.domain-entities.converters` for the details of how things get converted.
+     In summary:
+     - `[:map ...]` expects a JS object with `camelCase`, and gets wrapped as a CLJS map with
+       `:kebab-case` keyword keys. Values are recursively converted.
+     - `[:map-of ...]` is converted to a CLJS map, but the keys are left alone.
+     - `[:vector ...]` expects a JS array, and converts it to a vector.
+     - Use [[opaque]] to block conversion of (part of) a schema, if it's treated as opaque by the code."
+     [sym _ return-schema docstring args & body]
+     (macros/case
+       ;; In Clojure, this is a straightforward clone of mu/defn.
+       :clj  `(mu/defn ~sym :- ~return-schema ~docstring ~(vec args) ~@body)
+       ;; In CLJS, we do fancy cljs-bean wrapping based on the schema.
+       :cljs
+       (let [argnames (map (comp argname first) (partition 3 args))]
+         `(clojure.core/defn ~sym ~docstring [~@argnames]
+            (metabase.domain-entities.converters/outgoing
+              (let [~@(apply concat
+                             (for [[sym [argspec _ schema]] (map vector argnames (partition 3 args))]
+                               `[~argspec
+                                 ((metabase.domain-entities.converters/incoming (malli.core/ast ~schema)) ~sym)]))]
+              ~@body)))))))
+
+(clojure.core/defn opaque
+  "Marks a schema as `:bean/opaque true` so that it will be ignored by the converters."
+  [schema]
+  (mut/update-properties schema assoc :bean/opaque true))

--- a/src/metabase/domain_entities/queries/util.cljc
+++ b/src/metabase/domain_entities/queries/util.cljc
@@ -1,0 +1,32 @@
+(ns metabase.domain-entities.queries.util
+  "Utility functions used by the Queries in metabase-lib."
+  (:require
+   [metabase.domain-entities.malli :as de]))
+
+(def Expression
+  "Schema for an Expression that's part of a query filter."
+  [:map])
+
+(de/defn ^:export expressions-list :- [:vector [:map [:name string?] [:expression Expression]]]
+  "Turns a map of expressions by name into a list of `{:name name :expression expression}` objects."
+  [expressions :- [:map-of string? Expression]]
+  (mapv (fn [[name expr]] {:name name :expression expr}) expressions))
+
+(defn- unique-name [names original-name index]
+  (let [indexed-name (str original-name " (" index ")")]
+    (if (names indexed-name)
+      (recur names original-name (inc index))
+      indexed-name)))
+
+(de/defn ^:export unique-expression-name :- string?
+  "Generates an expression name that's unique in the given map of expressions."
+  [expressions   :- [:map-of string? (de/opaque Expression)]
+   original-name :- string?]
+  (let [expression-names (set (keys expressions))]
+    (if (not (expression-names original-name))
+      original-name
+      (let [re-duplicates (re-pattern (str "^" original-name " \\([0-9]+\\)$"))
+            duplicates    (set (filter #(or (= % original-name)
+                                            (re-matches re-duplicates %))
+                                       expression-names))]
+        (unique-name duplicates original-name (count duplicates))))))

--- a/src/metabase/util/malli.cljc
+++ b/src/metabase/util/malli.cljc
@@ -2,17 +2,19 @@
   (:refer-clojure :exclude [defn])
   (:require
    [clojure.core :as core]
-   [clojure.string :as str]
    [malli.core :as mc]
    [malli.destructure]
    [malli.error :as me]
-   [malli.experimental :as mx]
    [malli.generator :as mg]
-   [malli.instrument :as minst]
    [malli.util :as mut]
+   [metabase.shared.util.i18n :refer [tru]]
    [metabase.util :as u]
-   [metabase.util.i18n :as i18n :refer [deferred-tru]]
-   #?@(:clj [[ring.util.codec :as codec]])))
+   #?@(:clj  ([clojure.string :as str]
+              [malli.experimental :as mx]
+              [malli.instrument :as minst]
+              [metabase.util.i18n :as i18n]
+              [ring.util.codec :as codec])))
+  #?(:cljs (:require-macros [metabase.util.malli])))
 
 (core/defn- encode-uri [fragment]
   (#?(:clj codec/url-encode :cljs js/encodeURI) fragment))
@@ -40,9 +42,10 @@
 (core/defn- humanize-include-value
   "Pass into mu/humanize to include the value received in the error message."
   [{:keys [value message]}]
-  (str message ", " (deferred-tru "received") ": "(pr-str value)))
+  ;; TODO Should this be translated with more complete context? (tru "{0}, received: {1}" message (pr-str value))
+  (str message ", " (tru "received") ": " (pr-str value)))
 
-(core/defn- explain-fn-fail!
+(core/defn explain-fn-fail!
   "Used as reporting function to minst/instrument!"
   [type data]
   (let [{:keys [input args output value]} data
@@ -56,60 +59,62 @@
                                   output (->malli-io-link output value))
                       :humanized humanized}))))))
 
-;; since a reference to the private var is used in the macro, this will trip the eastwood :unused-private-vars linter,
-;; so just harmlessly "use" the var here.
-explain-fn-fail!
+#?(:clj
+   (core/defn- -defn [schema args]
+     (let [{:keys [name return doc meta arities] :as parsed} (mc/parse schema args)
+           _ (when (= ::mc/invalid parsed) (mc/-fail! ::parse-error {:schema schema, :args args}))
+           parse (fn [{:keys [args] :as parsed}] (merge (malli.destructure/parse args) parsed))
+           ->schema (fn [{:keys [schema]}] [:=> schema (:schema return :any)])
+           single (= :single (key arities))
+           parglists (if single
+                       (->> arities val parse vector)
+                       (->> arities val :arities (map parse)))
+           raw-arglists (map :raw-arglist parglists)
+           schema (as-> (map ->schema parglists) $ (if single (first $) (into [:function] $)))
+           annotated-doc (str/trim
+                           (str "Inputs: " (if single
+                                             (pr-str (first (mapv :raw-arglist parglists)))
+                                             (str "(" (str/join "\n           " (map (comp pr-str :raw-arglist) parglists)) ")"))
+                                "\n  Return: " (str/replace (u/pprint-to-str (:schema return :any))
+                                                            "\n"
+                                                            (str "\n          "))
+                                (when (not-empty doc) (str "\n\n  " doc))))
+           id (str (gensym "id"))]
+       `(let [defn# (core/defn
+                      ~name
+                      ~@(some-> annotated-doc vector)
+                      ~(assoc meta
+                              :raw-arglists (list 'quote raw-arglists)
+                              :schema schema
+                              :validate! id)
+                      ~@(map (fn [{:keys [arglist prepost body]}] `(~arglist ~prepost ~@body)) parglists)
+                      ~@(when-not single (some->> arities val :meta vector)))]
+          (mc/=> ~name ~schema)
+          (minst/instrument! {;; instrument the defn we just registered, via ~id
+                              :filters [(minst/-filter-var #(-> % meta :validate! (= ~id)))]
+                              :report explain-fn-fail!})
+          defn#))))
 
-(core/defn- -defn [schema args]
-  (let [{:keys [name return doc meta arities] :as parsed} (mc/parse schema args)
-        _ (when (= ::mc/invalid parsed) (mc/-fail! ::parse-error {:schema schema, :args args}))
-        parse (fn [{:keys [args] :as parsed}] (merge (malli.destructure/parse args) parsed))
-        ->schema (fn [{:keys [schema]}] [:=> schema (:schema return :any)])
-        single (= :single (key arities))
-        parglists (if single
-                    (->> arities val parse vector)
-                    (->> arities val :arities (map parse)))
-        raw-arglists (map :raw-arglist parglists)
-        schema (as-> (map ->schema parglists) $ (if single (first $) (into [:function] $)))
-        annotated-doc (str/trim
-                       (str "Inputs: " (if single
-                                         (pr-str (first (mapv :raw-arglist parglists)))
-                                         (str "(" (str/join "\n           " (map (comp pr-str :raw-arglist) parglists)) ")"))
-                            "\n  Return: " (str/replace (u/pprint-to-str (:schema return :any))
-                                                        "\n"
-                                                        (str "\n          "))
-                            (when (not-empty doc) (str "\n\n  " doc))))
-        id (str (gensym "id"))]
-    `(let [defn# (core/defn
-                   ~name
-                   ~@(some-> annotated-doc vector)
-                   ~(assoc meta
-                           :raw-arglists (list 'quote raw-arglists)
-                           :schema schema
-                           :validate! id)
-                   ~@(map (fn [{:keys [arglist prepost body]}] `(~arglist ~prepost ~@body)) parglists)
-                   ~@(when-not single (some->> arities val :meta vector)))]
-       (mc/=> ~name ~schema)
-       (minst/instrument! {;; instrument the defn we just registered, via ~id
-                           :filters [(minst/-filter-var #(-> % meta :validate! (= ~id)))]
-                           :report #'explain-fn-fail!})
-       defn#)))
-
-(defmacro defn
-  "Like s/defn, but for malli. Will always validate input and output without the need for calls to instrumentation (they are emitted automatically).
-   Calls to minst/unstrument! can remove this, so use a filter that avoids :validate! if you use that."
-  [& args]
-  (-defn mx/SchematizedParams args))
+#?(:clj
+   (defmacro defn
+     "Like s/defn, but for malli. Will always validate input and output without the need for calls to instrumentation (they are emitted automatically).
+     Calls to minst/unstrument! can remove this, so use a filter that avoids :validate! if you use that."
+     [& args]
+     (-defn mx/SchematizedParams args)))
 
 (def ^:private Schema
   [:and any?
    [:fn {:description "a malli schema"} mc/schema]])
 
 (def ^:private localized-string-schema
-  [:fn {:error/message "must be a localized string"}
-   i18n/localized-string?])
+  #?(:clj  [:fn {:error/message "must be a localized string"}
+            i18n/localized-string?]
+     ;; TODO Is there a way to check if a string is being localized in CLJS, by the `ttag`?
+     ;; The compiler seems to just inline the translated strings with no annotation or wrapping.
+     :cljs string?))
 
-(defn with-api-error-message
+;; Kondo gets confused by :refer [defn] on this, so it's referenced fully qualified.
+(metabase.util.malli/defn with-api-error-message
   "Update a malli schema to have a :description (used by umd/describe, which is used by api docs),
   and a :error/fn (used by me/humanize, which is used by defendpoint).
   They don't have to be the same, but usually are.


### PR DESCRIPTION
A `metabase.domain-entities.malli/defn` macro that (in CLJS) uses the
schemas for the arguments to drive wrapping of vanilla JS objects for
idiomatic use in CLJC code.

See the first two functions in `metabase.domain-entities.queries.util`
which get passed vanilla JS objects but can use them as CLJS maps.

