### PR TITLE
Mention changes to building drivers in Metabase 0.46.0 dox

### DIFF
--- a/docs/developers-guide/driver-changelog.md
+++ b/docs/developers-guide/driver-changelog.md
@@ -6,6 +6,36 @@ title: Driver interface changelog
 
 ## Metabase 0.46.0
 
+- The process for building a driver has changed slightly in Metabase 0.46.0. Your build command should now look
+  something like this:
+
+  ```sh
+  # Example for building the driver with bash or similar
+
+  # switch to the local checkout of the Metabase repo
+  cd /path/to/metabase/repo
+
+  # get absolute path to the driver project directory
+  DRIVER_PATH=`readlink -f ~/sudoku-driver`
+
+  # Build driver. See explanation in sample Sudoku driver README
+  clojure \
+    -Sdeps "{:aliases {:sudoku {:extra-deps {com.metabase/sudoku-driver {:local/root \"$DRIVER_PATH\"}}}}}"  \
+    -X:build:sudoku \
+    build-drivers.build-driver/build-driver! \
+    "{:driver :sudoku, :project-dir \"$DRIVER_PATH\", :target-dir \"$DRIVER_PATH/target\"}"
+  ```
+
+  Take a look at our [build instructions for the sample Sudoku
+  driver](https://github.com/metabase/sudoku-driver#build-it-updated-for-build-script-changes-in-metabase-0460)
+  for an explanation of the command.
+
+  Note that while this command itself is quite a lot to type, you no longer need to specify a `:build` alias in your
+  driver's `deps.edn` file.
+
+  Please upvote https://ask.clojure.org/index.php/7843/allow-specifying-aliases-coordinates-that-point-projects ,
+  which will allow us to simplify the driver build command in the future.
+
 - The multimethod `metabase.driver/table-rows-sample` has been added. This method is used in situations where Metabase
   needs a limited sample from a table, like when fingerprinting. The default implementation defined in the
   `metabase.db.metadata-queries` namespace runs an MBQL query using the regular query processor to produce the sample


### PR DESCRIPTION
Recent build script changes in #28767 means we need to change the way we build drivers. Call this out in the driver changelog.