### PR TITLE
Dashboard tabs CRUD

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -533,6 +533,7 @@
    metabase.api.common/defendpoint-async-schema                                                                              hooks.metabase.api.common/defendpoint
    metabase.api.common/defendpoint-schema                                                                                    hooks.metabase.api.common/defendpoint
    metabase.api.dashboard-test/with-chain-filter-fixtures                                                                    hooks.common/let-one-with-optional-value
+   metabase.api.dashboard-test/with-simple-dashboard-with-tabs                                                               hooks.common/with-one-binding
    metabase.api.card-test/with-card-param-values-fixtures                                                                    hooks.common/let-one-with-optional-value
    metabase.api.embed-test/do-response-formats                                                                               hooks.common/with-two-bindings
    metabase.api.embed-test/with-chain-filter-fixtures                                                                        hooks.common/let-one-with-optional-value
@@ -552,6 +553,7 @@
    metabase.models.collection-test/with-collection-hierarchy                                                                 hooks.common/let-one-with-optional-value
    metabase.models.collection-test/with-personal-and-impersonal-collections                                                  hooks.common/with-two-bindings
    metabase.models.dashboard-test/with-dash-in-collection                                                                    hooks.common/with-three-bindings
+   metabase.models.dashboard-tab-test/with-dashtab-in-personal-collection                                                    hooks.common/with-one-top-level-binding
    metabase.models.interface/define-simple-hydration-method                                                                  hooks.metabase.models.interface/define-hydration-method
    metabase.models.interface/define-batched-hydration-method                                                                 hooks.metabase.models.interface/define-hydration-method
    metabase.models.pulse-test/with-dashboard-subscription-in-collection                                                      hooks.common/with-four-bindings

--- a/enterprise/backend/test/metabase_enterprise/sandbox/api/dashboard_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/api/dashboard_test.clj
@@ -48,7 +48,7 @@
                                                     s/Keyword     s/Any}
                                                    "mapping")]
                             s/Keyword           s/Any}]
