### PR TITLE
add add question button to empty dashboard

### DIFF
--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.jsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.jsx
@@ -91,6 +91,7 @@ class Dashboard extends Component {
     }).isRequired,
     toggleSidebar: PropTypes.func.isRequired,
     closeSidebar: PropTypes.func.isRequired,
+    closeNavbar: PropTypes.func.isRequired,
     embedOptions: PropTypes.object,
   };
 
@@ -205,11 +206,7 @@ class Dashboard extends Component {
 
   onAddQuestion = () => {
     this.setEditing(true);
-    if (this.props.sidebar.name !== SIDEBAR_NAME.addQuestion) {
-      this.props.toggleSidebar(SIDEBAR_NAME.addQuestion);
-    } else {
-      this.props.closeSidebar();
-    }
+    this.props.toggleSidebar(SIDEBAR_NAME.addQuestion);
   };
 
   render() {
@@ -327,6 +324,7 @@ class Dashboard extends Component {
                     <DashboardEmptyState
                       isNightMode={shouldRenderAsNightMode}
                       addQuestion={this.onAddQuestion}
+                      closeNavbar={this.props.closeNavbar}
                     />
                   )}
                 </CardsContainer>

--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.jsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.jsx
@@ -204,13 +204,8 @@ class Dashboard extends Component {
   };
 
   onAddQuestion = () => {
-    if (this.props.sidebar.name !== SIDEBAR_NAME.addQuestion) {
-      return () => {
-        this.setEditing(true);
-        this.props.toggleSidebar(SIDEBAR_NAME.addQuestion);
-      };
-    }
-    return undefined;
+    this.setEditing(true);
+    this.props.toggleSidebar(SIDEBAR_NAME.addQuestion);
   };
 
   render() {

--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.jsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.jsx
@@ -205,7 +205,11 @@ class Dashboard extends Component {
 
   onAddQuestion = () => {
     this.setEditing(true);
-    this.props.toggleSidebar(SIDEBAR_NAME.addQuestion);
+    if (this.props.sidebar.name !== SIDEBAR_NAME.addQuestion) {
+      this.props.toggleSidebar(SIDEBAR_NAME.addQuestion);
+    } else {
+      this.props.closeSidebar();
+    }
   };
 
   render() {

--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.jsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.jsx
@@ -13,6 +13,8 @@ import { getValuePopulatedParameters } from "metabase-lib/parameters/utils/param
 import DashboardControls from "../../hoc/DashboardControls";
 import { DashboardSidebars } from "../DashboardSidebars";
 import DashboardGrid from "../DashboardGrid";
+import { SIDEBAR_NAME } from "../../constants";
+
 import {
   CardsContainer,
   DashboardStyled,
@@ -87,6 +89,7 @@ class Dashboard extends Component {
       name: PropTypes.string,
       props: PropTypes.object,
     }).isRequired,
+    toggleSidebar: PropTypes.func.isRequired,
     closeSidebar: PropTypes.func.isRequired,
     embedOptions: PropTypes.object,
   };
@@ -198,6 +201,16 @@ class Dashboard extends Component {
 
   onSharingClick = () => {
     this.props.setSharing(true);
+  };
+
+  onAddQuestion = () => {
+    if (this.props.sidebar.name !== SIDEBAR_NAME.addQuestion) {
+      return () => {
+        this.setEditing(true);
+        this.props.toggleSidebar(SIDEBAR_NAME.addQuestion);
+      };
+    }
+    return undefined;
   };
 
   render() {
@@ -314,6 +327,7 @@ class Dashboard extends Component {
                   ) : (
                     <DashboardEmptyState
                       isNightMode={shouldRenderAsNightMode}
+                      addQuestion={this.onAddQuestion}
                     />
                   )}
                 </CardsContainer>

--- a/frontend/src/metabase/dashboard/components/Dashboard/DashboardEmptyState/DashboardEmptyState.jsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/DashboardEmptyState/DashboardEmptyState.jsx
@@ -2,6 +2,8 @@ import React from "react";
 import PropTypes from "prop-types";
 import { t } from "ttag";
 
+import Button from "metabase/core/components/Button";
+import Link from "metabase/core/components/Link";
 import EmptyState from "metabase/components/EmptyState";
 import { Container } from "./DashboardEmptyState.styled";
 
@@ -17,9 +19,17 @@ const DashboardEmptyState = ({ isNightMode, addQuestion }) => (
     <EmptyState
       illustrationElement={questionCircle}
       title={t`This dashboard is looking empty.`}
-      message={t`Add a question to start making it useful!`}
-      action={t`Add a question`}
-      onActionClick={addQuestion}
+      message={
+        <>
+          <Button onlyText onClick={addQuestion}>
+            {t`Add a saved question`}
+          </Button>
+          {t`, or `}
+          <Link to="/question/new" className="text-bold text-brand">
+            {t`ask a new one`}
+          </Link>
+        </>
+      }
     />
   </Container>
 );

--- a/frontend/src/metabase/dashboard/components/Dashboard/DashboardEmptyState/DashboardEmptyState.jsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/DashboardEmptyState/DashboardEmptyState.jsx
@@ -3,9 +3,8 @@ import PropTypes from "prop-types";
 import { t } from "ttag";
 
 import Button from "metabase/core/components/Button";
-import Link from "metabase/core/components/Link";
 import EmptyState from "metabase/components/EmptyState";
-import { Container } from "./DashboardEmptyState.styled";
+import { Container, BrandLink } from "./DashboardEmptyState.styled";
 
 const propTypes = {
   isNightMode: PropTypes.bool.isRequired,
@@ -26,13 +25,13 @@ const DashboardEmptyState = ({ isNightMode, addQuestion, closeNavbar }) => (
             {t`Add a saved question`}
           </Button>
           {t`, or `}
-          <Link
+          <BrandLink
             to="/question/new"
             className="text-bold text-brand"
             onClick={closeNavbar}
           >
             {t`ask a new one`}
-          </Link>
+          </BrandLink>
         </>
       }
     />

--- a/frontend/src/metabase/dashboard/components/Dashboard/DashboardEmptyState/DashboardEmptyState.jsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/DashboardEmptyState/DashboardEmptyState.jsx
@@ -7,16 +7,19 @@ import { Container } from "./DashboardEmptyState.styled";
 
 const propTypes = {
   isNightMode: PropTypes.bool.isRequired,
+  addQuestion: PropTypes.func.isRequired,
 };
 
 const questionCircle = <span className="QuestionCircle">?</span>;
 
-const DashboardEmptyState = ({ isNightMode }) => (
+const DashboardEmptyState = ({ isNightMode, addQuestion }) => (
   <Container isNightMode={isNightMode}>
     <EmptyState
       illustrationElement={questionCircle}
       title={t`This dashboard is looking empty.`}
       message={t`Add a question to start making it useful!`}
+      action={t`Add a question`}
+      onActionClick={addQuestion}
     />
   </Container>
 );

--- a/frontend/src/metabase/dashboard/components/Dashboard/DashboardEmptyState/DashboardEmptyState.jsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/DashboardEmptyState/DashboardEmptyState.jsx
@@ -10,11 +10,12 @@ import { Container } from "./DashboardEmptyState.styled";
 const propTypes = {
   isNightMode: PropTypes.bool.isRequired,
   addQuestion: PropTypes.func.isRequired,
+  closeNavbar: PropTypes.func.isRequired,
 };
 
 const questionCircle = <span className="QuestionCircle">?</span>;
 
-const DashboardEmptyState = ({ isNightMode, addQuestion }) => (
+const DashboardEmptyState = ({ isNightMode, addQuestion, closeNavbar }) => (
   <Container isNightMode={isNightMode}>
     <EmptyState
       illustrationElement={questionCircle}
@@ -25,7 +26,11 @@ const DashboardEmptyState = ({ isNightMode, addQuestion }) => (
             {t`Add a saved question`}
           </Button>
           {t`, or `}
-          <Link to="/question/new" className="text-bold text-brand">
+          <Link
+            to="/question/new"
+            className="text-bold text-brand"
+            onClick={closeNavbar}
+          >
             {t`ask a new one`}
           </Link>
         </>

--- a/frontend/src/metabase/dashboard/components/Dashboard/DashboardEmptyState/DashboardEmptyState.styled.jsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/DashboardEmptyState/DashboardEmptyState.styled.jsx
@@ -1,9 +1,16 @@
 import styled from "@emotion/styled";
-
 import { space } from "metabase/styled-components/theme";
+import { color } from "metabase/lib/colors";
+
+import Link from "metabase/core/components/Link";
 
 export const Container = styled.div`
   box-sizing: border-box;
   color: ${({ isNightMode }) => (isNightMode ? "white" : "inherit")};
   margin-top: ${space(4)};
+`;
+
+export const BrandLink = styled(Link)`
+  color: ${color("brand")};
+  font-weight: bold;
 `;

--- a/frontend/src/metabase/dashboard/components/Dashboard/DashboardEmptyState/DashboardEmptyState.unit.spec.js
+++ b/frontend/src/metabase/dashboard/components/Dashboard/DashboardEmptyState/DashboardEmptyState.unit.spec.js
@@ -5,14 +5,19 @@ import DashboardEmptyState from "./DashboardEmptyState";
 
 describe("DashboardEmptyState", () => {
   it("renders", () => {
-    render(<DashboardEmptyState isNightMode={false} />);
+    render(
+      <DashboardEmptyState
+        isNightMode={false}
+        addQuestion={jest.fn()}
+        closeNavbar={jest.fn()}
+      />,
+    );
 
     expect(screen.getByText("?")).toBeInTheDocument();
     expect(
       screen.getByText("This dashboard is looking empty."),
     ).toBeInTheDocument();
-    expect(
-      screen.getByText("Add a question to start making it useful!"),
-    ).toBeInTheDocument();
+    expect(screen.getByText("Add a saved question")).toBeInTheDocument();
+    expect(screen.getByText("ask a new one")).toBeInTheDocument();
   });
 });

--- a/frontend/src/metabase/dashboard/containers/DashboardApp.jsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardApp.jsx
@@ -18,7 +18,7 @@ import { useLoadingTimer } from "metabase/hooks/use-loading-timer";
 import { useWebNotification } from "metabase/hooks/use-web-notification";
 
 import { fetchDatabaseMetadata } from "metabase/redux/metadata";
-import { getIsNavbarOpen, setErrorPage } from "metabase/redux/app";
+import { getIsNavbarOpen, closeNavbar, setErrorPage } from "metabase/redux/app";
 
 import { getDatabases, getMetadata } from "metabase/selectors/metadata";
 import {
@@ -100,6 +100,7 @@ const mapStateToProps = (state, props) => {
 
 const mapDispatchToProps = {
   ...dashboardActions,
+  closeNavbar,
   archiveDashboard: id => Dashboards.actions.setArchived({ id }, true),
   fetchDatabaseMetadata,
   setErrorPage,


### PR DESCRIPTION
slack discussion: https://metaboat.slack.com/archives/C01LQQ2UW03/p1676569653369959

### Description

- make it easier to add a first question to a dashboard by giving users an option to open the question sidebar or create a new question

![newDashHelpers](https://user-images.githubusercontent.com/30528226/219463507-472d2d43-bdae-459d-a177-d1faa21812b9.gif)


### How to verify

- make a new dashboard
- click the "add a question" button or the "create a question" link