### PR TITLE
Implement MLv2 `orderable-columns`

### DIFF
--- a/src/metabase/lib/aggregation.cljc
+++ b/src/metabase/lib/aggregation.cljc
@@ -2,14 +2,14 @@
   (:refer-clojure :exclude [count distinct max min])
   (:require
    [metabase.lib.common :as lib.common]
+   [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.metadata.calculation :as lib.metadata.calculation]
    [metabase.lib.schema :as lib.schema]
    [metabase.lib.schema.aggregation :as lib.schema.aggregation]
    [metabase.lib.schema.common :as lib.schema.common]
    [metabase.lib.util :as lib.util]
    [metabase.shared.util.i18n :as i18n]
-   [metabase.util.malli :as mu])
-  #?(:cljs (:require-macros [metabase.lib.aggregation])))
+   [metabase.util.malli :as mu]))
 
 (mu/defn resolve-aggregation :- ::lib.schema.aggregation/aggregation
   "Resolve an aggregation with a specific `index`."
@@ -206,3 +206,17 @@
        update :aggregation
        (fn [aggregations]
          (conj (vec aggregations) (lib.common/->op-arg query stage-number an-aggregate-clause)))))))
+
+(mu/defn aggregations :- [:maybe [:sequential lib.metadata/ColumnMetadata]]
+  "Get metadata about the aggregations in a given stage of a query."
+  [query        :- ::lib.schema/query
+   stage-number :- :int]
+  (when-let [aggregation-exprs (not-empty (:aggregation (lib.util/query-stage query stage-number)))]
+    (map-indexed (fn [i aggregation]
+                   (let [metadata (lib.metadata.calculation/metadata query stage-number aggregation)
+                         ag-ref   [:aggregation
+                                   {:lib/uuid  (str (random-uuid))
+                                    :base-type (:base_type metadata)}
+                                   i]]
+                     (assoc metadata :field_ref ag-ref, :source :aggregation)))
+                 aggregation-exprs)))

--- a/src/metabase/lib/breakout.cljc
+++ b/src/metabase/lib/breakout.cljc
@@ -1,6 +1,7 @@
 (ns metabase.lib.breakout
   (:require
    [clojure.string :as str]
+   [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.metadata.calculation :as lib.metadata.calculation]
    [metabase.lib.schema :as lib.schema]
    [metabase.lib.schema.expression :as lib.schema.expression]
@@ -29,3 +30,12 @@
                 expr)]
      (lib.util/update-query-stage query stage-number update :breakout (fn [breakouts]
                                                                         (conj (vec breakouts) expr))))))
+
+(mu/defn breakouts :- [:maybe [:sequential lib.metadata/ColumnMetadata]]
+  "Get metadata about the breakouts in a given stage of a `query`."
+  [query        :- ::lib.schema/query
+   stage-number :- :int]
+  (when-let [breakout-exprs (not-empty (:breakout (lib.util/query-stage query stage-number)))]
+    (mapv (fn [field-ref]
+            (assoc (lib.metadata.calculation/metadata query stage-number field-ref) :source :breakout))
+          breakout-exprs)))

--- a/src/metabase/lib/core.cljc
+++ b/src/metabase/lib/core.cljc
@@ -150,7 +150,8 @@
   [lib.order-by
    order-by
    order-by-clause
-   order-bys]
+   order-bys
+   orderable-columns]
   [lib.query
    native-query
    query

--- a/src/metabase/lib/core.cljc
+++ b/src/metabase/lib/core.cljc
@@ -99,8 +99,6 @@
    rtrim
    upper
    lower]
-  [lib.field
-   with-join-alias]
   [lib.filter
    filter
    add-filter
@@ -138,7 +136,9 @@
   [lib.join
    join
    join-clause
-   joins]
+   joins
+   with-join-alias
+   with-join-fields]
   [lib.limit
    current-limit
    limit]

--- a/src/metabase/lib/expression.cljc
+++ b/src/metabase/lib/expression.cljc
@@ -1,8 +1,11 @@
 (ns metabase.lib.expression
-  (:refer-clojure :exclude [+ - * / case coalesce abs time concat replace])
+  (:refer-clojure
+   :exclude
+   [+ - * / case coalesce abs time concat replace])
   (:require
    [clojure.string :as str]
    [metabase.lib.common :as lib.common]
+   [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.metadata.calculation :as lib.metadata.calculation]
    [metabase.lib.schema :as lib.schema]
    [metabase.lib.schema.common :as lib.schema.common]
@@ -197,3 +200,14 @@
 (lib.common/defop rtrim [s])
 (lib.common/defop upper [s])
 (lib.common/defop lower [s])
+
+(mu/defn expressions :- [:sequential lib.metadata/ColumnMetadata]
+  "Get metadata about the expressions in a given stage of a `query`."
+  [query        :- ::lib.schema/query
+   stage-number :- :int]
+  (for [[expression-name expression-definition] (:expressions (lib.util/query-stage query stage-number))]
+    (let [metadata (lib.metadata.calculation/metadata query stage-number expression-definition)]
+      (merge
+       metadata
+       {:field_ref [:expression {:lib/uuid (str (random-uuid)), :base-type (:base_type metadata)} expression-name]
+        :source    :expressions}))))

--- a/src/metabase/lib/field.cljc
+++ b/src/metabase/lib/field.cljc
@@ -148,10 +148,6 @@
   ([query stage-number x]
    (->field query stage-number x)))
 
-(defn with-join-alias
-  "Update a `field` so that it has `join-alias`."
-  [field-or-fn join-alias]
-  (if (fn? field-or-fn)
-    (fn [query stage-number]
-      (with-join-alias (field-or-fn query stage-number) join-alias))
-    (lib.options/update-options field-or-fn assoc :join-alias join-alias)))
+(defmethod lib.join/with-join-alias-method :field
+  [field-ref join-alias]
+  (lib.options/update-options field-ref assoc :join-alias join-alias))

--- a/src/metabase/lib/join.cljc
+++ b/src/metabase/lib/join.cljc
@@ -141,6 +141,37 @@
    (cond-> (join-clause query stage-number x)
      condition (assoc :condition (join-condition query stage-number condition)))))
 
