### PR TITLE
Removing join alias from source table in ChartSettingColumnEditor field options

### DIFF
--- a/frontend/src/metabase-lib/queries/StructuredQuery.ts
+++ b/frontend/src/metabase-lib/queries/StructuredQuery.ts
@@ -1264,7 +1264,7 @@ class StructuredQueryInner extends AtomicQuery {
 
       for (const dimension of filteredNonFKDimensions) {
         dimensionOptions.count++;
-        dimensionOptions.dimensions.push(dimension.withoutJoinAlias());
+        dimensionOptions.dimensions.push(dimension);
       }
 
       // de-duplicate explicit and implicit joined tables

--- a/frontend/src/metabase-lib/queries/StructuredQuery.ts
+++ b/frontend/src/metabase-lib/queries/StructuredQuery.ts
@@ -1264,7 +1264,7 @@ class StructuredQueryInner extends AtomicQuery {
 
       for (const dimension of filteredNonFKDimensions) {
         dimensionOptions.count++;
-        dimensionOptions.dimensions.push(dimension);
+        dimensionOptions.dimensions.push(dimension.withoutJoinAlias());
       }
 
       // de-duplicate explicit and implicit joined tables

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingColumnEditor.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingColumnEditor.tsx
@@ -41,6 +41,11 @@ const structuredQueryFieldOptions = (
   columns: DatasetColumn[],
 ) => {
   const options = query.fieldsOptions();
+  // Remove join alias from source table (#28663)
+  options.dimensions = options.dimensions.map(dimension =>
+    dimension.withoutJoinAlias(),
+  );
+
   const allFields = options.dimensions.concat(
     options.fks.reduce(
       (memo, fk) => memo.concat(fk.dimensions),


### PR DESCRIPTION
Fixes #28662 

This bug is happening because the `field_refs` on the columns returned from the dataset call do not match up with the dimensions calculated using `StructuredQuery.fieldOptions()`, specifically with respect to the options map in the field ref.

It appears that when you use a saved question as your "source table", it treats all columns as though they belong to that table, so there are no join aliases in the `field_refs` for that portion of the query, even if the saved question is made up multiple tables joined together, the backend produces field refs within the context of the query. However, when we produce dimension options from the structured query, we produce `field_refs` based on the context of our metadata, so columns from the source table include join aliases. In the screenshot below, you can see that the columns returned by the back end don't have any join aliases, while the ones produced by the frontend do:
![image](https://user-images.githubusercontent.com/1328979/221469044-264ee5a0-6ca8-47e5-9930-acf51389a4dd.png)

This PR adjusts `StructuredQuery.fieldOptions()` to act more like the API and says that if the dimension I'm looking at is part of the source table, then don't include any join alias in the field ref.

This PR currently doesn't include any tests, because I'm not sure if this is how we will want to solve this or not. If we decide this is an acceptable route then I'll add testing before merging.