### PR TITLE
Adds --include-field-values flag to serdes v2 export command

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/extract.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/extract.clj
@@ -46,9 +46,16 @@
   [opts]
   (log/tracef "Extracting Metabase with options: %s" (pr-str opts))
   (serdes.backfill/backfill-ids)
-  (let [model-pred (if (:data-model-only opts)
+  ;; TODO document and test data-model-only if we want to keep this feature...
+  (let [model-pred (cond
+                     (:data-model-only opts)
                      #{"Database" "Dimension" "Field" "FieldValues" "Metric" "Segment" "Table"}
-                     (constantly true))
+
+                     (:include-field-values opts)
+                     (constantly true)
+
+                     :else
+                     (complement #{"FieldValues"}))
         ;; This set of unowned top-level collections is used in several `extract-query` implementations.
         opts       (assoc opts :collection-set (collection-set-for-user (:user opts)))]
     (eduction cat (for [model serdes.models/exported-models

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
@@ -897,7 +897,15 @@
             (is (= #{[{:model "Database"   :id "My Database"}
                       {:model "Table"      :id "Schemaless Table"}
                       {:model "Field"      :id "Some Field"}]}
-                   (set (serdes.base/serdes-dependencies ser))))))))))
+                   (set (serdes.base/serdes-dependencies ser)))))))
+      (testing "extract-metabase behavior"
+        (testing "without :include-field-values"
+          (is (= #{}
+                 (by-model "FieldValues" (extract/extract-metabase {})))))
+        (testing "with :include-field-values true"
+          (let [models (->> {:include-field-values true} extract/extract-metabase (map (comp :model last :serdes/meta)))]
+            ;; why 6?
+            (is (= 6 (count (filter #{"FieldValues"} models))))))))))
 
 (deftest pulses-test
   (ts/with-empty-h2-app-db

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
@@ -789,7 +789,7 @@
           (reset! fv2s     (ts/create! FieldValues :field_id (:id @field2s)
                                        :values ["CONSTRUCTION" "DAYLIGHTING" "DELIVERY" "HAULING"]))
 
-          (reset! serialized (into [] (serdes.extract/extract-metabase {})))
+          (reset! serialized (into [] (serdes.extract/extract-metabase {:include-field-values true})))
 
           (testing "the expected fields are serialized"
             (is (= 1

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/storage/yaml_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/storage/yaml_test.clj
@@ -127,7 +127,7 @@
                          Field       [website {:name "Company/organization website" :table_id (:id table)}]
                          FieldValues [_       {:field_id (:id website)}]
                          Table       [_       {:name "Orders/Invoices" :db_id (:id db)}]]
-        (let [export          (into [] (extract/extract-metabase nil))]
+        (let [export          (into [] (extract/extract-metabase {:include-field-values true}))]
           (storage.yaml/store! export dump-dir)
           (testing "the right files in the right places"
             (is (= #{["Company__SLASH__organization website.yaml"]

--- a/src/metabase/cmd.clj
+++ b/src/metabase/cmd.clj
@@ -198,8 +198,7 @@
   [path & options]
   (let [opts (-> options
                  cmd-args->map
-                 (update :collections parse-int-list)
-                 (assoc :include-field-values (boolean (some #{"--include-field-values"} options))))]
+                 (update :collections parse-int-list))]
     (call-enterprise 'metabase-enterprise.serialization.cmd/v2-dump path opts)))
 
 (defn ^:command seed-entity-ids

--- a/src/metabase/cmd.clj
+++ b/src/metabase/cmd.clj
@@ -128,7 +128,7 @@
    ((resolve 'metabase.cmd.driver-methods/print-available-multimethods) true)))
 
 (defn- cmd-args->map
-  "Returns a map of keywords parsed from command-line argument flags and values. Handles 
+  "Returns a map of keywords parsed from command-line argument flags and values. Handles
    boolean flags as well as explicit values."
   [args]
   (m/map-keys #(keyword (str/replace-first % "--" ""))

--- a/src/metabase/cmd.clj
+++ b/src/metabase/cmd.clj
@@ -196,9 +196,7 @@
    --collections [collection-id-list] - a comma-separated list of IDs of collection to export
    --include-field-values             - flag, default false, controls export of field values"
   [path & options]
-  (let [opts (-> options
-                 cmd-args->map
-                 (update :collections parse-int-list))]
+  (let [opts (-> options cmd-args->map (update :collections parse-int-list))]
     (call-enterprise 'metabase-enterprise.serialization.cmd/v2-dump path opts)))
 
 (defn ^:command seed-entity-ids

--- a/test/metabase/cmd_test.clj
+++ b/test/metabase/cmd_test.clj
@@ -37,7 +37,7 @@
                (cmd/dump "/path/" "--num-cans" "2")))))
     (testing "export (v2)"
       (testing "with no options"
-        (is (= '(metabase-enterprise.serialization.cmd/v2-dump "/path/" {:collections nil :include-field-values false})
+        (is (= '(metabase-enterprise.serialization.cmd/v2-dump "/path/" {:collections nil})
                (cmd/export "/path/"))))
       (testing "with --collections list"
         (is (= '(metabase-enterprise.serialization.cmd/v2-dump "/path/" {:collections [1 2 3] :include-field-values true})

--- a/test/metabase/cmd_test.clj
+++ b/test/metabase/cmd_test.clj
@@ -37,8 +37,8 @@
                (cmd/dump "/path/" "--num-cans" "2")))))
     (testing "export (v2)"
       (testing "with no options"
-        (is (= '(metabase-enterprise.serialization.cmd/v2-dump "/path/" {:collections nil})
+        (is (= '(metabase-enterprise.serialization.cmd/v2-dump "/path/" {:collections nil :include-field-values false})
                (cmd/export "/path/"))))
       (testing "with --collections list"
-        (is (= '(metabase-enterprise.serialization.cmd/v2-dump "/path/" {:collections [1 2 3]})
-               (cmd/export "/path/" "--collections" "1,2,3")))))))
+        (is (= '(metabase-enterprise.serialization.cmd/v2-dump "/path/" {:collections [1 2 3] :include-field-values true})
+               (cmd/export "/path/" "--collections" "1,2,3" "--include-field-values")))))))


### PR DESCRIPTION
Adds the `--include-field-values` flag to the `export` command.

Resolves #28303

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/28848)
<!-- Reviewable:end -->
