### PR TITLE
Don't reset parameter values after modifying dashboards

### DIFF
--- a/frontend/src/metabase/dashboard/actions/save.js
+++ b/frontend/src/metabase/dashboard/actions/save.js
@@ -19,7 +19,7 @@ export const SAVE_DASHBOARD_AND_CARDS =
 
 export const saveDashboardAndCards = createThunkAction(
   SAVE_DASHBOARD_AND_CARDS,
-  function () {
+  function (preserveParameters = false) {
     return async function (dispatch, getState) {
       const state = getState();
       const { dashboards, dashcards, dashboardId } = state.dashboard;
@@ -128,7 +128,7 @@ export const saveDashboardAndCards = createThunkAction(
       await dispatch(Dashboards.actions.update(dashboard));
 
       // make sure that we've fully cleared out any dirty state from editing (this is overkill, but simple)
-      dispatch(fetchDashboard(dashboard.id, null)); // disable using query parameters when saving
+      dispatch(fetchDashboard(dashboard.id, null, preserveParameters)); // disable using query parameters when saving
     };
   },
 );

--- a/frontend/src/metabase/dashboard/components/DashboardInfoSidebar.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardInfoSidebar.tsx
@@ -32,7 +32,7 @@ type DashboardAttributeType = string | number | null | boolean;
 interface DashboardInfoSidebarProps {
   dashboard: Dashboard;
   setDashboardAttribute: (name: string, value: DashboardAttributeType) => void;
-  saveDashboardAndCards: (id: number) => void;
+  saveDashboardAndCards: () => void;
   revisions: RevisionType[];
   currentUser: User;
   revertToRevision: (revision: RevisionType) => void;
@@ -54,25 +54,25 @@ const DashboardInfoSidebar = ({
   const handleDescriptionChange = useCallback(
     (description: string) => {
       setDashboardAttribute("description", description);
-      saveDashboardAndCards(dashboard.id);
+      saveDashboardAndCards();
     },
-    [dashboard.id, saveDashboardAndCards, setDashboardAttribute],
+    [saveDashboardAndCards, setDashboardAttribute],
   );
 
   const handleUpdateCacheTTL = useCallback(
     (cache_ttl: number | null) => {
       setDashboardAttribute("cache_ttl", cache_ttl);
-      saveDashboardAndCards(dashboard.id);
+      saveDashboardAndCards();
     },
-    [dashboard.id, saveDashboardAndCards, setDashboardAttribute],
+    [saveDashboardAndCards, setDashboardAttribute],
   );
 
   const handleToggleAutoApplyFilters = useCallback(
     (isAutoApplyingFilters: boolean) => {
       setDashboardAttribute("auto_apply_filters", isAutoApplyingFilters);
-      saveDashboardAndCards(dashboard.id);
+      saveDashboardAndCards();
     },
-    [dashboard.id, saveDashboardAndCards, setDashboardAttribute],
+    [saveDashboardAndCards, setDashboardAttribute],
   );
 
   const events = useMemo(

--- a/frontend/src/metabase/dashboard/components/DashboardInfoSidebar.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardInfoSidebar.tsx
@@ -32,7 +32,7 @@ type DashboardAttributeType = string | number | null | boolean;
 interface DashboardInfoSidebarProps {
   dashboard: Dashboard;
   setDashboardAttribute: (name: string, value: DashboardAttributeType) => void;
-  saveDashboardAndCards: () => void;
+  saveDashboardAndCards: (preserveParameters: boolean) => void;
   revisions: RevisionType[];
   currentUser: User;
   revertToRevision: (revision: RevisionType) => void;
@@ -54,7 +54,7 @@ const DashboardInfoSidebar = ({
   const handleDescriptionChange = useCallback(
     (description: string) => {
       setDashboardAttribute("description", description);
-      saveDashboardAndCards();
+      saveDashboardAndCards(true);
     },
     [saveDashboardAndCards, setDashboardAttribute],
   );
@@ -62,7 +62,7 @@ const DashboardInfoSidebar = ({
   const handleUpdateCacheTTL = useCallback(
     (cache_ttl: number | null) => {
       setDashboardAttribute("cache_ttl", cache_ttl);
-      saveDashboardAndCards();
+      saveDashboardAndCards(true);
     },
     [saveDashboardAndCards, setDashboardAttribute],
   );
@@ -70,7 +70,7 @@ const DashboardInfoSidebar = ({
   const handleToggleAutoApplyFilters = useCallback(
     (isAutoApplyingFilters: boolean) => {
       setDashboardAttribute("auto_apply_filters", isAutoApplyingFilters);
-      saveDashboardAndCards();
+      saveDashboardAndCards(true);
     },
     [saveDashboardAndCards, setDashboardAttribute],
   );

--- a/frontend/src/metabase/dashboard/components/DashboardInfoSidebar.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardInfoSidebar.tsx
@@ -32,7 +32,7 @@ type DashboardAttributeType = string | number | null | boolean;
 interface DashboardInfoSidebarProps {
   dashboard: Dashboard;
   setDashboardAttribute: (name: string, value: DashboardAttributeType) => void;
-  saveDashboardAndCards: (preserveParameters: boolean) => void;
+  saveDashboardAndCards: (preserveParameters?: boolean) => void;
   revisions: RevisionType[];
   currentUser: User;
   revertToRevision: (revision: RevisionType) => void;

--- a/frontend/src/metabase/dashboard/containers/DashboardHeader.jsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardHeader.jsx
@@ -146,7 +146,7 @@ class DashboardHeader extends Component {
   }
 
   async onSave() {
-    await this.props.saveDashboardAndCards(this.props.dashboard.id);
+    await this.props.saveDashboardAndCards();
     this.onDoneEditing();
   }
 

--- a/frontend/src/metabase/dashboard/containers/DashboardHeader.jsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardHeader.jsx
@@ -145,8 +145,8 @@ class DashboardHeader extends Component {
     );
   }
 
-  async onSave() {
-    await this.props.saveDashboardAndCards();
+  async onSave(preserveParameters = false) {
+    await this.props.saveDashboardAndCards(preserveParameters);
     this.onDoneEditing();
   }
 
@@ -441,7 +441,7 @@ class DashboardHeader extends Component {
         editingButtons={this.getEditingButtons()}
         setDashboardAttribute={setDashboardAttribute}
         onLastEditInfoClick={() => setSidebar({ name: SIDEBAR_NAME.info })}
-        onSave={() => this.onSave()}
+        onSave={() => this.onSave(true)}
       />
     );
   }

--- a/frontend/src/metabase/dashboard/containers/DashboardHeader.jsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardHeader.jsx
@@ -145,7 +145,7 @@ class DashboardHeader extends Component {
     );
   }
 
-  async onSave(preserveParameters = false) {
+  async onSave(preserveParameters) {
     await this.props.saveDashboardAndCards(preserveParameters);
     this.onDoneEditing();
   }


### PR DESCRIPTION
Part of #29267, and probably relates to #5332


### Description

This is supposedly a regression which blocks #29267 milestone from progressing. This is when we update the dashboard settings `auto_apply_filters`, we should keep the filter values.

### How to verify

Run tests in `e2e/test/scenarios/dashboard-filters/old-parameters.cy.spec.js`, and they should all pass.

Or 
1. Create a dashboard and add a question
2. Add a parameter and connect to the added question from 1)
3. Set the parameter value. Ensure everything looks correct
4. Modify dashboard name, description, auto-apply values, or cache TTL (Pro or Enterprise)
5. The parameter value should remain the same.

### Demo

> **Note**
> While watching the demo, I notice the dashboard history bug which seems to be tracked in https://github.com/metabase/metabase/issues/30030 already

#### After

https://user-images.githubusercontent.com/1937582/233677842-5edb3ad2-bbd5-4de0-ac16-d9376166fcf1.mov

#### Before

https://user-images.githubusercontent.com/1937582/233677832-af4c2605-d674-427b-b5c8-3a0c48c4e4dc.mov

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/29729)
<!-- Reviewable:end -->
