### PR TITLE
Remove CSV upload support for redshift

### DIFF
--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -57,10 +57,6 @@
 ;;; |                                             metabase.driver impls                                              |
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
-(defmethod driver/database-supports? [:postgres :uploads]
-  [_driver _feat _db]
-  true)
-
 (defmethod driver/display-name :postgres [_] "PostgreSQL")
 
 (defmethod driver/database-supports? [:postgres :datetime-diff]
@@ -83,7 +79,7 @@
   [_driver _feat _db]
   true)
 
-(doseq [feature [:actions :actions/custom]]
+(doseq [feature [:actions :actions/custom :uploads]]
   (defmethod driver/database-supports? [:postgres feature]
     [driver _feat _db]
     ;; only supported for Postgres for right now. Not supported for child drivers like Redshift or whatever.


### PR DESCRIPTION
I accidentally added support for redshift when I added support for postgres. This PR removes it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/29981)
<!-- Reviewable:end -->
