### PR TITLE
Misc toucan1 methods to toucan 2

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -582,7 +582,8 @@
    metabase.test/with-temp-file                                                                                              hooks.metabase.test.util/with-temp-file
    metabase.test/with-temporary-setting-values                                                                               hooks.metabase.test.util/with-temporary-setting-values
    toucan.util.test/with-temp                                                                                                hooks.toucan.util.test/with-temp
-   toucan.util.test/with-temp*                                                                                               hooks.toucan.util.test/with-temp*}
+   toucan.util.test/with-temp*                                                                                               hooks.toucan.util.test/with-temp*
+   toucan2.core/with-call-count                                                                                              hooks.common/with-one-binding}
 
   :macroexpand
   {clojurewerkz.quartzite.jobs/build                                            macros.quartz/build-job

--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -506,7 +506,8 @@
   potemkin/defprotocol+                                                                clojure.core/defprotocol
   potemkin/defrecord+                                                                  clojure.core/defrecord
   potemkin/deftype+                                                                    clojure.core/deftype
-  toucan.db/with-call-counting                                                         clojure.core/fn}
+  toucan.db/with-call-counting                                                         clojure.core/fn
+  toucan2.core/with-call-count                                                         clojure.core/fn}
 
  :hooks
  {:analyze-call
@@ -585,8 +586,7 @@
    metabase.test/with-temp-file                                                                                              hooks.metabase.test.util/with-temp-file
    metabase.test/with-temporary-setting-values                                                                               hooks.metabase.test.util/with-temporary-setting-values
    toucan.util.test/with-temp                                                                                                hooks.toucan.util.test/with-temp
-   toucan.util.test/with-temp*                                                                                               hooks.toucan.util.test/with-temp*
-   toucan2.core/with-call-count                                                                                              hooks.common/with-one-binding}
+   toucan.util.test/with-temp*                                                                                               hooks.toucan.util.test/with-temp*}
 
   :macroexpand
   {clojurewerkz.quartzite.jobs/build                                            macros.quartz/build-job

--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -149,6 +149,9 @@
    toucan.db/query               {:message "Use mdb.query/query instead of toucan.db/query"}
    toucan.db/count               {:message "Use t2/count instead of toucan.db/count"}
    toucan.db/exists?             {:message "Use t2/exists? instead of toucan.db/exists?"}
+   toucan.db/transaction         {:message "Use t2/with-transaction instead of toucan.db/transaction"}
+   toucan.db/with-call-counting  {:message "Use t2/with-call-count instead of toucan.db/with-call-counting"}
+   toucan.db/execute!            {:message "Use t2/query-one instead of toucan.db/execute!"}
    toucan.db/reducible-query     {:message "Use mdb.query/reducible-query instead of toucan.db/reducible-query"}}
 
 

--- a/enterprise/backend/src/metabase_enterprise/advanced_permissions/models/permissions/application_permissions.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_permissions/models/permissions/application_permissions.clj
@@ -9,7 +9,6 @@
    [metabase.util.honey-sql-2 :as h2x]
    [metabase.util.schema :as su]
    [schema.core :as s]
-   [toucan.db :as db]
    [toucan2.core :as t2]))
 
 ;;; ---------------------------------------------------- Schemas -----------------------------------------------------
@@ -81,7 +80,7 @@
     (perms/log-permissions-changes diff-old changes)
     (perms/check-revision-numbers old-graph new-graph)
     (when (seq changes)
-      (db/transaction
+      (t2/with-transaction [_conn]
        (doseq [[group-id changes] changes]
          (update-application-permissions! group-id changes))
        (perms/save-perms-revision! ApplicationPermissionsRevision (:revision old-graph) (:groups old-graph) changes)))))

--- a/enterprise/backend/src/metabase_enterprise/advanced_permissions/models/permissions/group_manager.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_permissions/models/permissions/group_manager.clj
@@ -6,7 +6,6 @@
    [metabase.models :refer [PermissionsGroupMembership]]
    [metabase.util :as u]
    [metabase.util.i18n :refer [tru]]
