### PR TITLE
Strip semicolons from card refs in native queries

### DIFF
--- a/src/metabase/driver/sql/parameters/substitution.clj
+++ b/src/metabase/driver/sql/parameters/substitution.clj
@@ -311,7 +311,7 @@
 (defmethod ->replacement-snippet-info [:sql ReferencedCardQuery]
   [_ {:keys [query params]}]
   {:prepared-statement-args (not-empty params)
-   :replacement-snippet     (str "(" query ")")})
+   :replacement-snippet     (sql.qp/make-nestable-sql query)})
 
 
 ;;; ---------------------------------- Native Query Snippet replacement snippet info ---------------------------------

--- a/src/metabase/driver/sql/query_processor.clj
+++ b/src/metabase/driver/sql/query_processor.clj
@@ -43,10 +43,12 @@
   "The INNER query currently being processed, for situations where we need to refer back to it."
   nil)
 
-(defn- format-sql-source-query [_fn [sql params]]
+(defn make-nestable-sql [sql]
   ;; wrap `sql` string in parens and strip off any trailing semicolons.
-  (let [sql (str "(" (str/replace sql #";+\s*$" "") ")")]
-    (into [sql] params)))
+  (str "(" (str/replace sql #";[\s;]*$" "") ")"))
+
+(defn- format-sql-source-query [_fn [sql params]]
+  (into [(make-nestable-sql sql)] params))
 
 (sql/register-fn! ::sql-source-query #'format-sql-source-query)
 

--- a/src/metabase/driver/sql/query_processor.clj
+++ b/src/metabase/driver/sql/query_processor.clj
@@ -43,8 +43,9 @@
   "The INNER query currently being processed, for situations where we need to refer back to it."
   nil)
 
-(defn make-nestable-sql [sql]
-  ;; wrap `sql` string in parens and strip off any trailing semicolons.
+(defn make-nestable-sql
+  "For embedding native sql queries, wraps [sql] in parens and removes any semicolons"
+  [sql]
   (str "(" (str/replace sql #";[\s;]*$" "") ")"))
 
 (defn- format-sql-source-query [_fn [sql params]]

--- a/test/metabase/driver/sql/parameters/substitute_test.clj
+++ b/test/metabase/driver/sql/parameters/substitute_test.clj
@@ -279,7 +279,7 @@
     (let [query ["SELECT * FROM " (param "#123")]]
       (is (= ["SELECT * FROM (SELECT 1 `x`)" []]
              (substitute query {"#123" (params/map->ReferencedCardQuery {:card-id 123, :query "SELECT 1 `x`"})})))))
-  (testing "Referenced card query substitution removes trailing semicolons and whitespace"
+  (testing "Referenced card query substitution removes trailing semicolons and whitespace #28218"
     (let [query ["SELECT * FROM " (param "#123")]]
       (is (= ["SELECT * FROM (SELECT ';' `x`)" []]
              (substitute query {"#123" (params/map->ReferencedCardQuery {:card-id 123, :query "SELECT ';' `x`; ; "})}))))))

--- a/test/metabase/driver/sql/parameters/substitute_test.clj
+++ b/test/metabase/driver/sql/parameters/substitute_test.clj
@@ -278,8 +278,11 @@
   (testing "Referenced card query substitution"
     (let [query ["SELECT * FROM " (param "#123")]]
       (is (= ["SELECT * FROM (SELECT 1 `x`)" []]
-             (substitute query {"#123" (params/map->ReferencedCardQuery {:card-id 123, :query "SELECT 1 `x`"})}))))))
-
+             (substitute query {"#123" (params/map->ReferencedCardQuery {:card-id 123, :query "SELECT 1 `x`"})})))))
+  (testing "Referenced card query substitution removes trailing semicolons and whitespace"
+    (let [query ["SELECT * FROM " (param "#123")]]
+      (is (= ["SELECT * FROM (SELECT ';' `x`)" []]
+             (substitute query {"#123" (params/map->ReferencedCardQuery {:card-id 123, :query "SELECT ';' `x`; ; "})}))))))
 
 ;;; --------------------------------------------- Native Query Snippets ----------------------------------------------
 


### PR DESCRIPTION
Fixes #28218

While source-query substitution handled semicolons in native questions within outer mbql queries, we used a different code path when splicing into native queries. This brings the two paths inline.
