### PR TITLE
Fix Jest coverage config

### DIFF
--- a/.github/file-paths.yaml
+++ b/.github/file-paths.yaml
@@ -27,7 +27,8 @@ frontend_specs: &frontend_specs
   - *shared_specs
   - "frontend/test/!(__support__|__runner__)/**"
   - "frontend/**/*.unit.*"
-  - "jest.config.js"
+  - "jest.unit.conf.json"
+  - "jest.tz.unit.conf.json"
 
 frontend_all: &frontend_all
   - *ci

--- a/jest.unit.conf.json
+++ b/jest.unit.conf.json
@@ -40,18 +40,18 @@
   "coverageReporters": ["text", "html", "lcov"],
   "collectCoverageFrom": [
     "frontend/src/**/*.{js,jsx,ts,tsx}",
-    "enterprise/frontend/src/**/*.{js,jsx,ts,tsx}"
+    "enterprise/frontend/src/**/*.{js,jsx,ts,tsx}",
+    "!<rootDir>/**/*.styled.{js,jsx,ts,tsx}",
+    "!<rootDir>/**/*.story.{js,jsx,ts,tsx}",
+    "!<rootDir>/**/*.info.{js,jsx,ts,tsx}",
+    "!<rootDir>/**/*.unit.spec.{js,jsx,ts,tsx}"
   ],
   "coveragePathIgnorePatterns": [
     "/node_modules/",
     "/frontend/src/metabase/visualizations/lib/errors.js",
     "/frontend/src/cljs/",
     "/frontend/src/metabase/internal/",
-    "/frontend/test/",
-    ".styled.{jsx,tsx}",
-    ".info.js",
-    "**/*.unit.*",
-    "**/*.stories.{js,jsx,ts,tsx}"
+    "/frontend/test/"
   ],
   "testEnvironment": "jest-environment-jsdom",
   "watchPlugins": [


### PR DESCRIPTION
Fixes an issue with an invalid file name regexp in Jest config, causing problems while running tests on CI. Example error:

```
FAIL frontend/src/metabase/parameters/utils/parameter-id.unit.spec.ts
  ● Test suite failed to run

    SyntaxError: Invalid regular expression: /**/*.unit.*/: Nothing to repeat
        at String.match (<anonymous>)

      at node_modules/@jest/transform/build/shouldInstrument.js:139:66
          at Array.some (<anonymous>)
      at shouldInstrument (node_modules/@jest/transform/build/shouldInstrument.js:139:39)
      at ScriptTransformer.transform (node_modules/@jest/transform/build/ScriptTransformer.js:694:37)
```

### How to verify

1. Run `yarn test-unit --coverage`
2. Ensure it doesn't error and prints the coverage
3. Ensure you can't see `.styled`, `.unit.spec`, `.info`, and `.story` files in the coverage report
