### PR TITLE
Revert "make area charts full opacity for better legibility and consistency"

### DIFF
--- a/frontend/src/metabase/visualizations/components/LineAreaBarChart.css
+++ b/frontend/src/metabase/visualizations/components/LineAreaBarChart.css
@@ -285,7 +285,3 @@ text.value-label-white {
 .LineAreaBarChart .dc-chart .event-line.hover {
   stroke: var(--color-brand);
 }
-
-.LineAreaBarChart .dc-chart path.area {
-  fill-opacity: 1;
-}


### PR DESCRIPTION
Reverts metabase/metabase#28407

After some time using them, it's not 100% clear to us that this is an overall win, specifically in terms of legibility.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/29934)
<!-- Reviewable:end -->
