### PR TITLE
Adds list of exported settings, basic test

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/e2e_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/e2e_test.clj
@@ -18,6 +18,7 @@
                             Table]]
    [metabase.models.action :as action]
    [metabase.models.serialization :as serdes]
+   [metabase.models.setting :as setting]
    [metabase.test :as mt]
    [metabase.test.generate :as test-gen]
    [metabase.util.yaml :as yaml]
@@ -416,9 +417,12 @@
                               clean-entity)))))
 
               (testing "for settings"
-                (is (= (into {} (for [{:keys [key value]} (get @entities "Setting")]
-                                  [key value]))
-                       (yaml/from-file (io/file dump-dir "settings.yaml"))))))))))))
+                (let [settings (get @entities "Setting")]
+                  (is (every? @#'setting/exported-settings
+                              (set (map (comp symbol :key) settings))))
+                  (is (= (into {} (for [{:keys [key value]} settings]
+                                    [key value]))
+                         (yaml/from-file (io/file dump-dir "settings.yaml")))))))))))))
 
 ;; This is a seperate test instead of a `testing` block inside `e2e-storage-ingestion-test`
 ;; because it's quite tricky to set up the generative test to generate parameters with source is card

--- a/src/metabase/models/setting.clj
+++ b/src/metabase/models/setting.clj
@@ -149,8 +149,7 @@
   [:key])
 
 (def ^:private exported-settings
-  '#{admin-email
-     application-colors
+  '#{application-colors
      application-favicon-url
      application-font
      application-font-files
@@ -173,7 +172,6 @@
      humanization-strategy
      landing-page
      loading-message
-     map-tile-server-url
      max-results-bare-rows
      native-query-autocomplete-match-style
      persisted-models-enabled

--- a/src/metabase/models/setting.clj
+++ b/src/metabase/models/setting.clj
@@ -148,9 +148,54 @@
   [_setting]
   [:key])
 
+(def ^:private exported-settings
+  '#{admin-email
+     application-colors
+     application-favicon-url
+     application-font
+     application-font-files
+     application-logo-url
+     application-name
+     available-fonts
+     available-locales
+     available-timezones
+     breakout-bins-num
+     custom-formatting
+     custom-geojson
+     custom-geojson-enabled
+     enable-content-management?
+     enable-embedding
+     enable-nested-queries
+     enable-sandboxes?
+     enable-whitelabeling?
+     enable-xrays
+     hide-embed-branding?
+     humanization-strategy
+     landing-page
+     loading-message
+     map-tile-server-url
+     max-results-bare-rows
+     native-query-autocomplete-match-style
+     persisted-models-enabled
+     report-timezone
+     report-timezone-long
+     report-timezone-short
+     search-typeahead-enabled
+     show-homepage-data
+     show-homepage-pin-message
+     show-homepage-xrays
+     show-lighthouse-illustration
+     show-metabot
+     site-locale
+     site-name
+     source-address-header
+     start-of-week
+     subscription-allowed-domains})
+
 (defmethod serdes/extract-all "Setting" [_model _opts]
   (for [{:keys [key value]} (admin-writable-site-wide-settings
-                             :getter (partial get-value-of-type :string))]
+                             :getter (partial get-value-of-type :string))
+        :when (contains? exported-settings (symbol key))]
     {:serdes/meta [{:model "Setting" :id (name key)}]
      :key key
      :value value}))


### PR DESCRIPTION
This PR adds a simple list of setting which are appropriate to export by default, and attempts to limit these to settings that affect interaction, content, and visual style. Some settings should probably be removed or added from this list after discussion.

If there are strong objections, then we can skip this or come up with a different approach. There are so many settings that maybe groups or tags would help with this. If we export all settings then someone could just edit the YAML file, but that seems like asking a lot when we can identify settings that should never be transferred.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/29927)
<!-- Reviewable:end -->

resolves #29837