### PR TITLE
Link to the build drivers readme file

### DIFF
--- a/docs/developers-guide/drivers/plugins.md
+++ b/docs/developers-guide/drivers/plugins.md
@@ -67,7 +67,7 @@ The if-you're-interested reason is that Java's JDBC `DriverManager` won't use JD
 
 ## Building the driver
 
-To build a driver as a plugin JAR, check out the [Build-driver scripts README](https://github.com/metabase/metabase/tree/master/bin/build-drivers.sh).
+To build a driver as a plugin JAR, check out the [Build-driver scripts README](https://github.com/metabase/metabase/tree/master/bin/build-drivers.md).
 
 Place the JAR you built in your Metabase's `/plugins` directory, and you're off to the races.
 


### PR DESCRIPTION
An honest mistake in https://github.com/metabase/metabase/pull/28789.
The link needs to point to the readme file.