### PR TITLE
Fix not being able to open a card from a dashboard with sandboxing

### DIFF
--- a/e2e/test/scenarios/dashboard/click-behavior.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/click-behavior.cy.spec.js
@@ -9,6 +9,7 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
     restore();
     cy.signInAsAdmin();
     cy.intercept("POST", "/api/dataset").as("dataset");
+    cy.intercept("POST", "/api/card/*/query").as("cardQuery");
   });
 
   it("should show filters defined on a question with filter pass-thru (metabase#15993)", () => {
@@ -177,8 +178,8 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
     });
 
     cy.findByTestId("gauge-arc-1").click();
-    cy.wait("@dataset");
-    cy.findByText("Orders");
+    cy.wait("@cardQuery");
+    cy.findByDisplayValue("Orders").should("be.visible");
   });
 
   it("should navigate to a target from a progress card (metabase#23137)", () => {
@@ -195,8 +196,8 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
     });
 
     cy.findByTestId("progress-bar").click();
-    cy.wait("@dataset");
-    cy.findByText("Orders");
+    cy.wait("@cardQuery");
+    cy.findByDisplayValue("Orders").should("be.visible");
   });
 });
 

--- a/e2e/test/scenarios/dashboard/click-behavior.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/click-behavior.cy.spec.js
@@ -8,7 +8,6 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();
-    cy.intercept("POST", "/api/dataset").as("dataset");
     cy.intercept("POST", "/api/card/*/query").as("cardQuery");
   });
 

--- a/e2e/test/scenarios/dashboard/click-behavior.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/click-behavior.cy.spec.js
@@ -8,7 +8,7 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();
-    cy.intercept("POST", "/api/card/*/query").as("cardQuery");
+    cy.intercept("POST", "/api/dataset").as("dataset");
   });
 
   it("should show filters defined on a question with filter pass-thru (metabase#15993)", () => {
@@ -177,8 +177,8 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
     });
 
     cy.findByTestId("gauge-arc-1").click();
-    cy.wait("@cardQuery");
-    cy.findByDisplayValue("Orders").should("be.visible");
+    cy.wait("@dataset");
+    cy.findByText("Orders");
   });
 
   it("should navigate to a target from a progress card (metabase#23137)", () => {
@@ -195,8 +195,8 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
     });
 
     cy.findByTestId("progress-bar").click();
-    cy.wait("@cardQuery");
-    cy.findByDisplayValue("Orders").should("be.visible");
+    cy.wait("@dataset");
+    cy.findByText("Orders");
   });
 });
 

--- a/e2e/test/scenarios/dashboard/reproductions/29076-dashboard-card-drill-sandbox.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/reproductions/29076-dashboard-card-drill-sandbox.cy.spec.js
@@ -1,0 +1,30 @@
+import { describeEE, restore, visitDashboard } from "e2e/support/helpers";
+import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
+
+const { PRODUCTS_ID, PRODUCTS } = SAMPLE_DATABASE;
+
+describeEE("issue 29076", () => {
+  beforeEach(() => {
+    restore();
+
+    cy.intercept("/api/dashboard/*/dashcard/*/card/*/query").as("cardQuery");
+
+    cy.signInAsAdmin();
+    cy.sandboxTable({
+      table_id: PRODUCTS_ID,
+      attribute_remappings: {
+        attr_uid: ["dimension", ["field", PRODUCTS.ID, null]],
+      },
+    });
+    cy.signInAsSandboxedUser();
+  });
+
+  it("should be able to drilldown to a saved question in a dashboard with sandboxing (metabase#29076)", () => {
+    visitDashboard(1);
+    cy.wait("@cardQuery");
+
+    cy.findByText("Orders").click();
+    cy.wait("@cardQuery");
+    cy.findByText("Visualization").should("be.visible");
+  });
+});

