### PR TITLE
Change action menu to drill-through menu

### DIFF
--- a/e2e/test/scenarios/collections/permissions.cy.spec.js
+++ b/e2e/test/scenarios/collections/permissions.cy.spec.js
@@ -282,7 +282,7 @@ describe("collection permissions", () => {
                     cy.icon("lock").should("not.exist");
                     /**
                      *  We can take 2 routes from here - it will really depend on the design decision:
-                     *    1. Edit icon shouldn't exist at all in which case some other call to action menu/button should exist
+                     *    1. Edit icon shouldn't exist at all in which case some other call to drill-through menu/button should exist
                      *       notifying the user that this collection is archived and prompting them to unarchive it
                      *    2. Edit icon stays but with "Unarchive this item" ONLY in the menu
                      */

--- a/e2e/test/scenarios/visualizations/maps.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/maps.cy.spec.js
@@ -113,7 +113,7 @@ describe("scenarios > visualizations > maps", () => {
     cy.findByText("State:"); // column name key
     cy.findByText("Texas"); // feature name as value
 
-    // open actions menu and drill within it
+    // open drill-through menu and drill within it
     cy.get("@texas").click();
     cy.findByText(/View these People/i).click();
 

--- a/e2e/test/scenarios/visualizations/pivot_tables.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/pivot_tables.cy.spec.js
@@ -84,7 +84,7 @@ describe("scenarios > visualizations > pivot tables", () => {
 
   it("should allow drill through on cells", () => {
     createAndVisitTestQuestion();
-    // open actions menu
+    // open drill-through menu
     cy.findByText("783").click();
     // drill through to orders list
     cy.findByText("View these Orders").click();
@@ -97,7 +97,7 @@ describe("scenarios > visualizations > pivot tables", () => {
 
   it("should allow drill through on left/top header values", () => {
     createAndVisitTestQuestion();
-    // open actions menu and filter to that value
+    // open drill-through menu and filter to that value
     cy.findByText("Doohickey").click();
     popover().within(() => cy.findByText("=").click());
     // filter is applied
@@ -489,7 +489,7 @@ describe("scenarios > visualizations > pivot tables", () => {
 
     it("should allow filtering drill through (metabase#14632)", () => {
       assertOnPivotFields();
-      cy.findByText("Google").click(); // open actions menu
+      cy.findByText("Google").click(); // open drill-through menu
       popover().within(() => cy.findByText("=").click()); // drill with additional filter
       cy.findByText("Source is Google"); // filter was added
       cy.findByText("Row totals"); // it's still a pivot table

--- a/frontend/src/metabase-lib/parameters/utils/click-behavior.js
+++ b/frontend/src/metabase-lib/parameters/utils/click-behavior.js
@@ -197,7 +197,7 @@ function baseTypeFilterForParameterType(parameterType) {
 }
 
 export function clickBehaviorIsValid(clickBehavior) {
-  // opens action menu
+  // opens drill-through menu
   if (clickBehavior == null) {
     return true;
   }

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/TableClickBehaviorView/TableClickBehaviorView.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/TableClickBehaviorView/TableClickBehaviorView.tsx
@@ -25,7 +25,7 @@ function explainClickBehaviorType(
   return {
     action: t`Execute an action`,
     actionMenu: hasActionsMenu(dashcard)
-      ? t`Open the actions menu`
+      ? t`Open the drill-through menu`
       : t`Do nothing`,
     crossfilter: t`Update a dashboard filter`,
     link: t`Go to custom destination`,

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/utils.ts
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/utils.ts
@@ -26,7 +26,7 @@ export function getClickBehaviorOptionName(
 ) {
   if (value === "menu") {
     return hasActionsMenu(dashcard)
-      ? t`Open the Metabase actions menu`
+      ? t`Open the Metabase drill-through menu`
       : t`Do nothing`;
   }
   if (value === "link") {

--- a/frontend/src/metabase/lib/click-behavior.js
+++ b/frontend/src/metabase/lib/click-behavior.js
@@ -4,7 +4,7 @@ import Question from "metabase-lib/Question";
 
 export function getClickBehaviorDescription(dashcard) {
   const noBehaviorMessage = hasActionsMenu(dashcard)
-    ? t`Open the action menu`
+    ? t`Open the drill-through menu`
     : t`Do nothing`;
   if (isTableDisplay(dashcard)) {
     const count = Object.values(


### PR DESCRIPTION
Changes in-product mentions of Actions menu to Drill-through menu, to distinguish it from the new actions feature.

This PR only address the in-product text; it leaves code with references to the actions menu alone. We can clean that up later if necessary.

We'll address docs updates in a separate PR once this is merged.