### PR TITLE
Drop "Run" word from action modal title and action button

### DIFF
--- a/e2e/test/scenarios/dashboard/actions-on-dashboards.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/actions-on-dashboards.cy.spec.js
@@ -58,6 +58,8 @@ const MODEL_NAME = "Test Action Model";
         });
 
         it("adds a custom query action to a dashboard and runs it", () => {
+          const ACTION_NAME = "Update Score";
+
           queryWritableDB(
             `SELECT * FROM ${TEST_TABLE} WHERE id = 1`,
             dialect,
@@ -90,14 +92,13 @@ const MODEL_NAME = "Test Action Model";
             cy.findByText("Save").click();
           });
 
-
           cy.findByPlaceholderText("My new fantastic action").type(
-            "Update Score",
+            ACTION_NAME
           );
           cy.findByText("Create").click();
 
           createDashboardWithActionButton({
-            actionName: "Update Score",
+            actionName: ACTION_NAME,
             idFilter: true,
           });
 
@@ -108,7 +109,7 @@ const MODEL_NAME = "Test Action Model";
 
           cy.findByRole("dialog").within(() => {
             cy.findByLabelText("New score").type("55");
-            cy.button("Run").click();
+            cy.button(ACTION_NAME).click();
           });
 
           cy.wait("@executeAPI");

--- a/e2e/test/scenarios/models/model-actions.cy.spec.js
+++ b/e2e/test/scenarios/models/model-actions.cy.spec.js
@@ -207,7 +207,7 @@ describe(
 
       modal().within(() => {
         cy.findByLabelText(TEST_PARAMETER.name).type("1");
-        cy.button("Run").click();
+        cy.button(SAMPLE_QUERY_ACTION.name).click();
       });
 
       cy.findByText(`${SAMPLE_QUERY_ACTION.name} ran successfully`).should(
@@ -245,12 +245,12 @@ describe(
       cy.get("@queryActionPublicUrl").then(url => {
         cy.visit(url);
         cy.findByLabelText(TEST_PARAMETER.name).type("1");
-        cy.findByRole("button", { name: "Submit" }).click();
+        cy.button(SAMPLE_QUERY_ACTION.name).click();
         cy.findByText(`${SAMPLE_QUERY_ACTION.name} ran successfully`).should(
           "be.visible",
         );
         cy.findByRole("form").should("not.exist");
-        cy.findByRole("button", { name: "Submit" }).should("not.exist");
+        cy.button(SAMPLE_QUERY_ACTION.name).should("not.exist");
       });
 
       cy.get("@implicitActionPublicUrl").then(url => {
@@ -260,12 +260,12 @@ describe(
         cy.findByLabelText("Id").type("1");
         cy.findByLabelText(/quantity/i).type("2");
 
-        cy.findByRole("button", { name: "Submit" }).click();
+        cy.button(IMPLICIT_ACTION_NAME).click();
         cy.findByText(`${IMPLICIT_ACTION_NAME} ran successfully`).should(
           "be.visible",
         );
         cy.findByRole("form").should("not.exist");
-        cy.findByRole("button", { name: "Submit" }).should("not.exist");
+        cy.button(IMPLICIT_ACTION_NAME).should("not.exist");
       });
 
       cy.signInAsAdmin();
@@ -280,14 +280,14 @@ describe(
       cy.get("@queryActionPublicUrl").then(url => {
         cy.visit(url);
         cy.findByRole("form").should("not.exist");
-        cy.findByRole("button", { name: "Submit" }).should("not.exist");
+        cy.button(SAMPLE_QUERY_ACTION.name).should("not.exist");
         cy.findByText("Not found").should("be.visible");
       });
 
       cy.get("@implicitActionPublicUrl").then(url => {
         cy.visit(url);
         cy.findByRole("form").should("not.exist");
-        cy.findByRole("button", { name: "Submit" }).should("not.exist");
+        cy.button(IMPLICIT_ACTION_NAME).should("not.exist");
         cy.findByText("Not found").should("be.visible");
       });
     });

--- a/frontend/src/metabase/actions/components/ActionViz/Action.unit.spec.tsx
+++ b/frontend/src/metabase/actions/components/ActionViz/Action.unit.spec.tsx
@@ -255,7 +255,9 @@ describe("Actions > ActionViz > Action", () => {
     it("should render the action name as the form title", async () => {
       await setup({ settings: formSettings });
 
-      expect(screen.getByText("My Awesome Action")).toBeInTheDocument();
+      expect(
+        screen.getByRole("heading", { name: "My Awesome Action" }),
+      ).toBeInTheDocument();
     });
 
     it("should only show form fields with no provided values from dashboard filters", async () => {
@@ -300,7 +302,7 @@ describe("Actions > ActionViz > Action", () => {
         expect(screen.getByLabelText("Parameter 2")).toHaveValue(5),
       );
 
-      userEvent.click(screen.getByRole("button", { name: "Run" }));
+      userEvent.click(screen.getByRole("button", { name: ACTION.name }));
 
       await waitFor(async () => {
         const call = fetchMock.lastCall(ACTION_EXEC_MOCK_PATH);
@@ -327,7 +329,7 @@ describe("Actions > ActionViz > Action", () => {
         expect(screen.getByLabelText("Parameter 1")).toHaveValue("foo"),
       );
 
-      userEvent.click(screen.getByRole("button", { name: "Run" }));
+      userEvent.click(screen.getByRole("button", { name: ACTION.name }));
 
       await waitFor(async () => {
         const call = fetchMock.lastCall(ACTION_EXEC_MOCK_PATH);

--- a/frontend/src/metabase/actions/containers/ActionExecuteModal/ActionExecuteModal.tsx
+++ b/frontend/src/metabase/actions/containers/ActionExecuteModal/ActionExecuteModal.tsx
@@ -1,5 +1,4 @@
 import React, { useCallback } from "react";
-import { t } from "ttag";
 import { connect } from "react-redux";
 import _ from "underscore";
 import Actions from "metabase/entities/actions";
@@ -35,17 +34,15 @@ const ActionExecuteModal = ({
   onSubmit,
   onClose,
 }: ActionExecuteModalProps) => {
-  const title =
-    action.parameters.length > 0 ? action.name : t`Run ${action.name}?`;
-
   const handleSubmit = useCallback(
     (parameters: ParametersForActionExecution) => {
       return onSubmit({ action, parameters });
     },
     [action, onSubmit],
   );
+
   return (
-    <ModalContent title={title} onClose={onClose}>
+    <ModalContent title={action.name} onClose={onClose}>
       <ActionParametersInputForm
         action={action}
         onCancel={onClose}

--- a/frontend/src/metabase/actions/containers/ActionParametersInputForm/ActionParametersInputForm.unit.spec.tsx
+++ b/frontend/src/metabase/actions/containers/ActionParametersInputForm/ActionParametersInputForm.unit.spec.tsx
@@ -16,6 +16,7 @@ import {
 import ActionParametersInputForm from "./ActionParametersInputForm";
 import ActionParametersInputModal from "./ActionParametersInputModal";
 
+const mockAction = createMockQueryAction();
 const defaultProps = {
   missingParameters: [
     createMockActionParameter({
@@ -28,7 +29,7 @@ const defaultProps = {
     }),
   ],
   dashcardParamValues: {},
-  action: createMockQueryAction(),
+  action: mockAction,
   dashboard: createMockDashboard({ id: 123 }),
   dashcard: createMockDashboard({ id: 456 }),
   onSubmit: jest.fn(() => ({ success: true })),
@@ -89,7 +90,7 @@ describe("Actions > ActionParametersInputForm", () => {
       expect(screen.getByLabelText("Parameter 2")).toHaveValue("dos"),
     );
 
-    userEvent.click(screen.getByText("Run"));
+    userEvent.click(screen.getByText(mockAction.name));
 
     await waitFor(() => {
       expect(submitSpy).toHaveBeenCalledWith({

--- a/frontend/src/metabase/actions/utils.ts
+++ b/frontend/src/metabase/actions/utils.ts
@@ -432,5 +432,5 @@ export const getSubmitButtonLabel = (action: WritebackAction): string => {
     }
   }
 
-  return t`Run`;
+  return action.name;
 };

--- a/frontend/src/metabase/public/containers/PublicAction/PublicAction.tsx
+++ b/frontend/src/metabase/public/containers/PublicAction/PublicAction.tsx
@@ -64,6 +64,7 @@ function PublicAction({ action, publicId, onError }: Props) {
     <FormContainer>
       <FormTitle>{action.name}</FormTitle>
       <ActionForm
+        submitTitle={action.name}
         parameters={action.parameters}
         formSettings={formSettings}
         onSubmit={handleSubmit}

--- a/frontend/src/metabase/public/containers/PublicAction/PublicAction.unit.spec.tsx
+++ b/frontend/src/metabase/public/containers/PublicAction/PublicAction.unit.spec.tsx
@@ -98,15 +98,21 @@ describe("PublicAction", () => {
   it("shows acton form", async () => {
     await setup();
 
-    expect(screen.getByText(TEST_ACTION.name)).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: TEST_ACTION.name }),
+    ).toBeInTheDocument();
     expect(screen.getByLabelText(SIZE_PARAMETER.name)).toBeInTheDocument();
     expect(screen.getByLabelText(COLOR_PARAMETER.name)).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Submit" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: TEST_ACTION.name }),
+    ).toBeInTheDocument();
   });
 
   it("should allow to submit a clean form if all parameters are optional", async () => {
     await setup();
-    expect(screen.getByRole("button", { name: "Submit" })).toBeEnabled();
+    expect(
+      screen.getByRole("button", { name: TEST_ACTION.name }),
+    ).toBeEnabled();
   });
 
   it("doesn't let to submit until required parameters are filled", async () => {
@@ -117,11 +123,15 @@ describe("PublicAction", () => {
     await setup({ action });
 
     userEvent.type(screen.getByLabelText("Size"), "42");
-    expect(screen.getByRole("button", { name: "Submit" })).toBeDisabled();
+    expect(
+      screen.getByRole("button", { name: TEST_ACTION.name }),
+    ).toBeDisabled();
 
     userEvent.type(screen.getByLabelText("Color"), "metablue");
     await waitFor(() =>
-      expect(screen.getByRole("button", { name: "Submit" })).toBeEnabled(),
+      expect(
+        screen.getByRole("button", { name: TEST_ACTION.name }),
+      ).toBeEnabled(),
     );
   });
 
@@ -137,7 +147,7 @@ describe("PublicAction", () => {
 
     userEvent.type(screen.getByLabelText("Size"), "42");
     userEvent.type(screen.getByLabelText("Color"), "metablue");
-    userEvent.click(screen.getByRole("button", { name: "Submit" }));
+    userEvent.click(screen.getByRole("button", { name: TEST_ACTION.name }));
 
     await waitFor(() => {
       expect(
@@ -151,7 +161,7 @@ describe("PublicAction", () => {
 
     userEvent.type(screen.getByLabelText("Size"), "42");
     userEvent.type(screen.getByLabelText("Color"), "metablue");
-    userEvent.click(screen.getByRole("button", { name: "Submit" }));
+    userEvent.click(screen.getByRole("button", { name: TEST_ACTION.name }));
 
     expect(
       await screen.findByText(`${TEST_ACTION.name} ran successfully`),
@@ -165,7 +175,7 @@ describe("PublicAction", () => {
 
     userEvent.type(screen.getByLabelText("Size"), "42");
     userEvent.type(screen.getByLabelText("Color"), "metablue");
-    userEvent.click(screen.getByRole("button", { name: "Submit" }));
+    userEvent.click(screen.getByRole("button", { name: TEST_ACTION.name }));
 
     expect(await screen.findByText("Something's off")).toBeInTheDocument();
   });
@@ -182,8 +192,10 @@ describe("PublicAction", () => {
       expectedRequestBody: { parameters: {} },
     });
 
-    expect(screen.getByText(TEST_ACTION.name)).toBeInTheDocument();
-    userEvent.click(screen.getByRole("button", { name: "Submit" }));
+    expect(
+      screen.getByRole("heading", { name: TEST_ACTION.name }),
+    ).toBeInTheDocument();
+    userEvent.click(screen.getByRole("button", { name: TEST_ACTION.name }));
     await waitFor(() =>
       expect(
         fetchMock.done(`path:/api/public/action/${TEST_PUBLIC_ID}/execute`),


### PR DESCRIPTION

Closes https://github.com/metabase/metabase/issues/29067

### Description

Drop `Run` word from the modal's title and action buttons as misleading.

We have at least 3 places where this form (together with title and button) is used:
- public form 
- dashboard -> action button
- model -> actions

### How to verify

1. Public form

Create a model -> action -> share it -> open shared action

`Submit` is replaced with the action name in button text

<img width="1536" alt="Screenshot 2023-03-17 at 23 50 22" src="https://user-images.githubusercontent.com/125459446/226045725-fa23486c-43df-4fac-8a00-869a397d4353.png">

2. Dashboard -> action button

Create a dashboard -> add action button -> link action button to the action -> click button

`Run` is replaced with the action name button in the text

<img width="1536" alt="Screenshot 2023-03-18 at 00 00 34" src="https://user-images.githubusercontent.com/125459446/226046625-468dcb50-92c5-46af-a78d-e69eb410ea96.png">

3. Model

create a model -> actions tab -> create an action -> click Run at code block

`Run` word is replaced with action name in both modal title and action button

<img width="1235" alt="Screenshot 2023-03-17 at 23 49 46" src="https://user-images.githubusercontent.com/125459446/226046874-29f47d26-8b6a-4060-9d66-be456315e5d6.png">
<img width="1159" alt="Screenshot 2023-03-17 at 23 49 37" src="https://user-images.githubusercontent.com/125459446/226046882-a11150be-acff-497d-a811-f19f48dd806a.png">


### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
