### PR TITLE
Repro #28673: Dashboard subscription attachments sent by default

### DIFF
--- a/frontend/test/metabase/scenarios/sharing/subscriptions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/sharing/subscriptions.cy.spec.js
@@ -102,6 +102,16 @@ describe("scenarios > dashboard > subscriptions", () => {
 
         popover().isRenderedWithinViewport();
       });
+
+      it.skip("should not send attachments by default if not explicitly selected (metabase#28673)", () => {
+        openDashboardSubscriptions();
+        assignRecipient();
+
+        cy.findByLabelText("Attach results").should("not.be.checked");
+        sendEmailAndAssert(
+          ({ attachments }) => expect(attachments).to.be.empty,
+        );
+      });
     });
 
     describe("with existing subscriptions", () => {


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #28673 

### How to test this manually?
- `yarn test-cypress-open`
- `frontend/test/metabase/scenarios/sharing/subscriptions.cy.spec.js`
- Replace `it.skip()` with `it.only()` to run the test in isolation
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/221632109-4d642095-3faf-4fac-905e-8d5e55e9adf6.png)

