### PR TITLE
fix drill-through on legend for stacked charts

### DIFF
--- a/e2e/test/scenarios/visualizations/bar_chart.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/bar_chart.cy.spec.js
@@ -10,7 +10,7 @@ import {
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 
-const { ORDERS, ORDERS_ID, PEOPLE, PRODUCTS } = SAMPLE_DATABASE;
+const { ORDERS, ORDERS_ID, PEOPLE, PRODUCTS, PRODUCTS_ID } = SAMPLE_DATABASE;
 
 describe("scenarios > visualizations > bar chart", () => {
   beforeEach(() => {
@@ -275,6 +275,32 @@ describe("scenarios > visualizations > bar chart", () => {
       });
 
       cy.get("g.axis.yr").should("not.exist");
+    });
+  });
+
+  describe("with stacked bars", () => {
+    it("should drill-through correctly when stacking", () => {
+      visitQuestionAdhoc({
+        dataset_query: {
+          database: SAMPLE_DB_ID,
+          type: "query",
+          query: {
+            "source-table": PRODUCTS_ID,
+            aggregation: [["count"]],
+            breakout: [
+              ["field", PRODUCTS.CATEGORY],
+              ["field", PRODUCTS.CREATED_AT, { "temporal-unit": "month" }],
+            ],
+          },
+        },
+        display: "bar",
+        visualization_settings: { "stackable.stack_type": "stacked" },
+      });
+
+      cy.findAllByTestId("legend-item").findByText("Doohickey").click();
+      cy.findByText("View these Products").click();
+
+      cy.findByText("Category is Doohickey").should("be.visible");
     });
   });
 

--- a/frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx
+++ b/frontend/src/metabase/visualizations/components/LineAreaBarChart.jsx
@@ -311,7 +311,7 @@ export default class LineAreaBarChart extends Component {
     }
   };
 
-  handleSelectSeries = (event, index) => {
+  handleSelectSeries = (event, index, isReversed) => {
     const {
       card,
       series,
@@ -321,7 +321,9 @@ export default class LineAreaBarChart extends Component {
       onChangeCardAndRun,
     } = this.props;
 
-    const single = series[index];
+    const single = isReversed
+      ? series[series.length - index - 1]
+      : series[index];
     const hasBreakout = card._breakoutColumn != null;
 
     if (onEditSeries && !hasBreakout) {

--- a/frontend/src/metabase/visualizations/components/legend/Legend.jsx
+++ b/frontend/src/metabase/visualizations/components/legend/Legend.jsx
@@ -84,6 +84,7 @@ const Legend = ({
             color={colors[localIndex % colors.length]}
             isMuted={hovered && itemIndex !== hovered.index}
             isVertical={isVertical}
+            isReversed={isReversed}
             onHoverChange={onHoverChange}
             onSelectSeries={onSelectSeries}
             onRemoveSeries={onRemoveSeries}

--- a/frontend/src/metabase/visualizations/components/legend/LegendItem.jsx
+++ b/frontend/src/metabase/visualizations/components/legend/LegendItem.jsx
@@ -15,6 +15,7 @@ const propTypes = {
   color: PropTypes.string,
   isMuted: PropTypes.bool,
   isVertical: PropTypes.bool,
+  isReversed: PropTypes.bool,
   onHoverChange: PropTypes.func,
   onSelectSeries: PropTypes.func,
   onRemoveSeries: PropTypes.func,
@@ -26,12 +27,13 @@ const LegendItem = ({
   color,
   isMuted,
   isVertical,
+  isReversed,
   onHoverChange,
   onSelectSeries,
   onRemoveSeries,
 }) => {
   const handleItemClick = event => {
-    onSelectSeries && onSelectSeries(event, index);
+    onSelectSeries && onSelectSeries(event, index, isReversed);
   };
 
   const handleItemMouseEnter = event => {


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/29840
Reproduces #29840 

### Description

When we changed the stacking order for stacked bar/area charts to be top to bottom (PR https://github.com/metabase/metabase/pull/29005), we forgot to update the function that handled doing drill-throughs from the legend. As a result, a bug was introduced where drilling-through from the legend would filter by the wrong series ([slack](https://metaboat.slack.com/archives/C505ZNNH4/p1680626306460659), [loom](https://www.loom.com/share/2db3645881b64ab08f7d2d4fde2164f3)).

This PR fixes the bug by adding an `isReversed` method to the `handleSelectSeries` method in `LineAreaBarChart.jsx`, to properly determine which series to drill-through on for a stacked chart.

### How to verify

Create the following question using sample data, try drilling-through via the legend for both stacked and unstacked bar/area charts.

<img width="1362" alt="Screenshot 2023-04-04 at 10 52 44 AM" src="https://user-images.githubusercontent.com/37751258/229876928-66a7db16-c505-43ae-90e0-1d7e11f4ef5e.png">

### Demo


https://user-images.githubusercontent.com/37751258/229877506-66c6c3b3-f590-4b9e-a3f8-bd30974119c8.mov

Drill-through works on stacked bar/area chart


https://user-images.githubusercontent.com/37751258/229877598-d7c1a5fb-4bbf-4825-82fd-4e997236c7be.mov

Still works on unstacked bar chart


https://user-images.githubusercontent.com/37751258/229877680-21d30d74-2704-4c29-b2bf-160ee23430b0.mov

Drill-through still works on the chart itself

### Checklist

- [x] Tests have been added/updated to cover changes in this PR

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/29809)
<!-- Reviewable:end -->
