### PR TITLE
Add CSV uploads feature and have postgres and H2 support it

### DIFF
--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -490,6 +490,9 @@
     ;; Does the driver support experimental "writeback" actions like "delete this row" or "insert a new row" from 44+?
     :actions
 
+    ;; Does the driver support CSV uploads
+    :csv-uploads
+
     ;; Does the driver support custom writeback actions. Drivers that support this must
     ;; implement [[execute-write-query!]]
     :actions/custom

--- a/src/metabase/driver/h2.clj
+++ b/src/metabase/driver/h2.clj
@@ -49,6 +49,7 @@
                               :actions/custom            true
                               :datetime-diff             true
                               :now                       true
+                              :csv-uploads               true
                               :test/jvm-timezone-setting false}]
   (defmethod driver/database-supports? [:h2 feature]
     [_driver _feature _database]

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -56,6 +56,10 @@
 ;;; |                                             metabase.driver impls                                              |
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
+(defmethod driver/database-supports? [:postgres :csv-uploads]
+  [_driver _feat _db]
+  true)
+
 (defmethod driver/display-name :postgres [_] "PostgreSQL")
 
 (defmethod driver/database-supports? [:postgres :datetime-diff]


### PR DESCRIPTION
I created a `csv-uploads` feature and made Postgres and H2 support it. We can change the drivers that support it later, but I figured postgres and H2 support would be a good start - H2 can make some tests easier to write, and Postgres because we probably wouldn't want to release the feature with just H2, and postgres is the most used driver.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/29636)
<!-- Reviewable:end -->
