### PR TITLE
Fix conditional formatting render with black background when values >= 1,000

### DIFF
--- a/src/metabase/pulse/render/body.clj
+++ b/src/metabase/pulse/render/body.clj
@@ -135,7 +135,7 @@
                     ;; in the output and should be skipped
                     :when              (not (:remapped_from maybe-remapped-col))]
                 (if (isa? ((some-fn :effective_type :base_type) col) :type/Number)
-                  (common/->NumericWrapper col-name)
+                  (common/map->NumericWrapper {:num-str col-name :num-value col-name})
                   col-name))
    :bar-width (when include-bar? 99)})
 

--- a/src/metabase/pulse/render/color.clj
+++ b/src/metabase/pulse/render/color.clj
@@ -4,7 +4,6 @@
   (:require
    [cheshire.core :as json]
    [clojure.java.io :as io]
-   [clojure.string :as str]
    [metabase.pulse.render.common :as common]
    [metabase.pulse.render.js-engine :as js]
    [metabase.util.i18n :refer [trs]]
@@ -53,24 +52,12 @@
                       rows
                       (json/generate-string cols)
                       (json/generate-string viz-settings)))
-
-(defn- parse-number
-  [s]
-  (if (str/includes? s ".")
-    (parse-double s)
-    (parse-long s)))
-
 (defn get-background-color
   "Get the correct color for a cell in a pulse table. Returns color as string suitable for use CSS, e.g. a hex string or
   `rgba()` string. This is intended to be invoked on each cell of every row in the table. See `make-color-selector`
   for more info."
   ^String [color-selector cell-value column-name row-index]
-  (let [cell-value (cond
-                     (instance? NumericWrapper cell-value)
-                     (-> ^NumericWrapper cell-value
-                         .toString
-                         (str/replace #"," "")
-                         parse-number)
-                     :else
+  (let [cell-value (if (instance? NumericWrapper cell-value)
+                     (:num-value cell-value)
                      cell-value)]
-   (.asString (js/execute-fn color-selector cell-value row-index column-name))))
+    (.asString (js/execute-fn color-selector cell-value row-index column-name))))

--- a/src/metabase/pulse/render/color.clj
+++ b/src/metabase/pulse/render/color.clj
@@ -54,6 +54,12 @@
                       (json/generate-string cols)
                       (json/generate-string viz-settings)))
 
+(defn- parse-number
+  [s]
+  (if (str/includes? s ".")
+    (parse-double s)
+    (parse-long s)))
+
 (defn get-background-color
   "Get the correct color for a cell in a pulse table. Returns color as string suitable for use CSS, e.g. a hex string or
   `rgba()` string. This is intended to be invoked on each cell of every row in the table. See `make-color-selector`
@@ -63,7 +69,8 @@
                      (instance? NumericWrapper cell-value)
                      (-> ^NumericWrapper cell-value
                          .toString
-                         (str/replace #"," ""))
+                         (str/replace #"," "")
+                         parse-number)
                      :else
                      cell-value)]
    (.asString (js/execute-fn color-selector cell-value row-index column-name))))

--- a/src/metabase/pulse/render/color.clj
+++ b/src/metabase/pulse/render/color.clj
@@ -4,9 +4,14 @@
   (:require
    [cheshire.core :as json]
    [clojure.java.io :as io]
+   [clojure.string :as str]
+   [metabase.pulse.render.common :as common]
    [metabase.pulse.render.js-engine :as js]
    [metabase.util.i18n :refer [trs]]
-   [schema.core :as s]))
+   [schema.core :as s])
+  (:import
+    (metabase.pulse.render.common NumericWrapper)))
+
 
 (set! *warn-on-reflection* true)
 
@@ -54,4 +59,11 @@
   `rgba()` string. This is intended to be invoked on each cell of every row in the table. See `make-color-selector`
   for more info."
   ^String [color-selector cell-value column-name row-index]
