### PR TITLE
[CI] Refine and update code coverage rules and targets

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -17,7 +17,7 @@ coverage:
           - back-end
 
       front-end:
-        target: 40%
+        target: 50%
         threshold: 5%
         flags:
           - front-end

--- a/codecov.yml
+++ b/codecov.yml
@@ -10,7 +10,7 @@ coverage:
     project:
       back-end:
         # Project must always have at least 78% coverage (by line)
-        target: 78%
+        target: 85%
         # Whole-project test coverage is allowed to drop up to 5%. (For situtations where we delete code with full coverage)
         threshold: 5%
         flags:

--- a/codecov.yml
+++ b/codecov.yml
@@ -2,9 +2,6 @@ codecov:
     bot: "codecov-io"
     require_ci_to_pass: false
 
-ignore:
-  - "**/*.unit.*"
-
 coverage:
   status:
     project:

--- a/codecov.yml
+++ b/codecov.yml
@@ -2,6 +2,9 @@ codecov:
     bot: "codecov-io"
     require_ci_to_pass: false
 
+ignore:
+  - "**/*.unit.*"
+
 coverage:
   status:
     project:
@@ -31,6 +34,6 @@ flags:
 
   front-end:
     paths:
-      - enterprise/frontend
-      - frontend
+      - enterprise/frontend/src
+      - frontend/src
     carryforward: true

--- a/jest.unit.conf.json
+++ b/jest.unit.conf.json
@@ -40,8 +40,7 @@
   "coverageReporters": ["text", "html", "lcov"],
   "collectCoverageFrom": [
     "frontend/src/**/*.{js,jsx,ts,tsx}",
-    "enterprise/frontend/src/**/*.{js,jsx,ts,tsx}",
-    "**/*.stories.{js,jsx,ts,tsx}"
+    "enterprise/frontend/src/**/*.{js,jsx,ts,tsx}"
   ],
   "coveragePathIgnorePatterns": [
     "/node_modules/",
@@ -51,7 +50,8 @@
     "/frontend/test/",
     ".styled.{jsx,tsx}",
     ".info.js",
-    "**/*.unit.*"
+    "**/*.unit.*",
+    "**/*.stories.{js,jsx,ts,tsx}"
   ],
   "testEnvironment": "jest-environment-jsdom",
   "watchPlugins": [

--- a/jest.unit.conf.json
+++ b/jest.unit.conf.json
@@ -50,7 +50,8 @@
     "/frontend/src/metabase/internal/",
     "/frontend/test/",
     ".styled.{jsx,tsx}",
-    ".info.js"
+    ".info.js",
+    "**/*.unit.*"
   ],
   "testEnvironment": "jest-environment-jsdom",
   "watchPlugins": [


### PR DESCRIPTION
There are at least two things that we can improve here:
- Scope the `frontend` flag to only track source file changes instead of everything within the `frontend/` path
    - Explicitly ignore FE unit tests
- Bump frontend and backend targets because we improved the coverage

![image](https://user-images.githubusercontent.com/31325167/221403578-ade92bc0-049e-4d32-aa07-abd6ff2a42b9.png)
