### PR TITLE
Snowplow for actions

### DIFF
--- a/snowplow/iglu-client-embedded/schemas/com.metabase/action/jsonschema/1-0-0
+++ b/snowplow/iglu-client-embedded/schemas/com.metabase/action/jsonschema/1-0-0
@@ -1,0 +1,65 @@
+{
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "description": "Action events",
+  "self": {
+    "vendor": "com.metabase",
+    "name": "action",
+    "format": "jsonschema",
+    "version": "1-0-0"
+  },
+  "type": "object",
+  "properties": {
+    "event": {
+      "description": "Event name",
+      "type": "string",
+      "enum": [
+        "new",
+        "update",
+        "delete",
+        "execute"
+      ],
+      "maxLength": 128
+    },
+    "type": {
+      "description": "Action type",
+      "type": "string",
+      "enum": [
+        "http",
+        "implicit",
+        "query"
+      ],
+      "maxLength": 128
+    },
+    "action_id": {
+      "description": "Unique identifier for an action within the Metabase instance",
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 2147483647
+    },
+    "num_parameters": {
+      "description": "Number of a parameter if is a custom action",
+      "type": [
+        "integer",
+        "null"
+      ],
+      "minimum": 0,
+      "maximum": 2147483647
+    },
+    "context": {
+      "description": "The context that an action was executed in.",
+      "type": "string",
+      "enum": [
+        "model_detail",
+        "dashboard",
+        "public_form"
+      ],
+      "maxLength": 128
+    }
+  },
+  "required": [
+    "event",
+    "type",
+    "action_id"
+  ],
+  "additionalProperties": true
+}

--- a/snowplow/iglu-client-embedded/schemas/com.metabase/action/jsonschema/1-0-0
+++ b/snowplow/iglu-client-embedded/schemas/com.metabase/action/jsonschema/1-0-0
@@ -13,10 +13,10 @@
       "description": "Event name",
       "type": "string",
       "enum": [
-        "new",
-        "update",
-        "delete",
-        "execute"
+        "action_created",
+        "action_updated",
+        "action_deleted",
+        "action_executed"
       ],
       "maxLength": 128
     },

--- a/snowplow/iglu-client-embedded/schemas/com.metabase/action/jsonschema/1-0-0
+++ b/snowplow/iglu-client-embedded/schemas/com.metabase/action/jsonschema/1-0-0
@@ -32,7 +32,7 @@
     },
     "action_id": {
       "description": "Unique identifier for an action within the Metabase instance",
-      "type": "integer",
+      "type": ["integer", "null"],
       "minimum": 0,
       "maximum": 2147483647
     },
@@ -47,7 +47,10 @@
     },
     "context": {
       "description": "The context that an action was executed in.",
-      "type": "string",
+      "type": [
+        "string",
+        "null"
+        ],
       "enum": [
         "model_detail",
         "dashboard",

--- a/src/metabase/actions/execution.clj
+++ b/src/metabase/actions/execution.clj
@@ -4,6 +4,7 @@
    [medley.core :as m]
    [metabase.actions :as actions]
    [metabase.actions.http-action :as http-action]
+   [metabase.analytics.snowplow :as snowplow]
    [metabase.api.common :as api]
    [metabase.models :refer [Card DashboardCard Table]]
    [metabase.models.action :as action]
@@ -177,6 +178,10 @@
                                                :id dashcard-id
                                                :dashboard_id dashboard-id))
         action (api/check-404 (action/select-action :id (:action_id dashcard)))]
