### PR TITLE
Add a reproduction for dashboard sticky filter incorrectly positioned when moving between dashboards

### DIFF
--- a/e2e/test/scenarios/dashboard/reproductions/26230-dashboard-sticky-filter-incorrectly-positioned.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/reproductions/26230-dashboard-sticky-filter-incorrectly-positioned.cy.spec.js
@@ -10,7 +10,8 @@ describe("issue 26230", () => {
   });
 
   it("should show dashboard header when navigate from the end of other long dashboard (metabase#26230)", () => {
-    cy.findByRole("main").scrollTo("bottom");
+    cy.findByRole("main").scrollTo("bottom"); // This line is essential for the reproduction!
+
     cy.button("Toggle sidebar").click();
     cy.findByRole("main")
       .findByDisplayValue("dashboard with a tall card 2")

--- a/e2e/test/scenarios/dashboard/reproductions/26230-dashboard-sticky-filter-incorrectly-positioned.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/reproductions/26230-dashboard-sticky-filter-incorrectly-positioned.cy.spec.js
@@ -1,0 +1,118 @@
+import { merge } from "icepick";
+import { restore } from "e2e/support/helpers";
+
+describe("issue 26230", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+  });
+
+  it("should show dashboard header when navigate from the end of other long dashboard (metabase#26230)", () => {
+    prepareAndVisitDashboards();
+
+    cy.findByRole("main").scrollTo("bottom");
+    cy.button("Toggle sidebar").click();
+    cy.findByRole("main").within(() => {
+      cy.findByDisplayValue("dashboard with a tall card 2").should(
+        "not.be.visible",
+      );
+    });
+
+    cy.findByRole("listitem", { name: "dashboard with a tall card" }).click();
+    cy.findByRole("main").within(() => {
+      cy.findByDisplayValue("dashboard with a tall card").should("be.visible");
+    });
+  });
+});
+
+function prepareAndVisitDashboards() {
+  cy.createDashboard({
+    name: "dashboard with a tall card",
+    parameters: [
+      {
+        id: "12345678",
+        name: "Text",
+        slug: "text",
+        type: "string/=",
+        sectionId: "string",
+      },
+    ],
+  }).then(({ body: { id } }) => {
+    cy.request(
+      "POST",
+      `/api/dashboard/${id}/cards`,
+      createTextDashcard({
+        col: 0,
+        row: 0,
+        size_x: 4,
+        size_y: 20,
+        visualization_settings: {
+          text: "I am a tall card",
+        },
+      }),
+    );
+    bookmarkDashboard(id);
+  });
+
+  cy.createDashboard({
+    name: "dashboard with a tall card 2",
+    parameters: [
+      {
+        id: "87654321",
+        name: "Text",
+        slug: "text",
+        type: "string/=",
+        sectionId: "string",
+      },
+    ],
+  }).then(({ body: { id } }) => {
+    cy.request(
+      "POST",
+      `/api/dashboard/${id}/cards`,
+      createTextDashcard({
+        col: 0,
+        row: 0,
+        size_x: 4,
+        size_y: 20,
+        visualization_settings: {
+          text: "I am a tall card",
+        },
+      }),
+    );
+    bookmarkDashboard(id);
+    cy.visit(`/dashboard/${id}`);
+  });
+}
+
+function bookmarkDashboard(dashboardId) {
+  cy.request("POST", `/api/bookmark/dashboard/${dashboardId}`);
+}
+
+/**
+ *
+ * @param {Partial<import('metabase-types/api').DashboardOrderedCard>} dashcardDetails
+ * @returns
+ */
+function createTextDashcard(dashcardDetails) {
+  const defaultDashcardDetails = {
+    cardId: null,
+    col: 0,
+    row: 0,
+    size_x: 4,
+    size_y: 3,
+    series: [],
+    parameter_mappings: [],
+    visualization_settings: {
+      virtual_card: {
+        name: null,
+        display: "text",
+        visualization_settings: {},
+        dataset_query: {},
+        archived: false,
+      },
+      text: "Edit me",
+    },
+  };
+
+  return merge(defaultDashcardDetails, dashcardDetails);
+}

