### PR TITLE
Fix quick filter drill with nulls

### DIFF
--- a/e2e/test/scenarios/question/reproductions/29082-quick-filter-null.cy.spec.js
+++ b/e2e/test/scenarios/question/reproductions/29082-quick-filter-null.cy.spec.js
@@ -1,4 +1,20 @@
-import { openOrdersTable, popover, restore } from "e2e/support/helpers";
+import { popover, restore, visitQuestionAdhoc } from "e2e/support/helpers";
+import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
+import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
+
+const { ORDERS_ID, ORDERS } = SAMPLE_DATABASE;
+
+const questionDetails = {
+  name: "22788",
+  dataset_query: {
+    type: "query",
+    database: SAMPLE_DB_ID,
+    query: {
+      "source-table": ORDERS_ID,
+      filter: ["=", ["field", ORDERS.USER_ID, null], 1],
+    },
+  },
+};
 
 describe("issue 29082", () => {
   beforeEach(() => {
@@ -8,17 +24,24 @@ describe("issue 29082", () => {
   });
 
   it("should handle nulls in quick filters (metabase#29082)", () => {
-    openOrdersTable();
+    visitQuestionAdhoc(questionDetails);
     cy.wait("@dataset");
+    cy.findByText("Showing 11 rows").should("exist");
 
     cy.get(".TableInteractive-emptyCell").first().click();
     popover().within(() => cy.findByText("=").click());
     cy.wait("@dataset");
+    cy.findByText("Showing 8 rows").should("exist");
     cy.findByText("Discount is empty").should("exist");
+
+    cy.findByText("Discount is empty").within(() => cy.icon("close").click());
+    cy.wait("@dataset");
+    cy.findByText("Showing 11 rows").should("exist");
 
     cy.get(".TableInteractive-emptyCell").first().click();
     popover().within(() => cy.findByText("≠").click());
     cy.wait("@dataset");
+    cy.findByText("Showing 3 rows").should("exist");
     cy.findByText("Discount is not empty").should("exist");
   });
 });

--- a/e2e/test/scenarios/question/reproductions/29082-quick-filter-null.cy.spec.js
+++ b/e2e/test/scenarios/question/reproductions/29082-quick-filter-null.cy.spec.js
@@ -1,0 +1,24 @@
+import { openOrdersTable, popover, restore } from "e2e/support/helpers";
+
+describe("issue 29082", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsNormalUser();
+    cy.intercept("POST", "/api/dataset").as("dataset");
+  });
+
+  it("should handle nulls in quick filters (metabase#29082)", () => {
+    openOrdersTable();
+    cy.wait("@dataset");
+
+    cy.get(".TableInteractive-emptyCell").first().click();
+    popover().within(() => cy.findByText("=").click());
+    cy.wait("@dataset");
+    cy.findByText("Discount is empty").should("exist");
+
+    cy.get(".TableInteractive-emptyCell").first().click();
+    popover().within(() => cy.findByText("≠").click());
+    cy.wait("@dataset");
+    cy.findByText("Discount is not empty").should("exist");
+  });
+});

--- a/frontend/src/metabase-lib/queries/drills/quick-filter-drill.js
+++ b/frontend/src/metabase-lib/queries/drills/quick-filter-drill.js
@@ -1,12 +1,13 @@
 import {
   isa,
-  isTypeFK,
-  isTypePK,
   isDate,
   isNumeric,
+  isTypeFK,
+  isTypePK,
 } from "metabase-lib/types/utils/isa";
 import { TYPE } from "metabase-lib/types/constants";
 import { isLocalField } from "metabase-lib/queries/utils";
+import { fieldRefForColumn } from "metabase-lib/queries/utils/dataset";
 
 const INVALID_TYPES = [TYPE.Structured];
 
@@ -22,73 +23,58 @@ export function quickFilterDrill({ question, clicked }) {
     return null;
   }
 
-  const { column } = clicked;
+  const { column, value } = clicked;
   if (isTypePK(column.semantic_type) || isTypeFK(column.semantic_type)) {
     return null;
   }
 
-  const operators = getOperatorsForColumn(column);
+  const operators = getOperatorsForColumn(column, value);
   return { operators };
 }
 
