### PR TITLE
refactor `saveDashboardAndCards` thunk to use new `PUT` endpoint for dashcards

### DIFF
--- a/e2e/support/commands/api/composite/createNativeQuestionAndDashboard.js
+++ b/e2e/support/commands/api/composite/createNativeQuestionAndDashboard.js
@@ -5,14 +5,22 @@ Cypress.Commands.add(
       ({ body: { id: questionId } }) => {
         cy.createDashboard(dashboardDetails).then(
           ({ body: { id: dashboardId } }) => {
-            cy.request("POST", `/api/dashboard/${dashboardId}/cards`, {
-              cardId: questionId,
-              // Add sane defaults for the dashboard card size and position
-              row: 0,
-              col: 0,
-              size_x: 8,
-              size_y: 6,
-            });
+            cy.request("PUT", `/api/dashboard/${dashboardId}/cards`, {
+              cards: [
+                {
+                  id: -1,
+                  card_id: questionId,
+                  // Add sane defaults for the dashboard card size and position
+                  row: 0,
+                  col: 0,
+                  size_x: 8,
+                  size_y: 6,
+                },
+              ],
+            }).then(response => ({
+              ...response,
+              body: response.body[0],
+            }));
           },
         );
       },

--- a/e2e/support/commands/api/composite/createQuestionAndDashboard.js
+++ b/e2e/support/commands/api/composite/createQuestionAndDashboard.js
@@ -1,17 +1,26 @@
 Cypress.Commands.add(
   "createQuestionAndDashboard",
-  ({ questionDetails, dashboardDetails } = {}) => {
+  ({ questionDetails, dashboardDetails, cardDetails } = {}) => {
     cy.createQuestion(questionDetails).then(({ body: { id: questionId } }) => {
       cy.createDashboard(dashboardDetails).then(
         ({ body: { id: dashboardId } }) => {
-          cy.request("POST", `/api/dashboard/${dashboardId}/cards`, {
-            cardId: questionId,
-            // Add sane defaults for the dashboard card size
-            row: 0,
-            col: 0,
-            size_x: 8,
-            size_y: 6,
-          });
+          cy.request("PUT", `/api/dashboard/${dashboardId}/cards`, {
+            cards: [
+              {
+                id: -1,
+                card_id: questionId,
+                // Add sane defaults for the dashboard card size
+                row: 0,
+                col: 0,
+                size_x: 8,
+                size_y: 6,
+                ...cardDetails,
+              },
+            ],
+          }).then(response => ({
+            ...response,
+            body: response.body[0],
+          }));
         },
       );
     });

--- a/e2e/support/helpers/e2e-dashboard-helpers.js
+++ b/e2e/support/helpers/e2e-dashboard-helpers.js
@@ -10,6 +10,43 @@ export function getDashboardCard(index = 0) {
   return cy.get(".DashCard").eq(index);
 }
 
+function getDashCardApiUrl(dashId) {
+  return `/api/dashboard/${dashId}/cards`;
+}
+
+const DEFAULT_CARD = {
+  id: -1,
+  row: 0,
+  col: 0,
+  size_x: 8,
+  size_y: 8,
+  visualization_settings: {},
+  parameter_mappings: [],
+};
+
+export function addCardToDashboard({ card_id, dashboard_id, card } = {}) {
+  return cy
+    .request("PUT", getDashCardApiUrl(dashboard_id), {
+      cards: [
+        {
+          ...DEFAULT_CARD,
+          card_id,
+          ...card,
+        },
+      ],
+    })
+    .then(response => ({
+      ...response,
+      body: response.body[0],
+    }));
+}
+
+export function addCardsToDashboard({ dashboard_id, cards }) {
+  return cy.request("PUT", getDashCardApiUrl(dashboard_id), {
+    cards: cards.map(card => ({ ...DEFAULT_CARD, ...card })),
+  });
+}
+
 export function showDashboardCardActions(index = 0) {
   getDashboardCard(index).realHover();
 }

--- a/e2e/support/integration/visit-dashboard.js
+++ b/e2e/support/integration/visit-dashboard.js
@@ -1,4 +1,5 @@
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
+import { addCardToDashboard } from "e2e/support/helpers";
 
 const { PEOPLE_ID, PRODUCTS_ID, PRODUCTS } = SAMPLE_DATABASE;
 
@@ -64,32 +65,6 @@ export function setup() {
     "Dashboard with multiple cards, including markdown",
     "multiDashboard",
   );
-}
-
-function addCardToDashboard({ card_id, dashboard_id, card } = {}) {
-  const url = `/api/dashboard/${dashboard_id}/cards`;
-
-  return cy
-    .request("POST", url, {
-      cardId: card_id,
-    })
-    .then(({ body: { id } }) => {
-      cy.request("PUT", url, {
-        cards: [
-          {
-            id,
-            card_id,
-            row: 0,
-            col: 0,
-            size_x: 8,
-            size_y: 8,
-            visualization_settings: {},
-            parameter_mappings: [],
-            ...card,
-          },
-        ],
-      });
-    });
 }
 
 function addEmptyDashboard(name, alias) {

--- a/e2e/test/scenarios/custom-column/reproductions/19744-cc-after-aggregation-limited-filters.cy.spec.js
+++ b/e2e/test/scenarios/custom-column/reproductions/19744-cc-after-aggregation-limited-filters.cy.spec.js
@@ -4,6 +4,7 @@ import {
   visitQuestionAdhoc,
   popover,
   visitDashboard,
+  addCardToDashboard,
 } from "e2e/support/helpers";
 
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
@@ -72,17 +73,15 @@ function saveQuestion(name) {
 }
 
 function addQuestionToDashboardAndVisit() {
-  cy.createDashboard().then(({ body: { id } }) => {
-    cy.get("@questionId").then(cardId => {
-      cy.request("POST", `/api/dashboard/${id}/cards`, {
-        cardId,
-        row: 0,
-        col: 0,
-        size_x: 16,
-        size_y: 10,
+  cy.createDashboard().then(({ body: { id: dashboard_id } }) => {
+    cy.get("@questionId").then(card_id => {
+      addCardToDashboard({
+        card_id,
+        dashboard_id,
+        card: { size_x: 16, size_y: 10 },
       });
     });
 
-    visitDashboard(id);
+    visitDashboard(dashboard_id);
   });
 }

--- a/e2e/test/scenarios/dashboard-filters/parameters.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/parameters.cy.spec.js
@@ -8,6 +8,7 @@ import {
   getDashboardCard,
   selectDashboardFilter,
   saveDashboard,
+  addCardsToDashboard,
 } from "e2e/support/helpers";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
@@ -25,20 +26,24 @@ describe("scenarios > dashboard > parameters", () => {
 
     cy.createDashboard({ name: "my dash" }).then(({ body: { id } }) => {
       // add the same question twice
-      cy.request("POST", `/api/dashboard/${id}/cards`, {
-        cardId: 2, // Orders, count
-        row: 0,
-        col: 0,
-        size_x: 4,
-        size_y: 4,
-      });
-
-      cy.request("POST", `/api/dashboard/${id}/cards`, {
-        cardId: 2,
-        row: 0,
-        col: 4,
-        size_x: 4,
-        size_y: 4,
+      addCardsToDashboard({
+        dashboard_id: id,
+        cards: [
+          {
+            card_id: 2,
+            row: 0,
+            col: 0,
+            size_x: 4,
+            size_y: 4,
+          },
+          {
+            card_id: 2,
+            row: 0,
+            col: 4,
+            size_x: 4,
+            size_y: 4,
+          },
+        ],
       });
 
       visitDashboard(id);

--- a/e2e/test/scenarios/dashboard-filters/reproductions/12720-no-data-permissions-connected-filter.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/reproductions/12720-no-data-permissions-connected-filter.cy.spec.js
@@ -1,4 +1,9 @@
-import { restore, visitDashboard, filterWidget } from "e2e/support/helpers";
+import {
+  restore,
+  visitDashboard,
+  filterWidget,
+  addCardsToDashboard,
+} from "e2e/support/helpers";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 
 const { ORDERS } = SAMPLE_DATABASE;
@@ -42,53 +47,39 @@ describe("issue 12720", () => {
 
     cy.createNativeQuestion(questionDetails).then(
       ({ body: { id: SQL_ID } }) => {
-        cy.request("POST", "/api/dashboard/1/cards", {
-          cardId: SQL_ID,
-          row: 0,
-          col: 6, // making sure it doesn't overlap the existing card
-          size_x: 5,
-          size_y: 5,
-        }).then(({ body: { id: SQL_DASH_CARD_ID } }) => {
-          cy.log(
-            "Edit both cards (adjust their size and connect them to the filter)",
-          );
-
-          cy.request("PUT", "/api/dashboard/1/cards", {
-            cards: [
-              {
-                id: 1,
-                card_id: 1,
-                row: 0,
-                col: 0,
-                size_x: 5,
-                size_y: 5,
-                parameter_mappings: [
-                  {
-                    parameter_id: dashboardFilter.id,
-                    card_id: 1,
-                    target: ["dimension", ["field", ORDERS.CREATED_AT, null]],
-                  },
-                ],
-                visualization_settings: {},
-              },
-              {
-                id: SQL_DASH_CARD_ID,
-                card_id: SQL_ID,
-                row: 0,
-                col: 6,
-                size_x: 5,
-                size_y: 5,
-                parameter_mappings: [
-                  {
-                    parameter_id: dashboardFilter.id,
-                    card_id: SQL_ID,
-                    target: ["dimension", ["template-tag", "filter"]],
-                  },
-                ],
-                visualization_settings: {},
-              },
-            ],
-          });
+        addCardsToDashboard({
+          dashboard_id: 1,
+          cards: [
+            {
+              card_id: SQL_ID,
+              row: 0,
+              col: 6, // making sure it doesn't overlap the existing card
+              size_x: 5,
+              size_y: 5,
+              parameter_mappings: [
+                {
+                  parameter_id: dashboardFilter.id,
+                  card_id: SQL_ID,
+                  target: ["dimension", ["template-tag", "filter"]],
+                },
+              ],
+            },
+            // add filter to existing card
+            {
+              card_id: 1,
+              row: 0,
+              col: 0,
+              size_x: 5,
+              size_y: 5,
+              parameter_mappings: [
+                {
+                  parameter_id: dashboardFilter.id,
+                  card_id: 1,
+                  target: ["dimension", ["field", ORDERS.CREATED_AT, null]],
+                },
+              ],
+            },
+          ],
         });
       },
     );

--- a/e2e/test/scenarios/dashboard-filters/reproductions/19494-wrong-default-value-multiple-cards-same-question.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/reproductions/19494-wrong-default-value-multiple-cards-same-question.cy.spec.js
@@ -4,6 +4,7 @@ import {
   editDashboard,
   saveDashboard,
   visitDashboard,
+  addCardsToDashboard,
 } from "e2e/support/helpers";
 
 const filter1 = {
@@ -27,13 +28,25 @@ describe("issue 19494", () => {
     restore();
     cy.signInAsAdmin();
 
-    // Add another "Orders" question to the existing "Orders in a dashboard" dashboard
-    cy.request("POST", "/api/dashboard/1/cards", {
-      cardId: 1,
-      row: 0,
-      col: 0,
-      size_x: 9,
-      size_y: 9,
+    // Add two "Orders" questions to the existing "Orders in a dashboard" dashboard
+    addCardsToDashboard({
+      dashboard_id: 1,
+      cards: [
+        {
+          card_id: 1,
+          row: 0,
+          col: 0,
+          size_x: 8,
+          size_y: 8,
+        },
+        {
+          card_id: 1,
+          row: 0,
+          col: 8,
+          size_x: 8,
+          size_y: 8,
+        },
+      ],
     });
 
     // Add two dashboard filters (not yet connected to any of the cards)

--- a/e2e/test/scenarios/dashboard-filters/reproductions/25322-loading-list-values.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/reproductions/25322-loading-list-values.cy.spec.js
@@ -1,4 +1,9 @@
-import { popover, restore, visitDashboard } from "e2e/support/helpers";
+import {
+  addCardToDashboard,
+  popover,
+  restore,
+  visitDashboard,
+} from "e2e/support/helpers";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 
 const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
@@ -44,35 +49,19 @@ const createDashboard = () => {
     .then(({ body: { id: card_id } }) => {
       cy.createDashboard(dashboardDetails).then(
         ({ body: { id: dashboard_id } }) => {
-          cy.request("POST", `/api/dashboard/${dashboard_id}/cards`, {
-            cardId: card_id,
-            row: 0,
-            col: 0,
-            size_x: 4,
-            size_y: 4,
-          }).then(({ body: { id: dashcard_id } }) => {
-            cy.request("PUT", `/api/dashboard/${dashboard_id}/cards`, {
-              cards: [
+          addCardToDashboard({
+            dashboard_id,
+            card_id,
+            card: {
+              parameter_mappings: [
                 {
-                  id: dashcard_id,
                   card_id,
-                  row: 0,
-                  col: 0,
-                  size_x: 4,
-                  size_y: 4,
-                  parameter_mappings: [
-                    {
-                      card_id,
-                      parameter_id: parameterDetails.id,
-                      target: ["dimension", ["field", ORDERS.STATE, null]],
-                    },
-                  ],
+                  parameter_id: parameterDetails.id,
+                  target: ["dimension", ["field", ORDERS.STATE, null]],
                 },
               ],
-            }).then(() => {
-              return { dashboard_id };
-            });
-          });
+            },
+          }).then(() => ({ dashboard_id }));
         },
       );
     });

--- a/e2e/test/scenarios/dashboard-filters/reproductions/8030-reload-card-without-change.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/reproductions/8030-reload-card-without-change.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore, popover } from "e2e/support/helpers";
+import { restore, popover, addCardsToDashboard } from "e2e/support/helpers";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 
 const { ORDERS, ORDERS_ID, PRODUCTS, PRODUCTS_ID } = SAMPLE_DATABASE;
@@ -74,24 +74,25 @@ const createQuestionsAndDashboard = () => {
 };
 
 const setFilterMapping = ({ dashboard_id, card1_id, card2_id }) => {
-  return cy
-    .request("POST", `/api/dashboard/${dashboard_id}/cards`, {
-      cardId: card1_id,
-      row: 0,
-      col: 0,
-      size_x: 4,
-      size_y: 4,
-      parameter_mappings: [
-        {
-          parameter_id: filterDetails.id,
-          card_id: card1_id,
-          target: ["dimension", ["field", PRODUCTS.ID, null]],
-        },
-      ],
-    })
-    .then(() => {
-      return cy.request("POST", `/api/dashboard/${dashboard_id}/cards`, {
-        cardId: card2_id,
+  return addCardsToDashboard({
+    dashboard_id,
+    cards: [
+      {
+        card_id: card1_id,
+        row: 0,
+        col: 0,
+        size_x: 4,
+        size_y: 4,
+        parameter_mappings: [
+          {
+            parameter_id: filterDetails.id,
+            card_id: card1_id,
+            target: ["dimension", ["field", PRODUCTS.ID, null]],
+          },
+        ],
+      },
+      {
+        card_id: card2_id,
         row: 0,
         col: 4,
         size_x: 4,
@@ -103,8 +104,9 @@ const setFilterMapping = ({ dashboard_id, card1_id, card2_id }) => {
             target: ["dimension", ["field", ORDERS.ID, null]],
           },
         ],
-      });
-    });
+      },
+    ],
+  });
 };
 
 const interceptRequests = ({ dashboard_id, card1_id, card2_id }) => {

--- a/e2e/test/scenarios/dashboard/chained-filters.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/chained-filters.cy.spec.js
@@ -3,6 +3,7 @@ import {
   popover,
   showDashboardCardActions,
   visitDashboard,
+  addCardToDashboard,
 } from "e2e/support/helpers";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 
@@ -157,12 +158,9 @@ describe("scenarios > dashboard > chained filter", () => {
         });
 
         // Add previously created question to the dashboard
-        cy.request("POST", `/api/dashboard/${DASHBOARD_ID}/cards`, {
-          cardId: QUESTION_ID,
-          row: 0,
-          col: 0,
-          size_x: 8,
-          size_y: 6,
+        addCardToDashboard({
+          card_id: QUESTION_ID,
+          dashboard_id: DASHBOARD_ID,
         }).then(({ body: { id: DASH_CARD_ID } }) => {
           // Connect filter to that question
           cy.request("PUT", `/api/dashboard/${DASHBOARD_ID}/cards`, {

--- a/e2e/test/scenarios/dashboard/click-behavior.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/click-behavior.cy.spec.js
@@ -1,4 +1,8 @@
-import { restore, visitDashboard } from "e2e/support/helpers";
+import {
+  addCardToDashboard,
+  restore,
+  visitDashboard,
+} from "e2e/support/helpers";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 
 const { ORDERS, ORDERS_ID, PRODUCTS, PRODUCTS_ID, REVIEWS, REVIEWS_ID } =
@@ -22,31 +26,15 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
         ({ body: { id: nativeId } }) => {
           cy.createDashboard().then(({ body: { id: dashboardId } }) => {
             // Add native question to the dashboard
-            cy.request("POST", `/api/dashboard/${dashboardId}/cards`, {
-              cardId: nativeId,
-              row: 0,
-              col: 0,
-              size_x: 12,
-              size_y: 10,
-            }).then(({ body: { id: dashCardId } }) => {
-              // Add click behavior to the dashboard card and point it to the question 1
-              cy.request("PUT", `/api/dashboard/${dashboardId}/cards`, {
-                cards: [
-                  {
-                    id: dashCardId,
-                    card_id: nativeId,
-                    row: 0,
-                    col: 0,
-                    size_x: 12,
-                    size_y: 10,
-                    visualization_settings:
-                      getVisualizationSettings(question1Id),
-                  },
-                ],
-              });
-
-              visitDashboard(dashboardId);
+            addCardToDashboard({
+              dashboard_id: dashboardId,
+              card_id: nativeId,
+              card: {
+                // Add click behavior to the dashboard card and point it to the question 1
+                visualization_settings: getVisualizationSettings(question1Id),
+              },
             });
+            visitDashboard(dashboardId);
           });
         },
       );

--- a/e2e/test/scenarios/dashboard/dashboard-drill.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard-drill.cy.spec.js
@@ -5,6 +5,7 @@ import {
   filterWidget,
   showDashboardCardActions,
   visitDashboard,
+  addCardToDashboard,
 } from "e2e/support/helpers";
 
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
@@ -521,58 +522,41 @@ describe("scenarios > dashboard > dashboard drill", () => {
             },
           ],
         });
+
         cy.log("Add question to the dashboard");
-
-        cy.request("POST", `/api/dashboard/${DASHBOARD_ID}/cards`, {
-          cardId: QUESTION_ID,
-          row: 0,
-          col: 0,
-          size_x: 14,
-          size_y: 10,
-        }).then(({ body: { id: DASH_CARD_ID } }) => {
-          cy.log("Connect dashboard filter to the question");
-
-          cy.request("PUT", `/api/dashboard/${DASHBOARD_ID}/cards`, {
-            cards: [
-              {
-                id: DASH_CARD_ID,
-                card_id: QUESTION_ID,
-                row: 0,
-                col: 0,
-                size_x: 14,
-                size_y: 10,
-                series: [],
-                // Set "Click behavior"
-                visualization_settings: {
-                  click_behavior: {
-                    type: "crossfilter",
-                    parameterMapping: {
-                      "4ff53514": {
-                        source: {
-                          type: "column",
-                          id: "CREATED_AT",
-                          name: "Created At",
-                        },
-                        target: {
-                          type: "parameter",
-                          id: "4ff53514",
-                        },
-                        id: "4ff53514",
-                      },
+        addCardToDashboard({
+          card_id: QUESTION_ID,
+          dashboard_id: DASHBOARD_ID,
+          card: {
+            // Set "Click behavior"
+            visualization_settings: {
+              click_behavior: {
+                type: "crossfilter",
+                parameterMapping: {
+                  "4ff53514": {
+                    source: {
+                      type: "column",
+                      id: "CREATED_AT",
+                      name: "Created At",
                     },
+                    target: {
+                      type: "parameter",
+                      id: "4ff53514",
+                    },
+                    id: "4ff53514",
                   },
                 },
-                // Connect filter and card
-                parameter_mappings: [
-                  {
-                    parameter_id: "4ff53514",
-                    card_id: QUESTION_ID,
-                    target: ["dimension", ["field", REVIEWS.CREATED_AT, null]],
-                  },
-                ],
+              },
+            },
+            // Connect filter and card
+            parameter_mappings: [
+              {
+                parameter_id: "4ff53514",
+                card_id: QUESTION_ID,
+                target: ["dimension", ["field", REVIEWS.CREATED_AT, null]],
               },
             ],
-          });
+          },
         });
 
         visitDashboard(DASHBOARD_ID);
@@ -640,40 +624,24 @@ describe("scenarios > dashboard > dashboard drill", () => {
     }).then(({ body: { id: QUESTION_ID } }) => {
       cy.createDashboard().then(({ body: { id: DASHBOARD_ID } }) => {
         // Add previously added question to the dashboard
-        cy.request("POST", `/api/dashboard/${DASHBOARD_ID}/cards`, {
-          cardId: QUESTION_ID,
-          row: 0,
-          col: 0,
-          size_x: 10,
-          size_y: 6,
-        }).then(({ body: { id: DASH_CARD_ID } }) => {
-          // Add click through behavior to that question
-          cy.request("PUT", `/api/dashboard/${DASHBOARD_ID}/cards`, {
-            cards: [
-              {
-                id: DASH_CARD_ID,
-                card_id: QUESTION_ID,
-                row: 0,
-                col: 0,
-                size_x: 10,
-                size_y: 6,
-                series: [],
-                visualization_settings: {
-                  column_settings: {
-                    [`["ref",["field-id",${PRODUCTS.CATEGORY}]]`]: {
-                      click_behavior: {
-                        type: "link",
-                        linkType: "url",
-                        linkTemplate: "/",
-                        linkTextTemplate: LINK_NAME,
-                      },
-                    },
+        addCardToDashboard({
+          card_id: QUESTION_ID,
+          dashboard_id: DASHBOARD_ID,
+          card: {
+            // Add click through behavior to that question
+            visualization_settings: {
+              column_settings: {
+                [`["ref",["field-id",${PRODUCTS.CATEGORY}]]`]: {
+                  click_behavior: {
+                    type: "link",
+                    linkType: "url",
+                    linkTemplate: "/",
+                    linkTextTemplate: LINK_NAME,
                   },
                 },
-                parameter_mappings: [],
               },
-            ],
-          });
+            },
+          },
         });
 
         visitDashboard(DASHBOARD_ID);
@@ -728,43 +696,30 @@ describe("scenarios > dashboard > dashboard drill", () => {
           ],
         });
         // Add question to the dashboard
-        cy.request("POST", `/api/dashboard/${DASHBOARD_ID}/cards`, {
-          cardId: QUESTION_ID,
-          row: 0,
-          col: 0,
-          size_x: 14,
-          size_y: 10,
-        }).then(({ body: { id: DASH_CARD_ID } }) => {
-          // Connect dashboard filter to the question
-          cy.request("PUT", `/api/dashboard/${DASHBOARD_ID}/cards`, {
-            cards: [
+        addCardToDashboard({
+          card_id: QUESTION_ID,
+          dashboard_id: DASHBOARD_ID,
+          card: {
+            size_x: 14,
+            size_y: 10,
+            // Connect dashboard filter to the question
+            parameter_mappings: [
               {
-                id: DASH_CARD_ID,
+                parameter_id: "354cb21f",
                 card_id: QUESTION_ID,
-                row: 0,
-                col: 0,
-                size_x: 14,
-                size_y: 10,
-                series: [],
-                visualization_settings: {},
-                parameter_mappings: [
-                  {
-                    parameter_id: "354cb21f",
-                    card_id: QUESTION_ID,
-                    target: [
-                      "dimension",
-                      [
-                        "joined-field",
-                        "Products",
-                        ["field-id", PRODUCTS.CREATED_AT],
-                      ],
-                    ],
-                  },
+                target: [
+                  "dimension",
+                  [
+                    "joined-field",
+                    "Products",
+                    ["field-id", PRODUCTS.CREATED_AT],
+                  ],
                 ],
               },
             ],
-          });
+          },
         });
+
         // Set the filter to `previous 30 years` directly through the url
         cy.visit(`/dashboard/${DASHBOARD_ID}?date_filter=past30years`);
       });
@@ -804,32 +759,16 @@ describe("scenarios > dashboard > dashboard drill", () => {
       }).then(({ body: { id: QUESTION2_ID } }) => {
         cy.createDashboard().then(({ body: { id: DASHBOARD_ID } }) => {
           // Add the first question to the dashboard
-          cy.request("POST", `/api/dashboard/${DASHBOARD_ID}/cards`, {
-            cardId: QUESTION1_ID,
-            row: 0,
-            col: 0,
-            size_x: 12,
-            size_y: 8,
-          }).then(({ body: { id: DASH_CARD1_ID } }) => {
-            cy.request("PUT", `/api/dashboard/${DASHBOARD_ID}/cards`, {
-              cards: [
+          addCardToDashboard({
+            card_id: QUESTION1_ID,
+            dashboard_id: DASHBOARD_ID,
+            card: {
+              series: [
                 {
-                  id: DASH_CARD1_ID,
-                  card_id: QUESTION1_ID,
-                  row: 0,
-                  col: 0,
-                  size_x: 12,
-                  size_y: 8,
-                  series: [
-                    {
-                      id: QUESTION2_ID,
-                    },
-                  ],
-                  visualization_settings: {},
-                  parameter_mappings: [],
+                  id: QUESTION2_ID,
                 },
               ],
-            });
+            },
           });
 
           visitDashboard(DASHBOARD_ID);
@@ -1006,39 +945,23 @@ function createDashboard(
         ],
       });
 
-      cy.request("POST", `/api/dashboard/${dashboardId}/cards`, {
-        cardId: questionId,
-        row: 0,
-        col: 0,
-        size_x: 6,
-        size_y: 6,
-      }).then(({ body: { id: dashCardId } }) => {
-        cy.request("PUT", `/api/dashboard/${dashboardId}/cards`, {
-          cards: [
+      addCardToDashboard({
+        card_id: questionId,
+        dashboard_id: dashboardId,
+        card: {
+          parameter_mappings: [
             {
-              id: dashCardId,
+              parameter_id: "e8f79be9",
               card_id: questionId,
-              row: 0,
-              col: 0,
-              size_x: 6,
-              size_y: 6,
-              parameter_mappings: [
-                {
-                  parameter_id: "e8f79be9",
-                  card_id: questionId,
-                  target: [
-                    "dimension",
-                    ["field", PEOPLE.NAME, { "source-field": ORDERS.USER_ID }],
-                  ],
-                },
+              target: [
+                "dimension",
+                ["field", PEOPLE.NAME, { "source-field": ORDERS.USER_ID }],
               ],
-              visualization_settings,
             },
           ],
-        });
-
-        callback(dashboardId);
-      });
+          visualization_settings,
+        },
+      }).then(() => callback(dashboardId));
     },
   );
 }

--- a/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
@@ -11,6 +11,7 @@ import {
   visitDashboard,
   appbar,
   rightSidebar,
+  addCardToDashboard,
 } from "e2e/support/helpers";
 
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
@@ -265,50 +266,34 @@ describe("scenarios > dashboard", () => {
           ],
         });
 
-        // add previously created question to the dashboard
-        cy.request("POST", `/api/dashboard/${dashboardId}/cards`, {
-          cardId: questionId,
-          row: 0,
-          col: 0,
-          size_x: 10,
-          size_y: 8,
-        }).then(({ body: { id: dashCardId } }) => {
-          // connect filter to that question
-          cy.request("PUT", `/api/dashboard/${dashboardId}/cards`, {
-            cards: [
+        addCardToDashboard({
+          card_id: questionId,
+          dashboard_id: dashboardId,
+          card: {
+            parameter_mappings: [
               {
-                id: dashCardId,
+                parameter_id: "92eb69ea",
                 card_id: questionId,
-                row: 0,
-                col: 0,
-                size_x: 10,
-                size_y: 8,
-                parameter_mappings: [
-                  {
-                    parameter_id: "92eb69ea",
-                    card_id: questionId,
-                    target: ["dimension", ["field", PEOPLE.ID, null]],
-                  },
-                ],
-                visualization_settings: {
-                  // set click behavior to update filter (ID)
-                  click_behavior: {
-                    type: "crossfilter",
-                    parameterMapping: {
-                      "92eb69ea": {
-                        id: "92eb69ea",
-                        source: { id: "ID", name: "ID", type: "column" },
-                        target: {
-                          id: "92eb69ea",
-                          type: "parameter",
-                        },
-                      },
+                target: ["dimension", ["field", PEOPLE.ID, null]],
+              },
+            ],
+            visualization_settings: {
+              // set click behavior to update filter (ID)
+              click_behavior: {
+                type: "crossfilter",
+                parameterMapping: {
+                  "92eb69ea": {
+                    id: "92eb69ea",
+                    source: { id: "ID", name: "ID", type: "column" },
+                    target: {
+                      id: "92eb69ea",
+                      type: "parameter",
                     },
                   },
                 },
               },
-            ],
-          });
+            },
+          },
         });
 
         visitDashboard(dashboardId);

--- a/e2e/test/scenarios/dashboard/dashboard_local-only.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard_local-only.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore, filterWidget } from "e2e/support/helpers";
+import { restore, filterWidget, addCardToDashboard } from "e2e/support/helpers";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 
 const { PEOPLE, PEOPLE_ID } = SAMPLE_DATABASE;
@@ -24,57 +24,39 @@ describe("LOCAL TESTING ONLY > dashboard", () => {
     cy.request("GET", "/api/user/current").then(({ body: { id: USER_ID } }) => {
       cy.request("PUT", `/api/user/${USER_ID}`, { locale: "fr" });
     });
-    cy.createQuestion({
-      name: "15694",
-      query: { "source-table": PEOPLE_ID },
-    }).then(({ body: { id: QUESTION_ID } }) => {
-      cy.createDashboard().then(({ body: { id: DASHBOARD_ID } }) => {
-        // Add filter to the dashboard
-        cy.request("PUT", `/api/dashboard/${DASHBOARD_ID}`, {
-          parameters: [
+    cy.createQuestionAndDashboard({
+      questionDetails: {
+        name: "15694",
+        query: { "source-table": PEOPLE_ID },
+      },
+      dashboardDetails: {
+        parameters: [
+          {
+            name: "Location",
+            slug: "location",
+            id: "5aefc725",
+            type: "string/=",
+            sectionId: "location",
+          },
+        ],
+      },
+    }).then(({ body: { card_id, dashboard_id } }) => {
+      addCardToDashboard({
+        card_id,
+        dashboard_id,
+        card: {
+          parameter_mappings: [
             {
-              name: "Location",
-              slug: "location",
-              id: "5aefc725",
-              type: "string/=",
-              sectionId: "location",
+              parameter_id: "5aefc725",
+              card_id,
+              target: ["dimension", ["field", PEOPLE.STATE, null]],
             },
           ],
-        });
-        // Add card to the dashboard
-        cy.request("POST", `/api/dashboard/${DASHBOARD_ID}/cards`, {
-          cardId: QUESTION_ID,
-          row: 0,
-          col: 0,
-          size_x: 12,
-          size_y: 9,
-        }).then(({ body: { id: DASH_CARD_ID } }) => {
-          // Connect filter to the card
-          cy.request("PUT", `/api/dashboard/${DASHBOARD_ID}/cards`, {
-            cards: [
-              {
-                id: DASH_CARD_ID,
-                card_id: QUESTION_ID,
-                row: 0,
-                col: 0,
-                size_x: 12,
-                size_y: 9,
-                visualization_settings: {},
-                parameter_mappings: [
-                  {
-                    parameter_id: "5aefc725",
-                    card_id: QUESTION_ID,
-                    target: ["dimension", ["field", PEOPLE.STATE, null]],
-                  },
-                ],
-              },
-            ],
-          });
-        });
-
-        cy.visit(`/dashboard/${DASHBOARD_ID}?location=AK&location=CA`);
-        filterWidget().contains(/\{0\}/).should("not.exist");
+        },
       });
+
+      cy.visit(`/dashboard/${dashboard_id}?location=AK&location=CA`);
+      filterWidget().contains(/\{0\}/).should("not.exist");
     });
   });
 });

--- a/e2e/test/scenarios/dashboard/permissions.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/permissions.cy.spec.js
@@ -1,6 +1,10 @@
 import _ from "underscore";
 import { assoc } from "icepick";
-import { restore, visitDashboard } from "e2e/support/helpers";
+import {
+  addCardsToDashboard,
+  restore,
+  visitDashboard,
+} from "e2e/support/helpers";
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 
 describe("scenarios > dashboard > permissions", () => {
@@ -65,20 +69,12 @@ describe("scenarios > dashboard > permissions", () => {
     cy.createDashboard().then(({ body: { id: dashId } }) => {
       dashboardId = dashId;
 
-      cy.request("POST", `/api/dashboard/${dashId}/cards`, {
-        cardId: firstQuestionId,
-        row: 0,
-        col: 0,
-        size_x: 6,
-        size_y: 6,
-      }).then(({ body: { id: dashCardIdA } }) => {
-        cy.request("POST", `/api/dashboard/${dashId}/cards`, {
-          cardId: secondQuestionId,
-          row: 0,
-          col: 6,
-          size_x: 6,
-          size_y: 6,
-        });
+      addCardsToDashboard({
+        dashboard_id: dashId,
+        cards: [
+          { card_id: firstQuestionId, row: 0, col: 0, size_x: 6, size_y: 6 },
+          { card_id: secondQuestionId, row: 0, col: 6, size_x: 6, size_y: 6 },
+        ],
       });
     });
   });

--- a/e2e/test/scenarios/dashboard/reproductions/17160-click-behavior-multiple-options.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/reproductions/17160-click-behavior-multiple-options.cy.spec.js
@@ -1,4 +1,8 @@
-import { restore, visitDashboard } from "e2e/support/helpers";
+import {
+  addCardToDashboard,
+  restore,
+  visitDashboard,
+} from "e2e/support/helpers";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 
 const { PRODUCTS, PRODUCTS_ID } = SAMPLE_DATABASE;
@@ -116,12 +120,9 @@ function setup() {
         cy.wrap(dashboardId).as("sourceDashboardId");
 
         // Add the question to the dashboard
-        cy.request("POST", `/api/dashboard/${dashboardId}/cards`, {
-          cardId: questionId,
-          row: 0,
-          col: 0,
-          size_x: 12,
-          size_y: 10,
+        addCardToDashboard({
+          dashboard_id: dashboardId,
+          card_id: questionId,
         }).then(({ body: { id: dashCardId } }) => {
           // Add dashboard filter
           cy.request("PUT", `/api/dashboard/${dashboardId}`, {

--- a/e2e/test/scenarios/dashboard/reproductions/26230-dashboard-sticky-filter-incorrectly-positioned.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/reproductions/26230-dashboard-sticky-filter-incorrectly-positioned.cy.spec.js
@@ -1,4 +1,8 @@
-import { restore, visitDashboard } from "e2e/support/helpers";
+import {
+  addCardToDashboard,
+  restore,
+  visitDashboard,
+} from "e2e/support/helpers";
 
 describe("issue 26230", () => {
   beforeEach(() => {
@@ -74,21 +78,22 @@ function bookmarkDashboard(dashboardId) {
 }
 
 function createTextDashcard(id) {
-  cy.request("POST", `/api/dashboard/${id}/cards`, {
-    cardId: null,
-    col: 0,
-    row: 0,
-    size_x: 4,
-    size_y: 20,
-    visualization_settings: {
-      virtual_card: {
-        name: null,
-        display: "text",
-        visualization_settings: {},
-        dataset_query: {},
-        archived: false,
+  addCardToDashboard({
+    dashboard_id: id,
+    card_id: null,
+    card: {
+      size_x: 4,
+      size_y: 20,
+      visualization_settings: {
+        virtual_card: {
+          name: null,
+          display: "text",
+          visualization_settings: {},
+          dataset_query: {},
+          archived: false,
+        },
+        text: "I am a tall card",
       },
-      text: "I am a tall card",
     },
   });
 }

--- a/e2e/test/scenarios/embedding/reproductions/15860-locked-filters-same-source-table.cy.spec.js
+++ b/e2e/test/scenarios/embedding/reproductions/15860-locked-filters-same-source-table.cy.spec.js
@@ -3,6 +3,7 @@ import {
   popover,
   visitDashboard,
   visitIframe,
+  addCardsToDashboard,
 } from "e2e/support/helpers";
 
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
@@ -56,6 +57,13 @@ describe.skip("issue 15860", () => {
         query: { "source-table": PRODUCTS_ID },
       },
       dashboardDetails: {
+        embedding_params: {
+          q1_id: "locked",
+          q1_category: "enabled",
+          q2_id: "locked",
+          q2_category: "enabled",
+        },
+        enable_embedding: true,
         parameters: [
           q1IdFilter,
           q1CategoryFilter,
@@ -63,69 +71,56 @@ describe.skip("issue 15860", () => {
           q2CategoryFilter,
         ],
       },
-    }).then(({ body: { id: q1DashCard, card_id: q1, dashboard_id } }) => {
+      cardDetails: {
+        size_x: 8,
+        size_y: 6,
+      },
+    }).then(({ body: { card_id: q1, dashboard_id } }) => {
       // Create a second question with the same source table
       cy.createQuestion({
         name: "Q2",
         query: { "source-table": PRODUCTS_ID },
       }).then(({ body: { id: q2 } }) => {
-        // Add it to the dashboard
-        cy.request("POST", `/api/dashboard/${dashboard_id}/cards`, {
-          cardId: q2,
-          row: 0,
-          col: 8,
-          size_x: 10,
-          size_y: 6,
-        }).then(({ body: { id: q2DashCard } }) => {
-          // Map filters to the cards and rearrange cards so they can nicely fit
-          cy.request("PUT", `/api/dashboard/${dashboard_id}/cards`, {
-            cards: [
-              {
-                id: q1DashCard,
-                card_id: q1,
-                row: 0,
-                col: 0,
-                size_x: 8,
-                size_y: 6,
-                series: [],
-                visualization_settings: {},
-                parameter_mappings: [
-                  {
-                    parameter_id: q1IdFilter.id,
-                    card_id: q1,
-                    target: ["dimension", ["field", PRODUCTS.ID, null]],
-                  },
-                  {
-                    parameter_id: q1CategoryFilter.id,
-                    card_id: q1,
-                    target: ["dimension", ["field", PRODUCTS.CATEGORY, null]],
-                  },
-                ],
-              },
-              {
-                id: q2DashCard,
-                card_id: q2,
-                row: 0,
-                col: 8,
-                size_x: 10,
-                size_y: 6,
-                series: [],
-                visualization_settings: {},
-                parameter_mappings: [
-                  {
-                    parameter_id: q2IdFilter.id,
-                    card_id: q2,
-                    target: ["dimension", ["field", PRODUCTS.ID, null]],
-                  },
-                  {
-                    parameter_id: q2CategoryFilter.id,
-                    card_id: q2,
-                    target: ["dimension", ["field", PRODUCTS.CATEGORY, null]],
-                  },
-                ],
-              },
-            ],
-          });
+        addCardsToDashboard({
+          dashboard_id,
+          cards: [
+            // Add card for second question with parameter mappings
+            {
+              card_id: q2,
+              row: 0,
+              col: 8,
+              size_x: 10,
+              size_y: 6,
+              parameter_mappings: [
+                {
+                  parameter_id: q2IdFilter.id,
+                  card_id: q2,
+                  target: ["dimension", ["field", PRODUCTS.ID, null]],
+                },
+                {
+                  parameter_id: q2CategoryFilter.id,
+                  card_id: q2,
+                  target: ["dimension", ["field", PRODUCTS.CATEGORY, null]],
+                },
+              ],
+            },
+            // Add parameter mappings to first question's card
+            {
+              card_id: q1,
+              parameter_mappings: [
+                {
+                  parameter_id: q1IdFilter.id,
+                  card_id: q1,
+                  target: ["dimension", ["field", PRODUCTS.ID, null]],
+                },
+                {
+                  parameter_id: q1CategoryFilter.id,
+                  card_id: q1,
+                  target: ["dimension", ["field", PRODUCTS.CATEGORY, null]],
+                },
+              ],
+            },
+          ],
         });
       });
 

--- a/e2e/test/scenarios/filters/view.cy.spec.js
+++ b/e2e/test/scenarios/filters/view.cy.spec.js
@@ -3,6 +3,7 @@ import {
   popover,
   visitQuestion,
   visitDashboard,
+  addCardToDashboard,
 } from "e2e/support/helpers";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 
@@ -51,14 +52,7 @@ describe("scenarios > question > view", () => {
         },
       });
 
-      cy.request("POST", "/api/dashboard/2/cards", {
-        id: 2,
-        cardId: 4,
-        row: 0,
-        col: 0,
-        size_x: 12,
-        size_y: 8,
-      });
+      addCardToDashboard({ dashboard_id: 2, card_id: 4 });
     });
 
     it("should show filters by search for Vendor", () => {

--- a/e2e/test/scenarios/models/models-metadata.cy.spec.js
+++ b/e2e/test/scenarios/models/models-metadata.cy.spec.js
@@ -6,6 +6,7 @@ import {
   popover,
   openQuestionActions,
   questionInfoButton,
+  addCardToDashboard,
 } from "e2e/support/helpers";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import { startQuestionFromModel } from "./helpers/e2e-models-helpers";
@@ -331,12 +332,10 @@ describe("scenarios > models metadata", () => {
       cy.get("@modelId").then(modelId => {
         cy.createDashboard().then(response => {
           const dashboardId = response.body.id;
-          cy.request("POST", `/api/dashboard/${dashboardId}/cards`, {
-            cardId: modelId,
-            row: 0,
-            col: 0,
-            size_x: 18,
-            size_y: 9,
+          addCardToDashboard({
+            dashboard_id: dashboardId,
+            card_id: modelId,
+            card: { size_x: 18, size_y: 9 },
           });
 
           visitDashboard(dashboardId);

--- a/e2e/test/scenarios/models/reproductions/23024-cannot-apply-dash-filter-native-model.cy.spec.js
+++ b/e2e/test/scenarios/models/reproductions/23024-cannot-apply-dash-filter-native-model.cy.spec.js
@@ -1,4 +1,5 @@
 import {
+  addCardToDashboard,
   editDashboard,
   popover,
   restore,
@@ -66,12 +67,9 @@ describe("issue 23024", () => {
 function addModelToDashboardAndVisit() {
   cy.createDashboard().then(({ body: { id } }) => {
     cy.get("@modelId").then(cardId => {
-      cy.request("POST", `/api/dashboard/${id}/cards`, {
-        cardId,
-        row: 0,
-        col: 0,
-        size_x: 16,
-        size_y: 10,
+      addCardToDashboard({
+        dashboard_id: id,
+        card_id: cardId,
       });
     });
 

--- a/e2e/test/scenarios/question/nulls.cy.spec.js
+++ b/e2e/test/scenarios/question/nulls.cy.spec.js
@@ -5,6 +5,8 @@ import {
   summarize,
   visitDashboard,
   rightSidebar,
+  addCardsToDashboard,
+  addCardToDashboard,
 } from "e2e/support/helpers";
 
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
@@ -49,83 +51,68 @@ describe("scenarios > question > null", () => {
   it.skip("pie chart should handle `0`/`null` values (metabase#13626)", () => {
     // Preparation for the test: "Arrange and Act phase" - see repro steps in #13626
 
-    cy.createQuestion({
-      name: "13626",
-      query: {
-        "source-table": ORDERS_ID,
-        aggregation: [["sum", ["expression", "NewDiscount"]]],
-        breakout: [["field", ORDERS.ID, null]],
-        expressions: {
-          NewDiscount: [
-            "case",
-            [[["=", ["field", ORDERS.ID, null], 2], 0]],
-            { default: ["field", ORDERS.DISCOUNT, null] },
+    cy.createQuestionAndDashboard({
+      questionDetails: {
+        name: "13626",
+        query: {
+          "source-table": ORDERS_ID,
+          aggregation: [["sum", ["expression", "NewDiscount"]]],
+          breakout: [["field", ORDERS.ID, null]],
+          expressions: {
+            NewDiscount: [
+              "case",
+              [[["=", ["field", ORDERS.ID, null], 2], 0]],
+              { default: ["field", ORDERS.DISCOUNT, null] },
+            ],
+          },
+          filter: ["=", ["field", ORDERS.ID, null], 1, 2, 3],
+        },
+        display: "pie",
+      },
+      dashboardDetails: {
+        name: "13626D",
+        parameters: [
+          {
+            id: "1f97c149",
+            name: "ID",
+            slug: "id",
+            type: "id",
+          },
+        ],
+      },
+      cardDetails: {
+        size_x: 8,
+        size_y: 6,
+      },
+    }).then(({ body: { card_id, dashboard_id } }) => {
+      addCardToDashboard({
+        card_id,
+        dashboard_id,
+        card: {
+          parameter_mappings: [
+            {
+              parameter_id: "1f97c149",
+              card_id,
+              target: ["dimension", ["field", ORDERS.ID, null]],
+            },
           ],
         },
-        filter: ["=", ["field", ORDERS.ID, null], 1, 2, 3],
-      },
+      });
 
-      display: "pie",
-    }).then(({ body: { id: questionId } }) => {
-      cy.createDashboard({ name: "13626D" }).then(
-        ({ body: { id: dashboardId } }) => {
-          // add filter (ID) to the dashboard
-          cy.request("PUT", `/api/dashboard/${dashboardId}`, {
-            parameters: [
-              {
-                id: "1f97c149",
-                name: "ID",
-                slug: "id",
-                type: "id",
-              },
-            ],
-          });
+      // NOTE: The actual "Assertion" phase begins here
+      cy.visit(`/dashboard/${dashboard_id}?id=1`);
+      cy.findByText("13626D");
 
-          // add previously created question to the dashboard
-          cy.request("POST", `/api/dashboard/${dashboardId}/cards`, {
-            cardId: questionId,
-            row: 0,
-            col: 0,
-            size_x: 8,
-            size_y: 6,
-          }).then(({ body: { id: dashCardId } }) => {
-            // connect filter to that question
-            cy.request("PUT", `/api/dashboard/${dashboardId}/cards`, {
-              cards: [
-                {
-                  id: dashCardId,
-                  card_id: questionId,
-                  row: 0,
-                  col: 0,
-                  size_x: 8,
-                  size_y: 6,
-                  parameter_mappings: [
-                    {
-                      parameter_id: "1f97c149",
-                      card_id: questionId,
-                      target: ["dimension", ["field", ORDERS.ID, null]],
-                    },
-                  ],
-                },
-              ],
-            });
-          });
-          // NOTE: The actual "Assertion" phase begins here
-          cy.visit(`/dashboard/${dashboardId}?id=1`);
-          cy.findByText("13626D");
-
-          cy.log("Reported failing in v0.37.0.2");
-          cy.get(".DashCard").within(() => {
-            cy.findByTestId("loading-spinner").should("not.exist");
-            cy.findByText("13626");
-            // [quarantine]: flaking in CircleCI, passing locally
-            // TODO: figure out the cause of the failed test in CI after #13721 is merged
-            // cy.get("svg[class*=PieChart__Donut]");
-            // cy.get("[class*=PieChart__Value]").contains("0");
-            // cy.get("[class*=PieChart__Title]").contains(/total/i);
-          });
-        },
-      );
+      cy.log("Reported failing in v0.37.0.2");
+      cy.get(".DashCard").within(() => {
+        cy.findByTestId("loading-spinner").should("not.exist");
+        cy.findByText("13626");
+        // [quarantine]: flaking in CircleCI, passing locally
+        // TODO: figure out the cause of the failed test in CI after #13721 is merged
+        // cy.get("svg[class*=PieChart__Donut]");
+        // cy.get("[class*=PieChart__Value]").contains("0");
+        // cy.get("[class*=PieChart__Title]").contains(/total/i);
+      });
     });
   });
 
@@ -143,31 +130,12 @@ describe("scenarios > question > null", () => {
         cy.createDashboard().then(({ body: { id: DASHBOARD_ID } }) => {
           cy.log("Add both previously created questions to the dashboard");
 
-          [Q1_ID, Q2_ID].forEach((questionId, index) => {
-            const cardSizeX = 6;
-            const col = index === 0 ? 0 : cardSizeX; // making sure the second card doesn't overlap the first one
-
-            cy.request("POST", `/api/dashboard/${DASHBOARD_ID}/cards`, {
-              cardId: questionId,
-              row: 0,
-              col: col,
-              size_x: cardSizeX,
-              size_y: 4,
-            }).then(({ body: { id: DASHCARD_ID } }) => {
-              cy.request("PUT", `/api/dashboard/${DASHBOARD_ID}/cards`, {
-                cards: [
-                  {
-                    id: DASHCARD_ID,
-                    card_id: questionId,
-                    row: 0,
-                    col: col,
-                    size_x: cardSizeX,
-                    size_y: 4,
-                    parameter_mappings: [],
-                  },
-                ],
-              });
-            });
+          addCardsToDashboard({
+            dashboard_id: DASHBOARD_ID,
+            cards: [
+              { card_id: Q1_ID, row: 0, col: 0, size_x: 6, size_y: 4 },
+              { card_id: Q2_ID, row: 0, col: 6, size_x: 6, size_y: 4 },
+            ],
           });
 
           visitDashboard(DASHBOARD_ID);

--- a/e2e/test/scenarios/sharing/reproductions/20393-public-dashboard-nested-card-with-parameters.cy.spec.js
+++ b/e2e/test/scenarios/sharing/reproductions/20393-public-dashboard-nested-card-with-parameters.cy.spec.js
@@ -46,23 +46,15 @@ function createDashboardWithNestedCard() {
     native: { query: 'SELECT * FROM "ORDERS"', "template-tags": {} },
   }).then(({ body }) =>
     cy
-      .createQuestion({
-        name: "Q2",
-        query: { "source-table": `card__${body.id}` },
+      .createQuestionAndDashboard({
+        questionDetails: {
+          name: "Q2",
+          query: { "source-table": `card__${body.id}` },
+        },
+        dashboardDetails: {
+          name: "Q2 in a dashboard",
+        },
       })
-      .then(({ body: { id: cardId } }) =>
-        cy
-          .createDashboard("Q2 in a dashboard")
-          .then(({ body: { id: dashId } }) => {
-            cy.request("POST", `/api/dashboard/${dashId}/cards`, {
-              cardId,
-              row: 0,
-              col: 0,
-              size_x: 4,
-              size_y: 4,
-            });
-            visitDashboard(dashId);
-          }),
-      ),
+      .then(({ body: { dashboard_id } }) => visitDashboard(dashboard_id)),
   );
 }

--- a/e2e/test/scenarios/sharing/subscriptions.cy.spec.js
+++ b/e2e/test/scenarios/sharing/subscriptions.cy.spec.js
@@ -8,6 +8,7 @@ import {
   isOSS,
   visitDashboard,
   sendEmailAndAssert,
+  addCardToDashboard,
 } from "e2e/support/helpers";
 import { USERS } from "e2e/support/cypress_data";
 
@@ -192,34 +193,20 @@ describe("scenarios > dashboard > subscriptions", () => {
             });
 
             // Add question to the dashboard
-            cy.request("POST", `/api/dashboard/${DASHBOARD_ID}/cards`, {
-              cardId: QUESTION_ID,
-              row: 0,
-              col: 0,
-              size_x: 12,
-              size_y: 10,
-            }).then(({ body: { id: DASH_CARD_ID } }) => {
-              // Connect filter to that question
-              cy.request("PUT", `/api/dashboard/${DASHBOARD_ID}/cards`, {
-                cards: [
+            addCardToDashboard({
+              dashboard_id: DASHBOARD_ID,
+              card_id: QUESTION_ID,
+              card: {
+                parameter_mappings: [
                   {
-                    id: DASH_CARD_ID,
+                    parameter_id: "930e4001",
                     card_id: QUESTION_ID,
-                    row: 0,
-                    col: 0,
-                    size_x: 12,
-                    size_y: 10,
-                    parameter_mappings: [
-                      {
-                        parameter_id: "930e4001",
-                        card_id: QUESTION_ID,
-                        target: ["variable", ["template-tag", "qty"]],
-                      },
-                    ],
+                    target: ["variable", ["template-tag", "qty"]],
                   },
                 ],
-              });
+              },
             });
+
             assignRecipient({ dashboard_id: DASHBOARD_ID });
           },
         );

--- a/e2e/test/scenarios/visualizations/drillthroughs/chart_drill.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/drillthroughs/chart_drill.cy.spec.js
@@ -10,6 +10,7 @@ import {
   visitQuestion,
   visitDashboard,
   startNewQuestion,
+  addCardToDashboard,
 } from "e2e/support/helpers";
 
 import { USER_GROUPS, SAMPLE_DB_ID } from "e2e/support/cypress_data";
@@ -133,37 +134,20 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
           ({ body: { id: DASHBOARD_ID } }) => {
             cy.log("Add the first question to the dashboard");
 
-            cy.request("POST", `/api/dashboard/${DASHBOARD_ID}/cards`, {
-              cardId: Q1_ID,
-              row: 0,
-              col: 0,
-              size_x: 16,
-              size_y: 12,
-            }).then(({ body: { id: DASH_CARD_ID } }) => {
-              cy.log(
-                "Add additional series combining it with the second question",
-              );
-
-              cy.request("PUT", `/api/dashboard/${DASHBOARD_ID}/cards`, {
-                cards: [
+            addCardToDashboard({
+              card_id: Q1_ID,
+              dashboard_id: DASHBOARD_ID,
+              card: {
+                size_x: 16,
+                size_y: 12,
+                // Add additional series combining it with the second question
+                series: [
                   {
-                    id: DASH_CARD_ID,
-                    card_id: Q1_ID,
-                    row: 0,
-                    col: 0,
-                    size_x: 16,
-                    size_y: 12,
-                    series: [
-                      {
-                        id: Q2_ID,
-                        model: "card",
-                      },
-                    ],
-                    visualization_settings: {},
-                    parameter_mappings: [],
+                    id: Q2_ID,
+                    model: "card",
                   },
                 ],
-              });
+              },
             });
 
             visitDashboard(DASHBOARD_ID);
@@ -219,37 +203,20 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
           ({ body: { id: DASHBOARD_ID } }) => {
             cy.log("Add the first question to the dashboard");
 
-            cy.request("POST", `/api/dashboard/${DASHBOARD_ID}/cards`, {
-              cardId: Q1_ID,
-              row: 0,
-              col: 0,
-              size_x: 16,
-              size_y: 12,
-            }).then(({ body: { id: DASH_CARD_ID } }) => {
-              cy.log(
-                "Add additional series combining it with the second question",
-              );
-
-              cy.request("PUT", `/api/dashboard/${DASHBOARD_ID}/cards`, {
-                cards: [
+            addCardToDashboard({
+              card_id: Q1_ID,
+              dashboard_id: DASHBOARD_ID,
+              card: {
+                size_x: 16,
+                size_y: 12,
+                // Add additional series combining it with the second question
+                series: [
                   {
-                    id: DASH_CARD_ID,
-                    card_id: Q1_ID,
-                    row: 0,
-                    col: 0,
-                    size_x: 16,
-                    size_y: 12,
-                    series: [
-                      {
-                        id: Q2_ID,
-                        model: "card",
-                      },
-                    ],
-                    visualization_settings: {},
-                    parameter_mappings: [],
+                    id: Q2_ID,
+                    model: "card",
                   },
                 ],
-              });
+              },
             });
 
             visitDashboard(DASHBOARD_ID);
@@ -565,35 +532,20 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
       display: "pie",
     }).then(({ body: { id: QUESTION_ID } }) => {
       cy.createDashboard().then(({ body: { id: DASHBOARD_ID } }) => {
-        cy.request("POST", `/api/dashboard/${DASHBOARD_ID}/cards`, {
-          cardId: QUESTION_ID,
-          row: 0,
-          col: 0,
-          size_x: 16,
-          size_y: 10,
-        }).then(({ body: { id: DASH_CARD_ID } }) => {
-          // Add click through to the custom destination on a card
-          cy.request("PUT", `/api/dashboard/${DASHBOARD_ID}/cards`, {
-            cards: [
-              {
-                id: DASH_CARD_ID,
-                card_id: QUESTION_ID,
-                row: 0,
-                col: 0,
-                size_x: 16,
-                size_y: 10,
-                series: [],
-                visualization_settings: {
-                  click_behavior: {
-                    type: "link",
-                    linkType: "url",
-                    linkTemplate: "question/{{count}}",
-                  },
-                },
-                parameter_mappings: [],
+        addCardToDashboard({
+          card_id: QUESTION_ID,
+          dashboard_id: DASHBOARD_ID,
+          card: {
+            size_x: 16,
+            size_y: 10,
+            visualization_settings: {
+              click_behavior: {
+                type: "link",
+                linkType: "url",
+                linkTemplate: "question/{{count}}",
               },
-            ],
-          });
+            },
+          },
         });
 
         visitDashboard(DASHBOARD_ID);

--- a/e2e/test/scenarios/visualizations/drillthroughs/dash_drill.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/drillthroughs/dash_drill.cy.spec.js
@@ -1,5 +1,9 @@
 // Imported from drillthroughs.e2e.spec.js
-import { restore, visitDashboard } from "e2e/support/helpers";
+import {
+  addCardToDashboard,
+  restore,
+  visitDashboard,
+} from "e2e/support/helpers";
 
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
@@ -77,41 +81,35 @@ describe("scenarios > visualizations > drillthroughs > dash_drill", () => {
       const CARD_NAME = "Multiscalar Question";
 
       beforeEach(() => {
-        // Create muliscalar card
-        cy.createQuestion({
-          name: CARD_NAME,
-          query: {
-            "source-table": PEOPLE_ID,
-            aggregation: [["count"]],
-            breakout: [
-              ["field", PEOPLE.SOURCE, null],
-              ["field", PEOPLE.CREATED_AT, { "temporal-unit": "month" }],
-            ],
-          },
-          display: "line",
-        }).then(({ body: { id: CARD_ID } }) => {
-          cy.createDashboard({ name: DASHBOARD_NAME }).then(
-            ({ body: { id: DASHBOARD_ID } }) => {
-              // Add previously created question to the new dashboard
-              cy.request("POST", `/api/dashboard/${DASHBOARD_ID}/cards`, {
-                cardId: CARD_ID,
-                row: 0,
-                col: 0,
-                size_x: 16,
-                size_y: 12,
-              });
-
-              visitDashboard(DASHBOARD_ID);
-              cy.findByText(DASHBOARD_NAME);
-
-              cy.intercept("POST", `/api/card/${CARD_ID}/query`).as(
-                "cardQuery",
-              );
-
-              cy.findByText(CARD_NAME).click();
-              cy.wait("@cardQuery");
+        cy.createQuestionAndDashboard({
+          questionDetails: {
+            name: CARD_NAME,
+            // Create muliscalar card
+            query: {
+              "source-table": PEOPLE_ID,
+              aggregation: [["count"]],
+              breakout: [
+                ["field", PEOPLE.SOURCE, null],
+                ["field", PEOPLE.CREATED_AT, { "temporal-unit": "month" }],
+              ],
             },
-          );
+            display: "line",
+          },
+          dashboardDetails: {
+            name: DASHBOARD_NAME,
+          },
+          cardDetails: {
+            size_x: 16,
+            size_y: 12,
+          },
+        }).then(({ body: { dashboard_id, card_id } }) => {
+          visitDashboard(dashboard_id);
+          cy.findByText(DASHBOARD_NAME);
+
+          cy.intercept("POST", `/api/card/${card_id}/query`).as("cardQuery");
+
+          cy.findByText(CARD_NAME).click();
+          cy.wait("@cardQuery");
         });
       });
 
@@ -125,85 +123,61 @@ describe("scenarios > visualizations > drillthroughs > dash_drill", () => {
       it("should respect visualization type when entering a question from a dashboard (metabase#13415)", () => {
         const QUESTION_NAME = "13415";
 
-        cy.createQuestion({
-          name: QUESTION_NAME,
-          query: {
-            "source-table": ORDERS_ID,
-            aggregation: [["count"]],
-            breakout: [
-              [
-                "field",
-                PRODUCTS.CATEGORY,
-                { "source-field": ORDERS.PRODUCT_ID },
+        cy.createQuestionAndDashboard({
+          questionDetails: {
+            name: QUESTION_NAME,
+            query: {
+              "source-table": ORDERS_ID,
+              aggregation: [["count"]],
+              breakout: [
+                [
+                  "field",
+                  PRODUCTS.CATEGORY,
+                  { "source-field": ORDERS.PRODUCT_ID },
+                ],
+                ["field", ORDERS.CREATED_AT, { "temporal-unit": "year" }],
               ],
-              ["field", ORDERS.CREATED_AT, { "temporal-unit": "year" }],
+            },
+          },
+          dashboardDetails: {
+            // Add filter with the default value to the dashboard
+            parameters: [
+              {
+                id: "91bace6e",
+                name: "Category",
+                slug: "category",
+                type: "category",
+                default: ["Doohickey"],
+              },
             ],
           },
-        }).then(({ body: { id: QUESTION_ID } }) => {
-          cy.createDashboard().then(({ body: { id: DASHBOARD_ID } }) => {
-            cy.log("Add filter with the default value to the dashboard");
-
-            cy.request("PUT", `/api/dashboard/${DASHBOARD_ID}`, {
-              parameters: [
+        }).then(({ body: { dashboard_id, card_id } }) => {
+          // Adding filter parameter mapping to dashcard
+          addCardToDashboard({
+            card_id,
+            dashboard_id,
+            card: {
+              parameter_mappings: [
                 {
-                  id: "91bace6e",
-                  name: "Category",
-                  slug: "category",
-                  type: "category",
-                  default: ["Doohickey"],
+                  parameter_id: "91bace6e",
+                  card_id: card_id,
+                  target: [
+                    "dimension",
+                    [
+                      "field",
+                      PRODUCTS.CATEGORY,
+                      { "source-field": ORDERS.PRODUCT_ID },
+                    ],
+                  ],
                 },
               ],
-            });
-
-            cy.log("Add previously created question to the dashboard");
-
-            cy.request("POST", `/api/dashboard/${DASHBOARD_ID}/cards`, {
-              cardId: QUESTION_ID,
-              row: 0,
-              col: 0,
-              size_x: 10,
-              size_y: 8,
-            }).then(({ body: { id: DASH_CARD_ID } }) => {
-              cy.log("Connect filter to that question");
-
-              cy.request("PUT", `/api/dashboard/${DASHBOARD_ID}/cards`, {
-                cards: [
-                  {
-                    id: DASH_CARD_ID,
-                    card_id: QUESTION_ID,
-                    row: 0,
-                    col: 0,
-                    size_x: 10,
-                    size_y: 8,
-                    parameter_mappings: [
-                      {
-                        parameter_id: "91bace6e",
-                        card_id: QUESTION_ID,
-                        target: [
-                          "dimension",
-                          [
-                            "field",
-                            PRODUCTS.CATEGORY,
-                            { "source-field": ORDERS.PRODUCT_ID },
-                          ],
-                        ],
-                      },
-                    ],
-                  },
-                ],
-              });
-            });
-
-            cy.intercept("POST", "/api/dataset").as("dataset");
-
-            visitDashboard(DASHBOARD_ID);
-
-            cy.findByText(QUESTION_NAME).click();
-
-            cy.wait("@dataset");
-            cy.findByText("Category is Doohickey");
-            cy.findByText("177"); // Doohickeys for 2016
+            },
           });
+
+          visitDashboard(dashboard_id);
+          cy.findByText(QUESTION_NAME).click();
+          cy.findByText("Category is Doohickey");
+          cy.findByText("177"); // Doohickeys for 2016
         });
       });
     });
@@ -218,17 +192,9 @@ function clickScalarCardTitle(card_name) {
 
 function addCardToNewDashboard(dashboard_name, card_id) {
   cy.createDashboard({ name: dashboard_name }).then(
-    ({ body: { id: DASHBOARD_ID } }) => {
-      // Add a card to it (with predefined size 6,4 simply for readability)
-      cy.request("POST", `/api/dashboard/${DASHBOARD_ID}/cards`, {
-        cardId: card_id,
-        row: 0,
-        col: 0,
-        size_x: 6,
-        size_y: 4,
-      });
-      // Visit newly created dashboard
-      visitDashboard(DASHBOARD_ID);
+    ({ body: { id: dashboard_id } }) => {
+      addCardToDashboard({ card_id, dashboard_id });
+      visitDashboard(dashboard_id);
     },
   );
 }

--- a/e2e/test/scenarios/visualizations/line-bar-tooltips.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/line-bar-tooltips.cy.spec.js
@@ -3,6 +3,7 @@ import {
   popover,
   visitDashboard,
   saveDashboard,
+  addCardToDashboard,
 } from "e2e/support/helpers";
 
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
@@ -423,33 +424,17 @@ function setup({ question, addedSeriesQuestion }) {
 
 function setupDashboard(cardId, addedSeriesCardId) {
   return cy.createDashboard().then(({ body: { id: dashboardId } }) => {
-    return cy
-      .request("POST", `/api/dashboard/${dashboardId}/cards`, {
-        cardId,
-        row: 0,
-        col: 0,
+    return addCardToDashboard({
+      dashboard_id: dashboardId,
+      card_id: cardId,
+      card: {
         size_x: 18,
         size_y: 12,
-      })
-      .then(({ body: { id: dashCardId } }) => {
-        return cy.request("PUT", `/api/dashboard/${dashboardId}/cards`, {
-          cards: [
-            {
-              id: dashCardId,
-              card_id: cardId,
-              row: 0,
-              col: 0,
-              size_x: 18,
-              size_y: 12,
-              parameter_mappings: [],
-              series: addedSeriesCardId ? [{ id: addedSeriesCardId }] : [],
-            },
-          ],
-        });
-      })
-      .then(() => {
-        return dashboardId;
-      });
+        series: addedSeriesCardId ? [{ id: addedSeriesCardId }] : [],
+      },
+    }).then(() => {
+      return dashboardId;
+    });
   });
 }
 

--- a/e2e/test/scenarios/visualizations/line_chart.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/line_chart.cy.spec.js
@@ -5,6 +5,7 @@ import {
   visitDashboard,
   openSeriesSettings,
   queryBuilderMain,
+  addCardToDashboard,
 } from "e2e/support/helpers";
 
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
@@ -416,32 +417,16 @@ describe("scenarios > visualizations > line chart", () => {
       secondCardId,
     } = {}) {
       // Add the first question to the dashboard
-      cy.request("POST", `/api/dashboard/${dashboardId}/cards`, {
-        cardId: firstCardId,
-        row: 0,
-        col: 0,
-        size_x: 18,
-        size_y: 12,
-      }).then(({ body: { id: dashCardId } }) => {
-        // Combine the second question with the first one as the second series
-        cy.request("PUT", `/api/dashboard/${dashboardId}/cards`, {
-          cards: [
+      addCardToDashboard({
+        dashboard_id: dashboardId,
+        card_id: firstCardId,
+        card: {
+          series: [
             {
-              id: dashCardId,
-              card_id: firstCardId,
-              row: 0,
-              col: 0,
-              size_x: 18,
-              size_y: 12,
-              series: [
-                {
-                  id: secondCardId,
-                },
-              ],
-              parameter_mappings: [],
+              id: secondCardId,
             },
           ],
-        });
+        },
       });
     }
 

--- a/e2e/test/scenarios/visualizations/scalar.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/scalar.cy.spec.js
@@ -29,40 +29,24 @@ describe("scenarios > visualizations > scalar", () => {
       cy.skipOn(size === "mobile");
 
       cy.viewport(width, height);
-      cy.createQuestion({
-        name: "12629",
-        query: {
-          "source-table": ORDERS_ID,
-          aggregation: [["*", 1000000, ["sum", ["field", ORDERS.TOTAL, null]]]],
+      cy.createQuestionAndDashboard({
+        questionDetails: {
+          name: "12629",
+          query: {
+            "source-table": ORDERS_ID,
+            aggregation: [
+              ["*", 1000000, ["sum", ["field", ORDERS.TOTAL, null]]],
+            ],
+          },
+          display: "scalar",
         },
-        display: "scalar",
-      }).then(({ body: { id: questionId } }) => {
-        cy.createDashboard().then(({ body: { id: dashboardId } }) => {
-          // Add previously created question to the dashboard
-          cy.request("POST", `/api/dashboard/${dashboardId}/cards`, {
-            cardId: questionId,
-            row: 0,
-            col: 0,
-            size_x: 4,
-            size_y: 4,
-          }).then(({ body: { id: dashCardId } }) => {
-            cy.request("PUT", `/api/dashboard/${dashboardId}/cards`, {
-              cards: [
-                {
-                  id: dashCardId,
-                  card_id: questionId,
-                  row: 0,
-                  col: 0,
-                  size_x: 4,
-                  size_y: 4,
-                  parameter_mappings: [],
-                },
-              ],
-            });
-          });
-          visitDashboard(dashboardId);
-          cy.findByText("1.5T");
-        });
+        cardDetails: {
+          size_x: 4,
+          size_y: 4,
+        },
+      }).then(({ body: { dashboard_id } }) => {
+        visitDashboard(dashboard_id);
+        cy.findByText("1.5T");
       });
     });
   });

--- a/frontend/src/metabase/dashboard/actions/cards.js
+++ b/frontend/src/metabase/dashboard/actions/cards.js
@@ -18,8 +18,9 @@ import { loadMetadataForDashboard } from "./metadata";
 export const MARK_NEW_CARD_SEEN = "metabase/dashboard/MARK_NEW_CARD_SEEN";
 export const markNewCardSeen = createAction(MARK_NEW_CARD_SEEN);
 
+let tempId = -1;
 function generateTemporaryDashcardId() {
-  return Math.random();
+  return tempId--;
 }
 
 export const addCardToDashboard =

--- a/frontend/src/metabase/dashboard/actions/core.js
+++ b/frontend/src/metabase/dashboard/actions/core.js
@@ -55,8 +55,8 @@ export const onReplaceAllDashCardVisualizationSettings = createAction(
   (id, settings) => ({ id, settings }),
 );
 
-export const UPDATE_DASHCARD_ID = "metabase/dashboard/UPDATE_DASHCARD_ID";
-export const updateDashcardId = createAction(
-  UPDATE_DASHCARD_ID,
-  (oldDashcardId, newDashcardId) => ({ oldDashcardId, newDashcardId }),
+export const UPDATE_DASHCARD_IDS = "metabase/dashboard/UPDATE_DASHCARD_IDS";
+export const updateDashcardIds = createAction(
+  UPDATE_DASHCARD_IDS,
+  (oldDashcardIds, newDashcardIds) => ({ oldDashcardIds, newDashcardIds }),
 );

--- a/frontend/src/metabase/dashboard/actions/data-fetching.js
+++ b/frontend/src/metabase/dashboard/actions/data-fetching.js
@@ -79,7 +79,7 @@ export const setShowLoadingCompleteFavicon = createAction(
 
 // real dashcard ids are integers >= 1
 function isNewDashcard(dashcard) {
-  return dashcard.id < 1 && dashcard.id >= 0;
+  return dashcard.id < 0;
 }
 
 function isNewAdditionalSeriesCard(card, dashcard) {

--- a/frontend/src/metabase/dashboard/actions/save.js
+++ b/frontend/src/metabase/dashboard/actions/save.js
@@ -10,7 +10,7 @@ import { clickBehaviorIsValid } from "metabase-lib/parameters/utils/click-behavi
 
 import { getDashboardBeforeEditing } from "../selectors";
 
-import { updateDashcardId } from "./core";
+import { updateDashcardIds } from "./core";
 import { fetchDashboard } from "./data-fetching";
 import { hasDashboardChanged, haveDashboardCardsChanged } from "./utils";
 
@@ -67,18 +67,6 @@ export const saveDashboardAndCards = createThunkAction(
         return card;
       });
 
-      // remove isRemoved dashboards
-      await Promise.all(
-        dashboard.ordered_cards
-          .filter(dc => dc.isRemoved && !dc.isAdded)
-          .map(dc =>
-            DashboardApi.removeCard({
-              dashId: dashboard.id,
-              dashcardId: dc.id,
-            }),
-          ),
-      );
-
       // update parameter mappings
       dashboard.ordered_cards = dashboard.ordered_cards.map(dc => ({
         ...dc,
@@ -96,32 +84,6 @@ export const saveDashboardAndCards = createThunkAction(
         ),
       }));
 
-      // add new cards to dashboard
-      const updatedDashcards = await Promise.all(
-        dashboard.ordered_cards
-          .filter(dc => !dc.isRemoved)
-          .map(async dc => {
-            if (dc.isAdded) {
-              const result = await DashboardApi.addCard({
-                dashId: dashboard.id,
-                cardId: dc.card_id,
-                col: dc.col,
-                row: dc.row,
-                size_x: dc.size_x,
-                size_y: dc.size_y,
-                series: dc.series,
-                parameter_mappings: dc.parameter_mappings,
-                visualization_settings: dc.visualization_settings,
-                action_id: dc.action_id,
-              });
-              dispatch(updateDashcardId(dc.id, result.id));
-              return result;
-            } else {
-              return dc;
-            }
-          }),
-      );
-
       // update modified cards
       await Promise.all(
         dashboard.ordered_cards
@@ -138,8 +100,12 @@ export const saveDashboardAndCards = createThunkAction(
       }
 
       // update the dashboard cards
-      if (_.some(updatedDashcards, dc => dc.isDirty)) {
-        const cards = updatedDashcards.map(dc => ({
+      const dashcardsToUpdate = dashboard.ordered_cards.filter(
+        dc => !dc.isRemoved,
+      );
+      const updatedDashCards = await DashboardApi.updateCards({
+        dashId: dashboard.id,
+        cards: dashcardsToUpdate.map(dc => ({
           id: dc.id,
           card_id: dc.card_id,
           action_id: dc.action_id,
@@ -150,15 +116,14 @@ export const saveDashboardAndCards = createThunkAction(
           series: dc.series,
           visualization_settings: dc.visualization_settings,
           parameter_mappings: dc.parameter_mappings,
-        }));
-        const result = await DashboardApi.updateCards({
-          dashId: dashboard.id,
-          cards,
-        });
-        if (result.status !== "ok") {
-          throw new Error(result.status);
-        }
-      }
+        })),
+      });
+      dispatch(
+        updateDashcardIds(
+          dashcardsToUpdate.map(dc => dc.id),
+          updatedDashCards.map(dc => dc.id),
+        ),
+      );
 
       await dispatch(Dashboards.actions.update(dashboard));
 

--- a/frontend/src/metabase/dashboard/reducers.js
+++ b/frontend/src/metabase/dashboard/reducers.js
@@ -22,7 +22,7 @@ import {
   REMOVE_PARAMETER,
   FETCH_CARD_DATA,
   CLEAR_CARD_DATA,
-  UPDATE_DASHCARD_ID,
+  UPDATE_DASHCARD_IDS,
   MARK_CARD_AS_SLOW,
   SET_PARAMETER_VALUE,
   FETCH_DASHBOARD_CARD_DATA,
@@ -250,11 +250,16 @@ const dashcardData = handleActions(
       next: (state, { payload: { cardId, dashcardId } }) =>
         assocIn(state, [dashcardId, cardId]),
     },
-    [UPDATE_DASHCARD_ID]: {
-      next: (state, { payload: { oldDashcardId, newDashcardId } }) =>
-        chain(state)
-          .assoc(newDashcardId, state[oldDashcardId])
-          .dissoc(oldDashcardId)
+    [UPDATE_DASHCARD_IDS]: {
+      next: (state, { payload: { oldDashcardIds, newDashcardIds } }) =>
+        oldDashcardIds
+          .reduce(
+            (wrappedState, oldDcId, index) =>
+              wrappedState
+                .dissoc(oldDcId)
+                .assoc(newDashcardIds[index], state[oldDcId]),
+            chain(state),
+          )
           .value(),
     },
     [RESET]: { next: state => ({}) },

--- a/frontend/src/metabase/services.js
+++ b/frontend/src/metabase/services.js
@@ -121,8 +121,6 @@ export const DashboardApi = {
   get: GET("/api/dashboard/:dashId"),
   update: PUT("/api/dashboard/:id"),
   delete: DELETE("/api/dashboard/:dashId"),
-  addCard: POST("/api/dashboard/:dashId/cards"),
-  removeCard: DELETE("/api/dashboard/:dashId/cards"),
   updateCards: PUT("/api/dashboard/:dashId/cards"),
   favorite: POST("/api/dashboard/:dashId/favorite"),
   unfavorite: DELETE("/api/dashboard/:dashId/favorite"),


### PR DESCRIPTION
Merging into [BE PR branch `dashboard-bulk-create-delete`](https://github.com/metabase/metabase/pull/29641).

Part of epic https://github.com/metabase/metabase/issues/29502

### Description

Before updating our API requests to introduce the notion of tabs, we decided to first refactor the existing dashboard edit flow. Instead of using separate `POST` and `DELETE` requests for the individual cards being added and removed, we updated to `PUT` endpoint to handle adding and removing all cards at once.

### How to verify

Open a dashboard -> edit -> add and remove cards -> save

### Demo

https://user-images.githubusercontent.com/37751258/229574449-8f425851-4a9e-4108-ab55-82febce5ef3c.mov

### Checklist

- [x] Tests have been added/updated to cover changes in this PR

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/29762)
<!-- Reviewable:end -->
