### PR TITLE
Add Recent Item Links to link cards

### DIFF
--- a/frontend/src/metabase-types/api/activity.ts
+++ b/frontend/src/metabase-types/api/activity.ts
@@ -5,6 +5,10 @@ export interface ModelObject {
 }
 
 export interface RecentItem {
+  cnt: number;
+  max_ts: string;
+  model_id: number;
+  user_id: number;
   model: ModelType;
   model_object: ModelObject;
 }

--- a/frontend/src/metabase-types/api/mocks/activity.ts
+++ b/frontend/src/metabase-types/api/mocks/activity.ts
@@ -12,6 +12,10 @@ export const createMockRecentItem = (
 ): RecentItem => ({
   model: "table",
   model_object: createMockModelObject(),
+  cnt: 1,
+  model_id: 1,
+  max_ts: "2021-03-01T00:00:00.000Z",
+  user_id: 1,
   ...opts,
 });
 

--- a/frontend/src/metabase/visualizations/visualizations/LinkViz/LinkViz.styled.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/LinkViz/LinkViz.styled.tsx
@@ -2,6 +2,7 @@ import styled from "@emotion/styled";
 import { color } from "metabase/lib/colors";
 import Link from "metabase/core/components/Link";
 import Icon from "metabase/components/Icon";
+import RecentsList from "metabase/nav/components/RecentsList";
 
 export const DisplayLinkCardWrapper = styled.div`
   padding: 0.5rem;
@@ -38,7 +39,12 @@ export const CardLink = styled(Link)`
   }
 `;
 
-export const SearchResultsContainer = styled.div`
+export const BrandIconWithHorizontalMargin = styled(Icon)`
+  color: ${color("brand")};
+  margin: 0 0.5rem;
+`;
+
+const searchResultsStyles = `
   padding-top: 0.5rem;
   padding-bottom: 0.5rem;
   min-width: 20rem;
@@ -55,7 +61,10 @@ export const SearchResultsContainer = styled.div`
   pointer-events: all;
 `;
 
-export const BrandIconWithHorizontalMargin = styled(Icon)`
-  color: ${color("brand")};
-  margin: 0 0.5rem;
+export const SearchResultsContainer = styled.div`
+  ${searchResultsStyles}
+`;
+
+export const StyledRecentsList = styled(RecentsList)`
+  ${searchResultsStyles}
 `;

--- a/frontend/src/metabase/visualizations/visualizations/LinkViz/LinkViz.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/LinkViz/LinkViz.tsx
@@ -27,6 +27,7 @@ import {
   DisplayLinkCardWrapper,
   CardLink,
   SearchResultsContainer,
+  StyledRecentsList,
 } from "./LinkViz.styled";
 
 import { isUrlString } from "./utils";
@@ -75,7 +76,7 @@ function LinkViz({
         entity: {
           id: entity.id,
           db_id: entity.model === "table" ? entity.database_id : undefined,
-          name: entity.name,
+          name: entity.name ?? entity.model,
           model: entity.model,
           description: entity.description,
           display: entity.display,
@@ -131,15 +132,19 @@ function LinkViz({
     return (
       <EditLinkCardWrapper>
         <TippyPopover
-          visible={!!url?.length && inputIsFocused && !isUrlString(url)}
+          visible={inputIsFocused && !isUrlString(url)}
           content={
-            <SearchResultsContainer>
-              <SearchResults
-                searchText={url?.trim()}
-                onEntitySelect={handleEntitySelect}
-                models={MODELS_TO_SEARCH}
-              />
-            </SearchResultsContainer>
+            !url?.trim?.().length && !entity ? (
+              <StyledRecentsList onClick={handleEntitySelect} />
+            ) : (
+              <SearchResultsContainer>
+                <SearchResults
+                  searchText={url?.trim()}
+                  onEntitySelect={handleEntitySelect}
+                  models={MODELS_TO_SEARCH}
+                />
+              </SearchResultsContainer>
+            )
           }
           placement="bottom"
         >

--- a/frontend/src/metabase/visualizations/visualizations/LinkViz/LinkViz.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/LinkViz/LinkViz.tsx
@@ -76,7 +76,7 @@ function LinkViz({
         entity: {
           id: entity.id,
           db_id: entity.model === "table" ? entity.database_id : undefined,
-          name: entity.name ?? entity.model,
+          name: entity.name,
           model: entity.model,
           description: entity.description,
           display: entity.display,

--- a/frontend/src/metabase/visualizations/visualizations/LinkViz/utils.ts
+++ b/frontend/src/metabase/visualizations/visualizations/LinkViz/utils.ts
@@ -1,1 +1,1 @@
-export const isUrlString = (str: string) => /^http/i.test(str);
+export const isUrlString = (str?: string) => str && /^http/i.test(str);

--- a/frontend/test/__support__/server-mocks/activity.ts
+++ b/frontend/test/__support__/server-mocks/activity.ts
@@ -1,0 +1,6 @@
+import fetchMock from "fetch-mock";
+import type { RecentItem } from "metabase-types/api";
+
+export function setupRecentViewsEndpoints(recentlyViewedItems: RecentItem[]) {
+  fetchMock.get("path:/api/activity/recent_views", recentlyViewedItems);
+}

--- a/frontend/test/__support__/server-mocks/index.ts
+++ b/frontend/test/__support__/server-mocks/index.ts
@@ -1,4 +1,5 @@
 export * from "./action";
+export * from "./activity";
 export * from "./card";
 export * from "./collection";
 export * from "./dashboard";


### PR DESCRIPTION

Closes https://github.com/metabase/metabase/issues/29196

### Description

- Adapts the `RecentsList` component to work for selecting recent entities to link on link dashboard cards:
  - by accepting an `onClick` prop to switch the behavior from linking to clicking
  - by accepting a `className` so we can apply some custom styling 
- adds API mocks for the recent items API so we can unit test the component 

![recentLinkcarditems](https://user-images.githubusercontent.com/30528226/224838191-13b1a5a7-2686-4d0a-bbac-1a965ccc5762.gif)


### How to verify

- Open a dashboard, go to edit mode
- add a link card
- clicking in the input should automatically open recent items
- clicking a recent item should save it
- typing should hide recent items and start a search
- typing a url starting with http should hide all popovers

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
