### PR TITLE
[E2E] Fix `embedding-native` flake

### DIFF
--- a/frontend/test/metabase/scenarios/embedding/embedding-native.cy.spec.js
+++ b/frontend/test/metabase/scenarios/embedding/embedding-native.cy.spec.js
@@ -82,8 +82,9 @@ describe("scenarios > embedding > native questions", () => {
 
       // State: is not KS
       filterWidget().contains("State").click();
-      cy.findByPlaceholderText("Search the list").type("KS");
-      cy.findByTestId("KS-filter-value").click();
+      cy.findByPlaceholderText("Search the list").type("KS{enter}");
+      cy.findAllByTestId(/-filter-value$/).should("have.length", 1);
+      cy.findByTestId("KS-filter-value").should("be.visible").click();
       cy.button("Add filter").click();
 
       cy.findByText("Logan Weber").should("not.exist");

--- a/frontend/test/metabase/scenarios/embedding/shared/embedding-native.js
+++ b/frontend/test/metabase/scenarios/embedding/shared/embedding-native.js
@@ -16,7 +16,7 @@ WHERE true
 `;
 
 export const questionDetails = {
-  name: "Native Quesiton With Multiple Filters - Embedding Test",
+  name: "Native Question With Multiple Filters - Embedding Test",
   description: "FooBar",
   native: {
     "template-tags": {


### PR DESCRIPTION
The example of the failed run:
https://www.deploysentinel.com/ci/runs/63ee8ef6ff2076a2d808438b

Cypress tries to click on a detached element.
This PR will give it some more time while also making sure that the applied filter is the only one in the list.