### PR TITLE
Changed positioning on Input Button to always vertically align center

### DIFF
--- a/frontend/src/metabase/core/components/Input/Input.styled.tsx
+++ b/frontend/src/metabase/core/components/Input/Input.styled.tsx
@@ -110,10 +110,11 @@ type InputButtonProps = {
 
 export const InputButton = styled(IconButtonWrapper)<InputButtonProps>`
   position: absolute;
+  top: 50%;
+  transform: translateY(50%);
   color: ${props => color(props.onClick != null ? "text-dark" : "text-light")};
   padding: ${props => (props.size === "small" ? "0.5rem" : "0.75rem")};
   border-radius: 50%;
-  bottom: ${props => (props.size === "large" ? "0.125rem" : 0)};
 
   &:disabled {
     cursor: default;


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/27523

### Description

Setting TransformY and top position always vertically aligns icon to center no matter size of Icon or container.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. New Question
2. Sample Database -> Orders
3. Join to Products
4. Summarize with Count to Created At: Month and Products → Category
5. Visualize
6. Choose On

### Demo
Before: 
<img width="485" alt="Screen Shot 2023-03-05 at 4 36 52 PM" src="https://user-images.githubusercontent.com/89173284/222984820-bdb99a1a-0161-49e8-8953-02aaa1bcf8eb.png">

After:
<img width="453" alt="Screen Shot 2023-03-05 at 4 38 51 PM" src="https://user-images.githubusercontent.com/89173284/222984823-8f323560-78f0-4367-ab5a-156816f191b6.png">

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/28934)
<!-- Reviewable:end -->
