### PR TITLE
Convert JS direction string to a keyword for CLJC

### DIFF
--- a/src/metabase/lib/js.cljs
+++ b/src/metabase/lib/js.cljs
@@ -130,7 +130,7 @@
    (order-by a-query -1 x direction))
 
   ([a-query stage-number x direction]
-   (lib.order-by/order-by a-query stage-number x (js->clj direction))))
+   (lib.order-by/order-by a-query stage-number x (keyword direction))))
 
 (defn ^:export order-bys
   "Get the order-by clauses (as an array of opaque objects) in `a-query` at a given `stage-number`.


### PR DESCRIPTION
In JS, directions are encoded as string, in CLJC as keywords. Fix the conversion.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/29994)
<!-- Reviewable:end -->
