### PR TITLE
Fix default value handling for action parameters

### DIFF
--- a/frontend/src/metabase/actions/components/ActionForm/FormFieldEditor.unit.spec.tsx
+++ b/frontend/src/metabase/actions/components/ActionForm/FormFieldEditor.unit.spec.tsx
@@ -1,10 +1,10 @@
 import React, { useState } from "react";
 import userEvent from "@testing-library/user-event";
 import {
-  render,
-  screen,
   getIcon,
   queryIcon,
+  render,
+  screen,
   waitFor,
   within,
 } from "__support__/ui";
@@ -158,6 +158,58 @@ describe("FormFieldEditor", () => {
           valueOptions: undefined,
         }),
       );
+    });
+  });
+
+  describe("default values", () => {
+    it("keeps default value when converting between input types", async () => {
+      const fieldSettings = getDefaultFieldSettings({
+        fieldType: "string",
+        inputType: "string",
+        defaultValue: "default",
+      });
+
+      const { onChange } = setup({ fieldSettings });
+
+      userEvent.click(screen.getByLabelText("Field settings"));
+      expect(await screen.findByRole("tooltip")).toBeInTheDocument();
+
+      userEvent.click(screen.getByRole("radio", { name: "Long text" }));
+
+      expect(onChange).toHaveBeenLastCalledWith({
+        ...fieldSettings,
+        inputType: "text",
+        defaultValue: "default",
+      });
+    });
+
+    it("handles default value when switching between field types", async () => {
+      const fieldSettings = getDefaultFieldSettings({
+        fieldType: "string",
+        inputType: "text",
+        defaultValue: "123",
+        valueOptions: undefined,
+      });
+
+      const { onChange } = setup({ fieldSettings });
+      userEvent.click(screen.getByLabelText("Field settings"));
+      expect(await screen.findByRole("tooltip")).toBeInTheDocument();
+
+      userEvent.click(screen.getByText("Number"));
+      expect(onChange).toHaveBeenLastCalledWith({
+        ...fieldSettings,
+        fieldType: "number",
+        inputType: "number",
+        defaultValue: 123,
+      });
+
+      userEvent.click(screen.getByText("Date"));
+      expect(onChange).toHaveBeenLastCalledWith({
+        ...fieldSettings,
+        fieldType: "date",
+        inputType: "date",
+        defaultValue: undefined,
+      });
     });
   });
 });

--- a/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/FieldSettingsPopover.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/FieldSettingsPopover.tsx
@@ -11,6 +11,7 @@ import Input from "metabase/core/components/Input";
 import Radio from "metabase/core/components/Radio";
 import Toggle from "metabase/core/components/Toggle";
 import TippyPopoverWithTrigger from "metabase/components/PopoverWithTrigger/TippyPopoverWithTrigger";
+import { useUniqueId } from "metabase/hooks/use-unique-id";
 
 import { getInputTypes } from "./constants";
 import { getDefaultValueInputType } from "./utils";
