### PR TITLE
Do not show parameters for non-variable template tags in the action editor

### DIFF
--- a/e2e/support/helpers/e2e-action-helpers.js
+++ b/e2e/support/helpers/e2e-action-helpers.js
@@ -9,7 +9,9 @@ export function enableActionsForDB(dbId = SAMPLE_DB_ID) {
 }
 
 export function fillActionQuery(query) {
-  cy.get(".ace_content").type(query, { parseSpecialCharSequences: false });
+  cy.get(".ace_content:visible").type(query, {
+    parseSpecialCharSequences: false,
+  });
 }
 /**
  *

--- a/e2e/test/scenarios/models/model-actions.cy.spec.js
+++ b/e2e/test/scenarios/models/model-actions.cy.spec.js
@@ -330,6 +330,26 @@ describe(
         cy.findByLabelText("Success message").should("be.disabled");
       });
     });
+
+    it("should display parameters for variable template tags only", () => {
+      cy.visit("/");
+      cy.findByText("New").click();
+      popover().findByText("Action").click();
+      cy.findByText("Select a database").click();
+      popover().within(() => cy.findByText("QA Postgres12").click());
+
+      fillActionQuery("{{#1-orders-model}}");
+      cy.findByLabelText("#1-orders-model").should("not.exist");
+
+      fillActionQuery("{{snippet:101}}");
+      cy.findByLabelText("#1-orders-model").should("not.exist");
+      cy.findByLabelText("101").should("not.exist");
+
+      fillActionQuery("{{id}}");
+      cy.findByLabelText("#1-orders-model").should("not.exist");
+      cy.findByLabelText("101").should("not.exist");
+      cy.findByLabelText("Id").should("be.visible");
+    });
   },
 );
 

--- a/frontend/src/metabase/actions/containers/ActionCreator/utils.ts
+++ b/frontend/src/metabase/actions/containers/ActionCreator/utils.ts
@@ -75,7 +75,7 @@ export const setTemplateTagTypesFromFieldSettings = (
   const query = question.query() as NativeQuery;
   let tempQuestion = question.clone();
 
-  query.templateTagsWithoutSnippets().forEach((tag: TemplateTag) => {
+  query.variableTemplateTags().forEach((tag: TemplateTag) => {
     const currentQuery = tempQuestion.query() as NativeQuery;
     const fieldType = fields[tag.id]?.fieldType ?? "string";
     const nextTag = {


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/28983

How to test:
- New -> Action
- Enter `{{#1-orders-model}}` than `{{snippet:101}}` than `{{id}}`
- Previously you would get a parameter for a card tag until you have a variable parameter, now it's fixed
- Added a e2e test for this

<img width="955" alt="Screenshot 2023-03-08 at 17 28 49" src="https://user-images.githubusercontent.com/8542534/223755739-27e11d4d-1ade-4ae8-84e1-3a0be7e9ef68.png">

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/29028)
<!-- Reviewable:end -->
