### PR TITLE
hide ask metabot menu items when the model db is not supported

### DIFF
--- a/frontend/src/metabase/collections/components/ActionMenu/ActionMenu.tsx
+++ b/frontend/src/metabase/collections/components/ActionMenu/ActionMenu.tsx
@@ -13,6 +13,7 @@ import {
 } from "metabase/collections/utils";
 import { Bookmark, Collection, CollectionItem } from "metabase-types/api";
 import { State } from "metabase-types/store";
+import { canUseMetabotOnDatabase } from "metabase/metabot/utils";
 import Database from "metabase-lib/metadata/Database";
 import { EntityItemMenu } from "./ActionMenu.styled";
 
@@ -76,7 +77,8 @@ function ActionMenu({
   const canPreview = canPreviewItem(item, collection);
   const canMove = canMoveItem(item, collection);
   const canArchive = canArchiveItem(item, collection);
-  const canUseMetabot = database?.canWrite?.() && isMetabotEnabled;
+  const canUseMetabot =
+    database != null && canUseMetabotOnDatabase(database) && isMetabotEnabled;
 
   const handlePin = useCallback(() => {
     item.setPinned?.(!isItemPinned(item));

--- a/frontend/src/metabase/home/homepage/containers/HomePageApp/HomePageApp.tsx
+++ b/frontend/src/metabase/home/homepage/containers/HomePageApp/HomePageApp.tsx
@@ -6,6 +6,7 @@ import { openNavbar } from "metabase/redux/app";
 import { getSetting } from "metabase/selectors/settings";
 import { CollectionItem } from "metabase-types/api";
 import { State } from "metabase-types/store";
+import { canUseMetabotOnDatabase } from "metabase/metabot/utils";
 import Database from "metabase-lib/metadata/Database";
 import HomePage from "../../components/HomePage";
 
@@ -23,11 +24,11 @@ const mapStateToProps = (
   { databases, models }: EntityLoaderProps,
 ): StateProps => {
   const hasModels = models.length > 0;
-  const hasNativeWrite = databases.some(database => database.canWrite());
+  const hasSupportedDatabases = databases.some(canUseMetabotOnDatabase);
   const isMetabotEnabled = getSetting(state, "is-metabot-enabled");
 
   return {
-    hasMetabot: hasModels && hasNativeWrite && isMetabotEnabled,
+    hasMetabot: hasModels && hasSupportedDatabases && isMetabotEnabled,
   };
 };
 

--- a/frontend/src/metabase/metabot/components/MetabotWidget/MetabotWidget.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotWidget/MetabotWidget.tsx
@@ -11,6 +11,7 @@ import { getUser } from "metabase/selectors/user";
 import { getMetadata } from "metabase/selectors/metadata";
 import { Card, CollectionItem, DatabaseId, User } from "metabase-types/api";
 import { Dispatch, State } from "metabase-types/store";
+import { canUseMetabotOnDatabase } from "metabase/metabot/utils";
 import Question from "metabase-lib/Question";
 import Database from "metabase-lib/metadata/Database";
 import DatabasePicker from "../DatabasePicker";
@@ -48,7 +49,7 @@ const mapStateToProps = (
 ): StateProps => ({
   user: getUser(state),
   model: card ? new Question(card, getMetadata(state)) : null,
-  databases: databases.filter(d => d.canWrite()),
+  databases: databases.filter(canUseMetabotOnDatabase),
 });
 
 const mapDispatchToProps = (dispatch: Dispatch): DispatchProps => ({

--- a/frontend/src/metabase/metabot/components/MetabotWidget/MetabotWidget.unit.spec.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotWidget/MetabotWidget.unit.spec.tsx
@@ -140,4 +140,22 @@ describe("MetabotWidget", () => {
 
     expect(screen.getByText(/Hey there!/)).toBeInTheDocument();
   });
+
+  it("should not suggest databases that do not support metabot", async () => {
+    const mongoDbName = "Mongo";
+    await setup({
+      databases: [
+        TEST_DATABASE,
+        TEST_DATABASE_2,
+        createMockDatabase({
+          id: 3,
+          name: mongoDbName,
+          engine: "mongo",
+        }),
+      ],
+    });
+
+    userEvent.click(screen.getByText(TEST_DATABASE.name));
+    expect(screen.queryByText(mongoDbName)).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/metabase/metabot/containers/DatabaseMetabotApp/DatabaseMetabotApp.tsx
+++ b/frontend/src/metabase/metabot/containers/DatabaseMetabotApp/DatabaseMetabotApp.tsx
@@ -7,6 +7,7 @@ import { extractEntityId } from "metabase/lib/urls";
 import Databases from "metabase/entities/databases";
 import { DatabaseId } from "metabase-types/api";
 import { MetabotEntityType, State } from "metabase-types/store";
+import { canUseMetabotOnDatabase } from "metabase/metabot/utils";
 import Database from "metabase-lib/metadata/Database";
 import Metabot from "../../components/Metabot";
 
@@ -41,7 +42,7 @@ const mapStateToProps = (
     entityId,
     entityType: "database",
     database: Databases.selectors.getObject(state, { entityId }),
-    databases: databases.filter(database => database.canWrite()),
+    databases: databases.filter(canUseMetabotOnDatabase),
     initialPrompt: location?.query?.prompt,
   };
 };

--- a/frontend/src/metabase/metabot/utils.ts
+++ b/frontend/src/metabase/metabot/utils.ts
@@ -1,0 +1,10 @@
+import { getEngineNativeType } from "metabase/lib/engine";
+import Database from "metabase-lib/metadata/Database";
+
+export const canUseMetabotOnDatabase = (database: Database) => {
+  return (
+    database.features.includes("nested-queries") &&
+    database.canWrite() &&
+    getEngineNativeType(database.engine) === "sql"
+  );
+};

--- a/frontend/src/metabase/query_builder/components/QuestionActions.tsx
+++ b/frontend/src/metabase/query_builder/components/QuestionActions.tsx
@@ -121,7 +121,12 @@ const QuestionActions = ({
 
   const extraButtons = [];
 
-  if (database && canUseMetabotOnDatabase(database)) {
+  if (
+    isMetabotEnabled &&
+    isDataset &&
+    database &&
+    canUseMetabotOnDatabase(database)
+  ) {
     extraButtons.push({
       title: t`Ask Metabot`,
       icon: "insight",

--- a/frontend/src/metabase/query_builder/components/QuestionActions.tsx
+++ b/frontend/src/metabase/query_builder/components/QuestionActions.tsx
@@ -19,6 +19,7 @@ import { color } from "metabase/lib/colors";
 
 import BookmarkToggle from "metabase/core/components/BookmarkToggle";
 import { getSetting } from "metabase/selectors/settings";
+import { canUseMetabotOnDatabase } from "metabase/metabot/utils";
 import Question from "metabase-lib/Question";
 
 import {
@@ -90,7 +91,7 @@ const QuestionActions = ({
   const isDataset = question.isDataset();
   const canWrite = question.canWrite();
   const isSaved = question.isSaved();
-  const hasNativeWrite = question.database()?.canWrite();
+  const database = question.database();
 
   const canPersistDataset =
     PLUGIN_MODEL_PERSISTENCE.isModelLevelPersistenceEnabled() &&
@@ -120,7 +121,7 @@ const QuestionActions = ({
 
   const extraButtons = [];
 
-  if (isDataset && hasNativeWrite && isMetabotEnabled) {
+  if (database && canUseMetabotOnDatabase(database)) {
     extraButtons.push({
       title: t`Ask Metabot`,
       icon: "insight",


### PR DESCRIPTION
### Description

Hide "Ask Metabot" menu items when a database has no nested-queries support or it is not a SQL db.

### How to verify

1. Enable Metabot
2. Create a model M1 in an SQL db with nested-queries support
3. Create a model M2 in a non-sql db
4. Open the collections that contain the models
5. Click on the ellipsis icon for both models and ensure "Ask Metabot" menu item is visible only for the SQL database
6. Open models in the query builder chill mode
7. Click on the ellipsis icon for both models and ensure "Ask Metabot" menu item is visible only for the SQL database

### Checklist

- [x] Tests have been added/updated to cover changes in this PR

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/29843)
<!-- Reviewable:end -->