-  (.asString (js/execute-fn color-selector cell-value row-index column-name)))
+  (let [cell-value (cond
+                     (instance? NumericWrapper cell-value)
+                     (-> ^NumericWrapper cell-value
+                         .toString
+                         (str/replace #"," ""))
+                     :else
+                     cell-value)]
+   (.asString (js/execute-fn color-selector cell-value row-index column-name))))

--- a/src/metabase/pulse/render/common.clj
+++ b/src/metabase/pulse/render/common.clj
@@ -25,7 +25,7 @@
    :content                      [s/Any]
    (s/optional-key :render/text) (s/maybe s/Str)})
 
-(p.types/defrecord+ NumericWrapper [num-str]
+(p.types/defrecord+ NumericWrapper [^String num-str ^Number num-value]
   hiccup.util/ToString
   (to-str [_] num-str)
 
@@ -126,25 +126,27 @@
                         scientific? (str "E0")
                         percent?    (str "%"))
               fmtr (doto (DecimalFormat. fmt-str symbols) (.setRoundingMode RoundingMode/HALF_UP))]
-          (NumericWrapper.
-           (str (when prefix prefix)
-                (when (and currency? (or (nil? currency-style)
-                                         (= currency-style "symbol")))
-                  (get-in currency/currency [(keyword (or currency "USD")) :symbol]))
-                (when (and currency? (= currency-style "code"))
-                  (str (get-in currency/currency [(keyword (or currency "USD")) :code]) \space))
-                (cond-> (.format fmtr scaled-value)
-                  (not decimals) (strip-trailing-zeroes decimal))
-                (when (and currency? (= currency-style "name"))
-                  (str \space (get-in currency/currency [(keyword (or currency "USD")) :name_plural])))
-                (when suffix suffix))))
+          (map->NumericWrapper
+            {:num-value value
+             :num-str   (str (when prefix prefix)
+                             (when (and currency? (or (nil? currency-style)
+                                                      (= currency-style "symbol")))
+                               (get-in currency/currency [(keyword (or currency "USD")) :symbol]))
+                             (when (and currency? (= currency-style "code"))
+                               (str (get-in currency/currency [(keyword (or currency "USD")) :code]) \space))
+                             (cond-> (.format fmtr scaled-value)
+                               (not decimals) (strip-trailing-zeroes decimal))
+                             (when (and currency? (= currency-style "name"))
+                               (str \space (get-in currency/currency [(keyword (or currency "USD")) :name_plural])))
+                             (when suffix suffix))}))
         value))))
 
 (s/defn format-number :- NumericWrapper
   "Format a number `n` and return it as a NumericWrapper; this type is used to do special formatting in other
   `pulse.render` namespaces."
   ([n :- s/Num]
-   (NumericWrapper. (cl-format nil (if (integer? n) "~:d" "~,2f") n)))
+   (map->NumericWrapper {:num-str   (cl-format nil (if (integer? n) "~:d" "~,2f") n)
+                         :num-value n}))
   ([value column viz-settings]
    (let [fmttr (number-formatter column viz-settings)]
      (fmttr value))))

--- a/test/metabase/pulse/render/body_test.clj
+++ b/test/metabase/pulse/render/body_test.clj
@@ -46,11 +46,12 @@
 (defn- col-counts [results]
   (set (map (comp count :row) results)))
 
