### PR TITLE
fix dashboard opening in editing state when it shouldn't

### DIFF
--- a/e2e/test/scenarios/dashboard/reproductions/26826-dashboard-alien-card.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/reproductions/26826-dashboard-alien-card.cy.spec.js
@@ -5,7 +5,7 @@ import {
   saveDashboard,
 } from "e2e/support/helpers";
 
-describe.skip("issue 26826", () => {
+describe("issue 26826", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();

--- a/frontend/src/metabase/dashboard/containers/DashboardApp.jsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardApp.jsx
@@ -109,12 +109,11 @@ const mapDispatchToProps = {
 
 // NOTE: should use DashboardControls and DashboardData HoCs here?
 const DashboardApp = props => {
-  const options = parseHashOptions(window.location.hash);
-
   const { isRunning, isLoadingComplete, dashboard } = props;
 
-  const [editingOnLoad] = useState(options.edit);
-  const [addCardOnLoad] = useState(options.add && parseInt(options.add));
+  const options = parseHashOptions(window.location.hash);
+  const editingOnLoad = options.edit;
+  const addCardOnLoad = options.add && parseInt(options.add);
 
   const [isShowingToaster, setIsShowingToaster] = useState(false);
 


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/26826
### Description

In two situations, we open a dashboard directly into the editing state, with a card added:
1. When creating a new question, and selecting "Yes" when asked if you would like to add it to a dashboard
2. Clicking the "add to dashboard" button on an existing question

There was a bug where the flag to open a dashboard directly into the editing state would persist onto other dashboards, causing them to open in the editing state as well even though this was not intended by the user.

The root cause of this bug had to do with the `DashboardApp` component, where two variables, `editingOnLoad` and `addCardOnLoad`, were passed as props to the `Dashboard` component. The problem was that these variables were stored as React state variables. The `DashboardApp` component would re-render without unmounting when navigating directly between two dashboards via the search bar. Because this the component re-rendered without unmount, these variables would be preserved with their `true` values when navigating to the next dashboard, when in reality we want them to be recomputed for the new dashboard.

The fix for this problem was to save these variables as plain javascript variables, rather than React state. There was no need to use React state here given that the values were never updated `setState` was never called and we do not need to persist them between renders.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Create question: New question -> Raw data -> Invoices -> Visualize
2. Add to dashboard: Save -> Add this to dashboard? Yes -> Click on one dashboard -> Save
3. Navigate to another dashboard: Search -> some other dashboard name -> click
4. Confirm dashboard is not being edited, and card has not been added

### Demo

https://user-images.githubusercontent.com/37751258/226426317-fad8be8a-8eee-491a-b7f3-6dc6dd21718c.mov

### Checklist

- ✅ Tests have been added/updated to cover changes in this PR
