### PR TITLE
Delay substituting persisted native query until after analysis

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -50,6 +50,7 @@
   (eval . (put-clojure-indent 'mbql.match/match-one 1))
   (eval . (put-clojure-indent 'mbql.match/replace 1))
   (eval . (put-clojure-indent 'mbql.match/replace-in 2))
+  (eval . (put-clojure-indent 'mbql.u/replace 1))
   (eval . (put-clojure-indent 'mi/define-methods '(:form)))
   (eval . (put-clojure-indent 'mt/dataset 1))
   (eval . (put-clojure-indent 'mt/format-rows-by 1))

--- a/enterprise/backend/test/metabase_enterprise/sandbox/query_processor/middleware/row_level_restrictions_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/query_processor/middleware/row_level_restrictions_test.clj
@@ -1031,7 +1031,7 @@
                    (run-query)))))))))
 
 (deftest persistence-disabled-when-sandboxed
-  (mt/test-driver :postgres
+  (mt/test-drivers (mt/normal-drivers-with-feature :persist-models)
     (mt/dataset sample-dataset
       ;; with-gtaps creates a new copy of the database. So make sure to do that before anything else. Gets really
       ;; confusing when `(mt/id)` and friends change value halfway through the test

--- a/src/metabase/driver/sql/query_processor.clj
+++ b/src/metabase/driver/sql/query_processor.clj
@@ -1377,11 +1377,12 @@
                           :as source-query} :source-query}]
   (assoc honeysql-form
          :from [[(cond
+                   persisted
+                   (sql-source-query persisted nil)
+
                    native
                    (sql-source-query native params)
 
-                   persisted
-                   (sql-source-query persisted nil)
 
                    :else
                    (apply-clauses driver {} source-query))

--- a/src/metabase/driver/sql/query_processor.clj
+++ b/src/metabase/driver/sql/query_processor.clj
@@ -1383,7 +1383,6 @@
                    native
                    (sql-source-query native params)
 
-
                    :else
                    (apply-clauses driver {} source-query))
                  (let [table-alias (->honeysql driver (hx/identifier :table-alias source-query-alias))]

--- a/src/metabase/driver/sql/query_processor.clj
+++ b/src/metabase/driver/sql/query_processor.clj
@@ -1372,10 +1372,18 @@
 (defn- apply-source-query
   "Handle a `:source-query` clause by adding a recursive `SELECT` or native query. At the time of this writing, all
   source queries are aliased as `source`."
-  [driver honeysql-form {{:keys [native params], :as source-query} :source-query}]
+  [driver honeysql-form {{:keys [native params],
+                          persisted :persisted-info/native
+                          :as source-query} :source-query}]
   (assoc honeysql-form
-         :from [[(if native
+         :from [[(cond
+                   native
                    (sql-source-query native params)
+
+                   persisted
+                   (sql-source-query persisted nil)
+
+                   :else
                    (apply-clauses driver {} source-query))
                  (let [table-alias (->honeysql driver (hx/identifier :table-alias source-query-alias))]
                    (case (long hx/*honey-sql-version*)

--- a/src/metabase/query_processor/middleware/fetch_source_query.clj
+++ b/src/metabase/query_processor/middleware/fetch_source_query.clj
@@ -103,14 +103,6 @@
         (log/info (trs "Trimming trailing comment from card with id {0}" card-id))
         trimmed-string))))
 
-(defn- sub-cached-field-refs
-  "Change field refs by id into field refs by name."
-  [metadata]
-  (map (fn [m]
-         ;; is it ok to clobber expressions like this? I think so.
-         (assoc m :field_ref [:field (:name m) {:base-type (:base_type m)}]))
-       metadata))
-
 (defn- source-query
   "Get the query to be run from the card"
   [{dataset-query :dataset_query card-id :id :as card}]
@@ -152,7 +144,7 @@
        (log/info (trs "Found substitute cached query for card {0} from {1}.{2}"
                       card-id
                       (ddl.i/schema-name {:id database-id} (public-settings/site-uuid))
-                      (:table_name card))))
+                      (:table_name persisted-info))))
 
      ;; log the query at this point, it's useful for some purposes
      (log/debug (trs "Fetched source query from Card {0}:" card-id)
@@ -165,8 +157,7 @@
                                  (assoc :persisted-info/native
                                         (qp.persisted/persisted-info-native-query persisted-info)))
               :database        database-id
-              :source-metadata (cond-> (seq (map mbql.normalize/normalize-source-metadata result-metadata))
-                                 persisted? sub-cached-field-refs)}
+              :source-metadata (seq (map mbql.normalize/normalize-source-metadata result-metadata))}
        dataset? (assoc :source-query/dataset? dataset?)))))
 
 (s/defn ^:private source-table-str->card-id :- su/IntGreaterThanZero

--- a/src/metabase/query_processor/middleware/fix_bad_references.clj
+++ b/src/metabase/query_processor/middleware/fix_bad_references.clj
@@ -25,6 +25,10 @@
     (qp.store/fetch-and-store-tables! #{table-id})
     (qp.store/table table-id)))
 
+(def ^:dynamic *bad-field-reference-fn*
+  "A function to be called on each bad field found by this middleware. Not used except for in tests."
+  (fn bad-field-no-op [_field]))
+
 (defn- fix-bad-references*
   ([inner-query]
    (fix-bad-references* inner-query inner-query (find-source-table inner-query)))
@@ -63,6 +67,7 @@
                                           (if join-alias
                                             (trs "Guessing join {0}" (pr-str join-alias))
                                             (trs "Unable to infer an appropriate join. Query may not work as expected.")))))
+       (*bad-field-reference-fn* &match)
        (if join-alias
          [:field id (assoc opts :join-alias join-alias)]
          &match)))))

--- a/src/metabase/query_processor/middleware/persistence.clj
+++ b/src/metabase/query_processor/middleware/persistence.clj
@@ -4,14 +4,14 @@
    [metabase.query-processor.middleware.permissions :as qp.perms]))
 
 (defn substitute-persisted-query
-  "Replaces source-query with the native query to the cache table.
+  "Removes persisted information if user is sandboxed.
    `:persisted-info/native` is set in `fetch-source-query`.
 
    If permissions are applied to the query (sandboxing) then do not use the cached query.
    It may be be possible to use the persistence cache with sandboxing at a later date with further work."
   [{::qp.perms/keys [perms] :as  query}]
   (if perms
-    query
     (mbql.u/replace query
       (x :guard (every-pred map? :persisted-info/native))
-      {:native (:persisted-info/native x)})))
+      (dissoc x :persisted-info/native))
+    query))

--- a/src/metabase/query_processor/util/persisted_cache.clj
+++ b/src/metabase/query_processor/util/persisted_cache.clj
@@ -8,14 +8,6 @@
    [metabase.models.persisted-info :as persisted-info]
    [metabase.public-settings :as public-settings]))
 
-(defn- segmented-user?
-  []
-  (if-let [segmented? (resolve 'metabase-enterprise.sandbox.api.util/segmented-user?)]
-    (try (segmented?)
-      ;; Fail closed (i.e. default to true) if `segmented-user` throws an exception due to no current user being bound
-      (catch Throwable _ true))
-    false))
-
 (defn can-substitute?
   "Taking a card and a persisted-info record (possibly nil), returns whether the card's query can be substituted for a
   persisted version."
@@ -29,8 +21,7 @@
        (= (:query_hash persisted-info) (persisted-info/query-hash (:dataset_query card)))
        (= (:definition persisted-info)
           (persisted-info/metadata->definition (:result_metadata card)
-                                               (:table_name persisted-info)))
-       (not (segmented-user?))))
+                                               (:table_name persisted-info)))))
 
 (defn persisted-info-native-query
   "Returns a native query that selects from the persisted cached table from `persisted-info`. Does not check if

--- a/test/metabase/query_processor/persistence_test.clj
+++ b/test/metabase/query_processor/persistence_test.clj
@@ -58,7 +58,8 @@
   (let [updater (a/thread
                   (let [metadata (a/<!! (qp.async/result-metadata-for-query-async query))]
                     (db/update! 'Card id :result_metadata metadata)))]
-    (when (= ::timed-out (mt/wait-for-result updater 2000 ::timed-out))
+    ;; 4 seconds is long but redshift can be a little slow
+    (when (= ::timed-out (mt/wait-for-result updater 4000 ::timed-out))
       (throw (ex-info "Query metadata not set in time for querying against model"
                       {:location `populate-metadata})))))
 

--- a/test/metabase/query_processor/persistence_test.clj
+++ b/test/metabase/query_processor/persistence_test.clj
@@ -1,15 +1,18 @@
 (ns metabase.query-processor.persistence-test
-  (:require [clojure.string :as str]
+  (:require [clojure.core.async :as a]
+            [clojure.string :as str]
             [clojure.test :refer :all]
             [metabase.driver :as driver]
             [metabase.driver.ddl.interface :as ddl.i]
             [metabase.models :refer [Card]]
             [metabase.public-settings :as public-settings]
             [metabase.query-processor :as qp]
+            [metabase.query-processor.async :as qp.async]
             [metabase.query-processor.interface :as qp.i]
             [metabase.query-processor.middleware.fix-bad-references
              :as fix-bad-refs]
-            [metabase.test :as mt]))
+            [metabase.test :as mt]
+            [toucan.db :as db]))
 
 (deftest can-persist-test
   (testing "Can each database that allows for persistence actually persist"
@@ -51,35 +54,55 @@
 
 ;; sandbox tests in metabase-enterprise.sandbox.query-processor.middleware.row-level-restrictions-test
 
-(deftest persisted-stuff-rename-nocommit
-  (mt/test-drivers (mt/normal-drivers-with-feature :persist-models)
-    (mt/dataset sample-dataset
-      (mt/with-persistence-enabled [persist-models!]
-        (mt/with-temp* [Card [model {:dataset true
-                                     :database_id (mt/id)
-                                     :query_type :query
-                                     :dataset_query (mt/mbql-query products)}]]
-          (persist-models!)
-          (let [bad-refs (atom [])
-                price-field (mt/$ids $products.price)
-                category-field (mt/$ids $products.category)
-                query   {:type :query
-                         :database (mt/id)
-                         :query {:source-table (str "card__" (:id model))
-                                 :expressions {:adjective
-                                               [:case
-                                                [[[:> price-field 30] "expensive"]
-                                                 [[:> price-field 20] "not too bad"]]
-                                                {:default "not expensive"}]}
-                                 :aggregation [[:count]]
-                                 :breakout [[:expression :adjective]
-                                            category-field]}}
-                results (binding [fix-bad-refs/*bad-field-reference-fn*
-                                  (fn [x]
-                                    (swap! bad-refs conj x))]
-                          (qp/process-query query))
-                persisted-schema (ddl.i/schema-name (mt/db) (public-settings/site-uuid))]
-            (testing "Was persisted"
-              (is (str/includes? (-> results :data :native_form :query) persisted-schema)))
-            (testing "Did not find bad field clauses"
-              (is (= [] @bad-refs)))))))))
+(defn- populate-metadata [{query :dataset_query id :id :as _model}]
+  (let [updater (a/thread
+                  (let [metadata (a/<!! (qp.async/result-metadata-for-query-async query))]
+                    (db/update! 'Card id :result_metadata metadata)))]
+    (when (= ::timed-out (mt/wait-for-result updater 2000 ::timed-out))
+      (throw (ex-info "Query metadata not set in time for querying against model"
+                      {:location `populate-metadata})))))
+
+(deftest persisted-models-complex-queries-test
+  (testing "Can use aggregations and custom columns with persisted models (#28679)"
+    (mt/test-drivers (mt/normal-drivers-with-feature :persist-models)
+      (mt/dataset sample-dataset
+        (doseq [[query-type query] [[:query (mt/mbql-query products)]
+                                    [:native (mt/native-query
+                                              {:query "select * from products"})]]]
+          (mt/with-persistence-enabled [persist-models!]
+            (mt/with-temp* [Card [model {:dataset true
+                                         :database_id (mt/id)
+                                         :query_type query-type
+                                         :dataset_query query}]]
+              (when (= query-type :native)
+                ;; mbql we figure out metadata from query itself. native is opaque and must have metadata in order to
+                ;; know which fields are in the model.
+                (populate-metadata model))
+              (persist-models!)
+              (let [bad-refs (atom [])
+                    price-field (case query-type
+                                  :query (mt/$ids $products.price)
+                                  :native [:field "price" {:base-type :type/Float}])
+                    category-field (case query-type
+                                     :query (mt/$ids $products.category)
+                                     :native [:field "category" {:base-type :type/Text}])
+                    query   {:type :query
+                             :database (mt/id)
+                             :query {:source-table (str "card__" (:id model))
+                                     :expressions {"adjective"
+                                                   [:case
+                                                    [[[:> price-field 30] "expensive"]
+                                                     [[:> price-field 20] "not too bad"]]
+                                                    {:default "not expensive"}]}
+                                     :aggregation [[:count]]
+                                     :breakout [[:expression "adjective" nil]
+                                                category-field]}}
+                    results (binding [fix-bad-refs/*bad-field-reference-fn*
+                                      (fn [x]
+                                        (swap! bad-refs conj x))]
+                              (qp/process-query query))
+                    persisted-schema (ddl.i/schema-name (mt/db) (public-settings/site-uuid))]
+                (testing "Was persisted"
+                  (is (str/includes? (-> results :data :native_form :query) persisted-schema)))
+                (testing "Did not find bad field clauses"
+                  (is (= [] @bad-refs)))))))))))

--- a/test/metabase/query_processor/persistence_test.clj
+++ b/test/metabase/query_processor/persistence_test.clj
@@ -68,7 +68,8 @@
       (mt/dataset sample-dataset
         (doseq [[query-type query] [[:query (mt/mbql-query products)]
                                     [:native (mt/native-query
-                                              {:query "select * from products"})]]]
+                                              (mt/compile
+                                               (mt/mbql-query products)))]]]
           (mt/with-persistence-enabled [persist-models!]
             (mt/with-temp* [Card [model {:dataset true
                                          :database_id (mt/id)

--- a/test/metabase/query_processor/persistence_test.clj
+++ b/test/metabase/query_processor/persistence_test.clj
@@ -1,0 +1,85 @@
+(ns metabase.query-processor.persistence-test
+  (:require [clojure.string :as str]
+            [clojure.test :refer :all]
+            [metabase.driver :as driver]
+            [metabase.driver.ddl.interface :as ddl.i]
+            [metabase.models :refer [Card]]
+            [metabase.public-settings :as public-settings]
+            [metabase.query-processor :as qp]
+            [metabase.query-processor.interface :as qp.i]
+            [metabase.query-processor.middleware.fix-bad-references
+             :as fix-bad-refs]
+            [metabase.test :as mt]))
+
+(deftest can-persist-test
+  (testing "Can each database that allows for persistence actually persist"
+    (mt/test-drivers (mt/normal-drivers-with-feature :persist-models)
+      (testing (str driver/*driver* " can persist")
+        (mt/dataset test-data
+          (let [[success? error] (ddl.i/check-can-persist (mt/db))]
+            (is success? (str "Not able to persist on " driver/*driver*))
+            (is (= :persist.check/valid error))))))))
+
+(deftest persisted-models-max-rows-test
+  (testing "Persisted models should have the full number of rows of the underlying query,
+            not limited by `absolute-max-results` (#24793)"
+    #_{:clj-kondo/ignore [:discouraged-var]}
+    (with-redefs [qp.i/absolute-max-results 3]
+      (mt/test-drivers (mt/normal-drivers-with-feature :persist-models)
+        (mt/dataset daily-bird-counts
+          (mt/with-persistence-enabled [persist-models!]
+            (mt/with-temp* [Card [model {:dataset       true
+                                         :database_id   (mt/id)
+                                         :query_type    :query
+                                         :dataset_query {:database (mt/id)
+                                                         :type     :query
+                                                         :query    {:source-table (mt/id :bird-count)}}}]]
+              (let [ ;; Get the number of rows before the model is persisted
+                    query-on-top       {:database (mt/id)
+                                        :type     :query
+                                        :query    {:aggregation  [[:count]]
+                                                   :source-table (str "card__" (:id model))}}
+                    [[num-rows-query]] (mt/rows (qp/process-query query-on-top))]
+                ;; Persist the model
+                (persist-models!)
+                ;; Check the number of rows is the same after persisting
+                (let [query-on-top {:database (mt/id)
+                                    :type     :query
+                                    :query    {:aggregation [[:count]]
+                                               :source-table (str "card__" (:id model))}}]
+                  (is (= [[num-rows-query]] (mt/rows (qp/process-query query-on-top)))))))))))))
+
+;; sandbox tests in metabase-enterprise.sandbox.query-processor.middleware.row-level-restrictions-test
+
+(deftest persisted-stuff-rename-nocommit
+  (mt/test-drivers (mt/normal-drivers-with-feature :persist-models)
+    (mt/dataset sample-dataset
+      (mt/with-persistence-enabled [persist-models!]
+        (mt/with-temp* [Card [model {:dataset true
+                                     :database_id (mt/id)
+                                     :query_type :query
+                                     :dataset_query (mt/mbql-query products)}]]
+          (persist-models!)
+          (let [bad-refs (atom [])
+                price-field (mt/$ids $products.price)
+                category-field (mt/$ids $products.category)
+                query   {:type :query
+                         :database (mt/id)
+                         :query {:source-table (str "card__" (:id model))
+                                 :expressions {:adjective
+                                               [:case
+                                                [[[:> price-field 30] "expensive"]
+                                                 [[:> price-field 20] "not too bad"]]
+                                                {:default "not expensive"}]}
+                                 :aggregation [[:count]]
+                                 :breakout [[:expression :adjective]
+                                            category-field]}}
+                results (binding [fix-bad-refs/*bad-field-reference-fn*
+                                  (fn [x]
+                                    (swap! bad-refs conj x))]
+                          (qp/process-query query))
+                persisted-schema (ddl.i/schema-name (mt/db) (public-settings/site-uuid))]
+            (testing "Was persisted"
+              (is (str/includes? (-> results :data :native_form :query) persisted-schema)))
+            (testing "Did not find bad field clauses"
+              (is (= [] @bad-refs)))))))))

--- a/test/metabase/test/util/async.clj
+++ b/test/metabase/test/util/async.clj
@@ -21,10 +21,12 @@
   ([chan]
    (wait-for-result chan 200))
   ([chan timeout-ms]
+   (wait-for-result chan timeout-ms ::timed-out))
+  ([chan timeout-ms timed-out-val]
    (try
-     (let [[val port] (a/alts!! [chan (a/timeout timeout-ms)])]
+     (let [[val port] (a/alts!! [chan (a/timeout timeout-ms)] :priority true)]
        (if (not= port chan)
-         ::timed-out
+         timed-out-val
          val))
      (finally
        (a/close! chan)))))


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/28679

(I can't quite recreate the behavior of that issue but pretty sure this will solve it)

We were substituting persisted queries into the query at too early a stage.

Card 729 is a persisted model of `select * from categories`

```clojure
{:type :query,
 :query {:source-table "card__729",
         :expressions {:adjective ["case"
                                   [[[">" ["field" 100 nil] 30] ;; price > 30
                                     "expensive"]
                                    [[">" ["field" 100 nil] 20] ;; price > 20
                                     "not too bad"]]
                                   {:default "its ok"}]},
         :aggregation [["count"]],
         :breakout [["expression" "adjective" nil]
                    ["field" 101 nil]]}, ;; group by "adjective" and category
 :database 3,
 :parameters []}
```

This would immediately get turned into an equivalent

```clojure
{:type :query,
 :query {:source-table 12
         :persisted-info/native "select \"id\", \"ean\", \"title\", \"category\", \"vendor\", \"price\", \"rating\", \"created_at\" from \"metabase_cache_424a9_3\".\"model_729_products_r\""
         :expressions {:adjective ["case"
                                   [[[">" ["field" 100 nil] 30]
                                     "expensive"]
                                    [[">" ["field" 100 nil] 20]
                                     "not too bad"]]
                                   {:default "its ok"}]},
         :aggregation [["count"]],
         :breakout [["expression" "adjective" nil]
                    ["field" 101 nil]]},
 :database 3,
 :parameters []}
```

And the obvious failure here is the use of `[:field 100 nil]` (price) against an inner query of `select ... price ... from cache_table`. This could break many queries and caused a flood of

```
WARN middleware.fix-bad-references :: Bad :field clause [:field 100 #:metabase.query-processor.util.add-alias-info{:source-table :metabase.query-processor.util.add-alias-info/source, :source-alias "price"}] for field "products.price" at [:expressions "adjective" :case :>]: clause should have a :join-alias. Unable to infer an appropriate join. Query may not work as expected.
WARN middleware.fix-bad-references :: Bad :field clause [:field 100 #:metabase.query-processor.util.add-alias-info{:source-table :metabase.query-processor.util.add-alias-info/source, :source-alias "price"}] for field "products.price" at [:expressions "adjective" :case :>]: clause should have a :join-alias. Unable to infer an appropriate join. Query may not work as expected.
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/28739)
<!-- Reviewable:end -->
