### PR TITLE
MLv2 Column grouping utilities

### DIFF
--- a/frontend/src/metabase-lib/metadata.ts
+++ b/frontend/src/metabase-lib/metadata.ts
@@ -1,5 +1,5 @@
 import * as ML from "cljs/metabase.lib.js";
-import * as ML_ColumnGroup from "cljs/metabase.lib.column-group";
+import * as ML_ColumnGroup from "cljs/metabase.lib.column_group";
 import * as ML_MetadataCalculation from "cljs/metabase.lib.metadata.calculation";
 import type { DatabaseId } from "metabase-types/api";
 import type Metadata from "./metadata/Metadata";

--- a/frontend/src/metabase-lib/metadata.ts
+++ b/frontend/src/metabase-lib/metadata.ts
@@ -1,8 +1,15 @@
 import * as ML from "cljs/metabase.lib.js";
+import * as ML_ColumnGroup from "cljs/metabase.lib.column-group";
 import * as ML_MetadataCalculation from "cljs/metabase.lib.metadata.calculation";
 import type { DatabaseId } from "metabase-types/api";
 import type Metadata from "./metadata/Metadata";
-import type { Clause, MetadataProvider, Query, ColumnMetadata } from "./types";
+import type {
+  Clause,
+  MetadataProvider,
+  Query,
+  ColumnMetadata,
+  ColumnGroup,
+} from "./types";
 
 export function metadataProvider(
   databaseId: DatabaseId,
@@ -28,7 +35,15 @@ export type DisplayInfo = {
 // should always have display_name... see :metabase.lib.metadata.calculation/display-info schema
 export function displayInfo(
   query: Query,
-  x: Clause | ColumnMetadata,
+  x: Clause | ColumnMetadata | ColumnGroup,
 ): DisplayInfo {
   return ML.display_info(query, x);
+}
+
+export function groupColumns(columns: ColumnMetadata[]): ColumnGroup {
+  return ML_ColumnGroup.group_columns(columns);
+}
+
+export function getColumnsGroupColumns(group: ColumnGroup): ColumnMetadata[] {
+  return ML_ColumnGroup.columns_group_columns(group);
 }

--- a/frontend/src/metabase-lib/types.ts
+++ b/frontend/src/metabase-lib/types.ts
@@ -17,3 +17,6 @@ export type Clause = OrderByClause;
 
 declare const ColumnMetadata: unique symbol;
 export type ColumnMetadata = unknown & { _opaque: typeof ColumnMetadata };
+
+declare const ColumnGroup: unique symbol;
+export type ColumnGroup = unknown & { _opaque: typeof ColumnGroup };

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -16,6 +16,7 @@
                 :compiler-options {:reader-features #{:cljs-dev}}}
    :compiler-options {:reader-features #{:cljs-release}}
    :entries    [metabase.domain-entities.queries.util
+                metabase.lib.column-group
                 metabase.lib.js
                 metabase.lib.limit
                 metabase.mbql.js

--- a/src/metabase/lib/column_group.cljc
+++ b/src/metabase/lib/column_group.cljc
@@ -1,0 +1,107 @@
+(ns metabase.lib.column-group
+  (:require
+   [metabase.lib.join :as lib.join]
+   [metabase.lib.metadata :as lib.metadata]
+   [metabase.lib.metadata.calculation :as lib.metadata.calculation]
+   [metabase.lib.schema.common :as lib.schema.common]
+   [metabase.lib.schema.id :as lib.schema.id]
+   [metabase.lib.util :as lib.util]
+   [metabase.util.malli :as mu]))
+
+(def ^:private GroupType
+  [:enum
+   ;; the `:group-type/main` group includes all the columns from the source Table/Card/previous stage as well as ones
+   ;; added in this stage.
+   :group-type/main
+   ;; the other two group types are for various types of joins.
+   :group-type/join.explicit
+   :group-type/join.implicit])
+
+(def ^:private ColumnGroup
+  "Schema for the metadata returned by [[group-columns]], and accepted by [[columns-group-columns]]."
+  [:and
+   [:map
+    [:lib/type    [:= :metadata/column-group]]
+    [::group-type GroupType]
+    [::columns    [:sequential lib.metadata/ColumnMetadata]]]
+   [:multi
+    {:dispatch ::group-type}
+    [:group-type/main
+     any?]
+    [:group-type/join.explicit
+     [:map
+      [:join-alias [:ref ::lib.schema.common/non-blank-string]]]]
+    [:group-type/join.implicit
+     [:map
+      [:table-id [:ref ::lib.schema.id/table]]]]]])
+
+(defmethod lib.metadata.calculation/metadata-method :metadata/column-group
+  [_query _stage-number column-group]
+  column-group)
+
+(defmethod lib.metadata.calculation/display-info-method :metadata/column-group
+  [query stage-number column-group]
+  (merge
+   {:name "group", :display_name "<Group>"}
+   (case (::group-type column-group)
+     :group-type/main
+     (let [stage (lib.util/query-stage query stage-number)]
+       (when-let [table-id (:source-table stage)]
+         (when-let [table (lib.metadata/table query table-id)]
+           (lib.metadata.calculation/display-info query stage-number table))))
+
+     :group-type/join.explicit
+     (let [join-alias (:join-alias column-group)]
+       (when-let [join (lib.join/resolve-join query stage-number join-alias)]
+         (lib.metadata.calculation/display-info query stage-number join)))
+
+     :group-type/join.implicit
+     (let [table-id (:table-id column-group)]
+       (when-let [table (lib.metadata/table query table-id)]
+         (lib.metadata.calculation/display-info query stage-number table))))))
+
+(mu/defn ^:private column-group-info :- [:map [::group-type GroupType]]
+  "The value we should use to `group-by` inside [[group-columns]]."
+  [{source :lib/source, :as column-metadata} :- lib.metadata/ColumnMetadata]
+  (case source
+    :source/implicitly-joinable
+    {::group-type :group-type/join.implicit, :table-id (:table_id column-metadata)}
+
+    :source/joins
+    {::group-type :group-type/join.explicit, :join-alias (lib.join/current-join-alias column-metadata)}
+
+    {::group-type :group-type/main}))
+
+(mu/defn group-columns :- [:sequential ColumnGroup]
+  "Given a group of columns returned by a function like [[metabase.lib.order-by/orderable-columns]], group the columns
+  by Table or equivalent (e.g. Saved Question) so that they're in an appropriate shape for showing in the Query
+  Builder. e.g a sequence of columns like
+
+    [venues.id
+     venues.name
+     venues.category-id
+     ;; implicitly joinable
+     categories.id
+     categories.name]
+
+  would get grouped into groups like
+
+    [{::columns [venues.id
+                 venues.name
+                 venues.category-id]}
+     {::columns [categories.id
+                 categories.name]}]
+
+  Groups have the type `:metadata/column-group` and can be passed directly
+  to [[metabase.lib.metadata.calculation/display-info]]."
+  [column-metadatas :- [:sequential lib.metadata/ColumnMetadata]]
+  (mapv (fn [[group-info columns]]
+          (assoc group-info
+                 :lib/type :metadata/column-group
+                 ::columns columns))
+        (group-by column-group-info column-metadatas)))
+
+(mu/defn columns-group-columns :- [:sequential lib.metadata/ColumnMetadata]
+  "Get the columns associated with a column group"
+  [column-group :- ColumnGroup]
+  (::columns column-group))

--- a/src/metabase/lib/column_group.cljc
+++ b/src/metabase/lib/column_group.cljc
@@ -45,20 +45,29 @@
    {:name "group", :display_name "<Group>"}
    (case (::group-type column-group)
      :group-type/main
-     (let [stage (lib.util/query-stage query stage-number)]
-       (when-let [table-id (:source-table stage)]
-         (when-let [table (lib.metadata/table query table-id)]
-           (lib.metadata.calculation/display-info query stage-number table))))
+     (merge
+      (let [stage (lib.util/query-stage query stage-number)]
+        (when-let [table-id (:source-table stage)]
+          (when-let [table (lib.metadata/table query table-id)]
+            (lib.metadata.calculation/display-info query stage-number table))))
+      {:is_from_join           false
+       :is_implicitly_joinable false})
 
      :group-type/join.explicit
-     (let [join-alias (:join-alias column-group)]
-       (when-let [join (lib.join/resolve-join query stage-number join-alias)]
-         (lib.metadata.calculation/display-info query stage-number join)))
+     (merge
+      (let [join-alias (:join-alias column-group)]
+        (when-let [join (lib.join/resolve-join query stage-number join-alias)]
+          (lib.metadata.calculation/display-info query stage-number join)))
+      {:is_from_join           true
+       :is_implicitly_joinable false})
 
      :group-type/join.implicit
-     (let [table-id (:table-id column-group)]
-       (when-let [table (lib.metadata/table query table-id)]
-         (lib.metadata.calculation/display-info query stage-number table))))))
+     (merge
+      (let [table-id (:table-id column-group)]
+        (when-let [table (lib.metadata/table query table-id)]
+          (lib.metadata.calculation/display-info query stage-number table)))
+      {:is_from_join           false
+       :is_implicitly_joinable true}))))
 
 (mu/defn ^:private column-group-info :- [:map [::group-type GroupType]]
   "The value we should use to `group-by` inside [[group-columns]]."
@@ -72,7 +81,7 @@
 
     {::group-type :group-type/main}))
 
