### PR TITLE
Fix dashboard filter values coercion for actions

### DIFF
--- a/e2e/support/helpers/e2e-dragndrop-helpers.js
+++ b/e2e/support/helpers/e2e-dragndrop-helpers.js
@@ -1,0 +1,39 @@
+// Rely on native drag events, rather than on the coordinates
+// We have 3 "drag-handles" in this test. Their indexes are 0-based.
+export function dragField(startIndex, dropIndex) {
+  cy.get(".Icon-grabber2").should("be.visible").as("dragHandle");
+
+  const BUTTON_INDEX = 0;
+  const SLOPPY_CLICK_THRESHOLD = 10;
+  cy.get("@dragHandle")
+    .eq(dropIndex)
+    .then($target => {
+      const coordsDrop = $target[0].getBoundingClientRect();
+      cy.get("@dragHandle")
+        .eq(startIndex)
+        .then(subject => {
+          const coordsDrag = subject[0].getBoundingClientRect();
+          cy.wrap(subject)
+            .trigger("mousedown", {
+              button: BUTTON_INDEX,
+              clientX: coordsDrag.x,
+              clientY: coordsDrag.y,
+              force: true,
+            })
+            .trigger("mousemove", {
+              button: BUTTON_INDEX,
+              clientX: coordsDrag.x + SLOPPY_CLICK_THRESHOLD,
+              clientY: coordsDrag.y,
+              force: true,
+            });
+          cy.get("body")
+            .trigger("mousemove", {
+              button: BUTTON_INDEX,
+              clientX: coordsDrop.x,
+              clientY: coordsDrop.y,
+              force: true,
+            })
+            .trigger("mouseup");
+        });
+    });
+}

--- a/e2e/support/helpers/index.js
+++ b/e2e/support/helpers/index.js
@@ -12,6 +12,7 @@ export * from "./e2e-notebook-helpers";
 export * from "./e2e-cloud-helpers";
 export * from "./e2e-collection-helpers";
 export * from "./e2e-data-model-helpers";
+export * from "./e2e-dragndrop-helpers";
 export * from "./e2e-misc-helpers";
 export * from "./e2e-email-helpers";
 export * from "./e2e-ldap-helpers";

--- a/e2e/test/scenarios/visualizations/pivot_tables.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/pivot_tables.cy.spec.js
@@ -6,6 +6,7 @@ import {
   visitQuestion,
   visitDashboard,
   visitIframe,
+  dragField,
 } from "e2e/support/helpers";
 
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
@@ -991,46 +992,6 @@ function dragColumnHeader(el, xDistance = 50) {
       })
       .trigger("mouseup");
   });
-}
-
-// Rely on native drag events, rather than on the coordinates
-// We have 3 "drag-handles" in this test. Their indexes are 0-based.
-function dragField(startIndex, dropIndex) {
-  cy.get(".Icon-grabber2").should("be.visible").as("dragHandle");
-
-  const BUTTON_INDEX = 0;
-  const SLOPPY_CLICK_THRESHOLD = 10;
-  cy.get("@dragHandle")
-    .eq(dropIndex)
-    .then($target => {
-      const coordsDrop = $target[0].getBoundingClientRect();
-      cy.get("@dragHandle")
-        .eq(startIndex)
-        .then(subject => {
-          const coordsDrag = subject[0].getBoundingClientRect();
-          cy.wrap(subject)
-            .trigger("mousedown", {
-              button: BUTTON_INDEX,
-              clientX: coordsDrag.x,
-              clientY: coordsDrag.y,
-              force: true,
-            })
-            .trigger("mousemove", {
-              button: BUTTON_INDEX,
-              clientX: coordsDrag.x + SLOPPY_CLICK_THRESHOLD,
-              clientY: coordsDrag.y,
-              force: true,
-            });
-          cy.get("body")
-            .trigger("mousemove", {
-              button: BUTTON_INDEX,
-              clientX: coordsDrop.x,
-              clientY: coordsDrop.y,
-              force: true,
-            })
-            .trigger("mouseup");
-        });
-    });
 }
 
 function getIframeBody(selector = "iframe") {

--- a/frontend/src/metabase/actions/components/ActionViz/Action.tsx
+++ b/frontend/src/metabase/actions/components/ActionViz/Action.tsx
@@ -84,13 +84,13 @@ export function ActionComponent({
 
   const onSubmit = useCallback(
     (parameterMap: ParametersForActionExecution) => {
+      const action = dashcard.action;
+      const fieldSettings =
+        action?.visualization_settings?.fields ||
+        generateFieldSettingsFromParameters(action?.parameters ?? []);
+
       const params = {
-        ...setNumericValues(
-          dashcardParamValues,
-          generateFieldSettingsFromParameters(
-            dashcard?.action?.parameters ?? [],
-          ),
-        ),
+        ...setNumericValues(dashcardParamValues, fieldSettings),
         ...parameterMap,
       };
 


### PR DESCRIPTION
Closes #28951

### Description

Fixes dashboard filter values connected to numeric action parameters were not coerced to numbers before submitting the form. That was causing type mismatch errors.

### How to verify

1. Having a sample Postgres/MySQL database with actions enabled connected to Metabase
2. Create a GUI model from the products table
3. Create an action doing `UPDATE products SET category = {{ category }} WHERE id = {{ id }}` (set the ID parameter type to "number")
4. Create a new dashboard, add a products table, an ID dashboard filter, and the new action to it. Connect the ID filter to the ID action parameter
5. Fill in a product ID into the filter and hit Enter
6. Click the action button, and fill in a new product category (e.g. Gadget)
7. Click "Run", the action should change the category

### Demo

**Before**

https://user-images.githubusercontent.com/17258145/223203022-2b03c3e0-9036-4ea2-830c-e05054183bff.mp4

**After**

https://user-images.githubusercontent.com/17258145/223203047-eeebd8f2-be19-4f36-be1b-25b379bf82a6.mp4

### Checklist

- [x] Tests have been added/updated to cover changes in this PR

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/28963)
<!-- Reviewable:end -->
