### PR TITLE
Only save changed dashboards

### DIFF
--- a/e2e/support/helpers/e2e-dashboard-helpers.js
+++ b/e2e/support/helpers/e2e-dashboard-helpers.js
@@ -20,9 +20,7 @@ export function editDashboard() {
 }
 
 export function saveDashboard() {
-  cy.intercept("GET", "/api/dashboard/*").as("getDashboard");
   cy.findByText("Save").click();
-  cy.wait("@getDashboard");
   cy.findByText("You're editing this dashboard.").should("not.exist");
   cy.wait(1); // this is stupid but necessary to due to the dashboard resizing and detaching elements
 }

--- a/e2e/test/scenarios/dashboard-filters/reproductions/22788-flter-cc-dropped-on-second-edit.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/reproductions/22788-flter-cc-dropped-on-second-edit.cy.spec.js
@@ -4,6 +4,7 @@ import {
   filterWidget,
   editDashboard,
   saveDashboard,
+  sidebar,
 } from "e2e/support/helpers";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 
@@ -79,6 +80,12 @@ describe("issue 22788", () => {
       .within(() => {
         cy.findByText(ccDisplayName);
       });
+
+    // need to actually change the dashboard to test a real save
+    sidebar().within(() => {
+      cy.findByDisplayValue("Text").clear().type('my filter text');
+      cy.button('Done').click();
+    });
 
     saveDashboard();
 

--- a/frontend/src/metabase/dashboard/actions/actions.unit.spec.js
+++ b/frontend/src/metabase/dashboard/actions/actions.unit.spec.js
@@ -12,6 +12,7 @@ import {
   openAddQuestionSidebar,
   removeParameter,
   SET_DASHBOARD_ATTRIBUTES,
+  saveDashboardAndCards,
 } from "./index";
 
 DashboardApi.parameterSearch = jest.fn();
@@ -149,6 +150,42 @@ describe("dashboard actions", () => {
           },
         },
       });
