### PR TITLE
Remove personal collections from collection detail page

### DIFF
--- a/e2e/test/scenarios/collections/collection-items-listing.cy.spec.js
+++ b/e2e/test/scenarios/collections/collection-items-listing.cy.spec.js
@@ -25,7 +25,7 @@ describe("scenarios > collection items listing", () => {
   const PAGE_SIZE = 25;
 
   describe("pagination", () => {
-    const SUBCOLLECTIONS = 2;
+    const SUBCOLLECTIONS = 1;
     const ADDED_QUESTIONS = 15;
     const ADDED_DASHBOARDS = 14;
 

--- a/e2e/test/scenarios/collections/collections.cy.spec.js
+++ b/e2e/test/scenarios/collections/collections.cy.spec.js
@@ -389,7 +389,7 @@ describe("scenarios > collection defaults", () => {
           // Select all
           cy.findByLabelText("Select all items").click();
           cy.icon("dash").should("not.exist");
-          cy.findByText("6 items selected");
+          cy.findByText("5 items selected");
 
           // Deselect all
           cy.findByLabelText("Select all items").click();

--- a/e2e/test/scenarios/collections/collections.cy.spec.js
+++ b/e2e/test/scenarios/collections/collections.cy.spec.js
@@ -412,18 +412,6 @@ describe("scenarios > collection defaults", () => {
           cy.findByText(/item(s)? selected/).should("not.be.visible");
         });
 
-        it("should not be possible to archive or move a personal collection via bulk actions", () => {
-          cy.visit("/collection/root");
-
-          selectItemUsingCheckbox(
-            getPersonalCollectionName(USERS.admin),
-            "person",
-          );
-
-          cy.findByText("1 item selected").should("be.visible");
-          cy.button("Move").should("be.disabled");
-          cy.button("Archive").should("be.disabled");
-        });
       });
 
       describe("archive", () => {

--- a/e2e/test/scenarios/collections/collections.cy.spec.js
+++ b/e2e/test/scenarios/collections/collections.cy.spec.js
@@ -375,18 +375,6 @@ describe("scenarios > collection defaults", () => {
       });
     });
 
-    it("should not be able to move or archive a personal collection", () => {
-      cy.visit("/collection/root");
-
-      openEllipsisMenuFor(getPersonalCollectionName(USERS.admin));
-
-      popover().within(() => {
-        cy.findByText("Bookmark").should("be.visible");
-        cy.findByText("Move").should("not.exist");
-        cy.findByText("Archive").should("not.exist");
-      });
-    });
-
     describe("bulk actions", () => {
       describe("selection", () => {
         it("should be possible to apply bulk selection to all items (metabase#14705)", () => {

--- a/src/metabase/models/collection.clj
+++ b/src/metabase/models/collection.clj
@@ -488,10 +488,8 @@
        (visible-collection-ids->honeysql-filter-clause :id visible-collection-ids)
        ;; it is NOT a descendant of a visible Collection other than A
        (visible-collection-ids->direct-visible-descendant-clause (hydrate collection :effective_location) visible-collection-ids)
-       ;; if it is a personal Collection, it belongs to the current User.
-       [:or
-        [:= :personal_owner_id nil]
-        [:= :personal_owner_id *current-user-id*]]]
+       ;; don't want personal collections in collection items. Only on the sidebar
+       [:= :personal_owner_id nil]]
       ;; (any additional conditions)
       additional-honeysql-where-clauses)))
 

--- a/test/metabase/api/collection_test.clj
+++ b/test/metabase/api/collection_test.clj
@@ -1260,13 +1260,13 @@
     (testing "Do top-level collections show up as children of the Root Collection?"
       (with-collection-hierarchy [a b c d e f g]
         (testing "children"
-          (is (= (map collection-item ["A" "Rasta Toucan's Personal Collection"])
+          (is (= (map collection-item ["A"])
                  (remove-non-test-collections (api-get-root-collection-children)))))))
 
     (testing "...and collapsing children should work for the Root Collection as well"
       (with-collection-hierarchy [b d e f g]
         (testing "children"
-          (is (= (map collection-item ["B" "D" "F" "Rasta Toucan's Personal Collection"])
+          (is (= (map collection-item ["B" "D" "F"])
                  (remove-non-test-collections (api-get-root-collection-children)))))))
 
     (testing "does `archived` work on Collections as well?"


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/28755

https://github.com/metabase/metabase/pull/28023 Added "sub collections" to the collection detail page. Makes sense. The problem is that personal collections started appearing in this view. We have traditionally treated personal collections as siblings to the "Our Analytics" root of collections. So this was an impedence mismatch.

This PR just removes all personal collections from the items returned from `"api/collection/root/items"`. The personal collection is still visible in the sidebar (returned from
`api/collection/tree?tree=true&exclude-other-user-collections=true&exclude-archived=true` . Furthermore, all personal collections are still visible from the "three dots" menu on the sidebar.

![image](https://user-images.githubusercontent.com/6377293/222598508-a6c0101b-4a5f-4755-a1e9-d40387c96506.png)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/28879)
<!-- Reviewable:end -->
