### PR TITLE
Remove excess e2e tests helper

### DIFF
--- a/e2e/support/helpers/e2e-misc-helpers.js
+++ b/e2e/support/helpers/e2e-misc-helpers.js
@@ -286,14 +286,3 @@ export function visitPublicDashboard(id, { params = {} } = {}) {
     },
   );
 }
-
-/**
- * Returns a matcher function to find text content that is broken up by multiple elements
- *
- * @param {string} textToFind
- * @example
- * cy.findByText(getBrokenUpTextMatcher("my text with a styled word"))
- */
-export function getBrokenUpTextMatcher(textToFind) {
-  return (content, element) => element?.textContent === textToFind;
-}

--- a/e2e/test/scenarios/custom-column/cc-help-text.cy.spec.js
+++ b/e2e/test/scenarios/custom-column/cc-help-text.cy.spec.js
@@ -2,7 +2,6 @@ import {
   enterCustomColumnDetails,
   restore,
   openProductsTable,
-  getBrokenUpTextMatcher,
 } from "e2e/support/helpers";
 
 describe("scenarios > question > custom column > help text", () => {
@@ -16,12 +15,12 @@ describe("scenarios > question > custom column > help text", () => {
 
   it("should appear while inside a function", () => {
     enterCustomColumnDetails({ formula: "Lower(" });
-    cy.findByText(getBrokenUpTextMatcher("lower(text)"));
+    cy.contains("lower(text)");
   });
 
   it("should appear after a field reference", () => {
     enterCustomColumnDetails({ formula: "Lower([Category]" });
-    cy.findByText(getBrokenUpTextMatcher("lower(text)"));
+    cy.contains("lower(text)");
   });
 
   it("should not appear while outside a function", () => {

--- a/e2e/test/scenarios/custom-column/cc-typing-suggestion.cy.spec.js
+++ b/e2e/test/scenarios/custom-column/cc-typing-suggestion.cy.spec.js
@@ -1,6 +1,5 @@
 import {
   enterCustomColumnDetails,
-  getBrokenUpTextMatcher,
   openProductsTable,
   restore,
 } from "e2e/support/helpers";
@@ -53,7 +52,7 @@ describe("scenarios > question > custom column > typing suggestion", () => {
   it("should show expression function helper if a proper function is typed", () => {
     enterCustomColumnDetails({ formula: "lower(" });
 
-    cy.findByText(getBrokenUpTextMatcher("lower(text)")).should("be.visible");
+    cy.contains("lower(text)");
     cy.findByText("Returns the string of text in all lower case.").should(
       "be.visible",
     );


### PR DESCRIPTION
### Description

@nemanjaglumac gave me a hint that `cy.contains` has the same functionality included in it as our custom `getBrokenUpTextMatcher` helper, so I refactored tests that use it in favor of `getBrokenUpTextMatcher`

### Checklist

- [x] E2e tests should pass

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/29982)
<!-- Reviewable:end -->
