### PR TITLE
Better hover state for link cards

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/LinkViz/LinkViz.styled.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/LinkViz/LinkViz.styled.tsx
@@ -31,9 +31,10 @@ export const CardLink = styled(Link)`
   min-width: 0;
   gap: 0.5rem;
   align-items: center;
+  font-weight: bold;
+
   &:hover {
     color: ${color("brand")};
-    text-decoration: underline;
   }
 `;
 


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/28826

### Description

Makes text bold and not underlined when hovered

![bold](https://user-images.githubusercontent.com/30528226/222576527-3f4be529-d3b4-482f-bf50-1006265561a5.gif)

