### PR TITLE
(2/n) update `BulkActions` for new bulk collection actions UI

### DIFF
--- a/e2e/test/scenarios/collections/collections.cy.spec.js
+++ b/e2e/test/scenarios/collections/collections.cy.spec.js
@@ -407,7 +407,7 @@ describe("scenarios > collection defaults", () => {
           cy.findByLabelText("Select all items").click();
 
           cy.icon("check").should("not.exist");
-          cy.findByText(/items selected/).should("not.be.visible");
+          cy.findByText(/item(s)? selected/).should("not.be.visible");
         });
 
         it("should clean up selection when opening another collection (metabase#16491)", () => {
@@ -421,7 +421,7 @@ describe("scenarios > collection defaults", () => {
           cy.findByText("1 item selected").should("be.visible");
 
           cy.findByText("Our analytics").click();
-          cy.findByText(/items selected/).should("not.be.visible");
+          cy.findByText(/item(s)? selected/).should("not.be.visible");
         });
 
         it("should not be possible to archive or move a personal collection via bulk actions", () => {
@@ -443,12 +443,12 @@ describe("scenarios > collection defaults", () => {
           cy.visit("/collection/root");
           selectItemUsingCheckbox("Orders");
 
-          cy.findByText(/items selected/)
+          cy.findByText(/item(s)? selected/)
             .button("Archive")
             .click();
 
           cy.findByText("Orders").should("not.exist");
-          cy.findByText(/items selected/).should("not.be.visible");
+          cy.findByText(/item(s)? selected/).should("not.be.visible");
         });
       });
 
@@ -457,7 +457,7 @@ describe("scenarios > collection defaults", () => {
           cy.visit("/collection/root");
           selectItemUsingCheckbox("Orders");
 
-          cy.findByText(/items selected/)
+          cy.findByText(/item(s)? selected/)
             .button("Move")
             .click();
 
@@ -467,7 +467,7 @@ describe("scenarios > collection defaults", () => {
           });
 
           cy.findByText("Orders").should("not.exist");
-          cy.findByText(/items selected/).should("not.be.visible");
+          cy.findByText(/item(s)? selected/).should("not.be.visible");
 
           // Check that items were actually moved
           navigationSidebar().findByText("First collection").click();

--- a/e2e/test/scenarios/collections/collections.cy.spec.js
+++ b/e2e/test/scenarios/collections/collections.cy.spec.js
@@ -407,7 +407,7 @@ describe("scenarios > collection defaults", () => {
           cy.findByLabelText("Select all items").click();
 
           cy.icon("check").should("not.exist");
-          cy.findByTestId("bulk-action-bar").should("not.be.visible");
+          cy.findByText(/items selected/).should("not.be.visible");
         });
 
         it("should clean up selection when opening another collection (metabase#16491)", () => {
@@ -421,7 +421,7 @@ describe("scenarios > collection defaults", () => {
           cy.findByText("1 item selected").should("be.visible");
 
           cy.findByText("Our analytics").click();
-          cy.findByTestId("bulk-action-bar").should("not.be.visible");
+          cy.findByText(/items selected/).should("not.be.visible");
         });
 
         it("should not be possible to archive or move a personal collection via bulk actions", () => {
@@ -443,10 +443,12 @@ describe("scenarios > collection defaults", () => {
           cy.visit("/collection/root");
           selectItemUsingCheckbox("Orders");
 
-          cy.findByTestId("bulk-action-bar").button("Archive").click();
+          cy.findByText(/items selected/)
+            .button("Archive")
+            .click();
 
           cy.findByText("Orders").should("not.exist");
-          cy.findByTestId("bulk-action-bar").should("not.be.visible");
+          cy.findByText(/items selected/).should("not.be.visible");
         });
       });
 
@@ -455,7 +457,9 @@ describe("scenarios > collection defaults", () => {
           cy.visit("/collection/root");
           selectItemUsingCheckbox("Orders");
 
-          cy.findByTestId("bulk-action-bar").button("Move").click();
+          cy.findByText(/items selected/)
+            .button("Move")
+            .click();
 
           modal().within(() => {
             cy.findByText("First collection").click();
@@ -463,7 +467,7 @@ describe("scenarios > collection defaults", () => {
           });
 
           cy.findByText("Orders").should("not.exist");
-          cy.findByTestId("bulk-action-bar").should("not.be.visible");
+          cy.findByText(/items selected/).should("not.be.visible");
 
           // Check that items were actually moved
           navigationSidebar().findByText("First collection").click();

--- a/frontend/src/metabase/collections/components/BulkActions.jsx
+++ b/frontend/src/metabase/collections/components/BulkActions.jsx
@@ -51,7 +51,7 @@ function BulkActions(props) {
       <Motion
         defaultStyle={{
           opacity: 0,
-          translateY: 0,
+          translateY: 100,
         }}
         style={{
           opacity: showing ? spring(1) : spring(0),

--- a/frontend/src/metabase/collections/components/BulkActions.jsx
+++ b/frontend/src/metabase/collections/components/BulkActions.jsx
@@ -11,7 +11,6 @@ import CollectionCopyEntityModal from "metabase/collections/components/Collectio
 
 import { ANALYTICS_CONTEXT } from "metabase/collections/constants";
 import { canArchiveItem, canMoveItem } from "metabase/collections/utils";
-import { NAV_SIDEBAR_WIDTH_HALF } from "metabase/nav/constants";
 import {
   BulkActionsToast,
   CardButton,
@@ -19,52 +18,36 @@ import {
   ToastCard,
 } from "./BulkActions.styled";
 
-function BulkActions(props) {
-  const {
-    selected,
-    collection,
-    selectedItems,
-    selectedAction,
-    onArchive,
-    onMoveStart,
-    onCloseModal,
-    onMove,
-    onCopy,
-    isNavbarOpen,
-  } = props;
-
-  const onMoveClick = selected.every(item => canMoveItem(item, collection))
-    ? onMoveStart
-    : null;
-  const onArchiveClick = selected.every(item =>
-    canArchiveItem(item, collection),
-  )
-    ? onArchive
-    : null;
-
-  const showing = selected.length > 0;
+function BulkActions({
+  selected,
+  collection,
+  selectedItems,
+  selectedAction,
+  onArchive,
+  onMoveStart,
+  onCloseModal,
+  onMove,
+  onCopy,
+  isNavbarOpen,
+}) {
+  const canMove = selected.every(item => canMoveItem(item, collection));
+  const canArchive = selected.every(item => canArchiveItem(item, collection));
+  const isVisible = selected.length > 0;
 
   return (
     <>
-      {/* NOTE: these padding and grid sizes must be carefully matched
-      to the main content above to ensure the bulk checkbox lines up */}
       <Motion
         defaultStyle={{
           opacity: 0,
           translateY: 100,
         }}
         style={{
-          opacity: showing ? spring(1) : spring(0),
-          translateY: showing ? spring(0) : spring(100),
+          opacity: isVisible ? spring(1) : spring(0),
+          translateY: isVisible ? spring(0) : spring(100),
         }}
       >
         {({ translateY }) => (
-          <BulkActionsToast
-            style={{
-              transform: `translate(-50%, ${translateY}px)`,
-              marginLeft: isNavbarOpen ? NAV_SIDEBAR_WIDTH_HALF : 0,
-            }}
-          >
+          <BulkActionsToast translateY={translateY} isNavbarOpen={isNavbarOpen}>
             <ToastCard dark>
               <CardSide>
                 {ngettext(
@@ -77,15 +60,15 @@ function BulkActions(props) {
                 <CardButton
                   medium
                   purple
-                  disabled={!onMoveClick}
-                  onClick={onMoveClick}
+                  disabled={!canMove}
+                  onClick={onMoveStart}
                   data-metabase-event={`${ANALYTICS_CONTEXT};Bulk Actions;Move Items`}
                 >{t`Move`}</CardButton>
                 <CardButton
                   medium
                   purple
-                  disabled={!onArchiveClick}
-                  onClick={onArchiveClick}
+                  disabled={!canArchive}
+                  onClick={onArchive}
                   data-metabase-event={`${ANALYTICS_CONTEXT};Bulk Actions;Archive Items`}
                 >{t`Archive`}</CardButton>
               </CardSide>

--- a/frontend/src/metabase/collections/components/BulkActions.jsx
+++ b/frontend/src/metabase/collections/components/BulkActions.jsx
@@ -3,55 +3,21 @@ import React from "react";
 import { t, msgid, ngettext } from "ttag";
 import _ from "underscore";
 
-import BulkActionBar from "metabase/components/BulkActionBar";
-import Button from "metabase/core/components/Button";
+import { Motion, spring } from "react-motion";
 import Modal from "metabase/components/Modal";
-import StackedCheckBox from "metabase/components/StackedCheckBox";
 
 import CollectionMoveModal from "metabase/containers/CollectionMoveModal";
 import CollectionCopyEntityModal from "metabase/collections/components/CollectionCopyEntityModal";
 
 import { ANALYTICS_CONTEXT } from "metabase/collections/constants";
 import { canArchiveItem, canMoveItem } from "metabase/collections/utils";
+import { NAV_SIDEBAR_WIDTH_HALF } from "metabase/nav/constants";
 import {
-  ActionBarContent,
-  ActionBarText,
-  ActionControlsRoot,
+  BulkActionsToast,
+  CardButton,
+  CardSide,
+  ToastCard,
 } from "./BulkActions.styled";
-
-const BulkActionControls = ({ onArchive, onMove }) => (
-  <ActionControlsRoot>
-    <Button
-      ml={1}
-      medium
-      disabled={!onArchive}
-      onClick={onArchive}
-      data-metabase-event={`${ANALYTICS_CONTEXT};Bulk Actions;Archive Items`}
-    >{t`Archive`}</Button>
-    <Button
-      ml={1}
-      medium
-      disabled={!onMove}
-      onClick={onMove}
-      data-metabase-event={`${ANALYTICS_CONTEXT};Bulk Actions;Move Items`}
-    >{t`Move`}</Button>
-  </ActionControlsRoot>
-);
-
-const SelectionControls = ({
-  selected,
-  hasUnselected,
-  onSelectAll,
-  onSelectNone,
-  size = 18,
-}) =>
-  !hasUnselected ? (
-    <StackedCheckBox checked onChange={onSelectNone} size={size} />
-  ) : selected.length === 0 ? (
-    <StackedCheckBox onChange={onSelectAll} size={size} />
-  ) : (
-    <StackedCheckBox checked indeterminate onChange={onSelectAll} size={size} />
-  );
 
 function BulkActions(props) {
   const {
@@ -67,27 +33,66 @@ function BulkActions(props) {
     isNavbarOpen,
   } = props;
 
-  const canMove = selected.every(item => canMoveItem(item, collection));
-  const canArchive = selected.every(item => canArchiveItem(item, collection));
+  const onMoveClick = selected.every(item => canMoveItem(item, collection))
+    ? onMoveStart
+    : null;
+  const onArchiveClick = selected.every(item =>
+    canArchiveItem(item, collection),
+  )
+    ? onArchive
+    : null;
+
+  const showing = selected.length > 0;
 
   return (
-    <BulkActionBar showing={selected.length > 0} isNavbarOpen={isNavbarOpen}>
+    <>
       {/* NOTE: these padding and grid sizes must be carefully matched
-                   to the main content above to ensure the bulk checkbox lines up */}
-      <ActionBarContent>
-        <SelectionControls {...props} />
-        <BulkActionControls
-          onArchive={canArchive ? onArchive : null}
-          onMove={canMove ? onMoveStart : null}
-        />
-        <ActionBarText>
-          {ngettext(
-            msgid`${selected.length} item selected`,
-            `${selected.length} items selected`,
-            selected.length,
-          )}
-        </ActionBarText>
-      </ActionBarContent>
+      to the main content above to ensure the bulk checkbox lines up */}
+      <Motion
+        defaultStyle={{
+          opacity: 0,
+          translateY: 0,
+        }}
+        style={{
+          opacity: showing ? spring(1) : spring(0),
+          translateY: showing ? spring(0) : spring(100),
+        }}
+      >
+        {({ translateY }) => (
+          <BulkActionsToast
+            style={{
+              transform: `translate(-50%, ${translateY}px)`,
+              marginLeft: isNavbarOpen ? NAV_SIDEBAR_WIDTH_HALF : 0,
+            }}
+          >
+            <ToastCard dark>
+              <CardSide>
+                {ngettext(
+                  msgid`${selected.length} item selected`,
+                  `${selected.length} items selected`,
+                  selected.length,
+                )}
+              </CardSide>
+              <CardSide>
+                <CardButton
+                  medium
+                  purple
+                  disabled={!onMoveClick}
+                  onClick={onMoveClick}
+                  data-metabase-event={`${ANALYTICS_CONTEXT};Bulk Actions;Move Items`}
+                >{t`Move`}</CardButton>
+                <CardButton
+                  medium
+                  purple
+                  disabled={!onArchiveClick}
+                  onClick={onArchiveClick}
+                  data-metabase-event={`${ANALYTICS_CONTEXT};Bulk Actions;Archive Items`}
+                >{t`Archive`}</CardButton>
+              </CardSide>
+            </ToastCard>
+          </BulkActionsToast>
+        )}
+      </Motion>
       {!_.isEmpty(selectedItems) && selectedAction === "copy" && (
         <Modal onClose={onCloseModal}>
           <CollectionCopyEntityModal
@@ -113,7 +118,7 @@ function BulkActions(props) {
           />
         </Modal>
       )}
-    </BulkActionBar>
+    </>
   );
 }
 

--- a/frontend/src/metabase/collections/components/BulkActions.styled.tsx
+++ b/frontend/src/metabase/collections/components/BulkActions.styled.tsx
@@ -1,35 +1,36 @@
 import styled from "@emotion/styled";
-import { breakpointMinSmall } from "metabase/styled-components/theme";
-import { color } from "metabase/lib/colors";
+import Card from "metabase/components/Card";
+import Button from "metabase/core/components/Button";
+import { alpha, color } from "metabase/lib/colors";
+import { space } from "metabase/styled-components/theme";
 
-import { NAV_SIDEBAR_WIDTH } from "metabase/nav/constants";
-
-export const FixedBottomBar = styled.div<{ isNavbarOpen: boolean }>`
+export const BulkActionsToast = styled.div`
   position: fixed;
   bottom: 0;
-  left: ${props => (props.isNavbarOpen ? NAV_SIDEBAR_WIDTH : 0)};
-  right: 0;
-  border-top: 1px solid ${color("border")};
-  background-color: ${color("white")};
+  left: 50%;
+  margin-bottom: ${space(2)};
+  z-index: 999;
 `;
 
-export const ActionBarContent = styled.div`
-  padding: 0.5rem 1rem;
+export const ToastCard = styled(Card)`
+  padding: 0.75rem ${space(2)};
   display: flex;
   align-items: center;
-  width: 90%;
-  margin: 0 auto;
+  justify-content: space-between;
+  gap: 2.5rem;
+`;
 
-  ${breakpointMinSmall} {
-    padding-left: 2rem;
-    padding-right: 2rem;
+export const CardSide = styled.div`
+  display: flex;
+  align-items: center;
+  gap: ${space(2)};
+`;
+
+export const CardButton = styled(Button)`
+  border-color: ${alpha(color("bg-white"), 0)};
+  background-color: ${alpha(color("bg-white"), 0.1)};
+  :hover {
+    border-color: ${alpha(color("bg-white"), 0)};
+    background-color: ${alpha(color("bg-white"), 0.3)};
   }
-`;
-
-export const ActionBarText = styled.div`
-  margin-left: auto;
-`;
-
-export const ActionControlsRoot = styled.div`
-  margin-left: 0.5rem;
 `;

--- a/frontend/src/metabase/collections/components/BulkActions.styled.tsx
+++ b/frontend/src/metabase/collections/components/BulkActions.styled.tsx
@@ -2,12 +2,19 @@ import styled from "@emotion/styled";
 import Card from "metabase/components/Card";
 import Button from "metabase/core/components/Button";
 import { alpha, color } from "metabase/lib/colors";
+import { NAV_SIDEBAR_WIDTH } from "metabase/nav/constants";
 import { space } from "metabase/styled-components/theme";
 
-export const BulkActionsToast = styled.div`
+export const BulkActionsToast = styled.div<{
+  isNavbarOpen: boolean;
+  translateY: number;
+}>`
   position: fixed;
   bottom: 0;
   left: 50%;
+  transform: ${props => `translate(-50%, ${props.translateY}px)`};
+  margin-left: ${props =>
+    props.isNavbarOpen ? `${parseInt(NAV_SIDEBAR_WIDTH) / 2}px` : "0"};
   margin-bottom: ${space(2)};
   z-index: 999;
 `;

--- a/frontend/src/metabase/collections/containers/CollectionContent.jsx
+++ b/frontend/src/metabase/collections/containers/CollectionContent.jsx
@@ -289,14 +289,11 @@ function CollectionContent({
                       <BulkActions
                         selected={selected}
                         collection={collection}
-                        onSelectAll={handleSelectAll}
-                        onSelectNone={clear}
                         onArchive={handleBulkArchive}
                         onMoveStart={handleBulkMoveStart}
                         onMove={handleBulkMove}
                         onCloseModal={handleCloseModal}
                         onCopy={clear}
-                        hasUnselected={hasUnselected}
                         selectedItems={selectedItems}
                         selectedAction={selectedAction}
                         isNavbarOpen={isNavbarOpen}

--- a/frontend/src/metabase/components/BulkActionBar.styled.tsx
+++ b/frontend/src/metabase/components/BulkActionBar.styled.tsx
@@ -1,0 +1,13 @@
+import styled from "@emotion/styled";
+
+import { color } from "metabase/lib/colors";
+import { NAV_SIDEBAR_WIDTH } from "metabase/nav/constants";
+
+export const FixedBottomBar = styled.div<{ isNavbarOpen: boolean }>`
+  position: fixed;
+  bottom: 0;
+  left: ${props => (props.isNavbarOpen ? NAV_SIDEBAR_WIDTH : 0)};
+  right: 0;
+  border-top: 1px solid ${color("border")};
+  background-color: ${color("white")};
+`;

--- a/frontend/src/metabase/components/BulkActionBar.tsx
+++ b/frontend/src/metabase/components/BulkActionBar.tsx
@@ -1,7 +1,8 @@
 /* eslint-disable react/prop-types */
 import React from "react";
 import { Motion, spring } from "react-motion";
-import { FixedBottomBar } from "metabase/collections/components/BulkActions.styled";
+
+import { FixedBottomBar } from "./BulkActionBar.styled";
 
 interface BulkActionBarProps {
   children: React.ReactNode;

--- a/frontend/src/metabase/nav/constants.ts
+++ b/frontend/src/metabase/nav/constants.ts
@@ -3,3 +3,4 @@ export const APP_SUBHEADER_HEIGHT = "48px";
 export const APP_BAR_EXTENDED_HEIGHT = "98px";
 export const ADMIN_NAVBAR_HEIGHT = "65px";
 export const NAV_SIDEBAR_WIDTH = "324px";
+export const NAV_SIDEBAR_WIDTH_HALF = "162px";

--- a/frontend/src/metabase/nav/constants.ts
+++ b/frontend/src/metabase/nav/constants.ts
@@ -3,4 +3,3 @@ export const APP_SUBHEADER_HEIGHT = "48px";
 export const APP_BAR_EXTENDED_HEIGHT = "98px";
 export const ADMIN_NAVBAR_HEIGHT = "65px";
 export const NAV_SIDEBAR_WIDTH = "324px";
-export const NAV_SIDEBAR_WIDTH_HALF = "162px";


### PR DESCRIPTION
Epic: https://github.com/metabase/metabase/issues/28737

### Description

Second in a series of PR updating the UI for bulk actions (move and archive) on collections. ([Previous PR](https://github.com/metabase/metabase/pull/28793))

This PR implements the new toast design to house the action buttons.

![Hybrid Version - minimal selection - menu appears](https://user-images.githubusercontent.com/37751258/222234294-53b53bcd-4e9f-42f0-a99c-5bf80351b8e1.png)

Design from [Figma](https://www.figma.com/file/ZSze42p3ChrTnvbuKArhf4/Bulk-Actions-Bar?node-id=601%3A20398&t=iV0WIbN6ijdrCtGH-1)

### How to verify

Describe the steps to verify that the changes are working as expected.

 1. Open a collection from the sidebar.
 2. Select some or all items.
 3. Toast with new design should appear instead of old bottom bar.
 4. Try "move" and "archive" actions, should work.
 
 Note: right now the undo toast is still aligned to the bottom left corner, that will be fixed in the next PR.

### Demo

<img width="644" alt="Screenshot 2023-03-01 at 10 43 34 AM" src="https://user-images.githubusercontent.com/37751258/222235095-2016b5e9-d9fd-4bb3-a952-e9e902260f4d.png">

Before

https://user-images.githubusercontent.com/37751258/222235166-7556d716-f885-43e3-86b1-e6346cb3d64b.mov

After

### Checklist

- [✅] Tests have been added/updated to cover changes in this PR
