### PR TITLE
Remove reynes fs dep

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -77,8 +77,6 @@
   joda-time/joda-time                       {:mvn/version "2.12.2"}
   kixi/stats                                {:mvn/version "0.4.4"               ; Various statistic measures implemented as transducers
                                              :exclusions  [org.clojure/data.avl]}
-  me.raynes/fs                              {:mvn/version "1.4.6"               ; Filesystem tools
-                                             :exclusions  [org.apache.commons/commons-compress]}
   medley/medley                             {:mvn/version "1.4.0"}              ; lightweight lib of useful functions
   metabase/connection-pool                  {:mvn/version "1.2.0"}              ; simple wrapper around C3P0. JDBC connection pools
   metabase/saml20-clj                       {:mvn/version "2.1.0"}              ; EE SAML integration


### PR DESCRIPTION
According to @dpsutton is not used anymore. I wasn’t able to find it on the code as well