### PR TITLE
fix collection selector is out of the screen

### DIFF
--- a/e2e/test/scenarios/collections/collections.cy.spec.js
+++ b/e2e/test/scenarios/collections/collections.cy.spec.js
@@ -1,4 +1,5 @@
 import { assocIn } from "icepick";
+import _ from "underscore";
 import {
   restore,
   modal,
@@ -10,7 +11,6 @@ import {
   closeNavigationSidebar,
   openCollectionMenu,
   visitCollection,
-  getPersonalCollectionName,
 } from "e2e/support/helpers";
 import { USERS, USER_GROUPS } from "e2e/support/cypress_data";
 import { displaySidebarChildOf } from "./helpers/e2e-collections-sidebar.js";
@@ -19,12 +19,49 @@ const { nocollection } = USERS;
 const { DATA_GROUP } = USER_GROUPS;
 
 describe("scenarios > collection defaults", () => {
-  describe("sidebar behavior", () => {
-    beforeEach(() => {
-      restore();
-      cy.signInAsAdmin();
-    });
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+  });
 
+  describe("new collection modal", () => {
+    it("should be usable on small screens", () => {
+      const COLLECTIONS_COUNT = 5;
+      _.times(COLLECTIONS_COUNT, index => {
+        cy.request("POST", "/api/collection", {
+          name: `Collection ${index + 1}`,
+          color: "#509EE3",
+          parent_id: null,
+        });
+      });
+
+      cy.visit("/");
+
+      cy.viewport(800, 400);
+
+      cy.findByText("New").click();
+      cy.findByText("Collection").click();
+
+      modal().within(() => {
+        cy.findByLabelText("Name").type("Test collection");
+        cy.findByLabelText("Description").type("Test collection description");
+        cy.findByText("Our analytics").click();
+      });
+
+      popover().within(() => {
+        cy.findByText(`Collection ${COLLECTIONS_COUNT}`).click();
+      });
+
+      cy.findByText("Create").click();
+
+      cy.findByTestId("collection-name-heading").should(
+        "have.text",
+        "Test collection",
+      );
+    });
+  });
+
+  describe("sidebar behavior", () => {
     it("should navigate effortlessly through collections tree", () => {
       visitRootCollection();
 
@@ -411,7 +448,6 @@ describe("scenarios > collection defaults", () => {
           cy.findByText("Our analytics").click();
           cy.findByText(/item(s)? selected/).should("not.be.visible");
         });
-
       });
 
       describe("archive", () => {

--- a/frontend/src/metabase/collections/containers/FormCollectionPicker/FormCollectionPicker.tsx
+++ b/frontend/src/metabase/collections/containers/FormCollectionPicker/FormCollectionPicker.tsx
@@ -122,6 +122,7 @@ function FormCollectionPicker({
 
   return (
     <TippyPopoverWithTrigger
+      sizeToFit
       placement="bottom-start"
       renderTrigger={renderTrigger}
       popoverContent={renderContent}


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/28012

### Description

Make the parent collection picker popover fit within the screen

### How to verify

- Create a bunch of collections in the root if you don't have them already
- Reduce the browser window height to 500px
- New -> Collection -> open the parent collection picker and ensure you can scroll inside it

### Demo

Before
<img width="811" alt="Screen Shot 2023-03-10 at 12 53 22 PM" src="https://user-images.githubusercontent.com/14301985/224364950-e3ff2067-ab73-4ace-8e90-ed328f25e1bc.png">

After
<img width="810" alt="Screen Shot 2023-03-10 at 12 54 10 PM" src="https://user-images.githubusercontent.com/14301985/224364987-12cc49aa-2655-4e06-a114-e3e738825541.png">

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
