### PR TITLE
Refactored ExpressionEditorTextfield to TS

### DIFF
--- a/frontend/src/metabase-lib/expressions/diagnostics.js
+++ b/frontend/src/metabase-lib/expressions/diagnostics.js
@@ -27,11 +27,17 @@ export function countMatchingParentheses(tokens) {
 }
 
 /**
+ * @typedef {Object} ErrorWithMessage
+ * @property {string} message
+ */
+
+/**
  * @private
  * @param {string} source
  * @param {string} startRule
  * @param {object} query
  * @param {string | null} name
+ * @returns {ErrorWithMessage | null}
  */
 export function diagnose(source, startRule, query, name = null) {
   if (!source || source.length === 0) {

--- a/frontend/src/metabase-lib/expressions/diagnostics.js
+++ b/frontend/src/metabase-lib/expressions/diagnostics.js
@@ -30,7 +30,7 @@ export function countMatchingParentheses(tokens) {
  * @private
  * @param {string} source
  * @param {string} startRule
- * @param {string} query
+ * @param {object} query
  * @param {string | null} name
  */
 export function diagnose(source, startRule, query, name = null) {

--- a/frontend/src/metabase-lib/expressions/types.ts
+++ b/frontend/src/metabase-lib/expressions/types.ts
@@ -12,7 +12,10 @@ export interface HelpText {
 export interface HelpTextConfig {
   name: string;
   args?: HelpTextArg[]; // no args means that expression function doesn't accept any parameters, e.g. "CumulativeCount"
-  description: (database: Database, reportTimezone: string) => string;
+  description: (
+    database: Pick<Database, "features" | "engine">,
+    reportTimezone?: string,
+  ) => string;
   structure: string;
   docsPage?: string;
 }
@@ -22,3 +25,11 @@ export interface HelpTextArg {
   description: string;
   example: string;
 }
+
+export type MBQLClauseFunctionConfig = {
+  displayName: string;
+  type: string;
+  args: string[];
+  requiresFeature?: string;
+};
+export type MBQLClauseMap = Record<string, MBQLClauseFunctionConfig>;

--- a/frontend/src/metabase-lib/expressions/types.ts
+++ b/frontend/src/metabase-lib/expressions/types.ts
@@ -1,4 +1,4 @@
-import type { Database } from "metabase-types/api/database";
+import type Database from "metabase-lib/metadata/Database";
 
 export interface HelpText {
   name: string;
@@ -12,10 +12,7 @@ export interface HelpText {
 export interface HelpTextConfig {
   name: string;
   args?: HelpTextArg[]; // no args means that expression function doesn't accept any parameters, e.g. "CumulativeCount"
-  description: (
-    database: Pick<Database, "features" | "engine">,
-    reportTimezone?: string,
-  ) => string;
+  description: (database: Database, reportTimezone?: string) => string;
   structure: string;
   docsPage?: string;
 }

--- a/frontend/src/metabase-lib/metadata/Metric.ts
+++ b/frontend/src/metabase-lib/metadata/Metric.ts
@@ -11,6 +11,8 @@ import Base from "./Base";
  */
 
 export default class Metric extends Base {
+  name: string;
+
   displayName() {
     return this.name;
   }

--- a/frontend/src/metabase-lib/metadata/Segment.ts
+++ b/frontend/src/metabase-lib/metadata/Segment.ts
@@ -10,6 +10,8 @@ import Base from "./Base";
  */
 
 export default class Segment extends Base {
+  name: string;
+
   displayName() {
     return this.name;
   }

--- a/frontend/src/metabase-lib/metadata/Table.ts
+++ b/frontend/src/metabase-lib/metadata/Table.ts
@@ -13,6 +13,8 @@ import type Metadata from "./Metadata";
 import type Schema from "./Schema";
 import type Field from "./Field";
 import type Database from "./Database";
+import type Metric from "./Metric";
+import type Segment from "./Segment";
 
 /**
  * @typedef { import("./Metadata").SchemaName } SchemaName
@@ -32,6 +34,8 @@ class TableInner extends Base {
   schema_name: string;
   db_id: number;
   fields: Field[];
+  metrics: Metric[];
+  segments: Segment[];
   metadata?: Metadata;
   db?: Database | undefined | null;
 

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorHelpText.stories.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorHelpText.stories.tsx
@@ -2,6 +2,7 @@ import React, { useRef } from "react";
 import type { ComponentStory } from "@storybook/react";
 
 import { createMockDatabase } from "metabase-types/api/mocks";
+import Database from "metabase-lib/metadata/Database";
 
 import { getHelpText } from "./ExpressionEditorTextfield/helper-text-strings";
 import ExpressionEditorHelpText, {
@@ -17,7 +18,11 @@ const Template: ComponentStory<typeof ExpressionEditorHelpText> = args => {
   const target = useRef(null);
 
   const props: ExpressionEditorHelpTextProps = {
-    helpText: getHelpText("datetime-diff", createMockDatabase(), "UTC"),
+    helpText: getHelpText(
+      "datetime-diff",
+      new Database(createMockDatabase()),
+      "UTC",
+    ),
     width: 397,
     target,
   };

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorHelpText.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorHelpText.unit.spec.tsx
@@ -3,12 +3,13 @@ import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { getBrokenUpTextMatcher } from "__support__/ui";
 import { createMockDatabase } from "metabase-types/api/mocks";
+import Database from "metabase-lib/metadata/Database";
 import { getHelpText } from "./ExpressionEditorTextfield/helper-text-strings";
 import ExpressionEditorHelpText, {
   ExpressionEditorHelpTextProps,
 } from "./ExpressionEditorHelpText";
 
-const DATABASE = createMockDatabase();
+const DATABASE = new Database(createMockDatabase());
 
 describe("ExpressionEditorHelpText", () => {
   it("should render expression function info and example", async () => {

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield/ExpressionEditorTextfield.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield/ExpressionEditorTextfield.styled.tsx
@@ -5,7 +5,10 @@ import { space } from "metabase/styled-components/theme";
 import { color } from "metabase/lib/colors";
 import { inputPadding } from "metabase/core/style/input";
 
-export const EditorContainer = styled.div`
+export const EditorContainer = styled.div<{
+  isFocused: boolean;
+  hasError: boolean;
+}>`
   border: 1px solid;
   border-color: ${color("border")};
   border-radius: ${space(1)};
@@ -86,4 +89,10 @@ export const EditorEqualsSign = styled.div`
   height: 12px;
   font-weight: 700;
   margin: 0 3px 0 ${space(0)};
+`;
+
+export const ErrorMessageContainer = styled.div`
+  color: ${color("error")};
+  margin: 0.5rem 0;
+  white-space: pre-wrap;
 `;

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield/ExpressionEditorTextfield.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield/ExpressionEditorTextfield.tsx
@@ -1,9 +1,8 @@
 import React, { RefObject } from "react";
 import { t } from "ttag";
 import _ from "underscore";
-import AceEditor from "react-ace";
+import AceEditor, { ICommand, IMarker } from "react-ace";
 import * as ace from "ace-builds/src-noconflict/ace";
-import { ICommand, IMarker } from "react-ace/src/types";
 import { Ace } from "ace-builds";
 import ExplicitSize from "metabase/components/ExplicitSize";
 import type { Expression } from "metabase-types/types/Query";
@@ -26,11 +25,6 @@ import {
 } from "./ExpressionEditorTextfield.styled";
 
 ace.config.set("basePath", "/assets/ui/");
-
-interface CommandManager extends Ace.CommandManager {
-  // "commandKeyBinding" is not typed, but used in the code, and it works. So, adding an explicit typing here
-  commandKeyBinding: Ace.CommandMap;
-}
 
 type ErrorWithMessage = { message: string; pos?: number; len?: number };
 
@@ -274,7 +268,7 @@ class ExpressionEditorTextfield extends React.Component<
 
     this.clearSuggestions();
 
-    const errorMessage = this.diagnoseExpression() as ErrorWithMessage | null;
+    const errorMessage = this.diagnoseExpression();
     this.setState({ errorMessage });
 
     // whenever our input blurs we push the updated expression to our parent if valid
@@ -308,8 +302,7 @@ class ExpressionEditorTextfield extends React.Component<
     if (this.input.current) {
       const { editor } = this.input.current;
       const { suggestions } = this.state;
-      const tabBinding = (editor.commands as CommandManager).commandKeyBinding
-        .tab;
+      const tabBinding = editor.commands.commandKeyBinding.tab;
       if (suggestions.length > 0) {
         // Something to suggest? Tab is for choosing one of them
         editor.commands.bindKey("Tab", editor.commands.byName.chooseSuggestion);
@@ -317,8 +310,7 @@ class ExpressionEditorTextfield extends React.Component<
         if (Array.isArray(tabBinding) && tabBinding.length > 1) {
           // No more suggestions? Keep a single binding and remove the
           // second one (added to choose a suggestion)
-          (editor.commands as CommandManager).commandKeyBinding.tab =
-            tabBinding.shift();
+          editor.commands.commandKeyBinding.tab = tabBinding.shift();
         }
       }
     }
@@ -335,7 +327,7 @@ class ExpressionEditorTextfield extends React.Component<
     return expression;
   }
 
-  diagnoseExpression() {
+  diagnoseExpression(): ErrorWithMessage | null {
     const { source } = this.state;
     const {
       query,

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield/ExpressionEditorTextfield.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield/ExpressionEditorTextfield.tsx
@@ -1,123 +1,173 @@
-/* eslint-disable react/prop-types */
-import React from "react";
-import PropTypes from "prop-types";
-
+import React, { RefObject } from "react";
 import { t } from "ttag";
 import _ from "underscore";
 import AceEditor from "react-ace";
-
 import * as ace from "ace-builds/src-noconflict/ace";
+import { ICommand, IMarker } from "react-ace/src/types";
+import { Ace } from "ace-builds";
 import ExplicitSize from "metabase/components/ExplicitSize";
+import type { Expression } from "metabase-types/types/Query";
 import { format } from "metabase-lib/expressions/format";
 import { processSource } from "metabase-lib/expressions/process";
 import { diagnose } from "metabase-lib/expressions/diagnostics";
 import { tokenize } from "metabase-lib/expressions/tokenizer";
-
 import { isExpression } from "metabase-lib/expressions";
-import HelpText from "../ExpressionEditorHelpText";
+import type { HelpText } from "metabase-lib/expressions/types";
+import StructuredQuery from "metabase-lib/queries/StructuredQuery";
+
+import ExpressionEditorHelpText from "../ExpressionEditorHelpText";
 import ExpressionEditorSuggestions from "../ExpressionEditorSuggestions";
 import ExpressionMode from "../ExpressionMode";
-import { suggest } from "./suggest";
-
+import { suggest, Suggestion } from "./suggest";
 import {
   EditorContainer,
   EditorEqualsSign,
+  ErrorMessageContainer,
 } from "./ExpressionEditorTextfield.styled";
 
 ace.config.set("basePath", "/assets/ui/");
 
-const ErrorMessage = ({ error }) => {
-  return (
-    <>
-      {error && (
-        <div className="text-error mt1 mb1" style={{ whiteSpace: "pre-wrap" }}>
-          {error.message}
-        </div>
-      )}
-    </>
-  );
+interface CommandManager extends Ace.CommandManager {
+  // "commandKeyBinding" is not typed, but used in the code, and it works. So, adding an explicit typing here
+  commandKeyBinding: Ace.CommandMap;
+}
+
+type ErrorWithMessage = { message: string; pos?: number; len?: number };
+
+const ACE_OPTIONS = {
+  behavioursEnabled: false,
+  indentedSoftWrap: false,
+  minLines: 1,
+  maxLines: 9,
+  showLineNumbers: false,
+  showGutter: false,
+  showFoldWidgets: false,
+  showPrintMargin: false,
 };
 
-class ExpressionEditorTextfield extends React.Component {
-  constructor() {
-    super();
-    this.input = React.createRef();
-    this.suggestionTarget = React.createRef();
-  }
+interface ExpressionEditorTextfieldProps {
+  expression: Expression | undefined;
+  name: string;
+  query: StructuredQuery;
+  startRule?: string;
+  width?: number;
+  reportTimezone?: string;
 
-  static propTypes = {
-    expression: PropTypes.oneOfType([
-      PropTypes.number,
-      PropTypes.number,
-      PropTypes.array,
-    ]),
-    name: PropTypes.string,
-    onChange: PropTypes.func.isRequired,
-    onError: PropTypes.func.isRequired,
-    startRule: PropTypes.string.isRequired,
-    onBlankChange: PropTypes.func,
-    helpTextTarget: PropTypes.instanceOf(Element),
+  onChange: (expression: Expression | null) => void;
+  onError: (error: ErrorWithMessage | null) => void;
+  onBlankChange: (isBlank: boolean) => void;
+  onCommit: (expression: Expression | null) => void;
+  helpTextTarget: RefObject<HTMLElement>;
+}
+
+interface ExpressionEditorTextfieldState {
+  source: string;
+  expression: Expression;
+  suggestions: Suggestion[];
+  highlightedSuggestionIndex: number;
+  isFocused: boolean;
+  errorMessage: ErrorWithMessage | null;
+  helpText: HelpText | null;
+  hasChanges: boolean;
+}
+
+function transformPropsToState(
+  props: ExpressionEditorTextfieldProps,
+): ExpressionEditorTextfieldState {
+  const {
+    expression = ExpressionEditorTextfield.defaultProps.expression,
+    query,
+    startRule = ExpressionEditorTextfield.defaultProps.startRule,
+  } = props;
+  const source = format(expression, { query, startRule });
+
+  return {
+    source,
+    expression,
+    highlightedSuggestionIndex: 0,
+    helpText: null,
+    suggestions: [],
+    isFocused: false,
+    errorMessage: null,
+    hasChanges: false,
   };
+}
+
+class ExpressionEditorTextfield extends React.Component<
+  ExpressionEditorTextfieldProps,
+  ExpressionEditorTextfieldState
+> {
+  input = React.createRef<AceEditor>();
+  suggestionTarget = React.createRef<HTMLDivElement>();
 
   static defaultProps = {
-    expression: [null, ""],
+    expression: "",
     startRule: "expression",
-    placeholder: "write some math!",
   };
 
-  state = null;
+  state: ExpressionEditorTextfieldState;
+
+  constructor(props: ExpressionEditorTextfieldProps) {
+    super(props);
+
+    this.state = transformPropsToState(props);
+  }
 
   UNSAFE_componentWillMount() {
     this.UNSAFE_componentWillReceiveProps(this.props);
   }
 
-  UNSAFE_componentWillReceiveProps(newProps) {
+  UNSAFE_componentWillReceiveProps(
+    newProps: Readonly<ExpressionEditorTextfieldProps>,
+  ) {
     // we only refresh our state if we had no previous state OR if our expression changed
     const { expression, query, startRule } = newProps;
     if (!this.state || !_.isEqual(this.props.expression, expression)) {
       const source = format(expression, { query, startRule });
-      const currentSource = this.state?.source;
-      this.setState({ source, expression });
-      this.clearSuggestions();
+      const currentSource = this.state.source;
+      this.setState(transformPropsToState(newProps));
 
       // Reset caret position due to reformatting
       if (currentSource !== source && this.input.current) {
         const { editor } = this.input.current;
-        setTimeout(() => editor.gotoLine(1, source.length), 0);
+        setTimeout(() => editor.gotoLine(1, source.length, false), 0);
       }
     }
   }
 
   componentDidMount() {
-    const { editor } = this.input.current;
-    editor.getSession().setMode(new ExpressionMode());
+    if (this.input.current) {
+      const { editor } = this.input.current;
+      // "ExpressionMode" constructor is not typed, so cast it here explicitly
+      const mode = new ExpressionMode() as unknown as Ace.SyntaxMode;
 
-    editor.setOptions({
-      fontFamily: "Monaco, monospace",
-      fontSize: "12px",
-    });
+      editor.getSession().setMode(mode);
 
-    const passKeysToBrowser = editor.commands.byName.passKeysToBrowser;
-    editor.commands.bindKey("Tab", passKeysToBrowser);
-    editor.commands.bindKey("Shift-Tab", passKeysToBrowser);
-    editor.commands.removeCommand(editor.commands.byName.indent);
-    editor.commands.removeCommand(editor.commands.byName.outdent);
+      editor.setOptions({
+        fontFamily: "Monaco, monospace",
+        fontSize: "12px",
+      });
 
-    this.setCaretPosition(
-      this.state.source.length,
-      this.state.source.length === 0,
-    );
+      const passKeysToBrowser = editor.commands.byName.passKeysToBrowser;
+      editor.commands.bindKey("Tab", passKeysToBrowser);
+      editor.commands.bindKey("Shift-Tab", passKeysToBrowser);
+      editor.commands.removeCommand(editor.commands.byName.indent);
+      editor.commands.removeCommand(editor.commands.byName.outdent);
 
-    this.triggerAutosuggest();
+      if (this.state.source.length === 0) {
+        setTimeout(() => this.triggerAutosuggest());
+      }
+
+      this.triggerAutosuggest();
+    }
   }
 
-  onSuggestionSelected = index => {
+  onSuggestionSelected = (index: number) => {
     const { source, suggestions } = this.state;
     const suggestion = suggestions && suggestions[index];
 
-    const { editor } = this.input.current;
-
-    if (suggestion) {
+    if (this.input.current && suggestion) {
+      const { editor } = this.input.current;
       const { tokens } = tokenize(source);
       const token = tokens.find(t => t.end >= suggestion.index);
 
@@ -161,7 +211,7 @@ class ExpressionEditorTextfield extends React.Component {
           suggestions.length,
       });
     } else {
-      this.input.current.editor.navigateLineEnd();
+      this.input.current?.editor.navigateLineEnd();
     }
   };
 
@@ -175,7 +225,7 @@ class ExpressionEditorTextfield extends React.Component {
           suggestions.length,
       });
     } else {
-      this.input.current.editor.navigateLineEnd();
+      this.input.current?.editor.navigateLineEnd();
     }
   };
 
@@ -211,7 +261,7 @@ class ExpressionEditorTextfield extends React.Component {
     }
   };
 
-  handleInputBlur = e => {
+  handleInputBlur = (e: React.FocusEvent) => {
     this.setState({ isFocused: false });
 
     // Switching to another window also triggers the blur event.
@@ -224,7 +274,7 @@ class ExpressionEditorTextfield extends React.Component {
 
     this.clearSuggestions();
 
-    const errorMessage = this.diagnoseExpression();
+    const errorMessage = this.diagnoseExpression() as ErrorWithMessage | null;
     this.setState({ errorMessage });
 
     // whenever our input blurs we push the updated expression to our parent if valid
@@ -251,14 +301,15 @@ class ExpressionEditorTextfield extends React.Component {
     this.updateSuggestions([]);
   }
 
-  updateSuggestions(suggestions = []) {
+  updateSuggestions(suggestions: Suggestion[] | undefined = []) {
     this.setState({ suggestions });
 
     // Correctly bind Tab depending on whether suggestions are available or not
     if (this.input.current) {
       const { editor } = this.input.current;
       const { suggestions } = this.state;
-      const tabBinding = editor.commands.commandKeyBinding.tab;
+      const tabBinding = (editor.commands as CommandManager).commandKeyBinding
+        .tab;
       if (suggestions.length > 0) {
         // Something to suggest? Tab is for choosing one of them
         editor.commands.bindKey("Tab", editor.commands.byName.chooseSuggestion);
@@ -266,7 +317,8 @@ class ExpressionEditorTextfield extends React.Component {
         if (Array.isArray(tabBinding) && tabBinding.length > 1) {
           // No more suggestions? Keep a single binding and remove the
           // second one (added to choose a suggestion)
-          editor.commands.commandKeyBinding.tab = tabBinding.shift();
+          (editor.commands as CommandManager).commandKeyBinding.tab =
+            tabBinding.shift();
         }
       }
     }
@@ -285,7 +337,11 @@ class ExpressionEditorTextfield extends React.Component {
 
   diagnoseExpression() {
     const { source } = this.state;
-    const { query, startRule, name } = this.props;
+    const {
+      query,
+      startRule = ExpressionEditorTextfield.defaultProps.startRule,
+      name,
+    } = this.props;
     if (!source || source.length === 0) {
       return { message: t`Empty expression` };
     }
@@ -293,9 +349,16 @@ class ExpressionEditorTextfield extends React.Component {
   }
 
   commitExpression() {
-    const { query, startRule } = this.props;
+    const {
+      query,
+      startRule = ExpressionEditorTextfield.defaultProps.startRule,
+    } = this.props;
     const { source } = this.state;
-    const errorMessage = diagnose(source, startRule, query);
+    const errorMessage = diagnose(
+      source,
+      startRule,
+      query,
+    ) as ErrorWithMessage | null;
     this.setState({ errorMessage });
 
     if (errorMessage) {
@@ -313,15 +376,8 @@ class ExpressionEditorTextfield extends React.Component {
     this.handleExpressionChange(this.state.source);
   };
 
-  setCaretPosition = (position, autosuggest) => {
-    // FIXME setCaretPosition(this.input.current, position);
-    if (autosuggest) {
-      setTimeout(() => this.triggerAutosuggest());
-    }
-  };
-
-  handleExpressionChange = source => {
-    if (source !== this.state.source) {
+  handleExpressionChange(source: string) {
+    if (source) {
       this.setState({ hasChanges: true });
     }
 
@@ -329,12 +385,16 @@ class ExpressionEditorTextfield extends React.Component {
     if (this.props.onBlankChange) {
       this.props.onBlankChange(source.length === 0);
     }
-  };
+  }
 
-  handleCursorChange = selection => {
+  handleCursorChange(selection: Ace.Selection) {
     const cursor = selection.getCursor();
 
-    const { query, reportTimezone, startRule } = this.props;
+    const {
+      query,
+      reportTimezone,
+      startRule = ExpressionEditorTextfield.defaultProps.startRule,
+    } = this.props;
     const { source } = this.state;
     const { suggestions, helpText } = suggest({
       query,
@@ -344,15 +404,15 @@ class ExpressionEditorTextfield extends React.Component {
       targetOffset: cursor.column,
     });
 
-    this.setState({ helpText });
+    this.setState({ helpText: helpText || null });
     this.updateSuggestions(suggestions);
-  };
+  }
 
-  errorAsMarkers(errorMessage = null) {
+  errorAsMarkers(errorMessage: ErrorWithMessage | null = null): IMarker[] {
     if (errorMessage) {
       const { pos, len } = errorMessage;
       // Because not every error message offers location info (yet)
-      if (typeof pos === "number") {
+      if (typeof pos === "number" && typeof len === "number") {
         return [
           {
             startRow: 0,
@@ -368,7 +428,7 @@ class ExpressionEditorTextfield extends React.Component {
     return [];
   }
 
-  commands = [
+  commands: ICommand[] = [
     {
       name: "arrowDown",
       bindKey: { win: "Down", mac: "Down" },
@@ -392,6 +452,8 @@ class ExpressionEditorTextfield extends React.Component {
     },
     {
       name: "chooseSuggestion",
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore // Based on typings null is not a valid value, but bindKey is assigned dynamically if there are suggestions available.
       bindKey: null,
       exec: () => {
         this.chooseSuggestion();
@@ -407,7 +469,7 @@ class ExpressionEditorTextfield extends React.Component {
   ];
 
   render() {
-    const { source, suggestions, errorMessage, isFocused, hasChanges } =
+    const { source, suggestions, errorMessage, hasChanges, isFocused } =
       this.state;
 
     return (
@@ -430,19 +492,9 @@ class ExpressionEditorTextfield extends React.Component {
             fontSize={12}
             onBlur={this.handleInputBlur}
             onFocus={this.handleFocus}
-            role="ace-editor"
-            setOptions={{
-              behavioursEnabled: false,
-              indentedSoftWrap: false,
-              minLines: 1,
-              maxLines: 9,
-              showLineNumbers: false,
-              showGutter: false,
-              showFoldWidgets: false,
-              showPrintMargin: false,
-            }}
-            onChange={this.handleExpressionChange}
-            onCursorChange={this.handleCursorChange}
+            setOptions={ACE_OPTIONS}
+            onChange={source => this.handleExpressionChange(source)}
+            onCursorChange={selection => this.handleCursorChange(selection)}
             width="100%"
           />
           <ExpressionEditorSuggestions
@@ -452,8 +504,10 @@ class ExpressionEditorTextfield extends React.Component {
             highlightedIndex={this.state.highlightedSuggestionIndex}
           />
         </EditorContainer>
-        {hasChanges && <ErrorMessage error={errorMessage} />}
-        <HelpText
+        {errorMessage && hasChanges && (
+          <ErrorMessageContainer>{errorMessage.message}</ErrorMessageContainer>
+        )}
+        <ExpressionEditorHelpText
           target={this.props.helpTextTarget}
           helpText={this.state.helpText}
           width={this.props.width}

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield/helper-text-strings.ts
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield/helper-text-strings.ts
@@ -1,17 +1,21 @@
 import { t } from "ttag";
 import moment from "moment-timezone";
 
-import type { Database } from "metabase-types/api/database";
+import type { Database } from "metabase-types/api";
 import { HelpText, HelpTextConfig } from "metabase-lib/expressions/types";
 import {
   formatIdentifier,
   formatStringLiteral,
 } from "metabase-lib/expressions";
 
-const getDescriptionForNow = (database: Database, reportTimezone: string) => {
+const getDescriptionForNow: HelpTextConfig["description"] = (
+  database,
+  reportTimezone,
+) => {
   const hasTimezoneFeatureFlag = database.features.includes("set-timezone");
-  const timezone = hasTimezoneFeatureFlag ? reportTimezone : "UTC";
-  const nowAtTimezone = getNowAtTimezone(timezone, reportTimezone);
+  const timezone =
+    hasTimezoneFeatureFlag && reportTimezone ? reportTimezone : "UTC";
+  const nowAtTimezone = getNowAtTimezone(timezone);
 
   // H2 is the only DBMS we support where:
   // · set-timezone isn't a feature, and
@@ -25,10 +29,10 @@ const getDescriptionForNow = (database: Database, reportTimezone: string) => {
   }
 };
 
-const getNowAtTimezone = (timezone: string, reportTimezone: string) =>
-  timezone ? moment().tz(reportTimezone).format("LT") : moment().format("LT");
+const getNowAtTimezone = (timezone: string) =>
+  timezone ? moment().tz(timezone).format("LT") : moment().format("LT");
 
-const helperTextStrings: HelpTextConfig[] = [
+const HELPER_TEXT_STRINGS: HelpTextConfig[] = [
   {
     name: "count",
     structure: "Count",
@@ -969,10 +973,10 @@ See the full list here: https://w.wiki/4Jx`,
 
 export const getHelpText = (
   name: string,
-  database: Database,
-  reportTimezone: string,
+  database: Pick<Database, "features" | "engine">,
+  reportTimezone?: string,
 ): HelpText | undefined => {
-  const helperTextConfig = helperTextStrings.find(h => h.name === name);
+  const helperTextConfig = HELPER_TEXT_STRINGS.find(h => h.name === name);
 
   if (!helperTextConfig) {
     return;

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield/helper-text-strings.ts
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield/helper-text-strings.ts
@@ -1,8 +1,7 @@
 import { t } from "ttag";
 import moment from "moment-timezone";
-
-import type { Database } from "metabase-types/api";
 import { HelpText, HelpTextConfig } from "metabase-lib/expressions/types";
+import type Database from "metabase-lib/metadata/Database";
 import {
   formatIdentifier,
   formatStringLiteral,
@@ -973,7 +972,7 @@ See the full list here: https://w.wiki/4Jx`,
 
 export const getHelpText = (
   name: string,
-  database: Pick<Database, "features" | "engine">,
+  database: Database,
   reportTimezone?: string,
 ): HelpText | undefined => {
   const helperTextConfig = HELPER_TEXT_STRINGS.find(h => h.name === name);

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield/helper-text-strings.unit.spec.ts
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield/helper-text-strings.unit.spec.ts
@@ -1,11 +1,13 @@
 import { createMockDatabase } from "metabase-types/api/mocks/database";
+import { Database as DatabaseApi } from "metabase-types/api";
+import Database from "metabase-lib/metadata/Database";
 import { getHelpText } from "./helper-text-strings";
 
 describe("getHelpText", () => {
-  const database = createMockDatabase();
   const reportTimezone = "US/Hawaii";
 
   it("should be undefined if an unsupported function name is passed", () => {
+    const { database } = setup();
     const helpText = getHelpText(
       "this function name should not ever exist",
       database,
@@ -17,6 +19,7 @@ describe("getHelpText", () => {
 
   describe("should return help text if a supported name is passed", () => {
     it("count", () => {
+      const { database } = setup();
       const helpText = getHelpText("count", database, reportTimezone);
 
       expect(helpText?.structure).toBe("Count");
@@ -26,6 +29,7 @@ describe("getHelpText", () => {
     });
 
     it("percentile", () => {
+      const { database } = setup();
       const helpText = getHelpText("percentile", database, reportTimezone);
 
       expect(helpText?.structure).toBe("Percentile");
@@ -39,32 +43,37 @@ describe("getHelpText", () => {
 
   describe("help texts customized per database engine", () => {
     it("should include timestamps in description for default database engines", () => {
+      const { database } = setup();
       const helpText = getHelpText("now", database, reportTimezone);
 
-      expect(helpText?.description).toMatch(/currently/i);
+      expect(helpText?.description).toMatch("currently");
     });
 
     it("should not include timestamps in description for h2 database engines", () => {
-      const h2Database = { ...database, engine: "h2" };
-      const helpText = getHelpText("now", h2Database, reportTimezone);
+      const { database } = setup({ engine: "h2" });
+      const helpText = getHelpText("now", database, reportTimezone);
 
-      expect(helpText?.description).not.toMatch(/currently/i);
+      expect(helpText?.description).not.toMatch("currently");
     });
 
     it("should use custom reportTimezone in description for supporting database engines", () => {
-      const helpText = getHelpText(
-        "now",
-        { ...database, features: ["set-timezone"] },
-        reportTimezone,
-      );
+      const { database } = setup({ features: ["set-timezone"] });
+      const helpText = getHelpText("now", database, reportTimezone);
 
-      expect(helpText?.description).toMatch(new RegExp(reportTimezone));
+      expect(helpText?.description).toMatch(reportTimezone);
     });
 
     it("should default to UTC in description for database engines not supporting set-timezone", () => {
+      const { database } = setup();
       const helpText = getHelpText("now", database, reportTimezone);
 
-      expect(helpText?.description).toMatch(/UTC/);
+      expect(helpText?.description).toMatch("UTC");
     });
   });
 });
+
+function setup(dbOpts?: Partial<DatabaseApi>) {
+  const database = new Database(createMockDatabase(dbOpts));
+
+  return { database };
+}

--- a/frontend/src/types/ace-builds.d.ts
+++ b/frontend/src/types/ace-builds.d.ts
@@ -1,0 +1,10 @@
+import "ace-builds";
+
+declare module "ace-builds" {
+  namespace Ace {
+    interface CommandManager {
+      // "commandKeyBinding" is not typed, but used in the code, and it works. So, adding an explicit typing here
+      commandKeyBinding: Ace.CommandMap;
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@visx/shape": "2.12.2",
     "@visx/text": "1.7.0",
     "@visx/tooltip": "^2.10.0",
-    "ace-builds": "^1.4.7",
+    "ace-builds": "^1.4.13",
     "classlist-polyfill": "^1.2.0",
     "classnames": "^2.1.3",
     "color": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7012,11 +7012,6 @@ ace-builds@^1.4.13:
   resolved "https://registry.yarnpkg.com/ace-builds/-/ace-builds-1.4.13.tgz#186f42d3849ebcc6a48b93088a058489897514c1"
   integrity sha512-SOLzdaQkY6ecPKYRDDg+MY1WoGgXA34cIvYJNNoBMGGUswHmlauU2Hy0UL96vW0Fs/LgFbMUjD+6vqzWTldIYQ==
 
-ace-builds@^1.4.7:
-  version "1.4.12"
-  resolved "https://registry.yarnpkg.com/ace-builds/-/ace-builds-1.4.12.tgz#888efa386e36f4345f40b5233fcc4fe4c588fae7"
-  integrity sha512-G+chJctFPiiLGvs3+/Mly3apXTcfgE45dT5yp12BcWZ1kUs+gm0qd3/fv4gsz6fVag4mM0moHVpjHDIgph6Psg==
-
 acorn-globals@^7.0.0:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/acorn-globals/-/acorn-globals-7.0.1.tgz#0dbf05c44fa7c94332914c02066d5beff62c40c3"


### PR DESCRIPTION
Relates to https://github.com/metabase/metabase/issues/29029

### Description

Idea is to migrate ExpressionEditorTextfield component to TS to make it easier to maintain.

Also:
migrated `frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield/suggest.ts`

### How to verify

Describe the steps to verify that the changes are working as expected.

1. New question -> Sample Dataset -> Reviews
2. Try adding a custom expression through a Custom column, a Filter with custom expression or an Aggregation with custom expression.

Suggestions logic and autocomplete behavior should be the same as before.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/29337)
<!-- Reviewable:end -->
