### PR TITLE
Allow disabling basic/implicit actions

### DIFF
--- a/frontend/src/metabase/models/components/ModelDetailPage/ModelActionDetails/ModelActionDetails.tsx
+++ b/frontend/src/metabase/models/components/ModelDetailPage/ModelActionDetails/ModelActionDetails.tsx
@@ -83,9 +83,9 @@ function ModelActionDetails({
 
   const onDeleteImplicitActions = useCallback(() => {
     askConfirmation({
-      title: t`Disable basic actions`,
+      title: t`Disable basic actions?`,
       message: t`Disabling basic actions will also remove any buttons that use these actions. Are you sure you want to continue?`,
-      confirmButtonText: t`Continue`,
+      confirmButtonText: t`Disable`,
       onConfirm: () => {
         implicitActions.forEach(action => {
           onDeleteAction(action);

--- a/frontend/src/metabase/models/components/ModelDetailPage/ModelActionDetails/ModelActionDetails.tsx
+++ b/frontend/src/metabase/models/components/ModelDetailPage/ModelActionDetails/ModelActionDetails.tsx
@@ -143,7 +143,7 @@ function ModelActionDetails({
           <ActionMenu
             triggerIcon="ellipsis"
             items={menuItems}
-            triggerProps={ACTION_MENU_TRIGGER_PROPS}
+            triggerProps={{ "aria-label": t`Actions menu` }}
           />
         </ActionsHeader>
       )}
@@ -194,10 +194,6 @@ function mostRecentFirst(action: WritebackAction) {
   const createdAt = parseTimestamp(action["created_at"]);
   return -createdAt.unix();
 }
-
-const ACTION_MENU_TRIGGER_PROPS = {
-  "data-testid": "actions-menu",
-};
 
 export default _.compose(
   Actions.loadList({

--- a/frontend/src/metabase/models/components/ModelDetailPage/ModelActionDetails/ModelActionDetails.tsx
+++ b/frontend/src/metabase/models/components/ModelDetailPage/ModelActionDetails/ModelActionDetails.tsx
@@ -95,18 +95,24 @@ function ModelActionDetails({
   }, [implicitActions, askConfirmation, onDeleteAction]);
 
   const menuItems = useMemo(() => {
+    const items = [];
     const hasImplicitActions = implicitActions.length > 0;
-    return [
-      {
-        title: hasImplicitActions
-          ? t`Disable basic actions`
-          : t`Create basic actions`,
+
+    if (hasImplicitActions) {
+      items.push({
+        title: t`Disable basic actions`,
         icon: "bolt",
-        action: hasImplicitActions
-          ? onDeleteImplicitActions
-          : onEnableImplicitActions,
-      },
-    ];
+        action: onDeleteImplicitActions,
+      });
+    } else {
+      items.push({
+        title: t`Create basic actions`,
+        icon: "bolt",
+        action: onEnableImplicitActions,
+      });
+    }
+
+    return items;
   }, [implicitActions, onEnableImplicitActions, onDeleteImplicitActions]);
 
   const renderActionListItem = useCallback(

--- a/frontend/src/metabase/models/containers/ModelDetailPage/ModelDetailPage.unit.spec.tsx
+++ b/frontend/src/metabase/models/containers/ModelDetailPage/ModelDetailPage.unit.spec.tsx
@@ -718,6 +718,7 @@ describe("ModelDetailPage", () => {
 
           userEvent.click(screen.getByTestId("actions-menu"));
           userEvent.click(screen.getByText("Disable basic actions"));
+          userEvent.click(screen.getByRole("button", { name: "Continue" }));
 
           actions.forEach(action => {
             expect(deleteActionSpy).toHaveBeenCalledWith({ id: action.id });

--- a/frontend/src/metabase/models/containers/ModelDetailPage/ModelDetailPage.unit.spec.tsx
+++ b/frontend/src/metabase/models/containers/ModelDetailPage/ModelDetailPage.unit.spec.tsx
@@ -606,7 +606,7 @@ describe("ModelDetailPage", () => {
           const action = createMockQueryAction({ model_id: model.id() });
           await setupActions({ model, actions: [action] });
 
-          userEvent.click(screen.getByTestId("actions-menu"));
+          userEvent.click(screen.getByLabelText("Actions menu"));
           userEvent.click(screen.getByText("Create basic actions"));
 
           await waitFor(() => {
@@ -669,7 +669,7 @@ describe("ModelDetailPage", () => {
             actions: createMockImplicitCUDActions(model.id()),
           });
 
-          userEvent.click(screen.getByTestId("actions-menu"));
+          userEvent.click(screen.getByLabelText("Actions menu"));
 
           expect(
             screen.queryByText(/Create basic action/i),
@@ -716,7 +716,7 @@ describe("ModelDetailPage", () => {
           const actions = createMockImplicitCUDActions(model.id());
           await setupActions({ model, actions });
 
-          userEvent.click(screen.getByTestId("actions-menu"));
+          userEvent.click(screen.getByLabelText("Actions menu"));
           userEvent.click(screen.getByText("Disable basic actions"));
           userEvent.click(screen.getByRole("button", { name: "Continue" }));
 
@@ -729,7 +729,7 @@ describe("ModelDetailPage", () => {
           const model = getModel();
           await setupActions({ model, actions: [] });
 
-          userEvent.click(screen.getByTestId("actions-menu"));
+          userEvent.click(screen.getByLabelText("Actions menu"));
 
           expect(
             screen.queryByText("Disable basic actions"),

--- a/frontend/src/metabase/models/containers/ModelDetailPage/ModelDetailPage.unit.spec.tsx
+++ b/frontend/src/metabase/models/containers/ModelDetailPage/ModelDetailPage.unit.spec.tsx
@@ -23,6 +23,7 @@ import {
 import { checkNotNull } from "metabase/core/utils/types";
 import { ActionsApi } from "metabase/services";
 
+import Actions from "metabase/entities/actions";
 import Models from "metabase/entities/questions";
 import { ModalRoute } from "metabase/hoc/ModalRoute";
 import { getMetadata } from "metabase/selectors/metadata";
@@ -605,7 +606,7 @@ describe("ModelDetailPage", () => {
           const action = createMockQueryAction({ model_id: model.id() });
           await setupActions({ model, actions: [action] });
 
-          userEvent.click(screen.getByTestId("new-action-menu"));
+          userEvent.click(screen.getByTestId("actions-menu"));
           userEvent.click(screen.getByText("Create basic actions"));
 
           await waitFor(() => {
@@ -668,11 +669,10 @@ describe("ModelDetailPage", () => {
             actions: createMockImplicitCUDActions(model.id()),
           });
 
+          userEvent.click(screen.getByTestId("actions-menu"));
+
           expect(
             screen.queryByText(/Create basic action/i),
-          ).not.toBeInTheDocument();
-          expect(
-            screen.queryByTestId("new-action-menu"),
           ).not.toBeInTheDocument();
         });
 
@@ -708,6 +708,31 @@ describe("ModelDetailPage", () => {
           openActionMenu(action);
 
           expect(screen.queryByText("Archive")).not.toBeInTheDocument();
+        });
+
+        it("allows to disable implicit actions", async () => {
+          const deleteActionSpy = jest.spyOn(Actions.actions, "delete");
+          const model = getModel();
+          const actions = createMockImplicitCUDActions(model.id());
+          await setupActions({ model, actions });
+
+          userEvent.click(screen.getByTestId("actions-menu"));
+          userEvent.click(screen.getByText("Disable basic actions"));
+
+          actions.forEach(action => {
+            expect(deleteActionSpy).toHaveBeenCalledWith({ id: action.id });
+          });
+        });
+
+        it("doesn't allow to disable implicit actions if they don't exist", async () => {
+          const model = getModel();
+          await setupActions({ model, actions: [] });
+
+          userEvent.click(screen.getByTestId("actions-menu"));
+
+          expect(
+            screen.queryByText("Disable basic actions"),
+          ).not.toBeInTheDocument();
         });
       });
 
@@ -750,9 +775,7 @@ describe("ModelDetailPage", () => {
           expect(
             screen.queryByText("Create basic actions"),
           ).not.toBeInTheDocument();
-          expect(
-            screen.queryByTestId("new-action-menu"),
-          ).not.toBeInTheDocument();
+          expect(screen.queryByTestId("actions-menu")).not.toBeInTheDocument();
         });
 
         it("doesn't allow to edit actions", async () => {

--- a/frontend/src/metabase/models/containers/ModelDetailPage/ModelDetailPage.unit.spec.tsx
+++ b/frontend/src/metabase/models/containers/ModelDetailPage/ModelDetailPage.unit.spec.tsx
@@ -718,7 +718,7 @@ describe("ModelDetailPage", () => {
 
           userEvent.click(screen.getByLabelText("Actions menu"));
           userEvent.click(screen.getByText("Disable basic actions"));
-          userEvent.click(screen.getByRole("button", { name: "Continue" }));
+          userEvent.click(screen.getByRole("button", { name: "Disable" }));
 
           actions.forEach(action => {
             expect(deleteActionSpy).toHaveBeenCalledWith({ id: action.id });

--- a/frontend/test/__support__/server-mocks/action.ts
+++ b/frontend/test/__support__/server-mocks/action.ts
@@ -8,6 +8,7 @@ import {
 export function setupActionEndpoints(scope: Scope, action: WritebackAction) {
   scope.get(`/api/action/${action.id}`).reply(200, action);
   scope.put(`/api/action/${action.id}`).reply(200, action);
+  scope.delete(`/api/action/${action.id}`).reply(200, action);
 }
 
 export function setupActionsEndpoints(

--- a/frontend/test/metabase/scenarios/models/model-actions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/model-actions.cy.spec.js
@@ -134,8 +134,8 @@ describe("scenarios > models > actions", () => {
     cy.findByLabelText("Actions menu").click();
     popover().findByText("Disable basic actions").click();
     modal().within(() => {
-      cy.findByText("Disable basic actions").should("be.visible");
-      cy.button("Continue").click();
+      cy.findByText("Disable basic actions?").should("be.visible");
+      cy.button("Disable").click();
     });
     cy.findByLabelText("Action list").should("not.exist");
     cy.findByText("Create").should("not.exist");

--- a/frontend/test/metabase/scenarios/models/model-actions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/model-actions.cy.spec.js
@@ -130,6 +130,13 @@ describe("scenarios > models > actions", () => {
     });
 
     cy.findByRole("listitem", { name: "Delete Order" }).should("not.exist");
+
+    cy.findByTestId("actions-menu").click();
+    popover().findByText("Disable basic actions").click();
+    cy.findByLabelText("Action list").should("not.exist");
+    cy.findByText("Create").should("not.exist");
+    cy.findByText("Update").should("not.exist");
+    cy.findByText("Delete").should("not.exist");
   });
 
   it("should allow to execute actions from the model page", () => {

--- a/frontend/test/metabase/scenarios/models/model-actions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/model-actions.cy.spec.js
@@ -131,7 +131,7 @@ describe("scenarios > models > actions", () => {
 
     cy.findByRole("listitem", { name: "Delete Order" }).should("not.exist");
 
-    cy.findByTestId("actions-menu").click();
+    cy.findByLabelText("Actions menu").click();
     popover().findByText("Disable basic actions").click();
     modal().within(() => {
       cy.findByText("Disable basic actions").should("be.visible");

--- a/frontend/test/metabase/scenarios/models/model-actions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/model-actions.cy.spec.js
@@ -133,6 +133,10 @@ describe("scenarios > models > actions", () => {
 
     cy.findByTestId("actions-menu").click();
     popover().findByText("Disable basic actions").click();
+    modal().within(() => {
+      cy.findByText("Disable basic actions").should("be.visible");
+      cy.button("Continue").click();
+    });
     cy.findByLabelText("Action list").should("not.exist");
     cy.findByText("Create").should("not.exist");
     cy.findByText("Update").should("not.exist");


### PR DESCRIPTION
Epic #27581

Adds an ability to disable (delete) a model's basic/implicit actions from the model detail page.

### How to verify

1. Go to `/model/:id/detail/actions`
2. Click "Create basic actions" if they don't exist yet
3. Click the ellipsis icon under the page tab bar, click the "Disable basic actions" menu item
4. Ensure you can see a confirmation modal, and click "Continue"
5. Ensure the actions are removed
6. Click the ellipsis icon again, ensure you can see "Create basic actions" instead of "Disable" now

### Demo

https://user-images.githubusercontent.com/17258145/219740697-3536c7d8-115c-4ff6-b327-e2338ef3ee7a.mp4

### Checklist

- [x] Tests have been added/updated to cover changes in this PR

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/28417)
<!-- Reviewable:end -->