+(defmulti with-join-alias-method
+  "Implementation for [[with-join-alias]]."
+  {:arglists '([x join-alias])}
+  (fn [x _join-alias]
+    (lib.dispatch/dispatch-value x)))
+
+(mu/defn with-join-alias
+  "Add a specific `join-alias` to something `x`, either a `:field` or join map. Does not recursively update other
+  references (yet; we can add this in the future)."
+  [x join-alias :- ::lib.schema.common/non-blank-string]
+  (with-join-alias-method x join-alias))
+
+(defmethod with-join-alias-method :dispatch-type/fn
+  [f join-alias]
+  (fn [query stage-number]
+    (let [x (f query stage-number)]
+      (with-join-alias-method x join-alias))))
+
+(defmethod with-join-alias-method :mbql/join
+  [join join-alias]
+  (assoc join :alias join-alias))
+
+(mu/defn with-join-fields
+  "Update a join (or a function that will return a join) to include `:fields`, either `:all`, `:none`, or a sequence of
+  references."
+  [join fields :- ::lib.schema.join/fields]
+  (if (fn? join)
+    (fn [query stage-number]
+      (with-join-fields (join query stage-number) fields))
+    (assoc join :fields fields)))
+
 (mu/defn join :- ::lib.schema/query
   "Create a join map as if by [[join-clause]] and add it to a `query`.
 

--- a/src/metabase/lib/join.cljc
+++ b/src/metabase/lib/join.cljc
@@ -166,11 +166,11 @@
 (mu/defn with-join-fields
   "Update a join (or a function that will return a join) to include `:fields`, either `:all`, `:none`, or a sequence of
   references."
-  [join fields :- ::lib.schema.join/fields]
-  (if (fn? join)
+  [x fields :- ::lib.schema.join/fields]
+  (if (fn? x)
     (fn [query stage-number]
-      (with-join-fields (join query stage-number) fields))
-    (assoc join :fields fields)))
+      (with-join-fields (x query stage-number) fields))
+    (assoc x :fields fields)))
 
 (mu/defn join :- ::lib.schema/query
   "Create a join map as if by [[join-clause]] and add it to a `query`.

--- a/src/metabase/lib/metadata.cljc
+++ b/src/metabase/lib/metadata.cljc
@@ -42,7 +42,7 @@
   that they are largely compatible. So they're the same for now. We can revisit this in the future if we actually want
   to differentiate between the two versions."
   [:map
-   [:lib/type [:= :metadata/field]]
+   [:lib/type [:= :metadata/field]] ; TODO -- should this be changed to `:metadata/column`?
    [:id {:optional true} ::lib.schema.id/field]
    [:name ::lib.schema.common/non-blank-string]])
 

--- a/src/metabase/lib/order_by.cljc
+++ b/src/metabase/lib/order_by.cljc
@@ -1,11 +1,16 @@
 (ns metabase.lib.order-by
   (:require
+   [metabase.lib.aggregation :as lib.aggregation]
+   [metabase.lib.breakout :as lib.breakout]
    [metabase.lib.dispatch :as lib.dispatch]
    [metabase.lib.field :as lib.field]
+   [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.metadata.calculation :as lib.metadata.calculation]
    [metabase.lib.options :as lib.options]
    [metabase.lib.schema :as lib.schema]
+   [metabase.lib.schema.expression :as lib.schema.expression]
    [metabase.lib.schema.order-by :as lib.schema.order-by]
+   [metabase.lib.stage :as lib.stage]
    [metabase.lib.util :as lib.util]
    [metabase.shared.util.i18n :as i18n]
    [metabase.util.malli :as mu]))
@@ -87,5 +92,42 @@
   ([query :- ::lib.schema/query]
    (order-bys query -1))
   ([query :- ::lib.schema/query
-    stage-number :- [:int]]
+    stage-number :- :int]
    (not-empty (get (lib.util/query-stage query stage-number) :order-by))))
