### PR TITLE
Parallelize lots of QP tests and split out into smaller tests

### DIFF
--- a/test/metabase/query_processor_test/aggregation_test.clj
+++ b/test/metabase/query_processor_test/aggregation_test.clj
@@ -1,5 +1,6 @@
 (ns metabase.query-processor-test.aggregation-test
-  "Tests for MBQL aggregations."
+  "Tests for MBQL aggregations. Other advanced aggregation types are tested
+  in [[metabase.query-processor-test.advanced-math-test]]."
   (:require
    [clojure.test :refer :all]
    [metabase.models.field :refer [Field]]
@@ -8,7 +9,7 @@
    [metabase.test.data :as data]
    [metabase.test.util :as tu]))
 
-(deftest no-aggregation-test
+(deftest ^:parallel no-aggregation-test
   (mt/test-drivers (mt/normal-drivers)
     (testing "Test that no aggregation just returns rows as-is."
       (is (= [[1 "Red Medicine" 4 10.0646 -165.374 3]
@@ -25,43 +26,50 @@
                (mt/run-mbql-query venues
                  {:limit 10, :order-by [[:asc $id]]})))))))
 
-(deftest basic-aggregations-test
+(deftest ^:parallel count-aggregation-test
   (mt/test-drivers (mt/normal-drivers)
     (testing "count aggregation"
       (is (= [[100]]
              (mt/formatted-rows [int]
                (mt/run-mbql-query venues
-                 {:aggregation [[:count]]})))))
+                 {:aggregation [[:count]]})))))))
 
+(deftest ^:parallel sum-aggregation-test
+  (mt/test-drivers (mt/normal-drivers)
     (testing "sum aggregation"
       (is (= [[203]]
              (mt/formatted-rows [int]
                (mt/run-mbql-query venues
-                 {:aggregation [[:sum $price]]})))))
+                 {:aggregation [[:sum $price]]})))))))
 
+(deftest ^:parallel avg-aggregation-test
+  (mt/test-drivers (mt/normal-drivers)
     (testing "avg aggregation"
       (is (= [[35.5059]]
              (mt/formatted-rows [4.0]
                (mt/run-mbql-query venues
-                 {:aggregation [[:avg $latitude]]})))))
+                 {:aggregation [[:avg $latitude]]})))))))
 
+(deftest ^:parallel distinct-count-aggregation-test
+  (mt/test-drivers (mt/normal-drivers)
     (testing "distinct count aggregation"
       (is (= [[15]]
              (mt/formatted-rows [int]
                (mt/run-mbql-query checkins
                  {:aggregation [[:distinct $user_id]]})))))))
 
-(deftest standard-deviation-test
+(deftest ^:parallel standard-deviation-test
   (mt/test-drivers (mt/normal-drivers-with-feature :standard-deviation-aggregations)
     (testing "standard deviation aggregations"
       (let [query (mt/mbql-query venues {:aggregation [[:stddev $latitude]]})]
         (mt/with-native-query-testing-context query
-          (is (= {:cols [(qp.test/aggregate-col :stddev :venues :latitude)]
-                  :rows [[3.4]]}
-                 (qp.test/rows-and-cols
-                  (mt/format-rows-by [1.0]
-                    (mt/process-query query)))))))))
+          (is (=? {:cols [(qp.test/aggregate-col :stddev :venues :latitude)]
+                   :rows [[3.4]]}
+                  (qp.test/rows-and-cols
+                   (mt/format-rows-by [1.0]
+                     (mt/process-query query))))))))))
 
+(deftest ^:parallel standard-deviation-error-when-unsupported-test
   (mt/test-drivers (mt/normal-drivers-without-feature :standard-deviation-aggregations)
     (testing "Make sure standard deviations fail for drivers that don't support it"
       (is (thrown-with-msg?
@@ -70,61 +78,53 @@
            (mt/run-mbql-query venues
              {:aggregation [[:stddev $latitude]]}))))))
 
-;;; other advanced aggregation types are tested in [[metabase.query-processor-test.advanced-math-test]]
-
-
-;;; +----------------------------------------------------------------------------------------------------------------+
-;;; |                                                   MIN & MAX                                                    |
-;;; +----------------------------------------------------------------------------------------------------------------+
-
-(deftest min-test
+(deftest ^:parallel min-test
   (mt/test-drivers (mt/normal-drivers)
     (is (= [1]
            (mt/first-row
             (mt/format-rows-by [int]
               (mt/run-mbql-query venues
-                {:aggregation [[:min $price]]})))))
+                {:aggregation [[:min $price]]})))))))
 
+(deftest ^:parallel min-test-2
+  (mt/test-drivers (mt/normal-drivers)
     (is (= [[1 34.0071] [2 33.7701] [3 10.0646] [4 33.983]]
            (mt/formatted-rows [int 4.0]
              (mt/run-mbql-query venues
                {:aggregation [[:min $latitude]]
                 :breakout    [$price]}))))))
 
-(deftest max-test
+(deftest ^:parallel max-test
   (mt/test-drivers (mt/normal-drivers)
     (is (= [4]
            (mt/first-row
              (mt/format-rows-by [int]
                (mt/run-mbql-query venues
-                 {:aggregation [[:max $price]]})))))
+                 {:aggregation [[:max $price]]})))))))
 
+(deftest ^:parallel max-test-2
+  (mt/test-drivers (mt/normal-drivers)
     (is (= [[1 37.8078] [2 40.7794] [3 40.7262] [4 40.7677]]
            (mt/formatted-rows [int 4.0]
              (mt/run-mbql-query venues
                {:aggregation [[:max $latitude]]
                 :breakout    [$price]}))))))
 
-
-;;; +----------------------------------------------------------------------------------------------------------------+
-;;; |                                             MULTIPLE AGGREGATIONS                                              |
-;;; +----------------------------------------------------------------------------------------------------------------+
-
-(deftest multiple-aggregations-test
+(deftest ^:parallel two-aggregations-test
   (mt/test-drivers (mt/normal-drivers)
-    (testing "two aggregations"
-      (is (= [[100 203]]
-             (mt/formatted-rows [int int]
-               (mt/run-mbql-query venues
-                 {:aggregation [[:count] [:sum $price]]})))))
+    (is (= [[100 203]]
+           (mt/formatted-rows [int int]
+             (mt/run-mbql-query venues
+               {:aggregation [[:count] [:sum $price]]}))))))
 
-    (testing "three aggregations"
-      (is (= [[2 100 203]]
-             (mt/formatted-rows [int int int]
-               (mt/run-mbql-query venues
-                 {:aggregation [[:avg $price] [:count] [:sum $price]]})))))))
+(deftest ^:parallel three-aggregations-test
+  (mt/test-drivers (mt/normal-drivers)
+    (is (= [[2 100 203]]
+           (mt/formatted-rows [int int int]
+             (mt/run-mbql-query venues
+               {:aggregation [[:avg $price] [:count] [:sum $price]]}))))))
 
-(deftest multiple-aggregations-metadata-test
+(deftest ^:parallel multiple-aggregations-metadata-test
   ;; TODO - this isn't tested against Mongo because those driver doesn't currently work correctly with multiple
   ;; columns with the same name. It seems like it would be pretty easy to take the stuff we have for BigQuery and
   ;; generalize it so we can use it with Mongo
@@ -132,23 +132,25 @@
   ;; TODO part 2 -- not sure if this is still the case?
   (mt/test-drivers (disj (mt/normal-drivers) :mongo)
     (testing "make sure that multiple aggregations of the same type have the correct metadata (#4003)"
-      (is (= [(qp.test/aggregate-col :count)
-              (assoc (qp.test/aggregate-col :count) :name "count_2", :field_ref [:aggregation 1])]
-             (mt/cols
+      (is (=? [(qp.test/aggregate-col :count)
+               (assoc (qp.test/aggregate-col :count) :name "count_2", :field_ref [:aggregation 1])]
+              (mt/cols
                (mt/run-mbql-query venues
                  {:aggregation [[:count] [:count]]})))))))
 
 
 ;;; ------------------------------------------------- CUMULATIVE SUM -------------------------------------------------
 
-(deftest cumulate-sum-test
+(deftest ^:parallel cumulative-sum-without-breakout-test
   (mt/test-drivers (mt/normal-drivers)
     (testing "cum_sum w/o breakout should be treated the same as sum"
       (is (= [[120]]
              (mt/formatted-rows [int]
                (mt/run-mbql-query users
-                 {:aggregation [[:cum-sum $id]]})))))
+                 {:aggregation [[:cum-sum $id]]})))))))
 
+(deftest ^:parallel simple-cumulative-sum-test
+  (mt/test-drivers (mt/normal-drivers)
     (testing " Simple cumulative sum where breakout field is same as cum_sum field"
       (is (= [[ 1   1]
               [ 2   3]
@@ -168,8 +170,10 @@
              (mt/formatted-rows [int int]
                (mt/run-mbql-query users
                  {:aggregation [[:cum-sum $id]]
-                  :breakout    [$id]})))))
+                  :breakout    [$id]})))))))
 
+(deftest ^:parallel cumulative-sum-with-different-breakout-test
+  (mt/test-drivers (mt/normal-drivers)
     (testing " Cumulative sum w/ a different breakout field"
       (is (= [["Broen Olujimi"        14]
               ["Conchúr Tihomir"      21]
@@ -189,8 +193,10 @@
              (mt/formatted-rows [str int]
                (mt/run-mbql-query users
                  {:aggregation [[:cum-sum $id]]
-                  :breakout    [$name]})))))
+                  :breakout    [$name]})))))))
 
+(deftest ^:parallel cumulative-sum-with-different-breakout-that-requires-grouping-test
+  (mt/test-drivers (mt/normal-drivers)
     (testing " Cumulative sum w/ a different breakout field that requires grouping"
       (is (= [[1 1211]
               [2 4066]
@@ -201,51 +207,55 @@
                  {:aggregation [[:cum-sum $id]]
                   :breakout    [$price]})))))))
 
