### PR TITLE
Allow creating actions with "+ New" button

### DIFF
--- a/frontend/src/metabase/actions/containers/ActionCreator/ActionCreator.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/ActionCreator.tsx
@@ -15,6 +15,8 @@ import { getMetadata } from "metabase/selectors/metadata";
 
 import type {
   Card,
+  CardId,
+  DatabaseId,
   WritebackActionId,
   WritebackAction,
   WritebackQueryAction,
@@ -33,8 +35,8 @@ import CreateActionForm, {
 
 interface OwnProps {
   actionId?: WritebackActionId;
-  modelId: number;
-  databaseId?: number;
+  modelId?: CardId;
+  databaseId?: DatabaseId;
   onClose?: () => void;
 }
 
@@ -93,7 +95,7 @@ function ActionCreator({
 
   const [showSaveModal, setShowSaveModal] = useState(false);
 
-  const isEditable = model.canWriteActions();
+  const isEditable = isNew || model.canWriteActions();
 
   const handleCreate = async (values: CreateActionFormValues) => {
     if (action.type !== "query") {
@@ -196,8 +198,9 @@ export default _.compose(
     entityAlias: "initialAction",
   }),
   Questions.load({
-    id: (state: State, props: OwnProps) => props.modelId,
+    id: (state: State, props: OwnProps) => props?.modelId,
     entityAlias: "modelCard",
+    loadingAndErrorWrapper: false,
   }),
   Database.loadList(),
   connect(mapStateToProps, mapDispatchToProps),

--- a/frontend/src/metabase/actions/containers/ActionCreator/ActionCreator.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/ActionCreator.tsx
@@ -37,6 +37,7 @@ interface OwnProps {
   actionId?: WritebackActionId;
   modelId?: CardId;
   databaseId?: DatabaseId;
+  onSubmit?: (action: WritebackAction) => void;
   onClose?: () => void;
 }
 
@@ -80,6 +81,7 @@ function ActionCreator({
   model,
   onCreateAction,
   onUpdateAction,
+  onSubmit,
   onClose,
 }: Props) {
   const {
@@ -102,26 +104,30 @@ function ActionCreator({
       return; // only query action creation is supported now
     }
 
-    await onCreateAction({
+    const reduxAction = await onCreateAction({
       ...action,
       ...values,
       visualization_settings: formSettings,
     } as WritebackQueryAction);
+    const createdAction = Actions.HACK_getObjectFromAction(reduxAction);
 
     // Sync the editor state with data from save modal form
     handleActionChange(values);
 
     setShowSaveModal(false);
+    onSubmit?.(createdAction);
     onClose?.();
   };
 
-  const handleUpdate = () => {
+  const handleUpdate = async () => {
     if (isSavedAction(action)) {
-      onUpdateAction({
+      const reduxAction = await onUpdateAction({
         ...action,
         model_id: model.id(),
         visualization_settings: formSettings,
       });
+      const updatedAction = Actions.HACK_getObjectFromAction(reduxAction);
+      onSubmit?.(updatedAction);
     }
   };
 

--- a/frontend/src/metabase/actions/containers/ActionCreator/ActionCreator.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/ActionCreator.tsx
@@ -206,7 +206,6 @@ export default _.compose(
   Questions.load({
     id: (state: State, props: OwnProps) => props?.modelId,
     entityAlias: "modelCard",
-    loadingAndErrorWrapper: false,
   }),
   Database.loadList(),
   connect(mapStateToProps, mapDispatchToProps),

--- a/frontend/src/metabase/components/NewItemMenu/NewItemMenu.tsx
+++ b/frontend/src/metabase/components/NewItemMenu/NewItemMenu.tsx
@@ -1,17 +1,19 @@
 import React, { ReactNode, useCallback, useMemo, useState } from "react";
 import { t } from "ttag";
+import type { LocationDescriptor } from "history";
 
 import Modal from "metabase/components/Modal";
 import EntityMenu from "metabase/components/EntityMenu";
 
 import * as Urls from "metabase/lib/urls";
 
+import ActionCreator from "metabase/actions/containers/ActionCreator";
 import CreateCollectionModal from "metabase/collections/containers/CreateCollectionModal";
 import CreateDashboardModal from "metabase/dashboard/containers/CreateDashboardModal";
 
-import type { CollectionId } from "metabase-types/api";
+import type { CollectionId, WritebackAction } from "metabase-types/api";
 
-type ModalType = "new-dashboard" | "new-collection";
+type ModalType = "new-action" | "new-dashboard" | "new-collection";
 
 export interface NewItemMenuProps {
   className?: string;
@@ -20,10 +22,13 @@ export interface NewItemMenuProps {
   triggerIcon?: string;
   triggerTooltip?: string;
   analyticsContext?: string;
+  hasModels: boolean;
   hasDataAccess: boolean;
   hasNativeWrite: boolean;
   hasDatabaseWithJsonEngine: boolean;
+  hasDatabaseWithActionsEnabled: boolean;
   onCloseNavbar: () => void;
+  onChangeLocation: (nextLocation: LocationDescriptor) => void;
 }
 
 const NewItemMenu = ({
@@ -33,16 +38,27 @@ const NewItemMenu = ({
   triggerIcon,
   triggerTooltip,
   analyticsContext,
+  hasModels,
   hasDataAccess,
   hasNativeWrite,
   hasDatabaseWithJsonEngine,
+  hasDatabaseWithActionsEnabled,
   onCloseNavbar,
+  onChangeLocation,
 }: NewItemMenuProps) => {
   const [modal, setModal] = useState<ModalType>();
 
   const handleModalClose = useCallback(() => {
     setModal(undefined);
   }, []);
+
+  const handleActionCreated = useCallback(
+    (action: WritebackAction) => {
+      const nextLocation = Urls.modelDetail({ id: action.model_id }, "actions");
+      onChangeLocation(nextLocation);
+    },
+    [onChangeLocation],
+  );
 
   const menuItems = useMemo(() => {
     const items = [];
@@ -98,11 +114,22 @@ const NewItemMenu = ({
       });
     }
 
+    if (hasModels && hasDatabaseWithActionsEnabled && hasNativeWrite) {
+      items.push({
+        title: t`Action`,
+        icon: "bolt",
+        action: () => setModal("new-action"),
+        event: `${analyticsContext};New Action Click;`,
+      });
+    }
+
     return items;
   }, [
+    hasModels,
     hasDataAccess,
     hasNativeWrite,
     hasDatabaseWithJsonEngine,
+    hasDatabaseWithActionsEnabled,
     analyticsContext,
     onCloseNavbar,
   ]);
@@ -129,6 +156,13 @@ const NewItemMenu = ({
             <Modal onClose={handleModalClose}>
               <CreateDashboardModal
                 collectionId={collectionId}
+                onClose={handleModalClose}
+              />
+            </Modal>
+          ) : modal === "new-action" ? (
+            <Modal wide enableTransition={false} onClose={handleModalClose}>
+              <ActionCreator
+                onSubmit={handleActionCreated}
                 onClose={handleModalClose}
               />
             </Modal>

--- a/frontend/src/metabase/containers/NewItemMenu/NewItemMenu.tsx
+++ b/frontend/src/metabase/containers/NewItemMenu/NewItemMenu.tsx
@@ -1,36 +1,56 @@
 import { connect } from "react-redux";
+import { push } from "react-router-redux";
 import _ from "underscore";
-import { closeNavbar } from "metabase/redux/app";
+
 import NewItemMenu from "metabase/components/NewItemMenu";
+
 import Databases from "metabase/entities/databases";
+import Search from "metabase/entities/search";
+
+import { closeNavbar } from "metabase/redux/app";
 import {
   getHasDataAccess,
   getHasDatabaseWithJsonEngine,
   getHasNativeWrite,
+  getHasDatabaseWithActionsEnabled,
 } from "metabase/selectors/data";
+
 import { Database } from "metabase-types/api";
 import { State } from "metabase-types/store";
 
 interface MenuDatabaseProps {
   databases?: Database[];
+
+  // Search results (untyped yet)
+  models?: unknown[];
 }
 
 const mapStateToProps = (
   state: State,
-  { databases = [] }: MenuDatabaseProps,
+  { databases = [], models = [] }: MenuDatabaseProps,
 ) => ({
+  hasModels: models.length > 0,
   hasDataAccess: getHasDataAccess(databases),
   hasNativeWrite: getHasNativeWrite(databases),
   hasDatabaseWithJsonEngine: getHasDatabaseWithJsonEngine(databases),
+  hasDatabaseWithActionsEnabled: getHasDatabaseWithActionsEnabled(databases),
 });
 
 const mapDispatchToProps = {
   onCloseNavbar: closeNavbar,
+  onChangeLocation: push,
 };
 
 export default _.compose(
   Databases.loadList({
     loadingAndErrorWrapper: false,
+  }),
+  Search.loadList({
+    // Checking if there is at least one model,
+    // so we can decide if "Action" option should be shown
+    query: { models: "dataset", limit: 1 },
+    loadingAndErrorWrapper: false,
+    listName: "models",
   }),
   connect(mapStateToProps, mapDispatchToProps),
 )(NewItemMenu);

--- a/frontend/src/metabase/containers/NewItemMenu/NewItemMenu.tsx
+++ b/frontend/src/metabase/containers/NewItemMenu/NewItemMenu.tsx
@@ -15,8 +15,8 @@ import {
   getHasDatabaseWithActionsEnabled,
 } from "metabase/selectors/data";
 
-import { Database, CollectionItem } from "metabase-types/api";
-import { State } from "metabase-types/store";
+import type { Database, CollectionItem } from "metabase-types/api";
+import type { State } from "metabase-types/store";
 
 interface MenuDatabaseProps {
   databases?: Database[];

--- a/frontend/src/metabase/containers/NewItemMenu/NewItemMenu.tsx
+++ b/frontend/src/metabase/containers/NewItemMenu/NewItemMenu.tsx
@@ -15,14 +15,12 @@ import {
   getHasDatabaseWithActionsEnabled,
 } from "metabase/selectors/data";
 
-import { Database } from "metabase-types/api";
+import { Database, CollectionItem } from "metabase-types/api";
 import { State } from "metabase-types/store";
 
 interface MenuDatabaseProps {
   databases?: Database[];
-
-  // Search results (untyped yet)
-  models?: unknown[];
+  models?: CollectionItem[];
 }
 
 const mapStateToProps = (

--- a/frontend/src/metabase/containers/NewItemMenu/NewItemMenu.unit.spec.tsx
+++ b/frontend/src/metabase/containers/NewItemMenu/NewItemMenu.unit.spec.tsx
@@ -10,10 +10,13 @@ import { createMockCard, createMockDatabase } from "metabase-types/api/mocks";
 
 import NewItemMenu from "./NewItemMenu";
 
-// eslint-disable-next-line react/display-name
-jest.mock("metabase/actions/containers/ActionCreator", () => () => (
-  <div data-testid="mock-action-editor" />
-));
+jest.mock(
+  "metabase/actions/containers/ActionCreator",
+  () =>
+    function ActionCreator() {
+      return <div data-testid="mock-action-editor" />;
+    },
+);
 
 console.warn = jest.fn();
 console.error = jest.fn();
@@ -55,7 +58,7 @@ function setup({
 
   setupDatabasesEndpoints(scope, databases);
 
-  scope.get(/\/api\/search+/).reply(200, {
+  scope.get(/\/api\/search/).reply(200, {
     available_models: ["dataset"],
     models: ["dataset"],
     data: models,

--- a/frontend/src/metabase/containers/NewItemMenu/NewItemMenu.unit.spec.tsx
+++ b/frontend/src/metabase/containers/NewItemMenu/NewItemMenu.unit.spec.tsx
@@ -67,6 +67,10 @@ function setup({
 }
 
 describe("NewItemMenu", () => {
+  afterEach(() => {
+    nock.cleanAll();
+  });
+
   describe("New Action", () => {
     it("should open action editor on click", async () => {
       setup();

--- a/frontend/src/metabase/containers/NewItemMenu/NewItemMenu.unit.spec.tsx
+++ b/frontend/src/metabase/containers/NewItemMenu/NewItemMenu.unit.spec.tsx
@@ -1,0 +1,95 @@
+import React from "react";
+import nock from "nock";
+import userEvent from "@testing-library/user-event";
+
+import { renderWithProviders, screen } from "__support__/ui";
+import { setupDatabasesEndpoints } from "__support__/server-mocks";
+
+import type { Database } from "metabase-types/api";
+import { createMockCard, createMockDatabase } from "metabase-types/api/mocks";
+
+import NewItemMenu from "./NewItemMenu";
+
+// eslint-disable-next-line react/display-name
+jest.mock("metabase/actions/containers/ActionCreator", () => () => (
+  <div data-testid="mock-action-editor" />
+));
+
+console.warn = jest.fn();
+console.error = jest.fn();
+
+type SetupOpts = {
+  databases?: Database[];
+  hasModels?: boolean;
+};
+
+const SAMPLE_DATABASE = createMockDatabase({
+  id: 1,
+  engine: "postgres",
+  name: "Sample Database",
+  native_permissions: "write",
+  is_sample: true,
+  settings: null,
+});
+
+const DB_WITH_ACTIONS = createMockDatabase({
+  id: 2,
+  name: "Postgres with actions",
+  engine: "postgres",
+  native_permissions: "write",
+  settings: { "database-enable-actions": true },
+});
+
+const DB_WITHOUT_WRITE_ACCESS = createMockDatabase({
+  ...DB_WITH_ACTIONS,
+  id: 3,
+  native_permissions: "none",
+});
+
+function setup({
+  databases = [SAMPLE_DATABASE, DB_WITH_ACTIONS],
+  hasModels = true,
+}: SetupOpts = {}) {
+  const scope = nock(location.origin);
+  const models = hasModels ? [createMockCard({ dataset: true })] : [];
+
+  setupDatabasesEndpoints(scope, databases);
+
+  scope.get(/\/api\/search+/).reply(200, {
+    available_models: ["dataset"],
+    models: ["dataset"],
+    data: models,
+    total: models.length,
+  });
+
+  renderWithProviders(<NewItemMenu trigger={<button>New</button>} />);
+  userEvent.click(screen.getByText("New"));
+}
+
+describe("NewItemMenu", () => {
+  describe("New Action", () => {
+    it("should open action editor on click", async () => {
+      setup();
+
+      userEvent.click(await screen.findByText("Action"));
+      const modal = screen.getByRole("dialog");
+
+      expect(modal).toBeVisible();
+    });
+
+    it("should not be visible if there are no databases with actions enabled", () => {
+      setup({ databases: [SAMPLE_DATABASE] });
+      expect(screen.queryByText("Action")).not.toBeInTheDocument();
+    });
+
+    it("should not be visible if user has no models", () => {
+      setup({ hasModels: false });
+      expect(screen.queryByText("Action")).not.toBeInTheDocument();
+    });
+
+    it("should not be visible if user has no write data access", () => {
+      setup({ databases: [DB_WITHOUT_WRITE_ACCESS] });
+      expect(screen.queryByText("Action")).not.toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/metabase/lib/urls/models.ts
+++ b/frontend/src/metabase/lib/urls/models.ts
@@ -18,7 +18,7 @@ export function model(
 }
 
 export function modelDetail(card: CardOrSearchResult, tab = "") {
-  const baseUrl = `${model(card)}/detail`;
+  const baseUrl = `${model({ ...card, dataset: true })}/detail`;
   return tab ? `${baseUrl}/${tab}` : baseUrl;
 }
 

--- a/frontend/src/metabase/nav/components/NewItemButton/NewItemButton.tsx
+++ b/frontend/src/metabase/nav/components/NewItemButton/NewItemButton.tsx
@@ -22,7 +22,7 @@ const NewItemButton = ({ collectionId }: NewItemButtonProps) => {
         </NewButton>
       }
       collectionId={collectionId}
-      analyticsContext={"NavBar"}
+      analyticsContext="NavBar"
     />
   );
 };

--- a/frontend/src/metabase/selectors/data.ts
+++ b/frontend/src/metabase/selectors/data.ts
@@ -16,3 +16,9 @@ export const getHasNativeWrite = (databases: Database[]) => {
 export const getHasDatabaseWithJsonEngine = (databases: Database[]) => {
   return databases.some(d => getEngineNativeType(d.engine) === "json");
 };
+
+export const getHasDatabaseWithActionsEnabled = (databases: Database[]) => {
+  return databases.some(
+    database => !!database.settings?.["database-enable-actions"],
+  );
+};

--- a/frontend/test/metabase/scenarios/models/model-actions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/model-actions.cy.spec.js
@@ -154,9 +154,7 @@ describe(
       popover().findByText("Action").click();
 
       cy.findByText("Select a database").click();
-      popover()
-        .findByText(/QA Postgres/i)
-        .click();
+      popover().findByText("QA Postgres12").click();
 
       fillActionQuery(QUERY);
       cy.findByRole("button", { name: "Save" }).click();

--- a/frontend/test/metabase/scenarios/models/model-actions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/model-actions.cy.spec.js
@@ -146,6 +146,34 @@ describe(
       cy.findByText("Delete").should("not.exist");
     });
 
+    it("should allow to create an action with the New button", () => {
+      const QUERY = "UPDATE orders SET discount = {{ discount }}";
+      cy.visit("/");
+
+      cy.findByText("New").click();
+      popover().findByText("Action").click();
+
+      cy.findByText("Select a database").click();
+      popover()
+        .findByText(/QA Postgres/i)
+        .click();
+
+      fillActionQuery(QUERY);
+      cy.findByRole("button", { name: "Save" }).click();
+      modal().within(() => {
+        cy.findByLabelText("Name").type("Discount order");
+        cy.findByText("Select a model").click();
+      });
+      popover().findByText(SAMPLE_ORDERS_MODEL.name).click();
+      cy.findByRole("button", { name: "Create" }).click();
+
+      cy.get("@modelId").then(modelId => {
+        cy.url().should("include", `/model/${modelId}/detail/actions`);
+      });
+      cy.findByText("Discount order").should("be.visible");
+      cy.findByText(QUERY).should("be.visible");
+    });
+
     it("should allow to execute actions from the model page", () => {
       cy.get("@modelId").then(modelId => {
         createAction({


### PR DESCRIPTION
Epic #27581

Allows to create new query actions using the "New" button in the top application bar

The "Action" menu item should only show up when:

* there's at least one model available
* there's at least one database with native "write" permission
* there's at least one database with actions enabled

### How to verify

1. From any non-admin page in Metabase, click the "+ New" button in the top bar
2. Click "Action", fill in the query, click save, pick a model, etc.
3. Ensure you end up on the model detail page

### Demo

https://user-images.githubusercontent.com/17258145/219768369-8e154d8d-084d-4450-a956-80aa1fd20842.mp4

### Checklist

- [x] Tests have been added/updated to cover changes in this PR

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/28419)
<!-- Reviewable:end -->
