### PR TITLE
Disable action buttons when actions are disabled on a db

### DIFF
--- a/frontend/src/metabase/actions/components/ActionViz/Action.tsx
+++ b/frontend/src/metabase/actions/components/ActionViz/Action.tsx
@@ -123,12 +123,16 @@ function mapStateToProps(state: State, props: ActionProps) {
 }
 
 export function ActionFn(props: ActionProps) {
-  const actionsEnabled = !!props.metadata
-    ?.database(props.dashcard?.action?.database_id)
+  const {
+    metadata,
+    dashcard: { action },
+  } = props;
+  const actionsEnabled = !!metadata
+    ?.database(action?.database_id)
     ?.hasActionsEnabled?.();
 
   if (!props.dashcard?.action || !actionsEnabled) {
-    const tooltip = !props.dashcard?.action
+    const tooltip = !action
       ? t`No action assigned`
       : t`Actions are not enabled for this database`;
 

--- a/frontend/src/metabase/actions/components/ActionViz/Action.unit.spec.tsx
+++ b/frontend/src/metabase/actions/components/ActionViz/Action.unit.spec.tsx
@@ -11,6 +11,7 @@ import {
   createMockQueryAction,
   createMockImplicitQueryAction,
   createMockDashboard,
+  createMockDatabase,
 } from "metabase-types/api/mocks";
 
 import Action, { ActionComponent, ActionProps } from "./Action";
@@ -21,6 +22,7 @@ const defaultProps = {
     card_id: 777, // action model id
     action: createMockQueryAction({
       name: "My Awesome Action",
+      database_id: 2,
       parameters: [
         createMockActionParameter({
           id: "1",
@@ -65,7 +67,20 @@ async function setup(options?: Partial<ActionProps>) {
 }
 
 async function setupActionWrapper(options?: Partial<ActionProps>) {
-  return renderWithProviders(<Action {...defaultProps} {...options} />);
+  return renderWithProviders(<Action {...defaultProps} {...options} />, {
+    withSampleDatabase: true,
+    storeInitialState: {
+      entities: {
+        databases: {
+          1: createMockDatabase({ id: 1 }),
+          2: createMockDatabase({
+            id: 2,
+            settings: { "database-enable-actions": true },
+          }),
+        },
+      },
+    },
+  });
 }
 
 function setupExecutionEndpoint(expectedBody: any) {
@@ -91,6 +106,38 @@ describe("Actions > ActionViz > ActionComponent", () => {
         },
       });
       expect(screen.getByLabelText("bolt icon")).toBeInTheDocument();
+      expect(screen.getByRole("button")).toBeDisabled();
+      expect(screen.getByLabelText(/no action assigned/i)).toBeInTheDocument();
+    });
+
+    it("should render a disabled state for a button with an action from a database where actions are disabled", async () => {
+      await setupActionWrapper({
+        dashcard: {
+          ...defaultProps.dashcard,
+          action: createMockQueryAction({
+            name: "My Awesome Action",
+            database_id: 1,
+          }),
+        },
+      });
+      expect(screen.getByLabelText("bolt icon")).toBeInTheDocument();
+      expect(screen.getByRole("button")).toBeDisabled();
+      expect(
+        screen.getByLabelText(/actions are not enabled/i),
+      ).toBeInTheDocument();
+    });
+
+    it("should render an enabled state when the action is valid", async () => {
+      await setupActionWrapper({
+        dashcard: {
+          ...defaultProps.dashcard,
+          action: createMockQueryAction({
+            name: "My Awesome Action",
+            database_id: 2,
+          }),
+        },
+      });
+      expect(screen.getByRole("button")).toBeEnabled();
     });
 
     it("should render a button with default text", async () => {

--- a/frontend/src/metabase/actions/components/ActionViz/ActionButtonView.tsx
+++ b/frontend/src/metabase/actions/components/ActionViz/ActionButtonView.tsx
@@ -39,6 +39,7 @@ function ActionButtonView({
       onClick={onClick}
       isFullHeight={isFullHeight}
       focus={focus}
+      aria-label={tooltip}
       {...variantProps}
     >
       <StyledButtonContent>


### PR DESCRIPTION
### Description

- checks if an action's database has actions enabled before rendering the action visualization. If the database has actions disabled, it renders the button in a disabled state with an appropriate tooltip

![Screen Shot 2023-02-16 at 8 23 29 AM](https://user-images.githubusercontent.com/30528226/219410719-862398f5-2944-451a-99a3-1183346a0287.png)

buttons without any action get a similar disabled state, but a different tooltip

![Screen Shot 2023-02-16 at 8 23 35 AM](https://user-images.githubusercontent.com/30528226/219410812-62683391-210e-4887-bd72-ab666371a2e2.png)


### How to verify

- enable actions on a database (postgres or mysql)
- create a model from a table in that db
- create an action on that model from the model detail page
- create a dashboard
- add your action as an action button to the dashboard
- see that the action works
- disable actions for your db
- go back to your dashboard
- see that the action button is now disabled

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
