### PR TITLE
db/select-one-field -> t2/select-one-fn

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -134,6 +134,7 @@
    honeysql.core/call        {:message "Use hx/call instead because it is Honey SQL 2 friendly"}
    honeysql.core/raw         {:message "Use hx/raw instead because it is Honey SQL 2 friendly"}
    java-time/with-clock      {:message "Use mt/with-clock"}
+   toucan.db/select-one-field  {:message "Use t2/select-one-fn instead of toucan.db/select-one-field"}
    toucan.db/query           {:message "Use mdb.query/query instead of toucan.db/query"}
    toucan.db/reducible-query {:message "Use mdb.query/reducible-query instead of toucan.db/reducible-query"}}
 

--- a/dev/src/dev/debug_qp.clj
+++ b/dev/src/dev/debug_qp.clj
@@ -1,19 +1,20 @@
 (ns dev.debug-qp
   "TODO -- I think this should be moved to something like [[metabase.test.util.debug-qp]]"
-  (:require [clojure.data :as data]
-            [clojure.pprint :as pprint]
-            [clojure.string :as str]
-            [clojure.walk :as walk]
-            [lambdaisland.deep-diff2 :as ddiff]
-            [medley.core :as m]
-            [metabase.mbql.schema :as mbql.s]
-            [metabase.mbql.util :as mbql.u]
-            [metabase.models.field :refer [Field]]
-            [metabase.models.table :refer [Table]]
-            [metabase.query-processor :as qp]
-            [metabase.query-processor.reducible :as qp.reducible]
-            [metabase.util :as u]
-            [toucan.db :as db]))
+  (:require
+   [clojure.data :as data]
+   [clojure.pprint :as pprint]
+   [clojure.string :as str]
+   [clojure.walk :as walk]
+   [lambdaisland.deep-diff2 :as ddiff]
+   [medley.core :as m]
+   [metabase.mbql.schema :as mbql.s]
+   [metabase.mbql.util :as mbql.u]
+   [metabase.models.field :refer [Field]]
+   [metabase.models.table :refer [Table]]
+   [metabase.query-processor :as qp]
+   [metabase.query-processor.reducible :as qp.reducible]
+   [metabase.util :as u]
+   [toucan.db :as db]))
 
 ;;;; [[->sorted-mbql-query-map]]
 
@@ -98,11 +99,11 @@
 
 (defn- field-and-table-name [field-id]
   (let [{field-name :name, table-id :table_id} (db/select-one [Field :name :table_id] :id field-id)]
-    [(db/select-one-field :name Table :id table-id) field-name]))
+    [(t2/select-one-fn :name Table :id table-id) field-name]))
 
 (defn- add-table-id-name [table-id]
   (list 'do
-        (symbol (format "#_%s" (pr-str (db/select-one-field :name Table :id table-id))))
+        (symbol (format "#_%s" (pr-str (t2/select-one-fn :name Table :id table-id))))
         table-id))
 
 (defn add-names
@@ -576,7 +577,7 @@
 
       (m :guard (every-pred map? (comp integer? :source-table)))
       (-> (update m :source-table (fn [table-id]
-                                    [::$$ (some-> (db/select-one-field :name Table :id table-id) u/lower-case-en)]))
+                                    [::$$ (some-> (t2/select-one-fn :name Table :id table-id) u/lower-case-en)]))
           (expand table))
 
       (m :guard (every-pred map? (comp integer? :fk-field-id)))
@@ -618,7 +619,7 @@
     source-table
     (do
       (assert (integer? source-table))
-      (u/lower-case-en (db/select-one-field :name Table :id source-table)))
+      (u/lower-case-en (t2/select-one-fn :name Table :id source-table)))
 
     source-query
     (recur source-query)))

--- a/dev/src/dev/debug_qp.clj
+++ b/dev/src/dev/debug_qp.clj
@@ -14,7 +14,8 @@
    [metabase.query-processor :as qp]
    [metabase.query-processor.reducible :as qp.reducible]
    [metabase.util :as u]
-   [toucan.db :as db]))
+   [toucan.db :as db]
+   [toucan2.core :as t2]))
 
 ;;;; [[->sorted-mbql-query-map]]
 

--- a/enterprise/backend/src/metabase_enterprise/advanced_permissions/common.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_permissions/common.clj
@@ -5,7 +5,7 @@
    [metabase.models.permissions :as perms]
    [metabase.public-settings.premium-features :as premium-features]
    [metabase.util :as u]
