### PR TITLE
Env var to control retention of `query_execution` data

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/task/truncate_audit_log.clj
+++ b/enterprise/backend/src/metabase_enterprise/task/truncate_audit_log.clj
@@ -1,0 +1,18 @@
+(ns metabase-enterprise.task.truncate-audit-log
+  "EE implementation of the `audit-max-retention-days` setting, used to determine the retention policy for audit tables."
+  (:require
+   [metabase.models.setting :as setting]
+   [metabase.models.setting.multi-setting
+    :refer [define-multi-setting-impl]]
+   [metabase.task.truncate-audit-log :as task.truncate-audit-log]
+   [metabase.public-settings.premium-features :as premium-features]))
+
+(define-multi-setting-impl task.truncate-audit-log/audit-max-retention-days :ee
+  :getter (fn []
+            (let [env-var-value (setting/get-value-of-type :integer :audit-max-retention-days)]
+              (cond
+                (nil? env-var-value)  365
+                (zero? env-var-value) ##Inf
+                (< 30 env-var-value)  30
+                :else                 env-var-value))))
+

--- a/enterprise/backend/src/metabase_enterprise/task/truncate_audit_log.clj
+++ b/enterprise/backend/src/metabase_enterprise/task/truncate_audit_log.clj
@@ -4,15 +4,13 @@
    [metabase.models.setting :as setting]
    [metabase.models.setting.multi-setting
     :refer [define-multi-setting-impl]]
-   [metabase.task.truncate-audit-log :as task.truncate-audit-log]
-   [metabase.public-settings.premium-features :as premium-features]))
+   [metabase.task.truncate-audit-log :as task.truncate-audit-log]))
 
 (define-multi-setting-impl task.truncate-audit-log/audit-max-retention-days :ee
   :getter (fn []
             (let [env-var-value (setting/get-value-of-type :integer :audit-max-retention-days)]
               (cond
-                (nil? env-var-value)  365
+                (nil? env-var-value)  ##Inf
                 (zero? env-var-value) ##Inf
-                (< 30 env-var-value)  30
+                (< env-var-value 30)  30
                 :else                 env-var-value))))
-

--- a/enterprise/backend/src/metabase_enterprise/task/truncate_audit_log.clj
+++ b/enterprise/backend/src/metabase_enterprise/task/truncate_audit_log.clj
@@ -11,10 +11,10 @@
             (let [env-var-value      (setting/get-value-of-type :integer :audit-max-retention-days)
                   min-retention-days truncate-audit-log.i/min-retention-days]
               (cond
-                (nil? env-var-value)    ##Inf
-                (zero? env-var-value)   ##Inf
+                (nil? env-var-value)   ##Inf
+                (zero? env-var-value)  ##Inf
                 (< env-var-value
-                   min-retention-days)  (do
-                                          (truncate-audit-log.i/log-minimum-value-warning env-var-value)
-                                          min-retention-days)
-                :else                   env-var-value))))
+                   min-retention-days) (do
+                                         (truncate-audit-log.i/log-minimum-value-warning env-var-value)
+                                         min-retention-days)
+                :else                  env-var-value))))

--- a/enterprise/backend/src/metabase_enterprise/task/truncate_audit_log.clj
+++ b/enterprise/backend/src/metabase_enterprise/task/truncate_audit_log.clj
@@ -4,17 +4,17 @@
    [metabase.models.setting :as setting]
    [metabase.models.setting.multi-setting
     :refer [define-multi-setting-impl]]
-   [metabase.task.truncate-audit-log :as task.truncate-audit-log]))
+   [metabase.task.truncate-audit-log.interface :as truncate-audit-log.i]))
 
-(define-multi-setting-impl task.truncate-audit-log/audit-max-retention-days :ee
+(define-multi-setting-impl truncate-audit-log.i/audit-max-retention-days :ee
   :getter (fn []
             (let [env-var-value      (setting/get-value-of-type :integer :audit-max-retention-days)
-                  min-retention-days task.truncate-audit-log/min-retention-days]
+                  min-retention-days truncate-audit-log.i/min-retention-days]
               (cond
                 (nil? env-var-value)    ##Inf
                 (zero? env-var-value)   ##Inf
                 (< env-var-value
                    min-retention-days)  (do
-                                          (task.truncate-audit-log/log-minimum-value-warning min-retention-days)
+                                          (truncate-audit-log.i/log-minimum-value-warning env-var-value)
                                           min-retention-days)
                 :else                   env-var-value))))

