### PR TITLE
Release automation: publish Elastic Beanstalk artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -266,3 +266,22 @@ jobs:
     - name: Wait for Metabase to start
       run: while ! curl -s 'http://localhost:3000/api/health' | grep '{"status":"ok"}'; do sleep 1; done
       timeout-minutes: 3
+
+  publish-elastic-beanstalk-artifacts:
+    runs-on: ubuntu-20.04
+    needs: containerize
+    timeout-minutes: 15
+    env:
+      NO_SLACK: 1
+    steps:
+    - uses: actions/checkout@v3
+    - name: Prepare back-end environment
+      uses: ./.github/actions/prepare-backend
+    - name: Configure AWS credentials for S3
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.AWS_S3_RELEASE_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_S3_RELEASE_SECRET_ACCESS_KEY }}
+        aws-region: us-east-1
+    - name: Publish Elastic Beanstalk artifacts
+      run: ./bin/ebs.sh :version ${{ github.ref_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -268,7 +268,7 @@ jobs:
       timeout-minutes: 3
 
   publish-elastic-beanstalk-artifacts:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: containerize
     timeout-minutes: 15
     env:

--- a/bin/build/src/metabuild_common/aws.clj
+++ b/bin/build/src/metabuild_common/aws.clj
@@ -1,12 +1,14 @@
 (ns metabuild-common.aws
   (:require
+   [environ.core]
    [metabuild-common.env :as env]
    [metabuild-common.output :as out]
    [metabuild-common.shell :as sh]
    [metabuild-common.steps :as steps]))
 
 (defn aws-profile []
-  (env/env-or-throw :aws-default-profile))
+  (when (not (contains? environ.core/env :ci))
+    (env/env-or-throw :aws-default-profile)))
 
 (defn s3-copy!
   ([source dest]

--- a/bin/build/src/release.clj
+++ b/bin/build/src/release.clj
@@ -47,3 +47,12 @@
     (let [steps (or (seq (map u/parse-as-keyword steps))
                     (keys steps*))]
       (do-steps! steps))))
+
+(defn publish-ebs [args]
+  (u/exit-when-finished-nonzero-on-exception
+    (let [version (:version args)]
+      (c/set-version! version)
+      (c/set-edition! (if (str/starts-with? (c/version) "0") :oss :ee))
+      (c/set-branch! "release-x.y.z") ;; FIXME: branch is irrelevant for CD run
+      (u/announce (format "Preparing Elastic Beanstalk artifacts for version %s" (c/version)))
+      (do-steps! [:publish-elastic-beanstalk-artifacts]))))

--- a/bin/ebs.sh
+++ b/bin/ebs.sh
@@ -1,0 +1,15 @@
+#! /usr/bin/env bash
+
+set -euo pipefail
+
+# switch to project root directory if we're not already there
+script_directory=`dirname "${BASH_SOURCE[0]}"`
+cd "$script_directory/.."
+
+source "./bin/check-clojure-cli.sh"
+check_clojure_cli
+
+source "./bin/clear-outdated-cpcaches.sh"
+clear_outdated_cpcaches
+
+clojure -X:build:build/publish-ebs $@

--- a/deps.edn
+++ b/deps.edn
@@ -569,6 +569,13 @@
   :build/release
   {:exec-fn release/release}
 
+  ;; Only in the CI for now: publish EBS artifact
+  ;; FIXME: remove after full release automation on CI
+  ;;
+  ;;    clojure -X:build:build/publish-ebs
+  :build/publish-ebs
+  {:exec-fn release/publish-ebs}
+
   ;; extra paths and deps for working on build scripts, or running the tests.
   :build-dev
   {:extra-paths ["bin/build/test"]


### PR DESCRIPTION
The core logic is still from the release script in bin/release. The change here mostly wiring it up to GitHub Action so that it can be trigged upon a new git tag (during the release process).

## Before this PR

Publishing Elastic Beanstalk artifacts is part of the manual release process.

## After this PR

Elastic Beanstalk artifacts are created and published as soon as there is a newly pushed git tag.

![image](https://user-images.githubusercontent.com/7288/220529948-8c4ed38c-7bde-475a-8a05-a959009641c7.png)


Requirement: the following Action secrets must be set properly:
- `AWS_S3_RELEASE_ACCESS_KEY_ID`
- `AWS_S3_RELEASE_SECRET_ACCESS_KEY`

They must refer to an IAM with the proper access to (see `bin/release/src/release/common.clj`):
- _PutObject_ for S3 bucket: `s3://downloads.metabase.com/`
- Cloudfront distribution ID `E35CJLWZIZVG7K`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/28516)
<!-- Reviewable:end -->
