### PR TITLE
fix how isCustomWidgetCheck detects if widgets are react components

### DIFF
--- a/e2e/test/scenarios/models/models-metadata.cy.spec.js
+++ b/e2e/test/scenarios/models/models-metadata.cy.spec.js
@@ -152,6 +152,28 @@ describe("scenarios > models metadata", () => {
     cy.findByText("Pre-tax ($)");
   });
 
+  it("should allow setting column relations (metabase#29318)", () => {
+    cy.createNativeQuestion(
+      {
+        name: "Native Model",
+        dataset: true,
+        native: {
+          query: "SELECT * FROM ORDERS",
+        },
+      },
+      { visitQuestion: true },
+    );
+    openQuestionActions();
+    cy.findByText("Edit metadata").click();
+    openColumnOptions("USER_ID");
+    setColumnType("No special type", "Foreign Key");
+    cy.findByText("Select a target").click();
+    cy.findByText("People → ID").click();
+    cy.button("Save changes").click();
+    // TODO: Not much to do with it at the moment beyond saving it.
+    // Check that the relation is automatically suggested in the notebook once it is implemented.
+  });
+
   it("should keep metadata in sync with the query", () => {
     cy.createNativeQuestion(
       {

--- a/frontend/src/metabase-types/guards/forms.ts
+++ b/frontend/src/metabase-types/guards/forms.ts
@@ -3,12 +3,13 @@ import type {
   CustomFormFieldDefinition,
   FormFieldDefinition,
 } from "metabase-types/forms";
+import { isReactComponent } from "./react";
 
 export function isCustomWidget(
   formField: FormFieldDefinition,
 ): formField is CustomFormFieldDefinition {
   return (
     !(formField as StandardFormFieldDefinition).type &&
-    typeof (formField as CustomFormFieldDefinition).widget === "function"
+    isReactComponent((formField as CustomFormFieldDefinition).widget)
   );
 }

--- a/frontend/src/metabase-types/guards/react.ts
+++ b/frontend/src/metabase-types/guards/react.ts
@@ -8,3 +8,15 @@ export function isReactDOMTypeElement(
 ): element is React.ReactElement {
   return ReactIs.isElement(element) && typeof element.type === "string";
 }
+
+export function isReactComponent(
+  component: any,
+): component is React.FC | React.Component | React.ExoticComponent {
+  return (
+    typeof component === "function" ||
+    // Checking for "Exotic" components such as ones returned by memo, forwardRef
+    (typeof component === "object" &&
+      "$$typeof" in component &&
+      typeof component["$$typeof"] === "symbol")
+  );
+}


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/29318

### Description

The logic that checks if a form widget should be rendered as a custom component was not correct because it checked if a component is a function which works fine most of the time except when dealing with "exotic" components such as ones returned by `memo`, `lazy`, `forwardRef`, etc, which are objects. Updated here https://github.com/metabase/metabase/pull/27043 `connect` function from `react-redux` started returning a memorized component so that the connected form widget `FKTargetPicker` became an `object` which broke the form.

I also checked other places where we render custom widgets but the logic there is slightly different so it is not affected.

### How to verify

1. New -> Model -> Notebook -> Orders -> Save
2. Edit metadata -> Select `User Id`
3. Ensure you can select the foreign table field

### Demo

<img width="363" alt="Screenshot 2023-03-17 at 17 13 16" src="https://user-images.githubusercontent.com/8542534/225945469-923e37ba-a0f9-4e21-9c2d-786a126724f7.png">

### Checklist

- [x] Tests have been added/updated to cover changes in this PR

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/29334)
<!-- Reviewable:end -->
