### PR TITLE
Forbid no-console in code

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -56,7 +56,7 @@
         ]
       }
     ],
-    "no-console": 0,
+    "no-console": [2, {"allow": ["warn", "error"]}],
     "react/no-is-mounted": 2,
     "react/prefer-es6-class": 2,
     "react/display-name": 1,

--- a/e2e/.eslintrc
+++ b/e2e/.eslintrc
@@ -1,7 +1,8 @@
 {
   "rules": {
     "import/no-commonjs": 0,
-    "no-color-literals": 0
+    "no-color-literals": 0,
+    "no-console": 0
   },
   "env": {
     "cypress/globals": true,

--- a/enterprise/frontend/src/metabase-enterprise/whitelabel/lib/whitelabel.js
+++ b/enterprise/frontend/src/metabase-enterprise/whitelabel/lib/whitelabel.js
@@ -197,5 +197,6 @@ export function enabledApplicationNameReplacement() {
 try {
   updateColorsJS();
 } catch (e) {
+  // eslint-disable-next-line no-console
   console.log(e);
 }

--- a/enterprise/frontend/src/metabase-enterprise/whitelabel/lib/whitelabel.js
+++ b/enterprise/frontend/src/metabase-enterprise/whitelabel/lib/whitelabel.js
@@ -197,6 +197,5 @@ export function enabledApplicationNameReplacement() {
 try {
   updateColorsJS();
 } catch (e) {
-  // eslint-disable-next-line no-console
-  console.log(e);
+  console.error(e);
 }

--- a/frontend/src/metabase/.eslintrc
+++ b/frontend/src/metabase/.eslintrc
@@ -10,5 +10,13 @@
         ]
       }
     ]
-  }
+  },
+  "overrides": [
+    {
+      "files": ["**/*.unit.spec.{js,jsx,ts,tsx}"],
+      "rules": {
+        "no-console": 0
+      }
+    }
+  ]
 }

--- a/frontend/src/metabase/admin/databases/database.js
+++ b/frontend/src/metabase/admin/databases/database.js
@@ -92,8 +92,7 @@ const migrateDatabaseToNewSchedulingSettings = database => {
         },
       });
     } else {
-      // eslint-disable-next-line no-console
-      console.log(
+      console.error(
         `${MIGRATE_TO_NEW_SCHEDULING_SETTINGS} is no-op as scheduling settings are already set`,
       );
     }
@@ -235,8 +234,7 @@ export const deleteDatabase = function (databaseId, isDetailView = true) {
       );
       dispatch({ type: DELETE_DATABASE, payload: { databaseId } });
     } catch (error) {
-      // eslint-disable-next-line no-console
-      console.log("error deleting database", error);
+      console.error("error deleting database", error);
       dispatch({
         type: DELETE_DATABASE_FAILED,
         payload: { databaseId, error },
@@ -256,8 +254,7 @@ export const syncDatabaseSchema = createThunkAction(
         MetabaseAnalytics.trackStructEvent("Databases", "Manual Sync");
         return call;
       } catch (error) {
-        // eslint-disable-next-line no-console
-        console.log("error syncing database", error);
+        console.error("error syncing database", error);
       }
     };
   },
@@ -270,8 +267,7 @@ export const dismissSyncSpinner = createThunkAction(
       try {
         await MetabaseApi.db_dismiss_sync_spinner({ dbId: databaseId });
       } catch (error) {
-        // eslint-disable-next-line no-console
-        console.log("error dismissing sync spinner for database", error);
+        console.error("error dismissing sync spinner for database", error);
       }
     };
   },
@@ -287,8 +283,7 @@ export const rescanDatabaseFields = createThunkAction(
         MetabaseAnalytics.trackStructEvent("Databases", "Manual Sync");
         return call;
       } catch (error) {
-        // eslint-disable-next-line no-console
-        console.log("error syncing database", error);
+        console.error("error syncing database", error);
       }
     };
   },
@@ -304,8 +299,7 @@ export const discardSavedFieldValues = createThunkAction(
         MetabaseAnalytics.trackStructEvent("Databases", "Manual Sync");
         return call;
       } catch (error) {
-        // eslint-disable-next-line no-console
-        console.log("error syncing database", error);
+        console.error("error syncing database", error);
       }
     };
   },

