### PR TITLE
Check collection write perms on CSV upload

### DIFF
--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -994,6 +994,7 @@ saved later when it is ready."
   [collection_id filename csv-file]
   (when (not (setting/get :uploads-enabled))
     (throw (Exception. "Uploads are not enabled.")))
+  (collection/check-write-perms-for-collection collection_id)
   (let [db-id             (get-setting-or-throw! :uploads-database-id)
         database          (or (t2/select-one Database :id db-id)
                               (throw (Exception. (tru "The uploads database does not exist."))))

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -2615,6 +2615,17 @@
                    java.lang.Exception
                    #"^Uploads are not supported on Postgres databases\."
                    (upload!))))))
+       (testing "User must have write permissions on the collection"
+          (mt/with-non-admin-groups-no-root-collection-perms
+            (mt/with-temporary-setting-values [uploads-enabled      true
+                                               uploads-database-id  db-id
+                                               uploads-schema-name  "public"
+                                               uploads-table-prefix "uploaded_magic_"]
+              (mt/with-current-user (mt/user->id :lucky)
+                (is (thrown-with-msg?
+                     java.lang.Exception
+                     #"^You do not have curate permissions for this Collection\.$"
+                     (upload!)))))))
         (testing "Happy path"
           ;; create schema in the db
           (let [details (mt/dbdef->connection-details driver/*driver* :db {:database-name (:name (mt/db))})]


### PR DESCRIPTION
This PR adds checking that the user has write perms for the collection. Uses the same check as adding a question to a collection.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/29976)
<!-- Reviewable:end -->
