### PR TITLE
[CI] Optimize CodeQL so it doesn't run two times per commit

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,6 +1,11 @@
 name: "CodeQL"
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - 'master'
+      - 'release-**'
+  pull_request:
 
 jobs:
   analyze:


### PR DESCRIPTION
For whatever reason, this workflow was never optimized to run for push only on `master` and the release branches.
The result was that it was running two times per every single commit ever.

Example:
![image](https://user-images.githubusercontent.com/31325167/219501460-c7001d80-79f3-492c-b313-5448b83e4646.png)

It ran approximately 67k times so far with the average duration of 4m30s. That's more than 200 days!
