### PR TITLE
Add entity menu example to storybook

### DIFF
--- a/frontend/src/metabase/components/EntityMenu.stories.tsx
+++ b/frontend/src/metabase/components/EntityMenu.stories.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+import type { ComponentStory } from "@storybook/react";
+import EntityMenu from "./EntityMenu";
+
+export default {
+  title: "Entity Menu",
+  component: EntityMenu,
+};
+
+const Template: ComponentStory<typeof EntityMenu> = args => {
+  return <EntityMenu {...args} />;
+};
+
+const items = [
+  {
+    icon: "link",
+    title: "Option 1 - External link",
+    link: "https://google.com",
+    externalLink: true,
+  },
+  {
+    icon: "link",
+    title: "Option 2 - Relative link",
+    link: "/",
+  },
+  {
+    icon: "bolt",
+    title: "Option 3 - Action",
+    action: () => alert("Yo"),
+  },
+];
+
+export const Default = Template.bind({});
+Default.args = {
+  items,
+  trigger: <span>Hello</span>,
+};

--- a/frontend/src/metabase/components/EntityMenu.stories.tsx
+++ b/frontend/src/metabase/components/EntityMenu.stories.tsx
@@ -33,5 +33,5 @@ const items = [
 export const Default = Template.bind({});
 Default.args = {
   items,
-  trigger: <span>Hello</span>,
+  trigger: <span>Click Me</span>,
 };

--- a/frontend/src/metabase/components/EntityMenu.stories.tsx
+++ b/frontend/src/metabase/components/EntityMenu.stories.tsx
@@ -3,7 +3,7 @@ import type { ComponentStory } from "@storybook/react";
 import EntityMenu from "./EntityMenu";
 
 export default {
-  title: "Entity Menu",
+  title: "Components/Entity Menu",
   component: EntityMenu,
 };
 


### PR DESCRIPTION
<img width="1392" alt="Screen Shot 2023-02-24 at 12 39 09 PM" src="https://user-images.githubusercontent.com/5248953/221250261-2f69017c-1cfe-4dcb-bee7-bb1fb6539fb6.png">

Add basic documentation for the `EntityMenu` component.