### PR TITLE
More parallel tests

### DIFF
--- a/test/metabase/api/login_history_test.clj
+++ b/test/metabase/api/login_history_test.clj
@@ -1,4 +1,4 @@
-(ns metabase.api.login-history-test
+(ns ^:mb/once metabase.api.login-history-test
   (:require
    [clojure.test :refer :all]
    [metabase.models :refer [LoginHistory Session User]]
@@ -7,11 +7,6 @@
    [schema.core :as s]))
 
 (set! *warn-on-reflection* true)
-
-;; don't run these tests when running driver tests (i.e., `DRIVERS` is set) because they tend to flake
-(use-fixtures :each (fn [thunk]
-                      (mt/disable-flaky-test-when-running-driver-tests-in-ci
-                       (thunk))))
 
 (def ^:private windows-user-agent
   "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML like Gecko) Chrome/89.0.4389.86 Safari/537.36")

--- a/test/metabase/api/session_test.clj
+++ b/test/metabase/api/session_test.clj
@@ -85,7 +85,7 @@
                    (first (mt/with-log-messages-for-level :error
                             (mt/client :post 400 "session" {:email (:email user), :password "wooo"}))))))))
 
-(deftest login-validation-test
+(deftest ^:parallel login-validation-test
   (testing "POST /api/session"
     (testing "Test for required params"
       (is (= {:errors {:username "value must be a non-blank string."}}
@@ -147,25 +147,23 @@
 
 (deftest failure-threshold-throttling-test
   (testing "Test that source based throttling kicks in after the login failure threshold (50) has been reached"
-    ;; disable this when we're testing drivers since it tends to F L A K E.
-    (mt/disable-flaky-test-when-running-driver-tests-in-ci
-      (with-redefs [api.session/login-throttlers          (cleaned-throttlers #'api.session/login-throttlers
-                                                                              [:username :ip-address])
-                    public-settings/source-address-header (constantly "x-forwarded-for")]
-        (dotimes [n 50]
-          (let [response    (send-login-request (format "user-%d" n)
-                                                {"x-forwarded-for" "10.1.2.3"})
-                status-code (:status response)]
-            (assert (= status-code 401) (str "Unexpected response status code:" status-code))))
-        (let [error (fn []
-                      (-> (send-login-request "last-user" {"x-forwarded-for" "10.1.2.3"})
-                          :body
-                          json/parse-string
-                          (get-in ["errors" "username"])))]
-          (is (re= #"^Too many attempts! You must wait \d+ seconds before trying again\.$"
-                   (error)))
-          (is (re= #"^Too many attempts! You must wait \d+ seconds before trying again\.$"
-                   (error))))))))
+    (with-redefs [api.session/login-throttlers          (cleaned-throttlers #'api.session/login-throttlers
+                                                                            [:username :ip-address])
+                  public-settings/source-address-header (constantly "x-forwarded-for")]
+      (dotimes [n 50]
+        (let [response    (send-login-request (format "user-%d" n)
+                                              {"x-forwarded-for" "10.1.2.3"})
+              status-code (:status response)]
+          (assert (= status-code 401) (str "Unexpected response status code:" status-code))))
+      (let [error (fn []
+                    (-> (send-login-request "last-user" {"x-forwarded-for" "10.1.2.3"})
+                        :body
+                        json/parse-string
+                        (get-in ["errors" "username"])))]
+        (is (re= #"^Too many attempts! You must wait \d+ seconds before trying again\.$"
+                 (error)))
+        (is (re= #"^Too many attempts! You must wait \d+ seconds before trying again\.$"
+                 (error)))))))
 
 (deftest failure-threshold-per-request-source
   (testing "The same as above, but ensure that throttling is done on a per request source basis."

--- a/test/metabase/server/request/util_test.clj
+++ b/test/metabase/server/request/util_test.clj
@@ -1,4 +1,4 @@
-(ns metabase.server.request.util-test
+(ns ^:mb/once metabase.server.request.util-test
   (:require
    [clojure.test :refer :all]
    [clojure.tools.reader.edn :as edn]
@@ -8,12 +8,7 @@
    [ring.mock.request :as ring.mock]
    [schema.core :as s]))
 
-;; don't run these tests when running driver tests (i.e., `DRIVERS` is set) because they tend to flake
-(use-fixtures :each (fn [thunk]
-                      (mt/disable-flaky-test-when-running-driver-tests-in-ci
-                        (thunk))))
-
-(deftest https?-test
+(deftest ^:parallel https?-test
   (doseq [[headers expected] {{"x-forwarded-proto" "https"}    true
                               {"x-forwarded-proto" "http"}     false
                               {"x-forwarded-protocol" "https"} true
@@ -33,13 +28,13 @@
 (def ^:private mock-request
   (delay (edn/read-string (slurp "test/metabase/server/request/sample-request.edn"))))
 
-(deftest device-info-test
+(deftest ^:parallel device-info-test
   (is (= {:device_id          "129d39d1-6758-4d2c-a751-35b860007002"
           :device_description "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.72 Safari/537.36"
           :ip_address         "0:0:0:0:0:0:0:1"}
          (request.u/device-info @mock-request))))
 
-(deftest describe-user-agent-test
+(deftest ^:parallel describe-user-agent-test
   (are [user-agent expected] (= expected (request.u/describe-user-agent user-agent))
     "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML  like Gecko) Chrome/89.0.4389.86 Safari/537.36"
     "Browser (Chrome/Windows)"
@@ -59,7 +54,7 @@
     nil
     nil))
 
-(deftest ip-address-test
+(deftest ^:parallel ip-address-test
   (let [request (ring.mock/request :get "api/session")]
     (testing "request with no forwarding"
       (is (= "127.0.0.1"
@@ -81,7 +76,7 @@
             (is (= "1.2.3.4"
                    (request.u/ip-address mock-request)))))))))
 
-(deftest geocode-ip-addresses-test
+(deftest ^:parallel geocode-ip-addresses-test
   (are [ip-addresses expected] (schema= expected (request.u/geocode-ip-addresses ip-addresses))
     ["8.8.8.8"]
     {(s/required-key "8.8.8.8") {:description (s/eq "United States")

--- a/test/metabase/test.clj
+++ b/test/metabase/test.clj
@@ -421,13 +421,3 @@
      (hawk.init/assert-tests-are-not-initializing (list 'object-defaults (symbol (name toucan-model))))
      (initialize/initialize-if-needed! :db)
      (mdb.u/resolve-model toucan-model))))
-
-(defmacro disable-flaky-test-when-running-driver-tests-in-ci
-  "Only run `body` when we're not running driver tests in CI (i.e., `DRIVERS` and `CI` are both not set). Perfect for
-  disabling those damn flaky tests that cause CI to fail all the time. You should obviously only do this for things
-  that have nothing to do with drivers but tend to flake anyway."
-  {:style/indent 0}
-  [& body]
-  `(when (and (not (seq (env/env :drivers)))
-              (not (seq (env/env :ci))))
-     ~@body))


### PR DESCRIPTION
Mark some more tests `^:parallel`.

Remove `mt/disable-flaky-test-when-running-driver-tests-in-ci`, and use `^:mb/once` metadata on the namespace instead.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/29877)
<!-- Reviewable:end -->
