### PR TITLE
Fix notebook editor shows the remove button on the data step

### DIFF
--- a/e2e/test/scenarios/custom-column/reproductions/19745-cc-nested-query-remove-expressions.cy.spec.js
+++ b/e2e/test/scenarios/custom-column/reproductions/19745-cc-nested-query-remove-expressions.cy.spec.js
@@ -97,7 +97,7 @@ function removeExpression(name) {
 
 function removeAllExpressions() {
   getNotebookStep("expression", { stage: 1 }).within(() => {
-    cy.findByTestId("remove-step").click({ force: true });
+    cy.findByLabelText("Remove step").click({ force: true });
   });
 }
 

--- a/e2e/test/scenarios/question/reproductions/17514-ui-overlay.cy.spec.js
+++ b/e2e/test/scenarios/question/reproductions/17514-ui-overlay.cy.spec.js
@@ -172,7 +172,7 @@ function removeJoinedTable() {
   cy.findAllByText("Join data")
     .first()
     .parent()
-    .findByTestId("remove-step")
+    .findByLabelText("Remove step")
     .click({ force: true });
 }
 

--- a/frontend/src/metabase/query_builder/components/notebook/NotebookStep/NotebookStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/NotebookStep/NotebookStep.tsx
@@ -104,6 +104,7 @@ function NotebookStep({
   const color = getColor();
   const canPreview = step?.previewQuery?.isValid?.();
   const hasPreviewButton = !isPreviewOpen && canPreview;
+  const canRevert = typeof step.revert === "function";
 
   return (
     <ExpandingContent isInitiallyOpen={!isLastOpened} isOpen>
@@ -113,14 +114,16 @@ function NotebookStep({
       >
         <StepHeader color={color}>
           {title}
-          <Icon
-            name="close"
-            className="ml-auto cursor-pointer text-light text-medium-hover hover-child"
-            tooltip={t`Remove`}
-            onClick={handleClickRevert}
-            aria-label={t`Remove step`}
-            data-testid="remove-step"
-          />
+          {canRevert && (
+            <Icon
+              name="close"
+              className="ml-auto cursor-pointer text-light text-medium-hover hover-child"
+              tooltip={t`Remove`}
+              onClick={handleClickRevert}
+              aria-label={t`Remove step`}
+              data-testid="remove-step"
+            />
+          )}
         </StepHeader>
 
         {NotebookStepComponent && (

--- a/frontend/src/metabase/query_builder/components/notebook/NotebookStep/NotebookStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/NotebookStep/NotebookStep.tsx
@@ -118,6 +118,7 @@ function NotebookStep({
             className="ml-auto cursor-pointer text-light text-medium-hover hover-child"
             tooltip={t`Remove`}
             onClick={handleClickRevert}
+            aria-label={t`Remove step`}
             data-testid="remove-step"
           />
         </StepHeader>

--- a/frontend/src/metabase/query_builder/components/notebook/NotebookStep/NotebookStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/NotebookStep/NotebookStep.tsx
@@ -5,6 +5,7 @@ import { color as c } from "metabase/lib/colors";
 import { useToggle } from "metabase/hooks/use-toggle";
 
 import Icon from "metabase/components/Icon";
+import IconButtonWrapper from "metabase/components/IconButtonWrapper";
 import ExpandingContent from "metabase/components/ExpandingContent";
 
 import type Question from "metabase-lib/Question";
@@ -115,13 +116,16 @@ function NotebookStep({
         <StepHeader color={color}>
           {title}
           {canRevert && (
-            <Icon
-              name="close"
-              className="ml-auto cursor-pointer text-light text-medium-hover hover-child"
-              tooltip={t`Remove`}
-              aria-label={t`Remove step`}
+            <IconButtonWrapper
+              className="ml-auto text-light text-medium-hover hover-child"
               onClick={handleClickRevert}
-            />
+            >
+              <Icon
+                name="close"
+                tooltip={t`Remove`}
+                aria-label={t`Remove step`}
+              />
+            </IconButtonWrapper>
           )}
         </StepHeader>
 

--- a/frontend/src/metabase/query_builder/components/notebook/NotebookStep/NotebookStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/NotebookStep/NotebookStep.tsx
@@ -119,9 +119,8 @@ function NotebookStep({
               name="close"
               className="ml-auto cursor-pointer text-light text-medium-hover hover-child"
               tooltip={t`Remove`}
-              onClick={handleClickRevert}
               aria-label={t`Remove step`}
-              data-testid="remove-step"
+              onClick={handleClickRevert}
             />
           )}
         </StepHeader>

--- a/frontend/src/metabase/query_builder/components/notebook/NotebookStep/NotebookStep.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/NotebookStep/NotebookStep.unit.spec.tsx
@@ -92,13 +92,17 @@ describe("NotebookStep", () => {
     setup({ step });
 
     expect(screen.getByTestId(testId)).toBeInTheDocument();
-    expect(screen.getByLabelText("Remove step")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Remove step" }),
+    ).toBeInTheDocument();
   });
 
   it("doesn't render the remove button if step revert isn't implemented", () => {
     const step = createNotebookStep({ type: "data", revert: null });
     setup({ step });
 
-    expect(screen.queryByLabelText("Remove step")).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Remove step" }),
+    ).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/metabase/query_builder/components/notebook/NotebookStep/NotebookStep.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/NotebookStep/NotebookStep.unit.spec.tsx
@@ -94,4 +94,11 @@ describe("NotebookStep", () => {
     expect(screen.getByTestId(testId)).toBeInTheDocument();
     expect(screen.getByLabelText("Remove step")).toBeInTheDocument();
   });
+
+  it("doesn't render the remove button if step revert isn't implemented", () => {
+    const step = createNotebookStep({ type: "data", revert: null });
+    setup({ step });
+
+    expect(screen.queryByLabelText("Remove step")).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/metabase/query_builder/components/notebook/NotebookStep/NotebookStep.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/NotebookStep/NotebookStep.unit.spec.tsx
@@ -1,0 +1,97 @@
+import React from "react";
+import { renderWithProviders, screen } from "__support__/ui";
+import {
+  setupDatabasesEndpoints,
+  setupSearchEndpoints,
+} from "__support__/server-mocks";
+
+import { createSampleDatabase } from "metabase-types/api/mocks/presets";
+
+import { getSavedStructuredQuestion } from "metabase-lib/mocks";
+import type Question from "metabase-lib/Question";
+import type StructuredQuery from "metabase-lib/queries/StructuredQuery";
+
+import {
+  NotebookStep as INotebookStep,
+  NotebookStepType,
+} from "../lib/steps.types";
+import NotebookStep from "./NotebookStep";
+
+type SetupOpts = {
+  step?: INotebookStep;
+  question?: Question;
+};
+
+const DEFAULT_QUESTION = getSavedStructuredQuestion();
+const DEFAULT_QUERY = DEFAULT_QUESTION.query() as StructuredQuery;
+
+function createNotebookStep(opts = {}): INotebookStep {
+  return {
+    id: "test-step",
+    type: "data",
+    stageIndex: 0,
+    itemIndex: 0,
+    query: DEFAULT_QUERY,
+    valid: true,
+    active: true,
+    visible: true,
+    actions: [],
+    previewQuery: null,
+    next: null,
+    previous: null,
+    revert: jest.fn(),
+    clean: jest.fn(),
+    update: jest.fn(),
+    ...opts,
+  };
+}
+
+function setup({
+  step = createNotebookStep(),
+  question = DEFAULT_QUESTION,
+}: SetupOpts = {}) {
+  const openStep = jest.fn();
+  const updateQuery = jest.fn();
+
+  setupDatabasesEndpoints([createSampleDatabase()]);
+  setupSearchEndpoints([]);
+
+  renderWithProviders(
+    <NotebookStep
+      step={step}
+      sourceQuestion={question}
+      isLastStep={false}
+      isLastOpened={false}
+      openStep={openStep}
+      updateQuery={updateQuery}
+    />,
+  );
+
+  return {
+    openStep,
+    updateQuery,
+  };
+}
+
+const STEP_TYPES: NotebookStepType[] = [
+  "data",
+  "join",
+  "expression",
+  "filter",
+  "summarize",
+  "aggregate",
+  "breakout",
+  "sort",
+  "limit",
+];
+
+describe("NotebookStep", () => {
+  test.each(STEP_TYPES)(`renders a %s step correctly`, type => {
+    const step = createNotebookStep({ type });
+    const testId = `step-${type}-${step.stageIndex}-${step.itemIndex}`;
+    setup({ step });
+
+    expect(screen.getByTestId(testId)).toBeInTheDocument();
+    expect(screen.getByLabelText("Remove step")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Closes #29276

### Description

Fixes the notebook editor displayed the "remove" button next to non-removable steps ("Data" in our case). The notebook editor consists of steps (data, filter, join, aggregation, etc.), where each step can have a `revert` function that should remove the step. The "data" step doesn't have a `revert`, and the UI had to check that and hide the button in that case.

### How to verify

1. Open `/quesiton/:id/notebook`
2. Hover the "Data" step (the one where you can pick a table)
3. Ensure there's no "remove" button ("close" icon)
4. Try to add a filter/join/aggregation, ensure their notebook section has the remove button

### Demo

The button doesn't show up:

https://user-images.githubusercontent.com/17258145/228042606-132fd91a-fd8f-4e8e-835f-35415e78ffcb.mp4


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
