### PR TITLE
refactor custom `TabList` from `ModelDetailPage` into a core component

### DIFF
--- a/frontend/src/metabase/core/components/TabButton/TabButton.styled.tsx
+++ b/frontend/src/metabase/core/components/TabButton/TabButton.styled.tsx
@@ -1,0 +1,27 @@
+import styled from "@emotion/styled";
+
+import { color } from "metabase/lib/colors";
+
+export interface TabButtonProps {
+  isSelected?: boolean;
+}
+
+export const TabButtonLabel = styled.div`
+  width: 100%;
+  font-weight: bold;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;
+
+export const TabButtonRoot = styled.button<TabButtonProps>`
+  padding: 1rem 0;
+
+  color: ${props => (props.isSelected ? color("brand") : color("text-dark"))};
+  font-size: 0.875rem;
+  font-weight: 700;
+
+  cursor: pointer;
+
+  border-bottom: 3px solid
+    ${props => (props.isSelected ? color("brand") : "transparent")};
+`;

--- a/frontend/src/metabase/core/components/TabButton/TabButton.tsx
+++ b/frontend/src/metabase/core/components/TabButton/TabButton.tsx
@@ -1,0 +1,46 @@
+import React, {
+  ButtonHTMLAttributes,
+  MouseEvent,
+  useContext,
+  useCallback,
+} from "react";
+
+import { getTabId, getTabPanelId, TabContext } from "../Tab";
+import { TabButtonLabel, TabButtonRoot } from "./TabButton.styled";
+
+export interface TabButtonProps
+  extends ButtonHTMLAttributes<HTMLButtonElement> {
+  value?: string | number;
+}
+function TabButton({ value, children, onClick, ...props }: TabButtonProps) {
+  const { value: selectedValue, idPrefix, onChange } = useContext(TabContext);
+  const tabId = getTabId(idPrefix, value);
+  const panelId = getTabPanelId(idPrefix, value);
+  const isSelected = value === selectedValue;
+
+  const handleClick = useCallback(
+    (event: MouseEvent<HTMLButtonElement>) => {
+      onClick?.(event);
+      onChange?.(value);
+    },
+    [value, onClick, onChange],
+  );
+
+  return (
+    <TabButtonRoot
+      {...props}
+      id={tabId}
+      role="tab"
+      isSelected={isSelected}
+      aria-selected={isSelected}
+      aria-controls={panelId}
+      onClick={handleClick}
+    >
+      <TabButtonLabel>{children}</TabButtonLabel>
+    </TabButtonRoot>
+  );
+}
+
+export default Object.assign(TabButton, {
+  Root: TabButtonRoot,
+});

--- a/frontend/src/metabase/core/components/TabButton/index.ts
+++ b/frontend/src/metabase/core/components/TabButton/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./TabButton";

--- a/frontend/src/metabase/core/components/TabRow/TabRow.stories.tsx
+++ b/frontend/src/metabase/core/components/TabRow/TabRow.stories.tsx
@@ -1,0 +1,80 @@
+import React from "react";
+import type { ComponentStory } from "@storybook/react";
+import { useArgs } from "@storybook/client-api";
+
+import TabButton from "../TabButton";
+import TabLink from "../TabLink";
+import TabRow from "./TabRow";
+
+export default {
+  title: "Core/TabRow",
+  component: TabRow,
+};
+
+const sampleStyle = {
+  maxWidth: "800px",
+  padding: "10px",
+  border: "1px solid #ccc",
+};
+
+const Template: ComponentStory<typeof TabRow> = args => {
+  const [{ value }, updateArgs] = useArgs();
+  const handleChange = (value: unknown) => updateArgs({ value });
+
+  return (
+    <div style={sampleStyle}>
+      <TabRow {...args} value={value} onChange={handleChange}>
+        <TabButton value={1}>Tab 1</TabButton>
+        <TabButton value={2}>Tab 2</TabButton>
+        <TabButton value={3}>Tab 3</TabButton>
+        <TabButton value={4}>Tab 4</TabButton>
+        <TabButton value={5}>Tab 5</TabButton>
+        <TabButton value={6}>Tab 6</TabButton>
+        <TabButton value={7}>Tab 7</TabButton>
+      </TabRow>
+    </div>
+  );
+};
+
+export const Default = Template.bind({});
+Default.args = {
+  value: 1,
+};
+
+const LinkTemplate: ComponentStory<typeof TabRow> = args => {
+  const [{ value }, updateArgs] = useArgs();
+  const handleChange = (value: unknown) => updateArgs({ value });
+
+  return (
+    <div style={sampleStyle}>
+      <TabRow {...args} value={value} onChange={handleChange}>
+        <TabLink value={1} to="">
+          Tab 1
+        </TabLink>
+        <TabLink value={2} to="">
+          Tab 2
+        </TabLink>
+        <TabLink value={3} to="">
+          Tab 3
+        </TabLink>
+        <TabLink value={4} to="">
+          Tab 4
+        </TabLink>
+        <TabLink value={5} to="">
+          Tab 5
+        </TabLink>
+        <TabLink value={6} to="">
+          Tab 6
+        </TabLink>
+        <TabLink value={7} to="">
+          Tab 7
+        </TabLink>
+      </TabRow>
+    </div>
+  );
+};
+
+export const WithLinks = LinkTemplate.bind({});
+WithLinks.args = {
+  value: 1,
+};

--- a/frontend/src/metabase/core/components/TabRow/TabRow.styled.tsx
+++ b/frontend/src/metabase/core/components/TabRow/TabRow.styled.tsx
@@ -1,0 +1,22 @@
+import styled from "@emotion/styled";
+
+import { color } from "metabase/lib/colors";
+import BaseTabList from "metabase/core/components/TabList";
+import TabLink from "metabase/core/components/TabLink";
+import TabButton from "metabase/core/components/TabButton";
+
+export const TabList = styled(BaseTabList)`
+  border-bottom: 1px solid ${color("border")};
+
+  ${BaseTabList.Content} {
+    display: flex;
+  }
+
+  ${TabLink.Root}:not(:last-child) {
+    margin-right: 2rem;
+  }
+
+  ${TabButton.Root}:not(:last-child) {
+    margin-right: 2rem;
+  }
+`;

--- a/frontend/src/metabase/core/components/TabRow/TabRow.tsx
+++ b/frontend/src/metabase/core/components/TabRow/TabRow.tsx
@@ -1,0 +1,8 @@
+import React from "react";
+
+import { TabListProps } from "../TabList/TabList";
+import { TabList } from "./TabRow.styled";
+
+export default function TabRow<T>({ onChange, ...props }: TabListProps<T>) {
+  return <TabList onChange={onChange as (value: unknown) => void} {...props} />;
+}

--- a/frontend/src/metabase/core/components/TabRow/TabRow.unit.spec.tsx
+++ b/frontend/src/metabase/core/components/TabRow/TabRow.unit.spec.tsx
@@ -1,0 +1,32 @@
+import React, { useState } from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import TabButton from "../TabButton";
+import TabRow from "./TabRow";
+
+const TestTabRow = () => {
+  const [value, setValue] = useState(1);
+
+  return (
+    <TabRow value={value} onChange={setValue}>
+      <TabButton value={1}>Tab 1</TabButton>
+      <TabButton value={2}>Tab 2</TabButton>
+    </TabRow>
+  );
+};
+
+describe("TabRow", () => {
+  it("should navigate between tabs", () => {
+    render(<TestTabRow />);
+
+    const option1 = screen.getByRole("tab", { name: "Tab 1" });
+    const option2 = screen.getByRole("tab", { name: "Tab 2" });
+    expect(option1).toHaveAttribute("aria-selected", "true");
+    expect(option2).toHaveAttribute("aria-selected", "false");
+
+    userEvent.click(option2);
+    expect(option1).toHaveAttribute("aria-selected", "false");
+    expect(option2).toHaveAttribute("aria-selected", "true");
+  });
+});

--- a/frontend/src/metabase/core/components/TabRow/index.ts
+++ b/frontend/src/metabase/core/components/TabRow/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./TabRow";

--- a/frontend/src/metabase/models/components/ModelDetailPage/ModelDetailPage.styled.tsx
+++ b/frontend/src/metabase/models/components/ModelDetailPage/ModelDetailPage.styled.tsx
@@ -1,8 +1,11 @@
 import styled from "@emotion/styled";
-import TabLink from "metabase/core/components/TabLink";
-import BaseTabList from "metabase/core/components/TabList";
+
+import BaseTabRow from "metabase/core/components/TabRow";
 import BaseTabPanel from "metabase/core/components/TabPanel";
-import { color } from "metabase/lib/colors";
+
+export const TabRow = styled(BaseTabRow)`
+  margin: 1rem 0;
+`;
 
 export const RootLayout = styled.div`
   display: flex;
