### PR TITLE
[E2E] Fix Percy flake `parameters-widget`

### DIFF
--- a/frontend/test/__support__/e2e/helpers/e2e-dashboard-helpers.js
+++ b/frontend/test/__support__/e2e/helpers/e2e-dashboard-helpers.js
@@ -16,6 +16,7 @@ export function showDashboardCardActions(index = 0) {
 
 export function editDashboard() {
   cy.icon("pencil").click();
+  cy.findByText("You're editing this dashboard.");
 }
 
 export function saveDashboard() {

--- a/frontend/test/metabase-visual/dashboard/parameters-widget.cy.spec.js
+++ b/frontend/test/metabase-visual/dashboard/parameters-widget.cy.spec.js
@@ -48,7 +48,7 @@ describe(`visual tests > dashboard > parameters widget`, () => {
       });
     });
 
-    describe(`desktop`, () => {
+    describe("desktop", () => {
       it("is sticky in view mode", () => {
         cy.get("main")
           .scrollTo(0, 264)
@@ -63,7 +63,7 @@ describe(`visual tests > dashboard > parameters widget`, () => {
         );
       });
 
-      it("is sticky in edit mode", () => {
+      it("is not sticky in edit mode", () => {
         cy.icon("pencil").click();
 
         cy.findByTestId("dashboard-parameters-and-cards")
@@ -101,7 +101,7 @@ describe(`visual tests > dashboard > parameters widget`, () => {
           );
         });
 
-        it("is sticky in edit mode", () => {
+        it("is not sticky in edit mode", () => {
           cy.icon("pencil").click();
 
           cy.findByTestId("dashboard-parameters-and-cards")
@@ -147,7 +147,7 @@ describe(`visual tests > dashboard > parameters widget`, () => {
       });
     });
 
-    describe(`desktop`, () => {
+    describe("desktop", () => {
       it("is sticky in view mode", () => {
         cy.get("main")
           .scrollTo(0, 264)
@@ -162,7 +162,7 @@ describe(`visual tests > dashboard > parameters widget`, () => {
         );
       });
 
-      it("is sticky in edit mode", () => {
+      it("is not sticky in edit mode", () => {
         cy.findByText("test question");
 
         cy.icon("pencil").click();

--- a/frontend/test/metabase-visual/dashboard/parameters-widget.cy.spec.js
+++ b/frontend/test/metabase-visual/dashboard/parameters-widget.cy.spec.js
@@ -163,8 +163,6 @@ describe(`visual tests > dashboard > parameters widget`, () => {
       });
 
       it("is not sticky in edit mode", () => {
-        cy.findByText("test question");
-
         cy.icon("pencil").click();
 
         cy.findByTestId("dashboard-parameters-and-cards")

--- a/frontend/test/metabase-visual/dashboard/parameters-widget.cy.spec.js
+++ b/frontend/test/metabase-visual/dashboard/parameters-widget.cy.spec.js
@@ -1,4 +1,8 @@
-import { restore, visitDashboard } from "__support__/e2e/helpers";
+import {
+  restore,
+  visitDashboard,
+  editDashboard,
+} from "__support__/e2e/helpers";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
 const { PRODUCTS_ID } = SAMPLE_DATABASE;
@@ -64,7 +68,7 @@ describe(`visual tests > dashboard > parameters widget`, () => {
       });
 
       it("is not sticky in edit mode", () => {
-        cy.icon("pencil").click();
+        editDashboard();
 
         cy.findByTestId("dashboard-parameters-and-cards")
           .scrollTo(0, 464)
@@ -102,7 +106,7 @@ describe(`visual tests > dashboard > parameters widget`, () => {
         });
 
         it("is not sticky in edit mode", () => {
-          cy.icon("pencil").click();
+          editDashboard();
 
           cy.findByTestId("dashboard-parameters-and-cards")
             .scrollTo(0, 464)
@@ -163,7 +167,7 @@ describe(`visual tests > dashboard > parameters widget`, () => {
       });
 
       it("is not sticky in edit mode", () => {
-        cy.icon("pencil").click();
+        editDashboard();
 
         cy.findByTestId("dashboard-parameters-and-cards")
           .scrollTo(0, 464)
@@ -201,7 +205,7 @@ describe(`visual tests > dashboard > parameters widget`, () => {
         });
 
         it("is not sticky in edit mode", () => {
-          cy.icon("pencil").click();
+          editDashboard();
 
           cy.findByTestId("dashboard-parameters-and-cards")
             .scrollTo(0, 464)

--- a/frontend/test/metabase-visual/dashboard/parameters-widget.cy.spec.js
+++ b/frontend/test/metabase-visual/dashboard/parameters-widget.cy.spec.js
@@ -80,41 +80,44 @@ describe(`visual tests > dashboard > parameters widget`, () => {
       });
     });
 
-    describe(`mobile`, () => {
-      it("is sticky in view mode", () => {
-        cy.viewport(MOBILE_WIDTH, 667);
+    describe(
+      "mobile",
+      {
+        viewportHeight: 667,
+        viewportWidth: MOBILE_WIDTH,
+      },
+      () => {
+        it("is sticky in view mode", () => {
+          cy.get("main")
+            .scrollTo(0, 264)
+            .then(() => {
+              cy.createPercySnapshot(null, { widths: [MOBILE_WIDTH] });
+            });
 
-        cy.get("main")
-          .scrollTo(0, 264)
-          .then(() => {
-            cy.createPercySnapshot(null, { widths: [MOBILE_WIDTH] });
-          });
+          cy.findByTestId("dashboard-parameters-widget-container").should(
+            "have.css",
+            "position",
+            "fixed",
+          );
+        });
 
-        cy.findByTestId("dashboard-parameters-widget-container").should(
-          "have.css",
-          "position",
-          "fixed",
-        );
-      });
+        it("is sticky in edit mode", () => {
+          cy.icon("pencil").click();
 
-      it("is sticky in edit mode", () => {
-        cy.viewport(MOBILE_WIDTH, 667);
+          cy.findByTestId("dashboard-parameters-and-cards")
+            .scrollTo(0, 464)
+            .then(() => {
+              cy.createPercySnapshot(null, { widths: [MOBILE_WIDTH] });
+            });
 
-        cy.icon("pencil").click();
-
-        cy.findByTestId("dashboard-parameters-and-cards")
-          .scrollTo(0, 464)
-          .then(() => {
-            cy.createPercySnapshot(null, { widths: [MOBILE_WIDTH] });
-          });
-
-        cy.findByTestId("edit-dashboard-parameters-widget-container").should(
-          "not.have.css",
-          "position",
-          "fixed",
-        );
-      });
-    });
+          cy.findByTestId("edit-dashboard-parameters-widget-container").should(
+            "not.have.css",
+            "position",
+            "fixed",
+          );
+        });
+      },
+    );
   });
 
   describe(`${parametersLong.length} filters (non sticky on mobile)`, () => {
@@ -178,40 +181,43 @@ describe(`visual tests > dashboard > parameters widget`, () => {
       });
     });
 
-    describe(`mobile`, () => {
-      it("is not sticky in view mode", () => {
-        cy.viewport(MOBILE_WIDTH, 667);
+    describe(
+      "mobile",
+      {
+        viewportHeight: 667,
+        viewportWidth: MOBILE_WIDTH,
+      },
+      () => {
+        it("is not sticky in view mode", () => {
+          cy.get("main")
+            .scrollTo(0, 264)
+            .then(() => {
+              cy.createPercySnapshot(null, { widths: [MOBILE_WIDTH] });
+            });
 
-        cy.get("main")
-          .scrollTo(0, 264)
-          .then(() => {
-            cy.createPercySnapshot(null, { widths: [MOBILE_WIDTH] });
-          });
+          cy.findByTestId("dashboard-parameters-widget-container").should(
+            "not.have.css",
+            "position",
+            "fixed",
+          );
+        });
 
-        cy.findByTestId("dashboard-parameters-widget-container").should(
-          "not.have.css",
-          "position",
-          "fixed",
-        );
-      });
+        it("is not sticky in edit mode", () => {
+          cy.icon("pencil").click();
 
-      it("is not sticky in edit mode", () => {
-        cy.viewport(MOBILE_WIDTH, 667);
+          cy.findByTestId("dashboard-parameters-and-cards")
+            .scrollTo(0, 464)
+            .then(() => {
+              cy.createPercySnapshot(null, { widths: [MOBILE_WIDTH] });
+            });
 
-        cy.icon("pencil").click();
-
-        cy.findByTestId("dashboard-parameters-and-cards")
-          .scrollTo(0, 464)
-          .then(() => {
-            cy.createPercySnapshot(null, { widths: [MOBILE_WIDTH] });
-          });
-
-        cy.findByTestId("edit-dashboard-parameters-widget-container").should(
-          "not.have.css",
-          "position",
-          "fixed",
-        );
-      });
-    });
+          cy.findByTestId("edit-dashboard-parameters-widget-container").should(
+            "not.have.css",
+            "position",
+            "fixed",
+          );
+        });
+      },
+    );
   });
 });

--- a/frontend/test/metabase-visual/dashboard/parameters-widget.cy.spec.js
+++ b/frontend/test/metabase-visual/dashboard/parameters-widget.cy.spec.js
@@ -4,7 +4,7 @@ import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 const { PRODUCTS_ID } = SAMPLE_DATABASE;
 
 const questionDetails = {
-  query: { "source-table": PRODUCTS_ID },
+  query: { "source-table": PRODUCTS_ID, limit: 2 },
 };
 
 const parameter = {


### PR DESCRIPTION
Cypress was complaining that the icon "pencil" is still animating when it tries to click on it.
https://docs.cypress.io/guides/references/error-messages#cy-failed-because-the-element-is-currently-animating

Example of a failed run:
https://github.com/metabase/metabase/actions/runs/4251521072/jobs/7394267149#step:10:442

This was happening because we started all mobile tests from the desktop view.
Then we resized the window in the middle of the test.

The actual fix is https://github.com/metabase/metabase/commit/2f019fbbf24e4466de92ad23ff42aecc3af9feba

Explanation:
Using the test config object and setting the viewport size there removes the need for resizing in the middle of the test.

### Additional notes:
- This PR also fixes incorrect test titles