### PR TITLE
Remove exploded json fields in implicit actions

### DIFF
--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -575,8 +575,8 @@
    :int4          :type/Integer
    :int8          :type/BigInteger
    :interval      :type/*               ; time span
-   :json          :type/Structured
-   :jsonb         :type/Structured
+   :json          :type/JSON
+   :jsonb         :type/JSON
    :line          :type/*
    :lseg          :type/*
    :macaddr       :type/Structured

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -575,8 +575,8 @@
    :int4          :type/Integer
    :int8          :type/BigInteger
    :interval      :type/*               ; time span
-   :json          :type/JSON
-   :jsonb         :type/JSON
+   :json          :type/Structured
+   :jsonb         :type/Structured
    :line          :type/*
    :lseg          :type/*
    :macaddr       :type/Structured

--- a/src/metabase/driver/postgres/actions.clj
+++ b/src/metabase/driver/postgres/actions.clj
@@ -72,6 +72,7 @@
    :type/Float               "FLOAT"
    :type/Integer             "INTEGER"
    :type/IPAddress           "INET"
+   :type/JSON                "JSON"
    :type/Text                "TEXT"
    :type/Time                "TIME"
    :type/TimeWithTZ          "TIME WITH TIME ZONE"

--- a/src/metabase/driver/postgres/actions.clj
+++ b/src/metabase/driver/postgres/actions.clj
@@ -72,6 +72,7 @@
    :type/Float               "FLOAT"
    :type/Integer             "INTEGER"
    :type/IPAddress           "INET"
+   :type/Structured          "JSON"
    :type/Text                "TEXT"
    :type/Time                "TIME"
    :type/TimeWithTZ          "TIME WITH TIME ZONE"

--- a/src/metabase/driver/postgres/actions.clj
+++ b/src/metabase/driver/postgres/actions.clj
@@ -72,7 +72,6 @@
    :type/Float               "FLOAT"
    :type/Integer             "INTEGER"
    :type/IPAddress           "INET"
-   :type/Structured          "JSON"
    :type/Text                "TEXT"
    :type/Time                "TIME"
    :type/TimeWithTZ          "TIME WITH TIME ZONE"

--- a/src/metabase/models/action.clj
+++ b/src/metabase/models/action.clj
@@ -206,6 +206,7 @@
                       exposed-fields (into #{} (keep :id) (:result_metadata card))
                       parameters (->> fields
                                       (filter #(contains? exposed-fields (:id %)))
+                                      (remove :nfc_path) ;; remove exploded json fields
                                       (map (fn [field]
                                              {:id (u/slugify (:name field))
                                               :target [:variable [:template-tag (u/slugify (:name field))]]

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -2744,8 +2744,6 @@
 (deftest dashcard-action-execution-type-test
   (mt/test-drivers (mt/normal-drivers-with-feature :actions)
     (let [types [{:field-name "atext" :base-type :type/Text ::good "hello"}
-                 {:field-name "ajson" :base-type :type/JSON ::good "{\"a\": 1}"}
-                 {:field-name "axml" :base-type :type/XML ::good "<xml></xml>"}
                  {:field-name "aboolean" :base-type :type/Boolean ::good true ::bad "not boolean"}
                  {:field-name "ainteger" :base-type :type/Integer ::good 100}
                  {:field-name "afloat" :base-type :type/Float ::good 0.4}
@@ -2758,7 +2756,7 @@
                  {:field-name "adatetimetz" :base-type :type/DateTimeWithTZ #_#_::good "2020-02-02 14:39:59-0700" ::bad "not date"}]]
       (mt/with-temp-test-data
         ["types"
-         (map #(dissoc % ::good ::bad) types)
+         (map #(select-keys % [:field-name :base-type]) types)
          [["init"]]]
         (mt/with-actions-enabled
           (mt/with-actions [{card-id :id} {:dataset true :dataset_query (mt/mbql-query types)}

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -2756,7 +2756,7 @@
                  {:field-name "adatetimetz" :base-type :type/DateTimeWithTZ #_#_::good "2020-02-02 14:39:59-0700" ::bad "not date"}]]
       (mt/with-temp-test-data
         ["types"
-         (map #(select-keys % [:field-name :base-type]) types)
+         (map #(dissoc % ::good ::bad) types)
          [["init"]]]
         (mt/with-actions-enabled
           (mt/with-actions [{card-id :id} {:dataset true :dataset_query (mt/mbql-query types)}

--- a/test/metabase/driver/postgres_test.clj
+++ b/test/metabase/driver/postgres_test.clj
@@ -860,9 +860,9 @@
        (fn [enums-db]
          (mt/with-db enums-db
            (mt/with-actions-enabled
-             (mt/with-actions [{model-id :id :as model} {:dataset true
-                                                         :dataset_query
-                                                         (mt/mbql-query birds)}
+             (mt/with-actions [model {:dataset true
+                                      :dataset_query
+                                      (mt/mbql-query birds)}
                                {action-id :action-id} {:type :implicit
                                                        :kind "row/create"}]
                (testing "Enum fields are a valid implicit parameter target"
@@ -878,9 +878,9 @@
                         (mt/user-http-request :crowberto
                                               :post 200
                                               (format "action/%s/execute" action-id)
-                                              {:parameters {"name" "new bird"
+                                              {:parameters {"name"   "new bird"
                                                             "status" "good bird"
-                                                            "type" "turkey"}}))))))))))))
+                                                            "type"   "turkey"}}))))))))))))
 
 
 ;;; ------------------------------------------------ Timezone-related ------------------------------------------------

--- a/test/metabase/test/data/postgres.clj
+++ b/test/metabase/test/data/postgres.clj
@@ -1,11 +1,13 @@
 (ns metabase.test.data.postgres
   "Postgres driver test extensions."
   (:require
+   [metabase.driver.sql.query-processor :as sql.qp]
    [metabase.test.data.interface :as tx]
    [metabase.test.data.sql :as sql.tx]
    [metabase.test.data.sql-jdbc :as sql-jdbc.tx]
    [metabase.test.data.sql-jdbc.load-data :as load-data]
-   [metabase.test.data.sql.ddl :as ddl]))
+   [metabase.test.data.sql.ddl :as ddl]
+   [metabase.util.honey-sql-2 :as h2x]))
 
 (set! *warn-on-reflection* true)
 
@@ -36,6 +38,7 @@
                              :type/Float          "FLOAT"
                              :type/Integer        "INTEGER"
                              :type/IPAddress      "INET"
+                             :type/JSON           "JSON"
                              :type/Text           "TEXT"
                              :type/Time           "TIME"
                              :type/TimeWithTZ     "TIME WITH TIME ZONE"
@@ -77,8 +80,24 @@
    (kill-connections-to-db-sql database-name)
    (apply (get-method ddl/drop-db-ddl-statements :sql-jdbc/test-extensions) driver dbdef options)))
 
-(defmethod load-data/load-data! :postgres [& args]
-  (apply load-data/load-data-all-at-once! args))
+(defn cast-json-columns
+  "For each `:type/JSON` column, parse them with cheshire so they enter as json and not text."
+  [tabledef]
+  (if (some #{:type/JSON} (into [] (map :base-type) (:field-definitions tabledef)))
+    (let [parse-fns (map #(if (= % :type/JSON)
+                            (fn [json]
+                              [::sql.qp/compiled (h2x/cast "json" json)])
+                            identity)
+                         (map :base-type (:field-definitions tabledef)))]
+      (update tabledef :rows (fn [rows]
+                               (map (fn [row]
+                                      (map (fn [parser value] (parser value))
+                                           parse-fns row))
+                                    rows))))
+    tabledef))
+
+(defmethod load-data/load-data! :postgres [driver dbdef tabledef]
+  (load-data/load-data-all-at-once! driver dbdef (cast-json-columns tabledef)))
 
 (defmethod sql.tx/standalone-column-comment-sql :postgres [& args]
   (apply sql.tx/standard-standalone-column-comment-sql args))

--- a/test/metabase/test/data/postgres.clj
+++ b/test/metabase/test/data/postgres.clj
@@ -83,7 +83,7 @@
 (defn cast-json-columns
   "For each `:type/JSON` column, parse them with cheshire so they enter as json and not text."
   [tabledef]
-  (if (some #{:type/JSON} (into [] (map :base-type) (:field-definitions tabledef)))
+  (if (some (comp #{:type/JSON} :base-type) (:field-definitions tabledef))
     (let [parse-fns (map #(if (= % :type/JSON)
                             (fn [json]
                               [::sql.qp/compiled (h2x/cast "json" json)])


### PR DESCRIPTION
We need to handle implicit actions on models based on tables which have json fields. At the moment it doesn't treat these exploded json fields any differently and has a UI for each recognized one.
![image](https://user-images.githubusercontent.com/6377293/220791655-989b2344-41c1-4c02-ad5d-0ae809d4f237.png)

It would be really cool if this "Just Worked"™ but that's a tall order. Need to construct the nested json from all of these and we certainly don't get that for free.

In the alternative, we can hide the exploded json fields and the top level json field. That is what this PR does.

This will remove fields from being implicit parameter targets with the following logic: 
```clojure
(remove (some-fn
         ;; exploded json fields can't be recombined in sql yet
         :nfc_path
         ;; their parents, a json field, nor things like cidr, macaddr, xml, etc
         (comp #(isa? % :type/Structured) :effective_type)
         ;; or things which we don't recognize
         (comp #{:type/*} :effective_type)))
```
Which exludes
- `:nfc_path`: the nested json fields
- `:type/Structured`: the top level parent, but also things like cidr, macaddr, xml
- `:type/*`: unrecognized things like binary, blobs, geometry, etc.