### PR TITLE
Dashboard Tab entity

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/seed_entity_ids.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/seed_entity_ids.clj
@@ -40,7 +40,6 @@
   []
   (into {}
         (for [model (toucan-models)
-              :when (mdb.u/toucan-model? model)
               :let  [table-name (some-> model t2/table-name name)]
               :when table-name
               ;; ignore any models defined in test namespaces.

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -14378,6 +14378,93 @@ databaseChangeLog:
                   constraints:
                     nullable: false
 
+  - changeSet:
+      id: v47.00-006
+      author: qnkhuat
+      comment: Added 0.47.0 - Add dashboard_tab table
+      changes:
+        - createTable:
+            tableName: dashboard_tab
+            remarks: "Join table connecting dashboard to dashboardcards"
+            columns:
+              - column:
+                  name: id
+                  type: int
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: dashboard_id
+                  type: int
+                  remarks: The dashboard that a tab is on
+                  constraints:
+                    nullable: false
+                    referencedTableName: report_dashboard
+                    referencedColumnNames: id
+                    foreignKeyName: fk_dashboard_tab_ref_dashboard_id
+                    deleteCascade: true
+              - column:
+                  name: name
+                  remarks: Displayed name of the tab
+                  type: ${text.type}
+                  constraints:
+                    nullable: false
+              - column:
+                  name: position
+                  remarks: Position of the tab with respect to others tabs in dashboard
+                  type: int
+                  constraints:
+                    nullable: false
+              - column:
+                  name: entity_id
+                  type: char(21)
+                  remarks: Random NanoID tag for unique identity.
+                  constraints:
+                    nullable: false
+                    unique: true
+              - column:
+                  name: created_at
+                  remarks: The timestamp at which the tab was created
+                  type: ${timestamp_type}
+                  defaultValueComputed: current_timestamp
+                  constraints:
+                    nullable: false
+              - column:
+                  name: updated_at
+                  remarks: The timestamp at which the tab was last updated
+                  type: ${timestamp_type}
+                  defaultValueComputed: current_timestamp
+                  constraints:
+                    nullable: false
+
+  - changeSet:
+      id: v47.00-007
+      author: qnkhuat
+      comment: Added 0.47.0 -- add report_dashboardcard.dashboard_tab_id
+      changes:
+        - addColumn:
+            tableName: report_dashboardcard
+            columns:
+              - column:
+                  name: dashboard_tab_id
+                  type: int
+                  remarks: The referenced tab id that dashcard is on, it's nullable for dashboard with no tab
+                  constraints:
+                    nullable: true
+
+  - changeSet:
+      id: v47.00-008
+      author: qnkhuat
+      comment: Added 0.47.0 -- add report_dashboardcard.dashboard_tab_id fk constraint
+      changes:
+        - addForeignKeyConstraint:
+            baseTableName: report_dashboardcard
+            baseColumnNames: dashboard_tab_id
+            referencedTableName: dashboard_tab
+            referencedColumnNames: id
+            constraintName: fk_report_dashboardcard_ref_dashboard_tab_id
+            deleteCascade: true
 
 # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 

--- a/src/metabase/db/util.clj
+++ b/src/metabase/db/util.clj
@@ -13,10 +13,7 @@
   "Check if `model` is a toucan model.
   In toucan2 any keywords can be a model so it's always true for keyword."
   [model]
-  (if (keyword? model)
-    true
-    #_{:clj-kondo/ignore [:discouraged-var]}
-    (models/model? model)))
+  (or (keyword? model) (models/model? model)))
 
 (defn primary-key
   "Replacement of [[mdb.u/primary-key]], this is used to make the transition to toucan 2 easier.

--- a/src/metabase/models.clj
+++ b/src/metabase/models.clj
@@ -11,6 +11,7 @@
    [metabase.models.dashboard :as dashboard]
    [metabase.models.dashboard-card :as dashboard-card]
    [metabase.models.dashboard-card-series :as dashboard-card-series]
+   [metabase.models.dashboard-tab :as dashboard-tab]
    [metabase.models.database :as database]
    [metabase.models.dimension :as dimension]
    [metabase.models.field :as field]
@@ -56,6 +57,7 @@
          dashboard/keep-me
          dashboard-card/keep-me
          dashboard-card-series/keep-me
+         dashboard-tab/keep-me
          database/keep-me
          dimension/keep-me
          field/keep-me

--- a/src/metabase/models/dashboard.clj
+++ b/src/metabase/models/dashboard.clj
@@ -55,6 +55,12 @@
                            [:= :card.archived nil]]] ; e.g. DashCards with no corresponding Card, e.g. text Cards
               :order-by  [[:dashcard.created_at :asc]]}))
 
