### PR TITLE
Fix `NaN` as a default numeric parameter value in actions

### DIFF
--- a/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/FieldSettingsPopover.styled.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/FieldSettingsPopover.styled.tsx
@@ -8,11 +8,16 @@ export const SettingsPopoverBody = styled.div`
   padding: ${space(3)};
 `;
 
-export const SectionLabel = styled.div`
+export const SectionLabel = styled.label`
+  display: block;
   color: ${color("text-medium")};
   font-weight: bold;
   padding-left: ${space(0)};
   margin-bottom: ${space(1)};
+`;
+
+export const RequiredToggleLabel = styled.label`
+  font-weight: bold;
 `;
 
 export const Divider = styled.div`

--- a/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/FieldSettingsPopover.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/FieldSettingsPopover.tsx
@@ -12,6 +12,8 @@ import Radio from "metabase/core/components/Radio";
 import Toggle from "metabase/core/components/Toggle";
 import TippyPopoverWithTrigger from "metabase/components/PopoverWithTrigger/TippyPopoverWithTrigger";
 
+import { isEmpty } from "metabase/lib/validate";
+
 import { getFieldTypes, getInputTypes } from "./constants";
 import {
   SettingsTriggerIcon,
@@ -54,10 +56,15 @@ export function FieldSettingsPopover({
 }
 
 function cleanDefaultValue(fieldType: FieldType, value?: string | number) {
+  if (isEmpty(value)) {
+    return;
+  }
+
   if (fieldType === "number") {
     const clean = Number(value);
     return !Number.isNaN(clean) ? clean : 0;
   }
+
   return value;
 }
 

--- a/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/FieldSettingsPopover.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/FieldSettingsPopover.tsx
@@ -53,6 +53,14 @@ export function FieldSettingsPopover({
   );
 }
 
+function cleanDefaultValue(fieldType: FieldType, value?: string | number) {
+  if (fieldType === "number") {
+    const clean = Number(value);
+    return !Number.isNaN(clean) ? clean : 0;
+  }
+  return value;
+}
+
 export function FormCreatorPopoverBody({
   fieldSettings,
   onChange,
@@ -91,10 +99,7 @@ export function FormCreatorPopoverBody({
     onChange({
       ...fieldSettings,
       required,
-      defaultValue:
-        fieldSettings.fieldType === "number"
-          ? Number(defaultValue)
-          : defaultValue,
+      defaultValue: cleanDefaultValue(fieldSettings.fieldType, defaultValue),
     });
 
   const hasPlaceholder =

--- a/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/FieldSettingsPopover.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/FieldSettingsPopover.tsx
@@ -18,6 +18,7 @@ import {
   ToggleContainer,
   SettingsPopoverBody,
   SectionLabel,
+  RequiredToggleLabel,
   Divider,
 } from "./FieldSettingsPopover.styled";
 
@@ -208,16 +209,18 @@ function RequiredInput({
   return (
     <div>
       <ToggleContainer>
-        <strong>{t`Required`}</strong>
+        <RequiredToggleLabel htmlFor="is-required">{t`Required`}</RequiredToggleLabel>
         <Toggle
+          id="is-required"
           value={!!value}
           onChange={required => onChange({ required, defaultValue })}
         />
       </ToggleContainer>
       {!value && (
         <>
-          <SectionLabel>{t`Default Value`}</SectionLabel>
+          <SectionLabel htmlFor="default-value">{t`Default value`}</SectionLabel>
           <Input
+            id="default-value"
             fullWidth
             value={defaultValue ?? ""}
             onChange={e =>

--- a/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/FieldSettingsPopover.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/FieldSettingsPopover.tsx
@@ -22,13 +22,15 @@ import {
   Divider,
 } from "./FieldSettingsPopover.styled";
 
+export interface FieldSettingsPopoverProps {
+  fieldSettings: FieldSettings;
+  onChange: (fieldSettings: FieldSettings) => void;
+}
+
 export function FieldSettingsPopover({
   fieldSettings,
   onChange,
-}: {
-  fieldSettings: FieldSettings;
-  onChange: (fieldSettings: FieldSettings) => void;
-}) {
+}: FieldSettingsPopoverProps) {
   return (
     <TippyPopoverWithTrigger
       placement="bottom-end"

--- a/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/FieldSettingsPopover.unit.spec.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/FieldSettingsPopover.unit.spec.tsx
@@ -114,12 +114,12 @@ describe("actions > FormCreator > FieldSettingsPopover", () => {
     expect(onChange).toHaveBeenCalledTimes(1);
     expect(onChange).toHaveBeenLastCalledWith({
       ...settings,
-      defaultValue: 0,
+      defaultValue: undefined,
       required: false,
     });
 
     const defaultValueInput = screen.getByLabelText("Default value");
-    expect(defaultValueInput).toHaveValue("0");
+    expect(defaultValueInput).not.toHaveValue();
     await userEvent.type(defaultValueInput, "5");
 
     expect(onChange).toHaveBeenLastCalledWith({

--- a/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/FieldSettingsPopover.unit.spec.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/FieldSettingsPopover.unit.spec.tsx
@@ -1,13 +1,37 @@
-import React from "react";
+import React, { useState } from "react";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-
+import type { FieldSettings } from "metabase-types/api";
 import { getDefaultFieldSettings } from "../../../utils";
-import { FieldSettingsPopover } from "./FieldSettingsPopover";
+import {
+  FieldSettingsPopover,
+  FieldSettingsPopoverProps,
+} from "./FieldSettingsPopover";
+
+function WrappedFieldSettingsPopover({
+  fieldSettings: initialSettings,
+  onChange,
+}: FieldSettingsPopoverProps) {
+  const [settings, setSettings] = useState(initialSettings);
+
+  const handleChange = (nextSettings: FieldSettings) => {
+    setSettings(nextSettings);
+    onChange(nextSettings);
+  };
+
+  return (
+    <FieldSettingsPopover fieldSettings={settings} onChange={handleChange} />
+  );
+}
 
 function setup({ settings = getDefaultFieldSettings() } = {}) {
   const onChange = jest.fn();
-  render(<FieldSettingsPopover fieldSettings={settings} onChange={onChange} />);
+  render(
+    <WrappedFieldSettingsPopover
+      fieldSettings={settings}
+      onChange={onChange}
+    />,
+  );
   return { settings, onChange };
 }
 

--- a/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/FieldSettingsPopover.unit.spec.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/FieldSettingsPopover.unit.spec.tsx
@@ -99,4 +99,33 @@ describe("actions > FormCreator > FieldSettingsPopover", () => {
       placeholder: "$",
     });
   });
+
+  it("should fire onChange handler after changing required and default value properties", async () => {
+    const settings = getDefaultFieldSettings({
+      fieldType: "number",
+      required: true,
+    });
+    const { onChange } = setup({ settings });
+
+    userEvent.click(screen.getByLabelText("Field settings"));
+    await screen.findByTestId("field-settings-popover");
+
+    userEvent.click(screen.getByLabelText("Required"));
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenLastCalledWith({
+      ...settings,
+      defaultValue: 0,
+      required: false,
+    });
+
+    const defaultValueInput = screen.getByLabelText("Default value");
+    expect(defaultValueInput).toHaveValue("0");
+    await userEvent.type(defaultValueInput, "5");
+
+    expect(onChange).toHaveBeenLastCalledWith({
+      ...settings,
+      required: false,
+      defaultValue: 5,
+    });
+  });
 });

--- a/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/FieldSettingsPopover.unit.spec.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/FieldSettingsPopover.unit.spec.tsx
@@ -5,16 +5,17 @@ import userEvent from "@testing-library/user-event";
 import { getDefaultFieldSettings } from "../../../utils";
 import { FieldSettingsPopover } from "./FieldSettingsPopover";
 
+function setup({ settings = getDefaultFieldSettings() } = {}) {
+  const onChange = jest.fn();
+  render(<FieldSettingsPopover fieldSettings={settings} onChange={onChange} />);
+  return { settings, onChange };
+}
+
 describe("actions > FormCreator > FieldSettingsPopover", () => {
   it("should show the popover", async () => {
-    const changeSpy = jest.fn();
-    const settings = getDefaultFieldSettings();
+    setup();
 
-    render(
-      <FieldSettingsPopover fieldSettings={settings} onChange={changeSpy} />,
-    );
-
-    await userEvent.click(screen.getByLabelText("Field settings"));
+    userEvent.click(screen.getByLabelText("Field settings"));
 
     expect(
       await screen.findByTestId("field-settings-popover"),
@@ -22,24 +23,18 @@ describe("actions > FormCreator > FieldSettingsPopover", () => {
   });
 
   it("should fire onChange handler clicking a different field type", async () => {
-    const changeSpy = jest.fn();
-    const settings = getDefaultFieldSettings();
+    const { settings, onChange } = setup();
 
-    render(
-      <FieldSettingsPopover fieldSettings={settings} onChange={changeSpy} />,
-    );
-
-    await userEvent.click(screen.getByLabelText("Field settings"));
+    userEvent.click(screen.getByLabelText("Field settings"));
 
     expect(
       await screen.findByTestId("field-settings-popover"),
     ).toBeInTheDocument();
 
-    await userEvent.click(screen.getByText("Date"));
+    userEvent.click(screen.getByText("Date"));
 
-    expect(changeSpy).toHaveBeenCalledTimes(1);
-
-    expect(changeSpy).toHaveBeenCalledWith({
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith({
       ...settings,
       fieldType: "date",
       inputType: "date", // should set default input type for new field type
@@ -47,38 +42,27 @@ describe("actions > FormCreator > FieldSettingsPopover", () => {
   });
 
   it("should fire onChange handler clicking a different input type", async () => {
-    const changeSpy = jest.fn();
-    const settings = getDefaultFieldSettings();
+    const { settings, onChange } = setup();
 
-    render(
-      <FieldSettingsPopover fieldSettings={settings} onChange={changeSpy} />,
-    );
-
-    await userEvent.click(screen.getByLabelText("Field settings"));
+    userEvent.click(screen.getByLabelText("Field settings"));
 
     expect(
       await screen.findByTestId("field-settings-popover"),
     ).toBeInTheDocument();
 
-    await userEvent.click(screen.getByText("Dropdown"));
+    userEvent.click(screen.getByText("Dropdown"));
 
-    expect(changeSpy).toHaveBeenCalledTimes(1);
-
-    expect(changeSpy).toHaveBeenCalledWith({
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith({
       ...settings,
       inputType: "select",
     });
   });
 
   it("should fire onChange handler editing placeholder", async () => {
-    const changeSpy = jest.fn();
-    const settings = getDefaultFieldSettings();
+    const { settings, onChange } = setup();
 
-    render(
-      <FieldSettingsPopover fieldSettings={settings} onChange={changeSpy} />,
-    );
-
-    await userEvent.click(screen.getByLabelText("Field settings"));
+    userEvent.click(screen.getByLabelText("Field settings"));
 
     expect(
       await screen.findByTestId("field-settings-popover"),
@@ -86,7 +70,7 @@ describe("actions > FormCreator > FieldSettingsPopover", () => {
 
     await userEvent.type(screen.getByTestId("placeholder-input"), "$");
 
-    expect(changeSpy).toHaveBeenLastCalledWith({
+    expect(onChange).toHaveBeenLastCalledWith({
       ...settings,
       placeholder: "$",
     });


### PR DESCRIPTION
Epic #27581

### Description

Fixes an issue that making a numeric action parameter optional would set the default value to `NaN`

### How to verify

1. Open `/model/:id/detail/actions`
2. Click "New action"
3. Add a parameter, you can just fill in `{{ param }}`
4. Click the gear icon next to the parameter on the right side of the editor
5. Select type "Number" type
6. Click the "Required" toggle to make the parameter optional
7. Ensure the default value is `0`
8. Ensure you can set another value and that it's kept across action edits

### Demo

<details>
<summary>Before</summary>

https://user-images.githubusercontent.com/17258145/220676795-04a0136c-3fe7-4fdc-89ef-3fc5ac613b7f.mp4

</details>

<details>
<summary>After</summary>

https://user-images.githubusercontent.com/17258145/220676890-9ac15fa0-8a98-4d1a-b47f-f941e2c21d34.mp4

</details>

### Checklist

- [x] Tests have been added/updated to cover changes in this PR

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/28536)
<!-- Reviewable:end -->
