### PR TITLE
db/select-one-id -> t2/select-one-pk

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -134,6 +134,7 @@
    honeysql.core/call        {:message "Use hx/call instead because it is Honey SQL 2 friendly"}
    honeysql.core/raw         {:message "Use hx/raw instead because it is Honey SQL 2 friendly"}
    java-time/with-clock      {:message "Use mt/with-clock"}
+   toucan.db/select-one-id   {:message "Use toucan.db/select-one-id instead of toucan2.core/select-one-pk"}
    toucan.db/query           {:message "Use mdb.query/query instead of toucan.db/query"}
    toucan.db/reducible-query {:message "Use mdb.query/reducible-query instead of toucan.db/reducible-query"}}
 

--- a/enterprise/backend/src/metabase_enterprise/advanced_config/file/databases.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_config/file/databases.clj
@@ -8,7 +8,8 @@
    [metabase.util :as u]
    [metabase.util.i18n :refer [trs]]
    [metabase.util.log :as log]
-   [toucan.db :as db]))
+   [toucan.db :as db]
+   [toucan2.core :as t2]))
 
 (defsetting config-from-file-sync-databases
   "Whether to sync newly created Databases during config-from-file initialization. By default, true, but you can disable
@@ -39,7 +40,7 @@
   [database]
   ;; assert that we are able to connect to this Database. Otherwise, throw an Exception.
   (driver.u/can-connect-with-details? (keyword (:engine database)) (:details database) :throw-exceptions)
-  (if-let [existing-database-id (db/select-one-id Database :engine (:engine database), :name (:name database))]
+  (if-let [existing-database-id (t2/select-one-pk Database :engine (:engine database), :name (:name database))]
     (do
       (log/info (u/colorize :blue (trs "Updating Database {0} {1}" (:engine database) (pr-str (:name database)))))
       (db/update! Database existing-database-id database))

--- a/enterprise/backend/src/metabase_enterprise/advanced_config/file/users.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_config/file/users.clj
@@ -6,7 +6,8 @@
    [metabase.util :as u]
    [metabase.util.i18n :as i18n :refer [trs]]
    [metabase.util.log :as log]
-   [toucan.db :as db]))
+   [toucan.db :as db]
+   [toucan2.core :as t2]))
 
 (s/def :metabase-enterprise.advanced-config.file.users.config-file-spec/first_name
   string?)
@@ -40,7 +41,7 @@
 (defn- init-from-config-file!
   [user]
   ;; TODO -- if this is the FIRST user, we should probably make them a superuser, right?
-  (if-let [existing-user-id (db/select-one-id User :email (:email user))]
+  (if-let [existing-user-id (t2/select-one-pk User :email (:email user))]
     (do
       (log/info (u/colorize :blue (trs "Updating User with email {0}" (pr-str (:email user)))))
       (db/update! User existing-user-id user))

--- a/enterprise/backend/src/metabase_enterprise/serialization/load.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/load.clj
@@ -36,7 +36,8 @@
    [metabase.util.i18n :refer [trs]]
    [metabase.util.log :as log]
    [metabase.util.yaml :as yaml]
-   [toucan.db :as db])
+   [toucan.db :as db]
+   [toucan2.core :as t2])
   (:import
    (java.util UUID)))
 
