### PR TITLE
open chart settings when clicking active display type

### DIFF
--- a/frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.tsx
@@ -83,21 +83,8 @@ const ChartTypeSidebar = ({
     );
   }, [result, query]);
 
-  const handleClick = useCallback(
-    display => {
-      const newQuestion = question.setDisplay(display).lockDisplay(); // prevent viz auto-selection
-
-      updateQuestion(newQuestion, {
-        reload: false,
-        shouldUpdateUrl: question.query().isEditable(),
-      });
-      setUIControls({ isShowingRawTable: false });
-    },
-    [question, updateQuestion, setUIControls],
-  );
-
-  const handleSettingsClick = useCallback(
-    (e: React.MouseEvent<HTMLButtonElement>) => {
+  const openChartSettings = useCallback(
+    (e: React.MouseEvent) => {
       e.stopPropagation();
 
       onOpenChartSettings({
@@ -106,6 +93,23 @@ const ChartTypeSidebar = ({
       });
     },
     [onOpenChartSettings],
+  );
+
+  const handleClick = useCallback(
+    (display, e) => {
+      if (display === question.display()) {
+        openChartSettings(e);
+      } else {
+        const newQuestion = question.setDisplay(display).lockDisplay(); // prevent viz auto-selection
+
+        updateQuestion(newQuestion, {
+          reload: false,
+          shouldUpdateUrl: question.query().isEditable(),
+        });
+        setUIControls({ isShowingRawTable: false });
+      }
+    },
+    [question, updateQuestion, setUIControls, openChartSettings],
   );
 
   return (
@@ -123,8 +127,8 @@ const ChartTypeSidebar = ({
                 visualization={visualization}
                 isSelected={type === question.display()}
                 isSensible
-                onClick={() => handleClick(type)}
-                onSettingsClick={handleSettingsClick}
+                onClick={e => handleClick(type, e)}
+                onSettingsClick={openChartSettings}
               />
             )
           );
@@ -141,8 +145,8 @@ const ChartTypeSidebar = ({
                 visualization={visualization}
                 isSelected={type === question.display()}
                 isSensible={false}
-                onClick={() => handleClick(type)}
-                onSettingsClick={handleSettingsClick}
+                onClick={e => handleClick(type, e)}
+                onSettingsClick={openChartSettings}
               />
             )
           );
@@ -155,8 +159,8 @@ const ChartTypeSidebar = ({
 interface ChartTypeOptionProps {
   isSelected: boolean;
   isSensible: boolean;
-  onClick: () => void;
-  onSettingsClick: (e: React.MouseEvent<HTMLButtonElement>) => void;
+  onClick: (e: React.MouseEvent) => void;
+  onSettingsClick: (e: React.MouseEvent) => void;
   visualization: Visualization;
 }
 

--- a/frontend/test/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.unit.spec.js
+++ b/frontend/test/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.unit.spec.js
@@ -47,6 +47,21 @@ describe("ChartSettingsSidebar", () => {
     expect(updateQuestion).toHaveBeenCalled();
   });
 
+  it("should transition to settings page when clicking on the active display type", () => {
+    const onOpenChartSettings = jest.fn();
+
+    setup({
+      onOpenChartSettings,
+    });
+
+    fireEvent.click(screen.getByTestId("Gauge-button"));
+
+    expect(onOpenChartSettings).toHaveBeenCalledWith({
+      initialChartSettings: { section: "Data" },
+      showSidebarTitle: true,
+    });
+  });
+
   it("should display a gear icon when hovering selected display type", () => {
     const onOpenChartSettings = jest.fn();
     setup({

--- a/frontend/test/metabase/scenarios/visualizations/trendline.cy.spec.js
+++ b/frontend/test/metabase/scenarios/visualizations/trendline.cy.spec.js
@@ -27,12 +27,7 @@ describe("scenarios > question > trendline", () => {
   it("displays trendline when there are multiple numeric outputs (for simple question) (metabase#12781)", () => {
     // Change settings to trendline
     cy.findByText("Visualization").click();
-    sidebar().within(() => {
-      cy.icon("line").click();
-    });
-    cy.findByTestId("Line-button").within(() => {
-      cy.icon("gear").click();
-    });
+    cy.findByTestId("viz-settings-button").click();
     cy.findByText("Display").click();
     cy.findByText("Trend line").parent().children().last().click();
 


### PR DESCRIPTION
Small adjustment to https://github.com/metabase/metabase/pull/28238 to make it so that clicking the active viz type will bring you into the settings panel. To test:

- New Question => Orders => Count, group by CreatedAt: Year
- Click Visualize, then open Visualization panel
- Select Bar, the viz type should change
- Select Bar again, you should be brought to the settings panel

note: The gear is still visible and clickable. That behavior hasn't changed.