### PR TITLE
Serve webpack bundles from localhost only

### DIFF
--- a/package.json
+++ b/package.json
@@ -298,7 +298,7 @@
     "test-timezones": "yarn && ./frontend/test/__runner__/run_timezone_tests",
     "build:js": "yarn && webpack --bail",
     "build-watch:js": "yarn && webpack --watch",
-    "build-hot:js": "yarn && NODE_OPTIONS=--max-old-space-size=8096 WEBPACK_BUNDLE=hot webpack serve",
+    "build-hot:js": "yarn && NODE_OPTIONS=--max-old-space-size=8096 WEBPACK_BUNDLE=hot webpack serve --host 0.0.0.0",
     "build:cljs": "yarn && rm -rf frontend/src/cljs_release/* && shadow-cljs release app",
     "build-quick:cljs": "yarn && rm -rf frontend/src/cljs/* && shadow-cljs compile app",
     "build-watch:cljs": "yarn && shadow-cljs watch app",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -13,7 +13,6 @@ const WebpackNotifierPlugin = require("webpack-notifier");
 const ReactRefreshPlugin = require("@pmmmwh/react-refresh-webpack-plugin");
 
 const fs = require("fs");
-const os = require("os");
 
 const ASSETS_PATH = __dirname + "/resources/frontend_client/app/assets";
 const FONTS_PATH = __dirname + "/resources/frontend_client/app/fonts";
@@ -232,17 +231,12 @@ const config = (module.exports = {
 });
 
 if (WEBPACK_BUNDLE === "hot") {
-  const localIpAddress =
-    getLocalIpAddress("IPv4") || getLocalIpAddress("IPv6") || "0.0.0.0";
-
-  const webpackPort = 8080;
-  const webpackHost = `http://${localIpAddress}:${webpackPort}`;
   config.target = "web";
   // suffixing with ".hot" allows us to run both `yarn run build-hot` and `yarn run test` or `yarn run test-watch` simultaneously
   config.output.filename = "[name].hot.bundle.js?[contenthash]";
 
   // point the publicPath (inlined in index.html by HtmlWebpackPlugin) to the hot-reloading server
-  config.output.publicPath = webpackHost + "/" + config.output.publicPath;
+  config.output.publicPath = "http://localhost:8080/" + config.output.publicPath;
 
   config.module.rules.unshift({
     test: /\.(tsx?|jsx?)$/,
@@ -259,9 +253,6 @@ if (WEBPACK_BUNDLE === "hot") {
   });
 
   config.devServer = {
-    host: "local-ip",
-    port: webpackPort,
-    allowedHosts: "auto",
     hot: true,
     client: {
       progress: false,
@@ -337,19 +328,4 @@ if (WEBPACK_BUNDLE !== "production") {
   );
 
   config.devtool = "source-map";
-}
-
-function getLocalIpAddress(ipFamily) {
-  const networkInterfaces = os.networkInterfaces();
-  const interfaces = Object.keys(networkInterfaces)
-    .sort()
-    .map(iface => networkInterfaces[iface])
-    .reduce((interfaces, iface) => interfaces.concat(iface));
-
-  const externalInterfaces = interfaces.filter(iface => !iface.internal);
-
-  const { address } = externalInterfaces
-    .filter(({ family }) => family === ipFamily)
-    .shift();
-  return address;
 }


### PR DESCRIPTION
This is essentially a revert of PR #24454. It turns out that trying to be clever on the local IP address (to bind webpack server to) is fraught with perils, e.g. when Bluetooth devices are attached (see #27601), the machine is also connected via VPN (WireGuard, Tailscale, etc).

If anyone wants to manually bind another address, unfortunately the workaround is to use something like iptables, a reverse proxy, etc.

### Before this PR

Local development is broken if the local machine has more than one bound IP addresses:

### After this PR

Local development is guaranteed to work, due to the hardcoded `localhost`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/29969)
<!-- Reviewable:end -->
