### PR TITLE
Redirect from model detail if a question ID passed

### DIFF
--- a/frontend/src/metabase/models/containers/ModelDetailPage/ModelDetailPage.tsx
+++ b/frontend/src/metabase/models/containers/ModelDetailPage/ModelDetailPage.tsx
@@ -121,7 +121,13 @@ function ModelDetailPage({
   }, [location.pathname]);
 
   useMount(() => {
-    loadMetadataForCard(model.card());
+    const card = model.card();
+    const isModel = model.isDataset();
+    if (isModel) {
+      loadMetadataForCard(card);
+    } else {
+      onChangeLocation(Urls.question(card));
+    }
   });
 
   useEffect(() => {

--- a/frontend/src/metabase/models/containers/ModelDetailPage/ModelDetailPage.unit.spec.tsx
+++ b/frontend/src/metabase/models/containers/ModelDetailPage/ModelDetailPage.unit.spec.tsx
@@ -220,24 +220,27 @@ async function setup({
   const initialRoute = `${baseUrl}/${tab}`;
 
   const { store, history } = renderWithProviders(
-    <Route path="/model/:slug/detail">
-      <IndexRedirect to="usage" />
-      <Route path="usage" component={ModelDetailPage} />
-      <Route path="schema" component={ModelDetailPage} />
-      <Route path="actions" component={ModelDetailPage}>
-        <ModalRoute
-          path="new"
-          modal={ActionCreator}
-          modalProps={{ enableTransition: false }}
-        />
-        <ModalRoute
-          path=":actionId"
-          modal={ActionCreator}
-          modalProps={{ enableTransition: false }}
-        />
+    <>
+      <Route path="/model/:slug/detail">
+        <IndexRedirect to="usage" />
+        <Route path="usage" component={ModelDetailPage} />
+        <Route path="schema" component={ModelDetailPage} />
+        <Route path="actions" component={ModelDetailPage}>
+          <ModalRoute
+            path="new"
+            modal={ActionCreator}
+            modalProps={{ enableTransition: false }}
+          />
+          <ModalRoute
+            path=":actionId"
+            modal={ActionCreator}
+            modalProps={{ enableTransition: false }}
+          />
+        </Route>
+        <Redirect from="*" to="usage" />
       </Route>
-      <Redirect from="*" to="usage" />
-    </Route>,
+      <Route path="/question/:slug" component={() => null} />
+    </>,
     { withRouter: true, initialRoute },
   );
 
@@ -887,6 +890,13 @@ describe("ModelDetailPage", () => {
         "aria-selected",
         "true",
       );
+    });
+
+    it("redirects to query builder when trying to open a question", async () => {
+      const question = getSavedStructuredQuestion();
+      const { history } = await setup({ model: question });
+
+      expect(history?.getCurrentLocation().pathname).toBe(question.getUrl());
     });
 
     it("shows 404 when opening an archived model", async () => {


### PR DESCRIPTION
Epic #27581

Adds a redirect from `/model/:modelId/detail` to `/question/:questionId` when `modelId` is not a question modal

### How to verify

1. Paste `/model/:modelId/detail` with `modelId` being a question ID in your browser's address bar
2. Ensure you're redirected to `/question/:id`
3. Ensure you can still visit the model detail page for actual models

### Demo

https://user-images.githubusercontent.com/17258145/220099925-f8617cfc-0972-46fb-abc3-4ca0c2d3e898.mp4

### Checklist

- [x] Tests have been added/updated to cover changes in this PR

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/28442)
<!-- Reviewable:end -->
