### PR TITLE
Update org.slf4j/slf4j-api from 1.7.36 to 2.0.6

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -135,7 +135,7 @@
   org.mindrot/jbcrypt                       {:mvn/version "0.4"}                ; Crypto library
   org.postgresql/postgresql                 {:mvn/version "42.5.4"}             ; Postgres driver
   org.quartz-scheduler/quartz               {:mvn/version "2.3.2"}              ; Quartz job scheduler, provided by quartzite but this is a newer version.
-  org.slf4j/slf4j-api                       {:mvn/version "1.7.36"}             ; abstraction for logging frameworks -- allows end user to plug in desired logging framework at deployment time
+  org.slf4j/slf4j-api                       {:mvn/version "2.0.6"}              ; abstraction for logging frameworks -- allows end user to plug in desired logging framework at deployment time
   org.tcrawley/dynapath                     {:mvn/version "1.1.0"}              ; Dynamically add Jars (e.g. Oracle or Vertica) to classpath
   org.threeten/threeten-extra               {:mvn/version "1.7.2"}              ; extra Java 8 java.time classes like DayOfMonth and Quarter
   org.yaml/snakeyaml                        {:mvn/version "1.33"}               ; YAML parser

--- a/deps.edn
+++ b/deps.edn
@@ -98,7 +98,8 @@
   org.apache.logging.log4j/log4j-core       {:mvn/version "2.20.0"}             ; apache logging framework
   org.apache.logging.log4j/log4j-jcl        {:mvn/version "2.20.0"}             ; allows the commons-logging API to work with log4j 2
   org.apache.logging.log4j/log4j-jul        {:mvn/version "2.20.0"}             ; java.util.logging (JUL) -> Log4j2 adapter
-  org.apache.logging.log4j/log4j-slf4j-impl {:mvn/version "2.20.0"}             ; allows the slf4j API to work with log4j 2
+  org.apache.logging.log4j/log4j-slf4j2-impl
+                                            {:mvn/version "2.20.0"}             ; allows the slf4j2 API to work with log4j 2
   org.apache.poi/poi                        {:mvn/version "5.2.3"}              ; Work with Office documents (e.g. Excel spreadsheets) -- newer version than one specified by Docjure
   org.apache.poi/poi-ooxml                  {:mvn/version "5.2.3"
                                              :exclusions  [org.bouncycastle/bcpkix-jdk15on


### PR DESCRIPTION
Fixes #29090

The slf4j site makes it pretty clear that 2.X should be backwards compatible. The big thing to test here is that the correct implementation is picked up and that the log42.xml file is picked up and respected.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/29091)
<!-- Reviewable:end -->
