### PR TITLE
[CI] optimize JUnit report generation for backend tests

### DIFF
--- a/.github/actions/test-driver/action.yml
+++ b/.github/actions/test-driver/action.yml
@@ -28,5 +28,5 @@ runs:
         path: 'target/junit/**/*_test.xml'
         name: JUnit Test Report ${{ inputs.junit-name }}
         reporter: java-junit
-        limit-suites: failed
-        limit-tests: failed
+        list-suites: failed
+        list-tests: failed

--- a/.github/actions/test-driver/action.yml
+++ b/.github/actions/test-driver/action.yml
@@ -23,8 +23,10 @@ runs:
       shell: bash
     - name: Publish Test Report (JUnit)
       uses: dorny/test-reporter@v1
-      if: always()
+      if: failure()
       with:
         path: 'target/junit/**/*_test.xml'
         name: JUnit Test Report ${{ inputs.junit-name }}
         reporter: java-junit
+        limit-suites: failed
+        limit-tests: failed

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -139,11 +139,13 @@ jobs:
 
     - name: Publish Test Report (JUnit)
       uses: dorny/test-reporter@v1
-      if: always()
+      if: failure()
       with:
         path: 'target/junit/**/*_test.xml'
         name: JUnit Test Report be-tests-java-11-ee-pre-check
         reporter: java-junit
+        limit-suites: failed
+        limit-tests: failed
 
   be-tests:
     needs: files-changed
@@ -174,11 +176,13 @@ jobs:
 
     - name: Publish Test Report (JUnit)
       uses: dorny/test-reporter@v1
-      if: always()
+      if: failure()
       with:
         path: 'target/junit/**/*_test.xml'
         name: JUnit Test Report be-tests-java-${{ matrix.java-version }}-${{ matrix.edition }}
         reporter: java-junit
+        limit-suites: failed
+        limit-tests: failed
 
   be-tests-stub:
     needs: files-changed

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -144,8 +144,8 @@ jobs:
         path: 'target/junit/**/*_test.xml'
         name: JUnit Test Report be-tests-java-11-ee-pre-check
         reporter: java-junit
-        limit-suites: failed
-        limit-tests: failed
+        list-suites: failed
+        list-tests: failed
 
   be-tests:
     needs: files-changed
@@ -181,8 +181,8 @@ jobs:
         path: 'target/junit/**/*_test.xml'
         name: JUnit Test Report be-tests-java-${{ matrix.java-version }}-${{ matrix.edition }}
         reporter: java-junit
-        limit-suites: failed
-        limit-tests: failed
+        list-suites: failed
+        list-tests: failed
 
   be-tests-stub:
     needs: files-changed


### PR DESCRIPTION
[HTML reports](https://github.com/metabase/metabase/runs/11502914131) that [`dorny/test-reporter`](https://github.com/dorny/test-reporter) creates have proven to be useful for debugging failed backend tests.

However, we didn't really optimize its usage:
1. our test reports are too long and have to be trimmed (which probably causes https://github.com/metabase/metabase/issues/28509)
    - `Warning: Test report summary exceeded limit of 65535 bytes and will be trimmed`
2. we print those reports even for tests that are passing (which mostly nobody cares about) - they just create noise

### What does this PR accomplish?
1. Generates said report **only if test fails**
2. Prints only failed tests in the report, which should prevent "too long outputs" that need to be trimmed

