### PR TITLE
[CI] Use GitHub basic runners for `druid` and `sparksql` tests

### DIFF
--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -73,7 +73,7 @@ jobs:
   be-tests-druid-ee:
     needs: files-changed
     if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
-    runs-on: buildjet-2vcpu-ubuntu-2204
+    runs-on: ubuntu-22.04
     timeout-minutes: 60
     env:
       CI: 'true'
@@ -609,7 +609,7 @@ jobs:
   be-tests-sparksql-ee:
     needs: files-changed
     if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
-    runs-on: buildjet-2vcpu-ubuntu-2204
+    runs-on: ubuntu-22.04
     timeout-minutes: 60
     env:
       CI: 'true'

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -32,7 +32,7 @@ jobs:
     needs: files-changed
     if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
     runs-on: ubuntu-22.04
-    timeout-minutes: 60
+    timeout-minutes: 45
     env:
       CI: 'true'
       DRIVERS: athena
@@ -52,7 +52,7 @@ jobs:
     needs: files-changed
     if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
     runs-on: ubuntu-22.04
-    timeout-minutes: 60
+    timeout-minutes: 45
     env:
       CI: 'true'
       DRIVERS: bigquery-cloud-sdk
@@ -74,7 +74,7 @@ jobs:
     needs: files-changed
     if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
     runs-on: ubuntu-22.04
-    timeout-minutes: 60
+    timeout-minutes: 45
     env:
       CI: 'true'
       DRIVERS: druid
@@ -97,7 +97,7 @@ jobs:
     needs: files-changed
     if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
     runs-on: ubuntu-22.04
-    timeout-minutes: 60
+    timeout-minutes: 45
     env:
       CI: 'true'
       DRIVERS: googleanalytics
@@ -113,7 +113,7 @@ jobs:
     needs: files-changed
     if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
     runs-on: ubuntu-22.04
-    timeout-minutes: 60
+    timeout-minutes: 45
     env:
       CI: 'true'
       DRIVERS: 'googleanalytics,bigquery-cloud-sdk'
@@ -135,7 +135,7 @@ jobs:
     needs: files-changed
     if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
     runs-on: ubuntu-22.04
-    timeout-minutes: 60
+    timeout-minutes: 45
     env:
       CI: 'true'
       DRIVERS: mysql
@@ -161,7 +161,7 @@ jobs:
     needs: files-changed
     if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
     runs-on: ubuntu-22.04
-    timeout-minutes: 60
+    timeout-minutes: 45
     env:
       CI: 'true'
       DRIVERS: mysql
@@ -187,7 +187,7 @@ jobs:
     needs: files-changed
     if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
     runs-on: ubuntu-22.04
-    timeout-minutes: 60
+    timeout-minutes: 45
     env:
       CI: 'true'
       DRIVERS: mongo
@@ -210,7 +210,7 @@ jobs:
     needs: files-changed
     if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
     runs-on: ubuntu-22.04
-    timeout-minutes: 60
+    timeout-minutes: 45
     env:
       CI: 'true'
       DRIVERS: mongo
@@ -245,7 +245,7 @@ jobs:
     needs: files-changed
     if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
     runs-on: ubuntu-22.04
-    timeout-minutes: 60
+    timeout-minutes: 45
     env:
       CI: 'true'
       DRIVERS: mongo
@@ -268,7 +268,7 @@ jobs:
     needs: files-changed
     if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
     runs-on: ubuntu-22.04
-    timeout-minutes: 60
+    timeout-minutes: 45
     env:
       CI: 'true'
       DRIVERS: mongo
@@ -303,7 +303,7 @@ jobs:
     needs: files-changed
     if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
     runs-on: ubuntu-22.04
-    timeout-minutes: 60
+    timeout-minutes: 45
     env:
       CI: 'true'
       DRIVERS: mongo
@@ -329,7 +329,7 @@ jobs:
     needs: files-changed
     if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
     runs-on: ubuntu-22.04
-    timeout-minutes: 60
+    timeout-minutes: 45
     env:
       CI: 'true'
       DRIVERS: mysql
@@ -355,7 +355,7 @@ jobs:
     needs: files-changed
     if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
     runs-on: ubuntu-22.04
-    timeout-minutes: 60
+    timeout-minutes: 45
     env:
       CI: 'true'
       DRIVERS: mysql
@@ -393,7 +393,7 @@ jobs:
     needs: files-changed
     if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
     runs-on: ubuntu-22.04
