### PR TITLE
Fix flaky switch project id test for bigquery

### DIFF
--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
@@ -267,33 +267,11 @@
               ;; make sure all the fields for taxi_tips were synced
               (is (= 23 (db/count Field :table_id (u/the-id tbl))))))
           (testing " for querying"
-            (is (= ["ff0b96c0cada768361b1c9341e11905254644afb"
-                    "c7fd753040e0170e38049465089bca99c750f5ed8b3f6c547b303057ec23be36b9b86790fe417bb5949d980892460a2732a28a515bb805cf967bf4cf4b44b074"
-                    "2016-09-20T07:15:00Z"
-                    "2016-09-20T07:30:00Z"
-                    1265
-                    7.2
-                    nil
-                    nil
-                    nil
-                    nil
-                    0.01
-                    0.0
-                    nil
-                    0.0
-                    0.01
-                    "Cash"
-                    "303 Taxi"
-                    nil
-                    nil
-                    nil
-                    nil
-                    nil
-                    nil]
-                   (mt/first-row
-                     (mt/run-mbql-query taxi_trips
-                       {:filter [:= [:field (mt/id :taxi_trips :unique_key) nil]
-                                    "ff0b96c0cada768361b1c9341e11905254644afb"]})))))
+            (is (= 23
+                   (count (mt/first-row
+                            (mt/run-mbql-query taxi_trips
+                              {:filter [:= [:field (mt/id :taxi_trips :payment_type) nil]
+                                           "Cash"]}))))))
           (testing " has project-id-from-credentials set correctly"
             (is (= (bigquery-project-id) (get-in temp-db [:details :project-id-from-credentials])))))))))
 
@@ -347,7 +325,7 @@
                 :fields #{{:name "int_col", :database-type "INTEGER", :base-type :type/Integer, :database-position 0}
                           {:name "array_col", :database-type "INTEGER", :base-type :type/Array, :database-position 1}}}
                (driver/describe-table :bigquery-cloud-sdk (mt/db) {:name tbl-nm, :schema "v3_test_data"}))
-               "`describe-table` should detect the correct base-type for array type columns")))))
+            "`describe-table` should detect the correct base-type for array type columns")))))
 
 (deftest sync-inactivates-old-duplicate-tables
   (testing "If on the new driver, then downgrade, then upgrade again (#21981)"

--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
@@ -271,7 +271,8 @@
                    (count (mt/first-row
                             (mt/run-mbql-query taxi_trips
                               {:filter [:= [:field (mt/id :taxi_trips :payment_type) nil]
-                                           "Cash"]}))))))
+                                           "Cash"]
+                               :limit  1}))))))
           (testing " has project-id-from-credentials set correctly"
             (is (= (bigquery-project-id) (get-in temp-db [:details :project-id-from-credentials])))))))))
 


### PR DESCRIPTION
Fix the flaky test `metabase.driver.bigquery-cloud-sdk-test/project-id-override-test`
[Failed run](https://github.com/metabase/metabase/actions/runs/4340992162/jobs/7581031327)

For why it flakes see https://github.com/metabase/metabase/pull/27837 for more details.

It seems like the id change over time so it'll continue to flake if we use it.
Change it to filter by `payment_type` so it's guaranteed to return a row and we could just check if it returns enough columns.