+    });
+  });
+
+  describe("saveDashboardAndCards", () => {
+    it("should not save anything if the dashboard has not changed", async () => {
+      const dashboard = {
+        id: 1,
+        name: "Foo",
+        parameters: [],
+        ordered_cards: [
+          { id: 1, name: "Foo", card_id: 1 },
+          { id: 2, name: "Bar", card_id: 2 },
+        ],
+      };
+
+      const getState = () => ({
+        dashboard: {
+          isEditing: dashboard,
+          dashboardId: 1,
+          dashboards: {
+            1: {
+              ...dashboard,
+              ordered_cards: [1, 2],
+            },
+          },
+          dashcards: {
+            1: dashboard.ordered_cards[0],
+            2: dashboard.ordered_cards[1],
+          },
+        },
+      });
+
+      await saveDashboardAndCards()(dispatch, getState);
+
+      // if this is called only once, it means that the dashboard was not saved
+      expect(dispatch).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/frontend/src/metabase/dashboard/actions/utils.ts
+++ b/frontend/src/metabase/dashboard/actions/utils.ts
@@ -1,0 +1,32 @@
+import _ from "underscore";
+
+import type { Dashboard, DashboardOrderedCard } from "metabase-types/api";
+
+export function hasDashboardChanged(
+  dashboard: Dashboard,
+  dashboardBeforeEditing: Dashboard,
+) {
+  return !_.isEqual(
+    { ...dashboard, ordered_cards: dashboard.ordered_cards.length },
+    {
+      ...dashboardBeforeEditing,
+      ordered_cards: dashboardBeforeEditing.ordered_cards.length,
+    },
+  );
+}
+
+// sometimes the cards objects change order but all the cards themselves are the same
+// this should not trigger a save
+export function haveDashboardCardsChanged(
+  newCards: DashboardOrderedCard[],
+  oldCards: DashboardOrderedCard[],
+) {
+  return (
+    !newCards.every(newCard =>
+      oldCards.some(oldCard => _.isEqual(oldCard, newCard)),
+    ) ||
+    !oldCards.every(oldCard =>
+      newCards.some(newCard => _.isEqual(oldCard, newCard)),
+    )
+  );
+}

--- a/frontend/src/metabase/dashboard/actions/utils.unit.spec.ts
+++ b/frontend/src/metabase/dashboard/actions/utils.unit.spec.ts
@@ -1,0 +1,204 @@
+import {
+  createMockDashboard,
+  createMockDashboardOrderedCard,
+} from "metabase-types/api/mocks";
+import { hasDashboardChanged, haveDashboardCardsChanged } from "./utils";
+
+describe("dashboard > actions > utils", () => {
+  describe("hasDashboardChanged", () => {
+    it("should return false if the dashboard has not changed", () => {
+      const oldDash = createMockDashboard({
+        id: 1,
+        name: "old name",
+        parameters: [
+          { id: "1", name: "old name", type: "type/Text", slug: "my_param" },
+        ],
+      });
+      const newDash = createMockDashboard({
+        id: 1,
+        name: "old name",
+        parameters: [
+          { id: "1", name: "old name", type: "type/Text", slug: "my_param" },
+        ],
+      });
+
+      expect(hasDashboardChanged(newDash, oldDash)).toBe(false);
+    });
+
+    it("should return true if the dashboard has changed", () => {
+      const oldDash = createMockDashboard({ id: 1, name: "old name" });
+      const newDash = createMockDashboard({ id: 1, name: "new name" });
+
+      expect(hasDashboardChanged(newDash, oldDash)).toBe(true);
+    });
+
+    it("should return true if the deeply nested properties change", () => {
+      const oldDash = createMockDashboard({
+        id: 1,
+        name: "old name",
+        parameters: [
+          { id: "1", name: "old name", type: "type/Text", slug: "my_param" },
+        ],
+      });
+      const newDash = createMockDashboard({
+        id: 1,
+        name: "old name",
+        parameters: [
+          { id: "1", name: "new name", type: "type/Text", slug: "my_param" },
+        ],
+      });
+
+      expect(hasDashboardChanged(newDash, oldDash)).toBe(true);
+    });
+
+    it("should return true if the number of cards has changed", () => {
+      const oldDash = createMockDashboard({
+        id: 1,
+        name: "old name",
+        ordered_cards: [createMockDashboardOrderedCard()],
+      });
+      const newDash = createMockDashboard({ id: 1, name: "old name" });
+
+      expect(hasDashboardChanged(newDash, oldDash)).toBe(true);
+    });
+
+    it("should ignore card changes", () => {
+      const oldDash = createMockDashboard({
+        id: 1,
+        name: "old name",
+        ordered_cards: [createMockDashboardOrderedCard({ id: 1 })],
+      });
+      const newDash = createMockDashboard({
+        id: 1,
+        name: "old name",
+        ordered_cards: [createMockDashboardOrderedCard({ id: 2 })],
+      });
+
+      expect(hasDashboardChanged(newDash, oldDash)).toBe(false);
+    });
+  });
+
+  describe("haveDashboardCardsChanged", () => {
+    it("should return true if a card changed", () => {
+      const oldCards = [
+        createMockDashboardOrderedCard({ id: 1 }),
+        createMockDashboardOrderedCard({ id: 2 }),
+      ];
+      const newCards = [
+        createMockDashboardOrderedCard({ id: 2 }),
+        createMockDashboardOrderedCard({ id: 3 }),
+      ];
+
+      expect(haveDashboardCardsChanged(newCards, oldCards)).toBe(true);
+    });
+
+    it("should return true if a card was added", () => {
+      const oldCards = [
+        createMockDashboardOrderedCard({ id: 1 }),
+        createMockDashboardOrderedCard({ id: 2 }),
+      ];
+      const newCards = [
+        createMockDashboardOrderedCard({ id: 1 }),
+        createMockDashboardOrderedCard({ id: 2 }),
+        createMockDashboardOrderedCard({ id: 3 }),
+      ];
+
+      expect(haveDashboardCardsChanged(newCards, oldCards)).toBe(true);
+    });
+
+    it("should return true if a card was added and deleted", () => {
+      const oldCards = [
+        createMockDashboardOrderedCard({ id: 1 }),
+        createMockDashboardOrderedCard({ id: 2 }),
+        createMockDashboardOrderedCard({ id: 3 }),
+      ];
+      const newCards = [
+        createMockDashboardOrderedCard({ id: 1 }),
+        createMockDashboardOrderedCard({ id: 2 }),
+        createMockDashboardOrderedCard({ id: 4 }),
+      ];
+
+      expect(haveDashboardCardsChanged(newCards, oldCards)).toBe(true);
+    });
+
+    it("should return true if a card was removed", () => {
+      const oldCards = [
+        createMockDashboardOrderedCard({ id: 1 }),
+        createMockDashboardOrderedCard({ id: 2 }),
+      ];
+      const newCards = [createMockDashboardOrderedCard({ id: 1 })];
+
+      expect(haveDashboardCardsChanged(newCards, oldCards)).toBe(true);
+    });
+
+    it("should return true if deeply nested properties change", () => {
+      const oldCards = [
+        createMockDashboardOrderedCard({
+          id: 1,
+          visualization_settings: { foo: { bar: { baz: 21 } } },
+        }),
+        createMockDashboardOrderedCard({ id: 2 }),
+      ];
+      const newCards = [
+        createMockDashboardOrderedCard({
+          id: 1,
+          visualization_settings: { foo: { bar: { baz: 22 } } },
+        }),
+        createMockDashboardOrderedCard({ id: 2 }),
+      ];
+
+      expect(haveDashboardCardsChanged(newCards, oldCards)).toBe(true);
+    });
+
+    it("should return false if the dashboard cards have not changed", () => {
+      const oldCards = [
+        createMockDashboardOrderedCard({ id: 1 }),
+        createMockDashboardOrderedCard({ id: 2 }),
+      ];
+      const newCards = [
+        createMockDashboardOrderedCard({ id: 1 }),
+        createMockDashboardOrderedCard({ id: 2 }),
+      ];
+
+      expect(haveDashboardCardsChanged(newCards, oldCards)).toBe(false);
+    });
+
+    it("should return false if the dashboard cards have only changed order", () => {
+      const oldCards = [
+        createMockDashboardOrderedCard({ id: 1 }),
+        createMockDashboardOrderedCard({ id: 2 }),
+      ];
+      const newCards = [
+        createMockDashboardOrderedCard({ id: 2 }),
+        createMockDashboardOrderedCard({ id: 1 }),
+      ];
+
+      expect(haveDashboardCardsChanged(newCards, oldCards)).toBe(false);
+    });
+
+    it("should perform reasonably well for 1000 cards", () => {
+      const oldCards = Array(1000)
+        .fill("")
+        .map(index =>
+          createMockDashboardOrderedCard({
+            id: index,
+            visualization_settings: { foo: { bar: { baz: index * 10 } } },
+          }),
+        );
+      const newCards = Array(1000)
+        .fill("")
+        .map(index =>
+          createMockDashboardOrderedCard({
+            id: index,
+            visualization_settings: { foo: { bar: { baz: index * 10 } } },
+          }),
+        );
+
+      const startTime = performance.now();
+      expect(haveDashboardCardsChanged(newCards, oldCards)).toBe(false);
+      const endTime = performance.now();
+
+      expect(endTime - startTime).toBeLessThan(100); // 100 ms (locally this was 6 ms)
+    });
+  });
+});


### PR DESCRIPTION
slightly related to https://github.com/metabase/metabase/issues/28956

### Description

This is a small performance optimization whereby we shouldn't be saving and reloading dashboards that haven't changed.

![Screen Shot 2023-03-09 at 1 19 32 PM](https://user-images.githubusercontent.com/30528226/224146461-6381af5d-1af5-4f1e-9fee-a2ab006d8f5f.png)

### How to verify

- open your network inspector
- create a new empty dashboard
- click the edit button
- click the save button
- see that there are no API calls to the dashboard API endpoints
- click the edit button again
- change something about the dashboard
- save the dashboard
- see that API calls happen and changes are properly saved

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
