### PR TITLE
Clear Slack token if saved with a non-existant files channel

### DIFF
--- a/src/metabase/api/slack.clj
+++ b/src/metabase/api/slack.clj
@@ -40,6 +40,10 @@
       (slack/clear-channel-cache!))
     (let [processed-files-channel (slack/process-files-channel-name slack-files-channel)]
       (when (and processed-files-channel (not (slack/channel-exists? processed-files-channel)))
+        ;; Files channel could not be found; clear the token we had previously set since the integration should not be
+        ;; enabled.
+        (slack/slack-token-valid?! false)
+        (slack/slack-app-token! nil)
         (throw (ex-info (tru "Slack channel not found.")
                         {:errors {:slack-files-channel (tru "channel not found")}})))
       (slack/slack-files-channel! processed-files-channel))

--- a/src/metabase/integrations/slack.clj
+++ b/src/metabase/integrations/slack.clj
@@ -192,12 +192,13 @@
                         params)))
 
 (defn channel-exists?
-  "Returns true if the channel it exists."
+  "Returns a Boolean indicating whether a channel with a given name exists in the cache."
   [channel-name]
-  (let [channel-names (into #{} (comp (map (juxt :name :id))
-                                      cat)
-                            (:channels (slack-cached-channels-and-usernames)))]
-    (and channel-name (contains? channel-names channel-name))))
+  (boolean
+   (let [channel-names (into #{} (comp (map (juxt :name :id))
+                                       cat)
+                             (:channels (slack-cached-channels-and-usernames)))]
+     (and channel-name (contains? channel-names channel-name)))))
 
 (s/defn valid-token?
   "Check whether a Slack token is valid by checking if the `conversations.list` Slack api accepts it."


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/23254

When saving a new Slack integration, we have to save the token and fetch the entire list of channels to determine whether the provided value for `slack-files-channel` is valid. But if it's not valid, we need to clear the token so that the integration is not enabled. This wasn't happening properly before; I've fixed it in this PR.

Since Slack integrations are always deleted before a new one can be created, we don't have to worry about restoring a previous token here; we can always just reset it to `nil`.