### PR TITLE
Remove collection spec hack, update the test

### DIFF
--- a/e2e/test/scenarios/collections/collections.cy.spec.js
+++ b/e2e/test/scenarios/collections/collections.cy.spec.js
@@ -37,7 +37,7 @@ describe("scenarios > collection defaults", () => {
 
       cy.visit("/");
 
-      cy.viewport(800, 400);
+      cy.viewport(800, 500);
 
       cy.findByText("New").click();
       cy.findByText("Collection").click();
@@ -49,9 +49,7 @@ describe("scenarios > collection defaults", () => {
       });
 
       popover().within(() => {
-        cy.findByText(`Collection ${COLLECTIONS_COUNT}`).click({
-          waitForAnimations: false,
-        });
+        cy.findByText(`Collection ${COLLECTIONS_COUNT}`).click();
       });
 
       cy.findByText("Create").click();


### PR DESCRIPTION
### Description

Due to the limitation of our popover (https://github.com/metabase/metabase/issues/29207) it cannot position itself to cover the trigger element which makes it go out of the screen when its `min-height` is not available both on top and the bottom. Although the content in it is still accessible and scrollable which the spec I'm changing is supposed to check.

Addressing the comment from here https://github.com/metabase/metabase/pull/29198#discussion_r1135399727
