### PR TITLE
Fix wrong aggregation field's `base_type`

### DIFF
--- a/e2e/test/scenarios/filters/reproductions/25994-between-after-summarize-not-working.cy.spec.js
+++ b/e2e/test/scenarios/filters/reproductions/25994-between-after-summarize-not-working.cy.spec.js
@@ -23,7 +23,7 @@ const questionDetails = {
   },
 };
 
-describe.skip("issue 25994", () => {
+describe("issue 25994", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();

--- a/frontend/src/metabase-lib/queries/structured/Aggregation.ts
+++ b/frontend/src/metabase-lib/queries/structured/Aggregation.ts
@@ -12,7 +12,10 @@ import Metric from "metabase-lib/metadata/Metric";
 import StructuredQuery from "../StructuredQuery";
 import Dimension, { AggregationDimension } from "../../Dimension";
 import MBQLClause from "./MBQLClause";
+
 const INTEGER_AGGREGATIONS = new Set(["count", "cum-count", "distinct"]);
+const ORIGINAL_FIELD_TYPE_AGGREGATIONS = new Set(["min", "max"]);
+
 export default class Aggregation extends MBQLClause {
   /**
    * Replaces the aggregation in the parent query and returns the new StructuredQuery
@@ -134,7 +137,16 @@ export default class Aggregation extends MBQLClause {
 
   baseType() {
     const short = this.short();
-    return INTEGER_AGGREGATIONS.has(short) ? TYPE.Integer : TYPE.Float;
+    if (INTEGER_AGGREGATIONS.has(short)) {
+      return TYPE.Integer;
+    }
+
+    const field = this.dimension()?.field();
+    if (ORIGINAL_FIELD_TYPE_AGGREGATIONS.has(short) && field) {
+      return field.base_type;
+    }
+
+    return TYPE.Float;
   }
 
   /**

--- a/frontend/test/metabase-lib/lib/Dimension.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/Dimension.unit.spec.js
@@ -801,6 +801,62 @@ describe("Dimension", () => {
           expect(base_type).toBe("type/Integer");
         });
 
+        it.each([
+          {
+            field: ["field", PRODUCTS.CATEGORY.id, null],
+            fieldName: "category",
+            expectedType: "type/Text",
+          },
+          {
+            field: ["field", PRODUCTS.PRICE.id, null],
+            fieldName: "price",
+            expectedType: "type/Float",
+          },
+          {
+            field: [
+              "field",
+              PRODUCTS.CREATED_AT.id,
+              { "temporal-unit": "day" },
+            ],
+            fieldName: "created_at",
+            expectedType: "type/DateTime",
+          },
+        ])(
+          "should return $expectedType for min of $fieldName",
+          ({ field, expectedType }) => {
+            const { base_type } = aggregation(["min", field]).field();
+            expect(base_type).toBe(expectedType);
+          },
+        );
+
+        it.each([
+          {
+            field: ["field", PRODUCTS.CATEGORY.id, null],
+            fieldName: "category",
+            expectedType: "type/Text",
+          },
+          {
+            field: ["field", PRODUCTS.PRICE.id, null],
+            fieldName: "price",
+            expectedType: "type/Float",
+          },
+          {
+            field: [
+              "field",
+              PRODUCTS.CREATED_AT.id,
+              { "temporal-unit": "day" },
+            ],
+            fieldName: "created_at",
+            expectedType: "type/DateTime",
+          },
+        ])(
+          "should return $expectedType for max of $fieldName",
+          ({ field, expectedType }) => {
+            const { base_type } = aggregation(["max", field]).field();
+            expect(base_type).toBe(expectedType);
+          },
+        );
+
         it("should return an int field for count", () => {
           const { base_type } = aggregation(["count"]).field();
           expect(base_type).toBe("type/Integer");


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/25994

### Description

The current `base_type` set from `Aggregation` is for `min` and `max` aggregation functions is plainly wrong. The issue referenced for instance, has the aggregation field as **Min of Created Date**. And the issue was that we say the `base_type` is `type/Float` instead of using the underlying field's `base_type` of `type/DateTime`

#### Documentations confirming that `min` or `max` returns the same type as the input type (some of the databases from [supported databases](https://www.metabase.com/docs/latest/databases/connecting#connecting-to-supported-databases) that I could find their docs):
- [Postgres](https://www.postgresql.org/docs/15/functions-aggregate.html)
- [BigQuery](https://cloud.google.com/bigquery/docs/reference/standard-sql/aggregate_functions#max)
- [Amazon Athena](https://trino.io/docs/current/functions/aggregate.html#min)
    > Functions in Athena engine version 3 are based on Trino. For information about Trino functions, operators, and expressions, see [Functions and operators](https://trino.io/docs/current/functions.html) and the following subsections from the Trino documentation.
- [Presto](https://prestodb.io/docs/current/functions/aggregate.html?highlight=min)
- [Redshift](https://docs.aws.amazon.com/redshift/latest/dg/r_MIN.html#c_Supported_data_types_min)
- [SQL Server](https://learn.microsoft.com/en-us/sql/t-sql/functions/max-transact-sql?view=sql-server-ver16#return-types)
- [Vertica](https://www.vertica.com/docs/9.3.x/HTML/Content/Authoring/SQLReferenceManual/Functions/Aggregate/MINAggregate.htm)

### How to verify

There are a couple of ways

1. The unskipped reproduced E2E test is passing (1 test)
2. Follow [Flamber's repro from here](https://github.com/metabase/metabase/issues/25994#issuecomment-1283912610), and your query shouldn't result in any error.

### Demo

#### Question
<img width="1053" alt="image" src="https://user-images.githubusercontent.com/1937582/221901697-4a1e950b-a606-4e3d-bc6f-12bcdcbb80b5.png">

#### Before result
<img width="1104" alt="image" src="https://user-images.githubusercontent.com/1937582/221902555-35390bbf-6eef-465b-a277-9dccfb9b666b.png">


#### After result
<img width="632" alt="image" src="https://user-images.githubusercontent.com/1937582/221902025-ed380295-f67a-48bc-8d90-e4761192b4c2.png">

### Checklist

- [x] Tests have been added/updated to cover changes in this PR

### Note

This is the produced query before the fix which resulted in an error
```json
{
  "type": "query",
  "query": {
    "source-query": {
      "source-table": 1,
      "aggregation": [["min", ["field", 63, { "temporal-unit": "day" }]]],
      "breakout": [["field", 58, null]]
    },
    "filter": [
      "between",
      ["field", "min", { "base-type": "type/Float" }],
      "2016-01-29",
      "2023-02-28"
    ]
  },
  "database": 1,
  "parameters": []
}
```

VS the fixed query

```json
{
  "type": "query",
  "query": {
    "source-query": {
      "source-table": 1,
      "aggregation": [["min", ["field", 63, { "temporal-unit": "day" }]]],
      "breakout": [["field", 58, null]]
    },
    "filter": [
      "between",
      ["field", "min", { "base-type": "type/DateTime" }],
      "2016-01-29",
      "2023-02-28"
    ]
  },
  "database": 1,
  "parameters": []
}
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/28741)
<!-- Reviewable:end -->
