### PR TITLE
Fix missing database details blows up FE

### DIFF
--- a/frontend/src/metabase/ErrorBoundary.tsx
+++ b/frontend/src/metabase/ErrorBoundary.tsx
@@ -5,18 +5,15 @@ import { SmallGenericError } from "metabase/containers/ErrorPages";
 export default class ErrorBoundary extends React.Component<
   {
     onError?: (errorInfo: ErrorInfo) => void;
-    errorComponent?: Element;
   },
   {
     hasError: boolean;
-    errorDetails: string;
   }
 > {
   constructor(props: any) {
     super(props);
     this.state = {
       hasError: false,
-      errorDetails: "",
     };
   }
 
@@ -29,24 +26,17 @@ export default class ErrorBoundary extends React.Component<
     // if we don't provide a specific onError action, the component will display a generic error message
     if (this.props.onError) {
       this.props.onError(errorInfo);
-    } else {
       this.setState({
-        hasError: true,
-        errorDetails: errorInfo.componentStack,
+        hasError: false,
       });
     }
   }
 
   render() {
-    if (this.state.hasError && !this.props.onError) {
-      const ErrorComponent = this.props.errorComponent;
-
-      if (!ErrorComponent) {
-        return <SmallGenericError />;
-      }
-
-      return ErrorComponent;
+    if (this.state.hasError) {
+      return <SmallGenericError />;
     }
+
     return this.props.children;
   }
 }

--- a/frontend/src/metabase/ErrorBoundary.tsx
+++ b/frontend/src/metabase/ErrorBoundary.tsx
@@ -1,10 +1,11 @@
-import React, { ErrorInfo } from "react";
+import React, { ErrorInfo, ComponentType } from "react";
 
 import { SmallGenericError } from "metabase/containers/ErrorPages";
 
 export default class ErrorBoundary extends React.Component<
   {
     onError?: (errorInfo: ErrorInfo) => void;
+    errorComponent?: ComponentType;
   },
   {
     hasError: boolean;
@@ -34,7 +35,10 @@ export default class ErrorBoundary extends React.Component<
 
   render() {
     if (this.state.hasError) {
-      return <SmallGenericError />;
+      const ErrorComponent = this.props.errorComponent
+        ? this.props.errorComponent
+        : SmallGenericError;
+      return <ErrorComponent />;
     }
 
     return this.props.children;

--- a/frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx
+++ b/frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx
@@ -17,6 +17,8 @@ import { getSetting } from "metabase/selectors/settings";
 
 import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
 import DatabaseForm from "metabase/databases/containers/DatabaseForm";
+import ErrorBoundary from "metabase/ErrorBoundary";
+import { GenericError } from "metabase/containers/ErrorPages";
 import Database from "metabase-lib/metadata/Database";
 
 import { getEditingDatabase, getInitializeError } from "../selectors";
@@ -128,25 +130,27 @@ class DatabaseEditApp extends Component {
         <Breadcrumbs className="py4" crumbs={crumbs} />
 
         <DatabaseEditMain>
-          <div>
-            <div className="pt0">
-              <LoadingAndErrorWrapper
-                loading={!database}
-                error={initializeError}
-              >
-                <DatabaseEditContent>
-                  <DatabaseEditForm>
-                    <DatabaseForm
-                      initialValues={database}
-                      isAdvanced
-                      onSubmit={handleSubmit}
-                    />
-                  </DatabaseEditForm>
-                  <div>{addingNewDatabase && <DatabaseEditHelp />}</div>
-                </DatabaseEditContent>
-              </LoadingAndErrorWrapper>
+          <ErrorBoundary errorComponent={GenericError}>
+            <div>
+              <div className="pt0">
+                <LoadingAndErrorWrapper
+                  loading={!database}
+                  error={initializeError}
+                >
+                  <DatabaseEditContent>
+                    <DatabaseEditForm>
+                      <DatabaseForm
+                        initialValues={database}
+                        isAdvanced
+                        onSubmit={handleSubmit}
+                      />
+                    </DatabaseEditForm>
+                    <div>{addingNewDatabase && <DatabaseEditHelp />}</div>
+                  </DatabaseEditContent>
+                </LoadingAndErrorWrapper>
+              </div>
             </div>
-          </div>
+          </ErrorBoundary>
 
           {editingExistingDatabase && (
             <Sidebar

--- a/frontend/test/metabase/scenarios/admin/databases/list.cy.spec.js
+++ b/frontend/test/metabase/scenarios/admin/databases/list.cy.spec.js
@@ -103,17 +103,12 @@ describe("scenarios > admin > databases > list", () => {
     cy.url().should("match", /\/admin\/databases\/\d+$/);
   });
 
-  it.skip("should handle malformed (null) database details (metabase#25715)", () => {
-    cy.request("GET", "/api/database/1").then(({ body }) => {
-      const stubbedResponse = {
-        ...body,
-        details: null,
-      };
-
-      cy.intercept("GET", "/api/database/1", req => {
-        req.reply({ body: stubbedResponse });
-      }).as("loadDatabase");
-    });
+  it("should handle malformed (null) database details (metabase#25715)", () => {
+    cy.intercept("GET", "/api/database/1", req => {
+      req.reply(res => {
+        res.body.details = null;
+      });
+    }).as("loadDatabase");
 
     cy.visit("/admin/databases/1");
     cy.wait("@loadDatabase");


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/25715

### Description

1. Fix the behavior of `<ErrorBoundary />`
2. Add an `<ErrorBoundary />` to `<DatabaseEditApp />` so it's possible for users to remove database while it has an error.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Run the reproduced test case in this PR, and it should pass
### Demo
<img width="1010" alt="Screenshot 2023-02-24 at 6 50 09 PM" src="https://user-images.githubusercontent.com/1937582/221267824-533037a1-1fea-47bf-ae1a-eed775085800.png">


### Checklist

- [X] Tests have been added/updated to cover changes in this PR
