### PR TITLE
[Ci] Fix rerun workflow

### DIFF
--- a/.github/workflows/rerun-workflows.yml
+++ b/.github/workflows/rerun-workflows.yml
@@ -14,7 +14,6 @@ jobs:
     steps:
       - name: Generate job summary
         run: |
-          RUN_ID=${{ github.event.workflow_run.id }}
           echo "# ${{ github.event.workflow_run.name }} workflow failed! :x:" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "View the failed run attempt (#${{ github.event.workflow_run.run_attempt }}) using the following link:" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/rerun-workflows.yml
+++ b/.github/workflows/rerun-workflows.yml
@@ -15,9 +15,7 @@ jobs:
       - name: Generate job summary
         run: |
           RUN_ID=${{ github.event.workflow_run.id }}
-          WORKFLOW_NAME=${{ github.event.workflow_run.name }}
-
-          echo "# $WORKFLOW_NAME workflow failed! :x:" >> $GITHUB_STEP_SUMMARY
+          echo "# ${{ github.event.workflow_run.name }} workflow failed! :x:" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "View the failed run attempt (#${{ github.event.workflow_run.run_attempt }}) using the following link:" >> $GITHUB_STEP_SUMMARY
           echo "${{ github.event.workflow_run.html_url }}" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
Back when I added workflow summary in #28548, I didn't wrap `WORKFLOW_NAME` variable in a string. That caused errors for workflows that had two or more words in their names. 🤦 
"E2E Tests", for example.

[The error](https://github.com/metabase/metabase/actions/runs/4262839023/jobs/7418821475):
```
/home/runner/work/_temp/bbad475a-6a87-4e5a-b82e-972269038abf.sh: line 2: Tests: command not found
Error: Process completed with exit code 127.
```

This resulted in an increased failure rate
![image](https://user-images.githubusercontent.com/31325167/221195864-4b30a121-7514-4cbd-82cf-f98ef3cb33ab.png)
