### PR TITLE
Fix search styles

### DIFF
--- a/frontend/src/metabase/search/components/SearchResult.styled.jsx
+++ b/frontend/src/metabase/search/components/SearchResult.styled.jsx
@@ -64,17 +64,18 @@ export const ResultLink = styled(Link)`
 
 const resultStyles = props => `
   display: block;
-  background-color: ${props =>
-    props.isSelected ? lighten("brand", 0.63) : "transparent"};
-  min-height: ${props => (props.compact ? "36px" : "54px")};
+  background-color: ${
+    props.isSelected ? lighten("brand", 0.63) : "transparent"
+  };
+  min-height: ${props.compact ? "36px" : "54px"};
   padding-top: ${space(1)};
   padding-bottom: ${space(1)};
   padding-left: 14px;
-  padding-right: ${props => (props.compact ? "20px" : space(3))};
-  cursor: ${props => (props.active ? "pointer" : "default")};
+  padding-right: ${props.compact ? "20px" : space(3)};
+  cursor: ${props.active ? "pointer" : "default"};
 
   &:hover {
-    background-color: ${props => (props.acitve ? lighten("brand", 0.63) : "")};
+    background-color: ${props.acitve ? lighten("brand", 0.63) : ""};
 
     h3 {
       color: ${props =>
@@ -88,8 +89,8 @@ const resultStyles = props => `
     text-decoration-style: dashed;
 
     &:hover {
-      color: ${props => (props.active ? color("brand") : "")};
-      text-decoration-color: ${props => (props.active ? color("brand") : "")};
+      color: ${props.active ? color("brand") : ""};
+      text-decoration-color: ${props.active ? color("brand") : ""};
     }
   }
 
@@ -101,11 +102,11 @@ const resultStyles = props => `
   }
 
   h3 {
-    font-size: ${props => (props.compact ? "14px" : "16px")};
+    font-size: ${props.compact ? "14px" : "16px"};
     line-height: 1.2em;
     overflow-wrap: anywhere;
     margin-bottom: 0;
-    color: ${props => (props.active && props.isSelected ? color("brand") : "")};
+    color: ${props.active && props.isSelected ? color("brand") : ""};
   }
 
   .Icon-info {


### PR DESCRIPTION
### Description

I messed up some styles so none of the props were passing correctly. This manifested most obviously in the font size of the search component

should be like this (this branch) | not this (master)
--- | ---
![Screen Shot 2023-02-22 at 1 49 16 PM](https://user-images.githubusercontent.com/30528226/220755987-b1602e33-6205-49ea-9283-c6300348b9f5.png) | ![Screen Shot 2023-02-22 at 1 49 25 PM](https://user-images.githubusercontent.com/30528226/220755990-4e6b9151-4fad-4d04-a1a8-d35b6e421fff.png)


### How to verify

- Search for something in metabase
- title font size for search items should be 14px

