### PR TITLE
shared.ns/import-fn(s) emit optimized defn forms

### DIFF
--- a/shared/test/metabase/shared/util/namespaces_test.cljc
+++ b/shared/test/metabase/shared/util/namespaces_test.cljc
@@ -1,0 +1,39 @@
+(ns metabase.shared.util.namespaces-test
+  (:require
+   [clojure.test :refer [deftest is testing are]]
+   [metabase.shared.formatting.date :as shared.formatting.date]
+   [metabase.shared.util.namespaces :as shared.ns]))
+
+#?(:clj
+   (deftest ^:synchronized arity-form-test
+     (with-redefs [gensym (fn [prefix]
+                            (symbol (str prefix "1234")))]
+       (are [arglist expected-form] (= expected-form
+                                       (#'shared.ns/arity-form 'imported/fn arglist))
+         '[x]
+         '([x]
+           (imported/fn x))
+
+         '[x y]
+         '([x y]
+           (imported/fn x y))
+
+         '[{:destructured :map} x]
+         '([arg-1234 x]
+           (imported/fn arg-1234 x))
+
+         '[x & more]
+         '([x & more]
+           (apply imported/fn x more))))))
+
+;;; this is just an arbitrarily selected function that has `:export` metadata; we can change it to something else if
+;;; it changes upstream.
+(shared.ns/import-fn ^::extra-key shared.formatting.date/format-for-parameter)
+
+(deftest ^:parallel import-fn-test
+  (testing "Should copy important metadata from the source var"
+    (is (:export (meta #'format-for-parameter)))
+    (is (= (select-keys (meta #'shared.formatting.date/format-for-parameter) [:export :arglists :doc])
+           (select-keys (meta #'format-for-parameter) [:export :arglists :doc]))))
+  (testing "Should preserve metadata on the symbol(s) passed to import-fn(s)"
+    (is (::extra-key (meta #'format-for-parameter)))))


### PR DESCRIPTION
Resolves #29695

- Preserve metadata from the original var we're importing, including `:export`, `:arglists`, and `:doc`
- Preserve metadata attached to the symbols in `import-fn`/`import-fns` forms
- Add tests for this stuff for both JVM Clojure and ClojureScript
- Emit optimized `defn` forms, see below

New macroexpansion:

```clj
(defn format-for-parameter
  "Returns a formatting date string for a datetime used as a parameter to a Card."
  {:arglists '([value options])}
  ([value options] (shared.formatting.date/format-for-parameter value options)))
```

instead of 

```clj
(def format-for-parameter
  "docstring"
  (fn [& args_auto_1234]
    (apply shared.formatting.date/format-for-parameter args_auto_1234)))
```

The main reason I did this was less for performance than it was that the Cljs compiler seems to ignore `:arglists` metadata on a `defn` form, in favor of returning the **actual** arglists, and I wanted my tests to pass in Cljs.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/29700)
<!-- Reviewable:end -->
