### PR TITLE
Remove "Turn model into a saved question" button

### DIFF
--- a/e2e/test/scenarios/models/models-metadata.cy.spec.js
+++ b/e2e/test/scenarios/models/models-metadata.cy.spec.js
@@ -83,27 +83,6 @@ describe("scenarios > models metadata", () => {
 
       cy.findByText("Subtotal");
     });
-
-    it("clears custom metadata when a model is turned back into a question", () => {
-      openQuestionActions();
-
-      cy.findByText("Edit metadata").click();
-
-      openColumnOptions("Subtotal");
-
-      renameColumn("Subtotal", "Pre-tax");
-      setColumnType("No special type", "Cost");
-      cy.button("Save changes").click();
-
-      openQuestionActions();
-      popover().within(() => {
-        cy.findByText("Turn back to saved question").click();
-      });
-
-      cy.wait("@dataset");
-
-      cy.findByText("Subtotal");
-    });
   });
 
   it("should edit native model metadata", () => {

--- a/e2e/test/scenarios/models/models.cy.spec.js
+++ b/e2e/test/scenarios/models/models.cy.spec.js
@@ -157,28 +157,6 @@ describe("scenarios > models", () => {
     assertIsQuestion();
   });
 
-  it("allows to turn a model back into a saved question", () => {
-    cy.request("PUT", "/api/card/1", { dataset: true });
-    cy.intercept("PUT", "/api/card/1").as("cardUpdate");
-    cy.visit("/model/1");
-
-    openQuestionActions();
-    popover().within(() => {
-      cy.findByText("Turn back to saved question").click();
-    });
-
-    cy.wait("@cardUpdate");
-
-    cy.findByText("This is a question now.");
-    openQuestionActions();
-    assertIsQuestion();
-
-    cy.findByText("Undo").click();
-    cy.wait("@cardUpdate");
-    openQuestionActions();
-    assertIsModel();
-  });
-
   it("shows 404 when opening a question with a /dataset URL", () => {
     cy.visit("/model/1");
     cy.findByText(/We're a little lost/i);

--- a/e2e/test/scenarios/organization/bookmarks-question.cy.spec.js
+++ b/e2e/test/scenarios/organization/bookmarks-question.cy.spec.js
@@ -41,8 +41,9 @@ describe("scenarios > question > bookmarks", () => {
     });
 
     // Convert back to question
-    openQuestionActions();
-    cy.findByText("Turn back to saved question").click();
+    cy.findByTestId("toast-undo").within(() => {
+      cy.button("Undo").click();
+    });
 
     navigationSidebar().within(() => {
       cy.icon("model").should("not.exist");

--- a/frontend/src/metabase/query_builder/actions/models.js
+++ b/frontend/src/metabase/query_builder/actions/models.js
@@ -60,19 +60,6 @@ export const turnQuestionIntoDataset = () => async (dispatch, getState) => {
   );
 };
 
-export const turnDatasetIntoQuestion = () => async (dispatch, getState) => {
-  const dataset = getQuestion(getState());
-  const question = dataset.setDataset(false);
-  await dispatch(apiUpdateQuestion(question, { rerunQuery: true }));
-
-  dispatch(
-    addUndo({
-      message: t`This is a question now.`,
-      actions: [apiUpdateQuestion(dataset)],
-    }),
-  );
-};
-
 export const SET_RESULTS_METADATA = "metabase/qb/SET_RESULTS_METADATA";
 export const setResultsMetadata = createAction(SET_RESULTS_METADATA);
 

--- a/frontend/src/metabase/query_builder/components/QuestionActions.tsx
+++ b/frontend/src/metabase/query_builder/components/QuestionActions.tsx
@@ -56,7 +56,6 @@ interface Props {
     mode: string,
     opt: { datasetEditorTab: string },
   ) => void;
-  turnDatasetIntoQuestion: () => void;
   onInfoClick: () => void;
   onModelPersistenceChange: () => void;
   isModerator: boolean;
@@ -70,7 +69,6 @@ const QuestionActions = ({
   onOpenModal,
   question,
   setQueryBuilderMode,
-  turnDatasetIntoQuestion,
   onInfoClick,
   onModelPersistenceChange,
   isModerator,
@@ -169,13 +167,6 @@ const QuestionActions = ({
         icon: "model",
         action: handleTurnToModel,
         testId: TURN_INTO_DATASET_TESTID,
-      });
-    }
-    if (isDataset) {
-      extraButtons.push({
-        title: t`Turn back to saved question`,
-        icon: "model_framed",
-        action: turnDatasetIntoQuestion,
       });
     }
   }

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
@@ -337,7 +337,6 @@ ViewTitleHeaderRightSide.propTypes = {
   onEditSummary: PropTypes.func,
   onCloseSummary: PropTypes.func,
   setQueryBuilderMode: PropTypes.func,
-  turnDatasetIntoQuestion: PropTypes.func,
   areFiltersExpanded: PropTypes.bool,
   onExpandFilters: PropTypes.func,
   onCollapseFilters: PropTypes.func,
@@ -373,7 +372,6 @@ function ViewTitleHeaderRightSide(props) {
     onEditSummary,
     onCloseSummary,
     setQueryBuilderMode,
-    turnDatasetIntoQuestion,
     areFiltersExpanded,
     onExpandFilters,
     onCollapseFilters,
@@ -487,7 +485,6 @@ function ViewTitleHeaderRightSide(props) {
           onOpenModal={onOpenModal}
           question={question}
           setQueryBuilderMode={setQueryBuilderMode}
-          turnDatasetIntoQuestion={turnDatasetIntoQuestion}
           onInfoClick={handleInfoClick}
           onModelPersistenceChange={onModelPersistenceChange}
         />

--- a/frontend/src/metabase/query_builder/components/view/sidebars/DatasetManagementSection/DatasetManagementSection.jsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/DatasetManagementSection/DatasetManagementSection.jsx
@@ -3,10 +3,7 @@ import PropTypes from "prop-types";
 import { connect } from "react-redux";
 import { t } from "ttag";
 
-import {
-  setQueryBuilderMode,
-  turnDatasetIntoQuestion,
-} from "metabase/query_builder/actions";
+import { setQueryBuilderMode } from "metabase/query_builder/actions";
 
 import { PLUGIN_MODERATION } from "metabase/plugins";
 import Question from "metabase-lib/Question";
@@ -22,20 +19,14 @@ import {
 
 const mapDispatchToProps = {
   setQueryBuilderMode,
-  turnDatasetIntoQuestion,
 };
 
 DatasetManagementSection.propTypes = {
   dataset: PropTypes.instanceOf(Question).isRequired,
   setQueryBuilderMode: PropTypes.func.isRequired,
-  turnDatasetIntoQuestion: PropTypes.func.isRequired,
 };
 
-function DatasetManagementSection({
-  dataset,
-  setQueryBuilderMode,
-  turnDatasetIntoQuestion,
-}) {
+function DatasetManagementSection({ dataset, setQueryBuilderMode }) {
   const onEditQueryDefinitionClick = () => {
     setQueryBuilderMode("dataset", {
       datasetEditorTab: "query",
@@ -65,10 +56,6 @@ function DatasetManagementSection({
             <DatasetMetadataStrengthIndicator dataset={dataset} />
           </MetadataIndicatorContainer>
         </Row>
-        <Button
-          icon="model_framed"
-          onClick={turnDatasetIntoQuestion}
-        >{t`Turn back into a saved question`}</Button>
         <PLUGIN_MODERATION.QuestionModerationSection
           question={dataset}
           VerifyButton={Button}


### PR DESCRIPTION
This button has been around for a few Metabase versions, and it doesn't seem to be valuable, really. Allowing models to be turned back into questions brings extra complexity for other features. This PR removes the button for good.

### How to verify

1. Open a model (`/model/:id` page)
2. Click the "ellipsis" icon in the top-right
3. Ensure there's no "Turn back into a saved question" button

### Demo

**Before**

<img width="1036" alt="before" src="https://user-images.githubusercontent.com/17258145/226933923-548abb74-1646-4fa6-a1d7-a57bd0d97bc7.png">

**After**

<img width="1036" alt="after" src="https://user-images.githubusercontent.com/17258145/226933944-048cf9b6-c603-495c-99a9-1673d434da77.png">

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/29435)
<!-- Reviewable:end -->
