### PR TITLE
Optimize binning expressions; misc QP test improvements

### DIFF
--- a/src/metabase/driver/sql/query_processor.clj
+++ b/src/metabase/driver/sql/query_processor.clj
@@ -1072,11 +1072,8 @@
   (like-clause driver (->honeysql driver field) (update-string-value value #(str \% %)) options))
 
 (defmethod ->honeysql [:sql :between]
-  [driver [_ expr min-val max-val]]
-  (let [expr-hsql (->honeysql driver expr)]
-    [:and
-     [:>= expr (->honeysql driver min-val)]
-     [:<  expr (->honeysql driver max-val)]]))
+  [driver [_ field min-val max-val]]
+  [:between (->honeysql driver field) (->honeysql driver min-val) (->honeysql driver max-val)])
 
 (defmethod ->honeysql [:sql :>]
   [driver [_ field value]]

--- a/test/metabase/driver/sql/query_processor_test.clj
+++ b/test/metabase/driver/sql/query_processor_test.clj
@@ -1087,3 +1087,22 @@
                                (update 0 #(str/split-lines (mdb.query/format-sql % driver/*driver*))))]
               (testing "this query should not have any parameters"
                 (is (mc/validate [:cat [:sequential :string]] sql-args))))))))))
+
+(deftest ^:parallel binning-optimize-math-expressions-test
+  (testing "Don't include nonsense like `+ 0.0` and `- 0.0` when generating expressions for binning"
+    (mt/dataset sample-dataset
+      (binding [hx/*honey-sql-version* 2]
+        (is (= ["SELECT"
+                "  FLOOR((ORDERS.QUANTITY / 10)) * 10 AS QUANTITY,"
+                "  COUNT(*) AS count"
+                "FROM"
+                "  ORDERS"
+                "GROUP BY"
+                "  FLOOR((ORDERS.QUANTITY / 10)) * 10"
+                "ORDER BY"
+                "  FLOOR((ORDERS.QUANTITY / 10)) * 10 ASC"]
+               (-> (mbql->native (mt/mbql-query orders
+                                   {:aggregation [[:count]]
+                                    :breakout    [:binning-strategy $quantity :num-bins 10]}))
+                   (mdb.query/format-sql :h2)
+                   str/split-lines)))))))

--- a/test/metabase/driver/sql/query_processor_test_util.clj
+++ b/test/metabase/driver/sql/query_processor_test_util.clj
@@ -114,24 +114,27 @@
 
 (defn pprint-native-query-with-best-strategy
   "Attempt to compile `query` to a native query, and pretty-print it if possible."
-  [query]
-  (u/ignore-exceptions
-    (let [{native :query, :as query} (query->raw-native-query query)]
-      (str "\nNative Query =\n"
-           (cond
-             (and (string? native)
-                  (isa? driver/hierarchy driver/*driver* :sql))
-             (mdb.query/format-sql native driver/*driver*)
+  ([query]
+   (pprint-native-query-with-best-strategy (or driver/*driver* :h2) query))
 
-             (string? native)
-             native
+  ([driver query]
+   (u/ignore-exceptions
+     (let [{native :query, :as query} (query->raw-native-query query)]
+       (str "\nNative Query =\n"
+            (cond
+              (and (string? native)
+                   (isa? driver/hierarchy driver :sql))
+              (mdb.query/format-sql native driver)
 
-             :else
-             (u/pprint-to-str native))
-           \newline
-           \newline
-           (u/pprint-to-str (dissoc query :query))
-           \newline))))
+              (string? native)
+              native
+
+              :else
+              (u/pprint-to-str native))
+            \newline
+            \newline
+            (u/pprint-to-str (dissoc query :query))
+            \newline)))))
 
 (defn do-with-native-query-testing-context
   [query thunk]

--- a/test/metabase/query_processor/middleware/binning_test.clj
+++ b/test/metabase/query_processor/middleware/binning_test.clj
@@ -1,4 +1,5 @@
 (ns metabase.query-processor.middleware.binning-test
+  "There are more 'e2e' tests related to binning in [[metabase.query-processor-test.breakout-test]]."
   (:require
    [clojure.test :refer :all]
    [metabase.models.card :refer [Card]]
@@ -10,7 +11,7 @@
    [metabase.test :as mt]
    [metabase.util :as u]))
 
-(deftest filter->field-map-test
+(deftest ^:parallel filter->field-map-test
   (is (= {}
          (#'binning/filter->field-map [:and
                                        [:= [:field 1 nil] 10]
@@ -26,14 +27,14 @@
                                        [:< [:field 2 nil] 10]
                                        [:between [:field 3 nil] 5 10]]))))
 
-(deftest floor-to-test
+(deftest ^:parallel floor-to-test
   (are [x expected] (= expected
                        (#'binning/floor-to 1.0 x))
     1   1.0
     1.1 1.0
     1.8 1.0))
 
-(deftest ceil-to-test
+(deftest ^:parallel ceil-to-test
   (are [precision x expected] (= expected
                                  (#'binning/ceil-to precision x))
     1.0  1    1.0
@@ -43,7 +44,7 @@
     15.0 15.0 15.0
     15.0 16.0 30.0))
 
-(deftest nicer-bin-width-test
+(deftest ^:parallel nicer-bin-width-test
   (are [min max num-bins expected] (= expected
                                       (#'binning/nicer-bin-width min max num-bins))
     27      135      8 20
@@ -52,7 +53,7 @@
 (def ^:private test-min-max-fingerprint
   {:type {:type/Number {:min 100 :max 1000}}})
 
-(deftest extract-bounds-test
+(deftest ^:parallel extract-bounds-test
   (are [field-id->filters expected] (= expected
                                        (#'binning/extract-bounds 1 test-min-max-fingerprint field-id->filters))
     {1 [[:> [:field 1 nil] 1] [:< [:field 1 nil] 10]]}
@@ -73,7 +74,7 @@
     {1 [[:> [:field 1 nil] 200] [:< [:field 1 nil] 800] [:between [:field 1 nil] 600 700]]}
     {:min-value 600, :max-value 700}))
 
-(deftest nicer-breakout-test
+(deftest ^:parallel nicer-breakout-test
   (are [strategy opts expected] (= expected
                                    (#'binning/nicer-breakout strategy opts))
     :num-bins  {:min-value 100, :max-value 1000, :num-bins 8, :bin-width 0}  {:min-value 0.0, :max-value 1000.0, :num-bins 8, :bin-width 125.0}
@@ -85,7 +86,7 @@
     {:min-value 12.061602936923117, :max-value 238.32732001721533, :bin-width 28.28321, :num-bins 8}
     {:min-value 0.0, :max-value 240.0, :num-bins 8, :bin-width 30}))
 
-(deftest resolve-default-strategy-test
+(deftest ^:parallel resolve-default-strategy-test
   (is (= [:num-bins {:num-bins 8, :bin-width 28.28321}]
          (#'binning/resolve-default-strategy {:semantic_type :type/Income} 12.061602936923117 238.32732001721533))))
 


### PR DESCRIPTION
Tweaks I made while working on #15324, which turned out to be a FE bug anyway.

- Optimize SQL generated when using binning with a min-value of zero: don't include `+ 0.0` and `- 0.0`, which serve absolutely no purpose (see added test)
- `mt/with-native-query-testing-context` should format the SQL with `:h2` rules if `driver/*driver*` isn't bound
- Mark several pure-function tests inside `middleware.binning-test` as `^:parallel`