### PR TITLE
Make object detail viz work for non-logged-in users

### DIFF
--- a/e2e/test/scenarios/visualizations/object_detail.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/object_detail.cy.spec.js
@@ -8,6 +8,8 @@ import {
   resetTestTable,
   resyncDatabase,
   getTableId,
+  visitPublicQuestion,
+  visitPublicDashboard,
 } from "e2e/support/helpers";
 
 import { WRITABLE_DB_ID, SAMPLE_DB_ID } from "e2e/support/cypress_data";
@@ -322,6 +324,50 @@ function changeSorting(columnName, direction) {
         cy.icon('chevrondown').click();
         cy.findAllByText("Horse").should('have.length', 2);
       });
+    });
+  });
+});
+
+describe(`Object Detail > public`, () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+  });
+
+  it('can view a public object detail question', () => {
+
+    cy.createQuestion({ ...TEST_QUESTION, display: 'object' }).then(
+      ({ body: { id: questionId } }) => {
+        visitPublicQuestion(questionId);
+      },
+    );
+    cy.icon('warning').should('not.exist');
+
+    cy.findByTestId('object-detail').within(() => {
+      cy.findByText('User ID').should('be.visible');
+      cy.findByText('1283').should('be.visible');
+    });
+
+    cy.findByTestId('pagination-footer').within(() => {
+      cy.findByText("Item 1 of 3").should('be.visible');
+    });
+  });
+
+  it('can view an object detail question on a public dashboard', () => {
+    cy.createQuestionAndDashboard({ questionDetails: { ...TEST_QUESTION, display: 'object' } }).then(
+      ({ body: { dashboard_id } }) => {
+        visitPublicDashboard(dashboard_id);
+      });
+
+    cy.icon('warning').should('not.exist');
+
+    cy.findByTestId('object-detail').within(() => {
+      cy.findByText('User ID').should('be.visible');
+      cy.findByText('1283').should('be.visible');
+    });
+
+    cy.findByTestId('pagination-footer').within(() => {
+      cy.findByText("Item 1 of 3").should('be.visible');
     });
   });
 });