-
-;;; ------------------------------------------------ CUMULATIVE COUNT ------------------------------------------------
-(deftest cumulative-count-test
+(deftest ^:parallel cumulative-count-without-breakout-test
   (mt/test-drivers (mt/normal-drivers)
     (testing "cumulative count aggregations"
       (testing "w/o breakout should be treated the same as count"
-        (is (= {:rows [[15]]
-                :cols [(qp.test/aggregate-col :cum-count :users :id)]}
-               (qp.test/rows-and-cols
+        (is (=? {:rows [[15]]
+                 :cols [(qp.test/aggregate-col :cum-count :users :id)]}
+                (qp.test/rows-and-cols
                  (mt/format-rows-by [int]
                    (mt/run-mbql-query users
-                     {:aggregation [[:cum-count $id]]}))))))
+                     {:aggregation [[:cum-count $id]]})))))))))
 
+(deftest ^:parallel cumulative-count-with-breakout-test
+  (mt/test-drivers (mt/normal-drivers)
+    (testing "cumulative count aggregations"
       (testing "w/ breakout on field with distinct values"
-        (is (= {:rows [["Broen Olujimi"        1]
-                       ["Conchúr Tihomir"      2]
-                       ["Dwight Gresham"       3]
-                       ["Felipinho Asklepios"  4]
-                       ["Frans Hevel"          5]
-                       ["Kaneonuskatew Eiran"  6]
-                       ["Kfir Caj"             7]
-                       ["Nils Gotam"           8]
-                       ["Plato Yeshua"         9]
-                       ["Quentin Sören"       10]
-                       ["Rüstem Hebel"        11]
-                       ["Shad Ferdynand"      12]
-                       ["Simcha Yan"          13]
-                       ["Spiros Teofil"       14]
-                       ["Szymon Theutrich"    15]]
-                :cols [(qp.test/breakout-col :users :name)
-                       (qp.test/aggregate-col :cum-count :users :id)]}
-               (qp.test/rows-and-cols
+        (is (=? {:rows [["Broen Olujimi"        1]
+                        ["Conchúr Tihomir"      2]
+                        ["Dwight Gresham"       3]
+                        ["Felipinho Asklepios"  4]
+                        ["Frans Hevel"          5]
+                        ["Kaneonuskatew Eiran"  6]
+                        ["Kfir Caj"             7]
+                        ["Nils Gotam"           8]
+                        ["Plato Yeshua"         9]
+                        ["Quentin Sören"       10]
+                        ["Rüstem Hebel"        11]
+                        ["Shad Ferdynand"      12]
+                        ["Simcha Yan"          13]
+                        ["Spiros Teofil"       14]
+                        ["Szymon Theutrich"    15]]
+                 :cols [(qp.test/breakout-col :users :name)
+                        (qp.test/aggregate-col :cum-count :users :id)]}
+                (qp.test/rows-and-cols
                  (mt/format-rows-by [str int]
                    (mt/run-mbql-query users
                      {:aggregation [[:cum-count $id]]
-                      :breakout    [$name]}))))))
+                      :breakout    [$name]})))))))))
 
+(deftest ^:parallel cumulative-count-with-breakout-that-requires-grouping-test
+  (mt/test-drivers (mt/normal-drivers)
+    (testing "cumulative count aggregations"
       (testing "w/ breakout on field that requires grouping"
-        (is (= {:cols [(qp.test/breakout-col :venues :price)
-                       (qp.test/aggregate-col :cum-count :venues :id)]
-                :rows [[1 22]
-                       [2 81]
-                       [3 94]
-                       [4 100]]}
-               (qp.test/rows-and-cols
+        (is (=? {:cols [(qp.test/breakout-col :venues :price)
+                        (qp.test/aggregate-col :cum-count :venues :id)]
+                 :rows [[1 22]
+                        [2 81]
+                        [3 94]
+                        [4 100]]}
+                (qp.test/rows-and-cols
                  (mt/format-rows-by [int int]
                    (mt/run-mbql-query venues
                      {:aggregation [[:cum-count $id]]
@@ -256,12 +266,12 @@
     (tu/with-temp-vals-in-db Field (data/id :venues :price) {:settings {:is_priceless false}}
       (let [results (mt/run-mbql-query venues
                       {:aggregation [[:sum $price]]})]
-        (is (= (assoc (qp.test/aggregate-col :sum :venues :price)
-                      :settings {:is_priceless false})
-               (or (-> results mt/cols first)
-                   results)))))))
+        (is (=? (assoc (qp.test/aggregate-col :sum :venues :price)
+                       :settings {:is_priceless false})
+                (or (-> results mt/cols first)
+                    results)))))))
 
-(deftest duplicate-aggregations-test
+(deftest ^:parallel duplicate-aggregations-test
   (mt/test-drivers (mt/normal-drivers)
     (testing "Do we properly handle queries that have more than one of the same aggregation? (#5393)"
       (is (= [[5050 203]]
@@ -269,7 +279,7 @@
                (mt/run-mbql-query venues
                                   {:aggregation [[:sum $id] [:sum $price]]})))))))
 
-(deftest multiple-distinct-aggregations-test
+(deftest ^:parallel multiple-distinct-aggregations-test
   (testing "Multiple `:distinct` aggregations should work correctly (#13097)"
     (mt/test-drivers (mt/normal-drivers)
       (is (= [[100 4]]

--- a/test/metabase/query_processor_test/breakout_test.clj
+++ b/test/metabase/query_processor_test/breakout_test.clj
@@ -13,57 +13,57 @@
    [metabase.test :as mt]
    [metabase.util :as u]))
 
-(deftest basic-test
+(deftest ^:parallel single-column-with-aggregation-test
   (mt/test-drivers (mt/normal-drivers)
-    (testing "single column"
-      (testing "with breakout"
-        (is (= {:rows [[1 31] [2 70] [3 75] [4 77] [5 69] [6 70] [7 76] [8 81] [9 68] [10 78] [11 74] [12 59] [13 76] [14 62] [15 34]]
-                :cols [(qp.test/breakout-col :checkins :user_id)
-                       (qp.test/aggregate-col :count)]}
-               (qp.test/rows-and-cols
-                 (mt/format-rows-by [int int]
-                   (mt/run-mbql-query checkins
-                     {:aggregation [[:count]]
-                      :breakout    [$user_id]
-                      :order-by    [[:asc $user_id]]}))))))
+    (is (=? {:rows [[1 31] [2 70] [3 75] [4 77] [5 69] [6 70] [7 76] [8 81] [9 68] [10 78] [11 74] [12 59] [13 76] [14 62] [15 34]]
+             :cols [(qp.test/breakout-col :checkins :user_id)
+                    (qp.test/aggregate-col :count)]}
+            (qp.test/rows-and-cols
+             (mt/format-rows-by [int int]
+               (mt/run-mbql-query checkins
+                 {:aggregation [[:count]]
+                  :breakout    [$user_id]
+                  :order-by    [[:asc $user_id]]})))))))
 
-      (testing "without breakout"
-        (testing "This should act as a \"distinct values\" query and return ordered results"
-          (is (= {:cols [(qp.test/breakout-col :checkins :user_id)]
-                  :rows [[1] [2] [3] [4] [5] [6] [7] [8] [9] [10]]}
-                 (qp.test/rows-and-cols
-                   (mt/format-rows-by [int]
-                     (mt/run-mbql-query checkins
-                       {:breakout [$user_id]
-                        :limit    10}))))))))
+(deftest ^:parallel single-column-without-aggregation-test
+  (mt/test-drivers (mt/normal-drivers)
+    (testing "This should act as a \"distinct values\" query and return ordered results"
+      (is (=? {:cols [(qp.test/breakout-col :checkins :user_id)]
+               :rows [[1] [2] [3] [4] [5] [6] [7] [8] [9] [10]]}
+              (qp.test/rows-and-cols
+               (mt/format-rows-by [int]
+                 (mt/run-mbql-query checkins
+                   {:breakout [$user_id]
+                    :limit    10}))))))))
 
-    (testing "multiple columns"
-      (testing "without explicit order by"
-        (testing "Fields should be implicitly ordered :ASC for all the fields in `breakout` that are not specified in `order-by`"
-          (is (= {:rows [[1 1 1] [1 5 1] [1 7 1] [1 10 1] [1 13 1] [1 16 1] [1 26 1] [1 31 1] [1 35 1] [1 36 1]]
-                  :cols [(qp.test/breakout-col :checkins :user_id)
-                         (qp.test/breakout-col :checkins :venue_id)
-                         (qp.test/aggregate-col :count)]}
-                 (qp.test/rows-and-cols
-                   (mt/format-rows-by [int int int]
-                     (mt/run-mbql-query checkins
-                       {:aggregation [[:count]]
-                        :breakout    [$user_id $venue_id]
-                        :limit       10})))))))
+(deftest ^:parallel multiple-columns-without-order-by-test
+  (mt/test-drivers (mt/normal-drivers)
+    (testing "Fields should be implicitly ordered :ASC for all the fields in `breakout` that are not specified in `order-by`"
+      (is (=? {:rows [[1 1 1] [1 5 1] [1 7 1] [1 10 1] [1 13 1] [1 16 1] [1 26 1] [1 31 1] [1 35 1] [1 36 1]]
+               :cols [(qp.test/breakout-col :checkins :user_id)
+                      (qp.test/breakout-col :checkins :venue_id)
+                      (qp.test/aggregate-col :count)]}
+              (qp.test/rows-and-cols
+               (mt/format-rows-by [int int int]
+                 (mt/run-mbql-query checkins
+                   {:aggregation [[:count]]
+                    :breakout    [$user_id $venue_id]
+                    :limit       10}))))))))
 
-      (testing "with explicit order by"
-        (testing "`breakout` should not implicitly order by any fields specified in `order-by`"
-          (is (= {:rows [[15 2 1] [15 3 1] [15 7 1] [15 14 1] [15 16 1] [15 18 1] [15 22 1] [15 23 2] [15 24 1] [15 27 1]]
-                  :cols [(qp.test/breakout-col :checkins :user_id)
-                         (qp.test/breakout-col :checkins :venue_id)
-                         (qp.test/aggregate-col :count)]}
-                 (qp.test/rows-and-cols
-                   (mt/format-rows-by [int int int]
-                     (mt/run-mbql-query checkins
-                       {:aggregation [[:count]]
-                        :breakout    [$user_id $venue_id]
-                        :order-by    [[:desc $user_id]]
-                        :limit       10}))))))))))
+(deftest ^:parallel multiple-columns-with-order-by-test
+  (mt/test-drivers (mt/normal-drivers)
+    (testing "`breakout` should not implicitly order by any fields specified in `order-by`"
+      (is (=? {:rows [[15 2 1] [15 3 1] [15 7 1] [15 14 1] [15 16 1] [15 18 1] [15 22 1] [15 23 2] [15 24 1] [15 27 1]]
+               :cols [(qp.test/breakout-col :checkins :user_id)
+                      (qp.test/breakout-col :checkins :venue_id)
+                      (qp.test/aggregate-col :count)]}
+              (qp.test/rows-and-cols
+               (mt/format-rows-by [int int int]
+                 (mt/run-mbql-query checkins
+                   {:aggregation [[:count]]
+                    :breakout    [$user_id $venue_id]
+                    :order-by    [[:desc $user_id]]
+                    :limit       10}))))))))
 
 (deftest internal-remapping-test
   (mt/test-drivers (mt/normal-drivers)
@@ -100,70 +100,78 @@
                       qp.test/rows
                       (mapv last)))))))))
 
-(deftest binning-test
+(deftest ^:parallel bin-single-column-20-bins-test
   (mt/test-drivers (mt/normal-drivers-with-feature :binning)
-    (testing "Bin single column"
-      (testing "20 bins"
-        (is (= [[10.0 1] [32.0 4] [34.0 57] [36.0 29] [40.0 9]]
-               (mt/formatted-rows [1.0 int]
-                 (mt/run-mbql-query venues
-                   {:aggregation [[:count]]
-                    :breakout    [[:field %latitude {:binning {:strategy :num-bins, :num-bins 20}}]]})))))
+    (is (= [[10.0 1] [32.0 4] [34.0 57] [36.0 29] [40.0 9]]
+           (mt/formatted-rows [1.0 int]
+             (mt/run-mbql-query venues
+               {:aggregation [[:count]]
+                :breakout    [[:field %latitude {:binning {:strategy :num-bins, :num-bins 20}}]]}))))))
 
-      (testing "3 bins"
-        (is (= [[0.0 1] [20.0 90] [40.0 9]]
-               (mt/formatted-rows [1.0 int]
-                 (mt/run-mbql-query venues
-                   {:aggregation [[:count]]
-                    :breakout    [[:field %latitude {:binning {:strategy :num-bins, :num-bins 3}}]]}))))))
+(deftest ^:parallel bin-single-column-3-bins-test
+  (mt/test-drivers (mt/normal-drivers-with-feature :binning)
+    (is (= [[0.0 1] [20.0 90] [40.0 9]]
+           (mt/formatted-rows [1.0 int]
+             (mt/run-mbql-query venues
+               {:aggregation [[:count]]
+                :breakout    [[:field %latitude {:binning {:strategy :num-bins, :num-bins 3}}]]}))))))
 
-    (testing "Bin two columns"
-      (is (= [[10.0 -170.0 1] [32.0 -120.0 4] [34.0 -120.0 57] [36.0 -125.0 29] [40.0 -75.0 9]]
-             (mt/formatted-rows [1.0 1.0 int]
-               (mt/run-mbql-query venues
-                 {:aggregation [[:count]]
-                  :breakout    [[:field %latitude {:binning {:strategy :num-bins, :num-bins 20}}]
-                                [:field %longitude {:binning {:strategy :num-bins, :num-bins 20}}]]})))))
+(deftest ^:parallel bin-two-columns-test
+  (mt/test-drivers (mt/normal-drivers-with-feature :binning)
+    (is (= [[10.0 -170.0 1] [32.0 -120.0 4] [34.0 -120.0 57] [36.0 -125.0 29] [40.0 -75.0 9]]
+           (mt/formatted-rows [1.0 1.0 int]
+             (mt/run-mbql-query venues
+               {:aggregation [[:count]]
+                :breakout    [[:field %latitude {:binning {:strategy :num-bins, :num-bins 20}}]
+                              [:field %longitude {:binning {:strategy :num-bins, :num-bins 20}}]]}))))))
 
+(deftest ^:parallel binning-default-to-8-bins-test
+  (mt/test-drivers (mt/normal-drivers-with-feature :binning)
     (testing "should default to 8 bins when number of bins isn't specified"
       (is (= [[10.0 1] [30.0 90] [40.0 9]]
              (mt/formatted-rows [1.0 int]
                (mt/run-mbql-query venues
                  {:aggregation [[:count]]
-                  :breakout    [[:field %latitude {:binning {:strategy :default}}]]}))))
+                  :breakout    [[:field %latitude {:binning {:strategy :default}}]]})))))))
 
