### PR TITLE
Make LinkViz search test more robust

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/LinkViz/LinkViz.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/LinkViz/LinkViz.unit.spec.tsx
@@ -217,12 +217,12 @@ describe("LinkViz", () => {
       const searchInput = screen.getByPlaceholderText("https://example.com");
 
       userEvent.click(searchInput);
-      // There's a race here: as soon the search input is clicked into the text "Loading..."
-      // appears and is then replaced by "Question Uno". On CI, `findByText` was sometimes
-      // running while "Loading..." was still visible, so we added a timeout.
-      userEvent.click(
-        await screen.findByText("Question Uno", { timeout: 2000 }),
-      );
+      // There's a race here: as soon the search input is clicked into the text
+      // "Loading..." appears and is then replaced by "Question Uno". On CI,
+      // `findByText` was sometimes running while "Loading..." was still
+      // visible, so the extra expectation ensures good timing
+      expect(await screen.findByText("Loading...")).toBeInTheDocument();
+      userEvent.click(await screen.findByText("Question Uno"));
 
       expect(changeSpy).toHaveBeenCalledWith({
         link: {

--- a/frontend/src/metabase/visualizations/visualizations/LinkViz/LinkViz.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/LinkViz/LinkViz.unit.spec.tsx
@@ -217,7 +217,12 @@ describe("LinkViz", () => {
       const searchInput = screen.getByPlaceholderText("https://example.com");
 
       userEvent.click(searchInput);
-      userEvent.click(await screen.findByText("Question Uno"));
+      // There's a race here: as soon the search input is clicked into the text "Loading..."
+      // appears and is then replaced by "Question Uno". On CI, `findByText` was sometimes
+      // running while "Loading..." was still visible, so we added a timeout.
+      userEvent.click(
+        await screen.findByText("Question Uno", { timeout: 2000 }),
+      );
 
       expect(changeSpy).toHaveBeenCalledWith({
         link: {


### PR DESCRIPTION
It was flaking on CI due to the race described in the comment

#### Example failures
- https://github.com/metabase/metabase/actions/runs/4251982309/jobs/7395021570