### PR TITLE
[WIP] Try out GitHub custom runners for benchmarking

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -31,7 +31,7 @@ jobs:
   build:
     needs: files-changed
     if: github.event.pull_request.draft == false && needs.files-changed.outputs.e2e_all == 'true'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest-4-cores
     timeout-minutes: 25
     strategy:
       matrix:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -31,7 +31,7 @@ jobs:
   build:
     needs: files-changed
     if: github.event.pull_request.draft == false && needs.files-changed.outputs.e2e_all == 'true'
-    runs-on: ubuntu-latest-4-cores
+    runs-on: ubuntu-latest-8-cores
     timeout-minutes: 25
     strategy:
       matrix:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -31,7 +31,7 @@ jobs:
   build:
     needs: files-changed
     if: github.event.pull_request.draft == false && needs.files-changed.outputs.e2e_all == 'true'
-    runs-on: ubuntu-latest-8-cores
+    runs-on: ubuntu-latest-4-cores
     timeout-minutes: 25
     strategy:
       matrix:
@@ -60,7 +60,7 @@ jobs:
       always() &&
       needs.files-changed.outputs.e2e_all == 'true' &&
       needs.build.result == 'success'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest-4-cores
     timeout-minutes: 60
     name: e2e-tests-${{ matrix.folder }}${{ matrix.context }}-${{ matrix.edition }}
     env:
@@ -236,7 +236,7 @@ jobs:
           echo "Didn't run due to conditional filtering"
 
   visual-regression-tests:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest-4-cores
     timeout-minutes: 45
     needs: build
     name: percy-visual-regression-tests

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -78,7 +78,7 @@ jobs:
   fe-tests-unit:
     needs: files-changed
     if: github.event.pull_request.draft == false && needs.files-changed.outputs.frontend_all == 'true'
-    runs-on: buildjet-2vcpu-ubuntu-2204
+    runs-on: ubuntu-22.04
     timeout-minutes: 30
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
From some early experiments, it doesn't seem that using more than 4 cores improves the `build` job performance. Even 4 cores gives pretty similar results as the basic gitHub runner with the two cores.

### Build (`./bin/build.sh`)
#### 2 cores
| | [a](https://github.com/metabase/metabase/actions/runs/4446183297/usage) | [b](https://github.com/metabase/metabase/actions/runs/4443049102/usage) | [c](https://github.com/metabase/metabase/actions/runs/4446378522/usage) | average |
|--|--|--|--|--|
|build-oss | 17m 11s | 17m29s | 13m31s | av |
|build-ee | 13m 51s | 17m30s | 18m55s | av |

#### 4 cores
|  | a | b | c | average |
|--|--|--|--|--|
|build-oss | xx | xx | xx | average |
|build-ee | xx | xx | xx | average |

#### 8 cores
Ran only once and cancelled the second run when it went over 10-11m and it still didn't finish. It was clear that we gain no benefits from using more cores.
| job | [time](https://github.com/metabase/metabase/actions/runs/4429985165/usage) |
|--|--|
| build-oss | 10m34s |
| build-ee | 11m36s |

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/29247)
<!-- Reviewable:end -->