-                          (add-card! 200)))
+                          (:cards (add-card! 200))))
              (is (schema= [(s/one {:card_id            (s/eq card-id)
                                    :parameter_mappings (s/eq mappings)
                                    s/Keyword           s/Any}

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -673,8 +673,7 @@
   (let [dashboard (-> (api/write-check Dashboard id)
                       api/check-not-archived
                       (t2/hydrate [:ordered_cards :series :card] :ordered_tabs))
-        new-tabs  (when-not (nil? ordered_tabs)
-                    (map-indexed (fn [idx tab] (assoc tab :position idx)) ordered_tabs))]
+        new-tabs  (map-indexed (fn [idx tab] (assoc tab :position idx)) ordered_tabs)]
     (when (and (seq (:ordered_tabs dashboard))
                (not (every? #(some? (:dashboard_tab_id %)) cards)))
       (throw (ex-info (tru "This dashboard has tab, makes sure every card has a tab")

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -518,13 +518,13 @@
                                         [:to-create [:sequential [:map [:id ms/NegativeInt]]]]
                                         [:to-update [:sequential [:map [:id ms/PositiveInt]]]]
                                         [:to-delete [:sequential [:map [:id ms/PositiveInt]]]]]
-  "Given 2 lists of seq maps changes, where each map an `id` keys,
+  "Given 2 lists of seq maps items, where each map an `id` keys,
   return a map of 3 keys, `:to-create`, `:to-update`, `:to-delete`.
 
   Where:
-    :to-create is a list of maps that has negative ids in `new-changes`
-    :to-update is a list of maps that has ids in both `current-changes` and `new-changes`
-    :to delete is a list of maps that has ids only in `current-changes`"
+    :to-create is a list of maps that has negative ids in `new-items`
+    :to-update is a list of maps that has ids in both `current-items` and `new-items`
+    :to delete is a list of maps that has ids only in `current-items`"
   [current-items :- [:sequential [:map [:id ms/PositiveInt]]]
    new-items     :- [:sequential [:map [:id int?]]]]
   (let [new-change-ids     (set (map :id new-items))
@@ -646,8 +646,8 @@
 (def ^:private UpdatedDashboardTab
   [:map
    ;; id can be negative, it indicates a new card and BE should create them
-   [:id           int?]
-   [:name         ms/NonBlankString]])
+   [:id   ms/Int]
+   [:name ms/NonBlankString]])
 
 (api/defendpoint PUT "/:id/cards"
   "Update `Cards` and `Tabs` on a Dashboard. Request body should have the form:

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -677,7 +677,7 @@
                     (map-indexed (fn [idx tab] (assoc tab :position idx)) ordered_tabs))]
     (when (and (seq (:ordered_tabs dashboard))
                (not (every? #(some? (:dashboard_tab_id %)) cards)))
-      (throw (ex-info (tru "This dashboard has tab, makes sure every cards has a tab assigned")
+      (throw (ex-info (tru "This dashboard has tab, makes sure every card has a tab")
                       {:status-code 400})))
     (api/check-500
       (t2/with-transaction [_conn]

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -675,6 +675,10 @@
                       (t2/hydrate [:ordered_cards :series :card] :ordered_tabs))
         new-tabs  (when-not (nil? ordered_tabs)
                     (map-indexed (fn [idx tab] (assoc tab :position idx)) ordered_tabs))]
+    (when (and (seq (:ordered_tabs dashboard))
+               (not (every? #(some? (:dashboard_tab_id %)) cards)))
+      (throw (ex-info (tru "This dashboard has tab, makes sure every cards has a tab assigned")
+                      {:status-code 400})))
     (api/check-500
       (t2/with-transaction [_conn]
         (let [{:keys [temp->real-tab-ids

--- a/src/metabase/models/dashboard_card.clj
+++ b/src/metabase/models/dashboard_card.clj
@@ -180,7 +180,7 @@
    old-dashboard-card                        :- DashboardCardUpdates]
   (t2/with-transaction [_conn]
    (let [update-ks (cond-> [:action_id :row :col :size_x :size_y
-                            :parameter_mappings :visualization_settings]
+                            :parameter_mappings :visualization_settings :dashboard_tab_id]
                     ;; Allow changing card_id for action dashcards, but not for card dashcards.
                     ;; This is to preserve the existing behavior of questions and card_id
                     ;; I don't know why card_id couldn't be changed for cards though.
@@ -224,8 +224,7 @@
                                            :visualization_settings {}}
                                           (select-keys dashcard
                                                        [:dashboard_id :card_id :action_id :size_x :size_y :row :col
-                                                        :parameter_mappings
-                                                        :visualization_settings]))))]
+                                                        :parameter_mappings :visualization_settings :dashboard_tab_id]))))]
         ;; add series to the DashboardCard
         (update-dashboard-cards-series! (zipmap dashboard-card-ids (map #(get % :series []) dashboard-cards)))
         ;; return the full DashboardCard

--- a/src/metabase/util/malli/schema.clj
+++ b/src/metabase/util/malli/schema.clj
@@ -23,9 +23,22 @@
       [user :- (ms/InstanceOf User)]
       ...)"
   [model]
-  (mc/schema
-   [:fn {:error/fn (fn [_ _] (deferred-tru "value must be an instance of {0}" (name model)))}
-    #(models.dispatch/instance-of? model %)]))
+  (mu/with-api-error-message
+   [:fn #(models.dispatch/instance-of? model %)]
+   (deferred-tru "value must be an instance of {0}" (name model))))
+
+(defn maps-with-unique-key
+  "Given a schema of a sequence of maps, returns as chema that do an additional unique check on key `k`."
+  [maps-schema k]
+  (mu/with-api-error-message
+    [:and
+     [:fn (fn [maps]
+            (= (count maps)
+               (-> (map #(get % k) maps)
+                   distinct
+                   count)))]
+     maps-schema]
+    (deferred-tru "value must be seq of maps in which {0}s are unique" (name k))))
 
 ;;; -------------------------------------------------- Schemas --------------------------------------------------
 

--- a/src/metabase/util/malli/schema.clj
+++ b/src/metabase/util/malli/schema.clj
@@ -56,6 +56,12 @@
     ;; FIXME: greater than _or equal to_ zero.
     (deferred-tru "value must be an integer greater than zero.")))
 
+(def Int
+  "Schema representing an integer."
+  (mu/with-api-error-message
+    int?
+    (deferred-tru "value must be an integer.")))
+
 (def PositiveInt
   "Schema representing an integer than must also be greater than zero."
   (mu/with-api-error-message

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -280,51 +280,52 @@
 (deftest fetch-dashboard-test
   (testing "GET /api/dashboard/:id"
     (testing "fetch a dashboard WITH a dashboard card on it"
-      (mt/with-temp* [Dashboard     [{dashboard-id :id
-                                      :as          dashboard}    {:name "Test Dashboard"}]
-                      Card          [{card-id :id
-                                      :as     card}         {:name "Dashboard Test Card"}]
-                      DashboardCard [dashcard           {:dashboard_id dashboard-id, :card_id card-id}]
-                      User          [{user-id :id}      {:first_name "Test" :last_name "User"
-                                                         :email      "test@example.com"}]
-                      Revision      [_                  {:user_id  user-id
-                                                         :model    "Dashboard"
-                                                         :model_id dashboard-id
-                                                         :object   (revision/serialize-instance dashboard
-                                                                                                dashboard-id
-                                                                                                dashboard)}]]
+      (mt/with-temp* [Dashboard           [{dashboard-id :id
+                                            :as          dashboard}    {:name "Test Dashboard"}]
+                      Card                [{card-id :id
+                                            :as     card}         {:name "Dashboard Test Card"}]
+                      :model/DashboardTab [{dashtab-id :id}   {:name "Test Dashboard Tab" :position 0 :dashboard_id dashboard-id}]
+                      DashboardCard       [dashcard           {:dashboard_id dashboard-id :card_id card-id :dashboard_tab_id dashtab-id}]
+                      User                [{user-id :id}      {:first_name "Test" :last_name "User"
+                                                               :email      "test@example.com"}]
+                      Revision            [_                  {:user_id  user-id
+                                                               :model    "Dashboard"
+                                                               :model_id dashboard-id
+                                                               :object   (revision/serialize-instance dashboard
+                                                                                                      dashboard-id
+                                                                                                      dashboard)}]]
         (with-dashboards-in-readable-collection [dashboard-id]
           (api.card-test/with-cards-in-readable-collection [card-id]
-            (is (= (merge
-                    dashboard-defaults
-                    {:name                       "Test Dashboard"
-                     :creator_id                 (mt/user->id :rasta)
-                     :collection_id              true
-                     :collection_authority_level nil
-                     :can_write                  false
-                     :param_fields               nil
-                     :last-edit-info             {:timestamp true :id true :first_name "Test" :last_name "User" :email "test@example.com"}
-                     :ordered_tabs               []
-                     :ordered_cards              [{:size_x                     4
-                                                   :size_y                     4
-                                                   :col                        0
-                                                   :row                        0
-                                                   :collection_authority_level nil
-                                                   :updated_at                 true
-                                                   :created_at                 true
-                                                   :entity_id                  (:entity_id dashcard)
-                                                   :parameter_mappings         []
-                                                   :visualization_settings     {}
-                                                   :dashboard_tab_id           nil
-                                                   :card                       (merge api.card-test/card-defaults-no-hydrate
-                                                                                      {:name                   "Dashboard Test Card"
-                                                                                       :creator_id             (mt/user->id :rasta)
-                                                                                       :collection_id          true
-                                                                                       :display                "table"
-                                                                                       :entity_id              (:entity_id card)
-                                                                                       :visualization_settings {}
-                                                                                       :result_metadata        nil})
-                                                   :series                     []}]})
+            (is (=? (merge
+                     dashboard-defaults
+                     {:name                       "Test Dashboard"
+                      :creator_id                 (mt/user->id :rasta)
+                      :collection_id              true
+                      :collection_authority_level nil
+                      :can_write                  false
+                      :param_fields               nil
+                      :last-edit-info             {:timestamp true :id true :first_name "Test" :last_name "User" :email "test@example.com"}
+                      :ordered_tabs               [{:name "Test Dashboard Tab" :position 0 :id dashtab-id :dashboard_id dashboard-id}]
+                      :ordered_cards              [{:size_x                     4
+                                                    :size_y                     4
+                                                    :col                        0
+                                                    :row                        0
+                                                    :collection_authority_level nil
+                                                    :updated_at                 true
+                                                    :created_at                 true
+                                                    :entity_id                  (:entity_id dashcard)
+                                                    :parameter_mappings         []
+                                                    :visualization_settings     {}
+                                                    :dashboard_tab_id           dashtab-id
+                                                    :card                       (merge api.card-test/card-defaults-no-hydrate
+                                                                                       {:name                   "Dashboard Test Card"
+                                                                                        :creator_id             (mt/user->id :rasta)
+                                                                                        :collection_id          true
+                                                                                        :display                "table"
+                                                                                        :entity_id              (:entity_id card)
+                                                                                        :visualization_settings {}
+                                                                                        :result_metadata        nil})
+                                                    :series                     []}]})
                    (dashboard-response (mt/user-http-request :rasta :get 200 (format "dashboard/%d" dashboard-id)))))))))
 
     (testing "a dashboard that has link cards on it"

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -324,7 +324,6 @@
                                                                                        :entity_id              (:entity_id card)
                                                                                        :visualization_settings {}
                                                                                        :result_metadata        nil})
-                                                   :dashboard_tab_id           nil
                                                    :series                     []}]})
                    (dashboard-response (mt/user-http-request :rasta :get 200 (format "dashboard/%d" dashboard-id)))))))))
 
@@ -417,7 +416,6 @@
                                                                                              :query_type             nil
                                                                                              :visualization_settings {}
                                                                                              :result_metadata        nil})
-                                                         :dashboard_tab_id           nil
                                                          :series                     []}]})
                    (dashboard-response (mt/user-http-request :rasta :get 200 (format "dashboard/%d" dashboard-id)))))))))
     (testing "fetch a dashboard from an official collection includes the collection type"

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -1529,6 +1529,21 @@
                                  :position     1}]}
                resp))))))
 