-      (mt/with-temporary-setting-values [breakout-bin-width 5.0]
-        (is (= [[10.0 1] [30.0 61] [35.0 29] [40.0 9]]
-               (mt/formatted-rows [1.0 int]
-                 (mt/run-mbql-query venues
-                   {:aggregation [[:count]]
-                    :breakout    [[:field %latitude {:binning {:strategy :default}}]]}))))))
-
-    (testing "bin width"
-      (is (= [[10.0 1] [33.0 4] [34.0 57] [37.0 29] [40.0 9]]
+(deftest binning-with-different-breakout-bin-width-test
+  (mt/test-drivers (mt/normal-drivers-with-feature :binning)
+    (mt/with-temporary-setting-values [breakout-bin-width 5.0]
+      (is (= [[10.0 1] [30.0 61] [35.0 29] [40.0 9]]
              (mt/formatted-rows [1.0 int]
                (mt/run-mbql-query venues
                  {:aggregation [[:count]]
-                  :breakout    [[:field %latitude {:binning {:strategy :bin-width, :bin-width 1}}]]}))))
+                  :breakout    [[:field %latitude {:binning {:strategy :default}}]]})))))))
 
-      (testing "using a float"
-        (is (= [[10.0 1] [32.5 61] [37.5 29] [40.0 9]]
-               (mt/formatted-rows [1.0 int]
-                 (mt/run-mbql-query venues
-                   {:aggregation [[:count]]
-                    :breakout    [[:field %latitude {:binning {:strategy :bin-width, :bin-width 2.5}}]]}))))
+(deftest ^:parallel explicit-bin-width-test
+  (mt/test-drivers (mt/normal-drivers-with-feature :binning)
+    (is (= [[10.0 1] [33.0 4] [34.0 57] [37.0 29] [40.0 9]]
+           (mt/formatted-rows [1.0 int]
+             (mt/run-mbql-query venues
+               {:aggregation [[:count]]
+                :breakout    [[:field %latitude {:binning {:strategy :bin-width, :bin-width 1}}]]}))))))
 
-        (mt/with-temporary-setting-values [breakout-bin-width 1.0]
-          (is (= [[33.0 4] [34.0 57]]
-                 (mt/formatted-rows [1.0 int]
-                   (mt/run-mbql-query venues
-                     {:aggregation [[:count]]
-                      :filter      [:and
-                                    [:< $latitude 35]
-                                    [:> $latitude 20]]
-                      :breakout    [[:field %latitude {:binning {:strategy :default}}]]})))))))))
+(deftest ^:parallel explicit-float-bin-with-test
+  (mt/test-drivers (mt/normal-drivers-with-feature :binning)
+    (is (= [[10.0 1] [32.5 61] [37.5 29] [40.0 9]]
+           (mt/formatted-rows [1.0 int]
+             (mt/run-mbql-query venues
+               {:aggregation [[:count]]
+                :breakout    [[:field %latitude {:binning {:strategy :bin-width, :bin-width 2.5}}]]}))))))
 
-(deftest binning-info-test
+(deftest ^:parallel explicit-float-bin-width-different-breakout-bin-width-test
+  (mt/test-drivers (mt/normal-drivers-with-feature :binning)
+    (mt/with-temporary-setting-values [breakout-bin-width 1.0]
+      (is (= [[33.0 4] [34.0 57]]
+             (mt/formatted-rows [1.0 int]
+               (mt/run-mbql-query venues
+                 {:aggregation [[:count]]
+                  :filter      [:and
+                                [:< $latitude 35]
+                                [:> $latitude 20]]
+                  :breakout    [[:field %latitude {:binning {:strategy :default}}]]})))))))
+
+(deftest ^:parallel binning-info-test
   (mt/test-drivers (mt/normal-drivers-with-feature :binning)
     (testing "Validate binning info is returned with the binning-strategy"
       (testing "binning-strategy = default"
@@ -180,8 +188,11 @@
                       :breakout    [[:field %latitude {:binning {:strategy :default}}]]})
                    qp.test/cols
                    first
-                   (dissoc :base_type :effective_type)))))
+                   (dissoc :base_type :effective_type))))))))
 
+(deftest ^:parallel binning-info-with-explicit-strategy-test
+  (mt/test-drivers (mt/normal-drivers-with-feature :binning)
+    (testing "Validate binning info is returned with the binning-strategy"
       (testing "binning-strategy = num-bins: 5"
         (is (= (assoc (dissoc (qp.test/breakout-col :venues :latitude) :base_type :effective_type)
                       :binning_info {:min_value 7.5, :max_value 45.0, :num_bins 5, :bin_width 7.5, :binning_strategy :num-bins}
@@ -228,8 +239,10 @@
           (mt/with-native-query-testing-context query
             (is (= [[10.0 1] [32.0 4] [34.0 57] [36.0 29] [40.0 9]]
                    (mt/formatted-rows [1.0 int]
-                     (qp/process-query query))))))))
+                     (qp/process-query query))))))))))
 
+(deftest bin-nested-queries-use-default-binning-test
+  (mt/test-drivers (mt/normal-drivers-with-feature :binning :nested-queries)
     (testing "should be able to use :default binning in a nested query"
       (mt/with-temporary-setting-values [breakout-bin-width 5.0]
         (is (= [[10.0 1] [30.0 61] [35.0 29] [40.0 9]]
@@ -239,8 +252,10 @@
                     {:source-table $$venues
                      :aggregation  [[:count]]
                      :breakout     [[:field %latitude {:binning {:strategy :default}}]]}
-                    :order-by [[:asc $latitude]]}))))))
+                    :order-by [[:asc $latitude]]}))))))))
 
