### PR TITLE
Fix metric & segment description logic when definitions don't have `:source-table`

### DIFF
--- a/src/metabase/models/metric.clj
+++ b/src/metabase/models/metric.clj
@@ -17,6 +17,7 @@
    [metabase.models.serialization :as serdes]
    [metabase.util :as u]
    [metabase.util.i18n :refer [tru]]
+   [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [methodical.core :as methodical]
    [toucan.models :as models]
@@ -55,9 +56,16 @@
   [metadata-provider :- lib.metadata/MetadataProvider
    {:keys [definition], table-id :table_id, :as _metric}]
   (when (seq definition)
-    (when-let [{database-id :db_id} (lib.metadata.protocols/table metadata-provider table-id)]
-      (let [query (lib.query/query-from-legacy-inner-query metadata-provider database-id definition)]
-        (lib/describe-query query)))))
+    (when-let [{database-id :db_id} (when table-id
+                                      (lib.metadata.protocols/table metadata-provider table-id))]
+      (try
+        (let [definition (merge {:source-table table-id}
+                                definition)
+              query      (lib.query/query-from-legacy-inner-query metadata-provider database-id definition)]
+          (lib/describe-query query))
+        (catch Throwable e
+          (log/error e (tru "Error calculating Metric description: {0}" (ex-message e)))
+          nil)))))
 
 (defn- warmed-metadata-provider [metrics]
   (let [metadata-provider (doto (lib.metadata.jvm/application-database-metadata-provider)

--- a/src/metabase/models/segment.clj
+++ b/src/metabase/models/segment.clj
@@ -16,6 +16,7 @@
    [metabase.models.serialization :as serdes]
    [metabase.util :as u]
    [metabase.util.i18n :refer [tru]]
+   [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [methodical.core :as methodical]
    [toucan.models :as models]
@@ -55,9 +56,15 @@
   [metadata-provider :- lib.metadata/MetadataProvider
    {table-id :table_id, :keys [definition], :as _segment}]
   (when (seq definition)
-    (when-let [{database-id :db_id} (lib.metadata.protocols/table metadata-provider table-id)]
-      (let [query (lib.query/query-from-legacy-inner-query metadata-provider database-id definition)]
-        (lib/describe-top-level-key query :filter)))))
+    (when-let [{database-id :db_id} (when table-id (lib.metadata.protocols/table metadata-provider table-id))]
+      (try
+        (let [definition (merge {:source-table table-id}
+                                definition)
+              query      (lib.query/query-from-legacy-inner-query metadata-provider database-id definition)]
+          (lib/describe-top-level-key query :filter))
+        (catch Throwable e
+          (log/error e (tru "Error calculating Segment description: {0}" (ex-message e)))
+          nil)))))
 
 (defn- warmed-metadata-provider [segments]
   (let [metadata-provider (doto (lib.metadata.jvm/application-database-metadata-provider)

--- a/test/metabase/models/metric_test.clj
+++ b/test/metabase/models/metric_test.clj
@@ -125,12 +125,14 @@
                (serdes/raw-hash ["measurement" (serdes/identity-hash table) now])
                (serdes/identity-hash metric)))))))
 
-(deftest definition-descriptions-test
+(deftest definition-description-missing-definition-test
   (testing ":definition_description should hydrate to nil if :definition is missing"
     (t2.with-temp/with-temp [Metric metric {:name     "Metric A"
                                             :table_id (mt/id :users)}]
       (is (= nil
-             (:definition_description (t2/hydrate metric :definition_description))))))
+             (:definition_description (t2/hydrate metric :definition_description)))))))
+
+(deftest definition-description-test
   (t2.with-temp/with-temp [Segment {segment-id :id} {:name       "Checkins with ID = 1"
                                                      :table_id   (mt/id :checkins)
                                                      :definition (:query (mt/mbql-query checkins
@@ -144,3 +146,22 @@
                                                                                [:segment segment-id]]}))}]
     (is (= "Venues, Sum of Name, Filtered by Price equals 4 and Checkins with ID = 1"
            (:definition_description (t2/hydrate metric :definition_description))))))
+
+(deftest definition-description-missing-source-table-test
+  (testing "Should work if `:definition` does not include `:source-table`"
+    (t2.with-temp/with-temp [Metric metric {:name       "Metric B"
+                                            :table_id   (mt/id :venues)
+                                            :definition (mt/$ids venues
+                                                          {:aggregation [[:sum $category_id->categories.name]]
+                                                           :filter      [:= $price 4]})}]
+      (is (= "Venues, Sum of Name, Filtered by Price equals 4"
+             (:definition_description (t2/hydrate metric :definition_description)))))))
+
+(deftest definition-description-invalid-query-test
+  (testing "Should return `nil` if query is invalid"
+    (t2.with-temp/with-temp [Metric metric {:name       "Metric B"
+                                            :table_id   (mt/id :venues)
+                                            :definition (mt/$ids venues
+                                                          {:aggregation [[:sum $category_id->categories.name]]
+                                                           :filter      [:= [:field Integer/MAX_VALUE nil] 4]})}]
+      (is (nil? (:definition_description (t2/hydrate metric :definition_description)))))))


### PR DESCRIPTION
Fixes #29764

In #29507 I ported Metric and Segment description logic to MLv2 (on the backend, done with hydration), but it turns out in some cases the Metric or Segment definitions don't include the `:source-table` ID (this is stored separately in a `table_id` column). This PR fixes the hydration methods to make sure this info is included, and also to fail gracefully if we can't generate a description for a specific Model or Segment for some other reason rather than causing the entire endpoint to fail.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/29767)
<!-- Reviewable:end -->
