### PR TITLE
Add "basic" label to basic actions

### DIFF
--- a/frontend/src/metabase/models/components/ModelDetailPage/ModelActionDetails/ModelActionListItem.tsx
+++ b/frontend/src/metabase/models/components/ModelDetailPage/ModelActionDetails/ModelActionListItem.tsx
@@ -94,6 +94,9 @@ function ModelActionListItem({
         <div>
           <ActionTitle to={actionUrl}>{action.name}</ActionTitle>
           <ActionSubtitle>
+            {action.type === "implicit" && (
+              <ActionSubtitlePart>{t`Basic`}</ActionSubtitlePart>
+            )}
             {action.public_uuid && (
               <ActionSubtitlePart>{t`Public action form`}</ActionSubtitlePart>
             )}

--- a/frontend/src/metabase/models/components/ModelDetailPage/ModelActionDetails/ModelActionListItem.tsx
+++ b/frontend/src/metabase/models/components/ModelDetailPage/ModelActionDetails/ModelActionListItem.tsx
@@ -95,7 +95,7 @@ function ModelActionListItem({
           <ActionTitle to={actionUrl}>{action.name}</ActionTitle>
           <ActionSubtitle>
             {action.type === "implicit" && (
-              <ActionSubtitlePart>{t`Basic`}</ActionSubtitlePart>
+              <ActionSubtitlePart>{t`Basic action`}</ActionSubtitlePart>
             )}
             {action.public_uuid && (
               <ActionSubtitlePart>{t`Public action form`}</ActionSubtitlePart>

--- a/frontend/src/metabase/models/containers/ModelDetailPage/ModelDetailPage.unit.spec.tsx
+++ b/frontend/src/metabase/models/containers/ModelDetailPage/ModelDetailPage.unit.spec.tsx
@@ -534,7 +534,7 @@ describe("ModelDetailPage", () => {
           screen.getByText(`Created by ${action.creator.common_name}`),
         ).toBeInTheDocument();
         expect(await screen.findByLabelText("Run")).toBeInTheDocument();
-        expect(screen.queryByText("Basic")).not.toBeInTheDocument();
+        expect(screen.queryByText("Basic action")).not.toBeInTheDocument();
       });
 
       it("lists existing public query actions with public label", async () => {
@@ -564,7 +564,7 @@ describe("ModelDetailPage", () => {
         expect(screen.getByText("Update")).toBeInTheDocument();
         expect(screen.getByText("Delete")).toBeInTheDocument();
         expect(await screen.findAllByLabelText("Run")).toHaveLength(3);
-        expect(screen.getAllByText("Basic")).toHaveLength(3);
+        expect(screen.getAllByText("Basic action")).toHaveLength(3);
       });
 
       it("allows to create a new query action", async () => {

--- a/frontend/src/metabase/models/containers/ModelDetailPage/ModelDetailPage.unit.spec.tsx
+++ b/frontend/src/metabase/models/containers/ModelDetailPage/ModelDetailPage.unit.spec.tsx
@@ -534,6 +534,7 @@ describe("ModelDetailPage", () => {
           screen.getByText(`Created by ${action.creator.common_name}`),
         ).toBeInTheDocument();
         expect(await screen.findByLabelText("Run")).toBeInTheDocument();
+        expect(screen.queryByText("Basic")).not.toBeInTheDocument();
       });
 
       it("lists existing public query actions with public label", async () => {
@@ -563,6 +564,7 @@ describe("ModelDetailPage", () => {
         expect(screen.getByText("Update")).toBeInTheDocument();
         expect(screen.getByText("Delete")).toBeInTheDocument();
         expect(await screen.findAllByLabelText("Run")).toHaveLength(3);
+        expect(screen.getAllByText("Basic")).toHaveLength(3);
       });
 
       it("allows to create a new query action", async () => {

--- a/frontend/src/metabase/models/containers/ModelDetailPage/ModelDetailPage.unit.spec.tsx
+++ b/frontend/src/metabase/models/containers/ModelDetailPage/ModelDetailPage.unit.spec.tsx
@@ -271,523 +271,511 @@ function openActionMenu(action: WritebackAction) {
 }
 
 describe("ModelDetailPage", () => {
-  [
+  describe.each([
     { type: "structured", getModel: getStructuredModel },
     { type: "native", getModel: getNativeModel },
-  ].forEach(testCase => {
-    const { type, getModel } = testCase;
+  ])(`$type model`, ({ getModel }) => {
+    it("renders and shows general info", async () => {
+      await setup({
+        model: getModel({ name: "My Model", description: "Foo Bar" }),
+      });
 
-    describe(`${type} model`, () => {
-      it("renders and shows general info", async () => {
-        await setup({
-          model: getModel({ name: "My Model", description: "Foo Bar" }),
+      expect(screen.getByText("My Model")).toBeInTheDocument();
+      expect(screen.getByLabelText("Description")).toHaveTextContent("Foo Bar");
+    });
+
+    it("displays model contact", async () => {
+      const creator = createMockUser();
+      await setup({ model: getModel({ creator }) });
+
+      expect(screen.getByLabelText("Contact")).toHaveTextContent(
+        creator.common_name,
+      );
+    });
+
+    describe("management", () => {
+      it("allows to rename modal", async () => {
+        const model = getModel();
+        const { modelUpdateSpy } = await setup({ model });
+
+        const input = screen.getByDisplayValue(model.displayName() as string);
+        userEvent.clear(input);
+        userEvent.type(input, "New model name");
+        fireEvent.blur(input);
+
+        await waitFor(() => {
+          expect(modelUpdateSpy).toHaveBeenCalledWith({
+            ...model.card(),
+            name: "New model name",
+          });
         });
+      });
 
-        expect(screen.getByText("My Model")).toBeInTheDocument();
+      it("allows to change description", async () => {
+        const model = getModel();
+        const { modelUpdateSpy } = await setup({ model });
+
+        const input = screen.getByPlaceholderText("Add description");
+        userEvent.type(input, "Foo bar");
+        fireEvent.blur(input);
+
+        await waitFor(() => {
+          expect(modelUpdateSpy).toHaveBeenCalledWith({
+            ...model.card(),
+            description: "Foo bar",
+          });
+        });
         expect(screen.getByLabelText("Description")).toHaveTextContent(
-          "Foo Bar",
+          "Foo bar",
         );
       });
 
-      it("displays model contact", async () => {
-        const creator = createMockUser();
-        await setup({ model: getModel({ creator }) });
+      it("can be archived", async () => {
+        const model = getModel();
+        const { modelUpdateSpy } = await setup({ model });
 
-        expect(screen.getByLabelText("Contact")).toHaveTextContent(
-          creator.common_name,
+        userEvent.click(getIcon("ellipsis"));
+        userEvent.click(screen.getByText("Archive"));
+
+        expect(screen.getByRole("dialog")).toBeInTheDocument();
+        userEvent.click(screen.getByRole("button", { name: "Archive" }));
+
+        await waitFor(() => {
+          expect(modelUpdateSpy).toHaveBeenCalledWith(
+            { id: model.id() },
+            { archived: true },
+            expect.anything(),
+          );
+        });
+      });
+
+      it("can be moved to another collection", async () => {
+        const model = getModel({ collection_id: 1 });
+        const { modelUpdateSpy } = await setup({
+          model,
+          collections: [COLLECTION_1, COLLECTION_2],
+        });
+
+        userEvent.click(getIcon("ellipsis"));
+        userEvent.click(screen.getByText("Move"));
+
+        expect(screen.getByRole("dialog")).toBeInTheDocument();
+        userEvent.click(await screen.findByText(COLLECTION_2.name));
+        userEvent.click(screen.getByRole("button", { name: "Move" }));
+
+        expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+
+        await waitFor(() => {
+          expect(modelUpdateSpy).toHaveBeenCalledWith(
+            { id: model.id() },
+            { collection_id: COLLECTION_2.id },
+            expect.anything(),
+          );
+        });
+      });
+    });
+
+    describe("used by section", () => {
+      it("has an empty state", async () => {
+        const model = getModel();
+        await setup({ model });
+
+        expect(
+          screen.getByRole("link", { name: /Create a new question/i }),
+        ).toHaveAttribute("href", model.getUrl());
+        expect(
+          screen.getByText(/This model is not used by any questions yet/i),
+        ).toBeInTheDocument();
+      });
+
+      it("lists questions based on the model", async () => {
+        const q1 = getSavedStructuredQuestion({ id: 5, name: "Q1" });
+        const q2 = getSavedNativeQuestion({ id: 6, name: "Q2" });
+
+        await setup({
+          model: getModel({ name: "My Model" }),
+          usedBy: [q1, q2],
+        });
+
+        expect(screen.getByRole("link", { name: "Q1" })).toHaveAttribute(
+          "href",
+          q1.getUrl(),
+        );
+        expect(screen.getByRole("link", { name: "Q2" })).toHaveAttribute(
+          "href",
+          q2.getUrl(),
+        );
+
+        expect(
+          screen.queryByText(/Create a new question/i),
+        ).not.toBeInTheDocument();
+        expect(
+          screen.queryByText(/This model is not used by any questions yet/i),
+        ).not.toBeInTheDocument();
+      });
+    });
+
+    describe("schema section", () => {
+      it("displays model schema", async () => {
+        const model = getModel();
+        const fields = model.getResultMetadata();
+        await setup({ model, tab: "schema" });
+
+        userEvent.click(screen.getByText("Schema"));
+
+        expect(fields.length).toBeGreaterThan(0);
+        expect(screen.getByText(`${fields.length} fields`)).toBeInTheDocument();
+
+        fields.forEach((field: Field) => {
+          expect(screen.getByText(field.display_name)).toBeInTheDocument();
+        });
+      });
+    });
+
+    describe("actions section", () => {
+      it("is shown if actions are enabled for model's database", async () => {
+        await setup({
+          model: getModel(),
+          databases: [TEST_DATABASE_WITH_ACTIONS],
+        });
+        expect(screen.getByText("Actions")).toBeInTheDocument();
+      });
+
+      it("isn't shown if actions are disabled for model's database", async () => {
+        await setup({ model: getModel() });
+        expect(screen.queryByText("Actions")).not.toBeInTheDocument();
+      });
+
+      it("is shown if actions are disabled for the model's database but there are existing actions", async () => {
+        const model = getModel();
+        const action = createMockQueryAction({ model_id: model.id() });
+
+        await setup({
+          model: model,
+          actions: [action],
+        });
+
+        expect(screen.getByText("Actions")).toBeInTheDocument();
+      });
+
+      it("redirects to 'Used by' when trying to access actions tab without them enabled", async () => {
+        const { baseUrl, history } = await setup({
+          model: getModel(),
+          tab: "actions",
+        });
+
+        expect(history?.getCurrentLocation().pathname).toBe(`${baseUrl}/usage`);
+        expect(screen.getByRole("tab", { name: "Used by" })).toHaveAttribute(
+          "aria-selected",
+          "true",
         );
       });
 
-      describe("management", () => {
-        it("allows to rename modal", async () => {
-          const model = getModel();
-          const { modelUpdateSpy } = await setup({ model });
+      it("does not redirect to another tab if actions are disabled for the model's database but there are existing actions", async () => {
+        const model = getModel();
+        const action = createMockQueryAction({ model_id: model.id() });
 
-          const input = screen.getByDisplayValue(model.displayName() as string);
-          userEvent.clear(input);
-          userEvent.type(input, "New model name");
-          fireEvent.blur(input);
-
-          await waitFor(() => {
-            expect(modelUpdateSpy).toHaveBeenCalledWith({
-              ...model.card(),
-              name: "New model name",
-            });
-          });
+        await setup({
+          model,
+          actions: [action],
+          tab: "actions",
         });
 
-        it("allows to change description", async () => {
-          const model = getModel();
-          const { modelUpdateSpy } = await setup({ model });
+        expect(screen.getByRole("tab", { name: "Actions" })).toHaveAttribute(
+          "aria-selected",
+          "true",
+        );
+      });
 
-          const input = screen.getByPlaceholderText("Add description");
-          userEvent.type(input, "Foo bar");
-          fireEvent.blur(input);
+      it("shows empty state if there are no actions", async () => {
+        await setupActions({ model: getModel(), actions: [] });
+        expect(
+          screen.queryByRole("list", { name: /Action list/i }),
+        ).not.toBeInTheDocument();
+        expect(
+          screen.getByText(/No actions have been created yet/i),
+        ).toBeInTheDocument();
+      });
 
-          await waitFor(() => {
-            expect(modelUpdateSpy).toHaveBeenCalledWith({
-              ...model.card(),
-              description: "Foo bar",
-            });
-          });
-          expect(screen.getByLabelText("Description")).toHaveTextContent(
-            "Foo bar",
-          );
+      it("shows alert if actions are disabled for the model's database but there are existing actions", async () => {
+        const model = getModel();
+        const action = createMockQueryAction({ model_id: model.id() });
+
+        await setup({
+          model,
+          actions: [action],
+          tab: "actions",
         });
 
-        it("can be archived", async () => {
-          const model = getModel();
-          const { modelUpdateSpy } = await setup({ model });
+        expect(
+          screen.getByRole("list", { name: /Action list/i }),
+        ).toBeInTheDocument();
+        expect(
+          screen.getByText(
+            `Running Actions is not enabled for database ${TEST_DATABASE.name}`,
+          ),
+        ).toBeInTheDocument();
+      });
 
-          userEvent.click(getIcon("ellipsis"));
-          userEvent.click(screen.getByText("Archive"));
+      it("allows to create a new query action from the empty state", async () => {
+        await setupActions({ model: getModel(), actions: [] });
+        userEvent.click(screen.getByRole("link", { name: "New action" }));
+        expect(await screen.findByTestId("mock-action-editor")).toBeVisible();
+      });
 
-          expect(screen.getByRole("dialog")).toBeInTheDocument();
-          userEvent.click(screen.getByRole("button", { name: "Archive" }));
+      it("lists existing query actions", async () => {
+        const model = getModel();
+        const action = createMockQueryAction({ model_id: model.id() });
+        await setupActions({ model, actions: [action] });
 
-          await waitFor(() => {
-            expect(modelUpdateSpy).toHaveBeenCalledWith(
-              { id: model.id() },
-              { archived: true },
-              expect.anything(),
-            );
-          });
+        expect(screen.getByText(action.name)).toBeInTheDocument();
+        expect(screen.getByText(TEST_QUERY)).toBeInTheDocument();
+        expect(
+          screen.getByText(`Created by ${action.creator.common_name}`),
+        ).toBeInTheDocument();
+        expect(await screen.findByLabelText("Run")).toBeInTheDocument();
+      });
+
+      it("lists existing public query actions with public label", async () => {
+        const model = getModel();
+        const action = createMockQueryAction({
+          model_id: model.id(),
+          public_uuid: "mock-uuid",
+        });
+        await setupActions({ model, actions: [action] });
+
+        expect(screen.getByText(action.name)).toBeInTheDocument();
+        expect(screen.getByText(TEST_QUERY)).toBeInTheDocument();
+        expect(screen.getByText("Public action form")).toBeInTheDocument();
+        expect(
+          screen.getByText(`Created by ${action.creator.common_name}`),
+        ).toBeInTheDocument();
+      });
+
+      it("lists existing implicit actions", async () => {
+        const model = getModel();
+        await setupActions({
+          model,
+          actions: createMockImplicitCUDActions(model.id()),
         });
 
-        it("can be moved to another collection", async () => {
-          const model = getModel({ collection_id: 1 });
-          const { modelUpdateSpy } = await setup({
-            model,
-            collections: [COLLECTION_1, COLLECTION_2],
-          });
+        expect(screen.getByText("Create")).toBeInTheDocument();
+        expect(screen.getByText("Update")).toBeInTheDocument();
+        expect(screen.getByText("Delete")).toBeInTheDocument();
+        expect(await screen.findAllByLabelText("Run")).toHaveLength(3);
+      });
 
-          userEvent.click(getIcon("ellipsis"));
-          userEvent.click(screen.getByText("Move"));
+      it("allows to create a new query action", async () => {
+        const model = getModel();
+        await setupActions({
+          model,
+          actions: [createMockQueryAction({ model_id: model.id() })],
+        });
 
-          expect(screen.getByRole("dialog")).toBeInTheDocument();
-          userEvent.click(await screen.findByText(COLLECTION_2.name));
-          userEvent.click(screen.getByRole("button", { name: "Move" }));
+        userEvent.click(screen.getByRole("link", { name: "New action" }));
 
-          expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+        expect(await screen.findByTestId("mock-action-editor")).toBeVisible();
+      });
 
-          await waitFor(() => {
-            expect(modelUpdateSpy).toHaveBeenCalledWith(
-              { id: model.id() },
-              { collection_id: COLLECTION_2.id },
-              expect.anything(),
-            );
-          });
+      it("allows to edit a query action via link", async () => {
+        const model = getModel();
+        const action = createMockQueryAction({ model_id: model.id() });
+        await setupActions({ model, actions: [action] });
+
+        userEvent.click(screen.getByRole("link", { name: action.name }));
+
+        expect(await screen.findByTestId("mock-action-editor")).toBeVisible();
+      });
+
+      it("allows to edit a query action via menu", async () => {
+        const model = getModel();
+        const action = createMockQueryAction({ model_id: model.id() });
+        await setupActions({ model, actions: [action] });
+
+        openActionMenu(action);
+        userEvent.click(screen.getByText("Edit"));
+
+        expect(await screen.findByTestId("mock-action-editor")).toBeVisible();
+      });
+
+      it("allows to archive a query action", async () => {
+        const updateActionSpy = jest.spyOn(ActionsApi, "update");
+        const model = getModel();
+        const action = createMockQueryAction({ model_id: model.id() });
+        await setupActions({ model, actions: [action] });
+
+        const listItem = screen.getByRole("listitem", { name: action.name });
+        userEvent.click(within(listItem).getByLabelText("ellipsis icon"));
+        userEvent.click(screen.getByText("Archive"));
+
+        const modal = screen.getByRole("dialog");
+        userEvent.click(within(modal).getByRole("button", { name: "Archive" }));
+
+        expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+        expect(updateActionSpy).toHaveBeenCalledWith({
+          id: action.id,
+          archived: true,
         });
       });
 
-      describe("used by section", () => {
-        it("has an empty state", async () => {
-          const model = getModel();
-          await setup({ model });
-
-          expect(
-            screen.getByRole("link", { name: /Create a new question/i }),
-          ).toHaveAttribute("href", model.getUrl());
-          expect(
-            screen.getByText(/This model is not used by any questions yet/i),
-          ).toBeInTheDocument();
+      it("doesn't allow to archive an implicit action", async () => {
+        const model = getModel();
+        const action = createMockImplicitQueryAction({
+          model_id: model.id(),
         });
+        await setupActions({ model, actions: [action] });
 
-        it("lists questions based on the model", async () => {
-          const q1 = getSavedStructuredQuestion({ id: 5, name: "Q1" });
-          const q2 = getSavedNativeQuestion({ id: 6, name: "Q2" });
+        openActionMenu(action);
 
-          await setup({
-            model: getModel({ name: "My Model" }),
-            usedBy: [q1, q2],
-          });
-
-          expect(screen.getByRole("link", { name: "Q1" })).toHaveAttribute(
-            "href",
-            q1.getUrl(),
-          );
-          expect(screen.getByRole("link", { name: "Q2" })).toHaveAttribute(
-            "href",
-            q2.getUrl(),
-          );
-
-          expect(
-            screen.queryByText(/Create a new question/i),
-          ).not.toBeInTheDocument();
-          expect(
-            screen.queryByText(/This model is not used by any questions yet/i),
-          ).not.toBeInTheDocument();
-        });
+        expect(screen.queryByText("Archive")).not.toBeInTheDocument();
       });
 
-      describe("schema section", () => {
-        it("displays model schema", async () => {
-          const model = getModel();
-          const fields = model.getResultMetadata();
-          await setup({ model, tab: "schema" });
+      it("allows to disable implicit actions", async () => {
+        const deleteActionSpy = jest.spyOn(Actions.actions, "delete");
+        const model = getModel();
+        const actions = createMockImplicitCUDActions(model.id());
+        await setupActions({ model, actions });
 
-          userEvent.click(screen.getByText("Schema"));
+        userEvent.click(screen.getByLabelText("Actions menu"));
+        userEvent.click(screen.getByText("Disable basic actions"));
+        userEvent.click(screen.getByRole("button", { name: "Disable" }));
 
-          expect(fields.length).toBeGreaterThan(0);
-          expect(
-            screen.getByText(`${fields.length} fields`),
-          ).toBeInTheDocument();
-
-          fields.forEach((field: Field) => {
-            expect(screen.getByText(field.display_name)).toBeInTheDocument();
-          });
+        actions.forEach(action => {
+          expect(deleteActionSpy).toHaveBeenCalledWith({ id: action.id });
         });
       });
+    });
 
-      describe("actions section", () => {
-        it("is shown if actions are enabled for model's database", async () => {
-          await setup({
-            model: getModel(),
-            databases: [TEST_DATABASE_WITH_ACTIONS],
-          });
-          expect(screen.getByText("Actions")).toBeInTheDocument();
-        });
+    describe("read-only permissions", () => {
+      const model = getModel({ can_write: false });
 
-        it("isn't shown if actions are disabled for model's database", async () => {
-          await setup({ model: getModel() });
-          expect(screen.queryByText("Actions")).not.toBeInTheDocument();
-        });
-
-        it("is shown if actions are disabled for the model's database but there are existing actions", async () => {
-          const model = getModel();
-          const action = createMockQueryAction({ model_id: model.id() });
-
-          await setup({
-            model: model,
-            actions: [action],
-          });
-
-          expect(screen.getByText("Actions")).toBeInTheDocument();
-        });
-
-        it("redirects to 'Used by' when trying to access actions tab without them enabled", async () => {
-          const { baseUrl, history } = await setup({
-            model: getModel(),
-            tab: "actions",
-          });
-
-          expect(history?.getCurrentLocation().pathname).toBe(
-            `${baseUrl}/usage`,
-          );
-          expect(screen.getByRole("tab", { name: "Used by" })).toHaveAttribute(
-            "aria-selected",
-            "true",
-          );
-        });
-
-        it("does not redirect to another tab if actions are disabled for the model's database but there are existing actions", async () => {
-          const model = getModel();
-          const action = createMockQueryAction({ model_id: model.id() });
-
-          await setup({
-            model,
-            actions: [action],
-            tab: "actions",
-          });
-
-          expect(screen.getByRole("tab", { name: "Actions" })).toHaveAttribute(
-            "aria-selected",
-            "true",
-          );
-        });
-
-        it("shows empty state if there are no actions", async () => {
-          await setupActions({ model: getModel(), actions: [] });
-          expect(
-            screen.queryByRole("list", { name: /Action list/i }),
-          ).not.toBeInTheDocument();
-          expect(
-            screen.getByText(/No actions have been created yet/i),
-          ).toBeInTheDocument();
-        });
-
-        it("shows alert if actions are disabled for the model's database but there are existing actions", async () => {
-          const model = getModel();
-          const action = createMockQueryAction({ model_id: model.id() });
-
-          await setup({
-            model,
-            actions: [action],
-            tab: "actions",
-          });
-
-          expect(
-            screen.getByRole("list", { name: /Action list/i }),
-          ).toBeInTheDocument();
-          expect(
-            screen.getByText(
-              `Running Actions is not enabled for database ${TEST_DATABASE.name}`,
-            ),
-          ).toBeInTheDocument();
-        });
-
-        it("allows to create a new query action from the empty state", async () => {
-          await setupActions({ model: getModel(), actions: [] });
-          userEvent.click(screen.getByRole("link", { name: "New action" }));
-          expect(await screen.findByTestId("mock-action-editor")).toBeVisible();
-        });
-
-        it("lists existing query actions", async () => {
-          const model = getModel();
-          const action = createMockQueryAction({ model_id: model.id() });
-          await setupActions({ model, actions: [action] });
-
-          expect(screen.getByText(action.name)).toBeInTheDocument();
-          expect(screen.getByText(TEST_QUERY)).toBeInTheDocument();
-          expect(
-            screen.getByText(`Created by ${action.creator.common_name}`),
-          ).toBeInTheDocument();
-          expect(await screen.findByLabelText("Run")).toBeInTheDocument();
-        });
-
-        it("lists existing public query actions with public label", async () => {
-          const model = getModel();
-          const action = createMockQueryAction({
-            model_id: model.id(),
-            public_uuid: "mock-uuid",
-          });
-          await setupActions({ model, actions: [action] });
-
-          expect(screen.getByText(action.name)).toBeInTheDocument();
-          expect(screen.getByText(TEST_QUERY)).toBeInTheDocument();
-          expect(screen.getByText("Public action form")).toBeInTheDocument();
-          expect(
-            screen.getByText(`Created by ${action.creator.common_name}`),
-          ).toBeInTheDocument();
-        });
-
-        it("lists existing implicit actions", async () => {
-          const model = getModel();
-          await setupActions({
-            model,
-            actions: createMockImplicitCUDActions(model.id()),
-          });
-
-          expect(screen.getByText("Create")).toBeInTheDocument();
-          expect(screen.getByText("Update")).toBeInTheDocument();
-          expect(screen.getByText("Delete")).toBeInTheDocument();
-          expect(await screen.findAllByLabelText("Run")).toHaveLength(3);
-        });
-
-        it("allows to create a new query action", async () => {
-          const model = getModel();
-          await setupActions({
-            model,
-            actions: [createMockQueryAction({ model_id: model.id() })],
-          });
-
-          userEvent.click(screen.getByRole("link", { name: "New action" }));
-
-          expect(await screen.findByTestId("mock-action-editor")).toBeVisible();
-        });
-
-        it("allows to edit a query action via link", async () => {
-          const model = getModel();
-          const action = createMockQueryAction({ model_id: model.id() });
-          await setupActions({ model, actions: [action] });
-
-          userEvent.click(screen.getByRole("link", { name: action.name }));
-
-          expect(await screen.findByTestId("mock-action-editor")).toBeVisible();
-        });
-
-        it("allows to edit a query action via menu", async () => {
-          const model = getModel();
-          const action = createMockQueryAction({ model_id: model.id() });
-          await setupActions({ model, actions: [action] });
-
-          openActionMenu(action);
-          userEvent.click(screen.getByText("Edit"));
-
-          expect(await screen.findByTestId("mock-action-editor")).toBeVisible();
-        });
-
-        it("allows to archive a query action", async () => {
-          const updateActionSpy = jest.spyOn(ActionsApi, "update");
-          const model = getModel();
-          const action = createMockQueryAction({ model_id: model.id() });
-          await setupActions({ model, actions: [action] });
-
-          const listItem = screen.getByRole("listitem", { name: action.name });
-          userEvent.click(within(listItem).getByLabelText("ellipsis icon"));
-          userEvent.click(screen.getByText("Archive"));
-
-          const modal = screen.getByRole("dialog");
-          userEvent.click(
-            within(modal).getByRole("button", { name: "Archive" }),
-          );
-
-          expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
-          expect(updateActionSpy).toHaveBeenCalledWith({
-            id: action.id,
-            archived: true,
-          });
-        });
-
-        it("doesn't allow to archive an implicit action", async () => {
-          const model = getModel();
-          const action = createMockImplicitQueryAction({
-            model_id: model.id(),
-          });
-          await setupActions({ model, actions: [action] });
-
-          openActionMenu(action);
-
-          expect(screen.queryByText("Archive")).not.toBeInTheDocument();
-        });
-
-        it("allows to disable implicit actions", async () => {
-          const deleteActionSpy = jest.spyOn(Actions.actions, "delete");
-          const model = getModel();
-          const actions = createMockImplicitCUDActions(model.id());
-          await setupActions({ model, actions });
-
-          userEvent.click(screen.getByLabelText("Actions menu"));
-          userEvent.click(screen.getByText("Disable basic actions"));
-          userEvent.click(screen.getByRole("button", { name: "Disable" }));
-
-          actions.forEach(action => {
-            expect(deleteActionSpy).toHaveBeenCalledWith({ id: action.id });
-          });
-        });
+      it("doesn't allow to rename a model", async () => {
+        await setup({ model });
+        expect(
+          screen.getByDisplayValue(model.displayName() as string),
+        ).toBeDisabled();
       });
 
-      describe("read-only permissions", () => {
-        const model = getModel({ can_write: false });
-
-        it("doesn't allow to rename a model", async () => {
-          await setup({ model });
-          expect(
-            screen.getByDisplayValue(model.displayName() as string),
-          ).toBeDisabled();
-        });
-
-        it("doesn't allow to change description", async () => {
-          await setup({ model });
-          expect(screen.getByPlaceholderText("No description")).toBeDisabled();
-        });
-
-        it("doesn't show model management actions", async () => {
-          await setup({ model });
-          expect(queryIcon("ellipsis")).not.toBeInTheDocument();
-          expect(screen.queryByText("Archive")).not.toBeInTheDocument();
-          expect(screen.queryByText("Move")).not.toBeInTheDocument();
-        });
-
-        it("doesn't show a link to the query editor", async () => {
-          await setup({ model });
-          expect(screen.queryByText("Edit definition")).not.toBeInTheDocument();
-        });
-
-        it("doesn't show a link to the metadata editor", async () => {
-          await setup({ model });
-          userEvent.click(screen.getByText("Schema"));
-          expect(screen.queryByText("Edit metadata")).not.toBeInTheDocument();
-        });
-
-        it("doesn't allow to create actions", async () => {
-          await setupActions({ model, actions: [] });
-          expect(screen.queryByText("New action")).not.toBeInTheDocument();
-          expect(
-            screen.queryByText("Create basic actions"),
-          ).not.toBeInTheDocument();
-          expect(screen.queryByTestId("actions-menu")).not.toBeInTheDocument();
-        });
-
-        it("doesn't allow to edit actions", async () => {
-          const action = createMockQueryAction({ model_id: model.id() });
-          await setupActions({ model, actions: [action] });
-
-          openActionMenu(action);
-
-          expect(screen.getByText("View")).toBeInTheDocument();
-        });
-
-        it("doesn't allow to archive actions", async () => {
-          const action = createMockQueryAction({ model_id: model.id() });
-          await setupActions({ model, actions: [action] });
-
-          openActionMenu(action);
-
-          expect(screen.queryByText("Archive")).not.toBeInTheDocument();
-        });
+      it("doesn't allow to change description", async () => {
+        await setup({ model });
+        expect(screen.getByPlaceholderText("No description")).toBeDisabled();
       });
 
-      describe("no data permissions", () => {
-        it("doesn't show model editor links", async () => {
-          await setup({
-            model: getModel(),
-            databases: [],
-            tab: "schema",
-          });
-          expect(screen.queryByText("Edit definition")).not.toBeInTheDocument();
-          expect(screen.queryByText("Edit metadata")).not.toBeInTheDocument();
+      it("doesn't show model management actions", async () => {
+        await setup({ model });
+        expect(queryIcon("ellipsis")).not.toBeInTheDocument();
+        expect(screen.queryByText("Archive")).not.toBeInTheDocument();
+        expect(screen.queryByText("Move")).not.toBeInTheDocument();
+      });
+
+      it("doesn't show a link to the query editor", async () => {
+        await setup({ model });
+        expect(screen.queryByText("Edit definition")).not.toBeInTheDocument();
+      });
+
+      it("doesn't show a link to the metadata editor", async () => {
+        await setup({ model });
+        userEvent.click(screen.getByText("Schema"));
+        expect(screen.queryByText("Edit metadata")).not.toBeInTheDocument();
+      });
+
+      it("doesn't allow to create actions", async () => {
+        await setupActions({ model, actions: [] });
+        expect(screen.queryByText("New action")).not.toBeInTheDocument();
+        expect(
+          screen.queryByText("Create basic actions"),
+        ).not.toBeInTheDocument();
+        expect(screen.queryByTestId("actions-menu")).not.toBeInTheDocument();
+      });
+
+      it("doesn't allow to edit actions", async () => {
+        const action = createMockQueryAction({ model_id: model.id() });
+        await setupActions({ model, actions: [action] });
+
+        openActionMenu(action);
+
+        expect(screen.getByText("View")).toBeInTheDocument();
+      });
+
+      it("doesn't allow to archive actions", async () => {
+        const action = createMockQueryAction({ model_id: model.id() });
+        await setupActions({ model, actions: [action] });
+
+        openActionMenu(action);
+
+        expect(screen.queryByText("Archive")).not.toBeInTheDocument();
+      });
+    });
+
+    describe("no data permissions", () => {
+      it("doesn't show model editor links", async () => {
+        await setup({
+          model: getModel(),
+          databases: [],
+          tab: "schema",
+        });
+        expect(screen.queryByText("Edit definition")).not.toBeInTheDocument();
+        expect(screen.queryByText("Edit metadata")).not.toBeInTheDocument();
+      });
+
+      it("doesn't show a new question link", async () => {
+        await setup({ model: getModel(), databases: [], tab: "usage" });
+        expect(
+          screen.queryByText(/Create a new question/i),
+        ).not.toBeInTheDocument();
+      });
+
+      it("doesn't allow running actions", async () => {
+        const model = getModel();
+        const actions = [
+          ...createMockImplicitCUDActions(model.id()),
+          createMockQueryAction({ id: 4, model_id: model.id() }),
+        ];
+        await setupActions({ model, actions, databases: [] });
+
+        expect(screen.queryByLabelText("Run")).not.toBeInTheDocument();
+      });
+
+      it("doesn't allow to run an action if its database has actions disabled", async () => {
+        const action = createMockQueryAction({
+          database_id: TEST_DATABASE.id,
         });
 
-        it("doesn't show a new question link", async () => {
-          await setup({ model: getModel(), databases: [], tab: "usage" });
-          expect(
-            screen.queryByText(/Create a new question/i),
-          ).not.toBeInTheDocument();
+        await setupActions({
+          model: getModel(),
+          databases: [TEST_DATABASE],
+          actions: [action],
         });
 
-        it("doesn't allow running actions", async () => {
-          const model = getModel();
-          const actions = [
-            ...createMockImplicitCUDActions(model.id()),
-            createMockQueryAction({ id: 4, model_id: model.id() }),
-          ];
-          await setupActions({ model, actions, databases: [] });
+        expect(screen.queryByLabelText("Run")).not.toBeInTheDocument();
+      });
 
-          expect(screen.queryByLabelText("Run")).not.toBeInTheDocument();
+      it("allows to run an action if its database has actions enabled", async () => {
+        const action = createMockQueryAction({
+          database_id: TEST_DATABASE_WITH_ACTIONS.id,
         });
 
-        it("doesn't allow to run an action if its database has actions disabled", async () => {
-          const action = createMockQueryAction({
-            database_id: TEST_DATABASE.id,
-          });
-
-          await setupActions({
-            model: getModel(),
-            databases: [TEST_DATABASE],
-            actions: [action],
-          });
-
-          expect(screen.queryByLabelText("Run")).not.toBeInTheDocument();
+        await setupActions({
+          model: getModel(),
+          databases: [TEST_DATABASE_WITH_ACTIONS],
+          actions: [action],
         });
 
-        it("allows to run an action if its database has actions enabled", async () => {
-          const action = createMockQueryAction({
-            database_id: TEST_DATABASE_WITH_ACTIONS.id,
-          });
+        expect(screen.getByLabelText("Run")).toBeInTheDocument();
+      });
 
-          await setupActions({
-            model: getModel(),
-            databases: [TEST_DATABASE_WITH_ACTIONS],
-            actions: [action],
-          });
-
-          expect(screen.getByLabelText("Run")).toBeInTheDocument();
+      it("allows to run an action without native query access", async () => {
+        const action = createMockQueryAction({
+          database_id: TEST_DATABASE_WITH_ACTIONS_READONLY.id,
         });
 
-        it("allows to run an action without native query access", async () => {
-          const action = createMockQueryAction({
-            database_id: TEST_DATABASE_WITH_ACTIONS_READONLY.id,
-          });
-
-          await setupActions({
-            model: getModel(),
-            databases: [TEST_DATABASE_WITH_ACTIONS_READONLY],
-            actions: [action],
-          });
-
-          expect(screen.getByLabelText("Run")).toBeInTheDocument();
+        await setupActions({
+          model: getModel(),
+          databases: [TEST_DATABASE_WITH_ACTIONS_READONLY],
+          actions: [action],
         });
+
+        expect(screen.getByLabelText("Run")).toBeInTheDocument();
       });
     });
   });


### PR DESCRIPTION
Epic https://github.com/metabase/metabase/issues/28534

Please review this PR by each commit:
1. Add `describe.each` to allow running tests from IDE. No test changes
2. Add basic label + tests.

How to verify:
- Enable actions for you database in Admin -> Database -> Select DB -> Enable model actions
- Go to any model -> Info sidebar -> Model details -> Actions
- Create basic actions if you don't have them already
- Make sure they have "Basic" label in the subtitle

<img width="1043" alt="Screenshot 2023-04-07 at 18 37 07" src="https://user-images.githubusercontent.com/8542534/230636513-a57e9e2e-91d9-44cb-ab49-9a2a2e235931.png">

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/29892)
<!-- Reviewable:end -->
