### PR TITLE
[CI] Improve `codenotify` workflow

### DIFF
--- a/.github/workflows/codenotify.yml
+++ b/.github/workflows/codenotify.yml
@@ -6,7 +6,7 @@ on:
     # We're currently notifying developers only for frontend source changes.
     # Update this glob if that ever changes and we start including backend source code changes.
     paths:
-      - '**/frontend/src/metabase*/**.js'
+      - '**/frontend/src/metabase*/**'
 
 jobs:
   codenotify:

--- a/.github/workflows/codenotify.yml
+++ b/.github/workflows/codenotify.yml
@@ -6,7 +6,8 @@ on:
     # We're currently notifying developers only for frontend source changes.
     # Update this glob if that ever changes and we start including backend source code changes.
     paths:
-      - '**/frontend/src/metabase*/**'
+      - 'frontend/src/metabase/**'
+      - 'enterprise/frontend/src/metabase-enterprise/**'
 
 jobs:
   codenotify:

--- a/.github/workflows/codenotify.yml
+++ b/.github/workflows/codenotify.yml
@@ -16,6 +16,6 @@ jobs:
       - uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-      - uses: sourcegraph/codenotify@v0.4
+      - uses: sourcegraph/codenotify@v0.6.4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/codenotify.yml
+++ b/.github/workflows/codenotify.yml
@@ -3,6 +3,10 @@ name: Codenotify
 on:
   pull_request:
     types: [opened, synchronize, ready_for_review]
+    # We're currently notifying developers only for frontend source changes.
+    # Update this glob if that ever changes and we start including backend source code changes.
+    paths:
+      - '**/frontend/src/metabase*/**.js'
 
 jobs:
   codenotify:


### PR DESCRIPTION
If you search the codebase for `CODENOTIFY`, you'll notice it only ever relates to the frontend source changes.

```
❯ find . -type f -name CODENOTIFY
./frontend/src/metabase/home/homepage/CODENOTIFY
./frontend/src/metabase/sharing/CODENOTIFY
./frontend/src/metabase/auth/CODENOTIFY
./frontend/src/metabase/setup/CODENOTIFY
./frontend/src/metabase/status/CODENOTIFY
./frontend/src/metabase/timelines/CODENOTIFY
./frontend/src/metabase/visualizations/CODENOTIFY
./frontend/src/metabase/lib/colors/CODENOTIFY
./frontend/src/metabase/lib/CODENOTIFY
./frontend/src/metabase/account/CODENOTIFY
./enterprise/frontend/src/metabase-enterprise/whitelabel/CODENOTIFY
./enterprise/frontend/src/metabase-enterprise/advanced_config/CODENOTIFY
```

This PR adds path filtering that is slightly more permissive than this, but still scopes paths to source FE code to avoid unnecessary workflow runs.

This workflow ran for ~23-25k minutes to this date!