### PR TITLE
Fix public action page look

### DIFF
--- a/frontend/src/metabase/public/components/EmbedFrame/EmbedFrame.css
+++ b/frontend/src/metabase/public/components/EmbedFrame/EmbedFrame.css
@@ -1,3 +1,7 @@
+body {
+  background-color: transparent;
+}
+
 .EmbedFrame {
   background-color: white;
 }

--- a/frontend/src/metabase/public/containers/PublicAction/PublicAction.styled.tsx
+++ b/frontend/src/metabase/public/containers/PublicAction/PublicAction.styled.tsx
@@ -3,6 +3,7 @@ import { css } from "@emotion/react";
 import FormSubmitButton from "metabase/core/components/FormSubmitButton";
 import BaseLoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
 import { color } from "metabase/lib/colors";
+import { breakpointMaxSmall } from "metabase/styled-components/theme";
 
 export const LoadingAndErrorWrapper = styled(BaseLoadingAndErrorWrapper)`
   display: flex;
@@ -24,6 +25,11 @@ export const FormContainer = styled.div`
 
   ${FormSubmitButton.Button} {
     width: 100%;
+  }
+
+  ${breakpointMaxSmall} {
+    width: 100%;
+    padding: 0 0.5rem;
   }
 `;
 

--- a/frontend/src/metabase/public/containers/PublicAction/PublicActionLoader.tsx
+++ b/frontend/src/metabase/public/containers/PublicAction/PublicActionLoader.tsx
@@ -62,7 +62,7 @@ function PublicActionLoader({ params, setErrorPage }: Props) {
   }, [action, params.uuid, setErrorPage]);
 
   return (
-    <EmbedFrame footerVariant="big">
+    <EmbedFrame footerVariant="large">
       <LoadingAndErrorWrapper loading={!action}>
         {renderContent}
       </LoadingAndErrorWrapper>


### PR DESCRIPTION
Epic #27626

Fixes a couple of visual bugs on the public action page:

* page footer was messed up because of an incorrect variant prop
* on a certain screen size, part of the page had a `bg-light` background

### How to verify

1. Go to `/model/:id/details/actions`
2. Create a query action
3. Open the action in the editor, click the "gear" icon, and enable public sharing
4. Open the public link, and ensure the footer looks the same as below

### Demo

**Before**

![CleanShot 2023-02-16 at 15 22 15@2x](https://user-images.githubusercontent.com/17258145/219411724-1fbce91e-3cf0-4a89-85f4-64e2169248f3.png)


**After**

<img width="1028" alt="CleanShot 2023-02-16 at 15 22 42@2x" src="https://user-images.githubusercontent.com/17258145/219411745-20e8a535-22d7-4f22-b6cb-14b7db954a82.png">

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/28365)
<!-- Reviewable:end -->
