### PR TITLE
Fix copy-pasting sql into the action editor

### DIFF
--- a/frontend/src/metabase/actions/containers/ActionCreator/ActionCreator.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/ActionCreator.tsx
@@ -184,9 +184,7 @@ function ActionCreator({
 function ensureAceEditorClosed() {
   // @ts-expect-error — `ace` isn't typed yet
   const editor = window.ace?.edit(ACE_ELEMENT_ID);
-  if (editor) {
-    editor.completer.popup.hide();
-  }
+  editor?.completer?.popup?.hide();
 }
 
 function ActionCreatorWithContext({


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/28997

How to test:
- New -> Action
- Paste some SQL, e.g. `Select 1;` and click `Save` without typing any character into the editor (!)
- It should be possible to save this action

I didn't find a way to make pasting from clipboard work in cypress for the ace editor. We do it for regular fields https://github.com/metabase/metabase/blob/f71f20e18788f2997a55e8bdafb1a39843d06a13/e2e/test/scenarios/filters/reproductions/9339-clipboard-numeric-filter.cy.spec.js#L25, but this approach doesn't work here.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/29034)
<!-- Reviewable:end -->
