### PR TITLE
Decouple checking ddl from classifying h2 stmts

### DIFF
--- a/src/metabase/driver/h2.clj
+++ b/src/metabase/driver/h2.clj
@@ -136,25 +136,27 @@
 (mu/defn ^:private classify-query :- [:map
                                       [:command-types [:vector pos-int?]]
                                       [:remaining-sql [:maybe :string]]]
-  "Takes an h2 db id, and a query, returns the command-classes+types (see: ), and any remaining sql.
+  "Takes an h2 db id, and a query, returns the command-types from `query` and any remaining sql.
+   More info on command types here:
+   https://github.com/h2database/h2database/blob/master/h2/src/main/org/h2/command/CommandInterface.java
 
-  - Each `command-type` corresponds to a value in org.h2.command.CommandInterface, and match the commands in order.
+  - Each `command-type` corresponds to a value in org.h2.command.CommandInterface, and match the commands from `query` in order.
   - `remaining-sql` is a nillable sql string that is unable to be classified without running preceding queries first.
     Usually if `remaining-sql` exists we will deny the query."
   [database query]
   (when-let [h2-parser (make-h2-parser database)]
     (try
-      (let [command-list      (.prepareCommand h2-parser query)
-            command-list-type (.getCommandType ^org.h2.command.CommandList command-list)
+      (let [command           (.prepareCommand h2-parser query)
+            command-list-type (.getCommandType command)
             command-types     (cond-> [command-list-type]
-                                (not (instance? org.h2.command.CommandContainer command-list))
+                                (not (instance? org.h2.command.CommandContainer command))
                                 (into
                                  (map #(.getType ^org.h2.command.Prepared %))
                                  ;; when there are no fields: return no commands
-                                 (get-field command-list "commands" [])))]
+                                 (get-field command "commands" [])))]
         {:command-types command-types
          ;; when there is no remaining sql: return nil for remaining-sql
-         :remaining-sql (get-field command-list "remaining" nil)})
+         :remaining-sql (get-field command "remaining" nil)})
       ;; only valid queries can be classified.
       (catch org.h2.message.DbException _
         {:command-types [] :remaining-sql nil}))))
@@ -173,11 +175,12 @@
 ;; TODO: black-list RUNSCRIPT, and a bunch more -- but they're not technically ddl. Should be simple to build off of [[classify-query]].
 ;; e.g.: similar to contains-ddl? but instead of cmd-type-ddl? use: #(#{CommandInterface/RUNSCRIPT} %)
 
-(defn- check-disallow-ddl-commands [{:keys [database] {:keys [query]} :native :as in}]
-  (let [query-classification (classify-query database query)]
-    (when (and query (contains-ddl? query-classification))
-      (throw (ex-info "IllegalArgument: DDL commands are not allowed to be used with h2."
-                      {:classification query-classification})))))
+(defn- check-disallow-ddl-commands [{:keys [database] {:keys [query]} :native}]
+  (when query
+    (let [query-classification (classify-query database query)]
+      (when (contains-ddl? query-classification)
+        (throw (ex-info "IllegalArgument: DDL commands are not allowed to be used with h2."
+                        {:classification query-classification}))))))
 
 (defmethod driver/execute-reducible-query :h2
   [driver query chans respond]

--- a/src/metabase/driver/h2.clj
+++ b/src/metabase/driver/h2.clj
@@ -146,14 +146,14 @@
   [database query]
   (when-let [h2-parser (make-h2-parser database)]
     (try
-      (let [command           (.prepareCommand h2-parser query)
-            command-list-type (.getCommandType command)
-            command-types     (cond-> [command-list-type]
-                                (not (instance? org.h2.command.CommandContainer command))
-                                (into
-                                 (map #(.getType ^org.h2.command.Prepared %))
-                                 ;; when there are no fields: return no commands
-                                 (get-field command "commands" [])))]
+      (let [command            (.prepareCommand h2-parser query)
+            first-command-type (.getCommandType command)
+            command-types      (cond-> [first-command-type]
+                                 (not (instance? org.h2.command.CommandContainer command))
+                                 (into
+                                  (map #(.getType ^org.h2.command.Prepared %))
+                                  ;; when there are no fields: return no commands
+                                  (get-field command "commands" [])))]
         {:command-types command-types
          ;; when there is no remaining sql: return nil for remaining-sql
          :remaining-sql (get-field command "remaining" nil)})

--- a/src/metabase/driver/h2.clj
+++ b/src/metabase/driver/h2.clj
@@ -140,7 +140,7 @@
 
   - Each `command-type` corresponds to a value in org.h2.command.CommandInterface, and match the commands in order.
   - `remaining-sql` is a nillable sql string that is unable to be classified without running preceding queries first.
-    Usually `remaining-sql` it exists we will deny the query."
+    Usually if `remaining-sql` exists we will deny the query."
   [database query]
   (when-let [h2-parser (make-h2-parser database)]
     (try

--- a/src/metabase/driver/h2.clj
+++ b/src/metabase/driver/h2.clj
@@ -135,11 +135,12 @@
       (when (instance? SessionLocal session)
         (Parser. session)))))
 
-(mu/defn ^:private classify-query
-  :- [:map
-      [:command-class+types [:vector [:tuple :any :int]]]
-      [:remaining-sql [:maybe :string]]]
-  [database query :- :string]
+(defn- classify-query
+  "Takes an h2 db id, and a query, returns the command-classes+types (see: ), and any remaining sql.
+
+  - `remaining-sql` is a nillable sql string that is unable to be classified without running preceding queries first.
+    Usually if it exists we will deny the query."
+  [database query]
   (when-let [h2-parser (make-h2-parser database)]
     (try
       (let [command-list      (.prepareCommand h2-parser query)

--- a/test/metabase/driver/h2_test.clj
+++ b/test/metabase/driver/h2_test.clj
@@ -189,6 +189,8 @@
        CREATE ALIAS EXEC AS 'String shellexec(String cmd) throws java.io.IOException {Runtime.getRuntime().exec(cmd);return \"y4tacker\";}';"
       "CREATE ALIAS EXEC AS 'String shellexec(String cmd) throws java.io.IOException {Runtime.getRuntime().exec(cmd);return \"y4tacker\";}';")
 
+    (is (= nil (#'h2/check-disallow-ddl-commands {:database (u/the-id (mt/db)) :native {:query nil}})))
+
     (is (= nil (#'h2/check-disallow-ddl-commands
                 {:database (u/the-id (mt/db))
                  :engine :h2


### PR DESCRIPTION
- This should enable follow-up for easily blocking more types of queries.
- Check *all* statements to ensure they aren't "ddl", not just the 1st one.

Previously, we weren't thoroughly checking every single statement. So if more statements were passed in and the first statement was legit, we allowed them to run. Although H2 shouldn't be used for anything serious, it is still important to plug this vulnerability.

This separation also uncouples the JVM interop details from the purely functional computation of "are any of these statements DDL?". I believe this separation will [simplify detecting or denying query execution](https://github.com/metabase/metabase/pull/28510/files#diff-c4bd5c99a5e021fc7f1ecf5305075b8195b50845e23343846284a821fb0e4a3cR173-R174) based on their [org.h2.command.CommandInterface value](https://github.com/h2database/h2database/blob/master/h2/src/main/org/h2/command/CommandInterface.java#L16-L557).