### PR TITLE
Move disabled tooltip to be around button

### DIFF
--- a/frontend/src/metabase/actions/components/ActionViz/Action.tsx
+++ b/frontend/src/metabase/actions/components/ActionViz/Action.tsx
@@ -5,6 +5,8 @@ import { connect } from "react-redux";
 
 import { executeRowAction } from "metabase/dashboard/actions";
 
+import Tooltip from "metabase/core/components/Tooltip";
+
 import type {
   ActionDashboardCard,
   ParametersForActionExecution,
@@ -33,6 +35,7 @@ import {
 } from "./utils";
 import ActionVizForm from "./ActionVizForm";
 import ActionButtonView from "./ActionButtonView";
+import { FullContainer } from "./ActionButton.styled";
 
 export interface ActionProps extends VisualizationProps {
   dashcard: ActionDashboardCard;
@@ -140,13 +143,17 @@ export function ActionFn(props: ActionProps) {
       : t`Actions are not enabled for this database`;
 
     return (
-      <ActionButtonView
-        disabled
-        icon="bolt"
-        tooltip={tooltip}
-        settings={props.settings}
-        focus={props.isEditingDashcard}
-      />
+      <Tooltip tooltip={tooltip}>
+        <FullContainer>
+          <ActionButtonView
+            disabled
+            icon="bolt"
+            tooltip={tooltip}
+            settings={props.settings}
+            focus={props.isEditingDashcard}
+          />
+        </FullContainer>
+      </Tooltip>
     );
   }
 

--- a/frontend/src/metabase/actions/components/ActionViz/ActionButton.styled.tsx
+++ b/frontend/src/metabase/actions/components/ActionViz/ActionButton.styled.tsx
@@ -16,6 +16,11 @@ export const StyledButton = styled(Button)<{
       : ""}
 `;
 
+export const FullContainer = styled.div`
+  width: 100%;
+  height: 100%;
+`;
+
 export const StyledButtonContent = styled.div`
   display: flex;
   align-items: center;

--- a/frontend/src/metabase/actions/components/ActionViz/ActionButtonView.tsx
+++ b/frontend/src/metabase/actions/components/ActionViz/ActionButtonView.tsx
@@ -37,13 +37,14 @@ function ActionButtonView({
     <StyledButton
       disabled={!!disabled}
       onClick={onClick}
+      fullWidth
       isFullHeight={isFullHeight}
       focus={focus}
       aria-label={tooltip}
       {...variantProps}
     >
       <StyledButtonContent>
-        {icon && <Icon name={icon} tooltip={tooltip} />}
+        {icon && <Icon name={icon} />}
         <Ellipsified>{label ?? t`Click me`}</Ellipsified>
       </StyledButtonContent>
     </StyledButton>


### PR DESCRIPTION
https://metaboat.slack.com/archives/C04FG88HL95/p1676998729826389

### Description

- moves disabled tooltip for actions buttons away from the ⚡ icon to be around the whole button

![tooltiparound](https://user-images.githubusercontent.com/30528226/220422321-f0074022-fb13-4397-97c0-cfb5d2817a86.gif)

