### PR TITLE
Fix broken link to configuring jetty documentation

### DIFF
--- a/docs/troubleshooting-guide/timeout.md
+++ b/docs/troubleshooting-guide/timeout.md
@@ -29,7 +29,7 @@ If you can’t solve your problem using the troubleshooting guides:
 - Search for [known bugs or limitations][known-issues].
 
 [app-engine-timeout]: https://cloud.google.com/appengine/articles/deadlineexceedederrors
-[configuring-jetty]: https://www.eclipse.org/jetty/documentation/current/configuring-connectors.html
+[configuring-jetty]: https://www.eclipse.org/jetty/documentation/current/index.html#configuring-connectors
 [discourse]: https://discourse.metabase.com/
 [ec2-troubleshooting]: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/TroubleshootingInstancesConnecting.html
 [elb-timeout]: https://aws.amazon.com/blogs/aws/elb-idle-timeout-control/


### PR DESCRIPTION
This link in our documentation now returns a 404:
https://www.eclipse.org/jetty/documentation/current/configuring-connectors.html

I've replaced it with a new link returns the same content, but in a different format:
https://www.eclipse.org/jetty/documentation/current/index.html#configuring-connectors

You can preview the content of the old link [here](https://archive.ph/on3qu), but from 2014. Some of the content is the same, so I assume the new link points to the updated version of the same documentation.