+(deftest bin-nested-queries-error-on-no-fingerprint-test
+  (mt/test-drivers (mt/normal-drivers-with-feature :binning :nested-queries)
     (testing "Binning is not supported when there is no fingerprint to determine boundaries"
       ;; Unfortunately our new `add-source-metadata` middleware is just too good at what it does and will pull in
       ;; metadata from the source query, so disable that for now so we can make sure the `update-binning-strategy`
@@ -255,12 +270,11 @@
                    (qp/process-query
                     (nested-venues-query card)))))))))))
 
-(deftest field-in-breakout-and-fields-test
+(deftest ^:parallel field-in-breakout-and-fields-test
   (mt/test-drivers (mt/normal-drivers)
     (testing (str "if we include a Field in both breakout and fields, does the query still work? (Normalization should "
                   "be taking care of this) (#8760)")
-      (is (= :completed
-             (:status
+      (is (=? {:status :completed}
               (mt/run-mbql-query venues
                 {:breakout [$price]
-                 :fields   [$price]})))))))
+                 :fields   [$price]}))))))

--- a/test/metabase/query_processor_test/breakout_test.clj
+++ b/test/metabase/query_processor_test/breakout_test.clj
@@ -74,10 +74,10 @@
                                      {:aggregation [[:count]]
                                       :breakout    [$category_id]
                                       :limit       5})))]
-        (is (= [(assoc (qp.test/breakout-col :venues :category_id) :remapped_to "Category ID [internal remap]")
-                (qp.test/aggregate-col :count)
-                (#'qp.add-dimension-projections/create-remapped-col "Category ID [internal remap]" (mt/format-name "category_id") :type/Text)]
-               cols))
+        (is (=? [(assoc (qp.test/breakout-col :venues :category_id) :remapped_to "Category ID [internal remap]")
+                 (qp.test/aggregate-col :count)
+                 (#'qp.add-dimension-projections/create-remapped-col "Category ID [internal remap]" (mt/format-name "category_id") :type/Text)]
+                cols))
         (is (= [[2 8 "American"]
                 [3 2 "Artisan"]
                 [4 2 "Asian"]
@@ -176,37 +176,35 @@
     (testing "Validate binning info is returned with the binning-strategy"
       (testing "binning-strategy = default"
         ;; base_type can differ slightly between drivers and it's really not important for the purposes of this test
-        (is (= (assoc (dissoc (qp.test/breakout-col :venues :latitude) :base_type :effective_type)
-                      :binning_info {:min_value 10.0, :max_value 50.0, :num_bins 4, :bin_width 10.0, :binning_strategy :bin-width}
-                      :field_ref    [:field (mt/id :venues :latitude) {:binning {:strategy  :bin-width
-                                                                                 :min-value 10.0
-                                                                                 :max-value 50.0
-                                                                                 :num-bins  4
-                                                                                 :bin-width 10.0}}])
-               (-> (mt/run-mbql-query venues
-                     {:aggregation [[:count]]
-                      :breakout    [[:field %latitude {:binning {:strategy :default}}]]})
-                   qp.test/cols
-                   first
-                   (dissoc :base_type :effective_type))))))))
+        (is (=? (assoc (qp.test/breakout-col :venues :latitude)
+                       :binning_info {:min_value 10.0, :max_value 50.0, :num_bins 4, :bin_width 10.0, :binning_strategy :bin-width}
+                       :field_ref    [:field (mt/id :venues :latitude) {:binning {:strategy  :bin-width
+                                                                                  :min-value 10.0
+                                                                                  :max-value 50.0
+                                                                                  :num-bins  4
+                                                                                  :bin-width 10.0}}])
+                (-> (mt/run-mbql-query venues
+                      {:aggregation [[:count]]
+                       :breakout    [[:field %latitude {:binning {:strategy :default}}]]})
+                    qp.test/cols
+                    first)))))))
 
 (deftest ^:parallel binning-info-with-explicit-strategy-test
   (mt/test-drivers (mt/normal-drivers-with-feature :binning)
     (testing "Validate binning info is returned with the binning-strategy"
       (testing "binning-strategy = num-bins: 5"
-        (is (= (assoc (dissoc (qp.test/breakout-col :venues :latitude) :base_type :effective_type)
-                      :binning_info {:min_value 7.5, :max_value 45.0, :num_bins 5, :bin_width 7.5, :binning_strategy :num-bins}
-                      :field_ref    [:field (mt/id :venues :latitude) {:binning {:strategy  :num-bins
-                                                                                 :min-value 7.5
-                                                                                 :max-value 45.0
-                                                                                 :num-bins  5
-                                                                                 :bin-width 7.5}}])
-               (-> (mt/run-mbql-query venues
-                     {:aggregation [[:count]]
-                      :breakout    [[:field %latitude {:binning {:strategy :num-bins, :num-bins 5}}]]})
-                   qp.test/cols
-                   first
-                   (dissoc :base_type :effective_type))))))))
+        (is (=? (assoc (qp.test/breakout-col :venues :latitude)
+                       :binning_info {:min_value 7.5, :max_value 45.0, :num_bins 5, :bin_width 7.5, :binning_strategy :num-bins}
+                       :field_ref    [:field (mt/id :venues :latitude) {:binning {:strategy  :num-bins
+                                                                                  :min-value 7.5
+                                                                                  :max-value 45.0
+                                                                                  :num-bins  5
+                                                                                  :bin-width 7.5}}])
+                (-> (mt/run-mbql-query venues
+                      {:aggregation [[:count]]
+                       :breakout    [[:field %latitude {:binning {:strategy :num-bins, :num-bins 5}}]]})
+                    qp.test/cols
+                    first)))))))
 
 (deftest binning-error-test
   (mt/test-drivers (mt/normal-drivers-with-feature :binning)

--- a/test/metabase/query_processor_test/date_time_zone_functions_test.clj
+++ b/test/metabase/query_processor_test/date_time_zone_functions_test.clj
@@ -1020,15 +1020,17 @@
       (let [diffs (fn [a-str b-str]
                     (let [units [:second :minute :hour :day :week :month :quarter :year]]
                       (->> (mt/run-mbql-query times
-                             {:filter [:and [:= a-str $a_dt_tz_text] [:= b-str $b_dt_tz_text]]
+                             {:filter      [:and [:= a-str $a_dt_tz_text] [:= b-str $b_dt_tz_text]]
                               :expressions (into {} (for [unit units]
                                                       [(name unit) [:datetime-diff $a_dt_tz $b_dt_tz unit]]))
-                              :fields (into [] (for [unit units]
-                                                 [:expression (name unit)]))})
+                              :fields      (into [] (for [unit units]
+                                                      [:expression (name unit)]))})
                            (mt/formatted-rows (repeat (count units) int))
                            first
                            (zipmap units))))]
-        (run-datetime-diff-time-zone-tests diffs))))
+        (run-datetime-diff-time-zone-tests diffs)))))
+
+(deftest datetime-diff-time-zones-athena-test
   ;; Athena needs special treatment. It supports the `timestamp with time zone` type in query expressions
   ;; but not at rest. Here we create a native query that returns a `timestamp with time zone` type and then
   ;; run another query with `datetime-diff` against it.

--- a/test/metabase/query_processor_test/explicit_joins_test.clj
+++ b/test/metabase/query_processor_test/explicit_joins_test.clj
@@ -318,7 +318,7 @@
                       :order-by [[:asc $name]]
                       :limit    3})))))))))
 
-(deftest ^:parallel join-on-field-literal-test
+(deftest join-on-field-literal-test
   (mt/test-drivers (mt/normal-drivers-with-feature :left-join)
     (testing "Can we join on a Field literal for a source query?"
       ;; Also: if you join against an *explicit* source query, do all columns for both queries come back? (Only applies
@@ -797,7 +797,7 @@
   (str/join (for [i (range length)]
               (nth charset (mod i (count charset))))))
 
-(deftest ^:parallel ^:parallel very-long-join-name-test
+(deftest ^:parallel very-long-join-name-test
   (mt/test-drivers (mt/normal-drivers-with-feature :left-join)
     (testing "Drivers should work correctly even if joins have REALLLLLLY long names (#15978)"
       (doseq [[charset-name charset] charsets
@@ -853,7 +853,7 @@
                      (mt/formatted-rows [str int int int str]
                        (qp/process-query query)))))))))))
 
-(deftest ^:parallel ^:parallel join-order-test
+(deftest ^:parallel join-order-test
   (testing "Joins should be emitted in the same order as they were specified in MBQL (#15342)"
     (mt/test-drivers (mt/normal-drivers-with-feature :left-join :inner-join)
       ;; For SQL drivers, this is only fixed for drivers using Honey SQL 2. So skip the test for ones still using Honey

--- a/test/metabase/query_processor_test/explicit_joins_test.clj
+++ b/test/metabase/query_processor_test/explicit_joins_test.clj
@@ -13,7 +13,7 @@
    [metabase.test :as mt]
    [metabase.test.data.interface :as tx]))
 
-(deftest explict-join-with-default-options-test
+(deftest ^:parallel explict-join-with-default-options-test
   (testing "Can we specify an *explicit* JOIN using the default options?"
     (let [query (mt/mbql-query venues
                   {:joins [{:source-table $$categories
@@ -41,7 +41,7 @@
                    :alias        "f"}]
        :order-by [[:asc $name]]})))
 
-(deftest left-outer-join-test
+(deftest ^:parallel left-outer-join-test
   (mt/test-drivers (mt/normal-drivers-with-feature :left-join)
     (testing "Can we supply a custom alias? Can we do a left outer join ??"
       (is (= [["Big Red"          "Bayview Brood"]
@@ -63,10 +63,10 @@
               ["Peter Pelican"    "SoMa Squadron"]
               ["Russell Crow"     "Mission Street Murder"]]
              (mt/rows
-               (qp/process-query
-                (query-with-strategy :left-join))))))))
+              (qp/process-query
+               (query-with-strategy :left-join))))))))
 
-(deftest right-outer-join-test
+(deftest ^:parallel right-outer-join-test
   (mt/test-drivers (mt/normal-drivers-with-feature :right-join)
     (testing "Can we do a right outer join?"
       ;; the [nil "Fillmore Flock"] row will either come first or last depending on the driver; the rest of the rows will
@@ -88,10 +88,10 @@
                    (conj rows [nil "Fillmore Flock"]))]
         (is (= rows
                (mt/rows
-                 (qp/process-query
-                  (query-with-strategy :right-join)))))))))
+                (qp/process-query
+                 (query-with-strategy :right-join)))))))))
 
