### PR TITLE
Move require of test.test-mlv2 out of main code

### DIFF
--- a/dev/src/user.clj
+++ b/dev/src/user.clj
@@ -2,6 +2,7 @@
   (:require
    [hawk.assert-exprs]
    [metabase.bootstrap]
+   metabase.query-processor-test.test-mlv2
    [metabase.test-runner.assert-exprs]))
 
 (comment metabase.bootstrap/keep-me

--- a/src/metabase/query_processor.clj
+++ b/src/metabase/query_processor.clj
@@ -108,9 +108,6 @@
                          [column-level-perms-check :as ee.sandbox.columns]
                          [row-level-restrictions :as ee.sandbox.rows]]))
 
-(when-not config/is-prod?
-  (classloader/require 'metabase.query-processor-test.test-mlv2))
-
 (def ^:private pre-processing-middleware
   "Pre-processing middleware. Has the form
 

--- a/test/metabase/test_runner.clj
+++ b/test/metabase/test_runner.clj
@@ -9,6 +9,7 @@
    [humane-are.core :as humane-are]
    [metabase.bootstrap]
    [metabase.config :as config]
+   [metabase.query-processor-test.test-mlv2 :as qp-test.mlv2]
    [metabase.test-runner.assert-exprs]
    [metabase.test.data.env :as tx.env]
    [metabase.util.date-2]
@@ -23,6 +24,9 @@
   metabase.bootstrap/keep-me
   ;; make sure stuff like `schema=` and what not are loaded
   metabase.test-runner.assert-exprs/keep-me
+
+  ;; helpers for mvl2
+  qp-test.mlv2/keep-me
 
   ;; these are necessary so data_readers.clj functions can function
   metabase.util.date-2/keep-me


### PR DESCRIPTION
in query_processor.clj we were requiring

```clojure
(when-not config/is-prod?
  (classloader/require 'metabase.query-processor-test.test-mlv2))
```

And this was blowing up as it was not present in the aliases used for cypress and the FE crew.

Now user.clj requires it in the same way that it requires `[metabase.test-runner.assert-exprs]` so we can run tests with `partial=` and their ilk. And it is required by the test entry namespace so CI and test runners find it as well.

The `resolve` command in query_processor.clj now works in dev and CI

```clojure
query-processor=> (resolve 'metabase.query-processor-test.test-mlv2/post-processing-middleware)
,#'metabase.query-processor-test.test-mlv2/post-processing-middleware
```
(comma to prevent commit message from eliding as a comment)

so presumably tests that require the middleware tricks from this test namespace will continue to work.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30037)
<!-- Reviewable:end -->