+
+(defn- orderable-column? [{base-type :base_type, :as _column-metadata}]
+  (some (fn [orderable-base-type]
+          (isa? base-type orderable-base-type))
+        lib.schema.expression/orderable-types))
+
+(mu/defn orderable-columns :- [:sequential lib.metadata/ColumnMetadata]
+  "Get column metadata for all the columns you can order by in a given `stage-number` of a `query`. Rules are as
+  follows:
+
+  1. If the stage has aggregations or breakouts, you can only order by those columns. E.g.
+
+         SELECT id, count(*) AS count FROM core_user GROUP BY id ORDER BY count ASC;
+
+     You can't ORDER BY something not in the SELECT, e.g. ORDER BY user.first_name would not make sense here.
+
+  2. If the stage has no aggregations or breakouts, you can order by any visible Field:
+
+     a. You can filter by any custom `:expressions` in this stage of the query
+
+     b. You can filter by any Field 'exported' by the previous stage of the query, if there is one; otherwise you can
+        filter by any Fields from the current `:source-table`.
+
+     c. You can filter by any Fields exported by any explicit joins
+
+     d. You can filter by and Fields in Tables that are implicitly joinable."
+  ([query :- ::lib.schema/query]
+   (orderable-columns query -1))
+
+  ([query        :- ::lib.schema/query
+    stage-number :- :int]
+   (let [breakouts    (not-empty (lib.breakout/breakouts query stage-number))
+         aggregations (not-empty (lib.aggregation/aggregations query stage-number))]
+     (filter orderable-column?
+             (if (or breakouts aggregations)
+               (concat breakouts aggregations)
+               (lib.stage/visible-columns query stage-number))))))

--- a/src/metabase/lib/schema/expression.cljc
+++ b/src/metabase/lib/schema/expression.cljc
@@ -126,8 +126,12 @@
 (mr/def ::temporal
   (expression-schema :type/Temporal "expression returning a date, time, or date time"))
 
+(def orderable-types
+  "Set of base types that are orderable."
+  #{:type/Text :type/Number :type/Temporal})
+
 (mr/def ::orderable
-  (expression-schema #{:type/Text :type/Number :type/Temporal}
+  (expression-schema orderable-types
                      "an expression that can be compared with :> or :<"))
 
 (mr/def ::equality-comparable

--- a/src/metabase/lib/schema/join.cljc
+++ b/src/metabase/lib/schema/join.cljc
@@ -24,7 +24,7 @@
 (mr/def ::fields
   [:or
    [:enum :all :none]
-   ;;; TODO -- Pretty sure fields are supposed to be unique, even excluding `:lib/uuid`
+   ;; TODO -- Pretty sure fields are supposed to be unique, even excluding `:lib/uuid`
    [:sequential {:min 1} [:ref ::ref/ref]]])
 
 ;;; The name used to alias the joined table or query. This is usually generated automatically and generally looks

--- a/src/metabase/lib/stage.cljc
+++ b/src/metabase/lib/stage.cljc
@@ -2,6 +2,10 @@
   "Method implementations for a stage of a query."
   (:require
    [clojure.string :as str]
+   [medley.core :as m]
+   [metabase.lib.aggregation :as lib.aggregation]
+   [metabase.lib.breakout :as lib.breakout]
+   [metabase.lib.expression :as lib.expression]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.metadata.calculation :as lib.metadata.calculation]
    [metabase.lib.schema :as lib.schema]
@@ -15,24 +19,6 @@
    [metabase.util.malli :as mu]))
 
 (declare stage-metadata)
-
-(mu/defn ^:private breakout-columns :- [:maybe [:sequential lib.metadata/ColumnMetadata]]
-  [query        :- ::lib.schema/query
-   stage-number :- :int]
-  (when-let [{breakouts :breakout} (lib.util/query-stage query stage-number)]
-    (mapv (fn [field-ref]
-            (assoc (lib.metadata.calculation/metadata query stage-number field-ref) :source :breakout))
-          breakouts)))
-
-(mu/defn ^:private aggregation-columns :- [:maybe [:sequential lib.metadata/ColumnMetadata]]
-  [query        :- ::lib.schema/query
-   stage-number :- :int]
-  (when-let [{aggregations :aggregation} (lib.util/query-stage query stage-number)]
-    (map-indexed (fn [i aggregation]
-                   (let [metadata (lib.metadata.calculation/metadata query stage-number aggregation)
-                         ag-ref   [:aggregation {:lib/uuid (str (random-uuid))} i]]
-                     (assoc metadata :field_ref ag-ref)))
-                 aggregations)))
 
 (mu/defn ^:private fields-columns :- [:maybe [:sequential lib.metadata/ColumnMetadata]]
   [query        :- ::lib.schema/query
@@ -58,6 +44,14 @@
              [(or position 0) (u/lower-case-en (or field-name ""))])
            field-metadatas))
 
+(defn- ensure-field-refs [field-metadatas]
+  (for [field-metadata field-metadatas]
+    (cond-> field-metadata
+      (not (:field_ref field-metadata))
+      (assoc :field_ref [:field
+                         {:lib/uuid (str (random-uuid)), :base-type (:base_type field-metadata)}
+                         ((some-fn :id :name) field-metadata)]))))
+
 (mu/defn ^:private source-table-default-fields :- [:maybe [:sequential lib.metadata/ColumnMetadata]]
   "Determine the Fields we'd normally return for a source Table.
   See [[metabase.query-processor.middleware.add-implicit-clauses/add-implicit-fields]]."
@@ -66,7 +60,8 @@
   (when-let [field-metadatas (lib.metadata/fields query table-id)]
     (->> field-metadatas
          remove-hidden-default-fields
-         sort-default-fields)))
+         sort-default-fields
+         ensure-field-refs)))
 
 (mu/defn ^:private default-join-alias :- ::lib.schema.common/non-blank-string
   "Generate an alias for a join that doesn't already have one."
@@ -94,7 +89,7 @@
               (not (:alias join)) (assoc :alias (unique-name-generator (default-join-alias query stage-number join)))))
           joins)))
 
