### PR TITLE
docs - remove specific version option from migrate down command

### DIFF
--- a/docs/installation-and-operation/upgrading-metabase.md
+++ b/docs/installation-and-operation/upgrading-metabase.md
@@ -139,10 +139,4 @@ If you're running Docker, the command would be:
 docker run --rm metabase/metabase migrate down
 ```
 
-The default is to migrate down by one major version, but you can also specify a major version (as an integer) to downgrade to:
-
-```
-java -jar metabase.jar migrate down 44
-```
-
 Once the migration process completes, start up Metabase using the JAR or Docker image for the version you want to run.


### PR DESCRIPTION
Like it says on the label.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/29616)
<!-- Reviewable:end -->
