### PR TITLE
[CI] Fix `shared` file paths glob

### DIFF
--- a/.github/file-paths.yaml
+++ b/.github/file-paths.yaml
@@ -6,10 +6,10 @@ ci: &ci
   - ".github/**/!(*.md)"
 
 shared_sources: &shared_sources
-  - "shared/src"
+  - "shared/src/**"
 
 shared_specs: &shared_specs
-  - "shared/test"
+  - "shared/test/**"
 
 frontend_sources: &frontend_sources
   - *shared_sources


### PR DESCRIPTION
Here's an example from [a recent PR](https://github.com/metabase/metabase/pull/29700) that shows file-paths were ignoring modified source file in a `shared/src` folder.

```
Run dorny/paths-filter@v2.11.1
Fetching list of changed files for PR#29[7](https://github.com/metabase/metabase/actions/runs/4569045216/jobs/8064823086#step:3:8)00 from Github API
  Invoking listFiles(pull_number: 29700, per_page: 100)
  Received 2 items
  [modified] shared/src/metabase/shared/util/namespaces.clj
  [added] shared/test/metabase/shared/util/namespaces_test.cljc
Detected 2 changed files
Results:
Filter default = false
Filter ci = false
Filter shared_sources = false
Filter shared_specs = false
Filter frontend_sources = false
Filter frontend_specs = false
Filter frontend_all = false
Filter backend_presto_kerberos = false
Filter backend_sources = false
Filter backend_specs = false
Filter backend_all = false
Filter sources = false
Filter e2e_specs = false
Filter e2e_all = false
Filter snowplow = false
Filter documentation = false
Filter yaml = false
Filter codeql = false
Filter i1[8](https://github.com/metabase/metabase/actions/runs/4569045216/jobs/8064823086#step:3:9)n = false
Changes output set to []
```

This PR fixes that behavior by adding a wildcard that includes all folders and files within `shared/src` and `shared/test`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/29714)
<!-- Reviewable:end -->
