### PR TITLE
Add markdown support to EditableText

### DIFF
--- a/e2e/test/scenarios/collections/collections.cy.spec.js
+++ b/e2e/test/scenarios/collections/collections.cy.spec.js
@@ -180,7 +180,7 @@ describe("scenarios > collection defaults", () => {
 
   it("should support markdown in collection description", () => {
     cy.request("PUT", "/api/collection/9", {
-      description: "# header",
+      description: "[link](https://metabase.com)",
     });
 
     visitRootCollection();
@@ -194,8 +194,8 @@ describe("scenarios > collection defaults", () => {
     });
 
     popover().within(() => {
-      cy.findByRole("heading").contains("header");
-      cy.findByRole("heading").should("not.include.text", "# header");
+      cy.findByRole("link").should("include.text", "link");
+      cy.findByRole("link").should("not.include.text", "[link]");
     });
   });
 

--- a/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
@@ -92,6 +92,7 @@ describe("scenarios > dashboard", () => {
     cy.get("main header").within(() => {
       cy.icon("info").click();
     });
+    cy.findByText("How many orders were placed in each year?").click();
     cy.findByDisplayValue("How many orders were placed in each year?");
   });
 

--- a/e2e/test/scenarios/models/models.cy.spec.js
+++ b/e2e/test/scenarios/models/models.cy.spec.js
@@ -384,11 +384,12 @@ describe("scenarios > models", () => {
 
       questionInfoButton().click();
 
+      cy.findByTestId("editable-text").click();
       cy.findByPlaceholderText("Add description").type("foo").blur();
       cy.wait("@updateCard");
 
       cy.findByDisplayValue("M1");
-      cy.findByDisplayValue("foo");
+      cy.findByText("foo");
     });
   });
 

