### PR TITLE
Temporarily allow "card__\d+" strings as source-table

### DIFF
--- a/src/metabase/lib/util.cljc
+++ b/src/metabase/lib/util.cljc
@@ -378,7 +378,7 @@
     (when-let [[_match card-id-str] (re-find #"^card__(\d+)$" table-id)]
       (parse-long card-id-str))))
 
-(mu/defn source-table :- [:maybe ::lib.schema.id/table]
+(mu/defn source-table :- [:maybe [:or ::lib.schema.id/table [:re #"^card__\d+$"]]]
   "If this query has a `:source-table`, return it."
   [query]
   (-> query :stages first :source-table))


### PR DESCRIPTION
This is a just a quick patch to make master green again after incompatible parallel merges.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30024)
<!-- Reviewable:end -->
