### PR TITLE
Csv/basic uploader

### DIFF
--- a/frontend/src/metabase/collections/components/CollectionHeader/CollectionHeader.tsx
+++ b/frontend/src/metabase/collections/components/CollectionHeader/CollectionHeader.tsx
@@ -8,6 +8,7 @@ import CollectionCaption from "./CollectionCaption";
 import CollectionBookmark from "./CollectionBookmark";
 import CollectionMenu from "./CollectionMenu";
 import CollectionTimeline from "./CollectionTimeline";
+import CollectionUpload from "./CollectionUpload";
 
 import { HeaderActions, HeaderRoot } from "./CollectionHeader.styled";
 
@@ -32,6 +33,8 @@ const CollectionHeader = ({
   onCreateBookmark,
   onDeleteBookmark,
 }: CollectionHeaderProps): JSX.Element => {
+  const canUpload = true; // TODO: check settings for upload permissions
+
   return (
     <HeaderRoot>
       <CollectionCaption
@@ -46,6 +49,7 @@ const CollectionHeader = ({
           onCreateBookmark={onCreateBookmark}
           onDeleteBookmark={onDeleteBookmark}
         />
+        {canUpload && <CollectionUpload collection={collection} />}
         <CollectionMenu
           collection={collection}
           isAdmin={isAdmin}

--- a/frontend/src/metabase/collections/components/CollectionHeader/CollectionUpload.styled.tsx
+++ b/frontend/src/metabase/collections/components/CollectionHeader/CollectionUpload.styled.tsx
@@ -1,0 +1,15 @@
+import styled from "@emotion/styled";
+
+import { color } from "metabase/lib/colors";
+
+export const UploadInput = styled.input`
+  display: none;
+`;
+
+export const LoadingStateContainer = styled.div`
+  display: flex;
+  transform: translateY(10px);
+  align-items: center;
+  height: 16px;
+  color: ${color("brand")};
+`;

--- a/frontend/src/metabase/collections/components/CollectionHeader/CollectionUpload.tsx
+++ b/frontend/src/metabase/collections/components/CollectionHeader/CollectionUpload.tsx
@@ -1,0 +1,84 @@
+import React, { useState, useEffect } from "react";
+import { t } from "ttag";
+
+import type { Collection } from "metabase-types/api";
+import { color } from "metabase/lib/colors";
+import LoadingSpinner from "metabase/components/LoadingSpinner";
+
+import { CardApi } from "metabase/services";
+
+import { CollectionHeaderButton } from "./CollectionHeader.styled";
+import { UploadInput, LoadingStateContainer } from "./CollectionUpload.styled";
+
+const MAX_UPLOAD_SIZE = 200 * 1024 * 1024; // 200MB
+const CLEAR_ERROR_TIMEOUT = 3000;
+
+export default function ColllectionUpload({
+  collection,
+}: {
+  collection: Collection;
+}) {
+  const [isLoading, setIsLoading] = useState(false);
+  const [hasError, setHasError] = useState(false);
+
+  const handleFileUpload = async (
+    event: React.ChangeEvent<HTMLInputElement>,
+  ) => {
+    setIsLoading(true);
+
+    const file = event.target.files?.[0];
+
+    if (file) {
+      if (file.size > MAX_UPLOAD_SIZE) {
+        alert(t`File is too large. Please upload a file smaller than 200MB.`);
+        setIsLoading(false);
+        setHasError(true);
+        return;
+      }
+
+      const formData = new FormData();
+      formData.append("file", file);
+      formData.append("collection_id", String(collection.id));
+
+      await CardApi.uploadCSV(formData).catch(() => setHasError(true));
+
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    if (hasError) {
+      const timeout = setTimeout(() => setHasError(false), CLEAR_ERROR_TIMEOUT);
+      return () => clearTimeout(timeout);
+    }
+  }, [hasError]);
+
+  if (isLoading) {
+    return (
+      <LoadingStateContainer>
+        <LoadingSpinner size={16} />
+      </LoadingStateContainer>
+    );
+  }
+
+  const buttonIcon = hasError ? "close" : "arrow_up";
+  const buttonColor = hasError ? color("error") : undefined;
+
+  return (
+    <>
+      <label htmlFor="upload-csv">
+        <CollectionHeaderButton
+          as="span"
+          icon={buttonIcon}
+          color={buttonColor}
+        />
+      </label>
+      <UploadInput
+        id="upload-csv"
+        type="file"
+        accept="text/csv"
+        onChange={handleFileUpload}
+      />
+    </>
+  );
+}

--- a/frontend/src/metabase/collections/components/UploadOverlay/UploadOverlay.styled.tsx
+++ b/frontend/src/metabase/collections/components/UploadOverlay/UploadOverlay.styled.tsx
@@ -1,0 +1,21 @@
+import styled from "@emotion/styled";
+import { color, alpha } from "metabase/lib/colors";
+
+export const DragOverlay = styled.div<{ isDragActive: boolean }>`
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 1000;
+  background-color: ${alpha("white", 0.8)};
+  padding: 2rem;
+  font-size: 2rem;
+  color: ${color("text-dark")};
+  opacity: ${props => (props.isDragActive ? 1 : 0)};
+  transition: opacity 0.2s;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+`;

--- a/frontend/src/metabase/collections/components/UploadOverlay/UploadOverlay.tsx
+++ b/frontend/src/metabase/collections/components/UploadOverlay/UploadOverlay.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+import { t } from "ttag";
+
+import { DragOverlay } from "./UploadOverlay.styled";
+
+export default function UploadOverlay({
+  isDragActive,
+}: {
+  isDragActive: boolean;
+}) {
+  return (
+    <DragOverlay isDragActive={isDragActive}>
+      {t`Drop a CSV file to upload to this collection`}
+    </DragOverlay>
+  );
+}

--- a/frontend/src/metabase/collections/components/UploadOverlay/index.ts
+++ b/frontend/src/metabase/collections/components/UploadOverlay/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./UploadOverlay";

--- a/frontend/src/metabase/collections/containers/CollectionContent.jsx
+++ b/frontend/src/metabase/collections/containers/CollectionContent.jsx
@@ -2,6 +2,7 @@
 import React, { useEffect, useState, useCallback } from "react";
 import _ from "underscore";
 import { connect } from "react-redux";
+import { useDropzone } from "react-dropzone";
 
 import { usePrevious, useMount } from "react-use";
 import Bookmark from "metabase/entities/bookmarks";
@@ -19,6 +20,7 @@ import Header from "metabase/collections/containers/CollectionHeader";
 import ItemsTable from "metabase/collections/components/ItemsTable";
 import PinnedItemOverview from "metabase/collections/components/PinnedItemOverview";
 import { isPersonalCollectionChild } from "metabase/collections/utils";
+import { uploadCSV } from "metabase/collections/upload";
 
 import ItemsDragLayer from "metabase/containers/dnd/ItemsDragLayer";
 import PaginationControls from "metabase/components/PaginationControls";
@@ -26,6 +28,8 @@ import PaginationControls from "metabase/components/PaginationControls";
 import { usePagination } from "metabase/hooks/use-pagination";
 import { useListSelect } from "metabase/hooks/use-list-select";
 import { isSmallScreen } from "metabase/lib/dom";
+
+import UploadOverlay from "../components/UploadOverlay";
 import {
   CollectionEmptyContent,
   CollectionMain,
@@ -108,6 +112,21 @@ function CollectionContent({
     setIsBookmarked(shouldBeBookmarked);
   }, [bookmarks, collectionId]);
 
+  const onDrop = useCallback(
+    acceptedFiles => {
+      uploadCSV({ file: acceptedFiles[0], collectionId });
+    },
+    [collectionId],
+  );
+
+  const { getRootProps, isDragActive } = useDropzone({
+    onDrop,
+    maxFiles: 1,
+    noClick: true,
+    noDragEventsBubbling: true,
+    accept: { "text/csv": [".csv"] },
+  });
+
   const handleBulkArchive = useCallback(async () => {
     try {
       await Promise.all(selected.map(item => item.setArchived(true)));
@@ -166,6 +185,9 @@ function CollectionContent({
     deleteBookmark(collectionId, "collection");
   };
 
+  const canUpload = true; // TODO: check permissions
+  const rootProps = canUpload ? getRootProps() : {};
+
   const unpinnedQuery = {
     collection: collectionId,
     models: ALL_MODELS,
@@ -193,7 +215,8 @@ function CollectionContent({
         const hasPinnedItems = pinnedItems.length > 0;
 
         return (
-          <CollectionRoot>
+          <CollectionRoot {...rootProps}>
+            <UploadOverlay isDragActive={isDragActive} />
             <CollectionMain>
               <Header
                 collection={collection}

--- a/frontend/src/metabase/collections/containers/CollectionContent.styled.tsx
+++ b/frontend/src/metabase/collections/containers/CollectionContent.styled.tsx
@@ -2,6 +2,8 @@ import styled from "@emotion/styled";
 
 export const CollectionRoot = styled.div`
   padding-top: 1rem;
+  min-height: 100%;
+  position: relative;
 `;
 
 export const CollectionMain = styled.div`

--- a/frontend/src/metabase/collections/upload.ts
+++ b/frontend/src/metabase/collections/upload.ts
@@ -1,0 +1,39 @@
+import { t } from "ttag";
+import { CardApi } from "metabase/services";
+import type { CollectionId } from "metabase-types/api";
+
+const MAX_UPLOAD_SIZE = 200 * 1024 * 1024; // 200MB
+const MAX_UPLOAD_STRING = "200MB";
+
+export async function uploadCSV({
+  file,
+  collectionId,
+  onError,
+}: {
+  file?: File;
+  collectionId?: CollectionId;
+  onError?: (hasError: string) => void;
+}) {
+  if (!file) {
+    onError?.(t`You must select a file to upload.`);
+    return;
+  }
+
+  if (!collectionId) {
+    onError?.(t`You must select a collection to upload to.`);
+    return;
+  }
+
+  if (file.size > MAX_UPLOAD_SIZE) {
+    onError?.(t`You cannot upload files larger than ${MAX_UPLOAD_STRING}`);
+    return;
+  }
+
+  const formData = new FormData();
+  formData.append("file", file);
+  formData.append("collection_id", String(collectionId));
+
+  await CardApi.uploadCSV(formData).catch(() =>
+    onError?.(t`There was an error uploading your file.`),
+  );
+}

--- a/frontend/src/metabase/services.js
+++ b/frontend/src/metabase/services.js
@@ -89,6 +89,10 @@ export const CardApi = {
     ),
   ),
   create: POST("/api/card"),
+  uploadCSV: POST("/api/card/from-csv", {
+    formData: true,
+    fetch: true,
+  }),
   get: GET("/api/card/:cardId"),
   update: PUT("/api/card/:id"),
   delete: DELETE("/api/card/:id"),

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "react-dnd-html5-backend": "3",
     "react-dom": "~16.14.0",
     "react-draggable": "^3.3.2",
+    "react-dropzone": "^14.2.3",
     "react-element-to-jsx-string": "^13.1.0",
     "react-grid-layout": "^1.2.5",
     "react-is": "^17.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7598,6 +7598,11 @@ atob@^2.1.2:
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
 
+attr-accept@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/attr-accept/-/attr-accept-2.2.2.tgz#646613809660110749e92f2c10833b70968d929b"
+  integrity sha512-7prDjvt9HmqiZ0cl5CRjtS84sEyhsHP2coDkaZKRKVfCDo9s7iw7ChVmar78Gu9pC4SoR/28wFu/G5JJhTnqEg==
+
 autobind-decorator@^2.1.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/autobind-decorator/-/autobind-decorator-2.4.0.tgz#ea9e1c98708cf3b5b356f7cf9f10f265ff18239c"
@@ -11688,6 +11693,13 @@ file-loader@^6.2.0:
   dependencies:
     loader-utils "^2.0.0"
     schema-utils "^3.0.0"
+
+file-selector@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/file-selector/-/file-selector-0.6.0.tgz#fa0a8d9007b829504db4d07dd4de0310b65287dc"
+  integrity sha512-QlZ5yJC0VxHxQQsQhXvBaC7VRJ2uaxTf+Tfpu4Z/OcVQJVpZO+DGU0rkoVW5ce2SccxugvpBJoMvUs59iILYdw==
+  dependencies:
+    tslib "^2.4.0"
 
 file-system-cache@^1.0.5:
   version "1.0.5"
@@ -18085,6 +18097,15 @@ prop-types@15.x, prop-types@^15.0.0, prop-types@^15.5.10, prop-types@^15.5.4, pr
     object-assign "^4.1.1"
     react-is "^16.8.1"
 
+prop-types@^15.8.1:
+  version "15.8.1"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
+  integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
+  dependencies:
+    loose-envify "^1.4.0"
+    object-assign "^4.1.1"
+    react-is "^16.13.1"
+
 property-expr@^2.0.4:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/property-expr/-/property-expr-2.0.5.tgz#278bdb15308ae16af3e3b9640024524f4dc02cb4"
@@ -18480,6 +18501,15 @@ react-draggable@^4.0.0, react-draggable@^4.0.3:
     classnames "^2.2.5"
     prop-types "^15.6.0"
 
+react-dropzone@^14.2.3:
+  version "14.2.3"
+  resolved "https://registry.yarnpkg.com/react-dropzone/-/react-dropzone-14.2.3.tgz#0acab68308fda2d54d1273a1e626264e13d4e84b"
+  integrity sha512-O3om8I+PkFKbxCukfIR3QAGftYXDZfOE2N1mr/7qebQJHs7U+/RSL/9xomJNpRg9kM5h9soQSdf0Gc7OHF5Fug==
+  dependencies:
+    attr-accept "^2.2.2"
+    file-selector "^0.6.0"
+    prop-types "^15.8.1"
+
 react-element-to-jsx-string@^13.1.0:
   version "13.2.0"
   resolved "https://registry.yarnpkg.com/react-element-to-jsx-string/-/react-element-to-jsx-string-13.2.0.tgz#550bb9670e4d8c82977934c14db14469d156a70d"
@@ -18534,7 +18564,7 @@ react-is@17.0.2, react-is@^17.0.2:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
 
-react-is@^16.12.0, react-is@^16.13.0, react-is@^16.3.1, react-is@^16.7.0, react-is@^16.8.1:
+react-is@^16.12.0, react-is@^16.13.0, react-is@^16.13.1, react-is@^16.3.1, react-is@^16.7.0, react-is@^16.8.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
@@ -21225,6 +21255,11 @@ tslib@^2.0.3:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.2.0.tgz#fb2c475977e35e241311ede2693cee1ec6698f5c"
   integrity sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==
+
+tslib@^2.4.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.5.0.tgz#42bfed86f5787aeb41d031866c8f402429e0fddf"
+  integrity sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==
 
 tsutils@^3.21.0:
   version "3.21.0"


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/29563

### Description

Adds basic CSV upload and upload dropzone support to collections. We'll need to tweak most of the UI and status indicator/handling, but this should provide a good foundation for where to house the upload logic and give the backend something to test against.

### How to verify

Go to any collection and click the up arrow (need a better icon) or drag a file on top of the collection.

### Demo

![upload demo](https://user-images.githubusercontent.com/30528226/228084397-6facd112-e38a-4e30-9435-d90fa070a3c8.gif)

