### PR TITLE
Handle existing actions when database-enable-actions setting is disabled

### DIFF
--- a/frontend/src/metabase-lib/Question.ts
+++ b/frontend/src/metabase-lib/Question.ts
@@ -468,6 +468,12 @@ class QuestionInner {
     return this._card && this._card.can_write;
   }
 
+  canWriteActions(): boolean {
+    const database = this.database();
+    const hasActionsEnabled = database != null && database.hasActionsEnabled();
+    return this.canWrite() && hasActionsEnabled;
+  }
+
   canAutoRun(): boolean {
     const db = this.database();
     return (db && db.auto_run_queries) || false;

--- a/frontend/src/metabase-lib/metadata/Database.ts
+++ b/frontend/src/metabase-lib/metadata/Database.ts
@@ -2,6 +2,8 @@
 // @ts-nocheck
 import {
   Database as IDatabase,
+  DatabaseFeature,
+  DatabaseSettings,
   NativePermissions,
   StructuredQuery,
 } from "metabase-types/api";
@@ -31,6 +33,8 @@ class DatabaseInner extends Base {
   tables: Table[];
   schemas: Schema[];
   metadata: Metadata;
+  features: DatabaseFeature[];
+  settings?: DatabaseSettings;
   native_permissions: NativePermissions;
 
   // Only appears in  GET /api/database/:id
@@ -124,6 +128,14 @@ class DatabaseInner extends Base {
 
   supportsPersistence() {
     return this.hasFeature("persist-models");
+  }
+
+  supportsActions() {
+    return this.hasFeature("actions");
+  }
+
+  hasActionsEnabled() {
+    return Boolean(this.settings?.["database-enable-actions"]);
   }
 
   // QUESTIONS

--- a/frontend/src/metabase/actions/containers/ActionCreator/ActionCreator.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/ActionCreator.tsx
@@ -97,7 +97,6 @@ function resolveQuestion(
 function ActionCreator({
   action,
   model,
-  modelId,
   databaseId,
   metadata,
   onCreateAction,
@@ -138,7 +137,7 @@ function ActionCreator({
       setShowSaveModal(true);
     } else {
       const action = convertQuestionToAction(question, formSettings);
-      onUpdateAction({ ...action, model_id: modelId as number });
+      onUpdateAction({ ...action, model_id: model.id() });
       onClose?.();
     }
   };
@@ -196,7 +195,7 @@ function ActionCreator({
             initialValues={{
               name: question.displayName() ?? "",
               description: question.description(),
-              model_id: modelId,
+              model_id: model.id(),
             }}
             onCreate={handleCreate}
             onCancel={handleCloseNewActionModal}

--- a/frontend/src/metabase/actions/containers/ActionCreator/ActionCreator.unit.spec.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/ActionCreator.unit.spec.tsx
@@ -166,7 +166,7 @@ describe("ActionCreator", () => {
       expect(screen.getByText("FooBar")).toBeInTheDocument();
     });
 
-    it("blocks editing if a user doesn't have editing permissions", async () => {
+    it("blocks editing if the user doesn't have write permissions for the collection", async () => {
       const action = createMockQueryAction({
         parameters: [createMockActionParameter({ name: "FooBar" })],
       });
@@ -174,6 +174,29 @@ describe("ActionCreator", () => {
         can_write: false,
       });
       await setupEditing({ action, model, isAdmin: false });
+
+      expect(screen.getByDisplayValue(action.name)).toBeDisabled();
+      expect(queryIcon("grabber2")).not.toBeInTheDocument();
+      expect(screen.queryByLabelText("Field settings")).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: "Update" }),
+      ).not.toBeInTheDocument();
+
+      screen.getByLabelText("Action settings").click();
+
+      expect(screen.getByLabelText("Success message")).toBeDisabled();
+    });
+
+    it("blocks editing if actions are disabled for the database", async () => {
+      const action = createMockQueryAction({
+        parameters: [createMockActionParameter({ name: "FooBar" })],
+      });
+      const database = createMockDatabase({
+        settings: {
+          "database-enable-actions": false,
+        },
+      });
+      await setupEditing({ action, database, isAdmin: false });
 
       expect(screen.getByDisplayValue(action.name)).toBeDisabled();
       expect(queryIcon("grabber2")).not.toBeInTheDocument();

--- a/frontend/src/metabase/actions/containers/ActionCreator/ActionCreator.unit.spec.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/ActionCreator.unit.spec.tsx
@@ -14,11 +14,12 @@ import {
   setupCardsEndpoints,
   setupDatabasesEndpoints,
 } from "__support__/server-mocks";
-import { SAMPLE_DATABASE } from "__support__/sample_database_fixture";
 
+import { Card, Database, WritebackQueryAction } from "metabase-types/api";
 import {
   createMockActionParameter,
   createMockCard,
+  createMockDatabase,
   createMockQueryAction,
   createMockUser,
 } from "metabase-types/api/mocks";
@@ -27,42 +28,31 @@ import {
   createMockState,
 } from "metabase-types/store/mocks";
 
-import type { Card, WritebackQueryAction } from "metabase-types/api";
-import type Database from "metabase-lib/metadata/Database";
-import type Table from "metabase-lib/metadata/Table";
-
 import ActionCreator from "./ActionCreator";
-
-function getDatabaseObject(database: Database) {
-  return {
-    ...database.getPlainObject(),
-    tables: database.tables.map(getTableObject),
-  };
-}
-
-function getTableObject(table: Table) {
-  return {
-    ...table.getPlainObject(),
-    schema: table.schema_name,
-  };
-}
 
 type SetupOpts = {
   action?: WritebackQueryAction;
   model?: Card;
+  database?: Database;
   isAdmin?: boolean;
   isPublicSharingEnabled?: boolean;
 };
 
 async function setup({
   action,
-  model = createMockCard({ dataset: true, can_write: true }),
+  model = createMockCard({
+    dataset: true,
+    can_write: true,
+  }),
+  database = createMockDatabase({
+    settings: { "database-enable-actions": true },
+  }),
   isAdmin,
   isPublicSharingEnabled,
 }: SetupOpts = {}) {
   const scope = nock(location.origin);
 
-  setupDatabasesEndpoints(scope, [getDatabaseObject(SAMPLE_DATABASE)]);
+  setupDatabasesEndpoints(scope, [database]);
   setupCardsEndpoints(scope, [createMockCard(model)]);
 
   if (action) {
@@ -76,7 +66,6 @@ async function setup({
   renderWithProviders(
     <ActionCreator actionId={action?.id} modelId={model.id} />,
     {
-      withSampleDatabase: true,
       storeInitialState: createMockState({
         currentUser: createMockUser({
           is_superuser: isAdmin,
@@ -137,7 +126,7 @@ describe("ActionCreator", () => {
       getIcon("reference", "button").click();
 
       expect(screen.getByText("Data Reference")).toBeInTheDocument();
-      expect(screen.getByText(SAMPLE_DATABASE.name)).toBeInTheDocument();
+      expect(screen.getByText("Database")).toBeInTheDocument();
     });
 
     it("should show action settings button", async () => {

--- a/frontend/src/metabase/actions/utils.ts
+++ b/frontend/src/metabase/actions/utils.ts
@@ -18,9 +18,6 @@ import Field from "metabase-lib/metadata/Field";
 
 import type { FieldSettings as LocalFieldSettings } from "./types";
 
-export const checkDatabaseSupportsActions = (database: Database) =>
-  database.features.includes("actions");
-
 export const checkDatabaseActionsEnabled = (database: Database) =>
   !!database.settings?.["database-enable-actions"];
 

--- a/frontend/src/metabase/admin/databases/components/DatabaseEditApp/Sidebar/Sidebar.tsx
+++ b/frontend/src/metabase/admin/databases/components/DatabaseEditApp/Sidebar/Sidebar.tsx
@@ -7,10 +7,6 @@ import ConfirmContent from "metabase/components/ConfirmContent";
 import ModalWithTrigger from "metabase/components/ModalWithTrigger";
 
 import { isSyncCompleted } from "metabase/lib/syncing";
-import {
-  checkDatabaseSupportsActions,
-  checkDatabaseActionsEnabled,
-} from "metabase/actions/utils";
 import DeleteDatabaseModal from "metabase/admin/databases/components/DeleteDatabaseModel/DeleteDatabaseModal";
 
 import type { Database as IDatabase, DatabaseId } from "metabase-types/api";
@@ -55,8 +51,7 @@ const DatabaseEditAppSidebar = ({
 
   const isSynced = isSyncCompleted(database);
   const hasModelActionsSection =
-    isEditingDatabase &&
-    checkDatabaseSupportsActions(database.getPlainObject());
+    isEditingDatabase && database.supportsActions();
   const hasModelCachingSection =
     isModelPersistenceEnabled && database.supportsPersistence();
 
@@ -189,9 +184,7 @@ const DatabaseEditAppSidebar = ({
       {hasModelActionsSection && (
         <ModelActionsSidebarContent>
           <ModelActionsSection
-            hasModelActionsEnabled={checkDatabaseActionsEnabled(
-              database.getPlainObject(),
-            )}
+            hasModelActionsEnabled={database.hasActionsEnabled()}
             onToggleModelActionsEnabled={handleToggleModelActionsEnabled}
           />
         </ModelActionsSidebarContent>

--- a/frontend/src/metabase/models/components/ModelDetailPage/ModelActionDetails/ModelActionDetails.styled.tsx
+++ b/frontend/src/metabase/models/components/ModelDetailPage/ModelActionDetails/ModelActionDetails.styled.tsx
@@ -1,4 +1,5 @@
 import styled from "@emotion/styled";
+import Alert from "metabase/core/components/Alert";
 import EntityMenu from "metabase/components/EntityMenu";
 import { breakpointMaxMedium } from "metabase/styled-components/theme";
 
@@ -28,4 +29,8 @@ export const ActionList = styled.ul`
   ${breakpointMaxMedium} {
     width: 100%;
   }
+`;
+
+export const ActionAlert = styled(Alert)`
+  width: 70%;
 `;

--- a/frontend/src/metabase/models/components/ModelDetailPage/ModelActionDetails/ModelActionDetails.tsx
+++ b/frontend/src/metabase/models/components/ModelDetailPage/ModelActionDetails/ModelActionDetails.tsx
@@ -26,6 +26,7 @@ import {
   ActionsHeader,
   ActionMenu,
   ActionList,
+  ActionAlert,
 } from "./ModelActionDetails.styled";
 
 interface OwnProps {
@@ -105,6 +106,11 @@ function ModelActionDetails({
             />
           )}
         </ActionsHeader>
+      )}
+      {database && !hasActionsEnabled && (
+        <ActionAlert icon="warning" variant="error">
+          {t`Running Actions is not enabled for database ${database.displayName()}`}
+        </ActionAlert>
       )}
       {actions.length > 0 ? (
         <ActionList aria-label={t`Action list`}>

--- a/frontend/src/metabase/models/components/ModelDetailPage/ModelActionDetails/ModelActionDetails.tsx
+++ b/frontend/src/metabase/models/components/ModelDetailPage/ModelActionDetails/ModelActionDetails.tsx
@@ -57,7 +57,7 @@ function ModelActionDetails({
 }: Props) {
   const database = model.database();
   const hasActionsEnabled = database != null && database.hasActionsEnabled();
-  const canWrite = model.canWrite() && hasActionsEnabled;
+  const canWrite = model.canWriteActions();
   const hasImplicitActions = actions.some(action => action.type === "implicit");
 
   const actionsSorted = useMemo(

--- a/frontend/src/metabase/models/components/ModelDetailPage/ModelActionDetails/ModelActionDetails.tsx
+++ b/frontend/src/metabase/models/components/ModelDetailPage/ModelActionDetails/ModelActionDetails.tsx
@@ -54,7 +54,9 @@ function ModelActionDetails({
   actions,
   handleEnableImplicitActions,
 }: Props) {
-  const canWrite = model.canWrite();
+  const database = model.database();
+  const hasActionsEnabled = database != null && database.hasActionsEnabled();
+  const canWrite = model.canWrite() && hasActionsEnabled;
   const hasImplicitActions = actions.some(action => action.type === "implicit");
 
   const actionsSorted = useMemo(

--- a/frontend/src/metabase/models/containers/ModelDetailPage/ModelDetailPage.tsx
+++ b/frontend/src/metabase/models/containers/ModelDetailPage/ModelDetailPage.tsx
@@ -13,7 +13,6 @@ import Tables from "metabase/entities/tables";
 import { getMetadata } from "metabase/selectors/metadata";
 import title from "metabase/hoc/Title";
 
-import { checkDatabaseActionsEnabled } from "metabase/actions/utils";
 import { loadMetadataForCard } from "metabase/questions/actions";
 
 import ModelDetailPageView from "metabase/models/components/ModelDetailPage";
@@ -95,9 +94,8 @@ function ModelDetailPage({
 }: Props) {
   const [hasFetchedTableMetadata, setHasFetchedTableMetadata] = useState(false);
 
-  const database = model.database()?.getPlainObject();
-  const hasActionsEnabled =
-    database != null && checkDatabaseActionsEnabled(database);
+  const database = model.database();
+  const hasActionsEnabled = database != null && database.hasActionsEnabled();
 
   const mainTable = useMemo(
     () => (model.isStructured() ? model.query().sourceTable() : null),

--- a/frontend/src/metabase/models/containers/ModelDetailPage/ModelDetailPage.unit.spec.tsx
+++ b/frontend/src/metabase/models/containers/ModelDetailPage/ModelDetailPage.unit.spec.tsx
@@ -5,9 +5,9 @@ import userEvent from "@testing-library/user-event";
 
 import {
   fireEvent,
-  renderWithProviders,
   getIcon,
   queryIcon,
+  renderWithProviders,
   screen,
   waitFor,
   waitForElementToBeRemoved,
@@ -40,25 +40,25 @@ import {
   createMockCollection,
   createMockDatabase,
   createMockField,
-  createMockTable,
-  createMockUser,
   createMockImplicitCUDActions,
+  createMockNativeDatasetQuery,
+  createMockNativeQuery,
   createMockQueryAction as _createMockQueryAction,
   createMockStructuredDatasetQuery,
   createMockStructuredQuery,
-  createMockNativeDatasetQuery,
-  createMockNativeQuery,
+  createMockTable,
+  createMockUser,
 } from "metabase-types/api/mocks";
 
 import { TYPE } from "metabase-lib/types/constants";
 import type Question from "metabase-lib/Question";
 import {
-  getStructuredModel as _getStructuredModel,
   getNativeModel as _getNativeModel,
-  getSavedStructuredQuestion,
   getSavedNativeQuestion,
-  StructuredSavedCard,
+  getSavedStructuredQuestion,
+  getStructuredModel as _getStructuredModel,
   NativeSavedCard,
+  StructuredSavedCard,
 } from "metabase-lib/mocks";
 
 import ModelDetailPage from "./ModelDetailPage";
@@ -436,6 +436,18 @@ describe("ModelDetailPage", () => {
           expect(screen.queryByText("Actions")).not.toBeInTheDocument();
         });
 
+        it("is shown if actions are disabled for the model's database but there are existing actions", async () => {
+          const model = getModel();
+
+          await setup({
+            model: model,
+            actions: [createMockQueryAction({ model_id: model.id() })],
+            hasActionsEnabled: false,
+          });
+
+          expect(screen.getByText("Actions")).toBeInTheDocument();
+        });
+
         it("redirects to 'Used by' when trying to access actions tab without them enabled", async () => {
           const { baseUrl, history } = await setup({
             model: getModel(),
@@ -447,6 +459,22 @@ describe("ModelDetailPage", () => {
             `${baseUrl}/usage`,
           );
           expect(screen.getByRole("tab", { name: "Used by" })).toHaveAttribute(
+            "aria-selected",
+            "true",
+          );
+        });
+
+        it("does not redirect to another tab if actions are disabled for the model's database but there are existing actions", async () => {
+          const model = getModel();
+
+          await setup({
+            model,
+            actions: [createMockQueryAction({ model_id: model.id() })],
+            hasActionsEnabled: false,
+            tab: "actions",
+          });
+
+          expect(screen.getByRole("tab", { name: "Actions" })).toHaveAttribute(
             "aria-selected",
             "true",
           );

--- a/frontend/src/metabase/models/containers/ModelDetailPage/ModelDetailPage.unit.spec.tsx
+++ b/frontend/src/metabase/models/containers/ModelDetailPage/ModelDetailPage.unit.spec.tsx
@@ -438,10 +438,11 @@ describe("ModelDetailPage", () => {
 
         it("is shown if actions are disabled for the model's database but there are existing actions", async () => {
           const model = getModel();
+          const action = createMockQueryAction({ model_id: model.id() });
 
           await setup({
             model: model,
-            actions: [createMockQueryAction({ model_id: model.id() })],
+            actions: [action],
             hasActionsEnabled: false,
           });
 
@@ -466,10 +467,11 @@ describe("ModelDetailPage", () => {
 
         it("does not redirect to another tab if actions are disabled for the model's database but there are existing actions", async () => {
           const model = getModel();
+          const action = createMockQueryAction({ model_id: model.id() });
 
           await setup({
             model,
-            actions: [createMockQueryAction({ model_id: model.id() })],
+            actions: [action],
             hasActionsEnabled: false,
             tab: "actions",
           });
@@ -487,6 +489,27 @@ describe("ModelDetailPage", () => {
           ).not.toBeInTheDocument();
           expect(
             screen.getByText(/No actions have been created yet/i),
+          ).toBeInTheDocument();
+        });
+
+        it("shows empty state if actions are disabled for the model's database but there are existing actions", async () => {
+          const model = getModel();
+          const action = createMockQueryAction({ model_id: model.id() });
+
+          await setup({
+            model,
+            actions: [action],
+            tab: "actions",
+            hasActionsEnabled: false,
+          });
+
+          expect(
+            screen.getByRole("list", { name: /Action list/i }),
+          ).toBeInTheDocument();
+          expect(
+            screen.getByText(
+              `Running Actions is not enabled for database ${TEST_DATABASE.name}`,
+            ),
           ).toBeInTheDocument();
         });
 


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/28132

How to test:
- Enable actions for your database in Admin settings
- Create some actions for some model
- Disable actions for the database
- Go back to the model details page and the actions tab and make sure that existing actions are still there
- There should be a banner indicating that the setting is disabled
- It should be possible to view each existing action but don't change it

<img width="1007" alt="Screenshot 2023-02-15 at 22 21 48" src="https://user-images.githubusercontent.com/8542534/219145693-9e13db14-a3cd-402a-ba26-9965e763a14c.png">

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/28347)
<!-- Reviewable:end -->
