### PR TITLE
CSV Upload Dates and Datetimes Types

### DIFF
--- a/src/metabase/driver/h2.clj
+++ b/src/metabase/driver/h2.clj
@@ -525,4 +525,6 @@
     ::upload/text        "VARCHAR"
     ::upload/int         "INTEGER"
     ::upload/float       "DOUBLE PRECISION"
-    ::upload/boolean     "BOOLEAN"))
+    ::upload/boolean     "BOOLEAN"
+    ::upload/date        "DATE"
+    ::upload/datetime    "TIMESTAMP"))

--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -617,4 +617,6 @@
     ::upload/text        "TEXT"
     ::upload/int         "INTEGER"
     ::upload/float       "DOUBLE"
-    ::upload/boolean     "BOOLEAN"))
+    ::upload/boolean     "BOOLEAN"
+    ::upload/date        "DATE"
+    ::upload/datetime    "TIMESTAMP"))

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -763,4 +763,5 @@
     ::upload/text        "TEXT"
     ::upload/int         "INTEGER"
     ::upload/float       "FLOAT"
-    ::upload/boolean     "BOOLEAN"))
+    ::upload/boolean     "BOOLEAN"
+    ::upload/date        "DATE"))

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -764,4 +764,5 @@
     ::upload/int         "INTEGER"
     ::upload/float       "FLOAT"
     ::upload/boolean     "BOOLEAN"
-    ::upload/date        "DATE"))
+    ::upload/date        "DATE"
+    ::upload/datetime    "TIMESTAMP"))

--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -32,7 +32,7 @@
 ;;           |
 ;;        boolean
 
