### PR TITLE
Handle actions more gracefully when models are converted back to cards

### DIFF
--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -27,7 +27,8 @@
    [metabase.util.i18n :refer [tru]]
    [metabase.util.log :as log]
    [toucan.db :as db]
-   [toucan.models :as models]))
+   [toucan.models :as models]
+   [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
 
@@ -343,12 +344,10 @@
       ;; make sure this Card doesn't have circular source query references if we're updating the query
       (when (:dataset_query changes)
         (check-for-circular-source-query-references changes))
-      ;; prevent demoting a model if it has actions
+      ;; Archive associated actions
       (when (and (not (:dataset changes))
-                 (:dataset old-card-info)
-                 (db/select-one ['Action :id] :model_id id))
-        (throw (ex-info (tru "Cannot make a question from a model with actions")
-                        {:id id})))
+                 (:dataset old-card-info))
+        (t2/update! 'Action {:model_id id} {:archived true}))
       ;; Make sure any native query template tags match the DB in the query.
       (check-field-filter-fields-are-from-correct-database changes)
       ;; Make sure the Collection is in the default Collection namespace (e.g. as opposed to the Snippets Collection namespace)

--- a/test/metabase/api/action_test.clj
+++ b/test/metabase/api/action_test.clj
@@ -84,11 +84,7 @@
           (testing "Should not be allowed to list actions without permission on the model"
             (is (= "You don't have permissions to do that."
                    (mt/user-http-request :rasta :get 403 (str "action?model-id=" card-id)))
-                "Should not be able to list actions without read permission on the model"))
-          (testing "Should not be possible to demote a model with actions"
-            (is (partial= {:message "Cannot make a question from a model with actions"}
-                          (mt/user-http-request :crowberto :put 500 (str "card/" card-id)
-                                                {:dataset false})))))))))
+                "Should not be able to list actions without read permission on the model")))))))
 
 (deftest get-action-test
   (testing "GET /api/action/:id"


### PR DESCRIPTION
* If a model is converted to a card, archive the associated actions
* If an action is unarchived and its model _is_ a card, throw an error

(looking for a final product signoff from Kyle/Bruno/Conor)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/28521)
<!-- Reviewable:end -->
