### PR TITLE
Fix boolean icon in notebook editor filter popover

### DIFF
--- a/frontend/src/metabase-lib/types/utils/isa.js
+++ b/frontend/src/metabase-lib/types/utils/isa.js
@@ -90,10 +90,10 @@ export function getFieldType(field) {
     COORDINATE,
     FOREIGN_KEY,
     PRIMARY_KEY,
+    BOOLEAN,
     STRING,
     STRING_LIKE,
     NUMBER,
-    BOOLEAN,
   ]) {
     if (isFieldType(type, field)) {
       return type;

--- a/frontend/src/metabase-lib/types/utils/isa.unit.spec.js
+++ b/frontend/src/metabase-lib/types/utils/isa.unit.spec.js
@@ -94,6 +94,15 @@ describe("isa", () => {
       ).toEqual(STRING);
     });
 
+    it("should know a bool regardless of semantic_type", () => {
+      expect(
+        getFieldType({
+          base_type: TYPE.Boolean,
+          semantic_type: TYPE.Category,
+        }),
+      ).toEqual(BOOLEAN);
+    });
+
     it("should know what it doesn't know", () => {
       expect(getFieldType({ base_type: "DERP DERP DERP" })).toEqual(undefined);
     });


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/27681

### Description

In the Notebook editor the filter popover had a small visual big where boolean fields would have a string icon instead of a boolean one.

This PR fixes this by fixing the logic in the `getFieldType` util function to check if a field is a boolean type first before checking if it is a string.

### How to verify

1. Sample Database > Accounts table
2. Open notebook mode
3. Click filter
4. Active subscriptions and other boolean types have the "I/O" icon next to them


### Demo

![Screenshot 2023-02-22 at 7 56 20 AM](https://user-images.githubusercontent.com/37751258/220683760-52c04878-5178-4464-ad27-dac3e369b7da.png)
