### PR TITLE
Update number of retries in Cypress run mode

### DIFF
--- a/e2e/support/config.js
+++ b/e2e/support/config.js
@@ -125,7 +125,7 @@ const mainConfig = {
     json: true,
   },
   retries: {
-    runMode: 2,
+    runMode: 5,
     openMode: 0,
   },
 };


### PR DESCRIPTION
This should help us with e2e flakes.

Our flakes are nearly always Cypress limitations, not application problems.

We could alternatively stub more of our API responses in Cypress, but then we might need a contract test layer. 

Once a test run has spent 30 minutes compiling resources, we might as well allow the run to try more times.

