### PR TITLE
Ignore visualization settings for displaying model data titles

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/Table.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Table.jsx
@@ -497,6 +497,8 @@ export default class Table extends Component {
     const column = cols[columnIndex];
     if (isPivoted) {
       return formatColumn(column) || (columnIndex !== 0 ? t`Unset` : null);
+    } else if (this.props.card.dataset) {
+      return formatColumn(column);
     } else {
       return (
         settings.column(column)["_column_title_full"] || formatColumn(column)

--- a/frontend/test/metabase/scenarios/models/reproductions/20624-model-metadata-should-override-column-settings.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/reproductions/20624-model-metadata-should-override-column-settings.cy.spec.js
@@ -1,5 +1,4 @@
-import { restore } from "__support__/e2e/helpers";
-import { openDetailsSidebar } from "../helpers/e2e-models-helpers";
+import { openQuestionActions, restore } from "__support__/e2e/helpers";
 
 const renamedColumn = "TITLE renamed";
 
@@ -12,7 +11,7 @@ const questionDetails = {
   },
 };
 
-describe.skip("issue 20624", () => {
+describe("issue 20624", () => {
   beforeEach(() => {
     cy.intercept("PUT", "/api/card/*").as("updateCard");
 
@@ -23,13 +22,13 @@ describe.skip("issue 20624", () => {
   });
 
   it("models metadata should override previously defined column settings (metabase#20624)", () => {
-    openDetailsSidebar();
-    cy.findByText("Customize metadata").click();
+    openQuestionActions();
+    cy.findByText("Edit metadata").click();
 
     // Open settings for this column
-    cy.findByText(renamedColumn).click();
+    cy.findByText("TITLE").click();
     // Let's set a new name for it
-    cy.findByDisplayValue(renamedColumn).clear().type("Foo").blur();
+    cy.findByDisplayValue("TITLE").clear().type("Foo").blur();
 
     cy.button("Save changes").click();
     cy.wait("@updateCard");


### PR DESCRIPTION
Issue: https://github.com/metabase/metabase/issues/20624

This implements an alternative solution proposed by @dpsutton in https://github.com/metabase/metabase/issues/20624#issuecomment-1419674392

I haven't take a ton of time to address other part of the table other than the title itself. Maybe might be better to try to ignore the viz settings altogether not just the title. But at least this gives the idea how the bug could be solved.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/28530)
<!-- Reviewable:end -->
