### PR TITLE
fix exclude date filter serialization

### DIFF
--- a/e2e/support/helpers/e2e-dashboard-helpers.js
+++ b/e2e/support/helpers/e2e-dashboard-helpers.js
@@ -19,9 +19,12 @@ export function editDashboard() {
   cy.findByText("You're editing this dashboard.");
 }
 
-export function saveDashboard() {
-  cy.findByText("Save").click();
-  cy.findByText("You're editing this dashboard.").should("not.exist");
+export function saveDashboard({
+  buttonLabel = "Save",
+  editBarText = "You're editing this dashboard.",
+} = {}) {
+  cy.findByText(buttonLabel).click();
+  cy.findByText(editBarText).should("not.exist");
   cy.wait(1); // this is stupid but necessary to due to the dashboard resizing and detaching elements
 }
 

--- a/frontend/src/metabase-lib/queries/utils/query-time.js
+++ b/frontend/src/metabase-lib/queries/utils/query-time.js
@@ -603,6 +603,10 @@ export const setTimeComponent = (value, hours, minutes) => {
   }
 };
 
+const getMomentDateForSerialization = date => {
+  return date.clone().locale("en");
+};
+
 export const TIME_SELECTOR_DEFAULT_HOUR = 12;
 export const TIME_SELECTOR_DEFAULT_MINUTE = 30;
 
@@ -624,7 +628,7 @@ export const EXCLUDE_OPTIONS = {
         return {
           displayName,
           value,
-          serialized: date.format("ddd"),
+          serialized: getMomentDateForSerialization(date).format("ddd"),
           test: val => value === val,
         };
       }),
@@ -645,7 +649,7 @@ export const EXCLUDE_OPTIONS = {
       return {
         displayName,
         value,
-        serialized: date.format("MMM"),
+        serialized: getMomentDateForSerialization(date).format("MMM"),
         test: value => moment(value).format("MMMM") === displayName,
       };
     };
@@ -662,7 +666,7 @@ export const EXCLUDE_OPTIONS = {
         return {
           displayName: displayName + suffix,
           value,
-          serialized: date.format("Q"),
+          serialized: getMomentDateForSerialization(date).format("Q"),
           test: value => moment(value).format("Qo") === displayName,
         };
       }),

--- a/frontend/src/metabase/parameters/utils/date-formatting.ts
+++ b/frontend/src/metabase/parameters/utils/date-formatting.ts
@@ -62,7 +62,9 @@ const serializersByOperatorName: Record<
     const options = operator
       .getOptions()
       .flat()
-      .filter(({ test }) => !!_.find(values, (value: string) => test(value)));
+      .filter(
+        ({ test }) => _.find(values, (value: string) => test(value)) != null,
+      );
     return `exclude-${operator.name}-${options
       .map(({ serialized }) => serialized)
       .join("-")}`;

--- a/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/DatePicker.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/DatePicker.unit.spec.tsx
@@ -356,5 +356,30 @@ describe("DatePicker", () => {
         });
       });
     });
+
+    describe("Exclude", () => {
+      it("should correctly update exclude filter when value is 0 even though it is falsy", async () => {
+        const onChangeMock = jest.fn();
+
+        render(
+          <DatePickerStateWrapper filter={filter} onChange={onChangeMock} />,
+        );
+
+        userEvent.click(screen.getByText("Exclude..."));
+        userEvent.click(screen.getByText("Hours of the day..."));
+
+        expect(screen.getByTestId("exclude-0")).not.toBeChecked();
+
+        userEvent.click(screen.getByText("12 AM"));
+
+        expect(onChangeMock).toHaveBeenCalledWith([
+          "!=",
+          ["field", 1, { "temporal-unit": "hour-of-day" }],
+          0,
+        ]);
+
+        expect(screen.getByTestId("exclude-0")).not.toBeChecked();
+      });
+    });
   });
 });

--- a/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/DatePicker.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/DatePicker.unit.spec.tsx
@@ -368,9 +368,13 @@ describe("DatePicker", () => {
         userEvent.click(screen.getByText("Exclude..."));
         userEvent.click(screen.getByText("Hours of the day..."));
 
-        expect(screen.getByTestId("exclude-0")).not.toBeChecked();
+        const midnightCheckbox = screen.getByRole("checkbox", {
+          name: /12 AM/i,
+        });
 
-        userEvent.click(screen.getByText("12 AM"));
+        expect(midnightCheckbox).toBeChecked();
+
+        userEvent.click(midnightCheckbox);
 
         expect(onChangeMock).toHaveBeenCalledWith([
           "!=",
@@ -378,7 +382,7 @@ describe("DatePicker", () => {
           0,
         ]);
 
-        expect(screen.getByTestId("exclude-0")).not.toBeChecked();
+        expect(midnightCheckbox).not.toBeChecked();
       });
     });
   });

--- a/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/ExcludeDatePicker.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/ExcludeDatePicker.tsx
@@ -164,15 +164,16 @@ export default function ExcludeDatePicker({
         {options.map((inner, index) => (
           <ExcludeColumn key={index}>
             {inner.map(({ displayName, value, test }) => {
-              const checked = !_.find(values, value => test(value));
+              const isValueExcluded = values.find(value => test(value)) != null;
               return (
                 <ExcludeCheckBox
+                  data-testid={`exclude-${value}`}
                   key={value}
                   label={<ExcludeLabel>{displayName}</ExcludeLabel>}
-                  checked={checked}
+                  checked={!isValueExcluded}
                   checkedColor={primaryColor}
                   onChange={() => {
-                    if (checked) {
+                    if (!isValueExcluded) {
                       update([...values, value]);
                     } else {
                       update(values.filter(value => !test(value)));

--- a/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/ExcludeDatePicker.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/ExcludeDatePicker.tsx
@@ -167,7 +167,6 @@ export default function ExcludeDatePicker({
               const isValueExcluded = values.find(value => test(value)) != null;
               return (
                 <ExcludeCheckBox
-                  data-testid={`exclude-${value}`}
                   key={value}
                   label={<ExcludeLabel>{displayName}</ExcludeLabel>}
                   checked={!isValueExcluded}


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/29122

### Description

When serializing the "exclude" date filter on dashboards it was translating the values to the current locale of a user. It worked fine with numbers but months strings such as "Jan" got translated and it broke the filtering.

Also, this PR fixes another issue I found — the "exclude" filter incorrectly handled the zero value used for the "Hours of the day..." -> "12 AM" filter.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Create a dashboard with a card connected to the Time -> All options filter
2. Go to the account settings and change your locale to any other than English
3. On the dashboard try setting "Exclude" filter "Months of the year..." -> untick January
4. Ensure the filter is getting applied correctly and the value in url is serialized using English: `exclude-months-Jan`

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
