### PR TITLE
[E2E] Fix search flake

### DIFF
--- a/frontend/test/metabase/scenarios/onboarding/search/search.cy.spec.js
+++ b/frontend/test/metabase/scenarios/onboarding/search/search.cy.spec.js
@@ -45,6 +45,9 @@ describe("scenarios > auth > search", () => {
       cy.visit("/");
       cy.findByPlaceholderText("Search…").type("ord");
       cy.wait("@search");
+      cy.findAllByTestId("search-result-item-name")
+        .first()
+        .should("have.text", "Orders");
 
       cy.realPress("ArrowDown");
       cy.realPress("Enter");

--- a/frontend/test/metabase/scenarios/onboarding/search/search.cy.spec.js
+++ b/frontend/test/metabase/scenarios/onboarding/search/search.cy.spec.js
@@ -38,7 +38,7 @@ describe("scenarios > auth > search", () => {
       cy.findByText("Didn't find anything");
     });
 
-    it("allows select a search result from keyboard", () => {
+    it("allows to select a search result using keyboard", () => {
       cy.intercept("GET", "/api/search*").as("search");
 
       cy.signInAsNormalUser();

--- a/frontend/test/metabase/scenarios/onboarding/search/search.cy.spec.js
+++ b/frontend/test/metabase/scenarios/onboarding/search/search.cy.spec.js
@@ -49,7 +49,7 @@ describe("scenarios > auth > search", () => {
       cy.realPress("ArrowDown");
       cy.realPress("Enter");
 
-      cy.url().should("match", /\/question\/1-orders$/);
+      cy.location("pathname").should("eq", "/question/1-orders");
     });
   });
 });

--- a/frontend/test/metabase/scenarios/onboarding/search/search.cy.spec.js
+++ b/frontend/test/metabase/scenarios/onboarding/search/search.cy.spec.js
@@ -46,8 +46,8 @@ describe("scenarios > auth > search", () => {
       cy.findByPlaceholderText("Search…").type("ord");
       cy.wait("@search");
 
-      cy.get("body").trigger("keydown", { key: "ArrowDown" });
-      cy.get("body").trigger("keydown", { key: "Enter" });
+      cy.realPress("ArrowDown");
+      cy.realPress("Enter");
 
       cy.url().should("match", /\/question\/1-orders$/);
     });


### PR DESCRIPTION
`cypress-real-events` library works flawlessly.
Let's use it for keyboard navigation exclusively, please.

Example of a failed run:
https://www.deploysentinel.com/ci/runs/63f362db06a72c0e9ca6794f