### PR TITLE
[E2E] Fix native field filter related flakes

### DIFF
--- a/frontend/src/metabase/components/Popover/Popover.jsx
+++ b/frontend/src/metabase/components/Popover/Popover.jsx
@@ -6,6 +6,7 @@ import Tether from "tether";
 
 import cx from "classnames";
 import OnClickOutsideWrapper from "metabase/components/OnClickOutsideWrapper";
+import { isCypressActive } from "metabase/env";
 
 import "./Popover.css";
 
@@ -87,6 +88,10 @@ export default class Popover extends Component {
   };
 
   _getPopoverElement(isOpen) {
+    // 3s is an overkill for Cypress, but let's start with it and dial it down
+    // if we see that the flakes don't appear anymore
+    const resizeTimer = isCypressActive ? 3000 : 100;
+
     if (!this._popoverElement && isOpen) {
       this._popoverElement = document.createElement("span");
       this._popoverElement.className = `PopoverContainer ${this.props.containerClassName}`;
@@ -96,7 +101,7 @@ export default class Popover extends Component {
         if (this.state.width !== width || this.state.height !== height) {
           this.setState({ width, height });
         }
-      }, 100);
+      }, resizeTimer);
     }
     return this._popoverElement;
   }

--- a/frontend/test/metabase/scenarios/native-filters/helpers/e2e-field-filter-helpers.js
+++ b/frontend/test/metabase/scenarios/native-filters/helpers/e2e-field-filter-helpers.js
@@ -175,12 +175,15 @@ export function pickDefaultValue(searchTerm, result) {
   cy.findByText("Enter a default value…").click();
   cy.findByPlaceholderText("Enter a default value…").type(searchTerm);
 
-  // We could search for only one result inside popover()
-  // instead of `all` then `last`,
-  // but it flakes out as sometimes the popover
-  // is detached from the DOM.
+  // Popover is re-rendering every 100ms!
+  // That prevents us from targeting popover() element first,
+  // and then searching for strings inside of it.
   //
-  cy.findAllByText(result).last().click();
+  // Until FE finds a better solution, our best bet for E2E tests
+  // is to make sure the string is "visible" before acting on it.
+  // This seems to help with the flakiness.
+  //
+  cy.findByTestId(`${result}-filter-value`).should("be.visible").click();
 
   cy.button("Add filter").click();
 }


### PR DESCRIPTION
There have been historically numerous incidents involving Popover element. We're talking about the issues that users can see, but also an insane number of flaky E2E Cypress tests.

It's close to impossible to always adjust Cypress tests to the weird Popover behavior.
Most of these flakes (at least recently) are due to Cypress trying to click on an element that became detached from the DOM. No wonder this is happening when the popover recalculates it's position/dimensions every 100ms!

This is the example of a failed run:
https://www.deploysentinel.com/ci/runs/63ef82a2ff2076a2d821d8ba

## Explanation:
1. popover renders 
2. Cypress finds an input `Enter a default value…` and starts typing
3. It types the first letter `S` -> nothing happens yet because the number of filtered results is still large enough to keep the popover at this size
4. It types the second letter `y` ("Sy" total) -> the number of total results has shrunk and that triggers popover to resize
5. Just prior to popover starting to recalculate its boundaries, Cypress found the string it's searching for -> `Synergistic Granite Chair`
6. When Cypress wants to click on that string, it doesn't really exist anymore in the DOM because popover re-rendered