### PR TITLE
Use plugins directory sample-dataset for cypress tests

### DIFF
--- a/frontend/test/snapshot-creators/default.cy.snap.js
+++ b/frontend/test/snapshot-creators/default.cy.snap.js
@@ -81,7 +81,7 @@ describe("snapshots", () => {
     // update the Sample db connection string so it is valid in both CI and locally
     cy.request("GET", `/api/database/${SAMPLE_DB_ID}`).then(response => {
       response.body.details.db =
-        "./resources/sample-database.db;USER=GUEST;PASSWORD=guest";
+        "./plugins/sample-database.db;USER=GUEST;PASSWORD=guest";
       cy.request("PUT", `/api/database/${SAMPLE_DB_ID}`, response.body);
     });
   }


### PR DESCRIPTION
This PR prevents the `resources/sample-dataset.db.mv.db` file from changing whenever you run cypress tests, making it appear in the changed files for the git repository.

### Why is this needed?

In [Allow actions to run on H2 and sample database](https://github.com/metabase/metabase/pull/28212#top), I  removed ACCESS_MODE_DATA=r from the connection strings for H2. Now running a query on an H2 database updates the database file, unless it's opened with `ACCESS_MODE_DATA=r`. I assume this is because it's changing some command history state. Normally the app uses `$PLUGIN_DIR/sample-dataset.db.mv.db`, which is copied on app startup, and that's included in the `.gitignore`. But cypress tests use `resources/sample-dataset.db.mv.db`. This PR switches the cypress tests to use `$PLUGIN_DIR/sample-dataset.db.mv.db` instead, just like the app.