### PR TITLE
Git-ignore the new Malli types directory for clj-kondo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,4 +87,4 @@ dev/src/dev/nocommit/
 .calva/
 
 # malli + clj-kondo: ignore malli-types
-.clj-kondo/metosin/malli-types
+.clj-kondo/metosin/malli-types-clj


### PR DESCRIPTION
Malli renamed it from `malli-types` to `malli-types-clj`.

I removed `malli-types` from .gitignore since keeping it around [causes this bug](https://github.com/metosin/malli/issues/865).