### PR TITLE
Fix hang on launch

### DIFF
--- a/src/metabase/public_settings/premium_features.clj
+++ b/src/metabase/public_settings/premium_features.clj
@@ -16,6 +16,7 @@
    [metabase.util.log :as log]
    [metabase.util.schema :as su]
    [schema.core :as schema]
+   [toucan2.connection :as t2.conn]
    [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
@@ -45,17 +46,27 @@
 
 (declare premium-embedding-token)
 
-(defn- active-users-count* []
-  {:post [(integer? %)]}
-  "Returns the number of active users."
-  (assert ((requiring-resolve 'metabase.db/db-is-set-up?)) "Metabase DB is not yet set up")
-  (t2/count :core_user :is_active true))
-
-(def ^:private cached-active-user-count
-  "Primarily used for the settings because we don't wish it to be 100%."
-  (memoize/ttl
-    active-users-count*
-    :ttl/threshold (u/minutes->ms 5)))
+;; let's prevent the DB from getting slammed with calls to `active-user-count`, we only really need one in flight at a
+;; time.
+(let [f        (fn []
+                 {:post [(integer? %)]}
+                 (log/info (u/colorize :yellow "GETTING ACTIVE USER COUNT!"))
+                 (assert ((requiring-resolve 'metabase.db/db-is-set-up?)) "Metabase DB is not yet set up")
+                 ;; force this to use a new Connection, it seems to be getting called in situations where the Connection
+                 ;; is from a different thread and is invalid by the time we get to use it
+                 (let [result (binding [t2.conn/*current-connectable* nil]
+                                (t2/count :core_user :is_active true))]
+                   (log/info (u/colorize :green "=>") result)
+                   result))
+      memoized (memoize/ttl
+                f
+                :ttl/threshold (u/minutes->ms 5))
+      lock     (Object.)]
+  (defn- cached-active-users-count
+    "Primarily used for the settings because we don't wish it to be 100%. (HUH?)"
+    []
+    (locking lock
+      (memoized))))
 
 (defsetting active-users-count
   (deferred-tru "Cached number of active users. Refresh every 5 minutes.")
@@ -65,7 +76,7 @@
   :getter     (fn []
                 (if-not ((requiring-resolve 'metabase.db/db-is-set-up?))
                  0
-                 (cached-active-user-count))))
+                 (cached-active-users-count))))
 
 (defn- token-status-url [token base-url]
   (when (seq token)
@@ -86,7 +97,7 @@
 (defn- fetch-token-and-parse-body
   [token base-url]
   (some-> (token-status-url token base-url)
-          (http/get {:query-params {:users     (active-users-count*)
+          (http/get {:query-params {:users     (cached-active-users-count)
                                     :site-uuid (setting/get :site-uuid-for-premium-features-token-checks)}})
           :body
           (json/parse-string keyword)))
@@ -143,7 +154,7 @@
                 ;; tests to fail because a timed-out token check would get cached as a result.
                 (assert ((requiring-resolve 'metabase.db/db-is-set-up?)) "Metabase DB is not yet set up")
                 (u/with-timeout (u/seconds->ms 5)
-                  (active-users-count*))
+                  (cached-active-users-count))
                 (fetch-token-status* token))
               :ttl/threshold (u/minutes->ms 5))]
     (fn [token]


### PR DESCRIPTION
Before fetching premium/EE token status, we first fetch the active user count from the DB as a sanity check, since we include that when fetching token status... this was hanging for mysterious reasons, which caused launch to take six minutes in CI.

I think the root cause of the problem was that the active user count was getting triggered **on a different thread** inside an `INSERT` of some sort (TaskHistory `after-insert` or something like that), and Toucan 2 attempted to reuse the current connection ~which by then was no longer valid~ and seemed to just hang forever. Basically

1. Insert a TaskHistory, `with-open` a `Connection` (wrapped by a c3p0 `NewProxyConnection` and bind it to `*current-connectable*` 
2. For whatever reason, trigger the features check, on a different thread. `future` here preserves the `*current-connectable*` binding
3. ~Task History insert finished doing whatever it was doing, c3p0 nukes the `NewProxyConnection` or whatever~ 
4. (on a different thread) attempt to to the `SELECT COUNT(*)` query using the `*current-connectable*`, ~bound to the nuked `NewProxyConnection`~
5. This is hanging when trying to do anything at all with it, not really sure why, but it is for sure hanging. ~You would think C3PO could detect this and tell us "YOU CAN'T OPERATE ON A CLOSED CONNECTION" or something, but it doesn't seem to be smart enough to do that.~ Root issue was the lock discussed here https://github.com/seancorfield/next-jdbc/issues/244
6. Active user count times out after 5 seconds
7. Rinse and repeat this over and over 

So the fix here is to 

1. Force `active-user-count` to use a fresh Connection regardless of whether one is currently open or not
2. Improve the caching a bit so we don't slam the DB with calls if one is already in flight, only do one call at a time.

The second part is not really needed for the fix, but I thought I might as well do it while I was at it.

I want to try to solve this problem more generally, I will dig into this more and if I can figure out what's actually going on