--- a/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetail.tsx
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetail.tsx
@@ -342,6 +342,7 @@ export function ObjectDetailWrapper({
       />
       {hasPagination && (
         <PaginationFooter
+          data-testid="pagination-footer"
           start={currentObjectIndex}
           end={currentObjectIndex}
           total={data.rows.length}

--- a/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetail.tsx
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetail.tsx
@@ -31,6 +31,7 @@ import {
   getCanZoomPreviousRow,
   getCanZoomNextRow,
 } from "metabase/query_builder/selectors";
+import { getUser } from "metabase/selectors/user";
 
 import { isVirtualCardId } from "metabase-lib/metadata/utils/saved-questions";
 import { isPK } from "metabase-lib/types/utils/isa";
@@ -61,6 +62,12 @@ import {
 } from "./ObjectDetail.styled";
 
 const mapStateToProps = (state: State, { data }: ObjectDetailProps) => {
+  const isLoggedIn = !!getUser(state);
+
+  if (!isLoggedIn) {
+    return {};
+  }
+
   const table = getTableMetadata(state);
   let zoomedRowID = getZoomedObjectId(state);
   const isZooming = zoomedRowID != null;

--- a/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetail.tsx
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetail.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useCallback } from "react";
 import { connect } from "react-redux";
+import _ from "underscore";
 
 import { useMount, usePrevious } from "react-use";
 import { State } from "metabase-types/store";
@@ -201,7 +202,9 @@ export function ObjectDetailFn({
 
   const onFollowForeignKey = useCallback(
     (fk: ForeignKey) => {
-      followForeignKey({ objectId: zoomedRowID, fk });
+      zoomedRowID !== undefined
+        ? followForeignKey({ objectId: zoomedRowID, fk })
+        : _.noop();
     },
     [zoomedRowID, followForeignKey],
   );
@@ -257,10 +260,12 @@ export function ObjectDetailFn({
         >
           {showHeader && (
             <ObjectDetailHeader
-              canZoom={canZoom && (canZoomNextRow || canZoomPreviousRow)}
+              canZoom={Boolean(
+                canZoom && (canZoomNextRow || canZoomPreviousRow),
+              )}
               objectName={objectName}
               objectId={displayId}
-              canZoomPreviousRow={canZoomPreviousRow}
+              canZoomPreviousRow={!!canZoomPreviousRow}
               canZoomNextRow={canZoomNextRow}
               showActions={showActions}
               viewPreviousObjectDetail={viewPreviousObjectDetail}
@@ -431,11 +436,11 @@ export interface ObjectDetailBodyProps {
   hasRelationships: boolean;
   onVisualizationClick: OnVisualizationClickType;
   visualizationIsClickable: (clicked: unknown) => boolean;
-  tableForeignKeys: ForeignKey[];
-  tableForeignKeyReferences: {
+  tableForeignKeys?: ForeignKey[];
+  tableForeignKeyReferences?: {
     [key: number]: { status: number; value: number };
   };
-  followForeignKey: (fk: ForeignKey) => void;
+  followForeignKey?: (fk: ForeignKey) => void;
 }
 
 export function ObjectDetailBody({
@@ -450,6 +455,12 @@ export function ObjectDetailBody({
   tableForeignKeyReferences,
   followForeignKey,
 }: ObjectDetailBodyProps): JSX.Element {
+  const showRelationships =
+    hasRelationships &&
+    tableForeignKeys &&
+    tableForeignKeyReferences &&
+    followForeignKey;
+
   return (
     <ObjectDetailBodyWrapper>
       <DetailsTable
@@ -459,7 +470,7 @@ export function ObjectDetailBody({
         onVisualizationClick={onVisualizationClick}
         visualizationIsClickable={visualizationIsClickable}
       />
-      {hasRelationships && (
+      {showRelationships && (
         <Relationships
           objectName={objectName}
           tableForeignKeys={tableForeignKeys}

--- a/frontend/src/metabase/visualizations/components/ObjectDetail/types.ts
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/types.ts
@@ -21,20 +21,20 @@ export type OnVisualizationClickType =
 
 export interface ObjectDetailProps {
   data: DatasetData;
-  question: Question;
+  question?: Question;
   card?: SavedCard;
   dashcard?: DashboardOrderedCard;
   isObjectDetail?: boolean; // whether this should be shown in a modal
-  table: Table | null;
-  zoomedRow: unknown[] | undefined;
-  zoomedRowID: ObjectId;
-  tableForeignKeys: ForeignKey[];
-  tableForeignKeyReferences: {
+  table?: Table | null;
+  zoomedRow?: unknown[] | undefined;
+  zoomedRowID?: ObjectId;
+  tableForeignKeys?: ForeignKey[];
+  tableForeignKeyReferences?: {
     [key: number]: { status: number; value: number };
   };
   settings: any;
-  canZoom: boolean;
-  canZoomPreviousRow: boolean;
+  canZoom?: boolean;
+  canZoomPreviousRow?: boolean;
   canZoomNextRow?: boolean;
   isDataApp?: boolean;
   showActions?: boolean;

--- a/frontend/src/metabase/visualizations/components/ObjectDetail/utils.ts
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/utils.ts
@@ -15,8 +15,8 @@ import Table from "metabase-lib/metadata/Table";
 import { ObjectId } from "./types";
 
 export interface GetObjectNameArgs {
-  table: Table | null;
-  question: Question;
+  table?: Table | null;
+  question?: Question;
   cols: Column[];
   zoomedRow: unknown[] | undefined;
 }

--- a/frontend/src/metabase/visualizations/components/TableSimple/TableFooter.tsx
+++ b/frontend/src/metabase/visualizations/components/TableSimple/TableFooter.tsx
@@ -14,6 +14,7 @@ import {
 
 interface TableFooterProps {
   className?: string;
+  "data-testid"?: string;
   start: number;
   end: number;
   total: number;
@@ -27,6 +28,7 @@ const TableFooter = React.forwardRef<HTMLDivElement, TableFooterProps>(
   function TableFooter(
     {
       className,
+      "data-testid": dataTestId = "TableFooter",
       start,
       end,
       limit,
@@ -73,6 +75,7 @@ const TableFooter = React.forwardRef<HTMLDivElement, TableFooterProps>(
           className,
           "fullscreen-normal-text fullscreen-night-text",
         )}
+        data-testid={dataTestId}
         ref={ref}
       >
         <PaginationMessage>{paginateMessage}</PaginationMessage>


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/29324

### Description

Object detail has two "modes" - Visualization mode and Modal Mode. In Modal mode, it has some bonus features where it tries to use table metadata and foreign keys to pull in extra information about linked records. Users who are not logged in don't have access to that data, so the vanilla visualization was erroring. 

This adds a simple check that skips all the metadata selectors and magic for users that are not logged in. The visualization just falls back gracefully to only using the data passed to it.

![Screen Shot 2023-03-17 at 12 53 40 PM](https://user-images.githubusercontent.com/30528226/225993417-a8d5e493-32d6-4a53-872b-8d168b34533b.png)


### How to verify

1. make a question on any table and set it to detail viz.
2. make the question public
3. add the question to a dashboard
4. make that dashboard public
5. in an incognito window, verify that the detail viz works for both the public question and public dashboard.


### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
