### PR TITLE
lint e2e specs on CI

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -19,6 +19,7 @@ jobs:
     timeout-minutes: 3
     outputs:
       frontend_all: ${{ steps.changes.outputs.frontend_all }}
+      e2e_specs: ${{ steps.changes.outputs.e2e_specs }}
     steps:
       - uses: actions/checkout@v3
       - name: Test which files changed
@@ -30,7 +31,7 @@ jobs:
 
   fe-linter-prettier:
     needs: files-changed
-    if: needs.files-changed.outputs.frontend_all == 'true'
+    if: needs.files-changed.outputs.frontend_all == 'true' || needs.files-changed.outputs.e2e_specs == 'true'
     runs-on: ubuntu-22.04
     timeout-minutes: 10
     steps:
@@ -42,7 +43,7 @@ jobs:
 
   fe-linter-eslint:
     needs: files-changed
-    if: needs.files-changed.outputs.frontend_all == 'true'
+    if: needs.files-changed.outputs.frontend_all == 'true' || needs.files-changed.outputs.e2e_specs == 'true'
     runs-on: ubuntu-22.04
     timeout-minutes: 20
     steps:

--- a/e2e/.eslintrc
+++ b/e2e/.eslintrc
@@ -1,8 +1,7 @@
 {
   "rules": {
     "import/no-commonjs": 0,
-    "no-color-literals": 0,
-    "no-only-tests/no-only-tests": "error"
+    "no-color-literals": 0
   },
   "env": {
     "cypress/globals": true,

--- a/package.json
+++ b/package.json
@@ -281,7 +281,7 @@
     "type-check": "rm -rf frontend/src/{cljs,cljs_release} && yarn build-quick:cljs && tsc --noEmit",
     "remove-webpack-cache": "rm -rf ./node_modules/.cache",
     "lint": "yarn lint-eslint && yarn lint-prettier && yarn lint-docs-links && yarn lint-yaml && yarn type-check",
-    "lint-eslint": "yarn build-quick:cljs && eslint --ext .js,.jsx,.ts,.tsx --rulesdir frontend/lint/eslint-rules --max-warnings 0 enterprise/frontend/src frontend/src frontend/test",
+    "lint-eslint": "yarn build-quick:cljs && eslint --ext .js,.jsx,.ts,.tsx --rulesdir frontend/lint/eslint-rules --max-warnings 0 enterprise/frontend/src frontend/src frontend/test e2e/test",
     "lint-prettier": "yarn && prettier -l '{enterprise/,}frontend/**/*.{js,jsx,ts,tsx,css}' || (echo '\nThese files are not formatted correctly. Did you forget to \"yarn prettier\"?' && false)",
     "lint-docs-links": "yarn && ./bin/verify-doc-links",
     "lint-yaml": "yamllint **/*.{yaml,yml} --ignore=node_modules/**/*.{yaml,yml}",
@@ -348,6 +348,7 @@
       "node ./bin/verify-doc-links"
     ],
     "e2e/test/scenarios/*/{*.js,!(helpers|shared)/*.js}": [
+      "eslint --rulesdir frontend/lint/eslint-rules --max-warnings 0",
       "node e2e/validate-e2e-test-files.js"
     ]
   },


### PR DESCRIPTION
### Description

We need to run eslint when we not only change FE code but also e2e specs. Includes changes from https://github.com/metabase/metabase/pull/29139

### How to verify

Check the workflow condition makes sense. Test the workflow from here https://github.com/metabase/metabase/pull/29139

You can see the linter has failed on the test commit I created on purpose https://github.com/metabase/metabase/pull/29146/commits/faaf541960bb2c7f034d078e39c94f343ff5f040
<img width="862" alt="Screen Shot 2023-03-11 at 6 23 59 PM" src="https://user-images.githubusercontent.com/14301985/224512159-dbefe2bb-538a-4cfc-a4a6-221e768893fe.png">

### Checklist

- [n/a] Tests have been added/updated to cover changes in this PR
