### PR TITLE
Deprecate `unprepare/unprepare` [WIP]

### DIFF
--- a/src/metabase/driver/sql.clj
+++ b/src/metabase/driver/sql.clj
@@ -59,6 +59,13 @@
     (merge {:params nil
             :query  (unprepare/unprepare driver (cons sql params))})))
 
+(defmethod driver/mbql->native-spliced :sql
+  [driver query]
+  (if (= (sql.qp/honey-sql-version driver) 2)
+    (binding [sql.qp/*compile-with-inline-parameters* true]
+      (driver/mbql->native driver query))
+    ((get-method driver/mbql->native-spliced :metabase.driver/driver) driver query)))
+
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                              Convenience Imports                                               |

--- a/src/metabase/query_processor.clj
+++ b/src/metabase/query_processor.clj
@@ -323,10 +323,8 @@
   REPL; [[splice-params-in-response/splice-params-in-response]] middleware handles similar functionality for queries
   that are actually executed.)"
   [query]
-  ;; We need to preprocess the query first to get a valid database in case we're dealing with a nested query whose DB
-  ;; ID is the virtual DB identifier
-  (let [driver (driver.u/database->driver (:database (preprocess query)))]
-    (driver/splice-parameters-into-native-query driver (compile query))))
+  (binding [mbql-to-native/*compile-with-inline-parameters* true]
+    (compile query)))
 
 
 ;;; +----------------------------------------------------------------------------------------------------------------+

--- a/src/metabase/query_processor/middleware/splice_params_in_response.clj
+++ b/src/metabase/query_processor/middleware/splice_params_in_response.clj
@@ -28,6 +28,7 @@
   This feature is ultimately powered by the `metabase.driver/splice-parameters-into-native-query` method. For native
   queries without `:params` (which will be all of them for drivers that don't support the equivalent of prepared
   statement parameters, like Druid), this middleware does nothing."
+  {:deprecated "0.46.0"}
   [_query rff]
   (fn splice-params-in-response-rff* [metadata]
     (rff (splice-params-in-metadata metadata))))

--- a/test/metabase/driver/sql_jdbc_test.clj
+++ b/test/metabase/driver/sql_jdbc_test.clj
@@ -123,6 +123,9 @@
 
 ;;; --------------------------------- Tests for splice-parameters-into-native-query ----------------------------------
 
+;;; TODO -- these are not `:sql-jdbc` things at all, these belong in [[metabase.driver.sql-test]] or something like
+;;; that.
+
 (deftest ^:parallel splice-parameters-native-test
   (mt/test-drivers (sql-jdbc.tu/sql-jdbc-drivers)
     (testing (str "test splicing a single param\n"
@@ -130,17 +133,19 @@
                   "We can cross that bridge when we get there.)")
       (is (=  {:query  "SELECT * FROM birds WHERE name = 'Reggae'"
                :params nil}
-              (driver/splice-parameters-into-native-query driver/*driver*
-                {:query  "SELECT * FROM birds WHERE name = ?"
-                 :params ["Reggae"]}))))
+              (driver/splice-parameters-into-native-query
+               driver/*driver*
+               {:query  "SELECT * FROM birds WHERE name = ?"
+                :params ["Reggae"]}))))
 
     (testing "test splicing multiple params"
       (is (=  {:query
                "SELECT * FROM birds WHERE name = 'Reggae' AND type = 'toucan' AND favorite_food = 'blueberries';",
                :params nil}
-              (driver/splice-parameters-into-native-query driver/*driver*
-                {:query  "SELECT * FROM birds WHERE name = ? AND type = ? AND favorite_food = ?;"
-                 :params ["Reggae" "toucan" "blueberries"]}))))
+              (driver/splice-parameters-into-native-query
+               driver/*driver*
+               {:query  "SELECT * FROM birds WHERE name = ? AND type = ? AND favorite_food = ?;"
+                :params ["Reggae" "toucan" "blueberries"]}))))
 
     (testing (str "I think we're supposed to ignore multiple question narks, only single ones should get substituted "
                   "(`??` becomes `?` in JDBC, which is used for Postgres as a \")key exists?\" JSON operator amongst "
@@ -148,15 +153,17 @@
       (is (= {:query
               "SELECT * FROM birds WHERE favorite_food ?? bird_info AND name = 'Reggae'",
               :params nil}
-             (driver/splice-parameters-into-native-query driver/*driver*
-               {:query  "SELECT * FROM birds WHERE favorite_food ?? bird_info AND name = ?"
-                :params ["Reggae"]}))))
+             (driver/splice-parameters-into-native-query
+              driver/*driver*
+              {:query  "SELECT * FROM birds WHERE favorite_food ?? bird_info AND name = ?"
+               :params ["Reggae"]}))))
 
     (testing "splicing with no params should no-op"
       (is (= {:query "SELECT * FROM birds;", :params []}
-             (driver/splice-parameters-into-native-query driver/*driver*
-               {:query  "SELECT * FROM birds;"
-                :params []}))))))
+             (driver/splice-parameters-into-native-query
+              driver/*driver*
+              {:query  "SELECT * FROM birds;"
+               :params []}))))))
 
 (defn- spliced-count-of [table filter-clause]
   (let [query        {:database (mt/id)

--- a/test/metabase/query_processor_test/filter_test.clj
+++ b/test/metabase/query_processor_test/filter_test.clj
@@ -486,7 +486,7 @@
       (is (= 7
              (count-with-filter-clause checkins [:= !week.date "2015-06-21T07:00:00.000000000-00:00"]))))))
 
-(deftest string-escape-test
+(deftest ^:parallel string-escape-test
   ;; test `:sql` drivers that support native parameters
   (mt/test-drivers (mt/normal-drivers-with-feature :native-parameters)
     (testing "Make sure single quotes in parameters are escaped properly for the current driver"


### PR DESCRIPTION
Not needed any more since we can emit queries with inlined parameters directly with Honey SQL 2.

Resolves #28169

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/28319)
<!-- Reviewable:end -->
