### PR TITLE
Users can run actions if they have access to the database

### DIFF
--- a/src/metabase/query_processor/middleware/permissions.clj
+++ b/src/metabase/query_processor/middleware/permissions.clj
@@ -138,7 +138,7 @@
 
 (defn- query-action-perms
   [{:keys [database]}]
-  #{(perms/data-perms-path database)})
+  #{(perms/all-schemas-path database)})
 
 (s/defn check-query-action-permissions*
   "Check that User with `user-id` has permissions to run query action `query`, or throw an exception."

--- a/src/metabase/query_processor/middleware/permissions.clj
+++ b/src/metabase/query_processor/middleware/permissions.clj
@@ -136,10 +136,6 @@
 ;;; |                                                Writeback fns                                                   |
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
-(defn- query-action-perms
-  [{:keys [database]}]
-  #{(perms/all-schemas-path database)})
-
 (s/defn check-query-action-permissions*
   "Check that User with `user-id` has permissions to run query action `query`, or throw an exception."
   [outer-query :- su/Map]
@@ -147,9 +143,7 @@
   (when *card-id*
     (check-card-read-perms *card-id*))
   (when-not (has-data-perms? (required-perms outer-query))
-    (check-block-permissions outer-query))
-  (when-not (has-data-perms? (query-action-perms outer-query))
-    (throw (perms-exception (required-perms outer-query)))))
+    (check-block-permissions outer-query)))
 
 (defn check-query-action-permissions
   "Middleware that check that the current user has permissions to run the current query action."

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -2885,7 +2885,7 @@
                                 (mt/user-http-request :rasta :post 403 execute-path
                                                       {:parameters {"id" 1}})))))
               (testing "With read rights on the DB"
-                (perms/grant-full-data-permissions! (perms-group/all-users) (mt/db))
+                (perms/grant-permissions-for-all-schemas! (perms-group/all-users) (mt/db))
                 (try
                   (mt/with-actions-enabled
                     (is (= {:rows-affected 1}

--- a/test/metabase/query_processor/middleware/permissions_test.clj
+++ b/test/metabase/query_processor/middleware/permissions_test.clj
@@ -211,6 +211,31 @@
                                             {:id tag-name, :name tag-name, :display-name tag-name,
                                              :type "card", :card card-id}}}})))))))
 
+(deftest query-action-permissions-test
+  (testing "Query action permissions"
+    (mt/with-non-admin-groups-no-root-collection-perms
+      (mt/with-temp-copy-of-db
+        (perms/revoke-data-perms! (perms-group/all-users) (mt/id))
+        (let [query  (mt/mbql-query venues {:order-by [[:asc $id]], :limit 2})
+              check! qp.perms/check-query-action-permissions*]
+          (mt/with-temp Collection [collection]
+            (mt/with-temp Card [{model-id :id} {:collection_id (u/the-id collection)
+                                                :dataset_query query}]
+              (testing "are granted by default"
+                (check! query))
+              (testing "are revoked without access to the model"
+                (binding [qp.perms/*card-id* model-id]
+                  (is (thrown-with-msg?
+                       ExceptionInfo
+                       (re-pattern #"You do not have permissions to view Card [\d,]+")
+                       (check! query)))))
+              ;; Are revoked with DB access blocked: requires EE, see test in
+              ;; enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
+              (testing "are granted with access to the model"
+                (binding [api/*current-user-permissions-set* (delay #{(perms/collection-read-path (u/the-id collection))})
+                          qp.perms/*card-id* model-id]
+                  (check! query))))))))))
+
 (deftest end-to-end-test
   (testing (str "Make sure it works end-to-end: make sure bound `*current-user-id*` and `*current-user-permissions-set*` "
                 "are used to permissions check queries")


### PR DESCRIPTION
[Fixes #28425]

Takes care of the "Can run?" section of this table:

![image](https://user-images.githubusercontent.com/784417/224729857-1ff96b11-7385-497d-98fb-cb9cfa85dc60.png)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/29088)
<!-- Reviewable:end -->
