### PR TITLE
Optimize DB calls of dashboard card updates some more - 2

### DIFF
--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -43,8 +43,7 @@
    [metabase.util.schema :as su]
    [schema.core :as s]
    [toucan.db :as db]
-   [toucan.hydrate :refer [hydrate]]
-   [toucan2.tools.transformed :as transformed])
+   [toucan.hydrate :refer [hydrate]])
   (:import
    (java.util UUID)))
 

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -574,7 +574,7 @@
     (check-updated-parameter-mapping-permissions id cards)
     ;; transform the card data to the format of the DashboardCard model
     ;; so update-dashcards! can compare them with existing cards
-    (dashboard/update-dashcards! dashboard (map dashboard-card/from-json cards))
+    (dashboard/update-dashcards! dashboard (map dashboard-card/from-parsed-json cards))
     (events/publish-event! :dashboard-reposition-cards {:id id, :actor_id api/*current-user-id*, :dashcards cards})
     {:status :ok}))
 

--- a/src/metabase/models/dashboard_card.clj
+++ b/src/metabase/models/dashboard_card.clj
@@ -68,12 +68,13 @@
    =>
    true
    ```"
+  [dashboard-card]
   (t2/instance DashboardCard
-    (-> dashboard-card
-        (m/update-existing :parameter_mappings mi/normalize-parameters-list)
-        (m/update-existing :created_at (comp t/offset-date-time u.date/parse))
-        (m/update-existing :updated_at (comp t/offset-date-time u.date/parse))
-        (m/update-existing :visualization_settings mi/normalize-visualization-settings))))
+               (-> dashboard-card
+                   (m/update-existing :parameter_mappings mi/normalize-parameters-list)
+                   (m/update-existing :created_at (comp t/offset-date-time u.date/parse))
+                   (m/update-existing :updated_at (comp t/offset-date-time u.date/parse))
+                   (m/update-existing :visualization_settings mi/normalize-visualization-settings))))
 
 (defmethod serdes/hash-fields DashboardCard
   [_dashboard-card]

--- a/src/metabase/models/dashboard_card.clj
+++ b/src/metabase/models/dashboard_card.clj
@@ -57,11 +57,12 @@
 (defn from-parsed-json
   "Convert a map with dashboard-card into a Toucan instance assuming it came from parsed JSON and the map keys have
    been keywordized. This is useful if the data from a request body inside a `defendpoint` body, and you need it in the
-   same format as if it were selected from the DB with toucan.
+   same format as if it were selected from the DB with toucan. It doesn't transform the `:created_at` or `:updated_at`
+   fields, as the types of timestamp values differ by the application database driver.
 
    For example:
    ```
-   (= dashcard ;; from toucan select
+   (= dashcard ;; from toucan select, excluding :created_at and :updated_at
       (-> (json/generate-string dashcard)
           (json/parse-string true)
           from-parsed-json))
@@ -72,8 +73,6 @@
   (t2/instance DashboardCard
                (-> dashboard-card
                    (m/update-existing :parameter_mappings mi/normalize-parameters-list)
-                   (m/update-existing :created_at (comp t/offset-date-time u.date/parse))
-                   (m/update-existing :updated_at (comp t/offset-date-time u.date/parse))
                    (m/update-existing :visualization_settings mi/normalize-visualization-settings))))
 
 (defmethod serdes/hash-fields DashboardCard

--- a/src/metabase/models/dashboard_card.clj
+++ b/src/metabase/models/dashboard_card.clj
@@ -54,12 +54,22 @@
                            :visualization_settings :visualization-settings})
   :pre-insert pre-insert})
 
-(defn from-json
-  "Transform dashboard-card data coming from the serialized JSON from an API request to the same format as
-   if it were selected from the DB."
-  [data]
+(defn from-parsed-json
+  "Convert a map with dashboard-card into a Toucan instance assuming it came from parsed JSON and the map keys have
+   been keywordized. This is useful if the data from a request body inside a `defendpoint` body, and you need it in the
+   same format as if it were selected from the DB with toucan.
+
+   For example:
+   ```
+   (= dashcard ;; from toucan select
+      (-> (json/generate-string dashcard)
+          (json/parse-string true)
+          from-parsed-json))
+   =>
+   true
+   ```"
   (t2/instance DashboardCard
-    (-> data
+    (-> dashboard-card
         (m/update-existing :parameter_mappings mi/normalize-parameters-list)
         (m/update-existing :created_at (comp t/offset-date-time u.date/parse))
         (m/update-existing :updated_at (comp t/offset-date-time u.date/parse))

--- a/src/metabase/models/dashboard_card.clj
+++ b/src/metabase/models/dashboard_card.clj
@@ -162,7 +162,8 @@
                     ;; This is to preserve the existing behavior of questions and card_id
                     ;; I don't know why card_id couldn't be changed for cards though.
                      action_id (conj :card_id))
-         updates (shallow-updates (select-keys dashboard-card update-ks) (select-keys old-dashboard-card update-ks))]
+         updates (shallow-updates (select-keys dashboard-card update-ks)
+                                  (select-keys old-dashboard-card update-ks))]
      (when (seq updates)
        (db/update! DashboardCard id updates))
      (when (not= (:series dashboard-card [])

--- a/src/metabase/models/dashboard_card.clj
+++ b/src/metabase/models/dashboard_card.clj
@@ -1,7 +1,6 @@
 (ns metabase.models.dashboard-card
   (:require
    [clojure.set :as set]
-   [java-time :as t]
    [medley.core :as m]
    [metabase.db :as mdb]
    [metabase.db.query :as mdb.query]

--- a/src/metabase/models/dashboard_card.clj
+++ b/src/metabase/models/dashboard_card.clj
@@ -1,6 +1,7 @@
 (ns metabase.models.dashboard-card
   (:require
    [clojure.set :as set]
+   [java-time :as t]
    [medley.core :as m]
    [metabase.db :as mdb]
    [metabase.db.query :as mdb.query]
@@ -52,6 +53,17 @@
   :types      (constantly {:parameter_mappings     :parameters-list
                            :visualization_settings :visualization-settings})
   :pre-insert pre-insert})
+
+(defn from-json
+  "Transform dashboard-card data coming from the serialized JSON from an API request to the same format as
+   if it were selected from the DB."
+  [data]
+  (t2/instance DashboardCard
+    (-> data
+        (m/update-existing :parameter_mappings mi/normalize-parameters-list)
+        (m/update-existing :created_at (comp t/offset-date-time u.date/parse))
+        (m/update-existing :updated_at (comp t/offset-date-time u.date/parse))
+        (m/update-existing :visualization_settings mi/normalize-visualization-settings))))
 
 (defmethod serdes/hash-fields DashboardCard
   [_dashboard-card]

--- a/src/metabase/models/interface.clj
+++ b/src/metabase/models/interface.clj
@@ -146,8 +146,8 @@
   :out (comp (catch-normalization-exceptions normalize-metric-segment-definition) json-out-with-keywordization))
 
 (defn normalize-visualization-settings [viz-settings]
-  ;; frontend uses JSON-serialized versions of MBQL clauses as keys in `:column_settings`; we need to normalize them
-  ;; to modern MBQL clauses so things work correctly
+  "The frontend uses JSON-serialized versions of MBQL clauses as keys in `:column_settings`. This normalizes them
+   to modern MBQL clauses so things work correctly."
   (letfn [(normalize-column-settings-key [k]
             (some-> k u/qualified-name json/parse-string mbql.normalize/normalize json/generate-string))
           (normalize-column-settings [column-settings]

--- a/src/metabase/models/interface.clj
+++ b/src/metabase/models/interface.clj
@@ -145,7 +145,7 @@
   :in  (comp json-in normalize-metric-segment-definition)
   :out (comp (catch-normalization-exceptions normalize-metric-segment-definition) json-out-with-keywordization))
 
-(defn- normalize-visualization-settings [viz-settings]
+(defn normalize-visualization-settings [viz-settings]
   ;; frontend uses JSON-serialized versions of MBQL clauses as keys in `:column_settings`; we need to normalize them
   ;; to modern MBQL clauses so things work correctly
   (letfn [(normalize-column-settings-key [k]

--- a/src/metabase/models/interface.clj
+++ b/src/metabase/models/interface.clj
@@ -145,9 +145,10 @@
   :in  (comp json-in normalize-metric-segment-definition)
   :out (comp (catch-normalization-exceptions normalize-metric-segment-definition) json-out-with-keywordization))
 
-(defn normalize-visualization-settings [viz-settings]
+(defn normalize-visualization-settings
   "The frontend uses JSON-serialized versions of MBQL clauses as keys in `:column_settings`. This normalizes them
    to modern MBQL clauses so things work correctly."
+  [viz-settings]
   (letfn [(normalize-column-settings-key [k]
             (some-> k u/qualified-name json/parse-string mbql.normalize/normalize json/generate-string))
           (normalize-column-settings [column-settings]

--- a/test/metabase/models/dashboard_card_test.clj
+++ b/test/metabase/models/dashboard_card_test.clj
@@ -311,8 +311,8 @@
 (deftest from-decoded-json-test
   (testing "Dashboard Cards should remain the same if they are serialized to JSON,
             deserialized, and finally transformed with `from-parsed-json`."
-    (mt/with-temp* [Dashboard     [dash     {:name "my dashboard"   :created_at now}]
-                    Card          [card     {:name "some question"  :created_at now}]
+    (mt/with-temp* [Dashboard     [dash     {:name "my dashboard"}]
+                    Card          [card     {:name "some question"}]
                     DashboardCard [dashcard {:card_id (:id card)
                                              :dashboard_id (:id dash)
                                              :visualization_settings {:click_behavior {:type         "link",

--- a/test/metabase/models/dashboard_card_test.clj
+++ b/test/metabase/models/dashboard_card_test.clj
@@ -214,11 +214,11 @@
                     DashboardCard [dashcard-3 {:dashboard_id dashboard-id, :card_id card-id}]
                     Card          [{series-id-1 :id} {:name "Series Card 1"}]
                     Card          [{series-id-2 :id} {:name "Series Card 2"}]]
-      (testing "Should have fewer DB calls if there's no changes to the dashcards"
+      (testing "Should have fewer DB calls if there are no changes to the dashcards"
        (db/with-call-counting [call-count]
          (dashboard/update-dashcards! dashboard [dashcard-1 dashcard-2 dashcard-3])
          (is (= 6 (call-count)))))
-      (testing "Should have more calls if there's changes to the dashcards"
+      (testing "Should have more calls if there are changes to the dashcards"
        (db/with-call-counting [call-count]
          (dashboard/update-dashcards! dashboard [{:id     (:id dashcard-1)
                                                   :cardId card-id

--- a/test/metabase/models/dashboard_card_test.clj
+++ b/test/metabase/models/dashboard_card_test.clj
@@ -308,9 +308,9 @@
                (serdes/raw-hash [(serdes/identity-hash card) (serdes/identity-hash dash) {} 6 3 now])
                (serdes/identity-hash dashcard)))))))
 
-(deftest from-json-test
+(deftest from-decoded-json-test
   (testing "Dashboard Cards should remain the same if they are serialized to JSON,
-            deserialized, and finally transformed with `from-json`."
+            deserialized, and finally transformed with `from-parsed-json`."
     (mt/with-temp* [Dashboard     [dash     {:name "my dashboard"   :created_at now}]
                     Card          [card     {:name "some question"  :created_at now}]
                     DashboardCard [dashcard {:card_id (:id card)
@@ -326,6 +326,6 @@
       (let [dashcard     (db/select-one DashboardCard :id (u/the-id dashcard))
             serialized   (json/generate-string dashcard)
             deserialized (json/parse-string serialized true)
-            transformed  (dashboard-card/from-json deserialized)]
+            transformed  (dashboard-card/from-parsed-json deserialized)]
         (is (= dashcard
                transformed))))))

--- a/test/metabase/models/dashboard_card_test.clj
+++ b/test/metabase/models/dashboard_card_test.clj
@@ -323,7 +323,10 @@
                                                                        :target [:dimension [:field 1 nil]]}]
                                              :row                    4
                                              :col                    3}]]
-      (let [dashcard     (db/select-one DashboardCard :id (u/the-id dashcard))
+      ;; NOTE: we need to remove `:created_at` and `:updated_at` because they are not
+      ;; transformed by `from-parsed-json`
+      (let [dashcard     (dissoc (db/select-one DashboardCard :id (u/the-id dashcard))
+                                 :created_at :updated_at)
             serialized   (json/generate-string dashcard)
             deserialized (json/parse-string serialized true)
             transformed  (dashboard-card/from-parsed-json deserialized)]


### PR DESCRIPTION
This PR is the final push towards resolving [Dashboard update makes too many app DB calls](https://github.com/metabase/metabase/issues/28956#top).

For a test dashboard with 15 cards and 5 parameters, it reduced the DB call count on a `PUT /api/dashboard/:id/cards` request from 48 calls to 24 calls.

It builds on [Optimize DB calls of dashboard card updates some more](https://github.com/metabase/metabase/pull/29132#top) by making sure the dashcard data coming from the API is in the same format as the dashcard data coming from the database.

The previous PR does a shallow diff between existing dashcards from the DB and the dashcard data in the request body. But there are still unnecessary update DB calls if a dashcards had non-nil values for `parameter_mappings` or `visualization_settings`, because the format of the data is different (keywords vs strings).

This PR makes a change to the PUT "api/dashboard/:id/cards" handler, so that the dashcard data in the request body is transformed into the right format for comparison with existing dashcards, before `update-dashcards!` is called.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/29252)
<!-- Reviewable:end -->
