### PR TITLE
Handle models with joins

### DIFF
--- a/src/metabase/models/persisted_info.clj
+++ b/src/metabase/models/persisted_info.clj
@@ -16,7 +16,7 @@
   of a field."
   [{field-name :name :keys [base_type effective_type]}]
   {:field-name field-name
-     :base-type (or effective_type base_type)})
+   :base-type (or effective_type base_type)})
 
 (def ^:private Metadata
   "Spec for metadata. Just asserting we have base types and names, not the full metadata of the qp."

--- a/src/metabase/query_processor/util/persisted_cache.clj
+++ b/src/metabase/query_processor/util/persisted_cache.clj
@@ -1,6 +1,5 @@
 (ns metabase.query-processor.util.persisted-cache
   (:require
-   [clojure.string :as str]
    [metabase.driver :as driver]
    [metabase.driver.ddl.interface :as ddl.i]
    [metabase.driver.sql.util :as sql.u]

--- a/src/metabase/query_processor/util/persisted_cache.clj
+++ b/src/metabase/query_processor/util/persisted_cache.clj
@@ -26,20 +26,15 @@
 (defn persisted-info-native-query
   "Returns a native query that selects from the persisted cached table from `persisted-info`. Does not check if
   persistence is appropriate. Use [[can-substitute?]] for that check."
-  [persisted-info]
-  (let [database-id (:database_id persisted-info)
-        driver      (or driver/*driver* (driver.u/database->driver database-id))]
-    (format "select %s from %s.%s"
-            (str/join ", " (map #(sql.u/quote-name
-                                  driver
-                                  :field
-                                  (:field-name %))
-                                (get-in persisted-info [:definition :field-definitions])))
+  [{:keys [database_id table_name] :as _persisted-info}]
+  (let [driver      (or driver/*driver* (driver.u/database->driver database_id))]
+    ;; select * because we don't actually know the name of the fields when in the actual query. See #28902
+    (format "select * from %s.%s"
             (sql.u/quote-name
              driver
              :table
-             (ddl.i/schema-name {:id database-id} (public-settings/site-uuid)))
+             (ddl.i/schema-name {:id database_id} (public-settings/site-uuid)))
             (sql.u/quote-name
              driver
              :table
-             (:table_name persisted-info)))))
+             table_name))))

--- a/test/metabase/driver/common/parameters/values_test.clj
+++ b/test/metabase/driver/common/parameters/values_test.clj
@@ -342,7 +342,7 @@
                 (testing "tag uses persisted table"
                   (let [pi (db/select-one 'PersistedInfo :card_id (u/the-id model))]
                     (is (= "persisted" (:state pi)))
-                    (is (re-matches #"select \"id\", \"name\" from \"metabase_cache_[a-z0-9]+_[0-9]+\".\"model_[0-9]+_model\""
+                    (is (re-matches #"select \* from \"metabase_cache_[a-z0-9]+_[0-9]+\".\"model_[0-9]+_model\""
                                     (:query
                                      (value-for-tag
                                       {:name         "card-template-tag-test"


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/28902

We had been using the metadata from the query to get column names, and then `select (column-names) from persisted-table`.

But joins affect how columns are emitted.

For this tests, using orders join to products, selecting order.total and product.category. And the metadata from running this query uses the normal names `:name "total"`, and `:name "category"`. _BUT_ the emitted sql does not use these names:

```sql
SELECT "public"."orders"."total" AS "total",
       "products"."category" AS "products__category" -- <--------
FROM "public"."orders"
LEFT JOIN "public"."products" AS "products"
       ON "public"."orders"."product_id" = "products"."id"
```

When we persist, we do `create table as <(qp/compile query)> so we were creating a column named `products__category` _NOT_ "category". But later on we would select "category" and this would blow up.

```sql
select "total", "category" -- <- category doesn't exist in this table
from "metabase_cache_424a9_8"."model_1105_txbhmkrnoy"
```

Now a query of `{:source-table "card__<model-id>"}' emits the following query when the persisted cache is substituted:

```sql
SELECT "source"."total" AS "total",
       "source"."products__category" AS "products__category"
FROM (select * from "metabase_cache_424a9_8"."model_1152_lecqfzcjke") AS
"source"
LIMIT 1048575
```
