### PR TITLE
Create `cache_info` table in our persisted schemas

### DIFF
--- a/src/metabase/driver/ddl/interface.clj
+++ b/src/metabase/driver/ddl/interface.clj
@@ -2,7 +2,15 @@
   (:require
    [clojure.string :as str]
    [metabase.driver :as driver]
-   [metabase.util.i18n :refer [tru]]))
+   [metabase.public-settings :as public-settings]
+   [metabase.util.i18n :refer [tru]])
+  (:import
+   (java.time LocalDate)
+   (java.time.format DateTimeFormatter)))
+
+(set! *warn-on-reflection* true)
+
+
 
 (defn schema-name
   "Returns a schema name for persisting models. Needs the database to use the db id and the site-uuid to ensure that
@@ -40,6 +48,31 @@
   {:arglists '([database])}
   (fn [database] (driver/dispatch-on-initialized-driver (:engine database)))
   :hierarchy #'driver/hierarchy)
+
+(defn create-kv-table-honey-sql-form
+  "The honeysql form that creates the persisted schema `cache_info` table."
+  [schema-name]
+  {:create-table [(keyword schema-name "cache_info") :if-not-exists]
+   :with-columns [[:key :text] [:value :text]]})
+
+(defn kv-table-values
+  "Version 1 of the values to go in the key/value table `cache_info` table."
+  []
+  [{:key   "settings-version"
+    :value "1"}
+   {:key   "created-at"
+    ;; "2023-03-28"
+    :value (.format (LocalDate/now) DateTimeFormatter/ISO_LOCAL_DATE)}
+   {:key   "instance-uuid"
+    :value (public-settings/site-uuid)}
+   {:key   "instance-name"
+    :value (public-settings/site-name)}])
+
+(defn populate-kv-table-honey-sql-form
+  "The honeysql form that populates the persisted schema `cache_info` table."
+  [schema-name]
+  {:insert-into [(keyword schema-name "cache_info")]
+   :values (kv-table-values)})
 
 (defn error->message
   "Human readable messages for different connection errors."

--- a/src/metabase/driver/ddl/interface.clj
+++ b/src/metabase/driver/ddl/interface.clj
@@ -5,7 +5,7 @@
    [metabase.public-settings :as public-settings]
    [metabase.util.i18n :refer [tru]])
   (:import
-   (java.time LocalDate)
+   (java.time Instant)
    (java.time.format DateTimeFormatter)))
 
 (set! *warn-on-reflection* true)
@@ -61,8 +61,8 @@
   [{:key   "settings-version"
     :value "1"}
    {:key   "created-at"
-    ;; "2023-03-28"
-    :value (.format (LocalDate/now) DateTimeFormatter/ISO_LOCAL_DATE)}
+    ;; "2023-03-29T14:01:27.871697Z"
+    :value (.format DateTimeFormatter/ISO_INSTANT (Instant/now))}
    {:key   "instance-uuid"
     :value (public-settings/site-uuid)}
    {:key   "instance-name"

--- a/src/metabase/driver/postgres/ddl.clj
+++ b/src/metabase/driver/postgres/ddl.clj
@@ -69,17 +69,30 @@
                      [:persist.check/create-table
                       (fn create-table [conn]
                         (sql.ddl/execute! conn [(sql.ddl/create-table-sql database
-                                                          {:table-name table-name
-                                                           :field-definitions [{:field-name "field"
-                                                                                :base-type :type/Text}]}
-                                                          "select 1")]))]
+                                                                          {:table-name table-name
+                                                                           :field-definitions [{:field-name "field"
+                                                                                                :base-type :type/Text}]}
+                                                                          "select 1")]))]
                      [:persist.check/read-table
                       (fn read-table [conn]
                         (sql.ddl/jdbc-query conn [(format "select * from %s.%s"
-                                                   schema-name table-name)]))]
+                                                          schema-name table-name)]))]
                      [:persist.check/delete-table
                       (fn delete-table [conn]
-                        (sql.ddl/execute! conn [(sql.ddl/drop-table-sql database table-name)]))]]]
+                        (sql.ddl/execute! conn [(sql.ddl/drop-table-sql database table-name)]))]
+                     [:persist.check/create-kv-table
+                      (fn create-kv-table [conn]
+                        (sql.ddl/execute! conn [(format "drop table if exists %s.cache_info"
+                                                        schema-name)])
+                        (sql.ddl/execute! conn (sql/format
+                                                (ddl.i/create-kv-table-honey-sql-form schema-name)
+                                                {:dialect :ansi})))]
+                     [:persist.check/populate-kv-table
+                      (fn create-kv-table [conn]
+                        (sql.ddl/execute! conn (sql/format
+                                                (ddl.i/populate-kv-table-honey-sql-form
+                                                 schema-name)
+                                                {:dialect :ansi})))]]]
     (jdbc/with-db-connection [conn (sql-jdbc.conn/db->pooled-connection-spec database)]
       (jdbc/with-db-transaction
         [tx conn]

--- a/test/metabase/query_processor/persistence_test.clj
+++ b/test/metabase/query_processor/persistence_test.clj
@@ -14,7 +14,12 @@
    [metabase.query-processor.middleware.fix-bad-references
     :as fix-bad-refs]
    [metabase.test :as mt]
-   [toucan2.core :as t2]))
+   [toucan2.core :as t2])
+  (:import
+   (java.time Instant)
+   (java.time.temporal ChronoUnit)))
+
+(set! *warn-on-reflection* true)
 
 (deftest can-persist-test
   (testing "Can each database that allows for persistence actually persist"
@@ -26,15 +31,26 @@
             (is (= :persist.check/valid error)))
           (testing "Populates the `cache_info` table with v1 information"
             (let [schema-name (ddl.i/schema-name (mt/db) (public-settings/site-uuid))
-                  query {:query
-                         (first
-                          (sql/format {:select [:key :value]
-                                       :from [(keyword schema-name "cache_info")]}
-                                      {:dialect (if (= (:engine (mt/db)) :mysql)
-                                                  :mysql
-                                                  :ansi)}))}]
-              (is (= (into {} (map (juxt :key :value)) (ddl.i/kv-table-values))
-                     (into {} (->> query mt/native-query qp/process-query mt/rows)))))))))))
+                  query       {:query
+                               (first
+                                (sql/format {:select [:key :value]
+                                             :from   [(keyword schema-name "cache_info")]}
+                                            {:dialect (if (= (:engine (mt/db)) :mysql)
+                                                        :mysql
+                                                        :ansi)}))}
+                  values      (into {} (->> query mt/native-query qp/process-query mt/rows))]
+              (is (partial= {"settings-version" "1"
+                             "instance-uuid"    (public-settings/site-uuid)}
+                            (into {} (->> query mt/native-query qp/process-query mt/rows))))
+              (let [[low high]       [(.minus (Instant/now) 1 ChronoUnit/MINUTES)
+                                      (.plus (Instant/now) 1 ChronoUnit/MINUTES)]
+                    ^Instant created (some-> (get values "created-at")
+                                             (java.time.Instant/parse))]
+                (if created
+                  (is (and (.isAfter created low) (.isBefore created high))
+                      "Date was not created recently")
+                  (throw (ex-info "Did not find `created-at` in `cache_info` table"
+                                  {})))))))))))
 
 (deftest persisted-models-max-rows-test
   (testing "Persisted models should have the full number of rows of the underlying query,


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/29620

Half of the fix for running out of tables in redshift. The other half is some recurring job to use this information to drop schemas.

The other half is https://github.com/metabase/persistence-schema-garbage-collector

In order to know _which_ schemas are old enough to be deleted in redshift in CI, we need a timestamp. This adds a `cache_info` table in the schema used for persistence.

```sql
-- postgres/redshift
test-data=# select * from metabase_cache_424a9_379.cache_info ;
       key        |                value
------------------+--------------------------------------
 settings-version | 1
 created-at       | 2023-03-29T14:16:24.849866Z
 instance-uuid    | 407e4ba8-2bab-470f-aeb5-9fc63fd18c4e
 instance-name    | Metabase Test
(4 rows)
```

```sql
--mysql
mysql> select * from metabase_cache_424a9_435.cache_info;
+------------------+--------------------------------------+
| key              | value                                |
+------------------+--------------------------------------+
| settings-version | 1                                    |
| created-at       | 2023-03-29T14:16:26.928141Z          |
| instance-uuid    | 407e4ba8-2bab-470f-aeb5-9fc63fd18c4e |
| instance-name    | Metabase Test                        |
+------------------+--------------------------------------+
4 rows in set (0.00 sec)
```

our key values in v1:
```clojure
(defn kv-table-values
  "Version 1 of the values to go in the key/value table `cache_info` table."
  []
  [{:key   "settings-version"
    :value "1"}
   {:key   "created-at"
    ;; "2023-03-29T14:01:27.871697Z"
    :value (.format DateTimeFormatter/ISO_INSTANT (Instant/now))}
   {:key   "instance-uuid"
    :value (public-settings/site-uuid)}
   {:key   "instance-name"
    :value (public-settings/site-name)}])
```

This will enable us to delete cached schemas in shared databases (cloud versions like redshift) without risking wiping out a cached schema during an active test run.

The code to delete the schemas will be something like,

```clojure
(def spec (sql-jdbc.conn/connection-details->spec
           :redshift
           {:host "xxx.us-east-1.reshift.amazonaws.com"
            :db "db"
            :port 5439
            :user "user"
            :password "password"}))

(let [days-prior 1 ;; probably 2 to handle crossing day time. Can also adjust to 6 hours, etc
      threshold (.minus (java.time.LocalDate/now)
                        days-prior
                        java.time.temporal.ChronoUnit/DAYS)]
  (doseq [schema (->> ["select nspname from pg_namespace where nspname like 'metabase_cache%'"]
                      (jdbc/query spec)
                      (map :nspname))]
    (let [[{created :value}] (jdbc/query spec (sql/format {:select [:value]
                                                           :from [(keyword schema "cache_info")]
                                                           :where [:= :key "created-at"]}
                                                          {:dialect :ansi}))]
      (when created
        (let [creation-day (java.time.LocalDate/parse created)]
          (when (.isBefore creation-day threshold)
            (jdbc/execute! spec [(format "drop schema %s cascade" schema)])))))))
```

or if we want to do it in a single query:

```clojure
schemas=> (let [threshold     (.minus (java.time.Instant/now)
                                      2
                                      ;; two seconds is probably a little aggressive in the lambda
                                      java.time.temporal.ChronoUnit/SECONDS)
                cache-schemas (->> ["select nspname
                                 from pg_namespace
                                 where nspname like 'metabase_cache%'"]
                                   (jdbc/query spec)
                                   (map :nspname))]
            (jdbc/with-db-connection [conn spec]
              (jdbc/execute! conn [(format "set search_path= %s" (str/join ", " cache-schemas))])
              (let [schemas           (->> ["select distinct schemaname, tablename
                                   from pg_table_def
                                   where schemaname like 'metabase_cache%'
                                   and tablename = 'cache_info'"]
                                           (jdbc/query conn)
                                           (map :schemaname))
                    sql               (sql/format {:select [:schema :created-at]
                                                   :from   {:union-all
                                                            (for [schema schemas]
                                                              {:select [[[:inline schema] :schema]
                                                                        [{:select [:value]
                                                                          :from   [(keyword schema "cache_info")]
                                                                          :where  [:= :key [:inline "created-at"]]}
                                                                         :created-at]]})}}
                                                  {:dialect :ansi})
                    old?              (fn [{create-str :created-at}]
                                        (let [created (java.time.Instant/parse create-str)]
                                          (.isBefore created threshold)))
                    schemas-to-delete (->> (jdbc/query spec sql)
                                           (filter old?)
                                           (map :schema))]
                {:expired-schemas schemas-to-delete
                 :schemas-without-cache-info-table (set/difference (set cache-schemas) (set schemas))})))
{:expired-schemas ("metabase_cache_424a9_503"),
 :schemas-without-cache-info-table #{"metabase_cache_ec4b0_1"
                                     "metabase_cache_b34ad_63"
                                     "metabase_cache_3149f_63"
                                     "metabase_cache_78497_63"
                                     "metabase_cache_e74a8_145"
                                     "metabase_cache_f6495_14"
                                     "metabase_cache_984b5_63"
                                     "metabase_cache_754b4_63"
                                     "metabase_cache_424a9_357"
                                     "metabase_cache_7a4ab_63"
                                     "metabase_cache_52480_2"
                                     "metabase_cache_df490_63"}} ;; when there are any, string join them and delete them as above
```

As we transition to having a cache table, still need to watch out for old branches running that don't populate the cache table, hot fixes on older branches, etc. In the future we could just assume we can wipe those out once this has been out in the wild for a bit. 

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/29632)
<!-- Reviewable:end -->
