### PR TITLE
Reduce flakes in actions e2e tests

### DIFF
--- a/e2e/test/scenarios/dashboard/actions-on-dashboards.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/actions-on-dashboards.cy.spec.js
@@ -634,6 +634,8 @@ function createDashboardWithActionButton({
 
   if (idFilter) {
     cy.findByRole("dialog").within(() => {
+      cy.findByText(/has no parameters to map/i).should("not.exist");
+      cy.findByText(/Where should the values/i);
       cy.findAllByText(/ask the user/i)
         .first()
         .click();


### PR DESCRIPTION
### Description

This just adds some more guards to action tests that were causing flakes. We were getting a lot of failures on the parameter mapping step. I think these flakes were a consequence of loading actions data via a different endpoint and the render time changing. I tested this locally with devtools' 4x CPU slowdown and it was all good. 🤞 

![Screen Shot 2023-03-14 at 1 22 14 PM](https://user-images.githubusercontent.com/30528226/225114706-ae32fc4d-4e18-4e8a-85bf-57333098d151.png)


- [x] Tests have been added/updated to cover changes in this PR
