### PR TITLE
Add log4j dependency for custom json logging format

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -101,6 +101,8 @@
   org.apache.logging.log4j/log4j-jul        {:mvn/version "2.20.0"}             ; java.util.logging (JUL) -> Log4j2 adapter
   org.apache.logging.log4j/log4j-slf4j2-impl
                                             {:mvn/version "2.20.0"}             ; allows the slf4j2 API to work with log4j 2
+  org.apache.logging.log4j/log4j-layout-template-json
+                                            {:mvn/version "2.20.0"}             ; allows the custom json logging format
   org.apache.poi/poi                        {:mvn/version "5.2.3"}              ; Work with Office documents (e.g. Excel spreadsheets) -- newer version than one specified by Docjure
   org.apache.poi/poi-ooxml                  {:mvn/version "5.2.3"
                                              :exclusions  [org.bouncycastle/bcpkix-jdk15on


### PR DESCRIPTION
Related to https://github.com/metabase/metabase-ops/issues/667

### Description

Adding a log4j plugin for a [template json logging format](https://logging.apache.org/log4j/2.x/manual/layouts.html#json-template-layout) which is required for well-formatted logs. The default log4j template produce output which not really fit to our requirements. 
Also, it unlocks logging of an additional context in an easy-to-parse form which we will need in a near future. 

### Demo

Example of the custom output:

```
{"@timestamp":"2023-03-30T16:03:59.720+0200","level":"INFO","logger_name":"metabase.events","message":"Starting events listener: :metabase.events.last-login/LastLogin "}
{"@timestamp":"2023-03-30T16:03:59.720+0200","level":"INFO","logger_name":"metabase.events","message":"Starting events listener: :metabase.events.persisted-info/PersistedInfo "}
{"@timestamp":"2023-03-30T16:03:59.720+0200","level":"INFO","logger_name":"metabase.events","message":"Starting events listener: :metabase.events.sync-database/Sync "}
{"@timestamp":"2023-03-30T16:03:59.720+0200","level":"INFO","logger_name":"metabase.events","message":"Starting events listener: :metabase.events.driver-notifications/DriverNotifications "}
{"@timestamp":"2023-03-30T16:03:59.721+0200","level":"INFO","logger_name":"metabase.events","message":"Starting events listener: :metabase.events.revision/Revisions "}
{"@timestamp":"2023-03-30T16:03:59.721+0200","level":"INFO","logger_name":"metabase.events","message":"Starting events listener: :metabase.events.view-log/ViewLog "}
{"@timestamp":"2023-03-30T16:03:59.746+0200","level":"INFO","logger_name":"metabase.driver.impl","message":"Initializing driver :sql..."}
```

### Checks

No code added.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/29686)
<!-- Reviewable:end -->
