### PR TITLE
[CI] Do not mark JUnit reports as failed checks

### DIFF
--- a/.github/actions/test-driver/action.yml
+++ b/.github/actions/test-driver/action.yml
@@ -30,3 +30,4 @@ runs:
         reporter: java-junit
         list-suites: failed
         list-tests: failed
+        fail-on-error: false

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -146,6 +146,7 @@ jobs:
         reporter: java-junit
         list-suites: failed
         list-tests: failed
+        fail-on-error: false
 
   be-tests:
     needs: files-changed
@@ -183,6 +184,7 @@ jobs:
         reporter: java-junit
         list-suites: failed
         list-tests: failed
+        fail-on-error: false
 
   be-tests-stub:
     needs: files-changed


### PR DESCRIPTION
JUnit reports generated by `dorny/test-reporter` are not leaving stray ❌s all over the CI, every time a backend test fails in the first run. Even though we re-run the test, report doesn't get generated again.

This is a consequence of a decision to generate reports only on failure in order to reduce noise.

After this PR:
Even if the test fails, JUnit report WILL be generated but WILL NOT be marked as a failed step.