### PR TITLE
Improved datetime handling in Action Forms 🥴 

### DIFF
--- a/frontend/src/metabase/actions/containers/ActionParametersInputForm/utils.ts
+++ b/frontend/src/metabase/actions/containers/ActionParametersInputForm/utils.ts
@@ -25,15 +25,15 @@ export const formatValue = (
   value: string | number | null,
   inputType?: InputSettingType,
 ) => {
-  if (!isEmpty(value)) {
+  if (!isEmpty(value) && typeof value === "string") {
     if (inputType === "date" && moment(value).isValid()) {
-      return moment(value).utc(true).format("YYYY-MM-DD");
+      return moment(stripTZInfo(value)).format("YYYY-MM-DD");
     }
     if (inputType === "datetime" && moment(value).isValid()) {
-      return moment(value).utc(true).format("YYYY-MM-DDTHH:mm:ss");
+      return moment(stripTZInfo(value)).format("YYYY-MM-DDTHH:mm:ss");
     }
     if (inputType === "time") {
-      return moment(`2020-01-10 ${value}`).utc(true).format("HH:mm:ss");
+      return moment(stripTZInfo(`2020-01-10T${value}`)).format("HH:mm:ss");
     }
   }
   return value;
@@ -51,3 +51,8 @@ export const getInitialValues = (
     ]),
   );
 };
+
+function stripTZInfo(dateOrTimeString: string) {
+  // strip everything after a trailing tz (e.g. +08:00)
+  return moment(dateOrTimeString.replace(/(\+|-)\d{2}:\d{2}$/, "")).utc(true);
+}

--- a/frontend/src/metabase/actions/containers/ActionParametersInputForm/utils.ts
+++ b/frontend/src/metabase/actions/containers/ActionParametersInputForm/utils.ts
@@ -52,7 +52,7 @@ export const getInitialValues = (
   );
 };
 
-function stripTZInfo(dateOrTimeString: string) {
+export function stripTZInfo(dateOrTimeString: string) {
   // strip everything after a trailing tz (e.g. +08:00)
   return moment(dateOrTimeString.replace(/(\+|-)\d{2}:\d{2}$/, "")).utc(true);
 }

--- a/frontend/src/metabase/actions/containers/ActionParametersInputForm/utils.unit.spec.ts
+++ b/frontend/src/metabase/actions/containers/ActionParametersInputForm/utils.unit.spec.ts
@@ -1,6 +1,28 @@
-import { getChangedValues, formatValue } from "./utils";
+import { getChangedValues, formatValue, stripTZInfo } from "./utils";
 
 describe("actions > containers > ActionParametersInputForm > utils", () => {
+  describe("stripTZInfo", () => {
+    it("should strip timezone info from dateTimes", () => {
+      const result = stripTZInfo("2020-05-01T03:30:00-02:00");
+      expect(result.format()).toEqual("2020-05-01T03:30:00Z");
+    });
+
+    it("should strip timezone info from times", () => {
+      const result = stripTZInfo("2020-05-01T03:30:00+08:00");
+      expect(result.format()).toEqual("2020-05-01T03:30:00Z");
+    });
+
+    it("should not do anything to strings without time info", () => {
+      const result = stripTZInfo("2020-05-01");
+      expect(result.format()).toEqual("2020-05-01T00:00:00Z");
+    });
+
+    it("should not do anything to strings without timezone info", () => {
+      const result = stripTZInfo("2020-05-01T03:30:00");
+      expect(result.format()).toEqual("2020-05-01T03:30:00Z");
+    });
+  });
+
   describe("formatValue", () => {
     it("ignores null values", () => {
       const result = formatValue(null);

--- a/frontend/src/metabase/actions/containers/ActionParametersInputForm/utils.unit.spec.ts
+++ b/frontend/src/metabase/actions/containers/ActionParametersInputForm/utils.unit.spec.ts
@@ -17,14 +17,28 @@ describe("actions > containers > ActionParametersInputForm > utils", () => {
       expect(result).toEqual("123");
     });
 
-    it("formats dates", () => {
-      const result = formatValue("2020-05-01T00:00:00Z", "date");
-      expect(result).toEqual("2020-05-01");
-    });
+    const timezones = ["-02:00", "-07:00", "+01:00", "+09:00"];
 
-    it("formats datetimes", () => {
-      const result = formatValue("2020-05-01T05:00:00Z", "datetime");
-      expect(result).toEqual("2020-05-01T05:00:00");
+    timezones.forEach(offset => {
+      describe(`with timezone ${offset}`, () => {
+        it("formats dates", () => {
+          const result = formatValue(`2020-05-01T00:00:00${offset}`, "date");
+          expect(result).toEqual("2020-05-01");
+        });
+
+        it("formats datetimes", () => {
+          const result = formatValue(
+            `2020-05-01T05:00:00${offset}`,
+            "datetime",
+          );
+          expect(result).toEqual("2020-05-01T05:00:00");
+        });
+
+        it("formats times", () => {
+          const result = formatValue(`05:25:30${offset}`, "time");
+          expect(result).toEqual("05:25:30");
+        });
+      });
     });
   });
 


### PR DESCRIPTION
## Description

Metabase is very smart, even with dates, which are tough. The metabase API provides dates in the user's localized timezone. Often, when we drop those dates into javascript, it very (un)helpfully decides to localize them again! leading to wrong dates.  This further updates timezone handling in the actions codebase to disregard timezone data, and trust that the backend has already done sensible things with time conversion.

Like in https://github.com/metabase/metabase/pull/28627, the goals are
- when opening an update form, we should see the same values in form that we do in table viz
- after submitting data in an action form, the user should see the same values they typed

The previous PR worked only when metabase and the database were working in the same timezone. This should work consistently regardless of where metabase's timezone is set.

![Screen Shot 2023-03-07 at 1 26 12 PM](https://user-images.githubusercontent.com/30528226/223544336-54b0df99-0fea-4d7a-af33-e069549807e5.png)


## How to verify

**1. Create a dashboard with time data and an update form**
- create a model for a table with datetime data, like orders, make sure to add a sort paramater, like sort by id ASC
- enable basic actions for that model (on the model detail page)
- create a dashboard
- add the table view of the orders model to the dashboard
- add an ID filter to the dashboard
- add an action button to the dashboard
- link the action button to the Update action on the orders model
- save the dashboard

**2. Test the timezones**
- type in any row's id to the ID filter
- click the update button
- you should see all the order data populated in the form
- the created_at field should have the same datetime value as was displayed on the table
- change the datetime value and save the action
- see that the table display shows the time you updated
- see that re-opening the update modal populates the updated time as well

**3. Really test the timezones**
- open admin settings > localization
- change your metabase instance timezone to a different timezone
- go back to your dashboard
- see that the record you changed now has a _different_ time (i.e. it was updated tot he new metabase instance time) in the table view
- see that opening the update form also populates the same time as was displayed in the table
- submit a time update
- see that the time displayed in the table is the same one you typed in the form

**4. Really really test the timezones**
If you just really love timezones, you can spin up the timezone test in `actions-on-dashboards.cy.spec.ts` with `yarn test-cypress-open-qa` and it will populate both postgres and mysql tables with lots of different date + time columns and you can test all sorts of crazy permutations on them. They work!

😩 

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
