### PR TITLE
Fix 28368: null parameters for implicit actions in dashboards

### DIFF
--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -480,14 +480,15 @@
 ;; TODO - param should be `card_id`, not `cardId` (fix here + on frontend at the same time)
 #_{:clj-kondo/ignore [:deprecated-var]}
 (api/defendpoint-schema POST "/:id/cards"
-  "Add a `Card` to a Dashboard."
+  "Add a `Card` or `Action` to a Dashboard."
   [id :as {{:keys [cardId parameter_mappings row col size_x size_y], :as dashboard-card} :body}]
   {cardId             (s/maybe su/IntGreaterThanZero)
    parameter_mappings (s/maybe [dashboard-card/ParamMapping])
    row                su/IntGreaterThanOrEqualToZero
    col                su/IntGreaterThanOrEqualToZero
    size_x             su/IntGreaterThanZero
-   size_y             su/IntGreaterThanZero}
+   size_y             su/IntGreaterThanZero
+   action_id          (s/maybe su/IntGreaterThanZero)}
   (api/check-not-archived (api/write-check Dashboard id))
   (when cardId
     (api/check-not-archived (api/read-check Card cardId)))

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -481,7 +481,7 @@
 #_{:clj-kondo/ignore [:deprecated-var]}
 (api/defendpoint-schema POST "/:id/cards"
   "Add a `Card` or `Action` to a Dashboard."
-  [id :as {{:keys [cardId parameter_mappings row col size_x size_y], :as dashboard-card} :body}]
+  [id :as {{:keys [cardId parameter_mappings row col size_x size_y action_id], :as dashboard-card} :body}]
   {cardId             (s/maybe su/IntGreaterThanZero)
    parameter_mappings (s/maybe [dashboard-card/ParamMapping])
    row                su/IntGreaterThanOrEqualToZero

--- a/src/metabase/models/action.clj
+++ b/src/metabase/models/action.clj
@@ -250,7 +250,7 @@
   "Hydrates action from DashboardCard."
   [dashcards]
   (let [actions-by-id (when-let [action-ids (seq (keep :action_id dashcards))]
-                        (m/index-by :id (select-actions (map :card dashcards) :id [:in action-ids])))]
+                        (m/index-by :id (select-actions nil :id [:in action-ids])))]
     (for [dashcard dashcards]
       (m/assoc-some dashcard :action (get actions-by-id (:action_id dashcard))))))
 

--- a/src/metabase/models/action.clj
+++ b/src/metabase/models/action.clj
@@ -247,7 +247,7 @@
 
 (mi/define-batched-hydration-method dashcard-action
   :dashcard/action
-  "Hydrates action from DashboardCard."
+  "Hydrates action from DashboardCards."
   [dashcards]
   (let [actions-by-id (when-let [action-ids (seq (keep :action_id dashcards))]
                         (m/index-by :id (select-actions nil :id [:in action-ids])))]

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -2440,14 +2440,19 @@
   (mt/test-drivers (mt/normal-drivers-with-feature :actions)
     (mt/with-actions-test-data-and-actions-enabled
       (doseq [action-type [:http :implicit :query]]
-        (mt/with-actions [{:keys [action-id model-id]} {:type action-type :visualization_settings {:hello true}}]
+        (mt/with-actions [{:keys [action-id]} {:type action-type :visualization_settings {:hello true}}]
           (testing (str "Creating dashcard with action: " action-type)
             (mt/with-temp* [Dashboard [{dashboard-id :id}]]
               (is (partial= {:visualization_settings {:label "Update"}
-                             :action_id action-id
-                             :card_id model-id}
+                             :action_id              action-id
+                             :card_id                nil}
                             (mt/user-http-request :crowberto :post 200 (format "dashboard/%s/cards" dashboard-id)
-                                                  {:size_x 1 :size_y 1 :row 1 :col 1 :cardId model-id :action_id action-id
+                                                  {:size_x                 1
+                                                   :size_y                 1
+                                                   :row                    1
+                                                   :col                    1
+                                                   :cardId                 nil
+                                                   :action_id              action-id
                                                    :visualization_settings {:label "Update"}})))
               (is (partial= {:ordered_cards [{:action {:visualization_settings {:hello true}
                                                        :type (name action-type)


### PR DESCRIPTION
This PR fixes #28368

Previously, hydrated implicit actions for dashcards have null parameters if the action's model isn't in another dashcard on the dashboard.

The fix is to remove the assumption that an dashcard with an action has `card_id` equal to the action's model id. This assumption was implicitly made by the BE, including in the tests. But the FE doesn't satisfy this assumption when the dashcard is created. Dashcards are created by calls to `POST /api/dashboard/%s/cards`, and when the dashcard has an action, the `card_id` is null in the request.

The problem went undetected on the BE because the tests for dashcard actions expect the card_id field for action dashcards on the POST /api/dashboard/:id/cards request to include the model id of the action. But the FE doesn't satisfy this assumption.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/28369)
<!-- Reviewable:end -->