-    timeout-minutes: 60
+    timeout-minutes: 45
     env:
       CI: 'true'
       DRIVERS: oracle
@@ -420,7 +420,7 @@ jobs:
     needs: files-changed
     if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
     runs-on: ubuntu-22.04
-    timeout-minutes: 60
+    timeout-minutes: 45
     env:
       CI: 'true'
       DRIVERS: oracle
@@ -456,7 +456,7 @@ jobs:
     needs: files-changed
     if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
     runs-on: ubuntu-22.04
-    timeout-minutes: 60
+    timeout-minutes: 45
     env:
       CI: 'true'
       DRIVERS: postgres
@@ -485,7 +485,7 @@ jobs:
     needs: files-changed
     if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
     runs-on: ubuntu-22.04
-    timeout-minutes: 60
+    timeout-minutes: 45
     env:
       CI: 'true'
       DRIVERS: postgres
@@ -518,7 +518,7 @@ jobs:
     needs: files-changed
     if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
     runs-on: ubuntu-22.04
-    timeout-minutes: 60
+    timeout-minutes: 45
     env:
       CI: 'true'
       DRIVERS: presto-jdbc
@@ -568,7 +568,7 @@ jobs:
     needs: files-changed
     if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
     runs-on: ubuntu-22.04
-    timeout-minutes: 60
+    timeout-minutes: 45
     env:
       CI: 'true'
       DRIVERS: redshift
@@ -588,7 +588,7 @@ jobs:
     needs: files-changed
     if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
     runs-on: ubuntu-22.04
-    timeout-minutes: 60
+    timeout-minutes: 45
     env:
       CI: 'true'
       DRIVERS: snowflake
@@ -610,7 +610,7 @@ jobs:
     needs: files-changed
     if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
     runs-on: ubuntu-22.04
-    timeout-minutes: 60
+    timeout-minutes: 45
     env:
       CI: 'true'
       DRIVERS: sparksql
@@ -631,7 +631,7 @@ jobs:
     needs: files-changed
     if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
     runs-on: ubuntu-22.04
-    timeout-minutes: 60
+    timeout-minutes: 45
     env:
       CI: 'true'
       DRIVERS: sqlite
@@ -647,7 +647,7 @@ jobs:
     needs: files-changed
     if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
     runs-on: ubuntu-22.04
-    timeout-minutes: 60
+    timeout-minutes: 45
     env:
       CI: 'true'
       DRIVERS: sqlserver
@@ -675,7 +675,7 @@ jobs:
     needs: files-changed
     if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
     runs-on: ubuntu-22.04
-    timeout-minutes: 60
+    timeout-minutes: 45
     env:
       CI: 'true'
       DRIVERS: vertica


### PR DESCRIPTION
This happens a lot and it takes full 1h
```
Received 449465023 of 453659327 (99.1%), 0.1 MBs/sec
Received 449465023 of 453659327 (99.1%), 0.1 MBs/sec
Received 449465023 of 453659327 (99.1%), 0.1 MBs/sec
Received 449465023 of 453659327 (99.1%), 0.1 MBs/sec
Received 449465023 of 453659327 (99.1%), 0.1 MBs/sec
Received 449465023 of 453659327 (99.1%), 0.1 MBs/sec
Received 449465023 of 453659327 (99.1%), 0.1 MBs/sec
Received 449465023 of 453659327 (99.1%), 0.1 MBs/sec
Received 449465023 of 453659327 (99.1%), 0.1 MBs/sec
Received 449465023 of 453659327 (99.1%), 0.1 MBs/sec
Error: The operation was canceled.
```

Oh but this happens with GitHub hosted runners as well! 🤦 
https://github.com/metabase/metabase/actions/runs/4304721613/jobs/7506650207#step:5:2549
And the weirdest thing about GitHub's hosted runners is that it's impossible to cancel the run. The runner seems totally unresponsive.
```
Received 480084097 of 484278401 (99.1%), 0.2 MBs/sec
Received 480084097 of 484278401 (99.1%), 0.2 MBs/sec
Received 480084097 of 484278401 (99.1%), 0.2 MBs/sec
Received 480084097 of 484278401 (99.1%), 0.2 MBs/sec
```

However, I've seen BuildJet runners timing out much more often, so let's fix them at least.


> **Note**
> Even when running `druid` and `sparksql` using nominally slower GitHub runners, they still don't take more than 20 minutes to finish!