### PR TITLE
Fix can't join a table with another native question based on the same table

### DIFF
--- a/frontend/src/metabase/query_builder/components/DimensionList.jsx
+++ b/frontend/src/metabase/query_builder/components/DimensionList.jsx
@@ -80,7 +80,6 @@ export default class DimensionList extends Component {
       onRemoveDimension,
     } = this.props;
 
-    // XXX: Likely a typo
     const suppressSubDimensions =
       preventNumberSubDimensions && item.dimension.field().isSummable();
 
@@ -112,7 +111,6 @@ export default class DimensionList extends Component {
             triggerElement={this.renderSubDimensionTrigger(
               item.dimension,
               multiSelect,
-              // XXX: Never used since PR#18800
             )}
             tetherOptions={multiSelect ? null : SUBMENU_TETHER_OPTIONS}
             sizeToFit
@@ -186,8 +184,7 @@ export default class DimensionList extends Component {
     } = this.props;
     const dimension = useOriginalDimension
       ? item.dimension
-      : // XXX: 7. Important note that dimension with binning options is `dimension.defaultDimension()`
-        item.dimension.defaultDimension() || item.dimension;
+      : item.dimension.defaultDimension() || item.dimension;
     const shouldExcludeBinning =
       (!enableSubDimensions &&
         !useOriginalDimension &&
@@ -195,10 +192,6 @@ export default class DimensionList extends Component {
         dimension.binningStrategy()) ||
       (preventNumberSubDimensions && dimension.field().isSummable()) ||
       dimension.field().isFK();
-    // XXX 14. 🎉 dimension.field() after clicking to select each dimension in the `<DimensionList />`
-    // 1. Reviews join native Orders question: this._createFallbackField(), field().isSummable() is `true`
-    // 2. Orders join native Orders question: this._findMatchingQueryField(), field().isSummable() is `false` because it's a FK
-    // 3. Native Orders question join Orders this._findMatchingQueryField(), field().isSummable() is `true`
 
     if (shouldExcludeBinning) {
       // If we don't let user choose the sub-dimension, we don't want to treat the field


### PR DESCRIPTION
> **Note**
> The test is in https://github.com/metabase/metabase/pull/29834 (reproduction)

Superseded by https://github.com/metabase/metabase/pull/29879

Closes https://github.com/metabase/metabase/issues/29795

### Description

First, I need to be frank, I don't fully understand the whole intricate system, but I've summarize my finding so far.

I can conclude that the bug happens when we join a table with a native question that is based on the same table. When this happens `dimension.field().isSummable()` will be `false`
https://github.com/metabase/metabase/blob/0485afa86a71b46cfe19e2540e624d4d57d211dd/frontend/src/metabase/query_builder/components/DimensionList.jsx#L195-L205

This is because the field `USER_ID` type in this instance is `type/FK`. I trace back to this point
https://github.com/metabase/metabase/blob/0485afa86a71b46cfe19e2540e624d4d57d211dd/frontend/src/metabase-lib/Dimension.ts#L820-L823
where the dimension for `USER_ID` (the native question based on Orders table) seems to have some metadata (image 1) that isn't available from the native question alone (image 2).
1. <img width="1447" alt="image" src="https://user-images.githubusercontent.com/1937582/230500641-ca0bf66a-10e4-4428-906b-a1c0a8e91420.png">
2. <img width="1451" alt="image" src="https://user-images.githubusercontent.com/1937582/230500674-2627c337-7aa2-452a-b3f7-8bde40c9f4b7.png">


This causes the dimension to use the value from `defaultDimension()` (since `dimension.field().isSummable()` is `false`)
https://github.com/metabase/metabase/blob/0485afa86a71b46cfe19e2540e624d4d57d211dd/frontend/src/metabase/query_builder/components/DimensionList.jsx#L186-L188
which has a binning strategy (sent from BE):
- `USER_ID` has a default dimension option ID 29
    <img width="514" alt="image" src="https://user-images.githubusercontent.com/1937582/230499072-8becadfd-90ab-4664-89cd-5a35a227ce56.png">
- dimension option ID 29 specifies a binning strategy
    <img width="442" alt="image" src="https://user-images.githubusercontent.com/1937582/230499298-0331b2d2-a9ed-4833-a565-b225cbb03312.png">

The reason why joining a table with another native question that is based on a different table doesn't trigger this bug is because `dimension.field().isSummable()` will be `true`. This causes the the dimension value to be `dimension.baseDimension()` which doesn't have a binning strategy.

And here's my take.
1. The way this bug doesn't happen when joining a table with a native question based on another table that is relying on `dimension.field().isSummable()` to be `true` sounds weird. Since this condition exists because of this PR https://github.com/metabase/metabase/pull/18800. That doesn't sound like it wants to avoid binning on FK at all, but I do understand that since we don't know for sure that a column on a native that is `type/Integer` would actually be a value or an FK, it might make sense to add a comment somewhere here that we expect FK to fall into this condition as well, otherwise this just sounds like a fluke to me.
2. This is probably rare but the condition I add here only exists for this very specific reason. Another way to see that our Metabase lib entities are in a weird state is we could try changing this line https://github.com/metabase/metabase/blob/0485afa86a71b46cfe19e2540e624d4d57d211dd/frontend/src/metabase/query_builder/components/DimensionList.jsx#L188 to `item.dimension.defaultDimension().field().dimension() || item.dimension;` and we will see that now we will get a different dimension. That tells that there is an inconsistency between a dimension and its field at this point. It's also worth noting that we could use this said line and remove the `dimension.field().isFK()` check from this PR, and it's still fix the problem, but I just find `item.dimension.defaultDimension().field().dimension()` looks more hacky.

### How to verify

Run an E2E test in this PR: https://github.com/metabase/metabase/pull/29834

### Demo

#### Before the fix
<img width="1118" alt="Screenshot 2023-04-06 at 10 14 05 PM" src="https://user-images.githubusercontent.com/1937582/230498390-16ca1400-5634-4d6f-abf3-40f151937c69.png">

#### After the fix
<img width="1124" alt="Screenshot 2023-04-06 at 10 14 17 PM" src="https://user-images.githubusercontent.com/1937582/230498422-a9aab2ef-6d4d-41c1-8df7-abd00e490329.png">

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR (Added in https://github.com/metabase/metabase/pull/29834)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/29873)
<!-- Reviewable:end -->
