### PR TITLE
MLv2: Add `display-name` style parameter with `:default` and `:long` 

### DIFF
--- a/frontend/src/metabase-lib/order_by.unit.spec.ts
+++ b/frontend/src/metabase-lib/order_by.unit.spec.ts
@@ -134,9 +134,7 @@ describe("order by", () => {
       const orderBys = ML.orderBys(nextQuery);
 
       expect(orderBys).toHaveLength(1);
-      expect(ML.displayName(nextQuery, orderBys[0])).toBe(
-        "Products → Title ascending",
-      );
+      expect(ML.displayName(nextQuery, orderBys[0])).toBe("Title ascending");
     });
   });
 
@@ -162,7 +160,7 @@ describe("order by", () => {
       );
       const nextOrderBys = ML.orderBys(nextQuery);
       expect(ML.displayName(nextQuery, nextOrderBys[0])).toBe(
-        "Products → Category descending",
+        "Category descending",
       );
       expect(orderBys[0]).not.toEqual(nextOrderBys[0]);
     });

--- a/src/metabase/lib/aggregation.cljc
+++ b/src/metabase/lib/aggregation.cljc
@@ -41,7 +41,7 @@
     (lib.util/join-strings-with-conjunction
      (i18n/tru "and")
      (for [aggregation aggregations]
-       (lib.metadata.calculation/display-name query stage-number aggregation)))))
+       (lib.metadata.calculation/display-name query stage-number aggregation :long)))))
 
 (defmethod lib.metadata.calculation/metadata-method :aggregation
   [query stage-number [_ag opts index, :as _aggregation-ref]]
@@ -57,14 +57,14 @@
 ;;; TODO -- merge this stuff into `defop` somehow.
 
 (defmethod lib.metadata.calculation/display-name-method :aggregation
-  [query stage-number [_tag _opts index]]
-  (lib.metadata.calculation/display-name query stage-number (resolve-aggregation query stage-number index)))
+  [query stage-number [_tag _opts index] style]
+  (lib.metadata.calculation/display-name query stage-number (resolve-aggregation query stage-number index) style))
 
 (defmethod lib.metadata.calculation/display-name-method :count
-  [query stage-number [_count _opts x]]
+  [query stage-number [_count _opts x] style]
   ;; x is optional.
   (if x
-    (i18n/tru "Count of {0}" (lib.metadata.calculation/display-name query stage-number x))
+    (i18n/tru "Count of {0}" (lib.metadata.calculation/display-name query stage-number x style))
     (i18n/tru "Count")))
 
 (defmethod lib.metadata.calculation/column-name-method :count
@@ -76,7 +76,7 @@
 (lib.hierarchy/derive :count ::aggregation)
 
 (defmethod lib.metadata.calculation/display-name-method :case
-  [_query _stage-number _case]
+  [_query _stage-number _case _style]
   (i18n/tru "Case"))
 
 (defmethod lib.metadata.calculation/column-name-method :case
@@ -117,8 +117,8 @@
      arg)))
 
 (defmethod lib.metadata.calculation/display-name-method ::unary-aggregation
-  [query stage-number [tag _opts arg]]
-  (let [arg (lib.metadata.calculation/display-name query stage-number arg)]
+  [query stage-number [tag _opts arg] style]
+  (let [arg (lib.metadata.calculation/display-name query stage-number arg style)]
     (case tag
       :avg       (i18n/tru "Average of {0}"            arg)
       :cum-count (i18n/tru "Cumulative count of {0}"   arg)
@@ -132,8 +132,8 @@
       :var       (i18n/tru "Variance of {0}"           arg))))
 
 (defmethod lib.metadata.calculation/display-name-method :percentile
-  [query stage-number [_percentile _opts x p]]
-  (i18n/tru "{0}th percentile of {1}" p (lib.metadata.calculation/display-name query stage-number x)))
+  [query stage-number [_percentile _opts x p] style]
+  (i18n/tru "{0}th percentile of {1}" p (lib.metadata.calculation/display-name query stage-number x style)))
 
 (defmethod lib.metadata.calculation/column-name-method :percentile
   [query stage-number [_percentile _opts x p]]
@@ -150,8 +150,8 @@
 ;;; TODO : wait a minute, we do have that stuff now!
 
 (defmethod lib.metadata.calculation/display-name-method :sum-where
-  [query stage-number [_sum-where _opts x _pred]]
-  (i18n/tru "Sum of {0} matching condition" (lib.metadata.calculation/display-name query stage-number x)))
+  [query stage-number [_sum-where _opts x _pred] style]
+  (i18n/tru "Sum of {0} matching condition" (lib.metadata.calculation/display-name query stage-number x style)))
 
 (defmethod lib.metadata.calculation/column-name-method :sum-where
   [query stage-number [_sum-where _opts x _pred]]
@@ -160,7 +160,7 @@
 (lib.hierarchy/derive :sum-where ::aggregation)
 
 (defmethod lib.metadata.calculation/display-name-method :share
-  [_query _stage-number _share]
+  [_query _stage-number _share _style]
   (i18n/tru "Share of rows matching condition"))
 
 (defmethod lib.metadata.calculation/column-name-method :share
@@ -170,7 +170,7 @@
 (lib.hierarchy/derive :share ::aggregation)
 
 (defmethod lib.metadata.calculation/display-name-method :count-where
-  [_query _stage-number _count-where]
+  [_query _stage-number _count-where _style]
   (i18n/tru "Count of rows matching condition"))
 
 (defmethod lib.metadata.calculation/column-name-method :count-where

--- a/src/metabase/lib/breakout.cljc
+++ b/src/metabase/lib/breakout.cljc
@@ -15,7 +15,7 @@
     (i18n/tru "Grouped by {0}"
               (str/join (str \space (i18n/tru "and") \space)
                         (for [breakout breakouts]
-                          (lib.metadata.calculation/display-name query stage-number breakout))))))
+                          (lib.metadata.calculation/display-name query stage-number breakout :long))))))
 
 (mu/defn breakout :- ::lib.schema/query
   "Add a new breakout on an expression, presumably a Field reference."

--- a/src/metabase/lib/card.cljc
+++ b/src/metabase/lib/card.cljc
@@ -9,6 +9,10 @@
    [metabase.util.humanization :as u.humanization]
    [metabase.util.malli :as mu]))
 
