### PR TITLE
(Hopefully) temporary hack to work around app hanging on launch

### DIFF
--- a/bin/build.sh
+++ b/bin/build.sh
@@ -12,4 +12,4 @@ check_clojure_cli
 source "./bin/clear-outdated-cpcaches.sh"
 clear_outdated_cpcaches
 
-clojure -X:drivers:build:build/all $@
+clojure -X:drivers:build:build/all "$@"

--- a/src/metabase/db/connection.clj
+++ b/src/metabase/db/connection.clj
@@ -158,20 +158,20 @@
   java.sql.Connection
   (-transact [this body-fn opts]
     (cond
-      (or (not next.jdbc.transaction/*active-tx*)
-          (= :allow next.jdbc.transaction/*nested-tx*))
+      (or (not @#'next.jdbc.transaction/*active-tx*)
+          (= :allow @#'next.jdbc.transaction/*nested-tx*))
       (binding [next.jdbc.transaction/*active-tx* true]
         (#'next.jdbc.transaction/transact* this body-fn opts))
 
-      (= :ignore next.jdbc.transaction/*nested-tx*)
+      (= :ignore @#'next.jdbc.transaction/*nested-tx*)
       (body-fn this)
 
-      (= :prohibit next.jdbc.transaction/*nested-tx*)
+      (= :prohibit @#'next.jdbc.transaction/*nested-tx*)
       (throw (IllegalStateException. "Nested transactions are prohibited"))
 
       :else
       (throw (IllegalArgumentException.
               (str "*nested-tx* ("
-                   next.jdbc.transaction/*nested-tx*
+                   @#'next.jdbc.transaction/*nested-tx*
                    ") was not :allow, :ignore, or :prohibit"))))
     (#'next.jdbc.transaction/transact* this body-fn opts)))


### PR DESCRIPTION
Supersedes #29297

As I spent most of the day chronicling in the Slack thread https://metaboat.slack.com/archives/C010L1Z4F9S/p1678977318656679, the app is hanging on launch since we migrated from `clojure.java.jdbc` to `next.jdbc` in the previous cycle. It's running a query inside the `u/with-timeout` macro, which actually runs in a different thread; this is all happening inside of a transaction. `next.jdbc` gets a lock on the current `Connection` for the duration of the transaction, and c3p0 also tries to acquire this lock before calls to things like `.prepareStatement`, deadlocks ensue. `clojure.java.jdbc` didn't lock the Connection in the same way so this is only an issue since we switched over.

See upstream issue https://github.com/seancorfield/next-jdbc/issues/244

I don't have a clear picture yet for whether we might see this resolved upstream or if we'll have to work around it, so this is a temporary fix that should fix the CI issues and unblock the 46 release. I don't think it's a **great** fix, but it's certainly better than the app mysteriously hanging.

About the fix: this just replaces the `next.jdbc` implementation for the method underlying `with-transaction` for `java.sql.Connection` with one that is exactly the same but without the lock that is causing us so much trouble. Like I said, not a great fix.

I don't think we have any **easy** ways to fix this the right way. I think the right fix will entail one of these options:

* we could implement a Toucan 2 `:around` method or two to detect situations where we're trying to use a Connection inside a transaction in a different Thread than the one that opened it. Then we can go and clean up any places that are using `u/with-timeout`. This would be straightforward. But I think there might be some legitimate use cases where `u/with-timeout` makes sense inside of a transaction? TBD.
  * Alternatively we can just have it fetch a new connection from the connection pool if we're on a different thread, but I think that behavior is non-obvious. If you're in a transaction it's not obvious at all that wrapping something in `u/with-timeout` would take you outside the context of that transaction
* Try to make `u/with-timeout` work in some way that is less prone to breaking other things. Can we actually have this all be done on the same thread? Temporarily pass any locks we have along to the child thread? I think the answers are no and no, but there might be some sort of good solution to this problem we're overlooking
* Switch back to `clojure.java.jdbc`. Not out of the question
* Implement our own JDBC library. Also not out of the question, and not incredibly hard to do. At one point Toucan 2 was using an entirely custom JDBC stack, and we're already mostly implementing our own code for data warehouse query execution, so only the application database code currently uses `next.jdbc`. But I'd rather we collaborate on a community library and avoid the Lisp Curse