### PR TITLE
[CI] Remove unneeded step from drivers workflow

### DIFF
--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -563,9 +563,6 @@ jobs:
       with:
         junit-name: 'be-tests-presto-jdbc-ee'
         test-args: ":exclude-tags '[:mb/once]'"
-    # FIXME: Cannot find it in Ubuntu 22.04 (No such file or directory)
-    # - name: Capture max memory usage
-    #   run: cat /sys/fs/cgroup/memory/memory.max_usage_in_bytes
 
   be-tests-redshift-ee:
     needs: files-changed


### PR DESCRIPTION
See https://github.com/metabase/metabase/issues/28602 for reference.


> **Warning**
> This PR will intentionally be force-merged without running the checks first to avoid unnecessary CI cycles for a change that doesn't affect any part of the application, whatsoever.