+(mi/define-simple-hydration-method ordered-tabs
+  :ordered_tabs
+  "Return the ordered DashboardTabs associated with `dashboard-or-id`, sorted by tab position."
+  [dashboard-or-id]
+  (t2/select :model/DashboardTab :dashboard_id (u/the-id dashboard-or-id) {:order-by [[:position :asc]]}))
+
 (mi/define-batched-hydration-method collections-authority-level
   :collection_authority_level
   "Efficiently hydrate the `:collection_authority_level` of a sequence of dashboards."

--- a/src/metabase/models/dashboard_tab.clj
+++ b/src/metabase/models/dashboard_tab.clj
@@ -2,6 +2,7 @@
   (:require
    [metabase.models.dashboard :refer [Dashboard]]
    [metabase.models.interface :as mi]
+   [metabase.models.serialization :as serdes]
    [methodical.core :as methodical]
    [toucan2.core :as t2]))
 
@@ -19,3 +20,12 @@
   (let [dashboard (or (:dashboard dashtab)
                       (t2/select-one Dashboard :id (:dashboard_id dashtab)))]
     (mi/perms-objects-set dashboard read-or-write)))
+
+(defmethod serdes/hash-fields :model/DashboardTab
+  [_dashboard-tab]
+  [:name
+   (comp serdes/identity-hash
+        #(t2/select-one Dashboard :id %)
+        :dashboard_id)
+   :position
+   :created_at])

--- a/src/metabase/models/dashboard_tab.clj
+++ b/src/metabase/models/dashboard_tab.clj
@@ -1,0 +1,21 @@
+(ns metabase.models.dashboard-tab
+  (:require
+   [metabase.models.dashboard :refer [Dashboard]]
+   [metabase.models.interface :as mi]
+   [methodical.core :as methodical]
+   [toucan2.core :as t2]))
+
+(methodical/defmethod t2/table-name :model/DashboardTab [_model] :dashboard_tab)
+
+(doto :model/DashboardTab
+  (derive :metabase/model)
+  (derive ::mi/read-policy.full-perms-for-perms-set)
+  (derive ::mi/write-policy.full-perms-for-perms-set)
+  (derive :hook/timestamped?)
+  (derive :hook/entity-id))
+
+(defmethod mi/perms-objects-set :model/DashboardTab
+  [dashtab read-or-write]
+  (let [dashboard (or (:dashboard dashtab)
+                      (t2/select-one Dashboard :id (:dashboard_id dashtab)))]
+    (mi/perms-objects-set dashboard read-or-write)))

--- a/src/metabase/models/interface.clj
+++ b/src/metabase/models/interface.clj
@@ -374,6 +374,40 @@
   :args ::define-hydration-method
   :ret  any?)
 
