### PR TITLE
Add comments on setReadOnly connections

### DIFF
--- a/src/metabase/driver/h2.clj
+++ b/src/metabase/driver/h2.clj
@@ -396,6 +396,8 @@
   ;; steps that are in the default impl
   (let [conn (.getConnection (sql-jdbc.execute/datasource-with-diagnostic-info! driver database))]
     (try
+      ;; in H2, setting readOnly to true doesn't prevent writes
+      ;; see https://github.com/h2database/h2database/issues/1163
       (doto conn
         (.setReadOnly true))
       (catch Throwable e

--- a/src/metabase/driver/sql_jdbc/execute.clj
+++ b/src/metabase/driver/sql_jdbc/execute.clj
@@ -199,6 +199,9 @@
       (set-best-transaction-level! driver conn)
       (set-time-zone-if-supported! driver conn timezone-id)
       (try
+        ;; Setting the connection to read-only does not prevent writes on some databases, and is meant
+        ;; to be a hint to the driver to enable database optimizations
+        ;; See https://docs.oracle.com/javase/8/docs/api/java/sql/Connection.html#setReadOnly-boolean-
         (.setReadOnly conn true)
         (catch Throwable e
           (log/debug e (trs "Error setting connection to read-only"))))


### PR DESCRIPTION
According to java.sql.Connection [javadocs](https://docs.oracle.com/javase/8/docs/api/java/sql/Connection.html#setReadOnly-boolean-) `setReadOnly` puts a connection in read-only mode "as a hint to the driver to enable database optimizations". It doesn't guarantee writes are disabled.

To prevent confusion in the future about what `setReadOnly` does to a connection, I've left some explicit comments in the code.

Brought on by https://github.com/metabase/metabase/pull/28337