-   [toucan.db :as db]
    [toucan2.core :as t2]))
 
 (defn user-group-memberships
@@ -45,7 +44,7 @@
                                                     :user_id api/*current-user-id* :is_group_manager true)))
         (throw (ex-info (tru "Not allowed to edit group memberships")
                         {:status-code 403}))))
-    (db/transaction
+    (t2/with-transaction [_conn]
      (when (seq to-remove-group-ids)
        (t2/delete! PermissionsGroupMembership :user_id user-id, :group_id [:in to-remove-group-ids]))
      (when (seq to-add-group-ids)

--- a/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
+++ b/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
@@ -419,13 +419,13 @@
     (log/infof (trs "DB {0} had hardcoded dataset-id; changing to an inclusion pattern and updating table schemas"
                     db-id))
     (try
-      (db/execute! {:update (t2/table-name MetabaseTable)
-                    :set    {:schema dataset-id}
-                    :where  [:and
-                             [:= :db_id db-id]
-                             [:or
-                              [:= :schema nil]
-                              [:not= :schema dataset-id]]]})
+      (t2/query-one {:update (t2/table-name MetabaseTable)
+                     :set    {:schema dataset-id}
+                     :where  [:and
+                              [:= :db_id db-id]
+                              [:or
+                               [:= :schema nil]
+                               [:not= :schema dataset-id]]]})
       ;; if we are upgrading to the sdk driver after having downgraded back to the old driver we end up with
       ;; duplicated tables with nil schema. Happily only in the "dataset-id" schema and not all schemas. But just
       ;; leave them with nil schemas and they will get deactivated in sync.

--- a/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
+++ b/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
@@ -26,7 +26,6 @@
    [metabase.util.log :as log]
    [metabase.util.schema :as su]
    [schema.core :as s]
-   [toucan.db :as db]
    [toucan2.core :as t2])
   (:import
    (clojure.lang PersistentList)

--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -355,7 +355,7 @@ saved later when it is ready."
          metadata-timeout     (a/timeout metadata-sync-wait-ms)
          [metadata port]      (a/alts!! [result-metadata-chan metadata-timeout])
          timed-out?           (= port metadata-timeout)
-         card                 (db/transaction
+         card                 (t2/with-transaction [_conn]
                                ;; Adding a new card at `collection_position` could cause other cards in this
                                ;; collection to change position, check that and fix it if needed
                                (api/maybe-reconcile-collection-position! card-data)
@@ -569,7 +569,7 @@ saved later when it is ready."
   included, otherwise the metadata will be saved to the database asynchronously."
   [{:keys [id], :as card-before-update} {:keys [archived], :as card-updates}]
   ;; don't block our precious core.async thread, run the actual DB updates on a separate thread
-  (db/transaction
+  (t2/with-transaction [_conn]
    (api/maybe-reconcile-collection-position! card-before-update card-updates)
 
    (when (and (card-is-verified? card-before-update)
@@ -728,7 +728,7 @@ saved later when it is ready."
       ;; here. We are querying for the max card position for a given collection, then using that to base our position
       ;; changes if the cards are moving to a different collection. Without repeatable read here, it's possible we'll
       ;; get duplicates
-      (db/transaction
+      (t2/with-transaction [_conn]
         ;; If any of the cards have a `:collection_position`, we'll need to fixup the old collection now that the cards
         ;; are gone and update the position in the new collection
         (when-let [cards-with-position (seq (filter :collection_position cards))]

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -42,7 +42,6 @@
    [metabase.util.malli.schema :as ms]
    [metabase.util.schema :as su]
    [schema.core :as s]
-   [toucan.db :as db]
    [toucan.hydrate :refer [hydrate]]
    [toucan2.core :as t2])
   (:import
@@ -96,7 +95,7 @@
                         :cache_ttl           cache_ttl
                         :collection_id       collection_id
                         :collection_position collection_position}
-        dash           (db/transaction
+        dash           (t2/with-transaction [_conn]
                         ;; Adding a new dashboard at `collection_position` could cause other dashboards in this collection to change
                         ;; position, check that and fix up if needed
                         (api/maybe-reconcile-collection-position! dashboard-data)
@@ -335,7 +334,7 @@
                         :collection_id       collection_id
                         :collection_position collection_position}
         new-cards      (atom nil)
-        dashboard      (db/transaction
+        dashboard      (t2/with-transaction [_conn]
                         ;; Adding a new dashboard at `collection_position` could cause other dashboards in this
                         ;; collection to change position, check that and fix up if needed
                         (api/maybe-reconcile-collection-position! dashboard-data)
@@ -407,7 +406,7 @@
     ;; Do various permissions checks as needed
     (collection/check-allowed-to-change-collection dash-before-update dash-updates)
     (check-allowed-to-change-embedding dash-before-update dash-updates)
-    (db/transaction
+    (t2/with-transaction [_conn]
       ;; If the dashboard has an updated position, or if the dashboard is moving to a new collection, we might need to
       ;; adjust the collection position of other dashboards in the collection
       (api/maybe-reconcile-collection-position! dash-before-update dash-updates)

--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -1026,8 +1026,8 @@
 
 (defn- delete-all-field-values-for-database! [database-or-id]
   (when-let [field-values-ids (seq (database->field-values-ids database-or-id))]
-    (db/execute! {:delete-from :metabase_fieldvalues
-                  :where       [:in :id field-values-ids]})))
+    (t2/query-one {:delete-from :metabase_fieldvalues
+                   :where       [:in :id field-values-ids]})))
 
 
 ;; TODO - should this be something like DELETE /api/database/:id/field_values instead?

--- a/src/metabase/api/field.clj
+++ b/src/metabase/api/field.clj
@@ -23,7 +23,6 @@
    [metabase.util.malli.schema :as ms]
    [metabase.util.schema :as su]
    [schema.core :as s]
-   [toucan.db :as db]
    [toucan.hydrate :refer [hydrate]]
    [toucan2.core :as t2])
   (:import
@@ -137,7 +136,7 @@
         :fk_target_field_id "Invalid target field"))
     ;; everything checks out, now update the field
     (api/check-500
-     (db/transaction
+     (t2/with-transaction [_conn]
        (and
         (if removed-fk?
           (clear-dimension-on-fk-change! field)

--- a/src/metabase/api/google.clj
+++ b/src/metabase/api/google.clj
@@ -6,7 +6,7 @@
    [metabase.integrations.google :as google]
    [metabase.models.setting :as setting]
    [schema.core :as s]
-   [toucan.db :as db]))
+   [toucan2.core :as t2]))
 
 #_{:clj-kondo/ignore [:deprecated-var]}
 (api/defendpoint-schema PUT "/settings"
@@ -17,7 +17,7 @@
    google-auth-auto-create-accounts-domain (s/maybe s/Str)}
   (api/check-superuser)
   ;; Set google-auth-enabled in a separate step because it requires the client ID to be set first
-  (db/transaction
+  (t2/with-transaction [_conn]
    (setting/set-many! {:google-auth-client-id                   google-auth-client-id
                        :google-auth-auto-create-accounts-domain google-auth-auto-create-accounts-domain})
    (google/google-auth-enabled! google-auth-enabled)))

--- a/src/metabase/api/ldap.clj
+++ b/src/metabase/api/ldap.clj
@@ -9,7 +9,7 @@
    [metabase.util.i18n :refer [deferred-tru tru]]
    [metabase.util.log :as log]
    [metabase.util.schema :as su]
-   [toucan.db :as db]))
+   [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
 
@@ -112,7 +112,7 @@
         ldap-details  (set/rename-keys ldap-settings ldap/mb-settings->ldap-details)
         results       (ldap/test-ldap-connection ldap-details)]
     (if (= :SUCCESS (:status results))
-      (db/transaction
+      (t2/with-transaction [_conn]
        (setting/set-many! ldap-settings)
        (setting/set-value-of-type! :boolean :ldap-enabled (boolean (:ldap-enabled settings))))
       ;; test failed, return result message

--- a/src/metabase/api/permissions.clj
+++ b/src/metabase/api/permissions.clj
@@ -26,7 +26,6 @@
    [metabase.util.malli.schema :as ms]
    [metabase.util.schema :as su]
    [schema.core]
-   [toucan.db :as db]
    [toucan.hydrate :refer [hydrate]]
    [toucan2.core :as t2]))
 
@@ -85,7 +84,7 @@
                          :error (str (me/humanize explained)
                                      "\n"
                                      (pr-str explained))}))))
-    (db/transaction
+    (t2/with-transaction [_conn]
      (perms/update-data-perms-graph! (dissoc graph :sandboxes))
      (if-let [sandboxes (:sandboxes body)]
        (let [new-sandboxes (upsert-sandboxes! sandboxes)]

--- a/src/metabase/api/pulse.clj
+++ b/src/metabase/api/pulse.clj
@@ -29,7 +29,6 @@
    [metabase.util.schema :as su]
    [metabase.util.urls :as urls]
    [schema.core :as s]
-   [toucan.db :as db]
    [toucan.hydrate :refer [hydrate]]
    [toucan2.core :as t2])
   (:import
@@ -136,7 +135,7 @@
                     :collection_position collection_position
                     :dashboard_id        dashboard_id
                     :parameters          parameters}]
-    (db/transaction
+    (t2/with-transaction [_conn]
      ;; Adding a new pulse at `collection_position` could cause other pulses in this collection to change position,
      ;; check that and fix it if needed
      (api/maybe-reconcile-collection-position! pulse-data)
@@ -213,7 +212,7 @@
                    [403 (tru "Non-admin users without subscription permissions are not allowed to add recipients")])))
 
     (let [pulse-updates (maybe-add-recipients-for-sandboxed-users pulse-updates pulse-before-update)]
-      (db/transaction
+      (t2/with-transaction [_conn]
        ;; If the collection or position changed with this update, we might need to fixup the old and/or new collection,
        ;; depending on what changed.
        (api/maybe-reconcile-collection-position! pulse-before-update pulse-updates)

--- a/src/metabase/api/setup.clj
+++ b/src/metabase/api/setup.clj
@@ -32,7 +32,6 @@
    [metabase.util.log :as log]
    [metabase.util.schema :as su]
    [schema.core :as s]
-   [toucan.db :as db]
    [toucan2.core :as t2])
   (:import
    (java.util UUID)))
@@ -137,7 +136,7 @@
    auto_run_queries   (s/maybe s/Bool)}
   (letfn [(create! []
             (try
-              (db/transaction
+              (t2/with-transaction [_conn]
                (let [user-info (setup-create-user!
                                 {:email email, :first-name first_name, :last-name last_name, :password password})
                      db        (setup-create-database! {:name name

--- a/src/metabase/api/table.clj
+++ b/src/metabase/api/table.clj
@@ -92,7 +92,7 @@
   (let [existing-tables (t2/select Table :id [:in ids])]
     (api/check-404 (= (count existing-tables) (count ids)))
     (run! api/write-check existing-tables)
-    (let [updated-tables (db/transaction (mapv #(update-table!* % body) existing-tables))
+    (let [updated-tables (t2/with-transaction [_conn] (mapv #(update-table!* % body) existing-tables))
           newly-unhidden (when (and (contains? body :visibility_type) (nil? visibility_type))
                            (into [] (filter (comp some? :visibility_type)) existing-tables))]
       (sync-unhidden-tables newly-unhidden)

--- a/src/metabase/api/user.clj
+++ b/src/metabase/api/user.clj
@@ -256,7 +256,7 @@
   (api/check-superuser)
   (api/checkp (not (t2/exists? User :%lower.email (u/lower-case-en email)))
     "email" (tru "Email address already in use."))
-  (db/transaction
+  (t2/with-transaction [_conn]
     (let [new-user-id (u/the-id (user/create-and-invite-user!
                                  (u/select-keys-when body
                                    :non-nil [:first_name :last_name :email :password :login_attributes])
@@ -331,7 +331,7 @@
     ;; can't change email if it's already taken BY ANOTHER ACCOUNT
     (api/checkp (not (t2/exists? User, :%lower.email (if email (u/lower-case-en email) email), :id [:not= id]))
       "email" (tru "Email address already associated to another user."))
-    (db/transaction
+    (t2/with-transaction [_conn]
       ;; only superuser or self can update user info
       ;; implicitly prevent group manager from updating users' info
       (when (or (= id api/*current-user-id*)

--- a/src/metabase/db/data_migrations.clj
+++ b/src/metabase/db/data_migrations.clj
@@ -17,7 +17,6 @@
    [metabase.models.setting :as setting :refer [Setting]]
    [metabase.util :as u]
    [metabase.util.log :as log]
-   [toucan.db :as db]
    [toucan.models :as models]
    [toucan2.core :as t2]))
 
@@ -40,7 +39,7 @@
     (when-not (contains? ran-migrations migration-name)
       (log/info (format "Running data migration '%s'..." migration-name))
       (try
-       (db/transaction
+       (t2/with-transaction [_conn]
         (@migration-var))
        (catch Exception e
          (if catch?

--- a/src/metabase/models/action.clj
+++ b/src/metabase/models/action.clj
@@ -100,7 +100,7 @@
 (defn insert!
   "Inserts an Action and related type table. Returns the action id."
   [action-data]
-  (db/transaction
+  (t2/with-transaction [_conn]
     (let [action (first (t2/insert-returning-instances! Action (select-keys action-data action-columns)))
           model  (type->model (:type action))]
       (db/execute! {:insert-into (t2/table-name model)

--- a/src/metabase/models/action.clj
+++ b/src/metabase/models/action.clj
@@ -103,7 +103,7 @@
   (t2/with-transaction [_conn]
     (let [action (first (t2/insert-returning-instances! Action (select-keys action-data action-columns)))
           model  (type->model (:type action))]
-      (db/execute! {:insert-into (t2/table-name model)
+      (t2/query-one {:insert-into (t2/table-name model)
                     :values [(-> (apply dissoc action-data action-columns)
                                  (assoc :action_id (:id action))
                                  (cond->

--- a/src/metabase/models/collection.clj
+++ b/src/metabase/models/collection.clj
@@ -606,7 +606,7 @@
     ;; first move this Collection
     (log/info (trs "Moving Collection {0} and its descendants from {1} to {2}"
                    (u/the-id collection) (:location collection) new-location))
-    (db/transaction
+    (t2/with-transaction [_conn]
       (t2/update! Collection (u/the-id collection) {:location new-location})
       ;; we need to update all the descendant collections as well...
       (db/execute!
@@ -625,7 +625,7 @@
   [collection :- CollectionWithLocationAndIDOrRoot]
   (let [affected-collection-ids (cons (u/the-id collection)
                                       (collection->descendant-ids collection, :archived false))]
-    (db/transaction
+    (t2/with-transaction [_conn]
       (db/update-where! Collection {:id       [:in affected-collection-ids]
                                     :archived false}
         :archived true)
@@ -639,7 +639,7 @@
   [collection :- CollectionWithLocationAndIDOrRoot]
   (let [affected-collection-ids (cons (u/the-id collection)
                                       (collection->descendant-ids collection, :archived true))]
-    (db/transaction
+    (t2/with-transaction [_conn]
       (db/update-where! Collection {:id       [:in affected-collection-ids]
                                     :archived true}
         :archived false)

--- a/src/metabase/models/collection.clj
+++ b/src/metabase/models/collection.clj
@@ -609,7 +609,7 @@
     (t2/with-transaction [_conn]
       (t2/update! Collection (u/the-id collection) {:location new-location})
       ;; we need to update all the descendant collections as well...
-      (db/execute!
+      (t2/query-one
        {:update :collection
         :set    {:location [:replace :location orig-children-location new-children-location]}
         :where  [:like :location (str orig-children-location "%")]}))))
@@ -797,7 +797,7 @@
 
   This needs to be done recursively for all descendants as well."
   [collection :- (mi/InstanceOf Collection)]
-  (db/execute! {:delete-from :permissions
+  (t2/query-one {:delete-from :permissions
                 :where       [:in :object (for [collection (cons collection (descendants collection))
                                                 path-fn    [perms/collection-read-path
                                                             perms/collection-readwrite-path]]
@@ -886,7 +886,7 @@
     (when (:personal_owner_id collection)
       (throw (Exception. (tru "You cannot delete a Personal Collection!")))))
   ;; Delete permissions records for this Collection
-  (db/execute! {:delete-from :permissions
+  (t2/query-one {:delete-from :permissions
                 :where       [:or
                               [:= :object (perms/collection-readwrite-path collection)]
                               [:= :object (perms/collection-read-path collection)]]}))

--- a/src/metabase/models/collection/graph.clj
+++ b/src/metabase/models/collection/graph.clj
@@ -14,7 +14,6 @@
    [metabase.util.honey-sql-2 :as h2x]
    [metabase.util.schema :as su]
    [schema.core :as s]
-   [toucan.db :as db]
    [toucan2.core :as t2]))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
@@ -99,7 +98,7 @@
    (graph nil))
 
   ([collection-namespace :- (s/maybe su/KeywordOrString)]
-   (db/transaction
+   (t2/with-transaction [_conn]
      (-> collection-namespace
          non-personal-collection-ids
          (collection-permission-graph collection-namespace)))))
@@ -151,7 +150,7 @@
      (perms/log-permissions-changes diff-old changes)
      (perms/check-revision-numbers old-graph new-graph)
      (when (seq changes)
-       (db/transaction
+       (t2/with-transaction [_conn]
          (doseq [[group-id changes] changes]
            (update-group-permissions! collection-namespace group-id changes))
          (perms/save-perms-revision! CollectionPermissionGraphRevision (:revision old-graph)

--- a/src/metabase/models/dashboard.clj
+++ b/src/metabase/models/dashboard.clj
@@ -134,7 +134,7 @@
                                     :card_id           card-id
                                     :dashboard_card_id dashcard-id
                                     :position          position})]
-        (db/transaction
+        (t2/with-transaction [_conn]
           (binding [pulse/*allow-moving-dashboard-subscriptions* true]
             (db/update-where! Pulse {:dashboard_id dashboard-id}
               :name (:name dashboard)

--- a/src/metabase/models/dashboard_card.clj
+++ b/src/metabase/models/dashboard_card.clj
@@ -177,7 +177,7 @@
    Returns nil."
   [{:keys [id action_id] :as dashboard-card} :- DashboardCardUpdates
    old-dashboard-card                        :- DashboardCardUpdates]
-  (db/transaction
+  (t2/with-transaction [_conn]
    (let [update-ks (cond-> [:action_id :row :col :size_x :size_y
                             :parameter_mappings :visualization_settings]
                     ;; Allow changing card_id for action dashcards, but not for card dashcards.
@@ -216,7 +216,7 @@
   [dashboard-card :- NewDashboardCard]
   (let [{:keys [dashboard_id card_id action_id parameter_mappings visualization_settings size_x size_y row col series]
          :or   {series []}} dashboard-card]
-    (db/transaction
+    (t2/with-transaction [_conn]
       (let [dashboard-card (first (t2/insert-returning-instances!
                                     DashboardCard
                                     :dashboard_id           dashboard_id
@@ -239,7 +239,7 @@
   {:pre [(map? dashboard-card)
          (integer? user-id)]}
   (let [{:keys [id]} (dashboard dashboard-card)]
-    (db/transaction
+    (t2/with-transaction [_conn]
       (t2/delete! PulseCard :dashboard_card_id (:id dashboard-card))
       (t2/delete! DashboardCard :id (:id dashboard-card)))
     (events/publish-event! :dashboard-remove-cards {:id id :actor_id user-id :dashcards [dashboard-card]})))

--- a/src/metabase/models/database.clj
+++ b/src/metabase/models/database.clj
@@ -16,7 +16,6 @@
    [metabase.util.i18n :refer [trs]]
    [metabase.util.log :as log]
    [methodical.core :as methodical]
-   [toucan.db :as db]
    [toucan.models :as models]
    [toucan2.core :as t2]))
 
@@ -102,8 +101,8 @@
 
 (defn- pre-delete [{id :id, driver :engine, :as database}]
   (unschedule-tasks! database)
-  (db/execute! {:delete-from :permissions
-                :where       [:like :object (str "%" (perms/data-perms-path id) "%")]})
+  (t2/query-one {:delete-from :permissions
+                 :where       [:like :object (str "%" (perms/data-perms-path id) "%")]})
   (delete-orphaned-secrets! database)
   (try
     (driver/notify-database-updated driver database)

--- a/src/metabase/models/moderation_review.clj
+++ b/src/metabase/models/moderation_review.clj
@@ -71,7 +71,7 @@
     :moderator_id            su/IntGreaterThanZero
     (s/optional-key :status) Statuses
     (s/optional-key :text)   (s/maybe s/Str)}]
-  (db/transaction
+  (t2/with-transaction [_conn]
    (delete-extra-reviews! (:moderated_item_id params) (:moderated_item_type params))
    (db/update-where! ModerationReview {:moderated_item_id (:moderated_item_id params)
                                        :moderated_item_type (:moderated_item_type params)}

--- a/src/metabase/models/permissions.clj
+++ b/src/metabase/models/permissions.clj
@@ -1411,7 +1411,7 @@
      (when (or (seq old) (seq new))
        (log-permissions-changes old new)
        (check-revision-numbers old-graph new-graph)
-       (db/transaction
+       (t2/with-transaction [_conn]
         (doseq [[group-id changes] new]
           (update-group-permissions! group-id changes))
         (save-perms-revision! PermissionsRevision (:revision old-graph) old new)
@@ -1436,7 +1436,7 @@
      (when (or (seq old) (seq new))
        (log-permissions-changes old new)
        (check-revision-numbers old-graph new-graph)
-       (db/transaction
+       (t2/with-transaction [_conn]
          (doseq [[group-id changes] new]
            (update-execution-permissions! group-id changes))
          (save-perms-revision! PermissionsRevision (:revision old-graph) old new)))))

--- a/src/metabase/models/pulse.clj
+++ b/src/metabase/models/pulse.clj
@@ -482,7 +482,7 @@
   "Create a new Pulse/Alert with the properties specified in `notification`; add the `card-refs` to the Notification and
   add the Notification to `channels`. Returns the `id` of the newly created Notification."
   [notification card-refs :- (s/maybe [CardRef]) channels]
-  (db/transaction
+  (t2/with-transaction [_conn]
     (let [notification (first (t2/insert-returning-instances! Pulse notification))]
       (update-notification-cards! notification card-refs)
       (update-notification-channels! notification channels)

--- a/src/metabase/models/revision.clj
+++ b/src/metabase/models/revision.clj
@@ -157,7 +157,7 @@
          (t2/exists? User :id user-id)
          (integer? revision-id)]}
   (let [serialized-instance (t2/select-one-fn :object Revision, :model (name entity), :model_id id, :id revision-id)]
-    (db/transaction
+    (t2/with-transaction [_conn]
       ;; Do the reversion of the object
       (revert-to-revision! entity id user-id serialized-instance)
       ;; Push a new revision to record this change

--- a/src/metabase/models/setting.clj
+++ b/src/metabase/models/setting.clj
@@ -1017,7 +1017,7 @@
   ;; if setting any of the settings fails, roll back the entire DB transaction and the restore the cache from the DB
   ;; to revert any changes in the cache
   (try
-    (db/transaction
+    (t2/with-transaction [_conn]
       (doseq [[k v] settings]
         (metabase.models.setting/set! k v)))
     settings

--- a/src/metabase/models/user.clj
+++ b/src/metabase/models/user.clj
@@ -387,7 +387,7 @@
         new-group-ids      (set (map u/the-id new-groups-or-ids))
         [to-remove to-add] (data/diff old-group-ids new-group-ids)]
     (when (seq (concat to-remove to-add))
-      (db/transaction
+      (t2/with-transaction [_conn]
        (when (seq to-remove)
          (t2/delete! PermissionsGroupMembership :user_id user-id, :group_id [:in to-remove]))
        ;; a little inefficient, but we need to do a separate `insert!` for each group we're adding membership to,

--- a/src/metabase/server/middleware/log.clj
+++ b/src/metabase/server/middleware/log.clj
@@ -14,7 +14,7 @@
    [metabase.util :as u]
    [metabase.util.i18n :refer [trs]]
    [metabase.util.log :as log]
-   [toucan.db :as db])
+   [toucan2.core :as t2])
   (:import
    (clojure.core.async.impl.channels ManyToManyChannel)
    (com.mchange.v2.c3p0 PoolBackedDataSource)
@@ -204,7 +204,7 @@
       ;; non-API call or health or logs call, don't log it
       (handler request respond raise)
       ;; API call, log info about it
-      (db/with-call-counting [call-count-fn]
+      (t2/with-call-count [call-count-fn]
         (sql-jdbc.execute.diagnostic/capturing-diagnostic-info [diag-info-fn]
           (let [info           {:request       request
                                 :start-time    (System/nanoTime)

--- a/test/metabase/api/collection_test.clj
+++ b/test/metabase/api/collection_test.clj
@@ -623,7 +623,7 @@
                                             :user_id  user1-id
                                             :object   (revision/serialize-instance card2 card2-id card2)}]]
       ;; need different timestamps and Revision has a pre-update to throw as they aren't editable
-      (db/execute! {:update :revision
+      (t2/query-one {:update :revision
                     ;; in the past
                     :set {:timestamp (.minusHours (ZonedDateTime/now (ZoneId/of "UTC")) 24)}
                     :where [:= :id (:id _revision1)]})
@@ -717,13 +717,13 @@
                                    :user_id  failuser-id
                                    :object   (revision/serialize-instance dashboard dashboard-id dashboard)}]]
         (letfn [(at-year [year] (ZonedDateTime/of year 1 1 0 0 0 0 (ZoneId/of "UTC")))]
-          (db/execute! {:update :revision
+          (t2/query-one {:update :revision
                         ;; in the past
                         :set    {:timestamp (at-year 2015)}
                         :where  [:in :id (map :id [card-revision1 dash-revision1])]})
           ;; mark the later revisions with the user with name "pass". Note important that its the later revision by
           ;; id. Query assumes increasing timestamps with ids
-          (db/execute! {:update :revision
+          (t2/query-one {:update :revision
                         :set    {:timestamp (at-year 2021)
                                  :user_id   passuser-id}
                         :where  [:in :id (map :id [card-revision2 dash-revision2])]}))

--- a/test/metabase/api/pulse_test.clj
+++ b/test/metabase/api/pulse_test.clj
@@ -26,7 +26,6 @@
    [metabase.test.mock.util :refer [pulse-channel-defaults]]
    [metabase.util :as u]
    [schema.core :as s]
-   [toucan.db :as db]
    [toucan2.core :as t2]))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
@@ -77,9 +76,9 @@
       (grant-collection-perms-fn! (perms-group/all-users) collection)
       ;; use db/execute! instead of t2/update! so the updated_at field doesn't get automatically updated!
       (when (seq pulses-or-ids)
-        (db/execute! {:update :pulse
-                      :set    {:collection_id (u/the-id collection)}
-                      :where  [:in :id (set (map u/the-id pulses-or-ids))]}))
+        (t2/query-one {:update :pulse
+                       :set    {:collection_id (u/the-id collection)}
+                       :where  [:in :id (set (map u/the-id pulses-or-ids))]}))
       (f))))
 
 (defmacro ^:private with-pulses-in-nonreadable-collection [pulses-or-ids & body]

--- a/test/metabase/automagic_dashboards/core_test.clj
+++ b/test/metabase/automagic_dashboards/core_test.clj
@@ -23,7 +23,6 @@
    [metabase.util.i18n :refer [tru]]
    [ring.util.codec :as codec]
    [schema.core :as s]
-   [toucan.db :as db]
    [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
@@ -770,7 +769,7 @@
       @api/*current-user-permissions-set*
       (automagic-dashboards.test/with-dashboard-cleanup
         (let [database (t2/select-one Database :id db-id)]
-          (db/with-call-counting [call-count]
+          (t2/with-call-count [call-count]
             (magic/candidate-tables database)
             (is (= 4
                    (call-count)))))))))

--- a/test/metabase/models/dashboard_card_test.clj
+++ b/test/metabase/models/dashboard_card_test.clj
@@ -14,7 +14,6 @@
    [metabase.models.serialization :as serdes]
    [metabase.test :as mt]
    [metabase.util :as u]
-   [toucan.db :as db]
    [toucan2.core :as t2])
   (:import
    (java.time LocalDateTime)))
@@ -216,11 +215,11 @@
                     Card          [{series-id-1 :id} {:name "Series Card 1"}]
                     Card          [{series-id-2 :id} {:name "Series Card 2"}]]
       (testing "Should have fewer DB calls if there are no changes to the dashcards"
-        (db/with-call-counting [call-count]
+        (t2/with-call-count [call-count]
           (dashboard/update-dashcards! dashboard [dashcard-1 dashcard-2 dashcard-3])
           (is (= 6 (call-count)))))
       (testing "Should have more calls if there are changes to the dashcards"
-        (db/with-call-counting [call-count]
+        (t2/with-call-count [call-count]
           (dashboard/update-dashcards! dashboard [{:id     (:id dashcard-1)
                                                    :cardId card-id
                                                    :row    1

--- a/test/metabase/models/field_test.clj
+++ b/test/metabase/models/field_test.clj
@@ -8,7 +8,6 @@
    [metabase.models.table :refer [Table]]
    [metabase.test :as mt]
    [metabase.util :as u]
-   [toucan.db :as db]
    [toucan2.core :as t2]))
 
 (deftest unknown-types-test
@@ -27,8 +26,8 @@
     (testing (format "Field with unknown %s in DB should fall back to %s" column fallback-type)
       (mt/with-temp Field [field]
         (t2/query-one {:update :metabase_field
-                      :set    {column (u/qualified-name unknown-type)}
-                      :where  [:= :id (u/the-id field)]})
+                       :set    {column (u/qualified-name unknown-type)}
+                       :where  [:= :id (u/the-id field)]})
         (is (= fallback-type
                (t2/select-one-fn column Field :id (u/the-id field))))))
     (testing (format "Should throw an Exception if you attempt to save a Field with an invalid %s" column)

--- a/test/metabase/models/field_test.clj
+++ b/test/metabase/models/field_test.clj
@@ -26,7 +26,7 @@
                                                         :fallback-type nil}]]
     (testing (format "Field with unknown %s in DB should fall back to %s" column fallback-type)
       (mt/with-temp Field [field]
-        (db/execute! {:update :metabase_field
+        (t2/query-one {:update :metabase_field
                       :set    {column (u/qualified-name unknown-type)}
                       :where  [:= :id (u/the-id field)]})
         (is (= fallback-type

--- a/test/metabase/models/field_values_test.clj
+++ b/test/metabase/models/field_values_test.clj
@@ -16,7 +16,6 @@
    [metabase.sync :as sync]
    [metabase.test :as mt]
    [metabase.util :as u]
-   [toucan.db :as db]
    [toucan2.core :as t2]))
 
 (deftest field-should-have-field-values?-test
@@ -142,11 +141,11 @@
           (is (= :full (:type (field-values/get-or-create-full-field-values! (t2/select-one Field :id (mt/id :categories :name))))))))
 
       (testing "if an old FieldValues Exists, make sure we still return the full FieldValues and update last_used_at"
-        (db/execute! {:update :metabase_fieldvalues
-                      :where [:and
-                              [:= :field_id (mt/id :categories :name)]
-                              [:= :type "full"]]
-                      :set {:last_used_at (t/offset-date-time 2001 12)}})
+        (t2/query-one {:update :metabase_fieldvalues
+                       :where [:and
+                               [:= :field_id (mt/id :categories :name)]
+                               [:= :type "full"]]
+                       :set {:last_used_at (t/offset-date-time 2001 12)}})
         (is (= (t/offset-date-time 2001 12)
                (:last_used_at (t2/select-one FieldValues :field_id (mt/id :categories :name) :type :full))))
         (is (seq (:values (field-values/get-or-create-full-field-values! (t2/select-one Field :id (mt/id :categories :name))))))
@@ -157,9 +156,9 @@
   (testing "If FieldValues were saved as a map, normalize them to a sequence on the way out"
     (mt/with-temp FieldValues [fv {:field_id (mt/id :venues :id)
                                    :values   (json/generate-string ["1" "2" "3"])}]
-      (is (db/execute! {:update :metabase_fieldvalues
-                        :set    {:human_readable_values (json/generate-string {"1" "a", "2" "b", "3" "c"})}
-                        :where  [:= :id (:id fv)]}))
+      (is (t2/query-one {:update :metabase_fieldvalues
+                         :set    {:human_readable_values (json/generate-string {"1" "a", "2" "b", "3" "c"})}
+                         :where  [:= :id (:id fv)]}))
       (is (= ["a" "b" "c"]
              (:human_readable_values (t2/select-one FieldValues :id (:id fv))))))))
 

--- a/test/metabase/models/params_test.clj
+++ b/test/metabase/models/params_test.clj
@@ -6,7 +6,6 @@
    [metabase.models :refer [Card Field]]
    [metabase.models.params :as params]
    [metabase.test :as mt]
-   [toucan.db :as db]
    [toucan.hydrate :refer [hydrate]]
    [toucan.util.test :as tt]
    [toucan2.core :as t2]))
@@ -39,7 +38,7 @@
 
   (testing "make sure it works for multiple fields efficiently. Should only require one DB call to hydrate many Fields"
     (let [venues-fields (t2/select Field :table_id (mt/id :venues))]
-      (db/with-call-counting [call-count]
+      (t2/with-call-count [call-count]
         (hydrate venues-fields :name_field)
         (is (= 1
                (call-count))))))

--- a/test/metabase/models/user_test.clj
+++ b/test/metabase/models/user_test.clj
@@ -22,7 +22,6 @@
    [metabase.test.integrations.ldap :as ldap.test]
    [metabase.util :as u]
    [metabase.util.password :as u.password]
-   [toucan.db :as db]
    [toucan.hydrate :refer [hydrate]]
    [toucan2.core :as t2]))
 
@@ -273,7 +272,7 @@
                     _ {:name "Group 2"} #{:lucky}
                     _ {:name "Group 3"} #{}]
         (let [lucky-id (mt/user->id :lucky)]
-          (db/with-call-counting [call-count]
+          (t2/with-call-count [call-count]
             (user/group-ids lucky-id)
             (is (= 1
                    (call-count)))))))
@@ -316,7 +315,7 @@
                     _ {:name "Group 2"} #{:lucky}
                     _ {:name "Group 3"} #{}]
         (let [users (mapv test.users/fetch-user [:lucky :rasta])]
-          (db/with-call-counting [call-count]
+          (t2/with-call-count [call-count]
             (dorun (user/add-group-ids users))
             (is (= 1
                    (call-count)))))))

--- a/test/metabase/query_processor/middleware/fetch_source_query_test.clj
+++ b/test/metabase/query_processor/middleware/fetch_source_query_test.clj
@@ -250,7 +250,7 @@
                                    :query    {:source-table (str "card__" card-id)}}
             save-error            (try
                                     ;; `t2/update!` will fail because it will try to validate the query when it saves
-                                    (db/execute! {:update :report_card
+                                    (t2/query-one {:update :report_card
                                                   :set    {:dataset_query (json/generate-string circular-source-query)}
                                                   :where  [:= :id card-id]})
                                     nil
@@ -274,7 +274,7 @@
         ;; Make sure save isn't the thing throwing the Exception
         (let [save-error (try
                            ;; `t2/update!` will fail because it will try to validate the query when it saves,
-                           (db/execute! {:update :report_card
+                           (t2/query-one {:update :report_card
                                          :set    {:dataset_query (json/generate-string (circular-source-query card-2-id))}
                                          :where  [:= :id card-1-id]})
                            nil

--- a/test/metabase/query_processor/middleware/fetch_source_query_test.clj
+++ b/test/metabase/query_processor/middleware/fetch_source_query_test.clj
@@ -10,7 +10,7 @@
    [metabase.test :as mt]
    [metabase.util :as u]
    [schema.core :as s]
-   [toucan.db :as db]))
+   [toucan2.core :as t2]))
 
 (defn- resolve-card-id-source-tables [query]
   (:pre (mt/test-qp-middleware fetch-source-query/resolve-card-id-source-tables query)))
@@ -251,8 +251,8 @@
             save-error            (try
                                     ;; `t2/update!` will fail because it will try to validate the query when it saves
                                     (t2/query-one {:update :report_card
-                                                  :set    {:dataset_query (json/generate-string circular-source-query)}
-                                                  :where  [:= :id card-id]})
+                                                   :set    {:dataset_query (json/generate-string circular-source-query)}
+                                                   :where  [:= :id card-id]})
                                     nil
                                     (catch Throwable e
                                       (str "Failed to save Card:" e)))]
@@ -275,8 +275,8 @@
         (let [save-error (try
                            ;; `t2/update!` will fail because it will try to validate the query when it saves,
                            (t2/query-one {:update :report_card
-                                         :set    {:dataset_query (json/generate-string (circular-source-query card-2-id))}
-                                         :where  [:= :id card-1-id]})
+                                          :set    {:dataset_query (json/generate-string (circular-source-query card-2-id))}
+                                          :where  [:= :id card-1-id]})
                            nil
                            (catch Throwable e
                              (str "Failed to save Card:" e)))]

--- a/test/metabase/query_processor_test/expressions_test.clj
+++ b/test/metabase/query_processor_test/expressions_test.clj
@@ -10,7 +10,6 @@
    [metabase.test :as mt]
    [metabase.util :as u]
    [metabase.util.date-2 :as u.date]
-   [toucan.db :as db]
    [toucan2.core :as t2]))
 
 (deftest basic-test
@@ -365,7 +364,7 @@
                                                                                   (mt/id :lots-of-fields :b)}]
                                                              {:order-by [[:name :asc]]})]
                                           [:field id nil]))})]
-        (db/with-call-counting [call-count-fn]
+        (t2/with-call-count [call-count-fn]
           (mt/with-native-query-testing-context query
             (is (= 1
                    (-> (qp/process-query query) mt/rows ffirst))))

--- a/test/metabase/server/middleware/session_test.clj
+++ b/test/metabase/server/middleware/session_test.clj
@@ -313,7 +313,7 @@
       (t2/insert! Session {:id      (str test-uuid)
                            :user_id (mt/user->id :lucky)})
         ;; use low-level `execute!` because updating is normally disallowed for Sessions
-      (db/execute! {:update :core_session, :set {:created_at (t/instant 0)}, :where [:= :id (str test-uuid)]})
+      (t2/query-one {:update :core_session, :set {:created_at (t/instant 0)}, :where [:= :id (str test-uuid)]})
       (is (= nil
              (#'mw.session/current-user-info-for-session (str test-uuid) nil)))
       (finally

--- a/test/metabase/setup_test.clj
+++ b/test/metabase/setup_test.clj
@@ -6,13 +6,13 @@
     :as schema-migrations-test.impl]
    [metabase.setup :as setup]
    [metabase.test :as mt]
-   [toucan.db :as db]))
+   [toucan2.core :as t2]))
 
 (deftest has-user-setup-cached-test
   (testing "The has-user-setup getter should cache truthy results since it can never become falsey"
     ;; make sure some test users are created.
     (mt/initialize-if-needed! :test-users)
-    (db/with-call-counting [call-count]
+    (t2/with-call-count [call-count]
       ;; call has-user-setup several times.
       (dotimes [_ 5]
         (is (= true
@@ -25,7 +25,7 @@
     (schema-migrations-test.impl/with-temp-empty-app-db [_conn :h2]
       ;; make sure the DB is setup (e.g., run all the Liquibase migrations)
       (mdb/setup-db!)
-      (db/with-call-counting [call-count]
+      (t2/with-call-count [call-count]
         (dotimes [_ 5]
           (is (= false
                  (setup/has-user-setup))))
@@ -33,7 +33,7 @@
           (is (= 5
                  (call-count)))))))
   (testing "Switch back to the 'normal' app DB; value should still be cached for it"
-    (db/with-call-counting [call-count]
+    (t2/with-call-count [call-count]
       (is (= true
              (setup/has-user-setup)))
       (is (zero? (call-count))))))

--- a/test/metabase/test/data/users.clj
+++ b/test/metabase/test/data/users.clj
@@ -15,7 +15,6 @@
    [metabase.util :as u]
    [metabase.util.password :as u.password]
    [schema.core :as s]
-   [toucan.db :as db]
    [toucan.util.test :as tt]
    [toucan2.core :as t2])
   (:import
@@ -191,15 +190,15 @@
       (when-not user-email
         (throw (ex-info "User does not exist" {:user user})))
       (try
-        (db/execute! {:update :core_user
-                      :set    {:password      (u.password/hash-bcrypt user-email)
-                               :password_salt ""}
-                      :where  [:= :id user-id]})
+        (t2/query-one {:update :core_user
+                       :set    {:password      (u.password/hash-bcrypt user-email)
+                                :password_salt ""}
+                       :where  [:= :id user-id]})
         (apply client/client {:username user-email, :password user-email} args)
         (finally
-          (db/execute! {:update :core_user
-                        :set    old-password-info
-                        :where  [:= :id user-id]}))))))
+          (t2/query-one {:update :core_user
+                         :set    old-password-info
+                         :where  [:= :id user-id]}))))))
 
 (defn do-with-test-user [user-kwd thunk]
   (t/testing (format "with test user %s\n" user-kwd)

--- a/test/metabase/test/util.clj
+++ b/test/metabase/test/util.clj
@@ -484,7 +484,7 @@
       (t2/update! model (u/the-id object-or-id) column->temp-value)
       (f)
       (finally
-        (db/execute!
+        (t2/query-one
          {:update (t2/table-name model)
           :set    original-column->value
           :where  [:= :id (u/the-id object-or-id)]})))))
@@ -633,7 +633,7 @@
                                                  0)
                        max-id-condition      [:> (models/primary-key model) old-max-id]
                        additional-conditions (with-model-cleanup-additional-conditions model)]]
-          (db/execute!
+          (t2/query-one
            {:delete-from (t2/table-name model)
             :where       (if (seq additional-conditions)
                            [:and max-id-condition additional-conditions]


### PR DESCRIPTION
There are pretty safe changes since they don't change in behavior.

- [(db/transaction body) -> (t2/with-transaction [_conn] body)](https://github.com/metabase/metabase/pull/29511/commits/a6f343a573028a1d5fdf1b006c4f5c22e3aeaa27)
- [(db/with-call-counting) -> (t2/with-call-count)](https://github.com/metabase/metabase/pull/29511/commits/82bbf651b600bc82e585ef28e7ca359bb172debf)
- [db/execute -> t2/query-one](https://github.com/metabase/metabase/pull/29511/commits/47768e86b2a0a8e821acf0ab05a23feb4000315e)

Epic: #29231