-(defn- number [x]
-  (common/map->NumericWrapper {:num-str x :value x}))
+(defn- number [num-str num-value]
+  (common/map->NumericWrapper {:num-str   (str num-str)
+                               :num-value num-value}))
 
 (def ^:private default-header-result
-  [{:row       [(number "ID") (number "Latitude") "Last Login" "Name"]
+  [{:row       [(number "ID" "ID") (number "Latitude" "Latitude") "Last Login" "Name"]
     :bar-width nil}
    #{4}])
 
@@ -151,23 +152,23 @@
 
 ;; When there are too many columns, #'body/prep-for-html-rendering show narrow it
 (deftest narrow-the-columns
-  (is (= [{:row [(number "ID") (number "Latitude")]
+  (is (= [{:row [(number "ID" "ID") (number "Latitude" "Latitude")]
            :bar-width 99}
           #{2}]
          (prep-for-html-rendering' (subvec test-columns 0 2) test-data second 0 40.0))))
 
 ;; Basic test that result rows are formatted correctly (dates, floating point numbers etc)
 (deftest format-result-rows
-  (is (= [{:bar-width nil, :row [(number "1") (number "34.1") "April 1, 2014" "Stout Burgers & Beers"]}
-          {:bar-width nil, :row [(number "2") (number "34.04") "December 5, 2014" "The Apple Pan"]}
-          {:bar-width nil, :row [(number "3") (number "34.05") "August 1, 2014" "The Gorbals"]}]
+  (is (= [{:bar-width nil, :row [(number "1" 1) (number "34.1" 34.0996) "April 1, 2014" "Stout Burgers & Beers"]}
+          {:bar-width nil, :row [(number "2" 2) (number "34.04" 34.0406) "December 5, 2014" "The Apple Pan"]}
+          {:bar-width nil, :row [(number "3" 3) (number "34.05" 34.0474) "August 1, 2014" "The Gorbals"]}]
          (rest (#'body/prep-for-html-rendering pacific-tz {} {:cols test-columns :rows test-data})))))
 
 ;; Testing the bar-column, which is the % of this row relative to the max of that column
 (deftest bar-column
-  (is (= [{:bar-width (float 85.249),  :row [(number "1") (number "34.1") "April 1, 2014" "Stout Burgers & Beers"]}
-          {:bar-width (float 85.1015), :row [(number "2") (number "34.04") "December 5, 2014" "The Apple Pan"]}
-          {:bar-width (float 85.1185), :row [(number "3") (number "34.05") "August 1, 2014" "The Gorbals"]}]
+  (is (= [{:bar-width (float 85.249),  :row [(number "1" 1) (number "34.1" 34.0996) "April 1, 2014" "Stout Burgers & Beers"]}
+          {:bar-width (float 85.1015), :row [(number "2" 2) (number "34.04" 34.0406) "December 5, 2014" "The Apple Pan"]}
+          {:bar-width (float 85.1185), :row [(number "3" 3) (number "34.05" 34.0474) "August 1, 2014" "The Gorbals"]}]
          (rest (#'body/prep-for-html-rendering pacific-tz {} {:cols test-columns :rows test-data}
                                                {:bar-column second, :min-value 0, :max-value 40})))))
 
@@ -201,16 +202,16 @@
 
 ;; With a remapped column, the header should contain the name of the remapped column (not the original)1
 (deftest remapped-col
-  (is (= [{:row [(number "ID") (number "Latitude") "Rating Desc" "Last Login" "Name"]
+  (is (= [{:row [(number "ID" "ID") (number "Latitude" "Latitude") "Rating Desc" "Last Login" "Name"]
            :bar-width nil}
           #{5}]
          (prep-for-html-rendering' test-columns-with-remapping test-data-with-remapping nil nil nil))))
 
 ;; Result rows should include only the remapped column value, not the original
 (deftest include-only-remapped-column-name
-  (is (= [[(number "1") (number "34.1") "Bad" "April 1, 2014" "Stout Burgers & Beers"]
-          [(number "2") (number "34.04") "Ok" "December 5, 2014" "The Apple Pan"]
-          [(number "3") (number "34.05") "Good" "August 1, 2014" "The Gorbals"]]
+  (is (= [[(number "1" 1) (number "34.1" 34.0996) "Bad" "April 1, 2014" "Stout Burgers & Beers"]
+          [(number "2" 2) (number "34.04" 34.0406) "Ok" "December 5, 2014" "The Apple Pan"]
+          [(number "3" 3) (number "34.05" 34.0474) "Good" "August 1, 2014" "The Gorbals"]]
          (map :row (rest (#'body/prep-for-html-rendering  pacific-tz
                                                           {}
                                                           {:cols test-columns-with-remapping :rows test-data-with-remapping}))))))
@@ -232,9 +233,9 @@
                                 :coercion_strategy :Coercion/ISO8601->DateTime}))
 
 (deftest cols-with-semantic-types
-  (is (= [{:bar-width nil, :row [(number "1") (number "34.1") "April 1, 2014" "Stout Burgers & Beers"]}
-          {:bar-width nil, :row [(number "2") (number "34.04") "December 5, 2014" "The Apple Pan"]}
-          {:bar-width nil, :row [(number "3") (number "34.05") "August 1, 2014" "The Gorbals"]}]
+  (is (= [{:bar-width nil, :row [(number "1" 1) (number "34.1" 34.0996) "April 1, 2014" "Stout Burgers & Beers"]}
+          {:bar-width nil, :row [(number "2" 2) (number "34.04" 34.0406) "December 5, 2014" "The Apple Pan"]}
+          {:bar-width nil, :row [(number "3" 3) (number "34.05" 34.0474) "August 1, 2014" "The Gorbals"]}]
          (rest (#'body/prep-for-html-rendering pacific-tz
                                                {}
                                                {:cols test-columns-with-date-semantic-type :rows test-data})))))

--- a/test/metabase/pulse/render/body_test.clj
+++ b/test/metabase/pulse/render/body_test.clj
@@ -47,7 +47,7 @@
   (set (map (comp count :row) results)))
 
 (defn- number [x]
-  (common/map->NumericWrapper {:num-str x}))
+  (common/map->NumericWrapper {:num-str x :value x}))
 
 (def ^:private default-header-result
   [{:row       [(number "ID") (number "Latitude") "Last Login" "Name"]

--- a/test/metabase/pulse/render/table_test.clj
+++ b/test/metabase/pulse/render/table_test.clj
@@ -4,7 +4,9 @@
    [metabase.pulse.render.color :as color]
    [metabase.pulse.render.table :as table]
    [metabase.pulse.render.test-util :as render.tu]
-   [metabase.test :as mt]))
+   [metabase.test :as mt])
+  (:import
+    (metabase.pulse.render.common NumericWrapper)))
 
 (defn- query-results->header+rows
   "Makes pulse header and data rows with no bar-width. Including bar-width just adds extra HTML that will be ignored."
@@ -59,16 +61,20 @@
   (let [query-results {:cols [{:name "a"} {:name "b"} {:name "c"}]
                        :rows [[1 2 3]
                               [4 5 6]
-                              [7 8 9]]}]
-    (is (= {"1" nil
-            "2" nil
-            "3" "rgba(0, 255, 0, 0.75)"
-            "4" nil
-            "5" nil
-            "6" "rgba(0, 128, 128, 0.75)"
-            "7" "rgba(255, 0, 0, 0.65)"
-            "8" "rgba(255, 0, 0, 0.2)"
-            "9" "rgba(0, 0, 255, 0.75)"}
+                              [7 8 9]
+                              [7 8 (NumericWrapper. "4.5")]
+                              [7 8 (NumericWrapper. "1,001")]]}]
+    (is (= {"1"     nil
+            "2"     nil
+            "3"     "rgba(0, 255, 0, 0.75)"
+            "4"     nil
+            "4.5"   "rgba(0, 191, 64, 0.75)"
+            "5"     nil
+            "6"     "rgba(0, 128, 128, 0.75)"
+            "7"     "rgba(255, 0, 0, 0.65)"
+            "8"     "rgba(255, 0, 0, 0.2)"
+            "9"     "rgba(0, 0, 255, 0.75)"
+            "1,001" "rgba(0, 0, 255, 0.75)"}
            (-> (color/make-color-selector query-results (:visualization_settings render.tu/test-card))
                (#'table/render-table 0 ["a" "b" "c"] (query-results->header+rows query-results))
                find-table-body

--- a/test/metabase/pulse/render/table_test.clj
+++ b/test/metabase/pulse/render/table_test.clj
@@ -2,11 +2,10 @@
   (:require
    [clojure.test :refer :all]
    [metabase.pulse.render.color :as color]
+   [metabase.pulse.render.common :as common]
    [metabase.pulse.render.table :as table]
    [metabase.pulse.render.test-util :as render.tu]
-   [metabase.test :as mt])
-  (:import
-    (metabase.pulse.render.common NumericWrapper)))
+   [metabase.test :as mt]))
 
 (defn- query-results->header+rows
   "Makes pulse header and data rows with no bar-width. Including bar-width just adds extra HTML that will be ignored."
@@ -62,19 +61,21 @@
                        :rows [[1 2 3]
                               [4 5 6]
                               [7 8 9]
-                              [7 8 (NumericWrapper. "4.5")]
-                              [7 8 (NumericWrapper. "1,001")]]}]
-    (is (= {"1"     nil
-            "2"     nil
-            "3"     "rgba(0, 255, 0, 0.75)"
-            "4"     nil
-            "4.5"   "rgba(0, 191, 64, 0.75)"
-            "5"     nil
-            "6"     "rgba(0, 128, 128, 0.75)"
-            "7"     "rgba(255, 0, 0, 0.65)"
-            "8"     "rgba(255, 0, 0, 0.2)"
-            "9"     "rgba(0, 0, 255, 0.75)"
-            "1,001" "rgba(0, 0, 255, 0.75)"}
+                              [7 8 (common/map->NumericWrapper {:num-str "4.5" :num-value 4.5})]
+                              [7 8 (common/map->NumericWrapper {:num-str "1,001.5" :num-value 1001.5})]    ;; default floating point seperator .
+                              [7 8 (common/map->NumericWrapper {:num-str "1.001,5" :num-value 1001.5})]]}] ;; floating point seperator is ,
+    (is (= {"1"       nil
+            "2"       nil
+            "3"       "rgba(0, 255, 0, 0.75)"
+            "4"       nil
+            "4.5"     "rgba(0, 191, 64, 0.75)"
+            "5"       nil
+            "6"       "rgba(0, 128, 128, 0.75)"
+            "7"       "rgba(255, 0, 0, 0.65)"
+            "8"       "rgba(255, 0, 0, 0.2)"
+            "9"       "rgba(0, 0, 255, 0.75)"
+            "1.001,5" "rgba(0, 0, 255, 0.75)"
+            "1,001.5" "rgba(0, 0, 255, 0.75)"}
            (-> (color/make-color-selector query-results (:visualization_settings render.tu/test-card))
                (#'table/render-table 0 ["a" "b" "c"] (query-results->header+rows query-results))
                find-table-body

--- a/test/metabase/pulse/render/test_util.clj
+++ b/test/metabase/pulse/render/test_util.clj
@@ -37,6 +37,7 @@
                                :highlight_row true}
                               {:columns       ["c"]
                                :type          "range"
+                               :operator      "="
                                :min_type      "custom"
                                :min_value     3
                                :max_type      "custom"


### PR DESCRIPTION
Fixes #13892 and #28725

When rendering a table for pulse, BE calls a js function to get the appropriate background color for each cell.
We had this bug because when calling the js function, we provided the js function with an object `(NumericWrapper. "1,000")` instead of a number.

the js function is nice enough to detect this is not a number and automatically call `.toString` on it, but since we formatted the number with a comma ("1,000") it doesn't know how to convert this to a number and return a default black color.

The fix is to make sure we unwrap value and parse the number correctly.