### PR TITLE
Clojure migration to split v1 data perm paths into v2 data & query perms

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -401,7 +401,7 @@
   metabase.async.api-response-test/with-response                                       clojure.core/let
   metabase.dashboard-subscription-test/with-dashboard-sub-for-card                     clojure.core/let
   metabase.db.custom-migrations/defmigration                                           clj-kondo.lint-as/def-catch-all
-  metabase.db.custom-migrations/def-reversible-migration                               clj-kondo.lint-as/def-catch-all
+  metabase.db.custom-migrations/define-reversible-migration                            clj-kondo.lint-as/def-catch-all
   metabase.db.data-migrations/defmigration                                             clojure.core/def
   metabase.db.liquibase/with-liquibase                                                 clojure.core/let
   metabase.db.schema-migrations-test.impl/with-temp-empty-app-db                       clojure.core/let

--- a/bin/lint-migrations-file/src/change_set/strict.clj
+++ b/bin/lint-migrations-file/src/change_set/strict.clj
@@ -56,7 +56,7 @@
     :renameTable
     :renameTrigger
     :renameView
-    ;; assumes all custom changes use the `def-migration` or `def-reversible-migration` in
+    ;; assumes all custom changes use the `def-migration` or `define-reversible-migration` in
     ;; metabase.db.custom-migrations
     :customChange})
 

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -14263,6 +14263,14 @@ databaseChangeLog:
       rollback: # nothing to do, since we don't know which drivers used to be presto
 
   - changeSet:
+      id: v46.00-080
+      author: noahmoss
+      comment: Migrate data permission paths from v1 to v2 (splitting them into separate data and query permissions)
+      changes:
+        - customChange:
+            class: "metabase.db.custom_migrations.SplitDataPermissions"
+
+  - changeSet:
       id: v46.00-084
       author: qnkhuat
       comment: Added 0.46.0 - CASCADE delete for action.model_id

--- a/src/metabase/db/custom_migrations.clj
+++ b/src/metabase/db/custom_migrations.clj
@@ -13,7 +13,7 @@
 
 (set! *warn-on-reflection* true)
 
