### PR TITLE
Handle opening archived and not existing actions via URL

### DIFF
--- a/frontend/src/metabase/actions/containers/ActionCreatorModal/ActionCreatorModal.unit.spec.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreatorModal/ActionCreatorModal.unit.spec.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Route } from "react-router";
-import nock from "nock";
+import fetchMock from "fetch-mock";
 
 import {
   renderWithProviders,
@@ -45,14 +45,12 @@ async function setup({
   model = MODEL,
   action = ACTION,
 }: SetupOpts) {
-  const scope = nock(location.origin);
-
-  setupCardsEndpoints(scope, [model]);
+  setupCardsEndpoints([model]);
 
   if (action) {
-    setupActionsEndpoints(scope, model.id, [action]);
+    setupActionsEndpoints(model.id, [action]);
   } else {
-    scope.get(`/api/action/${ACTION_NOT_FOUND_ID}`).reply(404);
+    fetchMock.get(`path:/api/action/${ACTION_NOT_FOUND_ID}`, 404);
   }
 
   const { history } = renderWithProviders(
@@ -78,6 +76,10 @@ async function setup({
 }
 
 describe("actions > containers > ActionCreatorModal", () => {
+  afterEach(() => {
+    fetchMock.reset();
+  });
+
   it("renders correctly", async () => {
     await setup({ initialRoute: Urls.action(MODEL, ACTION.id) });
     expect(

--- a/frontend/src/metabase/actions/containers/ActionCreatorModal/ActionCreatorModal.unit.spec.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreatorModal/ActionCreatorModal.unit.spec.tsx
@@ -12,8 +12,6 @@ import {
   setupCardsEndpoints,
 } from "__support__/server-mocks";
 
-import * as Urls from "metabase/lib/urls";
-
 import type { Card, WritebackAction } from "metabase-types/api";
 import {
   createMockCard,
@@ -31,6 +29,7 @@ jest.mock(
 );
 
 const MODEL = createMockCard({ id: 1, dataset: true });
+const MODEL_SLUG = `${MODEL.id}-${MODEL.name.toLowerCase()}`;
 const ACTION = createMockQueryAction({ model_id: MODEL.id });
 const ACTION_NOT_FOUND_ID = 999;
 
@@ -81,32 +80,33 @@ describe("actions > containers > ActionCreatorModal", () => {
   });
 
   it("renders correctly", async () => {
-    await setup({ initialRoute: Urls.action(MODEL, ACTION.id) });
+    const initialRoute = `/model/${MODEL.id}/detail/actions/${ACTION.id}`;
+    await setup({ initialRoute });
     expect(
       await screen.findByTestId("mock-action-creator"),
     ).toBeInTheDocument();
   });
 
   it("redirects back to the model detail page if the action is not found", async () => {
-    const initialRoute = Urls.action(MODEL, ACTION_NOT_FOUND_ID);
+    const initialRoute = `/model/${MODEL.id}/detail/actions/${ACTION_NOT_FOUND_ID}`;
     const { history } = await setup({ initialRoute, action: null });
 
     expect(await screen.findByTestId("mock-model-detail")).toBeInTheDocument();
     expect(screen.queryByTestId("mock-action-creator")).not.toBeInTheDocument();
     expect(history?.getCurrentLocation().pathname).toBe(
-      Urls.modelDetail(MODEL, "actions"),
+      `/model/${MODEL_SLUG}/detail/actions`,
     );
   });
 
   it("redirects back to the model detail page if the action is archived", async () => {
     const action = { ...ACTION, archived: true };
-    const initialRoute = Urls.action(MODEL, action.id);
+    const initialRoute = `/model/${MODEL.id}/detail/actions/${action.id}`;
     const { history } = await setup({ initialRoute, action });
 
     expect(await screen.findByTestId("mock-model-detail")).toBeInTheDocument();
     expect(screen.queryByTestId("mock-action-creator")).not.toBeInTheDocument();
     expect(history?.getCurrentLocation().pathname).toBe(
-      Urls.modelDetail(MODEL, "actions"),
+      `/model/${MODEL_SLUG}/detail/actions`,
     );
   });
 });

--- a/frontend/src/metabase/actions/containers/ActionCreatorModal/ActionCreatorModal.unit.spec.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreatorModal/ActionCreatorModal.unit.spec.tsx
@@ -1,0 +1,110 @@
+import React from "react";
+import { Route } from "react-router";
+import nock from "nock";
+
+import {
+  renderWithProviders,
+  screen,
+  waitForElementToBeRemoved,
+} from "__support__/ui";
+import {
+  setupActionsEndpoints,
+  setupCardsEndpoints,
+} from "__support__/server-mocks";
+
+import * as Urls from "metabase/lib/urls";
+
+import type { Card, WritebackAction } from "metabase-types/api";
+import {
+  createMockCard,
+  createMockQueryAction,
+} from "metabase-types/api/mocks";
+
+import ActionCreatorModal from "./ActionCreatorModal";
+
+jest.mock(
+  "metabase/actions/containers/ActionCreator",
+  () =>
+    function MockActionCreator() {
+      return <div data-testid="mock-action-creator" />;
+    },
+);
+
+const MODEL = createMockCard({ id: 1, dataset: true });
+const ACTION = createMockQueryAction({ model_id: MODEL.id });
+const ACTION_NOT_FOUND_ID = 999;
+
+type SetupOpts = {
+  initialRoute: string;
+  action?: WritebackAction | null;
+  model?: Card;
+};
+
+async function setup({
+  initialRoute,
+  model = MODEL,
+  action = ACTION,
+}: SetupOpts) {
+  const scope = nock(location.origin);
+
+  setupCardsEndpoints(scope, [model]);
+
+  if (action) {
+    setupActionsEndpoints(scope, model.id, [action]);
+  } else {
+    scope.get(`/api/action/${ACTION_NOT_FOUND_ID}`).reply(404);
+  }
+
+  const { history } = renderWithProviders(
+    <>
+      <Route
+        path="/model/:slug/detail/actions/:actionId"
+        component={ActionCreatorModal}
+      />
+      <Route
+        path="/model/:slug/detail/actions"
+        component={() => <div data-testid="mock-model-detail" />}
+      />
+    </>,
+    {
+      withRouter: true,
+      initialRoute,
+    },
+  );
+
+  await waitForElementToBeRemoved(() => screen.queryAllByText(/Loading/i));
+
+  return { history };
+}
+
+describe("actions > containers > ActionCreatorModal", () => {
+  it("renders correctly", async () => {
+    await setup({ initialRoute: Urls.action(MODEL, ACTION.id) });
+    expect(
+      await screen.findByTestId("mock-action-creator"),
+    ).toBeInTheDocument();
+  });
+
+  it("redirects back to the model detail page if the action is not found", async () => {
+    const initialRoute = Urls.action(MODEL, ACTION_NOT_FOUND_ID);
+    const { history } = await setup({ initialRoute, action: null });
+
+    expect(await screen.findByTestId("mock-model-detail")).toBeInTheDocument();
+    expect(screen.queryByTestId("mock-action-creator")).not.toBeInTheDocument();
+    expect(history?.getCurrentLocation().pathname).toBe(
+      Urls.modelDetail(MODEL, "actions"),
+    );
+  });
+
+  it("redirects back to the model detail page if the action is archived", async () => {
+    const action = { ...ACTION, archived: true };
+    const initialRoute = Urls.action(MODEL, action.id);
+    const { history } = await setup({ initialRoute, action });
+
+    expect(await screen.findByTestId("mock-model-detail")).toBeInTheDocument();
+    expect(screen.queryByTestId("mock-action-creator")).not.toBeInTheDocument();
+    expect(history?.getCurrentLocation().pathname).toBe(
+      Urls.modelDetail(MODEL, "actions"),
+    );
+  });
+});

--- a/frontend/src/metabase/models/containers/ModelDetailPage/ModelDetailPage.unit.spec.tsx
+++ b/frontend/src/metabase/models/containers/ModelDetailPage/ModelDetailPage.unit.spec.tsx
@@ -529,7 +529,7 @@ describe("ModelDetailPage", () => {
         it("allows to create a new query action from the empty state", async () => {
           await setupActions({ model: getModel(), actions: [] });
           userEvent.click(screen.getByRole("link", { name: "New action" }));
-          expect(screen.getByTestId("mock-action-editor")).toBeVisible();
+          expect(await screen.findByTestId("mock-action-editor")).toBeVisible();
         });
 
         it("lists existing query actions", async () => {
@@ -583,7 +583,7 @@ describe("ModelDetailPage", () => {
 
           userEvent.click(screen.getByRole("link", { name: "New action" }));
 
-          expect(screen.getByTestId("mock-action-editor")).toBeVisible();
+          expect(await screen.findByTestId("mock-action-editor")).toBeVisible();
         });
 
         it("allows to edit a query action via link", async () => {
@@ -593,7 +593,7 @@ describe("ModelDetailPage", () => {
 
           userEvent.click(screen.getByRole("link", { name: action.name }));
 
-          expect(screen.getByTestId("mock-action-editor")).toBeVisible();
+          expect(await screen.findByTestId("mock-action-editor")).toBeVisible();
         });
 
         it("allows to edit a query action via menu", async () => {
@@ -604,7 +604,7 @@ describe("ModelDetailPage", () => {
           openActionMenu(action);
           userEvent.click(screen.getByText("Edit"));
 
-          expect(screen.getByTestId("mock-action-editor")).toBeVisible();
+          expect(await screen.findByTestId("mock-action-editor")).toBeVisible();
         });
 
         it("allows to create implicit actions", async () => {


### PR DESCRIPTION
Epic #27581

### Description

Handles a few corner cases with action URLs:

* opening an archived action via URL should now redirect you to a list of model actions
* opening a not existing action via URL should now redirect you to a list of model actions
* opening a link with action's model ID not matching the real one should result in a "not found" view

### How to verify

1. Go to `/model/:modelId/detail/actions`
2. Archive an action and try opening it via `/model/:modelId/detail/actions/:actionId` URL
3. Ensure you're navigated back to `/model/:modelId/detail/actions`
4. Try opening an action that doesn't exist, e.g. use `999` as an action ID
5. Ensure you're navigated back to `/model/:modelId/detail/actions`
6. Put an incorrect model ID into your action URL, but keep the action ID valid
7. Ensure you see a not found view

### Demo


https://user-images.githubusercontent.com/17258145/220416112-1a0e8f2a-90ea-4d81-a552-e84c6055c90e.mp4



### Checklist

- [x] Tests have been added/updated to cover changes in this PR

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/28493)
<!-- Reviewable:end -->
