### PR TITLE
Expose median aggregation for supported DBs

### DIFF
--- a/frontend/src/metabase-lib/expressions/config.js
+++ b/frontend/src/metabase-lib/expressions/config.js
@@ -85,6 +85,12 @@ export const MBQL_CLAUSES = {
     requiresFeature: "standard-deviation-aggregations",
   },
   avg: { displayName: `Average`, type: "aggregation", args: ["number"] },
+  median: {
+    displayName: `Median`,
+    type: "aggregation",
+    args: ["number"],
+    requiresFeature: "percentile-aggregations",
+  },
   min: { displayName: `Min`, type: "aggregation", args: ["expression"] },
   max: { displayName: `Max`, type: "aggregation", args: ["expression"] },
   share: { displayName: `Share`, type: "aggregation", args: ["boolean"] },
@@ -103,12 +109,6 @@ export const MBQL_CLAUSES = {
     type: "aggregation",
     args: ["number"],
     requiresFeature: "standard-deviation-aggregations",
-  },
-  median: {
-    displayName: `Median`,
-    type: "aggregation",
-    args: ["number"],
-    requiresFeature: "percentile-aggregations",
   },
   percentile: {
     displayName: `Percentile`,
@@ -444,11 +444,11 @@ export const AGGREGATION_FUNCTIONS = new Set([
   "distinct",
   "stddev",
   "avg",
+  "median",
   "min",
   "max",
   "share",
   "var",
-  "median",
   "percentile",
 ]);
 

--- a/frontend/src/metabase-lib/expressions/config.js
+++ b/frontend/src/metabase-lib/expressions/config.js
@@ -554,4 +554,5 @@ export const STANDARD_AGGREGATIONS = new Set([
   "avg",
   "min",
   "max",
+  "median",
 ]);

--- a/frontend/src/metabase-lib/operators/constants.js
+++ b/frontend/src/metabase-lib/operators/constants.js
@@ -345,6 +345,15 @@ export const AGGREGATION_OPERATORS = [
     requiredDriverFeature: "basic-aggregations",
   },
   {
+    short: "median",
+    name: t`Median of ...`,
+    columnName: t`Median`,
+    description: t`Median of all the values of a column`,
+    validFieldsFilters: [summableFields],
+    requiresField: true,
+    requiredDriverFeature: "percentile-aggregations",
+  },
+  {
     short: "distinct",
     name: t`Number of distinct values of ...`,
     columnName: t`Distinct values`,
@@ -397,14 +406,5 @@ export const AGGREGATION_OPERATORS = [
     validFieldsFilters: [scopeFields],
     requiresField: true,
     requiredDriverFeature: "basic-aggregations",
-  },
-  {
-    short: "median",
-    name: t`Median of ...`,
-    columnName: t`Median`,
-    description: t`Median value of a column`,
-    validFieldsFilters: [summableFields],
-    requiresField: true,
-    requiredDriverFeature: "percentile-aggregations",
   },
 ];

--- a/frontend/src/metabase-lib/operators/constants.js
+++ b/frontend/src/metabase-lib/operators/constants.js
@@ -398,4 +398,13 @@ export const AGGREGATION_OPERATORS = [
     requiresField: true,
     requiredDriverFeature: "basic-aggregations",
   },
+  {
+    short: "median",
+    name: t`Median of ...`,
+    columnName: t`Median`,
+    description: t`Median value of a column`,
+    validFieldsFilters: [summableFields],
+    requiresField: true,
+    requiredDriverFeature: "percentile-aggregations",
+  },
 ];

--- a/frontend/src/metabase-lib/operators/utils/index.unit.spec.js
+++ b/frontend/src/metabase-lib/operators/utils/index.unit.spec.js
@@ -181,6 +181,17 @@ describe("metabase-lib/operators/utils", () => {
         }),
       ]);
     });
