### PR TITLE
Make number widget input full width

### DIFF
--- a/frontend/src/metabase/parameters/components/widgets/NumberInputWidget/NumberInputWidget.tsx
+++ b/frontend/src/metabase/parameters/components/widgets/NumberInputWidget/NumberInputWidget.tsx
@@ -75,8 +75,9 @@ function NumberInputWidget({
         </TokenFieldWrapper>
       ) : (
         _.times(arity, i => (
-          <div className="inline-block" key={i}>
+          <div key={i}>
             <NumericInput
+              fullWidth
               className="p1"
               autoFocus={autoFocus && i === 0}
               value={unsavedArrayValue[i]}


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/28759

### How to verify

1. `+ New` › `Question` › `Sample Data` › `Orders`
2. `Save`
3. `Add to dashboard`
4. Add filter to dashboard: `Number` › `Greater than or Equal To`, attach to `Subtotal`

## Before

<img width="624" alt="image" src="https://user-images.githubusercontent.com/380816/221996732-b50b3bf8-a66e-420a-9043-9dfaa2e6b18b.png">

## After

<img width="394" alt="image" src="https://user-images.githubusercontent.com/380816/222243120-679092ec-933e-46bc-be5b-d79d7e27e0bd.png">


### Checklist

- [n/a] Tests have been added/updated to cover changes in this PR - minor visual change
