### PR TITLE
Resolve nested questions in native queries

### DIFF
--- a/src/metabase/query_processor/middleware/fetch_source_query.clj
+++ b/src/metabase/query_processor/middleware/fetch_source_query.clj
@@ -292,7 +292,7 @@
       remove-unneeded-database-ids
       extract-resolved-card-id))
 
-(s/defn ^:private resolve-card-id-source-tables* :- {:card-id (s/maybe su/IntGreaterThanZero)
+(s/defn resolve-card-id-source-tables* :- {:card-id (s/maybe su/IntGreaterThanZero)
                                                      :query   FullyResolvedQuery}
   "Resolve `card__n`-style `:source-tables` in `query`."
   [{inner-query :query, :as outer-query} :- mbql.s/Query]

--- a/src/metabase/query_processor/middleware/permissions.clj
+++ b/src/metabase/query_processor/middleware/permissions.clj
@@ -10,8 +10,8 @@
    [metabase.models.query.permissions :as query-perms]
    [metabase.plugins.classloader :as classloader]
    [metabase.query-processor.error-type :as qp.error-type]
-   [metabase.query-processor.middleware.resolve-referenced
-    :as qp.resolve-referenced]
+   [metabase.query-processor.util.tag-referenced-cards
+    :as qp.u.tag-referenced-cards]
    [metabase.util :as u]
    [metabase.util.i18n :refer [tru]]
    [metabase.util.log :as log]
@@ -86,7 +86,7 @@
     (when-not (has-data-perms? required-perms)
       (throw (perms-exception required-perms))))
   ;; check perms for any Cards referenced by this query (if it is a native query)
-  (doseq [{query :dataset_query} (qp.resolve-referenced/tags-referenced-cards outer-query)]
+  (doseq [{query :dataset_query} (qp.u.tag-referenced-cards/tags-referenced-cards outer-query)]
     (check-query-permissions* query)))
 
 (s/defn ^:private check-query-permissions*

--- a/src/metabase/query_processor/middleware/resolve_referenced.clj
+++ b/src/metabase/query_processor/middleware/resolve_referenced.clj
@@ -1,6 +1,8 @@
 (ns metabase.query-processor.middleware.resolve-referenced
   (:require
    [metabase.models.card :refer [Card]]
+   [metabase.query-processor.middleware.fetch-source-query
+    :as fetch-source-query]
    [metabase.query-processor.middleware.resolve-fields
     :as qp.resolve-fields]
    [metabase.query-processor.middleware.resolve-source-table
@@ -41,10 +43,11 @@
 (s/defn ^:private resolve-referenced-card-resources* :- clojure.lang.IPersistentMap
   [query]
   (doseq [referenced-card (tags-referenced-cards query)
-          :let [referenced-query (:dataset_query referenced-card)]]
+          :let [referenced-query (:dataset_query referenced-card)
+                resolved-query (fetch-source-query/resolve-card-id-source-tables* referenced-query)]]
     (check-query-database-id= referenced-query (:database query))
-    (qp.resolve-source-table/resolve-source-tables referenced-query)
-    (qp.resolve-fields/resolve-fields referenced-query))
+    (qp.resolve-source-table/resolve-source-tables resolved-query)
+    (qp.resolve-fields/resolve-fields resolved-query))
   query)
 
 (defn- card-subquery-graph

--- a/src/metabase/query_processor/middleware/resolve_referenced.clj
+++ b/src/metabase/query_processor/middleware/resolve_referenced.clj
@@ -7,31 +7,14 @@
     :as qp.resolve-fields]
    [metabase.query-processor.middleware.resolve-source-table
     :as qp.resolve-source-table]
+   [metabase.query-processor.util.tag-referenced-cards
+    :as qp.u.tag-referenced-cards]
    [metabase.util.i18n :refer [tru]]
    [schema.core :as s]
    [toucan.db :as db]
    [weavejester.dependency :as dep])
   (:import
    (clojure.lang ExceptionInfo)))
-
-(defn- query->template-tags
-  [query]
-  (vals (get-in query [:native :template-tags])))
-
-(defn- query->tag-card-ids
-  [query]
-  (keep :card-id (query->template-tags query)))
-
-(defn tags-referenced-cards
-  "Returns Card instances referenced by the given native `query`."
-  [query]
-  (mapv
-   (fn [card-id]
-     (if-let [card (db/select-one Card :id card-id)]
-       card
-       (throw (ex-info (tru "Referenced question #{0} could not be found" (str card-id))
-                       {:card-id card-id}))))
-   (query->tag-card-ids query)))
 
 (defn- check-query-database-id=
   [query database-id]
@@ -42,7 +25,7 @@
 
 (s/defn ^:private resolve-referenced-card-resources* :- clojure.lang.IPersistentMap
   [query]
-  (doseq [referenced-card (tags-referenced-cards query)
+  (doseq [referenced-card (qp.u.tag-referenced-cards/tags-referenced-cards query)
           :let [referenced-query (:dataset_query referenced-card)
                 resolved-query (fetch-source-query/resolve-card-id-source-tables* referenced-query)]]
     (check-query-database-id= referenced-query (:database query))
@@ -58,7 +41,7 @@
        (card-subquery-graph (dep/depend g card-id sub-card-id)
                             sub-card-id))
      graph
-     (query->tag-card-ids card-query))))
+     (qp.u.tag-referenced-cards/query->tag-card-ids card-query))))
 
 (defn- circular-ref-error
   [from-card to-card]
@@ -71,7 +54,7 @@
   [query]
   (try
    ;; `card-subquery-graph` will throw if there are circular references
-   (reduce card-subquery-graph (dep/graph) (query->tag-card-ids query))
+   (reduce card-subquery-graph (dep/graph) (qp.u.tag-referenced-cards/query->tag-card-ids query))
    (catch ExceptionInfo e
      (let [{:keys [reason node dependency]} (ex-data e)]
        (if (= reason :weavejester.dependency/circular-dependency)

--- a/src/metabase/query_processor/util/tag_referenced_cards.clj
+++ b/src/metabase/query_processor/util/tag_referenced_cards.clj
@@ -1,0 +1,25 @@
+(ns metabase.query-processor.util.tag-referenced-cards
+  (:require
+   [metabase.models.card :refer [Card]]
+   [metabase.util.i18n :refer [tru]]
+   [toucan.db :as db]))
+
+(defn- query->template-tags
+  [query]
+  (vals (get-in query [:native :template-tags])))
+
+(defn query->tag-card-ids
+  "Returns the card IDs from the template tags of the native query of `query`."
+  [query]
+  (keep :card-id (query->template-tags query)))
+
+(defn tags-referenced-cards
+  "Returns Card instances referenced by the given native `query`."
+  [query]
+  (mapv
+   (fn [card-id]
+     (if-let [card (db/select-one Card :id card-id)]
+       card
+       (throw (ex-info (tru "Referenced question #{0} could not be found" (str card-id))
+                       {:card-id card-id}))))
+   (query->tag-card-ids query)))

--- a/test/metabase/query_processor/middleware/resolve_referenced_test.clj
+++ b/test/metabase/query_processor/middleware/resolve_referenced_test.clj
@@ -15,19 +15,6 @@
 
 (set! *warn-on-reflection* true)
 
-(deftest tags-referenced-cards-lookup-test
-  (testing "returns Card instances from raw query"
-    (mt/with-temp* [Card [c1 {}]
-                    Card [c2 {}]]
-      (is (= [c1 c2]
-             (#'qp.resolve-referenced/tags-referenced-cards
-              {:native
-               {:template-tags
-                {"tag-name-not-important1" {:type    :card
-                                            :card-id (:id c1)}
-                 "tag-name-not-important2" {:type    :card
-                                            :card-id (:id c2)}}}}))))))
-
 (deftest resolve-card-resources-test
   (testing "resolve stores source table from referenced card"
     (mt/with-temp Card [mbql-card {:dataset_query (mt/mbql-query venues

--- a/test/metabase/query_processor/util/tag_referenced_cards_test.clj
+++ b/test/metabase/query_processor/util/tag_referenced_cards_test.clj
@@ -1,0 +1,19 @@
+(ns metabase.query-processor.util.tag-referenced-cards-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase.models.card :refer [Card]]
+   [metabase.query-processor.util.tag-referenced-cards :as qp.u.tag-referenced-cards]
+   [metabase.test :as mt]))
+
+(deftest tags-referenced-cards-lookup-test
+  (testing "returns Card instances from raw query"
+    (mt/with-temp* [Card [c1 {}]
+                    Card [c2 {}]]
+      (is (= [c1 c2]
+             (qp.u.tag-referenced-cards/tags-referenced-cards
+              {:native
+               {:template-tags
+                {"tag-name-not-important1" {:type    :card
+                                            :card-id (:id c1)}
+                 "tag-name-not-important2" {:type    :card
+                                            :card-id (:id c2)}}}}))))))

--- a/test/metabase/query_processor_test/native_test.clj
+++ b/test/metabase/query_processor_test/native_test.clj
@@ -1,9 +1,11 @@
 (ns metabase.query-processor-test.native-test
   (:require
    [clojure.test :refer :all]
+   [metabase.models.card :refer [Card]]
    [metabase.query-processor :as qp]
    [metabase.query-processor-test :as qp.test]
-   [metabase.test :as mt]))
+   [metabase.test :as mt]
+   [metabase.util :as u]))
 
 (deftest native-test
   (is (= {:rows
@@ -33,3 +35,22 @@
           (qp/process-query
            (mt/native-query
             {:query "select name from users;"}))))))
+
+(deftest native-referring-question-referring-question-test
+  (testing "Should be able to run native query referring a question referring a question (#25988)"
+    (mt/with-driver :h2
+      (mt/dataset sample-dataset
+        (mt/with-temp* [Card [card1 {:dataset_query (mt/mbql-query products)}]
+                        Card [card2 {:dataset_query {:query {:source-table (str "card__" (u/the-id card1))}
+                                                     :database (u/the-id (mt/db))
+                                                     :type :query}}]]
+          (let [card-tag (str "#" (u/the-id card2))
+                query    {:query         (format "SELECT CATEGORY, VENDOR FROM {{%s}} ORDER BY ID LIMIT 1" card-tag)
+                          :template-tags {card-tag
+                                          {:id           "afd1bf85-61d0-258c-99a7-a5b448728308"
+                                           :name         card-tag
+                                           :display-name card-tag
+                                           :type         :card
+                                           :card-id      (u/the-id card2)}}}]
+            (is (= [["Gizmo" "Swaniawski, Casper and Hilll"]]
+                   (mt/rows (qp/process-query (mt/native-query query)))))))))))


### PR DESCRIPTION
Fixes #25988.

`tag-referenced-cards` had to be extracted into a separate namespace to avoid circular dependencies.