--- a/frontend/src/metabase-lib/Question.ts
+++ b/frontend/src/metabase-lib/Question.ts
@@ -1377,7 +1377,7 @@ class QuestionInner {
     if (this.isStructured()) {
       const questionWithParameters = this.setParameters(parameters);
 
-      if (!this.query().readOnly()) {
+      if (this.query().isEditable()) {
         return questionWithParameters
           .setParameterValues(parameterValues)
           ._convertParametersToMbql()

--- a/frontend/src/metabase-lib/queries/StructuredQuery.ts
+++ b/frontend/src/metabase-lib/queries/StructuredQuery.ts
@@ -206,8 +206,7 @@ class StructuredQueryInner extends AtomicQuery {
    * Returns true if the database metadata (or lack thererof indicates the user can modify and run this query
    */
   readOnly() {
-    const database = this.database();
-    return database == null || database.native_permissions !== "write";
+    return !this.database();
   }
 
   /* Methods unique to this query type */

--- a/frontend/src/metabase-lib/queries/StructuredQuery.ts
+++ b/frontend/src/metabase-lib/queries/StructuredQuery.ts
@@ -206,7 +206,8 @@ class StructuredQueryInner extends AtomicQuery {
    * Returns true if the database metadata (or lack thererof indicates the user can modify and run this query
    */
   readOnly() {
-    return !this.database();
+    const database = this.database();
+    return database == null || database.native_permissions !== "write";
   }
 
   /* Methods unique to this query type */

--- a/frontend/src/metabase/dashboard/actions/metadata.js
+++ b/frontend/src/metabase/dashboard/actions/metadata.js
@@ -11,11 +11,14 @@ export const loadMetadataForDashboard = dashCards => dispatch => {
     .flatMap(dc => [dc.card].concat(dc.series || []));
 
   dispatch(loadMetadataForCards(cards));
+  dispatch(loadMetadataForLinkedTargets(dashCards));
 };
 
-export const loadMetadataForLinkedTargets =
-  visualizationSettings => async (dispatch, getState) => {
-    const linkTargets = getLinkTargets(visualizationSettings);
+const loadMetadataForLinkedTargets =
+  dashCards => async (dispatch, getState) => {
+    const linkTargets = dashCards.flatMap(card =>
+      getLinkTargets(card.visualization_settings),
+    );
     const fetchRequests = linkTargets
       .map(({ entity, entityId }) =>
         entity.actions.fetch({ id: entityId }, { noEvent: true }),

--- a/frontend/src/metabase/dashboard/actions/metadata.js
+++ b/frontend/src/metabase/dashboard/actions/metadata.js
@@ -10,8 +10,10 @@ export const loadMetadataForDashboard = dashCards => async dispatch => {
     .filter(dc => !isVirtualDashCard(dc)) // exclude text cards
     .flatMap(dc => [dc.card].concat(dc.series || []));
 
-  await dispatch(loadMetadataForCards(cards));
-  await dispatch(loadMetadataForLinkedTargets(dashCards));
+  await Promise.all([
+    dispatch(loadMetadataForCards(cards)),
+    dispatch(loadMetadataForLinkedTargets(dashCards)),
+  ]);
 };
 
 const loadMetadataForCards = cards => (dispatch, getState) => {

--- a/frontend/src/metabase/dashboard/actions/metadata.js
+++ b/frontend/src/metabase/dashboard/actions/metadata.js
@@ -14,6 +14,21 @@ export const loadMetadataForDashboard = dashCards => dispatch => {
   dispatch(loadMetadataForLinkedTargets(dashCards));
 };
 
+const loadMetadataForCards = cards => (dispatch, getState) => {
+  const metadata = getMetadata(getState());
+
+  const questions = cards
+    .filter(card => card.dataset_query) // exclude queries without perms
+    .map(card => new Question(card, metadata));
+
+  return dispatch(
+    loadMetadataForQueries(
+      questions.map(question => question.query()),
+      questions.map(question => question.dependentMetadata()),
+    ),
+  );
+};
+
 const loadMetadataForLinkedTargets =
   dashCards => async (dispatch, getState) => {
     const linkTargets = dashCards.flatMap(card =>
@@ -36,18 +51,3 @@ const loadMetadataForLinkedTargets =
 
     await dispatch(loadMetadataForCards(cards));
   };
-
-const loadMetadataForCards = cards => (dispatch, getState) => {
-  const metadata = getMetadata(getState());
-
-  const questions = cards
-    .filter(card => card.dataset_query) // exclude queries without perms
-    .map(card => new Question(card, metadata));
-
-  return dispatch(
-    loadMetadataForQueries(
-      questions.map(question => question.query()),
-      questions.map(question => question.dependentMetadata()),
-    ),
-  );
-};

--- a/frontend/src/metabase/dashboard/actions/metadata.js
+++ b/frontend/src/metabase/dashboard/actions/metadata.js
@@ -1,16 +1,44 @@
-import { loadMetadataForQueries } from "metabase/redux/metadata";
+import Questions from "metabase/entities/questions";
 import { getMetadata } from "metabase/selectors/metadata";
-
+import { loadMetadataForQueries } from "metabase/redux/metadata";
+import { getLinkTargets } from "metabase/lib/click-behavior";
 import Question from "metabase-lib/Question";
-
 import { isVirtualDashCard } from "../utils";
 
-export const loadMetadataForDashboard = dashCards => (dispatch, getState) => {
+export const loadMetadataForDashboard = dashCards => dispatch => {
+  const cards = dashCards
+    .filter(dc => !isVirtualDashCard(dc)) // exclude text cards
+    .flatMap(dc => [dc.card].concat(dc.series || []));
+
+  dispatch(loadMetadataForCards(cards));
+};
+
+export const loadMetadataForLinkedTargets =
+  visualizationSettings => async (dispatch, getState) => {
+    const linkTargets = getLinkTargets(visualizationSettings);
+    const fetchRequests = linkTargets
+      .map(({ entity, entityId }) =>
+        entity.actions.fetch({ id: entityId }, { noEvent: true }),
+      )
+      .map(action => dispatch(action).catch(e => console.error(e)));
+
+    await Promise.all(fetchRequests);
+
+    const cards = linkTargets
+      .filter(({ entityType }) => entityType === "question")
+      .map(({ entityId }) =>
+        Questions.selectors.getObject(getState(), { entityId }),
+      )
+      .filter(card => card != null);
+
+    await dispatch(loadMetadataForCards(cards));
+  };
+
+const loadMetadataForCards = cards => (dispatch, getState) => {
   const metadata = getMetadata(getState());
 
-  const questions = dashCards
-    .filter(dc => !isVirtualDashCard(dc) && dc.card.dataset_query) // exclude text cards and queries without perms
-    .flatMap(dc => [dc.card].concat(dc.series || []))
+  const questions = cards
+    .filter(card => card.dataset_query) // exclude queries without perms
     .map(card => new Question(card, metadata));
 
   return dispatch(

--- a/frontend/src/metabase/dashboard/actions/metadata.js
+++ b/frontend/src/metabase/dashboard/actions/metadata.js
@@ -5,13 +5,13 @@ import { getLinkTargets } from "metabase/lib/click-behavior";
 import Question from "metabase-lib/Question";
 import { isVirtualDashCard } from "../utils";
 
-export const loadMetadataForDashboard = dashCards => dispatch => {
+export const loadMetadataForDashboard = dashCards => async dispatch => {
   const cards = dashCards
     .filter(dc => !isVirtualDashCard(dc)) // exclude text cards
     .flatMap(dc => [dc.card].concat(dc.series || []));
 
-  dispatch(loadMetadataForCards(cards));
-  dispatch(loadMetadataForLinkedTargets(dashCards));
+  await dispatch(loadMetadataForCards(cards));
+  await dispatch(loadMetadataForLinkedTargets(dashCards));
 };
 
 const loadMetadataForCards = cards => (dispatch, getState) => {

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx
@@ -7,7 +7,7 @@ import type { LocationDescriptor } from "history";
 import { IconProps } from "metabase/components/Icon";
 
 import Visualization from "metabase/visualizations/components/Visualization";
-import WithVizSettingsData from "metabase/visualizations/hoc/WithVizSettingsData";
+import WithVizSettingsData from "metabase/dashboard/hoc/WithVizSettingsData";
 import { getVisualizationRaw } from "metabase/visualizations";
 
 import QueryDownloadWidget from "metabase/query_builder/components/QueryDownloadWidget";

--- a/frontend/src/metabase/dashboard/hoc/WithVizSettingsData.js
+++ b/frontend/src/metabase/dashboard/hoc/WithVizSettingsData.js
@@ -6,7 +6,6 @@ import _ from "underscore";
 
 import { getUserAttributes } from "metabase/selectors/user";
 import { getLinkTargets } from "metabase/lib/click-behavior";
-import { loadMetadataForLinkedTargets } from "metabase/dashboard/actions/metadata";
 
 // This HOC give access to data referenced in viz settings.
 // We use it to fetch and select entities needed for dashboard drill actions (e.g. clicking through to a question)
@@ -41,27 +40,12 @@ const WithVizSettingsData = ComposedComponent => {
       dispatch => ({ dispatch }),
     )(
       class WithVizSettingsData extends React.Component {
-        fetch() {
-          const { rawSeries, dispatch } = this.props;
+        dashcardSettings({ rawSeries }) {
           const [firstSeries] = rawSeries || [{}];
           const { visualization_settings } = firstSeries.card || {};
-          dispatch(loadMetadataForLinkedTargets(visualization_settings));
+          return visualization_settings;
         }
 
-        componentDidMount() {
-          this.fetch();
-        }
-
-        componentDidUpdate(prevProps) {
-          if (
-            !_.isEqual(
-              this.dashcardSettings(this.props),
-              this.dashcardSettings(prevProps),
-            )
-          ) {
-            this.fetch();
-          }
-        }
         render() {
           return <ComposedComponent {..._.omit(this.props, "dispatch")} />;
         }

--- a/frontend/src/metabase/dashboard/hoc/WithVizSettingsData.js
+++ b/frontend/src/metabase/dashboard/hoc/WithVizSettingsData.js
@@ -8,7 +8,6 @@ import { getUserAttributes } from "metabase/selectors/user";
 import { getLinkTargets } from "metabase/lib/click-behavior";
 
 // This HOC give access to data referenced in viz settings.
-// We use it to fetch and select entities needed for dashboard drill actions (e.g. clicking through to a question)
 const WithVizSettingsData = ComposedComponent => {
   return withRouter(
     connect(

--- a/frontend/src/metabase/dashboard/hoc/WithVizSettingsData.js
+++ b/frontend/src/metabase/dashboard/hoc/WithVizSettingsData.js
@@ -40,12 +40,6 @@ const WithVizSettingsData = ComposedComponent => {
       dispatch => ({ dispatch }),
     )(
       class WithVizSettingsData extends React.Component {
-        dashcardSettings({ rawSeries }) {
-          const [firstSeries] = rawSeries || [{}];
-          const { visualization_settings } = firstSeries.card || {};
-          return visualization_settings;
-        }
-
         render() {
           return <ComposedComponent {..._.omit(this.props, "dispatch")} />;
         }

--- a/frontend/src/metabase/dashboard/hoc/WithVizSettingsData.js
+++ b/frontend/src/metabase/dashboard/hoc/WithVizSettingsData.js
@@ -5,38 +5,12 @@ import { withRouter } from "react-router";
 import _ from "underscore";
 
 import { getUserAttributes } from "metabase/selectors/user";
-
-import Questions from "metabase/entities/questions";
-import Dashboards from "metabase/entities/dashboards";
-
-function hasLinkedQuestionOrDashboard({ type, linkType } = {}) {
-  if (type === "link") {
-    return linkType === "question" || linkType === "dashboard";
-  }
-  return false;
-}
-
-function mapLinkedEntityToEntityQuery({ linkType, targetId }) {
-  return {
-    entity: linkType === "question" ? Questions : Dashboards,
-    entityId: targetId,
-  };
-}
+import { getLinkTargets } from "metabase/lib/click-behavior";
+import { loadMetadataForLinkedTargets } from "metabase/dashboard/actions/metadata";
 
 // This HOC give access to data referenced in viz settings.
 // We use it to fetch and select entities needed for dashboard drill actions (e.g. clicking through to a question)
 const WithVizSettingsData = ComposedComponent => {
-  function getLinkTargets(settings) {
-    const { click_behavior, column_settings = {} } = settings || {};
-    return [
-      click_behavior,
-      ...Object.values(column_settings).map(
-        settings => settings.click_behavior,
-      ),
-    ]
-      .filter(hasLinkedQuestionOrDashboard)
-      .map(mapLinkedEntityToEntityQuery);
-  }
   return withRouter(
     connect(
       (state, props) => ({
@@ -67,19 +41,11 @@ const WithVizSettingsData = ComposedComponent => {
       dispatch => ({ dispatch }),
     )(
       class WithVizSettingsData extends React.Component {
-        dashcardSettings(props) {
-          const [firstSeries] = props.rawSeries || [{}];
-          const { visualization_settings } = firstSeries.card || {};
-          return visualization_settings;
-        }
-
         fetch() {
-          getLinkTargets(this.dashcardSettings(this.props)).forEach(
-            ({ entity, entityId }) =>
-              this.props.dispatch(
-                entity.actions.fetch({ id: entityId }, { noEvent: true }),
-              ),
-          );
+          const { rawSeries, dispatch } = this.props;
+          const [firstSeries] = rawSeries || [{}];
+          const { visualization_settings } = firstSeries.card || {};
+          dispatch(loadMetadataForLinkedTargets(visualization_settings));
         }
 
         componentDidMount() {

--- a/frontend/src/metabase/lib/click-behavior.js
+++ b/frontend/src/metabase/lib/click-behavior.js
@@ -1,5 +1,7 @@
 import { msgid, ngettext, t } from "ttag";
 import { getIn } from "icepick";
+import Questions from "metabase/entities/questions";
+import Dashboards from "metabase/entities/dashboards";
 import Question from "metabase-lib/Question";
 
 export function getClickBehaviorDescription(dashcard) {
@@ -45,4 +47,29 @@ export function hasActionsMenu(dashcard) {
 
 export function isTableDisplay(dashcard) {
   return dashcard?.card?.display === "table";
+}
+
+export function getLinkTargets(settings) {
+  const { click_behavior, column_settings = {} } = settings || {};
+  return [
+    click_behavior,
+    ...Object.values(column_settings).map(settings => settings.click_behavior),
+  ]
+    .filter(hasLinkedQuestionOrDashboard)
+    .map(mapLinkedEntityToEntityQuery);
+}
+
+function hasLinkedQuestionOrDashboard({ type, linkType } = {}) {
+  if (type === "link") {
+    return linkType === "question" || linkType === "dashboard";
+  }
+  return false;
+}
+
+function mapLinkedEntityToEntityQuery({ linkType, targetId }) {
+  return {
+    entity: linkType === "question" ? Questions : Dashboards,
+    entityType: linkType,
+    entityId: targetId,
+  };
 }


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/29076
Reproduces https://github.com/metabase/metabase/issues/29076

The previous check for data permissions worked only when there is no sandboxing applied. With sandboxing, the `database` object is returned by api endpoints but the table might be not. So we change the check from `readOnly` to `isEditable` which also checks for metadata being present, which won't be the same if the user doesn't have self-service access. The query builder also relies on the `isEditable()` check ([example](https://github.com/metabase/metabase/blob/d03cc876e65e3c8215189aa3b92af3dcd5290b3c/frontend/src/metabase/query_builder/components/view/QuestionFilters.jsx#L177)), so it seems like the way forward.

The caveat here is that the change in the permission check affects click actions as well. To make the check work, we need to load metadata for cards referenced in click actions. Most of the PR is dealing with that. If we don't load metadata here `isEditable()` would always return false for the cards outside of the dashboard, like ones added via `Custom Destination -> Question`.

<img width="873" alt="Screenshot 2023-04-03 at 18 47 22" src="https://user-images.githubusercontent.com/8542534/229561209-902acc1d-c1aa-47ff-8836-1c0ced1d0afa.png">


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/29758)
<!-- Reviewable:end -->
