### PR TITLE
Avoid changing H2 DB files when running tests

### DIFF
--- a/test/metabase/sample_data_test.clj
+++ b/test/metabase/sample_data_test.clj
@@ -20,10 +20,11 @@
 
 ;; These tools are pretty sophisticated for the amount of tests we have!
 
-(defn- sample-database-db []
-  ;; Open the DB in read-only mode so we don't accidentally modify it during testing
-  {:details (update (#'sample-data/try-to-extract-sample-database!)
-                    :db #(str % ";ACCESS_MODE_DATA=r"))
+(defn- sample-database-db [read-write?]
+  ;; If `read-write?` is false, open the DB in read-only mode so we don't accidentally modify it during testing
+  {:details (cond-> (#'sample-data/try-to-extract-sample-database!)
+              (not read-write?)
+              (update :db #(str % ";ACCESS_MODE_DATA=r")))
    :engine  :h2
    :name    "Sample Database"})
 
@@ -31,7 +32,7 @@
   "Execute `body` with a temporary Sample Database DB bound to `db-binding`."
   {:style/indent 1}
   [[db-binding] & body]
-  `(mt/with-temp Database [db# (sample-database-db)]
+  `(mt/with-temp Database [db# (sample-database-db false)]
      (sync/sync-database! db#)
      (let [~db-binding db#]
        ~@body)))
@@ -49,7 +50,7 @@
 
 ;;; ----------------------------------------------------- Tests ------------------------------------------------------
 
-(def ^:private extracted-db-path-regex #"^file:.*plugins/sample-database.db;USER=GUEST;PASSWORD=guest$")
+(def ^:private extracted-db-path-regex #"^file:.*plugins/sample-database.db;USER=GUEST;PASSWORD=guest.*")
 
 (deftest extract-sample-database-test
   (testing "The Sample Database is copied out of the JAR into the plugins directory before the DB details are saved."
@@ -106,7 +107,8 @@
 
 (deftest write-rows-sample-database-test
   (testing "should be able to execute INSERT, UPDATE, and DELETE statements on the Sample Database"
-    (with-temp-sample-database-db [db]
+    (mt/with-temp Database [db (sample-database-db true)]
+      (sync/sync-database! db)
       (mt/with-db db
         (let [conn-spec (sql-jdbc.conn/db->pooled-connection-spec (mt/db))]
           (testing "update row"

--- a/test/metabase/sample_data_test.clj
+++ b/test/metabase/sample_data_test.clj
@@ -21,7 +21,9 @@
 ;; These tools are pretty sophisticated for the amount of tests we have!
 
 (defn- sample-database-db []
-  {:details (#'sample-data/try-to-extract-sample-database!)
+  ;; Open the DB in read-only mode so we don't accidentally modify it during testing
+  {:details (update (#'sample-data/try-to-extract-sample-database!)
+                    :db #(str % ";ACCESS_MODE_DATA=r"))
    :engine  :h2
    :name    "Sample Database"})
 

--- a/test/metabase/util/ssh_test.clj
+++ b/test/metabase/util/ssh_test.clj
@@ -251,7 +251,8 @@
       (testing "ssh tunnel is reestablished if it becomes closed, so subsequent queries still succeed (H2 version)"
         (let [h2-port (tu/find-free-port)
               server  (init-h2-tcp-server h2-port)
-              uri     (format "tcp://localhost:%d/./test_resources/ssh/tiny-db;USER=GUEST;PASSWORD=guest" h2-port)
+              ; Use ACCESS_MODE_DATA=r to avoid updating the DB file
+              uri     (format "tcp://localhost:%d/./test_resources/ssh/tiny-db;USER=GUEST;PASSWORD=guest;ACCESS_MODE_DATA=r" h2-port)
               h2-db   {:port               h2-port
                        :host               "localhost"
                        :db                 uri


### PR DESCRIPTION
### The problem

Since [Allow actions to run on H2 and sample database](https://github.com/metabase/metabase/pull/28212#top), H2 DBs aren't set to read only on the connection. The connection URI used to include `ACCESS_MODE_DATA=r`, which would prevent changes to the DB file.

But now that we've removed this option, H2 DB files change whenever a statement is executed on them, even select statements. This is normally ok because we usually run queries against H2 databases that aren't tracked by git. 
But some tests update H2 DB files, so if you run the tests a couple of H2 DBs are changed from git's perspective:

<img width="521" alt="Screenshot 2023-03-23 at 11 28 59" src="https://user-images.githubusercontent.com/39073188/227172943-719d0e29-c40b-4a73-9481-43f3faee985f.png">

### The solution

This PR updates the test to include `ACCESS_MODE_DATA=r` in the connection strings for two H2 DBs that are tracked by git. That means actions won't work on them, but the DB files won't change. The downside of this approach is the tests can only do read-only queries, but so far that's the case.