### PR TITLE
[CI] Upgrade `codecov` action to v3

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -44,7 +44,7 @@ jobs:
     - name: Collect the test coverage
       run: clojure -X:dev:ee:ee-dev:test:cloverage
     - name: Upload coverage to codecov.io
-      uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@v3
       with:
         files: ./target/coverage/codecov.json
         flags: back-end

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -90,7 +90,7 @@ jobs:
     - run: yarn run test-unit --coverage --silent
       name: Run frontend unit tests
     - name: Upload coverage to codecov.io
-      uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@v3
       with:
         files: ./coverage/lcov.info
         flags: front-end


### PR DESCRIPTION
Get rid of this warning:
```
[be-linter-cloverage](https://github.com/metabase/metabase/actions/runs/4307847275/jobs/7513466307)
Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: codecov/codecov-action@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
```