### PR TITLE
Fix Missing type property on a card breaks the frontend on the Notebook view

### DIFF
--- a/frontend/src/metabase-lib/Dimension.ts
+++ b/frontend/src/metabase-lib/Dimension.ts
@@ -1247,8 +1247,9 @@ export class ExpressionDimension extends Dimension {
         return dimension?.field();
       };
 
-      type = infer(expr, mbql => field(mbql)?.base_type);
-      semantic_type = infer(expr, mbql => field(mbql)?.semantic_type);
+      type = infer(expr, mbql => field(mbql)?.base_type) ?? type;
+      semantic_type =
+        infer(expr, mbql => field(mbql)?.semantic_type) ?? semantic_type;
     } else {
       type = infer(this._expressionName);
     }

--- a/frontend/test/metabase/scenarios/question/reproductions/28221-missing-custom-field-metadata.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/reproductions/28221-missing-custom-field-metadata.cy.spec.js
@@ -1,0 +1,48 @@
+import { restore } from "__support__/e2e/helpers";
+
+import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
+
+const { PRODUCTS_ID, PRODUCTS, ORDERS_ID, ORDERS } = SAMPLE_DATABASE;
+
+describe("issue 28221", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+  });
+
+  it("should be able to select see notebook view even if a question custom field metadata is missing#27462", () => {
+    const questionName = "Reproduce 28221";
+    const customFieldName = "Non-existing field";
+    const questionDetails = {
+      name: questionName,
+      query: {
+        "source-table": ORDERS_ID,
+        joins: [
+          {
+            fields: "all",
+            "source-table": PRODUCTS_ID,
+            condition: [
+              "=",
+              ["field", ORDERS.PRODUCT_ID, null],
+              ["field", PRODUCTS.ID, { "join-alias": "Products" }],
+            ],
+            alias: "Products",
+          },
+        ],
+        expressions: {
+          [customFieldName]: ["field", 9999, null],
+        },
+      },
+    };
+
+    cy.createQuestion(questionDetails).then(({ body }) => {
+      const questionId = body.id;
+
+      cy.visit(`/question/${questionId}/notebook`);
+    });
+
+    cy.findByDisplayValue(questionName).should("be.visible");
+
+    cy.findByText(customFieldName).should("be.visible");
+  });
+});


### PR DESCRIPTION
Fixes #28221

### Description

I'm still not totally sure how users can arrive at this state. But this fixes the issue by not assinging `null` value back to `type` and `semantic_type` since we already default the `type` to a number. It seems counter-intuitive to assign `null` back.

### How to verify

Run the Cypress test at `frontend/test/metabase/scenarios/question/reproductions/28221-missing-custom-field-metadata.cy.spec.js`

### Checklist

- [X] Tests have been added/updated to cover changes in this PR
