### PR TITLE
Makes --include-field-values and --data-model-only coexist

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/extract.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/extract.clj
@@ -47,7 +47,9 @@
   (log/tracef "Extracting Metabase with options: %s" (pr-str opts))
   (serdes.backfill/backfill-ids)
   ;; TODO document and test data-model-only if we want to keep this feature...
-  (let [models (cond-> (if data-model-only serdes.models/data-model serdes.models/exported-models)
+  (let [models (cond-> (if data-model-only
+                         (conj serdes.models/data-model "Dimension")
+                         serdes.models/exported-models)
                  (not include-field-values) (disj "FieldValues"))
         ;; This set of unowned top-level collections is used in several `extract-query` implementations.
         opts   (assoc opts :collection-set (collection-set-for-user (:user opts)))]

--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/extract.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/extract.clj
@@ -43,16 +43,12 @@
 
   Takes an options map which is passed on to [[serdes.base/extract-all]] for each model. The options are documented
   there."
-  [opts]
+  [{:keys [data-model-only include-field-values] :as opts}]
   (log/tracef "Extracting Metabase with options: %s" (pr-str opts))
   (serdes.backfill/backfill-ids)
   ;; TODO document and test data-model-only if we want to keep this feature...
-  (let [models (if (:data-model-only opts)
-                 #{"Database" "Dimension" "Field" "FieldValues" "Metric" "Segment" "Table"}
-                 (set serdes.models/exported-models))
-        models (if (:include-field-values opts)
-                 models
-                 (disj models "FieldValues"))
+  (let [models (cond-> (if data-model-only serdes.models/data-model serdes.models/exported-models)
+                 (not include-field-values) (disj "FieldValues"))
         ;; This set of unowned top-level collections is used in several `extract-query` implementations.
         opts   (assoc opts :collection-set (collection-set-for-user (:user opts)))]
     (eduction cat (for [model models]

--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/models.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/models.clj
@@ -1,20 +1,25 @@
 (ns metabase-enterprise.serialization.v2.models)
 
+(def data-model
+  "Model types which make up the data model, no user-created content."
+  #{"Database"
+    "Field"
+    "FieldValues"
+    "Metric"
+    "Segment"
+    "Table"})
+
 (def exported-models
   "The list of models which are exported by serialization. Used for production code and by tests."
-  ["Action"
+  (conj
+   data-model
+   "Action"
    "Card"
    "Collection"
    "Dashboard"
-   "Database"
-   "Field"
-   "FieldValues"
-   "Metric"
    "NativeQuerySnippet"
-   "Segment"
    "Setting"
-   "Table"
-   "Timeline"])
+   "Timeline"))
 
 (def inlined-models
   "An additional list of models which are inlined into parent entities for serialization.

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
@@ -1349,9 +1349,14 @@
                       [{:model "Card"          :id c1-1-eid  :label "question_1_1"}]
                       ;; card that the card on dashboard linked to
                       [{:model "Card"          :id c1-2-eid  :label "question_1_2"}]}
-                 (->> (extract/extract-subtrees {:targets [["Collection" coll4-id]]})
-                      (map serdes.base/serdes-path)
-                      set)))))))))
+                    (->> (extract/extract-subtrees {:targets [["Collection" coll4-id]]})
+                         (map serdes.base/serdes-path)
+                         set)))))
+
+        (testing "data-model-only"
+          (let [results (into [] (extract/extract-metabase {:data-model-only true}))]
+            (is (seq (by-model "Table" results)))
+            (is (empty? (by-model "Dashboard" results)))))))))
 
 (deftest foreign-key-field-test
   (ts/with-empty-h2-app-db


### PR DESCRIPTION
Mainly for @snoe and @luizarakaki, since the other PR was auto-merged before it should have been. This PR just allows the two options to be used together, and adds a very basic test for `--data-model-only`. I think this was the original idea, but we should probably nail it down and document/test it if it's an official feature.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/28880)
<!-- Reviewable:end -->