-(mu/defn group-columns :- [:sequential ColumnGroup]
+(mu/defn ^:export group-columns :- [:sequential ColumnGroup]
   "Given a group of columns returned by a function like [[metabase.lib.order-by/orderable-columns]], group the columns
   by Table or equivalent (e.g. Saved Question) so that they're in an appropriate shape for showing in the Query
   Builder. e.g a sequence of columns like
@@ -101,7 +110,7 @@
                  ::columns columns))
         (group-by column-group-info column-metadatas)))
 
-(mu/defn columns-group-columns :- [:sequential lib.metadata/ColumnMetadata]
+(mu/defn ^:export columns-group-columns :- [:sequential lib.metadata/ColumnMetadata]
   "Get the columns associated with a column group"
   [column-group :- ColumnGroup]
   (::columns column-group))

--- a/src/metabase/lib/core.cljc
+++ b/src/metabase/lib/core.cljc
@@ -7,6 +7,7 @@
    [metabase.lib.aggregation :as lib.aggregation]
    [metabase.lib.breakout :as lib.breakout]
    [metabase.lib.card :as lib.card]
+   [metabase.lib.column-group :as lib.column-group]
    [metabase.lib.dev :as lib.dev]
    [metabase.lib.expression :as lib.expression]
    [metabase.lib.field :as lib.field]
@@ -30,6 +31,7 @@
 (comment lib.aggregation/keep-me
          lib.breakout/keep-me
          lib.card/keep-me
+         lib.column-group/keep-me
          lib.dev/keep-me
          lib.expression/keep-me
          lib.field/keep-me
@@ -68,6 +70,9 @@
   [lib.breakout
    breakout
    current-breakouts]
+  [lib.column-group
+   columns-group-columns
+   group-columns]
   [lib.dev
    field
    query-for-table-id

--- a/src/metabase/lib/join.cljc
+++ b/src/metabase/lib/join.cljc
@@ -75,6 +75,11 @@
         (i18n/tru "Saved Question #{0}" card-id)))
     (i18n/tru "Native Query")))
 
