### PR TITLE
Show not found view when opening archived model

### DIFF
--- a/frontend/src/metabase-lib/Question.ts
+++ b/frontend/src/metabase-lib/Question.ts
@@ -918,6 +918,10 @@ class QuestionInner {
     return table ? table.id : null;
   }
 
+  isArchived(): boolean {
+    return this._card && this._card.archived;
+  }
+
   getUrl({
     originalQuestion,
     clean = true,

--- a/frontend/src/metabase/models/containers/ModelDetailPage/ModelDetailPage.tsx
+++ b/frontend/src/metabase/models/containers/ModelDetailPage/ModelDetailPage.tsx
@@ -2,9 +2,11 @@ import React, { useEffect, useCallback, useMemo, useState } from "react";
 import _ from "underscore";
 import { connect } from "react-redux";
 import { replace } from "react-router-redux";
+import { useMount } from "react-use";
 import type { Location, LocationDescriptor } from "history";
 
-import { useMount } from "react-use";
+import { NotFound } from "metabase/containers/ErrorPages";
+
 import * as Urls from "metabase/lib/urls";
 
 import Actions from "metabase/entities/actions";
@@ -167,6 +169,10 @@ function ModelDetailPage({
     },
     [model, onChangeCollection],
   );
+
+  if (model.isArchived()) {
+    return <NotFound />;
+  }
 
   return (
     <>

--- a/frontend/src/metabase/models/containers/ModelDetailPage/ModelDetailPage.unit.spec.tsx
+++ b/frontend/src/metabase/models/containers/ModelDetailPage/ModelDetailPage.unit.spec.tsx
@@ -864,5 +864,16 @@ describe("ModelDetailPage", () => {
         "true",
       );
     });
+
+    it("shows 404 when opening an archived model", async () => {
+      const model = getStructuredModel({ archived: true });
+      const modelName = model.displayName() as string;
+      await setup({ model });
+
+      expect(screen.queryByText(modelName)).not.toBeInTheDocument();
+      expect(
+        screen.getByText("The page you asked for couldn't be found."),
+      ).toBeInTheDocument();
+    });
   });
 });


### PR DESCRIPTION
Epic #27581

Fixes it was possible to open a model detail page for an archived model. Metabase will now display a "not found" message.

### How to verify

1. Create and archive a model
2. Open `/model/:modelId/detail` with this model's ID
3. Ensure you see a not found view
4. Ensure you can still access the page for not-archived models

### Demo

https://user-images.githubusercontent.com/17258145/220106135-53ee169b-45a6-47c4-a5e7-79997a5ead17.mp4

### Checklist

- [x] Tests have been added/updated to cover changes in this PR

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/28443)
<!-- Reviewable:end -->
