### PR TITLE
Fix serdes v2 entity id backfill

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/backfill_ids.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/backfill_ids.clj
@@ -28,7 +28,7 @@
         (t2/update! model (get entity pk) {:entity_id eid})))))
 
 (defn- has-entity-id? [model]
-  (:entity-id (models/properties model)))
+  (::mi/entity-id (models/properties model)))
 
 (defn backfill-ids
   "Updates all rows of all models that are (a) serialized and (b) have `entity_id` columns to have the

--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/backfill_ids.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/backfill_ids.clj
@@ -28,7 +28,7 @@
         (t2/update! model (get entity pk) {:entity_id eid})))))
 
 (defn- has-entity-id? [model]
-  (::mi/entity-id (models/properties model)))
+  (:entity-id (models/properties model)))
 
 (defn backfill-ids
   "Updates all rows of all models that are (a) serialized and (b) have `entity_id` columns to have the

--- a/src/metabase/models/action.clj
+++ b/src/metabase/models/action.clj
@@ -46,6 +46,12 @@
                (u/update-if-exists template :parameters (mi/catch-normalization-exceptions mi/normalize-parameters-list)))
              mi/json-out-with-keywordization))
 
+(mi/define-simple-hydration-method model
+  :model
+  "Return the DashboardCard this action uses as a model."
+  [{:keys [model_id]}]
+  (t2/select-one Card :id model_id))
+
 (defn- check-model-is-not-a-saved-question
   [model-id]
   (when-not (t2/select-one-fn :dataset Card :id model-id)

--- a/src/metabase/models/action.clj
+++ b/src/metabase/models/action.clj
@@ -48,7 +48,7 @@
 
 (mi/define-simple-hydration-method model
   :model
-  "Return the DashboardCard this action uses as a model."
+  "Return the Card this action uses as a model."
   [{:keys [model_id]}]
   (t2/select-one Card :id model_id))
 

--- a/test/metabase/models/action_test.clj
+++ b/test/metabase/models/action_test.clj
@@ -84,6 +84,14 @@
                        :parameters [{:id "id" :type :number}]}
                       (hydrate (action/select-action :id action-id) :creator)))))))
 
+(deftest hydrate-model-test
+  (mt/test-drivers (mt/normal-drivers-with-feature :actions/custom)
+    (mt/with-actions-test-data-and-actions-enabled
+      (mt/with-actions [{:keys [model-id action-id] :as _context} {}]
+        (let [action (hydrate (action/select-action :id action-id) :model)]
+          (is (some? (:model action)))
+          (is (= (:id (:model action)) model-id)))))))
+
 (deftest dashcard-deletion-test
   (mt/test-drivers (mt/normal-drivers-with-feature :actions/custom)
     (mt/with-actions-enabled


### PR DESCRIPTION
This fixes `:entity-id` for Action which relied on previously-unimplemented `:model` hydration.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/29808)
<!-- Reviewable:end -->