-export function quickFilterDrillQuestion({ question, clicked, operator }) {
-  const { column, value } = clicked;
+export function quickFilterDrillQuestion({ question, clicked, filter }) {
+  const { column } = clicked;
 
-  if (isLocalField(column.field_ref)) {
-    return question.filter(operator, column, value);
+  if (isLocalColumn(column)) {
+    return question.query().filter(filter).question();
+  } else {
+    return question.query().nest().filter(filter).question();
   }
-
-  /**
-   * For aggregated and custom columns
-   * with field refs like ["aggregation", 0],
-   * we need to nest the query as filters like ["=", ["aggregation", 0], value] won't work
-   *
-   * So the query like
-   * {
-   *   aggregations: [["count"]]
-   *   source-table: 2,
-   * }
-   *
-   * Becomes
-   * {
-   *   source-query: {
-   *      aggregations: [["count"]]
-   *     source-table: 2,
-   *   },
-   *   filter: ["=", [ "field", "count", {"base-type": "type/BigInteger"} ], value]
-   * }
-   */
-
-  const nestedQuestion = question.query().nest().question();
-
-  return nestedQuestion.filter(
-    operator,
-    {
-      ...column,
-      field_ref: getFieldLiteralFromColumn(column),
-    },
-    value,
-  );
 }
 
-function getOperatorsForColumn(column) {
-  if (isNumeric(column) || isDate(column)) {
+function getOperatorsForColumn(column, value) {
+  const fieldRef = getColumnFieldRef(column);
+
+  if (INVALID_TYPES.some(type => isa(column.base_type, type))) {
+    return [];
+  } else if (value == null) {
     return [
-      { name: "<", operator: "<" },
-      { name: ">", operator: ">" },
-      { name: "=", operator: "=" },
-      { name: "≠", operator: "!=" },
+      { name: "=", filter: ["is-null", fieldRef] },
+      { name: "≠", filter: ["not-null", fieldRef] },
     ];
-  } else if (!INVALID_TYPES.some(type => isa(column.base_type, type))) {
+  } else if (isNumeric(column) || isDate(column)) {
     return [
-      { name: "=", operator: "=" },
-      { name: "≠", operator: "!=" },
+      { name: "<", filter: ["<", fieldRef, value] },
+      { name: ">", filter: [">", fieldRef, value] },
+      { name: "=", filter: ["=", fieldRef, value] },
+      { name: "≠", filter: ["!=", fieldRef, value] },
     ];
   } else {
-    return [];
+    return [
+      { name: "=", filter: ["=", fieldRef, value] },
+      { name: "≠", filter: ["!=", fieldRef, value] },
+    ];
   }
 }
 
-function getFieldLiteralFromColumn(column) {
-  return ["field", column.name, { "base-type": column.base_type }];
+function isLocalColumn(column) {
+  return isLocalField(column.field_ref);
+}
+
+function getColumnFieldRef(column) {
+  if (isLocalColumn(column)) {
+    return fieldRefForColumn(column);
+  } else {
+    return ["field", column.name, { "base-type": column.base_type }];
+  }
 }

--- a/frontend/src/metabase-lib/queries/drills/quick-filter-drill.js
+++ b/frontend/src/metabase-lib/queries/drills/quick-filter-drill.js
@@ -38,6 +38,26 @@ export function quickFilterDrillQuestion({ question, clicked, filter }) {
   if (isLocalColumn(column)) {
     return question.query().filter(filter).question();
   } else {
+    /**
+     * For aggregated and custom columns
+     * with field refs like ["aggregation", 0],
+     * we need to nest the query as filters like ["=", ["aggregation", 0], value] won't work
+     *
+     * So the query like
+     * {
+     *   aggregations: [["count"]]
+     *   source-table: 2,
+     * }
+     *
+     * Becomes
+     * {
+     *   source-query: {
+     *      aggregations: [["count"]]
+     *     source-table: 2,
+     *   },
+     *   filter: ["=", [ "field", "count", {"base-type": "type/BigInteger"} ], value]
+     * }
+     */
     return question.query().nest().filter(filter).question();
   }
 }

--- a/frontend/src/metabase/modes/components/drill/QuickFilterDrill.tsx
+++ b/frontend/src/metabase/modes/components/drill/QuickFilterDrill.tsx
@@ -11,12 +11,12 @@ const QuickFilterDrill: Drill = ({ question, clicked }) => {
     return [];
   }
 
-  return drill.operators.map(({ name, operator }) => ({
-    name: operator,
+  return drill.operators.map(({ name, filter }) => ({
+    name,
     title: <span className="h2">{name}</span>,
     section: "filter",
     buttonType: "token-filter",
-    question: () => quickFilterDrillQuestion({ question, clicked, operator }),
+    question: () => quickFilterDrillQuestion({ question, clicked, filter }),
   }));
 };
 

--- a/frontend/test/metabase/modes/components/drill/QuickFilterDrill.unit.spec.js
+++ b/frontend/test/metabase/modes/components/drill/QuickFilterDrill.unit.spec.js
@@ -14,6 +14,12 @@ const NUMBER_AND_DATE_FILTERS = [
   { name: "=", operator: "=" },
   { name: "≠", operator: "!=" },
 ];
+
+const NULL_FILTERS = [
+  { name: "=", operator: "is-null" },
+  { name: "≠", operator: "not-null" },
+];
+
 const OTHER_FILTERS = [
   { name: "=", operator: "=" },
   { name: "≠", operator: "!=" },
@@ -234,6 +240,30 @@ describe("QuickFilterDrill", () => {
         expect(question.datasetQuery().query).toEqual({
           "source-table": NESTED_QUESTION_SOURCE_TABLE_ID,
           filter: [operator, fieldRef, cellValue],
+        });
+        expect(question.display()).toBe("table");
+      });
+    });
+  });
+
+  describe("numeric cells with null values", () => {
+    const clickedField = ORDERS.TOTAL;
+    const { actions } = setup({ column: clickedField.column(), value: null });
+
+    it("should return correct filters", () => {
+      const filters = NULL_FILTERS.map(({ name }) => ({
+        name,
+      }));
+      expect(actions).toMatchObject(filters);
+    });
+
+    actions.forEach((action, i) => {
+      const { operator } = NULL_FILTERS[i];
+      it(`should correctly apply "${operator}" filter`, () => {
+        const question = action.question();
+        expect(question.datasetQuery().query).toEqual({
+          "source-table": ORDERS.id,
+          filter: [operator, clickedField.reference()],
         });
         expect(question.display()).toBe("table");
       });

--- a/frontend/test/metabase/modes/components/drill/QuickFilterDrill.unit.spec.js
+++ b/frontend/test/metabase/modes/components/drill/QuickFilterDrill.unit.spec.js
@@ -8,8 +8,16 @@ import {
 } from "__support__/sample_database_fixture";
 import Question from "metabase-lib/Question";
 
-const NUMBER_AND_DATE_FILTERS = ["<", ">", "=", "!="];
-const OTHER_FILTERS = ["=", "!="];
+const NUMBER_AND_DATE_FILTERS = [
+  { name: "<", operator: "<" },
+  { name: ">", operator: ">" },
+  { name: "=", operator: "=" },
+  { name: "≠", operator: "!=" },
+];
+const OTHER_FILTERS = [
+  { name: "=", operator: "=" },
+  { name: "≠", operator: "!=" },
+];
 
 const DEFAULT_NUMERIC_CELL_VALUE = 42;
 
@@ -111,14 +119,14 @@ describe("QuickFilterDrill", () => {
     const { actions } = setup({ column: clickedField.column() });
 
     it("should return correct filters", () => {
-      const filters = NUMBER_AND_DATE_FILTERS.map(operator => ({
-        name: operator,
+      const filters = NUMBER_AND_DATE_FILTERS.map(({ name }) => ({
+        name,
       }));
       expect(actions).toMatchObject(filters);
     });
 
     actions.forEach((action, i) => {
-      const operator = NUMBER_AND_DATE_FILTERS[i];
+      const { operator } = NUMBER_AND_DATE_FILTERS[i];
       it(`should correctly apply "${operator}" filter`, () => {
         const question = action.question();
         expect(question.datasetQuery().query).toEqual({
@@ -141,14 +149,14 @@ describe("QuickFilterDrill", () => {
     });
 
     it("should return correct filters", () => {
-      const filters = NUMBER_AND_DATE_FILTERS.map(operator => ({
-        name: operator,
+      const filters = NUMBER_AND_DATE_FILTERS.map(({ name }) => ({
+        name,
       }));
       expect(actions).toMatchObject(filters);
     });
 
     actions.forEach((action, i) => {
-      const operator = NUMBER_AND_DATE_FILTERS[i];
+      const { operator } = NUMBER_AND_DATE_FILTERS[i];
       it(`should correctly apply "${operator}" filter`, () => {
         const question = action.question();
         expect(question.datasetQuery().query).toEqual({
@@ -173,14 +181,14 @@ describe("QuickFilterDrill", () => {
     });
 
     it("should return correct filters", () => {
-      const filters = NUMBER_AND_DATE_FILTERS.map(operator => ({
-        name: operator,
+      const filters = NUMBER_AND_DATE_FILTERS.map(({ name }) => ({
+        name,
       }));
       expect(actions).toMatchObject(filters);
     });
 
     actions.forEach((action, i) => {
-      const operator = NUMBER_AND_DATE_FILTERS[i];
+      const { operator } = NUMBER_AND_DATE_FILTERS[i];
       it(`should correctly apply "${operator}" filter`, () => {
         const question = action.question();
         expect(question.datasetQuery().query).toEqual({
@@ -213,14 +221,14 @@ describe("QuickFilterDrill", () => {
     });
 
     it("should return correct filters", () => {
-      const filters = NUMBER_AND_DATE_FILTERS.map(operator => ({
-        name: operator,
+      const filters = NUMBER_AND_DATE_FILTERS.map(({ name }) => ({
+        name,
       }));
       expect(actions).toMatchObject(filters);
     });
 
     actions.forEach((action, i) => {
-      const operator = NUMBER_AND_DATE_FILTERS[i];
+      const { operator } = NUMBER_AND_DATE_FILTERS[i];
       it(`should correctly apply "${operator}" filter`, () => {
         const question = action.question();
         expect(question.datasetQuery().query).toEqual({
@@ -240,14 +248,14 @@ describe("QuickFilterDrill", () => {
     });
 
     it("should return correct filters", () => {
-      const filters = NUMBER_AND_DATE_FILTERS.map(operator => ({
-        name: operator,
+      const filters = NUMBER_AND_DATE_FILTERS.map(({ name }) => ({
+        name,
       }));
       expect(actions).toMatchObject(filters);
     });
 
     actions.forEach((action, i) => {
-      const operator = NUMBER_AND_DATE_FILTERS[i];
+      const { operator } = NUMBER_AND_DATE_FILTERS[i];
       it(`should correctly apply "${operator}" filter`, () => {
         const question = action.question();
         expect(question.datasetQuery().query).toEqual({
@@ -268,14 +276,14 @@ describe("QuickFilterDrill", () => {
     });
 
     it("should return correct filters", () => {
-      const filters = OTHER_FILTERS.map(operator => ({
-        name: operator,
+      const filters = OTHER_FILTERS.map(({ name }) => ({
+        name,
       }));
       expect(actions).toMatchObject(filters);
     });
 
     actions.forEach((action, i) => {
-      const operator = OTHER_FILTERS[i];
+      const { operator } = OTHER_FILTERS[i];
       it(`should correctly apply "${operator}" filter`, () => {
         const question = action.question();
         expect(question.datasetQuery().query).toEqual({
@@ -294,14 +302,14 @@ describe("QuickFilterDrill", () => {
     });
 
     it("should return correct filters", () => {
-      const filters = OTHER_FILTERS.map(operator => ({
-        name: operator,
+      const filters = OTHER_FILTERS.map(({ name }) => ({
+        name,
       }));
       expect(actions).toMatchObject(filters);
     });
 
     actions.forEach((action, i) => {
-      const operator = OTHER_FILTERS[i];
+      const { operator } = OTHER_FILTERS[i];
       it(`should correctly apply "${operator}" filter`, () => {
         const question = action.question();
         expect(question.datasetQuery().query).toEqual({


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/29082

Handles `NULL` values in quick filters. Previously this case wasn't taken into account and the FE created `["=", ["field", 10, null], null]` mbql clauses, which are incorrect and were removed in some parts of the UI. The correct clause is `["is-null", ["field", 10, null]]`

How to test:
- New -> Question -> Orders table -> Visualize
- Click on the empty cell in a numeric column, e.g. `Total`
- There should be just 2 quick filters - null and not null
- Click on each and make sure the results are correct

<img width="1100" alt="Screenshot 2023-03-14 at 15 58 38" src="https://user-images.githubusercontent.com/8542534/225024587-ec26697c-3af8-4cb5-876e-7e6b0f3ddcb5.png">
<img width="1102" alt="Screenshot 2023-03-14 at 15 58 43" src="https://user-images.githubusercontent.com/8542534/225024610-a7a31829-4834-42a2-88ab-0f9e88bd30ff.png">

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/29190)
<!-- Reviewable:end -->
