### PR TITLE
[CI] Increase E2E tests timeout

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -61,7 +61,7 @@ jobs:
       needs.files-changed.outputs.e2e_all == 'true' &&
       needs.build.result == 'success'
     runs-on: ubuntu-20.04
-    timeout-minutes: 45
+    timeout-minutes: 60
     name: e2e-tests-${{ matrix.folder }}${{ matrix.context }}-${{ matrix.edition }}
     env:
       MB_EDITION: ${{ matrix.edition }}


### PR DESCRIPTION
Related to this issue: #28577

This PR is needed to unblock CI as `e2e-visualizations-ee` is timing out more often than not.

> **Warning**
> This PR is committed with the `[ci skip]` flag and will need force-merging. I've made a conscious decision about this in order to save a bunch of CI cycles for the rest of the team. Because the diff touches a file in `.github/` folder, it would trigger literally all our test checks for nothing. 