-(defmacro def-reversible-migration
+(defmacro define-reversible-migration
   "Define a reversible custom migration. Both the forward and reverse migrations are defined using the same structure,
   similar to the bodies of multi-arity Clojure functions.
 
@@ -24,7 +24,7 @@
   Example:
 
   ```clj
-  (def-reversible-migration ExampleMigrationName
+  (define-reversible-migration ExampleMigrationName
    ([_database]
     (migration-body))
 
@@ -58,7 +58,7 @@
 (defmacro defmigration
   "Define a custom migration."
   [name migration-body]
-  `(def-reversible-migration ~name ~migration-body ([~'_] (no-op ~(str name)))))
+  `(define-reversible-migration ~name ~migration-body ([~'_] (no-op ~(str name)))))
 
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
@@ -82,11 +82,11 @@
     (when-let [db-id (second (re-find #"^/db/(\d+)/schema/$" v1-path))]
       [(str "/data/db/" db-id "/") (str "/query/db/" db-id "/schema/")])))
 
-(def-reversible-migration SplitDataPermissions
+(define-reversible-migration SplitDataPermissions
   ([_database]
    (let [current-perms-set (t2/select-fn-set
                             (juxt :object :group_id)
-                            :models/permissions
+                            :metabase.models.permissions/Permissions
                             {:where [:or
                                      [:like :object (h2x/literal "/db/%")]
                                      [:like :object (h2x/literal "/data/db/%")]

--- a/src/metabase/db/custom_migrations.clj
+++ b/src/metabase/db/custom_migrations.clj
@@ -8,6 +8,7 @@
    [toucan2.execute :as t2.execute])
   (:import
    (liquibase.change.custom CustomTaskChange CustomTaskRollback)
+   (liquibase.database.jvm JdbcConnection)
    (liquibase.exception ValidationErrors)))
 
 (set! *warn-on-reflection* true)
@@ -33,7 +34,7 @@
   `(defrecord ~name []
      CustomTaskChange
      (execute [_# database#]
-       (binding [toucan2.connection/*current-connectable* (.getWrappedConnection (.getConnection database#))]
+       (binding [toucan2.connection/*current-connectable* (.getWrappedConnection ^JdbcConnection (.getConnection database#))]
          (let [~db-binding-1 database#]
            ~@migration-body)))
      (getConfirmationMessage [_#]
@@ -45,7 +46,7 @@
 
      CustomTaskRollback
      (rollback [_# database#]
-       (binding [toucan2.connection/*current-connectable* (.getWrappedConnection (.getConnection database#))]
+       (binding [toucan2.connection/*current-connectable* (.getWrappedConnection ^JdbcConnection (.getConnection database#))]
          (let [~db-binding-2 database#]
            ~@reverse-migration-body)))))
 

--- a/src/metabase/db/custom_migrations.clj
+++ b/src/metabase/db/custom_migrations.clj
@@ -1,8 +1,13 @@
 (ns metabase.db.custom-migrations
-  (:require [metabase.util.log :as log]
-            [toucan2.connection :as t2.conn])
-  (:import [liquibase.change.custom CustomTaskChange CustomTaskRollback]
-           liquibase.exception.ValidationErrors))
+  (:require
+   [clojure.set :as set]
+   [metabase.util.honey-sql-2-extensions :as h2x]
+   [metabase.util.log :as log]
+   [toucan2.core :as t2]
+   [toucan2.execute :as t2.execute])
+  (:import
+   (liquibase.change.custom CustomTaskChange CustomTaskRollback)
+   (liquibase.exception ValidationErrors)))
 
 (set! *warn-on-reflection* true)
 
@@ -52,3 +57,49 @@
   "Define a custom migration."
   [name migration-body]
   `(def-reversible-migration ~name ~migration-body ([~'_] (no-op ~(str name)))))
+
+
+;;; +----------------------------------------------------------------------------------------------------------------+
+;;; |                                                  MIGRATIONS                                                    |
+;;; +----------------------------------------------------------------------------------------------------------------+
+
+(def ^:private base-path-regex
+  #"^(/db/\d+(?:/schema/(?:(?:[^\\/])|(?:\\/)|(?:\\\\))*(?:/table/\d+?)?)?/)((native/)|(query/(segmented/)?))?$")
+
+(defn- ->v2-paths
+  "Converts v1 data permission paths into v2 data and query permissions paths. This is similar to `->v2-path` in
+   metabase.models.permissions but somewhat simplified for the migration use case."
+  [v1-path]
+  (if-let [base-path (second (re-find base-path-regex v1-path))]
+    ;; For (almost) all v1 data paths, we simply extract the base path (e.g. "/db/1/schema/PUBLIC/table/1/")
+    ;; and construct new v2 paths by adding prefixes to the base path.
+    [(str "/data" base-path) (str "/query" base-path)]
+
+    ;; For the specific v1 path that grants full data access but no native query access, we add a
+    ;; /schema/ suffix to the corresponding v2 query permission path.
+    (when-let [db-id (second (re-find #"^/db/(\d+)/schema/$" v1-path))]
+      [(str "/data/db/" db-id "/") (str "/query/db/" db-id "/schema/")])))
+
+(def-reversible-migration SplitDataPermissions
+  ([_database]
+   (let [current-perms-set (t2/select-fn-set
+                            (juxt :object :group_id)
+                            :models/permissions
+                            {:where [:or
+                                     [:like :object (h2x/literal "/db/%")]
+                                     [:like :object (h2x/literal "/data/db/%")]
+                                     [:like :object (h2x/literal "/query/db/%")]]})
+         v2-perms-set      (into #{} (mapcat
+                                      (fn [[v1-path group-id]]
+                                        (for [v2-path (->v2-paths v1-path)]
+                                          [v2-path group-id]))
+                                      current-perms-set))
+         new-v2-perms      (into [] (set/difference v2-perms-set current-perms-set))]
+     (when (seq new-v2-perms)
+       (t2.execute/query-one {:insert-into :permissions
+                              :columns     [:object :group_id]
+                              :values      new-v2-perms}))))
+  ([_database]
+   (t2.execute/query-one {:delete-from :permissions
+                          :where [:or [:like :object (h2x/literal "/data/db/%")]
+                                      [:like :object (h2x/literal "/query/db/%")]]})))

--- a/src/metabase/db/custom_migrations.clj
+++ b/src/metabase/db/custom_migrations.clj
@@ -3,6 +3,7 @@
    [clojure.set :as set]
    [metabase.util.honey-sql-2-extensions :as h2x]
    [metabase.util.log :as log]
+   [toucan2.connection :as t2.conn]
    [toucan2.core :as t2]
    [toucan2.execute :as t2.execute])
   (:import

--- a/src/metabase/db/custom_migrations.clj
+++ b/src/metabase/db/custom_migrations.clj
@@ -1,7 +1,7 @@
 (ns metabase.db.custom-migrations
   (:require
    [clojure.set :as set]
-   [metabase.util.honey-sql-2-extensions :as h2x]
+   [metabase.util.honey-sql-2 :as h2x]
    [metabase.util.log :as log]
    [toucan2.connection :as t2.conn]
    [toucan2.core :as t2]

--- a/src/metabase/db/setup.clj
+++ b/src/metabase/db/setup.clj
@@ -152,10 +152,10 @@
   (u/profile (trs "Database setup")
     (u/with-us-locale
        (binding [mdb.connection/*application-db* (mdb.connection/application-db db-type data-source :create-pool? false) ; should already be a pool
-                 setting/*disable-cache*         true])
-       (verify-db-connection   db-type data-source)
-       (run-schema-migrations! db-type data-source auto-migrate?)
-       (run-data-migrations!)))
+                 setting/*disable-cache*         true]
+         (verify-db-connection   db-type data-source)
+         (run-schema-migrations! db-type data-source auto-migrate?)
+         (run-data-migrations!))))
   :done)
 
 ;;;; Toucan Setup.

--- a/src/metabase/db/setup.clj
+++ b/src/metabase/db/setup.clj
@@ -134,14 +134,11 @@
 
 (s/defn ^:private run-data-migrations!
   "Do any custom code-based migrations now that the db structure is up to date."
-  [db-type     :- s/Keyword
-   data-source :- javax.sql.DataSource]
+  []
   ;; TODO -- check whether we can remove the circular ref busting here.
   (when-not *disable-data-migrations*
     (classloader/require 'metabase.db.data-migrations)
-    (binding [mdb.connection/*application-db* (mdb.connection/application-db db-type data-source :create-pool? false) ; should already be a pool.
-              setting/*disable-cache*         true]
-      ((resolve 'metabase.db.data-migrations/run-all!)))))
+    ((resolve 'metabase.db.data-migrations/run-all!))))
 
 ;; TODO -- consider renaming to something like `verify-connection-and-migrate!`
 ;;
@@ -154,9 +151,11 @@
    auto-migrate? :- (s/maybe s/Bool)]
   (u/profile (trs "Database setup")
     (u/with-us-locale
-      (verify-db-connection   db-type data-source)
-      (run-schema-migrations! db-type data-source auto-migrate?)
-      (run-data-migrations!   db-type data-source)))
+       (binding [mdb.connection/*application-db* (mdb.connection/application-db db-type data-source :create-pool? false) ; should already be a pool
+                 setting/*disable-cache*         true])
+       (verify-db-connection   db-type data-source)
+       (run-schema-migrations! db-type data-source auto-migrate?)
+       (run-data-migrations!)))
   :done)
 
 ;;;; Toucan Setup.


### PR DESCRIPTION
This is a migration to convert v1 data permission paths that existed in an instance's database prior to v46 into separate v2 data and query permission paths. It uses the new mechanism to run Clojure migrations via Liquibase, since `REGEXP_SUBSTR` isn't available on MySQL 5.7. 

I'm not using the existing permission path conversion logic in `metabase.models.permissions` because we're trying to keep these migrations from having minimal dependencies on other parts of the codebase, to keep them robust. Instead I've replicated that logic using a single raw regex for the most part. Essentially, I have a regex to parse almost any v1 data perms path and extract the "base path", which is the path for the resource without any suffixes. Then the corresponding v2 paths are just the base path with `/data` or `/query` prefixes. The one exception is `/db/:id/schema` since the v2 query path also needs the `/schema` suffix, so I have special logic for handling this.

I've also added a test to make sure that each path type is converted appropriately.