### PR TITLE
adding delay to typing

### DIFF
--- a/frontend/test/metabase/scenarios/native-filters/helpers/e2e-sql-filter-helpers.js
+++ b/frontend/test/metabase/scenarios/native-filters/helpers/e2e-sql-filter-helpers.js
@@ -83,6 +83,9 @@ export function runQuery(xhrAlias = "dataset") {
  *
  * @param {string} query
  */
-export function enterParameterizedQuery(query) {
-  cy.get("@editor").type(query, { parseSpecialCharSequences: false });
+export function enterParameterizedQuery(query, options = {}) {
+  cy.get("@editor").type(query, {
+    parseSpecialCharSequences: false,
+    ...options,
+  });
 }

--- a/frontend/test/metabase/scenarios/native/native_subquery.cy.spec.js
+++ b/frontend/test/metabase/scenarios/native/native_subquery.cy.spec.js
@@ -283,7 +283,9 @@ describe("scenarios > question > native subquery", () => {
         cy.intercept("GET", `/api/card/${nestedQuestionId}`).as("loadQuestion");
 
         startNewNativeQuestion();
-        SQLFilter.enterParameterizedQuery(`SELECT * FROM {{${tagID}`);
+        SQLFilter.enterParameterizedQuery(`SELECT * FROM {{${tagID}`, {
+          delay: 100,
+        });
         cy.wait("@loadQuestion");
 
         cy.findByTestId("sidebar-header-title").should(


### PR DESCRIPTION
Should address the flake caused by unskipping the test from https://github.com/metabase/metabase/pull/28562 . Appears that cypress types too fast for the query editor to pick up the question reference, so it doesn't open the sidebar. Note that if I paste a whole query in the editor in stats, it also doesn't open the sidebar.

The delay should only be applied to this test.
