### PR TITLE
docs - fix typos

### DIFF
--- a/docs/paid-features/overview.md
+++ b/docs/paid-features/overview.md
@@ -31,13 +31,13 @@ Paid plans include more ways to manage permissions, including data sandboxing, w
 - [Block permissions](../permissions/data.md#block-access)
 - [SQL snippet folder permissions](../permissions/snippets.md)
 - [Application permissions](../permissions/application.md)
-- [Download permissions](../permissions/data#download-results)
-- [Database management permissions](../permissions/data#manage-database)
-- [Data model management permissions](../permissions/data#manage-data-model)
+- [Download permissions](../permissions/data.md#download-results)
+- [Database management permissions](../permissions/data.md#manage-database)
+- [Data model management permissions](../permissions/data.md#manage-data-model)
 
 ## People and group management
 
-- [Group managers](../people-and-groups/managing#group-managers)
+- [Group managers](../people-and-groups/managing.md#group-managers)
 
 ## Embedding
 
@@ -69,8 +69,8 @@ Tools for keeping your Metabase organized, so people can find your most importan
 
 All Metabase editions include global caching controls. Paid plans includes additional caching options that let you control caching for individual questions.
 
-- [Caching controls for individual questions](../configuring-metabase/caching#caching-per-question)
-- [Caching control per database](../configuring-metabase/caching#caching-per-database)
+- [Caching controls for individual questions](../configuring-metabase/caching.md#caching-per-question)
+- [Caching control per database](../configuring-metabase/caching.md#caching-per-database)
 
 ## Auditing
 

--- a/docs/paid-features/overview.md
+++ b/docs/paid-features/overview.md
@@ -31,7 +31,7 @@ Paid plans include more ways to manage permissions, including data sandboxing, w
 - [Block permissions](../permissions/data.md#block-access)
 - [SQL snippet folder permissions](../permissions/snippets.md)
 - [Application permissions](../permissions/application.md)
-- [Download permissions](../permissions/data#download-results
+- [Download permissions](../permissions/data#download-results)
 - [Database management permissions](../permissions/data#manage-database)
 - [Data model management permissions](../permissions/data#manage-data-model)
 
@@ -69,7 +69,7 @@ Tools for keeping your Metabase organized, so people can find your most importan
 
 All Metabase editions include global caching controls. Paid plans includes additional caching options that let you control caching for individual questions.
 
-- [Caching controls for individual questions](../configuring-metabase/cachingd#caching-per-question)
+- [Caching controls for individual questions](../configuring-metabase/caching#caching-per-question)
 - [Caching control per database](../configuring-metabase/caching#caching-per-database)
 
 ## Auditing


### PR DESCRIPTION
Fixes some docs issues that snuck in the auto-merge door.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/29659)
<!-- Reviewable:end -->
