### PR TITLE
🚧 WIP | Migrate notebook clauses to tippy popover

### DIFF
--- a/frontend/src/metabase/query_builder/components/notebook/NotebookCell.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/NotebookCell.tsx
@@ -10,7 +10,9 @@ import { alpha } from "metabase/lib/colors";
 
 const CONTAINER_PADDING = "10px";
 
-const _NotebookCell = styled.div`
+type BorderSide = "top" | "right" | "bottom" | "left";
+
+const _NotebookCell = styled.div<{ color: string; padding?: string }>`
   display: flex;
   align-items: center;
   flex-wrap: wrap;
@@ -25,7 +27,10 @@ export const NotebookCell = Object.assign(_NotebookCell, {
   CONTAINER_PADDING,
 });
 
-const NotebookCellItemContainer = styled.div`
+const NotebookCellItemContainer = styled.div<{
+  color: string;
+  inactive?: boolean;
+}>`
   display: flex;
   align-items: center;
   font-weight: bold;
@@ -48,7 +53,12 @@ const NotebookCellItemContainer = styled.div`
   }
 `;
 
-const NotebookCellItemContentContainer = styled.div`
+const NotebookCellItemContentContainer = styled.div<{
+  color: string;
+  inactive?: boolean;
+  border?: BorderSide;
+  roundedCorners: BorderSide[];
+}>`
   display: flex;
   align-items: center;
   padding: ${CONTAINER_PADDING};
@@ -81,7 +91,19 @@ const NotebookCellItemContentContainer = styled.div`
   transition: background 300ms linear;
 `;
 
