### PR TITLE
add 50ms delay when removing metabot sql query to fix flakes

### DIFF
--- a/e2e/test/scenarios/onboarding/metabot.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/metabot.cy.spec.js
@@ -138,7 +138,7 @@ const verifyHomeMetabot = () => {
 const verifyManualQueryEditing = () => {
   cy.findByText("Open Editor").click();
   cy.findByTestId("native-query-editor")
-    .type("{selectall}{backspace}")
+    .type("{selectall}{backspace}", { delay: 50 })
     .type(MANUAL_QUERY);
   cy.findByLabelText("Refresh").click();
   cy.wait("@dataset");


### PR DESCRIPTION
### Description

Fixes `metabot.cy.spec.js` flake caused by the native query editor and fast typing. Example failure where the query has not been removed before typing a new one https://www.deploysentinel.com/ci/runs/642f1930cd1ee5b12f17c30f

### How to verify

CI should be green

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/29872)
<!-- Reviewable:end -->
