### PR TITLE
Fix ace editor popover in action editor

### DIFF
--- a/frontend/src/metabase/actions/containers/ActionCreator/ActionCreator.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/ActionCreator.tsx
@@ -133,7 +133,7 @@ function ActionCreator({
   };
 
   const showSaveModal = () => {
-    maybeCloseAceEditor();
+    ensureAceEditorClosed();
     setShowSaveModal(true);
   };
 
@@ -181,7 +181,7 @@ function ActionCreator({
   );
 }
 
-function maybeCloseAceEditor() {
+function ensureAceEditorClosed() {
   const ace = "ace" in window ? (window.ace as any) : null;
   const editor = ace?.edit(ACE_ELEMENT_ID);
   if (editor) {

--- a/frontend/src/metabase/actions/containers/ActionCreator/ActionCreator.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/ActionCreator.tsx
@@ -182,8 +182,8 @@ function ActionCreator({
 }
 
 function ensureAceEditorClosed() {
-  const ace = "ace" in window ? (window.ace as any) : null;
-  const editor = ace?.edit(ACE_ELEMENT_ID);
+  // @ts-expect-error — `ace` isn't typed yet
+  const editor = window.ace?.edit(ACE_ELEMENT_ID);
   if (editor) {
     editor.completer.popup.hide();
   }

--- a/frontend/src/metabase/actions/containers/ActionCreator/ActionCreator.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/ActionCreator.tsx
@@ -29,6 +29,7 @@ import type Metadata from "metabase-lib/metadata/Metadata";
 import { isSavedAction } from "../../utils";
 import ActionContext, { useActionContext } from "./ActionContext";
 import ActionCreatorView from "./ActionCreatorView";
+import { ACE_ELEMENT_ID } from "./QueryActionEditor";
 import CreateActionForm, {
   FormValues as CreateActionFormValues,
 } from "./CreateActionForm";
@@ -95,7 +96,7 @@ function ActionCreator({
     renderEditorBody,
   } = useActionContext();
 
-  const [showSaveModal, setShowSaveModal] = useState(false);
+  const [isSaveModalShown, setShowSaveModal] = useState(false);
 
   const isEditable = isNew || model.canWriteActions();
 
@@ -131,9 +132,14 @@ function ActionCreator({
     }
   };
 
+  const showSaveModal = () => {
+    maybeCloseAceEditor();
+    setShowSaveModal(true);
+  };
+
   const handleClickSave = () => {
     if (isNew) {
-      setShowSaveModal(true);
+      showSaveModal();
     } else {
       handleUpdate();
       onClose?.();
@@ -158,7 +164,7 @@ function ActionCreator({
       >
         {renderEditorBody({ isEditable })}
       </ActionCreatorView>
-      {showSaveModal && (
+      {isSaveModalShown && (
         <Modal title={t`New Action`} onClose={handleCloseNewActionModal}>
           <CreateActionForm
             initialValues={{
@@ -173,6 +179,14 @@ function ActionCreator({
       )}
     </>
   );
+}
+
+function maybeCloseAceEditor() {
+  const ace = "ace" in window ? (window.ace as any) : null;
+  const editor = ace?.edit(ACE_ELEMENT_ID);
+  if (editor) {
+    editor.completer.popup.hide();
+  }
 }
 
 function ActionCreatorWithContext({

--- a/frontend/src/metabase/actions/containers/ActionCreator/QueryActionEditor.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/QueryActionEditor.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 
 import NativeQueryEditor from "metabase/query_builder/components/NativeQueryEditor";
+import { ACE_ELEMENT_ID } from "metabase/query_builder/components/NativeQueryEditor/constants";
 
 import type NativeQuery from "metabase-lib/queries/NativeQuery";
 
@@ -30,5 +31,7 @@ function QueryActionEditor({
     </>
   );
 }
+
+export { ACE_ELEMENT_ID };
 
 export default QueryActionEditor;

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx
@@ -39,7 +39,11 @@ import NativeQueryEditorSidebar from "./NativeQueryEditor/NativeQueryEditorSideb
 import VisibilityToggler from "./NativeQueryEditor/VisibilityToggler";
 import RightClickPopover from "./NativeQueryEditor/RightClickPopover";
 import DataSourceSelectors from "./NativeQueryEditor/DataSourceSelectors";
-import { SCROLL_MARGIN, MIN_HEIGHT_LINES } from "./NativeQueryEditor/constants";
+import {
+  ACE_ELEMENT_ID,
+  SCROLL_MARGIN,
+  MIN_HEIGHT_LINES,
+} from "./NativeQueryEditor/constants";
 import {
   calcInitialEditorHeight,
   getEditorLineHeight,
@@ -578,7 +582,7 @@ class NativeQueryEditor extends Component {
             this._editor.resize();
           }}
         >
-          <div className="flex-full" id="id_sql" ref={this.editor} />
+          <div className="flex-full" id={ACE_ELEMENT_ID} ref={this.editor} />
 
           <RightClickPopover
             isOpen={this.state.isSelectedTextPopoverOpen}

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/constants.ts
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/constants.ts
@@ -1,2 +1,3 @@
 export const SCROLL_MARGIN = 8;
 export const MIN_HEIGHT_LINES = 15;
+export const ACE_ELEMENT_ID = "id_sql";


### PR DESCRIPTION
Epic #27581

### Description

Fixes ace editor's autocompletion popover could overlap with the save action modal

### How to verify

1. "+ New" > Action
2. Fill in a query until ace's autocompletion popover shows up
3. Click the "Save" button below the query editor
4. Ensure ace's popover is closed and you can see the model clearly

### Demo

<details>
<summary>Before</summary>

https://user-images.githubusercontent.com/17258145/220688917-1a764b38-3882-48e5-8e64-98bfe3b68f08.mp4


</details>

<details>
<summary>After</summary>

https://user-images.githubusercontent.com/17258145/220688955-f0efca8f-b38f-44ff-b7ae-ca363c2544b2.mp4


</details>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/28525)
<!-- Reviewable:end -->
