### PR TITLE
Fix MLv2 order-by FE tests

### DIFF
--- a/frontend/src/metabase-lib/order_by.unit.spec.ts
+++ b/frontend/src/metabase-lib/order_by.unit.spec.ts
@@ -39,9 +39,15 @@ describe("order by", () => {
           name: "ID",
           display_name: "ID",
           effective_type: "type/BigInteger",
+          semantic_type: "type/PK",
+          is_calculated: false,
+          is_from_join: false,
+          is_from_previous_stage: false,
+          is_implicitly_joinable: false,
           table: {
             name: "ORDERS",
             display_name: "Orders",
+            is_source_table: true,
           },
         }),
       );
@@ -55,9 +61,15 @@ describe("order by", () => {
           name: "TITLE",
           display_name: "Title",
           effective_type: "type/Text",
+          semantic_type: "type/Category",
+          is_calculated: false,
+          is_from_join: false,
+          is_from_previous_stage: false,
+          is_implicitly_joinable: true,
           table: {
             name: "PRODUCTS",
             display_name: "Products",
+            is_source_table: false,
           },
         }),
       );


### PR DESCRIPTION
Fixes `metabase-lib/order_by` unit tests failing after changes to MLv2 CLJC code. The PR just patches the expected data structures to match the state of reality. The reason `master` turned red is that we don't trigger FE tests on CLJS metabase-lib code changes; however, we now have code and tests depending on it.

### How to verify

🟢 CI should be green

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30026)
<!-- Reviewable:end -->