-(deftest inner-join-test
+(deftest ^:parallel inner-join-test
   (mt/test-drivers (mt/normal-drivers-with-feature :inner-join)
     (testing "Can we do an inner join?"
       (is (= [["Big Red"        "Bayview Brood"]
@@ -107,10 +107,10 @@
               ["Peter Pelican"  "SoMa Squadron"]
               ["Russell Crow"   "Mission Street Murder"]]
              (mt/rows
-               (qp/process-query
-                (query-with-strategy :inner-join))))))))
+              (qp/process-query
+               (query-with-strategy :inner-join))))))))
 
-(deftest full-join-test
+(deftest ^:parallel full-join-test
   (mt/test-drivers (mt/normal-drivers-with-feature :full-join)
     (testing "Can we do a full join?"
       (let [rows [["Big Red"          "Bayview Brood"]
@@ -136,10 +136,10 @@
                    (conj rows [nil "Fillmore Flock"]))]
         (is (= rows
                (mt/rows
-                 (qp/process-query
-                  (query-with-strategy :full-join)))))))))
+                (qp/process-query
+                 (query-with-strategy :full-join)))))))))
 
-(deftest automatically-include-all-fields-test
+(deftest ^:parallel automatically-include-all-fields-test
   (mt/test-drivers (mt/normal-drivers-with-feature :left-join)
     (testing "Can we automatically include `:all` Fields?"
       (is (= {:columns (mapv mt/format-name ["id" "name" "flock_id" "id_2" "name_2"])
@@ -163,15 +163,15 @@
                         [1  "Russell Crow"     4   4   "Mission Street Murder"]]}
              (mt/format-rows-by [int str #(some-> % int) #(some-> % int) identity]
                (mt/rows+column-names
-                 (mt/dataset bird-flocks
-                   (mt/run-mbql-query bird
-                     {:joins    [{:source-table $$flock
-                                  :condition    [:= $flock_id &f.flock.id]
-                                  :alias        "f"
-                                  :fields       :all}]
-                      :order-by [[:asc $name]]})))))))))
+                (mt/dataset bird-flocks
+                  (mt/run-mbql-query bird
+                    {:joins    [{:source-table $$flock
+                                 :condition    [:= $flock_id &f.flock.id]
+                                 :alias        "f"
+                                 :fields       :all}]
+                     :order-by [[:asc $name]]})))))))))
 
-(deftest include-no-fields-test
+(deftest ^:parallel include-no-fields-test
   (mt/test-drivers (mt/normal-drivers-with-feature :left-join)
     (testing "Can we include no Fields (with `:none`)"
       (is (= {:columns (mapv mt/format-name ["id" "name" "flock_id"])
@@ -195,27 +195,27 @@
                         [1  "Russell Crow"     4]]}
              (mt/format-rows-by [#(some-> % int) str #(some-> % int)]
                (mt/rows+column-names
-                 (mt/dataset bird-flocks
-                   (mt/run-mbql-query bird
-                     {:joins    [{:source-table $$flock
-                                  :condition    [:= $flock_id &f.flock.id]
-                                  :alias        "f"
-                                  :fields       :none}]
-                      :order-by [[:asc $name]]})))))))))
+                (mt/dataset bird-flocks
+                  (mt/run-mbql-query bird
+                    {:joins    [{:source-table $$flock
+                                 :condition    [:= $flock_id &f.flock.id]
+                                 :alias        "f"
+                                 :fields       :none}]
+                     :order-by [[:asc $name]]})))))))))
 
-(deftest specific-fields-test
+(deftest ^:parallel specific-fields-test
   (mt/test-drivers (mt/normal-drivers-with-feature :left-join)
     (testing "Can we include a list of specific Fields?"
       (let [{:keys [columns rows]} (mt/format-rows-by [#(some-> % int) str identity]
                                      (mt/rows+column-names
-                                       (mt/dataset bird-flocks
-                                         (mt/run-mbql-query bird
-                                           {:fields   [$id $name]
-                                            :joins    [{:source-table $$flock
-                                                        :condition    [:= $flock_id &f.flock.id]
-                                                        :alias        "f"
-                                                        :fields       [&f.flock.name]}]
-                                            :order-by [[:asc $name]]}))))]
+                                      (mt/dataset bird-flocks
+                                        (mt/run-mbql-query bird
+                                          {:fields   [$id $name]
+                                           :joins    [{:source-table $$flock
+                                                       :condition    [:= $flock_id &f.flock.id]
+                                                       :alias        "f"
+                                                       :fields       [&f.flock.name]}]
+                                           :order-by [[:asc $name]]}))))]
         (is (= (mapv mt/format-name ["id" "name" "name_2"])
                columns))
         (is (= [[2  "Big Red"         "Bayview Brood"]
@@ -238,20 +238,20 @@
                 [1  "Russell Crow"    "Mission Street Murder"]]
                rows))))))
 
-(deftest all-fields-datetime-field-test
+(deftest ^:parallel all-fields-datetime-field-test
   (mt/test-drivers (mt/normal-drivers-with-feature :left-join)
     (testing (str "Do Joins with `:fields``:all` work if the joined table includes Fields that come back wrapped in"
                   " `:datetime-field` forms?")
       (let [{:keys [columns rows]} (mt/format-rows-by [int identity identity int identity int int]
                                      (mt/rows+column-names
-                                       (mt/run-mbql-query users
-                                         {:source-table $$users
-                                          :joins        [{:source-table $$checkins
-                                                          :alias        "c"
-                                                          :fields       "all"
-                                                          :condition    [:= $id &c.checkins.id]}]
-                                          :order-by     [["asc" &c.checkins.id]]
-                                          :limit        3})))]
+                                      (mt/run-mbql-query users
+                                        {:source-table $$users
+                                         :joins        [{:source-table $$checkins
+                                                         :alias        "c"
+                                                         :fields       "all"
+                                                         :condition    [:= $id &c.checkins.id]}]
+                                         :order-by     [["asc" &c.checkins.id]]
+                                         :limit        3})))]
         (is (= (mapv mt/format-name ["id" "name" "last_login" "id_2" "date" "user_id" "venue_id"])
                columns))
         ;; not sure why only Oracle seems to do this
@@ -260,7 +260,7 @@
                 [3 "Kaneonuskatew Eiran" "2014-11-06T16:15:00Z" 3 "2014-09-15T00:00:00Z" 8 56]]
                rows))))))
 
-(deftest select-*-source-query-test
+(deftest ^:parallel select-*-source-query-test
   (mt/test-drivers (disj (mt/normal-drivers-with-feature :left-join)
                          ;; mongodb doesn't support foreign keys required by this test
                          :mongo)
@@ -281,7 +281,7 @@
         (is (= [[1 5] [2 1] [3 8]]
                rows))))))
 
-(deftest join-against-nested-mbql-query-test
+(deftest ^:parallel join-against-nested-mbql-query-test
   (mt/test-drivers (mt/normal-drivers-with-feature :left-join)
     (testing "Can we join against a source nested MBQL query?"
       (is (= [[29 "20th Century Cafe" 12  37.775 -122.423 2]
@@ -318,33 +318,33 @@
                       :order-by [[:asc $name]]
                       :limit    3})))))))))
 
-(deftest join-on-field-literal-test
+(deftest ^:parallel join-on-field-literal-test
   (mt/test-drivers (mt/normal-drivers-with-feature :left-join)
     (testing "Can we join on a Field literal for a source query?"
       ;; Also: if you join against an *explicit* source query, do all columns for both queries come back? (Only applies
       ;; if you include `:source-metadata`)
-      (is (= {:rows [[1 3 46 3] [2 9 40 9] [4 7 5 7]]
+      (is (= {:rows    [[1 3 46 3] [2 9 40 9] [4 7 5 7]]
               :columns [(mt/format-name "venue_id") "count" (mt/format-name "category_id") "count_2"]}
              (mt/format-rows-by [int int int int]
                (mt/rows+column-names
-                 (mt/with-temp Card [{card-id :id} (qp.test-util/card-with-source-metadata-for-query
-                                                    (mt/mbql-query venues
-                                                      {:aggregation [[:count]]
-                                                       :breakout    [$category_id]}))]
-                   (mt/run-mbql-query checkins
-                     {:source-query {:source-table $$checkins
-                                     :aggregation  [[:count]]
-                                     :breakout     [$venue_id]}
-                      :joins
-                      [{:fields       :all
-                        :alias        "venues"
-                        :source-table (str "card__" card-id)
-                        :strategy         :inner-join
-                        :condition    [:=
-                                       [:field "count" {:base-type :type/Number}]
-                                       [:field "count" {:base-type :type/Number, :join-alias "venues"}]]}]
-                      :order-by     [[:asc $venue_id]]
-                      :limit        3})))))))))
+                (mt/with-temp Card [{card-id :id} (qp.test-util/card-with-source-metadata-for-query
+                                                   (mt/mbql-query venues
+                                                     {:aggregation [[:count]]
+                                                      :breakout    [$category_id]}))]
+                  (mt/run-mbql-query checkins
+                    {:source-query {:source-table $$checkins
+                                    :aggregation  [[:count]]
+                                    :breakout     [$venue_id]}
+                     :joins
+                     [{:fields       :all
+                       :alias        "venues"
+                       :source-table (str "card__" card-id)
+                       :strategy     :inner-join
+                       :condition    [:=
+                                      [:field "count" {:base-type :type/Number}]
+                                      [:field "count" {:base-type :type/Number, :join-alias "venues"}]]}]
+                     :order-by     [[:asc $venue_id]]
+                     :limit        3})))))))))
 
 (deftest aggregate-join-results-test
   (mt/test-drivers (mt/normal-drivers-with-feature :left-join)
@@ -399,7 +399,7 @@
                       :order-by     [[:asc $venue_id]]
                       :limit        3})))))))))
 
