### PR TITLE
[CI] Improve path-filtering logic for `fe-specs`

### DIFF
--- a/.github/file-paths.yaml
+++ b/.github/file-paths.yaml
@@ -25,7 +25,7 @@ frontend_sources: &frontend_sources
 
 frontend_specs: &frontend_specs
   - *shared_specs
-  - "frontend/test/!(__support__|__runner__)/**"
+  - "frontend/test/!(__support__/e2e|__runner__/*cypress*|metabase/scenarios|snapshot-creators|metabase-visual)/**"
   - "frontend/**.unit.*"
   - "jest.config.js"
 


### PR DESCRIPTION
@iethree 's PR touched only Cypress related files, but the CI ran all frontend workflows.

Let's take a look at [the output](https://github.com/metabase/metabase/actions/runs/4191482729/jobs/7265954077):
```
Run dorny/paths-filter@v2.11.1
Fetching list of changed files for PR#2[7](https://github.com/metabase/metabase/actions/runs/4191482729/jobs/7265954077#step:3:8)9[8](https://github.com/metabase/metabase/actions/runs/4191482729/jobs/7265954077#step:3:9)6 from Github API
  Invoking listFiles(pull_number: 27986, per_page: 100)
  Received 4 items
  [modified] frontend/test/__support__/e2e/cypress_data.js
  [modified] frontend/test/__support__/e2e/helpers/e2e-qa-databases-helpers.js
  [added] frontend/test/metabase/scenarios/admin/databases/actions.cy.spec.js
  [modified] frontend/test/snapshot-creators/qa-db.cy.snap.js
Detected 4 changed files
Results:
Filter default = false
Filter ci = false
Filter shared_sources = false
Filter shared_specs = false
Filter frontend_sources = false
Filter frontend_specs = true
Filter frontend_all = true
Filter backend_presto_kerberos = false
Filter backend_sources = false
Filter backend_specs = false
Filter backend_all = false
Filter sources = false
Filter e2e_specs = true
Filter e2e_all = true
Filter snowplow = false
Filter documentation = false
Filter yaml = false
Changes output set to ["frontend_specs","frontend_all","e2e_specs","e2e_all"]
```

This PR adds some additional logic to the file paths that should prevent this from happening again.