### PR TITLE
Fixes convert-timezone tests for redshift

### DIFF
--- a/.github/actions/test-driver/action.yml
+++ b/.github/actions/test-driver/action.yml
@@ -18,8 +18,6 @@ runs:
     - name: Build static viz frontend
       run: yarn build-static-viz
       shell: bash
-    - name: setup tmate
-      uses: lhotari/action-upterm@v1
     - name: Test database driver
       run: clojure -X:dev:ci:ee:ee-dev:drivers:drivers-dev:test ${{ inputs.test-args }}
       shell: bash

--- a/.github/actions/test-driver/action.yml
+++ b/.github/actions/test-driver/action.yml
@@ -18,6 +18,8 @@ runs:
     - name: Build static viz frontend
       run: yarn build-static-viz
       shell: bash
+    - name: setup tmate
+      uses: lhotari/action-upterm@v1
     - name: Test database driver
       run: clojure -X:dev:ci:ee:ee-dev:drivers:drivers-dev:test ${{ inputs.test-args }}
       shell: bash

--- a/test/metabase/query_processor_test/date_time_zone_functions_test.clj
+++ b/test/metabase/query_processor_test/date_time_zone_functions_test.clj
@@ -536,19 +536,19 @@
                      first))]
         (testing "timestamp with out timezone columns"
           (mt/with-report-timezone-id "UTC"
-            (testing "convert from Asia/Shanghai(+08:00) to Asia/Tokyo(+09:00)"
+            (testing "convert from Asia/Shanghai(+08:00) to Asia/Seoul(+09:00)"
               (is (= ["2004-03-19T09:19:09Z"
                       "2004-03-19T10:19:09+09:00"]
                      (mt/$ids (test-convert-tz
                                 $times.dt
-                                [:convert-timezone $times.dt "Asia/Tokyo" "Asia/Shanghai"])))))
+                                [:convert-timezone $times.dt "Asia/Seoul" "Asia/Shanghai"])))))
             (testing "source-timezone is required"
               (is (thrown-with-msg?
                     clojure.lang.ExceptionInfo
                     #"input column doesnt have a set timezone. Please set the source parameter in convertTimezone to convert it."
                     (mt/$ids (test-convert-tz
                                $times.dt
-                               [:convert-timezone [:field (mt/id :times :dt) nil] "Asia/Tokyo"]))))))
+                               [:convert-timezone [:field (mt/id :times :dt) nil] "Asia/Seoul"]))))))
 
           (when (driver/supports? driver/*driver* :set-timezone)
             (mt/with-report-timezone-id "Europe/Rome"
@@ -556,7 +556,7 @@
                 (is (= ["2004-03-19T09:19:09+01:00" "2004-03-19T17:19:09+09:00"]
                        (mt/$ids (test-convert-tz
                                   $times.dt
-                                  [:convert-timezone [:field (mt/id :times :dt) nil] "Asia/Tokyo" "Europe/Rome"]))))))))
+                                  [:convert-timezone [:field (mt/id :times :dt) nil] "Asia/Seoul" "Europe/Rome"]))))))))
 
         (testing "timestamp with time zone columns"
           (mt/with-report-timezone-id "UTC"
@@ -564,7 +564,7 @@
               (is (= ["2004-03-19T02:19:09Z" "2004-03-19T11:19:09+09:00"]
                      (mt/$ids (test-convert-tz
                                 $times.dt_tz
-                                [:convert-timezone [:field (mt/id :times :dt_tz) nil] "Asia/Tokyo"])))))
+                                [:convert-timezone [:field (mt/id :times :dt_tz) nil] "Asia/Seoul"])))))
 
             (testing "timestamp with time zone columns shouldn't have `source-timezone`"
               (is (thrown-with-msg?
@@ -573,7 +573,7 @@
                     (mt/$ids (test-convert-tz
                                $times.dt_tz
                                [:convert-timezone [:field (mt/id :times :dt_tz) nil]
-                                "Asia/Tokyo"
+                                "Asia/Seoul"
                                 "UTC"]))))))
 
           (when (driver/supports? driver/*driver* :set-timezone)
@@ -582,7 +582,7 @@
                 (is (= ["2004-03-19T03:19:09+01:00" "2004-03-19T11:19:09+09:00"]
                        (mt/$ids (test-convert-tz
                                   $times.dt_tz
-                                  [:convert-timezone [:field (mt/id :times :dt_tz) nil] "Asia/Tokyo"]))))))))
+                                  [:convert-timezone [:field (mt/id :times :dt_tz) nil] "Asia/Seoul"]))))))))
 
         (testing "with literal datetime"
           (mt/with-report-timezone-id "UTC"
@@ -603,7 +603,7 @@
                   10]                         ;; hour
                  (->> (mt/run-mbql-query
                         times
-                        {:expressions {"converted" [:convert-timezone $times.dt "Asia/Tokyo" "Asia/Shanghai"]
+                        {:expressions {"converted" [:convert-timezone $times.dt "Asia/Seoul" "Asia/Shanghai"]
                                        "hour"      [:get-hour [:expression "converted"]]}
                          :filter      [:= $times.index 1]
                          :fields      [$times.dt
@@ -619,8 +619,8 @@
                   20]                          ;; hour
                  (->> (mt/run-mbql-query
                         times
-                        {:expressions {"converted"  [:convert-timezone $times.dt "Asia/Tokyo" "UTC"]
-                                       "date-added" [:datetime-add [:convert-timezone $times.dt "Asia/Tokyo" "UTC"] 2 :hour]
+                        {:expressions {"converted"  [:convert-timezone $times.dt "Asia/Seoul" "UTC"]
+                                       "date-added" [:datetime-add [:convert-timezone $times.dt "Asia/Seoul" "UTC"] 2 :hour]
                                        "hour"       [:get-hour [:expression "date-added"]]}
                          :filter      [:= $times.index 1]
                          :fields      [$times.dt
@@ -650,7 +650,7 @@
                  (->> (mt/run-mbql-query
                         times
                         {:expressions {"to-07"       [:convert-timezone $times.dt "Asia/Saigon" "UTC"]
-                                       "to-07-to-09" [:convert-timezone [:expression "to-07"] "Asia/Tokyo"
+                                       "to-07-to-09" [:convert-timezone [:expression "to-07"] "Asia/Seoul"
                                                       "Asia/Saigon"]}
                          :filter      [:= $times.index 1]
                          :fields      [$times.dt
@@ -663,7 +663,7 @@
           (is (= ["2004-03-19T18:19:09+09:00"]
                  (->> (mt/run-mbql-query
                         times
-                        {:expressions {"converted" [:convert-timezone $times.dt "Asia/Tokyo" "UTC"]
+                        {:expressions {"converted" [:convert-timezone $times.dt "Asia/Seoul" "UTC"]
                                        "hour"       [:get-hour [:expression "converted"]]}
                          :filter      [:between [:expression "hour"] 17 18]
                          :fields      [[:expression "converted"]]})
@@ -673,7 +673,7 @@
           (is (= ["2004-03-19T18:19:09+09:00"]
                  (->> (mt/run-mbql-query
                         times
-                        {:expressions {"converted" [:convert-timezone $times.dt "Asia/Tokyo" "UTC"]
+                        {:expressions {"converted" [:convert-timezone $times.dt "Asia/Seoul" "UTC"]
                                        "hour"      [:get-hour [:expression "converted"]]}
                          :filter      [:= [:expression "hour"] 18]
                          :fields      [[:expression "converted"]]})
@@ -686,7 +686,7 @@
                                (mt/mbql-query
                                  times
                                  {:expressions {"to-07"       [:convert-timezone $times.dt "Asia/Saigon" "UTC"]
-                                                "to-07-to-09" [:convert-timezone [:expression "to-07"] "Asia/Tokyo"
+                                                "to-07-to-09" [:convert-timezone [:expression "to-07"] "Asia/Seoul"
                                                                "Asia/Saigon"]}
                                   :filter      [:= $times.index 1]
                                   :fields      [$times.dt

--- a/test/metabase/query_processor_test/date_time_zone_functions_test.clj
+++ b/test/metabase/query_processor_test/date_time_zone_functions_test.clj
@@ -522,8 +522,7 @@
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
 (deftest convert-timezone-test
-  ;; TODO redshift used to work, not sure why it's failing now.
-  (mt/test-drivers (disj (mt/normal-drivers-with-feature :convert-timezone) :redshift)
+  (mt/test-drivers (mt/normal-drivers-with-feature :convert-timezone)
     (mt/dataset times-mixed
       (letfn [(test-convert-tz
                 [field
@@ -595,8 +594,7 @@
                         ffirst)))))))))
 
 (deftest nested-convert-timezone-test
-  ;; TODO redshift used to work, not sure why it's failing now.
-  (mt/test-drivers (disj (mt/normal-drivers-with-feature :convert-timezone) :redshift)
+  (mt/test-drivers (mt/normal-drivers-with-feature :convert-timezone)
     (mt/with-report-timezone-id "UTC"
       (mt/dataset times-mixed
         (testing "convert-timezone nested with datetime extract"


### PR DESCRIPTION
The convert-timezone tests was failing on redshift last week, and we had a PR to temporarily skip them [here](https://github.com/metabase/metabase/pull/29883)

This unskip the test and fixes it.

TLDR solution: there might be a bug in how redshift handle japan time, the solution is to change the test to use Korean time(have the same timezone at +09) to avoid the bug.

---

Detail about my findings:

This test was not a flake, but it started failing last Friday for some reason. 
And to be completely honest, I don't know why it fails. 
Let's take this test for example:
https://github.com/metabase/metabase/blob/d3ac4d18dc1a5ec615142136f3ca64cfcac6a70e/test/metabase/query_processor_test/date_time_zone_functions_test.clj#L540-L545


The failure

```clojure
FAIL in metabase.query-processor-test.date-time-zone-functions-test/nested-convert-timezone-test (date_time_zone_functions_test.clj:601)

:redshift 
report timezone id = UTC using times-mixed dataset
 convert-timezone nested with datetime extract
expected: ["2004-03-19T09:19:09Z" "2004-03-19T10:19:09+09:00" 10]
  actual: ["2004-03-19T09:19:09Z" "2004-03-19T11:19:09+09:00" 11]
    diff: - [nil "2004-03-19T10:19:09+09:00" 10]
          + [nil "2004-03-19T11:19:09+09:00" 11]
```

It tries to convert a datetime column(no timezone) with  value `2004-03-19T09:19:09Z` using the expression `[:convert-timezone $times.dt "Asia/Tokyo" "Asia/Shanghai"]`.
Meaning: convert it so that this column's source timezone is Asia/Shanghai(+08) to the destination timezone is Asia/Tokyo(+09).

Since the destination and source timezone is 1 hour different in timezone, the correct output should be `2004-03-19T10:19:09Z` (from 9am to 10am).

But for some reason redshift started returning 11 am instead.
Here is a snapshot of the test above but I use the native query instead of mbql.

![Screenshot 2023-04-10 at 15 52 09](https://user-images.githubusercontent.com/25661381/230883901-dbfe00e8-9160-46e5-b022-7a565645cf1e.png)

Why did it start returning a different value all of the sudden? I don't know for sure. the fact that this only fails on redshift but not postgres might suggest that it's a redshift bug.

---
Completely rambling but I found out that Japan used to observe DST

from wiki
> Between 1948 and 1951 [occupied Japan](https://en.wikipedia.org/wiki/Occupied_Japan) observed [daylight saving time](https://en.wikipedia.org/wiki/Daylight_saving_time) (DST) from the first Saturday in May at 24:00 to the second Saturday in September at 24:00 (with the exception of 1949, when the spring forward transition was the first Saturday in April at 24:00)

so maybe this is a bug in redshift with respect to japan time only?
idk.


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/29923)
<!-- Reviewable:end -->
