### PR TITLE
🤖 Manual backport — Fix actions behavior on the archive page (#28994)

### DIFF
--- a/e2e/test/scenarios/models/model-actions.cy.spec.js
+++ b/e2e/test/scenarios/models/model-actions.cy.spec.js
@@ -5,6 +5,8 @@ import {
   restore,
   fillActionQuery,
   createAction,
+  navigationSidebar,
+  openNavigationSidebar,
 } from "e2e/support/helpers";
 
 import { createMockActionParameter } from "metabase-types/api/mocks";
@@ -83,7 +85,7 @@ describe(
       cy.intercept("PUT", "/api/action/*").as("updateAction");
     });
 
-    it("should allow to view, create, edit, and archive model actions", () => {
+    it("should allow CRUD operations on model actions", () => {
       cy.get("@modelId").then(id => {
         cy.visit(`/model/${id}/detail`);
         cy.wait("@getModel");
@@ -145,6 +147,24 @@ describe(
       cy.findByText("Create").should("not.exist");
       cy.findByText("Update").should("not.exist");
       cy.findByText("Delete").should("not.exist");
+
+      openNavigationSidebar();
+      navigationSidebar().within(() => {
+        cy.icon("ellipsis").click();
+      });
+      popover().findByText("View archive").click();
+
+      getArchiveListItem("Delete Order").within(() => {
+        cy.icon("unarchive").click({ force: true });
+      });
+      cy.findByText("Delete Order").should("not.exist");
+      cy.findByRole("button", { name: "Undo" }).click();
+      cy.findByText("Delete Order").should("be.visible");
+      getArchiveListItem("Delete Order").within(() => {
+        cy.icon("trash").click({ force: true });
+      });
+      cy.findByTestId("Delete Order").should("not.exist");
+      cy.findByRole("button", { name: "Undo" }).should("not.exist");
     });
 
     it("should allow to create an action with the New button", () => {
@@ -367,4 +387,8 @@ function disableSharingFor(actionName) {
   cy.findByRole("dialog").within(() => {
     cy.button("Cancel").click();
   });
+}
+
+function getArchiveListItem(itemName) {
+  return cy.findByTestId(`archive-item-${itemName}`);
 }

--- a/frontend/src/metabase/components/ArchivedItem.jsx
+++ b/frontend/src/metabase/components/ArchivedItem.jsx
@@ -24,7 +24,10 @@ const ArchivedItem = ({
   onToggleSelected,
   showSelect,
 }) => (
-  <div className="flex align-center p2 hover-parent hover--visibility border-bottom bg-light-hover">
+  <div
+    className="flex align-center p2 hover-parent hover--visibility border-bottom bg-light-hover"
+    data-testid={`archive-item-${name}`}
+  >
     <Swapper
       defaultElement={
         <ItemIconContainer>

--- a/frontend/src/metabase/containers/UndoListing.jsx
+++ b/frontend/src/metabase/containers/UndoListing.jsx
@@ -74,7 +74,7 @@ function UndoToast({ undo, onUndo, onDismiss }) {
         </CardContentSide>
         <CardContentSide>
           {undo.actions?.length > 0 && (
-            <UndoButton onClick={onUndo}>{t`Undo`}</UndoButton>
+            <UndoButton role="button" onClick={onUndo}>{t`Undo`}</UndoButton>
           )}
           <DismissIcon name="close" onClick={onDismiss} />
         </CardContentSide>

--- a/frontend/src/metabase/entities/search.js
+++ b/frontend/src/metabase/entities/search.js
@@ -7,6 +7,7 @@ import { ObjectUnionSchema } from "metabase/schema";
 
 import { canonicalCollectionId } from "metabase/collections/utils";
 
+import Actions from "./actions";
 import Bookmarks from "./bookmarks";
 import Collections from "./collections";
 import Dashboards from "./dashboards";
@@ -91,6 +92,7 @@ export default createEntity({
   // delegate to each entity's actionShouldInvalidateLists
   actionShouldInvalidateLists(action) {
     return (
+      Actions.actionShouldInvalidateLists(action) ||
       Bookmarks.actionShouldInvalidateLists(action) ||
       Collections.actionShouldInvalidateLists(action) ||
       Dashboards.actionShouldInvalidateLists(action) ||

--- a/frontend/src/metabase/schema.js
+++ b/frontend/src/metabase/schema.js
@@ -6,6 +6,7 @@ import { generateSchemaId } from "metabase-lib/metadata/utils/schema";
 import { SAVED_QUESTIONS_VIRTUAL_DB_ID } from "metabase-lib/metadata/utils/saved-questions";
 import { getUniqueFieldId } from "metabase-lib/metadata/utils/fields";
 
+export const ActionSchema = new schema.Entity("actions");
 export const QuestionSchema = new schema.Entity("questions");
 export const BookmarkSchema = new schema.Entity("bookmarks");
 export const DashboardSchema = new schema.Entity("dashboards");
@@ -107,6 +108,7 @@ TimelineSchema.define({
 });
 
 export const ENTITIES_SCHEMA_MAP = {
+  actions: ActionSchema,
   questions: QuestionSchema,
   bookmarks: BookmarkSchema,
   dashboards: DashboardSchema,


### PR DESCRIPTION
Manual backport for #28994. What changed:

1. Original PR adds a `role="button"` to `UndoListing's` `UndoButton` component. It was changed on `master` in #28994 for 47, so these changes were not backported. Simplify adding the same `role` prop to an old `UndoListing`
2. Adding a missing `ActionSchema` definition to `metabase/schemas`. The schema was added to `master` in #28836 (testing tooling PR) and wasn't backported to the release branch