### PR TITLE
[CI] CodeQL optimization

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,7 @@
+name: "Metabase CodeQL config"
+
+paths-ignore:
+  - "**/node_modules"
+  - "frontend/test/**"
+  - "frontend/**/*.unit.*"
+  - "e2e/**"

--- a/.github/file-paths.yaml
+++ b/.github/file-paths.yaml
@@ -91,3 +91,7 @@ documentation:
 yaml:
   - "**/*.yml"
   - "**/*.yaml"
+
+codeql:
+  - "frontend/src/**"
+  - "enterprise/frontend/src/**"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,7 +8,22 @@ on:
   pull_request:
 
 jobs:
+  files-changed:
+    name: Check which files changed
+    runs-on: ubuntu-22.04
+    timeout-minutes: 3
+    outputs:
+      codeql: ${{ steps.changes.outputs.codeql }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Test which files changed
+        uses: dorny/paths-filter@v2.11.1
+        id: changes
+        with:
+          token: ${{ github.token }}
+          filters: .github/file-paths.yaml
   analyze:
+    needs: files-changed
     runs-on: ubuntu-22.04
     steps:
     - name: Checkout repository

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -17,5 +17,6 @@ jobs:
       uses: github/codeql-action/init@v2
       with:
         languages: javascript
+        config-file: ./.github/codeql/codeql-config.yml
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2


### PR DESCRIPTION
We already had false positive security reports because CodeQL was scanning JS code in tests as well. This PR fixes that part by introducing [custom CodeQL config](https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/customizing-code-scanning#using-a-custom-configuration-file). It explicitly ignores test paths [^1]

On top of this, CodeQL workflow will from now on be triggered only when a PR touches files in frontend source folder(s).
This change alone will reduce CI usage because CodeQL workflow ran for every single commit. It ran 68k times so far with the average run time of ~5m!

[^1]: Do not confuse this with `paths-ignore` in workflow file itself.