### PR TITLE
Fix implicit actions not created in a deterministic order

### DIFF
--- a/e2e/test/scenarios/models/model-actions.cy.spec.js
+++ b/e2e/test/scenarios/models/model-actions.cy.spec.js
@@ -14,7 +14,11 @@ import {
   queryWritableDB,
 } from "e2e/support/helpers";
 
-import { SAMPLE_DB_ID, USER_GROUPS, WRITABLE_DB_ID } from "e2e/support/cypress_data";
+import {
+  SAMPLE_DB_ID,
+  USER_GROUPS,
+  WRITABLE_DB_ID,
+} from "e2e/support/cypress_data";
 
 import { createMockActionParameter } from "metabase-types/api/mocks";
 
@@ -109,9 +113,9 @@ describe(
 
       cy.findByRole("button", { name: /Create basic actions/i }).click();
       cy.findByLabelText("Action list").within(() => {
-        cy.findByText("Create").should("be.visible");
-        cy.findByText("Update").should("be.visible");
-        cy.findByText("Delete").should("be.visible");
+        cy.get("li").eq(0).findByText("Create").should("be.visible");
+        cy.get("li").eq(1).findByText("Update").should("be.visible");
+        cy.get("li").eq(2).findByText("Delete").should("be.visible");
       });
 
       cy.findByRole("link", { name: "New action" }).click();
@@ -295,9 +299,8 @@ describe(
   },
 );
 
-['postgres', 'mysql'].forEach((dialect) => {
+["postgres", "mysql"].forEach(dialect => {
   describe(`Write actions on model detail page (${dialect})`, () => {
-
     beforeEach(() => {
       cy.intercept("GET", "/api/card/*").as("getModel");
 
@@ -306,7 +309,10 @@ describe(
       cy.signInAsAdmin();
       resyncDatabase({ dbId: WRITABLE_DB_ID, tableName: WRITABLE_TEST_TABLE });
 
-      createModelFromTableName({ tableName: WRITABLE_TEST_TABLE, idAlias: "writableModelId" });
+      createModelFromTableName({
+        tableName: WRITABLE_TEST_TABLE,
+        idAlias: "writableModelId",
+      });
     });
 
     it("should allow action execution from the model detail page", () => {
@@ -379,9 +385,9 @@ describe(
         cy.visit(url);
         cy.findByLabelText(TEST_PARAMETER.name).type("1");
         cy.button(SAMPLE_QUERY_ACTION.name).click();
-        cy.findByText(`${SAMPLE_WRITABLE_QUERY_ACTION.name} ran successfully`).should(
-          "be.visible",
-        );
+        cy.findByText(
+          `${SAMPLE_WRITABLE_QUERY_ACTION.name} ran successfully`,
+        ).should("be.visible");
         cy.findByRole("form").should("not.exist");
         cy.button(SAMPLE_QUERY_ACTION.name).should("not.exist");
 
@@ -403,7 +409,6 @@ describe(
         cy.findByLabelText(/score/i).type("16");
         cy.findByLabelText(/team name/i).type("Bouncy Bears");
 
-
         cy.button(IMPLICIT_ACTION_NAME).click();
         cy.findByText(`${IMPLICIT_ACTION_NAME} ran successfully`).should(
           "be.visible",
@@ -420,7 +425,7 @@ describe(
           expect(row.score).to.equal(16);
           expect(row.team_name).to.equal("Bouncy Bears");
           // should not mutate form fields that we don't touch
-          expect(row.status).to.not.be.a('null');
+          expect(row.status).to.not.be.a("null");
         });
       });
 

--- a/frontend/src/metabase/entities/actions/actions.ts
+++ b/frontend/src/metabase/entities/actions/actions.ts
@@ -57,42 +57,32 @@ const defaultImplicitActionCreateOptions = {
 const enableImplicitActionsForModel =
   async (modelId: number, options = defaultImplicitActionCreateOptions) =>
   async (dispatch: Dispatch) => {
-    const requests = [];
-
     if (options.insert) {
-      requests.push(
-        ActionsApi.create({
-          name: t`Create`,
-          type: "implicit",
-          kind: "row/create",
-          model_id: modelId,
-        }),
-      );
+      await ActionsApi.create({
+        name: t`Create`,
+        type: "implicit",
+        kind: "row/create",
+        model_id: modelId,
+      });
     }
 
     if (options.update) {
-      requests.push(
-        ActionsApi.create({
-          name: t`Update`,
-          type: "implicit",
-          kind: "row/update",
-          model_id: modelId,
-        }),
-      );
+      await ActionsApi.create({
+        name: t`Update`,
+        type: "implicit",
+        kind: "row/update",
+        model_id: modelId,
+      });
     }
 
     if (options.delete) {
-      requests.push(
-        ActionsApi.create({
-          name: t`Delete`,
-          type: "implicit",
-          kind: "row/delete",
-          model_id: modelId,
-        }),
-      );
+      await ActionsApi.create({
+        name: t`Delete`,
+        type: "implicit",
+        kind: "row/delete",
+        model_id: modelId,
+      });
     }
-
-    await Promise.all(requests);
 
     dispatch(Actions.actions.invalidateLists());
   };

--- a/package.json
+++ b/package.json
@@ -349,6 +349,10 @@
       "prettier --write",
       "node ./bin/verify-doc-links"
     ],
+    "e2e/**/*.{js,jsx,ts,jsx}": [
+      "eslint --rulesdir frontend/lint/eslint-rules --max-warnings 0",
+      "prettier --write"
+    ],
     "e2e/test/scenarios/*/{*.js,!(helpers|shared)/*.js}": [
       "eslint --rulesdir frontend/lint/eslint-rules --max-warnings 0",
       "node e2e/validate-e2e-test-files.js"


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/29593

### Description

Using the solution described in #29593 i.e. waiting for each API call to create CREATE, UPDATE, DELETE actions before creating the next action.

### How to verify

E2E tests in `e2e/test/scenarios/models/model-actions.cy.spec.js` pass.

### Demo
#### [Before the fix (see screenshots in the original issue)](https://github.com/metabase/metabase/issues/29593#issue-1643525094) 

#### After the fix
<img width="1098" alt="image" src="https://user-images.githubusercontent.com/1937582/228282817-c6f0caf3-9abc-4ca2-9ccb-d114caed274e.png">

_Upload a demo video or before/after screenshots if sensible or remove the section_
### Checklist

- [X] Tests have been added/updated to cover changes in this PR

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/29605)
<!-- Reviewable:end -->
