### PR TITLE
Fix action database picker state without available databases

### DIFF
--- a/e2e/support/helpers/e2e-action-helpers.js
+++ b/e2e/support/helpers/e2e-action-helpers.js
@@ -1,9 +1,9 @@
 import { capitalize } from "inflection";
-import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
-export function enableActionsForDB(dbId = SAMPLE_DB_ID) {
+
+export function setActionsEnabledForDB(dbId, enabled = true) {
   return cy.request("PUT", `/api/database/${dbId}`, {
     settings: {
-      "database-enable-actions": true,
+      "database-enable-actions": enabled,
     },
   });
 }

--- a/e2e/test/scenarios/admin/settings/public-sharing.cy.spec.js
+++ b/e2e/test/scenarios/admin/settings/public-sharing.cy.spec.js
@@ -1,7 +1,7 @@
 import {
   restore,
   modal,
-  enableActionsForDB,
+  setActionsEnabledForDB,
   createAction,
 } from "e2e/support/helpers";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
@@ -180,7 +180,7 @@ describe("scenarios > admin > settings > public sharing", () => {
   });
 
   it("should see public actions", () => {
-    enableActionsForDB();
+    setActionsEnabledForDB(SAMPLE_DB_ID);
     const expectedActionName = "Public action";
 
     cy.createQuestion({

--- a/e2e/test/scenarios/models/model-actions.cy.spec.js
+++ b/e2e/test/scenarios/models/model-actions.cy.spec.js
@@ -329,8 +329,6 @@ describe(
       cy.visit("/");
       cy.findByText("New").click();
       popover().findByText("Action").click();
-      cy.findByText("Select a database").click();
-      popover().within(() => cy.findByText("QA Postgres12").click());
 
       fillActionQuery("{{#1-orders-model}}");
       cy.findByLabelText("#1-orders-model").should("not.exist");

--- a/e2e/test/scenarios/models/model-actions.cy.spec.js
+++ b/e2e/test/scenarios/models/model-actions.cy.spec.js
@@ -1,5 +1,5 @@
 import {
-  enableActionsForDB,
+  setActionsEnabledForDB,
   modal,
   popover,
   restore,
@@ -75,7 +75,7 @@ describe(
     beforeEach(() => {
       restore("postgres-12");
       cy.signInAsAdmin();
-      enableActionsForDB(PG_DB_ID);
+      setActionsEnabledForDB(PG_DB_ID);
 
       cy.createQuestion(SAMPLE_ORDERS_MODEL, {
         wrapId: true,
@@ -295,7 +295,7 @@ describe(
     it("should respect permissions", () => {
       // Enabling actions for sample database as well
       // to test database picker behavior in the action editor
-      enableActionsForDB(SAMPLE_DB_ID);
+      setActionsEnabledForDB(SAMPLE_DB_ID);
 
       cy.get("@modelId").then(modelId => {
         cy.request("POST", "/api/action", {

--- a/e2e/test/scenarios/models/model-actions.cy.spec.js
+++ b/e2e/test/scenarios/models/model-actions.cy.spec.js
@@ -174,12 +174,6 @@ describe(
       cy.findByText("New").click();
       popover().findByText("Action").click();
 
-      cy.findByText("Select a database").click();
-      popover().within(() => {
-        cy.findByText("Sample Database").should("not.exist");
-        cy.findByText("QA Postgres12").click();
-      });
-
       fillActionQuery(QUERY);
       cy.findByText(/New Action/)
         .clear()

--- a/frontend/src/metabase/actions/containers/ActionCreator/QueryActionEditor.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/QueryActionEditor.tsx
@@ -27,6 +27,7 @@ function QueryActionEditor({
         resizable={false}
         readOnly={!isEditable}
         requireWriteback
+        editorContext="action"
       />
     </>
   );

--- a/frontend/src/metabase/actions/containers/ActionCreator/QueryActionEditor.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/QueryActionEditor.tsx
@@ -26,7 +26,6 @@ function QueryActionEditor({
         hasParametersList={false}
         resizable={false}
         readOnly={!isEditable}
-        requireWriteback
         editorContext="action"
       />
     </>

--- a/frontend/src/metabase/actions/utils.ts
+++ b/frontend/src/metabase/actions/utils.ts
@@ -2,7 +2,6 @@ import { t } from "ttag";
 
 import type {
   ActionFormSettings,
-  Database,
   Parameter,
   WritebackAction,
   WritebackActionBase,
@@ -24,9 +23,6 @@ import { TYPE } from "metabase-lib/types/constants";
 import Field from "metabase-lib/metadata/Field";
 
 import type { FieldSettings as LocalFieldSettings } from "./types";
-
-export const checkDatabaseActionsEnabled = (database: Database) =>
-  !!database.settings?.["database-enable-actions"];
 
 const AUTOMATIC_DATE_TIME_FIELDS = [
   TYPE.CreationDate,

--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelector.jsx
@@ -565,7 +565,13 @@ export class UnconnectedDataSelector extends Component {
   // for steps where there's a single option sometimes we want to automatically select it
   // if `useOnlyAvailable*` prop is provided
   skipSteps() {
+    const { readOnly } = this.props;
     const { activeStep } = this.state;
+
+    if (readOnly) {
+      return;
+    }
+
     if (
       activeStep === DATABASE_STEP &&
       this.props.useOnlyAvailableDatabase &&
@@ -1123,7 +1129,7 @@ export class UnconnectedDataSelector extends Component {
           id="DataPopover"
           autoWidth
           ref={this.popover}
-          isInitiallyOpen={this.props.isInitiallyOpen}
+          isInitiallyOpen={this.props.isInitiallyOpen && !this.props.readOnly}
           containerClassName={this.props.containerClassName}
           triggerElement={this.getTriggerElement}
           triggerClasses={this.getTriggerClasses()}

--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelector.jsx
@@ -272,7 +272,6 @@ export class UnconnectedDataSelector extends Component {
     hasTableSearch: PropTypes.bool,
     canChangeDatabase: PropTypes.bool,
     containerClassName: PropTypes.string,
-    requireWriteback: PropTypes.bool,
 
     // from search entity list loader
     allError: PropTypes.bool,
@@ -895,7 +894,6 @@ export class UnconnectedDataSelector extends Component {
       onChangeField: this.onChangeField,
 
       // misc
-      requireWriteback: this.props.requireWriteback,
       isLoading: this.state.isLoading,
       hasNextStep: !!this.getNextStep(),
       onBack: this.getPreviousStep() ? this.previousStep : null,

--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorDatabasePicker/DataSelectorDatabasePicker.tsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorDatabasePicker/DataSelectorDatabasePicker.tsx
@@ -3,8 +3,6 @@ import React, { useCallback, useMemo } from "react";
 import Icon from "metabase/components/Icon";
 import AccordionList from "metabase/core/components/AccordionList";
 
-import { checkDatabaseActionsEnabled } from "metabase/actions/utils";
-
 import type { Database } from "metabase-types/api/database";
 
 import type { Schema } from "../types";
@@ -18,7 +16,6 @@ type DataSelectorDatabasePickerProps = {
   hasInitialFocus?: boolean;
   hasNextStep?: boolean;
   isLoading?: boolean;
-  requireWriteback?: boolean;
   selectedDatabase?: Database;
   selectedSchema?: Schema;
   onBack?: () => void;
@@ -30,7 +27,6 @@ type Item = {
   name: string;
   index: number;
   database: Database;
-  writebackEnabled?: boolean;
 };
 
 type Section = {
@@ -45,7 +41,6 @@ const DataSelectorDatabasePicker = ({
   hasNextStep,
   onBack,
   hasInitialFocus,
-  requireWriteback = false,
 }: DataSelectorDatabasePickerProps) => {
   const sections = useMemo(() => {
     const sections: Section[] = [];
@@ -54,20 +49,16 @@ const DataSelectorDatabasePicker = ({
       sections.push({ name: <RawDataBackButton /> });
     }
 
-    const databaseItems = databases
-      .filter(database =>
-        requireWriteback ? checkDatabaseActionsEnabled(database) : true,
-      )
-      .map((database, index) => ({
+    sections.push({
+      items: databases.map((database, index) => ({
         name: database.name,
         index,
         database,
-      }));
-
-    sections.push({ items: databaseItems });
+      })),
+    });
 
     return sections;
-  }, [databases, requireWriteback, onBack]);
+  }, [databases, onBack]);
 
   const handleChangeSection = useCallback(
     (section: Section, sectionIndex: number) => {

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx
@@ -517,7 +517,6 @@ class NativeQueryEditor extends Component {
       resizableBoxProps = {},
       snippetCollections = [],
       resizable,
-      requireWriteback = false,
       editorContext = "question",
       setDatasetQuery,
     } = this.props;
@@ -545,7 +544,6 @@ class NativeQueryEditor extends Component {
                 readOnly={readOnly}
                 setDatabaseId={this.setDatabaseId}
                 setTableId={this.setTableId}
-                requireWriteback={requireWriteback}
                 editorContext={editorContext}
               />
             </div>

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx
@@ -518,6 +518,7 @@ class NativeQueryEditor extends Component {
       snippetCollections = [],
       resizable,
       requireWriteback = false,
+      editorContext = "question",
       setDatasetQuery,
     } = this.props;
 
@@ -545,6 +546,7 @@ class NativeQueryEditor extends Component {
                 setDatabaseId={this.setDatabaseId}
                 setTableId={this.setTableId}
                 requireWriteback={requireWriteback}
+                editorContext={editorContext}
               />
             </div>
             {hasParametersList && (

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/DataSourceSelectors/DataSourceSelectors.jsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/DataSourceSelectors/DataSourceSelectors.jsx
@@ -17,6 +17,7 @@ const DataSourceSelectorsPropTypes = {
   setDatabaseId: PropTypes.func,
   setTableId: PropTypes.func,
   requireWriteback: PropTypes.bool,
+  editorContext: PropTypes.oneOf(["action", "question"]),
 };
 
 const PopulatedDataSourceSelectorsPropTypes = {
@@ -49,6 +50,7 @@ const TableSelectorPropTypes = {
 
 const PlaceholderPropTypes = {
   query: PropTypes.object,
+  editorContext: PropTypes.oneOf(["action", "question"]),
 };
 
 const DataSourceSelectors = ({
@@ -58,6 +60,7 @@ const DataSourceSelectors = ({
   setDatabaseId,
   setTableId,
   requireWriteback = false,
+  editorContext,
 }) => {
   const database = query.database();
 
@@ -76,7 +79,7 @@ const DataSourceSelectors = ({
   }, [query, requireWriteback]);
 
   if (!isNativeEditorOpen || databases.length === 0) {
-    return <Placeholder query={query} />;
+    return <Placeholder query={query} editorContext={editorContext} />;
   }
 
   return (
@@ -181,11 +184,18 @@ const TableSelector = ({ database, readOnly, selectedTable, setTableId }) => (
 
 TableSelector.propTypes = TableSelectorPropTypes;
 
-const Placeholder = ({ query }) => (
-  <div className="ml2 p2 text-medium">
-    {t`This question is written in ${getNativeQueryLanguage(query.engine())}.`}
-  </div>
-);
+const Placeholder = ({ query, editorContext }) => {
+  if (editorContext === "action") {
+    return null;
+  }
+
+  const language = getNativeQueryLanguage(query.engine());
+  return (
+    <div className="ml2 p2 text-medium">
+      {t`This question is written in ${language}.`}
+    </div>
+  );
+};
 
 Placeholder.propTypes = PlaceholderPropTypes;
 

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/DataSourceSelectors/DataSourceSelectors.jsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/DataSourceSelectors/DataSourceSelectors.jsx
@@ -62,11 +62,17 @@ const DataSourceSelectors = ({
   const database = query.database();
 
   const databases = useMemo(() => {
-    const databases = query.metadata().databasesList({ savedQuestions: false });
+    const allDatabases = query
+      .metadata()
+      .databasesList({ savedQuestions: false });
+
     if (!requireWriteback) {
-      return databases;
+      return allDatabases;
     }
-    return databases.filter(database => checkDatabaseActionsEnabled(database));
+
+    return allDatabases.filter(database =>
+      checkDatabaseActionsEnabled(database),
+    );
   }, [query, requireWriteback]);
 
   if (!isNativeEditorOpen || databases.length === 0) {

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/DataSourceSelectors/DataSourceSelectors.jsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/DataSourceSelectors/DataSourceSelectors.jsx
@@ -4,7 +4,6 @@ import { t } from "ttag";
 
 import { getNativeQueryLanguage } from "metabase/lib/engine";
 
-import { checkDatabaseActionsEnabled } from "metabase/actions/utils";
 import {
   DatabaseDataSelector,
   SchemaAndTableDataSelector,
@@ -73,9 +72,7 @@ const DataSourceSelectors = ({
       return allDatabases;
     }
 
-    return allDatabases.filter(database =>
-      checkDatabaseActionsEnabled(database),
-    );
+    return allDatabases.filter(database => database.hasActionsEnabled());
   }, [query, requireWriteback]);
 
   if (!isNativeEditorOpen || databases.length === 0) {

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/DataSourceSelectors/DataSourceSelectors.jsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/DataSourceSelectors/DataSourceSelectors.jsx
@@ -27,7 +27,6 @@ const PopulatedDataSourceSelectorsPropTypes = {
   readOnly: PropTypes.bool,
   setDatabaseId: PropTypes.func,
   setTableId: PropTypes.func,
-  requireWriteback: PropTypes.bool,
 };
 
 const DatabaseSelectorPropTypes = {
@@ -35,7 +34,6 @@ const DatabaseSelectorPropTypes = {
   databases: PropTypes.array,
   readOnly: PropTypes.bool,
   setDatabaseId: PropTypes.func,
-  requireWriteback: PropTypes.bool,
 };
 
 const SingleDatabaseNamePropTypes = {
@@ -97,7 +95,6 @@ const PopulatedDataSourceSelectors = ({
   readOnly,
   setDatabaseId,
   setTableId,
-  requireWriteback = false,
 }) => {
   const dataSourceSelectors = [];
 
@@ -114,7 +111,6 @@ const PopulatedDataSourceSelectors = ({
         key="db_selector"
         readOnly={readOnly}
         setDatabaseId={setDatabaseId}
-        requireWriteback={requireWriteback}
       />,
     );
   } else if (database) {
@@ -144,13 +140,7 @@ const checkIfThereAreMultipleDatabases = (database, databases) =>
   database == null ||
   (databases.length > 1 && databases.some(db => db.id === database.id));
 
-const DatabaseSelector = ({
-  database,
-  databases,
-  readOnly,
-  setDatabaseId,
-  requireWriteback = false,
-}) => (
+const DatabaseSelector = ({ database, databases, readOnly, setDatabaseId }) => (
   <div className="GuiBuilder-section GuiBuilder-data flex align-center ml2">
     <DatabaseDataSelector
       databases={databases}
@@ -158,7 +148,6 @@ const DatabaseSelector = ({
       setDatabaseFn={setDatabaseId}
       isInitiallyOpen={database == null}
       readOnly={readOnly}
-      requireWriteback={requireWriteback}
     />
   </div>
 );

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/DataSourceSelectors/DataSourceSelectors.jsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/DataSourceSelectors/DataSourceSelectors.jsx
@@ -73,7 +73,8 @@ const DataSourceSelectors = ({
     return allDatabases;
   }, [query, editorContext]);
 
-  if (!isNativeEditorOpen || databases.length === 0) {
+  const canSelectDatabase = databases.length > 0 && !readOnly;
+  if (!isNativeEditorOpen || !canSelectDatabase) {
     return <Placeholder query={query} editorContext={editorContext} />;
   }
 

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/DataSourceSelectors/DataSourceSelectors.jsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/DataSourceSelectors/DataSourceSelectors.jsx
@@ -73,8 +73,11 @@ const DataSourceSelectors = ({
     return allDatabases;
   }, [query, editorContext]);
 
-  const canSelectDatabase = databases.length > 0 && !readOnly;
-  if (!isNativeEditorOpen || !canSelectDatabase) {
+  if (
+    !isNativeEditorOpen ||
+    databases.length === 0 ||
+    (!database && readOnly)
+  ) {
     return <Placeholder query={query} editorContext={editorContext} />;
   }
 

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/DataSourceSelectors/DataSourceSelectors.jsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/DataSourceSelectors/DataSourceSelectors.jsx
@@ -15,7 +15,6 @@ const DataSourceSelectorsPropTypes = {
   readOnly: PropTypes.bool,
   setDatabaseId: PropTypes.func,
   setTableId: PropTypes.func,
-  requireWriteback: PropTypes.bool,
   editorContext: PropTypes.oneOf(["action", "question"]),
 };
 
@@ -58,7 +57,6 @@ const DataSourceSelectors = ({
   readOnly,
   setDatabaseId,
   setTableId,
-  requireWriteback = false,
   editorContext,
 }) => {
   const database = query.database();
@@ -68,12 +66,12 @@ const DataSourceSelectors = ({
       .metadata()
       .databasesList({ savedQuestions: false });
 
-    if (!requireWriteback) {
-      return allDatabases;
+    if (editorContext === "action") {
+      return allDatabases.filter(database => database.hasActionsEnabled());
     }
 
-    return allDatabases.filter(database => database.hasActionsEnabled());
-  }, [query, requireWriteback]);
+    return allDatabases;
+  }, [query, editorContext]);
 
   if (!isNativeEditorOpen || databases.length === 0) {
     return <Placeholder query={query} editorContext={editorContext} />;
@@ -87,7 +85,6 @@ const DataSourceSelectors = ({
       readOnly={readOnly}
       setDatabaseId={setDatabaseId}
       setTableId={setTableId}
-      requireWriteback={requireWriteback}
     />
   );
 };


### PR DESCRIPTION
Epic #27581

### Description

Fixes how the action editor database picker looks like if a user doesn't have access to any database with actions enabled

### How to verify

1. As an admin user, create a model and add a query action to it
2. Create a non-user on `/admin/people`
3. Turn off data permission to your model's database on `/admin/permissions/data/group`
4. Sign in as that user and open an action in the editor
5. Ensure you can't see an empty dropdown next to the database picker

### Demo

**Before**

<img width="352" alt="before" src="https://user-images.githubusercontent.com/17258145/223780764-1a89d17d-de96-4fd1-9676-5745c679095a.png">

**After**

<img width="309" alt="CleanShot 2023-03-15 at 14 11 25@2x" src="https://user-images.githubusercontent.com/17258145/225335022-e29e6a33-aeda-49d6-a033-008a9f7580ff.png">

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/29039)
<!-- Reviewable:end -->
