### PR TITLE
Fix saved question picker with 2+ dbs

### DIFF
--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelector.jsx
@@ -184,6 +184,7 @@ class DataSelectorInner extends Component {
 
 const DataSelector = _.compose(
   Databases.loadList({
+    query: { saved: true },
     loadingAndErrorWrapper: false,
     listName: "allDatabases",
   }),


### PR DESCRIPTION
How to test:
- Open `http://localhost:3000/question/notebook#eyJjcmVhdGlvblR5cGUiOiJjdXN0b21fcXVlc3Rpb24iLCJkYXRhc2V0X3F1ZXJ5Ijp7ImRhdGFiYXNlIjpudWxsLCJxdWVyeSI6eyJzb3VyY2UtdGFibGUiOm51bGx9LCJ0eXBlIjoicXVlcnkifSwiZGlzcGxheSI6InRhYmxlIiwidmlzdWFsaXphdGlvbl9zZXR0aW5ncyI6e319`
- Click `Saved Questions`
- It should show the saved question picker (currently it opens raw tables instead)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/28496)
<!-- Reviewable:end -->
