### PR TITLE
[CI] Improve path-filtering logic for `ci`

### DIFF
--- a/.github/file-paths.yaml
+++ b/.github/file-paths.yaml
@@ -3,7 +3,7 @@ default: &default
   - "bin/**"
 
 ci: &ci
-  - ".github/**(!.md)"
+  - ".github/**/!(*.md)"
 
 shared_sources: &shared_sources
   - "shared/src"

--- a/.github/file-paths.yaml
+++ b/.github/file-paths.yaml
@@ -3,7 +3,7 @@ default: &default
   - "bin/**"
 
 ci: &ci
-  - ".github/**"
+  - ".github/**(!.md)"
 
 shared_sources: &shared_sources
   - "shared/src"


### PR DESCRIPTION
We're triggering all workflows for a change inside of `.github/` folder.
But we have some markdown files (mostly issue or pull request templates and one readme). We should exclude them.