### PR TITLE
CSV: schema detection

### DIFF
--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -12,6 +12,7 @@
    [metabase.api.dataset :as api.dataset]
    [metabase.api.field :as api.field]
    [metabase.api.timeline :as api.timeline]
+   [metabase.csv :as csv]
    [metabase.driver :as driver]
    [metabase.email.messages :as messages]
    [metabase.events :as events]
@@ -970,5 +971,11 @@ saved later when it is ready."
    param-key ms/NonBlankString
    query     ms/NonBlankString}
   (param-values (api/read-check Card card-id) param-key query))
+
+(api/defendpoint ^:multipart POST "/from-csv"
+  "Create a table and model populated with the values from the attached CSV."
+  [:as {raw-params :params}]
+  (let [f (:tempfile (get raw-params "file"))]
+    {:status 200 :body (csv/detect-schema f)}))
 
 (api/define-routes)

--- a/src/metabase/csv.clj
+++ b/src/metabase/csv.clj
@@ -2,7 +2,6 @@
   (:require
    [clojure.data.csv :as csv]
    [clojure.java.io :as io]
-   [clojure.set :as set]
    [clojure.string :as str]
    [medley.core :as m]
    [metabase.search.util :as search-util]
@@ -63,11 +62,7 @@
     (nil? type-b)        type-a
     (isa? type-a type-b) type-b
     (isa? type-b type-a) type-a
-    :else
-    (let [common-ancestors (set/intersection (ancestors type-a) (ancestors type-b))]
-      (if (seq common-ancestors)
-        (first common-ancestors)
-        (throw (Exception. (trs "Unexpected type combination in the same column: {0} and {1}" type-a type-b)))))))
+    :else (throw (Exception. (trs "Unexpected type combination in the same column: {0} and {1}" type-a type-b)))))
 
 (defn- coalesce-types
   [types-so-far new-types]

--- a/src/metabase/csv.clj
+++ b/src/metabase/csv.clj
@@ -29,7 +29,7 @@
 
 (defn value->type
   "The most-specific possible type for a given value. Possibilities are:
-    - ::bolean
+    - ::boolean
     - ::int
     - ::float
     - ::varchar_255

--- a/src/metabase/csv.clj
+++ b/src/metabase/csv.clj
@@ -1,0 +1,78 @@
+(ns metabase.csv
+  (:require
+   [clojure.data.csv :as csv]
+   [clojure.java.io :as io]
+   [metabase.util :as u]
+   [metabase.util.i18n :refer [trs]]))
+
+(derive ::boolean     ::int)
+(derive ::boolean     ::varchar_255)
+(derive ::boolean     ::text)
+(derive ::int         ::float)
+(derive ::int         ::text)
+(derive ::int         ::varchar_255)
+(derive ::int         ::text)
+(derive ::float       ::varchar_255)
+(derive ::float       ::text)
+(derive ::varchar_255 ::text)
+
+(defn value->type
+  "The most-specific possible type for a given value. Possibilities are:
+    - ::bolean
+    - ::int
+    - ::float
+    - ::varchar_255
+    - ::text
+
+  NB: There are currently the following gotchas:
+    1. ints/floats are assumed to have commas as separators and periods as decimal points
+    2. 0 and 1 are assumed to be booleans, not ints."
+  [value]
+  (cond
+    (re-matches #"(?i)true|t|yes|y|1|false|f|no|n|0" value) ::boolean
+    (re-matches #"[\d,]+"                            value) ::int
+    (re-matches #"[\d,]*\.\d+"                       value) ::float
+    (re-matches #".{1,255}"                          value) ::varchar_255
+    :else                                                   ::text))
+
+(defn- row->types
+  [column-names row]
+  (->> row
+       (map vector column-names)
+       (map (fn [[column-name value]] [column-name (value->type value)]))
+       (into {})))
+
+(defn coalesce
+  "Returns the 'parent' type (the most general)."
+  [type-a type-b]
+  (cond
+    (isa? type-a type-b) type-b
+    (isa? type-b type-a) type-a
+    :else (throw (Exception. (trs "Unexpected type combination in the same column: {0} and {1}" type-a type-b)))))
+
+(defn- coalesce-types
+  [types-so-far new-types]
+  (->> types-so-far
+       (map (fn [[column-name old-type]]
+              [column-name (coalesce old-type (get new-types column-name))]))
+       (into {})))
+
+(defn- rows->schema
+  [header rows]
+  (let [normalized-header (map u/slugify header)]
+    (->> rows
+         (map (partial row->types normalized-header))
+         (reduce coalesce-types))))
+
+(defn detect-schema
+  "Returns a map of `normalized-column-name -> type` for the given CSV file. The CSV file *must* have headers as the
+  first row. Supported types are:
+    - ::int
+    - ::float
+    - ::boolean
+    - ::varchar_255
+    - ::text"
+  [csv-file]
+  (with-open [reader (io/reader csv-file)]
+    (let [[header & rows] (csv/read-csv reader)]
+      (rows->schema header rows ))))

--- a/src/metabase/csv.clj
+++ b/src/metabase/csv.clj
@@ -2,18 +2,29 @@
   (:require
    [clojure.data.csv :as csv]
    [clojure.java.io :as io]
+   [clojure.set :as set]
+   [clojure.string :as str]
+   [medley.core :as m]
+   [metabase.search.util :as search-util]
    [metabase.util :as u]
    [metabase.util.i18n :refer [trs]]))
 
+;;           text
+;;            |
+;;            |
+;;       varchar_255
+;;            |
+;;            |
+;;          float
+;;            |
+;;            |
+;;           int
+;;            |
+;;            |
+;;         boolean
 (derive ::boolean     ::int)
-(derive ::boolean     ::varchar_255)
-(derive ::boolean     ::text)
 (derive ::int         ::float)
-(derive ::int         ::text)
-(derive ::int         ::varchar_255)
-(derive ::int         ::text)
 (derive ::float       ::varchar_255)
-(derive ::float       ::text)
 (derive ::varchar_255 ::text)
 
 (defn value->type
@@ -23,15 +34,17 @@
     - ::float
     - ::varchar_255
     - ::text
+    - nil, in which case other functions are expected to replace it with ::text as the catch-all type
 
   NB: There are currently the following gotchas:
     1. ints/floats are assumed to have commas as separators and periods as decimal points
     2. 0 and 1 are assumed to be booleans, not ints."
   [value]
   (cond
+    (str/blank? value)                                      nil
     (re-matches #"(?i)true|t|yes|y|1|false|f|no|n|0" value) ::boolean
-    (re-matches #"[\d,]+"                            value) ::int
-    (re-matches #"[\d,]*\.\d+"                       value) ::float
+    (re-matches #"-?[\d,]+"                          value) ::int
+    (re-matches #"-?[\d,]*\.\d+"                     value) ::float
     (re-matches #".{1,255}"                          value) ::varchar_255
     :else                                                   ::text))
 
@@ -39,16 +52,22 @@
   [column-names row]
   (->> row
        (map vector column-names)
-       (map (fn [[column-name value]] [column-name (value->type value)]))
+       (map (fn [[column-name value]] [column-name (and value (value->type (search-util/normalize value)))]))
        (into {})))
 
 (defn coalesce
   "Returns the 'parent' type (the most general)."
   [type-a type-b]
   (cond
+    (nil? type-a)        type-b
+    (nil? type-b)        type-a
     (isa? type-a type-b) type-b
     (isa? type-b type-a) type-a
-    :else (throw (Exception. (trs "Unexpected type combination in the same column: {0} and {1}" type-a type-b)))))
+    :else
+    (let [common-ancestors (set/intersection (ancestors type-a) (ancestors type-b))]
+      (if (seq common-ancestors)
+        (first common-ancestors)
+        (throw (Exception. (trs "Unexpected type combination in the same column: {0} and {1}" type-a type-b)))))))
 
 (defn- coalesce-types
   [types-so-far new-types]
@@ -59,19 +78,23 @@
 
 (defn- rows->schema
   [header rows]
-  (let [normalized-header (map u/slugify header)]
+  (let [normalized-header (map (comp u/slugify str/trim) header)]
     (->> rows
          (map (partial row->types normalized-header))
-         (reduce coalesce-types))))
+         (reduce coalesce-types)
+         (m/map-vals #(or % ::text)))))
 
 (defn detect-schema
   "Returns a map of `normalized-column-name -> type` for the given CSV file. The CSV file *must* have headers as the
   first row. Supported types are:
+
     - ::int
     - ::float
     - ::boolean
     - ::varchar_255
-    - ::text"
+    - ::text
+
+  A column that is completely blank is assumed to be of type ::text."
   [csv-file]
   (with-open [reader (io/reader csv-file)]
     (let [[header & rows] (csv/read-csv reader)]

--- a/src/metabase/csv.clj
+++ b/src/metabase/csv.clj
@@ -3,7 +3,7 @@
    [clojure.data.csv :as csv]
    [clojure.java.io :as io]
    [clojure.string :as str]
-   [medley.core :as m]
+   [flatland.ordered.map :as ordered-map]
    [metabase.search.util :as search-util]
    [metabase.util :as u]
    [metabase.util.i18n :refer [trs]]))
@@ -48,11 +48,8 @@
     :else                                                   ::text))
 
 (defn- row->types
-  [column-names row]
-  (->> row
-       (map vector column-names)
-       (map (fn [[column-name value]] [column-name (and value (value->type (search-util/normalize value)))]))
-       (into {})))
+  [row]
+  (map (comp value->type search-util/normalize) row))
 
 (defn coalesce
   "Returns the 'parent' type (the most general)."
@@ -66,18 +63,25 @@
 
 (defn- coalesce-types
   [types-so-far new-types]
-  (->> types-so-far
-       (map (fn [[column-name old-type]]
-              [column-name (coalesce old-type (get new-types column-name))]))
-       (into {})))
+  (->> (map vector types-so-far new-types)
+       (map (partial apply coalesce))))
+
+(defn- pad
+  "Lengthen `values` until it is of length `n` by filling it with nils."
+  [n values]
+  (first (partition n n (repeat nil) values)))
 
 (defn- rows->schema
   [header rows]
-  (let [normalized-header (map (comp u/slugify str/trim) header)]
+  (let [normalized-header (map (comp u/slugify str/trim) header)
+        column-count      (count normalized-header)]
     (->> rows
-         (map (partial row->types normalized-header))
+         (map row->types)
+         (map (partial pad column-count))
          (reduce coalesce-types)
-         (m/map-vals #(or % ::text)))))
+         (map #(or % ::text))
+         (map vector normalized-header)
+         (ordered-map/ordered-map))))
 
 (defn detect-schema
   "Returns a map of `normalized-column-name -> type` for the given CSV file. The CSV file *must* have headers as the
@@ -93,4 +97,4 @@
   [csv-file]
   (with-open [reader (io/reader csv-file)]
     (let [[header & rows] (csv/read-csv reader)]
-      (rows->schema header rows ))))
+      (rows->schema header rows))))

--- a/test/metabase/csv_test.clj
+++ b/test/metabase/csv_test.clj
@@ -1,0 +1,49 @@
+(ns metabase.csv-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase.csv :as csv]))
+
+(def bool-type  :metabase.csv/boolean)
+(def int-type   :metabase.csv/int)
+(def float-type :metabase.csv/float)
+(def vchar-type :metabase.csv/varchar_255)
+(def text-type  :metabase.csv/text)
+
+(deftest type-detection-test
+  (doseq [[value expected] [["0"                          bool-type]
+                            ["1"                          bool-type]
+                            ["t"                          bool-type]
+                            ["T"                          bool-type]
+                            ["tRuE"                       bool-type]
+                            ["f"                          bool-type]
+                            ["F"                          bool-type]
+                            ["FAlse"                      bool-type]
+                            ["Y"                          bool-type]
+                            ["n"                          bool-type]
+                            ["yes"                        bool-type]
+                            ["NO"                         bool-type]
+                            ["2"                          int-type]
+                            ["9,986,000"                  int-type]
+                            ["3.14"                       float-type]
+                            [".14"                        float-type]
+                            ["0.14"                       float-type]
+                            ["9,986,000.0"                float-type]
+                            [(apply str (repeat 255 "x")) vchar-type]
+                            [(apply str (repeat 256 "x")) text-type]
+                            ["86 is my favorite number"   vchar-type]
+                            ["My favorite number is 86"   vchar-type]]]
+    (testing (format "\"%s\" is a %s" value expected)
+      (is (= expected (csv/value->type value))))))
+
+(deftest type-coalescing-test
+  (doseq [[type-a type-b expected] [[bool-type  int-type   int-type]
+                                    [int-type   bool-type  int-type] ;; ensure arg order doesn't matter
+                                    [int-type   float-type float-type]
+                                    [bool-type  vchar-type vchar-type]
+                                    [bool-type  text-type  text-type]
+                                    [int-type   vchar-type vchar-type]
+                                    [int-type   text-type  text-type]
+                                    [float-type vchar-type vchar-type]
+                                    [float-type text-type  text-type]
+                                    [vchar-type text-type  text-type]]]
+    (is (= expected (csv/coalesce type-a type-b)))))

--- a/test/metabase/csv_test.clj
+++ b/test/metabase/csv_test.clj
@@ -1,13 +1,18 @@
 (ns metabase.csv-test
   (:require
+   [clojure.string :as str]
    [clojure.test :refer :all]
-   [metabase.csv :as csv]))
+   [metabase.csv :as csv])
+  (:import
+   [java.io File]))
 
-(def bool-type  :metabase.csv/boolean)
-(def int-type   :metabase.csv/int)
-(def float-type :metabase.csv/float)
-(def vchar-type :metabase.csv/varchar_255)
-(def text-type  :metabase.csv/text)
+(set! *warn-on-reflection* true)
+
+(def bool-type      :metabase.csv/boolean)
+(def int-type       :metabase.csv/int)
+(def float-type     :metabase.csv/float)
+(def vchar-type     :metabase.csv/varchar_255)
+(def text-type      :metabase.csv/text)
 
 (deftest type-detection-test
   (doseq [[value expected] [["0"                          bool-type]
@@ -23,10 +28,12 @@
                             ["yes"                        bool-type]
                             ["NO"                         bool-type]
                             ["2"                          int-type]
+                            ["-86"                        int-type]
                             ["9,986,000"                  int-type]
                             ["3.14"                       float-type]
                             [".14"                        float-type]
                             ["0.14"                       float-type]
+                            ["-9,986.567"                 float-type]
                             ["9,986,000.0"                float-type]
                             [(apply str (repeat 255 "x")) vchar-type]
                             [(apply str (repeat 256 "x")) text-type]
@@ -46,4 +53,52 @@
                                     [float-type vchar-type vchar-type]
                                     [float-type text-type  text-type]
                                     [vchar-type text-type  text-type]]]
-    (is (= expected (csv/coalesce type-a type-b)))))
+    (is (= expected (csv/coalesce type-a type-b))
+        (format "%s + %s = %s" (name type-a) (name type-b) (name expected)))))
+
+(defn- csv-file-with
+  "Create a temp csv file with the given content and return the file"
+  [rows]
+  (let [contents (str/join "\n" rows)
+        csv-file (File/createTempFile "pokefans" ".csv")]
+    (spit csv-file contents)
+    csv-file))
+
+(deftest detect-schema-test
+  (testing "Well-formed CSV file"
+    (is (= {"name"             vchar-type
+            "age"              int-type
+            "favorite_pokemon" vchar-type}
+           (csv/detect-schema
+            (csv-file-with ["Name, Age, Favorite Pokémon"
+                            "Tim, 12, Haunter"
+                            "Ryan, 97, Paras"])))))
+  (testing "CSV missing data"
+    (is (= {"name"       vchar-type
+            "height"     int-type
+            "birth_year" float-type}
+           (csv/detect-schema
+            (csv-file-with ["Name, Height, Birth Year"
+                            "Luke Skywalker, 172, -19"
+                            "Darth Vader, 202, -41.9"
+                            "Watto, 137"          ; missing column
+                            "Sebulba, 112,"]))))) ; comma, but blank column
+  (testing "Type coalescing"
+    (is (= {"name"       vchar-type
+            "height"     float-type
+            "birth_year" vchar-type}
+           (csv/detect-schema
+            (csv-file-with ["Name, Height, Birth Year"
+                            "Rey Skywalker, 170, 15"
+                            "Darth Vader, 202.0, 41.9BBY"])))))
+  (testing "Boolean coalescing"
+    (is (= {"name"          vchar-type
+            "is_jedi_"      bool-type
+            "is_jedi__int_" int-type
+            "is_jedi__vc_"  vchar-type}
+           (csv/detect-schema
+            (csv-file-with ["Name, Is Jedi?, Is Jedi (int), Is Jedi (VC)"
+                            "Rey Skywalker, yes, true, t"
+                            "Darth Vader, YES, TRUE, Y"
+                            "Grogu, 1, 9001, probably?"
+                            "Han Solo, no, FaLsE, 0"]))))))

--- a/test/metabase/csv_test.clj
+++ b/test/metabase/csv_test.clj
@@ -101,4 +101,11 @@
                             "Rey Skywalker, yes, true, t"
                             "Darth Vader, YES, TRUE, Y"
                             "Grogu, 1, 9001, probably?"
-                            "Han Solo, no, FaLsE, 0"]))))))
+                            "Han Solo, no, FaLsE, 0"])))))
+  (testing "Order is ensured"
+    (let [header "a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t,u,v,w,x,y,z,zz,yy,xx,ww,vv,uu,tt,ss,rr,qq,pp,oo,nn,mm,ll,kk,jj,ii,hh,gg,ff,ee,dd,cc,bb,aa"]
+      (is (= (str/split header #",")
+             (keys
+              (csv/detect-schema
+               (csv-file-with [header
+                               "Luke,ah'm,yer,da,,,missing,columns,should,not,matter"]))))))))


### PR DESCRIPTION
Handles int/float/varchar(255)/text. We have plans to support dates and times later, but I wanted to ship this first.

I spent an hour making it handle ints and floats with more than 255 characters really gracefully and then realized that we're not going to encounter numbers that big anyway, so never mind that :upside_down_face:

I added the schema to the API response just so I had something to look at, but of course that's not "real" (and that's why there are no API tests).
 
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/29650)
<!-- Reviewable:end -->