-(mu/defn ^:private default-columns-added-by-join :- [:sequential lib.metadata/ColumnMetadata]
+(mu/defn ^:private default-columns-added-by-join :- [:maybe [:sequential lib.metadata/ColumnMetadata]]
   [query        :- ::lib.schema/query
    stage-number :- :int
    join         :- ::lib.schema.join/join]
@@ -109,7 +104,7 @@
            (mapcat (partial default-columns-added-by-join query stage-number))
            (ensure-all-joins-have-aliases query stage-number joins)))))
 
-(mu/defn ^:private default-columns :- [:sequential {:min 1} lib.metadata/ColumnMetadata]
+(mu/defn ^:private default-columns :- [:sequential lib.metadata/ColumnMetadata]
   "Calculate the columns to return if `:aggregations`/`:breakout`/`:fields` are unspecified.
 
   Formula for the so-called 'default' columns is
@@ -118,7 +113,9 @@
 
   1b. Default 'visible' Fields for our `:source-table`, OR
 
-  1c. `:lib/stage-metadata` if this is a `:mbql.stage/native` stage
+  1c. Metadata associated with a Saved Question, if `:source-table` is a `card__<id>` string, OR
+
+  1d. `:lib/stage-metadata` if this is a `:mbql.stage/native` stage
 
   PLUS
 
@@ -132,11 +129,22 @@
      (stage-metadata query previous-stage-number)
      ;; 1b or 1c
      (let [{:keys [source-table], :as this-stage} (lib.util/query-stage query stage-number)]
-       (if (integer? source-table)
-         ;; 1b: default visible Fields for the source Table
-         (source-table-default-fields query source-table)
-         ;; 1c: `:lib/stage-metadata` for the native query
-         (:columns (:lib/stage-metadata this-stage)))))
+       (or
+        ;; 1b: default visible Fields for the source Table
+        (when (integer? source-table)
+          (source-table-default-fields query source-table))
+        ;; 1c. Metadata associated with a Saved Question, if `:source-table` is a `card__<id>` string, OR
+        (when (string? source-table)
+          (when-let [[_match card-id-str] (re-find #"^card__(\d+)$" source-table)]
+            (when-let [card-id (parse-long card-id-str)]
+              (when-let [result-metadata (:result_metadata (lib.metadata/card query card-id))]
+                (not-empty (for [col (:columns result-metadata)]
+                             (assoc col
+                                    :field_ref [:field
+                                                {:lib/uuid (str (random-uuid)), :base-type (:base_type col)}
+                                                (:name col)])))))))
+        ;; 1d: `:lib/stage-metadata` for the native query
+        (:columns (:lib/stage-metadata this-stage)))))
    ;; 2: columns added by joins at this stage
    (default-columns-added-by-joins query stage-number)))
 
@@ -170,8 +178,8 @@
      (or
       (not-empty (into []
                        cat
-                       [(breakout-columns query stage-number)
-                        (aggregation-columns query stage-number)
+                       [(lib.breakout/breakouts query stage-number)
+                        (lib.aggregation/aggregations query stage-number)
                         (fields-columns query stage-number)]))
       (default-columns query stage-number)))))
 
@@ -199,3 +207,32 @@
         descriptions (for [k parts]
                        (lib.metadata.calculation/describe-top-level-key query stage-number k))]
     (str/join ", " (remove str/blank? descriptions))))
