### PR TITLE
Remove 'category' as a field type for action forms

### DIFF
--- a/docs/actions/custom.md
+++ b/docs/actions/custom.md
@@ -155,11 +155,6 @@ You can include placeholder text for all fields in the action form.
 - Date
 - Date + Time
 
-**Category**
-
-- Dropdown
-- Inline select
-
 For both **Dropdown** and **Inline select**, you can specify a list of options to present on the form, with each option on its own line.
 
 ![Dropdown select](./images/dropdown.png)

--- a/frontend/src/metabase-types/api/actions.ts
+++ b/frontend/src/metabase-types/api/actions.ts
@@ -96,7 +96,7 @@ export type OnSubmitActionForm = (
 // Action Forms
 
 export type ActionDisplayType = "form" | "button";
-export type FieldType = "string" | "number" | "date" | "category";
+export type FieldType = "string" | "number" | "date";
 
 export type DateInputType = "date" | "time" | "datetime";
 
@@ -108,8 +108,7 @@ export type InputSettingType =
   | "number"
   | "select"
   | "radio"
-  | "boolean"
-  | "category";
+  | "boolean";
 
 // these types get passed to the input components
 export type InputComponentType =
@@ -121,8 +120,7 @@ export type InputComponentType =
   | "radio"
   | "date"
   | "time"
-  | "datetime-local"
-  | "category";
+  | "datetime-local";
 
 export type Size = "small" | "medium" | "large";
 

--- a/frontend/src/metabase/actions/components/ActionForm/ActionForm.unit.spec.tsx
+++ b/frontend/src/metabase/actions/components/ActionForm/ActionForm.unit.spec.tsx
@@ -591,7 +591,7 @@ describe("Actions > ActionForm", () => {
           type: "form",
           fields: {
             "abc-123": makeFieldSettings({
-              inputType: "category",
+              inputType: "string",
               id: "abc-123",
               title: "input",
               required: false,
@@ -718,7 +718,7 @@ describe("Actions > ActionForm", () => {
       });
     });
 
-    it("can change a date field to a select field", async () => {
+    it("can change a date field to a number field", async () => {
       const formSettings: ActionFormSettings = {
         type: "form",
         fields: {
@@ -731,16 +731,15 @@ describe("Actions > ActionForm", () => {
       });
 
       userEvent.click(await screen.findByLabelText("Field settings"));
-      userEvent.click(await screen.findByText("Category"));
+      userEvent.click(await screen.findByText("Number"));
 
       await waitFor(() => {
         expect(setFormSettings).toHaveBeenCalledWith({
           ...formSettings,
           fields: {
             "abc-123": makeFieldSettings({
-              fieldType: "category",
-              inputType: "select",
-              valueOptions: [],
+              fieldType: "number",
+              inputType: "number",
             }),
           },
         });

--- a/frontend/src/metabase/actions/components/ActionForm/ActionFormFieldWidget.tsx
+++ b/frontend/src/metabase/actions/components/ActionForm/ActionFormFieldWidget.tsx
@@ -8,7 +8,6 @@ import FormRadioWidget, {
 import FormSelectWidget from "metabase/core/components/FormSelect";
 import FormNumericInputWidget from "metabase/core/components/FormNumericInput";
 import FormBooleanWidget from "metabase/core/components/FormToggle";
-import CategoryFieldPicker from "metabase/components/FormCategoryInput";
 
 import type { InputComponentType } from "metabase-types/api";
 import type { ActionFormFieldProps } from "metabase/actions/types";
@@ -27,7 +26,6 @@ const WIDGETS: Record<InputComponentType, React.FunctionComponent<any>> = {
   boolean: FormBooleanWidget,
   radio: VerticalRadio,
   select: FormSelectWidget,
-  category: CategoryFieldPicker,
 };
 
 interface FormWidgetProps {

--- a/frontend/src/metabase/actions/components/ActionForm/FormFieldEditor.tsx
+++ b/frontend/src/metabase/actions/components/ActionForm/FormFieldEditor.tsx
@@ -44,7 +44,7 @@ function cleanFieldValue(
 ) {
   if (value == null) {
     return value;
-  } else if (fieldType === "string" || fieldType === "category") {
+  } else if (fieldType === "string") {
     return String(value);
   } else if (fieldType === "number") {
     const number = Number(value);
@@ -76,7 +76,7 @@ function FormFieldEditor({
       option => option.value,
     );
 
-    // Allows to preserve dropdown/radio input types across number/string/category field types
+    // Allows to preserve dropdown/radio input types across number/string field types
     const nextInputType = inputTypesForNextFieldType.includes(inputType)
       ? inputType
       : inputTypesForNextFieldType[0];

--- a/frontend/src/metabase/actions/components/ActionForm/FormFieldEditor.unit.spec.tsx
+++ b/frontend/src/metabase/actions/components/ActionForm/FormFieldEditor.unit.spec.tsx
@@ -132,14 +132,6 @@ describe("FormFieldEditor", () => {
     it("handles value options when switching between field types", async () => {
       const { onChange } = setup({ fieldSettings: TEST_STRING_FIELD_SETTINGS });
 
-      userEvent.click(screen.getByText("Category"));
-      await waitFor(() =>
-        expect(onChange).toHaveBeenLastCalledWith({
-          ...TEST_STRING_FIELD_SETTINGS,
-          fieldType: "category",
-        }),
-      );
-
       userEvent.click(screen.getByText("Number"));
       await waitFor(() =>
         expect(onChange).toHaveBeenLastCalledWith({

--- a/frontend/src/metabase/actions/components/ActionForm/utils.ts
+++ b/frontend/src/metabase/actions/components/ActionForm/utils.ts
@@ -38,7 +38,6 @@ const fieldPropsTypeMap: FieldPropTypeMap = {
   time: "time",
   number: "number",
   boolean: "boolean",
-  category: "category",
   select: "select",
   radio: "radio",
 };

--- a/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/constants.ts
+++ b/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/constants.ts
@@ -19,10 +19,6 @@ export const getFieldTypes = (): FieldOptionType[] => [
     value: "date",
     name: t`Date`,
   },
-  {
-    value: "category",
-    name: t`Category`,
-  },
 ];
 
 interface InputOptionType {
@@ -81,5 +77,4 @@ export const getInputTypes = (): InputOptionsMap => ({
     //   name: t`quarter + year`,
     // },
   ],
-  category: [...getSelectInputs()],
 });

--- a/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/utils.ts
+++ b/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/utils.ts
@@ -68,7 +68,6 @@ const inputTypeMap: Record<InputSettingType, string> = {
   time: "time",
   number: "number",
   boolean: "boolean",
-  category: "text",
   select: "text",
   radio: "text",
 };

--- a/frontend/src/metabase/actions/containers/ActionCreator/utils.ts
+++ b/frontend/src/metabase/actions/containers/ActionCreator/utils.ts
@@ -27,7 +27,6 @@ type TagTypeMap = Record<string, TemplateTagType>;
 
 const fieldTypeToParameterTypeMap: FieldTypeMap = {
   string: "string/=",
-  category: "string/=",
   number: "number/=",
 };
 
@@ -40,7 +39,6 @@ const dateTypeToParameterTypeMap: FieldTypeMap = {
 
 const fieldTypeToTagTypeMap: TagTypeMap = {
   string: "text",
-  category: "text",
   number: "number",
   date: "date",
 };

--- a/frontend/src/metabase/actions/utils.ts
+++ b/frontend/src/metabase/actions/utils.ts
@@ -209,7 +209,7 @@ export const getInputType = (param: Parameter, field?: Field) => {
     return "string";
   }
   if (field.isCategory() && field.semantic_type !== TYPE.Name) {
-    return "category";
+    return "string";
   }
   return "string";
 };

--- a/frontend/src/metabase/actions/utils.unit.spec.ts
+++ b/frontend/src/metabase/actions/utils.unit.spec.ts
@@ -121,7 +121,7 @@ describe("sortActionParams", () => {
       );
 
       expect(settings.fieldType).toBe("string");
-      expect(settings.inputType).toBe("category");
+      expect(settings.inputType).toBe("string");
     });
 
     it("should generate settings for a dateTime field", () => {
@@ -389,11 +389,11 @@ describe("sortActionParams", () => {
       });
     });
 
-    it('should return "category" for categories', () => {
+    it('should return "string" for categories', () => {
       const field = createField({
         semantic_type: "type/Category",
       });
-      expect(getInputType(createParameter(), field)).toEqual("category");
+      expect(getInputType(createParameter(), field)).toEqual("string");
     });
 
     it('should return "text" for description', () => {

--- a/frontend/src/metabase/entities/actions/constants.ts
+++ b/frontend/src/metabase/entities/actions/constants.ts
@@ -11,7 +11,6 @@ interface TagTypeMap {
 
 export const fieldTypeToParameterTypeMap: FieldTypeMap = {
   string: "string/=",
-  category: "string/=",
   number: "number/=",
 };
 
@@ -24,7 +23,6 @@ export const dateTypeToParameterTypeMap: FieldTypeMap = {
 
 export const fieldTypeToTagTypeMap: TagTypeMap = {
   string: "text",
-  category: "text",
   number: "number",
   date: "date",
 };


### PR DESCRIPTION

### Description

String, text, and date are field types, category is an input type - or two input types actually. This is confusing, so this removes the "Category" data type.

![Screen Shot 2023-03-10 at 9 39 09 AM](https://user-images.githubusercontent.com/30528226/224374681-e33f1bf1-0185-4b59-b423-69d6e4ccdbf3.png)

### How to verify

- Make a new action!
- Don't see "category" anywhere
- making dropdowns + radios for text or number columns should still work

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
