### PR TITLE
[CI] Start using `was-backported` label

### DIFF
--- a/.github/workflows/auto-backport.yml
+++ b/.github/workflows/auto-backport.yml
@@ -54,7 +54,7 @@ jobs:
           git checkout master
           git push -u origin ${BACKPORT_BRANCH}
 
-          BACKPORT_PR_URL=$(hub pull-request -b "${TARGET_BRANCH}" -h "${BACKPORT_BRANCH}" -l "auto-backported" -a "${GITHUB_ACTOR}" -F- <<<"🤖 backported \"${ORIGINAL_TITLE}\"
+          BACKPORT_PR_URL=$(hub pull-request -b "${TARGET_BRANCH}" -h "${BACKPORT_BRANCH}" -l "was-backported" -a "${GITHUB_ACTOR}" -F- <<<"🤖 backported \"${ORIGINAL_TITLE}\"
 
           #${ORIGINAL_PULL_REQUEST_NUMBER}")
 

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -111,7 +111,7 @@ jobs:
           if [[ $(hub pr list -b "${TARGET_BRANCH}" -h "${BACKPORT_BRANCH}" -s "open") ]]; then
               echo "PR already exists"
           else
-              BACKPORT_PR_URL=$(hub pull-request -b "${TARGET_BRANCH}" -h "${BACKPORT_BRANCH}" -l "auto-backported" -a "${GITHUB_ACTOR}" -F- <<<"🤖 backported \"${ORIGINAL_TITLE}\"
+              BACKPORT_PR_URL=$(hub pull-request -b "${TARGET_BRANCH}" -h "${BACKPORT_BRANCH}" -l "was-backported" -a "${GITHUB_ACTOR}" -F- <<<"🤖 backported \"${ORIGINAL_TITLE}\"
 
               #${ORIGINAL_PULL_REQUEST_NUMBER}")
 


### PR DESCRIPTION
We have been using appropriately-named label `auto-backported` for automated backports for a long time. And it fits perfectly if an automated backport succeeds.

There are certain occasions when engineers need to manually backport something (due to a failed automated backport, for example). In such cases, `auto-backported` label is counter intuitive and people often don't realize they have to add that label to such PR.

Example of a manual backport that needed this label:
https://github.com/metabase/metabase/pull/29206

Label is the only way to track which PRs were backported and which ones weren't.
This subtle change should hopefully remove the confusion.

---
[According to documentation](https://hub.github.com/hub-pull-request.1.html), a label will be created if it doesn't exist.