+
+(defn- implicitly-joinable-columns [query column-metadatas]
+  (let [existing-table-ids (into #{} (map :table_id) column-metadatas)]
+    (into []
+          (comp (filter :fk_target_field_id)
+                (m/distinct-by :fk_target_field_id)
+                (map (fn [{source-field-id :id, target-field-id :fk_target_field_id}]
+                       (-> (lib.metadata/field query target-field-id)
+                           (assoc :source-field-id source-field-id))))
+                (remove #(contains? existing-table-ids (:table_id %)))
+                (m/distinct-by :table_id)
+                (mapcat (fn [{table-id :table_id, :keys [source-field-id]}]
+                          (for [field (source-table-default-fields query table-id)]
+                            (assoc field :field_ref [:field
+                                                     {:lib/uuid     (str (random-uuid))
+                                                      :base-type    (:base_type field)
+                                                      :source-field source-field-id}
+                                                     (:id field)])))))
+          column-metadatas)))
+
+(mu/defn visible-columns :- [:sequential lib.metadata/ColumnMetadata]
+  "Columns that are visible inside a given stage of a query. Ignores `:fields`, `:breakout`, and `:aggregation`."
+  [query stage-number]
+  (let [query   (lib.util/update-query-stage query stage-number dissoc :fields :breakout :aggregation)
+        columns (default-columns query stage-number)]
+    (concat
+     (lib.expression/expressions query stage-number)
+     columns
+     (implicitly-joinable-columns query columns))))

--- a/src/metabase/lib/util.cljc
+++ b/src/metabase/lib/util.cljc
@@ -140,7 +140,7 @@
     stage-number'))
 
 (defn previous-stage-number
-  "The index of the previous stage, if there is one."
+  "The index of the previous stage, if there is one. `nil` if there is no previous stage."
   [{:keys [stages], :as _query} stage-number]
   (let [stage-number (if (neg? stage-number)
                        (+ (count stages) stage-number)

--- a/test/metabase/lib/order_by_test.cljc
+++ b/test/metabase/lib/order_by_test.cljc
@@ -1,12 +1,17 @@
 (ns metabase.lib.order-by-test
   (:require
    [clojure.test :refer [deftest is testing]]
+   [medley.core :as m]
    [metabase.lib.convert :as lib.convert]
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.metadata.calculation :as lib.metadata.calculation]
+   [metabase.lib.order-by :as lib.order-by]
    [metabase.lib.query :as lib.query]
    [metabase.lib.test-metadata :as meta]
+   [metabase.lib.test-util :as lib.tu]
+   [metabase.lib.util :as lib.util]
+   [metabase.util :as u]
    #?@(:cljs ([metabase.test-runner.assert-exprs.approximately-equal]))))
 
 #?(:cljs (comment metabase.test-runner.assert-exprs.approximately-equal/keep-me))
@@ -121,17 +126,279 @@
 (deftest ^:parallel describe-order-by-expression-reference-test
     ;;   it("should work with expressions", () => {
   ;;     const query = {
-  ;;       "source-table": PRODUCTS.id,
+  ;;       "source-table": PRODUCTS.id
   ;;       expressions: {
-  ;;         Foo: ["concat", "Foo ", ["field", 4, null]],
-  ;;       },
-  ;;       "order-by": [["asc", ["expression", "Foo", null]]],
+  ;;         Foo: ["concat", "Foo ", ["field", 4, null]]
+  ;;       }
+  ;;       "order-by": [["asc", ["expression", "Foo", null]]]
   ;;     };
   ;;     expect(base_question._getOrderByDescription(PRODUCTS, query)).toEqual([
-  ;;       "Sorted by ",
-  ;;       ["Foo ascending"],
+  ;;       "Sorted by "
+  ;;       ["Foo ascending"]
   ;;     ]);
   ;;   });
   ;; });
 
   )
+
+(deftest ^:parallel orderable-columns-breakouts-test
+  (testing "If query has aggregations and/or breakouts, you can only order by those."
+    (let [query (-> (lib/query-for-table-name meta/metadata-provider "VENUES")
+                    (lib/aggregate (lib/sum (lib/field "VENUES" "PRICE")))
+                    (lib/aggregate (lib/avg (lib/+ (lib/field "VENUES" "PRICE") 1)))
+                    (lib/breakout (lib/field "VENUES" "CATEGORY_ID")))]
+      (testing (lib.util/format "Query =\n%s" (u/pprint-to-str query))
+        (is (=? [{:database_type      "INTEGER"
+                  :semantic_type      :type/FK
+                  :lib/type           :metadata/field
+                  :table_id           (meta/id :venues)
+                  :name               "CATEGORY_ID"
+                  :has_field_values   :none
+                  :source             :breakout
+                  :fk_target_field_id (meta/id :categories :id)
+                  :field_ref          [:field
+                                       {:base-type :type/Integer, :lib/uuid string?}
+                                       (meta/id :venues :category-id)]
+                  :effective_type     :type/Integer
+                  :id                 (meta/id :venues :category-id)
+                  :display_name       "Category ID"
+                  :base_type          :type/Integer}
+                 {:lib/type     :metadata/field
+                  :base_type    :type/Integer
+                  :name         "sum_price"
+                  :display_name "Sum of Price"
+                  :field_ref    [:aggregation {:lib/uuid string?, :base-type :type/Integer} 0]
+                  :source       :aggregation}
+                 {:lib/type     :metadata/field
+                  :base_type    :type/Float
+                  :name         "avg_price_plus_1"
+                  :display_name "Average of Price + 1"
+                  :field_ref    [:aggregation {:lib/uuid string?, :base-type :type/Float} 1]
+                  :source       :aggregation}]
+                (lib.order-by/orderable-columns query)))))))
+
+(deftest ^:parallel orderable-columns-breakouts-with-expression-test
+  (testing "If query has aggregations and/or breakouts, you can only order by those (with an expression)"
+    (let [query (-> (lib/query-for-table-name meta/metadata-provider "VENUES")
+                    (lib/expression "Category ID + 1"  (lib/+ (lib/field "VENUES" "CATEGORY_ID") 1))
+                    (lib/breakout [:expression {:lib/uuid (str (random-uuid))} "Category ID + 1"]))]
+      (testing (lib.util/format "Query =\n%s" (u/pprint-to-str query))
+        (is (=? [{:lib/type     :metadata/field
+                  :field_ref    [:expression {:lib/uuid string?} "Category ID + 1"]
+                  :name         "Category ID + 1"
+                  :display_name "Category ID + 1"
+                  :base_type    :type/Integer
+                  :source       :breakout}]
+                (lib.order-by/orderable-columns query)))))))
+
+(deftest ^:parallel orderable-columns-test
+  (let [query (lib/query-for-table-name meta/metadata-provider "VENUES")]
+    (testing (lib.util/format "Query =\n%s" (u/pprint-to-str query))
+      (is (=? [{:lib/type     :metadata/field
+                :name         "ID"
+                :display_name "ID"
+                :id           (meta/id :venues :id)
+                :table_id     (meta/id :venues)
+                :base_type    :type/BigInteger
+                :field_ref    [:field {:lib/uuid string?, :base-type :type/BigInteger} (meta/id :venues :id)]}
+               {:lib/type     :metadata/field
+                :name         "NAME"
+                :display_name "Name"
+                :id           (meta/id :venues :name)
+                :table_id     (meta/id :venues)
+                :base_type    :type/Text
+                :field_ref    [:field {:lib/uuid string?, :base-type :type/Text} (meta/id :venues :name)]}
+               {:lib/type     :metadata/field
+                :name         "CATEGORY_ID"
+                :display_name "Category ID"
+                :id           (meta/id :venues :category-id)
+                :table_id     (meta/id :venues)
+                :field_ref    [:field {:lib/uuid string?, :base-type :type/Integer} (meta/id :venues :category-id)]}
+               {:lib/type     :metadata/field
+                :name         "LATITUDE"
+                :display_name "Latitude"
+                :id           (meta/id :venues :latitude)
+                :table_id     (meta/id :venues)
+                :base_type    :type/Float
+                :field_ref    [:field {:lib/uuid string?, :base-type :type/Float} (meta/id :venues :latitude)]}
+               {:lib/type     :metadata/field
+                :name         "LONGITUDE"
+                :display_name "Longitude"
+                :id           (meta/id :venues :longitude)
+                :table_id     (meta/id :venues)
+                :base_type    :type/Float
+                :field_ref    [:field {:lib/uuid string?, :base-type :type/Float} (meta/id :venues :longitude)]}
+               {:lib/type     :metadata/field
+                :name         "PRICE"
+                :display_name "Price"
+                :id           (meta/id :venues :price)
+                :table_id     (meta/id :venues)
+                :base_type    :type/Integer
+                :field_ref    [:field {:lib/uuid string?, :base-type :type/Integer} (meta/id :venues :price)]}
+               {:lib/type     :metadata/field
+                :name         "ID"
+                :display_name "ID"
+                :id           (meta/id :categories :id)
+                :table_id     (meta/id :categories)
+                :base_type    :type/BigInteger
+                :field_ref    [:field
+                               {:lib/uuid string?, :base-type :type/BigInteger, :source-field (meta/id :venues :category-id)}
+                               (meta/id :categories :id)]}
+               {:lib/type     :metadata/field
+                :name         "NAME"
+                :display_name "Name"
+                :id           (meta/id :categories :name)
+                :table_id     (meta/id :categories)
+                :base_type    :type/Text
+                :field_ref    [:field
+                               {:lib/uuid string?, :base-type :type/Text, :source-field (meta/id :venues :category-id)}
+                               (meta/id :categories :name)]}]
+              (lib.order-by/orderable-columns query))))))
+
+(deftest ^:parallel orderable-expressions-test
+  (testing "orderable-columns should include expressions"
+    (let [query (-> (lib/query-for-table-name meta/metadata-provider "VENUES")
+                    (lib/expression "Category ID + 1"  (lib/+ (lib/field "VENUES" "CATEGORY_ID") 1)))]
+      (testing (lib.util/format "Query =\n%s" (u/pprint-to-str query))
+        (is (=? [{:lib/type     :metadata/field
+                  :base_type    :type/Integer
+                  :name         "category_id_plus_1"
+                  :display_name "Category ID + 1"
+                  :field_ref    [:expression
+                                 {:lib/uuid string?, :base-type :type/Integer}
+                                 "Category ID + 1"]
+                  :source       :expressions}
+                 {:id (meta/id :venues :id), :name "ID"}
+                 {:id (meta/id :venues :name), :name "NAME"}
+                 {:id (meta/id :venues :category-id), :name "CATEGORY_ID"}
+                 {:id (meta/id :venues :latitude), :name "LATITUDE"}
+                 {:id (meta/id :venues :longitude), :name "LONGITUDE"}
+                 {:id (meta/id :venues :price), :name "PRICE"}
+                 {:id (meta/id :categories :id), :name "ID"}
+                 {:id (meta/id :categories :name), :name "NAME"}]
+                (lib.order-by/orderable-columns query)))))))
+
+(defn- FIXME-is-empty
+  "FIXME: Currently no way to add an `:is-empty` clause inline."
+  [expr]
+  (fn [query stage-number]
+    (lib/is-empty query stage-number expr)))
+
+(deftest ^:parallel orderable-expressions-exclude-boolean-expressions-test
+  (testing "orderable-columns should filter out boolean expressions."
+    (let [query (-> (lib/query-for-table-name meta/metadata-provider "VENUES")
+                    (lib/expression "Name is empty?"  (FIXME-is-empty (lib/field "VENUES" "NAME"))))]
+      (testing (lib.util/format "Query =\n%s" (u/pprint-to-str query))
+        (is (=? [{:id (meta/id :venues :id), :name "ID"}
+                 {:id (meta/id :venues :name), :name "NAME"}
+                 {:id (meta/id :venues :category-id), :name "CATEGORY_ID"}
+                 {:id (meta/id :venues :latitude), :name "LATITUDE"}
+                 {:id (meta/id :venues :longitude), :name "LONGITUDE"}
+                 {:id (meta/id :venues :price), :name "PRICE"}
+                 {:id (meta/id :categories :id), :name "ID"}
+                 {:id (meta/id :categories :name), :name "NAME"}]
+                (lib.order-by/orderable-columns query)))))))
+
+(defn- FIXME-=
+  "FIXME: [[metabase.lib.core]] doesn't have a test-friendly version of `:=` yet."
+  [a b]
+  (fn [query stage-number]
+    (let [a (if (fn? a)
+              (a query stage-number)
+              a)
+          b (if (fn? b)
+              (b query stage-number)
+              b)]
+      ;; This is another FIXME!
+      #_{:clj-kondo/ignore [:invalid-arity]}
+      (lib/= query stage-number a b))))
+
+(deftest ^:parallel orderable-explicit-joins-test
+  (testing "orderable-columns should include columns from explicit joins"
+    (let [query (-> (lib/query-for-table-name meta/metadata-provider "VENUES")
+                    (lib/join (-> (lib/join-clause
+                                   (meta/table-metadata :categories)
+                                   (FIXME-=
+                                    (lib/field "VENUES" "CATEGORY_ID")
+                                    (lib/with-join-alias (lib/field "CATEGORIES" "ID") "Cat")))
+                                  (lib/with-join-alias "Cat")
+                                  (lib/with-join-fields :all))))]
+      (testing (lib.util/format "Query =\n%s" (u/pprint-to-str query))
+        (is (=? [{:id (meta/id :venues :id), :name "ID"}
+                 {:id (meta/id :venues :name), :name "NAME"}
+                 {:id (meta/id :venues :category-id), :name "CATEGORY_ID"}
+                 {:id (meta/id :venues :latitude), :name "LATITUDE"}
+                 {:id (meta/id :venues :longitude), :name "LONGITUDE"}
+                 {:id (meta/id :venues :price), :name "PRICE"}
+                 {:lib/type     :metadata/field
+                  :name         "ID"
+                  :display_name "Categories → ID" ; should we be using the explicit alias we gave this join?
+                  :source_alias "Cat"
+                  :id           (meta/id :categories :id)
+                  :table_id     (meta/id :categories)
+                  :base_type    :type/BigInteger
+                  :field_ref    [:field
+                                 {:lib/uuid string?, :base-type :type/BigInteger, :join-alias "Cat"}
+                                 (meta/id :categories :id)]}
+                 {:lib/type     :metadata/field
+                  :name         "NAME"
+                  :display_name "Categories → Name"
+                  :source_alias "Cat"
+                  :id           (meta/id :categories :name)
+                  :table_id     (meta/id :categories)
+                  :base_type    :type/Text
+                  :field_ref    [:field
+                                 {:lib/uuid string?, :base-type :type/Text, :join-alias "Cat"}
+                                 (meta/id :categories :name)]}]
+                (lib.order-by/orderable-columns query)))))))
+
+(deftest ^:parallel orderable-columns-source-metadata-test
+  (testing "orderable-columns should use metadata for source query."
+    (let [query (lib.tu/query-with-card-source-table)]
+      (testing (lib.util/format "Query =\n%s" (u/pprint-to-str query))
+        (is (=? [{:name "ID"
+                  :base_type :type/BigInteger
+                  :field_ref [:field {:lib/uuid string?, :base-type :type/BigInteger} "ID"]}
+                 {:name "NAME"
+                  :base_type :type/Text
+                  :field_ref [:field {:lib/uuid string?, :base-type :type/Text} "NAME"]}
+                 {:name "CATEGORY_ID"
+                  :base_type :type/Integer
+                  :field_ref [:field {:lib/uuid string?, :base-type :type/Integer} "CATEGORY_ID"]}
+                 {:name "LATITUDE"
+                  :base_type :type/Float
+                  :field_ref [:field {:lib/uuid string?, :base-type :type/Float} "LATITUDE"]}
+                 {:name "LONGITUDE"
+                  :base_type :type/Float
+                  :field_ref [:field {:lib/uuid string?, :base-type :type/Float} "LONGITUDE"]}
+                 {:name "PRICE"
+                  :base_type :type/Integer
+                  :field_ref [:field {:lib/uuid string?, :base-type :type/Integer} "PRICE"]}]
+                (lib.order-by/orderable-columns query)))))))
+
+(deftest ^:parallel orderable-columns-e2e-test
+  (testing "Use the metadata returned by `orderable-columns` to add a new order-by to a query."
+    (let [query (lib/query-for-table-name meta/metadata-provider "VENUES")]
+      (is (=? {:lib/type :mbql/query
+               :database (meta/id)
+               :stages   [{:lib/type     :mbql.stage/mbql
+                           :source-table (meta/id :venues)
+                           :lib/options  {:lib/uuid string?}}]}
+              query))
+      (testing (lib.util/format "Query =\n%s" (u/pprint-to-str query))
+        (let [orderable-columns (lib.order-by/orderable-columns query)
+              col               (m/find-first #(= (:id %) (meta/id :venues :name)) orderable-columns)
+              query'            (lib/order-by query col)]
+          (is (=? {:lib/type :mbql/query
+                   :database (meta/id)
+                   :stages   [{:lib/type     :mbql.stage/mbql
+                               :source-table (meta/id :venues)
+                               :lib/options  {:lib/uuid string?}
+                               :order-by     [[:asc
+                                               {:lib/uuid string?}
+                                               [:field {:lib/uuid string?, :base-type :type/Text} (meta/id :venues :name)]]]}]}
+                  query'))
+          (is (=? [[:asc
+                    {:lib/uuid string?}
+                    [:field {:lib/uuid string?, :base-type :type/Text} (meta/id :venues :name)]]]
+                  (lib/order-bys query'))))))))

--- a/test/metabase/lib/order_by_test.cljc
+++ b/test/metabase/lib/order_by_test.cljc
@@ -6,7 +6,6 @@
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.metadata.calculation :as lib.metadata.calculation]
-   [metabase.lib.order-by :as lib.order-by]
    [metabase.lib.query :as lib.query]
    [metabase.lib.test-metadata :as meta]
    [metabase.lib.test-util :as lib.tu]
@@ -175,7 +174,7 @@
                   :display_name "Average of Price + 1"
                   :field_ref    [:aggregation {:lib/uuid string?, :base-type :type/Float} 1]
                   :source       :aggregation}]
-                (lib.order-by/orderable-columns query)))))))
+                (lib/orderable-columns query)))))))
 
 (deftest ^:parallel orderable-columns-breakouts-with-expression-test
   (testing "If query has aggregations and/or breakouts, you can only order by those (with an expression)"
@@ -189,7 +188,7 @@
                   :display_name "Category ID + 1"
                   :base_type    :type/Integer
                   :source       :breakout}]
-                (lib.order-by/orderable-columns query)))))))
+                (lib/orderable-columns query)))))))
 
 (deftest ^:parallel orderable-columns-test
   (let [query (lib/query-for-table-name meta/metadata-provider "VENUES")]
@@ -253,7 +252,7 @@
                 :field_ref    [:field
                                {:lib/uuid string?, :base-type :type/Text, :source-field (meta/id :venues :category-id)}
                                (meta/id :categories :name)]}]
