### PR TITLE
Check actions are enabled on the CSV upload request

### DIFF
--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -8,6 +8,7 @@
    [clojure.walk :as walk]
    [compojure.core :refer [DELETE GET POST PUT]]
    [medley.core :as m]
+   [metabase.actions :as actions]
    [metabase.api.common :as api]
    [metabase.api.common.validation :as validation]
    [metabase.api.dataset :as api.dataset]
@@ -998,6 +999,9 @@ saved later when it is ready."
   (let [db-id             (get-setting-or-throw! :uploads-database-id)
         database          (or (t2/select-one Database :id db-id)
                               (throw (Exception. (tru "The uploads database does not exist."))))
+        _                 (try (actions/check-actions-enabled-for-database! database)
+                               (catch Exception _
+                                 (throw (Exception. (tru "The uploads database does not have actions enabled.")))))
         schema-name       (get-setting-or-throw! :uploads-schema-name)
         filename-prefix   (or (second (re-matches #"(.*)\.csv$" filename))
                               filename)


### PR DESCRIPTION
This PR checks actions are enabled and supported on the uploads database.

I did it this way to avoid having to enforce a constraint of `database-enable-actions=false => uploads-enabled=false`, which would require a migration of `database-enable-actions` away from a defsetting.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/29978)
<!-- Reviewable:end -->
