### PR TITLE
Remove deprecation notice on dump and load commands

### DIFF
--- a/src/metabase/cmd.clj
+++ b/src/metabase/cmd.clj
@@ -164,7 +164,9 @@
     (call-enterprise 'metabase-enterprise.serialization.cmd/v1-load path opts)))
 
 (defn ^:command import
-  "Load serialized Metabase instance as created by the [[export]] command from directory `path`."
+  "This command is in development. Prefer [[load]] for now."
+   
+   Load serialized Metabase instance as created by the [[export]] command from directory `path`."
   [path & options]
   (let [opts {:abort-on-error (boolean (some #{"--abort-on-error"} options))}]
     (call-enterprise 'metabase-enterprise.serialization.cmd/v2-load path opts)))

--- a/src/metabase/cmd.clj
+++ b/src/metabase/cmd.clj
@@ -164,8 +164,8 @@
     (call-enterprise 'metabase-enterprise.serialization.cmd/v1-load path opts)))
 
 (defn ^:command import
-  "This command is in development. Prefer [[load]] for now."
-   
+  "This command is in development. For now, use [[load]].
+
    Load serialized Metabase instance as created by the [[export]] command from directory `path`."
   [path & options]
   (let [opts {:abort-on-error (boolean (some #{"--abort-on-error"} options))}]
@@ -187,12 +187,14 @@
     (map #(Integer/parseInt %) (str/split s #","))))
 
 (defn ^:command export
-  "Serialize a Metabase into directory `path`. Replaces the [[dump]] command..
+  "This command is in development. For now, use [[dump]].
+                                                
+   Serialize a Metabase into directory `path`.
 
-  Options:
+   Options:
 
-   --collections [collection-id-list] - a comma-separated list of IDs of collection to export
-   --include-field-values             - flag, default false, controls export of field values"
+    --collections [collection-id-list] - a comma-separated list of IDs of collection to export
+    --include-field-values             - flag, default false, controls export of field values"
   [path & options]
   (let [opts (-> options cmd-args->map (update :collections parse-int-list))]
     (call-enterprise 'metabase-enterprise.serialization.cmd/v2-dump path opts)))

--- a/src/metabase/cmd.clj
+++ b/src/metabase/cmd.clj
@@ -188,7 +188,7 @@
 
 (defn ^:command export
   "This command is in development. For now, use [[dump]].
-                                                
+                                             
    Serialize a Metabase into directory `path`.
 
    Options:

--- a/src/metabase/cmd.clj
+++ b/src/metabase/cmd.clj
@@ -188,7 +188,7 @@
 
 (defn ^:command export
   "This command is in development. For now, use [[dump]].
-                                             
+
    Serialize a Metabase into directory `path`.
 
    Options:

--- a/src/metabase/cmd.clj
+++ b/src/metabase/cmd.clj
@@ -152,10 +152,8 @@
                               e))))]
     (apply f args)))
 
-(defn ^:command ^:deprecated load
-  "Deprecated: prefer [[import]] instead.
-
-  Load serialized metabase instance as created by [[dump]] command from directory `path`.
+(defn ^:command load
+  "Load serialized metabase instance as created by [[dump]] command from directory `path`.
 
   `--mode` can be one of `:update` or `:skip` (default). `--on-error` can be `:abort` or `:continue` (default)."
   [path & options]
@@ -171,10 +169,8 @@
   (let [opts {:abort-on-error (boolean (some #{"--abort-on-error"} options))}]
     (call-enterprise 'metabase-enterprise.serialization.cmd/v2-load path opts)))
 
-(defn ^:command ^:deprecated dump
-  "Deprecated: prefer [[export]] instead.
-
-  Serialized metabase instance into directory `path`. `args` options may contain --state option with one of
+(defn ^:command dump
+  "Serialized metabase instance into directory `path`. `args` options may contain --state option with one of
   `active` (default), `all`. With `active` option, do not dump archived entities."
   [path & options]
   (log/warn (u/colorize :red (trs "''dump'' is deprecated and will be removed in a future release. Please migrate to ''export''.")))


### PR DESCRIPTION
Since serialization v2 is still in development, people should stick with v1 for now.

This PR removes some confusing notices in the command descriptions that claim the v1 commands, `dump` and `load`, are deprecated.

It also updates the v2 command descriptions to notify people that these commands are still in development.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/29529)
<!-- Reviewable:end -->
