### PR TITLE
Fix docs link in action dashcard settings

### DIFF
--- a/frontend/src/metabase/actions/components/ActionViz/ActionDashcardSettings.styled.tsx
+++ b/frontend/src/metabase/actions/components/ActionViz/ActionDashcardSettings.styled.tsx
@@ -3,7 +3,7 @@ import styled from "@emotion/styled";
 import { space } from "metabase/styled-components/theme";
 import { color } from "metabase/lib/colors";
 
-import Link from "metabase/core/components/Link";
+import ExternalLink from "metabase/core/components/ExternalLink";
 
 export const ActionSettingsWrapper = styled.div`
   display: flex;
@@ -89,7 +89,7 @@ export const ExplainerText = styled.p`
   color: ${color("text-medium")};
 `;
 
-export const BrandLinkWithLeftMargin = styled(Link)`
+export const BrandLinkWithLeftMargin = styled(ExternalLink)`
   margin-left: ${space(1)};
   color: ${color("brand")};
 `;

--- a/frontend/src/metabase/actions/components/ActionViz/ActionDashcardSettings.tsx
+++ b/frontend/src/metabase/actions/components/ActionViz/ActionDashcardSettings.tsx
@@ -2,19 +2,19 @@ import React from "react";
 import { connect } from "react-redux";
 import { t } from "ttag";
 
+import Button from "metabase/core/components/Button";
+import EmptyState from "metabase/components/EmptyState";
+
+import { ConnectedActionPicker } from "metabase/actions/containers/ActionPicker/ActionPicker";
+import { setActionForDashcard } from "metabase/dashboard/actions";
+
 import type {
   ActionDashboardCard,
   Dashboard,
   WritebackAction,
 } from "metabase-types/api";
 
-import Button from "metabase/core/components/Button";
-
-import { ConnectedActionPicker } from "metabase/actions/containers/ActionPicker/ActionPicker";
-import { setActionForDashcard } from "metabase/dashboard/actions";
-import EmptyState from "metabase/components/EmptyState";
 import { ConnectedActionParameterMappingForm } from "./ActionParameterMapper";
-
 import {
   ActionSettingsWrapper,
   ParameterMapperContainer,

--- a/frontend/src/metabase/actions/components/ActionViz/ActionDashcardSettings.tsx
+++ b/frontend/src/metabase/actions/components/ActionViz/ActionDashcardSettings.tsx
@@ -5,6 +5,8 @@ import { t } from "ttag";
 import Button from "metabase/core/components/Button";
 import EmptyState from "metabase/components/EmptyState";
 
+import MetabaseSettings from "metabase/lib/settings";
+
 import { ConnectedActionPicker } from "metabase/actions/containers/ActionPicker/ActionPicker";
 import { setActionForDashcard } from "metabase/dashboard/actions";
 
@@ -70,7 +72,9 @@ export function ActionDashcardSettings({
                 </ActionSettingsHeader>
                 <ExplainerText>
                   {t`You can either ask users to enter values, or use the value of a dashboard filter.`}
-                  <BrandLinkWithLeftMargin to="https://www.metabase.com/docs/actions/custom">
+                  <BrandLinkWithLeftMargin
+                    href={MetabaseSettings.docsUrl("dashboards/actions")}
+                  >
                     {t`Learn more.`}
                   </BrandLinkWithLeftMargin>
                 </ExplainerText>


### PR DESCRIPTION
### Description

1. Changes a link from `/docs/actions/custom` to `/docs/dashboards/actions` per @jeff-bruemmer's [comment](https://metaboat.slack.com/archives/C04FG88HL95/p1678215914078399?thread_ts=1678214770.325779&cid=C04FG88HL95)
2. Makes it use the `ExternalLink` component instead of the in-app `Link`
3. Sorts imports

### How to verify

1. Create a dashboard
2. Add an action button to it
3. Click the "Pick an action" button in the sidebar
4. Pick an action
5. Ensure the "Learn more" link at the top of the modal points to `/docs/dashboard/actions` and is clickable (⚠️ the docs page is not up yet and it's expected)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/29046)
<!-- Reviewable:end -->