@@ -181,7 +182,7 @@
 (def ^:private ^{:arglists '([])} default-user-id
   (mdb.connection/memoize-for-application-db
    (fn []
-     (let [user (db/select-one-id User :is_superuser true)]
+     (let [user (t2/select-one-pk User :is_superuser true)]
        (assert user (trs "No admin users found! At least one admin user is needed to act as the owner for all the loaded entities."))
        user))))
 

--- a/enterprise/backend/src/metabase_enterprise/serialization/names.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/names.clj
@@ -21,7 +21,8 @@
    [metabase.util.schema :as su]
    [ring.util.codec :as codec]
    [schema.core :as s]
-   [toucan.db :as db]))
+   [toucan.db :as db]
+   [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
 
@@ -156,7 +157,7 @@
   [context _ _ db-name]
   (assoc context :database (if (= db-name "__virtual")
                              mbql.s/saved-questions-virtual-database-id
-                             (db/select-one-id Database :name db-name))))
+                             (t2/select-one-pk Database :name db-name))))
 
 (defmethod path->context* "schemas"
   [context _ _ schema]
@@ -164,14 +165,14 @@
 
 (defmethod path->context* "tables"
   [context _ _ table-name]
-  (assoc context :table (db/select-one-id Table
+  (assoc context :table (t2/select-one-pk Table
                           :db_id  (:database context)
                           :schema (:schema context)
                           :name   table-name)))
 
 (defmethod path->context* "fields"
   [context _ _ field-name]
-  (assoc context :field (db/select-one-id Field
+  (assoc context :field (t2/select-one-pk Field
                           :table_id (:table context)
                           :name     field-name)))
 
@@ -181,13 +182,13 @@
 
 (defmethod path->context* "metrics"
   [context _ _ metric-name]
-  (assoc context :metric (db/select-one-id Metric
+  (assoc context :metric (t2/select-one-pk Metric
                            :table_id (:table context)
                            :name     metric-name)))
 
 (defmethod path->context* "segments"
   [context _ _ segment-name]
-  (assoc context :segment (db/select-one-id Segment
+  (assoc context :segment (t2/select-one-pk Segment
                             :table_id (:table context)
                             :name     segment-name)))
 
@@ -195,7 +196,7 @@
   [context _ model-attrs collection-name]
   (if (= collection-name "root")
     (assoc context :collection nil)
-    (assoc context :collection (db/select-one-id Collection
+    (assoc context :collection (t2/select-one-pk Collection
                                  :name      collection-name
                                  :namespace (:namespace model-attrs)
                                  :location  (or (letfn [(collection-location [id]
@@ -208,30 +209,30 @@
 
 (defmethod path->context* "dashboards"
   [context _ _ dashboard-name]
-  (assoc context :dashboard (db/select-one-id Dashboard
+  (assoc context :dashboard (t2/select-one-pk Dashboard
                               :collection_id (:collection context)
                               :name          dashboard-name)))
 
 (defmethod path->context* "pulses"
   [context _ _ pulse-name]
-  (assoc context :dashboard (db/select-one-id Pulse
+  (assoc context :dashboard (t2/select-one-pk Pulse
                               :collection_id (:collection context)
                               :name          pulse-name)))
 
 (defmethod path->context* "cards"
   [context _ _ dashboard-name]
-  (assoc context :card (db/select-one-id Card
+  (assoc context :card (t2/select-one-pk Card
                          :collection_id (:collection context)
                          :name          dashboard-name)))
 
 (defmethod path->context* "users"
   [context _ _ email]
-  (assoc context :user (db/select-one-id User
+  (assoc context :user (t2/select-one-pk User
                          :email email)))
 
 (defmethod path->context* "snippets"
   [context _ _ snippet-name]
-  (assoc context :snippet (db/select-one-id NativeQuerySnippet
+  (assoc context :snippet (t2/select-one-pk NativeQuerySnippet
                                             :collection_id (:collection context)
                                             :name          snippet-name)))
 

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/api/subscription_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/api/subscription_test.clj
@@ -12,7 +12,7 @@
    [metabase.pulse-test :as pulse-test]
    [metabase.test :as mt]
    [metabase.util :as u]
-   [toucan.db :as db]))
+   [toucan2.core :as t2]))
 
 (defmacro ^:private with-subscription-disabled-for-all-users
   "Temporarily remove `subscription` permission for group `All Users`, execute `body` then re-grant it.
@@ -97,7 +97,7 @@
                       ;; manually add another user as recipient
                       (mt/with-temp PulseChannelRecipient [_ {:user_id (:id user)
                                                               :pulse_channel_id
-                                                              (db/select-one-id
+                                                              (t2/select-one-pk
                                                                PulseChannel :channel_type "email" :pulse_id (:id the-pulse))}]
                         (let [the-pulse   (pulse/retrieve-pulse (:id the-pulse))
                               channel     (api.alert/email-channel the-pulse)

--- a/enterprise/backend/test/metabase_enterprise/sandbox/api/dashboard_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/api/dashboard_test.clj
@@ -12,7 +12,6 @@
    [metabase.test :as mt]
    [metabase.util :as u]
    [schema.core :as s]
-   [toucan.db :as db]
    [toucan2.core :as t2]))
 
 (deftest chain-filter-sandboxed-field-values-test

--- a/enterprise/backend/test/metabase_enterprise/sandbox/api/dashboard_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/api/dashboard_test.clj
@@ -12,12 +12,13 @@
    [metabase.test :as mt]
    [metabase.util :as u]
    [schema.core :as s]
-   [toucan.db :as db]))
+   [toucan.db :as db]
+   [toucan2.core :as t2]))
 
 (deftest chain-filter-sandboxed-field-values-test
   (testing "When chain filter endpoints would normally return cached FieldValues (#13832), make sure sandboxing is respected"
     (met/with-gtaps {:gtaps {:categories {:query (mt/mbql-query categories {:filter [:< $id 3]})}}}
-      (mt/with-temp-vals-in-db FieldValues (u/the-id (db/select-one-id FieldValues :field_id (mt/id :categories :name))) {:values ["Good" "Bad"]}
+      (mt/with-temp-vals-in-db FieldValues (u/the-id (t2/select-one-pk FieldValues :field_id (mt/id :categories :name))) {:values ["Good" "Bad"]}
         (api.dashboard-test/with-chain-filter-fixtures [{:keys [dashboard]}]
           (with-redefs [metabase.models.params.chain-filter/use-cached-field-values? (constantly false)]
             (testing "GET /api/dashboard/:id/params/:param-key/values"

--- a/enterprise/backend/test/metabase_enterprise/sandbox/api/field_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/api/field_test.clj
@@ -7,13 +7,14 @@
    [metabase.models :refer [Field FieldValues User]]
    [metabase.models.field-values :as field-values]
    [metabase.test :as mt]
-   [toucan.db :as db]))
+   [toucan.db :as db]
+   [toucan2.core :as t2]))
 
 (deftest fetch-field-test
   (testing "GET /api/field/:id"
     (met/with-gtaps {:gtaps      {:venues {:query      (mt.tu/restricted-column-query (mt/id))
-                                          :remappings {:cat [:variable [:field (mt/id :venues :category_id) nil]]}}}
-                    :attributes {:cat 50}}
+                                           :remappings {:cat [:variable [:field (mt/id :venues :category_id) nil]]}}}
+                     :attributes {:cat 50}}
       (testing "Can I fetch a Field that I don't have read access for if I have segmented table access for it?"
         (let [result (mt/user-http-request :rasta :get 200 (str "field/" (mt/id :venues :name)))]
           (is (map? result))
@@ -87,10 +88,10 @@
                     (let [password (mt/random-name)]
                       (mt/with-temp User [another-user {:password password}]
                         (met/with-gtaps-for-user another-user {:gtaps      {:venues
-                                                                           {:remappings
-                                                                            {:cat
-                                                                             [:dimension (mt/id :venues :category_id)]}}}
-                                                              :attributes {:cat 5 #_BBQ}}
+                                                                            {:remappings
+                                                                             {:cat
+                                                                              [:dimension (mt/id :venues :category_id)]}}}
+                                                               :attributes {:cat 5 #_BBQ}}
                           (is (= {:field_id        (mt/id :venues :name)
                                   :values          [["Baby Blues BBQ"]
                                                     ["Bludso's BBQ"]
@@ -105,24 +106,24 @@
   (testing "GET /api/field/:id/values should returns correct human readable mapping if exists"
     (mt/with-temp-copy-of-db
       (let [field-id   (mt/id :venues :price)
-            full-fv-id (db/select-one-id FieldValues :field_id field-id :type :full)]
+            full-fv-id (t2/select-one-pk FieldValues :field_id field-id :type :full)]
         (db/update! FieldValues full-fv-id
                     :human_readable_values ["$" "$$" "$$$" "$$$$"])
         ;; sanity test without gtap
         (is (= [[1 "$"] [2 "$$"] [3 "$$$"] [4 "$$$$"]]
                (:values (mt/user-http-request :rasta :get 200 (format "field/%d/values" field-id)))))
         (met/with-gtaps {:gtaps      {:venues
-                                     {:remappings {:cat [:variable [:field (mt/id :venues :category_id) nil]]}}}
-                        :attributes {:cat 4}}
+                                      {:remappings {:cat [:variable [:field (mt/id :venues :category_id) nil]]}}}
+                         :attributes {:cat 4}}
           (is (= [[1 "$"] [3 "$$$"]]
                  (:values (mt/user-http-request :rasta :get 200 (format "field/%d/values" (mt/id :venues :price)))))))))))
 
 (deftest search-test
   (testing "GET /api/field/:id/search/:search-id"
     (met/with-gtaps {:gtaps      {:venues
-                                 {:remappings {:cat [:variable [:field (mt/id :venues :category_id) nil]]}
-                                  :query      (mt.tu/restricted-column-query (mt/id))}}
-                    :attributes {:cat 50}}
+                                  {:remappings {:cat [:variable [:field (mt/id :venues :category_id) nil]]}
+                                   :query      (mt.tu/restricted-column-query (mt/id))}}
+                     :attributes {:cat 50}}
       (testing (str "Searching via the query builder needs to use a GTAP when the user has segmented permissions. "
                     "This tests out a field search on a table with segmented permissions")
         ;; Rasta Toucan is only allowed to see Venues that are in the "Mexican" category [category_id = 50]. So
@@ -138,10 +139,10 @@
 
 (deftest caching-test
   (met/with-gtaps {:gtaps
-                  {:venues
-                   {:remappings {:cat [:variable [:field (mt/id :venues :category_id) nil]]}
-                    :query      (mt.tu/restricted-column-query (mt/id))}}
-                  :attributes {:cat 50}}
+                   {:venues
+                    {:remappings {:cat [:variable [:field (mt/id :venues :category_id) nil]]}
+                     :query      (mt.tu/restricted-column-query (mt/id))}}
+                   :attributes {:cat 50}}
     (let [field (db/select-one Field :id (mt/id :venues :name))]
       ;; Make sure FieldValues are populated
       (field-values/get-or-create-full-field-values! field)
@@ -158,9 +159,9 @@
         (let [password (mt/random-name)]
           (mt/with-temp User [another-user {:password password}]
             (met/with-gtaps-for-user another-user {:gtaps      {:venues
-                                                               {:remappings {:cat [:variable [:field (mt/id :venues :category_id) nil]]}
-                                                                :query      (mt.tu/restricted-column-query (mt/id))}}
-                                                  :attributes {:cat 5}}
+                                                                {:remappings {:cat [:variable [:field (mt/id :venues :category_id) nil]]}
+                                                                 :query      (mt.tu/restricted-column-query (mt/id))}}
+                                                   :attributes {:cat 5}}
               (mt/user-http-request another-user :get 200 (str "field/" (:id field) "/values"))
               ;; create another one for the new user
               (is (= 2 (db/count FieldValues
@@ -170,7 +171,7 @@
       (testing "Do we invalidate the cache when full FieldValues change"
         (try
           (let [;; Updating FieldValues which should invalidate the cache
-                fv-id      (db/select-one-id FieldValues :field_id (:id field) :type :full)
+                fv-id      (t2/select-one-pk FieldValues :field_id (:id field) :type :full)
                 new-values ["foo" "bar"]]
             (testing "Sanity check: make sure FieldValues exist"
               (is (some? fv-id)))
@@ -188,7 +189,7 @@
         (#'field-values/clear-advanced-field-values-for-field! field)
         ;; make sure we have a cache
         (mt/user-http-request :rasta :get 200 (str "field/" (:id field) "/values"))
-        (let [old-sandbox-fv-id (db/select-one-id FieldValues :field_id (:id field) :type :sandbox)]
+        (let [old-sandbox-fv-id (t2/select-one-pk FieldValues :field_id (:id field) :type :sandbox)]
           (with-redefs [field-values/advanced-field-values-expired? (fn [fv]
                                                                       (= (:id fv) old-sandbox-fv-id))]
             (mt/user-http-request :rasta :get 200 (str "field/" (:id field) "/values"))

--- a/enterprise/backend/test/metabase_enterprise/sso/integrations/jwt_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/integrations/jwt_test.clj
@@ -15,7 +15,8 @@
    [metabase.test.fixtures :as fixtures]
    [metabase.util :as u]
    [toucan.db :as db]
-   [toucan.util.test :as tt]))
+   [toucan.util.test :as tt]
+   [toucan2.core :as t2]))
 
 (use-fixtures :once (fixtures/initialize :test-users))
 
@@ -268,4 +269,4 @@
               (is (saml-test/successful-login? response))
               (is (= #{"All Users"
                        ":metabase-enterprise.sso.integrations.jwt-test/my-group"}
-                     (group-memberships (u/the-id (db/select-one-id User :email "newuser@metabase.com"))))))))))))
+                     (group-memberships (u/the-id (t2/select-one-pk User :email "newuser@metabase.com"))))))))))))

--- a/enterprise/backend/test/metabase_enterprise/sso/integrations/saml_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/integrations/saml_test.clj
@@ -20,7 +20,8 @@
    [ring.util.codec :as codec]
    [saml20-clj.core :as saml]
    [saml20-clj.encode-decode :as encode-decode]
-   [toucan.db :as db])
+   [toucan.db :as db]
+   [toucan2.core :as t2])
   (:import
    (java.net URL)
    (java.nio.charset StandardCharsets)
@@ -498,14 +499,14 @@
                                                saml-attribute-group "GroupMembership"]
               (try
                 ;; user doesn't exist until SAML request
-                (is (not (db/select-one-id User :%lower.email "newuser@metabase.com")))
+                (is (not (t2/select-one-pk User :%lower.email "newuser@metabase.com")))
                 (let [req-options (saml-post-request-options (new-user-with-single-group-saml-test-response)
                                                              (saml/str->base64 default-redirect-uri))
                       response    (client-full-response :post 302 "/auth/sso" req-options)]
                   (is (successful-login? response))
                   (is (= #{"All Users"
                            ":metabase-enterprise.sso.integrations.saml-test/group-1"}
-                         (group-memberships (db/select-one-id User :email "newuser@metabase.com")))))
+                         (group-memberships (t2/select-one-pk User :email "newuser@metabase.com")))))
                 (finally
                   (db/delete! User :%lower.email "newuser@metabase.com"))))))))))
 
@@ -523,7 +524,7 @@
                                                  saml-attribute-group "GroupMembership"]
                 (try
                   (testing "user doesn't exist until SAML request"
-                    (is (not (db/select-one-id User :%lower.email "newuser@metabase.com"))))
+                    (is (not (t2/select-one-pk User :%lower.email "newuser@metabase.com"))))
                   (let [req-options (saml-post-request-options (new-user-with-groups-saml-test-response)
                                                                (saml/str->base64 default-redirect-uri))
                         response    (client-full-response :post 302 "/auth/sso" req-options)]
@@ -531,7 +532,7 @@
                     (is (= #{"All Users"
                              ":metabase-enterprise.sso.integrations.saml-test/group-1"
                              ":metabase-enterprise.sso.integrations.saml-test/group-2"}
-                           (group-memberships (db/select-one-id User :email "newuser@metabase.com")))))
+                           (group-memberships (t2/select-one-pk User :email "newuser@metabase.com")))))
                   (finally
                     (db/delete! User :%lower.email "newuser@metabase.com")))))))))
     (testing "when several Attribute nodes exist (issue #20744)"
@@ -546,7 +547,7 @@
                                                  saml-attribute-group "GroupMembership"]
                 (try
                   (testing "user doesn't exist until SAML request"
-                    (is (not (db/select-one-id User :%lower.email "newuser@metabase.com"))))
+                    (is (not (t2/select-one-pk User :%lower.email "newuser@metabase.com"))))
                   (let [req-options (saml-post-request-options (new-user-with-groups-in-separate-attribute-nodes-saml-test-response)
                                                                (saml/str->base64 default-redirect-uri))
                         response    (client-full-response :post 302 "/auth/sso" req-options)]
@@ -554,7 +555,7 @@
                     (is (= #{"All Users"
                              ":metabase-enterprise.sso.integrations.saml-test/group-1"
                              ":metabase-enterprise.sso.integrations.saml-test/group-2"}
-                           (group-memberships (db/select-one-id User :email "newuser@metabase.com")))))
+                           (group-memberships (t2/select-one-pk User :email "newuser@metabase.com")))))
                   (finally
                     (db/delete! User :%lower.email "newuser@metabase.com")))))))))))
 

