### PR TITLE
Handle permissions with actions correctly

### DIFF
--- a/e2e/test/scenarios/models/model-actions.cy.spec.js
+++ b/e2e/test/scenarios/models/model-actions.cy.spec.js
@@ -24,10 +24,10 @@ const SAMPLE_ORDERS_MODEL = {
 
 const TEST_PARAMETER = createMockActionParameter({
   id: "49596bcb-62bb-49d6-a92d-bf5dbfddf43b",
-  name: "Total",
-  slug: "total",
+  name: "ID",
+  slug: "id",
   type: "number/=",
-  target: ["variable", ["template-tag", "total"]],
+  target: ["variable", ["template-tag", "id"]],
 });
 
 const TEST_TEMPLATE_TAG = {
@@ -277,37 +277,44 @@ describe(
       });
     });
 
-    it("should respect permissions", () => {
-      cy.get("@modelId").then(modelId => {
-        cy.request("POST", "/api/action", {
-          ...SAMPLE_QUERY_ACTION,
-          model_id: modelId,
+    describe("permissions", () => {
+      beforeEach(() => {
+        cy.get("@modelId").then(modelId => {
+          cy.request("POST", "/api/action", {
+            ...SAMPLE_QUERY_ACTION,
+            model_id: modelId,
+          });
         });
+      });
+
+      it("should respect permissions of the readonly user", () => {
         cy.signIn("readonly");
-        cy.visit(`/model/${modelId}/detail/actions`);
-        cy.wait("@getModel");
-      });
-
-      openActionMenuFor(SAMPLE_QUERY_ACTION.name);
-      popover().within(() => {
-        cy.findByText("Archive").should("not.exist");
-        cy.findByText("View").click();
-      });
-
-      cy.findByRole("dialog").within(() => {
-        cy.findByDisplayValue(SAMPLE_QUERY_ACTION.name).should("be.disabled");
-
-        cy.button("Save").should("not.exist");
-        cy.button("Update").should("not.exist");
-
-        assertQueryEditorDisabled();
-
-        cy.findByRole("form").within(() => {
-          cy.icon("gear").should("not.exist");
+        cy.get("@modelId").then(modelId => {
+          cy.visit(`/model/${modelId}/detail/actions`);
+          cy.wait("@getModel");
         });
 
-        cy.findByLabelText("Action settings").click();
-        cy.findByLabelText("Success message").should("be.disabled");
+        openActionMenuFor(SAMPLE_QUERY_ACTION.name);
+        popover().within(() => {
+          cy.findByText("Archive").should("not.exist");
+          cy.findByText("View").click();
+        });
+
+        cy.findByRole("dialog").within(() => {
+          cy.findByDisplayValue(SAMPLE_QUERY_ACTION.name).should("be.disabled");
+
+          cy.button("Save").should("not.exist");
+          cy.button("Update").should("not.exist");
+
+          assertQueryEditorDisabled();
+
+          cy.findByRole("form").within(() => {
+            cy.icon("gear").should("not.exist");
+          });
+
+          cy.findByLabelText("Action settings").click();
+          cy.findByLabelText("Success message").should("be.disabled");
+        });
       });
     });
   },

--- a/e2e/test/scenarios/models/model-actions.cy.spec.js
+++ b/e2e/test/scenarios/models/model-actions.cy.spec.js
@@ -1,24 +1,25 @@
 import {
+  createAction,
   enableActionsForDB,
+  fillActionQuery,
   modal,
   popover,
   restore,
-  fillActionQuery,
-  createAction,
 } from "e2e/support/helpers";
 
 import { createMockActionParameter } from "metabase-types/api/mocks";
+import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
+import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 
-const PG_DB_ID = 2;
-const PG_ORDERS_TABLE_ID = 9;
+const { ORDERS_ID } = SAMPLE_DATABASE;
 
 const SAMPLE_ORDERS_MODEL = {
   name: "Order",
   dataset: true,
   display: "table",
-  database: PG_DB_ID,
+  database: SAMPLE_DB_ID,
   query: {
-    "source-table": PG_ORDERS_TABLE_ID,
+    "source-table": ORDERS_ID,
   },
 };
 
@@ -42,7 +43,7 @@ const SAMPLE_QUERY_ACTION = {
   name: "Demo Action",
   type: "query",
   parameters: [TEST_PARAMETER],
-  database_id: PG_DB_ID,
+  database_id: SAMPLE_DB_ID,
   dataset_query: {
     type: "native",
     native: {
@@ -51,7 +52,7 @@ const SAMPLE_QUERY_ACTION = {
         [TEST_TEMPLATE_TAG.name]: TEST_TEMPLATE_TAG,
       },
     },
-    database: PG_DB_ID,
+    database: SAMPLE_DB_ID,
   },
   visualization_settings: {
     fields: {
@@ -65,260 +66,119 @@ const SAMPLE_QUERY_ACTION = {
   },
 };
 
-describe(
-  "scenarios > models > actions",
-  { tags: ["@external", "@actions"] },
-  () => {
-    beforeEach(() => {
-      restore("postgres-12");
-      cy.signInAsAdmin();
-      enableActionsForDB(PG_DB_ID);
+describe("scenarios > models > actions", { tags: ["@actions"] }, () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+    enableActionsForDB(SAMPLE_DB_ID);
 
-      cy.createQuestion(SAMPLE_ORDERS_MODEL, {
-        wrapId: true,
-        idAlias: "modelId",
-      });
-
-      cy.intercept("GET", "/api/card/*").as("getModel");
-      cy.intercept("PUT", "/api/action/*").as("updateAction");
+    cy.createQuestion(SAMPLE_ORDERS_MODEL, {
+      wrapId: true,
+      idAlias: "modelId",
     });
 
-    it("should allow to view, create, edit, and archive model actions", () => {
-      cy.get("@modelId").then(id => {
-        cy.visit(`/model/${id}/detail`);
-        cy.wait("@getModel");
-      });
+    cy.intercept("GET", "/api/card/*").as("getModel");
+    cy.intercept("PUT", "/api/action/*").as("updateAction");
+    cy.signOut();
+  });
 
-      cy.findByText("Actions").click();
-
-      cy.findByRole("button", { name: /Create basic actions/i }).click();
-      cy.findByLabelText("Action list").within(() => {
-        cy.findByText("Create").should("be.visible");
-        cy.findByText("Update").should("be.visible");
-        cy.findByText("Delete").should("be.visible");
-      });
-
-      cy.findByRole("link", { name: "New action" }).click();
-      fillActionQuery("DELETE FROM orders WHERE id = {{ id }}");
-      cy.findByRole("radiogroup", { name: "Field type" })
-        .findByText("Number")
-        .click();
-      cy.findByRole("button", { name: "Save" }).click();
-      modal().within(() => {
-        cy.findByLabelText("Name").type("Delete Order");
-        cy.findByRole("button", { name: "Create" }).click();
-      });
-      cy.findByLabelText("Action list")
-        .findByText("Delete Order")
-        .should("be.visible");
-
-      openActionEditorFor("Delete Order");
-      fillActionQuery(" AND status = 'pending'");
-      cy.findByRole("radiogroup", { name: "Field type" })
-        .findByLabelText("Number")
-        .should("be.checked");
-      cy.findByRole("button", { name: "Update" }).click();
-
-      cy.findByLabelText("Action list")
-        .findByText(
-          "DELETE FROM orders WHERE id = {{ id }} AND status = 'pending'",
-        )
-        .should("be.visible");
-
-      openActionMenuFor("Delete Order");
-      popover().findByText("Archive").click();
-
-      modal().within(() => {
-        cy.findByText("Archive Delete Order?").should("be.visible");
-        cy.findByRole("button", { name: "Archive" }).click();
-      });
-
-      cy.findByRole("listitem", { name: "Delete Order" }).should("not.exist");
-
-      cy.findByLabelText("Actions menu").click();
-      popover().findByText("Disable basic actions").click();
-      modal().within(() => {
-        cy.findByText("Disable basic actions?").should("be.visible");
-        cy.button("Disable").click();
-      });
-      cy.findByLabelText("Action list").should("not.exist");
-      cy.findByText("Create").should("not.exist");
-      cy.findByText("Update").should("not.exist");
-      cy.findByText("Delete").should("not.exist");
-    });
-
-    it("should allow to create an action with the New button", () => {
-      const QUERY = "UPDATE orders SET discount = {{ discount }}";
-      cy.visit("/");
-
-      cy.findByText("New").click();
-      popover().findByText("Action").click();
-
-      cy.findByText("Select a database").click();
-      popover().within(() => {
-        cy.findByText("Sample Database").should("not.exist");
-        cy.findByText("QA Postgres12").click();
-      });
-
-      fillActionQuery(QUERY);
-      cy.findByText(/New Action/)
-        .clear()
-        .type("Discount order");
-      cy.findByRole("button", { name: "Save" }).click();
-      modal().within(() => {
-        cy.findByText("Select a model").click();
-      });
-      popover().findByText(SAMPLE_ORDERS_MODEL.name).click();
-      cy.findByRole("button", { name: "Create" }).click();
-
-      cy.get("@modelId").then(modelId => {
-        cy.url().should("include", `/model/${modelId}/detail/actions`);
-      });
-      cy.findByText("Discount order").should("be.visible");
-      cy.findByText(QUERY).should("be.visible");
-    });
-
-    it("should allow to execute actions from the model page", () => {
-      cy.get("@modelId").then(modelId => {
-        createAction({
-          ...SAMPLE_QUERY_ACTION,
-          model_id: modelId,
+  describe("should allow to view, create, edit, and archive model actions", () => {
+    ["normal"].forEach(user => {
+      it(user, () => {
+        cy.get("@modelId").then(id => {
+          cy.signIn(user);
+          cy.visit(`/model/${id}/detail`);
+          cy.wait("@getModel");
         });
-        cy.visit(`/model/${modelId}/detail/actions`);
-        cy.wait("@getModel");
-      });
 
-      runActionFor(SAMPLE_QUERY_ACTION.name);
+        cy.findByText("Actions").click();
 
-      modal().within(() => {
-        cy.findByLabelText(TEST_PARAMETER.name).type("1");
-        cy.button("Run").click();
-      });
-
-      cy.findByText(`${SAMPLE_QUERY_ACTION.name} ran successfully`).should(
-        "be.visible",
-      );
-    });
-
-    it("should allow to make actions public and execute them", () => {
-      const IMPLICIT_ACTION_NAME = "Update order";
-
-      cy.get("@modelId").then(modelId => {
-        createAction({
-          ...SAMPLE_QUERY_ACTION,
-          model_id: modelId,
+        cy.findByRole("button", { name: /Create basic actions/i }).click();
+        cy.findByLabelText("Action list").within(() => {
+          cy.findByText("Create").should("be.visible");
+          cy.findByText("Update").should("be.visible");
+          cy.findByText("Delete").should("be.visible");
         });
-        createAction({
-          type: "implicit",
-          kind: "row/update",
-          name: IMPLICIT_ACTION_NAME,
-          model_id: modelId,
+
+        cy.findByRole("link", { name: "New action" }).click();
+        fillActionQuery("DELETE FROM orders WHERE id = {{ id }}");
+        cy.findByRole("radiogroup", { name: "Field type" })
+          .findByText("Number")
+          .click();
+        cy.findByRole("button", { name: "Save" }).click();
+        modal().within(() => {
+          cy.findByLabelText("Name").type("Delete Order");
+          cy.findByRole("button", { name: "Create" }).click();
         });
-        cy.visit(`/model/${modelId}/detail/actions`);
-        cy.wait("@getModel");
-      });
+        cy.findByLabelText("Action list")
+          .findByText("Delete Order")
+          .should("be.visible");
 
-      enableSharingFor(SAMPLE_QUERY_ACTION.name, {
-        publicUrlAlias: "queryActionPublicUrl",
-      });
-      enableSharingFor(IMPLICIT_ACTION_NAME, {
-        publicUrlAlias: "implicitActionPublicUrl",
-      });
+        openActionEditorFor("Delete Order");
+        fillActionQuery(" AND status = 'pending'");
+        cy.findByRole("radiogroup", { name: "Field type" })
+          .findByLabelText("Number")
+          .should("be.checked");
+        cy.findByRole("button", { name: "Update" }).click();
 
-      cy.signOut();
+        cy.findByLabelText("Action list")
+          .findByText(
+            "DELETE FROM orders WHERE id = {{ id }} AND status = 'pending'",
+          )
+          .should("be.visible");
 
-      cy.get("@queryActionPublicUrl").then(url => {
-        cy.visit(url);
-        cy.findByLabelText(TEST_PARAMETER.name).type("1");
-        cy.findByRole("button", { name: "Submit" }).click();
-        cy.findByText(`${SAMPLE_QUERY_ACTION.name} ran successfully`).should(
-          "be.visible",
-        );
-        cy.findByRole("form").should("not.exist");
-        cy.findByRole("button", { name: "Submit" }).should("not.exist");
-      });
+        openActionMenuFor("Delete Order");
+        popover().findByText("Archive").click();
 
-      cy.get("@implicitActionPublicUrl").then(url => {
-        cy.visit(url);
+        modal().within(() => {
+          cy.findByText("Archive Delete Order?").should("be.visible");
+          cy.findByRole("button", { name: "Archive" }).click();
+        });
 
-        // Order 1 has quantity 2 by default, so we're not actually mutating data
-        cy.findByLabelText("Id").type("1");
-        cy.findByLabelText(/quantity/i).type("2");
+        cy.findByRole("listitem", { name: "Delete Order" }).should("not.exist");
 
-        cy.findByRole("button", { name: "Submit" }).click();
-        cy.findByText(`${IMPLICIT_ACTION_NAME} ran successfully`).should(
-          "be.visible",
-        );
-        cy.findByRole("form").should("not.exist");
-        cy.findByRole("button", { name: "Submit" }).should("not.exist");
-      });
-
-      cy.signInAsAdmin();
-      cy.get("@modelId").then(modelId => {
-        cy.visit(`/model/${modelId}/detail/actions`);
-        cy.wait("@getModel");
-      });
-
-      disableSharingFor(SAMPLE_QUERY_ACTION.name);
-      disableSharingFor(IMPLICIT_ACTION_NAME);
-
-      cy.get("@queryActionPublicUrl").then(url => {
-        cy.visit(url);
-        cy.findByRole("form").should("not.exist");
-        cy.findByRole("button", { name: "Submit" }).should("not.exist");
-        cy.findByText("An error occurred.").should("be.visible");
-      });
-
-      cy.get("@implicitActionPublicUrl").then(url => {
-        cy.visit(url);
-        cy.findByRole("form").should("not.exist");
-        cy.findByRole("button", { name: "Submit" }).should("not.exist");
-        cy.findByText("An error occurred.").should("be.visible");
+        cy.findByLabelText("Actions menu").click();
+        popover().findByText("Disable basic actions").click();
+        modal().within(() => {
+          cy.findByText("Disable basic actions?").should("be.visible");
+          cy.button("Disable").click();
+        });
+        cy.findByLabelText("Action list").should("not.exist");
+        cy.findByText("Create").should("not.exist");
+        cy.findByText("Update").should("not.exist");
+        cy.findByText("Delete").should("not.exist");
       });
     });
+  });
 
-    describe("permissions", () => {
-      beforeEach(() => {
+  describe("should allow to execute actions from the model page", () => {
+    ["normal", "readonly", "nodata"].forEach(user => {
+      it(user, () => {
         cy.get("@modelId").then(modelId => {
-          cy.request("POST", "/api/action", {
+          cy.signInAsNormalUser();
+          createAction({
             ...SAMPLE_QUERY_ACTION,
             model_id: modelId,
           });
-        });
-      });
-
-      it("should respect permissions of the readonly user", () => {
-        cy.signIn("readonly");
-        cy.get("@modelId").then(modelId => {
+          cy.signIn(user);
           cy.visit(`/model/${modelId}/detail/actions`);
           cy.wait("@getModel");
         });
 
-        openActionMenuFor(SAMPLE_QUERY_ACTION.name);
-        popover().within(() => {
-          cy.findByText("Archive").should("not.exist");
-          cy.findByText("View").click();
+        runActionFor(SAMPLE_QUERY_ACTION.name);
+
+        modal().within(() => {
+          cy.findByLabelText(TEST_PARAMETER.name).type("1");
+          cy.button("Run").click();
         });
 
-        cy.findByRole("dialog").within(() => {
-          cy.findByDisplayValue(SAMPLE_QUERY_ACTION.name).should("be.disabled");
-
-          cy.button("Save").should("not.exist");
-          cy.button("Update").should("not.exist");
-
-          assertQueryEditorDisabled();
-
-          cy.findByRole("form").within(() => {
-            cy.icon("gear").should("not.exist");
-          });
-
-          cy.findByLabelText("Action settings").click();
-          cy.findByLabelText("Success message").should("be.disabled");
-        });
+        cy.findByText(`${SAMPLE_QUERY_ACTION.name} ran successfully`).should(
+          "be.visible",
+        );
       });
     });
-  },
-);
+  });
+});
 
 function runActionFor(actionName) {
   cy.findByRole("listitem", { name: actionName }).within(() => {
@@ -337,41 +197,4 @@ function openActionEditorFor(actionName, { isReadOnly = false } = {}) {
   popover()
     .findByText(isReadOnly ? "View" : "Edit")
     .click();
-}
-
-function assertQueryEditorDisabled() {
-  // Ace doesn't act as a normal input, so we can't use `should("be.disabled")`
-  // Instead we'd assert that a user can't type in the editor
-  fillActionQuery("QWERTY");
-  cy.findByText("QWERTY").should("not.exist");
-}
-
-function enableSharingFor(actionName, { publicUrlAlias }) {
-  openActionEditorFor(actionName);
-
-  cy.findByRole("dialog").within(() => {
-    cy.button("Action settings").click();
-    cy.findByLabelText("Make public").should("not.be.checked").click();
-    cy.findByLabelText("Public action form URL")
-      .invoke("val")
-      .then(url => {
-        cy.wrap(url).as(publicUrlAlias);
-      });
-    cy.button("Cancel").click();
-  });
-}
-
-function disableSharingFor(actionName) {
-  openActionEditorFor(actionName);
-  cy.findByRole("dialog").within(() => {
-    cy.findByRole("button", { name: "Action settings" }).click();
-    cy.findByLabelText("Make public").should("be.checked").click();
-  });
-  modal().within(() => {
-    cy.findByText("Disable this public link?").should("be.visible");
-    cy.findByRole("button", { name: "Yes" }).click();
-  });
-  cy.findByRole("dialog").within(() => {
-    cy.button("Cancel").click();
-  });
 }

--- a/e2e/test/scenarios/models/model-actions.cy.spec.js
+++ b/e2e/test/scenarios/models/model-actions.cy.spec.js
@@ -1,35 +1,33 @@
 import {
-  createAction,
-  describeEE,
   enableActionsForDB,
-  fillActionQuery,
   modal,
   popover,
   restore,
+  fillActionQuery,
+  createAction,
 } from "e2e/support/helpers";
 
 import { createMockActionParameter } from "metabase-types/api/mocks";
-import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
-import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 
-const { ORDERS_ID } = SAMPLE_DATABASE;
+const PG_DB_ID = 2;
+const PG_ORDERS_TABLE_ID = 9;
 
 const SAMPLE_ORDERS_MODEL = {
   name: "Order",
   dataset: true,
   display: "table",
-  database: SAMPLE_DB_ID,
+  database: PG_DB_ID,
   query: {
-    "source-table": ORDERS_ID,
+    "source-table": PG_ORDERS_TABLE_ID,
   },
 };
 
 const TEST_PARAMETER = createMockActionParameter({
   id: "49596bcb-62bb-49d6-a92d-bf5dbfddf43b",
-  name: "ID",
-  slug: "id",
+  name: "Total",
+  slug: "total",
   type: "number/=",
-  target: ["variable", ["template-tag", "id"]],
+  target: ["variable", ["template-tag", "total"]],
 });
 
 const TEST_TEMPLATE_TAG = {
@@ -44,7 +42,7 @@ const SAMPLE_QUERY_ACTION = {
   name: "Demo Action",
   type: "query",
   parameters: [TEST_PARAMETER],
-  database_id: SAMPLE_DB_ID,
+  database_id: PG_DB_ID,
   dataset_query: {
     type: "native",
     native: {
@@ -53,7 +51,7 @@ const SAMPLE_QUERY_ACTION = {
         [TEST_TEMPLATE_TAG.name]: TEST_TEMPLATE_TAG,
       },
     },
-    database: SAMPLE_DB_ID,
+    database: PG_DB_ID,
   },
   visualization_settings: {
     fields: {
@@ -67,164 +65,253 @@ const SAMPLE_QUERY_ACTION = {
   },
 };
 
-describe("scenarios > models > actions", { tags: ["@actions"] }, () => {
-  beforeEach(() => {
-    restore();
-    cy.signInAsAdmin();
-    enableActionsForDB(SAMPLE_DB_ID);
+describe(
+  "scenarios > models > actions",
+  { tags: ["@external", "@actions"] },
+  () => {
+    beforeEach(() => {
+      restore("postgres-12");
+      cy.signInAsAdmin();
+      enableActionsForDB(PG_DB_ID);
 
-    cy.createQuestion(SAMPLE_ORDERS_MODEL, {
-      wrapId: true,
-      idAlias: "modelId",
-    });
-
-    cy.intercept("GET", "/api/card/*").as("getModel");
-    cy.intercept("PUT", "/api/action/*").as("updateAction");
-    cy.signOut();
-  });
-
-  describe("should allow to view, create, edit, and archive model actions", () => {
-    ["normal"].forEach(user => {
-      it(user, () => {
-        cy.get("@modelId").then(id => {
-          cy.signIn(user);
-          cy.visit(`/model/${id}/detail`);
-          cy.wait("@getModel");
-        });
-
-        cy.findByText("Actions").click();
-
-        cy.findByRole("button", { name: /Create basic actions/i }).click();
-        cy.findByLabelText("Action list").within(() => {
-          cy.findByText("Create").should("be.visible");
-          cy.findByText("Update").should("be.visible");
-          cy.findByText("Delete").should("be.visible");
-        });
-
-        cy.findByRole("link", { name: "New action" }).click();
-        fillActionQuery("DELETE FROM orders WHERE id = {{ id }}");
-        cy.findByRole("radiogroup", { name: "Field type" })
-          .findByText("Number")
-          .click();
-        cy.findByRole("button", { name: "Save" }).click();
-        modal().within(() => {
-          cy.findByLabelText("Name").type("Delete Order");
-          cy.findByRole("button", { name: "Create" }).click();
-        });
-        cy.findByLabelText("Action list")
-          .findByText("Delete Order")
-          .should("be.visible");
-
-        openActionEditorFor("Delete Order");
-        fillActionQuery(" AND status = 'pending'");
-        cy.findByRole("radiogroup", { name: "Field type" })
-          .findByLabelText("Number")
-          .should("be.checked");
-        cy.findByRole("button", { name: "Update" }).click();
-
-        cy.findByLabelText("Action list")
-          .findByText(
-            "DELETE FROM orders WHERE id = {{ id }} AND status = 'pending'",
-          )
-          .should("be.visible");
-
-        openActionMenuFor("Delete Order");
-        popover().findByText("Archive").click();
-
-        modal().within(() => {
-          cy.findByText("Archive Delete Order?").should("be.visible");
-          cy.findByRole("button", { name: "Archive" }).click();
-        });
-
-        cy.findByRole("listitem", { name: "Delete Order" }).should("not.exist");
-
-        cy.findByLabelText("Actions menu").click();
-        popover().findByText("Disable basic actions").click();
-        modal().within(() => {
-          cy.findByText("Disable basic actions?").should("be.visible");
-          cy.button("Disable").click();
-        });
-        cy.findByLabelText("Action list").should("not.exist");
-        cy.findByText("Create").should("not.exist");
-        cy.findByText("Update").should("not.exist");
-        cy.findByText("Delete").should("not.exist");
+      cy.createQuestion(SAMPLE_ORDERS_MODEL, {
+        wrapId: true,
+        idAlias: "modelId",
       });
+
+      cy.intercept("GET", "/api/card/*").as("getModel");
+      cy.intercept("PUT", "/api/action/*").as("updateAction");
     });
-  });
 
-  describe("should allow to execute actions from the model page", () => {
-    ["normal", "readonly"].forEach(user => {
-      it(user, () => {
-        cy.get("@modelId").then(modelId => {
-          cy.signInAsNormalUser();
-          createAction({
-            ...SAMPLE_QUERY_ACTION,
-            model_id: modelId,
-          });
-          cy.signIn(user);
-          cy.visit(`/model/${modelId}/detail/actions`);
-          cy.wait("@getModel");
+    it("should allow to view, create, edit, and archive model actions", () => {
+      cy.get("@modelId").then(id => {
+        cy.visit(`/model/${id}/detail`);
+        cy.wait("@getModel");
+      });
+
+      cy.findByText("Actions").click();
+
+      cy.findByRole("button", { name: /Create basic actions/i }).click();
+      cy.findByLabelText("Action list").within(() => {
+        cy.findByText("Create").should("be.visible");
+        cy.findByText("Update").should("be.visible");
+        cy.findByText("Delete").should("be.visible");
+      });
+
+      cy.findByRole("link", { name: "New action" }).click();
+      fillActionQuery("DELETE FROM orders WHERE id = {{ id }}");
+      cy.findByRole("radiogroup", { name: "Field type" })
+        .findByText("Number")
+        .click();
+      cy.findByRole("button", { name: "Save" }).click();
+      modal().within(() => {
+        cy.findByLabelText("Name").type("Delete Order");
+        cy.findByRole("button", { name: "Create" }).click();
+      });
+      cy.findByLabelText("Action list")
+        .findByText("Delete Order")
+        .should("be.visible");
+
+      openActionEditorFor("Delete Order");
+      fillActionQuery(" AND status = 'pending'");
+      cy.findByRole("radiogroup", { name: "Field type" })
+        .findByLabelText("Number")
+        .should("be.checked");
+      cy.findByRole("button", { name: "Update" }).click();
+
+      cy.findByLabelText("Action list")
+        .findByText(
+          "DELETE FROM orders WHERE id = {{ id }} AND status = 'pending'",
+        )
+        .should("be.visible");
+
+      openActionMenuFor("Delete Order");
+      popover().findByText("Archive").click();
+
+      modal().within(() => {
+        cy.findByText("Archive Delete Order?").should("be.visible");
+        cy.findByRole("button", { name: "Archive" }).click();
+      });
+
+      cy.findByRole("listitem", { name: "Delete Order" }).should("not.exist");
+
+      cy.findByLabelText("Actions menu").click();
+      popover().findByText("Disable basic actions").click();
+      modal().within(() => {
+        cy.findByText("Disable basic actions?").should("be.visible");
+        cy.button("Disable").click();
+      });
+      cy.findByLabelText("Action list").should("not.exist");
+      cy.findByText("Create").should("not.exist");
+      cy.findByText("Update").should("not.exist");
+      cy.findByText("Delete").should("not.exist");
+    });
+
+    it("should allow to create an action with the New button", () => {
+      const QUERY = "UPDATE orders SET discount = {{ discount }}";
+      cy.visit("/");
+
+      cy.findByText("New").click();
+      popover().findByText("Action").click();
+
+      cy.findByText("Select a database").click();
+      popover().within(() => {
+        cy.findByText("Sample Database").should("not.exist");
+        cy.findByText("QA Postgres12").click();
+      });
+
+      fillActionQuery(QUERY);
+      cy.findByText(/New Action/)
+        .clear()
+        .type("Discount order");
+      cy.findByRole("button", { name: "Save" }).click();
+      modal().within(() => {
+        cy.findByText("Select a model").click();
+      });
+      popover().findByText(SAMPLE_ORDERS_MODEL.name).click();
+      cy.findByRole("button", { name: "Create" }).click();
+
+      cy.get("@modelId").then(modelId => {
+        cy.url().should("include", `/model/${modelId}/detail/actions`);
+      });
+      cy.findByText("Discount order").should("be.visible");
+      cy.findByText(QUERY).should("be.visible");
+    });
+
+    it("should allow to execute actions from the model page", () => {
+      cy.get("@modelId").then(modelId => {
+        createAction({
+          ...SAMPLE_QUERY_ACTION,
+          model_id: modelId,
         });
+        cy.visit(`/model/${modelId}/detail/actions`);
+        cy.wait("@getModel");
+      });
 
-        runActionFor(SAMPLE_QUERY_ACTION.name);
+      runActionFor(SAMPLE_QUERY_ACTION.name);
 
-        modal().within(() => {
-          cy.findByLabelText(TEST_PARAMETER.name).type("1");
-          cy.button("Run").click();
+      modal().within(() => {
+        cy.findByLabelText(TEST_PARAMETER.name).type("1");
+        cy.button("Run").click();
+      });
+
+      cy.findByText(`${SAMPLE_QUERY_ACTION.name} ran successfully`).should(
+        "be.visible",
+      );
+    });
+
+    it("should allow to make actions public and execute them", () => {
+      const IMPLICIT_ACTION_NAME = "Update order";
+
+      cy.get("@modelId").then(modelId => {
+        createAction({
+          ...SAMPLE_QUERY_ACTION,
+          model_id: modelId,
         });
+        createAction({
+          type: "implicit",
+          kind: "row/update",
+          name: IMPLICIT_ACTION_NAME,
+          model_id: modelId,
+        });
+        cy.visit(`/model/${modelId}/detail/actions`);
+        cy.wait("@getModel");
+      });
 
+      enableSharingFor(SAMPLE_QUERY_ACTION.name, {
+        publicUrlAlias: "queryActionPublicUrl",
+      });
+      enableSharingFor(IMPLICIT_ACTION_NAME, {
+        publicUrlAlias: "implicitActionPublicUrl",
+      });
+
+      cy.signOut();
+
+      cy.get("@queryActionPublicUrl").then(url => {
+        cy.visit(url);
+        cy.findByLabelText(TEST_PARAMETER.name).type("1");
+        cy.findByRole("button", { name: "Submit" }).click();
         cy.findByText(`${SAMPLE_QUERY_ACTION.name} ran successfully`).should(
           "be.visible",
         );
+        cy.findByRole("form").should("not.exist");
+        cy.findByRole("button", { name: "Submit" }).should("not.exist");
       });
-    });
-  });
-});
 
-describeEE("scenarios > models > actions", { tags: ["@actions"] }, () => {
-  beforeEach(() => {
-    restore();
-    cy.signInAsAdmin();
-    enableActionsForDB(SAMPLE_DB_ID);
+      cy.get("@implicitActionPublicUrl").then(url => {
+        cy.visit(url);
 
-    cy.createQuestion(SAMPLE_ORDERS_MODEL, {
-      wrapId: true,
-      idAlias: "modelId",
-    });
+        // Order 1 has quantity 2 by default, so we're not actually mutating data
+        cy.findByLabelText("Id").type("1");
+        cy.findByLabelText(/quantity/i).type("2");
 
-    cy.intercept("GET", "/api/card/*").as("getModel");
-    cy.intercept("PUT", "/api/action/*").as("updateAction");
-    cy.signOut();
-  });
-
-  describe("should allow to execute actions from the model page", () => {
-    ["sandboxed"].forEach(user => {
-      it(user, () => {
-        cy.get("@modelId").then(modelId => {
-          cy.signInAsNormalUser();
-          createAction({
-            ...SAMPLE_QUERY_ACTION,
-            model_id: modelId,
-          });
-          cy.signIn(user);
-          cy.visit(`/model/${modelId}/detail/actions`);
-          cy.wait("@getModel");
-        });
-
-        runActionFor(SAMPLE_QUERY_ACTION.name);
-
-        modal().within(() => {
-          cy.findByLabelText(TEST_PARAMETER.name).type("1");
-          cy.button("Run").click();
-        });
-
-        cy.findByText(`${SAMPLE_QUERY_ACTION.name} ran successfully`).should(
+        cy.findByRole("button", { name: "Submit" }).click();
+        cy.findByText(`${IMPLICIT_ACTION_NAME} ran successfully`).should(
           "be.visible",
         );
+        cy.findByRole("form").should("not.exist");
+        cy.findByRole("button", { name: "Submit" }).should("not.exist");
+      });
+
+      cy.signInAsAdmin();
+      cy.get("@modelId").then(modelId => {
+        cy.visit(`/model/${modelId}/detail/actions`);
+        cy.wait("@getModel");
+      });
+
+      disableSharingFor(SAMPLE_QUERY_ACTION.name);
+      disableSharingFor(IMPLICIT_ACTION_NAME);
+
+      cy.get("@queryActionPublicUrl").then(url => {
+        cy.visit(url);
+        cy.findByRole("form").should("not.exist");
+        cy.findByRole("button", { name: "Submit" }).should("not.exist");
+        cy.findByText("An error occurred.").should("be.visible");
+      });
+
+      cy.get("@implicitActionPublicUrl").then(url => {
+        cy.visit(url);
+        cy.findByRole("form").should("not.exist");
+        cy.findByRole("button", { name: "Submit" }).should("not.exist");
+        cy.findByText("An error occurred.").should("be.visible");
       });
     });
-  });
-});
+
+    it("should respect permissions", () => {
+      cy.get("@modelId").then(modelId => {
+        cy.request("POST", "/api/action", {
+          ...SAMPLE_QUERY_ACTION,
+          model_id: modelId,
+        });
+        cy.signIn("readonly");
+        cy.visit(`/model/${modelId}/detail/actions`);
+        cy.wait("@getModel");
+      });
+
+      openActionMenuFor(SAMPLE_QUERY_ACTION.name);
+      popover().within(() => {
+        cy.findByText("Archive").should("not.exist");
+        cy.findByText("View").click();
+      });
+
+      cy.findByRole("dialog").within(() => {
+        cy.findByDisplayValue(SAMPLE_QUERY_ACTION.name).should("be.disabled");
+
+        cy.button("Save").should("not.exist");
+        cy.button("Update").should("not.exist");
+
+        assertQueryEditorDisabled();
+
+        cy.findByRole("form").within(() => {
+          cy.icon("gear").should("not.exist");
+        });
+
+        cy.findByLabelText("Action settings").click();
+        cy.findByLabelText("Success message").should("be.disabled");
+      });
+    });
+  },
+);
 
 function runActionFor(actionName) {
   cy.findByRole("listitem", { name: actionName }).within(() => {
@@ -243,4 +330,41 @@ function openActionEditorFor(actionName, { isReadOnly = false } = {}) {
   popover()
     .findByText(isReadOnly ? "View" : "Edit")
     .click();
+}
+
+function assertQueryEditorDisabled() {
+  // Ace doesn't act as a normal input, so we can't use `should("be.disabled")`
+  // Instead we'd assert that a user can't type in the editor
+  fillActionQuery("QWERTY");
+  cy.findByText("QWERTY").should("not.exist");
+}
+
+function enableSharingFor(actionName, { publicUrlAlias }) {
+  openActionEditorFor(actionName);
+
+  cy.findByRole("dialog").within(() => {
+    cy.button("Action settings").click();
+    cy.findByLabelText("Make public").should("not.be.checked").click();
+    cy.findByLabelText("Public action form URL")
+      .invoke("val")
+      .then(url => {
+        cy.wrap(url).as(publicUrlAlias);
+      });
+    cy.button("Cancel").click();
+  });
+}
+
+function disableSharingFor(actionName) {
+  openActionEditorFor(actionName);
+  cy.findByRole("dialog").within(() => {
+    cy.findByRole("button", { name: "Action settings" }).click();
+    cy.findByLabelText("Make public").should("be.checked").click();
+  });
+  modal().within(() => {
+    cy.findByText("Disable this public link?").should("be.visible");
+    cy.findByRole("button", { name: "Yes" }).click();
+  });
+  cy.findByRole("dialog").within(() => {
+    cy.button("Cancel").click();
+  });
 }

--- a/frontend/src/metabase-lib/Question.ts
+++ b/frontend/src/metabase-lib/Question.ts
@@ -34,8 +34,8 @@ import * as QUERY from "metabase-lib/queries/utils/query";
 import * as Urls from "metabase/lib/urls";
 import { getCardUiParameters } from "metabase-lib/parameters/utils/cards";
 import {
-  DashboardApi,
   CardApi,
+  DashboardApi,
   maybeUsePivotEndpoint,
   MetabaseApi,
 } from "metabase/services";
@@ -490,8 +490,13 @@ class QuestionInner {
 
   canWriteActions(): boolean {
     const database = this.database();
-    const hasActionsEnabled = database != null && database.hasActionsEnabled();
-    return this.canWrite() && hasActionsEnabled;
+
+    return (
+      this.canWrite() &&
+      database != null &&
+      database.canWrite() &&
+      database.hasActionsEnabled()
+    );
   }
 
   supportsImplicitActions(): boolean {

--- a/frontend/src/metabase-lib/actions/utils.ts
+++ b/frontend/src/metabase-lib/actions/utils.ts
@@ -7,7 +7,7 @@ export const canRunAction = (
   databases: Database[],
 ) => {
   const database = databases.find(({ id }) => id === action.database_id);
-  return database != null && database.canWrite();
+  return database != null && database.hasActionsEnabled();
 };
 
 export const canEditAction = (action: WritebackAction, model: Question) => {

--- a/frontend/src/metabase-lib/actions/utils.unit.spec.ts
+++ b/frontend/src/metabase-lib/actions/utils.unit.spec.ts
@@ -12,18 +12,24 @@ describe("canRunAction", () => {
     expect(canRunAction(action, [])).toBe(false);
   });
 
-  it("should not be able to run an action if the database has readonly permissions", () => {
+  it("should not be able to run an action if the database has actions disabled", () => {
     const database = new Database(
-      createMockDatabase({ native_permissions: "read" }),
+      createMockDatabase({
+        native_permissions: "write",
+        settings: { "database-enable-actions": false },
+      }),
     );
     const action = createMockQueryAction({ database_id: database.id });
 
     expect(canRunAction(action, [database])).toBe(false);
   });
 
-  it("should be able to run an acton if the database has write permissions", () => {
+  it("should be able to run an acton if the database has actions enabled", () => {
     const database = new Database(
-      createMockDatabase({ native_permissions: "write" }),
+      createMockDatabase({
+        native_permissions: "read",
+        settings: { "database-enable-actions": true },
+      }),
     );
     const action = createMockQueryAction({ database_id: database.id });
 

--- a/frontend/src/metabase-lib/actions/utils.unit.spec.ts
+++ b/frontend/src/metabase-lib/actions/utils.unit.spec.ts
@@ -24,7 +24,7 @@ describe("canRunAction", () => {
     expect(canRunAction(action, [database])).toBe(false);
   });
 
-  it("should be able to run an acton if the database has actions enabled", () => {
+  it("should be able to run an action if the database has actions enabled", () => {
     const database = new Database(
       createMockDatabase({
         native_permissions: "read",

--- a/frontend/src/metabase/models/containers/ModelDetailPage/ModelDetailPage.unit.spec.tsx
+++ b/frontend/src/metabase/models/containers/ModelDetailPage/ModelDetailPage.unit.spec.tsx
@@ -127,6 +127,11 @@ const TEST_DATABASE_WITH_ACTIONS = createMockDatabase({
   settings: { "database-enable-actions": true },
 });
 
+const TEST_DATABASE_WITH_ACTIONS_READONLY = createMockDatabase({
+  ...TEST_DATABASE_WITH_ACTIONS,
+  native_permissions: "none",
+});
+
 function getStructuredModel(card?: Partial<StructuredSavedCard>) {
   return _getStructuredModel({
     ...card,
@@ -757,6 +762,20 @@ describe("ModelDetailPage", () => {
           await setupActions({
             model: getModel(),
             databases: [TEST_DATABASE_WITH_ACTIONS],
+            actions: [action],
+          });
+
+          expect(screen.getByLabelText("Run")).toBeInTheDocument();
+        });
+
+        it("allows to run an action without native query access", async () => {
+          const action = createMockQueryAction({
+            database_id: TEST_DATABASE_WITH_ACTIONS_READONLY.id,
+          });
+
+          await setupActions({
+            model: getModel(),
+            databases: [TEST_DATABASE_WITH_ACTIONS_READONLY],
             actions: [action],
           });
 

--- a/frontend/src/metabase/models/containers/ModelDetailPage/ModelDetailPage.unit.spec.tsx
+++ b/frontend/src/metabase/models/containers/ModelDetailPage/ModelDetailPage.unit.spec.tsx
@@ -127,11 +127,6 @@ const TEST_DATABASE_WITH_ACTIONS = createMockDatabase({
   settings: { "database-enable-actions": true },
 });
 
-const TEST_DATABASE_READONLY = createMockDatabase({
-  id: 2,
-  native_permissions: "read",
-});
-
 function getStructuredModel(card?: Partial<StructuredSavedCard>) {
   return _getStructuredModel({
     ...card,
@@ -740,21 +735,21 @@ describe("ModelDetailPage", () => {
           expect(screen.queryByLabelText("Run")).not.toBeInTheDocument();
         });
 
-        it("doesn't allow to run an action if its database has no write permissions", async () => {
+        it("doesn't allow to run an action if its database has actions disabled", async () => {
           const action = createMockQueryAction({
-            database_id: TEST_DATABASE_READONLY.id,
+            database_id: TEST_DATABASE.id,
           });
 
           await setupActions({
             model: getModel(),
-            databases: [TEST_DATABASE_WITH_ACTIONS, TEST_DATABASE_READONLY],
+            databases: [TEST_DATABASE],
             actions: [action],
           });
 
           expect(screen.queryByLabelText("Run")).not.toBeInTheDocument();
         });
 
-        it("allows to run an action if its database has write permissions", async () => {
+        it("allows to run an action if its database has actions enabled", async () => {
           const action = createMockQueryAction({
             database_id: TEST_DATABASE_WITH_ACTIONS.id,
           });


### PR DESCRIPTION
Follow up https://github.com/metabase/metabase/pull/28968

Further tweaks permissions for sandboxed & nodata users based on the latest feedback:
- They should be able to run an action with only `View` access to the collection with the enclosing model
- Editing an action, on the other hand, requires native query permissions

<img width="1109" alt="Screenshot 2023-03-07 at 18 07 56" src="https://user-images.githubusercontent.com/8542534/223479846-7fae707b-c7a2-4b92-9a50-764e49bb2e90.png">
<img width="1232" alt="Screenshot 2023-03-07 at 18 06 36" src="https://user-images.githubusercontent.com/8542534/223479883-4ceb6f27-8244-49f5-b888-b671cee339b2.png">

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/28990)
<!-- Reviewable:end -->
