### PR TITLE
Make dashboard buttons smaller on mobile

### DIFF
--- a/frontend/src/metabase/dashboard/components/DashboardGrid.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardGrid.jsx
@@ -175,9 +175,6 @@ class DashboardGrid extends Component {
     const desktop = dashboard.ordered_cards.map(this.getLayoutForDashCard);
     const mobile = generateMobileLayout({
       desktopLayout: desktop,
-      // We want to keep the heights for all visualizations equal not to break the visual rhythm
-      // Exceptions are text cards (can take too much vertical space)
-      // and scalar value cards (basically a number and some text on a big card)
       heightByDisplayType: {
         action: 1,
         link: 1,

--- a/frontend/src/metabase/dashboard/components/DashboardGrid.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardGrid.jsx
@@ -180,6 +180,7 @@ class DashboardGrid extends Component {
       // and scalar value cards (basically a number and some text on a big card)
       heightByDisplayType: {
         action: 1,
+        link: 1,
         text: 2,
         scalar: 4,
       },

--- a/frontend/src/metabase/dashboard/components/DashboardGrid.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardGrid.jsx
@@ -175,13 +175,13 @@ class DashboardGrid extends Component {
     const desktop = dashboard.ordered_cards.map(this.getLayoutForDashCard);
     const mobile = generateMobileLayout({
       desktopLayout: desktop,
+      defaultCardHeight: 6,
       heightByDisplayType: {
         action: 1,
         link: 1,
         text: 2,
         scalar: 4,
       },
-      defaultCardHeight: 6,
     });
     return { desktop, mobile };
   }

--- a/frontend/src/metabase/dashboard/components/DashboardGrid.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardGrid.jsx
@@ -179,6 +179,7 @@ class DashboardGrid extends Component {
       // Exceptions are text cards (can take too much vertical space)
       // and scalar value cards (basically a number and some text on a big card)
       heightByDisplayType: {
+        action: 1,
         text: 2,
         scalar: 4,
       },


### PR DESCRIPTION
Epics #27700, #28073

### Description

Makes action and link dashboard buttons take 1 cell height on mobile screens

### How to verify

1. Create a model and an action
2. Create a dashboard, add a button and a link card to it
3. Resize your browser window, so it's closer to mobile screen size
4. Ensure the button and the link don't look like squares

### Demo

| Before | After  |
|--------|-------|
| ![cleanshot_2023-03-01_at_14 38 25_2x_720](https://user-images.githubusercontent.com/17258145/222176781-ef65cb7d-a5ce-479a-bf5f-f82b80d0c418.png) | ![cleanshot_2023-03-01_at_14 40 08_2x_720](https://user-images.githubusercontent.com/17258145/222176799-f9aa463b-e73a-4268-ae40-55517ded522a.png) |

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/28783)
<!-- Reviewable:end -->
