### PR TITLE
Cleans up load/dump/import/export command invocation and option handling

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/serialization/api/serialize.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/api/serialize.clj
@@ -34,11 +34,10 @@
       (throw (ex-info (tru "Invalid Collection ID(s). These Collections do not exist: {0}"
                            (pr-str (set/difference (set collection_ids) (set existing-collection-ids))))
                       {:status-code 404}))))
-  (serialization.cmd/dump path
-                          {:v2                   true
-                           :selected-collections collection_ids
-                           :targets              (for [collection-id collection_ids]
-                                                   ["Collection" collection-id])})
+  (serialization.cmd/v2-dump path
+                             {:selected-collections collection_ids
+                              :targets              (for [collection-id collection_ids]
+                                                      ["Collection" collection-id])})
   ;; TODO -- not 100% sure this response makes sense. We can change it later with something more meaningful maybe
   {:status :ok})
 

--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/seed_entity_ids.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/seed_entity_ids.clj
@@ -99,11 +99,9 @@
   "Create entity IDs for any instances of models that support them but do not have them, i.e. find instances of models
   that have an `entity_id` column whose `entity_id` is `nil` and populate that column.
 
-  `options` are currently ignored but this may change in the future.
-
   Returns truthy if all missing entity IDs were created successfully, and falsey if there were any errors."
-  [options]
-  (log/infof "Seeding Entity IDs with options %s" (pr-str options))
+  []
+  (log/info "Seeding Entity IDs")
   (mdb/setup-db!)
   (let [{:keys [error-count]} (transduce
                                (map seed-entity-ids-for-model!)

--- a/enterprise/backend/test/metabase_enterprise/serialization/load_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/load_test.clj
@@ -4,7 +4,7 @@
    [clojure.data :as data]
    [clojure.java.io :as io]
    [clojure.test :refer [deftest is testing use-fixtures]]
-   [metabase-enterprise.serialization.cmd :refer [dump load]]
+   [metabase-enterprise.serialization.cmd :refer [v1-dump v1-load]]
    [metabase-enterprise.serialization.test-util :as ts]
    [metabase.models
     :refer [Card
@@ -316,8 +316,8 @@
                                                              table-id-categories
                                                              table-id-users
                                                              table-id-checkins])
-                          (dump dump-dir {:user        (:email (test.users/fetch-user :crowberto))
-                                          :only-db-ids #{db-id}})
+                          (v1-dump dump-dir {:user        (:email (test.users/fetch-user :crowberto))
+                                             :only-db-ids #{db-id}})
                           {:query-results (gather-orig-results [card-id
                                                                 card-arch-id
                                                                 card-id-root
@@ -393,7 +393,7 @@
                                            [Card               (db/select-one Card :id card-id-with-native-snippet)]
                                            [Card               (db/select-one Card :id card-join-card-id)]]})]
         (with-world-cleanup
-          (load dump-dir {:on-error :continue :mode :skip})
+          (v1-load dump-dir {:on-error :continue :mode :skip})
           (mt/with-db (db/select-one Database :name ts/temp-db-name)
             (doseq [[model entity] (:entities fingerprint)]
               (testing (format "%s \"%s\"" (type model) (:name entity))

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/seed_entity_ids_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/seed_entity_ids_test.clj
@@ -14,7 +14,7 @@
 
 (deftest seed-entity-ids-test
   (testing "Sanity check: should succeed before we go around testing specific situations"
-    (is (true? (v2.seed-entity-ids/seed-entity-ids! nil))))
+    (is (true? (v2.seed-entity-ids/seed-entity-ids!))))
   (testing "With a temp Collection with no entity ID"
     (let [now (LocalDateTime/of 2022 9 1 12 34 56)]
       (mt/with-temp Collection [c {:name       "No Entity ID Collection"
@@ -28,7 +28,7 @@
                  (entity-id)))
           (testing "Should return truthy on success"
             (is (= true
-                   (v2.seed-entity-ids/seed-entity-ids! nil))))
+                   (v2.seed-entity-ids/seed-entity-ids!))))
           (is (= "998b109c"
                  (entity-id))))
         (testing "Error: duplicate entity IDs"
@@ -43,6 +43,6 @@
                      (entity-id)))
               (testing "Should return falsey on error"
                 (is (= false
-                       (v2.seed-entity-ids/seed-entity-ids! nil))))
+                       (v2.seed-entity-ids/seed-entity-ids!))))
               (is (= nil
                      (entity-id))))))))))

--- a/src/metabase/cmd.clj
+++ b/src/metabase/cmd.clj
@@ -133,33 +133,17 @@
         (for [[k v] (partition 2 args)]
           [(mbql.u/normalize-token (subs k 2)) v])))
 
