### PR TITLE
Robuster Snowflake data loading

### DIFF
--- a/modules/drivers/snowflake/test/metabase/test/data/snowflake.clj
+++ b/modules/drivers/snowflake/test/metabase/test/data/snowflake.clj
@@ -80,7 +80,7 @@
 
   This is a function because [[unique-prefix]] can't be calculated until the application database is initialized
   because it relies on [[public-settings/site-uuid]]."
-  #'unique-prefix)
+  (memoize unique-prefix))
 
 (defn- qualified-db-name
   "Prepend `database-name` with the [[*database-prefix-fn*]] so we don't stomp on any other jobs running at the same


### PR DESCRIPTION
Whelp I messed up in #28420

If tests are running at like 11:55 PM UTC and then cross over the boundary to a new date then a specific test, `metabase.driver.snowflake-test/report-timezone-test`, will fail because it's calling the function to generate the unique prefix again and getting one for the next day, and that database doesn't exist. This is the guilty LoC: 

https://github.com/metabase/metabase/blob/72b4c637f63045d34cb7b7bd7ad590442807ca9e/modules/drivers/snowflake/test/metabase/driver/snowflake_test.clj#L196

And I did actually see this fail IRL today so it's not just my imagination.

Fix was to have the default `*database-prefix-fn*` be `(memoize unique-prefix)` rather than just `unique-prefix` so it will not change in the middle of a test run.

Before you ask why this is even a function in the first place, the short answer is that it has to be since the prefix includes `site-uuid` which cannot be determined in a top-level form because it's a Setting and Settings rely on the application database. So we have to wait until we need it to calculate it. I guess it could be a delay or something but that realization didn't come to me until just now and I don't feel like changing it