### PR TITLE
Fix e2e flake in dashboard downloads test

### DIFF
--- a/frontend/test/metabase/scenarios/downloads/downloads.cy.spec.js
+++ b/frontend/test/metabase/scenarios/downloads/downloads.cy.spec.js
@@ -67,14 +67,14 @@ describe("scenarios > question > download", () => {
       });
 
       cy.findByText("Q1").realHover();
-      cy.findAllByTestId("download-button").eq(0).click();
+      cy.findAllByTestId("download-button").eq(0).should("be.visible").click();
 
       popover().within(() => {
         cy.findByText(".png").click();
       });
 
       cy.findByText("Q2").realHover();
-      cy.findAllByTestId("download-button").eq(1).click();
+      cy.findAllByTestId("download-button").eq(1).should("be.visible").click();
 
       popover().within(() => {
         cy.findByText(".png").should("not.exist");

--- a/frontend/test/metabase/scenarios/downloads/downloads.cy.spec.js
+++ b/frontend/test/metabase/scenarios/downloads/downloads.cy.spec.js
@@ -84,9 +84,7 @@ describe("scenarios > question > download", () => {
     });
 
     it("from query builder", () => {
-      cy.createQuestion(canSavePngQuestion).then(({ body: { id } }) => {
-        cy.visit(`/question/${id}`);
-      });
+      cy.createQuestion(canSavePngQuestion, { visitQuestion: true });
 
       cy.findByTestId("download-button").click();
 
@@ -96,9 +94,7 @@ describe("scenarios > question > download", () => {
 
       cy.verifyDownload(".png", { contains: true });
 
-      cy.createQuestion(cannotSavePngQuestion).then(({ body: { id } }) => {
-        cy.visit(`/question/${id}`);
-      });
+      cy.createQuestion(cannotSavePngQuestion, { visitQuestion: true });
 
       cy.findByTestId("download-button").click();
 


### PR DESCRIPTION
Test was hovering then immediately clicking inside element shown by the hover.

Example of flake happening: https://github.com/metabase/metabase/actions/runs/4277270249/jobs/7446073694#step:12:194 

Flake recording:
https://www.deploysentinel.com/ci/runs/63fbe618a6931a441ee1b693