### PR TITLE
docs - add link to cloud docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -182,7 +182,7 @@ Metabase's reference documentation.
 
 ### Cloud
 
-- [Documentation for Metabase Cloud and Store](https:www.metabase.com/docs/latest/cloud/start)
+- [Documentation for Metabase Cloud and Store](https://www.metabase.com/docs/latest/cloud/start)
 
 ### Metabase API
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -180,6 +180,10 @@ Metabase's reference documentation.
 - [Auditing tools](./usage-and-performance-tools/audit.md)
 - [Admin tools](./usage-and-performance-tools/tools.md)
 
+### Cloud
+
+- [Documentation for Metabase Cloud and Store](https:www.metabase.com/docs/latest/cloud/start)
+
 ### Metabase API
 
 - [Metabase API documentation](./api-documentation.md)


### PR DESCRIPTION
We're nesting cloud docs in our documentation for discoverability. The sidebar relies on the docs README to build its nav. This PR adds a mention of cloud and uses the full URL, as the cloud docs aren't written in this repo (to avoid versioning).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/29733)
<!-- Reviewable:end -->