--- a/frontend/src/metabase/admin/databases/database.js
+++ b/frontend/src/metabase/admin/databases/database.js
@@ -92,6 +92,7 @@ const migrateDatabaseToNewSchedulingSettings = database => {
         },
       });
     } else {
+      // eslint-disable-next-line no-console
       console.log(
         `${MIGRATE_TO_NEW_SCHEDULING_SETTINGS} is no-op as scheduling settings are already set`,
       );
@@ -234,6 +235,7 @@ export const deleteDatabase = function (databaseId, isDetailView = true) {
       );
       dispatch({ type: DELETE_DATABASE, payload: { databaseId } });
     } catch (error) {
+      // eslint-disable-next-line no-console
       console.log("error deleting database", error);
       dispatch({
         type: DELETE_DATABASE_FAILED,
@@ -254,6 +256,7 @@ export const syncDatabaseSchema = createThunkAction(
         MetabaseAnalytics.trackStructEvent("Databases", "Manual Sync");
         return call;
       } catch (error) {
+        // eslint-disable-next-line no-console
         console.log("error syncing database", error);
       }
     };
@@ -267,6 +270,7 @@ export const dismissSyncSpinner = createThunkAction(
       try {
         await MetabaseApi.db_dismiss_sync_spinner({ dbId: databaseId });
       } catch (error) {
+        // eslint-disable-next-line no-console
         console.log("error dismissing sync spinner for database", error);
       }
     };
@@ -283,6 +287,7 @@ export const rescanDatabaseFields = createThunkAction(
         MetabaseAnalytics.trackStructEvent("Databases", "Manual Sync");
         return call;
       } catch (error) {
+        // eslint-disable-next-line no-console
         console.log("error syncing database", error);
       }
     };
@@ -299,6 +304,7 @@ export const discardSavedFieldValues = createThunkAction(
         MetabaseAnalytics.trackStructEvent("Databases", "Manual Sync");
         return call;
       } catch (error) {
+        // eslint-disable-next-line no-console
         console.log("error syncing database", error);
       }
     };

--- a/frontend/src/metabase/admin/datamodel/field.js
+++ b/frontend/src/metabase/admin/datamodel/field.js
@@ -19,8 +19,7 @@ export const rescanFieldValues = createThunkAction(
         );
         return call;
       } catch (error) {
-        // eslint-disable-next-line no-console
-        console.log("error manually re-scanning field values", error);
+        console.error("error manually re-scanning field values", error);
       }
     };
   },
@@ -38,8 +37,7 @@ export const discardFieldValues = createThunkAction(
         );
         return call;
       } catch (error) {
-        // eslint-disable-next-line no-console
-        console.log("error discarding field values", error);
+        console.error("error discarding field values", error);
       }
     };
   },

--- a/frontend/src/metabase/admin/datamodel/field.js
+++ b/frontend/src/metabase/admin/datamodel/field.js
@@ -19,6 +19,7 @@ export const rescanFieldValues = createThunkAction(
         );
         return call;
       } catch (error) {
+        // eslint-disable-next-line no-console
         console.log("error manually re-scanning field values", error);
       }
     };
@@ -37,6 +38,7 @@ export const discardFieldValues = createThunkAction(
         );
         return call;
       } catch (error) {
+        // eslint-disable-next-line no-console
         console.log("error discarding field values", error);
       }
     };

--- a/frontend/src/metabase/admin/datamodel/table.js
+++ b/frontend/src/metabase/admin/datamodel/table.js
@@ -19,6 +19,7 @@ export const rescanTableFieldValues = createThunkAction(
         );
         return call;
       } catch (error) {
+        // eslint-disable-next-line no-console
         console.log("error manually re-scanning field values", error);
       }
     };
@@ -37,6 +38,7 @@ export const discardTableFieldValues = createThunkAction(
         );
         return call;
       } catch (error) {
+        // eslint-disable-next-line no-console
         console.log("error discarding field values", error);
       }
     };

--- a/frontend/src/metabase/admin/datamodel/table.js
+++ b/frontend/src/metabase/admin/datamodel/table.js
@@ -19,8 +19,7 @@ export const rescanTableFieldValues = createThunkAction(
         );
         return call;
       } catch (error) {
-        // eslint-disable-next-line no-console
-        console.log("error manually re-scanning field values", error);
+        console.error("error manually re-scanning field values", error);
       }
     };
   },
