### PR TITLE
Allow small number and markdown cards

### DIFF
--- a/frontend/src/metabase/actions/components/ActionViz/ActionViz.tsx
+++ b/frontend/src/metabase/actions/components/ActionViz/ActionViz.tsx
@@ -18,6 +18,7 @@ export default Object.assign(Action, {
   canSavePng: false,
 
   minSize: { width: 1, height: 1 },
+  defaultSize: { width: 3, height: 1 },
 
   checkRenderable: () => true,
   isSensible: () => false,

--- a/frontend/src/metabase/visualizations/components/ChoroplethMap.jsx
+++ b/frontend/src/metabase/visualizations/components/ChoroplethMap.jsx
@@ -96,6 +96,7 @@ export default class ChoroplethMap extends Component {
   static propTypes = {};
 
   static minSize = { width: 4, height: 4 };
+  static defaultSize = { width: 4, height: 4 };
 
   static isSensible({ cols }) {
     return cols.filter(isString).length > 0 && cols.filter(isMetric).length > 0;

--- a/frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx
+++ b/frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx
@@ -82,6 +82,7 @@ export default class LineAreaBarChart extends Component {
   static supportsSeries = true;
 
   static minSize = { width: 4, height: 3 };
+  static defaultSize = { width: 4, height: 3 };
 
   static isSensible({ cols, rows }) {
     return (

--- a/frontend/src/metabase/visualizations/components/ScalarValue/ScalarValue.jsx
+++ b/frontend/src/metabase/visualizations/components/ScalarValue/ScalarValue.jsx
@@ -40,7 +40,7 @@ const ScalarValue = ({
         fontWeight: 900,
         unit: "rem",
         step: 0.2,
-        min: 2.2,
+        min: 1,
         max: gridSize ? getMaxFontSize(gridSize.width, totalNumGridCols) : 4,
       }),
     [fontFamily, gridSize, totalNumGridCols, value, width],

--- a/frontend/src/metabase/visualizations/components/ScalarValue/ScalarValue.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/ScalarValue/ScalarValue.styled.tsx
@@ -6,7 +6,7 @@ const TITLE_MAX_LINES = 2;
 const TITLE_LINE_HEIGHT_REM = 1.4;
 
 export const ScalarRoot = styled.div`
-  padding-top: ${((TITLE_MAX_LINES - 1) * TITLE_LINE_HEIGHT_REM) / 2}rem;
+  // padding-top: ${((TITLE_MAX_LINES - 1) * TITLE_LINE_HEIGHT_REM) / 2}rem;
   position: relative;
   display: flex;
   flex: 1;

--- a/frontend/src/metabase/visualizations/shared/types/visualization.ts
+++ b/frontend/src/metabase/visualizations/shared/types/visualization.ts
@@ -11,6 +11,10 @@ export type Visualization = {
     width: number;
     height: number;
   };
+  defaultSize: {
+    width: number;
+    height: number;
+  };
 
   isSensible: (data: DatasetData) => boolean;
   isLiveResizable: (series: Series) => boolean;

--- a/frontend/src/metabase/visualizations/visualizations/Funnel.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Funnel.jsx
@@ -38,10 +38,8 @@ export default class Funnel extends Component {
 
   static noHeader = true;
 
-  static minSize = {
-    width: 5,
-    height: 4,
-  };
+  static minSize = { width: 5, height: 4 };
+  static defaultSize = { width: 5, height: 4 };
 
   static isSensible({ cols, rows }) {
     return cols.length === 2;

--- a/frontend/src/metabase/visualizations/visualizations/LinkViz/LinkVizSettings.ts
+++ b/frontend/src/metabase/visualizations/visualizations/LinkViz/LinkVizSettings.ts
@@ -11,6 +11,7 @@ export const settings = {
   hidden: true,
   supportPreviewing: false,
   minSize: { width: 1, height: 1 },
+  defaultSize: { width: 3, height: 1 },
   checkRenderable: () => undefined,
   settings: {
     "card.title": {

--- a/frontend/src/metabase/visualizations/visualizations/PieChart/PieChart.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/PieChart/PieChart.jsx
@@ -56,6 +56,7 @@ export default class PieChart extends Component {
   static iconName = "pie";
 
   static minSize = { width: 4, height: 4 };
+  static defaultSize = { width: 4, height: 4 };
 
   static isSensible({ cols, rows }) {
     return cols.length === 2;

--- a/frontend/src/metabase/visualizations/visualizations/RowChart/RowChart.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/RowChart/RowChart.tsx
@@ -328,6 +328,7 @@ RowChartVisualization.noun = t`row chart`;
 
 RowChartVisualization.noHeader = true;
 RowChartVisualization.minSize = { width: 5, height: 4 };
+RowChartVisualization.defaultSize = { width: 5, height: 4 };
 
 RowChartVisualization.settings = {
   ...ROW_CHART_SETTINGS,

--- a/frontend/src/metabase/visualizations/visualizations/Scalar.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Scalar.jsx
@@ -41,7 +41,8 @@ export default class Scalar extends Component {
   static noHeader = true;
   static supportsSeries = true;
 
-  static minSize = { width: 3, height: 3 };
+  static minSize = { width: 1, height: 1 };
+  static defaultSize = { width: 3, height: 3 };
 
   static isSensible({ cols, rows }) {
     return rows.length === 1 && cols.length === 1;

--- a/frontend/src/metabase/visualizations/visualizations/Scalar.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Scalar.jsx
@@ -13,7 +13,7 @@ import ScalarValue, {
   ScalarTitle,
 } from "metabase/visualizations/components/ScalarValue";
 import { TYPE } from "metabase-lib/types/constants";
-import { ScalarContainer } from "./Scalar.styled";
+import { ScalarContainer, LabelIcon } from "./Scalar.styled";
 
 // convert legacy `scalar.*` visualization settings to format options
 function legacyScalarSettingsToFormatOptions(settings) {
@@ -215,6 +215,11 @@ export default class Scalar extends Component {
     };
     const isClickable = visualizationIsClickable(clicked);
 
+    const hideTitle =
+      !!settings["card.title"] &&
+      isDashboard &&
+      (gridSize?.width < 2 || gridSize?.height < 2);
+
     return (
       <ScalarWrapper>
         <div className="Card-title absolute top right p1 px2">
@@ -244,7 +249,14 @@ export default class Scalar extends Component {
             />
           </span>
         </ScalarContainer>
-        {isDashboard && (
+
+        {hideTitle ? (
+          <LabelIcon
+            name="ellipsis"
+            tooltip={settings["card.title"]}
+            size={10}
+          />
+        ) : (
           <ScalarTitle
             title={settings["card.title"]}
             description={settings["card.description"]}

--- a/frontend/src/metabase/visualizations/visualizations/Scalar.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Scalar.jsx
@@ -215,7 +215,7 @@ export default class Scalar extends Component {
     };
     const isClickable = visualizationIsClickable(clicked);
 
-    const hideTitle =
+    const showSmallTitle =
       !!settings["card.title"] &&
       isDashboard &&
       (gridSize?.width < 2 || gridSize?.height < 2);
@@ -250,22 +250,23 @@ export default class Scalar extends Component {
           </span>
         </ScalarContainer>
 
-        {hideTitle ? (
-          <LabelIcon
-            name="ellipsis"
-            tooltip={settings["card.title"]}
-            size={10}
-          />
-        ) : (
-          <ScalarTitle
-            title={settings["card.title"]}
-            description={settings["card.description"]}
-            onClick={
-              onChangeCardAndRun &&
-              (() => onChangeCardAndRun({ nextCard: card }))
-            }
-          />
-        )}
+        {isDashboard &&
+          (showSmallTitle ? (
+            <LabelIcon
+              name="ellipsis"
+              tooltip={settings["card.title"]}
+              size={10}
+            />
+          ) : (
+            <ScalarTitle
+              title={settings["card.title"]}
+              description={settings["card.description"]}
+              onClick={
+                onChangeCardAndRun &&
+                (() => onChangeCardAndRun({ nextCard: card }))
+              }
+            />
+          ))}
       </ScalarWrapper>
     );
   }

--- a/frontend/src/metabase/visualizations/visualizations/Scalar.styled.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/Scalar.styled.tsx
@@ -2,6 +2,7 @@ import styled from "@emotion/styled";
 import { css } from "@emotion/react";
 import Ellipsified from "metabase/core/components/Ellipsified";
 import { color } from "metabase/lib/colors";
+import Icon from "metabase/components/Icon";
 
 export interface ScalarContainerProps {
   isClickable: boolean;
@@ -19,4 +20,9 @@ export const ScalarContainer = styled(Ellipsified)<ScalarContainerProps>`
         color: ${color("brand")};
       }
     `}
+`;
+
+export const LabelIcon = styled(Icon)`
+  color: ${color("text-light")};
+  margin-top: 0.2rem;
 `;

--- a/frontend/src/metabase/visualizations/visualizations/Text/Text.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Text/Text.jsx
@@ -46,7 +46,7 @@ export default class Text extends Component {
   static supportPreviewing = true;
 
   static minSize = { width: 1, height: 1 };
-  static defaultSize = { width: 4, height: 1 };
+  static defaultSize = { width: 4, height: 4 };
 
   static checkRenderable() {
     // text can always be rendered, nothing needed here

--- a/frontend/src/metabase/visualizations/visualizations/Text/Text.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Text/Text.jsx
@@ -45,7 +45,8 @@ export default class Text extends Component {
   static hidden = true;
   static supportPreviewing = true;
 
-  static minSize = { width: 4, height: 1 };
+  static minSize = { width: 1, height: 1 };
+  static defaultSize = { width: 4, height: 1 };
 
   static checkRenderable() {
     // text can always be rendered, nothing needed here


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/29417

### Description

This separates out dashcard `minSize` and `defaultSize` properties to allow scalar and text visualizations to get smaller than their default sizes.

![Screen Shot 2023-03-24 at 1 18 46 PM](https://user-images.githubusercontent.com/30528226/227625615-16cbb391-289d-4bbe-9b30-d6ef0166aa89.png)


### How to verify

1. Add a markdown card to a dashboard
2. it should be 4x4
3. see that you can shrink it to 1x1
4. Add a question with a scalar visualization (e.g. `SELECT count(*) FROM ORDERS`) to a dashboard
5. see that it starts out at 3x3
6. see that you can shrink it to 1x1 if you want.



### Checklist

- [ ] Tests have been added/updated to cover changes in this PR

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/29537)
<!-- Reviewable:end -->
