### PR TITLE
Add current-limit setter for a query limit

### DIFF
--- a/src/metabase/lib/core.cljc
+++ b/src/metabase/lib/core.cljc
@@ -89,6 +89,7 @@
    join-clause
    joins]
   [lib.limit
+   current-limit
    limit]
   [lib.order-by
    order-by

--- a/src/metabase/lib/limit.cljc
+++ b/src/metabase/lib/limit.cljc
@@ -26,6 +26,7 @@
                                                        (dissoc stage :limit))))))
 
 (mu/defn current-limit :- [:maybe ::lib.schema.common/int-greater-than-zero]
+  "Get the maximum number of rows to be returned by a stage of a query. `nil` indicates there is no limit"
   ([query :- ::lib.schema/query]
    (current-limit query -1))
   ([query :- ::lib.schema/query

--- a/src/metabase/lib/limit.cljc
+++ b/src/metabase/lib/limit.cljc
@@ -24,3 +24,10 @@
                                                      (if n
                                                        (assoc stage :limit n)
                                                        (dissoc stage :limit))))))
+
+(mu/defn current-limit :- [:maybe ::lib.schema.common/int-greater-than-zero]
+  ([query :- ::lib.schema/query]
+   (current-limit query -1))
+  ([query :- ::lib.schema/query
+    stage-number :- :int]
+   (:limit (lib.util/query-stage query stage-number))))

--- a/test/metabase/lib/limit_test.cljc
+++ b/test/metabase/lib/limit_test.cljc
@@ -18,3 +18,19 @@
         (is (= ::not-found
                (limit (-> query
                           (lib/limit nil)))))))))
+
+(deftest ^:parallel current-limit-test
+  (testing "Last stage"
+    (let [query (lib/query-for-table-name meta/metadata-provider "VENUES")]
+      (is (nil? (lib/current-limit query)))
+      (is (nil? (lib/current-limit query -1)))
+      (is (= 100 (lib/current-limit (lib/limit query 100))))
+      (is (= 100 (lib/current-limit (lib/limit query 100) -1)))))
+  (testing "First stage"
+    (let [query (lib/query meta/metadata-provider {:database (meta/id)
+                                                   :type     :query
+                                                   :query    {:source-query {:source-table (meta/id :venues)}}})]
+      (is (nil? (lib/current-limit query 0)))
+      (is (nil? (lib/current-limit query 1)))
+      (is (= 100 (lib/current-limit (lib/limit query 0 100) 0)))
+      (is (nil? (lib/current-limit query 1))))))


### PR DESCRIPTION
Resolves #28695

Adding and removing a limit to a query was already implemented through `(limit query 100)` and `(limit query nil)` respectively. 

This adds a `current-limit` getter to get the value of a stage's limit. `(current-limit query)` for the last stage `(current-limit query stage-number)` for a specific stage.