--- a/modules/drivers/mongo/src/metabase/driver/mongo.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo.clj
@@ -25,7 +25,7 @@
    [monger.db :as mdb]
    [monger.json]
    [taoensso.nippy :as nippy]
-   [toucan.db :as db])
+   [toucan2.core :as t2])
   (:import
    (com.mongodb DB DBObject)
    (java.time Instant LocalDate LocalDateTime LocalTime OffsetDateTime OffsetTime ZonedDateTime)

--- a/modules/drivers/mongo/src/metabase/driver/mongo.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo.clj
@@ -348,7 +348,7 @@
   :sunday)
 
 (defn- get-id-field-id [table]
-  (db/select-one-id Field :name "_id" :table_id (u/the-id table)))
+  (t2/select-one-pk Field :name "_id" :table_id (u/the-id table)))
 
 (defmethod driver/table-rows-sample :mongo
   [_driver table fields rff opts]

--- a/modules/drivers/redshift/test/metabase/driver/redshift_test.clj
+++ b/modules/drivers/redshift/test/metabase/driver/redshift_test.clj
@@ -228,7 +228,7 @@
           (is (contains?
                (db/select-field :name Table :db_id (u/the-id database)) ; the new view should have been synced
                view-nm))
-          (let [table-id (db/select-one-id Table :db_id (u/the-id database), :name view-nm)]
+          (let [table-id (t2/select-one-pk Table :db_id (u/the-id database), :name view-nm)]
             ;; and its columns' :base_type should have been identified correctly
             (is (= [{:name "numeric_col",   :database_type "numeric(10,2)",         :base_type :type/Decimal}
                     {:name "weird_varchar", :database_type "character varying(50)", :base_type :type/Text}]
@@ -262,7 +262,7 @@
            (is (contains?
                 (db/select-field :name Table :db_id (u/the-id database)) ; the new view should have been synced without errors
                 view-nm))
-           (let [table-id (db/select-one-id Table :db_id (u/the-id database), :name view-nm)]
+           (let [table-id (t2/select-one-pk Table :db_id (u/the-id database), :name view-nm)]
              ;; and its columns' :base_type should have been identified correctly
              (is (= [{:name "case_when_numeric_inc_nulls", :database_type "numeric", :base_type :type/Decimal}
                      {:name "raw_null",                    :database_type "varchar", :base_type :type/Text}

--- a/modules/drivers/redshift/test/metabase/driver/redshift_test.clj
+++ b/modules/drivers/redshift/test/metabase/driver/redshift_test.clj
@@ -27,7 +27,8 @@
    [metabase.util.honey-sql-2 :as h2x]
    #_{:clj-kondo/ignore [:discouraged-namespace]}
    [metabase.util.honeysql-extensions :as hx]
-   [toucan.db :as db])
+   [toucan.db :as db]
+   [toucan2.core :as t2])
   (:import
    (metabase.plugins.jdbc_proxy ProxyDriver)))
 

--- a/src/metabase/api/alert.clj
+++ b/src/metabase/api/alert.clj
@@ -21,7 +21,8 @@
    [metabase.util.schema :as su]
    [schema.core :as s]
    [toucan.db :as db]
-   [toucan.hydrate :refer [hydrate]]))
+   [toucan.hydrate :refer [hydrate]]
+   [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
 
@@ -251,8 +252,8 @@
   (let [alert (pulse/retrieve-alert id)]
     (api/read-check alert)
     (api/let-404 [alert-id (u/the-id alert)
-                  pc-id    (db/select-one-id PulseChannel :pulse_id alert-id :channel_type "email")
-                  pcr-id   (db/select-one-id PulseChannelRecipient :pulse_channel_id pc-id :user_id api/*current-user-id*)]
+                  pc-id    (t2/select-one-pk PulseChannel :pulse_id alert-id :channel_type "email")
+                  pcr-id   (t2/select-one-pk PulseChannelRecipient :pulse_channel_id pc-id :user_id api/*current-user-id*)]
       (db/delete! PulseChannelRecipient :id pcr-id))
     ;; Send emails letting people know they have been unsubscribe
     (when (email/email-configured?)

--- a/src/metabase/api/field.clj
+++ b/src/metabase/api/field.clj
@@ -24,7 +24,8 @@
    [metabase.util.schema :as su]
    [schema.core :as s]
    [toucan.db :as db]
-   [toucan.hydrate :refer [hydrate]])
+   [toucan.hydrate :refer [hydrate]]
+   [toucan2.core :as t2])
   (:import
    (java.text NumberFormat)))
 
@@ -303,7 +304,7 @@
     (api/check (field-values/field-should-have-field-values? field)
       [400 (str "You can only update the human readable values of a mapped values of a Field whose value of "
                 "`has_field_values` is `list` or whose 'base_type' is 'type/Boolean'.")])
-    (if-let [field-value-id (db/select-one-id FieldValues, :field_id id :type :full)]
+    (if-let [field-value-id (t2/select-one-pk FieldValues, :field_id id :type :full)]
       (update-field-values! field-value-id value-pairs)
       (create-field-values! field value-pairs)))
   {:status :success})

--- a/src/metabase/api/public.clj
+++ b/src/metabase/api/public.clj
@@ -39,7 +39,8 @@
    [schema.core :as s]
    [throttle.core :as throttle]
    [toucan.db :as db]
-   [toucan.hydrate :refer [hydrate]])
+   [toucan.hydrate :refer [hydrate]]
+   [toucan2.core :as t2])
   (:import
    (clojure.lang ExceptionInfo)))
 
@@ -147,7 +148,7 @@
   `StreamingResponse` object that should be returned as the result of an API endpoint."
   [uuid export-format parameters & options]
   (validation/check-public-sharing-enabled)
-  (let [card-id (api/check-404 (db/select-one-id Card :public_uuid uuid, :archived false))]
+  (let [card-id (api/check-404 (t2/select-one-pk Card :public_uuid uuid, :archived false))]
     (apply run-query-for-card-with-id-async card-id export-format parameters options)))
 
 #_{:clj-kondo/ignore [:deprecated-var]}
@@ -241,7 +242,7 @@
   [uuid card-id dashcard-id parameters]
   {parameters (s/maybe su/JSONString)}
   (validation/check-public-sharing-enabled)
-  (let [dashboard-id (api/check-404 (db/select-one-id Dashboard :public_uuid uuid, :archived false))]
+  (let [dashboard-id (api/check-404 (t2/select-one-pk Dashboard :public_uuid uuid, :archived false))]
     (public-dashcard-results-async
      :dashboard-id  dashboard-id
      :card-id       card-id
@@ -256,7 +257,7 @@
   {dashcard-id su/IntGreaterThanZero
    parameters su/JSONString}
   (validation/check-public-sharing-enabled)
-  (let [dashboard-id (api/check-404 (db/select-one-id Dashboard :public_uuid uuid, :archived false))]
+  (let [dashboard-id (api/check-404 (t2/select-one-pk Dashboard :public_uuid uuid, :archived false))]
     (actions.execution/fetch-values dashboard-id dashcard-id (json/parse-string parameters))))
 
 (def ^:private dashcard-execution-throttle (throttle/make-throttler :dashcard-id :attempts-threshold 5000))
@@ -282,7 +283,7 @@
         throttle-time (assoc :headers {"Retry-After" throttle-time}))
       (do
         (validation/check-public-sharing-enabled)
-        (let [dashboard-id (api/check-404 (db/select-one-id Dashboard :public_uuid uuid, :archived false))]
+        (let [dashboard-id (api/check-404 (t2/select-one-pk Dashboard :public_uuid uuid, :archived false))]
           ;; Run this query with full superuser perms. We don't want the various perms checks
           ;; failing because there are no current user perms; if this Dashcard is public
           ;; you're by definition allowed to run it without a perms check anyway
@@ -395,7 +396,7 @@
   "Fetch FieldValues for a Field that is referenced by a public Card."
   [uuid field-id]
   (validation/check-public-sharing-enabled)
-  (let [card-id (db/select-one-id Card :public_uuid uuid, :archived false)]
+  (let [card-id (t2/select-one-pk Card :public_uuid uuid, :archived false)]
     (card-and-field-id->values card-id field-id)))
 
 (defn dashboard-and-field-id->values
@@ -410,7 +411,7 @@
   "Fetch FieldValues for a Field that is referenced by a Card in a public Dashboard."
   [uuid field-id]
   (validation/check-public-sharing-enabled)
-  (let [dashboard-id (api/check-404 (db/select-one-id Dashboard :public_uuid uuid, :archived false))]
+  (let [dashboard-id (api/check-404 (t2/select-one-pk Dashboard :public_uuid uuid, :archived false))]
     (dashboard-and-field-id->values dashboard-id field-id)))
 
 
@@ -439,7 +440,7 @@
   {value su/NonBlankString
    limit (s/maybe su/IntStringGreaterThanZero)}
   (validation/check-public-sharing-enabled)
-  (let [card-id (db/select-one-id Card :public_uuid uuid, :archived false)]
+  (let [card-id (t2/select-one-pk Card :public_uuid uuid, :archived false)]
     (search-card-fields card-id field-id search-field-id value (when limit (Integer/parseInt limit)))))
 
 #_{:clj-kondo/ignore [:deprecated-var]}
@@ -449,7 +450,7 @@
   {value su/NonBlankString
    limit (s/maybe su/IntStringGreaterThanZero)}
   (validation/check-public-sharing-enabled)
-  (let [dashboard-id (api/check-404 (db/select-one-id Dashboard :public_uuid uuid, :archived false))]
+  (let [dashboard-id (api/check-404 (t2/select-one-pk Dashboard :public_uuid uuid, :archived false))]
     (search-dashboard-fields dashboard-id field-id search-field-id value (when limit (Integer/parseInt limit)))))
 
 
@@ -482,7 +483,7 @@
   [uuid field-id remapped-id value]
   {value su/NonBlankString}
   (validation/check-public-sharing-enabled)
-  (let [card-id (api/check-404 (db/select-one-id Card :public_uuid uuid, :archived false))]
+  (let [card-id (api/check-404 (t2/select-one-pk Card :public_uuid uuid, :archived false))]
     (card-field-remapped-values card-id field-id remapped-id value)))
 
 #_{:clj-kondo/ignore [:deprecated-var]}
@@ -492,7 +493,7 @@
   [uuid field-id remapped-id value]
   {value su/NonBlankString}
   (validation/check-public-sharing-enabled)
-  (let [dashboard-id (db/select-one-id Dashboard :public_uuid uuid, :archived false)]
+  (let [dashboard-id (t2/select-one-pk Dashboard :public_uuid uuid, :archived false)]
     (dashboard-field-remapped-values dashboard-id field-id remapped-id value)))
 
 ;;; ------------------------------------------------ Param Values -------------------------------------------------
@@ -549,7 +550,7 @@
   [uuid card-id dashcard-id parameters]
   {parameters (s/maybe su/JSONString)}
   (validation/check-public-sharing-enabled)
-  (let [dashboard-id (api/check-404 (db/select-one-id Dashboard :public_uuid uuid, :archived false))]
+  (let [dashboard-id (api/check-404 (t2/select-one-pk Dashboard :public_uuid uuid, :archived false))]
     (public-dashcard-results-async
      :dashboard-id  dashboard-id
      :card-id       card-id

--- a/src/metabase/api/pulse.clj
+++ b/src/metabase/api/pulse.clj
@@ -30,7 +30,8 @@
    [metabase.util.urls :as urls]
    [schema.core :as s]
    [toucan.db :as db]
-   [toucan.hydrate :refer [hydrate]])
+   [toucan.hydrate :refer [hydrate]]
+   [toucan2.core :as t2])
   (:import
    (java.io ByteArrayInputStream)))
 
@@ -313,9 +314,9 @@
 (api/defendpoint-schema DELETE "/:id/subscription"
   "For users to unsubscribe themselves from a pulse subscription."
   [id]
-  (api/let-404 [pulse-id (db/select-one-id Pulse :id id)
-                pc-id    (db/select-one-id PulseChannel :pulse_id pulse-id :channel_type "email")
-                pcr-id   (db/select-one-id PulseChannelRecipient :pulse_channel_id pc-id :user_id api/*current-user-id*)]
+  (api/let-404 [pulse-id (t2/select-one-pk Pulse :id id)
+                pc-id    (t2/select-one-pk PulseChannel :pulse_id pulse-id :channel_type "email")
+                pcr-id   (t2/select-one-pk PulseChannelRecipient :pulse_channel_id pc-id :user_id api/*current-user-id*)]
     (db/delete! PulseChannelRecipient :id pcr-id))
   api/generic-204-no-content)
 

--- a/src/metabase/cmd/reset_password.clj
+++ b/src/metabase/cmd/reset_password.clj
@@ -4,14 +4,14 @@
    [metabase.models.user :as user :refer [User]]
    [metabase.util :as u]
    [metabase.util.i18n :refer [deferred-trs trs]]
-   [toucan.db :as db]))
+   [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
 
 (defn- set-reset-token!
   "Set and return a new `reset_token` for the user with EMAIL-ADDRESS."
   [email-address]
-  (let [user-id (or (db/select-one-id User, :%lower.email (u/lower-case-en email-address))
+  (let [user-id (or (t2/select-one-pk User, :%lower.email (u/lower-case-en email-address))
                     (throw (Exception. (str (deferred-trs "No user found with email address ''{0}''. " email-address)
                                             (deferred-trs "Please check the spelling and try again.")))))]
     (user/set-password-reset-token! user-id)))

--- a/src/metabase/models/application_permissions_revision.clj
+++ b/src/metabase/models/application_permissions_revision.clj
@@ -2,8 +2,8 @@
   (:require
    [metabase.models.interface :as mi]
    [metabase.util.i18n :refer [tru]]
-   [toucan.db :as db]
-   [toucan.models :as models]))
+   [toucan.models :as models]
+   [toucan2.core :as t2]))
 
 (models/defmodel ApplicationPermissionsRevision :application_permissions_revision)
 
@@ -18,5 +18,5 @@
   "Return the ID of the newest `ApplicationPermissionsRevision`, or zero if none have been made yet.
    (This is used by the permissions graph update logic that checks for changes since the original graph was fetched)."
   []
-  (or (db/select-one-id ApplicationPermissionsRevision {:order-by [[:id :desc]]})
+  (or (t2/select-one-pk ApplicationPermissionsRevision {:order-by [[:id :desc]]})
       0))

--- a/src/metabase/models/permissions_revision.clj
+++ b/src/metabase/models/permissions_revision.clj
@@ -2,8 +2,8 @@
   (:require
    [metabase.models.interface :as mi]
    [metabase.util.i18n :refer [tru]]
-   [toucan.db :as db]
-   [toucan.models :as models]))
+   [toucan.models :as models]
+   [toucan2.core :as t2]))
 
 (models/defmodel PermissionsRevision :permissions_revision)
 
@@ -18,5 +18,5 @@
   "Return the ID of the newest `PermissionsRevision`, or zero if none have been made yet.
    (This is used by the permissions graph update logic that checks for changes since the original graph was fetched)."
   []
-  (or (db/select-one-id PermissionsRevision {:order-by [[:id :desc]]})
+  (or (t2/select-one-pk PermissionsRevision {:order-by [[:id :desc]]})
       0))

--- a/src/metabase/models/pulse_channel.clj
+++ b/src/metabase/models/pulse_channel.clj
@@ -376,7 +376,7 @@
 
 (defn- import-recipients [channel-id emails]
   (let [incoming-users (set (for [email emails
-                                  :let [id (db/select-one-id 'User :email email)]]
+                                  :let [id (t2/select-one-pk 'User :email email)]]
                               (or id
                                   (:id (user/serdes-synthesize-user! {:email email})))))
         current-users  (set (db/select-field :user_id PulseChannelRecipient :pulse_channel_id channel-id))

--- a/src/metabase/models/serialization.clj
+++ b/src/metabase/models/serialization.clj
@@ -25,7 +25,8 @@
    [metabase.util.log :as log]
    [toucan.db :as db]
    [toucan.hydrate :refer [hydrate]]
-   [toucan.models :as models])
+   [toucan.models :as models]
+   [toucan2.core :as t2])
   (:refer-clojure :exclude [descendants]))
 
 (set! *warn-on-reflection* true)
@@ -492,7 +493,7 @@
   Unusual parameter order lets this be called as, for example,
   `(update x :creator_id import-fk-keyed 'Database :name)`."
   [portable model field]
-  (db/select-one-id model field portable))
+  (t2/select-one-pk model field portable))
 
 ;; -------------------------------------------------- Users ----------------------------------------------------------
 (defn export-user
@@ -573,7 +574,7 @@
   [[db-name schema table-name field-name :as field-id]]
   (when field-id
     (let [table_id (import-table-fk [db-name schema table-name])]
-      (db/select-one-id 'Field :table_id table_id :name field-name))))
+      (t2/select-one-pk 'Field :table_id table_id :name field-name))))
 
 (defn field->path
   "Given a `field_id` as exported by [[export-field-fk]], turn it into a `[{:model ...}]` path for the Field.
@@ -706,7 +707,7 @@
                   (-> &match
                       (assoc :database (if (= fully-qualified-name "database/__virtual")
                                          mbql.s/saved-questions-virtual-database-id
-                                         (db/select-one-id 'Database :name fully-qualified-name)))
+                                         (t2/select-one-pk 'Database :name fully-qualified-name)))
                       mbql-fully-qualified-names->ids*) ; Process other keys
 
                   {:card-id (entity-id :guard portable-id?)}

--- a/src/metabase/models/table.clj
+++ b/src/metabase/models/table.clj
@@ -233,8 +233,8 @@
         schema-name (when (= 3 (count path))
                       (-> path second :id))
         table-name  (-> path last :id)
-        db-id       (db/select-one-id Database :name db-name)]
-    (db/select-one Table :name table-name :db_id db-id :schema schema-name)))
+        db-id       (t2/select-one-pk Database :name db-name)]
+    (t2/select-one Table :name table-name :db_id db-id :schema schema-name)))
 
 (defmethod serdes/extract-one "Table"
   [_model-name _opts {:keys [db_id] :as table}]

--- a/src/metabase/models/table.clj
+++ b/src/metabase/models/table.clj
@@ -14,7 +14,8 @@
    [metabase.models.serialization :as serdes]
    [metabase.util :as u]
    [toucan.db :as db]
-   [toucan.models :as models]))
+   [toucan.models :as models]
+   [toucan2.core :as t2]))
 
 ;;; ----------------------------------------------- Constants + Entity -----------------------------------------------
 
@@ -156,11 +157,10 @@
   :pk_field
   "Return the ID of the primary key `Field` for `table`."
   [{:keys [id]}]
-  (db/select-one-id Field
+  (t2/select-one-pk Field
     :table_id        id
     :semantic_type   (mdb.u/isa :type/PK)
     :visibility_type [:not-in ["sensitive" "retired"]]))
-
 
 (defn- with-objects [hydration-key fetch-objects-fn tables]
   (let [table-ids         (set (map :id tables))

--- a/src/metabase/sync/sync_metadata/metabase_metadata.clj
+++ b/src/metabase/sync/sync_metadata/metabase_metadata.clj
@@ -19,7 +19,8 @@
    [metabase.util.log :as log]
    [metabase.util.schema :as su]
    [schema.core :as s]
-   [toucan.db :as db]))
+   [toucan.db :as db]
+   [toucan2.core :as t2]))
 
 (def ^:private KeypathComponents
   {:table-name (s/maybe su/NonBlankString)
@@ -47,7 +48,7 @@
    (when-not (= k :field_type)
      ;; fetch the corresponding Table, then set the Table or Field property
      (if table-name
-       (when-let [table-id (db/select-one-id Table
+       (when-let [table-id (t2/select-one-pk Table
                              ;; TODO: this needs to support schemas
                              :db_id  (u/the-id database)
                              :name   table-name

--- a/src/metabase/sync/sync_metadata/tables.clj
+++ b/src/metabase/sync/sync_metadata/tables.clj
@@ -17,7 +17,8 @@
    [metabase.util.i18n :refer [trs]]
    [metabase.util.log :as log]
    [schema.core :as s]
-   [toucan.db :as db]))
+   [toucan.db :as db]
+   [toucan2.core :as t2]))
 
 ;;; ------------------------------------------------ "Crufty" Tables -------------------------------------------------
 
@@ -96,7 +97,7 @@
 (defn create-or-reactivate-table!
   "Create a single new table in the database, or mark it as active if it already exists."
   [database {schema :schema, table-name :name, :as table}]
-  (if-let [existing-id (db/select-one-id Table
+  (if-let [existing-id (t2/select-one-pk Table
                          :db_id (u/the-id database)
                          :schema schema
                          :name table-name

--- a/src/metabase/transforms/materialize.clj
+++ b/src/metabase/transforms/materialize.clj
@@ -5,7 +5,8 @@
    [metabase.models.collection :as collection :refer [Collection]]
    [metabase.query-processor :as qp]
    [metabase.util :as u]
-   [toucan.db :as db]))
+   [toucan.db :as db]
+   [toucan2.core :as t2]))
 
 (declare get-or-create-root-container-collection!)
 
@@ -21,7 +22,7 @@
   ([collection-name]
    (get-collection collection-name (root-container-location)))
   ([collection-name location]
-   (db/select-one-id Collection
+   (t2/select-one-pk Collection
      :name     collection-name
      :location location)))
 

--- a/test/metabase/api/action_test.clj
+++ b/test/metabase/api/action_test.clj
@@ -521,7 +521,7 @@
                                      (format "action/%s/execute" action-id)
                                      {:parameters {:id 1 :name "European"}})))))
     (mt/with-actions [{:keys [action-id]} unshared-action-opts]
-      (let [nonexistent-id (inc (db/select-one-id Action {:order-by [[:id :desc]]}))]
+      (let [nonexistent-id (inc (t2/select-one-pk Action {:order-by [[:id :desc]]}))]
         (testing "Check that we get a 404 if the action doesn't exist"
           (is (= "Not found."
                  (mt/user-http-request :crowberto

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -49,6 +49,7 @@
    [ring.util.codec :as codec]
    [schema.core :as s]
    [toucan.db :as db]
+   [toucan2.core :as t2]
    [toucan2.protocols :as t2.protocols]
    [toucan2.tools.with-temp :as t2.with-temp])
   (:import
@@ -2240,7 +2241,7 @@
 (deftest chain-filter-should-use-cached-field-values-test
   (testing "Chain filter endpoints should use cached FieldValues if applicable (#13832)"
     ;; ignore the cache entries added by #23699
-    (mt/with-temp-vals-in-db FieldValues (db/select-one-id FieldValues :field_id (mt/id :categories :name) :hash_key nil) {:values ["Good" "Bad"]}
+    (mt/with-temp-vals-in-db FieldValues (t2/select-one-pk FieldValues :field_id (mt/id :categories :name) :hash_key nil) {:values ["Good" "Bad"]}
       (with-chain-filter-fixtures [{:keys [dashboard]}]
         (testing "GET /api/dashboard/:id/params/:param-key/values"
           (let-url [url (chain-filter-values-url dashboard "_CATEGORY_NAME_")]

--- a/test/metabase/api/database_test.clj
+++ b/test/metabase/api/database_test.clj
@@ -28,7 +28,8 @@
    [ring.util.codec :as codec]
    [schema.core :as s]
    [toucan.db :as db]
-   [toucan.hydrate :as hydrate]))
+   [toucan.hydrate :as hydrate]
+   [toucan2.core :as t2]))
 
 (use-fixtures :once (fixtures/initialize :db :plugins :test-drivers))
 
@@ -190,7 +191,7 @@
              (mt/user-http-request :crowberto :get 200 (format "database/%d/usage_info" db-id)))))
 
     (testing "404 if db does not exist"
-      (let [non-existing-db-id (inc (db/select-one-id Database {:order-by [[:id :desc]]}))]
+      (let [non-existing-db-id (inc (t2/select-one-pk Database {:order-by [[:id :desc]]}))]
         (is (= "Not found."
                (mt/user-http-request :crowberto :get 404
                                      (format "database/%d/usage_info" non-existing-db-id)))))))

--- a/test/metabase/api/public_test.clj
+++ b/test/metabase/api/public_test.clj
@@ -30,7 +30,8 @@
    [metabase.util :as u]
    [schema.core :as s]
    [throttle.core :as throttle]
-   [toucan.db :as db])
+   [toucan.db :as db]
+   [toucan2.core :as t2])
   (:import
    (java.io ByteArrayInputStream)
    (java.util UUID)))
@@ -471,7 +472,7 @@
       (mt/with-temporary-setting-values [enable-public-sharing true]
         (with-temp-public-dashboard-and-card [dash card dashcard]
           (with-temp-public-card [card-2]
-            (mt/with-temp DashboardCardSeries [_ {:dashboardcard_id (db/select-one-id DashboardCard
+            (mt/with-temp DashboardCardSeries [_ {:dashboardcard_id (t2/select-one-pk DashboardCard
                                                                       :card_id      (u/the-id card)
                                                                       :dashboard_id (u/the-id dash))
                                                   :card_id          (u/the-id card-2)}]
@@ -1401,7 +1402,7 @@
                   :post 200
                   (format "public/action/%s/execute" public_uuid)
                   {:parameters {:id 1 :name "European"}})
-                (is (= {:data   {"action_id" (db/select-one-id 'Action :public_uuid public_uuid)
+                (is (= {:data   {"action_id" (t2/select-one-pk 'Action :public_uuid public_uuid)
                                  "event"     "action_executed"
                                  "source"    "public_form"
                                  "type"      "query"}

--- a/test/metabase/api/session_test.clj
+++ b/test/metabase/api/session_test.clj
@@ -23,7 +23,8 @@
    [metabase.util :as u]
    [metabase.util.schema :as su]
    [schema.core :as s]
-   [toucan.db :as db])
+   [toucan.db :as db]
+   [toucan2.core :as t2])
   (:import
    (java.util UUID)))
 
@@ -198,7 +199,7 @@
       ;; Session
       (test.users/clear-cached-session-tokens!)
       (let [session-id       (test.users/username->token :rasta)
-            login-history-id (db/select-one-id LoginHistory :session_id session-id)]
+            login-history-id (t2/select-one-pk LoginHistory :session_id session-id)]
         (testing "LoginHistory should have been recorded"
           (is (integer? login-history-id)))
         ;; Ok, calling the logout endpoint should delete the Session in the DB. Don't worry, `test-users` will log back
@@ -472,7 +473,7 @@
           (is (schema= SessionResponse
                        (mt/client :post 200 "session" {:username "fred.taylor@metabase.com", :password "pa$$word"})))
           (testing "PermissionsGroupMembership should exist"
-            (let [user-id (db/select-one-id User :email "fred.taylor@metabase.com")]
+            (let [user-id (t2/select-one-pk User :email "fred.taylor@metabase.com")]
               (is (db/exists? PermissionsGroupMembership :group_id (u/the-id group) :user_id (u/the-id user-id))))))))))
 
 (deftest no-password-no-login-test

--- a/test/metabase/api/setup_test.clj
+++ b/test/metabase/api/setup_test.clj
@@ -21,7 +21,8 @@
    [metabase.util :as u]
    [metabase.util.schema :as su]
    [schema.core :as schema]
-   [toucan.db :as db]))
+   [toucan.db :as db]
+   [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
 
@@ -90,7 +91,7 @@
                    (public-settings/admin-email))))
 
           (testing "Should record :user-joined Activity (#12933)"
-            (let [user-id (u/the-id (db/select-one-id User :email email))]
+            (let [user-id (u/the-id (t2/select-one-pk User :email email))]
               (is (schema= {:topic         (schema/eq :user-joined)
                             :model_id      (schema/eq user-id)
                             :user_id       (schema/eq user-id)

--- a/test/metabase/api/user_test.clj
+++ b/test/metabase/api/user_test.clj
@@ -23,7 +23,8 @@
    [metabase.util.i18n :as i18n]
    [schema.core :as s]
    [toucan.db :as db]
-   [toucan.hydrate :as hydrate :refer [hydrate]]))
+   [toucan.hydrate :as hydrate :refer [hydrate]]
+   [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
 
@@ -436,7 +437,7 @@
 (defn- superuser-and-admin-pgm-info [email]
   {:is-superuser? (db/select-one-field :is_superuser User :%lower.email (u/lower-case-en email))
    :pgm-exists?   (db/exists? PermissionsGroupMembership
-                    :user_id  (db/select-one-id User :%lower.email (u/lower-case-en email))
+                    :user_id  (t2/select-one-pk User :%lower.email (u/lower-case-en email))
                     :group_id (u/the-id (perms-group/admin)))})
 
 (deftest create-user-add-to-admin-group-test

--- a/test/metabase/driver/postgres_test.clj
+++ b/test/metabase/driver/postgres_test.clj
@@ -34,7 +34,8 @@
    #_{:clj-kondo/ignore [:discouraged-namespace]}
    [metabase.util.honeysql-extensions :as hx]
    [metabase.util.log :as log]
-   [toucan.db :as db])
+   [toucan.db :as db]
+   [toucan2.core :as t2])
   (:import
    (java.sql DatabaseMetaData)))
 
@@ -208,7 +209,7 @@
                    (mt/rows (qp/process-query
                               {:database (u/the-id database)
                                :type     :query
-                               :query    {:source-table (db/select-one-id Table :name "presents-and-gifts")}}))))))))))
+                               :query    {:source-table (t2/select-one-pk Table :name "presents-and-gifts")}}))))))))))
 
 (mt/defdataset duplicate-names
   [["birds"
@@ -829,7 +830,7 @@
                  (driver/describe-table :postgres db {:name "birds"}))))
 
         (testing "check that when syncing the DB the enum types get recorded appropriately"
-          (let [table-id (db/select-one-id Table :db_id (u/the-id db), :name "birds")]
+          (let [table-id (t2/select-one-pk Table :db_id (u/the-id db), :name "birds")]
             (is (= #{{:name "name", :database_type "varchar", :base_type :type/Text}
                      {:name "type", :database_type "bird type", :base_type :type/PostgresEnum}
                      {:name "status", :database_type "bird_status", :base_type :type/PostgresEnum}}
@@ -837,8 +838,8 @@
                              (db/select [Field :name :database_type :base_type] :table_id table-id)))))))
 
         (testing "End-to-end check: make sure everything works as expected when we run an actual query"
-          (let [table-id           (db/select-one-id Table :db_id (u/the-id db), :name "birds")
-                bird-type-field-id (db/select-one-id Field :table_id table-id, :name "type")]
+          (let [table-id           (t2/select-one-pk Table :db_id (u/the-id db), :name "birds")
+                bird-type-field-id (t2/select-one-pk Field :table_id table-id, :name "type")]
             (is (= {:rows        [["Rasta" "good bird" "toucan"]]
                     :native_form {:query  (str "SELECT \"public\".\"birds\".\"name\" AS \"name\","
                                                " \"public\".\"birds\".\"status\" AS \"status\","
@@ -939,7 +940,7 @@
                                                      :percent-state  0.0
                                                      :average-length 12.0}}}}
                  (db/select-field->field :name :fingerprint Field
-                   :table_id (db/select-one-id Table :db_id (u/the-id database))))))))))
+                   :table_id (t2/select-one-pk Table :db_id (u/the-id database))))))))))
 
 
 ;;; ----------------------------------------------------- Other ------------------------------------------------------

--- a/test/metabase/integrations/common_test.clj
+++ b/test/metabase/integrations/common_test.clj
@@ -13,7 +13,8 @@
    [metabase.test :as mt :refer [with-user-in-groups]]
    [metabase.test.fixtures :as fixtures]
    [metabase.util :as u]
-   [toucan.db :as db]))
+   [toucan.db :as db]
+   [toucan2.core :as t2]))
 
 (use-fixtures :once (fixtures/initialize :db))
 
@@ -34,7 +35,7 @@
   (testing "the actual `PermissionsGroupMembership` object should not have been replaced"
     (with-user-in-groups [group {:name (str ::group)}
                           user  [group]]
-      (let [membership-id          #(db/select-one-id PermissionsGroupMembership
+      (let [membership-id          #(t2/select-one-pk PermissionsGroupMembership
                                                       :group_id (u/the-id group)
                                                       :user_id  (u/the-id user))
             original-membership-id (membership-id)]

--- a/test/metabase/models/params/chain_filter_test.clj
+++ b/test/metabase/models/params/chain_filter_test.clj
@@ -8,7 +8,8 @@
    [metabase.models.params.field-values :as params.field-values]
    [metabase.test :as mt]
    [metabase.util :as u]
-   [toucan.db :as db]))
+   [toucan.db :as db]
+   [toucan2.core :as t2]))
 
 (defmacro ^:private chain-filter [field field->value & options]
   `(chain-filter/chain-filter
@@ -484,7 +485,7 @@
             (is (= 1 (db/count FieldValues :field_id field-id :type :linked-filter)))))
 
         (testing "should do in-memory search with the cached FieldValues when search without constraints"
-          (mt/with-temp-vals-in-db FieldValues (db/select-one-id FieldValues :field_id field-id :type "full") {:values ["Good" "Bad"]}
+          (mt/with-temp-vals-in-db FieldValues (t2/select-one-pk FieldValues :field_id field-id :type "full") {:values ["Good" "Bad"]}
             (is (= {:values          ["Good"]
                     :has_more_values false}
                    (chain-filter-search categories.name nil "ood")))))

--- a/test/metabase/pulse_test.clj
+++ b/test/metabase/pulse_test.clj
@@ -21,7 +21,8 @@
    [metabase.test.util :as tu]
    [metabase.util :as u]
    [schema.core :as s]
-   [toucan.db :as db]))
+   [toucan.db :as db]
+   [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
 
@@ -371,7 +372,7 @@
       :fixture
       (fn [{:keys [pulse-id]} thunk]
         (mt/with-temp PulseChannelRecipient [_ {:user_id          (mt/user->id :crowberto)
-                                                :pulse_channel_id (db/select-one-id PulseChannel :pulse_id pulse-id)}]
+                                                :pulse_channel_id (t2/select-one-pk PulseChannel :pulse_id pulse-id)}]
           (thunk)))
 
       :assert

--- a/test/metabase/query_processor/middleware/add_dimension_projections_test.clj
+++ b/test/metabase/query_processor/middleware/add_dimension_projections_test.clj
@@ -8,7 +8,7 @@
     :as qp.add-dimension-projections]
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]
-   [toucan.db :as db]))
+   [toucan2.core :as t2]))
 
 (use-fixtures :once (fixtures/initialize :db))
 
@@ -291,7 +291,7 @@
                                           :alias        "Products"}]
                               :order-by [[:asc $id]]
                               :limit    2})
-              dimension-id (db/select-one-id Dimension :field_id (mt/id :orders :product_id))]
+              dimension-id (t2/select-one-pk Dimension :field_id (mt/id :orders :product_id))]
           (doseq [nesting-level [0 1]
                   :let          [query (mt/nest-query query nesting-level)]]
             (testing (format "nesting level = %d" nesting-level)
@@ -327,7 +327,7 @@
                                                          :order-by [[:asc $name]]
                                                          :limit    4})
             {remap-info :remaps, preprocessed :query} (add-fk-remaps query)
-            dimension-id                              (db/select-one-id Dimension
+            dimension-id                              (t2/select-one-pk Dimension
                                                         :field_id                (mt/id :venues :category_id)
                                                         :human_readable_field_id (mt/id :categories :name))]
         (is (integer? dimension-id))
@@ -379,10 +379,10 @@
                                                           {:fields   [$sender_id $receiver_id $text]
                                                            :order-by [[:asc $id]]
                                                            :limit    3})
-              sender-dimension-id                       (db/select-one-id Dimension
+              sender-dimension-id                       (t2/select-one-pk Dimension
                                                           :field_id                (mt/id :messages :sender_id)
                                                           :human_readable_field_id (mt/id :users :name))
-              receiver-dimension-id                     (db/select-one-id Dimension
+              receiver-dimension-id                     (t2/select-one-pk Dimension
                                                           :field_id                (mt/id :messages :receiver_id)
                                                           :human_readable_field_id (mt/id :users :name))
               {remap-info :remaps, preprocessed :query} (add-fk-remaps query)]

--- a/test/metabase/query_processor_test/remapping_test.clj
+++ b/test/metabase/query_processor_test/remapping_test.clj
@@ -10,7 +10,8 @@
    [metabase.query-processor-test :as qp.test]
    [metabase.query-processor.middleware.add-dimension-projections :as qp.add-dimension-projections]
    [metabase.test :as mt]
-   [toucan.db :as db]))
+   [toucan.db :as db]
+   [toucan2.core :as t2]))
 
 (deftest basic-internal-remapping-test
   (mt/test-drivers (mt/normal-drivers)
@@ -36,7 +37,7 @@
 (deftest basic-external-remapping-test
   (mt/test-drivers (mt/normal-drivers-with-feature :foreign-keys)
     (mt/with-column-remappings [venues.category_id categories.name]
-      (let [dimension-id (db/select-one-id Dimension :field_id (mt/id :venues :category_id))]
+      (let [dimension-id (t2/select-one-pk Dimension :field_id (mt/id :venues :category_id))]
         (is (= {:rows [["American" 2 8]
                        ["Artisan"  3 2]
                        ["Asian"    4 2]]
@@ -148,7 +149,7 @@
                                 :fk_field_id   %category_id
                                 :display_name  "Category ID [external remap]"
                                 :options       {::qp.add-dimension-projections/new-field-dimension-id
-                                                (db/select-one-id Dimension :field_id (mt/id :venues :category_id))}
+                                                (t2/select-one-pk Dimension :field_id (mt/id :venues :category_id))}
                                 :name          (mt/format-name "name_2")
                                 :remapped_from (mt/format-name "category_id")
                                 :field_ref     $category_id->categories.name))]}

--- a/test/metabase/sync/sync_metadata/fields/fetch_metadata_test.clj
+++ b/test/metabase/sync/sync_metadata/fields/fetch_metadata_test.clj
@@ -10,7 +10,8 @@
    [metabase.test :as mt]
    [metabase.test.mock.toucanery :as toucanery]
    [metabase.util :as u]
-   [toucan.db :as db]))
+   [toucan.db :as db]
+   [toucan2.core :as t2]))
 
 ;; `our-metadata` should match up with what we have in the DB
 (deftest does-metadata-match-test
@@ -90,7 +91,7 @@
                                                           :database-required false
                                                           :database-is-auto-increment false}}}}}}
 
-           (let [transactions-table-id   (u/the-id (db/select-one-id Table :db_id (u/the-id db), :name "transactions"))
+           (let [transactions-table-id   (u/the-id (t2/select-one-pk Table :db_id (u/the-id db), :name "transactions"))
                  remove-ids-and-nil-vals (partial walk/postwalk #(if-not (map? %)
                                                                    %
                                                                    ;; database-position isn't stable since they are

--- a/test/metabase/sync/sync_metadata/fields/sync_instances_test.clj
+++ b/test/metabase/sync/sync_metadata/fields/sync_instances_test.clj
@@ -9,7 +9,8 @@
    [metabase.test.mock.toucanery :as toucanery]
    [metabase.util :as u]
    [toucan.db :as db]
-   [toucan.util.test :as tt]))
+   [toucan.util.test :as tt]
+   [toucan2.core :as t2]))
 
 (def ^:private toucannery-transactions-expected-fields-hierarchy
   {"ts"     nil
@@ -33,7 +34,7 @@
                   Table    [table {:name "transactions", :db_id (u/the-id db)}]]
     ;; do the initial sync
     (sync-fields/sync-fields-for-table! table)
-    (let [transactions-table-id (u/the-id (db/select-one-id Table :db_id (u/the-id db), :name "transactions"))]
+    (let [transactions-table-id (u/the-id (t2/select-one-pk Table :db_id (u/the-id db), :name "transactions"))]
       (is (= toucannery-transactions-expected-fields-hierarchy
              (actual-fields-hierarchy transactions-table-id))))))
 
@@ -44,7 +45,7 @@
                     Table    [table {:name "transactions", :db_id (u/the-id db)}]]
       ;; do the initial sync
       (sync-fields/sync-fields-for-table! table)
-      (let [transactions-table-id (u/the-id (db/select-one-id Table :db_id (u/the-id db), :name "transactions"))]
+      (let [transactions-table-id (u/the-id (t2/select-one-pk Table :db_id (u/the-id db), :name "transactions"))]
         (db/delete! Field :table_id transactions-table-id, :name "age")
         ;; ok, resync the Table. `toucan.details.age` should be recreated, but only one. We should *not* have a
         ;; `toucan.age` Field as well, which was happening before the bugfix in this PR
@@ -63,10 +64,10 @@
       ;; do the initial sync
       (sync-metadata/sync-db-metadata! db)
       ;; delete our entry for the `transactions.toucan.details.age` field
-      (let [transactions-table-id (u/the-id (db/select-one-id Table :db_id (u/the-id db), :name "transactions"))
-            toucan-field-id       (u/the-id (db/select-one-id Field :table_id transactions-table-id, :name "toucan"))
-            details-field-id      (u/the-id (db/select-one-id Field :table_id transactions-table-id, :name "details", :parent_id toucan-field-id))
-            age-field-id          (u/the-id (db/select-one-id Field :table_id transactions-table-id, :name "age", :parent_id details-field-id))]
+      (let [transactions-table-id (u/the-id (t2/select-one-pk Table :db_id (u/the-id db), :name "transactions"))
+            toucan-field-id       (u/the-id (t2/select-one-pk Field :table_id transactions-table-id, :name "toucan"))
+            details-field-id      (u/the-id (t2/select-one-pk Field :table_id transactions-table-id, :name "details", :parent_id toucan-field-id))
+            age-field-id          (u/the-id (t2/select-one-pk Field :table_id transactions-table-id, :name "age", :parent_id details-field-id))]
         (db/delete! Field :id age-field-id)
         ;; now sync again.
         (sync-metadata/sync-db-metadata! db)
@@ -79,10 +80,10 @@
       ;; do the initial sync
       (sync-metadata/sync-db-metadata! db)
       ;; delete our entry for the `transactions.toucan.details.age` field
-      (let [transactions-table-id (u/the-id (db/select-one-id Table :db_id (u/the-id db), :name "transactions"))
-            toucan-field-id       (u/the-id (db/select-one-id Field :table_id transactions-table-id, :name "toucan"))
-            details-field-id      (u/the-id (db/select-one-id Field :table_id transactions-table-id, :name "details", :parent_id toucan-field-id))
-            age-field-id          (u/the-id (db/select-one-id Field :table_id transactions-table-id, :name "age", :parent_id details-field-id))]
+      (let [transactions-table-id (u/the-id (t2/select-one-pk Table :db_id (u/the-id db), :name "transactions"))
+            toucan-field-id       (u/the-id (t2/select-one-pk Field :table_id transactions-table-id, :name "toucan"))
+            details-field-id      (u/the-id (t2/select-one-pk Field :table_id transactions-table-id, :name "details", :parent_id toucan-field-id))
+            age-field-id          (u/the-id (t2/select-one-pk Field :table_id transactions-table-id, :name "age", :parent_id details-field-id))]
         (db/update! Field age-field-id :active false)
         ;; now sync again.
         (sync-metadata/sync-db-metadata! db)
@@ -94,10 +95,10 @@
       ;; do the initial sync
       (sync-metadata/sync-db-metadata! db)
       ;; delete our entry for the `transactions.toucan.details.age` field
-      (let [transactions-table-id (u/the-id (db/select-one-id Table :db_id (u/the-id db), :name "transactions"))
-            toucan-field-id       (u/the-id (db/select-one-id Field :table_id transactions-table-id, :name "toucan"))
-            details-field-id      (u/the-id (db/select-one-id Field :table_id transactions-table-id, :name "details", :parent_id toucan-field-id))
-            age-field-id          (u/the-id (db/select-one-id Field :table_id transactions-table-id, :name "age", :parent_id details-field-id))]
+      (let [transactions-table-id (u/the-id (t2/select-one-pk Table :db_id (u/the-id db), :name "transactions"))
+            toucan-field-id       (u/the-id (t2/select-one-pk Field :table_id transactions-table-id, :name "toucan"))
+            details-field-id      (u/the-id (t2/select-one-pk Field :table_id transactions-table-id, :name "details", :parent_id toucan-field-id))
+            age-field-id          (u/the-id (t2/select-one-pk Field :table_id transactions-table-id, :name "age", :parent_id details-field-id))]
         (db/update! Field details-field-id :active false)
         ;; now sync again.
         (sync-metadata/sync-db-metadata! db)
@@ -109,9 +110,9 @@
       ;; do the initial sync
       (sync-metadata/sync-db-metadata! db)
       ;; Add an entry for a `transactions.toucan.details.gender` field
-      (let [transactions-table-id (u/the-id (db/select-one-id Table :db_id (u/the-id db), :name "transactions"))
-            toucan-field-id       (u/the-id (db/select-one-id Field :table_id transactions-table-id, :name "toucan"))
-            details-field-id      (u/the-id (db/select-one-id Field :table_id transactions-table-id, :name "details", :parent_id toucan-field-id))
+      (let [transactions-table-id (u/the-id (t2/select-one-pk Table :db_id (u/the-id db), :name "transactions"))
+            toucan-field-id       (u/the-id (t2/select-one-pk Field :table_id transactions-table-id, :name "toucan"))
+            details-field-id      (u/the-id (t2/select-one-pk Field :table_id transactions-table-id, :name "details", :parent_id toucan-field-id))
             gender-field-id       (u/the-id (db/insert! Field
                                               :name          "gender"
                                               :database_type "VARCHAR"
@@ -130,9 +131,9 @@
       ;; do the initial sync
       (sync-metadata/sync-db-metadata! db)
       ;; Add an entry for a `transactions.toucan.details.gender` field
-      (let [transactions-table-id (u/the-id (db/select-one-id Table :db_id (u/the-id db), :name "transactions"))
-            toucan-field-id       (u/the-id (db/select-one-id Field :table_id transactions-table-id, :name "toucan"))
-            details-field-id      (u/the-id (db/select-one-id Field :table_id transactions-table-id, :name "details", :parent_id toucan-field-id))
+      (let [transactions-table-id (u/the-id (t2/select-one-pk Table :db_id (u/the-id db), :name "transactions"))
+            toucan-field-id       (u/the-id (t2/select-one-pk Field :table_id transactions-table-id, :name "toucan"))
+            details-field-id      (u/the-id (t2/select-one-pk Field :table_id transactions-table-id, :name "details", :parent_id toucan-field-id))
             food-likes-field-id   (u/the-id (db/insert! Field
                                               :name          "food-likes"
                                               :database_type "OBJECT"

--- a/test/metabase/sync/sync_metadata/fields_test.clj
+++ b/test/metabase/sync/sync_metadata/fields_test.clj
@@ -13,7 +13,8 @@
    [metabase.test.data.one-off-dbs :as one-off-dbs]
    [metabase.util :as u]
    [toucan.db :as db]
-   [toucan.hydrate :refer [hydrate]]))
+   [toucan.hydrate :refer [hydrate]]
+   [toucan2.core :as t2]))
 
 (defn- with-test-db-before-and-after-altering
   "Testing function that performs the following steps:
@@ -115,7 +116,7 @@
              (fn [database]
                (-> (qp/process-query {:database (u/the-id database)
                                       :type     :query
-                                      :query    {:source-table (db/select-one-id Table
+                                      :query    {:source-table (t2/select-one-pk Table
                                                                  :db_id (u/the-id database), :name "birds")}})
                    :data
                    :native_form

--- a/test/metabase/test/data/impl.clj
+++ b/test/metabase/test/data/impl.clj
@@ -21,7 +21,8 @@
    [metabase.util :as u]
    [metabase.util.log :as log]
    [potemkin :as p]
-   [toucan.db :as db]))
+   [toucan.db :as db]
+   [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
 
@@ -194,7 +195,7 @@
   [db-id table-name]
   {:pre [(integer? db-id) ((some-fn keyword? string?) table-name)]}
   (let [table-name        (name table-name)
-        table-id-for-name (partial db/select-one-id Table, :db_id db-id, :name)]
+        table-id-for-name (partial t2/select-one-pk Table, :db_id db-id, :name)]
     (or (table-id-for-name table-name)
         (table-id-for-name (let [db-name (db/select-one-field :name Database :id db-id)]
                              (tx/db-qualified-table-name db-name table-name)))
@@ -216,7 +217,7 @@
              [(u/the-id field) (qualified-field-name field)])))
 
 (defn- the-field-id* [table-id field-name & {:keys [parent-id]}]
-  (or (db/select-one-id Field, :active true, :table_id table-id, :name field-name, :parent_id parent-id)
+  (or (t2/select-one-pk Field, :active true, :table_id table-id, :name field-name, :parent_id parent-id)
       (let [{db-id :db_id, table-name :name} (db/select-one [Table :name :db_id] :id table-id)
             db-name                          (db/select-one-field :name Database :id db-id)
             field-name                       (qualified-field-name {:parent_id parent-id, :name field-name})

--- a/test/metabase/test/data/impl/verify.clj
+++ b/test/metabase/test/data/impl/verify.clj
@@ -7,7 +7,7 @@
    [metabase.test.data.interface :as tx]
    [metabase.util :as u]
    [metabase.util.log :as log]
-   [toucan.db :as db]))
+   [toucan2.core :as t2]))
 
 (defmulti verify-data-loaded-correctly
   "Make sure a `DatabaseDefinition` (see `metabase.test.data.interface`) was loaded correctly. This checks that all
@@ -89,7 +89,7 @@
             (throw (ex-info "Error verifying Field." (params->ex-data params) e)))))
       (log/debugf "All Fields for Table %s.%s loaded correctly." (pr-str actual-schema) (pr-str actual-name))
       (log/debugf "Verifying rows...")
-      (let [table-id           (or (db/select-one-id Table :db_id (u/the-id database), :name actual-name)
+      (let [table-id           (or (t2/select-one-pk Table :db_id (u/the-id database), :name actual-name)
                                    (throw (ex-info (format "Cannot find %s.%s after sync." (pr-str actual-schema) (pr-str actual-name))
                                                    (params->ex-data params))))
             expected-row-count (count rows)

--- a/test/metabase/test/util.clj
+++ b/test/metabase/test/util.clj
@@ -872,7 +872,7 @@
                                      remap)
                              remap)]
             (fn []
-              (let [preexisting-id (db/select-one-id FieldValues
+              (let [preexisting-id (t2/select-one-pk FieldValues
                                                      :field_id (:id original)
                                                      :type :full)
                     testing-thunk (fn []


### PR DESCRIPTION
there are no syntax or behavior changes between `db/select-one-id` and `t2/select-one-pk`(given that all of our pk is id).

So this is pretty much just `s/db\/select-one-id/t2\/select-one-pk`. And of course, doing a bunch of imports.