### PR TITLE
Fix serdes for query actions missing database dependency

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
@@ -769,7 +769,7 @@
               (let [ser (serdes.base/extract-one "Action" {} action)]
                 (is (schema= {:serdes/meta (s/eq [{:model "Action" :id (:entity_id action) :label "my_action"}])
                               :creator_id  (s/eq "ann@heart.band")
-                              :type        (s/eq :implicit)
+                              :type        (s/eq "implicit")
                               :kind        (s/eq "row/update")
                               :created_at  OffsetDateTime
                               :model_id    (s/eq card-eid-1)
@@ -805,6 +805,7 @@
               (let [ser (serdes.base/extract-one "Action" {} action)]
                 (is (schema= {:serdes/meta (s/eq [{:model "Action" :id (:entity_id action) :label "my_action"}])
                               :creator_id  (s/eq "ann@heart.band")
+                              :type        (s/eq "http")
                               :created_at  OffsetDateTime
                               :template    (s/eq {})
                               :model_id    (s/eq card-eid-1)
@@ -842,6 +843,7 @@
                 (is (schema= {:serdes/meta   (s/eq [{:model "Action"
                                                      :id    (:entity_id action)
                                                      :label "my_action"}])
+                              :type          (s/eq "query")
                               :creator_id    (s/eq "ann@heart.band")
                               :created_at    OffsetDateTime
                               :dataset_query (s/eq {:type "native", :native {:native "select 1"}, :database db-id})

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
@@ -7,7 +7,8 @@
    [metabase-enterprise.serialization.v2.ingest :as serdes.ingest]
    [metabase-enterprise.serialization.v2.load :as serdes.load]
    [metabase.models
-    :refer [Card
+    :refer [Action
+            Card
             Collection
             Dashboard
             DashboardCard
@@ -21,6 +22,7 @@
             Timeline
             TimelineEvent
             User]]
+   [metabase.models.action :as action]
    [metabase.models.serialization.base :as serdes.base]
    [metabase.util :as u]
    [schema.core :as s]
@@ -939,3 +941,39 @@
                        :template-tags
                        (get "snippet: things")
                        :snippet-id)))))))))
+
+(deftest load-action-test
+  (let [serialized (atom nil)
+        eid (u/generate-nano-id)]
+    (ts/with-source-and-dest-dbs
+      (testing "extraction succeeds"
+        (ts/with-source-db
+          (let [db       (ts/create! Database :name "my-db")
+                card     (ts/create! Card
+                                     :name "the query"
+                                     :query_type :native
+                                     :dataset true
+                                     :database_id (:id db)
+                                     :dataset_query {:database (:id db)
+                                                     :native {:type   :native
+                                                              :native {:query "wow"}}})
+                _action-id (action/insert! {:entity_id     eid
+                                            :name          "the action"
+                                            :model_id      (:id card)
+                                            :type          :query
+                                            :dataset_query "wow"
+                                            :database_id   (:id db)})]
+            (reset! serialized (into [] (serdes.extract/extract-metabase {})))
+            (let [action-serialized (first (filter (fn [{[{:keys [model id]}] :serdes/meta}]
+                                                     (and (= model "Action") (= id eid)))
+                                                   @serialized))]
+              (is (some? action-serialized))
+              (testing ":type should be a string"
+                (is (string? (:type action-serialized))))))))
+      (testing "loading succeeds"
+        (ts/with-dest-db
+          (serdes.load/load-metabase (ingestion-in-memory @serialized))
+          (let [action (db/select-one Action :entity_id eid)]
+            (is (some? action))
+            (testing ":type should be a keyword again"
+              (is (keyword? (:type action))))))))))

--- a/src/metabase/models/action.clj
+++ b/src/metabase/models/action.clj
@@ -267,7 +267,6 @@
   (-> (serdes.base/extract-one-basics "Action" action)
       (update :creator_id serdes.util/export-user)
       (update :model_id serdes.util/export-fk 'Card)
-      ;; :type is a keywordized in the model, but needs to be serialized as a string
       (update :type name)
       (cond-> (= (:type action) :query)
         (update :database_id serdes.util/export-fk-keyed 'Database :name))))

--- a/src/metabase/models/action.clj
+++ b/src/metabase/models/action.clj
@@ -26,7 +26,7 @@
   "Returns the model from an action type.
    `action-type` can be a string or a keyword."
   [action-type]
-  (case (keyword action-type)
+  (case action-type
     :http     HTTPAction
     :implicit ImplicitAction
     :query    QueryAction))
@@ -267,6 +267,8 @@
   (-> (serdes.base/extract-one-basics "Action" action)
       (update :creator_id serdes.util/export-user)
       (update :model_id serdes.util/export-fk 'Card)
+      ;; :type is a keywordized in the model, but needs to be serialized as a string
+      (update :type name)
       (cond-> (= (:type action) :query)
         (update :database_id serdes.util/export-fk-keyed 'Database :name))))
 
@@ -275,6 +277,7 @@
       serdes.base/load-xform-basics
       (update :creator_id serdes.util/import-user)
       (update :model_id serdes.util/import-fk 'Card)
+      (update :type keyword)
       (cond-> (= (:type action) "query")
         (update :database_id serdes.util/import-fk-keyed 'Database :name))))
 
@@ -289,7 +292,7 @@
 
 (defmethod serdes.base/serdes-dependencies "Action" [action]
   (concat [[{:model "Card" :id (:model_id action)}]]
-    (when (= (:type action) :query)
+    (when (= (:type action) "query")
       [[{:model "Database" :id (:database_id action)}]])))
 
 (defmethod serdes.base/storage-path "Action" [action _ctx]


### PR DESCRIPTION
This PR fixes a bug with serdes for query actions that is also causing a CI test to flake.

Currently, an error occurs when when serializing and deserializing the db with yaml, when a query action is loaded before the database it depends on is loaded:

```
org.h2.jdbc.JdbcSQLIntegrityConstraintViolationException: NULL not allowed for column "DATABASE_ID"; SQL statement:
                                                          INSERT INTO "QUERY_ACTION" ("DATABASE_ID", "DATASET_QUERY", "ACTION_ID") VALUES (NULL, ?, ?) [23502-212]
                SQL: "INSERT INTO \"QUERY_ACTION\" (\"DATABASE_ID\", \"DATASET_QUERY\", \"ACTION_ID\") VALUES (NULL, ?, ?)"
```

It is causing `metabase-enterprise.serialization.v2.e2e.yaml-test/e2e-storage-ingestion-test` to flake in CI ([example failure](https://github.com/metabase/metabase/actions/runs/4197523405/jobs/7294556452#step:4:449)). See this [slack discussion](https://metaboat.slack.com/archives/CKZEMT1MJ/p1676648480568839) for context

### Explanation of the bug

Serdes dependencies for actions are determined by this function (bug highlighted in the comments):
```clojure
(defmethod serdes.base/serdes-dependencies "Action" [action]
  (concat [[{:model "Card" :id (:model_id action)}]]
    (when (= (:type action) :query) ; <--- this should be "query", because during yaml serialization keywords become strings 
      [[{:model "Database" :id (:database_id action)}]])))
```

The `:type` of an action model instance is keywordized when it's selected from the DB, e.g. the `:type` might be `:query`. When it's serialized to yaml and ingested again, it becomes a string e.g. `"query"`. However, the `serdes.base/serdes-dependencies` function above expects `:type` to be a keyword, but it is a string if it has been ingested from yaml. The e2e tests pass most of the time because it's unlikely that a query action is loaded before the database, or everything else that depends on the database. And it wasn't caught in the [serdes-dependencies tests](enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj) because those tests don't do a round-trip with yaml serialization/deserialization. The tests assume the serialized entity is the same as the ingested entity.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/28449)
<!-- Reviewable:end -->