+(defmethod lib.metadata.calculation/display-info-method :mbql/join
+  [query stage-number join]
+  (let [display-name (lib.metadata.calculation/display-name query stage-number join)]
+    {:name (or (:alias join) display-name), :display_name display-name}))
+
 (mu/defn ^:private column-from-join-fields :- lib.metadata.calculation/ColumnMetadataWithSource
   "For a column that comes from a join `:fields` list, add or update metadata as needed, e.g. include join name in the
   display name."

--- a/src/metabase/lib/metadata/calculation.cljc
+++ b/src/metabase/lib/metadata/calculation.cljc
@@ -163,11 +163,16 @@
 
 (defmethod metadata-method :default
   [query stage-number x]
-  {:lib/type     :metadata/field
-   ;; TODO -- effective-type
-   :base_type    (type-of query stage-number x)
-   :name         (column-name query stage-number x)
-   :display_name (display-name query stage-number x)})
+  (try
+    {:lib/type     :metadata/field
+     ;; TODO -- effective-type
+     :base_type    (type-of query stage-number x)
+     :name         (column-name query stage-number x)
+     :display_name (display-name query stage-number x)}
+    (catch #?(:clj Throwable :cljs js/Error) e
+      (throw (ex-info (i18n/tru "Error calculating metadata {0}" (ex-message e))
+                      {:query query, :stage-number stage-number, :x x}
+                      e)))))
 
 (def ColumnMetadataWithSource
   "Schema for the column metadata that should be returned by [[metadata]]."
@@ -252,22 +257,27 @@
   "Default implementation of [[display-info-method]], available in case you want to use this in a different
   implementation and add additional information to it."
   [query stage-number x]
-  (let [x-metadata (metadata query stage-number x)]
-    (merge
-     ;; TODO -- not 100% convinced the FE should actually have access to `:name`, can't it use `:display_name`
-     ;; everywhere? Determine whether or not this is the case.
-     (select-keys x-metadata [:name :display_name :semantic_type])
-     ;; don't return `:base_type`, FE should just use `:effective_type` everywhere and not even need to know
-     ;; `:base_type` exists.
-     (when-let [effective-type ((some-fn :effective_type :base_type) x-metadata)]
-       {:effective_type effective-type})
-     (when-let [table-id (:table_id x-metadata)]
-       {:table (display-info query stage-number (lib.metadata/table query table-id))})
-     (when-let [source (:lib/source x-metadata)]
-       {:is_from_previous_stage (= source :source/previous-stage)
-        :is_from_join           (= source :source/joins)
-        :is_calculated          (= source :source/expressions)
-        :is_implicitly_joinable (= source :source/implicitly-joinable)}))))
+  (try
+    (let [x-metadata (metadata query stage-number x)]
+      (merge
+       ;; TODO -- not 100% convinced the FE should actually have access to `:name`, can't it use `:display_name`
+       ;; everywhere? Determine whether or not this is the case.
+       (select-keys x-metadata [:name :display_name :semantic_type])
+       ;; don't return `:base_type`, FE should just use `:effective_type` everywhere and not even need to know
+       ;; `:base_type` exists.
+       (when-let [effective-type ((some-fn :effective_type :base_type) x-metadata)]
+         {:effective_type effective-type})
+       (when-let [table-id (:table_id x-metadata)]
+         {:table (display-info query stage-number (lib.metadata/table query table-id))})
+       (when-let [source (:lib/source x-metadata)]
+         {:is_from_previous_stage (= source :source/previous-stage)
+          :is_from_join           (= source :source/joins)
+          :is_calculated          (= source :source/expressions)
+          :is_implicitly_joinable (= source :source/implicitly-joinable)})))
+    (catch #?(:clj Throwable :cljs js/Error) e
+      (throw (ex-info (i18n/tru "Error calculating display info: {0}" (ex-message e))
+                      {:query query, :stage-number stage-number, :x x}
+                      e)))))
 
 (defmethod display-info-method :default
   [query stage-number x]

--- a/src/metabase/lib/stage.cljc
+++ b/src/metabase/lib/stage.cljc
@@ -347,9 +347,13 @@
 
 (defmethod lib.metadata.calculation/display-name-method :mbql.stage/mbql
   [query stage-number _stage]
-  (let [descriptions (for [k display-name-parts]
-                       (lib.metadata.calculation/describe-top-level-key query stage-number k))]
-    (str/join ", " (remove str/blank? descriptions))))
+  (or
+   (not-empty
+    (let [descriptions (for [k display-name-parts]
+                         (lib.metadata.calculation/describe-top-level-key query stage-number k))]
+      (str/join ", " (remove str/blank? descriptions))))
+   (when-let [previous-stage-number (lib.util/previous-stage-number query stage-number)]
+     (lib.metadata.calculation/display-name query previous-stage-number (lib.util/query-stage query previous-stage-number)))))
 
 (defn- implicitly-joinable-columns
   "Columns that are implicitly joinable from some other columns in `column-metadatas`. To be joinable, the column has to

--- a/test/metabase/lib/card_test.cljc
+++ b/test/metabase/lib/card_test.cljc
@@ -13,23 +13,7 @@
 
 (deftest ^:parallel source-card-infer-metadata-test
   (testing "We should be able to calculate metadata for a Saved Question missing results_metadata"
-    (let [card-1            {:name          "My Card"
-                             :id            1
-                             :dataset_query {:database (meta/id)
-                                             :type     :query
-                                             :query    {:source-table (meta/id :checkins)
-                                                        :aggregation  [[:count]]
-                                                        :breakout     [[:field (meta/id :checkins :user-id) nil]]}}}
-          metadata-provider (lib.tu/composed-metadata-provider
-                             meta/metadata-provider
-                             (lib.tu/mock-metadata-provider
-                              {:cards [card-1]}))
-          query             {:lib/type     :mbql/query
-                             :lib/metadata metadata-provider
-                             :database     (meta/id)
-                             :type         :pipeline
-                             :stages       [{:lib/type     :mbql.stage/mbql
-                                             :source-table "card__1"}]}]
+    (let [query (lib.tu/query-with-card-source-table)]
       (is (=? [{:id                       (meta/id :checkins :user-id)
                 :name                     "USER_ID"
                 :lib/source               :source/card

--- a/test/metabase/lib/column_group_test.cljc
+++ b/test/metabase/lib/column_group_test.cljc
@@ -15,29 +15,25 @@
         columns (lib/orderable-columns query)
         groups  (lib/group-columns columns)]
     (is (not (mc/explain [:sequential @#'lib.column-group/ColumnGroup] groups)))
-    (is (=? [{:lib/source                :source/table-defaults
-              :lib/type                  :metadata/column-group
-              ::lib.column-group/columns [{:name "ID", :display_name "ID"}
-                                          {:name "NAME", :display_name "Name"}
-                                          {:name "CATEGORY_ID", :display_name "Category ID"}
-                                          {:name "LATITUDE", :display_name "Latitude"}
-                                          {:name "LONGITUDE", :display_name "Longitude"}
-                                          {:name "PRICE", :display_name "Price"}]}
-             {:lib/source                :source/implicitly-joinable
-              :lib/type                  :metadata/column-group
-              ::lib.column-group/columns [{:name "ID", :display_name "ID"}
-                                          {:name "NAME", :display_name "Name"}]}]
+    (is (=? [{::lib.column-group/group-type :group-type/main
+              :lib/type                     :metadata/column-group
+              ::lib.column-group/columns    [{:name "ID", :display_name "ID"}
+                                             {:name "NAME", :display_name "Name"}
+                                             {:name "CATEGORY_ID", :display_name "Category ID"}
+                                             {:name "LATITUDE", :display_name "Latitude"}
+                                             {:name "LONGITUDE", :display_name "Longitude"}
+                                             {:name "PRICE", :display_name "Price"}]}
+             {::lib.column-group/group-type :group-type/join.implicit
+              :lib/type                     :metadata/column-group
+              ::lib.column-group/columns    [{:name "ID", :display_name "ID"}
+                                             {:name "NAME", :display_name "Name"}]}]
             groups))
     (testing `lib/display-info
-      (is (=? [{:is_from_previous_stage false
-                :is_from_join           false
-                :is_calculated          false
+      (is (=? [{:is_from_join           false
                 :is_implicitly_joinable false
                 :name                   "VENUES"
                 :display_name           "Venues"}
-               {:is_from_previous_stage false
-                :is_from_join           false
-                :is_calculated          false
+               {:is_from_join           false
                 :is_implicitly_joinable true
                 :name                   "CATEGORIES"
                 :display_name           "Categories"}]
@@ -53,14 +49,12 @@
                     (lib/breakout (lib/field "VENUES" "NAME")))
         columns (lib/orderable-columns query)
         groups  (lib/group-columns columns)]
-    (is (=? [{:lib/source                :source/fields
-              ::lib.column-group/columns [{:display_name "Name", :lib/source :source/breakouts}
-                                          {:display_name "Sum of ID", :lib/source :source/aggregations}]}]
+    (is (=? [{::lib.column-group/group-type :group-type/main
+              ::lib.column-group/columns    [{:display_name "Name", :lib/source :source/breakouts}
+                                             {:display_name "Sum of ID", :lib/source :source/aggregations}]}]
             groups))
     (testing `lib/display-info
-      (is (=? [{:is_from_previous_stage false
-                :is_from_join           false
-                :is_calculated          false
+      (is (=? [{:is_from_join           false
                 :is_implicitly_joinable false
                 :name                   "VENUES"
                 :display_name           "Venues"}]
@@ -74,27 +68,23 @@
   (let [query   (lib.tu/query-with-card-source-table)
         columns (lib/orderable-columns query)
         groups  (lib/group-columns columns)]
-    (is (=? [{:lib/source                :source/card
-              ::lib.column-group/columns [{:display_name "User ID", :lib/source :source/card}
-                                          {:display_name "Count", :lib/source :source/card}]}
-             {:lib/source                :source/implicitly-joinable
-              :table-id                  (meta/id :users)
-              ::lib.column-group/columns [{:display_name "ID", :lib/source :source/implicitly-joinable}
-                                          {:display_name "Name", :lib/source :source/implicitly-joinable}
-                                          {:display_name "Last Login", :lib/source :source/implicitly-joinable}] }]
+    (is (=? [{::lib.column-group/group-type :group-type/main
+              ::lib.column-group/columns    [{:display_name "User ID", :lib/source :source/card}
+                                             {:display_name "Count", :lib/source :source/card}]}
+             {::lib.column-group/group-type :group-type/join.implicit
+              :table-id                     (meta/id :users)
+              ::lib.column-group/columns    [{:display_name "ID", :lib/source :source/implicitly-joinable}
+                                             {:display_name "Name", :lib/source :source/implicitly-joinable}
+                                             {:display_name "Last Login", :lib/source :source/implicitly-joinable}]}]
             groups))
     (testing `lib/display-info
       (is (=? [{:name                   "My Card"
                 :display_name           "My Card"
-                :is_from_previous_stage false
                 :is_from_join           false
-                :is_calculated          false
                 :is_implicitly_joinable false}
                {:name                   "USERS"
                 :display_name           "Users"
-                :is_from_previous_stage false
                 :is_from_join           false
-                :is_calculated          false
                 :is_implicitly_joinable true}]
               (for [group groups]
                 (lib/display-info query group)))))
@@ -106,28 +96,24 @@
   (let [query   (lib.tu/query-with-join)
         columns (lib/orderable-columns query)
         groups  (lib/group-columns columns)]
-    (is (=? [{:lib/source                :source/table-defaults
-              ::lib.column-group/columns [{:name "ID", :display_name "ID"}
-                                          {:name "NAME", :display_name "Name"}
-                                          {:name "CATEGORY_ID", :display_name "Category ID"}
-                                          {:name "LATITUDE", :display_name "Latitude"}
-                                          {:name "LONGITUDE", :display_name "Longitude"}
-                                          {:name "PRICE", :display_name "Price"}]}
-             {:lib/source                :source/joins
-              :join-alias                "Cat"
-              ::lib.column-group/columns [{:display_name "Categories → ID", :lib/source :source/joins}
-                                          {:display_name "Categories → Name", :lib/source :source/joins}]}]
+    (is (=? [{::lib.column-group/group-type :group-type/main
+              ::lib.column-group/columns    [{:name "ID", :display_name "ID"}
+                                             {:name "NAME", :display_name "Name"}
+                                             {:name "CATEGORY_ID", :display_name "Category ID"}
+                                             {:name "LATITUDE", :display_name "Latitude"}
+                                             {:name "LONGITUDE", :display_name "Longitude"}
+                                             {:name "PRICE", :display_name "Price"}]}
+             {::lib.column-group/group-type :group-type/join.explicit
+              :join-alias                   "Cat"
+              ::lib.column-group/columns    [{:display_name "Categories → ID", :lib/source :source/joins}
+                                             {:display_name "Categories → Name", :lib/source :source/joins}]}]
             groups))
     (testing `lib/display-info
-      (is (=? [{:is_from_previous_stage false
-                :is_from_join           false
-                :is_calculated          false
+      (is (=? [{:is_from_join           false
                 :is_implicitly_joinable false
                 :name                   "VENUES"
                 :display_name           "Venues"}
-               {:is_from_previous_stage false
-                :is_from_join           true
-                :is_calculated          false
+               {:is_from_join           true
                 :is_implicitly_joinable false
                 :name                   "Cat"
                 :display_name           "Categories"}]
@@ -141,36 +127,25 @@
   (let [query   (lib.tu/query-with-expression)
         columns (lib/orderable-columns query)
         groups  (lib/group-columns columns)]
-    (is (=? [{:lib/source                :source/table-defaults
-              ::lib.column-group/columns [{:name "ID", :display_name "ID"}
-                                          {:name "NAME", :display_name "Name"}
-                                          {:name "CATEGORY_ID", :display_name "Category ID"}
-                                          {:name "LATITUDE", :display_name "Latitude"}
-                                          {:name "LONGITUDE", :display_name "Longitude"}
-                                          {:name "PRICE", :display_name "Price"}]}
-             {:lib/source                :source/expressions
-              ::lib.column-group/columns [{:display_name "expr", :lib/source :source/expressions}]}
-             {:lib/source                :source/implicitly-joinable
-              :lib/type                  :metadata/column-group
-              ::lib.column-group/columns [{:name "ID", :display_name "ID"}
-                                          {:name "NAME", :display_name "Name"}]}]
+    (is (=? [{::lib.column-group/group-type :group-type/main
+              ::lib.column-group/columns    [{:name "ID", :display_name "ID"}
+                                             {:name "NAME", :display_name "Name"}
+                                             {:name "CATEGORY_ID", :display_name "Category ID"}
+                                             {:name "LATITUDE", :display_name "Latitude"}
+                                             {:name "LONGITUDE", :display_name "Longitude"}
+                                             {:name "PRICE", :display_name "Price"}
+                                             {:display_name "expr", :lib/source :source/expressions}]}
+             {::lib.column-group/group-type :group-type/join.implicit
+              :lib/type                     :metadata/column-group
+              ::lib.column-group/columns    [{:name "ID", :display_name "ID"}
+                                             {:name "NAME", :display_name "Name"}]}]
             groups))
     (testing `lib/display-info
-      (is (=? [{:is_from_previous_stage false
-                :is_from_join           false
-                :is_calculated          false
+      (is (=? [{:is_from_join           false
                 :is_implicitly_joinable false
                 :name                   "VENUES"
                 :display_name           "Venues"}
-               {:name                   "VENUES"
-                :display_name           "Venues"
-                :is_from_previous_stage false
-                :is_from_join           false
-                :is_calculated          true
-                :is_implicitly_joinable false}
-               {:is_from_previous_stage false
-                :is_from_join           false
-                :is_calculated          false
+               {:is_from_join           false
                 :is_implicitly_joinable true
                 :name                   "CATEGORIES"
                 :display_name           "Categories"}]
@@ -185,27 +160,24 @@
                     (lib/expression "expr" (lib/absolute-datetime "2020" :month)))
         columns (lib/orderable-columns query)
         groups  (lib/group-columns columns)]
-    (is (=? [{:lib/source                :source/card
-              ::lib.column-group/columns [{:display_name "User ID", :lib/source :source/card}
-                                          {:display_name "Count", :lib/source :source/card}]}
-             {:lib/source                :source/implicitly-joinable
-              :table-id                  (meta/id :users)
-              ::lib.column-group/columns [{:display_name "ID", :lib/source :source/implicitly-joinable}
-                                          {:display_name "Name", :lib/source :source/implicitly-joinable}
-                                          {:display_name "Last Login", :lib/source :source/implicitly-joinable}] }]
+    (is (=? [{::lib.column-group/group-type :group-type/main
+              ::lib.column-group/columns    [{:display_name "User ID", :lib/source :source/card}
+                                             {:display_name "Count", :lib/source :source/card}
+                                             {:display_name "expr", :lib/source :source/expressions}]}
+             {::lib.column-group/group-type :group-type/join.implicit
+              :table-id                     (meta/id :users)
+              ::lib.column-group/columns    [{:display_name "ID", :lib/source :source/implicitly-joinable}
+                                             {:display_name "Name", :lib/source :source/implicitly-joinable}
+                                             {:display_name "Last Login", :lib/source :source/implicitly-joinable}] }]
             groups))
     (testing `lib/display-info
       (is (=? [{:name                   "My Card"
                 :display_name           "My Card"
-                :is_from_previous_stage false
                 :is_from_join           false
-                :is_calculated          false
                 :is_implicitly_joinable false}
                {:name                   "USERS"
                 :display_name           "Users"
-                :is_from_previous_stage false
                 :is_from_join           false
-                :is_calculated          false
                 :is_implicitly_joinable true}]
               (for [group groups]
                 (lib/display-info query group)))))

--- a/test/metabase/lib/column_group_test.cljc
+++ b/test/metabase/lib/column_group_test.cljc
@@ -184,3 +184,32 @@
     (testing `lib/columns-group-columns
       (is (= columns
              (mapcat lib/columns-group-columns groups))))))
+
+(deftest ^:parallel native-query-test
+  (let [query  (lib.tu/native-query)
+        groups (lib/group-columns (lib/orderable-columns query))]
+    (is (=? [{::lib.column-group/group-type :group-type/main
+              ::lib.column-group/columns    [{:display_name "another Field", :lib/source :source/native}
+                                             {:display_name "sum of User ID", :lib/source :source/native}]}]
+            groups))
+    (testing `lib/display-info
+      (is (=? [{:display_name           "Native query"
+                :is_from_join           false
+                :is_implicitly_joinable false}]
+              (for [group groups]
+                (lib/display-info query group)))))))
+
+(deftest ^:parallel native-source-query-test
+  (let [query  (-> (lib.tu/native-query)
+                   lib/append-stage)
+        groups (lib/group-columns (lib/orderable-columns query))]
+    (is (=? [{::lib.column-group/group-type :group-type/main
+              ::lib.column-group/columns    [{:display_name "another Field", :lib/source :source/previous-stage}
+                                             {:display_name "sum of User ID", :lib/source :source/previous-stage}]}]
+            groups))
+    (testing `lib/display-info
+      (is (=? [{:display_name           "Native query"
+                :is_from_join           false
+                :is_implicitly_joinable false}]
+              (for [group groups]
+                (lib/display-info query group)))))))

--- a/test/metabase/lib/column_group_test.cljc
+++ b/test/metabase/lib/column_group_test.cljc
@@ -1,0 +1,214 @@
+(ns metabase.lib.column-group-test
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [malli.core :as mc]
+   [metabase.lib.column-group :as lib.column-group]
+   [metabase.lib.core :as lib]
+   [metabase.lib.test-metadata :as meta]
+   [metabase.lib.test-util :as lib.tu]
+   #?@(:cljs ([metabase.test-runner.assert-exprs.approximately-equal]))))
+
+#?(:cljs (comment metabase.test-runner.assert-exprs.approximately-equal/keep-me))
+
+(deftest ^:parallel group-columns-test
+  (let [query   (lib/query-for-table-name meta/metadata-provider "VENUES")
+        columns (lib/orderable-columns query)
+        groups  (lib/group-columns columns)]
+    (is (not (mc/explain [:sequential @#'lib.column-group/ColumnGroup] groups)))
+    (is (=? [{:lib/source                :source/table-defaults
+              :lib/type                  :metadata/column-group
+              ::lib.column-group/columns [{:name "ID", :display_name "ID"}
+                                          {:name "NAME", :display_name "Name"}
+                                          {:name "CATEGORY_ID", :display_name "Category ID"}
+                                          {:name "LATITUDE", :display_name "Latitude"}
+                                          {:name "LONGITUDE", :display_name "Longitude"}
+                                          {:name "PRICE", :display_name "Price"}]}
+             {:lib/source                :source/implicitly-joinable
+              :lib/type                  :metadata/column-group
+              ::lib.column-group/columns [{:name "ID", :display_name "ID"}
+                                          {:name "NAME", :display_name "Name"}]}]
+            groups))
+    (testing `lib/display-info
+      (is (=? [{:is_from_previous_stage false
+                :is_from_join           false
+                :is_calculated          false
+                :is_implicitly_joinable false
+                :name                   "VENUES"
+                :display_name           "Venues"}
+               {:is_from_previous_stage false
+                :is_from_join           false
+                :is_calculated          false
+                :is_implicitly_joinable true
+                :name                   "CATEGORIES"
+                :display_name           "Categories"}]
+              (for [group groups]
+                (lib/display-info query group)))))
+    (testing `lib/columns-group-columns
+      (is (= columns
+             (mapcat lib/columns-group-columns groups))))))
+
+(deftest ^:parallel group-columns-aggregation-and-breakout-test
+  (let [query   (-> (lib/query-for-table-name meta/metadata-provider "VENUES")
+                    (lib/aggregate (lib/sum (lib/field "VENUES" "ID")))
+                    (lib/breakout (lib/field "VENUES" "NAME")))
+        columns (lib/orderable-columns query)
+        groups  (lib/group-columns columns)]
+    (is (=? [{:lib/source                :source/fields
+              ::lib.column-group/columns [{:display_name "Name", :lib/source :source/breakouts}
+                                          {:display_name "Sum of ID", :lib/source :source/aggregations}]}]
+            groups))
+    (testing `lib/display-info
+      (is (=? [{:is_from_previous_stage false
+                :is_from_join           false
+                :is_calculated          false
+                :is_implicitly_joinable false
+                :name                   "VENUES"
+                :display_name           "Venues"}]
+              (for [group groups]
+                (lib/display-info query group)))))
+    (testing `lib/columns-group-columns
+      (is (= columns
+             (mapcat lib/columns-group-columns groups))))))
+
+(deftest ^:parallel group-columns-source-card-test
+  (let [query   (lib.tu/query-with-card-source-table)
+        columns (lib/orderable-columns query)
+        groups  (lib/group-columns columns)]
+    (is (=? [{:lib/source                :source/card
+              ::lib.column-group/columns [{:display_name "User ID", :lib/source :source/card}
+                                          {:display_name "Count", :lib/source :source/card}]}
+             {:lib/source                :source/implicitly-joinable
+              :table-id                  (meta/id :users)
+              ::lib.column-group/columns [{:display_name "ID", :lib/source :source/implicitly-joinable}
+                                          {:display_name "Name", :lib/source :source/implicitly-joinable}
+                                          {:display_name "Last Login", :lib/source :source/implicitly-joinable}] }]
+            groups))
+    (testing `lib/display-info
+      (is (=? [{:name                   "My Card"
+                :display_name           "My Card"
+                :is_from_previous_stage false
+                :is_from_join           false
+                :is_calculated          false
+                :is_implicitly_joinable false}
+               {:name                   "USERS"
+                :display_name           "Users"
+                :is_from_previous_stage false
+                :is_from_join           false
+                :is_calculated          false
+                :is_implicitly_joinable true}]
+              (for [group groups]
+                (lib/display-info query group)))))
+    (testing `lib/columns-group-columns
+      (is (= columns
+             (mapcat lib/columns-group-columns groups))))))
+
+(deftest ^:parallel group-columns-joins-test
+  (let [query   (lib.tu/query-with-join)
+        columns (lib/orderable-columns query)
+        groups  (lib/group-columns columns)]
+    (is (=? [{:lib/source                :source/table-defaults
+              ::lib.column-group/columns [{:name "ID", :display_name "ID"}
+                                          {:name "NAME", :display_name "Name"}
+                                          {:name "CATEGORY_ID", :display_name "Category ID"}
+                                          {:name "LATITUDE", :display_name "Latitude"}
+                                          {:name "LONGITUDE", :display_name "Longitude"}
+                                          {:name "PRICE", :display_name "Price"}]}
+             {:lib/source                :source/joins
+              :join-alias                "Cat"
+              ::lib.column-group/columns [{:display_name "Categories → ID", :lib/source :source/joins}
+                                          {:display_name "Categories → Name", :lib/source :source/joins}]}]
+            groups))
+    (testing `lib/display-info
+      (is (=? [{:is_from_previous_stage false
+                :is_from_join           false
+                :is_calculated          false
+                :is_implicitly_joinable false
+                :name                   "VENUES"
+                :display_name           "Venues"}
+               {:is_from_previous_stage false
+                :is_from_join           true
+                :is_calculated          false
+                :is_implicitly_joinable false
+                :name                   "Cat"
+                :display_name           "Categories"}]
+              (for [group groups]
+                (lib/display-info query group)))))
+    (testing `lib/columns-group-columns
+      (is (= columns
+             (mapcat lib/columns-group-columns groups))))))
+
+(deftest ^:parallel group-columns-expressions-test
+  (let [query   (lib.tu/query-with-expression)
+        columns (lib/orderable-columns query)
+        groups  (lib/group-columns columns)]
+    (is (=? [{:lib/source                :source/table-defaults
+              ::lib.column-group/columns [{:name "ID", :display_name "ID"}
+                                          {:name "NAME", :display_name "Name"}
+                                          {:name "CATEGORY_ID", :display_name "Category ID"}
+                                          {:name "LATITUDE", :display_name "Latitude"}
+                                          {:name "LONGITUDE", :display_name "Longitude"}
+                                          {:name "PRICE", :display_name "Price"}]}
+             {:lib/source                :source/expressions
+              ::lib.column-group/columns [{:display_name "expr", :lib/source :source/expressions}]}
+             {:lib/source                :source/implicitly-joinable
+              :lib/type                  :metadata/column-group
+              ::lib.column-group/columns [{:name "ID", :display_name "ID"}
+                                          {:name "NAME", :display_name "Name"}]}]
+            groups))
+    (testing `lib/display-info
+      (is (=? [{:is_from_previous_stage false
+                :is_from_join           false
+                :is_calculated          false
+                :is_implicitly_joinable false
+                :name                   "VENUES"
+                :display_name           "Venues"}
+               {:name                   "VENUES"
+                :display_name           "Venues"
+                :is_from_previous_stage false
+                :is_from_join           false
+                :is_calculated          true
+                :is_implicitly_joinable false}
+               {:is_from_previous_stage false
+                :is_from_join           false
+                :is_calculated          false
+                :is_implicitly_joinable true
+                :name                   "CATEGORIES"
+                :display_name           "Categories"}]
+              (for [group groups]
+                (lib/display-info query group)))))
+    (testing `lib/columns-group-columns
+      (is (= columns
+             (mapcat lib/columns-group-columns groups))))))
+
+(deftest ^:parallel group-columns-source-card-with-expressions-test
+  (let [query   (-> (lib.tu/query-with-card-source-table)
+                    (lib/expression "expr" (lib/absolute-datetime "2020" :month)))
+        columns (lib/orderable-columns query)
+        groups  (lib/group-columns columns)]
+    (is (=? [{:lib/source                :source/card
+              ::lib.column-group/columns [{:display_name "User ID", :lib/source :source/card}
+                                          {:display_name "Count", :lib/source :source/card}]}
+             {:lib/source                :source/implicitly-joinable
+              :table-id                  (meta/id :users)
+              ::lib.column-group/columns [{:display_name "ID", :lib/source :source/implicitly-joinable}
+                                          {:display_name "Name", :lib/source :source/implicitly-joinable}
+                                          {:display_name "Last Login", :lib/source :source/implicitly-joinable}] }]
+            groups))
+    (testing `lib/display-info
+      (is (=? [{:name                   "My Card"
+                :display_name           "My Card"
+                :is_from_previous_stage false
+                :is_from_join           false
+                :is_calculated          false
+                :is_implicitly_joinable false}
+               {:name                   "USERS"
+                :display_name           "Users"
+                :is_from_previous_stage false
+                :is_from_join           false
+                :is_calculated          false
+                :is_implicitly_joinable true}]
+              (for [group groups]
+                (lib/display-info query group)))))
+    (testing `lib/columns-group-columns
+      (is (= columns
+             (mapcat lib/columns-group-columns groups))))))

--- a/test/metabase/lib/field_test.cljc
+++ b/test/metabase/lib/field_test.cljc
@@ -90,20 +90,7 @@
              :base_type     :type/Integer
              :semantic_type :type/FK}
             (lib.metadata.calculation/metadata
-             (lib.tu/venues-query-with-last-stage
-              {:lib/type           :mbql.stage/native
-               :lib/stage-metadata {:lib/type :metadata/results
-                                    :columns  [{:lib/type      :metadata/field
-                                                :name          "abc"
-                                                :display_name  "another Field"
-                                                :base_type     :type/Integer
-                                                :semantic_type :type/FK}
-                                               {:lib/type      :metadata/field
-                                                :name          "sum"
-                                                :display_name  "sum of User ID"
-                                                :base_type     :type/Integer
-                                                :semantic_type :type/FK}]}
-               :native             "SELECT whatever"})
+             (lib.tu/native-query)
              -1
              [:field {:lib/uuid (str (random-uuid)), :base-type :type/Integer} "sum"])))))
 

--- a/test/metabase/lib/order_by_test.cljc
+++ b/test/metabase/lib/order_by_test.cljc
@@ -276,14 +276,7 @@
 
 (deftest ^:parallel orderable-explicit-joins-test
   (testing "orderable-columns should include columns from explicit joins"
-    (let [query (-> (lib/query-for-table-name meta/metadata-provider "VENUES")
-                    (lib/join (-> (lib/join-clause
-                                   (meta/table-metadata :categories)
-                                   [(lib/=
-                                      (lib/field "VENUES" "CATEGORY_ID")
-                                      (lib/with-join-alias (lib/field "CATEGORIES" "ID") "Cat"))])
-                                  (lib/with-join-alias "Cat")
-                                  (lib/with-join-fields :all))))]
+    (let [query (lib.tu/query-with-join)]
       (testing (lib.util/format "Query =\n%s" (u/pprint-to-str query))
         (is (=? [{:id (meta/id :venues :id) :name "ID"}
                  {:id (meta/id :venues :name) :name "NAME"}

--- a/test/metabase/lib/test_util.cljc
+++ b/test/metabase/lib/test_util.cljc
@@ -15,7 +15,6 @@
    :type         :pipeline
    :database     (meta/id)
    :stages       [{:lib/type     :mbql.stage/mbql
-                   :lib/options  {:lib/uuid (str (random-uuid))}
                    :source-table (meta/id :venues)}]})
 
 (defn venues-query-with-last-stage [m]
@@ -120,3 +119,24 @@
   []
   (-> (lib/query-for-table-name meta/metadata-provider "VENUES")
       (lib/expression "expr" (lib/absolute-datetime "2020" :month))))
+
+(defn native-query
+  "A sample native query."
+  []
+  {:lib/type     :mbql/query
+   :lib/metadata meta/metadata-provider
+   :type         :pipeline
+   :database     (meta/id)
+   :stages       [{:lib/type           :mbql.stage/native
+                   :lib/stage-metadata {:lib/type :metadata/results
+                                        :columns  [{:lib/type      :metadata/field
+                                                    :name          "abc"
+                                                    :display_name  "another Field"
+                                                    :base_type     :type/Integer
+                                                    :semantic_type :type/FK}
+                                                   {:lib/type      :metadata/field
+                                                    :name          "sum"
+                                                    :display_name  "sum of User ID"
+                                                    :base_type     :type/Integer
+                                                    :semantic_type :type/FK}]}
+                   :native             "SELECT whatever"}]})

--- a/test/metabase/lib/test_util.cljc
+++ b/test/metabase/lib/test_util.cljc
@@ -93,7 +93,8 @@
                                          :breakout     [[:field (meta/id :checkins :user-id) nil]]}}}]})))
 
 (defn query-with-card-source-table
-  "A query with a `card__<id>` source Table, and a metadata provider that has that Card. Card's name is `My Card`."
+  "A query with a `card__<id>` source Table, and a metadata provider that has that Card. Card's name is `My Card`. Card
+  'exports' two columns, `USER_ID` and `count`."
   []
   {:lib/type     :mbql/query
    :lib/metadata metadata-provider-with-card


### PR DESCRIPTION
Resolves #29991

New functions `group-columns` (to group columns from things like `orderable-columns` together into logical groups) and `columns-group-columns` to pull the columns back out of one of these logical groups. See #29991 for rational behind these helper functions.

@kulyk, the columns groups themselves are opaque objects, and you can call `displayInfo()` on them to get an appropriate `displayName` as well as `is_from_join` and `is_implicitly_joinable` information (none of the other keys made sense for a group since it seems like everything else gets grouped together), and you can get the columns back out of an individual group with `getColumnsGroupColumns(group)`. I wrote basic typescript wrappers for these new functions, altho I haven't actually tested them out yet, I think they should work tho.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30018)
<!-- Reviewable:end -->