@@ -38,8 +37,7 @@ export const discardTableFieldValues = createThunkAction(
         );
         return call;
       } catch (error) {
-        // eslint-disable-next-line no-console
-        console.log("error discarding field values", error);
+        console.error("error discarding field values", error);
       }
     };
   },

--- a/frontend/src/metabase/admin/settings/settings.js
+++ b/frontend/src/metabase/admin/settings/settings.js
@@ -43,6 +43,7 @@ export const initializeSettings = createThunkAction(
     try {
       await dispatch(reloadSettings());
     } catch (error) {
+      // eslint-disable-next-line no-console
       console.log("error fetching settings", error);
       throw error;
     }
@@ -57,6 +58,7 @@ export const updateSetting = createThunkAction(
       try {
         await SettingsApi.put(setting);
       } catch (error) {
+        // eslint-disable-next-line no-console
         console.log("error updating setting", setting, error);
         throw error;
       } finally {
@@ -74,6 +76,7 @@ export const updateSettings = createThunkAction(
       try {
         await SettingsApi.putAll(settings);
       } catch (error) {
+        // eslint-disable-next-line no-console
         console.log("error updating settings", settings, error);
         throw error;
       } finally {
@@ -94,6 +97,7 @@ export const updateEmailSettings = createThunkAction(
         await dispatch(reloadSettings());
         return result;
       } catch (error) {
+        // eslint-disable-next-line no-console
         console.log("error updating email settings", settings, error);
         throw error;
       }
@@ -107,6 +111,7 @@ export const sendTestEmail = createThunkAction(SEND_TEST_EMAIL, function () {
     try {
       await EmailApi.sendTest();
     } catch (error) {
+      // eslint-disable-next-line no-console
       console.log("error sending test email", error);
       throw error;
     }

--- a/frontend/src/metabase/admin/settings/settings.js
+++ b/frontend/src/metabase/admin/settings/settings.js
@@ -43,8 +43,7 @@ export const initializeSettings = createThunkAction(
     try {
       await dispatch(reloadSettings());
     } catch (error) {
-      // eslint-disable-next-line no-console
-      console.log("error fetching settings", error);
+      console.error("error fetching settings", error);
       throw error;
     }
   },
@@ -58,8 +57,7 @@ export const updateSetting = createThunkAction(
       try {
         await SettingsApi.put(setting);
       } catch (error) {
-        // eslint-disable-next-line no-console
-        console.log("error updating setting", setting, error);
+        console.error("error updating setting", setting, error);
         throw error;
       } finally {
         await dispatch(reloadSettings());
@@ -76,8 +74,7 @@ export const updateSettings = createThunkAction(
       try {
         await SettingsApi.putAll(settings);
       } catch (error) {
-        // eslint-disable-next-line no-console
-        console.log("error updating settings", settings, error);
+        console.error("error updating settings", settings, error);
         throw error;
       } finally {
         await dispatch(reloadSettings());
@@ -97,8 +94,7 @@ export const updateEmailSettings = createThunkAction(
         await dispatch(reloadSettings());
         return result;
       } catch (error) {
-        // eslint-disable-next-line no-console
-        console.log("error updating email settings", settings, error);
+        console.error("error updating email settings", settings, error);
         throw error;
       }
     };
@@ -111,8 +107,7 @@ export const sendTestEmail = createThunkAction(SEND_TEST_EMAIL, function () {
     try {
       await EmailApi.sendTest();
     } catch (error) {
-      // eslint-disable-next-line no-console
-      console.log("error sending test email", error);
+      console.error("error sending test email", error);
       throw error;
     }
   };

--- a/frontend/src/metabase/lib/card.js
+++ b/frontend/src/metabase/lib/card.js
@@ -32,8 +32,7 @@ export async function loadCard(cardId, { dispatch, getState }) {
     });
     return card;
   } catch (error) {
-    // eslint-disable-next-line no-console
-    console.log("error loading card", error);
+    console.error("error loading card", error);
     throw error;
   }
 }

--- a/frontend/src/metabase/lib/card.js
+++ b/frontend/src/metabase/lib/card.js
@@ -32,6 +32,7 @@ export async function loadCard(cardId, { dispatch, getState }) {
     });
     return card;
   } catch (error) {
+    // eslint-disable-next-line no-console
     console.log("error loading card", error);
     throw error;
   }

--- a/frontend/src/metabase/lib/dashboard_grid.js
+++ b/frontend/src/metabase/lib/dashboard_grid.js
@@ -75,6 +75,7 @@ function printGrid(cards, width) {
       }
     }
   }
+  // eslint-disable-next-line no-console
   console.log("\n" + grid.map(row => row.join(".")).join("\n") + "\n");
 }
 /*eslint-enable */

--- a/frontend/src/metabase/lib/dashboard_grid.js
+++ b/frontend/src/metabase/lib/dashboard_grid.js
@@ -75,7 +75,6 @@ function printGrid(cards, width) {
       }
     }
   }
-
   console.log("\n" + grid.map(row => row.join(".")).join("\n") + "\n");
 }
 /*eslint-enable */

