### PR TITLE
add `parent_id` when initializing Collection entity to fix broken move undos

### DIFF
--- a/e2e/support/helpers/e2e-ui-elements-helpers.js
+++ b/e2e/support/helpers/e2e-ui-elements-helpers.js
@@ -30,6 +30,10 @@ export function appBar() {
   return cy.get("#root header").first();
 }
 
+export function appContent() {
+  return cy.get("main");
+}
+
 export function openNavigationSidebar() {
   appBar().findByTestId("sidebar-toggle").click();
 }

--- a/frontend/src/metabase/entities/search.js
+++ b/frontend/src/metabase/entities/search.js
@@ -63,6 +63,7 @@ export default createEntity({
           data: data
             ? data.map(item => ({
                 collection_id: canonicalCollectionId(collection),
+                parent_id: canonicalCollectionId(collection),
                 archived: archived || false,
                 ...item,
               }))


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/28860

### Description

**Problem**

Pressing "undo" after moving a collection would not actually undo the move. See "before" demo below.

**Root Cause Analysis**

Moving a collection is done by calling the `setCollection` method in the `Collections` entity. [This method sets a `parent_id` using the underlying `.actions.update` method from `entities.js`.](https://github.com/metabase/metabase/blob/e09ecdb6e89fa9ea10b4d73b727c237a78182667/frontend/src/metabase/entities/collections/collections.ts#L61)

`.actions.update` creates an `undo` object that is used to handle undoing the action. [The `undo` object is created by picking the keys from the updated object off of the original entity. ](https://github.com/metabase/metabase/blob/e09ecdb6e89fa9ea10b4d73b727c237a78182667/frontend/src/metabase/lib/entities.js#L264)The root cause of this bug is that `parent_id` is not set on nested collections (see next screenshot), thus the `undo` object is empty, and the action is not actually undone upon clicking the button.

<img width="399" alt="Screenshot 2023-03-03 at 9 29 39 AM" src="https://user-images.githubusercontent.com/37751258/222788773-070b8721-a5cf-4702-8c78-d8c42b018766.png">

**Solution**

Curiously, `collection_id` is defined on the entity (see prior screenshot) despite not being included the response from the backend (see next screenshot).

<img width="361" alt="Screenshot 2023-03-03 at 9 35 55 AM" src="https://user-images.githubusercontent.com/37751258/222789224-de2708c5-5930-43bf-a322-b9ee2b715ed3.png">

It turns out, [this is being defined in the `api.list` action of the `Search` entity.](https://github.com/metabase/metabase/blob/e09ecdb6e89fa9ea10b4d73b727c237a78182667/frontend/src/metabase/entities/search.js#L65) Thus, we can also define `parent_id` here. We set `parent_id` by calling the [`canonicalCollectionId`](https://github.com/metabase/metabase/blob/9ffd596ff036ce00d155c51184a3a05b76101861/frontend/src/metabase/collections/utils.ts#LL117C5-L117C5) method on the collection, [as this is what is being used to compute the `parent_id` for the `setCollection` (move) action](https://github.com/metabase/metabase/blob/9ffd596ff036ce00d155c51184a3a05b76101861/frontend/src/metabase/entities/collections/collections.ts#L61).

### How to verify

1. Go to any collection with collections nested inside it.
2. Use the checkboxes to select one or more nested collections.
3. Click "move", then use the modal to move the collections to another collection.
4. Press "undo" in the toast.
5. Verify the move operation was undone.

### Demo

https://user-images.githubusercontent.com/37751258/222786962-ce44105c-93c6-41f1-ac16-a0d4135da4c7.mov

Before

https://user-images.githubusercontent.com/37751258/222787021-5f10b7d2-6c14-4959-a1f6-d821f123822b.mov

After

### Checklist

- ✅ Tests have been added/updated to cover changes in this PR
