### PR TITLE
Fix form field alignment for checkboxes

### DIFF
--- a/frontend/src/metabase/core/components/FormField/FormField.styled.tsx
+++ b/frontend/src/metabase/core/components/FormField/FormField.styled.tsx
@@ -72,13 +72,16 @@ export const FieldInfoLabel = styled.div`
 `;
 
 export interface FieldRootProps {
+  alignment: FieldAlignment;
   orientation: FieldOrientation;
 }
 
 export const FieldRoot = styled.div<FieldRootProps>`
   display: ${props => props.orientation === "horizontal" && "flex"};
   justify-content: ${props =>
-    props.orientation === "horizontal" && "space-between"};
+    props.alignment === "end" &&
+    props.orientation === "horizontal" &&
+    "space-between"};
   margin-bottom: 1.25rem;
 
   &:focus-within {

--- a/frontend/src/metabase/core/components/FormField/FormField.tsx
+++ b/frontend/src/metabase/core/components/FormField/FormField.tsx
@@ -45,7 +45,12 @@ const FormField = forwardRef(function FormField(
   const hasError = Boolean(error);
 
   return (
-    <FieldRoot {...props} ref={ref} orientation={orientation}>
+    <FieldRoot
+      {...props}
+      ref={ref}
+      alignment={alignment}
+      orientation={orientation}
+    >
       {alignment === "start" && children}
       {(title || description) && (
         <FieldCaption alignment={alignment} orientation={orientation}>


### PR DESCRIPTION
Fixes the issue mentioned in https://github.com/metabase/metabase/pull/28380

How to verify:
- `Checkbox` on the login page looks correct, e.g. the label is aligned to the left
- `Toggle` on the database details page looks correct, e.g. the toggle is aligned to the right

<img width="574" alt="Screenshot 2023-02-17 at 13 15 04" src="https://user-images.githubusercontent.com/8542534/219635834-b1493ff8-e092-4011-ba30-676aa011fa39.png">
<img width="664" alt="Screenshot 2023-02-17 at 13 15 16" src="https://user-images.githubusercontent.com/8542534/219635843-ad2ce4f7-06af-48bc-8fa6-bab014a1de5b.png">
