### PR TITLE
do not update entities from search models

### DIFF
--- a/frontend/src/metabase/entities/search.js
+++ b/frontend/src/metabase/entities/search.js
@@ -3,8 +3,6 @@ import { createEntity } from "metabase/lib/entities";
 import { GET } from "metabase/lib/api";
 import { entityTypeForObject } from "metabase/lib/schema";
 
-import { ObjectUnionSchema } from "metabase/schema";
-
 import { canonicalCollectionId } from "metabase/collections/utils";
 
 import Actions from "./actions";
@@ -74,8 +72,6 @@ export default createEntity({
       }
     },
   },
-
-  schema: ObjectUnionSchema,
 
   // delegate to the actual object's entity wrapEntity
   wrapEntity(object, dispatch = null) {


### PR DESCRIPTION
# Checking CI

Related to https://github.com/metabase/metabase/issues/29378

### Description

The search endpoint may return partial models of entities like dashboards or actions which is reasonable. However, for some reason, we updated actual entities in our store with the search models which can lead to app crash like here https://github.com/metabase/metabase/issues/29378

### How to verify

Describe the steps to verify that the changes are working as expected.

1. New question -> Sample Dataset -> ...
2. ...

### Demo

_Upload a demo video or before/after screenshots if sensible or remove the section_

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
