### PR TITLE
Fix dead link

### DIFF
--- a/docs/developers-guide/drivers/plugins.md
+++ b/docs/developers-guide/drivers/plugins.md
@@ -67,7 +67,7 @@ The if-you're-interested reason is that Java's JDBC `DriverManager` won't use JD
 
 ## Building the driver
 
-To build a driver as a plugin JAR, check out the [Build-driver scripts README](https://github.com/metabase/metabase/tree/master/bin/build-drivers).
+To build a driver as a plugin JAR, check out the [Build-driver scripts README](https://github.com/metabase/metabase/tree/master/bin/build-drivers.sh).
 
 Place the JAR you built in your Metabase's `/plugins` directory, and you're off to the races.
 


### PR DESCRIPTION
After #28767 landed into `master`, it broke it because linter complains about the broken links.
https://github.com/metabase/metabase/actions/runs/4304714519/jobs/7506128363#step:4:473

Not sure why it didn't catch it in the PR itself, but this will fix it.