### PR TITLE
add `disabled` prop to `TabButton`

### DIFF
--- a/frontend/src/metabase/core/components/TabButton/TabButton.styled.tsx
+++ b/frontend/src/metabase/core/components/TabButton/TabButton.styled.tsx
@@ -6,6 +6,7 @@ import Button from "metabase/core/components/Button";
 
 export interface TabButtonProps {
   isSelected?: boolean;
+  disabled?: boolean;
 }
 
 export const TabButtonLabel = styled.div`
@@ -20,11 +21,13 @@ export const TabButtonRoot = styled.button<TabButtonProps>`
 
   padding: 1rem 0;
 
-  color: ${props => (props.isSelected ? color("brand") : color("text-dark"))};
+  color: ${props =>
+    props.isSelected && !props.disabled ? color("brand") : color("text-dark")};
+  opacity: ${props => (props.disabled ? 0.3 : 1)};
   font-size: 0.875rem;
   font-weight: 700;
 
-  cursor: pointer;
+  cursor: ${props => (props.disabled ? "default" : "pointer")};
 
   border-bottom: 3px solid
     ${props => (props.isSelected ? color("brand") : "transparent")};
@@ -46,13 +49,21 @@ export const MenuButton = styled(Button)<TabButtonProps & { isOpen: boolean }>`
 
   ${props =>
     props.isOpen &&
+    !props.disabled &&
     css`
       color: ${color("brand")};
       background-color: ${color("bg-medium")};
     `}
   &:hover,:focus {
-    color: ${color("brand")};
-    background-color: ${color("bg-medium")};
+    ${props =>
+      props.disabled
+        ? css`
+            color: ${color("text-dark")};
+          `
+        : css`
+            color: ${color("brand")};
+            background-color: ${color("bg-medium")};
+          `}
   }
 `;
 

--- a/frontend/src/metabase/core/components/TabButton/TabButton.tsx
+++ b/frontend/src/metabase/core/components/TabButton/TabButton.tsx
@@ -88,6 +88,7 @@ function TabButton({
               isOpen={isMenuOpen}
               onClick={onClick}
               ref={menuButtonRef}
+              disabled={props.disabled}
             />
           )}
           popoverContent={({ closePopover }) => (

--- a/frontend/src/metabase/core/components/TabButton/TabButton.unit.spec.tsx
+++ b/frontend/src/metabase/core/components/TabButton/TabButton.unit.spec.tsx
@@ -4,9 +4,9 @@ import userEvent from "@testing-library/user-event";
 import { getIcon } from "__support__/ui";
 
 import TabRow from "../TabRow";
-import TabButton from "./TabButton";
+import TabButton, { TabButtonProps } from "./TabButton";
 
-function setup() {
+function setup(props?: TabButtonProps) {
   const action = jest.fn();
   const value = "some_value";
 
@@ -17,6 +17,7 @@ function setup() {
         menuItems={[
           { label: "first item", action: (context, value) => action(value) },
         ]}
+        {...props}
       >
         Tab 1
       </TabButton>
@@ -43,5 +44,15 @@ describe("TabButton", () => {
     (await screen.findByRole("option", { name: "first item" })).click();
 
     expect(action).toHaveBeenCalledWith(value);
+  });
+
+  it("should not open the menu when disabled", async () => {
+    setup({ disabled: true });
+
+    userEvent.click(getIcon("chevrondown"));
+
+    expect(
+      screen.queryByRole("option", { name: "first item" }),
+    ).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/metabase/core/components/TabRow/TabRow.stories.tsx
+++ b/frontend/src/metabase/core/components/TabRow/TabRow.stories.tsx
@@ -56,8 +56,10 @@ const Template: ComponentStory<typeof TabRow> = args => {
         <TabButton value={5} menuItems={menuItems}>
           Tab 5
         </TabButton>
-        <TabButton value={6}>Tab 6</TabButton>
-        <TabButton value={7} menuItems={menuItems}>
+        <TabButton value={6} disabled>
+          Tab 6
+        </TabButton>
+        <TabButton value={7} menuItems={menuItems} disabled>
           Tab 7
         </TabButton>
       </TabRow>


### PR DESCRIPTION
Merging into branch `feature-dashboard-tabs`, not `master`.

Part of epic https://github.com/metabase/metabase/issues/29502

### Description

In the [design](https://www.figma.com/file/DuwiUCVo1K4EUBw50pGYPy/Tabs-in-dashboards?node-id=104-5378&t=YxdES2QfP3rKI3rv-4) for dashboard tabs, we have a disabled state for the tab component when the user has not yet added any tabs to the dashboard.

<img width="374" alt="Screenshot 2023-04-03 at 1 08 28 PM" src="https://user-images.githubusercontent.com/37751258/229615976-97ed1b3d-ef52-45a7-9adb-c43675cfe539.png">

This PR adds styles based on the `disabled` prop of the `TabButton` to support this.

### How to verify

`yarn storybook` -> `TabRow`

### Demo

<img width="682" alt="Screenshot 2023-04-03 at 11 16 02 AM" src="https://user-images.githubusercontent.com/37751258/229616406-498b22a6-bd94-44df-9ed9-da7df5f538da.png">


### Checklist

- [x] Tests have been added/updated to cover changes in this PR

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/29772)
<!-- Reviewable:end -->
