### PR TITLE
Support MB_ENCRYPTION_SECRET_KEY as a docker secret

### DIFF
--- a/bin/docker/run_metabase.sh
+++ b/bin/docker/run_metabase.sh
@@ -49,6 +49,7 @@ docker_setup_env() {
     file_env 'MB_EMAIL_SMTP_USERNAME'
     file_env 'MB_LDAP_PASSWORD'
     file_env 'MB_LDAP_BIND_DN'
+    file_env 'MB_ENCRYPTION_SECRET_KEY'
 }
 
 # detect if the container is started as root or not

--- a/docs/installation-and-operation/running-metabase-on-docker.md
+++ b/docs/installation-and-operation/running-metabase-on-docker.md
@@ -295,6 +295,7 @@ We currently support the following [environment variables](../configuring-metaba
 - MB_EMAIL_SMTP_USERNAME
 - MB_LDAP_PASSWORD
 - MB_LDAP_BIND_DN
+- MB_ENCRYPTION_SECRET_KEY
 
 In order for the Metabase container to read the files and use the contents as a secret, the environment variable name needs to be appended with a "\_FILE" as explained above.
 


### PR DESCRIPTION
### Description

Add `_FILE` extension support to `MB_ENCRYPTION_SECRET_KEY` so it can be used as docker secret

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/29386)
<!-- Reviewable:end -->
