### PR TITLE
Solve flakiness on FormCreator unit test

### DIFF
--- a/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/FormCreator.unit.spec.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/FormCreator.unit.spec.tsx
@@ -86,7 +86,6 @@ describe("actions > containers > ActionCreator > FormCreator", () => {
       formSettings,
     });
 
-    // click the settings cog then the number input type
     userEvent.click(
       screen.getByRole("radio", {
         name: /number/i,

--- a/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/FormCreator.unit.spec.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/FormCreator.unit.spec.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import type {
@@ -74,7 +74,7 @@ describe("actions > containers > ActionCreator > FormCreator", () => {
     expect(screen.getByRole("textbox")).toBeInTheDocument();
   });
 
-  it("can change a string field to a numeric field", async () => {
+  it("can change a string field to a numeric field", () => {
     const formSettings: ActionFormSettings = {
       type: "form",
       fields: {
@@ -87,19 +87,20 @@ describe("actions > containers > ActionCreator > FormCreator", () => {
     });
 
     // click the settings cog then the number input type
-    userEvent.click(await screen.findByLabelText("Field settings"));
-    userEvent.click(await screen.findByText("Number"));
+    userEvent.click(
+      screen.getByRole("radio", {
+        name: /number/i,
+      }),
+    );
 
-    await waitFor(() => {
-      expect(onChange).toHaveBeenCalledWith({
-        ...formSettings,
-        fields: {
-          "abc-123": makeFieldSettings({
-            fieldType: "number",
-            inputType: "number",
-          }),
-        },
-      });
+    expect(onChange).toHaveBeenCalledWith({
+      ...formSettings,
+      fields: {
+        "abc-123": makeFieldSettings({
+          fieldType: "number",
+          inputType: "number",
+        }),
+      },
     });
   });
 
@@ -117,23 +118,21 @@ describe("actions > containers > ActionCreator > FormCreator", () => {
     });
 
     // click the settings cog then the number input type
-    userEvent.click(await screen.findByLabelText("Field settings"));
+    userEvent.click(screen.getByLabelText("Field settings"));
     userEvent.click(await screen.findByText("Long text"));
 
-    await waitFor(() => {
-      expect(onChange).toHaveBeenCalledWith({
-        ...formSettings,
-        fields: {
-          "abc-123": makeFieldSettings({
-            fieldType: "string",
-            inputType: "text",
-          }),
-        },
-      });
+    expect(onChange).toHaveBeenCalledWith({
+      ...formSettings,
+      fields: {
+        "abc-123": makeFieldSettings({
+          fieldType: "string",
+          inputType: "text",
+        }),
+      },
     });
   });
 
-  it("can change a numeric field to a date field", async () => {
+  it("can change a numeric field to a date field", () => {
     const formSettings: ActionFormSettings = {
       type: "form",
       fields: {
@@ -146,19 +145,20 @@ describe("actions > containers > ActionCreator > FormCreator", () => {
       formSettings,
     });
 
-    userEvent.click(await screen.findByLabelText("Field settings"));
-    userEvent.click(await screen.findByText("Date"));
+    userEvent.click(
+      screen.getByRole("radio", {
+        name: /date/i,
+      }),
+    );
 
-    await waitFor(() => {
-      expect(onChange).toHaveBeenCalledWith({
-        ...formSettings,
-        fields: {
-          "abc-123": makeFieldSettings({
-            fieldType: "date",
-            inputType: "date",
-          }),
-        },
-      });
+    expect(onChange).toHaveBeenCalledWith({
+      ...formSettings,
+      fields: {
+        "abc-123": makeFieldSettings({
+          fieldType: "date",
+          inputType: "date",
+        }),
+      },
     });
   });
 
@@ -174,19 +174,20 @@ describe("actions > containers > ActionCreator > FormCreator", () => {
       formSettings,
     });
 
-    userEvent.click(await screen.findByLabelText("Field settings"));
-    userEvent.click(await screen.findByText("Number"));
+    userEvent.click(
+      screen.getByRole("radio", {
+        name: /number/i,
+      }),
+    );
 
-    await waitFor(() => {
-      expect(onChange).toHaveBeenCalledWith({
-        ...formSettings,
-        fields: {
-          "abc-123": makeFieldSettings({
-            fieldType: "number",
-            inputType: "number",
-          }),
-        },
-      });
+    expect(onChange).toHaveBeenCalledWith({
+      ...formSettings,
+      fields: {
+        "abc-123": makeFieldSettings({
+          fieldType: "number",
+          inputType: "number",
+        }),
+      },
     });
   });
 
@@ -202,23 +203,21 @@ describe("actions > containers > ActionCreator > FormCreator", () => {
       formSettings,
     });
 
-    userEvent.click(await screen.findByLabelText("Field settings"));
+    userEvent.click(screen.getByLabelText("Field settings"));
     userEvent.click(await screen.findByRole("switch"));
 
-    await waitFor(() => {
-      expect(onChange).toHaveBeenCalledWith({
-        ...formSettings,
-        fields: {
-          "abc-123": makeFieldSettings({
-            required: true,
-            inputType: "string",
-          }),
-        },
-      });
+    expect(onChange).toHaveBeenCalledWith({
+      ...formSettings,
+      fields: {
+        "abc-123": makeFieldSettings({
+          required: true,
+          inputType: "string",
+        }),
+      },
     });
   });
 
-  it("displays default values", async () => {
+  it("displays default values", () => {
     const defaultValue = "foo bar";
     const parameter = makeParameter();
     const fieldSettings = makeFieldSettings({
@@ -236,7 +235,7 @@ describe("actions > containers > ActionCreator > FormCreator", () => {
       },
     });
 
-    expect(await screen.findByLabelText(fieldSettings.title)).toHaveValue(
+    expect(screen.getByLabelText(fieldSettings.title)).toHaveValue(
       defaultValue,
     );
   });


### PR DESCRIPTION
### Description

`can change a numeric field to a date field` test failed [several times at CI](https://github.com/metabase/metabase/actions/runs/4494440656/jobs/7906936751) and this PR is an attempt to fix it

<img width="1008" alt="image" src="https://user-images.githubusercontent.com/125459446/227199716-7c3e88e9-f2be-4af4-8b95-3b3dfa05e817.png">

### How to verify

rely on CI

### Demo

only this link I recorded during investigation https://www.loom.com/share/91aedd3d6e374c139cd5cbfad2c298bc

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/29474)
<!-- Reviewable:end -->
