### PR TITLE
improve `ColorRangeSelector` ux

### DIFF
--- a/frontend/src/metabase/core/components/ColorRangeSelector/ColorRangePopover.tsx
+++ b/frontend/src/metabase/core/components/ColorRangeSelector/ColorRangePopover.tsx
@@ -44,29 +44,36 @@ const ColorSelectorContent = forwardRef(function ColorRangeSelector(
     return customColorMapping ?? getDefaultColorMapping(colors);
   }, [colors, customColorMapping]);
 
+  const [isInverted, setIsInverted] = useState(() =>
+    getDefaultIsInverted(initialValue, colorMapping),
+  );
+
   const [color, setColor] = useState(() =>
     getDefaultColor(initialValue, colors, colorMapping),
   );
 
   const [value, setValue] = useState(() =>
-    getColorRange(color, colorMapping, getInverted(initialValue, colorMapping)),
+    getColorRange(color, colorMapping, isInverted),
   );
 
-  const handleSelect = useCallback(
+  const handleColorSelect = useCallback(
     (newColor: string) => {
+      const newValue = getColorRange(newColor, colorMapping, isInverted);
+
       setColor(newColor);
-      setValue(getColorRange(newColor, colorMapping));
+      setValue(newValue);
+      onChange?.(newValue);
     },
-    [colorMapping],
+    [colorMapping, isInverted, onChange],
   );
 
-  const handleChange = useCallback(
-    (newValue: string[]) => {
-      onChange?.(newValue);
-      onClose?.();
-    },
-    [onChange, onClose],
-  );
+  const handleToggleInvertedClick = useCallback(() => {
+    const newValue = getColorRange(color, colorMapping, !isInverted);
+
+    setIsInverted(!isInverted);
+    setValue(newValue);
+    onChange?.(newValue);
+  }, [color, colorMapping, isInverted, onChange]);
 
   return (
     <PopoverRoot {...props} ref={ref}>
@@ -76,14 +83,14 @@ const ColorSelectorContent = forwardRef(function ColorRangeSelector(
             key={index}
             color={value}
             isSelected={value === color}
-            onSelect={handleSelect}
+            onSelect={handleColorSelect}
           />
         ))}
       </PopoverColorList>
       <ColorRangeToggle
         value={value}
         isQuantile={isQuantile}
-        onChange={handleChange}
+        onClick={handleToggleInvertedClick}
       />
       {colorRanges.length > 0 && <PopoverDivider />}
       <PopoverColorRangeList>
@@ -92,7 +99,7 @@ const ColorSelectorContent = forwardRef(function ColorRangeSelector(
             key={index}
             value={range}
             isQuantile={isQuantile}
-            onChange={handleChange}
+            onClick={handleToggleInvertedClick}
           />
         ))}
       </PopoverColorRangeList>
@@ -132,7 +139,7 @@ const getDefaultColorMapping = (colors: string[]) => {
   return Object.fromEntries(colors.map(color => [color, ["white", color]]));
 };
 
