### PR TITLE
orderable-columns should not return columns that are already in order-bys

### DIFF
--- a/src/metabase/lib/expression.cljc
+++ b/src/metabase/lib/expression.cljc
@@ -53,6 +53,10 @@
    :base_type    (lib.metadata.calculation/type-of query stage-number expression-ref)
    :lib/source   :source/expressions})
 
+(defmethod lib.metadata.calculation/display-name-method :dispatch-type/integer
+  [_query _stage-number n]
+  (str n))
+
 (defmethod lib.metadata.calculation/display-name-method :dispatch-type/number
   [_query _stage-number n]
   (str n))

--- a/src/metabase/lib/join.cljc
+++ b/src/metabase/lib/join.cljc
@@ -55,12 +55,15 @@
   [query        :- ::lib.schema/query
    stage-number :- :int
    join-alias   :- ::lib.schema.common/non-blank-string]
-  (or (m/find-first #(= (:alias %) join-alias)
-                    (:joins (lib.util/query-stage query stage-number)))
-      (throw (ex-info (i18n/tru "No join named {0}" (pr-str join-alias))
-                      {:join-alias   join-alias
-                       :query        query
-                       :stage-number stage-number}))))
+  (let [{:keys [joins]} (lib.util/query-stage query stage-number)]
+    (or (m/find-first #(= (:alias %) join-alias)
+                      joins)
+        (throw (ex-info (i18n/tru "No join named {0}, found: {1}"
+                                  (pr-str join-alias)
+                                  (pr-str (mapv :alias joins)))
+                        {:join-alias   join-alias
+                         :query        query
+                         :stage-number stage-number})))))
 
 (defmethod lib.metadata.calculation/display-name-method :mbql/join
   [query _stage-number {[first-stage] :stages, :as _join}]

--- a/src/metabase/lib/metadata/calculation.cljc
+++ b/src/metabase/lib/metadata/calculation.cljc
@@ -179,9 +179,9 @@
    [:map
     [:lib/source ::lib.metadata/column-source]]])
 
-(mu/defn metadata :- [:or
-                      lib.metadata/ColumnMetadata
-                      [:sequential ColumnMetadataWithSource]]
+(mu/defn metadata :- [:maybe [:or
+                              lib.metadata/ColumnMetadata
+                              [:sequential ColumnMetadataWithSource]]]
   "Calculate appropriate metadata for something. What this looks like depends on what we're calculating metadata for.
   If it's a reference or expression of some sort, this should return a single `:metadata/field` map (i.e., something
   satisfying the [[metabase.lib.metadata/ColumnMetadata]] schema. If it's something like a stage of a query or a join

--- a/src/metabase/lib/order_by.cljc
+++ b/src/metabase/lib/order_by.cljc
@@ -3,6 +3,7 @@
    [metabase.lib.aggregation :as lib.aggregation]
    [metabase.lib.breakout :as lib.breakout]
    [metabase.lib.dispatch :as lib.dispatch]
+   [metabase.lib.equality :as lib.equality]
    [metabase.lib.hierarchy :as lib.hierarchy]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.metadata.calculation :as lib.metadata.calculation]
@@ -142,9 +143,19 @@
 
   ([query        :- ::lib.schema/query
     stage-number :- :int]
-   (let [breakouts    (not-empty (lib.breakout/breakouts query stage-number))
-         aggregations (not-empty (lib.aggregation/aggregations query stage-number))]
-     (filter orderable-column?
-             (if (or breakouts aggregations)
-               (concat breakouts aggregations)
-               (lib.stage/visible-columns query stage-number))))))
+   (let [existing-order-bys (mapv (fn [[_tag _opts expr]]
+                                    expr)
+                                  (order-bys query stage-number))
+         existing-order-by? (fn [x]
+                              (some (fn [existing-order-by]
+                                      (lib.equality/= (lib.ref/ref x) existing-order-by))
+                                    existing-order-bys))
+         breakouts          (not-empty (lib.breakout/breakouts query stage-number))
+         aggregations       (not-empty (lib.aggregation/aggregations query stage-number))
+         columns            (if (or breakouts aggregations)
+                              (concat breakouts aggregations)
+                              (lib.stage/visible-columns query stage-number))]
+     (into []
+           (comp (filter orderable-column?)
+                 (remove existing-order-by?))
+           columns))))

--- a/src/metabase/lib/table.cljc
+++ b/src/metabase/lib/table.cljc
@@ -52,13 +52,17 @@
   [table-metadata]
   (::join-alias table-metadata))
 
