### PR TITLE
chore: Fix local eslint config for webstorm

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -118,9 +118,6 @@
       "extends": ["plugin:@typescript-eslint/recommended"],
       "files": ["*.ts", "*.tsx"],
       "parser": "@typescript-eslint/parser",
-      "parserOptions": {
-        "project": "./tsconfig.json"
-      },
       "plugins": ["@typescript-eslint"],
       "rules": {
         "prefer-rest-params": "off",


### PR DESCRIPTION
### Description

When working in WebStorm there is an error:
<img width="1073" alt="Screenshot 2023-02-27 at 22 44 37" src="https://user-images.githubusercontent.com/7983744/221654580-85fa27bf-fce4-455d-b305-91f08b223dad.png">

It happens because eslint config tries to resolve tsconfig using relative path.

### How to verify

1. Try to open any TS file nested deep in the project structure, e.g. `frontend/src/metabase-lib/queries/StructuredQuery.ts`
2. There should be no error with eslint config

