### PR TITLE
Chartsettings use custom column names

### DIFF
--- a/frontend/src/metabase-lib/queries/StructuredQuery.ts
+++ b/frontend/src/metabase-lib/queries/StructuredQuery.ts
@@ -1257,14 +1257,17 @@ class StructuredQueryInner extends AtomicQuery {
 
     const table = this.table();
 
+    console.log(this.sourceTable());
+
     if (table) {
       const dimensionIsFKReference = dimension => dimension.field?.().isFK();
 
       const filteredNonFKDimensions = this.dimensions().filter(dimensionFilter);
 
       for (const dimension of filteredNonFKDimensions) {
+        console.log("pushing dimension, ", dimension);
         dimensionOptions.count++;
-        dimensionOptions.dimensions.push(dimension);
+        dimensionOptions.dimensions.push(dimension.withJoinAlias());
       }
 
       // de-duplicate explicit and implicit joined tables

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingColumnEditor.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingColumnEditor.tsx
@@ -34,7 +34,7 @@ interface ChartSettingColumnEditorProps {
   isDashboard?: boolean;
   metadata?: Metadata;
   isQueryRunning: boolean;
-  getCustomColumnName: (val: DatasetColumn) => string;
+  getCustomColumnName: (val: DatasetColumn, onlyCustom: boolean) => string;
 }
 
 const structuredQueryFieldOptions = (
@@ -204,12 +204,9 @@ const ChartSettingColumnEditor = ({
     // This ensures that we get the {table}→{column} syntax when appropriate. On anything other than the
     // Source table, there should be a table header above the list so we should only show the field name.
     if (column) {
-      const customName = getCustomColumnName(column);
-      if (customName) {
-        return customName;
-      } else if (sourceTable) {
-        return column.display_name;
-      }
+      return (
+        getCustomColumnName(column, !sourceTable) || dimension.displayName()
+      );
     }
 
     return dimension.displayName();

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingColumnEditor.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingColumnEditor.tsx
@@ -34,7 +34,7 @@ interface ChartSettingColumnEditorProps {
   isDashboard?: boolean;
   metadata?: Metadata;
   isQueryRunning: boolean;
-  getItemTitle: (val: DatasetColumn) => string;
+  getCustomColumnName: (val: DatasetColumn) => string;
 }
 
 const structuredQueryFieldOptions = (
@@ -104,7 +104,7 @@ const ChartSettingColumnEditor = ({
   isDashboard,
   metadata,
   isQueryRunning,
-  getItemTitle,
+  getCustomColumnName,
 }: ChartSettingColumnEditorProps) => {
   const fieldOptions = useMemo(() => {
     const query = question && question.query();
@@ -204,7 +204,7 @@ const ChartSettingColumnEditor = ({
     // This ensures that we get the {table}→{column} syntax when appropriate. On anything other than the
     // Source table, there should be a table header above the list so we should only show the field name.
     if (column) {
-      const customName = getItemTitle(column);
+      const customName = getCustomColumnName(column);
       if (customName) {
         return customName;
       } else if (sourceTable) {

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingColumnEditor.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingColumnEditor.tsx
@@ -48,6 +48,8 @@ const structuredQueryFieldOptions = (
       [] as Dimension[],
     ),
   );
+
+  console.log(allFields.map(f => f.column()));
   const missingDimensions = columns
     .filter(
       column =>
@@ -64,6 +66,7 @@ const structuredQueryFieldOptions = (
     )
     .filter(isNotNull);
 
+  console.log(missingDimensions.map(f => f.column()));
   return {
     name: query.sourceTable()?.display_name || t`Columns`,
     dimensions: options.dimensions.concat(missingDimensions).filter(isNotNull),

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingColumnEditor.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingColumnEditor.tsx
@@ -34,6 +34,7 @@ interface ChartSettingColumnEditorProps {
   isDashboard?: boolean;
   metadata?: Metadata;
   isQueryRunning: boolean;
+  getItemTitle: (val: DatasetColumn) => string;
 }
 
 const structuredQueryFieldOptions = (
@@ -103,6 +104,7 @@ const ChartSettingColumnEditor = ({
   isDashboard,
   metadata,
   isQueryRunning,
+  getItemTitle,
 }: ChartSettingColumnEditorProps) => {
   const fieldOptions = useMemo(() => {
     const query = question && question.query();
@@ -201,8 +203,13 @@ const ChartSettingColumnEditor = ({
     // When we have a colum returned, we want to use that display name as long as it's part of the source table
     // This ensures that we get the {table}→{column} syntax when appropriate. On anything other than the
     // Source table, there should be a table header above the list so we should only show the field name.
-    if (column && sourceTable) {
-      return column.display_name;
+    if (column) {
+      const customName = getItemTitle(column);
+      if (customName) {
+        return customName;
+      } else if (sourceTable) {
+        return column.display_name;
+      }
     }
 
     return dimension.displayName();

--- a/frontend/src/metabase/visualizations/visualizations/Table.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Table.jsx
@@ -279,14 +279,14 @@ export default class Table extends Component {
         isDashboard: extra.isDashboard,
         metadata: extra.metadata,
         isQueryRunning: extra.isQueryRunning,
-        getCustomColumnName: column => {
-          const customName = getIn(vizSettings, [
-            "column_settings",
-            getColumnKey(column),
-            "column_title",
-          ]);
-
-          return customName;
+        getCustomColumnName: (column, onlyCustom) => {
+          return onlyCustom
+            ? getIn(vizSettings, [
+                "column_settings",
+                getColumnKey(column),
+                "column_title",
+              ])
+            : getColumnNameFromSettings(vizSettings, column);
         },
       }),
     },

--- a/frontend/src/metabase/visualizations/visualizations/Table.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Table.jsx
@@ -280,6 +280,7 @@ export default class Table extends Component {
         metadata: extra.metadata,
         isQueryRunning: extra.isQueryRunning,
         getCustomColumnName: (column, onlyCustom) => {
+          console.log(vizSettings);
           return onlyCustom
             ? getIn(vizSettings, [
                 "column_settings",

--- a/frontend/test/metabase/scenarios/binning/binning-reproductions.cy.spec.js
+++ b/frontend/test/metabase/scenarios/binning/binning-reproductions.cy.spec.js
@@ -188,7 +188,7 @@ describe("binning related reproductions", () => {
     cy.findByText("Hour of Day");
   });
 
-  it("shouldn't duplicate the breakout field (metabase#22382)", () => {
+  it.only("shouldn't duplicate the breakout field (metabase#22382)", () => {
     const questionDetails = {
       name: "22382",
       query: {
@@ -206,7 +206,7 @@ describe("binning related reproductions", () => {
 
     cy.findByTestId("sidebar-left").within(() => {
       cy.findByText("Add or remove columns").click();
-      cy.findByText("Created At").click();
+      cy.findByText("Created At: Month").click();
       cy.button("Done").click();
     });
 

--- a/frontend/test/metabase/scenarios/joins/joins.cy.spec.js
+++ b/frontend/test/metabase/scenarios/joins/joins.cy.spec.js
@@ -199,7 +199,7 @@ describe("scenarios > question > joined questions", () => {
     cy.findByText("Sum Divide");
   });
 
-  it("should join saved questions that themselves contain joins (metabase#12928)", () => {
+  it.only("should join saved questions that themselves contain joins (metabase#12928)", () => {
     cy.intercept("GET", "/api/table/card__*/query_metadata").as(
       "cardQueryMetadata",
     );


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/28935

### Description
Updated the `ChartSettingOrderedColums` component to accept a getColumnName function. This function uses the same logic that the Table Viz does to render it's column titles

### How to verify

Describe the steps to verify that the changes are working as expected.

1. New question -> Sample Dataset -> Orders -> Visualize
2. Open columns settings and change the name of a column
3. The new column name should be displayed in chart settings

### Demo
Before updating name:
![image](https://user-images.githubusercontent.com/1328979/222991876-bec9b4c5-f80f-471f-8ea1-d5f235ad2602.png)

After updating name: 
![image](https://user-images.githubusercontent.com/1328979/222991954-f99d88ae-20ed-451f-8787-b479e8ddeb51.png)


### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
