### PR TITLE
Fix not being able to use field filters in databases without schema

### DIFF
--- a/e2e/test/scenarios/native-filters/reproductions/29786.cy.spec.js
+++ b/e2e/test/scenarios/native-filters/reproductions/29786.cy.spec.js
@@ -1,0 +1,33 @@
+import { filterWidget, openNativeEditor, restore } from "e2e/support/helpers";
+import * as SQLFilter from "../helpers/e2e-sql-filter-helpers";
+import * as FieldFilter from "../helpers/e2e-field-filter-helpers";
+
+const SQL_QUERY = "SELECT * FROM PRODUCTS WHERE {{f1}} AND {{f2}}";
+
+describe("issue 29786", { tags: "@external" }, () => {
+  beforeEach(() => {
+    restore("mysql-8");
+    cy.intercept("POST", "/api/dataset").as("dataset");
+    cy.signInAsAdmin();
+  });
+
+  it("should allow using field filters with null schema (metabase#29786)", () => {
+    openNativeEditor({ databaseName: "QA MySQL8" });
+    SQLFilter.enterParameterizedQuery(SQL_QUERY);
+
+    cy.findAllByText("Text").first().click();
+    SQLFilter.chooseType("Field Filter");
+    FieldFilter.mapTo({ table: "Products", field: "Category" });
+    cy.findAllByText("Text").last().click();
+    SQLFilter.chooseType("Field Filter");
+    FieldFilter.mapTo({ table: "Products", field: "Vendor" });
+
+    filterWidget().first().click();
+    FieldFilter.addWidgetStringFilter("Widget");
+    filterWidget().last().click();
+    FieldFilter.addWidgetStringFilter("Von-Gulgowski");
+
+    SQLFilter.runQuery();
+    cy.findByText("1087115303928").should("be.visible");
+  });
+});

--- a/frontend/src/metabase-lib/metadata/Schema.ts
+++ b/frontend/src/metabase-lib/metadata/Schema.ts
@@ -10,12 +10,12 @@ import type Table from "./Table";
 
 export default class Schema extends Base {
   id?: string;
-  name: string;
+  name: string | null;
   database: Database;
   tables: Table[];
 
   displayName() {
-    return titleize(humanize(this.name));
+    return this.name ? titleize(humanize(this.name)) : null;
   }
 
   getTables() {

--- a/frontend/src/metabase-lib/metadata/Schema.ts
+++ b/frontend/src/metabase-lib/metadata/Schema.ts
@@ -10,7 +10,7 @@ import type Table from "./Table";
 
 export default class Schema extends Base {
   id?: string;
-  name: string | null;
+  name: string;
   database: Database;
   tables: Table[];
 


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/29786
Reproduces https://github.com/metabase/metabase/issues/29786

In 0.45 it worked because the `ErrorBoundary` simply ignored any exceptions during rendering and now it shows a dedicated page.

How to verify:
- New -> SQL Query
- `SELECT * FROM PRODUCTS WHERE {{f1}} AND {{f2}}`
- Make `f1` and `f2` field filters, set their values, and run the query
- You should be able to run the query and get results

<img width="1086" alt="Screenshot 2023-04-12 at 15 13 08" src="https://user-images.githubusercontent.com/8542534/231453695-c36f97f4-99f4-4fc4-b8ee-dbdf6cbf1be8.png">

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30029)
<!-- Reviewable:end -->
