### PR TITLE
Hide databases without actions from the action editor database picker

### DIFF
--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorDatabasePicker/DataSelectorDatabasePicker.tsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorDatabasePicker/DataSelectorDatabasePicker.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useCallback, useMemo } from "react";
 
 import Icon from "metabase/components/Icon";
 import AccordionList from "metabase/core/components/AccordionList";
@@ -27,14 +27,15 @@ type DataSelectorDatabasePickerProps = {
 };
 
 type Item = {
-  database: Database;
-  index: number;
   name: string;
+  index: number;
+  database: Database;
   writebackEnabled?: boolean;
 };
 
 type Section = {
-  items: Item[];
+  name?: JSX.Element;
+  items?: Item[];
 };
 
 const DataSelectorDatabasePicker = ({
@@ -46,31 +47,37 @@ const DataSelectorDatabasePicker = ({
   hasInitialFocus,
   requireWriteback = false,
 }: DataSelectorDatabasePickerProps) => {
-  if (databases.length === 0) {
-    return <DataSelectorLoading />;
-  }
+  const sections = useMemo(() => {
+    const sections: Section[] = [];
 
-  const sections: Section[] = [
-    {
-      items: databases.map((database: Database, index: number) => ({
+    if (onBack) {
+      sections.push({ name: <RawDataBackButton /> });
+    }
+
+    sections.push({
+      items: databases.map((database, index) => ({
         name: database.name,
         index,
-        database: database,
+        database,
       })),
+    });
+
+    return sections;
+  }, [databases, onBack]);
+
+  const handleChangeSection = useCallback(
+    (section: Section, sectionIndex: number) => {
+      const isNavigationSection = onBack && sectionIndex === 0;
+      if (isNavigationSection) {
+        onBack();
+      }
+      return false;
     },
-  ];
+    [onBack],
+  );
 
-  const handleChangeSection = (_section: Section, sectionIndex: number) => {
-    const isNavigationSection = onBack && sectionIndex === 0;
-
-    if (isNavigationSection) {
-      onBack();
-    }
-    return false;
-  };
-
-  if (onBack) {
-    sections.unshift({ name: <RawDataBackButton /> } as any);
+  if (databases.length === 0) {
+    return <DataSelectorLoading />;
   }
 
   return (

--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorDatabasePicker/DataSelectorDatabasePicker.tsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorDatabasePicker/DataSelectorDatabasePicker.tsx
@@ -54,16 +54,20 @@ const DataSelectorDatabasePicker = ({
       sections.push({ name: <RawDataBackButton /> });
     }
 
-    sections.push({
-      items: databases.map((database, index) => ({
+    const databaseItems = databases
+      .filter(database =>
+        requireWriteback ? checkDatabaseActionsEnabled(database) : true,
+      )
+      .map((database, index) => ({
         name: database.name,
         index,
         database,
-      })),
-    });
+      }));
+
+    sections.push({ items: databaseItems });
 
     return sections;
-  }, [databases, onBack]);
+  }, [databases, requireWriteback, onBack]);
 
   const handleChangeSection = useCallback(
     (section: Section, sectionIndex: number) => {
@@ -89,11 +93,6 @@ const DataSelectorDatabasePicker = ({
       sections={sections}
       onChange={(item: Item) => onChangeDatabase(item.database)}
       onChangeSection={handleChangeSection}
-      itemIsClickable={
-        requireWriteback
-          ? (item: Item) => checkDatabaseActionsEnabled(item.database)
-          : undefined
-      }
       itemIsSelected={(item: Item) =>
         selectedDatabase && item.database.id === selectedDatabase.id
       }

--- a/frontend/test/metabase/scenarios/models/model-actions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/model-actions.cy.spec.js
@@ -154,7 +154,10 @@ describe(
       popover().findByText("Action").click();
 
       cy.findByText("Select a database").click();
-      popover().findByText("QA Postgres12").click();
+      popover().within(() => {
+        cy.findByText("Sample Database").should("not.exist");
+        cy.findByText("QA Postgres12").click();
+      });
 
       fillActionQuery(QUERY);
       cy.findByRole("button", { name: "Save" }).click();


### PR DESCRIPTION
Epic #28524
Discussion: [Slack](https://metaboat.slack.com/archives/C04DAKFDTCZ/p1676993234773259?thread_ts=1676992803.733439&cid=C04DAKFDTCZ)

### Description

Filters out databases without actions enabled when picking a database for a new action. We used to disable them, but it doesn't work really well right now if there are many databases to choose from.

### How to verify

1. Ensure you have at least one Postgres / MySQL database with actions enabled and any database without actions
2. From the top bar: "+ New" > Action
3. Ensure you can't see databases without actions enabled in the database picker
4. Note: it'd be cool to pre-select a database if there's only one DB, but messing around with the `DataSelector` component is hard and risky, see #27160

### Demo

**Before**

<img width="339" alt="filter-action-dbs-before" src="https://user-images.githubusercontent.com/17258145/220693383-adfdb20b-9961-4934-aafc-203a758f9391.png">

**After**

<img width="334" alt="filter-action-dbs-after" src="https://user-images.githubusercontent.com/17258145/220693431-ad4e2b13-aff2-4d73-bb54-8f46cfa222c3.png">

### Checklist

- [x] Tests have been added/updated to cover changes in this PR

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/28524)
<!-- Reviewable:end -->
