### PR TITLE
Backend for allow disabling auto-apply filters in slow dashboards

### DIFF
--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -14378,6 +14378,22 @@ databaseChangeLog:
                   constraints:
                     nullable: false
 
+  - changeSet:
+      id: v47.00-005
+      author: winlost
+      comment: Added 0.47.0 - Add auto_apply_filters to dashboard
+      changes:
+        - addColumn:
+            tableName: report_dashboard
+            columns:
+              - column:
+                  name: auto_apply_filters
+                  type: boolean
+                  remarks: Whether or not to auto-apply filters on a dashboard
+                  defaultValueBoolean: true
+                  constraints:
+                    nullable: false
+
 
 # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -387,7 +387,7 @@
   permissions for the Cards belonging to this Dashboard), but to change the value of `enable_embedding` you must be a
   superuser."
   [id :as {{:keys [description name parameters caveats points_of_interest show_in_getting_started enable_embedding
-                   embedding_params position archived collection_id collection_position cache_ttl auto_apply_filters]
+                   embedding_params position archived collection_id collection_position cache_ttl]
             :as dash-updates} :body}]
   {name                    (s/maybe su/NonBlankString)
    description             (s/maybe s/Str)
@@ -401,8 +401,7 @@
    archived                (s/maybe s/Bool)
    collection_id           (s/maybe su/IntGreaterThanZero)
    collection_position     (s/maybe su/IntGreaterThanZero)
-   cache_ttl               (s/maybe su/IntGreaterThanZero)
-   auto_apply_filters      (s/maybe s/Bool)}
+   cache_ttl               (s/maybe su/IntGreaterThanZero)}
   (let [dash-before-update (api/write-check Dashboard id)]
     ;; Do various permissions checks as needed
     (collection/check-allowed-to-change-collection dash-before-update dash-updates)

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -387,7 +387,7 @@
   permissions for the Cards belonging to this Dashboard), but to change the value of `enable_embedding` you must be a
   superuser."
   [id :as {{:keys [description name parameters caveats points_of_interest show_in_getting_started enable_embedding
-                   embedding_params position archived collection_id collection_position cache_ttl]
+                   embedding_params position archived collection_id collection_position cache_ttl auto_apply_filters]
             :as dash-updates} :body}]
   {name                    (s/maybe su/NonBlankString)
    description             (s/maybe s/Str)
@@ -401,7 +401,8 @@
    archived                (s/maybe s/Bool)
    collection_id           (s/maybe su/IntGreaterThanZero)
    collection_position     (s/maybe su/IntGreaterThanZero)
-   cache_ttl               (s/maybe su/IntGreaterThanZero)}
+   cache_ttl               (s/maybe su/IntGreaterThanZero)
+   auto_apply_filters      (s/maybe s/Bool)}
   (let [dash-before-update (api/write-check Dashboard id)]
     ;; Do various permissions checks as needed
     (collection/check-allowed-to-change-collection dash-before-update dash-updates)
@@ -415,7 +416,7 @@
       (when-let [updates (not-empty (u/select-keys-when dash-updates
                                       :present #{:description :position :collection_id :collection_position :cache_ttl}
                                       :non-nil #{:name :parameters :caveats :points_of_interest :show_in_getting_started :enable_embedding
-                                                 :embedding_params :archived}))]
+                                                 :embedding_params :archived :auto_apply_filters}))]
         (t2/update! Dashboard id updates))))
   ;; now publish an event and return the updated Dashboard
   (let [dashboard (t2/select-one Dashboard :id id)]

--- a/src/metabase/api/public.clj
+++ b/src/metabase/api/public.clj
@@ -204,7 +204,7 @@
    general public. Throws a 404 if the Dashboard doesn't exist."
   [& conditions]
   {:pre [(even? (count conditions))]}
-  (-> (api/check-404 (apply t2/select-one [Dashboard :name :description :id :parameters], :archived false, conditions))
+  (-> (api/check-404 (apply t2/select-one [Dashboard :name :description :id :parameters :auto_apply_filters], :archived false, conditions))
       (hydrate [:ordered_cards :card :series :dashcard/action] :param_fields)
       api.dashboard/add-query-average-durations
       (update :ordered_cards (fn [dashcards]

--- a/src/metabase/models/dashboard.clj
+++ b/src/metabase/models/dashboard.clj
@@ -166,7 +166,7 @@
 (defmethod revision/serialize-instance Dashboard
   [_model _id dashboard]
   (-> dashboard
-      (select-keys [:description :name :cache_ttl])
+      (select-keys [:description :name :cache_ttl :auto_apply_filters])
       (assoc :cards (vec (for [dashboard-card (ordered-cards dashboard)]
                            (-> (select-keys dashboard-card [:size_x :size_y :row :col :id :card_id])
                                (assoc :series (mapv :id (dashboard-card/series dashboard-card)))))))))
@@ -237,7 +237,10 @@
              (cond
                (< num-cards1 num-cards2) "added a card"
                (> num-cards1 num-cards2) "removed a card"
-               :else                     "rearranged the cards")))]
+               :else                     "rearranged the cards")))
+         (let [f (comp boolean :auto_apply_filters)]
+          (when (not= (f dashboard1) (f dashboard2))
+            (format "set auto apply filters to %s" (str (f dashboard2)))))]
         (concat (map-indexed check-series-change (:cards changes)))
         (->> (filter identity)
              build-sentence))))

