### PR TITLE
Add explanation text to the action editor

### DIFF
--- a/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/FormCreator.styled.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/FormCreator.styled.tsx
@@ -4,12 +4,17 @@ import Icon from "metabase/components/Icon";
 import { color, lighten } from "metabase/lib/colors";
 import { space } from "metabase/styled-components/theme";
 
-export const FormCreatorWrapper = styled.div`
+export const FormContainer = styled.div`
   flex: 1 1 0;
+  margin: 1rem 1.5rem;
   transition: flex 500ms ease-in-out;
-  padding: ${space(3)};
   background-color: ${color("white")};
-  overflow-y: auto;
+`;
+
+export const InfoText = styled.span`
+  display: block;
+  color: ${color("text-medium")};
+  margin-bottom: 2rem;
 `;
 
 export const FieldSettingsButtonsContainer = styled.div`

--- a/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/FormCreator.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/FormCreator.tsx
@@ -6,6 +6,8 @@ import ExternalLink from "metabase/core/components/ExternalLink";
 import { ActionForm } from "metabase/actions/components/ActionForm";
 import SidebarContent from "metabase/query_builder/components/SidebarContent";
 
+import MetabaseSettings from "metabase/lib/settings";
+
 import type { ActionFormSettings, Parameter } from "metabase-types/api";
 
 import { getDefaultFormSettings, sortActionParams } from "../../../utils";
@@ -61,7 +63,7 @@ function FormCreator({
   const docsLink = (
     <ExternalLink
       key="learn-more"
-      href="https://metabase.com"
+      href={MetabaseSettings.docsUrl("actions/custom")}
     >{t`Learn more`}</ExternalLink>
   );
 

--- a/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/FormCreator.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/FormCreator.tsx
@@ -1,7 +1,10 @@
 import React, { useState, useEffect, useMemo } from "react";
+import { jt, t } from "ttag";
 import _ from "underscore";
 
+import ExternalLink from "metabase/core/components/ExternalLink";
 import { ActionForm } from "metabase/actions/components/ActionForm";
+import SidebarContent from "metabase/query_builder/components/SidebarContent";
 
 import type { ActionFormSettings, Parameter } from "metabase-types/api";
 
@@ -10,7 +13,7 @@ import { addMissingSettings } from "../utils";
 import { hasNewParams } from "./utils";
 
 import { EmptyFormPlaceholder } from "./EmptyFormPlaceholder";
-import { FormCreatorWrapper } from "./FormCreator.styled";
+import { FormContainer, InfoText } from "./FormCreator.styled";
 
 function FormCreator({
   params,
@@ -47,23 +50,37 @@ function FormCreator({
 
   if (!sortedParams.length) {
     return (
-      <FormCreatorWrapper>
-        <EmptyFormPlaceholder onExampleClick={onExampleClick} />
-      </FormCreatorWrapper>
+      <SidebarContent title={t`Action parameters`}>
+        <FormContainer>
+          <EmptyFormPlaceholder onExampleClick={onExampleClick} />
+        </FormContainer>
+      </SidebarContent>
     );
   }
 
+  const docsLink = (
+    <ExternalLink
+      key="learn-more"
+      href="https://metabase.com"
+    >{t`Learn more`}</ExternalLink>
+  );
+
   return (
-    <FormCreatorWrapper>
-      <ActionForm
-        parameters={sortedParams}
-        isEditable={isEditable}
-        onClose={_.noop}
-        onSubmit={_.noop}
-        formSettings={formSettings}
-        setFormSettings={setFormSettings}
-      />
-    </FormCreatorWrapper>
+    <SidebarContent title={t`Action parameters`}>
+      <FormContainer>
+        <InfoText>
+          {jt`Configure your parameters' types and properties here. The values for these parameters can come from user input, or from a dashboard filter. ${docsLink}`}
+        </InfoText>
+        <ActionForm
+          parameters={sortedParams}
+          isEditable={isEditable}
+          onClose={_.noop}
+          onSubmit={_.noop}
+          formSettings={formSettings}
+          setFormSettings={setFormSettings}
+        />
+      </FormContainer>
+    </SidebarContent>
   );
 }
 


### PR DESCRIPTION
Epic #27581

Just adding a small little text that should help navigate through the action editor.

> **Warning**
> Still need an actual link for the "Learn more"

### How to verify

1. Go to `/model/:id/details/actions`
2. Click "New action" / open existing action in the native editor
3. Ensure you can see the next as on the screenshot below

### Demo

<img width="1332" alt="CleanShot 2023-02-17 at 13 42 22@2x" src="https://user-images.githubusercontent.com/17258145/219671801-fa9ff91b-e921-429d-9215-6e75d4a302e1.png">

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/28406)
<!-- Reviewable:end -->
