### PR TITLE
Standardize chart settings icon buttons

### DIFF
--- a/e2e/test/scenarios/binning/binning-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/binning/binning-reproductions.cy.spec.js
@@ -207,7 +207,9 @@ describe("binning related reproductions", () => {
     cy.findByTestId("sidebar-left").within(() => {
       cy.findByTestId("Table-button").click();
       cy.findByTextEnsureVisible("Table options");
-      cy.findByText("Created At").siblings(".Icon-eye_outline").click();
+      cy.findByText("Created At")
+        .siblings("[data-testid$=hide-button]")
+        .click();
       cy.button("Done").click();
     });
 

--- a/e2e/test/scenarios/native/native.cy.spec.js
+++ b/e2e/test/scenarios/native/native.cy.spec.js
@@ -166,7 +166,7 @@ describe("scenarios > question > native", () => {
     cy.findByTestId("sidebar-left")
       .as("sidebar")
       .contains(/hidden/i)
-      .siblings(".Icon-eye_outline")
+      .siblings("[data-testid$=hide-button]")
       .click();
     cy.get("@editor").type("{movetoend}, 3 as added");
     cy.get("@runQuery").click();

--- a/e2e/test/scenarios/native/reproductions/16914.cy.spec.js
+++ b/e2e/test/scenarios/native/reproductions/16914.cy.spec.js
@@ -19,7 +19,7 @@ describe("issue 16914", () => {
     cy.findByTestId("viz-settings-button").click();
     cy.findByTestId("sidebar-left")
       .contains(/hidden/i)
-      .siblings(".Icon-eye_outline")
+      .siblings("[data-testid$=hide-button]")
       .click();
     cy.button("Done").click();
 

--- a/e2e/test/scenarios/question/reproductions/17514-ui-overlay.cy.spec.js
+++ b/e2e/test/scenarios/question/reproductions/17514-ui-overlay.cy.spec.js
@@ -154,7 +154,7 @@ function openVisualizationOptions() {
 
 function hideColumn(columnName) {
   cy.findByTestId("chartsettings-sidebar").within(() => {
-    cy.findByText(columnName).siblings(".Icon-eye_outline").click();
+    cy.findByText(columnName).siblings("[data-testid$=hide-button]").click();
   });
 }
 

--- a/e2e/test/scenarios/question/settings.cy.spec.js
+++ b/e2e/test/scenarios/question/settings.cy.spec.js
@@ -38,14 +38,14 @@ describe("scenarios > question > settings", () => {
       cy.get("@tableOptions")
         .contains("Total")
         .scrollIntoView()
-        .nextAll(".Icon-eye_outline")
+        .siblings("[data-testid$=hide-button]")
         .click();
 
       // Add people.category
       cy.get("@tableOptions")
         .contains("Category")
         .scrollIntoView()
-        .nextAll(".Icon-add")
+        .siblings("[data-testid$=add-button]")
         .click();
 
       // wait a Category value to appear in the table, so we know the query completed
@@ -55,7 +55,7 @@ describe("scenarios > question > settings", () => {
       cy.get("@tableOptions")
         .contains("Ean")
         .scrollIntoView()
-        .nextAll(".Icon-add")
+        .siblings("[data-testid$=add-button]")
         .click();
 
       // wait a Ean value to appear in the table, so we know the query completed

--- a/e2e/test/scenarios/visualizations/pivot_tables.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/pivot_tables.cy.spec.js
@@ -1044,5 +1044,8 @@ function getIframeBody(selector = "iframe") {
 }
 
 function openColumnSettings(columnName) {
-  sidebar().findByText(columnName).siblings(".Icon-ellipsis").click();
+  sidebar()
+    .findByText(columnName)
+    .siblings("[data-testid$=settings-button]")
+    .click();
 }

--- a/e2e/test/scenarios/visualizations/reproductions/15353-pivot-settings-change-name-values.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/reproductions/15353-pivot-settings-change-name-values.cy.spec.js
@@ -25,7 +25,10 @@ describe("issue 15353", () => {
 
   it("should be able to change field name used for values (metabase#15353)", () => {
     cy.findByTestId("viz-settings-button").click();
-    sidebar().contains("Count").siblings(".Icon-ellipsis").click();
+    sidebar()
+      .contains("Count")
+      .siblings("[data-testid$=settings-button]")
+      .click();
 
     cy.findByDisplayValue("Count").type(" renamed").blur();
 

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.jsx
@@ -7,6 +7,7 @@ import { getColumnKey } from "metabase-lib/queries/utils/get-column-key";
 import ChartSettingSelect from "./ChartSettingSelect";
 import {
   SettingsIcon,
+  SettingsButton,
   ChartSettingFieldPickerRoot,
   FieldPickerColorPicker,
 } from "./ChartSettingFieldPicker.styled";
@@ -73,8 +74,9 @@ const ChartSettingFieldPicker = ({
         hiddenIcons
       />
       {columnKey && (
-        <SettingsIcon
-          name="ellipsis"
+        <SettingsButton
+          onlyIcon
+          icon="ellipsis"
           onClick={e => {
             onShowWidget(
               {
@@ -89,10 +91,11 @@ const ChartSettingFieldPicker = ({
         />
       )}
       {onRemove && (
-        <SettingsIcon
+        <SettingsButton
           data-testid={`remove-${value}`}
-          name="close"
-          size={14}
+          icon="close"
+          iconSize={14}
+          onlyIcon
           onClick={onRemove}
         />
       )}

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.styled.tsx
@@ -1,6 +1,7 @@
 import styled from "@emotion/styled";
 import { color } from "metabase/lib/colors";
 import Icon from "metabase/components/Icon";
+import Button from "metabase/core/components/Button";
 import SelectButton from "metabase/core/components/SelectButton";
 import Triggerable from "metabase/components/Triggerable";
 import ChartSettingColorPicker from "./ChartSettingColorPicker";
@@ -56,6 +57,15 @@ interface SettingsIconProps {
   noPointer?: boolean;
   noMargin?: boolean;
 }
+
+export const SettingsButton = styled(Button)<SettingsIconProps>`
+  margin-left: ${props => (props.noMargin ? "0" : "0.75rem")};
+  padding: 0;
+
+  &:hover: {
+    background: unset;
+  }
+`;
 
 export const SettingsIcon = styled(Icon)<SettingsIconProps>`
   margin-left: ${props => (props.noMargin ? "0" : "0.75rem")};

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldPicker.styled.tsx
@@ -62,8 +62,8 @@ export const SettingsButton = styled(Button)<SettingsIconProps>`
   margin-left: ${props => (props.noMargin ? "0" : "0.75rem")};
   padding: 0;
 
-  &:hover: {
-    background: unset;
+  &:hover {
+    background-color: unset;
   }
 `;
 

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingSelect.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingSelect.jsx
@@ -2,7 +2,9 @@
 import React from "react";
 
 import cx from "classnames";
-import Select, { Option } from "metabase/core/components/Select";
+import { Option } from "metabase/core/components/Select";
+
+import { SelectWithHighlightingIcon } from "./ChartSettingSelect.styled";
 
 const ChartSettingSelect = ({
   // Use null if value is undefined. If we pass undefined, Select will create an
@@ -16,7 +18,7 @@ const ChartSettingSelect = ({
   placeholderNoOptions,
   ...props
 }) => (
-  <Select
+  <SelectWithHighlightingIcon
     className={cx(className, "block")}
     disabled={
       options.length === 0 ||
@@ -33,7 +35,7 @@ const ChartSettingSelect = ({
         {option.name}
       </Option>
     ))}
-  </Select>
+  </SelectWithHighlightingIcon>
 );
 
 export default ChartSettingSelect;

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingSelect.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingSelect.styled.tsx
@@ -1,0 +1,10 @@
+import styled from "@emotion/styled";
+import Select from "metabase/core/components/Select";
+import SelectButton from "metabase/core/components/SelectButton";
+import { color } from "metabase/lib/colors";
+
+export const SelectWithHighlightingIcon = styled(Select)`
+  ${SelectButton.Icon}:hover {
+    color: ${color("brand")};
+  }
+`;

--- a/frontend/src/metabase/visualizations/components/settings/ColumnItem.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ColumnItem.jsx
@@ -10,8 +10,9 @@ import {
   ColumnItemColorPicker,
 } from "./ColumnItem.styled";
 
-const ActionIcon = ({ icon, onClick }) => (
+const ActionIcon = ({ icon, onClick, ...props }) => (
   <ColumnItemIcon
+    data-testid={props["data-testid"]}
     onlyIcon
     icon={icon}
     iconSize={16}
@@ -52,10 +53,34 @@ const ColumnItem = ({
         )}
         <ColumnItemContent>
           <ColumnItemSpan>{title}</ColumnItemSpan>
-          {onEdit && <ActionIcon icon="ellipsis" onClick={onEdit} />}
-          {onAdd && <ActionIcon icon="add" onClick={onAdd} />}
-          {onRemove && <ActionIcon icon="eye_outline" onClick={onRemove} />}
-          {onEnable && <ActionIcon icon="eye_crossed_out" onClick={onEnable} />}
+          {onEdit && (
+            <ActionIcon
+              icon="ellipsis"
+              onClick={onEdit}
+              data-testid={`${title}-settings-button`}
+            />
+          )}
+          {onAdd && (
+            <ActionIcon
+              icon="add"
+              onClick={onAdd}
+              data-testid={`${title}-add-button`}
+            />
+          )}
+          {onRemove && (
+            <ActionIcon
+              icon="eye_outline"
+              onClick={onRemove}
+              data-testid={`${title}-hide-button`}
+            />
+          )}
+          {onEnable && (
+            <ActionIcon
+              icon="eye_crossed_out"
+              onClick={onEnable}
+              data-testid={`${title}-show-button`}
+            />
+          )}
         </ColumnItemContent>
       </ColumnItemContainer>
     </ColumnItemRoot>

--- a/frontend/src/metabase/visualizations/components/settings/ColumnItem.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ColumnItem.jsx
@@ -1,6 +1,5 @@
 /* eslint-disable react/prop-types */
 import React from "react";
-
 import {
   ColumnItemIcon,
   ColumnItemSpan,
@@ -13,7 +12,9 @@ import {
 
 const ActionIcon = ({ icon, onClick }) => (
   <ColumnItemIcon
-    name={icon}
+    onlyIcon
+    icon={icon}
+    iconSize={16}
     onClick={e => {
       e.stopPropagation();
       onClick(e.target);

--- a/frontend/src/metabase/visualizations/components/settings/ColumnItem.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ColumnItem.styled.tsx
@@ -2,6 +2,7 @@ import styled from "@emotion/styled";
 import { color } from "metabase/lib/colors";
 
 import Icon from "metabase/components/Icon";
+import Button from "metabase/core/components/Button";
 import ChartSettingColorPicker from "./ChartSettingColorPicker";
 
 interface ColumnItemRootProps {
@@ -62,13 +63,12 @@ export const ColumnItemContainer = styled.div`
   align-items: center;
 `;
 
-export const ColumnItemIcon = styled(Icon)`
+export const ColumnItemIcon = styled(Button)`
   margin-left: 1rem;
-  cursor: pointer;
-  color: ${color("text-dark")};
+  padding: 0;
 
-  &:hover {
-    color: ${color("text-medium")};
+  &:hover: {
+    background: unset;
   }
 `;
 

--- a/frontend/src/metabase/visualizations/components/settings/ColumnItem.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ColumnItem.styled.tsx
@@ -67,8 +67,8 @@ export const ColumnItemIcon = styled(Button)`
   margin-left: 1rem;
   padding: 0;
 
-  &:hover: {
-    background: unset;
+  &:hover {
+    background-color: unset;
   }
 `;
 

--- a/frontend/test/metabase/visualizations/components/settings/ChartSettingFieldsPicker.unit.spec.js
+++ b/frontend/test/metabase/visualizations/components/settings/ChartSettingFieldsPicker.unit.spec.js
@@ -1,5 +1,6 @@
 import React from "react";
-import { renderWithProviders, screen, fireEvent } from "__support__/ui";
+import userEvent from "@testing-library/user-event";
+import { renderWithProviders, screen } from "__support__/ui";
 
 import ChartSettingFieldsPicker from "metabase/visualizations/components/settings/ChartSettingFieldsPicker";
 
@@ -41,7 +42,7 @@ describe("ChartSettingFieldsPicker", () => {
     expect(screen.queryByTestId("remove-avg")).not.toBeInTheDocument();
     expect(screen.getByText("Add another series")).toBeInTheDocument();
 
-    fireEvent.click(screen.getByText("Add another series"));
+    userEvent.click(screen.getByText("Add another series"));
 
     expect(onChange).toHaveBeenCalledWith(["avg", "count"]);
   });
@@ -58,12 +59,12 @@ describe("ChartSettingFieldsPicker", () => {
       screen.getByRole("img", { name: /chevrondown/i }),
     ).toBeInTheDocument();
 
-    fireEvent.click(screen.getByText("Average of Total"));
+    userEvent.click(screen.getByText("Average of Total"));
 
     //Check to see that count is in the popover
     expect(screen.getByText("Count")).toBeInTheDocument();
 
-    fireEvent.click(screen.getByText("Count"));
+    userEvent.click(screen.getByText("Count"));
 
     expect(onChange).toHaveBeenCalledWith(["count"]);
   });

--- a/frontend/test/metabase/visualizations/components/settings/ChartSettingFieldsPicker.unit.spec.js
+++ b/frontend/test/metabase/visualizations/components/settings/ChartSettingFieldsPicker.unit.spec.js
@@ -1,0 +1,70 @@
+import React from "react";
+import { renderWithProviders, screen, fireEvent } from "__support__/ui";
+
+import ChartSettingFieldsPicker from "metabase/visualizations/components/settings/ChartSettingFieldsPicker";
+
+const DEFAULT_PROPS = {
+  options: [
+    { name: "Count", value: "count" },
+    { name: "Average of Total", value: "avg" },
+  ],
+  colors: { avg: "#A989C5", count: "#509EE3" },
+  columnHasSettings: () => true,
+  value: ["avg", "count"],
+  addAnother: "Add another series",
+};
+
+const setup = props => {
+  renderWithProviders(
+    <ChartSettingFieldsPicker {...DEFAULT_PROPS} {...props} />,
+  );
+};
+
+describe("ChartSettingFieldsPicker", () => {
+  it("Should render both options", () => {
+    setup();
+
+    expect(screen.getByText("Average of Total")).toBeInTheDocument();
+    expect(screen.getByText("Count")).toBeInTheDocument();
+
+    //Expect there to be remove icons for both
+    expect(screen.getByTestId("remove-avg")).toBeInTheDocument();
+    expect(screen.getByTestId("remove-count")).toBeInTheDocument();
+  });
+
+  it("should show you a button to add another metric if there are unused options", () => {
+    const onChange = jest.fn();
+
+    setup({ value: ["avg"], onChange });
+
+    expect(screen.getByText("Average of Total")).toBeInTheDocument();
+    expect(screen.queryByTestId("remove-avg")).not.toBeInTheDocument();
+    expect(screen.getByText("Add another series")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("Add another series"));
+
+    expect(onChange).toHaveBeenCalledWith(["avg", "count"]);
+  });
+
+  it("should allow you to change an existing metric if there are unused options", () => {
+    const onChange = jest.fn();
+
+    setup({ value: ["avg"], onChange });
+
+    expect(screen.getByText("Average of Total")).toBeInTheDocument();
+    expect(screen.queryByTestId("remove-avg")).not.toBeInTheDocument();
+    expect(screen.getByText("Add another series")).toBeInTheDocument();
+    expect(
+      screen.getByRole("img", { name: /chevrondown/i }),
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("Average of Total"));
+
+    //Check to see that count is in the popover
+    expect(screen.getByText("Count")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("Count"));
+
+    expect(onChange).toHaveBeenCalledWith(["count"]);
+  });
+});


### PR DESCRIPTION
### Description
Updating the icons in some chart settings options to use the `<Button onlyIcon />` component to help standardize hover effects and colors, as well as help them be more semantically correct (they're not clickable buttons rather than clickable icons).

Also took the opportunity to add some unit tests around a related component. Tests don't fully corelate with the change, though it does use one of the changed icons. Existing tests will cover that impacted elements still function the way they should

### How to verify
1. New Question => Orders => Count, Average of Total by Created At
2. Open Viz Settings
3. All icons used (chevron down, ellipsis, close, drag handle) should have consistent hover effects.
4. Questions with multiple dimensions should behave the same way.

### Demo
![chrome_BqJLHxUiVy](https://user-images.githubusercontent.com/1328979/222529325-5aac7747-d0da-4fc2-bcc2-11ddb1239e1d.gif)

