### PR TITLE
Fix filtering not working for newly created models in the QB

### DIFF
--- a/e2e/test/scenarios/models/reproductions/28971-filters-model-new-model.cy.spec.js
+++ b/e2e/test/scenarios/models/reproductions/28971-filters-model-new-model.cy.spec.js
@@ -1,0 +1,38 @@
+import {
+  filter,
+  filterField,
+  filterFieldPopover,
+  modal,
+  popover,
+  restore,
+} from "e2e/support/helpers";
+
+describe("issue 28971", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsNormalUser();
+    cy.intercept("POST", "/api/card").as("createCard");
+    cy.intercept("POST", "/api/dataset").as("dataset");
+  });
+
+  it("should be able to filter a newly created model (metabase#28971)", () => {
+    cy.visit("/");
+
+    cy.findByText("New").click();
+    popover().within(() => cy.findByText("Model").click());
+    cy.findByText("Use the notebook editor").click();
+    popover().within(() => cy.findByText("Sample Database").click());
+    popover().within(() => cy.findByText("Orders").click());
+    cy.button("Save").click();
+    modal().within(() => cy.button("Save").click());
+    cy.wait("@createCard");
+
+    filter();
+    filterField("Quantity", { operator: "equal to" });
+    filterFieldPopover("Quantity").within(() => cy.findByText("20").click());
+    cy.button("Apply Filters").click();
+    cy.wait("@dataset");
+    cy.findByText("Quantity is equal to 20").should("exist");
+    cy.findByText("Showing 4 rows").should("exist");
+  });
+});

--- a/frontend/src/metabase/query_builder/actions/core/core.js
+++ b/frontend/src/metabase/query_builder/actions/core/core.js
@@ -213,6 +213,9 @@ export const apiCreateQuestion = question => {
     const card = createdQuestion.lockDisplay().card();
 
     dispatch.action(API_CREATE_QUESTION, card);
+
+    const metadataOptions = { reload: createdQuestion.isDataset() };
+    await dispatch(loadMetadataForCard(card, metadataOptions));
   };
 };
 


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/28971
Reproduces https://github.com/metabase/metabase/issues/28971

How to verify:
- New -> Model -> Notebook -> Orders -> Save
- Immediately after saving, click Filter
- Set a filter and apply
- The model should be filtered

<img width="449" alt="Screenshot 2023-03-16 at 16 47 25" src="https://user-images.githubusercontent.com/8542534/225654513-54410e76-293d-4b4b-8bcc-2b6acd73e4c7.png">

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/29278)
<!-- Reviewable:end -->
