### PR TITLE
Enable fix for eslint by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -345,16 +345,16 @@
       "prettier --write"
     ],
     "+(enterprise|frontend)/**/*.{js,jsx,ts,tsx}": [
-      "eslint --rulesdir frontend/lint/eslint-rules --max-warnings 0",
+      "eslint --rulesdir frontend/lint/eslint-rules --max-warnings 0 --fix",
       "prettier --write",
       "node ./bin/verify-doc-links"
     ],
     "e2e/**/*.{js,jsx,ts,jsx}": [
-      "eslint --rulesdir frontend/lint/eslint-rules --max-warnings 0",
+      "eslint --rulesdir frontend/lint/eslint-rules --max-warnings 0 --fix",
       "prettier --write"
     ],
     "e2e/test/scenarios/*/{*.js,!(helpers|shared)/*.js}": [
-      "eslint --rulesdir frontend/lint/eslint-rules --max-warnings 0",
+      "eslint --rulesdir frontend/lint/eslint-rules --max-warnings 0 --fix",
       "node e2e/validate-e2e-test-files.js"
     ]
   },


### PR DESCRIPTION
I found annoying to look for a way to pass `--fix` flag on pre-commit if e.g. import order is not correct. All auto-fixable problems should be fixed automatically!

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/29794)
<!-- Reviewable:end -->
