### PR TITLE
Fix flaky json test

### DIFF
--- a/bin/build/test/release/version_info_test.clj
+++ b/bin/build/test/release/version_info_test.clj
@@ -43,6 +43,6 @@
         (#'v-info/generate-version-info!)
         (let [actual (-> (#'v-info/tmp-version-info-filename)
                          (slurp)
-                         (json/read-json true))
+                         (json/read-str :key-fn keyword))
               expected (make-version-info edition test-versions)]
           (is (= expected actual)))))))

--- a/deps.edn
+++ b/deps.edn
@@ -557,7 +557,7 @@
   {:extra-paths ["bin/build/test"]
 
    :extra-deps
-   {org.clojure/data.json {:mvn/version "2.0.2"}}}
+   {org.clojure/data.json {:mvn/version "2.4.0"}}}
 
   ;;; Run tests for the build scripts:
   ;;;


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/28974

Occasionally in CI we get

```
“Syntax error compiling at (release/version_info_test.clj:46:26).\nNo such var: json/read-json\n”,
```

from `release.version-info-test`.
This namespace requires `[clojure.data.json :as json]` and uses the function `json/read-json` which is deprecated since version 2.x.

The way that deprecated function is defined in version 2.0.2 is

```clojure
(ns clojure.data.json)
...
(load "json_compat_0_1")
```

and in `clojure/data/json_compat_0_1.clj`:

```clojure
(in-ns 'clojure.data.json)

(defn read-json
  "DEPRECATED; replaced by read-str.
  ...)
```

And I guess the way that hawk requires some namespaces we can get into this half loaded, half not finished state and the var is not (yet) defined.

So we can just put aside this nonsense and use a non-deprecated var that isn't defined with a `load` statement but in the regular namespace we require.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/29048)
<!-- Reviewable:end -->
