### PR TITLE
fix aggregations sum, avg, and other aggregations can be used over a category field

### DIFF
--- a/frontend/src/metabase-lib/operators/constants.js
+++ b/frontend/src/metabase-lib/operators/constants.js
@@ -6,7 +6,7 @@ import {
   isDate,
   isBoolean,
   isScope,
-  isSummable,
+  isNonCoordinateNumber,
   isLongitude,
 } from "metabase-lib/types/utils/isa";
 import {
@@ -299,8 +299,8 @@ function allFields(fields) {
   return fields;
 }
 
-function summableFields(fields) {
-  return _.filter(fields, isSummable);
+function numberFields(fields) {
+  return _.filter(fields, isNonCoordinateNumber);
 }
 
 function scopeFields(fields) {
@@ -331,7 +331,7 @@ export const AGGREGATION_OPERATORS = [
     name: t`Sum of ...`,
     columnName: t`Sum`,
     description: t`Sum of all the values of a column.`,
-    validFieldsFilters: [summableFields],
+    validFieldsFilters: [numberFields],
     requiresField: true,
     requiredDriverFeature: "basic-aggregations",
   },
@@ -340,7 +340,7 @@ export const AGGREGATION_OPERATORS = [
     name: t`Average of ...`,
     columnName: t`Average`,
     description: t`Average of all the values of a column`,
-    validFieldsFilters: [summableFields],
+    validFieldsFilters: [numberFields],
     requiresField: true,
     requiredDriverFeature: "basic-aggregations",
   },
@@ -349,7 +349,7 @@ export const AGGREGATION_OPERATORS = [
     name: t`Median of ...`,
     columnName: t`Median`,
     description: t`Median of all the values of a column`,
-    validFieldsFilters: [summableFields],
+    validFieldsFilters: [numberFields],
     requiresField: true,
     requiredDriverFeature: "percentile-aggregations",
   },
@@ -367,7 +367,7 @@ export const AGGREGATION_OPERATORS = [
     name: t`Cumulative sum of ...`,
     columnName: t`Cumulative sum`, // NOTE: actually "Sum" as of 2019-10-01
     description: t`Additive sum of all the values of a column.\ne.x. total revenue over time.`,
-    validFieldsFilters: [summableFields],
+    validFieldsFilters: [numberFields],
     requiresField: true,
     requiredDriverFeature: "basic-aggregations",
   },
@@ -385,7 +385,7 @@ export const AGGREGATION_OPERATORS = [
     name: t`Standard deviation of ...`,
     columnName: t`Standard deviation`, // NOTE: actually "SD" as of 2019-10-01
     description: t`Number which expresses how much the values of a column vary among all rows in the answer.`,
-    validFieldsFilters: [summableFields],
+    validFieldsFilters: [numberFields],
     requiresField: true,
     requiredDriverFeature: "standard-deviation-aggregations",
   },

--- a/frontend/src/metabase-lib/types/utils/isa.js
+++ b/frontend/src/metabase-lib/types/utils/isa.js
@@ -150,6 +150,11 @@ export const isNumber = field =>
   isNumericBaseType(field) &&
   (field.semantic_type == null || isa(field.semantic_type, TYPE.Number));
 
+// This function is being used to detect number fields that can be used for aggregations and can be formatted as numbers.
+// Do not use this function to determine filtering behavior since coordinates should be filtered as numbers.
+export const isNonCoordinateNumber = field =>
+  isNumber(field) && !isCoordinate(field);
+
 export const isBinnedNumber = field => isNumber(field) && !!field.binning_info;
 
 export const isTime = field => {

--- a/frontend/src/metabase/visualizations/lib/settings/column.js
+++ b/frontend/src/metabase/visualizations/lib/settings/column.js
@@ -47,8 +47,7 @@ export function columnSettings({
 import MetabaseSettings from "metabase/lib/settings";
 import {
   isDate,
-  isNumber,
-  isCoordinate,
+  isNonCoordinateNumber,
   isCurrency,
   isDateWithoutTime,
 } from "metabase-lib/types/utils/isa";
@@ -440,13 +439,6 @@ export const NUMBER_COLUMN_SETTINGS = {
 };
 
 const COMMON_COLUMN_SETTINGS = {
-  // markdown_template: {
-  //   title: t`Markdown template`,
-  //   widget: "input",
-  //   props: {
-  //     placeholder: "{{value}}",
-  //   },
-  // },
   column: {
     getValue: column => column,
   },
@@ -476,7 +468,7 @@ export function getSettingDefinitionsForColumn(series, column) {
       ...DATE_COLUMN_SETTINGS,
       ...COMMON_COLUMN_SETTINGS,
     };
-  } else if (isNumber(column) && !isCoordinate(column)) {
+  } else if (isNonCoordinateNumber(column)) {
     return {
       ...extraColumnSettings,
       ...NUMBER_COLUMN_SETTINGS,


### PR DESCRIPTION
# WIP: checking CI

Closes https://github.com/metabase/metabase/issues/28523

### Description

Aggregations allowed using all summable fields, however, due to different semantic types such as "categorical" or "coordinate" we don't allow format these fields as numbers. Overall, it is not reasonable to even aggregate fields of these types.

### How to verify

1) Go to Admin -> Data Model -> Sample Database -> Orders -> Set Column Tax to Category
2) Click on New Question -> Sample Database -> Orders -> click Summarize by "Sum of"
3) Ensure the list does not contain "Tax" since it is a categorical field now

### Demo


### Checklist

- [ ] Tests have been added/updated to cover changes in this PR

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/29105)
<!-- Reviewable:end -->
