### PR TITLE
Run JS linter when e2e test files are touched

### DIFF
--- a/e2e/.eslintrc
+++ b/e2e/.eslintrc
@@ -1,8 +1,7 @@
 {
   "rules": {
     "import/no-commonjs": 0,
-    "no-color-literals": 0,
-    "no-only-tests/no-only-tests": "error"
+    "no-color-literals": 0
   },
   "env": {
     "cypress/globals": true,

--- a/e2e/test/scenarios/models/create.cy.spec.js
+++ b/e2e/test/scenarios/models/create.cy.spec.js
@@ -9,7 +9,7 @@ describe("scenarios > models > create", () => {
     cy.intercept("POST", "/api/dataset").as("dataset");
   });
 
-  it.only("creates a native query model via the New button", () => {
+  it("creates a native query model via the New button", () => {
     cy.visit("/");
 
     goFromHomePageToNewNativeQueryModelPage();

--- a/e2e/test/scenarios/models/create.cy.spec.js
+++ b/e2e/test/scenarios/models/create.cy.spec.js
@@ -9,7 +9,7 @@ describe("scenarios > models > create", () => {
     cy.intercept("POST", "/api/dataset").as("dataset");
   });
 
-  it("creates a native query model via the New button", () => {
+  it.only("creates a native query model via the New button", () => {
     cy.visit("/");
 
     goFromHomePageToNewNativeQueryModelPage();

--- a/package.json
+++ b/package.json
@@ -348,6 +348,7 @@
       "node ./bin/verify-doc-links"
     ],
     "e2e/test/scenarios/*/{*.js,!(helpers|shared)/*.js}": [
+      "eslint --rulesdir frontend/lint/eslint-rules --max-warnings 0",
       "node e2e/validate-e2e-test-files.js"
     ]
   },

--- a/package.json
+++ b/package.json
@@ -281,7 +281,7 @@
     "type-check": "rm -rf frontend/src/{cljs,cljs_release} && yarn build-quick:cljs && tsc --noEmit",
     "remove-webpack-cache": "rm -rf ./node_modules/.cache",
     "lint": "yarn lint-eslint && yarn lint-prettier && yarn lint-docs-links && yarn lint-yaml && yarn type-check",
-    "lint-eslint": "yarn build-quick:cljs && eslint --ext .js,.jsx,.ts,.tsx --rulesdir frontend/lint/eslint-rules --max-warnings 0 enterprise/frontend/src frontend/src frontend/test",
+    "lint-eslint": "yarn build-quick:cljs && eslint --ext .js,.jsx,.ts,.tsx --rulesdir frontend/lint/eslint-rules --max-warnings 0 enterprise/frontend/src frontend/src frontend/test e2e/test",
     "lint-prettier": "yarn && prettier -l '{enterprise/,}frontend/**/*.{js,jsx,ts,tsx,css}' || (echo '\nThese files are not formatted correctly. Did you forget to \"yarn prettier\"?' && false)",
     "lint-docs-links": "yarn && ./bin/verify-doc-links",
     "lint-yaml": "yamllint **/*.{yaml,yml} --ignore=node_modules/**/*.{yaml,yml}",


### PR DESCRIPTION
A recent [tweak I did](https://github.com/metabase/metabase/pull/28999) around this works in my editor, but was incomplete.

This adds the new e2e/test directory to the pre-commit flow and to the linter running in CI.

### How to Verify

🎗️  Please use a subbranch.

1. Add a `.only` to any e2e test.
2. Try to commit — husky should prevent you through the linter
3. Commit without verifying, with `git commit -m "Your message" --no-verify`
4. Push — linter should catch it in CI


