### PR TITLE
fix color range for null values in table

### DIFF
--- a/frontend/src/metabase/visualizations/lib/table_format.js
+++ b/frontend/src/metabase/visualizations/lib/table_format.js
@@ -156,16 +156,16 @@ export function compileFormatter(
 
 // NOTE: implement `extent` like this rather than using d3.extent since rows may
 // be a Java `List` rather than a JavaScript Array when used in Pulse formatting
-function extent(rows, colIndex) {
+export function extent(rows, colIndex) {
   let min = Infinity;
   let max = -Infinity;
   const length = rows.length;
   for (let i = 0; i < length; i++) {
     const value = rows[i][colIndex];
-    if (value < min) {
+    if (value != null && value < min) {
       min = value;
     }
-    if (value > max) {
+    if (value != null && value > max) {
       max = value;
     }
   }

--- a/frontend/test/metabase/visualizations/lib/table_format.unit.spec.js
+++ b/frontend/test/metabase/visualizations/lib/table_format.unit.spec.js
@@ -3,6 +3,7 @@ import {
   canCompareSubstrings,
   OPERATOR_FORMATTER_FACTORIES,
   compileFormatter,
+  extent,
 } from "metabase/visualizations/lib/table_format";
 
 describe("compileFormatter", () => {
@@ -137,5 +138,11 @@ describe("canCompareSubstrings", () => {
     expect(canCompareSubstrings("", "foo")).toBe(false);
     expect(canCompareSubstrings("foo", "")).toBe(false);
     expect(canCompareSubstrings("", "")).toBe(false);
+  });
+});
+
+describe("extent", () => {
+  it("should ignore null and undefined values", () => {
+    expect(extent([[null], [1], [undefined]], 0)).toEqual([1, 1]);
   });
 });

--- a/frontend/test/metabase/visualizations/lib/table_format.unit.spec.js
+++ b/frontend/test/metabase/visualizations/lib/table_format.unit.spec.js
@@ -142,6 +142,18 @@ describe("canCompareSubstrings", () => {
 });
 
 describe("extent", () => {
+  it("should correctly compute the extents for each column", () => {
+    const rows = [
+      [-12, 4, 8],
+      [0, -3, 2],
+      [-1, 0, 17],
+    ];
+
+    expect(extent(rows, 0)).toEqual([-12, 0]);
+    expect(extent(rows, 1)).toEqual([-3, 4]);
+    expect(extent(rows, 2)).toEqual([2, 17]);
+  });
+
   it("should ignore null and undefined values", () => {
     expect(extent([[null], [1], [undefined]], 0)).toEqual([1, 1]);
   });


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/11875

### Description

When visualizing a table with a color range conditional formatting rule, if the column on which the rule was applied on had null values, the style would not apply and no cells would be colored.

The root cause of the issue was that the [`min` value passed to `getColorScale` in the `compileFormatter` function of `table_format.js`](https://github.com/metabase/metabase/blob/29463626a2ddafa01946770ba7a7126586461d90/frontend/src/metabase/visualizations/lib/table_format.js#L122) was equal to `null` when `null` values were present in the column. My solution was to fix the [`extent`](https://github.com/metabase/metabase/blob/29463626a2ddafa01946770ba7a7126586461d90/frontend/src/metabase/visualizations/lib/table_format.js#L159) method to not use a `null` value when computing extents.

Now, `null` values will be colored as if they are equal to the minimum value in the range.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. New -> SQL Query
2. Paste the following query (taken from issue comments)

```sql
SELECT '0-1' AS "g", parsedatetime('2019-12-11', 'yyyy-MM-dd') AS "d", 17 AS "c" UNION ALL
SELECT '2-3' AS "g", parsedatetime('2019-12-11', 'yyyy-MM-dd') AS "d", 17 AS "c" UNION ALL
SELECT '4-5' AS "g", parsedatetime('2019-12-11', 'yyyy-MM-dd') AS "d", 15 AS "c" UNION ALL
SELECT '6-7' AS "g", parsedatetime('2019-12-11', 'yyyy-MM-dd') AS "d", 2 AS "c" UNION ALL
SELECT '8-9' AS "g", parsedatetime('2019-12-11', 'yyyy-MM-dd') AS "d", 15 AS "c" UNION ALL
SELECT '0-1' AS "g", parsedatetime('2019-12-12', 'yyyy-MM-dd') AS "d", null AS "c" UNION ALL
SELECT '2-3' AS "g", parsedatetime('2019-12-12', 'yyyy-MM-dd') AS "d", 13 AS "c" UNION ALL
SELECT '4-5' AS "g", parsedatetime('2019-12-12', 'yyyy-MM-dd') AS "d", 11 AS "c" UNION ALL
SELECT '6-7' AS "g", parsedatetime('2019-12-12', 'yyyy-MM-dd') AS "d", 1 AS "c" UNION ALL
SELECT '8-9' AS "g", parsedatetime('2019-12-12', 'yyyy-MM-dd') AS "d", 16 AS "c" UNION ALL
SELECT '0-1' AS "g", parsedatetime('2019-12-13', 'yyyy-MM-dd') AS "d", null AS "c" UNION ALL
SELECT '2-3' AS "g", parsedatetime('2019-12-13', 'yyyy-MM-dd') AS "d", null AS "c" UNION ALL
SELECT '4-5' AS "g", parsedatetime('2019-12-13', 'yyyy-MM-dd') AS "d", 14 AS "c" UNION ALL
SELECT '6-7' AS "g", parsedatetime('2019-12-13', 'yyyy-MM-dd') AS "d", 17 AS "c" UNION ALL
SELECT '8-9' AS "g", parsedatetime('2019-12-13', 'yyyy-MM-dd') AS "d", 5 AS "c" UNION ALL
SELECT '0-1' AS "g", parsedatetime('2019-12-14', 'yyyy-MM-dd') AS "d", null AS "c" UNION ALL
SELECT '2-3' AS "g", parsedatetime('2019-12-14', 'yyyy-MM-dd') AS "d", null AS "c" UNION ALL
SELECT '4-5' AS "g", parsedatetime('2019-12-14', 'yyyy-MM-dd') AS "d", null AS "c" UNION ALL
SELECT '6-7' AS "g", parsedatetime('2019-12-14', 'yyyy-MM-dd') AS "d", 8 AS "c" UNION ALL
SELECT '8-9' AS "g", parsedatetime('2019-12-14', 'yyyy-MM-dd') AS "d", 17 AS "c" UNION ALL
SELECT '0-1' AS "g", parsedatetime('2019-12-15', 'yyyy-MM-dd') AS "d", null AS "c" UNION ALL
SELECT '2-3' AS "g", parsedatetime('2019-12-15', 'yyyy-MM-dd') AS "d", null AS "c" UNION ALL
SELECT '4-5' AS "g", parsedatetime('2019-12-15', 'yyyy-MM-dd') AS "d", null AS "c" UNION ALL
SELECT '6-7' AS "g", parsedatetime('2019-12-15', 'yyyy-MM-dd') AS "d", null AS "c" UNION ALL
SELECT '8-9' AS "g", parsedatetime('2019-12-15', 'yyyy-MM-dd') AS "d", 14 AS "c"
```
3. Visualization settings -> Conditional formatting -> Which columns should be affected? c -> Formatting style color range
4. Confirm cells in c column are colored, ones with null values are colored as if they have min value

### Demo

<img width="1076" alt="Screenshot 2023-03-21 at 12 14 01 PM" src="https://user-images.githubusercontent.com/37751258/226716752-a1bbce75-ec94-47ba-8194-d81eb143937e.png">

Before

<img width="1079" alt="Screenshot 2023-03-21 at 12 10 58 PM" src="https://user-images.githubusercontent.com/37751258/226716785-dc02976e-7d93-4333-9e0d-4316fbbdd1c6.png">

After

### Checklist

- ✅ Tests have been added/updated to cover changes in this PR
