### PR TITLE
Cannot use filter relative interval on breakout fields

### DIFF
--- a/e2e/test/scenarios/filters/reproductions/25378-relative-date-on-breakout.cy.spec.js
+++ b/e2e/test/scenarios/filters/reproductions/25378-relative-date-on-breakout.cy.spec.js
@@ -24,7 +24,7 @@ const questionDetails = {
   display: "line",
 };
 
-describe.skip("issue 25378", () => {
+describe("issue 25378", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();

--- a/src/metabase/query_processor/middleware/optimize_temporal_filters.clj
+++ b/src/metabase/query_processor/middleware/optimize_temporal_filters.clj
@@ -69,7 +69,9 @@
   (:end (u.date/range t unit)))
 
 (defn- change-temporal-unit-to-default [field]
-  (mbql.u/update-field-options field assoc :temporal-unit :default))
+  (mbql.u/replace field
+    [:field _ (_ :guard (comp optimizable-units :temporal-unit))]
+    (mbql.u/update-field-options &match assoc :temporal-unit :default)))
 
 (defmulti ^:private temporal-value-lower-bound
   "Get a clause representing the *lower* bound that should be used when converting a `temporal-value-clause` (e.g.


### PR DESCRIPTION
Fixes #25378

When using a relative filter with a starting from n units ago on an aggregation with the same units, we were incorrectly assuming that we would be working with a field ref at the top level. However, in this scenario the field is nested such as `[:+ [:field $created_at {:temporal-unit :month}] [:interval 1 :month]]`. This change makes sure that we are altering the field-ref.
