### PR TITLE
Remove minSize constraint on dashboard cards

### DIFF
--- a/frontend/src/metabase/actions/components/ActionViz/ActionViz.tsx
+++ b/frontend/src/metabase/actions/components/ActionViz/ActionViz.tsx
@@ -17,7 +17,7 @@ export default Object.assign(Action, {
   disableSettingsConfig: true,
   canSavePng: false,
 
-  minSize: { width: 1, height: 1 },
+  defaultSize: { width: 1, height: 1 },
 
   checkRenderable: () => true,
   isSensible: () => false,

--- a/frontend/src/metabase/dashboard/actions/cards.js
+++ b/frontend/src/metabase/dashboard/actions/cards.js
@@ -36,7 +36,7 @@ export const addCardToDashboard =
       .map(id => dashcards[id])
       .filter(dc => !dc.isRemoved);
     const { visualization } = getVisualizationRaw([{ card }]);
-    const createdCardSize = visualization.minSize || DEFAULT_CARD_SIZE;
+    const createdCardSize = visualization.defaultSize || DEFAULT_CARD_SIZE;
     const dashcard = {
       id: generateTemporaryDashcardId(),
       dashboard_id: dashId,

--- a/frontend/src/metabase/dashboard/components/DashboardGrid.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardGrid.jsx
@@ -157,8 +157,7 @@ class DashboardGrid extends Component {
 
   getLayoutForDashCard(dashcard) {
     const { visualization } = getVisualizationRaw([{ card: dashcard.card }]);
-    const initialSize = DEFAULT_CARD_SIZE;
-    const minSize = visualization.minSize || DEFAULT_CARD_SIZE;
+    const initialSize = visualization.defaultSize || DEFAULT_CARD_SIZE;
     return {
       i: String(dashcard.id),
       x: dashcard.col || 0,
@@ -166,8 +165,8 @@ class DashboardGrid extends Component {
       w: dashcard.size_x || initialSize.width,
       h: dashcard.size_y || initialSize.height,
       dashcard: dashcard,
-      minW: minSize.width,
-      minH: minSize.height,
+      minW: 1,
+      minH: 1,
     };
   }
 

--- a/frontend/src/metabase/visualizations/components/ChoroplethMap.jsx
+++ b/frontend/src/metabase/visualizations/components/ChoroplethMap.jsx
@@ -95,7 +95,7 @@ function shouldUseCompactFormatting(groups, formatMetric) {
 export default class ChoroplethMap extends Component {
   static propTypes = {};
 
-  static minSize = { width: 4, height: 4 };
+  static defaultSize = { width: 4, height: 4 };
 
   static isSensible({ cols }) {
     return cols.filter(isString).length > 0 && cols.filter(isMetric).length > 0;

--- a/frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx
+++ b/frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx
@@ -80,7 +80,7 @@ export default class LineAreaBarChart extends Component {
   static noHeader = true;
   static supportsSeries = true;
 
-  static minSize = { width: 4, height: 3 };
+  static defaultSize = { width: 4, height: 3 };
 
   static isSensible({ cols, rows }) {
     return (

--- a/frontend/src/metabase/visualizations/shared/types/visualization.ts
+++ b/frontend/src/metabase/visualizations/shared/types/visualization.ts
@@ -7,7 +7,7 @@ export type Visualization = {
   noun: string;
   hidden?: boolean;
   noHeader: boolean;
-  minSize: {
+  defaultSize: {
     width: number;
     height: number;
   };

--- a/frontend/src/metabase/visualizations/visualizations/Funnel.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Funnel.jsx
@@ -38,7 +38,7 @@ export default class Funnel extends Component {
 
   static noHeader = true;
 
-  static minSize = {
+  static defaultSize = {
     width: 5,
     height: 4,
   };

--- a/frontend/src/metabase/visualizations/visualizations/Gauge.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Gauge.jsx
@@ -57,7 +57,7 @@ export default class Gauge extends Component {
   static identifier = "gauge";
   static iconName = "gauge";
 
-  static minSize = { width: 4, height: 4 };
+  static defaultSize = { width: 4, height: 4 };
 
   static isSensible({ cols, rows }) {
     return rows.length === 1 && cols.length === 1;

--- a/frontend/src/metabase/visualizations/visualizations/LinkViz/LinkVizSettings.ts
+++ b/frontend/src/metabase/visualizations/visualizations/LinkViz/LinkVizSettings.ts
@@ -10,7 +10,7 @@ export const settings = {
   supportsSeries: false,
   hidden: true,
   supportPreviewing: false,
-  minSize: { width: 1, height: 1 },
+  defaultSize: { width: 1, height: 1 },
   checkRenderable: () => undefined,
   settings: {
     "card.title": {

--- a/frontend/src/metabase/visualizations/visualizations/Map.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Map.jsx
@@ -48,7 +48,7 @@ export default class Map extends Component {
 
   static aliases = ["state", "country", "pin_map"];
 
-  static minSize = { width: 4, height: 4 };
+  static defaultSize = { width: 4, height: 4 };
 
   static isSensible({ cols, rows }) {
     return (

--- a/frontend/src/metabase/visualizations/visualizations/PieChart/PieChart.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/PieChart/PieChart.jsx
@@ -55,7 +55,7 @@ export default class PieChart extends Component {
   static identifier = "pie";
   static iconName = "pie";
 
-  static minSize = { width: 4, height: 4 };
+  static defaultSize = { width: 4, height: 4 };
 
   static isSensible({ cols, rows }) {
     return cols.length === 2;

--- a/frontend/src/metabase/visualizations/visualizations/Progress.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Progress.jsx
@@ -30,7 +30,7 @@ export default class Progress extends Component {
   static identifier = "progress";
   static iconName = "progress";
 
-  static minSize = { width: 3, height: 3 };
+  static defaultSize = { width: 3, height: 3 };
 
   static isSensible({ cols, rows }) {
     return rows.length === 1 && cols.length === 1;

--- a/frontend/src/metabase/visualizations/visualizations/RowChart/RowChart.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/RowChart/RowChart.tsx
@@ -327,7 +327,7 @@ RowChartVisualization.iconName = "horizontal_bar";
 RowChartVisualization.noun = t`row chart`;
 
 RowChartVisualization.noHeader = true;
-RowChartVisualization.minSize = { width: 5, height: 4 };
+RowChartVisualization.defaultSize = { width: 5, height: 4 };
 
 RowChartVisualization.settings = {
   ...ROW_CHART_SETTINGS,

--- a/frontend/src/metabase/visualizations/visualizations/Scalar.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Scalar.jsx
@@ -41,7 +41,7 @@ export default class Scalar extends Component {
   static noHeader = true;
   static supportsSeries = true;
 
-  static minSize = { width: 3, height: 3 };
+  static defaultSize = { width: 3, height: 3 };
 
   static isSensible({ cols, rows }) {
     return rows.length === 1 && cols.length === 1;

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar.jsx
@@ -31,7 +31,7 @@ export default class Smart extends React.Component {
   static iconName = "smartscalar";
   static canSavePng = false;
 
-  static minSize = { width: 3, height: 3 };
+  static defaultSize = { width: 3, height: 3 };
 
   static noHeader = true;
 

--- a/frontend/src/metabase/visualizations/visualizations/Table.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Table.jsx
@@ -40,7 +40,7 @@ export default class Table extends Component {
   static iconName = "table";
   static canSavePng = false;
 
-  static minSize = { width: 4, height: 3 };
+  static defaultSize = { width: 4, height: 3 };
 
   static isSensible({ cols, rows }) {
     return true;

--- a/frontend/src/metabase/visualizations/visualizations/Text/Text.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Text/Text.jsx
@@ -45,7 +45,7 @@ export default class Text extends Component {
   static hidden = true;
   static supportPreviewing = true;
 
-  static minSize = { width: 4, height: 1 };
+  static defaultSize = { width: 4, height: 1 };
 
   static checkRenderable() {
     // text can always be rendered, nothing needed here


### PR DESCRIPTION
Closes #5662 

Removes the `minSize` constraint on visualizations, instead opting for a `defaultSize` property.