### PR TITLE
Extract common object detail and table settings

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/ObjectDetail.jsx
@@ -1,13 +1,13 @@
 import { t } from "ttag";
-import _ from "underscore";
 
 import ObjectDetail from "metabase/visualizations/components/ObjectDetail";
-import ChartSettingOrderedColumns from "metabase/visualizations/components/settings/ChartSettingOrderedColumns";
 
-import { columnSettings } from "metabase/visualizations/lib/settings/column";
+import {
+  columnSettings,
+  tableColumnSettings,
+} from "metabase/visualizations/lib/settings/column";
 
 import { formatColumn } from "metabase/lib/formatting";
-import { findColumnIndexForColumnSetting } from "metabase-lib/queries/utils/dataset";
 
 const ObjectDetailProperties = {
   uiName: t`Detail`,
@@ -19,42 +19,8 @@ const ObjectDetailProperties = {
   disableClickBehavior: true,
   settings: {
     ...columnSettings({ hidden: true }),
-    "table.columns": {
-      section: t`Columns`,
-      title: t`Columns`,
-      widget: ChartSettingOrderedColumns,
-      getHidden: (_series, vizSettings) => vizSettings["table.pivot"],
-      isValid: ([{ card, data }]) =>
-        // If "table.columns" happened to be an empty array,
-        // it will be treated as "all columns are hidden",
-        // This check ensures it's not empty,
-        // otherwise it will be overwritten by `getDefault` below
-        card.visualization_settings["table.columns"].length !== 0 &&
-        _.all(
-          card.visualization_settings["table.columns"],
-          columnSetting =>
-            findColumnIndexForColumnSetting(data.cols, columnSetting) >= 0,
-        ),
-      getDefault: ([
-        {
-          data: { cols },
-        },
-      ]) =>
-        cols.map(col => ({
-          name: col.name,
-          fieldRef: col.field_ref,
-          enabled: col.visibility_type !== "details-only",
-        })),
-      getProps: ([
-        {
-          data: { cols },
-        },
-      ]) => ({
-        columns: cols,
-      }),
-    },
+    ...tableColumnSettings,
   },
-
   columnSettings: column => {
     const settings = {
       column_title: {

--- a/frontend/src/metabase/visualizations/visualizations/Table.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Table.jsx
@@ -10,14 +10,18 @@ import { getOptionFromColumn } from "metabase/visualizations/lib/settings/utils"
 import { getColumnCardinality } from "metabase/visualizations/lib/utils";
 import { formatColumn } from "metabase/lib/formatting";
 
-import ChartSettingOrderedColumns from "metabase/visualizations/components/settings/ChartSettingOrderedColumns";
 import ChartSettingLinkUrlInput from "metabase/visualizations/components/settings/ChartSettingLinkUrlInput";
 import ChartSettingsTableFormatting, {
   isFormattable,
 } from "metabase/visualizations/components/settings/ChartSettingsTableFormatting";
 
 import { makeCellBackgroundGetter } from "metabase/visualizations/lib/table_format";
-import { columnSettings } from "metabase/visualizations/lib/settings/column";
+import {
+  columnSettings,
+  tableColumnSettings,
+  getTitleForColumn,
+  isPivoted as _isPivoted,
+} from "metabase/visualizations/lib/settings/column";
 
 import {
   isMetric,
@@ -33,17 +37,6 @@ import * as Q_DEPRECATED from "metabase-lib/queries/utils";
 
 import TableSimple from "../components/TableSimple";
 import TableInteractive from "../components/TableInteractive/TableInteractive.jsx";
-
-const getTitleForColumn = (column, series, settings) => {
-  const isPivoted = Table.isPivoted(series, settings);
-  if (isPivoted) {
-    return formatColumn(column) || t`Unset`;
-  } else {
-    return (
-      settings.column(column)["_column_title_full"] || formatColumn(column)
-    );
-  }
-};
 
 export default class Table extends Component {
   static uiName = t`Table`;
@@ -69,28 +62,7 @@ export default class Table extends Component {
     // scalar can always be rendered, nothing needed here
   }
 
-  static isPivoted(series, settings) {
-    const [{ data }] = series;
-
-    if (!settings["table.pivot"]) {
-      return false;
-    }
-
-    const pivotIndex = _.findIndex(
-      data.cols,
-      col => col.name === settings["table.pivot_column"],
-    );
-    const cellIndex = _.findIndex(
-      data.cols,
-      col => col.name === settings["table.cell_column"],
-    );
-    const normalIndex = _.findIndex(
-      data.cols,
-      (col, index) => index !== pivotIndex && index !== cellIndex,
-    );
-
-    return pivotIndex >= 0 && cellIndex >= 0 && normalIndex >= 0;
-  }
+  static isPivoted = _isPivoted;
 
   static settings = {
     ...columnSettings({ hidden: true }),
@@ -171,56 +143,7 @@ export default class Table extends Component {
       readDependencies: ["table.pivot", "table.pivot_column"],
       persistDefault: true,
     },
-    // NOTE: table column settings may be identified by fieldRef (possible not normalized) or column name:
-    //   { name: "COLUMN_NAME", enabled: true }
-    //   { fieldRef: ["field", 2, {"source-field": 1}], enabled: true }
-    "table.columns": {
-      section: t`Columns`,
-      title: t`Columns`,
-      widget: ChartSettingOrderedColumns,
-      getHidden: (series, vizSettings) => vizSettings["table.pivot"],
-      isValid: ([{ card, data }]) =>
-        // If "table.columns" happened to be an empty array,
-        // it will be treated as "all columns are hidden",
-        // This check ensures it's not empty,
-        // otherwise it will be overwritten by `getDefault` below
-        card.visualization_settings["table.columns"].length !== 0 &&
-        _.all(
-          card.visualization_settings["table.columns"],
-          columnSetting =>
-            findColumnIndexForColumnSetting(data.cols, columnSetting) >= 0,
-        ),
-      getDefault: ([
-        {
-          data: { cols },
-        },
-      ]) =>
-        cols.map(col => ({
-          name: col.name,
-          fieldRef: col.field_ref,
-          enabled: col.visibility_type !== "details-only",
-        })),
-      getProps: (series, settings) => {
-        const [
-          {
-            data: { cols },
-          },
-        ] = series;
-
-        return {
-          columns: cols,
-          getColumnName: columnSetting => {
-            const columnIndex = findColumnIndexForColumnSetting(
-              cols,
-              columnSetting,
-            );
-            if (columnIndex >= 0) {
-              return getTitleForColumn(cols[columnIndex], series, settings);
-            }
-          },
-        };
-      },
-    },
+    ...tableColumnSettings,
     "table.column_widths": {},
     [DataGrid.COLUMN_FORMATTING_SETTING]: {
       section: t`Conditional Formatting`,

--- a/frontend/test/metabase/visualizations/visualizations/Table.unit.spec.js
+++ b/frontend/test/metabase/visualizations/visualizations/Table.unit.spec.js
@@ -12,7 +12,7 @@ import ChartSettings from "metabase/visualizations/components/ChartSettings";
 
 import Question from "metabase-lib/Question";
 
-const setup = () => {
+const setup = ({ vizType }) => {
   const Container = () => {
     const [question, setQuestion] = useState(
       new Question(
@@ -22,6 +22,7 @@ const setup = () => {
             query: {
               "source-table": ORDERS.id,
             },
+            display: vizType,
           },
           database: SAMPLE_DATABASE.id,
           visualization_settings: {},
@@ -59,34 +60,37 @@ const setup = () => {
   renderWithProviders(<Container />);
 };
 
-describe("table settings", () => {
-  it("should show you related columns in structured queries", async () => {
-    setup();
-    expect(await screen.findByText("More columns")).toBeInTheDocument();
-    expect(await screen.findByText("People")).toBeInTheDocument();
-    expect(await screen.findByText("Products")).toBeInTheDocument();
-  });
+// these visualizations share column settings, so all the tests should work for both
+["table", "object"].forEach(vizType => {
+  describe(`${vizType} column settings`, () => {
+    it("should show you related columns in structured queries", async () => {
+      setup({ vizType });
+      expect(await screen.findByText("More columns")).toBeInTheDocument();
+      expect(await screen.findByText("People")).toBeInTheDocument();
+      expect(await screen.findByText("Products")).toBeInTheDocument();
+    });
 
-  it("should allow you to show and hide columns", async () => {
-    setup();
-    userEvent.click(await screen.findByTestId("Tax-hide-button"));
+    it("should allow you to show and hide columns", async () => {
+      setup({ vizType });
+      userEvent.click(await screen.findByTestId("Tax-hide-button"));
 
-    expect(
-      await within(await screen.findByTestId("disabled-columns")).findByText(
-        "Tax",
-      ),
-    ).toBeInTheDocument();
+      expect(
+        await within(await screen.findByTestId("disabled-columns")).findByText(
+          "Tax",
+        ),
+      ).toBeInTheDocument();
 
-    userEvent.click(await screen.findByTestId("Tax-add-button"));
-    //If we can see the hide button, then we know it's been added back in.
-    expect(await screen.findByTestId("Tax-hide-button")).toBeInTheDocument();
-  });
+      userEvent.click(await screen.findByTestId("Tax-add-button"));
+      //If we can see the hide button, then we know it's been added back in.
+      expect(await screen.findByTestId("Tax-hide-button")).toBeInTheDocument();
+    });
 
-  it("should allow you to update a column name", async () => {
-    setup();
-    userEvent.click(await screen.findByTestId("Subtotal-settings-button"));
-    userEvent.type(await screen.findByDisplayValue("Subtotal"), " Updated");
-    userEvent.click(await screen.findByText("Tax"));
-    expect(await screen.findByText("Subtotal Updated")).toBeInTheDocument();
+    it("should allow you to update a column name", async () => {
+      setup({ vizType });
+      userEvent.click(await screen.findByTestId("Subtotal-settings-button"));
+      userEvent.type(await screen.findByDisplayValue("Subtotal"), " Updated");
+      userEvent.click(await screen.findByText("Tax"));
+      expect(await screen.findByText("Subtotal Updated")).toBeInTheDocument();
+    });
   });
 });


### PR DESCRIPTION
### Description

Changes made to table column settings in https://github.com/metabase/metabase/pull/28937 broke column settings for object detail viz. This is because object detail relies on table viz settings - and any changes to table viz can affect object detail viz. (though this was totally non-obvious).

The most straightforward fix was to simply copy the changes from that pr for table settings over to object detail settings.  However, that's just asking for this exact sort of bug to crop up again any time we change something in one or the other component.  

Instead, I extracted the entire `table.column_settings` and a few functions it uses into `visualizations/lib/settings` so both components can import the same settings, making it obvious that any change in the common settings affects both visualizations.

Before | After
-- | --
![detailsettingcrash](https://user-images.githubusercontent.com/30528226/226019164-c282d6df-f963-4684-b359-e02b19bfc8ef.gif) | ![detailsettingNocrash](https://user-images.githubusercontent.com/30528226/226019176-eb17f57a-537a-4fa3-8d16-1fe10666e522.gif)


### How to verify

- column reordering, hiding, and renaming should work identically and properly for table and object detail views

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
