### PR TITLE
Fix typo in driver development docs

### DIFF
--- a/docs/developers-guide/drivers/plugins.md
+++ b/docs/developers-guide/drivers/plugins.md
@@ -43,7 +43,7 @@ You _can_ (but shouldn't) set a driver to `lazy-load: false`, as this will make 
 
 ## Plugin initialization
 
-Metabase will initialize plugins automatically as needed. Initialization goes something like this: Metabase adds the driver to the classpath, then it performs ea `init` section of the plugin manifest, in order. In the [example manifest above](#example-manifest), there are two steps, a `load-namespace` step, and a `register-jdbc-driver` step:
+Metabase will initialize plugins automatically as needed. Initialization goes something like this: Metabase adds the driver to the classpath, then it performs each `init` section of the plugin manifest, in order. In the [example manifest above](#example-manifest), there are two steps, a `load-namespace` step, and a `register-jdbc-driver` step:
 
 ```yaml
 init:

--- a/docs/developers-guide/drivers/plugins.md
+++ b/docs/developers-guide/drivers/plugins.md
@@ -55,9 +55,9 @@ init:
 
 ## Loading namespaces
 
-You'll need to add one or more `load-namespace` steps to your driver manifest to tell Metabase which namespaces contain your driver method implementations. In the example above, the namespace is `metabase.driver.sqlite`. `load-namespace` calls `require` the [normal Clojure way, meaning it will load other namespaces listed in the `:require` section of its namespace declaration as needed. If your driver's method implementations are split across multiple namespaces, make sure they'll get loaded as well -- you can either have the main namespace handle this (e.g., by including them in the `:require` form in the namespace declaration) or by adding additional `load-namespace` steps.
+You'll need to add one or more `load-namespace` steps to your driver manifest to tell Metabase which namespaces contain your driver method implementations. In the example above, the namespace is `metabase.driver.sqlite`. `load-namespace` calls `require` the [normal Clojure way](https://clojuredocs.org/clojure.core/require), meaning it will load other namespaces listed in the `:require` section of its namespace declaration as needed. If your driver's method implementations are split across multiple namespaces, make sure they'll get loaded as well -- you can either have the main namespace handle this (e.g., by including them in the `:require` form in the namespace declaration) or by adding additional `load-namespace` steps.
 
-For some background on namespaces, see [Clojure namespaces][clojure-namespace].
+For some background on namespaces, see [Clojure namespaces](https://clojure.org/guides/learn/namespaces).
 
 ## Registering JDBC Drivers
 


### PR DESCRIPTION
I'm assuming `ea` is supposed to be `each`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/29665)
<!-- Reviewable:end -->
