### PR TITLE
Emit joins in SQL in the same order they are specified in MBQL

### DIFF
--- a/frontend/test/metabase/scenarios/joins/reproductions/15342-mysql-correct-joins-order.cy.spec.js
+++ b/frontend/test/metabase/scenarios/joins/reproductions/15342-mysql-correct-joins-order.cy.spec.js
@@ -7,7 +7,7 @@ import {
 
 const MYSQL_DB_NAME = "QA MySQL8";
 
-describe.skip("issue 15342", { tags: "@external" }, () => {
+describe("issue 15342", { tags: "@external" }, () => {
   beforeEach(() => {
     restore("mysql-8");
     cy.signInAsAdmin();

--- a/test/metabase/query_processor_test/explicit_joins_test.clj
+++ b/test/metabase/query_processor_test/explicit_joins_test.clj
@@ -4,6 +4,7 @@
    [clojure.string :as str]
    [clojure.test :refer :all]
    [metabase.driver :as driver]
+   [metabase.driver.sql.query-processor :as sql.qp]
    [metabase.driver.sql.query-processor-test-util :as sql.qp-test-util]
    [metabase.models :refer [Card]]
    [metabase.query-processor :as qp]
@@ -868,3 +869,33 @@
                       ["Doohickey" 3976 2 2 "Small Marble Shoes"]]
                      (mt/formatted-rows [str int int int str]
                        (qp/process-query query)))))))))))
+
+(deftest ^:parallel join-order-test
+  (testing "Joins should be emitted in the same order as they were specified in MBQL (#15342)"
+    (mt/test-drivers (mt/normal-drivers-with-feature :left-join :inner-join)
+      ;; For SQL drivers, this is only fixed for drivers using Honey SQL 2. So skip the test for ones still using Honey
+      ;; SQL 1. Honey SQL 1 support is slated for removal in Metabase 0.49.0.
+      (when (or (not (isa? driver/hierarchy driver/*driver* :sql))
+                (= (sql.qp/honey-sql-version driver/*driver*) 2))
+        (mt/dataset sample-dataset
+          (doseq [[first-join-strategy second-join-strategy] [[:inner-join :left-join]
+                                                              [:left-join :inner-join]]
+                  :let [query (mt/mbql-query people
+                                {:joins    [{:source-table $$orders
+                                             :alias        "Orders"
+                                             :condition    [:= $id &Orders.orders.user_id]
+                                             :strategy     first-join-strategy}
+                                            {:source-table $$products
+                                             :alias        "Products"
+                                             :condition    [:= &Orders.orders.product_id &Products.products.id]
+                                             :strategy     second-join-strategy}]
+                                 :fields   [$id &Orders.orders.id &Products.products.id]
+                                 :order-by [[:asc $id]
+                                            [:asc &Orders.orders.id]
+                                            [:asc &Products.products.id]]
+                                 :limit    1})]]
+            (testing (format "%s before %s" first-join-strategy second-join-strategy)
+              (mt/with-native-query-testing-context query
+                (is (= [[1 1 14]]
+                       (mt/formatted-rows [int int int]
+                         (qp/process-query query))))))))))))


### PR DESCRIPTION
Fixes P1 #15342 

Half the reason we started the port-to-Honey SQL 2 project (#28009) was to be able to fix this bug.

Note that for SQL drivers, this is only fixed for drivers that are using Honey SQL 2 (at the time of this writing, `:postgres`, `:redshift`, and `:mysql`; a PR for `:vertica` is currently waiting for review and one for `:h2` should be finished shortly). We should finish porting the rest of our drivers to Honey SQL 2 within the week. This test will automatically run against drivers once they switch to Honey SQL 2. 

I would prefer to get this ASAP, because the test will catch any errors that might pop up as we port to Honey SQL 2, if a driver is doing something custom when compiling `:joins`; it will make the rest of the porting process smoother

This is not something that can be backported because it relies on the switch to Honey SQL 2 which we are not going to backport.