### PR TITLE
fix pie chart legend not fading on hover

### DIFF
--- a/e2e/test/scenarios/visualizations/pie_chart.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/pie_chart.cy.spec.js
@@ -38,11 +38,11 @@ describe("scenarios > visualizations > pie chart", () => {
 
     cy.findByTestId("chart-legend").findByText("Doohickey").realHover();
     [
-      ["Doohickey", 1],
-      ["Gadget", 0.4],
-      ["Gizmo", 0.4],
-      ["Widget", 0.4],
-    ].map(args => checkLegendItemOpacity(args[0], args[1]));
+      ["Doohickey", "true"],
+      ["Gadget", "false"],
+      ["Gizmo", "false"],
+      ["Widget", "false"],
+    ].map(args => checkLegendItemAriaCurrent(args[0], args[1]));
   });
 });
 
@@ -62,9 +62,8 @@ function ensurePieChartRendered(rows, totalValue) {
   });
 }
 
-function checkLegendItemOpacity(title, opacity) {
+function checkLegendItemAriaCurrent(title, value) {
   cy.findByTestId("chart-legend")
     .findByTestId(`legend-item-${title}`)
-    .should("have.attr", "style")
-    .and("include", `opacity: ${opacity}`);
+    .should("have.attr", "aria-current", value);
 }

--- a/e2e/test/scenarios/visualizations/pie_chart.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/pie_chart.cy.spec.js
@@ -29,6 +29,21 @@ describe("scenarios > visualizations > pie chart", () => {
 
     ensurePieChartRendered(["Doohickey", "Gadget", "Gizmo", "Widget"], 200);
   });
+
+  it("should mute items in legend when hovering (metabase#29224)", () => {
+    visitQuestionAdhoc({
+      dataset_query: testQuery,
+      display: "pie",
+    });
+
+    cy.findByTestId("chart-legend").findByText("Doohickey").realHover();
+    [
+      ["Doohickey", 1],
+      ["Gadget", 0.4],
+      ["Gizmo", 0.4],
+      ["Widget", 0.4],
+    ].map(args => checkLegendItemOpacity(args[0], args[1]));
+  });
 });
 
 function ensurePieChartRendered(rows, totalValue) {
@@ -45,4 +60,11 @@ function ensurePieChartRendered(rows, totalValue) {
       cy.get(".LegendItem").contains(name).should("be.visible");
     });
   });
+}
+
+function checkLegendItemOpacity(title, opacity) {
+  cy.findByTestId("chart-legend")
+    .findByTestId(`legend-item-${title}`)
+    .should("have.attr", "style")
+    .and("include", `opacity: ${opacity}`);
 }

--- a/frontend/src/metabase/visualizations/components/LegendHorizontal.jsx
+++ b/frontend/src/metabase/visualizations/components/LegendHorizontal.jsx
@@ -12,29 +12,35 @@ export default class LegendHorizontal extends Component {
     const { className, titles, colors, hovered, onHoverChange } = this.props;
     return (
       <ol className={cx(className, styles.Legend, styles.horizontal)}>
-        {titles.map((title, index) => (
-          <li key={index}>
-            <LegendItem
-              ref={this["legendItem" + index]}
-              title={title}
-              color={colors[index % colors.length]}
-              isMuted={
-                hovered && hovered.index != null && index !== hovered.index
-              }
-              showTooltip={false}
-              onMouseEnter={() =>
-                onHoverChange &&
-                onHoverChange({
-                  index,
-                  element: ReactDOM.findDOMNode(
-                    this.refs["legendItem" + index],
-                  ),
-                })
-              }
-              onMouseLeave={() => onHoverChange && onHoverChange(null)}
-            />
-          </li>
-        ))}
+        {titles.map((title, index) => {
+          const isMuted =
+            hovered && hovered.index != null && index !== hovered.index;
+          return (
+            <li
+              key={index}
+              data-testid={`legend-item-${title}`}
+              {...(hovered && { "aria-current": !isMuted })}
+            >
+              <LegendItem
+                ref={this["legendItem" + index]}
+                title={title}
+                color={colors[index % colors.length]}
+                isMuted={isMuted}
+                showTooltip={false}
+                onMouseEnter={() =>
+                  onHoverChange &&
+                  onHoverChange({
+                    index,
+                    element: ReactDOM.findDOMNode(
+                      this.refs["legendItem" + index],
+                    ),
+                  })
+                }
+                onMouseLeave={() => onHoverChange && onHoverChange(null)}
+              />
+            </li>
+          );
+        })}
       </ol>
     );
   }

