### PR TITLE
Fix share dashboard attachment placement

### DIFF
--- a/frontend/src/metabase/sharing/components/AddEditSidebar/AddEditEmailSidebar.jsx
+++ b/frontend/src/metabase/sharing/components/AddEditSidebar/AddEditEmailSidebar.jsx
@@ -121,7 +121,7 @@ function _AddEditEmailSidebar({
             onChange={toggleSkipIfEmpty}
           />
         </div>
-        <div className="text-bold py2 flex justify-between align-center border-top">
+        <div className="text-bold py2 flex justify-between align-center border-top flex-wrap">
           <div className="flex align-center">
             <Heading>{t`Attach results`}</Heading>
             <Icon
@@ -131,12 +131,13 @@ function _AddEditEmailSidebar({
               tooltip={t`Attachments can contain up to 2,000 rows of data.`}
             />
           </div>
+
+          <EmailAttachmentPicker
+            cards={pulse.cards}
+            pulse={pulse}
+            setPulse={setPulse}
+          />
         </div>
-        <EmailAttachmentPicker
-          cards={pulse.cards}
-          pulse={pulse}
-          setPulse={setPulse}
-        />
         {pulse.id != null && (
           <DeleteSubscriptionAction
             pulse={pulse}

--- a/frontend/src/metabase/sharing/components/EmailAttachmentPicker.jsx
+++ b/frontend/src/metabase/sharing/components/EmailAttachmentPicker.jsx
@@ -183,7 +183,7 @@ export default class EmailAttachmentPicker extends Component {
     const { isEnabled, selectedAttachmentType, selectedCardIds } = this.state;
 
     return (
-      <div>
+      <>
         <Toggle
           aria-label={t`Attach results`}
           value={isEnabled}
@@ -191,7 +191,7 @@ export default class EmailAttachmentPicker extends Component {
         />
 
         {isEnabled && (
-          <div>
+          <div className="pt1 flex-full">
             <div className="my1 flex justify-between">
               <Label className="pt1">{t`File format`}</Label>
               <SegmentedControl
@@ -236,7 +236,7 @@ export default class EmailAttachmentPicker extends Component {
             </div>
           </div>
         )}
-      </div>
+      </>
     );
   }
 }


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/14575

### Description

Place Toggle at the same line as its label "Attach results:"

### How to verify

1. Dashboard -> Subscription -> Email

### Demo

| Before                                      | After                                       |
| ------------------------------------------- | ------------------------------------------- |
| <img width="371" alt="Screenshot 2023-03-07 at 18 49 01" src="https://user-images.githubusercontent.com/35399376/223507010-51923412-899a-4530-b2dd-0af6debc2d13.png"> | <img width="381" alt="Screenshot 2023-03-07 at 18 48 11" src="https://user-images.githubusercontent.com/35399376/223507136-99f610f6-d737-4571-a456-c5d01941326c.png"> |
| <img width="367" alt="Screenshot 2023-03-07 at 18 49 11" src="https://user-images.githubusercontent.com/35399376/223507093-e3dd16d1-c16d-4f61-84cd-55030b05e5ec.png"> | <img width="368" alt="Screenshot 2023-03-07 at 18 48 24" src="https://user-images.githubusercontent.com/35399376/223507176-6c12ec39-7d68-472f-bdaa-137c8d1c8900.png"> |

### Checklist

- [NA] Tests have been added/updated to cover changes in this PR

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/28996)
<!-- Reviewable:end -->