--- a/e2e/test/scenarios/dashboard/reproductions/26230-dashboard-sticky-filter-incorrectly-positioned.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/reproductions/26230-dashboard-sticky-filter-incorrectly-positioned.cy.spec.js
@@ -5,10 +5,11 @@ describe("issue 26230", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();
+
+    prepareAndVisitDashboards();
   });
 
   it("should show dashboard header when navigate from the end of other long dashboard (metabase#26230)", () => {
-    prepareAndVisitDashboards();
 
     cy.findByRole("main").scrollTo("bottom");
     cy.button("Toggle sidebar").click();

--- a/e2e/test/scenarios/dashboard/reproductions/26230-dashboard-sticky-filter-incorrectly-positioned.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/reproductions/26230-dashboard-sticky-filter-incorrectly-positioned.cy.spec.js
@@ -10,7 +10,6 @@ describe("issue 26230", () => {
   });
 
   it("should show dashboard header when navigate from the end of other long dashboard (metabase#26230)", () => {
-
     cy.findByRole("main").scrollTo("bottom");
     cy.button("Toggle sidebar").click();
     cy.findByRole("main").within(() => {
@@ -19,10 +18,9 @@ describe("issue 26230", () => {
       );
     });
 
+    cy.intercept("GET", "/api/dashboard/*").as("loadDashboard");
     cy.findByRole("listitem", { name: "dashboard with a tall card" }).click();
-    cy.findByRole("main").within(() => {
-      cy.findByDisplayValue("dashboard with a tall card").should("be.visible");
-    });
+    cy.wait("@loadDashboard");
   });
 });
 

--- a/e2e/test/scenarios/dashboard/reproductions/26230-dashboard-sticky-filter-incorrectly-positioned.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/reproductions/26230-dashboard-sticky-filter-incorrectly-positioned.cy.spec.js
@@ -17,9 +17,21 @@ describe("issue 26230", () => {
       .findByDisplayValue("dashboard with a tall card 2")
       .should("not.be.visible");
 
+    cy.findByTestId("dashboard-parameters-widget-container").should(
+      "have.css",
+      "position",
+      "fixed",
+    );
+
     cy.intercept("GET", "/api/dashboard/*").as("loadDashboard");
     cy.findByRole("listitem", { name: "dashboard with a tall card" }).click();
     cy.wait("@loadDashboard");
+
+    cy.findByTestId("dashboard-parameters-widget-container").should(
+      "not.have.css",
+      "position",
+      "fixed",
+    );
   });
 });
 

--- a/e2e/test/scenarios/dashboard/reproductions/26230-dashboard-sticky-filter-incorrectly-positioned.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/reproductions/26230-dashboard-sticky-filter-incorrectly-positioned.cy.spec.js
@@ -12,11 +12,9 @@ describe("issue 26230", () => {
   it("should show dashboard header when navigate from the end of other long dashboard (metabase#26230)", () => {
     cy.findByRole("main").scrollTo("bottom");
     cy.button("Toggle sidebar").click();
-    cy.findByRole("main").within(() => {
-      cy.findByDisplayValue("dashboard with a tall card 2").should(
-        "not.be.visible",
-      );
-    });
+    cy.findByRole("main")
+      .findByDisplayValue("dashboard with a tall card 2")
+      .should("not.be.visible");
 
     cy.intercept("GET", "/api/dashboard/*").as("loadDashboard");
     cy.findByRole("listitem", { name: "dashboard with a tall card" }).click();

--- a/e2e/test/scenarios/dashboard/reproductions/26230-dashboard-sticky-filter-incorrectly-positioned.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/reproductions/26230-dashboard-sticky-filter-incorrectly-positioned.cy.spec.js
@@ -1,5 +1,5 @@
 import { merge } from "icepick";
-import { restore } from "e2e/support/helpers";
+import { restore, visitDashboard } from "e2e/support/helpers";
 
 describe("issue 26230", () => {
   beforeEach(() => {
@@ -81,7 +81,7 @@ function prepareAndVisitDashboards() {
       }),
     );
     bookmarkDashboard(id);
-    cy.visit(`/dashboard/${id}`);
+    visitDashboard(id);
   });
 }
 

--- a/e2e/test/scenarios/dashboard/reproductions/26230-dashboard-sticky-filter-incorrectly-positioned.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/reproductions/26230-dashboard-sticky-filter-incorrectly-positioned.cy.spec.js
@@ -1,4 +1,3 @@
-import { merge } from "icepick";
 import { restore, visitDashboard } from "e2e/support/helpers";
 
 describe("issue 26230", () => {
@@ -48,19 +47,7 @@ function prepareAndVisitDashboards() {
       },
     ],
   }).then(({ body: { id } }) => {
-    cy.request(
-      "POST",
-      `/api/dashboard/${id}/cards`,
-      createTextDashcard({
-        col: 0,
-        row: 0,
-        size_x: 4,
-        size_y: 20,
-        visualization_settings: {
-          text: "I am a tall card",
-        },
-      }),
-    );
+    createTextDashcard(id);
     bookmarkDashboard(id);
   });
 
@@ -76,19 +63,7 @@ function prepareAndVisitDashboards() {
       },
     ],
   }).then(({ body: { id } }) => {
-    cy.request(
-      "POST",
-      `/api/dashboard/${id}/cards`,
-      createTextDashcard({
-        col: 0,
-        row: 0,
-        size_x: 4,
-        size_y: 20,
-        visualization_settings: {
-          text: "I am a tall card",
-        },
-      }),
-    );
+    createTextDashcard(id);
     bookmarkDashboard(id);
     visitDashboard(id);
   });
