### PR TITLE
Optimize DB calls of dashboard card updates some more

### DIFF
--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -570,11 +570,11 @@
              ...]}"
   [id :as {{:keys [cards]} :body}]
   {cards (su/non-empty [UpdatedDashboardCard])}
-  (api/check-not-archived (api/write-check Dashboard id))
-  (check-updated-parameter-mapping-permissions id cards)
-  (dashboard/update-dashcards! id cards)
-  (events/publish-event! :dashboard-reposition-cards {:id id, :actor_id api/*current-user-id*, :dashcards cards})
-  {:status :ok})
+  (let [dashboard (api/check-not-archived (api/write-check Dashboard id))]
+    (check-updated-parameter-mapping-permissions id cards)
+    (dashboard/update-dashcards! dashboard cards)
+    (events/publish-event! :dashboard-reposition-cards {:id id, :actor_id api/*current-user-id*, :dashcards cards})
+    {:status :ok}))
 
 #_{:clj-kondo/ignore [:deprecated-var]}
 (api/defendpoint-schema DELETE "/:id/cards"

--- a/src/metabase/api/public.clj
+++ b/src/metabase/api/public.clj
@@ -374,12 +374,14 @@
        (when-let [table-id (db/select-one-field :table_id Field :id field-id, :semantic_type (mdb.u/isa :type/PK))]
          (db/exists? Field :id search-field-id, :table_id table-id, :semantic_type (mdb.u/isa :type/Name))))))
 
-
 (defn- check-field-is-referenced-by-dashboard
   "Check that `field-id` belongs to a Field that is used as a parameter in a Dashboard with `dashboard-id`, or throw a
   404 Exception."
   [field-id dashboard-id]
-  (let [param-field-ids (params/dashboard->param-field-ids (api/check-404 (db/select-one Dashboard :id dashboard-id)))]
+  (let [dashboard       (-> (db/select-one Dashboard :id dashboard-id)
+                            api/check-404
+                            (hydrate [:ordered_cards :card]))
+        param-field-ids (params/dashboard->param-field-ids dashboard)]
     (api/check-404 (contains? param-field-ids field-id))))
 
 (defn card-and-field-id->values

--- a/src/metabase/api/public.clj
+++ b/src/metabase/api/public.clj
@@ -381,7 +381,7 @@
   (let [dashboard       (-> (db/select-one Dashboard :id dashboard-id)
                             api/check-404
                             (hydrate [:ordered_cards :card]))
-        param-field-ids (params/dashboard->param-field-ids dashboard)]
+        param-field-ids (params/dashcards->param-field-ids (:ordered_cards dashboard))]
     (api/check-404 (contains? param-field-ids field-id))))
 
 (defn card-and-field-id->values

--- a/src/metabase/models/dashboard.clj
+++ b/src/metabase/models/dashboard.clj
@@ -305,7 +305,7 @@
      (doseq [dashboard-card dashcards]
        (let [old-dashboard-card (-> (get id->old-dashcard (:id dashboard-card))
                                     (update :series #(map :id %)))
-             ;; udpate-dashboard-card! requires series to be a sequence of card IDs
+             ;; update-dashboard-card! requires series to be a sequence of card IDs
              dashboard-card     (update dashboard-card :series #(map :id %))]
          (dashboard-card/update-dashboard-card! dashboard-card old-dashboard-card))))
     (let [new-param-field-ids (params/dashboard->param-field-ids dashboard)

--- a/src/metabase/models/dashboard.clj
+++ b/src/metabase/models/dashboard.clj
@@ -267,7 +267,6 @@
                 "Newly Added:" newly-added-param-field-ids)
       (field-values/update-field-values-for-on-demand-dbs! newly-added-param-field-ids))))
 
-
 (defn add-dashcard!
   "Add a Card to a Dashboard.
    This function is provided for convenience and also makes sure various cleanup steps are performed when finished,

--- a/src/metabase/models/dashboard.clj
+++ b/src/metabase/models/dashboard.clj
@@ -304,14 +304,13 @@
         old-param-field-ids (params/dashboard->param-field-ids dashboard)
         dashcards           (t2/hydrate dashcards :card)
         new-param-field-ids (params/dashcards->param-field-ids dashcards)]
-    (db/transaction
-     (doseq [dashcard dashcards]
-       (let [old-dashcard       (-> (get id->old-dashcard (:id dashcard))
-                                    (update :series #(map :id %)))
+    (doseq [dashcard dashcards]
+      (let [old-dashcard       (-> (get id->old-dashcard (:id dashcard))
+                                   (update :series #(map :id %)))
              ;; update-dashboard-card! requires series to be a sequence of card IDs
-             dashboard-card     (update dashcard :series #(map :id %))]
-         (dashboard-card/update-dashboard-card! dashboard-card old-dashcard)))
-     (update-field-values-for-on-demand-dbs! old-param-field-ids new-param-field-ids))))
+            dashboard-card     (update dashcard :series #(map :id %))]
+        (dashboard-card/update-dashboard-card! dashboard-card old-dashcard)))
+    (update-field-values-for-on-demand-dbs! old-param-field-ids new-param-field-ids)))
 
 ;; TODO - we need to actually make this async, but then we'd need to make `save-card!` async, and so forth
 (defn- result-metadata-for-query

--- a/src/metabase/models/dashboard.clj
+++ b/src/metabase/models/dashboard.clj
@@ -292,6 +292,7 @@
   {:style/indent 1}
   [dashboard dashcards]
   (let [dashboard                  (t2/hydrate dashboard [:ordered_cards :series :card])
+        old-param-field-ids        (params/dashboard->param-field-ids dashboard)
         id->old-dashcard           (m/index-by :id (:ordered_cards dashboard))
         old-dashcard-ids           (set (keys id->old-dashcard))
         new-dashcard-ids           (set (map :id dashcards))
@@ -308,8 +309,8 @@
              ;; update-dashboard-card! requires series to be a sequence of card IDs
              dashboard-card     (update dashboard-card :series #(map :id %))]
          (dashboard-card/update-dashboard-card! dashboard-card old-dashboard-card))))
-    (let [new-param-field-ids (params/dashboard->param-field-ids dashboard)
-          old-param-field-ids (params/dashboard->param-field-ids dashboard)]
+    (let [new-dashboard       (t2/hydrate dashboard [:ordered_cards :series :card])
+          new-param-field-ids (params/dashboard->param-field-ids new-dashboard)]
       (update-field-values-for-on-demand-dbs! old-param-field-ids new-param-field-ids))))
 
 ;; TODO - we need to actually make this async, but then we'd need to make `save-card!` async, and so forth

--- a/src/metabase/models/dashboard.clj
+++ b/src/metabase/models/dashboard.clj
@@ -4,6 +4,7 @@
    [clojure.data :refer [diff]]
    [clojure.set :as set]
    [clojure.string :as str]
+   [medley.core :as m]
    [metabase.automagic-dashboards.populate :as populate]
    [metabase.db.query :as mdb.query]
    [metabase.events :as events]
@@ -195,8 +196,8 @@
                                                                       :dashboard_id dashboard-id
                                                                       :creator_id   user-id))
 
-          ;; If card is in both we need to change :size_x, :size_y, :row, and :col to match serialized-card as needed
-          :else (dashboard-card/update-dashboard-card! serialized-card)))))
+          ;; If card is in both we need to update it to match serialized-card as needed
+          :else (dashboard-card/update-dashboard-card! serialized-card current-card)))))
 
   serialized-dashboard)
 
@@ -253,7 +254,6 @@
   (let [dash (db/select-one Dashboard :id (u/the-id dashboard-or-id))]
     (params/dashboard->param-field-ids (hydrate dash [:ordered_cards :card]))))
 
-
 (defn- update-field-values-for-on-demand-dbs!
   "If the parameters have changed since last time this Dashboard was saved, we need to update the FieldValues
    for any Fields that belong to an 'On-Demand' synced DB."
@@ -285,24 +285,32 @@
         (update-field-values-for-on-demand-dbs! old-param-field-ids new-param-field-ids)))))
 
 (defn update-dashcards!
-  "Update the `dashcards` belonging to `dashboard-or-id`.
+  "Update the `dashcards` belonging to `dashboard`.
    This function is provided as a convenience instead of doing this yourself; it also makes sure various cleanup steps
    are performed when finished, for example updating FieldValues for On-Demand DBs.
    Returns `nil`."
   {:style/indent 1}
-  [dashboard-or-id dashcards]
-  (let [old-param-field-ids (dashboard-id->param-field-ids dashboard-or-id)
-        dashcard-ids        (db/select-ids DashboardCard, :dashboard_id (u/the-id dashboard-or-id))]
-    (doseq [{dashcard-id :id, :as dashboard-card} dashcards]
-      ;; ensure the dashcard we are updating is part of the given dashboard
-      (if (contains? dashcard-ids dashcard-id)
-        (dashboard-card/update-dashboard-card! (update dashboard-card :series #(filter identity (map :id %))))
-        (throw (ex-info (tru "Dashboard {0} does not have a DashboardCard with ID {1}"
-                             (u/the-id dashboard-or-id) dashcard-id)
-                        {:status-code 404}))))
-    (let [new-param-field-ids (dashboard-id->param-field-ids dashboard-or-id)]
+  [dashboard dashcards]
+  (let [dashboard                  (t2/hydrate dashboard [:ordered_cards :series :card])
+        id->old-dashcard           (m/index-by :id (:ordered_cards dashboard))
+        old-dashcard-ids           (set (keys id->old-dashcard))
+        new-dashcard-ids           (set (map :id dashcards))
+        [only-new _only-old _both] (diff new-dashcard-ids old-dashcard-ids)
+        ;; ensure the dashcards we are updating are part of the given dashboard
+        _ (when (seq only-new)
+            (throw (ex-info (tru "Dashboard {0} does not have a DashboardCard with ID {1}"
+                                 (u/the-id dashboard) (first only-new))
+                            {:status-code 404})))]
+    (db/transaction
+     (doseq [dashboard-card dashcards]
+       (let [old-dashboard-card (-> (get id->old-dashcard (:id dashboard-card))
+                                    (update :series #(map :id %)))
+             ;; udpate-dashboard-card! requires series to be a sequence of card IDs
+             dashboard-card     (update dashboard-card :series #(map :id %))]
+         (dashboard-card/update-dashboard-card! dashboard-card old-dashboard-card))))
+    (let [new-param-field-ids (params/dashboard->param-field-ids dashboard)
+          old-param-field-ids (params/dashboard->param-field-ids dashboard)]
       (update-field-values-for-on-demand-dbs! old-param-field-ids new-param-field-ids))))
-
 
 ;; TODO - we need to actually make this async, but then we'd need to make `save-card!` async, and so forth
 (defn- result-metadata-for-query

--- a/src/metabase/models/dashboard.clj
+++ b/src/metabase/models/dashboard.clj
@@ -305,9 +305,9 @@
         dashcards           (t2/hydrate dashcards :card)
         new-param-field-ids (params/dashcards->param-field-ids dashcards)]
     (doseq [dashcard dashcards]
-      (let [old-dashcard       (-> (get id->old-dashcard (:id dashcard))
+      (let [;; update-dashboard-card! requires series to be a sequence of card IDs
+            old-dashcard       (-> (get id->old-dashcard (:id dashcard))
                                    (update :series #(map :id %)))
-             ;; update-dashboard-card! requires series to be a sequence of card IDs
             dashboard-card     (update dashcard :series #(map :id %))]
         (dashboard-card/update-dashboard-card! dashboard-card old-dashcard)))
     (update-field-values-for-on-demand-dbs! old-param-field-ids new-param-field-ids)))

--- a/src/metabase/models/dashboard.clj
+++ b/src/metabase/models/dashboard.clj
@@ -300,18 +300,18 @@
         _ (when (seq only-new)
             (throw (ex-info (tru "Dashboard {0} does not have a DashboardCard with ID {1}"
                                  (u/the-id dashboard) (first only-new))
-                            {:status-code 404})))]
+                            {:status-code 404})))
+        old-param-field-ids (params/dashboard->param-field-ids dashboard)
+        dashcards           (t2/hydrate dashcards :card)
+        new-param-field-ids (params/dashcards->param-field-ids dashcards)]
     (db/transaction
      (doseq [dashcard dashcards]
        (let [old-dashcard       (-> (get id->old-dashcard (:id dashcard))
                                     (update :series #(map :id %)))
              ;; update-dashboard-card! requires series to be a sequence of card IDs
              dashboard-card     (update dashcard :series #(map :id %))]
-         (dashboard-card/update-dashboard-card! dashboard-card old-dashcard))))
-    (let [old-param-field-ids (params/dashboard->param-field-ids dashboard)
-          dashcards           (t2/hydrate dashcards :card)
-          new-param-field-ids (params/dashcards->param-field-ids dashcards)]
-      (update-field-values-for-on-demand-dbs! old-param-field-ids new-param-field-ids))))
+         (dashboard-card/update-dashboard-card! dashboard-card old-dashcard)))
+     (update-field-values-for-on-demand-dbs! old-param-field-ids new-param-field-ids))))
 
 ;; TODO - we need to actually make this async, but then we'd need to make `save-card!` async, and so forth
 (defn- result-metadata-for-query

--- a/src/metabase/models/dashboard_card.clj
+++ b/src/metabase/models/dashboard_card.clj
@@ -155,19 +155,20 @@
    Returns true if a row was updated, false otherwise."
   [{:keys [id action_id] :as dashboard-card} :- DashboardCardUpdates
    old-dashboard-card                        :- DashboardCardUpdates]
-  (let [update-ks (cond-> [:action_id :row :col :size_x :size_y
-                           :parameter_mappings :visualization_settings]
+  (db/transaction
+   (let [update-ks (cond-> [:action_id :row :col :size_x :size_y
+                            :parameter_mappings :visualization_settings]
                     ;; Allow changing card_id for action dashcards, but not for card dashcards.
                     ;; This is to preserve the existing behavior of questions and card_id
                     ;; I don't know why card_id couldn't be changed for cards though.
-                    action_id (conj :card_id))
-        updates (shallow-updates (select-keys dashboard-card update-ks) (select-keys old-dashboard-card update-ks))]
-    (when (seq updates)
-      (db/update! DashboardCard id updates))
-    (when (not= (:series dashboard-card [])
-                (:series old-dashboard-card []))
-      (update-dashboard-card-series! dashboard-card (:series dashboard-card)))
-    nil))
+                     action_id (conj :card_id))
+         updates (shallow-updates (select-keys dashboard-card update-ks) (select-keys old-dashboard-card update-ks))]
+     (when (seq updates)
+       (db/update! DashboardCard id updates))
+     (when (not= (:series dashboard-card [])
+                 (:series old-dashboard-card []))
+       (update-dashboard-card-series! dashboard-card (:series dashboard-card)))
+     nil)))
 
 (def ParamMapping
   "Schema for a parameter mapping as it would appear in the DashboardCard `:parameter_mappings` column."

--- a/src/metabase/models/dashboard_card.clj
+++ b/src/metabase/models/dashboard_card.clj
@@ -159,7 +159,8 @@
       (db/transaction (db/update! DashboardCard id updates)))
     (when (not= (:series dashboard-card [])
                 (:series old-dashboard-card []))
-      (update-dashboard-card-series! dashboard-card (:series dashboard-card)))))
+      (update-dashboard-card-series! dashboard-card (:series dashboard-card)))
+    nil))
 
 (def ParamMapping
   "Schema for a parameter mapping as it would appear in the DashboardCard `:parameter_mappings` column."

--- a/src/metabase/models/dashboard_card.clj
+++ b/src/metabase/models/dashboard_card.clj
@@ -152,7 +152,7 @@
 (s/defn update-dashboard-card!
   "Updates an existing DashboardCard including all DashboardCardSeries.
    `old-dashboard-card` is provided to avoid an extra DB call if there are no changes.
-   Returns true if a row was updated, false otherwise."
+   Returns nil."
   [{:keys [id action_id] :as dashboard-card} :- DashboardCardUpdates
    old-dashboard-card                        :- DashboardCardUpdates]
   (db/transaction

--- a/src/metabase/models/dashboard_card.clj
+++ b/src/metabase/models/dashboard_card.clj
@@ -151,7 +151,7 @@
 
 (s/defn update-dashboard-card!
   "Updates an existing DashboardCard including all DashboardCardSeries.
-   `old-dashboard-card` can be provided to avoid an extra DB call.
+   `old-dashboard-card` is provided to avoid an extra DB call if there are no changes.
    Returns true if a row was updated, false otherwise."
   [{:keys [id action_id] :as dashboard-card} :- DashboardCardUpdates
    old-dashboard-card                        :- DashboardCardUpdates]
@@ -163,7 +163,7 @@
                     action_id (conj :card_id))
         updates (shallow-updates (select-keys dashboard-card update-ks) (select-keys old-dashboard-card update-ks))]
     (when (seq updates)
-      (db/transaction (db/update! DashboardCard id updates)))
+      (db/update! DashboardCard id updates))
     (when (not= (:series dashboard-card [])
                 (:series old-dashboard-card []))
       (update-dashboard-card-series! dashboard-card (:series dashboard-card)))

--- a/src/metabase/models/dashboard_card.clj
+++ b/src/metabase/models/dashboard_card.clj
@@ -1,5 +1,6 @@
 (ns metabase.models.dashboard-card
   (:require
+   [clojure.data :as data]
    [clojure.set :as set]
    [medley.core :as m]
    [metabase.db :as mdb]
@@ -142,32 +143,23 @@
    s/Keyword                                s/Any})
 
 (s/defn update-dashboard-card!
-  "Update an existing DashboardCard including all DashboardCardSeries.
-   Returns true or throws an Exception."
-  [{:keys [id card_id action_id parameter_mappings visualization_settings] :as dashboard-card} :- DashboardCardUpdates]
-  (let [{:keys [size_x size_y row col series]} (merge {:series []} dashboard-card)]
-    (db/transaction
-     ;; update the dashcard itself (positional attributes)
-     (when (and size_x size_y row col)
-       (db/update-non-nil-keys! DashboardCard id
-                                (cond->
-                                  {:action_id              action_id
-                                   :size_x                 size_x
-                                   :size_y                 size_y
-                                   :row                    row
-                                   :col                    col
-                                   :parameter_mappings     parameter_mappings
-                                   :visualization_settings visualization_settings}
-                                  ;; Allow changing card for actions
-                                  ;; This is to preserve the existing behavior of questions and card_id
-                                  ;; I don't know why card_id couldn't be changed for questions though.
-                                  action_id (assoc :card_id card_id))))
-     ;; update series (only if they changed)
-     (when-not (= series (map :card_id (db/select [DashboardCardSeries :card_id]
-                                                  :dashboardcard_id id
-                                                  {:order-by [[:position :asc]]})))
-       (update-dashboard-card-series! dashboard-card series)))
-    nil))
+  "Updates an existing DashboardCard including all DashboardCardSeries.
+   `old-dashboard-card` can be provided to avoid an extra DB call.
+   Returns true if a row was updated, false otherwise."
+  [{:keys [id action_id] :as dashboard-card} :- DashboardCardUpdates
+   old-dashboard-card                        :- DashboardCardUpdates]
+  (let [update-ks (cond-> [:action_id :row :col :size_x :size_y
+                           :parameter_mappings :visualization_settings]
+                    ;; Allow changing card_id for action dashcards, but not for card dashcards.
+                    ;; This is to preserve the existing behavior of questions and card_id
+                    ;; I don't know why card_id couldn't be changed for cards though.
+                    action_id (conj :card_id))
+        [updates _ _] (data/diff (select-keys dashboard-card update-ks) (select-keys old-dashboard-card update-ks))]
+    (when (seq updates)
+      (db/transaction (db/update! DashboardCard id updates)))
+    (when (not= (:series dashboard-card [])
+                (:series old-dashboard-card []))
+      (update-dashboard-card-series! dashboard-card (:series dashboard-card)))))
 
 (def ParamMapping
   "Schema for a parameter mapping as it would appear in the DashboardCard `:parameter_mappings` column."

--- a/src/metabase/models/dashboard_card.clj
+++ b/src/metabase/models/dashboard_card.clj
@@ -142,8 +142,9 @@
    (s/optional-key :series)                 (s/maybe [su/IntGreaterThanZero])
    s/Keyword                                s/Any})
 
-(defn- shallow-updates [new old]
+(defn- shallow-updates
   "Returns the keys in `new` that have different values than the corresponding keys in `old`"
+  [new old]
   (into {}
         (filter (fn [[k v]]
                   (not= v (get old k)))

--- a/src/metabase/models/dashboard_card.clj
+++ b/src/metabase/models/dashboard_card.clj
@@ -1,6 +1,5 @@
 (ns metabase.models.dashboard-card
   (:require
-   [clojure.data :as data]
    [clojure.set :as set]
    [medley.core :as m]
    [metabase.db :as mdb]

--- a/src/metabase/models/params.clj
+++ b/src/metabase/models/params.clj
@@ -200,17 +200,17 @@
 
 (s/defn dashboard->param-field-ids :- #{su/IntGreaterThanZero}
   "Return a set of Field IDs referenced by parameters in Cards in this `dashboard`, or `nil` if none are referenced. This
-  also includes IDs of Fields that are to be found in the 'implicit' parameters for SQL template tag Field filters."
-  [dashboard]
-  (let [dashboard (hydrate dashboard [:ordered_cards :card])]
-    (set/union
-     (set (mbql.u/match (seq (dashboard->parameter-mapping-field-clauses dashboard))
-            [:field (id :guard integer?) _]
-            id))
-     (dashboard->card-param-field-ids dashboard))))
+  also includes IDs of Fields that are to be found in the 'implicit' parameters for SQL template tag Field filters.
+  It requires `dashboard-hydrated-with-cards` is a Dashboard hydrated with `[:ordered_cards :card]`."
+  [dashboard-hydrated-with-cards]
+  (set/union
+   (set (mbql.u/match (seq (dashboard->parameter-mapping-field-clauses dashboard-hydrated-with-cards))
+          [:field (id :guard integer?) _]
+          id))
+   (dashboard->card-param-field-ids dashboard-hydrated-with-cards)))
 
 (defmethod param-fields :metabase.models.dashboard/Dashboard [dashboard]
-  (-> dashboard dashboard->param-field-ids param-field-ids->fields))
+  (-> dashboard (hydrate [:ordered_cards :card]) dashboard->param-field-ids param-field-ids->fields))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                                 CARD-SPECIFIC                                                  |

--- a/src/metabase/models/params.clj
+++ b/src/metabase/models/params.clj
@@ -206,15 +206,8 @@
           id))
    (cards->card-param-field-ids (map :card dashcards))))
 
-(s/defn dashboard->param-field-ids :- #{su/IntGreaterThanZero}
-  "Return a set of Field IDs referenced by parameters in Cards in this `dashboard`, or `nil` if none are referenced. This
-  also includes IDs of Fields that are to be found in the 'implicit' parameters for SQL template tag Field filters.
-  `dashboard-hydrated-with-cards` must be a Dashboard hydrated with `[:ordered_cards :card]`."
-  [dashboard-hydrated-with-cards]
-  (dashcards->param-field-ids (:ordered_cards dashboard-hydrated-with-cards)))
-
 (defmethod param-fields :metabase.models.dashboard/Dashboard [dashboard]
-  (-> dashboard (hydrate [:ordered_cards :card]) dashboard->param-field-ids param-field-ids->fields))
+  (-> dashboard (hydrate [:ordered_cards :card]) :ordered_cards dashcards->param-field-ids param-field-ids->fields))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                                 CARD-SPECIFIC                                                  |

--- a/src/metabase/models/params.clj
+++ b/src/metabase/models/params.clj
@@ -191,7 +191,7 @@
 
 (defn- cards->card-param-field-ids
   "Return the IDs of any Fields referenced in the 'implicit' template tag field filter parameters for native queries in
-  the Cards in `cards`."
+  `cards`."
   [cards]
   (reduce set/union (map card->template-tag-field-ids cards)))
 
@@ -207,7 +207,10 @@
    (cards->card-param-field-ids (map :card dashcards))))
 
 (defmethod param-fields :metabase.models.dashboard/Dashboard [dashboard]
-  (-> dashboard (hydrate [:ordered_cards :card]) :ordered_cards dashcards->param-field-ids param-field-ids->fields))
+  (-> (hydrate dashboard [:ordered_cards :card])
+      :ordered_cards
+      dashcards->param-field-ids
+      param-field-ids->fields))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                                 CARD-SPECIFIC                                                  |

--- a/src/metabase/models/params.clj
+++ b/src/metabase/models/params.clj
@@ -193,7 +193,7 @@
   "Return the IDs of any Fields referenced in the 'implicit' template tag field filter parameters for native queries in
   the Cards in `cards`."
   [cards]
-  (set (mapcat card->template-tag-field-ids cards)))
+  (reduce set/union (map card->template-tag-field-ids cards)))
 
 (s/defn dashcards->param-field-ids :- #{su/IntGreaterThanZero}
   "Return a set of Field IDs referenced by parameters in Cards in the given `dashcards`, or `nil` if none are referenced. This

--- a/test/metabase/models/dashboard_card_test.clj
+++ b/test/metabase/models/dashboard_card_test.clj
@@ -209,38 +209,39 @@
             PUT /api/dashboard/:id/cards handler"
     (mt/with-temp* [Dashboard     [{dashboard-id :id :as dashboard}]
                     Card          [{card-id :id}]
-                    DashboardCard [{dashcard-id-1 :id} {:row 1
-                                                        :col 2
-                                                        :size_x 3
-                                                        :size_y 4
-                                                        :dashboard_id dashboard-id, :card_id card-id}]
-                    DashboardCard [{dashcard-id-2 :id} {:dashboard_id dashboard-id, :card_id card-id}]
-                    DashboardCard [{dashcard-id-3 :id} {:dashboard_id dashboard-id, :card_id card-id}]
+                    DashboardCard [dashcard-1 {:dashboard_id dashboard-id, :card_id card-id}]
+                    DashboardCard [dashcard-2 {:dashboard_id dashboard-id, :card_id card-id}]
+                    DashboardCard [dashcard-3 {:dashboard_id dashboard-id, :card_id card-id}]
                     Card          [{series-id-1 :id} {:name "Series Card 1"}]
                     Card          [{series-id-2 :id} {:name "Series Card 2"}]]
-      (db/with-call-counting [call-count]
-        (dashboard/update-dashcards! dashboard [{:id     dashcard-id-1
-                                                 :cardId card-id
-                                                 :row    1
-                                                 :col    2
-                                                 :size_x 3
-                                                 :size_y 4
-                                                 :series [{:id series-id-1}]}
-                                                {:id     dashcard-id-2
-                                                 :cardId card-id
-                                                 :row    1
-                                                 :col    2
-                                                 :size_x 3
-                                                 :size_y 4
-                                                 :series [{:id series-id-2}]}
-                                                {:id     dashcard-id-3
-                                                 :cardId card-id
-                                                 :row    1
-                                                 :col    2
-                                                 :size_x 3
-                                                 :size_y 4
-                                                 :series []}])
-        (is (= 13 (call-count)))))))
+      (testing "Should have fewer DB calls if there's no changes to the dashcards"
+       (db/with-call-counting [call-count]
+         (dashboard/update-dashcards! dashboard [dashcard-1 dashcard-2 dashcard-3])
+         (is (= 6 (call-count)))))
+      (testing "Should have fewer calls if there's changes to the dashcards"
+       (db/with-call-counting [call-count]
+         (dashboard/update-dashcards! dashboard [{:id     (:id dashcard-1)
+                                                  :cardId card-id
+                                                  :row    1
+                                                  :col    2
+                                                  :size_x 3
+                                                  :size_y 4
+                                                  :series [{:id series-id-1}]}
+                                                 {:id     (:id dashcard-2)
+                                                  :cardId card-id
+                                                  :row    1
+                                                  :col    2
+                                                  :size_x 3
+                                                  :size_y 4
+                                                  :series [{:id series-id-2}]}
+                                                 {:id     (:id dashcard-3)
+                                                  :cardId card-id
+                                                  :row    1
+                                                  :col    2
+                                                  :size_x 3
+                                                  :size_y 4
+                                                  :series []}])
+         (is (= 15 (call-count))))))))
 
 (deftest normalize-parameter-mappings-test
   (testing "DashboardCard parameter mappings should get normalized when coming out of the DB"

--- a/test/metabase/models/dashboard_card_test.clj
+++ b/test/metabase/models/dashboard_card_test.clj
@@ -171,8 +171,8 @@
                 :visualization_settings {}
                 :series                 []}
                (remove-ids-and-timestamps (dashboard-card/retrieve-dashboard-card dashcard-id)))))
-      (testing "return value from the update call should be true"
-        (is (true? (dashboard-card/update-dashboard-card!
+      (testing "return value from the update call should be nil"
+        (is (nil? (dashboard-card/update-dashboard-card!
                     {:id                     dashcard-id
                      :actor_id               (mt/user->id :rasta)
                      :dashboard_id           nil

--- a/test/metabase/models/dashboard_card_test.clj
+++ b/test/metabase/models/dashboard_card_test.clj
@@ -157,9 +157,10 @@
                 "ensure the card_id cannot be changed 4. ensure the dashboard_id cannot be changed")
     (mt/with-temp* [Dashboard     [{dashboard-id :id}]
                     Card          [{card-id :id}]
-                    DashboardCard [{dashcard-id :id} {:dashboard_id       dashboard-id
-                                                      :card_id            card-id
-                                                      :parameter_mappings [{:foo "bar"}]}]
+                    DashboardCard [{dashcard-id :id
+                                    :as dashboard-card} {:dashboard_id       dashboard-id
+                                                         :card_id            card-id
+                                                         :parameter_mappings [{:foo "bar"}]}]
                     Card          [{card-id-1 :id}   {:name "Test Card 1"}]
                     Card          [{card-id-2 :id}   {:name "Test Card 2"}]]
       (testing "unmodified dashcard"
@@ -183,7 +184,8 @@
                      :col                    1
                      :parameter_mappings     [{:foo "barbar"}]
                      :visualization_settings {}
-                     :series                 [card-id-2 card-id-1]}))))
+                     :series                 [card-id-2 card-id-1]}
+                    dashboard-card))))
       (testing "validate db captured everything"
         (is (= {:size_x                 5
                 :size_y                 3
@@ -217,7 +219,7 @@
                     DashboardCard [{dashcard-id-3 :id} {:dashboard_id dashboard-id, :card_id card-id}]
                     Card          [{series-id-1 :id} {:name "Series Card 1"}]
                     Card          [{series-id-2 :id} {:name "Series Card 2"}]]
-      (toucan2.execute/with-call-count [call-count]
+      (db/with-call-counting [call-count]
         (dashboard/update-dashcards! dashboard [{:id     dashcard-id-1
                                                  :cardId card-id
                                                  :row    1

--- a/test/metabase/models/dashboard_card_test.clj
+++ b/test/metabase/models/dashboard_card_test.clj
@@ -218,7 +218,7 @@
        (db/with-call-counting [call-count]
          (dashboard/update-dashcards! dashboard [dashcard-1 dashcard-2 dashcard-3])
          (is (= 6 (call-count)))))
-      (testing "Should have fewer calls if there's changes to the dashcards"
+      (testing "Should have more calls if there's changes to the dashcards"
        (db/with-call-counting [call-count]
          (dashboard/update-dashcards! dashboard [{:id     (:id dashcard-1)
                                                   :cardId card-id

--- a/test/metabase/models/dashboard_card_test.clj
+++ b/test/metabase/models/dashboard_card_test.clj
@@ -5,8 +5,7 @@
    [metabase.models.card :refer [Card]]
    [metabase.models.card-test :as card-test]
    [metabase.models.collection :refer [Collection]]
-   [metabase.models.dashboard :refer [Dashboard]]
-   [metabase.models.dashboard :as dashboard]
+   [metabase.models.dashboard :refer [Dashboard] :as dashboard]
    [metabase.models.dashboard-card
     :as dashboard-card
     :refer [DashboardCard]]


### PR DESCRIPTION
This PR makes progress towards solving [Dashboard update makes too many app DB calls](https://github.com/metabase/metabase/issues/28956#top)

It builds on Ngoc's work with [Don't update dashcard if it doesn't change](https://github.com/metabase/metabase/pull/29119#top) and includes a few more shortcuts to skip DB calls when they're duplicated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/29132)
<!-- Reviewable:end -->
