### PR TITLE
Fix long form scroll behavior in the action editor

### DIFF
--- a/frontend/src/metabase/actions/containers/ActionCreator/ActionCreator.styled.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/ActionCreator.styled.tsx
@@ -44,3 +44,9 @@ export const ModalLeft = styled.div`
   flex-direction: column;
   border-right: 1px solid ${color("border")};
 `;
+
+export const ModalRight = styled.div`
+  position: relative;
+  display: flex;
+  overflow-y: auto;
+`;

--- a/frontend/src/metabase/actions/containers/ActionCreator/ActionCreatorView.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/ActionCreatorView.tsx
@@ -14,6 +14,7 @@ import {
   ModalRoot,
   ModalActions,
   ModalLeft,
+  ModalRight,
 } from "metabase/actions/containers/ActionCreator/ActionCreator.styled";
 
 import { isNotNull } from "metabase/core/utils/types";
@@ -116,24 +117,26 @@ export default function ActionCreatorView({
             )}
           </ModalActions>
         </ModalLeft>
-        {activeSideView === "actionForm" ? (
-          <FormCreator
-            params={action.parameters ?? []}
-            formSettings={formSettings}
-            isEditable={isEditable && canChangeFieldSettings}
-            onChange={onChangeFormSettings}
-          />
-        ) : activeSideView === "dataReference" ? (
-          <DataReferenceInline onClose={closeSideView} />
-        ) : activeSideView === "actionSettings" ? (
-          <InlineActionSettings
-            action={action}
-            formSettings={formSettings}
-            isEditable={isEditable}
-            onChangeFormSettings={onChangeFormSettings}
-            onClose={closeSideView}
-          />
-        ) : null}
+        <ModalRight>
+          {activeSideView === "actionForm" ? (
+            <FormCreator
+              params={action.parameters ?? []}
+              formSettings={formSettings}
+              isEditable={isEditable && canChangeFieldSettings}
+              onChange={onChangeFormSettings}
+            />
+          ) : activeSideView === "dataReference" ? (
+            <DataReferenceInline onClose={closeSideView} />
+          ) : activeSideView === "actionSettings" ? (
+            <InlineActionSettings
+              action={action}
+              formSettings={formSettings}
+              isEditable={isEditable}
+              onChangeFormSettings={onChangeFormSettings}
+              onClose={closeSideView}
+            />
+          ) : null}
+        </ModalRight>
       </ActionCreatorBodyContainer>
     </ModalRoot>
   );

--- a/frontend/src/metabase/actions/containers/ActionCreator/InlineActionSettings.styled.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/InlineActionSettings.styled.tsx
@@ -4,6 +4,8 @@ import { color } from "metabase/lib/colors";
 import SidebarContent from "metabase/query_builder/components/SidebarContent";
 
 export const ActionSettingsContainer = styled.div`
+  width: 100%;
+
   ${SidebarContent.Header.Root} {
     position: sticky;
     top: 0;

--- a/frontend/src/metabase/actions/containers/ActionCreator/InlineDataReference.styled.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/InlineDataReference.styled.tsx
@@ -6,6 +6,7 @@ import SidebarContent from "metabase/query_builder/components/SidebarContent";
 export const DataReferenceContainer = styled.div`
   overflow: hidden;
   position: relative;
+  width: 100%;
   height: 100%;
   background-color: ${color("white")};
 


### PR DESCRIPTION
Epic ##27581

Adding `overflow-y: auto` to the action editor's right part to handle long content more nicely.

### How to verify

1. Pick a model with many columns
2. Enable basic actions for it
3. Open a create/update action in the editor and ensure it looks good
4. Ensure other sections of the editor look fine (data reference, action settings)

### Demo

**Before**

https://user-images.githubusercontent.com/17258145/220160883-102576ca-a00f-4cc3-924f-6141c901bb72.mp4

**After**

https://user-images.githubusercontent.com/17258145/220160748-db570769-6cbd-4364-bf4c-69c09c1be259.mp4

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/28455)
<!-- Reviewable:end -->
