### PR TITLE
MLv1: Fix `Question.datasetQuery()` not returning raw joins

### DIFF
--- a/frontend/src/metabase-lib/queries/StructuredQuery.ts
+++ b/frontend/src/metabase-lib/queries/StructuredQuery.ts
@@ -11,6 +11,7 @@ import {
   Aggregation,
   Breakout,
   Filter,
+  Join,
   LimitClause,
   OrderBy,
   DependentMetadataItem,
@@ -95,6 +96,10 @@ export interface SegmentOption {
   filter: ["segment", number];
   icon: string;
   query: StructuredQuery;
+}
+
+function unwrapJoin(join: Join | JoinWrapper): Join {
+  return join instanceof JoinWrapper ? join.raw() : join;
 }
 
 /**
@@ -613,11 +618,11 @@ class StructuredQueryInner extends AtomicQuery {
   }
 
   addJoin(join) {
-    return this._updateQuery(Q.addJoin, arguments);
+    return this._updateQuery(Q.addJoin, [unwrapJoin(join)]);
   }
 
   updateJoin(index, join) {
-    return this._updateQuery(Q.updateJoin, arguments);
+    return this._updateQuery(Q.updateJoin, [index, unwrapJoin(join)]);
   }
 
   removeJoin(index) {


### PR DESCRIPTION
This is @bshepherdson's fix for `Question.datasetQuery()` not returning a raw query. 

Sometimes it would actually return capital-J `Join`s rather than plain JS Objects.