### PR TITLE
Adding classname prop to ObjectDetail

### DIFF
--- a/e2e/test/scenarios/visualizations/object_detail.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/object_detail.cy.spec.js
@@ -4,11 +4,14 @@ import {
   openOrdersTable,
   openPeopleTable,
   openProductsTable,
+  visitQuestionAdhoc,
 } from "e2e/support/helpers";
 
+import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 
-const { ORDERS, ORDERS_ID, PRODUCTS, PRODUCTS_ID } = SAMPLE_DATABASE;
+const { ORDERS, ORDERS_ID, PRODUCTS, PRODUCTS_ID, PEOPLE, PEOPLE_ID } =
+  SAMPLE_DATABASE;
 
 const FIRST_ORDER_ID = 9676;
 const SECOND_ORDER_ID = 10874;
@@ -177,6 +180,49 @@ describe("scenarios > question > object details", () => {
 
     cy.location("search").should("eq", "?objectId=Rustic%20Paper%20Wallet");
     cy.findByTestId("object-detail").contains("Rustic Paper Wallet");
+  });
+
+  it("should work as a viz display type", () => {
+    const questionDetails = {
+      display: "object",
+      dataset_query: {
+        database: SAMPLE_DB_ID,
+        query: {
+          "source-table": ORDERS_ID,
+
+          joins: [
+            {
+              fields: "all",
+              "source-table": PRODUCTS_ID,
+              condition: [
+                "=",
+                ["field", ORDERS.PRODUCT_ID, null],
+                ["field", PRODUCTS.ID, { "join-alias": "Products" }],
+              ],
+              alias: "Products",
+            },
+            {
+              fields: "all",
+              "source-table": PEOPLE_ID,
+              condition: [
+                "=",
+                ["field", ORDERS.USER_ID, null],
+                ["field", PEOPLE.ID, { "join-alias": "People" }],
+              ],
+              alias: "People",
+            },
+          ],
+        },
+        type: "query",
+      },
+    };
+    visitQuestionAdhoc(questionDetails);
+
+    cy.findByTestId("object-detail");
+
+    cy.log("metabase(#29023)");
+    cy.findByText("People → Name").scrollIntoView().should("be.visible");
+    cy.findByText(/Item 1 of/i).should("be.visible");
   });
 });
 

--- a/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetail.tsx
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetail.tsx
@@ -130,6 +130,7 @@ export function ObjectDetailFn({
   viewPreviousObjectDetail,
   viewNextObjectDetail,
   closeObjectDetail,
+  className,
 }: ObjectDetailProps): JSX.Element | null {
   const [hasNotFoundError, setHasNotFoundError] = useState(false);
   const prevZoomedRowId = usePrevious(zoomedRowID);
@@ -237,7 +238,7 @@ export function ObjectDetailFn({
     showRelations && !!(tableForeignKeys && !!tableForeignKeys.length && hasPk);
 
   return (
-    <ObjectDetailContainer wide={hasRelationships}>
+    <ObjectDetailContainer wide={hasRelationships} className={className}>
       {hasNotFoundError ? (
         <ErrorWrapper>
           <NotFound />

--- a/frontend/src/metabase/visualizations/components/ObjectDetail/types.ts
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/types.ts
@@ -48,4 +48,5 @@ export interface ObjectDetailProps {
   viewPreviousObjectDetail: () => void;
   viewNextObjectDetail: () => void;
   closeObjectDetail: () => void;
+  className: string;
 }

--- a/frontend/src/metabase/visualizations/components/ObjectDetail/types.ts
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/types.ts
@@ -48,5 +48,5 @@ export interface ObjectDetailProps {
   viewPreviousObjectDetail: () => void;
   viewNextObjectDetail: () => void;
   closeObjectDetail: () => void;
-  className: string;
+  className?: string;
 }


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/29023

### Description
The `Visualization.jsx` adds a `className` to card it renders. Passing this to the Object Detail resolved the issue of no scrollbars being applied when the container was larger than the screen.

### How to verify
Repro details are in the linked issue

### Demo
![image](https://user-images.githubusercontent.com/1328979/223758124-22719c84-e9e6-4777-bec3-2e98a493e3c2.png)


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
