### PR TITLE
Update tools.build and usage

### DIFF
--- a/bin/build/src/build/uberjar.clj
+++ b/bin/build/src/build/uberjar.clj
@@ -38,7 +38,7 @@
 
 (defn all-paths [basis]
   (concat (:paths basis)
-          (get-in basis [:classpath-args :extra-paths])))
+          (get-in basis [:argmap :extra-paths])))
 
 (defn clean! []
   (u/step "Clean"

--- a/deps.edn
+++ b/deps.edn
@@ -472,7 +472,7 @@
     com.github.seancorfield/depstar   {:mvn/version "2.1.303"}
     expound/expound                   {:mvn/version "0.7.0"}                    ; better output of spec validation errors
     io.github.borkdude/grasp          {:mvn/version "0.0.3"}
-    io.github.clojure/tools.build     {:git/tag "v0.9.3" :git/sha "e537cd1"}
+    io.github.clojure/tools.build     {:git/tag "v0.9.4" :git/sha "76b78fe"}
     org.clojure/data.xml              {:mvn/version "0.2.0-alpha8"}
     org.clojure/tools.deps.alpha      {:mvn/version "0.12.985"}
     org.fedorahosted.tennera/jgettext {:mvn/version "0.15.1"}}


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/28975

(thanks very much @puredanger)

```clojure
uberjar=> (def basis (create-basis :oss))
,#'build.uberjar/basis
uberjar=> (:argmap basis)
nil          ;; nothing extra in oss

uberjar=> (def basis (create-basis :ee))
,#'build.uberjar/basis
uberjar=> (:argmap basis)
{:extra-paths ["enterprise/backend/src"]}

;; and if other aliases are used:
uberjar=> (def basis' (b/create-basis {:project "deps.edn" :aliases [:dev :test]}))
,#'build.uberjar/basis'
uberjar=> (:argmap basis')
{:extra-deps {lambdaisland/deep-diff2 {:mvn/version "2.7.169"},
              methodical/methodical {:mvn/version "0.15.1"},
              io.github.metabase/hawk {:sha
              "45ed36008014f9ac1ea66beb56fb1c4c39f8342b"},
              ....}
 :extra-paths ["dev/src"...]
 :jvm-opts ["-Dmb.run.mode=dev" ...]
 :exec-fn metabase.test-runner/find-and-run-tests-cli}
```

And for reference, those aliases in our deps.edn:
```clojure
  ;; include EE source code.
  :ee
  {:extra-paths ["enterprise/backend/src"]}

  ;; these aliases exist for symmetry with the ee aliases. Empty for now.
  :oss
  {}
```
