### PR TITLE
fix pagination state shared between collections

### DIFF
--- a/frontend/src/metabase/collections/containers/CollectionContent.jsx
+++ b/frontend/src/metabase/collections/containers/CollectionContent.jsx
@@ -80,7 +80,8 @@ function CollectionContent({
     sort_column: "name",
     sort_direction: "asc",
   });
-  const { handleNextPage, handlePreviousPage, setPage, page } = usePagination();
+  const { handleNextPage, handlePreviousPage, setPage, page, resetPage } =
+    usePagination();
   const { selected, toggleItem, toggleAll, getIsSelected, clear } =
     useListSelect(itemKeyFn);
   const previousCollection = usePrevious(collection);
@@ -94,8 +95,9 @@ function CollectionContent({
   useEffect(() => {
     if (previousCollection && previousCollection.id !== collection.id) {
       clear();
+      resetPage();
     }
-  }, [previousCollection, collection, clear]);
+  }, [previousCollection, collection, clear, resetPage]);
 
   useEffect(() => {
     const shouldBeBookmarked = bookmarks.some(

--- a/frontend/src/metabase/hooks/use-pagination.ts
+++ b/frontend/src/metabase/hooks/use-pagination.ts
@@ -12,10 +12,16 @@ export const usePagination = (initialPage = 0) => {
     [setPage],
   );
 
+  const resetPage = useCallback(
+    () => setPage(initialPage),
+    [setPage, initialPage],
+  );
+
   return {
     handleNextPage,
     handlePreviousPage,
     setPage,
     page,
+    resetPage,
   };
 };

--- a/frontend/src/metabase/hooks/use-pagination.unit.spec.ts
+++ b/frontend/src/metabase/hooks/use-pagination.unit.spec.ts
@@ -1,0 +1,15 @@
+import { renderHook, act } from "@testing-library/react-hooks";
+import { usePagination } from "./use-pagination";
+
+describe("usePagination", () => {
+  it("should set 'page' to 'initialPage' upon calling 'resetPage'", () => {
+    const initialPage = 3;
+    const { result } = renderHook(() => usePagination(initialPage));
+
+    act(() => result.current.handleNextPage());
+    expect(result.current.page).toEqual(initialPage + 1);
+
+    act(() => result.current.resetPage());
+    expect(result.current.page).toEqual(initialPage);
+  });
+});


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/28010

### Description

There was a bug where pagination state was being shared between collections. E.g. if you navigated to page 2 on one collection, then opened another collection from the sidebar, that collection would also be on page 2.

I fixed this by having the `usePagination` hook provide a `resetPage` function that will be called when navigating to another collection in `CollectionContent`. Note that I also renamed `use-pagination.js` to `use-pagination.ts` to convert to Typescript (no other changes were needed for the conversion).

### How to verify

Describe the steps to verify that the changes are working as expected.

Have multiple paginated (over 25 items) collections. In the first collection, navigate to another page. Open the other collection and confirm it is on the first page.

### Demo

https://user-images.githubusercontent.com/37751258/221270195-eb953a4f-8f4b-438b-a914-7d8f8e388050.mov

### Checklist

- [✅] Tests have been added/updated to cover changes in this PR
