### PR TITLE
`clj -M:run` should not specify `:dev` run mode

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -262,8 +262,7 @@
   ;; clojure -M:run:ee (include EE code)
   :run
   {:main-opts ["-m" "metabase.bootstrap"]
-   :jvm-opts  ["-Dmb.run.mode=dev"
-               "-Djava.awt.headless=true"                   ; prevent Java icon from randomly popping up in macOS dock
+   :jvm-opts  ["-Djava.awt.headless=true"                   ; prevent Java icon from randomly popping up in macOS dock
                "-Dmb.jetty.port=3000"]}
 
   ;; alias for CI-specific options.


### PR DESCRIPTION
`:dev` run mode implies the availability of `:dev` classpath stuff (the `dev` and `test` directories), don't specify a run mode if you're just running with `clj -M:run`. This will default to `:prod` run mode. `clj -M:dev:run` still specifies the Java option, so it will still run in `:dev` mode.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30004)
<!-- Reviewable:end -->
