### PR TITLE
Don't destroy app bar when hiding

### DIFF
--- a/e2e/test/scenarios/admin/people/group-managers.cy.spec.js
+++ b/e2e/test/scenarios/admin/people/group-managers.cy.spec.js
@@ -37,13 +37,21 @@ describeEE("scenarios > admin > people", () => {
       });
 
       // Edit group name
-      cy.icon("ellipsis").eq(0).click();
-      cy.findByText("Edit Name").click();
-      cy.get("input").type(" updated");
-      cy.button("Done").click();
+      cy.findByTestId("admin-content-table").within(() => {
+        cy.icon("ellipsis").eq(0).click();
+      });
+      popover().within(() => {
+        cy.findByText("Edit Name").click();
+      });
 
-      // Click on the group with the new name
-      cy.findByText("collection updated").click();
+      cy.findByTestId("admin-content-table").within(() => {
+        cy.findByDisplayValue("collection")
+          .type(" updated");
+        cy.button("Done").click();
+        // Click on the group with the new name
+        cy.findByText("collection updated").click();
+      });
+
 
       // Add "No Collection" user as a member
       cy.button("Add members").click();

--- a/e2e/test/scenarios/admin/people/group-managers.cy.spec.js
+++ b/e2e/test/scenarios/admin/people/group-managers.cy.spec.js
@@ -40,9 +40,8 @@ describeEE("scenarios > admin > people", () => {
       cy.findByTestId("admin-content-table").within(() => {
         cy.icon("ellipsis").eq(0).click();
       });
-      popover().within(() => {
-        cy.findByText("Edit Name").click();
-      });
+
+      popover().findByText("Edit Name").click();
 
       cy.findByTestId("admin-content-table").within(() => {
         cy.findByDisplayValue("collection")

--- a/e2e/test/scenarios/embedding/embedding-full-app.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-full-app.cy.spec.js
@@ -29,7 +29,7 @@ describe("scenarios > embedding > full app", () => {
       visitUrl({ url: "/", qs: { top_nav: false } });
       cy.findByText(/Bobby/).should("be.visible");
       cy.findByText("Our analytics").should("not.exist");
-      cy.findByTestId("main-logo").should("not.exist");
+      cy.findByTestId("main-logo").should("not.be.visible");
     });
 
     it("should not hide the top nav when the logo is still visible", () => {

--- a/frontend/src/metabase/App.tsx
+++ b/frontend/src/metabase/App.tsx
@@ -100,7 +100,7 @@ function App({
       <ScrollToTop>
         <AppContainer className="spread">
           <AppBanner />
-          {isAppBarVisible && <AppBar />}
+          <AppBar isVisible={isAppBarVisible} />
           <AppContentContainer isAdminApp={isAdminApp}>
             {isNavBarEnabled && <Navbar />}
             <AppContent ref={setViewportElement}>

--- a/frontend/src/metabase/components/AdminContentTable.jsx
+++ b/frontend/src/metabase/components/AdminContentTable.jsx
@@ -2,7 +2,7 @@
 import React from "react";
 
 const AdminContentTable = ({ columnTitles, children }) => (
-  <table className="ContentTable">
+  <table className="ContentTable" data-testid="admin-content-table">
     <thead>
       <tr>
         {columnTitles &&

--- a/frontend/src/metabase/nav/components/AppBar/AppBar.styled.tsx
+++ b/frontend/src/metabase/nav/components/AppBar/AppBar.styled.tsx
@@ -1,6 +1,7 @@
 import styled from "@emotion/styled";
 
-export const AppBarRoot = styled.header`
+export const AppBarRoot = styled.header<{ isVisible: boolean }>`
+  display: ${({ isVisible }) => (isVisible ? "block" : "none")};
   position: relative;
   z-index: 4;
 

--- a/frontend/src/metabase/nav/components/AppBar/AppBar.tsx
+++ b/frontend/src/metabase/nav/components/AppBar/AppBar.tsx
@@ -16,7 +16,7 @@ export interface AppBarProps {
   isProfileLinkVisible?: boolean;
   isCollectionPathVisible?: boolean;
   isQuestionLineageVisible?: boolean;
-  isVisible?: boolean;
+  isVisible: boolean;
   onToggleNavbar: () => void;
   onCloseNavbar: () => void;
   onLogout: () => void;

--- a/frontend/src/metabase/nav/components/AppBar/AppBar.tsx
+++ b/frontend/src/metabase/nav/components/AppBar/AppBar.tsx
@@ -16,6 +16,7 @@ export interface AppBarProps {
   isProfileLinkVisible?: boolean;
   isCollectionPathVisible?: boolean;
   isQuestionLineageVisible?: boolean;
+  isVisible?: boolean;
   onToggleNavbar: () => void;
   onCloseNavbar: () => void;
   onLogout: () => void;
@@ -25,7 +26,7 @@ const AppBar = (props: AppBarProps): JSX.Element => {
   const isSmallScreen = useIsSmallScreen();
 
   return (
-    <AppBarRoot data-testid="app-bar">
+    <AppBarRoot data-testid="app-bar" isVisible={props.isVisible}>
       {isSmallScreen ? <AppBarSmall {...props} /> : <AppBarLarge {...props} />}
     </AppBarRoot>
   );

--- a/frontend/src/metabase/nav/components/AppBar/AppBar.tsx
+++ b/frontend/src/metabase/nav/components/AppBar/AppBar.tsx
@@ -22,8 +22,13 @@ export interface AppBarProps {
   onLogout: () => void;
 }
 
-const AppBar = (props: AppBarProps): JSX.Element => {
+const AppBar = (props: AppBarProps): JSX.Element | null => {
   const isSmallScreen = useIsSmallScreen();
+
+  // don't render the app bar if there is no logged-in user
+  if (!props.currentUser) {
+    return null;
+  }
 
   return (
     <AppBarRoot data-testid="app-bar" isVisible={props.isVisible}>

--- a/frontend/src/metabase/nav/components/AppBar/AppBar.tsx
+++ b/frontend/src/metabase/nav/components/AppBar/AppBar.tsx
@@ -22,7 +22,7 @@ export interface AppBarProps {
   onLogout: () => void;
 }
 
-const AppBar = (props: AppBarProps): React.ReactNode => {
+const AppBar = (props: AppBarProps) => {
   const isSmallScreen = useIsSmallScreen();
 
   if (!props.currentUser) {

--- a/frontend/src/metabase/nav/components/AppBar/AppBar.tsx
+++ b/frontend/src/metabase/nav/components/AppBar/AppBar.tsx
@@ -22,10 +22,9 @@ export interface AppBarProps {
   onLogout: () => void;
 }
 
-const AppBar = (props: AppBarProps): JSX.Element | null => {
+const AppBar = (props: AppBarProps): React.ReactNode => {
   const isSmallScreen = useIsSmallScreen();
 
-  // don't render the app bar if there is no logged-in user
   if (!props.currentUser) {
     return null;
   }

--- a/frontend/src/metabase/nav/components/AppBar/AppBar.unit.spec.tsx
+++ b/frontend/src/metabase/nav/components/AppBar/AppBar.unit.spec.tsx
@@ -122,6 +122,7 @@ const getProps = (opts?: Partial<AppBarProps>): AppBarProps => ({
   onToggleNavbar: jest.fn(),
   onCloseNavbar: jest.fn(),
   onLogout: jest.fn(),
+  isVisible: true,
   ...opts,
 });
 

--- a/frontend/src/metabase/nav/containers/AppBar/AppBar.unit.spec.tsx
+++ b/frontend/src/metabase/nav/containers/AppBar/AppBar.unit.spec.tsx
@@ -143,20 +143,23 @@ describe("AppBar", () => {
 function setup(embedOptions: Partial<EmbedOptions>) {
   setupCollectionsEndpoints([]);
 
-  renderWithProviders(<Route path="/question/:slug" component={AppBar} />, {
-    withRouter: true,
-    initialRoute: "/question/1",
-    storeInitialState: {
-      app: createMockAppState({ isNavbarOpen: false }),
-      embed: createMockEmbedState({
-        ...DEFAULT_EMBED_OPTIONS,
-        ...embedOptions,
-      }),
-      qb: createMockQueryBuilderState({
-        card: createMockCard(),
-      }),
+  renderWithProviders(
+    <Route path="/question/:slug" component={() => <AppBar isVisible />} />,
+    {
+      withRouter: true,
+      initialRoute: "/question/1",
+      storeInitialState: {
+        app: createMockAppState({ isNavbarOpen: false }),
+        embed: createMockEmbedState({
+          ...DEFAULT_EMBED_OPTIONS,
+          ...embedOptions,
+        }),
+        qb: createMockQueryBuilderState({
+          card: createMockCard(),
+        }),
+      },
     },
-  });
+  );
 }
 
 function getMediaQuery(opts?: Partial<MediaQueryList>): MediaQueryList {


### PR DESCRIPTION
slightly related to https://github.com/metabase/metabase/issues/28956

### Description

Several situations in the app can cause us to want to temporarily hide the app bar
- entering admin mode
- entering dashboard edit mode
- entering dashboard full screen mode

In all cases, when "hiding" the app bar, we actually destroy it. what makes this problematic is that several components in the app bar make API calls when they're loaded, so any time we re-show the app bar, we make those API calls again unnecessarily.

This simply hides the app bar without destroying it, so hide/show is a simple css change instead of a destroy/recreate operation. This eliminates 2 API calls (on EE) for every re-show of the app bar.
- `app/assets/img/logo.svg`
- `api/util/bug_report_details`

![Screen Shot 2023-03-09 at 1 58 32 PM](https://user-images.githubusercontent.com/30528226/224158175-0e263871-ec95-4872-be06-0f6952f9e5ca.png)

It's also possible there's a small performance improvement by not totally redrawing the app bar, but that is small compared to not making a couple unnecessary network requests.

### How to verify

- Open your network inspector
- enter/exit admin settings
- you shouldn't see the two network requests listed above 😄 

### Checklist
- [x] Tests have been added/updated to cover changes in this PR
