### PR TITLE
Download charts as PNG

### DIFF
--- a/frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx
+++ b/frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx
@@ -14,8 +14,6 @@ import LoadingSpinner from "metabase/components/LoadingSpinner";
 import DownloadButton from "metabase/components/DownloadButton";
 import Tooltip from "metabase/core/components/Tooltip";
 import { PLUGIN_FEATURE_LEVEL_PERMISSIONS } from "metabase/plugins";
-import ModalWithTrigger from "metabase/components/ModalWithTrigger";
-import ModalContent from "metabase/components/ModalContent";
 
 import * as Urls from "metabase/lib/urls";
 
@@ -140,12 +138,7 @@ const QueryDownloadWidget = ({
                   ) : null}
                 </WidgetFormat>
               ))}
-              <ModalWithTrigger
-                triggerElement={<DownloadButton>PNG</DownloadButton>}
-                fit
-              >
-                <DownloadPNGModal />
-              </ModalWithTrigger>
+              <DownloadPNGButton />
             </div>
           </WidgetRoot>
         );
@@ -154,19 +147,28 @@ const QueryDownloadWidget = ({
   );
 };
 
-function DownloadPNGModal() {
+function DownloadPNGButton() {
+  const [clicked, setClicked] = useState(false);
   useEffect(() => {
     html2canvas(document.querySelector(".dc-chart")).then(canvas => {
-      console.log(canvas);
-      console.log("we be go?");
-      document.getElementById("png-canvas").appendChild(canvas);
+      const button = document.getElementById("png-download");
+      const title = document.querySelector(
+        'div[data-testid="qb-header"] span',
+      ).innerText;
+      button.download = `${title}-${new Date(Date.now()).toLocaleString(
+        "en",
+      )}.png`; // TODO - update with question name
+      button.href = canvas.toDataURL();
+      if (clicked) {
+        button.click();
+      }
     });
-  }, []);
+  }, [clicked]);
 
   return (
-    <ModalContent title="Download PNG">
-      <div id="png-canvas"></div>
-    </ModalContent>
+    <DownloadButton onClick={() => setClicked(true)}>
+      <a id="png-download">PNG</a>
+    </DownloadButton>
   );
 }
 

--- a/frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx
+++ b/frontend/src/metabase/query_builder/components/QueryDownloadWidget.jsx
@@ -1,7 +1,7 @@
 /* eslint-disable react/prop-types */
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import PropTypes from "prop-types";
-
+import html2canvas from "html2canvas";
 import { t } from "ttag";
 import { parse as urlParse } from "url";
 import querystring from "querystring";
@@ -14,6 +14,8 @@ import LoadingSpinner from "metabase/components/LoadingSpinner";
 import DownloadButton from "metabase/components/DownloadButton";
 import Tooltip from "metabase/core/components/Tooltip";
 import { PLUGIN_FEATURE_LEVEL_PERMISSIONS } from "metabase/plugins";
+import ModalWithTrigger from "metabase/components/ModalWithTrigger";
+import ModalContent from "metabase/components/ModalContent";
 
 import * as Urls from "metabase/lib/urls";
 