+;;; +----------------------------------------------------------------------------------------------------------------+
+;;; |                                               Toucan 2 Extensions                                              |
+;;; +----------------------------------------------------------------------------------------------------------------+
+
+;; --- predefined hooks
+
+(t2/define-before-insert :hook/timestamped?
+  [instance]
+  (-> instance
+      add-updated-at-timestamp
+      add-created-at-timestamp))
+
+(t2/define-before-update :hook/timestamped?
+  [instance]
+  (-> instance
+      add-updated-at-timestamp))
+
+(t2/define-before-insert :hook/created-at-timestamped?
+  [instance]
+  (-> instance
+      add-created-at-timestamp))
+
+(t2/define-before-insert :hook/updated-at-timestamped?
+  [instance]
+  (-> instance
+      add-updated-at-timestamp))
+
+(t2/define-before-insert :hook/entity-id
+  [instance]
+  (-> instance
+      add-entity-id))
+
+(methodical/prefer-method! #'t2.before-insert/before-insert :hook/timestamped? :hook/entity-id)
+
 
 (methodical/defmethod t2.model/resolve-model :around clojure.lang.Symbol
   "Handle models deriving from :metabase/model."

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -321,6 +321,7 @@
                                                                                        :entity_id              (:entity_id card)
                                                                                        :visualization_settings {}
                                                                                        :result_metadata        nil})
+                                                   :dashboard_tab_id           nil
                                                    :series                     []}]})
                    (dashboard-response (mt/user-http-request :rasta :get 200 (format "dashboard/%d" dashboard-id)))))))))
 
@@ -411,6 +412,7 @@
                                                                                              :query_type             nil
                                                                                              :visualization_settings {}
                                                                                              :result_metadata        nil})
