### PR TITLE
Adds --include-database-secrets flag for export

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
@@ -99,6 +99,20 @@
           (is (= #{coll-eid child-eid}
                  (by-model "Collection" (extract/extract-metabase {:user 218921})))))))))
 
+(deftest database-test
+  (mt/with-empty-h2-app-db
+    (ts/with-temp-dpc [Database   [_ {:name "My Database"}]]
+      (testing "without :include-database-secrets"
+        (let [extracted (extract/extract-metabase {})
+              dbs       (filter #(= "Database" (:model (last (serdes/path %)))) extracted)]
+          (is (= 1 (count dbs)))
+          (is (not-any? :details dbs))))
+      (testing "with :include-database-secrets"
+        (let [extracted (extract/extract-metabase {:include-database-secrets true})
+              dbs       (filter #(= "Database" (:model (last (serdes/path %)))) extracted)]
+          (is (= 1 (count dbs)))
+          (is (every? :details dbs)))))))
+
 (deftest dashboard-and-cards-test
   (mt/with-empty-h2-app-db
     (ts/with-temp-dpc [Collection [{coll-id    :id

--- a/src/metabase/cmd.clj
+++ b/src/metabase/cmd.clj
@@ -194,7 +194,8 @@
    Options:
 
     --collections [collection-id-list] - a comma-separated list of IDs of collection to export
-    --include-field-values             - flag, default false, controls export of field values"
+    --include-field-values             - flag, default false, controls export of field values
+    --include-database-secrets         - flag, default false, include database connection details"
   [path & options]
   (let [opts (-> options cmd-args->map (update :collections parse-int-list))]
     (call-enterprise 'metabase-enterprise.serialization.cmd/v2-dump path opts)))

--- a/src/metabase/models/database.clj
+++ b/src/metabase/models/database.clj
@@ -301,13 +301,11 @@
 ;;; ------------------------------------------------ Serialization ----------------------------------------------------
 
 (defmethod serdes/extract-one "Database"
-  [_model-name {secrets :database/secrets :or {secrets :exclude}} entity]
-  ;; TODO Support alternative encryption of secret database details.
-  ;; There's one optional foreign key: creator_id. Resolve it as an email.
-  (cond-> (serdes/extract-one-basics "Database" entity)
-    true                 (update :creator_id serdes/*export-user*)
-    true                 (dissoc :features) ; This is a synthetic column that isn't in the real schema.
-    (= :exclude secrets) (dissoc :details)))
+  [_model-name {:keys [include-database-secrets]} entity]
+  (-> (serdes/extract-one-basics "Database" entity)
+      (update :creator_id serdes/*export-user*)
+      (dissoc :features) ; This is a synthetic column that isn't in the real schema.
+      (cond-> (not include-database-secrets) (dissoc :details))))
 
 (defmethod serdes/entity-id "Database"
   [_ {:keys [name]}]


### PR DESCRIPTION
This changes the `--database/secrets reveal` argument to `--include-database-secrets` and adds a docstring and test to cover it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30078)
<!-- Reviewable:end -->