--- a/frontend/src/metabase/lib/dashboard_grid.js
+++ b/frontend/src/metabase/lib/dashboard_grid.js
@@ -75,7 +75,7 @@ function printGrid(cards, width) {
       }
     }
   }
-  // eslint-disable-next-line no-console
+
   console.log("\n" + grid.map(row => row.join(".")).join("\n") + "\n");
 }
 /*eslint-enable */

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx
@@ -361,8 +361,7 @@ class NativeQueryEditor extends Component {
           }));
           callback(null, resultsForAce);
         } catch (error) {
-          // eslint-disable-next-line no-console
-          console.log("error getting autocompletion data", error);
+          console.error("error getting autocompletion data", error);
           callback(null, []);
         }
       },

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx
@@ -361,6 +361,7 @@ class NativeQueryEditor extends Component {
           }));
           callback(null, resultsForAce);
         } catch (error) {
+          // eslint-disable-next-line no-console
           console.log("error getting autocompletion data", error);
           callback(null, []);
         }

--- a/frontend/src/metabase/query_builder/components/VisualizationError.jsx
+++ b/frontend/src/metabase/query_builder/components/VisualizationError.jsx
@@ -95,6 +95,7 @@ class VisualizationError extends Component {
 
   render() {
     const { via, question, duration, error, className } = this.props;
+    // eslint-disable-next-line no-console
     console.log("error", error);
 
     if (error && typeof error.status === "number") {

--- a/frontend/src/metabase/query_builder/components/VisualizationError.jsx
+++ b/frontend/src/metabase/query_builder/components/VisualizationError.jsx
@@ -95,8 +95,7 @@ class VisualizationError extends Component {
 
   render() {
     const { via, question, duration, error, className } = this.props;
-    // eslint-disable-next-line no-console
-    console.log("error", error);
+    console.error(error);
 
     if (error && typeof error.status === "number") {
       // Assume if the request took more than 15 seconds it was due to a timeout

--- a/frontend/src/metabase/selectors/metadata.unit.spec.js
+++ b/frontend/src/metabase/selectors/metadata.unit.spec.js
@@ -44,7 +44,6 @@ describe("getMetadata", () => {
 
   describe("connected database", () => {
     it("should have the proper number of tables", () => {
-      // console.log("metadata.databases", metadata.databases);
       const tableCount = Object.values(metadata.databases).reduce(
         (sum, db) => sum + db.tables.length,
         0,

--- a/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.jsx
+++ b/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.jsx
@@ -1109,6 +1109,7 @@ class TableInteractive extends Component {
 
       setTimeout(() => {
         const end = Date.now();
+        // eslint-disable-next-line no-console
         console.log(end - start);
         start = end;
 

--- a/frontend/test/.eslintrc
+++ b/frontend/test/.eslintrc
@@ -1,7 +1,8 @@
 {
   "rules": {
     "import/no-commonjs": 0,
-    "no-color-literals": 0
+    "no-color-literals": 0,
+    "no-console": 0
   },
   "env": {
     "node": true


### PR DESCRIPTION
### Description

Ever left `console.log` in your PR? you wasted CI time, time of reviewers and your time to fix it. 
Eslint can save you.

`console.error` and `console.warn` are allowed.

`console.log` is allowed in `unit.spec.*` and e2e.

For other cases if you really need `console.log`, use

```js
// eslint-disable-next-line no-console
console.log('my important log');
```

### How to verify

`yarn lint` should pass

adding `console.log` in the code should lead to lint fail.

### Demo

_Upload a demo video or before/after screenshots if sensible or remove the section_

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/29792)
<!-- Reviewable:end -->