-              (lib.order-by/orderable-columns query))))))
+              (lib/orderable-columns query))))))
 
 (deftest ^:parallel orderable-expressions-test
   (testing "orderable-columns should include expressions"
@@ -276,7 +275,7 @@
                  {:id (meta/id :venues :price), :name "PRICE"}
                  {:id (meta/id :categories :id), :name "ID"}
                  {:id (meta/id :categories :name), :name "NAME"}]
-                (lib.order-by/orderable-columns query)))))))
+                (lib/orderable-columns query)))))))
 
 (defn- FIXME-is-empty
   "FIXME: Currently no way to add an `:is-empty` clause inline."
@@ -297,7 +296,7 @@
                  {:id (meta/id :venues :price), :name "PRICE"}
                  {:id (meta/id :categories :id), :name "ID"}
                  {:id (meta/id :categories :name), :name "NAME"}]
-                (lib.order-by/orderable-columns query)))))))
+                (lib/orderable-columns query)))))))
 
 (defn- FIXME-=
   "FIXME: [[metabase.lib.core]] doesn't have a test-friendly version of `:=` yet."
@@ -350,7 +349,7 @@
                   :field_ref    [:field
                                  {:lib/uuid string?, :base-type :type/Text, :join-alias "Cat"}
                                  (meta/id :categories :name)]}]
