### PR TITLE
Add action parameter mapping explainer text

### DIFF
--- a/frontend/src/metabase/actions/components/ActionViz/ActionDashcardSettings.styled.tsx
+++ b/frontend/src/metabase/actions/components/ActionViz/ActionDashcardSettings.styled.tsx
@@ -14,6 +14,7 @@ export const ActionSettingsHeader = styled.h2`
   font-size: 1.25rem;
   padding-bottom: ${space(1)};
   padding-left: ${space(3)};
+  padding-right: ${space(3)};
 `;
 
 // make strolling nicer by fading out the top and bottom of the column
@@ -51,6 +52,7 @@ export const ActionSettingsLeft = styled.div`
 `;
 
 export const ActionSettingsRight = styled.div`
+  max-width: 30rem;
   display: flex;
   flex: 1;
   flex-direction: column;
@@ -76,4 +78,11 @@ export const ModalActions = styled.div`
   gap: 1rem;
   padding: 1rem;
   border-top: 1px solid ${color("border")};
+`;
+
+export const ExplainerText = styled.p`
+  margin-left: ${space(3)};
+  margin-right: ${space(3)};
+
+  color: ${color("text-medium")};
 `;

--- a/frontend/src/metabase/actions/components/ActionViz/ActionDashcardSettings.styled.tsx
+++ b/frontend/src/metabase/actions/components/ActionViz/ActionDashcardSettings.styled.tsx
@@ -3,6 +3,8 @@ import styled from "@emotion/styled";
 import { space } from "metabase/styled-components/theme";
 import { color } from "metabase/lib/colors";
 
+import Link from "metabase/core/components/Link";
+
 export const ActionSettingsWrapper = styled.div`
   display: flex;
   height: 80vh;
@@ -85,4 +87,9 @@ export const ExplainerText = styled.p`
   margin-right: ${space(3)};
 
   color: ${color("text-medium")};
+`;
+
+export const BrandLinkWithLeftMargin = styled(Link)`
+  margin-left: ${space(1)};
+  color: ${color("brand")};
 `;

