### PR TITLE
Fix semantics of group mapping query

### DIFF
--- a/src/metabase/integrations/common.clj
+++ b/src/metabase/integrations/common.clj
@@ -25,9 +25,11 @@
         user-id            (u/the-id user-or-id)
         current-group-ids  (when (seq mapped-group-ids)
                              (t2/select-fn-set :group_id PermissionsGroupMembership
-                                               :user_id  user-id
-                                               :group_id [:in mapped-group-ids]
-                                               :group_id [:not-in excluded-group-ids]))
+                                               {:where
+                                                [:and
+                                                 [:= :user_id user-id]
+                                                 [:in :group_id mapped-group-ids]
+                                                 [:not-in :group_id excluded-group-ids]]}))
         new-group-ids      (set/intersection (set (map u/the-id new-groups-or-ids))
                                              mapped-group-ids)
         ;; determine what's different between current mapped groups and new mapped groups

--- a/test/metabase/integrations/common_test.clj
+++ b/test/metabase/integrations/common_test.clj
@@ -98,9 +98,10 @@
                  (group-memberships user)))))
 
       (testing "but it's ignored if admin is not in mappings"
-        (with-user-in-groups [user [(perms-group/admin)]]
-          (integrations.common/sync-group-memberships! user #{} #{})
-          (is (= #{"All Users" "Administrators"}
+        (with-user-in-groups [group {:name (str ::group)}
+                              user  [(perms-group/admin)]]
+          (integrations.common/sync-group-memberships! user #{group} #{group})
+          (is (= #{"All Users" "Administrators" ":metabase.integrations.common-test/group"}
                  (group-memberships user)))))
 
       (testing "add admin role if the users are mapped to it"

--- a/test/metabase/integrations/common_test.clj
+++ b/test/metabase/integrations/common_test.clj
@@ -98,16 +98,22 @@
                  (group-memberships user)))))
 
       (testing "but it's ignored if admin is not in mappings"
-        (with-user-in-groups [group {:name (str ::group)}
-                              user  [(perms-group/admin)]]
-          (integrations.common/sync-group-memberships! user #{group} #{group})
-          (is (= #{"All Users" "Administrators" ":metabase.integrations.common-test/group"}
+        (with-user-in-groups [user [(perms-group/admin)]]
+          (integrations.common/sync-group-memberships! user #{} #{})
+          (is (= #{"All Users" "Administrators"}
                  (group-memberships user)))))
 
       (testing "add admin role if the users are mapped to it"
         (with-user-in-groups [user []]
           (integrations.common/sync-group-memberships! user #{(perms-group/admin)} #{(perms-group/admin)})
           (is (= #{"All Users" "Administrators"}
+                 (group-memberships user)))))
+
+      (testing "unmapped admin group is ignored even if other groups are added (#29718)"
+        (with-user-in-groups [group {:name (str ::group)}
+                              user  [(perms-group/admin)]]
+          (integrations.common/sync-group-memberships! user #{group} #{group})
+          (is (= #{"All Users" "Administrators" ":metabase.integrations.common-test/group"}
                  (group-memberships user)))))))
 
   (testing "Make sure the delete last admin exception is catched"


### PR DESCRIPTION
The semantics of this query changed after switching to toucan 2 in https://github.com/metabase/metabase/pull/27688 — basically, the second `:group_id` condition started overwriting the first one, instead of them both being applied. I've fixed the query to just use a honeysql `:where` form and added a test that would have caught this issue.

Resolves https://github.com/metabase/metabase/issues/29718

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/29738)
<!-- Reviewable:end -->
