### PR TITLE
Centering tab labels

### DIFF
--- a/frontend/src/metabase/core/components/Radio/Radio.tsx
+++ b/frontend/src/metabase/core/components/Radio/Radio.tsx
@@ -215,6 +215,7 @@ function isDefaultOption<TValue>(
 export default Object.assign(Radio, {
   RadioGroupVariants: [RadioGroupBubble, RadioGroupNormal],
   RadioLabelVariants: [RadioLabelBubble, RadioLabelNormal],
+  RadioLabelText: RadioLabelText,
   RadioContainerVariants: [
     RadioContainerBubble,
     RadioContainerNormal,

--- a/frontend/src/metabase/visualizations/components/ChartSettingsWidgetPopover.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/ChartSettingsWidgetPopover.styled.tsx
@@ -31,6 +31,10 @@ export const PopoverTabs = styled(Radio)`
     justify-content: center;
     padding-bottom: 0.75rem;
   }
+
+  ${Radio.RadioLabelText} {
+    flex: none;
+  }
 `;
 
 export const PopoverTitle = styled.h3`

--- a/frontend/test/metabase/visualizations/components/ChartSettingsWidgetPopover.unit.spec.jsx
+++ b/frontend/test/metabase/visualizations/components/ChartSettingsWidgetPopover.unit.spec.jsx
@@ -1,0 +1,75 @@
+import React, { useState } from "react";
+import { renderWithProviders, screen, fireEvent } from "__support__/ui";
+
+import ChartSettingsWidgetPopover from "metabase/visualizations/components/ChartSettingsWidgetPopover";
+
+const DEFAULT_PROPS = {
+  handleEndShowWidget: jest.fn(),
+};
+
+const FORMATTING_WIDGET = {
+  id: "column_settings",
+  section: "Formatting",
+  widget: function testWidget() {
+    return <p>Foo</p>;
+  },
+  onChange: () => {},
+};
+
+const STYLE_WIDGET = {
+  id: "series_settings",
+  section: "Style",
+  widget: function testWidget() {
+    return <p>Bar</p>;
+  },
+  onChange: () => {},
+};
+
+const setup = props => {
+  const Container = () => {
+    const [anchor, setAnchor] = useState();
+
+    return (
+      <>
+        <p ref={setAnchor}>Anchor</p>
+        <ChartSettingsWidgetPopover
+          anchor={anchor}
+          {...DEFAULT_PROPS}
+          {...props}
+        />
+      </>
+    );
+  };
+  return renderWithProviders(<Container />);
+};
+
+it("should display when an anchor is passed", async () => {
+  setup({ widgets: [FORMATTING_WIDGET, STYLE_WIDGET] });
+
+  expect(await screen.findByText("Formatting")).toBeInTheDocument();
+  expect(await screen.findByText("Style")).toBeInTheDocument();
+
+  //Should Default to rendering formatting
+  expect(await screen.findByText("Foo")).toBeInTheDocument();
+});
+
+it("should not show tabs when only 1 widget is passed", async () => {
+  setup({ widgets: [FORMATTING_WIDGET] });
+
+  expect(screen.queryByText("Formatting")).not.toBeInTheDocument();
+  expect(screen.queryByText("Style")).not.toBeInTheDocument();
+
+  //Should Default to rendering formatting
+  expect(await screen.findByText("Foo")).toBeInTheDocument();
+});
+
+it("should change tabs when clicked", async () => {
+  setup({ widgets: [FORMATTING_WIDGET, STYLE_WIDGET] });
+
+  //Should Default to rendering formatting
+  expect(await screen.findByText("Foo")).toBeInTheDocument();
+
+  fireEvent.click(await screen.findByText("Style"));
+
+  expect(await screen.findByText("Bar")).toBeInTheDocument();
+});

--- a/frontend/test/metabase/visualizations/components/ChartSettingsWidgetPopover.unit.spec.jsx
+++ b/frontend/test/metabase/visualizations/components/ChartSettingsWidgetPopover.unit.spec.jsx
@@ -1,5 +1,7 @@
 import React, { useState } from "react";
-import { renderWithProviders, screen, fireEvent } from "__support__/ui";
+import userEvent from "@testing-library/user-event";
+
+import { renderWithProviders, screen } from "__support__/ui";
 
 import ChartSettingsWidgetPopover from "metabase/visualizations/components/ChartSettingsWidgetPopover";
 
@@ -69,7 +71,7 @@ it("should change tabs when clicked", async () => {
   //Should Default to rendering formatting
   expect(await screen.findByText("Foo")).toBeInTheDocument();
 
-  fireEvent.click(await screen.findByText("Style"));
+  userEvent.click(await screen.findByText("Style"));
 
   expect(await screen.findByText("Bar")).toBeInTheDocument();
 });


### PR DESCRIPTION
Fixes #28541 

### Description
Removing flex styling from radio label text for Chart Settings popover

### How to verify
- Create a new question with more than one metric. IE: Orders, Count and Average of Total grouped by Created At: Year.
- Open chart settings and click the `...` icon on one of the metrics
- Tab labels should be centered instead of left aligned

### Demo
![image](https://user-images.githubusercontent.com/1328979/222261672-6fcfa1ec-babe-433d-b128-985c6791a4c8.png)

### Tests
No tests were added as we typically don't assert on styling in components. However, I'm open to suggestions if anyone has any