-(deftest joined-field-in-time-interval-test
+(deftest ^:parallel joined-field-in-time-interval-test
   (mt/test-drivers (mt/normal-drivers-with-feature :right-join)
     (testing "Should be able to use a joined field in a `:time-interval` clause"
       (is (= {:rows    []
@@ -414,7 +414,7 @@
                   :order-by [[:asc &c.checkins.id]]
                   :limit    10})))))))
 
-(deftest deduplicate-column-names-test
+(deftest ^:parallel deduplicate-column-names-test
   (mt/test-drivers (mt/normal-drivers-with-feature :left-join)
     (testing (str "Do we gracefully handle situtations where joins would produce multiple columns with the same name? "
                   "(Multiple columns named `id` in the example below)")
@@ -475,7 +475,7 @@
                     :order-by [[:asc $id]]
                     :limit    2}))))))))
 
-(deftest joined-date-filter-test
+(deftest ^:parallel joined-date-filter-test
   ;; TIMEZONE FIXME — The excluded drivers below don't have TIME types, so the `attempted-murders` dataset doesn't
   ;; currently work. We should use the closest equivalent types (e.g. `DATETIME` or `TIMESTAMP` so we can still load
   ;; the dataset and run tests using this dataset such as these, which doesn't even use the TIME type.
@@ -495,7 +495,7 @@
                              :fields       [&attempts_joined.datetime_tz]
                              :source-table $$attempts}]}))))))))
 
-(deftest expressions-referencing-joined-aggregation-expressions-test
+(deftest ^:parallel expressions-referencing-joined-aggregation-expressions-test
   (testing (mt/normal-drivers-with-feature :nested-queries :left-join :expressions)
     (testing "Should be able to use expressions against columns that come from aggregation expressions in joins"
       (is (= [[1 "Red Medicine" 4 10.065 -165.374 3 1.5 4 3 2 1]
@@ -521,7 +521,7 @@
                                  :fields       :all}]
                   :limit       3})))))))
 
-(deftest join-source-queries-with-joins-test
+(deftest ^:parallel join-source-queries-with-joins-test
   (testing "Should be able to join against source queries that themselves contain joins (#12928)"
     (mt/test-drivers (mt/normal-drivers-with-feature :nested-queries :left-join :foreign-keys)
       (mt/dataset sample-dataset
@@ -558,62 +558,37 @@
               (is (= [["Doohickey" "Affiliate" 783 "Doohickey" 3]
                       ["Doohickey" "Facebook" 816 "Doohickey" 3]]
                      (mt/formatted-rows [str str int str int]
-                       (qp/process-query query)))))))
-
-        (testing "and custom expressions (#13649) (#18086)"
-          (let [query (mt/mbql-query orders
-                        {:source-query {:source-table $$orders
-                                        :aggregation  [[:count]]
-                                        :breakout     [$product_id]
-                                        :filter       [:= $product_id 4]}
-                         :joins        [{:fields       :all
-                                         :source-query {:source-table $$orders
-                                                        :aggregation  [[:count]]
-                                                        :breakout     [$product_id]
-                                                        :filter       [:and
-                                                                       [:= $product_id 4]
-                                                                       [:> $quantity 3]]}
-                                         :condition    [:= $product_id &Q2.orders.product_id]
-                                         :alias        "Q2"}]
-                         :expressions {:expr [:/
-                                              [:field "count" {:base-type :type/BigInteger, :join-alias "Q2"}]
-                                              [:field "count" {:base-type :type/BigInteger}]]}
-                         :limit        2})]
-            (mt/with-native-query-testing-context query
-              ;; source.product_id, source.count, source.expr, source.Q2__product_id, source.Q2__count
-              (is (= [[4 89 0.46 4 41]]
-                     (mt/formatted-rows [int int 2.0 int int]
                        (qp/process-query query)))))))))))
 
-(deftest join-against-saved-question-with-sort-test
-  (mt/test-drivers (mt/normal-drivers-with-feature :nested-queries :left-join)
-    (testing "Should be able to join against a Saved Question that is sorted (#13744)"
+(deftest ^:parallel join-source-queries-with-joins-and-custom-expressions-test
+  (testing "Should be able to join against source queries that themselves contain joins and custom expressions (#13649) (#18086)"
+    (mt/test-drivers (mt/normal-drivers-with-feature :nested-queries :left-join :foreign-keys)
       (mt/dataset sample-dataset
-        (let [query (mt/mbql-query products
-                      {:joins    [{:source-query {:source-table $$products
-                                                  :aggregation  [[:count]]
-                                                  :breakout     [$category]
-                                                  :order-by     [[:asc [:aggregation 0]]]}
-                                   :alias        "Q1"
-                                   :condition    [:= $category [:field %category {:join-alias "Q1"}]]
-                                   :fields       :all}]
-                       :order-by [[:asc $id]]
-                       :limit    1})]
+        (let [query (mt/mbql-query orders
+                      {:source-query {:source-table $$orders
+                                      :aggregation  [[:count]]
+                                      :breakout     [$product_id]
+                                      :filter       [:= $product_id 4]}
+                       :joins        [{:fields       :all
+                                       :source-query {:source-table $$orders
+                                                      :aggregation  [[:count]]
+                                                      :breakout     [$product_id]
+                                                      :filter       [:and
+                                                                     [:= $product_id 4]
+                                                                     [:> $quantity 3]]}
+                                       :condition    [:= $product_id &Q2.orders.product_id]
+                                       :alias        "Q2"}]
+                       :expressions {:expr [:/
+                                            [:field "count" {:base-type :type/BigInteger, :join-alias "Q2"}]
+                                            [:field "count" {:base-type :type/BigInteger}]]}
+                       :limit        2})]
           (mt/with-native-query-testing-context query
-            (is (= [[1
-                     "1018947080336"
-                     "Rustic Paper Wallet"
-                     "Gizmo"
-                     "Swaniawski, Casper and Hilll"
-                     29.46
-                     4.6
-                     "2017-07-19T19:44:56.582Z"
-                     "Gizmo"
-                     51]]
-                   (mt/formatted-rows [int str str str str 2.0 1.0 str str int]
+            ;; source.product_id, source.count, source.expr, source.Q2__product_id, source.Q2__count
+            (is (= [[4 89 0.46 4 41]]
+                   (mt/formatted-rows [int int 2.0 int int]
                      (qp/process-query query))))))))))
 
-(deftest join-with-space-in-alias-test
+(deftest ^:parallel join-with-space-in-alias-test
   (mt/test-drivers (mt/normal-drivers-with-feature :nested-queries :left-join)
     (testing "Some drivers don't allow Table alises with spaces in them. Make sure joins still work."
       (mt/dataset sample-dataset
@@ -633,7 +608,7 @@
                      (mt/formatted-rows [int int]
                        (qp/process-query query)))))))))))
 
-(deftest joining-nested-queries-with-same-aggregation-test
+(deftest ^:parallel joining-nested-queries-with-same-aggregation-test
   (mt/test-drivers (mt/normal-drivers-with-feature :nested-queries :left-join)
     (testing (str "Should be able to join two nested queries with the same aggregation on a Field in their respective "
                   "source queries (#18512)")
@@ -671,7 +646,7 @@
                    (mt/formatted-rows [str int str int]
                      (qp/process-query query))))))))))
 
-(deftest join-against-same-table-as-source-query-source-table-test
+(deftest ^:parallel join-against-same-table-as-source-query-source-table-test
   (testing "Joining against the same table as the source table of the source query should work (#18502)"
     (mt/test-drivers (mt/normal-drivers-with-feature :nested-queries :left-join)
       (mt/dataset sample-dataset
@@ -735,7 +710,7 @@
                           ["Widget"    54 "Widget"    3109.31 "Widget"    3.15]]
                          (mt/formatted-rows [str int str 2.0 str 2.0] results))))))))))))
 
-(deftest use-correct-source-alias-for-fields-from-joins-test
+(deftest ^:parallel use-correct-source-alias-for-fields-from-joins-test
   (testing "Make sure we use the correct escaped alias for a Fields coming from joins (#20413)"
     (mt/test-drivers (mt/normal-drivers-with-feature :nested-queries :left-join)
       (mt/dataset sample-dataset
@@ -782,7 +757,7 @@
                                          int str str str str 2.0 2.0 str]
                        results))))))))))
 
-(deftest double-quotes-in-join-alias-test
+(deftest ^:parallel double-quotes-in-join-alias-test
   (mt/test-drivers (mt/normal-drivers-with-feature :left-join)
     (testing "Make sure our we handle (escape) double quotes in join aliases. Make sure we prevent SQL injection (#20307)"
       (let [expected-rows (mt/rows
@@ -822,7 +797,7 @@
   (str/join (for [i (range length)]
               (nth charset (mod i (count charset))))))
 
-(deftest ^:parallel very-long-join-name-test
+(deftest ^:parallel ^:parallel very-long-join-name-test
   (mt/test-drivers (mt/normal-drivers-with-feature :left-join)
     (testing "Drivers should work correctly even if joins have REALLLLLLY long names (#15978)"
       (doseq [[charset-name charset] charsets
@@ -853,7 +828,7 @@
                      (mt/formatted-rows [int str str str]
                        (qp/process-query query)))))))))))
 
-(deftest join-against-implicit-join-test
+(deftest ^:parallel join-against-implicit-join-test
   (testing "Should be able to explicitly join against an implicit join (#20519)"
     (mt/test-drivers (disj (mt/normal-drivers-with-feature :left-join :expressions :basic-aggregations)
                            ;; mongodb doesn't support foreign keys required by this test
@@ -878,7 +853,7 @@
                      (mt/formatted-rows [str int int int str]
                        (qp/process-query query)))))))))))
 