--- a/frontend/src/metabase/actions/components/ActionViz/ActionDashcardSettings.tsx
+++ b/frontend/src/metabase/actions/components/ActionViz/ActionDashcardSettings.tsx
@@ -71,7 +71,7 @@ export function ActionDashcardSettings({
                 <ExplainerText>
                   {t`You can either ask users to enter values, or use the value of a dashboard filter.`}
                   <Link
-                    to="/https://www.metabase.com/learn/dashboards/linking-filters" /* FIXME */
+                    to="https://www.metabase.com/docs/actions/custom"
                     className="text-brand ml1"
                   >
                     {t`Learn more.`}

--- a/frontend/src/metabase/actions/components/ActionViz/ActionDashcardSettings.tsx
+++ b/frontend/src/metabase/actions/components/ActionViz/ActionDashcardSettings.tsx
@@ -13,7 +13,6 @@ import Button from "metabase/core/components/Button";
 import { ConnectedActionPicker } from "metabase/actions/containers/ActionPicker/ActionPicker";
 import { setActionForDashcard } from "metabase/dashboard/actions";
 import EmptyState from "metabase/components/EmptyState";
-import Link from "metabase/core/components/Link";
 import { ConnectedActionParameterMappingForm } from "./ActionParameterMapper";
 
 import {
@@ -24,6 +23,7 @@ import {
   ActionSettingsRight,
   ModalActions,
   ExplainerText,
+  BrandLinkWithLeftMargin,
 } from "./ActionDashcardSettings.styled";
 
 const mapDispatchToProps = {
@@ -70,12 +70,9 @@ export function ActionDashcardSettings({
                 </ActionSettingsHeader>
                 <ExplainerText>
                   {t`You can either ask users to enter values, or use the value of a dashboard filter.`}
-                  <Link
-                    to="https://www.metabase.com/docs/actions/custom"
-                    className="text-brand ml1"
-                  >
+                  <BrandLinkWithLeftMargin to="https://www.metabase.com/docs/actions/custom">
                     {t`Learn more.`}
-                  </Link>
+                  </BrandLinkWithLeftMargin>
                 </ExplainerText>
               </>
             )}

--- a/frontend/src/metabase/actions/components/ActionViz/ActionDashcardSettings.tsx
+++ b/frontend/src/metabase/actions/components/ActionViz/ActionDashcardSettings.tsx
@@ -13,6 +13,7 @@ import Button from "metabase/core/components/Button";
 import { ConnectedActionPicker } from "metabase/actions/containers/ActionPicker/ActionPicker";
 import { setActionForDashcard } from "metabase/dashboard/actions";
 import EmptyState from "metabase/components/EmptyState";
+import Link from "metabase/core/components/Link";
 import { ConnectedActionParameterMappingForm } from "./ActionParameterMapper";
 
 import {
@@ -22,6 +23,7 @@ import {
   ActionSettingsLeft,
   ActionSettingsRight,
   ModalActions,
+  ExplainerText,
 } from "./ActionDashcardSettings.styled";
 
 const mapDispatchToProps = {
@@ -50,6 +52,8 @@ export function ActionDashcardSettings({
     setActionForDashcard(dashcard, newAction);
   };
 
+  const hasParameters = !!action?.parameters?.length;
+
   return (
     <ActionSettingsWrapper>
       <ActionSettingsLeft>
@@ -59,7 +63,22 @@ export function ActionDashcardSettings({
       <ActionSettingsRight>
         {action ? (
           <>
-            <ActionSettingsHeader>{action.name}</ActionSettingsHeader>
+            {hasParameters && (
+              <>
+                <ActionSettingsHeader>
+                  {t`Where should the values for '${action.name}' come from?`}
+                </ActionSettingsHeader>
+                <ExplainerText>
+                  {t`You can either ask users to enter values, or use the value of a dashboard filter.`}
+                  <Link
+                    to="/https://www.metabase.com/learn/dashboards/linking-filters" /* FIXME */
+                    className="text-brand ml1"
+                  >
+                    {t`Learn more.`}
+                  </Link>
+                </ExplainerText>
+              </>
+            )}
             <ParameterMapperContainer>
               <ConnectedActionParameterMappingForm
                 dashcard={dashcard}

--- a/frontend/src/metabase/actions/components/ActionViz/ActionDashcardSettings.unit.spec.tsx
+++ b/frontend/src/metabase/actions/components/ActionViz/ActionDashcardSettings.unit.spec.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import userEvent from "@testing-library/user-event";
 import nock from "nock";
-import { renderWithProviders, screen, waitFor } from "__support__/ui";
+import { renderWithProviders, screen } from "__support__/ui";
 
 import {
   setupActionEndpoints,
@@ -149,9 +149,10 @@ describe("ActionViz > ActionDashcardSettings", () => {
     });
 
     // action name should be visible in library and parameter mapper
-    await waitFor(() =>
-      expect(screen.getAllByText("Action Trois")).toHaveLength(2),
-    );
+    expect(await screen.findByText("Action Trois")).toBeInTheDocument();
+    expect(
+      await screen.findByText(/the values for 'Action Trois'/i),
+    ).toBeInTheDocument();
   });
 
   it("shows parameters for an action", async () => {

--- a/frontend/src/metabase/actions/components/ActionViz/ActionParameterMapper.styled.tsx
+++ b/frontend/src/metabase/actions/components/ActionViz/ActionParameterMapper.styled.tsx
@@ -3,11 +3,6 @@ import styled from "@emotion/styled";
 import { space } from "metabase/styled-components/theme";
 import { color } from "metabase/lib/colors";
 
-export const ParameterMapperContainer = styled.div`
-  min-width: 15rem;
-  max-width: 25rem;
-`;
-
 export const ParameterFormSection = styled.div`
   margin-top: ${space(2)};
 `;

--- a/frontend/src/metabase/actions/components/ActionViz/ActionParameterMapper.tsx
+++ b/frontend/src/metabase/actions/components/ActionViz/ActionParameterMapper.tsx
@@ -23,7 +23,6 @@ import EmptyState from "metabase/components/EmptyState";
 import type Question from "metabase-lib/Question";
 
 import {
-  ParameterMapperContainer,
   ParameterFormSection,
   ParameterFormLabel,
 } from "./ActionParameterMapper.styled";
@@ -83,7 +82,7 @@ export const ActionParameterMappingForm = ({
   );
 
   return (
-    <ParameterMapperContainer>
+    <div>
       {actionParameters.map((actionParam: WritebackParameter) => (
         <ParameterFormSection key={actionParam.id}>
           <ParameterFormLabel>
@@ -108,7 +107,7 @@ export const ActionParameterMappingForm = ({
       {actionParameters.length === 0 && (
         <EmptyState message={t`This action has no parameters to map`} />
       )}
-    </ParameterMapperContainer>
+    </div>
   );
 };
 


### PR DESCRIPTION
[Figma design](https://www.figma.com/file/nU3bpcpraxNgY9QOvS23gI/Add-context-to-action-parameters?node-id=0%3A1&t=ydWrQXSV7l8PHkDx-0)
[Slack discussion](https://metaboat.slack.com/archives/C04FG88HL95/p1676580936869439)

### Description

Adds some explanatory text to the action parameters mapper to make it less confusing.

![Screen Shot 2023-02-16 at 3 26 25 PM](https://user-images.githubusercontent.com/30528226/219501156-abfc47c1-df02-4896-a03d-354d60cd15a0.png)

### How to verify

1. add an action to a dashboard
2. in the action selection modal, select an action with parameter, and see some nice, helpful text with it!
