### PR TITLE
Do not render useless divider in field settings

### DIFF
--- a/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/FieldSettingsPopover.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/FieldSettingsPopover.tsx
@@ -100,14 +100,16 @@ export function FormCreatorPopoverBody({
         fieldType={fieldSettings.fieldType}
         onChange={handleUpdateInputType}
       />
-      <Divider />
+      <Divider data-testid="divider" />
       {hasPlaceholder && (
-        <PlaceholderInput
-          value={fieldSettings.placeholder ?? ""}
-          onChange={handleUpdatePlaceholder}
-        />
+        <>
+          <PlaceholderInput
+            value={fieldSettings.placeholder ?? ""}
+            onChange={handleUpdatePlaceholder}
+          />
+          <Divider data-testid="divider" />
+        </>
       )}
-      <Divider />
       <RequiredInput
         fieldSettings={fieldSettings}
         onChangeRequired={handleUpdateRequired}

--- a/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/FieldSettingsPopover.unit.spec.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/FieldSettingsPopover.unit.spec.tsx
@@ -60,6 +60,34 @@ describe("actions > FormCreator > FieldSettingsPopover", () => {
     });
   });
 
+  describe("when field has placeholder", () => {
+    it("should render two <Divider />s", async () => {
+      const settings = getDefaultFieldSettings({
+        fieldType: "string",
+      });
+      setup({ settings });
+
+      userEvent.click(screen.getByLabelText("Field settings"));
+      await screen.findByLabelText("Default value");
+
+      expect(screen.getAllByTestId("divider").length).toBe(2);
+    });
+  });
+
+  describe("when field does not have placeholder", () => {
+    it("should render one <Divider />", async () => {
+      const settings = getDefaultFieldSettings({
+        fieldType: "date",
+      });
+      setup({ settings });
+
+      userEvent.click(screen.getByLabelText("Field settings"));
+      await screen.findByLabelText("Default value");
+
+      expect(screen.getAllByTestId("divider").length).toBe(1);
+    });
+  });
+
   it("should allow to make the field required and optional", async () => {
     const settings = getDefaultFieldSettings({
       fieldType: "number",


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/28987

### Description

Do not render two dividers

### How to verify

Model -> Actions -> parameter -> choose date type

Before
<img width="819" alt="Screenshot 2023-03-21 at 17 20 26" src="https://user-images.githubusercontent.com/125459446/226635654-c8bbe520-1254-48ff-8be4-d5aae27ad7ad.png">

After

<img width="822" alt="Screenshot 2023-03-21 at 17 20 53" src="https://user-images.githubusercontent.com/125459446/226635701-11cffaf5-cc0c-4d84-a594-4fb9c9d8a27e.png">

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