-export function NotebookCellItem(props) {
+interface NotebookCellItemProps {
+  color: string;
+  inactive?: boolean;
+  readOnly?: boolean;
+  right?: React.ReactNode;
+  containerStyle?: React.CSSProperties;
+  rightContainerStyle?: React.CSSProperties;
+  children?: React.ReactNode;
+  onClick?: React.MouseEventHandler;
+  "data-testid"?: string;
+}
+
+export function NotebookCellItem(props: NotebookCellItemProps) {
   const {
     inactive,
     color,
@@ -94,7 +116,7 @@ export function NotebookCellItem(props) {
   } = props;
 
   const hasRightSide = React.isValidElement(right) && !readOnly;
-  const mainContentRoundedCorners = ["left"];
+  const mainContentRoundedCorners: BorderSide[] = ["left"];
   if (!hasRightSide) {
     mainContentRoundedCorners.push("right");
   }
@@ -130,7 +152,14 @@ export function NotebookCellItem(props) {
 
 NotebookCellItem.displayName = "NotebookCellItem";
 
-export const NotebookCellAdd = ({ initialAddText, ...props }) => (
+interface NotebookCellAddProps extends NotebookCellItemProps {
+  initialAddText?: React.ReactNode;
+}
+
+export const NotebookCellAdd = ({
+  initialAddText,
+  ...props
+}: NotebookCellAddProps) => (
   <NotebookCellItem {...props} inactive={!!initialAddText}>
     {initialAddText || <Icon name="add" className="text-white" />}
   </NotebookCellItem>

--- a/frontend/src/metabase/query_builder/components/notebook/NotebookCell.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/NotebookCell.tsx
@@ -41,6 +41,8 @@ const NotebookCellItemContainer = styled.div<{
   border-color: ${props =>
     props.inactive ? alpha(props.color, 0.25) : "transparent"};
 
+  cursor: ${props => (props.inactive ? "pointer" : "default")};
+
   &:hover {
     border-color: ${props => props.inactive && alpha(props.color, 0.8)};
   }

--- a/frontend/src/metabase/query_builder/components/notebook/NotebookCell.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/NotebookCell.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable react/prop-types */
-import React from "react";
+import React, { forwardRef } from "react";
 
 import styled from "@emotion/styled";
 import { css } from "@emotion/react";
@@ -101,54 +100,60 @@ interface NotebookCellItemProps {
   children?: React.ReactNode;
   onClick?: React.MouseEventHandler;
   "data-testid"?: string;
+  ref?: React.Ref<HTMLDivElement>;
 }
 
-export function NotebookCellItem(props: NotebookCellItemProps) {
-  const {
-    inactive,
-    color,
-    containerStyle,
-    right,
-    rightContainerStyle,
-    children,
-    readOnly,
-    ...restProps
-  } = props;
+export const NotebookCellItem: React.ComponentType<NotebookCellItemProps> =
+  forwardRef(function NotebookCellItem(
+    props: NotebookCellItemProps,
+    ref: React.Ref<HTMLDivElement>,
+  ) {
+    const {
+      inactive,
+      color,
+      containerStyle,
+      right,
+      rightContainerStyle,
+      children,
+      readOnly,
+      ...restProps
+    } = props;
 
-  const hasRightSide = React.isValidElement(right) && !readOnly;
-  const mainContentRoundedCorners: BorderSide[] = ["left"];
-  if (!hasRightSide) {
-    mainContentRoundedCorners.push("right");
-  }
-  return (
-    <NotebookCellItemContainer
-      inactive={inactive}
-      color={color}
-      {...restProps}
-      data-testid={props["data-testid"] ?? "notebook-cell-item"}
-    >
-      <NotebookCellItemContentContainer
+    const hasRightSide = React.isValidElement(right) && !readOnly;
+    const mainContentRoundedCorners: BorderSide[] = ["left"];
+    if (!hasRightSide) {
+      mainContentRoundedCorners.push("right");
+    }
+    return (
+      <NotebookCellItemContainer
         inactive={inactive}
         color={color}
-        roundedCorners={mainContentRoundedCorners}
-        style={containerStyle}
+        {...restProps}
+        data-testid={props["data-testid"] ?? "notebook-cell-item"}
+        ref={ref}
       >
-        {children}
-      </NotebookCellItemContentContainer>
-      {hasRightSide && (
         <NotebookCellItemContentContainer
           inactive={inactive}
           color={color}
-          border="left"
-          roundedCorners={["right"]}
-          style={rightContainerStyle}
+          roundedCorners={mainContentRoundedCorners}
+          style={containerStyle}
         >
-          {right}
+          {children}
         </NotebookCellItemContentContainer>
-      )}
-    </NotebookCellItemContainer>
-  );
-}
+        {hasRightSide && (
+          <NotebookCellItemContentContainer
+            inactive={inactive}
+            color={color}
+            border="left"
+            roundedCorners={["right"]}
+            style={rightContainerStyle}
+          >
+            {right}
+          </NotebookCellItemContentContainer>
+        )}
+      </NotebookCellItemContainer>
+    );
+  });
 
 NotebookCellItem.displayName = "NotebookCellItem";
 
@@ -156,13 +161,16 @@ interface NotebookCellAddProps extends NotebookCellItemProps {
   initialAddText?: React.ReactNode;
 }
 
-export const NotebookCellAdd = ({
-  initialAddText,
-  ...props
-}: NotebookCellAddProps) => (
-  <NotebookCellItem {...props} inactive={!!initialAddText}>
-    {initialAddText || <Icon name="add" className="text-white" />}
-  </NotebookCellItem>
-);
+export const NotebookCellAdd: React.ComponentType<NotebookCellAddProps> =
+  forwardRef(
+    (
+      { initialAddText, ...props }: NotebookCellAddProps,
+      ref: React.Ref<HTMLDivElement>,
+    ) => (
+      <NotebookCellItem {...props} inactive={!!initialAddText} ref={ref}>
+        {initialAddText || <Icon name="add" className="text-white" />}
+      </NotebookCellItem>
+    ),
+  );
 
 NotebookCellAdd.displayName = "NotebookCellAdd";

--- a/frontend/src/metabase/query_builder/components/notebook/steps/AggregateStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/AggregateStep.tsx
@@ -22,15 +22,18 @@ function AggregateStep({
       items={query.aggregations()}
       renderName={item => item.displayName()}
       readOnly={readOnly}
-      renderPopover={aggregation => (
+      renderPopover={({ item: aggregation, closePopover }) => (
         <AggregationPopover
           query={query}
           aggregation={aggregation}
-          onChangeAggregation={(newAggregation: IAggregation) =>
-            aggregation
-              ? updateQuery(aggregation.replace(newAggregation))
-              : updateQuery(query.aggregate(newAggregation))
-          }
+          onChangeAggregation={(newAggregation: IAggregation) => {
+            if (aggregation) {
+              updateQuery(aggregation.replace(newAggregation));
+            } else {
+              updateQuery(query.aggregate(newAggregation));
+            }
+            closePopover();
+          }}
         />
       )}
       isLastOpened={isLastOpened}

--- a/frontend/src/metabase/query_builder/components/notebook/steps/AggregateStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/AggregateStep.tsx
@@ -7,18 +7,6 @@ import type { Aggregation as IAggregation } from "metabase-types/types/Query";
 import type { NotebookStepUiComponentProps } from "../types";
 import ClauseStep from "./ClauseStep";
 
-const aggTetherOptions = {
-  attachment: "top left",
-  targetAttachment: "bottom left",
-  offset: "0 10px",
-  constraints: [
-    {
-      to: "scrollParent",
-      attachment: "together",
-    },
-  ],
-};
-
 function AggregateStep({
   color,
   query,
@@ -33,7 +21,6 @@ function AggregateStep({
       initialAddText={t`Pick the metric you want to see`}
       items={query.aggregations()}
       renderName={item => item.displayName()}
-      tetherOptions={aggTetherOptions}
       readOnly={readOnly}
       renderPopover={aggregation => (
         <AggregationPopover

--- a/frontend/src/metabase/query_builder/components/notebook/steps/BreakoutStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/BreakoutStep.tsx
@@ -21,15 +21,18 @@ function BreakoutStep({
       items={query.breakouts()}
       renderName={item => item.displayName() ?? ""}
       readOnly={readOnly}
-      renderPopover={breakout => (
+      renderPopover={({ item: breakout, closePopover }) => (
         <BreakoutPopover
           query={query}
           breakout={breakout}
-          onChangeBreakout={newBreakout =>
-            breakout
-              ? updateQuery(breakout.replace(newBreakout))
-              : updateQuery(query.breakout(newBreakout))
-          }
+          onChangeBreakout={newBreakout => {
+            if (breakout) {
+              updateQuery(breakout.replace(newBreakout));
+            } else {
+              updateQuery(query.breakout(newBreakout));
+            }
+            closePopover();
+          }}
         />
       )}
       isLastOpened={isLastOpened}

--- a/frontend/src/metabase/query_builder/components/notebook/steps/BreakoutStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/BreakoutStep.tsx
@@ -6,18 +6,6 @@ import BreakoutPopover from "metabase/query_builder/components/BreakoutPopover";
 import type { NotebookStepUiComponentProps } from "../types";
 import ClauseStep from "./ClauseStep";
 
-const breakoutTetherOptions = {
-  attachment: "top left",
-  targetAttachment: "bottom left",
-  offset: "10px 0",
-  constraints: [
-    {
-      to: "scrollParent",
-      attachment: "together",
-    },
-  ],
-};
-
 function BreakoutStep({
   color,
   query,
@@ -32,7 +20,6 @@ function BreakoutStep({
       initialAddText={t`Pick a column to group by`}
       items={query.breakouts()}
       renderName={item => item.displayName() ?? ""}
-      tetherOptions={breakoutTetherOptions}
       readOnly={readOnly}
       renderPopover={breakout => (
         <BreakoutPopover

--- a/frontend/src/metabase/query_builder/components/notebook/steps/ClauseStep.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/ClauseStep.styled.tsx
@@ -1,0 +1,17 @@
+import styled from "@emotion/styled";
+import TippyPopoverWithTrigger from "metabase/components/PopoverWithTrigger/TippyPopoverWithTrigger";
+
+export const ClauseStepPopover = styled(TippyPopoverWithTrigger)`
+  .tippy-box,
+  .tippy-content {
+    display: flex;
+  }
+`;
+
+ClauseStepPopover.defaultProps = {
+  sizeToFit: true,
+  disableContentSandbox: true,
+
+  // Popover content is expected handle width on its own
+  maxWidth: Infinity,
+};

--- a/frontend/src/metabase/query_builder/components/notebook/steps/ClauseStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/ClauseStep.tsx
@@ -1,12 +1,11 @@
 import React from "react";
-
 import Icon from "metabase/components/Icon";
-import TippyPopoverWithTrigger from "metabase/components/PopoverWithTrigger/TippyPopoverWithTrigger";
 import {
   NotebookCell,
   NotebookCellAdd,
   NotebookCellItem,
 } from "../NotebookCell";
+import { ClauseStepPopover } from "./ClauseStep.styled";
 
 export type RenderPopoverProps<T> = {
   item?: T;
@@ -42,9 +41,8 @@ const ClauseStep = <T,>({
   return (
     <NotebookCell color={color} data-testid={props["data-testid"]}>
       {items.map((item, index) => (
-        <TippyPopoverWithTrigger
+        <ClauseStepPopover
           key={index}
-          sizeToFit
           renderTrigger={({ onClick }) => (
             <NotebookCellItem
               color={color}
@@ -70,9 +68,8 @@ const ClauseStep = <T,>({
         />
       ))}
       {!readOnly && (
-        <TippyPopoverWithTrigger
+        <ClauseStepPopover
           isInitiallyVisible={isLastOpened}
-          sizeToFit
           renderTrigger={({ onClick }) => (
             <NotebookCellAdd
               color={color}

--- a/frontend/src/metabase/query_builder/components/notebook/steps/ClauseStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/ClauseStep.tsx
@@ -8,11 +8,17 @@ import {
   NotebookCellItem,
 } from "../NotebookCell";
 
+export type RenderPopoverProps<T> = {
+  item?: T;
+  index?: number;
+  closePopover: () => void;
+};
+
 interface ClauseStepProps<T> {
   color: string;
   items: T[];
   renderName: (item: T, index: number) => JSX.Element | string;
-  renderPopover: (item?: T, index?: number) => JSX.Element | null;
+  renderPopover: (props: RenderPopoverProps<T>) => JSX.Element | null;
   canRemove?: (item: T) => boolean;
   isLastOpened?: boolean;
   onRemove?: ((item: T, index: number) => void) | null;
@@ -58,7 +64,9 @@ const ClauseStep = <T,>({
               )}
             </NotebookCellItem>
           )}
-          popoverContent={renderPopover(item, index)}
+          popoverContent={({ closePopover }) =>
+            renderPopover({ item, index, closePopover })
+          }
         />
       ))}
       {!readOnly && (
@@ -72,7 +80,7 @@ const ClauseStep = <T,>({
               onClick={onClick}
             />
           )}
-          popoverContent={renderPopover()}
+          popoverContent={renderPopover}
         />
       )}
     </NotebookCell>

--- a/frontend/src/metabase/query_builder/components/notebook/steps/ClauseStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/ClauseStep.tsx
@@ -1,8 +1,7 @@
 import React from "react";
 
-import type Tether from "tether";
 import Icon from "metabase/components/Icon";
-import PopoverWithTrigger from "metabase/components/PopoverWithTrigger";
+import TippyPopoverWithTrigger from "metabase/components/PopoverWithTrigger/TippyPopoverWithTrigger";
 import {
   NotebookCell,
   NotebookCellAdd,
@@ -18,7 +17,6 @@ interface ClauseStepProps<T> {
   isLastOpened?: boolean;
   onRemove?: ((item: T, index: number) => void) | null;
   initialAddText?: string | null;
-  tetherOptions?: Tether.ITetherOptions | null;
   readOnly?: boolean;
   "data-testid"?: string;
 }
@@ -32,18 +30,21 @@ const ClauseStep = <T,>({
   onRemove = null,
   isLastOpened = false,
   initialAddText = null,
-  tetherOptions = null,
   readOnly,
   ...props
 }: ClauseStepProps<T>): JSX.Element => {
   return (
     <NotebookCell color={color} data-testid={props["data-testid"]}>
       {items.map((item, index) => (
-        <PopoverWithTrigger
-          tetherOptions={tetherOptions}
+        <TippyPopoverWithTrigger
           key={index}
-          triggerElement={
-            <NotebookCellItem color={color} readOnly={readOnly}>
+          sizeToFit
+          renderTrigger={({ onClick }) => (
+            <NotebookCellItem
+              color={color}
+              onClick={onClick}
+              readOnly={readOnly}
+            >
               {renderName(item, index)}
               {!readOnly && onRemove && (!canRemove || canRemove(item)) && (
                 <Icon
@@ -56,26 +57,23 @@ const ClauseStep = <T,>({
                 />
               )}
             </NotebookCellItem>
-          }
-          sizeToFit
-        >
-          {renderPopover(item, index)}
-        </PopoverWithTrigger>
+          )}
+          popoverContent={renderPopover(item, index)}
+        />
       ))}
       {!readOnly && (
-        <PopoverWithTrigger
-          triggerElement={
+        <TippyPopoverWithTrigger
+          isInitiallyVisible={isLastOpened}
+          sizeToFit
+          renderTrigger={({ onClick }) => (
             <NotebookCellAdd
               color={color}
               initialAddText={items.length === 0 && initialAddText}
+              onClick={onClick}
             />
-          }
-          tetherOptions={tetherOptions}
-          sizeToFit
-          isInitiallyOpen={isLastOpened}
-        >
-          {renderPopover()}
-        </PopoverWithTrigger>
+          )}
+          popoverContent={renderPopover()}
+        />
       )}
     </NotebookCell>
   );

--- a/frontend/src/metabase/query_builder/components/notebook/steps/ExpressionStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/ExpressionStep.tsx
@@ -23,18 +23,21 @@ const ExpressionStep = ({
       items={items}
       renderName={({ name }) => name}
       readOnly={readOnly}
-      renderPopover={item => (
+      renderPopover={({ item, closePopover }) => (
         <ExpressionWidget
           query={query}
           name={item?.name}
           expression={item?.expression}
           withName
           onChangeExpression={(newName, newExpression) => {
-            item?.expression
-              ? updateQuery(
-                  query.updateExpression(newName, newExpression, item.name),
-                )
-              : updateQuery(query.addExpression(newName, newExpression));
+            if (item?.expression) {
+              updateQuery(
+                query.updateExpression(newName, newExpression, item.name),
+              );
+            } else {
+              updateQuery(query.addExpression(newName, newExpression));
+            }
+            closePopover();
           }}
           reportTimezone={reportTimezone}
         />

--- a/frontend/src/metabase/query_builder/components/notebook/steps/FilterStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/FilterStep.tsx
@@ -20,15 +20,18 @@ function FilterStep({
       items={query.filters()}
       renderName={item => item.displayName()}
       readOnly={readOnly}
-      renderPopover={filter => (
+      renderPopover={({ item: filter, closePopover }) => (
         <FilterPopover
           query={query}
           filter={filter}
-          onChangeFilter={newFilter =>
-            filter
-              ? updateQuery(filter.replace(newFilter))
-              : updateQuery(query.filter(newFilter))
-          }
+          onChangeFilter={newFilter => {
+            if (filter) {
+              updateQuery(filter.replace(newFilter));
+            } else {
+              updateQuery(query.filter(newFilter));
+            }
+            closePopover();
+          }}
         />
       )}
       isLastOpened={isLastOpened}

--- a/frontend/src/metabase/query_builder/components/notebook/steps/SortStep/SortStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/SortStep/SortStep.tsx
@@ -47,15 +47,18 @@ function SortStep({
           onChange={handleUpdateSort}
         />
       )}
-      renderPopover={(sort, index) => (
+      renderPopover={({ item: sort, index, closePopover }) => (
         <SortPopover
           query={query}
           sort={sort}
           onChangeSort={newSort => {
             const isUpdate = sort && typeof index === "number";
-            return isUpdate
-              ? handleUpdateSort(newSort, index)
-              : handleAddSort(newSort);
+            if (isUpdate) {
+              handleUpdateSort(newSort, index);
+            } else {
+              handleAddSort(newSort);
+            }
+            closePopover();
           }}
         />
       )}


### PR DESCRIPTION
Epic #18951

Migrates notebook editor's `ClauseStep` component to `TippyPopoverWithTrigger` instead of a deprecated `PopoverWithTrigger`.

The key win here is that tippy popovers are lazy by default. Rendering all popover contents at once is causing performance issues for complex queries with many clauses (#12378). This won't fix the issue though, because `DataStep` and `JoinStep` still use the deprecated `PopoverWithTrigger` component (a child of `DataSelector`). But we should be in a much better place performance-wise now.

### How to verify

1. Open `/question/:id/notebook`
2. Play around with filters, summarization, and sorting clauses. Ensure everything works as on `master`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/29730)
<!-- Reviewable:end -->
