### PR TITLE
Create separate connection pools by connection type

### DIFF
--- a/src/metabase/driver/sql_jdbc/actions.clj
+++ b/src/metabase/driver/sql_jdbc/actions.clj
@@ -114,7 +114,7 @@
 (defn- do-with-jdbc-transaction [database-id f]
   (if *connection*
     (f *connection*)
-    (let [jdbc-spec (sql-jdbc.conn/db->pooled-connection-spec database-id)]
+    (let [jdbc-spec (sql-jdbc.conn/db+connection-type->pooled-connection-spec database-id ::sql-jdbc.conn/rw)]
       (with-open [conn (jdbc/get-connection jdbc-spec)]
         ;; execute inside of a transaction.
         (.setAutoCommit conn false)

--- a/src/metabase/driver/sql_jdbc/connection.clj
+++ b/src/metabase/driver/sql_jdbc/connection.clj
@@ -46,8 +46,9 @@
   driver/dispatch-on-initialized-driver
   :hierarchy #'driver/hierarchy)
 
-(defmethod connection-type+details->spec ::r
-  ;; For most drivers, the connection-type doesn't matter. We can use the same connection details.
+(defmethod connection-type+details->spec :default
+  ;; For most drivers, `connection-type` doesn't matter. Driver authors can implement `connection-details->spec` and use
+  ;; the same connection details for both read and writes.
   [driver _connection-type details-map]
   (connection-details->spec driver details-map))
 

--- a/src/metabase/driver/sql_jdbc/connection.clj
+++ b/src/metabase/driver/sql_jdbc/connection.clj
@@ -46,7 +46,7 @@
   driver/dispatch-on-initialized-driver
   :hierarchy #'driver/hierarchy)
 
-(defmethod connection-type+details->spec ::read
+(defmethod connection-type+details->spec ::r
   ;; For most drivers, the connection-type doesn't matter. We can use the same connection details.
   [driver _connection-type details-map]
   (connection-details->spec driver details-map))

--- a/src/metabase/driver/sql_jdbc/connection.clj
+++ b/src/metabase/driver/sql_jdbc/connection.clj
@@ -47,8 +47,8 @@
   :hierarchy #'driver/hierarchy)
 
 (defmethod connection-type+details->spec :default
-  ;; For most drivers, `connection-type` doesn't matter. Driver authors can implement `connection-details->spec` and use
-  ;; the same connection details for both read and writes.
+  ;; For most drivers, `connection-type` doesn't change the JDBC connection spec. Driver authors can implement
+  ;; `connection-details->spec` and use the same connection details for both read and write connections.
   [driver _connection-type details-map]
   (connection-details->spec driver details-map))
 
@@ -291,6 +291,8 @@
                     {:input (class db-or-id-or-spec)}))))
 
 (defn db->pooled-connection-spec
+  "Returns a JDBC connection spec that includes a cp30 `ComboPooledDataSource`.
+  Similar to [[db+connection-type->pooled-connection-spec]] but uses the `::r` connection type by default."
   [db-or-id-or-spec]
   (db+connection-type->pooled-connection-spec db-or-id-or-spec ::r))
 

--- a/src/metabase/driver/sql_jdbc/connection.clj
+++ b/src/metabase/driver/sql_jdbc/connection.clj
@@ -167,7 +167,6 @@
   database-id+connection-type->connection-pool
   (atom {}))
 
-;; TODO: this might need a connection-type too? or maybe it can be 1:1 with the database
 (defonce ^:private ^{:doc "A table (map of maps) of DB details hash values, keyed by Database `:id` and connection-type."}
   database-id+connection-type->jdbc-spec-hash
   (atom {}))

--- a/src/metabase/driver/sql_jdbc/execute.clj
+++ b/src/metabase/driver/sql_jdbc/execute.clj
@@ -526,7 +526,7 @@
   {:pre [(string? sql)]}
   (try
     (let [{:keys [details]} (qp.store/database)
-          jdbc-spec         (sql-jdbc.conn/connection-type+details->spec driver ::w details)]
+          jdbc-spec         (sql-jdbc.conn/connection-type+details->spec driver ::rw details)]
       ;; TODO -- should this be done in a transaction? Should we set the isolation level?
       (with-open [conn (jdbc/get-connection jdbc-spec)
                   stmt (statement-or-prepared-statement driver conn sql params nil)]

--- a/src/metabase/driver/sql_jdbc/execute.clj
+++ b/src/metabase/driver/sql_jdbc/execute.clj
@@ -526,7 +526,7 @@
   {:pre [(string? sql)]}
   (try
     (let [{:keys [details]} (qp.store/database)
-          jdbc-spec         (sql-jdbc.conn/connection-type+details->spec driver ::rw details)]
+          jdbc-spec         (sql-jdbc.conn/connection-type+details->spec driver ::sql-jdbc.conn/rw details)]
       ;; TODO -- should this be done in a transaction? Should we set the isolation level?
       (with-open [conn (jdbc/get-connection jdbc-spec)
                   stmt (statement-or-prepared-statement driver conn sql params nil)]

--- a/src/metabase/driver/sql_jdbc/execute.clj
+++ b/src/metabase/driver/sql_jdbc/execute.clj
@@ -526,7 +526,7 @@
   {:pre [(string? sql)]}
   (try
     (let [{:keys [details]} (qp.store/database)
-          jdbc-spec         (sql-jdbc.conn/connection-details->spec driver details)]
+          jdbc-spec         (sql-jdbc.conn/connection-type+details->spec driver ::w details)]
       ;; TODO -- should this be done in a transaction? Should we set the isolation level?
       (with-open [conn (jdbc/get-connection jdbc-spec)
                   stmt (statement-or-prepared-statement driver conn sql params nil)]

--- a/test/metabase/driver/sql_jdbc/connection_test.clj
+++ b/test/metabase/driver/sql_jdbc/connection_test.clj
@@ -111,7 +111,7 @@
   (mt/test-drivers (sql-jdbc.tu/sql-jdbc-drivers)
     (testing "db->pooled-connection-spec marks a connection pool invalid if the db details map changes\n"
       (let [db                       (mt/db)
-            connection-type          ::sql-jdbc.conn/write
+            connection-type          ::sql-jdbc.conn/r
             hash-change-called-times (atom 0)
             hash-change-fn           (fn [db-id _connection-type]
                                        (is (= (u/the-id db) db-id))
@@ -176,6 +176,6 @@
                        (:sslrootcert (#'sql-jdbc.conn/connection-details->spec :postgres
                                                                                (:details db))))
             "Secrets not loaded for db connections")
-        (is (= (#'sql-jdbc.conn/jdbc-spec-hash db ::sql-jdbc.conn/write)
-               (#'sql-jdbc.conn/jdbc-spec-hash db ::sql-jdbc.conn/write))
+        (is (= (#'sql-jdbc.conn/jdbc-spec-hash db ::sql-jdbc.conn/r)
+               (#'sql-jdbc.conn/jdbc-spec-hash db ::sql-jdbc.conn/r))
             "Same db produced different hashes due to secrets")))))

--- a/test/metabase/driver/sql_jdbc/connection_test.clj
+++ b/test/metabase/driver/sql_jdbc/connection_test.clj
@@ -52,17 +52,17 @@
             (mt/with-temp Database [database {:engine :h2, :details connection-details}]
               (testing "database id is not in our connection map initially"
                 ;; deref'ing a var to get the atom. looks weird
-                (is (empty? (get @@#'sql-jdbc.conn/database-id+connection-type->connection-pool
+                (is (empty? (get @@#'sql-jdbc.conn/database-id->connection-type->connection-pool
                                  (u/id database)))))
               (testing "when getting a pooled connection it is now in our connection map"
                 (let [stored-spec (sql-jdbc.conn/db->pooled-connection-spec database)
                       birds       (jdbc/query stored-spec ["SELECT * FROM birds"])]
                   (is (seq birds))
-                  (is (seq (get @@#'sql-jdbc.conn/database-id+connection-type->connection-pool
+                  (is (seq (get @@#'sql-jdbc.conn/database-id->connection-type->connection-pool
                                 (u/id database))))))
               (testing "and is no longer in our connection map after cleanup"
                 (#'sql-jdbc.conn/set-pool! (u/id database) ::sql-jdbc.conn/write nil nil)
-                (is (empty? (get @@#'sql-jdbc.conn/database-id+connection-type->connection-pool
+                (is (empty? (get @@#'sql-jdbc.conn/database-id->connection-type->connection-pool
                                  (u/id database)))))
               (testing "the pool has been destroyed"
                 (is @destroyed?)))))))))
@@ -122,7 +122,7 @@
           ;; a little bit hacky to redefine the log fn, but it's the most direct way to test
           (with-redefs [sql-jdbc.conn/log-jdbc-spec-hash-change-msg! hash-change-fn]
             (let [pool-spec-1 (sql-jdbc.conn/db+connection-type->pooled-connection-spec db connection-type)
-                  db-hash-1   (get-in @@#'sql-jdbc.conn/database-id+connection-type->jdbc-spec-hash [(u/the-id db) connection-type])]
+                  db-hash-1   (get-in @@#'sql-jdbc.conn/database-id->connection-type->jdbc-spec-hash [(u/the-id db) connection-type])]
               (testing "hash value calculated correctly for new pooled conn"
                 (is (some? pool-spec-1))
                 (is (integer? db-hash-1))
@@ -136,7 +136,7 @@
                   (let [ ;; this call should result in the connection pool becoming invalidated, and the new hash value
                         ;; being stored based upon these updated details
                         pool-spec-2  (sql-jdbc.conn/db+connection-type->pooled-connection-spec db-perturbed connection-type)
-                        db-hash-2    (get-in @@#'sql-jdbc.conn/database-id+connection-type->jdbc-spec-hash [(u/the-id db) connection-type])]
+                        db-hash-2    (get-in @@#'sql-jdbc.conn/database-id->connection-type->jdbc-spec-hash [(u/the-id db) connection-type])]
                     ;; to throw a wrench into things, kick off a sync of the original db (unperturbed); this
                     ;; simulates a long running sync that began before the perturbed details were saved to the app DB
                     ;; the sync steps SHOULD NOT invalidate the connection pool, because doing so could cause a seesaw

--- a/test/metabase/driver/sql_jdbc/connection_test.clj
+++ b/test/metabase/driver/sql_jdbc/connection_test.clj
@@ -61,7 +61,8 @@
                   (is (seq (get @@#'sql-jdbc.conn/database-id->connection-type->connection-pool
                                 (u/id database))))))
               (testing "and is no longer in our connection map after cleanup"
-                (#'sql-jdbc.conn/set-pool! (u/id database) ::sql-jdbc.conn/write nil nil)
+                (doseq [connection-type [::sql-jdbc.conn/r ::sql-jdbc.conn/rw]]
+                  (#'sql-jdbc.conn/invalidate-pool-for-db+connection-type! database connection-type))
                 (is (empty? (get @@#'sql-jdbc.conn/database-id->connection-type->connection-pool
                                  (u/id database)))))
               (testing "the pool has been destroyed"


### PR DESCRIPTION
This is a blocker to fixing https://github.com/metabase/metabase/issues/28189, as https://github.com/metabase/metabase/pull/28212 is dependent on this.

This PR breaks the assumption that there is at most one connection pool per database. It allows us to open multiple connection pools per database. This is handy for maintaining a read-only connection pool and read/write connection pool per database for example.

### Why have multiple connection pools per database?

We want to allow actions to be run on H2, which means we need to remove the `ACCESS_MODE_DATA=r` option from connection strings. However, this is the only thing stopping transactions from being read-only on H2, as there's no way to change the connection or transaction to read-only or not after the connection is created. So we need to have different connections for writing to a database and reading from a database.

### Highlights

When `notify-database-updated` is called for a database, both read and read/write connections are [invalidated](https://github.com/metabase/metabase/pull/28377/files#diff-52d394f85d35221cbf73eadbb648f468e697bea6c7c4438eed2d702740821a56R208).

I updated the default sql-jdbc implementation of `driver/execute-write-query!` to call `(sql-jdbc.conn/connection-type+details->spec driver :metabase.sql-jdbc.connection/r details)` instead of `(sql-jdbc.conn/connection-details->spec driver details)`.

Similarly, I updated `metabase.driver.sql-jdbc.actions/do-with-jdbc-transaction` to call `(sql-jdbc.conn/db+connection-type->pooled-connection-spec database-id ::rw)` instead of `(sql-jdbc.conn/db->pooled-connection-spec database-id)`.