### PR TITLE
Upgrading commons-fileupload/commons-fileupload to 1.5

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -48,6 +48,7 @@
   com.vladsch.flexmark/flexmark             {:mvn/version "0.64.0"}             ; Markdown parsing
   com.vladsch.flexmark/flexmark-ext-autolink
                                             {:mvn/version "0.64.0"}             ; Flexmark extension for auto-linking bare URLs
+  commons-fileupload/commons-fileupload     {:mvn/version "1.5"}                ; ring/ring-core 1.9.6 uses v1.4, but we want 1.5 due to a CVE. When we upgrade to the forthcoming ring/ring-core 1.10.0 we can remove this.
   commons-codec/commons-codec               {:mvn/version "1.15"}               ; Apache Commons -- useful codec util fns
   commons-io/commons-io                     {:mvn/version "2.11.0"}             ; Apache Commons -- useful IO util fns
   commons-net/commons-net                   {:mvn/version "3.9.0"}              ; Apache Commons -- useful network utils. Transitive dep of Snowplow, pinned due to CVE-2021-37533


### PR DESCRIPTION
Fixes #29439

This is a minor version bump that fixes a CVE. Assuming all tests pass, we are probably ok to merge.