### PR TITLE
create `TabRow` and `TabButton` core components

### DIFF
--- a/frontend/src/metabase/core/components/Tab/utils.ts
+++ b/frontend/src/metabase/core/components/Tab/utils.ts
@@ -6,6 +6,6 @@ export function getTabPanelId<T>(idPrefix: string, value: T): string {
   return `${idPrefix}-P-${value}`;
 }
 
-export function getTabButtonLabelId<T>(idPrefix: string, value: T): string {
-  return `${idPrefix}-B-L-${value}`;
+export function getTabButtonInputId<T>(idPrefix: string, value: T): string {
+  return `${idPrefix}-B-I-${value}`;
 }

--- a/frontend/src/metabase/core/components/Tab/utils.ts
+++ b/frontend/src/metabase/core/components/Tab/utils.ts
@@ -5,3 +5,7 @@ export function getTabId<T>(idPrefix: string, value: T): string {
 export function getTabPanelId<T>(idPrefix: string, value: T): string {
   return `${idPrefix}-P-${value}`;
 }
+
+export function getTabButtonLabelId<T>(idPrefix: string, value: T): string {
+  return `${idPrefix}-B-L-${value}`;
+}

--- a/frontend/src/metabase/core/components/TabButton/TabButton.styled.tsx
+++ b/frontend/src/metabase/core/components/TabButton/TabButton.styled.tsx
@@ -9,14 +9,26 @@ export interface TabButtonProps {
   disabled?: boolean;
 }
 
-export const TabButtonLabel = styled.div`
-  width: 100%;
+export const TabButtonInput = styled.input<TabButtonProps & { value: string }>`
+  width: ${props => `${props.value.length}ch`};
+  padding: 0;
+
+  border: none;
+  outline: none;
+  background-color: ${color("bg-light")};
+
+  color: ${props => (props.isSelected ? color("brand") : color("text-dark"))};
   font-weight: bold;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  text-align: center;
+
+  ${props =>
+    props.disabled &&
+    css`
+      pointer-events: none;
+    `}
 `;
 
-export const TabButtonRoot = styled.button<TabButtonProps>`
+export const TabButtonRoot = styled.div<TabButtonProps>`
   display: flex;
 
   padding: 1rem 0;

--- a/frontend/src/metabase/core/components/TabButton/TabButton.styled.tsx
+++ b/frontend/src/metabase/core/components/TabButton/TabButton.styled.tsx
@@ -1,6 +1,8 @@
 import styled from "@emotion/styled";
+import { css } from "@emotion/react";
 
 import { color } from "metabase/lib/colors";
+import Button from "metabase/core/components/Button";
 
 export interface TabButtonProps {
   isSelected?: boolean;
@@ -14,6 +16,8 @@ export const TabButtonLabel = styled.div`
 `;
 
 export const TabButtonRoot = styled.button<TabButtonProps>`
+  display: flex;
+
   padding: 1rem 0;
 
   color: ${props => (props.isSelected ? color("brand") : color("text-dark"))};
@@ -24,4 +28,52 @@ export const TabButtonRoot = styled.button<TabButtonProps>`
 
   border-bottom: 3px solid
     ${props => (props.isSelected ? color("brand") : "transparent")};
+`;
+
+export const MenuButton = styled(Button)<TabButtonProps & { isOpen: boolean }>`
+  transition: background-color 0s;
+
+  border: none;
+
+  padding: 0.25rem;
+  margin-left: 0.25rem;
+
+  ${props =>
+    props.isSelected &&
+    css`
+      color: ${color("brand")};
+    `}
+
+  ${props =>
+    props.isOpen &&
+    css`
+      color: ${color("brand")};
+      background-color: ${color("bg-medium")};
+    `}
+  &:hover,:focus {
+    color: ${color("brand")};
+    background-color: ${color("bg-medium")};
+  }
+`;
+
+export const MenuContent = styled.ul`
+  padding: 0.5rem;
+`;
+
+export const MenuItem = styled.li`
+  width: 100%;
+  padding: 0.85em 1.45em;
+  border-radius: 0.5em;
+
+  color: ${color("text-dark")};
+  font-weight: 700;
+  text-align: start;
+  text-decoration: none;
+
+  cursor: pointer;
+  &:focus,
+  :hover {
+    color: ${color("brand")};
+    background-color: ${color("bg-light")};
+  }
 `;

--- a/frontend/src/metabase/core/components/TabButton/TabButton.styled.tsx
+++ b/frontend/src/metabase/core/components/TabButton/TabButton.styled.tsx
@@ -6,6 +6,7 @@ import Button from "metabase/core/components/Button";
 
 export interface TabButtonProps {
   isSelected?: boolean;
+  disabled?: boolean;
 }
 
 export const TabButtonLabel = styled.div`
@@ -20,11 +21,13 @@ export const TabButtonRoot = styled.button<TabButtonProps>`
 
   padding: 1rem 0;
 
-  color: ${props => (props.isSelected ? color("brand") : color("text-dark"))};
+  color: ${props =>
+    props.isSelected && !props.disabled ? color("brand") : color("text-dark")};
+  opacity: ${props => (props.disabled ? 0.3 : 1)};
   font-size: 0.875rem;
   font-weight: 700;
 
-  cursor: pointer;
+  cursor: ${props => (props.disabled ? "default" : "pointer")};
 
   border-bottom: 3px solid
     ${props => (props.isSelected ? color("brand") : "transparent")};
@@ -46,13 +49,21 @@ export const MenuButton = styled(Button)<TabButtonProps & { isOpen: boolean }>`
 
   ${props =>
     props.isOpen &&
+    !props.disabled &&
     css`
       color: ${color("brand")};
       background-color: ${color("bg-medium")};
     `}
   &:hover,:focus {
-    color: ${color("brand")};
-    background-color: ${color("bg-medium")};
+    ${props =>
+      props.disabled
+        ? css`
+            color: ${color("text-dark")};
+          `
+        : css`
+            color: ${color("brand")};
+            background-color: ${color("bg-medium")};
+          `}
   }
 `;
 

--- a/frontend/src/metabase/core/components/TabButton/TabButton.styled.tsx
+++ b/frontend/src/metabase/core/components/TabButton/TabButton.styled.tsx
@@ -1,0 +1,27 @@
+import styled from "@emotion/styled";
+
+import { color } from "metabase/lib/colors";
+
+export interface TabButtonProps {
+  isSelected?: boolean;
+}
+
+export const TabButtonLabel = styled.div`
+  width: 100%;
+  font-weight: bold;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;
+
+export const TabButtonRoot = styled.button<TabButtonProps>`
+  padding: 1rem 0;
+
+  color: ${props => (props.isSelected ? color("brand") : color("text-dark"))};
+  font-size: 0.875rem;
+  font-weight: 700;
+
+  cursor: pointer;
+
+  border-bottom: 3px solid
+    ${props => (props.isSelected ? color("brand") : "transparent")};
+`;

--- a/frontend/src/metabase/core/components/TabButton/TabButton.styled.tsx
+++ b/frontend/src/metabase/core/components/TabButton/TabButton.styled.tsx
@@ -15,7 +15,7 @@ export const TabButtonInput = styled.input<TabButtonProps & { value: string }>`
 
   border: none;
   outline: none;
-  background-color: ${color("bg-light")};
+  background-color: transparent;
 
   color: ${props => (props.isSelected ? color("brand") : color("text-dark"))};
   font-weight: bold;

--- a/frontend/src/metabase/core/components/TabButton/TabButton.tsx
+++ b/frontend/src/metabase/core/components/TabButton/TabButton.tsx
@@ -40,6 +40,7 @@ export interface TabButtonMenuItem {
 export interface TabButtonProps extends HTMLAttributes<HTMLDivElement> {
   label: string;
   value?: TabButtonValue;
+  showMenu?: boolean;
   menuItems?: TabButtonMenuItem[];
   onEdit?: ChangeEventHandler<HTMLInputElement>;
   onFinishEditing?: () => void;
@@ -57,6 +58,7 @@ const TabButton = forwardRef(function TabButton(
     onFinishEditing,
     disabled = false,
     isEditing = false,
+    showMenu: showMenuProp = true,
     ...props
   }: TabButtonProps,
   inputRef: Ref<HTMLInputElement>,
@@ -66,7 +68,8 @@ const TabButton = forwardRef(function TabButton(
 
   const menuButtonRef = useRef<HTMLButtonElement>(null);
   const [isMenuOpen, setIsMenuOpen] = useState(false);
-  const showMenu = menuItems !== undefined && menuItems.length > 0;
+  const showMenu =
+    showMenuProp && menuItems !== undefined && menuItems.length > 0;
 
   const handleButtonClick: MouseEventHandler<HTMLDivElement> = useCallback(
     event => {

--- a/frontend/src/metabase/core/components/TabButton/TabButton.tsx
+++ b/frontend/src/metabase/core/components/TabButton/TabButton.tsx
@@ -88,6 +88,7 @@ function TabButton({
               isOpen={isMenuOpen}
               onClick={onClick}
               ref={menuButtonRef}
+              disabled={props.disabled}
             />
           )}
           popoverContent={({ closePopover }) => (

--- a/frontend/src/metabase/core/components/TabButton/TabButton.tsx
+++ b/frontend/src/metabase/core/components/TabButton/TabButton.tsx
@@ -1,0 +1,46 @@
+import React, {
+  ButtonHTMLAttributes,
+  MouseEvent,
+  useContext,
+  useCallback,
+} from "react";
+
+import { getTabId, getTabPanelId, TabContext } from "../Tab";
+import { TabButtonLabel, TabButtonRoot } from "./TabButton.styled";
+
+export interface TabButtonProps
+  extends ButtonHTMLAttributes<HTMLButtonElement> {
+  value?: string | number;
+}
+function TabButton({ value, children, onClick, ...props }: TabButtonProps) {
+  const { value: selectedValue, idPrefix, onChange } = useContext(TabContext);
+  const tabId = getTabId(idPrefix, value);
+  const panelId = getTabPanelId(idPrefix, value);
+  const isSelected = value === selectedValue;
+
+  const handleClick = useCallback(
+    (event: MouseEvent<HTMLButtonElement>) => {
+      onClick?.(event);
+      onChange?.(value);
+    },
+    [value, onClick, onChange],
+  );
+
+  return (
+    <TabButtonRoot
+      {...props}
+      id={tabId}
+      role="tab"
+      isSelected={isSelected}
+      aria-selected={isSelected}
+      aria-controls={panelId}
+      onClick={handleClick}
+    >
+      <TabButtonLabel>{children}</TabButtonLabel>
+    </TabButtonRoot>
+  );
+}
+
+export default Object.assign(TabButton, {
+  Root: TabButtonRoot,
+});

--- a/frontend/src/metabase/core/components/TabButton/TabButton.unit.spec.tsx
+++ b/frontend/src/metabase/core/components/TabButton/TabButton.unit.spec.tsx
@@ -4,9 +4,9 @@ import userEvent from "@testing-library/user-event";
 import { getIcon } from "__support__/ui";
 
 import TabRow from "../TabRow";
-import TabButton from "./TabButton";
+import TabButton, { TabButtonProps } from "./TabButton";
 
-function setup() {
+function setup(props?: TabButtonProps) {
   const action = jest.fn();
   const value = "some_value";
 
@@ -17,6 +17,7 @@ function setup() {
         menuItems={[
           { label: "first item", action: (context, value) => action(value) },
         ]}
+        {...props}
       >
         Tab 1
       </TabButton>
@@ -43,5 +44,15 @@ describe("TabButton", () => {
     (await screen.findByRole("option", { name: "first item" })).click();
 
     expect(action).toHaveBeenCalledWith(value);
+  });
+
+  it("should not open the menu when disabled", async () => {
+    setup({ disabled: true });
+
+    userEvent.click(getIcon("chevrondown"));
+
+    expect(
+      screen.queryByRole("option", { name: "first item" }),
+    ).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/metabase/core/components/TabButton/TabButton.unit.spec.tsx
+++ b/frontend/src/metabase/core/components/TabButton/TabButton.unit.spec.tsx
@@ -1,0 +1,47 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { getIcon } from "__support__/ui";
+
+import TabRow from "../TabRow";
+import TabButton from "./TabButton";
+
+function setup() {
+  const action = jest.fn();
+  const value = "some_value";
+
+  render(
+    <TabRow>
+      <TabButton
+        value={value}
+        menuItems={[
+          { label: "first item", action: (context, value) => action(value) },
+        ]}
+      >
+        Tab 1
+      </TabButton>
+    </TabRow>,
+  );
+  return { action, value };
+}
+
+describe("TabButton", () => {
+  it("should open the menu upon clicking the chevron", async () => {
+    setup();
+
+    userEvent.click(getIcon("chevrondown"));
+
+    expect(
+      await screen.findByRole("option", { name: "first item" }),
+    ).toBeInTheDocument();
+  });
+
+  it("should call the action function upon clicking an item in the menu", async () => {
+    const { action, value } = setup();
+
+    userEvent.click(getIcon("chevrondown"));
+    (await screen.findByRole("option", { name: "first item" })).click();
+
+    expect(action).toHaveBeenCalledWith(value);
+  });
+});

--- a/frontend/src/metabase/core/components/TabButton/TabButtonMenu.tsx
+++ b/frontend/src/metabase/core/components/TabButton/TabButtonMenu.tsx
@@ -1,6 +1,6 @@
 import React, { useContext } from "react";
 import { TabContext } from "../Tab/TabContext";
-import { getTabButtonLabelId } from "../Tab/utils";
+import { getTabButtonInputId } from "../Tab/utils";
 import {
   TabButtonMenuAction,
   TabButtonMenuItem,
@@ -29,7 +29,7 @@ export default function TabButtonMenu({
   return (
     <MenuContent
       role="listbox"
-      aria-labelledby={getTabButtonLabelId(context.idPrefix, value)}
+      aria-labelledby={getTabButtonInputId(context.idPrefix, value)}
       tabIndex={0}
     >
       {menuItems.map(({ label, action }) => (

--- a/frontend/src/metabase/core/components/TabButton/TabButtonMenu.tsx
+++ b/frontend/src/metabase/core/components/TabButton/TabButtonMenu.tsx
@@ -1,0 +1,47 @@
+import React, { useContext } from "react";
+import { TabContext } from "../Tab/TabContext";
+import { getTabButtonLabelId } from "../Tab/utils";
+import {
+  TabButtonMenuAction,
+  TabButtonMenuItem,
+  TabButtonValue,
+} from "./TabButton";
+import { MenuContent, MenuItem } from "./TabButton.styled";
+
+interface TabButtonMenuProps {
+  menuItems: TabButtonMenuItem[];
+  value?: TabButtonValue;
+  closePopover: () => void;
+}
+
+export default function TabButtonMenu({
+  menuItems,
+  value,
+  closePopover,
+}: TabButtonMenuProps) {
+  const context = useContext(TabContext);
+
+  const clickHandler = (action: TabButtonMenuAction) => () => {
+    action(context, value);
+    closePopover();
+  };
+
+  return (
+    <MenuContent
+      role="listbox"
+      aria-labelledby={getTabButtonLabelId(context.idPrefix, value)}
+      tabIndex={0}
+    >
+      {menuItems.map(({ label, action }) => (
+        <MenuItem
+          key={label}
+          onClick={clickHandler(action)}
+          role="option"
+          tabIndex={0}
+        >
+          {label}
+        </MenuItem>
+      ))}
+    </MenuContent>
+  );
+}

--- a/frontend/src/metabase/core/components/TabButton/index.ts
+++ b/frontend/src/metabase/core/components/TabButton/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./TabButton";

--- a/frontend/src/metabase/core/components/TabButton/index.ts
+++ b/frontend/src/metabase/core/components/TabButton/index.ts
@@ -1,1 +1,2 @@
 export { default } from "./TabButton";
+export * from "./TabButton";

--- a/frontend/src/metabase/core/components/TabRow/TabRow.stories.tsx
+++ b/frontend/src/metabase/core/components/TabRow/TabRow.stories.tsx
@@ -55,7 +55,12 @@ const Template: ComponentStory<typeof TabRow> = args => {
           renameMenuIndex={2}
           renameMenuLabel="Edit name"
         />
-        <TabButton label="Tab 4" value={4} />
+        <TabButton
+          label="Tab 4"
+          value={4}
+          menuItems={menuItems}
+          showMenu={false}
+        />
         <TabButton label="Tab 5" value={5} menuItems={menuItems} />
         <TabButton label="Tab 6" value={6} disabled />
         <TabButton label="Tab 7" value={7} menuItems={menuItems} disabled />

--- a/frontend/src/metabase/core/components/TabRow/TabRow.stories.tsx
+++ b/frontend/src/metabase/core/components/TabRow/TabRow.stories.tsx
@@ -1,0 +1,80 @@
+import React from "react";
+import type { ComponentStory } from "@storybook/react";
+import { useArgs } from "@storybook/client-api";
+
+import TabButton from "../TabButton";
+import TabLink from "../TabLink";
+import TabRow from "./TabRow";
+
+export default {
+  title: "Core/TabRow",
+  component: TabRow,
+};
+
+const sampleStyle = {
+  maxWidth: "800px",
+  padding: "10px",
+  border: "1px solid #ccc",
+};
+
+const Template: ComponentStory<typeof TabRow> = args => {
+  const [{ value }, updateArgs] = useArgs();
+  const handleChange = (value: unknown) => updateArgs({ value });
+
+  return (
+    <div style={sampleStyle}>
+      <TabRow {...args} value={value} onChange={handleChange}>
+        <TabButton value={1}>Tab 1</TabButton>
+        <TabButton value={2}>Tab 2</TabButton>
+        <TabButton value={3}>Tab 3</TabButton>
+        <TabButton value={4}>Tab 4</TabButton>
+        <TabButton value={5}>Tab 5</TabButton>
+        <TabButton value={6}>Tab 6</TabButton>
+        <TabButton value={7}>Tab 7</TabButton>
+      </TabRow>
+    </div>
+  );
+};
+
+export const Default = Template.bind({});
+Default.args = {
+  value: 1,
+};
+
+const LinkTemplate: ComponentStory<typeof TabRow> = args => {
+  const [{ value }, updateArgs] = useArgs();
+  const handleChange = (value: unknown) => updateArgs({ value });
+
+  return (
+    <div style={sampleStyle}>
+      <TabRow {...args} value={value} onChange={handleChange}>
+        <TabLink value={1} to="">
+          Tab 1
+        </TabLink>
+        <TabLink value={2} to="">
+          Tab 2
+        </TabLink>
+        <TabLink value={3} to="">
+          Tab 3
+        </TabLink>
+        <TabLink value={4} to="">
+          Tab 4
+        </TabLink>
+        <TabLink value={5} to="">
+          Tab 5
+        </TabLink>
+        <TabLink value={6} to="">
+          Tab 6
+        </TabLink>
+        <TabLink value={7} to="">
+          Tab 7
+        </TabLink>
+      </TabRow>
+    </div>
+  );
+};
+
+export const WithLinks = LinkTemplate.bind({});
+WithLinks.args = {
+  value: 1,
+};

--- a/frontend/src/metabase/core/components/TabRow/TabRow.stories.tsx
+++ b/frontend/src/metabase/core/components/TabRow/TabRow.stories.tsx
@@ -56,8 +56,10 @@ const Template: ComponentStory<typeof TabRow> = args => {
         <TabButton value={5} menuItems={menuItems}>
           Tab 5
         </TabButton>
-        <TabButton value={6}>Tab 6</TabButton>
-        <TabButton value={7} menuItems={menuItems}>
+        <TabButton value={6} disabled>
+          Tab 6
+        </TabButton>
+        <TabButton value={7} menuItems={menuItems} disabled>
           Tab 7
         </TabButton>
       </TabRow>

--- a/frontend/src/metabase/core/components/TabRow/TabRow.stories.tsx
+++ b/frontend/src/metabase/core/components/TabRow/TabRow.stories.tsx
@@ -18,7 +18,7 @@ const sampleStyle = {
   display: "flex",
   flexDirection: "column" as const,
   gap: "8px",
-  maxWidth: "800px",
+  width: "100%",
   padding: "10px",
   border: "1px solid #ccc",
 };
@@ -45,23 +45,20 @@ const Template: ComponentStory<typeof TabRow> = args => {
   return (
     <div style={sampleStyle}>
       <TabRow {...args} value={value} onChange={handleChange}>
-        <TabButton value={1} menuItems={menuItems}>
-          Tab 1
-        </TabButton>
-        <TabButton value={2}>Tab 2</TabButton>
-        <TabButton value={3} menuItems={menuItems}>
-          Tab 3
-        </TabButton>
-        <TabButton value={4}>Tab 4</TabButton>
-        <TabButton value={5} menuItems={menuItems}>
-          Tab 5
-        </TabButton>
-        <TabButton value={6} disabled>
-          Tab 6
-        </TabButton>
-        <TabButton value={7} menuItems={menuItems} disabled>
-          Tab 7
-        </TabButton>
+        <TabButton label="Tab 1" value={1} menuItems={menuItems} />
+        <TabButton label="Tab 2" value={2} />
+        <TabButton.Renameable
+          label="Tab 3 (Renameable)"
+          value={3}
+          menuItems={menuItems}
+          onRename={newLabel => setMessage(`Renamed to "${newLabel}"`)}
+          renameMenuIndex={2}
+          renameMenuLabel="Edit name"
+        />
+        <TabButton label="Tab 4" value={4} />
+        <TabButton label="Tab 5" value={5} menuItems={menuItems} />
+        <TabButton label="Tab 6" value={6} disabled />
+        <TabButton label="Tab 7" value={7} menuItems={menuItems} disabled />
       </TabRow>
       {message}
     </div>

--- a/frontend/src/metabase/core/components/TabRow/TabRow.stories.tsx
+++ b/frontend/src/metabase/core/components/TabRow/TabRow.stories.tsx
@@ -1,8 +1,11 @@
-import React from "react";
+import React, { useState } from "react";
 import type { ComponentStory } from "@storybook/react";
 import { useArgs } from "@storybook/client-api";
 
-import TabButton from "../TabButton";
+import TabButton, {
+  TabButtonMenuItem,
+  TabButtonMenuAction,
+} from "../TabButton";
 import TabLink from "../TabLink";
 import TabRow from "./TabRow";
 
@@ -12,6 +15,9 @@ export default {
 };
 
 const sampleStyle = {
+  display: "flex",
+  flexDirection: "column" as const,
+  gap: "8px",
   maxWidth: "800px",
   padding: "10px",
   border: "1px solid #ccc",
@@ -20,18 +26,42 @@ const sampleStyle = {
 const Template: ComponentStory<typeof TabRow> = args => {
   const [{ value }, updateArgs] = useArgs();
   const handleChange = (value: unknown) => updateArgs({ value });
+  const [message, setMessage] = useState("");
+
+  const action: TabButtonMenuAction = ({ value: selectedValue }, value) =>
+    setMessage(
+      `Clicked ${value}, currently selected value is ${selectedValue}`,
+    );
+
+  const menuItems: TabButtonMenuItem[] = [
+    {
+      label: "Click me!",
+      action,
+    },
+    { label: "Or me", action },
+    { label: "Clear", action: () => setMessage("") },
+  ];
 
   return (
     <div style={sampleStyle}>
       <TabRow {...args} value={value} onChange={handleChange}>
-        <TabButton value={1}>Tab 1</TabButton>
+        <TabButton value={1} menuItems={menuItems}>
+          Tab 1
+        </TabButton>
         <TabButton value={2}>Tab 2</TabButton>
-        <TabButton value={3}>Tab 3</TabButton>
+        <TabButton value={3} menuItems={menuItems}>
+          Tab 3
+        </TabButton>
         <TabButton value={4}>Tab 4</TabButton>
-        <TabButton value={5}>Tab 5</TabButton>
+        <TabButton value={5} menuItems={menuItems}>
+          Tab 5
+        </TabButton>
         <TabButton value={6}>Tab 6</TabButton>
-        <TabButton value={7}>Tab 7</TabButton>
+        <TabButton value={7} menuItems={menuItems}>
+          Tab 7
+        </TabButton>
       </TabRow>
+      {message}
     </div>
   );
 };

--- a/frontend/src/metabase/core/components/TabRow/TabRow.styled.tsx
+++ b/frontend/src/metabase/core/components/TabRow/TabRow.styled.tsx
@@ -10,6 +10,7 @@ export const TabList = styled(BaseTabList)`
 
   ${BaseTabList.Content} {
     display: flex;
+    overflow: hidden;
   }
 
   ${TabLink.Root}:not(:last-child) {

--- a/frontend/src/metabase/core/components/TabRow/TabRow.styled.tsx
+++ b/frontend/src/metabase/core/components/TabRow/TabRow.styled.tsx
@@ -1,0 +1,22 @@
+import styled from "@emotion/styled";
+
+import { color } from "metabase/lib/colors";
+import BaseTabList from "metabase/core/components/TabList";
+import TabLink from "metabase/core/components/TabLink";
+import TabButton from "metabase/core/components/TabButton";
+
+export const TabList = styled(BaseTabList)`
+  border-bottom: 1px solid ${color("border")};
+
+  ${BaseTabList.Content} {
+    display: flex;
+  }
+
+  ${TabLink.Root}:not(:last-child) {
+    margin-right: 2rem;
+  }
+
+  ${TabButton.Root}:not(:last-child) {
+    margin-right: 2rem;
+  }
+`;

--- a/frontend/src/metabase/core/components/TabRow/TabRow.tsx
+++ b/frontend/src/metabase/core/components/TabRow/TabRow.tsx
@@ -1,0 +1,8 @@
+import React from "react";
+
+import { TabListProps } from "../TabList/TabList";
+import { TabList } from "./TabRow.styled";
+
+export default function TabRow<T>({ onChange, ...props }: TabListProps<T>) {
+  return <TabList onChange={onChange as (value: unknown) => void} {...props} />;
+}

--- a/frontend/src/metabase/core/components/TabRow/TabRow.unit.spec.tsx
+++ b/frontend/src/metabase/core/components/TabRow/TabRow.unit.spec.tsx
@@ -10,8 +10,8 @@ const TestTabRow = () => {
 
   return (
     <TabRow value={value} onChange={setValue}>
-      <TabButton value={1}>Tab 1</TabButton>
-      <TabButton value={2}>Tab 2</TabButton>
+      <TabButton label="Tab 1" value={1} />
+      <TabButton label="Tab 2" value={2} />
     </TabRow>
   );
 };

--- a/frontend/src/metabase/core/components/TabRow/TabRow.unit.spec.tsx
+++ b/frontend/src/metabase/core/components/TabRow/TabRow.unit.spec.tsx
@@ -1,0 +1,32 @@
+import React, { useState } from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import TabButton from "../TabButton";
+import TabRow from "./TabRow";
+
+const TestTabRow = () => {
+  const [value, setValue] = useState(1);
+
+  return (
+    <TabRow value={value} onChange={setValue}>
+      <TabButton value={1}>Tab 1</TabButton>
+      <TabButton value={2}>Tab 2</TabButton>
+    </TabRow>
+  );
+};
+
+describe("TabRow", () => {
+  it("should navigate between tabs", () => {
+    render(<TestTabRow />);
+
+    const option1 = screen.getByRole("tab", { name: "Tab 1" });
+    const option2 = screen.getByRole("tab", { name: "Tab 2" });
+    expect(option1).toHaveAttribute("aria-selected", "true");
+    expect(option2).toHaveAttribute("aria-selected", "false");
+
+    userEvent.click(option2);
+    expect(option1).toHaveAttribute("aria-selected", "false");
+    expect(option2).toHaveAttribute("aria-selected", "true");
+  });
+});

--- a/frontend/src/metabase/core/components/TabRow/index.ts
+++ b/frontend/src/metabase/core/components/TabRow/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./TabRow";

--- a/frontend/src/metabase/models/components/ModelDetailPage/ModelDetailPage.styled.tsx
+++ b/frontend/src/metabase/models/components/ModelDetailPage/ModelDetailPage.styled.tsx
@@ -1,8 +1,11 @@
 import styled from "@emotion/styled";
-import TabLink from "metabase/core/components/TabLink";
-import BaseTabList from "metabase/core/components/TabList";
+
+import BaseTabRow from "metabase/core/components/TabRow";
 import BaseTabPanel from "metabase/core/components/TabPanel";
-import { color } from "metabase/lib/colors";
+
+export const TabRow = styled(BaseTabRow)`
+  margin: 1rem 0;
+`;
 
 export const RootLayout = styled.div`
   display: flex;
@@ -19,19 +22,6 @@ export const ModelMain = styled.div`
   flex-direction: column;
 
   padding-right: 3rem;
-`;
-
-export const TabList = styled(BaseTabList)`
-  margin: 1rem 0;
-  border-bottom: 1px solid ${color("border")};
-
-  ${BaseTabList.Content} {
-    display: flex;
-  }
-
-  ${TabLink.Root}:not(:last-child) {
-    margin-right: 2rem;
-  }
 `;
 
 export const TabPanel = styled(BaseTabPanel)`

--- a/frontend/src/metabase/models/components/ModelDetailPage/ModelDetailPage.tsx
+++ b/frontend/src/metabase/models/components/ModelDetailPage/ModelDetailPage.tsx
@@ -18,7 +18,7 @@ import ModelUsageDetails from "./ModelUsageDetails";
 import {
   RootLayout,
   ModelMain,
-  TabList,
+  TabRow,
   TabPanel,
   TabPanelContent,
 } from "./ModelDetailPage.styled";
@@ -58,7 +58,7 @@ function ModelDetailPage({
           onChangeCollection={onChangeCollection}
         />
         <TabContent value={tab}>
-          <TabList>
+          <TabRow>
             <TabLink
               value="usage"
               to={Urls.modelDetail(modelCard, "usage")}
@@ -73,7 +73,7 @@ function ModelDetailPage({
                 to={Urls.modelDetail(modelCard, "actions")}
               >{t`Actions`}</TabLink>
             )}
-          </TabList>
+          </TabRow>
           <TabPanel value="usage">
             <TabPanelContent>
               <ModelUsageDetails


### PR DESCRIPTION
Part of epic https://github.com/metabase/metabase/issues/29502

### Description

This PR is an amalgamation of several other approved PRs creating new `TabRow` and `TabButton` reusable UI components. This component will be used for dashboard tabs, see [design](https://www.figma.com/file/DuwiUCVo1K4EUBw50pGYPy/Tabs-in-dashboards?node-id=104-5192&t=ZHEoOQ6tvXLU2Mtx-0).

Merged PRs: _(note that originally these were merged to another branch, `feature-dashboard-tabs`, but I wanted to rename it so I opened a new PR here)_
[refactor custom `TabList` from `ModelDetailPage` into a core component #29669](https://github.com/metabase/metabase/pull/29669)
[add menu to `TabButton` #29697 ](https://github.com/metabase/metabase/pull/29697)
[add disabled prop to `TabButton` #29772 ](https://github.com/metabase/metabase/pull/29772)
[create renameable `TabButton` variant #29801 ](https://github.com/metabase/metabase/pull/29801)

### How to verify

`yarn storybook` -> `TabList`

### Demo

https://user-images.githubusercontent.com/37751258/229857872-716ba056-aeda-4541-b39a-bbf049b0727f.mov

### Checklist

- [x] Tests have been added/updated to cover changes in this PR

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/29939)
<!-- Reviewable:end -->