--- a/enterprise/backend/src/metabase_enterprise/task/truncate_audit_log.clj
+++ b/enterprise/backend/src/metabase_enterprise/task/truncate_audit_log.clj
@@ -8,9 +8,13 @@
 
 (define-multi-setting-impl task.truncate-audit-log/audit-max-retention-days :ee
   :getter (fn []
-            (let [env-var-value (setting/get-value-of-type :integer :audit-max-retention-days)]
+            (let [env-var-value      (setting/get-value-of-type :integer :audit-max-retention-days)
+                  min-retention-days task.truncate-audit-log/min-retention-days]
               (cond
-                (nil? env-var-value)  ##Inf
-                (zero? env-var-value) ##Inf
-                (< env-var-value 30)  30
-                :else                 env-var-value))))
+                (nil? env-var-value)    ##Inf
+                (zero? env-var-value)   ##Inf
+                (< env-var-value
+                   min-retention-days)  (do
+                                          (task.truncate-audit-log/log-minimum-value-warning min-retention-days)
+                                          min-retention-days)
+                :else                   env-var-value))))

--- a/enterprise/backend/test/metabase_enterprise/task/truncate_audit_log_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/task/truncate_audit_log_test.clj
@@ -1,0 +1,27 @@
+(ns metabase-enterprise.task.truncate-audit-log-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase.models.setting :as setting]
+   [metabase.public-settings.premium-features :as premium-features]
+   [metabase.task.truncate-audit-log :as task.truncate-audit-log]
+   [metabase.test :as mt]))
+
+(deftest audit-max-retention-days-test
+  ;; Tests for the OSS & Cloud implementations are in `metabase.task.truncate-audit-log-test`
+  (with-redefs [premium-features/enable-advanced-config? (constantly true)]
+    (is (= ##Inf (task.truncate-audit-log/audit-max-retention-days)))
+
+    (mt/with-temp-env-var-value [mb-audit-max-retention-days 0]
+      (is (= ##Inf (task.truncate-audit-log/audit-max-retention-days))))
+
+    (mt/with-temp-env-var-value [mb-audit-max-retention-days 100]
+      (is (= 100 (task.truncate-audit-log/audit-max-retention-days))))
+
+    ;; Acceptable values have a lower bound of 30
+    (mt/with-temp-env-var-value [mb-audit-max-retention-days 1]
+      (is (= 30 (task.truncate-audit-log/audit-max-retention-days))))
+
+    (is (thrown-with-msg?
+         java.lang.UnsupportedOperationException
+         #"You cannot set audit-max-retention-days"
+         (setting/set! :audit-max-retention-days 30)))))

--- a/enterprise/backend/test/metabase_enterprise/task/truncate_audit_log_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/task/truncate_audit_log_test.clj
@@ -3,23 +3,23 @@
    [clojure.test :refer :all]
    [metabase.models.setting :as setting]
    [metabase.public-settings.premium-features :as premium-features]
-   [metabase.task.truncate-audit-log :as task.truncate-audit-log]
+   [metabase.task.truncate-audit-log.interface :as truncate-audit-log.i]
    [metabase.test :as mt]))
 
 (deftest audit-max-retention-days-test
   ;; Tests for the OSS & Cloud implementations are in `metabase.task.truncate-audit-log-test`
   (with-redefs [premium-features/enable-advanced-config? (constantly true)]
-    (is (= ##Inf (task.truncate-audit-log/audit-max-retention-days)))
+    (is (= ##Inf (truncate-audit-log.i/audit-max-retention-days)))
 
     (mt/with-temp-env-var-value [mb-audit-max-retention-days 0]
-      (is (= ##Inf (task.truncate-audit-log/audit-max-retention-days))))
+      (is (= ##Inf (truncate-audit-log.i/audit-max-retention-days))))
 
     (mt/with-temp-env-var-value [mb-audit-max-retention-days 100]
-      (is (= 100 (task.truncate-audit-log/audit-max-retention-days))))
+      (is (= 100 (truncate-audit-log.i/audit-max-retention-days))))
 
     ;; Acceptable values have a lower bound of 30
     (mt/with-temp-env-var-value [mb-audit-max-retention-days 1]
-      (is (= 30 (task.truncate-audit-log/audit-max-retention-days))))
+      (is (= 30 (truncate-audit-log.i/audit-max-retention-days))))
 
     (is (thrown-with-msg?
          java.lang.UnsupportedOperationException

--- a/src/metabase/task/truncate_audit_log.clj
+++ b/src/metabase/task/truncate_audit_log.clj
@@ -31,10 +31,9 @@
               ##Inf
               (let [env-var-value (setting/get-value-of-type :integer :audit-max-retention-days)]
                   (cond
-                    (nil? env-var-value)  365
-                    (zero? env-var-value) ##Inf
-                    (< env-var-value 30)  30
-                    :else                 env-var-value)))))
+                    ((some-fn nil? zero?) env-var-value)  ##Inf
+                    (< env-var-value 30)                  30
+                    :else                                 env-var-value)))))
 
 (defn- query-execution-cleanup!
   "Delete QueryExecution rows older than the configured threshold."

--- a/src/metabase/task/truncate_audit_log.clj
+++ b/src/metabase/task/truncate_audit_log.clj
@@ -25,12 +25,12 @@
 (define-multi-setting-impl audit-max-retention-days :oss
   :getter (fn []
             (if-not (premium-features/is-hosted?)
-              30
+              ##Inf
               (let [env-var-value (setting/get-value-of-type :integer :audit-max-retention-days)]
                   (cond
                     (nil? env-var-value)  365
                     (zero? env-var-value) ##Inf
-                    (< 30 env-var-value)  30
+                    (< env-var-value 30)  30
                     :else                 env-var-value)))))
 
 (jobs/defjob ^{:doc "Triggers the removal of `query_execution` rows older than the configured threshold."} TruncateAuditLog [_]

--- a/src/metabase/task/truncate_audit_log.clj
+++ b/src/metabase/task/truncate_audit_log.clj
@@ -1,0 +1,58 @@
+(ns metabase.task.truncate-audit-log
+  "Tasks for truncating audit log tables, such as `query_execution`, based on a configured retention policy."
+  (:require
+   [clojurewerkz.quartzite.jobs :as jobs]
+   [clojurewerkz.quartzite.schedule.cron :as cron]
+   [clojurewerkz.quartzite.triggers :as triggers]
+   [metabase.config :as config]
+   [metabase.models.setting :as setting]
+   [metabase.models.setting.multi-setting
+    :refer [define-multi-setting define-multi-setting-impl]]
+   [metabase.public-settings.premium-features :as premium-features]
+   [metabase.task :as task]
+   [metabase.util.i18n :refer [deferred-tru trs]]
+   [metabase.util.log :as log]
+   [toucan2.core :as t2]))
+
+(set! *warn-on-reflection* true)
+
+(define-multi-setting audit-max-retention-days
+  (deferred-tru "Retention policy for the `query_execution` table.")
+  (fn [] (if (and config/ee-available? (premium-features/enable-advanced-config?)) :ee :oss))
+  :visibility :internal
+  :setter     :none)
+
+(define-multi-setting-impl audit-max-retention-days :oss
+  :getter (fn []
+            (if-not (premium-features/is-hosted?)
+              30
+              (let [env-var-value (setting/get-value-of-type :integer :audit-max-retention-days)]
+                  (cond
+                    (nil? env-var-value)  365
+                    (zero? env-var-value) ##Inf
+                    (< 30 env-var-value)  30
+                    :else                 env-var-value)))))
+
+(jobs/defjob ^{:doc "Triggers the removal of `query_execution` rows older than the configured threshold."} TruncateAuditLog [_]
+  (try
+    (when-not (infinite? (audit-max-retention-days))
+      (t2/delete! {:where [:< :started_at [:date_add [:now] [:interval (audit-max-retention-days) :day]]]}))
+    (catch Throwable e
+      (log/error e (trs "TruncateAuditLog task failed")))))
+
+(def ^:private truncate-audit-log-job-key "metabase.task.truncate-audit-log.job")
+(def ^:private truncate-audit-log-trigger-key "metabase.task.truncate-audit-log.trigger")
+
+(defmethod task/init! ::TruncateAuditLog [_]
+  (let [job     (jobs/build
+                 (jobs/of-type TruncateAuditLog)
+                 (jobs/with-identity (jobs/key truncate-audit-log-job-key)))
+        trigger (triggers/build
+                 (triggers/with-identity (triggers/key truncate-audit-log-trigger-key))
+                 (triggers/start-now)
+                 (triggers/with-schedule
+                   (cron/schedule
+                    ;; run every 12 hours
+                    (cron/cron-schedule "0 0 */12 * * ? *")
+                    (cron/with-misfire-handling-instruction-do-nothing))))]
+    (task/schedule-task! job trigger)))

--- a/src/metabase/task/truncate_audit_log.clj
+++ b/src/metabase/task/truncate_audit_log.clj
@@ -11,13 +11,18 @@
    [metabase.models.setting.multi-setting
     :refer [define-multi-setting define-multi-setting-impl]]
    [metabase.models.task-history :as task-history]
+   [metabase.plugins.classloader :as classloader]
    [metabase.public-settings.premium-features :as premium-features]
    [metabase.task :as task]
+   [metabase.util :as u]
    [metabase.util.i18n :refer [deferred-tru trs]]
    [metabase.util.log :as log]
    [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
+
+;; Load EE implementation if available
+(u/ignore-exceptions (classloader/require 'metabase-enterprise.task.truncate-audit-log))
 
 (define-multi-setting audit-max-retention-days
   (deferred-tru "Retention policy for the `query_execution` table.")

--- a/src/metabase/task/truncate_audit_log/interface.clj
+++ b/src/metabase/task/truncate_audit_log/interface.clj
@@ -1,0 +1,27 @@
+(ns metabase.task.truncate-audit-log.interface
+  ""
+  (:require
+   [metabase.config :as config]
+   [metabase.models.setting.multi-setting :refer [define-multi-setting]]
+   [metabase.public-settings.premium-features :as premium-features]
+   [metabase.util.i18n :refer [deferred-tru trs]]
+   [metabase.util.log :as log]))
+
+(define-multi-setting audit-max-retention-days
+  (deferred-tru "Retention policy for the `query_execution` table.")
+  (fn [] (if (and config/ee-available? (premium-features/enable-advanced-config?)) :ee :oss))
+  :visibility :internal
+  :setter     :none)
+
+(def min-retention-days
+  "Minimum allowed value for `audit-max-retention-days`."
+  30)
+
+(defn log-minimum-value-warning
+  "Logs a warning that the value for `audit-max-retention-days` is below the allowed minimum and will be overriden."
+  [env-var-value]
+  (log/warn (trs "MB_AUDIT_MAX_RETENTION_DAYS is set to {0}; using the minimum value of {1} instead."
+                 env-var-value
+                 min-retention-days)))
+
+

--- a/src/metabase/task/truncate_audit_log/interface.clj
+++ b/src/metabase/task/truncate_audit_log/interface.clj
@@ -1,5 +1,5 @@
 (ns metabase.task.truncate-audit-log.interface
-  ""
+  "Common definitions for the OSS and EE implementations of `truncate-audit-log`"
   (:require
    [metabase.config :as config]
    [metabase.models.setting.multi-setting :refer [define-multi-setting]]
@@ -23,5 +23,3 @@
   (log/warn (trs "MB_AUDIT_MAX_RETENTION_DAYS is set to {0}; using the minimum value of {1} instead."
                  env-var-value
                  min-retention-days)))
-
-

--- a/test/metabase/task/truncate_audit_log_test.clj
+++ b/test/metabase/task/truncate_audit_log_test.clj
@@ -1,0 +1,40 @@
+(ns metabase.task.truncate-audit-log-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase.models.setting :as setting]
+   [metabase.public-settings.premium-features :as premium-features]
+   [metabase.task.truncate-audit-log :as task.truncate-audit-log]
+   [metabase.test :as mt]))
+
+(deftest audit-max-retention-days-test
+  ;; Tests for the EE implementation are in `metabase-enterprise.task.truncate-audit-log-test`
+  (with-redefs [premium-features/enable-advanced-config? (constantly false)]
+    (testing "Self-hosted OSS instances default to infinite retention and cannot be changed"
+        (is (= ##Inf (task.truncate-audit-log/audit-max-retention-days)))
+
+        (mt/with-temp-env-var-value [mb-audit-max-retention-days 30]
+          (is (= ##Inf (task.truncate-audit-log/audit-max-retention-days))))
+
+        (is (thrown-with-msg?
+             java.lang.UnsupportedOperationException
+             #"You cannot set audit-max-retention-days"
+             (setting/set! :audit-max-retention-days 30))))
+
+    (testing "Cloud instances can have their value set by env var only, and default to 365"
+      (with-redefs [premium-features/is-hosted? (constantly true)]
+        (is (= 365 (task.truncate-audit-log/audit-max-retention-days)))
+
+        (mt/with-temp-env-var-value [mb-audit-max-retention-days 0]
+          (is (= ##Inf (task.truncate-audit-log/audit-max-retention-days))))
+
+        (mt/with-temp-env-var-value [mb-audit-max-retention-days 100]
+          (is (= 100 (task.truncate-audit-log/audit-max-retention-days))))
+
+        ;; Acceptable values have a lower bound of 30
+        (mt/with-temp-env-var-value [mb-audit-max-retention-days 1]
+          (is (= 30 (task.truncate-audit-log/audit-max-retention-days))))
+
+        (is (thrown-with-msg?
+             java.lang.UnsupportedOperationException
+             #"You cannot set audit-max-retention-days"
+             (setting/set! :audit-max-retention-days 30)))))))

--- a/test/metabase/task/truncate_audit_log_test.clj
+++ b/test/metabase/task/truncate_audit_log_test.clj
@@ -26,7 +26,7 @@
 
     (testing "Cloud instances can have their value set by env var only, and default to 365"
       (with-redefs [premium-features/is-hosted? (constantly true)]
-        (is (= 365 (task.truncate-audit-log/audit-max-retention-days)))
+        (is (= ##Inf (task.truncate-audit-log/audit-max-retention-days)))
 
         (mt/with-temp-env-var-value [mb-audit-max-retention-days 0]
           (is (= ##Inf (task.truncate-audit-log/audit-max-retention-days))))

--- a/test/metabase/task/truncate_audit_log_test.clj
+++ b/test/metabase/task/truncate_audit_log_test.clj
@@ -1,10 +1,14 @@
 (ns metabase.task.truncate-audit-log-test
   (:require
    [clojure.test :refer :all]
+   [java-time :as t]
+   [metabase.models.query-execution :refer [QueryExecution]]
    [metabase.models.setting :as setting]
    [metabase.public-settings.premium-features :as premium-features]
+   [metabase.query-processor.util :as qp.util]
    [metabase.task.truncate-audit-log :as task.truncate-audit-log]
-   [metabase.test :as mt]))
+   [metabase.test :as mt]
+   [toucan2.core :as t2]))
 
 (deftest audit-max-retention-days-test
   ;; Tests for the EE implementation are in `metabase-enterprise.task.truncate-audit-log-test`
@@ -38,3 +42,48 @@
              java.lang.UnsupportedOperationException
              #"You cannot set audit-max-retention-days"
              (setting/set! :audit-max-retention-days 30)))))))
+
+(def ^:private query-execution-defaults
+  {:hash         (qp.util/query-hash {})
+   :running_time 1
+   :result_rows  1
+   :native       false
+   :executor_id  nil
+   :card_id      nil
+   :context      :ad-hoc})
+
+(deftest query-execution-cleanup-test
+  (testing "When the task runs, rows in `query_execution` older than the configured threshold are deleted"
+    (mt/with-temp* [QueryExecution [{qe1-id :id} (merge query-execution-defaults
+                                                        {:started_at (t/offset-date-time)})]
+                    ;; 31 days ago
+                    QueryExecution [{qe2-id :id} (merge query-execution-defaults
+                                                        {:started_at (t/minus (t/offset-date-time) (t/days 31))})]
+                    ;; 1 year ago
+                    QueryExecution [{qe3-id :id} (merge query-execution-defaults
+                                                        {:started_at (t/minus (t/offset-date-time) (t/years 1))})]]
+      ;; Mock a cloud environment so that we can change the setting value via env var
+      (with-redefs [premium-features/is-hosted? (constantly true)]
+       (testing "When the threshold is 0 (representing infinity), no rows are deleted"
+         (mt/with-temp-env-var-value [mb-audit-max-retention-days 0]
+           (#'task.truncate-audit-log/query-execution-cleanup!)
+           (is (= #{qe1-id qe2-id qe3-id}
+                  (t2/select-fn-set :id QueryExecution {:where [:in :id [qe1-id qe2-id qe3-id]]}))))
+
+        (testing "When the threshold is 100 days, one row is deleted"
+         (mt/with-temp-env-var-value [mb-audit-max-retention-days 100]
+            (#'task.truncate-audit-log/query-execution-cleanup!)
+            (is (= #{qe1-id qe2-id}
+                   (t2/select-fn-set :id QueryExecution {:where [:in :id [qe1-id qe2-id qe3-id]]})))))
+
+        (testing "When the threshold is 30 days, two rows are deleted"
+         (mt/with-temp-env-var-value [mb-audit-max-retention-days 30]
+            (#'task.truncate-audit-log/query-execution-cleanup!)
+            (is (= #{qe1-id}
+                   (t2/select-fn-set :id QueryExecution {:where [:in :id [qe1-id qe2-id qe3-id]]})))))
+
+        (testing "When the threshold set to 1 day, the remaining row is not deleted because the minimum threshold is 30"
+         (mt/with-temp-env-var-value [mb-audit-max-retention-days 1]
+            (#'task.truncate-audit-log/query-execution-cleanup!)
+            (is (= #{qe1-id}
+                   (t2/select-fn-set :id QueryExecution {:where [:in :id [qe1-id qe2-id qe3-id]]}))))))))))

--- a/test/metabase/task/truncate_audit_log_test.clj
+++ b/test/metabase/task/truncate_audit_log_test.clj
@@ -7,6 +7,7 @@
    [metabase.public-settings.premium-features :as premium-features]
    [metabase.query-processor.util :as qp.util]
    [metabase.task.truncate-audit-log :as task.truncate-audit-log]
+   [metabase.task.truncate-audit-log.interface :as truncate-audit-log.i]
    [metabase.test :as mt]
    [toucan2.core :as t2]))
 
@@ -14,10 +15,10 @@
   ;; Tests for the EE implementation are in `metabase-enterprise.task.truncate-audit-log-test`
   (with-redefs [premium-features/enable-advanced-config? (constantly false)]
     (testing "Self-hosted OSS instances default to infinite retention and cannot be changed"
-        (is (= ##Inf (task.truncate-audit-log/audit-max-retention-days)))
+        (is (= ##Inf (truncate-audit-log.i/audit-max-retention-days)))
 
         (mt/with-temp-env-var-value [mb-audit-max-retention-days 30]
-          (is (= ##Inf (task.truncate-audit-log/audit-max-retention-days))))
+          (is (= ##Inf (truncate-audit-log.i/audit-max-retention-days))))
 
         (is (thrown-with-msg?
              java.lang.UnsupportedOperationException
@@ -26,17 +27,17 @@
 
     (testing "Cloud instances can have their value set by env var only, and default to 365"
       (with-redefs [premium-features/is-hosted? (constantly true)]
-        (is (= ##Inf (task.truncate-audit-log/audit-max-retention-days)))
+        (is (= ##Inf (truncate-audit-log.i/audit-max-retention-days)))
 
         (mt/with-temp-env-var-value [mb-audit-max-retention-days 0]
-          (is (= ##Inf (task.truncate-audit-log/audit-max-retention-days))))
+          (is (= ##Inf (truncate-audit-log.i/audit-max-retention-days))))
 
         (mt/with-temp-env-var-value [mb-audit-max-retention-days 100]
-          (is (= 100 (task.truncate-audit-log/audit-max-retention-days))))
+          (is (= 100 (truncate-audit-log.i/audit-max-retention-days))))
 
         ;; Acceptable values have a lower bound of 30
         (mt/with-temp-env-var-value [mb-audit-max-retention-days 1]
-          (is (= 30 (task.truncate-audit-log/audit-max-retention-days))))
+          (is (= 30 (truncate-audit-log.i/audit-max-retention-days))))
 
         (is (thrown-with-msg?
              java.lang.UnsupportedOperationException


### PR DESCRIPTION
Part of https://github.com/metabase/metabase/issues/4155

Adds a new setting `audit-max-retention-days` which can be set by env var (`MB_AUDIT_MAX_RETENTION_DAYS`) to control the number of days `query_execution` rows are preserved before being cleared. Also adds a task that runs twice a day to delete rows older than this threshold.

This setting currently defaults to `0` which represents infinity, so no rows will be deleted by default. It can be set by env var on EE/Pro and hosted instances, and has a minimum value of 30 days. In a subsequent release we will change the default value to enable cleanup automatically, but for now it is opt-in.