### PR TITLE
Clean up `Action` component tests

### DIFF
--- a/frontend/src/metabase/actions/components/ActionViz/Action.tsx
+++ b/frontend/src/metabase/actions/components/ActionViz/Action.tsx
@@ -129,7 +129,7 @@ function mapStateToProps(state: State, props: ActionProps) {
   };
 }
 
-export function ActionFn(props: ActionProps) {
+function ActionFn(props: ActionProps) {
   const {
     database,
     dashcard: { action },

--- a/frontend/src/metabase/actions/components/ActionViz/Action.tsx
+++ b/frontend/src/metabase/actions/components/ActionViz/Action.tsx
@@ -46,7 +46,7 @@ export interface ActionProps extends VisualizationProps {
   database: Database;
 }
 
-export function ActionComponent({
+function ActionComponent({
   dashcard,
   dashboard,
   dispatch,

--- a/frontend/src/metabase/actions/components/ActionViz/Action.unit.spec.tsx
+++ b/frontend/src/metabase/actions/components/ActionViz/Action.unit.spec.tsx
@@ -24,13 +24,23 @@ import {
 
 import Action, { ActionProps } from "./Action";
 
+const DASHBOARD_ID = 123;
+const DASHCARD_ID = 456;
+const ACTION_MODEL_ID = 777;
+
+const DATABASE_WITHOUT_ACTIONS = createMockDatabase({ id: 1 });
+const DATABASE = createMockDatabase({
+  id: 2,
+  settings: { "database-enable-actions": true },
+});
+
 const defaultProps = {
   dashcard: {
-    id: 456,
-    card_id: 777, // action model id
+    id: DASHCARD_ID,
+    card_id: ACTION_MODEL_ID,
     action: createMockQueryAction({
       name: "My Awesome Action",
-      database_id: 2,
+      database_id: DATABASE.id,
       parameters: [
         createMockActionParameter({
           id: "parameter_1",
@@ -47,17 +57,15 @@ const defaultProps = {
     parameter_mappings: [
       {
         parameter_id: "dash-param-1",
-        card_id: 1,
         target: ["variable", ["template-tag", "1"]],
       },
       {
         parameter_id: "dash-param-2",
-        card_id: 1,
         target: ["variable", ["template-tag", "2"]],
       },
     ],
   },
-  dashboard: createMockDashboard({ id: 123 }),
+  dashboard: createMockDashboard({ id: DASHBOARD_ID }),
   dispatch: _.noop,
   isSettings: false,
   isEditing: false,
@@ -65,12 +73,6 @@ const defaultProps = {
   onVisualizationClick: _.noop,
   parameterValues: {},
 } as unknown as ActionProps;
-
-const DATABASE_WITHOUT_ACTIONS = createMockDatabase({ id: 1 });
-const DATABASE = createMockDatabase({
-  id: 2,
-  settings: { "database-enable-actions": true },
-});
 
 type SetupOpts = Partial<ActionProps> & {
   awaitLoading?: boolean;
@@ -89,9 +91,12 @@ async function setup({ awaitLoading = true, ...props }: SetupOpts = {}) {
 }
 
 function setupExecutionEndpoint() {
-  fetchMock.post("path:/api/dashboard/123/dashcard/456/execute", {
-    "rows-updated": [1],
-  });
+  fetchMock.post(
+    `path:/api/dashboard/${DASHBOARD_ID}/dashcard/${DASHCARD_ID}/execute`,
+    {
+      "rows-updated": [1],
+    },
+  );
 }
 
 describe("Actions > ActionViz > Action", () => {
@@ -201,9 +206,9 @@ describe("Actions > ActionViz > Action", () => {
       setupExecutionEndpoint();
       await setup({
         dashcard: createMockActionDashboardCard({
-          id: 456,
-          dashboard_id: 123,
-          card_id: 777, // action model id
+          id: DASHCARD_ID,
+          dashboard_id: DASHBOARD_ID,
+          card_id: ACTION_MODEL_ID,
           action,
           card: defaultProps.dashcard.card,
           parameter_mappings: [
@@ -220,10 +225,10 @@ describe("Actions > ActionViz > Action", () => {
 
       await waitFor(async () => {
         const call = fetchMock.lastCall(
-          "path:/api/dashboard/123/dashcard/456/execute",
+          `path:/api/dashboard/${DASHBOARD_ID}/dashcard/${DASHCARD_ID}/execute`,
         );
         expect(await call?.request?.json()).toEqual({
-          modelId: 777,
+          modelId: ACTION_MODEL_ID,
           parameters: {
             parameter_1: 44,
           },
@@ -271,7 +276,7 @@ describe("Actions > ActionViz > Action", () => {
 
     it("should submit provided form input values to the action execution endpoint", async () => {
       const expectedBody = {
-        modelId: 777,
+        modelId: ACTION_MODEL_ID,
         parameters: {
           parameter_1: "foo",
           parameter_2: 5,
@@ -296,7 +301,7 @@ describe("Actions > ActionViz > Action", () => {
 
       await waitFor(async () => {
         const call = fetchMock.lastCall(
-          "path:/api/dashboard/123/dashcard/456/execute",
+          `path:/api/dashboard/${DASHBOARD_ID}/dashcard/${DASHCARD_ID}/execute`,
         );
         expect(await call?.request?.json()).toEqual(expectedBody);
       });
@@ -304,7 +309,7 @@ describe("Actions > ActionViz > Action", () => {
 
     it("should combine data from dashboard parameters and form input when submitting for execution", async () => {
       const expectedBody = {
-        modelId: 777,
+        modelId: ACTION_MODEL_ID,
         parameters: {
           parameter_1: "foo",
           parameter_2: 5,
@@ -327,7 +332,7 @@ describe("Actions > ActionViz > Action", () => {
 
       await waitFor(async () => {
         const call = fetchMock.lastCall(
-          "path:/api/dashboard/123/dashcard/456/execute",
+          `path:/api/dashboard/${DASHBOARD_ID}/dashcard/${DASHCARD_ID}/execute`,
         );
         expect(await call?.request?.json()).toEqual(expectedBody);
       });

--- a/frontend/src/metabase/actions/components/ActionViz/Action.unit.spec.tsx
+++ b/frontend/src/metabase/actions/components/ActionViz/Action.unit.spec.tsx
@@ -46,7 +46,7 @@ const ACTION = createMockQueryAction({
     }),
     createMockActionParameter({
       id: "parameter_2",
-      type: "type/Text",
+      type: "type/Integer",
       target: ["variable", ["template-tag", "2"]],
     }),
   ],

--- a/frontend/src/metabase/actions/components/ActionViz/Action.unit.spec.tsx
+++ b/frontend/src/metabase/actions/components/ActionViz/Action.unit.spec.tsx
@@ -88,6 +88,13 @@ async function setup({
 }: SetupOpts = {}) {
   setupDatabasesEndpoints([DATABASE, DATABASE_WITHOUT_ACTIONS]);
 
+  fetchMock.post(
+    `path:/api/dashboard/${DASHBOARD_ID}/dashcard/${DASHCARD_ID}/execute`,
+    {
+      "rows-updated": [1],
+    },
+  );
+
   renderWithProviders(
     <Action
       dashboard={dashboard}
@@ -107,15 +114,6 @@ async function setup({
       screen.queryAllByTestId("loading-spinner"),
     );
   }
-}
-
-function setupExecutionEndpoint() {
-  fetchMock.post(
-    `path:/api/dashboard/${DASHBOARD_ID}/dashcard/${DASHCARD_ID}/execute`,
-    {
-      "rows-updated": [1],
-    },
-  );
 }
 
 describe("Actions > ActionViz > Action", () => {
@@ -214,7 +212,6 @@ describe("Actions > ActionViz > Action", () => {
         },
       });
 
-      setupExecutionEndpoint();
       await setup({
         dashcard: createMockActionDashboardCard({
           action,
@@ -290,8 +287,6 @@ describe("Actions > ActionViz > Action", () => {
         },
       };
 
-      setupExecutionEndpoint();
-
       await setup({ settings: formSettings });
 
       userEvent.type(screen.getByLabelText("Parameter 1"), "foo");
@@ -322,8 +317,6 @@ describe("Actions > ActionViz > Action", () => {
           parameter_2: 5,
         },
       };
-
-      setupExecutionEndpoint();
 
       await setup({
         settings: formSettings,

--- a/frontend/src/metabase/actions/components/ActionViz/Action.unit.spec.tsx
+++ b/frontend/src/metabase/actions/components/ActionViz/Action.unit.spec.tsx
@@ -2,9 +2,15 @@ import React from "react";
 import _ from "underscore";
 import fetchMock from "fetch-mock";
 import userEvent from "@testing-library/user-event";
-import { waitFor } from "@testing-library/react";
 
-import { renderWithProviders, screen } from "__support__/ui";
+import {
+  renderWithProviders,
+  screen,
+  findIcon,
+  getIcon,
+  waitFor,
+} from "__support__/ui";
+
 import {
   createMockActionDashboardCard,
   createMockActionParameter,
@@ -96,7 +102,6 @@ function setupExecutionEndpoint() {
 }
 
 describe("Actions > ActionViz > ActionComponent", () => {
-  // button actions are just a modal trigger around forms
   describe("Button actions", () => {
     it("should render an empty state for a button with no action", async () => {
       await setupActionWrapper({
@@ -105,7 +110,7 @@ describe("Actions > ActionViz > ActionComponent", () => {
           action: undefined,
         },
       });
-      expect(screen.getByLabelText("bolt icon")).toBeInTheDocument();
+      expect(getIcon("bolt")).toBeInTheDocument();
       expect(screen.getByRole("button")).toBeDisabled();
       expect(screen.getByLabelText(/no action assigned/i)).toBeInTheDocument();
     });
@@ -120,7 +125,7 @@ describe("Actions > ActionViz > ActionComponent", () => {
           }),
         },
       });
-      expect(await screen.findByLabelText("bolt icon")).toBeInTheDocument();
+      expect(await findIcon("bolt")).toBeInTheDocument();
       expect(await screen.findByRole("button")).toBeDisabled();
       expect(
         await screen.findByLabelText(/actions are not enabled/i),

--- a/frontend/src/metabase/actions/components/ActionViz/Action.unit.spec.tsx
+++ b/frontend/src/metabase/actions/components/ActionViz/Action.unit.spec.tsx
@@ -28,6 +28,7 @@ import Action, { ActionProps } from "./Action";
 const DASHBOARD_ID = 123;
 const DASHCARD_ID = 456;
 const ACTION_MODEL_ID = 777;
+const ACTION_EXEC_MOCK_PATH = `path:/api/dashboard/${DASHBOARD_ID}/dashcard/${DASHCARD_ID}/execute`;
 
 const DATABASE_WITHOUT_ACTIONS = createMockDatabase({ id: 1 });
 const DATABASE = createMockDatabase({
@@ -88,12 +89,9 @@ async function setup({
 }: SetupOpts = {}) {
   setupDatabasesEndpoints([DATABASE, DATABASE_WITHOUT_ACTIONS]);
 
-  fetchMock.post(
-    `path:/api/dashboard/${DASHBOARD_ID}/dashcard/${DASHCARD_ID}/execute`,
-    {
-      "rows-updated": [1],
-    },
-  );
+  fetchMock.post(ACTION_EXEC_MOCK_PATH, {
+    "rows-updated": [1],
+  });
 
   renderWithProviders(
     <Action
@@ -228,9 +226,7 @@ describe("Actions > ActionViz > Action", () => {
       userEvent.click(screen.getByRole("button", { name: "Click me" }));
 
       await waitFor(async () => {
-        const call = fetchMock.lastCall(
-          `path:/api/dashboard/${DASHBOARD_ID}/dashcard/${DASHCARD_ID}/execute`,
-        );
+        const call = fetchMock.lastCall(ACTION_EXEC_MOCK_PATH);
         expect(await call?.request?.json()).toEqual({
           modelId: ACTION_MODEL_ID,
           parameters: {
@@ -302,9 +298,7 @@ describe("Actions > ActionViz > Action", () => {
       userEvent.click(screen.getByRole("button", { name: "Run" }));
 
       await waitFor(async () => {
-        const call = fetchMock.lastCall(
-          `path:/api/dashboard/${DASHBOARD_ID}/dashcard/${DASHCARD_ID}/execute`,
-        );
+        const call = fetchMock.lastCall(ACTION_EXEC_MOCK_PATH);
         expect(await call?.request?.json()).toEqual(expectedBody);
       });
     });
@@ -331,9 +325,7 @@ describe("Actions > ActionViz > Action", () => {
       userEvent.click(screen.getByRole("button", { name: "Run" }));
 
       await waitFor(async () => {
-        const call = fetchMock.lastCall(
-          `path:/api/dashboard/${DASHBOARD_ID}/dashcard/${DASHCARD_ID}/execute`,
-        );
+        const call = fetchMock.lastCall(ACTION_EXEC_MOCK_PATH);
         expect(await call?.request?.json()).toEqual(expectedBody);
       });
     });

--- a/frontend/src/metabase/actions/components/ActionViz/Action.unit.spec.tsx
+++ b/frontend/src/metabase/actions/components/ActionViz/Action.unit.spec.tsx
@@ -6,7 +6,6 @@ import userEvent from "@testing-library/user-event";
 import {
   renderWithProviders,
   screen,
-  findIcon,
   getIcon,
   waitFor,
   waitForElementToBeRemoved,
@@ -120,10 +119,10 @@ describe("Actions > ActionViz > Action", () => {
           }),
         },
       });
-      expect(await findIcon("bolt")).toBeInTheDocument();
-      expect(await screen.findByRole("button")).toBeDisabled();
+      expect(getIcon("bolt")).toBeInTheDocument();
+      expect(screen.getByRole("button")).toBeDisabled();
       expect(
-        await screen.findByLabelText(/actions are not enabled/i),
+        screen.getByLabelText(/actions are not enabled/i),
       ).toBeInTheDocument();
     });
 
@@ -137,7 +136,7 @@ describe("Actions > ActionViz > Action", () => {
           }),
         },
       });
-      expect(await screen.findByRole("button")).toBeEnabled();
+      expect(screen.getByRole("button")).toBeEnabled();
     });
 
     it("should render a button with default text", async () => {
@@ -266,7 +265,7 @@ describe("Actions > ActionViz > Action", () => {
       });
 
       expect(
-        await screen.findByRole("button", { name: "Click me" }),
+        screen.getByRole("button", { name: "Click me" }),
       ).toBeInTheDocument();
     });
 

--- a/frontend/test/__support__/ui.tsx
+++ b/frontend/test/__support__/ui.tsx
@@ -155,6 +155,10 @@ function MaybeDNDProvider({
   );
 }
 
+export function findIcon(name: string, role: ByRoleMatcher = "img") {
+  return screen.findByRole(role, { name: `${name} icon` });
+}
+
 export function getIcon(name: string, role: ByRoleMatcher = "img") {
   return screen.getByRole(role, { name: `${name} icon` });
 }

--- a/frontend/test/__support__/ui.tsx
+++ b/frontend/test/__support__/ui.tsx
@@ -155,10 +155,6 @@ function MaybeDNDProvider({
   );
 }
 
-export function findIcon(name: string, role: ByRoleMatcher = "img") {
-  return screen.findByRole(role, { name: `${name} icon` });
-}
-
 export function getIcon(name: string, role: ByRoleMatcher = "img") {
   return screen.getByRole(role, { name: `${name} icon` });
 }


### PR DESCRIPTION
Refactors `ActionViz/Action` component unit tests:

* uses `getIcon` / `queryIcon` wherever possible
* makes the tests always use the top-level action component instead of container and view. Also, removes `export` from these components to make it clear they're not used anywhere externally
* extracts common data like dashboard/dashcard/model IDs into constants as a lot of logic/tests rely on these IDs, and they're easy to miss
* breaks down default data into smaller parts to make it easier to compose things

Marked for backporting, so we can later backport #29092 too

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/29093)
<!-- Reviewable:end -->