-(deftest ^:parallel join-order-test
+(deftest ^:parallel ^:parallel join-order-test
   (testing "Joins should be emitted in the same order as they were specified in MBQL (#15342)"
     (mt/test-drivers (mt/normal-drivers-with-feature :left-join :inner-join)
       ;; For SQL drivers, this is only fixed for drivers using Honey SQL 2. So skip the test for ones still using Honey
@@ -908,7 +883,7 @@
                        (mt/formatted-rows [int int int]
                          (qp/process-query query))))))))))))
 
-(deftest join-with-brakout-and-aggregation-expression
+(deftest ^:parallel join-with-brakout-and-aggregation-expression
   (mt/test-drivers (mt/normal-drivers-with-feature :left-join)
     (mt/dataset sample-dataset
       (let [query (mt/mbql-query orders

--- a/test/metabase/query_processor_test/expressions_test.clj
+++ b/test/metabase/query_processor_test/expressions_test.clj
@@ -12,7 +12,7 @@
    [metabase.util.date-2 :as u.date]
    [toucan2.core :as t2]))
 
-(deftest basic-test
+(deftest ^:parallel basic-test
   (mt/test-drivers (mt/normal-drivers-with-feature :expressions)
     (testing "Do a basic query including an expression"
       (is (= [[1 "Red Medicine"                 4  10.0646 -165.374 3 5.0]
@@ -26,7 +26,7 @@
                   :limit       5
                   :order-by    [[:asc $id]]})))))))
 
-(deftest floating-point-division-test
+(deftest ^:parallel floating-point-division-test
   (mt/test-drivers (mt/normal-drivers-with-feature :expressions)
     (testing "Make sure FLOATING POINT division is done"
       (is (= [[1 "Red Medicine"           4 10.0646 -165.374 3 1.5] ; 3 / 2 SHOULD BE 1.5, NOT 1 (!)
@@ -36,8 +36,10 @@
                (mt/run-mbql-query venues
                  {:expressions {:my_cool_new_field [:/ $price 2]}
                   :limit       3
-                  :order-by    [[:asc $id]]})))))
+                  :order-by    [[:asc $id]]})))))))
 
+(deftest ^:parallel floating-point-division-for-expressions-test
+  (mt/test-drivers (mt/normal-drivers-with-feature :expressions)
     (testing "Make sure FLOATING POINT division is done when dividing by expressions/fields"
       (is (= [[0.6]
               [0.5]
@@ -50,7 +52,7 @@
                   :limit       3
                   :order-by    [[:asc $id]]})))))))
 
-(deftest nested-expressions-test
+(deftest ^:parallel nested-expressions-test
   (mt/test-drivers (mt/normal-drivers-with-feature :expressions)
     (testing "Can we do NESTED EXPRESSIONS ?"
       (is (= [[1 "Red Medicine"           4 10.0646 -165.374 3 3.0]
@@ -62,7 +64,7 @@
                   :limit       3
                   :order-by    [[:asc $id]]})))))))
 
-(deftest multiple-expressions-test
+(deftest ^:parallel multiple-expressions-test
   (mt/test-drivers (mt/normal-drivers-with-feature :expressions)
     (testing "Can we have MULTIPLE EXPRESSIONS?"
       (is (= [[1 "Red Medicine"           4 10.0646 -165.374 3 2.0 4.0]
@@ -75,7 +77,7 @@
                   :limit       3
                   :order-by    [[:asc $id]]})))))))
 
-(deftest expressions-in-fields-test
+(deftest ^:parallel expressions-in-fields-test
   (mt/test-drivers (mt/normal-drivers-with-feature :expressions)
     (testing "Can we refer to expressions inside a FIELDS clause?"
       (is (= [[4] [4] [5]]
@@ -86,7 +88,7 @@
                   :limit       3
                   :order-by    [[:asc $id]]})))))))
 
