### PR TITLE
Restrict metabase-lib v2 imports

### DIFF
--- a/enterprise/frontend/.eslintrc
+++ b/enterprise/frontend/.eslintrc
@@ -1,0 +1,10 @@
+{
+  "rules": {
+    "no-restricted-imports": [
+      "error",
+      {
+        "patterns": ["cljs/metabase.lib*"]
+      }
+    ]
+  }
+}

--- a/frontend/src/metabase/.eslintrc
+++ b/frontend/src/metabase/.eslintrc
@@ -2,7 +2,13 @@
   "rules": {
     "no-restricted-imports": [
       "error",
-      { "patterns": ["metabase-enterprise", "metabase-enterprise/*"] }
+      {
+        "patterns": [
+          "metabase-enterprise",
+          "metabase-enterprise/*",
+          "cljs/metabase.lib*"
+        ]
+      }
     ]
   }
 }


### PR DESCRIPTION
Restricts metabase-lib v2 ClojureScript imports from `metabase/**` and `metabase-enterprise/**`. It's meant to be used directly only by `metabase-lib` acting as a thin TypeScript wrapper library

<img width="1014" alt="CleanShot 2023-03-24 at 19 23 04@2x" src="https://user-images.githubusercontent.com/17258145/227621099-00770f13-55c5-4035-b9c8-9af737ecc685.png">
