### PR TITLE
Don't allow unscoped text selectors in e2e tests

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,8 @@
     "grunt.autoDetect": "off",
     "jake.autoDetect": "off",
     "gulp.autoDetect": "off",
-    "npm.autoDetect": "off"
+    "npm.autoDetect": "off",
+    "eslint.options": {
+      "rulePaths": ["frontend/lint/eslint-rules/"]
+    }
 }

--- a/e2e/.eslintrc
+++ b/e2e/.eslintrc
@@ -1,5 +1,6 @@
 {
   "rules": {
+    "no-unscoped-text-selectors": 2,
     "import/no-commonjs": 0,
     "no-color-literals": 0,
     "no-console": 0

--- a/e2e/test/scenarios/admin/databases/add-new-database.cy.spec.js
+++ b/e2e/test/scenarios/admin/databases/add-new-database.cy.spec.js
@@ -19,6 +19,7 @@ describe("admin > database > add", () => {
 
     cy.visit("/admin/databases/create");
     // should display a setup help card
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Need help connecting?");
 
     cy.findByLabelText("Database type").click();
@@ -40,7 +41,9 @@ describe("admin > database > add", () => {
     // should surface an error if the connection string is invalid
     cy.button("Save").click();
     cy.wait("@createDatabase");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(": check your connection string");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Implicitly relative file paths are not allowed.");
 
     // should be able to recover from an error and add database with the correct connection string
@@ -56,8 +59,10 @@ describe("admin > database > add", () => {
 
   describe("external databases", { tags: "@external" }, () => {
     it("should add Postgres database and redirect to listing (metabase#12972, metabase#14334, metabase#17450)", () => {
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("PostgreSQL").click({ force: true });
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Show advanced options").click();
 
       // Reproduces (metabase#14334)
@@ -66,6 +71,7 @@ describe("admin > database > add", () => {
         "aria-checked",
         "true",
       );
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("Additional JDBC connection string options");
       // Reproduces (metabase#17450)
       cy.findByLabelText("Choose when syncs and scans happen")
@@ -143,6 +149,7 @@ describe("admin > database > add", () => {
 
       cy.url().should("match", /\/admin\/databases\?created=true$/);
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("We're taking a look at your database!");
       cy.findByLabelText("close icon").click();
 
@@ -169,8 +176,11 @@ describe("admin > database > add", () => {
     });
 
     it("should add Mongo database and redirect to listing", () => {
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("MongoDB").click({ force: true });
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Show advanced options").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("Additional connection string options");
 
       typeAndBlurUsingLabel("Display name", "QA Mongo4");
@@ -181,6 +191,7 @@ describe("admin > database > add", () => {
       typeAndBlurUsingLabel("Password", "metasample123");
       typeAndBlurUsingLabel("Authentication database (optional)", "admin");
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Save").should("not.be.disabled").click();
 
       cy.wait("@createDatabase");
@@ -200,7 +211,9 @@ describe("admin > database > add", () => {
     it("should add Mongo database via the connection string", () => {
       const connectionString = `mongodb://metabase:metasample123@localhost:${QA_MONGO_PORT}/sample?authSource=admin`;
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("MongoDB").click({ force: true });
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Paste a connection string").click();
       typeAndBlurUsingLabel("Display name", "QA Mongo4");
       cy.findByLabelText("Port").should("not.exist");
@@ -211,6 +224,7 @@ describe("admin > database > add", () => {
         },
       );
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Save").should("not.be.disabled").click();
 
       cy.wait("@createDatabase");
@@ -228,8 +242,11 @@ describe("admin > database > add", () => {
     });
 
     it("should add MySQL database and redirect to listing", () => {
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("MySQL").click({ force: true });
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Show advanced options").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("Additional JDBC connection string options");
 
       typeAndBlurUsingLabel("Display name", "QA MySQL8");
@@ -246,6 +263,7 @@ describe("admin > database > add", () => {
         "allowPublicKeyRetrieval=true",
       );
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Save").should("not.be.disabled").click();
 
       cy.wait("@createDatabase");

--- a/e2e/test/scenarios/admin/databases/database-exceptions.cy.spec.js
+++ b/e2e/test/scenarios/admin/databases/database-exceptions.cy.spec.js
@@ -21,6 +21,7 @@ describe("scenarios > admin > databases > exceptions", () => {
     cy.get("nav").should("contain", "Metabase Admin");
     // The response still contains the database name,
     // so there's no reason we can't display it.
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains(/Sample Database/i);
     // This seems like a reasonable CTA if the database is beyond repair.
     cy.button("Remove this database").should("not.be.disabled");
@@ -43,6 +44,7 @@ describe("scenarios > admin > databases > exceptions", () => {
     cy.button("Save").click();
     cy.wait("@createDatabase");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("DATABASE CONNECTION ERROR").should("exist");
   });
 
@@ -52,6 +54,7 @@ describe("scenarios > admin > databases > exceptions", () => {
     cy.wait("@loadDatabase").then(({ response }) => {
       expect(response.statusCode).to.eq(404);
     });
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Not found.");
     cy.findByRole("table").should("not.exist");
   });
@@ -81,12 +84,16 @@ describe("scenarios > admin > databases > exceptions", () => {
     cy.wait("@failedGet");
 
     cy.findByRole("heading", { name: "Something's gone wrong" });
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(
       "We've run into an error. You can try refreshing the page, or just go back.",
     );
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(errorMessage).should("not.be.visible");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Show error details").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(errorMessage).should("be.visible");
   });
 });

--- a/e2e/test/scenarios/admin/databases/default-sample-database.cy.spec.js
+++ b/e2e/test/scenarios/admin/databases/default-sample-database.cy.spec.js
@@ -17,6 +17,7 @@ describe("scenarios > admin > databases > sample database", () => {
   it("database settings", () => {
     visitDatabase(SAMPLE_DB_ID);
     // should not display a setup help card
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Need help connecting?").should("not.exist");
 
     cy.log(
@@ -33,6 +34,7 @@ describe("scenarios > admin > databases > sample database", () => {
       .and("contain", "sample-database.db");
 
     cy.log("should be possible to modify the connection settings");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Show advanced options").click();
     // `auto_run_queries` toggle should be ON by default
     cy.findByLabelText("Rerun queries for simple explorations")
@@ -50,6 +52,7 @@ describe("scenarios > admin > databases > sample database", () => {
 
     cy.log("change the metadata_sync period");
     cy.findByLabelText("Choose when syncs and scans happen").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Hourly").click();
     popover().within(() => {
       cy.findByText("Daily").click({ force: true });
@@ -139,14 +142,18 @@ describe("scenarios > admin > databases > sample database", () => {
     // lets you trigger the manual database schema sync
     cy.button("Sync database schema now").click();
     cy.wait("@sync_schema");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Sync triggered!");
 
     // lets you trigger the manual rescan of field values
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Re-scan field values now").click();
     cy.wait("@rescan_values");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Scan triggered!");
 
     // lets you discard saved field values
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Danger Zone")
       .parent()
       .as("danger")
@@ -206,6 +213,7 @@ describe("scenarios > admin > databases > sample database", () => {
 
     cy.location("pathname").should("eq", "/admin/databases/"); // FIXME why the trailing slash?
     cy.intercept("POST", "/api/database/sample_database").as("sample_database");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Bring the sample database back", {
       timeout: 10000,
     }).click();
@@ -227,6 +235,7 @@ describe("scenarios > admin > databases > sample database", () => {
         expect(body.cache_ttl).to.be.null;
       });
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Show advanced options").click();
 
       setCustomCacheTTLValue("48");

--- a/e2e/test/scenarios/admin/datamodel/editor.cy.spec.js
+++ b/e2e/test/scenarios/admin/datamodel/editor.cy.spec.js
@@ -47,6 +47,7 @@ describe("scenarios > admin > datamodel > editor", () => {
       setValueAndBlurInput("Orders", "New orders");
       cy.wait("@updateTable");
       cy.findByDisplayValue("New orders").should("be.visible");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Updated Table display_name").should("be.visible");
 
       startNewQuestion();
@@ -62,10 +63,13 @@ describe("scenarios > admin > datamodel > editor", () => {
       setValueAndBlurInput(ORDERS_DESCRIPTION, "New description");
       cy.wait("@updateTable");
       cy.findByDisplayValue("New description").should("be.visible");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Updated Table description").should("be.visible");
 
       cy.visit(`/reference/databases/${SAMPLE_DB_ID}/tables/${ORDERS_ID}`);
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Orders").should("be.visible");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("New description").should("be.visible");
     });
 
@@ -73,18 +77,24 @@ describe("scenarios > admin > datamodel > editor", () => {
       visitTableMetadata();
       clearAndBlurInput(ORDERS_DESCRIPTION);
       cy.wait("@updateTable");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Updated Table description").should("be.visible");
 
       cy.visit(`/reference/databases/${SAMPLE_DB_ID}/tables/${ORDERS_ID}`);
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Orders").should("be.visible");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("No description yet").should("be.visible");
     });
 
     it("should allow changing the table visibility", () => {
       visitTableMetadata();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Hidden").click();
       cy.wait("@updateTable");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Updated Table visibility_type").should("be.visible");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("5 Hidden Tables").should("be.visible");
 
       startNewQuestion();
@@ -95,8 +105,10 @@ describe("scenarios > admin > datamodel > editor", () => {
       });
 
       visitTableMetadata();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Queryable").click();
       cy.wait("@updateTable");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("4 Hidden Tables").should("be.visible");
 
       startNewQuestion();
@@ -114,10 +126,13 @@ describe("scenarios > admin > datamodel > editor", () => {
       });
       cy.wait("@updateField");
       getFieldSection("TAX").findByDisplayValue("New tax").should("be.visible");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Updated Tax").should("be.visible");
 
       openOrdersTable();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("New tax").should("be.visible");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Tax").should("not.exist");
     });
 
@@ -130,12 +145,15 @@ describe("scenarios > admin > datamodel > editor", () => {
       getFieldSection("TOTAL")
         .findByDisplayValue("New description")
         .should("be.visible");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Updated Total").should("be.visible");
 
       cy.visit(
         `/reference/databases/${SAMPLE_DB_ID}/tables/${ORDERS_ID}/fields/${ORDERS.TOTAL}`,
       );
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Total").should("be.visible");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("New description").should("be.visible");
     });
 
@@ -145,12 +163,15 @@ describe("scenarios > admin > datamodel > editor", () => {
         clearAndBlurInput("The total billed amount.");
       });
       cy.wait("@updateField");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Updated Total").should("be.visible");
 
       cy.visit(
         `/reference/databases/${SAMPLE_DB_ID}/tables/${ORDERS_ID}/fields/${ORDERS.TOTAL}`,
       );
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Total").should("be.visible");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("No description yet").should("be.visible");
     });
 
@@ -160,11 +181,15 @@ describe("scenarios > admin > datamodel > editor", () => {
       popover().findByText("Do not include").click();
       cy.wait("@updateField");
       getFieldSection("TAX").findByText("Do not include").should("be.visible");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Do not include").should("be.visible");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Updated Tax").should("be.visible");
 
       openOrdersTable();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Total").should("be.visible");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Tax").should("not.exist");
     });
 
@@ -174,6 +199,7 @@ describe("scenarios > admin > datamodel > editor", () => {
       searchAndSelectValue("Currency");
       cy.wait("@updateField");
       getFieldSection("TAX").findByText("Currency").should("be.visible");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Updated Tax").should("be.visible");
 
       getFieldSection("TAX").findByText("US Dollar").click();
@@ -181,6 +207,7 @@ describe("scenarios > admin > datamodel > editor", () => {
       cy.wait("@updateField");
 
       openOrdersTable();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Tax (CA$)").should("be.visible");
     });
 
@@ -192,6 +219,7 @@ describe("scenarios > admin > datamodel > editor", () => {
       getFieldSection("USER_ID")
         .findByText("Products → ID")
         .should("be.visible");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Updated User ID").should("be.visible");
 
       startNewQuestion();
@@ -203,6 +231,7 @@ describe("scenarios > admin > datamodel > editor", () => {
       popover().within(() => {
         cy.findByText("Products").click();
       });
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("User ID").should("be.visible");
     });
 
@@ -273,14 +302,17 @@ describe("scenarios > admin > datamodel > editor", () => {
 
     it("should allow hiding and restoring all tables in a schema", () => {
       visitTableMetadata();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("4 Queryable Tables").should("be.visible");
       cy.findByLabelText("Hide all").click();
       cy.wait("@updateTables");
 
       visitTableMetadata();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("8 Hidden Tables").should("be.visible");
       cy.findByLabelText("Unhide all").click();
       cy.wait("@updateTables");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("8 Queryable Tables").should("be.visible");
     });
   });
@@ -296,10 +328,13 @@ describe("scenarios > admin > datamodel > editor", () => {
       setValueAndBlurInput("Tax", "New tax");
       cy.wait("@updateField");
       cy.findByDisplayValue("New tax").should("be.visible");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Updated Tax").should("be.visible");
 
       openOrdersTable();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("New tax").should("be.visible");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Tax").should("not.exist");
     });
 
@@ -308,50 +343,66 @@ describe("scenarios > admin > datamodel > editor", () => {
       setValueAndBlurInput("The total billed amount.", "New description");
       cy.wait("@updateField");
       cy.findByDisplayValue("New description").should("be.visible");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Updated Total").should("be.visible");
 
       cy.visit(
         `/reference/databases/${SAMPLE_DB_ID}/tables/${ORDERS_ID}/fields/${ORDERS.TOTAL}`,
       );
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Total").should("be.visible");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("New description").should("be.visible");
     });
 
     it("should allow changing the field visibility", () => {
       visitFieldMetadata({ fieldId: ORDERS.TAX });
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Everywhere").click();
       popover().findByText("Do not include").click();
       cy.wait("@updateField");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Do not include").should("be.visible");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Updated Tax").should("be.visible");
 
       openOrdersTable();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Total").should("be.visible");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Tax").should("not.exist");
     });
 
     it("should allow changing the field semantic type and currency", () => {
       visitFieldMetadata({ fieldId: ORDERS.TAX });
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("No semantic type").click();
       searchAndSelectValue("Currency");
       cy.wait("@updateField");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Currency").should("be.visible");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Updated Tax").should("be.visible");
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("US Dollar").click();
       searchAndSelectValue("Canadian Dollar");
       cy.wait("@updateField");
 
       openOrdersTable();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Tax (CA$)").should("be.visible");
     });
 
     it("should allow changing the field foreign key target", () => {
       visitFieldMetadata({ fieldId: ORDERS.USER_ID });
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("People → ID").click();
       popover().findByText("Products → ID").click();
       cy.wait("@updateField");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Products → ID").should("be.visible");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Updated User ID").should("be.visible");
 
       startNewQuestion();
@@ -363,6 +414,7 @@ describe("scenarios > admin > datamodel > editor", () => {
       popover().within(() => {
         cy.findByText("Products").click();
       });
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("User ID").should("be.visible");
     });
   });
@@ -381,6 +433,7 @@ describe("scenarios > admin > datamodel > editor", () => {
       setValueAndBlurInput("Orders", "New orders");
       cy.findByDisplayValue("New orders").should("be.visible");
       cy.wait("@updateTable");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Updated Table display_name");
       cy.signOut();
 
@@ -403,11 +456,14 @@ describe("scenarios > admin > datamodel > editor", () => {
       );
       cy.wait("@updateField");
       getFieldSection("TAX").findByDisplayValue("New tax").should("be.visible");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Updated Tax").should("be.visible");
 
       cy.signInAsNormalUser();
       openOrdersTable();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("New tax").should("be.visible");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Tax").should("not.exist");
     });
 
@@ -419,11 +475,14 @@ describe("scenarios > admin > datamodel > editor", () => {
       setValueAndBlurInput("Total", "New total");
       cy.wait("@updateField");
       cy.findByDisplayValue("New total").should("be.visible");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Updated Total").should("be.visible");
 
       cy.signInAsNormalUser();
       openOrdersTable();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("New total").should("be.visible");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Total").should("not.exist");
     });
 
@@ -434,13 +493,16 @@ describe("scenarios > admin > datamodel > editor", () => {
 
       cy.signIn("none");
       visitFieldMetadata({ fieldId: ORDERS.USER_ID });
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("People → ID").click();
       popover().within(() => {
         cy.findByText("Reviews → ID").should("not.exist");
         cy.findByText("Products → ID").click();
       });
       cy.wait("@updateField");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Products → ID").should("be.visible");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Updated User ID").should("be.visible");
 
       cy.signInAsNormalUser();
@@ -453,6 +515,7 @@ describe("scenarios > admin > datamodel > editor", () => {
       popover().within(() => {
         cy.findByText("Products").click();
       });
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("User ID").should("be.visible");
     });
 
@@ -463,6 +526,7 @@ describe("scenarios > admin > datamodel > editor", () => {
 
       cy.signIn("none");
       visitFieldMetadata({ tableId: REVIEWS_ID, fieldId: REVIEWS.PRODUCT_ID });
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Use original value").click();
       popover().findByText("Use foreign key").click();
       popover().findByText("Title").click();
@@ -470,6 +534,7 @@ describe("scenarios > admin > datamodel > editor", () => {
 
       cy.signInAsNormalUser();
       openReviewsTable({ limit: 1 });
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Rustic Paper Wallet").should("be.visible");
     });
 
@@ -478,6 +543,7 @@ describe("scenarios > admin > datamodel > editor", () => {
 
       cy.signIn("none");
       visitFieldMetadata({ tableId: REVIEWS_ID, fieldId: REVIEWS.PRODUCT_ID });
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Use original value").click();
       popover().within(() => {
         cy.findByText("Use original value").should("be.visible");
@@ -490,6 +556,7 @@ describe("scenarios > admin > datamodel > editor", () => {
 
       cy.signIn("none");
       visitFieldMetadata({ tableId: REVIEWS_ID, fieldId: REVIEWS.RATING });
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Use original value").click();
       popover().within(() => {
         cy.findByText("Use original value").should("be.visible");
@@ -498,13 +565,16 @@ describe("scenarios > admin > datamodel > editor", () => {
 
       cy.signInAsAdmin();
       visitFieldMetadata({ tableId: REVIEWS_ID, fieldId: REVIEWS.RATING });
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Use original value").click();
       popover().findByText("Custom mapping").click();
       cy.wait("@updateFieldDimension");
 
       cy.signIn("none");
       visitFieldMetadata({ tableId: REVIEWS_ID, fieldId: REVIEWS.RATING });
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Custom mapping").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(CUSTOM_MAPPING_ERROR).should("be.visible");
     });
   });

--- a/e2e/test/scenarios/admin/datamodel/field.cy.spec.js
+++ b/e2e/test/scenarios/admin/datamodel/field.cy.spec.js
@@ -69,11 +69,14 @@ describe.skip("scenarios > admin > datamodel > field", () => {
     it("lets you change field visibility", () => {
       visitAlias("@ORDERS_CREATED_AT_URL");
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("Everywhere").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("Do not include").click({ force: true });
       cy.wait("@fieldUpdate");
 
       cy.reload();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("Do not include");
     });
   });
@@ -84,11 +87,14 @@ describe.skip("scenarios > admin > datamodel > field", () => {
     it("lets you change to 'Search box'", () => {
       visitAlias("@ORDERS_QUANTITY_URL");
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("A list of all values").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("Search box").click();
       cy.wait("@fieldUpdate");
 
       cy.reload();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("Search box");
     });
   });
@@ -99,13 +105,18 @@ describe.skip("scenarios > admin > datamodel > field", () => {
     it("lets you change to 'Use foreign key' and change the target for field with fk", () => {
       visitAlias("@ORDERS_PRODUCT_ID_URL");
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("Use original value").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("Use foreign key").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("Title").click();
       cy.wait("@fieldDimensionUpdate");
 
       cy.reload();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("Use foreign key");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("Title");
     });
 
@@ -123,18 +134,24 @@ describe.skip("scenarios > admin > datamodel > field", () => {
       );
 
       // change to custom mapping
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Use original value").click();
       popover().findByText("Custom mapping").click();
 
       // update text for nulls from "null" to "nothin"
       cy.get("input[value=null]").clear().type("nothin");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Save").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Saved!");
 
       // check that it appears in QB
       startNewQuestion();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("sqlite").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Number With Nulls").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("nothin");
     });
   });
@@ -161,9 +178,11 @@ describe("Unfold JSON", () => {
     );
     // Go to field settings
     cy.visit(`/admin/datamodel/database/${WRITABLE_DB_ID}`);
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(/Many Data Types/i).click();
 
     // Check json is unfolded initially
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(/json.a/i).should("be.visible");
     cy.findByTestId("column-json").within(() => {
       cy.icon("gear").click();
@@ -180,13 +199,17 @@ describe("Unfold JSON", () => {
 
     // Sync database
     cy.visit(`/admin/databases/${WRITABLE_DB_ID}`);
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(/Sync database schema now/i).click();
     cy.wait("@sync_schema");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Sync triggered!");
 
     // Check json field is not unfolded
     cy.visit(`/admin/datamodel/database/${WRITABLE_DB_ID}`);
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(/Many Data Types/i).click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(/json.a/i).should("not.exist");
   });
 });

--- a/e2e/test/scenarios/admin/datamodel/hide_tables.cy.spec.js
+++ b/e2e/test/scenarios/admin/datamodel/hide_tables.cy.spec.js
@@ -17,19 +17,26 @@ describe("scenarios > admin > datamodel > hidden tables (metabase#9759)", () => 
   it("hidden table should not show up in various places in UI", () => {
     // Visit the main page, we shouldn't be able to see the table
     cy.visit(`/browse/${PRODUCTS_ID}`);
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Products");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Orders").should("not.exist");
 
     // It shouldn't show up for a normal user either
     cy.signInAsNormalUser();
     cy.visit(`/browse/${PRODUCTS_ID}`);
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Products");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Orders").should("not.exist");
 
     // It shouldn't show in a new question data picker
     startNewQuestion();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Sample Database").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Products");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Orders").should("not.exist");
   });
 });

--- a/e2e/test/scenarios/admin/datamodel/metadata.cy.spec.js
+++ b/e2e/test/scenarios/admin/datamodel/metadata.cy.spec.js
@@ -20,15 +20,19 @@ describe("scenarios > admin > datamodel > metadata", () => {
     // go directly to Data Model page for Sample Database
     cy.visit(`/admin/datamodel/database/${SAMPLE_DB_ID}`);
     // edit "Product ID" column in "Orders" table
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Orders").click();
     cy.findByTestId("column-PRODUCT_ID").find(".Icon-gear").click();
 
     // remap its original value to use foreign key
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Use original value").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Use foreign key").click();
     popover().within(() => {
       cy.findByText("Title").click();
     });
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(
       "You might want to update the field name to make sure it still makes sense based on your remapping choices.",
     );
@@ -51,12 +55,16 @@ describe("scenarios > admin > datamodel > metadata", () => {
     // go directly to Data Model page for Sample Database
     cy.visit(`/admin/datamodel/database/${SAMPLE_DB_ID}`);
     // edit "Rating" values in "Reviews" table
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Reviews").click();
     cy.findByTestId("column-RATING").find(".Icon-gear").click();
 
     // apply custom remapping for "Rating" values 1-5
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Use original value").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Custom mapping").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(
       "You might want to update the field name to make sure it still makes sense based on your remapping choices.",
     );
@@ -64,6 +72,7 @@ describe("scenarios > admin > datamodel > metadata", () => {
     Object.entries(customMap).forEach(([key, value]) => {
       cy.findByDisplayValue(key).click().clear().type(value);
     });
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Save").click();
 
     cy.log("Numeric ratings should be remapped to custom strings");
@@ -92,9 +101,11 @@ describe("scenarios > admin > datamodel > metadata", () => {
       { visitQuestion: true },
     );
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Created At: Hour of day");
 
     cy.log("Reported failing in v0.37.2");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(/^3:00 AM$/);
   });
 
@@ -110,7 +121,9 @@ describe("scenarios > admin > datamodel > metadata", () => {
 
     openReviewsTable({ mode: "notebook" });
     summarize({ mode: "notebook" });
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Count of rows").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Pick a column to group by").click();
     cy.get(".List-section-header").contains("Created At").click();
     cy.get(".List-section--expanded .List-item-title")

--- a/e2e/test/scenarios/admin/datamodel/metrics.cy.spec.js
+++ b/e2e/test/scenarios/admin/datamodel/metrics.cy.spec.js
@@ -33,12 +33,17 @@ describe("scenarios > admin > datamodel > metrics", () => {
     openOrdersTable({ mode: "notebook" });
 
     summarize({ mode: "notebook" });
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Common Metrics").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Revenue").click();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Pick a column to group by").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Created At").click();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Sort").click();
 
     // Sorts ascending by default
@@ -72,6 +77,7 @@ describe("scenarios > admin > datamodel > metrics", () => {
   describe("with no metrics", () => {
     it("should show no metrics in the list", () => {
       cy.visit("/admin/datamodel/metrics");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(
         "Create metrics to add them to the Summarize dropdown in the query builder",
       );
@@ -79,9 +85,11 @@ describe("scenarios > admin > datamodel > metrics", () => {
 
     it("should show how to create metrics", () => {
       cy.visit("/reference/metrics");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(
         "Metrics are the official numbers that your team cares about",
       );
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Learn how to create metrics");
     });
 
@@ -98,6 +106,7 @@ describe("scenarios > admin > datamodel > metrics", () => {
       // `data`, `filtered by` and `view`
       cy.wait(["@dataset", "@dataset", "@dataset"]);
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Count").click();
       popover().contains("Custom Expression").click();
 
@@ -113,9 +122,11 @@ describe("scenarios > admin > datamodel > metrics", () => {
       cy.wait("@dataset");
 
       // The test should fail on this step first
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Result: 93.8");
 
       // Let's make sure the custom expression is still preserved
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Foo").click();
       cy.get(".ace_content").should("contain", customExpression);
     });
@@ -139,8 +150,11 @@ describe("scenarios > admin > datamodel > metrics", () => {
     it("should show no questions based on a new metric", () => {
       cy.visit("/reference/metrics/1/questions");
       cy.findAllByText("Questions about orders < 100");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Loading...");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Loading...").should("not.exist");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(
         "Questions about this metric will appear here as they're added",
       );
@@ -158,14 +172,18 @@ describe("scenarios > admin > datamodel > metrics", () => {
       });
 
       cy.findByTestId("apply-filters").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Save").click();
       cy.findAllByText("Save").last().click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Not now").click();
 
       // Check the list
       cy.visit("/reference/metrics/1/questions");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Our analysis").should("not.exist");
       cy.findAllByText("Questions about orders < 100");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(
         "Orders, orders < 100, Filtered by Total is greater than or equal to 50",
       );
@@ -173,26 +191,34 @@ describe("scenarios > admin > datamodel > metrics", () => {
 
     it("should show the metric detail view for a specific id", () => {
       cy.visit("/admin/datamodel/metric/1");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Edit Your Metric");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Preview");
     });
 
     it("should update that metric", () => {
       cy.visit("/admin");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("Data Model").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("Metrics").click();
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("orders < 100")
         .parent()
         .parent()
         .parent()
         .find(".Icon-ellipsis")
         .click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("Edit Metric").click();
 
       // update the filter from "< 100" to "> 10"
       cy.url().should("match", /metric\/1$/);
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("Edit Your Metric");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains(/Total\s+is less than/).click();
       popover().contains("Less than").click();
       popover().contains("Greater than").click();
@@ -200,6 +226,7 @@ describe("scenarios > admin > datamodel > metrics", () => {
       popover().contains("Update filter").click();
 
       // confirm that the preview updated
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("Result: 18758");
 
       // update name and description, set a revision note, and save the update
@@ -208,19 +235,23 @@ describe("scenarios > admin > datamodel > metrics", () => {
         "{selectall}Count of orders with a total over $10.",
       );
       cy.get('[name="revision_message"]').type("time for a change");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("Save changes").click();
 
       // get redirected to previous page and see the new metric name
       cy.url().should("match", /datamodel\/metrics$/);
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("orders > 10");
 
       // clean up
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("orders > 10")
         .parent()
         .parent()
         .parent()
         .find(".Icon-ellipsis")
         .click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("Retire Metric").click();
       modal().find("textarea").type("delete it");
       modal().contains("button", "Retire").click();
@@ -256,21 +287,27 @@ describe("scenarios > admin > datamodel > metrics", () => {
         "**Navigate to the metrics page and assert the metric was indeed saved**",
       );
       cy.visit("/admin/datamodel/metrics");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(
         'Unexpected input given to normalize. Expected type to be "object", found "string".',
       ).should("not.exist");
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("13022_Metric"); // Name
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Orders, CE"); // Definition
     });
 
     it("should show CE that uses 'AND/OR' (metabase#13069, metabase#13070)", () => {
       cy.visit("/admin/datamodel/metrics");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("New metric").click();
 
       selectTable("Orders");
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Add filters to narrow your answer").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Custom Expression").click();
       cy.get(".ace_text-input")
         .clear()
@@ -279,6 +316,7 @@ describe("scenarios > admin > datamodel > metrics", () => {
       cy.button("Done").click();
 
       cy.log("**Assert that there is a filter text visible**");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("ID > 0 OR ID < 9876543210");
     });
   });

--- a/e2e/test/scenarios/admin/datamodel/reproductions/17768-entity-key-showing-binning-options.cy.spec.js
+++ b/e2e/test/scenarios/admin/datamodel/reproductions/17768-entity-key-showing-binning-options.cy.spec.js
@@ -34,6 +34,7 @@ describe("issue 17768", () => {
     openReviewsTable({ mode: "notebook" });
 
     summarize({ mode: "notebook" });
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Pick a column to group by").click();
 
     popover().within(() => {

--- a/e2e/test/scenarios/admin/datamodel/reproductions/18384-field-settings-breaks-ui.cy.spec.js
+++ b/e2e/test/scenarios/admin/datamodel/reproductions/18384-field-settings-breaks-ui.cy.spec.js
@@ -28,6 +28,7 @@ describe("issue 18384", () => {
       `/admin/datamodel/database/${SAMPLE_DB_ID}/schema/${SAMPLE_DB_SCHEMA_ID}/table/${PEOPLE_ID}/field/${PEOPLE.ADDRESS}/general`,
     );
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(/Address – Field Settings/i);
   });
 });

--- a/e2e/test/scenarios/admin/datamodel/reproductions/21984-data-model-registered-as-view.cy.spec.js
+++ b/e2e/test/scenarios/admin/datamodel/reproductions/21984-data-model-registered-as-view.cy.spec.js
@@ -23,11 +23,15 @@ describe("issue 21984", () => {
   it('should not show data model visited tables in search or in "Pick up where you left off" items on homepage (metabase#21984)', () => {
     cy.visit("/");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Metabase tips");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Pick up where you left off").should("not.exist");
 
     cy.findByPlaceholderText("Search…").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Recently viewed");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Nothing here");
   });
 });

--- a/e2e/test/scenarios/admin/datamodel/segments.cy.spec.js
+++ b/e2e/test/scenarios/admin/datamodel/segments.cy.spec.js
@@ -21,7 +21,9 @@ describe("scenarios > admin > datamodel > segments", () => {
   describe("with no segments", () => {
     it("should show no segments in UI", () => {
       cy.visit("/admin/datamodel/segments");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Segments").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(
         "Create segments to add them to the Filter dropdown in the query builder",
       );
@@ -29,7 +31,9 @@ describe("scenarios > admin > datamodel > segments", () => {
 
     it("should have 'Custom expression' in a filter list (metabase#13069)", () => {
       cy.visit("/admin/datamodel/segments");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("New segment").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Select a table").click();
 
       // Ugly hack to prevent failures that started after https://github.com/metabase/metabase/pull/24682 has been merged.
@@ -43,6 +47,7 @@ describe("scenarios > admin > datamodel > segments", () => {
         cy.findByText("Orders").click();
       });
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Add filters to narrow your answer").click();
 
       cy.log("Fails in v0.36.0 and v0.36.3. It exists in v0.35.4");
@@ -53,7 +58,9 @@ describe("scenarios > admin > datamodel > segments", () => {
 
     it("should show no segments", () => {
       cy.visit("/reference/segments");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Segments are interesting subsets of tables");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Learn how to create segments");
     });
   });
@@ -78,35 +85,47 @@ describe("scenarios > admin > datamodel > segments", () => {
     it("should show the segment fields list and detail view", () => {
       // In the list
       cy.visit("/reference/segments");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(SEGMENT_NAME);
 
       // Detail view
       cy.visit("/reference/segments/1");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Description");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("See this segment");
 
       // Segment fields
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Fields in this segment").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("See this segment").should("not.exist");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(`Fields in ${SEGMENT_NAME}`);
       cy.findAllByText("Discount");
     });
 
     it("should show up in UI list", () => {
       cy.visit("/admin/datamodel/segments");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains(SEGMENT_NAME);
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("Filtered by Total");
     });
 
     it("should show the segment details of a specific id", () => {
       cy.visit("/admin/datamodel/segment/1");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Edit Your Segment");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Preview");
     });
 
     it("should show no questions based on a new segment", () => {
       cy.visit("/reference/segments/1/questions");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(`Questions about ${SEGMENT_NAME}`);
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(
         "Questions about this segment will appear here as they're added",
       );
@@ -124,34 +143,46 @@ describe("scenarios > admin > datamodel > segments", () => {
       });
       cy.findByTestId("apply-filters").click();
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Product ID is 14");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Save").click();
       cy.findAllByText("Save").last().click();
 
       // Check list
       cy.visit("/reference/segments/1/questions");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(
         "Questions about this segment will appear here as they're added",
       ).should("not.exist");
-      cy.findByText(`Orders, Filtered by ${SEGMENT_NAME} and Product ID equals 14`);
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
+      cy.findByText(
+        `Orders, Filtered by ${SEGMENT_NAME} and Product ID equals 14`,
+      );
     });
 
     it("should update that segment", () => {
       cy.visit("/admin");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("Data Model").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("Segments").click();
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains(SEGMENT_NAME)
         .parent()
         .parent()
         .parent()
         .find(".Icon-ellipsis")
         .click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("Edit Segment").click();
 
       // update the filter from "< 100" to "> 10"
       cy.url().should("match", /segment\/1$/);
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("Edit Your Segment");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains(/Total\s+is less than/).click();
       popover().contains("Less than").click();
       popover().contains("Greater than").click();
@@ -159,6 +190,7 @@ describe("scenarios > admin > datamodel > segments", () => {
       popover().contains("Update filter").click();
 
       // confirm that the preview updated
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("18758 rows");
 
       // update name and description, set a revision note, and save the update
@@ -167,19 +199,23 @@ describe("scenarios > admin > datamodel > segments", () => {
         .clear()
         .type("All orders with a total over $10.");
       cy.get('[name="revision_message"]').type("time for a change");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("Save changes").click();
 
       // get redirected to previous page and see the new segment name
       cy.url().should("match", /datamodel\/segments$/);
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("Orders > 10");
 
       // clean up
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("Orders > 10")
         .parent()
         .parent()
         .parent()
         .find(".Icon-ellipsis")
         .click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("Retire Segment").click();
       modal().find("textarea").type("delete it");
       modal().contains("button", "Retire").click();

--- a/e2e/test/scenarios/admin/datamodel/table.cy.spec.js
+++ b/e2e/test/scenarios/admin/datamodel/table.cy.spec.js
@@ -17,12 +17,15 @@ describe("scenarios > admin > databases > table", () => {
 
   it("should be able to see details of each table", () => {
     cy.visit(`/admin/datamodel/database/${SAMPLE_DB_ID}`);
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(
       "Select any table to see its schema and add or edit metadata.",
     );
 
     // Orders
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Orders").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(
       "Select any table to see its schema and add or edit metadata.",
     ).should("not.exist");
@@ -34,7 +37,9 @@ describe("scenarios > admin > databases > table", () => {
   it("should show 404 if database does not exist (metabase#14652)", () => {
     cy.visit("/admin/datamodel/database/54321");
     cy.get(".AdminList-item").should("have.length", 0);
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Not found.");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Select a database");
   });
 
@@ -53,6 +58,7 @@ describe("scenarios > admin > databases > table", () => {
       cy.findAllByText("No semantic type");
 
       cy.get("input[value='Discount']");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Discount");
     });
 
@@ -63,6 +69,7 @@ describe("scenarios > admin > databases > table", () => {
 
     it("should see the created_at timestamp field", () => {
       cy.get("input[value='Created At']");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Creation timestamp");
     });
   });

--- a/e2e/test/scenarios/admin/people/group-managers.cy.spec.js
+++ b/e2e/test/scenarios/admin/people/group-managers.cy.spec.js
@@ -17,6 +17,7 @@ describeEE("scenarios > admin > people", () => {
     restore();
     cy.signInAsAdmin();
     cy.visit("/admin/people");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(normalUserName)
       .closest("tr")
       .findByText("2 other groups")
@@ -27,6 +28,7 @@ describeEE("scenarios > admin > people", () => {
     cy.signInAsNormalUser();
     cy.visit("/");
     cy.icon("gear").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Admin settings").click();
   });
 
@@ -38,20 +40,25 @@ describeEE("scenarios > admin > people", () => {
 
       // Edit group name
       cy.icon("ellipsis").eq(0).click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Edit Name").click();
       cy.get("input").type(" updated");
       cy.button("Done").click();
 
       // Click on the group with the new name
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("collection updated").click();
 
       // Add "No Collection" user as a member
       cy.button("Add members").click();
       cy.focused().type("No");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(noCollectionUserName).click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Add").click();
 
       // Find user row
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(noCollectionUserName).closest("tr").as("userRow");
 
       // Promote to manager and demote back to member
@@ -69,9 +76,11 @@ describeEE("scenarios > admin > people", () => {
       cy.get("@userRow").within(() => {
         cy.icon("close").click();
       });
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(noCollectionUserName).should("not.exist");
 
       // Demote myself
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(normalUserName)
         .closest("tr")
         .within(() => {
@@ -84,9 +93,11 @@ describeEE("scenarios > admin > people", () => {
       cy.url().should("match", /\/admin\/people\/groups$/);
 
       // Open another group
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("data").click();
 
       // Remove myself
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(normalUserName)
         .closest("tr")
         .within(() => {
@@ -100,6 +111,7 @@ describeEE("scenarios > admin > people", () => {
 
     it("can manage members from the people page", () => {
       // Open membership select for a user
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(noCollectionUserName)
         .closest("tr")
         .as("userRow")
@@ -130,6 +142,7 @@ describeEE("scenarios > admin > people", () => {
       });
 
       // Find own row
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(normalUserName)
         .closest("tr")
         .within(() => {

--- a/e2e/test/scenarios/admin/people/people.cy.spec.js
+++ b/e2e/test/scenarios/admin/people/people.cy.spec.js
@@ -38,6 +38,7 @@ describe("scenarios > admin > people", () => {
       cy.visit("/admin/people");
 
       assertTableRowsCount(TOTAL_USERS);
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(`${TOTAL_USERS} people found`);
 
       // A small sidebar selector
@@ -54,11 +55,13 @@ describe("scenarios > admin > people", () => {
       cy.log(
         "Dig into one of the user groups and make sure its members are listed",
       );
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("All Users").click();
       cy.get(".PageTitle").contains("All Users");
 
       // The same list as for "People"
       assertTableRowsCount(TOTAL_USERS);
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(`${TOTAL_USERS} members`);
 
       // We cannot add new users to the "All users" group directly
@@ -68,30 +71,40 @@ describe("scenarios > admin > people", () => {
       const GROUP = "collection";
 
       cy.get("@groupsTab").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(GROUP).closest("tr").contains("3");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(GROUP).click();
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("3 members");
 
       cy.button("Add members").click();
       cy.focused().type(admin.first_name);
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(adminUserName).click();
       cy.button("Add").click();
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("4 members");
 
       removeUserFromGroup(adminUserName);
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("3 members");
 
       // should load the members when navigating to the group directly
       cy.visit(`/admin/people/groups/${DATA_GROUP}`);
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("2 members");
 
       removeUserFromGroup(noCollectionUserName);
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("1 member");
 
       removeUserFromGroup(normalUserName);
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("0 members");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("A group is only as good as its members.");
     });
 
@@ -108,10 +121,14 @@ describe("scenarios > admin > people", () => {
       clickButton("Create");
 
       // second modal
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(`${FULL_NAME} has been added`);
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Show").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Done").click();
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(FULL_NAME);
     });
 
@@ -124,10 +141,14 @@ describe("scenarios > admin > people", () => {
       clickButton("Create");
 
       // second modal
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(`${email} has been added`);
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Show").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Done").click();
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(email);
     });
 
@@ -140,6 +161,7 @@ describe("scenarios > admin > people", () => {
       cy.findByLabelText("Last name").type(last_name + "New");
       cy.findByLabelText("Email").type(email.toUpperCase());
       clickButton("Create");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("Email address already in use.");
     });
 
@@ -191,20 +213,26 @@ describe("scenarios > admin > people", () => {
 
       cy.visit("/admin/people");
       showUserOptions(normalUserName);
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Edit user").click();
       cy.findByDisplayValue(normal.first_name).click().clear().type(NEW_NAME);
 
       clickButton("Update");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(NEW_FULL_NAME);
     });
 
     it("should reset user password without SMTP set up", () => {
       cy.visit("/admin/people");
       showUserOptions(normalUserName);
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Reset password").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(`Reset ${normalUserName}'s password?`);
       clickButton("Reset password");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(`${normalUserName}'s password has been reset`);
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(/^temporary password$/i);
       clickButton("Done");
     });
@@ -217,12 +245,16 @@ describe("scenarios > admin > people", () => {
 
         cy.visit("/admin/people");
         showUserOptions(normalUserName);
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("Reset password").click();
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText(`Reset ${normalUserName}'s password?`);
         clickButton("Reset password");
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText(`${normalUserName}'s password has been reset`).should(
           "not.exist",
         );
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText(/^temporary password$/i).should("not.exist");
       },
     );
@@ -231,14 +263,17 @@ describe("scenarios > admin > people", () => {
       cy.visit("/admin/people");
 
       cy.findByPlaceholderText("Find someone").type("no");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("5 people found");
       assertTableRowsCount(5);
 
       cy.findByPlaceholderText("Find someone").type("ne");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("1 person found");
       assertTableRowsCount(1);
 
       cy.findByPlaceholderText("Find someone").clear();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(`${TOTAL_USERS} people found`);
       assertTableRowsCount(TOTAL_USERS);
     });
@@ -248,6 +283,7 @@ describe("scenarios > admin > people", () => {
 
       cy.visit("/admin/people/groups");
       cy.get("main").scrollTo("bottom");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("readonly");
     });
 
@@ -278,12 +314,16 @@ describe("scenarios > admin > people", () => {
         clickButton("Create");
 
         // second modal
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText(`${FULL_NAME} has been added`);
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.contains(
           `We’ve sent an invite to ${email} with instructions to set their password.`,
         );
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("Done").click();
 
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText(FULL_NAME);
       });
 
@@ -306,7 +346,9 @@ describe("scenarios > admin > people", () => {
         clickButton("Create");
 
         // second modal
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText(`${FULL_NAME} has been added`);
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.contains(
           `We’ve sent an invite to ${email} with instructions to log in. If this user is unable to authenticate then you can reset their password.`,
         );
@@ -318,8 +360,10 @@ describe("scenarios > admin > people", () => {
             `/admin/people/${userId}/reset`,
           );
         });
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("Done").click();
 
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText(FULL_NAME);
       });
     });
@@ -348,15 +392,18 @@ describe("scenarios > admin > people", () => {
         waitForUserRequests();
 
         // Total
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText(`${NEW_TOTAL_USERS} people found`);
 
         // Page 1
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText(`1 - ${PAGE_SIZE}`);
         assertTableRowsCount(PAGE_SIZE);
         cy.findByTestId("previous-page-btn").should("be.disabled");
 
         cy.findByTestId("next-page-btn").click();
         waitForUserRequests();
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("Loading...").should("not.exist");
 
         // Page 2
@@ -366,9 +413,11 @@ describe("scenarios > admin > people", () => {
 
         cy.findByTestId("previous-page-btn").click();
         cy.wait("@users");
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("Loading...").should("not.exist");
 
         // Page 1
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText(`1 - ${PAGE_SIZE}`);
         assertTableRowsCount(PAGE_SIZE);
       });
@@ -378,15 +427,18 @@ describe("scenarios > admin > people", () => {
         cy.visit(`admin/people/groups/${ALL_USERS_GROUP}`);
 
         // Total
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText(`${NEW_TOTAL_USERS} members`);
 
         // Page 1
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText(`1 - ${PAGE_SIZE}`);
         assertTableRowsCount(PAGE_SIZE);
         cy.findByTestId("previous-page-btn").should("be.disabled");
 
         cy.findByTestId("next-page-btn").click();
         waitForUserRequests();
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("Loading...").should("not.exist");
 
         // Page 2
@@ -396,9 +448,11 @@ describe("scenarios > admin > people", () => {
 
         cy.findByTestId("previous-page-btn").click();
         cy.wait("@users");
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("Loading...").should("not.exist");
 
         // Page 1
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText(`1 - ${PAGE_SIZE}`);
         assertTableRowsCount(PAGE_SIZE);
       });
@@ -423,7 +477,9 @@ describeEE("scenarios > admin > people", () => {
     });
 
     cy.visit("/account/notifications");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Question");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Dashboard");
 
     cy.visit("/admin/people");
@@ -441,7 +497,9 @@ describeEE("scenarios > admin > people", () => {
 
     cy.visit("/account/notifications");
     cy.findByLabelText("bell icon");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Question").should("not.exist");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Dashboard").should("not.exist");
   });
 });

--- a/e2e/test/scenarios/admin/people/reproductions/23689-sandboxed-group-manager.cy.spec.js
+++ b/e2e/test/scenarios/admin/people/reproductions/23689-sandboxed-group-manager.cy.spec.js
@@ -21,6 +21,7 @@ describeEE("issue 23689", () => {
 
     visitGroupPermissionsPage(COLLECTION_GROUP);
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("3 members");
 
     findUserByFullName(normal);
@@ -33,6 +34,7 @@ describeEE("issue 23689", () => {
       .click({ force: true });
 
     // Sanity check instead of waiting for the PUT request
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Manager");
 
     cy.sandboxTable({
@@ -49,6 +51,7 @@ describeEE("issue 23689", () => {
   it("sandboxed group manager should see all other members (metabase#23689)", () => {
     visitGroupPermissionsPage(COLLECTION_GROUP);
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("3 members");
 
     findUserByFullName(sandboxed);
@@ -58,6 +61,7 @@ describeEE("issue 23689", () => {
     cy.visit("/admin/people");
     cy.wait("@membership");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(`${totalUsers} people found`);
     findUserByFullName(sandboxed);
     findUserByFullName(normal);

--- a/e2e/test/scenarios/admin/settings/cache.cy.spec.js
+++ b/e2e/test/scenarios/admin/settings/cache.cy.spec.js
@@ -27,6 +27,7 @@ describe.skip(
         setCachingValue("Minimum Query Duration", "1");
         setCachingValue("Cache Time-To-Live (TTL) multiplier", "2");
 
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("Saved");
 
         // Run the query and save the question

--- a/e2e/test/scenarios/admin/settings/cloud.cy.spec.js
+++ b/e2e/test/scenarios/admin/settings/cloud.cy.spec.js
@@ -11,7 +11,9 @@ describe.skip("Cloud settings section", () => {
     setupMetabaseCloud();
     cy.visit("/admin");
     cy.get(".AdminList-items").findByText("Cloud").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(/Cloud Settings/i);
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Go to the Metabase Store").should(
       "have.attr",
       "href",
@@ -23,6 +25,7 @@ describe.skip("Cloud settings section", () => {
     cy.visit("/admin");
     cy.get(".AdminList-items").findByText("Cloud").should("not.exist");
     cy.visit("/admin/settings/cloud");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(/Cloud Settings/i).should("not.exist");
   });
 });

--- a/e2e/test/scenarios/admin/settings/email.cy.spec.js
+++ b/e2e/test/scenarios/admin/settings/email.cy.spec.js
@@ -20,8 +20,10 @@ describe("scenarios > admin > settings > email settings", () => {
     cy.findByLabelText("Reply-To Address")
       .type("reply-to@metabase.test")
       .blur();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Save changes").click();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Changes saved!", { timeout: 10000 });
 
     // This part was added as a repro for metabase#17615
@@ -46,6 +48,7 @@ describe("scenarios > admin > settings > email settings", () => {
       "email-smtp-username": null,
     });
     cy.visit("/admin/settings/email");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Send test email").click();
     cy.findAllByText("Wrong host or port").should("have.length", 2);
   });
@@ -57,7 +60,9 @@ describe("scenarios > admin > settings > email settings", () => {
       setupSMTP();
 
       cy.visit("/admin/settings/email");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Send test email").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Sent!");
 
       cy.request("GET", `http://localhost:${WEB_PORT}/email`).then(
@@ -71,6 +76,7 @@ describe("scenarios > admin > settings > email settings", () => {
 
   it("should be able to clear email settings", () => {
     cy.visit("/admin/settings/email");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Clear").click();
     cy.findByLabelText("SMTP Host").should("have.value", "");
     cy.findByLabelText("SMTP Port").should("have.value", "");
@@ -87,6 +93,7 @@ describe("scenarios > admin > settings > email settings", () => {
       setupSMTP();
 
       cy.visit("/admin/settings/email");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Send test email").scrollIntoView();
       // Needed to scroll the page down first to be able to use findByRole() - it fails otherwise
       cy.button("Save changes").should("be.disabled");
@@ -111,6 +118,7 @@ describe("scenarios > admin > settings > email settings", () => {
     cy.button("Save changes").click();
 
     cy.wait("@updateSettings");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Wrong host or port");
 
     // But it shouldn't delete field values

--- a/e2e/test/scenarios/admin/settings/localization.cy.spec.js
+++ b/e2e/test/scenarios/admin/settings/localization.cy.spec.js
@@ -34,6 +34,7 @@ describe("scenarios > admin > localization", () => {
 
     // find and open that question
     cy.visit("/collection/root");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Orders created before June 1st 2016").click();
 
     cy.log("Assert the dates on the X axis");
@@ -67,6 +68,7 @@ describe("scenarios > admin > localization", () => {
     });
 
     cy.visit("/collection/root");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("13604").click();
 
     cy.log("Reported failing on v0.37.0.2 and labeled as `.Regression`");
@@ -118,19 +120,28 @@ describe("scenarios > admin > localization", () => {
 
   it("should not display excessive options in localization tab (metabase#14426)", () => {
     cy.visit("/admin/settings/localization");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(/Instance language/i);
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(/Report timezone/i);
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(/First day of the week/i);
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(/Localization options/i);
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains(/Column title/i).should("not.exist");
   });
 
   it("should use currency settings for number columns with style set to currency (metabase#10787)", () => {
     cy.visit("/admin/settings/localization");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Unit of currency");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("US Dollar").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Euro").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Saved");
 
     visitQuestionAdhoc({
@@ -152,6 +163,7 @@ describe("scenarios > admin > localization", () => {
       },
     });
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("€10.00");
   });
 
@@ -164,12 +176,15 @@ describe("scenarios > admin > localization", () => {
     cy.visit("/admin/settings/localization");
 
     // update the date style setting to YYYY/MM/DD
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("January 7, 2018").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("2018/1/7").click();
     cy.wait("@updateFormatting");
     cy.findAllByTestId("select-button-content").should("contain", "2018/1/7");
 
     // update the time style setting to 24 hour
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("17:24 (24-hour clock)").click();
     cy.wait("@updateFormatting");
     cy.findByDisplayValue("HH:mm").should("be.checked");
@@ -178,8 +193,11 @@ describe("scenarios > admin > localization", () => {
 
     // create a date filter and set it to the 'On' view to see a specific date
     cy.findByTextEnsureVisible("Created At").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Filter by this column").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Specific dates...").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("On").click();
 
     // ensure the date picker is ready
@@ -196,6 +214,7 @@ describe("scenarios > admin > localization", () => {
     // add a time to the date
     const TIME_SELECTOR_DEFAULT_HOUR = 12;
     const TIME_SELECTOR_DEFAULT_MINUTE = 30;
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Add a time").click();
     cy.findByDisplayValue(`${TIME_SELECTOR_DEFAULT_HOUR}`).clear().type("19");
     cy.findByDisplayValue(`${TIME_SELECTOR_DEFAULT_MINUTE}`).clear().type("56");
@@ -207,7 +226,9 @@ describe("scenarios > admin > localization", () => {
     cy.findByTestId("loading-spinner").should("not.exist");
 
     // verify that the correct row is displayed
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("2018/5/15, 19:56");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("127.52");
   });
 });

--- a/e2e/test/scenarios/admin/settings/maps.cy.spec.js
+++ b/e2e/test/scenarios/admin/settings/maps.cy.spec.js
@@ -8,6 +8,7 @@ describe("scenarios > admin > settings > map settings", () => {
 
   it("should be able to load and save a custom map", () => {
     cy.visit("/admin/settings/maps");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Add a map").click();
     cy.findByPlaceholderText("e.g. United Kingdom, Brazil, Mars").type(
       "Test Map",
@@ -17,25 +18,31 @@ describe("scenarios > admin > settings > map settings", () => {
     ).type(
       "https://raw.githubusercontent.com/metabase/metabase/master/resources/frontend_client/app/assets/geojson/world.json",
     );
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Load").click();
     cy.wait(2000).findAllByText("Select…").first().click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("NAME").click();
     cy.findAllByText("Select…").last().click();
     cy.findAllByText("NAME").last().click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Add map").click();
     cy.wait(3000).findByText("NAME").should("not.exist");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Test Map");
   });
 
   it("should be able to load a custom map even if a name has not been added yet (#14635)", () => {
     cy.intercept("GET", "/api/geojson*").as("load");
     cy.visit("/admin/settings/maps");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Add a map").click();
     cy.findByPlaceholderText(
       "Like https://my-mb-server.com/maps/my-map.json",
     ).type(
       "https://raw.githubusercontent.com/metabase/metabase/master/resources/frontend_client/app/assets/geojson/world.json",
     );
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Load").click();
     cy.wait("@load").then(interception => {
       expect(interception.response.statusCode).to.eq(200);
@@ -44,11 +51,14 @@ describe("scenarios > admin > settings > map settings", () => {
 
   it("should show an informative error when adding an invalid URL", () => {
     cy.visit("/admin/settings/maps");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Add a map").click();
     cy.findByPlaceholderText(
       "Like https://my-mb-server.com/maps/my-map.json",
     ).type("bad-url");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Load").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(
       "Invalid GeoJSON file location: must either start with http:// or https:// or be a relative path to a file on the classpath. " +
         "URLs referring to hosts that supply internal hosting metadata are prohibited.",
@@ -57,13 +67,16 @@ describe("scenarios > admin > settings > map settings", () => {
 
   it("should show an informative error when adding a valid URL that does not contain GeoJSON, or is missing required fields", () => {
     cy.visit("/admin/settings/maps");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Add a map").click();
 
     // Not GeoJSON
     cy.findByPlaceholderText(
       "Like https://my-mb-server.com/maps/my-map.json",
     ).type("https://metabase.com");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Load").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Invalid custom GeoJSON: does not contain features");
 
     // GeoJSON with an unsupported format (not a Feature or FeatureCollection)
@@ -72,7 +85,9 @@ describe("scenarios > admin > settings > map settings", () => {
       .type(
         "https://raw.githubusercontent.com/metabase/metabase/master/test_resources/test.geojson",
       );
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Load").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Invalid custom GeoJSON: does not contain features");
   });
 });

--- a/e2e/test/scenarios/admin/settings/public-sharing.cy.spec.js
+++ b/e2e/test/scenarios/admin/settings/public-sharing.cy.spec.js
@@ -97,7 +97,9 @@ describe("scenarios > admin > settings > public sharing", () => {
 
     cy.visit("/admin/settings/public-sharing");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Shared Dashboards").should("be.visible");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(expectedDashboardName).should("be.visible");
     cy.get("@dashboardUuid").then(dashboardUuid => {
       cy.findByText(
@@ -123,6 +125,7 @@ describe("scenarios > admin > settings > public sharing", () => {
       cy.findByText("Disable this link?").should("be.visible");
       cy.button("Yes").click();
     });
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("No dashboards have been publicly shared yet.").should(
       "be.visible",
     );
@@ -148,7 +151,9 @@ describe("scenarios > admin > settings > public sharing", () => {
 
     cy.visit("/admin/settings/public-sharing");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Shared Questions").should("be.visible");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(expectedQuestionName).should("be.visible");
     cy.get("@questionUuid").then(questionUuid => {
       cy.findByText(
@@ -174,6 +179,7 @@ describe("scenarios > admin > settings > public sharing", () => {
       cy.findByText("Disable this link?").should("be.visible");
       cy.button("Yes").click();
     });
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("No questions have been publicly shared yet.").should(
       "be.visible",
     );
@@ -215,7 +221,9 @@ describe("scenarios > admin > settings > public sharing", () => {
 
     cy.visit("/admin/settings/public-sharing");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Shared Action Forms").should("be.visible");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(expectedActionName).should("be.visible");
     cy.get("@actionUuid").then(actionUuid => {
       cy.findByText(`${location.origin}/public/action/${actionUuid}`).click();
@@ -242,6 +250,7 @@ describe("scenarios > admin > settings > public sharing", () => {
       cy.findByText("Disable this link?").should("be.visible");
       cy.button("Yes").click();
     });
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("No actions have been publicly shared yet.").should(
       "be.visible",
     );

--- a/e2e/test/scenarios/admin/settings/reproductions/21532-back-button.cy.spec.js
+++ b/e2e/test/scenarios/admin/settings/reproductions/21532-back-button.cy.spec.js
@@ -10,7 +10,9 @@ describe("issue 21532", () => {
     cy.visit("/");
 
     cy.icon("gear").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Admin settings").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Getting set up");
 
     cy.go("back");

--- a/e2e/test/scenarios/admin/settings/settings.cy.spec.js
+++ b/e2e/test/scenarios/admin/settings/settings.cy.spec.js
@@ -23,7 +23,9 @@ describe("scenarios > admin > settings", () => {
     () => {
       cy.onlyOn(isOSS);
       cy.visit("/admin/settings/setup");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Have your server maintained for you.");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Migrate to Metabase Cloud.");
       cy.findAllByRole("link", { name: "Learn more" })
         .should("have.attr", "href")
@@ -69,6 +71,7 @@ describe("scenarios > admin > settings", () => {
     // rather than aliasing it with .as()
     const emailInput = () =>
       cy
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         .contains("Email Address for Help Requests")
         .parent()
         .parent()
@@ -97,10 +100,13 @@ describe("scenarios > admin > settings", () => {
     cy.intercept("GET", "**/api/health", "ok").as("httpsCheck");
 
     // settings have loaded, but there's no redirect setting visible
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Site URL");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Redirect to HTTPS").should("not.exist");
 
     // switch site url to use https
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Site URL")
       .parent()
       .parent()
@@ -109,6 +115,7 @@ describe("scenarios > admin > settings", () => {
     popover().contains("https://").click({ force: true });
 
     cy.wait("@httpsCheck");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Redirect to HTTPS").parent().parent().contains("Disabled");
 
     restore(); // avoid leaving https site url
@@ -121,6 +128,7 @@ describe("scenarios > admin > settings", () => {
       req.reply({ forceNetworkError: true });
     }).as("httpsCheck");
     // switch site url to use https
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Site URL")
       .parent()
       .parent()
@@ -129,6 +137,7 @@ describe("scenarios > admin > settings", () => {
     popover().contains("https://").click({ force: true });
 
     cy.wait("@httpsCheck");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("It looks like HTTPS is not properly configured");
   });
 
@@ -141,11 +150,14 @@ describe("scenarios > admin > settings", () => {
 
     cy.visit("/admin/settings/localization");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("January 7, 2018").click({ force: true });
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("2018/1/7").click({ force: true });
     cy.wait("@saveFormatting");
     cy.findAllByTestId("select-button-content").should("contain", "2018/1/7");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("17:24 (24-hour clock)").click();
     cy.wait("@saveFormatting");
     cy.findByDisplayValue("HH:mm").should("be.checked");
@@ -160,6 +172,7 @@ describe("scenarios > admin > settings", () => {
     // Go back to the settings and reset the time formatting
     cy.visit("/admin/settings/localization");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("5:24 PM (12-hour clock)").click();
     cy.wait("@saveFormatting");
     cy.findByDisplayValue("h:mm A").should("be.checked");
@@ -174,15 +187,18 @@ describe("scenarios > admin > settings", () => {
     cy.intercept("PUT", "**/report-timezone").as("reportTimezone");
 
     cy.visit("/admin/settings/localization");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Report Timezone")
       .closest("li")
       .findByTestId("report-timezone-select-button")
       .click();
 
     cy.findByPlaceholderText("Find...").type("Centr");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("US/Central").click({ force: true });
 
     cy.wait("@reportTimezone");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("US/Central");
   });
 
@@ -210,8 +226,11 @@ describe("scenarios > admin > settings", () => {
     cy.visit("/admin/settings/general");
 
     cy.wait("@appSettings");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("We're a little lost...").should("not.exist");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(/Site name/i);
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(/Site URL/i);
   });
 
@@ -235,10 +254,14 @@ describe("scenarios > admin > settings", () => {
     setupMetabaseCloud();
     cy.visit("/admin/settings/general");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Site Name");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Site URL").should("not.exist");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Email").should("not.exist");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Updates").should("not.exist");
   });
 
@@ -247,6 +270,7 @@ describe("scenarios > admin > settings", () => {
     setupMetabaseCloud();
     cy.visit("/admin/settings/general");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Metabase Admin");
     cy.findByLabelText("store icon").should("not.exist");
   });
@@ -255,6 +279,7 @@ describe("scenarios > admin > settings", () => {
     it("should present the form and display errors", () => {
       cy.visit("/admin/settings/slack");
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Metabase on Slack");
       cy.findByLabelText("Slack Bot User OAuth Token").type("xoxb");
       cy.findByLabelText("Public channel to store image files").type(
@@ -262,6 +287,7 @@ describe("scenarios > admin > settings", () => {
       );
       cy.button("Save changes").click();
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(": invalid token");
     });
   });
@@ -277,6 +303,7 @@ describe("scenarios > admin > settings (OSS)", { tags: "@OSS" }, () => {
   it("should show the store link when running Metabase OSS", () => {
     cy.visit("/admin/settings/general");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Metabase Admin");
     cy.findByLabelText("store icon");
   });
@@ -293,13 +320,16 @@ describeEE("scenarios > admin > settings (EE)", () => {
     setupMetabaseCloud();
     cy.visit("/admin/settings/general");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Site Name");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Enterprise").should("not.exist");
   });
 
   it("should hide the store link when running Metabase EE", () => {
     cy.visit("/admin/settings/general");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Metabase Admin");
     cy.findByLabelText("store icon").should("not.exist");
   });

--- a/e2e/test/scenarios/admin/settings/sso/google.cy.spec.js
+++ b/e2e/test/scenarios/admin/settings/sso/google.cy.spec.js
@@ -28,6 +28,7 @@ describe("scenarios > admin > settings > SSO > Google", () => {
     typeAndBlurUsingLabel("Client ID", `example2.${CLIENT_ID_SUFFIX}`);
     cy.button("Save changes").click();
     cy.wait("@updateGoogleSettings");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Success").should("be.visible");
   });
 
@@ -63,6 +64,7 @@ describe("scenarios > admin > settings > SSO > Google", () => {
 
     typeAndBlurUsingLabel("Client ID", "fake-client-id");
     cy.button("Save and enable").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(
       `Invalid Google Sign-In Client ID: must end with ".${CLIENT_ID_SUFFIX}"`,
     ).should("be.visible");
@@ -72,6 +74,7 @@ describe("scenarios > admin > settings > SSO > Google", () => {
     setupGoogleAuth({ enabled: true });
     cy.signOut();
     cy.visit("/auth/login");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Sign in with email").should("be.visible");
     cy.findByRole("button", { name: /Google/ }).should("be.visible");
 
@@ -79,7 +82,9 @@ describe("scenarios > admin > settings > SSO > Google", () => {
     setupGoogleAuth({ enabled: false });
     cy.signOut();
     cy.visit("/auth/login");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Email address").should("be.visible");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Password").should("be.visible");
     cy.findByRole("button", { name: /Google/ }).should("not.exist");
   });

--- a/e2e/test/scenarios/admin/settings/sso/jwt.cy.spec.js
+++ b/e2e/test/scenarios/admin/settings/sso/jwt.cy.spec.js
@@ -66,6 +66,7 @@ describeEE("scenarios > admin > settings > SSO > JWT", () => {
     cy.button("Save changes").click();
     cy.wait("@updateSettings");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Success").should("exist");
   });
 

--- a/e2e/test/scenarios/admin/settings/sso/ldap.cy.spec.js
+++ b/e2e/test/scenarios/admin/settings/sso/ldap.cy.spec.js
@@ -30,6 +30,7 @@ describe(
       cy.button("Save and enable").click();
       cy.wait("@updateLdapSettings");
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Success").should("exist");
     });
 
@@ -89,16 +90,19 @@ describe(
 
       enterLdapSettings();
       enterLdapPort("asd");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("That's not a valid port number").should("exist");
 
       enterLdapPort("21.3");
       cy.button("Save and enable").click();
       cy.wait("@updateLdapSettings");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText('For input string: "21.3"').should("exist");
 
       enterLdapPort("123 ");
       cy.button("Save failed").click();
       cy.wait("@updateLdapSettings");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText('For input string: "123 "').should("exist");
     });
 
@@ -108,7 +112,9 @@ describe(
       cy.signOut();
       cy.visit("/auth/login");
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Username or email address").should("be.visible");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Password").should("be.visible");
     });
 

--- a/e2e/test/scenarios/admin/settings/sso/saml.cy.spec.js
+++ b/e2e/test/scenarios/admin/settings/sso/saml.cy.spec.js
@@ -26,6 +26,7 @@ describeEE("scenarios > admin > settings > SSO > SAML", () => {
     enterSamlSettings();
     cy.button("Save and enable").click();
     cy.wait("@updateSamlSettings");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Success").should("exist");
 
     cy.findAllByRole("link", { name: "Authentication" }).first().click();
@@ -39,6 +40,7 @@ describeEE("scenarios > admin > settings > SSO > SAML", () => {
     typeAndBlurUsingLabel("SAML Identity Provider URL", "https://other.test");
     cy.button("Save changes").click();
     cy.wait("@updateSamlSettings");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Success").should("exist");
 
     cy.findAllByRole("link", { name: "Authentication" }).first().click();

--- a/e2e/test/scenarios/admin/settings/whitelabel.cy.spec.js
+++ b/e2e/test/scenarios/admin/settings/whitelabel.cy.spec.js
@@ -26,7 +26,9 @@ describeEE("formatting > whitelabel", () => {
       cy.visit("/admin/settings/whitelabel");
       cy.findByLabelText("Application Name").clear().type(COMPANY_NAME);
       // Helps scroll the page up in order to see "Saved" notification
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Application Name").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Saved");
       cy.findByDisplayValue(COMPANY_NAME);
       cy.log("Company name has been updated!");
@@ -35,18 +37,23 @@ describeEE("formatting > whitelabel", () => {
     it("changes should reflect in different parts of UI", () => {
       cy.log("New company should show up on activity page");
       cy.visit("/activity");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(`${COMPANY_NAME} is up and running.`);
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Metabase is up and running.").should("not.exist");
 
       cy.log("New company should show up when logged out");
       cy.signOut();
       cy.visit("/");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(`Sign in to ${COMPANY_NAME}`);
 
       cy.log("New company should show up for a normal user");
       cy.signInAsNormalUser();
       cy.visit("/activity");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(`${COMPANY_NAME} is up and running.`);
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Metabase is up and running.").should("not.exist");
     });
 
@@ -54,12 +61,15 @@ describeEE("formatting > whitelabel", () => {
       cy.reload();
 
       cy.findByDisplayValue(COMPANY_NAME);
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains(
         `These are the primary colors used in charts and throughout ${COMPANY_NAME}.`,
       );
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains(`The top nav bar of ${COMPANY_NAME}.`);
 
       cy.visit("/admin/settings/general");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains(`The name used for this instance of ${COMPANY_NAME}.`);
     });
   });
@@ -101,6 +111,7 @@ describeEE("formatting > whitelabel", () => {
         "https://cdn.ecosia.org/assets/images/ico/favicon.ico",
       );
       cy.get("ul").eq(1).click("right");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Saved");
       checkFavicon();
     });
@@ -116,16 +127,19 @@ describeEE("formatting > whitelabel", () => {
   describe("loading message", () => {
     it("should update loading message", () => {
       cy.visit("/question/1");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Doing science...");
 
       const runningQueryMessage = "Running query...";
       changeLoadingMessage(runningQueryMessage);
       cy.visit("/question/1");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(runningQueryMessage);
 
       const loadingResultsMessage = "Loading results...";
       changeLoadingMessage(loadingResultsMessage);
       cy.visit("/question/1");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(loadingResultsMessage);
     });
   });
@@ -136,6 +150,7 @@ describeEE("formatting > whitelabel", () => {
       cy.findByAltText("Metabot");
 
       cy.visit("/admin/settings/whitelabel");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Display welcome message on the homepage").click();
 
       cy.visit("/");

--- a/e2e/test/scenarios/admin/subscription/payment-failure.cy.spec.js
+++ b/e2e/test/scenarios/admin/subscription/payment-failure.cy.spec.js
@@ -15,14 +15,17 @@ describe("banner", () => {
     });
 
     cy.visit("/");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("We couldn't process payment for your account.");
     cy.visit(`/admin/`);
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("We couldn't process payment for your account.");
 
     cy.signInAsNormalUser();
     cy.visit("/");
     // Wait for page to load
     cy.get("header");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("We couldn't process payment for your account.").should(
       "not.exist",
     );
@@ -37,14 +40,17 @@ describe("banner", () => {
     });
 
     cy.visit("/");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Pro features won’t work right now due to lack of payment.");
     cy.visit(`/admin/`);
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Pro features won’t work right now due to lack of payment.");
 
     cy.signInAsNormalUser();
     cy.visit("/");
     // Wait for page to load
     cy.get("header");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains(
       "Pro features won’t work right now due to lack of payment.",
     ).should("not.exist");

--- a/e2e/test/scenarios/admin/tools/erroring-questions.cy.spec.js
+++ b/e2e/test/scenarios/admin/tools/erroring-questions.cy.spec.js
@@ -56,6 +56,7 @@ describe.skip(
       it("should disable search input fields (metabase#18050)", () => {
         cy.visit(TOOLS_ERRORS_URL);
 
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("No results");
         cy.button("Rerun Selected").should("be.disabled");
         cy.findByPlaceholderText("Error contents").should("be.disabled");
@@ -83,6 +84,7 @@ describe.skip(
         cy.wait("@dataset");
 
         // The question is still there because we didn't fix it
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText(brokenQuestionDetails.name);
         cy.button("Rerun Selected").should("be.disabled");
 
@@ -94,6 +96,7 @@ describe.skip(
 
         cy.wait("@dataset");
 
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("No results");
       });
 
@@ -108,6 +111,7 @@ describe.skip(
 
         cy.wait("@dataset");
 
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("No results");
       });
     });

--- a/e2e/test/scenarios/admin/troubleshooting/help.cy.spec.js
+++ b/e2e/test/scenarios/admin/troubleshooting/help.cy.spec.js
@@ -16,7 +16,9 @@ describe("scenarios > admin > troubleshooting > help", () => {
     setupMetabaseCloud();
     cy.visit("/admin/troubleshooting/help");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Metabase Admin");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Contact support");
   });
 });
@@ -32,7 +34,9 @@ describe("scenarios > admin > troubleshooting > help", { tags: "@OSS" }, () => {
   it("should link `Get Help` to help", () => {
     cy.visit("/admin/troubleshooting/help");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Metabase Admin");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Get Help")
       .parents("a")
       .should("have.prop", "href")
@@ -52,7 +56,9 @@ describeEE("scenarios > admin > troubleshooting > help (EE)", () => {
   it("should link `Get Help` to help-premium", () => {
     cy.visit("/admin/troubleshooting/help");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Metabase Admin");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Get Help")
       .parents("a")
       .should("have.prop", "href")

--- a/e2e/test/scenarios/admin/troubleshooting/tasks.cy.spec.js
+++ b/e2e/test/scenarios/admin/troubleshooting/tasks.cy.spec.js
@@ -19,12 +19,16 @@ describe("scenarios > admin > troubleshooting > tasks", () => {
     cy.visit("/admin/troubleshooting/tasks");
     cy.wait("@first");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Troubleshooting logs");
     cy.icon("chevronleft").as("previous");
     cy.icon("chevronright").as("next");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("1 - 50");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("field values scanning");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("513");
 
     shouldBeDisabled("@previous");
@@ -33,9 +37,13 @@ describe("scenarios > admin > troubleshooting > tasks", () => {
     cy.get("@next").click();
     cy.wait("@second");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains(`51 - ${total}`);
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("1 - 50").should("not.exist");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("analyze");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("200");
 
     shouldNotBeDisabled("@previous");

--- a/e2e/test/scenarios/auditing/ad-hoc.cy.spec.js
+++ b/e2e/test/scenarios/auditing/ad-hoc.cy.spec.js
@@ -26,6 +26,7 @@ describeEE("audit > ad-hoc", () => {
     it("should appear in audit log (metabase#16845 metabase-enterprise#486)", () => {
       cy.visit("/admin/audit/members/log");
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Native")
         .parent()
         .parent()
@@ -37,6 +38,7 @@ describeEE("audit > ad-hoc", () => {
       cy.url().should("include", "/admin/audit/query/");
 
       cy.get(".PageTitle").contains("Query");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Open in Metabase");
       cy.get(".ace_content").contains("SELECT 123");
     });
@@ -62,6 +64,7 @@ describeEE("audit > ad-hoc", () => {
     it("should appear in audit log #29456", () => {
       cy.visit("/admin/audit/members/log");
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("GUI")
         .parent()
         .parent()
@@ -73,6 +76,7 @@ describeEE("audit > ad-hoc", () => {
       cy.url().should("include", "/admin/audit/query/");
 
       cy.get(".PageTitle").contains("Query");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Open in Metabase").should("be.visible");
 
       cy.findByTestId("read-only-notebook").within(() => {

--- a/e2e/test/scenarios/auditing/approved-domains.cy.spec.js
+++ b/e2e/test/scenarios/auditing/approved-domains.cy.spec.js
@@ -29,11 +29,14 @@ describeEE(
     it("should validate approved email domains for a question alert in the audit app", () => {
       visitQuestion(1);
       cy.icon("bell").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Set up an alert").click();
       cy.button("Done").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Your alert is all set up.");
 
       cy.visit("/admin/audit/subscriptions/alerts");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("1").click();
 
       modal().within(() => {
@@ -47,7 +50,9 @@ describeEE(
     it("should validate approved email domains for a dashboard subscription in the audit app", () => {
       visitDashboard(1);
       cy.icon("share").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Dashboard subscriptions").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Email it").click();
 
       sidebar().within(() => {
@@ -56,6 +61,7 @@ describeEE(
       });
 
       cy.visit("/admin/audit/subscriptions/subscriptions");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("1").click();
 
       modal().within(() => {

--- a/e2e/test/scenarios/auditing/auditing.cy.spec.js
+++ b/e2e/test/scenarios/auditing/auditing.cy.spec.js
@@ -55,17 +55,23 @@ describeEE("audit > auditing", () => {
 
     cy.log("View normal user's dashboard");
     cy.visit("/collection/root?type=dashboard");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(NORMAL_DASHBOARD).click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("This dashboard is looking empty.");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("My personal collection").should("not.exist");
 
     cy.log("View old existing question");
     visitQuestion(2);
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("18,760");
 
     cy.log("View newly created admin's question");
     cy.visit("/collection/root?type");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(ADMIN_QUESTION).click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(/ID/i);
   });
 
@@ -76,7 +82,9 @@ describeEE("audit > auditing", () => {
       cy.visit("/admin/audit/members/overview");
 
       // We haven't created any new members yet so this should be empty
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Active members and new members per day");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("No results!");
 
       // Wait for both of the charts to show up
@@ -116,6 +124,7 @@ describeEE("audit > auditing", () => {
       cy.findAllByText("Orders, Count").should("have.length", 1);
       cy.findAllByText(ADMIN_QUESTION).should("have.length", 1);
       cy.findAllByText("Sample Database").should("have.length", 4);
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(NORMAL_DASHBOARD);
     });
   });
@@ -124,7 +133,9 @@ describeEE("audit > auditing", () => {
     it("should load both tabs in Databases", () => {
       // Overview tab
       cy.visit("/admin/audit/databases/overview");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Total queries and their average speed");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("No results!").should("not.exist");
       cy.get(".LineAreaBarChart");
       cy.get("rect");
@@ -132,9 +143,13 @@ describeEE("audit > auditing", () => {
       // All databases tab
       cy.visit("/admin/audit/databases/all");
       cy.findByPlaceholderText("Database name");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("No results!").should("not.exist");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Sample Database");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(/Sync Schedule/i);
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains(year);
     });
 
@@ -148,13 +163,16 @@ describeEE("audit > auditing", () => {
 
       // All schemas tab
       cy.visit("/admin/audit/schemas/all");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("PUBLIC");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Saved Queries");
     });
 
     it("should load both tabs in Tables", () => {
       // Overview tab
       cy.visit("/admin/audit/tables/overview");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Most-queried tables");
       cy.findAllByText("No results!").should("not.exist");
       cy.findAllByText("Sample Database PUBLIC ORDERS");
@@ -176,7 +194,9 @@ describeEE("audit > auditing", () => {
       cy.visit("/admin/audit/tables/all");
       cy.findByPlaceholderText("Table name");
       cy.findAllByText("PUBLIC").should("have.length", 4);
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("REVIEWS"); // Table name in DB
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Reviews"); // Table display name
     });
   });
@@ -185,7 +205,9 @@ describeEE("audit > auditing", () => {
     it("should load both tabs in Questions", () => {
       // Overview tab
       cy.visit("/admin/audit/questions/overview");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Slowest queries");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Query views and speed per day");
       cy.findAllByText("No results!").should("not.exist");
       cy.get(".LineAreaBarChart").should("have.length", 3);
@@ -196,24 +218,33 @@ describeEE("audit > auditing", () => {
       cy.visit("/admin/audit/questions/all");
       cy.findByPlaceholderText("Question name");
       cy.findAllByText("Sample Database").should("have.length", 5);
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(NORMAL_QUESTION);
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Orders, Count, Grouped by Created At (year)");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("4").should("not.exist");
     });
 
     it("should load both tabs in Dashboards", () => {
       // Overview tab
       cy.visit("/admin/audit/dashboards/overview");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Most popular dashboards and their avg loading times");
       cy.findAllByText("Avg. Question Load Time (ms)");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(NORMAL_DASHBOARD);
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Orders");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Orders, Count").should("not.exist");
 
       // All dashboards tab
       cy.visit("/admin/audit/dashboards/all");
       cy.findByPlaceholderText("Dashboard name");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(ADMIN_DASHBOARD);
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(normal.first_name + " " + normal.last_name);
       cy.get("tr")
         .eq(1)
@@ -226,12 +257,16 @@ describeEE("audit > auditing", () => {
     it("should load both tabs in Downloads", () => {
       // Overview tab
       cy.visit("/admin/audit/downloads/overview");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("No results!").should("not.exist");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Largest downloads in the last 30 days");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(normal.first_name + " " + normal.last_name);
 
       // All downloads tab
       cy.visit("/admin/audit/downloads/all");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("No results").should("not.exist");
       cy.get("tr")
         .last()

--- a/e2e/test/scenarios/auditing/questions-audit.cy.spec.js
+++ b/e2e/test/scenarios/auditing/questions-audit.cy.spec.js
@@ -25,10 +25,12 @@ describeEE("audit > auditing > questions", () => {
 
       assertRowsOrder(QUERY_RUNS_DESC_ORDER);
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Query Runs").click();
 
       assertRowsOrder(QUERY_RUNS_ASC_ORDER);
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Query Runs").click();
 
       assertRowsOrder(QUERY_RUNS_DESC_ORDER);
@@ -39,6 +41,7 @@ describeEE("audit > auditing > questions", () => {
       cy.findByPlaceholderText("Question name").type("year");
 
       cy.get("tbody > tr").should("have.length", 1);
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Orders, Count, Grouped by Created At (year)");
     });
 
@@ -60,6 +63,7 @@ describeEE("audit > auditing > questions", () => {
       cy.findByPlaceholderText("Collection name").type("First");
 
       cy.get("tbody > tr").should("have.length", 1);
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("My question");
     });
 

--- a/e2e/test/scenarios/binning/binning-options.cy.spec.js
+++ b/e2e/test/scenarios/binning/binning-options.cy.spec.js
@@ -142,6 +142,7 @@ describe("scenarios > binning > binning options", () => {
 
       getTitle("Count by Total: Auto binned");
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Total: Auto binned").click();
       openBinningListForDimension("Total", "Auto binned");
 
@@ -157,6 +158,7 @@ describe("scenarios > binning > binning options", () => {
 
       getTitle("Count by Created At: Month");
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Created At: Month").click();
       openBinningListForDimension("Created At", "by month");
 
@@ -172,6 +174,7 @@ describe("scenarios > binning > binning options", () => {
 
       getTitle("Count by Longitude: Auto binned");
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Longitude: Auto binned").click();
       openBinningListForDimension("Longitude", "Auto binned");
 
@@ -183,7 +186,9 @@ describe("scenarios > binning > binning options", () => {
     it("should render time series binning options correctly", () => {
       openTable({ table: ORDERS_ID });
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Created At").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Distribution").click();
 
       getTitle("Count by Created At: Month");

--- a/e2e/test/scenarios/binning/binning-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/binning/binning-reproductions.cy.spec.js
@@ -28,17 +28,25 @@ describe("binning related reproductions", () => {
     });
 
     startNewQuestion();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Saved Questions").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("16327").click();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Pick the metric you want to see").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Count of rows").click();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Pick a column to group by").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(/CREATED_AT/i).realHover();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("by minute").click({ force: true });
 
     // Implicit assertion - it fails if there is more than one instance of the string, which is exactly what we need for this repro
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Month");
   });
 
@@ -74,7 +82,9 @@ describe("binning related reproductions", () => {
       expect(xhr.response.body.error).not.to.exist;
     });
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Count by Created At: Year");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("2018");
   });
 
@@ -90,22 +100,34 @@ describe("binning related reproductions", () => {
     );
 
     startNewQuestion();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Saved Questions").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("17975").click();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Pick the metric you want to see").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Count of rows").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Pick a column to group by").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("CREATED_AT").click();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Sort").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Created At (month)").click();
 
     // Change the binning of the breakout field
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("CREATED_AT: Month").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("by month").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Quarter").click();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Created At (quarter)");
   });
 
@@ -134,10 +156,14 @@ describe("binning related reproductions", () => {
       cy.findByText("ID").click();
     });
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Summarize").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Count of rows").click();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Pick a column to group by").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(/Question \d/).click();
 
     popover().within(() => {
@@ -146,6 +172,7 @@ describe("binning related reproductions", () => {
       cy.findByText("CREATED_AT").click();
     });
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Question 4 → Created At: Month");
 
     visualize();
@@ -162,12 +189,15 @@ describe("binning related reproductions", () => {
     // it is essential for this repro to find question following these exact steps
     // (for example, visiting `/collection/root` would yield different result)
     startNewQuestion();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Saved Questions").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("11439").click();
     visualize();
 
     summarize();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Group by")
       .parent()
       .within(() => {
@@ -185,6 +215,7 @@ describe("binning related reproductions", () => {
           .click({ force: true });
       });
     // // this step is maybe redundant since it fails to even find "by month"
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Hour of Day");
   });
 
@@ -267,8 +298,11 @@ describe("binning related reproductions", () => {
     it("should work for notebook mode", () => {
       openSummarizeOptions("Notebook mode");
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Pick the metric you want to see").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Count of rows").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Pick a column to group by").click();
 
       changeBinningForDimension({
@@ -303,7 +337,9 @@ describe("binning related reproductions", () => {
       });
 
       startNewQuestion();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Saved Questions").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("SQL Binning").click();
 
       visualize();
@@ -317,9 +353,11 @@ describe("binning related reproductions", () => {
 
       cy.wait("@dataset");
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Count by TOTAL: Auto binned");
       cy.get(".bar").should("have.length.of.at.most", 10);
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("-60");
     });
 
@@ -339,7 +377,9 @@ describe("binning related reproductions", () => {
         expect(xhr.response.body.error).not.to.exist;
       });
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Count by LONGITUDE: Auto binned");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("170° W");
     });
   });

--- a/e2e/test/scenarios/binning/correctness/longitude.cy.spec.js
+++ b/e2e/test/scenarios/binning/correctness/longitude.cy.spec.js
@@ -27,6 +27,7 @@ describe("scenarios > binning > correctness > longitude", () => {
           .should("contain", "Longitude")
           .and("contain", selected);
 
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("Done").click();
 
         getTitle(`Count by Longitude: ${selected}`);
@@ -47,6 +48,7 @@ describe("scenarios > binning > correctness > longitude", () => {
       .should("contain", "Longitude")
       .and("contain", "Unbinned");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Done").click();
 
     getTitle("Count by Longitude");

--- a/e2e/test/scenarios/binning/correctness/time-series.cy.spec.js
+++ b/e2e/test/scenarios/binning/correctness/time-series.cy.spec.js
@@ -56,6 +56,7 @@ describe("scenarios > binning > correctness > time series", () => {
           isSelected: true,
         }).should("have.text", selected);
 
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("Done").click();
 
         getTitle(titleRegex);

--- a/e2e/test/scenarios/binning/qb-explicit-joins.cy.spec.js
+++ b/e2e/test/scenarios/binning/qb-explicit-joins.cy.spec.js
@@ -62,7 +62,9 @@ describe("scenarios > binning > from a saved QB question with explicit joins", (
   context("via simple mode", () => {
     beforeEach(() => {
       startNewQuestion();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Saved Questions").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("QB Binning").click();
 
       visualize();
@@ -84,6 +86,7 @@ describe("scenarios > binning > from a saved QB question with explicit joins", (
 
       // Make sure time series footer works as well
       cy.findAllByTestId("select-button-content").contains("Year").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Quarter").click();
 
       cy.wait("@dataset");
@@ -123,11 +126,16 @@ describe("scenarios > binning > from a saved QB question with explicit joins", (
   context("via notebook mode", () => {
     beforeEach(() => {
       startNewQuestion();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Saved Questions").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("QB Binning").click();
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Pick the metric you want to see").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Count of rows").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Pick a column to group by").click();
     });
 
@@ -147,6 +155,7 @@ describe("scenarios > binning > from a saved QB question with explicit joins", (
 
       // Make sure time series footer works as well
       cy.findAllByTestId("select-button-content").contains("Year").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Quarter").click();
 
       cy.wait("@dataset");
@@ -188,16 +197,21 @@ describe("scenarios > binning > from a saved QB question with explicit joins", (
   context("via column popover", () => {
     beforeEach(() => {
       startNewQuestion();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Saved Questions").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("QB Binning").click();
       visualize();
     });
 
     it("should work for time series", () => {
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("People → Birth Date").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Distribution").click();
 
       // Reproduces metabase#16693
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Count by People → Birth Date: Month");
 
       assertOnXYAxisLabels({ xLabel: "People → Birth Date", yLabel: "Count" });
@@ -211,9 +225,11 @@ describe("scenarios > binning > from a saved QB question with explicit joins", (
 
       // Make sure time series footer works as well
       cy.findAllByTestId("select-button-content").contains("Month").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Quarter").click();
 
       // Reproduces metabase#16693
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Count by People → Birth Date: Quarter");
 
       cy.get(".axis.x")
@@ -223,25 +239,33 @@ describe("scenarios > binning > from a saved QB question with explicit joins", (
     });
 
     it("should work for number", () => {
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Products → Price").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Distribution").click();
 
       // Reproduces metabase#16693
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Count by Products → Price: Auto binned");
 
       assertOnXYAxisLabels({ xLabel: "Products → Price", yLabel: "Count" });
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("12.5");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("25");
 
       cy.get(".bar");
     });
 
     it("should work for longitude", () => {
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("People → Longitude").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Distribution").click();
 
       // Reproduces metabase#16693
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Count by People → Longitude: Auto binned");
 
       assertOnXYAxisLabels({
@@ -249,7 +273,9 @@ describe("scenarios > binning > from a saved QB question with explicit joins", (
         yLabel: "Count",
       });
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("170° W");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("160° W");
 
       cy.get(".bar");

--- a/e2e/test/scenarios/binning/qb-implicit-joins.cy.spec.js
+++ b/e2e/test/scenarios/binning/qb-implicit-joins.cy.spec.js
@@ -40,6 +40,7 @@ describe("scenarios > binning > from a saved QB question using implicit joins", 
 
       // Make sure time series assertQueryBuilderState works as well
       cy.findAllByTestId("select-button-content").contains("Year").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Month").click();
 
       cy.get(".cellData").should("contain", "April, 1958").and("contain", "37");
@@ -76,13 +77,17 @@ describe("scenarios > binning > from a saved QB question using implicit joins", 
     beforeEach(() => {
       cy.visit("/question/1/notebook");
       summarize({ mode: "notebook" });
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Count of rows").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Pick a column to group by").click();
       // Click "Order" accordion to collapse it and expose the other tables
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Order").click();
     });
 
     it("should work for time series", () => {
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("User").click();
       cy.findByPlaceholderText("Find...").type("birth");
 
@@ -100,12 +105,14 @@ describe("scenarios > binning > from a saved QB question using implicit joins", 
 
       // Make sure time series assertQueryBuilderStateter works as well
       cy.findAllByTestId("select-button-content").contains("Year").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Month").click();
 
       cy.get(".cellData").should("contain", "April, 1958").and("contain", "37");
     });
 
     it("should work for number", () => {
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Product").click();
 
       changeBinningForDimension({
@@ -122,6 +129,7 @@ describe("scenarios > binning > from a saved QB question using implicit joins", 
     });
 
     it("should work for longitude", () => {
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("User").click();
       cy.findByPlaceholderText("Find...").type("longitude");
 

--- a/e2e/test/scenarios/binning/qb-regular-table.cy.spec.js
+++ b/e2e/test/scenarios/binning/qb-regular-table.cy.spec.js
@@ -27,6 +27,7 @@ describe("scenarios > binning > binning options", () => {
       getTitle("Count by Total: 50 bins");
 
       cy.get(".bar");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("70");
     });
 
@@ -41,6 +42,7 @@ describe("scenarios > binning > binning options", () => {
       getTitle("Count by Created At: Quarter");
 
       cy.get("circle");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Q1 - 2017");
     });
 
@@ -55,6 +57,7 @@ describe("scenarios > binning > binning options", () => {
       getTitle("Count by Longitude: 20°");
 
       cy.get(".bar");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("180° W");
     });
   });
@@ -72,6 +75,7 @@ describe("scenarios > binning > binning options", () => {
       getTitle("Count by Total: 50 bins");
 
       cy.get(".bar");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("70");
     });
 
@@ -87,6 +91,7 @@ describe("scenarios > binning > binning options", () => {
       getTitle("Count by Created At: Quarter");
 
       cy.get("circle");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Q1 - 2017");
     });
 
@@ -102,6 +107,7 @@ describe("scenarios > binning > binning options", () => {
       getTitle("Count by Longitude: 20°");
 
       cy.get(".bar");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("180° W");
     });
   });
@@ -109,34 +115,43 @@ describe("scenarios > binning > binning options", () => {
   context("via column popover", () => {
     it("should work for number", () => {
       openTable({ table: ORDERS_ID });
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Total").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Distribution").click();
 
       getTitle("Count by Total: Auto binned");
 
       cy.get(".bar");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("60");
     });
 
     it("should work for time series", () => {
       openTable({ table: ORDERS_ID });
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Created At").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Distribution").click();
 
       getTitle("Count by Created At: Month");
 
       cy.get("circle");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("January, 2017");
     });
 
     it("should work for longitude/latitude", () => {
       openTable({ table: PEOPLE_ID });
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Longitude").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Distribution").click();
 
       getTitle("Count by Longitude: Auto binned");
 
       cy.get(".bar");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("170° W");
     });
   });

--- a/e2e/test/scenarios/binning/sql.cy.spec.js
+++ b/e2e/test/scenarios/binning/sql.cy.spec.js
@@ -35,7 +35,9 @@ describe("scenarios > binning > from a saved sql question", () => {
   context("via simple question", () => {
     beforeEach(() => {
       startNewQuestion();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Saved Questions").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("SQL Binning").click();
       visualize();
       cy.findByTextEnsureVisible("LONGITUDE");
@@ -55,6 +57,7 @@ describe("scenarios > binning > from a saved sql question", () => {
 
       waitAndAssertOnRequest("@dataset");
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Count by CREATED_AT: Year");
       cy.get("circle");
     });
@@ -68,6 +71,7 @@ describe("scenarios > binning > from a saved sql question", () => {
 
       waitAndAssertOnRequest("@dataset");
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Count by TOTAL: 50 bins");
       cy.get(".bar");
     });
@@ -81,6 +85,7 @@ describe("scenarios > binning > from a saved sql question", () => {
 
       waitAndAssertOnRequest("@dataset");
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Count by LONGITUDE: 10°");
       cy.get(".bar");
     });
@@ -89,11 +94,16 @@ describe("scenarios > binning > from a saved sql question", () => {
   context("via custom question", () => {
     beforeEach(() => {
       startNewQuestion();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Saved Questions").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("SQL Binning").click();
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Pick the metric you want to see").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Count of rows").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Pick a column to group by").click();
     });
 
@@ -104,6 +114,7 @@ describe("scenarios > binning > from a saved sql question", () => {
         toBinning: "Year",
       });
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Count by CREATED_AT: Year");
 
       visualize(response => {
@@ -120,6 +131,7 @@ describe("scenarios > binning > from a saved sql question", () => {
         toBinning: "50 bins",
       });
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Count by TOTAL: 50 bins");
 
       visualize(response => {
@@ -136,6 +148,7 @@ describe("scenarios > binning > from a saved sql question", () => {
         toBinning: "Bin every 10 degrees",
       });
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Count by LONGITUDE: 10°");
 
       visualize(response => {
@@ -149,44 +162,59 @@ describe("scenarios > binning > from a saved sql question", () => {
   context("via column popover", () => {
     beforeEach(() => {
       startNewQuestion();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Saved Questions").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("SQL Binning").click();
       visualize();
       cy.findByTextEnsureVisible("LONGITUDE");
     });
 
     it("should work for time series", () => {
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("CREATED_AT").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Distribution").click();
 
       assertOnXYAxisLabels({ xLabel: "CREATED_AT", yLabel: "Count" });
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Count by CREATED_AT: Month");
       cy.get("circle");
 
       // Open a popover with bucket options from the time series footer
       cy.findAllByTestId("select-button-content").contains("Month").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Quarter").click();
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Count by CREATED_AT: Quarter");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Q1 - 2017");
     });
 
     it("should work for number", () => {
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("TOTAL").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Distribution").click();
 
       assertOnXYAxisLabels({ xLabel: "TOTAL", yLabel: "Count" });
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Count by TOTAL: Auto binned");
       cy.get(".bar");
     });
 
     it("should work for longitude", () => {
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("LONGITUDE").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Distribution").click();
 
       assertOnXYAxisLabels({ xLabel: "LONGITUDE", yLabel: "Count" });
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Count by LONGITUDE: Auto binned");
       cy.get(".bar");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("170° W");
     });
   });

--- a/e2e/test/scenarios/collections/archive.cy.spec.js
+++ b/e2e/test/scenarios/collections/archive.cy.spec.js
@@ -34,6 +34,7 @@ describe("scenarios > collections > archive", () => {
     cy.visit("/archive");
 
     cy.get("main").scrollTo("bottom");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Item 40");
   });
 

--- a/e2e/test/scenarios/collections/collection-items-listing.cy.spec.js
+++ b/e2e/test/scenarios/collections/collection-items-listing.cy.spec.js
@@ -59,6 +59,7 @@ describe("scenarios > collection items listing", () => {
       visitRootCollection();
 
       // First page
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(`1 - ${PAGE_SIZE}`);
       cy.findByTestId("pagination-total").should("have.text", TOTAL_ITEMS);
       cy.findAllByTestId("collection-entry").should("have.length", PAGE_SIZE);
@@ -67,6 +68,7 @@ describe("scenarios > collection items listing", () => {
       cy.wait("@getCollectionItems");
 
       // Second page
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(`${PAGE_SIZE + 1} - ${TOTAL_ITEMS}`);
       cy.findByTestId("pagination-total").should("have.text", TOTAL_ITEMS);
       cy.findAllByTestId("collection-entry").should(
@@ -78,6 +80,7 @@ describe("scenarios > collection items listing", () => {
       cy.findByTestId("previous-page-btn").click();
 
       // First page
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(`1 - ${PAGE_SIZE}`);
       cy.findByTestId("pagination-total").should("have.text", TOTAL_ITEMS);
       cy.findAllByTestId("collection-entry").should("have.length", PAGE_SIZE);
@@ -224,6 +227,7 @@ describe("scenarios > collection items listing", () => {
 
       visitRootCollection();
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(`1 - ${PAGE_SIZE}`);
 
       cy.findByTestId("next-page-btn").click();
@@ -232,6 +236,7 @@ describe("scenarios > collection items listing", () => {
       toggleSortingFor(/Last edited at/i);
       cy.wait("@getCollectionItems");
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(`1 - ${PAGE_SIZE}`);
     });
   });

--- a/e2e/test/scenarios/collections/collection-pinned-overview.cy.spec.js
+++ b/e2e/test/scenarios/collections/collection-pinned-overview.cy.spec.js
@@ -128,6 +128,7 @@ describe("scenarios > collection pinned items overview", () => {
     openPinnedItemMenu(DASHBOARD_NAME);
     popover().findByText("Move").click();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(`Move "${DASHBOARD_NAME}"?`).should("be.visible");
   });
 
@@ -138,6 +139,7 @@ describe("scenarios > collection pinned items overview", () => {
     openPinnedItemMenu(DASHBOARD_NAME);
     popover().findByText("Duplicate").click();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(`Duplicate "${DASHBOARD_NAME}" and its questions`).should(
       "be.visible",
     );
@@ -152,6 +154,7 @@ describe("scenarios > collection pinned items overview", () => {
     cy.wait("@getPinnedItems");
 
     getPinnedSection().should("not.exist");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(DASHBOARD_NAME).should("not.exist");
   });
 

--- a/e2e/test/scenarios/collections/collections.cy.spec.js
+++ b/e2e/test/scenarios/collections/collections.cy.spec.js
@@ -39,7 +39,9 @@ describe("scenarios > collection defaults", () => {
 
       cy.viewport(800, 500);
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("New").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Collection").click();
 
       modal().within(() => {
@@ -52,6 +54,7 @@ describe("scenarios > collection defaults", () => {
         cy.findByText(`Collection ${COLLECTIONS_COUNT}`).click();
       });
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Create").click();
 
       cy.findByTestId("collection-name-heading").should(
@@ -140,6 +143,7 @@ describe("scenarios > collection defaults", () => {
       });
 
       // 2. Ensure we show the helpful tooltip with the full (long) collection name
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Fifth collection with a very long name").realHover();
       popover().contains("Fifth collection with a very long name");
     });
@@ -219,6 +223,7 @@ describe("scenarios > collection defaults", () => {
         },
       );
       visitRootCollection();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("admin@metabase.test").trigger("mouseenter");
       cy.findByRole("tooltip").should("not.exist");
     });
@@ -242,6 +247,7 @@ describe("scenarios > collection defaults", () => {
         },
       );
       visitRootCollection();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("averyverylongemail@veryverylongdomain.com").trigger(
         "mouseenter",
       );
@@ -263,6 +269,7 @@ describe("scenarios > collection defaults", () => {
       cy.createNativeQuestion(questionDetails);
 
       visitRootCollection();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Orders in a dashboard");
     });
 
@@ -273,16 +280,20 @@ describe("scenarios > collection defaults", () => {
         visitCollection(id);
       });
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Orders").as("dragSubject");
 
       navigationSidebar().findByText("Our analytics").as("dropTarget");
 
       dragAndDrop("dragSubject", "dropTarget");
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Moved question");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Orders").should("not.exist");
 
       visitRootCollection();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Orders");
     });
 
@@ -338,13 +349,16 @@ describe("scenarios > collection defaults", () => {
 
         // Even if user tries to navigate directly to the root collection, we have to make sure its content is not shown
         cy.visit("/collection/root");
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("You don't have permissions to do that.");
       });
 
       it("should be able to choose a child collection when saving a question (metabase#14052)", () => {
         openOrdersTable();
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("Save").click();
         // Click to choose which collection should this question be saved to
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText(revokedUsersPersonalCollectionName).click();
         popover().within(() => {
           cy.findByText(/Collections/i);
@@ -435,6 +449,7 @@ describe("scenarios > collection defaults", () => {
 
           // Select one
           selectItemUsingCheckbox("Orders");
+          // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
           cy.findByText("1 item selected").should("be.visible");
           cy.icon("dash").should("exist");
           cy.icon("check").should("exist");
@@ -442,12 +457,14 @@ describe("scenarios > collection defaults", () => {
           // Select all
           cy.findByLabelText("Select all items").click();
           cy.icon("dash").should("not.exist");
+          // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
           cy.findByText("5 items selected");
 
           // Deselect all
           cy.findByLabelText("Select all items").click();
 
           cy.icon("check").should("not.exist");
+          // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
           cy.findByText(/item(s)? selected/).should("not.be.visible");
         });
 
@@ -456,12 +473,16 @@ describe("scenarios > collection defaults", () => {
             collection_id: 1,
           });
           cy.visit("/collection/root");
+          // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
           cy.findByText("Your personal collection").click();
 
           selectItemUsingCheckbox("Orders");
+          // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
           cy.findByText("1 item selected").should("be.visible");
 
+          // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
           cy.findByText("Our analytics").click();
+          // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
           cy.findByText(/item(s)? selected/).should("not.be.visible");
         });
       });
@@ -471,11 +492,14 @@ describe("scenarios > collection defaults", () => {
           cy.visit("/collection/root");
           selectItemUsingCheckbox("Orders");
 
+          // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
           cy.findByText(/item(s)? selected/)
             .button("Archive")
             .click();
 
+          // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
           cy.findByText("Orders").should("not.exist");
+          // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
           cy.findByText(/item(s)? selected/).should("not.be.visible");
         });
       });
@@ -485,6 +509,7 @@ describe("scenarios > collection defaults", () => {
           cy.visit("/collection/root");
           selectItemUsingCheckbox("Orders");
 
+          // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
           cy.findByText(/item(s)? selected/)
             .button("Move")
             .click();
@@ -494,16 +519,22 @@ describe("scenarios > collection defaults", () => {
             cy.button("Move").click();
           });
 
+          // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
           cy.findByText("Orders").should("not.exist");
+          // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
           cy.findByText(/item(s)? selected/).should("not.be.visible");
 
           // Check that items were actually moved
           navigationSidebar().findByText("First collection").click();
+          // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
           cy.findByText("Orders");
 
+          // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
           cy.findByText("Undo").click();
           navigationSidebar().findByText("Our analytics").click();
+          // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
           cy.findByText("Orders").should("be.visible");
+          // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
           cy.findByText("Undo").should("not.exist");
         });
       });

--- a/e2e/test/scenarios/collections/permissions.cy.spec.js
+++ b/e2e/test/scenarios/collections/permissions.cy.spec.js
@@ -45,6 +45,7 @@ describe("collection permissions", () => {
                   appBar().within(() => {
                     cy.icon("add").click();
                   });
+                  // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
                   cy.findByText("Dashboard").click();
                   cy.findByTestId("select-button").findByText(
                     "Second collection",
@@ -54,6 +55,7 @@ describe("collection permissions", () => {
                 onlyOn(user === "admin", () => {
                   it("should offer to save dashboard to root collection from a dashboard page (metabase#16832)", () => {
                     cy.visit("/collection/root");
+                    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
                     cy.findByText("Orders in a dashboard").click();
                     appBar().within(() => {
                       cy.icon("add").click();
@@ -192,6 +194,7 @@ describe("collection permissions", () => {
                     });
                     popover().findByText("View archive").click();
                     cy.location("pathname").should("eq", "/archive");
+                    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
                     cy.findByText("Orders");
                   });
                 });
@@ -200,6 +203,7 @@ describe("collection permissions", () => {
                   it("shouldn't be able to archive/edit root or personal collection", () => {
                     cy.visit("/collection/root");
                     cy.icon("edit").should("not.exist");
+                    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
                     cy.findByText("Your personal collection").click();
                     cy.icon("edit").should("not.exist");
                   });
@@ -220,6 +224,7 @@ describe("collection permissions", () => {
                     });
 
                     openCollectionMenu();
+                    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
                     popover().within(() => cy.findByText("Archive").click());
                     cy.get(".Modal").findByText("Archive").click();
 
@@ -236,11 +241,14 @@ describe("collection permissions", () => {
                     });
 
                     // While we're here, we can test unarchiving the collection as well
+                    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
                     cy.findByText("Archived collection");
+                    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
                     cy.findByText("Undo").click();
 
                     cy.wait("@editCollection");
 
+                    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
                     cy.findByText(
                       "Sorry, you don’t have permission to see that.",
                     ).should("not.exist");
@@ -348,6 +356,7 @@ describe("collection permissions", () => {
             it("should not show pins or a helper text (metabase#20043)", () => {
               cy.visit("/collection/root");
 
+              // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
               cy.findByText("Orders in a dashboard");
               cy.icon("pin").should("not.exist");
             });
@@ -365,6 +374,7 @@ describe("collection permissions", () => {
             it("should not be able to use bulk actions on collection items (metabase#16490)", () => {
               cy.visit("/collection/root");
 
+              // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
               cy.findByText("Orders")
                 .closest("tr")
                 .within(() => {
@@ -372,6 +382,7 @@ describe("collection permissions", () => {
                   cy.findByRole("checkbox").should("not.exist");
                 });
 
+              // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
               cy.findByText("Orders in a dashboard")
                 .closest("tr")
                 .within(() => {
@@ -385,6 +396,7 @@ describe("collection permissions", () => {
                 const { first_name, last_name } = USERS[user];
                 cy.visit(route);
                 cy.icon("add").click();
+                // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
                 cy.findByText("Dashboard").click();
 
                 // Coming from the root collection, the initial offered collection will be "Our analytics" (read-only access)
@@ -417,6 +429,7 @@ describe("collection permissions", () => {
     cy.signIn("normal");
 
     openNativeEditor().type("select * from people");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Save").click();
 
     cy.findByTestId("select-button").findByText("Our analytics");

--- a/e2e/test/scenarios/collections/personal-collections.cy.spec.js
+++ b/e2e/test/scenarios/collections/personal-collections.cy.spec.js
@@ -60,12 +60,14 @@ describe("personal collections", () => {
       });
 
       cy.visit("/collection/root");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Your personal collection");
       navigationSidebar().within(() => {
         cy.icon("ellipsis").click();
       });
       popover().findByText("Other users' personal collections").click();
       cy.location("pathname").should("eq", "/collection/users");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(/All personal collections/i);
       Object.values(USERS).forEach(user => {
         const FULL_NAME = `${user.first_name} ${user.last_name}`;
@@ -83,6 +85,7 @@ describe("personal collections", () => {
 
       // Go to admin's personal collection
       cy.visit("/collection/root");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Your personal collection").click();
 
       getCollectionActions().within(() => {
@@ -131,6 +134,7 @@ describe("personal collections", () => {
       });
 
       cy.visit(`/collection/${NODATA_PERSONAL_COLLECTION_ID}`);
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Foo");
     });
   });
@@ -142,6 +146,7 @@ describe("personal collections", () => {
           cy.signIn(user);
 
           cy.visit("/collection/root");
+          // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
           cy.findByText("Your personal collection").click();
 
           // Create initial collection inside the personal collection and navigate to it
@@ -164,8 +169,10 @@ describe("personal collections", () => {
           );
 
           openCollectionMenu();
+          // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
           popover().within(() => cy.findByText("Archive").click());
           modal().findByRole("button", { name: "Archive" }).click();
+          // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
           cy.findByText("Archived collection");
           cy.get("@sidebar").findByText("Foo").should("not.exist");
         });

--- a/e2e/test/scenarios/collections/reproductions/23515-pinned-question-pagination.cy.spec.js
+++ b/e2e/test/scenarios/collections/reproductions/23515-pinned-question-pagination.cy.spec.js
@@ -17,9 +17,11 @@ describe("issue 23515", () => {
     cy.wait("@getCardQuery");
 
     cy.icon("triangle_right").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Rows 5-8 of first 2000").should("be.visible");
 
     cy.icon("triangle_left").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Rows 1-4 of first 2000").should("be.visible");
   });
 });

--- a/e2e/test/scenarios/collections/reproductions/24660-same-name-parent-collections.cy.spec.js
+++ b/e2e/test/scenarios/collections/reproductions/24660-same-name-parent-collections.cy.spec.js
@@ -18,13 +18,16 @@ describe("issue 24660", () => {
 
   it("should properly show contents of different collections with the same name (metabase#24660)", () => {
     startNewQuestion();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Saved Questions").click();
     cy.findAllByTestId("tree-item-name")
       .contains(collectionName)
       .first()
       .click();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(questions[1]);
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(questions[2]).should("not.exist");
   });
 });

--- a/e2e/test/scenarios/collections/revision-history.cy.spec.js
+++ b/e2e/test/scenarios/collections/revision-history.cy.spec.js
@@ -38,6 +38,7 @@ describe("revision history", () => {
 
       openRevisionHistory();
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(/created this/);
 
       cy.findAllByText("Revert").should("not.exist");
@@ -68,12 +69,15 @@ describe("revision history", () => {
                 visitAndEditDashboard(body.id);
               });
               cy.icon("add").last().click();
+              // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
               cy.findByText("Orders, Count").click();
               saveDashboard();
               openRevisionHistory();
+              // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
               cy.findByText(/added a card/)
                 .siblings("button")
                 .should("not.exist");
+              // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
               cy.findByText(/rearranged the cards/).should("not.exist");
             });
 
@@ -88,9 +92,11 @@ describe("revision history", () => {
               });
 
               // We reverted the dashboard to the state prior to adding any cards to it
+              // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
               cy.findByText("This dashboard is looking empty.");
 
               // Should be able to revert back again
+              // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
               cy.findByText("History");
               clickRevert(/added a card/);
 
@@ -99,6 +105,7 @@ describe("revision history", () => {
                 expect(body.cause).not.to.exist;
               });
 
+              // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
               cy.findByText("117.03");
             });
 
@@ -116,6 +123,7 @@ describe("revision history", () => {
                 expect(body.cause).not.to.exist;
               });
 
+              // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
               cy.contains(/^Orders$/);
             });
 
@@ -125,6 +133,7 @@ describe("revision history", () => {
               visitQuestion(1);
 
               questionInfoButton().click();
+              // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
               cy.findByText("History").click();
               // Last revert is the original state
               cy.findAllByTestId("question-revert-button").last().click();
@@ -134,6 +143,7 @@ describe("revision history", () => {
                 expect(body.cause).not.to.exist;
               });
 
+              // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
               cy.contains(/^Orders$/);
             });
           });

--- a/e2e/test/scenarios/cross-version/source/00-setup.cy.spec.js
+++ b/e2e/test/scenarios/cross-version/source/00-setup.cy.spec.js
@@ -9,7 +9,9 @@ describe(`setup on ${version}`, () => {
     cy.visit("/");
     // It redirects to the setup page
     cy.location("pathname").should("eq", "/setup");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Welcome to Metabase");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Let's get started").click();
 
     setupLanguage();

--- a/e2e/test/scenarios/cross-version/source/02-datamodel.cy.spec.js
+++ b/e2e/test/scenarios/cross-version/source/02-datamodel.cy.spec.js
@@ -18,8 +18,11 @@ it("should configure data model settings", () => {
 
   cy.get(".AdminList").findByText("Orders").click();
   cy.findByDisplayValue("Product ID").parent().find(".Icon-gear").click();
+  // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
   cy.findByText("Use original value").click();
+  // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
   cy.findByText("Use foreign key").click();
+  // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
   cy.findByText("Title").click();
   cy.wait("@updateProductId");
 
@@ -30,9 +33,12 @@ it("should configure data model settings", () => {
   );
 
   cy.findByDisplayValue("Rating").parent().find(".Icon-gear").click();
+  // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
   cy.findByText("Use original value").click();
+  // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
   cy.findByText("Custom mapping").click();
   cy.wait("@remapRatingValues");
+  // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
   cy.findByText(
     "You might want to update the field name to make sure it still makes sense based on your remapping choices.",
   );
@@ -58,6 +64,7 @@ it("should configure data model settings", () => {
 
   cy.intercept("PUT", `/api/field/${PRODUCTS.EAN}`).as("hideEan");
   cy.findByDisplayValue("Ean").parent().contains("Everywhere").click();
+  // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
   cy.findByText("Do not include").click();
   cy.wait("@hideEan");
 
@@ -70,7 +77,9 @@ it("should configure data model settings", () => {
       cy.findByText("Price").click();
     });
   cy.wait("@updatePriceField");
+  // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
   cy.findByText("US Dollar").click();
+  // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
   cy.findByText("Euro").click();
   cy.wait("@updatePriceField");
 
@@ -79,6 +88,7 @@ it("should configure data model settings", () => {
 
   cy.intercept("PUT", `/api/field/${PEOPLE.PASSWORD}`).as("hidePassword");
   cy.findByDisplayValue("Password").parent().contains("Everywhere").click();
+  // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
   cy.findByText("Do not include").click();
   cy.wait("@hidePassword");
 
@@ -106,8 +116,10 @@ it("should configure data model settings", () => {
   cy.request("POST", "/api/segment", segment);
 
   cy.visit("/admin/datamodel/segments");
+  // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
   cy.findByText(segment.name);
 
   cy.visit("/admin/datamodel/metrics");
+  // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
   cy.findByText(metric.name);
 });

--- a/e2e/test/scenarios/cross-version/source/03-questions.cy.spec.js
+++ b/e2e/test/scenarios/cross-version/source/03-questions.cy.spec.js
@@ -4,24 +4,35 @@ it("should create questions", () => {
   cy.signInAsAdmin();
 
   cy.visit("/question/new");
+  // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
   cy.findByText("Custom question").click();
+  // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
   cy.findByText("Orders").click();
   cy.icon("join_left_outer").click();
+  // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
   cy.findByText("Products").click();
   // Make sure `on` condition is populated automatically
+  // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
   cy.findByText("Product ID").click();
 
+  // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
   cy.findByText("Add filters to narrow your answer").click();
+  // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
   cy.findByText("Large Purchases").click();
 
+  // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
   cy.findByText("Pick the metric you want to see").click();
+  // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
   cy.findByText(/^Average of/).click();
 
   cy.findByRole("heading", { name: /Products?/ }).click();
+  // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
   cy.findByText("Rating").click();
 
+  // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
   cy.findByText("Pick a column to group by").click();
   cy.get(".List-section-title").contains("Products").click();
+  // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
   cy.findByText("Category").click();
 
   visualize();
@@ -29,9 +40,12 @@ it("should create questions", () => {
   cy.get(".bar").should("have.length", 4);
 
   cy.findByTestId("viz-settings-button").click();
+  // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
   cy.contains("Show values on data points").next().click();
+  // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
   cy.contains("3.71");
 
+  // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
   cy.findByText("Save").click();
   cy.findByLabelText("Name").clear().type("Rating of Best-selling Products");
   cy.findByLabelText("Description").type(
@@ -39,23 +53,34 @@ it("should create questions", () => {
     { delay: 0 },
   );
   cy.button("Save").click();
+  // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
   cy.findByText("Not now").click();
 
   cy.visit("/question/new");
+  // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
   cy.findByText("Custom question").click();
+  // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
   cy.findByText(/Sample (Dataset|Database)/).click();
+  // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
   cy.findByText("Orders").click();
 
+  // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
   cy.findByText("Pick the metric you want to see").click();
+  // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
   cy.findByText("Common Metrics").click();
+  // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
   cy.findByText("Revenue").click();
 
+  // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
   cy.findByText("Pick a column to group by").click();
+  // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
   cy.findByText("Created At")
     .closest(".List-item")
     .findByText("by month")
     .click({ force: true });
+  // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
   cy.findByText("Quarter").click();
+  // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
   cy.findByText("Created At: Quarter");
 
   visualize();
@@ -63,13 +88,17 @@ it("should create questions", () => {
 
   cy.findByTestId("viz-settings-button").click();
   cy.icon("area").click();
+  // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
   cy.findByText("Goal line").next().click();
   cy.findByDisplayValue("0").type("100000").blur();
   cy.get(".line");
+  // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
   cy.findByText("Goal");
 
+  // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
   cy.findByText("Save").click();
   cy.findByLabelText("Name").clear().type("Quarterly Revenue");
   cy.button("Save").click();
+  // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
   cy.findByText("Not now").click();
 });

--- a/e2e/test/scenarios/cross-version/target/smoke.cy.spec.js
+++ b/e2e/test/scenarios/cross-version/target/smoke.cy.spec.js
@@ -5,6 +5,7 @@ describe(`smoke test the migration to the version ${version}`, () => {
     cy.intercept("POST", "/api/card/*/query").as("cardQuery");
 
     cy.visit("/");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Sign in to Metabase");
 
     cy.findByLabelText("Email address").type("admin@metabase.test");
@@ -15,14 +16,17 @@ describe(`smoke test the migration to the version ${version}`, () => {
 
     // Question 1
     cy.visit("/collection/root");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Quarterly Revenue").click();
     cy.wait("@cardQuery");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("It's okay to play around with saved questions");
     cy.button("Okay").click();
 
     cy.get("circle");
     cy.get(".line");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Goal");
     cy.get(".x-axis-label").invoke("text").should("eq", "Created At");
     cy.get(".y-axis-label").invoke("text").should("eq", "Revenue");
@@ -39,6 +43,7 @@ describe(`smoke test the migration to the version ${version}`, () => {
 
     // Question 2
     cy.visit("/collection/root");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Rating of Best-selling Products").click();
     cy.wait("@cardQuery");
 

--- a/e2e/test/scenarios/custom-column/cc-data-type.cy.spec.js
+++ b/e2e/test/scenarios/custom-column/cc-data-type.cy.spec.js
@@ -82,8 +82,11 @@ describe("scenarios > question > custom column > data type", () => {
 
     cy.findByPlaceholderText("Enter a number").should("not.exist");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Relative dates...").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Past").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("days");
   });
 
@@ -101,8 +104,11 @@ describe("scenarios > question > custom column > data type", () => {
 
     cy.findByPlaceholderText("Enter a number").should("not.exist");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Relative dates...").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Past").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("days");
   });
 
@@ -120,8 +126,11 @@ describe("scenarios > question > custom column > data type", () => {
 
     cy.findByPlaceholderText("Enter a number").should("not.exist");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Relative dates...").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Past").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("days");
   });
 });

--- a/e2e/test/scenarios/custom-column/cc-error-feedback.cy.spec.js
+++ b/e2e/test/scenarios/custom-column/cc-error-feedback.cy.spec.js
@@ -10,6 +10,7 @@ describe("scenarios > question > custom column > error feedback", () => {
     cy.signInAsAdmin();
 
     openProductsTable({ mode: "notebook" });
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Custom column").click();
   });
 
@@ -19,6 +20,7 @@ describe("scenarios > question > custom column > error feedback", () => {
       name: "Non-existent",
     });
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains(/^Unknown Field: abcdef/i);
   });
 
@@ -28,6 +30,7 @@ describe("scenarios > question > custom column > error feedback", () => {
       name: "BadSubstring",
     });
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains(/positive integer/i);
   });
 });

--- a/e2e/test/scenarios/custom-column/cc-expression-editor.cy.spec.js
+++ b/e2e/test/scenarios/custom-column/cc-expression-editor.cy.spec.js
@@ -14,6 +14,7 @@ describe("scenarios > question > custom column > expression editor", () => {
     cy.viewport(1280, 800);
 
     openOrdersTable({ mode: "notebook" });
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Custom column").click();
 
     enterCustomColumnDetails({
@@ -49,6 +50,7 @@ describe("scenarios > question > custom column > expression editor", () => {
       .type("{movetoend}{backspace}", { force: true })
       .blur();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Expected expression");
     cy.button("Done").should("be.disabled");
   });

--- a/e2e/test/scenarios/custom-column/cc-help-text.cy.spec.js
+++ b/e2e/test/scenarios/custom-column/cc-help-text.cy.spec.js
@@ -10,38 +10,47 @@ describe("scenarios > question > custom column > help text", () => {
     cy.signInAsAdmin();
 
     openProductsTable({ mode: "notebook" });
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Custom column").click();
   });
 
   it("should appear while inside a function", () => {
     enterCustomColumnDetails({ formula: "Lower(" });
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("lower(text)");
   });
 
   it("should appear after a field reference", () => {
     enterCustomColumnDetails({ formula: "Lower([Category]" });
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("lower(text)");
   });
 
   it("should not appear while outside a function", () => {
     enterCustomColumnDetails({ formula: "Lower([Category])" });
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("lower(text)").should("not.exist");
   });
 
   it("should not appear when formula field is not in focus (metabase#15891)", () => {
     enterCustomColumnDetails({ formula: "rou{enter}1.5" });
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("round([Temperature])");
 
     // Click outside of formula field instead of blur
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Expression").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("round([Temperature])").should("not.exist");
 
     // Should also work with escape key
     cy.get("@formula").focus();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("round([Temperature])");
 
     cy.get("@formula").type("{esc}");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("round([Temperature])").should("not.exist");
   });
 
@@ -49,7 +58,9 @@ describe("scenarios > question > custom column > help text", () => {
     enterCustomColumnDetails({ formula: "rou{enter}" });
 
     // Shouldn't hide on click
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("round([Temperature])").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("round([Temperature])");
   });
 });

--- a/e2e/test/scenarios/custom-column/cc-typing-suggestion.cy.spec.js
+++ b/e2e/test/scenarios/custom-column/cc-typing-suggestion.cy.spec.js
@@ -10,6 +10,7 @@ describe("scenarios > question > custom column > typing suggestion", () => {
     cy.signInAsAdmin();
 
     openProductsTable({ mode: "notebook" });
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Custom column").click();
   });
 
@@ -28,6 +29,7 @@ describe("scenarios > question > custom column > typing suggestion", () => {
 
     // if the replacement is correct -> "[Rating]"
     // if the replacement is wrong -> "[Rating] ng"
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("[Rating] ng").should("not.exist");
   });
 
@@ -40,28 +42,34 @@ describe("scenarios > question > custom column > typing suggestion", () => {
     // accept the first suggested function, i.e. "length"
     cy.get("@formula").type("{enter}");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("length([Title])");
   });
 
   it("should correctly insert function suggestion with the opening parenthesis", () => {
     enterCustomColumnDetails({ formula: "LOW{enter}" });
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("lower(");
   });
 
   it("should show expression function helper if a proper function is typed", () => {
     enterCustomColumnDetails({ formula: "lower(" });
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("lower(text)");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Returns the string of text in all lower case.").should(
       "be.visible",
     );
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("lower([Status])").should("be.visible");
 
     cy.findByTestId("expression-helper-popover-arguments")
       .findByText("text")
       .realHover();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("The column with values to convert to lower case.").should(
       "be.visible",
     );

--- a/e2e/test/scenarios/custom-column/custom-column.cy.spec.js
+++ b/e2e/test/scenarios/custom-column/custom-column.cy.spec.js
@@ -33,6 +33,7 @@ describe("scenarios > question > custom column", () => {
 
     visualize();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("There was a problem with your question").should("not.exist");
     cy.get(".Visualization").contains("Math");
   });
@@ -47,9 +48,11 @@ describe("scenarios > question > custom column", () => {
     });
     cy.button("Done").click();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Summarize").click();
     popover().findByText("Count of rows").click();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Pick a column to group by").click();
     popover().findByText("Half Price").click();
 
@@ -62,6 +65,7 @@ describe("scenarios > question > custom column", () => {
 
     popover().last().findByText("10 bins").click();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Half Price: 10 bins").should("be.visible");
   });
 
@@ -75,9 +79,11 @@ describe("scenarios > question > custom column", () => {
     });
     cy.button("Done").click();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Summarize").click();
     popover().findByText("Count of rows").click();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Pick a column to group by").click();
     popover().findByText("Product Date").click();
 
@@ -90,6 +96,7 @@ describe("scenarios > question > custom column", () => {
 
     popover().last().findByText("Month of Year").click();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Product Date: Month of year").should("be.visible");
   });
 
@@ -103,9 +110,11 @@ describe("scenarios > question > custom column", () => {
     });
     cy.button("Done").click();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Summarize").click();
     popover().findByText("Count of rows").click();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Pick a column to group by").click();
     popover().findByText("UserLAT").click();
 
@@ -116,6 +125,7 @@ describe("scenarios > question > custom column", () => {
 
     popover().last().findByText("Bin every 10 degrees").click();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("UserLAT: 10°").should("be.visible");
   });
 
@@ -131,6 +141,7 @@ describe("scenarios > question > custom column", () => {
 
     summarize();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Group by").parent().findByText("Math").trigger("mouseenter");
 
     popover().contains("Math");
@@ -183,11 +194,14 @@ describe("scenarios > question > custom column", () => {
       cy.findByText("Total").click();
     });
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Pick a column to group by").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Created At").click();
 
     // Add custom column based on previous aggregates
     const columnName = "MegaTotal";
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Custom column").click();
 
     enterCustomColumnDetails({
@@ -198,6 +212,7 @@ describe("scenarios > question > custom column", () => {
 
     visualize();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("There was a problem with your question").should("not.exist");
     // This is a pre-save state of the question but the column name should appear
     // both in tabular and graph views (regardless of which one is currently selected)
@@ -207,10 +222,13 @@ describe("scenarios > question > custom column", () => {
   it("should not return same results for columns with the same name (metabase#12649)", () => {
     openOrdersTable({ mode: "notebook" });
     // join with Products
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Join data").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Products").click();
 
     // add custom column
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Custom column").click();
     enterCustomColumnDetails({ formula: "1 + 1", name: "x" });
     cy.button("Done").click();
@@ -258,6 +276,7 @@ describe("scenarios > question > custom column", () => {
       { visitQuestion: true },
     );
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(CC_NAME);
   });
 
@@ -293,6 +312,7 @@ describe("scenarios > question > custom column", () => {
 
     cy.log("Regression since v0.37.1 - it works on v0.37.0");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains(`Sum of ${CC_NAME}`);
     cy.get(".Visualization .dot").should("have.length.of.at.least", 8);
   });
@@ -315,9 +335,11 @@ describe("scenarios > question > custom column", () => {
       { visitQuestion: true },
     );
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("13634");
 
     cy.log("Reported failing in v0.34.3, v0.35.4, v0.36.8.2, v0.37.0.2");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Foo Bar");
     cy.findAllByText("57911");
   });
@@ -347,11 +369,13 @@ describe("scenarios > question > custom column", () => {
     // Test displays collapsed filter - click on number 1 to expand and show the filter name
     cy.icon("filter").parent().contains("1").click();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(/Subtotal is greater than 0/i)
       .parent()
       .find(".Icon-close")
       .click();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(CC_NAME);
   });
 
@@ -374,7 +398,9 @@ describe("scenarios > question > custom column", () => {
       { visitQuestion: true },
     );
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(CC_NAME);
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Gizmo2");
   });
 
@@ -409,10 +435,12 @@ describe("scenarios > question > custom column", () => {
     });
 
     // Remove join
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Join data")
       .parent()
       .find(".Icon-close")
       .click({ force: true }); // x is hidden and hover doesn't work so we have to force it
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Join data").should("not.exist");
 
     cy.log("Reported failing on 0.38.1-SNAPSHOT (6d77f099)");
@@ -422,6 +450,7 @@ describe("scenarios > question > custom column", () => {
       expect(response.body.error).to.not.exist;
     });
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("37.65");
   });
 
@@ -460,7 +489,9 @@ describe("scenarios > question > custom column", () => {
       { callback: xhr => expect(xhr.response.body.error).not.to.exist },
     );
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(CC_NAME);
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("37.65");
   });
 
@@ -475,6 +506,7 @@ describe("scenarios > question > custom column", () => {
       cy.visit(`/question/${QUESTION_ID}/notebook`);
     });
     summarize({ mode: "notebook" });
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Sum of ...").click();
     popover().findByText("MyCC [2021]").click();
     cy.findAllByTestId("notebook-cell-item")
@@ -489,6 +521,7 @@ describe("scenarios > question > custom column", () => {
 
   it.skip("should work with `isNull` function (metabase#15922)", () => {
     openOrdersTable({ mode: "notebook" });
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Custom column").click();
     enterCustomColumnDetails({
       formula: `isnull([Discount])`,
@@ -500,7 +533,9 @@ describe("scenarios > question > custom column", () => {
       expect(response.body.error).to.not.exist;
     });
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("37.65");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("No discount");
   });
 
@@ -517,6 +552,7 @@ describe("scenarios > question > custom column", () => {
       },
     });
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("CustomDate").click();
 
     popover().within(() => {
@@ -528,11 +564,13 @@ describe("scenarios > question > custom column", () => {
     });
 
     cy.wait("@dataset");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Showing 463 rows").should("be.visible");
   });
 
   it("should work with relative date filter applied to a custom column (metabase#16273)", () => {
     openOrdersTable({ mode: "notebook" });
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Custom column").click();
 
     enterCustomColumnDetails({
@@ -544,11 +582,15 @@ describe("scenarios > question > custom column", () => {
 
     filter({ mode: "notebook" });
     popover().contains("MiscDate").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Relative dates...").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Past").click();
     // The popover shows up with the default value selected - previous 30 days.
     // Since we don't have any orders in the Sample Database for that period, we have to change it to the previous 30 years.
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("days").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("years").click();
     cy.button("Add filter").click();
 
@@ -556,7 +598,9 @@ describe("scenarios > question > custom column", () => {
       expect(body.error).to.not.exist;
     });
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("MiscDate Previous 30 Years"); // Filter name
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("MiscDate"); // Column name
   });
 

--- a/e2e/test/scenarios/custom-column/reproductions/13289-cc-post-aggregation-zoom-in.cy.spec.js
+++ b/e2e/test/scenarios/custom-column/reproductions/13289-cc-post-aggregation-zoom-in.cy.spec.js
@@ -17,6 +17,7 @@ describe("issue 13289", () => {
 
     openOrdersTable({ mode: "notebook" });
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Custom column").click();
 
     // Add custom column that will be used later in summarize (group by)
@@ -26,8 +27,10 @@ describe("issue 13289", () => {
 
   it("should allow 'zoom in' drill-through when grouped by custom column (metabase#13289) (metabase#13289)", () => {
     summarize({ mode: "notebook" });
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Count of rows").click();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Pick a column to group by").click();
 
     popover().findByText(CC_NAME).click();
@@ -46,11 +49,14 @@ describe("issue 13289", () => {
         .click({ force: true });
     });
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Zoom in").click();
     cy.wait("@dataset");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("There was a problem with your question").should("not.exist");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(`${CC_NAME} is equal to 2`);
   });
 });

--- a/e2e/test/scenarios/custom-column/reproductions/13751-cc-allow-strings-in-filter.cy.spec.js
+++ b/e2e/test/scenarios/custom-column/reproductions/13751-cc-allow-strings-in-filter.cy.spec.js
@@ -15,6 +15,7 @@ describe("issue 13751", { tags: "@external" }, () => {
     cy.signInAsAdmin();
 
     startNewQuestion();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(PG_DB_NAME).should("be.visible").click();
     cy.findByTextEnsureVisible("People").click();
   });
@@ -32,6 +33,7 @@ describe("issue 13751", { tags: "@external" }, () => {
     });
 
     // Add filter based on custom column
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Add filters to narrow your answer").click();
     popover().within(() => {
       cy.findByText(CC_NAME).click();
@@ -49,6 +51,7 @@ describe("issue 13751", { tags: "@external" }, () => {
 
     visualize();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Arnold Adams");
   });
 });

--- a/e2e/test/scenarios/custom-column/reproductions/14517-cc-do-not-remove-regex-escape-chars.cy.spec.js
+++ b/e2e/test/scenarios/custom-column/reproductions/14517-cc-do-not-remove-regex-escape-chars.cy.spec.js
@@ -15,6 +15,7 @@ describe.skip(
       cy.signInAsAdmin();
 
       startNewQuestion();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(PG_DB_NAME).should("be.visible").click();
       cy.findByTextEnsureVisible("People").click();
     });

--- a/e2e/test/scenarios/custom-column/reproductions/14843-cc-apply-filter-not-equal-to.cy.spec.js
+++ b/e2e/test/scenarios/custom-column/reproductions/14843-cc-apply-filter-not-equal-to.cy.spec.js
@@ -35,7 +35,9 @@ describe("issue 14843", () => {
 
     popover().findByText(CC_NAME).click();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Equal to").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Not equal to").click();
 
     cy.findByPlaceholderText("Enter a number").type("3");
@@ -43,7 +45,9 @@ describe("issue 14843", () => {
 
     visualize();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(`${CC_NAME} is not equal to 3`);
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Rye").should("not.exist");
   });
 });

--- a/e2e/test/scenarios/custom-column/reproductions/18069-cc-sum-aggregation-dimension-type.cy.spec.js
+++ b/e2e/test/scenarios/custom-column/reproductions/18069-cc-sum-aggregation-dimension-type.cy.spec.js
@@ -30,6 +30,7 @@ describe("issue 18069", () => {
 
   it("should not allow choosing text fields for SUM (metabase#18069)", () => {
     summarize({ mode: "notebook" });
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Sum of ...").click();
 
     popover().within(() => {
@@ -49,6 +50,7 @@ describe("issue 18069", () => {
 
     visualize();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("1,041.45");
   });
 });

--- a/e2e/test/scenarios/custom-column/reproductions/18747-cc-connected-to-dashboard-parameter.cy.spec.js
+++ b/e2e/test/scenarios/custom-column/reproductions/18747-cc-connected-to-dashboard-parameter.cy.spec.js
@@ -43,8 +43,10 @@ describe("issue 18747", () => {
     addNumberParameterToDashboard();
     mapParameterToCustomColumn();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Save").click();
     // wait for saving to finish
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("You're editing this dashboard.").should("not.exist");
 
     addValueToParameterFilter();

--- a/e2e/test/scenarios/custom-column/reproductions/18814-cc-used-in-aggregation-for-nested-query.cy.spec.js
+++ b/e2e/test/scenarios/custom-column/reproductions/18814-cc-used-in-aggregation-for-nested-query.cy.spec.js
@@ -31,8 +31,10 @@ describe("issue 18814", () => {
     cy.icon("notebook").click();
 
     cy.icon("sum").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Count of rows").click();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Pick a column to group by").click();
     popover().contains(ccName).click();
 

--- a/e2e/test/scenarios/custom-column/reproductions/19744-cc-after-aggregation-limited-filters.cy.spec.js
+++ b/e2e/test/scenarios/custom-column/reproductions/19744-cc-after-aggregation-limited-filters.cy.spec.js
@@ -49,7 +49,9 @@ describe.skip("issue 19744", () => {
     editDashboard();
     cy.icon("filter").click();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Time").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("All Options").click();
 
     cy.get(".DashCard").contains("Select…").click();

--- a/e2e/test/scenarios/custom-column/reproductions/21513-cc-confusion-field-function.cy.spec.js
+++ b/e2e/test/scenarios/custom-column/reproductions/21513-cc-confusion-field-function.cy.spec.js
@@ -17,9 +17,11 @@ describe("issue 21513", () => {
     summarize({ mode: "notebook" });
     popover().findByText("Count of rows").click();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Pick a column to group by").click();
     popover().findByText("Category").click();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Custom column").click();
     enterCustomColumnDetails({
       formula: "[Count] * 2",

--- a/e2e/test/scenarios/custom-column/reproductions/23862-cc-group-by-nested.cy.spec.js
+++ b/e2e/test/scenarios/custom-column/reproductions/23862-cc-group-by-nested.cy.spec.js
@@ -47,7 +47,9 @@ describe("issue 23862", () => {
       );
     });
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Small");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("-36.53");
   });
 });

--- a/e2e/test/scenarios/custom-column/reproductions/24922-cc-case-segment.cy.spec.js
+++ b/e2e/test/scenarios/custom-column/reproductions/24922-cc-case-segment.cy.spec.js
@@ -34,11 +34,13 @@ describe("issue 24922", () => {
   it("should allow segments in case custom expressions (metabase#24922)", () => {
     openOrdersTable({ mode: "notebook" });
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Custom column").click();
     enterCustomColumnDetails(customColumnDetails);
     cy.button("Done").click();
 
     visualize();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("CustomColumn").should("be.visible");
   });
 });

--- a/e2e/test/scenarios/custom-column/reproductions/25189-cc-column-reference-only.cy.spec.js
+++ b/e2e/test/scenarios/custom-column/reproductions/25189-cc-column-reference-only.cy.spec.js
@@ -62,6 +62,7 @@ describe.skip("issue 25189", () => {
     });
 
     cy.wait("@dataset");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("No results!");
 
     // 3. We shouldn't see duplication in the breakout fields

--- a/e2e/test/scenarios/custom-column/reproductions/27745-cc-numeric-missing-summarize.cy.spec.js
+++ b/e2e/test/scenarios/custom-column/reproductions/27745-cc-numeric-missing-summarize.cy.spec.js
@@ -21,7 +21,9 @@ import {
 
     it("should display all summarize options if the only numeric field is a custom column (metabase#27745)", () => {
       startNewQuestion();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(/Writable/i).click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(/colors/i).click();
       cy.icon("add_data").click();
       enterCustomColumnDetails({

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-date.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-date.cy.spec.js
@@ -59,6 +59,7 @@ describe("scenarios > dashboard > filters > date", () => {
   // make sure the default filter works for just one of the available options
   it(`should work when set as the default filter`, () => {
     setFilter("Time", "Month and Year");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Default value").next().click();
 
     DateFilter.setMonthAndYear({
@@ -66,6 +67,7 @@ describe("scenarios > dashboard > filters > date", () => {
       year: "2016",
     });
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Select…").click();
     popover().contains("Created At").first().click();
 
@@ -77,8 +79,10 @@ describe("scenarios > dashboard > filters > date", () => {
     });
 
     // Make sure we can override the default value
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("November, 2016").click();
     popover().contains("June").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("33.9");
   });
 
@@ -92,20 +96,27 @@ describe("scenarios > dashboard > filters > date", () => {
       cy.findByText("All Options").click();
     });
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("No default").click();
     // click on Relative dates..., to open the relative date filter type tabs
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Relative dates...").click();
     // choose Next, under which the new options should be available
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Next").click();
     // click on Days (the default value), which should open the resolution dropdown
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("days").click();
     // Hours should appear in the selection box (don't click it)
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("hours");
     // Minutes should appear in the selection box; click it
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("minutes").click();
     // also check the "Include this minute" checkbox
     // which is actually "Include" followed by "this minute" wrapped in <strong>, so has to be clicked this way
     cy.icon("ellipsis").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Include this minute").click();
   });
 
@@ -123,6 +134,7 @@ describe("scenarios > dashboard > filters > date", () => {
       cy.findByText("Toutes les options").click(); // "All Options"
     });
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Sélectionner...").click(); // "Select…"
     popover().contains("Created At").first().click();
 
@@ -131,11 +143,16 @@ describe("scenarios > dashboard > filters > date", () => {
       editBarText: "Vous êtes en train d'éditer ce tableau de bord.",
     });
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Filtre de date").click(); // "Date Filter"
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Exclure...").click(); // "Exclude..."
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Mois de l'année...").click(); // "Months of the year..."
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("janvier").click(); // "January"
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Mettre à jour le filtre").click(); // "Update filter"
 
     cy.url().should(

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-id.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-id.cy.spec.js
@@ -21,6 +21,7 @@ describe("scenarios > dashboard > filters > ID", () => {
     editDashboard();
     setFilter("ID");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Select…").click();
   });
   describe("should work for the primary key", () => {
@@ -40,6 +41,7 @@ describe("scenarios > dashboard > filters > ID", () => {
     });
 
     it("when set as the default filter", () => {
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Default value").next().click();
       addWidgetStringFilter("15");
 
@@ -70,6 +72,7 @@ describe("scenarios > dashboard > filters > ID", () => {
     });
 
     it("when set as the default filter", () => {
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Default value").next().click();
       addWidgetStringFilter("4");
 
@@ -102,6 +105,7 @@ describe("scenarios > dashboard > filters > ID", () => {
     });
 
     it("when set as the default filter", () => {
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Default value").next().click();
       addWidgetStringFilter("10");
 

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-location.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-location.cy.spec.js
@@ -48,9 +48,11 @@ describe("scenarios > dashboard > filters > location", () => {
 
   it(`should work when set as the default filter`, () => {
     setFilter("Location", "Is");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Select…").click();
     popover().contains("City").click();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Default value").next().click();
 
     addWidgetStringFilter("Abbeville");

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-nested.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-nested.cy.spec.js
@@ -55,7 +55,9 @@ describe("scenarios > dashboard > filters > nested questions", () => {
     });
 
     editDashboard();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(filter.name).find(".Icon-gear").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Select…").click();
 
     // This part reproduces metabase#13186
@@ -77,19 +79,24 @@ describe("scenarios > dashboard > filters > nested questions", () => {
     cy.button("Add filter").click();
     cy.wait("@dashcardQuery2");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("2 selections");
     cy.get("tbody > tr").should("have.length", 2);
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Doohickey").should("not.exist");
 
     cy.reload();
     cy.wait("@dashcardQuery2");
 
     cy.location("search").should("eq", "?text=Gizmo&text=Gadget");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("2 selections");
 
     editDashboard();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(filter.name).find(".Icon-gear").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Column to filter on")
       .parent()
       .contains(/Category/i)
@@ -125,8 +132,10 @@ describe("scenarios > dashboard > filters > nested questions", () => {
 
     setFilter("ID");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("No valid fields").should("not.exist");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Select…").click();
     popover().contains("ID").click();
   });

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-number.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-number.cy.spec.js
@@ -51,6 +51,7 @@ describe("scenarios > dashboard > filters > number", () => {
 
   it(`should work when set as the default filter`, () => {
     setFilter("Number", "Equal to");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Default value").next().click();
 
     addWidgetNumberFilter("2.07");

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-sql-date.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-sql-date.cy.spec.js
@@ -63,12 +63,14 @@ describe("scenarios > dashboard > filters > SQL > date", () => {
   it(`should work when set as the default filter`, () => {
     setFilter("Time", "Month and Year");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Default value").next().click();
     DateFilter.setMonthAndYear({
       month: "October",
       year: "2017",
     });
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Select…").click();
     popover().contains("Month and Year").click();
     saveDashboard();
@@ -79,8 +81,10 @@ describe("scenarios > dashboard > filters > SQL > date", () => {
     });
 
     // Make sure we can override the default value
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("October, 2017").click();
     popover().contains("August").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Oda Brakus");
   });
 });

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-sql-id.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-sql-id.cy.spec.js
@@ -38,6 +38,7 @@ describe("scenarios > dashboard > filters > SQL > ID", () => {
     });
 
     it("when set as the default filter", () => {
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Default value").next().click();
       addWidgetStringFilter("15");
 
@@ -66,6 +67,7 @@ describe("scenarios > dashboard > filters > SQL > ID", () => {
     });
 
     it("when set as the default filter", () => {
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Default value").next().click();
       addWidgetStringFilter("4");
 

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-sql-location.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-sql-location.cy.spec.js
@@ -58,9 +58,11 @@ describe("scenarios > dashboard > filters > location", () => {
   it(`should work when set as the default filter`, () => {
     setFilter("Location", "Is");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Select…").click();
     popover().contains("Is").click();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Default value").next().click();
 
     addWidgetStringFilter("Rye");

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-sql-number.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-sql-number.cy.spec.js
@@ -60,10 +60,12 @@ describe("scenarios > dashboard > filters > SQL > text/category", () => {
 
   it(`should work when set as the default filter`, () => {
     setFilter("Number", "Equal to");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Default value").next().click();
 
     addWidgetNumberFilter("3.8");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Select…").click();
     popover().contains("Equal to").click();
 

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-sql-required-field-filter.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-sql-required-field-filter.cy.spec.js
@@ -95,6 +95,7 @@ describe("scenarios > dashboard > filters > SQL > field filter > required ", () 
 
     // Let's make sure the default dashboard filter is respected upon a subsequent visit from the root
     cy.visit("/collection/root");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Required Filters Dashboard").click();
 
     cy.location("search").should("eq", "?category=Widget");

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-sql-required-simple-filter.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-sql-required-simple-filter.cy.spec.js
@@ -79,6 +79,7 @@ describe("scenarios > dashboard > filters > SQL > simple filter > required ", ()
     cy.location("search").should("eq", "?text=");
 
     // SQL question defaults
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Foo");
 
     // The empty filter widget
@@ -89,10 +90,12 @@ describe("scenarios > dashboard > filters > SQL > simple filter > required ", ()
     // This part confirms that the issue metabase#13960 has been fixed
     cy.location("search").should("eq", "?text=");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Foo");
 
     // Let's make sure the default dashboard filter is respected upon a subsequent visit from the root
     cy.visit("/collection/root");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Required Filters Dashboard").click();
 
     cy.location("search").should("eq", "?text=Bar");

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-sql-text-category.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-sql-text-category.cy.spec.js
@@ -60,9 +60,11 @@ describe("scenarios > dashboard > filters > SQL > text/category", () => {
   it(`should work when set as the default filter and when that filter is removed (metabase#20493)`, () => {
     setFilter("Text or Category", "Is");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Select…").click();
     popover().contains("Is").click();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Default value").next().click();
 
     applyFilterByType("Is", "Gizmo");
@@ -81,6 +83,7 @@ describe("scenarios > dashboard > filters > SQL > text/category", () => {
 
     applyFilterByType("Is", "Doohickey");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Rustic Paper Wallet").should("not.exist");
   });
 });

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-text-category.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-text-category.cy.spec.js
@@ -50,15 +50,18 @@ describe("scenarios > dashboard > filters > text/category", () => {
   it(`should work when set as the default filter which (if cleared) should not be preserved on reload (metabase#13960)`, () => {
     setFilter("Text or Category", "Is");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Select…").click();
     popover().contains("Source").click();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Default value").next().click();
 
     applyFilterByType("Is", "Organic");
 
     // We need to add another filter only to reproduce metabase#13960
     setFilter("ID");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Select…").click();
     popover().contains("User ID").click();
 

--- a/e2e/test/scenarios/dashboard-filters/old-parameters.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/old-parameters.cy.spec.js
@@ -63,6 +63,7 @@ describe("scenarios > dashboard > OLD parameters", () => {
     it("should work", () => {
       cy.findAllByText("Doohickey");
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("Category").click();
       popover().within(() => {
         cy.findByText("Gadget").click();
@@ -70,6 +71,7 @@ describe("scenarios > dashboard > OLD parameters", () => {
       });
 
       // verify that the filter is applied
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Doohickey").should("not.exist");
     });
   });
@@ -120,6 +122,7 @@ describe("scenarios > dashboard > OLD parameters", () => {
     });
 
     it("should work", () => {
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("City").click();
       popover().within(() => {
         cy.get("input").type("Flagstaff{enter}");
@@ -191,6 +194,7 @@ describe("scenarios > dashboard > OLD parameters", () => {
     it("should work", () => {
       cy.findAllByText("Doohickey");
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("Category").click();
       popover().within(() => {
         cy.findByText("Gadget").click();
@@ -198,6 +202,7 @@ describe("scenarios > dashboard > OLD parameters", () => {
       });
 
       // verify that the filter is applied
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Doohickey").should("not.exist");
     });
   });

--- a/e2e/test/scenarios/dashboard-filters/parameters.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/parameters.cy.spec.js
@@ -53,8 +53,11 @@ describe("scenarios > dashboard > parameters", () => {
 
     // add a category filter
     cy.icon("filter").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Text or Category").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Is").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("A single value").click();
 
     // connect it to people.name and product.category
@@ -63,10 +66,12 @@ describe("scenarios > dashboard > parameters", () => {
     selectDashboardFilter(getDashboardCard(1), "Category");
 
     // finish editing filter and save dashboard
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Save").click();
 
     // wait for saving to finish
     cy.wait("@dashboard");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("You're editing this dashboard.").should("not.exist");
 
     // confirm that typing searches both fields
@@ -173,41 +178,51 @@ describe("scenarios > dashboard > parameters", () => {
       },
     );
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(startsWith.name).click();
     cy.findByPlaceholderText("Enter some text").type("G");
     // Make sure the dropdown list with values is not populated,
     // because it makes no sense for non-exact parameter string operators.
     // See: https://github.com/metabase/metabase/pull/15477
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Gizmo").should("not.exist");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Gadget").should("not.exist");
 
     cy.button("Add filter").click();
 
     const startsWithSlug = `${startsWith.slug}=G`;
     cy.location("search").should("eq", `?${startsWithSlug}`);
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("37.65").should("not.exist");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(endsWith.name).click();
     cy.findByPlaceholderText("Enter some text").type("zmo");
     // Make sure the dropdown list with values is not populated,
     // because it makes no sense for non-exact parameter string operators.
     // See: https://github.com/metabase/metabase/pull/15477
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Gizmo").should("not.exist");
 
     cy.button("Add filter").click();
 
     const endsWithSlug = `${endsWith.slug}=zmo`;
     cy.location("search").should("eq", `?${startsWithSlug}&${endsWithSlug}`);
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("52.72").should("not.exist");
 
     // Remove filter (metabase#17933)
     cy.icon("pencil").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(startsWith.name).find(".Icon-gear").click();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Remove").click();
     cy.location("search").should("eq", `?${endsWithSlug}`);
 
     // Remove filter name (metabase#10829)
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(endsWith.name).find(".Icon-gear").click();
     cy.findByDisplayValue(endsWith.name).clear().blur();
 
@@ -222,6 +237,7 @@ describe("scenarios > dashboard > parameters", () => {
     cy.log("URL should reset");
     cy.location("search").should("eq", "");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("37.65");
   });
 
@@ -434,6 +450,7 @@ describe("scenarios > dashboard > parameters", () => {
     cy.get("@fetchAllCategories").should("have.been.calledOnce");
 
     cy.button("Update filter").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("2 selections").click();
 
     // Even after we reopen the dropdown, it shouldn't send additional requests for values (metabase#16103)
@@ -446,6 +463,7 @@ describe("scenarios > dashboard > parameters", () => {
     });
 
     cy.button("Update filter").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("2 selections").should("not.exist");
     filterWidget().contains("Widget");
 
@@ -453,6 +471,7 @@ describe("scenarios > dashboard > parameters", () => {
     // Do not limit number of results (metabase#15695)
     // Prior to the issue being fixed, the cap was 100 results
     cy.findByPlaceholderText("Search the list").type("Syner");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Synergistic Wool Coat");
 
     cy.location("search").should(
@@ -463,7 +482,9 @@ describe("scenarios > dashboard > parameters", () => {
 
     // It should not reset previously defined filters when exiting 'edit' mode without making any changes (metabase#5332, metabase#17139)
     editDashboard();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Cancel").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("You're editing this dashboard.").should("not.exist");
 
     cy.location("search").should(
@@ -484,7 +505,9 @@ describe("scenarios > dashboard > parameters", () => {
 
       selectDashboardFilter(getDashboardCard(), "User ID");
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Save").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("You're editing this dashboard.").should("not.exist");
 
       cy.signIn("nodata");
@@ -535,26 +558,32 @@ describe("scenarios > dashboard > parameters", () => {
     );
 
     editDashboard();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(parameter1Details.name).click();
     selectDashboardFilter(getDashboardCard(), "Category");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(parameter2Details.name).click();
     selectDashboardFilter(getDashboardCard(), "Vendor");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Linked filters").click();
     sidebar().findByRole("switch").click();
     saveDashboard();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(parameter2Details.name).click();
     popover().within(() => {
       cy.findByText("Barrows-Johns").should("exist");
       cy.findByText("Balistreri-Ankunding").should("exist");
     });
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(parameter1Details.name).click();
     popover().within(() => {
       cy.findByText("Gadget").click();
       cy.button("Add filter").click();
     });
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(parameter2Details.name).click();
     popover().within(() => {
       cy.findByText("Barrows-Johns").should("exist");

--- a/e2e/test/scenarios/dashboard-filters/reproductions/12985-dropdown-search.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/reproductions/12985-dropdown-search.cy.spec.js
@@ -80,6 +80,7 @@ describe("issue 12985 > dashboard filter dropdown/search", () => {
     cy.button("Add filter").click();
 
     cy.location("search").should("eq", "?category=Gadget");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Ergonomic Silk Coat");
   });
 
@@ -133,8 +134,10 @@ describe("issue 12985 > dashboard filter dropdown/search", () => {
     filterWidget().contains("Category").click();
     // It will fail at this point until the issue is fixed because popover never appears
     popover().contains("Gadget").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Add filter").click();
     cy.url().should("contain", "?category=Gadget");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Ergonomic Silk Coat");
   });
 });

--- a/e2e/test/scenarios/dashboard-filters/reproductions/16112-nodata-should-use-dashboard-filters.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/reproductions/16112-nodata-should-use-dashboard-filters.cy.spec.js
@@ -91,6 +91,7 @@ describe("issues 15119 and 16112", () => {
       },
     );
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(reviewerFilter.name).click();
     popover().contains("adam").click();
     cy.button("Add filter").click();
@@ -98,6 +99,7 @@ describe("issues 15119 and 16112", () => {
     cy.get(".DashCard").should("contain", "adam");
     cy.location("search").should("eq", "?reviewer=adam");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(ratingFilter.name).click();
 
     popover().contains("5").click();

--- a/e2e/test/scenarios/dashboard-filters/reproductions/17211-false-no-matching-filter-alert.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/reproductions/17211-false-no-matching-filter-alert.cy.spec.js
@@ -69,8 +69,10 @@ describe("issue 17211", () => {
     filterWidget().click();
 
     cy.findByPlaceholderText("Search by City").type("abb");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Abbeville").click();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("No matching City found").should("not.exist");
   });
 });

--- a/e2e/test/scenarios/dashboard-filters/reproductions/17551-include-today-in-all-time-next-filter.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/reproductions/17551-include-today-in-all-time-next-filter.cy.spec.js
@@ -65,7 +65,9 @@ describe("issue 17551", () => {
 
     cy.url().should("include", "?date_filter=next30days~");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("tomorrow");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("today");
   });
 });

--- a/e2e/test/scenarios/dashboard-filters/reproductions/17775-filter-custom-column-date.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/reproductions/17775-filter-custom-column-date.cy.spec.js
@@ -53,6 +53,7 @@ describe.skip("issue 17775", () => {
     // Make sure filter can be connected to the custom column using UI, rather than using API.
     cy.get("main header").find(".Icon-gear").click();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Column to filter on")
       .parent()
       .within(() => {
@@ -71,6 +72,7 @@ describe.skip("issue 17775", () => {
 
     setQuarterAndYear({ quarter: "Q1", year: "2019" });
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("37.65");
 
     cy.findAllByText("February 11, 2019, 9:40 PM").should("have.length", 2);

--- a/e2e/test/scenarios/dashboard-filters/reproductions/19494-wrong-default-value-multiple-cards-same-question.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/reproductions/19494-wrong-default-value-multiple-cards-same-question.cy.spec.js
@@ -71,9 +71,11 @@ describe("issue 19494", () => {
     saveDashboard();
 
     checkAppliedFilter("Card 1 Filter", "Doohickey");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("148.23");
 
     checkAppliedFilter("Card 2 Filter", "Gizmo");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("110.93");
   });
 });

--- a/e2e/test/scenarios/dashboard-filters/reproductions/20656-dashboard-breaks-for-user-without-card-permissions.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/reproductions/20656-dashboard-breaks-for-user-without-card-permissions.cy.spec.js
@@ -63,6 +63,7 @@ describe("issue 20656", () => {
 
     // Make sure the filter widget is there
     filterWidget();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Sorry, you don't have permission to see this card.");
 
     // Trying to edit the filter should not show mapping fields and shouldn't break frontend (metabase#24536)
@@ -72,6 +73,7 @@ describe("issue 20656", () => {
       .find(".Icon-gear")
       .click();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Column to filter on")
       .parent()
       .within(() => {

--- a/e2e/test/scenarios/dashboard-filters/reproductions/22482-round-relative-ranges.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/reproductions/22482-round-relative-ranges.cy.spec.js
@@ -19,18 +19,21 @@ describe("issue 22482", () => {
     editDashboard();
     setFilter("Time", "All Options");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Select…").click();
     popover().contains("Created At").eq(0).click();
 
     saveDashboard();
 
     filterWidget().click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Relative dates...").click();
   });
 
   it("should round relative date range (metabase#22482)", () => {
     cy.findByTestId("relative-datetime-value").clear().type(15);
     cy.findByTestId("relative-datetime-unit").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("months").click();
 
     const expectedRange = getFormattedRange(
@@ -38,6 +41,7 @@ describe("issue 22482", () => {
       moment().add(-1, "month").endOf("month"),
     );
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(expectedRange);
   });
 });

--- a/e2e/test/scenarios/dashboard-filters/reproductions/22788-flter-cc-dropped-on-second-edit.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/reproductions/22788-flter-cc-dropped-on-second-edit.cy.spec.js
@@ -75,6 +75,7 @@ describe("issue 22788", () => {
     openFilterSettings();
 
     // Make sure the filter is still connected to the custom column
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Column to filter on")
       .parent()
       .within(() => {
@@ -83,8 +84,8 @@ describe("issue 22788", () => {
 
     // need to actually change the dashboard to test a real save
     sidebar().within(() => {
-      cy.findByDisplayValue("Text").clear().type('my filter text');
-      cy.button('Done').click();
+      cy.findByDisplayValue("Text").clear().type("my filter text");
+      cy.button("Done").click();
     });
 
     saveDashboard();

--- a/e2e/test/scenarios/dashboard-filters/reproductions/24235-exlude-all-date-options.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/reproductions/24235-exlude-all-date-options.cy.spec.js
@@ -37,6 +37,7 @@ describe("issue 24235", () => {
       },
     );
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(parameter.name).click();
 
     popover().within(() => {
@@ -48,6 +49,7 @@ describe("issue 24235", () => {
     });
 
     cy.wait("@getCardQuery");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Rows 1-13 of 200").should("be.visible");
   });
 });

--- a/e2e/test/scenarios/dashboard-filters/reproductions/24500-gracefully-deal-with-corrupted-filter.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/reproductions/24500-gracefully-deal-with-corrupted-filter.cy.spec.js
@@ -110,12 +110,14 @@ describe.skip("issues 15279 and 24500", () => {
 
     // The corrupted filter is now present in the UI, but it doesn't work (as expected)
     // People can now easily remove it
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Select…");
 
     editDashboard();
     filterWidget().last().find(".Icon-gear").click();
     // Uncomment the next line if we end up disabling fields for the corrupted filter
     // cy.findByText("No valid fields")
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Remove").click();
     saveDashboard();
 

--- a/e2e/test/scenarios/dashboard-filters/reproductions/25322-loading-list-values.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/reproductions/25322-loading-list-values.cy.spec.js
@@ -38,6 +38,7 @@ describe("issue 25322", () => {
       throttleFieldValuesRequest(dashboard_id);
     });
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(parameterDetails.name).click();
     popover().findByTestId("loading-spinner").should("exist");
   });

--- a/e2e/test/scenarios/dashboard-filters/reproductions/25355-multi-series-parameter-mapping.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/reproductions/25355-multi-series-parameter-mapping.cy.spec.js
@@ -59,11 +59,14 @@ describe("issue 25248", () => {
     createDashboard();
     editDashboard();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(parameterDetails.name).click();
     cy.findAllByText("Select…").first().click();
     popover().findAllByText("Created At").first().click();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Order.Created At").should("be.visible");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Select…").should("be.visible");
   });
 });

--- a/e2e/test/scenarios/dashboard-filters/reproductions/25374-comma-separated-values-not-passed-to-question.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/reproductions/25374-comma-separated-values-not-passed-to-question.cy.spec.js
@@ -86,6 +86,7 @@ describe("issue 25374", () => {
 
   it("should pass comma-separated values down to the connected question (metabase#25374-1)", () => {
     // Drill-through and go to the question
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(questionDetails.name).click();
     cy.wait("@cardQuery");
 

--- a/e2e/test/scenarios/dashboard-filters/reproductions/25908-contains-filter-case-sensitivity.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/reproductions/25908-contains-filter-case-sensitivity.cy.spec.js
@@ -69,10 +69,13 @@ describe("issue 25908", () => {
   });
 
   it("`contains` dashboard filter should respect case insensitivity on a title-drill-through (metabase#25908)", () => {
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(questionDetails.name).click();
     cy.wait("@dataset");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Title contains Li");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(`Showing ${CASE_INSENSITIVE_ROWS} rows`);
   });
 });

--- a/e2e/test/scenarios/dashboard-filters/reproductions/27356-navigation-between-two-dashboards.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/reproductions/27356-navigation-between-two-dashboards.cy.spec.js
@@ -40,13 +40,19 @@ describe("issue 27356", () => {
   it("should seamlessly move between dashboards with or without filters without triggering an error (metabase#27356)", () => {
     openNavigationSidebar();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(paramDashboard.name).click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("This dashboard is looking empty.");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(regularDashboard.name).click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("This dashboard is looking empty.");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(paramDashboard.name).click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("This dashboard is looking empty.");
   });
 });

--- a/e2e/test/scenarios/dashboard-filters/reproductions/27768-cc-filter-appears-disconnected.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/reproductions/27768-cc-filter-appears-disconnected.cy.spec.js
@@ -49,6 +49,7 @@ describe.skip("issue 27768", () => {
     editDashboard();
     getFilterOptions(filter.name);
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Select…").click();
     popover().contains("CCategory").click();
     saveDashboard();
@@ -63,7 +64,9 @@ describe.skip("issue 27768", () => {
     editDashboard();
     getFilterOptions(filter.name);
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Select…").should("not.exist");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Column to filter on").parent().contains("Product.CCategory");
   });
 });

--- a/e2e/test/scenarios/dashboard/actions-on-dashboards.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/actions-on-dashboards.cy.spec.js
@@ -78,7 +78,10 @@ const MODEL_NAME = "Test Action Model";
           });
 
           cy.findByRole("tab", { name: "Actions" }).click();
-          cy.findByText("New action").click();
+
+          cy.findByTestId("model-actions-header")
+            .findByText("New action")
+            .click();
 
           cy.findByRole("dialog").within(() => {
             fillActionQuery(
@@ -97,7 +100,7 @@ const MODEL_NAME = "Test Action Model";
           });
 
           cy.findByPlaceholderText("My new fantastic action").type(ACTION_NAME);
-          cy.findByText("Create").click();
+          cy.findByTestId("create-action-form").button("Create").click();
 
           createDashboardWithActionButton({
             actionName: ACTION_NAME,

--- a/e2e/test/scenarios/dashboard/chained-filters.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/chained-filters.cy.spec.js
@@ -30,6 +30,7 @@ describe("scenarios > dashboard > chained filter", () => {
       });
 
       // connect that to people.state
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Column to filter on")
         .parent()
         .within(() => {
@@ -40,7 +41,9 @@ describe("scenarios > dashboard > chained filter", () => {
       });
 
       // open the linked filters tab, and click the click to add a City filter
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Linked filters").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("add another dashboard filter").click();
       popover().within(() => {
         cy.findByText("Location").click();
@@ -48,6 +51,7 @@ describe("scenarios > dashboard > chained filter", () => {
       });
 
       // connect that to person.city
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Column to filter on")
         .parent()
         .within(() => {
@@ -58,6 +62,7 @@ describe("scenarios > dashboard > chained filter", () => {
       });
 
       // Link city to state
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Limit this filter's choices")
         .parent()
         .within(() => {
@@ -76,16 +81,20 @@ describe("scenarios > dashboard > chained filter", () => {
           cy.findByText("Filtered column");
         });
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Save").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("You're editing this dashboard.").should("not.exist");
 
       // now test that it worked!
       // Select Alaska as a state. We should see Anchorage as a option but not Anacoco
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Location").click();
       popover().within(() => {
         cy.findByText("AK").click();
         cy.findByText("Add filter").click();
       });
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Location 1").click();
       popover().within(() => {
         cy.findByPlaceholderText(
@@ -97,6 +106,7 @@ describe("scenarios > dashboard > chained filter", () => {
         cy.get("input").first().clear();
       });
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("AK").click();
       popover().within(() => {
         cy.findByText("AK").click();
@@ -106,6 +116,7 @@ describe("scenarios > dashboard > chained filter", () => {
       });
 
       // do it again to make sure it isn't cached incorrectly
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Location 1").click();
       popover().within(() => {
         cy.get("input").first().type("An");
@@ -113,6 +124,7 @@ describe("scenarios > dashboard > chained filter", () => {
         cy.findByText("Anchorage").should("not.exist");
       });
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("GA").click();
       popover().within(() => {
         cy.findByText("GA").click();
@@ -120,6 +132,7 @@ describe("scenarios > dashboard > chained filter", () => {
       });
 
       // do it again without a state filter to make sure it isn't cached incorrectly
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Location 1").click();
       popover().within(() => {
         cy.get("input").first().type("An");

--- a/e2e/test/scenarios/dashboard/click-behavior.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/click-behavior.cy.spec.js
@@ -43,7 +43,9 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
     // Drill-through
     cy.findAllByTestId("cell-data").get(".link").contains("0").realClick();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("117.03").should("not.exist"); // Total for the order in which quantity wasn't 0
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Quantity is equal to 0");
 
     const getVisualizationSettings = targetId => ({
@@ -115,9 +117,11 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
     cy.findAllByTestId("cell-data").contains("5").first().click();
 
     // Make sure filter is set
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Rating is equal to 5");
 
     // Make sure it's connected to the original question
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Started from 16334");
 
     // Make sure the original visualization didn't change
@@ -166,6 +170,7 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
 
     cy.findByTestId("gauge-arc-1").click();
     cy.wait("@dataset");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Orders");
   });
 
@@ -184,6 +189,7 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
 
     cy.findByTestId("progress-bar").click();
     cy.wait("@dataset");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Orders");
   });
 });

--- a/e2e/test/scenarios/dashboard/dashboard-drill.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard-drill.cy.spec.js
@@ -980,27 +980,31 @@ describe("scenarios > dashboard > dashboard drill", () => {
 
     visitDashboard(1);
     cy.wait("@dashboard");
-    cy.findByText("Orders").click();
+    cy.findByTestId("dashcard").findByText("Orders").click();
     cy.wait("@cardQuery");
     cy.findByLabelText(buttonLabel).should("be.visible");
     cy.icon("notebook").click();
     summarize({ mode: "notebook" });
-    cy.findByText("Count of rows").click();
+    popover().findByText("Count of rows").click();
     cy.findByLabelText(buttonLabel).should("be.visible");
     visualize();
     cy.findByLabelText(buttonLabel).click();
     cy.wait("@dashboard");
-    cy.findByText(dashboardName).should("be.visible");
+    cy.findByTestId("dashboard-header")
+      .findByText(dashboardName)
+      .should("be.visible");
 
     getDashboardCard().realHover();
     getDashboardCardMenu().click();
     popover().findByText("Edit question").click();
     cy.findByLabelText(buttonLabel).click();
     cy.wait("@dashboard");
-    cy.findByText(dashboardName).should("be.visible");
+    cy.findByTestId("dashboard-header")
+      .findByText(dashboardName)
+      .should("be.visible");
 
     appBar().findByText("Our analytics").click();
-    cy.findByText("Orders").click();
+    cy.findByTestId("collection-table").findByText("Orders").click();
     cy.findByLabelText(buttonLabel).should("not.exist");
   });
 });

--- a/e2e/test/scenarios/dashboard/dashboard-drill.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard-drill.cy.spec.js
@@ -41,11 +41,15 @@ describe("scenarios > dashboard > dashboard drill", () => {
     });
 
     // configure a URL click through on the  "MY_NUMBER" column
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("On-click behavior for each column")
       .parent()
       .parent()
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       .within(() => cy.findByText("MY_NUMBER").click());
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Go to a custom destination").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("URL").click();
 
     // set the url and text template
@@ -59,11 +63,13 @@ describe("scenarios > dashboard > dashboard drill", () => {
       cy.findByText("Done").click();
     });
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Save").click();
 
     setParamValue("My Param", "param-value");
 
     // click value and confirm url updates
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("column value: 111").click();
     cy.location("pathname").should("eq", "/foo/111/param-value");
   });
@@ -114,6 +120,7 @@ describe("scenarios > dashboard > dashboard drill", () => {
       },
     );
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Click to find out which state does Rye belong to.").click();
 
     cy.log("Reported failing on v0.37.2");
@@ -163,16 +170,25 @@ describe("scenarios > dashboard > dashboard drill", () => {
     });
 
     // configure a dashboard target for the "MY_NUMBER" column
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("On-click behavior for each column")
       .parent()
       .parent()
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       .within(() => cy.findByText("MY_NUMBER").click());
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Go to a custom destination").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Saved question").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Orders").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Orders → User ID").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     popover().within(() => cy.findByText("MY_NUMBER").click());
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Products → Category").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     popover().within(() => cy.findByText("My Param").click());
 
     // set the text template
@@ -180,19 +196,25 @@ describe("scenarios > dashboard > dashboard drill", () => {
       "num: {{my_number}}",
       { parseSpecialCharSequences: false },
     );
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Save").click();
 
     // wait to leave editing mode and set a param value
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("You're editing this dashboard.").should("not.exist");
     setParamValue("My Param", "Widget");
 
     // click on table value
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("num: 111").click();
 
     // show filtered question
     cy.findAllByText("Orders");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("User ID is 111");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Category is Widget");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Showing 5 rows");
   });
 
@@ -217,18 +239,27 @@ describe("scenarios > dashboard > dashboard drill", () => {
     });
 
     // configure clicks on "MY_NUMBER to update the param
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("On-click behavior for each column")
       .parent()
       .parent()
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       .within(() => cy.findByText("MY_NUMBER").click());
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Go to a custom destination").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Link to")
       .parent()
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       .within(() => cy.findByText("Dashboard").click());
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     modal().within(() => cy.findByText("end dash").click());
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Available filters")
       .parent()
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       .within(() => cy.findByText("My Param").click());
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     popover().within(() => cy.findByText("MY_STRING").click());
 
     // set the text template
@@ -236,13 +267,16 @@ describe("scenarios > dashboard > dashboard drill", () => {
       "text: {{my_string}}",
       { parseSpecialCharSequences: false },
     );
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Save").click();
 
     // click on table value
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("text: foo").click();
 
     // check that param was set to "foo"
     cy.location("search").should("eq", "?my_param=foo");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("My Param")
       .parent()
       .within(() => {
@@ -258,11 +292,15 @@ describe("scenarios > dashboard > dashboard drill", () => {
       cy.icon("click").click();
     });
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("On-click behavior for each column")
       .parent()
       .parent()
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       .within(() => cy.findByText("MY_NUMBER").click());
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Go to a custom destination").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("URL").click();
 
     modal().within(() => {
@@ -271,8 +309,10 @@ describe("scenarios > dashboard > dashboard drill", () => {
       cy.findByText("Done").click();
     });
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Save").click();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Click behavior").click();
 
     cy.location("pathname").should("eq", "/dashboard/2");
@@ -289,24 +329,34 @@ describe("scenarios > dashboard > dashboard drill", () => {
     });
 
     // configure clicks on "MY_NUMBER to update the param
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("On-click behavior for each column")
       .parent()
       .parent()
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       .within(() => cy.findByText("MY_NUMBER").click());
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Update a dashboard filter").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Pick one or more filters to update")
       .parent()
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       .within(() => cy.findByText("My Param").click());
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     popover().within(() => cy.findByText("MY_STRING").click());
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Save").click();
 
     // click on table value
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("111").click();
 
     // check that param was set to "foo"
     cy.location("search").should("eq", "?my_param=foo");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("My Param")
       .parent()
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       .within(() => cy.findByText("foo"));
   });
 
@@ -367,17 +417,25 @@ describe("scenarios > dashboard > dashboard drill", () => {
     });
 
     it("when clicking on the field value (metabase#13062-1)", () => {
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("xavier").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("=").click();
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Reviewer is xavier");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Rating is 2 selections");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("Reprehenderit non error"); // xavier's review
     });
 
     it("when clicking on the card title (metabase#13062-2)", () => {
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(questionDetails.name).click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Rating is 2 selections");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("Ad perspiciatis quis et consectetur."); // 5 star review
     });
   });
@@ -492,7 +550,9 @@ describe("scenarios > dashboard > dashboard drill", () => {
 
     visitDashboard(1);
     // Product ID in the first row (query fails for User ID as well)
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("105").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("View details").click();
 
     cy.log("Reported on v0.29.3");
@@ -616,6 +676,7 @@ describe("scenarios > dashboard > dashboard drill", () => {
     });
 
     // formatting works, so we see "USD" in the table
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("USD 111.00").click();
     cy.location("pathname").should("eq", "/it/worked");
   });
@@ -866,9 +927,13 @@ describe("scenarios > dashboard > dashboard drill", () => {
 
       drillThroughCardTitle("Orders");
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("37.65");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("110.93");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("52.72").should("not.exist");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Showing 2 rows");
 
       postDrillAssertion();
@@ -879,8 +944,10 @@ describe("scenarios > dashboard > dashboard drill", () => {
 
       drillThroughCardTitle("Orders");
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("37.65").should("not.exist");
       cy.findAllByText("105.12");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Showing 191 rows");
 
       postDrillAssertion();

--- a/e2e/test/scenarios/dashboard/dashboard-management.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard-management.cy.spec.js
@@ -68,6 +68,7 @@ describe("managing dashboard from the dashboard's edit menu", () => {
             it("should be able to duplicate a dashboard", () => {
               cy.intercept("POST", "/api/dashboard/1/copy").as("copyDashboard");
 
+              // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
               cy.findByText("Duplicate").click();
               cy.location("pathname").should("eq", "/dashboard/1/copy");
               cy.get(".Modal").within(() => {
@@ -79,6 +80,7 @@ describe("managing dashboard from the dashboard's edit menu", () => {
                 "eq",
                 "/dashboard/2-orders-in-a-dashboard-duplicate",
               );
+              // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
               cy.findByText(`Orders in a dashboard - Duplicate`);
             });
 
@@ -96,12 +98,15 @@ describe("managing dashboard from the dashboard's edit menu", () => {
               });
 
               assertOnRequest("updateDashboard");
+              // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
               cy.contains("37.65");
               // it should update dashboard's collection after the move without the page reload (metabase#13059)
               appBar().contains("First collection");
 
               // Why do we use "Dashboard moved to" here (without its location, btw) vs. "Moved dashboard" for the same action?
+              // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
               cy.findByText("Dashboard moved to");
+              // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
               cy.findByText("Undo").click();
               assertOnRequest("updateDashboard");
 
@@ -113,12 +118,16 @@ describe("managing dashboard from the dashboard's edit menu", () => {
                 cy.findByText("Archive").click();
               });
               cy.location("pathname").should("eq", "/dashboard/1/archive");
+              // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
               cy.findByText("Archive this dashboard?"); //Without this, there is some race condition and the button click fails
               clickButton("Archive");
               assertOnRequest("updateDashboard");
               cy.location("pathname").should("eq", "/collection/root");
+              // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
               cy.findByText("Orders in a dashboard").should("not.exist");
+              // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
               cy.findByText("Archived dashboard");
+              // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
               cy.findByText("Undo").click();
               assertOnRequest("updateDashboard");
             });

--- a/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
@@ -33,17 +33,23 @@ describe("scenarios > dashboard", () => {
 
   it("should create new dashboard and navigate to it from the nav bar and from the root collection (metabase#20638)", () => {
     cy.visit("/");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("New").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Dashboard").click();
 
     createDashboardUsingUI("Dash A", "Desc A");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("This dashboard is looking empty.");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("You're editing this dashboard.");
 
     // See it as a listed dashboard
     cy.visit("/collection/root?type=dashboard");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("This dashboard is looking empty.").should("not.exist");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Dash A");
 
     cy.log(
@@ -54,7 +60,9 @@ describe("scenarios > dashboard", () => {
 
     createDashboardUsingUI("Dash B", "Desc B");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("This dashboard is looking empty.");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("You're editing this dashboard.");
   });
 
@@ -94,6 +102,7 @@ describe("scenarios > dashboard", () => {
     cy.get("main header").within(() => {
       cy.icon("info").click();
     });
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("How many orders were placed in each year?").click();
     cy.findByDisplayValue("How many orders were placed in each year?");
   });
@@ -104,6 +113,7 @@ describe("scenarios > dashboard", () => {
     visitDashboard(1);
 
     cy.icon("pencil").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("You're editing this dashboard.");
 
     cy.findByTestId("dashboard-name-heading")
@@ -119,6 +129,7 @@ describe("scenarios > dashboard", () => {
     visitDashboard(1);
 
     cy.icon("pencil").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("You're editing this dashboard.");
 
     cy.findByTestId("dashboard-name-heading")
@@ -126,8 +137,10 @@ describe("scenarios > dashboard", () => {
       .type("{selectall}Orders per year")
       .blur();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("You're editing this dashboard.");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Cancel").click();
     cy.findByDisplayValue("Orders in a dashboard");
   });
@@ -154,8 +167,11 @@ describe("scenarios > dashboard", () => {
     cy.icon("filter").click();
     // Adding location/state doesn't make much sense for this case,
     // but we're testing just that the filter is added to the dashboard
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Location").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Is").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Select…").click();
 
     popover().within(() => {
@@ -168,6 +184,7 @@ describe("scenarios > dashboard", () => {
 
     cy.log("Assert that the selected filter is present in the dashboard");
     cy.icon("location");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Location");
   });
 
@@ -175,9 +192,11 @@ describe("scenarios > dashboard", () => {
     visitDashboard(1);
     cy.icon("pencil").click();
     cy.get(".QueryBuilder-section .Icon-add").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Orders, Count").click();
     saveDashboard();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Orders, Count");
   });
 
@@ -208,11 +227,14 @@ describe("scenarios > dashboard", () => {
 
     cy.visit("/collection/root");
     // enter newly created dashboard
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("dash:11007").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("This dashboard is looking empty.");
     // add previously created question to it
     cy.icon("pencil").click();
     cy.icon("add").last().click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("11007").click();
 
     // add first filter
@@ -241,7 +263,9 @@ describe("scenarios > dashboard", () => {
     // and connect it to the card
     selectDashboardFilter(cy.get(".DashCard"), "Category");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Save").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("You're editing this dashboard.").should("not.exist");
   });
 
@@ -347,7 +371,9 @@ describe("scenarios > dashboard", () => {
     cy.findByTestId("dashboardcard-actions-panel").within(() => {
       cy.icon("click").click();
     });
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("COUNT(*)").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Update a dashboard filter").click();
 
     checkOptionsForFilter("ID");
@@ -469,7 +495,9 @@ describe("scenarios > dashboard", () => {
     visitDashboard(1);
 
     cy.wait("@loadDashboard");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Orders in a dashboard");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("37.65");
   });
 
@@ -492,6 +520,7 @@ describe("scenarios > dashboard", () => {
     });
 
     visitDashboard(1);
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("37.65");
     assertScrollBarExists();
     cy.icon("share").click();
@@ -527,8 +556,10 @@ describe("scenarios > dashboard", () => {
 
     cy.visit("/collection/root");
     // enter newly created dashboard
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("dash:29450").click();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Add a saved question").click();
 
     sidebar().within(() => {
@@ -540,8 +571,10 @@ describe("scenarios > dashboard", () => {
 
   it("should show collection breadcrumbs for a dashboard", () => {
     visitDashboard(1);
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     appBar().within(() => cy.findByText("Our analytics").click());
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Orders").should("be.visible");
   });
 
@@ -551,10 +584,13 @@ describe("scenarios > dashboard", () => {
     cy.icon("pencil").click();
     cy.findByTestId("dashcard").realHover();
     cy.icon("close").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Orders").should("not.exist");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Undo").click();
     saveDashboard();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Orders").should("be.visible");
   });
 

--- a/e2e/test/scenarios/dashboard/dashboard_data_permissions.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard_data_permissions.cy.spec.js
@@ -47,8 +47,11 @@ describe("support > permissions (metabase#8472)", () => {
     // Filter the first card by User Address
     selectDashboardFilter(cy.get(".DashCard").first(), "Address");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Done").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Save").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Orders in a dashboard").click();
   });
 

--- a/e2e/test/scenarios/dashboard/duplicate.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/duplicate.cy.spec.js
@@ -13,14 +13,18 @@ describe("scenarios > dashboard > duplicate", () => {
       cy.icon("ellipsis").click();
     });
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Duplicate").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText('Duplicate "Orders in a dashboard" and its questions');
 
     cy.findByRole("checkbox").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText('Duplicate "Orders in a dashboard"');
 
     cy.button("Duplicate").click();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Orders in a dashboard - Duplicate");
   });
 
@@ -31,20 +35,25 @@ describe("scenarios > dashboard > duplicate", () => {
       cy.icon("ellipsis").click();
     });
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Duplicate").click();
 
     // Change destination collection
     cy.findByTestId("select-button").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("My personal collection").click();
 
     cy.button("Duplicate").click();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Orders in a dashboard - Duplicate");
 
     // Duplicated dashboard and question should live in personal collection
     visitCollection(1);
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Orders");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Orders in a dashboard - Duplicate");
   });
 });

--- a/e2e/test/scenarios/dashboard/permissions.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/permissions.cy.spec.js
@@ -82,23 +82,31 @@ describe("scenarios > dashboard > permissions", () => {
   it("should let admins view all cards in a dashboard", () => {
     visitDashboard(dashboardId);
     // Admin can see both questions
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("First Question");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("foo");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Second Question");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("bar");
   });
 
   it("should display dashboards with some cards locked down", () => {
     cy.signIn("nodata");
     visitDashboard(dashboardId);
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Sorry, you don't have permission to see this card.");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Second Question");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("bar");
   });
 
   it("should display an error if they don't have perms for the dashboard", () => {
     cy.signIn("nocollection");
     visitDashboard(dashboardId);
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Sorry, you don’t have permission to see that.");
   });
 });

--- a/e2e/test/scenarios/dashboard/reproductions/17160-click-behavior-multiple-options.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/reproductions/17160-click-behavior-multiple-options.cy.spec.js
@@ -45,6 +45,7 @@ describe("issue 17160", () => {
 
     cy.url().should("include", "/dashboard");
     cy.location("search").should("eq", "?category=Doohickey&category=Gadget");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(TARGET_DASHBOARD_NAME);
 
     assertMultipleValuesFilterState();
@@ -71,6 +72,7 @@ describe("issue 17160", () => {
     cy.url().should("include", "/public/dashboard");
     cy.location("search").should("eq", "?category=Doohickey&category=Gadget");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(TARGET_DASHBOARD_NAME);
 
     assertMultipleValuesFilterState();

--- a/e2e/test/scenarios/dashboard/reproductions/18454-card-description.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/reproductions/18454-card-description.cy.spec.js
@@ -34,6 +34,7 @@ describe("issue 18454", () => {
     cy.get(".DashCard").within(() => {
       cy.icon("info").trigger("mouseenter", { force: true });
     });
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(CARD_DESCRIPTION);
   });
 });

--- a/e2e/test/scenarios/dashboard/reproductions/20637-add-series-to-dashcard.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/reproductions/20637-add-series-to-dashcard.cy.spec.js
@@ -19,6 +19,7 @@ describe("adding an additional series to a dashcard (metabase#20637)", () => {
     // the button is made clickable by css using :hover so we need to force it
     cy.findByTestId("add-series-button").click({ force: true });
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("20637 Question 2").click();
     // make sure the card query endpoint was used
     cy.wait("@additionalSeriesCardQuery");

--- a/e2e/test/scenarios/dashboard/reproductions/26826-dashboard-alien-card.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/reproductions/26826-dashboard-alien-card.cy.spec.js
@@ -20,6 +20,7 @@ describe("issue 26826", () => {
 
     openRecentItemFromSearch("Orders in a dashboard");
     cy.get(".Card").should("have.length", 1);
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("You're editing this dashboard.").should("not.exist");
   });
 });

--- a/e2e/test/scenarios/dashboard/reproductions/29076-dashboard-card-drill-sandbox.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/reproductions/29076-dashboard-card-drill-sandbox.cy.spec.js
@@ -23,8 +23,10 @@ describeEE("issue 29076", () => {
     visitDashboard(1);
     cy.wait("@cardQuery");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Orders").click();
     cy.wait("@cardQuery");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Visualization").should("be.visible");
   });
 });

--- a/e2e/test/scenarios/dashboard/text-box.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/text-box.cy.spec.js
@@ -35,22 +35,30 @@ describe("scenarios > dashboard > text-box", () => {
       // edit mode
       cy.icon("palette").eq(1).click();
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Vertical Alignment");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Horizontal Alignment");
     });
 
     it("should not render edit and preview actions when not editing", () => {
       // Exit edit mode and check for edit options
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Save").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("You are editing a dashboard").should("not.exist");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("Text text text");
       cy.icon("edit_document").should("not.exist");
       cy.icon("eye").should("not.exist");
     });
 
     it("should switch between rendered markdown and textarea input", () => {
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Text *text* __text__");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Save").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("Text text text");
     });
   });
@@ -66,25 +74,33 @@ describe("scenarios > dashboard > text-box", () => {
 
     // fixed in metabase#11358
     it("should load after save/refresh (metabase#12873)", () => {
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Test Dashboard");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("This dashboard is looking empty.");
 
       // Add save text box to dash
       addTextBox("Dashboard testing text");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Save").click();
 
       // Reload page
       cy.reload();
 
       // Page should still load
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("New");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Loading...").should("not.exist");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Cannot read property 'type' of undefined").should(
         "not.exist",
       );
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Test Dashboard");
 
       // Text box should still load
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Dashboard testing text");
     });
 
@@ -92,6 +108,7 @@ describe("scenarios > dashboard > text-box", () => {
       addTextBox(
         "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam ut fermentum erat, nec sagittis justo. Vivamus vitae ipsum semper, consectetur odio at, rutrum nisi. Fusce maximus consequat porta. Mauris libero mi, viverra ac hendrerit quis, rhoncus quis ante. Pellentesque molestie ut felis non congue. Vivamus finibus ligula id fringilla rutrum. Donec quis dignissim ligula, vitae tempor urna.\n\nDonec quis enim porta, porta lacus vel, maximus lacus. Sed iaculis leo tortor, vel tempor velit tempus vitae. Nulla facilisi. Vivamus quis sagittis magna. Aenean eu eros augue. Sed euismod pulvinar laoreet. Morbi commodo, sem sed dictum faucibus, sem ante ultrices libero, nec ornare risus lacus eget velit. Etiam sagittis lectus non erat tristique tempor. Sed in ipsum urna. Sed venenatis turpis at orci feugiat, ut gravida lectus luctus.",
       );
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Save").click();
 
       cy.wait("@dashboardUpdated");
@@ -108,7 +125,9 @@ describe("scenarios > dashboard > text-box", () => {
         "- Visit https://www.metabase.com{enter}- Or go to [Metabase](https://www.metabase.com)",
       );
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Save").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("You're editing this dashboard.").should("not.exist");
 
       cy.get(".Card")
@@ -130,10 +149,13 @@ describe("scenarios > dashboard > text-box", () => {
       cy.findByText("Text or Category").click();
       cy.findByText("Is").click();
     });
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Save").click();
 
     // confirm text box and filter are still there
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("text text text");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Text");
   });
 });

--- a/e2e/test/scenarios/dashboard/text-parameters.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/text-parameters.cy.spec.js
@@ -27,6 +27,7 @@ describe("scenarios > dashboard > parameters in text cards", () => {
     });
     editDashboard();
     setFilter("Number", "Equal to");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(
       "You can connect widgets to {{variables}} in text cards.",
     ).should("exist");
@@ -38,24 +39,31 @@ describe("scenarios > dashboard > parameters in text cards", () => {
     editDashboard();
     setFilter("Number", "Equal to");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Select…").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("foo").click();
     saveDashboard();
 
     filterWidget().click();
     cy.findByPlaceholderText("Enter a number").type(`1{enter}`);
     cy.button("Add filter").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Variable: 1").should("exist");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("1").click();
     popover().within(() => {
       cy.findByRole("textbox").click().type("2{enter}");
       cy.button("Update filter").click();
     });
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Variable: 1 and 2").should("exist");
 
     editDashboard();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Equal to").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("foo").should("exist");
   });
 
@@ -72,7 +80,9 @@ describe("scenarios > dashboard > parameters in text cards", () => {
     editDashboard();
     setFilter("Time", "Relative Date");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Select…").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("foo").click();
     saveDashboard();
 
@@ -81,11 +91,13 @@ describe("scenarios > dashboard > parameters in text cards", () => {
       cy.findByText("Today").click();
     });
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Variable: Aujourd'hui").should("exist");
 
     // Let's make sure the localization was reset back to the user locale by checking that specific text exists in
     // English on the homepage.
     cy.visit("/");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Pick up where you left off").should("exist");
   });
 

--- a/e2e/test/scenarios/dashboard/title-drill.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/title-drill.cy.spec.js
@@ -34,15 +34,20 @@ describe("scenarios > dashboard > title drill", () => {
     describe("as a user with access to underlying data", () => {
       it("should let you click through the title to the query builder (metabase#13042)", () => {
         // wait for qustion to load
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("foo");
 
         // drill through title
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("Q1").click();
 
         // check that we're in the QB now
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("This question is written in SQL.");
 
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("foo");
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("bar");
       });
     });
@@ -55,15 +60,20 @@ describe("scenarios > dashboard > title drill", () => {
 
       it("should let you click through the title to the query builder (metabase#13042)", () => {
         // wait for qustion to load
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("foo");
 
         // drill through title
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("Q1").click();
 
         // check that we're in the QB now
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("This question is written in SQL.");
 
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("foo");
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("bar");
       });
     });
@@ -137,6 +147,7 @@ describe("scenarios > dashboard > title drill", () => {
       it("'contains' filter should still work after title drill through IF the native question field filter's type matches exactly (metabase#16181)", () => {
         checkScalarResult("200");
 
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("Text contains").click();
         cy.findByPlaceholderText("Enter some text").type("bb").blur();
         cy.button("Add filter").click();
@@ -145,6 +156,7 @@ describe("scenarios > dashboard > title drill", () => {
         checkScalarResult("12");
 
         // Drill through on the quesiton's title
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("16181").click();
 
         checkFilterLabelAndValue("Filter", "bb");
@@ -161,6 +173,7 @@ describe("scenarios > dashboard > title drill", () => {
       it("'contains' filter should still work after title drill through IF the native question field filter's type matches exactly (metabase#16181)", () => {
         checkScalarResult("200");
 
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("Text contains").click();
         cy.findByPlaceholderText("Enter some text").type("bb").blur();
         cy.button("Add filter").click();
@@ -169,6 +182,7 @@ describe("scenarios > dashboard > title drill", () => {
         checkScalarResult("12");
 
         // Drill through on the quesiton's title
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("16181").click();
 
         checkFilterLabelAndValue("Filter", "bb");
@@ -242,15 +256,19 @@ describe("scenarios > dashboard > title drill", () => {
         cy.wait("@cardQuery");
 
         // make sure query results are correct
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("42");
 
         // drill through title
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("GUI Question").click();
 
         // make sure the query builder filter is present
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("Category is Doohickey");
 
         // make sure the results match
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("42");
       });
     });
@@ -265,12 +283,15 @@ describe("scenarios > dashboard > title drill", () => {
         cy.wait("@cardQuery");
 
         // make sure query results are correct
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("42");
 
         // drill through title
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("GUI Question").click();
 
         // make sure the results match
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("42");
 
         // update the parameter filter to a new value
@@ -285,12 +306,14 @@ describe("scenarios > dashboard > title drill", () => {
         cy.wait("@cardQuery");
 
         // make sure the results reflect the new filter
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("53");
 
         // make sure the set parameter filter persists after a page refresh
         cy.reload();
         cy.wait("@cardQuery");
 
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("53");
 
         // make sure the unset id parameter works
@@ -304,6 +327,7 @@ describe("scenarios > dashboard > title drill", () => {
         cy.get(".RunButton").first().click();
         cy.wait("@cardQuery");
 
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("1");
       });
     });

--- a/e2e/test/scenarios/dashboard/x-rays.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/x-rays.cy.spec.js
@@ -26,12 +26,17 @@ describe("scenarios > x-rays", () => {
 
     cy.visit("/");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(
       "Try out these sample x-rays to see what Metabase can do.",
     ).should("not.exist");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(/^A summary of/).should("not.exist");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(/^A glance at/).should("not.exist");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(/^A look at/).should("not.exist");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(/^Some insights about/).should("not.exist");
   });
 
@@ -71,10 +76,12 @@ describe("scenarios > x-rays", () => {
     cy.get(".dot")
       .eq(23) // Random dot
       .click({ force: true });
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("X-ray").click();
 
     // x-rays take long time even locally - that can timeout in CI so we have to extend it
     cy.wait("@dataset", { timeout: 30000 });
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(
       "A closer look at number of Orders where Created At is in March 2018 and Category is Gadget",
     );
@@ -91,7 +98,9 @@ describe("scenarios > x-rays", () => {
       });
 
       startNewQuestion();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Saved Questions").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("15655").click();
       visualize();
       summarize();
@@ -101,6 +110,7 @@ describe("scenarios > x-rays", () => {
 
       cy.button("Done").click();
       cy.get(".bar").first().click({ force: true });
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(action).click();
 
       cy.wait("@xray").then(xhr => {
@@ -134,8 +144,10 @@ describe("scenarios > x-rays", () => {
       });
 
       cy.get(".bar").first().click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(action).click();
       cy.wait("@xray");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("null").should("not.exist");
     });
   });
@@ -149,12 +161,15 @@ describe("scenarios > x-rays", () => {
 
     cy.button("Save this").click();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Your dashboard was saved");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("See it").click();
 
     cy.url().should("contain", "a-look-at-your-orders-table");
 
     cy.get(".Card").contains("18,760");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("How these transactions are distributed");
   });
 
@@ -166,16 +181,20 @@ describe("scenarios > x-rays", () => {
     cy.wait("@geojson", { timeout });
 
     // confirm results of "Total transactions" card are present
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("18,760", timeout);
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Total transactions").click();
 
     // confirm we're in the query builder with the same results
     cy.url().should("contain", "/question");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("18,760");
 
     cy.go("back");
 
     // add a parameter filter to the auto dashboard
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("State", timeout).click();
 
     cy.findByPlaceholderText("Search the list").type("GA{enter}");
@@ -183,11 +202,15 @@ describe("scenarios > x-rays", () => {
     cy.button("Add filter").click();
 
     // confirm results of "Total transactions" card were updated
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("463", timeout);
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Total transactions").click();
 
     // confirm parameter filter is applied as filter in query builder
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("State is GA");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("463");
   });
 });

--- a/e2e/test/scenarios/downloads/downloads.cy.spec.js
+++ b/e2e/test/scenarios/downloads/downloads.cy.spec.js
@@ -48,10 +48,13 @@ describe("scenarios > question > download", () => {
   testCases.forEach(fileType => {
     it(`downloads ${fileType} file`, () => {
       startNewQuestion();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Saved Questions").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Orders, Count").click();
 
       visualize();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("18,760");
 
       downloadAndAssert({ fileType }, sheet => {
@@ -88,6 +91,7 @@ describe("scenarios > question > download", () => {
 
       popover().find("input").type("1");
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Add filter").click();
 
       cy.wait("@dashboard");
@@ -109,6 +113,7 @@ describe("scenarios > question > download", () => {
         visitDashboard(dashboard.id);
       });
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Q1").realHover();
       getDashboardCardMenu(0).click();
 
@@ -117,6 +122,7 @@ describe("scenarios > question > download", () => {
         cy.findByText(".png").click();
       });
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Q2").realHover();
       getDashboardCardMenu(1).click();
 
@@ -165,6 +171,7 @@ describe("scenarios > dashboard > download pdf", () => {
 
     cy.findByLabelText("dashboard-menu-button").click();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Export as PDF").click();
 
     cy.verifyDownload("saving pdf dashboard.pdf", { contains: true });

--- a/e2e/test/scenarios/downloads/reproductions/10803-timestamp-formatting.cy.spec.js
+++ b/e2e/test/scenarios/downloads/reproductions/10803-timestamp-formatting.cy.spec.js
@@ -37,6 +37,7 @@ describe("issue 10803", () => {
 
     it(`should format the date properly for ${fileType} in unsaved questions`, () => {
       // Add a space at the end of the query to make it "dirty"
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains(/open editor/i).click();
       cy.get(".ace_editor").type("{movetoend} ");
 

--- a/e2e/test/scenarios/downloads/reproductions/18440-remapped-display-value-dropped.cy.spec.js
+++ b/e2e/test/scenarios/downloads/reproductions/18440-remapped-display-value-dropped.cy.spec.js
@@ -41,7 +41,9 @@ describe("issue 18440", () => {
     it(`export should include a column with remapped values for ${fileType} (metabase#18440-1)`, () => {
       visitQuestionAdhoc(questionDetails);
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Product ID");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Awesome Concrete Shoes");
 
       downloadAndAssert({ fileType }, assertion);

--- a/e2e/test/scenarios/downloads/reproductions/18573-remapped-fields-not-renamed.cy.spec.js
+++ b/e2e/test/scenarios/downloads/reproductions/18573-remapped-fields-not-renamed.cy.spec.js
@@ -40,7 +40,9 @@ describe("issue 18573", () => {
   it(`for the remapped columns, it should preserve renamed column name in exports for xlsx (metabase#18573)`, () => {
     visitQuestionAdhoc(questionDetails);
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Foo");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Awesome Concrete Shoes");
 
     downloadAndAssert({ fileType: "xlsx" }, assertion);

--- a/e2e/test/scenarios/downloads/reproductions/19889-native-query-export-column-order.cy.spec.js
+++ b/e2e/test/scenarios/downloads/reproductions/19889-native-query-export-column-order.cy.spec.js
@@ -22,11 +22,13 @@ describe("issue 19889", () => {
     });
 
     // Reorder columns a and b
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("column a")
       .trigger("mousedown", 0, 0, { force: true })
       .trigger("mousemove", 5, 5, { force: true })
       .trigger("mousemove", 100, 0, { force: true })
       .trigger("mouseup", 100, 0, { force: true });
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Started from").click(); // Give DOM some time to update
   });
 
@@ -52,6 +54,7 @@ describe("issue 19889", () => {
     });
 
     it(`should order columns correctly in saved native query exports when the query was modified but not re-run before save (#19889)`, () => {
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains(/open editor/i).click();
       cy.get(".ace_editor").type(
         '{selectall}select 1 "column x", 2 "column y", 3 "column c"',

--- a/e2e/test/scenarios/embedding/embedding-dashboard.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-dashboard.cy.spec.js
@@ -48,6 +48,7 @@ describe("scenarios > embedding > dashboard parameters", () => {
       });
 
       cy.icon("share").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Embed in your application").click();
 
       cy.findByRole("heading", { name: "Parameters" })
@@ -65,6 +66,7 @@ describe("scenarios > embedding > dashboard parameters", () => {
             });
         });
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Editable").click();
 
       cy.get("@allParameters").within(() => {
@@ -75,9 +77,11 @@ describe("scenarios > embedding > dashboard parameters", () => {
           });
       });
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Locked").click();
 
       // set the locked parameter's value
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Preview Locked Parameters")
         .parent()
         .within(() => {
@@ -111,13 +115,16 @@ describe("scenarios > embedding > dashboard parameters", () => {
       cy.get(".ScalarValue").invoke("text").should("eq", "2");
 
       // verify that disabled filters don't show up
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Source").should("not.exist");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("User").should("not.exist");
 
       // only Name parameter should be visible
       openFilterOptions("Name");
 
       cy.findByPlaceholderText("Search by Name").type("L");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Lina Heaney").click();
 
       cy.button("Add filter").click();
@@ -134,11 +141,14 @@ describe("scenarios > embedding > dashboard parameters", () => {
       });
 
       cy.icon("share").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Embed in your application").click();
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Locked").click();
       popover().contains("Disabled").click();
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Editable").click();
       popover().contains("Disabled").click();
 
@@ -220,6 +230,7 @@ describe("scenarios > embedding > dashboard parameters", () => {
       cy.log("should accept url parameters");
 
       cy.url().then(url => cy.visit(url + "?id=1&id=3"));
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains(".ScalarValue", "2");
     });
   });

--- a/e2e/test/scenarios/embedding/embedding-full-app.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-full-app.cy.spec.js
@@ -70,6 +70,7 @@ describe("scenarios > embedding > full app", () => {
       appBar().within(() => {
         cy.findByTestId("main-logo").should("be.visible");
       });
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Our analytics").should("not.exist");
     });
 
@@ -94,7 +95,9 @@ describe("scenarios > embedding > full app", () => {
         cy.findByPlaceholderText("Search…").should("be.visible");
       });
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Our analytics").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Orders in a dashboard").should("be.visible");
 
       appBar().within(() => {
@@ -106,7 +109,9 @@ describe("scenarios > embedding > full app", () => {
   describe("browse data", () => {
     it("should hide the top nav when nothing is shown", () => {
       visitUrl({ url: "/browse", qs: { side_nav: false, logo: false } });
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Our data").should("be.visible");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Our analytics").should("not.exist");
       appBar().should("not.exist");
     });
@@ -118,11 +123,13 @@ describe("scenarios > embedding > full app", () => {
 
       cy.findByTestId("qb-header").should("be.visible");
       cy.findByTestId("qb-header-left-side").realHover();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(/Edited/).should("be.visible");
 
       cy.icon("refresh").should("be.visible");
       cy.icon("notebook").should("be.visible");
       cy.button("Summarize").should("be.visible");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Filter").should("be.visible");
     });
 
@@ -135,7 +142,9 @@ describe("scenarios > embedding > full app", () => {
     it("should hide the question's additional info by a param", () => {
       visitQuestionUrl({ url: "/question/1", qs: { additional_info: false } });
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Our analytics").should("be.visible");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(/Edited/).should("not.exist");
     });
 
@@ -160,6 +169,7 @@ describe("scenarios > embedding > full app", () => {
           qs: { top_nav: true, new_button: true, side_nav: false },
         });
 
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("New").click();
         popover().findByText("Question").click();
         popover().findByText("Sample Database").click();
@@ -183,6 +193,7 @@ describe("scenarios > embedding > full app", () => {
           qs: { side_nav: false },
         });
 
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("Sample Database").should("be.visible");
       });
     });
@@ -224,13 +235,16 @@ describe("scenarios > embedding > full app", () => {
     it("should show the dashboard header by default", () => {
       visitDashboardUrl({ url: "/dashboard/1" });
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Orders in a dashboard").should("be.visible");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(/Edited/).should("be.visible");
     });
 
     it("should hide the dashboard header by a param", () => {
       visitDashboardUrl({ url: "/dashboard/1", qs: { header: false } });
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Orders in a dashboard").should("not.exist");
     });
 
@@ -240,8 +254,11 @@ describe("scenarios > embedding > full app", () => {
         qs: { additional_info: false },
       });
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Orders in a dashboard").should("be.visible");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(/Edited/).should("not.exist");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Our analytics").should("be.visible");
     });
 
@@ -271,6 +288,7 @@ describe("scenarios > embedding > full app", () => {
     it("should show the dashboard header by default", () => {
       visitXrayDashboardUrl({ url: "/auto/dashboard/table/1" });
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("More X-rays").should("be.visible");
       cy.button("Save this").should("be.visible");
     });
@@ -281,6 +299,7 @@ describe("scenarios > embedding > full app", () => {
         qs: { header: false },
       });
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("More X-rays").should("be.visible");
       cy.button("Save this").should("not.exist");
     });

--- a/e2e/test/scenarios/embedding/embedding-native.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-native.cy.spec.js
@@ -30,8 +30,11 @@ describe("scenarios > embedding > native questions", () => {
 
       visitIframe();
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("Lora Cronin");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("Organic");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("39.58");
 
       filterWidget().should("not.exist");
@@ -45,6 +48,7 @@ describe("scenarios > embedding > native questions", () => {
       setParameter("Product ID", "Editable");
 
       // We must enter a value for a locked parameter
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Preview Locked Parameters")
         .parent()
         .within(() => {
@@ -71,13 +75,16 @@ describe("scenarios > embedding > native questions", () => {
 
       visitIframe();
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("Organic");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("Twitter").should("not.exist");
 
       // Created At: Q2, 2018
       filterWidget().contains("Created At").click();
       cy.findByTestId("select-button").click();
       popover().contains("2018").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Q2").click();
 
       // State: is not KS
@@ -87,14 +94,17 @@ describe("scenarios > embedding > native questions", () => {
       cy.findByTestId("KS-filter-value").should("be.visible").click();
       cy.button("Add filter").click();
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Logan Weber").should("not.exist");
 
       // Product ID is 10
       cy.findByPlaceholderText("Product ID").type("10{enter}");
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("Affiliate").should("not.exist");
 
       // Let's try to remove one filter
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Q2, 2018")
         .closest("fieldset")
         .within(() => {
@@ -108,8 +118,11 @@ describe("scenarios > embedding > native questions", () => {
 
       cy.findByTestId("table-row").should("have.length", 1);
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("December 29, 2018, 4:54 AM");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("CO");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Sid Mills").should("not.exist");
 
       cy.location("search").should("eq", "?id=926&state=KS&product_id=10");

--- a/e2e/test/scenarios/embedding/embedding-premium-token.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-premium-token.cy.spec.js
@@ -31,8 +31,10 @@ describe(
       );
 
       cy.visit(embeddingPage);
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Full-app embedding").click();
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains(
         "With some of our paid plans, you can embed the full Metabase app and enable your users to drill-through to charts, browse collections, and use the graphical query builder. You can also get priority support, more tools to help you share your insights with your teams and powerful options to help you create seamless, interactive data experiences for your customers.",
       );
@@ -43,8 +45,10 @@ describe(
 
       cy.findByRole("heading").invoke("text").should("eq", "Premium embedding");
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(discountedWarning);
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(
         "Enter the token you bought from the Metabase Store below.",
       );
@@ -62,6 +66,7 @@ describe(
         );
       });
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(invalidTokenMessage);
 
       // 2. Try a valid format, but an invalid token
@@ -73,6 +78,7 @@ describe(
         expect(body["error-details"]).to.be.null;
       });
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(invalidTokenMessage);
 
       // 3. Try submitting an empty value
@@ -84,6 +90,7 @@ describe(
         expect(body).to.eq("");
       });
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(invalidTokenMessage).should("not.exist");
     });
 
@@ -100,6 +107,7 @@ describe(
       });
 
       cy.wait("@getSettings");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(
         /Your Premium Embedding license is active until Dec 3(0|1), 2122\./,
       );

--- a/e2e/test/scenarios/embedding/embedding-questions.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-questions.cy.spec.js
@@ -42,31 +42,40 @@ describe("scenarios > embedding > questions ", () => {
     });
 
     cy.icon("share").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Embed in your application").click();
 
     visitIframe();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(title);
 
     cy.icon("info").realHover();
     popover().contains(description);
 
     // Data model: Renamed column
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Product ID as Title");
     // Data model: Display value changed to show FK
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Awesome Concrete Shoes");
     // Custom column
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Math");
     // Question settings: Renamed column
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Billed");
     // Question settings: Column formating
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("€39.72");
     // Question settings: Abbreviated date, day enabled, 24H clock with seconds
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Mon, Feb 11, 2019, 21:40:27");
     // Question settings: Show mini-bar
     cy.findAllByTestId("mini-bar");
 
     // Data model: Subtotal is turned off globally
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Subtotal").should("not.exist");
   });
 
@@ -78,6 +87,7 @@ describe("scenarios > embedding > questions ", () => {
     });
 
     cy.icon("share").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Embed in your application").click();
 
     visitIframe();
@@ -114,25 +124,33 @@ describe("scenarios > embedding > questions ", () => {
     });
 
     cy.icon("share").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Embed in your application").click();
 
     visitIframe();
 
     // Global (Data model) settings should be preserved
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Product ID as Title");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Awesome Concrete Shoes");
 
     // Custom column
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Math");
 
     // Base question visualization settings should reset to the defaults (inherit global formatting)
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Total");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("39.72");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("February 11, 2019, 9:40 PM");
 
     cy.findAllByTestId("mini-bar").should("not.exist");
 
     // Data model: Subtotal is turned off globally
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Subtotal").should("not.exist");
   });
 
@@ -144,26 +162,38 @@ describe("scenarios > embedding > questions ", () => {
     });
 
     cy.icon("share").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Embed in your application").click();
 
     visitIframe();
 
     // Base question assertions
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Product ID as Title");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Awesome Concrete Shoes");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Math");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Billed");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("€39.72");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Mon, Feb 11, 2019, 21:40:27");
     cy.findAllByTestId("mini-bar");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Subtotal").should("not.exist");
 
     // Joined table fields
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("98.52598640° W");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("User → Birth Date");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("December 12, 1986");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("October 7, 2017, 1:34 AM");
   });
 
@@ -174,6 +204,7 @@ describe("scenarios > embedding > questions ", () => {
     visitQuestion(CARD_ID);
 
     cy.icon("share").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Embed in your application").click();
 
     visitIframe();
@@ -187,6 +218,7 @@ describe("scenarios > embedding > questions ", () => {
       });
     });
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Februar 11, 2019, 9:40 PM");
   });
 });

--- a/e2e/test/scenarios/embedding/embedding-smoketests.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-smoketests.cy.spec.js
@@ -40,11 +40,14 @@ describe("scenarios > embedding > smoke tests", () => {
       cy.location("pathname").should("eq", embeddingPage);
 
       // Some info we provide to users before they enable embedding
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("More details");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("By enabling embedding you're agreeing to");
 
       assertLinkMatchesUrl("our embedding license.", licenseUrl);
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("More details").click();
       licenseExplanations.forEach(licenseExplanation => {
         cy.findByText(licenseExplanation);
@@ -55,12 +58,15 @@ describe("scenarios > embedding > smoke tests", () => {
       // Let's examine the contents of the enabled embedding page (the url stays the same)
       cy.location("pathname").should("eq", embeddingPage);
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains(
         "Allow questions, dashboards, and more to be embedded. Learn more.",
       );
       assertLinkMatchesUrl("Learn more.", learnEmbeddingUrl);
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Enabled");
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Standalone embeds").click();
       if (isOSS) {
         cy.contains(
@@ -70,7 +76,9 @@ describe("scenarios > embedding > smoke tests", () => {
         assertLinkMatchesUrl("one of our paid plans.", upgradeUrl);
       }
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(/Embedding secret key/i);
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(
         "Standalone Embed Secret Key used to sign JSON Web Tokens for requests to /api/embed endpoints. This lets you create a secure environment limited to specific users or organizations.",
       );
@@ -80,10 +88,14 @@ describe("scenarios > embedding > smoke tests", () => {
       cy.button("Regenerate key");
 
       // List of all embedded dashboards and questions
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(/Embedded dashboards/i);
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("No dashboards have been embedded yet.");
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(/Embedded questions/i);
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("No questions have been embedded yet.");
 
       // Full app embedding section (available only for EE version and in PRO hosted plans)
@@ -141,11 +153,14 @@ describe("scenarios > embedding > smoke tests", () => {
           cy.findByText("Font").should("not.exist");
         }
 
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("Parameters");
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText(
           /This (question|dashboard) doesn't have any parameters to configure yet./,
         );
 
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText(
           /You will need to publish this (question|dashboard) before you can embed it in another application./,
         );
@@ -155,7 +170,9 @@ describe("scenarios > embedding > smoke tests", () => {
 
         visitIframe();
 
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.contains(objectName);
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.contains("37.65");
 
         if (isOSS) {
@@ -170,11 +187,13 @@ describe("scenarios > embedding > smoke tests", () => {
         cy.signInAsAdmin();
 
         cy.visit(embeddingPage);
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("Standalone embeds").click();
         cy.wait("@currentlyEmbeddedObject");
 
         const sectionName = new RegExp(`Embedded ${object}s`, "i");
 
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.contains(sectionName)
           .closest("li")
           .find("tbody tr")
@@ -183,7 +202,9 @@ describe("scenarios > embedding > smoke tests", () => {
 
         visitAndEnableSharing(object);
 
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("Danger zone");
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText(
           /This will disable embedding for this (question|dashboard)./,
         );
@@ -192,14 +213,17 @@ describe("scenarios > embedding > smoke tests", () => {
         cy.wait("@embedObject");
 
         visitIframe();
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("Embedding is not enabled for this object.");
 
         cy.signInAsAdmin();
 
         cy.visit(embeddingPage);
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("Standalone embeds").click();
         cy.wait("@currentlyEmbeddedObject");
 
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.contains(/No (questions|dashboards) have been embedded yet./);
       });
     });

--- a/e2e/test/scenarios/embedding/embedding-snippets.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-snippets.cy.spec.js
@@ -17,10 +17,14 @@ describe("scenarios > embedding > code snippets", () => {
   it("dashboard should have the correct embed snippet", () => {
     visitDashboard(1);
     cy.icon("share").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Embed in your application").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Code").click();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("To embed this dashboard in your application:");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(
       "Insert this code snippet in your server code to generate the signed embedding URL",
     );
@@ -31,6 +35,7 @@ describe("scenarios > embedding > code snippets", () => {
       .should("match", JS_CODE({ type: "dashboard" }));
 
     // set transparent background metabase#23477
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Transparent").click();
     cy.get(".ace_content")
       .first()
@@ -68,10 +73,14 @@ describe("scenarios > embedding > code snippets", () => {
   it("question should have the correct embed snippet", () => {
     visitQuestion(1);
     cy.icon("share").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Embed in your application").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Code").click();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("To embed this question in your application:");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(
       "Insert this code snippet in your server code to generate the signed embedding URL",
     );
@@ -82,6 +91,7 @@ describe("scenarios > embedding > code snippets", () => {
       .should("match", JS_CODE({ type: "question" }));
 
     // set transparent background metabase#23477
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Transparent").click();
     cy.get(".ace_content")
       .first()

--- a/e2e/test/scenarios/embedding/reproductions/15860-locked-filters-same-source-table.cy.spec.js
+++ b/e2e/test/scenarios/embedding/reproductions/15860-locked-filters-same-source-table.cy.spec.js
@@ -140,6 +140,7 @@ describe.skip("issue 15860", () => {
 
   it("should work for locked linked filters connected to different cards with the same source table (metabase#15860)", () => {
     cy.icon("share").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Embed in your application").click();
 
     setDefaultValueForLockedFilter("Q1 ID", 1);
@@ -147,6 +148,7 @@ describe.skip("issue 15860", () => {
 
     visitIframe();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Q1 Category").click();
 
     popover().within(() => {
@@ -155,6 +157,7 @@ describe.skip("issue 15860", () => {
         .and("contain", "Gizmo");
     });
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Q2 Category").click();
 
     popover().within(() => {

--- a/e2e/test/scenarios/embedding/reproductions/20438-dashboard-filter-single-value.cy.spec.js
+++ b/e2e/test/scenarios/embedding/reproductions/20438-dashboard-filter-single-value.cy.spec.js
@@ -84,6 +84,7 @@ describe("issue 20438", () => {
 
   it("dashboard filter connected to the field filter should work with a single value in embedded dashboards (metabase#20438)", () => {
     cy.icon("share").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Embed in your application").click();
 
     visitIframe();

--- a/e2e/test/scenarios/embedding/reproductions/20634-locked-parameters-in-embedded-question.cy.spec.js
+++ b/e2e/test/scenarios/embedding/reproductions/20634-locked-parameters-in-embedded-question.cy.spec.js
@@ -29,6 +29,7 @@ describe("locked parameters in embedded question (metabase#20634)", () => {
 
   it("should let the user lock parameters to specific values", () => {
     cy.icon("share").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Embed in your application").click();
 
     cy.get(".Modal--full").within(() => {
@@ -40,6 +41,7 @@ describe("locked parameters in embedded question (metabase#20634)", () => {
         });
     });
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Locked").click();
 
     cy.get(".Modal--full").within(() => {
@@ -55,6 +57,7 @@ describe("locked parameters in embedded question (metabase#20634)", () => {
     visitIframe();
 
     // verify that the Text parameter doesn't show up but that its value is reflected in the dashcard
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Text").should("not.exist");
     cy.get(".CardVisualization").within(() => {
       cy.contains("foo");

--- a/e2e/test/scenarios/embedding/reproductions/30535-session-sandboxing.cy.spec.js
+++ b/e2e/test/scenarios/embedding/reproductions/30535-session-sandboxing.cy.spec.js
@@ -32,6 +32,7 @@ describeEE("issue 30535", () => {
 
   it("user session should not apply sandboxing to a signed embedded question (metabase#30535)", () => {
     cy.icon("share").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Embed in your application").click();
 
     cy.document().then(doc => {

--- a/e2e/test/scenarios/filters/filter-bulk.cy.spec.js
+++ b/e2e/test/scenarios/filters/filter-bulk.cy.spec.js
@@ -105,7 +105,9 @@ describe("scenarios > filters > bulk filtering", () => {
 
     applyFilters();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Quantity is equal to 20").should("be.visible");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Showing 4 rows").should("be.visible");
   });
 
@@ -124,7 +126,9 @@ describe("scenarios > filters > bulk filtering", () => {
 
     applyFilters();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Count is greater than or equal to 500").should("be.visible");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Showing 21 rows").should("be.visible");
   });
 
@@ -140,7 +144,9 @@ describe("scenarios > filters > bulk filtering", () => {
 
     applyFilters();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Category is Gadget").should("be.visible");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Showing first 2,000 rows").should("be.visible");
   });
 
@@ -152,8 +158,11 @@ describe("scenarios > filters > bulk filtering", () => {
 
     applyFilters();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Quantity is greater than 20").should("be.visible");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Quantity is less than 25").should("be.visible");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Showing 17 rows").should("be.visible");
   });
 
@@ -165,8 +174,11 @@ describe("scenarios > filters > bulk filtering", () => {
 
     applyFilters();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Quantity is greater than 20").should("be.visible");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Quantity is less than 30").should("not.exist");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Showing 138 rows").should("be.visible");
   });
 
@@ -216,6 +228,7 @@ describe("scenarios > filters > bulk filtering", () => {
       applyFilters();
 
       cy.findByTestId("qb-filters-panel").findByText(SEGMENT_2_NAME);
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Showing 1,915 rows");
 
       filter();
@@ -233,6 +246,7 @@ describe("scenarios > filters > bulk filtering", () => {
       applyFilters();
 
       cy.findByTestId("qb-filters-panel").should("not.exist");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Showing first 2,000 rows");
     });
 
@@ -272,6 +286,7 @@ describe("scenarios > filters > bulk filtering", () => {
       });
       applyFilters();
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Showing 2 rows").should("be.visible");
     });
 
@@ -281,6 +296,7 @@ describe("scenarios > filters > bulk filtering", () => {
       });
       applyFilters();
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Showing 2 rows").should("be.visible");
 
       filter();
@@ -290,6 +306,7 @@ describe("scenarios > filters > bulk filtering", () => {
       });
       applyFilters();
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Showing 1 row").should("be.visible");
     });
 
@@ -299,6 +316,7 @@ describe("scenarios > filters > bulk filtering", () => {
       });
       applyFilters();
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Showing 2 rows").should("be.visible");
 
       filter();
@@ -308,6 +326,7 @@ describe("scenarios > filters > bulk filtering", () => {
       });
       applyFilters();
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Showing 4 rows").should("be.visible");
     });
   });
@@ -324,13 +343,16 @@ describe("scenarios > filters > bulk filtering", () => {
       });
       applyFilters();
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Created At Today").should("be.visible");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Showing 0 rows").should("be.visible");
     });
 
     it("can add a date shortcut filter from the popover", () => {
       filterField("Created At").findByLabelText("more options").click();
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Last 3 Months").click();
 
       modal().within(() => {
@@ -338,7 +360,9 @@ describe("scenarios > filters > bulk filtering", () => {
       });
       applyFilters();
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Created At Previous 3 Months").should("be.visible");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Showing 0 rows").should("be.visible");
     });
 
@@ -349,7 +373,9 @@ describe("scenarios > filters > bulk filtering", () => {
           cy.findByLabelText("more options").click();
         });
       });
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Specific dates...").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Before").click();
 
       popover().within(() => {
@@ -365,15 +391,18 @@ describe("scenarios > filters > bulk filtering", () => {
       });
       applyFilters();
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Created At is before January 1, 2017").should(
         "be.visible",
       );
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Showing 744 rows").should("be.visible");
     });
 
     it("Can cancel adding date filter", () => {
       filterField("Created At").findByLabelText("more options").click();
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Discount").click();
 
       filterField("Created At").within(() => {
@@ -395,7 +424,9 @@ describe("scenarios > filters > bulk filtering", () => {
       });
       applyFilters();
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Source is Affiliate").should("be.visible");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Showing 506 rows").should("be.visible");
     });
 
@@ -405,7 +436,9 @@ describe("scenarios > filters > bulk filtering", () => {
       });
       applyFilters();
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("State is AZ").should("be.visible");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Showing 20 rows").should("be.visible");
     });
   });
@@ -423,8 +456,11 @@ describe("scenarios > filters > bulk filtering", () => {
 
       applyFilters();
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Showing 2 rows").should("be.visible");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("131.68").should("be.visible"); // total for order id 17
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("123.99").should("be.visible"); // total for order id 18
     });
 
@@ -435,6 +471,7 @@ describe("scenarios > filters > bulk filtering", () => {
 
       applyFilters();
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Showing 107 rows").should("be.visible");
     });
   });
@@ -453,6 +490,7 @@ describe("scenarios > filters > bulk filtering", () => {
 
       applyFilters();
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Showing 5 rows").should("be.visible");
     });
 
@@ -464,6 +502,7 @@ describe("scenarios > filters > bulk filtering", () => {
 
       applyFilters();
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Showing 8 rows").should("be.visible");
     });
 
@@ -475,7 +514,9 @@ describe("scenarios > filters > bulk filtering", () => {
 
       applyFilters();
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("City is 2 selections").should("be.visible");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Showing 1 row").should("be.visible");
     });
   });
@@ -499,7 +540,9 @@ describe("scenarios > filters > bulk filtering", () => {
 
       applyFilters();
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Price between 50 80").should("be.visible");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Showing 72 rows").should("be.visible");
     });
 
@@ -511,7 +554,9 @@ describe("scenarios > filters > bulk filtering", () => {
 
       applyFilters();
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Price is greater than 50").should("be.visible");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Showing 106 rows").should("be.visible");
     });
 
@@ -523,7 +568,9 @@ describe("scenarios > filters > bulk filtering", () => {
 
       applyFilters();
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Price is less than or equal to 50").should("be.visible");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Showing 94 rows").should("be.visible");
     });
   });
@@ -569,7 +616,9 @@ describe("scenarios > filters > bulk filtering", () => {
 
       applyFilters();
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Price is greater than 90").should("be.visible");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Showing 10 rows").should("be.visible");
     });
   });

--- a/e2e/test/scenarios/filters/filter.cy.spec.js
+++ b/e2e/test/scenarios/filters/filter.cy.spec.js
@@ -33,7 +33,9 @@ describe("scenarios > question > filter", () => {
 
     openOrdersTable({ mode: "notebook" });
     // join with Products
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Join data").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Products").click();
     // add filter
     filter({ mode: "notebook" });
@@ -43,19 +45,28 @@ describe("scenarios > question > filter", () => {
       // also, we need to eliminate "Product ID" - that's why I used `$`
       cy.contains(/products?$/i).click({ force: true });
     });
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Category").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Is").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Is not").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Gizmo").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Add filter").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Category is not Gizmo");
 
     visualize();
 
     cy.log("The point of failure in 0.37.0-rc3");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("37.65");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("There was a problem with your question").should("not.exist");
     // this is not the point of this repro, but additionally make sure the filter is working as intended on "Gizmo"
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("3621077291879").should("not.exist"); // one of the "Gizmo" EANs
   });
 
@@ -99,6 +110,7 @@ describe("scenarios > question > filter", () => {
       { visitQuestion: true },
     );
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("12872");
     cy.log("At the moment of unfixed issue, it's showing '0'");
     cy.get(".ScalarValue").contains("1");
@@ -187,8 +199,10 @@ describe("scenarios > question > filter", () => {
     // Test shows two filter collapsed - click on number 2 to expand and show filter names
     cy.icon("filter").parent().contains("2").click();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(AGGREGATED_FILTER);
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(/^Created At is after/i)
       .parent()
       .find(".Icon-close")
@@ -197,21 +211,27 @@ describe("scenarios > question > filter", () => {
     cy.log(
       "**Removing or changing filters shouldn't remove aggregated filter**",
     );
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(AGGREGATED_FILTER);
   });
 
   it("should be able to add date filter with calendar collapsed (metabase#14327)", () => {
     openOrdersTable({ mode: "notebook" });
     filter({ mode: "notebook" });
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Created At").click({ force: true });
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Specific dates...").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Before").click();
     // Collapse the calendar view
     cy.icon("calendar").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Add filter")
       .closest(".Button")
       .should("not.be.disabled")
       .click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(/^Created At is before/i);
   });
 
@@ -236,8 +256,10 @@ describe("scenarios > question > filter", () => {
       display: "table",
     });
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(/Created At > Product? → Created At/i).click();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains(/\[Created At\] > \[Products? → Created At\]/);
   });
 
@@ -277,17 +299,21 @@ describe("scenarios > question > filter", () => {
     );
 
     cy.get(".cellData").contains("Widget");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Showing 1 row");
   });
 
   it("should reject Enter when the filter expression is invalid", () => {
     openReviewsTable({ mode: "notebook" });
     filter({ mode: "notebook" });
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Custom Expression").click();
 
     enterCustomColumnDetails({ formula: "[Rating] > 2E{enter}" }); // there should numbers after 'E'
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Missing exponent");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Rating is greater than 2").should("not.exist");
   });
 
@@ -310,6 +336,7 @@ describe("scenarios > question > filter", () => {
 
     enterCustomColumnDetails({ formula: "c" });
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("case")
       .closest("li")
       .should("have.css", "background-color")
@@ -317,11 +344,13 @@ describe("scenarios > question > filter", () => {
 
     cy.get("@formula").type("{downarrow}");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("case")
       .closest("li")
       .should("have.css", "background-color")
       .and("eq", transparent);
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("ceil")
       .closest("li")
       .should("have.css", "background-color")
@@ -353,7 +382,9 @@ describe("scenarios > question > filter", () => {
     }).then(({ body: { id: QUESTION_ID } }) => {
       cy.visit(`/question/${QUESTION_ID}/notebook`);
     });
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Filter").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Custom Expression").click();
     enterCustomColumnDetails({ formula: "su" });
     popover().contains(/Sum of Total/i);
@@ -364,6 +395,7 @@ describe("scenarios > question > filter", () => {
   it("should filter using IsNull() and IsEmpty()", () => {
     openReviewsTable({ mode: "notebook" });
     filter({ mode: "notebook" });
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Custom Expression").click();
 
     enterCustomColumnDetails({ formula: "NOT IsNull([Rating])" });
@@ -373,6 +405,7 @@ describe("scenarios > question > filter", () => {
 
     cy.get(".QueryBuilder .Icon-add").click();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Custom Expression").click();
 
     enterCustomColumnDetails({ formula: "NOT IsEmpty([Reviewer])" });
@@ -383,50 +416,73 @@ describe("scenarios > question > filter", () => {
     // check that filter is applied and rows displayed
     visualize();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Showing 1,112 rows");
   });
 
   it("should convert 'is empty' on a text column to a custom expression using IsEmpty()", () => {
     openReviewsTable();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Reviewer").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Filter by this column").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Is").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Is empty").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Add filter").click();
 
     // filter out everything
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Showing 0 rows");
 
     // change the corresponding custom expression
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Reviewer is empty").click();
     cy.get(".Icon-chevronleft").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Custom Expression").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("isempty([Reviewer])");
     cy.get(".ace_text-input").clear().type("NOT IsEmpty([Reviewer])");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Done").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Showing 1,112 rows");
   });
 
   it("should convert 'is empty' on a numeric column to a custom expression using IsNull()", () => {
     openReviewsTable();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Rating").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Filter by this column").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Equal to").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Is empty").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Add filter").click();
 
     // filter out everything
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Showing 0 rows");
 
     // change the corresponding custom expression
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Rating is empty").click();
     cy.get(".Icon-chevronleft").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Custom Expression").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("isnull([Rating])");
     cy.get(".ace_text-input")
       .clear()
       .type("NOT IsNull([Rating])", { delay: 50 });
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Done").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Showing 1,112 rows");
   });
 
@@ -448,9 +504,12 @@ describe("scenarios > question > filter", () => {
       display: "table",
     });
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Title does not contain Wallet").click();
     cy.get(".Icon-chevronleft").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Custom Expression").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains('doesNotContain([Title], "Wallet", "case-insensitive")');
   });
 
@@ -472,8 +531,10 @@ describe("scenarios > question > filter", () => {
       display: "table",
     });
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Title does not contain Wallet").click();
     cy.get(".Icon-chevronleft").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Custom Expression").click();
     // Before we implement this feature, we can only assert that the input field for custom expression doesn't show at all
     cy.get(".ace_text-input");
@@ -484,6 +545,7 @@ describe("scenarios > question > filter", () => {
 
     // Via the GUI, create a filter with "include-current" option
     filter({ mode: "notebook" });
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Created At").click({ force: true });
     popover().within(() => {
       cy.contains("Relative dates...").click();
@@ -492,10 +554,12 @@ describe("scenarios > question > filter", () => {
     });
     popover()
       .last()
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       .within(() => cy.findByText(/^Include/).click());
     cy.button("Add filter").click();
 
     // Switch to custom expression
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Created At Previous 30 Days").click();
 
     popover().within(() => {
@@ -506,6 +570,7 @@ describe("scenarios > question > filter", () => {
     cy.button("Done").click();
 
     // Back to GUI and "Include today" should be still checked
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Created At Previous 30 Days").click();
     popover().within(() => {
       cy.icon("ellipsis").click();
@@ -536,39 +601,48 @@ describe("scenarios > question > filter", () => {
       display: "table",
     });
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("wilma-muller");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Reviewer contains MULLER").click();
     cy.get(".Icon-chevronleft").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Custom Expression").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains('contains([Reviewer], "MULLER", "case-insensitive")');
     cy.button("Done").click();
     cy.wait("@dataset").then(xhr => {
       expect(xhr.response.body.data.rows).to.have.lengthOf(1);
     });
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("wilma-muller");
   });
 
   it("should reject a number literal", () => {
     openProductsTable({ mode: "notebook" });
     filter({ mode: "notebook" });
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Custom Expression").click();
 
     enterCustomColumnDetails({ formula: "3.14159" });
     cy.get("@formula").blur();
 
     cy.button("Done").should("be.disabled");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Expecting boolean but found 3.14159");
   });
 
   it("should reject a string literal", () => {
     openProductsTable({ mode: "notebook" });
     filter({ mode: "notebook" });
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Custom Expression").click();
 
     enterCustomColumnDetails({ formula: '"TheAnswer"' });
     cy.get("@formula").blur();
 
     cy.button("Done").should("be.disabled");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText('Expecting boolean but found "TheAnswer"');
   });
 
@@ -587,32 +661,39 @@ describe("scenarios > question > filter", () => {
     });
 
     cy.get(".cellData").contains("Count").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Filter by this column").click();
     cy.findByPlaceholderText("Enter a number").type("42");
     cy.button("Update filter").should("not.be.disabled").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Doohickey");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Gizmo").should("not.exist");
   });
 
   it("custom expression filter should reference fields by their name, not by their id (metabase#15748)", () => {
     openOrdersTable({ mode: "notebook" });
     filter({ mode: "notebook" });
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Custom Expression").click();
 
     enterCustomColumnDetails({ formula: "[Total] < [Subtotal]" });
     cy.get("@formula").blur();
 
     cy.button("Done").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Total < Subtotal");
   });
 
   it("custom expression filter should allow the use of parentheses in combination with logical operators (metabase#15754)", () => {
     openOrdersTable({ mode: "notebook" });
     filter({ mode: "notebook" });
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Custom Expression").click();
     cy.get(".ace_text-input")
       .type("([ID] > 2 OR [Subtotal] = 100) and [Tax] < 4")
       .blur();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(/^Expected closing parenthesis but found/).should(
       "not.exist",
     );
@@ -624,14 +705,17 @@ describe("scenarios > question > filter", () => {
 
     openOrdersTable({ mode: "notebook" });
     filter({ mode: "notebook" });
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Custom Expression").click();
     cy.get(".ace_text-input").type("0 < [ID]").blur();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Expecting field but found 0");
   });
 
   it("should allow switching focus with Tab", () => {
     openOrdersTable({ mode: "notebook" });
     filter({ mode: "notebook" });
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Custom Expression").click();
     cy.get(".ace_text-input").type("[Tax] > 0");
 
@@ -643,6 +727,7 @@ describe("scenarios > question > filter", () => {
   it("should allow choosing a suggestion with Tab", () => {
     openOrdersTable({ mode: "notebook" });
     filter({ mode: "notebook" });
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Custom Expression").click();
 
     // Try to auto-complete Tax
@@ -665,14 +750,17 @@ describe("scenarios > question > filter", () => {
   it("should allow hiding the suggestion list with Escape", () => {
     openOrdersTable({ mode: "notebook" });
     filter({ mode: "notebook" });
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Custom Expression").click();
 
     // Try to auto-complete Tax
     cy.get(".ace_text-input").type("Ta");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Tax");
 
     // Esc closes the suggestion popover
     cy.realPress("{esc}");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Tax").should("not.exist");
   });
 
@@ -702,8 +790,11 @@ describe("scenarios > question > filter", () => {
     cy.findByTestId("apply-filters").click();
 
     cy.findByLabelText("notebook icon").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Category is Gizmo").should("exist"); // filter
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Created At: Month").should("exist"); // summary 1
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Average of Count").should("exist"); // summary 2
   });
 
@@ -712,6 +803,7 @@ describe("scenarios > question > filter", () => {
     openPeopleTable({ mode: "notebook" });
     filter({ mode: "notebook" });
     popover().findByText("State").click({ force: true });
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("AL").click();
     cy.button("Add filter").isVisibleInPopover();
   });
@@ -746,6 +838,7 @@ describe("scenarios > question > filter", () => {
 
     assertOnLegendLabels();
     cy.get(".line").should("have.length", 3);
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Save").click();
     cy.button("Save").click();
     cy.button("Not now").click();
@@ -767,22 +860,30 @@ describe("scenarios > question > filter", () => {
         `/admin/datamodel/database/${SAMPLE_DB_ID}/schema/${SAMPLE_DB_SCHEMA_ID}/table/${ORDERS_ID}`,
       );
       // this value isn't actually selected, it's just the default
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("US Dollar").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Euro").click();
 
       openOrdersTable();
     });
 
     it("should show correct currency symbols in currency single field filter", () => {
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Discount (€)").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Filter by this column").click();
       cy.findByTestId("input-prefix").should("contain", "€");
     });
 
     it("should show correct currency symbols in currency between field filter", () => {
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Discount (€)").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Filter by this column").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Equal to").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Between").click();
 
       cy.findAllByTestId("input-prefix").then(els => {
@@ -814,17 +915,21 @@ describe("scenarios > question > filter", () => {
     it("adding an ID filter shouldn't cause page error and page reload (metabase#16198-2)", () => {
       openOrdersTable({ mode: "notebook" });
       filter({ mode: "notebook" });
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Custom Expression").click();
       cy.get(".ace_text-input").type("[Total] < [Product → Price]").blur();
       cy.button("Done").click();
       // Filter currently says "Total is less than..." but it can change in https://github.com/metabase/metabase/pull/16174 to "Total < Price"
       // See: https://github.com/metabase/metabase/pull/16209#discussion_r638129099
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(/^Total/);
       cy.icon("add").last().click();
       popover().findByText(/^ID$/i).click();
       cy.findByPlaceholderText("Enter an ID").type("1");
       cy.button("Add filter").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(/^Total/);
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Something went wrong").should("not.exist");
     });
 
@@ -835,6 +940,7 @@ describe("scenarios > question > filter", () => {
       cy.findByPlaceholderText("Enter a number").type("123");
       cy.button("Add filter").click();
       cy.icon("add").last().click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Custom Expression").click();
       cy.get(".ace_text-input").type("[Total] < [Product → Price]").blur();
       cy.button("Done").click();
@@ -843,6 +949,7 @@ describe("scenarios > question > filter", () => {
       popover().findByText(/^ID$/i).click();
       cy.findByPlaceholderText("Enter an ID").type("1");
       cy.button("Add filter").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Total is equal to 123")
         .parent()
         .find(".Icon-close")
@@ -937,6 +1044,7 @@ describe("scenarios > question > filter", () => {
     it("with case", () => {
       cy.icon("notebook").click();
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Custom column").click();
       enterCustomColumnDetails({
         formula: "Case(boolean, 45, -10)",

--- a/e2e/test/scenarios/filters/operators.cy.spec.js
+++ b/e2e/test/scenarios/filters/operators.cy.spec.js
@@ -66,8 +66,11 @@ describe("operators in questions", () => {
   describe("fields have proper operators", () => {
     it("text operators", () => {
       startNewQuestion();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("Sample Database").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("Products").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Add filters to narrow your answer").click();
 
       popover().within(() => {
@@ -83,8 +86,11 @@ describe("operators in questions", () => {
 
     it("number operators", () => {
       startNewQuestion();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("Sample Database").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("Products").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Add filters to narrow your answer").click();
 
       popover().within(() => {
@@ -100,8 +106,11 @@ describe("operators in questions", () => {
 
     it("relative date operators", () => {
       startNewQuestion();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("Sample Database").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("Products").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Add filters to narrow your answer").click();
 
       popover().within(() => {
@@ -128,8 +137,11 @@ describe("operators in questions", () => {
 
     it("specific date operators", () => {
       startNewQuestion();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("Sample Database").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("Products").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Add filters to narrow your answer").click();
 
       popover().within(() => {
@@ -156,8 +168,11 @@ describe("operators in questions", () => {
 
     it("exclude date operators", () => {
       startNewQuestion();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("Sample Database").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("Products").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Add filters to narrow your answer").click();
 
       popover().within(() => {
@@ -181,8 +196,11 @@ describe("operators in questions", () => {
 
     it("id operators", () => {
       startNewQuestion();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("Sample Database").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("Products").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Add filters to narrow your answer").click();
 
       popover().within(() => {
@@ -198,8 +216,11 @@ describe("operators in questions", () => {
 
     it("geo operators", () => {
       startNewQuestion();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("Sample Database").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("People").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Add filters to narrow your answer").click();
 
       popover().within(() => {

--- a/e2e/test/scenarios/filters/relative-datetime.cy.spec.js
+++ b/e2e/test/scenarios/filters/relative-datetime.cy.spec.js
@@ -33,6 +33,7 @@ describe("scenarios > question > relative-datetime", () => {
           date([[-30, unit]]),
         ]);
         withStartingFrom("Past", [10, unit], [10, unit]);
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("Showing 2 rows").should("exist");
       }),
     );
@@ -47,6 +48,7 @@ describe("scenarios > question > relative-datetime", () => {
           date([[30, unit]]),
         ]);
         withStartingFrom("Next", [10, unit], [10, unit]);
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("Showing 2 rows").should("exist");
       }),
     );
@@ -64,6 +66,7 @@ describe("scenarios > question > relative-datetime", () => {
 
       cy.wait("@dataset");
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Created At Previous 30 Days").click();
       setRelativeDatetimeValue(1);
       setRelativeDatetimeUnit("year");
@@ -132,9 +135,11 @@ describe("scenarios > question > relative-datetime", () => {
       });
       cy.wait("@dataset");
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("There was a problem with your question").should(
         "not.exist",
       );
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("No results!").should("exist");
     });
 
@@ -227,9 +232,11 @@ describe("scenarios > question > relative-datetime", () => {
       });
       cy.wait("@dataset");
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Created At Next 30 Days, starting 7 days ago").should(
         "not.exist",
       );
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Created At Next 30 Days, starting 7 days from now").should(
         "exist",
       );

--- a/e2e/test/scenarios/filters/reproductions/16621-create-multiple-filters-with-same-value.cy.spec.js
+++ b/e2e/test/scenarios/filters/reproductions/16621-create-multiple-filters-with-same-value.cy.spec.js
@@ -8,14 +8,18 @@ describe("issue 16661", () => {
   });
 
   it("should be possible to create multiple filter that start with the same value (metabase#16621)", () => {
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Category").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Filter by this column").click();
     cy.findByPlaceholderText("Search the list").type("Doo{enter}");
     cy.findByTestId("Doo-filter-value").click();
     cy.button("Add filter").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Category is Doo").click();
     cy.findByTestId("Doohickey-filter-value").click();
     cy.button("Update filter").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Category is 2 selections");
   });
 });

--- a/e2e/test/scenarios/filters/reproductions/18770-post-aggregation-filter-disrupts-drillthrough.cy.spec.js
+++ b/e2e/test/scenarios/filters/reproductions/18770-post-aggregation-filter-disrupts-drillthrough.cy.spec.js
@@ -38,6 +38,7 @@ describe.skip("issue 18770", () => {
 
     visualize();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("4,784").click();
     popover()
       .should("contain", "View these Orders")

--- a/e2e/test/scenarios/filters/reproductions/20551-filter-starts-with.cy.spec.js
+++ b/e2e/test/scenarios/filters/reproductions/20551-filter-starts-with.cy.spec.js
@@ -9,6 +9,7 @@ describe("issue 20551", () => {
   it("should allow filtering with includes, rather than starts with (metabase#20551)", () => {
     openProductsTable({ mode: "notebook" });
     filter({ mode: "notebook" });
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Category").click();
 
     // Make sure input field is auto-focused
@@ -17,10 +18,14 @@ describe("issue 20551", () => {
       .type("i");
 
     // All categories that contain `i`
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Doohickey");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Gizmo");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Widget");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Gadget").should("not.exist");
   });
 });

--- a/e2e/test/scenarios/filters/reproductions/20683-postgres-current-quarter.cy.spec.js
+++ b/e2e/test/scenarios/filters/reproductions/20683-postgres-current-quarter.cy.spec.js
@@ -6,27 +6,38 @@ describe("issue 20683", { tags: "@external" }, () => {
     cy.signInAsAdmin();
 
     cy.visit("/");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("New").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Question").should("be.visible").click();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("QA Postgres12").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Orders").click();
   });
 
   it("should filter postgres with the 'current quarter' filter (metabase#20683)", () => {
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Add filters to narrow your answer").click();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Created At").click();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Relative dates...").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Past").click({ force: true });
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Current").click({ force: true });
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Quarter").click();
 
     visualize();
 
     // We don't have entries for the current quarter so we expect no results
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("No results!");
   });
 });

--- a/e2e/test/scenarios/filters/reproductions/21979-exclude-day-of-the-week.cy.spec.js
+++ b/e2e/test/scenarios/filters/reproductions/21979-exclude-day-of-the-week.cy.spec.js
@@ -9,10 +9,14 @@ describe("issue 21979", () => {
   });
 
   it("exclude 'day of the week' should show the correct day reference in the UI (metabase#21979)", () => {
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Filter").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Created At").click();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Exclude...").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Days of the week...").click();
 
     popover().within(() => {
@@ -21,6 +25,7 @@ describe("issue 21979", () => {
     });
 
     cy.log("Make sure the filter references correct day in the UI");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Created At excludes Monday").should("be.visible");
 
     cy.button("Visualize").click();
@@ -28,9 +33,11 @@ describe("issue 21979", () => {
 
     // One of the products created on Monday
     cy.log("Make sure the query is correct");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Enormous Marble Wallet").should("not.exist");
 
     cy.log("Make sure we can re-enable the excluded filter");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Created At excludes Monday").click();
 
     popover().within(() => {
@@ -41,7 +48,9 @@ describe("issue 21979", () => {
       cy.wait("@dataset");
     });
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Created At excludes Thursday").should("be.visible");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Enormous Marble Wallet").should("be.visible");
   });
 });

--- a/e2e/test/scenarios/filters/reproductions/22230-filter-on-aggregation-max-of.cy.spec.js
+++ b/e2e/test/scenarios/filters/reproductions/22230-filter-on-aggregation-max-of.cy.spec.js
@@ -32,6 +32,7 @@ describe("issue 22230", () => {
   });
 
   it("should be able to filter on an aggregation (metabase#22230)", () => {
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Filter").click();
     popover().contains("Max of Name").click();
     cy.findByTestId("select-button").click();
@@ -41,8 +42,11 @@ describe("issue 22230", () => {
     cy.button("Add filter").click();
 
     visualize();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Showing 2 rows").should("be.visible");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Zora Schamberger").should("be.visible");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Zoie Kozey").should("be.visible");
   });
 });

--- a/e2e/test/scenarios/filters/reproductions/22730-table-column-time-filter.cy.spec.js
+++ b/e2e/test/scenarios/filters/reproductions/22730-table-column-time-filter.cy.spec.js
@@ -19,6 +19,7 @@ describe("issue 22730", () => {
   });
 
   it("allows filtering by time column (metabase#22730)", () => {
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Explore results").click();
     cy.wait("@dataset");
 
@@ -37,7 +38,9 @@ describe("issue 22730", () => {
       cy.button("Add filter").click();
     });
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("before-row");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("after-row").should("not.exist");
   });
 });

--- a/e2e/test/scenarios/filters/reproductions/24664-multiple-filters-editing.cy.spec.js
+++ b/e2e/test/scenarios/filters/reproductions/24664-multiple-filters-editing.cy.spec.js
@@ -8,21 +8,27 @@ describe("issue 24664", () => {
   });
 
   it("should be possible to create multiple filter that start with the same value (metabase#24664)", () => {
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Category").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Filter by this column").click();
     cy.findByTestId("Doohickey-filter-value").click();
     cy.button("Add filter").click();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Category").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Filter by this column").click();
     cy.findByTestId("Gizmo-filter-value").click();
     cy.button("Add filter").click();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Category is Gizmo").click();
     cy.findByTestId("Widget-filter-value").click();
     cy.button("Update filter").click();
 
     // First filter is still there
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Category is Doohickey");
   });
 });

--- a/e2e/test/scenarios/filters/reproductions/24994-update-filters.cy.spec.js
+++ b/e2e/test/scenarios/filters/reproductions/24994-update-filters.cy.spec.js
@@ -49,12 +49,15 @@ describe("issue 24994", () => {
     // Three filters
     cy.findByTestId("filters-visibility-control").contains("3").click();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Category is 2 selections").click();
     assertFilterValueIsSelected("Gadget");
     assertFilterValueIsSelected("Gizmo");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Doohickey").click();
     assertFilterValueIsSelected("Doohickey");
     cy.button("Update filter").should("not.be.disabled").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Category is 3 selections");
   });
 });

--- a/e2e/test/scenarios/filters/reproductions/25378-relative-date-on-breakout.cy.spec.js
+++ b/e2e/test/scenarios/filters/reproductions/25378-relative-date-on-breakout.cy.spec.js
@@ -35,9 +35,11 @@ describe("issue 25378", () => {
   it("should be able to use relative date filter on a breakout after the aggregation (metabase#25378)", () => {
     cy.icon("notebook").click();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Filter").click();
     popover().contains("Created At").click();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(/^Relative dates/).click();
     // Change `days` to `months`
     cy.findAllByTestId("select-button-content").contains("days").click();
@@ -46,6 +48,7 @@ describe("issue 25378", () => {
     popover().within(() => {
       cy.icon("ellipsis").click();
     });
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(/^Starting from/).click();
 
     cy.button("Add filter").click();

--- a/e2e/test/scenarios/filters/reproductions/25927-column-filters-not-working-after-cc.cy.spec.js
+++ b/e2e/test/scenarios/filters/reproductions/25927-column-filters-not-working-after-cc.cy.spec.js
@@ -32,7 +32,9 @@ describe("issue 25927", () => {
 
   it("column filter should work for questions with custom column (metabase#25927)", () => {
     cy.findAllByTestId("header-cell").contains("Created At: Month").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Filter by this column").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Last 30 Days").click();
 
     cy.wait("@dataset");

--- a/e2e/test/scenarios/filters/reproductions/25990-filter-nested-join.cy.spec.js
+++ b/e2e/test/scenarios/filters/reproductions/25990-filter-nested-join.cy.spec.js
@@ -41,12 +41,15 @@ describe("issue 25990", () => {
   it("should allow to filter by a column in a joined table (metabase#25990)", () => {
     visitQuestionAdhoc(questionDetails);
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Filter").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("People - User").click();
     cy.findByPlaceholderText("Enter an ID").type("10");
     cy.button("Apply Filters").click();
     cy.wait("@dataset");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("ID is 10").should("be.visible");
   });
 });

--- a/e2e/test/scenarios/filters/reproductions/25994-between-after-summarize-not-working.cy.spec.js
+++ b/e2e/test/scenarios/filters/reproductions/25994-between-after-summarize-not-working.cy.spec.js
@@ -33,8 +33,10 @@ describe("issue 25994", () => {
   });
 
   it("should be possible to use 'between' dates filter after aggregation (metabase#25994)", () => {
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Filter").click();
     popover().findByText("Min of Created At: Day").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Specific dates...").click();
 
     // It doesn't really matter which dates we select so let's go with whatever is offered

--- a/e2e/test/scenarios/filters/reproductions/26861-exclude-breaks-native.cy.spec.js
+++ b/e2e/test/scenarios/filters/reproductions/26861-exclude-breaks-native.cy.spec.js
@@ -35,9 +35,12 @@ describe.skip("issue 26861", () => {
 
   it("exclude filter shouldn't break native questions with field filters (metabase#26861)", () => {
     filterWidget().click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Exclude...").click();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Days of the week...").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Tuesday").click();
 
     cy.button("Update filter").click();
@@ -45,7 +48,9 @@ describe.skip("issue 26861", () => {
     // A part of this bug is that we have to manually run the query so the next step will fail
     cy.wait("@dataset");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("CREATED_AT excludes Tuesday");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("117.03").should("not.exist");
   });
 });

--- a/e2e/test/scenarios/filters/reproductions/27123-exclude-always-shows-days-of-week.cy.spec.js
+++ b/e2e/test/scenarios/filters/reproductions/27123-exclude-always-shows-days-of-week.cy.spec.js
@@ -20,8 +20,11 @@ describe("issue 27123", () => {
 
   it("exclude filter should not resolve to 'Days of the week' regardless of the chosen granularity  (metabase#27123)", () => {
     cy.findAllByTestId("header-cell").contains("Created At").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Filter by this column").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Exclude...").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Months of the year...").click();
 
     popover()

--- a/e2e/test/scenarios/filters/reproductions/9339-clipboard-numeric-filter.cy.spec.js
+++ b/e2e/test/scenarios/filters/reproductions/9339-clipboard-numeric-filter.cy.spec.js
@@ -9,13 +9,18 @@ describe("issue 9339", () => {
   it("should not paste non-numeric values into single-value numeric filters (metabase#9339)", () => {
     openOrdersTable();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Total").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Filter by this column").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Equal to").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Greater than").click();
 
     paste(cy.findByPlaceholderText("Enter a number"), "9339,1234");
     cy.findByDisplayValue("9339").should("be.visible");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("1,234").should("not.exist");
     cy.button("Add filter").should("be.enabled");
   });

--- a/e2e/test/scenarios/filters/view.cy.spec.js
+++ b/e2e/test/scenarios/filters/view.cy.spec.js
@@ -21,7 +21,9 @@ describe("scenarios > question > view", () => {
       cy.visit("/admin/permissions/collections/root");
       cy.icon("close").first().click();
       cy.findAllByRole("option").contains("View").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Save changes").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Yes").click();
 
       // Native query saved in dasbhoard
@@ -71,6 +73,7 @@ describe("scenarios > question > view", () => {
 
       // Filter by category and vendor
       // TODO: this should show values and allow searching
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("This question is written in SQL.");
       cy.findAllByText("VENDOR").first().click();
       popover().within(() => {
@@ -93,10 +96,12 @@ describe("scenarios > question > view", () => {
       // Navigate to Q from Dashboard
       cy.signIn("nodata");
       visitDashboard(2);
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Question").click();
 
       // Filter by category and vendor
       // TODO: this should show values and allow searching
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("This question is written in SQL.");
       cy.findAllByText("VENDOR").first().click();
       popover().within(() => {

--- a/e2e/test/scenarios/joins/joins.cy.spec.js
+++ b/e2e/test/scenarios/joins/joins.cy.spec.js
@@ -45,6 +45,7 @@ describe("scenarios > question > joined questions", () => {
     popover().contains("Product ID").click();
 
     visualize();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("37.65");
 
     cy.findByTestId("question-table-badges").within(() => {
@@ -62,29 +63,36 @@ describe("scenarios > question > joined questions", () => {
       cy.wait("@dataset");
     });
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Rating is equal to 2");
 
     // Post-join aggregation (metabase#11452):
     cy.icon("notebook").click();
     summarize({ mode: "notebook" });
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Average of ...").click();
     popover().contains(joinedTable).click();
     popover().contains("Rating").click();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Pick a column to group by").click();
     popover().contains(joinedTable).click();
     popover().contains("Reviewer").click();
 
     visualize();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Rating is equal to 2");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Showing 89 rows");
 
     // Make sure UI overlay doesn't obstruct viewing results after we save this question (metabase#13468)
     saveQuestion();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Rating is equal to 2");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Showing 89 rows");
 
     function saveQuestion() {
@@ -110,7 +118,9 @@ describe("scenarios > question > joined questions", () => {
 
     // start a custom question with question a
     startNewQuestion();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Saved Questions").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("question a").click();
 
     // join to question b
@@ -122,7 +132,9 @@ describe("scenarios > question > joined questions", () => {
     });
 
     // select the join columns
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     popover().within(() => cy.findByText("A_COLUMN").click());
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     popover().within(() => cy.findByText("B_COLUMN").click());
 
     visualize();
@@ -133,8 +145,11 @@ describe("scenarios > question > joined questions", () => {
       cy.findByText("question a");
       cy.findByText("question b");
     });
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("A_COLUMN");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Question 5 → B Column");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Showing 1 row");
   });
 
@@ -201,6 +216,7 @@ describe("scenarios > question > joined questions", () => {
 
     visualize();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Sum Divide");
   });
 
@@ -268,8 +284,10 @@ describe("scenarios > question > joined questions", () => {
 
     // Join two previously saved questions
     startNewQuestion();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Saved Questions").click();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("12928_Q1").click();
     cy.wait("@cardQueryMetadata");
 
@@ -279,9 +297,11 @@ describe("scenarios > question > joined questions", () => {
       cy.findByTextEnsureVisible("Saved Questions").click();
     });
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("12928_Q2").click();
     cy.wait("@cardQueryMetadata");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains(/Products? → Category/).click();
 
     popover()
@@ -336,6 +356,7 @@ describe("scenarios > question > joined questions", () => {
     });
 
     cy.get(".dot").eq(2).click({ force: true });
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("X-ray").click();
 
     cy.wait("@xray").then(xhr => {
@@ -351,6 +372,7 @@ describe("scenarios > question > joined questions", () => {
       "How this metric is distributed across different numbers",
     );
     // Main title
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains(/^A closer look at/);
     // Make sure at least one card is rendered
     cy.get(".DashCard");
@@ -375,7 +397,9 @@ describe("scenarios > question > joined questions", () => {
     cy.icon("join_left_outer").click();
 
     popover().findByText("Sample Database").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Saved Questions").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("15578").click();
 
     popover().findByText("ID").click();
@@ -407,6 +431,7 @@ describe("scenarios > question > joined questions", () => {
 
     // 415 rows mean the join is done correctly,
     // (join on product's FK + join on the same "created_at" field)
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Showing 415 rows");
   });
 
@@ -453,9 +478,11 @@ describe("scenarios > question > joined questions", () => {
     summarize({ mode: "notebook" });
     selectFromDropdown("Count of rows");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Pick a column to group by").click();
     selectFromDropdown("Created At");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Join data").click();
     selectFromDropdown("Products");
     selectFromDropdown("Count");

--- a/e2e/test/scenarios/joins/reproductions/15342-mysql-correct-joins-order.cy.spec.js
+++ b/e2e/test/scenarios/joins/reproductions/15342-mysql-correct-joins-order.cy.spec.js
@@ -17,7 +17,9 @@ describe("issue 15342", { tags: "@external" }, () => {
 
   it("should correctly order joins for MySQL queries (metabase#15342)", () => {
     startNewQuestion();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(MYSQL_DB_NAME).click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("People").click();
 
     addJoin({

--- a/e2e/test/scenarios/joins/reproductions/17710-notebook-incomplete-joins-removed.cy.spec.js
+++ b/e2e/test/scenarios/joins/reproductions/17710-notebook-incomplete-joins-removed.cy.spec.js
@@ -15,6 +15,7 @@ describe("issue 17710", () => {
   it("should remove only invalid join clauses (metabase#17710)", () => {
     openOrdersTable({ mode: "notebook" });
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Join data").click();
     popover().findByText("Products").click();
 

--- a/e2e/test/scenarios/joins/reproductions/17712-notebook-extra-sections-removed.cy.spec.js
+++ b/e2e/test/scenarios/joins/reproductions/17712-notebook-extra-sections-removed.cy.spec.js
@@ -10,6 +10,7 @@ describe("issue 17712", () => {
   it("doesn't remove extra sections when removing a single section (metabase#17712)", () => {
     openOrdersTable({ mode: "notebook" });
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Join data").click();
     popover().findByText("Products").click();
     cy.findByTestId("step-join-0-0")

--- a/e2e/test/scenarios/joins/reproductions/17767-cannot-join-on-aggregation-with-implicit-joins.cy.spec.js
+++ b/e2e/test/scenarios/joins/reproductions/17767-cannot-join-on-aggregation-with-implicit-joins.cy.spec.js
@@ -25,6 +25,7 @@ describe("issue 17767", () => {
 
     cy.icon("notebook").click();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Join data").click();
 
     // Join "Previous results" with
@@ -41,6 +42,7 @@ describe("issue 17767", () => {
       expect(response.body.error).to.not.exist;
     });
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("xavier");
   });
 });

--- a/e2e/test/scenarios/joins/reproductions/17968-notebook-join-table-names.cy.spec.js
+++ b/e2e/test/scenarios/joins/reproductions/17968-notebook-join-table-names.cy.spec.js
@@ -10,6 +10,7 @@ describe("issue 17968", () => {
   it("shows correct table names when joining many tables (metabase#17968)", () => {
     openOrdersTable({ mode: "notebook" });
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Join data").click();
     popover().findByText("Products").click();
 

--- a/e2e/test/scenarios/joins/reproductions/18502-cannot-join-two-saved-questions-same-table.cy.spec.js
+++ b/e2e/test/scenarios/joins/reproductions/18502-cannot-join-two-saved-questions-same-table.cy.spec.js
@@ -26,8 +26,10 @@ describe("issue 18502", () => {
     cy.createQuestion(question2);
 
     startNewQuestion();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Saved Questions").click();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("18502#1").click();
     cy.icon("join_left_outer").click();
     cy.wait("@getCollectionContent");
@@ -37,13 +39,16 @@ describe("issue 18502", () => {
       cy.findByText("18502#2").click();
     });
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Created At").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Birth Date").click();
 
     visualize(response => {
       expect(response.body.error).to.not.exist;
     });
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("April, 2016");
   });
 });

--- a/e2e/test/scenarios/joins/reproductions/18512-cannot-join-two-saved-questions-with-same-implicit-explicit-grouped-field.cy.spec.js
+++ b/e2e/test/scenarios/joins/reproductions/18512-cannot-join-two-saved-questions-with-same-implicit-explicit-grouped-field.cy.spec.js
@@ -26,8 +26,10 @@ describe("issue 18512", () => {
     cy.createQuestion(question2);
 
     startNewQuestion();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Saved Questions").click();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("18512#1").click();
     cy.wait("@cardQueryMetadata");
 
@@ -46,6 +48,7 @@ describe("issue 18512", () => {
       expect(response.body.error).to.not.exist;
     });
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Products → Created At");
   });
 });

--- a/e2e/test/scenarios/joins/reproductions/18589-numeric-binning-in-joins.cy.spec.js
+++ b/e2e/test/scenarios/joins/reproductions/18589-numeric-binning-in-joins.cy.spec.js
@@ -25,6 +25,7 @@ describe("issue 18589", () => {
 
     visualize();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("2,860,368");
   });
 });

--- a/e2e/test/scenarios/joins/reproductions/18630-field-literals-in-joins.cy.spec.js
+++ b/e2e/test/scenarios/joins/reproductions/18630-field-literals-in-joins.cy.spec.js
@@ -59,6 +59,7 @@ describe("issue 18630", () => {
     // The query runs and we assert the page is not blank,
     // rather than an infinite loop and stack overflow.
     // 'test question' is the name of the question.
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("test question");
   });
 });

--- a/e2e/test/scenarios/joins/reproductions/20519-cannot-join-on-aggregation-with-implicit-joins-and-nested-query.cy.spec.js
+++ b/e2e/test/scenarios/joins/reproductions/20519-cannot-join-on-aggregation-with-implicit-joins-and-nested-query.cy.spec.js
@@ -59,7 +59,9 @@ describe("issue 20519", () => {
       expect(response.body.error).not.to.exist;
     });
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Doohickey");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Two");
   });
 });

--- a/e2e/test/scenarios/joins/reproductions/22859-multi-nested-joins-wrong-aliasing.cy.spec.js
+++ b/e2e/test/scenarios/joins/reproductions/22859-multi-nested-joins-wrong-aliasing.cy.spec.js
@@ -40,6 +40,7 @@ describe("issue 22859 - multiple levels of nesting", () => {
 
     // Join Orders table with the previously saved question and save it again
     openOrdersTable({ mode: "notebook" });
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Join data").click();
 
     popover().within(() => {
@@ -77,7 +78,9 @@ describe("issue 22859 - multiple levels of nesting", () => {
 
   it("third level of nesting with joins should result in proper column aliasing (metabase#22859-2)", () => {
     startNewQuestion();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Saved Questions").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("22859-Q2").click();
 
     visualize();

--- a/e2e/test/scenarios/joins/reproductions/27380-dashboard-drops-joined-fields-on-zoom-in.cy.spec.js
+++ b/e2e/test/scenarios/joins/reproductions/27380-dashboard-drops-joined-fields-on-zoom-in.cy.spec.js
@@ -35,6 +35,7 @@ describe.skip("issue 27380", () => {
   it("should not drop fields from joined table on dashboard 'zoom-in' (metabase#27380)", () => {
     // Doesn't really matter which 'circle" we click on the graph
     cy.get("circle").last().realClick();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Zoom in").click();
     cy.wait("@dataset");
 
@@ -43,7 +44,9 @@ describe.skip("issue 27380", () => {
     cy.get("y-axis-label").invoke("text").should("eq", "Count");
 
     cy.icon("notebook").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Pick a column to group by").should("not.exist");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(/Products? → Created At: Month/);
   });
 });

--- a/e2e/test/scenarios/models/create.cy.spec.js
+++ b/e2e/test/scenarios/models/create.cy.spec.js
@@ -15,7 +15,9 @@ describe("scenarios > models > create", () => {
     goFromHomePageToNewNativeQueryModelPage();
 
     // Cancel creation with confirmation modal
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Cancel").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Discard").click();
 
     // Now we will create a model
@@ -26,13 +28,16 @@ describe("scenarios > models > create", () => {
 
     cy.get(".ace_editor").should("be.visible").type("select * from ORDERS");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Save").click();
 
     cy.findByPlaceholderText("What is the name of your model?").type(modelName);
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Save").click();
 
     // After saving, we land on view mode for the model
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Summarize");
 
     checkIfPinned();

--- a/e2e/test/scenarios/models/model-actions.cy.spec.js
+++ b/e2e/test/scenarios/models/model-actions.cy.spec.js
@@ -109,6 +109,7 @@ describe(
         cy.wait("@getModel");
       });
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Actions").click();
 
       cy.findByRole("button", { name: /Create basic actions/i }).click();
@@ -162,8 +163,11 @@ describe(
         cy.button("Disable").click();
       });
       cy.findByLabelText("Action list").should("not.exist");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Create").should("not.exist");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Update").should("not.exist");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Delete").should("not.exist");
 
       openNavigationSidebar();
@@ -175,8 +179,10 @@ describe(
       getArchiveListItem("Delete Order").within(() => {
         cy.icon("unarchive").click({ force: true });
       });
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Delete Order").should("not.exist");
       cy.findByRole("button", { name: "Undo" }).click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Delete Order").should("be.visible");
       getArchiveListItem("Delete Order").within(() => {
         cy.icon("trash").click({ force: true });
@@ -189,10 +195,12 @@ describe(
       const QUERY = "UPDATE orders SET discount = {{ discount }}";
       cy.visit("/");
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("New").click();
       popover().findByText("Action").click();
 
       fillActionQuery(QUERY);
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(/New Action/)
         .clear()
         .type("Discount order");
@@ -206,7 +214,9 @@ describe(
       cy.get("@modelId").then(modelId => {
         cy.url().should("include", `/model/${modelId}/detail/actions`);
       });
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Discount order").should("be.visible");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(QUERY).should("be.visible");
     });
 
@@ -276,11 +286,13 @@ describe(
 
       // Check can only see the action database
       cy.findByRole("dialog").findByText("QA Postgres12").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Sample Database").should("not.exist");
     });
 
     it("should display parameters for variable template tags only", () => {
       cy.visit("/");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("New").click();
       popover().findByText("Action").click();
 
@@ -340,6 +352,7 @@ describe(
         cy.button(SAMPLE_QUERY_ACTION.name).click();
       });
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(`${SAMPLE_QUERY_ACTION.name} ran successfully`).should(
         "be.visible",
       );

--- a/e2e/test/scenarios/models/models-metadata.cy.spec.js
+++ b/e2e/test/scenarios/models/models-metadata.cy.spec.js
@@ -46,13 +46,16 @@ describe("scenarios > models metadata", () => {
         cy.findByTextEnsureVisible("89%").trigger("mouseenter");
       });
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(
         "Some columns are missing a column type, description, or friendly name.",
       );
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(
         "Adding metadata makes it easier for your team to explore this data.",
       );
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Edit metadata").click();
 
       cy.url().should("include", "/metadata");
@@ -67,12 +70,14 @@ describe("scenarios > models metadata", () => {
       startQuestionFromModel("GUI Model");
 
       visualize();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Pre-tax ($)");
     });
 
     it("allows for canceling changes", () => {
       openQuestionActions();
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Edit metadata").click();
 
       openColumnOptions("Subtotal");
@@ -82,12 +87,14 @@ describe("scenarios > models metadata", () => {
 
       cy.button("Cancel").click();
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Subtotal");
     });
 
     it("clears custom metadata when a model is turned back into a question", () => {
       openQuestionActions();
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Edit metadata").click();
 
       openColumnOptions("Subtotal");
@@ -103,6 +110,7 @@ describe("scenarios > models metadata", () => {
 
       cy.wait("@dataset");
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Subtotal");
     });
   });
@@ -125,13 +133,16 @@ describe("scenarios > models metadata", () => {
       cy.findByTextEnsureVisible("37%").trigger("mouseenter");
     });
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(
       "Most columns are missing a column type, description, or friendly name.",
     );
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(
       "Adding metadata makes it easier for your team to explore this data.",
     );
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Edit metadata").click();
 
     cy.url().should("include", "/metadata");
@@ -150,6 +161,7 @@ describe("scenarios > models metadata", () => {
     startQuestionFromModel("Native Model");
 
     visualize();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Pre-tax ($)");
   });
 
@@ -165,10 +177,13 @@ describe("scenarios > models metadata", () => {
       { visitQuestion: true },
     );
     openQuestionActions();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Edit metadata").click();
     openColumnOptions("USER_ID");
     setColumnType("No special type", "Foreign Key");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Select a target").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("People → ID").click();
     cy.button("Save changes").click();
     // TODO: Not much to do with it at the moment beyond saving it.
@@ -229,6 +244,7 @@ describe("scenarios > models metadata", () => {
       .and("not.contain", "SUBTOTAL");
 
     openQuestionActions();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Edit metadata").click();
 
     cy.findByTextEnsureVisible("TAX");
@@ -378,8 +394,11 @@ describe("scenarios > models metadata", () => {
 
       cy.createQuestion(questionDetails, { visitQuestion: true });
       openQuestionActions();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Vendor").should("not.exist");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Edit metadata").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Vendor").should("be.visible");
     });
   });

--- a/e2e/test/scenarios/models/models-query-editor.cy.spec.js
+++ b/e2e/test/scenarios/models/models-query-editor.cy.spec.js
@@ -41,6 +41,7 @@ describe("scenarios > models query editor", () => {
       cy.findByTestId("data-step-cell").contains("Orders");
       cy.button("Save changes").should("be.disabled");
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Row limit").click();
       cy.findByPlaceholderText("Enter a limit").type("2");
 
@@ -74,6 +75,7 @@ describe("scenarios > models query editor", () => {
         cy.findByText("Edit query definition").click();
       });
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Row limit").click();
       cy.findByPlaceholderText("Enter a limit").type("2");
 
@@ -205,22 +207,27 @@ describe("scenarios > models query editor", () => {
         cy.findByText("Edit metadata").click();
       });
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(/Syntax error in SQL/).should("be.visible");
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Query").click();
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(/Syntax error in SQL/).should("be.visible");
 
       cy.get(".ace_content").type("{backspace}".repeat(" FROM".length));
       runNativeQuery();
 
       cy.get(".cellData").contains(1);
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(/Syntax error in SQL/).should("not.exist");
 
       cy.button("Save changes").click();
       cy.wait("@updateCard");
 
       cy.get(".cellData").contains(1);
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(/Syntax error in SQL/).should("not.exist");
     });
   });

--- a/e2e/test/scenarios/models/models-with-aggregation-and-breakout.cy.spec.js
+++ b/e2e/test/scenarios/models/models-with-aggregation-and-breakout.cy.spec.js
@@ -31,7 +31,9 @@ describe("scenarios > models with aggregation and breakout", () => {
     turnIntoModel();
     cy.wait("@updateCard");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Created At: Month");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Distinct values of Product ID");
   });
 });

--- a/e2e/test/scenarios/models/models.cy.spec.js
+++ b/e2e/test/scenarios/models/models.cy.spec.js
@@ -149,7 +149,9 @@ describe("scenarios > models", () => {
     cy.get(".LineAreaBarChart");
 
     turnIntoModel();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("This is a model now.");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Undo").click();
 
     cy.get(".LineAreaBarChart");
@@ -169,10 +171,12 @@ describe("scenarios > models", () => {
 
     cy.wait("@cardUpdate");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("This is a question now.");
     openQuestionActions();
     assertIsQuestion();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Undo").click();
     cy.wait("@cardUpdate");
     openQuestionActions();
@@ -181,6 +185,7 @@ describe("scenarios > models", () => {
 
   it("shows 404 when opening a question with a /dataset URL", () => {
     cy.visit("/model/1");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(/We're a little lost/i);
   });
 
@@ -263,6 +268,7 @@ describe("scenarios > models", () => {
       cy.findAllByRole("option").should("have.length", 4);
       selectFromDropdown("Products");
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Add filters to narrow your answer").click();
       selectFromDropdown("Products", { force: true });
       selectFromDropdown("Price", { force: true });
@@ -271,14 +277,17 @@ describe("scenarios > models", () => {
       cy.findByPlaceholderText("Enter a number").type("50");
       cy.button("Add filter").click();
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Pick the metric you want to see").click();
       selectFromDropdown("Count of rows");
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Pick a column to group by").click();
       selectFromDropdown("Created At");
 
       visualize();
       cy.get(".LineAreaBarChart");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Save").click();
 
       modal().within(() => {
@@ -352,6 +361,7 @@ describe("scenarios > models", () => {
       cy.visit("/model/1");
       cy.wait("@dataset");
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Subtotal").click();
       selectFromDropdown("Sum over time");
 
@@ -388,6 +398,7 @@ describe("scenarios > models", () => {
       cy.wait("@updateCard");
 
       cy.findByDisplayValue("M1");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("foo");
     });
   });
@@ -427,10 +438,12 @@ describe("scenarios > models", () => {
     closeQuestionActions();
 
     // Check card tags are supported by models
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(/Open editor/i).click();
     cy.get(".ace_content").type(
       "{leftarrow}{leftarrow}{backspace}{backspace}#1",
     );
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Save").click();
     modal().findByText("Save").click();
 
@@ -478,7 +491,9 @@ describe("scenarios > models", () => {
     turnIntoModel();
 
     visitCollection("root");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Useful data");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("A model");
   });
 
@@ -490,7 +505,9 @@ describe("scenarios > models", () => {
     cy.wait("@cardUpdate");
 
     visitCollection("root");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Useful data").should("not.exist");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("A model").should("not.exist");
   });
 

--- a/e2e/test/scenarios/models/reproductions/19737-data-picker-not-showing-moved-model.cy.spec.js
+++ b/e2e/test/scenarios/models/reproductions/19737-data-picker-not-showing-moved-model.cy.spec.js
@@ -20,9 +20,12 @@ describe("issue 19737", () => {
 
     moveModel(modelName, "My personal collection");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Moved model");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("New").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Question").should("be.visible").click();
 
     popover().within(() => {
@@ -38,11 +41,14 @@ describe("issue 19737", () => {
 
     moveModel(modelName, "First collection");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Moved model");
     // Close the modal so the next time we move the model another model will always be shown
     cy.icon("close:visible").click();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("New").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Question").should("be.visible").click();
 
     // Open question picker (this is crucial) so the collection list are loaded.
@@ -60,9 +66,12 @@ describe("issue 19737", () => {
 
     moveModel(modelName, "My personal collection");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Moved model");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("New").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Question").should("be.visible").click();
 
     popover().within(() => {

--- a/e2e/test/scenarios/models/reproductions/19776-data-picker-not-displayed-after-archiving-model.cy.spec.js
+++ b/e2e/test/scenarios/models/reproductions/19776-data-picker-not-displayed-after-archiving-model.cy.spec.js
@@ -16,13 +16,19 @@ describe("issue 19776", () => {
     openEllipsisMenuFor(modelName);
     popover().contains("Archive").click();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Archived model");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("New").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Question").should("be.visible").click();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Sample Database");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Saved Questions");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Models").should("not.exist");
   });
 });

--- a/e2e/test/scenarios/models/reproductions/20042-nodata-user-blank-screen.cy.spec.js
+++ b/e2e/test/scenarios/models/reproductions/20042-nodata-user-blank-screen.cy.spec.js
@@ -17,7 +17,9 @@ describe("issue 20042", () => {
 
     cy.wait("@query");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Orders Model");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("37.65");
   });
 });

--- a/e2e/test/scenarios/models/reproductions/20624-model-metadata-should-override-column-settings.cy.spec.js
+++ b/e2e/test/scenarios/models/reproductions/20624-model-metadata-should-override-column-settings.cy.spec.js
@@ -24,9 +24,11 @@ describe.skip("issue 20624", () => {
 
   it("models metadata should override previously defined column settings (metabase#20624)", () => {
     openDetailsSidebar();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Customize metadata").click();
 
     // Open settings for this column
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(renamedColumn).click();
     // Let's set a new name for it
     cy.findByDisplayValue(renamedColumn).clear().type("Foo").blur();

--- a/e2e/test/scenarios/models/reproductions/20963-can-not-convert-question-with-snippets-to-model.cy.spec.js
+++ b/e2e/test/scenarios/models/reproductions/20963-can-not-convert-question-with-snippets-to-model.cy.spec.js
@@ -22,6 +22,7 @@ describe("issue 20963", () => {
 
     // Creat a snippet
     cy.icon("snippet").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Create a snippet").click();
 
     modal().within(() => {
@@ -34,6 +35,7 @@ describe("issue 20963", () => {
 
     cy.get("@editor").type(`{moveToStart}select `);
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Save").click();
     modal().within(() => {
       // I don't know why the input lost focus, especially when we ran the query before saving.
@@ -44,6 +46,7 @@ describe("issue 20963", () => {
     });
 
     // dismiss modal
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Not now").click();
 
     // Convert into to a model

--- a/e2e/test/scenarios/models/reproductions/22517-add-remove-column-drops-metadata.cy.spec.js
+++ b/e2e/test/scenarios/models/reproductions/22517-add-remove-column-drops-metadata.cy.spec.js
@@ -18,6 +18,7 @@ describe("issue 22517", () => {
     );
 
     openQuestionActions();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Edit metadata").click();
 
     renameColumn("ID", "Foo");
@@ -28,9 +29,11 @@ describe("issue 22517", () => {
 
   it("adding or removging a column should not drop previously edited metadata (metabase#22517)", () => {
     openQuestionActions();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Edit query definition").click();
 
     // Make sure previous metadata changes are reflected in the UI
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Foo");
 
     // This will edit the original query and add the `SIZE` column
@@ -43,10 +46,13 @@ describe("issue 22517", () => {
     cy.get(".NativeQueryEditor .Icon-play").click();
     cy.wait("@dataset");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Foo");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Save changes").click();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Foo");
   });
 });

--- a/e2e/test/scenarios/models/reproductions/22518.cy.spec.js
+++ b/e2e/test/scenarios/models/reproductions/22518.cy.spec.js
@@ -23,10 +23,12 @@ describe("issue 22518", () => {
 
   it("UI should immediately reflect model query changes upon saving (metabase#22518)", () => {
     openQuestionActions();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Edit query definition").click();
 
     cy.get(".ace_content").type(", 'b' bar");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Save changes").click();
 
     cy.findAllByTestId("header-cell")

--- a/e2e/test/scenarios/models/reproductions/22519-casting-fails-query.cy.spec.js
+++ b/e2e/test/scenarios/models/reproductions/22519-casting-fails-query.cy.spec.js
@@ -24,7 +24,9 @@ describe.skip("issue 22519", () => {
 
     cy.visit(ratingDataModelUrl);
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Don't cast").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("UNIX seconds → Datetime").click();
     cy.wait("@updateField");
   });
@@ -32,11 +34,13 @@ describe.skip("issue 22519", () => {
   it("model query should not fail when data model is using casting (metabase#22519)", () => {
     cy.createQuestion(questionDetails, { visitQuestion: true });
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("xavier");
 
     turnIntoModel();
 
     cy.wait("@dataset");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("xavier");
   });
 });

--- a/e2e/test/scenarios/models/reproductions/22715-remapped-values-override-column-identifier.cy.spec.js
+++ b/e2e/test/scenarios/models/reproductions/22715-remapped-values-override-column-identifier.cy.spec.js
@@ -48,11 +48,15 @@ describe("filtering based on the remapped column name should result in a correct
   });
 
   it("when done through the column header action (metabase#22715-1)", () => {
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Created At").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Filter by this column").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Today").click();
 
     cy.wait("@dataset");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Today").should("not.exist");
 
     cy.get(".cellData").should("have.length", 4).and("contain", "Created At");

--- a/e2e/test/scenarios/models/reproductions/23024-cannot-apply-dash-filter-native-model.cy.spec.js
+++ b/e2e/test/scenarios/models/reproductions/23024-cannot-apply-dash-filter-native-model.cy.spec.js
@@ -51,9 +51,12 @@ describe("issue 23024", () => {
 
     cy.icon("filter").click();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Text or Category").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Is").click();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Column to filter on")
       .parent()
       .within(() => {

--- a/e2e/test/scenarios/models/reproductions/23421-visualization-settins-breaks-ui.cy.spec.js
+++ b/e2e/test/scenarios/models/reproductions/23421-visualization-settins-breaks-ui.cy.spec.js
@@ -25,6 +25,7 @@ describe("issue 23421", () => {
 
   it("`visualization_settings` should not break UI (metabase#23421)", () => {
     openQuestionActions();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Edit query definition").click();
 
     cy.get(".ace_content").should("contain", query);

--- a/e2e/test/scenarios/models/reproductions/25537-model-picker-locale.cy.spec.js
+++ b/e2e/test/scenarios/models/reproductions/25537-model-picker-locale.cy.spec.js
@@ -24,6 +24,7 @@ describe("issue 25537", () => {
     cy.icon("model").click();
     cy.wait("@getCollectionContent");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(questionDetails.name).should("exist");
   });
 });

--- a/e2e/test/scenarios/models/reproductions/26091-new-models-picker.cy.spec.js
+++ b/e2e/test/scenarios/models/reproductions/26091-new-models-picker.cy.spec.js
@@ -33,6 +33,7 @@ describe("issue 26091", () => {
       cy.findByText("Raw Data").click();
       cy.findByText("Orders").click();
     });
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Save").click();
     modal().within(() => {
       cy.findByLabelText("Name").clear().type("New model");

--- a/e2e/test/scenarios/models/reproductions/28193-cannot-use-custom-column.cy.spec.js
+++ b/e2e/test/scenarios/models/reproductions/28193-cannot-use-custom-column.cy.spec.js
@@ -17,6 +17,7 @@ describe.skip("issue 28193", () => {
     // Go directly to model's query definition
     cy.visit("/model/1/query");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Custom column").click();
     enterCustomColumnDetails({
       formula: "[Tax]",

--- a/e2e/test/scenarios/models/reproductions/28971-filters-model-new-model.cy.spec.js
+++ b/e2e/test/scenarios/models/reproductions/28971-filters-model-new-model.cy.spec.js
@@ -18,10 +18,15 @@ describe("issue 28971", () => {
   it("should be able to filter a newly created model (metabase#28971)", () => {
     cy.visit("/");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("New").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     popover().within(() => cy.findByText("Model").click());
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Use the notebook editor").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     popover().within(() => cy.findByText("Sample Database").click());
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     popover().within(() => cy.findByText("Orders").click());
     cy.button("Save").click();
     modal().within(() => cy.button("Save").click());
@@ -29,10 +34,13 @@ describe("issue 28971", () => {
 
     filter();
     filterField("Quantity", { operator: "equal to" });
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     filterFieldPopover("Quantity").within(() => cy.findByText("20").click());
     cy.button("Apply Filters").click();
     cy.wait("@dataset");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Quantity is equal to 20").should("exist");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Showing 4 rows").should("exist");
   });
 });

--- a/e2e/test/scenarios/models/reproductions/29378-actions-search-crash.cy.spec.js
+++ b/e2e/test/scenarios/models/reproductions/29378-actions-search-crash.cy.spec.js
@@ -39,17 +39,22 @@ describe("issue 29378", () => {
 
     cy.visit(`/model/${MODEL_ID}/detail`);
     cy.findByRole("tab", { name: "Actions" }).click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(ACTION_DETAILS.name).should("be.visible");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(ACTION_DETAILS.dataset_query.native.query).should(
       "be.visible",
     );
 
     cy.findByRole("tab", { name: "Used by" }).click();
     cy.findByPlaceholderText("Search…").type(ACTION_DETAILS.name);
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(ACTION_DETAILS.name).should("be.visible");
 
     cy.findByRole("tab", { name: "Actions" }).click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(ACTION_DETAILS.name).should("be.visible");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(ACTION_DETAILS.dataset_query.native.query).should(
       "be.visible",
     );

--- a/e2e/test/scenarios/models/reproductions/29951-model-editor-results-metadata.cy.spec.js
+++ b/e2e/test/scenarios/models/reproductions/29951-model-editor-results-metadata.cy.spec.js
@@ -32,6 +32,7 @@ describe("issue 29951", () => {
     cy.wait("@dataset");
 
     openQuestionActions();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Edit query definition").click();
     removeExpression("CC2");
     cy.findByRole("button", { name: "Save changes" }).click();
@@ -41,6 +42,7 @@ describe("issue 29951", () => {
     dragColumn(0, 100);
     cy.findAllByRole("button", { name: "Get Answer" }).first().click();
     cy.wait("@dataset");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Showing first 2,000 rows").should("be.visible");
   });
 });

--- a/e2e/test/scenarios/native-filters/reproductions/11480.cy.spec.js
+++ b/e2e/test/scenarios/native-filters/reproductions/11480.cy.spec.js
@@ -23,6 +23,7 @@ describe("issue 11480", () => {
 
     // Run the query and see an error.
     SQLFilter.runQuery();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains(`Data conversion error converting "some text"`);
 
     // Oh wait! That doesn't match the total column, so we'll change the parameter to a number.
@@ -31,6 +32,7 @@ describe("issue 11480", () => {
 
     // When we run it again, the default has been cleared out so we get the right error.
     SQLFilter.runQuery();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains(
       "You'll need to pick a value for 'X' before this query can run.",
     );

--- a/e2e/test/scenarios/native-filters/reproductions/12581.cy.spec.js
+++ b/e2e/test/scenarios/native-filters/reproductions/12581.cy.spec.js
@@ -37,7 +37,9 @@ describe("issue 12581", () => {
 
   it("should correctly display a revision state after a restore (metabase#12581)", () => {
     // Start with the original version of the question made with API
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(/Open Editor/i).click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(/Open Editor/i).should("not.exist");
 
     // Both delay and a repeated sequence of `{selectall}{backspace}` are there to prevent typing flakes
@@ -48,6 +50,7 @@ describe("issue 12581", () => {
       .type("{selectall}{backspace}", { delay: 50 });
     cy.get("@editor").click().type("{selectall}{backspace}SELECT 1");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Save").click();
     modal().within(() => {
       cy.button("Save").click();
@@ -58,17 +61,21 @@ describe("issue 12581", () => {
 
     cy.findByTestId("revision-history-button").click();
     // Make sure sidebar opened and the history loaded
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("You created this");
 
     cy.findByTestId("question-revert-button").click(); // Revert to the first revision
     cy.wait("@dataset");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("You reverted to an earlier revision");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(/Open Editor/i).click();
 
     cy.log("Reported failing on v0.35.3");
     cy.get("@editor").should("be.visible").and("contain", ORIGINAL_QUERY);
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("37.65");
 
     // Filter dropdown field

--- a/e2e/test/scenarios/native-filters/reproductions/13961.cy.spec.js
+++ b/e2e/test/scenarios/native-filters/reproductions/13961.cy.spec.js
@@ -64,6 +64,7 @@ describe.skip("issue 13961", () => {
     cy.log("URL is correct at this point, but there are no results");
 
     cy.location("search").should("eq", `?${productIdFilter.name}=1`);
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Rustic Paper Wallet"); // Product ID 1, Gizmo
   });
 });

--- a/e2e/test/scenarios/native-filters/reproductions/14145.cy.spec.js
+++ b/e2e/test/scenarios/native-filters/reproductions/14145.cy.spec.js
@@ -41,13 +41,16 @@ describe.skip("issue 14145", () => {
 
   it("`field-id` should update when database source is changed (metabase#14145)", () => {
     // Change the source from "Sample Database" to the other database
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(/Open Editor/i).click();
 
     cy.get(".GuiBuilder-data").as("source").contains("Sample Database").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Sample2").click();
 
     // First assert on the UI
     cy.icon("variable").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(/Field to map to/)
       .siblings("a")
       .contains("Category");

--- a/e2e/test/scenarios/native-filters/reproductions/14302.cy.spec.js
+++ b/e2e/test/scenarios/native-filters/reproductions/14302.cy.spec.js
@@ -31,6 +31,7 @@ describe("issue 14302", () => {
   it("should not make the question dirty when there are no changes (metabase#14302)", () => {
     cy.log("Reported on v0.37.5 - Regression since v0.37.0");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Save").should("not.exist");
   });
 });

--- a/e2e/test/scenarios/native-filters/reproductions/15163.cy.spec.js
+++ b/e2e/test/scenarios/native-filters/reproductions/15163.cy.spec.js
@@ -89,6 +89,7 @@ const dashboardDetails = {
     });
 
     it(`${test.toUpperCase()} version:\n should be able to view SQL question when accessing via dashboard with filters connected to modified card without SQL permissions (metabase#15163)`, () => {
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("New Title").click();
 
       cy.wait("@cardQuery", { timeout: 5000 }).then(xhr => {
@@ -97,6 +98,7 @@ const dashboardDetails = {
 
       cy.get(".ace_content").should("not.be.visible");
       cy.get(".cellData").should("contain", "51");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Showing 1 row");
     });
   });

--- a/e2e/test/scenarios/native-filters/reproductions/15981.cy.spec.js
+++ b/e2e/test/scenarios/native-filters/reproductions/15981.cy.spec.js
@@ -24,6 +24,7 @@ describe("issue 15981", () => {
     cy.get(".Visualization").contains("Rustic Paper Wallet");
 
     cy.icon("contract").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Showing 51 rows");
     cy.icon("play").should("not.exist");
   });

--- a/e2e/test/scenarios/native-filters/reproductions/16756.cy.spec.js
+++ b/e2e/test/scenarios/native-filters/reproductions/16756.cy.spec.js
@@ -40,6 +40,7 @@ describe("issue 16756", () => {
   });
 
   it("should allow switching between date filter types (metabase#16756)", () => {
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(/Open editor/i).click();
     cy.icon("variable").click();
 
@@ -61,6 +62,7 @@ describe("issue 16756", () => {
     runQuery();
 
     // We expect "No results"
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("No results!");
   });
 });

--- a/e2e/test/scenarios/native-filters/reproductions/27257.cy.spec.js
+++ b/e2e/test/scenarios/native-filters/reproductions/27257.cy.spec.js
@@ -21,6 +21,7 @@ describe("issue 27257", () => {
       cy.icon("string");
     });
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Variable type").parent().findByText("Text").click();
     popover().contains("Number").click();
 
@@ -37,6 +38,7 @@ describe("issue 27257", () => {
 
   it("should not drop numeric filter widget value on refresh even if it's zero (metabase#27257)", () => {
     cy.reload();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Here's where your results will appear");
     cy.findByDisplayValue("0");
   });

--- a/e2e/test/scenarios/native-filters/reproductions/29786.cy.spec.js
+++ b/e2e/test/scenarios/native-filters/reproductions/29786.cy.spec.js
@@ -28,6 +28,7 @@ describe("issue 29786", { tags: "@external" }, () => {
     FieldFilter.addWidgetStringFilter("Von-Gulgowski");
 
     SQLFilter.runQuery();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("1087115303928").should("be.visible");
   });
 });

--- a/e2e/test/scenarios/native-filters/sql-field-filter.cy.spec.js
+++ b/e2e/test/scenarios/native-filters/sql-field-filter.cy.spec.js
@@ -75,6 +75,7 @@ describe("scenarios > filters > sql filters > field filter", () => {
         field: "Longitude",
       });
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("None").should("be.visible");
 
       filterWidget().should("not.exist");
@@ -84,11 +85,14 @@ describe("scenarios > filters > sql filters > field filter", () => {
       cy.get(".RunButton").first().click();
 
       cy.wait("@dataset");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Hudson Borer");
     });
 
     it("should let you change the field filter type to something else and restore the filter widget (metabase#13825)", () => {
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Longitude").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Address").click();
 
       FieldFilter.setWidgetType("String contains");
@@ -129,6 +133,7 @@ describe("scenarios > filters > sql filters > field filter", () => {
 
     it("should work despite it not showing up in the widget type list", () => {
       cy.createNativeQuestion(questionDetails, { visitQuestion: true });
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Showing 42 rows");
 
       clearFilterValue();
@@ -140,11 +145,14 @@ describe("scenarios > filters > sql filters > field filter", () => {
       });
 
       cy.findByTestId("qb-header").find(".Icon-play").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Showing 51 rows");
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Open Editor").click();
       cy.icon("variable").click();
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Filter widget type")
         .parent()
         .findAllByTestId("select-button")

--- a/e2e/test/scenarios/native-filters/sql-filters-source.cy.spec.js
+++ b/e2e/test/scenarios/native-filters/sql-filters-source.cy.spec.js
@@ -90,6 +90,7 @@ describe("scenarios > filters > sql filters > values source", () => {
       FieldFilter.selectFilterValueFromList("Gadget", { addFilter: false });
       FieldFilter.selectFilterValueFromList("Gizmo");
       SQLFilter.runQuery("cardQuery");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Showing 51 rows").should("exist");
 
       SQLFilter.toggleRequired();
@@ -383,6 +384,7 @@ describeEE("scenarios > filters > sql filters > values source", () => {
     checkFilterValueNotInList("Doohickey");
     FieldFilter.selectFilterValueFromList("Gizmo");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Open Editor").click();
     cy.icon("variable").click();
     FieldFilter.openEntryForm(true);

--- a/e2e/test/scenarios/native-filters/sql-filters.cy.spec.js
+++ b/e2e/test/scenarios/native-filters/sql-filters.cy.spec.js
@@ -96,7 +96,9 @@ describe("scenarios > filters > sql filters > basic filter types", () => {
       filterWidget().click();
       // Since we have fixed dates in Sample Database (dating back a couple of years), it'd be cumbersome to click back month by month.
       // Instead, let's choose the 15th of the current month and assert that there are no products / no results.
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("15").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Update filter").click();
 
       SQLFilter.runQuery();
@@ -109,8 +111,11 @@ describe("scenarios > filters > sql filters > basic filter types", () => {
     it("when set as the default value for a required filter", () => {
       SQLFilter.toggleRequired();
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Select a default value…").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("15").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Update filter").click();
 
       SQLFilter.runQuery();
@@ -143,6 +148,7 @@ describe("scenarios > filters > sql filters > basic filter types", () => {
     // resize window to mobile form factor
     cy.viewport(480, 800);
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("1 active filter").click();
 
     cy.get("fieldset")

--- a/e2e/test/scenarios/native/data_ref.cy.spec.js
+++ b/e2e/test/scenarios/native/data_ref.cy.spec.js
@@ -16,19 +16,27 @@ describe("scenarios > native question > data reference sidebar", () => {
     cy.get("[data-testid='sidebar-header-title']").findByText(
       "Sample Database",
     );
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("ORDERS").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(
       "Confirmed Sample Company orders for a product, from a user.",
     );
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("9 columns");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("QUANTITY").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Number of products bought.");
     // clicking the title should navigate back
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("QUANTITY").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("ORDERS").click();
     cy.get("[data-testid='sidebar-header-title']")
       .findByText("Sample Database")
       .click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Data Reference");
   });
 
@@ -45,17 +53,26 @@ describe("scenarios > native question > data reference sidebar", () => {
     // Move question to personal collection
     openQuestionActions();
     cy.findByTestId("move-button").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("My personal collection").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Move").click();
 
     openNativeEditor();
     cy.icon("reference").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("1 model");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Native Products Model").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("A model of the Products table"); // description
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Bobby Tables's Personal Collection"); // collection
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("1 column");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("RENAMED_ID").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("No description");
   });
 });

--- a/e2e/test/scenarios/native/native-mongo.cy.spec.js
+++ b/e2e/test/scenarios/native/native-mongo.cy.spec.js
@@ -11,12 +11,17 @@ describe("scenarios > question > native > mongo", { tags: "@external" }, () => {
     cy.signInAsNormalUser();
 
     cy.visit("/");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("New").click();
     // Reproduces metabase#20499 issue
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Native query").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(MONGO_DB_NAME).click();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Select a table").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Orders").click();
   });
 
@@ -32,6 +37,7 @@ describe("scenarios > question > native > mongo", { tags: "@external" }, () => {
 
     cy.findByTextEnsureVisible("18,760");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Save").click();
 
     cy.findByTextEnsureVisible("Save new question");
@@ -44,6 +50,7 @@ describe("scenarios > question > native > mongo", { tags: "@external" }, () => {
 
     cy.wait("@createQuestion");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Not now").click();
 
     cy.url().should("match", /\/question\/\d+-[a-z0-9-]*$/);

--- a/e2e/test/scenarios/native/native-mysql.cy.spec.js
+++ b/e2e/test/scenarios/native/native-mysql.cy.spec.js
@@ -46,9 +46,11 @@ describe("scenatios > question > native > mysql", { tags: "@external" }, () => {
     cy.wait("@dataset");
     cy.findByTextEnsureVisible("SUBTOTAL");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("37.65");
 
     // Save the query
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Save").click();
 
     modal().within(() => {
@@ -61,6 +63,7 @@ describe("scenatios > question > native > mysql", { tags: "@external" }, () => {
 
     cy.findByTextEnsureVisible("Not now").click();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Save").should("not.exist");
     cy.url().should("match", /\/question\/\d+-[a-z0-9-]*$/);
   });

--- a/e2e/test/scenarios/native/native.cy.spec.js
+++ b/e2e/test/scenarios/native/native.cy.spec.js
@@ -26,12 +26,14 @@ describe("scenarios > question > native", () => {
   it("lets you create and run a SQL question", () => {
     openNativeEditor().type("select count(*) from orders");
     runQuery();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("18,760");
   });
 
   it("displays an error", () => {
     openNativeEditor().type("select * from not_a_table");
     runQuery();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains('Table "NOT_A_TABLE" not found');
   });
 
@@ -42,6 +44,7 @@ describe("scenarios > question > native", () => {
         "{shift}{leftarrow}".repeat(19), // highlight back to the front
     );
     runQuery();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains('Table "ORD" not found');
   });
 
@@ -51,6 +54,7 @@ describe("scenarios > question > native", () => {
     });
     cy.get("input[placeholder*='Stars']").type("3");
     runQuery();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Showing 168 rows");
   });
 
@@ -66,6 +70,7 @@ describe("scenarios > question > native", () => {
     cy.get("input[placeholder*='Enter a default value']").type("Gizmo");
     runQuery();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Save").click();
 
     modal().within(() => {
@@ -80,14 +85,17 @@ describe("scenarios > question > native", () => {
       });
     });
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Not now").click();
   });
 
   it("can save a question with no rows", () => {
     openNativeEditor().type("select * from people where false");
     runQuery();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("No results!");
     cy.icon("contract").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Save").click();
 
     modal().within(() => {
@@ -122,6 +130,7 @@ describe("scenarios > question > native", () => {
       });
     });
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("This has a value");
 
     FILTERS.forEach(operator => {
@@ -185,6 +194,7 @@ describe("scenarios > question > native", () => {
 
     runQuery();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Save").click();
 
     modal().within(() => {
@@ -197,6 +207,7 @@ describe("scenarios > question > native", () => {
         expect(requestBody?.parameters?.length).to.equal(2);
       });
     });
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Not now").click();
 
     // Now load the question again and parameters[] should still be there
@@ -223,6 +234,7 @@ describe("scenarios > question > native", () => {
       { autorun: false },
     );
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Here's where your results will appear").should("be.visible");
   });
 
@@ -235,6 +247,7 @@ describe("scenarios > question > native", () => {
     cy.button("Preview the query").click();
     cy.wait("@datasetNative");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(/where CATEGORY='Gadget'/).should("be.visible");
   });
 
@@ -246,6 +259,7 @@ describe("scenarios > question > native", () => {
     cy.button("Preview the query").click();
     cy.wait("@datasetNative");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(/missing required parameters/).should("be.visible");
   });
 
@@ -267,10 +281,12 @@ describe("scenarios > question > native", () => {
 
     cy.button("View the SQL").click();
     cy.wait("@datasetNative");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(/FROM "PUBLIC"."ORDERS"/).should("be.visible");
 
     cy.button("Convert this question to SQL").click();
     runQuery();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Showing 1 row").should("be.visible");
   });
 
@@ -306,6 +322,7 @@ describe("scenarios > question > native", () => {
 
       runQuery();
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("18,760");
 
       cy.findByLabelText("Close").click();
@@ -330,8 +347,10 @@ describe("scenarios > question > native", () => {
         .focus()
         .type(`${PROMPT}{enter}`);
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(errorMessage);
       cy.button("Try again").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(errorMessage);
       cy.button("Rephrase").click();
 
@@ -345,6 +364,7 @@ describe("scenarios > question > native", () => {
       cy.wait("@databasePrompt");
 
       runQuery();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("18,760");
     });
   });

--- a/e2e/test/scenarios/native/reproductions/15946-mongo-pre-select-table.cy.spec.js
+++ b/e2e/test/scenarios/native/reproductions/15946-mongo-pre-select-table.cy.spec.js
@@ -8,7 +8,9 @@ describe.skip("issue 15946", { tags: "@external" }, () => {
     cy.signInAsAdmin();
 
     startNewQuestion();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(MONGO_DB_NAME).click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Orders").click();
   });
 

--- a/e2e/test/scenarios/native/reproductions/18148-save-button-before-it-is-possible-to-save.cy.spec.js
+++ b/e2e/test/scenarios/native/reproductions/18148-save-button-before-it-is-possible-to-save.cy.spec.js
@@ -15,13 +15,17 @@ describe("issue 18148", () => {
   });
 
   it("should not offer to save the question before it is actually possible to save it (metabase#18148)", () => {
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Select a database");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Save").should("have.attr", "aria-disabled", "true");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(dbName).click();
 
     cy.get(".ace_content").should("be.visible").type("select foo");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Save").click();
 
     cy.get(".Modal").should("exist");

--- a/e2e/test/scenarios/native/reproductions/18418-saved-question-db-appears-in-db-picker.cy.spec.js
+++ b/e2e/test/scenarios/native/reproductions/18418-saved-question-db-appears-in-db-picker.cy.spec.js
@@ -20,8 +20,10 @@ describe("issue 18418", () => {
   it("should not show saved questions DB in native question's DB picker (metabase#18418)", () => {
     cy.createNativeQuestion(questionDetails, { visitQuestion: true });
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Explore results").click();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Save").click();
 
     cy.get(".Modal").button("Save").click();

--- a/e2e/test/scenarios/native/reproductions/19451.cy.spec.js
+++ b/e2e/test/scenarios/native/reproductions/19451.cy.spec.js
@@ -31,14 +31,20 @@ describe("issue 19451", () => {
   });
 
   it("question field filter shows all tables from a selected database (metabase#19451)", () => {
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Open Editor").click();
     cy.icon("variable").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Products").click();
     cy.icon("chevronleft").click();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Products");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Orders");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("People");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Reviews");
   });
 });

--- a/e2e/test/scenarios/native/reproductions/21550-snippet-scrollbar.cy.spec.js
+++ b/e2e/test/scenarios/native/reproductions/21550-snippet-scrollbar.cy.spec.js
@@ -14,6 +14,7 @@ describe("issue 21550", () => {
 
     cy.icon("snippet").click();
     cy.wait("@rootCollection");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Create a snippet").click();
 
     modal().within(() => {
@@ -25,6 +26,7 @@ describe("issue 21550", () => {
       cy.wait("@rootCollection");
     });
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("people").realHover();
     cy.get(".Icon-chevrondown").click({ force: true });
 

--- a/e2e/test/scenarios/native/reproductions/21597-query-build-card-save-modal.cy.spec.js
+++ b/e2e/test/scenarios/native/reproductions/21597-query-build-card-save-modal.cy.spec.js
@@ -47,6 +47,7 @@ describe("issue 21597", { tags: "@external" }, () => {
     });
 
     cy.get(".NativeQueryEditor .Icon-play").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("200");
 
     // Change DB
@@ -58,6 +59,7 @@ describe("issue 21597", { tags: "@external" }, () => {
       cy.findByText(databaseCopyName).click();
     });
     cy.get(".NativeQueryEditor .Icon-play").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains(
       `Failed to fetch Field ${PRODUCTS.CATEGORY}: Field does not exist, or belongs to a different Database.`,
     );

--- a/e2e/test/scenarios/native/reproductions/23510-load-data-reference-metadata.cy.spec.js
+++ b/e2e/test/scenarios/native/reproductions/23510-load-data-reference-metadata.cy.spec.js
@@ -33,6 +33,7 @@ describe("issue 23510", () => {
       { visitQuestion: true },
     );
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Open Editor").click();
     cy.icon("reference").click();
 

--- a/e2e/test/scenarios/native/snippets/snippet-permissions.cy.spec.js
+++ b/e2e/test/scenarios/native/snippets/snippet-permissions.cy.spec.js
@@ -24,6 +24,7 @@ describeEE("scenarios > question > snippets", () => {
 
       openNativeEditor();
       cy.icon("snippet").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("Create a snippet").click();
 
       modal().within(() => {
@@ -37,6 +38,7 @@ describeEE("scenarios > question > snippets", () => {
       });
 
       cy.wait("@snippetCreated");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("{{snippet: one}}");
 
       cy.icon("play").first().click();
@@ -60,6 +62,7 @@ describeEE("scenarios > question > snippets", () => {
     // create folder
     cy.icon("snippet").click();
     cy.findByTestId("sidebar-right").as("sidebar").find(".Icon-add").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     popover().within(() => cy.findByText("New folder").click());
     modal().within(() => {
       cy.findByText("Create your new folder");
@@ -83,17 +86,23 @@ describeEE("scenarios > question > snippets", () => {
       cy.findByText("Edit").click();
     });
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     modal().within(() => cy.findByText("Top folder").click());
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     popover().within(() => cy.findByText("my favorite snippets").click());
     cy.intercept("/api/collection/root/items?namespace=snippets").as(
       "updateList",
     );
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     modal().within(() => cy.findByText("Save").click());
 
     // check that everything is in the right spot
     cy.wait("@updateList");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("snippet 1").should("not.exist");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("my favorite snippets").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("snippet 1");
   });
 
@@ -116,6 +125,7 @@ describeEE("scenarios > question > snippets", () => {
       cy.visit("/collection/root");
 
       cy.wait("@collections");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Snippet Folder").should("not.exist");
     });
 
@@ -133,6 +143,7 @@ describeEE("scenarios > question > snippets", () => {
           .click({ force: true });
       });
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Change permissions").click();
 
       // Update permissions for "All users" and let them only "View" this folder
@@ -148,7 +159,9 @@ describeEE("scenarios > question > snippets", () => {
       cy.wait("@updatePermissions");
 
       // Now let's do the sanity check for the top level (root) snippet permissions and make sure nothing changed there
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Snippets").parent().next().find(".Icon-ellipsis").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Change permissions").click();
 
       // UI check

--- a/e2e/test/scenarios/native/snippets/snippets.cy.spec.js
+++ b/e2e/test/scenarios/native/snippets/snippets.cy.spec.js
@@ -24,6 +24,7 @@ describe("scenarios > question > snippets", () => {
 
     // Add a snippet of that text
     cy.icon("snippet").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Create a snippet").click();
 
     modal().within(() => {
@@ -51,10 +52,12 @@ describe("scenarios > question > snippets", () => {
     openNativeEditor().type("select ");
     // 2. snippet
     cy.icon("snippet").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("stuff-snippet").click();
 
     // Open the snippet edit modal
     cy.icon("chevrondown").click({ force: true });
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Edit").click();
 
     // Update the name and content
@@ -115,6 +118,7 @@ describe("scenarios > question > snippets", () => {
     });
 
     cy.get(".Visualization").as("results").findByText("37.65");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(/Open Editor/i).click();
     // We need these mid-point checks to make sure Cypress typed the sequence/query correctly
     // Check 1

--- a/e2e/test/scenarios/onboarding/about.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/about.cy.spec.js
@@ -7,14 +7,19 @@ describe("scenarios > about Metabase", () => {
 
     cy.visit("/");
     cy.icon("gear").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("About Metabase").click();
   });
 
   it.skip("should display correct Metabase version (metabase#15656)", () => {
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(/You're on version v[01](\.\d+){2,3}(-[\w\d]+)?/i);
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(/Built on \d{4}-\d{2}-\d{2}/);
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Branch: ?").should("not.exist");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Hash: ?").should("not.exist");
   });
 });

--- a/e2e/test/scenarios/onboarding/auth/forgot_password.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/auth/forgot_password.cy.spec.js
@@ -16,7 +16,9 @@ describe("scenarios > auth > password", { tags: "@external" }, () => {
     cy.visit("/auth/forgot_password");
 
     cy.findByLabelText("Email address").type(admin.email);
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Send password reset email").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(/Check your email/);
 
     getInbox().then(({ body: [{ html }] }) => {

--- a/e2e/test/scenarios/onboarding/auth/signin.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/auth/signin.cy.spec.js
@@ -30,7 +30,9 @@ describe("scenarios > auth > signin", () => {
     cy.visit("/");
     cy.findByLabelText("Email address").type(admin.email);
     cy.findByLabelText("Password").type("INVALID" + admin.password);
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Sign in").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("did not match stored password");
   });
 
@@ -38,7 +40,9 @@ describe("scenarios > auth > signin", () => {
     cy.visit("/");
     cy.findByLabelText("Email address").type("INVALID" + admin.email);
     cy.findByLabelText("Password").type(admin.password);
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Sign in").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("did not match stored password");
   });
 
@@ -46,7 +50,9 @@ describe("scenarios > auth > signin", () => {
     cy.visit("/auth/login");
     cy.findByLabelText("Email address").should("be.focused").type(admin.email);
     cy.findByLabelText("Password").type(admin.password);
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Sign in").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains(/[a-z ]+, Bob/i);
   });
 
@@ -54,7 +60,9 @@ describe("scenarios > auth > signin", () => {
     cy.visit("/auth/login");
     cy.findByLabelText("Email address").type(admin.email.toUpperCase());
     cy.findByLabelText("Password").type(admin.password);
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Sign in").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains(/[a-z ]+, Bob/i);
   });
 
@@ -73,22 +81,28 @@ describe("scenarios > auth > signin", () => {
     cy.visit("/");
     // Browse data moved to an icon
     browse().click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Sample Database").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Orders").click();
     cy.wait("@dataset");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("37.65");
 
     // signout and reload page with question hash in url
     cy.signOut();
     cy.reload();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Sign in to Metabase");
     cy.findByLabelText("Email address").type(admin.email);
     cy.findByLabelText("Password").type(admin.password);
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Sign in").click();
 
     // order table should load after login
     cy.wait("@dataset");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("37.65");
   });
 
@@ -102,8 +116,10 @@ describe("scenarios > auth > signin", () => {
 
       cy.visit("/");
       cy.url().should("contain", "auth/login");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("I seem to have forgotten my password").click();
       cy.url().should("contain", "auth/forgot_password");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Back to sign in").click();
       cy.url().should("contain", "auth/login");
     });

--- a/e2e/test/scenarios/onboarding/auth/sso.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/auth/sso.cy.spec.js
@@ -22,6 +22,7 @@ describe("scenarios > auth > signin > SSO", () => {
     it(`login history tab should be available with ${auth} enabled (metabase#15558)`, () => {
       mockCurrentUserProperty(auth, true);
       cy.visit("/account/profile");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Login History");
     });
   });
@@ -33,6 +34,7 @@ describe("scenarios > auth > signin > SSO", () => {
     });
 
     it("should show SSO button", () => {
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Sign in with email");
 
       // Google SSO button is piped through an iframe
@@ -40,18 +42,22 @@ describe("scenarios > auth > signin > SSO", () => {
     });
 
     it("should show login form when directed to sign in with email", () => {
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Sign in with email").click();
       cy.findByLabelText("Email address");
       cy.findByLabelText("Password");
       cy.button("Sign in").should("be.disabled");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Sign in with Google");
     });
 
     it("should surface login errors with Google sign in enabled (metabase#16122)", () => {
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Sign in with email").click();
       cy.findByLabelText("Email address").type("foo@bar.test");
       cy.findByLabelText("Password").type("123");
       cy.button("Sign in").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("Password: did not match stored password");
     });
 
@@ -59,6 +65,7 @@ describe("scenarios > auth > signin > SSO", () => {
       const loginProtectedURL = "/admin/permissions/data";
 
       cy.visit(loginProtectedURL);
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Sign in with email").click();
       fillInAuthForm();
 
@@ -79,6 +86,7 @@ describe("scenarios > auth > signin > SSO", () => {
       cy.visit("/");
       // Google SSO button is piped through an iframe
       cy.get("iframe");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Sign in with email").should("not.exist");
     });
   });

--- a/e2e/test/scenarios/onboarding/home/activity-page.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/home/activity-page.cy.spec.js
@@ -21,8 +21,11 @@ describe("metabase > scenarios > home > activity-page", () => {
 
   it("should show test startup activity ", () => {
     cy.visit("/activity");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Activity");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Metabase is up and running.");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("added a question to the dashboard - Orders in a dashboard");
   });
 
@@ -31,21 +34,27 @@ describe("metabase > scenarios > home > activity-page", () => {
 
     // Make and a save new question
     openProductsTable();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Rating").click();
     popover().within(() => {
       cy.findByText("Filter by this column").click();
       cy.findByPlaceholderText("Enter a number").type("5");
       cy.findByText("Add filter").click();
     });
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Save").click();
     cy.get("[value='Products, Filtered by Rating equals 5']");
     cy.findAllByText("Save").last().click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Not now").click();
 
     // View a dashboard
     cy.visit("/collection/root?type=dashboard");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Orders in a dashboard").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("My personal collection").should("not.exist");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Orders");
     cy.get(".Card").should("have.length", 1);
 
@@ -55,6 +64,7 @@ describe("metabase > scenarios > home > activity-page", () => {
 
     cy.findAllByText("joined!").should("have.length", 2);
     cy.findAllByText(getFullName(normal)).should("have.length", 2);
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Products, Filtered by Rating equals 5");
   });
 
@@ -78,6 +88,7 @@ describe("metabase > scenarios > home > activity-page", () => {
 
     cy.visit("/activity");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("You added a question to the dashboard - Orders in a dashboard")
       .closest("li")
       .findByRole("link", { name: "Orders" })

--- a/e2e/test/scenarios/onboarding/home/browse.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/home/browse.cy.spec.js
@@ -8,14 +8,20 @@ describe("scenarios > browse data", () => {
 
   it("basic UI flow should work", () => {
     cy.visit("/");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(/Browse data/).click();
     cy.location("pathname").should("eq", "/browse");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(/^Our data$/i);
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Learn about our data").click();
     cy.location("pathname").should("eq", "/reference/databases");
     cy.go("back");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Sample Database").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Products").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Rustic Paper Wallet");
   });
 });

--- a/e2e/test/scenarios/onboarding/home/homepage.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/home/homepage.cy.spec.js
@@ -21,10 +21,13 @@ describe("scenarios > home > homepage", () => {
 
       cy.visit("/");
       cy.wait("@getXrayCandidates");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Try out these sample x-rays to see what Metabase can do.");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Orders").click();
 
       cy.wait("@getXrayDashboard");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("More X-rays");
     });
 
@@ -34,11 +37,14 @@ describe("scenarios > home > homepage", () => {
 
       cy.visit("/");
       cy.wait("@getXrayCandidates");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Here are some explorations of");
       cy.findAllByRole("link").contains("H2");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Orders").click();
 
       cy.wait("@getXrayDashboard");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("More X-rays");
     });
 
@@ -48,15 +54,23 @@ describe("scenarios > home > homepage", () => {
       cy.intercept("/api/automagic-*/database/**", getXrayCandidates());
 
       cy.visit("/");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(/Here are some explorations of the/);
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("public");
       cy.findAllByRole("link").contains("H2");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Orders");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("People").should("not.exist");
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("public").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("private").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("People");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Orders").should("not.exist");
     });
   });
@@ -70,29 +84,37 @@ describe("scenarios > home > homepage", () => {
       cy.signInAsAdmin();
 
       visitDashboard(1);
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Orders in a dashboard");
 
       cy.visit("/");
       cy.wait("@getRecentItems");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Pick up where you left off");
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Orders in a dashboard").click();
       cy.wait("@getDashboard");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Orders");
     });
 
     it("should display popular items for a new user", () => {
       cy.signInAsAdmin();
       visitDashboard(1);
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Orders in a dashboard");
       cy.signOut();
 
       cy.signInAsNormalUser();
       cy.visit("/");
       cy.wait("@getPopularItems");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Here are some popular dashboards");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Orders in a dashboard").click();
       cy.wait("@getDashboard");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Orders");
     });
 
@@ -100,6 +122,7 @@ describe("scenarios > home > homepage", () => {
       cy.signInAsAdmin();
 
       visitDashboard(1);
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Orders in a dashboard");
 
       cy.visit("/collection/root");
@@ -110,7 +133,9 @@ describe("scenarios > home > homepage", () => {
 
       cy.visit("/");
       cy.wait("@getRecentItems");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Orders in a dashboard").should("be.visible");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Orders, Count").should("not.exist");
     });
   });

--- a/e2e/test/scenarios/onboarding/navbar/new-menu.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/navbar/new-menu.cy.spec.js
@@ -6,6 +6,7 @@ describe("metabase > scenarios > navbar > new menu", () => {
     cy.signInAsAdmin();
 
     cy.visit("/");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("New").click();
   });
 

--- a/e2e/test/scenarios/onboarding/notifications.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/notifications.cy.spec.js
@@ -80,6 +80,7 @@ describe("scenarios > account > notifications", () => {
     it("should be able to see help info", () => {
       openUserNotifications();
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Not seeing one here?").click();
 
       modal().within(() => {
@@ -93,14 +94,18 @@ describe("scenarios > account > notifications", () => {
     it("should be able to see alerts notifications", () => {
       openUserNotifications();
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Question");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Emailed hourly", { exact: false });
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Created by you", { exact: false });
     });
 
     it("should be able to unsubscribe and delete an alert when the user created it", () => {
       openUserNotifications();
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Question");
       clickUnsubscribe();
 
@@ -124,6 +129,7 @@ describe("scenarios > account > notifications", () => {
       cy.signInAsAdmin();
       openUserNotifications();
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Question");
       clickUnsubscribe();
 
@@ -132,6 +138,7 @@ describe("scenarios > account > notifications", () => {
         cy.findByText("Unsubscribe").click();
       });
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Question").should("not.exist");
     });
   });
@@ -150,6 +157,7 @@ describe("scenarios > account > notifications", () => {
     it("should be able to see help info", () => {
       openUserNotifications();
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Not seeing one here?").click();
 
       modal().within(() => {
@@ -163,14 +171,18 @@ describe("scenarios > account > notifications", () => {
     it("should be able to see pulses notifications", () => {
       openUserNotifications();
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Subscription");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Slack’d hourly", { exact: false });
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Created by you", { exact: false });
     });
 
     it("should be able to unsubscribe and delete a pulse when the user has created it", () => {
       openUserNotifications();
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Subscription");
       clickUnsubscribe();
 
@@ -179,6 +191,7 @@ describe("scenarios > account > notifications", () => {
         cy.findByText("Yes, delete this subscription").click();
       });
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Subscription").should("not.exist");
     });
   });

--- a/e2e/test/scenarios/onboarding/reference/databases.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/reference/databases.cy.spec.js
@@ -8,6 +8,7 @@ describe("scenarios > reference > databases", () => {
 
   it("should see the listing", () => {
     cy.visit("/reference/databases");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Sample Database");
   });
 
@@ -19,35 +20,46 @@ describe("scenarios > reference > databases", () => {
 
   it("should let an admin edit details about the database", () => {
     cy.visit("/reference/databases/1");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Edit").click();
     // Q - is there any cleaner way to get a nearby element without having to know the DOM?
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Description")
       .parent()
       .parent()
       .find("textarea")
       .type("A pretty ok store");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Save").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("A pretty ok store");
   });
 
   it("should let an admin start to edit and cancel without saving", () => {
     cy.visit("/reference/databases/1");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Edit").click();
     // Q - is there any cleaner way to get a nearby element without having to know the DOM?
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Why this")
       .parent()
       .parent()
       .find("textarea")
       .type("Turns out it's not");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Cancel").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Turns out").should("have.length", 0);
   });
 
   it("should let an admin edit the database name", () => {
     cy.visit("/reference/databases/1");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Edit").click();
     cy.get(".wrapper input").clear().type("My definitely profitable business");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Save").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("My definitely profitable business");
   });
 

--- a/e2e/test/scenarios/onboarding/reference/metrics.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/reference/metrics.cy.spec.js
@@ -25,58 +25,76 @@ describe("scenarios > reference > metrics", () => {
 
   it("should see the listing", () => {
     cy.visit("/reference/metrics");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(METRIC_NAME);
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(METRIC_DESCRIPTION);
   });
 
   it("should let the user navigate to details", () => {
     cy.visit("/reference/metrics");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(METRIC_NAME).click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Why this metric is interesting");
   });
 
   it("should let an admin edit details about the metric", () => {
     cy.visit("/reference/metrics");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(METRIC_NAME).click();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Edit").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Description")
       .parent()
       .parent()
       .find("textarea")
       .clear()
       .type("Count of orders under $100");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Save").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Reason for changes")
       .parent()
       .parent()
       .find("textarea")
       .type("Renaming the description");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Save changes").click();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Count of orders under $100");
   });
 
   it("should let an admin start to edit and cancel without saving", () => {
     cy.visit("/reference/metrics");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(METRIC_NAME).click();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Edit").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Why this metric is interesting")
       .parent()
       .parent()
       .find("textarea")
       .type("Because it's very nice");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Cancel").click();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Because it's very nice").should("have.length", 0);
   });
 
   it("should have different URI while editing the metric", () => {
     cy.visit("/reference/metrics");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(METRIC_NAME).click();
 
     cy.url().should("match", /\/reference\/metrics\/\d+$/);
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Edit").click();
     cy.url().should("match", /\/reference\/metrics\/\d+\/edit$/);
   });

--- a/e2e/test/scenarios/onboarding/reference/reproductions/5276-remove-field-type.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/reference/reproductions/5276-remove-field-type.cy.spec.js
@@ -10,16 +10,24 @@ describe("issue 5276", () => {
   it("should allow removing the field type (metabase#5276)", () => {
     cy.visit("/reference/databases");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Sample Database").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Tables in Sample Database").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Products").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Fields in this table").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Edit").click();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Score").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     popover().within(() => cy.findByText("No field type").click());
     cy.button("Save").click();
     cy.wait("@updateField");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Score").should("not.exist");
   });
 });

--- a/e2e/test/scenarios/onboarding/search/recently-viewed.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/search/recently-viewed.cy.spec.js
@@ -55,6 +55,7 @@ describe("search > recently viewed", () => {
   });
 
   it("allows to select an item from keyboard", () => {
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Recently viewed");
     cy.get("body").trigger("keydown", { key: "ArrowDown" });
     cy.get("body").trigger("keydown", { key: "ArrowDown" });
@@ -83,6 +84,7 @@ describeEE("search > recently viewed > enterprise features", () => {
   it("should show verified badge in the 'Recently viewed' list (metabase#18021)", () => {
     cy.findByPlaceholderText("Search…").click();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Recently viewed")
       .parent()
       .within(() => {

--- a/e2e/test/scenarios/onboarding/search/search-pagination.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/search/search-pagination.cy.spec.js
@@ -29,6 +29,7 @@ describe("scenarios > search", () => {
     cy.findByTestId("previous-page-btn").should("be.disabled");
 
     // First page
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(`1 - ${PAGE_SIZE}`);
     cy.findByTestId("pagination-total").should("have.text", TOTAL_ITEMS);
     cy.findAllByTestId("search-result-item").should("have.length", PAGE_SIZE);
@@ -36,6 +37,7 @@ describe("scenarios > search", () => {
     cy.findByTestId("next-page-btn").click();
 
     // Second page
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(`${PAGE_SIZE + 1} - ${TOTAL_ITEMS}`);
     cy.findByTestId("pagination-total").should("have.text", TOTAL_ITEMS);
     cy.findAllByTestId("search-result-item").should("have.length", 1);
@@ -44,6 +46,7 @@ describe("scenarios > search", () => {
     cy.findByTestId("previous-page-btn").click();
 
     // First page
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(`1 - ${PAGE_SIZE}`);
     cy.findByTestId("pagination-total").should("have.text", TOTAL_ITEMS);
     cy.findAllByTestId("search-result-item").should("have.length", PAGE_SIZE);

--- a/e2e/test/scenarios/onboarding/search/search.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/search/search.cy.spec.js
@@ -28,6 +28,7 @@ describe("scenarios > auth > search", () => {
       cy.signInAsNormalUser();
       cy.visit("/");
       cy.findByPlaceholderText("Search…").type("product{enter}");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Products");
     });
 
@@ -35,6 +36,7 @@ describe("scenarios > auth > search", () => {
       cy.signIn("nodata");
       cy.visit("/");
       cy.findByPlaceholderText("Search…").type("product{enter}");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Didn't find anything");
     });
 

--- a/e2e/test/scenarios/onboarding/setup/setup.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/setup/setup.cy.spec.js
@@ -30,6 +30,7 @@ describe("scenarios > setup", () => {
         },
       });
       cy.location("pathname").should("eq", "/setup");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Welcome to Metabase");
       cy.findByTextEnsureVisible("Let's get started").click();
 
@@ -37,8 +38,10 @@ describe("scenarios > setup", () => {
       // Language
       // ========
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("What's your preferred language?");
       cy.findByLabelText("English");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Next").click();
 
       // ====
@@ -48,6 +51,7 @@ describe("scenarios > setup", () => {
       // "Next" should be disabled on the blank form
       // NOTE: unclear why cy.findByText("Next", { selector: "button" }) doesn't work
       // alternative: cy.contains("Next").should("be.disabled");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Next").closest("button").should("be.disabled");
 
       cy.findByLabelText("First name").type("Testy");
@@ -60,7 +64,9 @@ describe("scenarios > setup", () => {
       cy.findByLabelText("Confirm your password").type("password");
 
       // the form shouldn't be valid yet and we should display an error
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("must include one number", { exact: false });
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Next").closest("button").should("be.disabled");
 
       // now try a strong password that doesn't match
@@ -74,7 +80,9 @@ describe("scenarios > setup", () => {
         .blur();
 
       // tell the user about the mismatch after clicking "Next"
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Next").closest("button").should("be.disabled");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("passwords do not match", { exact: false });
 
       // fix that mismatch
@@ -83,6 +91,7 @@ describe("scenarios > setup", () => {
         .type(strongPassword);
 
       // Submit the first section
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Next").click();
 
       // ========
@@ -90,46 +99,60 @@ describe("scenarios > setup", () => {
       // ========
 
       // The database step should be open
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Add your data");
 
       // test database setup help card is NOT displayed before DB is selected
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Need help connecting?").should("not.be.visible");
 
       // test that you can return to user settings if you want
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Hi, Testy. Nice to meet you!").click();
       cy.findByLabelText("Email").should("have.value", "testy@metabase.test");
 
       // test database setup help card is NOT displayed on other steps
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Need help connecting?").should("not.be.visible");
 
       // now back to database setting
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Next").click();
 
       // check database setup card is visible
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("MySQL").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Need help connecting?").should("be.visible");
 
       cy.findByLabelText("Remove database").click();
       cy.findByPlaceholderText("Search for a database…").type("SQL");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("SQLite").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Need help connecting?");
 
       // add h2 database
       cy.findByLabelText("Remove database").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Show more options").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("H2").click();
       cy.findByLabelText("Display name").type("Metabase H2");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Connect database").closest("button").should("be.disabled");
 
       const dbFilename = "e2e/runner/empty.db";
       const dbPath = Cypress.config("fileServerFolder") + "/" + dbFilename;
       cy.findByLabelText("Connection String").type(`file:${dbPath}`);
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Connect database")
         .closest("button")
         .should("not.be.disabled")
         .click();
 
       // test database setup help card is hidden on the next step
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Need help connecting?").should("not.be.visible");
 
       // ================
@@ -137,23 +160,29 @@ describe("scenarios > setup", () => {
       // ================
 
       // collection defaults to on and describes data collection
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("All collection is completely anonymous.");
       // turn collection off, which hides data collection description
       cy.findByLabelText(
         "Allow Metabase to anonymously collect usage events",
       ).click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("All collection is completely anonymous.").should(
         "not.exist",
       );
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Finish").click();
 
       // ==================
       // Finish & Subscribe
       // ==================
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("You're all set up!");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(
         "Get infrequent emails about new releases and feature updates.",
       );
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Take me to Metabase").click();
       cy.location("pathname").should("eq", "/");
     });
@@ -162,16 +191,20 @@ describe("scenarios > setup", () => {
   it("should set up Metabase without first name and last name (metabase#22754)", () => {
     // This is a simplified version of the "scenarios > setup" test
     cy.visit("/");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Welcome to Metabase");
     cy.location("pathname").should("eq", "/setup");
     cy.findByTextEnsureVisible("Let's get started").click();
 
     // Language
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("What's your preferred language?");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("English").click();
     cy.button("Next").click();
 
     // User
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("What should we call you?");
 
     cy.findByLabelText("Email").type(admin.email);
@@ -181,13 +214,18 @@ describe("scenarios > setup", () => {
     cy.findByLabelText("Confirm your password").type(admin.password);
     cy.button("Next").click();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Hi. Nice to meet you!");
 
     // Database
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Add your data");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("I'll add my data later");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Show more options").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("H2").click();
     cy.findByLabelText("Display name").type("Metabase H2");
 
@@ -200,6 +238,7 @@ describe("scenarios > setup", () => {
     cy.findByLabelText(
       "Allow Metabase to anonymously collect usage events",
     ).click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("All collection is completely anonymous.").should(
       "not.exist",
     );
@@ -207,6 +246,7 @@ describe("scenarios > setup", () => {
 
     // Finish & Subscribe
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Take me to Metabase").click();
     cy.location("pathname").should("eq", "/");
   });
@@ -216,11 +256,14 @@ describe("scenarios > setup", () => {
   it("should allow pre-filling user details", () => {
     cy.visit(`/setup#123456`);
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Welcome to Metabase");
     cy.findByTextEnsureVisible("Let's get started").click();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("What's your preferred language?");
     cy.findByLabelText("English");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Next").click();
 
     cy.findByLabelText("First name").should("have.value", "Testy");
@@ -248,10 +291,12 @@ describeWithSnowplow("scenarios > setup", () => {
     cy.visit(`/setup`);
 
     // 2 - setup/step_seen
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Welcome to Metabase");
     cy.button("Let's get started").click();
 
     // 3 - setup/step_seen
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("What's your preferred language?");
 
     expectGoodSnowplowEvents(3);
@@ -261,6 +306,7 @@ describeWithSnowplow("scenarios > setup", () => {
     blockSnowplow();
     cy.visit(`/setup`);
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Welcome to Metabase");
     cy.button("Let's get started").click();
 

--- a/e2e/test/scenarios/onboarding/setup/user_settings.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/setup/user_settings.cy.spec.js
@@ -15,6 +15,7 @@ describe("user > settings", () => {
 
   it("should be able to remove first name and last name (metabase#22754)", () => {
     cy.visit("/account/profile");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(fullName);
     cy.findByLabelText("First name").clear();
     cy.findByLabelText("Last name").clear();
@@ -42,6 +43,7 @@ describe("user > settings", () => {
     cy.intercept("GET", "/api/permissions/membership").as("membership");
     cy.visit("/account/profile");
     cy.findByDisplayValue(first_name).click().clear().type("John");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Update").click();
     cy.findByDisplayValue("John");
 
@@ -55,6 +57,7 @@ describe("user > settings", () => {
 
     cy.visit("/account/profile");
     cy.wait("@getUser");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Password").should("exist");
   });
 
@@ -62,6 +65,7 @@ describe("user > settings", () => {
     cy.signOut();
     cy.visit("/account/profile");
     cy.url().should("include", "/auth/login");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Sign in to Metabase");
   });
 
@@ -71,11 +75,15 @@ describe("user > settings", () => {
     cy.findByLabelText("Current password").type(password);
     cy.findByLabelText("Create a password").type(password);
     cy.findByLabelText("Confirm your password").type(password);
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Save").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Success");
 
     cy.findByLabelText("gear icon").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Sign out").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Sign in to Metabase");
   });
 
@@ -89,6 +97,7 @@ describe("user > settings", () => {
       .type("qwerty123")
       .blur();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("password is too common");
     cy.get("@passwordInput").clear();
 
@@ -101,6 +110,7 @@ describe("user > settings", () => {
     cy.findByLabelText("Confirm your password").type("new_password1");
 
     cy.button("Save").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Invalid password");
   });
 
@@ -109,7 +119,9 @@ describe("user > settings", () => {
 
     cy.visit("/account/profile");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Use site default").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     popover().within(() => cy.findByText("Indonesian").click());
 
     cy.button("Update").click();
@@ -149,6 +161,7 @@ describe("user > settings", () => {
     });
 
     it("should hide change password tab", () => {
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Password").should("not.exist");
     });
   });
@@ -162,6 +175,7 @@ describe("user > settings", () => {
     });
 
     it("should hide change password tab", () => {
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Password").should("not.exist");
     });
 
@@ -181,6 +195,7 @@ describe("user > settings", () => {
     });
 
     it("should hide change password tab", () => {
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Password").should("not.exist");
     });
 
@@ -199,6 +214,7 @@ describe("user > settings", () => {
     });
 
     it("should hide change password tab", () => {
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Password").should("not.exist");
     });
 

--- a/e2e/test/scenarios/onboarding/urls.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/urls.cy.spec.js
@@ -20,6 +20,7 @@ describe("URLs", () => {
     it(`should slugify database name when opening it from /browse"`, () => {
       cy.visit("/browse");
       cy.findByTextEnsureVisible("Sample Database").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Sample Database");
       cy.location("pathname").should(
         "eq",
@@ -33,6 +34,7 @@ describe("URLs", () => {
     ].forEach(url => {
       it("should open 'Saved Questions' database correctly", () => {
         cy.visit(url);
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("Saved Questions");
         cy.location("pathname").should("eq", url);
       });
@@ -42,6 +44,7 @@ describe("URLs", () => {
   describe("dashboards", () => {
     it("should slugify dashboard URLs", () => {
       cy.visit("/collection/root");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Orders in a dashboard").click();
       cy.location("pathname").should(
         "eq",
@@ -53,6 +56,7 @@ describe("URLs", () => {
   describe("questions", () => {
     it("should slugify question URLs", () => {
       cy.visit("/collection/root");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Orders").click();
       cy.location("pathname").should("eq", "/question/1-orders");
     });
@@ -61,12 +65,14 @@ describe("URLs", () => {
   describe("collections", () => {
     it("should slugify collection name", () => {
       cy.visit("/collection/root");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("First collection").click();
       cy.location("pathname").should("eq", "/collection/9-first-collection");
     });
 
     it("should slugify current user's personal collection name correctly", () => {
       cy.visit("/collection/root");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Your personal collection").click();
       cy.location("pathname").should(
         "eq",
@@ -80,12 +86,14 @@ describe("URLs", () => {
         cy.icon("ellipsis").click();
       });
       popover().findByText("Other users' personal collections").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("All personal collections");
       cy.location("pathname").should("eq", "/collection/users");
     });
 
     it("should slugify users' personal collection URLs", () => {
       cy.visit("/collection/users");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(getFullName(normal)).click();
       cy.location("pathname").should(
         "eq",

--- a/e2e/test/scenarios/organization/bookmarks-collection.cy.spec.js
+++ b/e2e/test/scenarios/organization/bookmarks-collection.cy.spec.js
@@ -76,6 +76,7 @@ describe("scenarios > organization > bookmarks > collection", () => {
     cy.visit("/collection/root");
 
     pin(name);
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(/Rows/);
     bookmarkPinnedItem(name);
   });
@@ -89,6 +90,7 @@ describe("scenarios > organization > bookmarks > collection", () => {
     cy.visit("/collection/root");
 
     pin(name);
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("A dashboard");
     bookmarkPinnedItem(name);
   });

--- a/e2e/test/scenarios/organization/bookmarks-question.cy.spec.js
+++ b/e2e/test/scenarios/organization/bookmarks-question.cy.spec.js
@@ -33,7 +33,9 @@ describe("scenarios > question > bookmarks", () => {
 
     // Convert to model
     openQuestionActions();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Turn into a model").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Turn this into a model").click();
 
     navigationSidebar().within(() => {
@@ -42,6 +44,7 @@ describe("scenarios > question > bookmarks", () => {
 
     // Convert back to question
     openQuestionActions();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Turn back to saved question").click();
 
     navigationSidebar().within(() => {

--- a/e2e/test/scenarios/organization/edit-history-metadata.cy.spec.js
+++ b/e2e/test/scenarios/organization/edit-history-metadata.cy.spec.js
@@ -14,12 +14,14 @@ describe("scenarios > collection items metadata", () => {
     it("should display last edit moment for dashboards", () => {
       visitDashboard(1);
       changeDashboard();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(/Edited a few seconds ago/i);
     });
 
     it("should display last edit moment for questions", () => {
       visitQuestion(1);
       changeQuestion();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(/Edited a few seconds ago/i);
     });
   });
@@ -28,8 +30,10 @@ describe("scenarios > collection items metadata", () => {
     it("should display if user is the last editor", () => {
       cy.signInAsAdmin();
       visitDashboard(1);
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(/Edited .* by you/i);
       visitQuestion(1);
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(/Edited .* by you/i);
     });
 
@@ -40,8 +44,10 @@ describe("scenarios > collection items metadata", () => {
 
       cy.signIn("normal");
       visitDashboard(1);
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(new RegExp(`Edited .* by ${expectedName}`, "i"));
       visitQuestion(1);
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(new RegExp(`Edited .* by ${expectedName}`, "i"));
     });
 
@@ -53,12 +59,15 @@ describe("scenarios > collection items metadata", () => {
       cy.visit("/collection/root");
       // Ensure nothing is edited by current user,
       // Otherwise, the test is irrelevant
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(fullName).should("not.exist");
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Orders").click();
       changeQuestion();
 
       cy.visit("/collection/root");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Orders in a dashboard").click();
       changeDashboard();
 

--- a/e2e/test/scenarios/organization/moderation-question.cy.spec.js
+++ b/e2e/test/scenarios/organization/moderation-question.cy.spec.js
@@ -29,6 +29,7 @@ describeEE("scenarios > saved question moderation", () => {
 
       // 2. Question's history
       questionInfoButton().click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("History");
       cy.findAllByText("You verified this")
         .should("have.length", 2)
@@ -48,6 +49,7 @@ describeEE("scenarios > saved question moderation", () => {
 
       // 5. Question's collection
       cy.visit("/collection/root");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Orders, Count").closest("a").find(".Icon-verified");
 
       // Let's go back to the question and remove the verification
@@ -62,8 +64,11 @@ describeEE("scenarios > saved question moderation", () => {
 
       // 2. Question's history
       questionInfoButton().click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("History");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("You removed verification");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("You verified this"); // Implicit assertion - there can be only one :)
 
       // 3. Recently viewed list
@@ -82,6 +87,7 @@ describeEE("scenarios > saved question moderation", () => {
 
       // 5. Question's collection
       cy.visit("/collection/root");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Orders, Count")
         .closest("a")
         .find(".Icon-verified")
@@ -109,15 +115,18 @@ describeEE("scenarios > saved question moderation", () => {
       cy.icon("verified").should("not.exist");
 
       questionInfoButton().click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(`${adminFullName} verified this`).should("not.exist");
 
       cy.findByPlaceholderText("Search…").type("orders{enter}");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Orders, Count, Grouped by Created At (year)")
         .find(".Icon-verified")
         .should("not.exist");
 
       cy.visit("/collection/root");
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Orders, Count, Grouped by Created At (year)")
         .find(".Icon-verified")
         .should("not.exist");
@@ -132,10 +141,12 @@ describeEE("scenarios > saved question moderation", () => {
       cy.findAllByText(`${adminFullName} verified this`);
 
       cy.findByPlaceholderText("Search…").type("orders{enter}");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Orders, Count").icon("verified");
 
       cy.visit("/collection/root");
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Orders, Count").icon("verified");
     });
   });

--- a/e2e/test/scenarios/organization/timelines-collection.cy.spec.js
+++ b/e2e/test/scenarios/organization/timelines-collection.cy.spec.js
@@ -34,40 +34,51 @@ describe("scenarios > organization > timelines > collection", () => {
       cy.visit("/collection/root");
       cy.icon("calendar").click();
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Add an event").click();
       cy.findByLabelText("Event name").type("RC1");
       cy.findByLabelText("Date").type("10/20/2020");
       cy.button("Create").click();
       cy.wait("@createEvent");
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("RC1").should("be.visible");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("October 20, 2020").should("be.visible");
       cy.icon("star").should("be.visible");
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Add an event").click();
       cy.findByLabelText("Event name").type("RC2");
       cy.findByLabelText("Date").type("5/12/2021");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Star").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Balloons").click();
       cy.button("Create").click();
       cy.wait("@createEvent");
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("RC2").should("be.visible");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("May 12, 2021").should("be.visible");
       cy.icon("balloons").should("be.visible");
     });
 
     it("should create an event in a personal collection", () => {
       cy.visit("/collection/root");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Your personal collection").click();
       cy.icon("calendar").click();
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Add an event").click();
       cy.findByLabelText("Event name").type("RC1");
       cy.findByLabelText("Date").type("10/20/2020");
       cy.button("Create").click();
       cy.wait("@createEvent");
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("RC1").should("be.visible");
     });
 
@@ -84,9 +95,13 @@ describe("scenarios > organization > timelines > collection", () => {
       cy.visit("/collection/root/timelines");
 
       cy.findByPlaceholderText("Search for an event").type("V1");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("v1.0").should("be.visible");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("v1.1").should("be.visible");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("RC1").should("not.exist");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("RC2").should("not.exist");
     });
 
@@ -94,6 +109,7 @@ describe("scenarios > organization > timelines > collection", () => {
       cy.visit("/collection/root");
 
       cy.icon("calendar").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Add an event").click();
 
       cy.findByLabelText("Event name").type("RC1");
@@ -101,13 +117,19 @@ describe("scenarios > organization > timelines > collection", () => {
       getModal().within(() => {
         cy.findByRole("button", { name: "calendar icon" }).click();
       });
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("15").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Done").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Create").click();
       cy.wait("@createEvent");
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Our analytics events").should("be.visible");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("RC1").should("be.visible");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("AM").should("not.exist");
     });
 
@@ -115,17 +137,23 @@ describe("scenarios > organization > timelines > collection", () => {
       cy.visit("/collection/root");
 
       cy.icon("calendar").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Add an event").click();
 
       cy.findByLabelText("Event name").type("RC1");
       cy.findByLabelText("Date").type("5/12/2021");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Markdown supported").should("be.visible");
       cy.findByLabelText("Description").type("*1.0-rc1* release");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Create").click();
       cy.wait("@createEvent");
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Our analytics events").should("be.visible");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("RC1").should("be.visible");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("1.0-rc1").should("be.visible");
     });
 
@@ -133,6 +161,7 @@ describe("scenarios > organization > timelines > collection", () => {
       cy.visit("/collection/root");
 
       cy.icon("calendar").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Add an event").click();
 
       cy.findByLabelText("Event name").type("RC1");
@@ -140,16 +169,23 @@ describe("scenarios > organization > timelines > collection", () => {
       getModal().within(() => {
         cy.findByRole("button", { name: "calendar icon" }).click();
       });
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("15").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Add time").click();
       cy.findByLabelText("Hours").clear().type("10");
       cy.findByLabelText("Minutes").clear().type("20");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Done").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Create").click();
       cy.wait("@createEvent");
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Our analytics events").should("be.visible");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("RC1").should("be.visible");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(/10:20 AM/).should("be.visible");
     });
 
@@ -157,6 +193,7 @@ describe("scenarios > organization > timelines > collection", () => {
       cy.visit("/collection/root");
 
       cy.icon("calendar").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Add an event").click();
 
       cy.findByLabelText("Event name").type("RC1");
@@ -164,14 +201,21 @@ describe("scenarios > organization > timelines > collection", () => {
       getModal().within(() => {
         cy.findByRole("button", { name: "calendar icon" }).click();
       });
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("15").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Add time").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Done").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Create").click();
       cy.wait("@createEvent");
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Our analytics events").should("be.visible");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("RC1").should("be.visible");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(/12:00 AM/).should("be.visible");
     });
 
@@ -180,11 +224,13 @@ describe("scenarios > organization > timelines > collection", () => {
       cy.visit("/collection/root/timelines");
 
       openMenu("RC1");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Edit event").click();
       cy.findByLabelText("Event name").clear().type("RC2");
       cy.button("Update").click();
       cy.wait("@updateEvent");
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("RC2").should("be.visible");
     });
 
@@ -199,17 +245,24 @@ describe("scenarios > organization > timelines > collection", () => {
       });
 
       cy.visit("/collection/root/timelines");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Metrics").click();
       openMenu("RC2");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Move event").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Releases").click();
       getModal().within(() => cy.button("Move").click());
       cy.wait("@updateEvent");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("RC2").should("not.exist");
 
       cy.icon("chevronleft").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Releases").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("RC1");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("RC2");
     });
 
@@ -224,16 +277,22 @@ describe("scenarios > organization > timelines > collection", () => {
       });
 
       cy.visit("/collection/root/timelines");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Metrics").click();
       openMenu("RC2");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Move event").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Releases").click();
       getModal().within(() => cy.button("Move").click());
       cy.wait("@updateEvent");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("RC2").should("not.exist");
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Undo").click();
       cy.wait("@updateEvent");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("RC2").should("be.visible");
     });
 
@@ -246,11 +305,15 @@ describe("scenarios > organization > timelines > collection", () => {
       cy.visit("/collection/root/timelines");
 
       openMenu("RC1");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Edit event").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Archive event").click();
       cy.wait("@updateEvent");
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Releases").should("be.visible");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("RC1").should("not.exist");
     });
 
@@ -263,12 +326,16 @@ describe("scenarios > organization > timelines > collection", () => {
       cy.visit("/collection/root/timelines");
 
       openMenu("RC1");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Archive event").click();
       cy.wait("@updateEvent");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("RC1").should("not.exist");
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Undo").click();
       cy.wait("@updateEvent");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("RC1").should("be.visible");
     });
 
@@ -280,17 +347,23 @@ describe("scenarios > organization > timelines > collection", () => {
 
       cy.visit("/collection/root/timelines");
       openMenu("Releases");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("View archived events").click();
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Archived events").should("be.visible");
       openMenu("RC1");
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Unarchive event").click();
       cy.wait("@updateEvent");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("No events found").should("be.visible");
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Undo").click();
       cy.wait("@updateEvent");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("RC1").should("be.visible");
     });
 
@@ -302,13 +375,18 @@ describe("scenarios > organization > timelines > collection", () => {
 
       cy.visit("/collection/root/timelines");
       openMenu("Releases");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("View archived events").click();
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Archived events").should("be.visible");
       openMenu("RC1");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Delete event").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Delete").click();
       cy.wait("@deleteEvent");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("No events found").should("be.visible");
     });
 
@@ -317,10 +395,13 @@ describe("scenarios > organization > timelines > collection", () => {
       cy.createTimeline({ name: "Metrics" });
 
       cy.visit(`/collection/root/timelines/1`);
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Releases");
 
       cy.icon("chevronleft").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Releases");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Metrics");
     });
 
@@ -328,6 +409,7 @@ describe("scenarios > organization > timelines > collection", () => {
       cy.createTimeline({ name: "Releases" });
 
       cy.visit(`/collection/root/timelines/1`);
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Releases");
       cy.icon("chevronleft").should("not.exist");
     });
@@ -340,12 +422,16 @@ describe("scenarios > organization > timelines > collection", () => {
 
       cy.visit("/collection/root/timelines");
       openMenu("Releases");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("New timeline").click();
       cy.findByLabelText("Name").type("Launches");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Create").click();
       cy.wait("@createTimeline");
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Launches").should("be.visible");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Add an event").should("be.visible");
     });
 
@@ -357,11 +443,14 @@ describe("scenarios > organization > timelines > collection", () => {
 
       cy.visit("/collection/root/timelines");
       openMenu("Releases");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Edit timeline details").click();
       cy.findByLabelText("Name").clear().type("Launches");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Update").click();
       cy.wait("@updateTimeline");
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Launches").should("be.visible");
     });
 
@@ -373,6 +462,7 @@ describe("scenarios > organization > timelines > collection", () => {
 
       cy.visit("/collection/root/timelines");
       openMenu("Our analytics events");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Move timeline").click();
 
       getModal().within(() => {
@@ -381,7 +471,9 @@ describe("scenarios > organization > timelines > collection", () => {
         cy.wait("@updateTimeline");
       });
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Our analytics events").should("be.visible");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(`${getFullName(admin)}'s Personal Collection`).should(
         "be.visible",
       );
@@ -395,16 +487,24 @@ describe("scenarios > organization > timelines > collection", () => {
 
       cy.visit("/collection/root/timelines");
       openMenu("Releases");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Edit timeline details").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Archive timeline and all events").click();
       cy.wait("@updateTimeline");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Our analytics events").should("be.visible");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Add an event").should("be.visible");
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Undo").click();
       cy.wait("@updateTimeline");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Releases").should("be.visible");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("RC1").should("be.visible");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("RC2").should("be.visible");
     });
 
@@ -420,7 +520,9 @@ describe("scenarios > organization > timelines > collection", () => {
       });
 
       cy.visit("/collection/root/timelines");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Release notes").should("be.visible");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Holiday list").should("be.visible");
     });
 
@@ -438,6 +540,7 @@ describe("scenarios > organization > timelines > collection", () => {
       });
 
       cy.visit("/collection/root/timelines");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Release notes").should("be.visible");
     });
 
@@ -449,18 +552,24 @@ describe("scenarios > organization > timelines > collection", () => {
 
       cy.visit("/collection/root/timelines");
       openMenu("Releases");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Edit timeline details").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Archive timeline and all events").click();
       cy.wait("@updateTimeline");
 
       openMenu("Our analytics events");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("View archived timelines").click();
 
       openMenu("Releases");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Unarchive timeline").click();
       cy.wait("@updateTimeline");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("No timelines found");
       getModal().within(() => cy.icon("chevronleft").click());
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Releases");
     });
 
@@ -472,31 +581,41 @@ describe("scenarios > organization > timelines > collection", () => {
 
       cy.visit("/collection/root/timelines");
       openMenu("Releases");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Edit timeline details").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Archive timeline and all events").click();
       cy.wait("@updateTimeline");
 
       openMenu("Our analytics events");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("View archived timelines").click();
 
       openMenu("Releases");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Delete timeline").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Delete").click();
       cy.wait("@deleteTimeline");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("No timelines found");
       getModal().within(() => cy.icon("chevronleft").click());
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Our analytics events");
     });
 
     it("should preserve collection names for default timelines", () => {
       cy.visit("/");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("First collection").click();
 
       cy.icon("calendar").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Add an event").click();
       cy.findByLabelText("Event name").type("RC1");
       cy.findByLabelText("Date").type("10/20/2020");
       cy.button("Create").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("First collection events");
       cy.wait("@createTimeline");
       cy.icon("close").click();
@@ -509,10 +628,12 @@ describe("scenarios > organization > timelines > collection", () => {
 
       cy.icon("calendar").click();
       openMenu("1st collection events");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Edit timeline details").click();
       cy.findByLabelText("Name").clear().type("Releases");
       cy.button("Update").click();
       cy.wait("@updateTimeline");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Releases");
     });
 
@@ -526,12 +647,14 @@ describe("scenarios > organization > timelines > collection", () => {
       cy.visit("/collection/root/timelines");
 
       openMenu("RC1");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Edit event").click();
       cy.findByDisplayValue("2022/10/12").should("be.visible");
 
       cy.findByLabelText("Date").clear().type("2022/10/15");
       cy.button("Update").click();
       cy.wait("@updateEvent");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("2022/10/15").should("be.visible");
     });
 
@@ -545,6 +668,7 @@ describe("scenarios > organization > timelines > collection", () => {
       cy.visit("/collection/root/timelines");
 
       openMenu("RC1");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Edit event").click();
       getModal().within(() => {
         cy.findByRole("button", { name: "calendar icon" }).click();
@@ -562,7 +686,9 @@ describe("scenarios > organization > timelines > collection", () => {
       cy.visit("/collection/root");
 
       cy.icon("calendar").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Our analytics events").should("be.visible");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Add an event").should("not.exist");
     });
 
@@ -577,7 +703,9 @@ describe("scenarios > organization > timelines > collection", () => {
       cy.signIn("readonly");
       cy.visit("/collection/root");
       cy.icon("calendar").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Releases").should("be.visible");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Add an event").should("not.exist");
     });
   });
@@ -603,6 +731,7 @@ describeWithSnowplow("scenarios > collections > timelines", () => {
     // 3 - pageview
     cy.icon("calendar").click();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Add an event").click();
     cy.findByLabelText("Event name").type("Event");
     cy.findByLabelText("Date").type("10/20/2020");

--- a/e2e/test/scenarios/organization/timelines-question.cy.spec.js
+++ b/e2e/test/scenarios/organization/timelines-question.cy.spec.js
@@ -25,9 +25,11 @@ describe("scenarios > organization > timelines > question", () => {
     it("should create the first event and timeline", () => {
       visitQuestion(3);
       cy.wait("@getCollection");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Visualization").should("be.visible");
 
       cy.icon("calendar").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Add an event").click();
 
       cy.findByLabelText("Event name").type("RC1");
@@ -35,7 +37,9 @@ describe("scenarios > organization > timelines > question", () => {
       cy.button("Create").click();
       cy.wait("@createEvent");
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Our analytics events").should("be.visible");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("RC1").should("be.visible");
     });
 
@@ -47,9 +51,11 @@ describe("scenarios > organization > timelines > question", () => {
 
       visitQuestion(3);
       cy.wait("@getCollection");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Visualization").should("be.visible");
 
       cy.icon("calendar").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Add an event").click();
 
       cy.findByLabelText("Event name").type("RC2");
@@ -57,8 +63,11 @@ describe("scenarios > organization > timelines > question", () => {
       cy.button("Create").click();
       cy.wait("@createEvent");
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Releases").should("be.visible");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("RC1").should("be.visible");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("RC2").should("be.visible");
     });
 
@@ -74,16 +83,23 @@ describe("scenarios > organization > timelines > question", () => {
 
       visitQuestion(3);
       cy.wait("@getCollection");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Visualization").should("be.visible");
 
       cy.findByLabelText("calendar icon").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("v1").should("not.exist");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("v2").should("be.visible");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("v3").should("be.visible");
 
       cy.findByLabelText("table2 icon").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("v1").should("be.visible");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("v2").should("be.visible");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("v3").should("be.visible");
     });
 
@@ -95,18 +111,24 @@ describe("scenarios > organization > timelines > question", () => {
 
       visitQuestion(3);
       cy.wait("@getCollection");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Visualization").should("be.visible");
 
       cy.icon("calendar").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Releases").should("be.visible");
       rightSidebar().within(() => cy.icon("ellipsis").click());
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Edit event").click();
 
       cy.findByLabelText("Event name").clear().type("RC2");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Update").click();
       cy.wait("@updateEvent");
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Releases").should("be.visible");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("RC2").should("be.visible");
     });
 
@@ -121,17 +143,23 @@ describe("scenarios > organization > timelines > question", () => {
 
       visitQuestion(3);
       cy.wait("@getCollection");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Visualization").should("be.visible");
 
       cy.icon("calendar").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Builds").should("be.visible");
       rightSidebar().within(() => cy.icon("ellipsis").click());
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Move event").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Releases").click();
       cy.button("Move").click();
       cy.wait("@updateEvent");
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Builds").should("not.exist");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Releases").should("be.visible");
     });
 
@@ -143,17 +171,23 @@ describe("scenarios > organization > timelines > question", () => {
 
       visitQuestion(3);
       cy.wait("@getCollection");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Visualization").should("be.visible");
 
       cy.icon("calendar").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Releases").should("be.visible");
       rightSidebar().within(() => cy.icon("ellipsis").click());
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Archive event").click();
       cy.wait("@updateEvent");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("RC1").should("not.exist");
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Undo").click();
       cy.wait("@updateEvent");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("RC1").should("be.visible");
     });
 
@@ -173,7 +207,9 @@ describe("scenarios > organization > timelines > question", () => {
       visitQuestion(3);
       cy.icon("calendar").click();
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Releases").should("be.visible");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Release notes").should("be.visible");
     });
 
@@ -200,6 +236,7 @@ describe("scenarios > organization > timelines > question", () => {
         },
       });
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Visualization").should("be.visible");
       cy.findByLabelText("star icon").should("be.visible");
     });
@@ -229,6 +266,7 @@ describe("scenarios > organization > timelines > question", () => {
         },
       });
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Visualization").should("be.visible");
       cy.findByLabelText("star icon").should("not.exist");
     });
@@ -254,6 +292,7 @@ describe("scenarios > organization > timelines > question", () => {
         },
       });
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Visualization").should("be.visible");
       cy.findByLabelText("star icon").should("be.visible");
     });
@@ -275,11 +314,13 @@ describe("scenarios > organization > timelines > question", () => {
 
       visitQuestion(3);
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Visualization").should("be.visible");
       cy.findByLabelText("cloud icon").should("be.visible");
 
       // should hide individual events from chart if hidden in sidebar
       cy.icon("calendar").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Releases").click();
       toggleEventVisibility("RC1");
 
@@ -314,6 +355,7 @@ describe("scenarios > organization > timelines > question", () => {
 
       // its timeline, visible but having one hidden event
       // should display its checkbox with a "dash" icon
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Releases")
         .closest("[aria-label=Timeline card header]")
         .within(() => {
@@ -332,8 +374,10 @@ describe("scenarios > organization > timelines > question", () => {
 
       // should initialize events in a hidden timelime
       // with event checkboxes unchecked
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Timeline for collection").click();
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("TC1")
         .closest("[aria-label=Timeline event card]")
         .within(() => {
@@ -342,6 +386,7 @@ describe("scenarios > organization > timelines > question", () => {
 
       // making a hidden timeline visible
       // should make its events automatically visible
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Timeline for collection")
         .closest("[aria-label=Timeline card header]")
         .within(() => cy.findByRole("checkbox").click());
@@ -364,10 +409,13 @@ describe("scenarios > organization > timelines > question", () => {
     it("should not allow creating default timelines", () => {
       cy.signIn("readonly");
       visitQuestion(3);
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Created At").should("be.visible");
 
       cy.icon("calendar").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(/Events in Metabase/);
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Add an event").should("not.exist");
     });
 
@@ -380,10 +428,13 @@ describe("scenarios > organization > timelines > question", () => {
       cy.signOut();
       cy.signIn("readonly");
       visitQuestion(3);
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Created At").should("be.visible");
 
       cy.icon("calendar").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Releases").should("be.visible");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Add an event").should("not.exist");
       rightSidebar().within(() => cy.icon("ellipsis").should("not.exist"));
     });

--- a/e2e/test/scenarios/permissions/admin-permissions.cy.spec.js
+++ b/e2e/test/scenarios/permissions/admin-permissions.cy.spec.js
@@ -65,11 +65,15 @@ describe("scenarios > admin > permissions", { tags: "@OSS" }, () => {
     cy.intercept("PUT", "/api/permissions/graph", req => {
       req.reply(500, "Server error");
     });
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Save changes").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("button", "Yes").click();
 
     // see error modal
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Server error");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("There was an error saving");
   });
 
@@ -192,6 +196,7 @@ describe("scenarios > admin > permissions", { tags: "@OSS" }, () => {
         cy.button("Yes").click();
       });
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Save changes").should("not.exist");
 
       assertPermissionTable([
@@ -283,6 +288,7 @@ describe("scenarios > admin > permissions", { tags: "@OSS" }, () => {
         "Unrestricted",
       );
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("You've made changes to permissions.");
 
       // Switching to databases focus should not show any warnings
@@ -320,6 +326,7 @@ describe("scenarios > admin > permissions", { tags: "@OSS" }, () => {
         cy.visit("/admin/permissions");
 
         // no groups selected initially and it shows an empty state
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("Select a group to see its data permissions");
 
         const groups = [
@@ -359,7 +366,9 @@ describe("scenarios > admin > permissions", { tags: "@OSS" }, () => {
           `/admin/permissions/data/group/${ADMIN_GROUP}`,
         );
 
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("Permissions for the Administrators group");
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("1 person");
 
         assertPermissionTable([["Sample Database", "Unrestricted", "Yes"]]);
@@ -467,6 +476,7 @@ describe("scenarios > admin > permissions", { tags: "@OSS" }, () => {
           cy.button("Yes").click();
         });
 
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("Save changes").should("not.exist");
 
         assertPermissionTable([
@@ -488,6 +498,7 @@ describe("scenarios > admin > permissions", { tags: "@OSS" }, () => {
 
         cy.get("label").contains("Databases").click();
 
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("Select a database to see group permissions");
 
         selectSidebarItem("Sample Database");
@@ -573,6 +584,7 @@ describe("scenarios > admin > permissions", { tags: "@OSS" }, () => {
           cy.button("Yes").click();
         });
 
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("Save changes").should("not.exist");
 
         assertPermissionTable([
@@ -610,13 +622,18 @@ describeEE("scenarios > admin > permissions", () => {
       "include",
       `/admin/permissions/data/database/${SAMPLE_DB_ID}/schema/PUBLIC/table/${ORDERS_ID}/segmented/group/${ALL_USERS_GROUP}`,
     );
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Grant sandboxed access to this table");
     cy.button("Save").should("be.disabled");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Pick a column").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("User ID").click();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Pick a user attribute").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("attr_uid").click();
     cy.button("Save").click();
 
@@ -639,9 +656,11 @@ describeEE("scenarios > admin > permissions", () => {
       "include",
       `/admin/permissions/data/database/${SAMPLE_DB_ID}/schema/PUBLIC/table/${ORDERS_ID}/segmented/group/${ALL_USERS_GROUP}`,
     );
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Grant sandboxed access to this table");
 
     cy.button("Save").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Grant sandboxed access to this table").should("not.exist");
 
     cy.button("Save changes").click();
@@ -659,6 +678,7 @@ describeEE("scenarios > admin > permissions", () => {
   it("'block' data permission should not have editable 'native query editing' option (metabase#17738)", () => {
     cy.visit(`/admin/permissions/data/database/${SAMPLE_DB_ID}`);
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("All Users")
       .closest("tr")
       .as("allUsersRow")
@@ -691,8 +711,10 @@ describeEE("scenarios > admin > permissions", () => {
     cy.signIn("nodata");
     visitQuestion(1);
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("There was a problem with your question");
     cy.findByTestId("viz-settings-button").should("not.exist");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Visualization").should("not.exist");
   });
 
@@ -708,6 +730,7 @@ describeEE("scenarios > admin > permissions", () => {
     cy.signIn("nodata");
     visitDashboard(1);
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Sorry, you don't have permission to see this card.");
   });
 });

--- a/e2e/test/scenarios/permissions/application-permissions.cy.spec.js
+++ b/e2e/test/scenarios/permissions/application-permissions.cy.spec.js
@@ -68,12 +68,14 @@ describeEE("scenarios > admin > permissions > application", () => {
       it("gives ability to create dashboard subscriptions", () => {
         visitDashboard(1);
         cy.icon("subscription").click();
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("Create a dashboard subscription");
       });
 
       it("gives ability to create question alerts", () => {
         visitQuestion(1);
         cy.icon("bell").click();
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText(
           "To send alerts, an admin needs to set up email integration.",
         );
@@ -113,21 +115,29 @@ describeEE("scenarios > admin > permissions > application", () => {
         cy.visit("/");
         cy.icon("gear").click();
 
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("Admin settings").click();
 
         // Tools smoke test
         cy.url().should("include", "/admin/tools/errors");
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("Questions that errored when last run");
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("broken_question");
 
         // Audit smoke test
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("Audit").click();
         cy.url().should("include", "/admin/audit/members/overview");
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("All members").click();
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText(getFullName(admin));
 
         // Troubleshooting smoke test
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("Troubleshooting").click();
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("Diagnostic Info");
       });
     });
@@ -138,15 +148,19 @@ describeEE("scenarios > admin > permissions > application", () => {
         cy.visit("/");
         cy.icon("gear").click();
 
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("Admin settings").should("not.exist");
 
         cy.visit("/admin/tools/errors");
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("Sorry, you don’t have permission to see that.");
 
         cy.visit("/admin/tools/errors");
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("Sorry, you don’t have permission to see that.");
 
         cy.visit("/admin/troubleshooting/help");
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("Sorry, you don’t have permission to see that.");
       });
     });
@@ -174,17 +188,22 @@ describeEE("scenarios > admin > permissions > application", () => {
         cy.visit("/");
         cy.icon("gear").click();
 
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("Admin settings").click();
 
         cy.url().should("include", "/admin/settings/general");
 
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("License and Billing").should("not.exist");
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("Setup").should("not.exist");
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("Updates").should("not.exist");
 
         // General smoke test
         cy.get("#setting-site-name").clear().type("new name").blur();
 
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("Saved");
       });
     });

--- a/e2e/test/scenarios/permissions/data-model-permissions.cy.spec.js
+++ b/e2e/test/scenarios/permissions/data-model-permissions.cy.spec.js
@@ -45,11 +45,15 @@ describeEE("scenarios > admin > permissions", () => {
 
     // Go to the admin settings
     cy.icon("gear").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Admin settings").click();
 
     // Assert the Data Model page state
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Data Model");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("1 Queryable Table");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Orders").click();
 
     cy.wait("@tableMetadataFetch");
@@ -63,10 +67,13 @@ describeEE("scenarios > admin > permissions", () => {
       .blur();
     cy.wait("@tableUpdate");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Updated Table display_name");
 
     // Update the table visibility
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Hidden").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("1 Hidden Table");
   });
 
@@ -87,14 +94,21 @@ describeEE("scenarios > admin > permissions", () => {
 
     // Go to the admin settings
     cy.icon("gear").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Admin settings").click();
 
     // Assert the Data Model page state
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Data Model");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("4 Queryable Tables");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Orders");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Products");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("People");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Reviews");
   });
 

--- a/e2e/test/scenarios/permissions/database-details-permissions.cy.spec.js
+++ b/e2e/test/scenarios/permissions/database-details-permissions.cy.spec.js
@@ -45,6 +45,7 @@ describeEE(
 
       cy.visit("/");
       cy.icon("gear").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Admin settings").should("be.visible").click();
 
       cy.location("pathname").should("eq", "/admin/databases");
@@ -54,6 +55,7 @@ describeEE(
         .and("not.contain", "Settings")
         .and("not.contain", "Data Model");
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Sample Database").click();
 
       cy.findByTestId("database-actions-panel")

--- a/e2e/test/scenarios/permissions/download-permissions.cy.spec.js
+++ b/e2e/test/scenarios/permissions/download-permissions.cy.spec.js
@@ -98,6 +98,7 @@ describeEE("scenarios > admin > permissions > data > downloads", () => {
 
     visitQuestion("1");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Showing first 2,000 rows");
     cy.icon("download").should("not.exist");
   });
@@ -116,6 +117,7 @@ describeEE("scenarios > admin > permissions > data > downloads", () => {
 
     visitQuestion("1");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Showing first 2,000 rows");
     cy.icon("download").should("not.exist");
 

--- a/e2e/test/scenarios/permissions/permissions-baseline.cy.spec.js
+++ b/e2e/test/scenarios/permissions/permissions-baseline.cy.spec.js
@@ -49,6 +49,7 @@ describe("scenarios > permissions", () => {
   it("should let a user with no data permissions view questions", () => {
     cy.signIn("nodata");
     visitQuestion(1);
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("February 11, 2019, 9:40 PM"); // check that the data loads
   });
 });

--- a/e2e/test/scenarios/permissions/reproductions/13347-cannot-select-saved-question-in-database-without-data-permissions.cy.spec.js
+++ b/e2e/test/scenarios/permissions/reproductions/13347-cannot-select-saved-question-in-database-without-data-permissions.cy.spec.js
@@ -45,11 +45,14 @@ describe.skip("issue 13347", { tags: "@external" }, () => {
       cy.signIn("none");
 
       startNewQuestion();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Saved Questions").click();
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       test === "QB" ? cy.findByText("Q1").click() : cy.findByText("Q2").click();
 
       cy.wait("@dataset", { timeout: 5000 });
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("37.65");
     });
   });

--- a/e2e/test/scenarios/permissions/reproductions/17763-cannot-edit-granular-after-block.cy.spec.js
+++ b/e2e/test/scenarios/permissions/reproductions/17763-cannot-edit-granular-after-block.cy.spec.js
@@ -18,6 +18,7 @@ describeEE("issue 17763", () => {
   it('should be able to edit tables permissions in granular view after "block" permissions (metabase#17763)', () => {
     cy.visit(`/admin/permissions/data/database/${SAMPLE_DB_ID}`);
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Block").click();
 
     popover().contains("Granular").click();

--- a/e2e/test/scenarios/permissions/reproductions/17777-hidden-tables-not-available.cy.spec.js
+++ b/e2e/test/scenarios/permissions/reproductions/17777-hidden-tables-not-available.cy.spec.js
@@ -17,6 +17,7 @@ describe.skip("issue 17777", () => {
   it("should still be able to set permissions on individual tables, even though they are hidden in data model (metabase#17777)", () => {
     cy.visit(`/admin/permissions/data/group/${ALL_USERS_GROUP}`);
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Permissions for the All Users group");
     cy.findByTextEnsureVisible("Sample Database").click();
 

--- a/e2e/test/scenarios/permissions/reproductions/19603-archived-sub-collection-shows-up-in-permissions.cy.spec.js
+++ b/e2e/test/scenarios/permissions/reproductions/19603-archived-sub-collection-shows-up-in-permissions.cy.spec.js
@@ -16,7 +16,9 @@ describe("issue 19603", () => {
   it("archived subcollection should not show up in permissions (metabase#19603)", () => {
     cy.visit("/admin/permissions/collections");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("First collection").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Second collection").should("not.exist");
   });
 });

--- a/e2e/test/scenarios/permissions/reproductions/20436-incorrect-display-of-database-permissions-level.cy.spec.js
+++ b/e2e/test/scenarios/permissions/reproductions/20436-incorrect-display-of-database-permissions-level.cy.spec.js
@@ -21,9 +21,11 @@ describe("issue 20436", () => {
 
   it("should display correct permissions on the database level after changes on the table level (metabase#20436)", () => {
     cy.visit(url);
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Unrestricted");
 
     // Go the the view where we can change permissions for individual tables
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Sample Database").click();
 
     // Change the permission levels for ANY of the tables - it doesn't matter which one
@@ -40,6 +42,7 @@ describe("issue 20436", () => {
     cy.wait("@updatePermissions");
 
     cy.visit(url);
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Unrestricted");
   });
 });

--- a/e2e/test/scenarios/permissions/reproductions/22447-illogical-UI-elements-for-nodata.cy.spec.js
+++ b/e2e/test/scenarios/permissions/reproductions/22447-illogical-UI-elements-for-nodata.cy.spec.js
@@ -14,6 +14,7 @@ describe("UI elements that make no sense for users without data permissions (met
     visitQuestion("1");
 
     cy.findByTestId("viz-settings-button");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Visualization").click();
 
     cy.findByTestId("display-options-sensible");
@@ -24,12 +25,14 @@ describe("UI elements that make no sense for users without data permissions (met
     });
 
     cy.findByTextEnsureVisible("Line options");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Save")
       .as("saveButton")
       .invoke("css", "pointer-events")
       .should("equal", "none");
 
     cy.get("@saveButton").realHover();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("You don't have permission to save this question.");
 
     cy.findByTestId("qb-header-action-panel").within(() => {
@@ -37,6 +40,7 @@ describe("UI elements that make no sense for users without data permissions (met
     });
 
     cy.visit("/collection/root");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("New").click();
 
     popover()
@@ -65,12 +69,14 @@ describe("UI elements that make no sense for users without data permissions (met
     cy.findByTextEnsureVisible("There was a problem with your question");
 
     cy.findByTestId("viz-settings-button").should("not.exist");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Visualization").should("not.exist");
 
     cy.findByTestId("qb-header-action-panel").within(() => {
       cy.icon("refresh").should("not.exist");
     });
     cy.visit("/collection/root");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("New").click();
 
     popover()

--- a/e2e/test/scenarios/permissions/reproductions/22473-cannot-unsubscribe-from-notifications-without-collection-perms.cy.spec.js
+++ b/e2e/test/scenarios/permissions/reproductions/22473-cannot-unsubscribe-from-notifications-without-collection-perms.cy.spec.js
@@ -14,6 +14,7 @@ describe("issue 22473", () => {
   it("nocollection user should be able to view and unsubscribe themselves from a subscription", () => {
     cy.visit(`/dashboard/1`);
     cy.icon("subscription").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Email it").click();
     cy.findByPlaceholderText("Enter user names or email addresses")
       .click()
@@ -26,6 +27,7 @@ describe("issue 22473", () => {
     cy.signIn("nocollection");
     cy.visit("/account/notifications");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Orders in a dashboard").should("exist");
     cy.findByTestId("notifications-list").within(() => {
       cy.findByLabelText("close icon").click();
@@ -33,6 +35,7 @@ describe("issue 22473", () => {
     modal().within(() => {
       cy.button("Unsubscribe").click();
     });
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Orders in a dashboard").should("not.exist");
   });
 });

--- a/e2e/test/scenarios/permissions/reproductions/22727-readonly-collection-offered-on-save.cy.spec.js
+++ b/e2e/test/scenarios/permissions/reproductions/22727-readonly-collection-offered-on-save.cy.spec.js
@@ -23,10 +23,12 @@ describe("issue 22727", () => {
     // We already have a reproduction that makes sure "Our analytics" is not offered when starting from an ad-hoc question (table).
     visitQuestion(1);
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("31.44").click();
     popover().contains("=").click();
     cy.wait("@dataset");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Save").click();
 
     cy.get(".Modal").within(() => {

--- a/e2e/test/scenarios/permissions/reproductions/23981-root-collection-breadcrumbs.cy.spec.js
+++ b/e2e/test/scenarios/permissions/reproductions/23981-root-collection-breadcrumbs.cy.spec.js
@@ -38,7 +38,9 @@ describe("issue 23981", () => {
       },
     });
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Save").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(`${getFullName(nocollection)}'s Personal Collection`).click();
 
     popover().within(() => {

--- a/e2e/test/scenarios/permissions/sandboxes.cy.spec.js
+++ b/e2e/test/scenarios/permissions/sandboxes.cy.spec.js
@@ -44,24 +44,30 @@ describeEE("formatting > sandboxes", () => {
 
     it("should add key attributes to an existing user", () => {
       cy.icon("ellipsis").last().click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Edit user").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Add an attribute").click();
       cy.findByPlaceholderText("Key").type("User ID");
       cy.findByPlaceholderText("Value").type("3");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Update").click();
     });
 
     it("should add key attributes to a new user", () => {
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Invite someone").click();
       cy.findByPlaceholderText("Johnny").type("John");
       cy.findByPlaceholderText("Appleseed").type("Smith");
       cy.findByPlaceholderText("nicetoseeyou@email.com").type(
         "john@smith.test",
       );
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Add an attribute").click();
       cy.findByPlaceholderText("Key").type("User ID");
       cy.findByPlaceholderText("Value").type("1");
       cy.findAllByText("Create").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Done").click();
     });
   });
@@ -149,9 +155,12 @@ describeEE("formatting > sandboxes", () => {
         popover().within(() => {
           cy.findByText("Total").click({ force: true });
         });
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("Equal to").click();
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("Greater than").click();
         cy.findByPlaceholderText("Enter a number").type("100");
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("Add filter").click();
 
         visualize();
@@ -205,7 +214,9 @@ describeEE("formatting > sandboxes", () => {
 
       openOrdersTable({ mode: "notebook" });
       summarize({ mode: "notebook" });
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Count of rows").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Pick a column to group by").click();
 
       cy.log(
@@ -225,7 +236,9 @@ describeEE("formatting > sandboxes", () => {
 
       visualize();
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Count by User → ID");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("11"); // Sum of orders for user with ID #1
     });
 
@@ -327,6 +340,7 @@ describeEE("formatting > sandboxes", () => {
 
         // Find saved question in "Our analytics"
         cy.visit("/collection/root");
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText(QUESTION_NAME).click();
 
         cy.wait("@cardQuery");
@@ -335,13 +349,16 @@ describeEE("formatting > sandboxes", () => {
           // Click on the first bar in a graph (Category: "Doohickey")
           cy.get(".bar").eq(0).click({ force: true });
         });
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("View these Orders").click();
 
         cy.log("Reported failing on v1.37.0.2");
         cy.wait("@dataset").then(xhr => {
           expect(xhr.response.body.error).not.to.exist;
         });
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("Category is Doohickey");
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("97.44"); // Subtotal for order #10
       });
     });
@@ -400,6 +417,7 @@ describeEE("formatting > sandboxes", () => {
 
       // Find saved question in "Our analytics"
       cy.visit("/collection/root");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(QUESTION_NAME).click();
 
       cy.wait("@cardQuery");
@@ -408,11 +426,14 @@ describeEE("formatting > sandboxes", () => {
         // Click on the first bar in a graph (Category: "Doohickey")
         cy.get(".bar").eq(0).click({ force: true });
       });
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("View these Orders").click();
 
       cy.wait("@dataset");
       cy.log("Reported failing on v1.36.4");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Category is Doohickey");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("97.44"); // Subtotal for order #10
     });
 
@@ -473,6 +494,7 @@ describeEE("formatting > sandboxes", () => {
         });
 
         cy.get(".cellData").contains("Awesome Concrete Shoes").click();
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText(/View details/i).click();
 
         cy.log(
@@ -572,6 +594,7 @@ describeEE("formatting > sandboxes", () => {
             "It should show remapped Display Values instead of Product ID",
           );
           cy.get(".cellData").contains("Awesome Concrete Shoes").click();
+          // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
           cy.findByText(/View details/i).click();
 
           cy.log(
@@ -623,6 +646,7 @@ describeEE("formatting > sandboxes", () => {
         });
 
         // Title of the first order for User ID = 1
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("Awesome Concrete Shoes");
       });
     });
@@ -686,6 +710,7 @@ describeEE("formatting > sandboxes", () => {
         cy.intercept("POST", "/api/dataset").as("dataset");
 
         cy.visit("/collection/root");
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText(QUESTION_NAME).click();
 
         cy.wait("@cardQuery");
@@ -694,11 +719,13 @@ describeEE("formatting > sandboxes", () => {
           // Click on the second bar in a graph (Category: "Widget")
           cy.get(".bar").eq(1).click({ force: true });
         });
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("View these Orders").click();
 
         cy.wait("@dataset").then(xhr => {
           expect(xhr.response.body.error).not.to.exist;
         });
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.contains("37.65");
       });
     });
@@ -724,11 +751,14 @@ describeEE("formatting > sandboxes", () => {
       cy.icon("eye")
         .eq(1) // No better way of doing this, undfortunately (see table above)
         .click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Sandboxed").click();
       cy.button("Change").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(
         "Use a saved question to create a custom view for this table",
       ).click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(QUESTION_NAME).click();
       cy.button("Save").click();
 
@@ -737,6 +767,7 @@ describeEE("formatting > sandboxes", () => {
         expect(response.body.message).to.eq(ERROR_MESSAGE);
       });
       cy.get(".Modal").scrollTo("bottom");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(ERROR_MESSAGE);
     });
 
@@ -744,11 +775,17 @@ describeEE("formatting > sandboxes", () => {
       createJoinedQuestion("14766_joined");
 
       startNewQuestion();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Saved Questions").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("14766_joined").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Pick the metric you want to see").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Count of rows").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Pick a column to group by").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(/Products? → ID/).click();
 
       visualize(response => {
@@ -794,7 +831,9 @@ describeEE("formatting > sandboxes", () => {
       cy.wait("@dataset").then(xhr => {
         expect(xhr.response.body.error).not.to.exist;
       });
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("Subtotal").should("not.exist");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("37.65").should("not.exist");
     });
 
@@ -859,7 +898,9 @@ describeEE("formatting > sandboxes", () => {
         visitQuestion(QUESTION_ID);
       });
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Twitter");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Row totals");
     });
 
@@ -875,6 +916,7 @@ describeEE("formatting > sandboxes", () => {
       visitDashboard(1);
       cy.icon("subscription").click();
       // We're starting without email or Slack being set up so it's expected to see the following:
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Create a dashboard subscription");
       cy.findAllByRole("link", { name: "set up email" });
       cy.findAllByRole("link", { name: "configure Slack" });
@@ -897,6 +939,7 @@ describeEE("formatting > sandboxes", () => {
 
       cy.visit("/pulse/create");
       cy.wait("@collection");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Where should this data go?")
         .parent()
         .within(() => {
@@ -923,6 +966,7 @@ describeEE("formatting > sandboxes", () => {
         callback: xhr => expect(xhr.response.body.error).not.to.exist,
       });
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("37.65");
     });
 
@@ -995,8 +1039,10 @@ describeEE("formatting > sandboxes", () => {
         cy.signInAsSandboxedUser();
         visitDashboard(1);
         cy.icon("subscription").click();
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("Email it").click();
         cy.findByPlaceholderText("Enter user names or email addresses").click();
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("User 1").click();
         sendEmailAndAssert(email => {
           expect(email.html).to.include("Orders in a dashboard");

--- a/e2e/test/scenarios/question/nested.cy.spec.js
+++ b/e2e/test/scenarios/question/nested.cy.spec.js
@@ -62,17 +62,23 @@ describe("scenarios > question > nested", () => {
     );
 
     openHeaderCellContextMenu("Count");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Distribution").click();
     cy.wait("@dataset");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Count by Count: Auto binned");
     cy.get(".bar").should("have.length.of.at.least", 8);
 
     // Go back to the nested question and make sure Sum over time works
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Nested GUI").click();
 
     openHeaderCellContextMenu("Count");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Sum over time").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Sum of Count");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("137");
 
     // Make sure it works for a SQL question
@@ -94,17 +100,23 @@ describe("scenarios > question > nested", () => {
     );
 
     openHeaderCellContextMenu("COUNT");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Distribution").click();
     cy.wait("@dataset");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Count by COUNT: Auto binned");
     cy.get(".bar").should("have.length.of.at.least", 5);
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Nested SQL").click();
 
     openHeaderCellContextMenu("COUNT");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Sum over time").click();
     cy.wait("@dataset");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Sum of COUNT");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("744");
   });
 
@@ -131,6 +143,7 @@ describe("scenarios > question > nested", () => {
       { visitQuestion: true },
     );
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("10511");
     cy.findAllByText("June, 2016");
     cy.findAllByText("13");
@@ -141,14 +154,20 @@ describe("scenarios > question > nested", () => {
 
     // add initial aggregation ("Average of Total by Order ID")
     summarize({ mode: "notebook" });
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Average of ...").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Total").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Pick a column to group by").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("ID").click();
 
     // add another aggregation ("Count by Average of Total")
     summarize({ mode: "notebook" });
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Count of rows").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Pick a column to group by").click();
     cy.log("Reported failing on v0.34.3 - v0.37.0.2");
     popover()
@@ -263,12 +282,15 @@ describe("scenarios > question > nested", () => {
     createNestedQuestion({ baseQuestionDetails });
 
     // The column title
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Products → Category").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Distribution").click();
     cy.wait("@dataset");
 
     summarize();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Group by")
       .parent()
       .within(() => {
@@ -398,20 +420,31 @@ describe("scenarios > question > nested", () => {
           cy.spy(win.console, "warn").as("consoleWarn");
         },
       });
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("New").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Question").should("be.visible").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Saved Questions").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("15725").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Pick the metric you want to see").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Count of rows").click();
     });
 
     it("Count of rows AND Sum of VAL by CAT (metabase#15725-1)", () => {
       cy.icon("add").last().click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(/^Sum of/).click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("VAL").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Sum of VAL");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Pick a column to group by").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("CAT").click();
 
       visualize();
@@ -420,17 +453,21 @@ describe("scenarios > question > nested", () => {
         "not.be.calledWith",
         "Removing invalid MBQL clause",
       );
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Sum of VAL");
     });
 
     it("Count of rows by CAT + add sum of VAL later from the sidebar (metabase#15725-2)", () => {
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Pick a column to group by").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("CAT").click();
 
       visualize();
 
       summarize();
       cy.findByTestId("add-aggregation-button").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(/^Sum of/).click();
       popover().findByText("VAL").click();
       cy.wait("@dataset").then(xhr => {
@@ -453,6 +490,7 @@ describe("scenarios > question > nested", () => {
 
     cy.createNativeQuestion(questionDetails, { visitQuestion: true });
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Explore results").click();
     cy.wait("@dataset");
 
@@ -482,7 +520,9 @@ describe("scenarios > question > nested", () => {
     });
     cy.findByTestId("apply-filters").click();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Synergistic Granite Chair");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Rustic Paper Wallet").should("not.exist");
 
     function saveQuestion() {
@@ -513,7 +553,9 @@ describe("scenarios > question > nested", () => {
       },
     });
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Filter").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Summaries").click();
     cy.findByTestId("operator-select").click();
     popover().contains("Equal to").click();
@@ -521,12 +563,15 @@ describe("scenarios > question > nested", () => {
     cy.button("Apply Filters").click();
     cy.wait("@dataset");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Count is equal to 5");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Showing 100 rows");
 
     saveQuestion();
 
     reloadQuestion();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Showing 100 rows");
 
     cy.icon("notebook").click();

--- a/e2e/test/scenarios/question/new.cy.spec.js
+++ b/e2e/test/scenarios/question/new.cy.spec.js
@@ -32,7 +32,9 @@ describe("scenarios > question > new", () => {
 
       startNewQuestion();
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("Pick your starting data");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Sample3").isVisibleInPopover();
     });
 
@@ -60,11 +62,13 @@ describe("scenarios > question > new", () => {
         4,
       );
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("Saved question in Our analytics");
       cy.findAllByRole("link", { name: "Our analytics" })
         .should("have.attr", "href")
         .and("eq", "/collection/root");
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("Table in Sample Database");
       cy.findAllByRole("link", { name: "Sample Database" })
         .should("have.attr", "href")
@@ -75,6 +79,7 @@ describe("scenarios > question > new", () => {
       cy.findByPlaceholderText("Search for a table…");
       cy.findByTestId("input-reset-button").click();
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Saved Questions").click();
 
       // Search is now scoped to questions only
@@ -92,20 +97,27 @@ describe("scenarios > question > new", () => {
         // should display the collection tree on the left side
         .should("contain", "Our analytics");
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Orders, Count").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Orders").should("not.exist");
       visualize();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("18,760");
       // should reopen saved question picker after returning back to editor mode
       cy.icon("notebook").click();
       cy.findByTestId("data-step-cell").contains("Orders, Count").click();
       // It is now possible to choose another saved question
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Orders");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Saved Questions").click();
       popover().contains("Sample Database").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Products").click();
       cy.findByTestId("data-step-cell").contains("Products");
       visualize();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Rustic Paper Wallet");
     });
 
@@ -182,6 +194,7 @@ describe("scenarios > question > new", () => {
     cy.get(".QueryBuilder .Icon-notebook").click();
     cy.url().should("include", "question/notebook#");
     cy.get(".QueryBuilder .Icon-sql").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Convert this question to SQL").click();
     cy.url().should("include", "question#");
   });
@@ -237,7 +250,9 @@ describe("scenarios > question > new", () => {
       },
     });
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("User ID is 1");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("37.65");
   });
 });

--- a/e2e/test/scenarios/question/notebook.cy.spec.js
+++ b/e2e/test/scenarios/question/notebook.cy.spec.js
@@ -32,8 +32,10 @@ describe("scenarios > question > notebook", () => {
   it("shouldn't offer to save the question when there were no changes (metabase#13470)", () => {
     openOrdersTable();
     // save question initially
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Save").click();
     cy.get(".ModalBody").contains("Save").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Not now").click();
     // enter "notebook" and visualize without changing anything
     cy.icon("notebook").click();
@@ -41,20 +43,25 @@ describe("scenarios > question > notebook", () => {
     cy.button("Visualize").click();
 
     // there were no changes to the question, so we shouldn't have the option to "Save"
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Save").should("not.exist");
   });
 
   it("should allow post-aggregation filters", () => {
     // start a custom question with orders
     startNewQuestion();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Sample Database").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Orders").click();
 
     // count orders by user id, filter to the one user with 46 orders
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Pick the metric").click();
     popover().within(() => {
       cy.findByText("Count of rows").click();
     });
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Pick a column to group by").click();
     popover().within(() => {
       cy.contains("User ID").click();
@@ -68,14 +75,18 @@ describe("scenarios > question > notebook", () => {
 
     visualize();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("2372"); // user's id in the table
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Showing 1 row"); // ensure only one user was returned
   });
 
   it("shouldn't show sub-dimensions for FK (metabase#16787)", () => {
     openOrdersTable({ mode: "notebook" });
     summarize({ mode: "notebook" });
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Pick a column to group by").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("User ID")
       .closest(".List-item")
       .find(".Field-extra")
@@ -95,7 +106,9 @@ describe("scenarios > question > notebook", () => {
       display: "table",
     });
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("ID between 96 97").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Between").click();
     cy.findByTestId("operator-select-list").within(() => {
       cy.contains("Is not");
@@ -109,6 +122,7 @@ describe("scenarios > question > notebook", () => {
     cy.intercept("POST", "/api/dataset").as("dataset");
     openProductsTable({ mode: "notebook" });
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Custom column").click();
     addSimpleCustomColumn("EXPR");
 
@@ -130,14 +144,18 @@ describe("scenarios > question > notebook", () => {
 
     visualize();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("EXPR");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("EXPR (1)");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("EXPR (2)");
   });
 
   it("should process the updated expression when pressing Enter", () => {
     openProductsTable({ mode: "notebook" });
     filter({ mode: "notebook" });
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Custom Expression").click();
 
     enterCustomColumnDetails({ formula: "[Price] > 1" });
@@ -146,12 +164,15 @@ describe("scenarios > question > notebook", () => {
     cy.button("Done").click();
 
     // change the corresponding custom expression
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Price is greater than 1").click();
     cy.get(".Icon-chevronleft").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Custom Expression").click();
 
     cy.get("@formula").clear().type("[Price] > 1 AND [Price] < 5{enter}");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains(/^Price is less than 5/i);
   });
 
@@ -179,18 +200,23 @@ describe("scenarios > question > notebook", () => {
 
     cy.createQuestion(questionDetails, { visitQuestion: true });
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Showing 98 rows");
 
     cy.findByTestId("filters-visibility-control").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Product ID is 2").click();
 
     popover().find("input").type("3{enter}");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Product ID is 2 selections");
 
     // Still loading
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Showing 98 rows");
 
     cy.wait("@dataset");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Showing 175 rows");
   });
 
@@ -198,11 +224,15 @@ describe("scenarios > question > notebook", () => {
   it.skip("should show an info popover for dimensions listened by the custom expression editor", () => {
     // start a custom question with orders
     startNewQuestion();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Sample Database").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Orders").click();
 
     // type a dimension name
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Add filters to narrow your answer").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Custom Expression").click();
     enterCustomColumnDetails({ formula: "Total" });
 
@@ -228,6 +258,7 @@ describe("scenarios > question > notebook", () => {
 
     it("popover should not render outside of viewport regardless of the screen resolution (metabase#15502-1)", () => {
       // Initial filter popover usually renders correctly within the viewport
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Add filters to narrow your answer").as("filter").click();
       popover().isRenderedWithinViewport();
       // Click anywhere outside this popover to close it because the issue with rendering happens when popover opens for the second time
@@ -238,6 +269,7 @@ describe("scenarios > question > notebook", () => {
 
     it("popover should not cover the button that invoked it (metabase#15502-2)", () => {
       // Initial summarize/metric popover usually renders initially without blocking the button
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Pick the metric you want to see").as("metric").click();
       // Click outside to close this popover
       cy.icon("gear").click();
@@ -267,24 +299,30 @@ describe("scenarios > question > notebook", () => {
 
       visualize();
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("Example");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("Big");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("Small");
     });
 
     it("should work on custom filter", () => {
       filter({ mode: "notebook" });
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Custom Expression").click();
 
       enterCustomColumnDetails({ formula: "[Subtotal] - Tax > 140" });
       cy.get("@formula").blur();
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains(/^redundant input/i).should("not.exist");
 
       cy.button("Done").should("not.be.disabled").click();
 
       visualize();
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("Showing 97 rows");
     });
 
@@ -298,6 +336,7 @@ describe("scenarios > question > notebook", () => {
 
       it(`should work on custom aggregation with ${filter}`, () => {
         summarize({ mode: "notebook" });
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("Custom Expression").click();
 
         enterCustomColumnDetails({ formula: expression });
@@ -306,14 +345,18 @@ describe("scenarios > question > notebook", () => {
           .click()
           .type(filter, { delay: 100 });
 
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.contains(/^expected closing parenthesis/i).should("not.exist");
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.contains(/^redundant input/i).should("not.exist");
 
         cy.button("Done").should("not.be.disabled").click();
 
         visualize();
 
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.contains(filter);
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.contains(result);
       });
     });
@@ -323,7 +366,9 @@ describe("scenarios > question > notebook", () => {
   // fix users' pain caused by the inability to unselect all columns
   it("select no columns select the first one", () => {
     startNewQuestion();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Sample Database").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Orders").click();
     cy.findByTestId("fields-picker").click();
 
@@ -336,7 +381,9 @@ describe("scenarios > question > notebook", () => {
 
     visualize();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Tax");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("ID").should("not.exist");
   });
 
@@ -354,6 +401,7 @@ describe("scenarios > question > notebook", () => {
     cy.createQuestion(questionDetails, { visitQuestion: true });
 
     filter();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Summaries").click();
 
     filterField("Max of Name", {
@@ -375,6 +423,7 @@ describe("scenarios > question > notebook", () => {
     cy.createQuestion(questionDetails, { visitQuestion: true });
 
     filter();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Summaries").click();
     filterField("Min of Vendor", {
       operator: "ends with",
@@ -410,11 +459,14 @@ describe("scenarios > question > notebook", () => {
   // flaky test
   it.skip("should show an info popover when hovering over a field picker option for a table", () => {
     startNewQuestion();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Sample Database").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Orders").click();
 
     cy.findByTestId("fields-picker").click();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Total").trigger("mouseenter");
 
     popover().contains("The total billed amount.");
@@ -430,11 +482,14 @@ describe("scenarios > question > notebook", () => {
 
     // start a custom question with question a
     startNewQuestion();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Saved Questions").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("question a").click();
 
     cy.findByTestId("fields-picker").click();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("A_COLUMN").trigger("mouseenter");
 
     popover().contains("A_COLUMN");
@@ -449,7 +504,9 @@ describe("scenarios > question > notebook", () => {
     });
 
     startNewQuestion();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Saved Questions").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Orders, Count").click();
     visualize();
   });

--- a/e2e/test/scenarios/question/nulls.cy.spec.js
+++ b/e2e/test/scenarios/question/nulls.cy.spec.js
@@ -34,6 +34,7 @@ describe("scenarios > question > null", () => {
 
     // find and open previously created question
     cy.visit("/collection/root");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("13571").click();
 
     cy.log("'No Results since at least v0.34.3");
@@ -153,6 +154,7 @@ describe("scenarios > question > null", () => {
     openOrdersTable();
 
     // Total of "39.72", and the next cell is the `discount` (which is empty)
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("39.72")
       .closest(".TableInteractive-cellWrapper")
       .next()
@@ -163,8 +165,10 @@ describe("scenarios > question > null", () => {
 
     popover().contains("=").click();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("39.72");
     // This row ([id] 3) had the `discount` column value and should be filtered out now
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("49.21").should("not.exist");
   });
 
@@ -177,6 +181,7 @@ describe("scenarios > question > null", () => {
         // remove pre-selected "Count"
         cy.icon("close").click();
       });
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Add a metric").click();
       // dropdown immediately opens with the new set of metrics to choose from
       popover().within(() => {
@@ -184,9 +189,12 @@ describe("scenarios > question > null", () => {
         cy.findByText("Discount").click();
       });
       // Group by
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("Created At").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("Cumulative sum of Discount by Created At: Month");
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("There was a problem with your question").should(
         "not.exist",
       );

--- a/e2e/test/scenarios/question/query-external.cy.spec.js
+++ b/e2e/test/scenarios/question/query-external.cy.spec.js
@@ -24,10 +24,13 @@ supportedDatabases.forEach(({ database, snapshotName, dbName }) => {
 
     it(`can query ${database} database`, () => {
       startNewQuestion();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(dbName).click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Orders").click();
 
       visualize();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("37.65");
     });
   });

--- a/e2e/test/scenarios/question/question-management.cy.spec.js
+++ b/e2e/test/scenarios/question/question-management.cy.spec.js
@@ -42,6 +42,7 @@ describe("managing question from the question's details sidebar", () => {
                 .type("1")
                 .blur();
               assertOnRequest("updateQuestion");
+              // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
               cy.findByText("Orders1");
             });
 
@@ -54,6 +55,7 @@ describe("managing question from the question's details sidebar", () => {
 
               assertOnRequest("updateQuestion");
 
+              // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
               cy.findByText("foo");
             });
 
@@ -72,11 +74,14 @@ describe("managing question from the question's details sidebar", () => {
 
                 openQuestionActions();
                 cy.findByTestId("move-button").click();
+                // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
                 cy.findByText("My personal collection").click();
                 clickButton("Move");
                 assertOnRequest("updateQuestion");
+                // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
                 cy.contains("37.65");
 
+                // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
                 cy.contains(
                   `Question moved to ${getPersonalCollectionName(USERS[user])}`,
                 );
@@ -111,11 +116,14 @@ describe("managing question from the question's details sidebar", () => {
 
                 openQuestionActions();
                 cy.findByTestId("move-button").click();
+                // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
                 cy.findByText("My personal collection").click();
                 clickButton("Move");
                 assertOnRequest("updateQuestion");
+                // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
                 cy.contains("37.65");
 
+                // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
                 cy.contains(
                   `Model moved to ${getPersonalCollectionName(USERS[user])}`,
                 );
@@ -138,6 +146,7 @@ describe("managing question from the question's details sidebar", () => {
               );
               openQuestionActions();
               cy.findByTestId("archive-button").click();
+              // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
               cy.findByText(
                 "It will also be removed from the filter that uses it to populate values.",
               ).should("not.exist");
@@ -146,14 +155,18 @@ describe("managing question from the question's details sidebar", () => {
               cy.wait("@getItems"); // pinned items
               cy.wait("@getItems"); // unpinned items
               cy.location("pathname").should("eq", "/collection/root");
+              // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
               cy.findByText("Orders").should("not.exist");
 
               cy.findByPlaceholderText("Search…").click();
+              // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
               cy.findByText("Recently viewed");
+              // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
               cy.findByText("Nothing here");
 
               // Check page for archived questions
               cy.visit("/question/1");
+              // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
               cy.findByText("This question has been archived");
             });
 
@@ -227,6 +240,7 @@ describe("managing question from the question's details sidebar", () => {
                 cy.findByTestId("archive-button").should("not.exist");
               });
 
+              // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
               cy.findByText("Revert").should("not.exist");
             });
           });

--- a/e2e/test/scenarios/question/reproductions/13097-mongo-apply-distinct-count-multiple-columns.cy.spec.js
+++ b/e2e/test/scenarios/question/reproductions/13097-mongo-apply-distinct-count-multiple-columns.cy.spec.js
@@ -31,12 +31,16 @@ describe("issue 13097", { tags: "@external" }, () => {
   it("should correctly apply distinct count on multiple columns (metabase#13097)", () => {
     summarize({ mode: "notebook" });
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Number of distinct values of ...").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("City").click();
 
     cy.findAllByTestId("notebook-cell-item").find(".Icon-add").click();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Number of distinct values of ...").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("State").click();
 
     visualize();

--- a/e2e/test/scenarios/question/reproductions/13263-postgres-show-row-details-on-pk-click.cy.spec.js
+++ b/e2e/test/scenarios/question/reproductions/13263-postgres-show-row-details-on-pk-click.cy.spec.js
@@ -25,7 +25,9 @@ describe("postgres > user > query", { tags: "@external" }, () => {
     // Assertions
     cy.log("Fails in v0.36.6");
     // This could be omitted because real test is searching for "37.65" on the page
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("There was a problem with your question").should("not.exist");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("37.65");
   });
 });

--- a/e2e/test/scenarios/question/reproductions/14957-unable-to-save-question-before-query-executed.cy.spec.js
+++ b/e2e/test/scenarios/question/reproductions/14957-unable-to-save-question-before-query-executed.cy.spec.js
@@ -11,6 +11,7 @@ describe.skip("issue 14957", { tags: "@external" }, () => {
   it("should save a question before query has been executed (metabase#14957)", () => {
     openNativeEditor({ databaseName: PG_DB_NAME }).type("select pg_sleep(60)");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Save").click();
 
     cy.findByLabelText("Name").type("14957");

--- a/e2e/test/scenarios/question/reproductions/15714-cc-postgres-percentile-accepts-two-params.cy.spec.js
+++ b/e2e/test/scenarios/question/reproductions/15714-cc-postgres-percentile-accepts-two-params.cy.spec.js
@@ -12,18 +12,22 @@ describe("postgres > question > custom columns", { tags: "@external" }, () => {
     cy.signInAsAdmin();
 
     startNewQuestion();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(PG_DB_NAME).should("be.visible").click();
     cy.findByTextEnsureVisible("Orders").click();
   });
 
   it("`Percentile` custom expression function should accept two parameters (metabase#15714)", () => {
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Pick the metric you want to see").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Custom Expression").click();
     enterCustomColumnDetails({ formula: "Percentile([Subtotal], 0.1)" });
     cy.findByPlaceholderText("Something nice and descriptive")
       .as("description")
       .click();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Function Percentile expects 1 argument").should("not.exist");
     cy.get("@description").type("A");
     cy.button("Done").should("not.be.disabled").click();

--- a/e2e/test/scenarios/question/reproductions/17512.cy.spec.js
+++ b/e2e/test/scenarios/question/reproductions/17512.cy.spec.js
@@ -22,7 +22,9 @@ describe("issue 17512", () => {
       "CE",
     );
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Pick a column to group by").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Created At").click();
 
     addCustomColumn("1 + 1", "CC");
@@ -31,7 +33,9 @@ describe("issue 17512", () => {
       expect(body.error).to.not.exist;
     });
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("CE");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("CC");
   });
 });

--- a/e2e/test/scenarios/question/reproductions/17514-ui-overlay.cy.spec.js
+++ b/e2e/test/scenarios/question/reproductions/17514-ui-overlay.cy.spec.js
@@ -98,14 +98,18 @@ describe("issue 17514", () => {
       cy.location("search").should("eq", "?date_filter=past30years");
       cy.wait("@cardQuery");
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Previous 30 Years");
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("17514").click();
       cy.wait("@dataset");
       cy.findByTextEnsureVisible("Subtotal");
 
       // Cypress cannot click elements that are blocked by an overlay so this will immediately fail if the issue is not fixed
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("110.93").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Filter by this value");
     });
   });
@@ -125,6 +129,7 @@ describe("issue 17514", () => {
       visualize();
       cy.findByTextEnsureVisible("Subtotal");
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Save").click();
 
       cy.get(".Modal").within(() => {
@@ -135,13 +140,16 @@ describe("issue 17514", () => {
     it("should not show the run overlay because of the references to the orphaned fields (metabase#17514-2)", () => {
       openNotebookMode();
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Join data").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Products").click();
 
       visualize();
 
       // Cypress cannot click elements that are blocked by an overlay so this will immediately fail if the issue is not fixed
       cy.findByTextEnsureVisible("Subtotal").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Filter by this column");
     });
   });

--- a/e2e/test/scenarios/question/reproductions/17910-revision-history-update.cy.spec.js
+++ b/e2e/test/scenarios/question/reproductions/17910-revision-history-update.cy.spec.js
@@ -15,6 +15,7 @@ describe("issue 17910", () => {
   it("revisions should work after creating a question without reloading (metabase#17910)", () => {
     openOrdersTable();
     cy.intercept("POST", `/api/card`).as("card");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Save").click();
     modal().within(() => {
       cy.findByText("Save").click();

--- a/e2e/test/scenarios/question/reproductions/17963-mongo-filter-expression-compare-two-fields.cy.spec.js
+++ b/e2e/test/scenarios/question/reproductions/17963-mongo-filter-expression-compare-two-fields.cy.spec.js
@@ -11,11 +11,14 @@ describe("issue 17963", { tags: "@external" }, () => {
     cy.signInAsAdmin();
 
     startNewQuestion();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("QA Mongo4").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Orders").click();
   });
 
   it("should be able to compare two fields using filter expression (metabase#17963)", () => {
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Add filters to narrow your answer").click();
 
     popover().contains("Custom Expression").click();
@@ -28,9 +31,12 @@ describe("issue 17963", { tags: "@external" }, () => {
 
     cy.button("Done").click();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Discount > Quantity");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Pick the metric you want to see").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Count of rows").click();
 
     visualize();

--- a/e2e/test/scenarios/question/reproductions/18207-string-min-max.cy.spec.js
+++ b/e2e/test/scenarios/question/reproductions/18207-string-min-max.cy.spec.js
@@ -20,34 +20,51 @@ describe("issue 18207", () => {
   });
 
   it("should be possible to use MIN on a string column (metabase#18207, metabase#22155)", () => {
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Minimum of").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Price");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Rating");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Ean").should("be.visible");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Category").click();
 
     visualize();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Doohickey");
   });
 
   it("should be possible to use MAX on a string column (metabase#18207, metabase#22155)", () => {
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Maximum of").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Price");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Rating");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Ean").should("be.visible");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Category").click();
 
     visualize();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Widget");
   });
 
   it("should be not possible to use AVERAGE on a string column (metabase#18207, metabase#22155)", () => {
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Average of").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Price");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Rating");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Ean").should("not.exist");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Category").should("not.exist");
   });
 
@@ -61,20 +78,24 @@ describe("issue 18207", () => {
       cy.findByText("Done").click();
     });
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Pick a column to group by").click();
     popover().contains("Category").click();
 
     visualize();
 
     // Why is it not a table?
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Visualization").click();
     leftSidebar().within(() => {
       cy.icon("table").click();
       cy.findByTestId("Table-button").realHover();
       cy.icon("gear").click();
     });
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Done").click();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Zemlak-Wiegand");
   });
 });

--- a/e2e/test/scenarios/question/reproductions/19341-disabled-nested-queries.cy.spec.js
+++ b/e2e/test/scenarios/question/reproductions/19341-disabled-nested-queries.cy.spec.js
@@ -54,8 +54,10 @@ describe("issue 19341", () => {
 
     // Test "Explore results" button is hidden for native questions
     cy.visit("/collection/root");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(TEST_NATIVE_QUESTION_NAME).click();
     cy.wait("@cardQuery");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Explore results").should("not.exist");
   });
 });

--- a/e2e/test/scenarios/question/reproductions/19742-data-picker-closes-after-hiding-table.cy.spec.js
+++ b/e2e/test/scenarios/question/reproductions/19742-data-picker-closes-after-hiding-table.cy.spec.js
@@ -10,6 +10,7 @@ describe("issue 19742", () => {
   // and don't refresh the app state (like by doing cy.visit)
   it("shouldn't auto-close the data selector after a table was hidden", () => {
     cy.visit("/");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("New").click();
     selectFromDropdown("Question");
     selectFromDropdown("Sample Database");
@@ -18,10 +19,13 @@ describe("issue 19742", () => {
     cy.icon("gear").click();
     selectFromDropdown("Admin settings");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Data Model").click();
     hideTable("Orders");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Exit admin").click();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("New").click();
     selectFromDropdown("Question");
     selectFromDropdown("Sample Database");

--- a/e2e/test/scenarios/question/reproductions/20627-nested-long-names-wrong-aliases.cy.spec.js
+++ b/e2e/test/scenarios/question/reproductions/20627-nested-long-names-wrong-aliases.cy.spec.js
@@ -25,12 +25,17 @@ describe("issue 20627", () => {
   it("nested queries should handle long column and/or table names (metabase#20627)", () => {
     openOrdersTable({ mode: "notebook" });
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Join data").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(newTableName).click();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Summarize").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Count of rows").click();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Pick a column to group by").click();
     popover().within(() => {
       cy.contains(newTableName).click();
@@ -38,6 +43,7 @@ describe("issue 20627", () => {
       cy.findByText("Category").click();
     });
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Custom column").click();
     enterCustomColumnDetails({ formula: "1 + 1", name: "Math" });
     cy.button("Done").click();

--- a/e2e/test/scenarios/question/reproductions/20809-nesting-explicit-implicit-filter.cy.spec.js
+++ b/e2e/test/scenarios/question/reproductions/20809-nesting-explicit-implicit-filter.cy.spec.js
@@ -74,6 +74,7 @@ describe("issue 20809", () => {
       expect(response.body.error).to.not.exist;
     });
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("37.65");
   });
 });

--- a/e2e/test/scenarios/question/reproductions/22247-timeseries-filter-all-time.cy.spec.js
+++ b/e2e/test/scenarios/question/reproductions/22247-timeseries-filter-all-time.cy.spec.js
@@ -20,6 +20,7 @@ describe("time-series filter widget", () => {
     sidebar().contains("Created At").click();
     cy.wait("@dataset");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("All Time").click();
 
     popover().within(() => {
@@ -37,9 +38,11 @@ describe("time-series filter widget", () => {
     cy.findAllByText("Summarize").first().click();
     cy.findAllByText("Created At").last().click();
     cy.wait("@dataset");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Done").click();
 
     // switch to previous 30 quarters
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("All Time").click();
     popover().within(() => {
       cy.findByText("All Time").click();
@@ -57,11 +60,15 @@ describe("time-series filter widget", () => {
   it.skip("should stay in-sync with the actual filter", () => {
     cy.findAllByText("Filter").first().click();
     cy.findAllByText("Created At").last().click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Last 3 Months").click();
     cy.wait("@dataset");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Created At Previous 3 Months").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("months").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("years").click();
     cy.button("Add filter").click();
     cy.wait("@dataset");
@@ -69,10 +76,12 @@ describe("time-series filter widget", () => {
     cy.findAllByText("Summarize").first().click();
     cy.findAllByText("Created At").last().click();
     cy.wait("@dataset");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Done").click();
 
     cy.findByTextEnsureVisible("Created At Previous 3 Years");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Previous 3 Years").click();
     popover().within(() => {
       cy.findByText("Previous").should("be.visible");
@@ -84,10 +93,12 @@ describe("time-series filter widget", () => {
     popover().within(() => {
       cy.findByText("Previous").click();
     });
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("All Time").click();
     cy.button("Apply").click();
     cy.wait("@dataset");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Created At Previous 3 Years").should("not.exist");
     cy.findByTextEnsureVisible("All Time");
   });

--- a/e2e/test/scenarios/question/reproductions/24839-summarize-source-question-with-summarization.cy.spec.js
+++ b/e2e/test/scenarios/question/reproductions/24839-summarize-source-question-with-summarization.cy.spec.js
@@ -36,7 +36,9 @@ describe("issue 24839: should be able to summarize a nested question based on th
 
   it.skip("from the notebook GUI (metabase#24839-1)", () => {
     cy.icon("notebook").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Summarize").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Sum of ...").click();
     popover()
       .should("contain", "Sum of Quantity")

--- a/e2e/test/scenarios/question/reproductions/25016-column-filter-multi-stage-query.cy.spec.js
+++ b/e2e/test/scenarios/question/reproductions/25016-column-filter-multi-stage-query.cy.spec.js
@@ -37,6 +37,7 @@ describe("issue 25016", () => {
 
   it("should be possible to filter by a column in a multi-stage query (metabase#25016)", () => {
     visitQuestionAdhoc(questionDetails);
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Category").click();
 
     popover().within(() => {
@@ -46,6 +47,7 @@ describe("issue 25016", () => {
     });
 
     cy.wait("@dataset");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Showing 1 row").should("be.visible");
   });
 });

--- a/e2e/test/scenarios/question/reproductions/25144-saved-questions-first-question.cy.spec.js
+++ b/e2e/test/scenarios/question/reproductions/25144-saved-questions-first-question.cy.spec.js
@@ -11,15 +11,18 @@ describe("issue 25144", () => {
   it("should show Saved Questions section after creating the first question (metabase#25144)", () => {
     cy.visit("/");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("New").click();
     popover().findByText("Question").click();
     popover().findByText("Orders").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Save").click();
     modal().findByLabelText("Name").clear().type("Orders question");
     modal().button("Save").click();
     cy.wait("@createCard");
     modal().button("Not now").click();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("New").click();
     popover().findByText("Question").click();
     popover().findByText("Saved Questions").click();
@@ -29,9 +32,11 @@ describe("issue 25144", () => {
   it("should show Models section after creation the first model (metabase#24878)", () => {
     cy.visit("/");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("New").click();
     popover().findByText("Question").click();
     popover().findByText("Orders").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Save").click();
     modal().findByLabelText("Name").clear().type("Orders model");
     modal().button("Save").click();
@@ -43,6 +48,7 @@ describe("issue 25144", () => {
     modal().button("Turn this into a model").click();
     cy.wait("@updateCard");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("New").click();
     popover().findByText("Question").click();
     popover().findByText("Models").click();

--- a/e2e/test/scenarios/question/reproductions/27462-no-field-options-for-double-aggregations.cy.spec.js
+++ b/e2e/test/scenarios/question/reproductions/27462-no-field-options-for-double-aggregations.cy.spec.js
@@ -38,6 +38,7 @@ describe("issue 27462", () => {
 
     cy.button("Visualize").click();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("200").should("be.visible");
   });
 });

--- a/e2e/test/scenarios/question/reproductions/28221-missing-custom-field-metadata.cy.spec.js
+++ b/e2e/test/scenarios/question/reproductions/28221-missing-custom-field-metadata.cy.spec.js
@@ -43,6 +43,7 @@ describe("issue 28221", () => {
 
     cy.findByDisplayValue(questionName).should("be.visible");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(customFieldName).should("be.visible");
   });
 });

--- a/e2e/test/scenarios/question/reproductions/28874-notebook-pivot.cy.spec.js
+++ b/e2e/test/scenarios/question/reproductions/28874-notebook-pivot.cy.spec.js
@@ -30,10 +30,12 @@ describe("issue 28874", () => {
   it("should allow to modify a pivot question in the notebook (metabase#28874)", () => {
     visitQuestionAdhoc(questionDetails, { mode: "notebook" });
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Product ID")
       .parent()
       .within(() => cy.icon("close").click());
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Product ID").should("not.exist");
   });
 });

--- a/e2e/test/scenarios/question/reproductions/29082-quick-filter-null.cy.spec.js
+++ b/e2e/test/scenarios/question/reproductions/29082-quick-filter-null.cy.spec.js
@@ -26,22 +26,31 @@ describe("issue 29082", () => {
   it("should handle nulls in quick filters (metabase#29082)", () => {
     visitQuestionAdhoc(questionDetails);
     cy.wait("@dataset");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Showing 11 rows").should("exist");
 
     cy.get(".TableInteractive-emptyCell").first().click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     popover().within(() => cy.findByText("=").click());
     cy.wait("@dataset");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Showing 8 rows").should("exist");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Discount is empty").should("exist");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Discount is empty").within(() => cy.icon("close").click());
     cy.wait("@dataset");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Showing 11 rows").should("exist");
 
     cy.get(".TableInteractive-emptyCell").first().click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     popover().within(() => cy.findByText("≠").click());
     cy.wait("@dataset");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Showing 3 rows").should("exist");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Discount is not empty").should("exist");
   });
 });

--- a/e2e/test/scenarios/question/reproductions/4482-temporal-min-max.cy.spec.js
+++ b/e2e/test/scenarios/question/reproductions/4482-temporal-min-max.cy.spec.js
@@ -6,33 +6,40 @@ describe("issue 4482", () => {
     cy.signInAsAdmin();
 
     startNewQuestion();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Sample Database").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Products").click();
   });
 
   it("should be possible to summarize min of a temporal column (metabase#4482-1)", () => {
     pickMetric("Minimum of");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Created At").click();
 
     visualize();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("April 1, 2016, 12:00 AM");
   });
 
   it("should be possible to summarize max of a temporal column (metabase#4482-2)", () => {
     pickMetric("Maximum of");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Created At").click();
 
     visualize();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("April 1, 2019, 12:00 AM");
   });
 
   it("should be not possible to average a temporal column (metabase#4482-3)", () => {
     pickMetric("Average of");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Created At").should("not.exist");
   });
 });

--- a/e2e/test/scenarios/question/reproductions/6239-sort-using-cust-exp.cy.spec.js
+++ b/e2e/test/scenarios/question/reproductions/6239-sort-using-cust-exp.cy.spec.js
@@ -14,6 +14,7 @@ describe("issue 6239", () => {
     openOrdersTable({ mode: "notebook" });
 
     summarize({ mode: "notebook" });
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Custom Expression").click();
 
     cy.get(".ace_text-input").type("CountIf([Total] > 0)").blur();
@@ -21,11 +22,13 @@ describe("issue 6239", () => {
     cy.findByPlaceholderText("Something nice and descriptive").type("CE");
     cy.button("Done").click();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Pick a column to group by").click();
     popover().contains("Created At").first().click();
   });
 
   it("should be possible to sort by using custom expression (metabase#6239)", () => {
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Sort").click();
     popover().contains(/^CE$/).click();
 

--- a/e2e/test/scenarios/question/reproductions/9027-new-questions-not-in-saved-questions-immediately.cy.spec.js
+++ b/e2e/test/scenarios/question/reproductions/9027-new-questions-not-in-saved-questions-immediately.cy.spec.js
@@ -15,9 +15,11 @@ describe("issue 9027", () => {
     cy.signInAsAdmin();
 
     startNewQuestion();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Saved Questions").click();
 
     // Wait for the existing questions to load
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Orders");
 
     openNativeEditor({ fromCurrentPage: true });

--- a/e2e/test/scenarios/question/saved.cy.spec.js
+++ b/e2e/test/scenarios/question/saved.cy.spec.js
@@ -22,28 +22,38 @@ describe("scenarios > question > saved", () => {
     openOrdersTable();
     cy.icon("notebook").click();
     summarize({ mode: "notebook" });
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Count of rows").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Pick a column to group by").click();
     popover().findByText("Total").click();
     // Save the question
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Save").click();
     modal().within(() => {
       cy.findByText("Save").click();
     });
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Not now").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Save").should("not.exist");
 
     // Add a filter in order to be able to save question again
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Filter").click();
     popover()
       .findByText(/^Total$/)
       .click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Equal to").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Greater than").click();
     cy.findByPlaceholderText("Enter a number").type("60");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Add filter").click();
 
     // Save question - opens "Save question" modal
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Save").click();
 
     modal().within(() => {
@@ -76,17 +86,22 @@ describe("scenarios > question > saved", () => {
     cy.findAllByText("Orders"); // question and table name appears
 
     // filter to only orders with quantity=100
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Quantity").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     popover().within(() => cy.findByText("Filter by this column").click());
     popover().within(() => {
       cy.findByPlaceholderText("Search the list").type("100");
       cy.findByText("100").click();
       cy.findByText("Add filter").click();
     });
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Quantity is equal to 100");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Showing 2 rows"); // query updated
 
     // check that save will give option to replace
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Save").click();
     modal().within(() => {
       cy.findByText('Replace original question, "Orders"');
@@ -95,9 +110,13 @@ describe("scenarios > question > saved", () => {
     });
 
     // click "Started from Orders" and check that the original question is restored
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Started from").within(() => cy.findByText("Orders").click());
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Showing first 2,000 rows"); // query updated
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Started from").should("not.exist");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Quantity is equal to 100").should("not.exist");
   });
 
@@ -146,20 +165,25 @@ describe("scenarios > question > saved", () => {
       cy.findByTestId("question-revert-button").click();
     });
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(/reverted to an earlier revision/i);
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(/This is a question/i).should("not.exist");
   });
 
   it("should show table name in header with a table info popover on hover", () => {
     visitQuestion(1);
     cy.findByTestId("question-table-badges").trigger("mouseenter");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("9 columns");
   });
 
   it("should show collection breadcrumbs for a saved question in the root collection", () => {
     visitQuestion(1);
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     appBar().within(() => cy.findByText("Our analytics").click());
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Orders").should("be.visible");
   });
 
@@ -169,8 +193,10 @@ describe("scenarios > question > saved", () => {
     });
 
     visitQuestion(1);
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     appBar().within(() => cy.findByText("Second collection").click());
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Orders").should("be.visible");
   });
 
@@ -194,6 +220,7 @@ describe("scenarios > question > saved", () => {
     cy.signIn("readonly");
     visitQuestion(1);
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Tax")
       .closest(".TableInteractive-headerCellData")
       .as("headerCell")

--- a/e2e/test/scenarios/question/settings.cy.spec.js
+++ b/e2e/test/scenarios/question/settings.cy.spec.js
@@ -49,6 +49,7 @@ describe("scenarios > question > settings", () => {
         .click();
 
       // wait a Category value to appear in the table, so we know the query completed
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("Widget");
 
       // Add people.ean
@@ -59,6 +60,7 @@ describe("scenarios > question > settings", () => {
         .click();
 
       // wait a Ean value to appear in the table, so we know the query completed
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("8833419218504");
 
       // confirm that the table contains the right columns
@@ -122,9 +124,11 @@ describe("scenarios > question > settings", () => {
 
       reloadResults();
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("117.03").should("not.exist");
 
       // This click doesn't do anything, but simply allows the array to be updated (test gives false positive without this step)
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Visible columns").click();
 
       findColumnAtIndex("Products → Category", 5);
@@ -133,6 +137,7 @@ describe("scenarios > question > settings", () => {
       // https://github.com/metabase/metabase/pull/21338#pullrequestreview-928807257
 
       // Add "Address"
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Address").siblings(".Icon-add").click();
 
       // The result automatically load when adding new fields but two requests are fired.
@@ -173,15 +178,18 @@ describe("scenarios > question > settings", () => {
       });
 
       cy.findByTestId("viz-settings-button").click(); // open settings sidebar
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Conditional Formatting"); // confirm it's open
       cy.get(".TableInteractive").findByText("Subtotal").click(); // open subtotal column header actions
       popover().within(() => cy.icon("gear").click()); // open subtotal column settings
 
       //cy.findByText("Table options").should("not.exist"); // no longer displaying the top level settings
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Separator style"); // shows subtotal column settings
 
       cy.get(".TableInteractive").findByText("Created At").click(); // open created_at column header actions
       popover().within(() => cy.icon("gear").click()); // open created_at column settings
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Date style"); // shows created_at column settings
     });
 
@@ -206,6 +214,7 @@ describe("scenarios > question > settings", () => {
 
       visitQuestionAdhoc(questionDetails);
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(newColumnTitle);
 
       cy.findByTestId("viz-settings-button").click();
@@ -223,15 +232,22 @@ describe("scenarios > question > settings", () => {
           cy.icon("ellipsis").click();
         });
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Normal").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Currency").click();
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("US Dollar").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Bitcoin").click();
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("In every table cell").click();
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("₿ 2.07");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("₿ 6.10");
     });
   });
@@ -241,21 +257,28 @@ describe("scenarios > question > settings", () => {
       // create a question and add it to a modal
       openOrdersTable();
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("Save").click();
       cy.get(".ModalContent").contains("button", "Save").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("Yes please!").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("Orders in a dashboard").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Cancel").click();
 
       // create a new question to see if the "add to a dashboard" modal is still there
       openNavigationSidebar();
       browse().click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("Sample Database").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("Orders").click();
 
       // This next assertion might not catch bugs where the modal displays after
       // a quick delay. With the previous presentation of this bug, the modal
       // was immediately visible, so I'm not going to add any waits.
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("Add this question to a dashboard").should("not.exist");
     });
   });

--- a/e2e/test/scenarios/question/summarization.cy.spec.js
+++ b/e2e/test/scenarios/question/summarization.cy.spec.js
@@ -88,6 +88,7 @@ describe("scenarios > question > summarize sidebar", () => {
 
     getRemoveDimensionButton({ name: "User → State" }).click();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("User → State").should("not.exist");
   });
 
@@ -139,14 +140,18 @@ describe("scenarios > question > summarize sidebar", () => {
       { visitQuestion: true },
     );
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("49.54");
   });
 
   it("breakout binning popover should have normal height even when it's rendered lower on the screen (metabase#15445)", () => {
     cy.visit("/question/1/notebook");
     summarize({ mode: "notebook" });
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Count of rows").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Pick a column to group by").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Created At")
       .closest(".List-item")
       .findByText("by month")
@@ -173,6 +178,7 @@ describe("scenarios > question > summarize sidebar", () => {
 
     visualize();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("318.7");
   });
 
@@ -229,6 +235,7 @@ describe("scenarios > question > summarize sidebar", () => {
       cy.get(".List-item").contains("by month").click({ force: true });
     });
     // this should be among the granular selection choices
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Hour of Day").click();
   });
 
@@ -262,6 +269,7 @@ describe("scenarios > question > summarize sidebar", () => {
     removeMetricFromSidebar("Sum of Subtotal");
 
     cy.wait("@dataset");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Sum of Subtotal").should("not.exist");
 
     // "Sum of Total" should not be sorted, nor any other header cell
@@ -270,7 +278,9 @@ describe("scenarios > question > summarize sidebar", () => {
     removeMetricFromSidebar("Sum of Total");
 
     cy.wait("@dataset");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(/No results!/i).should("not.exist");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("744"); // `Count` for year 2016
   });
 
@@ -279,6 +289,7 @@ describe("scenarios > question > summarize sidebar", () => {
     openReviewsTable();
 
     summarize();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Group by")
       .parent()
       .findByText("Title")

--- a/e2e/test/scenarios/sharing/alert/alert-permissions.cy.spec.js
+++ b/e2e/test/scenarios/sharing/alert/alert-permissions.cy.spec.js
@@ -46,9 +46,12 @@ describe("scenarios > alert > alert permissions", { tags: "@external" }, () => {
       // Change alert
       visitQuestion(1);
       cy.icon("bell").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Edit").click();
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Daily").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Weekly").click();
 
       cy.button("Save changes").click();
@@ -67,7 +70,9 @@ describe("scenarios > alert > alert permissions", { tags: "@external" }, () => {
       visitQuestion(1);
       cy.icon("bell").click();
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Unsubscribe").should("not.exist");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Set up an alert");
     });
 
@@ -75,7 +80,9 @@ describe("scenarios > alert > alert permissions", { tags: "@external" }, () => {
       visitQuestion(2);
       cy.icon("bell").click();
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(`You're receiving ${getFullName(admin)}'s alerts`);
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Set up your own alert");
     });
 
@@ -83,6 +90,7 @@ describe("scenarios > alert > alert permissions", { tags: "@external" }, () => {
       visitQuestion(3);
       cy.icon("bell").click();
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("You set up an alert");
     });
 
@@ -90,15 +98,19 @@ describe("scenarios > alert > alert permissions", { tags: "@external" }, () => {
       // Unsubscribe from your own alert
       visitQuestion(3);
       cy.icon("bell").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Unsubscribe").click();
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Okay, you're unsubscribed");
 
       // Unsubscribe from others' alerts
       visitQuestion(2);
       cy.icon("bell").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Unsubscribe").click();
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Okay, you're unsubscribed");
     });
   });

--- a/e2e/test/scenarios/sharing/alert/alert-types.cy.spec.js
+++ b/e2e/test/scenarios/sharing/alert/alert-types.cy.spec.js
@@ -58,6 +58,7 @@ describe("scenarios > alert > types", { tags: "@external" }, () => {
 
         openAlertModal();
 
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("Done").click();
 
         cy.wait("@savedAlert").then(({ response: { body } }) => {
@@ -72,24 +73,31 @@ describe("scenarios > alert > types", { tags: "@external" }, () => {
       // Set goal on timeseries question
       visitQuestion(timeSeriesQuestionId);
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Visualization").click();
       leftSidebar().within(() => {
         cy.icon("line").realHover();
         cy.icon("gear").click();
       });
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Line options");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Display").click();
 
       setGoal("7000");
 
       // Save question
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Save").click();
       cy.get(".Modal").button("Save").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Save question").should("not.exist");
 
       openAlertModal();
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Reaches the goal line").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("The first time").click();
 
       cy.button("Done").click();
@@ -112,6 +120,7 @@ describe("scenarios > alert > types", { tags: "@external" }, () => {
       //   "Goal-based alerts aren't yet supported for charts with more than one line",
       // );
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Done").click();
 
       // The alert condition should fall back to rows

--- a/e2e/test/scenarios/sharing/alert/alert.cy.spec.js
+++ b/e2e/test/scenarios/sharing/alert/alert.cy.spec.js
@@ -18,6 +18,7 @@ describe("scenarios > alert", () => {
       visitQuestion(1);
       cy.icon("bell").click();
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(
         "To send alerts, you'll need to set up email or Slack integration.",
       );
@@ -29,6 +30,7 @@ describe("scenarios > alert", () => {
       visitQuestion(1);
       cy.icon("bell").click();
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(
         "To send alerts, an admin needs to set up email integration.",
       );
@@ -47,14 +49,21 @@ describe("scenarios > alert", () => {
         visitQuestion(1);
         cy.icon("bell").click();
 
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("The wide world of alerts");
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("There are a few different kinds of alerts you can get");
 
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.contains("When a raw data question returns any results");
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.contains("When a line or bar crosses a goal line");
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.contains("When a progress bar reaches its goal");
 
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("Set up an alert").click();
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("Done").click();
 
         cy.wait("@savedAlert");
@@ -65,7 +74,9 @@ describe("scenarios > alert", () => {
 
         cy.icon("bell").click();
 
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("Let's set up your alert");
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("The wide world of alerts").should("not.exist");
       });
     });

--- a/e2e/test/scenarios/sharing/approved-domains.cy.spec.js
+++ b/e2e/test/scenarios/sharing/approved-domains.cy.spec.js
@@ -28,13 +28,16 @@ describeEE(
       visitQuestion(1);
 
       cy.icon("bell").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Set up an alert").click();
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Email alerts to:")
         .parent()
         .within(() => addEmailRecipient(deniedEmail));
 
       cy.button("Done").should("be.disabled");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(alertError);
     });
 
@@ -42,6 +45,7 @@ describeEE(
     it.skip("should validate approved email domains for a dashboard subscription (metabase#17977)", () => {
       visitDashboard(1);
       cy.icon("subscription").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Email it").click();
 
       sidebar().within(() => {

--- a/e2e/test/scenarios/sharing/public-question.cy.spec.js
+++ b/e2e/test/scenarios/sharing/public-question.cy.spec.js
@@ -71,6 +71,7 @@ describe("scenarios > question > public", () => {
 
     cy.wait("@publicQuery");
     // Name of a city from the expected results
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Winner");
   });
 

--- a/e2e/test/scenarios/sharing/public.cy.spec.js
+++ b/e2e/test/scenarios/sharing/public.cy.spec.js
@@ -84,26 +84,35 @@ describe("scenarios > public", () => {
         cy.findByText("Is").click();
       });
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("Select…").click();
       popover().contains("Category").click();
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("Done").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("Save").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("You're editing this dashboard.").should("not.exist");
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains(COUNT_ALL);
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("Text")
         .parent()
         .parent()
         .find("fieldset")
         .should("not.exist");
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Text").click();
 
       popover().within(() => {
         cy.findByText("Doohickey").click();
       });
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("Add filter").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains(COUNT_DOOHICKEY);
 
       cy.url()
@@ -120,11 +129,13 @@ describe("scenarios > public", () => {
 
       cy.icon("share").click();
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("Enable sharing")
         .parent()
         .find("input[type=checkbox]")
         .check();
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("Public link")
         .parent()
         .find("input")
@@ -141,11 +152,13 @@ describe("scenarios > public", () => {
 
       cy.icon("share").click();
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("Enable sharing")
         .parent()
         .find("input[type=checkbox]")
         .check();
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("Public link")
         .parent()
         .find("input")
@@ -158,16 +171,20 @@ describe("scenarios > public", () => {
     it("should show shared questions and dashboards in admin settings", () => {
       cy.visit("/admin/settings/public-sharing");
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Enable Public Sharing").should("be.visible");
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(
         "Enable admins to create publicly viewable links (and embeddable iframes) for Questions and Dashboards.",
       ).should("be.visible");
 
       // shared questions
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("sql param").should("be.visible");
 
       // shared dashboard
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("parameterized dashboard").should("be.visible");
     });
 
@@ -177,23 +194,33 @@ describe("scenarios > public", () => {
 
         it(`should be able to view public questions`, () => {
           cy.visit(questionPublicLink);
+          // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
           cy.contains(COUNT_ALL);
 
+          // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
           cy.contains("Category").click();
+          // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
           cy.contains("Doohickey").click();
+          // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
           cy.contains("Add filter").click();
 
+          // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
           cy.contains(COUNT_DOOHICKEY);
         });
 
         it(`should be able to view public dashboards`, () => {
           cy.visit(dashboardPublicLink);
+          // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
           cy.contains(COUNT_ALL);
 
+          // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
           cy.contains("Text").click();
+          // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
           cy.contains("Doohickey").click();
+          // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
           cy.contains("Add filter").click();
 
+          // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
           cy.contains(COUNT_DOOHICKEY);
 
           // Enter full-screen button
@@ -217,17 +244,22 @@ describe("scenarios > public", () => {
       it("should be able to view public dashboards by anonymous users", () => {
         cy.signOut();
         cy.visit(dashboardPublicLink);
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.contains(COUNT_ALL);
 
         cy.button("Apply").should("not.exist");
 
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.contains("Text").click();
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.contains("Doohickey").click();
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.contains("Add filter").click();
 
         cy.button("Apply").should("be.visible").click();
         cy.button("Apply").should("not.exist");
 
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.contains(COUNT_DOOHICKEY);
 
         // Enter full-screen button

--- a/e2e/test/scenarios/sharing/pulse.cy.spec.js
+++ b/e2e/test/scenarios/sharing/pulse.cy.spec.js
@@ -13,7 +13,9 @@ describe("scenarios > pulse", { tags: "@external" }, () => {
 
     cy.findByPlaceholderText("Important metrics").click().type("pulse title");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Select a question").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Orders, Count").click();
 
     cy.findByPlaceholderText("Enter user names or email addresses")
@@ -21,12 +23,14 @@ describe("scenarios > pulse", { tags: "@external" }, () => {
       .blur();
 
     // pulse card preview
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("18,760");
 
     cy.button("Create pulse").click();
 
     cy.url().should("match", /\/collection\/root$/);
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("pulse title");
   });
 
@@ -54,7 +58,9 @@ describe("scenarios > pulse", { tags: "@external" }, () => {
 
     it("should load existing pulses", () => {
       cy.visit("/collection/root");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("pulse title").click({ force: true });
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("18,760");
     });
 
@@ -65,8 +71,10 @@ describe("scenarios > pulse", { tags: "@external" }, () => {
         .clear()
         .type("new pulse title");
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("Save changes").click();
       cy.url().should("match", /\/collection\/root$/);
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("new pulse title");
     });
   });

--- a/e2e/test/scenarios/sharing/reproductions/16108-missing-tooltip.cy.spec.js
+++ b/e2e/test/scenarios/sharing/reproductions/16108-missing-tooltip.cy.spec.js
@@ -9,10 +9,13 @@ describe("issue 16108", () => {
   it("should display a tooltip for CTA icons on an individual question (metabase#16108)", () => {
     visitQuestion(1);
     cy.icon("download").realHover();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Download full results");
     cy.icon("bell").realHover();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Get alerts");
     cy.icon("share").realHover();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Sharing");
   });
 });

--- a/e2e/test/scenarios/sharing/reproductions/16918.cy.spec.js
+++ b/e2e/test/scenarios/sharing/reproductions/16918.cy.spec.js
@@ -31,7 +31,9 @@ describe("issue 16918", () => {
   it(`should load question binned by "Month of Year" or similar granularity (metabase#16918)`, () => {
     cy.visit("/pulse/create");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Select a question").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("16918").click();
 
     cy.wait("@cardPreview").then(xhr => {
@@ -39,6 +41,7 @@ describe("issue 16918", () => {
     });
 
     // Cypress should be able to find question title in the card preview
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("16918");
   });
 });

--- a/e2e/test/scenarios/sharing/reproductions/17547.cy.spec.js
+++ b/e2e/test/scenarios/sharing/reproductions/17547.cy.spec.js
@@ -34,6 +34,7 @@ describe("issue 17547", () => {
       cy.findByText("Edit").click();
     });
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("AM").click();
     cy.button("Save changes").click();
 

--- a/e2e/test/scenarios/sharing/reproductions/17657.cy.spec.js
+++ b/e2e/test/scenarios/sharing/reproductions/17657.cy.spec.js
@@ -18,6 +18,7 @@ describe("issue 17657", () => {
 
     cy.icon("subscription").click();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(/^Emailed monthly/).click();
 
     sidebar().within(() => {
@@ -27,6 +28,7 @@ describe("issue 17657", () => {
     // Open the popover with all users
     cy.findByPlaceholderText("Enter user names or email addresses").click();
     // Pick admin as a recipient
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(`${first_name} ${last_name}`).click();
 
     sidebar().within(() => {

--- a/e2e/test/scenarios/sharing/reproductions/17658.cy.spec.js
+++ b/e2e/test/scenarios/sharing/reproductions/17658.cy.spec.js
@@ -25,9 +25,12 @@ describe("issue 17658", { tags: "@external" }, () => {
 
     cy.icon("subscription").click();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(/^Emailed monthly/).click();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Delete this subscription").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(/^This dashboard will no longer be emailed to/).click();
 
     cy.button("Delete").click();

--- a/e2e/test/scenarios/sharing/reproductions/18009-nodata-creates-subscription-receives-error.cy.spec.js
+++ b/e2e/test/scenarios/sharing/reproductions/18009-nodata-creates-subscription-receives-error.cy.spec.js
@@ -21,6 +21,7 @@ describe("issue 18009", { tags: "@external" }, () => {
 
     cy.icon("subscription").click();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Email it").click();
 
     cy.findByPlaceholderText("Enter user names or email addresses").click();
@@ -29,6 +30,7 @@ describe("issue 18009", { tags: "@external" }, () => {
       .click();
 
     // Click anywhere to close the popover that covers the "Send email now" button
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("To:").click();
 
     sendEmailAndAssert(email => {

--- a/e2e/test/scenarios/sharing/reproductions/18344-subscription-shows-original-question-name.cy.spec.js
+++ b/e2e/test/scenarios/sharing/reproductions/18344-subscription-shows-original-question-name.cy.spec.js
@@ -36,17 +36,21 @@ describe("issue 18344", { tags: "@external" }, () => {
     });
 
     saveDashboard();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("OrdersFoo");
   });
 
   it("subscription should not include original question name when it's been renamed in the dashboard (metabase#18344)", () => {
     // Send a test email subscription
     cy.icon("subscription").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Email it").click();
 
     cy.findByPlaceholderText("Enter user names or email addresses").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(`${first_name} ${last_name}`).click();
     // Click this just to close the popover that is blocking the "Send email now" button
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(`To:`).click();
 
     sendEmailAndAssert(email => {

--- a/e2e/test/scenarios/sharing/reproductions/18352-subscription-int64-value-card.cy.spec.js
+++ b/e2e/test/scenarios/sharing/reproductions/18352-subscription-int64-value-card.cy.spec.js
@@ -37,11 +37,14 @@ describe("issue 18352", { tags: "@external" }, () => {
   it("should send the card with the INT64 values (metabase#18352)", () => {
     cy.icon("subscription").click();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Email it").click();
 
     cy.findByPlaceholderText("Enter user names or email addresses").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(`${first_name} ${last_name}`).click();
     // Click this just to close the popover that is blocking the "Send email now" button
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(`To:`).click();
 
     sendEmailAndAssert(({ html }) => {

--- a/e2e/test/scenarios/sharing/reproductions/18669-test-email-with-parameters.cy.spec.js
+++ b/e2e/test/scenarios/sharing/reproductions/18669-test-email-with-parameters.cy.spec.js
@@ -30,6 +30,7 @@ describeEE("issue 18669", { tags: "@external" }, () => {
 
   it("should send a test email with non-default parameters (metabase#18669)", () => {
     cy.icon("subscription").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Email it").click();
 
     cy.findByPlaceholderText("Enter user names or email addresses")

--- a/e2e/test/scenarios/sharing/reproductions/20393-public-dashboard-nested-card-with-parameters.cy.spec.js
+++ b/e2e/test/scenarios/sharing/reproductions/20393-public-dashboard-nested-card-with-parameters.cy.spec.js
@@ -20,6 +20,7 @@ describe("issue 20393", () => {
     popover().contains("CREATED_AT").click();
 
     // save the dashboard
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Save").click();
 
     // open the sharing modal and enable sharing
@@ -27,6 +28,7 @@ describe("issue 20393", () => {
     cy.findByRole("switch").click();
 
     // navigate to the public dashboard link
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Public link")
       .parent()
       .within(() => {
@@ -36,6 +38,7 @@ describe("issue 20393", () => {
       });
 
     // verify that the card is visible on the page
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Q2");
   });
 });

--- a/e2e/test/scenarios/sharing/reproductions/21559-subscription-bar-sent-as-scalar.cy.spec.js
+++ b/e2e/test/scenarios/sharing/reproductions/21559-subscription-bar-sent-as-scalar.cy.spec.js
@@ -52,6 +52,7 @@ describe("issue 21559", { tags: "@external" }, () => {
   it("should respect dashboard card visualization (metabase#21559)", () => {
     cy.findByTestId("add-series-button").click({ force: true });
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(q2Details.name).click();
     cy.get(".AddSeriesModal").within(() => {
       cy.findByText("Done").click();
@@ -63,6 +64,7 @@ describe("issue 21559", { tags: "@external" }, () => {
     saveDashboard();
 
     cy.icon("subscription").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Email it").click();
 
     cy.findByPlaceholderText("Enter user names or email addresses")

--- a/e2e/test/scenarios/sharing/reproductions/22524-public-dashboard-updates-after-changing-parameters.cy.spec.js
+++ b/e2e/test/scenarios/sharing/reproductions/22524-public-dashboard-updates-after-changing-parameters.cy.spec.js
@@ -38,6 +38,7 @@ describe("issue 22524", () => {
     editDashboard();
     setFilter("Text or Category", "Is");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Select…").click();
     popover().contains("City").click();
 
@@ -47,6 +48,7 @@ describe("issue 22524", () => {
     cy.icon("share").click();
     cy.findByRole("switch").click();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Public link")
       .parent()
       .within(() => {
@@ -59,6 +61,7 @@ describe("issue 22524", () => {
     cy.findByPlaceholderText("Text").clear().type("Rye{enter}");
 
     // Check results
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("2-7900 Cuerno Verde Road");
   });
 });

--- a/e2e/test/scenarios/sharing/subscriptions.cy.spec.js
+++ b/e2e/test/scenarios/sharing/subscriptions.cy.spec.js
@@ -24,6 +24,7 @@ describe("scenarios > dashboard > subscriptions", () => {
     cy.createDashboard().then(({ body: { id: DASHBOARD_ID } }) => {
       visitDashboard(DASHBOARD_ID);
     });
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("This dashboard is looking empty.");
 
     cy.icon("share")
@@ -32,6 +33,7 @@ describe("scenarios > dashboard > subscriptions", () => {
       .click();
 
     cy.icon("subscription").should("not.exist");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(/Share this dashboard with people *./i).should("not.exist");
   });
 
@@ -47,6 +49,7 @@ describe("scenarios > dashboard > subscriptions", () => {
       .click()
       .type("Foo");
     cy.button("Save").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("You're editing this dashboard.").should("not.exist");
     cy.icon("share").closest("a").click();
 
@@ -55,6 +58,7 @@ describe("scenarios > dashboard > subscriptions", () => {
     // Dashboard subscriptions are not shown because
     // getting notifications with static text-only cards doesn't make a lot of sense
     cy.icon("subscription").should("not.exist");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(/Share this dashboard with people *./i);
   });
 
@@ -76,13 +80,16 @@ describe("scenarios > dashboard > subscriptions", () => {
       it("should not enable subscriptions without the recipient (metabase#17657)", () => {
         openDashboardSubscriptions();
 
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("Email it").click();
 
         // Make sure no recipients have been assigned
         cy.findByPlaceholderText("Enter user names or email addresses");
 
         // Change the schedule to "Monthly"
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("Hourly").click();
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("Monthly").click();
 
         sidebar().within(() => {
@@ -92,12 +99,14 @@ describe("scenarios > dashboard > subscriptions", () => {
 
       it("should allow creation of a new email subscription", () => {
         createEmailSubscription();
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("Emailed hourly");
       });
 
       it("should not render people dropdown outside of the borders of the screen (metabase#17186)", () => {
         openDashboardSubscriptions();
 
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("Email it").click();
         cy.findByPlaceholderText("Enter user names or email addresses").click();
 
@@ -119,6 +128,7 @@ describe("scenarios > dashboard > subscriptions", () => {
       beforeEach(createEmailSubscription);
       it("should show existing dashboard subscriptions", () => {
         openDashboardSubscriptions();
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("Emailed hourly");
       });
     });
@@ -127,17 +137,23 @@ describe("scenarios > dashboard > subscriptions", () => {
       assignRecipient();
       // This is extremely fragile
       // TODO: update test once changes from `https://github.com/metabase/metabase/pull/14121` are merged into `master`
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Attach results")
         .parent()
         .parent()
         .next()
         .find("input") // Toggle
         .click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Questions to attach").click();
       clickButton("Done");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Subscriptions");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Emailed hourly").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Delete this subscription").scrollIntoView();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Questions to attach");
       cy.findAllByRole("listitem")
         .contains("Orders") // yields the whole <li> element
@@ -148,15 +164,20 @@ describe("scenarios > dashboard > subscriptions", () => {
 
     it("should not display 'null' day of the week (metabase#14405)", () => {
       assignRecipient();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("To:").click();
       cy.findAllByTestId("select-button").contains("Hourly").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Monthly").click();
       cy.findAllByTestId("select-button").contains("First").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("15th (Midpoint)").click();
       cy.findAllByTestId("select-button").contains("15th (Midpoint)").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("First").click();
       clickButton("Done");
       // Implicit assertion (word mustn't contain string "null")
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(/^Emailed monthly on the first (?!null)/);
     });
 
@@ -212,6 +233,7 @@ describe("scenarios > dashboard > subscriptions", () => {
         );
       });
       // Click anywhere outside to close the popover
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("15705D").click();
       sendEmailAndAssert(email => {
         expect(email.html).not.to.include(
@@ -231,9 +253,11 @@ describe("scenarios > dashboard > subscriptions", () => {
         "You can use Markdown here, and include variables {{like_this}}",
       ).type(TEXT_CARD);
       cy.button("Save").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("You're editing this dashboard.").should("not.exist");
       assignRecipient();
       // Click outside popover to close it and at the same time check that the text card content is shown as expected
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(TEXT_CARD).click();
       sendEmailAndAssert(email => {
         expect(email.html).to.include(TEXT_CARD);
@@ -245,13 +269,16 @@ describe("scenarios > dashboard > subscriptions", () => {
     beforeEach(() => {
       mockSlackConfigured();
       openDashboardSubscriptions();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Send it to Slack").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Send this dashboard to Slack");
     });
 
     it("should not enable 'Done' button before channel is selected (metabase#14494)", () => {
       cy.findAllByRole("button", { name: "Done" }).should("be.disabled");
       cy.findByPlaceholderText("Pick a user or channel...").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("#work").click();
       cy.findAllByRole("button", { name: "Done" }).should("not.be.disabled");
     });
@@ -261,6 +288,7 @@ describe("scenarios > dashboard > subscriptions", () => {
         "be.disabled",
       );
       cy.findByPlaceholderText("Pick a user or channel...").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("#work").click();
       cy.findAllByRole("button", { name: "Done" }).should("not.be.disabled");
     });
@@ -280,9 +308,11 @@ describe("scenarios > dashboard > subscriptions", () => {
 
       it("should have a list of the default parameters applied to the subscription", () => {
         assignRecipient();
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("Text is Corbin Mertz");
         clickButton("Done");
 
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("Text is Corbin Mertz");
       });
     });
@@ -297,8 +327,10 @@ describe("scenarios > dashboard > subscriptions", () => {
     describe("with no parameters", () => {
       it("should have no parameters section", () => {
         openDashboardSubscriptions();
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("Email it").click();
 
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("Set filter values for when this gets sent").should(
           "not.exist",
         );
@@ -314,6 +346,7 @@ describe("scenarios > dashboard > subscriptions", () => {
         assignRecipient();
         clickButton("Done");
 
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("Text is Corbin Mertz");
       });
 
@@ -321,6 +354,7 @@ describe("scenarios > dashboard > subscriptions", () => {
         assignRecipient();
         clickButton("Done");
 
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("Emailed hourly").click();
 
         cy.findAllByText("Corbin Mertz").last().click();
@@ -336,6 +370,7 @@ describe("scenarios > dashboard > subscriptions", () => {
 
         clickButton("Done");
         cy.wait("@pulsePut");
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("Text is 2 selections and 1 more filter");
       });
     });

--- a/e2e/test/scenarios/visualizations/bar_chart.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/bar_chart.cy.spec.js
@@ -46,6 +46,7 @@ describe("scenarios > visualizations > bar chart", () => {
         }),
       );
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("(empty)").should("not.exist");
     });
 
@@ -58,6 +59,7 @@ describe("scenarios > visualizations > bar chart", () => {
         }),
       );
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("(empty)");
     });
   });
@@ -79,7 +81,9 @@ describe("scenarios > visualizations > bar chart", () => {
       });
 
       cy.get(".bar").should("have.length", 5); // there are six bars when null isn't filtered
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("1,800"); // correct data has this on the y-axis
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("16,000").should("not.exist"); // If nulls are included the y-axis stretches much higher
     });
   });
@@ -187,7 +191,9 @@ describe("scenarios > visualizations > bar chart", () => {
           cy.icon("eye_outline").click();
         });
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Filter").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Product").click();
 
       cy.findByTestId("filter-field-Category").within(() => {
@@ -202,6 +208,7 @@ describe("scenarios > visualizations > bar chart", () => {
         cy.findByText("Gadget").click();
       });
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Apply Filters").click();
 
       getDraggableElements().should("have.length", 3);
@@ -298,8 +305,10 @@ describe("scenarios > visualizations > bar chart", () => {
       });
 
       cy.findAllByTestId("legend-item").findByText("Doohickey").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("View these Products").click();
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Category is Doohickey").should("be.visible");
     });
   });
@@ -329,10 +338,13 @@ describe("scenarios > visualizations > bar chart", () => {
     cy.findByTestId("viz-settings-button").click();
     cy.get("[data-testid^=draggable-item]").should("have.length", 100);
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("ID is less than 101").click();
     cy.findByDisplayValue("101").type("{backspace}2");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Update filter").click();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(
       "This chart type doesn't support more than 100 series of data.",
     );

--- a/e2e/test/scenarios/visualizations/drillthroughs/chart_drill.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/drillthroughs/chart_drill.cy.spec.js
@@ -47,7 +47,9 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
       { visitQuestion: true },
     );
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Gadget");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("January, 2017");
     cy.wait(100); // wait longer to avoid grabbing the svg before a chart redraw
 
@@ -60,13 +62,19 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
     // new filter applied
     // Note: Test was flaking because apparently mouseup doesn't always happen at the same position.
     //       It is enough that we assert that the filter exists and that it starts with May, 2016
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains(/^Created At between May, 2016/);
     // more granular axis labels
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("June, 2016");
     // confirm that product category is still broken out
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Gadget");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Doohickey");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Gizmo");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Widget");
   });
 
@@ -101,7 +109,8 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
       cy.wait("@dataset");
 
       granularity === "month"
-        ? cy.findByText("Created At between September, 2016 February, 2017")
+        ? // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
+          cy.findByText("Created At between September, 2016 February, 2017")
         : // Once the issue gets fixed, figure out the positive assertion for the "month-of-year" granularity
           null;
 
@@ -260,21 +269,29 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
     });
     // Build a new question off that grouping by City
     startNewQuestion();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Saved Questions").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("CA People").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Hudson Borer");
     summarize();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Summarize by").parent().parent().contains("City").click();
 
     // wait for chart to load
     cy.wait("@dataset");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Count by City");
     // drill into the first bar
     cy.get(".bar").first().click({ force: true });
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("View this CA People").click();
 
     // check that filter is applied and person displayed
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("City is Beaver Dams");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Dominique Leffler");
   });
 
@@ -291,57 +308,75 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
 
     // Load the question up
     cy.visit("/collection/root");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Orders by Created At: Week").click({ force: true });
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("January, 2019");
 
     // drill into a recent week
     cy.get(".dot").eq(-4).click({ force: true });
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("View these Orders").click();
 
     // check that filter is applied and rows displayed
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Showing 127 rows");
 
     cy.log("Filter should show the range between two dates");
     // Now click on the filter widget to see if the proper parameters got passed in
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Created At between").click();
   });
 
   it.skip("should drill-through on filtered aggregated results (metabase#13504)", () => {
     openOrdersTable({ mode: "notebook" });
     summarize({ mode: "notebook" });
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Count of rows").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Pick a column to group by").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Created At").click();
 
     // add filter: Count > 1
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Filter").click();
     popover().within(() => {
       cy.findByText("Count").click();
       cy.findByText("Equal to").click();
     });
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Greater than").click();
     cy.findByPlaceholderText("Enter a number").click().type("1");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Add filter").click();
 
     visualize();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Visualization").click();
     cy.icon("line").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Done").click();
     cy.log("Mid-point assertion");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Count by Created At: Month");
     // at this point, filter is displaying correctly with the name
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Count is greater than 1");
 
     // drill-through
     cy.get(".dot")
       .eq(10) // random dot
       .click({ force: true });
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("View these Orders").click();
 
     cy.log("Reproduced on 0.34.3, 0.35.4, 0.36.7 and 0.37.0-rc2");
     // when the bug is present, filter is missing a name (showing only "is 256")
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Count is equal to 256");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("There was a problem with your question").should("not.exist");
   });
 
@@ -481,14 +516,19 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
       },
       display: "table",
     });
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(/^10 –/)
       .closest(".TableInteractive-cellWrapper")
       .next()
       .contains("85")
       .click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("View these Orders").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Quantity is greater than or equal to 10");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Quantity is less than 20");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Showing 85 rows");
   });
 
@@ -510,11 +550,15 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
     });
 
     // click on the Count column cell showing the count of null rows
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("16,845").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("View these Orders").click();
 
     // count number of distinct values in the Discount column
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Discount ($)").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Distinct values").click();
 
     // there should be 0 distinct values since they are all null
@@ -576,6 +620,7 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
 
       // Drill-through the last bar (Widget)
       cy.get(".bar").last().click({ force: true });
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("View these Products").click();
     });
 
@@ -585,8 +630,11 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
       cy.url().should("include", "/question#");
 
       cy.log("Assert on the correct product category: Widget");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Category is Widget");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Gizmo").should("not.exist");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Doohickey").should("not.exist");
     });
   });

--- a/e2e/test/scenarios/visualizations/drillthroughs/dash_drill.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/drillthroughs/dash_drill.cy.spec.js
@@ -34,6 +34,7 @@ describe("scenarios > visualizations > drillthroughs > dash_drill", () => {
 
         addCardToNewDashboard(DASHBOARD_NAME, Q2.id);
 
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText(DASHBOARD_NAME);
         clickScalarCardTitle(Q2.name);
       });
@@ -42,6 +43,7 @@ describe("scenarios > visualizations > drillthroughs > dash_drill", () => {
         cy.log("Assert that the url is correct");
         cy.location("pathname").should("eq", `/question/${Q2.expectedPath}`);
 
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.contains("18,760");
       });
     });
@@ -66,12 +68,14 @@ describe("scenarios > visualizations > drillthroughs > dash_drill", () => {
 
         addCardToNewDashboard(DASHBOARD_NAME, Q2.id);
 
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText(DASHBOARD_NAME);
         clickScalarCardTitle(Q2.name);
       });
 
       it("should result in a correct query result", () => {
         cy.location("pathname").should("eq", `/question/${Q2.expectedPath}`);
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("5,755");
       });
     });
@@ -114,6 +118,7 @@ describe("scenarios > visualizations > drillthroughs > dash_drill", () => {
       });
 
       it("should result in a correct query result", () => {
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("Affiliate");
         cy.get(".dot").should("have.length.of.at.least", 100);
       });

--- a/e2e/test/scenarios/visualizations/funnel.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/funnel.cy.spec.js
@@ -80,6 +80,7 @@ describe("scenarios > visualizations > funnel chart", () => {
         cy.icon("eye_outline").click();
       });
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Filter").click();
 
     cy.findByTestId("filter-field-Source").within(() => {
@@ -94,6 +95,7 @@ describe("scenarios > visualizations > funnel chart", () => {
       cy.findByText("Facebook").click();
     });
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Apply Filters").click();
 
     getDraggableElements().should("have.length", 4);

--- a/e2e/test/scenarios/visualizations/gauge.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/gauge.cy.spec.js
@@ -38,6 +38,7 @@ describe("scenarios > visualizations > gauge chart", () => {
     );
 
     cy.findByTestId("gauge-arc-1").trigger("mousemove");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Something went wrong").should("not.exist");
   });
 });

--- a/e2e/test/scenarios/visualizations/line_chart.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/line_chart.cy.spec.js
@@ -40,6 +40,7 @@ describe("scenarios > visualizations > line chart", () => {
 
     cy.findByTestId("viz-settings-button").click();
     openSeriesSettings("Count");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Right").click();
     cy.get(Y_AXIS_RIGHT_SELECTOR);
   });
@@ -97,6 +98,7 @@ describe("scenarios > visualizations > line chart", () => {
       },
     });
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(
       "This chart type doesn't support more than 100 series of data.",
     );
@@ -494,6 +496,7 @@ describe("scenarios > visualizations > line chart", () => {
         },
         display: "line",
       });
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Category is Doohickey");
     });
 

--- a/e2e/test/scenarios/visualizations/maps.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/maps.cy.spec.js
@@ -25,25 +25,31 @@ describe("scenarios > visualizations > maps", () => {
     cy.get(".NativeQueryEditor .Icon-play").click();
 
     // switch to a pin map visualization
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Visualization").click();
     cy.icon("pinmap").click();
     cy.findByTestId("Map-button").within(() => {
       cy.icon("gear").click();
     });
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Map type").next().click();
     popover().contains("Pin map").click();
 
     // When the settings sidebar opens, both latitude and longitude selects are
     // open. That makes it difficult to select each in Cypress, so we click
     // outside twice to close both of them before reopening them one-by-one. :(
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("New question").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("New question").click();
 
     // select both columns
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Latitude field").next().click();
     popover().contains("LAT").click();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Longitude field").next().click();
     popover().contains("LNG").click();
 
@@ -71,6 +77,7 @@ describe("scenarios > visualizations > maps", () => {
       { visitQuestion: true },
     );
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Visualization").closest(".Button").as("vizButton");
     cy.get("@vizButton").click();
     cy.findByTestId("display-options-sensible").as("sensibleOptions");
@@ -110,18 +117,23 @@ describe("scenarios > visualizations > maps", () => {
     cy.get("@texas").trigger("mousemove");
 
     // check tooltip content
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("State:"); // column name key
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Texas"); // feature name as value
 
     // open drill-through menu and drill within it
     cy.get("@texas").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(/View these People/i).click();
 
     cy.log("Reported as a regression since v0.37.0");
     cy.wait("@dataset").then(xhr => {
       expect(xhr.request.body.query.filter).not.to.contain("Texas");
     });
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("State is TX");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("171 Olive Oyle Lane"); // Address in the first row
   });
 
@@ -165,8 +177,11 @@ describe("scenarios > visualizations > maps", () => {
 
     cy.get(".leaflet-interactive").trigger("mousemove");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Latitude:");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Longitude:");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("1");
   });
 
@@ -195,6 +210,7 @@ describe("scenarios > visualizations > maps", () => {
     // Ensure chart is rendered
     cy.get(".leaflet-interactive");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Visualization").click();
 
     // Ensure the Map visualization is sensible

--- a/e2e/test/scenarios/visualizations/object_detail.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/object_detail.cy.spec.js
@@ -177,6 +177,7 @@ describe("scenarios > question > object details", () => {
     cy.findByTestId("qb-filters-panel").findByText(
       `Product ID is ${PRODUCT_ID}`,
     );
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(`Showing ${EXPECTED_LINKED_ORDERS_COUNT} rows`);
   });
 
@@ -253,7 +254,9 @@ describe("scenarios > question > object details", () => {
     cy.findByTestId("object-detail");
 
     cy.log("metabase(#29023)");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("People → Name").scrollIntoView().should("be.visible");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(/Item 1 of/i).should("be.visible");
   });
 });

--- a/e2e/test/scenarios/visualizations/pivot_tables.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/pivot_tables.cy.spec.js
@@ -40,6 +40,7 @@ describe("scenarios > visualizations > pivot tables", () => {
   it("should be created from an ad-hoc question", () => {
     visitQuestionAdhoc({ dataset_query: testQuery, display: "pivot" });
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(/Count by Users? → Source and Products? → Category/); // ad-hoc title
 
     cy.findByTestId("viz-settings-button").click();
@@ -65,9 +66,11 @@ describe("scenarios > visualizations > pivot tables", () => {
     createAndVisitTestQuestion();
 
     // Switch to "ordinary" table
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Visualization").click();
     cy.icon("table").should("be.visible").click();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains(`Started from ${QUESTION_NAME}`);
 
     cy.log("Assertions on a table itself");
@@ -86,29 +89,42 @@ describe("scenarios > visualizations > pivot tables", () => {
   it("should allow drill through on cells", () => {
     createAndVisitTestQuestion();
     // open drill-through menu
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("783").click();
     // drill through to orders list
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("View these Orders").click();
     // filters are applied
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Source is Affiliate");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Category is Doohickey");
     // data loads
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("45.04");
   });
 
   it("should allow drill through on left/top header values", () => {
     createAndVisitTestQuestion();
     // open drill-through menu and filter to that value
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Doohickey").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     popover().within(() => cy.findByText("=").click());
     // filter is applied
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Category is Doohickey");
     // filter out affiliate as a source
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Affiliate").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     popover().within(() => cy.findByText("≠").click());
     // filter is applied and value is gone from the left header
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Source is not Affiliate");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Affiliate").should("not.exist");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("3,193"); // new grand total
   });
 
@@ -125,6 +141,7 @@ describe("scenarios > visualizations > pivot tables", () => {
     dragField(1, 0);
 
     // One field should now be empty
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Drag fields here");
 
     cy.log("Implicit assertions on a table itself");
@@ -194,25 +211,37 @@ describe("scenarios > visualizations > pivot tables", () => {
       },
     });
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("215"); // see a non-subtotal value
 
     // click to collapse rows
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Doohickey").parent().find(".Icon-dash").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("1,352"); // subtotal is still there
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("215").should("not.exist"); // value is hidden
 
     // click to uncollapse
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Totals for Doohickey").parent().find(".Icon-add").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("215"); // ...and it's back!
 
     // collapse the column
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Product → Category").parent().find(".Icon-dash").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("215").should("not.exist"); // value is hidden
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("294").should("not.exist"); // value in another section is also hidden
 
     // uncollapse Doohickey
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Totals for Doohickey").parent().find(".Icon-add").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("215"); // value in doohickey is visible
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("294").should("not.exist"); // the other one is still hidden
   });
 
@@ -256,14 +285,20 @@ describe("scenarios > visualizations > pivot tables", () => {
     };
 
     visitQuestionAdhoc(questionDetails);
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("1162").should("be.visible");
     // Collapse "User ID" column
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("User ID").parent().find(".Icon-dash").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Totals for 1162").should("be.visible");
 
     //Expanding the grouped column should still work
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Totals for 1162").parent().find(".Icon-add").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("1162").should("be.visible");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("34").should("be.visible");
   });
 
@@ -280,8 +315,10 @@ describe("scenarios > visualizations > pivot tables", () => {
       },
     });
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(/Count by Users? → Source and Products? → Category/); // ad-hoc title
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("3,520"); // check for one of the subtotals
 
     // open settings
@@ -290,12 +327,15 @@ describe("scenarios > visualizations > pivot tables", () => {
 
     // Confirm that Product -> Category doesn't have the option to hide subtotals
     openColumnSettings(/Product → Category/);
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Show totals").should("not.be.visible");
 
     // turn off subtotals for User -> Source
     openColumnSettings(/Users? → Source/);
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Show totals").parent().find("input").click();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("3,520").should("not.exist"); // the subtotal has disappeared!
   });
 
@@ -310,7 +350,9 @@ describe("scenarios > visualizations > pivot tables", () => {
       },
     });
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("899").should("not.exist"); // confirm that "Affiliate" is collapsed
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("3,520"); // affiliate subtotal is visible
 
     // open settings
@@ -318,15 +360,19 @@ describe("scenarios > visualizations > pivot tables", () => {
 
     // turn off subtotals for User -> Source
     openColumnSettings(/Users? → Source/);
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Show totals").parent().find("input").click();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("3,520").should("not.exist"); // the subtotal isn't there
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("899"); // Affiliate is no longer collapsed
   });
 
   it("should allow column formatting", () => {
     visitQuestionAdhoc({ dataset_query: testQuery, display: "pivot" });
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(/Count by Users? → Source and Products? → Category/); // ad-hoc title
 
     cy.findByTestId("viz-settings-button").click();
@@ -334,10 +380,12 @@ describe("scenarios > visualizations > pivot tables", () => {
     openColumnSettings(/Users? → Source/);
 
     cy.log("New panel for the column options");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(/Column title/);
 
     cy.log("Change the title for this column");
     cy.get("input[id=column_title]").clear().type("ModifiedTITLE").blur();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Done").click();
     cy.get(".Visualization").within(() => {
       cy.findByText("ModifiedTITLE");
@@ -347,6 +395,7 @@ describe("scenarios > visualizations > pivot tables", () => {
   it("should allow value formatting", () => {
     visitQuestionAdhoc({ dataset_query: testQuery, display: "pivot" });
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(/Count by Users? → Source and Products? → Category/); // ad-hoc title
 
     cy.findByTestId("viz-settings-button").click();
@@ -354,13 +403,19 @@ describe("scenarios > visualizations > pivot tables", () => {
     openColumnSettings(/Count/);
 
     cy.log("New panel for the column options");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Column title");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Style");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Separator style");
 
     cy.log("Change the value formatting");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Normal").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Percent").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Done").click();
     cy.get(".Visualization").within(() => {
       cy.findByText("78,300%");
@@ -370,12 +425,14 @@ describe("scenarios > visualizations > pivot tables", () => {
   it("should not allow sorting of value fields", () => {
     visitQuestionAdhoc({ dataset_query: testQuery, display: "pivot" });
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(/Count by Users? → Source and Products? → Category/); // ad-hoc title
 
     cy.findByTestId("viz-settings-button").click();
     assertOnPivotSettings();
     openColumnSettings(/Count/);
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(/Sort order/).should("not.be.visible");
   });
 
@@ -408,12 +465,16 @@ describe("scenarios > visualizations > pivot tables", () => {
 
     // sort descending
     cy.icon("arrow_down").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("158 – 160");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("8 – 10").should("not.exist");
 
     // sort ascending
     cy.icon("arrow_up").realClick();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("8 – 10");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("158 – 160").should("not.exist");
   });
 
@@ -428,6 +489,7 @@ describe("scenarios > visualizations > pivot tables", () => {
       visualization_settings: {},
     });
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Pivot tables can only be used with aggregated queries.");
   });
 
@@ -455,15 +517,21 @@ describe("scenarios > visualizations > pivot tables", () => {
       });
 
       // value headings
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Sum of Total");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Sum of Twice Total");
 
       // check values in the table
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("42,156.87"); // sum of total for 2016
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("84,313.74"); // sum of "twice total" for 2016
 
       // check grand totals
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("1,510,621.68"); // sum of total grand total
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("3,021,243.37"); // sum of "twice total" grand total
     });
 
@@ -488,9 +556,13 @@ describe("scenarios > visualizations > pivot tables", () => {
         display: "pivot",
       });
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("category_foo");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Doohickeyfoo");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("42"); // count of Doohickeyfoo
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("200"); // grand total
     });
   });
@@ -519,11 +591,17 @@ describe("scenarios > visualizations > pivot tables", () => {
 
     it("should allow filtering drill through (metabase#14632)", () => {
       assertOnPivotFields();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Google").click(); // open drill-through menu
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       popover().within(() => cy.findByText("=").click()); // drill with additional filter
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Source is Google"); // filter was added
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Row totals"); // it's still a pivot table
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("1,027"); // primary data value
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("3,798"); // subtotal value
     });
   });
@@ -571,11 +649,13 @@ describe("scenarios > visualizations > pivot tables", () => {
       describe(test.case, () => {
         beforeEach(() => {
           cy.visit("collection/root");
+          // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
           cy.findByText(test.subject).click();
           cy.icon("share").click();
         });
 
         it("should display pivot table in a public link", () => {
+          // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
           cy.findByText("Public link")
             .parent()
             .find("input")
@@ -589,15 +669,19 @@ describe("scenarios > visualizations > pivot tables", () => {
 
         // Skipped to avoid flake
         it.skip("should display pivot table in an embed preview", () => {
+          // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
           cy.findByText(/Embed in your application/).click();
           // we use preview endpoints when MB is iframed in itself
+          // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
           cy.findByText(test.subject);
           getIframeBody().within(assertOnPivotFields);
         });
 
         it("should display pivot table in an embed URL", () => {
+          // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
           cy.findByText(/Embed in your application/).click();
 
+          // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
           cy.findByText("Publish").click();
 
           // visit the iframe src directly to ensure it's not sing preview endpoints
@@ -613,6 +697,7 @@ describe("scenarios > visualizations > pivot tables", () => {
   it("should open the download popover (metabase#14750)", () => {
     createAndVisitTestQuestion();
     cy.icon("download").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     popover().within(() => cy.findByText("Download full results"));
   });
 
@@ -638,8 +723,11 @@ describe("scenarios > visualizations > pivot tables", () => {
       visitQuestion(QUESTION_ID);
     });
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Grand totals");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Row totals");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("200");
   });
 
@@ -679,6 +767,7 @@ describe("scenarios > visualizations > pivot tables", () => {
       display: "line",
     });
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Visualization").click();
     leftSidebar().within(() => {
       // This part is still failing. Uncomment when fixed.
@@ -743,12 +832,18 @@ describe("scenarios > visualizations > pivot tables", () => {
       },
     });
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("November 9, 2016");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("November 10, 2016");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("November 11, 2016");
     collapseRowsFor("Created At: Day");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Totals for November 9, 2016");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Totals for November 10, 2016");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Totals for November 11, 2016");
 
     function collapseRowsFor(column_name) {
@@ -836,13 +931,18 @@ describe("scenarios > visualizations > pivot tables", () => {
     });
 
     cy.findByTestId("viz-settings-button").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Conditional Formatting").click();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Add a rule").click();
     cy.findByTestId("conditional-formatting-value-input").type("70");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("is equal to").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("is less than or equal to").click();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("[data-testid=pivot-table-cell]", "65.09").should(
       "have.css",
       "background-color",

--- a/e2e/test/scenarios/visualizations/reproductions/13504-post-aggregation-drill.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/reproductions/13504-post-aggregation-drill.cy.spec.js
@@ -32,10 +32,13 @@ describe("issue 13504", () => {
     cy.createQuestion(questionDetails, { visitQuestion: true });
 
     cy.get(".dot").eq(0).click({ force: true });
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(/View these Orders/).click();
     cy.wait("@dataset");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Total is greater than 50").should("be.visible");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Created At is March, 2017").should("be.visible");
   });
 });

--- a/e2e/test/scenarios/visualizations/reproductions/14148-pivot-table-postgres.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/reproductions/14148-pivot-table-postgres.cy.spec.js
@@ -37,7 +37,9 @@ describe("issue 14148", { tags: "@external" }, () => {
       "Reported failing on v0.38.0-rc1 querying Postgres, Redshift and BigQuery. It works on MySQL and H2.",
     );
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(/Grand totals/i);
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("2,500");
   });
 });

--- a/e2e/test/scenarios/visualizations/reproductions/16170-line-mongo-replace-missing-values.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/reproductions/16170-line-mongo-replace-missing-values.cy.spec.js
@@ -36,6 +36,7 @@ describe("issue 16170", { tags: "@external" }, () => {
 
       replaceMissingValuesWith(replacementValue);
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Done").click();
 
       assertOnTheYAxis();

--- a/e2e/test/scenarios/visualizations/reproductions/17524.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/reproductions/17524.cy.spec.js
@@ -61,6 +61,7 @@ describe("issue 17524", () => {
       cy.icon("play").last().click();
 
       cy.get("polygon");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Save").should("not.exist");
     });
   });

--- a/e2e/test/scenarios/visualizations/reproductions/18061-maps-only-nulls-crash-frontend.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/reproductions/18061-maps-only-nulls-crash-frontend.cy.spec.js
@@ -102,14 +102,17 @@ describe("issue 18061", () => {
       cy.window().then(w => (w.beforeReload = true));
 
       cy.icon("filter").parent().contains("1").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("ID is less than 3").click();
 
       popover().find("input").type("{backspace}2");
 
       cy.button("Update filter").click();
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Something went wrong").should("not.exist");
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("ID is less than 2");
       cy.get(".PinMap");
 
@@ -126,6 +129,7 @@ describe("issue 18061", () => {
       addFilter("Twitter");
 
       cy.wait("@dashCardQuery");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Something went wrong").should("not.exist");
 
       cy.location("search").should("eq", "?category=Twitter");
@@ -136,7 +140,9 @@ describe("issue 18061", () => {
     it("should handle data sets that contain only null values for longitude/latitude (metabase#18061-3)", () => {
       visitAlias("@publicLink");
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("18061D");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("18061");
       cy.get(".PinMap");
 

--- a/e2e/test/scenarios/visualizations/reproductions/18063-maps-null-location-wrong-tooltip.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/reproductions/18063-maps-null-location-wrong-tooltip.cy.spec.js
@@ -25,6 +25,7 @@ describe("issue 18063", () => {
 
     // Click anywhere to close both popovers that open automatically.
     // Please see: https://github.com/metabase/metabase/issues/18063#issuecomment-927836691
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Map type").click();
   });
 

--- a/e2e/test/scenarios/visualizations/reproductions/18776-timeseries-hidden-axis-freeze.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/reproductions/18776-timeseries-hidden-axis-freeze.cy.spec.js
@@ -28,6 +28,7 @@ describe("issue 18776", () => {
 
   it("should not freeze when opening a timeseries chart with sparse data and without the X-axis", () => {
     visitQuestionAdhoc(questionDetails);
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Visualization").should("be.visible");
   });
 });

--- a/e2e/test/scenarios/visualizations/reproductions/18976-pivot-table-columns.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/reproductions/18976-pivot-table-columns.cy.spec.js
@@ -27,6 +27,7 @@ describe("issue 18976", () => {
   it("should display a pivot table as regular one when pivot columns are missing (metabase#18976)", () => {
     visitQuestionAdhoc(questionDetails);
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Showing 1 row");
   });
 });

--- a/e2e/test/scenarios/visualizations/reproductions/18996-table-image-pagination.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/reproductions/18996-table-image-pagination.cy.spec.js
@@ -41,8 +41,10 @@ describe("issue 18996", () => {
       visitDashboard(dashboard_id);
     });
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(/Rows \d+-\d+ of 10/).should("be.visible");
     cy.icon("triangle_right").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(/Rows \d+-\d+ of 10/).should("be.visible");
   });
 });

--- a/e2e/test/scenarios/visualizations/reproductions/21392-chart-many-columns-freeze.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/reproductions/21392-chart-many-columns-freeze.cy.spec.js
@@ -30,6 +30,7 @@ describe("issue 21392", () => {
 
   it("should render a chart with many columns without freezing (metabase#21392)", () => {
     visitQuestionAdhoc({ dataset_query: TEST_QUERY, display: "line" });
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Visualization").should("be.visible");
   });
 });

--- a/e2e/test/scenarios/visualizations/reproductions/21452-xhr-on-every-char-for-rename.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/reproductions/21452-xhr-on-every-char-for-rename.cy.spec.js
@@ -34,10 +34,12 @@ describe("issue 21452", () => {
   it("should not fire POST request after every character during display name change (metabase#21452)", () => {
     openSeriesSettings("Sum of Quantity");
     cy.findByDisplayValue("Sum of Quantity").clear().type("Foo");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Display type").click();
     // Blur will result in another POST request which is expected
     cy.wait("@dataset");
     // Dismiss the popup and close settings
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Done").click();
 
     cy.get("circle").first().realHover();

--- a/e2e/test/scenarios/visualizations/reproductions/21504-pie-settings-formatting.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/reproductions/21504-pie-settings-formatting.cy.spec.js
@@ -27,7 +27,9 @@ describe("issue 21504", () => {
     });
 
     cy.findByTestId("viz-settings-button").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Display").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("April, 2016").should("be.visible");
   });
 });

--- a/e2e/test/scenarios/visualizations/reproductions/21615-convert-to-sql.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/reproductions/21615-convert-to-sql.cy.spec.js
@@ -29,7 +29,9 @@ describe("issue 21615", () => {
     cy.icon("sql").click();
     cy.button("Convert this question to SQL").click();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Visualization").should("be.visible");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Something went wrong").should("not.exist");
   });
 });

--- a/e2e/test/scenarios/visualizations/reproductions/21665-multi-series-frontend-reload.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/reproductions/21665-multi-series-frontend-reload.cy.spec.js
@@ -42,6 +42,7 @@ describe("issue 21665", () => {
 
     cy.findByTestId("add-series-button").click({ force: true });
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(Q2.name).click();
 
     cy.get(".AddSeriesModal").within(() => {
@@ -60,6 +61,7 @@ describe("issue 21665", () => {
     });
 
     cy.get("@dashboardLoaded").should("have.been.calledThrice");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("There was a problem displaying this chart.").should(
       "be.visible",
     );

--- a/e2e/test/scenarios/visualizations/reproductions/22527-scatter-negative-values-not-rendered.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/reproductions/22527-scatter-negative-values-not-rendered.cy.spec.js
@@ -28,6 +28,7 @@ describe.skip("issue 22527", () => {
       cy.findByTextEnsureVisible("Data").click();
     });
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Bubble size").parent().contains("Select a field").click();
 
     popover().contains(/size/i).click();

--- a/e2e/test/scenarios/visualizations/reproductions/28304-table-columns-unknown.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/reproductions/28304-table-columns-unknown.cy.spec.js
@@ -62,6 +62,7 @@ describe("issue 28304", () => {
   });
 
   it("table should should generate default columns when table.columns entries do not match data.cols (metabase#28304)", () => {
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Count by Created At: Month").should("be.visible");
 
     cy.findByTestId("viz-settings-button").click();

--- a/e2e/test/scenarios/visualizations/reproductions/28311-sorting-table-columns.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/reproductions/28311-sorting-table-columns.cy.spec.js
@@ -57,6 +57,7 @@ describe("issue 25250", () => {
   });
 
   it("pivot table should show standalone values when collapsed to the sub-level grouping (metabase#25250)", () => {
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Product ID").should("be.visible");
 
     cy.findByTestId("viz-settings-button").click();

--- a/e2e/test/scenarios/visualizations/reproductions/6010-metric-filter-drill.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/reproductions/6010-metric-filter-drill.cy.spec.js
@@ -16,10 +16,13 @@ describe("issue 6010", () => {
       .then(({ body: { id } }) => visitQuestion(id));
 
     cy.get(".dot").eq(0).click({ force: true });
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(/View these Orders/).click();
     cy.wait("@dataset");
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Created At is January, 2018").should("be.visible");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Total is greater than 150").should("be.visible");
   });
 });

--- a/e2e/test/scenarios/visualizations/scalar.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/scalar.cy.spec.js
@@ -64,10 +64,13 @@ describe("scenarios > visualizations > scalar", () => {
       display: "scalar",
     });
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("April 30, 2018");
     cy.findByTestId("viz-settings-button").click();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Show the time").should("be.hidden");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Time style").should("be.hidden");
   });
 });

--- a/e2e/test/scenarios/visualizations/scatter.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/scatter.cy.spec.js
@@ -82,6 +82,7 @@ describe("scenarios > visualizations > scatter", () => {
       },
     });
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Visualization");
     cy.findAllByText("79").should("not.exist");
   });

--- a/e2e/test/scenarios/visualizations/smartscalar-trend.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/smartscalar-trend.cy.spec.js
@@ -29,6 +29,7 @@ describe("scenarios > visualizations > scalar", () => {
     cy.log("Bug: showing blank visualization");
 
     cy.get(".ScalarValue").contains("100");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Nothing to compare for the previous month.");
   });
 });

--- a/e2e/test/scenarios/visualizations/table.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/table.cy.spec.js
@@ -18,12 +18,14 @@ describe("scenarios > visualizations > table", () => {
   it("should allow to display any column as link with extrapolated url and text", () => {
     openPeopleTable({ limit: 2 });
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("City").click();
 
     popover().within(() => {
       cy.icon("gear").click();
     });
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Link").click();
 
     cy.findByTestId("link_text").type("{{C");
@@ -43,6 +45,7 @@ describe("scenarios > visualizations > table", () => {
       })
       .blur();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Wood River 1 fixed text").should(
       "have.attr",
       "href",
@@ -173,6 +176,7 @@ describe("scenarios > visualizations > table", () => {
   it("should show the field metadata popover for a foreign key field (metabase#19577)", () => {
     openOrdersTable({ limit: 2 });
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Product ID").trigger("mouseenter");
 
     popover().within(() => {
@@ -195,6 +199,7 @@ describe("scenarios > visualizations > table", () => {
   it.skip("should close the colum popover on subsequent click (metabase#16789)", () => {
     openPeopleTable({ limit: 2 });
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("City").click();
     popover().within(() => {
       cy.icon("arrow_up");
@@ -205,6 +210,7 @@ describe("scenarios > visualizations > table", () => {
       cy.findByText("Distinct values");
     });
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("City").click();
     // Although arbitrary waiting is considered an anti-pattern and a really bad practice, I couldn't find any other way to reproduce this issue.
     // Cypress is too fast and is doing the assertions in that split second while popover is reloading which results in a false positive result.

--- a/e2e/test/scenarios/visualizations/trendline.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/trendline.cy.spec.js
@@ -26,9 +26,12 @@ describe("scenarios > question > trendline", () => {
 
   it("displays trendline when there are multiple numeric outputs (for simple question) (metabase#12781)", () => {
     // Change settings to trendline
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Visualization").click();
     cy.findByTestId("viz-settings-button").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Display").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Trend line").parent().children().last().click();
 
     // Check graph is still there

--- a/e2e/test/scenarios/visualizations/waterfall.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/waterfall.cy.spec.js
@@ -48,6 +48,7 @@ describe("scenarios > visualizations > waterfall", () => {
       "select 'A' as product, 10 as profit union select 'B' as product, -4 as profit",
     );
     cy.get(".NativeQueryEditor .Icon-play").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Visualization").click();
     cy.icon("waterfall").click();
 
@@ -60,17 +61,22 @@ describe("scenarios > visualizations > waterfall", () => {
     );
 
     cy.get(".NativeQueryEditor .Icon-play").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Visualization").click();
     switchToWaterfallDisplay();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Select a field").click();
     cy.get(".List-item").contains("X").click();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Select a field").click();
     cy.get(".List-item").contains("Y").click();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Axes").click();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Linear").click();
     cy.get(".List-item").contains("Ordinal").click();
 
@@ -82,11 +88,14 @@ describe("scenarios > visualizations > waterfall", () => {
       "select 1 as X, 10 as Y union select 2 as X, -2 as Y",
     );
     cy.get(".NativeQueryEditor .Icon-play").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Visualization").click();
     switchToWaterfallDisplay();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Select a field").click();
     cy.get(".List-item").contains("X").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Select a field").click();
     cy.get(".List-item").contains("Y").click();
 
@@ -96,10 +105,15 @@ describe("scenarios > visualizations > waterfall", () => {
   it("should work with time-series data", () => {
     openOrdersTable({ mode: "notebook" });
     summarize({ mode: "notebook" });
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Count of rows").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Pick a column to group by").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Created At").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Filter").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Custom Expression").click();
     cy.get(".ace_text-input")
       .type("between([Created At], '2016-01-01', '2016-08-01')")
@@ -108,6 +122,7 @@ describe("scenarios > visualizations > waterfall", () => {
 
     visualize();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Visualization").click();
     switchToWaterfallDisplay();
 
@@ -117,12 +132,16 @@ describe("scenarios > visualizations > waterfall", () => {
   it("should hide the Total label if there is no space", () => {
     openOrdersTable({ mode: "notebook" });
     summarize({ mode: "notebook" });
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Count of rows").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Pick a column to group by").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Created At").click();
 
     visualize();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Visualization").click();
     switchToWaterfallDisplay();
 
@@ -145,13 +164,16 @@ describe("scenarios > visualizations > waterfall", () => {
       display: "line",
     });
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Visualization").click();
     switchToWaterfallDisplay();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Waterfall chart does not support multiple series");
 
     cy.findByTestId("remove-count").click();
     cy.get(".CardVisualization svg"); // Chart renders after removing the second metric
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(/Add another/).should("not.exist");
   });
 
@@ -172,16 +194,20 @@ describe("scenarios > visualizations > waterfall", () => {
       display: "line",
     });
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Visualization").click();
     switchToWaterfallDisplay();
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Select a field").click();
     cy.get(".List-item").contains("Created At").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains("Select a field").click();
     cy.get(".List-item").contains("Count").click();
 
     cy.get(".CardVisualization svg"); // Chart renders after removing the second metric
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(/Add another/).should("not.exist");
   });
 
@@ -196,6 +222,7 @@ describe("scenarios > visualizations > waterfall", () => {
         database: SAMPLE_DB_ID,
       },
     });
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Visualization").click();
     cy.icon("waterfall").click({ force: true });
     cy.get(".Visualization .bar");
@@ -252,26 +279,34 @@ describe("scenarios > visualizations > waterfall", () => {
 
       openNativeEditor().type("select 'A' as X, -4.56 as Y");
       cy.get(".NativeQueryEditor .Icon-play").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("Visualization").click();
       switchToWaterfallDisplay();
     });
 
     it("should have increase, decrease, and total color options", () => {
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("Display").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Increase color").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Decrease color").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Total color").click();
     });
 
     it("should allow toggling of the total bar", () => {
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("Display").click();
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("Show total").next().click();
 
       cy.get(".Visualization .axis.x").within(() => {
         cy.findByText("Total").should("not.exist");
       });
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("Show total").next().click();
       cy.get(".Visualization .axis.x").within(() => {
         cy.findByText("Total");
@@ -279,10 +314,12 @@ describe("scenarios > visualizations > waterfall", () => {
     });
 
     it("should allow toggling of value labels", () => {
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("Display").click();
 
       cy.get(".Visualization .value-label").should("not.exist");
 
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("Show values on data points").next().click();
       cy.get(".Visualization .value-label").contains(4.56).should("be.visible");
     });

--- a/e2e/test/visual/visualizations/pie.cy.spec.js
+++ b/e2e/test/visual/visualizations/pie.cy.spec.js
@@ -32,6 +32,7 @@ describe("visual tests > visualizations > pie", () => {
       },
     });
 
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("2,610");
     cy.createPercySnapshot();
   });

--- a/frontend/lint/eslint-rules/no-unscoped-text-selectors.js
+++ b/frontend/lint/eslint-rules/no-unscoped-text-selectors.js
@@ -1,0 +1,71 @@
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+function rule(context) {
+  return {
+    Identifier(node) {
+      if (isBadFindByText(node) && hasDirectParentTestBlock(node)) {
+        const name = isContains(node) ? "contains" : "findByText";
+
+        context.report({
+          node,
+          message: `cy.${name} should be scoped to a container (try using .within())`,
+        });
+      }
+    },
+  };
+}
+
+const isTestBlock = node => {
+  return ["it", "before", "beforeEach"].includes(
+    // when it's a plain it() call, we look at the callee name
+    node?.parent?.parent?.callee?.name ??
+      // when it's got a .only, we need to look at the callee object
+      node?.parent?.parent?.callee?.object?.name,
+  );
+};
+
+const hasDirectParentTestBlock = node => {
+  return isTestBlock(findNearestBlockStatement(node));
+};
+
+const findNearestBlockStatement = node => {
+  if (!node?.parent) {
+    return null;
+  }
+  if (node.parent.type === "BlockStatement") {
+    return node.parent;
+  }
+  return findNearestBlockStatement(node.parent);
+};
+
+const isDirectlyChainedOffOfCy = node => {
+  return node.parent.object?.name === "cy";
+};
+
+const isFindByText = node => {
+  return node.name === "findByText";
+};
+
+const isContains = node => {
+  return node.name === "contains";
+};
+
+const isBadFindByText = node => {
+  return (
+    (isFindByText(node) || isContains(node)) && isDirectlyChainedOffOfCy(node)
+  );
+};
+
+// eslint-disable-next-line import/no-commonjs
+module.exports = {
+  meta: {
+    type: "problem",
+    docs: {
+      description: "Flags all top-level cy.findByText and cy.contains calls",
+    },
+    schema: [], // no options
+  },
+  create: rule,
+};

--- a/frontend/lint/eslint-rules/no-unscoped-text-selectors.unit.spec.js
+++ b/frontend/lint/eslint-rules/no-unscoped-text-selectors.unit.spec.js
@@ -1,0 +1,58 @@
+/* eslint-disable import/no-commonjs */
+const RuleTester = require("eslint").RuleTester;
+const rule = require("./no-unscoped-text-selectors");
+
+const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 2015 } });
+
+const scopeError = { message: /should be scoped/i };
+
+const blockTypes = ["it", "before", "beforeEach", "it.only", "it.banana"];
+
+const blockWrapper = (content, blockType = "it") => `
+  ${blockType}('should test something', () => {
+    ${content}
+  });
+`;
+
+const validCases = [
+  `cy.get('#my-div').within(() => findByText('foo'));`,
+  `cy.get('#my-div').within(() => {
+    findByText('foo')
+  });`,
+  `cy.get('#my-div').findByText('foo');`,
+  `cy.findByLabelText('label-name').findByText('this is fine');`,
+  `cy
+    .findByLabelText('label-name')
+    .findByText('this is fine')
+    .click();
+  ;`,
+  `cy.get('#my-div').within(() => {
+    cy.contains('my string of text').click();
+  });`,
+  `cy.get('#my-div').contains('my string of text').click();`,
+];
+
+const invalidCases = [
+  "cy.findByText('foo');",
+  "cy.findByText('foo').click();",
+  `cy.findByText('foo').within(() => {
+    cy.findByText('bar').click();
+  }).click().clack();`,
+  "cy.contains('foobar');",
+  "cy.contains('foobar').click();",
+];
+
+ruleTester.run("no-unscoped-text-selectors", rule, {
+  valid: blockTypes.flatMap(blockType =>
+    validCases.map(testCase => ({
+      code: blockWrapper(testCase, blockType),
+    })),
+  ),
+
+  invalid: blockTypes.flatMap(blockType =>
+    invalidCases.map(testCase => ({
+      code: blockWrapper(testCase, blockType),
+      errors: [scopeError],
+    })),
+  ),
+});

--- a/frontend/src/metabase/actions/containers/ActionCreator/CreateActionForm/CreateActionForm.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/CreateActionForm/CreateActionForm.tsx
@@ -59,7 +59,7 @@ function CreateActionForm({
       onSubmit={onCreate}
     >
       {({ isValid }) => (
-        <Form disabled={!isValid}>
+        <Form disabled={!isValid} data-testid="create-action-form">
           <FormInput
             name="name"
             title={t`Name`}

--- a/frontend/src/metabase/dashboard/components/DashboardHeader.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHeader.tsx
@@ -137,6 +137,7 @@ const DashboardHeader = ({
       <HeaderRoot
         isNavBarOpen={isNavBarOpen}
         className={cx("QueryBuilder-section", headerClassName)}
+        data-testid="dashboard-header"
         ref={header}
       >
         <HeaderContent hasSubHeader showSubHeader={showSubHeader}>

--- a/frontend/src/metabase/models/components/ModelDetailPage/ModelActionDetails/ModelActionDetails.tsx
+++ b/frontend/src/metabase/models/components/ModelDetailPage/ModelActionDetails/ModelActionDetails.tsx
@@ -162,7 +162,7 @@ function ModelActionDetails({
   return (
     <Root>
       {canWrite && (
-        <ActionsHeader>
+        <ActionsHeader data-testid="model-actions-header">
           <Button as={Link} to={newActionUrl}>{t`New action`}</Button>
           {menuItems.length > 0 && (
             <ActionMenu


### PR DESCRIPTION
[Approved RFC](https://www.notion.so/metabase/52-Disallow-top-level-findByText-in-e2e-tests-9cef8dc4a77a49dfb2e41392913b7281)

### Description

We frequently run into a problem with unscoped `cy.findByText()` and `cy.contains()` calls in our e2e tests. They're difficult to understand and are very error prone when other elements in the application change.  Most of the problems with these calls are ameliorated by simply scoping them to a container.

For example: 

❌  Bad 👇 
```js
it('should run the query correctly', () => {
  cy.findByText('42');
});

it('should run the query correctly', () => {
  cy.contains('Save');
});
```


✅  Better 👇 
```js
it('should run the query correctly', () => {
  cy.findByTestId('table-interactive-wrapper').within(() => {
    cy.findByText('42');
  });
});

// also 

cy.findByTestId('table-interactive-wrapper').findByText('42');

```
This adds a pretty simple lint rule that disables using `FindByText` and `contains` at the top-level of a test block, requiring it to be chained in some way or within some other selector block.

## How to test
1. Run the tests! `node frontend/lint/eslint-rules/no-unscoped-text-selectors.unit.spec.js`
2. Open up an e2e file and write a bad selector.

## Implementation 

Fixing the existing **3151** violations of this rule is prohibitively difficult, and probably less valuable than fixing all of them entails. We want to enforce this rule going forward, and hopefully clean up some of the existing violations as we touch those files or tests.

I considered several ways to implement this
1. 👎 Limiting the total number of eslint errors. Unfortunately, this cannot be done on a rule-by-rule basis, so this could allow other linting violations to slip through if we fix/delete some of these violations. 😢 
2. 👎 Using a pre-commit hook to enforce this. This would be fine for individual commits, but it would require changes to how we lint all code in PRs and on the master branch. This might be hard to maintain or follow down the road.
3. 👎 Changing all violative uses to something like `cy._DEPRECATED_contains('bananas')`. This was Ariya's suggestion, and makes a lot of sense. I decided against it for 2 reasons: (a) the codemod could be a little tricky to write, and (b) I think it might be vulnerable to lazy copypasta continuing its usage.
4. 👍 Adding eslint-disable comments to all existing usage. It's dumb, it's simple, it obviously just works. It was easy to implement using [eslint-interactive](https://github.com/mizdra/eslint-interactive). I think it's less vulnerable to copy-pasta perpetuation because we have a pretty strong existing custom that you have to have a darn good reason to disable a lint rule in new code you're writing.

Open to feedback if you think there's a better implementation approach!

## ToDo

- [x] disallow unscoped cy.findByText(text)
- [x] disallow unscoped cy.contains(text)
- [x] allow chained usage (because it's scoped without .within)
- [x] implement without requiring cleanup of all occurrences
- [x] add unit tests

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30059)
<!-- Reviewable:end -->
