### PR TITLE
Adding metabot inner-query alias

### DIFF
--- a/src/metabase/metabot/util.clj
+++ b/src/metabase/metabot/util.clj
@@ -67,7 +67,7 @@
   [sql]
   (str/replace
    sql
-   #"\{\s*\{\s*#\s*\d+\s*\}\s*\}\s*"
+   #"\{\s*\{\s*#\s*\d+\s*\}\s*\}"
    (fn [match] (str/replace match #"\s*" ""))))
 
 (defn inner-query
@@ -77,7 +77,7 @@
   (let [column-aliases (->> (aliases model)
                             (map (partial apply format "\"%s\" AS %s"))
                             (str/join ","))]
-    (->> (format "SELECT %s FROM {{#%s}}" column-aliases id)
+    (->> (format "SELECT %s FROM {{#%s}} AS INNER_QUERY" column-aliases id)
          mdb.query/format-sql
          fix-model-reference)))
 

--- a/test/metabase/metabot/metabot_util_test.clj
+++ b/test/metabase/metabot/metabot_util_test.clj
@@ -2,9 +2,11 @@
   (:require
    [clojure.test :refer :all]
    [metabase.db.query :as mdb.query]
+   [metabase.lib.native :as lib-native]
    [metabase.metabot-test :as metabot-test]
    [metabase.metabot.util :as metabot-util]
    [metabase.models :refer [Card Database]]
+   [metabase.query-processor :as qp]
    [metabase.test :as mt]
    [metabase.util :as u]
    [toucan2.core :as t2]))
@@ -133,3 +135,27 @@
             {:inner_query "SELECT * FROM {{#123}} AS INNER_QUERY"
              :sql_name    "MY_MODEL"}
             "SELECT * FROM MY_MODEL")))))
+
+(deftest ensure-generated-sql-works-test
+  (testing "Ensure the generated sql (including creating a CTE and querying from it) is valid (i.e. produces a result)."
+    (mt/test-drivers #{:h2 :postgres :redshift}
+      (mt/dataset sample-dataset
+        (mt/with-temp* [Card [{model-name :name :as model}
+                              {:dataset_query
+                               {:database (mt/id)
+                                :type     :query
+                                :query    {:source-table (mt/id :people)}}
+                               :dataset true}]]
+          (let [{:keys [inner_query] :as denormalized-model} (metabot-util/denormalize-model model)
+                sql     (metabot-util/bot-sql->final-sql
+                         denormalized-model
+                         (format "SELECT * FROM %s LIMIT 1" model-name))
+                results (qp/process-query
+                         {:database (mt/id)
+                          :type     "native"
+                          :native   {:query         sql
+                                     :template-tags (update-vals
+                                                     (lib-native/template-tags inner_query)
+                                                     (fn [m] (update m :id str)))}})]
+            (is (= 1 (count (get-in results [:data :rows]))))))))))
+

--- a/test/metabase/metabot/metabot_util_test.clj
+++ b/test/metabase/metabot/metabot_util_test.clj
@@ -128,8 +128,8 @@
 
 (deftest bot-sql->final-sql-test
   (testing "A simple test of interpolation of denormalized data with bot sql"
-    (is (= "WITH MY_MODEL AS (SELECT * FROM {{#123}}) SELECT * FROM MY_MODEL"
+    (is (= "WITH MY_MODEL AS (SELECT * FROM {{#123}} AS INNER_QUERY) SELECT * FROM MY_MODEL"
            (metabot-util/bot-sql->final-sql
-            {:inner_query "SELECT * FROM {{#123}}"
+            {:inner_query "SELECT * FROM {{#123}} AS INNER_QUERY"
              :sql_name    "MY_MODEL"}
             "SELECT * FROM MY_MODEL")))))

--- a/test/metabase/metabot/metabot_util_test.clj
+++ b/test/metabase/metabot/metabot_util_test.clj
@@ -158,4 +158,3 @@
                                                      (lib-native/template-tags inner_query)
                                                      (fn [m] (update m :id str)))}})]
             (is (= 1 (count (get-in results [:data :rows]))))))))))
-

--- a/test/metabase/metabot/metabot_util_test.clj
+++ b/test/metabase/metabot/metabot_util_test.clj
@@ -149,7 +149,7 @@
           (let [{:keys [inner_query] :as denormalized-model} (metabot-util/denormalize-model model)
                 sql     (metabot-util/bot-sql->final-sql
                          denormalized-model
-                         (format "SELECT * FROM %s LIMIT 1" model-name))
+                         (format "SELECT * FROM %s" model-name))
                 results (qp/process-query
                          {:database (mt/id)
                           :type     "native"
@@ -157,4 +157,4 @@
                                      :template-tags (update-vals
                                                      (lib-native/template-tags inner_query)
                                                      (fn [m] (update m :id str)))}})]
-            (is (= 1 (count (get-in results [:data :rows]))))))))))
+            (is (some? (seq (get-in results [:data :rows]))))))))))


### PR DESCRIPTION
Some of our sql variants require aliases on the inner query in the CTE. Adding this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/29850)
<!-- Reviewable:end -->
