### PR TITLE
[Ci] Fix wildcard glob pattern

### DIFF
--- a/.github/file-paths.yaml
+++ b/.github/file-paths.yaml
@@ -26,7 +26,7 @@ frontend_sources: &frontend_sources
 frontend_specs: &frontend_specs
   - *shared_specs
   - "frontend/test/!(__support__|__runner__)/**"
-  - "frontend/**.unit.*"
+  - "frontend/**/*.unit.*"
   - "jest.config.js"
 
 frontend_all: &frontend_all
@@ -68,7 +68,7 @@ sources: &sources
   - *backend_sources
 
 e2e_specs: &e2e_specs
-  - "**.cy.*.js"
+  - "**/*.cy.*.js"
   - "frontend/test/__support__/e2e/**"
   - "frontend/test/__runner__/*cypress*"
 
@@ -84,8 +84,8 @@ snowplow:
 
 documentation:
   - "docs/**"
-  - "**.md"
+  - "**/*.md"
 
 yaml:
-  - "**.yml"
-  - "**.yaml"
+  - "**/*.yml"
+  - "**/*.yaml"


### PR DESCRIPTION
I've just realized that Cypress tests were all skipped when I committed a Cypress file change! 😮 
https://github.com/metabase/metabase/actions/runs/4223580904/jobs/7333489202

```
Run dorny/paths-filter@v2.11.1
Fetching list of changed files for PR#28445 from Github API
  Invoking listFiles(pull_number: 2[8](https://github.com/metabase/metabase/actions/runs/4223580904/jobs/7333489202#step:3:9)445, per_page: 100)
  Received 1 items
  [modified] frontend/test/metabase/scenarios/permissions/application-permissions.cy.spec.js
Detected 1 changed files
Results:
Filter default = false
Filter ci = false
Filter shared_sources = false
Filter shared_specs = false
Filter frontend_sources = false
Filter frontend_specs = true  <<<< wrong
Filter frontend_all = true  <<<< wrong
Filter backend_presto_kerberos = false
Filter backend_sources = false
Filter backend_specs = false
Filter backend_all = false
Filter sources = false
Filter e2e_specs = false  <<<< wrong
Filter e2e_all = false  <<<< wrong
Filter snowplow = false
Filter documentation = false
Filter yaml = false
Changes output set to ["frontend_specs","frontend_all"]
```

It ran frontend tests (which is a bug I'm trying to fix in https://github.com/metabase/metabase/pull/28366), and completely skipped all E2E specs.

The root cause is the difference between the glob library that GitHub is using vs the one that `dorny/paths-filter` is using!

[Filter pattern cheat sheet for Github](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet)
`**` matches zero or more of **any** character **including `/`**

In the glob library that this action is using ([picomatch](https://github.com/micromatch/picomatch)), it seems that it doesn't work like that, even though [their definition is confusingly similar](https://github.com/micromatch/picomatch#basic-globbing):
> Matches any character zero or more times, including path separators. Note that `**` will only match path separators (`/`, and `\\` on Windows) when they are the only characters in a path segment.
