### PR TITLE
Add fallback stub for `be-checks`

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -221,3 +221,19 @@ jobs:
           m2-cache-key: be-check
       - name: Check namespaces
         run: clojure -M:ee:drivers:check
+
+  be-check-stub:
+    needs: files-changed
+    if: |
+      always() &&
+      github.event.pull_request.draft == false &&
+      needs.files-changed.outputs.backend_all == 'false'
+    runs-on: ubuntu-20.04
+    name: be-check-java-${{ matrix.java-version }}
+    timeout-minutes: 10
+    strategy:
+      matrix:
+        java-version: [11, 17, 19]
+    steps:
+      - run: |
+          echo "Didn't run due to conditional filtering"


### PR DESCRIPTION
Even though the `dorny/paths-filter` action is pretty amazing, it doesn't work with the dynamically generated jobs (from a matrix). In such cases, we need to provide a fallback stub that is matching the inverted filter logic.

This PR is doing exactly that.