### PR TITLE
Fix flaky `metabase.query-processor-test.timezones-test/filter-datetime-by-date-in-timezone-test`

### DIFF
--- a/test/metabase/query_processor_test/timezones_test.clj
+++ b/test/metabase/query_processor_test/timezones_test.clj
@@ -311,7 +311,7 @@
                            (u.date/with-time-zone-same-instant timezone)
                            t/offset-date-time)
                        (-> (mt/run-mbql-query relative_filter {:fields [$created]
-                                                               :filter [:time-interval $created :current :minute]})
+                                                               :filter [:time-interval $created :current :day]})
                            mt/first-row
                            first
                            (u.date/parse nil)


### PR DESCRIPTION
I've seen this test flake twice today, in both `:presto-jdbc` and `:mysql`.

The test would create a test database with a single row, a timestamp whose value was `now()`, then sync the database and run a query that would use a relative date filter to return rows that were in the current minute.

This worked fine like 99% of the time, but if we crossed the threshold into a different minute between loading the data and running the query, the row would no longer come back, resulting in an NPE. This failure could be reproduced every time by adding a `(Thread/sleep 60000)` somewhere in the test between loading the data and running the query.

The fix was to use a unit with less-granular resolution -- `:day` in this case rather than `:minute`. Changing the unit doesn't matter a ton here since we're just testing that relative-date stuff works regardless of the `report-timezone`, and this test would still fail fairly consistently if we were adjusting timezones incorrectly.

This could still flake if we go from current time = 23:59:00 to 00:00 in between loading data and running the query, but I haven't figured out how to rework the test to avoid that situation, and that will still happen 1440 times less often than the current flake. So still a big net win.