### PR TITLE
Fix load-from-csv tests for Postgres in CI

### DIFF
--- a/.github/actions/test-driver/action.yml
+++ b/.github/actions/test-driver/action.yml
@@ -18,6 +18,8 @@ runs:
     - name: Build static viz frontend
       run: yarn build-static-viz
       shell: bash
+    - name: Setup upterm session
+      uses: lhotari/action-upterm@v1
     - name: Test database driver
       run: clojure -X:dev:ci:ee:ee-dev:drivers:drivers-dev:test ${{ inputs.test-args }}
       shell: bash

--- a/test/metabase/csv_test.clj
+++ b/test/metabase/csv_test.clj
@@ -5,9 +5,7 @@
    [clojure.test :refer :all]
    [metabase.csv :as csv]
    [metabase.driver :as driver]
-   [metabase.test :as mt])
-  (:import
-   [java.io File]))
+   [metabase.test :as mt]))
 
 (set! *warn-on-reflection* true)
 
@@ -73,7 +71,7 @@
 
 (defn- schema-for
   [rows]
-  (with-temp-csv "pokefans.csv" rows (csv/detect-schema (File. "pokefans.csv"))))
+  (with-temp-csv "pokefans.csv" rows (csv/detect-schema (io/file "pokefans.csv"))))
 
 (deftest detect-schema-test
   (testing "Well-formed CSV file"
@@ -137,7 +135,7 @@
         (with-temp-csv "pokefans.csv" ["id" "2" "3"]
           (testing "Can upload two files with the same name"
             ;; Sleep for a second, because the table name is based on the current second
-            (is (some? (csv/load-from-csv driver/*driver* (mt/id) "public" (File. "pokefans.csv"))))
+            (is (some? (csv/load-from-csv driver/*driver* (mt/id) "public" (io/file "pokefans.csv"))))
             (Thread/sleep 1000)
             (with-temp-csv "../pokefans.csv" ["name" "Luke" "Han"]
-              (is (some? (csv/load-from-csv driver/*driver* (mt/id) "public" (File. "../pokefans.csv")))))))))))
+              (is (some? (csv/load-from-csv driver/*driver* (mt/id) "public" (io/file "../pokefans.csv")))))))))))

--- a/test/metabase/csv_test.clj
+++ b/test/metabase/csv_test.clj
@@ -139,4 +139,5 @@
             ;; Sleep for a second, because the table name is based on the current second
             (is (some? (csv/load-from-csv driver/*driver* (mt/id) "public" (File. "pokefans.csv"))))
             (Thread/sleep 1000)
-            (is (some? (csv/load-from-csv driver/*driver* (mt/id) "public" (File. "pokefans.csv"))))))))))
+            (with-temp-csv "../pokefans.csv" ["name" "Luke" "Han"]
+              (is (some? (csv/load-from-csv driver/*driver* (mt/id) "public" (File. "../pokefans.csv")))))))))))

--- a/test/metabase/driver/postgres_test.clj
+++ b/test/metabase/driver/postgres_test.clj
@@ -2,6 +2,8 @@
   "Tests for features/capabilities specific to PostgreSQL driver, such as support for Postgres UUID or enum types."
   (:require
    [cheshire.core :as json]
+   [clojure.string :as str]
+   [clojure.java.io :as io]
    [clojure.java.jdbc :as jdbc]
    [clojure.string :as str]
    [clojure.test :refer :all]
@@ -1157,75 +1159,90 @@
               absolute-path
               (str/ends-with? ".p12"))))))
 
+(defmacro with-temp-csv
+  "Creates a temp csv file with the given `rows`. The file is deleted after the
+   body is executed. This is needed instead of using File/createTempFile because Postgres might not have access to the temp directory."
+  [file-name rows & body]
+  `(let [csv-data# (str/join "\n" ~rows)]
+     (with-open [writer# (io/writer ~file-name)]
+       (.write writer# csv-data#))
+     (try
+       ~@body
+       (finally
+         (clojure.java.io/delete-file ~file-name)))))
+
 (deftest load-from-csv-test
   (testing "Upload a CSV file"
     (mt/test-driver :postgres
-      (mt/with-empty-db
-        (driver/load-from-csv
-         driver/*driver*
-         (mt/id)
-         "public"
-         "upload_test"
-         (csv-test/csv-file-with ["id,empty,string,bool,float" "2,,string,true,1.1" "3,,string,false,1.1"]))
-        (testing "Table and Fields exist after sync"
-          (sync/sync-database! (mt/db))
-          (let [table (t2/select-one Table :schema "public" :name "upload_test" :db_id (mt/id))]
-            (is (some? table))
-            (is (=? {:database_position 0
-                     :database_type     "int4"
-                     :display_name      "ID"
-                     :semantic_type     :type/PK
-                     :base_type         :type/Integer}
-                    (t2/select-one Field :name "id" :table_id (:id table))))
-            (is (=? {:database_position 1
-                     :database_type     "text"
-                     :base_type         :type/Text}
-                    (t2/select-one Field :name "empty" :table_id (:id table))))
-            (is (=? {:database_position 2
-                     :database_type     "varchar"
-                     :base_type         :type/Text}
-                    (t2/select-one Field :name "string" :table_id (:id table))))
-            (is (=? {:database_position 3
-                     :database_type     "bool"
-                     :base_type         :type/Boolean}
-                    (t2/select-one Field :name "bool" :table_id (:id table))))
-            (is (=? {:database_position 4
-                     :database_type     "float8"
-                     :base_type         :type/Float}
-                    (t2/select-one Field :name "float" :table_id (:id table))))
-            (testing "Check the data was uploaded into the table"
-              (is (= [[2]] (-> (mt/process-query {:database (mt/id)
-                                                  :type :query
-                                                  :query {:source-table (:id table)
-                                                          :aggregation [[:count]]}})
-                               mt/rows))))))))))
+      (with-temp-csv "temp.csv" ["id,empty,string,bool,float" "2,,string,true,1.1" "3,,string,false,1.1"]
+        (mt/with-empty-db
+          (driver/load-from-csv
+           driver/*driver*
+           (mt/id)
+           "public"
+           "upload_test"
+           (io/file "temp.csv"))
+          (testing "Table and Fields exist after sync"
+            (sync/sync-database! (mt/db))
+            (let [table (t2/select-one Table :schema "public" :name "upload_test" :db_id (mt/id))]
+              (is (some? table))
+              (is (=? {:database_position 0
+                       :database_type     "int4"
+                       :display_name      "ID"
+                       :semantic_type     :type/PK
+                       :base_type         :type/Integer}
+                      (t2/select-one Field :name "id" :table_id (:id table))))
+              (is (=? {:database_position 1
+                       :database_type     "text"
+                       :base_type         :type/Text}
+                      (t2/select-one Field :name "empty" :table_id (:id table))))
+              (is (=? {:database_position 2
+                       :database_type     "varchar"
+                       :base_type         :type/Text}
+                      (t2/select-one Field :name "string" :table_id (:id table))))
+              (is (=? {:database_position 3
+                       :database_type     "bool"
+                       :base_type         :type/Boolean}
+                      (t2/select-one Field :name "bool" :table_id (:id table))))
+              (is (=? {:database_position 4
+                       :database_type     "float8"
+                       :base_type         :type/Float}
+                      (t2/select-one Field :name "float" :table_id (:id table))))
+              (testing "Check the data was uploaded into the table"
+                (is (= [[2]] (-> (mt/process-query {:database (mt/id)
+                                                    :type :query
+                                                    :query {:source-table (:id table)
+                                                            :aggregation [[:count]]}})
+                                 mt/rows)))))))))))
 
 (deftest load-from-csv-sql-injection-test
   (mt/test-driver :postgres
     (mt/with-empty-db
       (testing "Can't upload a CSV with a semi-colon in the file name"
-        (let [file-name (str (csv-test/csv-file-with ["id" "2"]))]
+        (with-temp-csv "file.csv" ["id" "2"]
           (is (thrown-with-msg?
                ExceptionInfo #"Error uploading CSV: \";\" in "
                (driver/load-from-csv
                 driver/*driver*
                 (mt/id)
                 "public"
-                (str "upload_test(id) FROM " file-name "; DROP TABLE users; --")
-                (csv-test/csv-file-with ["id" "2"])))))))))
+                "upload_test"
+                (str "public.upload_test(id) FROM file.csv; DROP TABLE users; --")
+                (io/file "file.csv")))))))))
 
 (deftest load-from-csv-failed-test
   (mt/test-driver :postgres
     (mt/with-empty-db
       (testing "Can't upload a CSV with missing values"
-        (is (thrown-with-msg?
-              ExceptionInfo #"ERROR: missing data for column"
-             (driver/load-from-csv
-              driver/*driver*
-              (mt/id)
-              "public"
-              "upload_test"
-              (csv-test/csv-file-with ["id,column_that_doesnt_have_a_value" "2"])))))
+        (with-temp-csv "file.csv" ["id,column_that_doesnt_have_a_value" "2"]
+          (is (thrown-with-msg?
+               ExceptionInfo #"ERROR: missing data for column"
+               (driver/load-from-csv
+                driver/*driver*
+                (mt/id)
+                "public"
+                "upload_test"
+                (io/file "file.csv"))))))
       (testing "Check that the table isn't created if the upload fails"
         (sync/sync-database! (mt/db))
         (is (nil? (t2/select-one Table :db_id (mt/id))))))))

--- a/test/metabase/driver/postgres_test.clj
+++ b/test/metabase/driver/postgres_test.clj
@@ -1206,16 +1206,17 @@
   (mt/test-driver :postgres
     (mt/with-empty-db
       (testing "Can't upload a CSV with a semi-colon in the file name"
-        (csv-test/with-temp-csv "file.csv" ["id" "2"]
-          (is (thrown-with-msg?
-               ExceptionInfo #"Error uploading CSV: \";\" in "
-               (driver/load-from-csv
-                driver/*driver*
-                (mt/id)
-                "public"
-                "upload_test"
-                (str "public.upload_test(id) FROM file.csv; DROP TABLE users; --")
-                (io/file "file.csv")))))))))
+        (let [malicious-filename "public.upload_test(id) FROM file.csv; DROP TABLE users; --"]
+          (csv-test/with-temp-csv malicious-filename
+            ["id" "2"]
+            (is (thrown-with-msg?
+                 ExceptionInfo #"Error uploading CSV: \";\" in "
+                 (driver/load-from-csv
+                  driver/*driver*
+                  (mt/id)
+                  "public"
+                  "upload_test"
+                  (io/file malicious-filename))))))))))
 
 (deftest load-from-csv-failed-test
   (mt/test-driver :postgres


### PR DESCRIPTION
There is an error in CI on `csv/main` with the tests in the `metabase.driver.postgres-test` that test `driver/load-from-csv`.

Here's an example test failure: https://github.com/metabase/metabase/actions/runs/4625070615/jobs/8180497771?pr=29829#step:4:749

```
 clojure.lang.ExceptionInfo: Error executing write query: ERROR: could not open file "/tmp/pokefans7155410569990484249.csv" for reading: No such file or directory
```

This is coming from executing the COPY FROM … command to load the csv data into the table.
It’s probably because the /tmp directory is private for postgres in CI, but not locally. See this SO post: https://dba.stackexchange.com/questions/114568/cannot-read-from-tmp-with-postgresql-copy-but-able-to-read-the-same-file-from

My solution is to avoid the /tmp directory altogether, and create a temporary file in the current directory, and delete the file immediately after the csv is used.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/29854)
<!-- Reviewable:end -->
