### PR TITLE
Repro #28193: Cannot use custom column with models

### DIFF
--- a/frontend/test/metabase/scenarios/models/reproductions/28193-cannot-use-custom-column.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/reproductions/28193-cannot-use-custom-column.cy.spec.js
@@ -1,0 +1,48 @@
+import { restore, enterCustomColumnDetails } from "__support__/e2e/helpers";
+
+const ccName = "CTax";
+
+describe.skip("issue 28193", () => {
+  beforeEach(() => {
+    cy.intercept("POST", "/api/dataset").as("dataset");
+
+    restore();
+    cy.signInAsAdmin();
+
+    // Turn the question into a model
+    cy.request("PUT", "/api/card/1", { dataset: true });
+  });
+
+  it("should be able to use custom column in a model query (metabase#28193)", () => {
+    // Go directly to model's query definition
+    cy.visit("/model/1/query");
+
+    cy.findByText("Custom column").click();
+    enterCustomColumnDetails({
+      formula: "[Tax]",
+      name: ccName,
+    });
+    cy.button("Done").click();
+
+    cy.get(".RunButton").click();
+    cy.wait("@dataset");
+
+    cy.button("Save changes").click();
+    cy.location("pathname").should("not.include", "/query");
+
+    assertOnColumns();
+
+    cy.reload();
+    cy.wait("@dataset");
+
+    assertOnColumns();
+  });
+});
+
+function assertOnColumns() {
+  cy.findAllByText("2.07").should("be.visible").and("have.length", 2);
+  cy.findAllByTestId("header-cell")
+    .should("be.visible")
+    .last()
+    .should("have.text", ccName);
+}


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #28193 

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/models/reproductions/28193-cannot-use-custom-column.cy.spec.js`
- Unskip repro
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/219043472-17f4b792-4246-4502-acaa-9afff589422c.png)

