### PR TITLE
Expand aggregation function options for all supported fields

### DIFF
--- a/frontend/src/metabase-lib/metadata/Table.ts
+++ b/frontend/src/metabase-lib/metadata/Table.ts
@@ -108,7 +108,7 @@ class TableInner extends Base {
 
   // AGGREGATIONS
   aggregationOperators() {
-    return getAggregationOperators(this, this.fields);
+    return getAggregationOperators(this.db, this.fields);
   }
 
   aggregationOperatorsLookup() {

--- a/frontend/src/metabase-lib/operators/utils/index.js
+++ b/frontend/src/metabase-lib/operators/utils/index.js
@@ -82,14 +82,12 @@ export function getFilterOperators(field, table, selected) {
     });
 }
 
-export function getSupportedAggregationOperators(table) {
+export function getSupportedAggregationOperators(database) {
   return AGGREGATION_OPERATORS.filter(operator => {
     if (!operator.requiredDriverFeature) {
       return true;
     }
-    return (
-      table.db && table.db.features.includes(operator.requiredDriverFeature)
-    );
+    return database?.features.includes(operator.requiredDriverFeature);
   });
 }
 
@@ -102,8 +100,8 @@ function populateFields(aggregationOperator, fields) {
   };
 }
 
-export function getAggregationOperators(table, fields) {
-  return getSupportedAggregationOperators(table)
+export function getAggregationOperators(database, fields) {
+  return getSupportedAggregationOperators(database)
     .map(operator => populateFields(operator, fields))
     .filter(
       aggregation =>

--- a/frontend/src/metabase-lib/operators/utils/index.unit.spec.js
+++ b/frontend/src/metabase-lib/operators/utils/index.unit.spec.js
@@ -141,23 +141,21 @@ describe("metabase-lib/operators/utils", () => {
   });
 
   describe("getSupportedAggregationOperators", () => {
-    function getTable(features) {
+    function getDatabase(features) {
       return {
-        db: {
-          features,
-        },
+        features,
       };
     }
 
     it("returns nothing without DB features", () => {
-      const table = getTable([]);
-      const operators = getSupportedAggregationOperators(table);
+      const db = getDatabase([]);
+      const operators = getSupportedAggregationOperators(db);
       expect(operators).toHaveLength(0);
     });
 
     it("returns correct basic aggregation operators", () => {
-      const table = getTable(["basic-aggregations"]);
-      const operators = getSupportedAggregationOperators(table);
+      const db = getDatabase(["basic-aggregations"]);
+      const operators = getSupportedAggregationOperators(db);
       expect(operators.map(o => o.short)).toEqual([
         "rows",
         "count",
@@ -172,8 +170,8 @@ describe("metabase-lib/operators/utils", () => {
     });
 
     it("filters out operators not supported by database", () => {
-      const table = getTable(["standard-deviation-aggregations"]);
-      const operators = getSupportedAggregationOperators(table);
+      const db = getDatabase(["standard-deviation-aggregations"]);
+      const operators = getSupportedAggregationOperators(db);
       expect(operators).toEqual([
         expect.objectContaining({
           short: "stddev",
@@ -183,8 +181,8 @@ describe("metabase-lib/operators/utils", () => {
     });
 
     it('returns "median" aggregation operator if "percentile-aggregations" driver feature is supported', () => {
-      const table = getTable(["percentile-aggregations"]);
-      const operators = getSupportedAggregationOperators(table);
+      const db = getDatabase(["percentile-aggregations"]);
+      const operators = getSupportedAggregationOperators(db);
       expect(operators).toEqual([
         expect.objectContaining({
           short: "median",
@@ -196,13 +194,10 @@ describe("metabase-lib/operators/utils", () => {
 
   describe("getAggregationOperators", () => {
     function setup({ fields = [] } = {}) {
-      const table = {
-        fields,
-        db: {
-          features: ["basic-aggregations", "standard-deviation-aggregations"],
-        },
+      const database = {
+        features: ["basic-aggregations", "standard-deviation-aggregations"],
       };
-      const fullOperators = getAggregationOperators(table, fields);
+      const fullOperators = getAggregationOperators(database, fields);
       return {
         fullOperators,
         operators: fullOperators.map(operator => operator.short),

--- a/frontend/src/metabase-lib/operators/utils/index.unit.spec.js
+++ b/frontend/src/metabase-lib/operators/utils/index.unit.spec.js
@@ -148,14 +148,14 @@ describe("metabase-lib/operators/utils", () => {
     }
 
     it("returns nothing without DB features", () => {
-      const db = getDatabase([]);
-      const operators = getSupportedAggregationOperators(db);
+      const database = getDatabase([]);
+      const operators = getSupportedAggregationOperators(database);
       expect(operators).toHaveLength(0);
     });
 
     it("returns correct basic aggregation operators", () => {
-      const db = getDatabase(["basic-aggregations"]);
-      const operators = getSupportedAggregationOperators(db);
+      const database = getDatabase(["basic-aggregations"]);
+      const operators = getSupportedAggregationOperators(database);
       expect(operators.map(o => o.short)).toEqual([
         "rows",
         "count",
@@ -170,8 +170,8 @@ describe("metabase-lib/operators/utils", () => {
     });
 
     it("filters out operators not supported by database", () => {
-      const db = getDatabase(["standard-deviation-aggregations"]);
-      const operators = getSupportedAggregationOperators(db);
+      const database = getDatabase(["standard-deviation-aggregations"]);
+      const operators = getSupportedAggregationOperators(database);
       expect(operators).toEqual([
         expect.objectContaining({
           short: "stddev",
@@ -181,8 +181,8 @@ describe("metabase-lib/operators/utils", () => {
     });
 
     it('returns "median" aggregation operator if "percentile-aggregations" driver feature is supported', () => {
-      const db = getDatabase(["percentile-aggregations"]);
-      const operators = getSupportedAggregationOperators(db);
+      const database = getDatabase(["percentile-aggregations"]);
+      const operators = getSupportedAggregationOperators(database);
       expect(operators).toEqual([
         expect.objectContaining({
           short: "median",

--- a/frontend/src/metabase-lib/queries/StructuredQuery.ts
+++ b/frontend/src/metabase-lib/queries/StructuredQuery.ts
@@ -648,19 +648,18 @@ class StructuredQueryInner extends AtomicQuery {
    * @returns an array of aggregation options for the currently selected table
    */
   aggregationOperators(): AggregationOperator[] {
-    const expressionFields = this.expressionDimensions().map(
-      expressionDimension => expressionDimension.field(),
-    );
-
     const table = this.table();
-    return (
-      (table &&
-        getAggregationOperators(table, [
-          ...expressionFields,
-          ...table.fields,
-        ])) ||
-      []
-    );
+
+    if (table) {
+      const fieldOptions = this.fieldOptions()
+        .all()
+        .map(dimension => dimension.field?.())
+        .filter(field => field != null);
+
+      return getAggregationOperators(table.db, fieldOptions);
+    }
+
+    return [];
   }
 
   aggregationOperatorsLookup(): Record<string, AggregationOperator> {

--- a/frontend/src/metabase-lib/queries/StructuredQuery.ts
+++ b/frontend/src/metabase-lib/queries/StructuredQuery.ts
@@ -653,7 +653,7 @@ class StructuredQueryInner extends AtomicQuery {
     if (table) {
       const fieldOptions = this.fieldOptions()
         .all()
-        .map(dimension => dimension.field?.())
+        .map(dimension => dimension.field())
         .filter(field => field != null);
 
       return getAggregationOperators(table.db, fieldOptions);

--- a/frontend/src/metabase-types/api/query.ts
+++ b/frontend/src/metabase-types/api/query.ts
@@ -1,10 +1,12 @@
-import type { TemplateTags } from "../types/Query";
+import type { AggregationClause, TemplateTags } from "../types/Query";
 import type { DatabaseId } from "./database";
 import type { FieldId } from "./field";
 import type { TableId } from "./table";
 
 export interface StructuredQuery {
   "source-table"?: TableId;
+
+  aggregation?: AggregationClause;
 }
 
 export interface NativeQuery {


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/12248

### Description

It is not possible to add an aggregation for fields from implicitly joined tables.

### How to verify

Use case 1 - https://github.com/metabase/metabase/issues/12248#issuecomment-730270741

Use case 2 -

1. Use the same setup as in use case 1 in the admin site.
2. Start new Question -> Reviews
3. Add explicit join with Products
4. Try to add an aggregation based on `Products.Price`

### Demo


https://user-images.githubusercontent.com/7983744/228362964-5ee95e18-cacd-464f-80a3-c066aa74b22a.mov


### Checklist

- [x] Tests have been added/updated to cover changes in this PR

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/29623)
<!-- Reviewable:end -->
