### PR TITLE
test migrate-field-database-type-test

### DIFF
--- a/test/metabase/db/schema_migrations_test.clj
+++ b/test/metabase/db/schema_migrations_test.clj
@@ -987,6 +987,7 @@
                                                                 {:name "MySQL Field 1" :table_id mysql-table-id :database_type "json"    :base_type :type/SerializedJSON}
                                                                 {:name "MySQL Field 2" :table_id mysql-table-id :database_type "varchar" :base_type :type/Text}])
             _ (migrate! :up)
+
             new-base-types (t2/select-pk->fn :base_type Field)]
         (are [field-id expected] (= expected (get new-base-types field-id))
           pg-field-1-id :type/JSON


### PR DESCRIPTION
This PR exists only to test whether migrate-field-database-type-test is flaky for the be-tests-mysql-5-7-ee driver job in the driver tests workflow

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/29926)
<!-- Reviewable:end -->
