### PR TITLE
Repro #29517: Broken drill-through for questions based on remapped native models

### DIFF
--- a/e2e/test/scenarios/models/reproductions/29517-native-remapped-model-drill-through-click-behavior.cy.spec.js
+++ b/e2e/test/scenarios/models/reproductions/29517-native-remapped-model-drill-through-click-behavior.cy.spec.js
@@ -1,0 +1,124 @@
+import {
+  restore,
+  popover,
+  visitQuestion,
+  visitDashboard,
+} from "e2e/support/helpers";
+import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
+
+const questionDetails = {
+  name: "29517",
+  dataset: true,
+  native: {
+    query:
+      'Select Orders."ID" AS "ID",\nOrders."CREATED_AT" AS "CREATED_AT"\nFrom Orders',
+    "template-tags": {},
+  },
+};
+
+describe.skip("issue 29517 - nested question based on native model with remapped values", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+
+    cy.createNativeQuestion(questionDetails).then(({ body: { id } }) => {
+      cy.intercept("GET", `/api/database/${SAMPLE_DB_ID}/schema/PUBLIC`).as(
+        "schema",
+      );
+      cy.visit(`/model/${id}/metadata`);
+      cy.wait("@schema");
+
+      mapModelColumnToDatabase({ table: "Orders", field: "ID" });
+      selectModelColumn("CREATED_AT");
+      mapModelColumnToDatabase({ table: "Orders", field: "Created At" });
+
+      cy.intercept("PUT", `/api/card/*`).as("updateModel");
+      cy.button("Save changes").click();
+      cy.wait("@updateModel");
+
+      const nestedQuestionDetails = {
+        query: {
+          "source-table": `card__${id}`,
+          aggregation: [["count"]],
+          breakout: [
+            [
+              "field",
+              "CREATED_AT",
+              { "temporal-unit": "month", "base-type": "type/DateTime" },
+            ],
+          ],
+        },
+        display: "line",
+      };
+
+      cy.createQuestionAndDashboard({
+        questionDetails: nestedQuestionDetails,
+      }).then(({ body: card }) => {
+        const { card_id, dashboard_id } = card;
+
+        cy.editDashboardCard(card, {
+          visualization_settings: {
+            click_behavior: {
+              type: "link",
+              linkType: "dashboard",
+              targetId: 1, // Orders in a dashboard
+              parameterMapping: {},
+            },
+          },
+        });
+
+        cy.wrap(card_id).as("nestedQuestionId");
+        cy.wrap(dashboard_id).as("dashboardId");
+      });
+    });
+  });
+
+  it("drill-through should work (metabase#29517-1)", () => {
+    cy.get("@nestedQuestionId").then(id => {
+      visitQuestion(id);
+    });
+
+    cy.intercept("POST", "/api/dataset").as("dataset");
+    // We can click on any circle; this index was chosen randomly
+    cy.get("circle").eq(25).click({ force: true });
+    popover()
+      .findByText(/^View these/)
+      .click();
+    cy.wait("@dataset");
+
+    cy.findByTestId("qb-filters-panel").should(
+      "contain",
+      "Created At is May, 2018",
+    );
+    cy.findByTestId("view-footer").should("contain", "Showing 520 rows");
+  });
+
+  it("click behavoir to custom destination should work (metabase#29517-2)", () => {
+    cy.get("@dashboardId").then(id => {
+      visitDashboard(id);
+    });
+
+    cy.intercept("GET", "/api/dashboard/1").as("loadTargetDashboard");
+    cy.get("circle").eq(25).click({ force: true });
+    cy.wait("@loadTargetDashboard");
+
+    cy.location("pathname").should("eq", "/dashboard/1");
+    cy.get(".cellData").contains("37.65");
+  });
+});
+
+function mapModelColumnToDatabase({ table, field }) {
+  cy.findByText("Database column this maps to")
+    .closest("#formField-id")
+    .findByTestId("select-button")
+    .click();
+  popover().findByRole("option", { name: table }).click();
+  popover().findByRole("option", { name: field }).click();
+  cy.contains(`${table} → ${field}`).should("be.visible");
+  cy.findByDisplayValue(field);
+  cy.findByLabelText("Description").should("not.be.empty");
+}
+
+function selectModelColumn(column) {
+  cy.findAllByTestId("header-cell").contains(column).click();
+}

--- a/e2e/test/scenarios/models/reproductions/29517-native-remapped-model-drill-through-click-behavior.cy.spec.js
+++ b/e2e/test/scenarios/models/reproductions/29517-native-remapped-model-drill-through-click-behavior.cy.spec.js
@@ -16,7 +16,7 @@ const questionDetails = {
   },
 };
 
-describe.skip("issue 29517 - nested question based on native model with remapped values", () => {
+describe("issue 29517 - nested question based on native model with remapped values", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #29517 

### How to test this manually?
- `yarn test-cypress-open`
- `e2e/test/scenarios/models/reproductions/29517-native-remapped-model-drill-through-click-behavior.cy.spec.js`
- All tests should pass because the breaking change has been reverted in #29551


### Screenshots:
![image](https://user-images.githubusercontent.com/31325167/227910917-647b4626-bf81-4df9-9622-fae22c2ffacd.png)

How things looked while the feature was still broken:
Scenario 1: Question drill-through
![image](https://user-images.githubusercontent.com/31325167/227910445-391e9f5b-2703-4c29-b0b2-d136fb5a346e.png)

Scenario 2: Dashboard click behavior
![image](https://user-images.githubusercontent.com/31325167/227910560-f4b7d1c5-2450-440e-8e32-de95a0401ab3.png)


