### PR TITLE
create renameable `TabButton` variant

### DIFF
--- a/frontend/src/metabase/core/components/Tab/utils.ts
+++ b/frontend/src/metabase/core/components/Tab/utils.ts
@@ -6,6 +6,6 @@ export function getTabPanelId<T>(idPrefix: string, value: T): string {
   return `${idPrefix}-P-${value}`;
 }
 
-export function getTabButtonLabelId<T>(idPrefix: string, value: T): string {
-  return `${idPrefix}-B-L-${value}`;
+export function getTabButtonInputId<T>(idPrefix: string, value: T): string {
+  return `${idPrefix}-B-I-${value}`;
 }

--- a/frontend/src/metabase/core/components/TabButton/TabButton.styled.tsx
+++ b/frontend/src/metabase/core/components/TabButton/TabButton.styled.tsx
@@ -9,14 +9,26 @@ export interface TabButtonProps {
   disabled?: boolean;
 }
 
-export const TabButtonLabel = styled.div`
-  width: 100%;
+export const TabButtonInput = styled.input<TabButtonProps & { value: string }>`
+  width: ${props => `${props.value.length}ch`};
+  padding: 0;
+
+  border: none;
+  outline: none;
+  background-color: ${color("bg-light")};
+
+  color: ${props => (props.isSelected ? color("brand") : color("text-dark"))};
   font-weight: bold;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  text-align: center;
+
+  ${props =>
+    props.disabled &&
+    css`
+      pointer-events: none;
+    `}
 `;
 
-export const TabButtonRoot = styled.button<TabButtonProps>`
+export const TabButtonRoot = styled.div<TabButtonProps>`
   display: flex;
 
   padding: 1rem 0;

--- a/frontend/src/metabase/core/components/TabButton/TabButtonMenu.tsx
+++ b/frontend/src/metabase/core/components/TabButton/TabButtonMenu.tsx
@@ -1,6 +1,6 @@
 import React, { useContext } from "react";
 import { TabContext } from "../Tab/TabContext";
-import { getTabButtonLabelId } from "../Tab/utils";
+import { getTabButtonInputId } from "../Tab/utils";
 import {
   TabButtonMenuAction,
   TabButtonMenuItem,
@@ -29,7 +29,7 @@ export default function TabButtonMenu({
   return (
     <MenuContent
       role="listbox"
-      aria-labelledby={getTabButtonLabelId(context.idPrefix, value)}
+      aria-labelledby={getTabButtonInputId(context.idPrefix, value)}
       tabIndex={0}
     >
       {menuItems.map(({ label, action }) => (

--- a/frontend/src/metabase/core/components/TabRow/TabRow.stories.tsx
+++ b/frontend/src/metabase/core/components/TabRow/TabRow.stories.tsx
@@ -18,7 +18,7 @@ const sampleStyle = {
   display: "flex",
   flexDirection: "column" as const,
   gap: "8px",
-  maxWidth: "800px",
+  width: "100%",
   padding: "10px",
   border: "1px solid #ccc",
 };
@@ -45,23 +45,20 @@ const Template: ComponentStory<typeof TabRow> = args => {
   return (
     <div style={sampleStyle}>
       <TabRow {...args} value={value} onChange={handleChange}>
-        <TabButton value={1} menuItems={menuItems}>
-          Tab 1
-        </TabButton>
-        <TabButton value={2}>Tab 2</TabButton>
-        <TabButton value={3} menuItems={menuItems}>
-          Tab 3
-        </TabButton>
-        <TabButton value={4}>Tab 4</TabButton>
-        <TabButton value={5} menuItems={menuItems}>
-          Tab 5
-        </TabButton>
-        <TabButton value={6} disabled>
-          Tab 6
-        </TabButton>
-        <TabButton value={7} menuItems={menuItems} disabled>
-          Tab 7
-        </TabButton>
+        <TabButton label="Tab 1" value={1} menuItems={menuItems} />
+        <TabButton label="Tab 2" value={2} />
+        <TabButton.Renameable
+          label="Tab 3 (Renameable)"
+          value={3}
+          menuItems={menuItems}
+          onRename={newLabel => setMessage(`Renamed to "${newLabel}"`)}
+          renameMenuIndex={2}
+          renameMenuLabel="Edit name"
+        />
+        <TabButton label="Tab 4" value={4} />
+        <TabButton label="Tab 5" value={5} menuItems={menuItems} />
+        <TabButton label="Tab 6" value={6} disabled />
+        <TabButton label="Tab 7" value={7} menuItems={menuItems} disabled />
       </TabRow>
       {message}
     </div>

--- a/frontend/src/metabase/core/components/TabRow/TabRow.styled.tsx
+++ b/frontend/src/metabase/core/components/TabRow/TabRow.styled.tsx
@@ -10,6 +10,7 @@ export const TabList = styled(BaseTabList)`
 
   ${BaseTabList.Content} {
     display: flex;
+    overflow: hidden;
   }
 
   ${TabLink.Root}:not(:last-child) {

--- a/frontend/src/metabase/core/components/TabRow/TabRow.unit.spec.tsx
+++ b/frontend/src/metabase/core/components/TabRow/TabRow.unit.spec.tsx
@@ -10,8 +10,8 @@ const TestTabRow = () => {
 
   return (
     <TabRow value={value} onChange={setValue}>
-      <TabButton value={1}>Tab 1</TabButton>
-      <TabButton value={2}>Tab 2</TabButton>
+      <TabButton label="Tab 1" value={1} />
+      <TabButton label="Tab 2" value={2} />
     </TabRow>
   );
 };


### PR DESCRIPTION
Mering into `feature-dashboard-tabs`, not `master`.

Part of epic https://github.com/metabase/metabase/issues/29502

### Description

Per our [design](https://www.figma.com/file/DuwiUCVo1K4EUBw50pGYPy/Tabs-in-dashboards?node-id=104-5192&t=gVuUpLzKcCWwbUr6-4), we need to be able to rename the label of the tab component for dashboard tabs.

<img width="268" alt="Screenshot 2023-04-04 at 8 21 00 AM" src="https://user-images.githubusercontent.com/37751258/229840225-ec7e3eb3-0165-415c-8627-0c2da60e454d.png">

This PR creates a reusable variant of `TabButton`, `TabButton.Renameable`, that provides that behavior.

### How to verify

`yarn storybook` -> `TabRow`

### Demo

https://user-images.githubusercontent.com/37751258/229857872-716ba056-aeda-4541-b39a-bbf049b0727f.mov

### Checklist

- [x] Tests have been added/updated to cover changes in this PR

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/29801)
<!-- Reviewable:end -->
