### PR TITLE
[CI] Do not run `i18n` workflow on spec changes

### DIFF
--- a/.github/file-paths.yaml
+++ b/.github/file-paths.yaml
@@ -95,3 +95,8 @@ yaml:
 codeql:
   - "frontend/src/**"
   - "enterprise/frontend/src/**"
+
+i18n:
+  - *default
+  - *ci
+  - *sources

--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -26,7 +26,7 @@ jobs:
         m2-cache-key: 'i18n'
     - run: sudo apt install gettext
 
-    - run: ./bin/i18n/update-translation-template
-      name: Check i18n tags/make sure template can be built
-    - run: ./bin/i18n/build-translation-resources
-      name: Verify i18n translations (.po files)
+    - name: Check i18n tags/make sure template can be built
+      run: ./bin/i18n/update-translation-template
+    - name: Verify i18n translations (.po files)
+      run: ./bin/i18n/build-translation-resources


### PR DESCRIPTION
We're running `i18n` workflow for basically any change in the code.
That approach wasteful because there is absolutely no reason to run these scripts when we change only test files.

The example of redundant run (only E2E spec was changed so it couldn't affect translation strings in any way):
https://github.com/metabase/metabase/actions/runs/4446054985

**This workflow takes 4m30s on average to run, which is the reason more this optimization is needed!**