### PR TITLE
Optimize formatNumber and formatDate*

### DIFF
--- a/shared/src/metabase/shared/formatting/internal/date_options.cljc
+++ b/shared/src/metabase/shared/formatting/internal/date_options.cljc
@@ -2,7 +2,7 @@
   "Normalization and helper predicates for date formatting options maps."
   (:require
    [metabase.shared.formatting.constants :as constants]
-   [metabase.util :as u]))
+   [metabase.shared.util.options :as options]))
 
 (def ^:private default-options
   {:date-enabled   true
@@ -20,6 +20,33 @@
 (def ^:private time-only?
   #{:hour-of-day})
 
+(def ^:private normalize-options
+  (let [decoder (options/options-decoder {:compact "compact"
+                                          :date-abbreviate "date_abbreviate"
+                                          :date-format "date_format"
+                                          :date-separator "date_separator"
+                                          :date-style "date_style"
+                                          :decimals "decimals"
+                                          :is-exclude "isExclude"
+                                          :local "local"
+                                          :maximum-fraction-digits "maximumFractionDigits"
+                                          :minimum-fraction-digits "minimumFractionDigits"
+                                          :no-range "noRange"
+                                          :number-separators "number_separators"
+                                          :time-enabled "time_enabled"
+                                          :time-style "time_style"
+                                          :time-format "time_format"
+                                          :type "type"
+                                          :unit "unit"
+                                          :view-as "view_as"
+                                          :weekday-enabled "weekday_enabled"})]
+    #?(:clj  decoder
+       :cljs #(-> %
+                  decoder
+                  (m/update-existing :time-format js->clj)
+                  (m/update-existing :date-format js->clj)
+                  (m/update-existing :date-style  js->clj)))))
+
 (defn prepare-options
   "Normalizes the options map. This returns a Clojure map with `:kebab-case-keys`, whatever the input object or
   key spelling.
@@ -31,7 +58,7 @@
   - transforming `:compact true` to `:output-density \"compact\"` (takes precedence over `\"condensed\"`).
   - make `:unit` a keyword"
   [options]
-  (let [options                               (-> (u/normalize-map options)
+  (let [options                               (-> (normalize-options options)
                                                   (update :unit keyword))
         {:keys [compact date-abbreviate
                 type unit]

--- a/shared/src/metabase/shared/formatting/numbers.cljc
+++ b/shared/src/metabase/shared/formatting/numbers.cljc
@@ -2,7 +2,7 @@
   (:require
    [metabase.shared.formatting.internal.numbers :as internal]
    [metabase.shared.formatting.internal.numbers-core :as core]
-   [metabase.util :as u]))
+   [metabase.shared.util.options :as options]))
 
 (declare format-number)
 
@@ -82,6 +82,21 @@
              :else (internal/number-formatter-for-options options))]
     (core/format-number-basic nf number)))
 
+(def ^:private normalize-options
+  (options/options-decoder {:compact                    "compact"
+                            :currency                   "currency"
+                            :currency-style             "currency_style"
+                            :maximum-fraction-digits    "maximumFractionDigits"
+                            :minimum-fraction-digits    "minimumFractionDigits"
+                            :minimum-integer-digits     "minimumIntegerDigits"
+                            :maximum-significant-digits "maximumSignificantDigits"
+                            :minimum-significant-digits "minimumSignificantDigits"
+                            :negative-in-parentheses    "negativeInParentheses"
+                            :number-separators          "number_separators"
+                            :number-style               "number_style"
+                            :scale                      "scale"
+                            :type                       "type"}))
+
 (defn ^:export format-number
   "Formats a number according to a map of options.
   The options:
@@ -103,7 +118,7 @@
       - \"decimal\" (the default) is basic numeric notation.
   - `:scale` number: Gives a factor by which to multiply the value before rendering it."
   [number options]
-  (let [{:keys [compact negative-in-parentheses number-style scale] :as options} (u/normalize-map options)]
+  (let [{:keys [compact negative-in-parentheses number-style scale] :as options} (normalize-options options)]
     (cond
       (and scale (not (NaN? scale))) (format-number (* scale number) (dissoc options :scale))
 

--- a/shared/src/metabase/shared/util/options.cljc
+++ b/shared/src/metabase/shared/util/options.cljc
@@ -1,0 +1,18 @@
+(ns metabase.shared.util.options
+  #?(:cljs (:require
+            [cljs-bean.core :as bean])))
+
+(defn options-decoder
+  "Given a map of keyword Clojure option names to string JS property names, returns a function
+  that will transform a JS object to a CLJS map based on those names.
+
+  Uses cljs-bean to do this efficiently and on-demand."
+  [key->prop]
+  #?(:clj  identity
+     :cljs (let [prop->key (into {} (for [[k v] key->prop]
+                                      [v k]))]
+             #(if (map? %)
+                %
+                (bean/bean %
+                           :key->prop key->prop
+                           :prop->key prop->key)))))

--- a/shared/src/metabase/shared/util/time.cljc
+++ b/shared/src/metabase/shared/util/time.cljc
@@ -3,10 +3,10 @@
   In Java these return [[OffsetDateTime]], in JavaScript they return Moments.
   Most of the implementations are in the split CLJ/CLJS files [[metabase.shared.util.internal.time]]."
   (:require
+   [metabase.shared.util.options :as options]
    [metabase.shared.util.internal.time :as internal]
    [metabase.shared.util.internal.time-common :as common]
-   [metabase.shared.util.namespaces :as shared.ns]
-   [metabase.util :as u]))
+   [metabase.shared.util.namespaces :as shared.ns]))
 
 ;; Importing and re-exporting some functions defined in each implementation.
 (shared.ns/import-fn common/to-range)
@@ -15,8 +15,11 @@
 (shared.ns/import-fn internal/same-month?)
 (shared.ns/import-fn internal/same-year?)
 
-(defn- prep-options [options]
-  (merge internal/default-options (u/normalize-map options)))
+(def ^:private prep-options
+  (let [decoder (options/options-decoder {:local  "local"
+                                          :locale "locale"
+                                          :unit   "unit"})]
+    #(merge internal/default-options (decoder %))))
 
 (defn ^:export coerce-to-timestamp
   "Parses a timestamp value into a date object. This can be a straightforward Unix timestamp or ISO format string.


### PR DESCRIPTION
These were causing perceptible lag on dashboards. The culprit is
not the formatting itself, but conversion of the `options`
objects into Clojure-friendly form.

In particular, transforming `"snake_case"` and `"camelCase"` strings
into `:kebab-case` requires a lot of string munging. These are fairly
hot functions, called on each cell of a table every time they re-render,
so it pays to be fast here.

This improves the time spent here by 2.5-3x on my machine, and that's
likely to scale up even more with larger tables.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/28623)
<!-- Reviewable:end -->
