### PR TITLE
Updating graph.metrics when column is removed

### DIFF
--- a/e2e/test/scenarios/visualizations/reproductions/20548-bar-duplicate-y-axis-after-changing-metrics.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/reproductions/20548-bar-duplicate-y-axis-after-changing-metrics.cy.spec.js
@@ -18,7 +18,7 @@ const questionDetails = {
   },
 };
 
-describe.skip("issue 20548", () => {
+describe("issue 20548", () => {
   beforeEach(() => {
     cy.intercept("POST", "/api/dataset").as("dataset");
 
@@ -42,7 +42,7 @@ describe.skip("issue 20548", () => {
 
     cy.findByTestId("viz-settings-button").click();
     // Implicit assertion - it would fail if it finds more than one "Count" in the sidebar
-    sidebar().findByDisplayValue("Count");
+    sidebar().findAllByText("Count").should("have.length", 1);
   });
 });
 

--- a/frontend/src/metabase-lib/Question.ts
+++ b/frontend/src/metabase-lib/Question.ts
@@ -740,36 +740,33 @@ class QuestionInner {
     );
 
     const graphMetrics = this.setting("graph.metrics");
+
     if (
       graphMetrics &&
-      addedColumnNames.length > 0 &&
-      removedColumnNames.length === 0
+      (addedColumnNames.length > 0 || removedColumnNames.length > 0)
     ) {
       const addedMetricColumnNames = addedColumnNames.filter(
         name =>
           query.columnDimensionWithName(name) instanceof AggregationDimension,
       );
 
-      if (addedMetricColumnNames.length > 0) {
-        return this.updateSettings({
-          "graph.metrics": [...graphMetrics, ...addedMetricColumnNames],
-        });
-      }
-    }
-
-    if (
-      graphMetrics &&
-      removedColumnNames.length > 0 &&
-      addedColumnNames.length === 0
-    ) {
       const removedMetricColumnNames = removedColumnNames.filter(
         name =>
           previousQuery.columnDimensionWithName(name) instanceof
           AggregationDimension,
       );
-      return this.updateSettings({
-        "graph.metrics": _.difference(graphMetrics, removedMetricColumnNames),
-      });
+
+      if (
+        addedMetricColumnNames.length > 0 ||
+        removedMetricColumnNames.length > 0
+      ) {
+        return this.updateSettings({
+          "graph.metrics": [
+            ..._.difference(graphMetrics, removedMetricColumnNames),
+            ...addedMetricColumnNames,
+          ],
+        });
+      }
     }
 
     const tableColumns = this.setting("table.columns");

--- a/frontend/src/metabase-lib/Question.ts
+++ b/frontend/src/metabase-lib/Question.ts
@@ -757,6 +757,21 @@ class QuestionInner {
       }
     }
 
+    if (
+      graphMetrics &&
+      removedColumnNames.length > 0 &&
+      addedColumnNames.length === 0
+    ) {
+      const removedMetricColumnNames = removedColumnNames.filter(
+        name =>
+          previousQuery.columnDimensionWithName(name) instanceof
+          AggregationDimension,
+      );
+      return this.updateSettings({
+        "graph.metrics": _.difference(graphMetrics, removedMetricColumnNames),
+      });
+    }
+
     const tableColumns = this.setting("table.columns");
     if (
       tableColumns &&


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/20548

### Description
Bug was caused because we update `graph.metrics` when we add a metric column, but not when we remove one. This caused us to compare the current a previous queries, see that a new value was added, and then append it to the existing `graph.metrics`.  This PR makes a check very similar to when we add a column, when checks if we have removed a metric and if so, update `graph.metrics` accordingly.

### How to verify
1. New -> Question -> Products -> Count and Sum of Price grouped by Category
2. Visualize, and go to Settings and change the order of metrics (need to write metrics to viz settings)
3. Open the summary panel
4. Remove Count, then re add Count, repeat a few times
5.  Count column should never be duplicated

### Demo
![chrome_EY1rrLjuun](https://user-images.githubusercontent.com/1328979/224803502-b44f5278-52f5-497c-a415-7978f3dc15c5.gif)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
