### PR TITLE
Reload collection data after CSV upload

### DIFF
--- a/frontend/src/metabase/redux/uploads.ts
+++ b/frontend/src/metabase/redux/uploads.ts
@@ -2,9 +2,12 @@ import { assocIn, updateIn } from "icepick";
 import { t } from "ttag";
 
 import { CardApi } from "metabase/services";
-import { Dispatch, GetState, State } from "metabase-types/store";
-import { CollectionId } from "metabase-types/api";
-import { FileUploadState } from "metabase-types/store/upload";
+import Collections from "metabase/entities/collections";
+
+import type { Dispatch, GetState, State } from "metabase-types/store";
+import type { CollectionId } from "metabase-types/api";
+import type { FileUploadState } from "metabase-types/store/upload";
+
 import {
   createAction,
   createThunkAction,
@@ -77,6 +80,8 @@ export const uploadFile = createThunkAction(
           modelId: response.model_id,
         }),
       );
+
+      dispatch(Collections.actions.invalidateLists());
     },
 );
 


### PR DESCRIPTION
### Description

After successfully CSV upload, this refreshes collection content so newly-created model data is visible without a page refresh.

![live-reload-csv](https://user-images.githubusercontent.com/30528226/231284648-bffec0be-6301-41cb-9993-6eeb4416fe12.gif)

### How to verify

**CSV Setup:**
1. pull this branch and restart your backend
2. make sure you have at least one actions-enabled postgres DB
3. in admin settings, enable uploads and identfy an existing schema and add an upload prefix setting

**Testing this PR:**
5. drag a csv into a collection
6. after successful upload, you should see the newly-created model 🥳 

### Checklist

TODO: update e2e tests in https://github.com/metabase/metabase/pull/30005 when it merges

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30009)
<!-- Reviewable:end -->
