### PR TITLE
[E2E] Fix flaky `native-filters` test (21246 repro)

### DIFF
--- a/frontend/test/metabase/scenarios/native-filters/reproductions/21246.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native-filters/reproductions/21246.cy.spec.js
@@ -9,6 +9,8 @@ const questionDetails = {
 
 describe("issue 21246", () => {
   beforeEach(() => {
+    cy.intercept("POST", "/api/dataset").as("dataset");
+
     restore();
     cy.signInAsAdmin();
 
@@ -53,6 +55,8 @@ describe("issue 21246", () => {
 
       cy.get("@questionId").then(id => {
         cy.visit(`/question/${id}`);
+        cy.wait("@dataset");
+
         cy.get(".ScalarValue").invoke("text").should("eq", "18,760");
       });
     });
@@ -66,10 +70,12 @@ describe("issue 21246", () => {
       // Let's set filter values directly through URL, rather than through the UI
       // for the sake of speed and reliability
       cy.visit(`/question/${id}?${fieldFilterValue}`);
+      cy.wait("@dataset");
 
       resultAssertion("404");
 
       cy.visit(`/question/${id}?${fieldFilterValue}&${dateFilterValue}`);
+      cy.wait("@dataset");
 
       resultAssertion("12");
     });


### PR DESCRIPTION
I was able to reproduce the failure on 2 GHz Quad-Core Intel Core i5, 16 GB 3733 MHz LPDDR4X which is still more than two times faster than the default GitHub hosted runner.

Example of a failed run: https://www.deploysentinel.com/ci/runs/63f77f61c49013addc71544a

We're now explicitly waiting for the dataset to come back before we can assert on the result.