-(deftest dont-return-expressions-if-fields-is-explicit-test
+(deftest ^:parallel dont-return-expressions-if-fields-is-explicit-test
   (mt/test-drivers (mt/normal-drivers-with-feature :expressions)
     ;; bigquery doesn't let you have hypthens in field, table, etc names
     (let [priceplusone (if (= driver/*driver* :bigquery-cloud-sdk) "price_plus_1" "Price + 1")
@@ -120,7 +122,7 @@
                     :order-by    [[:asc [:expression priceplusone]]]
                     :limit       3}))))))))
 
-(deftest expressions-in-order-by-test
+(deftest ^:parallel expressions-in-order-by-test
   (mt/test-drivers (mt/normal-drivers-with-feature :expressions)
     (testing "Can we refer to expressions inside an ORDER BY clause?"
       (is (= [[100 "Mohawk Bend"         46 34.0777 -118.265 2 102.0]
@@ -141,7 +143,7 @@
                   :limit       3
                   :order-by    [[:desc $price] [:desc [:expression :x]]]})))))))
 
-(deftest aggregate-breakout-expression-test
+(deftest ^:parallel aggregate-breakout-expression-test
   (mt/test-drivers (mt/normal-drivers-with-feature :expressions)
     (testing "Can we AGGREGATE + BREAKOUT by an EXPRESSION?"
       (is (= [[2 22] [4 59] [6 13] [8 6]]
@@ -151,7 +153,7 @@
                   :aggregation [[:count]]
                   :breakout    [[:expression :x]]})))))))
 
-(deftest expressions-should-include-type-test
+(deftest ^:parallel expressions-should-include-type-test
   (mt/test-drivers (mt/normal-drivers-with-feature :expressions)
     (testing "Custom aggregation expressions should include their type"
       (let [cols (mt/cols
@@ -193,7 +195,7 @@
      (mt/$ids ~'bird-count
               (calculate-bird-scarcity* ~formula ~filter-clause))))
 
-(deftest ^:parallel nulls-and-zeroes-test
+(deftest ^:parallel ^:parallel nulls-and-zeroes-test
   (mt/test-drivers (disj (mt/normal-drivers-with-feature :expressions)
                          ;; bigquery doesn't let you have hypthens in field, table, etc names
                          ;; therefore a different macro is tested in bigquery driver tests
@@ -297,7 +299,7 @@
 ;;; |                                                     JOINS                                                      |
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
-(deftest expressions+joins-test
+(deftest ^:parallel expressions+joins-test
   (mt/test-drivers (mt/normal-drivers-with-feature :expressions :left-join :date-arithmetics)
     (testing "Do calculated columns play well with joins"
       (is (= "Simcha Yan"
@@ -347,7 +349,7 @@
 ;; Make sure no part of query compilation is lazy as that won't play well with dynamic bindings.
 ;; This is not an issue limited to expressions, but using expressions is the most straightforward
 ;; way to reproducing it.
-(deftest no-lazyness-test
+(deftest ^:parallel no-lazyness-test
   ;; Sometimes Kondo thinks this is unused, depending on the state of the cache -- see comments in
   ;; [[hooks.metabase.test.data]] for more information. It's definitely used to.
   #_{:clj-kondo/ignore [:unused-binding]}
@@ -371,7 +373,7 @@
           (testing "# of app DB calls should not be some insane number"
             (is (< (call-count-fn) 20))))))))
 
-(deftest expression-with-slashes
+(deftest ^:parallel expression-with-slashes
   (mt/test-drivers (disj
                      (mt/normal-drivers-with-feature :expressions)
                      ;; Slashes documented as not allowed in BQ
@@ -387,7 +389,7 @@
                   :limit       3
                   :order-by    [[:asc $id]]})))))))
 
-(deftest expression-using-aggregation-test
+(deftest ^:parallel expression-using-aggregation-test
   (mt/test-drivers (mt/normal-drivers-with-feature :expressions)
     (testing "Can we use aggregations from previous steps in expressions (#12762)"
       (is (= [["20th Century Cafe" 2 2 0]
@@ -404,7 +406,7 @@
                                                [:field "max" {:base-type :type/Number}]
                                                [:field "min" {:base-type :type/Number}]]}})))))))
 
-(deftest expression-with-duplicate-column-name
+(deftest ^:parallel expression-with-duplicate-column-name
   (mt/test-drivers (mt/normal-drivers-with-feature :expressions)
     (testing "Can we use expression with same column name as table (#14267)"
       (mt/dataset sample-dataset
@@ -419,7 +421,7 @@
                    (mt/formatted-rows [str int]
                      (qp/process-query query))))))))))
 
-(deftest fk-field-and-duplicate-names-test
+(deftest ^:parallel fk-field-and-duplicate-names-test
   (mt/test-drivers (mt/normal-drivers-with-feature :expressions :foreign-keys)
     (testing "Expressions with `fk->` fields and duplicate names should work correctly (#14854)"
       (mt/dataset sample-dataset
@@ -436,7 +438,7 @@
                  (mt/formatted-rows [int int int 1.0 1.0 1.0 identity str int str]
                    results))))))))
 
-(deftest string-operations-from-subquery
+(deftest ^:parallel string-operations-from-subquery
   (mt/test-drivers (mt/normal-drivers-with-feature :expressions :regex)
     (testing "regex-match-first and replace work when evaluated against a subquery (#14873)"
       (mt/dataset test-data
@@ -455,7 +457,7 @@
                   ["Rush Street" "Rush" "RushStreet"]]
                  (mt/formatted-rows [str str str] results))))))))
 
-(deftest expression-name-weird-characters-test
+(deftest ^:parallel expression-name-weird-characters-test
   (mt/test-drivers (mt/normal-drivers-with-feature :expressions)
     (testing "An expression whose name contains weird characters works properly"
       (let [query (mt/mbql-query venues
@@ -467,7 +469,7 @@
                  (mt/formatted-rows [int str int 4.0 4.0 int int]
                    (qp/process-query query)))))))))
 
-(deftest join-table-on-itself-with-custom-column-test
+(deftest ^:parallel join-table-on-itself-with-custom-column-test
   (testing "Should be able to join a source query against itself using an expression (#17770)"
     (mt/test-drivers (mt/normal-drivers-with-feature :nested-queries :expressions :left-join)
       (mt/dataset sample-dataset
@@ -495,7 +497,7 @@
                    (mt/formatted-rows [str int int str int int]
                      (qp/process-query query))))))))))
 
-(deftest nested-expressions-with-existing-names-test
+(deftest ^:parallel nested-expressions-with-existing-names-test
   (testing "Expressions with the same name as existing columns should work correctly in nested queries (#21131)"
     (mt/test-drivers (mt/normal-drivers-with-feature :nested-queries :expressions)
       (mt/dataset sample-dataset

--- a/test/metabase/query_processor_test/fields_test.clj
+++ b/test/metabase/query_processor_test/fields_test.clj
@@ -5,7 +5,7 @@
    [metabase.query-processor-test :as qp.test]
    [metabase.test :as mt]))
 
-(deftest fields-clause-test
+(deftest ^:parallel fields-clause-test
   (mt/test-drivers (mt/normal-drivers)
     (testing (str "Test that we can restrict the Fields that get returned to the ones specified, and that results come "
                   "back in the order of the IDs in the `fields` clause")
@@ -23,7 +23,7 @@
                      (mt/col :venues :id)]}
              (mt/format-rows-by [str int]
                (qp.test/rows-and-cols
-                 (mt/run-mbql-query venues
-                   {:fields   [$name $id]
-                    :limit    10
-                    :order-by [[:asc $id]]}))))))))
+                (mt/run-mbql-query venues
+                  {:fields   [$name $id]
+                   :limit    10
+                   :order-by [[:asc $id]]}))))))))

--- a/test/metabase/query_processor_test/filter_test.clj
+++ b/test/metabase/query_processor_test/filter_test.clj
@@ -9,7 +9,7 @@
    [metabase.query-processor-test.timezones-test :as timezones-test]
    [metabase.test :as mt]))
 
-(deftest and-test
+(deftest ^:parallel and-test
   (mt/test-drivers (mt/normal-drivers)
     (testing ":and, :>, :>="
       (is (= [[55 "Dal Rae Restaurant"       67 33.983  -118.096 4]
@@ -20,8 +20,10 @@
              (mt/formatted-rows :venues
                (mt/run-mbql-query venues
                  {:filter   [:and [:> $id 50] [:>= $price 4]]
-                  :order-by [[:asc $id]]})))))
+                  :order-by [[:asc $id]]})))))))
 
+(deftest ^:parallel and-test-2
+  (mt/test-drivers (mt/normal-drivers)
     (testing ":and, :<, :>, :!="
       (is (= [[21 "PizzaHacker"          58 37.7441 -122.421 2]
               [23 "Taqueria Los Coyotes" 50 37.765  -122.42  2]]
@@ -30,7 +32,7 @@
                  {:filter   [:and [:< $id 24] [:> $id 20] [:!= $id 22]]
                   :order-by [[:asc $id]]})))))))
 
-(deftest filter-by-false-test
+(deftest ^:parallel filter-by-false-test
   (mt/test-drivers (mt/normal-drivers)
     (testing (str "Check that we're checking for non-nil values, not just logically true ones. There's only one place "
                   "(out of 3) that I don't like")

--- a/test/metabase/query_processor_test/order_by_test.clj
+++ b/test/metabase/query_processor_test/order_by_test.clj
@@ -6,7 +6,7 @@
    [metabase.test :as mt]
    [schema.core :as s]))
 
-(deftest order-by-test
+(deftest ^:parallel order-by-test
   (mt/test-drivers (mt/normal-drivers)
     (is (= [[1 12 375]
             [1  9 139]
@@ -26,70 +26,71 @@
                            [:asc $id]]
                 :limit    10}))))))
 
-(deftest order-by-aggregate-fields-test
+(deftest ^:parallel order-by-count-test
   (mt/test-drivers (mt/normal-drivers)
-    (testing :count
-      (is (= [[4  6]
-              [3 13]
-              [1 22]
-              [2 59]]
-             (mt/formatted-rows [int int]
+    (is (= [[4  6]
+            [3 13]
+            [1 22]
+            [2 59]]
+           (mt/formatted-rows [int int]
+             (mt/run-mbql-query venues
+               {:aggregation [[:count]]
+                :breakout    [$price]
+                :order-by    [[:asc [:aggregation 0]]]}))))))
+
+(deftest ^:parallel order-by-sum-test
+  (mt/test-drivers (mt/normal-drivers)
+    (is (= [[2 2855]
+            [1 1211]
+            [3  615]
+            [4  369]]
+           (mt/formatted-rows [int int]
+             (mt/run-mbql-query venues
+               {:aggregation [[:sum $id]]
+                :breakout    [$price]
+                :order-by    [[:desc [:aggregation 0]]]}))))))
+
+(deftest ^:parallel order-by-distinct-count-test
+  (mt/test-drivers (mt/normal-drivers)
+    (is (= [[4  6]
+            [3 13]
+            [1 22]
+            [2 59]]
+           (mt/formatted-rows [int int]
+             (mt/run-mbql-query venues
+               {:aggregation [[:distinct $id]]
+                :breakout    [$price]
+                :order-by    [[:asc [:aggregation 0]]]}))))))
+
+(deftest ^:parallel order-by-average-test
+  (mt/test-drivers (mt/normal-drivers)
+    (let [driver-floors-average? (#{:redshift :sqlserver} driver/*driver*)]
+      (is (= [[3 22.0]
+              [2 (if driver-floors-average? 28.0 28.3)]
+              [1 (if driver-floors-average? 32.0 32.8)]
+              [4 (if driver-floors-average? 53.0 53.5)]]
+             (mt/formatted-rows [int 1.0]
                (mt/run-mbql-query venues
-                 {:aggregation [[:count]]
+                 {:aggregation [[:avg $category_id]]
                   :breakout    [$price]
-                  :order-by    [[:asc [:aggregation 0]]]})))))
+                  :order-by    [[:asc [:aggregation 0]]]})))))))
 
-    (testing :sum
-      (is (= [[2 2855]
-              [1 1211]
-              [3  615]
-              [4  369]]
-             (mt/formatted-rows [int int]
-               (mt/run-mbql-query venues
-                 {:aggregation [[:sum $id]]
-                  :breakout    [$price]
-                  :order-by    [[:desc [:aggregation 0]]]})))))
-
-
-    (testing :distinct
-      (is (= [[4  6]
-              [3 13]
-              [1 22]
-              [2 59]]
-             (mt/formatted-rows [int int]
-               (mt/run-mbql-query venues
-                 {:aggregation [[:distinct $id]]
-                  :breakout    [$price]
-                  :order-by    [[:asc [:aggregation 0]]]})))))
-
-    (testing :avg
-      (let [driver-floors-average? (#{:redshift :sqlserver} driver/*driver*)]
-        (is (= [[3 22.0]
-                [2 (if driver-floors-average? 28.0 28.3)]
-                [1 (if driver-floors-average? 32.0 32.8)]
-                [4 (if driver-floors-average? 53.0 53.5)]]
-               (mt/formatted-rows [int 1.0]
-                 (mt/run-mbql-query venues
-                   {:aggregation [[:avg $category_id]]
-                    :breakout    [$price]
-                    :order-by    [[:asc [:aggregation 0]]]})))))))
-
-  (testing :stddev
-    (mt/test-drivers (mt/normal-drivers-with-feature :standard-deviation-aggregations)
-      ;; standard deviation calculations are always NOT EXACT (normal behavior) so just test that the results are in a
-      ;; certain RANGE.
-      (letfn [(row-schema [price lower-bound upper-bound]
-                (s/one [(s/one (s/eq price)
-                               (format "price = %d" price))
-                        (s/one (s/pred #(< lower-bound % upper-bound))
-                               (format "%.1f < value < %.1f" lower-bound upper-bound))]
-                       "row"))]
-        (is (schema= [(row-schema 3 23.0 27.0)
-                      (row-schema 1 22.0 26.0)
-                      (row-schema 2 19.0 23.0)
-                      (row-schema 4 12.0 16.0)]
-                     (mt/formatted-rows [int 1.0]
-                       (mt/run-mbql-query venues
-                         {:aggregation [[:stddev $category_id]]
-                          :breakout    [$price]
-                          :order-by    [[:desc [:aggregation 0]]]}))))))))
+(deftest ^:parallel order-by-standard-deviation-test
+  (mt/test-drivers (mt/normal-drivers-with-feature :standard-deviation-aggregations)
+    ;; standard deviation calculations are always NOT EXACT (normal behavior) so just test that the results are in a
+    ;; certain RANGE.
+    (letfn [(row-schema [price lower-bound upper-bound]
+              (s/one [(s/one (s/eq price)
+                             (format "price = %d" price))
+                      (s/one (s/pred #(< lower-bound % upper-bound))
+                             (format "%.1f < value < %.1f" lower-bound upper-bound))]
+                     "row"))]
+      (is (schema= [(row-schema 3 23.0 27.0)
+                    (row-schema 1 22.0 26.0)
+                    (row-schema 2 19.0 23.0)
+                    (row-schema 4 12.0 16.0)]
+                   (mt/formatted-rows [int 1.0]
+                     (mt/run-mbql-query venues
+                       {:aggregation [[:stddev $category_id]]
+                        :breakout    [$price]
+                        :order-by    [[:desc [:aggregation 0]]]})))))))

--- a/test/metabase/query_processor_test/page_test.clj
+++ b/test/metabase/query_processor_test/page_test.clj
@@ -5,7 +5,7 @@
    [metabase.query-processor :as qp]
    [metabase.test :as mt]))
 
-(deftest page-test
+(deftest ^:parallel page-test
   (mt/test-drivers (mt/normal-drivers)
     (testing "Test that we can get \"pages\" of results."
       (letfn [(page-is [expected page-num]


### PR DESCRIPTION
1. Split lots of QP tests that had several distinct test cases from one single `deftest` form into several smaller `deftest` forms. This is easier to debug and reason about. I think unless there is some compelling reason to do so (i.e., lots of shared state), we should generally try to error towards having several smaller `deftest` forms rather than a few huge ones
2. Mark a ton of QP tests that are completely pure `^:parallel`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/29940)
<!-- Reviewable:end -->
