### PR TITLE
Put db-level cache_ttl behind enterprise feature flag

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/advanced_config/caching.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_config/caching.clj
@@ -1,0 +1,10 @@
+(ns metabase-enterprise.advanced-config.caching
+  (:require
+   [metabase.public-settings.premium-features :refer [defenterprise]]))
+
+(defenterprise db-cache-ttl
+  "Fetches the cache TTL set for a given database. Since this is EE-only functionality, the corresponding OSS function
+  always returns nil."
+  :feature :advanced-config
+  [database]
+  (:cache_ttl database))

--- a/enterprise/backend/test/metabase_enterprise/advanced_config/caching_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_config/caching_test.clj
@@ -1,0 +1,22 @@
+(ns metabase-enterprise.advanced-config.caching-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase.models :refer [Card Dashboard Database]]
+   [metabase.public-settings :as public-settings]
+   [metabase.public-settings.premium-features-test
+    :as premium-features-test]
+   [metabase.query-processor.card :as qp.card]
+   [metabase.test :as mt]
+   [metabase.util :as u]))
+
+(deftest query-cache-ttl-hierarchy-test
+  (premium-features-test/with-premium-features #{:advanced-config}
+    (mt/discard-setting-changes [enable-query-caching]
+      (public-settings/enable-query-caching! true)
+      (testing "multiple ttl, db ttl wins"
+        ;; corresponding OSS tests in metabase-enterprise.advanced-config.caching-test
+        (mt/with-temp* [Database [db {:cache_ttl 1337}]
+                        Dashboard [dash]
+                        Card [card {:database_id (u/the-id db)}]]
+          (is (= (* 3600 1337)
+                 (:cache-ttl (#'qp.card/query-for-card card {} {} {} {:dashboard-id (u/the-id dash)})))))))))

--- a/enterprise/backend/test/metabase_enterprise/advanced_config/caching_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_config/caching_test.clj
@@ -13,7 +13,7 @@
   (premium-features-test/with-premium-features #{:advanced-config}
     (mt/discard-setting-changes [enable-query-caching]
       (public-settings/enable-query-caching! true)
-      (testing "multiple ttl, db ttl wins"
+      (testing "database TTL takes effect when no dashboard or card TTLs are set"
         ;; corresponding OSS tests in metabase-enterprise.advanced-config.caching-test
         (mt/with-temp* [Database [db {:cache_ttl 1337}]
                         Dashboard [dash]

--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -30,6 +30,7 @@
    [metabase.models.table :refer [Table]]
    [metabase.plugins.classloader :as classloader]
    [metabase.public-settings :as public-settings]
+   [metabase.public-settings.premium-features :as premium-features]
    [metabase.sample-data :as sample-data]
    [metabase.sync.analyze :as analyze]
    [metabase.sync.field-values :as field-values]
@@ -745,6 +746,10 @@
    auto_run_queries (s/maybe s/Bool)
    cache_ttl        (s/maybe su/IntGreaterThanZero)}
   (api/check-superuser)
+  (when cache_ttl
+    (api/check (premium-features/enable-advanced-config?)
+               [402 (tru (str "The cache TTL database setting is only enabled if you have a premium token with the "
+                              "advanced-config feature."))]))
   (let [is-full-sync?    (or (nil? is_full_sync)
                              (boolean is_full_sync))
         details-or-error (test-connection-details engine details)
@@ -929,8 +934,10 @@
         ;; do nothing in the case that user is not in control of
         ;; scheduling. leave them as they are in the db
 
-        ;; unlike the other fields, folks might want to nil out cache_ttl
-        (t2/update! Database id {:cache_ttl cache_ttl})
+        ;; unlike the other fields, folks might want to nil out cache_ttl. it should also only be settable on EE
+        ;; with the advanced-config feature enabled.
+        (when (premium-features/enable-advanced-config?)
+          (t2/update! Database id {:cache_ttl cache_ttl}))
 
         (let [db (t2/select-one Database :id id)]
           (events/publish-event! :database-update db)

--- a/src/metabase/query_processor/card.clj
+++ b/src/metabase/query_processor/card.clj
@@ -12,6 +12,7 @@
    [metabase.models.database :refer [Database]]
    [metabase.models.query :as query]
    [metabase.public-settings :as public-settings]
+   [metabase.public-settings.premium-features :refer [defenterprise]]
    [metabase.query-processor :as qp]
    [metabase.query-processor.error-type :as qp.error-type]
    [metabase.query-processor.middleware.constraints :as qp.constraints]
@@ -41,13 +42,18 @@
                   (u/emoji "💾"))
         ttl-seconds))))
 
+(defenterprise db-cache-ttl
+  "Fetches the cache TTL set for the given database. Returns nil on OSS."
+  metabase-enterprise.advanced-config.caching
+  [_database])
+
 (defn- ttl-hierarchy
   "Returns the cache ttl (in seconds), by first checking whether there is a stored value for the database,
   dashboard, or card (in that order of increasing preference), and if all of those don't exist, then the
   `query-magic-ttl`, which is based on average execution time."
   [card dashboard database query]
   (when (public-settings/enable-query-caching)
-    (let [ttls (map :cache_ttl [card dashboard database])
+    (let [ttls              [(:cache_ttl card) (:cache_ttl dashboard) (db-cache-ttl database)]
           most-granular-ttl (first (filter some? ttls))]
       (or (when most-granular-ttl ; stored TTLs are in hours; convert to seconds
             (* most-granular-ttl 3600))

--- a/test/metabase/api/database_test.clj
+++ b/test/metabase/api/database_test.clj
@@ -286,7 +286,7 @@
                                         :engine  (u/qualified-name ::test-driver)
                                         :details {:db "my_db"}}))))))
 
-    (testing "should throw a 403 error if trying to set `cache_ttl` on OSS"
+    (testing "should throw a 402 error if trying to set `cache_ttl` on OSS"
       (with-redefs [premium-features/enable-advanced-config? (constantly false)]
         (mt/user-http-request :crowberto :post 402 "database"
                               {:name      (mt/random-name)

--- a/test/metabase/api/database_test.clj
+++ b/test/metabase/api/database_test.clj
@@ -15,6 +15,7 @@
    [metabase.models.permissions :as perms]
    [metabase.models.permissions-group :as perms-group]
    [metabase.models.setting :as setting :refer [defsetting]]
+   [metabase.public-settings.premium-features :as premium-features]
    [metabase.sync.analyze :as analyze]
    [metabase.sync.field-values :as field-values]
    [metabase.sync.sync-metadata :as sync-metadata]
@@ -241,6 +242,7 @@
     (testing "can we set `is_full_sync` to `false` when we create the Database?"
       (is (= {:is_full_sync false}
              (select-keys (create-db-via-api! {:is_full_sync false}) [:is_full_sync]))))
+
     (testing "if `:let-user-control-scheduling` is false it will ignore any schedules provided"
       (let [monthly-schedule {:schedule_type "monthly" :schedule_day "fri" :schedule_frame "last"}
             {:keys [details metadata_sync_schedule cache_field_values_schedule]}
@@ -249,6 +251,7 @@
         (is (not (:let-user-control-scheduling details)))
         (is (= "daily" (-> cache_field_values_schedule u.cron/cron-string->schedule-map :schedule_type)))
         (is (= "hourly" (-> metadata_sync_schedule u.cron/cron-string->schedule-map :schedule_type)))))
+
     (testing "if `:let-user-control-scheduling` is true it will accept the schedules"
       (let [monthly-schedule {:schedule_type "monthly" :schedule_day "fri" :schedule_frame "last"}
             {:keys [details metadata_sync_schedule cache_field_values_schedule]}
@@ -258,6 +261,7 @@
         (is (:let-user-control-scheduling details))
         (is (= "monthly" (-> cache_field_values_schedule u.cron/cron-string->schedule-map :schedule_type)))
         (is (= "monthly" (-> metadata_sync_schedule u.cron/cron-string->schedule-map :schedule_type)))))
+
     (testing "well known connection errors are reported properly"
       (let [dbname (mt/random-name)
             exception (Exception. (format "FATAL: database \"%s\" does not exist" dbname))]
@@ -269,6 +273,7 @@
                                         :engine       "postgres"
                                         :details      {:host "localhost", :port 5432
                                                        :dbname "fakedb", :user "rastacan"}}))))))
+
     (testing "unknown connection errors are reported properly"
       (let [exception (Exception. "Unknown driver message" (java.net.ConnectException. "Failed!"))]
         (is (= {:errors  {:host "check your host settings"
@@ -279,7 +284,20 @@
                  (mt/user-http-request :crowberto :post 400 "database"
                                        {:name    (mt/random-name)
                                         :engine  (u/qualified-name ::test-driver)
-                                        :details {:db "my_db"}}))))))))
+                                        :details {:db "my_db"}}))))))
+
+    (testing "should throw a 403 error if trying to set `cache_ttl` on OSS"
+      (with-redefs [premium-features/enable-advanced-config? (constantly false)]
+        (mt/user-http-request :crowberto :post 402 "database"
+                              {:name      (mt/random-name)
+                               :engine    (u/qualified-name ::test-driver)
+                               :details   {:db "my_db"}
+                               :cache_ttl 13})))
+
+    (testing "should allow setting `cache_ttl` on EE"
+      (with-redefs [premium-features/enable-advanced-config? (constantly true)]
+        (is (partial= {:cache_ttl 13}
+                      (create-db-via-api! {:cache_ttl 13})))))))
 
 (deftest delete-database-test
   (testing "DELETE /api/database/:id"
@@ -299,7 +317,6 @@
         (let [updates {:name         "Cam's Awesome Toucan Database"
                        :engine       "h2"
                        :is_full_sync false
-                       :cache_ttl    1337
                        :details      {:host "localhost", :port 5432, :dbname "fakedb", :user "rastacan"}}
               update! (fn [expected-status-code]
                         (mt/user-http-request :crowberto :put expected-status-code (format "database/%d" db-id) updates))]
@@ -309,11 +326,10 @@
             (with-redefs [driver/can-connect? (constantly true)]
               (is (= nil
                      (:valid (update! 200))))
-              (let [curr-db (t2/select-one [Database :name :engine :cache_ttl :details :is_full_sync], :id db-id)]
+              (let [curr-db (t2/select-one [Database :name :engine :details :is_full_sync], :id db-id)]
                 (is (=
                      {:details      {:host "localhost", :port 5432, :dbname "fakedb", :user "rastacan"}
                       :engine       :h2
-                      :cache_ttl    1337
                       :name         "Cam's Awesome Toucan Database"
                       :is_full_sync false
                       :features     (driver.u/features :h2 curr-db)}
@@ -329,18 +345,28 @@
             (mt/user-http-request :crowberto :put 200 (format "database/%d" db-id) updates))
           (is (= false
                  (t2/select-one-fn :auto_run_queries Database, :id db-id))))))
-    (testing "should be able to unset cache_ttl"
-      (mt/with-temp Database [{db-id :id}]
-        (let [updates1 {:cache_ttl    1337}
-              updates2 {:cache_ttl    nil}
-              updates1! (fn [] (mt/user-http-request :crowberto :put 200 (format "database/%d" db-id) updates1))
-              updates2! (fn [] (mt/user-http-request :crowberto :put 200 (format "database/%d" db-id) updates2))]
-          (updates1!)
-          (let [curr-db (t2/select-one [Database :cache_ttl], :id db-id)]
-            (is (= 1337 (:cache_ttl curr-db))))
-          (updates2!)
-          (let [curr-db (t2/select-one [Database :cache_ttl], :id db-id)]
-            (is (= nil (:cache_ttl curr-db)))))))))
+
+    (testing "should not be able to modify `cache_ttl` in OSS"
+      (with-redefs [premium-features/enable-advanced-config? (constantly false)]
+        (mt/with-temp Database [{db-id :id} {:engine ::test-driver}]
+          (let [updates {:cache_ttl 13}]
+            (mt/user-http-request :crowberto :put 200 (format "database/%d" db-id) updates))
+          (is (= nil
+                 (t2/select-one-fn :cache_ttl Database, :id db-id))))))
+
+    (testing "should be able to set and unset `cache_ttl` in EE"
+      (with-redefs [premium-features/enable-advanced-config? (constantly true)]
+        (mt/with-temp Database [{db-id :id} {:engine ::test-driver}]
+          (let [updates1 {:cache_ttl 1337}
+                updates2 {:cache_ttl nil}
+                updates1! (fn [] (mt/user-http-request :crowberto :put 200 (format "database/%d" db-id) updates1))
+                updates2! (fn [] (mt/user-http-request :crowberto :put 200 (format "database/%d" db-id) updates2))]
+            (updates1!)
+            (let [curr-db (t2/select-one [Database :cache_ttl], :id db-id)]
+              (is (= 1337 (:cache_ttl curr-db))))
+            (updates2!)
+            (let [curr-db (t2/select-one [Database :cache_ttl], :id db-id)]
+              (is (= nil (:cache_ttl curr-db))))))))))
 
 (deftest fetch-database-metadata-test
   (testing "GET /api/database/:id/metadata"

--- a/test/metabase/query_processor/card_test.clj
+++ b/test/metabase/query_processor/card_test.clj
@@ -41,12 +41,13 @@
                       Dashboard [dash {:cache_ttl 1338}]
                       Card [card {:database_id (u/the-id db)}]]
         (is (= (* 3600 1338) (:cache-ttl (#'qp.card/query-for-card card {} {} {} {:dashboard-id (u/the-id dash)}))))))
-    (testing "multiple ttl, db wins"
+    (testing "multiple ttl, db ttl does not take effect on OSS so nil result"
+      ;; corresponding EE test in metabase-enterprise.advanced-config.caching-test
       (mt/with-temp* [Database [db {:cache_ttl 1337}]
                       Dashboard [dash]
                       Card [card {:database_id (u/the-id db)}]]
-        (is (= (* 3600 1337) (:cache-ttl (#'qp.card/query-for-card card {} {} {} {:dashboard-id (u/the-id dash)}))))))
-    (testing "no ttl, nil res"
+        (is (= nil (:cache-ttl (#'qp.card/query-for-card card {} {} {} {:dashboard-id (u/the-id dash)}))))))
+    (testing "no ttl, nil result"
       (mt/with-temp* [Database [db]
                       Dashboard [dash]
                       Card [card {:database_id (u/the-id db)}]]


### PR DESCRIPTION
Resolves https://github.com/metabase/metabase/issues/29477

* Throws a 402 (payment required) error when adding a new database with the `cache_ttl` key if the `advanced-config` feature is not enabled.
* Does not update `cache_ttl` when updating a database if the `advanced-config` feature is not enabled
* Does not take the DB-level `cache_ttl` value into account when running a card if `advanced-config` is not enabled