### PR TITLE
Only grab logs for test namespace

### DIFF
--- a/test/metabase/util/log_test.cljc
+++ b/test/metabase/util/log_test.cljc
@@ -6,16 +6,16 @@
 
 (deftest basic-logp-test
   (is (= [[:warn nil "a message"]]
-         (tlog/with-log-messages-for-level :warn
+         (tlog/with-log-messages-for-level [metabase.util.log-test :warn]
            (log/info "not this one")
            (log/warn "a message"))))
   (is (= [[:info nil "here's one"]
           [:warn nil "a message"]]
-         (tlog/with-log-messages-for-level :info
+         (tlog/with-log-messages-for-level [metabase.util.log-test :info]
            (log/info "here's one")
            (log/warn "a message"))))
   (is (= [[:info nil ":keyword 78"]]
-         (tlog/with-log-messages-for-level :info
+         (tlog/with-log-messages-for-level [metabase.util.log-test :info]
            (log/info :keyword 78)))))
 
 (deftest logp-levels-test
@@ -33,7 +33,7 @@
               [:debug nil "debug"]
               [:trace nil "trace"]]]
     (are [prefix level] (= (take prefix logs)
-                           (tlog/with-log-messages-for-level ['metabase.util.log-test
+                           (tlog/with-log-messages-for-level [metabase.util.log-test
                                                               level]
                              (spam)))
          ;0 :off - this doesn't work in CLJ and perhaps should?
@@ -46,5 +46,5 @@
 
 (deftest logf-formatting-test
   (is (= [[:info nil "input: 8, 3; output: ignored"]]
-         (tlog/with-log-messages-for-level :info
+         (tlog/with-log-messages-for-level [metabase.util.log-test :info]
            (log/infof "input: %d, %d; %s: ignored" 8 3 "output")))))

--- a/test/metabase/util/log_test.cljc
+++ b/test/metabase/util/log_test.cljc
@@ -32,7 +32,10 @@
               [:info  nil "info"]
               [:debug nil "debug"]
               [:trace nil "trace"]]]
-    (are [prefix level] (= (take prefix logs) (tlog/with-log-messages-for-level level (spam)))
+    (are [prefix level] (= (take prefix logs)
+                           (tlog/with-log-messages-for-level ['metabase.util.log-test
+                                                              level]
+                             (spam)))
          ;0 :off - this doesn't work in CLJ and perhaps should?
          1 :fatal
          2 :error


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/28621

can't ensure that other threads aren't also logging:

```
FAIL in metabase.util.log-test/logp-levels-test (log_test.cljc:35)
(= (take 6 logs) (tlog/with-log-messages-for-level :trace (spam)))
expected: ([:fatal nil "fatal"]
           [:error nil "error"]
           [:warn nil "warn"]
           [:info nil "info"]
           [:debug nil "debug"]
           [:trace nil "trace"])
  actual: [[:fatal nil "fatal"]
           [:error nil "error"]
           [:trace nil "Checking cancelation status after waiting 1000.0 ms"]
           [:warn nil "warn"]
           [:info nil "info"]
           [:debug nil "debug"]
           [:trace nil "Checking cancelation status after waiting 1000.0 ms"]
           [:trace nil "trace"]]
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/28816)
<!-- Reviewable:end -->
