### PR TITLE
"sync" instead of "scan" field values

### DIFF
--- a/e2e/test/scenarios/admin/databases/edit.cy.spec.js
+++ b/e2e/test/scenarios/admin/databases/edit.cy.spec.js
@@ -222,7 +222,7 @@ describe("scenarios > admin > databases > edit", () => {
       );
 
       cy.visit(`/admin/databases/${SAMPLE_DB_ID}`);
-      cy.findByText("Re-scan field values now").click();
+      cy.findByText("Re-sync field values now").click();
       cy.wait("@rescan_values");
       cy.findByText("Scan triggered!");
     });

--- a/e2e/test/scenarios/permissions/database-details-permissions.cy.spec.js
+++ b/e2e/test/scenarios/permissions/database-details-permissions.cy.spec.js
@@ -58,7 +58,7 @@ describeEE(
 
       cy.findByTestId("database-actions-panel")
         .should("contain", "Sync database schema now")
-        .and("contain", "Re-scan field values now")
+        .and("contain", "Re-sync field values now")
         .and("contain", "Discard saved field values")
         .and("not.contain", "Remove this database");
 

--- a/frontend/src/metabase/admin/databases/components/DatabaseEditApp/Sidebar/Sidebar.tsx
+++ b/frontend/src/metabase/admin/databases/components/DatabaseEditApp/Sidebar/Sidebar.tsx
@@ -124,10 +124,10 @@ const DatabaseEditAppSidebar = ({
             <SidebarGroup.ListItem>
               <ActionButton
                 actionFn={handleReScanFieldValues}
-                normalText={t`Re-scan field values now`}
+                normalText={t`Re-sync field values now`}
                 activeText={t`Starting…`}
                 failedText={t`Failed to start scan`}
-                successText={t`Scan triggered!`}
+                successText={t`Sync triggered!`}
               />
             </SidebarGroup.ListItem>
             {!isSynced && (

--- a/frontend/src/metabase/admin/databases/components/DatabaseEditApp/Sidebar/Sidebar.unit.spec.tsx
+++ b/frontend/src/metabase/admin/databases/components/DatabaseEditApp/Sidebar/Sidebar.unit.spec.tsx
@@ -71,9 +71,9 @@ describe("DatabaseEditApp/Sidebar", () => {
     expect(syncDatabaseSchema).toHaveBeenCalledWith(database.id);
   });
 
-  it("re-scans database field values", () => {
+  it("re-syncs database field values", () => {
     const { database, rescanDatabaseFields } = setup();
-    userEvent.click(screen.getByText(/Re-scan field values now/i));
+    userEvent.click(screen.getByText(/Re-sync field values now/i));
     expect(rescanDatabaseFields).toHaveBeenCalledWith(database.id);
   });
 

--- a/frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx
+++ b/frontend/src/metabase/admin/datamodel/components/UpdateCachedFieldValues.jsx
@@ -12,10 +12,10 @@ export default class UpdateCachedFieldValues extends React.Component {
         <ActionButton
           className="Button mr2"
           actionFn={this.props.rescanFieldValues}
-          normalText={t`Re-scan this field`}
+          normalText={t`Re-sync this field`}
           activeText={t`Starting…`}
-          failedText={t`Failed to start scan`}
-          successText={t`Scan triggered!`}
+          failedText={t`Failed to start sync`}
+          successText={t`Sync triggered!`}
         />
         <ActionButton
           className="Button Button--danger"

--- a/frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx
+++ b/frontend/src/metabase/admin/datamodel/containers/TableSettingsApp.jsx
@@ -98,10 +98,10 @@ class UpdateFieldValues extends Component {
         <ActionButton
           className="Button mr2"
           actionFn={this.props.rescanTableFieldValues}
-          normalText={t`Re-scan this table`}
+          normalText={t`Re-sync this table`}
           activeText={t`Starting…`}
-          failedText={t`Failed to start scan`}
-          successText={t`Scan triggered!`}
+          failedText={t`Failed to start sync`}
+          successText={t`Sync triggered!`}
         />
         <ActionButton
           className="Button Button--danger"


### PR DESCRIPTION

### Description

Updates field values update language from "scan" to "sync"

![syncDontScan](https://user-images.githubusercontent.com/30528226/227607176-36da3e7b-f6ba-4f53-8614-835d3fb30276.gif)


### How to verify

Describe the steps to verify that the changes are working as expected.

1. admin settings > database options
2. you should see "re-sync field values" instead of "re-scan field values"

### Checklist

- [x] Tests have been added/updated to cover changes in this PR

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/29533)
<!-- Reviewable:end -->
