### PR TITLE
Separate date from datetime binning options

### DIFF
--- a/src/metabase/api/table.clj
+++ b/src/metabase/api/table.clj
@@ -135,6 +135,43 @@
 (def ^:private hour-str (deferred-tru "Hour"))
 (def ^:private day-str (deferred-tru "Day"))
 
+
+;; note the order of these options corresponds to the order they will be shown to the user in the UI
+(def ^:private time-options
+  [[minute-str "minute"]
+   [hour-str "hour"]
+   [(deferred-tru "Minute of Hour") "minute-of-hour"]])
+
+(def ^:private datetime-options
+  [[minute-str "minute"]
+   [hour-str "hour"]
+   [day-str "day"]
+   [(deferred-tru "Week") "week"]
+   [(deferred-tru "Month") "month"]
+   [(deferred-tru "Quarter") "quarter"]
+   [(deferred-tru "Year") "year"]
+   [(deferred-tru "Minute of Hour") "minute-of-hour"]
+   [(deferred-tru "Hour of Day") "hour-of-day"]
+   [(deferred-tru "Day of Week") "day-of-week"]
+   [(deferred-tru "Day of Month") "day-of-month"]
+   [(deferred-tru "Day of Year") "day-of-year"]
+   [(deferred-tru "Week of Year") "week-of-year"]
+   [(deferred-tru "Month of Year") "month-of-year"]
+   [(deferred-tru "Quarter of Year") "quarter-of-year"]])
+
+(def ^:private date-options
+  [[day-str "day"]
+   [(deferred-tru "Week") "week"]
+   [(deferred-tru "Month") "month"]
+   [(deferred-tru "Quarter") "quarter"]
+   [(deferred-tru "Year") "year"]
+   [(deferred-tru "Day of Week") "day-of-week"]
+   [(deferred-tru "Day of Month") "day-of-month"]
+   [(deferred-tru "Day of Year") "day-of-year"]
+   [(deferred-tru "Week of Year") "week-of-year"]
+   [(deferred-tru "Month of Year") "month-of-year"]
+   [(deferred-tru "Quarter of Year") "quarter-of-year"]])
+
 (def ^:private dimension-options
   (let [default-entry [auto-bin-str ["default"]]]
     (zipmap (range)
@@ -142,51 +179,39 @@
              (map (fn [[name param]]
                     {:name name
                      :mbql [:field nil {:temporal-unit param}]
-                     :type "type/DateTime"})
-                  ;; note the order of these options corresponds to the order they will be shown to the user in the UI
-                  [[minute-str "minute"]
-                   [hour-str "hour"]
-                   [day-str "day"]
-                   [(deferred-tru "Week") "week"]
-                   [(deferred-tru "Month") "month"]
-                   [(deferred-tru "Quarter") "quarter"]
-                   [(deferred-tru "Year") "year"]
-                   [(deferred-tru "Minute of Hour") "minute-of-hour"]
-                   [(deferred-tru "Hour of Day") "hour-of-day"]
-                   [(deferred-tru "Day of Week") "day-of-week"]
-                   [(deferred-tru "Day of Month") "day-of-month"]
-                   [(deferred-tru "Day of Year") "day-of-year"]
-                   [(deferred-tru "Week of Year") "week-of-year"]
-                   [(deferred-tru "Month of Year") "month-of-year"]
-                   [(deferred-tru "Quarter of Year") "quarter-of-year"]])
+                     :type :type/Date})
+                  date-options)
              (map (fn [[name param]]
                     {:name name
                      :mbql [:field nil {:temporal-unit param}]
-                     :type "type/Time"})
-                  [[minute-str "minute"]
-                   [hour-str "hour"]
-                   [(deferred-tru "Minute of Hour") "minute-of-hour"]])
+                     :type :type/DateTime})
+                  datetime-options)
+             (map (fn [[name param]]
+                    {:name name
+                     :mbql [:field nil {:temporal-unit param}]
+                     :type :type/Time})
+                  time-options)
              (conj
               (mapv (fn [[name [strategy param]]]
                       {:name name
                        :mbql [:field nil {:binning (merge {:strategy strategy}
                                                           (when param
                                                             {strategy param}))}]
-                       :type "type/Number"})
+                       :type :type/Number})
                     [default-entry
                      [(deferred-tru "10 bins") ["num-bins" 10]]
                      [(deferred-tru "50 bins") ["num-bins" 50]]
                      [(deferred-tru "100 bins") ["num-bins" 100]]])
               {:name dont-bin-str
                :mbql nil
-               :type "type/Number"})
+               :type :type/Number})
              (conj
               (mapv (fn [[name [strategy param]]]
                       {:name name
                        :mbql [:field nil {:binning (merge {:strategy strategy}
                                                           (when param
                                                             {strategy param}))}]
-                       :type "type/Coordinate"})
+                       :type :type/Coordinate})
                     [default-entry
                      [(deferred-tru "Bin every 0.1 degrees") ["bin-width" 0.1]]
                      [(deferred-tru "Bin every 1 degree") ["bin-width" 1.0]]
@@ -194,7 +219,7 @@
                      [(deferred-tru "Bin every 20 degrees") ["bin-width" 20.0]]])
               {:name dont-bin-str
                :mbql nil
-               :type "type/Coordinate"})))))
+               :type :type/Coordinate})))))
 
 (def ^:private dimension-options-for-response
   (m/map-keys str dimension-options))
