### PR TITLE
Handle licenses from git-deps for our use of next.jdbc

### DIFF
--- a/bin/build/resources/overrides.edn
+++ b/bin/build/resources/overrides.edn
@@ -1,66 +1,30 @@
 {:override/group
  {"com.fasterxml.jackson.dataformat" {:resource "apache2_0.txt"}
-  "com.google.auth"                  {:resource "apache2_0.txt"}
-  "com.google.cloud"                 {:resource "apache2_0.txt"}
-  "com.google.cloud.sql"             {:resource "apache2_0.txt"}
-  "com.google.code.gson"             {:resource "apache2_0.txt"}
   "com.google.guava"                 {:resource "apache2_0.txt"}
-  "com.google.http-client"           {:resource "apache2_0.txt"}
-  "com.google.protobuf"              {:resource "apache2_0.txt"}
   "com.onelogin"                     {:resource "MIT.txt"}
   "com.vladsch.flexmark"             {:resource "BSD.txt"}
-  "io.netty"                         {:resource "apache2_0.txt"}
-  "org.apache.hadoop"                {:resource "apache2_0.txt"}
   "org.clojure"                      {:resource "EPL.txt"}
-  "org.eclipse.jetty"                {:resource "apache2_0.txt"}
-  "org.opensaml"                     {:resource "apache2_0.txt"}
-  "org.ow2.asm"                      {:resource "BSD.txt"}
-  "xalan"                            {:resource "apache2_0.txt"}}
+  "org.opensaml"                     {:resource "apache2_0.txt"}}
 
  "amalloy"                     {"ring-gzip-middleware" {:resource "MIT.txt"}}
  "buddy"                       {"buddy-core" {:resource "apache2_0.txt"}}
  "colorize"                    {"colorize" {:resource "EPL.txt"}}
- "com.github.jnr"              {"jffi$native" {:resource "apache2_0.txt"}}
- "com.google.api-client"       {"google-api-client" {:resource "apache2_0.txt"}}
- "com.google.auto.value"       {"auto-value-annotations" {:resource "apache2_0.txt"}}
- "com.google.http-client"      {"google-http-client"          {:resource "apache2_0.txt"}
-                                "google-http-client-jackson2" {:resource "apache2_0.txt"}}
- "com.google.oauth-client"     {"google-oauth-client" {:resource "apache2_0.txt"}}
- "com.jolbox"                  {"bonecp" {:resource "apache2_0.txt"}}
  "com.sun.activation"          {"jakarta.activation" {:resource "EDL.txt"}}
- "com.sun.istack"              {"istack-commons-runtime" {:resource "EDL.txt"}}
- "com.sun.jersey"              {"jersey-server"  {:resource "apache2_0.txt"}
-                                "jersey-core"    {:resource "GPL1_1.txt"}
-                                "jersey-json"    {:resource "GPL1_1.txt"}
-                                "jersey-client"  {:resource "apache2_0.txt"}
-                                "jersey-servlet" {:resource "GPL1_1.txt"}}
- "com.sun.jersey.contribs"     {"jersey-guice" {:resource "GPL1_1.txt"}}
- "com.thoughtworks.paranamer"  {"paranamer" {:resource "BSD.txt"}}
- "de.rototor.pdfbox"           {"graphics2d" {:resource "apache2_0.txt"}}
  "hiccup"                      {"hiccup" {:resource "EPL.txt"}}
  "io.dropwizard.metrics"       {"metrics-core" {:resource "apache2_0.txt"}}
- "jakarta.activation"          {"jakarta.activation-api" {:resource "EDL.txt"}}
  "jakarta.xml.bind"            {"jakarta.xml.bind-api" {:resource "EDL.txt"}}
+ ;; --- three new additions
  "javax.servlet"               {"servlet-api" {:resource "CDDL_1.txt"}}
  "javax.servlet.jsp"           {"jsp-api" {:resource "GPL2_0.txt"}}
  "metabase"                    {"saml20-clj" {:resource "EPL_2.txt"}}
+ ;;; ^^^
  "methodical"                  {"methodical" {:resource "EPL_2.txt"}}
- "net.jcip"                    {"jcip-annotations" {:resource "CC_2_5.txt"}}
  "net.redhogs.cronparser"      {"cron-parser-core" {:resource "MIT.txt"}}
  "net.shibboleth.utilities"    {"java-support" {:resource "apache2_0.txt"}}
  "net.thisptr"                 {"jackson-jq" {:resource "apache2_0.txt"}}
  "org.antlr"                   {"antlr-runtime"  {:resource "BSD.txt"}
                                 "antlr4-runtime" {:resource "BSD.txt"}}