-(def type->parent
+(def ^:private type->parent
   ;; listed in depth-first order
   {::varchar_255 ::text
    ::float       ::varchar_255
@@ -45,7 +45,7 @@
   (set/union (set (keys type->parent))
              (set (vals type->parent))))
 
-(def type->ancestors
+(def ^:private type->ancestors
   (into {} (for [type types]
              [type (loop [ret (ordered-set/ordered-set)
                           type type]
@@ -98,7 +98,7 @@
     (contains? ys (first xs)) (first xs)
     :else (lowest-common-member (rest xs) ys)))
 
-(defn lowest-common-ancestor [type-a type-b]
+(defn- lowest-common-ancestor [type-a type-b]
   (cond
     (nil? type-a) type-b
     (nil? type-b) type-a

--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -24,10 +24,10 @@
 ;;              / \
 ;;             /   \
 ;;            /     \
-;;         float   date
+;;         float   datetime
 ;;           |       |
 ;;           |       |
-;;          int   datetime
+;;          int    date
 ;;           |
 ;;           |
 ;;        boolean
@@ -38,8 +38,8 @@
    ::float       ::varchar_255
    ::int         ::float
    ::boolean     ::int
-   ::date        ::varchar_255
-   ::datetime    ::date})
+   ::datetime    ::varchar_255
+   ::date        ::datetime})
 
 (def ^:private types
   (set/union (set (keys type->parent))
@@ -145,7 +145,9 @@
 
 (defn- parse-datetime
   [s]
-  (t/local-date-time s))
+  (cond
+    (date-string? s) (t/local-date-time (t/local-date s) (t/local-time "00:00:00"))
+    (datetime-string? s) (t/local-date-time s)))
 
 (def ^:private upload-type->parser
   {::varchar_255 identity

--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -92,11 +92,11 @@
   [row]
   (map (comp value->type search-util/normalize) row))
 
-(defn- lowest-common-member [xs ys]
+(defn- lowest-common-member [[x & xs :as all-xs] ys]
   (cond
-    (empty? xs) (throw (IllegalArgumentException. (str "{0} and {1} must have a common member" xs ys)))
-    (contains? ys (first xs)) (first xs)
-    :else (lowest-common-member (rest xs) ys)))
+    (empty? all-xs)  (throw (IllegalArgumentException. (format "%s and %s must have a common member" xs ys)))
+    (contains? ys x) x
+    :else            (recur xs ys)))
 
 (defn- lowest-common-ancestor [type-a type-b]
   (cond

--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -2,13 +2,14 @@
   (:require
    [clojure.data.csv :as csv]
    [clojure.java.io :as io]
+   [clojure.set :as set]
    [clojure.string :as str]
    [flatland.ordered.map :as ordered-map]
+   [flatland.ordered.set :as ordered-set]
    [java-time :as t]
    [metabase.driver :as driver]
    [metabase.search.util :as search-util]
-   [metabase.util :as u]
-   [metabase.util.i18n :refer [trs]]))
+   [metabase.util :as u]))
 
 (set! *warn-on-reflection* true)
 
@@ -16,23 +17,45 @@
 ;;;; | Schema detection |
 ;;;; +------------------+
 
-;;           text
-;;            |
-;;            |
-;;       varchar_255
-;;            |
-;;            |
-;;          float
-;;            |
-;;            |
-;;           int
-;;            |
-;;            |
-;;         boolean
-(derive ::boolean     ::int)
-(derive ::int         ::float)
-(derive ::float       ::varchar_255)
-(derive ::varchar_255 ::text)
+;;              text
+;;               |
+;;               |
+;;          varchar_255
+;;              / \
+;;             /   \
+;;            /     \
+;;         float   date
+;;           |
+;;           |
+;;          int
+;;           |
+;;           |
+;;        boolean
+
+(def type->parent
+  {::boolean     ::int
+   ::int         ::float
+   ::float       ::varchar_255
+   ::date        ::varchar_255
+   ::varchar_255 ::text})
+
+(def ^:private types
+  (set/union (set (keys type->parent))
+             (set (vals type->parent))))
+
+(def type->ancestors
+  (into {} (for [type types]
+             [type (loop [ret (ordered-set/ordered-set)
+                          type type]
+                     (if-let [parent (type->parent type)]
+                       (recur (conj ret parent) parent)
+                       ret))])))
+
+(defn- date-string? [s]
+  (try (t/local-date s)
+       true
+       (catch Exception _
+         false)))
 
 (defn value->type
   "The most-specific possible type for a given value. Possibilities are:
@@ -52,6 +75,7 @@
     (re-matches #"(?i)true|t|yes|y|1|false|f|no|n|0" value) ::boolean
     (re-matches #"-?[\d,]+"                          value) ::int
     (re-matches #"-?[\d,]*\.\d+"                     value) ::float
+    (date-string?                                    value) ::date
     (re-matches #".{1,255}"                          value) ::varchar_255
     :else                                                   ::text))
 
@@ -59,20 +83,25 @@
   [row]
   (map (comp value->type search-util/normalize) row))
 
-(defn coalesce
-  "Returns the 'parent' type (the most general)."
-  [type-a type-b]
+(defn- lowest-common-member [xs ys]
   (cond
-    (nil? type-a)        type-b
-    (nil? type-b)        type-a
-    (isa? type-a type-b) type-b
-    (isa? type-b type-a) type-a
-    :else (throw (Exception. (trs "Unexpected type combination in the same column: {0} and {1}" type-a type-b)))))
+    (empty? xs) (throw (IllegalArgumentException. (str "{0} and {1} must have a common member" xs ys)))
+    (contains? ys (first xs)) (first xs)
+    :else (lowest-common-member (rest xs) ys)))
+
+(defn lowest-common-ancestor [type-a type-b]
+  (cond
+    (nil? type-a) type-b
+    (nil? type-b) type-a
+    (= type-a type-b) type-a
+    (contains? (type->ancestors type-a) type-b) type-b
+    (contains? (type->ancestors type-b) type-a) type-a
+    :else (lowest-common-member (type->ancestors type-a) (type->ancestors type-b))))
 
 (defn- coalesce-types
   [types-so-far new-types]
   (->> (map vector types-so-far new-types)
-       (mapv (partial apply coalesce))))
+       (mapv (partial apply lowest-common-ancestor))))
 
 (defn- pad
   "Lengthen `values` until it is of length `n` by filling it with nils."
@@ -101,12 +130,17 @@
     (re-matches #"(?i)true|t|yes|y|1" s) true
     (re-matches #"(?i)false|f|no|n|0" s) false))
 
+(defn- parse-date
+  [s]
+  (t/local-date s))
+
 (def ^:private upload-type->parser
   {::varchar_255 identity
    ::text        identity
    ::int         #(Integer/parseInt (str/trim %))
    ::float       #(parse-double (str/trim %))
-   ::boolean     #(parse-bool (str/trim %))})
+   ::boolean     #(parse-bool (str/trim %))
+   ::date        #(parse-date (str/trim %))})
 
 (defn- parsed-rows
   "Returns a vector of parsed rows from a `csv-file`.
@@ -140,6 +174,7 @@
     - ::boolean
     - ::varchar_255
     - ::text
+    - ::date
 
   A column that is completely blank is assumed to be of type ::text."
   [csv-file]

--- a/test/metabase/upload_test.clj
+++ b/test/metabase/upload_test.clj
@@ -244,7 +244,8 @@
                          "2022-01-01T00:00:00"]))
         (testing "Fields exists after sync"
           (sync/sync-database! (mt/db))
-          (let [table (t2/select-one Table :name "upload_test" :db_id (mt/id))]
+          (let [table (t2/select-one Table :db_id (mt/id))]
+            (is (=? {:name #"(?i)upload_test"} table))
             (testing "Check the datetime column the correct base_type"
               (is (=? {:name      #"(?i)datetime"
                        :base_type :type/DateTime}

--- a/test/metabase/upload_test.clj
+++ b/test/metabase/upload_test.clj
@@ -75,7 +75,7 @@
                                     [date-type     text-type     text-type]
                                     [datetime-type vchar-type    vchar-type]
                                     [datetime-type text-type     text-type]]]
-    (is (= expected (upload/lowest-common-ancestor type-a type-b))
+    (is (= expected (#'upload/lowest-common-ancestor type-a type-b))
         (format "%s + %s = %s" (name type-a) (name type-b) (name expected)))))
 
 (defn csv-file-with

--- a/test/metabase/upload_test.clj
+++ b/test/metabase/upload_test.clj
@@ -58,7 +58,7 @@
                                     [bool-type     int-type      int-type]
                                     [bool-type     date-type     vchar-type]
                                     [bool-type     datetime-type vchar-type]
-                                    [bool-type     vchar-type    vchar-type] ;; ensure arg order doesn't matter
+                                    [bool-type     vchar-type    vchar-type]
                                     [bool-type     text-type     text-type]
                                     [int-type      bool-type     int-type]
                                     [int-type      float-type    float-type]
@@ -74,7 +74,8 @@
                                     [date-type     vchar-type    vchar-type]
                                     [date-type     text-type     text-type]
                                     [datetime-type vchar-type    vchar-type]
-                                    [datetime-type text-type     text-type]]]
+                                    [datetime-type text-type     text-type]
+                                    [vchar-type    text-type     text-type]]]
     (is (= expected (#'upload/lowest-common-ancestor type-a type-b))
         (format "%s + %s = %s" (name type-a) (name type-b) (name expected)))))
 


### PR DESCRIPTION
This PR adds basic date and datetime parsing for CSV uploads.

Some caveats:

Dates need to be in the format like "2023-01-01" and datetimes need to be in the format like "2023-01-01T00:00:00". Any other format will fail.

It assumes that every driver that implements csv uploads also supports date/datetime base types. This assumption will have to be broken to support drivers like sqlite, which don't have date or datetime types.

Not in this PR:
- specifying MM/DD/YYYY vs DD/MM/YYYY
- other separators like DD.MM.YYYY and DD/MM/YYYY
- time types

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30076)
<!-- Reviewable:end -->