+(defmethod lib.join/with-join-fields-method :metadata/table
+  [table-metadata fields]
+  (assoc table-metadata ::join-fields fields))
+
 (defmethod lib.join/join-clause-method :metadata/table
-  [query stage-number {::keys [join-alias], :as table-metadata}]
-  (lib.join/join-clause-method query
-                               stage-number
-                               (merge
-                                {:lib/type     :mbql.stage/mbql
-                                 :lib/options  {:lib/uuid (str (random-uuid))}
-                                 :source-table (:id table-metadata)}
-                                (when join-alias
-                                  {:alias join-alias}))))
+  [query stage-number {::keys [join-alias join-fields], :as table-metadata}]
+  (cond-> (lib.join/join-clause-method query
+                                       stage-number
+                                       (merge
+                                        {:lib/type     :mbql.stage/mbql
+                                         :lib/options  {:lib/uuid (str (random-uuid))}
+                                         :source-table (:id table-metadata)}))
+    join-alias  (lib.join/with-join-alias join-alias)
+    join-fields (lib.join/with-join-fields join-fields)))

--- a/src/metabase/lib/table.cljc
+++ b/src/metabase/lib/table.cljc
@@ -58,11 +58,11 @@
 
 (defmethod lib.join/join-clause-method :metadata/table
   [query stage-number {::keys [join-alias join-fields], :as table-metadata}]
-  (cond-> (lib.join/join-clause-method query
-                                       stage-number
-                                       (merge
-                                        {:lib/type     :mbql.stage/mbql
-                                         :lib/options  {:lib/uuid (str (random-uuid))}
-                                         :source-table (:id table-metadata)}))
+  (cond-> (lib.join/join-clause query
+                                stage-number
+                                (merge
+                                 {:lib/type     :mbql.stage/mbql
+                                  :lib/options  {:lib/uuid (str (random-uuid))}
+                                  :source-table (:id table-metadata)}))
     join-alias  (lib.join/with-join-alias join-alias)
     join-fields (lib.join/with-join-fields join-fields)))

--- a/src/metabase/lib/table.cljc
+++ b/src/metabase/lib/table.cljc
@@ -64,9 +64,8 @@
   [query stage-number {::keys [join-alias join-fields], :as table-metadata}]
   (cond-> (lib.join/join-clause query
                                 stage-number
-                                (merge
-                                 {:lib/type     :mbql.stage/mbql
-                                  :lib/options  {:lib/uuid (str (random-uuid))}
-                                  :source-table (:id table-metadata)}))
+                                {:lib/type     :mbql.stage/mbql
+                                 :lib/options  {:lib/uuid (str (random-uuid))}
+                                 :source-table (:id table-metadata)})
     join-alias  (lib.join/with-join-alias join-alias)
     join-fields (lib.join/with-join-fields join-fields)))

--- a/test/metabase/lib/order_by_test.cljc
+++ b/test/metabase/lib/order_by_test.cljc
@@ -365,24 +365,145 @@
                 (lib/append-stage)
                 (lib/orderable-columns))))))
 
