### PR TITLE
[CI] Run Frontend and Drivers tests on Ubuntu 22.04

### DIFF
--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   files-changed:
     name: Check which files changed
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 3
     outputs:
       backend_all: ${{ steps.changes.outputs.backend_all }}
@@ -31,7 +31,7 @@ jobs:
   be-tests-athena-ee:
     needs: files-changed
     if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 60
     env:
       CI: 'true'
@@ -51,7 +51,7 @@ jobs:
   be-tests-bigquery-cloud-sdk-ee:
     needs: files-changed
     if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 60
     env:
       CI: 'true'
@@ -73,7 +73,7 @@ jobs:
   be-tests-druid-ee:
     needs: files-changed
     if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
-    runs-on: buildjet-2vcpu-ubuntu-2004
+    runs-on: buildjet-2vcpu-ubuntu-2204
     timeout-minutes: 60
     env:
       CI: 'true'
@@ -96,7 +96,7 @@ jobs:
   be-tests-googleanalytics-ee:
     needs: files-changed
     if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 60
     env:
       CI: 'true'
@@ -112,7 +112,7 @@ jobs:
   be-google-related-drivers-classpath-test:
     needs: files-changed
     if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 60
     env:
       CI: 'true'
@@ -134,7 +134,7 @@ jobs:
   be-tests-mariadb-10-2-ee:
     needs: files-changed
     if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 60
     env:
       CI: 'true'
@@ -160,7 +160,7 @@ jobs:
   be-tests-mariadb-latest-ee:
     needs: files-changed
     if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 60
     env:
       CI: 'true'
@@ -186,7 +186,7 @@ jobs:
   be-tests-mongo-4-2-ee:
     needs: files-changed
     if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 60
     env:
       CI: 'true'
@@ -209,7 +209,7 @@ jobs:
   be-tests-mongo-4-2-ssl-ee:
     needs: files-changed
     if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 60
     env:
       CI: 'true'
@@ -244,7 +244,7 @@ jobs:
   be-tests-mongo-5-0-ee:
     needs: files-changed
     if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 60
     env:
       CI: 'true'
@@ -267,7 +267,7 @@ jobs:
   be-tests-mongo-5-0-ssl-ee:
     needs: files-changed
     if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 60
     env:
       CI: 'true'
@@ -302,7 +302,7 @@ jobs:
   be-tests-mongo-latest-ee:
     needs: files-changed
     if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 60
     env:
       CI: 'true'
@@ -328,7 +328,7 @@ jobs:
   be-tests-mysql-5-7-ee:
     needs: files-changed
     if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 60
     env:
       CI: 'true'
@@ -354,7 +354,7 @@ jobs:
   be-tests-mysql-latest-ee:
     needs: files-changed
     if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 60
     env:
       CI: 'true'
@@ -392,7 +392,7 @@ jobs:
   be-tests-oracle-18-4-ee:
     needs: files-changed
     if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 60
     env:
       CI: 'true'
@@ -419,7 +419,7 @@ jobs:
   be-tests-oracle-21-3-ee:
     needs: files-changed
     if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 60
     env:
       CI: 'true'
@@ -455,7 +455,7 @@ jobs:
   be-tests-postgres-ee:
     needs: files-changed
     if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 60
     env:
       CI: 'true'
@@ -484,7 +484,7 @@ jobs:
   be-tests-postgres-latest-ee:
     needs: files-changed
     if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 60
     env:
       CI: 'true'
@@ -517,7 +517,7 @@ jobs:
   be-tests-presto-jdbc-ee:
     needs: files-changed
     if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 60
     env:
       CI: 'true'
@@ -569,7 +569,7 @@ jobs:
   be-tests-redshift-ee:
     needs: files-changed
     if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 60
     env:
       CI: 'true'
@@ -589,7 +589,7 @@ jobs:
   be-tests-snowflake-ee:
     needs: files-changed
     if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 60
     env:
       CI: 'true'
@@ -611,7 +611,7 @@ jobs:
   be-tests-sparksql-ee:
     needs: files-changed
     if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
-    runs-on: buildjet-2vcpu-ubuntu-2004
+    runs-on: buildjet-2vcpu-ubuntu-2204
     timeout-minutes: 60
     env:
       CI: 'true'
@@ -632,7 +632,7 @@ jobs:
   be-tests-sqlite-ee:
     needs: files-changed
     if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 60
     env:
       CI: 'true'
@@ -648,7 +648,7 @@ jobs:
   be-tests-sqlserver-ee:
     needs: files-changed
     if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 60
     env:
       CI: 'true'
@@ -676,7 +676,7 @@ jobs:
   be-tests-vertica-ee:
     needs: files-changed
     if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 60
     env:
       CI: 'true'

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -563,8 +563,9 @@ jobs:
       with:
         junit-name: 'be-tests-presto-jdbc-ee'
         test-args: ":exclude-tags '[:mb/once]'"
-    - name: Capture max memory usage
-      run: cat /sys/fs/cgroup/memory/memory.max_usage_in_bytes
+    # FIXME: Cannot find it in Ubuntu 22.04 (No such file or directory)
+    # - name: Capture max memory usage
+    #   run: cat /sys/fs/cgroup/memory/memory.max_usage_in_bytes
 
   be-tests-redshift-ee:
     needs: files-changed

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   files-changed:
     name: Check which files changed
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 3
     outputs:
       frontend_all: ${{ steps.changes.outputs.frontend_all }}
@@ -31,7 +31,7 @@ jobs:
   fe-linter-prettier:
     needs: files-changed
     if: needs.files-changed.outputs.frontend_all == 'true'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 10
     steps:
     - uses: actions/checkout@v3
@@ -43,7 +43,7 @@ jobs:
   fe-linter-eslint:
     needs: files-changed
     if: needs.files-changed.outputs.frontend_all == 'true'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 20
     steps:
     - uses: actions/checkout@v3
@@ -59,7 +59,7 @@ jobs:
   fe-type-check:
     needs: files-changed
     if: needs.files-changed.outputs.frontend_all == 'true'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 10
     steps:
     - uses: actions/checkout@v3
@@ -77,7 +77,7 @@ jobs:
   fe-tests-unit:
     needs: files-changed
     if: github.event.pull_request.draft == false && needs.files-changed.outputs.frontend_all == 'true'
-    runs-on: buildjet-2vcpu-ubuntu-2004
+    runs-on: buildjet-2vcpu-ubuntu-2204
     timeout-minutes: 30
     steps:
     - uses: actions/checkout@v3
@@ -98,7 +98,7 @@ jobs:
   fe-tests-timezones:
     needs: files-changed
     if: github.event.pull_request.draft == false && needs.files-changed.outputs.frontend_all == 'true'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 14
     steps:
     - uses: actions/checkout@v3
@@ -114,7 +114,7 @@ jobs:
   fe-chromatic:
     needs: files-changed
     if: github.event.pull_request.draft == false && needs.files-changed.outputs.frontend_all == 'true'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3


### PR DESCRIPTION
We have to start running all our tests on the latest ubuntu images (22.04)

This PR first moves Frontend and Drivers tests for two reasons:
- custom `buildjet-2vcpu-ubuntu-2004` have been timing out a lot and I hope that the latest ubuntu images might have less network issues
- "re-run" workflow started failing every time it needs to re-run Driver of Frontend workflow
    - this was pointing to the [differences in custom BuildJet runners vs hosted GitHub runners](https://buildjet.com/for-github-actions/docs/runners#known-differences-between-buildjet-and-github-actions)
