### PR TITLE
Remove unecessary serdes for ParameterCard

### DIFF
--- a/src/metabase/models/parameter_card.clj
+++ b/src/metabase/models/parameter_card.clj
@@ -1,8 +1,6 @@
 (ns metabase.models.parameter-card
   (:require
    [metabase.models.interface :as mi]
-   [metabase.models.serialization.base :as serdes.base]
-   [metabase.models.serialization.util :as serdes.util]
    [metabase.util :as u]
    [metabase.util.i18n :refer [tru]]
    [metabase.util.malli :as mu]

--- a/src/metabase/models/parameter_card.clj
+++ b/src/metabase/models/parameter_card.clj
@@ -76,18 +76,3 @@
         upsertable-parameters (filter upsertable? parameters)]
     (upsert-from-parameters! parameterized-object-type parameterized-object-id upsertable-parameters)
     (delete-all-for-parameterized-object! parameterized-object-type parameterized-object-id (map :id upsertable-parameters))))
-
-;;; ----------------------------------------------- SERIALIZATION ----------------------------------------------------
-;; ParameterCard are not serialized as their own, separate entities. They are inlined onto their parent ParameterizedObjects
-
-(defmethod serdes.base/load-xform "ParameterCard"
-  [parameter-card]
-  (let [parameterized-model (case (:parameterized_object_type parameter-card)
-                              "dashboard" 'Dashboard
-                              "card"      'Card)]
-    (-> parameter-card
-        (dissoc :serdes/meta)
-        (update :card_id                 serdes.util/import-fk 'Card)
-        (update :parameterized_object_id serdes.util/import-fk parameterized-model)
-        (update :parameter_mappings      serdes.util/import-parameter-mappings)
-        (update :visualization_settings  serdes.util/import-visualization-settings))))


### PR DESCRIPTION
We added these lines in https://github.com/metabase/metabase/pull/27495 but it's actually not needed.

There is no need to load Parameter when serdes because they're created when insert `Dashboard/Card` defined in the pre-insert hook [here](https://github.com/metabase/metabase/blob/88aa0fab6f0542c4c7503c00c53b2cc04272a4f8/src/metabase/models/dashboard.clj#L95).

There are tests to make sure we do have Parameter created when serdes [here](https://github.com/metabase/metabase/blob/88aa0fab6f0542c4c7503c00c53b2cc04272a4f8/enterprise/backend/test/metabase_enterprise/serialization/v2/e2e/yaml_test.clj#L491)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/28596)
<!-- Reviewable:end -->
