### PR TITLE
Better handle numeric action parameters with "select" and "radio" types

### DIFF
--- a/frontend/src/metabase-types/api/actions.ts
+++ b/frontend/src/metabase-types/api/actions.ts
@@ -129,6 +129,8 @@ export type Size = "small" | "medium" | "large";
 export type DateRange = [string, string];
 export type NumberRange = [number, number];
 
+export type FieldValueOptions = (string | number)[];
+
 export interface FieldSettings {
   id: string;
   name: string;
@@ -142,7 +144,7 @@ export interface FieldSettings {
   defaultValue?: string | number;
   hidden: boolean;
   range?: DateRange | NumberRange;
-  valueOptions?: (string | number)[];
+  valueOptions?: FieldValueOptions;
   width?: Size;
   height?: number;
   hasSearch?: boolean;

--- a/frontend/src/metabase/actions/components/ActionForm/ActionForm.unit.spec.tsx
+++ b/frontend/src/metabase/actions/components/ActionForm/ActionForm.unit.spec.tsx
@@ -710,6 +710,7 @@ describe("Actions > ActionForm", () => {
             "abc-123": makeFieldSettings({
               fieldType: "category",
               inputType: "select",
+              valueOptions: [],
             }),
           },
         });

--- a/frontend/src/metabase/actions/components/ActionForm/FormFieldEditor.tsx
+++ b/frontend/src/metabase/actions/components/ActionForm/FormFieldEditor.tsx
@@ -12,6 +12,7 @@ import {
   getInputTypes,
 } from "../../containers/ActionCreator/FormCreator/constants";
 
+import { inputTypeHasOptions } from "./utils";
 import { FormFieldWidget } from "./ActionFormFieldWidget";
 import {
   Column,
@@ -42,11 +43,24 @@ function FormFieldEditor({
   const inputTypes = useMemo(getInputTypes, []);
 
   const handleChangeFieldType = (nextFieldType: FieldType) => {
-    const [defaultInputType] = inputTypes[nextFieldType];
+    // When field type changes, we automatically set the first available input type
+    const [nextInputType] = inputTypes[nextFieldType];
+
+    const shouldResetOptions =
+      nextFieldType !== fieldSettings.fieldType ||
+      !inputTypeHasOptions(nextInputType.value);
+
+    const defaultValueOptions = inputTypeHasOptions(nextInputType.value)
+      ? []
+      : undefined;
+
     onChange({
       ...fieldSettings,
       fieldType: nextFieldType,
-      inputType: defaultInputType.value,
+      inputType: nextInputType.value,
+      valueOptions: shouldResetOptions
+        ? defaultValueOptions
+        : fieldSettings.valueOptions,
     });
   };
 

--- a/frontend/src/metabase/actions/components/ActionForm/FormFieldEditor.tsx
+++ b/frontend/src/metabase/actions/components/ActionForm/FormFieldEditor.tsx
@@ -43,21 +43,28 @@ function FormFieldEditor({
   const inputTypeOptions = useMemo(getInputTypes, []);
 
   const handleChangeFieldType = (nextFieldType: FieldType) => {
-    // When field type changes, we automatically set the first available input type
-    const [nextInputType] = inputTypeOptions[nextFieldType];
+    const currentInputType = fieldSettings.inputType;
+    const inputTypesForNextFieldType = inputTypeOptions[nextFieldType].map(
+      option => option.value,
+    );
+
+    // Allows to preserve dropdown/radio input types across number/string/category field types
+    const nextInputType = inputTypesForNextFieldType.includes(currentInputType)
+      ? currentInputType
+      : inputTypesForNextFieldType[0];
 
     const shouldResetOptions =
       nextFieldType !== fieldSettings.fieldType ||
-      !inputTypeHasOptions(nextInputType.value);
+      !inputTypeHasOptions(nextInputType);
 
-    const defaultValueOptions = inputTypeHasOptions(nextInputType.value)
+    const defaultValueOptions = inputTypeHasOptions(nextInputType)
       ? []
       : undefined;
 
     onChange({
       ...fieldSettings,
       fieldType: nextFieldType,
-      inputType: nextInputType.value,
+      inputType: nextInputType,
       valueOptions: shouldResetOptions
         ? defaultValueOptions
         : fieldSettings.valueOptions,

--- a/frontend/src/metabase/actions/components/ActionForm/FormFieldEditor.tsx
+++ b/frontend/src/metabase/actions/components/ActionForm/FormFieldEditor.tsx
@@ -39,12 +39,12 @@ function FormFieldEditor({
   isEditable,
   onChange,
 }: FormFieldEditorProps) {
-  const fieldTypes = useMemo(getFieldTypes, []);
-  const inputTypes = useMemo(getInputTypes, []);
+  const fieldTypeOptions = useMemo(getFieldTypes, []);
+  const inputTypeOptions = useMemo(getInputTypes, []);
 
   const handleChangeFieldType = (nextFieldType: FieldType) => {
     // When field type changes, we automatically set the first available input type
-    const [nextInputType] = inputTypes[nextFieldType];
+    const [nextInputType] = inputTypeOptions[nextFieldType];
 
     const shouldResetOptions =
       nextFieldType !== fieldSettings.fieldType ||
@@ -83,7 +83,7 @@ function FormFieldEditor({
               <Subtitle>{t`Field type`}</Subtitle>
               <Radio
                 value={fieldSettings.fieldType}
-                options={fieldTypes}
+                options={fieldTypeOptions}
                 aria-label={t`Field type`}
                 variant="bubble"
                 onChange={handleChangeFieldType}

--- a/frontend/src/metabase/actions/components/ActionForm/FormFieldEditor.unit.spec.tsx
+++ b/frontend/src/metabase/actions/components/ActionForm/FormFieldEditor.unit.spec.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import userEvent from "@testing-library/user-event";
 import {
   render,
@@ -21,20 +21,31 @@ const DEFAULT_FIELD: FormFieldEditorProps["field"] = {
 
 function setup({
   field = DEFAULT_FIELD,
-  fieldSettings = getDefaultFieldSettings(),
+  fieldSettings: initialFieldSettings = getDefaultFieldSettings(),
   isEditable = true,
   onChange = jest.fn(),
 }: Partial<FormFieldEditorProps> = {}) {
-  render(
-    <FormProvider initialValues={{}} onSubmit={jest.fn()}>
+  function WrappedFormFieldEditor() {
+    const [fieldSettings, setFieldSettings] = useState(initialFieldSettings);
+    return (
       <FormFieldEditor
         field={field}
         fieldSettings={fieldSettings}
         isEditable={isEditable}
-        onChange={onChange}
+        onChange={nextFieldSettings => {
+          onChange(nextFieldSettings);
+          setFieldSettings(nextFieldSettings);
+        }}
       />
+    );
+  }
+
+  render(
+    <FormProvider initialValues={{}} onSubmit={jest.fn()}>
+      <WrappedFormFieldEditor />
     </FormProvider>,
   );
+
   return { onChange };
 }
 
@@ -121,8 +132,8 @@ describe("FormFieldEditor", () => {
       expect(onChange).toHaveBeenLastCalledWith({
         ...initialSettings,
         fieldType: "string",
-        inputType: "string",
-        valueOptions: undefined,
+        inputType: "radio",
+        valueOptions: [],
       }),
     );
   });

--- a/frontend/src/metabase/actions/components/ActionForm/FormFieldEditor.unit.spec.tsx
+++ b/frontend/src/metabase/actions/components/ActionForm/FormFieldEditor.unit.spec.tsx
@@ -97,53 +97,57 @@ describe("FormFieldEditor", () => {
     expect(queryIcon("grabber2")).not.toBeInTheDocument();
   });
 
-  it("formats value options when switching between field and input types", async () => {
-    const initialSettings: FieldSettings = {
+  describe("field values", () => {
+    const TEST_STRING_FIELD_SETTINGS: FieldSettings = {
       ...getDefaultFieldSettings(),
       fieldType: "string",
       inputType: "select",
       valueOptions: ["1", "2", "3", "not-a-number"],
     };
-    const { onChange } = setup({ fieldSettings: initialSettings });
 
-    userEvent.click(screen.getByLabelText("Field settings"));
-    const popover = await screen.findByRole("tooltip");
+    it("keeps value options when switching between input types", async () => {
+      const { onChange } = setup({ fieldSettings: TEST_STRING_FIELD_SETTINGS });
+      userEvent.click(screen.getByLabelText("Field settings"));
+      const popover = await screen.findByRole("tooltip");
 
-    userEvent.click(
-      await within(popover).findByRole("radio", { name: "Text" }),
-    );
-    expect(onChange).toHaveBeenLastCalledWith({
-      ...initialSettings,
-      inputType: "string",
+      userEvent.click(within(popover).getByRole("radio", { name: "Text" }));
+      await waitFor(() =>
+        expect(onChange).toHaveBeenLastCalledWith({
+          ...TEST_STRING_FIELD_SETTINGS,
+          inputType: "string",
+        }),
+      );
+
+      userEvent.click(
+        within(popover).getByRole("radio", { name: "Inline select" }),
+      );
+      await waitFor(() =>
+        expect(onChange).toHaveBeenLastCalledWith({
+          ...TEST_STRING_FIELD_SETTINGS,
+          inputType: "radio",
+        }),
+      );
     });
 
-    userEvent.click(
-      await within(popover).findByRole("radio", { name: "Inline select" }),
-    );
-    await waitFor(() =>
-      expect(onChange).toHaveBeenLastCalledWith({
-        ...initialSettings,
-        inputType: "radio",
-      }),
-    );
+    it("cleans value options when switching between field types", async () => {
+      const { onChange } = setup({ fieldSettings: TEST_STRING_FIELD_SETTINGS });
 
-    userEvent.click(screen.getByText("Category"));
-    await waitFor(() =>
-      expect(onChange).toHaveBeenLastCalledWith({
-        ...initialSettings,
-        fieldType: "category",
-        inputType: "radio",
-      }),
-    );
+      userEvent.click(screen.getByText("Category"));
+      await waitFor(() =>
+        expect(onChange).toHaveBeenLastCalledWith({
+          ...TEST_STRING_FIELD_SETTINGS,
+          fieldType: "category",
+        }),
+      );
 
-    userEvent.click(screen.getByText("Number"));
-    await waitFor(() =>
-      expect(onChange).toHaveBeenLastCalledWith({
-        ...initialSettings,
-        fieldType: "number",
-        inputType: "radio",
-        valueOptions: [1, 2, 3],
-      }),
-    );
+      userEvent.click(screen.getByText("Number"));
+      await waitFor(() =>
+        expect(onChange).toHaveBeenLastCalledWith({
+          ...TEST_STRING_FIELD_SETTINGS,
+          fieldType: "number",
+          valueOptions: [1, 2, 3],
+        }),
+      );
+    });
   });
 });

--- a/frontend/src/metabase/actions/components/ActionForm/FormFieldEditor.unit.spec.tsx
+++ b/frontend/src/metabase/actions/components/ActionForm/FormFieldEditor.unit.spec.tsx
@@ -97,12 +97,12 @@ describe("FormFieldEditor", () => {
     expect(queryIcon("grabber2")).not.toBeInTheDocument();
   });
 
-  it("clears field value options on a need", async () => {
+  it("formats value options when switching between field and input types", async () => {
     const initialSettings: FieldSettings = {
       ...getDefaultFieldSettings(),
-      fieldType: "number",
+      fieldType: "string",
       inputType: "select",
-      valueOptions: [1, 2, 3],
+      valueOptions: ["1", "2", "3", "not-a-number"],
     };
     const { onChange } = setup({ fieldSettings: initialSettings });
 
@@ -110,11 +110,11 @@ describe("FormFieldEditor", () => {
     const popover = await screen.findByRole("tooltip");
 
     userEvent.click(
-      await within(popover).findByRole("radio", { name: "Number" }),
+      await within(popover).findByRole("radio", { name: "Text" }),
     );
     expect(onChange).toHaveBeenLastCalledWith({
       ...initialSettings,
-      inputType: "number",
+      inputType: "string",
     });
 
     userEvent.click(
@@ -127,13 +127,22 @@ describe("FormFieldEditor", () => {
       }),
     );
 
-    userEvent.click(screen.getByText("Text"));
+    userEvent.click(screen.getByText("Category"));
     await waitFor(() =>
       expect(onChange).toHaveBeenLastCalledWith({
         ...initialSettings,
-        fieldType: "string",
+        fieldType: "category",
         inputType: "radio",
-        valueOptions: [],
+      }),
+    );
+
+    userEvent.click(screen.getByText("Number"));
+    await waitFor(() =>
+      expect(onChange).toHaveBeenLastCalledWith({
+        ...initialSettings,
+        fieldType: "number",
+        inputType: "radio",
+        valueOptions: [1, 2, 3],
       }),
     );
   });

--- a/frontend/src/metabase/actions/components/ActionForm/FormFieldEditor.unit.spec.tsx
+++ b/frontend/src/metabase/actions/components/ActionForm/FormFieldEditor.unit.spec.tsx
@@ -129,7 +129,7 @@ describe("FormFieldEditor", () => {
       );
     });
 
-    it("cleans value options when switching between field types", async () => {
+    it("handles value options when switching between field types", async () => {
       const { onChange } = setup({ fieldSettings: TEST_STRING_FIELD_SETTINGS });
 
       userEvent.click(screen.getByText("Category"));
@@ -146,6 +146,16 @@ describe("FormFieldEditor", () => {
           ...TEST_STRING_FIELD_SETTINGS,
           fieldType: "number",
           valueOptions: [1, 2, 3],
+        }),
+      );
+
+      userEvent.click(screen.getByText("Date"));
+      await waitFor(() =>
+        expect(onChange).toHaveBeenLastCalledWith({
+          ...TEST_STRING_FIELD_SETTINGS,
+          fieldType: "date",
+          inputType: "date",
+          valueOptions: undefined,
         }),
       );
     });

--- a/frontend/src/metabase/actions/components/ActionForm/utils.ts
+++ b/frontend/src/metabase/actions/components/ActionForm/utils.ts
@@ -9,6 +9,7 @@ import type {
   InputComponentType,
   Parameter,
   WritebackParameter,
+  FieldType,
 } from "metabase-types/api";
 import type {
   ActionFormProps,
@@ -41,6 +42,12 @@ const fieldPropsTypeMap: FieldPropTypeMap = {
   radio: "radio",
 };
 
+function getSampleOptions(fieldType: FieldType) {
+  return fieldType === "number"
+    ? getOptionsFromArray([1, 2, 3])
+    : getOptionsFromArray([t`Option One`, t`Option Two`, t`Option Three`]);
+}
+
 export const getFormField = (
   parameter: Parameter,
   fieldSettings: FieldSettings,
@@ -70,7 +77,7 @@ export const getFormField = (
   if (inputTypeHasOptions(fieldSettings.inputType)) {
     fieldProps.options = fieldSettings.valueOptions?.length
       ? getOptionsFromArray(fieldSettings.valueOptions)
-      : [];
+      : getSampleOptions(fieldSettings.fieldType);
   }
 
   return fieldProps;

--- a/frontend/src/metabase/actions/components/ActionForm/utils.ts
+++ b/frontend/src/metabase/actions/components/ActionForm/utils.ts
@@ -23,14 +23,8 @@ const getOptionsFromArray = (
   options: (number | string)[],
 ): ActionFormOption[] => options.map(o => ({ name: o, value: o }));
 
-const getSampleOptions = () => [
-  { name: t`Option One`, value: 1 },
-  { name: t`Option Two`, value: 2 },
-  { name: t`Option Three`, value: 3 },
-];
-
-const inputTypeHasOptions = (fieldSettings: FieldSettings) =>
-  ["select", "radio"].includes(fieldSettings.inputType);
+export const inputTypeHasOptions = (inputType: InputSettingType) =>
+  ["select", "radio"].includes(inputType);
 
 type FieldPropTypeMap = Record<InputSettingType, InputComponentType>;
 
@@ -73,10 +67,10 @@ export const getFormField = (
     field: fieldSettings.field,
   };
 
-  if (inputTypeHasOptions(fieldSettings)) {
+  if (inputTypeHasOptions(fieldSettings.inputType)) {
     fieldProps.options = fieldSettings.valueOptions?.length
       ? getOptionsFromArray(fieldSettings.valueOptions)
-      : getSampleOptions();
+      : [];
   }
 
   return fieldProps;

--- a/frontend/src/metabase/actions/components/ActionViz/Action.tsx
+++ b/frontend/src/metabase/actions/components/ActionViz/Action.tsx
@@ -89,10 +89,10 @@ export function ActionComponent({
         action?.visualization_settings?.fields ||
         generateFieldSettingsFromParameters(action?.parameters ?? []);
 
-      const params = {
-        ...setNumericValues(dashcardParamValues, fieldSettings),
-        ...parameterMap,
-      };
+      const params = setNumericValues(
+        { ...dashcardParamValues, ...parameterMap },
+        fieldSettings,
+      );
 
       return executeRowAction({
         dashboard,

--- a/frontend/src/metabase/actions/components/ActionViz/Action.unit.spec.tsx
+++ b/frontend/src/metabase/actions/components/ActionViz/Action.unit.spec.tsx
@@ -33,7 +33,7 @@ const defaultProps = {
         }),
         createMockActionParameter({
           id: "parameter_2",
-          type: "type/Text",
+          type: "type/Integer",
           target: ["variable", ["template-tag", "2"]],
         }),
       ],
@@ -275,7 +275,7 @@ describe("Actions > ActionViz > ActionComponent", () => {
         modelId: 777,
         parameters: {
           parameter_1: "foo",
-          parameter_2: "bar",
+          parameter_2: 5,
         },
       };
 
@@ -288,9 +288,9 @@ describe("Actions > ActionViz > ActionComponent", () => {
         expect(screen.getByLabelText("Parameter 1")).toHaveValue("foo"),
       );
 
-      userEvent.type(screen.getByLabelText("Parameter 2"), "bar");
+      userEvent.type(screen.getByLabelText("Parameter 2"), "5");
       await waitFor(() =>
-        expect(screen.getByLabelText("Parameter 2")).toHaveValue("bar"),
+        expect(screen.getByLabelText("Parameter 2")).toHaveValue(5),
       );
 
       userEvent.click(screen.getByRole("button", { name: "Run" }));
@@ -308,7 +308,7 @@ describe("Actions > ActionViz > ActionComponent", () => {
         modelId: 777,
         parameters: {
           parameter_1: "foo",
-          parameter_2: "baz",
+          parameter_2: 5,
         },
       };
 
@@ -316,7 +316,7 @@ describe("Actions > ActionViz > ActionComponent", () => {
 
       await setup({
         settings: formSettings,
-        parameterValues: { "dash-param-2": "baz" },
+        parameterValues: { "dash-param-2": "5" },
       });
 
       userEvent.type(screen.getByLabelText("Parameter 1"), "foo");

--- a/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/FieldSettingsButtons.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/FieldSettingsButtons.tsx
@@ -32,6 +32,7 @@ export function FieldSettingsButtons({
     <FieldSettingsButtonsContainer>
       {hasOptions && (
         <OptionPopover
+          fieldType={fieldSettings.fieldType}
           options={fieldSettings.valueOptions ?? []}
           onChange={updateOptions}
         />

--- a/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/OptionEditor.styled.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/OptionEditor.styled.tsx
@@ -7,15 +7,22 @@ export const OptionEditorContainer = styled.div`
   display: flex;
   flex-direction: column;
   padding: ${space(2)};
+  gap: ${space(1)};
 `;
 
-export const AddMorePrompt = styled.div`
+export const AddMorePrompt = styled.div<{ isVisible: boolean }>`
   text-align: center;
   font-size: 0.875rem;
-  margin: ${space(1)} 0;
   height: 1.25rem;
   color: ${color("text-light")};
   transition: opacity 0.2s ease-in-out;
+  opacity: ${props => (props.isVisible ? 1 : 0)};
+`;
+
+export const ErrorMessage = styled.div`
+  text-align: center;
+  font-size: 0.875rem;
+  color: ${color("error")};
 `;
 
 export const TextArea = styled.textarea`

--- a/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/OptionEditor.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/OptionEditor.tsx
@@ -5,29 +5,72 @@ import TippyPopoverWithTrigger from "metabase/components/PopoverWithTrigger/Tipp
 import Button from "metabase/core/components/Button";
 import Icon from "metabase/components/Icon";
 
+import type { FieldType } from "metabase-types/api";
+
 import {
   OptionEditorContainer,
   AddMorePrompt,
+  ErrorMessage,
   TextArea,
 } from "./OptionEditor.styled";
 
-type ValueOptions = (string | number)[];
+export type ValueOptions = (string | number)[];
 
 const optionsToText = (options: ValueOptions) => options.join("\n");
 const textToOptions = (text: string): ValueOptions =>
   text.split("\n").map(option => option.trim());
 
-export const OptionPopover = ({
-  options,
-  onChange,
-}: {
+function cleanOptions(options: ValueOptions, fieldType: FieldType) {
+  if (fieldType === "number") {
+    return options.map(option => Number(option));
+  }
+  return options;
+}
+
+function validateOptions(options: ValueOptions, fieldType: FieldType) {
+  if (fieldType === "number") {
+    const isValid = options.every(option => !Number.isNaN(option));
+    return isValid ? undefined : t`Invalid number format`;
+  }
+  return;
+}
+
+export interface OptionEditorProps {
+  fieldType: FieldType;
   options: ValueOptions;
   onChange: (options: ValueOptions) => void;
-}) => {
+}
+
+export const OptionPopover = ({
+  fieldType,
+  options,
+  onChange,
+}: OptionEditorProps) => {
   const [text, setText] = useState(optionsToText(options));
-  const save = (closePopover: () => void) => {
-    onChange(textToOptions(text));
-    closePopover();
+  const [error, setError] = useState<string | null>(null);
+
+  const hasOptions = text.length > 0;
+  const isDirty = text !== optionsToText(options);
+  const hasError = Boolean(error);
+  const canSave = hasOptions && isDirty && !hasError;
+
+  const handleTextChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setText(e.target.value);
+    if (hasError) {
+      setError(null);
+    }
+  };
+
+  const handleSave = (closePopover: () => void) => {
+    setError(null);
+    const nextOptions = cleanOptions(textToOptions(text), fieldType);
+    const error = validateOptions(nextOptions, fieldType);
+    if (error) {
+      setError(error);
+    } else {
+      onChange(nextOptions);
+      closePopover();
+    }
   };
 
   return (
@@ -41,13 +84,18 @@ export const OptionPopover = ({
         <OptionEditorContainer>
           <TextArea
             value={text}
-            onChange={e => setText(e.target.value)}
+            onChange={handleTextChange}
             placeholder={t`Enter one option per line`}
           />
-          <AddMorePrompt style={{ opacity: text.length ? 1 : 0 }}>
+          <AddMorePrompt isVisible={hasOptions}>
             {t`Press enter to add another option`}
           </AddMorePrompt>
-          <Button onClick={() => save(closePopover)} small>
+          {hasError && <ErrorMessage>{error}</ErrorMessage>}
+          <Button
+            disabled={!canSave}
+            onClick={() => handleSave(closePopover)}
+            small
+          >
             {t`Save`}
           </Button>
         </OptionEditorContainer>

--- a/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/OptionEditor.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/OptionEditor.tsx
@@ -5,7 +5,7 @@ import TippyPopoverWithTrigger from "metabase/components/PopoverWithTrigger/Tipp
 import Button from "metabase/core/components/Button";
 import Icon from "metabase/components/Icon";
 
-import type { FieldType } from "metabase-types/api";
+import type { FieldType, FieldValueOptions } from "metabase-types/api";
 
 import {
   OptionEditorContainer,
@@ -14,20 +14,18 @@ import {
   TextArea,
 } from "./OptionEditor.styled";
 
-export type ValueOptions = (string | number)[];
-
-const optionsToText = (options: ValueOptions) => options.join("\n");
-const textToOptions = (text: string): ValueOptions =>
+const optionsToText = (options: FieldValueOptions) => options.join("\n");
+const textToOptions = (text: string): FieldValueOptions =>
   text.split("\n").map(option => option.trim());
 
-function cleanOptions(options: ValueOptions, fieldType: FieldType) {
+function cleanOptions(options: FieldValueOptions, fieldType: FieldType) {
   if (fieldType === "number") {
     return options.map(option => Number(option));
   }
   return options;
 }
 
-function getValidationError(options: ValueOptions, fieldType: FieldType) {
+function getValidationError(options: FieldValueOptions, fieldType: FieldType) {
   if (fieldType === "number") {
     const isValid = options.every(option => !Number.isNaN(option));
     return isValid ? undefined : t`Invalid number format`;
@@ -37,8 +35,8 @@ function getValidationError(options: ValueOptions, fieldType: FieldType) {
 
 export interface OptionEditorProps {
   fieldType: FieldType;
-  options: ValueOptions;
-  onChange: (options: ValueOptions) => void;
+  options: FieldValueOptions;
+  onChange: (options: FieldValueOptions) => void;
 }
 
 export const OptionPopover = ({

--- a/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/OptionEditor.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/OptionEditor.tsx
@@ -27,7 +27,7 @@ function cleanOptions(options: ValueOptions, fieldType: FieldType) {
   return options;
 }
 
-function validateOptions(options: ValueOptions, fieldType: FieldType) {
+function getValidationError(options: ValueOptions, fieldType: FieldType) {
   if (fieldType === "number") {
     const isValid = options.every(option => !Number.isNaN(option));
     return isValid ? undefined : t`Invalid number format`;
@@ -64,7 +64,7 @@ export const OptionPopover = ({
   const handleSave = (closePopover: () => void) => {
     setError(null);
     const nextOptions = cleanOptions(textToOptions(text), fieldType);
-    const error = validateOptions(nextOptions, fieldType);
+    const error = getValidationError(nextOptions, fieldType);
     if (error) {
       setError(error);
     } else {

--- a/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/OptionEditor.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/OptionEditor.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { t } from "ttag";
 
 import TippyPopoverWithTrigger from "metabase/components/PopoverWithTrigger/TippyPopoverWithTrigger";
@@ -51,6 +51,16 @@ export const OptionPopover = ({
   const isDirty = text !== optionsToText(options);
   const hasError = Boolean(error);
   const canSave = hasOptions && isDirty && !hasError;
+
+  useEffect(() => {
+    if (optionsToText(options) !== text) {
+      setText(optionsToText(options));
+    }
+    // Ignore text changes caused by user edits,
+    // and only trigger when options change from outside
+    // (e.g. on field type change)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [options]);
 
   const handleTextChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     setText(e.target.value);

--- a/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/OptionEditor.unit.spec.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/OptionEditor.unit.spec.tsx
@@ -1,8 +1,8 @@
 import React, { useState } from "react";
 import userEvent from "@testing-library/user-event";
 import { render, screen, getIcon } from "__support__/ui";
-import type { FieldType } from "metabase-types/api";
-import { OptionPopover, OptionEditorProps, ValueOptions } from "./OptionEditor";
+import type { FieldType, FieldValueOptions } from "metabase-types/api";
+import { OptionPopover, OptionEditorProps } from "./OptionEditor";
 
 async function baseSetup({
   fieldType = "string",
@@ -15,7 +15,7 @@ async function baseSetup({
       <OptionPopover
         fieldType={fieldType}
         options={options}
-        onChange={(nextOptions: ValueOptions) => {
+        onChange={(nextOptions: FieldValueOptions) => {
           setOptions(nextOptions);
           onChange(nextOptions);
         }}
@@ -37,7 +37,7 @@ async function baseSetup({
 const DEFAULT_STRING_OPTIONS = ["foo", "bar"];
 const DEFAULT_NUMBER_OPTIONS = [-5, 0, 5];
 
-type TestCase = [FieldType, ValueOptions];
+type TestCase = [FieldType, FieldValueOptions];
 
 describe("OptionEditor", () => {
   describe.each<TestCase>([

--- a/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/OptionEditor.unit.spec.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/OptionEditor.unit.spec.tsx
@@ -1,0 +1,107 @@
+import React, { useState } from "react";
+import userEvent from "@testing-library/user-event";
+import { render, screen, getIcon } from "__support__/ui";
+import type { FieldType } from "metabase-types/api";
+import { OptionPopover, OptionEditorProps, ValueOptions } from "./OptionEditor";
+
+async function baseSetup({
+  fieldType = "string",
+  options: initialOptions = [],
+  onChange = jest.fn(),
+}: Partial<OptionEditorProps> = {}) {
+  function UncontrolledOptionEditor() {
+    const [options, setOptions] = useState(initialOptions);
+    return (
+      <OptionPopover
+        fieldType={fieldType}
+        options={options}
+        onChange={(nextOptions: ValueOptions) => {
+          setOptions(nextOptions);
+          onChange(nextOptions);
+        }}
+      />
+    );
+  }
+
+  render(<UncontrolledOptionEditor />);
+
+  userEvent.click(getIcon("list"));
+  await screen.findByRole("tooltip");
+
+  const input = screen.getByPlaceholderText("Enter one option per line");
+  const saveButton = screen.getByRole("button", { name: "Save" });
+
+  return { input, saveButton, onChange };
+}
+
+const DEFAULT_STRING_OPTIONS = ["foo", "bar"];
+const DEFAULT_NUMBER_OPTIONS = [-5, 0, 5];
+
+type TestCase = [FieldType, ValueOptions];
+
+describe("OptionEditor", () => {
+  describe.each<TestCase>([
+    ["string", DEFAULT_STRING_OPTIONS],
+    ["number", DEFAULT_NUMBER_OPTIONS],
+  ])("given %s field type", (fieldType, options) => {
+    const setup = (options: Partial<OptionEditorProps> = {}) =>
+      baseSetup({ ...options, fieldType });
+
+    it("should render an empty state correctly", async () => {
+      const { input, saveButton } = await setup({ options: [] });
+      expect(input).toHaveValue("");
+      expect(saveButton).toBeDisabled();
+    });
+
+    it("should render initial value correctly", async () => {
+      const { input, saveButton } = await setup({ options });
+      expect(input).toHaveValue(options.join("\n"));
+      expect(saveButton).toBeDisabled();
+    });
+
+    it("should handle changes correctly", async () => {
+      const { input, saveButton, onChange } = await setup({ options: [] });
+
+      userEvent.type(input, options.join("\n"));
+      userEvent.click(saveButton);
+
+      expect(input).toHaveValue(options.join("\n"));
+      expect(saveButton).toBeDisabled();
+      expect(onChange).toHaveBeenCalledWith(options);
+    });
+
+    it("should close popover on save", async () => {
+      const { input, saveButton } = await setup({ options: [] });
+
+      userEvent.type(input, options.join("\n"));
+      userEvent.click(saveButton);
+
+      expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("given number field type", () => {
+    it("should validate values", async () => {
+      const { input, saveButton, onChange } = await baseSetup({
+        fieldType: "number",
+      });
+
+      userEvent.type(input, "foo\nbar");
+      userEvent.click(saveButton);
+
+      expect(screen.getByText("Invalid number format")).toBeInTheDocument();
+      expect(saveButton).toBeDisabled();
+      expect(onChange).not.toHaveBeenCalled();
+
+      userEvent.clear(input);
+      expect(
+        screen.queryByText("Invalid number format"),
+      ).not.toBeInTheDocument();
+
+      userEvent.type(input, "1\n2");
+      userEvent.click(saveButton);
+
+      expect(onChange).toHaveBeenCalledWith([1, 2]);
+    });
+  });
+});

--- a/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/constants.ts
+++ b/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/constants.ts
@@ -30,12 +30,7 @@ interface InputOptionType {
   name: string;
 }
 
-interface InputOptionsMap {
-  string: InputOptionType[];
-  number: InputOptionType[];
-  date: InputOptionType[];
-  category: InputOptionType[];
-}
+type InputOptionsMap = Record<FieldType, InputOptionType[]>;
 
 const getTextInputs = (): InputOptionType[] => [
   {


### PR DESCRIPTION
Closes #28953

### Description

Ensures we're coercing values for numeric parameters with "select" or "radio" input values. Adds a few safety nets to prevent us from having non-numbers in the list of options:

* adds validation to options popover before submit
* makes field type change a bit smarter: when'd try to preserve the input type and coerce `valueOptions` to a new field type and throwing away values that can't be converted (e.g. when changing from "string" to "number", value options like `[ "1", "2", "A" ]` would turn into `[ 1, 2 ]`)
* updates sample options for select/radio inputs, so numbers always use numbers and strings always use strings

### How to verify

Follows the steps from #28953

### Demo

https://user-images.githubusercontent.com/17258145/223750916-6d74f5bc-8bea-4991-93c1-7602cd0fb36f.mp4

### Checklist

- [x] Tests have been added/updated to cover changes in this PR

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/29000)
<!-- Reviewable:end -->
