### PR TITLE
Repro 29795 - Metadata is required when trying join on an SQL based questions

### DIFF
--- a/e2e/test/scenarios/joins/reproductions/29795-native-query-join-question-misses-metadata.cy.spec.js
+++ b/e2e/test/scenarios/joins/reproductions/29795-native-query-join-question-misses-metadata.cy.spec.js
@@ -5,7 +5,7 @@ import {
   openOrdersTable,
 } from "e2e/support/helpers";
 
-describe("issue 29795", () => {
+describe.skip("issue 29795", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();

--- a/e2e/test/scenarios/joins/reproductions/29795-native-query-join-question-misses-metadata.cy.spec.js
+++ b/e2e/test/scenarios/joins/reproductions/29795-native-query-join-question-misses-metadata.cy.spec.js
@@ -1,0 +1,43 @@
+import {
+  restore,
+  visualize,
+  popover,
+  openOrdersTable,
+} from "e2e/support/helpers";
+
+describe("issue 29795", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+  });
+
+  it.skip("should allow join based on native query (metabase#29795)", () => {
+    const NATIVE_QUESTION = "native question";
+    cy.createNativeQuestion({
+      name: NATIVE_QUESTION,
+      native: { query: `Select * FROM "PUBLIC"."ORDERS"` },
+    });
+
+    openOrdersTable({ mode: "notebook" });
+
+    cy.findByTestId("action-buttons").findByText("Join data").click();
+
+    popover().within(() => {
+      cy.icon("chevronleft").click();
+      cy.findByText("Saved Questions").click();
+      cy.findByText(NATIVE_QUESTION).click();
+    });
+
+    popover().within(() => {
+      cy.findByText("ID").click();
+    });
+
+    popover().within(() => {
+      cy.findByText("USER_ID").click();
+    });
+
+    visualize(response => {
+      expect(response.body.error).not.to.exist;
+    });
+  });
+});

--- a/e2e/test/scenarios/joins/reproductions/29795-native-query-join-question-misses-metadata.cy.spec.js
+++ b/e2e/test/scenarios/joins/reproductions/29795-native-query-join-question-misses-metadata.cy.spec.js
@@ -11,12 +11,16 @@ describe("issue 29795", () => {
     cy.signInAsAdmin();
   });
 
-  it.skip("should allow join based on native query (metabase#29795)", () => {
+  it("should allow join based on native query (metabase#29795)", () => {
     const NATIVE_QUESTION = "native question";
-    cy.createNativeQuestion({
-      name: NATIVE_QUESTION,
-      native: { query: `Select * FROM "PUBLIC"."ORDERS"` },
-    });
+    const LIMIT = 5;
+    cy.createNativeQuestion(
+      {
+        name: NATIVE_QUESTION,
+        native: { query: `SELECT * FROM "PUBLIC"."ORDERS" LIMIT ${LIMIT}` },
+      },
+      { loadMetadata: true },
+    );
 
     openOrdersTable({ mode: "notebook" });
 
@@ -38,6 +42,7 @@ describe("issue 29795", () => {
 
     visualize(response => {
       expect(response.body.error).not.to.exist;
+      cy.findByText(`Showing ${LIMIT} rows`);
     });
   });
 });

--- a/e2e/test/scenarios/joins/reproductions/29795-native-query-join-question-misses-metadata.cy.spec.js
+++ b/e2e/test/scenarios/joins/reproductions/29795-native-query-join-question-misses-metadata.cy.spec.js
@@ -20,20 +20,20 @@ describe("issue 29795", () => {
 
     openOrdersTable({ mode: "notebook" });
 
-    cy.findByTestId("action-buttons").findByText("Join data").click();
+    cy.button("Join data").click();
 
     popover().within(() => {
       cy.icon("chevronleft").click();
       cy.findByText("Saved Questions").click();
-      cy.findByText(NATIVE_QUESTION).click();
+      cy.findByRole("menuitem", { name: NATIVE_QUESTION }).click();
     });
 
     popover().within(() => {
-      cy.findByText("ID").click();
+      cy.findByRole("option", { name: "ID" }).click();
     });
 
     popover().within(() => {
-      cy.findByText("USER_ID").click();
+      cy.findByRole("option", { name: "USER_ID" }).click();
     });
 
     visualize(response => {

--- a/e2e/test/scenarios/joins/reproductions/29795-native-query-join-question-misses-metadata.cy.spec.js
+++ b/e2e/test/scenarios/joins/reproductions/29795-native-query-join-question-misses-metadata.cy.spec.js
@@ -40,9 +40,8 @@ describe.skip("issue 29795", () => {
       cy.findByRole("option", { name: "USER_ID" }).click();
     });
 
-    visualize(response => {
-      expect(response.body.error).not.to.exist;
-      cy.findByText(`Showing ${LIMIT} rows`);
+    visualize(() => {
+      cy.findByText(/USER ID/i);
     });
   });
 });


### PR DESCRIPTION
Status
READY 

### What does this PR accomplish?
Reproduces #29795

### How to test this manually?

yarn test-cypress-open
`e2e/test/scenarios/joins/reproductions/29795-native-query-join-question-misses-metadata.cy.spec.js`
(For still unfixed bug)
<img width="938" alt="image" src="https://user-images.githubusercontent.com/125459446/230183284-f233af53-a7d3-4616-8b64-9a103b02cf3a.png">

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/29834)
<!-- Reviewable:end -->
