### PR TITLE
Reproduce broken audit log #29456

### DIFF
--- a/e2e/test/scenarios/auditing/ad-hoc.cy.spec.js
+++ b/e2e/test/scenarios/auditing/ad-hoc.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore, describeEE, openNativeEditor } from "e2e/support/helpers";
+import { restore, describeEE, openNativeEditor, startNewQuestion } from "e2e/support/helpers";
 
 describeEE("audit > ad-hoc", () => {
   describe("native query", () => {
@@ -34,6 +34,43 @@ describeEE("audit > ad-hoc", () => {
       cy.get(".PageTitle").contains("Query");
       cy.findByText("Open in Metabase");
       cy.get(".ace_content").contains("SELECT 123");
+    });
+  });
+
+  describe("notebook query", () => {
+    beforeEach(() => {
+      cy.intercept('/api/dataset').as('dataset');
+
+      restore();
+
+      cy.log("Run ad hoc notebook query as normal user");
+      cy.signInAsNormalUser();
+      startNewQuestion();
+      cy.findByTextEnsureVisible("Sample Database").click();
+      cy.findByTextEnsureVisible("Orders").click();
+
+      cy.button('Visualize').click();
+
+      cy.wait('@dataset');
+      // Sign in as admin to be able to access audit logs in tests
+      cy.signInAsAdmin();
+    });
+
+    it.skip("should appear in audit log #29456", () => {
+      cy.visit("/admin/audit/members/log");
+
+      cy.findByText("GUI")
+        .parent()
+        .parent()
+        .within(() => {
+          cy.findByText("Ad-hoc").click();
+        });
+
+      cy.log("Assert that the query page is not blank");
+      cy.url().should("include", "/admin/audit/query/");
+
+      cy.get(".PageTitle").contains("Query");
+      cy.findByText("Open in Metabase");
     });
   });
 });


### PR DESCRIPTION
Reproduces https://github.com/metabase/metabase/issues/29456 and https://github.com/metabase/metabase/issues/28531

![testauditlog](https://user-images.githubusercontent.com/30528226/227015607-2eb9d413-f434-4a90-b86c-36bc27124d93.gif)

https://www.loom.com/share/e70a17838e27463e9508e651a8288328