--- a/frontend/src/metabase/visualizations/components/LegendItem.jsx
+++ b/frontend/src/metabase/visualizations/components/LegendItem.jsx
@@ -64,7 +64,6 @@ export default class LegendItem extends Component {
         onMouseEnter={onMouseEnter}
         onMouseLeave={onMouseLeave}
         onClick={onClick}
-        data-testid={`legend-item-${title}`}
       >
         {icon && (
           <IconContainer>

--- a/frontend/src/metabase/visualizations/components/LegendItem.jsx
+++ b/frontend/src/metabase/visualizations/components/LegendItem.jsx
@@ -53,14 +53,18 @@ export default class LegendItem extends Component {
           "no-decoration flex align-center fullscreen-normal-text fullscreen-night-text",
           {
             mr1: showTitle,
-            muted: isMuted,
             "cursor-pointer": onClick,
           },
         )}
-        style={{ overflowX: "hidden", flex: "0 1 auto" }}
+        style={{
+          overflowX: "hidden",
+          flex: "0 1 auto",
+          opacity: isMuted ? 0.4 : 1,
+        }}
         onMouseEnter={onMouseEnter}
         onMouseLeave={onMouseLeave}
         onClick={onClick}
+        data-testid={`legend-item-${title}`}
       >
         {icon && (
           <IconContainer>

--- a/frontend/src/metabase/visualizations/components/LegendVertical.jsx
+++ b/frontend/src/metabase/visualizations/components/LegendVertical.jsx
@@ -68,7 +68,7 @@ export default class LegendVertical extends Component {
         {items.map((title, index) => {
           const isMuted =
             hovered && hovered.index != null && index !== hovered.index;
-          title = Array.isArray(title) ? title[0] : title;
+          const legendItemTitle = Array.isArray(title) ? title[0] : title;
           return (
             <li
               key={index}
@@ -84,12 +84,12 @@ export default class LegendVertical extends Component {
                 })
               }
               onMouseLeave={e => onHoverChange && onHoverChange()}
-              data-testid={`legend-item-${title}`}
+              data-testid={`legend-item-${legendItemTitle}`}
               {...(hovered && { "aria-current": !isMuted })}
             >
               <LegendItem
                 ref={"legendItem" + index}
-                title={title}
+                title={legendItemTitle}
                 color={colors[index % colors.length]}
                 isMuted={isMuted}
                 showTooltip={false}

--- a/frontend/src/metabase/visualizations/components/LegendVertical.jsx
+++ b/frontend/src/metabase/visualizations/components/LegendVertical.jsx
@@ -68,6 +68,7 @@ export default class LegendVertical extends Component {
         {items.map((title, index) => {
           const isMuted =
             hovered && hovered.index != null && index !== hovered.index;
+          title = Array.isArray(title) ? title[0] : title;
           return (
             <li
               key={index}
@@ -83,10 +84,12 @@ export default class LegendVertical extends Component {
                 })
               }
               onMouseLeave={e => onHoverChange && onHoverChange()}
+              data-testid={`legend-item-${title}`}
+              {...(hovered && { "aria-current": !isMuted })}
             >
               <LegendItem
                 ref={"legendItem" + index}
-                title={Array.isArray(title) ? title[0] : title}
+                title={title}
                 color={colors[index % colors.length]}
                 isMuted={isMuted}
                 showTooltip={false}

--- a/frontend/src/metabase/visualizations/components/LegendVertical.jsx
+++ b/frontend/src/metabase/visualizations/components/LegendVertical.jsx
@@ -65,41 +65,43 @@ export default class LegendVertical extends Component {
     }
     return (
       <ol className={cx(className, styles.Legend, styles.vertical)}>
-        {items.map((title, index) => (
-          <li
-            key={index}
-            ref={"item" + index}
-            className="flex flex-no-shrink"
-            onMouseEnter={e =>
-              onHoverChange &&
-              onHoverChange({
-                index,
-                element: ReactDOM.findDOMNode(this.refs["legendItem" + index]),
-              })
-            }
-            onMouseLeave={e => onHoverChange && onHoverChange()}
-          >
-            <LegendItem
-              ref={"legendItem" + index}
-              title={Array.isArray(title) ? title[0] : title}
-              color={colors[index % colors.length]}
-              isMuted={
-                hovered && hovered.index != null && index !== hovered.index
+        {items.map((title, index) => {
+          const isMuted =
+            hovered && hovered.index != null && index !== hovered.index;
+          return (
+            <li
+              key={index}
+              ref={"item" + index}
+              className="flex flex-no-shrink"
+              onMouseEnter={e =>
+                onHoverChange &&
+                onHoverChange({
+                  index,
+                  element: ReactDOM.findDOMNode(
+                    this.refs["legendItem" + index],
+                  ),
+                })
               }
-              showTooltip={false}
-            />
-            {Array.isArray(title) && (
-              <span
-                className={cx("LegendItem", "flex-align-right pl1", {
-                  muted:
-                    hovered && hovered.index != null && index !== hovered.index,
-                })}
-              >
-                {title[1]}
-              </span>
-            )}
-          </li>
-        ))}
+              onMouseLeave={e => onHoverChange && onHoverChange()}
+            >
+              <LegendItem
+                ref={"legendItem" + index}
+                title={Array.isArray(title) ? title[0] : title}
+                color={colors[index % colors.length]}
+                isMuted={isMuted}
+                showTooltip={false}
+              />
+              {Array.isArray(title) && (
+                <span
+                  className={cx("LegendItem", "flex-align-right pl1")}
+                  style={{ opacity: isMuted ? 0.4 : 1 }}
+                >
+                  {title[1]}
+                </span>
+              )}
+            </li>
+          );
+        })}
         {overflowCount > 0 ? (
           <li key="extra" className="flex flex-no-shrink">
             <Tooltip


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/29224

### Description

The items in the legend for the pie chart were not fading when one was being hovered.

For some reason the style defined in `Legend.css` was not applying, so I replaced the class name in favor of just defining the style inline. I also had to add the style to the `span` that contains the percentage value in the legend.

### How to verify

1. Add a pie chart to a dashboard
2. Make card wide (to test `LegendVertical` compoonent) -> hover over legend items -> confirm fading
3. Make card tall (to test `LegendHorizontal`) -> hover over legend items -> confirm fading

### Demo

https://user-images.githubusercontent.com/37751258/226741507-14828eb0-570c-4f03-8ddd-bf2e8d1c2151.mov

Before

https://user-images.githubusercontent.com/37751258/226741676-f30b9055-11fd-44d9-a5ff-eba14158ee67.mov

After


### Checklist

- ✅ Tests have been added/updated to cover changes in this PR
