### PR TITLE
Add Read-Only Notebook View

### DIFF
--- a/e2e/test/scenarios/auditing/ad-hoc.cy.spec.js
+++ b/e2e/test/scenarios/auditing/ad-hoc.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore, describeEE, openNativeEditor, startNewQuestion } from "e2e/support/helpers";
+import { restore, describeEE, openNativeEditor, openOrdersTable } from "e2e/support/helpers";
 
 describeEE("audit > ad-hoc", () => {
   describe("native query", () => {
@@ -45,18 +45,16 @@ describeEE("audit > ad-hoc", () => {
 
       cy.log("Run ad hoc notebook query as normal user");
       cy.signInAsNormalUser();
-      startNewQuestion();
-      cy.findByTextEnsureVisible("Sample Database").click();
-      cy.findByTextEnsureVisible("Orders").click();
+      openOrdersTable();
 
       cy.button('Visualize').click();
-
       cy.wait('@dataset');
+
       // Sign in as admin to be able to access audit logs in tests
       cy.signInAsAdmin();
     });
 
-    it.skip("should appear in audit log #29456", () => {
+    it("should appear in audit log #29456", () => {
       cy.visit("/admin/audit/members/log");
 
       cy.findByText("GUI")
@@ -70,7 +68,14 @@ describeEE("audit > ad-hoc", () => {
       cy.url().should("include", "/admin/audit/query/");
 
       cy.get(".PageTitle").contains("Query");
-      cy.findByText("Open in Metabase");
+      cy.findByText("Open in Metabase").should('be.visible');
+
+      cy.findByTestId('read-only-notebook').within(() => {
+        cy.findByTestId('data-step-cell').within(() => {
+          cy.findByText("Orders");
+        });
+        cy.findByText(/Filter/i).should("not.exist");
+      });
     });
   });
 });

--- a/enterprise/frontend/src/metabase-enterprise/audit_app/lib/mode.js
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/lib/mode.js
@@ -76,8 +76,10 @@ const AuditDrill = ({ question, clicked }) => {
           name: "detail",
           title: `View this`,
           default: true,
-          url() {
-            return `/admin/audit/query/${encodeURIComponent(String(value))}`;
+          action() {
+            return push(
+              `/admin/audit/query/${encodeURIComponent(String(value))}`,
+            );
           },
         },
       ];

--- a/enterprise/frontend/src/metabase-enterprise/audit_app/pages/AuditQueryDetail.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/pages/AuditQueryDetail.jsx
@@ -2,9 +2,9 @@
 import React from "react";
 import { t } from "ttag";
 
+import QueryViewer from "metabase/query_builder/containers/QueryViewer";
 import { serializeCardForUrl } from "metabase/lib/card";
 
-import ReadOnlyNotebook from "metabase/query_builder/components/notebook/ReadOnlyNotebook";
 import * as QueryDetailCards from "../lib/cards/query_detail";
 import OpenInMetabase from "../components/OpenInMetabase";
 import AuditCustomView from "../containers/AuditCustomView";
@@ -29,7 +29,7 @@ const AuditQueryDetail = ({ params: { queryHash } }) => (
           title="Query"
           subtitle={<OpenInMetabase to={`/question#${serializedHash}`} />}
         >
-          <ReadOnlyNotebook datasetQuery={datasetQuery} />
+          <QueryViewer datasetQuery={datasetQuery} />
         </AuditContent>
       );
     }}

--- a/enterprise/frontend/src/metabase-enterprise/audit_app/pages/AuditQueryDetail.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/pages/AuditQueryDetail.jsx
@@ -1,14 +1,14 @@
 /* eslint-disable react/prop-types */
 import React from "react";
 import { t } from "ttag";
-import _ from "underscore";
-
-import { connect } from "react-redux";
-import NativeQueryEditor from "metabase/query_builder/components/NativeQueryEditor";
-
-import GuiQueryEditor from "metabase/query_builder/components/GuiQueryEditor";
 
 import { serializeCardForUrl } from "metabase/lib/card";
+
+import ReadOnlyNotebook from "metabase/query_builder/components/notebook/ReadOnlyNotebook";
+import * as QueryDetailCards from "../lib/cards/query_detail";
+import OpenInMetabase from "../components/OpenInMetabase";
+import AuditCustomView from "../containers/AuditCustomView";
+import AuditContent from "../components/AuditContent";
 
 const AuditQueryDetail = ({ params: { queryHash } }) => (
   <AuditCustomView card={QueryDetailCards.details(queryHash)}>
@@ -20,101 +20,20 @@ const AuditQueryDetail = ({ params: { queryHash } }) => (
       if (!datasetQuery) {
         return <div>{t`Query Not Recorded, sorry`}</div>;
       }
+      const serializedHash = serializeCardForUrl({
+        dataset_query: datasetQuery,
+      });
 
       return (
         <AuditContent
           title="Query"
-          subtitle={
-            <OpenInMetabase
-              to={
-                "/question#" +
-                serializeCardForUrl({
-                  dataset_query: datasetQuery,
-                })
-              }
-            />
-          }
+          subtitle={<OpenInMetabase to={`/question#${serializedHash}`} />}
         >
-          <div className="pt4" style={{ pointerEvents: "none" }}>
-            <QueryBuilderReadOnly
-              card={{
-                name: "",
-                visualization_settings: {},
-                display: "table",
-                dataset_query: datasetQuery,
-              }}
-            />
-          </div>
+          <ReadOnlyNotebook datasetQuery={datasetQuery} />
         </AuditContent>
       );
     }}
   </AuditCustomView>
 );
-
-import { getMetadata } from "metabase/selectors/metadata";
-
-import ExplicitSize from "metabase/components/ExplicitSize";
-import { loadMetadataForCard } from "metabase/questions/actions";
-import NativeQuery from "metabase-lib/queries/NativeQuery";
-import Question from "metabase-lib/Question";
-import * as QueryDetailCards from "../lib/cards/query_detail";
-import OpenInMetabase from "../components/OpenInMetabase";
-import AuditCustomView from "../containers/AuditCustomView";
-import AuditContent from "../components/AuditContent";
-
-const mapStateToProps = state => ({ metadata: getMetadata(state) });
-const mapDispatchToProps = { loadMetadataForCard };
-
-class QueryBuilderReadOnlyInner extends React.Component {
-  state = {
-    isNativeEditorOpen: false,
-  };
-
-  setIsNativeEditorOpen = open => {
-    this.setState({ isNativeEditorOpen: open });
-  };
-
-  componentDidMount() {
-    const { card, loadMetadataForCard } = this.props;
-    loadMetadataForCard(card);
-  }
-
-  render() {
-    const { card, metadata, height } = this.props;
-    const question = new Question(card, metadata);
-
-    const query = question.query();
-
-    if (query instanceof NativeQuery) {
-      return (
-        <NativeQueryEditor
-          question={question}
-          query={query}
-          location={{ query: {} }}
-          readOnly
-          viewHeight={height}
-          isNativeEditorOpen={this.state.isNativeEditorOpen}
-          setIsNativeEditorOpen={this.setIsNativeEditorOpen}
-        />
-      );
-    } else {
-      const tableMetadata = query.table();
-      return tableMetadata ? (
-        <GuiQueryEditor
-          datasetQuery={card.dataset_query}
-          query={query}
-          databases={tableMetadata && [tableMetadata.db]}
-          setDatasetQuery={() => {}} // no-op to appease flow
-          readOnly
-        />
-      ) : null;
-    }
-  }
-}
-
-const QueryBuilderReadOnly = _.compose(
-  connect(mapStateToProps, mapDispatchToProps),
-  ExplicitSize(),
-)(QueryBuilderReadOnlyInner);
 
 export default AuditQueryDetail;

--- a/frontend/src/metabase-types/api/query.ts
+++ b/frontend/src/metabase-types/api/query.ts
@@ -5,12 +5,6 @@ import type { TableId } from "./table";
 
 export interface StructuredQuery {
   "source-table"?: TableId;
-  joins?: any[];
-  filter?: any[];
-  aggregation?: any[];
-  breakout?: any[];
-  "order-by"?: any[];
-  limit?: number;
 }
 
 export interface NativeQuery {
@@ -115,10 +109,3 @@ export type DimensionReferenceWithOptions =
 export type DimensionReference =
   | DimensionReferenceWithOptions
   | TemplateTagReference;
-
-export type Join = {
-  fields: any;
-  condition: any[];
-  alias: string;
-  "source-table": TableId;
-};

--- a/frontend/src/metabase-types/api/query.ts
+++ b/frontend/src/metabase-types/api/query.ts
@@ -5,6 +5,12 @@ import type { TableId } from "./table";
 
 export interface StructuredQuery {
   "source-table"?: TableId;
+  joins?: any[];
+  filter?: any[];
+  aggregation?: any[];
+  breakout?: any[];
+  "order-by"?: any[];
+  limit?: number;
 }
 
 export interface NativeQuery {
@@ -109,3 +115,10 @@ export type DimensionReferenceWithOptions =
 export type DimensionReference =
   | DimensionReferenceWithOptions
   | TemplateTagReference;
+
+export type Join = {
+  fields: any;
+  condition: any[];
+  alias: string;
+  "source-table": TableId;
+};

--- a/frontend/src/metabase/query_builder/components/notebook/Notebook.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/Notebook.tsx
@@ -26,6 +26,7 @@ interface NotebookOwnProps {
   updateQuestion: (question: Question) => Promise<void>;
   runQuestionQuery: () => void;
   setQueryBuilderMode: (mode: string) => void;
+  readOnly?: boolean;
 }
 
 interface NotebookCardProps {

--- a/frontend/src/metabase/query_builder/components/notebook/NotebookCell.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/NotebookCell.jsx
@@ -86,10 +86,11 @@ export function NotebookCellItem(props) {
     right,
     rightContainerStyle,
     children,
+    readOnly,
     ...restProps
   } = props;
 
-  const hasRightSide = React.isValidElement(right);
+  const hasRightSide = React.isValidElement(right) && !readOnly;
   const mainContentRoundedCorners = ["left"];
   if (!hasRightSide) {
     mainContentRoundedCorners.push("right");

--- a/frontend/src/metabase/query_builder/components/notebook/NotebookStep/NotebookStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/NotebookStep/NotebookStep.tsx
@@ -45,6 +45,7 @@ interface NotebookStepProps {
   reportTimezone?: string;
   openStep: (id: string) => void;
   updateQuery: (query: StructuredQuery) => Promise<void>;
+  readOnly?: boolean;
 }
 
 function NotebookStep({
@@ -55,6 +56,7 @@ function NotebookStep({
   reportTimezone,
   openStep,
   updateQuery,
+  readOnly = false,
 }: NotebookStepProps) {
   const [isPreviewOpen, { turnOn: openPreview, turnOff: closePreview }] =
     useToggle(false);
@@ -105,7 +107,7 @@ function NotebookStep({
   const color = getColor();
   const canPreview = step?.previewQuery?.isValid?.();
   const hasPreviewButton = !isPreviewOpen && canPreview;
-  const canRevert = typeof step.revert === "function";
+  const canRevert = typeof step.revert === "function" && !readOnly;
 
   return (
     <ExpandingContent isInitiallyOpen={!isLastOpened} isOpen>
@@ -140,21 +142,24 @@ function NotebookStep({
                 updateQuery={updateQuery}
                 isLastOpened={isLastOpened}
                 reportTimezone={reportTimezone}
+                readOnly={readOnly}
               />
             </StepContent>
-            <StepButtonContainer>
-              <ActionButton
-                ml={[1, 2]}
-                className={
-                  !hasPreviewButton ? "hidden disabled" : "text-brand-hover"
-                }
-                icon="play"
-                title={t`Preview`}
-                color={c("text-light")}
-                transparent
-                onClick={openPreview}
-              />
-            </StepButtonContainer>
+            {!readOnly && (
+              <StepButtonContainer>
+                <ActionButton
+                  ml={[1, 2]}
+                  className={
+                    !hasPreviewButton ? "hidden disabled" : "text-brand-hover"
+                  }
+                  icon="play"
+                  title={t`Preview`}
+                  color={c("text-light")}
+                  transparent
+                  onClick={openPreview}
+                />
+              </StepButtonContainer>
+            )}
           </StepBody>
         )}
 
@@ -162,7 +167,7 @@ function NotebookStep({
           <NotebookStepPreview step={step} onClose={closePreview} />
         )}
 
-        {actionButtons.length > 0 && (
+        {actionButtons.length > 0 && !readOnly && (
           <StepActionsContainer data-testid="action-buttons">
             {actionButtons}
           </StepActionsContainer>

--- a/frontend/src/metabase/query_builder/components/notebook/NotebookSteps/NotebookSteps.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/NotebookSteps/NotebookSteps.tsx
@@ -14,10 +14,11 @@ interface NotebookStepsProps {
   sourceQuestion?: Question;
   reportTimezone?: string;
   updateQuestion: (question: Question) => Promise<void>;
+  readOnly?: boolean;
 }
 
-function getInitialOpenSteps(question: Question): OpenSteps {
-  const isNew = !question.table();
+function getInitialOpenSteps(question: Question, readOnly: boolean): OpenSteps {
+  const isNew = !readOnly && !question.table();
   return isNew
     ? {
         "0:filter": true,
@@ -32,9 +33,10 @@ function NotebookSteps({
   sourceQuestion,
   reportTimezone,
   updateQuestion,
+  readOnly = false,
 }: NotebookStepsProps) {
   const [openSteps, setOpenSteps] = useState<OpenSteps>(
-    getInitialOpenSteps(question),
+    getInitialOpenSteps(question, readOnly),
   );
   const [lastOpenedStep, setLastOpenedStep] = useState<string | null>(null);
 
@@ -92,6 +94,7 @@ function NotebookSteps({
             reportTimezone={reportTimezone}
             updateQuery={onChange}
             openStep={handleStepOpen}
+            readOnly={readOnly}
           />
         );
       })}

--- a/frontend/src/metabase/query_builder/components/notebook/ReadOnlyNotebook.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/ReadOnlyNotebook.styled.tsx
@@ -1,0 +1,5 @@
+import styled from "@emotion/styled";
+
+export const ReadOnlyNotebookContainer = styled.div`
+  pointer-events: none;
+`;

--- a/frontend/src/metabase/query_builder/components/notebook/ReadOnlyNotebook.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/ReadOnlyNotebook.tsx
@@ -1,14 +1,12 @@
 import React, { useEffect, useMemo } from "react";
 import _ from "underscore";
-import type { AnyAction } from "redux";
 import { useSelector, useDispatch } from "react-redux";
 
 import { getMetadata } from "metabase/selectors/metadata";
 import { loadMetadataForCard } from "metabase/questions/actions";
-import type { DatasetQuery } from "metabase-types/types/Card";
 
 import Notebook from "metabase/query_builder/components/notebook/Notebook";
-import type { Card } from "metabase-types/api";
+import type { StructuredDatasetQuery } from "metabase-types/api";
 import Question from "metabase-lib/Question";
 
 import { ReadOnlyNotebookContainer } from "./ReadOnlyNotebook.styled";
@@ -16,18 +14,15 @@ import { ReadOnlyNotebookContainer } from "./ReadOnlyNotebook.styled";
 export default function ReadOnlyNotebook({
   datasetQuery,
 }: {
-  datasetQuery: DatasetQuery;
+  datasetQuery: StructuredDatasetQuery;
 }) {
   const dispatch = useDispatch();
   const metadata = useSelector(getMetadata, _.isEqual);
-  const card = useMemo(
-    () => ({ dataset_query: datasetQuery } as Card),
-    [datasetQuery],
-  );
+  const card = useMemo(() => ({ dataset_query: datasetQuery }), [datasetQuery]);
 
   useEffect(() => {
     async function loadMetadata() {
-      await dispatch(loadMetadataForCard(card) as unknown as AnyAction);
+      await dispatch(loadMetadataForCard(card as any) as any);
     }
     loadMetadata();
   }, [card, dispatch]);
@@ -39,7 +34,7 @@ export default function ReadOnlyNotebook({
   const question = new Question(card, metadata);
 
   return (
-    <ReadOnlyNotebookContainer>
+    <ReadOnlyNotebookContainer data-testid="read-only-notebook">
       <Notebook question={question} hasVisualizeButton={false} readOnly />
     </ReadOnlyNotebookContainer>
   );

--- a/frontend/src/metabase/query_builder/components/notebook/ReadOnlyNotebook.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/ReadOnlyNotebook.tsx
@@ -1,38 +1,11 @@
-import React, { useEffect, useMemo } from "react";
-import _ from "underscore";
-import { useSelector, useDispatch } from "react-redux";
-
-import { getMetadata } from "metabase/selectors/metadata";
-import { loadMetadataForCard } from "metabase/questions/actions";
+import React from "react";
 
 import Notebook from "metabase/query_builder/components/notebook/Notebook";
-import type { StructuredDatasetQuery } from "metabase-types/api";
-import Question from "metabase-lib/Question";
+import type Question from "metabase-lib/Question";
 
 import { ReadOnlyNotebookContainer } from "./ReadOnlyNotebook.styled";
 
-export default function ReadOnlyNotebook({
-  datasetQuery,
-}: {
-  datasetQuery: StructuredDatasetQuery;
-}) {
-  const dispatch = useDispatch();
-  const metadata = useSelector(getMetadata, _.isEqual);
-  const card = useMemo(() => ({ dataset_query: datasetQuery }), [datasetQuery]);
-
-  useEffect(() => {
-    async function loadMetadata() {
-      await dispatch(loadMetadataForCard(card as any) as any);
-    }
-    loadMetadata();
-  }, [card, dispatch]);
-
-  if (!datasetQuery.database || !metadata.databases[datasetQuery.database]) {
-    return null;
-  }
-
-  const question = new Question(card, metadata);
-
+export default function ReadOnlyNotebook({ question }: { question: Question }) {
   return (
     <ReadOnlyNotebookContainer data-testid="read-only-notebook">
       <Notebook question={question} hasVisualizeButton={false} readOnly />

--- a/frontend/src/metabase/query_builder/components/notebook/ReadOnlyNotebook.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/ReadOnlyNotebook.tsx
@@ -1,0 +1,46 @@
+import React, { useEffect, useMemo } from "react";
+import _ from "underscore";
+import type { AnyAction } from "redux";
+import { useSelector, useDispatch } from "react-redux";
+
+import { getMetadata } from "metabase/selectors/metadata";
+import { loadMetadataForCard } from "metabase/questions/actions";
+import type { DatasetQuery } from "metabase-types/types/Card";
+
+import Notebook from "metabase/query_builder/components/notebook/Notebook";
+import type { Card } from "metabase-types/api";
+import Question from "metabase-lib/Question";
+
+import { ReadOnlyNotebookContainer } from "./ReadOnlyNotebook.styled";
+
+export default function ReadOnlyNotebook({
+  datasetQuery,
+}: {
+  datasetQuery: DatasetQuery;
+}) {
+  const dispatch = useDispatch();
+  const metadata = useSelector(getMetadata, _.isEqual);
+  const card = useMemo(
+    () => ({ dataset_query: datasetQuery } as Card),
+    [datasetQuery],
+  );
+
+  useEffect(() => {
+    async function loadMetadata() {
+      await dispatch(loadMetadataForCard(card) as unknown as AnyAction);
+    }
+    loadMetadata();
+  }, [card, dispatch]);
+
+  if (!datasetQuery.database || !metadata.databases[datasetQuery.database]) {
+    return null;
+  }
+
+  const question = new Question(card, metadata);
+
+  return (
+    <ReadOnlyNotebookContainer>
+      <Notebook question={question} hasVisualizeButton={false} readOnly />
+    </ReadOnlyNotebookContainer>
+  );
+}

--- a/frontend/src/metabase/query_builder/components/notebook/ReadOnlyNotebook.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/ReadOnlyNotebook.unit.spec.tsx
@@ -1,15 +1,18 @@
 import React from "react";
-import type { StructuredDatasetQuery } from "metabase-types/api";
 
+import { renderWithProviders, screen, getIcon } from "__support__/ui";
+import { createEntitiesState } from "__support__/store";
 import { setupDatabasesEndpoints } from "__support__/server-mocks/database";
 import { setupSearchEndpoints } from "__support__/server-mocks/search";
-import { renderWithProviders, screen, getIcon } from "__support__/ui";
+
+import type { StructuredDatasetQuery } from "metabase-types/api";
 import { createMockState } from "metabase-types/store/mocks";
-
 import { createMockStructuredDatasetQuery } from "metabase-types/api/mocks";
-
-import { createEntitiesState } from "__support__/store";
 import { createSampleDatabase } from "metabase-types/api/mocks/presets";
+
+import { getMetadata } from "metabase/selectors/metadata";
+
+import Question from "metabase-lib/Question";
 
 import ReadOnlyNotebook from "./ReadOnlyNotebook";
 
@@ -24,7 +27,15 @@ const setup = ({ query }: { query: StructuredDatasetQuery }) => {
   setupDatabasesEndpoints([database]);
   setupSearchEndpoints([]);
 
-  renderWithProviders(<ReadOnlyNotebook datasetQuery={query} />, {
+  const metadata = getMetadata(state);
+
+  const card = {
+    dataset_query: query,
+  };
+
+  const question = new Question(card, metadata);
+
+  renderWithProviders(<ReadOnlyNotebook question={question} />, {
     storeInitialState: state,
   });
 };

--- a/frontend/src/metabase/query_builder/components/notebook/ReadOnlyNotebook.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/ReadOnlyNotebook.unit.spec.tsx
@@ -5,7 +5,8 @@ import { createEntitiesState } from "__support__/store";
 import { setupDatabasesEndpoints } from "__support__/server-mocks/database";
 import { setupSearchEndpoints } from "__support__/server-mocks/search";
 
-import type { StructuredDatasetQuery } from "metabase-types/api";
+import type { DatasetQuery } from "metabase-types/types/Card";
+
 import { createMockState } from "metabase-types/store/mocks";
 import { createMockStructuredDatasetQuery } from "metabase-types/api/mocks";
 import { createSampleDatabase } from "metabase-types/api/mocks/presets";
@@ -16,7 +17,14 @@ import Question from "metabase-lib/Question";
 
 import ReadOnlyNotebook from "./ReadOnlyNotebook";
 
-const setup = ({ query }: { query: StructuredDatasetQuery }) => {
+const makeQuery = (options: any) => {
+  // we have to cast this because we have 2 incompatible DatasetQuery types
+  return createMockStructuredDatasetQuery({
+    query: options,
+  }) as DatasetQuery;
+};
+
+const setup = ({ query }: { query: DatasetQuery }) => {
   const database = createSampleDatabase();
   const state = createMockState({
     entities: createEntitiesState({
@@ -43,11 +51,9 @@ const setup = ({ query }: { query: StructuredDatasetQuery }) => {
 describe("Notebook > ReadOnlyNotebook", () => {
   describe("Basic notebook functionality", () => {
     it("shows filters", async () => {
-      const query = createMockStructuredDatasetQuery({
-        query: {
-          "source-table": 1,
-          filter: [">", ["field", 3, null], 10],
-        },
+      const query = makeQuery({
+        "source-table": 1,
+        filter: [">", ["field", 3, null], 10],
       });
       setup({ query });
       expect(await screen.findByText("Products")).toBeInTheDocument();
@@ -57,12 +63,10 @@ describe("Notebook > ReadOnlyNotebook", () => {
     });
 
     it("shows summaries", async () => {
-      const query = createMockStructuredDatasetQuery({
-        query: {
-          "source-table": 1,
-          aggregation: [["avg", ["field", 7, null]]],
-          breakout: [["field", 3, null]],
-        },
+      const query = makeQuery({
+        "source-table": 1,
+        aggregation: [["avg", ["field", 7, null]]],
+        breakout: [["field", 3, null]],
       });
       setup({ query });
       expect(await screen.findByText("Products")).toBeInTheDocument();
@@ -72,11 +76,9 @@ describe("Notebook > ReadOnlyNotebook", () => {
     });
 
     it("shows order by", async () => {
-      const query = createMockStructuredDatasetQuery({
-        query: {
-          "source-table": 1,
-          "order-by": [["asc", ["field", 2, null]]],
-        },
+      const query = makeQuery({
+        "source-table": 1,
+        "order-by": [["asc", ["field", 2, null]]],
       });
       setup({ query });
       expect(screen.getByTestId("read-only-notebook")).toBeInTheDocument();
@@ -90,11 +92,9 @@ describe("Notebook > ReadOnlyNotebook", () => {
     });
 
     it("shows limit clauses", async () => {
-      const query = createMockStructuredDatasetQuery({
-        query: {
-          "source-table": 1,
-          limit: 120,
-        },
+      const query = makeQuery({
+        "source-table": 1,
+        limit: 120,
       });
       setup({ query });
 
@@ -108,18 +108,14 @@ describe("Notebook > ReadOnlyNotebook", () => {
 
   describe("Read only features", () => {
     it("shows the read-only notebook editor", async () => {
-      const query = createMockStructuredDatasetQuery({
-        query: { "source-table": 1 },
-      });
+      const query = makeQuery({ "source-table": 1 });
       setup({ query });
       expect(screen.getByTestId("read-only-notebook")).toBeInTheDocument();
       expect(await screen.findByText("Products")).toBeInTheDocument();
     });
 
     it("does not show the visualize button", async () => {
-      const query = createMockStructuredDatasetQuery({
-        query: { "source-table": 1 },
-      });
+      const query = makeQuery({ "source-table": 1 });
       setup({ query });
       expect(screen.getByTestId("read-only-notebook")).toBeInTheDocument();
       expect(await screen.findByText("Products")).toBeInTheDocument();
@@ -127,20 +123,16 @@ describe("Notebook > ReadOnlyNotebook", () => {
     });
 
     it("does not show preview buttons", async () => {
-      const query = createMockStructuredDatasetQuery({
-        query: { "source-table": 1 },
-      });
+      const query = makeQuery({ "source-table": 1 });
       setup({ query });
       expect(await screen.findByText("Products")).toBeInTheDocument();
       expect(screen.queryByLabelText("play icon")).not.toBeInTheDocument();
     });
 
     it("does not show remove buttons", async () => {
-      const query = createMockStructuredDatasetQuery({
-        query: {
-          "source-table": 1,
-          filter: [">", ["field", 3, null], 10],
-        },
+      const query = makeQuery({
+        "source-table": 1,
+        filter: [">", ["field", 3, null], 10],
       });
       setup({ query });
       expect(await screen.findByText("Products")).toBeInTheDocument();
@@ -151,11 +143,9 @@ describe("Notebook > ReadOnlyNotebook", () => {
     });
 
     it("does not show add buttons", async () => {
-      const query = createMockStructuredDatasetQuery({
-        query: {
-          "source-table": 1,
-          filter: [">", ["field", 3, null], 10],
-        },
+      const query = makeQuery({
+        "source-table": 1,
+        filter: [">", ["field", 3, null], 10],
       });
       setup({ query });
       expect(await screen.findByText("Products")).toBeInTheDocument();
@@ -166,11 +156,9 @@ describe("Notebook > ReadOnlyNotebook", () => {
     });
 
     it("does not show dropdowns to pick columns", async () => {
-      const query = createMockStructuredDatasetQuery({
-        query: {
-          "source-table": 1,
-          filter: [">", ["field", 3, null], 10],
-        },
+      const query = makeQuery({
+        "source-table": 1,
+        filter: [">", ["field", 3, null], 10],
       });
       setup({ query });
       expect(await screen.findByText("Products")).toBeInTheDocument();
@@ -181,10 +169,8 @@ describe("Notebook > ReadOnlyNotebook", () => {
     });
 
     it("does not show sections without query clauses or section add buttons", async () => {
-      const query = createMockStructuredDatasetQuery({
-        query: {
-          "source-table": 1,
-        },
+      const query = makeQuery({
+        "source-table": 1,
       });
       setup({ query });
       expect(await screen.findByText("Products")).toBeInTheDocument();

--- a/frontend/src/metabase/query_builder/components/notebook/ReadOnlyNotebook.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/ReadOnlyNotebook.unit.spec.tsx
@@ -1,0 +1,188 @@
+import React from "react";
+import type { StructuredDatasetQuery } from "metabase-types/api";
+
+import { setupDatabasesEndpoints } from "__support__/server-mocks/database";
+import { setupSearchEndpoints } from "__support__/server-mocks/search";
+import { renderWithProviders, screen, getIcon } from "__support__/ui";
+import { createMockState } from "metabase-types/store/mocks";
+
+import { createMockStructuredDatasetQuery } from "metabase-types/api/mocks";
+
+import { createEntitiesState } from "__support__/store";
+import { createSampleDatabase } from "metabase-types/api/mocks/presets";
+
+import ReadOnlyNotebook from "./ReadOnlyNotebook";
+
+const setup = ({ query }: { query: StructuredDatasetQuery }) => {
+  const database = createSampleDatabase();
+  const state = createMockState({
+    entities: createEntitiesState({
+      databases: [database],
+    }),
+  });
+
+  setupDatabasesEndpoints([database]);
+  setupSearchEndpoints([]);
+
+  renderWithProviders(<ReadOnlyNotebook datasetQuery={query} />, {
+    storeInitialState: state,
+  });
+};
+
+describe("Notebook > ReadOnlyNotebook", () => {
+  describe("Basic notebook functionality", () => {
+    it("shows filters", async () => {
+      const query = createMockStructuredDatasetQuery({
+        query: {
+          "source-table": 1,
+          filter: [">", ["field", 3, null], 10],
+        },
+      });
+      setup({ query });
+      expect(await screen.findByText("Products")).toBeInTheDocument();
+      expect(
+        await screen.findByText("ID is greater than 10"),
+      ).toBeInTheDocument();
+    });
+
+    it("shows summaries", async () => {
+      const query = createMockStructuredDatasetQuery({
+        query: {
+          "source-table": 1,
+          aggregation: [["avg", ["field", 7, null]]],
+          breakout: [["field", 3, null]],
+        },
+      });
+      setup({ query });
+      expect(await screen.findByText("Products")).toBeInTheDocument();
+      expect(await screen.findByText("Average of Price")).toBeInTheDocument();
+      expect(await screen.findByText("by")).toBeInTheDocument();
+      expect(await screen.findByText("ID")).toBeInTheDocument();
+    });
+
+    it("shows order by", async () => {
+      const query = createMockStructuredDatasetQuery({
+        query: {
+          "source-table": 1,
+          "order-by": [["asc", ["field", 2, null]]],
+        },
+      });
+      setup({ query });
+      expect(screen.getByTestId("read-only-notebook")).toBeInTheDocument();
+      expect(await screen.findByText("Products")).toBeInTheDocument();
+
+      expect(await screen.findByText("Sort")).toBeInTheDocument();
+      expect(await screen.findByText("Rating")).toBeInTheDocument();
+
+      // sort ascending shows an up arrow
+      expect(getIcon("arrow_up")).toBeInTheDocument();
+    });
+
+    it("shows limit clauses", async () => {
+      const query = createMockStructuredDatasetQuery({
+        query: {
+          "source-table": 1,
+          limit: 120,
+        },
+      });
+      setup({ query });
+
+      expect(await screen.findByText("Products")).toBeInTheDocument();
+      expect(await screen.findByText("Row limit")).toBeInTheDocument();
+
+      const limitInput = await screen.findByPlaceholderText("Enter a limit");
+      expect(limitInput).toHaveValue(120);
+    });
+  });
+
+  describe("Read only features", () => {
+    it("shows the read-only notebook editor", async () => {
+      const query = createMockStructuredDatasetQuery({
+        query: { "source-table": 1 },
+      });
+      setup({ query });
+      expect(screen.getByTestId("read-only-notebook")).toBeInTheDocument();
+      expect(await screen.findByText("Products")).toBeInTheDocument();
+    });
+
+    it("does not show the visualize button", async () => {
+      const query = createMockStructuredDatasetQuery({
+        query: { "source-table": 1 },
+      });
+      setup({ query });
+      expect(screen.getByTestId("read-only-notebook")).toBeInTheDocument();
+      expect(await screen.findByText("Products")).toBeInTheDocument();
+      expect(screen.queryByText("Visualize")).not.toBeInTheDocument();
+    });
+
+    it("does not show preview buttons", async () => {
+      const query = createMockStructuredDatasetQuery({
+        query: { "source-table": 1 },
+      });
+      setup({ query });
+      expect(await screen.findByText("Products")).toBeInTheDocument();
+      expect(screen.queryByLabelText("play icon")).not.toBeInTheDocument();
+    });
+
+    it("does not show remove buttons", async () => {
+      const query = createMockStructuredDatasetQuery({
+        query: {
+          "source-table": 1,
+          filter: [">", ["field", 3, null], 10],
+        },
+      });
+      setup({ query });
+      expect(await screen.findByText("Products")).toBeInTheDocument();
+      expect(
+        await screen.findByText("ID is greater than 10"),
+      ).toBeInTheDocument();
+      expect(screen.queryByLabelText("close icon")).not.toBeInTheDocument();
+    });
+
+    it("does not show add buttons", async () => {
+      const query = createMockStructuredDatasetQuery({
+        query: {
+          "source-table": 1,
+          filter: [">", ["field", 3, null], 10],
+        },
+      });
+      setup({ query });
+      expect(await screen.findByText("Products")).toBeInTheDocument();
+      expect(
+        await screen.findByText("ID is greater than 10"),
+      ).toBeInTheDocument();
+      expect(screen.queryByLabelText("add icon")).not.toBeInTheDocument();
+    });
+
+    it("does not show dropdowns to pick columns", async () => {
+      const query = createMockStructuredDatasetQuery({
+        query: {
+          "source-table": 1,
+          filter: [">", ["field", 3, null], 10],
+        },
+      });
+      setup({ query });
+      expect(await screen.findByText("Products")).toBeInTheDocument();
+
+      expect(
+        screen.queryByLabelText("chevrondown icon"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("does not show sections without query clauses or section add buttons", async () => {
+      const query = createMockStructuredDatasetQuery({
+        query: {
+          "source-table": 1,
+        },
+      });
+      setup({ query });
+      expect(await screen.findByText("Products")).toBeInTheDocument();
+
+      expect(screen.queryByText("Filter")).not.toBeInTheDocument();
+      expect(screen.queryByText("Summarize")).not.toBeInTheDocument();
+      expect(screen.queryByText("Join data")).not.toBeInTheDocument();
+      expect(screen.queryByText("Custom column")).not.toBeInTheDocument();
+      expect(screen.queryByText("Row limit")).not.toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/metabase/query_builder/components/notebook/steps/AggregateStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/AggregateStep.jsx
@@ -22,7 +22,7 @@ export default function AggregateStep({
   query,
   updateQuery,
   isLastOpened,
-  ...props
+  readOnly,
 }) {
   return (
     <ClauseStep
@@ -32,6 +32,7 @@ export default function AggregateStep({
       items={query.aggregations()}
       renderName={item => item.displayName()}
       tetherOptions={aggTetherOptions}
+      readOnly={readOnly}
       renderPopover={aggregation => (
         <AggregationPopover
           query={query}

--- a/frontend/src/metabase/query_builder/components/notebook/steps/BreakoutStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/BreakoutStep.jsx
@@ -22,6 +22,7 @@ export default function BreakoutStep({
   query,
   updateQuery,
   isLastOpened,
+  readOnly,
   ...props
 }) {
   return (
@@ -32,6 +33,7 @@ export default function BreakoutStep({
       items={query.breakouts()}
       renderName={item => item.displayName()}
       tetherOptions={breakoutTetherOptions}
+      readOnly={readOnly}
       renderPopover={breakout => (
         <BreakoutPopover
           query={query}

--- a/frontend/src/metabase/query_builder/components/notebook/steps/ClauseStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/ClauseStep.tsx
@@ -19,6 +19,7 @@ interface ClauseStepProps<T> {
   onRemove?: ((item: T, index: number) => void) | null;
   initialAddText?: string | null;
   tetherOptions?: Tether.ITetherOptions | null;
+  readOnly?: boolean;
   "data-testid"?: string;
 }
 
@@ -32,6 +33,7 @@ const ClauseStep = <T,>({
   isLastOpened = false,
   initialAddText = null,
   tetherOptions = null,
+  readOnly,
   ...props
 }: ClauseStepProps<T>): JSX.Element => {
   return (
@@ -41,9 +43,9 @@ const ClauseStep = <T,>({
           tetherOptions={tetherOptions}
           key={index}
           triggerElement={
-            <NotebookCellItem color={color}>
+            <NotebookCellItem color={color} readOnly={readOnly}>
               {renderName(item, index)}
-              {onRemove && (!canRemove || canRemove(item)) && (
+              {!readOnly && onRemove && (!canRemove || canRemove(item)) && (
                 <Icon
                   ml={1}
                   name="close"
@@ -60,19 +62,21 @@ const ClauseStep = <T,>({
           {renderPopover(item, index)}
         </PopoverWithTrigger>
       ))}
-      <PopoverWithTrigger
-        triggerElement={
-          <NotebookCellAdd
-            color={color}
-            initialAddText={items.length === 0 && initialAddText}
-          />
-        }
-        tetherOptions={tetherOptions}
-        sizeToFit
-        isInitiallyOpen={isLastOpened}
-      >
-        {renderPopover()}
-      </PopoverWithTrigger>
+      {!readOnly && (
+        <PopoverWithTrigger
+          triggerElement={
+            <NotebookCellAdd
+              color={color}
+              initialAddText={items.length === 0 && initialAddText}
+            />
+          }
+          tetherOptions={tetherOptions}
+          sizeToFit
+          isInitiallyOpen={isLastOpened}
+        >
+          {renderPopover()}
+        </PopoverWithTrigger>
+      )}
     </NotebookCell>
   );
 };

--- a/frontend/src/metabase/query_builder/components/notebook/steps/DataStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/DataStep.jsx
@@ -15,10 +15,10 @@ import {
 } from "../FieldsPickerIcon";
 import FieldsPicker from "./FieldsPicker";
 
-function DataStep({ color, query, updateQuery }) {
+function DataStep({ color, query, updateQuery, readOnly }) {
   const question = query.question();
   const table = query.table();
-  const canSelectTableColumns = table && query.isRaw();
+  const canSelectTableColumns = table && query.isRaw() && !readOnly;
 
   const hasCollectionDatasetsStep =
     question &&

--- a/frontend/src/metabase/query_builder/components/notebook/steps/ExpressionStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/ExpressionStep.tsx
@@ -10,6 +10,7 @@ export interface ExpressionStepProps {
   updateQuery: (query: StructuredQuery) => Promise<void>;
   isLastOpened: boolean;
   reportTimezone: string;
+  readOnly?: boolean;
 }
 
 const ExpressionStep = ({
@@ -18,6 +19,7 @@ const ExpressionStep = ({
   updateQuery,
   isLastOpened,
   reportTimezone,
+  readOnly,
 }: ExpressionStepProps): JSX.Element => {
   const items = Object.entries(query.expressions()).map(
     ([name, expression]) => ({ name, expression }),
@@ -28,6 +30,7 @@ const ExpressionStep = ({
       color={color}
       items={items}
       renderName={({ name }) => name}
+      readOnly={readOnly}
       renderPopover={item => (
         <ExpressionWidget
           query={query}

--- a/frontend/src/metabase/query_builder/components/notebook/steps/FilterStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/FilterStep.jsx
@@ -10,6 +10,7 @@ export default function FilterStep({
   query,
   updateQuery,
   isLastOpened,
+  readOnly,
   ...props
 }) {
   return (
@@ -18,6 +19,7 @@ export default function FilterStep({
       initialAddText={t`Add filters to narrow your answer`}
       items={query.filters()}
       renderName={item => item.displayName()}
+      readOnly={readOnly}
       renderPopover={filter => (
         <FilterPopover
           query={query}

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
@@ -66,6 +66,7 @@ const joinStepPropTypes = {
   isLastOpened: PropTypes.bool,
   updateQuery: PropTypes.func.isRequired,
   sourceQuestion: PropTypes.object,
+  readOnly: PropTypes.bool,
 };
 
 const JOIN_OPERATOR_OPTIONS = [
@@ -84,6 +85,7 @@ export default function JoinStep({
   updateQuery,
   isLastOpened,
   sourceQuestion,
+  readOnly,
 }) {
   const isSingleJoinStep = step.itemIndex != null;
   let joins = query.joins();
@@ -114,6 +116,7 @@ export default function JoinStep({
                 updateQuery={updateQuery}
                 isLastOpened={isLastOpened && isLast}
                 sourceQuestion={sourceQuestion}
+                readOnly={readOnly}
               />
             </JoinClauseContainer>
           );
@@ -138,9 +141,17 @@ const joinClausePropTypes = {
   sourceQuestion: PropTypes.object,
   showRemove: PropTypes.bool,
   updateQuery: PropTypes.func,
+  readOnly: PropTypes.bool,
 };
 
-function JoinClause({ color, join, sourceQuestion, updateQuery, showRemove }) {
+function JoinClause({
+  color,
+  join,
+  sourceQuestion,
+  updateQuery,
+  showRemove,
+  readOnly,
+}) {
   const joinDimensionPickersRef = useRef([]);
   const parentDimensionPickersRef = useRef([]);
 
@@ -232,6 +243,7 @@ function JoinClause({ color, join, sourceQuestion, updateQuery, showRemove }) {
 
         <JoinTablePicker
           join={join}
+          readOnly={readOnly}
           query={query}
           joinedTable={joinedTable}
           color={color}
@@ -297,6 +309,7 @@ function JoinClause({ color, join, sourceQuestion, updateQuery, showRemove }) {
                       ref={ref =>
                         (parentDimensionPickersRef.current[index] = ref)
                       }
+                      readOnly={readOnly}
                       data-testid="parent-dimension"
                     />
                     <JoinConditionLabel>
@@ -327,21 +340,23 @@ function JoinClause({ color, join, sourceQuestion, updateQuery, showRemove }) {
                       ref={ref =>
                         (joinDimensionPickersRef.current[index] = ref)
                       }
+                      readOnly={readOnly}
                       data-testid="join-dimension"
                     />
-                    {isLast ? (
-                      <JoinDimensionsRightControl
-                        isValidJoin={join.isValid()}
-                        color={color}
-                        isFirst={isFirst}
-                        onAddNewDimensionPair={() =>
-                          addNewDimensionsPair(index + 1)
-                        }
-                        onRemoveDimensionPair={removeDimensionPair}
-                      />
-                    ) : (
-                      <JoinConditionLabel>{t`and`}</JoinConditionLabel>
-                    )}
+                    {!readOnly &&
+                      (isLast ? (
+                        <JoinDimensionsRightControl
+                          isValidJoin={join.isValid()}
+                          color={color}
+                          isFirst={isFirst}
+                          onAddNewDimensionPair={() =>
+                            addNewDimensionsPair(index + 1)
+                          }
+                          onRemoveDimensionPair={removeDimensionPair}
+                        />
+                      ) : (
+                        <JoinConditionLabel>{t`and`}</JoinConditionLabel>
+                      ))}
                   </Row>
                 </JoinDimensionControlsContainer>
               );
@@ -403,6 +418,7 @@ const joinTablePickerPropTypes = {
   sourceQuestion: PropTypes.object,
   updateQuery: PropTypes.func,
   onSourceTableSet: PropTypes.func.isRequired,
+  readOnly: PropTypes.bool,
 };
 
 function JoinTablePicker({
@@ -413,6 +429,7 @@ function JoinTablePicker({
   sourceQuestion,
   updateQuery,
   onSourceTableSet,
+  readOnly,
 }) {
   const databases = [
     query.database(),
@@ -438,6 +455,7 @@ function JoinTablePicker({
     <NotebookCellItem
       color={color}
       inactive={!joinedTable}
+      readOnly={readOnly}
       right={
         joinedTable && (
           <JoinFieldsPicker
@@ -569,6 +587,7 @@ const joinDimensionCellItemPropTypes = {
   onRemove: PropTypes.func.isRequired,
   color: PropTypes.string,
   testID: PropTypes.string,
+  readOnly: PropTypes.bool,
 };
 
 function getDimensionSourceName(dimension) {
@@ -585,7 +604,13 @@ function getDimensionDisplayName(dimension) {
   return dimension.displayName();
 }
 
-function JoinDimensionCellItem({ dimension, color, testID, onRemove }) {
+function JoinDimensionCellItem({
+  dimension,
+  color,
+  testID,
+  onRemove,
+  readOnly,
+}) {
   return (
     <NotebookCellItem color={color} inactive={!dimension} data-testid={testID}>
       <DimensionContainer>
@@ -597,7 +622,7 @@ function JoinDimensionCellItem({ dimension, color, testID, onRemove }) {
           )}
           {getDimensionDisplayName(dimension)}
         </div>
-        {dimension && <RemoveDimensionIcon onClick={onRemove} />}
+        {dimension && !readOnly && <RemoveDimensionIcon onClick={onRemove} />}
       </DimensionContainer>
     </NotebookCellItem>
   );
@@ -616,6 +641,7 @@ const joinDimensionPickerPropTypes = {
   }).isRequired,
   query: PropTypes.object.isRequired,
   color: PropTypes.string,
+  readOnly: PropTypes.bool,
   "data-testid": PropTypes.string,
 };
 
@@ -625,7 +651,8 @@ class JoinDimensionPicker extends React.Component {
   }
 
   render() {
-    const { dimension, onChange, onRemove, options, query, color } = this.props;
+    const { dimension, onChange, onRemove, options, query, color, readOnly } =
+      this.props;
     const testID = this.props["data-testid"] || "join-dimension";
 
     function onRemoveDimension(e) {
@@ -642,6 +669,7 @@ class JoinDimensionPicker extends React.Component {
             color={color}
             testID={testID}
             onRemove={onRemoveDimension}
+            readOnly={readOnly}
           />
         }
       >

--- a/frontend/src/metabase/query_builder/components/notebook/steps/SortStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/SortStep.jsx
@@ -9,12 +9,14 @@ export default function SortStep({
   query,
   updateQuery,
   isLastOpened,
+  readOnly,
   ...props
 }) {
   return (
     <ClauseStep
       color={color}
       items={query.sorts()}
+      readOnly={readOnly}
       renderName={(sort, index) => (
         <span
           className="flex align-center"

--- a/frontend/src/metabase/query_builder/containers/QueryViewer.tsx
+++ b/frontend/src/metabase/query_builder/containers/QueryViewer.tsx
@@ -1,0 +1,54 @@
+import React, { useEffect, useMemo } from "react";
+import _ from "underscore";
+import { useSelector, useDispatch } from "react-redux";
+
+import NativeQueryEditor from "metabase/query_builder/components/NativeQueryEditor";
+import ReadOnlyNotebook from "metabase/query_builder/components/notebook/ReadOnlyNotebook";
+
+import { getMetadata } from "metabase/selectors/metadata";
+import { loadMetadataForCard } from "metabase/questions/actions";
+
+import type { DatasetQuery } from "metabase-types/types/Card";
+
+import Question from "metabase-lib/Question";
+
+export default function QueryViewer({
+  datasetQuery,
+}: {
+  datasetQuery: DatasetQuery;
+}) {
+  const dispatch = useDispatch();
+  const metadata = useSelector(getMetadata, _.isEqual);
+  const card = useMemo(() => ({ dataset_query: datasetQuery }), [datasetQuery]);
+
+  useEffect(() => {
+    async function loadMetadata() {
+      await dispatch(loadMetadataForCard(card as any) as any);
+    }
+    loadMetadata();
+  }, [card, dispatch]);
+
+  const question = new Question(card, metadata);
+
+  const query = question.query();
+
+  if (question.isNative()) {
+    return (
+      <NativeQueryEditor
+        question={question}
+        query={query}
+        location={{ query: {} }}
+        readOnly
+        viewHeight={800}
+        isNativeEditorOpen
+        resizable={false}
+      />
+    );
+  }
+
+  if (query.tables()) {
+    return <ReadOnlyNotebook question={question} />;
+  }
+
+  return null;
+}

--- a/frontend/src/metabase/query_builder/containers/QueryViewer.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/containers/QueryViewer.unit.spec.tsx
@@ -1,0 +1,99 @@
+import React from "react";
+import type { DatasetQuery } from "metabase-types/types/Card";
+import type { DatasetQuery as DatasetQueryAPI } from "metabase-types/api";
+
+import { setupDatabasesEndpoints } from "__support__/server-mocks/database";
+import { setupSearchEndpoints } from "__support__/server-mocks/search";
+import { renderWithProviders, screen, getIcon } from "__support__/ui";
+import { createMockState } from "metabase-types/store/mocks";
+
+import {
+  createMockStructuredDatasetQuery,
+  createMockNativeDatasetQuery,
+} from "metabase-types/api/mocks";
+
+import { createEntitiesState } from "__support__/store";
+import { createSampleDatabase } from "metabase-types/api/mocks/presets";
+
+import QueryViewer from "./QueryViewer";
+
+const setup = ({ query }: { query: DatasetQueryAPI }) => {
+  const database = createSampleDatabase();
+  const state = createMockState({
+    entities: createEntitiesState({
+      databases: [database],
+    }),
+  });
+
+  setupDatabasesEndpoints([database]);
+  setupSearchEndpoints([]);
+
+  // we have to cast this because we have 2 incompatible DatasetQuery types
+  renderWithProviders(<QueryViewer datasetQuery={query as DatasetQuery} />, {
+    storeInitialState: state,
+  });
+};
+
+describe("Query Builder > Query Viewer", () => {
+  describe("structured queries", () => {
+    it("shows a complex notebook query", async () => {
+      const query = createMockStructuredDatasetQuery({
+        query: {
+          "source-table": 1,
+          filter: [">", ["field", 3, null], 10],
+          aggregation: [["avg", ["field", 7, null]]],
+          breakout: [["field", 3, null]],
+          "order-by": [["asc", ["field", 2, null]]],
+          limit: 120,
+        },
+      });
+      setup({ query });
+      expect(screen.getByTestId("read-only-notebook")).toBeInTheDocument();
+
+      expect(await screen.findByText("Products")).toBeInTheDocument();
+
+      expect(screen.getByText("Filter")).toBeInTheDocument();
+      expect(screen.getByText("ID is greater than 10")).toBeInTheDocument();
+
+      expect(screen.getByText("Average of Price")).toBeInTheDocument();
+      expect(screen.getByText("by")).toBeInTheDocument();
+      expect(screen.getByText("ID")).toBeInTheDocument();
+
+      expect(screen.getByText("Sort")).toBeInTheDocument();
+      // sort ascending shows an up arrow
+      expect(getIcon("arrow_up")).toBeInTheDocument();
+      expect(screen.getByText("Rating")).toBeInTheDocument();
+
+      expect(screen.getByText("Row limit")).toBeInTheDocument();
+
+      const limitInput = screen.getByPlaceholderText("Enter a limit");
+      expect(limitInput).toHaveValue(120);
+    });
+
+    it("does not show the visualize button", async () => {
+      const query = createMockStructuredDatasetQuery({
+        query: { "source-table": 1 },
+      });
+      setup({ query });
+      expect(screen.getByTestId("read-only-notebook")).toBeInTheDocument();
+      expect(await screen.findByText("Products")).toBeInTheDocument();
+      expect(screen.queryByText("Visualize")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("native queries", () => {
+    it("shows the native query editor", async () => {
+      const query = createMockNativeDatasetQuery({
+        native: {
+          query: "SELECT * FROM products WHERE id > 10;",
+        },
+      });
+
+      setup({ query });
+
+      expect(
+        await screen.findByTestId("mock-native-query-editor"),
+      ).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
Resolves https://github.com/metabase/metabase/issues/29456
Resolves https://github.com/metabase/metabase/issues/28531
Resolves https://github.com/metabase/metabase/issues/28639

### Description

Until now, the audit log was showing the old/deprecated GUI query builder (instead of the notebook) to graphically represent queries not built with SQL.  Most importantly, this component started throwing page-crashing errors in the audit log. Instead of fixing deprecated code, I opted to replace that view with a simple read-only version of the notebook query builder.

1. Creates a New `QueryViewer` container that pulls in appropriate metadata for a query and shows either the notebook editor or native query editor in read only mode, as appropriate.
2. Creates a new `ReadOnlyNotebook` component which passes down `readOnly` props through the notebook editor to hide various UI elements that suggest you should be clicking on them.
3. Adds unit test coverage, which I think is the first and only unit test coverage for the notebook editor 🥳 

**Before**
(when it didn't crash)
![Screen Shot 2023-03-24 at 11 02 56 AM](https://user-images.githubusercontent.com/30528226/227596392-9a06b87e-d8f3-4490-ab12-2dd95c26aa4c.png)


**After**

![Screen Shot 2023-03-23 at 3 23 28 PM](https://user-images.githubusercontent.com/30528226/227585741-87b59806-b87a-446d-9be9-c90db350b6b5.png)

### How to verify

1. Startup metabase enterprise
2. open a new question and create a GUI question with filters, aggregations, limits, etc.
3. open another new question and create a sql question
5. Open the audit log by going to admin settings > audit > audit log
6. click on the two ad-hoc queries you made and see that both notebook and native queries display properly
7. ensure that both query viewers are non-interactive
8. refresh the page on the audit page and ensure that the query displays still display properly there

### Checklist

- [x] Tests have been added/updated to cover changes in this PR

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/29525)
<!-- Reviewable:end -->
