### PR TITLE
Detect types for empty CSV files appropriately

### DIFF
--- a/src/metabase/csv.clj
+++ b/src/metabase/csv.clj
@@ -84,7 +84,7 @@
     (->> rows
          (map row->types)
          (map (partial pad column-count))
-         (reduce coalesce-types)
+         (reduce coalesce-types (repeat column-count nil))
          (map #(or % ::text))
          (map vector normalized-header)
          (ordered-map/ordered-map))))

--- a/test/metabase/csv_test.clj
+++ b/test/metabase/csv_test.clj
@@ -111,7 +111,16 @@
              (keys
               (csv/detect-schema
                (csv-file-with [header
-                               "Luke,ah'm,yer,da,,,missing,columns,should,not,matter"]))))))))
+                               "Luke,ah'm,yer,da,,,missing,columns,should,not,matter"])))))))
+  (testing "Empty contents (with header) are okay"
+      (is (= {"name"     text-type
+              "is_jedi_" text-type}
+             (csv/detect-schema
+              (csv-file-with ["Name, Is Jedi?"])))))
+  (testing "Completely empty contents are okay"
+      (is (= {}
+             (csv/detect-schema
+              (csv-file-with [""]))))))
 
 (deftest file->table-name-test
   (testing "File name is slugified"


### PR DESCRIPTION
We'll probably detect completely empty files elsewhere and say something about it, but the type detector shouldn't barf in any case.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/29754)
<!-- Reviewable:end -->