--- a/test/metabase/api/embed_test.clj
+++ b/test/metabase/api/embed_test.clj
@@ -149,7 +149,7 @@
    :param_fields           nil})
 
 (def successful-dashboard-info
-  {:description nil, :parameters [], :ordered_cards [], :param_fields nil})
+  {:auto_apply_filters true, :description nil, :parameters [], :ordered_cards [], :param_fields nil})
 
 (def ^:private yesterday (time/minus (time/now) (time/days 1)))
 

--- a/test/metabase/api/revision_test.clj
+++ b/test/metabase/api/revision_test.clj
@@ -163,7 +163,7 @@
                :message      nil
                :user         @rasta-revision-info
                :diff         nil
-               :description  "rearranged the cards."}]
+               :description  "rearranged the cards and set auto apply filters to true."}]
              (->> (get-revisions :dashboard id)
                   (mapv (fn [rev]
                           (if-not (:diff rev)

--- a/test/metabase/events/revision_test.clj
+++ b/test/metabase/events/revision_test.clj
@@ -44,9 +44,10 @@
    :visualization_settings {}})
 
 (defn- dashboard->revision-object [dashboard]
-  {:description  nil
-   :cache_ttl    nil
-   :name         (:name dashboard)})
+  {:description        nil
+   :cache_ttl          nil
+   :auto_apply_filters true
+   :name               (:name dashboard)})
 
 (deftest card-create-test
   (testing ":card-create"


### PR DESCRIPTION
Epic: https://github.com/metabase/metabase/issues/29267
Product doc: https://www.notion.so/metabase/Prevent-auto-apply-filters-in-slow-dashboards-cc02d90dac9e42ee91f34c2a9810212f

This is 1/x of the epic

### Description

Add BE code to support Prevent auto-apply filters in slow dashboards project.
1. Add `auto_apply_filters` column to the dashboard
2. Can update dashboard with `auto_apply_filters` attribute
3. Returns `auto_apply_filters` in the API
4. Returns `auto_apply_filters` in the public dashboard

### How to verify

1. can GET `/api/dashboard/<dashboard_id>` and have `auto_apply_filters` in the dashboard in the response.
2. can PUT `/api/dashboard/<dashboard_id>` by sending `auto_apply_filters` in the request body.
3. can GET `/api/public/dashboard/<dashboard_uuid>` and have `auto_apply_filters` in the dashboard in the response

### Demo

#### GET `/api/dashboard/<dashboard_id>`
<img width="784" alt="image" src="https://user-images.githubusercontent.com/1937582/231737235-a816db7f-458e-41c5-8515-3f7e6c3bc29e.png">

### Checklist

- [X] Tests have been added/updated to cover changes in this PR

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30069)
<!-- Reviewable:end -->
