### PR TITLE
Passing dashboard object to isEditing

### DIFF
--- a/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
@@ -535,6 +535,22 @@ describe("scenarios > dashboard", () => {
     cy.findAllByText("18,760").should("have.length", 2);
   });
 
+  it("should allow you to add questions using 'Add a saved question' button (metabase#29450)", () => {
+    cy.createDashboard({ name: "dash:29450" });
+
+    cy.visit("/collection/root");
+    // enter newly created dashboard
+    cy.findByText("dash:29450").click();
+
+    cy.findByText("Add a saved question").click();
+
+    sidebar().within(() => {
+      cy.findByText("Orders, Count").click();
+    });
+
+    saveDashboard();
+  });
+
   it("should show collection breadcrumbs for a dashboard", () => {
     visitDashboard(1);
     appbar().within(() => cy.findByText("Our analytics").click());

--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.jsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.jsx
@@ -205,7 +205,8 @@ class Dashboard extends Component {
   };
 
   onAddQuestion = () => {
-    this.setEditing(true);
+    const { dashboard } = this.props;
+    this.setEditing(dashboard);
     this.props.toggleSidebar(SIDEBAR_NAME.addQuestion);
   };
 


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/29450

### Description
We had an instance where we were passing `true` to `setEditingDashboard`, when it's actually expecting a dashboard object. This is because it compares `dashboard.ordered_cards.length` when saving. The fix replaces the boolean value with `this.props.dashboard`.

### How to verify

1. Create or navigate to an empty dashboard
2. Click on the text "Add an existing question"
3. Add a question and save. Dashboard should save without issue

### Checklist
- [x] Tests have been added/updated to cover changes in this PR
