### PR TITLE
add menu to `TabButton`

### DIFF
--- a/frontend/src/metabase/core/components/Tab/utils.ts
+++ b/frontend/src/metabase/core/components/Tab/utils.ts
@@ -5,3 +5,7 @@ export function getTabId<T>(idPrefix: string, value: T): string {
 export function getTabPanelId<T>(idPrefix: string, value: T): string {
   return `${idPrefix}-P-${value}`;
 }
+
+export function getTabButtonLabelId<T>(idPrefix: string, value: T): string {
+  return `${idPrefix}-B-L-${value}`;
+}

--- a/frontend/src/metabase/core/components/TabButton/TabButton.styled.tsx
+++ b/frontend/src/metabase/core/components/TabButton/TabButton.styled.tsx
@@ -1,6 +1,8 @@
 import styled from "@emotion/styled";
+import { css } from "@emotion/react";
 
 import { color } from "metabase/lib/colors";
+import Button from "metabase/core/components/Button";
 
 export interface TabButtonProps {
   isSelected?: boolean;
@@ -14,6 +16,8 @@ export const TabButtonLabel = styled.div`
 `;
 
 export const TabButtonRoot = styled.button<TabButtonProps>`
+  display: flex;
+
   padding: 1rem 0;
 
   color: ${props => (props.isSelected ? color("brand") : color("text-dark"))};
@@ -24,4 +28,52 @@ export const TabButtonRoot = styled.button<TabButtonProps>`
 
   border-bottom: 3px solid
     ${props => (props.isSelected ? color("brand") : "transparent")};
+`;
+
+export const MenuButton = styled(Button)<TabButtonProps & { isOpen: boolean }>`
+  transition: background-color 0s;
+
+  border: none;
+
+  padding: 0.25rem;
+  margin-left: 0.25rem;
+
+  ${props =>
+    props.isSelected &&
+    css`
+      color: ${color("brand")};
+    `}
+
+  ${props =>
+    props.isOpen &&
+    css`
+      color: ${color("brand")};
+      background-color: ${color("bg-medium")};
+    `}
+  &:hover,:focus {
+    color: ${color("brand")};
+    background-color: ${color("bg-medium")};
+  }
+`;
+
+export const MenuContent = styled.ul`
+  padding: 0.5rem;
+`;
+
+export const MenuItem = styled.li`
+  width: 100%;
+  padding: 0.85em 1.45em;
+  border-radius: 0.5em;
+
+  color: ${color("text-dark")};
+  font-weight: 700;
+  text-align: start;
+  text-decoration: none;
+
+  cursor: pointer;
+  &:focus,
+  :hover {
+    color: ${color("brand")};
+    background-color: ${color("bg-light")};
+  }
 `;

--- a/frontend/src/metabase/core/components/TabButton/TabButton.unit.spec.tsx
+++ b/frontend/src/metabase/core/components/TabButton/TabButton.unit.spec.tsx
@@ -1,0 +1,47 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { getIcon } from "__support__/ui";
+
+import TabRow from "../TabRow";
+import TabButton from "./TabButton";
+
+function setup() {
+  const action = jest.fn();
+  const value = "some_value";
+
+  render(
+    <TabRow>
+      <TabButton
+        value={value}
+        menuItems={[
+          { label: "first item", action: (context, value) => action(value) },
+        ]}
+      >
+        Tab 1
+      </TabButton>
+    </TabRow>,
+  );
+  return { action, value };
+}
+
+describe("TabButton", () => {
+  it("should open the menu upon clicking the chevron", async () => {
+    setup();
+
+    userEvent.click(getIcon("chevrondown"));
+
+    expect(
+      await screen.findByRole("option", { name: "first item" }),
+    ).toBeInTheDocument();
+  });
+
+  it("should call the action function upon clicking an item in the menu", async () => {
+    const { action, value } = setup();
+
+    userEvent.click(getIcon("chevrondown"));
+    (await screen.findByRole("option", { name: "first item" })).click();
+
+    expect(action).toHaveBeenCalledWith(value);
+  });
+});

--- a/frontend/src/metabase/core/components/TabButton/TabButtonMenu.tsx
+++ b/frontend/src/metabase/core/components/TabButton/TabButtonMenu.tsx
@@ -1,0 +1,47 @@
+import React, { useContext } from "react";
+import { TabContext } from "../Tab/TabContext";
+import { getTabButtonLabelId } from "../Tab/utils";
+import {
+  TabButtonMenuAction,
+  TabButtonMenuItem,
+  TabButtonValue,
+} from "./TabButton";
+import { MenuContent, MenuItem } from "./TabButton.styled";
+
+interface TabButtonMenuProps {
+  menuItems: TabButtonMenuItem[];
+  value?: TabButtonValue;
+  closePopover: () => void;
+}
+
+export default function TabButtonMenu({
+  menuItems,
+  value,
+  closePopover,
+}: TabButtonMenuProps) {
+  const context = useContext(TabContext);
+
+  const clickHandler = (action: TabButtonMenuAction) => () => {
+    action(context, value);
+    closePopover();
+  };
+
+  return (
+    <MenuContent
+      role="listbox"
+      aria-labelledby={getTabButtonLabelId(context.idPrefix, value)}
+      tabIndex={0}
+    >
+      {menuItems.map(({ label, action }) => (
+        <MenuItem
+          key={label}
+          onClick={clickHandler(action)}
+          role="option"
+          tabIndex={0}
+        >
+          {label}
+        </MenuItem>
+      ))}
+    </MenuContent>
+  );
+}

--- a/frontend/src/metabase/core/components/TabButton/index.ts
+++ b/frontend/src/metabase/core/components/TabButton/index.ts
@@ -1,1 +1,2 @@
 export { default } from "./TabButton";
+export * from "./TabButton";

--- a/frontend/src/metabase/core/components/TabRow/TabRow.stories.tsx
+++ b/frontend/src/metabase/core/components/TabRow/TabRow.stories.tsx
@@ -1,8 +1,11 @@
-import React from "react";
+import React, { useState } from "react";
 import type { ComponentStory } from "@storybook/react";
 import { useArgs } from "@storybook/client-api";
 
-import TabButton from "../TabButton";
+import TabButton, {
+  TabButtonMenuItem,
+  TabButtonMenuAction,
+} from "../TabButton";
 import TabLink from "../TabLink";
 import TabRow from "./TabRow";
 
@@ -12,6 +15,9 @@ export default {
 };
 
 const sampleStyle = {
+  display: "flex",
+  flexDirection: "column" as const,
+  gap: "8px",
   maxWidth: "800px",
   padding: "10px",
   border: "1px solid #ccc",
@@ -20,18 +26,42 @@ const sampleStyle = {
 const Template: ComponentStory<typeof TabRow> = args => {
   const [{ value }, updateArgs] = useArgs();
   const handleChange = (value: unknown) => updateArgs({ value });
+  const [message, setMessage] = useState("");
+
+  const action: TabButtonMenuAction = ({ value: selectedValue }, value) =>
+    setMessage(
+      `Clicked ${value}, currently selected value is ${selectedValue}`,
+    );
+
+  const menuItems: TabButtonMenuItem[] = [
+    {
+      label: "Click me!",
+      action,
+    },
+    { label: "Or me", action },
+    { label: "Clear", action: () => setMessage("") },
+  ];
 
   return (
     <div style={sampleStyle}>
       <TabRow {...args} value={value} onChange={handleChange}>
-        <TabButton value={1}>Tab 1</TabButton>
+        <TabButton value={1} menuItems={menuItems}>
+          Tab 1
+        </TabButton>
         <TabButton value={2}>Tab 2</TabButton>
-        <TabButton value={3}>Tab 3</TabButton>
+        <TabButton value={3} menuItems={menuItems}>
+          Tab 3
+        </TabButton>
         <TabButton value={4}>Tab 4</TabButton>
-        <TabButton value={5}>Tab 5</TabButton>
+        <TabButton value={5} menuItems={menuItems}>
+          Tab 5
+        </TabButton>
         <TabButton value={6}>Tab 6</TabButton>
-        <TabButton value={7}>Tab 7</TabButton>
+        <TabButton value={7} menuItems={menuItems}>
+          Tab 7
+        </TabButton>
       </TabRow>
+      {message}
     </div>
   );
 };


### PR DESCRIPTION
Part of epic https://github.com/metabase/metabase/issues/29502

### Description

For the dashboard tabs project, we need a menu in the tab UI ([design](https://www.figma.com/file/DuwiUCVo1K4EUBw50pGYPy/Tabs-in-dashboards?node-id=104-5192&t=36a1jPhBGlRVQU5B-4), screenshot below). This PR adds that functionality to the `TabButton` component created in the [previous](https://github.com/metabase/metabase/pull/29669) PR

<img width="266" alt="Screenshot 2023-03-30 at 1 00 53 PM" src="https://user-images.githubusercontent.com/37751258/228950969-1a858177-fb57-42c6-9928-d1bda290ae1a.png">

### How to verify

Describe the steps to verify that the changes are working as expected.

`yarn storybook` -> `TabRow`

### Demo

https://user-images.githubusercontent.com/37751258/228951733-0ddac534-b9e2-414b-ad18-b3a78211f577.mov

### Checklist

- [x] Tests have been added/updated to cover changes in this PR

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/29697)
<!-- Reviewable:end -->