-(deftest ^:parallel orderable-columns-include-expressions-test
-  (testing "orderable-columns should include expressions"
-    (is (=? [{:name "ID"}
-             {:name "NAME"}
-             {:name "CATEGORY_ID"}
-             {:name "LATITUDE"}
-             {:name "LONGITUDE"}
-             {:name "PRICE"}
-             {:lib/type     :metadata/field
-              :name         "expr"
-              :display_name "expr"
-              :lib/source   :source/expressions}
-             {:name "ID", :lib/source :source/implicitly-joinable}
-             {:name "NAME", :lib/source :source/implicitly-joinable}]
-            (-> (lib/query-for-table-name meta/metadata-provider "VENUES")
-                (lib/expression "expr" (lib/absolute-datetime "2020" :month))
-                (lib/fields [(lib/field "VENUES" "ID")])
-                (lib/orderable-columns))))))
+(deftest ^:parallel orderable-columns-exclude-already-sorted-columns-test
+  (testing "orderable-columns should not return normal Fields already included in :order-by (#29807)"
+    (let [query (lib/query-for-table-name meta/metadata-provider "VENUES")]
+      (is (=? [{:display_name "ID",          :lib/source :source/table-defaults}
+               {:display_name "Name",        :lib/source :source/table-defaults}
+               {:display_name "Category ID", :lib/source :source/table-defaults}
+               {:display_name "Latitude",    :lib/source :source/table-defaults}
+               {:display_name "Longitude",   :lib/source :source/table-defaults}
+               {:display_name "Price",       :lib/source :source/table-defaults}
+               {:display_name "ID",          :lib/source :source/implicitly-joinable}
+               {:display_name "Name",        :lib/source :source/implicitly-joinable}]
+              (lib/orderable-columns query)))
+      (let [query' (lib/order-by query (second (lib/orderable-columns query)))]
+        (is (=? {:stages [{:order-by [[:asc {} [:field {} (meta/id :venues :name)]]]}]}
+                query'))
+        (is (=? [[:asc {} [:field {} (meta/id :venues :name)]]]
+                (lib/order-bys query')))
+        (is (=? [{:display_name "ID",          :lib/source :source/table-defaults}
+                 {:display_name "Category ID", :lib/source :source/table-defaults}
+                 {:display_name "Latitude",    :lib/source :source/table-defaults}
+                 {:display_name "Longitude",   :lib/source :source/table-defaults}
+                 {:display_name "Price",       :lib/source :source/table-defaults}
+                 {:display_name "ID",          :lib/source :source/implicitly-joinable}
+                 {:display_name "Name",        :lib/source :source/implicitly-joinable}]
+                (lib/orderable-columns query')))
+        (testing "Introduce a new stage"
+          (let [query'' (lib/append-stage query')]
+            (is (=? [{:display_name "ID",          :lib/source :source/previous-stage}
+                     {:display_name "Name",        :lib/source :source/previous-stage}
+                     {:display_name "Category ID", :lib/source :source/previous-stage}
+                     {:display_name "Latitude",    :lib/source :source/previous-stage}
+                     {:display_name "Longitude",   :lib/source :source/previous-stage}
+                     {:display_name "Price",       :lib/source :source/previous-stage}
+                     {:display_name "ID",          :lib/source :source/implicitly-joinable}
+                     {:display_name "Name",        :lib/source :source/implicitly-joinable}]
+                    (lib/orderable-columns query'')))))))))
+
+(deftest ^:parallel orderable-columns-exclude-already-sorted-aggregation-test
+  (testing "orderable-columns should not return aggregation refs that are already in :order-by (#29807)"
+    (let [query (-> (lib/query-for-table-name meta/metadata-provider "VENUES")
+                    (lib/aggregate (lib/sum (lib/field (meta/id :venues :price))))
+                    (lib/aggregate (lib/sum (lib/field (meta/id :venues :id)))))]
+      (is (=? [{:display_name "Sum of Price", :lib/source :source/aggregations}
+               {:display_name "Sum of ID",    :lib/source :source/aggregations}]
+              (lib/orderable-columns query)))
+      (let [query' (lib/order-by query (first (lib/orderable-columns query)))]
+        (is (=? [{:display_name "Sum of ID", :lib/source :source/aggregations}]
+                (lib/orderable-columns query')))))))
+
+(deftest ^:parallel orderable-columns-exclude-already-sorted-joined-columns-test
+  (testing "orderable-columns should not return joined columns that are already in :order-by (#29807)"
+    (let [query (-> (lib/query-for-table-name meta/metadata-provider "VENUES")
+                    (lib/join (-> (lib/table (meta/id :categories))
+                                  (lib/with-join-alias "Cat")
+                                  (lib/with-join-fields :all))
+                              (lib/= (lib/field (meta/id :venues :category-id))
+                                     (-> (lib/field (meta/id :categories :id))
+                                         (lib/with-join-alias "Cat")))))]
+      (is (=? {:stages [{:joins
+                         [{:stages    [{}]
+                           :alias     "Cat"
+                           :fields    :all
+                           :condition [:=
+                                       {}
+                                       [:field {} (meta/id :venues :category-id)]
+                                       [:field {:join-alias "Cat"} (meta/id :categories :id)]]}]}]}
+              query))
+      (is (=? [{:display_name "ID",                :lib/source :source/table-defaults}
+               {:display_name "Name",              :lib/source :source/table-defaults}
+               {:display_name "Category ID",       :lib/source :source/table-defaults}
+               {:display_name "Latitude",          :lib/source :source/table-defaults}
+               {:display_name "Longitude",         :lib/source :source/table-defaults}
+               {:display_name "Price",             :lib/source :source/table-defaults}
+               ;; implicitly joinable versions shouldn't be returned either, since we have an explicit join.
+               {:display_name "Categories → ID",   :lib/source :source/joins}
+               {:display_name "Categories → Name", :lib/source :source/joins}]
+              (lib/orderable-columns query)))
+      (let [query' (lib/order-by query (m/find-first #(= (:display_name %) "Categories → Name")
+                                                     (lib/orderable-columns query)))]
+        (is (=? [{:display_name "ID",                :lib/source :source/table-defaults}
+                 {:display_name "Name",              :lib/source :source/table-defaults}
+                 {:display_name "Category ID",       :lib/source :source/table-defaults}
+                 {:display_name "Latitude",          :lib/source :source/table-defaults}
+                 {:display_name "Longitude",         :lib/source :source/table-defaults}
+                 {:display_name "Price",             :lib/source :source/table-defaults}
+                 {:display_name "Categories → ID",   :lib/source :source/joins}]
+                (lib/orderable-columns query')))))))
+
+(deftest ^:parallel orderable-columns-exclude-already-sorted-implicitly-joinable-columns-test
+  (testing "orderable-columns should not return implicitly joinable columns that are already in :order-by (#29807)"
+    (let [query (lib/query-for-table-name meta/metadata-provider "VENUES")]
+      (is (=? [{:display_name "ID",          :lib/source :source/table-defaults}
+               {:display_name "Name",        :lib/source :source/table-defaults}
+               {:display_name "Category ID", :lib/source :source/table-defaults}
+               {:display_name "Latitude",    :lib/source :source/table-defaults}
+               {:display_name "Longitude",   :lib/source :source/table-defaults}
+               {:display_name "Price",       :lib/source :source/table-defaults}
+               {:display_name "ID",          :lib/source :source/implicitly-joinable}
+               {:display_name "Name",        :lib/source :source/implicitly-joinable}]
+              (lib/orderable-columns query)))
+      (let [query' (lib/order-by query (last (lib/orderable-columns query)))]
+        (is (=? {:stages [{:order-by [[:asc {} [:field
+                                                {:source-field (meta/id :venues :category-id)}
+                                                (meta/id :categories :name)]]]}]}
+                query'))
+        (is (=? [{:display_name "ID",          :lib/source :source/table-defaults}
+                 {:display_name "Name",        :lib/source :source/table-defaults}
+                 {:display_name "Category ID", :lib/source :source/table-defaults}
+                 {:display_name "Latitude",    :lib/source :source/table-defaults}
+                 {:display_name "Longitude",   :lib/source :source/table-defaults}
+                 {:display_name "Price",       :lib/source :source/table-defaults}
+                 {:display_name "ID",          :lib/source :source/implicitly-joinable}]
+                (lib/orderable-columns query')))))))
+
+(deftest ^:parallel orderable-columns-exclude-already-sorted-expression-test
+  (testing "orderable-columns should not return expressions that are already in :order-by (#29807)"
+    (let [query (-> (lib/query-for-table-name meta/metadata-provider "VENUES")
+                    (lib/expression "My Expression" (lib/+ 2 3)))]
+      (is (=? [{:display_name "ID",            :lib/source :source/table-defaults}
+               {:display_name "Name",          :lib/source :source/table-defaults}
+               {:display_name "Category ID",   :lib/source :source/table-defaults}
+               {:display_name "Latitude",      :lib/source :source/table-defaults}
+               {:display_name "Longitude",     :lib/source :source/table-defaults}
+               {:display_name "Price",         :lib/source :source/table-defaults}
+               {:display_name "My Expression", :lib/source :source/expressions}
+               {:display_name "ID",            :lib/source :source/implicitly-joinable}
+               {:display_name "Name",          :lib/source :source/implicitly-joinable}]
+              (lib/orderable-columns query)))
+      (let [query' (lib/order-by query (m/find-first #(= (:display_name %) "My Expression")
+                                                     (lib/orderable-columns query)))]
+        (is (=? [{:display_name "ID",            :lib/source :source/table-defaults}
+                 {:display_name "Name",          :lib/source :source/table-defaults}
+                 {:display_name "Category ID",   :lib/source :source/table-defaults}
+                 {:display_name "Latitude",      :lib/source :source/table-defaults}
+                 {:display_name "Longitude",     :lib/source :source/table-defaults}
+                 {:display_name "Price",         :lib/source :source/table-defaults}
+                 {:display_name "ID",            :lib/source :source/implicitly-joinable}
+                 {:display_name "Name",          :lib/source :source/implicitly-joinable}]
+                (lib/orderable-columns query')))))))
 
 (deftest ^:parallel order-by-expression-test
   (let [query (-> (lib/query-for-table-name meta/metadata-provider "VENUES")

--- a/test/metabase/lib/table_test.cljc
+++ b/test/metabase/lib/table_test.cljc
@@ -1,0 +1,24 @@
+(ns metabase.lib.table-test
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [metabase.lib.core :as lib]
+   [metabase.lib.test-metadata :as meta]))
+
+(deftest ^:parallel join-table-metadata-test
+  (testing "You should be able to pass :metadata/table to lib/join"
+    (let [query (-> (lib/query-for-table-name meta/metadata-provider "VENUES")
+                    (lib/join (-> (lib/table (meta/id :categories))
+                                  (lib/with-join-alias "Cat")
+                                  (lib/with-join-fields :all))
+                              (lib/= (lib/field (meta/id :venues :category-id))
+                                     (-> (lib/field (meta/id :categories :id))
+                                         (lib/with-join-alias "Cat")))))]
+      (is (=? {:stages [{:joins
+                         [{:stages    [{}]
+                           :alias     "Cat"
+                           :fields    :all
+                           :condition [:=
+                                       {}
+                                       [:field {} (meta/id :venues :category-id)]
+                                       [:field {:join-alias "Cat"} (meta/id :categories :id)]]}]}]}
+              query)))))


### PR DESCRIPTION
Resolves #29807

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/29874)
<!-- Reviewable:end -->
