### PR TITLE
Explore the option to pre-populate forms in E2E tests

### DIFF
--- a/e2e/test/scenarios/admin/databases/add.cy.spec.js
+++ b/e2e/test/scenarios/admin/databases/add.cy.spec.js
@@ -21,8 +21,13 @@ describe("scenarios > admin > databases > add", () => {
     cy.findByText("Need help connecting?");
 
     chooseDatabase("H2");
-    typeAndBlurUsingLabel("Display name", "Test");
-    typeAndBlurUsingLabel("Connection String", "invalid");
+    // Using the Cypress application actions
+    cy.window().its("formikProps").invoke("setFieldValue", "name", "Test");
+    cy.window()
+      .its("formikProps")
+      .invoke("setFieldValue", "details.db", "invalid");
+    // typeAndBlurUsingLabel("Display name", "Test");
+    // typeAndBlurUsingLabel("Connection String", "invalid");
 
     cy.button("Save").click();
     cy.wait("@createDatabase");

--- a/frontend/src/metabase/core/components/FormProvider/FormProvider.tsx
+++ b/frontend/src/metabase/core/components/FormProvider/FormProvider.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Formik } from "formik";
+import { Formik, useFormikContext } from "formik";
 import type { FormikConfig, FormikValues } from "formik";
 import type { AnySchema } from "yup";
 import useFormSubmit from "metabase/core/hooks/use-form-submit";
@@ -16,6 +16,7 @@ function FormProvider<T extends FormikValues, C = unknown>({
   validationSchema,
   validationContext,
   onSubmit,
+  children,
   ...props
 }: FormProviderProps<T, C>): JSX.Element {
   const { state, handleSubmit } = useFormSubmit({ onSubmit });
@@ -33,9 +34,20 @@ function FormProvider<T extends FormikValues, C = unknown>({
         validate={handleValidate}
         onSubmit={handleSubmit}
         {...props}
-      />
+      >
+        <>
+          {window.Cypress && <CypressFormikHelper />}
+          {children}
+        </>
+      </Formik>
     </FormContext.Provider>
   );
+}
+
+function CypressFormikHelper() {
+  const formikProps = useFormikContext();
+  window.formikProps = formikProps;
+  return null;
 }
 
 export default FormProvider;


### PR DESCRIPTION
> **Warning**
> This should be in draft until I can figure out how to deal with TypeScript types.

Closes https://github.com/metabase/metabase/issues/29428

### Description

Adding a way to fill form programmatically, so we can speed up Cypress test when using Formik forms

### How to verify

All tests are ✅

### Demo
You can see that now Cypress can fill our forms programmatically (by calling `.setFieldValue()`) 🤖 
<img width="1334" alt="Screenshot 2023-03-28 at 7 43 09 PM" src="https://user-images.githubusercontent.com/1937582/228337300-2eb01f89-55bf-43a1-9ccb-0f31e73706c0.png">


### Checklist

- [ ] Tests have been added/updated to cover changes in this PR

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/29617)
<!-- Reviewable:end -->
