### PR TITLE
Handle data permission error for dashboard actions

### DIFF
--- a/frontend/src/metabase/actions/components/ActionViz/Action.tsx
+++ b/frontend/src/metabase/actions/components/ActionViz/Action.tsx
@@ -7,6 +7,11 @@ import { executeRowAction } from "metabase/dashboard/actions";
 
 import Tooltip from "metabase/core/components/Tooltip";
 
+import {
+  getResponseErrorMessage,
+  GenericErrorResponse,
+} from "metabase/core/utils/errors";
+
 import type {
   ActionDashboardCard,
   ParametersForActionExecution,
@@ -37,14 +42,20 @@ import ActionVizForm from "./ActionVizForm";
 import ActionButtonView from "./ActionButtonView";
 import { FullContainer } from "./ActionButton.styled";
 
-export interface ActionProps extends VisualizationProps {
+interface OwnProps {
   dashcard: ActionDashboardCard;
   dashboard: Dashboard;
-  dispatch: Dispatch;
   parameterValues: { [id: string]: ParameterValueOrArray };
   isEditingDashcard: boolean;
-  database: Database;
+  dispatch: Dispatch;
 }
+
+interface DatabaseLoaderProps {
+  database: Database;
+  error?: GenericErrorResponse;
+}
+
+export type ActionProps = VisualizationProps & OwnProps & DatabaseLoaderProps;
 
 function ActionComponent({
   dashcard,
@@ -133,14 +144,17 @@ function ActionFn(props: ActionProps) {
   const {
     database,
     dashcard: { action },
+    error,
   } = props;
 
   const hasActionsEnabled = database?.hasActionsEnabled?.();
 
-  if (!action || !hasActionsEnabled) {
-    const tooltip = !action
-      ? t`No action assigned`
-      : t`Actions are not enabled for this database`;
+  if (error || !action || !hasActionsEnabled) {
+    const tooltip = getErrorTooltip({
+      hasActionAssigned: !!action,
+      hasActionsEnabled,
+      error,
+    });
 
     return (
       <Tooltip tooltip={tooltip}>
@@ -160,10 +174,32 @@ function ActionFn(props: ActionProps) {
   return <ConnectedActionComponent {...props} />;
 }
 
+function getErrorTooltip({
+  hasActionAssigned,
+  hasActionsEnabled,
+  error,
+}: {
+  hasActionAssigned: boolean;
+  hasActionsEnabled: boolean;
+  error?: GenericErrorResponse;
+}) {
+  if (error) {
+    return getResponseErrorMessage(error);
+  }
+  if (!hasActionAssigned) {
+    return t`No action assigned`;
+  }
+  if (!hasActionsEnabled) {
+    return t`Actions are not enabled for this database`;
+  }
+  return t`Something's gone wrong`;
+}
+
 export default _.compose(
   Databases.load({
     id: (state: State, props: ActionProps) =>
       props.dashcard?.action?.database_id,
+    loadingAndErrorWrapper: false,
   }),
   connect(mapStateToProps),
 )(ActionFn);

--- a/frontend/src/metabase/actions/components/ActionViz/Action.tsx
+++ b/frontend/src/metabase/actions/components/ActionViz/Action.tsx
@@ -7,10 +7,7 @@ import { executeRowAction } from "metabase/dashboard/actions";
 
 import Tooltip from "metabase/core/components/Tooltip";
 
-import {
-  getResponseErrorMessage,
-  GenericErrorResponse,
-} from "metabase/core/utils/errors";
+import { getResponseErrorMessage } from "metabase/core/utils/errors";
 
 import type {
   ActionDashboardCard,
@@ -52,7 +49,7 @@ interface OwnProps {
 
 interface DatabaseLoaderProps {
   database: Database;
-  error?: GenericErrorResponse;
+  error?: unknown;
 }
 
 export type ActionProps = VisualizationProps & OwnProps & DatabaseLoaderProps;
@@ -181,7 +178,7 @@ function getErrorTooltip({
 }: {
   hasActionAssigned: boolean;
   hasActionsEnabled: boolean;
-  error?: GenericErrorResponse;
+  error?: unknown;
 }) {
   if (error) {
     return getResponseErrorMessage(error);

--- a/frontend/src/metabase/actions/components/ActionViz/Action.unit.spec.tsx
+++ b/frontend/src/metabase/actions/components/ActionViz/Action.unit.spec.tsx
@@ -3,7 +3,10 @@ import fetchMock from "fetch-mock";
 import userEvent from "@testing-library/user-event";
 
 import { renderWithProviders, screen, getIcon, waitFor } from "__support__/ui";
-import { setupDatabasesEndpoints } from "__support__/server-mocks";
+import {
+  setupDatabasesEndpoints,
+  setupUnauthorizedDatabasesEndpoints,
+} from "__support__/server-mocks";
 
 import type { ActionDashboardCard } from "metabase-types/api";
 import type { ParameterTarget } from "metabase-types/types/Parameter";
@@ -81,16 +84,13 @@ async function setup({
   hasDataPermissions = true,
   ...props
 }: SetupOpts = {}) {
+  const databases = [DATABASE, DATABASE_WITHOUT_ACTIONS];
+
   if (hasDataPermissions) {
-    setupDatabasesEndpoints([DATABASE, DATABASE_WITHOUT_ACTIONS]);
+    setupDatabasesEndpoints(databases);
     fetchMock.post(ACTION_EXEC_MOCK_PATH, { "rows-updated": [1] });
   } else {
-    const error = {
-      status: 403,
-      body: "You don't have permission to do this",
-    };
-    fetchMock.get(`path:/api/database/${DATABASE.id}`, error);
-    fetchMock.get(`path:/api/database/${DATABASE_WITHOUT_ACTIONS.id}`, error);
+    setupUnauthorizedDatabasesEndpoints(databases);
   }
 
   renderWithProviders(

--- a/frontend/test/__support__/server-mocks/database.ts
+++ b/frontend/test/__support__/server-mocks/database.ts
@@ -2,6 +2,7 @@ import fetchMock from "fetch-mock";
 import _ from "underscore";
 import { SAVED_QUESTIONS_DATABASE } from "metabase/databases/constants";
 import { Database } from "metabase-types/api";
+import { PERMISSION_ERROR } from "./constants";
 import { setupTableEndpoints } from "./table";
 
 export function setupDatabaseEndpoints(db: Database) {
@@ -39,3 +40,14 @@ export const setupSchemaEndpoints = (db: Database) => {
     );
   });
 };
+
+export function setupUnauthorizedDatabaseEndpoints(db: Database) {
+  fetchMock.get(`path:/api/database/${db.id}`, {
+    status: 403,
+    body: PERMISSION_ERROR,
+  });
+}
+
+export function setupUnauthorizedDatabasesEndpoints(dbs: Database[]) {
+  dbs.forEach(db => setupUnauthorizedDatabaseEndpoints(db));
+}


### PR DESCRIPTION
### Description

Ensures the dashboard action button component handles errors when fetching an action database. The most prominent need for this is when a user without data permissions to an action database opens the dashboard: the action button component tries to fetch a database, the BE responds with 403, and the entity loader renders a default error component that doesn't fit into space available to the button.

Based on test changes from #29093

### How to verify

1. As an admin, add a new user on `/admin/people`
2. Go to `/admin/permissions/data/group/1` and disable data permissions to a database with actions enabled
3. Create a dashboard and add a button to it (the action should use a database with limited permissions)
4. Sign in as a regular user and open the dashboard from the previous step
5. Ensure the button is disabled (visually and nothing happens on click) and that you can see an explainer tooltip on hover

### Demo

**Before**

![before](https://user-images.githubusercontent.com/17258145/224109856-dd232106-be4f-4fab-bd01-5fe59908ffda.png)

**After**

<img width="1167" alt="after" src="https://user-images.githubusercontent.com/17258145/224109901-e8454135-9297-48b1-b7cf-237c5482b435.png">

### Checklist

- [x] Tests have been added/updated to cover changes in this PR

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/29092)
<!-- Reviewable:end -->
