### PR TITLE
GH 28304 and GH 28311

### DIFF
--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedSimple.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedSimple.tsx
@@ -62,6 +62,10 @@ export const ChartSettingOrderedSimple = ({
   paddingLeft,
   hideOnDisabled = false,
 }: ChartSettingOrderedSimpleProps) => {
+  const processedItems = hideOnDisabled
+    ? orderedItems.filter(item => item.enabled)
+    : orderedItems;
+
   const toggleDisplay = (selectedItem: SortableItem) => {
     const index = orderedItems.findIndex(item => item.key === selectedItem.key);
     onChange(updateIn(orderedItems, [index, "enabled"], enabled => !enabled));
@@ -108,9 +112,9 @@ export const ChartSettingOrderedSimple = ({
         </ExtraButton>
       )}
 
-      {orderedItems.length > 0 ? (
+      {processedItems.length > 0 ? (
         <ChartSettingOrderedItems
-          items={orderedItems}
+          items={processedItems}
           getItemName={getItemTitle}
           onRemove={hasOnEnable ? toggleDisplay : undefined}
           onEnable={hasOnEnable ? toggleDisplay : undefined}

--- a/frontend/test/__support__/e2e/helpers/e2e-ui-elements-helpers.js
+++ b/frontend/test/__support__/e2e/helpers/e2e-ui-elements-helpers.js
@@ -22,6 +22,10 @@ export function rightSidebar() {
   return cy.findAllByTestId("sidebar-right");
 }
 
+export function leftSidebar() {
+  return cy.findAllByTestId("sidebar-left");
+}
+
 export function navigationSidebar() {
   return cy.get("#root aside").first();
 }
@@ -94,4 +98,12 @@ export const moveColumnDown = (column, distance) => {
     .trigger("mousemove", 5, 5, { force: true })
     .trigger("mousemove", 0, distance * 50, { force: true })
     .trigger("mouseup", 0, distance * 50, { force: true });
+};
+
+export const moveColumnUp = (column, distance) => {
+  column
+    .trigger("mousedown", 0, 0, { force: true })
+    .trigger("mousemove", 5, -5, { force: true })
+    .trigger("mousemove", 0, distance * -50, { force: true })
+    .trigger("mouseup", 0, distance * -50, { force: true });
 };

--- a/frontend/test/metabase/scenarios/question/settings.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/settings.cy.spec.js
@@ -149,7 +149,7 @@ describe("scenarios > question > settings", () => {
       // This click doesn't do anything, but simply allows the array to be updated (test gives false positive without this step)
       cy.get("body").click("bottomRight");
 
-      findColumnAtIndex("Products → Category", 6);
+      findColumnAtIndex("Products → Category", 5);
 
       // We need to do some additional checks. Please see:
       // https://github.com/metabase/metabase/pull/21338#pullrequestreview-928807257

--- a/frontend/test/metabase/scenarios/visualizations/reproductions/28304-table-columns-unknown.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/reproductions/28304-table-columns-unknown.cy.spec.js
@@ -1,0 +1,73 @@
+import {
+  restore,
+  visitQuestionAdhoc,
+  leftSidebar,
+  getDraggableElements,
+} from "__support__/e2e/helpers";
+import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
+import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
+
+const { ORDERS_ID, ORDERS } = SAMPLE_DATABASE;
+
+const questionDetails = {
+  name: "28304",
+  dataset_query: {
+    type: "query",
+    query: {
+      "source-table": ORDERS_ID,
+      aggregation: [["count"]],
+      breakout: [
+        ["field", ORDERS.CREATED_AT, { "temporal-unit": "month" }],
+        ["field", ORDERS.USER_ID, null],
+        ["field", ORDERS.PRODUCT_ID, null],
+      ],
+    },
+    database: SAMPLE_DB_ID,
+  },
+  display: "table",
+  visualization_settings: {
+    "table.columns": [
+      {
+        fieldRef: ["field", ORDERS.ID, null],
+        enabled: true,
+      },
+      {
+        fieldRef: ["field", ORDERS.USER_ID, null],
+        enabled: true,
+      },
+      {
+        fieldRef: ["field", ORDERS.PRODUCT_ID, null],
+        enabled: true,
+      },
+      {
+        fieldRef: ["field", ORDERS.SUBTOTAL, null],
+        enabled: true,
+      },
+      {
+        fieldRef: ["field", ORDERS.TAX, null],
+        enabled: true,
+      },
+      {
+        fieldRef: ["field", ORDERS.DISCOUNT, null],
+        enabled: true,
+      },
+    ],
+  },
+};
+
+describe("issue 25250", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+
+    visitQuestionAdhoc(questionDetails);
+  });
+
+  it("pivot table should show standalone values when collapsed to the sub-level grouping (metabase#25250)", () => {
+    cy.findByText("Count by 3 breakouts").should("be.visible");
+
+    cy.findByTestId("viz-settings-button").click();
+    leftSidebar().should("not.contain", "[Unknown]");
+    getDraggableElements().should("have.length", 2);
+  });
+});

--- a/frontend/test/metabase/scenarios/visualizations/reproductions/28311-sorting-table-columns.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/reproductions/28311-sorting-table-columns.cy.spec.js
@@ -1,0 +1,67 @@
+import {
+  restore,
+  visitQuestionAdhoc,
+  getDraggableElements,
+  moveColumnUp,
+} from "__support__/e2e/helpers";
+import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
+import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
+
+const { ORDERS_ID, ORDERS } = SAMPLE_DATABASE;
+
+const questionDetails = {
+  name: "28311",
+  dataset_query: {
+    type: "query",
+    query: {
+      "source-table": ORDERS_ID,
+    },
+    database: SAMPLE_DB_ID,
+  },
+  display: "table",
+  visualization_settings: {
+    "table.columns": [
+      {
+        fieldRef: ["field", ORDERS.ID, null],
+        enabled: true,
+      },
+      {
+        fieldRef: ["field", ORDERS.USER_ID, null],
+        enabled: true,
+      },
+      {
+        fieldRef: ["field", ORDERS.PRODUCT_ID, null],
+        enabled: true,
+      },
+      {
+        fieldRef: ["field", ORDERS.SUBTOTAL, null],
+        enabled: false,
+      },
+      {
+        fieldRef: ["field", ORDERS.TAX, null],
+        enabled: false,
+      },
+      {
+        fieldRef: ["field", ORDERS.DISCOUNT, null],
+        enabled: false,
+      },
+    ],
+  },
+};
+
+describe("issue 25250", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+
+    visitQuestionAdhoc(questionDetails);
+  });
+
+  it("pivot table should show standalone values when collapsed to the sub-level grouping (metabase#25250)", () => {
+    cy.findByText("Product ID").should("be.visible");
+
+    cy.findByTestId("viz-settings-button").click();
+    moveColumnUp(getDraggableElements().contains("Product ID"), 2);
+    getDraggableElements().eq(0).should("contain", "Product ID");
+  });
+});

--- a/frontend/test/metabase/visualizations/components/settings/ChartSettingOrderedSimple.unit.spec.js
+++ b/frontend/test/metabase/visualizations/components/settings/ChartSettingOrderedSimple.unit.spec.js
@@ -27,6 +27,6 @@ describe("chartsettingorderedsimple", () => {
 
     expect(screen.getByText("foo")).toBeVisible();
     expect(screen.getByText("bar")).toBeVisible();
-    expect(screen.queryByText("another")).not.toBeVisible();
+    expect(screen.queryByText("another")).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Fixes #28304 , #28311 

Changing `table.columns` to be driven by `getValue` so that we can do some processing on the list of column settings before sending it to the widget.

WIP