### PR TITLE
[E2E] Fix model-revision-history flake

### DIFF
--- a/frontend/test/metabase/scenarios/models/models-revision-history.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/models-revision-history.cy.spec.js
@@ -34,9 +34,7 @@ describe("scenarios > models > revision history", () => {
   it("should allow reverting to a saved question state", () => {
     visitModel(3);
 
-    questionInfoButton().click();
-
-    cy.findByText("History");
+    openRevisionHistory();
     cy.findAllByTestId("question-revert-button").click();
     cy.wait("@revertToRevision");
 
@@ -65,9 +63,7 @@ describe("scenarios > models > revision history", () => {
     assertIsQuestion();
     closeQuestionActions();
 
-    questionInfoButton().click();
-
-    cy.findByText("History");
+    openRevisionHistory();
 
     cy.findByText(/Turned this into a model/i)
       .closest("li")
@@ -112,4 +108,11 @@ function visitModel(id) {
   cy.intercept("POST", "/api/dataset").as("dataset");
   cy.visit(`/model/${id}`);
   cy.wait("@dataset");
+}
+
+function openRevisionHistory() {
+  cy.intercept("GET", "/api/user").as("user");
+  questionInfoButton().click();
+  cy.wait("@user");
+  cy.findByText("History");
 }

--- a/frontend/test/metabase/scenarios/models/models-revision-history.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/models-revision-history.cy.spec.js
@@ -1,20 +1,4 @@
-import {
-  restore,
-  modal,
-  filter,
-  filterField,
-  visitQuestion,
-  openQuestionActions,
-  closeQuestionActions,
-  questionInfoButton,
-} from "__support__/e2e/helpers";
-
-import {
-  assertIsModel,
-  assertQuestionIsBasedOnModel,
-  saveQuestionBasedOnModel,
-  assertIsQuestion,
-} from "./helpers/e2e-models-helpers";
+import { restore, questionInfoButton } from "__support__/e2e/helpers";
 
 describe("scenarios > models > revision history", () => {
   beforeEach(() => {
@@ -27,8 +11,6 @@ describe("scenarios > models > revision history", () => {
       name: "Orders Model",
       dataset: true,
     });
-    cy.intercept("PUT", "/api/card/3").as("updateCard");
-    cy.intercept("POST", "/api/revision/revert").as("revertToRevision");
   });
 
   it("should allow reverting to a saved question state", () => {
@@ -38,69 +20,14 @@ describe("scenarios > models > revision history", () => {
     revertTo("You created this");
     cy.wait("@dataset");
 
-    openQuestionActions();
-    assertIsQuestion();
+    cy.location("pathname").should("match", /^\/question\/3/);
     cy.get(".LineAreaBarChart");
 
-    filter();
-    filterField("Discount", {
-      operator: "Not empty",
-    });
+    revertTo("^Turned this into a model");
+    cy.wait("@dataset");
 
-    cy.findByTestId("apply-filters").click();
-
-    cy.findByText("Save").click();
-    modal().within(() => {
-      cy.findByText(/Replace original question/i);
-    });
-  });
-
-  it("should allow reverting to a model state", () => {
-    cy.request("PUT", "/api/card/3", { dataset: false });
-
-    visitQuestion(3);
-    openQuestionActions();
-    assertIsQuestion();
-    closeQuestionActions();
-
-    openRevisionHistory();
-
-    cy.findByText(/Turned this into a model/i)
-      .closest("li")
-      .within(() => {
-        cy.findByTestId("question-revert-button").click();
-      });
-    cy.wait("@revertToRevision");
-
-    openQuestionActions();
-    assertIsModel();
-    closeQuestionActions();
-
-    cy.get(".LineAreaBarChart").should("not.exist");
-
-    filter();
-    filterField("Count", {
-      placeholder: "min",
-      value: "2000",
-    });
-    cy.findByTestId("apply-filters").click();
-
-    assertQuestionIsBasedOnModel({
-      model: "Orders Model",
-      collection: "Our analytics",
-      table: "Orders",
-    });
-
-    saveQuestionBasedOnModel({ modelId: 3, name: "Q1" });
-
-    assertQuestionIsBasedOnModel({
-      questionName: "Q1",
-      model: "Orders Model",
-      collection: "Our analytics",
-      table: "Orders",
-    });
-
-    cy.url().should("not.include", "/question/3");
+    cy.location("pathname").should("match", /^\/model\/3/);
+    cy.get(".cellData");
   });
 });
 
@@ -114,6 +41,7 @@ function openRevisionHistory() {
   cy.intercept("GET", "/api/user").as("user");
   questionInfoButton().click();
   cy.wait("@user");
+
   cy.findByText("History");
 }
 

--- a/frontend/test/metabase/scenarios/models/models-revision-history.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/models-revision-history.cy.spec.js
@@ -13,7 +13,7 @@ describe("scenarios > models > revision history", () => {
     });
   });
 
-  it("should allow reverting to a saved question state", () => {
+  it("should allow reverting to a saved question state and back into a model again", () => {
     visitModel(3);
 
     openRevisionHistory();

--- a/frontend/test/metabase/scenarios/models/models-revision-history.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/models-revision-history.cy.spec.js
@@ -32,10 +32,7 @@ describe("scenarios > models > revision history", () => {
   });
 
   it("should allow reverting to a saved question state", () => {
-    cy.visit("/model/3");
-    openQuestionActions();
-    assertIsModel();
-    closeQuestionActions();
+    visitModel(3);
 
     questionInfoButton().click();
 
@@ -110,3 +107,9 @@ describe("scenarios > models > revision history", () => {
     cy.url().should("not.include", "/question/3");
   });
 });
+
+function visitModel(id) {
+  cy.intercept("POST", "/api/dataset").as("dataset");
+  cy.visit(`/model/${id}`);
+  cy.wait("@dataset");
+}

--- a/frontend/test/metabase/scenarios/models/models-revision-history.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/models-revision-history.cy.spec.js
@@ -35,8 +35,8 @@ describe("scenarios > models > revision history", () => {
     visitModel(3);
 
     openRevisionHistory();
-    cy.findAllByTestId("question-revert-button").click();
-    cy.wait("@revertToRevision");
+    revertTo("You created this");
+    cy.wait("@dataset");
 
     openQuestionActions();
     assertIsQuestion();
@@ -115,4 +115,9 @@ function openRevisionHistory() {
   questionInfoButton().click();
   cy.wait("@user");
   cy.findByText("History");
+}
+
+function revertTo(history) {
+  const r = new RegExp(history);
+  cy.findByText(r).closest("li").findByTestId("question-revert-button").click();
 }


### PR DESCRIPTION
Example of a failed run: https://www.deploysentinel.com/ci/runs/63f80d340d824a88a39baecb
This flake started appearing frequently in the last month or so.

We didn't wait for model to load, and we waited for wrong requests in the history sidebar.
On top of the flake fix, this PR greatly simplifies both tests and merges them into one.

Please do not repeat assertions that we already test elsewhere (in multiple places)!

### Note
Models E2E tests in general tend to repeat expensive UI assertions and need to be optimized. I'll do that in the next PR.