### PR TITLE
Add global nock setup

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/license/components/LicenseAndBillingSettings/LicenseAndBillingSettings.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/license/components/LicenseAndBillingSettings/LicenseAndBillingSettings.unit.spec.tsx
@@ -57,7 +57,6 @@ const mockUpdateToken = (valid: boolean) => {
 
 describe("LicenseAndBilling", () => {
   afterEach(() => {
-    nock.cleanAll();
     jest.restoreAllMocks();
   });
 

--- a/enterprise/frontend/src/metabase-enterprise/sandboxes/components/EditSandboxingModal/EditSandboxingModal.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/sandboxes/components/EditSandboxingModal/EditSandboxingModal.unit.spec.tsx
@@ -63,7 +63,6 @@ const setup = ({
 describe("EditSandboxingModal", () => {
   afterEach(() => {
     jest.clearAllMocks();
-    nock.cleanAll();
   });
 
   describe("EditSandboxingModal", () => {

--- a/enterprise/frontend/src/metabase-enterprise/snippets/components/SnippetCollectionFormModal.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/snippets/components/SnippetCollectionFormModal.unit.spec.tsx
@@ -84,10 +84,6 @@ const LABEL = {
 };
 
 describe("SnippetCollectionFormModal", () => {
-  afterEach(() => {
-    nock.cleanAll();
-  });
-
   describe("new folder", () => {
     it("displays correct blank state", async () => {
       await setup();

--- a/frontend/src/metabase/actions/components/ActionViz/Action.unit.spec.tsx
+++ b/frontend/src/metabase/actions/components/ActionViz/Action.unit.spec.tsx
@@ -100,10 +100,6 @@ function setupExecutionEndpoint(expectedBody: any) {
 }
 
 describe("Actions > ActionViz > ActionComponent", () => {
-  afterEach(() => {
-    nock.cleanAll();
-  });
-
   // button actions are just a modal trigger around forms
   describe("Button actions", () => {
     it("should render an empty state for a button with no action", async () => {

--- a/frontend/src/metabase/actions/components/ActionViz/ActionDashcardSettings.unit.spec.tsx
+++ b/frontend/src/metabase/actions/components/ActionViz/ActionDashcardSettings.unit.spec.tsx
@@ -110,10 +110,6 @@ const setup = (
 };
 
 describe("ActionViz > ActionDashcardSettings", () => {
-  afterEach(() => {
-    nock.cleanAll();
-  });
-
   it("shows the action dashcard settings component", () => {
     setup();
 

--- a/frontend/src/metabase/actions/containers/ActionCreator/tests/ActionCreator-Common.unit.spec.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/tests/ActionCreator-Common.unit.spec.tsx
@@ -1,4 +1,3 @@
-import nock from "nock";
 import userEvent from "@testing-library/user-event";
 
 import { screen } from "__support__/ui";
@@ -19,10 +18,6 @@ async function setup({
 }
 
 describe("ActionCreator > Common", () => {
-  afterEach(() => {
-    nock.cleanAll();
-  });
-
   describe.each([
     ["query", createMockQueryAction],
     ["implicit", createMockImplicitQueryAction],

--- a/frontend/src/metabase/actions/containers/ActionCreator/tests/ActionCreator-ImplicitActions.unit.spec.ts
+++ b/frontend/src/metabase/actions/containers/ActionCreator/tests/ActionCreator-ImplicitActions.unit.spec.ts
@@ -1,5 +1,3 @@
-import nock from "nock";
-
 import { screen, queryIcon } from "__support__/ui";
 
 import {
@@ -18,10 +16,6 @@ async function setup({
 }
 
 describe("ActionCreator > Implicit Actions", () => {
-  afterEach(() => {
-    nock.cleanAll();
-  });
-
   it("renders correctly", async () => {
     const { action } = await setup();
 

--- a/frontend/src/metabase/actions/containers/ActionCreator/tests/ActionCreator-QueryActions.unit.spec.ts
+++ b/frontend/src/metabase/actions/containers/ActionCreator/tests/ActionCreator-QueryActions.unit.spec.ts
@@ -1,5 +1,3 @@
-import nock from "nock";
-
 import { screen, getIcon, queryIcon } from "__support__/ui";
 
 import {
@@ -10,10 +8,6 @@ import {
 import { setup } from "./common";
 
 describe("ActionCreator > Query Actions", () => {
-  afterEach(() => {
-    nock.cleanAll();
-  });
-
   describe("new action", () => {
     it("renders correctly", async () => {
       await setup();

--- a/frontend/src/metabase/actions/containers/ActionCreator/tests/ActionCreator-Sharing.unit.spec.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/tests/ActionCreator-Sharing.unit.spec.tsx
@@ -1,4 +1,3 @@
-import nock from "nock";
 import userEvent from "@testing-library/user-event";
 
 import { screen, waitFor } from "__support__/ui";
@@ -19,10 +18,6 @@ async function setup({
 }
 
 describe("ActionCreator > Sharing", () => {
-  afterEach(() => {
-    nock.cleanAll();
-  });
-
   describe.each([
     ["query", createMockQueryAction],
     ["implicit", createMockImplicitQueryAction],

--- a/frontend/src/metabase/actions/containers/ActionParametersInputForm/ActionParametersInputForm.unit.spec.tsx
+++ b/frontend/src/metabase/actions/containers/ActionParametersInputForm/ActionParametersInputForm.unit.spec.tsx
@@ -63,10 +63,6 @@ function setupPrefetch() {
 }
 
 describe("Actions > ActionParametersInputForm", () => {
-  afterEach(() => {
-    nock.cleanAll();
-  });
-
   it("should render an action form", async () => {
     await setup();
     expect(screen.getByTestId("action-form")).toBeInTheDocument();

--- a/frontend/src/metabase/admin/databases/components/DeleteDatabaseModel/DeleteDatabaseModal.unit.spec.tsx
+++ b/frontend/src/metabase/admin/databases/components/DeleteDatabaseModel/DeleteDatabaseModal.unit.spec.tsx
@@ -45,7 +45,6 @@ const setup = async ({
 describe("DeleteDatabaseModal", () => {
   afterEach(() => {
     jest.clearAllMocks();
-    nock.cleanAll();
   });
 
   it("should allow deleting database without content after confirming its name", async () => {

--- a/frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget/GroupMappingsWidget.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget/GroupMappingsWidget.unit.spec.tsx
@@ -23,10 +23,6 @@ const setup = ({
 };
 
 describe("GroupMappingsWidget", () => {
-  afterEach(() => {
-    nock.cleanAll();
-  });
-
   describe("when a mapping is set for admin group", () => {
     const settingBody = [
       {

--- a/frontend/src/metabase/collections/containers/CreateCollectionForm.unit.spec.tsx
+++ b/frontend/src/metabase/collections/containers/CreateCollectionForm.unit.spec.tsx
@@ -53,10 +53,6 @@ describe("CreateCollectionForm", () => {
     nock(location.origin).get("/api/collection").reply(200, [ROOT_COLLECTION]);
   });
 
-  afterEach(() => {
-    nock.cleanAll();
-  });
-
   it("displays correct blank state", () => {
     setup();
 

--- a/frontend/src/metabase/components/FormCategoryInput/CategoryFieldPicker.unit.spec.tsx
+++ b/frontend/src/metabase/components/FormCategoryInput/CategoryFieldPicker.unit.spec.tsx
@@ -39,10 +39,6 @@ const productVendorField = new Field({
 });
 
 describe("CategoryFieldPicker", () => {
-  afterEach(() => {
-    nock.cleanAll();
-  });
-
   describe("given a few distinct values", () => {
     beforeEach(() => {
       nock(location.origin)

--- a/frontend/src/metabase/containers/DataPicker/tests/DataPicker-Common.unit.spec.ts
+++ b/frontend/src/metabase/containers/DataPicker/tests/DataPicker-Common.unit.spec.ts
@@ -1,5 +1,3 @@
-import nock from "nock";
-
 import { screen } from "__support__/ui";
 
 import { setup, SAMPLE_DATABASE, SAMPLE_TABLE } from "./common";
@@ -7,10 +5,6 @@ import { setup, SAMPLE_DATABASE, SAMPLE_TABLE } from "./common";
 describe("DataPicker", () => {
   beforeAll(() => {
     window.HTMLElement.prototype.scrollIntoView = jest.fn();
-  });
-
-  afterEach(() => {
-    nock.cleanAll();
   });
 
   it("shows data type picker by default", async () => {

--- a/frontend/src/metabase/containers/DataPicker/tests/DataPicker-Models.unit.spec.ts
+++ b/frontend/src/metabase/containers/DataPicker/tests/DataPicker-Models.unit.spec.ts
@@ -1,5 +1,4 @@
 import userEvent from "@testing-library/user-event";
-import nock from "nock";
 
 import { screen, waitForElementToBeRemoved } from "__support__/ui";
 
@@ -28,10 +27,6 @@ const ROOT_COLLECTION_MODEL_VIRTUAL_SCHEMA_ID = getCollectionVirtualSchemaId(
 describe("DataPicker — picking models", () => {
   beforeAll(() => {
     window.HTMLElement.prototype.scrollIntoView = jest.fn();
-  });
-
-  afterEach(() => {
-    nock.cleanAll();
   });
 
   it("opens the picker", async () => {

--- a/frontend/src/metabase/containers/DataPicker/tests/DataPicker-Questions.unit.spec.ts
+++ b/frontend/src/metabase/containers/DataPicker/tests/DataPicker-Questions.unit.spec.ts
@@ -1,5 +1,4 @@
 import userEvent from "@testing-library/user-event";
-import nock from "nock";
 
 import { screen, waitForElementToBeRemoved } from "__support__/ui";
 
@@ -26,10 +25,6 @@ const ROOT_COLLECTION_QUESTIONS_VIRTUAL_SCHEMA_ID =
 describe("DataPicker — picking questions", () => {
   beforeAll(() => {
     window.HTMLElement.prototype.scrollIntoView = jest.fn();
-  });
-
-  afterEach(() => {
-    nock.cleanAll();
   });
 
   it("opens the picker", async () => {

--- a/frontend/src/metabase/containers/DataPicker/tests/DataPicker-RawData.unit.spec.ts
+++ b/frontend/src/metabase/containers/DataPicker/tests/DataPicker-RawData.unit.spec.ts
@@ -1,5 +1,4 @@
 import userEvent from "@testing-library/user-event";
-import nock from "nock";
 
 import { screen, waitForElementToBeRemoved } from "__support__/ui";
 
@@ -19,10 +18,6 @@ import {
 describe("DataPicker — picking raw data", () => {
   beforeAll(() => {
     window.HTMLElement.prototype.scrollIntoView = jest.fn();
-  });
-
-  afterEach(() => {
-    nock.cleanAll();
   });
 
   it("opens the picker", async () => {

--- a/frontend/src/metabase/containers/ItemPicker/ItemPicker.unit.spec.js
+++ b/frontend/src/metabase/containers/ItemPicker/ItemPicker.unit.spec.js
@@ -169,10 +169,6 @@ async function openCollection(itemName) {
 }
 
 describe("ItemPicker", () => {
-  afterEach(() => {
-    nock.cleanAll();
-  });
-
   it("displays items from the root collection by default", async () => {
     await setup();
 

--- a/frontend/src/metabase/containers/NewItemMenu/NewItemMenu.unit.spec.tsx
+++ b/frontend/src/metabase/containers/NewItemMenu/NewItemMenu.unit.spec.tsx
@@ -70,10 +70,6 @@ function setup({
 }
 
 describe("NewItemMenu", () => {
-  afterEach(() => {
-    nock.cleanAll();
-  });
-
   describe("New Action", () => {
     it("should open action editor on click", async () => {
       setup();

--- a/frontend/src/metabase/dashboard/containers/CreateDashboardModal.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/containers/CreateDashboardModal.unit.spec.tsx
@@ -52,10 +52,6 @@ describe("CreateDashboardModal", () => {
     nock(location.origin).get("/api/collection").reply(200, [ROOT_COLLECTION]);
   });
 
-  afterEach(() => {
-    nock.cleanAll();
-  });
-
   it("displays empty form fields", () => {
     setup();
 

--- a/frontend/src/metabase/models/containers/ModelDetailPage/ModelDetailPage.unit.spec.tsx
+++ b/frontend/src/metabase/models/containers/ModelDetailPage/ModelDetailPage.unit.spec.tsx
@@ -272,10 +272,6 @@ function openActionMenu(action: WritebackAction) {
 }
 
 describe("ModelDetailPage", () => {
-  afterEach(() => {
-    nock.cleanAll();
-  });
-
   [
     { type: "structured", getModel: getStructuredModel },
     { type: "native", getModel: getNativeModel },

--- a/frontend/src/metabase/nav/components/RecentsList.unit.spec.js
+++ b/frontend/src/metabase/nav/components/RecentsList.unit.spec.js
@@ -54,10 +54,6 @@ async function setup(recents = recentsData) {
 }
 
 describe("RecentsList", () => {
-  afterEach(() => {
-    nock.cleanAll();
-  });
-
   it("shows list of recents", async () => {
     await setup();
     await screen.findByText("Question I visited");

--- a/frontend/src/metabase/nav/containers/AppBar/AppBar.unit.spec.tsx
+++ b/frontend/src/metabase/nav/containers/AppBar/AppBar.unit.spec.tsx
@@ -24,7 +24,6 @@ describe("AppBar", () => {
 
     afterEach(() => {
       jest.clearAllMocks();
-      nock.cleanAll();
       restoreMockEmbedding();
     });
 

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbar.unit.spec.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbar.unit.spec.tsx
@@ -166,10 +166,6 @@ async function setupCollectionPage({
 }
 
 describe("nav > containers > MainNavbar", () => {
-  afterEach(() => {
-    nock.cleanAll();
-  });
-
   describe("homepage link", () => {
     it("should render", async () => {
       await setup();

--- a/frontend/src/metabase/nav/containers/Navbar.unit.spec.tsx
+++ b/frontend/src/metabase/nav/containers/Navbar.unit.spec.tsx
@@ -65,10 +65,6 @@ async function setup({
 }
 
 describe("nav > containers > Navbar > Core App", () => {
-  afterEach(() => {
-    nock.cleanAll();
-  });
-
   it("should be open when isOpen is true", async () => {
     await setup({ isOpen: true });
     const navbar = screen.getByTestId("main-navbar-root");

--- a/frontend/src/metabase/parameters/components/ValuesSourceModal/ValuesSourceModal.unit.spec.tsx
+++ b/frontend/src/metabase/parameters/components/ValuesSourceModal/ValuesSourceModal.unit.spec.tsx
@@ -23,10 +23,6 @@ import { createMockUiParameter } from "metabase-lib/parameters/mock";
 import ValuesSourceModal from "./ValuesSourceModal";
 
 describe("ValuesSourceModal", () => {
-  afterEach(() => {
-    nock.cleanAll();
-  });
-
   describe("fields source", () => {
     it("should show a message about not connected fields", () => {
       setup();
@@ -243,8 +239,7 @@ describe("ValuesSourceModal", () => {
 
       await waitFor(() => {
         expect(screen.getByRole("textbox")).toHaveValue("A\nB\nC");
-      }),
-        { timeout: 3000 };
+      });
     });
 
     it("should display a message when the user has no access to the card", async () => {

--- a/frontend/src/metabase/public/containers/PublicAction/PublicAction.unit.spec.tsx
+++ b/frontend/src/metabase/public/containers/PublicAction/PublicAction.unit.spec.tsx
@@ -101,10 +101,6 @@ async function setup({
 }
 
 describe("PublicAction", () => {
-  beforeEach(() => {
-    nock.cleanAll();
-  });
-
   it("shows acton form", async () => {
     await setup();
 

--- a/frontend/src/metabase/query_builder/actions/core/initializeQB.unit.spec.ts
+++ b/frontend/src/metabase/query_builder/actions/core/initializeQB.unit.spec.ts
@@ -147,7 +147,6 @@ describe("QB Actions > initializeQB", () => {
   });
 
   afterEach(() => {
-    nock.cleanAll();
     jest.restoreAllMocks();
   });
 

--- a/frontend/src/metabase/query_builder/components/DataSelector/saved-question-picker/SavedQuestionPicker.unit.spec.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/saved-question-picker/SavedQuestionPicker.unit.spec.jsx
@@ -85,10 +85,6 @@ describe("SavedQuestionPicker", () => {
     window.HTMLElement.prototype.scrollIntoView = jest.fn();
   });
 
-  afterEach(() => {
-    nock.cleanAll();
-  });
-
   it("shows the current user personal collection on the top after the root", async () => {
     await setup();
 

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.unit.spec.js
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.unit.spec.js
@@ -198,10 +198,6 @@ describe.skip("Notebook Editor > Join Step", () => {
       });
   });
 
-  afterEach(() => {
-    nock.cleanAll();
-  });
-
   it("displays a source table and suggests to pick a join table", async () => {
     await setup();
     expect(screen.getByText("Orders")).toBeInTheDocument();

--- a/frontend/src/metabase/query_builder/components/template_tags/SnippetFormModal/SnippetFormModal.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/SnippetFormModal/SnippetFormModal.unit.spec.tsx
@@ -86,10 +86,6 @@ const LABEL = {
 };
 
 describe("SnippetFormModal", () => {
-  afterEach(() => {
-    nock.cleanAll();
-  });
-
   describe("new snippet", () => {
     it("displays correct blank state", async () => {
       await setup();

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader.unit.spec.js
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader.unit.spec.js
@@ -361,10 +361,6 @@ describe("ViewHeader", () => {
           });
         });
 
-        afterEach(() => {
-          nock.cleanAll();
-        });
-
         it("calls save function on title update", () => {
           const { onSave } = setup({ question });
           const title = screen.getByTestId("saved-question-header-title");
@@ -525,10 +521,6 @@ describe("View Header | Not saved native question", () => {
 });
 
 describe("View Header | Saved native question", () => {
-  afterEach(() => {
-    nock.cleanAll();
-  });
-
   it("displays database a question is using", () => {
     const { question } = setupSavedNative();
     const databaseName = question.database().displayName();

--- a/frontend/src/metabase/query_builder/components/view/sidebars/ModelCacheManagementSection/ModelCacheManagementSection.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/ModelCacheManagementSection/ModelCacheManagementSection.unit.spec.tsx
@@ -62,7 +62,6 @@ async function setup({
 
 describe("ModelCacheManagementSection", () => {
   afterEach(() => {
-    nock.cleanAll();
     jest.restoreAllMocks();
   });
 

--- a/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar.unit.spec.js
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar.unit.spec.js
@@ -108,10 +108,6 @@ async function setup({ question, cachingEnabled = true } = {}) {
 }
 
 describe("QuestionInfoSidebar", () => {
-  afterEach(() => {
-    nock.cleanAll();
-  });
-
   describe("common features", () => {
     [
       { type: "Saved Question", getObject: getQuestion },

--- a/frontend/src/metabase/search/components/InfoText.unit.spec.js
+++ b/frontend/src/metabase/search/components/InfoText.unit.spec.js
@@ -17,10 +17,6 @@ async function setup(result) {
 }
 
 describe("InfoText", () => {
-  afterEach(() => {
-    nock.cleanAll();
-  });
-
   it("shows collection info for a question", async () => {
     await setup({
       model: "card",

--- a/frontend/test/jest-setup-env.js
+++ b/frontend/test/jest-setup-env.js
@@ -1,0 +1,7 @@
+import nock from "nock";
+
+afterEach(function () {
+  nock.restore();
+  nock.cleanAll();
+  nock.activate();
+});

--- a/frontend/test/jest-setup-env.js
+++ b/frontend/test/jest-setup-env.js
@@ -2,6 +2,9 @@ import nock from "nock";
 
 afterEach(function () {
   nock.restore();
+  nock.abortPendingRequests();
   nock.cleanAll();
+  nock.enableNetConnect();
+  nock.emitter.removeAllListeners();
   nock.activate();
 });

--- a/frontend/test/jest-setup.js
+++ b/frontend/test/jest-setup.js
@@ -11,6 +11,12 @@ process.on("uncaughtException", err =>
   console.error("WARNING: UNCAUGHT EXCEPTION", err),
 );
 
+// these functions are used by nock, but they are removed by jsdom
+if (!global.setImmediate) {
+  global.setImmediate = global.setTimeout;
+  global.clearImmediate = global.clearTimeout;
+}
+
 if (process.env["DISABLE_LOGGING"] || process.env["DISABLE_LOGGING_FRONTEND"]) {
   global.console = {
     ...console.log,

--- a/frontend/test/metabase/admin/tasks/containers/Logs.unit.spec.js
+++ b/frontend/test/metabase/admin/tasks/containers/Logs.unit.spec.js
@@ -6,13 +6,7 @@ import Logs from "metabase/admin/tasks/containers/Logs";
 import { UtilApi } from "metabase/services";
 
 describe("Logs", () => {
-  afterEach(() => {
-    nock.cleanAll();
-  });
-
   describe("log fetching", () => {
-    afterEach(() => nock.cleanAll());
-
     it("should call UtilApi.logs after 1 second", () => {
       jest.useFakeTimers();
       nock(location.origin).get("/api/util/logs").reply(200, []);

--- a/frontend/test/metabase/containers/SaveQuestionModal.unit.spec.js
+++ b/frontend/test/metabase/containers/SaveQuestionModal.unit.spec.js
@@ -147,10 +147,6 @@ describe("SaveQuestionModal", () => {
       .reply(200, TEST_COLLECTIONS);
   });
 
-  afterEach(() => {
-    nock.cleanAll();
-  });
-
   describe("new question", () => {
     it("should suggest a name for structured queries", async () => {
       await setup(getQuestion());

--- a/frontend/test/metabase/entities/databases.unit.spec.js
+++ b/frontend/test/metabase/entities/databases.unit.spec.js
@@ -10,10 +10,6 @@ describe("database entity", () => {
     store = getStore();
   });
 
-  afterEach(() => {
-    nock.cleanAll();
-  });
-
   it("should save database metadata in redux", async () => {
     nock(location.origin)
       .get("/api/database/123/metadata")

--- a/frontend/test/metabase/entities/schemas.unit.spec.js
+++ b/frontend/test/metabase/entities/schemas.unit.spec.js
@@ -12,10 +12,6 @@ describe("schema entity", () => {
     store = getStore();
   });
 
-  afterEach(() => {
-    nock.cleanAll();
-  });
-
   it("should save metadata from fetching a schema's tables", async () => {
     nock(location.origin)
       .get("/api/database/1/schema/public")

--- a/frontend/test/metabase/lib/api.unit.spec.js
+++ b/frontend/test/metabase/lib/api.unit.spec.js
@@ -3,10 +3,6 @@ import api, { GET, POST, PUT } from "metabase/lib/api";
 api.basename = "";
 
 describe("api", () => {
-  afterEach(() => {
-    nock.cleanAll();
-  });
-
   const successResponse = { status: "ok" };
 
   it("should GET", async () => {

--- a/frontend/test/metabase/query_builder/components/DataSelector.unit.spec.js
+++ b/frontend/test/metabase/query_builder/components/DataSelector.unit.spec.js
@@ -31,10 +31,6 @@ describe("DataSelector", () => {
       });
   });
 
-  afterEach(() => {
-    nock.cleanAll();
-  });
-
   const emptyMetadata = {
     databases: {},
     schemas: {},

--- a/jest.unit.conf.json
+++ b/jest.unit.conf.json
@@ -27,7 +27,10 @@
     "<rootDir>/frontend/test/metabase-bootstrap.js",
     "<rootDir>/frontend/test/register-visualizations.js"
   ],
-  "setupFilesAfterEnv": ["@testing-library/jest-dom/extend-expect"],
+  "setupFilesAfterEnv": [
+    "@testing-library/jest-dom/extend-expect",
+    "<rootDir>/frontend/test/jest-setup-env.js"
+  ],
   "globals": {
     "ace": {},
     "ga": {},


### PR DESCRIPTION
- Moves nock setup to a single configuration file so it's no longer required to do `nock.cleanAll()` in each test
- Tries to solve timeout issues with Jest by following this section of the docs https://github.com/nock/nock#memory-issues-with-jest