+(deftest update-cards-error-handling-test
+  (testing "PUT /api/dashboard/:id/cards"
+    (with-simple-dashboard-with-tabs [{:keys [dashboard-id]}]
+      (testing "if a dashboard has tabs, check if all cards from the request has a tab_id"
+        (is (= "This dashboard has tab, makes sure every cards has a tab assigned"
+               (mt/user-http-request :crowberto :put 400 (format "dashboard/%d/cards" dashboard-id)
+                                     {:cards        (conj
+                                                      (current-cards dashboard-id)
+                                                      {:id      -1
+                                                       :size_x  4
+                                                       :size_y  4
+                                                       :col     1
+                                                       :row     1})
+                                      :ordered_tabs (dashboard/ordered-tabs dashboard-id)})))))))
+
 ;;; -------------------------------------- Create dashcards tests ---------------------------------------
 
 (deftest simple-creation-with-no-additional-series-test

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -1214,7 +1214,8 @@
                                                             :col                0
                                                             :size_x             4
                                                             :size_y             4
-                                                            :parameter_mappings mappings}]}))
+                                                            :parameter_mappings mappings}]
+                                                   :ordered_tabs []}))
             :dashcards    (fn [] (t2/select DashboardCard :dashboard_id dashboard-id))})))))
 
 (defn- dashcard-like-response
@@ -1247,11 +1248,13 @@
              :update-mappings!       (fn [expected-status-code]
                                        (mt/user-http-request :rasta :put expected-status-code
                                                              (format "dashboard/%d/cards" dashboard-id)
-                                                             {:cards [(assoc dashcard-info :parameter_mappings new-mappings)]}))
+                                                             {:cards        [(assoc dashcard-info :parameter_mappings new-mappings)]
+                                                              :ordered_tabs []}))
              :update-size!           (fn []
                                        (mt/user-http-request :rasta :put 200
                                                              (format "dashboard/%d/cards" dashboard-id)
-                                                             {:cards [new-dashcard-info]}))}))))))
+                                                             {:cards        [new-dashcard-info]
+                                                              :ordered_tabs []}))}))))))
 
 (defn- do-with-simple-dashboard-with-tabs
   [f]
@@ -1406,7 +1409,8 @@
                                                           :col    3
                                                           :row    3
                                                           :card_id card-id-2
-                                                          :series  [{:id series-id-1}]}]}))
+                                                          :series  [{:id series-id-1}]}]
+                                                 :ordered_tabs []}))
             updated-card-1 {:id           dashcard-id-1
                             :card_id      card-id-1
                             :dashboard_id dashboard-id
@@ -1533,17 +1537,18 @@
     (with-dashboards-in-writeable-collection [dashboard-id]
       (api.card-test/with-cards-in-readable-collection [card-id]
         (let [resp (:cards (mt/user-http-request :rasta :put 200 (format "dashboard/%d/cards" dashboard-id)
-                                                 {:cards [{:id                     -1
-                                                           :card_id                card-id
-                                                           :row                    4
-                                                           :col                    4
-                                                           :size_x                 4
-                                                           :size_y                 4
-                                                           :parameter_mappings     [{:parameter_id "abc"
-                                                                                     :card_id 123
-                                                                                     :hash "abc"
-                                                                                     :target "foo"}]
-                                                           :visualization_settings {}}]}))]
+                                                 {:cards        [{:id                     -1
+                                                                  :card_id                card-id
+                                                                  :row                    4
+                                                                  :col                    4
+                                                                  :size_x                 4
+                                                                  :size_y                 4
+                                                                  :parameter_mappings     [{:parameter_id "abc"
+                                                                                            :card_id 123
+                                                                                            :hash "abc"
+                                                                                            :target "foo"}]
+                                                                  :visualization_settings {}}]
+                                                  :ordered_tabs []}))]
           ;; extra sure here because the dashcard we given has a negative id
           (testing "the inserted dashcards has ids auto-generated"
             (is (pos? (:id (first resp)))))
@@ -1580,13 +1585,14 @@
     (with-dashboards-in-writeable-collection [dashboard-id]
       (api.card-test/with-cards-in-readable-collection [card-id series-id-1]
         (let [dashboard-cards (:cards (mt/user-http-request :rasta :put 200 (format "dashboard/%d/cards" dashboard-id)
-                                                            {:cards [{:id      -1
-                                                                      :card_id card-id
-                                                                      :row     4
-                                                                      :col     4
-                                                                      :size_x  4
-                                                                      :size_y  4
-                                                                      :series [{:id series-id-1}]}]}))]
+                                                            {:cards        [{:id      -1
+                                                                             :card_id card-id
+                                                                             :row     4
+                                                                             :col     4
+                                                                             :size_x  4
+                                                                             :size_y  4
+                                                                             :series [{:id series-id-1}]}]
+                                                             :ordered_tabs []}))]
           (is (=? [{:row                    4
                     :col                    4
                     :size_x                 4
@@ -1621,14 +1627,15 @@
                               :action_id              action-id
                               :card_id                nil}]
                             (:cards (mt/user-http-request :crowberto :put 200 (format "dashboard/%s/cards" dashboard-id)
-                                                          {:cards [{:id                     -1
-                                                                    :size_x                 1
-                                                                    :size_y                 1
-                                                                    :row                    1
-                                                                    :col                    1
-                                                                    :card_id                nil
-                                                                    :action_id              action-id
-                                                                    :visualization_settings {:label "Update"}}]}))))
+                                                          {:cards        [{:id                     -1
+                                                                           :size_x                 1
+                                                                           :size_y                 1
+                                                                           :row                    1
+                                                                           :col                    1
+                                                                           :card_id                nil
+                                                                           :action_id              action-id
+                                                                           :visualization_settings {:label "Update"}}]
+                                                           :ordered_tabs []}))))
               (is (partial= {:ordered_cards [{:action (cond-> {:visualization_settings {:hello true}
                                                                :type (name action-type)
                                                                :parameters [{:id "id"}]}
@@ -1675,17 +1682,18 @@
      Card      {card-id :id}      {:archived true}]
     (is (= "The object has been archived."
            (:message (mt/user-http-request :rasta :put 404 (format "dashboard/%d/cards" dashboard-id)
-                                           {:cards [{:id                     -1
-                                                     :card_id                card-id
-                                                     :row                    4
-                                                     :col                    4
-                                                     :size_x                 4
-                                                     :size_y                 4
-                                                     :parameter_mappings     [{:parameter_id "abc"
-                                                                               :card_id 123
-                                                                               :hash "abc"
-                                                                               :target "foo"}]
-                                                     :visualization_settings {}}]}))))))
+                                           {:cards       [{:id                     -1
+                                                           :card_id                card-id
+                                                           :row                    4
+                                                           :col                    4
+                                                           :size_x                 4
+                                                           :size_y                 4
+                                                           :parameter_mappings     [{:parameter_id "abc"
+                                                                                     :card_id 123
+                                                                                     :hash "abc"
+                                                                                     :target "foo"}]
+                                                           :visualization_settings {}}]
+                                            :ordered_tabs []}))))))
 
 ;;; -------------------------------------- Update dashcards only tests ---------------------------------------
 
