### PR TITLE
Handle errors when enabling database actions

### DIFF
--- a/frontend/src/metabase/admin/databases/components/DatabaseEditApp/Sidebar/ModelActionsSection/ModelActionsSection.styled.tsx
+++ b/frontend/src/metabase/admin/databases/components/DatabaseEditApp/Sidebar/ModelActionsSection/ModelActionsSection.styled.tsx
@@ -22,3 +22,9 @@ export const Description = styled.p`
   color: ${color("text-medium")};
   line-height: 22px;
 `;
+
+export const Error = styled(Description)`
+  color: ${color("error")};
+  border-left: 3px solid ${color("error")};
+  padding-left: 12px;
+`;

--- a/frontend/src/metabase/admin/databases/components/DatabaseEditApp/Sidebar/ModelActionsSection/ModelActionsSection.tsx
+++ b/frontend/src/metabase/admin/databases/components/DatabaseEditApp/Sidebar/ModelActionsSection/ModelActionsSection.tsx
@@ -27,7 +27,7 @@ function ModelActionsSection({
       setError(null);
       await onToggleModelActionsEnabled(enabled);
     } catch (err) {
-      setError(getResponseErrorMessage(err) || t`Something went wrong`);
+      setError(getResponseErrorMessage(err) || t`An error occurred`);
     }
   };
 

--- a/frontend/src/metabase/admin/databases/components/DatabaseEditApp/Sidebar/ModelActionsSection/ModelActionsSection.tsx
+++ b/frontend/src/metabase/admin/databases/components/DatabaseEditApp/Sidebar/ModelActionsSection/ModelActionsSection.tsx
@@ -1,23 +1,36 @@
-import React from "react";
+import React, { useState } from "react";
 import { t } from "ttag";
 
 import Toggle from "metabase/core/components/Toggle";
+import { getResponseErrorMessage } from "metabase/core/utils/errors";
 
 import {
   ToggleContainer,
   Label,
   Description,
+  Error,
 } from "./ModelActionsSection.styled";
 