-   [toucan.db :as db]))
+   [toucan2.core :as t2]))
 
 (defn with-advanced-permissions
   "Adds to `user` a set of boolean flag indiciate whether or not current user has access to an advanced permissions.
@@ -29,7 +29,7 @@
 (defn current-user-is-manager-of-group?
   "Return true if current-user is a manager of `group-or-id`."
   [group-or-id]
-  (db/select-one-field :is_group_manager PermissionsGroupMembership
+  (t2/select-one-fn :is_group_manager PermissionsGroupMembership
                        :user_id api/*current-user-id* :group_id (u/the-id group-or-id)))
 
 (defn filter-tables-by-data-model-perms

--- a/enterprise/backend/src/metabase_enterprise/sandbox/models/group_table_access_policy.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/models/group_table_access_policy.clj
@@ -94,7 +94,7 @@
    ;; not all GTAPs have Cards
    (when card-id
      ;; not all Cards have saved result metadata
-     (when-let [result-metadata (db/select-one-field :result_metadata Card :id card-id)]
+     (when-let [result-metadata (t2/select-one-fn :result_metadata Card :id card-id)]
        (check-columns-match-table table-id result-metadata))))
 
   ([table-id :- su/IntGreaterThanZero result-metadata-columns]
@@ -112,7 +112,7 @@
   [{new-result-metadata :result_metadata, card-id :id}]
   (when new-result-metadata
     (when-let [gtaps-using-this-card (not-empty (db/select [GroupTableAccessPolicy :id :table_id] :card_id card-id))]
-      (let [original-result-metadata (db/select-one-field :result_metadata Card :id card-id)]
+      (let [original-result-metadata (t2/select-one-fn :result_metadata Card :id card-id)]
         (when-not (= original-result-metadata new-result-metadata)
           (doseq [{table-id :table_id} gtaps-using-this-card]
             (try
@@ -144,7 +144,7 @@
                       (u/select-keys-when sandbox :present #{:card_id :attribute_remappings})))
         (db/select-one GroupTableAccessPolicy :id id))
       (let [expected-permission-path (perms/table-segmented-query-path (:table_id sandbox))]
-        (when-let [permission-path-id (db/select-one-field :id Permissions :object expected-permission-path)]
+        (when-let [permission-path-id (t2/select-one-fn :id Permissions :object expected-permission-path)]
           (db/insert! GroupTableAccessPolicy (assoc sandbox :permission_id permission-path-id)))))))
 
 (defn- pre-insert [gtap]

--- a/enterprise/backend/src/metabase_enterprise/sandbox/query_processor/middleware/row_level_restrictions.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/query_processor/middleware/row_level_restrictions.clj
@@ -31,7 +31,8 @@
    [metabase.util.log :as log]
    [metabase.util.schema :as su]
    [schema.core :as s]
-   [toucan.db :as db]))
+   [toucan.db :as db]
+   [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
 
@@ -99,7 +100,7 @@
   (when-let [field-id (mbql.u/match-one target-field-clause [:field (field-id :guard integer?) _] field-id)]
     ;; TODO -- we should be using the QP store for this. But when trying to change this I ran into "QP Store is not
     ;; initialized" errors. We should figure out why that's the case and then fix this
-    (db/select-one-field :base_type Field :id field-id)))
+    (t2/select-one-fn :base_type Field :id field-id)))
 
 (defn- attr-value->param-value
   "Take an `attr-value` with a desired `target-type` and coerce to that type if need be. If not type is given or it's
@@ -258,7 +259,7 @@
   [{card-id :card_id, table-id :table_id}]
   (if card-id
     (qp.store/cached card-id
-      (query-perms/perms-set (db/select-one-field :dataset_query Card :id card-id), :throw-exceptions? true))
+      (query-perms/perms-set (t2/select-one-fn :dataset_query Card :id card-id), :throw-exceptions? true))
     #{(perms/table-query-path (db/select-one Table :id table-id))}))
 
 (defn- gtaps->perms-set [gtaps]

--- a/enterprise/backend/src/metabase_enterprise/serialization/load.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/load.clj
@@ -36,7 +36,8 @@
    [metabase.util.i18n :refer [trs]]
    [metabase.util.log :as log]
    [metabase.util.yaml :as yaml]
-   [toucan.db :as db])
+   [toucan.db :as db]
+   [toucan2.core :as t2])
   (:import
    (java.util UUID)))
 
@@ -714,7 +715,7 @@
 (defn- derive-location
   [context]
   (if-let [parent-id (:collection context)]
-    (str (db/select-one-field :location Collection :id parent-id) parent-id "/")
+    (str (t2/select-one-fn :location Collection :id parent-id) parent-id "/")
     "/"))
 
 (defn- make-reload-fn [all-results]

--- a/enterprise/backend/src/metabase_enterprise/serialization/names.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/names.clj
@@ -21,7 +21,8 @@
    [metabase.util.schema :as su]
    [ring.util.codec :as codec]
    [schema.core :as s]
-   [toucan.db :as db]))
+   [toucan.db :as db]
+   [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
 
@@ -199,7 +200,7 @@
                                  :name      collection-name
                                  :namespace (:namespace model-attrs)
                                  :location  (or (letfn [(collection-location [id]
-                                                          (db/select-one-field :location Collection :id id))]
+                                                          (t2/select-one-fn :location Collection :id id))]
                                                   (some-> context
                                                           :collection
                                                           collection-location

--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/extract.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/extract.clj
@@ -13,7 +13,8 @@
    [metabase.models.serialization :as serdes]
    [metabase.util.log :as log]
    [toucan.db :as db]
-   [toucan.hydrate :refer [hydrate]]))
+   [toucan.hydrate :refer [hydrate]]
+   [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
 
@@ -144,7 +145,7 @@
     (log/info "Dashboard cards outside the collection")
     (log/info "======================================")
     (doseq [[dash-id card-ids] escaped-dashcards
-            :let [dash-name (db/select-one-field :name Dashboard :id dash-id)]]
+            :let [dash-name (t2/select-one-fn :name Dashboard :id dash-id)]]
       (log/infof "Dashboard %d: %s\n" dash-id dash-name)
       (doseq [card_id card-ids
               :let [card (db/select-one [Card :collection_id :name] :id card_id)]]

--- a/enterprise/backend/test/metabase_enterprise/advanced_config/file/users_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_config/file/users_test.clj
@@ -6,7 +6,8 @@
    [metabase.models :refer [User]]
    [metabase.public-settings.premium-features-test :as premium-features-test]
    [metabase.util.password :as u.password]
-   [toucan.db :as db]))
+   [toucan.db :as db]
+   [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
 
@@ -32,8 +33,8 @@
         (is (= 1
                (db/count User :email "cam+config-file-test@metabase.com"))))
       (testing "upsert if User already exists"
-        (let [hashed-password          (fn [] (db/select-one-field :password User :email "cam+config-file-test@metabase.com"))
-              salt                     (fn [] (db/select-one-field :password_salt User :email "cam+config-file-test@metabase.com"))
+        (let [hashed-password          (fn [] (t2/select-one-fn :password User :email "cam+config-file-test@metabase.com"))
+              salt                     (fn [] (t2/select-one-fn :password_salt User :email "cam+config-file-test@metabase.com"))
               original-hashed-password (hashed-password)]
           (binding [advanced-config.file/*config* {:version 1
                                                    :config  {:users [{:first_name "Cam"

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/api/group_manager_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/api/group_manager_test.clj
@@ -10,7 +10,8 @@
    [metabase.public-settings.premium-features-test :as premium-features-test]
    [metabase.test :as mt]
    [metabase.util :as u]
-   [toucan.db :as db]))
+   [toucan.db :as db]
+   [toucan2.core :as t2]))
 
 (deftest permissions-group-apis-test
   (testing "/api/permissions/group"
@@ -353,11 +354,11 @@
                                   :is_group_manager true)
 
                 (testing "Can't edit users' info"
-                  (let [current-user-first-name (db/select-one-field :first_name User :id (:id user))]
+                  (let [current-user-first-name (t2/select-one-fn :first_name User :id (:id user))]
                     (update-user-firstname user 200)
                     ;; call still success but first name won't get updated
                     (is (= current-user-first-name
-                           (db/select-one-field :first_name User :id (:id user))))))
+                           (t2/select-one-fn :first_name User :id (:id user))))))
 
                 (testing "Can add/remove user to groups they're manager of"
                   (is (= (set [{:id               (:id (perms-group/all-users))

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
@@ -13,7 +13,8 @@
    [metabase.sync.concurrent :as sync.concurrent]
    [metabase.test :as mt]
    [metabase.util :as u]
-   [toucan.db :as db]))
+   [toucan.db :as db]
+   [toucan2.core :as t2]))
 
 (defn- do-with-all-user-data-perms
   [graph f]
@@ -215,11 +216,11 @@
 
         (testing "A non-admin with no data access can trigger a re-scan of field values if they have data model perms"
           (db/delete! FieldValues :field_id (mt/id :venues :price))
-          (is (= nil (db/select-one-field :values FieldValues, :field_id (mt/id :venues :price))))
+          (is (= nil (t2/select-one-fn :values FieldValues, :field_id (mt/id :venues :price))))
           (with-all-users-data-perms {(mt/id) {:data       {:schemas :block :native :none}
                                                :data-model {:schemas {"PUBLIC" {(mt/id :venues) :all}}}}}
             (mt/user-http-request :rasta :post 200 (format "field/%d/rescan_values" (mt/id :venues :price))))
-          (is (= [1 2 3 4] (db/select-one-field :values FieldValues, :field_id (mt/id :venues :price))))))
+          (is (= [1 2 3 4] (t2/select-one-fn :values FieldValues, :field_id (mt/id :venues :price))))))
 
       (testing "POST /api/field/:id/discard_values"
         (testing "A non-admin can discard field values if they have data model perms for the table"
@@ -230,11 +231,11 @@
             (mt/user-http-request :rasta :post 200 (format "field/%d/discard_values" field-id))))
 
         (testing "A non-admin with no data access can discard field values if they have data model perms"
-          (is (= [1 2 3 4] (db/select-one-field :values FieldValues, :field_id (mt/id :venues :price))))
+          (is (= [1 2 3 4] (t2/select-one-fn :values FieldValues, :field_id (mt/id :venues :price))))
           (with-all-users-data-perms {(mt/id) {:data       {:schemas :block :native :none}
                                                :data-model {:schemas {"PUBLIC" {(mt/id :venues) :all}}}}}
             (mt/user-http-request :rasta :post 200 (format "field/%d/discard_values" (mt/id :venues :price))))
-          (is (= nil (db/select-one-field :values FieldValues, :field_id (mt/id :venues :price)))))))))
+          (is (= nil (t2/select-one-fn :values FieldValues, :field_id (mt/id :venues :price)))))))))
 
 (deftest update-table-test
   (mt/with-temp Table [{table-id :id} {:db_id (mt/id) :schema "PUBLIC"}]
@@ -281,12 +282,12 @@
 
       (testing "A non-admin with no data access can trigger a re-scan of field values if they have data model perms"
         (db/delete! FieldValues :field_id (mt/id :venues :price))
-        (is (= nil (db/select-one-field :values FieldValues, :field_id (mt/id :venues :price))))
+        (is (= nil (t2/select-one-fn :values FieldValues, :field_id (mt/id :venues :price))))
         (with-redefs [sync.concurrent/submit-task (fn [task] (task))]
           (with-all-users-data-perms {(mt/id) {:data       {:schemas :block :native :none}
                                                :data-model {:schemas {"PUBLIC" {(mt/id :venues) :all}}}}}
             (mt/user-http-request :rasta :post 200 (format "table/%d/rescan_values" (mt/id :venues)))))
-        (is (= [1 2 3 4] (db/select-one-field :values FieldValues, :field_id (mt/id :venues :price))))))
+        (is (= [1 2 3 4] (t2/select-one-fn :values FieldValues, :field_id (mt/id :venues :price))))))
 
     (testing "POST /api/table/:id/discard_values"
       (testing "A non-admin can discard field values if they have data model perms for the table"
@@ -396,7 +397,7 @@
         (with-all-users-data-perms {db-id {:data    {:schemas :block :native :none}
                                            :details :yes}}
           (mt/user-http-request :rasta :post 200 (format "database/%d/discard_values" db-id)))
-        (is (= nil (db/select-one-field :values FieldValues, :field_id field-id)))
+        (is (= nil (t2/select-one-fn :values FieldValues, :field_id field-id)))
         (mt/user-http-request :crowberto :post 200 (format "database/%d/rescan_values" db-id)))
 
       ;; Use test database for rescan_values tests so we can verify that scan actually succeeds
@@ -406,11 +407,11 @@
 
       (testing "A non-admin with no data access can trigger a re-scan of field values if they have DB details perms"
         (db/delete! FieldValues :field_id (mt/id :venues :price))
-        (is (= nil (db/select-one-field :values FieldValues, :field_id (mt/id :venues :price))))
+        (is (= nil (t2/select-one-fn :values FieldValues, :field_id (mt/id :venues :price))))
         (with-all-users-data-perms {(mt/id) {:data   {:schemas :block :native :none}
                                              :details :yes}}
           (mt/user-http-request :rasta :post 200 (format "database/%d/rescan_values" (mt/id))))
-        (is (= [1 2 3 4] (db/select-one-field :values FieldValues, :field_id (mt/id :venues :price))))))))
+        (is (= [1 2 3 4] (t2/select-one-fn :values FieldValues, :field_id (mt/id :venues :price))))))))
 
 (deftest fetch-db-test
   (mt/with-temp Database [{db-id :id}]

--- a/enterprise/backend/test/metabase_enterprise/audit_app/api/user_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/audit_app/api/user_test.clj
@@ -4,7 +4,8 @@
    [metabase.models :refer [Card Dashboard DashboardCard Pulse PulseCard PulseChannel PulseChannelRecipient User]]
    [metabase.public-settings.premium-features-test :as premium-features-test]
    [metabase.test :as mt]
-   [toucan.db :as db]))
+   [toucan.db :as db]
+   [toucan2.core :as t2]))
 
 (deftest delete-subscriptions-test
   (testing "DELETE /api/ee/audit-app/user/:id/subscriptions"
@@ -45,8 +46,8 @@
                                                                        :pulse_channel_id dash-sub-chan-id}]]
           (letfn [(describe-objects []
                     {:num-subscriptions                (db/count PulseChannelRecipient :user_id user-id)
-                     :alert-archived?                  (db/select-one-field :archived Pulse :id alert-id)
-                     :dashboard-subscription-archived? (db/select-one-field :archived Pulse :id dash-sub-id)})
+                     :alert-archived?                  (t2/select-one-fn :archived Pulse :id alert-id)
+                     :dashboard-subscription-archived? (t2/select-one-fn :archived Pulse :id dash-sub-id)})
                   (api-delete-subscriptions! [request-user-name-or-id expected-status-code]
                     (mt/user-http-request request-user-name-or-id
                                           :delete expected-status-code

--- a/enterprise/backend/test/metabase_enterprise/audit_app/pages/alerts_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/audit_app/pages/alerts_test.clj
@@ -8,7 +8,7 @@
    [metabase.query-processor :as qp]
    [metabase.test :as mt]
    [metabase.util :as u]
-   [toucan.db :as db]))
+   [toucan2.core :as t2]))
 
 (defn- alerts [card-name]
   (mt/with-test-user :crowberto
@@ -71,7 +71,7 @@
                                "Every hour"
                                (mt/user->id :rasta)
                                "Rasta Toucan"
-                               (db/select-one-field :created_at PulseChannel :id channel-2-id)
+                               (t2/select-one-fn :created_at PulseChannel :id channel-2-id)
                                0]
                               [card-id
                                card-name
@@ -83,7 +83,7 @@
                                "At 8:00 AM, on the first Tuesday of the month"
                                (mt/user->id :rasta)
                                "Rasta Toucan"
-                               (db/select-one-field :created_at PulseChannel :id channel-id)
+                               (t2/select-one-fn :created_at PulseChannel :id channel-id)
                                0]]}
                    (mt/rows+column-names
                     (alerts (str/join (rest (butlast card-name)))))))))))))

--- a/enterprise/backend/test/metabase_enterprise/audit_app/pages/dashboard_subscriptions_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/audit_app/pages/dashboard_subscriptions_test.clj
@@ -8,7 +8,7 @@
    [metabase.query-processor :as qp]
    [metabase.test :as mt]
    [metabase.util :as u]
-   [toucan.db :as db]))
+   [toucan2.core :as t2]))
 
 (defn- dashboard-subscriptions [dashboard-name]
   (mt/with-test-user :crowberto
@@ -69,7 +69,7 @@
                                "Every hour"
                                (mt/user->id :rasta)
                                "Rasta Toucan"
-                               (db/select-one-field :created_at PulseChannel :id channel-2-id)
+                               (t2/select-one-fn :created_at PulseChannel :id channel-2-id)
                                0]
                               [dashboard-id
                                dashboard-name
@@ -81,7 +81,7 @@
                                "At 8:00 AM, on the first Tuesday of the month"
                                (mt/user->id :rasta)
                                "Rasta Toucan"
-                               (db/select-one-field :created_at PulseChannel :id channel-id)
+                               (t2/select-one-fn :created_at PulseChannel :id channel-id)
                                0]]}
                    (mt/rows+column-names
                     (dashboard-subscriptions (str/join (rest (butlast dashboard-name)))))))))))))

--- a/enterprise/backend/test/metabase_enterprise/sandbox/api/dashboard_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/api/dashboard_test.clj
@@ -12,7 +12,8 @@
    [metabase.test :as mt]
    [metabase.util :as u]
    [schema.core :as s]
-   [toucan.db :as db]))
+   [toucan.db :as db]
+   [toucan2.core :as t2]))
 
 (deftest chain-filter-sandboxed-field-values-test
   (testing "When chain filter endpoints would normally return cached FieldValues (#13832), make sure sandboxing is respected"
@@ -66,7 +67,7 @@
              (is (= {:status "ok"}
                     (update-mappings! 200)))
              (is (= new-mappings
-                    (db/select-one-field :parameter_mappings DashboardCard :dashboard_id dashboard-id, :card_id card-id))))))))))
+                    (t2/select-one-fn :parameter_mappings DashboardCard :dashboard_id dashboard-id, :card_id card-id))))))))))
 
 (deftest parameters-with-source-is-card-test
   (testing "dashboard with a parameter that has source is a card, it should respects sandboxing"

--- a/enterprise/backend/test/metabase_enterprise/sandbox/api/gtap_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/api/gtap_test.clj
@@ -10,7 +10,8 @@
    [metabase.server.middleware.util :as mw.util]
    [metabase.test :as mt]
    [schema.core :as s]
-   [toucan.db :as db]))
+   [toucan.db :as db]
+   [toucan2.core :as t2]))
 
 (deftest require-auth-test
   (testing "Must be authenticated to query for GTAPs"
@@ -256,7 +257,7 @@
               (is (db/exists? GroupTableAccessPolicy :table_id table-id-1 :group_id group-id))))
 
           (testing "Test that we can update a sandbox using the permission graph API"
-            (let [sandbox-id (db/select-one-field :id GroupTableAccessPolicy
+            (let [sandbox-id (t2/select-one-fn :id GroupTableAccessPolicy
                                                   :table_id table-id-1
                                                   :group_id group-id)
                   graph      (-> (perms/data-perms-graph)
@@ -273,7 +274,7 @@
                                            :group_id group-id)))))
 
           (testing "Test that we can create and update multiple sandboxes at once using the permission graph API"
-            (let [sandbox-id (db/select-one-field :id GroupTableAccessPolicy
+            (let [sandbox-id (t2/select-one-fn :id GroupTableAccessPolicy
                                                   :table_id table-id-1
                                                   :group_id group-id)
                   graph       (-> (perms/data-perms-graph)

--- a/enterprise/backend/test/metabase_enterprise/sandbox/models/group_table_access_policy_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/models/group_table_access_policy_test.clj
@@ -7,7 +7,8 @@
    [metabase.query-processor :as qp]
    [metabase.test :as mt]
    [metabase.util :as u]
-   [toucan.db :as db]))
+   [toucan.db :as db]
+   [toucan2.core :as t2]))
 
 (deftest normalize-attribute-remappings-test
   (testing "make sure attribute-remappings come back from the DB normalized the way we'd expect"
@@ -20,7 +21,7 @@
       (is (= {"venue_id" {:type   :category
                           :target [:variable [:field (mt/id :venues :id) nil]]
                           :value  5}}
-             (db/select-one-field :attribute_remappings GroupTableAccessPolicy :id (u/the-id gtap)))))
+             (t2/select-one-fn :attribute_remappings GroupTableAccessPolicy :id (u/the-id gtap)))))
 
     (testing (str "apparently sometimes they are saved with just the target, but not type or value? Make sure these "
                   "get normalized correctly.")
@@ -28,7 +29,7 @@
                                                   :group_id             (u/the-id (perms-group/all-users))
                                                   :attribute_remappings {"user" ["variable" ["field" (mt/id :venues :id) nil]]}}]
         (is (= {"user" [:variable [:field (mt/id :venues :id) nil]]}
-               (db/select-one-field :attribute_remappings GroupTableAccessPolicy :id (u/the-id gtap))))))))
+               (t2/select-one-fn :attribute_remappings GroupTableAccessPolicy :id (u/the-id gtap))))))))
 
 (deftest disallow-changing-table-id-test
   (testing "You can't change the table_id of a GTAP after it has been created."

--- a/enterprise/backend/test/metabase_enterprise/serialization/api/serialize_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/api/serialize_test.clj
@@ -6,7 +6,7 @@
     :as premium-features-test]
    [metabase.test :as mt]
    [metabase.util.files :as u.files]
-   [toucan.db :as db]))
+   [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
 
@@ -21,7 +21,7 @@
       (testing "Sanity Check"
         (is (integer? collection-id))
         (is (= collection-id
-               (db/select-one-field :collection_id Card :id card-id))))
+               (t2/select-one-fn :collection_id Card :id card-id))))
       (mt/with-temp-dir [dir "serdes-dir"]
         (f {:collection-id collection-id
             :collection-filename (if collection-slug

--- a/enterprise/backend/test/metabase_enterprise/serialization/test_util.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/test_util.clj
@@ -14,7 +14,8 @@
    [metabase.test :as mt]
    [metabase.test.data :as data]
    [toucan.db :as db]
-   [toucan.util.test :as tt]))
+   [toucan.util.test :as tt]
+   [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
 
@@ -42,7 +43,7 @@
   "Gets the personal collection ID for :crowberto (needed for tests). Must be public because the `with-world` macro
   is public."
   []
-  (db/select-one-field :id Collection :personal_owner_id (mt/user->id :crowberto)))
+  (t2/select-one-fn :id Collection :personal_owner_id (mt/user->id :crowberto)))
 
 (defmacro with-temp-dpc
   "Wraps with-temp*, but binding `*allow-deleting-personal-collections*` to true so that temporary personal collections

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/backfill_ids_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/backfill_ids_test.clj
@@ -5,7 +5,8 @@
    [metabase-enterprise.serialization.v2.backfill-ids :as serdes.backfill]
    [metabase.models :refer [Collection]]
    [metabase.test :as mt]
-   [toucan.db :as db]))
+   [toucan.db :as db]
+   [toucan2.core :as t2]))
 
 (deftest backfill-needed-test
   (mt/with-empty-h2-app-db
@@ -43,9 +44,9 @@
       (testing "backfill"
         (serdes.backfill/backfill-ids-for Collection)
         (testing "sets a blank entity_id"
-          (is (some? (db/select-one-field :entity_id Collection :id c2-id))))
+          (is (some? (t2/select-one-fn :entity_id Collection :id c2-id))))
         (testing "does not change the original entity_id"
-          (is (= c1-eid (db/select-one-field :entity_id Collection :id c1-id))))))))
+          (is (= c1-eid (t2/select-one-fn :entity_id Collection :id c1-id))))))))
 
 (deftest repeatable-test
   (mt/with-empty-h2-app-db
@@ -58,10 +59,10 @@
 
       (testing "backfilling twice"
         (serdes.backfill/backfill-ids-for Collection)
-        (let [first-eid (db/select-one-field :entity_id Collection :id c2-id)]
+        (let [first-eid (t2/select-one-fn :entity_id Collection :id c2-id)]
           (db/update! Collection c2-id {:entity_id nil})
           (is (= #{c1-eid nil}
                  (db/select-field :entity_id Collection)))
           (serdes.backfill/backfill-ids-for Collection)
           (testing "produces the same entity_id both times"
-            (is (= first-eid (db/select-one-field :entity_id Collection :id c2-id)))))))))
+            (is (= first-eid (t2/select-one-fn :entity_id Collection :id c2-id)))))))))

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/e2e_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/e2e_test.clj
@@ -343,7 +343,7 @@
               (testing "for Tables"
                 (doseq [{:keys [db_id name] :as coll} (get @entities "Table")]
                   (is (= (clean-entity coll)
-                         (->> (db/select-one-field :id 'Database :name db_id)
+                         (->> (t2/select-one-fn :id 'Database :name db_id)
                               (db/select-one 'Table :name name :db_id)
                               (serdes/extract-one "Table" {})
                               clean-entity)))))
@@ -352,8 +352,8 @@
                 (doseq [{[db schema table] :table_id name :name :as coll} (get @entities "Field")]
                   (is (nil? schema))
                   (is (= (clean-entity coll)
-                         (->> (db/select-one-field :id 'Database :name db)
-                              (db/select-one-field :id 'Table :schema schema :name table :db_id)
+                         (->> (t2/select-one-fn :id 'Database :name db)
+                              (t2/select-one-fn :id 'Table :schema schema :name table :db_id)
                               (db/select-one 'Field :name name :table_id)
                               (serdes/extract-one "Field" {})
                               clean-entity)))))

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/seed_entity_ids_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/seed_entity_ids_test.clj
@@ -6,7 +6,8 @@
     :as v2.seed-entity-ids]
    [metabase.models :refer [Collection]]
    [metabase.test :as mt]
-   [toucan.db :as db])
+   [toucan.db :as db]
+   [toucan2.core :as t2])
   (:import
    (java.time LocalDateTime)))
 
@@ -23,7 +24,7 @@
                                    :color      "#FF0000"}]
         (db/update! Collection (:id c) :entity_id nil)
         (letfn [(entity-id []
-                  (some-> (db/select-one-field :entity_id Collection :id (:id c)) str/trim))]
+                  (some-> (t2/select-one-fn :entity_id Collection :id (:id c)) str/trim))]
           (is (= nil
                  (entity-id)))
           (testing "Should return truthy on success"
@@ -38,7 +39,7 @@
                                         :color      "#FF0000"}]
             (db/update! Collection (:id c2) :entity_id nil)
             (letfn [(entity-id []
-                      (some-> (db/select-one-field :entity_id Collection :id (:id c2)) str/trim))]
+                      (some-> (t2/select-one-fn :entity_id Collection :id (:id c2)) str/trim))]
               (is (= nil
                      (entity-id)))
               (testing "Should return falsey on error"

--- a/enterprise/backend/test/metabase_enterprise/sso/integrations/jwt_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/integrations/jwt_test.clj
@@ -15,7 +15,8 @@
    [metabase.test.fixtures :as fixtures]
    [metabase.util :as u]
    [toucan.db :as db]
-   [toucan.util.test :as tt]))
+   [toucan.util.test :as tt]
+   [toucan2.core :as t2]))
 
 (use-fixtures :once (fixtures/initialize :test-users))
 
@@ -120,7 +121,7 @@
                  (get-in response [:headers "Location"]))))
         (testing "login attributes"
           (is (= {"extra" "keypairs", "are" "also present"}
-                 (db/select-one-field :login_attributes User :email "rasta@metabase.com"))))))))
+                 (t2/select-one-fn :login_attributes User :email "rasta@metabase.com"))))))))
 
 (deftest no-open-redirect-test
   (testing "Check a JWT with bad (open redirect)"
@@ -184,7 +185,7 @@
             (testing "attributes"
               (is (= {"more" "stuff"
                       "for"  "the new user"}
-                     (db/select-one-field :login_attributes User :email "newuser@metabase.com"))))))))))
+                     (t2/select-one-fn :login_attributes User :email "newuser@metabase.com"))))))))))
 
 (deftest update-account-test
   (testing "A new account with 'Unknown' name will be created for a new JWT user without a first or last name."

--- a/enterprise/backend/test/metabase_enterprise/sso/integrations/saml_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/integrations/saml_test.clj
@@ -20,7 +20,8 @@
    [ring.util.codec :as codec]
    [saml20-clj.core :as saml]
    [saml20-clj.encode-decode :as encode-decode]
-   [toucan.db :as db])
+   [toucan.db :as db]
+   [toucan2.core :as t2])
   (:import
    (java.net URL)
    (java.nio.charset StandardCharsets)
@@ -275,7 +276,7 @@
 
 (defn- saml-login-attributes [email]
   (let [attribute-keys (keys (some-saml-attributes nil))]
-    (-> (db/select-one-field :login_attributes User :email email)
+    (-> (t2/select-one-fn :login_attributes User :email email)
         (select-keys attribute-keys))))
 
 (deftest validate-request-id-test

--- a/modules/drivers/druid/test/metabase/driver/druid/sync_test.clj
+++ b/modules/drivers/druid/test/metabase/driver/druid/sync_test.clj
@@ -7,7 +7,8 @@
             [metabase.timeseries-query-processor-test.util :as tqpt]
             [metabase.util :as u]
             [schema.core :as s]
-            [toucan.db :as db]))
+            [toucan.db :as db]
+            [toucan2.core :as t2]))
 
 (deftest sync-test
   (mt/test-driver :druid
@@ -35,7 +36,7 @@
                    (update :fields (partial sort-by :database-position)))))))))
 
 (defn- db-dbms-version [db-or-id]
-  (db/select-one-field :dbms_version Database :id (u/the-id db-or-id)))
+  (t2/select-one-fn :dbms_version Database :id (u/the-id db-or-id)))
 
 (defn- check-dbms-version [dbms-version]
   (s/check sync-dbms-ver/DBMSVersion dbms-version))

--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -171,7 +171,7 @@
                                                          (name f)))
       (case f
         :database    (api/read-check Database model_id)
-        :table       (api/read-check Database (db/select-one-field :db_id Table, :id model_id))
+        :table       (api/read-check Database (t2/select-one-fn :db_id Table, :id model_id))
         :using_model (api/read-check Card model_id)))
     (let [cards (filter mi/can-read? (cards-for-filter-option f model_id))
           last-edit-info (:card (last-edit/fetch-last-edited-info {:card-ids (map :id cards)}))]
@@ -323,7 +323,7 @@ saved later when it is ready."
                            id))
             :else
             (future
-              (let [current-query (db/select-one-field :dataset_query Card :id id)]
+              (let [current-query (t2/select-one-fn :dataset_query Card :id id)]
                 (if (= (:dataset_query card) current-query)
                   (do (db/update! Card id {:result_metadata metadata})
                       (log/info (trs "Metadata updated asynchronously for card {0}" id)))

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -43,7 +43,8 @@
    [metabase.util.schema :as su]
    [schema.core :as s]
    [toucan.db :as db]
-   [toucan.hydrate :refer [hydrate]])
+   [toucan.hydrate :refer [hydrate]]
+   [toucan2.core :as t2])
   (:import
    (java.util UUID)))
 
@@ -475,7 +476,7 @@
             ;; check whether we'd actually be able to query this Table (do we have ad-hoc data perms for it?)
             (when-not (query-perms/can-query-table? database-id table-id)
               (throw (ex-info (tru "You must have data permissions to add a parameter referencing the Table {0}."
-                                   (pr-str (db/select-one-field :name Table :id table-id)))
+                                   (pr-str (t2/select-one-fn :name Table :id table-id)))
                               {:status-code        403
                                :database-id        database-id
                                :table-id           table-id
@@ -616,7 +617,7 @@
   (api/check-superuser)
   (validation/check-public-sharing-enabled)
   (api/check-not-archived (api/read-check Dashboard dashboard-id))
-  {:uuid (or (db/select-one-field :public_uuid Dashboard :id dashboard-id)
+  {:uuid (or (t2/select-one-fn :public_uuid Dashboard :id dashboard-id)
              (u/prog1 (str (UUID/randomUUID))
                (db/update! Dashboard dashboard-id
                  :public_uuid       <>
@@ -674,7 +675,7 @@
   [:as {dashboard :body}]
   (let [parent-collection-id (if api/*is-superuser?*
                                (:id (populate/get-or-create-root-container-collection))
-                               (db/select-one-field :id 'Collection
+                               (t2/select-one-fn :id 'Collection
                                  :personal_owner_id api/*current-user-id*))]
     (->> (dashboard/save-transient-dashboard! dashboard parent-collection-id)
          (events/publish-event! :dashboard-create))))

--- a/src/metabase/api/embed.clj
+++ b/src/metabase/api/embed.clj
@@ -38,7 +38,8 @@
    [metabase.util.log :as log]
    [metabase.util.schema :as su]
    [schema.core :as s]
-   [toucan.db :as db]))
+   [toucan.db :as db]
+   [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
 
@@ -195,7 +196,7 @@
   [[metabase.api.dashboard/run-query-for-dashcard-async]]."
   [dashboard-id :- su/IntGreaterThanZero
    slug->value  :- {s/Any s/Any}]
-  (let [parameters (db/select-one-field :parameters Dashboard :id dashboard-id)
+  (let [parameters (t2/select-one-fn :parameters Dashboard :id dashboard-id)
         slug->id   (into {} (map (juxt :slug :id)) parameters)]
     (vec (for [[slug value] slug->value
                :let         [slug (u/qualified-name slug)]]
@@ -229,7 +230,7 @@
         add-implicit-card-parameters
         (remove-token-parameters token-params)
         (remove-locked-and-disabled-params (or embedding-params
-                                               (db/select-one-field :embedding_params Card :id card-id))))))
+                                               (t2/select-one-fn :embedding_params Card :id card-id))))))
 
 (defn run-query-for-card-with-params-async
   "Run the query associated with Card with `card-id` using JWT `token-params`, user-supplied URL `query-params`,
@@ -262,7 +263,7 @@
         (substitute-token-parameters-in-text token-params)
         (remove-token-parameters token-params)
         (remove-locked-and-disabled-params (or embedding-params
-                                               (db/select-one-field :embedding_params Dashboard, :id dashboard-id))))))
+                                               (t2/select-one-fn :embedding_params Dashboard, :id dashboard-id))))))
 
 (defn dashcard-results-async
   "Return results for running the query belonging to a DashboardCard. Returns a `StreamingResponse`."
@@ -335,7 +336,7 @@
       :export-format     export-format
       :card-id           card-id
       :token-params      (embed/get-in-unsigned-token-or-throw unsigned-token [:params])
-      :embedding-params  (db/select-one-field :embedding_params Card :id card-id)
+      :embedding-params  (t2/select-one-fn :embedding_params Card :id card-id)
       :query-params      query-params
       :qp-runner         qp-runner
       :constraints       constraints
@@ -405,7 +406,7 @@
       :dashboard-id     dashboard-id
       :dashcard-id      dashcard-id
       :card-id          card-id
-      :embedding-params (db/select-one-field :embedding_params Dashboard :id dashboard-id)
+      :embedding-params (t2/select-one-fn :embedding_params Dashboard :id dashboard-id)
       :token-params     (embed/get-in-unsigned-token-or-throw unsigned-token [:params])
       :query-params     query-params
       :constraints      constraints

--- a/src/metabase/api/field.clj
+++ b/src/metabase/api/field.clj
@@ -24,7 +24,8 @@
    [metabase.util.schema :as su]
    [schema.core :as s]
    [toucan.db :as db]
-   [toucan.hydrate :refer [hydrate]])
+   [toucan.hydrate :refer [hydrate]]
+   [toucan2.core :as t2])
   (:import
    (java.text NumberFormat)))
 
@@ -217,7 +218,7 @@
   ;; `[original remapped]`. The code for this exists in the [[search-values]] function below. So let's just use
   ;; [[search-values]] without a search term to fetch all values.
   (if-let [human-readable-field-id (when (= has-field-values-type :list)
-                                     (db/select-one-field :human_readable_field_id Dimension :field_id (u/the-id field)))]
+                                     (t2/select-one-fn :human_readable_field_id Dimension :field_id (u/the-id field)))]
     {:values          (search-values (api/check-404 field)
                                      (api/check-404 (db/select-one Field :id human-readable-field-id)))
      :field_id        field-id
@@ -335,7 +336,7 @@
   (u/the-id (:table_id field)))
 
 (defn- db-id [field]
-  (u/the-id (db/select-one-field :db_id Table :id (table-id field))))
+  (u/the-id (t2/select-one-fn :db_id Table :id (table-id field))))
 
 (defn- follow-fks
   "Automatically follow the target IDs in an FK `field` until we reach the PK it points to, and return that. For

--- a/src/metabase/api/public.clj
+++ b/src/metabase/api/public.clj
@@ -39,7 +39,8 @@
    [schema.core :as s]
    [throttle.core :as throttle]
    [toucan.db :as db]
-   [toucan.hydrate :refer [hydrate]])
+   [toucan.hydrate :refer [hydrate]]
+   [toucan2.core :as t2])
   (:import
    (clojure.lang ExceptionInfo)))
 
@@ -371,7 +372,7 @@
        (db/exists? Dimension :field_id field-id, :human_readable_field_id search-field-id)
        ;; just do a couple small queries to figure this out, we could write a fancy query to join Field against itself
        ;; and do this in one but the extra code complexity isn't worth it IMO
-       (when-let [table-id (db/select-one-field :table_id Field :id field-id, :semantic_type (mdb.u/isa :type/PK))]
+       (when-let [table-id (t2/select-one-fn :table_id Field :id field-id, :semantic_type (mdb.u/isa :type/PK))]
          (db/exists? Field :id search-field-id, :table_id table-id, :semantic_type (mdb.u/isa :type/Name))))))
 
 (defn- check-field-is-referenced-by-dashboard

--- a/src/metabase/api/query_description.clj
+++ b/src/metabase/api/query_description.clj
@@ -9,7 +9,8 @@
    [metabase.models.segment :refer [Segment]]
    [metabase.util.i18n :refer [deferred-tru]]
    [metabase.util.log :as log]
-   [toucan.db :as db]))
+   [toucan.db :as db]
+   [toucan2.core :as t2]))
 
 (defn- get-table-description
   [metadata _query]
@@ -18,7 +19,7 @@
 (defn- field-clause->display-name [clause]
   (mbql.u/match-one clause
     [:field (id :guard integer?) _]
-    (db/select-one-field :display_name Field :id id)
+    (t2/select-one-fn :display_name Field :id id)
 
     [:field (field-name :guard string?) _]
     field-name))
@@ -41,7 +42,7 @@
 
                              [:metric (arg :guard integer?)]
                              {:type :metric
-                              :arg  (let [metric-name (db/select-one-field :name Metric :id arg)]
+                              :arg  (let [metric-name (t2/select-one-fn :name Metric :id arg)]
                                       (if-not (str/blank? metric-name)
                                         metric-name
                                         (deferred-tru "[Unknown Metric]")))}
@@ -66,7 +67,7 @@
 (defn- get-breakout-description
   [_metadata query]
   (when-let [breakouts (seq (:breakout query))]
-    {:breakout (map #(db/select-one-field :display_name Field :id %) breakouts)}))
+    {:breakout (map #(t2/select-one-fn :display_name Field :id %) breakouts)}))
 
 (defn- get-filter-clause-description
   [_metadata filt]

--- a/src/metabase/api/timeline_event.clj
+++ b/src/metabase/api/timeline_event.clj
@@ -14,7 +14,8 @@
    [metabase.util.i18n :refer [tru]]
    [metabase.util.schema :as su]
    [schema.core :as s]
-   [toucan.db :as db]))
+   [toucan.db :as db]
+   [toucan2.core :as t2]))
 
 #_{:clj-kondo/ignore [:deprecated-var]}
 (api/defendpoint-schema POST "/"
@@ -44,7 +45,7 @@
                           {:creator_id api/*current-user-id*
                            :timestamp  parsed}
                           (when-not icon
-                            {:icon (db/select-one-field :icon Timeline :id timeline_id)}))]
+                            {:icon (t2/select-one-fn :icon Timeline :id timeline_id)}))]
       (snowplow/track-event! ::snowplow/new-event-created
                              api/*current-user-id*
                              (cond-> {:time_matters time_matters

--- a/src/metabase/api/user.clj
+++ b/src/metabase/api/user.clj
@@ -23,7 +23,8 @@
    [metabase.util.schema :as su]
    [schema.core :as s]
    [toucan.db :as db]
-   [toucan.hydrate :refer [hydrate]]))
+   [toucan.hydrate :refer [hydrate]]
+   [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
 
@@ -191,7 +192,7 @@
   "Adds `sso_source` key to the `User`, so FE could determine if the user is logged in via SSO."
   [{:keys [id] :as user}]
   (if (premium-features/enable-sso?)
-    (assoc user :sso_source (db/select-one-field :sso_source User :id id))
+    (assoc user :sso_source (t2/select-one-fn :sso_source User :id id))
     user))
 
 (defn- add-has-question-and-dashboard

--- a/src/metabase/db/data_migrations.clj
+++ b/src/metabase/db/data_migrations.clj
@@ -18,7 +18,8 @@
    [metabase.util :as u]
    [metabase.util.log :as log]
    [toucan.db :as db]
-   [toucan.models :as models]))
+   [toucan.models :as models]
+   [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
 
@@ -190,7 +191,7 @@
   For some reasons during data-migration [[metabase.models.setting/get]] return the default value defined in
   [[metabase.models.setting/defsetting]] instead of value from Setting table."
   [k]
-  (db/select-one-field :value Setting :key (name k)))
+  (t2/select-one-fn :value Setting :key (name k)))
 
 (defn- remove-admin-group-from-mappings-by-setting-key!
   [mapping-setting-key]

--- a/src/metabase/db/metadata_queries.clj
+++ b/src/metabase/db/metadata_queries.clj
@@ -15,7 +15,7 @@
    [metabase.util :as u]
    [metabase.util.schema :as su]
    [schema.core :as s]
-   [toucan.db :as db]))
+   [toucan2.core :as t2]))
 
 (defn- qp-query [db-id mbql-query]
   {:pre [(integer? db-id)]}
@@ -30,7 +30,7 @@
 
 (defn- field-query [{table-id :table_id} mbql-query]
   {:pre [(integer? table-id)]}
-  (qp-query (db/select-one-field :db_id Table, :id table-id)
+  (qp-query (t2/select-one-fn :db_id Table, :id table-id)
             ;; this seeming useless `merge` statement IS in fact doing something important. `ql/query` is a threading
             ;; macro for building queries. Do not remove
             (assoc mbql-query :source-table table-id)))

--- a/src/metabase/driver/util.clj
+++ b/src/metabase/driver/util.clj
@@ -15,7 +15,7 @@
    [metabase.util.log :as log]
    [metabase.util.schema :as su]
    [schema.core :as s]
-   [toucan.db :as db])
+   [toucan2.core :as t2])
   (:import
    (java.io ByteArrayInputStream)
    (java.security KeyFactory KeyStore PrivateKey)
@@ -173,7 +173,7 @@
    ^{::memoize/args-fn (fn [[db-id]]
                          [(mdb.connection/unique-identifier) db-id])}
    (fn [db-id]
-     (db/select-one-field :engine 'Database, :id db-id))
+     (t2/select-one-fn :engine 'Database, :id db-id))
    :ttl/threshold 1000))
 
 (defn database->driver

--- a/src/metabase/events/persisted_info.clj
+++ b/src/metabase/events/persisted_info.clj
@@ -6,7 +6,8 @@
    [metabase.models.persisted-info :as persisted-info]
    [metabase.public-settings :as public-settings]
    [metabase.util.log :as log]
-   [toucan.db :as db]))
+   [toucan.db :as db]
+   [toucan2.core :as t2]))
 
 (def ^:private persisted-info-topics
   "The `Set` of event topics which are subscribed to add persisted-info to new models."
@@ -33,7 +34,7 @@
     (when (and (:dataset card)
                (public-settings/persisted-models-enabled)
                (get-in (db/select-one Database :id (:database_id card)) [:options :persist-models-enabled])
-               (nil? (db/select-one-field :id PersistedInfo :card_id (:id card))))
+               (nil? (t2/select-one-fn :id PersistedInfo :card_id (:id card))))
       (persisted-info/turn-on-model! (:actor_id card) card))
     (catch Throwable e
       (log/warn (format "Failed to process persisted-info event. %s" (:topic event)) e))))

--- a/src/metabase/models/action.clj
+++ b/src/metabase/models/action.clj
@@ -48,7 +48,7 @@
 
 (defn- check-model-is-not-a-saved-question
   [model-id]
-  (when-not (db/select-one-field :dataset Card :id model-id)
+  (when-not (t2/select-one-fn :dataset Card :id model-id)
     (throw (ex-info (tru "Actions must be made with models, not cards.")
                     {:status-code 400}))))
 

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -127,7 +127,7 @@
 
     ;; this is an update, and dataset_query hasn't changed => no-op
     (and existing-card-id
-         (= query (db/select-one-field :dataset_query Card :id existing-card-id)))
+         (= query (t2/select-one-fn :dataset_query Card :id existing-card-id)))
     (do
       (log/debugf "Not inferring result metadata for Card %s: query has not changed" existing-card-id)
       card)
@@ -169,7 +169,7 @@
                   {:status-code 400}))
 
         :else
-        (recur (or (db/select-one-field :dataset_query Card :id source-card-id)
+        (recur (or (t2/select-one-fn :dataset_query Card :id source-card-id)
                    (throw (ex-info (tru "Card {0} does not exist." source-card-id)
                                    {:status-code 404})))
                (conj ids-already-seen source-card-id))))))
@@ -221,7 +221,7 @@
                                                                      :where     [:in :field.id (set field-ids)]})]
         (when-not (= field-db-id query-db-id)
           (throw (ex-info (letfn [(describe-database [db-id]
-                                    (format "%d %s" db-id (pr-str (db/select-one-field :name 'Database :id db-id))))]
+                                    (format "%d %s" db-id (pr-str (t2/select-one-fn :name 'Database :id db-id))))]
                             (tru "Invalid Field Filter: Field {0} belongs to Database {1}, but the query is against Database {2}"
                                  (format "%d %s.%s" field-id (pr-str table-name) (pr-str field-name))
                                  (describe-database field-db-id)

--- a/src/metabase/models/collection.clj
+++ b/src/metabase/models/collection.clj
@@ -27,6 +27,7 @@
    [toucan.db :as db]
    [toucan.hydrate :refer [hydrate]]
    [toucan.models :as models]
+   [toucan2.core :as t2]
    [toucan2.protocols :as t2.protocols])
   (:import
    (metabase.models.collection.root RootCollection)))
@@ -181,7 +182,7 @@
   {:pre [(contains? collection :namespace)]}
   (when location
     (when-let [parent-id (location-path->parent-id location)]
-      (let [parent-namespace (db/select-one-field :namespace Collection :id parent-id)]
+      (let [parent-namespace (t2/select-one-fn :namespace Collection :id parent-id)]
         (when-not (= (keyword collection-namespace) (keyword parent-namespace))
           (let [msg (tru "Collection must be in the same namespace as its parent")]
             (throw (ex-info msg {:status-code 400, :errors {:location msg}})))))))
@@ -955,7 +956,7 @@
         parent-id        (when parent
                            (or (:entity_id parent) (serdes/identity-hash parent)))
         owner-email      (when (:personal_owner_id coll)
-                           (db/select-one-field :email 'User :id (:personal_owner_id coll)))]
+                           (t2/select-one-fn :email 'User :id (:personal_owner_id coll)))]
     (-> (serdes/extract-one-basics "Collection" coll)
         (dissoc :location)
         (assoc :parent_id parent-id :personal_owner_id owner-email)
@@ -982,7 +983,7 @@
   (serdes/maybe-labeled "Collection" coll :slug))
 
 (defmethod serdes/descendants "Collection" [_model-name id]
-  (let [location    (db/select-one-field :location Collection :id id)
+  (let [location    (t2/select-one-fn :location Collection :id id)
         child-colls (set (for [child-id (db/select-ids Collection {:where [:like :location (str location id "/%")]})]
                            ["Collection" child-id]))
         dashboards  (set (for [dash-id (db/select-ids 'Dashboard :collection_id id)]

--- a/src/metabase/models/field.clj
+++ b/src/metabase/models/field.clj
@@ -18,6 +18,7 @@
    [toucan.db :as db]
    [toucan.hydrate :refer [hydrate]]
    [toucan.models :as models]
+   [toucan2.core :as t2]
    [toucan2.tools.hydrate :as t2.hydrate]))
 
 (set! *warn-on-reflection* true)
@@ -351,7 +352,7 @@
   (mdb.connection/memoize-for-application-db
    (fn [field-id]
      {:pre [(integer? field-id)]}
-     (db/select-one-field :table_id Field, :id field-id))))
+     (t2/select-one-fn :table_id Field, :id field-id))))
 
 (defn field-id->database-id
   "Return the ID of the Database this Field belongs to."
@@ -374,7 +375,7 @@
   (let [table (when (number? table_id)
                    (db/select-one 'Table :id table_id))
         db    (when table
-                (db/select-one-field :name 'Database :id (:db_id table)))
+                (t2/select-one-fn :name 'Database :id (:db_id table)))
         [db schema table] (if (number? table_id)
                             [db (:schema table) (:name table)]
                             ;; If table_id is not a number, it's already been exported as a [db schema table] triple.

--- a/src/metabase/models/field_values.clj
+++ b/src/metabase/models/field_values.clj
@@ -31,7 +31,8 @@
    [metabase.util.schema :as su]
    [schema.core :as s]
    [toucan.db :as db]
-   [toucan.models :as models]))
+   [toucan.models :as models]
+   [toucan2.core :as t2]))
 
 (def ^Integer category-cardinality-threshold
   "Fields with less than this many distinct values should automatically be given a semantic type of `:type/Category`.
@@ -135,10 +136,10 @@
                        :status-code 400})))
     ;; if we're updating the values of a Full FieldValues, delete all Advanced FieldValues of this field
     (when (and values
-           (= (or type (db/select-one-field :type FieldValues :id id))
+           (= (or type (t2/select-one-fn :type FieldValues :id id))
               :full))
      (clear-advanced-field-values-for-field! (or field_id
-                                                 (db/select-one-field :field_id FieldValues :id id))))))
+                                                 (t2/select-one-fn :field_id FieldValues :id id))))))
 
 (defn- post-select [field-values]
   (cond-> field-values

--- a/src/metabase/models/metric.clj
+++ b/src/metabase/models/metric.clj
@@ -11,7 +11,8 @@
    [metabase.util :as u]
    [metabase.util.i18n :refer [tru]]
    [toucan.db :as db]
-   [toucan.models :as models]))
+   [toucan.models :as models]
+   [toucan2.core :as t2]))
 
 (models/defmodel Metric :metric)
 
@@ -24,7 +25,7 @@
   (u/prog1 updates
     ;; throw an Exception if someone tries to update creator_id
     (when (contains? updates :creator_id)
-      (when (not= creator_id (db/select-one-field :creator_id Metric :id id))
+      (when (not= creator_id (t2/select-one-fn :creator_id Metric :id id))
         (throw (UnsupportedOperationException. (tru "You cannot update the creator_id of a Metric.")))))))
 
 (defmethod mi/perms-objects-set Metric

--- a/src/metabase/models/native_query_snippet.clj
+++ b/src/metabase/models/native_query_snippet.clj
@@ -8,8 +8,8 @@
    [metabase.util.i18n :refer [deferred-tru tru]]
    [metabase.util.schema :as su]
    [schema.core :as s]
-   [toucan.db :as db]
-   [toucan.models :as models]))
+   [toucan.models :as models]
+   [toucan2.core :as t2]))
 
 ;;; ----------------------------------------------- Entity & Lifecycle -----------------------------------------------
 
@@ -27,7 +27,7 @@
   (u/prog1 updates
     ;; throw an Exception if someone tries to update creator_id
     (when (contains? updates :creator_id)
-      (when (not= creator_id (db/select-one-field :creator_id NativeQuerySnippet :id id))
+      (when (not= creator_id (t2/select-one-fn :creator_id NativeQuerySnippet :id id))
         (throw (UnsupportedOperationException. (tru "You cannot update the creator_id of a NativeQuerySnippet.")))))
     (collection/check-collection-namespace NativeQuerySnippet (:collection_id updates))))
 

--- a/src/metabase/models/params/chain_filter.clj
+++ b/src/metabase/models/params/chain_filter.clj
@@ -85,7 +85,8 @@
    [metabase.util.log :as log]
    [metabase.util.schema :as su]
    [schema.core :as s]
-   [toucan.db :as db]))
+   [toucan.db :as db]
+   [toucan2.core :as t2]))
 
 ;; so the hydration method for name_field is loaded
 (comment params/keep-me)
@@ -137,7 +138,7 @@
           [:= field-clause value]))))
 
 (defn- name-for-logging [model id]
-  (format "%s %d %s" (name model) id (u/format-color 'blue (pr-str (db/select-one-field :name model :id id)))))
+  (format "%s %d %s" (name model) id (u/format-color 'blue (pr-str (t2/select-one-fn :name model :id id)))))
 
 (defn- format-join-for-logging [join]
   (format "%s %s -> %s %s"
@@ -597,12 +598,12 @@
 (defn- check-valid-search-field
   "Before running a search query, make sure the Field actually exists and that it's a Text field."
   [field-id]
-  (let [base-type (db/select-one-field :base_type Field :id field-id)]
+  (let [base-type (t2/select-one-fn :base_type Field :id field-id)]
     (when-not base-type
       (throw (ex-info (tru "Field {0} does not exist." field-id)
                       {:field field-id, :status-code 404})))
     (when-not (isa? base-type :type/Text)
-      (let [field-name (db/select-one-field :name Field :id field-id)]
+      (let [field-name (t2/select-one-fn :name Field :id field-id)]
         (throw (ex-info (tru "Cannot search against non-Text Field {0} {1}" field-id (pr-str field-name))
                         {:status-code 400
                          :field-id    field-id
@@ -645,7 +646,7 @@
 
 (defn- search-cached-field-values? [field-id constraints]
   (and (use-cached-field-values? field-id)
-       (isa? (db/select-one-field :base_type Field :id field-id) :type/Text)
+       (isa? (t2/select-one-fn :base_type Field :id field-id) :type/Text)
        (db/exists? FieldValues (merge {:field_id field-id, :values [:not= nil], :human_readable_values nil}
                                   ;; if we are doing a search, make sure we only use field values
                                   ;; when we're certain the fieldvalues we stored are all the possible values.

--- a/src/metabase/models/pulse.clj
+++ b/src/metabase/models/pulse.clj
@@ -50,7 +50,7 @@
   (let [defaults      {:parameters []}
         dashboard-id  (:dashboard_id notification)
         collection-id (if dashboard-id
-                        (db/select-one-field :collection_id 'Dashboard, :id dashboard-id)
+                        (t2/select-one-fn :collection_id 'Dashboard, :id dashboard-id)
                         (:collection_id notification))
         notification  (->> (for [[k v] notification
                                  :when (some? v)]

--- a/src/metabase/models/pulse_channel.clj
+++ b/src/metabase/models/pulse_channel.clj
@@ -213,7 +213,7 @@
         last-recipient?        (zero? other-recipients-count)]
     (when last-recipient?
       ;; make sure this channel doesn't have any email-address (non-User) recipients.
-      (let [details              (db/select-one-field :details PulseChannel :id channel-id)
+      (let [details              (t2/select-one-fn :details PulseChannel :id channel-id)
             has-email-addresses? (seq (:emails details))]
         (when-not has-email-addresses?
           (db/delete! PulseChannel :id channel-id))))))

--- a/src/metabase/models/query.clj
+++ b/src/metabase/models/query.clj
@@ -8,7 +8,8 @@
    [metabase.models.interface :as mi]
    [metabase.util.honey-sql-2 :as h2x]
    [toucan.db :as db]
-   [toucan.models :as models]))
+   [toucan.models :as models]
+   [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
 
@@ -26,7 +27,7 @@
    Returns `nil` if no information is available."
   ^Integer [^bytes query-hash]
   {:pre [(instance? (Class/forName "[B") query-hash)]}
-  (db/select-one-field :average_execution_time Query :query_hash query-hash))
+  (t2/select-one-fn :average_execution_time Query :query_hash query-hash))
 
 (defn- int-casting-type
   "Return appropriate type for use in SQL `CAST(x AS type)` statement.

--- a/src/metabase/models/revision.clj
+++ b/src/metabase/models/revision.clj
@@ -8,7 +8,8 @@
    [metabase.util.i18n :refer [tru]]
    [toucan.db :as db]
    [toucan.hydrate :refer [hydrate]]
-   [toucan.models :as models]))
+   [toucan.models :as models]
+   [toucan2.core :as t2]))
 
 (def ^:const max-revisions
   "Maximum number of revisions to keep for each individual object. After this limit is surpassed, the oldest revisions
@@ -155,7 +156,7 @@
          (integer? user-id)
          (db/exists? User :id user-id)
          (integer? revision-id)]}
-  (let [serialized-instance (db/select-one-field :object Revision, :model (name entity), :model_id id, :id revision-id)]
+  (let [serialized-instance (t2/select-one-fn :object Revision, :model (name entity), :model_id id, :id revision-id)]
     (db/transaction
       ;; Do the reversion of the object
       (revert-to-revision! entity id user-id serialized-instance)

--- a/src/metabase/models/segment.clj
+++ b/src/metabase/models/segment.clj
@@ -10,7 +10,8 @@
    [metabase.util :as u]
    [metabase.util.i18n :refer [tru]]
    [toucan.db :as db]
-   [toucan.models :as models]))
+   [toucan.models :as models]
+   [toucan2.core :as t2]))
 
 (models/defmodel Segment :segment)
 
@@ -23,7 +24,7 @@
   (u/prog1 updates
     ;; throw an Exception if someone tries to update creator_id
     (when (contains? updates :creator_id)
-      (when (not= creator_id (db/select-one-field :creator_id Segment :id id))
+      (when (not= creator_id (t2/select-one-fn :creator_id Segment :id id))
         (throw (UnsupportedOperationException. (tru "You cannot update the creator_id of a Segment.")))))))
 
 (defmethod mi/perms-objects-set Segment

--- a/src/metabase/models/setting.clj
+++ b/src/metabase/models/setting.clj
@@ -429,14 +429,14 @@
     ;; cannot use db (and cache populated from db) if db is not set up
     (when (and (db-is-set-up?) (allows-site-wide-values? setting))
       (let [v (if *disable-cache*
-                (db/select-one-field :value Setting :key (setting-name setting-definition-or-name))
+                (t2/select-one-fn :value Setting :key (setting-name setting-definition-or-name))
                 (do
                   (setting.cache/restore-cache-if-needed!)
                   (let [cache (setting.cache/cache)]
                     (if (nil? cache)
                       ;; If another thread is populating the cache for the first time, we will have a nil value for
                       ;; the cache and must hit the db while the cache populates
-                      (db/select-one-field :value Setting :key (setting-name setting-definition-or-name))
+                      (t2/select-one-fn :value Setting :key (setting-name setting-definition-or-name))
                       (clojure.core/get cache (setting-name setting-definition-or-name))))))]
         (not-empty v)))))
 

--- a/src/metabase/models/setting/cache.clj
+++ b/src/metabase/models/setting/cache.clj
@@ -9,7 +9,8 @@
    [metabase.util.honey-sql-2 :as h2x]
    [metabase.util.i18n :refer [trs]]
    [metabase.util.log :as log]
-   [toucan.db :as db])
+   [toucan.db :as db]
+   [toucan2.core :as t2])
   (:import
    (java.util.concurrent.locks ReentrantLock)))
 
@@ -90,7 +91,7 @@
                             (with-out-str (jdbc/print-sql-exception-chain e))))))))
   ;; Now that we updated the value in the DB, go ahead and update our cached value as well, because we know about the
   ;; changes
-  (swap! (cache*) assoc settings-last-updated-key (db/select-one-field :value 'Setting :key settings-last-updated-key)))
+  (swap! (cache*) assoc settings-last-updated-key (t2/select-one-fn :value 'Setting :key settings-last-updated-key)))
 
 (defn- cache-out-of-date?
   "Check whether our Settings cache is out of date. We know the cache is out of date if either of the following
@@ -111,7 +112,7 @@
         (when-let [last-known-update (core/get current-cache settings-last-updated-key)]
           ;; compare it to the value in the DB. This is done be seeing whether a row exists
           ;; WHERE value > <local-value>
-          (u/prog1 (db/select-one-field :value 'Setting
+          (u/prog1 (t2/select-one-fn :value 'Setting
                      {:where [:and
                               [:= :key settings-last-updated-key]
                               [:> :value last-known-update]]})

--- a/src/metabase/models/table.clj
+++ b/src/metabase/models/table.clj
@@ -14,7 +14,8 @@
    [metabase.models.serialization :as serdes]
    [metabase.util :as u]
    [toucan.db :as db]
-   [toucan.models :as models]))
+   [toucan.models :as models]
+   [toucan2.core :as t2]))
 
 ;;; ----------------------------------------------- Constants + Entity -----------------------------------------------
 
@@ -44,7 +45,7 @@
 
 (defn- pre-insert [table]
   (let [defaults {:display_name        (humanization/name->human-readable-name (:name table))
-                  :field_order         (driver/default-field-order (db/select-one-field :engine Database :id (:db_id table)))
+                  :field_order         (driver/default-field-order (t2/select-one-fn :engine Database :id (:db_id table)))
                   :initial_sync_status "incomplete"}]
     (merge defaults table)))
 
@@ -211,14 +212,14 @@
   (mdb.connection/memoize-for-application-db
    (fn [table-id]
      {:pre [(integer? table-id)]}
-     (db/select-one-field :db_id Table, :id table-id))))
+     (t2/select-one-fn :db_id Table, :id table-id))))
 
 ;;; ------------------------------------------------- Serialization -------------------------------------------------
 (defmethod serdes/dependencies "Table" [table]
   [[{:model "Database" :id (:db_id table)}]])
 
 (defmethod serdes/generate-path "Table" [_ table]
-  (let [db-name (db/select-one-field :name 'Database :id (:db_id table))]
+  (let [db-name (t2/select-one-fn :name 'Database :id (:db_id table))]
     (filterv some? [{:model "Database" :id db-name}
                     (when (:schema table)
                       {:model "Schema" :id (:schema table)})
@@ -239,12 +240,12 @@
 (defmethod serdes/extract-one "Table"
   [_model-name _opts {:keys [db_id] :as table}]
   (-> (serdes/extract-one-basics "Table" table)
-      (assoc :db_id (db/select-one-field :name 'Database :id db_id))))
+      (assoc :db_id (t2/select-one-fn :name 'Database :id db_id))))
 
 (defmethod serdes/load-xform "Table"
   [{:keys [db_id] :as table}]
   (-> (serdes/load-xform-basics table)
-      (assoc :db_id (db/select-one-field :id 'Database :name db_id))))
+      (assoc :db_id (t2/select-one-fn :id 'Database :name db_id))))
 
 (defmethod serdes/storage-path "Table" [table _ctx]
   (concat (serdes/storage-table-path-prefix (serdes/path table))

--- a/src/metabase/models/task_history.clj
+++ b/src/metabase/models/task_history.clj
@@ -16,7 +16,8 @@
    [metabase.util.schema :as su]
    [schema.core :as s]
    [toucan.db :as db]
-   [toucan.models :as models]))
+   [toucan.models :as models]
+   [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
 
@@ -35,7 +36,7 @@
   ;; the date that task finished, it deletes everything after that. As we continue to add TaskHistory entries, this
   ;; ensures we'll have a good amount of history for debugging/troubleshooting, but not grow too large and fill the
   ;; disk.
-  (when-let [clean-before-date (db/select-one-field :ended_at TaskHistory {:limit    1
+  (when-let [clean-before-date (t2/select-one-fn :ended_at TaskHistory {:limit    1
                                                                            :offset   num-rows-to-keep
                                                                            :order-by [[:ended_at :desc]]})]
     (db/simple-delete! TaskHistory :ended_at [:<= clean-before-date])))
@@ -89,7 +90,7 @@
             :ended_at     (u.date/format-rfc3339 (:ended_at task))}
            (when-let [db-id (:db_id task)]
              {:db_id     db-id
-              :db_engine (db/select-one-field :engine Database :id db-id)}))))
+              :db_engine (t2/select-one-fn :engine Database :id db-id)}))))
 
 (defn- post-insert
   [task]

--- a/src/metabase/query_processor/card.clj
+++ b/src/metabase/query_processor/card.clj
@@ -23,7 +23,8 @@
    [metabase.util.log :as log]
    [metabase.util.schema :as su]
    [schema.core :as s]
-   [toucan.db :as db]))
+   [toucan.db :as db]
+   [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
 
@@ -93,7 +94,7 @@
   parameters to the API request must be allowed for this type (i.e. `:string/=` is allowed for a `:string` parameter,
   but `:number/=` is not)."
   [card-id]
-  (let [query (api/check-404 (db/select-one-field :dataset_query Card :id card-id))]
+  (let [query (api/check-404 (t2/select-one-fn :dataset_query Card :id card-id))]
     (into
      {}
      (comp

--- a/src/metabase/query_processor/middleware/fetch_source_query.clj
+++ b/src/metabase/query_processor/middleware/fetch_source_query.clj
@@ -42,6 +42,7 @@
    [metabase.util.schema :as su]
    [schema.core :as s]
    [toucan.db :as db]
+   [toucan2.core :as t2]
    [weavejester.dependency :as dep]))
 
 (set! *warn-on-reflection* true)
@@ -284,7 +285,7 @@
       extract-resolved-card-id))
 
 (s/defn resolve-card-id-source-tables* :- {:card-id (s/maybe su/IntGreaterThanZero)
-                                                     :query   FullyResolvedQuery}
+                                                    :query   FullyResolvedQuery}
   "Resolve `card__n`-style `:source-tables` in `query`."
   [{inner-query :query, :as outer-query} :- mbql.s/Query]
   (if-not inner-query
@@ -301,7 +302,7 @@
   (fn [query rff context]
     (let [{:keys [query card-id]} (resolve-card-id-source-tables* query)]
       (if card-id
-        (let [dataset? (db/select-one-field :dataset Card :id card-id)]
+        (let [dataset? (t2/select-one-fn :dataset Card :id card-id)]
           (binding [qp.perms/*card-id* (or card-id qp.perms/*card-id*)]
             (qp query
                 (fn [metadata]

--- a/src/metabase/query_processor/middleware/parameters/mbql.clj
+++ b/src/metabase/query_processor/middleware/parameters/mbql.clj
@@ -8,7 +8,7 @@
    [metabase.models.field :refer [Field]]
    [metabase.models.params :as params]
    [schema.core :as s]
-   [toucan.db :as db]))
+   [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
 
@@ -31,7 +31,7 @@
     ;; If it *is* a number then recursively call this function and parse the param value as a number as appropriate.
     (and (#{:id :category} param-type)
          (let [base-type (mbql.u/match-one field-clause
-                           [:field (id :guard integer?) _]  (db/select-one-field :base_type Field :id id)
+                           [:field (id :guard integer?) _]  (t2/select-one-fn :base_type Field :id id)
                            [:field (_ :guard string?) opts] (:base-type opts))]
            (isa? base-type :type/Number)))
     (recur :number param-value field-clause)

--- a/src/metabase/query_processor/middleware/resolve_referenced.clj
+++ b/src/metabase/query_processor/middleware/resolve_referenced.clj
@@ -12,6 +12,7 @@
    [metabase.util.i18n :refer [tru]]
    [schema.core :as s]
    [toucan.db :as db]
+   [toucan2.core :as t2]
    [weavejester.dependency :as dep])
   (:import
    (clojure.lang ExceptionInfo)))
@@ -35,7 +36,7 @@
 
 (defn- card-subquery-graph
   [graph card-id]
-  (let [card-query (db/select-one-field :dataset_query Card :id card-id)]
+  (let [card-query (t2/select-one-fn :dataset_query Card :id card-id)]
     (reduce
      (fn [g sub-card-id]
        (card-subquery-graph (dep/depend g card-id sub-card-id)

--- a/src/metabase/query_processor/middleware/visualization_settings.clj
+++ b/src/metabase/query_processor/middleware/visualization_settings.clj
@@ -5,7 +5,7 @@
    [metabase.public-settings :as public-settings]
    [metabase.query-processor.store :as qp.store]
    [metabase.shared.models.visualization-settings :as mb.viz]
-   [toucan.db :as db]))
+   [toucan2.core :as t2]))
 
 (defn- normalize-field-settings
   [id settings]
@@ -29,7 +29,7 @@
   [query]
   (or (-> query :viz-settings)
       (when-let [card-id (-> query :info :card-id)]
-        (mb.viz/db->norm (db/select-one-field :visualization_settings Card :id card-id)))))
+        (mb.viz/db->norm (t2/select-one-fn :visualization_settings Card :id card-id)))))
 
 (defn update-viz-settings
   "Middleware for fetching and processing a table's visualization settings so that they can be incorporated

--- a/src/metabase/query_processor/store.clj
+++ b/src/metabase/query_processor/store.clj
@@ -310,7 +310,7 @@
 
     ;; cache lookups of Card.dataset_query
     (qp.store/cached card-id
-      (db/select-one-field :dataset_query Card :id card-id))"
+      (t2/select-one-fn :dataset_query Card :id card-id))"
   {:style/indent 1}
   [k-or-ks & body]
   ;; for the unique key use a gensym prefixed by the namespace to make for easier store debugging if needed

--- a/src/metabase/setup.clj
+++ b/src/metabase/setup.clj
@@ -4,7 +4,8 @@
    [metabase.db.connection :as mdb.connection]
    [metabase.models.setting :as setting :refer [defsetting Setting]]
    [metabase.models.user :refer [User]]
-   [toucan.db :as db])
+   [toucan.db :as db]
+   [toucan2.core :as t2])
   (:import
    (java.util UUID)))
 
@@ -33,7 +34,7 @@
   ;; value or setting DB values and the like
   (or (when-let [mb-setup-token (env/env :mb-setup-token)]
         (setting/set-value-of-type! :string :setup-token mb-setup-token))
-      (db/select-one-field :value Setting :key "setup-token")
+      (t2/select-one-fn :value Setting :key "setup-token")
       (setting/set-value-of-type! :string :setup-token (str (UUID/randomUUID)))))
 
 (defsetting has-user-setup

--- a/src/metabase/sync/analyze/classify.clj
+++ b/src/metabase/sync/analyze/classify.clj
@@ -32,7 +32,8 @@
    [metabase.util :as u]
    [metabase.util.log :as log]
    [schema.core :as s]
-   [toucan.db :as db]))
+   [toucan.db :as db]
+   [toucan2.core :as t2]))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                         CLASSIFYING INDIVIDUAL FIELDS                                          |
@@ -96,7 +97,7 @@
   "Run various classifiers on `field` and its `fingerprint`, and save any detected changes."
   ([field :- i/FieldInstance]
    (classify! field (or (:fingerprint field)
-                        (db/select-one-field :fingerprint Field :id (u/the-id field)))))
+                        (t2/select-one-fn :fingerprint Field :id (u/the-id field)))))
 
   ([field :- i/FieldInstance, fingerprint :- (s/maybe i/Fingerprint)]
    (sync-util/with-error-handling (format "Error classifying %s" (sync-util/name-for-logging field))

--- a/src/metabase/task/follow_up_emails.clj
+++ b/src/metabase/task/follow_up_emails.clj
@@ -13,7 +13,8 @@
    [metabase.task :as task]
    [metabase.util.date-2 :as u.date]
    [metabase.util.log :as log]
-   [toucan.db :as db]))
+   [toucan.db :as db]
+   [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
 
@@ -48,7 +49,7 @@
 (defn- instance-creation-timestamp
   "The date this Metabase instance was created. We use the `:date_joined` of the first `User` to determine this."
   ^java.time.temporal.Temporal []
-  (db/select-one-field :date_joined User, {:order-by [[:date_joined :asc]]}))
+  (t2/select-one-fn :date_joined User, {:order-by [[:date_joined :asc]]}))
 
 (jobs/defjob ^{:doc "Sends out a general 2 week email follow up email"} FollowUpEmail [_]
   ;; if we've already sent the follow-up email then we are done

--- a/src/metabase/task/persist_refresh.clj
+++ b/src/metabase/task/persist_refresh.clj
@@ -68,7 +68,7 @@
 
 (defn- refresh-with-stats! [refresher database stats persisted-info]
   ;; Since this could be long running, double check state just before refreshing
-  (when (contains? refreshable-states (db/select-one-field :state PersistedInfo :id (:id persisted-info)))
+  (when (contains? refreshable-states (t2/select-one-fn :state PersistedInfo :id (:id persisted-info)))
     (log/info (trs "Attempting to refresh persisted model {0}." (:card_id persisted-info)))
     (let [card (db/select-one Card :id (:card_id persisted-info))
           definition (persisted-info/metadata->definition (:result_metadata card)
@@ -133,7 +133,7 @@
           unpersist-fn (fn []
                          (reduce (fn [stats persisted-info]
                                    ;; Since this could be long running, double check state just before deleting
-                                   (let [current-state (db/select-one-field :state PersistedInfo :id (:id persisted-info))
+                                   (let [current-state (t2/select-one-fn :state PersistedInfo :id (:id persisted-info))
                                          card-info     (db/select-one [Card :archived :dataset]
                                                                       :id (:card_id persisted-info))]
                                      (if (or (contains? prunable-states current-state)

--- a/src/metabase/transforms/core.clj
+++ b/src/metabase/transforms/core.clj
@@ -19,7 +19,8 @@
    [metabase.util.i18n :refer [tru]]
    [metabase.util.schema :as su]
    [schema.core :as s]
-   [toucan.db :as db]))
+   [toucan.db :as db]
+   [toucan2.core :as t2]))
 
 (s/defn ^:private add-bindings :- Bindings
   [bindings :- Bindings, source :- SourceName, new-bindings :- (s/maybe DimensionBindings)]
@@ -37,7 +38,7 @@
     field-name
 
     [:field (id :guard integer?) _]
-    (db/select-one-field :name Field :id id)))
+    (t2/select-one-fn :name Field :id id)))
 
 (s/defn ^:private infer-resulting-dimensions :- DimensionBindings
   [bindings :- Bindings, {:keys [joins name]} :- Step, query :- mbql.s/Query]

--- a/test/metabase/analytics/snowplow_test.clj
+++ b/test/metabase/analytics/snowplow_test.clj
@@ -10,7 +10,8 @@
    [metabase.test.fixtures :as fixtures]
    [metabase.util :as u]
    [metabase.util.date-2 :as u.date]
-   [toucan.db :as db])
+   [toucan.db :as db]
+   [toucan2.core :as t2])
   (:import
    (java.util LinkedHashMap)))
 
@@ -169,7 +170,7 @@
           (is (= [] (pop-event-data-and-user-id!))))))))
 
 (deftest instance-creation-test
-  (let [original-value (db/select-one-field :value Setting :key "instance-creation")]
+  (let [original-value (t2/select-one-fn :value Setting :key "instance-creation")]
     (try
       (testing "Instance creation timestamp is set only once when setting is first fetched"
         (db/delete! Setting :key "instance-creation")

--- a/test/metabase/api/action_test.clj
+++ b/test/metabase/api/action_test.clj
@@ -357,9 +357,9 @@
               action-path    (str "action/" action-id)]
           (testing "Archiving"
             (mt/user-http-request :crowberto :put 200 action-path {:archived true})
-            (is (true? (db/select-one-field :archived Action :id action-id)))
+            (is (true? (t2/select-one-fn :archived Action :id action-id)))
             (mt/user-http-request :crowberto :put 200 action-path {:archived false})
-            (is (false? (db/select-one-field :archived Action :id action-id))))
+            (is (false? (t2/select-one-fn :archived Action :id action-id))))
           (testing "Validate POST"
             (testing "Required fields"
               (is (partial= {:errors {:name "string"},

--- a/test/metabase/api/alert_test.clj
+++ b/test/metabase/api/alert_test.clj
@@ -15,7 +15,8 @@
    [metabase.test :as mt]
    [metabase.test.mock.util :refer [pulse-channel-defaults]]
    [metabase.util :as u]
-   [toucan.db :as db]))
+   [toucan.db :as db]
+   [toucan2.core :as t2]))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                              Helper Fns & Macros                                               |
@@ -795,7 +796,7 @@
                (with-alert-setup
                  (et/with-expected-messages 1 (api:unsubscribe! :rasta 204 alert))
                  (array-map
-                  :archived? (db/select-one-field :archived Pulse :id (u/the-id alert))
+                  :archived? (t2/select-one-fn :archived Pulse :id (u/the-id alert))
                   :emails    (et/regex-email-bodies #"https://metabase.com/testmb"
                                                     #"Foo"))))))))
 
@@ -812,7 +813,7 @@
                (with-alert-setup
                  (et/with-expected-messages 1 (api:unsubscribe! :rasta 204 alert))
                  (array-map
-                  :archived? (db/select-one-field :archived Pulse :id (u/the-id alert))
+                  :archived? (t2/select-one-fn :archived Pulse :id (u/the-id alert))
                   :emails    (et/regex-email-bodies #"https://metabase.com/testmb"
                                                     #"Foo"))))))))
 
@@ -833,7 +834,7 @@
                    ((alert-client :crowberto)
                     :put 200 (alert-url alert) (assoc-in (default-alert-req card pc-1) [:channels 0 :enabled] false)))
                  (array-map
-                  :archived? (db/select-one-field :archived Pulse :id (u/the-id alert))
+                  :archived? (t2/select-one-fn :archived Pulse :id (u/the-id alert))
                   :emails    (et/regex-email-bodies #"https://metabase.com/testmb"
                                                     #"letting you know that Crowberto Corv"))))))))
 
@@ -854,7 +855,7 @@
                    ((alert-client :crowberto)
                     :put 200 (alert-url alert) (assoc-in (default-alert-req card pc-1) [:channels 0 :enabled] true)))
                  (array-map
-                  :archived? (db/select-one-field :archived Pulse :id (u/the-id alert))
+                  :archived? (t2/select-one-fn :archived Pulse :id (u/the-id alert))
                   :emails    (et/regex-email-bodies #"https://metabase.com/testmb"
                                                     #"now getting alerts about .*Foo")
                   :emails  (et/regex-email-bodies #"https://metabase.com/testmb"

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -49,7 +49,8 @@
    [metabase.util.schema :as su]
    [schema.core :as s]
    [toucan.db :as db]
-   [toucan.hydrate :refer [hydrate]])
+   [toucan.hydrate :refer [hydrate]]
+   [toucan2.core :as t2])
   (:import
    (java.io ByteArrayInputStream)
    (java.util UUID)
@@ -247,7 +248,7 @@
              (fn [[f timestamp] [card-or-id username]]
                [(fn []
                   (let [card-id   (u/the-id card-or-id)
-                        card-name (db/select-one-field :name Card :id card-id)]
+                        card-name (t2/select-one-fn :name Card :id card-id)]
                     (testing (format "\nCard %d %s viewed by %s on %s" card-id (pr-str card-name) username timestamp)
                       (mt/with-temp ViewLog [_ {:model     "card"
                                                 :model_id  card-id
@@ -580,7 +581,7 @@
                        :semantic_type :type/Quantity
                        :source        :aggregation
                        :field_ref     [:aggregation 0]}]
-                     (db/select-one-field :result_metadata Card :name card-name))))))))))
+                     (t2/select-one-fn :result_metadata Card :name card-name))))))))))
 
 (deftest updating-card-updates-metadata
   (let [query          (mt/mbql-query venues {:fields [$id $name]})
@@ -607,7 +608,7 @@
                :rasta :put 200 (str "card/" card-id)
                (assoc card :dataset_query modified-query))
               (is (= ["ID" "NAME" "PRICE"]
-                     (map norm (db/select-one-field :result_metadata Card :id card-id)))))))))
+                     (map norm (t2/select-one-fn :result_metadata Card :id card-id)))))))))
     (testing "Updating other parts but not query does not update the metadata"
       (let [orig   qp.async/result-metadata-for-query-async
             called (atom 0)]
@@ -681,7 +682,7 @@
                                                   :nil%           0.0},
                                          :type   {:type/Number {:min 100.0, :max 100.0, :avg 100.0, :q1 100.0, :q3 100.0 :sd nil}}}
                          :field_ref     [:field "count" {:base-type (count-base-type)}]}]
-                       (db/select-one-field :result_metadata Card :name card-name))))
+                       (t2/select-one-fn :result_metadata Card :name card-name))))
               (testing "Was the user id found in the generated SQL?"
                 (is (= true
                        (boolean
@@ -846,13 +847,13 @@
   (mt/with-temp Card [card {:name "Original Name"}]
     (with-cards-in-writeable-collection card
       (is (= "Original Name"
-             (db/select-one-field :name Card, :id (u/the-id card))))
+             (t2/select-one-fn :name Card, :id (u/the-id card))))
       (is (= {:timestamp true, :first_name "Rasta", :last_name "Toucan", :email "rasta@metabase.com", :id true}
              (-> (mt/user-http-request :rasta :put 200 (str "card/" (u/the-id card)) {:name "Updated Name"})
                  mt/boolean-ids-and-timestamps
                  :last-edit-info)))
       (is (= "Updated Name"
-             (db/select-one-field :name Card, :id (u/the-id card)))))))
+             (t2/select-one-fn :name Card, :id (u/the-id card)))))))
 
 (deftest can-we-update-a-card-s-archived-status-
   (mt/with-temp Card [card]
@@ -889,14 +890,14 @@
     (mt/with-temp Card [card {:description "What a nice Card"}]
       (with-cards-in-writeable-collection card
         (mt/user-http-request :rasta :put 200 (str "card/" (u/the-id card)) {:description nil})
-        (is (nil? (db/select-one-field :description Card :id (u/the-id card))))))))
+        (is (nil? (t2/select-one-fn :description Card :id (u/the-id card))))))))
 
 (deftest description-should-be-blankable-as-well
   (mt/with-temp Card [card {:description "What a nice Card"}]
     (with-cards-in-writeable-collection card
       (mt/user-http-request :rasta :put 200 (str "card/" (u/the-id card)) {:description ""})
       (is (= ""
-             (db/select-one-field :description Card :id (u/the-id card)))))))
+             (t2/select-one-fn :description Card :id (u/the-id card)))))))
 
 (deftest update-card-parameters-test
   (testing "PUT /api/card/:id"
@@ -961,7 +962,7 @@
           (mt/user-http-request :crowberto :put 200 (str "card/" (u/the-id card))
                                 {:embedding_params {:abc "enabled"}})
           (is (= {:abc "enabled"}
-                 (db/select-one-field :embedding_params Card :id (u/the-id card)))))))))
+                 (t2/select-one-fn :embedding_params Card :id (u/the-id card)))))))))
 
 (deftest can-we-change-the-collection-position-of-a-card-
   (mt/with-temp Card [card]
@@ -969,7 +970,7 @@
       (mt/user-http-request :rasta :put 200 (str "card/" (u/the-id card))
                             {:collection_position 1})
       (is (= 1
-             (db/select-one-field :collection_position Card :id (u/the-id card)))))))
+             (t2/select-one-fn :collection_position Card :id (u/the-id card)))))))
 
 (deftest can-we-change-the-collection-preview-flag-of-a-card-
   (mt/with-temp Card [card]
@@ -977,7 +978,7 @@
       (mt/user-http-request :rasta :put 200 (str "card/" (u/the-id card))
                             {:collection_preview false})
       (is (= false
-             (db/select-one-field :collection_preview Card :id (u/the-id card)))))))
+             (t2/select-one-fn :collection_preview Card :id (u/the-id card)))))))
 
 (deftest ---and-unset--unpin--it-as-well-
   (mt/with-temp Card [card {:collection_position 1}]
@@ -985,7 +986,7 @@
       (mt/user-http-request :rasta :put 200 (str "card/" (u/the-id card))
                             {:collection_position nil})
       (is (= nil
-             (db/select-one-field :collection_position Card :id (u/the-id card)))))))
+             (t2/select-one-fn :collection_position Card :id (u/the-id card)))))))
 
 (deftest ---we-shouldn-t-be-able-to-if-we-don-t-have-permissions-for-the-collection
   (mt/with-non-admin-groups-no-root-collection-perms
@@ -994,7 +995,7 @@
       (mt/user-http-request :rasta :put 403 (str "card/" (u/the-id card))
                             {:collection_position 1})
       (is (= nil
-             (db/select-one-field :collection_position Card :id (u/the-id card)))))))
+             (t2/select-one-fn :collection_position Card :id (u/the-id card)))))))
 
 (deftest gets-a-card
   (mt/with-non-admin-groups-no-root-collection-perms
@@ -1003,7 +1004,7 @@
       (mt/user-http-request :rasta :put 403 (str "card/" (u/the-id card))
                             {:collection_position nil})
       (is (= 1
-             (db/select-one-field :collection_position Card :id (u/the-id card)))))))
+             (t2/select-one-fn :collection_position Card :id (u/the-id card)))))))
 
 (deftest update-card-validation-test
   (testing "PUT /api/card"
@@ -1273,7 +1274,7 @@
                              (update-card! :rasta 403 {:dataset_query (mt/mbql-query users)}))))
               (testing "make sure query hasn't changed in the DB"
                 (is (= (mt/mbql-query checkins)
-                       (db/select-one-field :dataset_query Card :id card-id)))))
+                       (t2/select-one-fn :dataset_query Card :id card-id)))))
 
             (testing "should be allowed to update other fields if query is passed in but hasn't changed (##11719)"
               (is (schema= {:id            (s/eq card-id)
@@ -1686,7 +1687,7 @@
         (let [card (mt/user-http-request :rasta :post 200 "card"
                                          (assoc (card-with-name-and-query)
                                                 :collection_id (u/the-id collection)))]
-          (is (= (db/select-one-field :collection_id Card :id (u/the-id card))
+          (is (= (t2/select-one-fn :collection_id Card :id (u/the-id card))
                  (u/the-id collection))))))))
 
 (deftest make-sure-we-card-creation-fails-if-we-try-to-set-a--collection-id--we-don-t-have-permissions-for
@@ -1705,7 +1706,7 @@
     (mt/with-temp* [Card       [card]
                     Collection [collection]]
       (mt/user-http-request :crowberto :put 200 (str "card/" (u/the-id card)) {:collection_id (u/the-id collection)})
-      (is (= (db/select-one-field :collection_id Card :id (u/the-id card))
+      (is (= (t2/select-one-fn :collection_id Card :id (u/the-id card))
              (u/the-id collection))))))
 
 (deftest update-card-require-parent-perms-test
@@ -1739,7 +1740,7 @@
             (testing "Should be able to change it once you have perms for both collections"
               (perms/grant-collection-readwrite-permissions! (perms-group/all-users) original-collection)
               (change-collection! 200)
-              (is (= (db/select-one-field :collection_id Card :id (u/the-id card))
+              (is (= (t2/select-one-fn :collection_id Card :id (u/the-id card))
                      (u/the-id new-collection))))))))))
 
 
@@ -2158,13 +2159,13 @@
                                                  [:native
                                                   (u/the-id native-ds) (u/the-id native-nested)]]]
           (query! card-id) ;; populate metadata
-          (let [metadata (db/select-one-field :result_metadata Card :id card-id)
+          (let [metadata (t2/select-one-fn :result_metadata Card :id card-id)
                 ;; simulate updating metadat with user changed stuff
                 user-edited (add-preserved metadata)]
             (db/update! Card card-id :result_metadata user-edited)
             (testing "Saved metadata preserves user edits"
               (is (= (map only-user-edits user-edited)
-                     (map only-user-edits (db/select-one-field :result_metadata Card :id card-id)))))
+                     (map only-user-edits (t2/select-one-fn :result_metadata Card :id card-id)))))
             (testing "API response includes user edits"
               (is (= (map only-user-edits user-edited)
                      (->> (query! card-id)
@@ -2215,7 +2216,7 @@
                           (map (comp u/upper-case-en :display_name)))))
               (is (= ["EDITED DISPLAY" "EDITED DISPLAY" "PRICE"]
                      (map (comp u/upper-case-en :display_name)
-                          (db/select-one-field :result_metadata Card :id card-id))))
+                          (t2/select-one-fn :result_metadata Card :id card-id))))
               (testing "Even if you only send the new query and not existing metadata"
                 (is (= ["EDITED DISPLAY" "EDITED DISPLAY"]
                      (->> (update-card! {:id (u/the-id card) :dataset_query query}) :result_metadata (map :display_name)))))

--- a/test/metabase/api/collection_test.clj
+++ b/test/metabase/api/collection_test.clj
@@ -36,6 +36,7 @@
    [metabase.util.schema :as su]
    [schema.core :as s]
    [toucan.db :as db]
+   [toucan2.core :as t2]
    [toucan2.tools.with-temp :as t2.with-temp])
   (:import
    (java.time ZoneId ZonedDateTime)))
@@ -1473,12 +1474,12 @@
                                          {:name "foo" :authority_level "official"})
                    :authority_level)))
         (is (= :official
-               (db/select-one-field :authority_level Collection :id (u/the-id collection)))))
+               (t2/select-one-fn :authority_level Collection :id (u/the-id collection)))))
       (testing "But not for personal collections"
         (let [personal-coll (collection/user->personal-collection (mt/user->id :crowberto))]
           (mt/user-http-request :crowberto :put 403 (str "collection/" (u/the-id personal-coll))
                                 {:authority_level "official"})
-          (is (nil? (db/select-one-field :authority_level Collection :id (u/the-id personal-coll))))))
+          (is (nil? (t2/select-one-fn :authority_level Collection :id (u/the-id personal-coll))))))
       (testing "And not for children of personal collections"
         (let [personal-coll (collection/user->personal-collection (mt/user->id :crowberto))]
           (mt/with-temp Collection [child-coll]

--- a/test/metabase/api/database_test.clj
+++ b/test/metabase/api/database_test.clj
@@ -28,7 +28,8 @@
    [ring.util.codec :as codec]
    [schema.core :as s]
    [toucan.db :as db]
-   [toucan.hydrate :as hydrate]))
+   [toucan.hydrate :as hydrate]
+   [toucan2.core :as t2]))
 
 (use-fixtures :once (fixtures/initialize :db :plugins :test-drivers))
 
@@ -328,7 +329,7 @@
           (let [updates {:auto_run_queries false}]
             (mt/user-http-request :crowberto :put 200 (format "database/%d" db-id) updates))
           (is (= false
-                 (db/select-one-field :auto_run_queries Database, :id db-id))))))
+                 (t2/select-one-fn :auto_run_queries Database, :id db-id))))))
     (testing "should be able to unset cache_ttl"
       (mt/with-temp Database [{db-id :id}]
         (let [updates1 {:cache_ttl    1337}
@@ -1442,7 +1443,7 @@
   (testing "Admins should be allowed to update Database-local Settings (#19409)"
     (mt/with-temp-vals-in-db Database (mt/id) {:settings nil}
       (letfn [(settings []
-                (db/select-one-field :settings Database :id (mt/id)))
+                (t2/select-one-fn :settings Database :id (mt/id)))
               (set-settings! [m]
                 (mt/user-http-request :crowberto :put 200 (format "database/%d" (mt/id))
                                       {:settings m}))]

--- a/test/metabase/api/field_test.clj
+++ b/test/metabase/api/field_test.clj
@@ -14,7 +14,8 @@
    [metabase.util :as u]
    [ring.util.codec :as codec]
    [toucan.db :as db]
-   [toucan.hydrate :refer [hydrate]]))
+   [toucan.hydrate :refer [hydrate]]
+   [toucan2.core :as t2]))
 
 (use-fixtures :once (fixtures/initialize :plugins))
 
@@ -182,7 +183,7 @@
     (testing "when we set the semantic-type from `:type/FK` to something else, make sure `:fk_target_field_id` is set to nil"
       (mt/with-temp* [Field [{fk-field-id :id}]
                       Field [{field-id :id} {:semantic_type :type/FK, :fk_target_field_id fk-field-id}]]
-        (let [original-val (boolean (db/select-one-field :fk_target_field_id Field, :id field-id))]
+        (let [original-val (boolean (t2/select-one-fn :fk_target_field_id Field, :id field-id))]
           (testing "before API call"
             (is (= true
                    original-val)))
@@ -190,7 +191,7 @@
           (mt/user-http-request :crowberto :put 200 (format "field/%d" field-id) {:semantic_type :type/Name})
           (testing "after API call"
             (is (= nil
-                   (db/select-one-field :fk_target_field_id Field, :id field-id)))))))))
+                   (t2/select-one-fn :fk_target_field_id Field, :id field-id)))))))))
 
 (deftest update-fk-target-field-id-test
   (testing "PUT /api/field/:id"
@@ -199,7 +200,7 @@
         (mt/user-http-request :crowberto :put 200 (str "field/" field-id)
                               {:semantic_type :type/Quantity})
         (is (= :type/Quantity
-               (db/select-one-field :semantic_type Field, :id field-id)))))))
+               (t2/select-one-fn :semantic_type Field, :id field-id)))))))
 
 (defn- field->field-values
   "Fetch the `FieldValues` object that corresponds to a given `Field`."

--- a/test/metabase/api/metric_test.clj
+++ b/test/metabase/api/metric_test.clj
@@ -13,8 +13,8 @@
    [metabase.test :as mt]
    [metabase.test.data :as data]
    [metabase.util :as u]
-   [toucan.db :as db]
-   [toucan.hydrate :refer [hydrate]]))
+   [toucan.hydrate :refer [hydrate]]
+   [toucan2.core :as t2]))
 
 ;; ## Helper Fns
 
@@ -169,7 +169,7 @@
                   :crowberto :put 200 (str "metric/" id)
                   {:archived true, :revision_message "Archive the Metric"})))
       (is (= true
-             (db/select-one-field :archived Metric :id id))))))
+             (t2/select-one-fn :archived Metric :id id))))))
 
 (deftest unarchive-test
   (testing "Can we unarchive a Metric with the PUT endpoint?"
@@ -177,7 +177,7 @@
       (is (some? (mt/user-http-request
                   :crowberto :put 200 (str "metric/" id)
                   {:archived false, :revision_message "Unarchive the Metric"})))
-      (is (= false (db/select-one-field :archived Metric :id id))))))
+      (is (= false (t2/select-one-fn :archived Metric :id id))))))
 
 (deftest delete-test
   (testing "DELETE /api/metric/:id"

--- a/test/metabase/api/native_query_snippet_test.clj
+++ b/test/metabase/api/native_query_snippet_test.clj
@@ -9,7 +9,8 @@
    [metabase.util.schema :as su]
    [schema.core :as s]
    [toucan.db :as db]
-   [toucan.util.test :as tt]))
+   [toucan.util.test :as tt]
+   [toucan2.core :as t2]))
 
 (def ^:private test-snippet-fields [:content :creator_id :description :name])
 
@@ -169,7 +170,7 @@
         (mt/with-temp NativeQuerySnippet [snippet {:name "test-snippet", :content "1", :creator_id (mt/user->id :lucky)}]
           (mt/user-http-request :crowberto :put 200 (snippet-url (:id snippet)) {:creator_id (mt/user->id :rasta)})
           (is (= (mt/user->id :lucky)
-                 (db/select-one-field :creator_id NativeQuerySnippet :id (:id snippet)))))))))
+                 (t2/select-one-fn :creator_id NativeQuerySnippet :id (:id snippet)))))))))
 
 (deftest update-snippet-collection-test
   (testing "PUT /api/native-query-snippet/:id"
@@ -188,7 +189,7 @@
                              (select-keys [:collection_id :errors])))))
                 (testing "\nvalue in app DB"
                   (is (= (:id dest)
-                         (db/select-one-field :collection_id NativeQuerySnippet :id snippet-id)))))))))
+                         (t2/select-one-fn :collection_id NativeQuerySnippet :id snippet-id)))))))))
 
       (testing "\nShould throw an error if you try to move it to a Collection not in the 'snippets' namespace"
         (tt/with-temp* [Collection         [{collection-id :id}]

--- a/test/metabase/api/public_test.clj
+++ b/test/metabase/api/public_test.clj
@@ -30,7 +30,8 @@
    [metabase.util :as u]
    [schema.core :as s]
    [throttle.core :as throttle]
-   [toucan.db :as db])
+   [toucan.db :as db]
+   [toucan2.core :as t2])
   (:import
    (java.io ByteArrayInputStream)
    (java.util UUID)))
@@ -608,7 +609,7 @@
 
 (deftest double-check-that-the-field-has-fieldvalues
   (is (= [1 2 3 4]
-         (db/select-one-field :values FieldValues :field_id (mt/id :venues :price)))))
+         (t2/select-one-fn :values FieldValues :field_id (mt/id :venues :price)))))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                        New FieldValues search endpoints                                        |

--- a/test/metabase/api/pulse_test.clj
+++ b/test/metabase/api/pulse_test.clj
@@ -26,7 +26,8 @@
    [metabase.test.mock.util :refer [pulse-channel-defaults]]
    [metabase.util :as u]
    [schema.core :as s]
-   [toucan.db :as db]))
+   [toucan.db :as db]
+   [toucan2.core :as t2]))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                              Helper Fns & Macros                                               |
@@ -492,7 +493,7 @@
                     Collection [collection]]
       (mt/user-http-request :crowberto :put 200 (str "pulse/" (u/the-id pulse))
                             {:collection_id (u/the-id collection)})
-      (is (= (db/select-one-field :collection_id Pulse :id (u/the-id pulse))
+      (is (= (t2/select-one-fn :collection_id Pulse :id (u/the-id pulse))
              (u/the-id collection))))))
 
 (deftest change-collection-test
@@ -505,7 +506,7 @@
         ;; now make an API call to move collections
         (mt/user-http-request :rasta :put 200 (str "pulse/" (u/the-id pulse)) {:collection_id (u/the-id new-collection)})
         ;; Check to make sure the ID has changed in the DB
-        (is (= (db/select-one-field :collection_id Pulse :id (u/the-id pulse))
+        (is (= (t2/select-one-fn :collection_id Pulse :id (u/the-id pulse))
                (u/the-id new-collection)))))
 
     (testing "...but if we don't have the Permissions for the old collection, we should get an Exception"
@@ -534,7 +535,7 @@
       (mt/user-http-request :rasta :put 200 (str "pulse/" (u/the-id pulse))
                             {:collection_position 1})
       (is (= 1
-             (db/select-one-field :collection_position Pulse :id (u/the-id pulse)))))
+             (t2/select-one-fn :collection_position Pulse :id (u/the-id pulse)))))
 
     (testing "...and unset (unpin) it as well?"
       (pulse-test/with-pulse-in-collection [_ collection pulse]
@@ -543,21 +544,21 @@
         (mt/user-http-request :rasta :put 200 (str "pulse/" (u/the-id pulse))
                               {:collection_position nil})
         (is (= nil
-               (db/select-one-field :collection_position Pulse :id (u/the-id pulse))))))
+               (t2/select-one-fn :collection_position Pulse :id (u/the-id pulse))))))
 
     (testing "...we shouldn't be able to if we don't have permissions for the Collection"
       (pulse-test/with-pulse-in-collection [_db _collection pulse]
         (mt/user-http-request :rasta :put 403 (str "pulse/" (u/the-id pulse))
                               {:collection_position 1})
         (is (= nil
-               (db/select-one-field :collection_position Pulse :id (u/the-id pulse))))
+               (t2/select-one-fn :collection_position Pulse :id (u/the-id pulse))))
 
         (testing "shouldn't be able to unset (unpin) a Pulse"
           (db/update! Pulse (u/the-id pulse) :collection_position 1)
           (mt/user-http-request :rasta :put 403 (str "pulse/" (u/the-id pulse))
                                 {:collection_position nil})
           (is (= 1
-                 (db/select-one-field :collection_position Pulse :id (u/the-id pulse)))))))))
+                 (t2/select-one-fn :collection_position Pulse :id (u/the-id pulse)))))))))
 
 (deftest archive-test
   (testing "Can we archive a Pulse?"
@@ -566,7 +567,7 @@
       (mt/user-http-request :rasta :put 200 (str "pulse/" (u/the-id pulse))
                             {:archived true})
       (is (= true
-             (db/select-one-field :archived Pulse :id (u/the-id pulse)))))))
+             (t2/select-one-fn :archived Pulse :id (u/the-id pulse)))))))
 
 (deftest unarchive-test
   (testing "Can we unarchive a Pulse?"
@@ -576,7 +577,7 @@
       (mt/user-http-request :rasta :put 200 (str "pulse/" (u/the-id pulse))
                             {:archived false})
       (is (= false
-             (db/select-one-field :archived Pulse :id (u/the-id pulse))))))
+             (t2/select-one-fn :archived Pulse :id (u/the-id pulse))))))
 
   (testing "Does unarchiving a Pulse affect its Cards & Recipients? It shouldn't. This should behave as a PATCH-style endpoint!"
     (mt/with-non-admin-groups-no-root-collection-perms

--- a/test/metabase/api/segment_test.clj
+++ b/test/metabase/api/segment_test.clj
@@ -12,8 +12,8 @@
    [metabase.server.middleware.util :as mw.util]
    [metabase.test :as mt]
    [metabase.util :as u]
-   [toucan.db :as db]
-   [toucan.hydrate :refer [hydrate]]))
+   [toucan.hydrate :refer [hydrate]]
+   [toucan2.core :as t2]))
 
 ;; ## Helper Fns
 
@@ -173,7 +173,7 @@
         (is (map? (mt/user-http-request :crowberto :put 200 (str "segment/" id)
                                         {:archived true, :revision_message "Archive the Segment"})))
         (is (= true
-               (db/select-one-field :archived Segment :id id)))))))
+               (t2/select-one-fn :archived Segment :id id)))))))
 
 (deftest unarchive-test
   (testing "PUT /api/segment/:id"
@@ -182,7 +182,7 @@
         (is (map? (mt/user-http-request :crowberto :put 200 (str "segment/" id)
                                         {:archived false, :revision_message "Unarchive the Segment"})))
         (is (= false
-               (db/select-one-field :archived Segment :id id)))))))
+               (t2/select-one-fn :archived Segment :id id)))))))
 
 
 ;; ## DELETE /api/segment/:id

--- a/test/metabase/api/setup_test.clj
+++ b/test/metabase/api/setup_test.clj
@@ -21,7 +21,8 @@
    [metabase.util :as u]
    [metabase.util.schema :as su]
    [schema.core :as schema]
-   [toucan.db :as db]))
+   [toucan.db :as db]
+   [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
 
@@ -181,7 +182,7 @@
                      (db/exists? Database :name db-name))))
             (testing (format "should be able to set %s to %s (default: %s) during creation" k (pr-str v) default)
               (is (= (if (some? v) v default)
-                     (db/select-one-field k Database :name db-name))))))))
+                     (t2/select-one-fn k Database :name db-name))))))))
 
     (testing "Setup should trigger sync right away for the newly created Database (#12826)"
       (let [db-name (mt/random-name)]

--- a/test/metabase/api/timeline_test.clj
+++ b/test/metabase/api/timeline_test.clj
@@ -12,7 +12,8 @@
    [metabase.server.middleware.util :as mw.util]
    [metabase.test :as mt]
    [metabase.util :as u]
-   [toucan.db :as db]))
+   [toucan.db :as db]
+   [toucan2.core :as t2]))
 
 (deftest auth-tests
   (testing "Authentication"
@@ -162,7 +163,7 @@
                      (-> (db/select-one Timeline :collection_id id) :name))))
             (testing "Check that the icon is 'star' by default"
               (is (= "star"
-                     (-> (db/select-one-field :icon Timeline :collection_id id)))))))))))
+                     (-> (t2/select-one-fn :icon Timeline :collection_id id)))))))))))
 
 (deftest update-timeline-test
   (testing "PUT /api/timeline/:id"

--- a/test/metabase/api/user_test.clj
+++ b/test/metabase/api/user_test.clj
@@ -23,7 +23,8 @@
    [metabase.util.i18n :as i18n]
    [schema.core :as s]
    [toucan.db :as db]
-   [toucan.hydrate :as hydrate :refer [hydrate]]))
+   [toucan.hydrate :as hydrate :refer [hydrate]]
+   [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
 
@@ -434,7 +435,7 @@
                  (db/exists? User :%lower.email (u/lower-case-en email)))))))))
 
 (defn- superuser-and-admin-pgm-info [email]
-  {:is-superuser? (db/select-one-field :is_superuser User :%lower.email (u/lower-case-en email))
+  {:is-superuser? (t2/select-one-fn :is_superuser User :%lower.email (u/lower-case-en email))
    :pgm-exists?   (db/exists? PermissionsGroupMembership
                     :user_id  (db/select-one-id User :%lower.email (u/lower-case-en email))
                     :group_id (u/the-id (perms-group/admin)))})
@@ -498,7 +499,7 @@
   ::personal-collection-name
   "Hydrate `::personal-collection-name`. This is just for tests."
   [user]
-  (db/select-one-field :name Collection :id (:personal_collection_id user)))
+  (t2/select-one-fn :name Collection :id (:personal_collection_id user)))
 
 (deftest admin-update-other-user-test
   (testing "PUT /api/user/:id"
@@ -766,7 +767,7 @@
                  (user-test/user-group-names (mt/user->id :rasta)))))
         (testing "first name"
           (is (= "Rasta"
-                 (db/select-one-field :first_name User :id (mt/user->id :rasta)))))))
+                 (t2/select-one-fn :first_name User :id (mt/user->id :rasta)))))))
 
     (testing "if we pass user_group_memberships as a non-superuser the call should succeed, so long as the value doesn't change"
       (mt/with-temp-vals-in-db User (mt/user->id :rasta) {:first_name "Rasta"}
@@ -779,7 +780,7 @@
                  (user-test/user-group-names (mt/user->id :rasta)))))
         (testing "first name"
           (is (= "Reggae"
-                 (db/select-one-field :first_name User :id (mt/user->id :rasta)))))))
+                 (t2/select-one-fn :first_name User :id (mt/user->id :rasta)))))))
 
     (testing (str "We should be able to put someone in the Admin group when we update them them (is_superuser = TRUE "
                   "and user_group_memberships including admin group ID)")
@@ -799,7 +800,7 @@
                                :first_name             "Cool New First Name"})
         (is (= {:is-superuser? false, :pgm-exists? false, :first-name "Old First Name"}
                (assoc (superuser-and-admin-pgm-info email)
-                      :first-name (db/select-one-field :first_name User :id id))))))
+                      :first-name (t2/select-one-fn :first_name User :id id))))))
 
     (testing (str "if we try to create a new user with is_superuser TRUE but user_group_memberships that does not include the Admin "
                   "group ID, things should fail")
@@ -826,7 +827,7 @@
 
   (testing "Double-check that the test cleaned up after itself"
     (is (= "Rasta"
-           (db/select-one-field :first_name User :id (mt/user->id :rasta))))
+           (t2/select-one-fn :first_name User :id (mt/user->id :rasta))))
     (is (= {:name "Rasta Toucan's Personal Collection"
             :slug "rasta_toucan_s_personal_collection"}
            (mt/derecordize (db/select-one [Collection :name :slug] :personal_owner_id (mt/user->id :rasta)))))))
@@ -839,7 +840,7 @@
                            :put expected-status-code (str "user/" user-id)
                            {:locale new-locale}))
               (locale-from-db []
-                (db/select-one-field :locale User :id user-id))]
+                (t2/select-one-fn :locale User :id user-id))]
         (let [url (str "user/" user-id)]
           (testing "normal Users should be able to update their own locale"
             (doseq [[message locale] {"to a language-country locale (with dash)"       "es-MX"
@@ -899,7 +900,7 @@
                                :last_name  "whatever"
                                :email      (:email user)})
         (is (= true
-               (db/select-one-field :is_active User :id (:id user)))
+               (t2/select-one-fn :is_active User :id (:id user)))
             "the user should now be active")))
 
     (testing "error conditions"
@@ -932,12 +933,12 @@
 (defn- user-can-reset-password? [superuser?]
   (mt/with-temp User [user {:password "def", :is_superuser (boolean superuser?)}]
     (let [creds           {:username (:email user), :password "def"}
-          hashed-password (db/select-one-field :password User, :%lower.email (u/lower-case-en (:email user)))]
+          hashed-password (t2/select-one-fn :password User, :%lower.email (u/lower-case-en (:email user)))]
       ;; use API to reset the users password
       (mt/client creds :put 200 (format "user/%d/password" (:id user)) {:password     "abc123!!DEF"
                                                                         :old_password "def"})
       ;; now simply grab the lastest pass from the db and compare to the one we have from before reset
-      (not= hashed-password (db/select-one-field :password User, :%lower.email (u/lower-case-en (:email user)))))))
+      (not= hashed-password (t2/select-one-fn :password User, :%lower.email (u/lower-case-en (:email user)))))))
 
 (deftest can-reset-password-test
   (testing "PUT /api/user/:id/password"
@@ -1017,12 +1018,12 @@
           (let [creds {:username "def@metabase.com"
                        :password "def123"}]
             (testing "defaults to true"
-              (is (true? (db/select-one-field property User, :id id))))
+              (is (true? (t2/select-one-fn property User, :id id))))
             (testing "response"
               (is (= {:success true}
                      (mt/client creds :put 200 (format "user/%d/modal/%s" id endpoint)))))
             (testing (str endpoint "?")
-              (is (false? (db/select-one-field property User, :id id)))))))
+              (is (false? (t2/select-one-fn property User, :id id)))))))
 
       (testing "shouldn't be allowed to set someone else's status"
         (is (= "You don't have permissions to do that."

--- a/test/metabase/cmd/rotate_encryption_key_test.clj
+++ b/test/metabase/cmd/rotate_encryption_key_test.clj
@@ -21,7 +21,8 @@
    [metabase.util.i18n :as i18n]
    [methodical.core :as methodical]
    [toucan.db :as db]
-   [toucan.models :as models])
+   [toucan.models :as models]
+   [toucan2.core :as t2])
   (:import
    (java.nio.charset StandardCharsets)))
 
@@ -125,13 +126,13 @@
                   ;; plain->newkey
                   (testing "for unencrypted values"
                     (is (not= "unencrypted value" (raw-value "nocrypt")))
-                    (is (= "unencrypted value" (db/select-one-field :value Setting :key "nocrypt")))
-                    (is (mt/secret-value-equals? secret-val (db/select-one-field :value Secret :id @secret-id-unenc))))
+                    (is (= "unencrypted value" (t2/select-one-fn :value Setting :key "nocrypt")))
+                    (is (mt/secret-value-equals? secret-val (t2/select-one-fn :value Secret :id @secret-id-unenc))))
                   ;; samekey->samekey
                   (testing "for values encrypted with the same key"
                     (is (not= "encrypted with k1" (raw-value "k1crypted")))
-                    (is (= "encrypted with k1" (db/select-one-field :value Setting :key "k1crypted")))
-                    (is (mt/secret-value-equals? secret-val (db/select-one-field :value Secret :id @secret-id-enc))))))
+                    (is (= "encrypted with k1" (t2/select-one-fn :value Setting :key "k1crypted")))
+                    (is (mt/secret-value-equals? secret-val (t2/select-one-fn :value Secret :id @secret-id-enc))))))
 
               (testing "settings-last-updated is updated AND plaintext"
                 (is (not= original-timestamp (raw-value "settings-last-updated")))
@@ -141,15 +142,15 @@
                 (encryption-test/with-secret-key k1 (rotate-encryption-key! k2))
                 (testing "with new key"
                   (encryption-test/with-secret-key k2
-                    (is (= "unencrypted value" (db/select-one-field :value Setting :key "nocrypt")))
-                    (is (= {:db "/tmp/test.db"} (db/select-one-field :details Database :id 1)))
-                    (is (mt/secret-value-equals? secret-val (db/select-one-field :value Secret :id @secret-id-unenc)))))
+                    (is (= "unencrypted value" (t2/select-one-fn :value Setting :key "nocrypt")))
+                    (is (= {:db "/tmp/test.db"} (t2/select-one-fn :details Database :id 1)))
+                    (is (mt/secret-value-equals? secret-val (t2/select-one-fn :value Secret :id @secret-id-unenc)))))
                 (testing "but not with old key"
                   (encryption-test/with-secret-key k1
-                    (is (not= "unencrypted value" (db/select-one-field :value Setting :key "nocrypt")))
-                    (is (not= "{\"db\":\"/tmp/test.db\"}" (db/select-one-field :details Database :id 1)))
+                    (is (not= "unencrypted value" (t2/select-one-fn :value Setting :key "nocrypt")))
+                    (is (not= "{\"db\":\"/tmp/test.db\"}" (t2/select-one-fn :details Database :id 1)))
                     (is (not (mt/secret-value-equals? secret-val
-                                                      (db/select-one-field :value Secret :id @secret-id-unenc)))))))
+                                                      (t2/select-one-fn :value Secret :id @secret-id-unenc)))))))
 
               (testing "full rollback when a database details looks encrypted with a different key than the current one"
                 (encryption-test/with-secret-key k3
@@ -165,8 +166,8 @@
                        #"Can't decrypt app db with MB_ENCRYPTION_SECRET_KEY"
                        (rotate-encryption-key! k3))))
                 (encryption-test/with-secret-key k3
-                  (is (not= {:db "/tmp/k2.db"} (db/select-one-field :details Database :name "k2")))
-                  (is (= {:db "/tmp/k3.db"} (db/select-one-field :details Database :name "k3")))))
+                  (is (not= {:db "/tmp/k2.db"} (t2/select-one-fn :details Database :name "k2")))
+                  (is (= {:db "/tmp/k3.db"} (t2/select-one-fn :details Database :name "k3")))))
 
               (testing "rotate-encryption-key! to nil decrypts the encrypted keys"
                 (db/update! Database 1 {:details "{\"db\":\"/tmp/test.db\"}"})
@@ -176,8 +177,8 @@
                 (is (= "unencrypted value" (raw-value "nocrypt")))
                 ;; at this point, both the originally encrypted, and the originally unencrypted secret instances
                 ;; should be decrypted
-                (is (mt/secret-value-equals? secret-val (db/select-one-field :value Secret :id @secret-id-unenc)))
-                (is (mt/secret-value-equals? secret-val (db/select-one-field :value Secret :id @secret-id-enc))))
+                (is (mt/secret-value-equals? secret-val (t2/select-one-fn :value Secret :id @secret-id-unenc)))
+                (is (mt/secret-value-equals? secret-val (t2/select-one-fn :value Secret :id @secret-id-enc))))
 
               (testing "short keys fail to rotate"
                 (is (thrown? Throwable (rotate-encryption-key! "short")))))))))))

--- a/test/metabase/db/data_migrations_test.clj
+++ b/test/metabase/db/data_migrations_test.clj
@@ -11,7 +11,8 @@
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]
    [metabase.util :as u]
-   [toucan.db :as db]))
+   [toucan.db :as db]
+   [toucan2.core :as t2]))
 
 (use-fixtures :once (fixtures/initialize :db))
 
@@ -336,7 +337,7 @@
 
 (defn- get-json-setting
   [setting-k]
-  (json/parse-string (db/select-one-field :value Setting :key (name setting-k))))
+  (json/parse-string (t2/select-one-fn :value Setting :key (name setting-k))))
 
 (defn- call-with-ldap-and-sso-configured [ldap-group-mappings sso-group-mappings f]
   (mt/with-temporary-raw-setting-values

--- a/test/metabase/db/fix_mysql_utf8_test.clj
+++ b/test/metabase/db/fix_mysql_utf8_test.clj
@@ -115,4 +115,4 @@
                   (testing "We should be able to insert UTF-8 values"
                     (insert-row!)
                     (is (= test-unicode-str
-                           (db/select-one-field :name Database :name test-unicode-str)))))))))))))
+                           (t2/select-one-fn :name Database :name test-unicode-str)))))))))))))

--- a/test/metabase/db/schema_migrations_test.clj
+++ b/test/metabase/db/schema_migrations_test.clj
@@ -88,7 +88,7 @@
         (doseq [id [1 2]]
           (testing (format "Field %d" id)
             (is (= id
-                   (db/select-one-field :database_position Field :id id)))))))))
+                   (t2/select-one-fn :database_position Field :id id)))))))))
 
 (defn- create-raw-user!
   "create a user but skip pre and post insert steps"
@@ -776,12 +776,12 @@
         (migrate!)
         (testing "A personal Collection should get created_at set by to the date_joined from its owner"
           (is (= (t/offset-date-time #t "2022-10-20T02:09Z")
-                 (t/offset-date-time (db/select-one-field :created_at Collection :id personal-collection-id)))))
+                 (t/offset-date-time (t2/select-one-fn :created_at Collection :id personal-collection-id)))))
         (testing "A non-personal Collection should get created_at set to its oldest object"
           (is (= (t/offset-date-time #t "2021-10-20T02:09Z")
-                 (t/offset-date-time (db/select-one-field :created_at Collection :id impersonal-collection-id)))))
+                 (t/offset-date-time (t2/select-one-fn :created_at Collection :id impersonal-collection-id)))))
         (testing "Empty Collection should not have been updated"
-          (let [empty-collection-created-at (t/offset-date-time (db/select-one-field :created_at Collection :id empty-collection-id))]
+          (let [empty-collection-created-at (t/offset-date-time (t2/select-one-fn :created_at Collection :id empty-collection-id))]
             (is (not= (t/offset-date-time #t "2021-10-20T02:09Z")
                       empty-collection-created-at))
             (is (not= (t/offset-date-time #t "2022-10-20T02:09Z")

--- a/test/metabase/events/last_login_test.clj
+++ b/test/metabase/events/last_login_test.clj
@@ -4,7 +4,7 @@
    [metabase.events.last-login :as last-login]
    [metabase.models.user :refer [User]]
    [metabase.test :as mt]
-   [toucan.db :as db]))
+   [toucan2.core :as t2]))
 
 (deftest user-login-test
   (testing "`:user-login` event"
@@ -14,4 +14,4 @@
       (last-login/process-last-login-event {:topic :user-login
                                             :item  {:user_id    user-id
                                                     :session_id "doesntmatter"}})
-      (is (some? (db/select-one-field :last_login User :id user-id))))))
+      (is (some? (t2/select-one-fn :last_login User :id user-id))))))

--- a/test/metabase/models/card_test.clj
+++ b/test/metabase/models/card_test.clj
@@ -236,18 +236,18 @@
       (mt/with-temp Card [{card-id :id} {:dataset_query   (mt/mbql-query venues)
                                          :result_metadata metadata}]
         (is (= (mt/derecordize metadata)
-               (mt/derecordize (db/select-one-field :result_metadata Card :id card-id))))))))
+               (mt/derecordize (t2/select-one-fn :result_metadata Card :id card-id))))))))
 
 (deftest populate-result-metadata-if-needed-test
   (doseq [[creating-or-updating f]
           {"creating" (fn [properties f]
                         (mt/with-temp Card [{card-id :id} properties]
-                          (f (db/select-one-field :result_metadata Card :id card-id))))
+                          (f (t2/select-one-fn :result_metadata Card :id card-id))))
            "updating" (fn [changes f]
                         (mt/with-temp Card [{card-id :id} {:dataset_query   (mt/mbql-query checkins)
                                                            :result_metadata (qp/query->expected-cols (mt/mbql-query checkins))}]
                           (db/update! Card card-id changes)
-                          (f (db/select-one-field :result_metadata Card :id card-id))))}]
+                          (f (t2/select-one-fn :result_metadata Card :id card-id))))}]
     (testing (format "When %s a Card\n" creating-or-updating)
       (testing "If result_metadata is empty, we should attempt to populate it"
         (f {:dataset_query (mt/mbql-query venues)}
@@ -324,7 +324,7 @@
    (fn [original expected]
      (mt/with-temp Card [card {:visualization_settings original}]
        (is (= expected
-              (db/select-one-field :visualization_settings Card :id (u/the-id card))))))))
+              (t2/select-one-fn :visualization_settings Card :id (u/the-id card))))))))
 
 (deftest validate-template-tag-field-ids-test
   (testing "Disallow saving a Card with native query Field filter template tags referencing a different Database (#14145)"
@@ -389,7 +389,7 @@
 
           (is (= [{:parameter_id     "_CATEGORY_NAME_"
                    :target expected}]
-                 (db/select-one-field :parameter_mappings Card :id card-id))))))))
+                 (t2/select-one-fn :parameter_mappings Card :id card-id))))))))
 
 (deftest validate-parameter-mappings-test
   (testing "Should validate Card :parameter_mappings when"
@@ -421,7 +421,7 @@
       (is (= [{:parameter_id "22486e00",
                :card_id      1,
                :target       [:dimension [:field 1 nil]]}]
-             (db/select-one-field :parameter_mappings Card :id card-id))))))
+             (t2/select-one-fn :parameter_mappings Card :id card-id))))))
 
 (deftest identity-hash-test
   (testing "Card hashes are composed of the name and the collection's hash"
@@ -538,7 +538,7 @@
           (is (=? [{:id   "param_2"
                     :name "Param 2"
                     :type :category}]
-                  (db/select-one-field :parameters Dashboard :id (:id dashboard))))
+                  (t2/select-one-fn :parameters Dashboard :id (:id dashboard))))
 
           (testing "but no changes with parameter on card"
             (is (=? [{:name                 "Param 1"
@@ -547,7 +547,7 @@
                       :values_source_type   "card"
                       :values_source_config {:card_id     source-card-id
                                              :value_field (mt/$ids $products.title)}}]
-                    (db/select-one-field :parameters Card :id (:id card)))))))
+                    (t2/select-one-fn :parameters Card :id (:id card)))))))
 
       (testing "on archive card"
         (db/update! Card source-card-id {:archived true})
@@ -559,7 +559,7 @@
           (is (=? [{:id   "param_1"
                     :name "Param 1"
                     :type :category}]
-                  (db/select-one-field :parameters Card :id (:id card)))))))))
+                  (t2/select-one-fn :parameters Card :id (:id card)))))))))
 
 (deftest descendants-test
   (testing "regular cards don't depend on anything"
@@ -605,7 +605,7 @@
         (is (= {:version 2
                 :pie.show_legend true
                 :pie.percent_visibility "inside"}
-               (db/select-one-field :visualization_settings Card :id card-id)))))
+               (t2/select-one-fn :visualization_settings Card :id card-id)))))
   (testing ":visualization_settings v. 1 should be upgraded to v. 2 and persisted on update"
     (mt/with-temp Card [{card-id :id} {:visualization_settings {:pie.show_legend true}}]
       (db/update! Card card-id :name "Favorite Toucan Foods")

--- a/test/metabase/models/dashboard_card_test.clj
+++ b/test/metabase/models/dashboard_card_test.clj
@@ -14,7 +14,8 @@
    [metabase.models.serialization :as serdes]
    [metabase.test :as mt]
    [metabase.util :as u]
-   [toucan.db :as db])
+   [toucan.db :as db]
+   [toucan2.core :as t2])
   (:import
    (java.time LocalDateTime)))
 
@@ -96,7 +97,7 @@
     (let [upd-series (fn [series]
                        (dashboard-card/update-dashboard-card-series! {:id dashcard-id} series)
                        (set (for [card-id (db/select-field :card_id DashboardCardSeries, :dashboardcard_id dashcard-id)]
-                              (db/select-one-field :name Card, :id card-id))))]
+                              (t2/select-one-fn :name Card, :id card-id))))]
       (is (= #{}
              (upd-series [])))
       (is (= #{"card1"}
@@ -258,7 +259,7 @@
       (is (= [{:parameter_id "22486e00"
                :card_id      (u/the-id card)
                :target       [:dimension [:field (mt/id :venues :id) nil]]}]
-             (db/select-one-field :parameter_mappings DashboardCard :id (u/the-id dashcard)))))))
+             (t2/select-one-fn :parameter_mappings DashboardCard :id (u/the-id dashcard)))))))
 
 (deftest normalize-visualization-settings-test
   (testing "DashboardCard visualization settings should get normalized to use modern MBQL syntax"
@@ -270,7 +271,7 @@
                                                 :card_id                (u/the-id card)
                                                 :visualization_settings original}]
            (is (= expected
-                  (db/select-one-field :visualization_settings DashboardCard :id (u/the-id dashcard))))))))))
+                  (t2/select-one-fn :visualization_settings DashboardCard :id (u/the-id dashcard))))))))))
 
 (deftest normalize-parameter-mappings-test-2
   (testing "make sure parameter mappings correctly normalize things like legacy MBQL clauses"

--- a/test/metabase/models/dashboard_test.clj
+++ b/test/metabase/models/dashboard_test.clj
@@ -18,7 +18,8 @@
    [metabase.test.util :as tu]
    [metabase.util :as u]
    [toucan.db :as db]
-   [toucan.util.test :as tt])
+   [toucan.util.test :as tt]
+   [toucan2.core :as t2])
   (:import
    (java.time LocalDateTime)))
 
@@ -200,9 +201,9 @@
     (testing "Pulse name and collection-id updates"
       (db/update! Dashboard dashboard-id :name "Lucky's Close Shaves" :collection_id collection-id-2)
       (is (= "Lucky's Close Shaves"
-             (db/select-one-field :name Pulse :id pulse-id)))
+             (t2/select-one-fn :name Pulse :id pulse-id)))
       (is (= collection-id-2
-             (db/select-one-field :collection_id Pulse :id pulse-id))))
+             (t2/select-one-fn :collection_id Pulse :id pulse-id))))
     (testing "PulseCard syncing"
       (tt/with-temp Card [{new-card-id :id}]
         (dashboard/add-dashcard! dashboard-id new-card-id {:row    0
@@ -363,7 +364,7 @@
                    :values_query_type "list",
                    :values_source_type "card",
                    :values_source_config {:card_id card-id, :value_field [:field 2 nil]}}]
-                 (db/select-one-field :parameters Dashboard :id dashboard-id))))))))
+                 (t2/select-one-fn :parameters Dashboard :id dashboard-id))))))))
 
 (deftest should-add-default-values-source-test
   (testing "shoudld add default if not exists"
@@ -375,7 +376,7 @@
                 :slug                 "category_name"
                 :id                   "_CATEGORY_NAME_"
                 :type                 :category}]
-              (db/select-one-field :parameters Dashboard :id dashboard-id)))))
+              (t2/select-one-fn :parameters Dashboard :id dashboard-id)))))
 
   (testing "shoudld not override if existsed "
     (mt/with-temp* [Card      [{card-id :id}]
@@ -394,7 +395,7 @@
                 :values_query_type    "list",
                 :values_source_type   "card",
                 :values_source_config {:card_id card-id, :value_field [:field 2 nil]}}]
-              (db/select-one-field :parameters Dashboard :id dashboard-id))))))
+              (t2/select-one-fn :parameters Dashboard :id dashboard-id))))))
 
 (deftest identity-hash-test
   (testing "Dashboard hashes are composed of the name and parent collection's hash"

--- a/test/metabase/models/database_test.clj
+++ b/test/metabase/models/database_test.clj
@@ -20,7 +20,8 @@
    [metabase.test.fixtures :as fixtures]
    [metabase.util :as u]
    [schema.core :as s]
-   [toucan.db :as db]))
+   [toucan.db :as db]
+   [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
 
@@ -289,7 +290,7 @@
            (db/update! Database id :engine :sqlite))))
     (testing " updating other attributes of a sample database is allowed"
       (db/update! Database id :name "My New Name")
-      (is (= "My New Name" (db/select-one-field :name Database :id id))))))
+      (is (= "My New Name" (t2/select-one-fn :name Database :id id))))))
 
 (driver/register! ::test, :abstract? true)
 
@@ -297,7 +298,7 @@
   (testing "Make sure databases preserve namespaced driver names"
     (mt/with-temp Database [{db-id :id} {:engine (u/qualified-name ::test)}]
       (is (= ::test
-             (db/select-one-field :engine Database :id db-id))))))
+             (t2/select-one-fn :engine Database :id db-id))))))
 
 (deftest identity-hash-test
   (testing "Database hashes are composed of the name and engine"

--- a/test/metabase/models/field_test.clj
+++ b/test/metabase/models/field_test.clj
@@ -8,7 +8,8 @@
    [metabase.models.table :refer [Table]]
    [metabase.test :as mt]
    [metabase.util :as u]
-   [toucan.db :as db]))
+   [toucan.db :as db]
+   [toucan2.core :as t2]))
 
 (deftest unknown-types-test
   (doseq [{:keys [column unknown-type fallback-type]} [{:column        :base_type
@@ -29,7 +30,7 @@
                       :set    {column (u/qualified-name unknown-type)}
                       :where  [:= :id (u/the-id field)]})
         (is (= fallback-type
-               (db/select-one-field column Field :id (u/the-id field))))))
+               (t2/select-one-fn column Field :id (u/the-id field))))))
     (testing (format "Should throw an Exception if you attempt to save a Field with an invalid %s" column)
       (is (thrown-with-msg?
            clojure.lang.ExceptionInfo

--- a/test/metabase/models/field_values_test.clj
+++ b/test/metabase/models/field_values_test.clj
@@ -16,7 +16,8 @@
    [metabase.sync :as sync]
    [metabase.test :as mt]
    [metabase.util :as u]
-   [toucan.db :as db]))
+   [toucan.db :as db]
+   [toucan2.core :as t2]))
 
 (deftest field-should-have-field-values?-test
   (doseq [[group input->expected] {"Text and Category Fields"
@@ -112,10 +113,10 @@
                   Field       [{field-id :id} {:table_id table-id}]
                   FieldValues [_              {:field_id field-id, :values "[1,2,3]"}]]
     (is (= [1 2 3]
-           (db/select-one-field :values FieldValues, :field_id field-id)))
+           (t2/select-one-fn :values FieldValues, :field_id field-id)))
     (field-values/clear-field-values-for-field! field-id)
     (is (= nil
-           (db/select-one-field :values FieldValues, :field_id field-id)))))
+           (t2/select-one-fn :values FieldValues, :field_id field-id)))))
 
 (defn- find-values [field-values-id]
   (-> (db/select-one FieldValues :id field-values-id)
@@ -178,9 +179,9 @@
                                   :details      "{\"db\": \"mem:temp\"}"}]
         ;; Sync the database so we have the new table and it's fields
         (sync/sync-database! db)
-        (let [table-id        (db/select-one-field :id Table :db_id (u/the-id db) :name "FOO")
-              field-id        (db/select-one-field :id Field :table_id table-id :name "CATEGORY_ID")
-              field-values-id (db/select-one-field :id FieldValues :field_id field-id)]
+        (let [table-id        (t2/select-one-fn :id Table :db_id (u/the-id db) :name "FOO")
+              field-id        (t2/select-one-fn :id Field :table_id table-id :name "CATEGORY_ID")
+              field-values-id (t2/select-one-fn :id FieldValues :field_id field-id)]
           ;; Add in human readable values for remapping
           (is (db/update! FieldValues field-values-id {:human_readable_values ["a" "b" "c"]}))
           (let [expected-original-values {:values                [1 2 3]

--- a/test/metabase/models/humanization_test.clj
+++ b/test/metabase/models/humanization_test.clj
@@ -4,13 +4,13 @@
    [metabase.models.humanization :as humanization]
    [metabase.models.table :refer [Table]]
    [metabase.test.util :as tu]
-   [toucan.db :as db]
-   [toucan.util.test :as tt]))
+   [toucan.util.test :as tt]
+   [toucan2.core :as t2]))
 
 (defn- get-humanized-display-name [actual-name strategy]
   (with-redefs [humanization/humanization-strategy (constantly strategy)]
     (tt/with-temp Table [{table-id :id} {:name actual-name}]
-      (db/select-one-field :display_name Table, :id table-id))))
+      (t2/select-one-fn :display_name Table, :id table-id))))
 
 (deftest humanized-display-name-test
   (testing "check that we get the expected :display_name with humanization *enabled*"
@@ -35,7 +35,7 @@
                                                            :none     "fussybird_sightings"}}]
       (tu/with-temporary-setting-values [humanization-strategy "simple"]
         (tt/with-temp Table [{table-id :id} {:name actual-name}]
-          (letfn [(display-name [] (db/select-one-field :display_name Table, :id table-id))]
+          (letfn [(display-name [] (t2/select-one-fn :display_name Table, :id table-id))]
             (testing "initial display name"
               (is (= (:initial expected)
                      (display-name))))
@@ -57,4 +57,4 @@
             (testing (format "switch from %s -> %s" initial-strategy new-strategy)
               (humanization/humanization-strategy! new-strategy)
               (is (= "My Favorite Table"
-                     (db/select-one-field :display_name Table, :id table-id))))))))))
+                     (t2/select-one-fn :display_name Table, :id table-id))))))))))

--- a/test/metabase/models/native_query_snippet_test.clj
+++ b/test/metabase/models/native_query_snippet_test.clj
@@ -4,7 +4,8 @@
    [metabase.models :refer [Collection NativeQuerySnippet]]
    [metabase.models.serialization :as serdes]
    [metabase.test :as mt]
-   [toucan.db :as db])
+   [toucan.db :as db]
+   [toucan2.core :as t2])
   (:import
    (java.time LocalDateTime)))
 
@@ -18,14 +19,14 @@
            #"You cannot update the creator_id of a NativeQuerySnippet\."
            (db/update! NativeQuerySnippet snippet-id :creator_id (mt/user->id :rasta))))
       (is (= (mt/user->id :lucky)
-             (db/select-one-field :creator_id NativeQuerySnippet :id snippet-id))))))
+             (t2/select-one-fn :creator_id NativeQuerySnippet :id snippet-id))))))
 
 (deftest snippet-collection-test
   (testing "Should be allowed to create snippets in a Collection in the :snippets namespace"
     (mt/with-temp* [Collection         [{collection-id :id} {:namespace "snippets"}]
                     NativeQuerySnippet [{snippet-id :id} {:collection_id collection-id}]]
       (is (= collection-id
-             (db/select-one-field :collection_id NativeQuerySnippet :id snippet-id)))))
+             (t2/select-one-fn :collection_id NativeQuerySnippet :id snippet-id)))))
 
   (doseq [[source dest] [[nil "snippets"]
                          ["snippets" "snippets"]
@@ -39,7 +40,7 @@
                                                              {:collection_id source-collection-id})]]
         (db/update! NativeQuerySnippet snippet-id :collection_id (when dest dest-collection-id))
         (is (= (when dest dest-collection-id)
-               (db/select-one-field :collection_id NativeQuerySnippet :id snippet-id))))))
+               (t2/select-one-fn :collection_id NativeQuerySnippet :id snippet-id))))))
 
   (doseq [collection-namespace [nil "x"]]
     (testing (format "Should *not* be allowed to create snippets in a Collection in the %s namespace"

--- a/test/metabase/models/params/chain_filter_test.clj
+++ b/test/metabase/models/params/chain_filter_test.clj
@@ -8,7 +8,8 @@
    [metabase.models.params.field-values :as params.field-values]
    [metabase.test :as mt]
    [metabase.util :as u]
-   [toucan.db :as db]))
+   [toucan.db :as db]
+   [toucan2.core :as t2]))
 
 (defmacro ^:private chain-filter [field field->value & options]
   `(chain-filter/chain-filter
@@ -562,7 +563,7 @@
   [field-or-field-id thunk]
   (mt/with-model-cleanup [FieldValues]
     (let [field-id         (u/the-id field-or-field-id)
-          has_field_values (db/select-one-field :has_field_values Field :id field-id)
+          has_field_values (t2/select-one-fn :has_field_values Field :id field-id)
           fvs              (db/select FieldValues :field_id field-id)]
       ;; switch to "list" to prevent [[field-values/create-or-update-full-field-values!]]
       ;; from changing this to `nil` if the field is `auto-list` and exceeds threshholds

--- a/test/metabase/models/permissions_group_membership_test.clj
+++ b/test/metabase/models/permissions_group_membership_test.clj
@@ -8,7 +8,8 @@
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]
    [metabase.util :as u]
-   [toucan.db :as db]))
+   [toucan.db :as db]
+   [toucan2.core :as t2]))
 
 (use-fixtures :once (fixtures/initialize :test-users))
 
@@ -17,14 +18,14 @@
     (mt/with-temp User [user]
       (db/insert! PermissionsGroupMembership {:user_id (u/the-id user), :group_id (u/the-id (perms-group/admin))})
       (is (= true
-             (db/select-one-field :is_superuser User :id (u/the-id user)))))))
+             (t2/select-one-fn :is_superuser User :id (u/the-id user)))))))
 
 (deftest remove-is-superuser-test
   (testing "when you delete a PermissionsGroupMembership for a User in the admin group, it should set their `is_superuser` flag"
     (mt/with-temp User [user {:is_superuser true}]
       (db/delete! PermissionsGroupMembership :user_id (u/the-id user), :group_id (u/the-id (perms-group/admin)))
       (is (= false
-             (db/select-one-field :is_superuser User :id (u/the-id user))))))
+             (t2/select-one-fn :is_superuser User :id (u/the-id user))))))
 
   (testing "it should not let you remove the last admin"
     (mt/with-single-admin-user [{id :id}]

--- a/test/metabase/models/permissions_group_test.clj
+++ b/test/metabase/models/permissions_group_test.clj
@@ -16,7 +16,8 @@
    [metabase.util.honey-sql-2 :as h2x]
    [metabase.util.schema :as su]
    [schema.core :as s]
-   [toucan.db :as db]))
+   [toucan.db :as db]
+   [toucan2.core :as t2]))
 
 (use-fixtures :once (fixtures/initialize :test-users))
 
@@ -89,13 +90,13 @@
     (mt/with-temp User [{user-id :id}]
       (db/insert! PermissionsGroupMembership, :user_id user-id, :group_id (u/the-id (perms-group/admin)))
       (is (= true
-             (db/select-one-field :is_superuser User, :id user-id))))
+             (t2/select-one-fn :is_superuser User, :id user-id))))
 
     (testing "removing user from Admin should set is_superuser -> false"
       (mt/with-temp User [{user-id :id} {:is_superuser true}]
         (db/delete! PermissionsGroupMembership, :user_id user-id, :group_id (u/the-id (perms-group/admin)))
         (is (= false
-               (db/select-one-field :is_superuser User, :id user-id)))))
+               (t2/select-one-fn :is_superuser User, :id user-id)))))
 
     (testing "setting is_superuser -> true should add user to Admin"
       (mt/with-temp User [{user-id :id}]

--- a/test/metabase/models/pulse_test.clj
+++ b/test/metabase/models/pulse_test.clj
@@ -25,7 +25,8 @@
    [schema.core :as s]
    [toucan.db :as db]
    [toucan.hydrate :refer [hydrate]]
-   [toucan.util.test :as tt])
+   [toucan.util.test :as tt]
+   [toucan2.core :as t2])
   (:import
    (java.time LocalDateTime)))
 
@@ -301,7 +302,7 @@
                   :pulse-id         pulse-id
                   :pulse-channel-id pulse-channel-id
                   :archived?        (fn []
-                                      (db/select-one-field :archived Pulse :id pulse-id))})))]
+                                      (t2/select-one-fn :archived Pulse :id pulse-id))})))]
     (testing "automatically archive a Pulse when the last user unsubscribes"
       (testing "one subscriber"
         (do-with-objects

--- a/test/metabase/models/setting/cache_test.clj
+++ b/test/metabase/models/setting/cache_test.clj
@@ -8,7 +8,8 @@
    [metabase.public-settings :as public-settings]
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]
-   [toucan.db :as db]))
+   [toucan.db :as db]
+   [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
 
@@ -106,7 +107,7 @@
   (setting-test/toucan-name! "Reggae Toucan")
   (simulate-another-instance-updating-setting! :toucan-name "Bird Can")
   (is (= "Bird Can"
-         (db/select-one-field :value Setting :key "toucan-name")))
+         (t2/select-one-fn :value Setting :key "toucan-name")))
   (reset-last-update-check!)
   ;; calling `setting-test/toucan-name` will call `restore-cache-if-needed!`, which will in turn call `should-restore-cache?`.
   ;; Since memoized value is no longer present, this should call `cache-out-of-date?`, which checks the DB; it will

--- a/test/metabase/models/setting_test.clj
+++ b/test/metabase/models/setting_test.clj
@@ -15,7 +15,8 @@
    [metabase.util.encryption-test :as encryption-test]
    [metabase.util.i18n :as i18n :refer [deferred-tru]]
    [schema.core :as s]
-   [toucan.db :as db]))
+   [toucan.db :as db]
+   [toucan2.core :as t2]))
 
 (use-fixtures :once (fixtures/initialize :db))
 
@@ -86,7 +87,7 @@
 (defn db-fetch-setting
   "Fetch `Setting` value from the DB to verify things work as we expect."
   [setting-name]
-  (db/select-one-field :value Setting, :key (name setting-name)))
+  (t2/select-one-fn :value Setting, :key (name setting-name)))
 
 (defn setting-exists-in-db?
   "Returns a boolean indicating whether a setting has a value stored in the application DB."
@@ -413,7 +414,7 @@
 
 (defn- set-and-fetch-csv-setting-value! [v]
   (test-csv-setting! v)
-  {:db-value     (db/select-one-field :value setting/Setting :key "test-csv-setting")
+  {:db-value     (t2/select-one-fn :value setting/Setting :key "test-csv-setting")
    :parsed-value (test-csv-setting)})
 
 (deftest csv-setting-test
@@ -518,7 +519,7 @@
 (defn settings-last-updated-value-in-db
   "Fetches the timestamp of the last updated setting."
   []
-  (db/select-one-field :value Setting :key setting.cache/settings-last-updated-key))
+  (t2/select-one-fn :value Setting :key setting.cache/settings-last-updated-key))
 
 (defsetting uncached-setting
   "A test setting that should *not* be cached."

--- a/test/metabase/models/table_test.clj
+++ b/test/metabase/models/table_test.clj
@@ -8,7 +8,7 @@
    [metabase.sync :as sync]
    [metabase.test :as mt]
    [metabase.test.data.one-off-dbs :as one-off-dbs]
-   [toucan.db :as db]))
+   [toucan2.core :as t2]))
 
 (deftest valid-field-order?-test
   (testing "A valid field ordering is a set IDs  of all active fields in a given table"
@@ -68,7 +68,7 @@
       (testing (format "Should be able to create/delete Table with schema name %s" (pr-str schema-name))
         (mt/with-temp Table [{table-id :id} {:schema schema-name}]
           (is (= schema-name
-                 (db/select-one-field :schema Table :id table-id))))))))
+                 (t2/select-one-fn :schema Table :id table-id))))))))
 
 (deftest identity-hash-test
   (testing "Table hashes are composed of the schema name, table name and the database's identity-hash"

--- a/test/metabase/models/user_test.clj
+++ b/test/metabase/models/user_test.clj
@@ -29,7 +29,8 @@
    [metabase.util :as u]
    [metabase.util.password :as u.password]
    [toucan.db :as db]
-   [toucan.hydrate :refer [hydrate]]))
+   [toucan.hydrate :refer [hydrate]]
+   [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
 
@@ -225,7 +226,7 @@
                                         :last_name        "SomeLdapStuff"
                                         :login_attributes {:local_birds ["Steller's Jay" "Mountain Chickadee"]}})
       (is (= {"local_birds" ["Steller's Jay" "Mountain Chickadee"]}
-             (db/select-one-field :login_attributes User :email "ldaptest@metabase.com")))
+             (t2/select-one-fn :login_attributes User :email "ldaptest@metabase.com")))
       (finally
         (db/delete! User :email "ldaptest@metabase.com")))))
 
@@ -362,7 +363,7 @@
 
         (testing "their is_superuser flag should be set to true"
           (is (= true
-                 (db/select-one-field :is_superuser User :id (u/the-id user)))))))
+                 (t2/select-one-fn :is_superuser User :id (u/the-id user)))))))
 
     (testing "should be able to remove someone from the Admin group"
       (mt/with-temp User [user {:is_superuser true}]
@@ -372,7 +373,7 @@
 
         (testing "their is_superuser flag should be set to false"
           (is (= false
-                 (db/select-one-field :is_superuser User :id (u/the-id user)))))))
+                 (t2/select-one-fn :is_superuser User :id (u/the-id user)))))))
 
     (testing "should run all changes in a transaction -- if one set of changes fails, others should not be persisted"
       (testing "Invalid ADD operation"
@@ -382,7 +383,7 @@
           (u/ignore-exceptions
             (user/set-permissions-groups! user #{(perms-group/all-users) Integer/MAX_VALUE}))
           (is (= true
-                 (db/select-one-field :is_superuser User :id (u/the-id user))))))
+                 (t2/select-one-fn :is_superuser User :id (u/the-id user))))))
 
       (testing "Invalid REMOVE operation"
         ;; Attempt to remove someone from All Users + add to a valid group at the same time -- neither should persist
@@ -398,7 +399,7 @@
   (testing "set-password!"
     (testing "should change the password"
       (mt/with-temp User [{user-id :id} {:password "ABC_DEF"}]
-        (letfn [(password [] (db/select-one-field :password User :id user-id))]
+        (letfn [(password [] (t2/select-one-fn :password User :id user-id))]
           (let [original-password (password)]
             (user/set-password! user-id "p@ssw0rd")
             (is (not= original-password
@@ -408,7 +409,7 @@
       (mt/with-temp User [{user-id :id} {:reset_token "ABC123"}]
         (user/set-password! user-id "p@ssw0rd")
         (is (= nil
-               (db/select-one-field :reset_token User :id user-id)))))
+               (t2/select-one-fn :reset_token User :id user-id)))))
 
     (testing "should clear out all existing Sessions"
       (mt/with-temp* [User [{user-id :id}]]
@@ -427,7 +428,7 @@
       (testing "valid locale"
         (mt/with-temp User [{user-id :id} {:locale "en_US"}]
           (is (= "en_US"
-                 (db/select-one-field :locale User :id user-id)))))
+                 (t2/select-one-fn :locale User :id user-id)))))
       (testing "invalid locale"
         (is (thrown-with-msg?
              Throwable
@@ -439,7 +440,7 @@
         (testing "valid locale"
           (db/update! User user-id :locale "en_GB")
           (is (= "en_GB"
-                 (db/select-one-field :locale User :id user-id))))
+                 (t2/select-one-fn :locale User :id user-id))))
         (testing "invalid locale"
           (is (thrown-with-msg?
                Throwable
@@ -451,12 +452,12 @@
     (mt/with-temp User [{user-id :id} {:locale "EN-us"}]
       (testing "creating a new User"
         (is (= "en_US"
-               (db/select-one-field :locale User :id user-id))))
+               (t2/select-one-fn :locale User :id user-id))))
 
       (testing "updating a User"
         (db/update! User user-id :locale "en-GB")
         (is (= "en_GB"
-               (db/select-one-field :locale User :id user-id)))))))
+               (t2/select-one-fn :locale User :id user-id)))))))
 
 (deftest delete-pulse-subscriptions-when-archived-test
   (testing "Delete a User's Pulse/Alert/Dashboard Subscription subscriptions when they get archived"
@@ -487,8 +488,8 @@
   (testing "Setting `:password` with [[db/update!]] should hash the password, just like [[db/insert!]]"
     (let [plaintext-password "password-1234"]
       (mt/with-temp User [{user-id :id} {:password plaintext-password}]
-        (let [salt                     (fn [] (db/select-one-field :password_salt User :id user-id))
-              hashed-password          (fn [] (db/select-one-field :password User :id user-id))
+        (let [salt                     (fn [] (t2/select-one-fn :password_salt User :id user-id))
+              hashed-password          (fn [] (t2/select-one-fn :password User :id user-id))
               original-hashed-password (hashed-password)]
           (testing "sanity check: check that password can be verified"
             (is (u.password/verify-password plaintext-password

--- a/test/metabase/query_processor/middleware/results_metadata_test.clj
+++ b/test/metabase/query_processor/middleware/results_metadata_test.clj
@@ -13,10 +13,11 @@
    [metabase.util :as u]
    [metabase.util.schema :as su]
    [schema.core :as s]
-   [toucan.db :as db]))
+   [toucan.db :as db]
+   [toucan2.core :as t2]))
 
 (defn- card-metadata [card]
-  (db/select-one-field :result_metadata Card :id (u/the-id card)))
+  (t2/select-one-fn :result_metadata Card :id (u/the-id card)))
 
 (defn- round-to-2-decimals
   "Defaults [[mt/round-all-decimals]] to 2 digits"

--- a/test/metabase/query_processor/middleware/validate_temporal_bucketing_test.clj
+++ b/test/metabase/query_processor/middleware/validate_temporal_bucketing_test.clj
@@ -5,7 +5,7 @@
    [metabase.query-processor.middleware.validate-temporal-bucketing
     :as validate-temporal-bucketing]
    [metabase.test :as mt]
-   [toucan.db :as db]))
+   [toucan2.core :as t2]))
 
 (defn- validate [query]
   (validate-temporal-bucketing/validate-temporal-bucketing query))
@@ -21,11 +21,11 @@
                                 [:field
                                  (case field-clause-type
                                    :id   (mt/id :attempts field)
-                                   :name (db/select-one-field :name Field :id (mt/id :attempts field)))
+                                   :name (t2/select-one-fn :name Field :id (mt/id :attempts field)))
                                  (merge
                                   {:temporal-unit unit}
                                   (when (= field-clause-type :name)
-                                    {:base-type (db/select-one-field :base_type Field :id (mt/id :attempts field))}))]
+                                    {:base-type (t2/select-one-fn :base_type Field :id (mt/id :attempts field))}))]
                                 [:relative-datetime -1 unit]]}))]
             ;; I don't think we need to test every possible combination in the world here -- that will get tested by
             ;; other stuff

--- a/test/metabase/query_processor/test_util.clj
+++ b/test/metabase/query_processor/test_util.clj
@@ -19,7 +19,7 @@
    [metabase.util :as u]
    [metabase.util.schema :as su]
    [schema.core :as s]
-   [toucan.db :as db]))
+   [toucan2.core :as t2]))
 
 ;; TODO - I don't think we different QP test util namespaces? We should roll this namespace into
 ;; `metabase.query-processor-test`
@@ -118,8 +118,8 @@
     (fk-table-alias-name (data/id :categories) (data/id :venues :category_id)) ;; -> \"CATEGORIES__via__CATEGORY_ID\""
   [table-or-id field-or-id]
   (#'qp.add-implicit-joins/join-alias
-   (db/select-one-field :name Table :id (u/the-id table-or-id))
-   (db/select-one-field :name Field :id (u/the-id field-or-id))))
+   (t2/select-one-fn :name Table :id (u/the-id table-or-id))
+   (t2/select-one-fn :name Field :id (u/the-id field-or-id))))
 
 
 ;;; ------------------------------------------------- Timezone Stuff -------------------------------------------------

--- a/test/metabase/query_processor_test.clj
+++ b/test/metabase/query_processor_test.clj
@@ -22,7 +22,8 @@
    [metabase.util :as u]
    [metabase.util.log :as log]
    [schema.core :as s]
-   [toucan.db :as db]))
+   [toucan.db :as db]
+   [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
 
@@ -195,7 +196,7 @@
         (update :display_name (partial format "%s → %s" (str/replace (:display_name source-col) #"(?i)\sid$" "")))
         (assoc :field_ref    [:field (:id dest-col) {:source-field (:id source-col)}]
                :fk_field_id  (:id source-col)
-               :source_alias (#'qp.add-implicit-joins/join-alias (db/select-one-field :name Table :id (data/id dest-table-kw))
+               :source_alias (#'qp.add-implicit-joins/join-alias (t2/select-one-fn :name Table :id (data/id dest-table-kw))
                                                                  (:name source-col))))))
 
 (declare cols)

--- a/test/metabase/query_processor_test/nested_queries_test.clj
+++ b/test/metabase/query_processor_test/nested_queries_test.clj
@@ -21,7 +21,8 @@
    [metabase.test :as mt]
    [metabase.util :as u]
    [schema.core :as s]
-   [toucan.db :as db]))
+   [toucan.db :as db]
+   [toucan2.core :as t2]))
 
 (deftest basic-test
   (mt/test-drivers (mt/normal-drivers-with-feature :nested-queries)
@@ -952,7 +953,7 @@
 
 (defn- field-id->name [field-id]
   (let [{field-name :name, table-id :table_id} (db/select-one [Field :name :table_id] :id field-id)
-        table-name                             (db/select-one-field :name Table :id table-id)]
+        table-name                             (t2/select-one-fn :name Table :id table-id)]
     (format "%s.%s" table-name field-name)))
 
 (deftest inception-test

--- a/test/metabase/query_processor_test/timezones_test.clj
+++ b/test/metabase/query_processor_test/timezones_test.clj
@@ -12,7 +12,7 @@
    [metabase.test.data.sql :as sql.tx]
    [metabase.util.date-2 :as u.date]
    [metabase.util.honeysql-extensions :as hx]
-   [toucan.db :as db]))
+   [toucan2.core :as t2]))
 
 ;; TIMEZONE FIXME
 (def broken-drivers
@@ -99,12 +99,12 @@
                    "same as specifying UTC for a report timezone")))))))
 
 (defn- table-identifier [table-key]
-  (let [table-name (db/select-one-field :name Table, :id (mt/id table-key))]
+  (let [table-name (t2/select-one-fn :name Table, :id (mt/id table-key))]
     (apply hx/identifier :table (sql.tx/qualified-name-components driver/*driver* (:name (mt/db)) table-name))))
 
 (defn- field-identifier [table-key field-key]
-  (let [table-name (db/select-one-field :name Table, :id (mt/id table-key))
-        field-name (db/select-one-field :name Field, :id (mt/id table-key field-key))]
+  (let [table-name (t2/select-one-fn :name Table, :id (mt/id table-key))
+        field-name (t2/select-one-fn :name Field, :id (mt/id table-key field-key))]
     (apply hx/identifier :field (sql.tx/qualified-name-components driver/*driver* (:name (mt/db)) table-name field-name))))
 
 (defn- honeysql->sql [honeysql]

--- a/test/metabase/sync/analyze/fingerprint/fingerprinters_test.clj
+++ b/test/metabase/sync/analyze/fingerprint/fingerprinters_test.clj
@@ -9,7 +9,7 @@
    [metabase.sync.analyze.fingerprint.fingerprinters :as fingerprinters]
    [metabase.test :as mt]
    [schema.core :as s]
-   [toucan.db :as db]))
+   [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
 
@@ -148,7 +148,7 @@
                                            :percent-email  (s/eq 0.0)
                                            :percent-state  (s/eq 0.0)
                                            :average-length (s/pred #(< 15 % 16) "between 15 and 16")}}}
-                     (db/select-one-field :fingerprint Field :id (mt/id :venues :name)))))
+                     (t2/select-one-fn :fingerprint Field :id (mt/id :venues :name)))))
       (testing "date fingerprints"
         (is (schema= {:global {:distinct-count (s/eq (if (= driver/*driver* :mongo)
                                                        383 ; mongo samples the last 500 rows only
@@ -156,7 +156,7 @@
                                :nil%           (s/eq 0.0)}
                       :type   {:type/DateTime {:earliest (s/pred #(str/starts-with? % "2013-01-03"))
                                                :latest   (s/pred #(str/starts-with? % "2015-12-29"))}}}
-                     (db/select-one-field :fingerprint Field :id (mt/id :checkins :date)))))
+                     (t2/select-one-fn :fingerprint Field :id (mt/id :checkins :date)))))
       (testing "number fingerprints"
         (is (schema= {:global {:distinct-count (s/eq 4)
                                :nil%           (s/eq 0.0)}
@@ -166,7 +166,7 @@
                                              :max (s/eq 4.0)
                                              :sd  (s/pred #(< 0.76 % 0.78) "between 0.76 and 0.78")
                                              :avg (s/eq 2.03)}}}
-                     (db/select-one-field :fingerprint Field :id (mt/id :venues :price))))))))
+                     (t2/select-one-fn :fingerprint Field :id (mt/id :venues :price))))))))
 
 (deftest ^:parallel valid-serialized-json?-test
   (testing "recognizes substrings of json"

--- a/test/metabase/sync/analyze/fingerprint_test.clj
+++ b/test/metabase/sync/analyze/fingerprint_test.clj
@@ -14,7 +14,8 @@
    [metabase.util :as u]
    [schema.core :as s]
    [toucan.db :as db]
-   [toucan.util.test :as tt]))
+   [toucan.util.test :as tt]
+   [toucan2.core :as t2]))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                   TESTS FOR WHICH FIELDS NEED FINGERPRINTING                                   |
@@ -264,7 +265,7 @@
                                            :percent-email  (s/eq 0.0)
                                            :average-length (s/pred #(< 15 % 16) "between 15 and 16")
                                            :percent-state  (s/eq 0.0)}}}
-                     (db/select-one-field :fingerprint Field :id (mt/id :venues :name))))))))
+                     (t2/select-one-fn :fingerprint Field :id (mt/id :venues :name))))))))
 
 (deftest fingerprinting-test
   (testing "fingerprinting truncates text fields (see #13288)"

--- a/test/metabase/sync/analyze_test.clj
+++ b/test/metabase/sync/analyze_test.clj
@@ -20,7 +20,8 @@
    [metabase.test.sync :as test.sync :refer [sync-survives-crash?]]
    [metabase.util :as u]
    [toucan.db :as db]
-   [toucan.util.test :as tt]))
+   [toucan.util.test :as tt]
+   [toucan2.core :as t2]))
 
 (deftest skip-analysis-of-fields-with-current-fingerprint-version-test
   (testing "Check that Fields do *not* get analyzed if they're not newly created and fingerprint version is current"
@@ -31,7 +32,7 @@
         :semantic_type       nil
         :fingerprint_version Short/MAX_VALUE)
       ;; the type of the value that comes back may differ a bit between different application DBs
-      (let [analysis-date (db/select-one-field :last_analyzed Field :table_id (data/id :venues))]
+      (let [analysis-date (t2/select-one-fn :last_analyzed Field :table_id (data/id :venues))]
         ;; ok, NOW run the analysis process
         (analyze/analyze-table! (db/select-one Table :id (data/id :venues)))
         ;; check and make sure all the Fields don't have semantic types and their last_analyzed date didn't change
@@ -155,7 +156,7 @@
   (db/exists? Field :id (u/the-id field), :last_analyzed [:not= nil]))
 
 (defn- latest-sync-time [table]
-  (db/select-one-field :last_analyzed Field
+  (t2/select-one-fn :last_analyzed Field
     :last_analyzed [:not= nil]
     :table_id      (u/the-id table)
     {:order-by [[:last_analyzed :desc]]}))
@@ -267,7 +268,7 @@
                        "started_at" true
                        "ended_at"   true
                        "duration"   true
-                       "db_engine"  (name (db/select-one-field :engine Database :id (mt/id)))
+                       "db_engine"  (name (t2/select-one-fn :engine Database :id (mt/id)))
                        "db_id"      true
                        "task_name"  "classify-tables"}
                 :user-id nil}

--- a/test/metabase/sync/field_values_test.clj
+++ b/test/metabase/sync/field_values_test.clj
@@ -12,10 +12,11 @@
    [metabase.test :as mt]
    [metabase.test.data :as data]
    [metabase.test.data.one-off-dbs :as one-off-dbs]
-   [toucan.db :as db]))
+   [toucan.db :as db]
+   [toucan2.core :as t2]))
 
 (defn- venues-price-field-values []
-  (db/select-one-field :values FieldValues, :field_id (mt/id :venues :price), :type :full))
+  (t2/select-one-fn :values FieldValues, :field_id (mt/id :venues :price), :type :full))
 
 (defn- sync-database!' [step database]
   (let [{:keys [step-info task-history]} (sync.util-test/sync-database! step database)]
@@ -71,7 +72,7 @@
     (testing "Fetching field values causes an on-demand update and marks Field Values as active"
       (is (partial= {:values [[1] [2] [3] [4]]}
                     (mt/user-http-request :rasta :get 200 (format "field/%d/values" (mt/id :venues :price)))))
-      (is (t/after? (db/select-one-field :last_used_at FieldValues :field_id (mt/id :venues :price) :type :full)
+      (is (t/after? (t2/select-one-fn :last_used_at FieldValues :field_id (mt/id :venues :price) :type :full)
                     (t/minus (t/offset-date-time) (t/hours 2))))
       (testing "Field is syncing after usage"
         (db/update! FieldValues
@@ -143,7 +144,7 @@
     (one-off-dbs/insert-rows-and-sync! (one-off-dbs/range-str 50))
     (testing "has_field_values should be auto-list"
       (is (= :auto-list
-             (db/select-one-field :has_field_values Field :id (mt/id :blueberries_consumed :str)))))
+             (t2/select-one-fn :has_field_values Field :id (mt/id :blueberries_consumed :str)))))
 
     (testing "... and it should also have some FieldValues"
       (is (= {:values                (one-off-dbs/range-str 50)
@@ -163,7 +164,7 @@
       (one-off-dbs/insert-rows-and-sync! (one-off-dbs/range-str 50 (+ 100 field-values/auto-list-cardinality-threshold)))
       (testing "has_field_values should have been set to nil."
         (is (= nil
-               (db/select-one-field :has_field_values Field :id (mt/id :blueberries_consumed :str)))))
+               (t2/select-one-fn :has_field_values Field :id (mt/id :blueberries_consumed :str)))))
 
       (testing "its FieldValues should also get deleted."
         (is (= nil
@@ -176,7 +177,7 @@
     (one-off-dbs/insert-rows-and-sync! [(str/join (repeat 50 "A"))])
     (testing "has_field_values should be auto-list"
       (is (= :auto-list
-             (db/select-one-field :has_field_values Field :id (mt/id :blueberries_consumed :str)))))
+             (t2/select-one-fn :has_field_values Field :id (mt/id :blueberries_consumed :str)))))
 
     (testing "... and it should also have some FieldValues"
       (is (= {:values                [(str/join (repeat 50 "A"))]
@@ -189,7 +190,7 @@
       (one-off-dbs/insert-rows-and-sync! [(str/join (repeat (+ 100 field-values/*total-max-length*) "A"))])
       (testing "has_field_values should have been set to nil."
         (is (= nil
-               (db/select-one-field :has_field_values Field :id (mt/id :blueberries_consumed :str)))))
+               (t2/select-one-fn :has_field_values Field :id (mt/id :blueberries_consumed :str)))))
 
       (testing "All of its FieldValues should also get deleted."
         (is (= nil
@@ -205,7 +206,7 @@
       (db/update! Field (mt/id :blueberries_consumed :str) :has_field_values "list")
       (testing "has_more_values should initially be false"
         (is (= false
-               (db/select-one-field :has_more_values FieldValues :field_id (mt/id :blueberries_consumed :str)))))
+               (t2/select-one-fn :has_more_values FieldValues :field_id (mt/id :blueberries_consumed :str)))))
       ;; Manually add an advanced field values to test whether or not it got deleted later
       (db/insert! FieldValues {:field_id (mt/id :blueberries_consumed :str)
                                :type :sandbox
@@ -214,7 +215,7 @@
         (one-off-dbs/insert-rows-and-sync! (one-off-dbs/range-str 50 (+ 100 metadata-queries/absolute-max-distinct-values-limit)))
         (testing "has_field_values shouldn't change and has_more_values should be true"
           (is (= :list
-                 (db/select-one-field :has_field_values Field
+                 (t2/select-one-fn :has_field_values Field
                                       :id (mt/id :blueberries_consumed :str)))))
         (testing "it should still have FieldValues, but the stored list has at most [metadata-queries/absolute-max-distinct-values-limit] elements"
           (is (= {:values                (take metadata-queries/absolute-max-distinct-values-limit
@@ -236,13 +237,13 @@
       (db/update! Field (mt/id :blueberries_consumed :str) :has_field_values "list")
       (testing "has_more_values should initially be false"
         (is (= false
-               (db/select-one-field :has_more_values FieldValues :field_id (mt/id :blueberries_consumed :str)))))
+               (t2/select-one-fn :has_more_values FieldValues :field_id (mt/id :blueberries_consumed :str)))))
 
       (testing "insert a row with the value length exceeds our length limit\n"
         (one-off-dbs/insert-rows-and-sync! [(str/join (repeat (+ 100 field-values/*total-max-length*) "A"))])
         (testing "has_field_values shouldn't change and has_more_values should be true"
           (is (= :list
-                 (db/select-one-field :has_field_values Field
+                 (t2/select-one-fn :has_field_values Field
                                       :id (mt/id :blueberries_consumed :str)))))
         (testing "it should still have FieldValues, but the stored list is just a sub-list of all distinct values and `has_more_values` = true"
           (is (= {:values                [(str/join (repeat 50 "A"))]

--- a/test/metabase/sync/sync_metadata/dbms_version_test.clj
+++ b/test/metabase/sync/sync_metadata/dbms_version_test.clj
@@ -6,10 +6,11 @@
    [metabase.test :as mt]
    [metabase.util :as u]
    [schema.core :as s]
-   [toucan.db :as db]))
+   [toucan.db :as db]
+   [toucan2.core :as t2]))
 
 (defn- db-dbms-version [db-or-id]
-  (db/select-one-field :dbms_version Database :id (u/the-id db-or-id)))
+  (t2/select-one-fn :dbms_version Database :id (u/the-id db-or-id)))
 
 (defn- check-dbms-version [dbms-version]
   (s/check (s/maybe sync-dbms-ver/DBMSVersion) dbms-version))

--- a/test/metabase/sync/sync_metadata/fields/sync_instances_test.clj
+++ b/test/metabase/sync/sync_metadata/fields/sync_instances_test.clj
@@ -9,7 +9,8 @@
    [metabase.test.mock.toucanery :as toucanery]
    [metabase.util :as u]
    [toucan.db :as db]
-   [toucan.util.test :as tt]))
+   [toucan.util.test :as tt]
+   [toucan2.core :as t2]))
 
 (def ^:private toucannery-transactions-expected-fields-hierarchy
   {"ts"     nil
@@ -123,7 +124,7 @@
         ;; now sync again.
         (sync-metadata/sync-db-metadata! db)
         ;; field should become inactive
-        (is (false? (db/select-one-field :active Field :id gender-field-id))))))
+        (is (false? (t2/select-one-fn :active Field :id gender-field-id))))))
 
   (testing "When a nested field is marked inactive so are its children"
     (tt/with-temp* [Database [db {:engine ::toucanery/toucanery}]]
@@ -151,4 +152,4 @@
         ;; now sync again.
         (sync-metadata/sync-db-metadata! db)
         ;; field should become inactive
-        (is (false? (db/select-one-field :active Field :id blueberries-field-id)))))))
+        (is (false? (t2/select-one-fn :active Field :id blueberries-field-id)))))))

--- a/test/metabase/sync/sync_metadata/fields_test.clj
+++ b/test/metabase/sync/sync_metadata/fields_test.clj
@@ -13,7 +13,8 @@
    [metabase.test.data.one-off-dbs :as one-off-dbs]
    [metabase.util :as u]
    [toucan.db :as db]
-   [toucan.hydrate :refer [hydrate]]))
+   [toucan.hydrate :refer [hydrate]]
+   [toucan2.core :as t2]))
 
 (defn- with-test-db-before-and-after-altering
   "Testing function that performs the following steps:
@@ -129,7 +130,7 @@
 (deftest pk-sync-test
   (testing "Test PK Syncing"
     (mt/with-temp-copy-of-db
-      (letfn [(get-semantic-type [] (db/select-one-field :semantic_type Field, :id (mt/id :venues :id)))]
+      (letfn [(get-semantic-type [] (t2/select-one-fn :semantic_type Field, :id (mt/id :venues :id)))]
         (testing "Semantic type should be :id to begin with"
           (is (= :type/PK
                  (get-semantic-type))))
@@ -155,13 +156,13 @@
   (testing "Check that Foreign Key relationships were created on sync as we expect"
     (testing "checkins.venue_id"
       (is (= (mt/id :venues :id)
-             (db/select-one-field :fk_target_field_id Field, :id (mt/id :checkins :venue_id)))))
+             (t2/select-one-fn :fk_target_field_id Field, :id (mt/id :checkins :venue_id)))))
     (testing "checkins.user_id"
       (is (= (mt/id :users :id)
-             (db/select-one-field :fk_target_field_id Field, :id (mt/id :checkins :user_id)))))
+             (t2/select-one-fn :fk_target_field_id Field, :id (mt/id :checkins :user_id)))))
     (testing "venues.category_id"
       (is (= (mt/id :categories :id)
-             (db/select-one-field :fk_target_field_id Field, :id (mt/id :venues :category_id)))))))
+             (t2/select-one-fn :fk_target_field_id Field, :id (mt/id :venues :category_id)))))))
 
 (deftest sync-table-fks-test
   (testing "Check that sync-table! causes FKs to be set like we'd expect"

--- a/test/metabase/sync/sync_metadata/sync_timezone_test.clj
+++ b/test/metabase/sync/sync_metadata/sync_timezone_test.clj
@@ -7,10 +7,11 @@
    [metabase.sync.util-test :as sync.util-test]
    [metabase.test :as mt]
    [metabase.util :as u]
-   [toucan.db :as db]))
+   [toucan.db :as db]
+   [toucan2.core :as t2]))
 
 (defn- db-timezone [db-or-id]
-  (db/select-one-field :timezone Database :id (u/the-id db-or-id)))
+  (t2/select-one-fn :timezone Database :id (u/the-id db-or-id)))
 
 (deftest sync-timezone-test
   (mt/test-drivers #{:h2 :postgres}

--- a/test/metabase/sync/util_test.clj
+++ b/test/metabase/sync/util_test.clj
@@ -15,7 +15,8 @@
    [metabase.test :as mt]
    [metabase.test.util :as tu]
    [toucan.db :as db]
-   [toucan.util.test :as tt]))
+   [toucan.util.test :as tt]
+   [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
 
@@ -257,31 +258,31 @@
       (let [_  (db/update! Database (:id (mt/db)) :initial_sync_status "incomplete")
             db (db/select-one Database :id (:id (mt/db)))]
         (sync/sync-database! db)
-        (is (= "complete" (db/select-one-field :initial_sync_status Database :id (:id db))))))
+        (is (= "complete" (t2/select-one-fn :initial_sync_status Database :id (:id db))))))
 
    (testing "If `initial-sync-status` on a DB is `complete`, it remains `complete` when sync is run again"
       (let [_  (db/update! Database (:id (mt/db)) :initial_sync_status "complete")
             db (db/select-one Database :id (:id (mt/db)))]
         (sync/sync-database! db)
-        (is (= "complete" (db/select-one-field :initial_sync_status Database :id (:id db))))))
+        (is (= "complete" (t2/select-one-fn :initial_sync_status Database :id (:id db))))))
 
    (testing "If `initial-sync-status` on a table is `incomplete`, it is marked as `complete` after the sync-fks step
             has finished"
-      (let [table-id (db/select-one-field :id Table :db_id (:id (mt/db)))
+      (let [table-id (t2/select-one-fn :id Table :db_id (:id (mt/db)))
             _        (db/update! Table table-id :initial_sync_status "incomplete")
             _table   (db/select-one Table :id table-id)]
         (sync/sync-database! (mt/db))
-        (is (= "complete" (db/select-one-field :initial_sync_status Table :id table-id)))))
+        (is (= "complete" (t2/select-one-fn :initial_sync_status Table :id table-id)))))
 
    (testing "Database and table syncs are marked as complete even if the initial scan is :schema only"
       (let [_        (db/update! Database (:id (mt/db)) :initial_sync_status "incomplete")
             db       (db/select-one Database :id (:id (mt/db)))
-            table-id (db/select-one-field :id Table :db_id (:id (mt/db)))
+            table-id (t2/select-one-fn :id Table :db_id (:id (mt/db)))
             _        (db/update! Table table-id :initial_sync_status "incomplete")
             _table   (db/select-one Table :id table-id)]
         (sync/sync-database! db {:scan :schema})
-        (is (= "complete" (db/select-one-field :initial_sync_status Database :id (:id db))))
-        (is (= "complete" (db/select-one-field :initial_sync_status Table :id table-id)))))
+        (is (= "complete" (t2/select-one-fn :initial_sync_status Database :id (:id db))))
+        (is (= "complete" (t2/select-one-fn :initial_sync_status Table :id table-id)))))
 
    (testing "If a non-recoverable error occurs during sync, `initial-sync-status` on the database is set to `aborted`"
       (let [_  (db/update! Database (:id (mt/db)) :initial_sync_status "incomplete")
@@ -291,11 +292,11 @@
                                                         "fake-step"
                                                         (fn [_] (throw (java.net.ConnectException.))))])]
           (sync/sync-database! db)
-          (is (= "aborted" (db/select-one-field :initial_sync_status Database :id (:id db)))))))
+          (is (= "aborted" (t2/select-one-fn :initial_sync_status Database :id (:id db)))))))
 
    (testing "If `initial-sync-status` is `aborted` for a database, it is set to `complete` the next time sync finishes
            without error"
       (let [_  (db/update! Database (:id (mt/db)) :initial_sync_status "complete")
             db (db/select-one Database :id (:id (mt/db)))]
         (sync/sync-database! db)
-        (is (= "complete" (db/select-one-field :initial_sync_status Database :id (:id db))))))))
+        (is (= "complete" (t2/select-one-fn :initial_sync_status Database :id (:id db))))))))

--- a/test/metabase/test/data/impl.clj
+++ b/test/metabase/test/data/impl.clj
@@ -21,7 +21,8 @@
    [metabase.util :as u]
    [metabase.util.log :as log]
    [potemkin :as p]
-   [toucan.db :as db]))
+   [toucan.db :as db]
+   [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
 
@@ -196,7 +197,7 @@
   (let [table-name        (name table-name)
         table-id-for-name (partial db/select-one-id Table, :db_id db-id, :name)]
     (or (table-id-for-name table-name)
-        (table-id-for-name (let [db-name (db/select-one-field :name Database :id db-id)]
+        (table-id-for-name (let [db-name (t2/select-one-fn :name Database :id db-id)]
                              (tx/db-qualified-table-name db-name table-name)))
         (let [{driver :engine, db-name :name} (db/select-one [Database :engine :name] :id db-id)]
           (throw
@@ -218,7 +219,7 @@
 (defn- the-field-id* [table-id field-name & {:keys [parent-id]}]
   (or (db/select-one-id Field, :active true, :table_id table-id, :name field-name, :parent_id parent-id)
       (let [{db-id :db_id, table-name :name} (db/select-one [Table :name :db_id] :id table-id)
-            db-name                          (db/select-one-field :name Database :id db-id)
+            db-name                          (t2/select-one-fn :name Database :id db-id)
             field-name                       (qualified-field-name {:parent_id parent-id, :name field-name})
             all-field-names                  (all-field-names table-id)]
         (throw

--- a/test/metabase/test/data/interface.clj
+++ b/test/metabase/test/data/interface.clj
@@ -27,7 +27,8 @@
    [potemkin.types :as p.types]
    [pretty.core :as pretty]
    [schema.core :as s]
-   [toucan.db :as db]))
+   [toucan.db :as db]
+   [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
 
@@ -397,7 +398,7 @@
 
   ([_driver aggregation-type {field-id :id, table-id :table_id}]
    {:pre [(some? table-id)]}
-   (first (qp/query->expected-cols {:database (db/select-one-field :db_id Table :id table-id)
+   (first (qp/query->expected-cols {:database (t2/select-one-fn :db_id Table :id table-id)
                                     :type     :query
                                     :query    {:source-table table-id
                                                :aggregation  [[aggregation-type [:field-id field-id]]]}}))))

--- a/test/metabase/test/data/mbql_query_impl.clj
+++ b/test/metabase/test/data/mbql_query_impl.clj
@@ -5,7 +5,7 @@
    [clojure.test :refer :all]
    [clojure.walk :as walk]
    [metabase.models.field :refer [Field]]
-   [toucan.db :as db]))
+   [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
 
@@ -69,10 +69,10 @@
                    :dest-token-str    dest-token-str})))
 
 (defn field-name [field-id]
-  (db/select-one-field :name Field :id field-id))
+  (t2/select-one-fn :name Field :id field-id))
 
 (defn field-base-type [field-id]
-  (db/select-one-field :base_type Field :id field-id))
+  (t2/select-one-fn :base_type Field :id field-id))
 
 (defn- field-literal [source-table-symb token-str]
   (if (str/includes? token-str "/")

--- a/test/metabase/test/data/users.clj
+++ b/test/metabase/test/data/users.clj
@@ -16,7 +16,8 @@
    [metabase.util.password :as u.password]
    [schema.core :as s]
    [toucan.db :as db]
-   [toucan.util.test :as tt])
+   [toucan.util.test :as tt]
+   [toucan2.core :as t2])
   (:import
    (clojure.lang ExceptionInfo)))
 
@@ -181,7 +182,7 @@
       (fetch-user user)
       (apply client-fn user args))
     (let [user-id             (u/the-id user)
-          user-email          (db/select-one-field :email User :id user-id)
+          user-email          (t2/select-one-fn :email User :id user-id)
           [old-password-info] (db/simple-select User {:select [:password :password_salt]
                                                       :where  [:= :id user-id]})]
       (when-not user-email

--- a/test/metabase/test/util.clj
+++ b/test/metabase/test/util.clj
@@ -390,7 +390,7 @@
     (if (and (not raw-setting?) (#'setting/env-var-value setting-k))
       (do-with-temp-env-var-value (setting/setting-env-map-name setting-k) value thunk)
       (let [original-value (if raw-setting?
-                             (db/select-one-field :value Setting :key setting-k)
+                             (t2/select-one-fn :value Setting :key setting-k)
                              (#'setting/get setting-k))]
         (try
          (if raw-setting?
@@ -855,7 +855,7 @@
      ([thunk [original-column-id remap]]
       (let [original       (db/select-one Field :id (u/the-id original-column-id))
             describe-field (fn [{table-id :table_id, field-name :name}]
-                             (format "%s.%s" (db/select-one-field :name Table :id table-id) field-name))]
+                             (format "%s.%s" (t2/select-one-fn :name Table :id table-id) field-name))]
         (if (integer? remap)
           ;; remap is integer => fk remap
           (let [remapped (db/select-one Field :id (u/the-id remap))]

--- a/test/metabase/test/util_test.clj
+++ b/test/metabase/test/util_test.clj
@@ -7,11 +7,11 @@
    [metabase.test :as mt]
    [metabase.test.data :as data]
    [metabase.util :as u]
-   [toucan.db :as db]))
+   [toucan2.core :as t2]))
 
 (deftest with-temp-vals-in-db-test
   (testing "let's make sure this acutally works right!"
-    (let [position #(db/select-one-field :position Field :id (data/id :venues :price))]
+    (let [position #(t2/select-one-fn :position Field :id (data/id :venues :price))]
       (mt/with-temp-vals-in-db Field (data/id :venues :price) {:position -1}
         (is (= -1
                (position))))
@@ -23,7 +23,7 @@
      (mt/with-temp-vals-in-db Field (data/id :venues :price) {:position -1}
        (throw (Exception.))))
     (is (= 5
-           (db/select-one-field :position Field :id (data/id :venues :price))))))
+           (t2/select-one-fn :position Field :id (data/id :venues :price))))))
 
 (setting/defsetting test-util-test-setting
   "Another internal test setting"


### PR DESCRIPTION
there are no syntax or behavior changes between `db/select-one-field` and `t2/select-one-fn`(given that all of our pk is id).

So this is pretty much just `s/db\/select-one-field/t2\/select-one-fn`. And of course, doing a bunch of imports.