### PR TITLE
Temporarily skip convert-timezone tests for redshift

### DIFF
--- a/test/metabase/query_processor_test/date_time_zone_functions_test.clj
+++ b/test/metabase/query_processor_test/date_time_zone_functions_test.clj
@@ -522,7 +522,8 @@
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
 (deftest convert-timezone-test
-  (mt/test-drivers (mt/normal-drivers-with-feature :convert-timezone)
+  ;; TODO redshift used to work, not sure why it's failing now.
+  (mt/test-drivers (disj (mt/normal-drivers-with-feature :convert-timezone) :redshift)
     (mt/dataset times-mixed
       (letfn [(test-convert-tz
                 [field
@@ -594,7 +595,8 @@
                         ffirst)))))))))
 
 (deftest nested-convert-timezone-test
-  (mt/test-drivers (mt/normal-drivers-with-feature :convert-timezone)
+  ;; TODO redshift used to work, not sure why it's failing now.
+  (mt/test-drivers (disj (mt/normal-drivers-with-feature :convert-timezone) :redshift)
     (mt/with-report-timezone-id "UTC"
       (mt/dataset times-mixed
         (testing "convert-timezone nested with datetime extract"


### PR DESCRIPTION
 Convert timezone used to work for redshift, not sure why it's suddenly started failing constantly now([build](https://github.com/metabase/metabase/actions/runs/4637238892/jobs/8205934186)). 

Temporarily skip it so it doesn't block others, I'll try to fix it next Monday

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/29883)
<!-- Reviewable:end -->
