### PR TITLE
[CI] Start using the latest `maildev` (2.0.5) and adjust ports

### DIFF
--- a/.github/workflows/e2e-main.yml
+++ b/.github/workflows/e2e-main.yml
@@ -83,10 +83,10 @@ jobs:
             java-version: 11
     services:
       maildev:
-        image: maildev/maildev:1.1.0
+        image: maildev/maildev:2.0.5
         ports:
-          - "80:80"
-          - "25:25"
+          - "1080:1080"
+          - "1025:1025"
         credentials:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -189,10 +189,10 @@ jobs:
         edition: [ee]
     services:
       maildev:
-        image: maildev/maildev:1.1.0
+        image: maildev/maildev:2.0.5
         ports:
-          - "80:80"
-          - "25:25"
+          - "1080:1080"
+          - "1025:1025"
         credentials:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -97,10 +97,10 @@ jobs:
             java-version: 11
     services:
       maildev:
-        image: maildev/maildev:1.1.0
+        image: maildev/maildev:2.0.5
         ports:
-          - "80:80"
-          - "25:25"
+          - "1080:1080"
+          - "1025:1025"
         credentials:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -244,10 +244,10 @@ jobs:
         edition: [ee]
     services:
       maildev:
-        image: maildev/maildev:1.1.0
+        image: maildev/maildev:2.0.5
         ports:
-          - "80:80"
-          - "25:25"
+          - "1080:1080"
+          - "1025:1025"
         credentials:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/percy-issue-comment.yml
+++ b/.github/workflows/percy-issue-comment.yml
@@ -75,7 +75,7 @@ jobs:
           jar xf target/uberjar/metabase.jar version.properties
           mv version.properties resources/
       - name: Run maildev
-        run: docker run -d -p 80:80 -p 25:25 maildev/maildev:1.1.0
+        run: docker run -d -p 1080:1080 -p 1025:1025 maildev/maildev:2.0.5
       - name: Percy Test
         run: yarn run test-visual-run
         env:

--- a/.github/workflows/percy-visual-label.yml
+++ b/.github/workflows/percy-visual-label.yml
@@ -31,7 +31,7 @@ jobs:
           jar xf target/uberjar/metabase.jar version.properties
           mv version.properties resources/
       - name: Run maildev
-        run: docker run -d -p 80:80 -p 25:25 maildev/maildev:1.1.0
+        run: docker run -d -p 1080:1080 -p 1025:1025 maildev/maildev:2.0.5
       - name: Percy Test
         run: yarn run test-visual-run
         env:

--- a/frontend/test/__support__/e2e/cypress_data.js
+++ b/frontend/test/__support__/e2e/cypress_data.js
@@ -172,3 +172,8 @@ export const QA_DB_CONFIG = {
     },
   },
 };
+
+export const WEBMAIL_CONFIG = {
+  WEB_PORT: 1080,
+  SMTP_PORT: 1025,
+};

--- a/frontend/test/__support__/e2e/helpers/e2e-email-helpers.js
+++ b/frontend/test/__support__/e2e/helpers/e2e-email-helpers.js
@@ -1,18 +1,22 @@
+import { WEBMAIL_CONFIG } from "../cypress_data";
+
 const INBOX_TIMEOUT = 5000;
 const INBOX_INTERVAL = 100;
 
