### PR TITLE
remove own series settings limit

### DIFF
--- a/frontend/src/metabase/visualizations/lib/settings/graph.js
+++ b/frontend/src/metabase/visualizations/lib/settings/graph.js
@@ -5,6 +5,7 @@ import {
   getFriendlyName,
   getDefaultDimensionsAndMetrics,
   preserveExistingColumnsOrder,
+  MAX_SERIES,
 } from "metabase/visualizations/lib/utils";
 
 import {
@@ -105,7 +106,8 @@ export const GRAPH_DATA_SETTINGS = {
     title: t`X-axis`,
     widget: "fields",
     getMarginBottom: (series, vizSettings) =>
-      vizSettings["graph.dimensions"]?.length === 2 && series.length <= 20
+      vizSettings["graph.dimensions"]?.length === 2 &&
+      series.length <= MAX_SERIES
         ? "0.5rem"
         : "1rem",
     isValid: (series, vizSettings) =>
@@ -220,7 +222,9 @@ export const GRAPH_DATA_SETTINGS = {
       }));
     },
     getHidden: (series, settings) => {
-      return settings["graph.dimensions"]?.length < 2 || series.length > 20;
+      return (
+        settings["graph.dimensions"]?.length < 2 || series.length > MAX_SERIES
+      );
     },
     dashboard: false,
     readDependencies: ["series_settings.colors", "series_settings"],


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/28796

### Description

When revamping the visualization settings UI we added a new limit of 20 series for the series reordering widget. However, later on, we moved other series settings such as color, and title to the reordering series UI and now it is impossible to change the title of the 21st series. The maximum number of supported series is 100.

### How to verify

1. New question -> Sample Dataset -> Orders -> Summarize by Created At and Orders ID
2. Reorder X-axis dimensions so that Created At comes first and then goes Orders ID
3. Add a filter: Orders ID < 101
4. Ensure the chart renders and allows to configure settings of all 100 series
5. Change the filter to Orders ID < 102
6. Ensure the chart is not rendered and there are no series settings

### Demo

<img width="482" alt="Screen Shot 2023-03-02 at 6 38 44 PM" src="https://user-images.githubusercontent.com/14301985/222561662-fd96934b-705d-4c0e-a57f-af87777451f7.png">

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
