### PR TITLE
MLv1 🌲tree shake to remove dead/unused code: remove 1% of the total LoC

### DIFF
--- a/frontend/src/metabase-lib/Dimension.ts
+++ b/frontend/src/metabase-lib/Dimension.ts
@@ -421,13 +421,6 @@ export default class Dimension {
     return this.temporalUnit() && /-of-/.test(this.temporalUnit());
   }
 
-  /**
-   * Whether temporal bucketing is being applied, *and* the bucketing is an truncation operation such as "day of month";
-   */
-  isTemporalTruncation(): boolean {
-    return this.temporalUnit() && !this.isTemporalExtraction();
-  }
-
   // binning-strategy stuff
   binningOptions() {
     return this.getOption("binning");

--- a/frontend/src/metabase-lib/Dimension.ts
+++ b/frontend/src/metabase-lib/Dimension.ts
@@ -336,27 +336,8 @@ export default class Dimension {
     return this.field().aggregationOperators();
   }
 
-  /**
-   * Valid filter operators on this dimension
-   */
-  aggregationOperator(
-    operatorName: string,
-  ): AggregationOperator | null | undefined {
-    return this.field().aggregationOperator(operatorName);
-  }
-
   defaultAggregationOperator(): AggregationOperator | null | undefined {
     return this.aggregationOperators()[0];
-  }
-
-  defaultAggregation() {
-    const aggregation = this.defaultAggregationOperator();
-
-    if (aggregation) {
-      return [aggregation.short, this.mbql()];
-    }
-
-    return null;
   }
 
   // BREAKOUTS

--- a/frontend/src/metabase-lib/expressions/config.js
+++ b/frontend/src/metabase-lib/expressions/config.js
@@ -37,28 +37,6 @@ export const OPERATOR_PRECEDENCE = {
   or: 5,
 };
 
-export const EXPRESSION_TYPES = [
-  "expression",
-  "aggregation",
-  "boolean",
-  "string",
-  "number",
-];
-
-export const EXPRESSION_SUBTYPES = {
-  // can't currently add "boolean" as a subtype of expression due to conflict between segments and fields
-  expression: new Set(["string", "number"]),
-};
-
-export const isExpressionType = (typeA, typeB) =>
-  typeA === typeB ||
-  (EXPRESSION_SUBTYPES[typeB] && EXPRESSION_SUBTYPES[typeB].has(typeA)) ||
-  false;
-
-export function getFunctionArgType(clause, index) {
-  return clause.multiple ? clause.args[0] : clause.args[index];
-}
-
 export const MBQL_CLAUSES = {
   // aggregation functions
   count: { displayName: `Count`, type: "aggregation", args: [] },
@@ -502,12 +480,12 @@ export const EXPRESSION_FUNCTIONS = new Set([
   "coalesce",
 ]);
 
-export const EXPRESSION_OPERATORS = new Set(["+", "-", "*", "/"]);
+const EXPRESSION_OPERATORS = new Set(["+", "-", "*", "/"]);
 export const FILTER_OPERATORS = new Set(["!=", "<=", ">=", "<", ">", "="]);
 
-export const BOOLEAN_UNARY_OPERATORS = new Set(["not"]);
-export const LOGICAL_AND_OPERATOR = new Set(["and"]);
-export const LOGICAL_OR_OPERATOR = new Set(["or"]);
+const BOOLEAN_UNARY_OPERATORS = new Set(["not"]);
+const LOGICAL_AND_OPERATOR = new Set(["and"]);
+const LOGICAL_OR_OPERATOR = new Set(["or"]);
 
 export const FUNCTIONS = new Set([
   ...EXPRESSION_FUNCTIONS,

--- a/frontend/src/metabase-lib/expressions/index.js
+++ b/frontend/src/metabase-lib/expressions/index.js
@@ -52,11 +52,7 @@ export function formatIdentifier(name, { quotes = EDITOR_QUOTES } = {}) {
   return quoteString(name, quotes.identifierQuoteDefault);
 }
 
-export function parseIdentifierString(identifierString) {
-  return unquoteString(identifierString);
-}
-
-export function isReservedWord(word) {
+function isReservedWord(word) {
   return !!getMBQLName(word);
 }
 
@@ -141,9 +137,6 @@ export function formatStringLiteral(
   { quotes = EDITOR_QUOTES } = {},
 ) {
   return quoteString(mbqlString, quotes.literalQuoteDefault);
-}
-export function parseStringLiteral(expressionString) {
-  return unquoteString(expressionString);
 }
 
 const DOUBLE_QUOTE = '"';

--- a/frontend/src/metabase-lib/expressions/pratt/compiler.ts
+++ b/frontend/src/metabase-lib/expressions/pratt/compiler.ts
@@ -28,9 +28,9 @@ export type Expr =
   | string
   | boolean
   | ([string, ...Expr[]] & { node?: Node });
-export type CompilerPass = (expr: Expr) => Expr;
+type CompilerPass = (expr: Expr) => Expr;
 
-export interface Options {
+interface Options {
   getMBQLName(expressionName: string): string | undefined;
   passes?: CompilerPass[];
 }

--- a/frontend/src/metabase-lib/expressions/pratt/parser.ts
+++ b/frontend/src/metabase-lib/expressions/pratt/parser.ts
@@ -348,7 +348,7 @@ function shouldReparent(leftType: NodeType, rightType: NodeType) {
   }
 }
 
-export function getASType(type: NodeType, parentType: NodeType) {
+function getASType(type: NodeType, parentType: NodeType) {
   if (type === GROUP) {
     // A list of function call arguments is first interpreted as a GROUP, then
     // reinterpreted as an ARG_LIST if its the child of a CALL

--- a/frontend/src/metabase-lib/expressions/pratt/types.ts
+++ b/frontend/src/metabase-lib/expressions/pratt/types.ts
@@ -1,14 +1,8 @@
 import { isProduction } from "metabase/env";
 
-export const VOID = Symbol("Unknown Type");
-
-export type VariableKind =
-  | "dimension"
-  | "segment"
-  | "aggregation"
-  | "expression";
-export type Type = VariableKind | "string" | "number" | "boolean";
-export type VariableId = number;
+type VariableKind = "dimension" | "segment" | "aggregation" | "expression";
+type Type = VariableKind | "string" | "number" | "boolean";
+type VariableId = number;
 
 export interface Token {
   type: NodeType;
@@ -88,7 +82,7 @@ export interface Hooks {
  * easily distinguish between compilation error exceptions and exceptions due to
  * bugs
  */
-export abstract class ExpressionError extends Error {
+abstract class ExpressionError extends Error {
   abstract get pos(): number | null;
   abstract get len(): number | null;
 }
@@ -121,7 +115,7 @@ export class ResolverError extends ExpressionError {
   }
 }
 
-export class AssertionError extends Error {
+class AssertionError extends Error {
   data?: any;
 
   constructor(message: string, data?: any) {

--- a/frontend/src/metabase-lib/expressions/resolver.js
+++ b/frontend/src/metabase-lib/expressions/resolver.js
@@ -4,9 +4,9 @@ import { ResolverError } from "metabase-lib/expressions/pratt/types";
 import { OPERATOR as OP } from "./tokenizer";
 import { getMBQLName, MBQL_CLAUSES } from "./index";
 
-export const FIELD_MARKERS = ["dimension", "segment", "metric"];
+const FIELD_MARKERS = ["dimension", "segment", "metric"];
 export const LOGICAL_OPS = [OP.Not, OP.And, OP.Or];
-export const NUMBER_OPS = [OP.Plus, OP.Minus, OP.Star, OP.Slash];
+const NUMBER_OPS = [OP.Plus, OP.Minus, OP.Star, OP.Slash];
 export const COMPARISON_OPS = [
   OP.Equal,
   OP.NotEqual,

--- a/frontend/src/metabase-lib/expressions/types.ts
+++ b/frontend/src/metabase-lib/expressions/types.ts
@@ -17,7 +17,7 @@ export interface HelpTextConfig {
   docsPage?: string;
 }
 
-export interface HelpTextArg {
+interface HelpTextArg {
   name: string;
   description: string;
   example: string;

--- a/frontend/src/metabase-lib/metadata/Field.ts
+++ b/frontend/src/metabase-lib/metadata/Field.ts
@@ -47,7 +47,7 @@ import type Table from "./Table";
 import type Metadata from "./Metadata";
 import { getIconForField, getUniqueFieldId } from "./utils/fields";
 
-export const LONG_TEXT_MIN = 80;
+const LONG_TEXT_MIN = 80;
 
 /**
  * @typedef { import("./Metadata").FieldValues } FieldValues

--- a/frontend/src/metabase-lib/metadata/utils/models.ts
+++ b/frontend/src/metabase-lib/metadata/utils/models.ts
@@ -18,7 +18,7 @@ import NativeQuery from "metabase-lib/queries/NativeQuery";
 import { isSameField } from "metabase-lib/queries/utils/field-ref";
 import { isStructured } from "metabase-lib/queries/utils";
 
-export type FieldMetadata = {
+type FieldMetadata = {
   id?: number;
   name: string;
   display_name: string;
@@ -87,11 +87,11 @@ export function getDatasetMetadataCompletenessPercentage(
   return Math.round(percent * 100) / 100;
 }
 
-export function isSupportedTemplateTagForModel(tag: TemplateTag) {
+function isSupportedTemplateTagForModel(tag: TemplateTag) {
   return ["card", "snippet"].includes(tag.type);
 }
 
-export function checkDatabaseSupportsModels(database?: Database | null) {
+function checkDatabaseSupportsModels(database?: Database | null) {
   return database && database.hasFeature("nested-queries");
 }
 
@@ -115,7 +115,7 @@ export function checkCanBeModel(question: Question) {
     .every(isSupportedTemplateTagForModel);
 }
 
-export type Card = CardObject & {
+type Card = CardObject & {
   id?: CardId;
   dataset?: boolean;
 };

--- a/frontend/src/metabase-lib/metadata/utils/saved-questions.js
+++ b/frontend/src/metabase-lib/metadata/utils/saved-questions.js
@@ -1,7 +1,7 @@
 import { generateSchemaId } from "metabase-lib/metadata/utils/schema";
 
 export const SAVED_QUESTIONS_VIRTUAL_DB_ID = -1337;
-export const ROOT_COLLECTION_VIRTUAL_SCHEMA_NAME = "Everything else";
+const ROOT_COLLECTION_VIRTUAL_SCHEMA_NAME = "Everything else";
 
 export const ROOT_COLLECTION_VIRTUAL_SCHEMA = getCollectionVirtualSchemaId({
   id: null,

--- a/frontend/src/metabase-lib/mocks.ts
+++ b/frontend/src/metabase-lib/mocks.ts
@@ -15,12 +15,11 @@ import {
 import Question from "metabase-lib/Question";
 import NativeQuery from "metabase-lib/queries/NativeQuery";
 import StructuredQuery from "metabase-lib/queries/StructuredQuery";
-import Query from "metabase-lib/queries/Query";
 
 export type NativeSavedCard = SavedCard<NativeDatasetQuery>;
-export type NativeUnsavedCard = UnsavedCard<NativeDatasetQuery>;
+type NativeUnsavedCard = UnsavedCard<NativeDatasetQuery>;
 export type StructuredSavedCard = SavedCard<StructuredDatasetQuery>;
-export type StructuredUnsavedCard = UnsavedCard<StructuredDatasetQuery>;
+type StructuredUnsavedCard = UnsavedCard<StructuredDatasetQuery>;
 
 const BASE_GUI_QUESTION: StructuredUnsavedCard = {
   display: "table",
@@ -56,7 +55,7 @@ const SAVED_QUESTION = {
   result_metadata: [],
 };
 
-export function getQuestion(card: Partial<Card>) {
+function getQuestion(card: Partial<Card>) {
   return new Question(
     {
       ...BASE_GUI_QUESTION,
@@ -70,16 +69,6 @@ export function getQuestion(card: Partial<Card>) {
 
 export function getAdHocQuestion(card?: Partial<StructuredUnsavedCard>) {
   return getQuestion({ ...BASE_GUI_QUESTION, ...card });
-}
-
-export function getCleanStructuredQuestion(
-  card?: Partial<StructuredUnsavedCard>,
-) {
-  let question = getAdHocQuestion(card);
-  if (question.query() instanceof StructuredQuery) {
-    question = question.setQuery(new Query());
-  }
-  return question;
 }
 
 export function getUnsavedNativeQuestion(card?: Partial<NativeUnsavedCard>) {

--- a/frontend/src/metabase-lib/parameters/constants.ts
+++ b/frontend/src/metabase-lib/parameters/constants.ts
@@ -127,27 +127,6 @@ export const ID_OPTION = {
   name: t`ID`,
 };
 
-export const CATEGORY_OPTION = { type: "category", name: t`Category` };
-
-export const LOCATION_OPTIONS = [
-  {
-    type: "location/city",
-    name: t`City`,
-  },
-  {
-    type: "location/state",
-    name: t`State`,
-  },
-  {
-    type: "location/zip_code",
-    name: t`ZIP or Postal Code`,
-  },
-  {
-    type: "location/country",
-    name: t`Country`,
-  },
-];
-
 export const TYPE_SUPPORTS_LINKED_FILTERS = [
   "string",
   "category",

--- a/frontend/src/metabase-lib/parameters/types.ts
+++ b/frontend/src/metabase-lib/parameters/types.ts
@@ -2,8 +2,7 @@ import { Parameter } from "metabase-types/api";
 import type { ParameterTarget } from "metabase-types/types/Parameter";
 import type Field from "metabase-lib/metadata/Field";
 
-export interface ValuePopulatedParameter
-  extends ParameterWithTemplateTagTarget {
+interface ValuePopulatedParameter extends ParameterWithTemplateTagTarget {
   value?: any;
 }
 

--- a/frontend/src/metabase-lib/parameters/utils/mbql.js
+++ b/frontend/src/metabase-lib/parameters/utils/mbql.js
@@ -167,7 +167,7 @@ export function numberParameterValueToMBQL(parameter, fieldRef) {
   );
 }
 
-export function isFieldFilterParameterConveratableToMBQL(parameter) {
+function isFieldFilterParameterConveratableToMBQL(parameter) {
   const { value, target } = parameter;
   const hasValue = hasParameterValue(value);
   const hasWellFormedTarget = Array.isArray(target?.[1]);

--- a/frontend/src/metabase-lib/parameters/utils/template-tags.ts
+++ b/frontend/src/metabase-lib/parameters/utils/template-tags.ts
@@ -8,7 +8,7 @@ import type { ParameterWithTarget } from "metabase-lib/parameters/types";
 import { getTemplateTagFromTarget } from "metabase-lib/parameters/utils/targets";
 import { hasParameterValue } from "metabase-lib/parameters/utils/parameter-values";
 
-export function getTemplateTagType(tag: TemplateTag) {
+function getTemplateTagType(tag: TemplateTag) {
   const { type } = tag;
   if (type === "date") {
     return "date/single";
@@ -22,9 +22,7 @@ export function getTemplateTagType(tag: TemplateTag) {
   }
 }
 
-export function getTemplateTagParameterTarget(
-  tag: TemplateTag,
-): ParameterTarget {
+function getTemplateTagParameterTarget(tag: TemplateTag): ParameterTarget {
   return tag.type === "dimension"
     ? ["dimension", ["template-tag", tag.name]]
     : ["variable", ["template-tag", tag.name]];

--- a/frontend/src/metabase-lib/queries/NativeQuery.ts
+++ b/frontend/src/metabase-lib/queries/NativeQuery.ts
@@ -343,10 +343,6 @@ export default class NativeQuery extends AtomicQuery {
     return this.templateTags().some(t => t.type === "snippet");
   }
 
-  templateTagsWithoutSnippets(): TemplateTag[] {
-    return this.templateTags().filter(t => t.type !== "snippet");
-  }
-
   referencedQuestionIds(): number[] {
     return this.templateTags()
       .filter(tag => tag.type === "card")

--- a/frontend/src/metabase-lib/queries/structured/Filter.ts
+++ b/frontend/src/metabase-lib/queries/structured/Filter.ts
@@ -28,7 +28,7 @@ import Dimension from "../../Dimension";
 import StructuredQuery from "../StructuredQuery";
 import MBQLClause from "./MBQLClause";
 
-export interface FilterDisplayNameOpts {
+interface FilterDisplayNameOpts {
   includeDimension?: boolean;
   includeOperator?: boolean;
 }

--- a/frontend/src/metabase-lib/queries/structured/Join.ts
+++ b/frontend/src/metabase-lib/queries/structured/Join.ts
@@ -102,15 +102,6 @@ export default class Join extends MBQLObjectClause {
     return this["source-query"];
   }
 
-  setJoinSourceQuery(query: StructuredQuery) {
-    return this.set({
-      ...this,
-      "source-table": undefined,
-      "source-query": query,
-      condition: null,
-    });
-  }
-
   _uniqueAlias(name: JoinAlias): JoinAlias {
     const usedAliases = new Set(
       this.query()

--- a/frontend/src/metabase-lib/queries/utils/actions.js
+++ b/frontend/src/metabase-lib/queries/utils/actions.js
@@ -125,7 +125,7 @@ export function drillFilter(query, value, column) {
   return addOrUpdateFilter(query, filter);
 }
 
-export function addOrUpdateFilter(query, newFilter) {
+function addOrUpdateFilter(query, newFilter) {
   // replace existing filter, if it exists
   for (const filter of query.filters()) {
     const dimension = filter.dimension();
@@ -145,7 +145,7 @@ const getNextUnit = unit => {
   return UNITS[Math.max(0, UNITS.indexOf(unit) - 1)];
 };
 
-export function addOrUpdateBreakout(query, newBreakout) {
+function addOrUpdateBreakout(query, newBreakout) {
   // replace existing breakout, if it exists
   for (const breakout of query.breakouts()) {
     if (breakout.dimension().isSameBaseDimension(newBreakout)) {

--- a/frontend/src/metabase-lib/queries/utils/aggregation.js
+++ b/frontend/src/metabase-lib/queries/utils/aggregation.js
@@ -1,7 +1,6 @@
-import _ from "underscore";
 import { STANDARD_AGGREGATIONS } from "metabase-lib/expressions";
 import * as FieldRef from "./field-ref";
-import { noNullValues, add, update, remove, clear } from "./util";
+import { add, update, remove, clear } from "./util";
 
 // returns canonical list of Aggregations, i.e. with deprecated "rows" removed
 export function getAggregations(aggregation) {
@@ -50,14 +49,6 @@ export function isBareRows(ac) {
   return getAggregations(ac).length === 0;
 }
 
-export function hasEmptyAggregation(ac) {
-  return _.any(getAggregations(ac), aggregation => !noNullValues(aggregation));
-}
-
-export function hasValidAggregation(ac) {
-  return _.all(getAggregations(ac), aggregation => noNullValues(aggregation));
-}
-
 // AGGREGATION TYPES
 
 // NOTE: these only differentiate between "standard", "metric", and "custom", but do not validate the aggregation
@@ -82,10 +73,10 @@ export function isCustom(aggregation) {
 
 // AGGREGATION OPTIONS / NAMED AGGREGATIONS
 
-export function hasOptions(aggregation) {
+function hasOptions(aggregation) {
   return Array.isArray(aggregation) && aggregation[0] === "aggregation-options";
 }
-export function getOptions(aggregation) {
+function getOptions(aggregation) {
   return hasOptions(aggregation) && aggregation[2] ? aggregation[2] : {};
 }
 export function getContent(aggregation) {
@@ -123,15 +114,6 @@ export function getMetric(aggregation) {
 export function getOperator(aggregation) {
   if (isStandard(aggregation)) {
     return aggregation[0];
-  } else {
-    return null;
-  }
-}
-
-// get the fieldId from a standard aggregation clause
-export function getField(aggregation) {
-  if (isStandard(aggregation)) {
-    return aggregation[1];
   } else {
     return null;
   }

--- a/frontend/src/metabase-lib/queries/utils/breakout.js
+++ b/frontend/src/metabase-lib/queries/utils/breakout.js
@@ -6,7 +6,7 @@ export function getBreakouts(breakouts) {
 }
 
 // turns a list of Breakouts into the canonical BreakoutClause
-export function getBreakoutClause(breakouts) {
+function getBreakoutClause(breakouts) {
   breakouts = getBreakouts(breakouts);
   if (breakouts.length === 0) {
     return undefined;

--- a/frontend/src/metabase-lib/queries/utils/card.js
+++ b/frontend/src/metabase-lib/queries/utils/card.js
@@ -6,35 +6,11 @@ import { normalizeParameterValue } from "metabase-lib/parameters/utils/parameter
 import { deriveFieldOperatorFromParameter } from "metabase-lib/parameters/utils/operators";
 import * as Q_DEPRECATED from "metabase-lib/queries/utils"; // legacy
 
-export const STRUCTURED_QUERY_TEMPLATE = {
-  type: "query",
-  database: null,
-  query: {
-    "source-table": null,
-    aggregation: undefined,
-    breakout: undefined,
-    filter: undefined,
-  },
-};
-
-export const NATIVE_QUERY_TEMPLATE = {
-  type: "native",
-  database: null,
-  native: {
-    query: "",
-    "template-tags": {},
-  },
-};
-
 export function isStructured(card) {
   return card.dataset_query.type === "query";
 }
 
-export function isNative(card) {
-  return card.dataset_query.type === "native";
-}
-
-export function cardVisualizationIsEquivalent(cardA, cardB) {
+function cardVisualizationIsEquivalent(cardA, cardB) {
   return _.isEqual(
     _.pick(cardA, "display", "visualization_settings"),
     _.pick(cardB, "display", "visualization_settings"),
@@ -67,14 +43,6 @@ export function getQuery(card) {
   } else {
     return null;
   }
-}
-
-export function getTableMetadata(card, metadata) {
-  const query = getQuery(card);
-  if (query && query["source-table"] != null) {
-    return metadata.table(query["source-table"]) || null;
-  }
-  return null;
 }
 
 // NOTE Atte Keinänen 7/5/17: Still used in dashboards and public questions.

--- a/frontend/src/metabase-lib/queries/utils/description.js
+++ b/frontend/src/metabase-lib/queries/utils/description.js
@@ -129,7 +129,7 @@ export function formatQueryDescription(parts, options = {}) {
   }
 }
 
-export function joinList(list, joiner) {
+function joinList(list, joiner) {
   return _.flatten(
     list.map((l, i) => (i === list.length - 1 ? [l] : [l, joiner])),
     true,

--- a/frontend/src/metabase-lib/queries/utils/dimension.ts
+++ b/frontend/src/metabase-lib/queries/utils/dimension.ts
@@ -6,7 +6,7 @@ import type NativeQuery from "metabase-lib/queries/NativeQuery";
 
 import Dimension from "metabase-lib/Dimension";
 
-export function getDimension(
+function getDimension(
   fieldRef: ConcreteField | VariableTarget,
   metadata: Metadata,
   query?: StructuredQuery | NativeQuery | null | undefined,

--- a/frontend/src/metabase-lib/queries/utils/expression.js
+++ b/frontend/src/metabase-lib/queries/utils/expression.js
@@ -1,15 +1,8 @@
 import _ from "underscore";
-import {
-  expressions_list,
-  unique_expression_name,
-} from "cljs/metabase.domain_entities.queries.util";
+import { unique_expression_name } from "cljs/metabase.domain_entities.queries.util";
 
 export function getExpressions(expressions = {}) {
   return expressions;
-}
-
-export function getExpressionsList(expressions = {}) {
-  return expressions_list(expressions);
 }
 
 export function addExpression(expressions = {}, name, expression) {

--- a/frontend/src/metabase-lib/queries/utils/field.js
+++ b/frontend/src/metabase-lib/queries/utils/field.js
@@ -3,12 +3,12 @@ import _ from "underscore";
 import { add, update, remove, clear } from "./util";
 
 // returns canonical list of Fields, with nulls removed
-export function getFields(fields) {
+function getFields(fields) {
   return (fields || []).filter(b => b != null);
 }
 
 // turns a list of Fields into the canonical FieldClause
-export function getFieldClause(fields) {
+function getFieldClause(fields) {
   fields = getFields(fields);
   if (fields.length === 0) {
     return undefined;
@@ -64,9 +64,4 @@ export function getRemappings(field) {
   const remappings = (field && field.remappings) || [];
   const fieldValues = getFieldValues(field);
   return [...fieldValues, ...remappings];
-}
-
-export function getHumanReadableValue(value, fieldValues = []) {
-  const fieldValue = _.findWhere(fieldValues, { [0]: value });
-  return fieldValue && fieldValue.length === 2 ? fieldValue[1] : String(value);
 }

--- a/frontend/src/metabase-lib/queries/utils/index.js
+++ b/frontend/src/metabase-lib/queries/utils/index.js
@@ -10,7 +10,7 @@ export * from "./field-ref";
 // need to communicate or use that, use this constant
 export const HARD_ROW_LIMIT = 2000;
 
-export const NEW_QUERY_TEMPLATES = {
+const NEW_QUERY_TEMPLATES = {
   query: {
     database: null,
     type: "query",
@@ -43,10 +43,6 @@ export function createQuery(type = "query", databaseId, tableId) {
 
 export function isStructured(dataset_query) {
   return dataset_query && dataset_query.type === "query";
-}
-
-export function isNative(dataset_query) {
-  return dataset_query && dataset_query.type === "native";
 }
 
 export function cleanQuery(query) {

--- a/frontend/src/metabase-lib/queries/utils/join.js
+++ b/frontend/src/metabase-lib/queries/utils/join.js
@@ -6,7 +6,7 @@ export function getJoins(joins) {
 }
 
 // turns a list of Joins into the canonical JoinClause
-export function getJoinClause(joins) {
+function getJoinClause(joins) {
   joins = getJoins(joins);
   if (joins.length === 0) {
     return undefined;

--- a/frontend/src/metabase-lib/queries/utils/order-by.js
+++ b/frontend/src/metabase-lib/queries/utils/order-by.js
@@ -6,7 +6,7 @@ export function getOrderBys(breakout) {
 }
 
 // turns a list of OrderBys into the canonical OrderByClause
-export function getOrderByClause(breakouts) {
+function getOrderByClause(breakouts) {
   breakouts = getOrderBys(breakouts);
   if (breakouts.length === 0) {
     return undefined;

--- a/frontend/src/metabase-lib/queries/utils/query-time.js
+++ b/frontend/src/metabase-lib/queries/utils/query-time.js
@@ -139,7 +139,7 @@ export function generateTimeFilterValuesDescriptions(filter) {
   }
 }
 
-export function generateTimeIntervalDescription(n, unit) {
+function generateTimeIntervalDescription(n, unit) {
   if (unit === "day") {
     switch (n) {
       case "current":
@@ -179,7 +179,7 @@ export function generateTimeIntervalDescription(n, unit) {
   }
 }
 
-export function generateTimeValueDescription(value, bucketing, isExclude) {
+function generateTimeValueDescription(value, bucketing, isExclude) {
   if (typeof value === "number" && bucketing === "hour-of-day") {
     return moment().hour(value).format("h A");
   } else if (typeof value === "string") {
@@ -294,29 +294,6 @@ export function parseFieldBucketing(field, defaultUnit = null) {
   return defaultUnit;
 }
 
-// returns field with temporal bucketing removed
-export function parseFieldTarget(field) {
-  const dimension = FieldDimension.parseMBQLOrWarn(field);
-  if (dimension) {
-    return dimension.withoutTemporalBucketing();
-  }
-  return field;
-}
-
-/**
- * Get the raw integer ID from a `field` clause, otherwise return the clause as-is. (TODO: Why would we want to
- * return the clause as-is?)
- */
-export function parseFieldTargetId(field) {
-  const dimension = FieldDimension.parseMBQLOrWarn(field);
-  if (dimension) {
-    if (dimension.isIntegerFieldId()) {
-      return dimension.fieldIdOrName();
-    }
-  }
-  return field;
-}
-
 // 271821 BC and 275760 AD and should be far enough in the past/future
 function max() {
   return moment(new Date(864000000000000));
@@ -330,7 +307,7 @@ export function isRelativeDatetime(value) {
   return Array.isArray(value) && value[0] === "relative-datetime";
 }
 
-export function isInterval(mbql) {
+function isInterval(mbql) {
   if (!Array.isArray(mbql)) {
     return false;
   }
@@ -394,7 +371,7 @@ export function formatStartingFrom(bucketing, n) {
   return "";
 }
 
-export function getTimeInterval(mbql) {
+function getTimeInterval(mbql) {
   if (Array.isArray(mbql) && mbql[0] === "time-interval") {
     return [mbql[1], mbql[2], mbql[3] || "day"];
   }
@@ -576,11 +553,6 @@ export const getTimeComponent = value => {
     date = moment();
   }
   return { hours, minutes, date };
-};
-
-export const hasTimeComponent = value => {
-  const { hours, minutes } = getTimeComponent(value);
-  return typeof hours === "number" && typeof minutes === "number";
 };
 
 export const setTimeComponent = (value, hours, minutes) => {

--- a/frontend/src/metabase-lib/queries/utils/query.js
+++ b/frontend/src/metabase-lib/queries/utils/query.js
@@ -24,10 +24,6 @@ export const clearAggregations = query =>
   setAggregationClause(query, A.clearAggregations(query.aggregation));
 
 export const isBareRows = query => A.isBareRows(query.aggregation);
-export const hasEmptyAggregation = query =>
-  A.hasEmptyAggregation(query.aggregation);
-export const hasValidAggregation = query =>
-  A.hasValidAggregation(query.aggregation);
 
 // BREAKOUT
 
@@ -82,7 +78,6 @@ export const clearOrderBy = query =>
   setOrderByClause(query, O.clearOrderBy(query["order-by"]));
 
 // FIELD
-export const getFields = query => FIELD.getFields(query.fields);
 export const addField = (query, field) =>
   setFieldsClause(query, FIELD.addField(query.fields, field));
 export const updateField = (query, index, field) =>
@@ -103,8 +98,6 @@ export const clearLimit = query =>
 // EXPRESSIONS
 
 export const getExpressions = query => E.getExpressions(query.expressions);
-export const getExpressionsList = query =>
-  E.getExpressionsList(query.expressions);
 export const addExpression = (query, name, expression) =>
   setExpressionClause(
     query,

--- a/frontend/src/metabase-lib/queries/utils/util.js
+++ b/frontend/src/metabase-lib/queries/utils/util.js
@@ -1,37 +1,5 @@
 import _ from "underscore";
 
-// determines whether 2 field IDs are equal. This is needed rather than
-// doing a simple comparison because field IDs are not guaranteed to be numeric:
-// the might be FieldLiterals, e.g. [field-literal <name> <unit>], instead.
-export const fieldIdsEq = (a, b) => {
-  if (typeof a !== typeof b) {
-    return false;
-  }
-
-  if (typeof a === "number") {
-    return a === b;
-  }
-
-  if (a == null && b == null) {
-    return true;
-  }
-
-  // field literals
-  if (
-    Array.isArray(a) &&
-    Array.isArray(b) &&
-    a.length === 3 &&
-    b.length === 3 &&
-    a[0] === "field" &&
-    b[0] === "field"
-  ) {
-    return a[1] === b[1];
-  }
-
-  console.warn("Don't know how to compare these IDs:", a, b);
-  return false;
-};
-
 export const noNullValues = clause => _.all(clause, c => c != null);
 
 // these are mostly to circumvent Flow type checking :-/

--- a/frontend/src/metabase-lib/types/constants.js
+++ b/frontend/src/metabase-lib/types/constants.js
@@ -14,11 +14,11 @@ export const FOREIGN_KEY = "FOREIGN_KEY";
 export const PRIMARY_KEY = "PRIMARY_KEY";
 
 // other types used for various purposes
-export const ENTITY = "ENTITY";
+const ENTITY = "ENTITY";
 export const SUMMABLE = "SUMMABLE";
 export const SCOPE = "SCOPE";
 export const CATEGORY = "CATEGORY";
-export const DIMENSION = "DIMENSION";
+const DIMENSION = "DIMENSION";
 
 export const UNKNOWN = "UNKNOWN";
 

--- a/frontend/src/metabase-lib/types/utils/isa.js
+++ b/frontend/src/metabase-lib/types/utils/isa.js
@@ -150,8 +150,6 @@ export const isNumber = field =>
   isNumericBaseType(field) &&
   (field.semantic_type == null || isa(field.semantic_type, TYPE.Number));
 
-export const isBinnedNumber = field => isNumber(field) && !!field.binning_info;
-
 export const isTime = field => {
   if (!field) {
     return false;


### PR DESCRIPTION
Remove dead code in MLv1. Less code in MLv1, less stuff to worry about porting.

This removes about 1% of the total LoC currently in metabase-lib (source and tests). That's not nothing!

There is a lot of duplicate code in MLv1, and a lot of it is apparently unused. Not even used in tests! Remove dead code not used in tests = improved test coverage 😉 

I did several passes with [knip](https://github.com/webpro/knip) and ESLint to find exports that weren't used anywhere, un-export them, then find out they weren't used **at all**, and remove them entirely, then rinse and repeat as more stuff that was only used by those unused exports became unused.

There are more probably more things we can remove, e.g. there is some stuff that is definitely only used in tests, and some class methods that Knip reports are unused but I'm not really sure about