### PR TITLE
[E2E] Fix Cypress grep pre-filtering

### DIFF
--- a/e2e/support/config.js
+++ b/e2e/support/config.js
@@ -88,7 +88,7 @@ const defaultConfig = {
 
     // `grepIntegrationFolder` needs to point to the root!
     // See: https://github.com/cypress-io/cypress/issues/24452#issuecomment-1295377775
-    config.env.grepIntegrationFolder = "../";
+    config.env.grepIntegrationFolder = "../../";
     config.env.grepFilterSpecs = true;
 
     config.env.HAS_ENTERPRISE_TOKEN = hasEnterpriseToken;


### PR DESCRIPTION
This was originally fixed in https://github.com/metabase/metabase/pull/26387.
I made a regression when moving all E2E files to the root `e2e/` folder in #28749

As stated in the original fix and in the comment, `grepIntegrationFolder` needs to point to the root.

How to test?
CI run on this PR alone is a test. Because it should only find affected files and run them, instead of going through 400+ files:

This run with the fix applied (took 4 minutes):
```
  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ Cypress:        10.9.0                                                                         │
  │ Browser:        Chrome 110 (headless)                                                          │
  │ Node Version:   v16.10.0 (/opt/hostedtoolcache/node/16.10.0/x64/bin/node)                      │
  │ Specs:          8 found (embedding/embedding-premium-token.cy.spec.js, embedding/embedding-smo │
  │                 ketests.cy.spec.js, organization/moderation-collection.cy.spec.js, permissions │
  │                 /admin-permissions.cy.spec.js, sharing/subscriptions.cy.spec.js, admin/databas │
  │                 es/list.cy.spec.js, ad...)                                                     │
  │ Searched:       e2e/test/scenarios/**/*.cy.spec.js                                             │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘
```

Prior to this fix (took 30 minutes):
```
  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ Cypress:        10.9.0                                                                         │
  │ Browser:        Chrome 110 (headless)                                                          │
  │ Node Version:   v16.10.0 (/opt/hostedtoolcache/node/16.10.0/x64/bin/node)                      │
  │ Specs:          429 found (auditing/ad-hoc.cy.spec.js, auditing/approved-domains.cy.spec.js, a │
  │                 uditing/auditing.cy.spec.js, auditing/questions-audit.cy.spec.js, auditing/sub │
  │                 scriptions.cy.spec.js, binning/binning-options.cy.spec.js, binning/binning-rep │
  │                 roductions.cy.spec.js, b...)                                                   │
  │ Searched:       e2e/test/scenarios/**/*.cy.spec.js                                             │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘
```