### PR TITLE
(1/n) update `BaseItemsTable` for new collections bulk actions UI

### DIFF
--- a/e2e/test/scenarios/collections/collections.cy.spec.js
+++ b/e2e/test/scenarios/collections/collections.cy.spec.js
@@ -390,7 +390,24 @@ describe("scenarios > collection defaults", () => {
     describe("bulk actions", () => {
       describe("selection", () => {
         it("should be possible to apply bulk selection to all items (metabase#14705)", () => {
-          bulkSelectDeselectWorkflow();
+          cy.visit("/collection/root");
+
+          // Select one
+          selectItemUsingCheckbox("Orders");
+          cy.findByText("1 item selected").should("be.visible");
+          cy.icon("dash").should("exist");
+          cy.icon("check").should("exist");
+
+          // Select all
+          cy.findByLabelText("Select all items").click();
+          cy.icon("dash").should("not.exist");
+          cy.findByText("6 items selected");
+
+          // Deselect all
+          cy.findByLabelText("Select all items").click();
+
+          cy.icon("check").should("not.exist");
+          cy.findByTestId("bulk-action-bar").should("not.be.visible");
         });
 
         it("should clean up selection when opening another collection (metabase#16491)", () => {
@@ -419,25 +436,6 @@ describe("scenarios > collection defaults", () => {
           cy.button("Move").should("be.disabled");
           cy.button("Archive").should("be.disabled");
         });
-
-        function bulkSelectDeselectWorkflow() {
-          cy.visit("/collection/root");
-          selectItemUsingCheckbox("Orders");
-          cy.findByText("1 item selected").should("be.visible");
-
-          cy.findByTestId("bulk-action-bar").within(() => {
-            // Select all
-            cy.findByRole("checkbox");
-            cy.icon("dash").click({ force: true });
-            cy.icon("dash").should("not.exist");
-            cy.findByText("6 items selected");
-
-            // Deselect all
-            cy.icon("check").click({ force: true });
-          });
-          cy.icon("check").should("not.exist");
-          cy.findByTestId("bulk-action-bar").should("not.be.visible");
-        }
       });
 
       describe("archive", () => {
@@ -514,10 +512,7 @@ function openEllipsisMenuFor(item) {
 function selectItemUsingCheckbox(item, icon = "table") {
   cy.findByText(item)
     .closest("tr")
-    .within(() => {
-      cy.icon(icon).trigger("mouseover");
-      cy.findByRole("checkbox").click();
-    });
+    .within(() => cy.findByRole("checkbox").click());
 }
 
 function visitRootCollection() {

--- a/frontend/src/metabase/collections/components/BaseItemsTable.jsx
+++ b/frontend/src/metabase/collections/components/BaseItemsTable.jsx
@@ -134,7 +134,7 @@ function BaseItemsTable({
   const canSelect = collection.can_write || false;
 
   return (
-    <Table {...props}>
+    <Table canSelect={canSelect} {...props}>
       <colgroup>
         {canSelect && <col style={{ width: "70px" }} />}
         <col style={{ width: "70px" }} />

--- a/frontend/src/metabase/collections/components/BaseItemsTable.jsx
+++ b/frontend/src/metabase/collections/components/BaseItemsTable.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import { t } from "ttag";
 
+import CheckBox from "metabase/core/components/CheckBox";
 import BaseTableItem from "./BaseTableItem";
 import {
   ColumnHeader,
@@ -10,6 +11,7 @@ import {
   SortingControlContainer,
   TBody,
   LastEditedByCol,
+  BulkSelectWrapper,
 } from "./BaseItemsTable.styled";
 
 const sortingOptsShape = PropTypes.shape({
@@ -68,11 +70,14 @@ BaseItemsTable.propTypes = {
   items: PropTypes.arrayOf(PropTypes.object),
   collection: PropTypes.object,
   selectedItems: PropTypes.arrayOf(PropTypes.object),
+  hasUnselected: PropTypes.bool,
   isPinned: PropTypes.bool,
   renderItem: PropTypes.func,
   sortingOptions: sortingOptsShape,
   onSortingOptionsChange: PropTypes.func,
   onToggleSelected: PropTypes.func,
+  onSelectAll: PropTypes.func,
+  onSelectNone: PropTypes.func,
   onCopy: PropTypes.func,
   onMove: PropTypes.func,
   onDrop: PropTypes.func,
@@ -95,6 +100,7 @@ function BaseItemsTable({
   items,
   collection = {},
   selectedItems,
+  hasUnselected,
   isPinned,
   renderItem = defaultItemRenderer,
   onCopy,
@@ -103,6 +109,8 @@ function BaseItemsTable({
   sortingOptions,
   onSortingOptionsChange,
   onToggleSelected,
+  onSelectAll,
+  onSelectNone,
   getIsSelected = () => false,
   headless = false,
   ...props
@@ -127,6 +135,7 @@ function BaseItemsTable({
     <Table {...props}>
       <colgroup>
         <col style={{ width: "70px" }} />
+        <col style={{ width: "70px" }} />
         <col />
         <LastEditedByCol />
         <col style={{ width: "140px" }} />
@@ -139,6 +148,18 @@ function BaseItemsTable({
           }
         >
           <tr>
+            <ColumnHeader>
+              <BulkSelectWrapper>
+                <CheckBox
+                  checked={selectedItems?.length > 0 || false}
+                  indeterminate={
+                    (selectedItems?.length > 0 && hasUnselected) || false
+                  }
+                  onChange={hasUnselected ? onSelectAll : onSelectNone}
+                  aria-label={t`Select all items`}
+                />
+              </BulkSelectWrapper>
+            </ColumnHeader>
             <SortableColumnHeader
               name="model"
               sortingOptions={sortingOptions}

--- a/frontend/src/metabase/collections/components/BaseItemsTable.jsx
+++ b/frontend/src/metabase/collections/components/BaseItemsTable.jsx
@@ -131,10 +131,12 @@ function BaseItemsTable({
       onToggleSelected,
     });
 
+  const canSelect = collection.can_write || false;
+
   return (
     <Table {...props}>
       <colgroup>
-        <col style={{ width: "70px" }} />
+        {canSelect && <col style={{ width: "70px" }} />}
         <col style={{ width: "70px" }} />
         <col />
         <LastEditedByCol />
@@ -148,18 +150,20 @@ function BaseItemsTable({
           }
         >
           <tr>
-            <ColumnHeader>
-              <BulkSelectWrapper>
-                <CheckBox
-                  checked={selectedItems?.length > 0 || false}
-                  indeterminate={
-                    (selectedItems?.length > 0 && hasUnselected) || false
-                  }
-                  onChange={hasUnselected ? onSelectAll : onSelectNone}
-                  aria-label={t`Select all items`}
-                />
-              </BulkSelectWrapper>
-            </ColumnHeader>
+            {canSelect && (
+              <ColumnHeader>
+                <BulkSelectWrapper>
+                  <CheckBox
+                    checked={selectedItems?.length > 0 || false}
+                    indeterminate={
+                      (selectedItems?.length > 0 && hasUnselected) || false
+                    }
+                    onChange={hasUnselected ? onSelectAll : onSelectNone}
+                    aria-label={t`Select all items`}
+                  />
+                </BulkSelectWrapper>
+              </ColumnHeader>
+            )}
             <SortableColumnHeader
               name="model"
               sortingOptions={sortingOptions}

--- a/frontend/src/metabase/collections/components/BaseItemsTable.styled.jsx
+++ b/frontend/src/metabase/collections/components/BaseItemsTable.styled.jsx
@@ -10,11 +10,13 @@ import EntityItem from "metabase/components/EntityItem";
 import Icon from "metabase/components/Icon";
 import Link from "metabase/core/components/Link";
 import BaseModelDetailLink from "metabase/models/components/ModelDetailLink";
+import IconButtonWrapper from "metabase/components/IconButtonWrapper";
 
-const LAST_EDITED_BY_INDEX = 3;
-const LAST_EDITED_AT_INDEX = 4;
+const LAST_EDITED_BY_INDEX = 4;
+const LAST_EDITED_AT_INDEX = 5;
 
 export const Table = styled.table`
+  background-color: ${color("white")};
   table-layout: fixed;
   border-collapse: unset;
 
@@ -28,6 +30,22 @@ export const Table = styled.table`
       display: none;
     }
   }
+
+  thead {
+    th {
+      border-top: 1px solid ${color("border")};
+
+      &:first-of-type {
+        border-top-left-radius: 8px;
+        border-left: 1px solid ${color("border")};
+      }
+
+      &:last-child {
+        border-top-right-radius: 8px;
+        border-right: 1px solid ${color("border")};
+      }
+    }
+  }
 `;
 
 Table.defaultProps = { className: "ContentTable" };
@@ -36,6 +54,12 @@ export const ColumnHeader = styled.th`
   padding: 1em 1em 0.75em !important;
   font-weight: bold;
   color: ${color("text-medium")};
+`;
+
+export const BulkSelectWrapper = styled(IconButtonWrapper)`
+  padding-left: 12px;
+  padding-right: 12px;
+  width: 3em;
 `;
 
 export const LastEditedByCol = styled.col`
@@ -124,8 +148,6 @@ export const TableItemSecondaryField = styled.span`
 `;
 
 export const TBody = styled.tbody`
-  background-color: ${color("white")};
-
   td {
     border: none;
     background-color: transparent;
@@ -143,16 +165,6 @@ export const TBody = styled.tbody`
 
   tr {
     background-color: transparent;
-  }
-
-  tr:first-of-type {
-    td:first-of-type {
-      border-top-left-radius: 8px;
-    }
-
-    td:last-child {
-      border-top-right-radius: 8px;
-    }
   }
 
   tr:last-child {

--- a/frontend/src/metabase/collections/components/BaseItemsTable.styled.tsx
+++ b/frontend/src/metabase/collections/components/BaseItemsTable.styled.tsx
@@ -12,24 +12,13 @@ import Link from "metabase/core/components/Link";
 import BaseModelDetailLink from "metabase/models/components/ModelDetailLink";
 import IconButtonWrapper from "metabase/components/IconButtonWrapper";
 
-const LAST_EDITED_BY_INDEX = 4;
-const LAST_EDITED_AT_INDEX = 5;
+const LAST_EDITED_BY_INDEX = 3;
+const LAST_EDITED_AT_INDEX = 4;
 
-export const Table = styled.table`
+export const Table = styled.table<{ canSelect: boolean }>`
   background-color: ${color("white")};
   table-layout: fixed;
   border-collapse: unset;
-
-  ${breakpointMaxMedium} {
-    & td:nth-of-type(${LAST_EDITED_BY_INDEX}),
-    th:nth-of-type(${LAST_EDITED_BY_INDEX}),
-    col:nth-of-type(${LAST_EDITED_BY_INDEX}),
-    td:nth-of-type(${LAST_EDITED_AT_INDEX}),
-    th:nth-of-type(${LAST_EDITED_AT_INDEX}),
-    col:nth-of-type(${LAST_EDITED_AT_INDEX}) {
-      display: none;
-    }
-  }
 
   thead {
     th {
@@ -46,6 +35,25 @@ export const Table = styled.table`
       }
     }
   }
+
+  ${props => {
+    const offset = props.canSelect ? 1 : 0;
+    const offsetEditedByIndex = LAST_EDITED_BY_INDEX + offset;
+    const offsetEditedAtIndex = LAST_EDITED_AT_INDEX + offset;
+
+    return `
+      ${breakpointMaxMedium} {
+        & td:nth-of-type(${offsetEditedByIndex}),
+        th:nth-of-type(${offsetEditedByIndex}),
+        col:nth-of-type(${offsetEditedByIndex}),
+        td:nth-of-type(${offsetEditedAtIndex}),
+        th:nth-of-type(${offsetEditedAtIndex}),
+        col:nth-of-type(${offsetEditedAtIndex}) {
+          display: none;
+        }
+      }
+    `;
+  }}
 `;
 
 Table.defaultProps = { className: "ContentTable" };
@@ -120,7 +128,7 @@ export const ModelDetailLink = styled(BaseModelDetailLink)`
   visibility: hidden;
 `;
 
-export const SortingControlContainer = styled.div`
+export const SortingControlContainer = styled.div<{ isActive: boolean }>`
   display: flex;
   align-items: center;
   color: ${props => (props.isActive ? color("text-dark") : "")};

--- a/frontend/src/metabase/collections/components/BaseTableItem.jsx
+++ b/frontend/src/metabase/collections/components/BaseTableItem.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from "react";
+import React, { useCallback } from "react";
 import PropTypes from "prop-types";
 import moment from "moment-timezone";
 
@@ -59,8 +59,6 @@ export function BaseTableItem({
   onDrop,
   onToggleSelected,
 }) {
-  const [isHoveringOverRow, setIsHoveringOverRow] = useState(false);
-
   const handleSelectionToggled = useCallback(() => {
     onToggleSelected(item);
   }, [item, onToggleSelected]);
@@ -93,28 +91,27 @@ export function BaseTableItem({
     // that only accepts native DOM elements as its children
     // So styled-components can't be used here
     return (
-      <tr
-        onMouseEnter={() => {
-          setIsHoveringOverRow(true);
-        }}
-        onMouseLeave={() => {
-          setIsHoveringOverRow(false);
-        }}
-        key={item.id}
-        data-testid={testId}
-        style={trStyles}
-      >
+      <tr key={item.id} data-testid={testId} style={trStyles}>
+        <ItemCell data-testid={`${testId}-check`}>
+          <EntityIconCheckBox
+            item={item}
+            variant="list"
+            icon={icon}
+            pinned={isPinned}
+            disabled={!canSelect}
+            selected={isSelected}
+            onToggleSelected={handleSelectionToggled}
+            selectable
+            showCheckbox
+          />
+        </ItemCell>
         <ItemCell data-testid={`${testId}-type`}>
           <EntityIconCheckBox
             item={item}
             variant="list"
             icon={icon}
             pinned={isPinned}
-            selectable={canSelect}
-            selected={isSelected}
             disabled={!canSelect}
-            onToggleSelected={handleSelectionToggled}
-            showCheckbox={isHoveringOverRow}
           />
         </ItemCell>
         <ItemNameCell data-testid={`${testId}-name`}>
@@ -168,7 +165,6 @@ export function BaseTableItem({
     isPinned,
     isSelected,
     handleSelectionToggled,
-    isHoveringOverRow,
     linkProps,
     collection,
     onCopy,

--- a/frontend/src/metabase/collections/components/BaseTableItem.jsx
+++ b/frontend/src/metabase/collections/components/BaseTableItem.jsx
@@ -92,26 +92,26 @@ export function BaseTableItem({
     // So styled-components can't be used here
     return (
       <tr key={item.id} data-testid={testId} style={trStyles}>
-        <ItemCell data-testid={`${testId}-check`}>
-          <EntityIconCheckBox
-            item={item}
-            variant="list"
-            icon={icon}
-            pinned={isPinned}
-            disabled={!canSelect}
-            selected={isSelected}
-            onToggleSelected={handleSelectionToggled}
-            selectable
-            showCheckbox
-          />
-        </ItemCell>
+        {canSelect && (
+          <ItemCell data-testid={`${testId}-check`}>
+            <EntityIconCheckBox
+              item={item}
+              variant="list"
+              icon={icon}
+              pinned={isPinned}
+              selected={isSelected}
+              onToggleSelected={handleSelectionToggled}
+              selectable
+              showCheckbox
+            />
+          </ItemCell>
+        )}
         <ItemCell data-testid={`${testId}-type`}>
           <EntityIconCheckBox
             item={item}
             variant="list"
             icon={icon}
             pinned={isPinned}
-            disabled={!canSelect}
           />
         </ItemCell>
         <ItemNameCell data-testid={`${testId}-name`}>

--- a/frontend/src/metabase/collections/containers/CollectionContent.jsx
+++ b/frontend/src/metabase/collections/containers/CollectionContent.jsx
@@ -264,11 +264,14 @@ function CollectionContent({
                           handleUnpinnedItemsSortingChange
                         }
                         selectedItems={selected}
+                        hasUnselected={hasUnselected}
                         getIsSelected={getIsSelected}
                         onToggleSelected={toggleItem}
                         onDrop={clear}
                         onMove={handleMove}
                         onCopy={handleCopy}
+                        onSelectAll={handleSelectAll}
+                        onSelectNone={clear}
                       />
                       <div className="flex justify-end my3">
                         {hasPagination && (

--- a/frontend/test/metabase/collections/BaseItemsTable.unit.spec.js
+++ b/frontend/test/metabase/collections/BaseItemsTable.unit.spec.js
@@ -82,22 +82,39 @@ describe("Collections BaseItemsTable", () => {
     expect(screen.queryByTestId("model-detail-link")).not.toBeInTheDocument();
   });
 
-  it("allows user to select all items", () => {
+  it("allows user with write permission to select all items", () => {
     const onSelectAll = jest.fn();
-    setup({ hasUnselected: true, onSelectAll });
+    setup({
+      hasUnselected: true,
+      onSelectAll,
+      collection: { can_write: true },
+    });
 
     userEvent.click(screen.getByLabelText("Select all items"));
 
     expect(onSelectAll).toHaveBeenCalled();
   });
 
-  it("allows user to deselect all items", () => {
+  it("allows user with write permission to deselect all items", () => {
     const onSelectNone = jest.fn();
-    setup({ hasUnselected: false, onSelectNone });
+    setup({
+      hasUnselected: false,
+      onSelectNone,
+      collection: { can_write: true },
+    });
 
     userEvent.click(screen.getByLabelText("Select all items"));
 
     expect(onSelectNone).toHaveBeenCalled();
+  });
+
+  it("does not display select all checkbox to user without write permissions", () => {
+    setup({
+      hasUnselected: true,
+      onSelectAll: jest.fn(),
+    });
+
+    expect(screen.queryByLabelText("Select all items")).not.toBeInTheDocument();
   });
 
   describe("models", () => {

--- a/frontend/test/metabase/collections/BaseItemsTable.unit.spec.js
+++ b/frontend/test/metabase/collections/BaseItemsTable.unit.spec.js
@@ -82,6 +82,24 @@ describe("Collections BaseItemsTable", () => {
     expect(screen.queryByTestId("model-detail-link")).not.toBeInTheDocument();
   });
 
+  it("allows user to select all items", () => {
+    const onSelectAll = jest.fn();
+    setup({ hasUnselected: true, onSelectAll });
+
+    userEvent.click(screen.queryByLabelText("Select all items"));
+
+    expect(onSelectAll).toHaveBeenCalled();
+  });
+
+  it("allows user to deselect all items", () => {
+    const onSelectNone = jest.fn();
+    setup({ hasUnselected: false, onSelectNone });
+
+    userEvent.click(screen.queryByLabelText("Select all items"));
+
+    expect(onSelectNone).toHaveBeenCalled();
+  });
+
   describe("models", () => {
     const model = getCollectionItem({
       id: 1,

--- a/frontend/test/metabase/collections/BaseItemsTable.unit.spec.js
+++ b/frontend/test/metabase/collections/BaseItemsTable.unit.spec.js
@@ -86,7 +86,7 @@ describe("Collections BaseItemsTable", () => {
     const onSelectAll = jest.fn();
     setup({ hasUnselected: true, onSelectAll });
 
-    userEvent.click(screen.queryByLabelText("Select all items"));
+    userEvent.click(screen.getByLabelText("Select all items"));
 
     expect(onSelectAll).toHaveBeenCalled();
   });
@@ -95,7 +95,7 @@ describe("Collections BaseItemsTable", () => {
     const onSelectNone = jest.fn();
     setup({ hasUnselected: false, onSelectNone });
 
-    userEvent.click(screen.queryByLabelText("Select all items"));
+    userEvent.click(screen.getByLabelText("Select all items"));
 
     expect(onSelectNone).toHaveBeenCalled();
   });


### PR DESCRIPTION
_Opened a new PR because I messed up the merge on the [last one](https://github.com/metabase/metabase/pull/28750) 😅_

Epic: https://github.com/metabase/metabase/issues/28737

### Description

This PR updates the collections table (`BaseItemsTable`) to a newer design intended to make bulk actions (move/archive multiple items) more visible.

<img width="781" alt="Screenshot 2023-02-28 at 10 09 13 AM" src="https://user-images.githubusercontent.com/37751258/221942032-b749ecd4-78a0-487e-93cb-e8e289e83b55.png">

Design from [Figma](https://www.figma.com/file/ZSze42p3ChrTnvbuKArhf4/Bulk-Actions-Bar?node-id=601%3A20398&t=fgpwfFaCAwRDkCqV-1)

UI components and styles are changed in `BaseItemsTable.jsx`, `BaseItemsTable.styled.jsx`, and `BaseTableItem.jsx`. Additional props are added to provide the methods needed for bulk actions. The methods themselves are already defined since this is not new functionality.

Note that there is still the old `BulkActionsBar` at the bottom of the screen with its own select all checkbox. This will be removed in my next PR (will merge onto this branch before `master`).

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Open a collection from the sidebar.
2. Table should have new header UI.
3. Try selecting individual rows, as well as selecting/deselecting all rows with the checkbox in the header.
4. Open the same collection with a user without write access, they should not see any checkboxes.

### Demo

https://user-images.githubusercontent.com/37751258/221943545-a6c7e6bb-621a-469e-a240-01ccd11f90c5.mov

### Checklist

- [✅] Tests have been added/updated to cover changes in this PR
