### PR TITLE
Don't search for actions to link

### DIFF
--- a/frontend/src/metabase/nav/components/SearchResults.jsx
+++ b/frontend/src/metabase/nav/components/SearchResults.jsx
@@ -74,6 +74,7 @@ export default _.compose(
     query: (_state, props) => ({
       q: props.searchText,
       limit: DEFAULT_SEARCH_LIMIT,
+      models: props.models,
     }),
   }),
 )(SearchResults);

--- a/frontend/src/metabase/visualizations/visualizations/LinkViz/LinkViz.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/LinkViz/LinkViz.tsx
@@ -33,6 +33,15 @@ import {
 
 import { isUrlString } from "./utils";
 
+const MODELS_TO_SEARCH = [
+  "card",
+  "dataset",
+  "dashboard",
+  "collection",
+  "database",
+  "table",
+];
+
 export interface LinkVizProps {
   dashcard: DashboardOrderedCard;
   isEditing: boolean;
@@ -129,6 +138,7 @@ function LinkViz({
               <SearchResults
                 searchText={url?.trim()}
                 onEntitySelect={handleEntitySelect}
+                models={MODELS_TO_SEARCH}
               />
             </SearchResultsContainer>
           }


### PR DESCRIPTION
### Description

We don't really need to (or support) linking actions in dashboards. This adds a simple `models` prop to the `SearchResults` component that allows us to limit the models it searches

. | .
--- | ---
Link cards don't search actions anymore | ![Screen Shot 2023-02-21 at 12 48 14 PM](https://user-images.githubusercontent.com/30528226/220444344-a8ae4356-4416-42df-980f-64c744dc601d.png)
global search still searches everything | ![Screen Shot 2023-02-21 at 12 48 26 PM](https://user-images.githubusercontent.com/30528226/220444310-329f03a0-5ce5-4633-b6a7-4e6776fad995.png)

### How to verify

- add a link card to a dashboard
- search for an action name
- you shouldn't see the action
- make sure you can still see actions in global search

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR

🤔  not sure this can be tested without an e2e test, and not sure it's that valuable 
