### PR TITLE
[CI] Improve path-filtering logic for `frontend_sources`

### DIFF
--- a/.github/file-paths.yaml
+++ b/.github/file-paths.yaml
@@ -13,7 +13,6 @@ shared_specs: &shared_specs
 
 frontend_sources: &frontend_sources
   - *shared_sources
-  - "frontend/**"
   - "enterprise/frontend/**"
   - "frontend/!(test)/**"
   - "yarn.lock"


### PR DESCRIPTION
I've changed only E2E support file (`frontend/test/__support__/e2e/helpers/e2e-email-helpers.js`) in #28323, but the test suite ran all FE, BE and E2E tests, nevertheless.

Let's take a look at [the output](https://github.com/metabase/metabase/actions/runs/4183104335/jobs/7247036334):
```
Run dorny/paths-filter@v2.11.1
Fetching list of changed files for PR#28323 from Github API
  Invoking listFiles(pull_number: 2[8](https://github.com/metabase/metabase/actions/runs/4183104335/jobs/7247036334#step:3:9)323, per_page: 100)
  Received 1 items
  [modified] frontend/test/__support__/e2e/helpers/e2e-email-helpers.js
Detected 1 changed files
Results:
Filter default = false
Filter ci = false
Filter shared_sources = false
Filter shared_specs = false
Filter frontend_sources = true
Filter frontend_specs = false
Filter frontend_all = true
Filter backend_presto_kerberos = false
Filter backend_sources = false
Filter backend_specs = false
Filter backend_all = true
Filter sources = true
Filter e2e_specs = true
Filter e2e_all = true
Filter snowplow = false
Filter documentation = false
Filter yaml = false
Changes output set to ["frontend_sources","frontend_all","backend_all","sources","e2e_specs","e2e_all"]
```

It triggered `frontend_sources`, which in turn triggered `frontend_all` and `backend_all`