--- a/e2e/test/scenarios/models/models.cy.spec.js
+++ b/e2e/test/scenarios/models/models.cy.spec.js
@@ -384,7 +384,6 @@ describe("scenarios > models", () => {
 
       questionInfoButton().click();
 
-      cy.findByTestId("editable-text").click();
       cy.findByPlaceholderText("Add description").type("foo").blur();
       cy.wait("@updateCard");
 

--- a/frontend/src/metabase/collections/components/BaseTableItem.jsx
+++ b/frontend/src/metabase/collections/components/BaseTableItem.jsx
@@ -128,7 +128,11 @@ export function BaseTableItem({
               <DescriptionIcon
                 name="info"
                 size={16}
-                tooltip={<Markdown>{item.description}</Markdown>}
+                tooltip={
+                  <Markdown disallowHeading unstyleLinks>
+                    {item.description}
+                  </Markdown>
+                }
               />
             )}
           </ItemLink>

--- a/frontend/src/metabase/collections/components/CollectionHeader/CollectionCaption.tsx
+++ b/frontend/src/metabase/collections/components/CollectionHeader/CollectionCaption.tsx
@@ -66,6 +66,7 @@ const CollectionCaption = ({
           isDisabled={!isEditable}
           isOptional
           isMultiline
+          isMarkdown
           onChange={handleChangeDescription}
         />
       )}

--- a/frontend/src/metabase/collections/components/CollectionHeader/CollectionHeader.unit.spec.tsx
+++ b/frontend/src/metabase/collections/components/CollectionHeader/CollectionHeader.unit.spec.tsx
@@ -81,6 +81,10 @@ describe("CollectionHeader", () => {
 
       render(<CollectionHeader {...props} />);
 
+      // show input
+      const editableText = screen.getByText("Description");
+      userEvent.click(editableText);
+
       const input = screen.getByDisplayValue("Description");
       userEvent.clear(input);
       userEvent.type(input, "New description");

--- a/frontend/src/metabase/collections/components/CollectionHeader/CollectionHeader.unit.spec.tsx
+++ b/frontend/src/metabase/collections/components/CollectionHeader/CollectionHeader.unit.spec.tsx
@@ -138,6 +138,10 @@ describe("CollectionHeader", () => {
 
       render(<CollectionHeader {...props} />);
 
+      // show input
+      const editableText = screen.getByText("Description");
+      userEvent.click(editableText);
+
       const input = screen.getByDisplayValue("Description");
       expect(input).toBeInTheDocument();
       expect(input).toBeDisabled();

--- a/frontend/src/metabase/core/components/EditableText/EditableText.stories.tsx
+++ b/frontend/src/metabase/core/components/EditableText/EditableText.stories.tsx
@@ -30,3 +30,13 @@ WithMaxWidth.args = {
   placeholder: "Enter title",
   style: { maxWidth: 500 },
 };
+
+export const WithMarkdown = Template.bind({});
+WithMarkdown.args = {
+  initialValue: `**bold** text
+
+  *multiline*
+
+  and [link](https://metabase.com)`,
+  placeholder: "Enter description",
+};

--- a/frontend/src/metabase/core/components/EditableText/EditableText.stories.tsx
+++ b/frontend/src/metabase/core/components/EditableText/EditableText.stories.tsx
@@ -39,4 +39,6 @@ WithMarkdown.args = {
 
   and [link](https://metabase.com)`,
   placeholder: "Enter description",
+  isMultiline: true,
+  isMarkdown: true,
 };

--- a/frontend/src/metabase/core/components/EditableText/EditableText.styled.tsx
+++ b/frontend/src/metabase/core/components/EditableText/EditableText.styled.tsx
@@ -1,7 +1,7 @@
 import styled from "@emotion/styled";
 import { css } from "@emotion/react";
-
 import { color } from "metabase/lib/colors";
+import MarkdownBase from "../Markdown";
 
 export interface EditableTextRootProps {
   isEditing?: boolean;
@@ -57,4 +57,8 @@ export const EditableTextArea = styled.textarea`
   &:focus {
     cursor: text;
   }
+`;
+
+export const Markdown = styled(MarkdownBase)`
+  position: absolute;
 `;

--- a/frontend/src/metabase/core/components/EditableText/EditableText.tsx
+++ b/frontend/src/metabase/core/components/EditableText/EditableText.tsx
@@ -8,11 +8,16 @@ import React, {
   useEffect,
   useState,
   useRef,
+  MouseEvent,
 } from "react";
 
 import { usePrevious } from "react-use";
 
-import { EditableTextArea, EditableTextRoot } from "./EditableText.styled";
+import {
+  EditableTextArea,
+  EditableTextRoot,
+  Markdown,
+} from "./EditableText.styled";
 
 export type EditableTextAttributes = Omit<
   HTMLAttributes<HTMLDivElement>,
@@ -26,6 +31,7 @@ export interface EditableTextProps extends EditableTextAttributes {
   isOptional?: boolean;
   isMultiline?: boolean;
   isDisabled?: boolean;
+  isMarkdown?: boolean;
   onChange?: (value: string) => void;
   onFocus?: () => void;
   onBlur?: () => void;
@@ -40,6 +46,7 @@ const EditableText = forwardRef(function EditableText(
     isOptional = false,
     isMultiline = false,
     isDisabled = false,
+    isMarkdown = false,
     onChange,
     onFocus,
     onBlur,
@@ -50,8 +57,10 @@ const EditableText = forwardRef(function EditableText(
 ) {
   const [inputValue, setInputValue] = useState(initialValue ?? "");
   const [submitValue, setSubmitValue] = useState(initialValue ?? "");
+  const [isInFocus, setIsInFocus] = useState(isEditing);
   const displayValue = inputValue ? inputValue : placeholder;
   const submitOnBlur = useRef(true);
+  const input = useRef<HTMLTextAreaElement>(null);
   const previousInitialValue = usePrevious(initialValue);
 
   useEffect(() => {
@@ -60,17 +69,36 @@ const EditableText = forwardRef(function EditableText(
     }
   }, [initialValue, previousInitialValue]);
 
+  useEffect(() => {
+    if (isMarkdown && isInFocus) {
+      input.current?.focus();
+    }
+  }, [isInFocus, isMarkdown]);
+
   const handleBlur = useCallback(
     e => {
+      if (isMarkdown) {
+        setIsInFocus(false);
+      }
+
       if (!isOptional && !inputValue) {
         setInputValue(submitValue);
       } else if (inputValue !== submitValue && submitOnBlur.current) {
         setSubmitValue(inputValue);
         onChange?.(inputValue);
       }
+
       onBlur?.();
     },
-    [inputValue, submitValue, isOptional, onChange, onBlur],
+    [
+      inputValue,
+      submitValue,
+      isOptional,
+      isMarkdown,
+      onChange,
+      onBlur,
+      setIsInFocus,
+    ],
   );
 
   const handleChange = useCallback(
@@ -96,24 +124,36 @@ const EditableText = forwardRef(function EditableText(
     [submitValue, isMultiline],
   );
 
+  const handleRootElementClick = (event: MouseEvent) => {
+    if ((event.target as HTMLElement).tagName.toLowerCase() !== "a") {
+      setIsInFocus(true);
+    }
+  };
+
   return (
     <EditableTextRoot
+      onClick={isMarkdown ? handleRootElementClick : undefined}
       {...props}
       ref={ref}
       isEditing={isEditing}
       isDisabled={isDisabled}
       data-value={`${displayValue}\u00A0`}
     >
-      <EditableTextArea
-        value={inputValue}
-        placeholder={placeholder}
-        disabled={isDisabled}
-        data-testid={dataTestId}
-        onFocus={onFocus}
-        onBlur={handleBlur}
-        onChange={handleChange}
-        onKeyDown={handleKeyDown}
-      />
+      {isMarkdown && !isInFocus && <Markdown>{inputValue}</Markdown>}
+
+      {((isMarkdown && isInFocus) || !isMarkdown) && (
+        <EditableTextArea
+          ref={input}
+          value={inputValue}
+          placeholder={placeholder}
+          disabled={isDisabled}
+          data-testid={dataTestId}
+          onFocus={onFocus}
+          onBlur={handleBlur}
+          onChange={handleChange}
+          onKeyDown={handleKeyDown}
+        />
+      )}
     </EditableTextRoot>
   );
 });

--- a/frontend/src/metabase/core/components/EditableText/EditableText.tsx
+++ b/frontend/src/metabase/core/components/EditableText/EditableText.tsx
@@ -141,6 +141,7 @@ const EditableText = forwardRef(function EditableText(
       isEditing={isEditing}
       isDisabled={isDisabled}
       data-value={`${displayValue}\u00A0`}
+      data-testid="editable-text"
     >
       {shouldShowMarkdown && <Markdown>{inputValue}</Markdown>}
       {shouldShowInput && (

--- a/frontend/src/metabase/core/components/EditableText/EditableText.tsx
+++ b/frontend/src/metabase/core/components/EditableText/EditableText.tsx
@@ -130,6 +130,9 @@ const EditableText = forwardRef(function EditableText(
     }
   };
 
+  const shouldShowMarkdown = isMarkdown && !isInFocus && inputValue;
+  const shouldShowInput = !shouldShowMarkdown;
+
   return (
     <EditableTextRoot
       onClick={isMarkdown ? handleRootElementClick : undefined}
@@ -139,9 +142,8 @@ const EditableText = forwardRef(function EditableText(
       isDisabled={isDisabled}
       data-value={`${displayValue}\u00A0`}
     >
-      {isMarkdown && !isInFocus && <Markdown>{inputValue}</Markdown>}
-
-      {((isMarkdown && isInFocus) || !isMarkdown) && (
+      {shouldShowMarkdown && <Markdown>{inputValue}</Markdown>}
+      {shouldShowInput && (
         <EditableTextArea
           ref={input}
           value={inputValue}

--- a/frontend/src/metabase/core/components/EditableText/EditableText.tsx
+++ b/frontend/src/metabase/core/components/EditableText/EditableText.tsx
@@ -60,7 +60,7 @@ const EditableText = forwardRef(function EditableText(
   const [isInFocus, setIsInFocus] = useState(isEditing);
   const displayValue = inputValue ? inputValue : placeholder;
   const submitOnBlur = useRef(true);
-  const input = useRef<HTMLTextAreaElement>(null);
+  const inputRef = useRef<HTMLTextAreaElement>(null);
   const previousInitialValue = usePrevious(initialValue);
 
   useEffect(() => {
@@ -70,16 +70,18 @@ const EditableText = forwardRef(function EditableText(
   }, [initialValue, previousInitialValue]);
 
   useEffect(() => {
-    if (isMarkdown && isInFocus) {
-      input.current?.focus();
+    if (!isMarkdown) {
+      return;
+    }
+
+    if (isInFocus) {
+      inputRef.current?.focus();
     }
   }, [isInFocus, isMarkdown]);
 
   const handleBlur = useCallback(
     e => {
-      if (isMarkdown) {
-        setIsInFocus(false);
-      }
+      setIsInFocus(false);
 
       if (!isOptional && !inputValue) {
         setInputValue(submitValue);
@@ -90,15 +92,7 @@ const EditableText = forwardRef(function EditableText(
 
       onBlur?.();
     },
-    [
-      inputValue,
-      submitValue,
-      isOptional,
-      isMarkdown,
-      onChange,
-      onBlur,
-      setIsInFocus,
-    ],
+    [inputValue, submitValue, isOptional, onChange, onBlur, setIsInFocus],
   );
 
   const handleChange = useCallback(
@@ -125,13 +119,12 @@ const EditableText = forwardRef(function EditableText(
   );
 
   const handleRootElementClick = (event: MouseEvent) => {
-    if ((event.target as HTMLElement).tagName.toLowerCase() !== "a") {
+    if (!(event.target instanceof HTMLAnchorElement)) {
       setIsInFocus(true);
     }
   };
 
   const shouldShowMarkdown = isMarkdown && !isInFocus && inputValue;
-  const shouldShowInput = !shouldShowMarkdown;
 
   return (
     <EditableTextRoot
@@ -143,10 +136,11 @@ const EditableText = forwardRef(function EditableText(
       data-value={`${displayValue}\u00A0`}
       data-testid="editable-text"
     >
-      {shouldShowMarkdown && <Markdown>{inputValue}</Markdown>}
-      {shouldShowInput && (
+      {shouldShowMarkdown ? (
+        <Markdown>{inputValue}</Markdown>
+      ) : (
         <EditableTextArea
-          ref={input}
+          ref={inputRef}
           value={inputValue}
           placeholder={placeholder}
           disabled={isDisabled}

--- a/frontend/src/metabase/core/components/EditableText/EditableText.unit.spec.tsx
+++ b/frontend/src/metabase/core/components/EditableText/EditableText.unit.spec.tsx
@@ -1,7 +1,7 @@
 import React from "react";
-
 import userEvent from "@testing-library/user-event";
-import { fireEvent, screen, render, waitFor } from "__support__/ui";
+
+import { screen, render, waitFor } from "__support__/ui";
 import EditableText, { EditableTextProps } from "./EditableText";
 
 const setup = (props?: Partial<EditableTextProps>) => {
@@ -63,7 +63,7 @@ describe("EditableText", () => {
       expect(screen.getByRole("textbox")).toHaveFocus();
     });
 
-    fireEvent.blur(screen.getByRole("textbox"));
+    userEvent.tab();
 
     expect(screen.getByTestId("editable-text")).toHaveTextContent("bold link");
     expect(screen.queryByRole("textbox")).not.toBeInTheDocument();

--- a/frontend/src/metabase/core/components/EditableText/EditableText.unit.spec.tsx
+++ b/frontend/src/metabase/core/components/EditableText/EditableText.unit.spec.tsx
@@ -1,0 +1,83 @@
+import React from "react";
+
+import userEvent from "@testing-library/user-event";
+import { fireEvent, screen, render, waitFor } from "__support__/ui";
+import EditableText, { EditableTextProps } from "./EditableText";
+
+const setup = (props?: Partial<EditableTextProps>) => {
+  render(<EditableText {...props} />);
+};
+
+describe("EditableText", () => {
+  describe("when there is no initial value", () => {
+    it("should render input", () => {
+      setup();
+
+      expect(screen.getByRole("textbox")).toBeInTheDocument();
+    });
+  });
+
+  it("should render markdown, not input", () => {
+    setup({
+      initialValue: "Description",
+      isMarkdown: true,
+    });
+
+    expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+    expect(screen.getByText("Description")).toBeInTheDocument();
+  });
+
+  it("should render input after a click", () => {
+    setup({
+      initialValue: "Description",
+      isMarkdown: true,
+    });
+
+    userEvent.click(screen.getByText("Description"));
+
+    expect(screen.getByRole("textbox")).toBeInTheDocument();
+  });
+
+  it("should focus the input", async () => {
+    setup({
+      initialValue: "Description",
+      isMarkdown: true,
+    });
+
+    userEvent.click(screen.getByText("Description"));
+
+    await waitFor(() => {
+      expect(screen.getByRole("textbox")).toHaveFocus();
+    });
+  });
+
+  it("should render markdown on blur", async () => {
+    setup({
+      initialValue: "**bold** [link](https://metabase.com)",
+      isMarkdown: true,
+    });
+
+    userEvent.click(screen.getByTestId("editable-text"));
+
+    await waitFor(() => {
+      expect(screen.getByRole("textbox")).toHaveFocus();
+    });
+
+    fireEvent.blur(screen.getByRole("textbox"));
+
+    expect(screen.getByTestId("editable-text")).toHaveTextContent("bold link");
+    expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+  });
+
+  it("should not render input if click happened on the link", () => {
+    setup({
+      initialValue: "**bold** [link](https://metabase.com)",
+      isMarkdown: true,
+    });
+
+    userEvent.click(screen.getByRole("link"));
+
+    expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+    expect(screen.getByTestId("editable-text")).toHaveTextContent("bold link");
+  });
+});

--- a/frontend/src/metabase/core/components/Markdown/Markdown.styled.tsx
+++ b/frontend/src/metabase/core/components/Markdown/Markdown.styled.tsx
@@ -2,8 +2,9 @@ import { FC, ReactElement } from "react";
 import ReactMarkdown from "react-markdown";
 import styled from "@emotion/styled";
 import { color } from "metabase/lib/colors";
+import type { MarkdownProps } from "./Markdown";
 
-export const MarkdownRoot = styled(getComponent(ReactMarkdown))`
+export const MarkdownRoot = styled(getComponent(ReactMarkdown))<MarkdownProps>`
   p {
     margin: 0;
     line-height: 1.57em;
@@ -16,11 +17,11 @@ export const MarkdownRoot = styled(getComponent(ReactMarkdown))`
   a {
     cursor: pointer;
     text-decoration: none;
-    color: ${color("brand")};
+    color: ${props => (props.unstyleLinks ? color("white") : color("brand"))};
   }
 
   a:hover {
-    text-decoration: underline;
+    text-decoration: ${props => (props.unstyleLinks ? "none" : "underline")};
   }
 
   img {

--- a/frontend/src/metabase/core/components/Markdown/Markdown.tsx
+++ b/frontend/src/metabase/core/components/Markdown/Markdown.tsx
@@ -1,17 +1,39 @@
-import React from "react";
+import React, { ComponentPropsWithRef } from "react";
 import remarkGfm from "remark-gfm";
+import ReactMarkdown from "react-markdown";
 import { MarkdownRoot } from "./Markdown.styled";
 
 const REMARK_PLUGINS = [remarkGfm];
 
-export interface MarkdownProps {
+export interface MarkdownProps
+  extends ComponentPropsWithRef<typeof ReactMarkdown> {
   className?: string;
-  children?: string;
+  disallowHeading?: boolean;
+  unstyleLinks?: boolean;
+  children: string;
 }
 
-const Markdown = ({ className, children = "" }: MarkdownProps): JSX.Element => {
+const Markdown = ({
+  className,
+  children = "",
+  disallowHeading = false,
+  ...rest
+}: MarkdownProps): JSX.Element => {
+  const additionalOptions = {
+    ...(disallowHeading && {
+      disallowedElements: ["h1", "h2", "h3", "h4", "h5", "h6"],
+      unwrapDisallowed: true,
+    }),
+  };
+
   return (
-    <MarkdownRoot className={className} remarkPlugins={REMARK_PLUGINS}>
+    <MarkdownRoot
+      className={className}
+      remarkPlugins={REMARK_PLUGINS}
+      linkTarget={"_blank"}
+      {...additionalOptions}
+      {...rest}
+    >
       {children}
     </MarkdownRoot>
   );

--- a/frontend/src/metabase/core/components/Markdown/Markdown.tsx
+++ b/frontend/src/metabase/core/components/Markdown/Markdown.tsx
@@ -17,6 +17,7 @@ const Markdown = ({
   className,
   children = "",
   disallowHeading = false,
+  unstyleLinks = false,
   ...rest
 }: MarkdownProps): JSX.Element => {
   const additionalOptions = {
@@ -31,6 +32,7 @@ const Markdown = ({
       className={className}
       remarkPlugins={REMARK_PLUGINS}
       linkTarget={"_blank"}
+      unstyleLinks={unstyleLinks}
       {...additionalOptions}
       {...rest}
     >

--- a/frontend/src/metabase/dashboard/components/DashboardInfoSidebar.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardInfoSidebar.tsx
@@ -77,6 +77,7 @@ const DashboardInfoSidebar = ({
           isDisabled={!dashboard.can_write}
           onChange={handleDescriptionChange}
           isMultiline
+          isMarkdown
           placeholder={t`Add description`}
           key={`dashboard-description-${dashboard.description}`}
         />

--- a/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar.tsx
@@ -68,6 +68,7 @@ export const QuestionInfoSidebar = ({
           }
           isOptional
           isMultiline
+          isMarkdown
           isDisabled={!canWrite}
           onChange={handleSave}
         />

--- a/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar.unit.spec.js
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar.unit.spec.js
@@ -1,6 +1,7 @@
 import React from "react";
 import fetchMock from "fetch-mock";
 
+import userEvent from "@testing-library/user-event";
 import {
   renderWithProviders,
   screen,
@@ -187,6 +188,9 @@ describe("QuestionInfoSidebar", () => {
       await setup({
         question: getQuestion({ description: "Foo bar", can_write: false }),
       });
+      // show input
+      userEvent.click(screen.getByTestId("editable-text"));
+
       expect(screen.queryByPlaceholderText("Add description")).toHaveValue(
         "Foo bar",
       );

--- a/frontend/src/metabase/visualizations/components/ChartCaption.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/components/ChartCaption.unit.spec.tsx
@@ -60,13 +60,13 @@ describe("ChartCaption", () => {
   it("should render markdown in description", () => {
     setup({
       series: getSeries({ card: createMockCard({ name: "card name" }) }),
-      settings: { "card.description": "# header" },
+      settings: { "card.description": "[link](https://metabase.com)" },
     });
 
     userEvent.hover(getIcon("info"));
 
-    const tooltipContent = screen.getByRole("heading");
+    const tooltipContent = screen.getByRole("link");
     expect(tooltipContent).toBeInTheDocument();
-    expect(tooltipContent).toHaveTextContent("header");
+    expect(tooltipContent).toHaveTextContent("link");
   });
 });

--- a/frontend/src/metabase/visualizations/components/ScalarValue/ScalarValue.jsx
+++ b/frontend/src/metabase/visualizations/components/ScalarValue/ScalarValue.jsx
@@ -77,7 +77,14 @@ export const ScalarTitle = ({ title, description, onClick }) => (
     </ScalarTitleContent>
     {description && description.length > 0 && (
       <ScalarDescriptionContainer className="hover-child">
-        <Tooltip tooltip={<Markdown>{description}</Markdown>} maxWidth="22em">
+        <Tooltip
+          tooltip={
+            <Markdown disallowHeading unstyleLinks>
+              {description}
+            </Markdown>
+          }
+          maxWidth="22em"
+        >
           <Icon name="info_outline" />
         </Tooltip>
       </ScalarDescriptionContainer>

--- a/frontend/src/metabase/visualizations/components/legend/LegendCaption.jsx
+++ b/frontend/src/metabase/visualizations/components/legend/LegendCaption.jsx
@@ -41,7 +41,14 @@ const LegendCaption = ({
       </LegendLabel>
       <LegendRightContent>
         {description && (
-          <Tooltip tooltip={<Markdown>{description}</Markdown>} maxWidth="22em">
+          <Tooltip
+            tooltip={
+              <Markdown disallowHeading unstyleLinks>
+                {description}
+              </Markdown>
+            }
+            maxWidth="22em"
+          >
             <LegendDescriptionIcon className="hover-child hover-child--smooth" />
           </Tooltip>
         )}

--- a/frontend/src/metabase/visualizations/visualizations/Scalar.unit.spec.js
+++ b/frontend/src/metabase/visualizations/visualizations/Scalar.unit.spec.js
@@ -58,7 +58,7 @@ describe("MetricForm", () => {
   });
 
   it("should render markdown in description", () => {
-    const DESCRIPTION = "# header";
+    const DESCRIPTION = "[link](https://metabase.com)";
 
     render(
       <Scalar
@@ -72,8 +72,8 @@ describe("MetricForm", () => {
     userEvent.hover(getIcon("info_outline"));
 
     expect(
-      within(screen.getByRole("tooltip")).getByRole("heading"),
-    ).toHaveTextContent("header");
+      within(screen.getByRole("tooltip")).getByRole("link"),
+    ).toHaveTextContent("link");
   });
 
   it("should render compact if normal formatting is >6 characters", () => {


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/29882

### Description

- Add markdown support to editable text (Dashboard sidebar info, question sidebar info)
- disable heading tags in tooltips
- show links as a text in tooltips (white and no underline)
- open links in new tab from editable text

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Open existing dashboard, add to description 
```
`**bold** text

  *multiline*

  and [link](https://metabase.com)
```

make sure text is formatted as markdown when you leave input (on blur)

### Demo

check storybook -> [EditableText](https://61d4abcd959e8c003aa51d4c-mqkorqxzxr.chromatic.com/?path=/story/core-editabletext--with-markdown)

https://www.loom.com/share/e54d6e67dde3480f989fa568371b6c28

### Checklist

- [x] Tests have been added/updated to cover changes in this PR

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/29890)
<!-- Reviewable:end -->
