### PR TITLE
REAL launch lag fix :wrench:

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -32,6 +32,8 @@
                                                            org.slf4j/slf4j-api]}
   com.draines/postal                        {:mvn/version "2.0.5"}              ; SMTP library
   com.github.seancorfield/honeysql          {:mvn/version "2.4.1002"}           ; Honey SQL 2. SQL generation from Clojure data maps
+  com.github.seancorfield/next.jdbc         {:git/url "https://github.com/seancorfield/next-jdbc.git"
+                                             :sha     "8f372917a4b8b55c893ef6586f9ffe8dce4cbc7e"} ; for https://github.com/seancorfield/next-jdbc/issues/245; when this makes it to a release we can switch to that.
   com.github.vertical-blank/sql-formatter   {:mvn/version "2.0.3"}              ; Java SQL formatting library https://github.com/vertical-blank/sql-formatter
   com.google.guava/guava                    {:mvn/version "31.1-jre"}           ; dep for BigQuery, Spark, and GA. Require here rather than letting different dep versions stomp on each other — see comments on #9697
   com.fasterxml.jackson.core/jackson-databind

--- a/src/metabase/db/connection.clj
+++ b/src/metabase/db/connection.clj
@@ -137,3 +137,9 @@
 (methodical/defmethod t2.conn/do-with-connection :default
   [_connectable f]
   (t2.conn/do-with-connection *application-db* f))
+
+(methodical/defmethod t2.conn/do-with-transaction :around java.sql.Connection
+  [connection options f]
+  ;; Do not deadlock if using a Connection in a different thread inside of a transaction -- see
+  ;; https://github.com/seancorfield/next-jdbc/issues/244.
+  (next-method connection (assoc options :nested-transaction-rule :ignore) f))


### PR DESCRIPTION
Supercedes #29303

Use the fix from https://github.com/seancorfield/next-jdbc/issues/244 / https://github.com/seancorfield/next-jdbc/issues/245 / https://github.com/seancorfield/next-jdbc/commit/8f372917a4b8b55c893ef6586f9ffe8dce4cbc7e to address our lag-on-launch issue.

See explanation of the issue in description for #29303. This PR uses the `next.jdbc` option for transactions that does not use the locking that was causing us problems