### PR TITLE
Fix tooltip

### DIFF
--- a/frontend/src/metabase/models/components/ModelDetailPage/ModelActionDetails/ModelActionListItem.tsx
+++ b/frontend/src/metabase/models/components/ModelDetailPage/ModelActionDetails/ModelActionListItem.tsx
@@ -116,7 +116,7 @@ function ModelActionListItem({
                   as={Link}
                   icon="play"
                   onlyIcon
-                  tooltip={t`Run action`}
+                  tooltip={t`Run`}
                 />
               </ActionRunButtonContainer>
             }


### PR DESCRIPTION
Epic #27581

Changing "Run action" to "Run" because we're at the phase of `master` when new UI strings can't be added