### PR TITLE
Fix actions behavior on the archive page

### DIFF
--- a/e2e/test/scenarios/models/model-actions.cy.spec.js
+++ b/e2e/test/scenarios/models/model-actions.cy.spec.js
@@ -5,6 +5,8 @@ import {
   restore,
   fillActionQuery,
   createAction,
+  navigationSidebar,
+  openNavigationSidebar,
 } from "e2e/support/helpers";
 
 import { createMockActionParameter } from "metabase-types/api/mocks";
@@ -83,7 +85,7 @@ describe(
       cy.intercept("PUT", "/api/action/*").as("updateAction");
     });
 
-    it("should allow to view, create, edit, and archive model actions", () => {
+    it("should allow CRUD operations on model actions", () => {
       cy.get("@modelId").then(id => {
         cy.visit(`/model/${id}/detail`);
         cy.wait("@getModel");
@@ -145,6 +147,24 @@ describe(
       cy.findByText("Create").should("not.exist");
       cy.findByText("Update").should("not.exist");
       cy.findByText("Delete").should("not.exist");
+
+      openNavigationSidebar();
+      navigationSidebar().within(() => {
+        cy.icon("ellipsis").click();
+      });
+      popover().findByText("View archive").click();
+
+      getArchiveListItem("Delete Order").within(() => {
+        cy.icon("unarchive").click({ force: true });
+      });
+      cy.findByText("Delete Order").should("not.exist");
+      cy.findByRole("button", { name: "Undo" }).click();
+      cy.findByText("Delete Order").should("be.visible");
+      getArchiveListItem("Delete Order").within(() => {
+        cy.icon("trash").click({ force: true });
+      });
+      cy.findByTestId("Delete Order").should("not.exist");
+      cy.findByRole("button", { name: "Undo" }).should("not.exist");
     });
 
     it("should allow to create an action with the New button", () => {
@@ -367,4 +387,8 @@ function disableSharingFor(actionName) {
   cy.findByRole("dialog").within(() => {
     cy.button("Cancel").click();
   });
+}
+
+function getArchiveListItem(itemName) {
+  return cy.findByTestId(`archive-item-${itemName}`);
 }

--- a/frontend/src/metabase/components/ArchivedItem.jsx
+++ b/frontend/src/metabase/components/ArchivedItem.jsx
@@ -24,7 +24,10 @@ const ArchivedItem = ({
   onToggleSelected,
   showSelect,
 }) => (
-  <div className="flex align-center p2 hover-parent hover--visibility border-bottom bg-light-hover">
+  <div
+    className="flex align-center p2 hover-parent hover--visibility border-bottom bg-light-hover"
+    data-testid={`archive-item-${name}`}
+  >
     <Swapper
       defaultElement={
         <ItemIconContainer>

--- a/frontend/src/metabase/containers/UndoListing.jsx
+++ b/frontend/src/metabase/containers/UndoListing.jsx
@@ -71,7 +71,10 @@ function UndoToast({ undo, onUndo, onDismiss }) {
             </CardContentSide>
             <CardContentSide>
               {undo.actions?.length > 0 && (
-                <UndoButton onClick={onUndo}>{t`Undo`}</UndoButton>
+                <UndoButton
+                  role="button"
+                  onClick={onUndo}
+                >{t`Undo`}</UndoButton>
               )}
               <DismissIcon name="close" onClick={onDismiss} />
             </CardContentSide>

--- a/frontend/src/metabase/entities/search.js
+++ b/frontend/src/metabase/entities/search.js
@@ -7,6 +7,7 @@ import { ObjectUnionSchema } from "metabase/schema";
 
 import { canonicalCollectionId } from "metabase/collections/utils";
 
+import Actions from "./actions";
 import Bookmarks from "./bookmarks";
 import Collections from "./collections";
 import Dashboards from "./dashboards";
@@ -91,6 +92,7 @@ export default createEntity({
   // delegate to each entity's actionShouldInvalidateLists
   actionShouldInvalidateLists(action) {
     return (
+      Actions.actionShouldInvalidateLists(action) ||
       Bookmarks.actionShouldInvalidateLists(action) ||
       Collections.actionShouldInvalidateLists(action) ||
       Dashboards.actionShouldInvalidateLists(action) ||

--- a/frontend/src/metabase/schema.js
+++ b/frontend/src/metabase/schema.js
@@ -109,6 +109,7 @@ TimelineSchema.define({
 });
 
 export const ENTITIES_SCHEMA_MAP = {
+  actions: ActionSchema,
   questions: QuestionSchema,
   bookmarks: BookmarkSchema,
   dashboards: DashboardSchema,


### PR DESCRIPTION
Epic #27581

### Description

Fixes archiving and unarchiving actions from the archive page wasn't working as expected. It was impossible to archive an action back using the "Undo" toast button. The root cause is that the actions entity wasn't properly hooked up with the Search entity used to grab archived items.

### How to verify

1. Archive a query action
2. Open `/archive`
3. Hover the archived action item and click the "unarchive" icon
4. Ensure the action disappeared from the list
5. Click the "Undo" button on the floating toast at the bottom
6. Ensure the action showed up in the archive again

### Demo

**Before**

https://user-images.githubusercontent.com/17258145/223500935-d8a602df-09da-4b71-adc2-90f428cdf805.mp4

**After**

https://user-images.githubusercontent.com/17258145/223500966-7fc6b24c-26a2-4757-a568-0c22ffd48c12.mp4

### Checklist

- [x] Tests have been added/updated to cover changes in this PR

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/28994)
<!-- Reviewable:end -->
