### PR TITLE
Chartsettings use custom column names

### DIFF
--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingColumnEditor.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingColumnEditor.tsx
@@ -34,7 +34,7 @@ interface ChartSettingColumnEditorProps {
   isDashboard?: boolean;
   metadata?: Metadata;
   isQueryRunning: boolean;
-  getCustomColumnName: (val: DatasetColumn) => string;
+  getCustomColumnName: (val: DatasetColumn, onlyCustom: boolean) => string;
 }
 
 const structuredQueryFieldOptions = (
@@ -204,12 +204,9 @@ const ChartSettingColumnEditor = ({
     // This ensures that we get the {table}→{column} syntax when appropriate. On anything other than the
     // Source table, there should be a table header above the list so we should only show the field name.
     if (column) {
-      const customName = getCustomColumnName(column);
-      if (customName) {
-        return customName;
-      } else if (sourceTable) {
-        return column.display_name;
-      }
+      return (
+        getCustomColumnName(column, !sourceTable) || dimension.displayName()
+      );
     }
 
     return dimension.displayName();

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingColumnEditor.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingColumnEditor.tsx
@@ -34,7 +34,7 @@ interface ChartSettingColumnEditorProps {
   isDashboard?: boolean;
   metadata?: Metadata;
   isQueryRunning: boolean;
-  getItemTitle: (val: DatasetColumn) => string;
+  getCustomColumnName: (val: DatasetColumn) => string;
 }
 
 const structuredQueryFieldOptions = (
@@ -104,7 +104,7 @@ const ChartSettingColumnEditor = ({
   isDashboard,
   metadata,
   isQueryRunning,
-  getItemTitle,
+  getCustomColumnName,
 }: ChartSettingColumnEditorProps) => {
   const fieldOptions = useMemo(() => {
     const query = question && question.query();
@@ -204,7 +204,7 @@ const ChartSettingColumnEditor = ({
     // This ensures that we get the {table}→{column} syntax when appropriate. On anything other than the
     // Source table, there should be a table header above the list so we should only show the field name.
     if (column) {
-      const customName = getItemTitle(column);
+      const customName = getCustomColumnName(column);
       if (customName) {
         return customName;
       } else if (sourceTable) {

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingColumnEditor.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingColumnEditor.tsx
@@ -34,6 +34,7 @@ interface ChartSettingColumnEditorProps {
   isDashboard?: boolean;
   metadata?: Metadata;
   isQueryRunning: boolean;
+  getItemTitle: (val: DatasetColumn) => string;
 }
 
 const structuredQueryFieldOptions = (
@@ -103,6 +104,7 @@ const ChartSettingColumnEditor = ({
   isDashboard,
   metadata,
   isQueryRunning,
+  getItemTitle,
 }: ChartSettingColumnEditorProps) => {
   const fieldOptions = useMemo(() => {
     const query = question && question.query();
@@ -201,8 +203,13 @@ const ChartSettingColumnEditor = ({
     // When we have a colum returned, we want to use that display name as long as it's part of the source table
     // This ensures that we get the {table}→{column} syntax when appropriate. On anything other than the
     // Source table, there should be a table header above the list so we should only show the field name.
-    if (column && sourceTable) {
-      return column.display_name;
+    if (column) {
+      const customName = getItemTitle(column);
+      if (customName) {
+        return customName;
+      } else if (sourceTable) {
+        return column.display_name;
+      }
     }
 
     return dimension.displayName();

--- a/frontend/src/metabase/visualizations/visualizations/Table.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Table.jsx
@@ -279,14 +279,14 @@ export default class Table extends Component {
         isDashboard: extra.isDashboard,
         metadata: extra.metadata,
         isQueryRunning: extra.isQueryRunning,
-        getCustomColumnName: column => {
-          const customName = getIn(vizSettings, [
-            "column_settings",
-            getColumnKey(column),
-            "column_title",
-          ]);
-
-          return customName;
+        getCustomColumnName: (column, onlyCustom) => {
+          return onlyCustom
+            ? getIn(vizSettings, [
+                "column_settings",
+                getColumnKey(column),
+                "column_title",
+              ])
+            : getColumnNameFromSettings(vizSettings, column);
         },
       }),
     },


### PR DESCRIPTION
Updates the Table viz so that custom column names are appropriately shown throughout the settings. Custom names should now render in both the column picker and the column ordered.

Example:
![chrome_51qOOLJD7D](https://user-images.githubusercontent.com/1328979/221326284-a743e7fb-0fb6-4c9c-8b61-3d4185c87568.gif)
