### PR TITLE
Remove text coverage reporter from jest

### DIFF
--- a/jest.unit.conf.json
+++ b/jest.unit.conf.json
@@ -39,7 +39,7 @@
     "document": {}
   },
   "coverageDirectory": "./coverage",
-  "coverageReporters": ["text", "html", "lcov"],
+  "coverageReporters": ["html", "lcov"],
   "collectCoverageFrom": [
     "frontend/src/**/*.{js,jsx,ts,tsx}",
     "enterprise/frontend/src/**/*.{js,jsx,ts,tsx}",


### PR DESCRIPTION
### Description

Just remove text coverage reporter - logs become a bit less heavy.

### Demo

Before 
<img width="1157" alt="image" src="https://user-images.githubusercontent.com/125459446/226639725-a504c340-dc70-44ec-a56c-a90f5031a160.png">

After
<img width="1078" alt="image" src="https://user-images.githubusercontent.com/125459446/226740726-893941e3-008b-45e2-8720-4f6576f9734b.png">

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/29394)
<!-- Reviewable:end -->
