### PR TITLE
Disable basic actions for unsupported models

### DIFF
--- a/frontend/src/metabase-lib/Question.ts
+++ b/frontend/src/metabase-lib/Question.ts
@@ -474,6 +474,16 @@ class QuestionInner {
     return this.canWrite() && hasActionsEnabled;
   }
 
+  supportsImplicitActions(): boolean {
+    const query = this.query();
+
+    return (
+      this.isDataset() &&
+      query instanceof StructuredQuery &&
+      !query.hasAnyClauses()
+    );
+  }
+
   canAutoRun(): boolean {
     const db = this.database();
     return (db && db.auto_run_queries) || false;

--- a/frontend/src/metabase-lib/Question.ts
+++ b/frontend/src/metabase-lib/Question.ts
@@ -476,12 +476,7 @@ class QuestionInner {
 
   supportsImplicitActions(): boolean {
     const query = this.query();
-
-    return (
-      this.isDataset() &&
-      query instanceof StructuredQuery &&
-      !query.hasAnyClauses()
-    );
+    return query instanceof StructuredQuery && !query.hasAnyClauses();
   }
 
   canAutoRun(): boolean {

--- a/frontend/src/metabase-types/api/query.ts
+++ b/frontend/src/metabase-types/api/query.ts
@@ -3,8 +3,11 @@ import type { DatabaseId } from "./database";
 import type { FieldId } from "./field";
 import type { TableId } from "./table";
 
+export type LimitClause = number;
+
 export interface StructuredQuery {
   "source-table"?: TableId;
+  limit?: LimitClause;
 }
 
 export interface NativeQuery {

--- a/frontend/src/metabase-types/api/query.ts
+++ b/frontend/src/metabase-types/api/query.ts
@@ -3,11 +3,8 @@ import type { DatabaseId } from "./database";
 import type { FieldId } from "./field";
 import type { TableId } from "./table";
 
-export type LimitClause = number;
-
 export interface StructuredQuery {
   "source-table"?: TableId;
-  limit?: LimitClause;
 }
 
 export interface NativeQuery {

--- a/frontend/src/metabase/models/components/ModelDetailPage/ModelActionDetails/ModelActionDetails.tsx
+++ b/frontend/src/metabase/models/components/ModelDetailPage/ModelActionDetails/ModelActionDetails.tsx
@@ -149,11 +149,13 @@ function ModelActionDetails({
       {canWrite && (
         <ActionsHeader>
           <Button as={Link} to={newActionUrl}>{t`New action`}</Button>
-          <ActionMenu
-            triggerIcon="ellipsis"
-            items={menuItems}
-            triggerProps={{ "aria-label": t`Actions menu` }}
-          />
+          {menuItems.length > 0 && (
+            <ActionMenu
+              triggerIcon="ellipsis"
+              items={menuItems}
+              triggerProps={{ "aria-label": t`Actions menu` }}
+            />
+          )}
         </ActionsHeader>
       )}
       {database && !hasActionsEnabled && (

--- a/frontend/src/metabase/models/components/ModelDetailPage/ModelActionDetails/ModelActionDetails.tsx
+++ b/frontend/src/metabase/models/components/ModelDetailPage/ModelActionDetails/ModelActionDetails.tsx
@@ -72,6 +72,7 @@ function ModelActionDetails({
   const database = model.database();
   const hasActionsEnabled = database != null && database.hasActionsEnabled();
   const canWrite = model.canWriteActions();
+  const supportsImplicitActions = model.supportsImplicitActions();
 
   const actionsSorted = useMemo(
     () => _.sortBy(actions, mostRecentFirst),
@@ -106,7 +107,7 @@ function ModelActionDetails({
         icon: "bolt",
         action: onDeleteImplicitActions,
       });
-    } else {
+    } else if (supportsImplicitActions) {
       items.push({
         title: t`Create basic actions`,
         icon: "bolt",
@@ -115,7 +116,12 @@ function ModelActionDetails({
     }
 
     return items;
-  }, [implicitActions, onEnableImplicitActions, onDeleteImplicitActions]);
+  }, [
+    implicitActions,
+    supportsImplicitActions,
+    onEnableImplicitActions,
+    onDeleteImplicitActions,
+  ]);
 
   const renderActionListItem = useCallback(
     (action: WritebackAction) => {

--- a/frontend/src/metabase/models/components/ModelDetailPage/ModelActionDetails/ModelActionDetails.tsx
+++ b/frontend/src/metabase/models/components/ModelDetailPage/ModelActionDetails/ModelActionDetails.tsx
@@ -169,7 +169,7 @@ function ModelActionDetails({
         </ActionList>
       ) : (
         <NoActionsState
-          hasCreateButton={canWrite}
+          hasCreateButton={canWrite && supportsImplicitActions}
           onCreateClick={onEnableImplicitActions}
         />
       )}

--- a/frontend/src/metabase/models/containers/ModelDetailPage/ModelDetailPage.unit.spec.tsx
+++ b/frontend/src/metabase/models/containers/ModelDetailPage/ModelDetailPage.unit.spec.tsx
@@ -880,6 +880,9 @@ describe("ModelDetailPage", () => {
       await setup({ model });
 
       expect(screen.queryByLabelText("Action menu")).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: "Create basic actions" }),
+      ).not.toBeInTheDocument();
     });
   });
 

--- a/frontend/src/metabase/models/containers/ModelDetailPage/ModelDetailPage.unit.spec.tsx
+++ b/frontend/src/metabase/models/containers/ModelDetailPage/ModelDetailPage.unit.spec.tsx
@@ -607,82 +607,6 @@ describe("ModelDetailPage", () => {
           expect(await screen.findByTestId("mock-action-editor")).toBeVisible();
         });
 
-        it("allows to create implicit actions", async () => {
-          const createActionSpy = jest.spyOn(ActionsApi, "create");
-          const model = getModel();
-          const action = createMockQueryAction({ model_id: model.id() });
-          await setupActions({ model, actions: [action] });
-
-          userEvent.click(screen.getByLabelText("Actions menu"));
-          userEvent.click(screen.getByText("Create basic actions"));
-
-          await waitFor(() => {
-            expect(createActionSpy).toHaveBeenCalledWith({
-              name: "Create",
-              type: "implicit",
-              kind: "row/create",
-              model_id: model.id(),
-            });
-          });
-          expect(createActionSpy).toHaveBeenCalledWith({
-            name: "Update",
-            type: "implicit",
-            kind: "row/update",
-            model_id: model.id(),
-          });
-          expect(createActionSpy).toHaveBeenCalledWith({
-            name: "Delete",
-            type: "implicit",
-            kind: "row/delete",
-            model_id: model.id(),
-          });
-        });
-
-        it("allows to create implicit actions from the empty state", async () => {
-          const createActionSpy = jest.spyOn(ActionsApi, "create");
-          const model = getModel();
-          await setupActions({ model, actions: [] });
-
-          userEvent.click(
-            screen.getByRole("button", { name: /Create basic action/i }),
-          );
-
-          await waitFor(() => {
-            expect(createActionSpy).toHaveBeenCalledWith({
-              name: "Create",
-              type: "implicit",
-              kind: "row/create",
-              model_id: model.id(),
-            });
-          });
-          expect(createActionSpy).toHaveBeenCalledWith({
-            name: "Update",
-            type: "implicit",
-            kind: "row/update",
-            model_id: model.id(),
-          });
-          expect(createActionSpy).toHaveBeenCalledWith({
-            name: "Delete",
-            type: "implicit",
-            kind: "row/delete",
-            model_id: model.id(),
-          });
-        });
-
-        it("doesn't allow to create implicit actions when they already exist", async () => {
-          const model = getModel();
-          await setupActions({
-            model,
-            actions: createMockImplicitCUDActions(model.id()),
-          });
-
-          userEvent.click(screen.getByLabelText("Actions menu"));
-
-          expect(
-            screen.queryByText(/Create basic action/i),
-          ).not.toBeInTheDocument();
-        });
-
         it("allows to archive a query action", async () => {
           const updateActionSpy = jest.spyOn(ActionsApi, "update");
           const model = getModel();
@@ -730,17 +654,6 @@ describe("ModelDetailPage", () => {
           actions.forEach(action => {
             expect(deleteActionSpy).toHaveBeenCalledWith({ id: action.id });
           });
-        });
-
-        it("doesn't allow to disable implicit actions if they don't exist", async () => {
-          const model = getModel();
-          await setupActions({ model, actions: [] });
-
-          userEvent.click(screen.getByLabelText("Actions menu"));
-
-          expect(
-            screen.queryByText("Disable basic actions"),
-          ).not.toBeInTheDocument();
         });
       });
 
@@ -852,6 +765,104 @@ describe("ModelDetailPage", () => {
       expect(list.queryByText("Reviews")).not.toBeInTheDocument();
     });
 
+    it("allows to create implicit actions", async () => {
+      const createActionSpy = jest.spyOn(ActionsApi, "create");
+      const action = createMockQueryAction({ model_id: model.id() });
+      await setupActions({ model, actions: [action] });
+
+      userEvent.click(screen.getByLabelText("Actions menu"));
+      userEvent.click(screen.getByText("Create basic actions"));
+
+      await waitFor(() => {
+        expect(createActionSpy).toHaveBeenCalledWith({
+          name: "Create",
+          type: "implicit",
+          kind: "row/create",
+          model_id: model.id(),
+        });
+      });
+      expect(createActionSpy).toHaveBeenCalledWith({
+        name: "Update",
+        type: "implicit",
+        kind: "row/update",
+        model_id: model.id(),
+      });
+      expect(createActionSpy).toHaveBeenCalledWith({
+        name: "Delete",
+        type: "implicit",
+        kind: "row/delete",
+        model_id: model.id(),
+      });
+    });
+
+    it("allows to create implicit actions from the empty state", async () => {
+      const createActionSpy = jest.spyOn(ActionsApi, "create");
+      await setupActions({ model, actions: [] });
+
+      userEvent.click(
+        screen.getByRole("button", { name: /Create basic action/i }),
+      );
+
+      await waitFor(() => {
+        expect(createActionSpy).toHaveBeenCalledWith({
+          name: "Create",
+          type: "implicit",
+          kind: "row/create",
+          model_id: model.id(),
+        });
+      });
+      expect(createActionSpy).toHaveBeenCalledWith({
+        name: "Update",
+        type: "implicit",
+        kind: "row/update",
+        model_id: model.id(),
+      });
+      expect(createActionSpy).toHaveBeenCalledWith({
+        name: "Delete",
+        type: "implicit",
+        kind: "row/delete",
+        model_id: model.id(),
+      });
+    });
+
+    it("doesn't allow to create implicit actions when they already exist", async () => {
+      await setupActions({
+        model,
+        actions: createMockImplicitCUDActions(model.id()),
+      });
+
+      userEvent.click(screen.getByLabelText("Actions menu"));
+
+      expect(
+        screen.queryByText(/Create basic action/i),
+      ).not.toBeInTheDocument();
+    });
+
+    it("doesn't allow to disable implicit actions if they don't exist", async () => {
+      await setupActions({ model, actions: [] });
+
+      userEvent.click(screen.getByLabelText("Actions menu"));
+
+      expect(
+        screen.queryByText("Disable basic actions"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("doesn't allow to create basic actions for a non-raw models", async () => {
+      const model = getStructuredModel({
+        dataset_query: createMockStructuredDatasetQuery({
+          query: createMockStructuredQuery({
+            "source-table": 1,
+            limit: 10,
+          }),
+        }),
+      });
+
+      await setup({ model });
+
+      expect(screen.queryByLabelText("Action menu")).not.toBeInTheDocument();
+    });
+
     describe("no data permissions", () => {
       it("shows limited model info", async () => {
         await setup({ model, hasDataPermissions: false });
@@ -878,6 +889,12 @@ describe("ModelDetailPage", () => {
       expect(
         screen.queryByTestId("model-relationships"),
       ).not.toBeInTheDocument();
+    });
+
+    it("doesn't allow to create basic actions", async () => {
+      await setup({ model });
+
+      expect(screen.queryByLabelText("Action menu")).not.toBeInTheDocument();
     });
   });
 

--- a/frontend/src/metabase/models/containers/ModelDetailPage/ModelDetailPage.unit.spec.tsx
+++ b/frontend/src/metabase/models/containers/ModelDetailPage/ModelDetailPage.unit.spec.tsx
@@ -848,21 +848,6 @@ describe("ModelDetailPage", () => {
       ).not.toBeInTheDocument();
     });
 
-    it("doesn't allow to create basic actions for a non-raw models", async () => {
-      const model = getStructuredModel({
-        dataset_query: createMockStructuredDatasetQuery({
-          query: createMockStructuredQuery({
-            "source-table": 1,
-            limit: 10,
-          }),
-        }),
-      });
-
-      await setup({ model });
-
-      expect(screen.queryByLabelText("Action menu")).not.toBeInTheDocument();
-    });
-
     describe("no data permissions", () => {
       it("shows limited model info", async () => {
         await setup({ model, hasDataPermissions: false });

--- a/frontend/test/metabase-lib/lib/Question.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/Question.unit.spec.js
@@ -86,6 +86,59 @@ const orders_metric_filter_card = {
   },
 };
 
+const orders_filter_card = {
+  id: 2,
+  name: "# orders data",
+  display: "line",
+  dataset_query: {
+    type: "query",
+    database: SAMPLE_DATABASE.id,
+    query: {
+      "source-table": ORDERS.id,
+      filter: [">", ["field", ORDERS.TOTAL.id, null], 10],
+    },
+  },
+};
+
+const orders_join_card = {
+  id: 2,
+  name: "# orders data",
+  display: "line",
+  dataset_query: {
+    type: "query",
+    database: SAMPLE_DATABASE.id,
+    query: {
+      "source-table": ORDERS.id,
+      joins: [
+        {
+          fields: "all",
+          "source-table": PRODUCTS.id,
+          condition: [
+            "=",
+            ["field-id", ORDERS.PRODUCT_ID.id],
+            ["joined-field", "Products", ["field-id", PRODUCTS.ID.id]],
+          ],
+          alias: "Products",
+        },
+      ],
+    },
+  },
+};
+
+const orders_expression_card = {
+  id: 2,
+  name: "# orders data",
+  display: "line",
+  dataset_query: {
+    type: "query",
+    database: SAMPLE_DATABASE.id,
+    query: {
+      "source-table": ORDERS.id,
+      expressions: { double_total: ["+", 1, 1] },
+    },
+  },
+};
+
 const orders_multi_stage_card = {
   id: 2,
   name: "# orders data",
@@ -1519,6 +1572,43 @@ describe("Question", () => {
       const newQuestion = question.omitTransientCardIds();
 
       expect(newQuestion).toBe(question);
+    });
+  });
+
+  describe("Question.prototype.supportsImplicitActions", () => {
+    it("should allow to create implicit actions for a raw model", () => {
+      const question = new Question(orders_raw_card, metadata);
+      expect(question.supportsImplicitActions()).toBeTruthy();
+    });
+
+    it("should not allow to create implicit actions for a model with aggregations", () => {
+      const question = new Question(orders_count_card, metadata);
+      expect(question.supportsImplicitActions()).toBeFalsy();
+    });
+
+    it("should not allow to create implicit actions for a model with filters", () => {
+      const question = new Question(orders_filter_card, metadata);
+      expect(question.supportsImplicitActions()).toBeFalsy();
+    });
+
+    it("should not allow to create implicit actions for a model with joins", () => {
+      const question = new Question(orders_join_card, metadata);
+      expect(question.supportsImplicitActions()).toBeFalsy();
+    });
+
+    it("should not allow to create implicit actions for a model with expressions", () => {
+      const question = new Question(orders_expression_card, metadata);
+      expect(question.supportsImplicitActions()).toBeFalsy();
+    });
+
+    it("should not allow to create implicit actions for a model with multiple stages", () => {
+      const question = new Question(orders_multi_stage_card, metadata);
+      expect(question.supportsImplicitActions()).toBeFalsy();
+    });
+
+    it("should allow to create implicit actions for a native model", () => {
+      const question = new Question(native_orders_count_card, metadata);
+      expect(question.supportsImplicitActions()).toBeFalsy();
     });
   });
 });


### PR DESCRIPTION
How to verify:
- Create a model with filters (or aggregations, expressions, joins)
- Go to the model detail page -> actions
- Ensure it's not possible to add basic actions to this model

<img width="791" alt="Screenshot 2023-02-28 at 17 25 31" src="https://user-images.githubusercontent.com/8542534/221936553-8a8d06f7-0910-4401-95a0-ba0e363862ea.png">
<img width="1406" alt="Screenshot 2023-02-28 at 19 56 11" src="https://user-images.githubusercontent.com/8542534/221938781-d3b07948-144f-4b89-babd-af25fd8f309c.png">

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/28748)
<!-- Reviewable:end -->
