### PR TITLE
Remove setting readOnly on H2 connections

### DIFF
--- a/src/metabase/driver/h2.clj
+++ b/src/metabase/driver/h2.clj
@@ -392,15 +392,9 @@
 
 (defmethod sql-jdbc.execute/connection-with-timezone :h2
   [driver database ^String _timezone-id]
-  ;; h2 doesn't support setting timezones, or changing the transaction level without admin perms, so we can skip those
-  ;; steps that are in the default impl
-  (let [conn (.getConnection (sql-jdbc.execute/datasource-with-diagnostic-info! driver database))]
-    (try
-      (doto conn
-        (.setReadOnly true))
-      (catch Throwable e
-        (.close conn)
-        (throw e)))))
+  ;; h2 doesn't support setting timezones, or setting the connection to read-only, or changing the transaction level
+  ;; without admin perms, so we can skip those steps that are in the default impl
+  (.getConnection (sql-jdbc.execute/datasource-with-diagnostic-info! driver database)))
 
 ;; de-CLOB any CLOB values that come back
 (defmethod sql-jdbc.execute/read-column-thunk :h2


### PR DESCRIPTION
`(.setReadOnly conn true)` on an H2 connection is a lie. It doesn't prevent writes. So this PR removes setting it on new connections.

For example, I can still delete the CHECKINS table from the test-data H2 database if `ACCESS_MODE_DATA=rws` is set on the connection string, despite calling `(.setReadOnly conn true)` on the connection.
```
;; After changing `ACCESS_MODE_DATA=r` to `ACCESS_MODE_DATA=rws`:
(require '[metabase.driver.sql-jdbc.execute :as sql-jdbc.execute])

(let [database (toucan.db/select-one 'Database :engine :h2 :name "test-data")
      conn (doto (.getConnection (sql-jdbc.execute/datasource-with-diagnostic-info! :h2 database))
                 (.setReadOnly true))
      stmt (sql-jdbc.execute/prepared-statement :h2 conn "DELETE CHECKINS;" [])]
  (.execute stmt))
```

What's more, `(do (.setReadOnly conn true) (.isReadOnly conn)` returns false.
```
(let [database (toucan.db/select-one 'Database :engine :h2 :name "test-data")
      conn (doto (.getConnection (sql-jdbc.execute/datasource-with-diagnostic-info! :h2 database))
                 (.setReadOnly true))]
  (.isReadOnly conn))
=> false
```

It seems like only `ACCESS_MODE_DATA=r` in the connection string sets readOnly to true.