### PR TITLE
Add new design for ExpressionEditorHelpText

### DIFF
--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorHelpText.stories.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorHelpText.stories.tsx
@@ -1,11 +1,12 @@
 import React, { useRef } from "react";
 import type { ComponentStory } from "@storybook/react";
 
-import { getHelpText } from "metabase/query_builder/components/expressions/ExpressionEditorTextfield/helper-text-strings";
 import { createMockDatabase } from "metabase-types/api/mocks";
-import { HelpText } from "metabase-lib/expressions/types";
 
-import ExpressionEditorHelpText from "./ExpressionEditorHelpText";
+import { getHelpText } from "./ExpressionEditorTextfield/helper-text-strings";
+import ExpressionEditorHelpText, {
+  ExpressionEditorHelpTextProps,
+} from "./ExpressionEditorHelpText";
 
 export default {
   title: "Query Builder/ExpressionEditorHelpText",
@@ -15,14 +16,10 @@ export default {
 const Template: ComponentStory<typeof ExpressionEditorHelpText> = args => {
   const target = useRef(null);
 
-  const helpText = getHelpText(
-    "datetime-diff",
-    createMockDatabase(),
-    "UTC",
-  ) as HelpText;
+  const helpText = getHelpText("datetime-diff", createMockDatabase(), "UTC");
 
-  const props = {
-    helpText,
+  const props: ExpressionEditorHelpTextProps = {
+    helpText: helpText || null,
     width: 397,
     target,
   };

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorHelpText.stories.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorHelpText.stories.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+import type { ComponentStory } from "@storybook/react";
+
+import { getHelpText } from "metabase/query_builder/components/expressions/ExpressionEditorTextfield/helper-text-strings";
+import type { Database } from "metabase-types/api";
+import { HelpText } from "metabase-lib/expressions/types";
+import ExpressionEditorHelpText from "./ExpressionEditorHelpText";
+
+export default {
+  title: "Query Builder/ExpressionEditorHelpText",
+  component: ExpressionEditorHelpText,
+};
+
+const Template: ComponentStory<typeof ExpressionEditorHelpText> = args => {
+  const helpText = getHelpText(
+    "datetime-diff",
+    null as unknown as Database, // Database is not needed for this particular help text generator
+    "UTC",
+  ) as HelpText;
+
+  const props = {
+    helpText,
+    width: 397,
+    target: null as any,
+  };
+
+  return <ExpressionEditorHelpText {...props} />;
+};
+
+export const Default = Template;

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorHelpText.stories.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorHelpText.stories.tsx
@@ -16,10 +16,8 @@ export default {
 const Template: ComponentStory<typeof ExpressionEditorHelpText> = args => {
   const target = useRef(null);
 
-  const helpText = getHelpText("datetime-diff", createMockDatabase(), "UTC");
-
   const props: ExpressionEditorHelpTextProps = {
-    helpText: helpText || null,
+    helpText: getHelpText("datetime-diff", createMockDatabase(), "UTC"),
     width: 397,
     target,
   };

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorHelpText.stories.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorHelpText.stories.tsx
@@ -1,9 +1,10 @@
-import React from "react";
+import React, { useRef } from "react";
 import type { ComponentStory } from "@storybook/react";
 
 import { getHelpText } from "metabase/query_builder/components/expressions/ExpressionEditorTextfield/helper-text-strings";
-import type { Database } from "metabase-types/api";
+import { createMockDatabase } from "metabase-types/api/mocks";
 import { HelpText } from "metabase-lib/expressions/types";
+
 import ExpressionEditorHelpText from "./ExpressionEditorHelpText";
 
 export default {
@@ -12,16 +13,18 @@ export default {
 };
 
 const Template: ComponentStory<typeof ExpressionEditorHelpText> = args => {
+  const target = useRef(null);
+
   const helpText = getHelpText(
     "datetime-diff",
-    null as unknown as Database, // Database is not needed for this particular help text generator
+    createMockDatabase(),
     "UTC",
   ) as HelpText;
 
   const props = {
     helpText,
     width: 397,
-    target: null as any,
+    target,
   };
 
   return <ExpressionEditorHelpText {...props} />;

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorHelpText.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorHelpText.styled.tsx
@@ -1,0 +1,33 @@
+import styled from "@emotion/styled";
+import { color } from "metabase/lib/colors";
+
+export const Container = styled.div`
+  padding: 1.5rem;
+
+  font-size: 0.875rem;
+`;
+
+export const FunctionHelpCode = styled.div`
+  padding: 0.75rem 1rem 0.75rem;
+  margin: 0.5rem 0 1.5rem;
+
+  background-color: ${color("bg-light")};
+
+  color: ${color("text-dark")};
+  font-family: Monaco, monospace;
+`;
+
+export const ExampleBlock = styled.div`
+  color: ${color("text-light")};
+`;
+
+export const ExampleTitleText = styled.div`
+  margin-bottom: 0.25rem;
+
+  font-size: 0.75rem;
+  font-weight: 700;
+`;
+
+export const ExampleCode = styled.div`
+  font-family: Monaco, monospace;
+`;

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorHelpText.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorHelpText.styled.tsx
@@ -1,4 +1,5 @@
 import styled from "@emotion/styled";
+import { monospaceFontFamily } from "metabase/styled-components/theme";
 import { color } from "metabase/lib/colors";
 
 export const Container = styled.div`
@@ -14,7 +15,7 @@ export const FunctionHelpCode = styled.div`
   background-color: ${color("bg-light")};
 
   color: ${color("text-dark")};
-  font-family: Monaco, monospace;
+  font-family: ${monospaceFontFamily};
 `;
 
 export const ExampleBlock = styled.div`
@@ -29,5 +30,5 @@ export const ExampleTitleText = styled.div`
 `;
 
 export const ExampleCode = styled.div`
-  font-family: Monaco, monospace;
+  font-family: ${monospaceFontFamily};
 `;

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorHelpText.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorHelpText.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React from "react";
 import { t } from "ttag";
 import TippyPopover from "metabase/components/Popover/TippyPopover";
 import { HelpText } from "metabase-lib/expressions/types";
@@ -11,7 +11,7 @@ import {
 } from "./ExpressionEditorHelpText.styled";
 
 export interface ExpressionEditorHelpTextProps {
-  helpText: HelpText | null;
+  helpText: HelpText | undefined;
   width: number;
   target: React.RefObject<HTMLElement>;
 }
@@ -21,12 +21,6 @@ const ExpressionEditorHelpText = ({
   width,
   target,
 }: ExpressionEditorHelpTextProps) => {
-  useEffect(() => {
-    if (!helpText) {
-      console.warn('Empty "helpText" provided for ExpressionEditorHelpText');
-    }
-  }, [helpText]);
-
   if (!helpText) {
     return null;
   }

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorHelpText.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorHelpText.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { t } from "ttag";
 import TippyPopover from "metabase/components/Popover/TippyPopover";
 import { HelpText } from "metabase-lib/expressions/types";
@@ -10,8 +10,8 @@ import {
   FunctionHelpCode,
 } from "./ExpressionEditorHelpText.styled";
 
-interface ExpressionEditorHelpTextProps {
-  helpText: HelpText;
+export interface ExpressionEditorHelpTextProps {
+  helpText: HelpText | null;
   width: number;
   target: React.RefObject<HTMLElement>;
 }
@@ -21,6 +21,12 @@ const ExpressionEditorHelpText = ({
   width,
   target,
 }: ExpressionEditorHelpTextProps) => {
+  useEffect(() => {
+    if (!helpText) {
+      console.warn('Empty "helpText" provided for ExpressionEditorHelpText');
+    }
+  }, [helpText]);
+
   if (!helpText) {
     return null;
   }

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorHelpText.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorHelpText.tsx
@@ -1,13 +1,14 @@
 import React from "react";
 import { t } from "ttag";
-
-import { color } from "metabase/lib/colors";
-import MetabaseSettings from "metabase/lib/settings";
-import ExternalLink from "metabase/core/components/ExternalLink";
-import Icon from "metabase/components/Icon";
 import TippyPopover from "metabase/components/Popover/TippyPopover";
 import { HelpText } from "metabase-lib/expressions/types";
-import { getHelpDocsUrl } from "./ExpressionEditorTextfield/helper-text-strings";
+import {
+  Container,
+  ExampleBlock,
+  ExampleCode,
+  ExampleTitleText,
+  FunctionHelpCode,
+} from "./ExpressionEditorHelpText.styled";
 
 interface ExpressionEditorHelpTextProps {
   helpText: HelpText;
@@ -33,34 +34,14 @@ const ExpressionEditorHelpText = ({
       content={
         <>
           {/* Prevent stealing focus from input box causing the help text to be closed (metabase#17548) */}
-          <div onMouseDown={e => e.preventDefault()}>
-            <p
-              className="p2 m0 text-monospace text-bold"
-              style={{ background: color("bg-yellow") }}
-            >
-              {helpText.structure}
-            </p>
-            <div className="p2 border-top">
-              <p className="mt0 text-bold">{helpText.description}</p>
-              <p className="text-code m0 text-body">{helpText.example}</p>
-            </div>
-            <div className="p2 border-top">
-              {helpText.args.map(({ name, description }, index) => (
-                <div key={index}>
-                  <h4 className="text-medium">{name}</h4>
-                  <p className="mt1 text-bold">{description}</p>
-                </div>
-              ))}
-              <ExternalLink
-                className="link text-bold block my1"
-                target="_blank"
-                href={MetabaseSettings.docsUrl(getHelpDocsUrl(helpText))}
-              >
-                <Icon name="reference" size={12} className="mr1" />
-                {t`Learn more`}
-              </ExternalLink>
-            </div>
-          </div>
+          <Container onMouseDown={e => e.preventDefault()}>
+            <div>{helpText.description}</div>
+            <FunctionHelpCode>{helpText.structure}</FunctionHelpCode>
+            <ExampleBlock>
+              <ExampleTitleText>{t`Example`}</ExampleTitleText>
+              <ExampleCode>{helpText.example}</ExampleCode>
+            </ExampleBlock>
+          </Container>
         </>
       }
     />

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorHelpText.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorHelpText.tsx
@@ -13,7 +13,7 @@ import {
 interface ExpressionEditorHelpTextProps {
   helpText: HelpText;
   width: number;
-  target: Element;
+  target: React.RefObject<HTMLElement>;
 }
 
 const ExpressionEditorHelpText = ({

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorHelpText.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorHelpText.unit.spec.tsx
@@ -1,0 +1,45 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { createMockDatabase } from "metabase-types/api/mocks";
+import { getHelpText } from "./ExpressionEditorTextfield/helper-text-strings";
+import ExpressionEditorHelpText, {
+  ExpressionEditorHelpTextProps,
+} from "./ExpressionEditorHelpText";
+
+describe("ExpressionEditorHelpText", () => {
+  it("should render expression function info and example", async () => {
+    setup();
+
+    // have to wait for TippyPopover to render content
+    expect(
+      await screen.findByText("datetimeDiff(datetime1, datetime2, unit)"),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByText(
+        "Get the difference between two datetime values (datetime2 minus datetime1) using the specified unit of time.",
+      ),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByText('datetimeDiff([created_at], [shipped_at], "month")'),
+    ).toBeInTheDocument();
+  });
+});
+
+function setup(additionalProps?: Partial<ExpressionEditorHelpTextProps>) {
+  const target = { current: null };
+  const database = createMockDatabase();
+
+  const props: ExpressionEditorHelpTextProps = {
+    helpText:
+      additionalProps?.helpText ||
+      getHelpText("datetime-diff", database, "UTC") ||
+      null,
+    width: 397,
+    target,
+    ...additionalProps,
+  };
+
+  render(<ExpressionEditorHelpText {...props} />);
+}

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorHelpText.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorHelpText.unit.spec.tsx
@@ -34,8 +34,7 @@ function setup(additionalProps?: Partial<ExpressionEditorHelpTextProps>) {
   const props: ExpressionEditorHelpTextProps = {
     helpText:
       additionalProps?.helpText ||
-      getHelpText("datetime-diff", database, "UTC") ||
-      null,
+      getHelpText("datetime-diff", database, "UTC"),
     width: 397,
     target,
     ...additionalProps,

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield/helper-text-strings.ts
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield/helper-text-strings.ts
@@ -876,9 +876,3 @@ export const getHelpText = (
 
 const getNowAtTimezone = (timezone: string, reportTimezone: string) =>
   timezone ? moment().tz(reportTimezone).format("LT") : moment().format("LT");
-
-export const getHelpDocsUrl = ({ docsPage }: HelpText): string => {
-  return docsPage
-    ? `questions/query-builder/expressions/${docsPage}`
-    : "questions/query-builder/expressions";
-};

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.styled.tsx
@@ -30,6 +30,8 @@ export const FieldTitle = styled.div`
 
 export const IconWrapper = styled(IconButtonWrapper)`
   margin-left: 4px;
+
+  cursor: default;
 `;
 
 export const StyledFieldTitleIcon = styled(Icon)`


### PR DESCRIPTION
Relates to https://github.com/metabase/metabase/issues/28668

### Description

Add new layout and design for Help text popover

### How to verify

Describe the steps to verify that the changes are working as expected.

1. New question -> Sample Dataset -> Custom column
2. Write a function name, e.g. `abs`

OR

1. `yarn storybook`
2. find `ExpressionEditorHelpText` story

### Demo

<table>
<tr>
<th> Before: </th>
<th> After: </th>
</tr>
<tr>
<td>

<img width="400" alt="Screenshot 2023-03-04 at 00 31 29" src="https://user-images.githubusercontent.com/7983744/222823202-89306fa2-6692-4217-9d0b-5b1b9cddc14b.png">

</td>
<td>

<img width="400" alt="Screenshot 2023-03-04 at 00 30 34" src="https://user-images.githubusercontent.com/7983744/222823238-dbc611e6-4bbf-4c4f-a55f-0aeedc992d62.png">

</td>
</tr>
</table>

### Checklist

- [x] Updated version matches designs
- [x] Tests have been adjusted
