### PR TITLE
[MLv2] Fix `mu/defn` in CLJS

### DIFF
--- a/.clj-kondo/macros/metabase/domain_entities/malli.clj
+++ b/.clj-kondo/macros/metabase/domain_entities/malli.clj
@@ -5,6 +5,12 @@
      (comment ~schema) ;; Reference the schema
      ~@(for [[sym _path] (partition 2 defs)]
          `(do
-            (defn ~sym "docs" [_x#] nil)
-            (defn ~(symbol (str "with-" (name sym))) "docs" [x# _new#] x#)
-            (defn ~(symbol (str (name sym) "-js")) "docs" [x#] x#)))))
+            (defn ~(vary-meta sym
+                              assoc :export true)
+              "docs" [_x#] nil)
+            (defn ~(vary-meta (symbol (str "with-" (name sym)))
+                              assoc :export true)
+              "docs" [x# _new#] x#)
+            (defn ~(vary-meta (symbol (str (name sym) "-js"))
+                              assoc :export true)
+              "docs" [x#] x#)))))

--- a/src/metabase/domain_entities/malli.clj
+++ b/src/metabase/domain_entities/malli.clj
@@ -2,18 +2,7 @@
   (:refer-clojure :exclude [defn])
   (:require
     [malli.instrument]
-    [metabase.util.malli :as mu]
     [net.cgrand.macrovich :as macros]))
-
-(defmacro defn
-  "In Clojure this is simply [[mu/defn]].
-
-  That breaks CLJS advanced compilation since it returns a `let` and not a `defn`.
-  So in CLJS this is just [[clojure.core/defn]]."
-  [sym _ return-schema docs args & body]
-  (macros/case
-    :clj  `(mu/defn ~sym :- ~return-schema ~docs ~args ~@body)
-    :cljs `(clojure.core/defn ~sym ~docs ~(mapv first (partition 3 args)) ~@body)))
 
 (defmacro -define-getter
   "Generates an accessor, given the symbol and path to the value."

--- a/src/metabase/domain_entities/queries/util.cljc
+++ b/src/metabase/domain_entities/queries/util.cljc
@@ -1,7 +1,7 @@
 (ns metabase.domain-entities.queries.util
   "Utility functions used by the Queries in metabase-lib."
   (:require
-   [metabase.domain-entities.malli :as de]
+   [metabase.util.malli :as mu]
    #?@(:cljs ([metabase.domain-entities.converters :as converters]))))
 
 (def Expression
@@ -24,7 +24,7 @@
   #?(:cljs (converters/outgoing ExpressionList)
      :clj  identity))
 
-(de/defn ^:export expressions-list :- ExpressionList
+(mu/defn ^:export expressions-list :- ExpressionList
   "Turns a map of expressions by name into a list of `{:name name :expression expression}` objects."
   [expressions :- ExpressionMap]
   (->> expressions
@@ -38,7 +38,7 @@
       (recur names original-name (inc index))
       indexed-name)))
 
-(de/defn ^:export unique-expression-name :- string?
+(mu/defn ^:export unique-expression-name :- string?
   "Generates an expression name that's unique in the given map of expressions."
   [expressions   :- ExpressionMap
    original-name :- string?]

--- a/src/metabase/util/malli.cljc
+++ b/src/metabase/util/malli.cljc
@@ -13,6 +13,7 @@
               [malli.experimental :as mx]
               [malli.instrument :as minst]
               [metabase.util.i18n :as i18n]
+              [net.cgrand.macrovich :as macros]
               [ring.util.codec :as codec])))
   #?(:cljs (:require-macros [metabase.util.malli])))
 
@@ -73,7 +74,7 @@
      [_id]))
 
 #?(:clj
-   (core/defn- -defn [schema args]
+   (core/defn- -defn [target schema args]
      (let [{:keys [name return doc meta arities] :as parsed} (mc/parse schema args)
            _ (when (= ::mc/invalid parsed) (mc/-fail! ::parse-error {:schema schema, :args args}))
            parse (fn [{:keys [args] :as parsed}] (merge (malli.destructure/parse args) parsed))
@@ -92,27 +93,36 @@
                                                             "\n"
                                                             (str "\n          "))
                                 (when (not-empty doc) (str "\n\n  " doc))))
-           id (str (gensym "id"))]
-       `(let [defn# (core/defn
-                      ~name
-                      ~@(some-> annotated-doc vector)
-                      ~(assoc meta
-                              :raw-arglists (list 'quote raw-arglists)
-                              :schema schema
-                              :validate! id)
-                      ~@(map (fn [{:keys [arglist prepost body]}] `(~arglist ~prepost ~@body)) parglists)
-                      ~@(when-not single (some->> arities val :meta vector)))]
-          (mc/=> ~name ~schema)
-          ;; instrument the defn we just registered, via ~id
-          (instrument! ~id)
-          defn#))))
+           id (str (gensym "id"))
+           inner-defn `(core/defn
+                         ~name
+                         ~@(some-> annotated-doc vector)
+                         ~(assoc meta
+                                 :raw-arglists (list 'quote raw-arglists)
+                                 :schema schema
+                                 :validate! id)
+                         ~@(map (fn [{:keys [arglist prepost body]}] `(~arglist ~prepost ~@body)) parglists)
+                         ~@(when-not single (some->> arities val :meta vector)))]
+       (case target
+         :clj  `(let [defn# ~inner-defn]
+                  (mc/=> ~name ~schema)
+                  ;; instrument the defn we just registered, via ~id
+                  (instrument! ~id)
+                  defn#)
+         ;; Vars aren't real in CLJS, so wrapping the inner `defn` in a `let` doesn't work like in does in CLJ.
+         ;; In CLJS `mu/defn` is just `cljs.core/defn` with some extra metadata and augmented docstring;
+         ;; [[mc/=>]] is not called, nor is [[instrument!]].
+         :cljs inner-defn))))
 
 #?(:clj
    (defmacro defn
      "Like s/defn, but for malli. Will always validate input and output without the need for calls to instrumentation (they are emitted automatically).
      Calls to minst/unstrument! can remove this, so use a filter that avoids :validate! if you use that."
      [& args]
-     (-defn mx/SchematizedParams args)))
+     ;; [[macros/case]] only works properly in a `defmacro`, not in a helper function called by a `defmacro`.
+     ;; So we use it here and pass :clj or :cljs to [[-defn]].
+     (-defn (macros/case :clj :clj :cljs :cljs)
+            mx/SchematizedParams args)))
 
 (def ^:private Schema
   [:and any?


### PR DESCRIPTION
It's broken there because it tries to capture the Var returned by
`defn` in a `let`. Vars aren't real in CLJS, so this doesn't work.
The compile succeeds but the JS output is subtly broken.

