### PR TITLE
[MLv2] Disallow duplicate UUIDs in a query

### DIFF
--- a/src/metabase/lib/schema.cljc
+++ b/src/metabase/lib/schema.cljc
@@ -20,6 +20,7 @@
    [metabase.lib.schema.literal]
    [metabase.lib.schema.order-by :as order-by]
    [metabase.lib.schema.ref :as ref]
+   [metabase.lib.schema.util :as lib.schema.util]
    [metabase.util.malli.registry :as mr]))
 
 (comment metabase.lib.schema.expression.arithmetic/keep-me
@@ -32,7 +33,6 @@
 (mr/def ::stage.native
   [:map
    [:lib/type [:= :mbql.stage/native]]
-   [:lib/options ::common/options]
    [:native any?]
    [:args {:optional true} [:sequential any?]]])
 
@@ -51,7 +51,6 @@
   [:and
    [:map
     [:lib/type     [:= :mbql.stage/mbql]]
-    [:lib/options  ::common/options]
     [:joins        {:optional true} [:ref ::join/joins]]
     [:expressions  {:optional true} [:ref ::expression/expressions]]
     [:breakout     {:optional true} ::breakouts]
@@ -105,8 +104,10 @@
    [:* ::stage.additional]])
 
 (mr/def ::query
-  [:map
-   [:lib/type [:= :mbql/query]]
-   [:database ::id/database]
-   [:type [:= :pipeline]]
-   [:stages ::stages]])
+  [:and
+   [:map
+    [:lib/type [:= :mbql/query]]
+    [:database ::id/database]
+    [:type [:= :pipeline]]
+    [:stages ::stages]]
+   lib.schema.util/UniqueUUIDs])

