### PR TITLE
Add action URL to public sharing admin settings

### DIFF
--- a/frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing/PublicLinksListing.jsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/PublicLinksListing/PublicLinksListing.jsx
@@ -162,6 +162,7 @@ export const PublicLinksActionListing = connect(mapStateToProps)(
         load={ActionsApi.listPublic}
         revoke={ActionsApi.deletePublicLink}
         type={t`Public Action Listing`}
+        getUrl={action => Urls.action({ id: action.model_id }, action.id)}
         getPublicUrl={({ public_uuid }) =>
           Urls.publicAction(siteUrl, public_uuid)
         }

--- a/frontend/test/__support__/e2e/helpers/e2e-action-helpers.js
+++ b/frontend/test/__support__/e2e/helpers/e2e-action-helpers.js
@@ -7,3 +7,11 @@ export function enableActionsForDB(dbId = SAMPLE_DB_ID) {
     },
   });
 }
+
+/**
+ *
+ * @param {import("metabase/entities/actions/actions").CreateQueryActionParams} actionDetails
+ */
+export function createAction(actionDetails) {
+  return cy.request("POST", "/api/action", actionDetails);
+}

--- a/frontend/test/metabase/scenarios/admin/settings/public-sharing.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/public-sharing.cy.spec.js
@@ -1,8 +1,62 @@
-import { restore, modal, enableActionsForDB } from "__support__/e2e/helpers";
-import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
+import {
+  restore,
+  modal,
+  enableActionsForDB,
+  createAction,
+} from "__support__/e2e/helpers";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
+import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
 
 const { ORDERS_ID } = SAMPLE_DATABASE;
+
+const DEFAULT_ACTION_DETAILS = {
+  database_id: SAMPLE_DB_ID,
+  dataset_query: {
+    database: SAMPLE_DB_ID,
+    native: {
+      query: "UPDATE orders SET quantity = 0 WHERE id = {{order_id}}",
+      "template-tags": {
+        order_id: {
+          "display-name": "Order ID",
+          id: "fake-uuid",
+          name: "order_id",
+          type: "text",
+        },
+      },
+    },
+    type: "native",
+  },
+  name: "Reset order quantity",
+  description: "Set order quantity to 0",
+  type: "query",
+  parameters: [
+    {
+      id: "fake-uuid",
+      hasVariableTemplateTagTarget: true,
+      name: "Order ID",
+      slug: "order_id",
+      type: "string/=",
+      target: ["variable", ["template-tag", "fake-uuid"]],
+    },
+  ],
+  visualization_settings: {
+    fields: {
+      "fake-uuid": {
+        id: "fake-uuid",
+        fieldType: "string",
+        inputType: "string",
+        hidden: false,
+        order: 999,
+        required: true,
+        name: "",
+        title: "",
+        placeholder: "",
+        description: "",
+      },
+    },
+    type: "button",
+  },
+};
 
 describe("scenarios > admin > settings > public sharing", () => {
   beforeEach(() => {
@@ -142,6 +196,7 @@ describe("scenarios > admin > settings > public sharing", () => {
 
     cy.get("@modelId").then(modelId => {
       createAction({
+        ...DEFAULT_ACTION_DETAILS,
         name: expectedActionName,
         model_id: modelId,
       }).then(({ body }) => {
@@ -192,62 +247,3 @@ describe("scenarios > admin > settings > public sharing", () => {
     );
   });
 });
-
-/**
- *
- * @param {import("metabase/entities/actions/actions").CreateQueryActionParams} actionDetails
- */
-function createAction(actionDetails) {
-  const defaultActionDetails = {
-    database_id: SAMPLE_DB_ID,
-    dataset_query: {
-      database: SAMPLE_DB_ID,
-      native: {
-        query: "UPDATE orders SET quantity = 0 WHERE id = {{order_id}}",
-        "template-tags": {
-          order_id: {
-            "display-name": "Order ID",
-            id: "fake-uuid",
-            name: "order_id",
-            type: "text",
-          },
-        },
-      },
-      type: "native",
-    },
-    name: "Reset order quantity",
-    description: "Set order quantity to 0",
-    type: "query",
-    parameters: [
-      {
-        id: "fake-uuid",
-        hasVariableTemplateTagTarget: true,
-        name: "Order ID",
-        slug: "order_id",
-        type: "string/=",
-        target: ["variable", ["template-tag", "fake-uuid"]],
-      },
-    ],
-    visualization_settings: {
-      fields: {
-        "fake-uuid": {
-          id: "fake-uuid",
-          fieldType: "string",
-          inputType: "string",
-          hidden: false,
-          order: 999,
-          required: true,
-          name: "",
-          title: "",
-          placeholder: "",
-          description: "",
-        },
-      },
-      type: "button",
-    },
-  };
-  return cy.request("POST", "/api/action", {
-    ...defaultActionDetails,
-    ...actionDetails,
-  });
-}

--- a/frontend/test/metabase/scenarios/admin/settings/public-sharing.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/settings/public-sharing.cy.spec.js
@@ -170,7 +170,17 @@ describe("scenarios > admin > settings > public sharing", () => {
       cy.visit("/admin/settings/public-sharing");
     });
 
-    cy.findByText(expectedActionName).should("not.have.attr", "href");
+    cy.then(function () {
+      cy.findByText(expectedActionName).click();
+      cy.url().should(
+        "eq",
+        `${location.origin}/model/${this.modelId}/detail/actions/${this.actionId}`,
+      );
+      cy.findByRole("dialog").within(() => {
+        cy.findByText(expectedActionName).should("be.visible");
+      });
+      cy.visit("/admin/settings/public-sharing");
+    });
 
     cy.button("Revoke link").click();
     modal().within(() => {


### PR DESCRIPTION
- Epic: https://github.com/metabase/metabase/issues/27626
- Integration PR: https://github.com/metabase/metabase/pull/28300

### Note
This is a work that's removed from https://github.com/metabase/metabase/pull/27675 since https://github.com/metabase/metabase/pull/28300 isn't merged to `master` yet.

This branch includes a merge commit from `master`, so if the [upstream PR](https://github.com/metabase/metabase/pull/28300) merge `master` into itself, I'll need to rebase this PR accordingly.

### Description

Add links to action in public sharing admin settings `/admin/settings/public-sharing

### How to verify

Follow the test steps from https://github.com/metabase/metabase/pull/27675

### Demo

<img src="https://user-images.githubusercontent.com/1937582/217960509-8e574b20-a712-49e2-9226-26314801383a.png" />

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/28312)
<!-- Reviewable:end -->
