### PR TITLE
28668 Add expression function arguments interactivity

### DIFF
--- a/e2e/support/helpers/e2e-misc-helpers.js
+++ b/e2e/support/helpers/e2e-misc-helpers.js
@@ -261,3 +261,14 @@ export function visitPublicDashboard(id) {
     },
   );
 }
+
+/**
+ * Returns a matcher function to find text content that is broken up by multiple elements
+ *
+ * @param {string} textToFind
+ * @example
+ * cy.findByText(getBrokenUpTextMatcher("my text with a styled word"))
+ */
+export function getBrokenUpTextMatcher(textToFind) {
+  return (content, element) => element.textContent === textToFind
+}

--- a/e2e/support/helpers/e2e-misc-helpers.js
+++ b/e2e/support/helpers/e2e-misc-helpers.js
@@ -270,5 +270,5 @@ export function visitPublicDashboard(id) {
  * cy.findByText(getBrokenUpTextMatcher("my text with a styled word"))
  */
 export function getBrokenUpTextMatcher(textToFind) {
-  return (content, element) => element.textContent === textToFind
+  return (content, element) => element?.textContent === textToFind
 }

--- a/e2e/test/scenarios/custom-column/cc-help-text.cy.spec.js
+++ b/e2e/test/scenarios/custom-column/cc-help-text.cy.spec.js
@@ -2,6 +2,7 @@ import {
   enterCustomColumnDetails,
   restore,
   openProductsTable,
+  getBrokenUpTextMatcher,
 } from "e2e/support/helpers";
 
 describe("scenarios > question > custom column > help text", () => {
@@ -15,12 +16,12 @@ describe("scenarios > question > custom column > help text", () => {
 
   it("should appear while inside a function", () => {
     enterCustomColumnDetails({ formula: "Lower(" });
-    cy.findByText("lower(text)");
+    cy.findByText(getBrokenUpTextMatcher("lower(text)"));
   });
 
   it("should appear after a field reference", () => {
     enterCustomColumnDetails({ formula: "Lower([Category]" });
-    cy.findByText("lower(text)");
+    cy.findByText(getBrokenUpTextMatcher("lower(text)"));
   });
 
   it("should not appear while outside a function", () => {

--- a/e2e/test/scenarios/custom-column/cc-typing-suggestion.cy.spec.js
+++ b/e2e/test/scenarios/custom-column/cc-typing-suggestion.cy.spec.js
@@ -1,5 +1,6 @@
 import {
   enterCustomColumnDetails,
+  getBrokenUpTextMatcher,
   openProductsTable,
   restore,
 } from "e2e/support/helpers";
@@ -47,5 +48,22 @@ describe("scenarios > question > custom column > typing suggestion", () => {
     enterCustomColumnDetails({ formula: "LOW{enter}" });
 
     cy.contains("lower(");
+  });
+
+  it("should show expression function helper if a proper function is typed", () => {
+    enterCustomColumnDetails({ formula: "lower(" });
+
+    cy.findByText(getBrokenUpTextMatcher("lower(text)")).should("be.visible");
+    cy.findByText("Returns the string of text in all lower case.").should(
+      "be.visible",
+    );
+    cy.findByText("lower([Status])").should("be.visible");
+
+    cy.findByTestId("expression-helper-popover-arguments")
+      .findByText("text")
+      .realHover();
+    cy.findByText("The column with values to convert to lower case.").should(
+      "be.visible",
+    );
   });
 });

--- a/e2e/test/scenarios/custom-column/cc-typing-suggestion.cy.spec.js
+++ b/e2e/test/scenarios/custom-column/cc-typing-suggestion.cy.spec.js
@@ -62,6 +62,7 @@ describe("scenarios > question > custom column > typing suggestion", () => {
     cy.findByTestId("expression-helper-popover-arguments")
       .findByText("text")
       .realHover();
+
     cy.findByText("The column with values to convert to lower case.").should(
       "be.visible",
     );

--- a/frontend/src/metabase-lib/expressions/types.ts
+++ b/frontend/src/metabase-lib/expressions/types.ts
@@ -13,7 +13,6 @@ export interface HelpTextConfig {
   name: string;
   args: HelpTextArg[];
   description: (database: Database, reportTimezone: string) => string;
-  example: string;
   structure: string;
   docsPage?: string;
 }
@@ -21,4 +20,5 @@ export interface HelpTextConfig {
 export interface HelpTextArg {
   name: string;
   description: string;
+  example: string;
 }

--- a/frontend/src/metabase-lib/expressions/types.ts
+++ b/frontend/src/metabase-lib/expressions/types.ts
@@ -2,7 +2,7 @@ import type { Database } from "metabase-types/api/database";
 
 export interface HelpText {
   name: string;
-  args: HelpTextArg[];
+  args?: HelpTextArg[]; // no args means that expression function doesn't accept any parameters, e.g. "CumulativeCount"
   description: string;
   example: string;
   structure: string;
@@ -11,7 +11,7 @@ export interface HelpText {
 
 export interface HelpTextConfig {
   name: string;
-  args: HelpTextArg[];
+  args?: HelpTextArg[]; // no args means that expression function doesn't accept any parameters, e.g. "CumulativeCount"
   description: (database: Database, reportTimezone: string) => string;
   structure: string;
   docsPage?: string;

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorHelpText.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorHelpText.styled.tsx
@@ -18,6 +18,10 @@ export const FunctionHelpCode = styled.div`
   font-family: ${monospaceFontFamily};
 `;
 
+export const FunctionHelpCodeArgument = styled.span`
+  color: ${color("brand")};
+`;
+
 export const ExampleBlock = styled.div`
   color: ${color("text-light")};
 `;

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorHelpText.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorHelpText.tsx
@@ -1,13 +1,16 @@
 import React from "react";
 import { t } from "ttag";
 import TippyPopover from "metabase/components/Popover/TippyPopover";
+import Tooltip from "metabase/core/components/Tooltip";
 import { HelpText } from "metabase-lib/expressions/types";
+import { HELPER_TEXT_ARGUMENTS_PLACEHOLDER } from "./ExpressionEditorTextfield/helper-text-strings";
 import {
   Container,
   ExampleBlock,
   ExampleCode,
   ExampleTitleText,
   FunctionHelpCode,
+  FunctionHelpCodeArgument,
 } from "./ExpressionEditorHelpText.styled";
 
 export interface ExpressionEditorHelpTextProps {
@@ -25,6 +28,11 @@ const ExpressionEditorHelpText = ({
     return null;
   }
 
+  const { description, structure, args } = helpText;
+  const [leftText, rightText = ""] = structure.split(
+    HELPER_TEXT_ARGUMENTS_PLACEHOLDER,
+  );
+
   return (
     <TippyPopover
       maxWidth={width}
@@ -35,8 +43,19 @@ const ExpressionEditorHelpText = ({
         <>
           {/* Prevent stealing focus from input box causing the help text to be closed (metabase#17548) */}
           <Container onMouseDown={e => e.preventDefault()}>
-            <div>{helpText.description}</div>
-            <FunctionHelpCode>{helpText.structure}</FunctionHelpCode>
+            <div>{description}</div>
+            <FunctionHelpCode>
+              {leftText}
+              {args.map(({ name, description }, index) => (
+                <span key={name}>
+                  <Tooltip tooltip={description} placement="bottom-start">
+                    <FunctionHelpCodeArgument>{name}</FunctionHelpCodeArgument>
+                  </Tooltip>
+                  {index + 1 < args.length && ", "}
+                </span>
+              ))}
+              {rightText}
+            </FunctionHelpCode>
             <ExampleBlock>
               <ExampleTitleText>{t`Example`}</ExampleTitleText>
               <ExampleCode>{helpText.example}</ExampleCode>

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorHelpText.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorHelpText.tsx
@@ -42,9 +42,12 @@ const ExpressionEditorHelpText = ({
       content={
         <>
           {/* Prevent stealing focus from input box causing the help text to be closed (metabase#17548) */}
-          <Container onMouseDown={e => e.preventDefault()}>
+          <Container
+            onMouseDown={e => e.preventDefault()}
+            data-testid="expression-helper-popover"
+          >
             <div>{description}</div>
-            <FunctionHelpCode>
+            <FunctionHelpCode data-testid="expression-helper-popover-arguments">
               {leftText}
               {args.map(({ name, description }, index) => (
                 <span key={name}>

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorHelpText.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorHelpText.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import { t } from "ttag";
 import TippyPopover from "metabase/components/Popover/TippyPopover";
 import Tooltip from "metabase/core/components/Tooltip";
-import { isNotNull } from "metabase/core/utils/types";
 import { HelpText } from "metabase-lib/expressions/types";
 import {
   Container,
@@ -46,16 +45,22 @@ const ExpressionEditorHelpText = ({
             <div>{description}</div>
             <FunctionHelpCode data-testid="expression-helper-popover-arguments">
               {structure}
-              {isNotNull(args) && "("}
-              {args?.map(({ name, description }, index) => (
-                <span key={name}>
-                  <Tooltip tooltip={description} placement="bottom-start">
-                    <FunctionHelpCodeArgument>{name}</FunctionHelpCodeArgument>
-                  </Tooltip>
-                  {index + 1 < args.length && ", "}
-                </span>
-              ))}
-              {isNotNull(args) && ")"}
+              {args != null && (
+                <>
+                  (
+                  {args.map(({ name, description }, index) => (
+                    <span key={name}>
+                      <Tooltip tooltip={description} placement="bottom-start">
+                        <FunctionHelpCodeArgument>
+                          {name}
+                        </FunctionHelpCodeArgument>
+                      </Tooltip>
+                      {index + 1 < args.length && ", "}
+                    </span>
+                  ))}
+                  )
+                </>
+              )}
             </FunctionHelpCode>
             <ExampleBlock>
               <ExampleTitleText>{t`Example`}</ExampleTitleText>

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorHelpText.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorHelpText.tsx
@@ -2,8 +2,8 @@ import React from "react";
 import { t } from "ttag";
 import TippyPopover from "metabase/components/Popover/TippyPopover";
 import Tooltip from "metabase/core/components/Tooltip";
+import { isNotNull } from "metabase/core/utils/types";
 import { HelpText } from "metabase-lib/expressions/types";
-import { HELPER_TEXT_ARGUMENTS_PLACEHOLDER } from "./ExpressionEditorTextfield/helper-text-strings";
 import {
   Container,
   ExampleBlock,
@@ -29,9 +29,6 @@ const ExpressionEditorHelpText = ({
   }
 
   const { description, structure, args } = helpText;
-  const [leftText, rightText = ""] = structure.split(
-    HELPER_TEXT_ARGUMENTS_PLACEHOLDER,
-  );
 
   return (
     <TippyPopover
@@ -48,8 +45,9 @@ const ExpressionEditorHelpText = ({
           >
             <div>{description}</div>
             <FunctionHelpCode data-testid="expression-helper-popover-arguments">
-              {leftText}
-              {args.map(({ name, description }, index) => (
+              {structure}
+              {isNotNull(args) && "("}
+              {args?.map(({ name, description }, index) => (
                 <span key={name}>
                   <Tooltip tooltip={description} placement="bottom-start">
                     <FunctionHelpCodeArgument>{name}</FunctionHelpCodeArgument>
@@ -57,7 +55,7 @@ const ExpressionEditorHelpText = ({
                   {index + 1 < args.length && ", "}
                 </span>
               ))}
-              {rightText}
+              {isNotNull(args) && ")"}
             </FunctionHelpCode>
             <ExampleBlock>
               <ExampleTitleText>{t`Example`}</ExampleTitleText>

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorHelpText.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorHelpText.unit.spec.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { getBrokenUpTextMatcher } from "__support__/ui";
 import { createMockDatabase } from "metabase-types/api/mocks";
 import { getHelpText } from "./ExpressionEditorTextfield/helper-text-strings";
 import ExpressionEditorHelpText, {
@@ -26,8 +27,7 @@ describe("ExpressionEditorHelpText", () => {
 
     expect(
       screen.getByText(
-        (content, element) =>
-          element.textContent === "datetimeDiff(datetime1, datetime2, unit)",
+        getBrokenUpTextMatcher("datetimeDiff(datetime1, datetime2, unit)"),
       ),
     ).toBeInTheDocument();
 
@@ -54,7 +54,7 @@ describe("ExpressionEditorHelpText", () => {
       "expression-helper-popover-arguments",
     );
 
-    helpText?.args.forEach(({ name, description }) => {
+    helpText?.args?.forEach(({ name, description }) => {
       const argumentEl = within(argumentsCodeBlock).getByText(name);
 
       expect(argumentEl).toBeInTheDocument();

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorHelpText.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorHelpText.unit.spec.tsx
@@ -8,7 +8,7 @@ import ExpressionEditorHelpText, {
   ExpressionEditorHelpTextProps,
 } from "./ExpressionEditorHelpText";
 
-const database = createMockDatabase();
+const DATABASE = createMockDatabase();
 
 describe("ExpressionEditorHelpText", () => {
   it("should render expression function info and example", async () => {
@@ -38,10 +38,34 @@ describe("ExpressionEditorHelpText", () => {
     ).toBeInTheDocument();
   });
 
+  it("should handle expression function without arguments", async () => {
+    setup({ helpText: getHelpText("cum-count", DATABASE, "UTC") });
+
+    // have to wait for TippyPopover to render content
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("expression-helper-popover"),
+      ).toBeInTheDocument();
+    });
+
+    expect(screen.getAllByText("CumulativeCount")).toHaveLength(2);
+
+    const exampleCodeEl = screen.getByTestId(
+      "expression-helper-popover-arguments",
+    );
+    expect(
+      within(exampleCodeEl).getByText("CumulativeCount"),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByText("The additive total of rows across a breakout."),
+    ).toBeInTheDocument();
+  });
+
   it("should render function arguments with tooltip", async () => {
     const {
       props: { helpText },
-    } = setup({ helpText: getHelpText("concat", database, "UTC") });
+    } = setup({ helpText: getHelpText("concat", DATABASE, "UTC") });
 
     // have to wait for TippyPopover to render content
     await waitFor(() => {
@@ -72,7 +96,7 @@ function setup(additionalProps?: Partial<ExpressionEditorHelpTextProps>) {
   const props: ExpressionEditorHelpTextProps = {
     helpText:
       additionalProps?.helpText ||
-      getHelpText("datetime-diff", database, "UTC"),
+      getHelpText("datetime-diff", DATABASE, "UTC"),
     width: 397,
     target,
     ...additionalProps,

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield/helper-text-strings.ts
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield/helper-text-strings.ts
@@ -490,7 +490,7 @@ const helperTextStrings: HelpTextConfig[] = [
       },
       {
         name: t`unit`,
-        description: t`Choose from: "year", "month", "week", "day", "hour", "minute", or "second".`,
+        description: t`Choose from: ${"year"}, ${"quarter"}, ${"month"}, ${"week"}, ${"day"}, ${"hour"}, ${"minute"}, ${"second"}, or ${"millisecond"}.`,
         example: formatStringLiteral("month"),
       },
     ],
@@ -597,7 +597,7 @@ const helperTextStrings: HelpTextConfig[] = [
       },
       {
         name: t`text`,
-        description: t`Type of interval like "day", "month", "year".`,
+        description: t`Type of interval like ${"day"}, ${"month"}, ${"year"}.`,
         example: formatStringLiteral("day"),
       },
     ],
@@ -620,7 +620,7 @@ const helperTextStrings: HelpTextConfig[] = [
       },
       {
         name: t`text`,
-        description: t`Type of interval like "day", "month", "year".`,
+        description: t`Type of interval like ${"day"}, ${"month"}, ${"year"}.`,
         example: formatStringLiteral("month"),
       },
     ],
@@ -637,7 +637,7 @@ const helperTextStrings: HelpTextConfig[] = [
       },
       {
         name: t`text`,
-        description: t`Type of interval like "day", "month", "year".`,
+        description: t`Type of interval like ${"day"}, ${"month"}, ${"year"}.`,
         example: formatStringLiteral("day"),
       },
     ],
@@ -860,7 +860,7 @@ const helperTextStrings: HelpTextConfig[] = [
       },
       {
         name: t`unit`,
-        description: t`"year", "month", "quarter", "day", "hour", "minute", "second" or "millisecond".`,
+        description: t`Choose from: ${"year"}, ${"quarter"}, ${"month"}, ${"week"}, ${"day"}, ${"hour"}, ${"minute"}, ${"second"}, or ${"millisecond"}.`,
         example: formatStringLiteral("month"),
       },
     ],
@@ -884,7 +884,7 @@ const helperTextStrings: HelpTextConfig[] = [
       },
       {
         name: t`unit`,
-        description: t`"year", "month", "quarter", "day", "hour", "minute", "second" or "millisecond".`,
+        description: t`Choose from: ${"year"}, ${"quarter"}, ${"month"}, ${"week"}, ${"day"}, ${"hour"}, ${"minute"}, ${"second"}, or ${"millisecond"}.`,
         example: formatStringLiteral("month"),
       },
     ],

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield/helper-text-strings.ts
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield/helper-text-strings.ts
@@ -21,683 +21,747 @@ const getDescriptionForNow = (database: Database, reportTimezone: string) => {
   }
 };
 
+export const HELPER_TEXT_ARGUMENTS_PLACEHOLDER = "$args";
+const argsPlaceholder = HELPER_TEXT_ARGUMENTS_PLACEHOLDER;
+
 const helperTextStrings: HelpTextConfig[] = [
   {
     name: "count",
     structure: "Count",
     description: () => t`Returns the count of rows in the selected data.`,
-    example: "Count",
     args: [],
   },
   {
     name: "cum-count",
     structure: "CumulativeCount",
     description: () => t`The additive total of rows across a breakout.`,
-    example: "CumulativeCount",
     args: [],
   },
   {
     name: "sum",
-    structure: "Sum(" + t`column` + ")",
+    structure: `Sum(${argsPlaceholder})`,
     description: () => t`Adds up all the values of the column.`,
-    example: "Sum([" + t`Subtotal` + "])",
-    args: [{ name: t`column`, description: t`The column or number to sum.` }],
+    args: [
+      {
+        name: t`column`,
+        description: t`The column or number to sum.`,
+        example: "[" + t`Subtotal` + "]",
+      },
+    ],
   },
   {
     name: "cum-sum",
-    structure: "CumulativeSum(" + t`column` + ")",
+    structure: `CumulativeSum(${argsPlaceholder})`,
     description: () => t`The rolling sum of a column across a breakout.`,
-    example: "CumulativeSum([" + t`Subtotal` + "])",
-    args: [{ name: t`column`, description: t`The column or number to sum.` }],
+    args: [
+      {
+        name: t`column`,
+        description: t`The column or number to sum.`,
+        example: "[" + t`Subtotal` + "]",
+      },
+    ],
   },
   {
     name: "distinct",
-    structure: "Distinct(" + t`column` + ")",
+    structure: `Distinct(${argsPlaceholder})`,
     description: () => t`The number of distinct values in this column.`,
-    example: "Distinct([" + t`Last Name` + "])",
     args: [
       {
         name: t`column`,
         description: t`The column whose distinct values to count.`,
+        example: "[" + t`Last Name` + "]",
       },
     ],
   },
   {
     name: "stddev",
-    structure: "StandardDeviation(" + t`column` + ")",
+    structure: `StandardDeviation(${argsPlaceholder})`,
     description: () => t`Calculates the standard deviation of the column.`,
-    example: "StandardDeviation([" + t`Population` + "])",
     args: [
       {
         name: t`column`,
         description: t`The numeric column to get standard deviation of.`,
+        example: "[" + t`Population` + "]",
       },
     ],
   },
   {
     name: "avg",
-    structure: "Average(" + t`column` + ")",
+    structure: `Average(${argsPlaceholder})`,
     description: () => t`Returns the average of the values in the column.`,
-    example: "Average([" + t`Quantity` + "])",
     args: [
       {
         name: t`column`,
         description: t`The numeric column whose values to average.`,
+        example: "[" + t`Quantity` + "]",
       },
     ],
   },
   {
     name: "median",
-    structure: "Median(" + t`column` + ")",
+    structure: `Median(${argsPlaceholder})`,
     description: () => t`Returns the median of all the values of a column.`,
-    example: "Median([" + t`Quantity` + "])",
     args: [
       {
         name: t`column`,
         description: t`The numeric column whose values to average.`,
+        example: "[" + t`Quantity` + "]",
       },
     ],
   },
   {
     name: "min",
-    structure: "Min(" + t`column` + ")",
+    structure: `Min(${argsPlaceholder})`,
     description: () => t`Returns the smallest value found in the column`,
-    example: "Min([" + t`Salary` + "])",
     args: [
       {
         name: t`column`,
         description: t`The numeric column whose minimum you want to find.`,
+        example: "[" + t`Salary` + "]",
       },
     ],
   },
   {
     name: "max",
-    structure: "Max(" + t`column` + ")",
+    structure: `Max(${argsPlaceholder})`,
     description: () => t`Returns the largest value found in the column.`,
-    example: "Max([" + t`Age` + "])",
     args: [
       {
         name: t`column`,
         description: t`The numeric column whose maximum you want to find.`,
+        example: "[" + t`Age` + "]",
       },
     ],
   },
   {
     name: "share",
-    structure: "Share(" + t`condition` + ")",
+    structure: `Share(${argsPlaceholder})`,
     description: () =>
       t`Returns the percent of rows in the data that match the condition, as a decimal.`,
-    example: "Share([" + t`Source` + '] = "' + t`Google` + '")',
     args: [
       {
         name: t`condition`,
         description: t`Something that should evaluate to true or false.`,
+        example: "[" + t`Source` + '] = "' + t`Google` + '"',
       },
     ],
   },
   {
     name: "count-where",
-    structure: "CountIf(" + t`condition` + ")",
+    structure: `CountIf(${argsPlaceholder})`,
     description: () => t`Only counts rows where the condition is true.`,
-    example: "CountIf([" + t`Subtotal` + "] > 100)",
     args: [
       {
         name: t`condition`,
         description: t`Something that should evaluate to true or false.`,
+        example: "[" + t`Subtotal` + "] > 100",
       },
     ],
   },
   {
     name: "sum-where",
-    structure: "SumIf(" + t`column` + ", " + t`condition` + ")",
+    structure: `SumIf(${argsPlaceholder})`,
     description: () =>
       t`Sums up the specified column only for rows where the condition is true.`,
-    example:
-      "SumIf([" +
-      t`Subtotal` +
-      "], [" +
-      t`Order Status` +
-      '] = "' +
-      t`Valid` +
-      '")',
     args: [
-      { name: t`column`, description: t`The numeric column to sum.` },
+      {
+        name: t`column`,
+        description: t`The numeric column to sum.`,
+        example: "[" + t`Subtotal` + "]",
+      },
       {
         name: t`condition`,
         description: t`Something that should evaluate to true or false.`,
+        example: "[" + t`Order Status` + '] = "' + t`Valid` + '")',
       },
     ],
   },
   {
     name: "var",
-    structure: "Variance(" + t`column` + ")",
+    structure: `Variance(${argsPlaceholder})`,
     description: () => t`Returns the numeric variance for a given column.`,
-    example: "Variance([" + t`Temperature` + "])",
     args: [
       {
         name: t`column`,
         description: t`The column or number to get the variance of.`,
+        example: "[" + t`Temperature` + "]",
       },
     ],
   },
   {
     name: "median",
-    structure: "Median(" + t`column` + ")",
+    structure: `Median(${argsPlaceholder})`,
     description: () => t`Returns the median value of the specified column.`,
-    example: "Median([" + t`Age` + "])",
     args: [
       {
         name: t`column`,
         description: t`The column or number to get the median of.`,
+        example: "[" + t`Age` + "]",
       },
     ],
   },
   {
     name: "percentile",
-    structure: "Percentile(" + t`column` + ", " + t`percentile-value` + ")",
+    structure: `Percentile(${argsPlaceholder})`,
     description: () =>
       t`Returns the value of the column at the percentile value.`,
-    example: "Percentile([" + t`Score` + "], 0.9)",
     args: [
       {
         name: t`column`,
         description: t`The column or number to get the percentile of.`,
+        example: "[" + t`Score` + "]",
       },
       {
         name: t`percentile-value`,
         description: t`The value of the percentile.`,
+        example: "0.9",
       },
     ],
   },
   {
     name: "lower",
-    structure: "lower(" + t`text` + ")",
+    structure: `lower(${argsPlaceholder})`,
     description: () => t`Returns the string of text in all lower case.`,
-    example: "lower([" + t`Status` + "])",
     args: [
       {
         name: t`text`,
         description: t`The column with values to convert to lower case.`,
+        example: "[" + t`Status` + "]",
       },
     ],
   },
   {
     name: "upper",
-    structure: "upper(" + t`text` + ")",
+    structure: `upper(${argsPlaceholder})`,
     description: () => t`Returns the text in all upper case.`,
-    example: "upper([" + t`Status` + "])",
     args: [
       {
         name: t`text`,
         description: t`The column with values to convert to upper case.`,
+        example: "[" + t`Status` + "]",
       },
     ],
   },
   {
     name: "substring",
-    structure:
-      "substring(" + t`text` + ", " + t`position` + ", " + t`length` + ")",
+    structure: `substring(${argsPlaceholder})`,
     description: () => t`Returns a portion of the supplied text.`,
-    example: "substring([" + t`Title` + "], 1, 10)",
     args: [
       {
         name: t`text`,
         description: t`The column or text to return a portion of.`,
+        example: "[" + t`Title` + "]",
       },
       {
         name: t`position`,
         description: t`The position to start copying characters. Index starts at position 1.`,
+        example: "1",
       },
-      { name: t`length`, description: t`The number of characters to return.` },
+      {
+        name: t`length`,
+        description: t`The number of characters to return.`,
+        example: "10",
+      },
     ],
     docsPage: "substring",
   },
   {
     name: "regex-match-first",
-    structure: "regexextract(" + t`text` + ", " + t`regular_expression` + ")",
+    structure: `regexextract(${argsPlaceholder})`,
     description: () =>
       t`Extracts matching substrings according to a regular expression.`,
-    example: "regexextract([" + t`Address` + '], "[0-9]+")',
     args: [
-      { name: t`text`, description: t`The column or text to search through.` },
+      {
+        name: t`text`,
+        description: t`The column or text to search through.`,
+        example: "[" + t`Address` + "]",
+      },
       {
         name: t`regular_expression`,
         description: t`The regular expression to match.`,
+        example: '"[0-9]+"',
       },
     ],
     docsPage: "regexextract",
   },
   {
     name: "concat",
-    structure: "concat(" + t`value1` + ", " + t`value2` + ", …)",
+    structure: `concat(${argsPlaceholder})`,
     description: () => t`Combine two or more strings of text together.`,
-    example: "concat([" + t`Last Name` + '], ", ", [' + t`First Name` + "])",
     args: [
-      { name: t`value1`, description: t`The column or text to begin with.` },
+      {
+        name: t`value1`,
+        description: t`The column or text to begin with.`,
+        example: "[" + t`Last Name` + "]",
+      },
       {
         name: t`value2`,
-        description: t`This will be added to the end of value1, and so on.`,
+        description: t`This will be added to the end of value1.`,
+        example: "[" + t`First Name` + "]",
+      },
+      {
+        name: "…",
+        description: t`This will be added to the end of value2, and so on.`,
+        example: "[" + t`First Name` + "]",
       },
     ],
     docsPage: "concat",
   },
   {
     name: "replace",
-    structure: "replace(" + t`text` + ", " + t`find` + ", " + t`replace` + ")",
+    structure: `replace(${argsPlaceholder})`,
     description: () => t`Replaces a part of the input text with new text.`,
-    example:
-      "replace([" +
-      t`Title` +
-      '], "' +
-      t`Enormous` +
-      '", "' +
-      t`Gigantic` +
-      '")',
     args: [
-      { name: t`text`, description: t`The column or text to search through.` },
-      { name: t`find`, description: t`The text to find.` },
-      { name: t`replace`, description: t`The text to use as the replacement.` },
+      {
+        name: t`text`,
+        description: t`The column or text to search through.`,
+        example: "[" + t`Title` + "]",
+      },
+      {
+        name: t`find`,
+        description: t`The text to find.`,
+        example: '"' + t`Enormous` + '"',
+      },
+      {
+        name: t`replace`,
+        description: t`The text to use as the replacement.`,
+        example: '"' + t`Gigantic` + '"',
+      },
     ],
   },
   {
     name: "length",
-    structure: "length(" + t`text` + ")",
+    structure: `length(${argsPlaceholder})`,
     description: () => t`Returns the number of characters in text.`,
-    example: "length([" + t`Comment` + "])",
     args: [
       {
         name: t`text`,
         description: t`The column or text you want to get the length of.`,
+        example: "[" + t`Comment` + "]",
       },
     ],
   },
   {
     name: "trim",
-    structure: "trim(" + t`text` + ")",
+    structure: `trim(${argsPlaceholder})`,
     description: () =>
       t`Removes leading and trailing whitespace from a string of text.`,
-    example: "trim([" + t`Comment` + "])",
     args: [
-      { name: t`text`, description: t`The column or text you want to trim.` },
+      {
+        name: t`text`,
+        description: t`The column or text you want to trim.`,
+        example: "[" + t`Comment` + "]",
+      },
     ],
   },
   {
     name: "rtrim",
-    structure: "rtrim(" + t`text` + ")",
+    structure: `rtrim(${argsPlaceholder})`,
     description: () => t`Removes trailing whitespace from a string of text.`,
-    example: "rtrim([" + t`Comment` + "])",
     args: [
-      { name: t`text`, description: t`The column or text you want to trim.` },
+      {
+        name: t`text`,
+        description: t`The column or text you want to trim.`,
+        example: "[" + t`Comment` + "]",
+      },
     ],
   },
   {
     name: "ltrim",
-    structure: "ltrim(" + t`text` + ")",
+    structure: `ltrim(${argsPlaceholder})`,
     description: () => t`Removes leading whitespace from a string of text.`,
-    example: "ltrim([" + t`Comment` + "])",
     args: [
-      { name: t`text`, description: t`The column or text you want to trim.` },
+      {
+        name: t`text`,
+        description: t`The column or text you want to trim.`,
+        example: "[" + t`Comment` + "]",
+      },
     ],
   },
   {
     name: "abs",
-    structure: "abs(" + t`column` + ")",
+    structure: `abs(${argsPlaceholder})`,
     description: () =>
       t`Returns the absolute (positive) value of the specified column.`,
-    example: "abs([" + t`Debt` + "])",
     args: [
       {
         name: t`column`,
         description: t`The column or number to return absolute (positive) value of.`,
+        example: "[" + t`Debt` + "]",
       },
     ],
   },
   {
     name: "floor",
-    structure: "floor(" + t`column` + ")",
+    structure: `floor(${argsPlaceholder})`,
     description: () => t`Rounds a decimal number down.`,
-    example: "floor([" + t`Price` + "])",
     args: [
-      { name: t`column`, description: t`The column or number to round down.` },
+      {
+        name: t`column`,
+        description: t`The column or number to round down.`,
+        example: "[" + t`Price` + "]",
+      },
     ],
   },
   {
     name: "ceil",
-    structure: "ceil(" + t`column` + ")",
+    structure: `ceil(${argsPlaceholder})`,
     description: () => t`Rounds a decimal number up.`,
-    example: "ceil([" + t`Price` + "])",
     args: [
-      { name: t`column`, description: t`The column or number to round up.` },
+      {
+        name: t`column`,
+        description: t`The column or number to round up.`,
+        example: "[" + t`Price` + "]",
+      },
     ],
   },
   {
     name: "round",
-    structure: "round(" + t`column` + ")",
+    structure: `round(${argsPlaceholder})`,
     description: () =>
       t`Rounds a decimal number either up or down to the nearest integer value.`,
-    example: "round([" + t`Temperature` + "])",
     args: [
       {
         name: t`column`,
         description: t`The column or number to round to nearest integer.`,
+        example: "[" + t`Temperature` + "]",
       },
     ],
   },
   {
     name: "sqrt",
-    structure: "sqrt(" + t`column` + ")",
+    structure: `sqrt(${argsPlaceholder})`,
     description: () => t`Returns the square root.`,
-    example: "sqrt([" + t`Hypotenuse` + "])",
     args: [
       {
         name: t`column`,
         description: t`The column or number to return square root value of.`,
+        example: "[" + t`Hypotenuse` + "]",
       },
     ],
   },
   {
     name: "power",
-    structure: "power(" + t`column` + ", " + t`exponent` + ")",
+    structure: `power(${argsPlaceholder})`,
     description: () => t`Raises a number to the power of the exponent value.`,
-    example: "power([" + t`Length` + "], 2)",
     args: [
       {
         name: t`column`,
         description: t`The column or number raised to the exponent.`,
+        example: "[" + t`Length` + "]",
       },
-      { name: t`exponent`, description: t`The value of the exponent.` },
+      {
+        name: t`exponent`,
+        description: t`The value of the exponent.`,
+        example: "2",
+      },
     ],
   },
   {
     name: "log",
-    structure: "log(" + t`column` + ")",
+    structure: `log(${argsPlaceholder})`,
     description: () => t`Returns the base 10 log of the number.`,
-    example: "log([" + t`Value` + "])",
     args: [
       {
         name: t`column`,
         description: t`The column or number to return the natural logarithm value of.`,
+        example: "[" + t`Value` + "]",
       },
     ],
   },
   {
     name: "datetime-diff",
-    structure:
-      "datetimeDiff(" +
-      t`datetime1` +
-      ", " +
-      t`datetime2` +
-      ", " +
-      t`unit` +
-      ")",
+    structure: `datetimeDiff(${argsPlaceholder})`,
     description: () =>
       t`Get the difference between two datetime values (datetime2 minus datetime1) using the specified unit of time.`,
-    example:
-      "datetimeDiff([" +
-      t`created_at` +
-      "], [" +
-      t`shipped_at` +
-      "], " +
-      t`"month"` +
-      ")",
     args: [
       {
-        name: t`datetime1, datetime2`,
-        description: t`The columns or expressions with your datetime values.`,
+        name: t`datetime1`,
+        description: t`The column or expression with your datetime value.`,
+        example: "[" + t`created_at` + "]",
+      },
+      {
+        name: t`datetime2`,
+        description: t`The column or expression with your datetime value.`,
+        example: "[" + t`shipped_at` + "]",
       },
       {
         name: t`unit`,
         description: t`Choose from: "year", "month", "week", "day", "hour", "minute", or "second".`,
+        example: '"month"',
       },
     ],
     docsPage: "datetimediff",
   },
   {
     name: "exp",
-    structure: "exp(" + t`column` + ")",
+    structure: `exp(${argsPlaceholder})`,
     description: () =>
       t`Returns Euler's number, e, raised to the power of the supplied number.`,
-    example: "exp([" + t`Interest Months` + "])",
     args: [
       {
         name: t`column`,
         description: t`The column or number to return the exponential value of.`,
+        example: "[" + t`Interest Months` + "]",
       },
     ],
   },
   {
     name: "contains",
-    structure: "contains(" + t`string1` + ", " + t`string2` + ")",
+    structure: `contains(${argsPlaceholder})`,
     description: () => t`Checks to see if string1 contains string2 within it.`,
-    example: "contains([" + t`Status` + '], "' + t`Pass` + '")',
     args: [
-      { name: t`string1`, description: t`The column or text to check.` },
-      { name: t`string2`, description: t`The string of text to look for.` },
+      {
+        name: t`string1`,
+        description: t`The column or text to check.`,
+        example: "[" + t`Status` + "]",
+      },
+      {
+        name: t`string2`,
+        description: t`The string of text to look for.`,
+        example: '"' + t`Pass` + '"',
+      },
     ],
   },
   {
     name: "starts-with",
-    structure: "startsWith(" + t`text` + ", " + t`comparison` + ")",
+    structure: `startsWith(${argsPlaceholder})`,
     description: () =>
       t`Returns true if the beginning of the text matches the comparison text.`,
-    example:
-      "startsWith([" + t`Course Name` + '], "' + t`Computer Science` + '")',
     args: [
-      { name: t`text`, description: t`The column or text to check.` },
+      {
+        name: t`text`,
+        description: t`The column or text to check.`,
+        example: "[" + t`Course Name` + "]",
+      },
       {
         name: t`comparison`,
         description: t`The string of text that the original text should start with.`,
+        example: '"' + t`Computer Science` + '"',
       },
     ],
   },
   {
     name: "ends-with",
-    structure: "endsWith(" + t`text` + ", " + t`comparison` + ")",
+    structure: `endsWith(${argsPlaceholder})`,
     description: () =>
       t`Returns true if the end of the text matches the comparison text.`,
-    example: "endsWith([" + t`Appetite` + '], "' + t`hungry` + '")',
     args: [
-      { name: t`text`, description: t`The column or text to check.` },
+      {
+        name: t`text`,
+        description: t`The column or text to check.`,
+        example: "[" + t`Appetite` + "]",
+      },
       {
         name: t`comparison`,
         description: t`The string of text that the original text should end with.`,
+        example: '"' + t`hungry` + '"',
       },
     ],
   },
   {
     name: "between",
-    structure: "between(" + t`column` + ", " + t`start` + ", " + t`end` + ")",
+    structure: `between(${argsPlaceholder})`,
     description: () =>
       t`Checks a date or number column's values to see if they're within the specified range.`,
-    example: "between([" + t`Created At` + '], "2019-01-01", "2020-12-31")',
     args: [
       {
         name: t`column`,
         description: t`The date or numeric column that should be within the start and end values.`,
+        example: "[" + t`Created At` + "]",
       },
-      { name: t`start`, description: t`The beginning of the range.` },
-      { name: t`end`, description: t`The end of the range.` },
+      {
+        name: t`start`,
+        description: t`The beginning of the range.`,
+        example: '"2019-01-01"',
+      },
+      {
+        name: t`end`,
+        description: t`The end of the range.`,
+        example: '"2022-12-31"',
+      },
     ],
   },
   {
     name: "interval",
-    structure: "timeSpan(" + t`number` + ", " + t`text` + ")",
+    structure: `timeSpan(${argsPlaceholder})`,
     description: () => t`Gets a time interval of specified length`,
-    example: 'timeSpan(7, "day")',
     args: [
       {
         name: t`number`,
         description: t`Period of interval, where negative values are back in time.`,
+        example: "7",
       },
       {
         name: t`text`,
         description: t`Type of interval like "day", "month", "year".`,
+        example: '"day"',
       },
     ],
   },
   {
     name: "time-interval",
-    structure:
-      "interval(" + t`column` + ", " + t`number` + ", " + t`text` + ")",
+    structure: `interval(${argsPlaceholder})`,
     description: () =>
       t`Checks a date column's values to see if they're within the relative range.`,
-    example: "interval([" + t`Created At` + '], -1, "month")',
     args: [
       {
         name: t`column`,
         description: t`The date column to return interval of.`,
+        example: "[" + t`Created At` + "]",
       },
       {
         name: t`number`,
         description: t`Period of interval, where negative values are back in time.`,
+        example: "-1",
       },
       {
         name: t`text`,
         description: t`Type of interval like "day", "month", "year".`,
+        example: '"month"',
       },
     ],
   },
   {
     name: "relative-datetime",
-    structure: "relativeDateTime(" + t`number` + ", " + t`text` + ")",
+    structure: `relativeDateTime(${argsPlaceholder})`,
     description: () => t`Gets a timestamp relative to the current time`,
-    example: 'relativeDateTime(-30, "day")',
     args: [
       {
         name: t`number`,
         description: t`Period of interval, where negative values are back in time.`,
+        example: "-30",
       },
       {
         name: t`text`,
         description: t`Type of interval like "day", "month", "year".`,
+        example: '"day"',
       },
     ],
   },
   {
     name: "is-null",
-    structure: "isnull(" + t`column` + ")",
+    structure: `isnull(${argsPlaceholder})`,
     description: () => t`Checks if a column is null`,
-    example: "isnull([" + t`Discount` + "])",
     args: [
       {
         name: t`column`,
         description: t`The column to check.`,
+        example: "[" + t`Discount` + "]",
       },
     ],
     docsPage: "isnull",
   },
   {
     name: "is-empty",
-    structure: "isempty(" + t`column` + ")",
+    structure: `isempty(${argsPlaceholder})`,
     description: () => t`Checks if a column is empty`,
-    example: "isempty([" + t`Name` + "])",
     args: [
       {
         name: t`column`,
         description: t`The column to check.`,
+        example: "[" + t`Name` + "]",
       },
     ],
     docsPage: "isempty",
   },
   {
     name: "coalesce",
-    structure: "coalesce(" + t`value1` + ", " + t`value2` + ", …)",
+    structure: `coalesce(${argsPlaceholder})`,
     description: () =>
       t`Looks at the values in each argument in order and returns the first non-null value for each row.`,
-    example:
-      "coalesce([" +
-      t`Comments` +
-      "], [" +
-      t`Notes` +
-      '], "' +
-      t`No comments` +
-      '")',
     args: [
-      { name: t`value1`, description: t`The column or value to return.` },
+      {
+        name: t`value1`,
+        description: t`The column or value to return.`,
+        example: "[" + t`Comments` + "]",
+      },
       {
         name: t`value2`,
-        description: t`If value1 is empty, value2 gets returned if its not empty, and so on.`,
+        description: t`If value1 is empty, value2 gets returned if its not empty.`,
+        example: "[" + t`Notes` + "]",
+      },
+      {
+        name: "…",
+        description: t`If value1 is empty, and value2 is empty, the next non-empty one will be returned.`,
+        example: '"' + t`No comments` + '"',
       },
     ],
     docsPage: "coalesce",
   },
   {
     name: "case",
-    structure: "case(" + t`condition` + ", " + t`output` + ", …)",
+    structure: `case(${argsPlaceholder})`,
     description: () =>
       t`Tests an expression against a list of cases and returns the corresponding value of the first matching case, with an optional default value if nothing else is met.`,
-    example:
-      "case([" +
-      t`Weight` +
-      '] > 200, "' +
-      t`Large` +
-      '", [' +
-      t`Weight` +
-      '] > 150, "' +
-      t`Medium` +
-      '", "' +
-      t`Small` +
-      '")',
     args: [
       {
         name: t`condition`,
         description: t`Something that should evaluate to true or false.`,
+        example: "[" + t`Weight` + "] > 200",
       },
       {
         name: t`output`,
-        description: t`The value that will be returned if the preceding condition is true, and so on.`,
+        description: t`The value that will be returned if the preceding condition is true.`,
+        example: '"' + t`Large` + '"',
+      },
+      {
+        name: "…",
+        description: t`You can add more conditions to test.`,
+        example:
+          "[" + t`Weight` + '] > 150, "' + t`Medium` + '", "' + t`Small` + '"',
       },
     ],
     docsPage: "case",
   },
   {
     name: "get-year",
-    structure: "year(" + t`column` + ")",
+    structure: `year(${argsPlaceholder})`,
     description: () =>
       t`Takes a datetime and returns an integer with the number of the year.`,
-    example: "year([" + t`Created At` + "])",
     args: [
       {
         name: t`column`,
         description: t`The datetime column.`,
+        example: "[" + t`Created At` + "]",
       },
     ],
   },
   {
     name: "get-quarter",
-    structure: "quarter(" + t`column` + ")",
+    structure: `quarter(${argsPlaceholder})`,
     description: () =>
       t`Takes a datetime and returns an integer (1-4) with the number of the quarter in the year.`,
-    example: "quarter([" + t`Created At` + "])",
     args: [
       {
         name: t`column`,
         description: t`The datetime column.`,
+        example: "[" + t`Created At` + "]",
       },
     ],
   },
   {
     name: "get-month",
-    structure: "month(" + t`column` + ")",
+    structure: `month(${argsPlaceholder})`,
     description: () =>
       t`Takes a datetime and returns an integer (1-12) with the number of the month in the year.`,
-    example: "month([" + t`Created At` + "])",
     args: [
       {
         name: t`column`,
         description: t`The datetime column.`,
+        example: "[" + t`Created At` + "]",
       },
     ],
   },
   {
     name: "get-week",
-    structure: "week(" + t`column` + ", " + t`mode` + ")",
+    structure: `week(${argsPlaceholder})`,
     description: () => t`Extracts the week of the year as an integer.`,
-    example: "week([" + t`Created At` + '], "iso")',
     args: [
       {
         name: t`column`,
         description: t`The name of the column with your date or datetime value.`,
+        example: "[" + t`Created At` + "]",
       },
       {
         name: t`mode`,
@@ -706,115 +770,118 @@ const helperTextStrings: HelpTextConfig[] = [
 - US: Week 1 starts on Jan 1. All other weeks start on Sunday.
 - Instance: Week 1 starts on Jan 1. All other weeks start on the day defined in your Metabase localization settings.
 `,
+        example: '"iso"',
       },
     ],
   },
   {
     name: "get-day",
-    structure: "day(" + t`column` + ")",
+    structure: `day(${argsPlaceholder})`,
     description: () =>
       t`Takes a datetime and returns an integer (1-31) with the number of the day of the month.`,
-    example: "day([" + t`Created At` + "])",
     args: [
       {
         name: t`column`,
         description: t`The datetime column.`,
+        example: "[" + t`Created At` + "]",
       },
     ],
   },
   {
     name: "get-day-of-week",
-    structure: "weekday(" + t`column` + ")",
+    structure: `weekday(${argsPlaceholder})`,
     description: () =>
       t`Takes a datetime and returns an integer (1-7) with the number of the day of the week.`,
-    example: "weekday([" + t`Created At` + "])",
     args: [
       {
         name: t`column`,
         description: t`The datetime column.`,
+        example: "[" + t`Created At` + "]",
       },
     ],
   },
   {
     name: "get-hour",
-    structure: "hour(" + t`column` + ")",
+    structure: `hour(${argsPlaceholder})`,
     description: () =>
       t`Takes a datetime and returns an integer (0-23) with the number of the hour. No AM/PM.`,
-    example: "hour([" + t`Created At` + "])",
     args: [
       {
         name: t`column`,
         description: t`The datetime column.`,
+        example: "[" + t`Created At` + "]",
       },
     ],
   },
   {
     name: "get-minute",
-    structure: "minute(" + t`column` + ")",
+    structure: `minute(${argsPlaceholder})`,
     description: () =>
       t`Takes a datetime and returns an integer (0-59) with the number of the minute in the hour.`,
-    example: "minute([" + t`Created At` + "])",
     args: [
       {
         name: t`column`,
         description: t`The datetime column.`,
+        example: "[" + t`Created At` + "]",
       },
     ],
   },
   {
     name: "get-second",
-    structure: "second(" + t`column` + ")",
+    structure: `second(${argsPlaceholder})`,
     description: () =>
       t`Takes a datetime and returns an integer (0-59) with the number of the seconds in the minute.`,
-    example: "second([" + t`Created At` + "])",
     args: [
       {
         name: t`column`,
         description: t`The datetime column.`,
+        example: "[" + t`Created At` + "]",
       },
     ],
   },
   {
     name: "datetime-add",
-    structure:
-      "datetimeAdd(" + t`column` + ", " + t`amount` + ", " + t`unit` + ")",
+    structure: `datetimeAdd(${argsPlaceholder})`,
     description: () => t`Adds some units of time to a date or timestamp value.`,
-    example: "datetimeAdd([" + t`Created At` + '], 1, "' + t`month` + '")',
     args: [
       {
         name: t`column`,
         description: t`The column with your date or timestamp values.`,
+        example: "[" + t`Created At` + "]",
       },
       {
         name: t`amount`,
         description: t`The number of units to be added.`,
+        example: "1",
       },
       {
         name: t`unit`,
         description: t`"year", "month", "quarter", "day", "hour", "minute", "second" or "millisecond".`,
+        example: '"month"',
       },
     ],
     docsPage: "datetimeadd",
   },
   {
     name: "datetime-subtract",
-    structure:
-      "datetimeSubtract(" + t`column` + ", " + t`amount` + ", " + t`unit` + ")",
+    structure: `datetimeSubtract(${argsPlaceholder})`,
     description: () =>
       t`Subtracts some units of time to a date or timestamp value.`,
-    example: "datetimeSubtract([" + t`Created At` + '], 1, "' + t`month` + '")',
     args: [
       {
         name: t`column`,
         description: t`The column with your date or timestamp values.`,
+        example: "[" + t`Created At` + "]",
       },
       {
         name: t`amount`,
         description: t`The number of units to be subtracted.`,
+        example: "1",
       },
       {
         name: t`unit`,
         description: t`"year", "month", "quarter", "day", "hour", "minute", "second" or "millisecond".`,
+        example: '"month"',
       },
     ],
     docsPage: "datetimesubtract",
@@ -823,36 +890,29 @@ const helperTextStrings: HelpTextConfig[] = [
     name: "now",
     structure: "now",
     description: getDescriptionForNow,
-    example: "now",
     args: [],
   },
   {
     name: "convert-timezone",
-    structure:
-      "convertTimezone(" +
-      t`column` +
-      ", " +
-      t`target` +
-      ", [" +
-      t`source` +
-      "])",
+    structure: `convertTimezone(${argsPlaceholder})`,
     description: () => t`Convert timezone of a date or timestamp column.
 We support tz database time zone names.
 See the full list here: https://w.wiki/4Jx`,
-    example:
-      "convertTimezone([" + t`Created At` + '], "Asia/Ho_Chi_Minh", "UTC")',
     args: [
       {
         name: t`column`,
         description: t`The column with your date or timestamp values.`,
+        example: "[" + t`Created At` + "]",
       },
       {
         name: t`target`,
         description: t`The timezone you want to assign to your column.`,
+        example: '"Asia/Ho_Chi_Minh"',
       },
       {
         name: t`source`,
         description: t`The current time zone. Only required for timestamps with no time zone.`,
+        example: '"UTC"',
       },
     ],
     docsPage: "converttimezone",
@@ -866,12 +926,20 @@ export const getHelpText = (
 ): HelpText | undefined => {
   const helperTextConfig = helperTextStrings.find(h => h.name === name);
 
-  return (
-    helperTextConfig && {
-      ...helperTextConfig,
-      description: helperTextConfig.description(database, reportTimezone),
-    }
-  );
+  if (!helperTextConfig) {
+    return;
+  }
+
+  const { structure, args, description } = helperTextConfig;
+
+  return {
+    ...helperTextConfig,
+    example: structure.replace(
+      HELPER_TEXT_ARGUMENTS_PLACEHOLDER,
+      args.map(({ example }) => example).join(", "),
+    ),
+    description: description(database, reportTimezone),
+  };
 };
 
 const getNowAtTimezone = (timezone: string, reportTimezone: string) =>

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield/helper-text-strings.ts
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield/helper-text-strings.ts
@@ -38,7 +38,7 @@ const helperTextStrings: HelpTextConfig[] = [
   },
   {
     name: "sum",
-    structure: `Sum`,
+    structure: "Sum",
     description: () => t`Adds up all the values of the column.`,
     args: [
       {
@@ -50,7 +50,7 @@ const helperTextStrings: HelpTextConfig[] = [
   },
   {
     name: "cum-sum",
-    structure: `CumulativeSum`,
+    structure: "CumulativeSum",
     description: () => t`The rolling sum of a column across a breakout.`,
     args: [
       {
@@ -62,7 +62,7 @@ const helperTextStrings: HelpTextConfig[] = [
   },
   {
     name: "distinct",
-    structure: `Distinct`,
+    structure: "Distinct",
     description: () => t`The number of distinct values in this column.`,
     args: [
       {
@@ -74,7 +74,7 @@ const helperTextStrings: HelpTextConfig[] = [
   },
   {
     name: "stddev",
-    structure: `StandardDeviation`,
+    structure: "StandardDeviation",
     description: () => t`Calculates the standard deviation of the column.`,
     args: [
       {
@@ -86,7 +86,7 @@ const helperTextStrings: HelpTextConfig[] = [
   },
   {
     name: "avg",
-    structure: `Average`,
+    structure: "Average",
     description: () => t`Returns the average of the values in the column.`,
     args: [
       {
@@ -98,7 +98,7 @@ const helperTextStrings: HelpTextConfig[] = [
   },
   {
     name: "median",
-    structure: `Median`,
+    structure: "Median",
     description: () => t`Returns the median of all the values of a column.`,
     args: [
       {
@@ -110,7 +110,7 @@ const helperTextStrings: HelpTextConfig[] = [
   },
   {
     name: "min",
-    structure: `Min`,
+    structure: "Min",
     description: () => t`Returns the smallest value found in the column`,
     args: [
       {
@@ -122,7 +122,7 @@ const helperTextStrings: HelpTextConfig[] = [
   },
   {
     name: "max",
-    structure: `Max`,
+    structure: "Max",
     description: () => t`Returns the largest value found in the column.`,
     args: [
       {
@@ -134,7 +134,7 @@ const helperTextStrings: HelpTextConfig[] = [
   },
   {
     name: "share",
-    structure: `Share`,
+    structure: "Share",
     description: () =>
       t`Returns the percent of rows in the data that match the condition, as a decimal.`,
     args: [
@@ -149,7 +149,7 @@ const helperTextStrings: HelpTextConfig[] = [
   },
   {
     name: "count-where",
-    structure: `CountIf`,
+    structure: "CountIf",
     description: () => t`Only counts rows where the condition is true.`,
     args: [
       {
@@ -161,7 +161,7 @@ const helperTextStrings: HelpTextConfig[] = [
   },
   {
     name: "sum-where",
-    structure: `SumIf`,
+    structure: "SumIf",
     description: () =>
       t`Sums up the specified column only for rows where the condition is true.`,
     args: [
@@ -181,7 +181,7 @@ const helperTextStrings: HelpTextConfig[] = [
   },
   {
     name: "var",
-    structure: `Variance`,
+    structure: "Variance",
     description: () => t`Returns the numeric variance for a given column.`,
     args: [
       {
@@ -193,7 +193,7 @@ const helperTextStrings: HelpTextConfig[] = [
   },
   {
     name: "median",
-    structure: `Median`,
+    structure: "Median",
     description: () => t`Returns the median value of the specified column.`,
     args: [
       {
@@ -205,7 +205,7 @@ const helperTextStrings: HelpTextConfig[] = [
   },
   {
     name: "percentile",
-    structure: `Percentile`,
+    structure: "Percentile",
     description: () =>
       t`Returns the value of the column at the percentile value.`,
     args: [
@@ -223,7 +223,7 @@ const helperTextStrings: HelpTextConfig[] = [
   },
   {
     name: "lower",
-    structure: `lower`,
+    structure: "lower",
     description: () => t`Returns the string of text in all lower case.`,
     args: [
       {
@@ -235,7 +235,7 @@ const helperTextStrings: HelpTextConfig[] = [
   },
   {
     name: "upper",
-    structure: `upper`,
+    structure: "upper",
     description: () => t`Returns the text in all upper case.`,
     args: [
       {
@@ -247,7 +247,7 @@ const helperTextStrings: HelpTextConfig[] = [
   },
   {
     name: "substring",
-    structure: `substring`,
+    structure: "substring",
     description: () => t`Returns a portion of the supplied text.`,
     args: [
       {
@@ -270,7 +270,7 @@ const helperTextStrings: HelpTextConfig[] = [
   },
   {
     name: "regex-match-first",
-    structure: `regexextract`,
+    structure: "regexextract",
     description: () =>
       t`Extracts matching substrings according to a regular expression.`,
     args: [
@@ -289,7 +289,7 @@ const helperTextStrings: HelpTextConfig[] = [
   },
   {
     name: "concat",
-    structure: `concat`,
+    structure: "concat",
     description: () => t`Combine two or more strings of text together.`,
     args: [
       {
@@ -312,7 +312,7 @@ const helperTextStrings: HelpTextConfig[] = [
   },
   {
     name: "replace",
-    structure: `replace`,
+    structure: "replace",
     description: () => t`Replaces a part of the input text with new text.`,
     args: [
       {
@@ -334,7 +334,7 @@ const helperTextStrings: HelpTextConfig[] = [
   },
   {
     name: "length",
-    structure: `length`,
+    structure: "length",
     description: () => t`Returns the number of characters in text.`,
     args: [
       {
@@ -346,7 +346,7 @@ const helperTextStrings: HelpTextConfig[] = [
   },
   {
     name: "trim",
-    structure: `trim`,
+    structure: "trim",
     description: () =>
       t`Removes leading and trailing whitespace from a string of text.`,
     args: [
@@ -359,7 +359,7 @@ const helperTextStrings: HelpTextConfig[] = [
   },
   {
     name: "rtrim",
-    structure: `rtrim`,
+    structure: "rtrim",
     description: () => t`Removes trailing whitespace from a string of text.`,
     args: [
       {
@@ -371,7 +371,7 @@ const helperTextStrings: HelpTextConfig[] = [
   },
   {
     name: "ltrim",
-    structure: `ltrim`,
+    structure: "ltrim",
     description: () => t`Removes leading whitespace from a string of text.`,
     args: [
       {
@@ -383,7 +383,7 @@ const helperTextStrings: HelpTextConfig[] = [
   },
   {
     name: "abs",
-    structure: `abs`,
+    structure: "abs",
     description: () =>
       t`Returns the absolute (positive) value of the specified column.`,
     args: [
@@ -396,7 +396,7 @@ const helperTextStrings: HelpTextConfig[] = [
   },
   {
     name: "floor",
-    structure: `floor`,
+    structure: "floor",
     description: () => t`Rounds a decimal number down.`,
     args: [
       {
@@ -408,7 +408,7 @@ const helperTextStrings: HelpTextConfig[] = [
   },
   {
     name: "ceil",
-    structure: `ceil`,
+    structure: "ceil",
     description: () => t`Rounds a decimal number up.`,
     args: [
       {
@@ -420,7 +420,7 @@ const helperTextStrings: HelpTextConfig[] = [
   },
   {
     name: "round",
-    structure: `round`,
+    structure: "round",
     description: () =>
       t`Rounds a decimal number either up or down to the nearest integer value.`,
     args: [
@@ -433,7 +433,7 @@ const helperTextStrings: HelpTextConfig[] = [
   },
   {
     name: "sqrt",
-    structure: `sqrt`,
+    structure: "sqrt",
     description: () => t`Returns the square root.`,
     args: [
       {
@@ -445,7 +445,7 @@ const helperTextStrings: HelpTextConfig[] = [
   },
   {
     name: "power",
-    structure: `power`,
+    structure: "power",
     description: () => t`Raises a number to the power of the exponent value.`,
     args: [
       {
@@ -462,7 +462,7 @@ const helperTextStrings: HelpTextConfig[] = [
   },
   {
     name: "log",
-    structure: `log`,
+    structure: "log",
     description: () => t`Returns the base 10 log of the number.`,
     args: [
       {
@@ -474,7 +474,7 @@ const helperTextStrings: HelpTextConfig[] = [
   },
   {
     name: "datetime-diff",
-    structure: `datetimeDiff`,
+    structure: "datetimeDiff",
     description: () =>
       t`Get the difference between two datetime values (datetime2 minus datetime1) using the specified unit of time.`,
     args: [
@@ -498,7 +498,7 @@ const helperTextStrings: HelpTextConfig[] = [
   },
   {
     name: "exp",
-    structure: `exp`,
+    structure: "exp",
     description: () =>
       t`Returns Euler's number, e, raised to the power of the supplied number.`,
     args: [
@@ -511,7 +511,7 @@ const helperTextStrings: HelpTextConfig[] = [
   },
   {
     name: "contains",
-    structure: `contains`,
+    structure: "contains",
     description: () => t`Checks to see if string1 contains string2 within it.`,
     args: [
       {
@@ -528,7 +528,7 @@ const helperTextStrings: HelpTextConfig[] = [
   },
   {
     name: "starts-with",
-    structure: `startsWith`,
+    structure: "startsWith",
     description: () =>
       t`Returns true if the beginning of the text matches the comparison text.`,
     args: [
@@ -546,7 +546,7 @@ const helperTextStrings: HelpTextConfig[] = [
   },
   {
     name: "ends-with",
-    structure: `endsWith`,
+    structure: "endsWith",
     description: () =>
       t`Returns true if the end of the text matches the comparison text.`,
     args: [
@@ -564,7 +564,7 @@ const helperTextStrings: HelpTextConfig[] = [
   },
   {
     name: "between",
-    structure: `between`,
+    structure: "between",
     description: () =>
       t`Checks a date or number column's values to see if they're within the specified range.`,
     args: [
@@ -587,7 +587,7 @@ const helperTextStrings: HelpTextConfig[] = [
   },
   {
     name: "interval",
-    structure: `timeSpan`,
+    structure: "timeSpan",
     description: () => t`Gets a time interval of specified length`,
     args: [
       {
@@ -604,7 +604,7 @@ const helperTextStrings: HelpTextConfig[] = [
   },
   {
     name: "time-interval",
-    structure: `interval`,
+    structure: "interval",
     description: () =>
       t`Checks a date column's values to see if they're within the relative range.`,
     args: [
@@ -627,7 +627,7 @@ const helperTextStrings: HelpTextConfig[] = [
   },
   {
     name: "relative-datetime",
-    structure: `relativeDateTime`,
+    structure: "relativeDateTime",
     description: () => t`Gets a timestamp relative to the current time`,
     args: [
       {
@@ -644,7 +644,7 @@ const helperTextStrings: HelpTextConfig[] = [
   },
   {
     name: "is-null",
-    structure: `isnull`,
+    structure: "isnull",
     description: () => t`Checks if a column is null`,
     args: [
       {
@@ -657,7 +657,7 @@ const helperTextStrings: HelpTextConfig[] = [
   },
   {
     name: "is-empty",
-    structure: `isempty`,
+    structure: "isempty",
     description: () => t`Checks if a column is empty`,
     args: [
       {
@@ -670,7 +670,7 @@ const helperTextStrings: HelpTextConfig[] = [
   },
   {
     name: "coalesce",
-    structure: `coalesce`,
+    structure: "coalesce",
     description: () =>
       t`Looks at the values in each argument in order and returns the first non-null value for each row.`,
     args: [
@@ -694,7 +694,7 @@ const helperTextStrings: HelpTextConfig[] = [
   },
   {
     name: "case",
-    structure: `case`,
+    structure: "case",
     description: () =>
       t`Tests an expression against a list of cases and returns the corresponding value of the first matching case, with an optional default value if nothing else is met.`,
     args: [
@@ -720,7 +720,7 @@ const helperTextStrings: HelpTextConfig[] = [
   },
   {
     name: "get-year",
-    structure: `year`,
+    structure: "year",
     description: () =>
       t`Takes a datetime and returns an integer with the number of the year.`,
     args: [
@@ -733,7 +733,7 @@ const helperTextStrings: HelpTextConfig[] = [
   },
   {
     name: "get-quarter",
-    structure: `quarter`,
+    structure: "quarter",
     description: () =>
       t`Takes a datetime and returns an integer (1-4) with the number of the quarter in the year.`,
     args: [
@@ -746,7 +746,7 @@ const helperTextStrings: HelpTextConfig[] = [
   },
   {
     name: "get-month",
-    structure: `month`,
+    structure: "month",
     description: () =>
       t`Takes a datetime and returns an integer (1-12) with the number of the month in the year.`,
     args: [
@@ -759,7 +759,7 @@ const helperTextStrings: HelpTextConfig[] = [
   },
   {
     name: "get-week",
-    structure: `week`,
+    structure: "week",
     description: () => t`Extracts the week of the year as an integer.`,
     args: [
       {
@@ -780,7 +780,7 @@ const helperTextStrings: HelpTextConfig[] = [
   },
   {
     name: "get-day",
-    structure: `day`,
+    structure: "day",
     description: () =>
       t`Takes a datetime and returns an integer (1-31) with the number of the day of the month.`,
     args: [
@@ -793,7 +793,7 @@ const helperTextStrings: HelpTextConfig[] = [
   },
   {
     name: "get-day-of-week",
-    structure: `weekday`,
+    structure: "weekday",
     description: () =>
       t`Takes a datetime and returns an integer (1-7) with the number of the day of the week.`,
     args: [
@@ -806,7 +806,7 @@ const helperTextStrings: HelpTextConfig[] = [
   },
   {
     name: "get-hour",
-    structure: `hour`,
+    structure: "hour",
     description: () =>
       t`Takes a datetime and returns an integer (0-23) with the number of the hour. No AM/PM.`,
     args: [
@@ -819,7 +819,7 @@ const helperTextStrings: HelpTextConfig[] = [
   },
   {
     name: "get-minute",
-    structure: `minute`,
+    structure: "minute",
     description: () =>
       t`Takes a datetime and returns an integer (0-59) with the number of the minute in the hour.`,
     args: [
@@ -832,7 +832,7 @@ const helperTextStrings: HelpTextConfig[] = [
   },
   {
     name: "get-second",
-    structure: `second`,
+    structure: "second",
     description: () =>
       t`Takes a datetime and returns an integer (0-59) with the number of the seconds in the minute.`,
     args: [
@@ -845,7 +845,7 @@ const helperTextStrings: HelpTextConfig[] = [
   },
   {
     name: "datetime-add",
-    structure: `datetimeAdd`,
+    structure: "datetimeAdd",
     description: () => t`Adds some units of time to a date or timestamp value.`,
     args: [
       {
@@ -868,7 +868,7 @@ const helperTextStrings: HelpTextConfig[] = [
   },
   {
     name: "datetime-subtract",
-    structure: `datetimeSubtract`,
+    structure: "datetimeSubtract",
     description: () =>
       t`Subtracts some units of time to a date or timestamp value.`,
     args: [
@@ -897,7 +897,7 @@ const helperTextStrings: HelpTextConfig[] = [
   },
   {
     name: "convert-timezone",
-    structure: `convertTimezone`,
+    structure: "convertTimezone",
     description: () => t`Convert timezone of a date or timestamp column.
 We support tz database time zone names.
 See the full list here: https://w.wiki/4Jx`,

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield/helper-text-strings.ts
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield/helper-text-strings.ts
@@ -3,6 +3,10 @@ import moment from "moment-timezone";
 
 import type { Database } from "metabase-types/api/database";
 import { HelpText, HelpTextConfig } from "metabase-lib/expressions/types";
+import {
+  formatIdentifier,
+  formatStringLiteral,
+} from "metabase-lib/expressions";
 
 const getDescriptionForNow = (database: Database, reportTimezone: string) => {
   const hasTimezoneFeatureFlag = database.features.includes("set-timezone");
@@ -21,195 +25,194 @@ const getDescriptionForNow = (database: Database, reportTimezone: string) => {
   }
 };
 
-export const HELPER_TEXT_ARGUMENTS_PLACEHOLDER = "$args";
-const argsPlaceholder = HELPER_TEXT_ARGUMENTS_PLACEHOLDER;
-
 const helperTextStrings: HelpTextConfig[] = [
   {
     name: "count",
     structure: "Count",
     description: () => t`Returns the count of rows in the selected data.`,
-    args: [],
   },
   {
     name: "cum-count",
     structure: "CumulativeCount",
     description: () => t`The additive total of rows across a breakout.`,
-    args: [],
   },
   {
     name: "sum",
-    structure: `Sum(${argsPlaceholder})`,
+    structure: `Sum`,
     description: () => t`Adds up all the values of the column.`,
     args: [
       {
         name: t`column`,
         description: t`The column or number to sum.`,
-        example: "[" + t`Subtotal` + "]",
+        example: formatIdentifier(t`Subtotal`),
       },
     ],
   },
   {
     name: "cum-sum",
-    structure: `CumulativeSum(${argsPlaceholder})`,
+    structure: `CumulativeSum`,
     description: () => t`The rolling sum of a column across a breakout.`,
     args: [
       {
         name: t`column`,
         description: t`The column or number to sum.`,
-        example: "[" + t`Subtotal` + "]",
+        example: formatIdentifier(t`Subtotal`),
       },
     ],
   },
   {
     name: "distinct",
-    structure: `Distinct(${argsPlaceholder})`,
+    structure: `Distinct`,
     description: () => t`The number of distinct values in this column.`,
     args: [
       {
         name: t`column`,
         description: t`The column whose distinct values to count.`,
-        example: "[" + t`Last Name` + "]",
+        example: formatIdentifier(t`Last Name`),
       },
     ],
   },
   {
     name: "stddev",
-    structure: `StandardDeviation(${argsPlaceholder})`,
+    structure: `StandardDeviation`,
     description: () => t`Calculates the standard deviation of the column.`,
     args: [
       {
         name: t`column`,
         description: t`The numeric column to get standard deviation of.`,
-        example: "[" + t`Population` + "]",
+        example: formatIdentifier(t`Population`),
       },
     ],
   },
   {
     name: "avg",
-    structure: `Average(${argsPlaceholder})`,
+    structure: `Average`,
     description: () => t`Returns the average of the values in the column.`,
     args: [
       {
         name: t`column`,
         description: t`The numeric column whose values to average.`,
-        example: "[" + t`Quantity` + "]",
+        example: formatIdentifier(t`Quantity`),
       },
     ],
   },
   {
     name: "median",
-    structure: `Median(${argsPlaceholder})`,
+    structure: `Median`,
     description: () => t`Returns the median of all the values of a column.`,
     args: [
       {
         name: t`column`,
         description: t`The numeric column whose values to average.`,
-        example: "[" + t`Quantity` + "]",
+        example: formatIdentifier(t`Quantity`),
       },
     ],
   },
   {
     name: "min",
-    structure: `Min(${argsPlaceholder})`,
+    structure: `Min`,
     description: () => t`Returns the smallest value found in the column`,
     args: [
       {
         name: t`column`,
         description: t`The numeric column whose minimum you want to find.`,
-        example: "[" + t`Salary` + "]",
+        example: formatIdentifier(t`Salary`),
       },
     ],
   },
   {
     name: "max",
-    structure: `Max(${argsPlaceholder})`,
+    structure: `Max`,
     description: () => t`Returns the largest value found in the column.`,
     args: [
       {
         name: t`column`,
         description: t`The numeric column whose maximum you want to find.`,
-        example: "[" + t`Age` + "]",
+        example: formatIdentifier(t`Age`),
       },
     ],
   },
   {
     name: "share",
-    structure: `Share(${argsPlaceholder})`,
+    structure: `Share`,
     description: () =>
       t`Returns the percent of rows in the data that match the condition, as a decimal.`,
     args: [
       {
         name: t`condition`,
         description: t`Something that should evaluate to true or false.`,
-        example: "[" + t`Source` + '] = "' + t`Google` + '"',
+        example: `${formatIdentifier(t`Source`)} = ${formatStringLiteral(
+          t`Google`,
+        )}`,
       },
     ],
   },
   {
     name: "count-where",
-    structure: `CountIf(${argsPlaceholder})`,
+    structure: `CountIf`,
     description: () => t`Only counts rows where the condition is true.`,
     args: [
       {
         name: t`condition`,
         description: t`Something that should evaluate to true or false.`,
-        example: "[" + t`Subtotal` + "] > 100",
+        example: `${formatIdentifier(t`Subtotal`)} > 100`,
       },
     ],
   },
   {
     name: "sum-where",
-    structure: `SumIf(${argsPlaceholder})`,
+    structure: `SumIf`,
     description: () =>
       t`Sums up the specified column only for rows where the condition is true.`,
     args: [
       {
         name: t`column`,
         description: t`The numeric column to sum.`,
-        example: "[" + t`Subtotal` + "]",
+        example: formatIdentifier(t`Subtotal`),
       },
       {
         name: t`condition`,
         description: t`Something that should evaluate to true or false.`,
-        example: "[" + t`Order Status` + '] = "' + t`Valid` + '")',
+        example: `${formatIdentifier(t`Order Status`)} = ${formatStringLiteral(
+          t`Valid`,
+        )}`,
       },
     ],
   },
   {
     name: "var",
-    structure: `Variance(${argsPlaceholder})`,
+    structure: `Variance`,
     description: () => t`Returns the numeric variance for a given column.`,
     args: [
       {
         name: t`column`,
         description: t`The column or number to get the variance of.`,
-        example: "[" + t`Temperature` + "]",
+        example: formatIdentifier(t`Temperature`),
       },
     ],
   },
   {
     name: "median",
-    structure: `Median(${argsPlaceholder})`,
+    structure: `Median`,
     description: () => t`Returns the median value of the specified column.`,
     args: [
       {
         name: t`column`,
         description: t`The column or number to get the median of.`,
-        example: "[" + t`Age` + "]",
+        example: formatIdentifier(t`Age`),
       },
     ],
   },
   {
     name: "percentile",
-    structure: `Percentile(${argsPlaceholder})`,
+    structure: `Percentile`,
     description: () =>
       t`Returns the value of the column at the percentile value.`,
     args: [
       {
         name: t`column`,
         description: t`The column or number to get the percentile of.`,
-        example: "[" + t`Score` + "]",
+        example: formatIdentifier(t`Score`),
       },
       {
         name: t`percentile-value`,
@@ -220,37 +223,37 @@ const helperTextStrings: HelpTextConfig[] = [
   },
   {
     name: "lower",
-    structure: `lower(${argsPlaceholder})`,
+    structure: `lower`,
     description: () => t`Returns the string of text in all lower case.`,
     args: [
       {
         name: t`text`,
         description: t`The column with values to convert to lower case.`,
-        example: "[" + t`Status` + "]",
+        example: formatIdentifier(t`Status`),
       },
     ],
   },
   {
     name: "upper",
-    structure: `upper(${argsPlaceholder})`,
+    structure: `upper`,
     description: () => t`Returns the text in all upper case.`,
     args: [
       {
         name: t`text`,
         description: t`The column with values to convert to upper case.`,
-        example: "[" + t`Status` + "]",
+        example: formatIdentifier(t`Status`),
       },
     ],
   },
   {
     name: "substring",
-    structure: `substring(${argsPlaceholder})`,
+    structure: `substring`,
     description: () => t`Returns a portion of the supplied text.`,
     args: [
       {
         name: t`text`,
         description: t`The column or text to return a portion of.`,
-        example: "[" + t`Title` + "]",
+        example: formatIdentifier(t`Title`),
       },
       {
         name: t`position`,
@@ -267,188 +270,188 @@ const helperTextStrings: HelpTextConfig[] = [
   },
   {
     name: "regex-match-first",
-    structure: `regexextract(${argsPlaceholder})`,
+    structure: `regexextract`,
     description: () =>
       t`Extracts matching substrings according to a regular expression.`,
     args: [
       {
         name: t`text`,
         description: t`The column or text to search through.`,
-        example: "[" + t`Address` + "]",
+        example: formatIdentifier(t`Address`),
       },
       {
         name: t`regular_expression`,
         description: t`The regular expression to match.`,
-        example: '"[0-9]+"',
+        example: formatStringLiteral("[0-9]+"),
       },
     ],
     docsPage: "regexextract",
   },
   {
     name: "concat",
-    structure: `concat(${argsPlaceholder})`,
+    structure: `concat`,
     description: () => t`Combine two or more strings of text together.`,
     args: [
       {
         name: t`value1`,
         description: t`The column or text to begin with.`,
-        example: "[" + t`Last Name` + "]",
+        example: formatIdentifier(t`Last Name`),
       },
       {
         name: t`value2`,
         description: t`This will be added to the end of value1.`,
-        example: "[" + t`First Name` + "]",
+        example: formatStringLiteral(", "),
       },
       {
         name: "…",
         description: t`This will be added to the end of value2, and so on.`,
-        example: "[" + t`First Name` + "]",
+        example: formatIdentifier(t`First Name`),
       },
     ],
     docsPage: "concat",
   },
   {
     name: "replace",
-    structure: `replace(${argsPlaceholder})`,
+    structure: `replace`,
     description: () => t`Replaces a part of the input text with new text.`,
     args: [
       {
         name: t`text`,
         description: t`The column or text to search through.`,
-        example: "[" + t`Title` + "]",
+        example: formatIdentifier(t`Title`),
       },
       {
         name: t`find`,
         description: t`The text to find.`,
-        example: '"' + t`Enormous` + '"',
+        example: formatStringLiteral(t`Enormous`),
       },
       {
         name: t`replace`,
         description: t`The text to use as the replacement.`,
-        example: '"' + t`Gigantic` + '"',
+        example: formatStringLiteral(t`Gigantic`),
       },
     ],
   },
   {
     name: "length",
-    structure: `length(${argsPlaceholder})`,
+    structure: `length`,
     description: () => t`Returns the number of characters in text.`,
     args: [
       {
         name: t`text`,
         description: t`The column or text you want to get the length of.`,
-        example: "[" + t`Comment` + "]",
+        example: formatIdentifier(t`Comment`),
       },
     ],
   },
   {
     name: "trim",
-    structure: `trim(${argsPlaceholder})`,
+    structure: `trim`,
     description: () =>
       t`Removes leading and trailing whitespace from a string of text.`,
     args: [
       {
         name: t`text`,
         description: t`The column or text you want to trim.`,
-        example: "[" + t`Comment` + "]",
+        example: formatIdentifier(t`Comment`),
       },
     ],
   },
   {
     name: "rtrim",
-    structure: `rtrim(${argsPlaceholder})`,
+    structure: `rtrim`,
     description: () => t`Removes trailing whitespace from a string of text.`,
     args: [
       {
         name: t`text`,
         description: t`The column or text you want to trim.`,
-        example: "[" + t`Comment` + "]",
+        example: formatIdentifier(t`Comment`),
       },
     ],
   },
   {
     name: "ltrim",
-    structure: `ltrim(${argsPlaceholder})`,
+    structure: `ltrim`,
     description: () => t`Removes leading whitespace from a string of text.`,
     args: [
       {
         name: t`text`,
         description: t`The column or text you want to trim.`,
-        example: "[" + t`Comment` + "]",
+        example: formatIdentifier(t`Comment`),
       },
     ],
   },
   {
     name: "abs",
-    structure: `abs(${argsPlaceholder})`,
+    structure: `abs`,
     description: () =>
       t`Returns the absolute (positive) value of the specified column.`,
     args: [
       {
         name: t`column`,
         description: t`The column or number to return absolute (positive) value of.`,
-        example: "[" + t`Debt` + "]",
+        example: formatIdentifier(t`Debt`),
       },
     ],
   },
   {
     name: "floor",
-    structure: `floor(${argsPlaceholder})`,
+    structure: `floor`,
     description: () => t`Rounds a decimal number down.`,
     args: [
       {
         name: t`column`,
         description: t`The column or number to round down.`,
-        example: "[" + t`Price` + "]",
+        example: formatIdentifier(t`Price`),
       },
     ],
   },
   {
     name: "ceil",
-    structure: `ceil(${argsPlaceholder})`,
+    structure: `ceil`,
     description: () => t`Rounds a decimal number up.`,
     args: [
       {
         name: t`column`,
         description: t`The column or number to round up.`,
-        example: "[" + t`Price` + "]",
+        example: formatIdentifier(t`Price`),
       },
     ],
   },
   {
     name: "round",
-    structure: `round(${argsPlaceholder})`,
+    structure: `round`,
     description: () =>
       t`Rounds a decimal number either up or down to the nearest integer value.`,
     args: [
       {
         name: t`column`,
         description: t`The column or number to round to nearest integer.`,
-        example: "[" + t`Temperature` + "]",
+        example: formatIdentifier(t`Temperature`),
       },
     ],
   },
   {
     name: "sqrt",
-    structure: `sqrt(${argsPlaceholder})`,
+    structure: `sqrt`,
     description: () => t`Returns the square root.`,
     args: [
       {
         name: t`column`,
         description: t`The column or number to return square root value of.`,
-        example: "[" + t`Hypotenuse` + "]",
+        example: formatIdentifier(t`Hypotenuse`),
       },
     ],
   },
   {
     name: "power",
-    structure: `power(${argsPlaceholder})`,
+    structure: `power`,
     description: () => t`Raises a number to the power of the exponent value.`,
     args: [
       {
         name: t`column`,
         description: t`The column or number raised to the exponent.`,
-        example: "[" + t`Length` + "]",
+        example: formatIdentifier(t`Length`),
       },
       {
         name: t`exponent`,
@@ -459,132 +462,132 @@ const helperTextStrings: HelpTextConfig[] = [
   },
   {
     name: "log",
-    structure: `log(${argsPlaceholder})`,
+    structure: `log`,
     description: () => t`Returns the base 10 log of the number.`,
     args: [
       {
         name: t`column`,
         description: t`The column or number to return the natural logarithm value of.`,
-        example: "[" + t`Value` + "]",
+        example: formatIdentifier(t`Value`),
       },
     ],
   },
   {
     name: "datetime-diff",
-    structure: `datetimeDiff(${argsPlaceholder})`,
+    structure: `datetimeDiff`,
     description: () =>
       t`Get the difference between two datetime values (datetime2 minus datetime1) using the specified unit of time.`,
     args: [
       {
         name: t`datetime1`,
         description: t`The column or expression with your datetime value.`,
-        example: "[" + t`created_at` + "]",
+        example: formatIdentifier(t`created_at`),
       },
       {
         name: t`datetime2`,
         description: t`The column or expression with your datetime value.`,
-        example: "[" + t`shipped_at` + "]",
+        example: formatIdentifier(t`shipped_at`),
       },
       {
         name: t`unit`,
         description: t`Choose from: "year", "month", "week", "day", "hour", "minute", or "second".`,
-        example: '"month"',
+        example: formatStringLiteral("month"),
       },
     ],
     docsPage: "datetimediff",
   },
   {
     name: "exp",
-    structure: `exp(${argsPlaceholder})`,
+    structure: `exp`,
     description: () =>
       t`Returns Euler's number, e, raised to the power of the supplied number.`,
     args: [
       {
         name: t`column`,
         description: t`The column or number to return the exponential value of.`,
-        example: "[" + t`Interest Months` + "]",
+        example: formatIdentifier(t`Interest Months`),
       },
     ],
   },
   {
     name: "contains",
-    structure: `contains(${argsPlaceholder})`,
+    structure: `contains`,
     description: () => t`Checks to see if string1 contains string2 within it.`,
     args: [
       {
         name: t`string1`,
         description: t`The column or text to check.`,
-        example: "[" + t`Status` + "]",
+        example: formatIdentifier(t`Status`),
       },
       {
         name: t`string2`,
         description: t`The string of text to look for.`,
-        example: '"' + t`Pass` + '"',
+        example: formatStringLiteral(t`Pass`),
       },
     ],
   },
   {
     name: "starts-with",
-    structure: `startsWith(${argsPlaceholder})`,
+    structure: `startsWith`,
     description: () =>
       t`Returns true if the beginning of the text matches the comparison text.`,
     args: [
       {
         name: t`text`,
         description: t`The column or text to check.`,
-        example: "[" + t`Course Name` + "]",
+        example: formatIdentifier(t`Course Name`),
       },
       {
         name: t`comparison`,
         description: t`The string of text that the original text should start with.`,
-        example: '"' + t`Computer Science` + '"',
+        example: formatStringLiteral(t`Computer Science`),
       },
     ],
   },
   {
     name: "ends-with",
-    structure: `endsWith(${argsPlaceholder})`,
+    structure: `endsWith`,
     description: () =>
       t`Returns true if the end of the text matches the comparison text.`,
     args: [
       {
         name: t`text`,
         description: t`The column or text to check.`,
-        example: "[" + t`Appetite` + "]",
+        example: formatIdentifier(t`Appetite`),
       },
       {
         name: t`comparison`,
         description: t`The string of text that the original text should end with.`,
-        example: '"' + t`hungry` + '"',
+        example: formatStringLiteral(t`hungry`),
       },
     ],
   },
   {
     name: "between",
-    structure: `between(${argsPlaceholder})`,
+    structure: `between`,
     description: () =>
       t`Checks a date or number column's values to see if they're within the specified range.`,
     args: [
       {
         name: t`column`,
         description: t`The date or numeric column that should be within the start and end values.`,
-        example: "[" + t`Created At` + "]",
+        example: formatIdentifier(t`Created At`),
       },
       {
         name: t`start`,
         description: t`The beginning of the range.`,
-        example: '"2019-01-01"',
+        example: formatStringLiteral("2019-01-01"),
       },
       {
         name: t`end`,
         description: t`The end of the range.`,
-        example: '"2022-12-31"',
+        example: formatStringLiteral("2022-12-31"),
       },
     ],
   },
   {
     name: "interval",
-    structure: `timeSpan(${argsPlaceholder})`,
+    structure: `timeSpan`,
     description: () => t`Gets a time interval of specified length`,
     args: [
       {
@@ -595,20 +598,20 @@ const helperTextStrings: HelpTextConfig[] = [
       {
         name: t`text`,
         description: t`Type of interval like "day", "month", "year".`,
-        example: '"day"',
+        example: formatStringLiteral("day"),
       },
     ],
   },
   {
     name: "time-interval",
-    structure: `interval(${argsPlaceholder})`,
+    structure: `interval`,
     description: () =>
       t`Checks a date column's values to see if they're within the relative range.`,
     args: [
       {
         name: t`column`,
         description: t`The date column to return interval of.`,
-        example: "[" + t`Created At` + "]",
+        example: formatIdentifier(t`Created At`),
       },
       {
         name: t`number`,
@@ -618,13 +621,13 @@ const helperTextStrings: HelpTextConfig[] = [
       {
         name: t`text`,
         description: t`Type of interval like "day", "month", "year".`,
-        example: '"month"',
+        example: formatStringLiteral("month"),
       },
     ],
   },
   {
     name: "relative-datetime",
-    structure: `relativeDateTime(${argsPlaceholder})`,
+    structure: `relativeDateTime`,
     description: () => t`Gets a timestamp relative to the current time`,
     args: [
       {
@@ -635,133 +638,134 @@ const helperTextStrings: HelpTextConfig[] = [
       {
         name: t`text`,
         description: t`Type of interval like "day", "month", "year".`,
-        example: '"day"',
+        example: formatStringLiteral("day"),
       },
     ],
   },
   {
     name: "is-null",
-    structure: `isnull(${argsPlaceholder})`,
+    structure: `isnull`,
     description: () => t`Checks if a column is null`,
     args: [
       {
         name: t`column`,
         description: t`The column to check.`,
-        example: "[" + t`Discount` + "]",
+        example: formatIdentifier(t`Discount`),
       },
     ],
     docsPage: "isnull",
   },
   {
     name: "is-empty",
-    structure: `isempty(${argsPlaceholder})`,
+    structure: `isempty`,
     description: () => t`Checks if a column is empty`,
     args: [
       {
         name: t`column`,
         description: t`The column to check.`,
-        example: "[" + t`Name` + "]",
+        example: formatIdentifier(t`Name`),
       },
     ],
     docsPage: "isempty",
   },
   {
     name: "coalesce",
-    structure: `coalesce(${argsPlaceholder})`,
+    structure: `coalesce`,
     description: () =>
       t`Looks at the values in each argument in order and returns the first non-null value for each row.`,
     args: [
       {
         name: t`value1`,
         description: t`The column or value to return.`,
-        example: "[" + t`Comments` + "]",
+        example: formatIdentifier(t`Comments`),
       },
       {
         name: t`value2`,
         description: t`If value1 is empty, value2 gets returned if its not empty.`,
-        example: "[" + t`Notes` + "]",
+        example: formatIdentifier(t`Notes`),
       },
       {
         name: "…",
         description: t`If value1 is empty, and value2 is empty, the next non-empty one will be returned.`,
-        example: '"' + t`No comments` + '"',
+        example: formatStringLiteral(t`No comments`),
       },
     ],
     docsPage: "coalesce",
   },
   {
     name: "case",
-    structure: `case(${argsPlaceholder})`,
+    structure: `case`,
     description: () =>
       t`Tests an expression against a list of cases and returns the corresponding value of the first matching case, with an optional default value if nothing else is met.`,
     args: [
       {
         name: t`condition`,
         description: t`Something that should evaluate to true or false.`,
-        example: "[" + t`Weight` + "] > 200",
+        example: `${formatIdentifier(t`Weight`)} > 200`,
       },
       {
         name: t`output`,
         description: t`The value that will be returned if the preceding condition is true.`,
-        example: '"' + t`Large` + '"',
+        example: formatStringLiteral(t`Large`),
       },
       {
         name: "…",
         description: t`You can add more conditions to test.`,
-        example:
-          "[" + t`Weight` + '] > 150, "' + t`Medium` + '", "' + t`Small` + '"',
+        example: `${formatIdentifier(t`Weight`)} > 150, ${formatStringLiteral(
+          t`Medium`,
+        )}, ${formatStringLiteral(t`Small`)}`,
       },
     ],
     docsPage: "case",
   },
   {
     name: "get-year",
-    structure: `year(${argsPlaceholder})`,
+    structure: `year`,
     description: () =>
       t`Takes a datetime and returns an integer with the number of the year.`,
     args: [
       {
         name: t`column`,
         description: t`The datetime column.`,
-        example: "[" + t`Created At` + "]",
+        example: formatIdentifier(t`Created At`),
       },
     ],
   },
   {
     name: "get-quarter",
-    structure: `quarter(${argsPlaceholder})`,
+    structure: `quarter`,
     description: () =>
       t`Takes a datetime and returns an integer (1-4) with the number of the quarter in the year.`,
     args: [
       {
         name: t`column`,
         description: t`The datetime column.`,
-        example: "[" + t`Created At` + "]",
+        example: formatIdentifier(t`Created At`),
       },
     ],
   },
   {
     name: "get-month",
-    structure: `month(${argsPlaceholder})`,
+    structure: `month`,
     description: () =>
       t`Takes a datetime and returns an integer (1-12) with the number of the month in the year.`,
     args: [
       {
         name: t`column`,
         description: t`The datetime column.`,
-        example: "[" + t`Created At` + "]",
+        example: formatIdentifier(t`Created At`),
       },
     ],
   },
   {
     name: "get-week",
-    structure: `week(${argsPlaceholder})`,
+    structure: `week`,
     description: () => t`Extracts the week of the year as an integer.`,
     args: [
       {
         name: t`column`,
         description: t`The name of the column with your date or datetime value.`,
-        example: "[" + t`Created At` + "]",
+        example: formatIdentifier(t`Created At`),
       },
       {
         name: t`mode`,
@@ -770,84 +774,84 @@ const helperTextStrings: HelpTextConfig[] = [
 - US: Week 1 starts on Jan 1. All other weeks start on Sunday.
 - Instance: Week 1 starts on Jan 1. All other weeks start on the day defined in your Metabase localization settings.
 `,
-        example: '"iso"',
+        example: formatStringLiteral("iso"),
       },
     ],
   },
   {
     name: "get-day",
-    structure: `day(${argsPlaceholder})`,
+    structure: `day`,
     description: () =>
       t`Takes a datetime and returns an integer (1-31) with the number of the day of the month.`,
     args: [
       {
         name: t`column`,
         description: t`The datetime column.`,
-        example: "[" + t`Created At` + "]",
+        example: formatIdentifier(t`Created At`),
       },
     ],
   },
   {
     name: "get-day-of-week",
-    structure: `weekday(${argsPlaceholder})`,
+    structure: `weekday`,
     description: () =>
       t`Takes a datetime and returns an integer (1-7) with the number of the day of the week.`,
     args: [
       {
         name: t`column`,
         description: t`The datetime column.`,
-        example: "[" + t`Created At` + "]",
+        example: formatIdentifier(t`Created At`),
       },
     ],
   },
   {
     name: "get-hour",
-    structure: `hour(${argsPlaceholder})`,
+    structure: `hour`,
     description: () =>
       t`Takes a datetime and returns an integer (0-23) with the number of the hour. No AM/PM.`,
     args: [
       {
         name: t`column`,
         description: t`The datetime column.`,
-        example: "[" + t`Created At` + "]",
+        example: formatIdentifier(t`Created At`),
       },
     ],
   },
   {
     name: "get-minute",
-    structure: `minute(${argsPlaceholder})`,
+    structure: `minute`,
     description: () =>
       t`Takes a datetime and returns an integer (0-59) with the number of the minute in the hour.`,
     args: [
       {
         name: t`column`,
         description: t`The datetime column.`,
-        example: "[" + t`Created At` + "]",
+        example: formatIdentifier(t`Created At`),
       },
     ],
   },
   {
     name: "get-second",
-    structure: `second(${argsPlaceholder})`,
+    structure: `second`,
     description: () =>
       t`Takes a datetime and returns an integer (0-59) with the number of the seconds in the minute.`,
     args: [
       {
         name: t`column`,
         description: t`The datetime column.`,
-        example: "[" + t`Created At` + "]",
+        example: formatIdentifier(t`Created At`),
       },
     ],
   },
   {
     name: "datetime-add",
-    structure: `datetimeAdd(${argsPlaceholder})`,
+    structure: `datetimeAdd`,
     description: () => t`Adds some units of time to a date or timestamp value.`,
     args: [
       {
         name: t`column`,
         description: t`The column with your date or timestamp values.`,
-        example: "[" + t`Created At` + "]",
+        example: formatIdentifier(t`Created At`),
       },
       {
         name: t`amount`,
@@ -857,21 +861,21 @@ const helperTextStrings: HelpTextConfig[] = [
       {
         name: t`unit`,
         description: t`"year", "month", "quarter", "day", "hour", "minute", "second" or "millisecond".`,
-        example: '"month"',
+        example: formatStringLiteral("month"),
       },
     ],
     docsPage: "datetimeadd",
   },
   {
     name: "datetime-subtract",
-    structure: `datetimeSubtract(${argsPlaceholder})`,
+    structure: `datetimeSubtract`,
     description: () =>
       t`Subtracts some units of time to a date or timestamp value.`,
     args: [
       {
         name: t`column`,
         description: t`The column with your date or timestamp values.`,
-        example: "[" + t`Created At` + "]",
+        example: formatIdentifier(t`Created At`),
       },
       {
         name: t`amount`,
@@ -881,7 +885,7 @@ const helperTextStrings: HelpTextConfig[] = [
       {
         name: t`unit`,
         description: t`"year", "month", "quarter", "day", "hour", "minute", "second" or "millisecond".`,
-        example: '"month"',
+        example: formatStringLiteral("month"),
       },
     ],
     docsPage: "datetimesubtract",
@@ -890,11 +894,10 @@ const helperTextStrings: HelpTextConfig[] = [
     name: "now",
     structure: "now",
     description: getDescriptionForNow,
-    args: [],
   },
   {
     name: "convert-timezone",
-    structure: `convertTimezone(${argsPlaceholder})`,
+    structure: `convertTimezone`,
     description: () => t`Convert timezone of a date or timestamp column.
 We support tz database time zone names.
 See the full list here: https://w.wiki/4Jx`,
@@ -902,17 +905,17 @@ See the full list here: https://w.wiki/4Jx`,
       {
         name: t`column`,
         description: t`The column with your date or timestamp values.`,
-        example: "[" + t`Created At` + "]",
+        example: formatIdentifier(t`Created At`),
       },
       {
         name: t`target`,
         description: t`The timezone you want to assign to your column.`,
-        example: '"Asia/Ho_Chi_Minh"',
+        example: formatStringLiteral("Asia/Ho_Chi_Minh"),
       },
       {
         name: t`source`,
         description: t`The current time zone. Only required for timestamps with no time zone.`,
-        example: '"UTC"',
+        example: formatStringLiteral("UTC"),
       },
     ],
     docsPage: "converttimezone",
@@ -930,16 +933,20 @@ export const getHelpText = (
     return;
   }
 
-  const { structure, args, description } = helperTextConfig;
+  const { description } = helperTextConfig;
 
   return {
     ...helperTextConfig,
-    example: structure.replace(
-      HELPER_TEXT_ARGUMENTS_PLACEHOLDER,
-      args.map(({ example }) => example).join(", "),
-    ),
+    example: getHelpExample(helperTextConfig),
     description: description(database, reportTimezone),
   };
+};
+
+const getHelpExample = ({ structure, args }: HelpTextConfig): string => {
+  const exampleParameters =
+    args?.length && args.map(({ example }) => example).join(", ");
+
+  return `${structure}${exampleParameters ? `(${exampleParameters})` : ""}`;
 };
 
 const getNowAtTimezone = (timezone: string, reportTimezone: string) =>

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield/helper-text-strings.unit.spec.ts
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield/helper-text-strings.unit.spec.ts
@@ -15,13 +15,26 @@ describe("getHelpText", () => {
     expect(helpText).toBeUndefined();
   });
 
-  it("should return help text if a supported name is passed", () => {
-    const helpText = getHelpText("count", database, reportTimezone);
+  describe("should return help text if a supported name is passed", () => {
+    it("count", () => {
+      const helpText = getHelpText("count", database, reportTimezone);
 
-    expect(helpText?.structure).toBe("Count");
-    expect(helpText?.example).toBe("Count");
-    expect(helpText?.description).toMatch(/returns the count of rows/i);
-    expect(helpText?.args).toHaveLength(0);
+      expect(helpText?.structure).toBe("Count");
+      expect(helpText?.example).toBe("Count");
+      expect(helpText?.description).toMatch(/returns the count of rows/i);
+      expect(helpText?.args).toBe(undefined);
+    });
+
+    it("percentile", () => {
+      const helpText = getHelpText("percentile", database, reportTimezone);
+
+      expect(helpText?.structure).toBe("Percentile");
+      expect(helpText?.example).toBe("Percentile([Score], 0.9)");
+      expect(helpText?.description).toBe(
+        "Returns the value of the column at the percentile value.",
+      );
+      expect(helpText?.args).toHaveLength(2);
+    });
   });
 
   describe("help texts customized per database engine", () => {

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield/suggest.unit.spec.js
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield/suggest.unit.spec.js
@@ -155,22 +155,24 @@ describe("metabase/lib/expression/suggest", () => {
       });
 
       it("should provide help text for the function", () => {
-        const { structure, args } = helpText({
+        const { structure, example, args } = helpText({
           source: "substring(",
           query: ORDERS.query(),
           startRule: "expression",
         });
-        expect(structure).toEqual("substring(text, position, length)");
+        expect(structure).toEqual("substring");
+        expect(example).toEqual("substring([Title], 1, 10)");
         expect(args).toHaveLength(3);
       });
 
       it("should provide help text for the unique match", () => {
-        const { structure, args } = helpText({
+        const { structure, example, args } = helpText({
           source: "lower", // doesn't need to be "lower(" since it's a unique match
           query: ORDERS.query(),
           startRule: "expression",
         });
-        expect(structure).toEqual("lower(text)");
+        expect(structure).toEqual("lower");
+        expect(example).toEqual("lower([Status])");
         expect(args).toHaveLength(1);
       });
 

--- a/frontend/test/__support__/ui.tsx
+++ b/frontend/test/__support__/ui.tsx
@@ -10,6 +10,7 @@ import { Provider } from "react-redux";
 import { ThemeProvider } from "@emotion/react";
 import { DragDropContextProvider } from "react-dnd";
 import HTML5Backend from "react-dnd-html5-backend";
+import type { MatcherFunction } from "@testing-library/dom";
 
 import { state as sampleDatabaseReduxState } from "__support__/sample_database_fixture";
 
@@ -161,6 +162,17 @@ export function getIcon(name: string, role: ByRoleMatcher = "img") {
 
 export function queryIcon(name: string, role: ByRoleMatcher = "img") {
   return screen.queryByRole(role, { name: `${name} icon` });
+}
+
+/**
+ * Returns a matcher function to find text content that is broken up by multiple elements
+ *
+ * @param {string} textToFind
+ * @example
+ * screen.getByText(getBrokenUpTextMatcher("my text with a styled word"))
+ */
+export function getBrokenUpTextMatcher(textToFind: string): MatcherFunction {
+  return (content, element) => element?.textContent === textToFind;
 }
 
 export * from "@testing-library/react";


### PR DESCRIPTION
Relates to https://github.com/metabase/metabase/issues/28668

### Description

Add tooltips for expression helper arguments

Design - https://www.figma.com/file/68g8S9L4cMesbctGfCySl7/De-crazy-the-expression-editor-function-helper-popover?node-id=9%3A355&t=qKnJtq4qlVGzSCar-4

### How to verify

Describe the steps to verify that the changes are working as expected.

1. New question -> Sample Dataset -> Custom column
2. Write a function name, e.g. `abs`

OR

1. `yarn storybook`
2. find `ExpressionEditorHelpText` story

### Demo

https://user-images.githubusercontent.com/7983744/223212122-c0e8c4b6-c6c9-4d7b-a09f-9348087cabed.mov

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/28966)
<!-- Reviewable:end -->
