### PR TITLE
Revert "`clj -M:run` should not think it's running in `:dev` mode (#30004)"

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -262,7 +262,8 @@
   ;; clojure -M:run:ee (include EE code)
   :run
   {:main-opts ["-m" "metabase.bootstrap"]
-   :jvm-opts  ["-Djava.awt.headless=true"                   ; prevent Java icon from randomly popping up in macOS dock
+   :jvm-opts  ["-Dmb.run.mode=dev"
+               "-Djava.awt.headless=true"                   ; prevent Java icon from randomly popping up in macOS dock
                "-Dmb.jetty.port=3000"]}
 
   ;; alias for CI-specific options.


### PR DESCRIPTION
This reverts commit 8a11e382ddf9ff21240e5383b9905f99415cd57b.

The namespace `metabase.server.middleware.security` controls our content security policy header. In dev we allow connections to 8080 for webpack assets. Not dev we deny these.

`clj -M:run` is dev since it is running the project from source, not a jar. This `mb.run.mode` was removed when we were fighting require issues for `metabase.query-processor-test.test-mlv2`. That's solved so we can restore the dev property to `:run`.


#### Before

`clj -M:run`

<img width="946" alt="image" src="https://user-images.githubusercontent.com/6377293/231535178-454a6c21-8e03-4240-90f5-943ee37f90f7.png">
<img width="1171" alt="image" src="https://user-images.githubusercontent.com/6377293/231535205-27438885-01fd-4626-b6ee-684452daf564.png">

```clojure
(defn- content-security-policy-header
  "`Content-Security-Policy` header. See https://content-security-policy.com for more details."
  []
  {"Content-Security-Policy"
   (str/join
    (for [[k vs] {:default-src  ["'none'"]
                  :script-src   (concat
                                  ["'self'"
                                   "'unsafe-eval'" ; TODO - we keep working towards removing this entirely
                                   "https://maps.google.com"
                                   "https://accounts.google.com"
                                   (when (public-settings/anon-tracking-enabled)
                                     "https://www.google-analytics.com")
                                   ;; for webpack hot reloading
                                   (when config/is-dev?   ;; <----------- when dev, allow connections to 8080
                                     "*:8080")
....)
```

#### After

<img width="951" alt="image" src="https://user-images.githubusercontent.com/6377293/231535713-656c00d3-61bb-42fd-9f6e-f19b9bf73687.png">

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30043)
<!-- Reviewable:end -->
