### PR TITLE
adding hasMultipleDimensions check to hasLegend clause

### DIFF
--- a/e2e/support/helpers/e2e-ui-elements-helpers.js
+++ b/e2e/support/helpers/e2e-ui-elements-helpers.js
@@ -97,5 +97,5 @@ export const moveColumnDown = (column, distance) => {
 };
 
 export const queryBuilderMain = () => {
-  return cy.get("main main");
+  return cy.findByTestId("query-builder-main");
 };

--- a/e2e/support/helpers/e2e-ui-elements-helpers.js
+++ b/e2e/support/helpers/e2e-ui-elements-helpers.js
@@ -95,3 +95,7 @@ export const moveColumnDown = (column, distance) => {
     .trigger("mousemove", 0, distance * 50, { force: true })
     .trigger("mouseup", 0, distance * 50, { force: true });
 };
+
+export const queryBuilderMain = () => {
+  return cy.get("main main");
+};

--- a/e2e/test/scenarios/visualizations/line_chart.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/line_chart.cy.spec.js
@@ -416,7 +416,7 @@ describe("scenarios > visualizations > line chart", () => {
       cy.findByText("Category is Doohickey");
     });
 
-    it("should not drop the chart legend (metabase#4995)", () => {
+    it.only("should not drop the chart legend (metabase#4995)", () => {
       cy.findAllByTestId("legend-item").should("contain", "Doohickey");
 
       cy.log("Ensure that legend is hidden when not dealing with multi series");

--- a/e2e/test/scenarios/visualizations/line_chart.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/line_chart.cy.spec.js
@@ -415,8 +415,13 @@ describe("scenarios > visualizations > line chart", () => {
       cy.findByText("Category is Doohickey");
     });
 
-    it.skip("should not drop the chart legend (metabase#4995)", () => {
+    it("should not drop the chart legend (metabase#4995)", () => {
       cy.findAllByTestId("legend-item").should("contain", "Doohickey");
+
+      cy.log("Ensure that legend is hidden when not dealing with multi series");
+      cy.findByTestId("viz-settings-button").click();
+      cy.findByTestId("remove-CATEGORY").click();
+      cy.get("main main").should("not.contain", "Doohickey");
     });
 
     it("should display correct axis labels (metabase#12782)", () => {

--- a/e2e/test/scenarios/visualizations/line_chart.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/line_chart.cy.spec.js
@@ -416,7 +416,7 @@ describe("scenarios > visualizations > line chart", () => {
       cy.findByText("Category is Doohickey");
     });
 
-    it.only("should not drop the chart legend (metabase#4995)", () => {
+    it("should not drop the chart legend (metabase#4995)", () => {
       cy.findAllByTestId("legend-item").should("contain", "Doohickey");
 
       cy.log("Ensure that legend is hidden when not dealing with multi series");

--- a/e2e/test/scenarios/visualizations/line_chart.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/line_chart.cy.spec.js
@@ -4,6 +4,7 @@ import {
   popover,
   visitDashboard,
   openSeriesSettings,
+  queryBuilderMain,
 } from "e2e/support/helpers";
 
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
@@ -421,7 +422,7 @@ describe("scenarios > visualizations > line chart", () => {
       cy.log("Ensure that legend is hidden when not dealing with multi series");
       cy.findByTestId("viz-settings-button").click();
       cy.findByTestId("remove-CATEGORY").click();
-      cy.get("main main").should("not.contain", "Doohickey");
+      queryBuilderMain().should("not.contain", "Doohickey");
     });
 
     it("should display correct axis labels (metabase#12782)", () => {

--- a/frontend/src/metabase/query_builder/components/view/View.jsx
+++ b/frontend/src/metabase/query_builder/components/view/View.jsx
@@ -345,7 +345,10 @@ class View extends React.Component {
     const isSidebarOpen = leftSidebar || rightSidebar;
 
     return (
-      <QueryBuilderMain isSidebarOpen={isSidebarOpen}>
+      <QueryBuilderMain
+        isSidebarOpen={isSidebarOpen}
+        data-testid="query-builder-main"
+      >
         {isNative ? (
           this.renderNativeQueryEditor()
         ) : (

--- a/frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx
+++ b/frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx
@@ -273,9 +273,14 @@ export default class LineAreaBarChart extends Component {
     const canSelectTitle = cardIds.size === 1 && onChangeCardAndRun;
 
     const hasMultipleSeries = series.length > 1;
+    const hasMultipleDimensions = settings["graph.dimensions"].length > 1;
     const canChangeSeries = onAddSeries || onEditSeries || onRemoveSeries;
     const hasLegendButtons = !hasTitle && actionButtons;
-    const hasLegend = hasMultipleSeries || canChangeSeries || hasLegendButtons;
+    const hasLegend =
+      hasMultipleSeries ||
+      canChangeSeries ||
+      hasLegendButtons ||
+      hasMultipleDimensions;
 
     const seriesSettings =
       settings.series && series.map(single => settings.series(single));

--- a/frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx
+++ b/frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx
@@ -273,14 +273,10 @@ export default class LineAreaBarChart extends Component {
     const canSelectTitle = cardIds.size === 1 && onChangeCardAndRun;
 
     const hasMultipleSeries = series.length > 1;
-    const hasMultipleDimensions = settings["graph.dimensions"].length > 1;
     const canChangeSeries = onAddSeries || onEditSeries || onRemoveSeries;
     const hasLegendButtons = !hasTitle && actionButtons;
     const hasLegend =
-      hasMultipleSeries ||
-      canChangeSeries ||
-      hasLegendButtons ||
-      hasMultipleDimensions;
+      hasMultipleSeries || canChangeSeries || hasLegendButtons || hasBreakout;
 
     const seriesSettings =
       settings.series && series.map(single => settings.series(single));


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/4995

### Description
We have logic that uses a few properties to determine whether or not a legend is shown in a line/area/bar chart. If the chart has multiple series, if we're able to change the series (dashcards), or it does not have a title but has actionButtons (also Dashcards... I think). However, if you had a multi series chart and hid or filtered all but one series, the legend would dissappear. This change adds a new check to the logic which is: does the graph have more than 1 dimension. Multiple dimensions implies that the series was intentionally broken out, and when this bug was filed, knowing that breakoutDimension the series on the screen was referencing may not have been as obvious (we now show it right on the data screen).

### How to verify
1. New -> Question -> Count of Products, grouped by Created At: Year, Category
2. Visualize, go to settings and hide all but one series. The legend should still persist
3. enable all series, go to filter and filter out all but one category, the legend should still persist

### Demo
![image](https://user-images.githubusercontent.com/1328979/224704603-56253852-8b73-4829-bb0d-1c72aa100ade.png)

### Checklist
- [x] Tests have been added/updated to cover changes in this PR
