### PR TITLE
[CI] Include shared sources in file paths sources

### DIFF
--- a/.github/file-paths.yaml
+++ b/.github/file-paths.yaml
@@ -65,6 +65,7 @@ backend_all: &backend_all
   - *frontend_sources # keep it here until we detect static viz changes
 
 sources: &sources
+  - *shared_sources
   - *frontend_sources
   - *backend_sources
 


### PR DESCRIPTION
Unless `shared_sources` were intentionally left out, it seems we have to include them in (all) `sources`.