### PR TITLE
[CI] Print useful summary in a re-run workflow

### DIFF
--- a/.github/workflows/rerun-workflows.yml
+++ b/.github/workflows/rerun-workflows.yml
@@ -1,4 +1,4 @@
-name: Rerun Flaky Workflows
+name: Re-run Flaky Workflows
 
 on:
   workflow_run:
@@ -8,24 +8,31 @@ on:
 
 jobs:
   rerun-on-failure:
+    name: 'Re-run ''${{ github.event.workflow_run.name }}'' workflow'
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'failure' }}
     steps:
-      - uses: actions/github-script@v6
+      - name: Generate job summary
+        run: |
+          RUN_ID=${{ github.event.workflow_run.id }}
+          WORKFLOW_NAME=${{ github.event.workflow_run.name }}
+
+          echo "# $WORKFLOW_NAME workflow failed! :x:" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "View the failed run attempt (#${{ github.event.workflow_run.run_attempt }}) using the following link:" >> $GITHUB_STEP_SUMMARY
+          echo "${{ github.event.workflow_run.html_url }}" >> $GITHUB_STEP_SUMMARY
+
+      - name: Trigger a re-run
+        uses: actions/github-script@v6
         with:
           script: |
             const MAX_ATTEMPTS = 2;
             const ATTEMPT = ${{ github.event.workflow_run.run_attempt }};
 
             if (ATTEMPT <= MAX_ATTEMPTS) {
-              console.log("Rerruning...");
-
               github.rest.actions.reRunWorkflowFailedJobs({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 run_id: ${{ github.event.workflow_run.id }},
               });
-            } else {
-              console.log("Rerunning didn't help!");
-              console.log("Please check workflow " + ${{ github.event.workflow_run.id }});
             }


### PR DESCRIPTION
### Before:
- Workflow didn't have any summary
- Job didn't point out to which workflow is being re-run (it had generic name `rerun-on-failure`)
![image](https://user-images.githubusercontent.com/31325167/220738816-2c704ef7-4de1-4e9c-b284-01c58a977d1f.png)

### Now
- It should print a summary that clearly points out to a failed workflow name
- Summary also provides a link to the failed run attempt - makes it easier to debug
- Job name is dynamically generated and includes failed workflow name
![image](https://user-images.githubusercontent.com/31325167/220739284-0a0ab775-cf57-4c38-90a7-6a4d9ea4285c.png)
