### PR TITLE
stack area chart with breakouts

### DIFF
--- a/frontend/src/metabase/visualizations/lib/settings/graph.js
+++ b/frontend/src/metabase/visualizations/lib/settings/graph.js
@@ -358,12 +358,19 @@ export const STACKABLE_SETTINGS = {
       }
       return true;
     },
-    getDefault: ([{ card, data }], settings) =>
+    getDefault: ([{ card, data }], settings) => {
       // legacy setting and default for D-M-M+ charts
-      settings["stackable.stacked"] ||
-      (card.display === "area" && settings["graph.metrics"].length > 1)
-        ? "stacked"
-        : null,
+      if (settings["stackable.stacked"]) {
+        return settings["stackable.stacked"];
+      }
+
+      const shouldStack =
+        card.display === "area" &&
+        (settings["graph.metrics"].length > 1 ||
+          settings["graph.dimensions"].length > 1);
+
+      return shouldStack ? "stacked" : null;
+    },
     getHidden: (series, settings) => {
       const displays = series.map(single => settings.series(single).display);
       const stackableDisplays = displays.filter(display =>
@@ -371,7 +378,7 @@ export const STACKABLE_SETTINGS = {
       );
       return stackableDisplays.length <= 1;
     },
-    readDependencies: ["graph.metrics", "series"],
+    readDependencies: ["graph.metrics", "graph.dimensions", "series"],
   },
   "stackable.stack_display": {
     section: t`Display`,

--- a/frontend/src/metabase/visualizations/lib/settings/graph.unit.spec.js
+++ b/frontend/src/metabase/visualizations/lib/settings/graph.unit.spec.js
@@ -1,0 +1,46 @@
+import { STACKABLE_SETTINGS } from "./graph";
+
+describe("STACKABLE_SETTINGS", () => {
+  describe("stackable.stack_type", () => {
+    describe("getDefault", () => {
+      const getDefault = STACKABLE_SETTINGS["stackable.stack_type"].getDefault;
+
+      it("should return stacked if area chart has more than 1 metric", () => {
+        const value = getDefault([{ card: { display: "area" } }], {
+          "graph.metrics": ["foo", "bar"],
+          "graph.dimensions": [],
+        });
+
+        expect(value).toBe("stacked");
+      });
+
+      it("should return stacked if area chart has more than 1 dimension", () => {
+        const value = getDefault([{ card: { display: "area" } }], {
+          "graph.metrics": [],
+          "graph.dimensions": ["foo", "bar"],
+        });
+
+        expect(value).toBe("stacked");
+      });
+
+      it("should return null if area chart has 1 metric and 1 dimension", () => {
+        const value = getDefault([{ card: { display: "area" } }], {
+          "graph.metrics": ["foo"],
+          "graph.dimensions": ["bar"],
+        });
+
+        expect(value).toBeNull();
+      });
+
+      it("should return the legacy 'stackable.stacked' value if present", () => {
+        const value = getDefault([{ card: { display: "area" } }], {
+          "stackable.stacked": "normalized",
+          "graph.metrics": ["foo", "bar"],
+          "graph.dimensions": ["bar"],
+        });
+
+        expect(value).toBe("normalized");
+      });
+    });
+  });
+});

--- a/src/metabase/pulse/render/body.clj
+++ b/src/metabase/pulse/render/body.clj
@@ -347,7 +347,9 @@
                       (= (:stackable.stack_type viz-settings) "stacked")
                       (and
                        (= (:display card) :area)
-                       (> (count (:graph.metrics viz-settings)) 1)))]
+                       (or
+                        (> (count (:graph.metrics viz-settings)) 1)
+                        (> (count (:graph.dimensions viz-settings)) 1))))]
     (if stacked
       (assoc viz-settings :stackable.stack_type "stacked")
       viz-settings)))


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/28515

### Description

Stack area charts with breakouts by default.
Static viz stacked area charts are broken due to https://github.com/metabase/metabase/issues/20559

### How to verify

1. New question -> Sample Dataset -> Orders -> Summarize Count by Created At and Product[Category]
2. Change the viz type to `area`
3. Ensure the chart is stacked
4. Add it on a dashboard and send a test subscription
5. Ensure it is stacked (but broken now)


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