-                (lib.order-by/orderable-columns query)))))))
+                (lib/orderable-columns query)))))))
 
 (deftest ^:parallel orderable-columns-source-metadata-test
   (testing "orderable-columns should use metadata for source query."
@@ -374,7 +373,7 @@
                  {:name "PRICE"
                   :base_type :type/Integer
                   :field_ref [:field {:lib/uuid string?, :base-type :type/Integer} "PRICE"]}]
-                (lib.order-by/orderable-columns query)))))))
+                (lib/orderable-columns query)))))))
 
 (deftest ^:parallel orderable-columns-e2e-test
   (testing "Use the metadata returned by `orderable-columns` to add a new order-by to a query."
@@ -386,7 +385,7 @@
                            :lib/options  {:lib/uuid string?}}]}
               query))
       (testing (lib.util/format "Query =\n%s" (u/pprint-to-str query))
-        (let [orderable-columns (lib.order-by/orderable-columns query)
+        (let [orderable-columns (lib/orderable-columns query)
               col               (m/find-first #(= (:id %) (meta/id :venues :name)) orderable-columns)
               query'            (lib/order-by query col)]
           (is (=? {:lib/type :mbql/query

--- a/test/metabase/lib/order_by_test.cljc
+++ b/test/metabase/lib/order_by_test.cljc
@@ -126,15 +126,15 @@
 (deftest ^:parallel describe-order-by-expression-reference-test
     ;;   it("should work with expressions", () => {
   ;;     const query = {
-  ;;       "source-table": PRODUCTS.id
+  ;;       "source-table": PRODUCTS.id,
   ;;       expressions: {
-  ;;         Foo: ["concat", "Foo ", ["field", 4, null]]
-  ;;       }
-  ;;       "order-by": [["asc", ["expression", "Foo", null]]]
+  ;;         Foo: ["concat", "Foo ", ["field", 4, null]],
+  ;;       },
+  ;;       "order-by": [["asc", ["expression", "Foo", null]]],
   ;;     };
   ;;     expect(base_question._getOrderByDescription(PRODUCTS, query)).toEqual([
-  ;;       "Sorted by "
-  ;;       ["Foo ascending"]
+  ;;       "Sorted by ",
+  ;;       ["Foo ascending"],
   ;;     ]);
   ;;   });
   ;; });

--- a/test/metabase/lib/test_metadata.cljc
+++ b/test/metabase/lib/test_metadata.cljc
@@ -808,7 +808,7 @@
                :semantic_type  :type/PK
                :fingerprint    nil}
               {:lib/type       :metadata/field
-               :display_name   "NAME"
+               :display_name   "NAME" ; TODO -- these display names are icky
                :field_ref      [:field "NAME" {:base-type :type/Text}]
                :name           "NAME"
                :base_type      :type/Text


### PR DESCRIPTION
Implements #28691
Implements #29577

This PR adds a new function, `orderable-columns`, to return a list of Field metadatas for columns that can be ordered in a given stage of a query. I've added e2e tests to make sure you can use these results and add order bys with them. I tried to dogfood MLv2 as much as possible and avoid building queries by hand in the tests here

I'm not 100% sure this response format exactly matches how the frontend would like it, but we can adjust as needed as a follow on when we start wiring it up