### PR TITLE
Typo: "JSON folding" should be "JSON unfolding"

### DIFF
--- a/docs/databases/connections/mysql.md
+++ b/docs/databases/connections/mysql.md
@@ -42,7 +42,7 @@ See our [guide to SSH tunneling](../ssh-tunnel.md).
 
 ### Unfold JSON Columns
 
-In some databases, Metabase can unfold JSON columns into component fields to yield a table where each JSON key becomes a column. JSON unfolding is on by default, but you can turn off JSON folding if performance is slow.
+In some databases, Metabase can unfold JSON columns into component fields to yield a table where each JSON key becomes a column. JSON unfolding is on by default, but you can turn off JSON unfolding if performance is slow.
 
 ### Additional JDBC connection string options
 

--- a/docs/databases/connections/postgresql.md
+++ b/docs/databases/connections/postgresql.md
@@ -109,7 +109,7 @@ openssl pkcs8 -topk8 -inform PEM -outform DER -in client-key.pem -out client-key
 
 ### Unfold JSON Columns
 
-In some databases, Metabase can unfold JSON columns into component fields to yield a table where each JSON key becomes a column. JSON unfolding is on by default, but you can turn off JSON folding if performance is slow.
+In some databases, Metabase can unfold JSON columns into component fields to yield a table where each JSON key becomes a column. JSON unfolding is on by default, but you can turn off JSON unfolding if performance is slow.
 
 ### Additional JDBC connection string options
 


### PR DESCRIPTION
Found a typo in docs. There's no such thing as JSON folding, only JSON unfolding.