### PR TITLE
"Sync" instead of "Scan" in database settings

### DIFF
--- a/frontend/src/metabase/databases/components/DatabaseSyncScheduleField/DatabaseSyncScheduleField.tsx
+++ b/frontend/src/metabase/databases/components/DatabaseSyncScheduleField/DatabaseSyncScheduleField.tsx
@@ -39,7 +39,7 @@ const DatabaseSyncScheduleField = ({
       <SchedulePicker
         schedule={value ?? DEFAULT_SCHEDULE}
         scheduleOptions={SCHEDULE_OPTIONS}
-        textBeforeInterval={t`Scan`}
+        textBeforeInterval={t`Sync`}
         minutesOnHourPicker
         onScheduleChange={handleScheduleChange}
       />


### PR DESCRIPTION
### Description

Fixing a little type that @nllho  found in database sync settings (it used to incorrectly say "scan")

![Screen Shot 2023-03-24 at 4 16 02 PM](https://user-images.githubusercontent.com/30528226/227653391-6c1c5085-4434-4a44-a4bf-368875171945.png)


### How to verify

1. Go to the database connection form
2. expand the sync schedule section by clicking "Choose when syncs and scans happen"
3. see "sync" instead of "scan" next to the input.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/29543)
<!-- Reviewable:end -->
