### PR TITLE
Reorganize ActionCreator tests and cover implicit actions

### DIFF
--- a/frontend/src/metabase-types/api/mocks/actions.ts
+++ b/frontend/src/metabase-types/api/mocks/actions.ts
@@ -49,10 +49,10 @@ export const createMockQueryAction = ({
 export const createMockImplicitQueryAction = ({
   creator = createMockUserInfo(),
   ...opts
-}: Partial<WritebackImplicitQueryAction>): WritebackImplicitQueryAction => ({
+}: Partial<WritebackImplicitQueryAction> = {}): WritebackImplicitQueryAction => ({
   id: 1,
   kind: "row/create",
-  name: "",
+  name: "Implicit Query Action",
   description: "",
   model_id: 1,
   parameters: [],

--- a/frontend/src/metabase/actions/containers/ActionCreator/ActionCreator.unit.spec.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/ActionCreator.unit.spec.tsx
@@ -85,14 +85,6 @@ async function setup({
   );
 }
 
-async function setupEditing({
-  action = createMockQueryAction(),
-  ...opts
-}: SetupOpts = {}) {
-  await setup({ action, ...opts });
-  return { action };
-}
-
 const SITE_URL = "http://localhost:3000";
 
 describe("ActionCreator", () => {
@@ -141,7 +133,8 @@ describe("ActionCreator", () => {
 
   describe("editing action", () => {
     it("renders correctly", async () => {
-      const { action } = await setupEditing();
+      const action = createMockQueryAction();
+      await setup({ action });
 
       expect(screen.getByText(action.name)).toBeInTheDocument();
       expect(screen.queryByText(/New action/i)).not.toBeInTheDocument();
@@ -160,10 +153,11 @@ describe("ActionCreator", () => {
     });
 
     it("renders parameters", async () => {
-      const action = createMockQueryAction({
-        parameters: [createMockActionParameter({ name: "FooBar" })],
+      await setup({
+        action: createMockQueryAction({
+          parameters: [createMockActionParameter({ name: "FooBar" })],
+        }),
       });
-      await setupEditing({ action });
 
       expect(screen.getByText("FooBar")).toBeInTheDocument();
     });
@@ -172,7 +166,7 @@ describe("ActionCreator", () => {
       const action = createMockQueryAction({
         parameters: [createMockActionParameter({ name: "FooBar" })],
       });
-      await setupEditing({ action, canWrite: false });
+      await setup({ action, canWrite: false });
 
       expect(screen.getByDisplayValue(action.name)).toBeDisabled();
       expect(queryIcon("grabber2")).not.toBeInTheDocument();
@@ -190,7 +184,7 @@ describe("ActionCreator", () => {
       const action = createMockQueryAction({
         parameters: [createMockActionParameter({ name: "FooBar" })],
       });
-      await setupEditing({ action, hasActionsEnabled: false });
+      await setup({ action, hasActionsEnabled: false });
 
       expect(screen.getByDisplayValue(action.name)).toBeDisabled();
       expect(queryIcon("grabber2")).not.toBeInTheDocument();
@@ -206,9 +200,11 @@ describe("ActionCreator", () => {
 
     describe("admin users and has public sharing enabled", () => {
       const mockUuid = "mock-uuid";
+      const action = createMockQueryAction();
 
       it("should show action settings button", async () => {
-        await setupEditing({
+        await setup({
+          action,
           isAdmin: true,
           isPublicSharingEnabled: true,
         });
@@ -219,7 +215,8 @@ describe("ActionCreator", () => {
       });
 
       it("should be able to enable action public sharing", async () => {
-        await setupEditing({
+        await setup({
+          action,
           isAdmin: true,
           isPublicSharingEnabled: true,
         });
@@ -248,7 +245,7 @@ describe("ActionCreator", () => {
       });
 
       it("should be able to disable action public sharing", async () => {
-        await setupEditing({
+        await setup({
           action: createMockQueryAction({ public_uuid: mockUuid }),
           isAdmin: true,
           isPublicSharingEnabled: true,
@@ -281,7 +278,7 @@ describe("ActionCreator", () => {
       });
 
       it("should be able to set success message", async () => {
-        await setupEditing();
+        await setup({ action });
 
         userEvent.click(
           screen.getByRole("button", { name: "Action settings" }),
@@ -298,8 +295,11 @@ describe("ActionCreator", () => {
     });
 
     describe("no permission to see public sharing", () => {
+      const action = createMockQueryAction();
+
       it("should not show sharing settings when user is admin but public sharing is disabled", async () => {
-        await setupEditing({
+        await setup({
+          action,
           isAdmin: true,
           isPublicSharingEnabled: false,
         });
@@ -315,7 +315,8 @@ describe("ActionCreator", () => {
       });
 
       it("should not show sharing settings when user is not admin but public sharing is enabled", async () => {
-        await setupEditing({
+        await setup({
+          action,
           isPublicSharingEnabled: true,
         });
 

--- a/frontend/src/metabase/actions/containers/ActionCreator/tests/ActionCreator-Common.unit.spec.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/tests/ActionCreator-Common.unit.spec.tsx
@@ -1,7 +1,7 @@
 import nock from "nock";
-import userEvent, { specialChars } from "@testing-library/user-event";
+import userEvent from "@testing-library/user-event";
 
-import { screen, waitFor } from "__support__/ui";
+import { screen } from "__support__/ui";
 
 import {
   createMockImplicitQueryAction,
@@ -29,7 +29,7 @@ describe("ActionCreator > Common", () => {
   ])(`%s actions`, (_, getAction) => {
     describe("with write permissions", () => {
       it("should show action settings button", async () => {
-        await setup({ action: getAction(), canEdit: true });
+        await setup({ action: getAction(), canWrite: true });
         const button = screen.getByRole("button", { name: "Action settings" });
         expect(button).toBeInTheDocument();
       });
@@ -41,26 +41,25 @@ describe("ActionCreator > Common", () => {
           screen.getByRole("button", { name: "Action settings" }),
         );
 
-        const messageBox = screen.getByRole("textbox", {
-          name: "Success message",
-        });
-        expect(messageBox).toHaveValue("Thanks for your submission.");
-
-        await waitFor(() => expect(messageBox).toBeEnabled());
-        userEvent.type(messageBox, `${specialChars.selectAll}Thanks!`);
-        expect(messageBox).toHaveValue("Thanks!");
+        userEvent.type(
+          screen.getByRole("textbox", { name: "Success message" }),
+          `Thanks!`,
+        );
+        expect(
+          screen.getByRole("textbox", { name: "Success message" }),
+        ).toHaveValue("Thanks!");
       });
     });
 
     describe("with read-only permissions", () => {
       it("should show action settings button", async () => {
-        await setup({ action: getAction(), canEdit: false });
+        await setup({ action: getAction(), canWrite: false });
         const button = screen.getByRole("button", { name: "Action settings" });
         expect(button).toBeInTheDocument();
       });
 
       it("should not allow editing success message", async () => {
-        await setup({ canEdit: false });
+        await setup({ canWrite: false });
 
         userEvent.click(
           screen.getByRole("button", { name: "Action settings" }),

--- a/frontend/src/metabase/actions/containers/ActionCreator/tests/ActionCreator-Common.unit.spec.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/tests/ActionCreator-Common.unit.spec.tsx
@@ -1,0 +1,77 @@
+import nock from "nock";
+import userEvent, { specialChars } from "@testing-library/user-event";
+
+import { screen, waitFor } from "__support__/ui";
+
+import {
+  createMockImplicitQueryAction,
+  createMockQueryAction,
+} from "metabase-types/api/mocks";
+
+import { setup as baseSetup, SetupOpts } from "./common";
+
+async function setup({
+  action = createMockImplicitQueryAction(),
+  ...opts
+}: SetupOpts = {}) {
+  await baseSetup({ action, ...opts });
+  return { action };
+}
+
+describe("ActionCreator > Common", () => {
+  afterEach(() => {
+    nock.cleanAll();
+  });
+
+  describe.each([
+    ["query", createMockQueryAction],
+    ["implicit", createMockImplicitQueryAction],
+  ])(`%s actions`, (_, getAction) => {
+    describe("with write permissions", () => {
+      it("should show action settings button", async () => {
+        await setup({ action: getAction(), canEdit: true });
+        const button = screen.getByRole("button", { name: "Action settings" });
+        expect(button).toBeInTheDocument();
+      });
+
+      it("should be able to set success message", async () => {
+        await setup();
+
+        userEvent.click(
+          screen.getByRole("button", { name: "Action settings" }),
+        );
+
+        const messageBox = screen.getByRole("textbox", {
+          name: "Success message",
+        });
+        expect(messageBox).toHaveValue("Thanks for your submission.");
+
+        await waitFor(() => expect(messageBox).toBeEnabled());
+        userEvent.type(messageBox, `${specialChars.selectAll}Thanks!`);
+        expect(messageBox).toHaveValue("Thanks!");
+      });
+    });
+
+    describe("with read-only permissions", () => {
+      it("should show action settings button", async () => {
+        await setup({ action: getAction(), canEdit: false });
+        const button = screen.getByRole("button", { name: "Action settings" });
+        expect(button).toBeInTheDocument();
+      });
+
+      it("should not allow editing success message", async () => {
+        await setup({ canEdit: false });
+
+        userEvent.click(
+          screen.getByRole("button", { name: "Action settings" }),
+        );
+
+        expect(
+          screen.getByRole("textbox", {
+            name: "Success message",
+          }),
+        ).toBeDisabled();
+      });
+    });
+  });
+});

--- a/frontend/src/metabase/actions/containers/ActionCreator/tests/ActionCreator-ImplicitActions.unit.spec.ts
+++ b/frontend/src/metabase/actions/containers/ActionCreator/tests/ActionCreator-ImplicitActions.unit.spec.ts
@@ -1,5 +1,5 @@
 import nock from "nock";
-import userEvent, { specialChars } from "@testing-library/user-event";
+import userEvent from "@testing-library/user-event";
 
 import { screen, waitFor, queryIcon } from "__support__/ui";
 
@@ -73,17 +73,6 @@ describe("ActionCreator > Implicit Actions", () => {
   describe("admin users and has public sharing enabled", () => {
     const mockUuid = "mock-uuid";
 
-    it("should show action settings button", async () => {
-      await setup({
-        isAdmin: true,
-        isPublicSharingEnabled: true,
-      });
-
-      expect(
-        screen.getByRole("button", { name: "Action settings" }),
-      ).toBeInTheDocument();
-    });
-
     it("should be able to enable action public sharing", async () => {
       await setup({
         isAdmin: true,
@@ -144,21 +133,6 @@ describe("ActionCreator > Implicit Actions", () => {
       expect(
         screen.queryByRole("textbox", { name: "Public action link URL" }),
       ).not.toBeInTheDocument();
-    });
-
-    it("should be able to set success message", async () => {
-      await setup();
-
-      userEvent.click(screen.getByRole("button", { name: "Action settings" }));
-
-      const messageBox = screen.getByRole("textbox", {
-        name: "Success message",
-      });
-      expect(messageBox).toHaveValue("Thanks for your submission.");
-
-      await waitFor(() => expect(messageBox).toBeEnabled());
-      userEvent.type(messageBox, `${specialChars.selectAll}Thanks!`);
-      expect(messageBox).toHaveValue("Thanks!");
     });
   });
 

--- a/frontend/src/metabase/actions/containers/ActionCreator/tests/ActionCreator-ImplicitActions.unit.spec.ts
+++ b/frontend/src/metabase/actions/containers/ActionCreator/tests/ActionCreator-ImplicitActions.unit.spec.ts
@@ -1,0 +1,194 @@
+import nock from "nock";
+import userEvent, { specialChars } from "@testing-library/user-event";
+
+import { screen, waitFor, queryIcon } from "__support__/ui";
+
+import {
+  createMockActionParameter,
+  createMockImplicitQueryAction,
+} from "metabase-types/api/mocks";
+
+import { setup as baseSetup, SITE_URL, SetupOpts } from "./common";
+
+async function setup({
+  action = createMockImplicitQueryAction(),
+  ...opts
+}: SetupOpts = {}) {
+  await baseSetup({ action, ...opts });
+  return { action };
+}
+
+describe("ActionCreator > Implicit Actions", () => {
+  afterEach(() => {
+    nock.cleanAll();
+  });
+
+  it("renders correctly", async () => {
+    const { action } = await setup();
+
+    expect(screen.getByText(action.name)).toBeInTheDocument();
+    expect(screen.getByText("Auto tracking schema")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument();
+
+    expect(screen.queryByText(/New action/i)).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("mock-native-query-editor"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders parameters", async () => {
+    await setup({
+      action: createMockImplicitQueryAction({
+        parameters: [createMockActionParameter({ name: "FooBar" })],
+      }),
+    });
+
+    expect(screen.getByText("FooBar")).toBeInTheDocument();
+  });
+
+  test.each([
+    ["write permissions", true],
+    ["read-only permissions", false],
+  ])("doesn't let to change the action with %s", async (_, canEdit) => {
+    const { action } = await setup({
+      action: createMockImplicitQueryAction({
+        parameters: [createMockActionParameter({ name: "FooBar" })],
+      }),
+      canEdit,
+    });
+
+    expect(screen.getByDisplayValue(action.name)).toBeDisabled();
+
+    expect(screen.queryByLabelText("Field settings")).not.toBeInTheDocument();
+    expect(queryIcon("grabber2")).not.toBeInTheDocument();
+
+    expect(
+      screen.queryByRole("button", { name: "Update" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Create" }),
+    ).not.toBeInTheDocument();
+  });
+
+  describe("admin users and has public sharing enabled", () => {
+    const mockUuid = "mock-uuid";
+
+    it("should show action settings button", async () => {
+      await setup({
+        isAdmin: true,
+        isPublicSharingEnabled: true,
+      });
+
+      expect(
+        screen.getByRole("button", { name: "Action settings" }),
+      ).toBeInTheDocument();
+    });
+
+    it("should be able to enable action public sharing", async () => {
+      await setup({
+        isAdmin: true,
+        isPublicSharingEnabled: true,
+      });
+
+      screen.getByRole("button", { name: "Action settings" }).click();
+
+      expect(screen.getByText("Action settings")).toBeInTheDocument();
+      const makePublicToggle = screen.getByRole("switch", {
+        name: "Make public",
+      });
+      expect(makePublicToggle).not.toBeChecked();
+      expect(
+        screen.queryByRole("textbox", { name: "Public action link URL" }),
+      ).not.toBeInTheDocument();
+
+      screen.getByRole("switch", { name: "Make public" }).click();
+
+      await waitFor(() => {
+        expect(makePublicToggle).toBeChecked();
+      });
+
+      const expectedPublicLinkUrl = `${SITE_URL}/public/action/${mockUuid}`;
+      expect(
+        screen.getByRole("textbox", { name: "Public action link URL" }),
+      ).toHaveValue(expectedPublicLinkUrl);
+    });
+
+    it("should be able to disable action public sharing", async () => {
+      await setup({
+        action: createMockImplicitQueryAction({ public_uuid: mockUuid }),
+        isAdmin: true,
+        isPublicSharingEnabled: true,
+      });
+      screen.getByRole("button", { name: "Action settings" }).click();
+
+      expect(screen.getByText("Action settings")).toBeInTheDocument();
+      const makePublicToggle = screen.getByRole("switch", {
+        name: "Make public",
+      });
+      expect(makePublicToggle).toBeChecked();
+      const expectedPublicLinkUrl = `${SITE_URL}/public/action/${mockUuid}`;
+      expect(
+        screen.getByRole("textbox", { name: "Public action link URL" }),
+      ).toHaveValue(expectedPublicLinkUrl);
+
+      makePublicToggle.click();
+      expect(
+        screen.getByRole("heading", { name: "Disable this public link?" }),
+      ).toBeInTheDocument();
+      screen.getByRole("button", { name: "Yes" }).click();
+
+      await waitFor(() => {
+        expect(makePublicToggle).not.toBeChecked();
+      });
+
+      expect(
+        screen.queryByRole("textbox", { name: "Public action link URL" }),
+      ).not.toBeInTheDocument();
+    });
+
+    it("should be able to set success message", async () => {
+      await setup();
+
+      userEvent.click(screen.getByRole("button", { name: "Action settings" }));
+
+      const messageBox = screen.getByRole("textbox", {
+        name: "Success message",
+      });
+      expect(messageBox).toHaveValue("Thanks for your submission.");
+
+      await waitFor(() => expect(messageBox).toBeEnabled());
+      userEvent.type(messageBox, `${specialChars.selectAll}Thanks!`);
+      expect(messageBox).toHaveValue("Thanks!");
+    });
+  });
+
+  describe("no permission to see public sharing", () => {
+    it("should not show sharing settings when user is admin but public sharing is disabled", async () => {
+      await setup({
+        isAdmin: true,
+        isPublicSharingEnabled: false,
+      });
+
+      userEvent.click(screen.getByRole("button", { name: "Action settings" }));
+      expect(
+        screen.queryByRole("switch", {
+          name: "Make public",
+        }),
+      ).not.toBeInTheDocument();
+    });
+
+    it("should not show sharing settings when user is not admin but public sharing is enabled", async () => {
+      await setup({
+        isAdmin: false,
+        isPublicSharingEnabled: true,
+      });
+
+      userEvent.click(screen.getByRole("button", { name: "Action settings" }));
+      expect(
+        screen.queryByRole("switch", {
+          name: "Make public",
+        }),
+      ).not.toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/metabase/actions/containers/ActionCreator/tests/ActionCreator-ImplicitActions.unit.spec.ts
+++ b/frontend/src/metabase/actions/containers/ActionCreator/tests/ActionCreator-ImplicitActions.unit.spec.ts
@@ -1,14 +1,13 @@
 import nock from "nock";
-import userEvent from "@testing-library/user-event";
 
-import { screen, waitFor, queryIcon } from "__support__/ui";
+import { screen, queryIcon } from "__support__/ui";
 
 import {
   createMockActionParameter,
   createMockImplicitQueryAction,
 } from "metabase-types/api/mocks";
 
-import { setup as baseSetup, SITE_URL, SetupOpts } from "./common";
+import { setup as baseSetup, SetupOpts } from "./common";
 
 async function setup({
   action = createMockImplicitQueryAction(),
@@ -68,101 +67,5 @@ describe("ActionCreator > Implicit Actions", () => {
     expect(
       screen.queryByRole("button", { name: "Create" }),
     ).not.toBeInTheDocument();
-  });
-
-  describe("admin users and has public sharing enabled", () => {
-    const mockUuid = "mock-uuid";
-
-    it("should be able to enable action public sharing", async () => {
-      await setup({
-        isAdmin: true,
-        isPublicSharingEnabled: true,
-      });
-
-      screen.getByRole("button", { name: "Action settings" }).click();
-
-      expect(screen.getByText("Action settings")).toBeInTheDocument();
-      const makePublicToggle = screen.getByRole("switch", {
-        name: "Make public",
-      });
-      expect(makePublicToggle).not.toBeChecked();
-      expect(
-        screen.queryByRole("textbox", { name: "Public action link URL" }),
-      ).not.toBeInTheDocument();
-
-      screen.getByRole("switch", { name: "Make public" }).click();
-
-      await waitFor(() => {
-        expect(makePublicToggle).toBeChecked();
-      });
-
-      const expectedPublicLinkUrl = `${SITE_URL}/public/action/${mockUuid}`;
-      expect(
-        screen.getByRole("textbox", { name: "Public action link URL" }),
-      ).toHaveValue(expectedPublicLinkUrl);
-    });
-
-    it("should be able to disable action public sharing", async () => {
-      await setup({
-        action: createMockImplicitQueryAction({ public_uuid: mockUuid }),
-        isAdmin: true,
-        isPublicSharingEnabled: true,
-      });
-      screen.getByRole("button", { name: "Action settings" }).click();
-
-      expect(screen.getByText("Action settings")).toBeInTheDocument();
-      const makePublicToggle = screen.getByRole("switch", {
-        name: "Make public",
-      });
-      expect(makePublicToggle).toBeChecked();
-      const expectedPublicLinkUrl = `${SITE_URL}/public/action/${mockUuid}`;
-      expect(
-        screen.getByRole("textbox", { name: "Public action link URL" }),
-      ).toHaveValue(expectedPublicLinkUrl);
-
-      makePublicToggle.click();
-      expect(
-        screen.getByRole("heading", { name: "Disable this public link?" }),
-      ).toBeInTheDocument();
-      screen.getByRole("button", { name: "Yes" }).click();
-
-      await waitFor(() => {
-        expect(makePublicToggle).not.toBeChecked();
-      });
-
-      expect(
-        screen.queryByRole("textbox", { name: "Public action link URL" }),
-      ).not.toBeInTheDocument();
-    });
-  });
-
-  describe("no permission to see public sharing", () => {
-    it("should not show sharing settings when user is admin but public sharing is disabled", async () => {
-      await setup({
-        isAdmin: true,
-        isPublicSharingEnabled: false,
-      });
-
-      userEvent.click(screen.getByRole("button", { name: "Action settings" }));
-      expect(
-        screen.queryByRole("switch", {
-          name: "Make public",
-        }),
-      ).not.toBeInTheDocument();
-    });
-
-    it("should not show sharing settings when user is not admin but public sharing is enabled", async () => {
-      await setup({
-        isAdmin: false,
-        isPublicSharingEnabled: true,
-      });
-
-      userEvent.click(screen.getByRole("button", { name: "Action settings" }));
-      expect(
-        screen.queryByRole("switch", {
-          name: "Make public",
-        }),
-      ).not.toBeInTheDocument();
-    });
   });
 });

--- a/frontend/src/metabase/actions/containers/ActionCreator/tests/ActionCreator-ImplicitActions.unit.spec.ts
+++ b/frontend/src/metabase/actions/containers/ActionCreator/tests/ActionCreator-ImplicitActions.unit.spec.ts
@@ -45,15 +45,24 @@ describe("ActionCreator > Implicit Actions", () => {
     expect(screen.getByText("FooBar")).toBeInTheDocument();
   });
 
-  test.each([
-    ["write permissions", true],
-    ["read-only permissions", false],
-  ])("doesn't let to change the action with %s", async (_, canEdit) => {
+  it("allows only form settings changes", async () => {
     const { action } = await setup({
       action: createMockImplicitQueryAction({
         parameters: [createMockActionParameter({ name: "FooBar" })],
       }),
-      canEdit,
+    });
+
+    expect(screen.getByDisplayValue(action.name)).toBeDisabled();
+    expect(screen.queryByLabelText("Field settings")).not.toBeInTheDocument();
+    expect(queryIcon("grabber2")).not.toBeInTheDocument();
+  });
+
+  it("blocks editing if the user doesn't have write permissions for the collection", async () => {
+    const { action } = await setup({
+      action: createMockImplicitQueryAction({
+        parameters: [createMockActionParameter({ name: "FooBar" })],
+      }),
+      canWrite: false,
     });
 
     expect(screen.getByDisplayValue(action.name)).toBeDisabled();

--- a/frontend/src/metabase/actions/containers/ActionCreator/tests/ActionCreator-QueryActions.unit.spec.ts
+++ b/frontend/src/metabase/actions/containers/ActionCreator/tests/ActionCreator-QueryActions.unit.spec.ts
@@ -1,93 +1,16 @@
-import React from "react";
 import nock from "nock";
 import userEvent from "@testing-library/user-event";
 
-import {
-  renderWithProviders,
-  screen,
-  waitFor,
-  waitForElementToBeRemoved,
-  getIcon,
-  queryIcon,
-} from "__support__/ui";
-import {
-  setupCardsEndpoints,
-  setupDatabasesEndpoints,
-} from "__support__/server-mocks";
+import { screen, waitFor, getIcon, queryIcon } from "__support__/ui";
 
-import { WritebackAction } from "metabase-types/api";
 import {
   createMockActionParameter,
-  createMockCard,
-  createMockDatabase,
   createMockQueryAction,
-  createMockUser,
 } from "metabase-types/api/mocks";
-import {
-  createMockSettingsState,
-  createMockState,
-} from "metabase-types/store/mocks";
 
-import ActionCreator from "./ActionCreator";
+import { setup, SITE_URL } from "./common";
 
-type SetupOpts = {
-  action?: WritebackAction;
-  canWrite?: boolean;
-  hasActionsEnabled?: boolean;
-  isAdmin?: boolean;
-  isPublicSharingEnabled?: boolean;
-};
-
-async function setup({
-  action,
-  canWrite = true,
-  hasActionsEnabled = true,
-  isAdmin = false,
-  isPublicSharingEnabled = false,
-}: SetupOpts = {}) {
-  const scope = nock(location.origin);
-  const model = createMockCard({
-    dataset: true,
-    can_write: canWrite,
-  });
-  const database = createMockDatabase({
-    settings: { "database-enable-actions": hasActionsEnabled },
-  });
-
-  setupDatabasesEndpoints(scope, [database]);
-  setupCardsEndpoints(scope, [model]);
-
-  if (action) {
-    scope.get(`/api/action/${action.id}`).reply(200, action);
-    scope.delete(`/api/action/${action.id}/public_link`).reply(204);
-    scope
-      .post(`/api/action/${action.id}/public_link`)
-      .reply(200, { uuid: "mock-uuid" });
-  }
-
-  renderWithProviders(
-    <ActionCreator actionId={action?.id} modelId={model.id} />,
-    {
-      storeInitialState: createMockState({
-        currentUser: createMockUser({
-          is_superuser: isAdmin,
-        }),
-        settings: createMockSettingsState({
-          "enable-public-sharing": isPublicSharingEnabled,
-          "site-url": SITE_URL,
-        }),
-      }),
-    },
-  );
-
-  await waitForElementToBeRemoved(() =>
-    screen.queryByTestId("loading-spinner"),
-  );
-}
-
-const SITE_URL = "http://localhost:3000";
-
-describe("ActionCreator", () => {
+describe("ActionCreator > Query Actions", () => {
   afterEach(() => {
     nock.cleanAll();
   });

--- a/frontend/src/metabase/actions/containers/ActionCreator/tests/ActionCreator-QueryActions.unit.spec.ts
+++ b/frontend/src/metabase/actions/containers/ActionCreator/tests/ActionCreator-QueryActions.unit.spec.ts
@@ -1,14 +1,13 @@
 import nock from "nock";
-import userEvent from "@testing-library/user-event";
 
-import { screen, waitFor, getIcon, queryIcon } from "__support__/ui";
+import { screen, getIcon, queryIcon } from "__support__/ui";
 
 import {
   createMockActionParameter,
   createMockQueryAction,
 } from "metabase-types/api/mocks";
 
-import { setup, SITE_URL } from "./common";
+import { setup } from "./common";
 
 describe("ActionCreator > Query Actions", () => {
   afterEach(() => {
@@ -119,127 +118,6 @@ describe("ActionCreator > Query Actions", () => {
       screen.getByLabelText("Action settings").click();
 
       expect(screen.getByLabelText("Success message")).toBeDisabled();
-    });
-
-    describe("admin users and has public sharing enabled", () => {
-      const mockUuid = "mock-uuid";
-      const action = createMockQueryAction();
-
-      it("should be able to enable action public sharing", async () => {
-        await setup({
-          action,
-          isAdmin: true,
-          isPublicSharingEnabled: true,
-        });
-
-        screen.getByRole("button", { name: "Action settings" }).click();
-
-        expect(screen.getByText("Action settings")).toBeInTheDocument();
-        const makePublicToggle = screen.getByRole("switch", {
-          name: "Make public",
-        });
-        expect(makePublicToggle).not.toBeChecked();
-        expect(
-          screen.queryByRole("textbox", { name: "Public action link URL" }),
-        ).not.toBeInTheDocument();
-
-        screen.getByRole("switch", { name: "Make public" }).click();
-
-        await waitFor(() => {
-          expect(makePublicToggle).toBeChecked();
-        });
-
-        const expectedPublicLinkUrl = `${SITE_URL}/public/action/${mockUuid}`;
-        expect(
-          screen.getByRole("textbox", { name: "Public action link URL" }),
-        ).toHaveValue(expectedPublicLinkUrl);
-      });
-
-      it("should be able to disable action public sharing", async () => {
-        await setup({
-          action: createMockQueryAction({ public_uuid: mockUuid }),
-          isAdmin: true,
-          isPublicSharingEnabled: true,
-        });
-        screen.getByRole("button", { name: "Action settings" }).click();
-
-        expect(screen.getByText("Action settings")).toBeInTheDocument();
-        const makePublicToggle = screen.getByRole("switch", {
-          name: "Make public",
-        });
-        expect(makePublicToggle).toBeChecked();
-        const expectedPublicLinkUrl = `${SITE_URL}/public/action/${mockUuid}`;
-        expect(
-          screen.getByRole("textbox", { name: "Public action link URL" }),
-        ).toHaveValue(expectedPublicLinkUrl);
-
-        makePublicToggle.click();
-        expect(
-          screen.getByRole("heading", { name: "Disable this public link?" }),
-        ).toBeInTheDocument();
-        screen.getByRole("button", { name: "Yes" }).click();
-
-        await waitFor(() => {
-          expect(makePublicToggle).not.toBeChecked();
-        });
-
-        expect(
-          screen.queryByRole("textbox", { name: "Public action link URL" }),
-        ).not.toBeInTheDocument();
-      });
-
-      it("should be able to set success message", async () => {
-        await setup({ action });
-
-        userEvent.click(
-          screen.getByRole("button", { name: "Action settings" }),
-        );
-
-        userEvent.type(
-          screen.getByRole("textbox", { name: "Success message" }),
-          `Thanks!`,
-        );
-        expect(
-          screen.getByRole("textbox", { name: "Success message" }),
-        ).toHaveValue("Thanks!");
-      });
-    });
-
-    describe("no permission to see public sharing", () => {
-      const action = createMockQueryAction();
-
-      it("should not show sharing settings when user is admin but public sharing is disabled", async () => {
-        await setup({
-          action,
-          isAdmin: true,
-          isPublicSharingEnabled: false,
-        });
-
-        userEvent.click(
-          screen.getByRole("button", { name: "Action settings" }),
-        );
-        expect(
-          screen.queryByRole("switch", {
-            name: "Make public",
-          }),
-        ).not.toBeInTheDocument();
-      });
-
-      it("should not show sharing settings when user is not admin but public sharing is enabled", async () => {
-        await setup({
-          action,
-          isPublicSharingEnabled: true,
-        });
-
-        userEvent.click(
-          screen.getByRole("button", { name: "Action settings" }),
-        );
-        expect(
-          screen.queryByRole("switch", {
-            name: "Make public",
-          }),
-        ).not.toBeInTheDocument();
-      });
     });
   });
 });

--- a/frontend/src/metabase/actions/containers/ActionCreator/tests/ActionCreator-QueryActions.unit.spec.ts
+++ b/frontend/src/metabase/actions/containers/ActionCreator/tests/ActionCreator-QueryActions.unit.spec.ts
@@ -47,7 +47,7 @@ describe("ActionCreator > Query Actions", () => {
     });
 
     it("should show action settings button", async () => {
-      await setup({ isAdmin: true, isPublicSharingEnabled: true });
+      await setup();
       expect(
         screen.getByRole("button", { name: "Action settings" }),
       ).toBeInTheDocument();
@@ -124,18 +124,6 @@ describe("ActionCreator > Query Actions", () => {
     describe("admin users and has public sharing enabled", () => {
       const mockUuid = "mock-uuid";
       const action = createMockQueryAction();
-
-      it("should show action settings button", async () => {
-        await setup({
-          action,
-          isAdmin: true,
-          isPublicSharingEnabled: true,
-        });
-
-        expect(
-          screen.getByRole("button", { name: "Action settings" }),
-        ).toBeInTheDocument();
-      });
 
       it("should be able to enable action public sharing", async () => {
         await setup({

--- a/frontend/src/metabase/actions/containers/ActionCreator/tests/ActionCreator-Sharing.unit.spec.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/tests/ActionCreator-Sharing.unit.spec.tsx
@@ -1,0 +1,146 @@
+import nock from "nock";
+import userEvent from "@testing-library/user-event";
+
+import { screen, waitFor } from "__support__/ui";
+
+import {
+  createMockImplicitQueryAction,
+  createMockQueryAction,
+} from "metabase-types/api/mocks";
+
+import { setup as baseSetup, SITE_URL, SetupOpts } from "./common";
+
+async function setup({
+  action = createMockImplicitQueryAction(),
+  ...opts
+}: SetupOpts = {}) {
+  await baseSetup({ action, ...opts });
+  return { action };
+}
+
+describe("ActionCreator > Sharing", () => {
+  afterEach(() => {
+    nock.cleanAll();
+  });
+
+  describe.each([
+    ["query", createMockQueryAction],
+    ["implicit", createMockImplicitQueryAction],
+  ])(`%s actions`, (_, getAction) => {
+    describe("admin users and has public sharing enabled", () => {
+      const mockUuid = "mock-uuid";
+      const privateAction = getAction();
+      const publicAction = getAction({ public_uuid: mockUuid });
+
+      it("should show action settings button", async () => {
+        await setup({
+          action: privateAction,
+          isAdmin: true,
+          isPublicSharingEnabled: true,
+        });
+
+        expect(
+          screen.getByRole("button", { name: "Action settings" }),
+        ).toBeInTheDocument();
+      });
+
+      it("should be able to enable action public sharing", async () => {
+        await setup({
+          action: privateAction,
+          isAdmin: true,
+          isPublicSharingEnabled: true,
+        });
+
+        screen.getByRole("button", { name: "Action settings" }).click();
+
+        expect(screen.getByText("Action settings")).toBeInTheDocument();
+        const makePublicToggle = screen.getByRole("switch", {
+          name: "Make public",
+        });
+        expect(makePublicToggle).not.toBeChecked();
+        expect(
+          screen.queryByRole("textbox", { name: "Public action link URL" }),
+        ).not.toBeInTheDocument();
+
+        screen.getByRole("switch", { name: "Make public" }).click();
+
+        await waitFor(() => {
+          expect(makePublicToggle).toBeChecked();
+        });
+
+        const expectedPublicLinkUrl = `${SITE_URL}/public/action/${mockUuid}`;
+        expect(
+          screen.getByRole("textbox", { name: "Public action link URL" }),
+        ).toHaveValue(expectedPublicLinkUrl);
+      });
+
+      it("should be able to disable action public sharing", async () => {
+        await setup({
+          action: publicAction,
+          isAdmin: true,
+          isPublicSharingEnabled: true,
+        });
+        screen.getByRole("button", { name: "Action settings" }).click();
+
+        expect(screen.getByText("Action settings")).toBeInTheDocument();
+        const makePublicToggle = screen.getByRole("switch", {
+          name: "Make public",
+        });
+        expect(makePublicToggle).toBeChecked();
+        const expectedPublicLinkUrl = `${SITE_URL}/public/action/${mockUuid}`;
+        expect(
+          screen.getByRole("textbox", { name: "Public action link URL" }),
+        ).toHaveValue(expectedPublicLinkUrl);
+
+        makePublicToggle.click();
+        expect(
+          screen.getByRole("heading", { name: "Disable this public link?" }),
+        ).toBeInTheDocument();
+        screen.getByRole("button", { name: "Yes" }).click();
+
+        await waitFor(() => {
+          expect(makePublicToggle).not.toBeChecked();
+        });
+
+        expect(
+          screen.queryByRole("textbox", { name: "Public action link URL" }),
+        ).not.toBeInTheDocument();
+      });
+    });
+
+    describe("no permission to see public sharing", () => {
+      it("should not show sharing settings when user is admin but public sharing is disabled", async () => {
+        await setup({
+          action: getAction(),
+          isAdmin: true,
+          isPublicSharingEnabled: false,
+        });
+
+        userEvent.click(
+          screen.getByRole("button", { name: "Action settings" }),
+        );
+        expect(
+          screen.queryByRole("switch", {
+            name: "Make public",
+          }),
+        ).not.toBeInTheDocument();
+      });
+
+      it("should not show sharing settings when user is not admin but public sharing is enabled", async () => {
+        await setup({
+          action: getAction(),
+          isPublicSharingEnabled: true,
+        });
+
+        userEvent.click(
+          screen.getByRole("button", { name: "Action settings" }),
+        );
+        expect(
+          screen.queryByRole("switch", {
+            name: "Make public",
+          }),
+        ).not.toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/frontend/src/metabase/actions/containers/ActionCreator/tests/common.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/tests/common.tsx
@@ -1,0 +1,83 @@
+/* istanbul ignore file */
+import React from "react";
+import nock from "nock";
+
+import {
+  renderWithProviders,
+  screen,
+  waitForElementToBeRemoved,
+} from "__support__/ui";
+import {
+  setupCardsEndpoints,
+  setupDatabasesEndpoints,
+} from "__support__/server-mocks";
+
+import type { WritebackAction } from "metabase-types/api";
+import {
+  createMockCard,
+  createMockDatabase,
+  createMockUser,
+} from "metabase-types/api/mocks";
+import {
+  createMockSettingsState,
+  createMockState,
+} from "metabase-types/store/mocks";
+
+import ActionCreator from "../ActionCreator";
+
+export const SITE_URL = "http://localhost:3000";
+
+export type SetupOpts = {
+  action?: WritebackAction;
+  canWrite?: boolean;
+  hasActionsEnabled?: boolean;
+  isAdmin?: boolean;
+  isPublicSharingEnabled?: boolean;
+};
+
+export async function setup({
+  action,
+  canWrite = true,
+  hasActionsEnabled = true,
+  isAdmin = false,
+  isPublicSharingEnabled = false,
+}: SetupOpts = {}) {
+  const scope = nock(location.origin);
+  const model = createMockCard({
+    dataset: true,
+    can_write: canWrite,
+  });
+  const database = createMockDatabase({
+    settings: { "database-enable-actions": hasActionsEnabled },
+  });
+
+  setupDatabasesEndpoints(scope, [database]);
+  setupCardsEndpoints(scope, [model]);
+
+  if (action) {
+    scope.get(`/api/action/${action.id}`).reply(200, action);
+    scope.delete(`/api/action/${action.id}/public_link`).reply(204);
+    scope
+      .post(`/api/action/${action.id}/public_link`)
+      .reply(200, { uuid: "mock-uuid" });
+  }
+
+  renderWithProviders(
+    <ActionCreator actionId={action?.id} modelId={model.id} />,
+    {
+      storeInitialState: createMockState({
+        currentUser: createMockUser({
+          is_superuser: isAdmin,
+        }),
+        settings: createMockSettingsState({
+          "enable-public-sharing": isPublicSharingEnabled,
+          "site-url": SITE_URL,
+        }),
+      }),
+    },
+  );
+
+  await waitForElementToBeRemoved(() =>
+    screen.queryByTestId("loading-spinner"),
+  );
+}

--- a/frontend/src/metabase/actions/containers/ActionCreator/tests/utils.unit.spec.ts
+++ b/frontend/src/metabase/actions/containers/ActionCreator/tests/utils.unit.spec.ts
@@ -12,7 +12,7 @@ import {
   removeOrphanSettings,
   setParameterTypesFromFieldSettings,
   setTemplateTagTypesFromFieldSettings,
-} from "./utils";
+} from "../utils";
 
 const createQuestionWithTemplateTags = (tagType: TemplateTagType) =>
   getUnsavedNativeQuestion({

--- a/frontend/test/metabase/scenarios/models/model-actions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/model-actions.cy.spec.js
@@ -3,6 +3,7 @@ import {
   modal,
   popover,
   restore,
+  createAction,
 } from "__support__/e2e/helpers";
 
 import { createMockActionParameter } from "metabase-types/api/mocks";
@@ -129,7 +130,7 @@ describe("scenarios > models > actions", () => {
     });
 
     cy.get("@modelId").then(modelId => {
-      cy.request("POST", "/api/action", {
+      createAction({
         ...SAMPLE_QUERY_ACTION,
         model_id: modelId,
       });


### PR DESCRIPTION
Epic #27581, part of #28327

* breaks down `ActionCreator` tests into different files (common, implicit actions, query actions, sharing)
* runs common and sharing tests against both implicit and query actions
* adds test coverage to changes in #28327
* adds E2E test for changes in #28327

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/28332)
<!-- Reviewable:end -->
