### PR TITLE
Hide model detail new question link without data permissions

### DIFF
--- a/frontend/src/metabase/models/components/ModelDetailPage/ModelDetailPage.tsx
+++ b/frontend/src/metabase/models/components/ModelDetailPage/ModelDetailPage.tsx
@@ -76,7 +76,10 @@ function ModelDetailPage({
           </TabList>
           <TabPanel value="usage">
             <TabPanelContent>
-              <ModelUsageDetails model={model} />
+              <ModelUsageDetails
+                model={model}
+                hasNewQuestionLink={hasDataPermissions}
+              />
             </TabPanelContent>
           </TabPanel>
           <TabPanel value="schema">

--- a/frontend/src/metabase/models/components/ModelDetailPage/ModelUsageDetails/ModelUsageDetails.tsx
+++ b/frontend/src/metabase/models/components/ModelDetailPage/ModelUsageDetails/ModelUsageDetails.tsx
@@ -25,6 +25,7 @@ import { CardListItem, CardTitle } from "./ModelUsageDetails.styled";
 
 interface OwnProps {
   model: Question;
+  hasNewQuestionLink: boolean;
 }
 
 interface EntityLoaderProps {
@@ -33,18 +34,20 @@ interface EntityLoaderProps {
 
 type Props = OwnProps & EntityLoaderProps;
 
-function ModelUsageDetails({ model, cards }: Props) {
+function ModelUsageDetails({ model, cards, hasNewQuestionLink }: Props) {
   if (cards.length === 0) {
     return (
       <EmptyStateContainer>
         <EmptyStateTitle>{t`This model is not used by any questions yet.`}</EmptyStateTitle>
-        <EmptyStateActionContainer>
-          <Button
-            as={Link}
-            to={model.composeDataset().getUrl()}
-            icon="add"
-          >{t`Create a new question`}</Button>
-        </EmptyStateActionContainer>
+        {hasNewQuestionLink && (
+          <EmptyStateActionContainer>
+            <Button
+              as={Link}
+              to={model.composeDataset().getUrl()}
+              icon="add"
+            >{t`Create a new question`}</Button>
+          </EmptyStateActionContainer>
+        )}
       </EmptyStateContainer>
     );
   }

--- a/frontend/src/metabase/models/containers/ModelDetailPage/ModelDetailPage.unit.spec.tsx
+++ b/frontend/src/metabase/models/containers/ModelDetailPage/ModelDetailPage.unit.spec.tsx
@@ -729,6 +729,13 @@ describe("ModelDetailPage", () => {
           expect(screen.queryByText("Edit metadata")).not.toBeInTheDocument();
         });
 
+        it("doesn't show a new question link", async () => {
+          await setup({ model: getModel(), databases: [], tab: "usage" });
+          expect(
+            screen.queryByText(/Create a new question/i),
+          ).not.toBeInTheDocument();
+        });
+
         it("doesn't allow running actions", async () => {
           const model = getModel();
           const actions = [


### PR DESCRIPTION
Epic #27581

### Description

Hides new question link in model detail's "Used by" tab empty state if a user doesn't have required data permissions to actually make a question from a model.

### How to verify

1. Sign in as an admin
2. Add a non-admin user from `/admin/people`
3. Go to `/admin/permissions/data/database/` and disable data access for "All users" for one of the connected databases
4. Create a model based on a table in this database
5. Open `/model/:modelId/detail/usage` as an admin
6. Ensure you can see the new question button link in the empty state
7. Open the same page as a regular user created in step 2
8. Ensure you can't see the new question button link in the empty state

### Checklist

- [x] Tests have been added/updated to cover changes in this PR

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/29022)
<!-- Reviewable:end -->
