### PR TITLE
[E2E] Fix explicit joins dashboard filters flake

### DIFF
--- a/frontend/test/metabase/scenarios/dashboard-filters/dashboard-filters-explicit-join.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters/dashboard-filters-explicit-join.cy.spec.js
@@ -24,6 +24,7 @@ const questionDetails = {
         alias: "Products",
       },
     ],
+    limit: 5,
   },
 };
 

--- a/frontend/test/metabase/scenarios/dashboard-filters/dashboard-filters-explicit-join.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters/dashboard-filters-explicit-join.cy.spec.js
@@ -42,6 +42,10 @@ const dashboardDetails = {
 
 describe("scenarios > dashboard > filters", () => {
   beforeEach(() => {
+    cy.intercept("GET", `/api/dashboard/*/params/${filter.id}/values`).as(
+      "filterValues",
+    );
+
     restore();
     cy.signInAsAdmin();
 
@@ -79,6 +83,7 @@ describe("scenarios > dashboard > filters", () => {
 
   it("should work properly when connected to the explicitly joined field", () => {
     filterWidget().click();
+    cy.wait("@filterValues");
 
     cy.findByPlaceholderText("Search the list").type("Awe");
 

--- a/frontend/test/metabase/scenarios/dashboard-filters/dashboard-filters-explicit-join.cy.spec.js
+++ b/frontend/test/metabase/scenarios/dashboard-filters/dashboard-filters-explicit-join.cy.spec.js
@@ -1,9 +1,4 @@
-import {
-  restore,
-  filterWidget,
-  popover,
-  visitDashboard,
-} from "__support__/e2e/helpers";
+import { restore, filterWidget, visitDashboard } from "__support__/e2e/helpers";
 import { SAMPLE_DATABASE } from "__support__/e2e/cypress_sample_database";
 
 const { ORDERS, ORDERS_ID, PRODUCTS, PRODUCTS_ID } = SAMPLE_DATABASE;
@@ -106,9 +101,7 @@ describe("scenarios > dashboard > filters", () => {
 });
 
 function selectFromDropdown(values) {
-  popover().within(() => {
-    values.forEach(value => {
-      cy.findByText(value).click();
-    });
+  values.forEach(value => {
+    cy.findByTestId(`${value}-filter-value`).should("be.visible").click();
   });
 }


### PR DESCRIPTION
Example of a failed run: https://www.deploysentinel.com/ci/runs/63f809b5c977b83868f47d52

Popover re-calculating its own dimensions caused Cypress to want to click on an element detached from DOM.

This PR explicitly waits for all filter results to load first.
And then removes the need to find popover by using individual filter result's `data-testId`.