### PR TITLE
Fix v1 dump long file names

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/serialization/names.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/names.clj
@@ -24,10 +24,16 @@
 
 (def ^:private root-collection-path "/collections/root")
 
+(def ^:private label-limit 100)
+
 (defn safe-name
   "Return entity name URL encoded except that spaces are retained."
-  [entity]
-  (some-> entity ((some-fn :email :name)) codec/url-encode (str/replace "%20" " ")))
+  ([{:keys [id email name]}]
+   (when-let [label (or email name)]
+     (let [label (if (< (count label) label-limit)
+                   label
+                   (str (subs label 0 label-limit) "_" id))]
+       (-> label codec/url-encode (str/replace "%20" " "))))))
 
 (def unescape-name
   "Inverse of `safe-name`."

--- a/enterprise/backend/test/metabase_enterprise/serialization/names_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/names_test.clj
@@ -8,9 +8,14 @@
             [toucan.db :as db]))
 
 (deftest safe-name-test
-  (are [s expected] (= (names/safe-name {:name s}) expected)
-    "foo"         "foo"
-    "foo/bar baz" "foo%2Fbar baz"))
+  (testing "basic escaping"
+    (are [s expected] (= expected (names/safe-name {:name s}))
+      "foo"         "foo"
+      "foo/bar baz" "foo%2Fbar baz"))
+  (testing "extremely long entity names (#29246)"
+    (is (= "json_field %E2%86%92 level1 %E2%86%92 level2 %E2%86%92 level3 %E2%86%92 level4 %E2%86%92 level5 %E2%86%92 level6 %E2%86%92 level7 %E2%86%92 level8 %E2%86%92 level9 %E2%86%92 level1_72"
+           (names/safe-name {:name "json_field → level1 → level2 → level3 → level4 → level5 → level6 → level7 → level8 → level9 → level10 → level11 → level12 → level13 → level14 → level15 → level16 → level17 → level18 → level19 → level20"
+                             :id 72})))))
 
 (deftest unescape-name-test
   (are [s expected] (= expected


### PR DESCRIPTION
This updates the `dump` command to limit filenames to use up to 100 characters of the entity's `:name`, otherwise truncate it and append the entity's `:id` to the filename. 100 is just an arbitrary limit, since we can't really know the filename or path length limit of the host operating system.

Resolves #29246

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/29329)
<!-- Reviewable:end -->
