### PR TITLE
Bump FE unit tests timeout to 30 mins

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -78,7 +78,7 @@ jobs:
     needs: files-changed
     if: github.event.pull_request.draft == false && needs.files-changed.outputs.frontend_all == 'true'
     runs-on: buildjet-2vcpu-ubuntu-2004
-    timeout-minutes: 20
+    timeout-minutes: 30
     steps:
     - uses: actions/checkout@v3
     - name: Prepare front-end environment


### PR DESCRIPTION
Our FE unit tests have been timing out consistently at 20 minutes.