### PR TITLE
Show a submit button for an action without parameters

### DIFF
--- a/frontend/src/metabase/public/containers/PublicAction/PublicAction.tsx
+++ b/frontend/src/metabase/public/containers/PublicAction/PublicAction.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useMemo, useState } from "react";
 
-import { useMount } from "react-use";
 import title from "metabase/hoc/Title";
 import { PublicApi } from "metabase/services";
 
@@ -31,7 +30,6 @@ interface Props {
 
 function PublicAction({ action, publicId, onError }: Props) {
   const [isSubmitted, setSubmitted] = useState(false);
-  const hasParameters = action.parameters.length > 0;
   const successMessage = getSuccessMessage(action);
 
   const formSettings = useMemo(() => {
@@ -58,18 +56,8 @@ function PublicAction({ action, publicId, onError }: Props) {
     [publicId, formSettings, onError],
   );
 
-  useMount(() => {
-    if (!hasParameters) {
-      handleSubmit({});
-    }
-  });
-
   if (isSubmitted) {
     return <FormResultMessage>{successMessage}</FormResultMessage>;
-  }
-
-  if (!hasParameters) {
-    return null;
   }
 
   return (

--- a/frontend/src/metabase/public/containers/PublicAction/PublicAction.unit.spec.tsx
+++ b/frontend/src/metabase/public/containers/PublicAction/PublicAction.unit.spec.tsx
@@ -184,7 +184,7 @@ describe("PublicAction", () => {
     expect(screen.queryByRole("form")).not.toBeInTheDocument();
   });
 
-  it("does not immediately executes an action without parameters", async () => {
+  it("handles actions without parameters", async () => {
     const { executeActionEndpointSpy } = await setup({
       action: { ...TEST_ACTION, parameters: [] },
       expectedRequestBody: { parameters: {} },

--- a/frontend/src/metabase/public/containers/PublicAction/PublicAction.unit.spec.tsx
+++ b/frontend/src/metabase/public/containers/PublicAction/PublicAction.unit.spec.tsx
@@ -184,17 +184,14 @@ describe("PublicAction", () => {
     expect(screen.queryByRole("form")).not.toBeInTheDocument();
   });
 
-  it("immediately executes an action without parameters", async () => {
+  it("does not immediately executes an action without parameters", async () => {
     const { executeActionEndpointSpy } = await setup({
       action: { ...TEST_ACTION, parameters: [] },
       expectedRequestBody: { parameters: {} },
     });
 
-    expect(
-      await screen.findByText(`${TEST_ACTION.name} ran successfully`),
-    ).toBeInTheDocument();
-    expect(screen.queryByText(TEST_ACTION.name)).not.toBeInTheDocument();
-    expect(screen.queryByRole("form")).not.toBeInTheDocument();
-    expect(executeActionEndpointSpy.isDone()).toBe(true);
+    expect(screen.getByText(TEST_ACTION.name)).toBeInTheDocument();
+    userEvent.click(screen.getByRole("button", { name: "Submit" }));
+    await waitFor(() => expect(executeActionEndpointSpy.isDone()).toBe(true));
   });
 });


### PR DESCRIPTION
Epic https://github.com/metabase/metabase/issues/27626

How to verify:
- Create an action without parameters, e.g. `UPDATE PRODUCTS SET CATEGORY = CATEGORY`
- Make the action public and open the public form
- There should be an action name and the button to submit the form despite not having a single parameter to fill out

<img width="497" alt="Screenshot 2023-02-20 at 18 10 08" src="https://user-images.githubusercontent.com/8542534/220155600-825147b7-4175-46c8-a73e-3183d22eb816.png">

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/28453)
<!-- Reviewable:end -->