-(defn- resolve-enterprise-command [symb]
-  (try
-    (classloader/require (symbol (namespace symb)))
-    (resolve symb)
-    (catch Throwable e
-      (throw (ex-info (trs "The ''{0}'' command is only available in Metabase Enterprise Edition." (name symb))
-                      {:command symb}
-                      e)))))
-
-;;; [[load]] and [[dump]] are the SerDes v1 versions. [[import]] and [[export]] are SerDes v2 versions of [[load]]
-;;; and [[dump]]. The v1 versions are deprecated.
-
-(defn- import*
-  "Impl for [[load]] (v1) and [[import]] (v2)."
-  ([path v2?]
-   (import* path v2? "--mode" :skip "--on-error" :continue))
-
-  ([path v2? & options]
-   (when-not v2?
-     (log/warn (u/colorize :red (trs "''load'' is deprecated and will be removed in a future release. Please migrate to ''import''."))))
-   (let [options (cond-> options
-                   v2?
-                   (concat ["--v2" "true"]))
-         cmd (resolve-enterprise-command 'metabase-enterprise.serialization.cmd/load)]
-     (cmd path (->> options
-                    cmd-args->map
-                    (m/map-vals mbql.u/normalize-token))))))
+(defn- call-enterprise
+  "Resolves enterprise command by symbol and calls with args, or else throws error if not EE"
+  [symb & args]
+  (let [f (try
+            (classloader/require (symbol (namespace symb)))
+            (resolve symb)
+            (catch Throwable e
+              (throw (ex-info (trs "The ''{0}'' command is only available in Metabase Enterprise Edition." (name symb))
+                              {:command symb}
+                              e))))]
+    (apply f args)))
 
 (defn ^:command ^:deprecated load
   "Deprecated: prefer [[import]] instead.
@@ -168,28 +152,16 @@
 
   `--mode` can be one of `:update` or `:skip` (default). `--on-error` can be `:abort` or `:continue` (default)."
   [path & options]
-  (apply import* path false options))
+  (log/warn (u/colorize :red (trs "''load'' is deprecated and will be removed in a future release. Please migrate to ''import''.")))
+  (let [opts (merge {:mode     :skip
+                     :on-error :continue}
+                    (m/map-vals mbql.u/normalize-token (cmd-args->map options)))]
+    (call-enterprise 'metabase-enterprise.serialization.cmd/v1-load path opts)))
 
 (defn ^:command import
-  "Load serialized Metabase instance as created by the [[export]] command from directory `path`. Replaces the [[load]]
-  command. Options are the same as for `load`.
-
-  `--mode` can be one of `:update` or `:skip` (default). `--on-error` can be `:abort` or `:continue` (default)."
-  [path & options]
-  (apply import* path true options))
-
-(defn- export*
-  ([path v2?]
-   (export* path v2? "--state" :active))
-
-  ([path v2? & options]
-   (when-not v2?
-     (log/warn (u/colorize :red (trs "''dump'' is deprecated and will be removed in a future release. Please migrate to ''export''."))))
-   (let [options (cond-> options
-                   v2?
-                   (concat ["--v2" true]))
-         cmd     (resolve-enterprise-command 'metabase-enterprise.serialization.cmd/dump)]
-     (cmd path (cmd-args->map options)))))
+  "Load serialized Metabase instance as created by the [[export]] command from directory `path`."
+  [path]
+  (call-enterprise 'metabase-enterprise.serialization.cmd/v2-load path))
 
 (defn ^:command ^:deprecated dump
   "Deprecated: prefer [[export]] instead.
@@ -197,24 +169,25 @@
   Serialized metabase instance into directory `path`. `args` options may contain --state option with one of
   `active` (default), `all`. With `active` option, do not dump archived entities."
   [path & options]
-  (apply export* path false options))
+  (log/warn (u/colorize :red (trs "''dump'' is deprecated and will be removed in a future release. Please migrate to ''export''.")))
+  (let [options (merge {:mode     :skip
+                        :on-error :continue}
+                       (cmd-args->map options))]
+    (call-enterprise 'metabase-enterprise.serialization.cmd/v1-dump path options)))
 
 (defn ^:command export
-  "Serialize a Metabase into directory `path`. Replaces the [[dump]] command. Options are the same as for `path`.
+  "Serialize a Metabase into directory `path`. Replaces the [[dump]] command..
 
   `options` may contain `--state` option with one of `active` (default), `all`. With `active` option, do not dump
   archived entities."
   [path & options]
-  (apply export* path true options))
+  (call-enterprise 'metabase-enterprise.serialization.cmd/v2-dump path (cmd-args->map options)))
 
 (defn ^:command seed-entity-ids
   "Add entity IDs for instances of serializable models that don't already have them."
-  [& options]
-  (let [cmd     (resolve-enterprise-command 'metabase-enterprise.serialization.cmd/seed-entity-ids)
-        options (cmd-args->map options)]
-    (system-exit! (if (cmd options)
-                    0
-                    1))))
+  []
+  (when-not (call-enterprise 'metabase-enterprise.serialization.cmd/seed-entity-ids)
+    (throw (Exception. "Error encountered while seeding entity IDs"))))
 
 (defn ^:command rotate-encryption-key
   "Rotate the encryption key of a metabase database. The MB_ENCRYPTION_SECRET_KEY environment variable has to be set to

--- a/test/metabase/cmd_test.clj
+++ b/test/metabase/cmd_test.clj
@@ -13,51 +13,29 @@
     (is (fn? the-fxn))))
 
 (deftest import-test
-  (with-redefs [cmd/resolve-enterprise-command (constantly
-                                                (fn [& args]
-                                                  (cons 'f args)))]
+  (with-redefs [cmd/call-enterprise list]
     (testing "load (v1)"
       (testing "with no options"
-        (is (= '(f "/path/" {:mode :skip, :on-error :continue})
+        (is (= '(metabase-enterprise.serialization.cmd/v1-load "/path/" {:mode :skip, :on-error :continue})
                (cmd/load "/path/"))))
       (testing "with options"
-        (is (= '(f "/path/" {:num-cans :2})
-               (cmd/load "/path/" "--num-cans" "2")))
-        (testing "People can still set --v2 true"
-          (is (= '(f "/path/" {:v2 :true})
-                 (cmd/load "/path/" "--v2" "true"))))))
+        (is (= '(metabase-enterprise.serialization.cmd/v1-load "/path/" {:mode :skip, :on-error :continue :num-cans :2})
+               (cmd/load "/path/" "--num-cans" "2")))))
     (testing "import (v2)"
       (testing "with no options"
-        (is (= '(f "/path/" {:mode :skip, :on-error :continue, :v2 :true})
-               (cmd/import "/path/"))))
-      (testing "with options"
-        (is (= '(f "/path/" {:num-cans :2, :v2 :true})
-               (cmd/import "/path/" "--num-cans" "2")))
-        (testing "Don't let people override --v2 true"
-          (is (= '(f "/path/" {:v2 :true})
-                 (cmd/import "/path/" "--v2" "false"))))))))
+        (is (= '(metabase-enterprise.serialization.cmd/v2-load "/path/")
+               (cmd/import "/path/")))))))
 
 (deftest export-test
-  (with-redefs [cmd/resolve-enterprise-command (constantly
-                                                (fn [& args]
-                                                  (cons 'f args)))]
+  (with-redefs [cmd/call-enterprise list]
     (testing "dump (v1)"
       (testing "with no options"
-        (is (= '(f "/path/" {:state :active})
+        (is (= '(metabase-enterprise.serialization.cmd/v1-dump "/path/" {:mode :skip, :on-error :continue})
                (cmd/dump "/path/"))))
       (testing "with options"
-        (is (= '(f "/path/" {:num-cans "2"})
-               (cmd/dump "/path/" "--num-cans" "2")))
-        (testing "People can still set --v2 true"
-          (is (= '(f "/path/" {:v2 "true"})
-                 (cmd/dump "/path/" "--v2" "true"))))))
+        (is (= '(metabase-enterprise.serialization.cmd/v1-dump "/path/" {:mode :skip, :on-error :continue, :num-cans "2"})
+               (cmd/dump "/path/" "--num-cans" "2")))))
     (testing "export (v2)"
       (testing "with no options"
-        (is (= '(f "/path/" {:state :active, :v2 true})
-               (cmd/export "/path/"))))
-      (testing "with options"
-        (is (= '(f "/path/" {:num-cans "2", :v2 true})
-               (cmd/export "/path/" "--num-cans" "2")))
-        (testing "Don't let people override --v2 true"
-          (is (= '(f "/path/" {:v2 true})
-                 (cmd/export "/path/" "--v2" "false"))))))))
+        (is (= '(metabase-enterprise.serialization.cmd/v2-dump "/path/" {})
+               (cmd/export "/path/")))))))


### PR DESCRIPTION
In the interest of keeping PRs focused, this is just a small cleanup of command handling for the serdes v1+v2 commands, in order to make other changes around options easier to implement. This PR should be super quick to review/merge if the tests pass 🙏 

The idea here is to simplify the way we handle v1/v2 export/import commands. The new way handles each command's CLI arguments before calling the designated implementation function directly, instead of hopping through two functions that munge options and versions together.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/28710)
<!-- Reviewable:end -->
