### PR TITLE
Remove unnecessary `retrieve-dashboard-card` call on every update to a dashcard

### DIFF
--- a/src/metabase/models/dashboard_card.clj
+++ b/src/metabase/models/dashboard_card.clj
@@ -145,7 +145,7 @@
 
 (s/defn update-dashboard-card!
   "Update an existing DashboardCard including all DashboardCardSeries.
-   Returns the updated DashboardCard or throws an Exception."
+   Returns true or throws an Exception."
   [{:keys [id card_id action_id parameter_mappings visualization_settings] :as dashboard-card} :- DashboardCardUpdates]
   (let [{:keys [size_x size_y row col series]} (merge {:series []} dashboard-card)]
     (db/transaction
@@ -169,7 +169,7 @@
                                                   :dashboardcard_id id
                                                   {:order-by [[:position :asc]]})))
        (update-dashboard-card-series! dashboard-card series)))
-    (retrieve-dashboard-card id)))
+    true))
 
 (def ParamMapping
   "Schema for a parameter mapping as it would appear in the DashboardCard `:parameter_mappings` column."

--- a/src/metabase/models/dashboard_card.clj
+++ b/src/metabase/models/dashboard_card.clj
@@ -169,7 +169,7 @@
                                                   :dashboardcard_id id
                                                   {:order-by [[:position :asc]]})))
        (update-dashboard-card-series! dashboard-card series)))
-    true))
+    nil))
 
 (def ParamMapping
   "Schema for a parameter mapping as it would appear in the DashboardCard `:parameter_mappings` column."

--- a/test/metabase/models/dashboard_card_test.clj
+++ b/test/metabase/models/dashboard_card_test.clj
@@ -170,19 +170,19 @@
                 :visualization_settings {}
                 :series                 []}
                (remove-ids-and-timestamps (dashboard-card/retrieve-dashboard-card dashcard-id)))))
-      (testing "return value from the update call should be true"
-        (is (true? (dashboard-card/update-dashboard-card!
-                    {:id                     dashcard-id
-                     :actor_id               (mt/user->id :rasta)
-                     :dashboard_id           nil
-                     :card_id                nil
-                     :size_x                 5
-                     :size_y                 3
-                     :row                    1
-                     :col                    1
-                     :parameter_mappings     [{:foo "barbar"}]
-                     :visualization_settings {}
-                     :series                 [card-id-2 card-id-1]}))))
+      (testing "return value from the update call should be nil"
+        (is (nil? (dashboard-card/update-dashboard-card!
+                   {:id                     dashcard-id
+                    :actor_id               (mt/user->id :rasta)
+                    :dashboard_id           nil
+                    :card_id                nil
+                    :size_x                 5
+                    :size_y                 3
+                    :row                    1
+                    :col                    1
+                    :parameter_mappings     [{:foo "barbar"}]
+                    :visualization_settings {}
+                    :series                 [card-id-2 card-id-1]}))))
       (testing "validate db captured everything"
         (is (= {:size_x                 5
                 :size_y                 3

--- a/test/metabase/models/dashboard_card_test.clj
+++ b/test/metabase/models/dashboard_card_test.clj
@@ -170,36 +170,19 @@
                 :visualization_settings {}
                 :series                 []}
                (remove-ids-and-timestamps (dashboard-card/retrieve-dashboard-card dashcard-id)))))
-      (testing "return value from the update call"
-        (is (= {:size_x                 5
-                :size_y                 3
-                :col                    1
-                :row                    1
-                :parameter_mappings     [{:foo "barbar"}]
-                :visualization_settings {}
-                :series                 [{:name                   "Test Card 2"
-                                          :description            nil
-                                          :display                :table
-                                          :dataset_query          {}
-                                          :visualization_settings {}}
-                                         {:name                   "Test Card 1"
-                                          :description            nil
-                                          :display                :table
-                                          :dataset_query          {}
-                                          :visualization_settings {}}]}
-               (remove-ids-and-timestamps
-                (dashboard-card/update-dashboard-card!
-                 {:id                     dashcard-id
-                  :actor_id               (mt/user->id :rasta)
-                  :dashboard_id           nil
-                  :card_id                nil
-                  :size_x                 5
-                  :size_y                 3
-                  :row                    1
-                  :col                    1
-                  :parameter_mappings     [{:foo "barbar"}]
-                  :visualization_settings {}
-                  :series                 [card-id-2 card-id-1]})))))
+      (testing "return value from the update call should be true"
+        (is (true? (dashboard-card/update-dashboard-card!
+                    {:id                     dashcard-id
+                     :actor_id               (mt/user->id :rasta)
+                     :dashboard_id           nil
+                     :card_id                nil
+                     :size_x                 5
+                     :size_y                 3
+                     :row                    1
+                     :col                    1
+                     :parameter_mappings     [{:foo "barbar"}]
+                     :visualization_settings {}
+                     :series                 [card-id-2 card-id-1]}))))
       (testing "validate db captured everything"
         (is (= {:size_x                 5
                 :size_y                 3


### PR DESCRIPTION
Partially solves [Dashboard update makes too many app DB calls](https://github.com/metabase/metabase/issues/28956#top)

The handler for PUT "api/dashboard/:id/cards" requires a large number of DB calls. Handling this request means [`update-dashboard-card!`](https://github.com/metabase/metabase/blob/89f8d515fe544cf85ed810b0b4cdc112222c71b5/src/metabase/models/dashboard_card.clj#L146) is called per dashcard in the dashboard, and this PR optimizes the performance of that function. 

`update-dashboard-card!` is called in two places, both of which discard the return value. So we don't need the return value, which requires an extra 2 DB calls to fetch the updated dashboard card. This PR removes these calls.

Here are the places `update-dashboard-card!` is called:

1. The `defmethod` body for `revision/revert-to-revision!` dispatched on `Dashboard`
https://github.com/metabase/metabase/blob/89f8d515fe544cf85ed810b0b4cdc112222c71b5/src/metabase/models/dashboard.clj#L201
It's called in a `doseq` body, so the result is discarded.

2. The `update-dashcards!` function body, which is called under the PUT request handler we're trying to optimize. https://github.com/metabase/metabase/blob/89f8d515fe544cf85ed810b0b4cdc112222c71b5/src/metabase/models/dashboard.clj#L301
It's also called in a `doseq` body.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/29037)
<!-- Reviewable:end -->
