### PR TITLE
Fixes notebook editor not working for pivot questions until results are loaded

### DIFF
--- a/e2e/test/scenarios/question/reproductions/28874-notebook-pivot.cy.spec.js
+++ b/e2e/test/scenarios/question/reproductions/28874-notebook-pivot.cy.spec.js
@@ -21,7 +21,7 @@ const questionDetails = {
   },
 };
 
-describe.skip("issue 28874", () => {
+describe("issue 28874", () => {
   beforeEach(() => {
     restore();
     cy.signInAsNormalUser();

--- a/e2e/test/scenarios/question/reproductions/28874-notebook-pivot.cy.spec.js
+++ b/e2e/test/scenarios/question/reproductions/28874-notebook-pivot.cy.spec.js
@@ -1,0 +1,39 @@
+import { restore, visitQuestionAdhoc } from "e2e/support/helpers";
+import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
+import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
+
+const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
+
+const questionDetails = {
+  name: "28874",
+  display: "pivot",
+  dataset_query: {
+    database: SAMPLE_DB_ID,
+    type: "query",
+    query: {
+      "source-table": ORDERS_ID,
+      aggregation: [["count"]],
+      breakout: [
+        ["field", ORDERS.CREATED_AT, { "temporal-unit": "year" }],
+        ["field", ORDERS.PRODUCT_ID, null],
+      ],
+    },
+  },
+};
+
+describe.skip("issue 28874", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsNormalUser();
+  });
+
+  it("should allow to modify a pivot question in the notebook (metabase#28874)", () => {
+    visitQuestionAdhoc(questionDetails, { mode: "notebook" });
+
+    cy.findByText("Product ID")
+      .parent()
+      .within(() => cy.icon("close").click());
+
+    cy.findByText("Product ID").should("not.exist");
+  });
+});

--- a/frontend/src/metabase/query_builder/actions/core/updateQuestion.ts
+++ b/frontend/src/metabase/query_builder/actions/core/updateQuestion.ts
@@ -169,12 +169,15 @@ export const updateQuestion = (
       if (isPivot && hasBreakouts) {
         const key = "pivot_table.column_split";
         const rawSeries = getRawSeries(getState()) as Series;
-        const series = assocIn(rawSeries, [0, "card"], newQuestion.card());
-        const setting = getQuestionWithDefaultVisualizationSettings(
-          newQuestion,
-          series,
-        ).setting(key);
-        newQuestion = newQuestion.updateSettings({ [key]: setting });
+
+        if (rawSeries) {
+          const series = assocIn(rawSeries, [0, "card"], newQuestion.card());
+          const setting = getQuestionWithDefaultVisualizationSettings(
+            newQuestion,
+            series,
+          ).setting(key);
+          newQuestion = newQuestion.updateSettings({ [key]: setting });
+        }
       }
 
       run = checkShouldRerunPivotTableQuestion({


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/28874
Reproduces https://github.com/metabase/metabase/issues/28874

How to test:
- Run the new test
- The test should fail without the changes in this PR and pass otherwise

The root cause seems to be that there is an implicit dependency on query results being loaded before the notebook is opened for **pivot** questions.

<img width="1175" alt="Screenshot 2023-03-06 at 14 06 19" src="https://user-images.githubusercontent.com/8542534/223105927-c2b4ed3f-99af-4e96-8d9a-af5d9d9bd157.png">

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/28945)
<!-- Reviewable:end -->
