### PR TITLE
Use question metadata for `generateQueryDescription`

### DIFF
--- a/frontend/src/metabase-lib/Question.ts
+++ b/frontend/src/metabase-lib/Question.ts
@@ -1339,13 +1339,11 @@ class QuestionInner {
     // cache the metadata provider we create for our metadata.
     if (metadata === this._metadata) {
       if (!this.__mlv2MetadataProvider) {
-        console.log("Caching MLv2 metadata");
         this.__mlv2MetadataProvider = MLv2.metadataProvider(
           this.databaseId(),
           metadata,
         );
       }
-      console.log("Using cached MLv2 metadata");
       metadata = this.__mlv2MetadataProvider;
     }
 
@@ -1355,7 +1353,6 @@ class QuestionInner {
     }
 
     if (!this.__mlv2Query) {
-      console.log("Caching MLv2 query based on", this.datasetQuery());
       this.__mlv2QueryMetadata = metadata;
       this.__mlv2Query = MLv2.query(
         this.databaseId(),
@@ -1364,7 +1361,6 @@ class QuestionInner {
       );
     }
 
-    console.log("Using cached MLv2 query");
     return this.__mlv2Query;
   }
 

--- a/frontend/src/metabase-lib/Question.ts
+++ b/frontend/src/metabase-lib/Question.ts
@@ -1365,7 +1365,7 @@ class QuestionInner {
   }
 
   generateQueryDescription() {
-    const query = this._getMLv2Query(this._metadata);
+    const query = this._getMLv2Query();
     return MLv2.suggestedName(query);
   }
 

--- a/frontend/src/metabase-lib/Question.ts
+++ b/frontend/src/metabase-lib/Question.ts
@@ -1368,27 +1368,9 @@ class QuestionInner {
     return this.__mlv2Query;
   }
 
-  generateQueryDescription(tableMetadata) {
-    let metadata =
-      tableMetadata?.id != null
-        ? assocIn(
-            this._metadata,
-            ["tables", String(tableMetadata.id)],
-            tableMetadata,
-          )
-        : this._metadata;
-
-    if (tableMetadata) {
-      for (const fieldMetadata of tableMetadata?.fields) {
-        metadata = assocIn(
-          metadata,
-          ["fields", String(fieldMetadata.id)],
-          fieldMetadata,
-        );
-      }
-    }
-
-    return MLv2.suggestedName(this._getMLv2Query(metadata));
+  generateQueryDescription() {
+    const query = this._getMLv2Query(this._metadata);
+    return MLv2.suggestedName(query);
   }
 
   getUrlWithParameters(parameters, parameterValues, { objectId, clean } = {}) {

--- a/frontend/src/metabase/containers/SaveQuestionModal.jsx
+++ b/frontend/src/metabase/containers/SaveQuestionModal.jsx
@@ -26,7 +26,6 @@ export default class SaveQuestionModal extends Component {
   static propTypes = {
     question: PropTypes.object.isRequired,
     originalQuestion: PropTypes.object,
-    tableMetadata: PropTypes.object, // can't be required, sometimes null
     onCreate: PropTypes.func.isRequired,
     onSave: PropTypes.func.isRequired,
     onClose: PropTypes.func.isRequired,
@@ -73,13 +72,12 @@ export default class SaveQuestionModal extends Component {
   };
 
   render() {
-    const { question, originalQuestion, initialCollectionId, tableMetadata } =
-      this.props;
+    const { question, originalQuestion, initialCollectionId } = this.props;
 
     const isReadonly = originalQuestion != null && !originalQuestion.canWrite();
 
     const initialValues = {
-      name: question.generateQueryDescription(tableMetadata),
+      name: question.generateQueryDescription(),
       description: question.description() || "",
       collection_id:
         question.collectionId() === undefined || isReadonly

--- a/frontend/src/metabase/query_builder/components/AggregationPopover/AggregationPopover.jsx
+++ b/frontend/src/metabase/query_builder/components/AggregationPopover/AggregationPopover.jsx
@@ -52,10 +52,6 @@ export default class AggregationPopover extends Component {
     // passing a dimension disables the field picker and only shows relevant aggregations
     dimension: PropTypes.object,
 
-    // DEPRECATED: replaced with `query`
-    tableMetadata: PropTypes.object,
-    datasetQuery: PropTypes.object,
-
     aggregationOperators: PropTypes.array,
 
     showCustom: PropTypes.bool,

--- a/frontend/src/metabase/query_builder/components/QueryModals.jsx
+++ b/frontend/src/metabase/query_builder/components/QueryModals.jsx
@@ -77,7 +77,6 @@ class QueryModals extends React.Component {
         <SaveQuestionModal
           question={this.props.question}
           originalQuestion={this.props.originalQuestion}
-          tableMetadata={this.props.tableMetadata}
           initialCollectionId={this.props.initialCollectionId}
           onSave={async question => {
             // if saving modified question, don't show "add to dashboard" modal
@@ -110,7 +109,6 @@ class QueryModals extends React.Component {
         <SaveQuestionModal
           question={this.props.question}
           originalQuestion={this.props.originalQuestion}
-          tableMetadata={this.props.tableMetadata}
           initialCollectionId={this.props.initialCollectionId}
           onSave={async question => {
             await this.props.onSave(question);
@@ -144,7 +142,6 @@ class QueryModals extends React.Component {
         <SaveQuestionModal
           question={this.props.question}
           originalQuestion={this.props.originalQuestion}
-          tableMetadata={this.props.tableMetadata}
           onSave={async question => {
             await this.props.onSave(question, false);
             this.showAlertsAfterQuestionSaved();
@@ -163,7 +160,6 @@ class QueryModals extends React.Component {
         <SaveQuestionModal
           question={this.props.question}
           originalQuestion={this.props.originalQuestion}
-          tableMetadata={this.props.tableMetadata}
           onSave={async question => {
             await this.props.onSave(question, false);
             onOpenModal(MODAL_TYPES.EMBED);

--- a/frontend/src/metabase/query_builder/containers/QueryBuilder.jsx
+++ b/frontend/src/metabase/query_builder/containers/QueryBuilder.jsx
@@ -50,7 +50,6 @@ import {
   getIsNew,
   getIsObjectDetail,
   getTables,
-  getTableMetadata,
   getTableForeignKeys,
   getTableForeignKeyReferences,
   getUiControls,
@@ -122,7 +121,6 @@ const mapStateToProps = (state, props) => {
     databases: getDatabasesList(state),
     nativeDatabases: getNativeDatabases(state),
     tables: getTables(state),
-    tableMetadata: getTableMetadata(state),
 
     query: getQuery(state),
     metadata: getMetadata(state),

--- a/frontend/test/metabase-lib/lib/Question.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/Question.unit.spec.js
@@ -1570,19 +1570,14 @@ describe("Question", () => {
   });
 
   describe("Question.generateQueryDescription", () => {
-    const mockTableMetadata = {
-      display_name: "Order",
-      fields: [{ id: 1, display_name: "Total" }],
-    };
-
     it("should work with multiple aggregations", () => {
       const question = base_question.setDatasetQuery({
         query: {
           "source-table": ORDERS.id,
-          aggregation: [["count"], ["sum", ["field", 1, null]]],
+          aggregation: [["count"], ["sum", ["field", 6, null]]],
         },
       });
-      expect(question.generateQueryDescription(mockTableMetadata)).toEqual(
+      expect(question.generateQueryDescription()).toEqual(
         "Orders, Count and Sum of Total",
       );
     });
@@ -1600,9 +1595,7 @@ describe("Question", () => {
           ],
         },
       });
-      expect(question.generateQueryDescription(mockTableMetadata)).toEqual(
-        "Orders, Revenue",
-      );
+      expect(question.generateQueryDescription()).toEqual("Orders, Revenue");
     });
   });
 });

--- a/frontend/test/metabase/containers/SaveQuestionModal.unit.spec.js
+++ b/frontend/test/metabase/containers/SaveQuestionModal.unit.spec.js
@@ -30,7 +30,6 @@ const setup = async (
     <SaveQuestionModal
       question={question}
       originalQuestion={originalQuestion}
-      tableMetadata={question.table()}
       onCreate={onCreateMock}
       onSave={onSaveMock}
       onClose={onCloseMock}


### PR DESCRIPTION
Patch for #29200

It seems like `generateQueryDescription` should be free to use its internal `Metadata` instance. We used to generate these descriptions in a separate function, so it made sense to pass it externally. But now we're calling the method for a question we'd like to get a description for. At that point, the question should have all the necessary metadata loaded.

The PR also removes the `tableMetadata` from a few query builder components. It seems like it was added to `QueryBuilder's` `mapStateToProps` only to be propagated down to the `SaveQuestionModal`.