### PR TITLE
[🚧 WIP] Bring markdown support to descriptions

### DIFF
--- a/frontend/src/metabase/collections/components/BaseTableItem.jsx
+++ b/frontend/src/metabase/collections/components/BaseTableItem.jsx
@@ -10,6 +10,7 @@ import Ellipsified from "metabase/core/components/Ellipsified";
 import EntityItem from "metabase/components/EntityItem";
 import DateTime from "metabase/components/DateTime";
 import Tooltip from "metabase/core/components/Tooltip";
+import Markdown from "metabase/core/components/Markdown";
 import ActionMenu from "metabase/collections/components/ActionMenu";
 
 import { color } from "metabase/lib/colors";
@@ -125,7 +126,7 @@ export function BaseTableItem({
               <DescriptionIcon
                 name="info"
                 size={16}
-                tooltip={item.description}
+                tooltip={<Markdown>{item.description}</Markdown>}
               />
             )}
           </ItemLink>

--- a/frontend/src/metabase/components/MetadataInfo/MetadataInfo.styled.tsx
+++ b/frontend/src/metabase/components/MetadataInfo/MetadataInfo.styled.tsx
@@ -4,6 +4,7 @@ import { color } from "metabase/lib/colors";
 import Icon from "metabase/components/Icon";
 import { isReducedMotionPreferred } from "metabase/lib/dom";
 import _LoadingSpinner from "metabase/components/LoadingSpinner";
+import Markdown from "metabase/core/components/Markdown";
 
 const TRANSITION_DURATION = () => (isReducedMotionPreferred() ? "0" : "0.25s");
 
@@ -30,7 +31,7 @@ export const InfoContainer = styled(Container)`
   padding: 1.1em;
 `;
 
-export const Description = styled.div`
+export const Description = styled(Markdown)`
   white-space: pre-line;
   max-height: 200px;
   overflow: auto;

--- a/frontend/src/metabase/query_builder/components/dataref/QuestionPane/QuestionPane.tsx
+++ b/frontend/src/metabase/query_builder/components/dataref/QuestionPane/QuestionPane.tsx
@@ -59,7 +59,7 @@ const QuestionPane = ({
       <PaneContent>
         <QuestionPaneDescription>
           {question.description() ? (
-            <Description>{question.description()}</Description>
+            <Description>{question.description() ?? ""}</Description>
           ) : (
             <EmptyDescription>{t`No description`}</EmptyDescription>
           )}

--- a/frontend/src/metabase/visualizations/components/ScalarValue/ScalarValue.jsx
+++ b/frontend/src/metabase/visualizations/components/ScalarValue/ScalarValue.jsx
@@ -6,6 +6,7 @@ import React, { useMemo } from "react";
 
 import Icon from "metabase/components/Icon";
 import Tooltip from "metabase/core/components/Tooltip";
+import Markdown from "metabase/core/components/Markdown";
 import Ellipsified from "metabase/core/components/Ellipsified";
 import {
   ScalarRoot,
@@ -73,9 +74,9 @@ export const ScalarTitle = ({ title, description, onClick }) => (
         {title}
       </Ellipsified>
     </ScalarTitleContent>
-    {description && description.length > 0 && (
+    {description && (
       <ScalarDescriptionContainer className="hover-child">
-        <Tooltip tooltip={description} maxWidth="22em">
+        <Tooltip tooltip={<Markdown>{description}</Markdown>} maxWidth="22em">
           <Icon name="info_outline" />
         </Tooltip>
       </ScalarDescriptionContainer>

--- a/frontend/src/metabase/visualizations/components/legend/LegendCaption.jsx
+++ b/frontend/src/metabase/visualizations/components/legend/LegendCaption.jsx
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import { iconPropTypes } from "metabase/components/Icon";
 import Tooltip from "metabase/core/components/Tooltip";
 import Ellipsified from "metabase/core/components/Ellipsified";
+import Markdown from "metabase/core/components/Markdown";
 import LegendActions from "./LegendActions";
 import {
   LegendCaptionRoot,
@@ -40,7 +41,7 @@ const LegendCaption = ({
       </LegendLabel>
       <LegendRightContent>
         {description && (
-          <Tooltip tooltip={description} maxWidth="22em">
+          <Tooltip tooltip={<Markdown>{description}</Markdown>} maxWidth="22em">
             <LegendDescriptionIcon className="hover-child hover-child--smooth" />
           </Tooltip>
         )}


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/28754 https://github.com/metabase/metabase/issues/27803

### Description

Render markdown syntax in descriptions

### How to verify

Put in the description following md

```
# Title

**important note**, [reference](https://metabase.com)
```

#### Collection

New -> Collection

Put code above to the description.

Add newly created collection to another collection, go to that another collection and check description of the new collection via tooltip
 
<img width="1097" alt="Screenshot 2023-03-27 at 11 44 07" src="https://user-images.githubusercontent.com/125459446/227895412-3de8b870-9061-4653-97bf-bee75c37a64a.png">

#### Question

New -> Question (choose anything)

Put code above to the description. Add question to the dashboard. Check description from the tooltips

<img width="474" alt="Screenshot 2023-03-27 at 12 09 05" src="https://user-images.githubusercontent.com/125459446/227896345-c5d9de68-953a-4145-9f35-5bdb0a748960.png">
<img width="532" alt="Screenshot 2023-03-27 at 12 08 36" src="https://user-images.githubusercontent.com/125459446/227896349-5f9472d3-c7e5-4ea0-8361-c39e995e368c.png">
<img width="845" alt="Screenshot 2023-03-27 at 11 25 45" src="https://user-images.githubusercontent.com/125459446/227897119-da36471c-bcef-4163-9e71-692bc1f64ebd.png">



#### Dashboard

New -> Dashboard.

Put code above to the description. Go to collection with newly created dashboard and check tooltip.

<img width="501" alt="Screenshot 2023-03-27 at 12 10 21" src="https://user-images.githubusercontent.com/125459446/227896679-fbaf999a-3151-4944-b079-3398cc1ff305.png">

## Bonus (markdown inside of the table and column descriptions)

Go to admin settings and update description of column and some field (put the code above).

<img width="777" alt="Screenshot 2023-03-27 at 11 12 12" src="https://user-images.githubusercontent.com/125459446/227897534-58027467-ad7b-4f88-a2f5-1d0ee83a988a.png">
<img width="568" alt="Screenshot 2023-03-27 at 11 11 24" src="https://user-images.githubusercontent.com/125459446/227897542-26068515-a995-4c11-a418-75f874fe508e.png">


### Demo

Here will be a link to the demo

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/29549)
<!-- Reviewable:end -->
