### PR TITLE
Return internal operator representation in resolve-expression

### DIFF
--- a/src/metabase/lib/expression.cljc
+++ b/src/metabase/lib/expression.cljc
@@ -33,8 +33,7 @@
    stage-number    :- :int
    expression-name :- ::lib.schema.common/non-blank-string]
   (let [stage (lib.util/query-stage query stage-number)]
-    (or (some-> (get-in stage [:expressions expression-name])
-                lib.common/external-op)
+    (or (get-in stage [:expressions expression-name])
         (throw (ex-info (i18n/tru "No expression named {0}" (pr-str expression-name))
                         {:expression-name expression-name
                          :query           query

--- a/src/metabase/lib/metadata/calculation.cljc
+++ b/src/metabase/lib/metadata/calculation.cljc
@@ -154,11 +154,6 @@
   [query stage-number [_tag _opts expr]]
   (type-of query stage-number expr))
 
-;;; Ugh
-(defmethod type-of-method :lib/external-op
-  [query stage-number {:keys [operator options args]}]
-  (type-of query stage-number (into [(keyword operator) options] args)))
-
 (defmulti metadata-method
   "Impl for [[metadata]]."
   {:arglists '([query stage-number x])}

--- a/src/metabase/lib/schema/expression.cljc
+++ b/src/metabase/lib/schema/expression.cljc
@@ -153,7 +153,3 @@
    {:min 1, :error/message ":expressions definition map of expression name -> expression"}
    ::common/non-blank-string
    ::expression])
-
-(defmethod type-of* :lib/external-op
-  [{:keys [operator options args] :or {options {}}}]
-  (type-of (into [(keyword operator) options] args)))

--- a/test/metabase/lib/expression_test.cljc
+++ b/test/metabase/lib/expression_test.cljc
@@ -6,7 +6,6 @@
    [metabase.lib.expression :as lib.expression]
    [metabase.lib.metadata.calculation :as lib.metadata.calculation]
    [metabase.lib.schema :as lib.schema]
-   [metabase.lib.schema.common :as schema.common]
    [metabase.lib.schema.expression :as lib.schema.expression]
    [metabase.lib.test-metadata :as meta]
    [metabase.lib.test-util :as lib.tu]

--- a/test/metabase/lib/expression_test.cljc
+++ b/test/metabase/lib/expression_test.cljc
@@ -83,7 +83,6 @@
                         (lib/expression "myexpr" expr))
               resolved (lib.expression/resolve-expression query 0 "myexpr")]
           (is (mc/validate ::lib.schema/query query))
-          (is (mc/validate ::schema.common/external-op resolved))
           (is (= typ (lib.schema.expression/type-of resolved))))))))
 
 (deftest ^:parallel col-info-expression-ref-test


### PR DESCRIPTION
Related to #29867.

This PR makes `metabase.lib.expression/resolve-expression` return clauses in the internal representation. This means that we can get rid of the `type-of*` and `type-of-method` method definitions for `:lib/external-op`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/29930)
<!-- Reviewable:end -->
