### PR TITLE
Fix missing summarize operations after creation of numeric custom column

### DIFF
--- a/e2e/test/scenarios/custom-column/reproductions/27745-cc-numeric-missing-summarize.cy.spec.js
+++ b/e2e/test/scenarios/custom-column/reproductions/27745-cc-numeric-missing-summarize.cy.spec.js
@@ -8,7 +8,7 @@ import {
 } from "e2e/support/helpers";
 
 ["postgres", "mysql"].forEach(dialect => {
-  describe.skip(`issue 27745 (${dialect})`, { tags: "@external" }, () => {
+  describe(`issue 27745 (${dialect})`, { tags: "@external" }, () => {
     const tableName = "colors27745";
 
     beforeEach(() => {

--- a/frontend/src/metabase-lib/metadata/Table.ts
+++ b/frontend/src/metabase-lib/metadata/Table.ts
@@ -116,7 +116,6 @@ class TableInner extends Base {
   }
 
   aggregationOperator(short) {
-    // this is the refactor as well, remove a deprecated function.
     return this.aggregationOperatorsLookup()[short];
   }
 

--- a/frontend/src/metabase-lib/metadata/Table.ts
+++ b/frontend/src/metabase-lib/metadata/Table.ts
@@ -116,12 +116,8 @@ class TableInner extends Base {
   }
 
   aggregationOperator(short) {
-    return this.aggregation_operators_lookup[short];
-  }
-
-  // @deprecated: use aggregationOperatorsLookup
-  get aggregation_operators_lookup() {
-    return this.aggregationOperatorsLookup();
+    // this is the refactor as well, remove a deprecated function.
+    return this.aggregationOperatorsLookup()[short];
   }
 
   // FIELDS

--- a/frontend/src/metabase-lib/metadata/Table.ts
+++ b/frontend/src/metabase-lib/metadata/Table.ts
@@ -108,7 +108,7 @@ class TableInner extends Base {
 
   // AGGREGATIONS
   aggregationOperators() {
-    return getAggregationOperators(this);
+    return getAggregationOperators(this, this.fields);
   }
 
   aggregationOperatorsLookup() {

--- a/frontend/src/metabase-lib/operators/utils/index.js
+++ b/frontend/src/metabase-lib/operators/utils/index.js
@@ -102,9 +102,9 @@ function populateFields(aggregationOperator, fields) {
   };
 }
 
-export function getAggregationOperators(table) {
+export function getAggregationOperators(table, fields = table.fields) {
   return getSupportedAggregationOperators(table)
-    .map(operator => populateFields(operator, table.fields))
+    .map(operator => populateFields(operator, fields))
     .filter(
       aggregation =>
         !aggregation.requiresField ||

--- a/frontend/src/metabase-lib/operators/utils/index.js
+++ b/frontend/src/metabase-lib/operators/utils/index.js
@@ -102,7 +102,7 @@ function populateFields(aggregationOperator, fields) {
   };
 }
 
-export function getAggregationOperators(table, fields = table.fields) {
+export function getAggregationOperators(table, fields) {
   return getSupportedAggregationOperators(table)
     .map(operator => populateFields(operator, fields))
     .filter(

--- a/frontend/src/metabase-lib/operators/utils/index.unit.spec.js
+++ b/frontend/src/metabase-lib/operators/utils/index.unit.spec.js
@@ -202,7 +202,7 @@ describe("metabase-lib/operators/utils", () => {
           features: ["basic-aggregations", "standard-deviation-aggregations"],
         },
       };
-      const fullOperators = getAggregationOperators(table);
+      const fullOperators = getAggregationOperators(table, fields);
       return {
         fullOperators,
         operators: fullOperators.map(operator => operator.short),

--- a/frontend/src/metabase-lib/queries/StructuredQuery.ts
+++ b/frontend/src/metabase-lib/queries/StructuredQuery.ts
@@ -679,8 +679,6 @@ class StructuredQueryInner extends AtomicQuery {
    * @returns the field options for the provided aggregation
    */
   aggregationFieldOptions(agg: string | AggregationOperator): DimensionOptions {
-    // XXX: We need to fix this function so that it takes expression (custom field) into account
-    // aggregationOperator seem to check if the aggregation would be valid for the the given table
     const aggregation: AggregationOperator =
       typeof agg === "string" ? this.aggregationOperator(agg) : agg;
 
@@ -1285,8 +1283,6 @@ class StructuredQueryInner extends AtomicQuery {
     const table = this.table();
 
     if (table) {
-      // XXX: I might need to refer to this part where `dimensionOptions` takes
-      // expressions (custom field) into account, but not the `aggregationOperators`
       const filteredNonFKDimensions = this.dimensions().filter(dimensionFilter);
 
       for (const dimension of filteredNonFKDimensions) {
@@ -1297,7 +1293,6 @@ class StructuredQueryInner extends AtomicQuery {
       // de-duplicate explicit and implicit joined tables
       const explicitJoins = this._getExplicitJoinsSet(joins);
 
-      // This is only a refactor, I moved this line down to limit the scope where this variable could be used.
       const dimensionIsFKReference = dimension => dimension.field?.().isFK();
       const fkDimensions = this.dimensions().filter(dimensionIsFKReference);
 

--- a/frontend/src/metabase-lib/queries/structured/Aggregation.ts
+++ b/frontend/src/metabase-lib/queries/structured/Aggregation.ts
@@ -157,9 +157,7 @@ export default class Aggregation extends MBQLClause {
       return this.aggregation().isValid();
     } else if (this.isStandard() && this.dimension()) {
       const dimension = this.dimension();
-      const aggregationOperator = this.query()
-        .table()
-        .aggregationOperator(this[0]);
+      const aggregationOperator = this.query().aggregationOperator(this[0]);
       return (
         aggregationOperator &&
         (!aggregationOperator.requiresField ||

--- a/frontend/src/metabase-lib/utils/create-lookup-by-property.ts
+++ b/frontend/src/metabase-lib/utils/create-lookup-by-property.ts
@@ -1,8 +1,8 @@
-export function createLookupByProperty(items: any[], property: string) {
-  const lookup: Record<string, any> = {};
+export function createLookupByProperty<T>(items: T[], property: keyof T) {
+  const lookup: Record<string, T> = {};
 
   for (const item of items) {
-    lookup[item[property]] = item;
+    lookup[item[property] as unknown as string] = item;
   }
 
   return lookup;

--- a/frontend/src/metabase/query_builder/components/AggregationPopover/AggregationPopover.jsx
+++ b/frontend/src/metabase/query_builder/components/AggregationPopover/AggregationPopover.jsx
@@ -143,11 +143,12 @@ export default class AggregationPopover extends Component {
   };
 
   _getAvailableAggregations() {
+    // XXX: This looks like the place we generate the options for the aggregation popover
     const { aggregationOperators, query, dimension, showRawData } = this.props;
     return (
       aggregationOperators ||
       dimension?.aggregationOperators() ||
-      query.table().aggregationOperators()
+      query.aggregationOperators()
     ).filter(
       aggregationOperator =>
         showRawData || aggregationOperator.short !== "rows",

--- a/frontend/src/metabase/query_builder/components/AggregationPopover/AggregationPopover.jsx
+++ b/frontend/src/metabase/query_builder/components/AggregationPopover/AggregationPopover.jsx
@@ -143,7 +143,6 @@ export default class AggregationPopover extends Component {
   };
 
   _getAvailableAggregations() {
-    // XXX: This looks like the place we generate the options for the aggregation popover
     const { aggregationOperators, query, dimension, showRawData } = this.props;
     return (
       aggregationOperators ||


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/27745

### Description

Previously, any code regarding the aggregation operators will only be called from `Table` it's fine until we have a table which doesn't have certain field types, but we introduce those field types in expressions. Since `Table`s are not aware of expressions which only exist in `StructuredQuery`. It caused the bug.

This PR address the bug by shifting calls to `aggregationOperators` and `aggregationOperator` from `Table` to `StructuredQuery` instead.

### How to verify

2 ways to test this PR.

1. Run Cypress tests in `e2e/test/scenarios/custom-column/reproductions/27745-cc-numeric-missing-summarize.cy.spec.js` and it should pass.

OR

1. Create a question based on `Orders` only select `id` and `created_at`.
2. Open the query builder, and select the saved question from the previous step as a source.
3. Click on **Summarize** button, and make sure there is no **Average of ...** option
4. Close the aggregation section
5. Add this expression `case([ID] = 1, 2, 3)` (or other expression which results in numeric field)
6. Click on **Summarize** button, and make sure there is **Average of ...** option
7. Click **Visualize** should show the result.

### Demo

#### Before (no aggregations for numeric fields)
<img width="230" alt="Screenshot 2023-03-17 at 6 53 12 PM" src="https://user-images.githubusercontent.com/1937582/225993425-879640c7-e4b9-4c5d-92eb-43653f4e3e92.png">


#### After (has aggregations for numeric fields)
<img width="258" alt="Screenshot 2023-03-17 at 6 52 50 PM" src="https://user-images.githubusercontent.com/1937582/225993404-52855401-6b1f-412d-89a5-ffa8d4afb73b.png">



### Checklist

- [X] Tests have been added/updated to cover changes in this PR (E2E + Unit)