@@ -98,20 +73,13 @@ function bookmarkDashboard(dashboardId) {
   cy.request("POST", `/api/bookmark/dashboard/${dashboardId}`);
 }
 
-/**
- *
- * @param {Partial<import('metabase-types/api').DashboardOrderedCard>} dashcardDetails
- * @returns
- */
-function createTextDashcard(dashcardDetails) {
-  const defaultDashcardDetails = {
+function createTextDashcard(id) {
+  cy.request("POST", `/api/dashboard/${id}/cards`, {
     cardId: null,
     col: 0,
     row: 0,
     size_x: 4,
-    size_y: 3,
-    series: [],
-    parameter_mappings: [],
+    size_y: 20,
     visualization_settings: {
       virtual_card: {
         name: null,
@@ -120,9 +88,7 @@ function createTextDashcard(dashcardDetails) {
         dataset_query: {},
         archived: false,
       },
-      text: "Edit me",
+      text: "I am a tall card",
     },
-  };
-
-  return merge(defaultDashcardDetails, dashcardDetails);
+  });
 }

--- a/e2e/test/scenarios/dashboard/reproductions/26230-dashboard-sticky-filter-incorrectly-positioned.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/reproductions/26230-dashboard-sticky-filter-incorrectly-positioned.cy.spec.js
@@ -8,7 +8,7 @@ describe("issue 26230", () => {
     prepareAndVisitDashboards();
   });
 
-  it("should show dashboard header when navigate from the end of other long dashboard (metabase#26230)", () => {
+  it("should not preserve the sticky filter behavior when navigating to the second dashboard (metabase#26230)", () => {
     cy.findByRole("main").scrollTo("bottom"); // This line is essential for the reproduction!
 
     cy.button("Toggle sidebar").click();


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/26230

### Description

This PR only adds a reproduction for https://github.com/metabase/metabase/issues/26230. The issue has already been fixed by https://github.com/metabase/metabase/pull/27425.

However, there's a little trouble trying to make this test works as expected.

First, since the issue has been fixed the E2E test in this PR would be green, however, to assert that we write the test that would have caught the issue had it happened again. We need to make sure that by reverting PR #27425, the test would fail.
<img src="https://user-images.githubusercontent.com/1937582/227506750-4cee633e-c216-4588-8754-52945fa17874.png" width="300" />

However, there was trouble trying to assert that certain elements are being hidden under the incorrectly positioned filter ([context on Slack](https://metaboat.slack.com/archives/C04DAKFDTCZ/p1679595403687369)). I and @nemanjaglumac have tried checking `hiddenElement.should("be.visible")` and `hiddenElement.click()` and both assertions didn't fail.
![image](https://user-images.githubusercontent.com/1937582/227507540-dd17f516-5cf0-4803-ba27-43fb440fa2f0.png)
You can see from the screenshot above that I check both the dashboard name and edit icon should be visible when it's not, but the assertions didn't fail (below is how the dashboard header would look like normally)
<img width="1129" alt="Screenshot 2023-03-24 at 11 18 21 AM" src="https://user-images.githubusercontent.com/1937582/227507801-e1a752a6-a460-477d-acb4-1d53e71dfbe1.png">

The workaround we had are
1. Check that the boundary of both the dashboard header and the filter are intersected
2. Check that the filter doesn't have CSS `position: fixed`.

While they all look great on paper, 1. doesn't guarantee that the filter would always cover the dashboard header, as it could have been rendered behind the dashboard header. 2. also doesn't guarantee that the filter always covers the dashboard header as that also depends on the markup too. So, checking CSS `position: fixed` sounds more straightforward in this case given we know if the position isn't `fixed` the issue won't occur.

### How to verify

1. Run Cypress test `e2e/test/scenarios/dashboard/reproductions/26230-dashboard-sticky-filter-incorrectly-positioned.cy.spec.js` and it should be green
2. Revert PR #27425 or commit https://github.com/metabase/metabase/commit/a89ade03b63f29707cd4d73fc7d8c5e9a5470720, and run the test again. Now it should fail. If it's still green that means this repro doesn't correctly capture the issue.

### Demo

#### Before
![image](https://user-images.githubusercontent.com/1937582/227512879-9be5fc19-151c-439f-a77e-948f5de72986.png)

#### After (looks like when you refresh the page since previously the UI state was wrong after navigating client-side)
<img width="1446" alt="image" src="https://user-images.githubusercontent.com/1937582/227512998-7e84a503-a134-40a6-a63f-625b5da9f762.png">

```[tasklist]
### Checklist
- [X] Tests have been added/updated to cover changes in this PR
- [x] Add `.Reproduced` label to https://github.com/metabase/metabase/issues/26230 after this PR is merged.
```