--- a/src/metabase/lib/schema.cljc
+++ b/src/metabase/lib/schema.cljc
@@ -8,7 +8,6 @@
   future we can deprecate that namespace and eventually do away with it entirely."
   (:require
    [metabase.lib.schema.aggregation :as aggregation]
-   [metabase.lib.schema.common :as common]
    [metabase.lib.schema.expression :as expression]
    [metabase.lib.schema.expression.arithmetic]
    [metabase.lib.schema.expression.conditional]

--- a/src/metabase/lib/schema/util.cljc
+++ b/src/metabase/lib/schema/util.cljc
@@ -1,0 +1,43 @@
+(ns metabase.lib.schema.util
+  (:require
+   [metabase.lib.options :as lib.options]))
+
+(declare collect-uuids)
+
+(defn- collect-uuids-in-map [m]
+  (into (filterv some? [(:lib/uuid m)
+                        (:lib/uuid (lib.options/options m))])
+        (comp (remove (fn [[k _v]]
+                        (#{:lib/metadata :lib/stage-metadata} k)))
+              (mapcat (fn [[_k v]]
+                        (collect-uuids v))))
+        m))
+
+(defn- collect-uuids-in-sequence [xs]
+  (into [] (mapcat collect-uuids) xs))
+
+(defn collect-uuids
+  "Return all the `:lib/uuid`s in a part of an MBQL query (a clause or map) as a sequence. This will be used to ensure
+  there are no duplicates."
+  [x]
+  (cond
+    (map? x)        (collect-uuids-in-map x)
+    (sequential? x) (collect-uuids-in-sequence x)
+    :else           nil))
+
+(defn unique-uuids?
+  "True if all the `:lib/uuid`s in something are unique."
+  [x]
+  (reduce
+   (fn [seen x]
+     (if (contains? seen x)
+       (reduced false)
+       (conj seen x)))
+   #{}
+   (collect-uuids x)))
+
+(def UniqueUUIDs
+  "Malli schema for to ensure that all `:lib/uuid`s are unique."
+  [:fn
+   {:error/message "all :lib/uuids must be unique"}
+   #'unique-uuids?])

--- a/test/metabase/lib/schema/expression/conditional_test.cljc
+++ b/test/metabase/lib/schema/expression/conditional_test.cljc
@@ -49,7 +49,6 @@
     (case-expr 1 1.1)
     :type/Number))
 
-
 (deftest ^:parallel coalesce-test
   (is (mc/validate
        :mbql.clause/coalesce
@@ -64,7 +63,6 @@
         :type         :pipeline
         :database     (meta/id)
         :stages       [{:lib/type     :mbql.stage/mbql,
-                        :lib/options  {:lib/uuid "455a9f5e-4996-4df9-82aa-01bc083b2efe"}
                         :source-table (meta/id :venues)
                         :expressions  {"expr"
                                        [:coalesce

--- a/test/metabase/lib/schema/util_test.cljc
+++ b/test/metabase/lib/schema/util_test.cljc
@@ -1,6 +1,6 @@
 (ns metabase.lib.schema.util-test
   (:require
-   [clojure.test :refer [are deftest]]
+   [clojure.test :refer [are deftest is]]
    [metabase.lib.schema.util :as lib.schema.util]))
 
 (defn- query [uuid-1 uuid-2]
@@ -47,7 +47,5 @@
      "00000000-0000-0000-0000-000000000020"]))
 
 (deftest ^:parallel unique-uuids?-test
-  (are [query expected] (= expected
-                           (lib.schema.util/unique-uuids? query))
-    query-with-no-duplicate-uuids true
-    query-with-duplicate-uuids    false))
+  (is (lib.schema.util/unique-uuids? query-with-no-duplicate-uuids))
+  (is (not (lib.schema.util/unique-uuids? query-with-duplicate-uuids))))

--- a/test/metabase/lib/schema/util_test.cljc
+++ b/test/metabase/lib/schema/util_test.cljc
@@ -1,6 +1,8 @@
 (ns metabase.lib.schema.util-test
   (:require
    [clojure.test :refer [are deftest is]]
+   [malli.core :as mc]
+   [malli.error :as me]
    [metabase.lib.schema.util :as lib.schema.util]))
 
 (defn- query [uuid-1 uuid-2]
@@ -46,6 +48,22 @@
      "00000000-0000-0000-0000-000000000010"
      "00000000-0000-0000-0000-000000000020"]))
 
+(deftest ^:parallel collect-uuids-from-lib-options
+  (is (= ["f590f35f-9224-45f1-8334-422f15fc4abd"]
+         (lib.schema.util/collect-uuids
+          {:lib/type :mbql/query
+           :database 1
+           :type     :pipeline
+           :stages   [{:lib/type     :mbql.stage/mbql
+                       :source-table 2
+                       :lib/options  {:lib/uuid "f590f35f-9224-45f1-8334-422f15fc4abd"}}]}))))
+
 (deftest ^:parallel unique-uuids?-test
   (is (lib.schema.util/unique-uuids? query-with-no-duplicate-uuids))
   (is (not (lib.schema.util/unique-uuids? query-with-duplicate-uuids))))
+
+(deftest ^:parallel UniqueUUIDs-schema-test
+  (is (not (mc/explain lib.schema.util/UniqueUUIDs query-with-no-duplicate-uuids)))
+  (is (mc/explain lib.schema.util/UniqueUUIDs query-with-duplicate-uuids))
+  (is (= ["Duplicate :lib/uuid \"00000000-0000-0000-0000-000000000001\""]
+         (me/humanize (mc/explain lib.schema.util/UniqueUUIDs query-with-duplicate-uuids)))))

--- a/test/metabase/lib/schema/util_test.cljc
+++ b/test/metabase/lib/schema/util_test.cljc
@@ -1,0 +1,53 @@
+(ns metabase.lib.schema.util-test
+  (:require
+   [clojure.test :refer [are deftest]]
+   [metabase.lib.schema.util :as lib.schema.util]))
+
+(defn- query [uuid-1 uuid-2]
+  {:lib/type :mbql/query
+   :type     :pipeline
+   :database 1
+   :stages   [{:lib/type     :mbql.stage/mbql
+               :source-table 2
+               :filter       [:=
+                              {:lib/uuid "00000000-0000-0000-0000-000000000010"}
+                              [:field
+                               {:lib/uuid uuid-1, :base-type :type/Text}
+                               3]
+                              4]}
+              {:lib/type :mbql.stage/mbql
+               :filter   [:=
+                          {:lib/uuid "00000000-0000-0000-0000-000000000020"}
+                          [:field
+                           {:lib/uuid uuid-2, :base-type :type/Text}
+                           "my_field"]
+                          4]}]})
+
+(def query-with-no-duplicate-uuids
+  (query "00000000-0000-0000-0000-000000000001"
+         "00000000-0000-0000-0000-000000000002"))
+
+(def query-with-duplicate-uuids
+  (query "00000000-0000-0000-0000-000000000001"
+         "00000000-0000-0000-0000-000000000001"))
+
+(deftest ^:parallel collect-uuids-test
+  (are [query expected-uuids] (= expected-uuids
+                                 (sort (lib.schema.util/collect-uuids query)))
+    query-with-no-duplicate-uuids
+    ["00000000-0000-0000-0000-000000000001"
+     "00000000-0000-0000-0000-000000000002"
+     "00000000-0000-0000-0000-000000000010"
+     "00000000-0000-0000-0000-000000000020"]
+
+    query-with-duplicate-uuids
+    ["00000000-0000-0000-0000-000000000001"
+     "00000000-0000-0000-0000-000000000001"
+     "00000000-0000-0000-0000-000000000010"
+     "00000000-0000-0000-0000-000000000020"]))
+
+(deftest ^:parallel unique-uuids?-test
+  (are [query expected] (= expected
+                           (lib.schema.util/unique-uuids? query))
+    query-with-no-duplicate-uuids true
+    query-with-duplicate-uuids    false))

--- a/test/metabase/lib/schema_test.cljc
+++ b/test/metabase/lib/schema_test.cljc
@@ -2,6 +2,7 @@
   (:require
    [clojure.test :refer [deftest is testing]]
    [malli.core :as mc]
+   [malli.error :as me]
    [metabase.lib.schema :as lib.schema]
    [metabase.lib.schema.util-test :as lib.schema.util-test]))
 
@@ -9,4 +10,6 @@
   (testing "sanity check: make sure query is valid with different UUIDs"
     (is (not (mc/explain ::lib.schema/query lib.schema.util-test/query-with-no-duplicate-uuids))))
   (testing "should not validate if UUIDs are duplicated"
-    (is (mc/explain ::lib.schema/query lib.schema.util-test/query-with-duplicate-uuids))))
+    (is (mc/explain ::lib.schema/query lib.schema.util-test/query-with-duplicate-uuids))
+    (is (= ["Duplicate :lib/uuid \"00000000-0000-0000-0000-000000000001\""]
+           (me/humanize (mc/explain ::lib.schema/query lib.schema.util-test/query-with-duplicate-uuids))))))

--- a/test/metabase/lib/schema_test.cljc
+++ b/test/metabase/lib/schema_test.cljc
@@ -1,0 +1,12 @@
+(ns metabase.lib.schema-test
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [malli.core :as mc]
+   [metabase.lib.schema :as lib.schema]
+   [metabase.lib.schema.util-test :as lib.schema.util-test]))
+
+(deftest ^:parallel disallow-duplicate-uuids-test
+  (testing "sanity check: make sure query is valid with different UUIDs"
+    (is (not (mc/explain ::lib.schema/query lib.schema.util-test/query-with-no-duplicate-uuids))))
+  (testing "should not validate if UUIDs are duplicated"
+    (is (mc/explain ::lib.schema/query lib.schema.util-test/query-with-duplicate-uuids))))


### PR DESCRIPTION
Resolves #28722

Adds a new restriction to the `:metabase.lib.schema/query` schema that all `:lib/uuid`s in the query have to be unique.

Adding another clause to a query with a duplicate UUID should be considered wrong, because it defeats the purpose of having the UUIDs in the first place. I don't think we're doing this anywhere right now, but putting this restriction in place will catch any bugs as they pop up so we don't accidentally introduce any.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/29696)
<!-- Reviewable:end -->
