### PR TITLE
Add MLv2 to shared files on CI

### DIFF
--- a/.github/file-paths.yaml
+++ b/.github/file-paths.yaml
@@ -7,6 +7,7 @@ ci: &ci
 
 shared_sources: &shared_sources
   - "shared/src/**"
+  - "src/metabase/lib/**"
 
 shared_specs: &shared_specs
   - "shared/test/**"


### PR DESCRIPTION
This should make sure we run FE changes when files under `src/metabase/lib/**` change (shared MLv2 source code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30027)
<!-- Reviewable:end -->