@@ -1720,17 +1728,18 @@
                (remove-ids-and-booleanize-timestamps (dashboard-card/retrieve-dashboard-card dashcard-id-2))))
         ;; TODO adds tests for return
         (mt/user-http-request :rasta :put 200 (format "dashboard/%d/cards" dashboard-id)
-                              {:cards [{:id     dashcard-id-1
-                                        :size_x 4
-                                        :size_y 2
-                                        :col    0
-                                        :row    0
-                                        :series [{:id series-id-1}]}
-                                       {:id     dashcard-id-2
-                                        :size_x 1
-                                        :size_y 1
-                                        :col    1
-                                        :row    3}]})
+                              {:cards        [{:id     dashcard-id-1
+                                               :size_x 4
+                                               :size_y 2
+                                               :col    0
+                                               :row    0
+                                               :series [{:id series-id-1}]}
+                                              {:id     dashcard-id-2
+                                               :size_x 1
+                                               :size_y 1
+                                               :col    1
+                                               :row    3}]
+                               :ordered_tabs []})
         (is (= {:size_x                 4
                 :size_y                 2
                 :col                    0
@@ -1793,7 +1802,8 @@
           ;; TODO adds test for return
           (mt/user-http-request :rasta :put 200 (format "dashboard/%d/cards" dashboard-id)
                                        {:cards [(assoc action-card :card_id model-id-2)
-                                                (assoc question-card :card_id model-id-2)]})
+                                                (assoc question-card :card_id model-id-2)]
+                                        :ordered_tabs []})
           ;; Only action card should change
           (is (partial= [{:card_id model-id-2}
                          {:card_id model-id}]
@@ -1836,7 +1846,8 @@
                             :series [{:id series-id-1}]}]
                    :ordered_tabs  []}
                   (mt/user-http-request :rasta :put 200
-                                        (format "dashboard/%d/cards" dashboard-id) {:cards [(dashcard-like-response dashcard-id-3)]})))
+                                        (format "dashboard/%d/cards" dashboard-id) {:cards [(dashcard-like-response dashcard-id-3)]
+                                                                                    :ordered_tabs []})))
           (is (= 1
                  (count (t2/select-pks-set DashboardCard, :dashboard_id dashboard-id)))))))
     (testing "prune"
@@ -1847,10 +1858,10 @@
         (with-dashboards-in-writeable-collection [dashboard-id]
           (is (= 2
                  (count (t2/select-pks-set DashboardCard, :dashboard_id dashboard-id))))
-          (is (=? {:ordered_tabs  []
-                   :cards []}
+          (is (=? {:ordered_tabs []
+                   :cards        []}
                   (mt/user-http-request :rasta :put 200
-                                        (format "dashboard/%d/cards" dashboard-id) {:cards []})))
+                                        (format "dashboard/%d/cards" dashboard-id) {:cards [] :ordered_tabs []})))
           (is (= 0
                  (count (t2/select-pks-set DashboardCard, :dashboard_id dashboard-id)))))))))
 

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -1222,16 +1222,11 @@
   (t2/hydrate (t2/select-one DashboardCard :id id) :series))
 
 (defn- current-cards
-  "Retursn the current ordered cards of a dashboard."
+  "Returns the current ordered cards of a dashboard."
   [dashboard-id]
   (-> dashboard-id
       dashboard/ordered-cards
       (t2/hydrate :series)))
