### PR TITLE
fix aggressive y-axis splitting in line, area, bar charts

### DIFF
--- a/e2e/test/scenarios/visualizations/bar_chart.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/bar_chart.cy.spec.js
@@ -225,6 +225,59 @@ describe("scenarios > visualizations > bar chart", () => {
     });
   });
 
+  // Note (EmmadUsmani): see `line_chart.cy.spec.js` for more test cases of this
+  describe("with split y-axis (metabase#12939)", () => {
+    it("should split the y-axis when column settings differ", () => {
+      visitQuestionAdhoc({
+        dataset_query: {
+          type: "query",
+          query: {
+            "source-table": ORDERS_ID,
+            aggregation: [
+              ["avg", ["field", ORDERS.TOTAL, null]],
+              ["min", ["field", ORDERS.TOTAL, null]],
+            ],
+            breakout: [
+              ["field", ORDERS.CREATED_AT, { "temporal-unit": "month" }],
+            ],
+          },
+          database: SAMPLE_DB_ID,
+        },
+        display: "bar",
+        visualization_settings: {
+          column_settings: {
+            '["name","avg"]': { number_style: "decimal" },
+            '["name","min"]': { number_style: "percent" },
+          },
+        },
+      });
+
+      cy.get("g.axis.yr").should("be.visible");
+    });
+
+    it("should not split the y-axis when semantic_type, column settings are same and values are not far", () => {
+      visitQuestionAdhoc({
+        dataset_query: {
+          type: "query",
+          query: {
+            "source-table": ORDERS_ID,
+            aggregation: [
+              ["avg", ["field", ORDERS.TOTAL, null]],
+              ["min", ["field", ORDERS.TOTAL, null]],
+            ],
+            breakout: [
+              ["field", ORDERS.CREATED_AT, { "temporal-unit": "month" }],
+            ],
+          },
+          database: SAMPLE_DB_ID,
+        },
+        display: "bar",
+      });
+
+      cy.get("g.axis.yr").should("not.exist");
+    });
+  });
+
   it("supports up to 100 series (metabase#28796)", () => {
     visitQuestionAdhoc({
       display: "bar",

--- a/e2e/test/scenarios/visualizations/line_chart.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/line_chart.cy.spec.js
@@ -10,7 +10,8 @@ import {
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 
-const { ORDERS, ORDERS_ID, PRODUCTS, PRODUCTS_ID } = SAMPLE_DATABASE;
+const { ORDERS, ORDERS_ID, PRODUCTS, PRODUCTS_ID, PEOPLE, PEOPLE_ID } =
+  SAMPLE_DATABASE;
 
 const Y_AXIS_RIGHT_SELECTOR = ".axis.yr";
 
@@ -199,6 +200,99 @@ describe("scenarios > visualizations > line chart", () => {
     });
 
     cy.get(`.sub._0`).find("circle").should("have.length", 2);
+  });
+
+  describe("y-axis splitting (metabase#12939)", () => {
+    it("should not split the y-axis when columns are of the same semantic_type and have close values", () => {
+      visitQuestionAdhoc({
+        dataset_query: {
+          type: "query",
+          query: {
+            "source-table": ORDERS_ID,
+            aggregation: [
+              ["avg", ["field", ORDERS.TOTAL, null]],
+              ["min", ["field", ORDERS.TOTAL, null]],
+            ],
+            breakout: [
+              ["field", ORDERS.CREATED_AT, { "temporal-unit": "month" }],
+            ],
+          },
+          database: SAMPLE_DB_ID,
+        },
+        display: "line",
+      });
+
+      cy.get("g.axis.yr").should("not.exist");
+    });
+
+    it("should split the y-axis when columns are of different semantic_type", () => {
+      visitQuestionAdhoc({
+        dataset_query: {
+          type: "query",
+          query: {
+            "source-table": PEOPLE_ID,
+            aggregation: [
+              ["avg", ["field", PEOPLE.LATITUDE, null]],
+              ["avg", ["field", PEOPLE.LONGITUDE, null]],
+            ],
+            breakout: [
+              ["field", PEOPLE.CREATED_AT, { "temporal-unit": "month" }],
+            ],
+          },
+          database: SAMPLE_DB_ID,
+        },
+        display: "line",
+      });
+
+      cy.get("g.axis.yr").should("be.visible");
+    });
+
+    it("should split the y-six when columns are of the same semantic_type but have far values", () => {
+      visitQuestionAdhoc({
+        dataset_query: {
+          type: "query",
+          query: {
+            "source-table": ORDERS_ID,
+            aggregation: [
+              ["sum", ["field", ORDERS.TOTAL, null]],
+              ["min", ["field", ORDERS.TOTAL, null]],
+            ],
+            breakout: [
+              ["field", ORDERS.CREATED_AT, { "temporal-unit": "month" }],
+            ],
+          },
+          database: SAMPLE_DB_ID,
+        },
+        display: "line",
+      });
+
+      cy.get("g.axis.yr").should("be.visible");
+    });
+
+    it("should not split the y-axis when the setting is disabled", () => {
+      visitQuestionAdhoc({
+        dataset_query: {
+          type: "query",
+          query: {
+            "source-table": ORDERS_ID,
+            aggregation: [
+              ["sum", ["field", ORDERS.TOTAL, null]],
+              ["min", ["field", ORDERS.TOTAL, null]],
+            ],
+            breakout: [
+              ["field", ORDERS.CREATED_AT, { "temporal-unit": "month" }],
+            ],
+          },
+          database: SAMPLE_DB_ID,
+        },
+        display: "line",
+        visualization_settings: {
+          "graph.y_axis.auto_split": false,
+        },
+      });
+
+      cy.get("g.axis.yr").should("not.exist");
+    });
   });
 
   describe("tooltip of combined dashboard cards (multi-series) should show the correct column title (metabase#16249", () => {

--- a/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
+++ b/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
@@ -59,6 +59,7 @@ import {
   isMultiCardSeries,
   hasClickBehavior,
   replaceNullValuesForOrdinal,
+  shouldSplitYAxis,
 } from "./renderer_utils";
 
 import lineAndBarOnRender from "./LineAreaBarPostRender";
@@ -290,15 +291,12 @@ function getYAxisSplit(
     }
   }
 
-  // don't auto-split if the metric columns are all identical, i.e. it's a breakout multiseries
-  const hasDifferentYAxisColumns =
-    _.uniq(series.map(s => JSON.stringify(s.data.cols[1]))).length > 1;
   if (
-    !isScalarSeries &&
-    chartType !== "scatter" &&
-    !isStacked(settings, datas) &&
-    hasDifferentYAxisColumns &&
-    settings["graph.y_axis.auto_split"] !== false
+    shouldSplitYAxis(
+      { settings, chartType, isScalarSeries, series },
+      datas,
+      yExtents,
+    )
   ) {
     // NOTE: this version computes the split after assigning fixed left/right
     // which causes other series to move around when changing the setting

--- a/frontend/src/metabase/visualizations/lib/renderer_utils.js
+++ b/frontend/src/metabase/visualizations/lib/renderer_utils.js
@@ -372,11 +372,7 @@ export function shouldSplitYAxis(
     return true;
   }
 
-  const columnSettings = series.map(s =>
-    normalizeLineAreaBarSettings(
-      settings.column_settings[getColumnSettingsKey(s)],
-    ),
-  );
+  const columnSettings = series.map(s => normalizeColumnSettings(settings, s));
   const hasDifferentColumnSettings = columnSettings.some(s1 =>
     columnSettings.some(s2 => !_.isEqual(s1, s2)),
   );
@@ -394,28 +390,15 @@ export function shouldSplitYAxis(
   return minRange / chartRange <= 0.05;
 }
 
-function getColumnSettingsKey(series) {
-  return JSON.stringify(["name", series.data.cols[1].name]);
-}
+function normalizeColumnSettings(settings, series) {
+  const colSettings = { ...settings.column(series.data.cols[1]) };
+  delete colSettings._column_title_full;
+  delete colSettings._numberFormatter;
+  delete colSettings.column;
+  delete colSettings.prefix;
+  delete colSettings.suffix;
 
-function normalizeLineAreaBarSettings(colSettings) {
-  const defaultSettings = {
-    number_style: "decimal",
-    number_separators: ".,",
-    currency: "USD",
-    currency_style: "symbol",
-    prefix: "",
-    suffix: "",
-  };
-
-  if (colSettings === undefined) {
-    return defaultSettings;
-  }
-  if (colSettings.number_style !== "currency") {
-    delete colSettings.currency;
-    delete colSettings.currency_style;
-  }
-  return { ...defaultSettings, ...colSettings };
+  return colSettings;
 }
 
 /************************************************************ PROPERTIES ************************************************************/

--- a/frontend/src/metabase/visualizations/lib/renderer_utils.js
+++ b/frontend/src/metabase/visualizations/lib/renderer_utils.js
@@ -352,6 +352,37 @@ export function xValueForWaterfallTotal({ settings, series }) {
   return TOTAL_ORDINAL_VALUE;
 }
 
+export function shouldSplitYAxis(
+  { settings, chartType, isScalarSeries, series },
+  datas,
+  yExtents,
+) {
+  if (
+    isScalarSeries ||
+    chartType === "scatter" ||
+    settings["graph.y_axis.auto_split"] === false ||
+    isStacked(settings, datas)
+  ) {
+    return false;
+  }
+
+  const hasDifferentYAxisColTypes =
+    _.uniq(series.map(s => s.data.cols[1].semantic_type)).length > 1;
+  if (hasDifferentYAxisColTypes) {
+    return true;
+  }
+
+  // Note (EmmadUsmani): For charts where the series have the same `semantic_type`
+  // for their y-axis columns, we still want to split the axis if one series has a
+  // disproportionately large range of values compared to another.
+  const minRange = Math.min(...yExtents.map(extent => extent[1] - extent[0]));
+  const maxExtent = Math.max(...yExtents.map(extent => extent[1]));
+  const minExtent = Math.min(...yExtents.map(extent => extent[0]));
+  const chartRange = maxExtent - minExtent;
+
+  return chartRange >= 10 * minRange;
+}
+
 /************************************************************ PROPERTIES ************************************************************/
 
 export const isTimeseries = settings =>

--- a/frontend/src/metabase/visualizations/lib/renderer_utils.js
+++ b/frontend/src/metabase/visualizations/lib/renderer_utils.js
@@ -22,6 +22,7 @@ import { computeNumericDataInverval, dimensionIsNumeric } from "./numeric";
 
 import { getAvailableCanvasWidth, getAvailableCanvasHeight } from "./utils";
 import { invalidDateWarning, nullDimensionWarning } from "./warnings";
+import { getLineAreaBarComparisonSettings } from "./settings";
 
 export function initChart(chart, element) {
   // set the bounds
@@ -372,7 +373,9 @@ export function shouldSplitYAxis(
     return true;
   }
 
-  const columnSettings = series.map(s => normalizeColumnSettings(settings, s));
+  const columnSettings = series.map(s =>
+    getLineAreaBarComparisonSettings(settings.column(s.data.cols[1])),
+  );
   const hasDifferentColumnSettings = columnSettings.some(s1 =>
     columnSettings.some(s2 => !_.isEqual(s1, s2)),
   );
@@ -388,17 +391,6 @@ export function shouldSplitYAxis(
   // Note (EmmadUsmani): When the series with the smallest range is less than 5%
   // of the chart's total range, we split the y-axis so it doesn't look too small.
   return minRange / chartRange <= 0.05;
-}
-
-function normalizeColumnSettings(settings, series) {
-  const colSettings = { ...settings.column(series.data.cols[1]) };
-  delete colSettings._column_title_full;
-  delete colSettings._numberFormatter;
-  delete colSettings.column;
-  delete colSettings.prefix;
-  delete colSettings.suffix;
-
-  return colSettings;
 }
 
 /************************************************************ PROPERTIES ************************************************************/

--- a/frontend/src/metabase/visualizations/lib/settings.js
+++ b/frontend/src/metabase/visualizations/lib/settings.js
@@ -1,6 +1,7 @@
 /* eslint-disable react/prop-types */
 import { getIn } from "icepick";
 
+import _ from "underscore";
 import ChartSettingInput from "metabase/visualizations/components/settings/ChartSettingInput";
 import ChartSettingInputGroup from "metabase/visualizations/components/settings/ChartSettingInputGroup";
 import ChartSettingInputNumeric from "metabase/visualizations/components/settings/ChartSettingInputNumeric";
@@ -275,4 +276,27 @@ function getColumnClickBehavior(columnSettings) {
         },
       };
     }, null);
+}
+
+const KEYS_TO_COMPARE = new Set([
+  "number_style",
+  "currency",
+  "currency_style",
+  "number_separators",
+  "decimals",
+  "scale",
+  "prefix",
+  "suffix",
+]);
+
+export function getLineAreaBarComparisonSettings(columnSettings) {
+  return _.pick(columnSettings, (value, key) => {
+    if (!KEYS_TO_COMPARE.has(key)) {
+      return false;
+    }
+    if ((key === "prefix" || key === "suffix") && value === "") {
+      return false;
+    }
+    return true;
+  });
 }


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/12939

### Description

Our previous logic for determining when to split the y-axis for the `Split y-axis when necessary` setting (which is enabled by default) was nonsensically aggressive. It essentially always split the y-axis whenever the different series in a visualization had different columns for their y-axis (see code in [`LineAreaBarRenderer.js`](https://github.com/metabase/metabase/blob/26656c26ad10ed3581eb40cd682ab37cd7e612c6/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js#L300)), which for most multi-series charts is the case.

The new logic introduced in this PR is more nuanced. While keeping the existing preliminary checks (scalar series, stacked, scatter chart, setting disabled), we replaced the aggressive `hasDifferentYAxisColumns` with three new checks:

1. The semantic types of the columns are different. When series have different units on the y-axes, we should split the axis.
2. Column settings are different. If the column settings are different that means the way we want to format the labels for each column differ, so we should show multiple axes.
3. The smallest range on the chart is ≤5% of the chart's total range. This is to prevent any one series from becoming too small and unreadable.

### How to verify

1. New question -> Orders, Average of Total and Average of Subtotal, Grouped by Product → Category
2. Visualize with bars
3. By default, y-axis should not be split (before it was)
4. Try changing any column settings (e.g. currency formatting), it now should be split
5. Try stacking the bars, y-axis should not be split
6. Deselect "Split y-axis when necessary", y-axis should not be split
7. Try another question with a larger range of values, e.g. Orders, Sum of Total and Minimum of Total, Grouped by Created At (month), y-axis should be split by default

### Demo

<img width="1858" alt="Screenshot 2023-03-15 at 3 47 17 PM" src="https://user-images.githubusercontent.com/37751258/225466825-da4d21a6-b610-4f8f-854a-a55937d1b90a.png">
Before, many of these charts (top left, bottom left, bottom right) have their y-axes split in places where it really isn't necessary, making the data look very skewed.

<img width="1859" alt="Screenshot 2023-03-15 at 3 37 07 PM" src="https://user-images.githubusercontent.com/37751258/225466927-9aa5bbc5-4bee-4f34-a64f-9ff58f2653e2.png">
After, those three no longer have their y-axes split, while the ones that needed it still do.

https://user-images.githubusercontent.com/37751258/225459283-31666bf0-0669-4f1b-bc94-8665981f6c30.mov

### Checklist

- ✅ Tests have been added/updated to cover changes in this PR
