### PR TITLE
Add a reproduction for unable to properly filter on an aggregation

### DIFF
--- a/e2e/test/scenarios/question/reproductions/22230-query-builder-aggregation-filtering.cy.spec.js
+++ b/e2e/test/scenarios/question/reproductions/22230-query-builder-aggregation-filtering.cy.spec.js
@@ -1,0 +1,43 @@
+import {
+  restore,
+  popover,
+  summarize,
+  openPeopleTable,
+  visualize,
+} from "e2e/support/helpers";
+
+describe("issue 22230", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+  });
+
+  it("should allow filtering on aggregated fields", () => {
+    openPeopleTable({ mode: "notebook" });
+
+    summarize({ mode: "notebook" });
+    popover().findByRole("option", { name: "Maximum of ..." }).click();
+    // I don't know why this can't be chained, I tried it and it didn't work.
+    popover().findByRole("option", { name: "Name" }).click();
+
+    // findByRole doesn't work here, and I don't know why.
+    cy.findByText("Pick a column to group by").click();
+    popover().findByRole("option", { name: "Source" }).click();
+
+    // can't use `filter()` because it found multiple filter buttons and Cypress only allows clicking on one element at a time.
+    cy.button("Filter").click();
+    popover().findByRole("option", { name: "Max of Name" }).click();
+    // can't add aria-label to the input, since it's past the translation period.
+    cy.findByTestId("select-button").click();
+    // can't use `popover()` because there are 2 popovers, and I tested that it also didn't work.
+    cy.findByRole("option", { name: "Starts with" }).click();
+    popover().findByPlaceholderText("Enter some text").type("Zo");
+    popover().button("Add filter").click();
+
+    visualize();
+
+    cy.findByText("Showing 2 rows").should("be.visible");
+    cy.findByText("Zora Schamberger").should("be.visible");
+    cy.findByText("Zoie Kozey").should("be.visible");
+  });
+});

--- a/e2e/test/scenarios/question/reproductions/22230-query-builder-aggregation-filtering.cy.spec.js
+++ b/e2e/test/scenarios/question/reproductions/22230-query-builder-aggregation-filtering.cy.spec.js
@@ -17,19 +17,14 @@ describe("issue 22230", () => {
 
     summarize({ mode: "notebook" });
     popover().findByRole("option", { name: "Maximum of ..." }).click();
-    // I don't know why this can't be chained, I tried it and it didn't work.
     popover().findByRole("option", { name: "Name" }).click();
 
-    // findByRole doesn't work here, and I don't know why.
     cy.findByText("Pick a column to group by").click();
     popover().findByRole("option", { name: "Source" }).click();
 
-    // can't use `filter()` because it found multiple filter buttons and Cypress only allows clicking on one element at a time.
     cy.button("Filter").click();
     popover().findByRole("option", { name: "Max of Name" }).click();
-    // can't add aria-label to the input, since it's past the translation period.
     cy.findByTestId("select-button").click();
-    // can't use `popover()` because there are 2 popovers, and I tested that it also didn't work.
     cy.findByRole("option", { name: "Starts with" }).click();
     popover().findByPlaceholderText("Enter some text").type("Zo");
     popover().button("Add filter").click();


### PR DESCRIPTION
> **Warning**
> This is a duplicate of #23869

> **Note**
> The duplication is fixed in https://github.com/metabase/metabase/pull/29608

Closes https://github.com/metabase/metabase/issues/22230

### Description

I couldn't reproduce with the step described in #22230, so I believe this has been fixed.

I only add the reproduction so this won't regress again.

### How to verify

1. Run an E2E test in `e2e/test/scenarios/question/reproductions/22230-query-builder-aggregation-filtering.cy.spec.js`
### Demo

- <img width="1120" alt="image" src="https://user-images.githubusercontent.com/1937582/227634410-512fe41e-2bfc-41c6-9015-a6ba55224d8b.png">
- <img width="364" alt="image" src="https://user-images.githubusercontent.com/1937582/227634429-8bd00dc3-7d2d-4393-9e5d-583a18821afb.png">


```[tasklist]
### Checklist
- [ ] Tests have been added/updated to cover changes in this PR
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/29539)
<!-- Reviewable:end -->