+(defmethod lib.metadata.calculation/display-name-method :metadata/card
+  [_query _stage-number card-metadata _style]
+  ((some-fn :display_name :name) card-metadata))
+
 (defmethod lib.metadata.calculation/metadata-method :metadata/card
   [_query _stage-number {card-name :name, display-name :display_name, :as card-metadata}]
   (cond-> card-metadata

--- a/src/metabase/lib/expression.cljc
+++ b/src/metabase/lib/expression.cljc
@@ -53,19 +53,19 @@
    :lib/source   :source/expressions})
 
 (defmethod lib.metadata.calculation/display-name-method :dispatch-type/integer
-  [_query _stage-number n]
+  [_query _stage-number n _style]
   (str n))
 
 (defmethod lib.metadata.calculation/display-name-method :dispatch-type/number
-  [_query _stage-number n]
+  [_query _stage-number n _style]
   (str n))
 
 (defmethod lib.metadata.calculation/display-name-method :dispatch-type/string
-  [_query _stage-number s]
+  [_query _stage-number s _style]
   (str \" s \"))
 
 (defmethod lib.metadata.calculation/display-name-method :expression
-  [_query _stage-number [_expression _opts expression-name]]
+  [_query _stage-number [_expression _opts expression-name] _style]
   expression-name)
 
 (defmethod lib.metadata.calculation/column-name-method :expression
@@ -101,7 +101,7 @@
   (lib.hierarchy/derive tag ::infix-operator))
 
 (defmethod lib.metadata.calculation/display-name-method ::infix-operator
-  [query stage-number [tag _opts & args]]
+  [query stage-number [tag _opts & args] _style]
   (infix-display-name query stage-number (get infix-operator-display-name tag) args))
 
 (defn- infix-column-name
@@ -166,8 +166,8 @@
       (lib.util/format "minus_%d_%s" (clojure.core/abs amount) unit-str))))
 
 (defmethod lib.metadata.calculation/display-name-method :datetime-add
-  [query stage-number [_datetime-add _opts x amount unit]]
-  (str (lib.metadata.calculation/display-name query stage-number x)
+  [query stage-number [_datetime-add _opts x amount unit] style]
+  (str (lib.metadata.calculation/display-name query stage-number x style)
        \space
        (interval-display-name amount unit)))
 
@@ -179,8 +179,8 @@
 
 ;;; for now we'll just pretend `:coalesce` isn't a present and just use the display name for the expr it wraps.
 (defmethod lib.metadata.calculation/display-name-method :coalesce
-  [query stage-number [_coalesce _opts expr _null-expr]]
-  (lib.metadata.calculation/display-name query stage-number expr))
+  [query stage-number [_coalesce _opts expr _null-expr] style]
+  (lib.metadata.calculation/display-name query stage-number expr style))
 
 (defmethod lib.metadata.calculation/column-name-method :coalesce
   [query stage-number [_coalesce _opts expr _null-expr]]

--- a/src/metabase/lib/field.cljc
+++ b/src/metabase/lib/field.cljc
@@ -41,8 +41,8 @@
 (mu/defn ^:private resolve-field-id :- lib.metadata/ColumnMetadata
   "Integer Field ID: get metadata from the metadata provider. This is probably not 100% the correct thing to do if
   this isn't the first stage of the query, but we can fix that behavior in a follow-on"
-  [query         :- ::lib.schema/query
-   field-id      :- ::lib.schema.id/field]
+  [query     :- ::lib.schema/query
+   field-id  :- ::lib.schema.id/field]
   (lib.metadata/field query field-id))
 
 (mu/defn ^:private resolve-column-name-in-metadata :- [:maybe lib.metadata/ColumnMetadata]

--- a/src/metabase/lib/filter.cljc
+++ b/src/metabase/lib/filter.cljc
@@ -11,8 +11,8 @@
    [metabase.lib.temporal-bucket :as lib.temporal-bucket]
    [metabase.lib.util :as lib.util]
    [metabase.shared.util.i18n :as i18n]
-   [metabase.util.malli :as mu]
-   #?(:cljs (:require-macros [metabase.lib.filter]))))
+   [metabase.util.malli :as mu])
+  #?(:cljs (:require-macros [metabase.lib.filter])))
 
 (comment metabase.lib.schema/keep-me)
 

--- a/src/metabase/lib/join.cljc
+++ b/src/metabase/lib/join.cljc
@@ -66,7 +66,7 @@
                          :stage-number stage-number})))))
 
 (defmethod lib.metadata.calculation/display-name-method :mbql/join
-  [query _stage-number {[first-stage] :stages, :as _join}]
+  [query _stage-number {[first-stage] :stages, :as _join} _style]
   (if-let [source-table (:source-table first-stage)]
     (if (integer? source-table)
       (:display_name (lib.metadata/table query source-table))

--- a/src/metabase/lib/metric.cljc
+++ b/src/metabase/lib/metric.cljc
@@ -41,14 +41,14 @@
       :type/*))
 
 (defmethod lib.metadata.calculation/display-name-method :metadata/metric
-  [_query _stage-number metric-metadata]
+  [_query _stage-number metric-metadata _style]
   (or ((some-fn :display_name :name) metric-metadata)
       (i18n/tru "[Unknown Metric]")))
 
 (defmethod lib.metadata.calculation/display-name-method :metric
-  [query stage-number [_tag _opts metric-id-or-name]]
+  [query stage-number [_tag _opts metric-id-or-name] style]
   (or (when-let [metric-metadata (resolve-metric query metric-id-or-name)]
-        (lib.metadata.calculation/display-name query stage-number metric-metadata))
+        (lib.metadata.calculation/display-name query stage-number metric-metadata style))
       (i18n/tru "[Unknown Metric]")))
 
 (defmethod lib.metadata.calculation/column-name-method :metric

--- a/src/metabase/lib/order_by.cljc
+++ b/src/metabase/lib/order_by.cljc
@@ -17,6 +17,9 @@
    [metabase.shared.util.i18n :as i18n]
    [metabase.util.malli :as mu]))
 
+(lib.hierarchy/derive :asc  ::order-by-clause)
+(lib.hierarchy/derive :desc ::order-by-clause)
+
 (defmethod lib.metadata.calculation/describe-top-level-key-method :order-by
   [query stage-number _k]
   (when-let [order-bys (not-empty (:order-by (lib.util/query-stage query stage-number)))]
@@ -24,21 +27,19 @@
               (lib.util/join-strings-with-conjunction
                (i18n/tru "and")
                (for [order-by order-bys]
-                 (lib.metadata.calculation/display-name query stage-number order-by))))))
+                 (lib.metadata.calculation/display-name query stage-number order-by :long))))))
 
-(defmethod lib.metadata.calculation/display-name-method :asc
-  [query stage-number [_tag _opts expr]]
-  (i18n/tru "{0} ascending" (lib.metadata.calculation/display-name query stage-number expr)))
+(defmethod lib.metadata.calculation/display-name-method ::order-by-clause
+  [query stage-number [tag _opts expr] style]
+  (let [expr-display-name (lib.metadata.calculation/display-name query stage-number expr style)]
+    (case tag
+      :asc  (i18n/tru "{0} ascending"  expr-display-name)
+      :desc (i18n/tru "{0} descending" expr-display-name))))
 
-(defmethod lib.metadata.calculation/display-name-method :desc
-  [query stage-number [_tag _opts expr]]
-  (i18n/tru "{0} descending" (lib.metadata.calculation/display-name query stage-number expr)))
-
-(doseq [tag [:asc :desc]]
-  (defmethod lib.metadata.calculation/display-info-method tag
-    [query stage-number [tag _opts expr]]
-    (assoc (lib.metadata.calculation/display-info query stage-number expr)
-           :direction tag)))
+(defmethod lib.metadata.calculation/display-info-method ::order-by-clause
+  [query stage-number [tag _opts expr]]
+  (assoc (lib.metadata.calculation/display-info query stage-number expr)
+         :direction tag))
 
 (defmulti ^:private ->order-by-clause
   {:arglists '([query stage-number x])}
@@ -46,11 +47,7 @@
     (lib.dispatch/dispatch-value x))
   :hierarchy lib.hierarchy/hierarchy)
 
-(defmethod ->order-by-clause :asc
-  [_query _stage-number clause]
-  (lib.options/ensure-uuid clause))
-
-(defmethod ->order-by-clause :desc
+(defmethod ->order-by-clause ::order-by-clause
   [_query _stage-number clause]
   (lib.options/ensure-uuid clause))
 
@@ -61,6 +58,8 @@
 ;;; by default, try to convert `x` to a ref and then order by `:asc`
 (defmethod ->order-by-clause :default
   [_query _stage-number x]
+  (when (nil? x)
+    (throw (ex-info (i18n/tru "Can''t order by nil") {})))
   (lib.options/ensure-uuid [:asc (lib.ref/ref x)]))
 
 (mu/defn ^:private with-direction :- ::lib.schema.order-by/order-by
@@ -103,7 +102,7 @@
 
   ([query
     stage-number :- [:maybe :int]
-    x
+    x            :- some?
     direction    :- [:maybe [:enum :asc :desc]]]
    (let [stage-number (or stage-number -1)
          new-order-by (cond-> (->order-by-clause query stage-number x)

--- a/src/metabase/lib/query.cljc
+++ b/src/metabase/lib/query.cljc
@@ -26,8 +26,8 @@
   (lib.metadata.calculation/metadata query stage-number (lib.util/query-stage x stage-number)))
 
 (defmethod lib.metadata.calculation/display-name-method :mbql/query
-  [query stage-number x]
-  (lib.metadata.calculation/display-name query stage-number (lib.util/query-stage x stage-number)))
+  [query stage-number x style]
+  (lib.metadata.calculation/display-name query stage-number (lib.util/query-stage x stage-number) style))
 
 (defn query-with-stages
   "Create a query from a sequence of stages."

--- a/src/metabase/lib/ref.cljc
+++ b/src/metabase/lib/ref.cljc
@@ -14,5 +14,5 @@
 (mu/defn ref :- ::lib.schema.ref/ref
   "Create a fresh ref that can be added to a query, e.g. a `:field`, `:aggregation`, or `:expression` reference. Will
   create a new UUID every time this is called."
-  ([x]
-   (ref-method x)))
+  [x]
+  (ref-method x))

--- a/src/metabase/lib/segment.cljc
+++ b/src/metabase/lib/segment.cljc
@@ -6,13 +6,13 @@
    [metabase.shared.util.i18n :as i18n]))
 
 (defmethod lib.metadata.calculation/display-name-method :metadata/segment
-  [_query _stage-number segment-metadata]
+  [_query _stage-number segment-metadata _style]
   (or ((some-fn :display_name :name) segment-metadata)
       (i18n/tru "[Unknown Segment]")))
 
 (defmethod lib.metadata.calculation/display-name-method :segment
-  [query stage-number [_tag _opts segment-id-or-name]]
+  [query stage-number [_tag _opts segment-id-or-name] style]
   (or (when (integer? segment-id-or-name)
         (when-let [segment-metadata (lib.metadata/segment query segment-id-or-name)]
-          (lib.metadata.calculation/display-name query stage-number segment-metadata)))
+          (lib.metadata.calculation/display-name query stage-number segment-metadata style)))
       (i18n/tru "[Unknown Segment]")))

--- a/src/metabase/lib/stage.cljc
+++ b/src/metabase/lib/stage.cljc
@@ -227,7 +227,7 @@
   (stage-metadata query stage-number))
 
 (defmethod lib.metadata.calculation/display-name-method :mbql.stage/native
-  [_query _stage-number _stage]
+  [_query _stage-number _stage _style]
   (i18n/tru "Native query"))
 
 (def ^:private display-name-parts
@@ -239,14 +239,17 @@
    :limit])
 
 (defmethod lib.metadata.calculation/display-name-method :mbql.stage/mbql
-  [query stage-number _stage]
+  [query stage-number _stage style]
   (or
    (not-empty
     (let [descriptions (for [k display-name-parts]
                          (lib.metadata.calculation/describe-top-level-key query stage-number k))]
       (str/join ", " (remove str/blank? descriptions))))
    (when-let [previous-stage-number (lib.util/previous-stage-number query stage-number)]
-     (lib.metadata.calculation/display-name query previous-stage-number (lib.util/query-stage query previous-stage-number)))))
+     (lib.metadata.calculation/display-name query
+                                            previous-stage-number
+                                            (lib.util/query-stage query previous-stage-number)
+                                            style))))
 
 (defn- implicitly-joinable-columns
   "Columns that are implicitly joinable from some other columns in `column-metadatas`. To be joinable, the column has to

--- a/test/metabase/lib/column_group_test.cljc
+++ b/test/metabase/lib/column_group_test.cljc
@@ -10,7 +10,7 @@
 
 #?(:cljs (comment metabase.test-runner.assert-exprs.approximately-equal/keep-me))
 
-(deftest ^:parallel group-columns-test
+(deftest ^:parallel test
   (let [query   (lib/query-for-table-name meta/metadata-provider "VENUES")
         columns (lib/orderable-columns query)
         groups  (lib/group-columns columns)]
@@ -43,7 +43,7 @@
       (is (= columns
              (mapcat lib/columns-group-columns groups))))))
 
-(deftest ^:parallel group-columns-aggregation-and-breakout-test
+(deftest ^:parallel aggregation-and-breakout-test
   (let [query   (-> (lib/query-for-table-name meta/metadata-provider "VENUES")
                     (lib/aggregate (lib/sum (lib/field "VENUES" "ID")))
                     (lib/breakout (lib/field "VENUES" "NAME")))
@@ -64,7 +64,7 @@
       (is (= columns
              (mapcat lib/columns-group-columns groups))))))
 
-(deftest ^:parallel group-columns-source-card-test
+(deftest ^:parallel source-card-test
   (let [query   (lib.tu/query-with-card-source-table)
         columns (lib/orderable-columns query)
         groups  (lib/group-columns columns)]
@@ -92,7 +92,7 @@
       (is (= columns
              (mapcat lib/columns-group-columns groups))))))
 
-(deftest ^:parallel group-columns-joins-test
+(deftest ^:parallel joins-test
   (let [query   (lib.tu/query-with-join)
         columns (lib/orderable-columns query)
         groups  (lib/group-columns columns)]
@@ -105,8 +105,8 @@
                                              {:name "PRICE", :display_name "Price"}]}
              {::lib.column-group/group-type :group-type/join.explicit
               :join-alias                   "Cat"
-              ::lib.column-group/columns    [{:display_name "Categories → ID", :lib/source :source/joins}
-                                             {:display_name "Categories → Name", :lib/source :source/joins}]}]
+              ::lib.column-group/columns    [{:display_name "ID", :lib/source :source/joins}
+                                             {:display_name "Name", :lib/source :source/joins}]}]
             groups))
     (testing `lib/display-info
       (is (=? [{:is_from_join           false
@@ -123,7 +123,7 @@
       (is (= columns
              (mapcat lib/columns-group-columns groups))))))
 
-(deftest ^:parallel group-columns-expressions-test
+(deftest ^:parallel expressions-test
   (let [query   (lib.tu/query-with-expression)
         columns (lib/orderable-columns query)
         groups  (lib/group-columns columns)]
@@ -155,7 +155,7 @@
       (is (= columns
              (mapcat lib/columns-group-columns groups))))))
 
-(deftest ^:parallel group-columns-source-card-with-expressions-test
+(deftest ^:parallel source-card-with-expressions-test
   (let [query   (-> (lib.tu/query-with-card-source-table)
                     (lib/expression "expr" (lib/absolute-datetime "2020" :month)))
         columns (lib/orderable-columns query)

--- a/test/metabase/lib/column_group_test.cljc
+++ b/test/metabase/lib/column_group_test.cljc
@@ -10,7 +10,7 @@
 
 #?(:cljs (comment metabase.test-runner.assert-exprs.approximately-equal/keep-me))
 
-(deftest ^:parallel test
+(deftest ^:parallel basic-test
   (let [query   (lib/query-for-table-name meta/metadata-provider "VENUES")
         columns (lib/orderable-columns query)
         groups  (lib/group-columns columns)]

--- a/test/metabase/lib/field_test.cljc
+++ b/test/metabase/lib/field_test.cljc
@@ -1,6 +1,6 @@
 (ns metabase.lib.field-test
   (:require
-   [clojure.test :refer [deftest is testing]]
+   [clojure.test :refer [are deftest is testing]]
    [medley.core :as m]
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
@@ -122,9 +122,11 @@
                {:join-alias "CATEGORIES__via__CATEGORY_ID"
                 :lib/uuid   "8704e09b-496e-4045-8148-1eef28e96b51"}
                (meta/id :categories :name)]]
-    (is (= "Categories → Name"
-           (lib.metadata.calculation/display-name query -1 field)))
-    (is (=? {:display_name "Categories → Name"}
+    (are [style expected] (= expected
+                             (lib/display-name query -1 field style))
+      :default "Name"
+      :long    "Categories → Name")
+    (is (=? {:display_name "Name"}
             (lib.metadata.calculation/metadata query -1 field)))))
 
 (deftest ^:parallel field-with-temporal-unit-test
@@ -175,8 +177,10 @@
     (let [query           (lib/query-for-table-name meta/metadata-provider "VENUES")
           categories-name (m/find-first #(= (:id %) (meta/id :categories :name))
                                         (lib/orderable-columns query))]
-      (is (= "Categories → Name"
-             (lib/display-name query categories-name)))
+      (are [style expected] (= expected
+                               (lib/display-name query -1 categories-name style))
+        :default "Name"
+        :long    "Categories → Name")
       (let [query' (lib/order-by query categories-name)]
         (is (= "Venues, Sorted by Categories → Name ascending"
                (lib/describe-query query')))))))

--- a/test/metabase/lib/filter_test.cljc
+++ b/test/metabase/lib/filter_test.cljc
@@ -4,6 +4,7 @@
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.test-metadata :as meta]
+   [metabase.lib.test-util :as lib.tu]
    #?@(:cljs ([metabase.test-runner.assert-exprs.approximately-equal]))))
 
 (defn- test-clause [result-filter f & args]
@@ -203,3 +204,13 @@
       (is (=? extended-and-query third-add))
       (is (=? [first-result-filter second-result-filter third-result-filter]
               (lib/filters third-add))))))
+
+(deftest ^:parallel ends-with-display-name-test
+  (testing "#29947"
+    (is (= "Name ends with \"t\""
+           (lib/display-name
+            lib.tu/venues-query
+            [:ends-with
+             {:lib/uuid "953597df-a96d-4453-a57b-665e845abc69"}
+             [:field {:lib/uuid "be28f393-538a-406b-90da-bac5f8ef565e"} (meta/id :venues :name)]
+             "t"]))) ))

--- a/test/metabase/lib/join_test.cljc
+++ b/test/metabase/lib/join_test.cljc
@@ -147,7 +147,7 @@
                  :lib/metadata meta/metadata-provider}]
       (let [metadata (lib.metadata.calculation/metadata query)]
         (is (=? [(merge (meta/field-metadata :categories :name)
-                        {:display_name                  "Categories → Name"
+                        {:display_name                  "Name"
                          :lib/source                    :source/fields
                          :metabase.lib.field/join-alias "CATEGORIES__via__CATEGORY_ID"})]
                 metadata))
@@ -272,7 +272,7 @@
               :lib/source-column-alias  "NAME"
               :lib/desired-column-alias "NAME"}
              {:name                     "ID"
-              :display_name             "Categories → Categories → ID"
+              :display_name             "ID"
               :lib/source-column-alias  "ID"
               :lib/desired-column-alias "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXY_bfaf4e7b"}]
             (lib.metadata.calculation/metadata query)))))

--- a/test/metabase/lib/order_by_test.cljc
+++ b/test/metabase/lib/order_by_test.cljc
@@ -293,14 +293,14 @@
                  {:id (meta/id :venues :price) :name "PRICE"}
                  {:lib/type     :metadata/field
                   :name         "ID"
-                  :display_name "Categories → ID" ; should we be using the explicit alias we gave this join?
+                  :display_name "ID"
                   :source_alias "Cat"
                   :id           (meta/id :categories :id)
                   :table_id     (meta/id :categories)
                   :base_type    :type/BigInteger}
                  {:lib/type     :metadata/field
                   :name         "NAME"
-                  :display_name "Categories → Name"
+                  :display_name "Name"
                   :source_alias "Cat"
                   :id           (meta/id :categories :name)
                   :table_id     (meta/id :categories)
@@ -478,7 +478,7 @@
               :lib/type                 :metadata/field
               :base_type                :type/BigInteger
               :effective_type           :type/BigInteger
-              :display_name             "Categories → ID"
+              :display_name             "ID"
               :table_id                 (meta/id :categories)
               :lib/source-column-alias  "Cat__ID"
               :lib/desired-column-alias "Cat__ID"}]
@@ -562,25 +562,26 @@
                                          [:field {} (meta/id :venues :category-id)]
                                          [:field {:join-alias "Cat"} (meta/id :categories :id)]]]}]}]}
               query))
-      (is (=? [{:display_name "ID",                :lib/source :source/table-defaults}
-               {:display_name "Name",              :lib/source :source/table-defaults}
-               {:display_name "Category ID",       :lib/source :source/table-defaults}
-               {:display_name "Latitude",          :lib/source :source/table-defaults}
-               {:display_name "Longitude",         :lib/source :source/table-defaults}
-               {:display_name "Price",             :lib/source :source/table-defaults}
+      (is (=? [{:display_name "ID",          :lib/source :source/table-defaults}
+               {:display_name "Name",        :lib/source :source/table-defaults}
+               {:display_name "Category ID", :lib/source :source/table-defaults}
+               {:display_name "Latitude",    :lib/source :source/table-defaults}
+               {:display_name "Longitude",   :lib/source :source/table-defaults}
+               {:display_name "Price",       :lib/source :source/table-defaults}
                ;; implicitly joinable versions shouldn't be returned either, since we have an explicit join.
-               {:display_name "Categories → ID",   :lib/source :source/joins}
-               {:display_name "Categories → Name", :lib/source :source/joins}]
+               {:display_name "ID",   :lib/source :source/joins}
+               {:display_name "Name", :lib/source :source/joins}]
               (lib/orderable-columns query)))
-      (let [query' (lib/order-by query (m/find-first #(= (:display_name %) "Categories → Name")
+      (let [query' (lib/order-by query (m/find-first #(and (= (:source_alias %) "Cat")
+                                                           (= (:display_name %) "Name"))
                                                      (lib/orderable-columns query)))]
-        (is (=? [{:display_name "ID",                :lib/source :source/table-defaults}
-                 {:display_name "Name",              :lib/source :source/table-defaults}
-                 {:display_name "Category ID",       :lib/source :source/table-defaults}
-                 {:display_name "Latitude",          :lib/source :source/table-defaults}
-                 {:display_name "Longitude",         :lib/source :source/table-defaults}
-                 {:display_name "Price",             :lib/source :source/table-defaults}
-                 {:display_name "Categories → ID",   :lib/source :source/joins}]
+        (is (=? [{:display_name "ID",          :lib/source :source/table-defaults}
+                 {:display_name "Name",        :lib/source :source/table-defaults}
+                 {:display_name "Category ID", :lib/source :source/table-defaults}
+                 {:display_name "Latitude",    :lib/source :source/table-defaults}
+                 {:display_name "Longitude",   :lib/source :source/table-defaults}
+                 {:display_name "Price",       :lib/source :source/table-defaults}
+                 {:display_name "ID",          :lib/source :source/joins}]
                 (lib/orderable-columns query')))))))
 
 (deftest ^:parallel orderable-columns-exclude-already-sorted-implicitly-joinable-columns-test

--- a/test/metabase/lib/stage_test.cljc
+++ b/test/metabase/lib/stage_test.cljc
@@ -120,29 +120,42 @@
                          :expressions {"ID + 1" [:+ {} [:field {} (meta/id :venues :id)] 1]
                                        "ID + 2" [:+ {} [:field {} (meta/id :venues :id)] 2]}}]}
               query))
-      (is (=? [{:id (meta/id :venues :id),          :name "ID",          :lib/source :source/table-defaults}
-               {:id (meta/id :venues :name),        :name "NAME",        :lib/source :source/table-defaults}
-               {:id (meta/id :venues :category-id), :name "CATEGORY_ID", :lib/source :source/table-defaults}
-               {:id (meta/id :venues :latitude),    :name "LATITUDE",    :lib/source :source/table-defaults}
-               {:id (meta/id :venues :longitude),   :name "LONGITUDE",   :lib/source :source/table-defaults}
-               {:id (meta/id :venues :price),       :name "PRICE",       :lib/source :source/table-defaults}
-               {:name "ID + 1", :lib/source :source/expressions}
-               {:name "ID + 2", :lib/source :source/expressions}
-               {:id                       (meta/id :categories :id)
-                :name                     "ID"
-                :lib/source               :source/joins
-                :source_alias             "Cat"
-                :display_name             "Categories → ID"
-                :lib/source-column-alias  "ID"
-                :lib/desired-column-alias "Cat__ID"}
-               {:id                       (meta/id :categories :name)
-                :name                     "NAME"
-                :lib/source               :source/joins
-                :source_alias             "Cat"
-                :display_name             "Categories → Name"
-                :lib/source-column-alias  "NAME"
-                :lib/desired-column-alias "Cat__NAME"}]
-              (lib.metadata.calculation/metadata query))))))
+      (let [metadata (lib.metadata.calculation/metadata query)]
+        (is (=? [{:id (meta/id :venues :id), :name "ID", :lib/source :source/table-defaults}
+                 {:id (meta/id :venues :name), :name "NAME", :lib/source :source/table-defaults}
+                 {:id (meta/id :venues :category-id), :name "CATEGORY_ID", :lib/source :source/table-defaults}
+                 {:id (meta/id :venues :latitude), :name "LATITUDE", :lib/source :source/table-defaults}
+                 {:id (meta/id :venues :longitude), :name "LONGITUDE", :lib/source :source/table-defaults}
+                 {:id (meta/id :venues :price), :name "PRICE", :lib/source :source/table-defaults}
+                 {:name "ID + 1", :lib/source :source/expressions}
+                 {:name "ID + 2", :lib/source :source/expressions}
+                 {:id                       (meta/id :categories :id)
+                  :name                     "ID"
+                  :lib/source               :source/joins
+                  :source_alias             "Cat"
+                  :display_name             "ID"
+                  :lib/source-column-alias  "ID"
+                  :lib/desired-column-alias "Cat__ID"}
+                 {:id                       (meta/id :categories :name)
+                  :name                     "NAME"
+                  :lib/source               :source/joins
+                  :source_alias             "Cat"
+                  :display_name             "Name"
+                  :lib/source-column-alias  "NAME"
+                  :lib/desired-column-alias "Cat__NAME"}]
+                metadata))
+        (testing ":long display names"
+          (is (= ["ID"
+                  "Name"
+                  "Category ID"
+                  "Latitude"
+                  "Longitude"
+                  "Price"
+                  "ID + 1"
+                  "ID + 2"
+                  "Categories → ID"
+                  "Categories → Name"]
+                 (mapv #(lib.metadata.calculation/display-name query -1 % :long) metadata))))))))
 
 (deftest ^:parallel metadata-with-fields-only-include-expressions-in-fields-test
   (testing "If query includes :fields, only return expressions that are in :fields"

--- a/test/metabase/query_processor_test/test_mlv2.clj
+++ b/test/metabase/query_processor_test/test_mlv2.clj
@@ -127,11 +127,7 @@
      {:source-table (_id :guard #(str/starts-with? % "card__"))}
      (mbql.u/match-one &match
        [:field (_field-name :guard string?) _opts]
-       "#29941"))
-   ;; #29947: `:ends-with` broken
-   (mbql.u/match-one legacy-query
-     :ends-with
-     "#29947")))
+       "#29941"))))
 
 (defn- test-mlv2-metadata [original-query _qp-metadata]
   {:pre [(map? original-query)]}


### PR DESCRIPTION
Resolves #30047
Fixes #29947

I was originally going to add a new `long-display-name` method, but then threading thru "longness" meant everyone needed their own `long-display-name` method, which got silly. So eventually I just settled on adding a new *style* parameter to `display-name-method` to specify whether you want `:default` style or `:long` style. `:default` style is what the FE wants for most things; `:long` is currently only used for query suggested name generation. 

I also consolidated some of the display name methods for filter clauses now that we have the lib hierarchy.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30062)
<!-- Reviewable:end -->
