### PR TITLE
Remove archived actions from GET /api/action/public results

### DIFF
--- a/src/metabase/api/action.clj
+++ b/src/metabase/api/action.clj
@@ -63,7 +63,7 @@
   []
   (validation/check-has-application-permission :setting)
   (validation/check-public-sharing-enabled)
-  (db/select [Action :name :id :public_uuid :model_id], :public_uuid [:not= nil]))
+  (db/select [Action :name :id :public_uuid :model_id], :public_uuid [:not= nil], :archived false))
 
 (api/defendpoint GET "/:action-id"
   [action-id]

--- a/test/metabase/api/action_test.clj
+++ b/test/metabase/api/action_test.clj
@@ -280,7 +280,11 @@
                    (mt/user-http-request :rasta :get 403 "action/public"))))
           (testing "Test that superusers can fetch a list of publicly-accessible actions"
             (is (= [{:name "Test action" :id action-id :public_uuid (:public_uuid action-opts) :model_id model-id}]
-                   (filter #(= (:id %) action-id) (mt/user-http-request :crowberto :get 200 "action/public"))))))))))
+                   (filter #(= (:id %) action-id) (mt/user-http-request :crowberto :get 200 "action/public"))))))
+        (testing "We cannot fetch an archived action"
+          (mt/with-actions [{} (assoc action-opts :archived true)]
+            (is (= []
+                   (mt/user-http-request :crowberto :get 200 "action/public")))))))))
 
 (deftest share-action-test
   (testing "POST /api/action/:id/public_link"


### PR DESCRIPTION
This PR excludes archived actions from the response from the GET "/api/action/public" endpoint.

It follows from [Action archiving](https://github.com/metabase/metabase/pull/28268#top) and [[Feature] Allow actions to be shared via public link: Milestone 2](https://github.com/metabase/metabase/pull/27845#top).

It should have been part of Milestone 2 but because archiving actions was only added shortly before milestone 2 was merged, it wasn't caught.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/28307)
<!-- Reviewable:end -->
