### PR TITLE
Fix action editor name bug

### DIFF
--- a/frontend/src/metabase/actions/containers/ActionCreator/CreateActionForm/CreateActionForm.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/CreateActionForm/CreateActionForm.tsx
@@ -58,8 +58,8 @@ function CreateActionForm({
       validationSchema={ACTION_SCHEMA}
       onSubmit={onCreate}
     >
-      {({ dirty }) => (
-        <Form disabled={!dirty}>
+      {({ isValid }) => (
+        <Form disabled={!isValid}>
           <FormInput
             name="name"
             title={t`Name`}
@@ -78,7 +78,7 @@ function CreateActionForm({
             {!!onCancel && (
               <Button type="button" onClick={onCancel}>{t`Cancel`}</Button>
             )}
-            <FormSubmitButton title={t`Create`} disabled={!dirty} primary />
+            <FormSubmitButton title={t`Create`} disabled={!isValid} primary />
           </FormFooter>
         </Form>
       )}

--- a/frontend/test/metabase/scenarios/models/model-actions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/models/model-actions.cy.spec.js
@@ -160,9 +160,11 @@ describe(
       });
 
       fillActionQuery(QUERY);
+      cy.findByText(/New Action/)
+        .clear()
+        .type("Discount order");
       cy.findByRole("button", { name: "Save" }).click();
       modal().within(() => {
-        cy.findByLabelText("Name").type("Discount order");
         cy.findByText("Select a model").click();
       });
       popover().findByText(SAMPLE_ORDERS_MODEL.name).click();


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/28680

### Description

There was a bug where if the user gave a name to an action in the action editor, then pressed "Save", in the save modal the "Create" button would be disabled, despite the user haven already given the action a name.

I fixed this by changing the `disabled` prop on the `Form` and `FormSubmitButton` components in `CreateActionForm` to check if schema is invalid (`!isValid`), rather than checking `!dirty`, since it is possible for the form to valid but not dirty if the user already input a title in the action editor.

### How to verify

1. Create a model from a single table (new > model) in a DB that has actions enabled
2. go to the model detail page for that model. Click the actions tab
3. create a new custom action
4. edit the action name in the title of the modal and write a query (query need not be valid)
5. click save, see the save modal pop up
6. see that the create button is enabled

### Demo

https://user-images.githubusercontent.com/37751258/221671261-8b308a27-9bc1-4b72-bdf2-5b88730b7d7f.mov

### Checklist

- [✅] Tests have been added/updated to cover changes in this PR
