### PR TITLE
fix missing group by columns from joined tables

### DIFF
--- a/e2e/test/scenarios/joins/reproductions/27873-missing-joined-group-by.cy.spec.js
+++ b/e2e/test/scenarios/joins/reproductions/27873-missing-joined-group-by.cy.spec.js
@@ -32,7 +32,7 @@ const questionDetails = {
   display: "table",
 };
 
-describe.skip("issue 27873", () => {
+describe("issue 27873", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();

--- a/e2e/test/scenarios/question/summarization.cy.spec.js
+++ b/e2e/test/scenarios/question/summarization.cy.spec.js
@@ -71,7 +71,7 @@ describe("scenarios > question > summarize sidebar", () => {
     });
   });
 
-  it("selected dimensions from another table includes the table name when becomes pinned to the top", () => {
+  it("selected dimensions from another table includes the table alias when becomes pinned to the top", () => {
     getDimensionByName({ name: "State" }).click();
 
     cy.button("Done").click();
@@ -79,16 +79,16 @@ describe("scenarios > question > summarize sidebar", () => {
     summarize();
 
     cy.findByTestId("pinned-dimensions").within(() => {
-      getDimensionByName({ name: "People → State" }).should(
+      getDimensionByName({ name: "User → State" }).should(
         "have.attr",
         "aria-selected",
         "true",
       );
     });
 
-    getRemoveDimensionButton({ name: "People → State" }).click();
+    getRemoveDimensionButton({ name: "User → State" }).click();
 
-    cy.findByText("People → State").should("not.exist");
+    cy.findByText("User → State").should("not.exist");
   });
 
   it("selecting a binning adds a dimension", () => {

--- a/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/DimensionList/DimensionList.jsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/DimensionList/DimensionList.jsx
@@ -44,7 +44,9 @@ export const DimensionList = ({
   const isDimensionSelected = dimension =>
     dimensions.some(d => {
       // sometimes `dimension` has a join-alias and `d` doesn't -- with/without is equivalent in this scenario
-      return d.isSameBaseDimension(dimension.withoutJoinAlias());
+      return d
+        .withoutJoinAlias()
+        .isSameBaseDimension(dimension.withoutJoinAlias());
     });
 
   const [filter, setFilter] = useState("");
@@ -101,14 +103,16 @@ export const DimensionList = ({
       {!hasFilter && (
         <ul data-testid="pinned-dimensions">
           {pinnedItems.map(item => {
-            const shouldIncludeTable =
-              item.dimension?.tableId?.() !== queryTableId;
+            const isForeignDimension =
+              item.dimension != null &&
+              item.dimension.tableId?.() !== queryTableId;
+            const name = getItemName(item, isForeignDimension);
 
             return (
               <DimensionListItem
-                key={getItemName(item)}
+                key={name}
                 dimension={item.dimension}
-                name={getItemName(item, shouldIncludeTable)}
+                name={name}
                 iconName={getItemIcon(item)}
                 dimensions={dimensions}
                 onRemoveDimension={handleRemove}

--- a/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/DimensionList/utils.js
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/DimensionList/utils.js
@@ -1,16 +1,11 @@
 import _ from "underscore";
 
-export const getItemName = (item, shouldIncludeTable) => {
-  const dimensionName = item.name ?? item.dimension?.displayName();
-
-  if (!shouldIncludeTable) {
-    return dimensionName;
+export const getItemName = (item, isForeignDimension) => {
+  if (isForeignDimension) {
+    return item.dimension.render();
   }
 
-  const field = item.dimension?.field?.();
-  const tableName = field?.table?.displayName();
-
-  return `${tableName} → ${dimensionName}`;
+  return item.name ?? item.dimension?.displayName();
 };
 
 export const getItemIcon = item => item.icon ?? item.dimension?.icon();


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/27873

### Description

Fixes missing in the summarization sidebar "group by" columns from joined tables. The reason is that the code that detected whether a dimension is selected while comparing two dimensions took one dimension without join-alias so it worked for non-joined tables and failed on joined ones.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. New question -> Sample Dataset -> Orders join People -> in the notebook summarize Count by People[Source]
2. Click visualize and open the summarization sidebar
3. Ensure the People[Source] dimension is selected

### Checklist

- [n/a] Tests have been added/updated to cover changes in this PR

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/29230)
<!-- Reviewable:end -->
