### PR TITLE
Fix metadata handling during implicit joins resolution

### DIFF
--- a/src/metabase/query_processor/middleware/add_implicit_joins.clj
+++ b/src/metabase/query_processor/middleware/add_implicit_joins.clj
@@ -20,7 +20,7 @@
 (defn- implicitly-joined-fields
   "Find fields that come from implicit join in form `x`, presumably a query.
   Fields from metadata are not considered. It is expected, that field which would cause implicit join is in the query
-  and not just in it's metadata. Example of query having `:source-field` fields in `:source-metadata` and no use of 
+  and not just in it's metadata. Example of query having `:source-field` fields in `:source-metadata` and no use of
   `:source-field` field in corresponding `:source-query` would be the one, that uses remappings. See
   [[metabase.models.params.custom-values-test/with-mbql-card-test]]."
   [x]

--- a/test/metabase/query_processor/middleware/add_implicit_joins_test.clj
+++ b/test/metabase/query_processor/middleware/add_implicit_joins_test.clj
@@ -605,19 +605,13 @@
     (testing "`:join-alias` is correctly updated in metadata fields containing `:source-field`"
       ;; Used metadata are simplified (invalid) for testing purposes. To the best of my knowledge only `:field_ref`
       ;;   could contain field with `:source-field` option that should be updated.
-      ;;
       (testing "With `:source-field` field in the `:source-metadata` and not in the`:source-query`, query should be left intact"
-        (is (query= (mt/mbql-query products
+        (let [query (mt/mbql-query products
                       {:source-query {:source-table $$orders
                                       :fields [$id]}
-                       :source-metadata [{:field_ref $orders.product_id->category}]})
-                    (add-implicit-joins
-                     (mt/mbql-query products
-                       {:source-query {:source-table $$orders
-                                       :fields [$id]}
-                        :source-metadata [{:field_ref $orders.product_id->category}]})))))
-      ;; #26631 Case 1
-      (testing "Join query with implicit join into query with nested query with implicit join as source"
+                       :source-metadata [{:field_ref $orders.product_id->category}]})]
+          (is (query= query (add-implicit-joins query)))))
+      (testing "#26631 Case 1: Join query with implicit join into query with nested query with implicit join as source"
         (is (= (mt/mbql-query products
                  {:source-query {:source-table $$orders
                                  :aggregation [[:count]]
@@ -657,8 +651,7 @@
                                            :aggregation [[:count]]
                                            :breakout [$reviews.product_id->category]}
                             :source-metadata [{:field_ref $reviews.product_id->category}]}]})))))
-      ;; #26631 Case 3
-      (testing "Join query with implicit join into a query with a table as source"
+      (testing "#26631 Case 3: Join query with implicit join into a query with a table as source"
         (is (query= (mt/mbql-query products
                       {:source-table $$products
                        :joins [{:join-alias "Q2"

--- a/test/metabase/query_processor/middleware/add_implicit_joins_test.clj
+++ b/test/metabase/query_processor/middleware/add_implicit_joins_test.clj
@@ -603,7 +603,7 @@
     ;; With remapping, metadata may contain field with `:source-field` which is not used in corresponding query.
     ;;   See [[metabase.models.params.custom-values-test/with-mbql-card-test]].
     (testing "`:join-alias` is correctly updated in metadata fields containing `:source-field`"
-      ;; Used metadata are simplified (invalid) for testing purposes. To the best of my knowledge only `:field_ref` 
+      ;; Used metadata are simplified (invalid) for testing purposes. To the best of my knowledge only `:field_ref`
       ;;   could contain field with `:source-field` option that should be updated.
       ;;
       (testing "With `:source-field` field in the `:source-metadata` and not in the`:source-query`, query should be left intact"

--- a/test/metabase/query_processor/middleware/add_implicit_joins_test.clj
+++ b/test/metabase/query_processor/middleware/add_implicit_joins_test.clj
@@ -597,3 +597,92 @@
                                                      &Products.products.category]
                                       :fields       :none}]
                       :fields       [$product_id->products.category]})))))))
