### PR TITLE
fix flaky fetch-logs-test

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/advanced_config/api/logs_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_config/api/logs_test.clj
@@ -1,4 +1,4 @@
-(ns metabase-enterprise.advanced-config.api.logs-test
+(ns ^:mb/once metabase-enterprise.advanced-config.api.logs-test
   "Tests for /api/ee/logs endpoints"
   (:require
    [clojure.test :refer :all]

--- a/enterprise/backend/test/metabase_enterprise/advanced_config/api/logs_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_config/api/logs_test.clj
@@ -42,12 +42,14 @@
                      (->> (ee.api.logs/query-execution-logs 2023 2)
                           (filter #(#{user-id} (:executor_id %)))
                           (filter #((set (map :id [qe-a qe-b])) (:id %)))
-                          (map #(select-keys % [:started_at :id]))))))
+                          (map #(select-keys % [:started_at :id]))))))))))
 
-            (testing "require admins"
-              (is (= "You don't have permissions to do that."
-                     (mt/user-http-request :rasta :get 403 "ee/logs/query_execution/2023-02")))))
-          (testing "Logs endpoint only works when `:advanced-config` feature is available."
-            (premium-features.test/with-premium-features #{}
-              (is (= "This API endpoint is only enabled if you have a premium token with the :advanced-config feature."
-                     (mt/user-http-request :crowberto :get 402 "ee/logs/query_execution/2023-02"))))))))))
+    (testing "permission tests"
+      (testing "require admins"
+        (premium-features.test/with-premium-features #{:advanced-config}
+          (is (= "You don't have permissions to do that."
+                 (mt/user-http-request :rasta :get 403 "ee/logs/query_execution/2023-02")))))
+      (testing "only works when `:advanced-config` feature is available."
+        (premium-features.test/with-premium-features #{}
+          (is (= "This API endpoint is only enabled if you have a premium token with the :advanced-config feature."
+                 (mt/user-http-request :crowberto :get 402 "ee/logs/query_execution/2023-02"))))))))

--- a/enterprise/backend/test/metabase_enterprise/advanced_config/api/logs_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_config/api/logs_test.clj
@@ -3,6 +3,7 @@
   (:require
    [clojure.test :refer :all]
    [java-time :as t]
+   [metabase-enterprise.advanced-config.api.logs :as ee.api.logs]
    [metabase.models.query-execution :refer [QueryExecution]]
    [metabase.public-settings.premium-features-test :as premium-features.test]
    [metabase.query-processor.util :as qp.util]
@@ -31,14 +32,22 @@
                         QueryExecution [qe-b (merge query-execution-defaults
                                                     {:executor_id user-id
                                                      :started_at  (t/minus now (t/days 32))})]]
-          (testing "Query Executions within `:yyyy-mm` are returned."
-            (premium-features.test/with-premium-features #{:advanced-config}
+          (premium-features.test/with-premium-features #{:advanced-config}
+            (testing "Query Executions within `:yyyy-mm` are returned."
               (is (= [(select-keys qe-a [:started_at :id])]
-                     (->> (mt/user-http-request test-user :get 200 "ee/logs/query_execution/2023-02")
+                     ;; we're calling the function directly instead of calling the API
+                     ;; because we want the test to run against the empty h2 DB we bound above
+                     ;; Until we figure out how to completely re-bind a database for API calls
+                     ;; this should be enough
+                     (->> (ee.api.logs/query-execution-logs 2023 2)
                           (filter #(#{user-id} (:executor_id %)))
                           (filter #((set (map :id [qe-a qe-b])) (:id %)))
-                          (map #(select-keys % [:started_at :id])))))))
+                          (map #(select-keys % [:started_at :id]))))))
+
+            (testing "require admins"
+              (is (= "You don't have permissions to do that."
+                     (mt/user-http-request :rasta :get 403 "ee/logs/query_execution/2023-02")))))
           (testing "Logs endpoint only works when `:advanced-config` feature is available."
             (premium-features.test/with-premium-features #{}
               (is (= "This API endpoint is only enabled if you have a premium token with the :advanced-config feature."
-                     (mt/user-http-request test-user :get 402 "ee/logs/query_execution/2023-02"))))))))))
+                     (mt/user-http-request :crowberto :get 402 "ee/logs/query_execution/2023-02"))))))))))

--- a/enterprise/backend/test/metabase_enterprise/advanced_config/api/logs_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_config/api/logs_test.clj
@@ -23,8 +23,8 @@
   (testing "GET /api/logs/query_execution/:yyyy-mm"
     (let [test-user :crowberto
           user-id   (mt/user->id test-user)]
-      ;; QueryExecution is an unbounded mega table, so run this test in an empty appdb
-      ;; otherwise calling the API will returns a zillion of log and we'll get OOM or stackoverflow.
+      ;; QueryExecution is an unbounded mega table and query it could result in a full table scan :( (See: #29103)
+      ;; Run the test in an empty database to make querying less intense.
       (mt/with-empty-h2-app-db
         (mt/with-temp* [QueryExecution [qe-a (merge query-execution-defaults
                                                     {:executor_id user-id

--- a/test/metabase/dashboard_subscription_test.clj
+++ b/test/metabase/dashboard_subscription_test.clj
@@ -434,8 +434,9 @@
 
     :fixture
     (fn [{dashboard-id :dashboard-id} thunk]
-      (with-link-card-fixture-for-dashboard (t2/select-one Dashboard :id dashboard-id) [_]
-        (thunk)))
+      (mt/with-temporary-setting-values [site-name "Metabase Test"]
+        (with-link-card-fixture-for-dashboard (t2/select-one Dashboard :id dashboard-id) [_]
+          (thunk))))
     :assert
     {:email
      (fn [_ _]

--- a/test/metabase/test/data.clj
+++ b/test/metabase/test/data.clj
@@ -257,6 +257,7 @@
 
   Makes use of functionality in the [[metabase.db.schema-migrations-test.impl]] namespace since that already does what
   we need."
+  {:style/indent 0}
   [& body]
   `(schema-migrations-test.impl/with-temp-empty-app-db [conn# :h2]
      (schema-migrations-test.impl/run-migrations-in-range! conn# [0 "v99.00-000"]) ; this should catch all migrations)


### PR DESCRIPTION
Well, we're doing a full table scan on Query_execution every time we run this test and during the drivers test, that table can grow by a lot.
[Failing run](https://github.com/metabase/metabase/actions/runs/4381637709/jobs/7669906281)

full table scan on query_execution is an awared problem: #29103

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/29112)
<!-- Reviewable:end -->