@@ -51,98 +53,122 @@ const QueryDownloadWidget = ({
       triggerClassesClose={classNameClose}
       disabled={status === `pending` ? true : null}
     >
-      {({ onClose: closePopover }) => (
-        <WidgetRoot
-          isExpanded={result.data && result.data.rows_truncated != null}
-        >
-          <WidgetHeader>
-            <h4>{t`Download full results`}</h4>
-          </WidgetHeader>
-          {result.data != null && result.data.rows_truncated != null && (
-            <WidgetMessage>
-              <p>{t`Your answer has a large number of rows so it could take a while to download.`}</p>
-              <p>{getLimitedDownloadSizeText(result)}</p>
-            </WidgetMessage>
-          )}
-          <div>
-            {EXPORT_FORMATS.map(type => (
-              <WidgetFormat key={type}>
-                {dashcardId && token ? (
-                  <DashboardEmbedQueryButton
-                    key={type}
-                    type={type}
-                    dashcardId={dashcardId}
-                    token={token}
-                    card={card}
-                    params={params}
-                    onDownloadStart={() => {
-                      setStatus("pending");
-                      closePopover();
-                    }}
-                    onDownloadResolved={() => setStatus("resolved")}
-                    onDownloadRejected={() => setStatus("rejected")}
-                  />
-                ) : uuid ? (
-                  <PublicQueryButton
-                    key={type}
-                    type={type}
-                    uuid={uuid}
-                    result={result}
-                    onDownloadStart={() => {
-                      setStatus("pending");
-                      closePopover();
-                    }}
-                    onDownloadResolved={() => setStatus("resolved")}
-                    onDownloadRejected={() => setStatus("rejected")}
-                  />
-                ) : token ? (
-                  <EmbedQueryButton
-                    key={type}
-                    type={type}
-                    token={token}
-                    onDownloadStart={() => {
-                      setStatus("pending");
-                      closePopover();
-                    }}
-                    onDownloadResolved={() => setStatus("resolved")}
-                    onDownloadRejected={() => setStatus("rejected")}
-                  />
-                ) : card && card.id ? (
-                  <SavedQueryButton
-                    key={type}
-                    type={type}
-                    card={card}
-                    result={result}
-                    disabled={status === "pending"}
-                    onDownloadStart={() => {
-                      setStatus("pending");
-                      closePopover();
-                    }}
-                    onDownloadResolved={() => setStatus("resolved")}
-                    onDownloadRejected={() => setStatus("rejected")}
-                  />
-                ) : card && !card.id ? (
-                  <UnsavedQueryButton
-                    key={type}
-                    type={type}
-                    result={result}
-                    visualizationSettings={visualizationSettings}
-                    onDownloadStart={() => {
-                      setStatus("pending");
-                      closePopover();
-                    }}
-                    onDownloadResolved={() => setStatus("resolved")}
-                    onDownloadRejected={() => setStatus("rejected")}
-                  />
-                ) : null}
-              </WidgetFormat>
-            ))}
-          </div>
-        </WidgetRoot>
-      )}
+      {({ onClose: closePopover }) => {
+        return (
+          <WidgetRoot
+            isExpanded={result.data && result.data.rows_truncated != null}
+          >
+            <WidgetHeader>
+              <h4>{t`Download full results`}</h4>
+            </WidgetHeader>
+            {result.data != null && result.data.rows_truncated != null && (
+              <WidgetMessage>
+                <p>{t`Your answer has a large number of rows so it could take a while to download.`}</p>
+                <p>{getLimitedDownloadSizeText(result)}</p>
+              </WidgetMessage>
+            )}
+            <div>
+              {EXPORT_FORMATS.map(type => (
+                <WidgetFormat key={type}>
+                  {dashcardId && token ? (
+                    <DashboardEmbedQueryButton
+                      key={type}
+                      type={type}
+                      dashcardId={dashcardId}
+                      token={token}
+                      card={card}
+                      params={params}
+                      onDownloadStart={() => {
+                        setStatus("pending");
+                        closePopover();
+                      }}
+                      onDownloadResolved={() => setStatus("resolved")}
+                      onDownloadRejected={() => setStatus("rejected")}
+                    />
+                  ) : uuid ? (
+                    <PublicQueryButton
+                      key={type}
+                      type={type}
+                      uuid={uuid}
+                      result={result}
+                      onDownloadStart={() => {
+                        setStatus("pending");
+                        closePopover();
+                      }}
+                      onDownloadResolved={() => setStatus("resolved")}
+                      onDownloadRejected={() => setStatus("rejected")}
+                    />
+                  ) : token ? (
+                    <EmbedQueryButton
+                      key={type}
+                      type={type}
+                      token={token}
+                      onDownloadStart={() => {
+                        setStatus("pending");
+                        closePopover();
+                      }}
+                      onDownloadResolved={() => setStatus("resolved")}
+                      onDownloadRejected={() => setStatus("rejected")}
+                    />
+                  ) : card && card.id ? (
+                    <SavedQueryButton
+                      key={type}
+                      type={type}
+                      card={card}
+                      result={result}
+                      disabled={status === "pending"}
+                      onDownloadStart={() => {
+                        setStatus("pending");
+                        closePopover();
+                      }}
+                      onDownloadResolved={() => setStatus("resolved")}
+                      onDownloadRejected={() => setStatus("rejected")}
+                    />
+                  ) : card && !card.id ? (
+                    <UnsavedQueryButton
+                      key={type}
+                      type={type}
+                      result={result}
+                      visualizationSettings={visualizationSettings}
+                      onDownloadStart={() => {
+                        setStatus("pending");
+                        closePopover();
+                      }}
+                      onDownloadResolved={() => setStatus("resolved")}
+                      onDownloadRejected={() => setStatus("rejected")}
+                    />
+                  ) : null}
+                </WidgetFormat>
+              ))}
+              <ModalWithTrigger
+                triggerElement={<DownloadButton>PNG</DownloadButton>}
+                fit
+              >
+                <DownloadPNGModal />
+              </ModalWithTrigger>
+            </div>
+          </WidgetRoot>
+        );
+      }}
     </PopoverWithTrigger>
   );
 };
