### PR TITLE
Handle action db and model db different

### DIFF
--- a/src/metabase/actions/execution.clj
+++ b/src/metabase/actions/execution.clj
@@ -5,7 +5,7 @@
    [metabase.actions :as actions]
    [metabase.actions.http-action :as http-action]
    [metabase.api.common :as api]
-   [metabase.models :refer [Card DashboardCard Table]]
+   [metabase.models :refer [Card DashboardCard Database Table]]
    [metabase.models.action :as action]
    [metabase.models.persisted-info :as persisted-info]
    [metabase.models.query :as query]
@@ -79,6 +79,11 @@
                          :parameters             request-parameters
                          :destination-parameters (:parameters action)}))))
     (actions/check-actions-enabled! action)
+    (let [model (db/select-one Card :id (:model_id action))]
+      (when (and (= action-type :query) (not= (:database_id model) (:database_id action)))
+        ;; the above check checks the db of the model. We check the db of the query action here
+        (actions/check-actions-enabled-for-database!
+         (db/select-one Database :id (:database_id action)))))
     (try
       (case action-type
         :query

--- a/src/metabase/api/action.clj
+++ b/src/metabase/api/action.clj
@@ -107,7 +107,7 @@
     (when (and database_id (not= database_id (:database_id model)))
       (let [model-db (db/select-one Database :id (:database_id model))
             action-db (db/select-one Database :id database_id)]
-       (throw (ex-info (tru "Model database not equal to action database")
+       (throw (ex-info (tru "Actions need to use the same database as the model.")
                        {:status-code 400
                         :model-database (:name model-db)
                         :action-database (:name action-db)}))))

--- a/src/metabase/api/action.clj
+++ b/src/metabase/api/action.clj
@@ -106,7 +106,7 @@
   (let [model (api/write-check Card model_id)]
     (doseq [db-id (cond-> [(:database_id model)] database_id (conj database_id))]
       (actions/check-actions-enabled-for-database!
-       (db/select-one 'Database :id db-id))))
+       (db/select-one Database :id db-id))))
   (let [action-id (action/insert! (assoc action :creator_id api/*current-user-id*))]
     (if action-id
       (action/select-action :id action-id)

--- a/test/metabase/api/action_test.clj
+++ b/test/metabase/api/action_test.clj
@@ -99,43 +99,71 @@
             (is (= "You don't have permissions to do that."
                    (mt/user-http-request :rasta :get 403 (format "action/%d" action-id))))))))))
 
-(deftest create-action-test
-  (testing "when action's database and model's database disagree"
-    (mt/dataset sample-dataset
-      (mt/with-actions-enabled
-        (let [sample-dataset-id (mt/id)]
-          (mt/dataset test-data
-            (mt/with-actions-enabled
-              (is (not= (mt/id) sample-dataset-id))
-              (mt/with-temp* [Card [model {:dataset true
-                                           :dataset_query
-                                           (mt/native-query
-                                            {:query "select * from checkins limit 1"})}]]
-                (let [action {:name "test action",
-                              :type :query,
-                              :model_id (:id model),         ;; model against test-data
-                              :database_id sample-dataset-id ;; action against sample-dataset
-                              :dataset_query
-                              {:native
-                               {:query "update people
-                                        set source = {{source}}
-                                        where id = {{id}}",
-                                :template-tags {:source {:id "source-param",
-                                                         :name "source",
-                                                         :display-name "Source",
-                                                         :type "text"},
-                                                :id {:id "id-param",
-                                                     :name "id",
-                                                     :display-name "Id",
-                                                     :type "text"}}},
-                               :database sample-dataset-id
-                               :type "native"}}
-                      response (mt/user-http-request :rasta :post 400 "action"
-                                                     action)]
-                  (is (partial= {:message "Model database not equal to action database"
-                                 :data {:model-database "test-data",
-                                        :action-database "sample-dataset"}}
-                                response)))))))))))
+(deftest action-model-db-disagree-test
+  (let [cross-db-action (fn cross-db-action [model-id other-db-id]
+                          {:type :query
+                           :model_id model-id       ;; model against one-db
+                           :database_id other-db-id ;; action against sample-dataset
+                           :name "cross db action"
+                           :dataset_query
+                           {:native
+                            {:query "update people
+                                       set source = {{source}}
+                                     where id = {{id}}",
+                             :template-tags {:source {:id "source",
+                                                      :name "source",
+                                                      :display-name "Source",
+                                                      :type "text"},
+                                             :id {:id "id",
+                                                  :name "id",
+                                                  :display-name "Id",
+                                                  :type "number"}}},
+                            :database other-db-id
+                            :type "native"}
+                           :parameters [{:id "id"
+                                         :slug "id"
+                                         :type :number
+                                         :target [:variable
+                                                  [:template-tag "id"]]}
+                                        {:id "source"
+                                         :slug "source"
+                                         :type :text
+                                         :required false
+                                         :target [:variable
+                                                  [:template-tag "source"]]}]})]
+    (testing "when action's database and model's database disagree"
+      (testing "Both dbs are checked for actions enabled at creation"
+        (mt/dataset sample-dataset
+          (let [sample-dataset-id (mt/id)]
+            (mt/dataset test-data
+              (mt/with-actions-enabled
+                (is (not= (mt/id) sample-dataset-id))
+                (mt/with-temp* [Card [model {:dataset true
+                                             :dataset_query
+                                             (mt/native-query
+                                              {:query "select * from checkins limit 1"})}]]
+                  (let [action (cross-db-action (:id model) sample-dataset-id)
+                        response (mt/user-http-request :rasta :post 400 "action"
+                                                       action)]
+                    (testing "Checks both databases for actions enabled"
+                      (is (partial= {:message "Actions are not enabled."
+                                     :data {:database-id sample-dataset-id}}
+                                    response))))))))))
+      (testing "When executing, both dbs are checked for enabled"
+        (mt/dataset sample-dataset
+          (let [sample-dataset-id (mt/id)]
+            (mt/with-actions-test-data-and-actions-enabled
+              (mt/with-actions [{model-id :id} {:dataset true
+                                                :dataset_query (mt/mbql-query categories)}
+                                {action-on-other-id :action-id} (cross-db-action model-id
+                                                                                 sample-dataset-id)]
+                (is (partial= {:message "Actions are not enabled."
+                               :data {:database-id sample-dataset-id}}
+                              (mt/user-http-request :crowberto
+                                                    :post 400
+                                                    (format "action/%s/execute" action-on-other-id)
+                                                    ;; Twitter is the current value so effectively a no-op
+                                                    {:parameters {:id 1 :source "Twitter"}})))))))))))
 
 (deftest unified-action-create-test
   (mt/with-actions-enabled


### PR DESCRIPTION
The +New -> Action workflow lets you create an action. This starts with the user choosing the database, writing the action. On save it prompts you to choose a model it should live under. But this model's db and the db chosen originally are not checked in the FE to be the same. This is also desired behavior.

When executing, we check that the action's database has actions enabled. But "action's database" is ambiguous now: the model's database or the query action's database. This PR ensures we check both when they are different.

> **Warning**
> The screenshot is out of date. The error visible there is that the databases don't agree. That is now fine behavior, but they both must have actions enabled.

#### The Workflow
When clicking on "+New" and choosing "Action", you just dive in with a database selector and start writing sql.
<img width="1182" alt="image" src="https://user-images.githubusercontent.com/6377293/221265051-5bd36e03-045e-4745-8b8a-157288052f32.png">

But you can start writing your action against whatever table you like. Only on saving do you have to attach your action to a model. But the models are displayed by collection and give no idea about the underlying database, or if they have actions enabled.

So you can easily add an action on database 1 to a model on database 2.
![image](https://user-images.githubusercontent.com/6377293/221266741-af1e12bb-e0d7-4575-b43e-faa2d7f17a74.png)


<img width="1182" alt="image" src="https://user-images.githubusercontent.com/6377293/221264660-15efef22-7f87-4824-99dc-4ec08502f18b.png">

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/28616)
<!-- Reviewable:end -->
