### PR TITLE
22788 fix custom column filter lose their settings when editing dashboards a second time

### DIFF
--- a/e2e/test/scenarios/dashboard-filters/reproductions/22788-flter-cc-dropped-on-second-edit.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/reproductions/22788-flter-cc-dropped-on-second-edit.cy.spec.js
@@ -10,6 +10,7 @@ import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 const { PRODUCTS_ID, PRODUCTS } = SAMPLE_DATABASE;
 
 const ccName = "Custom Category";
+const ccDisplayName = "Product.Custom Category";
 
 const questionDetails = {
   name: "22788",
@@ -33,7 +34,7 @@ const dashboardDetails = {
   parameters: [filter],
 };
 
-describe.skip("issue 22788", () => {
+describe("issue 22788", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();
@@ -76,7 +77,7 @@ describe.skip("issue 22788", () => {
     cy.findByText("Column to filter on")
       .parent()
       .within(() => {
-        cy.findByText(ccName);
+        cy.findByText(ccDisplayName);
       });
 
     saveDashboard();

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardCardParameterMapper.jsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardCardParameterMapper.jsx
@@ -25,6 +25,7 @@ import Question from "metabase-lib/Question";
 import { isDateParameter } from "metabase-lib/parameters/utils/parameter-type";
 import { isVariableTarget } from "metabase-lib/parameters/utils/targets";
 
+import { normalize } from "metabase-lib/queries/utils/normalize";
 import {
   getEditingParameter,
   getParameterTarget,
@@ -95,8 +96,8 @@ export function DashCardCardParameterMapper({
   const onlyAcceptsSingleValue =
     isVariableTarget(target) && !isDateParameter(editingParameter);
   const isDisabled = mappingOptions.length === 0 || isActionDashCard(dashcard);
-  const selectedMappingOption = _.find(mappingOptions, o =>
-    _.isEqual(o.target, target),
+  const selectedMappingOption = _.find(mappingOptions, option =>
+    _.isEqual(normalize(option.target), normalize(target)),
   );
 
   const handleChangeTarget = useCallback(

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardCardParameterMapper.jsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardCardParameterMapper.jsx
@@ -28,7 +28,7 @@ import { isVariableTarget } from "metabase-lib/parameters/utils/targets";
 import {
   getEditingParameter,
   getParameterTarget,
-  makeGetParameterMappingOptions,
+  getParameterMappingOptions,
 } from "../../../selectors";
 import { setParameterMapping } from "../../../actions";
 
@@ -60,7 +60,7 @@ function formatSelected({ name, sectionName }) {
 const mapStateToProps = (state, props) => ({
   editingParameter: getEditingParameter(state, props),
   target: getParameterTarget(state, props),
-  mappingOptions: makeGetParameterMappingOptions()(state, props),
+  mappingOptions: getParameterMappingOptions(state, props),
   metadata: getMetadata(state),
 });
 

--- a/frontend/src/metabase/dashboard/selectors.js
+++ b/frontend/src/metabase/dashboard/selectors.js
@@ -178,15 +178,12 @@ export const getParameters = createSelector(
   },
 );
 
-export const makeGetParameterMappingOptions = () => {
-  const getParameterMappingOptions = createSelector(
-    [getMetadata, getEditingParameter, getCard, getDashCard],
-    (metadata, parameter, card, dashcard) => {
-      return _getParameterMappingOptions(metadata, parameter, card, dashcard);
-    },
-  );
-  return getParameterMappingOptions;
-};
+export const getParameterMappingOptions = createSelector(
+  [getMetadata, getEditingParameter, getCard, getDashCard],
+  (metadata, parameter, card, dashcard) => {
+    return _getParameterMappingOptions(metadata, parameter, card, dashcard);
+  },
+);
 
 export const getDefaultParametersById = createSelector(
   [getDashboard],


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/22788

### Description
this fixes the issue where custom field parameter seems to be unselected when editing dashboard a second time. The reason is because how current Metabase lib is handling expression's MBQL. In FE, we uses `["expression", "name", null]` while in BE, we will normalize it to `["expression" "name"]`.


### How to verify

2 Ways to test this:
1. Follow the reproduce steps from https://github.com/metabase/metabase/issues/22788#issuecomment-1129239421:
2. Run Cypress tests on `22788-flter-cc-dropped-on-second-edit.cy.spec.js` and it should pass.

### Demo

These are the results from editing a dashboard that has a filter connect to a question's custom field the second time.

#### Before
<img width="532" alt="image" src="https://user-images.githubusercontent.com/1937582/222738212-1318a7a4-0495-441c-92be-f00a0d1bc210.png">


#### After
<img width="532" alt="image" src="https://user-images.githubusercontent.com/1937582/222738091-7360e10b-40e0-4c2f-955d-b8d168df094c.png">

### Checklist

- [x] Tests have been added/updated to cover changes in this PR

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/28903)
<!-- Reviewable:end -->
