### PR TITLE
Fixing case where no fields in a table cause a failure

### DIFF
--- a/src/metabase/metabot/util.clj
+++ b/src/metabase/metabot/util.clj
@@ -181,6 +181,7 @@
                         (if-some [enums (field->pseudo-enums table field)]
                           (assoc acc field-name enums)
                           acc))
+                      {}
                       fields)
         columns      (vec
                       (for [{column-name :name :keys [database_required database_type]} fields]


### PR DESCRIPTION
There was a reduce in  `table->pseudo-ddl` that didn't have a seed. If no fields were present, an error was thrown regarding function arity.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30036)
<!-- Reviewable:end -->
