### PR TITLE
[E2E] Fix `notifications` flake

### DIFF
--- a/frontend/test/metabase/scenarios/onboarding/notifications.cy.spec.js
+++ b/frontend/test/metabase/scenarios/onboarding/notifications.cy.spec.js
@@ -115,7 +115,8 @@ describe("scenarios > account > notifications", () => {
         cy.findByText("Delete this alert").click();
       });
 
-      cy.findByText("Question").should("not.exist");
+      modal().should("not.exist");
+      cy.findByTestId("notification-list").should("not.exist");
     });
 
     it("should be able to unsubscribe from an alert when the user has not created it", () => {

--- a/frontend/test/metabase/scenarios/onboarding/notifications.cy.spec.js
+++ b/frontend/test/metabase/scenarios/onboarding/notifications.cy.spec.js
@@ -107,6 +107,7 @@ describe("scenarios > account > notifications", () => {
       modal().within(() => {
         cy.findByText("Confirm you want to unsubscribe");
         cy.findByText("Unsubscribe").click();
+        cy.findByText("Unsubscribe").should("not.exist");
       });
 
       modal().within(() => {

--- a/frontend/test/metabase/scenarios/onboarding/notifications.cy.spec.js
+++ b/frontend/test/metabase/scenarios/onboarding/notifications.cy.spec.js
@@ -78,7 +78,7 @@ describe("scenarios > account > notifications", () => {
     });
 
     it("should be able to see help info", () => {
-      cy.visit("/account/notifications");
+      openUserNotifications();
 
       cy.findByText("Not seeing one here?").click();
 
@@ -91,7 +91,7 @@ describe("scenarios > account > notifications", () => {
     });
 
     it("should be able to see alerts notifications", () => {
-      cy.visit("/account/notifications");
+      openUserNotifications();
 
       cy.findByText("Question");
       cy.findByText("Emailed hourly", { exact: false });
@@ -99,7 +99,7 @@ describe("scenarios > account > notifications", () => {
     });
 
     it("should be able to unsubscribe and delete an alert when the user created it", () => {
-      cy.visit("/account/notifications");
+      openUserNotifications();
 
       cy.findByText("Question");
       clickUnsubscribe();
@@ -122,7 +122,7 @@ describe("scenarios > account > notifications", () => {
     it("should be able to unsubscribe from an alert when the user has not created it", () => {
       cy.signOut();
       cy.signInAsAdmin();
-      cy.visit("/account/notifications");
+      openUserNotifications();
 
       cy.findByText("Question");
       clickUnsubscribe();
@@ -148,7 +148,7 @@ describe("scenarios > account > notifications", () => {
     });
 
     it("should be able to see help info", () => {
-      cy.visit("/account/notifications");
+      openUserNotifications();
 
       cy.findByText("Not seeing one here?").click();
 
@@ -161,7 +161,7 @@ describe("scenarios > account > notifications", () => {
     });
 
     it("should be able to see pulses notifications", () => {
-      cy.visit("/account/notifications");
+      openUserNotifications();
 
       cy.findByText("Subscription");
       cy.findByText("Slack’d hourly", { exact: false });
@@ -169,7 +169,7 @@ describe("scenarios > account > notifications", () => {
     });
 
     it("should be able to unsubscribe and delete a pulse when the user has created it", () => {
-      cy.visit("/account/notifications");
+      openUserNotifications();
 
       cy.findByText("Subscription");
       clickUnsubscribe();
@@ -188,4 +188,10 @@ function clickUnsubscribe() {
   cy.findByTestId("notifications-list").within(() => {
     cy.findByLabelText("close icon").click();
   });
+}
+
+function openUserNotifications() {
+  cy.intercept("GET", "/api/pulse?*").as("loadSubscriptions");
+  cy.visit("/account/notifications");
+  cy.wait("@loadSubscriptions");
 }


### PR DESCRIPTION
Example of the failed run:
https://www.deploysentinel.com/ci/runs/63ef716f3cc79870625c17b7

According to DeploySentinel statistics, this test was among the most flaky ones:
```
frontend/test/metabase/scenarios/onboarding/notifications.cy.spec.js > scenarios > account > notifications alerts should be able to unsubscribe and delete an alert when the user created it
- Failure Rate: 18.18%
- Flake Rate: 76.14%
```
Something weird is going on with the modal when it re-renders. [I made sure that the "Unsubscribe" button doesn't **exist** in the DOM](https://github.com/metabase/metabase/compare/fix-notifications-flake?expand=1#diff-ea930e6443b4eb1cff1408c28776970fe43ce7ca6df8fa3eaf342c296c7b248fR110) before moving on to the next assertion.

Notice how "Unsubscribe" was still in the DOM even though you don't see it in the UI. Cypress marked it as "not visible" element.
![image](https://user-images.githubusercontent.com/31325167/219690966-39190fce-c83f-49e1-879a-a948c0fbbc25.png)

I've additionally made sure that the page fully loaded before starting with assertions.

After this PR:
![image](https://user-images.githubusercontent.com/31325167/219691463-bf0936a8-3ea6-431f-ad6f-20944b2b939d.png)

