### PR TITLE
Fix models being broken after changing column order

### DIFF
--- a/e2e/test/scenarios/models/reproductions/29951-model-editor-results-metadata.cy.spec.js
+++ b/e2e/test/scenarios/models/reproductions/29951-model-editor-results-metadata.cy.spec.js
@@ -1,0 +1,61 @@
+import {
+  getNotebookStep,
+  openQuestionActions,
+  restore,
+} from "e2e/support/helpers";
+import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
+
+const { ORDERS_ID, ORDERS } = SAMPLE_DATABASE;
+
+const questionDetails = {
+  name: "29951",
+  query: {
+    "source-table": ORDERS_ID,
+    expressions: {
+      CC1: ["+", ["field", ORDERS.TOTAL], 1],
+      CC2: ["+", ["field", ORDERS.TOTAL], 1],
+    },
+  },
+  dataset: true,
+};
+
+describe("issue 29951", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+    cy.intercept("POST", "/api/dataset").as("dataset");
+    cy.intercept("PUT", "/api/card/*").as("updateCard");
+  });
+
+  it("should allow to run the model query after changing custom columns (metabase#29951)", () => {
+    cy.createQuestion(questionDetails, { visitQuestion: true });
+    cy.wait("@dataset");
+
+    openQuestionActions();
+    cy.findByText("Edit query definition").click();
+    removeExpression("CC2");
+    cy.findByRole("button", { name: "Save changes" }).click();
+    cy.wait("@updateCard");
+    cy.wait("@dataset");
+
+    dragColumn(0, 100);
+    cy.findAllByRole("button", { name: "Get Answer" }).first().click();
+    cy.wait("@dataset");
+    cy.findByText("Showing first 2,000 rows").should("be.visible");
+  });
+});
+
+const removeExpression = name => {
+  getNotebookStep("expression")
+    .findByText(name)
+    .findByLabelText("close icon")
+    .click();
+};
+
+const dragColumn = (index, distance) => {
+  cy.get(".react-draggable")
+    .eq(index)
+    .trigger("mousedown", 0, 0, { force: true })
+    .trigger("mousemove", distance, 0, { force: true })
+    .trigger("mouseup", distance, 0, { force: true });
+};

--- a/frontend/src/metabase/query_builder/actions/core/core.js
+++ b/frontend/src/metabase/query_builder/actions/core/core.js
@@ -225,7 +225,7 @@ export const apiUpdateQuestion = (question, { rerunQuery } = {}) => {
     const originalQuestion = getOriginalQuestion(getState());
     question = question || getQuestion(getState());
 
-    rerunQuery = rerunQuery || getIsResultDirty(getState());
+    rerunQuery = rerunQuery ?? getIsResultDirty(getState());
 
     // Needed for persisting visualization columns for pulses/alerts, see #6749
     const series = getTransformedSeries(getState());
@@ -264,9 +264,10 @@ export const apiUpdateQuestion = (question, { rerunQuery } = {}) => {
 
     dispatch({ type: API_UPDATE_QUESTION, payload: updatedQuestion.card() });
 
+    const metadataOptions = { reload: question.isDataset() };
+    await dispatch(loadMetadataForCard(question.card(), metadataOptions));
+
     if (rerunQuery) {
-      const metadataOptions = { reload: question.isDataset() };
-      await dispatch(loadMetadataForCard(question.card(), metadataOptions));
       dispatch(runQuestionQuery());
     }
   };

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.jsx
@@ -182,6 +182,7 @@ function DatasetEditor(props) {
     height,
     isDirty: isModelQueryDirty,
     setQueryBuilderMode,
+    runQuestionQuery,
     setDatasetEditorTab,
     setFieldMetadata,
     onCancelDatasetChanges,
@@ -306,13 +307,14 @@ function DatasetEditor(props) {
     if (canBeDataset && isBrandNewDataset) {
       onOpenModal(MODAL_TYPES.SAVE);
     } else if (canBeDataset) {
-      await onSave(dataset);
-      setQueryBuilderMode("view");
+      await onSave(dataset, { rerunQuery: false });
+      await setQueryBuilderMode("view");
+      await runQuestionQuery();
     } else {
       onOpenModal(MODAL_TYPES.CAN_NOT_CREATE_MODEL);
       throw new Error(t`Variables in models aren't supported yet`);
     }
-  }, [dataset, onSave, setQueryBuilderMode, onOpenModal]);
+  }, [dataset, onSave, setQueryBuilderMode, runQuestionQuery, onOpenModal]);
 
   const handleColumnSelect = useCallback(
     column => {

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.jsx
@@ -309,7 +309,7 @@ function DatasetEditor(props) {
     } else if (canBeDataset) {
       await onSave(dataset, { rerunQuery: false });
       await setQueryBuilderMode("view");
-      await runQuestionQuery();
+      runQuestionQuery();
     } else {
       onOpenModal(MODAL_TYPES.CAN_NOT_CREATE_MODEL);
       throw new Error(t`Variables in models aren't supported yet`);

--- a/frontend/src/metabase/query_builder/containers/QueryBuilder.jsx
+++ b/frontend/src/metabase/query_builder/containers/QueryBuilder.jsx
@@ -275,7 +275,7 @@ function QueryBuilder(props) {
   );
 
   const handleSave = useCallback(
-    async (updatedQuestion, { rerunQuery = false } = {}) => {
+    async (updatedQuestion, { rerunQuery } = {}) => {
       await apiUpdateQuestion(updatedQuestion, { rerunQuery });
       if (!rerunQuery) {
         await updateUrl(updatedQuestion, { dirty: false });


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/29951

The problem was that we used the original question (the model) when re-running the query when saving changes to the model and returning to the chill mode. But the chill mode expects to work with an-hoc question based on the model, and there was an issue where we used `results_metadata` from the query being run for the wrong question. This PR solves the issue by making sure we re-run the query with the correct question.

The "correct question" here means what we get from `getQuestion` selector. It depends on the `queryBuilderMode`, so it's important to set it to `view` (the chill mode) before executing the query after leaving the dataset editor. I've left more comments in the PR about the change.

How to verify:
- Either follow the steps from the original issue closely or run the cypress test

<img width="873" alt="Screenshot 2023-04-13 at 17 51 24" src="https://user-images.githubusercontent.com/8542534/231798854-485955b2-bb90-47c1-8fef-2c2bef59f57e.png">

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30073)
<!-- Reviewable:end -->
