### PR TITLE
fix dashcards not resizing with window

### DIFF
--- a/frontend/src/metabase/visualizations/components/CardRenderer.jsx
+++ b/frontend/src/metabase/visualizations/components/CardRenderer.jsx
@@ -106,11 +106,5 @@ class CardRenderer extends Component {
 
 export default ExplicitSize({
   wrapped: true,
-  refreshMode: props => {
-    const { isDashboard, isEditing } = props;
-    if (isDashboard) {
-      return isEditing ? "debounce" : "debounceLeading";
-    }
-    return "throttle";
-  },
+  refreshMode: props => (props.isDashboard ? "debounce" : "throttle"),
 })(CardRenderer);


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/29226

### Description

We had an issue where visualizations in dashboard cards would not resize properly with the window (see before video).

The root cause of the problem was that in [`CardRenderer` we were providing a `refreshMode` of `debounceLeading` to the `ExplicitSize` HoC for dashboards not in editing mode.](https://github.com/metabase/metabase/blob/0896fc2d39212be61677fa13e23dfa9f93365520/frontend/src/metabase/visualizations/components/CardRenderer.jsx#L112) The solution I implemented in this PR was to use `debounce` instead for all dashboards, regardless of if the user was editing or not.

Over the past year this value has changed several times in different PRs. Initially in https://github.com/metabase/metabase/pull/22094, when the notion of `refreshMode`s for `ExplicitSize` was introduced, it was set to `debounce` for dashboards. I believe this originally was correct and in this PR have gone back to that logic.

However, in https://github.com/metabase/metabase/pull/24739 it was changed to `debounceLeading`, which I believe was a mistake. In https://github.com/metabase/metabase/pull/26569 it was changed to `debounce`, but only for dashboards that were being edited.

`debounce`, not `debounceLeading`, should be the correct behavior for window resizing regardless of if the user is editing the dashboard. With `debounce`, the [`__updateSize()` method in `ExplicitSize`](https://github.com/metabase/metabase/blob/0896fc2d39212be61677fa13e23dfa9f93365520/frontend/src/metabase/components/ExplicitSize.jsx#L125) will be called when the user is done resizing the window with the final size, which is what we want in order to correctly update the visualization. 

`debounceLeading`, on the other hand, will call `__updateSize()` only once when the user starts dragging their window, but it will not be called subsequent times. If the user drags the window to a much larger size quickly (e.g. always growing the window at least once during the debounce interval), then `__updateSize()` will not be called with the final size of the window. 

This drawing summarizes the difference between the behaviors.

![IMG_05C3438C4370-1](https://user-images.githubusercontent.com/37751258/226687372-09fcb110-f582-4d71-b72f-60aba01e6987.jpeg)

[The documentation for the underscore debounce method](https://underscorejs.org/#debounce), as well as [an article from CSSTricks](https://css-tricks.com/debouncing-throttling-explained-examples/#aa-resize-example), both say to use debounce with the leading option for window resizing.


### How to verify

Describe the steps to verify that the changes are working as expected.

1. Create a dashboard with a single card that is a line chart visualization.
2. Quickly grow and shrink the browser window, and confirm the visualization resizes shortly after stopping.

### Demo

https://user-images.githubusercontent.com/37751258/226689177-582dc4b1-339a-4ea7-b4c0-e0fceffcb49a.mov

Before

https://user-images.githubusercontent.com/37751258/226689890-60d25da3-20b5-4cd4-8315-47a22b4f8a5e.mov

After

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR

I'm not sure if there's an easy way to test this. It is possible to write an e2e test that resizes the window and checks if the visualization has grown, but because [`ExplicitSize` ignores the `refreshMode` when running in Cypress,
](https://github.com/metabase/metabase/blob/2149795e610cdb2b1a744724a2402db196bfb5a2/frontend/src/metabase/components/ExplicitSize.jsx#LL66C3-L66C3) that test would pass even without this fix, so it doesn't really test if the behavior in the actual user environment is correct.