+
+(deftest metadata-join-alias-test
+  (mt/dataset sample-dataset
+    ;; With remapping, metadata may contain field with `:source-field` which is not used in corresponding query.
+    ;;   See [[metabase.models.params.custom-values-test/with-mbql-card-test]].
+    (testing "`:join-alias` is correctly updated in metadata fields containing `:source-field`"
+      ;; Used metadata are simplified (invalid) for testing purposes. To the best of my knowledge only `:field_ref` 
+      ;;   could contain field with `:source-field` option that should be updated.
+      ;;
+      (testing "With `:source-field` field in the `:source-metadata` and not in the`:source-query`, query should be left intact"
+        (is (query= (mt/mbql-query products
+                      {:source-query {:source-table $$orders
+                                      :fields [$id]}
+                       :source-metadata [{:field_ref $orders.product_id->category}]})
+                    (add-implicit-joins
+                     (mt/mbql-query products
+                       {:source-query {:source-table $$orders
+                                       :fields [$id]}
+                        :source-metadata [{:field_ref $orders.product_id->category}]})))))
+      ;; #26631 Case 1
+      (testing "Join query with implicit join into query with nested query with implicit join as source"
+        (is (= (mt/mbql-query products
+                 {:source-query {:source-table $$orders
+                                 :aggregation [[:count]]
+                                 :breakout [&PRODUCTS__via__PRODUCT_ID.$orders.product_id->category]
+                                 :joins [{:alias "PRODUCTS__via__PRODUCT_ID"
+                                          :fields :none
+                                          :condition [:= $orders.product_id &PRODUCTS__via__PRODUCT_ID.$id]
+                                          :strategy :left-join
+                                          :source-table $$products
+                                          :fk-field-id %orders.product_id}]}
+                  :source-metadata [{:field_ref &PRODUCTS__via__PRODUCT_ID.$orders.product_id->category}]
+                  :joins [{:alias "Q2"
+                           :condition [:=
+                                       &PRODUCTS__via__PRODUCT_ID.$orders.product_id->category
+                                       &Q2.$reviews.product_id->category]
+                           :strategy :left-join
+                           :source-query {:source-table $$reviews
+                                          :aggregation [[:count]]
+                                          :breakout [&PRODUCTS__via__PRODUCT_ID.$reviews.product_id->category]
+                                          :joins [{:alias "PRODUCTS__via__PRODUCT_ID"
+                                                   :fields :none
+                                                   :condition [:= $reviews.product_id &PRODUCTS__via__PRODUCT_ID.$id]
+                                                   :strategy :left-join
+                                                   :source-table $$products
+                                                   :fk-field-id %reviews.product_id}]}
+                           :source-metadata [{:field_ref &PRODUCTS__via__PRODUCT_ID.$reviews.product_id->category}]}]})
+               (add-implicit-joins
+                (mt/mbql-query products
+                  {:source-query {:source-table $$orders
+                                  :aggregation [[:count]]
+                                  :breakout [$orders.product_id->category]}
+                   :source-metadata [{:field_ref $orders.product_id->category}]
+                   :joins [{:alias "Q2"
+                            :condition [:= $orders.product_id->category &Q2.$reviews.product_id->category]
+                            :strategy :left-join
+                            :source-query {:source-table $$reviews
+                                           :aggregation [[:count]]
+                                           :breakout [$reviews.product_id->category]}
+                            :source-metadata [{:field_ref $reviews.product_id->category}]}]})))))
+      ;; #26631 Case 3
+      (testing "Join query with implicit join into a query with a table as source"
+        (is (query= (mt/mbql-query products
+                      {:source-table $$products
+                       :joins [{:join-alias "Q2"
+                                :fields :all
+                                :condition [:= $category &Q2.$orders.product_id->category]
+                                :strategy :left-join
+                                :source-query {:source-table $$orders
+                                               :aggregation [[:count]]
+                                               :breakout [&PRODUCTS__via__PRODUCT_ID.$orders.product_id->category]
+                                               :joins [{:alias "PRODUCTS__via__PRODUCT_ID"
+                                                        :fields :none
+                                                        :strategy :left-join
+                                                        :condition [:= $orders.product_id &PRODUCTS__via__PRODUCT_ID.$id]
+                                                        :source-table $$products
+                                                        :fk-field-id %orders.product_id}]}
+                                :source-metadata [{:field_ref &PRODUCTS__via__PRODUCT_ID.$orders.product_id->category}]}]})
+                    (add-implicit-joins
+                     (mt/mbql-query products
+                       {:source-table $$products
+                        :joins [{:join-alias "Q2"
+                                 :fields :all
+                                 :condition [:= $category &Q2.$orders.product_id->category]
+                                 :strategy :left-join
+                                 :source-query {:source-table $$orders
+                                                :aggregation [[:count]]
+                                                :breakout [$orders.product_id->category]}
+                                 :source-metadata [{:field_ref $orders.product_id->category}]}]}))))))))


### PR DESCRIPTION
Closes #26631

### Description

Issue in question is concerned with incorrect `:source-metadata` updates during implicit joins resolution. Solution could be to either ignore metadata completely, or update it correctly.

While researching the issue, [this line](https://github.com/lbrdnk/metabase/blob/8a420da113fc21fbbd37e1956ca876da2171b8aa/src/metabase/query_processor/middleware/annotate.clj#L271) in `metabase.query-processor.middleware.annotate` made me decide that updating join aliases in fields with `:source-field` in metadata is desired.


#### Reproductions from #26631

Reproductions 1 and 3 are included in new test. I was unable to reproduce case no. 2 from the issue.


### How to verify

See new test or follow instructions in #26631. I've also ran `clj -X:dev:ee:ee-dev:drivers:drivers-dev:test` for `h2` driver with no failures.


### Checklist

- [X] Tests have been added/updated to cover changes in this PR

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/29053)
<!-- Reviewable:end -->
