### PR TITLE
Fix line-bar-tooltip spec

### DIFF
--- a/frontend/test/metabase/scenarios/dashboard/reproductions/20637-add-series-to-dashcard.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard/reproductions/20637-add-series-to-dashcard.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore } from "__support__/e2e/helpers";
+import { restore, saveDashboard } from "__support__/e2e/helpers";
 
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
@@ -33,16 +33,6 @@ describe("adding an additional series to a dashcard (metabase#20637)", () => {
     cy.wait(["@dashcardQuery", "@additionalSeriesDashcardQuery"]);
   });
 });
-
-function saveDashboard() {
-  cy.intercept("PUT", "/api/dashboard/*").as("updateDashboard");
-  cy.intercept("PUT", "/api/dashboard/*/cards").as("updateDashCards");
-  cy.intercept("GET", "/api/dashboard/*").as("loadDashboard");
-
-  cy.findByText("Save").click();
-
-  cy.wait(["@updateDashboard", "@updateDashCards", "@loadDashboard"]);
-}
 
 function createQuestionsAndDashboard() {
   const dashcardQuestion = {

--- a/frontend/test/metabase/scenarios/visualizations/line-bar-tooltips.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/line-bar-tooltips.cy.spec.js
@@ -1,4 +1,9 @@
-import { restore, popover, visitDashboard } from "__support__/e2e/helpers";
+import {
+  restore,
+  popover,
+  visitDashboard,
+  saveDashboard,
+} from "__support__/e2e/helpers";
 
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
@@ -490,5 +495,6 @@ function saveDashCardVisualizationOptions() {
   cy.get(".Modal").within(() => {
     cy.findByText("Done").click();
   });
-  cy.findByText("Save").click();
+
+  saveDashboard();
 }


### PR DESCRIPTION
## Changes

Fixes `frontend/test/metabase/scenarios/visualizations/line-bar-tooltips.cy.spec.js` spec. It appears that the test did not wait for a dashboard to be saved and on weak agents, the test clicked save, then hovered over the chart to show the tooltip, but after that, the dashboard got saved which shifts the layout so the tooltip disappears and only then cypress tried to read its values.

Here is the screenshot from a video artifact:
<img width="813" alt="Screen Shot 2023-02-21 at 9 50 15 PM" src="https://user-images.githubusercontent.com/14301985/220492260-e5e29d7b-5456-4f17-8176-a1382044c4d9.png">
