### PR TITLE
Fix language selector not scrolling with keyboard

### DIFF
--- a/frontend/src/metabase/components/Popover/Popover.jsx
+++ b/frontend/src/metabase/components/Popover/Popover.jsx
@@ -240,14 +240,11 @@ export default class Popover extends Component {
       >
         {typeof this.props.children === "function"
           ? this.props.children(childProps)
-          : React.Children.count(this.props.children) === 1 &&
-            // NOTE: workaround for https://github.com/facebook/react/issues/12136
-            !Array.isArray(this.props.children)
-          ? React.cloneElement(
-              React.Children.only(this.props.children),
-              childProps,
-            )
-          : this.props.children}
+          : React.Children.map(this.props.children, child =>
+              React.isValidElement(child)
+                ? React.cloneElement(child, childProps)
+                : child,
+            )}
       </div>
     );
     if (this.props.noOnClickOutsideWrapper) {

--- a/frontend/src/metabase/components/Popover/Popover.unit.spec.tsx
+++ b/frontend/src/metabase/components/Popover/Popover.unit.spec.tsx
@@ -1,0 +1,85 @@
+import { render, screen } from "@testing-library/react";
+import React, { ReactNode, useRef } from "react";
+import Popover from "./Popover";
+
+interface TestChildComponentProps {
+  maxHeight?: number;
+}
+
+function TestChildComponent({ maxHeight }: TestChildComponentProps) {
+  return (
+    <>
+      <div>child component</div>
+      {maxHeight && <div>has max height</div>}
+    </>
+  );
+}
+
+interface TestComponentProps {
+  children: ReactNode;
+  isOpen: boolean;
+}
+
+function TestComponent({ children, isOpen }: TestComponentProps) {
+  const targetRef = useRef<HTMLDivElement>(null);
+
+  return (
+    <div ref={targetRef}>
+      <Popover target={targetRef.current} isOpen={isOpen}>
+        {children}
+      </Popover>
+    </div>
+  );
+}
+
+interface SetupProps {
+  popoverContent?: ReactNode;
+  isOpen?: boolean;
+}
+
+function setup({
+  popoverContent = <TestChildComponent />,
+  isOpen = true,
+}: SetupProps) {
+  render(<TestComponent isOpen={isOpen}>{popoverContent}</TestComponent>);
+}
+
+describe("Popover", () => {
+  it("should render its children when 'isOpen' is true", () => {
+    setup({});
+    expect(screen.getByText("child component")).toBeInTheDocument();
+  });
+
+  it("should not render its children when 'isOpen' is false", () => {
+    setup({ isOpen: false });
+    expect(screen.queryByText("child component")).not.toBeInTheDocument();
+  });
+
+  it("should provide a 'maxHeight' prop to a single child", () => {
+    setup({});
+    expect(screen.getByText("has max height")).toBeInTheDocument();
+  });
+
+  it("should provide a 'maxHeight' prop to multiple children", () => {
+    setup({
+      popoverContent: [
+        <TestChildComponent key={0} />,
+        <TestChildComponent key={1} />,
+      ],
+    });
+    expect(screen.getAllByText("has max height").length).toEqual(2);
+  });
+
+  it("should provide a 'maxHeight' prop to a function child", () => {
+    const popoverContent = ({ maxHeight }: { maxHeight: number }) => (
+      <>
+        <TestChildComponent maxHeight={maxHeight} />
+        <TestChildComponent />
+      </>
+    );
+    setup({
+      popoverContent,
+    });
+    expect(screen.getAllByText("has max height").length).toEqual(1);
+  });
+});


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/28345

### Description

The language picker in the account settings page was not scrolling when the user selected a non-visible option with their keyboard. The problem was that the `Popover` component was not passing the `maxHeight` prop to `AccordionList`. I fixed this by refactoring the code in `Popover` to make sure `childProps` were being given in the case that `this.props.children` was an array of multiple children, which was not being done previously.

_Note: this fixes the problem for many other use cases of the `AccordianList` component. However, some uses like the filter picker in the notebook editor still do not scroll properly. I will file a separate issue to track that._

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Settings -> Account settings -> Language
2. Try navigating through select menu with keyboard, confirm it scrolls

### Demo

https://user-images.githubusercontent.com/37751258/221035626-464fa64d-9aca-4910-921e-17afc43721bd.mov

### Checklist

- [✅] Tests have been added/updated to cover changes in this PR
