### PR TITLE
Clear CSV upload state after a while

### DIFF
--- a/frontend/src/metabase/redux/uploads.ts
+++ b/frontend/src/metabase/redux/uploads.ts
@@ -1,4 +1,4 @@
-import { assocIn, updateIn } from "icepick";
+import { assocIn, dissocIn, updateIn } from "icepick";
 import { t } from "ttag";
 
 import { CardApi } from "metabase/services";
@@ -15,19 +15,20 @@ import {
 } from "metabase/lib/redux";
 
 export const UPLOAD_FILE_TO_COLLECTION = "metabase/collection/UPLOAD_FILE";
-
 const UPLOAD_FILE_TO_COLLECTION_START = "metabase/collection/UPLOAD_FILE_START";
-
 const UPLOAD_FILE_TO_COLLECTION_END = "metabase/collection/UPLOAD_FILE_END";
-
 const UPLOAD_FILE_TO_COLLECTION_ERROR = "metabase/collection/UPLOAD_FILE_ERROR";
+const UPLOAD_FILE_TO_COLLECTION_CLEAR = "metabase/collection/UPLOAD_FILE_CLEAR";
 
 const MAX_UPLOAD_SIZE = 200 * 1024 * 1024; // 200MB
 const MAX_UPLOAD_STRING = "200MB";
 
+const CLEAR_AFTER_MS = 5000;
+
 const uploadStart = createAction(UPLOAD_FILE_TO_COLLECTION_START);
 const uploadEnd = createAction(UPLOAD_FILE_TO_COLLECTION_END);
 const uploadError = createAction(UPLOAD_FILE_TO_COLLECTION_ERROR);
+const clearUpload = createAction(UPLOAD_FILE_TO_COLLECTION_CLEAR);
 
 export const getAllUploads = (state: State) =>
   Object.keys(state.upload).map(key => state.upload[key]);
@@ -36,8 +37,7 @@ export const uploadFile = createThunkAction(
   UPLOAD_FILE_TO_COLLECTION,
   (file: File, collectionId: CollectionId) =>
     async (dispatch: Dispatch, getState: GetState) => {
-      const uploads = getAllUploads(getState());
-      const id = uploads.length;
+      const id = Date.now();
 
       if (file.size > MAX_UPLOAD_SIZE) {
         uploadError({
@@ -70,18 +70,20 @@ export const uploadFile = createThunkAction(
         },
       );
 
-      if (!response) {
-        return;
+      if (response) {
+        dispatch(
+          uploadEnd({
+            id,
+            modelId: response.model_id,
+          }),
+        );
+
+        dispatch(Collections.actions.invalidateLists());
       }
 
-      dispatch(
-        uploadEnd({
-          id,
-          modelId: response.model_id,
-        }),
-      );
-
-      dispatch(Collections.actions.invalidateLists());
+      setTimeout(() => {
+        dispatch(clearUpload({ id }));
+      }, CLEAR_AFTER_MS);
     },
 );
 
@@ -122,6 +124,9 @@ const upload = handleActions<
           ...payload,
           status: "error",
         })),
+    },
+    [UPLOAD_FILE_TO_COLLECTION_CLEAR]: {
+      next: (state, { payload: { id } }) => dissocIn(state, [id]),
     },
   },
   {},


### PR DESCRIPTION
### Description

Bugfix: If you uploaded a CSV that errored, the upload status indicator would always have an error title. This is caused by the fact that we set the title to an error state if any file is in an errored status. Because we kept that upload data in state indefinitely, the upload indicator would permanently show "Error uploading your file" because we never cleared out that upload state data.  This clears the upload data after completion so that the error (or success) state doesn't persist indefinitely.

state | demo
--- | ---
before | ![always-error](https://user-images.githubusercontent.com/30528226/231293928-c67d43a6-e647-413e-8f22-5f41e0482ed2.gif)
after | ![upload-status](https://user-images.githubusercontent.com/30528226/231293964-fdf3d3a2-801f-44fc-9ec8-74324dc87565.gif)

### How to verify

Describe the steps to verify that the changes are working as expected.

CSV Setup:
1. pull this branch and restart your backend
1. make sure you have at least one actions-enabled postgres DB
1. in admin settings, enable uploads and identfy an existing schema and add an upload prefix setting

Testing this PR:
4. drag an invalid csv into a collection, see an error
5. drag a valid csv into a collection
6. when the error CSV goes away, the status toast should update to show a uploading or success message

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30014)
<!-- Reviewable:end -->
