### PR TITLE
[CI] Increase FE timezones tests timeout

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -100,7 +100,7 @@ jobs:
     needs: files-changed
     if: github.event.pull_request.draft == false && needs.files-changed.outputs.frontend_all == 'true'
     runs-on: ubuntu-22.04
-    timeout-minutes: 14
+    timeout-minutes: 20
     steps:
     - uses: actions/checkout@v3
     - name: Prepare front-end environment


### PR DESCRIPTION
These tests started timing out frequently. Not sure exactly why or what changed but we need to increase the timeout to avoid frequent CI failures.

Example of a failure: https://github.com/metabase/metabase/actions/runs/4467803349/jobs/7847730170?pr=29353