### PR TITLE
update the row chart style

### DIFF
--- a/frontend/src/metabase/visualizations/shared/components/RowChartView/RowChartView.tsx
+++ b/frontend/src/metabase/visualizations/shared/components/RowChartView/RowChartView.tsx
@@ -199,7 +199,7 @@ const RowChartView = <TDatum,>({
           stroke={theme.axis.color}
           tickStroke={theme.axis.color}
           tickLabelProps={() => ({
-            fill: theme.axis.color,
+            fill: theme.axis.ticks.color,
             fontSize: theme.axis.ticks.size,
             fontWeight: theme.axis.ticks.weight,
             textAnchor: "end",

--- a/frontend/src/metabase/visualizations/visualizations/RowChart/utils/theme.ts
+++ b/frontend/src/metabase/visualizations/visualizations/RowChart/utils/theme.ts
@@ -1,21 +1,20 @@
 import { color } from "metabase/lib/colors";
 import { RowChartTheme } from "metabase/visualizations/shared/components/RowChart/types";
 
-// FIXME: provide font-family
 export const getChartTheme = (fontFamily: string = "Lato"): RowChartTheme => {
   return {
     axis: {
-      color: color("bg-dark"),
+      color: color("text-light"),
       ticks: {
         size: 12,
         weight: 900,
-        color: color("bg-dark"),
+        color: color("text-medium"),
         family: fontFamily,
       },
       label: {
         size: 14,
         weight: 900,
-        color: color("bg-dark"),
+        color: color("text-medium"),
         family: fontFamily,
       },
     },


### PR DESCRIPTION
### Description

We've made the `text-light` color darker for better a11y, but the row chart used an invalid alias for ticks and axes so it did not get the new look.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. New question -> Sample Dataset -> Orders: summarize Count by Product[Category]
2. Select the Row viz type
3. Ensure ticks and axes are dark as on the Bar viz type charts

### Demo

#### Before
<img width="1368" alt="Screen Shot 2023-02-24 at 9 14 46 PM" src="https://user-images.githubusercontent.com/14301985/221324140-ee3bb6f8-24dc-4bf5-8129-5bbc2c79502b.png">

#### After
<img width="1356" alt="Screen Shot 2023-02-24 at 8 40 05 PM" src="https://user-images.githubusercontent.com/14301985/221321438-9f6217c0-6ee0-4946-906d-064b61b4fdda.png">

### Checklist

- [n/a] Tests have been added/updated to cover changes in this PR — style change
