### PR TITLE
Handle no data perms for model detail page

### DIFF
--- a/frontend/src/metabase/models/components/ModelDetailPage/ModelActionDetails/ModelActionDetails.tsx
+++ b/frontend/src/metabase/models/components/ModelDetailPage/ModelActionDetails/ModelActionDetails.tsx
@@ -32,6 +32,7 @@ import {
 
 interface OwnProps {
   model: Question;
+  canRunActions: boolean;
 }
 
 interface DispatchProps {
@@ -60,6 +61,7 @@ function mapDispatchToProps(dispatch: Dispatch, { model }: OwnProps) {
 function ModelActionDetails({
   model,
   actions,
+  canRunActions,
   onEnableImplicitActions,
   onArchiveAction,
   onDeleteAction,
@@ -125,12 +127,13 @@ function ModelActionDetails({
             action={action}
             actionUrl={actionUrl}
             canWrite={canWrite}
+            canRun={canRunActions}
             onArchive={onArchiveAction}
           />
         </li>
       );
     },
-    [model, canWrite, onArchiveAction],
+    [model, canWrite, canRunActions, onArchiveAction],
   );
 
   const newActionUrl = Urls.newAction(model.card() as Card);

--- a/frontend/src/metabase/models/components/ModelDetailPage/ModelActionDetails/ModelActionListItem.tsx
+++ b/frontend/src/metabase/models/components/ModelDetailPage/ModelActionDetails/ModelActionListItem.tsx
@@ -24,6 +24,7 @@ interface Props {
   action: WritebackAction;
   actionUrl: string;
   canWrite: boolean;
+  canRun: boolean;
   onArchive: (action: WritebackAction) => void;
 }
 
@@ -48,6 +49,7 @@ function ModelActionListItem({
   action,
   actionUrl,
   canWrite,
+  canRun,
   onArchive,
 }: Props) {
   const canArchive = canWrite && action.type !== "implicit";
@@ -105,13 +107,15 @@ function ModelActionListItem({
         ) : action.type === "implicit" ? (
           <ImplicitActionCardContent />
         ) : null}
-        <ModalWithTrigger
-          triggerElement={<ActionRunButton as={Link} icon="play" onlyIcon />}
-        >
-          {({ onClose }: ModalProps) => (
-            <ActionExecuteModal actionId={action.id} onClose={onClose} />
-          )}
-        </ModalWithTrigger>
+        {canRun && (
+          <ModalWithTrigger
+            triggerElement={<ActionRunButton as={Link} icon="play" onlyIcon />}
+          >
+            {({ onClose }: ModalProps) => (
+              <ActionExecuteModal actionId={action.id} onClose={onClose} />
+            )}
+          </ModalWithTrigger>
+        )}
       </ActionCard>
       {confirmationModal}
     </>

--- a/frontend/src/metabase/models/components/ModelDetailPage/ModelDetailHeader/ModelDetailHeader.tsx
+++ b/frontend/src/metabase/models/components/ModelDetailPage/ModelDetailHeader/ModelDetailHeader.tsx
@@ -24,13 +24,19 @@ import {
 
 interface Props {
   model: Question;
+  hasEditDefinitionLink: boolean;
   onChangeName: (name?: string) => void;
   onChangeCollection: (collection: Collection) => void;
 }
 
 type HeaderModal = "move" | "archive";
 
-function ModelDetailHeader({ model, onChangeName, onChangeCollection }: Props) {
+function ModelDetailHeader({
+  model,
+  hasEditDefinitionLink,
+  onChangeName,
+  onChangeCollection,
+}: Props) {
   const [modal, setModal] = useState<HeaderModal | null>(null);
 
   const modelCard = model.card();
@@ -93,7 +99,7 @@ function ModelDetailHeader({ model, onChangeName, onChangeCollection }: Props) {
           <ModelFootnote>{t`Model`}</ModelFootnote>
         </div>
         <ModelHeaderButtonsContainer>
-          {canWrite && (
+          {hasEditDefinitionLink && canWrite && (
             <Button as={Link} to={queryEditorLink}>{t`Edit definition`}</Button>
           )}
           <Button primary as={Link} to={exploreDataLink}>{t`Explore`}</Button>

--- a/frontend/src/metabase/models/components/ModelDetailPage/ModelDetailPage.tsx
+++ b/frontend/src/metabase/models/components/ModelDetailPage/ModelDetailPage.tsx
@@ -27,6 +27,7 @@ interface Props {
   model: Question;
   mainTable?: Table | null;
   tab: string;
+  hasDataPermissions: boolean;
   hasActionsTab: boolean;
   onChangeName: (name?: string) => void;
   onChangeDescription: (description?: string | null) => void;
@@ -37,6 +38,7 @@ function ModelDetailPage({
   model,
   tab,
   mainTable,
+  hasDataPermissions,
   hasActionsTab,
   onChangeName,
   onChangeDescription,
@@ -49,6 +51,7 @@ function ModelDetailPage({
       <ModelMain>
         <ModelDetailHeader
           model={model}
+          hasEditDefinitionLink={hasDataPermissions}
           onChangeName={onChangeName}
           onChangeCollection={onChangeCollection}
         />
@@ -76,13 +79,19 @@ function ModelDetailPage({
           </TabPanel>
           <TabPanel value="schema">
             <TabPanelContent>
-              <ModelSchemaDetails model={model} />
+              <ModelSchemaDetails
+                model={model}
+                hasEditMetadataLink={hasDataPermissions}
+              />
             </TabPanelContent>
           </TabPanel>
           {hasActionsTab && (
             <TabPanel value="actions">
               <TabPanelContent>
-                <ModelActionDetails model={model} />
+                <ModelActionDetails
+                  model={model}
+                  canRunActions={hasDataPermissions}
+                />
               </TabPanelContent>
             </TabPanel>
           )}

--- a/frontend/src/metabase/models/components/ModelDetailPage/ModelSchemaDetails/ModelSchemaDetails.tsx
+++ b/frontend/src/metabase/models/components/ModelDetailPage/ModelSchemaDetails/ModelSchemaDetails.tsx
@@ -20,9 +20,10 @@ import {
 
 interface Props {
   model: Question;
+  hasEditMetadataLink: boolean;
 }
 
-function ModelSchemaDetails({ model }: Props) {
+function ModelSchemaDetails({ model, hasEditMetadataLink }: Props) {
   const canWrite = model.canWrite();
 
   const metadataEditorUrl = Urls.modelEditor(model.card(), {
@@ -51,7 +52,7 @@ function ModelSchemaDetails({ model }: Props) {
     <>
       <SchemaHeader>
         <span>{fieldsCount}</span>
-        {canWrite && (
+        {hasEditMetadataLink && canWrite && (
           <Button as={Link} to={metadataEditorUrl}>{t`Edit metadata`}</Button>
         )}
       </SchemaHeader>

--- a/frontend/src/metabase/models/containers/ModelDetailPage/ModelDetailPage.tsx
+++ b/frontend/src/metabase/models/containers/ModelDetailPage/ModelDetailPage.tsx
@@ -37,7 +37,7 @@ type OwnProps = {
   children: React.ReactNode;
 };
 
-type ModelEntityLoaderProps = {
+type EntityLoadersProps = {
   actions: WritebackAction[];
   modelCard: Card;
 };
@@ -65,12 +65,9 @@ type DispatchProps = {
   onChangeLocation: (location: LocationDescriptor) => void;
 };
 
-type Props = OwnProps & ModelEntityLoaderProps & StateProps & DispatchProps;
+type Props = OwnProps & EntityLoadersProps & StateProps & DispatchProps;
 
-function mapStateToProps(
-  state: State,
-  props: OwnProps & ModelEntityLoaderProps,
-) {
+function mapStateToProps(state: State, props: OwnProps & EntityLoadersProps) {
   const metadata = getMetadata(state);
   const model = new Question(props.modelCard, metadata);
   return { model };
@@ -205,7 +202,7 @@ function getModelId(state: State, props: OwnProps) {
 
 function getModelDatabaseId(
   state: State,
-  props: OwnProps & ModelEntityLoaderProps,
+  props: OwnProps & EntityLoadersProps,
 ) {
   return props.modelCard.dataset_query.database;
 }
@@ -222,7 +219,7 @@ export default _.compose(
       "model-id": getModelId(state, props),
     }),
   }),
-  connect<StateProps, DispatchProps, OwnProps & ModelEntityLoaderProps, State>(
+  connect<StateProps, DispatchProps, OwnProps & EntityLoadersProps, State>(
     mapStateToProps,
     mapDispatchToProps,
   ),

--- a/frontend/src/metabase/models/containers/ModelDetailPage/ModelDetailPage.tsx
+++ b/frontend/src/metabase/models/containers/ModelDetailPage/ModelDetailPage.tsx
@@ -100,6 +100,7 @@ function ModelDetailPage({
   const [hasFetchedTableMetadata, setHasFetchedTableMetadata] = useState(false);
 
   const database = model.database();
+  const hasDataPermissions = model.query().isEditable();
   const hasActions = actions.length > 0;
   const hasActionsEnabled = database != null && database.hasActionsEnabled();
   const hasActionsTab = hasActions || hasActionsEnabled;
@@ -123,10 +124,14 @@ function ModelDetailPage({
   useMount(() => {
     const card = model.card();
     const isModel = model.isDataset();
-    if (isModel) {
-      loadMetadataForCard(card);
-    } else {
+
+    if (!isModel) {
       onChangeLocation(Urls.question(card));
+      return;
+    }
+
+    if (hasDataPermissions) {
+      loadMetadataForCard(card);
     }
   });
 
@@ -186,6 +191,7 @@ function ModelDetailPage({
         model={model}
         mainTable={mainTable}
         tab={tab}
+        hasDataPermissions={hasDataPermissions}
         hasActionsTab={hasActionsTab}
         onChangeName={handleNameChange}
         onChangeDescription={handleDescriptionChange}
@@ -214,7 +220,7 @@ function getPageTitle({ modelCard }: Props) {
 
 export default _.compose(
   Questions.load({ id: getModelId, entityAlias: "modelCard" }),
-  Databases.load({ id: getModelDatabaseId }),
+  Databases.load({ id: getModelDatabaseId, loadingAndErrorWrapper: false }),
   Actions.loadList({
     query: (state: State, props: OwnProps) => ({
       "model-id": getModelId(state, props),

--- a/frontend/src/metabase/models/containers/ModelDetailPage/ModelDetailPage.tsx
+++ b/frontend/src/metabase/models/containers/ModelDetailPage/ModelDetailPage.tsx
@@ -124,14 +124,10 @@ function ModelDetailPage({
   useMount(() => {
     const card = model.card();
     const isModel = model.isDataset();
-
-    if (!isModel) {
-      onChangeLocation(Urls.question(card));
-      return;
-    }
-
-    if (hasDataPermissions) {
+    if (isModel) {
       loadMetadataForCard(card);
+    } else {
+      onChangeLocation(Urls.question(card));
     }
   });
 

--- a/frontend/src/metabase/models/containers/ModelDetailPage/ModelDetailPage.unit.spec.tsx
+++ b/frontend/src/metabase/models/containers/ModelDetailPage/ModelDetailPage.unit.spec.tsx
@@ -180,6 +180,7 @@ type SetupOpts = {
   tab?: string;
   actions?: WritebackAction[];
   hasActionsEnabled?: boolean;
+  hasDataPermissions?: boolean;
   collections?: Collection[];
   usedBy?: Question[];
 };
@@ -191,6 +192,7 @@ async function setup({
   collections = [],
   usedBy = [],
   hasActionsEnabled = false,
+  hasDataPermissions = true,
 }: SetupOpts) {
   const scope = nock(location.origin).persist();
 
@@ -198,9 +200,15 @@ async function setup({
 
   const card = model.card() as Card;
 
-  setupDatabasesEndpoints(scope, [
-    hasActionsEnabled ? TEST_DATABASE_WITH_ACTIONS : TEST_DATABASE,
-  ]);
+  if (hasDataPermissions) {
+    setupDatabasesEndpoints(scope, [
+      hasActionsEnabled ? TEST_DATABASE_WITH_ACTIONS : TEST_DATABASE,
+    ]);
+  } else {
+    setupDatabasesEndpoints(scope, []);
+    scope.get(`/api/database/${TEST_DATABASE.id}`).reply(403);
+    scope.get(`/api/database/${TEST_DATABASE_WITH_ACTIONS.id}`).reply(403);
+  }
 
   scope
     .get("/api/card")
@@ -800,6 +808,29 @@ describe("ModelDetailPage", () => {
           expect(screen.queryByText("Archive")).not.toBeInTheDocument();
         });
       });
+
+      describe("no data permissions", () => {
+        it("doesn't show model editor links", async () => {
+          await setup({
+            model: getModel(),
+            hasDataPermissions: false,
+            tab: "schema",
+          });
+          expect(screen.queryByText("Edit definition")).not.toBeInTheDocument();
+          expect(screen.queryByText("Edit metadata")).not.toBeInTheDocument();
+        });
+
+        it("doesn't allow running actions", async () => {
+          const model = getModel();
+          const actions = [
+            ...createMockImplicitCUDActions(model.id()),
+            createMockQueryAction({ model_id: model.id() }),
+          ];
+          await setupActions({ model, actions, hasDataPermissions: false });
+
+          expect(queryIcon("play")).not.toBeInTheDocument();
+        });
+      });
     });
   });
 
@@ -823,6 +854,18 @@ describe("ModelDetailPage", () => {
         list.getByRole("link", { name: TABLE_1.displayName() }),
       ).toHaveAttribute("href", TABLE_1.newQuestion().getUrl());
       expect(list.queryByText("Reviews")).not.toBeInTheDocument();
+    });
+
+    describe("no data permissions", () => {
+      it("shows limited model info", async () => {
+        await setup({ model, hasDataPermissions: false });
+
+        expect(screen.queryByText("Relationships")).not.toBeInTheDocument();
+        expect(screen.queryByText("Backing table")).not.toBeInTheDocument();
+        expect(
+          screen.queryByText(TEST_TABLE.display_name),
+        ).not.toBeInTheDocument();
+      });
     });
   });
 


### PR DESCRIPTION
Epic #27581

Makes the model detail page handle users with no data permissions for the underlying model database. Technically a user doesn't have access to the database object and its child data (tables, fields, metadata, etc.). As a result:

* "Edit definition" and "Edit metadata" buttons leading to the model editor are hidden
* related tables and backing table links are hidden
* controls for execution actions are hidden

### How to verify

1. Go to `/admin/permissions/data/database`
2. Pick your model's database, set "No self-service" data access for the "All Users" group
3. Sign in as a non-admin user and try to open the model detail page
4. Ensure everything looks like described at the beginning of the PR description

### Checklist

- [x] Tests have been added/updated to cover changes in this PR

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/28464)
<!-- Reviewable:end -->
