### PR TITLE
Fix syntax in rerun workflows logic 🤦‍♂️ 

### DIFF
--- a/.github/workflows/rerun-workflows.yml
+++ b/.github/workflows/rerun-workflows.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   rerun-on-failure:
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion }} == 'failure'
+    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
     steps:
       - uses: actions/github-script@v6
         with:


### PR DESCRIPTION
Ever since I introduced this workflow I was wondering why do we get so many errors when trying to rerun failed workflows.

The example:
https://github.com/metabase/metabase/actions/runs/4201852080

```
[rerun-on-failure](https://github.com/metabase/metabase/actions/runs/4201852080/jobs/7289293568#step:2:51)
Unhandled error: HttpError: This workflow run cannot be retried
```

Turns out I missed a logic error in a syntax. Syntax itself is still correct according to the schema. Hence, why this workflow was able to run at all.

This PR fixes this.