### PR TITLE
Bind *card-id* when executing a dashboard subscription to fix perm checks

### DIFF
--- a/e2e/test/scenarios/sharing/reproductions/18009-nodata-creates-subscription-receives-error.cy.spec.js
+++ b/e2e/test/scenarios/sharing/reproductions/18009-nodata-creates-subscription-receives-error.cy.spec.js
@@ -6,7 +6,7 @@ import {
   sendEmailAndAssert,
 } from "e2e/support/helpers";
 
-describe.skip("issue 18009", { tags: "@external" }, () => {
+describe("issue 18009", { tags: "@external" }, () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();

--- a/src/metabase/pulse.clj
+++ b/src/metabase/pulse.clj
@@ -24,7 +24,6 @@
    [metabase.pulse.util :as pu]
    [metabase.query-processor :as qp]
    [metabase.query-processor.dashboard :as qp.dashboard]
-   [metabase.query-processor.middleware.permissions :as qp.perms]
    [metabase.query-processor.timezone :as qp.timezone]
    [metabase.server.middleware.session :as mw.session]
    [metabase.util :as u]
@@ -62,20 +61,19 @@
   (try
     (let [card-id (u/the-id card-or-id)
           card    (db/select-one Card :id card-id)
-          result  (binding [qp.perms/*card-id* card-id]
-                   (qp.dashboard/run-query-for-dashcard-async
-                    :dashboard-id  (u/the-id dashboard)
-                    :card-id       card-id
-                    :dashcard-id   (u/the-id dashcard)
-                    :context       :pulse ; TODO - we should support for `:dashboard-subscription` and use that to differentiate the two
-                    :export-format :api
-                    :parameters    parameters
-                    :middleware    {:process-viz-settings? true
-                                    :js-int-to-string?     false}
-                    :run           (fn [query info]
-                                     (qp/process-query-and-save-with-max-results-constraints!
-                                      (assoc query :async? false)
-                                      info))))]
+          result  (qp.dashboard/run-query-for-dashcard-async
+                   :dashboard-id  (u/the-id dashboard)
+                   :card-id       card-id
+                   :dashcard-id   (u/the-id dashcard)
+                   :context       :pulse ; TODO - we should support for `:dashboard-subscription` and use that to differentiate the two
+                   :export-format :api
+                   :parameters    parameters
+                   :middleware    {:process-viz-settings? true
+                                   :js-int-to-string?     false}
+                   :run           (fn [query info]
+                                    (qp/process-query-and-save-with-max-results-constraints!
+                                     (assoc query :async? false)
+                                     info)))]
       {:card     card
        :dashcard dashcard
        :result   result})

--- a/src/metabase/pulse.clj
+++ b/src/metabase/pulse.clj
@@ -9,7 +9,9 @@
    [metabase.integrations.slack :as slack]
    [metabase.models.card :refer [Card]]
    [metabase.models.dashboard :refer [Dashboard]]
-   [metabase.models.dashboard-card :as dashboard-card :refer [DashboardCard]]
+   [metabase.models.dashboard-card
+    :as dashboard-card
+    :refer [DashboardCard]]
    [metabase.models.database :refer [Database]]
    [metabase.models.interface :as mi]
    [metabase.models.pulse :as pulse :refer [Pulse]]
@@ -22,6 +24,7 @@
    [metabase.pulse.util :as pu]
    [metabase.query-processor :as qp]
    [metabase.query-processor.dashboard :as qp.dashboard]
+   [metabase.query-processor.middleware.permissions :as qp.perms]
    [metabase.query-processor.timezone :as qp.timezone]
    [metabase.server.middleware.session :as mw.session]
    [metabase.util :as u]
@@ -59,19 +62,20 @@
   (try
     (let [card-id (u/the-id card-or-id)
           card    (db/select-one Card :id card-id)
-          result  (qp.dashboard/run-query-for-dashcard-async
-                     :dashboard-id  (u/the-id dashboard)
-                     :card-id       card-id
-                     :dashcard-id   (u/the-id dashcard)
-                     :context       :pulse ; TODO - we should support for `:dashboard-subscription` and use that to differentiate the two
-                     :export-format :api
-                     :parameters    parameters
-                     :middleware    {:process-viz-settings? true
-                                     :js-int-to-string?     false}
-                     :run           (fn [query info]
-                                      (qp/process-query-and-save-with-max-results-constraints!
-                                       (assoc query :async? false)
-                                       info)))]
+          result  (binding [qp.perms/*card-id* card-id]
+                   (qp.dashboard/run-query-for-dashcard-async
+                    :dashboard-id  (u/the-id dashboard)
+                    :card-id       card-id
+                    :dashcard-id   (u/the-id dashcard)
+                    :context       :pulse ; TODO - we should support for `:dashboard-subscription` and use that to differentiate the two
+                    :export-format :api
+                    :parameters    parameters
+                    :middleware    {:process-viz-settings? true
+                                    :js-int-to-string?     false}
+                    :run           (fn [query info]
+                                     (qp/process-query-and-save-with-max-results-constraints!
+                                      (assoc query :async? false)
+                                      info))))]
       {:card     card
        :dashcard dashcard
        :result   result})

--- a/src/metabase/query_processor/card.clj
+++ b/src/metabase/query_processor/card.clj
@@ -189,8 +189,7 @@
                   ;; customize the `context` passed to the QP
                   (^:once fn* [query info]
                    (qp.streaming/streaming-response [context export-format (u/slugify (:card-name info))]
-                     (binding [qp.perms/*card-id* card-id]
-                       (qp-runner query info context)))))
+                                                    (qp-runner query info context))))
         card  (api/read-check (db/select-one [Card :id :name :dataset_query :database_id
                                               :cache_ttl :collection_id :dataset :result_metadata]
                                              :id card-id))
@@ -211,4 +210,5 @@
       (validate-card-parameters card-id (mbql.normalize/normalize-fragment [:parameters] parameters)))
     (log/tracef "Running query for Card %d:\n%s" card-id
                 (u/pprint-to-str query))
-    (run query info)))
+    (binding [qp.perms/*card-id* card-id]
+     (run query info))))

--- a/test/metabase/dashboard_subscription_test.clj
+++ b/test/metabase/dashboard_subscription_test.clj
@@ -638,11 +638,11 @@
           original-native-perm (get-in (perms/data-perms-graph) native-perm-path)]
       (try
         (mt/with-temp* [Dashboard [{dashboard-id :id, :as dashboard} {:name "Dashboard"}]
-                        Card      [{card-id :id} {:name "Products (SQL)"
-                                                  :dataset_query (mt/native-query {:query
-                                                                                   "SELECT * FROM venues LIMIT 1"})}]
+                        Card      [{card-id :id} {:name          "Products (SQL)"
+                                                  :dataset_query (mt/native-query
+                                                                  {:query "SELECT * FROM venues LIMIT 1"})}]
                         DashboardCard [_ {:dashboard_id dashboard-id
-                                          :card_id     card-id}]]
+                                          :card_id      card-id}]]
           (perms/update-data-perms-graph! (assoc-in (perms/data-perms-graph) native-perm-path :none))
           (is (= [[1 "Red Medicine" 4 10.0646 -165.374 3]]
                  (-> (@#'metabase.pulse/execute-dashboard {:creator_id (mt/user->id :rasta)} dashboard)

--- a/test/metabase/dashboard_subscription_test.clj
+++ b/test/metabase/dashboard_subscription_test.clj
@@ -4,15 +4,17 @@
    [metabase.models
     :refer [Card
             Collection
-            Database
             Dashboard
             DashboardCard
+            Database
             Pulse
             PulseCard
             PulseChannel
             PulseChannelRecipient
             Table
             User]]
+   [metabase.models.permissions :as perms]
+   [metabase.models.permissions-group :as perms-group]
    [metabase.models.pulse :as pulse]
    [metabase.public-settings :as public-settings]
    [metabase.pulse]
@@ -628,6 +630,30 @@
                                       :visualization_settings {:text "{{foo}}"}}]]
       (is (= [{:text "Doohickey and Gizmo"}]
              (@#'metabase.pulse/execute-dashboard {:creator_id (mt/user->id :rasta)} dashboard))))))
+
+(deftest no-native-perms-test
+  (testing "A native query on a dashboard executes succesfully even if the subscription creator does not have native
+           query permissions (#28947)"
+    (try
+      (mt/with-temp* [Dashboard [{dashboard-id :id, :as dashboard} {:name "Dashboard"}]
+                      Card      [{card-id :id} {:name "Products (SQL)"
+                                                :dataset_query (mt/native-query {:query
+                                                                                 "SELECT * FROM venues LIMIT 1"})}]
+                      DashboardCard [_ {:dashboard_id dashboard-id
+                                        :card_id     card-id}]]
+        (perms/update-data-perms-graph! (assoc-in (perms/data-perms-graph)
+                                                  [:groups (u/the-id (perms-group/all-users)) (mt/id) :data :native]
+                                                  :none))
+        (is (= [[1 "Red Medicine" 4 10.0646 -165.374 3]]
+               (-> (@#'metabase.pulse/execute-dashboard {:creator_id (mt/user->id :rasta)} dashboard)
+                   first
+                   :result
+                   :data
+                   :rows))))
+      (finally
+        (perms/update-data-perms-graph! (assoc-in (perms/data-perms-graph)
+                                                  [:groups (u/the-id (perms-group/all-users)) (mt/id) :data :native]
+                                                  :write))))))
 
 (deftest actions-are-skipped-test
   (testing "Actions should be filtered out"

--- a/test/metabase/models/permissions_test.clj
+++ b/test/metabase/models/permissions_test.clj
@@ -872,8 +872,8 @@
   (is (= :non-scoped      (perms/classify-path "/application/monitoring/")))
 
   (is (= :query-v2        (perms/classify-path "/query/db/0/native/")))
-  (is (= :data-v2         (perms/classify-path "/data/db/3/schema/something/table/3/")))
-  )
+  (is (= :data-v2         (perms/classify-path "/data/db/3/schema/something/table/3/"))))
+
 
 (deftest data-permissions-classify-path
   (is (= :data (perms/classify-path "/db/3/")))


### PR DESCRIPTION
Resolves https://github.com/metabase/metabase/issues/28947

When executing a card in a dashboard subscription, `qp.perms/*card-id*` wasn't been bound to the card's ID. This meant that the QP permission check was treating it as an ad-hoc native query rather than a saved question, and thus requiring native query perms to execute.

It's a simple fix to bind `*card-id*` before executing the query. Also added a test for this scenario which didn't exist before.