### PR TITLE
Fix for static distribution invalidation, resolves #19699

### DIFF
--- a/bin/build/src/release/common.clj
+++ b/bin/build/src/release/common.clj
@@ -3,7 +3,8 @@
    [clojure.string :as str]
    [metabuild-common.core :as u]))
 
-(def cloudfront-distribution-id "E35CJLWZIZVG7K")
+(def downloads-cloudfront-distribution-id "E35CJLWZIZVG7K")
+(def static-cloudfront-distribution-id "E1HU16PWP1JPMC")
 
 (def ^String root-directory
   "e.g. /Users/cam/metabase"

--- a/bin/build/src/release/common/upload.clj
+++ b/bin/build/src/release/common/upload.clj
@@ -11,4 +11,4 @@
   ([source-file version filename]
    (u/step (format "Upload %s to %s" source-file (c/artifact-download-url version filename))
      (u/s3-copy! (u/assert-file-exists source-file) (c/s3-artifact-url version filename))
-     (u/create-cloudfront-invalidation! c/cloudfront-distribution-id (c/s3-artifact-path version filename)))))
+     (u/create-cloudfront-invalidation! c/downloads-cloudfront-distribution-id (c/s3-artifact-path version filename)))))

--- a/bin/build/src/release/version_info.clj
+++ b/bin/build/src/release/version_info.clj
@@ -62,9 +62,9 @@
 (defn- upload-version-info! []
   (u/step "Upload version info"
     (u/s3-copy! (format "s3://%s" (version-info-url)) (format "s3://%s.previous" (version-info-url)))
-    (u/s3-copy! (u/assert-file-exists (tmp-version-info-filename)) (format "s3://%s" (version-info-url))) 
+    (u/s3-copy! (u/assert-file-exists (tmp-version-info-filename)) (format "s3://%s" (version-info-url)))
     (u/create-cloudfront-invalidation! c/static-cloudfront-distribution-id (format "/%s" (version-info-filename)))))
-    
+
 (defn- validate-version-info []
   (u/step (format "Validate version info at %s" (version-info-url))
     (let [info           (current-version-info)

--- a/bin/build/src/release/version_info.clj
+++ b/bin/build/src/release/version_info.clj
@@ -62,8 +62,9 @@
 (defn- upload-version-info! []
   (u/step "Upload version info"
     (u/s3-copy! (format "s3://%s" (version-info-url)) (format "s3://%s.previous" (version-info-url)))
-    (u/s3-copy! (u/assert-file-exists (tmp-version-info-filename)) (format "s3://%s" (version-info-url)))))
-
+    (u/s3-copy! (u/assert-file-exists (tmp-version-info-filename)) (format "s3://%s" (version-info-url))) 
+    (u/create-cloudfront-invalidation! c/static-cloudfront-distribution-id (format "/%s" (version-info-filename)))))
+    
 (defn- validate-version-info []
   (u/step (format "Validate version info at %s" (version-info-url))
     (let [info           (current-version-info)


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/19699

>The release script can fail because the version info check fails, in release.version-info/validate-version-info. The trouble is that upload-version-info! pushes the updated version info to S3, but does not create a Cloudfront invalidation (like we do for other S3 uploads) against static.metabase.com, which happens to be a different Cloudfront instance than downloads.metabase.com.

Added invalidation for `static.metabase.com` distribution as a step of `upload-version-info`