### PR TITLE
Normalize Link Card icon sizes and spacing

### DIFF
--- a/frontend/src/metabase-types/api/dashboard.ts
+++ b/frontend/src/metabase-types/api/dashboard.ts
@@ -86,7 +86,6 @@ export type UnrestrictedLinkEntity = {
   display_name?: string;
   description?: string;
   display?: CardDisplayType;
-  getIcon?: () => { name: string };
 };
 
 export type RestrictedLinkEntity = {

--- a/frontend/src/metabase-types/api/dashboard.ts
+++ b/frontend/src/metabase-types/api/dashboard.ts
@@ -86,6 +86,7 @@ export type UnrestrictedLinkEntity = {
   display_name?: string;
   description?: string;
   display?: CardDisplayType;
+  getIcon?: () => { name: string };
 };
 
 export type RestrictedLinkEntity = {

--- a/frontend/src/metabase/visualizations/visualizations/LinkViz/EntityDisplay.styled.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/LinkViz/EntityDisplay.styled.tsx
@@ -1,7 +1,5 @@
 import styled from "@emotion/styled";
 
-import Icon from "metabase/components/Icon";
-
 export const EntityDisplayContainer = styled.div`
   width: 100%;
   display: flex;
@@ -15,8 +13,5 @@ export const LeftContainer = styled.div`
   width: 100%;
   display: flex;
   align-items: center;
-`;
-
-export const IconWithHorizontalMargin = styled(Icon)`
-  margin: 0 1rem;
+  gap: 1rem;
 `;

--- a/frontend/src/metabase/visualizations/visualizations/LinkViz/EntityDisplay.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/LinkViz/EntityDisplay.tsx
@@ -1,20 +1,15 @@
 import React from "react";
 import { t } from "ttag";
 
-import type { LinkEntity } from "metabase-types/api";
+import type { LinkEntity, UnrestrictedLinkEntity } from "metabase-types/api";
 import { isRestrictedLinkEntity } from "metabase-types/guards/dashboard";
 
 import Ellipsified from "metabase/core/components/Ellipsified";
 import Icon from "metabase/components/Icon";
-import { ItemIcon } from "metabase/search/components/SearchResult";
-
 import { color } from "metabase/lib/colors";
+import { isEmpty } from "metabase/lib/validate";
 
-import {
-  EntityDisplayContainer,
-  LeftContainer,
-  IconWithHorizontalMargin,
-} from "./EntityDisplay.styled";
+import { EntityDisplayContainer, LeftContainer } from "./EntityDisplay.styled";
 
 export const EntityDisplay = ({
   entity,
@@ -23,11 +18,11 @@ export const EntityDisplay = ({
   entity: LinkEntity;
   showDescription?: boolean;
 }) => {
-  if (isRestrictedLinkEntity(entity)) {
+  if (entity && isRestrictedLinkEntity(entity)) {
     return (
       <EntityDisplayContainer>
         <LeftContainer>
-          <IconWithHorizontalMargin name="key" color={color("text-light")} />
+          <Icon name="key" color={color("text-light")} />
           <Ellipsified>{t`Sorry, you don't have permission to see this link.`}</Ellipsified>
         </LeftContainer>
       </EntityDisplayContainer>
@@ -37,7 +32,7 @@ export const EntityDisplay = ({
   return (
     <EntityDisplayContainer>
       <LeftContainer>
-        <ItemIcon item={entity} type={entity?.model} active />
+        <Icon color={color("brand")} name={getSearchIconName(entity)} />
         <Ellipsified>{entity?.name}</Ellipsified>
       </LeftContainer>
       {showDescription && entity?.description && (
@@ -50,3 +45,27 @@ export const EntityDisplay = ({
     </EntityDisplayContainer>
   );
 };
+
+export const UrlLinkDisplay = ({ url }: { url?: string }) => {
+  const urlIcon = isEmpty(url) ? "question" : "link";
+
+  return (
+    <EntityDisplayContainer>
+      <LeftContainer>
+        <Icon color={color("brand")} name={urlIcon} />
+        <Ellipsified>{!isEmpty(url) ? url : t`Choose a link`}</Ellipsified>
+      </LeftContainer>
+    </EntityDisplayContainer>
+  );
+};
+
+function getSearchIconName(entity: UnrestrictedLinkEntity) {
+  const entityIcon = entity.getIcon?.() ?? { name: "link" };
+
+  // we need to change this icon to make it match the icon in the search results
+  if (entity.model === "table") {
+    entityIcon.name = "database";
+  }
+
+  return entityIcon.name;
+}

--- a/frontend/src/metabase/visualizations/visualizations/LinkViz/EntityDisplay.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/LinkViz/EntityDisplay.tsx
@@ -1,34 +1,21 @@
 import React from "react";
 import { t } from "ttag";
 
-import type { LinkEntity, UnrestrictedLinkEntity } from "metabase-types/api";
-import { isRestrictedLinkEntity } from "metabase-types/guards/dashboard";
-
 import Ellipsified from "metabase/core/components/Ellipsified";
 import Icon from "metabase/components/Icon";
 import { color } from "metabase/lib/colors";
 import { isEmpty } from "metabase/lib/validate";
 
 import { EntityDisplayContainer, LeftContainer } from "./EntityDisplay.styled";
+import { WrappedUnrestrictedLinkEntity } from "./types";
 
 export const EntityDisplay = ({
   entity,
   showDescription = false,
 }: {
-  entity: LinkEntity;
+  entity: WrappedUnrestrictedLinkEntity;
   showDescription?: boolean;
 }) => {
-  if (entity && isRestrictedLinkEntity(entity)) {
-    return (
-      <EntityDisplayContainer>
-        <LeftContainer>
-          <Icon name="key" color={color("text-light")} />
-          <Ellipsified>{t`Sorry, you don't have permission to see this link.`}</Ellipsified>
-        </LeftContainer>
-      </EntityDisplayContainer>
-    );
-  }
-
   return (
     <EntityDisplayContainer>
       <LeftContainer>
@@ -46,7 +33,17 @@ export const EntityDisplay = ({
   );
 };
 
+export const RestrictedEntityDisplay = () => (
+  <EntityDisplayContainer>
+    <LeftContainer>
+      <Icon name="key" color={color("text-light")} />
+      <Ellipsified>{t`Sorry, you don't have permission to see this link.`}</Ellipsified>
+    </LeftContainer>
+  </EntityDisplayContainer>
+);
+
 export const UrlLinkDisplay = ({ url }: { url?: string }) => {
+  // show a question mark icon for the empty state
   const urlIcon = isEmpty(url) ? "question" : "link";
 
   return (
@@ -59,7 +56,7 @@ export const UrlLinkDisplay = ({ url }: { url?: string }) => {
   );
 };
 
-function getSearchIconName(entity: UnrestrictedLinkEntity) {
+function getSearchIconName(entity: WrappedUnrestrictedLinkEntity) {
   const entityIcon = entity.getIcon?.() ?? { name: "link" };
 
   // we need to change this icon to make it match the icon in the search results

--- a/frontend/src/metabase/visualizations/visualizations/LinkViz/LinkViz.styled.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/LinkViz/LinkViz.styled.tsx
@@ -13,7 +13,7 @@ export const DisplayLinkCardWrapper = styled.div`
 `;
 
 export const EditLinkCardWrapper = styled.div`
-  padding: 0.5rem;
+  padding: 0.5rem 1rem;
   display: flex;
   flex-direction: column;
   justify-content: center;

--- a/frontend/src/metabase/visualizations/visualizations/LinkViz/LinkViz.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/LinkViz/LinkViz.tsx
@@ -15,7 +15,11 @@ import { useToggle } from "metabase/hooks/use-toggle";
 import Search from "metabase/entities/search";
 
 import { isRestrictedLinkEntity } from "metabase-types/guards/dashboard";
-import { EntityDisplay, UrlLinkDisplay } from "./EntityDisplay";
+import {
+  EntityDisplay,
+  UrlLinkDisplay,
+  RestrictedEntityDisplay,
+} from "./EntityDisplay";
 import { settings } from "./LinkVizSettings";
 
 import {
@@ -26,6 +30,7 @@ import {
 } from "./LinkViz.styled";
 
 import { isUrlString } from "./utils";
+import { WrappedUnrestrictedLinkEntity } from "./types";
 
 const MODELS_TO_SEARCH = [
   "card",
@@ -93,12 +98,12 @@ function LinkViz({
     if (isRestrictedLinkEntity(entity)) {
       return (
         <EditLinkCardWrapper>
-          <EntityDisplay entity={entity} />
+          <RestrictedEntityDisplay />
         </EditLinkCardWrapper>
       );
     }
 
-    const wrappedEntity = Search.wrapEntity({
+    const wrappedEntity: WrappedUnrestrictedLinkEntity = Search.wrapEntity({
       ...entity,
       database_id: entity.db_id ?? entity.database_id,
       table_id: entity.model === "table" ? entity.id : undefined,

--- a/frontend/src/metabase/visualizations/visualizations/LinkViz/LinkViz.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/LinkViz/LinkViz.tsx
@@ -1,12 +1,9 @@
 import React, { useState, useEffect } from "react";
 import { usePrevious } from "react-use";
 
-import { t } from "ttag";
-
 import Input from "metabase/core/components/Input";
 import SearchResults from "metabase/nav/components/SearchResults";
 import TippyPopover from "metabase/components/Popover/TippyPopover";
-import Ellipsified from "metabase/core/components/Ellipsified";
 
 import type {
   DashboardOrderedCard,
@@ -17,10 +14,8 @@ import type {
 import { useToggle } from "metabase/hooks/use-toggle";
 import Search from "metabase/entities/search";
 
-import { isEmpty } from "metabase/lib/validate";
-
 import { isRestrictedLinkEntity } from "metabase-types/guards/dashboard";
-import { EntityDisplay } from "./EntityDisplay";
+import { EntityDisplay, UrlLinkDisplay } from "./EntityDisplay";
 import { settings } from "./LinkVizSettings";
 
 import {
@@ -28,7 +23,6 @@ import {
   DisplayLinkCardWrapper,
   CardLink,
   SearchResultsContainer,
-  BrandIconWithHorizontalMargin,
 } from "./LinkViz.styled";
 
 import { isUrlString } from "./utils";
@@ -160,13 +154,10 @@ function LinkViz({
     );
   }
 
-  const urlIcon = isEmpty(url) ? "question" : "link";
-
   return (
     <DisplayLinkCardWrapper>
       <CardLink to={url ?? ""} target="_blank" rel="noreferrer">
-        <BrandIconWithHorizontalMargin name={urlIcon} />
-        <Ellipsified>{!isEmpty(url) ? url : t`Choose a link`}</Ellipsified>
+        <UrlLinkDisplay url={url} />
       </CardLink>
     </DisplayLinkCardWrapper>
   );

--- a/frontend/src/metabase/visualizations/visualizations/LinkViz/types.ts
+++ b/frontend/src/metabase/visualizations/visualizations/LinkViz/types.ts
@@ -1,0 +1,9 @@
+import { UnrestrictedLinkEntity } from "metabase-types/api";
+
+type WrappedEntity = {
+  getIcon: () => { name: string };
+  getUrl: () => string;
+};
+
+export type WrappedUnrestrictedLinkEntity = UnrestrictedLinkEntity &
+  WrappedEntity;


### PR DESCRIPTION
resolves https://github.com/metabase/metabase/issues/28857

### Description

In this issue, my chickens came home to roost. Namely, I took a shortcut with original implementation of entity icons, which _almost_ paid off: I just imported the `ItemIcon` component from the `SearchResult` component, and boom! done! right?

Wrong. It turns out, the `SearchResults` icons are doing a little internal resizing magic to make them look just right in that component, and up-sizing them to 20px, and _sometimes_ adds some extra padding. The file icon is the worst offender here. The 20px icon size was forcing entity links lower in the card than link cards.

This removes the shortcut implementation, makes all link icons 16px, uses a dedicated component and unified colors and spacing for link icons, which I probably should have done in the first place.

. | .
---|---
Before  | ![Screen Shot 2023-03-03 at 2 23 20 PM](https://user-images.githubusercontent.com/30528226/222836108-5496c789-8ea7-487c-a5eb-7c27a0486060.png)
After | ![Screen Shot 2023-03-03 at 2 25 19 PM](https://user-images.githubusercontent.com/30528226/222836106-fc3987f6-d01c-4df0-afee-d61086c87336.png)
### How to verify

- open a dashboard
- add two link cards: one with an external url, and another to a metabase entity
- put them next to each other
- make your browser window pretty short (less than 700 px)
- see that the icons and text are still centered vertically.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
