### PR TITLE
Error if Cypress test uses ".only"

### DIFF
--- a/e2e/.eslintrc
+++ b/e2e/.eslintrc
@@ -1,7 +1,8 @@
 {
   "rules": {
     "import/no-commonjs": 0,
-    "no-color-literals": 0
+    "no-color-literals": 0,
+    "no-only-tests/no-only-tests": "error"
   },
   "env": {
     "cypress/globals": true,


### PR DESCRIPTION
There's been some regression where `.only` stopped being caught by the linters in Cypress.

This restores the rule.