@@ -19,19 +22,6 @@ export const ModelMain = styled.div`
   flex-direction: column;
 
   padding-right: 3rem;
-`;
-
-export const TabList = styled(BaseTabList)`
-  margin: 1rem 0;
-  border-bottom: 1px solid ${color("border")};
-
-  ${BaseTabList.Content} {
-    display: flex;
-  }
-
-  ${TabLink.Root}:not(:last-child) {
-    margin-right: 2rem;
-  }
 `;
 
 export const TabPanel = styled(BaseTabPanel)`

--- a/frontend/src/metabase/models/components/ModelDetailPage/ModelDetailPage.tsx
+++ b/frontend/src/metabase/models/components/ModelDetailPage/ModelDetailPage.tsx
@@ -18,7 +18,7 @@ import ModelUsageDetails from "./ModelUsageDetails";
 import {
   RootLayout,
   ModelMain,
-  TabList,
+  TabRow,
   TabPanel,
   TabPanelContent,
 } from "./ModelDetailPage.styled";
@@ -58,7 +58,7 @@ function ModelDetailPage({
           onChangeCollection={onChangeCollection}
         />
         <TabContent value={tab}>
-          <TabList>
+          <TabRow>
             <TabLink
               value="usage"
               to={Urls.modelDetail(modelCard, "usage")}
@@ -73,7 +73,7 @@ function ModelDetailPage({
                 to={Urls.modelDetail(modelCard, "actions")}
               >{t`Actions`}</TabLink>
             )}
-          </TabList>
+          </TabRow>
           <TabPanel value="usage">
             <TabPanelContent>
               <ModelUsageDetails


### PR DESCRIPTION
Part of epic https://github.com/metabase/metabase/issues/29502

### Description

The [design](https://www.figma.com/file/DuwiUCVo1K4EUBw50pGYPy/Tabs-in-dashboards?node-id=104-5192&t=tCyOUqw5FDYfPSO9-0) shown below for dashboard tabs requires a horiziontal tab bar component. This [used](https://github.com/metabase/metabase/pull/22701) to be the style of the `TabList` core component, but it was later [changed](https://github.com/metabase/metabase/pull/24493) in favor of another style in modals. Then we later ended up [recreating](https://github.com/metabase/metabase/pull/27959) the horizontal style in the `ModelDetailPage`.

<img width="253" alt="Screenshot 2023-03-29 at 12 54 22 PM" src="https://user-images.githubusercontent.com/37751258/228652490-0dbe2537-19e4-494a-bafe-96fbfa03d4a2.png">

This PR refactors that horizontal `TabList` into a core component, `TabRow`, so that it can be used both in the `ModelDetailPage` and for dashboard tabs, as well as anywhere else we would like to use it later. Currently the functionality is barebones, but later I will re-introduce the scrolling behavior it originally had, as well as support for dropdown menus in the individual `TabButton` components.

### How to verify

`yarn storybook` -> `TabRow`

Also go to a model detail page (can create a new model from +New -> Model -> Sample Data -> Orders) and confirm it is unchanged there

### Demo

https://user-images.githubusercontent.com/37751258/228652964-dbe40c35-0326-41e9-bea2-dac04fb36024.mov

<img width="509" alt="Screenshot 2023-03-29 at 12 29 36 PM" src="https://user-images.githubusercontent.com/37751258/228653022-d2248224-bd88-44a0-989f-503a58ef974a.png">

### Checklist

- ✅ Tests have been added/updated to cover changes in this PR

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/29669)
<!-- Reviewable:end -->