+
+function DownloadPNGModal() {
+  useEffect(() => {
+    html2canvas(document.querySelector(".dc-chart")).then(canvas => {
+      console.log(canvas);
+      console.log("we be go?");
+      document.getElementById("png-canvas").appendChild(canvas);
+    });
+  }, []);
+
+  return (
+    <ModalContent title="Download PNG">
+      <div id="png-canvas"></div>
+    </ModalContent>
+  );
+}
 
 const UnsavedQueryButton = ({
   type,

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "diff": "^3.2.0",
     "formik": "^2.2.9",
     "history": "3",
+    "html2canvas": "^1.4.1",
     "humanize-plus": "^1.8.1",
     "icepick": "2.4.0",
     "iframe-resizer": "^4.3.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7787,6 +7787,11 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
+base64-arraybuffer@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz#1c37589a7c4b0746e34bd1feb951da2df01c1bdc"
+  integrity sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==
+
 base64-js@^1.0.2:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.3.1.tgz#58ece8cb75dd07e71ed08c736abc5fac4dbf8df1"
@@ -9369,6 +9374,13 @@ css-in-js-utils@^3.1.0:
   integrity sha512-fJAcud6B3rRu+KHYk+Bwf+WFL2MDCJJ1XG9x137tJQ0xYxor7XziQtuGFbWNdqrvF4Tk26O3H73nfVqXt/fW1A==
   dependencies:
     hyphenate-style-name "^1.0.3"
+
+css-line-break@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/css-line-break/-/css-line-break-2.1.0.tgz#bfef660dfa6f5397ea54116bb3cb4873edbc4fa0"
+  integrity sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==
+  dependencies:
+    utrie "^1.0.2"
 
 css-loader@1.0.1:
   version "1.0.1"
@@ -12666,6 +12678,14 @@ html-webpack-plugin@^4.0.0:
     pretty-error "^2.1.1"
     tapable "^1.1.3"
     util.promisify "1.0.0"
+
+html2canvas@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/html2canvas/-/html2canvas-1.4.1.tgz#7cef1888311b5011d507794a066041b14669a543"
+  integrity sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==
+  dependencies:
+    css-line-break "^2.1.0"
+    text-segmentation "^1.0.3"
 
 htmlparser2@^3.10.1:
   version "3.10.1"
@@ -20757,6 +20777,13 @@ tether@^1.2.0:
   resolved "https://registry.yarnpkg.com/tether/-/tether-1.4.7.tgz#d56a818590d8fe72e387f77a67f93ab96d8e1fb2"
   integrity sha512-Z0J1aExjoFU8pybVkQAo/vD2wfSO63r+XOPfWQMC5qtf1bI7IWqNk4MiyBcgvvnY8kqnY06dVdvwTK2S3PU/Fw==
 
+text-segmentation@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/text-segmentation/-/text-segmentation-1.0.3.tgz#52a388159efffe746b24a63ba311b6ac9f2d7943"
+  integrity sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==
+  dependencies:
+    utrie "^1.0.2"
+
 text-table@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
@@ -21601,6 +21628,13 @@ utils-merge@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=
+
+utrie@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/utrie/-/utrie-1.0.2.tgz#d42fe44de9bc0119c25de7f564a6ed1b2c87a645"
+  integrity sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==
+  dependencies:
+    base64-arraybuffer "^1.0.2"
 
 uuid-browser@^3.1.0:
   version "3.1.0"


### PR DESCRIPTION
Adds `.PNG` as an option when downloading a chart from the query builder, to make it easier to get data from Metabase into presentations or wherever you just need an image.

<img width="1392" alt="Screen Shot 2023-02-16 at 10 51 54 AM" src="https://user-images.githubusercontent.com/5248953/219417953-2862a42e-b7ba-402a-b461-ca266b91a16e.png">

When the .png option button is clicked we:
- Use [html2canvas](https://html2canvas.hertzen.com/) to grab the current state of the chart element and turn it into a canvas element.
- From there the library takes that canvas element and converts it into a data URI
- That gets attached to our download button as a `href` property, and we set the download title as the chart title + the current time.
- We simulate a click on the element to have the browser download it.

Here's a loom of it in action. https://www.loom.com/share/158a16243b744eacbd084ffadc03750a

In terms of moving this from pretty solid proof of concept to production ready we'd need:
- [ ] Test coverage
- [ ] Not hardcode `en` as the `.toLocaleString` option.
- [ ] PNG option icon
- [ ] There's an issue, probably due to my naive use of `useEffect` here where the image will download twice initially
- [ ] Unclear what'll happen if this gets added to dashboards, since I'm using `.dc-chart` as the element to grab. Something to watch out for as part of [this task](https://github.com/orgs/metabase/projects/50/views/1?pane=issue&itemId=20569411)

Closes #4701