### PR TITLE
Fixing Table isValid check

### DIFF
--- a/frontend/src/metabase-lib/Question.ts
+++ b/frontend/src/metabase-lib/Question.ts
@@ -742,13 +742,14 @@ class QuestionInner {
 
     let addedColumns = cols.filter(col => {
       const hasVizSettings =
-        findColumnSettingIndexForColumn(vizSettings, col) >= 0;
+        findColumnSettingIndexForColumn(vizSettings, col, false) >= 0;
       return !hasVizSettings;
     });
     const validVizSettings = vizSettings.filter(colSetting => {
-      const hasColumn = findColumnIndexForColumnSetting(cols, colSetting) >= 0;
+      const hasColumn =
+        findColumnIndexForColumnSetting(cols, colSetting, false) >= 0;
       const isMutatingColumn =
-        findColumnIndexForColumnSetting(addedColumns, colSetting) >= 0;
+        findColumnIndexForColumnSetting(addedColumns, colSetting, false) >= 0;
       return hasColumn && !isMutatingColumn;
     });
     const noColumnsRemoved = validVizSettings.length === vizSettings.length;

--- a/frontend/src/metabase-lib/queries/utils/dataset.js
+++ b/frontend/src/metabase-lib/queries/utils/dataset.js
@@ -45,7 +45,11 @@ export function normalizeFieldRef(fieldRef) {
   return dimension && dimension.mbql();
 }
 
-export function findColumnIndexForColumnSetting(columns, columnSetting) {
+export function findColumnIndexForColumnSetting(
+  columns,
+  columnSetting,
+  useName = true,
+) {
   // NOTE: need to normalize field refs because they may be old style [fk->, 1, 2]
   const fieldRef = normalizeFieldRef(columnSetting.fieldRef);
   // first try to find by fieldRef
@@ -58,10 +62,16 @@ export function findColumnIndexForColumnSetting(columns, columnSetting) {
     }
   }
   // if that fails, find by column name
-  return _.findIndex(columns, col => col.name === columnSetting.name);
+  return useName
+    ? _.findIndex(columns, col => col.name === columnSetting.name)
+    : -1;
 }
 
-export function findColumnSettingIndexForColumn(columnSettings, column) {
+export function findColumnSettingIndexForColumn(
+  columnSettings,
+  column,
+  useName = true,
+) {
   const fieldRef = normalizeFieldRef(fieldRefForColumn(column));
   if (fieldRef !== null) {
     const index = columnSettings.findIndex(columnSetting =>
@@ -71,9 +81,11 @@ export function findColumnSettingIndexForColumn(columnSettings, column) {
       return index;
     }
   }
-  return columnSettings.findIndex(
-    columnSetting => columnSetting.name === column.name,
-  );
+  return useName
+    ? columnSettings.findIndex(
+        columnSetting => columnSetting.name === column.name,
+      )
+    : -1;
 }
 
 export function syncTableColumnsToQuery(question) {

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardActionButtons/ChartSettingsButton.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardActionButtons/ChartSettingsButton.tsx
@@ -12,6 +12,7 @@ import {
 } from "metabase-types/api";
 import { Series } from "metabase-types/types/Visualization";
 import Metadata from "metabase-lib/metadata/Metadata";
+import Question from "metabase-lib/Question";
 
 import DashCardActionButton from "./DashCardActionButton";
 
@@ -30,6 +31,8 @@ function ChartSettingsButton({
   onReplaceAllVisualizationSettings,
   metadata,
 }: Props) {
+  const question = new Question(series[0].card, metadata);
+
   return (
     <ModalWithTrigger
       wide
@@ -49,6 +52,7 @@ function ChartSettingsButton({
         dashboard={dashboard}
         dashcard={dashcard}
         metadata={metadata}
+        question={question}
       />
     </ModalWithTrigger>
   );

--- a/frontend/src/metabase/query_builder/components/notebook/steps/AggregateStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/AggregateStep.jsx
@@ -26,6 +26,7 @@ export default function AggregateStep({
 }) {
   return (
     <ClauseStep
+      data-testid="aggregate-step"
       color={color}
       initialAddText={t`Pick the metric you want to see`}
       items={query.aggregations()}

--- a/frontend/src/metabase/query_builder/components/notebook/steps/BreakoutStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/BreakoutStep.jsx
@@ -26,6 +26,7 @@ export default function BreakoutStep({
 }) {
   return (
     <ClauseStep
+      data-testid="breakout-step"
       color={color}
       initialAddText={t`Pick a column to group by`}
       items={query.breakouts()}

--- a/frontend/src/metabase/query_builder/components/notebook/steps/ClauseStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/ClauseStep.jsx
@@ -22,7 +22,7 @@ export default function ClauseStep({
   ...props
 }) {
   return (
-    <NotebookCell color={color}>
+    <NotebookCell color={color} data-testid={props["data-testid"]}>
       {items.map((item, index) => (
         <PopoverWithTrigger
           tetherOptions={tetherOptions}

--- a/frontend/src/metabase/query_builder/components/view/ConvertQueryModal/ConvertQueryModal.tsx
+++ b/frontend/src/metabase/query_builder/components/view/ConvertQueryModal/ConvertQueryModal.tsx
@@ -24,6 +24,7 @@ const BUTTON_TITLE = {
 
 interface UpdateQuestionOpts {
   shouldUpdateUrl?: boolean;
+  run?: boolean;
 }
 
 interface ConvertQueryModalProps {
@@ -53,7 +54,7 @@ const ConvertQueryModal = ({
       database: question.datasetQuery().database,
     });
 
-    onUpdateQuestion?.(newQuestion, { shouldUpdateUrl: true });
+    onUpdateQuestion?.(newQuestion, { shouldUpdateUrl: true, run: true });
     onClose?.();
   }, [question, query, onUpdateQuestion, onClose]);
 

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingColumnEditor.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingColumnEditor.tsx
@@ -10,6 +10,7 @@ import { isNotNull } from "metabase/core/utils/types";
 import Metadata from "metabase-lib/metadata/Metadata";
 import StructuredQuery from "metabase-lib/queries/StructuredQuery";
 import NativeQuery from "metabase-lib/queries/NativeQuery";
+import AtomicQuery from "metabase-lib/queries/AtomicQuery";
 import Question from "metabase-lib/Question";
 import Dimension from "metabase-lib/Dimension";
 
@@ -61,8 +62,9 @@ const structuredQueryFieldOptions = (
       ),
     )
     .filter(isNotNull);
+
   return {
-    name: query.table()?.display_name || t`Columns`,
+    name: query.sourceTable()?.display_name || t`Columns`,
     dimensions: options.dimensions.concat(missingDimensions).filter(isNotNull),
     fks: options.fks.map(fk => ({
       name:
@@ -78,6 +80,7 @@ const structuredQueryFieldOptions = (
 const nativeQueryFieldOptions = (
   columns: DatasetColumn[],
   metadata?: Metadata,
+  query?: AtomicQuery,
 ) => {
   const allDimensions = columns
     .map(column =>
@@ -85,21 +88,10 @@ const nativeQueryFieldOptions = (
     )
     .filter(isNotNull);
 
-  const groupedDimensions = _.groupBy(
-    allDimensions,
-    dimension => dimension.field().table?.displayName() || t`Columns`,
-  );
-  const tables = Object.keys(groupedDimensions);
-  const firstTable = tables[0];
   return {
-    name: firstTable,
-    dimensions: groupedDimensions[firstTable],
-    fks: tables
-      .filter(table => table !== firstTable)
-      .map(table => ({
-        name: table,
-        dimensions: groupedDimensions[table],
-      })),
+    name: query?.sourceTable()?.displayName() || t`Columns`,
+    dimensions: allDimensions,
+    fks: [],
   };
 };
 
@@ -114,10 +106,14 @@ const ChartSettingColumnEditor = ({
 }: ChartSettingColumnEditorProps) => {
   const fieldOptions = useMemo(() => {
     const query = question && question.query();
-    if (query instanceof StructuredQuery && !isDashboard) {
+    if ((query instanceof NativeQuery || isDashboard) && columns) {
+      return nativeQueryFieldOptions(
+        columns,
+        metadata || query.metadata(),
+        query,
+      );
+    } else if (query instanceof StructuredQuery) {
       return structuredQueryFieldOptions(query, columns);
-    } else if ((query instanceof NativeQuery || isDashboard) && columns) {
-      return nativeQueryFieldOptions(columns, metadata);
     } else {
       return {
         name: "",
@@ -130,6 +126,12 @@ const ChartSettingColumnEditor = ({
   const getColumnSettingByDimension = (dimension: Dimension) => {
     return columnSettings.find(setting =>
       dimension.isSameBaseDimension(setting.fieldRef as ConcreteField),
+    );
+  };
+
+  const getColumnByDimension = (dimension: Dimension) => {
+    return columns.find(column =>
+      dimension.isSameBaseDimension(column.field_ref as ConcreteField),
     );
   };
 
@@ -193,6 +195,16 @@ const ChartSettingColumnEditor = ({
     ]);
   };
 
+  const getDimensionLabel = (dimension: Dimension, sourceTable = true) => {
+    const column = getColumnByDimension(dimension);
+
+    if (column && sourceTable) {
+      return column.display_name;
+    }
+
+    return dimension.displayName();
+  };
+
   return (
     <div className="list">
       <TableHeaderContainer>
@@ -206,7 +218,7 @@ const ChartSettingColumnEditor = ({
       </TableHeaderContainer>
       {fieldOptions.dimensions.map((dimension, index) => (
         <FieldCheckbox
-          label={dimension.displayName()}
+          label={getDimensionLabel(dimension)}
           onClick={() => toggleColumn(dimension)}
           checked={columnIsEnabled(dimension)}
           key={`${dimension.displayName()}-${index}`}
@@ -226,7 +238,7 @@ const ChartSettingColumnEditor = ({
           </TableHeaderContainer>
           {fk.dimensions.map((dimension, index) => (
             <FieldCheckbox
-              label={dimension.displayName()}
+              label={getDimensionLabel(dimension, false)}
               onClick={() => toggleColumn(dimension)}
               checked={columnIsEnabled(dimension)}
               key={`${fk.name}-${dimension.displayName()}-${index}`}

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingColumnEditor.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingColumnEditor.tsx
@@ -198,6 +198,9 @@ const ChartSettingColumnEditor = ({
   const getDimensionLabel = (dimension: Dimension, sourceTable = true) => {
     const column = getColumnByDimension(dimension);
 
+    // When we have a colum returned, we want to use that display name as long as it's part of the source table
+    // This ensures that we get the {table}→{column} syntax when appropriate. On anything other than the
+    // Source table, there should be a table header above the list so we should only show the field name.
     if (column && sourceTable) {
       return column.display_name;
     }
@@ -206,7 +209,7 @@ const ChartSettingColumnEditor = ({
   };
 
   return (
-    <div className="list">
+    <div>
       <TableHeaderContainer>
         <TableName>{fieldOptions.name}</TableName>
         <BulkActionButton

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingColumnEditor.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingColumnEditor.tsx
@@ -210,26 +210,28 @@ const ChartSettingColumnEditor = ({
 
   return (
     <div>
-      <TableHeaderContainer>
-        <TableName>{fieldOptions.name}</TableName>
-        <BulkActionButton
-          tableInColumns={tableInColumnSettings(fieldOptions.dimensions)}
-          bulkEnable={() => enableColumns(fieldOptions.dimensions)}
-          bulkDisable={() => disableColumns(fieldOptions.dimensions)}
-          testid={`bulk-action-${fieldOptions.name}`}
-        />
-      </TableHeaderContainer>
-      {fieldOptions.dimensions.map((dimension, index) => (
-        <FieldCheckbox
-          label={getDimensionLabel(dimension)}
-          onClick={() => toggleColumn(dimension)}
-          checked={columnIsEnabled(dimension)}
-          key={`${dimension.displayName()}-${index}`}
-          disabled={isQueryRunning}
-        />
-      ))}
+      <div data-testid={`${fieldOptions.name}-columns`}>
+        <TableHeaderContainer>
+          <TableName>{fieldOptions.name}</TableName>
+          <BulkActionButton
+            tableInColumns={tableInColumnSettings(fieldOptions.dimensions)}
+            bulkEnable={() => enableColumns(fieldOptions.dimensions)}
+            bulkDisable={() => disableColumns(fieldOptions.dimensions)}
+            testid={`bulk-action-${fieldOptions.name}`}
+          />
+        </TableHeaderContainer>
+        {fieldOptions.dimensions.map((dimension, index) => (
+          <FieldCheckbox
+            label={getDimensionLabel(dimension)}
+            onClick={() => toggleColumn(dimension)}
+            checked={columnIsEnabled(dimension)}
+            key={`${dimension.displayName()}-${index}`}
+            disabled={isQueryRunning}
+          />
+        ))}
+      </div>
       {fieldOptions.fks.map(fk => (
-        <>
+        <div data-testid={`${fk.name}-columns`} key={`${fk.name}-columns`}>
           <TableHeaderContainer>
             <TableName>{fk.name}</TableName>
             <BulkActionButton
@@ -248,7 +250,7 @@ const ChartSettingColumnEditor = ({
               disabled={isQueryRunning}
             />
           ))}
-        </>
+        </div>
       ))}
     </div>
   );

--- a/frontend/src/metabase/visualizations/visualizations/Table.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Table.jsx
@@ -186,10 +186,10 @@ export default class Table extends Component {
           tableColumns &&
           tableColumns.length !== 0 &&
           (extra.isQueryRunning ||
-            _.all(
+            _.every(
               tableColumns,
               columnSetting =>
-                !columnSettings.enabled ||
+                !columnSetting.enabled ||
                 findColumnIndexForColumnSetting(data.cols, columnSetting) >= 0,
             ));
         if (!isValid) {

--- a/frontend/src/metabase/visualizations/visualizations/Table.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Table.jsx
@@ -35,6 +35,7 @@ import {
 import {
   findColumnIndexForColumnSetting,
   findColumnForColumnSetting,
+  findColumnSettingIndexForColumn,
 } from "metabase-lib/queries/utils/dataset";
 import { getColumnKey } from "metabase-lib/queries/utils/get-column-key";
 import * as Q_DEPRECATED from "metabase-lib/queries/utils";
@@ -191,6 +192,12 @@ export default class Table extends Component {
               columnSetting =>
                 !columnSetting.enabled ||
                 findColumnIndexForColumnSetting(data.cols, columnSetting) >= 0,
+            )) &&
+          (extra.isQueryRunning ||
+            _.every(
+              data.cols,
+              column =>
+                findColumnSettingIndexForColumn(tableColumns, column) >= 0,
             ));
         if (!isValid) {
           return data.cols.map(col => ({

--- a/frontend/test/metabase/scenarios/native/native.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native/native.cy.spec.js
@@ -12,7 +12,7 @@ import {
 import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
-const { ORDERS_ID } = SAMPLE_DATABASE;
+const { ORDERS_ID, ORDERS } = SAMPLE_DATABASE;
 
 describe("scenarios > question > native", () => {
   beforeEach(() => {
@@ -251,28 +251,52 @@ describe("scenarios > question > native", () => {
   });
 
   it("should allow to convert a structured query to a native query", () => {
-    visitQuestionAdhoc(
-      {
-        display: "table",
-        dataset_query: {
-          type: "query",
-          query: {
-            "source-table": ORDERS_ID,
-            limit: 1,
-          },
-          database: SAMPLE_DB_ID,
+    visitQuestionAdhoc({
+      display: "table",
+      dataset_query: {
+        type: "query",
+        query: {
+          "source-table": ORDERS_ID,
+          limit: 1,
+          fields: [
+            ["field", ORDERS.ID, null],
+            ["field", ORDERS.USER_ID, null],
+            ["field", ORDERS.PRODUCT_ID, null],
+          ],
         },
+        database: SAMPLE_DB_ID,
       },
-      { mode: "notebook", autorun: false },
-    );
+      visualization_settings: {
+        "table.colums": [
+          {
+            enabled: true,
+            fieldRef: ["field", ORDERS.ID, null],
+            name: "ID",
+          },
+          {
+            enabled: true,
+            fieldRef: ["field", ORDERS.USER_ID, null],
+            name: "User ID",
+          },
+          {
+            enabled: true,
+            fieldRef: ["field", ORDERS.PRODUCT_ID, null],
+            name: "Product ID",
+          },
+        ],
+      },
+    });
 
+    cy.icon("notebook").click();
     cy.button("View the SQL").click();
     cy.wait("@datasetNative");
     cy.findByText(/FROM "PUBLIC"."ORDERS"/).should("be.visible");
 
     cy.button("Convert this question to SQL").click();
-    runQuery();
+
+    //Ensure that the new native query ran after being converted
     cy.findByText("Showing 1 row").should("be.visible");
+    cy.findAllByTestId("header-cell").contains("USER_ID").should("be.visible");
   });
 });
 

--- a/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
@@ -12,7 +12,6 @@ import {
   summarize,
   visitQuestionAdhoc,
   visualize,
-  openNotebook,
 } from "__support__/e2e/helpers";
 
 import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
@@ -400,34 +399,6 @@ describe("scenarios > question > notebook", () => {
     popover().findByText("Product ID").click();
 
     visualize();
-  });
-
-  it("should re-run the query when converting a structured query to a native query", () => {
-    openOrdersTable();
-    cy.findByTestId("viz-settings-button").click();
-    cy.findByText("Add or remove columns").click();
-    cy.findByText("Deselect All").click();
-    cy.findByTestId("Orders-columns").within(() => {
-      cy.findByText("ID").click();
-      cy.findByText("User ID").click();
-      cy.findByText("Product ID").click();
-    });
-    cy.get(".RunButton").first().click();
-    cy.wait("@dataset");
-    cy.findByTestId("loading-spinner").should("not.exist");
-
-    openNotebook();
-    cy.icon("sql").click();
-    cy.button("Convert this question to SQL").click();
-
-    cy.findByTestId("viz-settings-button").click();
-    cy.findByText("Add or remove columns").click();
-
-    cy.findByTestId("Columns-columns").within(() => {
-      cy.findByLabelText("ID").should("be.checked");
-      cy.findByLabelText("USER_ID").should("be.checked");
-      cy.findByLabelText("PRODUCT_ID").should("be.checked");
-    });
   });
 
   // flaky test

--- a/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
@@ -12,6 +12,7 @@ import {
   summarize,
   visitQuestionAdhoc,
   visualize,
+  openNotebook,
 } from "__support__/e2e/helpers";
 
 import { SAMPLE_DB_ID } from "__support__/e2e/cypress_data";
@@ -399,6 +400,34 @@ describe("scenarios > question > notebook", () => {
     popover().findByText("Product ID").click();
 
     visualize();
+  });
+
+  it("should re-run the query when converting a structured query to a native query", () => {
+    openOrdersTable();
+    cy.findByTestId("viz-settings-button").click();
+    cy.findByText("Add or remove columns").click();
+    cy.findByText("Deselect All").click();
+    cy.findByTestId("Orders-columns").within(() => {
+      cy.findByText("ID").click();
+      cy.findByText("User ID").click();
+      cy.findByText("Product ID").click();
+    });
+    cy.get(".RunButton").first().click();
+    cy.wait("@dataset");
+    cy.findByTestId("loading-spinner").should("not.exist");
+
+    openNotebook();
+    cy.icon("sql").click();
+    cy.button("Convert this question to SQL").click();
+
+    cy.findByTestId("viz-settings-button").click();
+    cy.findByText("Add or remove columns").click();
+
+    cy.findByTestId("Columns-columns").within(() => {
+      cy.findByLabelText("ID").should("be.checked");
+      cy.findByLabelText("USER_ID").should("be.checked");
+      cy.findByLabelText("PRODUCT_ID").should("be.checked");
+    });
   });
 
   // flaky test

--- a/frontend/test/metabase/scenarios/question/reproductions/17514-ui-overlay.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/reproductions/17514-ui-overlay.cy.spec.js
@@ -88,7 +88,7 @@ describe("issue 17514", () => {
 
       cy.findByTestId("chartsettings-sidebar").within(() => {
         cy.findByText("Add or remove columns").click();
-        cy.findByText("Ean").click();
+        cy.findByText("Products → Ean").click();
       });
 
       closeModal();

--- a/frontend/test/metabase/scenarios/visualizations/reproductions/28304-table-columns-unknown.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/reproductions/28304-table-columns-unknown.cy.spec.js
@@ -16,11 +16,7 @@ const questionDetails = {
     query: {
       "source-table": ORDERS_ID,
       aggregation: [["count"]],
-      breakout: [
-        ["field", ORDERS.CREATED_AT, { "temporal-unit": "month" }],
-        ["field", ORDERS.USER_ID, null],
-        ["field", ORDERS.PRODUCT_ID, null],
-      ],
+      breakout: [["field", ORDERS.CREATED_AT, { "temporal-unit": "month" }]],
     },
     database: SAMPLE_DB_ID,
   },
@@ -52,10 +48,13 @@ const questionDetails = {
         enabled: true,
       },
     ],
+    column_settings: {
+      '["name","count"]': { show_mini_bar: true },
+    },
   },
 };
 
-describe("issue 25250", () => {
+describe("issue 28304", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();
@@ -63,11 +62,14 @@ describe("issue 25250", () => {
     visitQuestionAdhoc(questionDetails);
   });
 
-  it("pivot table should show standalone values when collapsed to the sub-level grouping (metabase#25250)", () => {
-    cy.findByText("Count by 3 breakouts").should("be.visible");
+  it("table should should generate default columns when table.columns entries do not match data.cols  (metabase#28304)", () => {
+    cy.findByText("Count by Created At: Month").should("be.visible");
 
     cy.findByTestId("viz-settings-button").click();
     leftSidebar().should("not.contain", "[Unknown]");
+    leftSidebar().should("contain", "Created At");
+    leftSidebar().should("contain", "Count");
+    cy.findAllByTestId("mini-bar").should("have.length.greaterThan", 0);
     getDraggableElements().should("have.length", 2);
   });
 });

--- a/frontend/test/metabase/scenarios/visualizations/table.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/table.cy.spec.js
@@ -7,6 +7,7 @@ import {
   enterCustomColumnDetails,
   visualize,
   summarize,
+  openNotebook,
 } from "__support__/e2e/helpers";
 
 describe("scenarios > visualizations > table", () => {
@@ -189,6 +190,63 @@ describe("scenarios > visualizations > table", () => {
     popover().within(() => {
       cy.contains("No special type");
       cy.findByText("No description");
+    });
+  });
+
+  it("should compute default 'table.columns' when adding new columns", () => {
+    openOrdersTable();
+    cy.findByTestId("viz-settings-button").click();
+    cy.findByText("Add or remove columns").click();
+    cy.findByText("Deselect All").click();
+    cy.findByTestId("Orders-columns").within(() => {
+      cy.findByText("ID").click();
+      cy.findByText("User ID").click();
+      cy.findByText("Product ID").click();
+    });
+    cy.get(".RunButton").first().click();
+    cy.wait("@dataset");
+    cy.findByTestId("loading-spinner").should("not.exist");
+
+    openNotebook();
+
+    // Add aggregates
+    cy.findByText("Summarize").click();
+    cy.findByText("Count of rows").click();
+    cy.findByTestId("aggregate-step").within(() => {
+      cy.icon("add").click();
+    });
+    cy.findByText("Average of ...").click();
+    cy.findByText("Total").click();
+
+    // Add Breakouts
+    cy.findByText("Pick a column to group by").click();
+    popover().within(() => {
+      cy.findByText("ID").click();
+    });
+    cy.findByTestId("breakout-step").within(() => {
+      cy.icon("add").click();
+    });
+    popover().within(() => {
+      cy.findByText("User ID").click();
+    });
+    cy.findByTestId("breakout-step").within(() => {
+      cy.icon("add").click();
+    });
+    popover().within(() => {
+      cy.findByText("Product ID").click();
+    });
+
+    visualize();
+
+    cy.findByTestId("viz-settings-button").click();
+    cy.findByText("Add or remove columns").click();
+
+    cy.findByTestId("Orders-columns").within(() => {
+      cy.findByLabelText("Count").should("be.checked");
+      cy.findByLabelText("Average of Total").should("be.checked");
+      cy.findByLabelText("ID").should("be.checked");
+      cy.findByLabelText("User ID").should("be.checked");
+      cy.findByLabelText("Product ID").should("be.checked");
     });
   });
 


### PR DESCRIPTION
Fixes #28304 

How to test:
- New -> Question -> Orders -> Visualize
- Go to table settings and move a column to a new place
- Go back to notebook editor, and summartize by count, group by Created At: Year -> Visualize
- Switch viz back to table (it is likely showing up as a line chart)
- You should see both the Created At and Count columns there to re-order. Previously, you would have only seen Created At.

The original e2e test has been updated to check for the presence of the Count field, as well as check that the column formatting has been applied.