-
-(defn- current-tabs
-  "Retursn the current ordered tabs of a dashboard."
-  [dashboard-id]
-  (dashboard/ordered-tabs dashboard-id))
 
 (defn do-with-update-cards-parameter-mapping-permissions-fixtures [f]
   (do-with-add-card-parameter-mapping-permissions-fixtures
@@ -1297,25 +1292,19 @@
          [Dashboard               {dashboard-id :id}  {}
           Card                    {card-id-1 :id}     {}
           Card                    {card-id-2 :id}     {}
-          :model/DashboardTab     {dashtab-id-1 :id}  {:name         "Tab 1"
-                                                       :dashboard_id dashboard-id
-                                                       :position     0}
-          :model/DashboardTab     {dashtab-id-2 :id}  {:name         "Tab 2"
-                                                       :dashboard_id dashboard-id
-                                                       :position 1}
-          :model/DashboardTab     {dashtab-id-3 :id}  {:name         "Tab 3"
-                                                       :dashboard_id dashboard-id
-                                                       :position 1}
+          :model/DashboardTab     {dashtab-id-1 :id}  {:name "Tab 1" :dashboard_id dashboard-id :position 0}
+          :model/DashboardTab     {dashtab-id-2 :id}  {:name "Tab 2" :dashboard_id dashboard-id :position 1}
+          :model/DashboardTab     {dashtab-id-3 :id}  {:name "Tab 3" :dashboard_id dashboard-id :position 2}
           DashboardCard           {dashcard-id-1 :id} {:dashboard_id dashboard-id, :card_id card-id-1, :dashboard_tab_id dashtab-id-1}
           DashboardCard           {dashcard-id-2 :id} {:dashboard_id dashboard-id, :card_id card-id-1, :dashboard_tab_id dashtab-id-2}
           DashboardCard           {dashcard-id-3 :id} {:dashboard_id dashboard-id, :card_id card-id-1, :dashboard_tab_id dashtab-id-2}]
         (let [resp (mt/user-http-request :rasta :put 200 (format "dashboard/%d/cards" dashboard-id)
-                                                         {:ordered_tabs  [{:id       dashtab-id-1
-                                                                           :name     "Tab 1 edited"}
-                                                                          {:id       dashtab-id-2
-                                                                           :name     "Tab 2"}
-                                                                          {:id       -1
-                                                                           :name     "New tab"}]
+                                                         {:ordered_tabs  [{:id   dashtab-id-1
+                                                                           :name "Tab 1 edited"}
+                                                                          {:id   dashtab-id-2
+                                                                           :name "Tab 2"}
+                                                                          {:id   -1
+                                                                           :name "New tab"}]
                                                           :cards [{:id     dashcard-id-1
                                                                    :size_x 4
                                                                    :size_y 4
@@ -1461,7 +1450,8 @@
                                                         {:ordered_tabs [{:name     "Tab new"
                                                                          :id       -1}
                                                                         {:name     "Tab 1 moved to second position"
-                                                                         :id       dashtab-id-1}]}))]
+                                                                         :id       dashtab-id-1}]
+                                                         :cards        []}))]
 
           (is (=? [{:dashboard_id dashboard-id
                     :name         "Tab new"
@@ -1877,7 +1867,7 @@
                 (mt/user-http-request :rasta :put 200
                                       (format "dashboard/%d/cards" dashboard-id)
                                       {:ordered_tabs [(t2/select-one :model/DashboardTab :id dashtab-id-1)]
-                                       :cards (current-cards dashboard-id)})))
+                                       :cards (remove #(= (:dashboard_tab_id %) dashtab-id-2) (current-cards dashboard-id))})))
         (testing "deteted 1 tab, we should have"
           (testing "1 card left"
             (is (= 1
@@ -1897,7 +1887,7 @@
                 (mt/user-http-request :rasta :put 200
                                       (format "dashboard/%d/cards" dashboard-id)
                                       {:ordered_tabs []
-                                       :cards (current-cards dashboard-id)})))
+                                       :cards (remove #(= (:dashboard_tab_id %) dashtab-id-2) (current-cards dashboard-id))})))
         (testing "dashboard should be empty"
           (testing "0 card left"
             (is (= 0

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -1533,7 +1533,7 @@
   (testing "PUT /api/dashboard/:id/cards"
     (with-simple-dashboard-with-tabs [{:keys [dashboard-id]}]
       (testing "if a dashboard has tabs, check if all cards from the request has a tab_id"
-        (is (= "This dashboard has tab, makes sure every cards has a tab assigned"
+        (is (= "This dashboard has tab, makes sure every card has a tab"
                (mt/user-http-request :crowberto :put 400 (format "dashboard/%d/cards" dashboard-id)
                                      {:cards        (conj
                                                       (current-cards dashboard-id)
@@ -1902,7 +1902,7 @@
             (is (= 1
                    (t2/count :model/DashboardTab :dashboard_id dashboard-id)))))))
     (testing "prune"
-      (with-simple-dashboard-with-tabs [{:keys [dashboard-id dashtab-id-1 dashtab-id-2]}]
+      (with-simple-dashboard-with-tabs [{:keys [dashboard-id dashtab-id-2]}]
         (testing "we have 2 tabs, each has 1 card to begin with"
           (is (= 2
                  (t2/count DashboardCard, :dashboard_id dashboard-id)))


### PR DESCRIPTION
Pursuant to https://github.com/metabase/metabase/pull/29802 and is should complete milestone 1 of https://github.com/metabase/metabase/issues/29502

Note that this PR contains only BE changes, to try out the feature, checkout https://github.com/metabase/metabase/pull/30189

This PR updates `PUT /api/dashboard/:id/cards` so that it takes a new `ordered_tabs` key.
- to create tabs, include a tab with a negative id
- to delete tabs, don't include that tab in the payload
- to update tabs, update tab information in the tabs payload
- the tab doesn't need to include `tab.position`, the position is inferred from the index of `ordered_tabs`.

```clojure
(mt/user-http-request :crowberto :put 200 (format "dashboard/%d/cards" dashboard-id)
                                     {:ordered_tabs [{:name     "Tab 1"
                                                      :id       -1}
                                                     {:name     "Tab 2"
                                                      :id       -2}]
                                      :cards [{:id     -1
                                               :size_x 1
                                               :size_y 1
                                               :col    1
                                               :row    1
                                               :dashboardtab_id -1
                                               :card_id card-id}
                                              {:id     -2
                                               :size_x 1
                                               :size_y 1
                                               :col    2
                                               :row    2
                                               :dashboardtab_id -2
                                               :card_id card-id}]})
;; => 
{:cards
 ({:size_x 1,
   :series (),
   :dashboardtab_id 19,
   ...}
  {:size_x 1,
   :series (),
   :dashboardtab_id 20,
   ...}),
 :ordered_tabs
 ({:id 19,
   :dashboard_id 1241,
   :name "Tab 1",
   :position 0}
  {:id 20,
   :dashboard_id 1241,
   :name "Tab 2",
   :position 1})}
```


Also updates `GET /api/dashboard/:id` to returns the tabs info as well

```diff
{
  :id 1
  :ordered_cards [{:id      1
                   :card_id 1
                   :card    {:id 1
                             :name 
                             ...} 
+                  :dashboardtab_id  1
                   ...}]
+ :ordered_tabs [{:id       1
+                 :position 1
+                 :name     "First tab"
+                }]
  ...
}
```

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/29861)
<!-- Reviewable:end -->
