### PR TITLE
[MLv2] Round-trip JS <-> CLJS Cards on demand; use for display locking

### DIFF
--- a/frontend/src/metabase-lib/Question.ts
+++ b/frontend/src/metabase-lib/Question.ts
@@ -1460,7 +1460,7 @@ class QuestionInner {
 
   generateQueryDescription() {
     const query = this._getMLv2Query();
-    return ML.suggested_name(query);
+    return ML.suggestedName(query);
   }
 
   getUrlWithParameters(parameters, parameterValues, { objectId, clean } = {}) {

--- a/frontend/src/metabase-lib/Question.ts
+++ b/frontend/src/metabase-lib/Question.ts
@@ -141,8 +141,9 @@ function massageForRoundTripCheck(x) {
   Object.keys(x).forEach(k => {
     // Skip dataset_query - it's transformed separately and sometimes round-trips with slightly
     // different details but the same meaning.
-    result[k] =
-      k === "dataset_query" ? undefined : massageForRoundTripCheck(x[k]);
+    //result[k] =
+    //  k === "dataset_query" ? undefined : massageForRoundTripCheck(x[k]);
+    result[k] = massageForRoundTripCheck(x[k]);
   });
   return result;
 }
@@ -247,6 +248,8 @@ class QuestionInner {
           : undefined),
       });
       if (!_.isEqual(originalCard, roundTripped)) {
+        console.log("round-trip mismatch", originalCard, roundTripped);
+        //debugger;
         throw new Error(
           "round-tripped Question._card is not the same as the original",
         );

--- a/frontend/src/metabase-lib/Question.ts
+++ b/frontend/src/metabase-lib/Question.ts
@@ -1,7 +1,7 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 import _ from "underscore";
-import { assoc, assocIn, chain, dissoc, getIn } from "icepick";
+import { assoc, assocIn, chain, dissoc } from "icepick";
 /* eslint-disable import/order */
 // NOTE: the order of these matters due to circular dependency issues
 import slugg from "slugg";
@@ -27,6 +27,7 @@ import {
   Parameter as ParameterObject,
   ParameterId,
 } from "metabase-types/api";
+import * as C from "cljs/metabase.domain_entities.card";
 
 import * as AGGREGATION from "metabase-lib/queries/utils/aggregation";
 import * as FILTER from "metabase-lib/queries/utils/filter";
@@ -58,6 +59,7 @@ import {
   getParameterValuesBySlug,
   normalizeParameters,
 } from "metabase-lib/parameters/utils/parameter-values";
+import { normalize } from "metabase-lib/queries/utils/normalize";
 import {
   getTemplateTagParametersFromCard,
   remapParameterValuesToTemplateTags,
@@ -103,15 +105,66 @@ export type QuestionCreatorOpts = {
 };
 
 /**
+ * An "opaque type": this is a strong type the TS compiler understands, but you can only create one in this file.
+ *
+ * This technique gives us a way to pass around opaque CLJS values that TS will track for us, and in other files it
+ * gets treated like `unknown` so it can't be examined, manipulated or a new one created.
+ */
+type CljsCard = unknown & { _opaque: typeof CljsCard };
+declare const CljsCard: unique symbol;
+
+function massageForRoundTripCheck(x) {
+  if (typeof x === "undefined" || x == null) {
+    return null;
+  }
+  if (typeof x !== "object") {
+    return x;
+  }
+
+  if (Array.isArray(x)) {
+    const ret = x.map(massageForRoundTripCheck);
+    if (ret.length === 2 && (ret[0] === "field" || ret[0] === "expression")) {
+      ret.push(null);
+    }
+    return ret;
+  }
+
+  const ret = {};
+  for (const k of Object.keys(x)) {
+    ret[k] = massageForRoundTripCheck(x[k]);
+  }
+  return ret;
+}
+
+function diffKeys(a, b) {
+  const keys = [];
+  for (const k of Object.keys(a)) {
+    if (!_.isEqual(a[k], b[k])) {
+      keys.push(k);
+    }
+  }
+  return keys;
+}
+
+/**
  * This is a wrapper around a question/card object, which may contain one or more Query objects
  */
 
 class QuestionInner {
   /**
-   * The plain object presentation of this question, equal to the format that Metabase REST API understands.
+   * The plain JS object representation of this question, equal to the format that Metabase REST API understands.
    * It is called `card` for both historical reasons and to make a clear distinction to this class.
+   *
+   * DO NOT use `this._card` directly - see `this.card()` and its lazy conversion logic.
    */
-  _card: CardObject;
+  _card?: CardObject;
+
+  /**
+   * The CLJS map representation of this question. Opaque to TS, intended to be passed to CLJC functions.
+   *
+   * DO NOT use `this._cljsCardCached` directly - see `this._cljsCard()` and its lazy conversion logic.
+   */
+  _cljsCardCached?: CljsCard;
 
   /**
    * The Question wrapper requires a metadata object because the queries it contains (like {@link StructuredQuery})
@@ -129,11 +182,19 @@ class QuestionInner {
    * Question constructor
    */
   constructor(
-    card: CardObject,
+    card: CardObject | CljsCard,
     metadata?: Metadata,
     parameterValues?: ParameterValues,
   ) {
-    this._card = card;
+    // The constructor can be passed either the vanilla JS `CardObject` or a CLJS map.
+    // This caches whichever representation is passed in.
+    // If the other is needed it will be converted lazily; see `card()` and `_cljsCard()`.
+    if (!card || card.constructor === Object) {
+      this._card = (card as CardObject) || {};
+    } else {
+      this._cljsCardCached = card as CljsCard;
+    }
+
     this._metadata =
       metadata ||
       new Metadata({
@@ -147,6 +208,7 @@ class QuestionInner {
     this._parameterValues = parameterValues || {};
   }
 
+  // TODO: Remove callers and this method - Question is already immutable (up to caching).
   clone() {
     return new Question(this._card, this._metadata, this._parameterValues);
   }
@@ -155,18 +217,76 @@ class QuestionInner {
     return this._metadata;
   }
 
-  card() {
+  card(): CardObject {
     return this._doNotCallSerializableCard();
   }
 
-  _doNotCallSerializableCard() {
+  /** Returns the cached CLJS representation, or lazily creates it from {@link _card}. */
+  private _cljsCard(): CljsCard {
+    if (!this._cljsCardCached) {
+      if (!this._card) {
+        throw new Error(
+          "infinite loop - Question has neither _card nor _cljsCardCached",
+        );
+      }
+      this._cljsCardCached = C.from_js(
+        this.databaseId(),
+        this.metadata(),
+        this._card,
+      );
+
+      // TODO: Remove this dev-time check, eventually. It's a useful debugging aid during this transition.
+      const roundTripped = massageForRoundTripCheck(
+        C.to_js(this._cljsCardCached),
+      );
+      // Slightly massage the JS card to match a few details of the CLJS transition.
+      const originalCard = massageForRoundTripCheck({
+        ...this._card,
+        ...("parameters" in this._card
+          ? { parameters: this._card.parameters }
+          : undefined),
+      });
+      if (!_.isEqual(originalCard, roundTripped)) {
+        console.log(
+          originalCard,
+          roundTripped,
+          diffKeys(originalCard, roundTripped),
+        );
+        //debugger;
+        throw new Error(
+          "round-tripped Question._card is not the same as the original",
+        );
+      }
+    }
+    return this._cljsCardCached;
+  }
+
+  /** Returns the cached plain JS representation, or lazily creates it from {@link _cljsCard}. */
+  _doNotCallSerializableCard(): CardObject {
+    if (!this._card) {
+      if (!this._cljsCardCached) {
+        throw new Error(
+          "infinite loop - Question has neither _card nor _cljsCardCached",
+        );
+      }
+      this._card = C.to_js(this._cljsCardCached);
+    }
     return this._card;
   }
 
   setCard(card: CardObject): Question {
-    const q = this.clone();
-    q._card = card;
-    return q;
+    return new Question(card, this.metadata(), this._parameterValues);
+  }
+
+  private _fromCljs(cljsCard: CljsCard): Question {
+    // Note that in CLJS:
+    //   (let [x {:foo "bar"}]
+    //     (identical? x (assoc x :foo "bar")))
+    // That is, updating some key of a map to the same value results in returning the original map.
+    // Here we detect these non-changes and simply return `this` for efficiency, caching, etc.
+    return cljsCard === this._cljsCardCached
+      ? this
+      : new Question(cljsCard, this.metadata(), this._parameterValues);
   }
 
   withoutNameAndId() {
@@ -202,7 +322,7 @@ class QuestionInner {
    * This is just a wrapper object, the data is stored in `this._card.dataset_query` in a format specific to the query type.
    */
   query(): AtomicQuery {
-    const datasetQuery = this._card.dataset_query;
+    const datasetQuery = this.card().dataset_query;
 
     for (const QueryClass of [StructuredQuery, NativeQuery, InternalQuery]) {
       if (QueryClass.isDatasetQueryType(datasetQuery)) {
@@ -222,11 +342,11 @@ class QuestionInner {
   }
 
   setEnableEmbedding(enabled: boolean): Question {
-    return this.setCard(assoc(this._card, "enable_embedding", enabled));
+    return this.setCard(assoc(this.card(), "enable_embedding", enabled));
   }
 
   setEmbeddingParams(params: Record<string, any> | null): Question {
-    return this.setCard(assoc(this._card, "embedding_params", params));
+    return this.setCard(assoc(this.card(), "embedding_params", params));
   }
 
   /**
@@ -234,7 +354,7 @@ class QuestionInner {
    * The query is saved to the `dataset_query` field of the Card object.
    */
   setQuery(newQuery: BaseQuery): Question {
-    if (this._card.dataset_query !== newQuery.datasetQuery()) {
+    if (this.card().dataset_query !== newQuery.datasetQuery()) {
       return this.setCard(
         assoc(this.card(), "dataset_query", newQuery.datasetQuery()),
       );
@@ -268,7 +388,7 @@ class QuestionInner {
    * The visualization type of the question
    */
   display(): string {
-    return this._card && this._card.display;
+    return this.card()?.display;
   }
 
   setDisplay(display) {
@@ -276,7 +396,7 @@ class QuestionInner {
   }
 
   cacheTTL(): number | null {
-    return this._card?.cache_ttl;
+    return this.card()?.cache_ttl;
   }
 
   setCacheTTL(cache) {
@@ -287,8 +407,8 @@ class QuestionInner {
    * returns whether this question is a model
    * @returns boolean
    */
-  isDataset() {
-    return this._card && this._card.dataset;
+  isDataset(): boolean {
+    return !!this.card()?.dataset;
   }
 
   setDataset(dataset) {
@@ -296,7 +416,7 @@ class QuestionInner {
   }
 
   isPersisted() {
-    return this._card && this._card.persisted;
+    return this.card()?.persisted;
   }
 
   setPersisted(isPersisted) {
@@ -315,23 +435,26 @@ class QuestionInner {
   }
 
   setDisplayIsLocked(locked: boolean): Question {
-    return this.setCard(assoc(this.card(), "displayIsLocked", locked));
+    return this._fromCljs(C.with_display_is_locked(this._cljsCard(), locked));
   }
 
   displayIsLocked(): boolean {
-    return this._card && this._card.displayIsLocked;
+    return C.display_is_locked(this._cljsCard());
   }
 
   // If we're locked to a display that is no longer "sensible", unlock it
   // unless it was locked in unsensible
-  maybeUnlockDisplay(sensibleDisplays, previousSensibleDisplays): Question {
-    const wasSensible =
-      previousSensibleDisplays == null ||
-      previousSensibleDisplays.includes(this.display());
-    const isSensible = sensibleDisplays.includes(this.display());
-    const shouldUnlock = wasSensible && !isSensible;
-    const locked = this.displayIsLocked() && !shouldUnlock;
-    return this.setDisplayIsLocked(locked);
+  maybeUnlockDisplay(
+    sensibleDisplays: string[],
+    previousSensibleDisplays?: string[],
+  ): Question {
+    return this._fromCljs(
+      C.maybe_unlock_display(
+        this._cljsCard(),
+        sensibleDisplays,
+        previousSensibleDisplays,
+      ),
+    );
   }
 
   // Switches display based on data shape. For 1x1 data, we show a scalar. If
@@ -442,7 +565,7 @@ class QuestionInner {
   }
 
   settings(): VisualizationSettings {
-    return (this._card && this._card.visualization_settings) || {};
+    return this.card()?.visualization_settings || {};
   }
 
   setting(settingName, defaultValue = undefined) {
@@ -485,7 +608,7 @@ class QuestionInner {
   }
 
   canWrite(): boolean {
-    return this._card && this._card.can_write;
+    return this.card()?.can_write;
   }
 
   canWriteActions(): boolean {
@@ -893,11 +1016,12 @@ class QuestionInner {
    * A user-defined name for the question
    */
   displayName(): string | null | undefined {
-    return this._card && this._card.name;
+    return this.card()?.name;
   }
 
   slug(): string | null | undefined {
-    return this._card?.name && `${this._card.id}-${slugg(this._card.name)}`;
+    const card = this.card();
+    return card?.name && `${card.id}-${slugg(card.name)}`;
   }
 
   setDisplayName(name: string | null | undefined) {
@@ -905,7 +1029,7 @@ class QuestionInner {
   }
 
   collectionId(): number | null | undefined {
-    return this._card && this._card.collection_id;
+    return this.card()?.collection_id;
   }
 
   setCollectionId(collectionId: number | null | undefined) {
@@ -913,7 +1037,7 @@ class QuestionInner {
   }
 
   id(): number {
-    return this._card && this._card.id;
+    return this.card()?.id;
   }
 
   setId(id: number | undefined): Question {
@@ -941,7 +1065,7 @@ class QuestionInner {
   }
 
   description(): string | null {
-    return this._card && this._card.description;
+    return this.card().description;
   }
 
   setDescription(description) {
@@ -949,11 +1073,11 @@ class QuestionInner {
   }
 
   lastEditInfo() {
-    return this._card && this._card["last-edit-info"];
+    return this.card()?.["last-edit-info"];
   }
 
   lastQueryStart() {
-    return this._card?.last_query_start;
+    return this.card()?.last_query_start;
   }
 
   isSaved(): boolean {
@@ -961,11 +1085,11 @@ class QuestionInner {
   }
 
   publicUUID(): string {
-    return this._card && this._card.public_uuid;
+    return this.card()?.public_uuid;
   }
 
   setPublicUUID(public_uuid: string | null): Question {
-    return this.setCard({ ...this._card, public_uuid });
+    return this.setCard({ ...this.card(), public_uuid });
   }
 
   database(): Database | null | undefined {
@@ -991,7 +1115,7 @@ class QuestionInner {
   }
 
   isArchived(): boolean {
-    return this._card && this._card.archived;
+    return !!this.card()?.archived;
   }
 
   getUrl({
@@ -1165,8 +1289,7 @@ class QuestionInner {
     const parameters = normalizeParameters(this.parameters());
 
     if (canUseCardApiEndpoint) {
-      const dashboardId = this._card.dashboardId;
-      const dashcardId = this._card.dashcardId;
+      const { dashboardId, dashcardId } = this.card();
 
       const queryParams = {
         cardId: this.id(),
@@ -1222,9 +1345,7 @@ class QuestionInner {
   }
 
   setParameterValues(parameterValues) {
-    const question = this.clone();
-    question._parameterValues = parameterValues;
-    return question;
+    return new Question(this.card(), this._metadata, parameterValues);
   }
 
   // TODO: Fix incorrect Flow signature
@@ -1280,35 +1401,36 @@ class QuestionInner {
     creationType,
   } = {}) {
     const query = clean ? this.query().clean() : this.query();
+    const card = this.card();
     const cardCopy = {
-      name: this._card.name,
-      description: this._card.description,
-      collection_id: this._card.collection_id,
-      dataset_query: query.datasetQuery(),
-      display: this._card.display,
-      parameters: this._card.parameters,
-      dataset: this._card.dataset,
+      name: card.name,
+      description: card.description,
+      collection_id: card.collection_id,
+      dataset_query: normalize(query.datasetQuery()),
+      display: card.display,
+      parameters: card.parameters,
+      dataset: card.dataset,
       ...(_.isEmpty(this._parameterValues)
         ? undefined
         : {
             parameterValues: this._parameterValues,
           }),
       // this is kinda wrong. these values aren't really part of the card, but this is a convenient place to put them
-      visualization_settings: this._card.visualization_settings,
+      visualization_settings: card.visualization_settings,
       ...(includeOriginalCardId
         ? {
-            original_card_id: this._card.original_card_id,
+            original_card_id: card.original_card_id,
           }
         : {}),
       ...(includeDisplayIsLocked
         ? {
-            displayIsLocked: this._card.displayIsLocked,
+            displayIsLocked: card.displayIsLocked,
           }
         : {}),
 
       ...(creationType ? { creationType } : {}),
-      dashboardId: this._card.dashboardId,
-      dashcardId: this._card.dashcardId,
+      dashboardId: card.dashboardId,
+      dashcardId: card.dashcardId,
     };
     return utf8_to_b64url(JSON.stringify(sortObject(cardCopy)));
   }
@@ -1336,35 +1458,6 @@ class QuestionInner {
       .setParameterValues(undefined);
 
     return hasQueryBeenAltered ? question.markDirty() : question;
-  }
-
-  _getMLv2Query(metadata = this._metadata): Query {
-    // cache the metadata provider we create for our metadata.
-    if (metadata === this._metadata) {
-      if (!this.__mlv2MetadataProvider) {
-        this.__mlv2MetadataProvider = ML.metadataProvider(
-          this.databaseId(),
-          metadata,
-        );
-      }
-      metadata = this.__mlv2MetadataProvider;
-    }
-
-    if (this.__mlv2QueryMetadata !== metadata) {
-      this.__mlv2QueryMetadata = null;
-      this.__mlv2Query = null;
-    }
-
-    if (!this.__mlv2Query) {
-      this.__mlv2QueryMetadata = metadata;
-      this.__mlv2Query = ML.fromLegacyQuery(
-        this.databaseId(),
-        metadata,
-        this.datasetQuery(),
-      );
-    }
-
-    return this.__mlv2Query;
   }
 
   generateQueryDescription() {
@@ -1410,7 +1503,7 @@ class QuestionInner {
   }
 
   getModerationReviews() {
-    return getIn(this, ["_card", "moderation_reviews"]) || [];
+    return this.card()?.moderation_reviews || [];
   }
 }
 

--- a/frontend/src/metabase-lib/Question.ts
+++ b/frontend/src/metabase-lib/Question.ts
@@ -139,7 +139,10 @@ function massageForRoundTripCheck(x) {
   // An object: recursively massage each value.
   const result = {};
   Object.keys(x).forEach(k => {
-    result[k] = massageForRoundTripCheck(x[k]);
+    // Skip dataset_query - it's transformed separately and sometimes round-trips with slightly
+    // different details but the same meaning.
+    result[k] =
+      k === "dataset_query" ? undefined : massageForRoundTripCheck(x[k]);
   });
   return result;
 }
@@ -237,7 +240,6 @@ class QuestionInner {
       const roundTripped = massageForRoundTripCheck(
         CARD.to_js(this._cljsCardCached),
       );
-      // Slightly massage the JS card to match a few details of the CLJS transition.
       const originalCard = massageForRoundTripCheck({
         ...this._card,
         ...("parameters" in this._card

--- a/frontend/src/metabase-lib/Question.ts
+++ b/frontend/src/metabase-lib/Question.ts
@@ -27,7 +27,7 @@ import {
   Parameter as ParameterObject,
   ParameterId,
 } from "metabase-types/api";
-import * as C from "cljs/metabase.domain_entities.card";
+import * as CARD from "cljs/metabase.domain_entities.card";
 
 import * as AGGREGATION from "metabase-lib/queries/utils/aggregation";
 import * as FILTER from "metabase-lib/queries/utils/filter";
@@ -227,7 +227,7 @@ class QuestionInner {
           "infinite loop - Question has neither _card nor _cljsCardCached",
         );
       }
-      this._cljsCardCached = C.from_js(
+      this._cljsCardCached = CARD.from_js(
         this.databaseId(),
         this.metadata(),
         this._card,
@@ -235,7 +235,7 @@ class QuestionInner {
 
       // TODO: Remove this dev-time check, eventually. It's a useful debugging aid during this transition.
       const roundTripped = massageForRoundTripCheck(
-        C.to_js(this._cljsCardCached),
+        CARD.to_js(this._cljsCardCached),
       );
       // Slightly massage the JS card to match a few details of the CLJS transition.
       const originalCard = massageForRoundTripCheck({
@@ -261,7 +261,7 @@ class QuestionInner {
           "infinite loop - Question has neither _card nor _cljsCardCached",
         );
       }
-      this._card = C.to_js(this._cljsCardCached);
+      this._card = CARD.to_js(this._cljsCardCached);
     }
     return this._card;
   }
@@ -427,11 +427,13 @@ class QuestionInner {
   }
 
   setDisplayIsLocked(locked: boolean): Question {
-    return this._fromCljs(C.with_display_is_locked(this._cljsCard(), locked));
+    return this._fromCljs(
+      CARD.with_display_is_locked(this._cljsCard(), locked),
+    );
   }
 
   displayIsLocked(): boolean {
-    return C.display_is_locked(this._cljsCard());
+    return CARD.display_is_locked(this._cljsCard());
   }
 
   // If we're locked to a display that is no longer "sensible", unlock it
@@ -441,7 +443,7 @@ class QuestionInner {
     previousSensibleDisplays?: string[],
   ): Question {
     return this._fromCljs(
-      C.maybe_unlock_display(
+      CARD.maybe_unlock_display(
         this._cljsCard(),
         sensibleDisplays,
         previousSensibleDisplays,
@@ -1452,9 +1454,13 @@ class QuestionInner {
     return hasQueryBeenAltered ? question.markDirty() : question;
   }
 
+  _getMLv2Query(): Query {
+    return CARD.dataset_query(this._cljsCard());
+  }
+
   generateQueryDescription() {
     const query = this._getMLv2Query();
-    return ML.suggestedName(query);
+    return ML.suggested_name(query);
   }
 
   getUrlWithParameters(parameters, parameterValues, { objectId, clean } = {}) {

--- a/frontend/src/metabase-lib/metadata.ts
+++ b/frontend/src/metabase-lib/metadata.ts
@@ -8,7 +8,7 @@ export function metadataProvider(
   databaseId: DatabaseId,
   metadata: Metadata,
 ): MetadataProvider {
-  return ML.metadataProvider(databaseId, metadata);
+  return ML.__GT_metadata_provider(databaseId, metadata);
 }
 
 export function displayName(query: Query, clause: Clause): string {

--- a/frontend/src/metabase-lib/metadata/Table.ts
+++ b/frontend/src/metabase-lib/metadata/Table.ts
@@ -62,7 +62,7 @@ class TableInner extends Base {
 
   question() {
     return Question.create({
-      databaseId: (this.db && this.db.id) || this.db_id,
+      databaseId: this.db?.id || this.db_id,
       tableId: this.id,
       metadata: this.metadata,
     });

--- a/frontend/src/metabase-lib/metadata/Table.ts
+++ b/frontend/src/metabase-lib/metadata/Table.ts
@@ -62,7 +62,7 @@ class TableInner extends Base {
 
   question() {
     return Question.create({
-      databaseId: this.db && this.db.id,
+      databaseId: (this.db && this.db.id) || this.db_id,
       tableId: this.id,
       metadata: this.metadata,
     });

--- a/frontend/src/metabase-lib/native.ts
+++ b/frontend/src/metabase-lib/native.ts
@@ -1,0 +1,11 @@
+import * as ML from "cljs/metabase.lib.js";
+import { TemplateTags } from "metabase-types/types/Query";
+
+export function templateTags(
+  queryText: string,
+  existingTags?: TemplateTags,
+): TemplateTags {
+  return existingTags
+    ? ML.template_tags(queryText, existingTags)
+    : ML.template_tags(queryText);
+}

--- a/frontend/src/metabase-lib/queries/NativeQuery.ts
+++ b/frontend/src/metabase-lib/queries/NativeQuery.ts
@@ -4,7 +4,6 @@ import { t } from "ttag";
 import { assoc, assocIn, chain, getIn, updateIn } from "icepick";
 import _ from "underscore";
 import slugg from "slugg";
-import * as ML from "cljs/metabase.lib.js";
 import { ParameterValuesConfig } from "metabase-types/api";
 import {
   Card,
@@ -28,6 +27,7 @@ import ValidationError from "metabase-lib/ValidationError";
 import { isFieldReference } from "metabase-lib/references";
 import Dimension, { FieldDimension, TemplateTagDimension } from "../Dimension";
 import DimensionOptions from "../DimensionOptions";
+import * as ML from "../v2";
 
 import { getNativeQueryTable } from "./utils/native-query-table";
 
@@ -438,7 +438,7 @@ export default class NativeQuery extends AtomicQuery {
    */
   private _getUpdatedTemplateTags(queryText: string): TemplateTags {
     return queryText && this.supportsNativeParameters()
-      ? ML.template_tags(queryText, this.templateTagsMap())
+      ? ML.templateTags(queryText, this.templateTagsMap())
       : {};
   }
 

--- a/frontend/src/metabase-lib/queries/StructuredQuery.ts
+++ b/frontend/src/metabase-lib/queries/StructuredQuery.ts
@@ -222,7 +222,7 @@ class StructuredQueryInner extends AtomicQuery {
    * @returns the underlying MBQL query object
    */
   query(): StructuredQueryObject {
-    return this._structuredDatasetQuery.query;
+    return this._structuredDatasetQuery.query || {};
   }
 
   setQuery(query: StructuredQueryObject): StructuredQuery {

--- a/frontend/src/metabase-lib/query.ts
+++ b/frontend/src/metabase-lib/query.ts
@@ -15,7 +15,7 @@ export function toLegacyQuery(query: Query): DatasetQuery {
 }
 
 export function suggestedName(query: Query): string {
-  return ML.suggestedName(query);
+  return ML.suggested_name(query);
 }
 
 declare function RemoveClauseFn(query: Query, targetClause: Clause): Query;

--- a/frontend/src/metabase-lib/v2.ts
+++ b/frontend/src/metabase-lib/v2.ts
@@ -3,6 +3,7 @@
 export * from "./comparison";
 export * from "./metadata";
 export * from "./limit";
+export * from "./native";
 export * from "./order_by";
 export * from "./query";
 export * from "./types";

--- a/frontend/src/metabase/components/MetadataInfo/TableInfo/ConnectedTables.unit.spec.tsx
+++ b/frontend/src/metabase/components/MetadataInfo/TableInfo/ConnectedTables.unit.spec.tsx
@@ -20,11 +20,13 @@ describe("ConnectedTables", () => {
   it("should show a label for each connected table", () => {
     const table = new Table({
       id: 1,
+      db_id: 2,
       fks: [
         {
           origin: {
             table: {
               id: 2,
+              db_id: 2,
               display_name: "Foo",
             },
           },
@@ -33,6 +35,7 @@ describe("ConnectedTables", () => {
           origin: {
             table: {
               id: 3,
+              db_id: 2,
               display_name: "Bar",
             },
           },

--- a/frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.unit.spec.js
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.unit.spec.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { render, fireEvent, screen, within } from "@testing-library/react";
 
-import { SAMPLE_DATABASE } from "__support__/sample_database_fixture";
+import { ORDERS } from "__support__/sample_database_fixture";
 
 import ChartTypeSidebar from "metabase/query_builder/components/view/sidebars/ChartTypeSidebar";
 
@@ -11,7 +11,7 @@ const DATA = {
 };
 
 const setup = props => {
-  const question = SAMPLE_DATABASE.question().setDisplay("gauge");
+  const question = ORDERS.question().setDisplay("gauge");
   render(
     <ChartTypeSidebar
       question={question}

--- a/frontend/test/__support__/sample_database_fixture.json
+++ b/frontend/test/__support__/sample_database_fixture.json
@@ -62,7 +62,7 @@
         "description": "Because we want to know the total I ugess",
         "table_id": 1,
         "definition": {
-          "filter": [">", 6, 20],
+          "filter": [">", ["field", 6, null], 20],
           "aggregation": [["sum", ["field", 6, null]]],
           "source-table": 1
         },

--- a/frontend/test/metabase-lib/lib/Question.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/Question.unit.spec.js
@@ -69,7 +69,9 @@ const orders_count_where_card = {
     database: SAMPLE_DATABASE.id,
     query: {
       "source-table": ORDERS.id,
-      aggregation: [["count-where", [">", ORDERS.TOTAL.id, 50]]],
+      aggregation: [
+        ["count-where", [">", ["field", ORDERS.TOTAL.id, null], 50]],
+      ],
     },
   },
 };

--- a/frontend/test/metabase-lib/lib/Question.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/Question.unit.spec.js
@@ -1572,6 +1572,7 @@ describe("Question", () => {
   describe("Question.generateQueryDescription", () => {
     it("should work with multiple aggregations", () => {
       const question = base_question.setDatasetQuery({
+        type: "query",
         query: {
           "source-table": ORDERS.id,
           aggregation: [["count"], ["sum", ["field", 6, null]]],
@@ -1584,6 +1585,7 @@ describe("Question", () => {
 
     it("should work with named aggregations", () => {
       const question = base_question.setDatasetQuery({
+        type: "query",
         query: {
           "source-table": ORDERS.id,
           aggregation: [

--- a/package.json
+++ b/package.json
@@ -293,6 +293,7 @@
     "test-unit": "yarn build-quick:cljs && jest --maxWorkers=2 --config jest.unit.conf.json",
     "test-unit-keep-cljs": "jest --maxWorkers=2 --config jest.unit.conf.json",
     "test-unit-watch": "yarn test-unit --watch",
+    "test-unit-watch-keep-cljs": "jest --maxWorkers=2 --config jest.unit.conf.json --watch",
     "test-unit-watch:cljs": "yarn concurrently -n 'cljs,tests' 'yarn build-watch:cljs' 'yarn test-unit-keep-cljs --watch'",
     "test-timezones-unit": "yarn build-quick:cljs && jest --silent --maxWorkers=2 --config jest.tz.unit.conf.json",
     "test-timezones": "yarn && ./frontend/test/__runner__/run_timezone_tests",

--- a/package.json
+++ b/package.json
@@ -293,7 +293,6 @@
     "test-unit": "yarn build-quick:cljs && jest --maxWorkers=2 --config jest.unit.conf.json",
     "test-unit-keep-cljs": "jest --maxWorkers=2 --config jest.unit.conf.json",
     "test-unit-watch": "yarn test-unit --watch",
-    "test-unit-watch-keep-cljs": "jest --maxWorkers=2 --config jest.unit.conf.json --watch",
     "test-unit-watch:cljs": "yarn concurrently -n 'cljs,tests' 'yarn build-watch:cljs' 'yarn test-unit-keep-cljs --watch'",
     "test-timezones-unit": "yarn build-quick:cljs && jest --silent --maxWorkers=2 --config jest.tz.unit.conf.json",
     "test-timezones": "yarn && ./frontend/test/__runner__/run_timezone_tests",

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -15,7 +15,8 @@
    :dev        {:output-dir "frontend/src/cljs/"
                 :compiler-options {:reader-features #{:cljs-dev}}}
    :compiler-options {:reader-features #{:cljs-release}}
-   :entries    [metabase.domain-entities.queries.util
+   :entries    [metabase.domain-entities.card
+                metabase.domain-entities.queries.util
                 metabase.lib.js
                 metabase.lib.limit
                 metabase.mbql.js

--- a/src/metabase/domain_entities/card.cljc
+++ b/src/metabase/domain_entities/card.cljc
@@ -1,12 +1,12 @@
 (ns metabase.domain-entities.card
   "Functions for building, updating and querying Cards (that is, Metabase questions)."
   (:require
+   [malli.util :as mut]
    [metabase.domain-entities.malli :as de]
    [metabase.lib.schema :as lib.schema]
    [metabase.util.malli :as mu]
    #?@(:cljs ([metabase.domain-entities.converters :as converters]
               [malli.core :as mc]
-              [malli.util :as mut]
               [metabase.lib.convert :as lib.convert]
               [metabase.lib.js :as lib.js]))))
 

--- a/src/metabase/domain_entities/card.cljc
+++ b/src/metabase/domain_entities/card.cljc
@@ -6,8 +6,6 @@
    [metabase.lib.schema :as lib.schema]
    [metabase.util.malli :as mu]
    #?@(:cljs ([metabase.domain-entities.converters :as converters]
-              [malli.core :as mc]
-              [metabase.lib.convert :as lib.convert]
               [metabase.lib.js :as lib.js]))))
 
 ;;; ----------------------------------- Schemas for Card -----------------------------------------

--- a/src/metabase/domain_entities/card.cljc
+++ b/src/metabase/domain_entities/card.cljc
@@ -1,0 +1,260 @@
+(ns metabase.domain-entities.card
+  "Functions for building, updating and querying Cards (that is, Metabase questions)."
+  (:require
+   [metabase.domain-entities.malli :as de]
+   [metabase.lib.schema :as lib.schema]
+   [metabase.util.malli :as mu]
+   #?@(:cljs ([metabase.domain-entities.converters :as converters]
+              [malli.core :as mc]
+              [malli.util :as mut]
+              [metabase.lib.convert :as lib.convert]
+              [metabase.lib.js :as lib.js]))))
+
+;;; ----------------------------------- Schemas for Card -----------------------------------------
+(def VisualizationSettings
+  "Malli schema for `visualization_settings` - a map of strings to opaque JS values."
+  [:map-of string? :any])
+
+(def LocalFieldReference
+  "Malli schema for a *legacy* field clause for a local field."
+  [:tuple
+   [:= :field]
+   number?
+   [:maybe [:map-of string? :any]]])
+
+(def ForeignFieldReference
+  "Malli schema for a *legacy* field clause for a foreign field."
+  [:tuple
+   [:= :field]
+   [:or number? string?]
+   [:map [:source-field {:js/prop "source-field"} [:or number? string?]]]])
+
+(def VariableTarget
+  "Malli schema for a parameter that references a template variable."
+  [:tuple [:= :template-tag] string?])
+
+(def ParameterTarget
+  "Malli schema for a parameter's target field."
+  [:orn
+   [:variable [:tuple [:= :variable] VariableTarget]]
+   [:dimension [:tuple
+                [:= :dimension]
+                [:or LocalFieldReference ForeignFieldReference VariableTarget]]]])
+
+(def Parameter
+  "Malli schema for each Card.parameters value."
+  [:map
+   [:id string?]
+   [:name string?]
+   [:display-name {:optional true :js/prop "display-name"} string?]
+   [:slug string?]
+   [:type string?]
+   [:sectionId {:optional true :js-prep "sectionId"} string?]
+   [:default {:optional true} :any]
+   [:filtering-parameters {:optional true :js/prop "filteringParameters"} [:vector string?]]
+   [:is-multi-select {:optional true :js/prop "isMultiSelect"} boolean?]
+   [:required {:optional true} boolean?]
+   [:target {:optional true} ParameterTarget]
+   [:value {:optional true} :any]
+   [:values_query_type {:optional true} :any]
+   [:values_source_config {:optional true} :any]
+   [:values_source_type {:optional true} :any]])
+
+(def Card
+  "Malli schema for a possibly-saved Card."
+  [:schema
+   [:map
+    [:archived {:optional true} boolean?]
+    [:average_query_time {:optional true} number?]
+    [:breakout-column {:optional true :js/prop "_breakoutColumn"} :any]
+    [:breakout-value {:optional true :js/prop "_breakoutValue"} :any]
+    [:cache-ttl {:optional true} [:maybe number?]]
+    [:can_write {:optional true} boolean?]
+    [:collection {:optional true} :any]
+    [:collection_id [:maybe number?]]
+    [:collection_position [:maybe number?]]
+    [:collection_preview boolean?]
+    [:created_at [:maybe string?]] ;; TODO: Date regex?
+    [:creator {:optional true}
+     [:map
+      [:id number?]
+      [:common_name string?]
+      [:date_joined string?] ;; TODO: Date regex
+      [:email string?]
+      [:first_name  [:maybe string?]]
+      [:is_qbnewb boolean?]
+      [:is_superuser boolean?]
+      [:last_login string?] ;; TODO: Date regex
+      [:last_name   [:maybe string?]]]]
+    [:creator_id {:optional true} number?]
+    [:creation-type {:optional true :js/prop "creationType"} string?]
+    [:dashboard_count {:optional true} number?]
+    [:dashboard-id {:optional true :js/prop "dashboardId"} number?]
+    [:dashcard-id  {:optional true :js/prop "dashcardId"}  number?]
+    [:database_id {:optional true} number?]
+    [:dataset {:optional true} boolean?]
+    [:dataset_query ::lib.schema/query] ;; NOTE: This is not converted using Malli; see CardNoQuery.
+    [:description [:maybe string?]]
+    ;; TODO: Display is really an enum but I don't know all its values.
+    ;; Known values: table, scalar, gauge, map, area, bar, line. There are more missing for sure.
+    [:display string?]
+    [:display-is-locked {:optional true :js/prop "displayIsLocked"} boolean?]
+    [:embedding_params {:optional true} :any]
+    [:enable_embedding {:optional true} boolean?]
+    [:entity_id {:optional true} string?]
+    [:id {:optional true} [:or number? string?]]
+    [:last-edit-info {:optional true :js/prop "last-edit-info"} :any]
+    [:last-query-start {:optional true} :any]
+    [:made_public_by_id {:optional true} [:maybe number?]]
+    [:moderation_reviews {:optional true} [:vector :any]]
+    [:name {:optional true} string?]
+    [:original_card_id {:optional true} number?]
+    [:original_card_name {:optional true :js/prop "originalCardName"} string?]
+    [:parameter_mappings {:optional true} [:vector :any]]
+    [:parameter_usage_count {:optional true} number?]
+    [:parameters {:optional true} [:sequential Parameter]]
+    [:persisted {:optional true} boolean?]
+    [:public_uuid {:optional true} [:maybe string?]]
+    [:query_type {:optional true} string?] ;; TODO: Probably an enum
+    [:result_metadata {:optional true} :any]
+    [:series_index {:optional true :js/prop "_seriesIndex"} :any]
+    [:series_key {:optional true :js/prop "_seriesKey"} :any]
+    [:table_id {:optional true} [:maybe number?]]
+    [:updated_at {:optional true} string?] ;; TODO: Date regex
+    [:visualization_settings VisualizationSettings]]])
+
+#?(:cljs
+   (def ^:private CardNoQuery
+     "Modified schema for Card, with the `:dataset_query` key set to :any.
+     Queries are special and we want Malli to disregard them."
+     (-> Card
+         mc/schema
+         mc/children
+         first
+         (mut/assoc-in [:dataset_query] :any))))
+
+#?(:cljs
+   (def ^:private ->CardNoQuery
+     "Converter from a plain JS object `Card` to a CLJS map for the card.
+     Has special handling for the query since we can't capture it well with Malli.
+     This returns the Card converting everything but the query, which is left alone."
+     (converters/incoming CardNoQuery)))
+
+#?(:cljs
+   (def ^:private CardNoQuery->
+     "Converter from CLJS map to a plain JS object `Card`.
+     Has special handling for the query since we can't capture it well with Malli.
+     This returns the Card converting everything but the query, which is left alone."
+     (converters/outgoing CardNoQuery)))
+
+
+;;; ------------------------------- JS<->CLJS conversion helpers ---------------------------------
+#?(:cljs
+   ;; This is annoying, but `clj->js` will squash namespaced keywords to just the `name`, which breaks the round-trip
+   ;; in a few specific cases (eg. [:template-tags "foo" :widget-type] can be `:date/all-options`).
+   ;; `clj->js` supports overriding how keyword map keys get transformed, but it doesn't let you override how it
+   ;; handles values, hence this custom function.
+   (defn- fix-namespaced-values [x]
+     (cond
+       (keyword? x)    (if-let [ns-part (namespace x)]
+                         (str ns-part "/" (name x))
+                         (name x))
+       (map? x)        (update-vals x fix-namespaced-values)
+       (sequential? x) (map fix-namespaced-values x)
+       :else           x)))
+
+#?(:cljs
+  (defn- outgoing-query [query]
+    (let [legacy (lib.convert/->legacy-MBQL query)]
+      #?(:cljs (-> legacy fix-namespaced-values clj->js)
+         :clj  legacy))))
+
+;;; ---------------------------------------- Exported API ----------------------------------------
+(de/define-getters-and-setters Card
+  ;; NOTE: Do not use define-getters-and-setters for `dataset-query`; it needs special handling.
+  display           [:display]
+  display-is-locked [:display-is-locked])
+
+#_#?(:cljs
+   (defn ^:export query-from-js
+     "Converter for a plain JS object query to a CLJS map.
+     Needs special handling, and not just a Malli conversion."
+     [js-query metadata-provider]
+     (let [converted   (if (object? js-query) (js->clj js-query) js-query)]
+       (->> converted
+            mbql.normalize/normalize
+            lib.convert/->pMBQL
+            (lib.query/query metadata-provider)))))
+
+#?(:cljs
+   (def ^:export from-js
+     "Converter from plain JS objects to CLJS maps.
+     You should pass this a JS `Card` and an instance of `Metadata`."
+     (fn [database-id js-metadata ^js js-card]
+       (let [query       (lib.js/query database-id js-metadata (.-dataset_query js-card))
+             card        (->CardNoQuery js-card)]
+         (js/console.log "from-js, before query added" card query)
+         (assoc card :dataset_query query)))))
+
+#?(:cljs
+   (defn ^:export to-js
+     "Converter from CLJS maps to plain JS objects."
+     [card]
+     (let [js-query (outgoing-query (:dataset_query card))]
+       (js/console.log "to-js, query" (:dataset_query card) js-query)
+       (-> card
+           (assoc :dataset_query js-query)
+           CardNoQuery->))))
+
+(mu/defn ^:export dataset-query :- ::lib.schema/query
+  "Returns the `:dataset_query` of a `Card`.
+
+  This can't be generated by [[de/define-getters-and-setters]] because the conversion of queries requires special
+  handling."
+  [card :- Card]
+  (when-not (map? card)
+    (throw (ex-info "dataset-query does not auto-convert; call from-js first" {})))
+  (:dataset_query card))
+
+(mu/defn ^:export with-dataset-query :- Card
+  "Attaches a `:dataset_query` to a `Card`.
+
+  This can't be generated by [[de/define-getters-and-setters]] because the conversion of queries requires special
+  handling.
+  "
+  [card :- Card dataset-query :- ::lib.schema/query]
+  (when-not (map? card)
+    (throw (ex-info "with-dataset-query does not auto-convert; call from-js first" {})))
+  (when-not (map? dataset-query)
+    (throw (ex-info "with-dataset-query does not auto-convert; call lib.js/query first" {})))
+  (assoc card :dataset_query dataset-query))
+
+(defn- set-like [inner-schema]
+  [:schema [:or [:set inner-schema] [:sequential inner-schema]]])
+
+(mu/defn ^:export maybe-unlock-display :- Card
+  "Given current and previous sets of \"sensible\" display settings, check which of them the current `:display` setting
+  is in.
+  - If it's in the previous set, or the previous set is not defined, consider `:display` formerly sensible.
+  - If `:display` is in current set, consider `:display` currently sensible.
+
+  The `:display` should be unlocked if:
+  - it was formerly sensible, AND
+  - it is not currently sensible, AND
+  - the display is currently locked.
+  If the display is not currently locked, this never locks it."
+  ([card :- Card
+    current-sensible-displays :- (set-like string?)]
+   (maybe-unlock-display card current-sensible-displays nil))
+
+  ([card :- Card
+    current-sensible-displays  :- (set-like string?)
+    previous-sensible-displays :- [:maybe (set-like string?)]]
+   (let [dsp                 (display card)
+         previous            (set previous-sensible-displays)
+         current             (set current-sensible-displays)
+         formerly-sensible?  (or (empty? previous) (previous dsp)) ; An empty previous set is always sensible.
+         currently-sensible? (current dsp)
+         should-unlock?      (and formerly-sensible? (not currently-sensible?))]
+     (with-display-is-locked card (and (display-is-locked card)
+                                       (not should-unlock?))))))

--- a/src/metabase/lib/convert.cljc
+++ b/src/metabase/lib/convert.cljc
@@ -68,6 +68,13 @@
   [[_tag value opts]]
   (lib.options/ensure-uuid [:value opts value]))
 
+(defmethod ->pMBQL :time-interval
+  [[_tag w x y z]]
+  (default-MBQL-clause->pMBQL
+    (if (map? z)
+      [:time-interval z w x y]
+      [:time-interval w x y])))
+
 (defmethod ->pMBQL :aggregation-options
   [[_tag aggregation options]]
   (let [[tag opts & args] (->pMBQL aggregation)]
@@ -138,6 +145,11 @@
                 :trim :ltrim :rtrim :upper :lower]]
   (defmethod ->legacy-MBQL clause [input]
     (aggregation->legacy-MBQL input)))
+
+(defmethod ->legacy-MBQL :time-interval [[tag options & args]]
+  (clause-with-options->legacy-MBQL
+    (into [tag (set/rename-keys options {:include-current :include_current})]
+          args)))
 
 (defn- chain-stages [{:keys [stages]}]
   ;; :source-metadata aka :lib/stage-metadata is handled differently in the two formats.

--- a/src/metabase/lib/convert.cljc
+++ b/src/metabase/lib/convert.cljc
@@ -219,4 +219,7 @@
                (dissoc :stages)
                (update-vals ->legacy-MBQL))
            {:type      query-type
-            query-type inner-query})))
+            ;; This is here rather than in :mbql.stage/native, because the correct naming for a native query is:
+            ;; {:type :native :native {:query "SQL string"}} but for a nested query it's
+            ;; {:source-query {:native "SQL string"}} facepalm.png
+            query-type (set/rename-keys inner-query {:native :query})})))

--- a/src/metabase/lib/js.cljs
+++ b/src/metabase/lib/js.cljs
@@ -50,7 +50,7 @@
         (lib.core/template-tags query-text)
         lib.core/TemplateTags->)))
 
-(defn ^:export suggestedName
+(defn ^:export suggested-name
   "Return a nice description of a query."
   [query]
   (lib.metadata.calculation/suggested-name query))
@@ -64,7 +64,7 @@
     (mbql.normalize/normalize <>)
     (convert/->pMBQL <>)))
 
-(defn ^:export metadataProvider
+(defn ^:export ->metadata-provider
   "Convert metadata to a metadata provider if it is not one already."
   [database-id metadata]
   (if (lib.metadata.protocols/metadata-provider? metadata)
@@ -73,10 +73,13 @@
 
 (defn ^:export query
   "Coerce a plain map `query` to an actual query object that you can use with MLv2."
-  [database-id metadata query-map]
-  (let [query-map (pMBQL query-map)]
-    (log/debugf "query map: %s" (pr-str query-map))
-    (lib.query/query (metadataProvider database-id metadata) query-map)))
+  ([metadata-provider query-map]
+   (let [query-map (pMBQL query-map)]
+     (log/debugf "query map: %s" (pr-str query-map))
+     (lib.query/query metadata-provider query-map)))
+
+  ([database-id metadata query-map]
+   (query (->metadata-provider database-id metadata) query-map)))
 
 (defn- fix-namespaced-values
   "This converts namespaced keywords to strings as `\"foo/bar\"`.

--- a/src/metabase/lib/js.cljs
+++ b/src/metabase/lib/js.cljs
@@ -98,7 +98,10 @@
 (defn ^:export legacy-query
   "Coerce a CLJS pMBQL query back to (1) a legacy query (2) in vanilla JS."
   [query-map]
-  (-> query-map convert/->legacy-MBQL fix-namespaced-values clj->js))
+  (-> query-map
+      convert/->legacy-MBQL
+      fix-namespaced-values
+      (clj->js :keyword-fn u/qualified-name)))
 
 (defn ^:export orderable-columns
   "Return a sequence of Column metadatas about the columns you can add order bys for in a given stage of `a-query.` To

--- a/src/metabase/lib/query.cljc
+++ b/src/metabase/lib/query.cljc
@@ -134,7 +134,7 @@
    (native-query metadata-provider nil inner-query))
 
   ([metadata-provider :- lib.metadata/MetadataProvider
-    results-metadata  :- lib.metadata/StageMetadata
+    results-metadata  :- [:maybe lib.metadata/StageMetadata]
     inner-query]
    (query-with-stages metadata-provider
                       [(-> {:lib/type           :mbql.stage/native

--- a/src/metabase/lib/schema/filter.cljc
+++ b/src/metabase/lib/schema/filter.cljc
@@ -72,7 +72,7 @@
      #_part  [:ref ::expression/string]]))
 
 (def ^:private time-interval-options
-  [:map [:include-current {:optional true} :boolean]]) ; default false
+  [:map [:include-current {:optional true :js/prop "include_current"} :boolean]]) ; default false
 
 ;; SUGAR: rewritten as a filter clause with a relative-datetime value
 (mbql-clause/define-mbql-clause :time-interval :- :type/Boolean

--- a/test/metabase/lib/convert_test.cljc
+++ b/test/metabase/lib/convert_test.cljc
@@ -179,4 +179,37 @@
                                          [:field 23402 nil]
                                          [:field 23100 {:join-alias "CATEGORIES__via__CATEGORY_ID"}]]
                           :strategy     :left-join
-                          :fk-field-id  23402}]}}))
+                          :fk-field-id  23402}]}}
+
+    {:database 67
+     :query {:aggregation [[:aggregation-options
+                            [:avg
+                             [:field
+                              809
+                              {:metabase.query-processor.util.add-alias-info/source-alias "RATING"
+                               :metabase.query-processor.util.add-alias-info/source-table 224}]]
+                            {:name "avg"
+                             :metabase.query-processor.util.add-alias-info/desired-alias "avg"
+                             :metabase.query-processor.util.add-alias-info/position 1
+                             :metabase.query-processor.util.add-alias-info/source-alias "avg"}]]
+             :source-table 224}
+     :type :query}
+
+    {:dataset_query {:query    {:source-table 2
+                                :filter [:and [:time-interval [:field 15 nil]
+                                               :current :day {:include_current true}]]}
+                     :type     :query
+                     :database 1}
+     :display "table"}))
+
+(comment
+  (= {:dataset_query {:query {:source-table 2
+                              :filter [:and [:time-interval [:field 15 nil] :current :day {:include_current true}]]}
+                      :type :query
+                      :database 1}
+      :display "table"}
+     {:dataset_query {:type :query
+                      :database 1
+                      :query {:source-table 2
+                              :filter [:and [:aggregation-options [:time-interval [:field 15 nil] :current :day] {:include_current true}]]}}
+      :display "table"}))


### PR DESCRIPTION
This introduces a Malli schema for `Card`, the representation for a
"question" in Metabase, and supports conversion between the JS map
`Card` and CLJS maps.

The `dataset_query` field holding the native or MBQL query is special,
and this PR uses the `->legacy-MBQL` conversion from #29419.

A TS `Question` can be created with either the JS or CLJS rep for the
card, and the methods `Question.card()` and `Question._cljsCard()`
lazily convert the other form into the requested form and cache it.

The existing `_getMLv2Query` logic is replaced; it is subsumed by the
conversion of the whole card including the query.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/29520)
<!-- Reviewable:end -->