@@ -143,10 +144,13 @@ function PlaceholderInput({
   value: string;
   onChange: (newPlaceholder: string) => void;
 }) {
+  const id = useUniqueId();
+
   return (
     <div>
-      <SectionLabel>{t`Placeholder text`}</SectionLabel>
+      <SectionLabel htmlFor={id}>{t`Placeholder text`}</SectionLabel>
       <Input
+        id={id}
         fullWidth
         value={value}
         onChange={e => onChange(e.target.value)}
@@ -167,6 +171,8 @@ function RequiredInput({
   onChangeRequired,
   onChangeDefaultValue,
 }: RequiredInputProps) {
+  const id = useUniqueId();
+
   const handleDefaultValueChange = ({
     target: { value },
   }: ChangeEvent<HTMLInputElement>) => {
@@ -182,14 +188,22 @@ function RequiredInput({
   return (
     <div>
       <ToggleContainer>
-        <RequiredToggleLabel htmlFor="is-required">{t`Required`}</RequiredToggleLabel>
-        <Toggle id="is-required" value={required} onChange={onChangeRequired} />
+        <RequiredToggleLabel
+          htmlFor={`${id}-required`}
+        >{t`Required`}</RequiredToggleLabel>
+        <Toggle
+          id={`${id}-required`}
+          value={required}
+          onChange={onChangeRequired}
+        />
       </ToggleContainer>
       {required && (
         <>
-          <SectionLabel htmlFor="default-value">{t`Default value`}</SectionLabel>
+          <SectionLabel htmlFor={`${id}-default`}>
+            {t`Default value`}
+          </SectionLabel>
           <Input
-            id="default-value"
+            id={`${id}-default`}
             type={getDefaultValueInputType(inputType)}
             fullWidth
             value={defaultValue ?? ""}

--- a/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/FieldSettingsPopover.unit.spec.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/FieldSettingsPopover.unit.spec.tsx
@@ -36,44 +36,23 @@ function setup({ settings = getDefaultFieldSettings() } = {}) {
 }
 
 describe("actions > FormCreator > FieldSettingsPopover", () => {
-  it("should show the popover", async () => {
-    setup();
-
-    userEvent.click(screen.getByLabelText("Field settings"));
-
-    expect(
-      await screen.findByTestId("field-settings-popover"),
-    ).toBeInTheDocument();
-  });
-
-  it("should fire onChange handler clicking a different input type", async () => {
+  it("should allow to change the input type", async () => {
     const { settings, onChange } = setup();
 
     userEvent.click(screen.getByLabelText("Field settings"));
+    userEvent.click(await screen.findByText("Dropdown"));
 
-    expect(
-      await screen.findByTestId("field-settings-popover"),
-    ).toBeInTheDocument();
-
-    userEvent.click(screen.getByText("Dropdown"));
-
-    expect(onChange).toHaveBeenCalledTimes(1);
     expect(onChange).toHaveBeenCalledWith({
       ...settings,
       inputType: "select",
     });
   });
 
-  it("should fire onChange handler editing placeholder", async () => {
+  it("should allow to change the placeholder", async () => {
     const { settings, onChange } = setup();
 
     userEvent.click(screen.getByLabelText("Field settings"));
-
-    expect(
-      await screen.findByTestId("field-settings-popover"),
-    ).toBeInTheDocument();
-
-    await userEvent.type(screen.getByTestId("placeholder-input"), "$");
+    userEvent.type(await screen.findByLabelText("Placeholder text"), "$");
 
     expect(onChange).toHaveBeenLastCalledWith({
       ...settings,
@@ -81,32 +60,44 @@ describe("actions > FormCreator > FieldSettingsPopover", () => {
     });
   });
 
-  it("should fire onChange handler after changing required and default value properties", async () => {
+  it("should allow to make the field required and optional", async () => {
     const settings = getDefaultFieldSettings({
       fieldType: "number",
       required: true,
-      defaultValue: 10,
     });
     const { onChange } = setup({ settings });
 
     userEvent.click(screen.getByLabelText("Field settings"));
-    await screen.findByTestId("field-settings-popover");
-
-    userEvent.click(screen.getByLabelText("Required"));
-    expect(onChange).toHaveBeenCalledTimes(1);
+    userEvent.click(await screen.findByLabelText("Required"));
     expect(onChange).toHaveBeenLastCalledWith({
       ...settings,
       required: false,
-      defaultValue: undefined,
     });
+    expect(screen.queryByLabelText("Default value")).not.toBeInTheDocument();
 
     userEvent.click(screen.getByLabelText("Required"));
-    await userEvent.type(screen.getByLabelText("Default value"), "5");
-
     expect(onChange).toHaveBeenLastCalledWith({
       ...settings,
       required: true,
-      defaultValue: 5,
+    });
+    expect(screen.getByLabelText("Default value")).toBeInTheDocument();
+  });
+
+  it("should allow to set the default value", async () => {
+    const settings = getDefaultFieldSettings({
+      fieldType: "number",
+      required: true,
+    });
+    const { onChange } = setup({ settings });
+    userEvent.click(screen.getByLabelText("Field settings"));
+
+    const input = await screen.findByLabelText("Default value");
+    userEvent.clear(input);
+    userEvent.type(input, "10");
+
+    expect(onChange).toHaveBeenLastCalledWith({
+      ...settings,
+      defaultValue: 10,
     });
   });
 });

--- a/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/utils.ts
+++ b/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/utils.ts
@@ -1,9 +1,11 @@
 import { t } from "ttag";
 import _ from "underscore";
-
 import { moveElement } from "metabase/core/utils/arrays";
-
-import type { WritebackAction, FieldSettingsMap } from "metabase-types/api";
+import {
+  FieldSettingsMap,
+  InputSettingType,
+  WritebackAction,
+} from "metabase-types/api";
 
 export const getSubmitButtonColor = (action: WritebackAction): string => {
   if (action.type === "implicit" && action.kind === "row/delete") {
@@ -56,4 +58,21 @@ export const reorderFields = (
   );
 
   return _.indexBy(fieldsWithUpdatedOrderProperty, "id");
+};
+
+const inputTypeMap: Record<InputSettingType, string> = {
+  string: "text",
+  text: "textarea",
+  date: "date",
+  datetime: "datetime-local",
+  time: "time",
+  number: "number",
+  boolean: "boolean",
+  category: "text",
+  select: "text",
+  radio: "text",
+};
+
+export const getDefaultValueInputType = (inputType: InputSettingType) => {
+  return inputTypeMap[inputType];
 };


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/29073
Demo https://www.loom.com/share/f44d5b5f12d84fcfb253c7c156f036cd

Changes:
- When field type is changed, converts the default value to the new type, if possible. If not - drops the value. This is the same we do with option values.
- Uses the correct input type for the default value

How to test:
- New -> Action -> `UPDATE  {{param}}`
- Click on the gear icon for for the field. Set some default value.
- Change the field type to another one. Check the conversion logic
- Try to enter a default value for every field type. Make sure the input type is the correct one.

<img width="654" alt="Screenshot 2023-03-10 at 18 54 21" src="https://user-images.githubusercontent.com/8542534/224375801-5836e68c-49f4-4881-ad9a-6c9a699b664b.png">

