### PR TITLE
fix syntax error in `bin/build-for-test`

### DIFF
--- a/bin/build-for-test
+++ b/bin/build-for-test
@@ -29,9 +29,9 @@ check-uberjar-hash() {
 }
 
 build-uberjar-for-test() {
-  ./bin/build.sh version
+  ./bin/build.sh :steps [:version]
   echo -e "\n$VERSION_PROPERTY_NAME=$(source-hash)" >> resources/version.properties
-  ./bin/build.sh uberjar
+  ./bin/build.sh :steps [:uberjar]
 }
 
 if [ ! -f "target/uberjar/metabase.jar" ] || ! check-uberjar-hash; then


### PR DESCRIPTION
### Description

[ Build script overhaul 2023 #28767 ](https://github.com/metabase/metabase/pull/28767) introduced a minor regression where `bin/build-for-test` had a syntax error, causing our e2e test script to break locally.

This PR adds @camsaul's fix for it ([Slack thread](https://github.com/metabase/metabase/pull/28767))

### How to verify

1. `yarn test-cypress-open-qa`
2. confirm script works without error and cypress opens
