### PR TITLE
make area charts full opacity for better legibility and consistency

### DIFF
--- a/frontend/src/metabase/visualizations/components/LineAreaBarChart.css
+++ b/frontend/src/metabase/visualizations/components/LineAreaBarChart.css
@@ -285,3 +285,7 @@ text.value-label-white {
 .LineAreaBarChart .dc-chart .event-line.hover {
   stroke: var(--color-brand);
 }
+
+.LineAreaBarChart .dc-chart path.area {
+  fill-opacity: 1;
+}


### PR DESCRIPTION
<img width="1392" alt="Screen Shot 2023-02-17 at 8 47 40 AM" src="https://user-images.githubusercontent.com/5248953/219678037-8350e51c-31da-4913-87bb-11d5f523dff0.png">
<img width="1392" alt="Screen Shot 2023-02-17 at 8 46 57 AM" src="https://user-images.githubusercontent.com/5248953/219678045-ad5dd3d7-1068-4d89-b62a-28ff8a3dfa07.png">

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/28407)
<!-- Reviewable:end -->