- "org.eclipse.jetty"           {"jetty-webapp" {:resource "EPL.txt"}}
  "org.eclipse.jetty.toolchain" {"jetty-jakarta-servlet-api" {:resource "EPL.txt"}}
- "org.fusesource.leveldbjni"   {"leveldbjni-all" {:resource "BSD.txt"}}
- "org.glassfish.jaxb"          {"jaxb-runtime" {:resource "EDL.txt"}
-                                "txw2"         {:resource "EDL.txt"}}
- "org.liquibase"               {"liquibase-core" {:resource "apache2_0.txt"}}
- "org.mortbay.jetty"           {"jetty"          {:resource "apache2_0.txt"}
-                                "jetty-util"     {:resource "apache2_0.txt"}
-                                "jetty-security" {:resource "apache2_0.txt"}}
- "org.openid4java"             {"openid4java-nodeps" {:resource "apache2_0.txt"}}
  "org.quartz-scheduler"        {"quartz" {:resource "apache2_0.txt"}}
  "org.slf4j"                   {"slf4j-api" {:resource "MIT.txt"}}
  "stencil"                     {"stencil" {:resource "EPL.txt"}}}

--- a/bin/build/resources/overrides.edn
+++ b/bin/build/resources/overrides.edn
@@ -1,15 +1,27 @@
 {:override/group
  {"com.fasterxml.jackson.dataformat" {:resource "apache2_0.txt"}
+  "com.google.auth"                  {:resource "apache2_0.txt"}
+  "metabase"                         {:resource "EPL_2.txt"}
   "com.google.guava"                 {:resource "apache2_0.txt"}
+  "com.google.http-client"           {:resource "apache2_0.txt"}
+  "com.google.protobuf"              {:resource "apache2_0.txt"}
   "com.onelogin"                     {:resource "MIT.txt"}
   "com.vladsch.flexmark"             {:resource "BSD.txt"}
+  "io.netty"                         {:resource "apache2_0.txt"}
   "org.clojure"                      {:resource "EPL.txt"}
   "org.opensaml"                     {:resource "apache2_0.txt"}}
 
  "amalloy"                     {"ring-gzip-middleware" {:resource "MIT.txt"}}
  "buddy"                       {"buddy-core" {:resource "apache2_0.txt"}}
  "colorize"                    {"colorize" {:resource "EPL.txt"}}
+ "com.amazonaws"               {"aws-java-sdk-core" {:resource "apache2_0.txt"}}
+ "com.google.api"              {"gax-grpc"     {:resource "BSD.txt"}
+                                "gax-httpjson" {:resource "BSD.txt"}
+                                "gax"          {:resource "BSD.txt"}}
+ "com.google.api-client"       {"google-api-client" {:resource "apache2_0.txt"}}
+ "com.google.oauth-client"     {"google-oauth-client" {:resource "apache2_0.txt"}}
  "com.sun.activation"          {"jakarta.activation" {:resource "EDL.txt"}}
+ "com.vertica.jdbc"            {"vertica-jdbc" {:resource "MIT.txt"}}
  "hiccup"                      {"hiccup" {:resource "EPL.txt"}}
  "io.dropwizard.metrics"       {"metrics-core" {:resource "apache2_0.txt"}}
  "jakarta.xml.bind"            {"jakarta.xml.bind-api" {:resource "EDL.txt"}}
@@ -24,6 +36,7 @@
  "net.thisptr"                 {"jackson-jq" {:resource "apache2_0.txt"}}
  "org.antlr"                   {"antlr-runtime"  {:resource "BSD.txt"}
                                 "antlr4-runtime" {:resource "BSD.txt"}}
+ "org.codehaus.mojo"           {"animal-sniffer-annotations" {:resource "MIT.txt"}}
  "org.eclipse.jetty.toolchain" {"jetty-jakarta-servlet-api" {:resource "EPL.txt"}}
  "org.quartz-scheduler"        {"quartz" {:resource "apache2_0.txt"}}
  "org.slf4j"                   {"slf4j-api" {:resource "MIT.txt"}}

--- a/bin/build/resources/overrides.edn
+++ b/bin/build/resources/overrides.edn
@@ -25,11 +25,7 @@
  "hiccup"                      {"hiccup" {:resource "EPL.txt"}}
  "io.dropwizard.metrics"       {"metrics-core" {:resource "apache2_0.txt"}}
  "jakarta.xml.bind"            {"jakarta.xml.bind-api" {:resource "EDL.txt"}}
- ;; --- three new additions
  "javax.servlet"               {"servlet-api" {:resource "CDDL_1.txt"}}
- "javax.servlet.jsp"           {"jsp-api" {:resource "GPL2_0.txt"}}
- "metabase"                    {"saml20-clj" {:resource "EPL_2.txt"}}
- ;;; ^^^
  "methodical"                  {"methodical" {:resource "EPL_2.txt"}}
  "net.redhogs.cronparser"      {"cron-parser-core" {:resource "MIT.txt"}}
  "net.shibboleth.utilities"    {"java-support" {:resource "apache2_0.txt"}}

--- a/bin/build/src/build.clj
+++ b/bin/build/src/build.clj
@@ -136,7 +136,8 @@
     clojure -X:build:build/list-without-license"
   [_options]
   (let [basis                     (b/create-basis
-                                   {:project (u/filename u/project-root-directory "deps.edn")})
+                                   {:project (u/filename u/project-root-directory "deps.edn")
+                                    :aliases ["ee" "drivers"]})
         {:keys [without-license]} (license/process*
                                    {:libs              (:libs basis)
                                     :backfill          (edn/read-string

--- a/bin/build/src/build.clj
+++ b/bin/build/src/build.clj
@@ -135,12 +135,10 @@
 
     clojure -X:build:build/list-without-license"
   [_options]
-  (let [[classpath]               (u/sh {:dir    u/project-root-directory
-                                         :quiet? true}
-                                        "clojure" "-A:ee" "-Spath")
-        classpath-entries         (license/jar-entries classpath)
+  (let [basis                     (b/create-basis
+                                   {:project (u/filename u/project-root-directory "deps.edn")})
         {:keys [without-license]} (license/process*
-                                   {:classpath-entries classpath-entries
+                                   {:libs              (:libs basis)
                                     :backfill          (edn/read-string
                                                         (slurp (io/resource "overrides.edn")))})]
     (if (seq without-license)

--- a/bin/build/src/build/licenses.clj
+++ b/bin/build/src/build/licenses.clj
@@ -285,7 +285,7 @@ Read license information from a pom. This reads only the local pom and does not 
 
   (let [overrides (edn/read-string (slurp (io/resource "overrides.edn")))
         by-group  (:override/group overrides)
-        by-group? false]
+        by-group? false #_true]
     (keep (fn [[lib _junk]]
             (let [without-license (->> (process* {:libs (:libs basis)
                                                   :backfill


### PR DESCRIPTION
```clojure
licenses=> (process* {:libs (-> basis :libs (select-keys '[com.github.seancorfield/next.jdbc]))})
{:with-license
 [[com.github.seancorfield/next.jdbc
   {:coords {:group "com.github.seancorfield", :artifact "next.jdbc"},
    :license
    "THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE PUBLIC..."}]],
 :without-license nil}
```

Previously it just filtered out non-jar deps.

some cleanup to make it easier to test, organizationally, etc.

Organizationally, now there is

```clojure
(defmulti lib-license
  "Determine the license from an lib. Implementations for both :mvn (jar) and :deps (git deps)."
  (fn [[_lib-name info]]
    (:deps/manifest info)))

(defmethod lib-license :mvn ...)
(defmethod lib-license :deps ...)
```

A few nicer cleanups. Searching through a jar filesystem and a git directory are both behind 
```clojure
(defprotocol FileSearch
  (-file-search [_ files]
    "Find the first file matching the names passed in. Returns a Path."))
```


And while i was in here, for each lib in our overrides.edn, I threw it out of the overrides and checked if we still got any warning.

#### Everything still works:

```
❯ clojure -X:build build/build! :edition :ee :steps '[:licenses]'
Warning: environ value /Users/dan/.sdkman/candidates/java/current for key :java-home has been overwritten with /Users/dan/.sdkman/candidates/java/17.0.1-zulu/zulu-17.jdk/Contents/Home
$ "git" "symbolic-ref" "--short" "HEAD"
  cleanup-license-check
$ "git" "describe" "--abbrev=0" "--tags"
  v0.45.0-RC2
Running build steps for Enterprise Edition version v1.45.1-SNAPSHOT: licenses
  Generate backend license information from jar files
    License information generated at /Users/dan/projects/work/metabase/resources/license-backend-third-party.txt
  Run `yarn licenses generate-disclaimer`
    $ "yarn" "licenses" "generate-disclaimer"
  All build steps finished.
```

```
❯ clojure -X:build build/list-without-license
All dependencies have licenses
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/29343)
<!-- Reviewable:end -->