+const { WEB_PORT, SMTP_PORT } = WEBMAIL_CONFIG;
+
 /**
  * Make sure you have webmail Docker image running locally:
- * `docker run -p 80:80 -p 25:25 maildev/maildev:1.1.0`
+ * `docker run -d -p 1080:1080 -p 1025:1025 maildev/maildev:2.0.5`
  * or
- * `npx maildev -s 25 -w 80`
+ * `npx maildev -s 1025 -w 1080`
  */
 export const setupSMTP = () => {
   cy.log("Set up Webmail SMTP server");
 
   cy.request("PUT", "/api/email", {
     "email-smtp-host": "localhost",
-    "email-smtp-port": "25",
+    "email-smtp-port": SMTP_PORT,
     "email-smtp-username": "admin",
     "email-smtp-password": "admin",
     "email-smtp-security": "none",
@@ -30,20 +34,22 @@ export const getInbox = () => {
 };
 
 const getInboxWithRetry = (timeout = INBOX_TIMEOUT) => {
-  return cy.request("GET", `http://localhost:80/email`).then(response => {
-    if (response.body.length) {
-      return cy.wrap(response);
-    } else if (timeout > 0) {
-      cy.wait(INBOX_INTERVAL);
-      return getInboxWithRetry(timeout - INBOX_INTERVAL);
-    } else {
-      throw new Error("Inbox retry timeout");
-    }
-  });
+  return cy
+    .request("GET", `http://localhost:${WEB_PORT}/email`)
+    .then(response => {
+      if (response.body.length) {
+        return cy.wrap(response);
+      } else if (timeout > 0) {
+        cy.wait(INBOX_INTERVAL);
+        return getInboxWithRetry(timeout - INBOX_INTERVAL);
+      } else {
+        throw new Error("Inbox retry timeout");
+      }
+    });
 };
 
 export const clearInbox = () => {
-  return cy.request("DELETE", "http://localhost:80/email/all");
+  return cy.request("DELETE", `http://localhost:${WEB_PORT}/email/all`);
 };
 
 export const openEmailPage = emailSubject => {
@@ -73,3 +79,14 @@ export const sendSubscriptionsEmail = recipient => {
 
   clickSend();
 };
+
+export function sendEmailAndAssert(callback) {
+  cy.intercept("POST", "/api/pulse/test").as("emailSent");
+
+  cy.findByText("Send email now").click();
+  cy.wait("@emailSent");
+
+  cy.request("GET", `http://localhost:${WEB_PORT}/email`).then(({ body }) => {
+    callback(body[0]);
+  });
+}

--- a/frontend/test/metabase/scenarios/README.md
+++ b/frontend/test/metabase/scenarios/README.md
@@ -2,7 +2,7 @@
 
 ## Running
 
-- If you are running tests that include `alert > email_alert`, run `docker run -p 80:80 -p 25:25 maildev/maildev:1.1.0` in terminal first for setting up email through your localhost
+- If you are running tests that include `alert > email_alert`, run `docker run -d -p 1080:1080 -p 1025:1025 maildev/maildev:2.0.5` in terminal first for setting up email through your localhost
 
 ## Metabase QA DB Tests
 

--- a/frontend/test/metabase/scenarios/admin/settings/email.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/email.cy.spec.js
@@ -1,4 +1,7 @@
 import { restore, setupSMTP } from "__support__/e2e/helpers";
+import { WEBMAIL_CONFIG } from "__support__/e2e/cypress_data";
+
+const { SMTP_PORT, WEB_PORT } = WEBMAIL_CONFIG;
 
 describe("scenarios > admin > settings > email settings", () => {
   beforeEach(() => {
@@ -9,7 +12,7 @@ describe("scenarios > admin > settings > email settings", () => {
   it("should be able to save email settings (metabase#17615)", () => {
     cy.visit("/admin/settings/email");
     cy.findByLabelText("SMTP Host").type("localhost").blur();
-    cy.findByLabelText("SMTP Port").type("25").blur();
+    cy.findByLabelText("SMTP Port").type(SMTP_PORT).blur();
     cy.findByLabelText("SMTP Username").type("admin").blur();
     cy.findByLabelText("SMTP Password").type("admin").blur();
     cy.findByLabelText("From Address").type("mailer@metabase.test").blur();
@@ -23,7 +26,7 @@ describe("scenarios > admin > settings > email settings", () => {
 
     // This part was added as a repro for metabase#17615
     cy.findByDisplayValue("localhost");
-    cy.findByDisplayValue("25");
+    cy.findByDisplayValue(SMTP_PORT);
     cy.findAllByDisplayValue("admin");
     cy.findByDisplayValue("mailer@metabase.test");
     cy.findByDisplayValue("Sender Name");
@@ -56,10 +59,13 @@ describe("scenarios > admin > settings > email settings", () => {
       cy.visit("/admin/settings/email");
       cy.findByText("Send test email").click();
       cy.findByText("Sent!");
-      cy.request("GET", "http://localhost:80/email").then(({ body }) => {
-        const emailBody = body[0].text;
-        expect(emailBody).to.include("Your Metabase emails are working");
-      });
+
+      cy.request("GET", `http://localhost:${WEB_PORT}/email`).then(
+        ({ body }) => {
+          const emailBody = body[0].text;
+          expect(emailBody).to.include("Your Metabase emails are working");
+        },
+      );
     },
   );
 
@@ -96,7 +102,7 @@ describe("scenarios > admin > settings > email settings", () => {
     cy.findByLabelText("SMTP Host")
       .type("foo") // Invalid SMTP host
       .blur();
-    cy.findByLabelText("SMTP Port").type("25").blur();
+    cy.findByLabelText("SMTP Port").type(SMTP_PORT).blur();
     cy.findByLabelText("SMTP Username").type("admin").blur();
     cy.findByLabelText("SMTP Password").type("admin").blur();
     cy.findByLabelText("From Address").type("mailer@metabase.test").blur();

--- a/frontend/test/metabase/scenarios/permissions/sandboxes.cy.spec.js
+++ b/frontend/test/metabase/scenarios/permissions/sandboxes.cy.spec.js
@@ -14,6 +14,7 @@ import {
   visitQuestion,
   visitDashboard,
   startNewQuestion,
+  sendEmailAndAssert,
 } from "__support__/e2e/helpers";
 
 import { USER_GROUPS, SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
@@ -983,8 +984,6 @@ describeEE("formatting > sandboxes", () => {
       "sandboxed user should receive sandboxed dashboard subscription",
       { tags: "@external" },
       () => {
-        cy.intercept("POST", "/api/pulse/test").as("emailSent");
-
         setupSMTP();
 
         cy.sandboxTable({
@@ -1000,12 +999,10 @@ describeEE("formatting > sandboxes", () => {
         cy.findByText("Email it").click();
         cy.findByPlaceholderText("Enter user names or email addresses").click();
         cy.findByText("User 1").click();
-        cy.findByText("Send email now").click();
-        cy.wait("@emailSent");
-        cy.request("GET", "http://localhost:80/email").then(({ body }) => {
-          expect(body[0].html).to.include("Orders in a dashboard");
-          expect(body[0].html).to.include("37.65");
-          expect(body[0].html).not.to.include("148.23"); // Order for user with ID 3
+        sendEmailAndAssert(email => {
+          expect(email.html).to.include("Orders in a dashboard");
+          expect(email.html).to.include("37.65");
+          expect(email.html).not.to.include("148.23"); // Order for user with ID 3
         });
       },
     );

--- a/frontend/test/metabase/scenarios/sharing/reproductions/18009-nodata-creates-subscription-receives-error.cy.spec.js
+++ b/frontend/test/metabase/scenarios/sharing/reproductions/18009-nodata-creates-subscription-receives-error.cy.spec.js
@@ -3,7 +3,7 @@ import {
   popover,
   setupSMTP,
   visitDashboard,
-  clickSend,
+  sendEmailAndAssert,
 } from "__support__/e2e/helpers";
 
 describe.skip("issue 18009", { tags: "@external" }, () => {
@@ -31,14 +31,12 @@ describe.skip("issue 18009", { tags: "@external" }, () => {
     // Click anywhere to close the popover that covers the "Send email now" button
     cy.findByText("To:").click();
 
-    clickSend();
-
-    cy.request("GET", "http://localhost:80/email").then(({ body }) => {
-      expect(body[0].html).not.to.include(
+    sendEmailAndAssert(email => {
+      expect(email.html).not.to.include(
         "An error occurred while displaying this card.",
       );
 
-      expect(body[0].html).to.include("37.65");
+      expect(email.html).to.include("37.65");
     });
   });
 });

--- a/frontend/test/metabase/scenarios/sharing/reproductions/18344-subscription-shows-original-question-name.cy.spec.js
+++ b/frontend/test/metabase/scenarios/sharing/reproductions/18344-subscription-shows-original-question-name.cy.spec.js
@@ -4,7 +4,7 @@ import {
   saveDashboard,
   setupSMTP,
   visitDashboard,
-  clickSend,
+  sendEmailAndAssert,
 } from "__support__/e2e/helpers";
 
 import { USERS } from "__support__/e2e/cypress_data";
@@ -49,10 +49,8 @@ describe("issue 18344", { tags: "@external" }, () => {
     // Click this just to close the popover that is blocking the "Send email now" button
     cy.findByText(`To:`).click();
 
-    clickSend();
-
-    cy.request("GET", "http://localhost:80/email").then(({ body }) => {
-      expect(body[0].html).to.include("OrdersFoo");
+    sendEmailAndAssert(email => {
+      expect(email.html).to.include("OrdersFoo");
     });
   });
 });

--- a/frontend/test/metabase/scenarios/sharing/reproductions/18352-subscription-int64-value-card.cy.spec.js
+++ b/frontend/test/metabase/scenarios/sharing/reproductions/18352-subscription-int64-value-card.cy.spec.js
@@ -3,7 +3,7 @@ import {
   setupSMTP,
   visitQuestion,
   visitDashboard,
-  clickSend,
+  sendEmailAndAssert,
 } from "__support__/e2e/helpers";
 import { USERS } from "__support__/e2e/cypress_data";
 
@@ -44,17 +44,13 @@ describe("issue 18352", { tags: "@external" }, () => {
     // Click this just to close the popover that is blocking the "Send email now" button
     cy.findByText(`To:`).click();
 
-    clickSend();
+    sendEmailAndAssert(({ html }) => {
+      expect(html).not.to.include(
+        "An error occurred while displaying this card.",
+      );
 
-    cy.request("GET", "http://localhost:80/email").then(
-      ({ body: [{ html }] }) => {
-        expect(html).not.to.include(
-          "An error occurred while displaying this card.",
-        );
-
-        expect(html).to.include("foo");
-        expect(html).to.include("bar");
-      },
-    );
+      expect(html).to.include("foo");
+      expect(html).to.include("bar");
+    });
   });
 });

--- a/frontend/test/metabase/scenarios/sharing/reproductions/21559-subscription-bar-sent-as-scalar.cy.spec.js
+++ b/frontend/test/metabase/scenarios/sharing/reproductions/21559-subscription-bar-sent-as-scalar.cy.spec.js
@@ -4,6 +4,7 @@ import {
   editDashboard,
   saveDashboard,
   setupSMTP,
+  sendEmailAndAssert,
 } from "__support__/e2e/helpers";
 
 import { USERS } from "__support__/e2e/cypress_data";
@@ -33,7 +34,6 @@ const q2Details = {
 
 describe("issue 21559", { tags: "@external" }, () => {
   beforeEach(() => {
-    cy.intercept("POST", "/api/pulse/test").as("emailSent");
     restore();
     cy.signInAsAdmin();
 
@@ -70,11 +70,9 @@ describe("issue 21559", { tags: "@external" }, () => {
       .type(`${admin.first_name} ${admin.last_name}{enter}`)
       .blur(); // blur is needed to close the popover
 
-    cy.findByText("Send email now").click();
-    cy.wait("@emailSent");
-    cy.request("GET", "http://localhost:80/email").then(({ body }) => {
-      expect(body[0].html).to.include("img"); // Bar chart is sent as img (inline attachment)
-      expect(body[0].html).not.to.include("80.52"); // Scalar displays its value in HTML
+    sendEmailAndAssert(email => {
+      expect(email.html).to.include("img"); // Bar chart is sent as img (inline attachment)
+      expect(email.html).not.to.include("80.52"); // Scalar displays its value in HTML
     });
   });
 });

--- a/frontend/test/metabase/scenarios/sharing/subscriptions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/sharing/subscriptions.cy.spec.js
@@ -7,7 +7,7 @@ import {
   mockSlackConfigured,
   isOSS,
   visitDashboard,
-  clickSend,
+  sendEmailAndAssert,
 } from "__support__/e2e/helpers";
 import { USERS } from "__support__/e2e/cypress_data";
 
@@ -216,12 +216,11 @@ describe("scenarios > dashboard > subscriptions", () => {
       });
       // Click anywhere outside to close the popover
       cy.findByText("15705D").click();
-      clickSend();
-      cy.request("GET", "http://localhost:80/email").then(({ body }) => {
-        expect(body[0].html).not.to.include(
+      sendEmailAndAssert(email => {
+        expect(email.html).not.to.include(
           "An error occurred while displaying this card.",
         );
-        expect(body[0].html).to.include("2,738");
+        expect(email.html).to.include("2,738");
       });
     });
 
@@ -239,9 +238,8 @@ describe("scenarios > dashboard > subscriptions", () => {
       assignRecipient();
       // Click outside popover to close it and at the same time check that the text card content is shown as expected
       cy.findByText(TEXT_CARD).click();
-      clickSend();
-      cy.request("GET", "http://localhost:80/email").then(({ body }) => {
-        expect(body[0].html).to.include(TEXT_CARD);
+      sendEmailAndAssert(email => {
+        expect(email.html).to.include(TEXT_CARD);
       });
     });
   });


### PR DESCRIPTION
For unknown reason, we've been using really old `maildev` Docker image 1.1.0
Version 2.0.5 is the newest one and there shouldn't be any reason why we can't use that one.

My apologies to the reviewers for a rather large PR. I could've broken it up in two pieces maybe.

### What does this PR accomplish?
- updates the `maildev` version from 1.10 to 2.0.5
- updates port mappings we use in yaml workflows and in E2E tests
- as a necessity, it also adds a new helper function to make it easier to update code in the future
- resolves https://github.com/metabase/metabase/issues/20722