### PR TITLE
Make string/contains and string/does-not-contain filters in native questions case-insensitive

### DIFF
--- a/frontend/src/metabase-lib/parameters/utils/parameter-values.js
+++ b/frontend/src/metabase-lib/parameters/utils/parameter-values.js
@@ -34,6 +34,7 @@ export function normalizeParameter(parameter) {
     slug: parameter.slug,
     type: parameter.type,
     target: parameter.target,
+    options: parameter.options,
     values_query_type: getQueryType(parameter),
     values_source_type: getSourceType(parameter),
     values_source_config: getSourceConfig(parameter),
@@ -43,11 +44,12 @@ export function normalizeParameter(parameter) {
 export function normalizeParameters(parameters) {
   return parameters
     .filter(parameter => _.has(parameter, "value"))
-    .map(({ type, value, target, id }) => ({
+    .map(({ id, type, value, target, options }) => ({
       id,
       type,
       value: normalizeParameterValue(type, value),
       target,
+      options,
     }));
 }
 

--- a/frontend/src/metabase-lib/parameters/utils/template-tags.ts
+++ b/frontend/src/metabase-lib/parameters/utils/template-tags.ts
@@ -1,6 +1,10 @@
 import _ from "underscore";
 
-import { Parameter, ParameterValuesConfig } from "metabase-types/api";
+import {
+  Parameter,
+  ParameterOptions,
+  ParameterValuesConfig,
+} from "metabase-types/api";
 import type { ParameterTarget } from "metabase-types/types/Parameter";
 import type { Card } from "metabase-types/types/Card";
 import type { TemplateTag } from "metabase-types/types/Query";
@@ -39,10 +43,23 @@ export function getTemplateTagParameter(
     name: tag["display-name"],
     slug: tag.name,
     default: tag.default,
+    options: getTemplateTagParameterOptions(tag),
     values_query_type: config?.values_query_type,
     values_source_type: config?.values_source_type,
     values_source_config: config?.values_source_config,
   };
+}
+
+function getTemplateTagParameterOptions(
+  tag: TemplateTag,
+): ParameterOptions | undefined {
+  switch (tag["widget-type"]) {
+    case "string/contains":
+    case "string/does-not-contain":
+      return { "case-sensitive": false };
+    default:
+      return undefined;
+  }
 }
 
 // NOTE: this should mirror `template-tag-parameters` in src/metabase/api/embed.clj

--- a/frontend/src/metabase-types/api/parameters.ts
+++ b/frontend/src/metabase-types/api/parameters.ts
@@ -45,6 +45,11 @@ export interface Parameter extends ParameterValuesConfig {
   filteringParameters?: ParameterId[];
   isMultiSelect?: boolean;
   value?: any;
+  options?: ParameterOptions;
+}
+
+export interface ParameterOptions {
+  "case-sensitive"?: boolean;
 }
 
 export interface ParameterValuesConfig {


### PR DESCRIPTION
Epic https://github.com/metabase/metabase/issues/29881

Makes `string/contains` and `string/does-not-contain` field filters in native questions to be case-insensitive. The change would only affect new questions or questions after an update. Existing questions without modifications would not be affected.

How to verify:
- New -> SQL query -> `SELECT * FROM PEOPLE WHERE {{filter}}`
- Change the parameter Text -> Field Filter, People, Name, String contain
- Set the parameter value and run the query
- Make sure the case of the search string is ignored

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/29886)
<!-- Reviewable:end -->