@@ -207,33 +232,40 @@
        (map str)))
 
 (def ^:private datetime-dimension-indexes
-  (create-dim-index-seq "type/DateTime"))
+  (create-dim-index-seq :type/DateTime))
 
 (def ^:private time-dimension-indexes
-  (create-dim-index-seq "type/Time"))
+  (create-dim-index-seq :type/Time))
+
+(def ^:private date-dimension-indexes
+  (create-dim-index-seq :type/Date))
 
 (def ^:private numeric-dimension-indexes
-  (create-dim-index-seq "type/Number"))
+  (create-dim-index-seq :type/Number))
 
 (def ^:private coordinate-dimension-indexes
-  (create-dim-index-seq "type/Coordinate"))
+  (create-dim-index-seq :type/Coordinate))
 
 (defn- dimension-index-for-type [dim-type pred]
-  (first (m/find-first (fn [[_k v]]
-                         (and (= dim-type (:type v))
-                              (pred v))) dimension-options-for-response)))
+  (let [dim' (keyword dim-type)]
+    (first (m/find-first (fn [[_k v]]
+                           (and (= dim' (:type v))
+                                (pred v))) dimension-options-for-response))))
+
+(def ^:private datetime-default-index
+  (dimension-index-for-type :type/DateTime #(= (str day-str) (str (:name %)))))
 
 (def ^:private date-default-index
-  (dimension-index-for-type "type/DateTime" #(= (str day-str) (str (:name %)))))
+  (dimension-index-for-type :type/Date #(= (str day-str) (str (:name %)))))
 
 (def ^:private time-default-index
-  (dimension-index-for-type "type/Time" #(= (str hour-str) (str (:name %)))))
+  (dimension-index-for-type :type/Time #(= (str hour-str) (str (:name %)))))
 
 (def ^:private numeric-default-index
-  (dimension-index-for-type "type/Number" #(.contains ^String (str (:name %)) (str auto-bin-str))))
+  (dimension-index-for-type :type/Number #(.contains ^String (str (:name %)) (str auto-bin-str))))
 
 (def ^:private coordinate-default-index
-  (dimension-index-for-type "type/Coordinate" #(.contains ^String (str (:name %)) (str auto-bin-str))))
+  (dimension-index-for-type :type/Coordinate #(.contains ^String (str (:name %)) (str auto-bin-str))))
 
 (defn- supports-numeric-binning? [driver]
   (and driver (driver/supports? driver :binning)))
@@ -244,8 +276,11 @@
                                        (types/field-is-type? :type/Time field)
                                        [time-default-index time-dimension-indexes]
 
+                                       (types/field-is-type? :type/Date field)
+                                       [date-default-index date-dimension-indexes]
+
                                        (types/temporal-field? field)
-                                       [date-default-index datetime-dimension-indexes]
+                                       [datetime-default-index datetime-dimension-indexes]
 
                                        (and min_value max_value
                                             (isa? semantic_type :type/Coordinate)

--- a/test/metabase/api/table_test.clj
+++ b/test/metabase/api/table_test.clj
@@ -764,8 +764,8 @@
                 field    (field-from-response response "date")]
             ;; some dbs don't have a date type and return a datetime
             (is (= (case (:effective_type field)
-                     "type/DateTime" @#'api.table/datetime-dimension-indexes
-                     "type/Date"     @#'api.table/date-dimension-indexes
+                     ("type/DateTime" "type/Instant") @#'api.table/datetime-dimension-indexes
+                     "type/Date"                      @#'api.table/date-dimension-indexes
                      (throw (ex-info "Invalid type for date field or field not found"
                                      {:expected-types #{"type/DateTime" "type/Date"}
                                       :found          (:effective_type field)


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/27362

The BE sends over binning indexes for each field and a top level map for how to interpret these keys.

```javascript
❯ http get http://localhost:3000/api/table/10658/query_metadata Cookie:$SESSION -pb
{
    "active": true,
    "caveats": null,
    "created_at": "2023-03-21T22:20:42.363169Z",
    "db": {
        "engine": "postgres",
        "features": [ "full-join", ... ],
        "id": 499,
        ...
    },
    "db_id": 499,
    "dimension_options": {
        "0": { "mbql": [ "field", null, { "temporal-unit": "day" } ],
               "name": "Day",
               "type": "type/Date"},
        "1": { "mbql": [ "field", null, { "temporal-unit": "week" } ],
               "name": "Week",
               "type": "type/Date" },
        "10": { "mbql": ["field", null, { "temporal-unit": "quarter-of-year"}],
                "name": "Quarter of Year",
                "type": "type/Date" },
        "11": { "mbql": [ "field", null, { "temporal-unit": "minute" } ],
                "name": "Minute",
                "type": "type/DateTime"},
        "12": { "mbql": [ "field", null, { "temporal-unit": "hour"}],
                "name": "Hour",
                "type": "type/DateTime"},
        ... // more options. They have a type, an id, and an mbql clause
    },
    "display_name": "Different Times",
    "entity_type": null,
    "fields": [{"name": "id",},
               {"name": "dt",
                "dimension_options": [
                    "11", "12", "13", "14", "15", "16", "17",
                    "18", "19", "20", "21", "22", "23", "24", "25"]
                "database_type": "timestamp",
                "effective_type": "type/DateTime",
               },
               {"name": "t",
                "dimension_options": [ "26", "27", "28" ],
                "effective_type": "type/Time",
                "database_type": "time"
               },
               {"name": "d",
                "database_type": "date",
                "dimension_options": [ "0", "1", "2", "3", "4", "5",
                                       "6", "7", "8", "9", "10" ],
                "effective_type": "type/Date",
        }
    ],
    "name": "different_times",
    ...
}
```

This PR adds some new types just for dates so that you don't get offered by group a date by hour or minute.

This adds new indexes to this list, which makes us wary that these indexes have leaked out and cannot be changed. But that is not the case. This is essentially compression on the response. When the FE saves a query, it does not include the index but uses the mbql query to insert the proper temporal-unit:

```clojure
;; a "date" field choosing the quarter option
{:type :query,
 :query {:source-table 5,
         :breakout [[:field 49 {:temporal-unit :quarter}]],
         :aggregation [[:count]]},
 :database 1}

;; the same query but binning by week
{:database 1,
 :query {:source-table 5,
         :breakout [[:field 49 {:temporal-unit :week}]],
         :aggregation [[:count]]},
 :type :query}
```

So the index is relative to just the editing session of the query, and the indexes do not have to be stable when we add new ones.

#### Before
![image](https://user-images.githubusercontent.com/6377293/226757642-96d5ca08-91fe-4b6d-9470-06cb70edefdc.png)

#### After
<img width="1218" alt="image" src="https://user-images.githubusercontent.com/6377293/226757710-8e218cc7-0b67-43c5-8598-184bfac61f20.png">

The four circled options (minute, hour, minute of hour, hour of day) are not offered as bins for dates, which of course lack a time component.

#### Queries that have invalid choices after migrating

The queries are broken so the option doesn't make sense from the start:
<img width="1159" alt="image" src="https://user-images.githubusercontent.com/6377293/226763772-0ea4d375-290b-46aa-a592-0f100c806e7f.png">


But the FE doesn't crash and populates the current (invalid) choice of hour and offers the correct list
<img width="1442" alt="image" src="https://user-images.githubusercontent.com/6377293/226763635-ea4ec88c-c831-4705-8e46-dc037558fafb.png">