-interface ModelActionsSectionProps {
+export interface ModelActionsSectionProps {
   hasModelActionsEnabled: boolean;
-  onToggleModelActionsEnabled: (enabled: boolean) => void;
+  onToggleModelActionsEnabled: (enabled: boolean) => Promise<void>;
 }
 
 function ModelActionsSection({
   hasModelActionsEnabled,
   onToggleModelActionsEnabled,
 }: ModelActionsSectionProps) {
+  const [error, setError] = useState<string | null>(null);
+
+  const handleToggleModelActionsEnabled = async (enabled: boolean) => {
+    try {
+      setError(null);
+      await onToggleModelActionsEnabled(enabled);
+    } catch (err) {
+      setError(getResponseErrorMessage(err) || t`Something went wrong`);
+    }
+  };
+
   return (
     <div>
       <ToggleContainer>
@@ -25,9 +38,10 @@ function ModelActionsSection({
         <Toggle
           id="model-actions-toggle"
           value={hasModelActionsEnabled}
-          onChange={onToggleModelActionsEnabled}
+          onChange={handleToggleModelActionsEnabled}
         />
       </ToggleContainer>
+      {error ? <Error>{error}</Error> : null}
       <Description>{t`Allow actions from models created from this data to be run. Actions are able to read, write, and possibly delete data.`}</Description>
       <Description>{t`Note: Your database user will need write permissions.`}</Description>
     </div>

--- a/frontend/src/metabase/admin/databases/components/DatabaseEditApp/Sidebar/ModelActionsSection/ModelActionsSection.unit.spec.tsx
+++ b/frontend/src/metabase/admin/databases/components/DatabaseEditApp/Sidebar/ModelActionsSection/ModelActionsSection.unit.spec.tsx
@@ -1,0 +1,82 @@
+import React, { useState } from "react";
+import userEvent from "@testing-library/user-event";
+import { render, screen, waitFor } from "__support__/ui";
+import ModelActionsSection, {
+  ModelActionsSectionProps,
+} from "./ModelActionsSection";
+
+function ModelActionSectionWrapper({
+  hasModelActionsEnabled: initialValue,
+  onToggleModelActionsEnabled: onChange,
+}: ModelActionsSectionProps) {
+  const [isEnabled, setEnabled] = useState(initialValue);
+
+  const handleChange = async (nextValue: boolean) => {
+    await onChange(nextValue);
+    setEnabled(nextValue);
+  };
+
+  return (
+    <ModelActionsSection
+      hasModelActionsEnabled={isEnabled}
+      onToggleModelActionsEnabled={handleChange}
+    />
+  );
+}
+
+function setup({
+  hasModelActionsEnabled = false,
+  onToggleModelActionsEnabled = jest.fn(),
+}: Partial<ModelActionsSectionProps>) {
+  render(
+    <ModelActionSectionWrapper
+      hasModelActionsEnabled={hasModelActionsEnabled}
+      onToggleModelActionsEnabled={onToggleModelActionsEnabled}
+    />,
+  );
+
+  const toggle = screen.getByLabelText("Model actions");
+
+  return { toggle, onToggleModelActionsEnabled };
+}
+
+describe("ModelActionsSection", () => {
+  it("should allow toggling actions", async () => {
+    const { toggle, onToggleModelActionsEnabled } = setup({
+      hasModelActionsEnabled: false,
+    });
+
+    expect(toggle).not.toBeChecked();
+
+    userEvent.click(toggle);
+
+    await waitFor(() => expect(toggle).toBeChecked());
+    expect(onToggleModelActionsEnabled).toHaveBeenLastCalledWith(true);
+
+    userEvent.click(toggle);
+
+    await waitFor(() => expect(toggle).not.toBeChecked());
+    expect(onToggleModelActionsEnabled).toHaveBeenLastCalledWith(false);
+  });
+
+  it("should handle errors while toggling actions", async () => {
+    const errorMessage = "Lacking write database permissions";
+    const onToggleModelActionsEnabled = jest.fn().mockRejectedValueOnce({
+      data: { message: errorMessage },
+    });
+
+    const { toggle } = setup({
+      hasModelActionsEnabled: false,
+      onToggleModelActionsEnabled,
+    });
+
+    userEvent.click(toggle);
+    await waitFor(() => expect(toggle).not.toBeChecked());
+    expect(screen.getByText(errorMessage)).toBeInTheDocument();
+
+    userEvent.click(toggle);
+    await waitFor(() => expect(toggle).toBeChecked());
+    expect(screen.queryByText(errorMessage)).not.toBeInTheDocument();
+    expect(onToggleModelActionsEnabled).toHaveBeenLastCalledWith(true);
+  });
+});

--- a/frontend/src/metabase/admin/databases/components/DatabaseEditApp/Sidebar/Sidebar.tsx
+++ b/frontend/src/metabase/admin/databases/components/DatabaseEditApp/Sidebar/Sidebar.tsx
@@ -25,7 +25,9 @@ interface DatabaseEditAppSidebarProps {
   database: Database;
   isAdmin: boolean;
   isModelPersistenceEnabled: boolean;
-  updateDatabase: (database: { id: DatabaseId } & Partial<IDatabase>) => void;
+  updateDatabase: (
+    database: { id: DatabaseId } & Partial<IDatabase>,
+  ) => Promise<void>;
   syncDatabaseSchema: (databaseId: DatabaseId) => void;
   dismissSyncSpinner: (databaseId: DatabaseId) => void;
   rescanDatabaseFields: (databaseId: DatabaseId) => void;

--- a/frontend/src/metabase/admin/databases/components/DatabaseEditApp/Sidebar/Sidebar.tsx
+++ b/frontend/src/metabase/admin/databases/components/DatabaseEditApp/Sidebar/Sidebar.tsx
@@ -28,11 +28,14 @@ interface DatabaseEditAppSidebarProps {
   updateDatabase: (
     database: { id: DatabaseId } & Partial<IDatabase>,
   ) => Promise<void>;
-  syncDatabaseSchema: (databaseId: DatabaseId) => void;
-  dismissSyncSpinner: (databaseId: DatabaseId) => void;
-  rescanDatabaseFields: (databaseId: DatabaseId) => void;
-  discardSavedFieldValues: (databaseId: DatabaseId) => void;
-  deleteDatabase: (databaseId: DatabaseId, isDetailView: boolean) => void;
+  syncDatabaseSchema: (databaseId: DatabaseId) => Promise<void>;
+  dismissSyncSpinner: (databaseId: DatabaseId) => Promise<void>;
+  rescanDatabaseFields: (databaseId: DatabaseId) => Promise<void>;
+  discardSavedFieldValues: (databaseId: DatabaseId) => Promise<void>;
+  deleteDatabase: (
+    databaseId: DatabaseId,
+    isDetailView: boolean,
+  ) => Promise<void>;
 }
 
 const DatabaseEditAppSidebar = ({


### PR DESCRIPTION
Closes #27852

### Description

Adds error handling to a toggle enabling/disabling actions for a database

### How to verify

1. For your Postgres / MySQL database, create a _database_ user with read-only permissions
2. Connect the database to Metabase using these credentials
3. Try to enable actions using the sidebar on the database connection page
4. Ensure you can see an error

**Quicker way**

1. Remove [this condition](https://github.com/metabase/metabase/blob/0eb21adb625a53dda779a60c45f9f59254363ee1/frontend/src/metabase/admin/databases/components/DatabaseEditApp/Sidebar/Sidebar.tsx#L184), so the actions toggle shows up for database not supporting actions
2. Try to enable actions for e.g. Mongo
3. Ensure you can see an error

### Demo

> **Warning**
> For demo purposes, I've made the actions control show up for database not supporting actions. This shouldn't happen in the real world

https://user-images.githubusercontent.com/17258145/221905416-74ef955f-6f05-4924-afb1-28ba77886dac.mp4

### Checklist

- [x] Tests have been added/updated to cover changes in this PR

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/28744)
<!-- Reviewable:end -->
