### PR TITLE
Clean up GroupMappingsWidget unit test

### DIFF
--- a/frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget/GroupMappingsWidget.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget/GroupMappingsWidget.unit.spec.tsx
@@ -51,12 +51,9 @@ describe("GroupMappingsWidget", () => {
       // Confirm remove
       userEvent.click(screen.getByText("Yes"));
 
-      await waitFor(
-        () => {
-          expect(onChangeSettingSpy).toHaveBeenCalledTimes(1);
-        },
-        { timeout: 10000 },
-      );
+      await waitFor(() => {
+        expect(onChangeSettingSpy).toHaveBeenCalledTimes(1);
+      });
     });
   });
 
@@ -112,7 +109,7 @@ describe("GroupMappingsWidget", () => {
 
     it("handles deleting mapped groups after deleting mapping", async () => {
       fetchMock.delete("path:/api/permissions/group/3", 200);
-      fetchMock.delete("/api/permissions/group/4", 200);
+      fetchMock.delete("path:/api/permissions/group/4", 200);
       setup();
 
       expect(await screen.findByText("cn=People")).toBeInTheDocument();


### PR DESCRIPTION
With fetch-mock, we hope we won't need timeouts inside waitFor functions.

Plus a path tweak without which the test was passing but with an error.