### PR TITLE
CSV upload: fix stack overflow in detect-schema

### DIFF
--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -72,8 +72,7 @@
 (defn- coalesce-types
   [types-so-far new-types]
   (->> (map vector types-so-far new-types)
-       (map (partial apply coalesce))
-       vec))
+       (mapv (partial apply coalesce))))
 
 (defn- pad
   "Lengthen `values` until it is of length `n` by filling it with nils."

--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -72,7 +72,8 @@
 (defn- coalesce-types
   [types-so-far new-types]
   (->> (map vector types-so-far new-types)
-       (map (partial apply coalesce))))
+       (map (partial apply coalesce))
+       vec))
 
 (defn- pad
   "Lengthen `values` until it is of length `n` by filling it with nils."


### PR DESCRIPTION
`detect-schema` runs out of stack on large files. This fixes by realising the intermediate collection. Tested with Ryan's [games.csv](https://metaboat.slack.com/files/U5A85JL4V/F052LVD5PJR/games.csv).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/29983)
<!-- Reviewable:end -->
