### PR TITLE
revert centering of undo toast

### DIFF
--- a/frontend/src/metabase/containers/UndoListing.jsx
+++ b/frontend/src/metabase/containers/UndoListing.jsx
@@ -9,7 +9,6 @@ import { dismissUndo, performUndo } from "metabase/redux/undo";
 
 import BodyComponent from "metabase/components/BodyComponent";
 
-import { getIsNavbarOpen } from "metabase/redux/app";
 import {
   CardContent,
   CardContentSide,
@@ -88,10 +87,9 @@ function UndoToast({ undo, onUndo, onDismiss }) {
 function UndoListingInner() {
   const dispatch = useDispatch();
   const undos = useSelector(state => state.undo);
-  const isNavbarOpen = useSelector(getIsNavbarOpen);
 
   return (
-    <UndoList isNavbarOpen={isNavbarOpen}>
+    <UndoList>
       {undos.map(undo => (
         <UndoToast
           key={undo._domId}

--- a/frontend/src/metabase/containers/UndoListing.styled.tsx
+++ b/frontend/src/metabase/containers/UndoListing.styled.tsx
@@ -3,17 +3,13 @@ import Card from "metabase/components/Card";
 import Icon from "metabase/components/Icon";
 import Link from "metabase/core/components/Link";
 import { alpha, color, lighten } from "metabase/lib/colors";
-import { NAV_SIDEBAR_WIDTH } from "metabase/nav/constants";
 import { space } from "metabase/styled-components/theme";
 
-export const UndoList = styled.ul<{ isNavbarOpen: boolean }>`
+export const UndoList = styled.ul`
   position: fixed;
-  left: 50%;
-  transform: translateX(-50%);
+  left: 0;
   bottom: 0;
-  margin-left: ${props =>
-    props.isNavbarOpen ? `${parseInt(NAV_SIDEBAR_WIDTH) / 2}px` : 0};
-  margin-bottom: ${space(2)};
+  margin: ${space(2)};
   z-index: 999;
 `;
 


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/29235

### Description

After [discussion with the design team on slack](https://metaboat.slack.com/archives/C02H619CJ8K/p1678887464173259), we decided to revert the change we made in https://github.com/metabase/metabase/pull/28807 that centered the undo toast.

### How to verify

1. Go to any dashboard you have edit access on
2. Edit, remove a card
3. Undo toast should be in bottom left corner of screen

### Demo

https://user-images.githubusercontent.com/37751258/225727809-9393669d-0733-4e0c-9a4a-7e56b5abfc0c.mov

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR

Not sure how to test a CSS change 🤔