+
+    it('returns "median" aggregation operator if "percentile-aggregations" driver feature is supported', () => {
+      const table = getTable(["percentile-aggregations"]);
+      const operators = getSupportedAggregationOperators(table);
+      expect(operators).toEqual([
+        expect.objectContaining({
+          short: "median",
+          requiredDriverFeature: "percentile-aggregations",
+        }),
+      ]);
+    });
   });
 
   describe("getAggregationOperators", () => {

--- a/frontend/src/metabase-lib/queries/utils/description.js
+++ b/frontend/src/metabase-lib/queries/utils/description.js
@@ -77,6 +77,11 @@ export function getAggregationDescription(tableMetadata, query, options) {
             t`Average of `,
             getFieldName(tableMetadata, aggregation[1], options),
           ];
+        case "median":
+          return [
+            t`Median of `,
+            getFieldName(tableMetadata, aggregation[1], options),
+          ];
         case "distinct":
           return [
             t`Distinct values of `,
@@ -264,6 +269,8 @@ export function formatAggregationDescription({ aggregation }, options = {}) {
           return [t`Cumulative count`];
         case "avg":
           return [t`Average of `, agg["arg"]];
+        case "median":
+          return [t`Median of `, agg["arg"]];
         case "distinct":
           return [t`Distinct values of `, agg["arg"]];
         case "stddev":
@@ -276,6 +283,13 @@ export function formatAggregationDescription({ aggregation }, options = {}) {
           return [t`Maximum of `, agg["arg"]];
         case "min":
           return [t`Minimum of `, agg["arg"]];
+        default: {
+          console.warn(
+            "Unknown aggregation type in formatAggregationDescription",
+            agg["type"],
+          );
+          return null;
+        }
       }
     }),
   );

--- a/frontend/src/metabase-lib/queries/utils/description.js
+++ b/frontend/src/metabase-lib/queries/utils/description.js
@@ -285,7 +285,7 @@ export function formatAggregationDescription({ aggregation }, options = {}) {
           return [t`Minimum of `, agg["arg"]];
         default: {
           console.warn(
-            "Unknown aggregation type in formatAggregationDescription",
+            "Unexpected aggregation type in formatAggregationDescription: ",
             agg["type"],
           );
           return null;

--- a/frontend/src/metabase-types/types/Query.ts
+++ b/frontend/src/metabase-types/types/Query.ts
@@ -98,6 +98,7 @@ export type Aggregation =
   | CountAgg
   | CountFieldAgg
   | AvgAgg
+  | MedianAgg
   | CumSumAgg
   | DistinctAgg
   | StdDevAgg
@@ -120,6 +121,7 @@ type CountAgg = ["count"];
 
 type CountFieldAgg = ["count", ConcreteField];
 type AvgAgg = ["avg", ConcreteField];
+type MedianAgg = ["median", ConcreteField];
 type CumSumAgg = ["cum-sum", ConcreteField];
 type DistinctAgg = ["distinct", ConcreteField];
 type StdDevAgg = ["stddev", ConcreteField];

--- a/frontend/src/metabase/query_builder/components/AggregationPopover/AggregationPopover.jsx
+++ b/frontend/src/metabase/query_builder/components/AggregationPopover/AggregationPopover.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import ReactDOM from "react-dom";
 import PropTypes from "prop-types";
@@ -64,6 +63,8 @@ export default class AggregationPopover extends Component {
     showRawData: PropTypes.bool,
 
     width: PropTypes.number,
+    maxHeight: PropTypes.number,
+    alwaysExpanded: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -355,7 +356,9 @@ export default class AggregationPopover extends Component {
           />
         </ExpressionPopoverRoot>
       );
-    } else if (choosingField) {
+    }
+
+    if (choosingField) {
       const [agg, fieldId] = aggregation;
       return (
         <div style={{ minWidth: 300 }}>
@@ -383,27 +386,27 @@ export default class AggregationPopover extends Component {
           />
         </div>
       );
-    } else {
-      return (
-        <AggregationItemList
-          width={this.props.width}
-          maxHeight={this.props.maxHeight}
-          alwaysExpanded={this.props.alwaysExpanded}
-          sections={sections}
-          onChange={this.onPickAggregation}
-          itemIsSelected={this.itemIsSelected.bind(this)}
-          renderSectionIcon={section => <Icon name={section.icon} size={18} />}
-          renderItemExtra={this.renderItemExtra.bind(this)}
-          getItemClassName={item =>
-            item.metric?.archived ? "text-medium" : null
-          }
-          onChangeSection={(section, sectionIndex) => {
-            if (section.custom) {
-              this.onPickAggregation({ custom: true });
-            }
-          }}
-        />
-      );
     }
+
+    return (
+      <AggregationItemList
+        width={this.props.width}
+        maxHeight={this.props.maxHeight}
+        alwaysExpanded={this.props.alwaysExpanded}
+        sections={sections}
+        onChange={this.onPickAggregation}
+        itemIsSelected={this.itemIsSelected.bind(this)}
+        renderSectionIcon={section => <Icon name={section.icon} size={18} />}
+        renderItemExtra={this.renderItemExtra.bind(this)}
+        getItemClassName={item =>
+          item.metric?.archived ? "text-medium" : null
+        }
+        onChangeSection={(section, sectionIndex) => {
+          if (section.custom) {
+            this.onPickAggregation({ custom: true });
+          }
+        }}
+      />
+    );
   }
 }

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield/helper-text-strings.ts
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield/helper-text-strings.ts
@@ -87,6 +87,18 @@ const helperTextStrings: HelpTextConfig[] = [
     ],
   },
   {
+    name: "median",
+    structure: "Median(" + t`column` + ")",
+    description: () => t`Returns the median of all the values of a column.`,
+    example: "Median([" + t`Quantity` + "])",
+    args: [
+      {
+        name: t`column`,
+        description: t`The numeric column whose values to average.`,
+      },
+    ],
+  },
+  {
     name: "min",
     structure: "Min(" + t`column` + ")",
     description: () => t`Returns the smallest value found in the column`,

--- a/frontend/src/metabase/visualizations/lib/settings/column.js
+++ b/frontend/src/metabase/visualizations/lib/settings/column.js
@@ -286,10 +286,10 @@ export const NUMBER_COLUMN_SETTINGS = {
     widget: "select",
     props: {
       options: [
-        { name: "Normal", value: "decimal" },
-        { name: "Percent", value: "percent" },
-        { name: "Scientific", value: "scientific" },
-        { name: "Currency", value: "currency" },
+        { name: t`Normal`, value: "decimal" },
+        { name: t`Percent`, value: "percent" },
+        { name: t`Scientific`, value: "scientific" },
+        { name: t`Currency`, value: "currency" },
       ],
     },
     getDefault: (column, settings) =>

--- a/frontend/test/__support__/e2e/helpers/e2e-bi-basics-helpers.js
+++ b/frontend/test/__support__/e2e/helpers/e2e-bi-basics-helpers.js
@@ -1,5 +1,10 @@
 import { popover } from "__support__/e2e/helpers";
 
+/**
+ * Initiate Summarize action
+ *
+ * @param {(undefined|"notebook")} mode
+ */
 export function summarize({ mode } = {}) {
   initiateAction("Summarize", mode);
 }
@@ -10,6 +15,10 @@ export function filter({ mode } = {}) {
 
 export function join() {
   initiateAction("Join", "notebook");
+}
+
+export function addCustomColumn() {
+  initiateAction("CustomColumn", "notebook");
 }
 
 export function filterField(
@@ -67,7 +76,7 @@ function changeValue(subject, newValue, placeholder) {
 /**
  * Initiate a certain action such as filtering or summarizing taking the question's mode into account.
  *
- * @param {("Summarize"|"Filter")} actionType
+ * @param {("Summarize"|"Filter"|"Join"|"CustomColumn")} actionType
  * @param {(undefined|"notebook")} mode
  */
 function initiateAction(actionType, mode) {
@@ -83,31 +92,19 @@ function initiateAction(actionType, mode) {
   }
 }
 
+const ActionTypeToIconMap = {
+  Filter: "filter",
+  Summarize: "sum",
+  Join: "join_left_outer",
+  CustomColumn: "add_data",
+};
+
 /**
  * Get the appropriate icon depending on the action type.
  *
- * @param {("Summarize"|"Filter")} actionType
+ * @param {("Summarize"|"Filter"|"Join"|"CustomColumn")} actionType
  * @returns string
  */
 function getIcon(actionType) {
-  let icon;
-
-  switch (actionType) {
-    case "Filter":
-      icon = "filter";
-      break;
-
-    case "Summarize":
-      icon = "sum";
-      break;
-
-    case "Join":
-      icon = "join_left_outer";
-      break;
-
-    default:
-      break;
-  }
-
-  return icon;
+  return ActionTypeToIconMap[actionType];
 }

--- a/frontend/test/__support__/e2e/helpers/e2e-bi-basics-helpers.js
+++ b/frontend/test/__support__/e2e/helpers/e2e-bi-basics-helpers.js
@@ -92,7 +92,7 @@ function initiateAction(actionType, mode) {
   }
 }
 
-const ActionTypeToIconMap = {
+const ACTION_TYPE_TO_ICON_MAP = {
   Filter: "filter",
   Summarize: "sum",
   Join: "join_left_outer",
@@ -106,5 +106,5 @@ const ActionTypeToIconMap = {
  * @returns string
  */
 function getIcon(actionType) {
-  return ActionTypeToIconMap[actionType];
+  return ACTION_TYPE_TO_ICON_MAP[actionType];
 }

--- a/frontend/test/__support__/e2e/helpers/e2e-notebook-helpers.js
+++ b/frontend/test/__support__/e2e/helpers/e2e-notebook-helpers.js
@@ -1,3 +1,5 @@
+import { popover } from "__support__/e2e/helpers/e2e-ui-elements-helpers";
+
 export function openNotebook() {
   return cy.icon("notebook").click();
 }
@@ -30,5 +32,32 @@ export function visualize(callback) {
     if (callback) {
       callback(response);
     }
+  });
+}
+
+export function addSummaryField({ metric, field, stage = 0, index = 0 }) {
+  getNotebookStep("summarize", { stage, index })
+    .findByTestId("aggregate-step")
+    .findAllByTestId("notebook-cell-item")
+    .last()
+    .click();
+
+  popover().within(() => {
+    cy.findByText(metric).click();
+    if (field) {
+      cy.findByText(field).click();
+    }
+  });
+}
+
+export function addSummaryGroupingField({ field, stage = 0, index = 0 }) {
+  getNotebookStep("summarize", { stage, index })
+    .findByTestId("breakout-step")
+    .findAllByTestId("notebook-cell-item")
+    .last()
+    .click();
+
+  popover().within(() => {
+    cy.findByText(field).click();
   });
 }

--- a/frontend/test/metabase/scenarios/filters/filter.cy.spec.js
+++ b/frontend/test/metabase/scenarios/filters/filter.cy.spec.js
@@ -712,7 +712,7 @@ describe("scenarios > question > filter", () => {
     cy.button("Add filter").isVisibleInPopover();
   });
 
-  it("shoud retain all data series after saving a question where custom expression formula is the first metric (metabase#15882)", () => {
+  it("should retain all data series after saving a question where custom expression formula is the first metric (metabase#15882)", () => {
     visitQuestionAdhoc({
       dataset_query: {
         database: SAMPLE_DB_ID,

--- a/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
@@ -21,418 +21,444 @@ const { ORDERS, ORDERS_ID, PEOPLE, PEOPLE_ID, PRODUCTS, PRODUCTS_ID } =
   SAMPLE_DATABASE;
 
 describe("scenarios > question > notebook", () => {
-  beforeEach(() => {
-    restore();
-    cy.signInAsAdmin();
-  });
-
-  it("shouldn't offer to save the question when there were no changes (metabase#13470)", () => {
-    openOrdersTable();
-    // save question initially
-    cy.findByText("Save").click();
-    cy.get(".ModalBody").contains("Save").click();
-    cy.findByText("Not now").click();
-    // enter "notebook" and visualize without changing anything
-    cy.icon("notebook").click();
-
-    cy.button("Visualize").click();
-
-    // there were no changes to the question, so we shouldn't have the option to "Save"
-    cy.findByText("Save").should("not.exist");
-  });
-
-  it("should allow post-aggregation filters", () => {
-    // start a custom question with orders
-    startNewQuestion();
-    cy.contains("Sample Database").click();
-    cy.contains("Orders").click();
-
-    // count orders by user id, filter to the one user with 46 orders
-    cy.contains("Pick the metric").click();
-    popover().within(() => {
-      cy.findByText("Count of rows").click();
-    });
-    cy.contains("Pick a column to group by").click();
-    popover().within(() => {
-      cy.contains("User ID").click();
-    });
-    cy.icon("filter").click();
-    popover().within(() => {
-      cy.icon("int").click();
-      cy.get("input").type("46");
-      cy.contains("Add filter").click();
+  describe("default db", () => {
+    beforeEach(() => {
+      restore();
+      cy.signInAsAdmin();
     });
 
-    visualize();
+    it("shouldn't offer to save the question when there were no changes (metabase#13470)", () => {
+      openOrdersTable();
+      // save question initially
+      cy.findByText("Save").click();
+      cy.get(".ModalBody").contains("Save").click();
+      cy.findByText("Not now").click();
+      // enter "notebook" and visualize without changing anything
+      cy.icon("notebook").click();
 
-    cy.contains("2372"); // user's id in the table
-    cy.contains("Showing 1 row"); // ensure only one user was returned
-  });
+      cy.button("Visualize").click();
 
-  it("shouldn't show sub-dimensions for FK (metabase#16787)", () => {
-    openOrdersTable({ mode: "notebook" });
-    summarize({ mode: "notebook" });
-    cy.findByText("Pick a column to group by").click();
-    cy.findByText("User ID")
-      .closest(".List-item")
-      .find(".Field-extra")
-      .should("not.have.descendants", "*");
-  });
+      // there were no changes to the question, so we shouldn't have the option to "Save"
+      cy.findByText("Save").should("not.exist");
+    });
 
-  it("should show the original custom expression filter field on subsequent click (metabase#14726)", () => {
-    visitQuestionAdhoc({
-      dataset_query: {
-        database: SAMPLE_DB_ID,
-        query: {
-          "source-table": ORDERS_ID,
-          filter: ["between", ["field", ORDERS.ID, null], 96, 97],
+    it("should allow post-aggregation filters", () => {
+      // start a custom question with orders
+      startNewQuestion();
+      cy.contains("Sample Database").click();
+      cy.contains("Orders").click();
+
+      // count orders by user id, filter to the one user with 46 orders
+      cy.contains("Pick the metric").click();
+      popover().within(() => {
+        cy.findByText("Count of rows").click();
+      });
+      cy.contains("Pick a column to group by").click();
+      popover().within(() => {
+        cy.contains("User ID").click();
+      });
+      cy.icon("filter").click();
+      popover().within(() => {
+        cy.icon("int").click();
+        cy.get("input").type("46");
+        cy.contains("Add filter").click();
+      });
+
+      visualize();
+
+      cy.contains("2372"); // user's id in the table
+      cy.contains("Showing 1 row"); // ensure only one user was returned
+    });
+
+    it("shouldn't show sub-dimensions for FK (metabase#16787)", () => {
+      openOrdersTable({ mode: "notebook" });
+      summarize({ mode: "notebook" });
+      cy.findByText("Pick a column to group by").click();
+      cy.findByText("User ID")
+        .closest(".List-item")
+        .find(".Field-extra")
+        .should("not.have.descendants", "*");
+    });
+
+    it("should show the original custom expression filter field on subsequent click (metabase#14726)", () => {
+      visitQuestionAdhoc({
+        dataset_query: {
+          database: SAMPLE_DB_ID,
+          query: {
+            "source-table": ORDERS_ID,
+            filter: ["between", ["field", ORDERS.ID, null], 96, 97],
+          },
+          type: "query",
         },
-        type: "query",
-      },
-      display: "table",
+        display: "table",
+      });
+
+      cy.findByText("ID between 96 97").click();
+      cy.findByText("Between").click();
+      popover().within(() => {
+        cy.contains("Is not");
+        cy.contains("Greater than");
+        cy.contains("Less than");
+      });
     });
 
-    cy.findByText("ID between 96 97").click();
-    cy.findByText("Between").click();
-    popover().within(() => {
-      cy.contains("Is not");
-      cy.contains("Greater than");
-      cy.contains("Less than");
-    });
-  });
+    it("should append indexes to duplicate custom expression names (metabase#12104)", () => {
+      cy.viewport(1920, 800); // we're looking for a column name beyond the right of the default viewport
+      cy.intercept("POST", "/api/dataset").as("dataset");
+      openProductsTable({ mode: "notebook" });
 
-  it("should append indexes to duplicate custom expression names (metabase#12104)", () => {
-    cy.viewport(1920, 800); // we're looking for a column name beyond the right of the default viewport
-    cy.intercept("POST", "/api/dataset").as("dataset");
-    openProductsTable({ mode: "notebook" });
+      cy.findByText("Custom column").click();
+      addSimpleCustomColumn("EXPR");
 
-    cy.findByText("Custom column").click();
-    addSimpleCustomColumn("EXPR");
+      getNotebookStep("expression").within(() => {
+        cy.icon("add").click();
+      });
+      addSimpleCustomColumn("EXPR");
 
-    getNotebookStep("expression").within(() => {
-      cy.icon("add").click();
-    });
-    addSimpleCustomColumn("EXPR");
+      getNotebookStep("expression").within(() => {
+        cy.icon("add").click();
+      });
+      addSimpleCustomColumn("EXPR");
 
-    getNotebookStep("expression").within(() => {
-      cy.icon("add").click();
-    });
-    addSimpleCustomColumn("EXPR");
+      getNotebookStep("expression").within(() => {
+        cy.findByText("EXPR");
+        cy.findByText("EXPR (1)");
+        cy.findByText("EXPR (2)");
+      });
 
-    getNotebookStep("expression").within(() => {
+      visualize();
+
       cy.findByText("EXPR");
       cy.findByText("EXPR (1)");
       cy.findByText("EXPR (2)");
     });
 
-    visualize();
-
-    cy.findByText("EXPR");
-    cy.findByText("EXPR (1)");
-    cy.findByText("EXPR (2)");
-  });
-
-  it("should process the updated expression when pressing Enter", () => {
-    openProductsTable({ mode: "notebook" });
-    filter({ mode: "notebook" });
-    cy.findByText("Custom Expression").click();
-    enterCustomColumnDetails({ formula: "[Price] > 1" });
-
-    cy.button("Done").click();
-
-    // change the corresponding custom expression
-    cy.findByText("Price is greater than 1").click();
-    cy.get(".Icon-chevronleft").click();
-    cy.findByText("Custom Expression").click();
-
-    cy.get("@formula").clear().type("[Price] > 1 AND [Price] < 5{enter}");
-
-    cy.contains(/^Price is less than 5/i);
-  });
-
-  it("should show the real number of rows instead of HARD_ROW_LIMIT when loading (metabase#17397)", () => {
-    cy.intercept(
-      {
-        method: "POST",
-        url: "/api/dataset",
-        middleware: true,
-      },
-      req => {
-        req.on("response", res => {
-          // Throttle the response to 500 Kbps to simulate a mobile 3G connection
-          res.setThrottle(500);
-        });
-      },
-    ).as("dataset");
-
-    const questionDetails = {
-      query: {
-        "source-table": ORDERS_ID,
-        filter: ["=", ["field", ORDERS.PRODUCT_ID, null], 2],
-      },
-    };
-
-    cy.createQuestion(questionDetails, { visitQuestion: true });
-
-    cy.contains("Showing 98 rows");
-
-    cy.findByTestId("filters-visibility-control").click();
-    cy.findByText("Product ID is 2").click();
-
-    popover().find("input").type("3{enter}");
-    cy.findByText("Product ID is 2 selections");
-
-    // Still loading
-    cy.contains("Showing 98 rows");
-
-    cy.wait("@dataset");
-    cy.contains("Showing 175 rows");
-  });
-
-  // flaky test (#19454)
-  it.skip("should show an info popover for dimensions listened by the custom expression editor", () => {
-    // start a custom question with orders
-    startNewQuestion();
-    cy.contains("Sample Database").click();
-    cy.contains("Orders").click();
-
-    // type a dimension name
-    cy.findByText("Add filters to narrow your answer").click();
-    cy.findByText("Custom Expression").click();
-    enterCustomColumnDetails({ formula: "Total" });
-
-    // hover over option in the suggestion list
-    cy.findByTestId("expression-suggestions-list")
-      .findByText("Total")
-      .trigger("mouseenter");
-
-    // confirm that the popover is shown
-    popover().contains("The total billed amount.");
-    popover().contains("80.36");
-  });
-
-  describe.skip("popover rendering issues (metabase#15502)", () => {
-    beforeEach(() => {
-      restore();
-      cy.signInAsAdmin();
-      cy.viewport(1280, 720);
-      startNewQuestion();
-      cy.findByTextEnsureVisible("Sample Database").click();
-      cy.findByTextEnsureVisible("Orders").click();
-    });
-
-    it("popover should not render outside of viewport regardless of the screen resolution (metabase#15502-1)", () => {
-      // Initial filter popover usually renders correctly within the viewport
-      cy.findByText("Add filters to narrow your answer").as("filter").click();
-      popover().isRenderedWithinViewport();
-      // Click anywhere outside this popover to close it because the issue with rendering happens when popover opens for the second time
-      cy.icon("gear").click();
-      cy.get("@filter").click();
-      popover().isRenderedWithinViewport();
-    });
-
-    it("popover should not cover the button that invoked it (metabase#15502-2)", () => {
-      // Initial summarize/metric popover usually renders initially without blocking the button
-      cy.findByText("Pick the metric you want to see").as("metric").click();
-      // Click outside to close this popover
-      cy.icon("gear").click();
-      // Popover invoked again blocks the button making it impossible to click the button for the third time
-      cy.get("@metric").click();
-      cy.get("@metric").click();
-    });
-  });
-
-  describe("arithmetic (metabase#13175)", () => {
-    beforeEach(() => {
-      openOrdersTable({ mode: "notebook" });
-    });
-
-    it("should work on custom column with `case`", () => {
-      cy.icon("add_data").click();
-
-      enterCustomColumnDetails({
-        formula: "case([Subtotal] + Tax > 100, 'Big', 'Small')",
-      });
-
-      cy.findByPlaceholderText("Something nice and descriptive")
-        .click()
-        .type("Example", { delay: 100 });
-
-      cy.button("Done").should("not.be.disabled").click();
-
-      visualize();
-
-      cy.contains("Example");
-      cy.contains("Big");
-      cy.contains("Small");
-    });
-
-    it("should work on custom filter", () => {
+    it("should process the updated expression when pressing Enter", () => {
+      openProductsTable({ mode: "notebook" });
       filter({ mode: "notebook" });
       cy.findByText("Custom Expression").click();
+      enterCustomColumnDetails({ formula: "[Price] > 1" });
 
-      enterCustomColumnDetails({ formula: "[Subtotal] - Tax > 140" });
+      cy.button("Done").click();
 
-      cy.contains(/^redundant input/i).should("not.exist");
+      // change the corresponding custom expression
+      cy.findByText("Price is greater than 1").click();
+      cy.get(".Icon-chevronleft").click();
+      cy.findByText("Custom Expression").click();
 
-      cy.button("Done").should("not.be.disabled").click();
+      cy.get("@formula").clear().type("[Price] > 1 AND [Price] < 5{enter}");
 
-      visualize();
-
-      cy.contains("Showing 97 rows");
+      cy.contains(/^Price is less than 5/i);
     });
 
-    const CASES = {
-      CountIf: ["CountIf(([Subtotal] + [Tax]) > 10)", "18,760"],
-      SumIf: ["SumIf([Subtotal], ([Subtotal] + [Tax] > 20))", "1,447,850.28"],
-    };
+    it("should show the real number of rows instead of HARD_ROW_LIMIT when loading (metabase#17397)", () => {
+      cy.intercept(
+        {
+          method: "POST",
+          url: "/api/dataset",
+          middleware: true,
+        },
+        req => {
+          req.on("response", res => {
+            // Throttle the response to 500 Kbps to simulate a mobile 3G connection
+            res.setThrottle(500);
+          });
+        },
+      ).as("dataset");
 
-    Object.entries(CASES).forEach(([filter, formula]) => {
-      const [expression, result] = formula;
+      const questionDetails = {
+        query: {
+          "source-table": ORDERS_ID,
+          filter: ["=", ["field", ORDERS.PRODUCT_ID, null], 2],
+        },
+      };
 
-      it(`should work on custom aggregation with ${filter}`, () => {
-        summarize({ mode: "notebook" });
+      cy.createQuestion(questionDetails, { visitQuestion: true });
+
+      cy.contains("Showing 98 rows");
+
+      cy.findByTestId("filters-visibility-control").click();
+      cy.findByText("Product ID is 2").click();
+
+      popover().find("input").type("3{enter}");
+      cy.findByText("Product ID is 2 selections");
+
+      // Still loading
+      cy.contains("Showing 98 rows");
+
+      cy.wait("@dataset");
+      cy.contains("Showing 175 rows");
+    });
+
+    // flaky test (#19454)
+    it.skip("should show an info popover for dimensions listened by the custom expression editor", () => {
+      // start a custom question with orders
+      startNewQuestion();
+      cy.contains("Sample Database").click();
+      cy.contains("Orders").click();
+
+      // type a dimension name
+      cy.findByText("Add filters to narrow your answer").click();
+      cy.findByText("Custom Expression").click();
+      enterCustomColumnDetails({ formula: "Total" });
+
+      // hover over option in the suggestion list
+      cy.findByTestId("expression-suggestions-list")
+        .findByText("Total")
+        .trigger("mouseenter");
+
+      // confirm that the popover is shown
+      popover().contains("The total billed amount.");
+      popover().contains("80.36");
+    });
+
+    describe.skip("popover rendering issues (metabase#15502)", () => {
+      beforeEach(() => {
+        restore();
+        cy.signInAsAdmin();
+        cy.viewport(1280, 720);
+        startNewQuestion();
+        cy.findByTextEnsureVisible("Sample Database").click();
+        cy.findByTextEnsureVisible("Orders").click();
+      });
+
+      it("popover should not render outside of viewport regardless of the screen resolution (metabase#15502-1)", () => {
+        // Initial filter popover usually renders correctly within the viewport
+        cy.findByText("Add filters to narrow your answer").as("filter").click();
+        popover().isRenderedWithinViewport();
+        // Click anywhere outside this popover to close it because the issue with rendering happens when popover opens for the second time
+        cy.icon("gear").click();
+        cy.get("@filter").click();
+        popover().isRenderedWithinViewport();
+      });
+
+      it("popover should not cover the button that invoked it (metabase#15502-2)", () => {
+        // Initial summarize/metric popover usually renders initially without blocking the button
+        cy.findByText("Pick the metric you want to see").as("metric").click();
+        // Click outside to close this popover
+        cy.icon("gear").click();
+        // Popover invoked again blocks the button making it impossible to click the button for the third time
+        cy.get("@metric").click();
+        cy.get("@metric").click();
+      });
+    });
+
+    describe("arithmetic (metabase#13175)", () => {
+      beforeEach(() => {
+        openOrdersTable({ mode: "notebook" });
+      });
+
+      it("should work on custom column with `case`", () => {
+        cy.icon("add_data").click();
+
+        enterCustomColumnDetails({
+          formula: "case([Subtotal] + Tax > 100, 'Big', 'Small')",
+        });
+
+        cy.findByPlaceholderText("Something nice and descriptive")
+          .click()
+          .type("Example", { delay: 100 });
+
+        cy.button("Done").should("not.be.disabled").click();
+
+        visualize();
+
+        cy.contains("Example");
+        cy.contains("Big");
+        cy.contains("Small");
+      });
+
+      it("should work on custom filter", () => {
+        filter({ mode: "notebook" });
         cy.findByText("Custom Expression").click();
 
-        enterCustomColumnDetails({ formula: expression });
+        enterCustomColumnDetails({ formula: "[Subtotal] - Tax > 140" });
 
-        cy.findByPlaceholderText("Name (required)")
-          .click()
-          .type(filter, { delay: 100 });
-
-        cy.contains(/^expected closing parenthesis/i).should("not.exist");
         cy.contains(/^redundant input/i).should("not.exist");
 
         cy.button("Done").should("not.be.disabled").click();
 
         visualize();
 
-        cy.contains(filter);
-        cy.contains(result);
+        cy.contains("Showing 97 rows");
+      });
+
+      const CASES = {
+        CountIf: ["CountIf(([Subtotal] + [Tax]) > 10)", "18,760"],
+        SumIf: ["SumIf([Subtotal], ([Subtotal] + [Tax] > 20))", "1,447,850.28"],
+      };
+
+      Object.entries(CASES).forEach(([filter, formula]) => {
+        const [expression, result] = formula;
+
+        it(`should work on custom aggregation with ${filter}`, () => {
+          summarize({ mode: "notebook" });
+          cy.findByText("Custom Expression").click();
+
+          enterCustomColumnDetails({ formula: expression });
+
+          cy.findByPlaceholderText("Name (required)")
+            .click()
+            .type(filter, { delay: 100 });
+
+          cy.contains(/^expected closing parenthesis/i).should("not.exist");
+          cy.contains(/^redundant input/i).should("not.exist");
+
+          cy.button("Done").should("not.be.disabled").click();
+
+          visualize();
+
+          cy.contains(filter);
+          cy.contains(result);
+        });
       });
     });
-  });
 
-  // intentional simplification of "Select none" to quickly
-  // fix users' pain caused by the inability to unselect all columns
-  it("select no columns select the first one", () => {
-    startNewQuestion();
-    cy.contains("Sample Database").click();
-    cy.contains("Orders").click();
-    cy.findByTestId("fields-picker").click();
+    // intentional simplification of "Select none" to quickly
+    // fix users' pain caused by the inability to unselect all columns
+    it("select no columns select the first one", () => {
+      startNewQuestion();
+      cy.contains("Sample Database").click();
+      cy.contains("Orders").click();
+      cy.findByTestId("fields-picker").click();
 
-    popover().within(() => {
-      cy.findByText("Select none").click();
-      cy.findByLabelText("ID").should("be.disabled");
-      cy.findByText("Tax").click();
-      cy.findByLabelText("ID").should("be.enabled").click();
+      popover().within(() => {
+        cy.findByText("Select none").click();
+        cy.findByLabelText("ID").should("be.disabled");
+        cy.findByText("Tax").click();
+        cy.findByLabelText("ID").should("be.enabled").click();
+      });
+
+      visualize();
+
+      cy.findByText("Tax");
+      cy.findByText("ID").should("not.exist");
     });
 
-    visualize();
+    it("should treat max/min on a name as a string filter (metabase#21973)", () => {
+      const questionDetails = {
+        name: "21973",
+        query: {
+          "source-table": PEOPLE_ID,
+          aggregation: [["max", ["field", PEOPLE.NAME, null]]],
+          breakout: [["field", PEOPLE.SOURCE, null]],
+        },
+        display: "table",
+      };
 
-    cy.findByText("Tax");
-    cy.findByText("ID").should("not.exist");
-  });
+      cy.createQuestion(questionDetails, { visitQuestion: true });
 
-  it("should treat max/min on a name as a string filter (metabase#21973)", () => {
-    const questionDetails = {
-      name: "21973",
-      query: {
-        "source-table": PEOPLE_ID,
-        aggregation: [["max", ["field", PEOPLE.NAME, null]]],
-        breakout: [["field", PEOPLE.SOURCE, null]],
-      },
-      display: "table",
-    };
+      filter();
+      cy.findByText("Summaries").click();
 
-    cy.createQuestion(questionDetails, { visitQuestion: true });
+      filterField("Max of Name", {
+        operator: "Starts with",
+      });
+    });
 
-    filter();
-    cy.findByText("Summaries").click();
+    it("should treat max/min on a category as a string filter (metabase#22154)", () => {
+      const questionDetails = {
+        name: "22154",
+        query: {
+          "source-table": PRODUCTS_ID,
+          aggregation: [["min", ["field", PRODUCTS.VENDOR, null]]],
+          breakout: [["field", PRODUCTS.CATEGORY, null]],
+        },
+        display: "table",
+      };
 
-    filterField("Max of Name", {
-      operator: "Starts with",
+      cy.createQuestion(questionDetails, { visitQuestion: true });
+
+      filter();
+      cy.findByText("Summaries").click();
+      filterField("Min of Vendor", {
+        operator: "ends with",
+      });
+    });
+
+    it("should prompt to join with a model if the question is based on a model", () => {
+      cy.createQuestion({
+        name: "Products model",
+        query: { "source-table": PRODUCTS_ID },
+        dataset: true,
+        display: "table",
+      });
+
+      cy.createQuestion({
+        name: "Orders model",
+        query: { "source-table": ORDERS_ID },
+        dataset: true,
+        display: "table",
+      });
+
+      startNewQuestion();
+      popover().findByText("Models").click();
+      popover().findByText("Products model").click();
+      join();
+      popover().findByText("Orders model").click();
+      popover().findByText("ID").click();
+      popover().findByText("Product ID").click();
+
+      visualize();
+    });
+
+    // flaky test
+    it.skip("should show an info popover when hovering over a field picker option for a table", () => {
+      startNewQuestion();
+      cy.contains("Sample Database").click();
+      cy.contains("Orders").click();
+
+      cy.findByTestId("fields-picker").click();
+
+      cy.findByText("Total").trigger("mouseenter");
+
+      popover().contains("The total billed amount.");
+      popover().contains("80.36");
+    });
+
+    // flaky test
+    it.skip("should show an info popover when hovering over a field picker option for a saved question", () => {
+      cy.createNativeQuestion({
+        name: "question a",
+        native: { query: "select 'foo' as a_column" },
+      });
+
+      // start a custom question with question a
+      startNewQuestion();
+      cy.findByText("Saved Questions").click();
+      cy.findByText("question a").click();
+
+      cy.findByTestId("fields-picker").click();
+
+      cy.findByText("A_COLUMN").trigger("mouseenter");
+
+      popover().contains("A_COLUMN");
+      popover().contains("No description");
     });
   });
 
-  it("should treat max/min on a category as a string filter (metabase#22154)", () => {
-    const questionDetails = {
-      name: "22154",
-      query: {
-        "source-table": PRODUCTS_ID,
-        aggregation: [["min", ["field", PRODUCTS.VENDOR, null]]],
-        breakout: [["field", PRODUCTS.CATEGORY, null]],
-      },
-      display: "table",
-    };
-
-    cy.createQuestion(questionDetails, { visitQuestion: true });
-
-    filter();
-    cy.findByText("Summaries").click();
-    filterField("Min of Vendor", {
-      operator: "ends with",
-    });
-  });
-
-  it("should prompt to join with a model if the question is based on a model", () => {
-    cy.createQuestion({
-      name: "Products model",
-      query: { "source-table": PRODUCTS_ID },
-      dataset: true,
-      display: "table",
+  describe("postgres", () => {
+    beforeEach(() => {
+      restore("postgres-12");
+      cy.signInAsAdmin();
     });
 
-    cy.createQuestion({
-      name: "Orders model",
-      query: { "source-table": ORDERS_ID },
-      dataset: true,
-      display: "table",
+    it('should show Median aggregation function for databases that support "percentile-aggregations" driver feature', () => {
+      // start a custom question with orders
+      startNewQuestion();
+      cy.contains("QA Postgres12").click();
+      cy.contains("Products").click();
+
+      cy.contains("Summarize").click();
+
+      cy.contains("Pick the metric you want to see").click();
+      popover().within(() => {
+        cy.findByText("Median of ...").click();
+        cy.findByText("Price").click();
+      });
+
+      cy.contains("Median of Price");
     });
-
-    startNewQuestion();
-    popover().findByText("Models").click();
-    popover().findByText("Products model").click();
-    join();
-    popover().findByText("Orders model").click();
-    popover().findByText("ID").click();
-    popover().findByText("Product ID").click();
-
-    visualize();
-  });
-
-  // flaky test
-  it.skip("should show an info popover when hovering over a field picker option for a table", () => {
-    startNewQuestion();
-    cy.contains("Sample Database").click();
-    cy.contains("Orders").click();
-
-    cy.findByTestId("fields-picker").click();
-
-    cy.findByText("Total").trigger("mouseenter");
-
-    popover().contains("The total billed amount.");
-    popover().contains("80.36");
-  });
-
-  // flaky test
-  it.skip("should show an info popover when hovering over a field picker option for a saved question", () => {
-    cy.createNativeQuestion({
-      name: "question a",
-      native: { query: "select 'foo' as a_column" },
-    });
-
-    // start a custom question with question a
-    startNewQuestion();
-    cy.findByText("Saved Questions").click();
-    cy.findByText("question a").click();
-
-    cy.findByTestId("fields-picker").click();
-
-    cy.findByText("A_COLUMN").trigger("mouseenter");
-
-    popover().contains("A_COLUMN");
-    popover().contains("No description");
   });
 
   it("should allow to pick a saved question when there are models", () => {

--- a/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
@@ -451,6 +451,24 @@ describe("scenarios > question > notebook", () => {
     visualize();
   });
 
+  it('should not show "median" aggregation option for databases that do not support "percentile-aggregations" driver feature', () => {
+    startNewQuestion();
+    popover().within(() => {
+      cy.contains("Sample Database").click();
+      cy.contains("Orders").click();
+    });
+
+    getNotebookStep("summarize")
+      .findByTestId("aggregate-step")
+      .findAllByTestId("notebook-cell-item")
+      .last()
+      .click();
+
+    popover().within(() => {
+      cy.findByText("Median of ...").should("not.exist");
+    });
+  });
+
   describe('"median" aggregation function', { tags: "@external" }, () => {
     beforeEach(() => {
       restore("postgres-12");
@@ -512,8 +530,19 @@ describe("scenarios > question > notebook", () => {
       cy.findAllByTestId("header-cell")
         .should("contain", "Median of Median of Mega price")
         .should("contain", "Median of Count");
+    });
 
-      cy.findByTestId("qb-header-action-panel").findByText("Summarize").click();
+    it("should support Summarize side panel", () => {
+      startNewQuestion();
+      popover().within(() => {
+        cy.findByText("QA Postgres12").click();
+        cy.findByText("Products").click();
+      });
+
+      visualize();
+
+      summarize();
+
       cy.findByTestId("add-aggregation-button").click();
 
       popover().within(() => {

--- a/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
+++ b/frontend/test/metabase/scenarios/question/notebook.cy.spec.js
@@ -21,444 +21,418 @@ const { ORDERS, ORDERS_ID, PEOPLE, PEOPLE_ID, PRODUCTS, PRODUCTS_ID } =
   SAMPLE_DATABASE;
 
 describe("scenarios > question > notebook", () => {
-  describe("default db", () => {
-    beforeEach(() => {
-      restore();
-      cy.signInAsAdmin();
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+  });
+
+  it("shouldn't offer to save the question when there were no changes (metabase#13470)", () => {
+    openOrdersTable();
+    // save question initially
+    cy.findByText("Save").click();
+    cy.get(".ModalBody").contains("Save").click();
+    cy.findByText("Not now").click();
+    // enter "notebook" and visualize without changing anything
+    cy.icon("notebook").click();
+
+    cy.button("Visualize").click();
+
+    // there were no changes to the question, so we shouldn't have the option to "Save"
+    cy.findByText("Save").should("not.exist");
+  });
+
+  it("should allow post-aggregation filters", () => {
+    // start a custom question with orders
+    startNewQuestion();
+    cy.contains("Sample Database").click();
+    cy.contains("Orders").click();
+
+    // count orders by user id, filter to the one user with 46 orders
+    cy.contains("Pick the metric").click();
+    popover().within(() => {
+      cy.findByText("Count of rows").click();
+    });
+    cy.contains("Pick a column to group by").click();
+    popover().within(() => {
+      cy.contains("User ID").click();
+    });
+    cy.icon("filter").click();
+    popover().within(() => {
+      cy.icon("int").click();
+      cy.get("input").type("46");
+      cy.contains("Add filter").click();
     });
 
-    it("shouldn't offer to save the question when there were no changes (metabase#13470)", () => {
-      openOrdersTable();
-      // save question initially
-      cy.findByText("Save").click();
-      cy.get(".ModalBody").contains("Save").click();
-      cy.findByText("Not now").click();
-      // enter "notebook" and visualize without changing anything
-      cy.icon("notebook").click();
+    visualize();
 
-      cy.button("Visualize").click();
+    cy.contains("2372"); // user's id in the table
+    cy.contains("Showing 1 row"); // ensure only one user was returned
+  });
 
-      // there were no changes to the question, so we shouldn't have the option to "Save"
-      cy.findByText("Save").should("not.exist");
-    });
+  it("shouldn't show sub-dimensions for FK (metabase#16787)", () => {
+    openOrdersTable({ mode: "notebook" });
+    summarize({ mode: "notebook" });
+    cy.findByText("Pick a column to group by").click();
+    cy.findByText("User ID")
+      .closest(".List-item")
+      .find(".Field-extra")
+      .should("not.have.descendants", "*");
+  });
 
-    it("should allow post-aggregation filters", () => {
-      // start a custom question with orders
-      startNewQuestion();
-      cy.contains("Sample Database").click();
-      cy.contains("Orders").click();
-
-      // count orders by user id, filter to the one user with 46 orders
-      cy.contains("Pick the metric").click();
-      popover().within(() => {
-        cy.findByText("Count of rows").click();
-      });
-      cy.contains("Pick a column to group by").click();
-      popover().within(() => {
-        cy.contains("User ID").click();
-      });
-      cy.icon("filter").click();
-      popover().within(() => {
-        cy.icon("int").click();
-        cy.get("input").type("46");
-        cy.contains("Add filter").click();
-      });
-
-      visualize();
-
-      cy.contains("2372"); // user's id in the table
-      cy.contains("Showing 1 row"); // ensure only one user was returned
-    });
-
-    it("shouldn't show sub-dimensions for FK (metabase#16787)", () => {
-      openOrdersTable({ mode: "notebook" });
-      summarize({ mode: "notebook" });
-      cy.findByText("Pick a column to group by").click();
-      cy.findByText("User ID")
-        .closest(".List-item")
-        .find(".Field-extra")
-        .should("not.have.descendants", "*");
-    });
-
-    it("should show the original custom expression filter field on subsequent click (metabase#14726)", () => {
-      visitQuestionAdhoc({
-        dataset_query: {
-          database: SAMPLE_DB_ID,
-          query: {
-            "source-table": ORDERS_ID,
-            filter: ["between", ["field", ORDERS.ID, null], 96, 97],
-          },
-          type: "query",
+  it("should show the original custom expression filter field on subsequent click (metabase#14726)", () => {
+    visitQuestionAdhoc({
+      dataset_query: {
+        database: SAMPLE_DB_ID,
+        query: {
+          "source-table": ORDERS_ID,
+          filter: ["between", ["field", ORDERS.ID, null], 96, 97],
         },
-        display: "table",
-      });
-
-      cy.findByText("ID between 96 97").click();
-      cy.findByText("Between").click();
-      popover().within(() => {
-        cy.contains("Is not");
-        cy.contains("Greater than");
-        cy.contains("Less than");
-      });
+        type: "query",
+      },
+      display: "table",
     });
 
-    it("should append indexes to duplicate custom expression names (metabase#12104)", () => {
-      cy.viewport(1920, 800); // we're looking for a column name beyond the right of the default viewport
-      cy.intercept("POST", "/api/dataset").as("dataset");
-      openProductsTable({ mode: "notebook" });
+    cy.findByText("ID between 96 97").click();
+    cy.findByText("Between").click();
+    popover().within(() => {
+      cy.contains("Is not");
+      cy.contains("Greater than");
+      cy.contains("Less than");
+    });
+  });
 
-      cy.findByText("Custom column").click();
-      addSimpleCustomColumn("EXPR");
+  it("should append indexes to duplicate custom expression names (metabase#12104)", () => {
+    cy.viewport(1920, 800); // we're looking for a column name beyond the right of the default viewport
+    cy.intercept("POST", "/api/dataset").as("dataset");
+    openProductsTable({ mode: "notebook" });
 
-      getNotebookStep("expression").within(() => {
-        cy.icon("add").click();
-      });
-      addSimpleCustomColumn("EXPR");
+    cy.findByText("Custom column").click();
+    addSimpleCustomColumn("EXPR");
 
-      getNotebookStep("expression").within(() => {
-        cy.icon("add").click();
-      });
-      addSimpleCustomColumn("EXPR");
+    getNotebookStep("expression").within(() => {
+      cy.icon("add").click();
+    });
+    addSimpleCustomColumn("EXPR");
 
-      getNotebookStep("expression").within(() => {
-        cy.findByText("EXPR");
-        cy.findByText("EXPR (1)");
-        cy.findByText("EXPR (2)");
-      });
+    getNotebookStep("expression").within(() => {
+      cy.icon("add").click();
+    });
+    addSimpleCustomColumn("EXPR");
 
-      visualize();
-
+    getNotebookStep("expression").within(() => {
       cy.findByText("EXPR");
       cy.findByText("EXPR (1)");
       cy.findByText("EXPR (2)");
     });
 
-    it("should process the updated expression when pressing Enter", () => {
-      openProductsTable({ mode: "notebook" });
+    visualize();
+
+    cy.findByText("EXPR");
+    cy.findByText("EXPR (1)");
+    cy.findByText("EXPR (2)");
+  });
+
+  it("should process the updated expression when pressing Enter", () => {
+    openProductsTable({ mode: "notebook" });
+    filter({ mode: "notebook" });
+    cy.findByText("Custom Expression").click();
+    enterCustomColumnDetails({ formula: "[Price] > 1" });
+
+    cy.button("Done").click();
+
+    // change the corresponding custom expression
+    cy.findByText("Price is greater than 1").click();
+    cy.get(".Icon-chevronleft").click();
+    cy.findByText("Custom Expression").click();
+
+    cy.get("@formula").clear().type("[Price] > 1 AND [Price] < 5{enter}");
+
+    cy.contains(/^Price is less than 5/i);
+  });
+
+  it("should show the real number of rows instead of HARD_ROW_LIMIT when loading (metabase#17397)", () => {
+    cy.intercept(
+      {
+        method: "POST",
+        url: "/api/dataset",
+        middleware: true,
+      },
+      req => {
+        req.on("response", res => {
+          // Throttle the response to 500 Kbps to simulate a mobile 3G connection
+          res.setThrottle(500);
+        });
+      },
+    ).as("dataset");
+
+    const questionDetails = {
+      query: {
+        "source-table": ORDERS_ID,
+        filter: ["=", ["field", ORDERS.PRODUCT_ID, null], 2],
+      },
+    };
+
+    cy.createQuestion(questionDetails, { visitQuestion: true });
+
+    cy.contains("Showing 98 rows");
+
+    cy.findByTestId("filters-visibility-control").click();
+    cy.findByText("Product ID is 2").click();
+
+    popover().find("input").type("3{enter}");
+    cy.findByText("Product ID is 2 selections");
+
+    // Still loading
+    cy.contains("Showing 98 rows");
+
+    cy.wait("@dataset");
+    cy.contains("Showing 175 rows");
+  });
+
+  // flaky test (#19454)
+  it.skip("should show an info popover for dimensions listened by the custom expression editor", () => {
+    // start a custom question with orders
+    startNewQuestion();
+    cy.contains("Sample Database").click();
+    cy.contains("Orders").click();
+
+    // type a dimension name
+    cy.findByText("Add filters to narrow your answer").click();
+    cy.findByText("Custom Expression").click();
+    enterCustomColumnDetails({ formula: "Total" });
+
+    // hover over option in the suggestion list
+    cy.findByTestId("expression-suggestions-list")
+      .findByText("Total")
+      .trigger("mouseenter");
+
+    // confirm that the popover is shown
+    popover().contains("The total billed amount.");
+    popover().contains("80.36");
+  });
+
+  describe.skip("popover rendering issues (metabase#15502)", () => {
+    beforeEach(() => {
+      restore();
+      cy.signInAsAdmin();
+      cy.viewport(1280, 720);
+      startNewQuestion();
+      cy.findByTextEnsureVisible("Sample Database").click();
+      cy.findByTextEnsureVisible("Orders").click();
+    });
+
+    it("popover should not render outside of viewport regardless of the screen resolution (metabase#15502-1)", () => {
+      // Initial filter popover usually renders correctly within the viewport
+      cy.findByText("Add filters to narrow your answer").as("filter").click();
+      popover().isRenderedWithinViewport();
+      // Click anywhere outside this popover to close it because the issue with rendering happens when popover opens for the second time
+      cy.icon("gear").click();
+      cy.get("@filter").click();
+      popover().isRenderedWithinViewport();
+    });
+
+    it("popover should not cover the button that invoked it (metabase#15502-2)", () => {
+      // Initial summarize/metric popover usually renders initially without blocking the button
+      cy.findByText("Pick the metric you want to see").as("metric").click();
+      // Click outside to close this popover
+      cy.icon("gear").click();
+      // Popover invoked again blocks the button making it impossible to click the button for the third time
+      cy.get("@metric").click();
+      cy.get("@metric").click();
+    });
+  });
+
+  describe("arithmetic (metabase#13175)", () => {
+    beforeEach(() => {
+      openOrdersTable({ mode: "notebook" });
+    });
+
+    it("should work on custom column with `case`", () => {
+      cy.icon("add_data").click();
+
+      enterCustomColumnDetails({
+        formula: "case([Subtotal] + Tax > 100, 'Big', 'Small')",
+      });
+
+      cy.findByPlaceholderText("Something nice and descriptive")
+        .click()
+        .type("Example", { delay: 100 });
+
+      cy.button("Done").should("not.be.disabled").click();
+
+      visualize();
+
+      cy.contains("Example");
+      cy.contains("Big");
+      cy.contains("Small");
+    });
+
+    it("should work on custom filter", () => {
       filter({ mode: "notebook" });
       cy.findByText("Custom Expression").click();
-      enterCustomColumnDetails({ formula: "[Price] > 1" });
 
-      cy.button("Done").click();
+      enterCustomColumnDetails({ formula: "[Subtotal] - Tax > 140" });
 
-      // change the corresponding custom expression
-      cy.findByText("Price is greater than 1").click();
-      cy.get(".Icon-chevronleft").click();
-      cy.findByText("Custom Expression").click();
+      cy.contains(/^redundant input/i).should("not.exist");
 
-      cy.get("@formula").clear().type("[Price] > 1 AND [Price] < 5{enter}");
+      cy.button("Done").should("not.be.disabled").click();
 
-      cy.contains(/^Price is less than 5/i);
+      visualize();
+
+      cy.contains("Showing 97 rows");
     });
 
-    it("should show the real number of rows instead of HARD_ROW_LIMIT when loading (metabase#17397)", () => {
-      cy.intercept(
-        {
-          method: "POST",
-          url: "/api/dataset",
-          middleware: true,
-        },
-        req => {
-          req.on("response", res => {
-            // Throttle the response to 500 Kbps to simulate a mobile 3G connection
-            res.setThrottle(500);
-          });
-        },
-      ).as("dataset");
+    const CASES = {
+      CountIf: ["CountIf(([Subtotal] + [Tax]) > 10)", "18,760"],
+      SumIf: ["SumIf([Subtotal], ([Subtotal] + [Tax] > 20))", "1,447,850.28"],
+    };
 
-      const questionDetails = {
-        query: {
-          "source-table": ORDERS_ID,
-          filter: ["=", ["field", ORDERS.PRODUCT_ID, null], 2],
-        },
-      };
+    Object.entries(CASES).forEach(([filter, formula]) => {
+      const [expression, result] = formula;
 
-      cy.createQuestion(questionDetails, { visitQuestion: true });
-
-      cy.contains("Showing 98 rows");
-
-      cy.findByTestId("filters-visibility-control").click();
-      cy.findByText("Product ID is 2").click();
-
-      popover().find("input").type("3{enter}");
-      cy.findByText("Product ID is 2 selections");
-
-      // Still loading
-      cy.contains("Showing 98 rows");
-
-      cy.wait("@dataset");
-      cy.contains("Showing 175 rows");
-    });
-
-    // flaky test (#19454)
-    it.skip("should show an info popover for dimensions listened by the custom expression editor", () => {
-      // start a custom question with orders
-      startNewQuestion();
-      cy.contains("Sample Database").click();
-      cy.contains("Orders").click();
-
-      // type a dimension name
-      cy.findByText("Add filters to narrow your answer").click();
-      cy.findByText("Custom Expression").click();
-      enterCustomColumnDetails({ formula: "Total" });
-
-      // hover over option in the suggestion list
-      cy.findByTestId("expression-suggestions-list")
-        .findByText("Total")
-        .trigger("mouseenter");
-
-      // confirm that the popover is shown
-      popover().contains("The total billed amount.");
-      popover().contains("80.36");
-    });
-
-    describe.skip("popover rendering issues (metabase#15502)", () => {
-      beforeEach(() => {
-        restore();
-        cy.signInAsAdmin();
-        cy.viewport(1280, 720);
-        startNewQuestion();
-        cy.findByTextEnsureVisible("Sample Database").click();
-        cy.findByTextEnsureVisible("Orders").click();
-      });
-
-      it("popover should not render outside of viewport regardless of the screen resolution (metabase#15502-1)", () => {
-        // Initial filter popover usually renders correctly within the viewport
-        cy.findByText("Add filters to narrow your answer").as("filter").click();
-        popover().isRenderedWithinViewport();
-        // Click anywhere outside this popover to close it because the issue with rendering happens when popover opens for the second time
-        cy.icon("gear").click();
-        cy.get("@filter").click();
-        popover().isRenderedWithinViewport();
-      });
-
-      it("popover should not cover the button that invoked it (metabase#15502-2)", () => {
-        // Initial summarize/metric popover usually renders initially without blocking the button
-        cy.findByText("Pick the metric you want to see").as("metric").click();
-        // Click outside to close this popover
-        cy.icon("gear").click();
-        // Popover invoked again blocks the button making it impossible to click the button for the third time
-        cy.get("@metric").click();
-        cy.get("@metric").click();
-      });
-    });
-
-    describe("arithmetic (metabase#13175)", () => {
-      beforeEach(() => {
-        openOrdersTable({ mode: "notebook" });
-      });
-
-      it("should work on custom column with `case`", () => {
-        cy.icon("add_data").click();
-
-        enterCustomColumnDetails({
-          formula: "case([Subtotal] + Tax > 100, 'Big', 'Small')",
-        });
-
-        cy.findByPlaceholderText("Something nice and descriptive")
-          .click()
-          .type("Example", { delay: 100 });
-
-        cy.button("Done").should("not.be.disabled").click();
-
-        visualize();
-
-        cy.contains("Example");
-        cy.contains("Big");
-        cy.contains("Small");
-      });
-
-      it("should work on custom filter", () => {
-        filter({ mode: "notebook" });
+      it(`should work on custom aggregation with ${filter}`, () => {
+        summarize({ mode: "notebook" });
         cy.findByText("Custom Expression").click();
 
-        enterCustomColumnDetails({ formula: "[Subtotal] - Tax > 140" });
+        enterCustomColumnDetails({ formula: expression });
 
+        cy.findByPlaceholderText("Name (required)")
+          .click()
+          .type(filter, { delay: 100 });
+
+        cy.contains(/^expected closing parenthesis/i).should("not.exist");
         cy.contains(/^redundant input/i).should("not.exist");
 
         cy.button("Done").should("not.be.disabled").click();
 
         visualize();
 
-        cy.contains("Showing 97 rows");
+        cy.contains(filter);
+        cy.contains(result);
       });
-
-      const CASES = {
-        CountIf: ["CountIf(([Subtotal] + [Tax]) > 10)", "18,760"],
-        SumIf: ["SumIf([Subtotal], ([Subtotal] + [Tax] > 20))", "1,447,850.28"],
-      };
-
-      Object.entries(CASES).forEach(([filter, formula]) => {
-        const [expression, result] = formula;
-
-        it(`should work on custom aggregation with ${filter}`, () => {
-          summarize({ mode: "notebook" });
-          cy.findByText("Custom Expression").click();
-
-          enterCustomColumnDetails({ formula: expression });
-
-          cy.findByPlaceholderText("Name (required)")
-            .click()
-            .type(filter, { delay: 100 });
-
-          cy.contains(/^expected closing parenthesis/i).should("not.exist");
-          cy.contains(/^redundant input/i).should("not.exist");
-
-          cy.button("Done").should("not.be.disabled").click();
-
-          visualize();
-
-          cy.contains(filter);
-          cy.contains(result);
-        });
-      });
-    });
-
-    // intentional simplification of "Select none" to quickly
-    // fix users' pain caused by the inability to unselect all columns
-    it("select no columns select the first one", () => {
-      startNewQuestion();
-      cy.contains("Sample Database").click();
-      cy.contains("Orders").click();
-      cy.findByTestId("fields-picker").click();
-
-      popover().within(() => {
-        cy.findByText("Select none").click();
-        cy.findByLabelText("ID").should("be.disabled");
-        cy.findByText("Tax").click();
-        cy.findByLabelText("ID").should("be.enabled").click();
-      });
-
-      visualize();
-
-      cy.findByText("Tax");
-      cy.findByText("ID").should("not.exist");
-    });
-
-    it("should treat max/min on a name as a string filter (metabase#21973)", () => {
-      const questionDetails = {
-        name: "21973",
-        query: {
-          "source-table": PEOPLE_ID,
-          aggregation: [["max", ["field", PEOPLE.NAME, null]]],
-          breakout: [["field", PEOPLE.SOURCE, null]],
-        },
-        display: "table",
-      };
-
-      cy.createQuestion(questionDetails, { visitQuestion: true });
-
-      filter();
-      cy.findByText("Summaries").click();
-
-      filterField("Max of Name", {
-        operator: "Starts with",
-      });
-    });
-
-    it("should treat max/min on a category as a string filter (metabase#22154)", () => {
-      const questionDetails = {
-        name: "22154",
-        query: {
-          "source-table": PRODUCTS_ID,
-          aggregation: [["min", ["field", PRODUCTS.VENDOR, null]]],
-          breakout: [["field", PRODUCTS.CATEGORY, null]],
-        },
-        display: "table",
-      };
-
-      cy.createQuestion(questionDetails, { visitQuestion: true });
-
-      filter();
-      cy.findByText("Summaries").click();
-      filterField("Min of Vendor", {
-        operator: "ends with",
-      });
-    });
-
-    it("should prompt to join with a model if the question is based on a model", () => {
-      cy.createQuestion({
-        name: "Products model",
-        query: { "source-table": PRODUCTS_ID },
-        dataset: true,
-        display: "table",
-      });
-
-      cy.createQuestion({
-        name: "Orders model",
-        query: { "source-table": ORDERS_ID },
-        dataset: true,
-        display: "table",
-      });
-
-      startNewQuestion();
-      popover().findByText("Models").click();
-      popover().findByText("Products model").click();
-      join();
-      popover().findByText("Orders model").click();
-      popover().findByText("ID").click();
-      popover().findByText("Product ID").click();
-
-      visualize();
-    });
-
-    // flaky test
-    it.skip("should show an info popover when hovering over a field picker option for a table", () => {
-      startNewQuestion();
-      cy.contains("Sample Database").click();
-      cy.contains("Orders").click();
-
-      cy.findByTestId("fields-picker").click();
-
-      cy.findByText("Total").trigger("mouseenter");
-
-      popover().contains("The total billed amount.");
-      popover().contains("80.36");
-    });
-
-    // flaky test
-    it.skip("should show an info popover when hovering over a field picker option for a saved question", () => {
-      cy.createNativeQuestion({
-        name: "question a",
-        native: { query: "select 'foo' as a_column" },
-      });
-
-      // start a custom question with question a
-      startNewQuestion();
-      cy.findByText("Saved Questions").click();
-      cy.findByText("question a").click();
-
-      cy.findByTestId("fields-picker").click();
-
-      cy.findByText("A_COLUMN").trigger("mouseenter");
-
-      popover().contains("A_COLUMN");
-      popover().contains("No description");
     });
   });
 
-  describe("postgres", () => {
-    beforeEach(() => {
-      restore("postgres-12");
-      cy.signInAsAdmin();
+  // intentional simplification of "Select none" to quickly
+  // fix users' pain caused by the inability to unselect all columns
+  it("select no columns select the first one", () => {
+    startNewQuestion();
+    cy.contains("Sample Database").click();
+    cy.contains("Orders").click();
+    cy.findByTestId("fields-picker").click();
+
+    popover().within(() => {
+      cy.findByText("Select none").click();
+      cy.findByLabelText("ID").should("be.disabled");
+      cy.findByText("Tax").click();
+      cy.findByLabelText("ID").should("be.enabled").click();
     });
 
-    it('should show Median aggregation function for databases that support "percentile-aggregations" driver feature', () => {
-      // start a custom question with orders
-      startNewQuestion();
-      cy.contains("QA Postgres12").click();
-      cy.contains("Products").click();
+    visualize();
 
-      cy.contains("Summarize").click();
+    cy.findByText("Tax");
+    cy.findByText("ID").should("not.exist");
+  });
 
-      cy.contains("Pick the metric you want to see").click();
-      popover().within(() => {
-        cy.findByText("Median of ...").click();
-        cy.findByText("Price").click();
-      });
+  it("should treat max/min on a name as a string filter (metabase#21973)", () => {
+    const questionDetails = {
+      name: "21973",
+      query: {
+        "source-table": PEOPLE_ID,
+        aggregation: [["max", ["field", PEOPLE.NAME, null]]],
+        breakout: [["field", PEOPLE.SOURCE, null]],
+      },
+      display: "table",
+    };
 
-      cy.contains("Median of Price");
+    cy.createQuestion(questionDetails, { visitQuestion: true });
+
+    filter();
+    cy.findByText("Summaries").click();
+
+    filterField("Max of Name", {
+      operator: "Starts with",
     });
+  });
+
+  it("should treat max/min on a category as a string filter (metabase#22154)", () => {
+    const questionDetails = {
+      name: "22154",
+      query: {
+        "source-table": PRODUCTS_ID,
+        aggregation: [["min", ["field", PRODUCTS.VENDOR, null]]],
+        breakout: [["field", PRODUCTS.CATEGORY, null]],
+      },
+      display: "table",
+    };
+
+    cy.createQuestion(questionDetails, { visitQuestion: true });
+
+    filter();
+    cy.findByText("Summaries").click();
+    filterField("Min of Vendor", {
+      operator: "ends with",
+    });
+  });
+
+  it("should prompt to join with a model if the question is based on a model", () => {
+    cy.createQuestion({
+      name: "Products model",
+      query: { "source-table": PRODUCTS_ID },
+      dataset: true,
+      display: "table",
+    });
+
+    cy.createQuestion({
+      name: "Orders model",
+      query: { "source-table": ORDERS_ID },
+      dataset: true,
+      display: "table",
+    });
+
+    startNewQuestion();
+    popover().findByText("Models").click();
+    popover().findByText("Products model").click();
+    join();
+    popover().findByText("Orders model").click();
+    popover().findByText("ID").click();
+    popover().findByText("Product ID").click();
+
+    visualize();
+  });
+
+  // flaky test
+  it.skip("should show an info popover when hovering over a field picker option for a table", () => {
+    startNewQuestion();
+    cy.contains("Sample Database").click();
+    cy.contains("Orders").click();
+
+    cy.findByTestId("fields-picker").click();
+
+    cy.findByText("Total").trigger("mouseenter");
+
+    popover().contains("The total billed amount.");
+    popover().contains("80.36");
+  });
+
+  // flaky test
+  it.skip("should show an info popover when hovering over a field picker option for a saved question", () => {
+    cy.createNativeQuestion({
+      name: "question a",
+      native: { query: "select 'foo' as a_column" },
+    });
+
+    // start a custom question with question a
+    startNewQuestion();
+    cy.findByText("Saved Questions").click();
+    cy.findByText("question a").click();
+
+    cy.findByTestId("fields-picker").click();
+
+    cy.findByText("A_COLUMN").trigger("mouseenter");
+
+    popover().contains("A_COLUMN");
+    popover().contains("No description");
   });
 
   it("should allow to pick a saved question when there are models", () => {
@@ -473,6 +447,41 @@ describe("scenarios > question > notebook", () => {
     cy.findByText("Orders, Count").click();
     visualize();
   });
+
+  it(
+    'should show Median aggregation function for databases that support "percentile-aggregations" driver feature',
+    { tags: "@external" },
+    () => {
+      restore("postgres-12");
+      cy.signInAsAdmin();
+
+      // add a question with "Products" and "Median of Price" aggregation by "Category"
+      startNewQuestion();
+      popover().within(() => {
+        cy.findByText("QA Postgres12").click();
+        cy.findByText("Products").click();
+      });
+
+      cy.findByText("Pick the metric you want to see").click();
+      popover().within(() => {
+        cy.findByText("Median of ...").click();
+        cy.findByText("Price").click();
+      });
+
+      getNotebookStep("summarize")
+        .findByText("Median of Price")
+        .should("be.visible");
+
+      cy.findByText("Pick a column to group by").click();
+      popover().within(() => {
+        cy.findByText("Category").click();
+      });
+
+      visualize();
+
+      cy.findAllByTestId("header-cell").should("contain", "Median of Price");
+    },
+  );
 });
 
 function addSimpleCustomColumn(name) {


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/20928

### Description

We should add median aggregation to the normal aggregation dropdown menu.
It should be available only for databases that support `percentile-aggregations` driver feature (Postgres)



### Demo

https://user-images.githubusercontent.com/7983744/220696632-b02fb69d-07b5-404b-b213-e6d933b4076d.mov



### Checklist

- [ ] Tests have been added/updated to cover changes in this PR

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/28526)
<!-- Reviewable:end -->
