### PR TITLE
[E2E] Fix embedding flake in repro #20634

### DIFF
--- a/e2e/test/scenarios/embedding/reproductions/20634-locked-parameters-in-embedded-question.cy.spec.js
+++ b/e2e/test/scenarios/embedding/reproductions/20634-locked-parameters-in-embedded-question.cy.spec.js
@@ -2,6 +2,8 @@ import { restore, visitIframe } from "e2e/support/helpers";
 
 describe("locked parameters in embedded question (metabase#20634)", () => {
   beforeEach(() => {
+    cy.intercept("PUT", "/api/card/*").as("publishChanges");
+
     restore();
     cy.signInAsAdmin();
 
@@ -46,6 +48,7 @@ describe("locked parameters in embedded question (metabase#20634)", () => {
 
       // publish the embedded question so that we can directly navigate to its url
       cy.findByText("Publish").click();
+      cy.wait("@publishChanges");
     });
 
     // directly navigate to the embedded question


### PR DESCRIPTION
This particular test was flaking badly, which corresponds to the apparent degradation of GitHub's hosted runners.

![image](https://user-images.githubusercontent.com/31325167/222700535-936daa22-d435-4722-8fbc-266bc3acdfe6.png)

Example of a failed run: https://www.deploysentinel.com/ci/runs/6401205a52fff0d49155a20d

### Cause
The request to update (publish) the card `PUT /api/card/4` didn't come back before Cypress continued. So when we signed out and visited embedded page, parameters were malformed and it just printed the error on the page `Unknown parameter :text.`

### Fix
We now explicitly wait for this `PUT` request before going further.