### PR TITLE
Remove unused stuff in metabase-lib/queries/utils/description.js

### DIFF
--- a/shared/src/metabase/mbql/util.cljc
+++ b/shared/src/metabase/mbql/util.cljc
@@ -303,7 +303,7 @@
   "Rewrite various 'syntatic sugar' filter clauses like `:time-interval` and `:inside` as simpler, logically
   equivalent clauses. This can be used to simplify the number of filter clauses that need to be supported by anything
   that needs to enumerate all the possible filter types (such as driver query processor implementations, or the
-  implementation `negate-filter-clause` below.)"
+  implementation [[negate-filter-clause]] below.)"
   [filter-clause :- mbql.s/Filter]
   (-> filter-clause
       desugar-current-relative-datetime


### PR DESCRIPTION
`metabase-lib/queries/utils/description.js` consists of two things:

- a handful of utility functions for joining strings together
- An almost line-for-line copy of the query description stuff in `Question.ts`, but only used by the `Metric` and `Segment` components with some ability to output React components directly

This PR removes all of the unused stuff in this file -- query description stuff not used by the two call sites and other unused exported functions.

At some point we should get rid of this file entirely and use the versions in `Question.ts` (soon to be in MLv2/ClojureScript) but in the mean time this is a step in the right direction