### PR TITLE
[CI] Fix Google related drivers classpath test

### DIFF
--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -128,7 +128,7 @@ jobs:
     - name: Test Google Related Drivers Classpath
       uses: ./.github/actions/test-driver
       with:
-        junit-name: 'be-tests-google-related--classpath-test'
+        junit-name: 'be-google-related-drivers-classpath-test'
         test-args: ':only "[metabase.query-processor-test.expressions-test metabase.driver.google-test metabase.driver.googleanalytics-test]"'
 
   be-tests-mariadb-10-2-ee:

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -109,17 +109,14 @@ jobs:
         junit-name: 'be-tests-googleanalytics-ee'
         test-args: ":exclude-tags '[:mb/once]'"
 
-  be-tests-google-related-classpath-ee:
+  be-google-related-drivers-classpath-test:
     needs: files-changed
     if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
     runs-on: ubuntu-20.04
     timeout-minutes: 60
-    strategy:
-      matrix:
-        driver: ['googleanalytics', 'bigquery-cloud-sdk']
     env:
       CI: 'true'
-      DRIVERS: ${{ matrix.driver }}
+      DRIVERS: 'googleanalytics,bigquery-cloud-sdk'
       MB_BIGQUERY_TEST_PROJECT_ID: ${{ secrets.BIGQUERY_TEST_PROJECT_ID }}
       MB_BIGQUERY_TEST_CLIENT_ID: ${{ secrets.MB_BIGQUERY_TEST_CLIENT_ID }}
       MB_BIGQUERY_TEST_CLIENT_SECRET: ${{ secrets.MB_BIGQUERY_TEST_CLIENT_SECRET }}
@@ -128,10 +125,10 @@ jobs:
       MB_BIGQUERY_CLOUD_SDK_TEST_SERVICE_ACCOUNT_JSON: ${{ secrets.MB_BIGQUERY_CLOUD_SDK_TEST_SERVICE_ACCOUNT_JSON }}
     steps:
     - uses: actions/checkout@v3
-    - name: Test Google Related Classpath drivers
+    - name: Test Google Related Drivers Classpath
       uses: ./.github/actions/test-driver
       with:
-        junit-name: 'be-tests-${{ matrix.driver }}-classpath-ee'
+        junit-name: 'be-tests-google-related--classpath-test'
         test-args: ':only "[metabase.query-processor-test.expressions-test metabase.driver.google-test metabase.driver.googleanalytics-test]"'
 
   be-tests-mariadb-10-2-ee:


### PR DESCRIPTION
When I originally migrated this test from CircleCI in https://github.com/metabase/metabase/pull/27162, I totally misread [a comma-separated string](https://github.com/metabase/metabase/pull/27162/files#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47L569) for the matrix of two strings.

The job should load both drivers at the same time and this PR fixes it.