-const getInverted = (
+const getDefaultIsInverted = (
   value: string[],
   colorMapping: Record<string, string[]>,
 ) => {

--- a/frontend/src/metabase/core/components/ColorRangeSelector/ColorRangeSelector.tsx
+++ b/frontend/src/metabase/core/components/ColorRangeSelector/ColorRangeSelector.tsx
@@ -38,6 +38,7 @@ const ColorRangeSelector = forwardRef(function ColorRangeSelector(
           colors={value}
           isQuantile={isQuantile}
           onClick={onClick}
+          role="button"
         />
       )}
       popoverContent={({ closePopover }) => (

--- a/frontend/src/metabase/core/components/ColorRangeSelector/ColorRangeSelector.unit.spec.tsx
+++ b/frontend/src/metabase/core/components/ColorRangeSelector/ColorRangeSelector.unit.spec.tsx
@@ -1,0 +1,35 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+
+import { color } from "metabase/lib/colors";
+import ColorRangeSelector from "./ColorRangeSelector";
+
+const DEFAULT_VALUE = [color("white"), color("brand")];
+const DEFAULT_COLORS = [color("brand"), color("summarize"), color("filter")];
+
+interface TestColorRangeSelectorProps {
+  onChange: (newValue: string[]) => void;
+}
+
+function TestColorRangeSelector({ onChange }: TestColorRangeSelectorProps) {
+  return (
+    <ColorRangeSelector
+      value={DEFAULT_VALUE}
+      colors={DEFAULT_COLORS}
+      onChange={onChange}
+    />
+  );
+}
+
+describe("ColorRangeSelector", () => {
+  it("should call `onChange` upon clicking a color", async () => {
+    const onChange = jest.fn();
+    render(<TestColorRangeSelector onChange={onChange} />);
+
+    screen.getByRole("button").click();
+    expect(await screen.findByRole("tooltip")).toBeInTheDocument();
+
+    screen.getByLabelText(color("summarize")).click();
+    expect(onChange).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/metabase/core/components/ColorRangeSelector/ColorRangeSelector.unit.spec.tsx
+++ b/frontend/src/metabase/core/components/ColorRangeSelector/ColorRangeSelector.unit.spec.tsx
@@ -21,15 +21,24 @@ function TestColorRangeSelector({ onChange }: TestColorRangeSelectorProps) {
   );
 }
 
+function setup() {
+  const onChange = jest.fn();
+  render(<TestColorRangeSelector onChange={onChange} />);
+
+  return { onChange };
+}
+
 describe("ColorRangeSelector", () => {
   it("should call `onChange` upon clicking a color", async () => {
-    const onChange = jest.fn();
-    render(<TestColorRangeSelector onChange={onChange} />);
+    const { onChange } = setup();
 
     screen.getByRole("button").click();
     expect(await screen.findByRole("tooltip")).toBeInTheDocument();
 
     screen.getByLabelText(color("summarize")).click();
+    expect(onChange).toHaveBeenCalled();
+
+    screen.getByLabelText(color("filter")).click();
     expect(onChange).toHaveBeenCalled();
   });
 });

--- a/frontend/src/metabase/core/components/ColorRangeSelector/ColorRangeSelector.unit.spec.tsx
+++ b/frontend/src/metabase/core/components/ColorRangeSelector/ColorRangeSelector.unit.spec.tsx
@@ -7,23 +7,15 @@ import ColorRangeSelector from "./ColorRangeSelector";
 const DEFAULT_VALUE = [color("white"), color("brand")];
 const DEFAULT_COLORS = [color("brand"), color("summarize"), color("filter")];
 
-interface TestColorRangeSelectorProps {
-  onChange: (newValue: string[]) => void;
-}
-
-function TestColorRangeSelector({ onChange }: TestColorRangeSelectorProps) {
-  return (
+function setup() {
+  const onChange = jest.fn();
+  render(
     <ColorRangeSelector
       value={DEFAULT_VALUE}
       colors={DEFAULT_COLORS}
       onChange={onChange}
-    />
+    />,
   );
-}
-
-function setup() {
-  const onChange = jest.fn();
-  render(<TestColorRangeSelector onChange={onChange} />);
 
   return { onChange };
 }

--- a/frontend/src/metabase/core/components/ColorRangeSelector/ColorRangeToggle.styled.tsx
+++ b/frontend/src/metabase/core/components/ColorRangeSelector/ColorRangeToggle.styled.tsx
@@ -8,6 +8,7 @@ export const ToggleRoot = styled.div`
 
 export const ToggleColorRange = styled(ColorRange)`
   flex: 1 1 auto;
+  cursor: default;
 `;
 
 export const ToggleButton = styled(Button)`

--- a/frontend/src/metabase/core/components/ColorRangeSelector/ColorRangeToggle.tsx
+++ b/frontend/src/metabase/core/components/ColorRangeSelector/ColorRangeToggle.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useState } from "react";
+import React from "react";
 import {
   ToggleButton,
   ToggleColorRange,
@@ -8,32 +8,18 @@ import {
 export interface ColorRangeToggleProps {
   value: string[];
   isQuantile?: boolean;
-  onChange?: (newValue: string[]) => void;
+  onClick?: () => void;
 }
 
 const ColorRangeToggle = ({
   value,
   isQuantile,
-  onChange,
+  onClick,
 }: ColorRangeToggleProps) => {
-  const [isInverted, setIsInverted] = useState(false);
-
-  const displayValue = useMemo(() => {
-    return isInverted ? Array.from(value).reverse() : value;
-  }, [value, isInverted]);
-
-  const handleButtonClick = useCallback(() => {
-    setIsInverted(isInverted => !isInverted);
-  }, []);
-
   return (
     <ToggleRoot>
-      <ToggleColorRange
-        colors={displayValue}
-        isQuantile={isQuantile}
-        onSelect={onChange}
-      />
-      <ToggleButton icon="compare" small onClick={handleButtonClick} />
+      <ToggleColorRange colors={value} isQuantile={isQuantile} />
+      <ToggleButton icon="compare" small onClick={onClick} />
     </ToggleRoot>
   );
 };


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/27278

### Description

Some users pointed out that the behavior for our color picker was unintuitive, as you had to  click on the color range preview after selecting the new color for the change to actually take affect.

This PR changes the behavior to be be user friendly. Instead of having to click twice, clicking on the new color will immediately change the selected color value to it. Additional, the popover now no longer closes after making the selection, so the user can continue to browse and try out different colors.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. New question -> People -> Count by State
2. Visualization -> Map -> settings -> click on color bar
3. Clicking on a different color should immediately change the selection to it
4. Clicking on the invert button (dual arrows icon) should immediately invert the selection. When selecting different colors the selection should remain inverted.

### Demo

https://user-images.githubusercontent.com/37751258/227244746-745eb134-3ee9-4812-ae13-cc32e61e66aa.mov

Before

https://user-images.githubusercontent.com/37751258/227245966-3c4e85bb-3919-420f-95f4-30e2c4e40244.mov

After


### Checklist

- ✅ Tests have been added/updated to cover changes in this PR
