### PR TITLE
[E2E] Allow custom browser for Cypress database snapshot generation

### DIFF
--- a/e2e/runner/cypress-runner-generate-snapshots.js
+++ b/e2e/runner/cypress-runner-generate-snapshots.js
@@ -1,5 +1,7 @@
 const cypress = require("cypress");
 
+const { parseArguments, args } = require("./cypress-runner-utils");
+
 const getConfig = baseUrl => {
   return {
     browser: "chrome",
@@ -11,7 +13,14 @@ const getConfig = baseUrl => {
 };
 
 const generateSnapshots = async (baseUrl, exitFunction) => {
-  const snapshotConfig = getConfig(baseUrl);
+  // We only ever care about a broswer out of all possible user arguments,
+  // when it comes to the snapshot generation.
+  // Anything else could result either in a failure or in a wrong database snapshot!
+  const { browser } = await parseArguments(args);
+  const customBrowser = browser ? { browser } : null;
+
+  const baseConfig = getConfig(baseUrl);
+  const snapshotConfig = Object.assign({}, baseConfig, customBrowser);
 
   try {
     const { status, message, totalFailed, failures } = await cypress.run(

--- a/e2e/runner/cypress-runner-run-tests.js
+++ b/e2e/runner/cypress-runner-run-tests.js
@@ -1,7 +1,10 @@
 const cypress = require("cypress");
 const arg = require("arg");
 
-const { executeYarnCommand } = require("./cypress-runner-utils");
+const {
+  executeYarnCommand,
+  parseArguments,
+} = require("./cypress-runner-utils");
 
 const args = arg(
   {
@@ -15,21 +18,6 @@ const folder = args["--folder"];
 const isFolder = !!folder;
 
 const isOpenMode = args["--open"];
-
-const parseArguments = async () => {
-  const cliArgs = args._;
-
-  // cypress.cli.parseArguments requires `cypress run` as the first two arguments
-  if (cliArgs[0] !== "cypress") {
-    cliArgs.unshift("cypress");
-  }
-
-  if (cliArgs[1] !== "run") {
-    cliArgs.splice(1, 0, "run");
-  }
-
-  return await cypress.cli.parseRunArguments(cliArgs);
-};
 
 const getSourceFolder = folder => {
   return `./e2e/test/scenarios/${folder}/**/*.cy.spec.js`;
@@ -50,7 +38,7 @@ const runCypress = async (baseUrl, exitFunction) => {
     spec: isFolder && getSourceFolder(folder),
   };
 
-  const userArgs = await parseArguments();
+  const userArgs = await parseArguments(args);
 
   const finalConfig = Object.assign({}, defaultConfig, userArgs);
 

--- a/e2e/runner/cypress-runner-run-tests.js
+++ b/e2e/runner/cypress-runner-run-tests.js
@@ -1,18 +1,10 @@
 const cypress = require("cypress");
-const arg = require("arg");
 
 const {
   executeYarnCommand,
   parseArguments,
+  args,
 } = require("./cypress-runner-utils");
-
-const args = arg(
-  {
-    "--folder": String, // The name of the folder to run files from
-    "--open": [Boolean], // Run Cypress in open mode or not? Doesn't accept additional arguments
-  },
-  { permissive: true }, // Passes all other flags and args to the Cypress parser
-);
 
 const folder = args["--folder"];
 const isFolder = !!folder;

--- a/e2e/runner/cypress-runner-utils.js
+++ b/e2e/runner/cypress-runner-utils.js
@@ -1,4 +1,5 @@
 const { exec } = require("child_process");
+const arg = require("arg");
 const chalk = require("chalk");
 const cypress = require("cypress");
 
@@ -31,10 +32,16 @@ function executeYarnCommand({ command, message } = {}) {
   });
 }
 
+const args = arg(
+  {
+    "--folder": String, // The name of the folder to run files from
+    "--open": [Boolean], // Run Cypress in open mode or not? Doesn't accept additional arguments
+  },
+  { permissive: true }, // Passes all other flags and args to the Cypress parser
+);
+
 async function parseArguments(args) {
   const cliArgs = args._;
-  console.log("cliArgs");
-  console.log(cliArgs);
 
   // cypress.cli.parseArguments requires `cypress run` as the first two arguments
   if (cliArgs[0] !== "cypress") {
@@ -54,4 +61,5 @@ module.exports = {
   printCyan,
   executeYarnCommand,
   parseArguments,
+  args,
 };

--- a/e2e/runner/cypress-runner-utils.js
+++ b/e2e/runner/cypress-runner-utils.js
@@ -1,5 +1,6 @@
 const { exec } = require("child_process");
 const chalk = require("chalk");
+const cypress = require("cypress");
 
 function printBold(message) {
   console.log(chalk.bold(message));
@@ -30,9 +31,27 @@ function executeYarnCommand({ command, message } = {}) {
   });
 }
 
+async function parseArguments(args) {
+  const cliArgs = args._;
+  console.log("cliArgs");
+  console.log(cliArgs);
+
+  // cypress.cli.parseArguments requires `cypress run` as the first two arguments
+  if (cliArgs[0] !== "cypress") {
+    cliArgs.unshift("cypress");
+  }
+
+  if (cliArgs[1] !== "run") {
+    cliArgs.splice(1, 0, "run");
+  }
+
+  return await cypress.cli.parseRunArguments(cliArgs);
+}
+
 module.exports = {
   printBold,
   printYellow,
   printCyan,
   executeYarnCommand,
+  parseArguments,
 };


### PR DESCRIPTION
@cam ran into an issue when trying to run Cypress locally (on WSL) without Chrome installed.

Due to a convoluted way we run Cypress (and the fact that we both generate custom database snapshots and run Cypress tests afterwards), snapshots part didn't handle user custom CLI input.

This PR fixes that.

Unfortunately, this fix possibly made things a tiny bit more convoluted.
We need to parse all user arguments for snapshots and then to only extract the `browser` flag (if it exists).

Unless we separate how we run snapshots from how we run the main Cypress tests in the future, we're bound to have some duplication.