+    (snowplow/track-event! ::snowplow/execute-action api/*current-user-id* {:event     :execute
+                                                                            :source    :dashboard
+                                                                            :type      (:type action)
+                                                                            :action_id (:id action)})
     (execute-action! action request-parameters)))
 
 (defn- fetch-implicit-action-values

--- a/src/metabase/actions/execution.clj
+++ b/src/metabase/actions/execution.clj
@@ -178,10 +178,9 @@
                                                :id dashcard-id
                                                :dashboard_id dashboard-id))
         action (api/check-404 (action/select-action :id (:action_id dashcard)))]
-    (snowplow/track-event! ::snowplow/execute-action api/*current-user-id* {:event     :execute
-                                                                            :source    :dashboard
-                                                                            :type      (:type action)
-                                                                            :action_id (:id action)})
+    (snowplow/track-event! ::snowplow/action-executed api/*current-user-id* {:source    :dashboard
+                                                                             :type      (:type action)
+                                                                             :action_id (:id action)})
     (execute-action! action request-parameters)))
 
 (defn- fetch-implicit-action-values

--- a/src/metabase/analytics/snowplow.clj
+++ b/src/metabase/analytics/snowplow.clj
@@ -135,7 +135,8 @@
    ::database  "1-0-0"
    ::instance  "1-1-0"
    ::timeline  "1-0-0"
-   ::task      "1-0-0"})
+   ::task      "1-0-0"
+   ::action    "1-0-0"})
 
 (defn- app-db-type
   "Returns the type of the Metabase application database as a string (e.g. PostgreSQL, MySQL)"
@@ -175,7 +176,8 @@
        ;; Make sure keywords in payload are converted to strings in snake-case
        (m/map-kv
         (fn [k v] [(normalize-kw k) (if (keyword? v) (normalize-kw v) v)])
-        (assoc data :event event-kw))))
+        (merge {:event event-kw}
+               data))))
 
 (defn- track-event-impl!
   "Wrapper function around the `.track` method on a Snowplow tracker. Can be redefined in tests to instead append
@@ -193,7 +195,11 @@
    ::database-connection-successful ::database
    ::database-connection-failed     ::database
    ::new-event-created              ::timeline
-   ::new-task-history               ::task})
+   ::new-task-history               ::task
+   ::new-action                     ::action
+   ::update-action                  ::action
+   ::delete-action                  ::action
+   ::execute-action                 ::action})
 
 (defn track-event!
   "Send a single analytics event to the Snowplow collector, if tracking is enabled for this MB instance and a collector

--- a/src/metabase/analytics/snowplow.clj
+++ b/src/metabase/analytics/snowplow.clj
@@ -176,8 +176,7 @@
        ;; Make sure keywords in payload are converted to strings in snake-case
        (m/map-kv
         (fn [k v] [(normalize-kw k) (if (keyword? v) (normalize-kw v) v)])
-        (merge {:event event-kw}
-               data))))
+        (assoc data :event event-kw))))
 
 (defn- track-event-impl!
   "Wrapper function around the `.track` method on a Snowplow tracker. Can be redefined in tests to instead append
@@ -196,10 +195,10 @@
    ::database-connection-failed     ::database
    ::new-event-created              ::timeline
    ::new-task-history               ::task
-   ::new-action                     ::action
-   ::update-action                  ::action
-   ::delete-action                  ::action
-   ::execute-action                 ::action})
+   ::action-created                 ::action
+   ::action-updated                 ::action
+   ::action-deleted                 ::action
+   ::action-executed                ::action})
 
 (defn track-event!
   "Send a single analytics event to the Snowplow collector, if tracking is enabled for this MB instance and a collector

--- a/src/metabase/api/action.clj
+++ b/src/metabase/api/action.clj
@@ -5,6 +5,7 @@
    [metabase.actions :as actions]
    [metabase.actions.execution :as actions.execution]
    [metabase.actions.http-action :as http-action]
+   [metabase.analytics.snowplow :as snowplow]
    [metabase.api.common :as api]
    [metabase.api.common.validation :as validation]
    [metabase.models :refer [Action Card]]
@@ -75,7 +76,10 @@
 #_{:clj-kondo/ignore [:deprecated-var]}
 (api/defendpoint-schema DELETE "/:action-id"
   [action-id]
-  (api/write-check Action action-id)
+  (let [action (api/write-check Action action-id)]
+    (snowplow/track-event! ::snowplow/delete-action api/*current-user-id* {:event     :delete
+                                                                           :type       (:type action)
+                                                                           :action_id action-id}))
   (db/delete! Action :id action-id)
   api/generic-204-no-content)
 
@@ -106,6 +110,10 @@
   (let [model (api/write-check Card model_id)]
     (actions/check-actions-enabled-for-database! (db/select-one 'Database :id (:database_id model))))
   (let [action-id (action/insert! (assoc action :creator_id api/*current-user-id*))]
+    (snowplow/track-event! ::snowplow/new-action api/*current-user-id* {:event          :new
+                                                                        :type           type
+                                                                        :action_id      action-id
+                                                                        :num_parameters (count parameters)})
     (if action-id
       (action/select-action :id action-id)
       ;; db/insert! does not return a value when used with h2
@@ -134,7 +142,12 @@
   (actions/check-actions-enabled! id)
   (let [existing-action (api/write-check Action id)]
     (action/update! (assoc action :id id) existing-action))
-  (action/select-action :id id))
+  (let [{:keys [parameters type] :as action} (action/select-action :id id)]
+    (snowplow/track-event! ::snowplow/update-action api/*current-user-id* {:event          :update
+                                                                           :type           type
+                                                                           :action_id      id
+                                                                           :num_parameters (count parameters)})
+    action))
 
 (api/defendpoint POST "/:id/public_link"
   "Generate publicly-accessible links for this Action. Returns UUID to be used in public links. (If this
@@ -171,8 +184,11 @@
   [id :as {{:keys [parameters], :as _body} :body}]
   {id       pos-int?
    parameters [:maybe [:map-of :keyword any?]]}
-  (-> (action/select-action :id id :archived false)
-      (api/check-404)
-      (actions.execution/execute-action! (update-keys parameters name))))
+  (let [{:keys [type] :as action} (api/check-404 (action/select-action :id id :archived false))]
+    (snowplow/track-event! ::snowplow/execute-action api/*current-user-id* {:event     :execute
+                                                                            :source    :model_detail
+                                                                            :type      type
+                                                                            :action_id id})
+    (actions.execution/execute-action! action (update-keys parameters name))))
 
 (api/define-routes)

--- a/src/metabase/api/action.clj
+++ b/src/metabase/api/action.clj
@@ -78,7 +78,7 @@
   [action-id]
   (let [action (api/write-check Action action-id)]
     (snowplow/track-event! ::snowplow/delete-action api/*current-user-id* {:event     :delete
-                                                                           :type       (:type action)
+                                                                           :type      (:type action)
                                                                            :action_id action-id}))
   (db/delete! Action :id action-id)
   api/generic-204-no-content)

--- a/src/metabase/api/public.clj
+++ b/src/metabase/api/public.clj
@@ -588,7 +588,7 @@
           (let [action (api/check-404 (action/select-action :public_uuid uuid :archived false))]
             ;; Undo middleware string->keyword coercion
             (snowplow/track-event! ::snowplow/execute-action api/*current-user-id* {:event     :execute
-                                                                                    :source    :dashboard
+                                                                                    :source    :public_form
                                                                                     :type      (:type action)
                                                                                     :action_id (:id action)})
             (actions.execution/execute-action! action (update-keys parameters name))))))))

--- a/src/metabase/api/public.clj
+++ b/src/metabase/api/public.clj
@@ -587,10 +587,9 @@
         (binding [api/*current-user-permissions-set* (delay #{"/"})]
           (let [action (api/check-404 (action/select-action :public_uuid uuid :archived false))]
             ;; Undo middleware string->keyword coercion
-            (snowplow/track-event! ::snowplow/execute-action api/*current-user-id* {:event     :execute
-                                                                                    :source    :public_form
-                                                                                    :type      (:type action)
-                                                                                    :action_id (:id action)})
+            (snowplow/track-event! ::snowplow/action-executed api/*current-user-id* {:source    :public_form
+                                                                                     :type      (:type action)
+                                                                                     :action_id (:id action)})
             (actions.execution/execute-action! action (update-keys parameters name))))))))
 
 

--- a/src/metabase/api/public.clj
+++ b/src/metabase/api/public.clj
@@ -7,6 +7,7 @@
    [medley.core :as m]
    [metabase.actions :as actions]
    [metabase.actions.execution :as actions.execution]
+   [metabase.analytics.snowplow :as snowplow]
    [metabase.api.card :as api.card]
    [metabase.api.common :as api]
    [metabase.api.common.validation :as validation]
@@ -586,6 +587,10 @@
         (binding [api/*current-user-permissions-set* (delay #{"/"})]
           (let [action (api/check-404 (action/select-action :public_uuid uuid :archived false))]
             ;; Undo middleware string->keyword coercion
+            (snowplow/track-event! ::snowplow/execute-action api/*current-user-id* {:event     :execute
+                                                                                    :source    :dashboard
+                                                                                    :type      (:type action)
+                                                                                    :action_id (:id action)})
             (actions.execution/execute-action! action (update-keys parameters name))))))))
 
 

--- a/src/metabase/api/public.clj
+++ b/src/metabase/api/public.clj
@@ -586,10 +586,10 @@
         ;; you're by definition allowed to run it without a perms check anyway
         (binding [api/*current-user-permissions-set* (delay #{"/"})]
           (let [action (api/check-404 (action/select-action :public_uuid uuid :archived false))]
-            ;; Undo middleware string->keyword coercion
             (snowplow/track-event! ::snowplow/action-executed api/*current-user-id* {:source    :public_form
                                                                                      :type      (:type action)
                                                                                      :action_id (:id action)})
+            ;; Undo middleware string->keyword coercion
             (actions.execution/execute-action! action (update-keys parameters name))))))))
 
 

--- a/src/metabase/models/action.clj
+++ b/src/metabase/models/action.clj
@@ -22,14 +22,16 @@
 (models/defmodel ImplicitAction :implicit_action)
 (models/defmodel Action :action)
 
-(defn type->model
+(def ^:private type->model
   "Returns the model from an action type.
    `action-type` can be a string or a keyword."
-  [action-type]
-  (case action-type
-    :http     HTTPAction
-    :implicit ImplicitAction
-    :query    QueryAction))
+  {:http     HTTPAction
+   :implicit ImplicitAction
+   :query    QueryAction})
+
+(def action-types
+  "A set of all valid action types."
+  (set (keys type->model)))
 
 ;;; You can read/write an Action if you can read/write its model (Card)
 (doto Action

--- a/src/metabase/models/action.clj
+++ b/src/metabase/models/action.clj
@@ -22,16 +22,14 @@
 (models/defmodel ImplicitAction :implicit_action)
 (models/defmodel Action :action)
 
-(def ^:private type->model
+(defn type->model
   "Returns the model from an action type.
    `action-type` can be a string or a keyword."
-  {:http     HTTPAction
-   :implicit ImplicitAction
-   :query    QueryAction})
-
-(def action-types
-  "A set of all valid action types."
-  (set (keys type->model)))
+  [action-type]
+  (case action-type
+    :http     HTTPAction
+    :implicit ImplicitAction
+    :query    QueryAction))
 
 ;;; You can read/write an Action if you can read/write its model (Card)
 (doto Action

--- a/test/metabase/api/action_test.clj
+++ b/test/metabase/api/action_test.clj
@@ -219,7 +219,7 @@
               (testing (format "add an action of type %s" type)
                 (is (=? {:user-id (str (mt/user->id :crowberto))
                          :data    {"action_id"      (:id new-action)
-                                   "event"          "new"
+                                   "event"          "action_created"
                                    "num_parameters" (count parameters)
                                    "type"           type}}
                         (last (snowplow-test/pop-event-data-and-user-id!)))))
@@ -228,7 +228,7 @@
                 (let [updated-action (mt/user-http-request :crowberto :put 200 (str "action/" (:id new-action)) {:name "new name"})]
                   (is (=? {:user-id (str (mt/user->id :crowberto))
                            :data    {"action_id"      (:id updated-action)
-                                     "event"          "update"
+                                     "event"          "action_updated"
                                      "type"           type}}
                           (last (snowplow-test/pop-event-data-and-user-id!))))))
 
@@ -236,7 +236,7 @@
                 (mt/user-http-request :crowberto :delete 204 (str "action/" (:id new-action)))
                 (is (=? {:user-id (str (mt/user->id :crowberto))
                          :data    {"action_id"      (:id new-action)
-                                   "event"          "delete"
+                                   "event"          "action_deleted"
                                    "type"           type}}
                         (last (snowplow-test/pop-event-data-and-user-id!))))))))))))
 
@@ -410,7 +410,7 @@
                                         {:parameters {:id 1 :name "European"}})))
           (testing "track a snowplow event"
             (is (= {:data {"action_id" action-id
-                           "event"     "execute"
+                           "event"     "action_executed"
                            "source"    "model_detail"
                            "type"      "query"}
                     :user-id (str (mt/user->id :crowberto))}

--- a/test/metabase/api/action_test.clj
+++ b/test/metabase/api/action_test.clj
@@ -10,7 +10,8 @@
    [metabase.util.schema :as su]
    [schema.core :as s]
    [toucan.db :as db]
-   [toucan2.core :as t2])
+   [toucan2.core :as t2]
+   [toucan2.tools.with-temp :as t2.with-temp])
   (:import
    (java.util UUID)))
 
@@ -213,7 +214,8 @@
   (snowplow-test/with-fake-snowplow-collector
     (mt/with-actions-enabled
       (testing "Should send a snowplow event when"
-        (mt/with-actions [{card-id :id} {:dataset true :dataset_query (mt/mbql-query users)}]
+        (t2.with-temp/with-temp
+          [Card {card-id :id} {:dataset true}]
           (doseq [{:keys [type parameters] :as action} (all-actions-default card-id)]
             (let [new-action (mt/user-http-request :crowberto :post 200 "action" action)]
               (testing (format "adding an action of type %s" type)

--- a/test/metabase/api/action_test.clj
+++ b/test/metabase/api/action_test.clj
@@ -212,11 +212,11 @@
 (deftest snowplow-test
   (snowplow-test/with-fake-snowplow-collector
     (mt/with-actions-enabled
-      (testing "Should track when"
+      (testing "Should send a snowplow event when"
         (mt/with-actions [{card-id :id} {:dataset true :dataset_query (mt/mbql-query users)}]
           (doseq [{:keys [type parameters] :as action} (all-actions-default card-id)]
             (let [new-action (mt/user-http-request :crowberto :post 200 "action" action)]
-              (testing (format "add an action of type %s" type)
+              (testing (format "adding an action of type %s" type)
                 (is (=? {:user-id (str (mt/user->id :crowberto))
                          :data    {"action_id"      (:id new-action)
                                    "event"          "action_created"
@@ -408,7 +408,7 @@
                                         :post 200
                                         (format "action/%s/execute" action-id)
                                         {:parameters {:id 1 :name "European"}})))
-          (testing "track a snowplow event"
+          (testing "send a snowplow event"
             (is (= {:data {"action_id" action-id
                            "event"     "action_executed"
                            "source"    "model_detail"

--- a/test/metabase/api/action_test.clj
+++ b/test/metabase/api/action_test.clj
@@ -40,27 +40,27 @@
 
 (defn all-actions-default
   [card-id]
-  [{:name "Get example"
-    :description "A dummy HTTP action"
-    :type "http"
-    :model_id card-id
-    :template {:method "GET"
-               :url "https://example.com/{{x}}"}
-    :parameters [{:id "x" :type "text"}]
+  [{:name            "Get example"
+    :description     "A dummy HTTP action"
+    :type            "http"
+    :model_id        card-id
+    :template        {:method "GET"
+                      :url    "https://example.com/{{x}}"}
+    :parameters      [{:id "x" :type "text"}]
     :response_handle ".body"
-    :error_handle ".status >= 400"}
-   {:name "Query example"
-    :description "A simple update query action"
-    :type "query"
-    :model_id card-id
+    :error_handle    ".status >= 400"}
+   {:name          "Query example"
+    :description   "A simple update query action"
+    :type          "query"
+    :model_id      card-id
     :dataset_query (update (mt/native-query {:query "update users set name = 'foo' where id = {{x}}"})
                            :type name)
-    :database_id (t2/select-one-fn :database_id Card :id card-id)
-    :parameters [{:id "x" :type "type/biginteger"}]}
-   {:name "Implicit example"
-    :type "implicit"
-    :model_id card-id
-    :kind "row/create"
+    :database_id   (t2/select-one-fn :database_id Card :id card-id)
+    :parameters    [{:id "x" :type "type/biginteger"}]}
+   {:name       "Implicit example"
+    :type       "implicit"
+    :model_id   card-id
+    :kind       "row/create"
     :parameters [{:id "nonexistent" :special "shouldbeignored"} {:id "id" :special "hello"}]}])
 
 (deftest list-actions-test

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -2628,7 +2628,7 @@
                 (is (has-valid-action-execution-error-message?
                      (mt/user-http-request :crowberto :post 500 execute-path
                                            {:parameters {"id" "BAD"}}))))
-              (testing "should track snowplow"
+              (testing "should send a snowplow event"
                 (snowplow-test/with-fake-snowplow-collector
                   (mt/user-http-request :crowberto :post 200 execute-path
                                         {:parameters {"id" 1}})

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -6,6 +6,7 @@
    [clojure.test :refer :all]
    [clojure.walk :as walk]
    [medley.core :as m]
+   [metabase.analytics.snowplow-test :as snowplow-test]
    [metabase.api.card-test :as api.card-test]
    [metabase.api.common :as api]
    [metabase.api.dashboard :as api.dashboard]
@@ -2626,7 +2627,17 @@
               (testing "Sending an invalid number should fail gracefully"
                 (is (has-valid-action-execution-error-message?
                      (mt/user-http-request :crowberto :post 500 execute-path
-                                           {:parameters {"id" "BAD"}})))))))))))
+                                           {:parameters {"id" "BAD"}}))))
+              (testing "should track snowplow"
+                (snowplow-test/with-fake-snowplow-collector
+                  (mt/user-http-request :crowberto :post 200 execute-path
+                                        {:parameters {"id" 1}})
+                  (is (= {:data {"action_id" action-id
+                                 "event"     "execute"
+                                 "source"    "dashboard"
+                                 "type"      "query"}
+                          :user-id (str (mt/user->id :crowberto))}
+                         (last (snowplow-test/pop-event-data-and-user-id!)))))))))))))
 
 (deftest dashcard-http-action-execution-test
   (mt/test-drivers (mt/normal-drivers-with-feature :actions)

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -2633,7 +2633,7 @@
                   (mt/user-http-request :crowberto :post 200 execute-path
                                         {:parameters {"id" 1}})
                   (is (= {:data {"action_id" action-id
-                                 "event"     "execute"
+                                 "event"     "action_executed"
                                  "source"    "dashboard"
                                  "type"      "query"}
                           :user-id (str (mt/user->id :crowberto))}

--- a/test/metabase/api/public_test.clj
+++ b/test/metabase/api/public_test.clj
@@ -1405,7 +1405,7 @@
                   {:parameters {:id 1 :name "European"}})
                 (is (= {:data   {"action_id" (db/select-one-id 'Action :public_uuid public_uuid)
                                  "event"     "execute"
-                                 "source"    "dashboard"
+                                 "source"    "public_form"
                                  "type"      "query"}
                         :user-id nil}
                        (last (snowplow-test/pop-event-data-and-user-id!))))))))))))

--- a/test/metabase/api/public_test.clj
+++ b/test/metabase/api/public_test.clj
@@ -1397,7 +1397,7 @@
                         :post 400
                         (format "public/action/%s/execute" public_uuid)
                         {:parameters {:id 1 :name "European"}})))))
-            (testing "Check that we track snowplow when execute an action"
+            (testing "Check that we send a snowplow event when execute an action"
               (snowplow-test/with-fake-snowplow-collector
                 (client/client
                   :post 200

--- a/test/metabase/api/public_test.clj
+++ b/test/metabase/api/public_test.clj
@@ -1404,7 +1404,7 @@
                   (format "public/action/%s/execute" public_uuid)
                   {:parameters {:id 1 :name "European"}})
                 (is (= {:data   {"action_id" (db/select-one-id 'Action :public_uuid public_uuid)
-                                 "event"     "execute"
+                                 "event"     "action_executed"
                                  "source"    "public_form"
                                  "type"      "query"}
                         :user-id nil}


### PR DESCRIPTION
Resolves #28580

Product wishes to track:
- new/update/delete action events
- execute actions events

To do that I created a single schema that will be used to keep track of all these events:
```
{
  :event          #{action_created, action_updated, action_deleted, action_executed}
  :type           #{http, implicit, query}
  :action_id      unique-id
  :context        #{model_detail, dashboard, public_form} ;; only for for run_action event
  :num_parameters integer ;; only for when running custom action
}
```

I considered splitting them to 2 different schemas but I find that redundant. We had been using this pattern of a single schema per entity and using an `event` key to distinguish event types, so it's better to keep using that pattern here.


How to test: follow the instruction [here](https://www.notion.so/metabase/Snowplow-integration-5da1f874beda4153b4fccfa6c1e77caa?pvs=4) to setup local snowplow server and how to check recorded events.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/28733)
<!-- Reviewable:end -->