+                                                         :dashboard_tab_id           nil
                                                          :series                     []}]})
                    (dashboard-response (mt/user-http-request :rasta :get 200 (format "dashboard/%d" dashboard-id)))))))))
     (testing "fetch a dashboard from an official collection includes the collection type"
@@ -1335,6 +1337,7 @@
                   :col                        4
                   :row                        4
                   :series                     []
+                  :dashboard_tab_id           nil
                   :parameter_mappings         [{:parameter_id "abc" :card_id 123, :hash "abc", :target "foo"}]
                   :visualization_settings     {}
                   :created_at                 true

--- a/test/metabase/models/dashboard_tab_test.clj
+++ b/test/metabase/models/dashboard_tab_test.clj
@@ -1,0 +1,89 @@
+(ns metabase.models.dashboard-tab-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase.api.common :as api]
+   [metabase.models :refer [Card Collection Dashboard DashboardCard]]
+   [metabase.models.interface :as mi]
+   [metabase.models.permissions :as perms]
+   [metabase.test :as mt]
+   [metabase.test.fixtures :as fixtures]
+   [toucan2.core :as t2]
+   [toucan2.tools.with-temp :as t2.with-temp]))
+
+(use-fixtures
+  :once
+  (fixtures/initialize :test-users-personal-collections))
+
+(defn do-with-dashtab-in-personal-collection [f]
+  (let [owner-id (mt/user->id :rasta)
+        coll     (t2/select-one Collection :personal_owner_id owner-id)]
+    (t2.with-temp/with-temp
+      [Card            card     {}
+       Dashboard       dash     {:collection_id (:id coll)}
+       :model/DashboardTab dashtab  {:dashboard_id (:id dash)}
+       DashboardCard   dashcard {:dashboard_id (:id dash) :card_id (:id card) :dashboard_tab_id (:id dashtab)}]
+      (f {:owner-id   owner-id
+          :collection coll
+          :card       card
+          :dashboard  dash
+          :dashcard   dashcard
+          :dashtab    dashtab}))))
+
+(defmacro with-dashtab-in-personal-collection
+  [binding & body]
+  `(do-with-dashtab-in-personal-collection (fn [~binding] ~@body)))
+
+(deftest perms-test
+  (with-dashtab-in-personal-collection {:keys [collection dashboard dashtab] :as _dashtab}
+    (testing "dashtab's permission is the permission of dashboard they're on"
+      (is (= (mi/perms-objects-set dashtab :read)
+             (mi/perms-objects-set dashboard :read)))
+      (is (= (mi/perms-objects-set dashtab :write)
+             (mi/perms-objects-set dashboard :write))))
+
+    (testing (str "Check that if a Dashtab of a Dashboard is in a Collection, someone who would not be able to see it under the old "
+                  "artifact-permissions regime will be able to see it if they have permissions for that Collection")
+      (binding [api/*current-user-permissions-set* (delay #{(perms/collection-read-path collection)})]
+        (mi/perms-objects-set dashtab :read)
+        (is (= true (mi/can-read? dashtab)))
+        (is (= false (mi/can-write? dashtab)))))
+
+    (testing "Do we have *write* Permissions for a dashtab if we have *write* Permissions for the Collection it's in?"
+      (binding [api/*current-user-permissions-set* (delay #{(perms/collection-readwrite-path collection)})]
+        (is (= true (mi/can-read? dashtab)))
+        (is (= true (mi/can-write? dashtab)))))
+
+    (testing "A user that can't see the Collection that the Dashboard is in can't read and write the dashtab"
+      (mt/with-current-user (mt/user->id :lucky)
+        (is (= false (mi/can-read? dashboard)))
+        (is (= false (mi/can-write? dashboard)))))
+
+    (testing "A user that can see the Collection that the Dashboard is in can read and write the dashtab"
+      (mt/with-current-user (mt/user->id :rasta)
+        (is (= true (mi/can-read? dashboard)))
+        (is (= true (mi/can-write? dashboard)))))))
+
+(deftest dependency-test
+  (testing "Deleting a dashtab should delete the associated dashboardcards"
+    (with-dashtab-in-personal-collection {:keys [dashtab dashcard]}
+      (t2/delete! dashtab)
+      (is (= nil (t2/select-one DashboardCard :id (:id dashcard))))))
+
+  (testing "Deleting a dashboard will delete all its dashcards"
+    (with-dashtab-in-personal-collection {:keys [dashboard dashtab dashcard]}
+      (t2/delete! dashboard)
+      (is (= nil (t2/select-one :model/DashboardTab :id (:id dashtab))))
+      (is (= nil (t2/select-one DashboardCard :id (:id dashcard)))))))
+
+(deftest hydration-test
+  (testing "hydrate a dashboard will return all of its tabs"
+    (t2.with-temp/with-temp
+      [Card            card      {}
+       Dashboard       dashboard {}
+       :model/DashboardTab dashtab-1 {:dashboard_id (:id dashboard) :position 0}
+       :model/DashboardTab dashtab-2 {:dashboard_id (:id dashboard) :position 1}
+       DashboardCard   _         {:dashboard_id (:id dashboard) :card_id (:id card) :dashboard_tab_id (:id dashtab-1)}
+       DashboardCard   _         {:dashboard_id (:id dashboard) :card_id (:id card) :dashboard_tab_id (:id dashtab-2)}]
+      (is (=? {:ordered_tabs [{:id (:id dashtab-1) :position 0 :dashboard_id (:id dashboard)}
+                              {:id (:id dashtab-2) :position 1 :dashboard_id (:id dashboard)}]}
+              (t2/hydrate dashboard :ordered_tabs))))))

--- a/test/metabase/test/util.clj
+++ b/test/metabase/test/util.clj
@@ -137,6 +137,11 @@
    DashboardCardSeries
    (constantly {:position 0})
 
+   :model/DashboardTab
+   (fn [_]
+     {:name     (tu.random/random-name)
+      :position 0})
+
    Database
    (fn [_] {:details   {}
             :engine    :h2


### PR DESCRIPTION
BE for milestone 1 of https://github.com/metabase/metabase/issues/29502

This PR adds a new table `report_dashboardtab` that will be used to store tabs info for a dashboard.
To know how it's going to be used, see https://github.com/metabase/metabase/pull/29861

[Eng doc](https://www.notion.so/metabase/Engineering-Notes-Data-Model-Plan-92672ca13d9c4d45921df269bf13a657?pvs=4)

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/29802)
<!-- Reviewable:end -->
