### PR TITLE
Entity Search + Indexing

### DIFF
--- a/e2e/test/scenarios/models/model-indexes.cy.spec.js
+++ b/e2e/test/scenarios/models/model-indexes.cy.spec.js
@@ -1,0 +1,124 @@
+import {
+  restore,
+  openQuestionActions,
+  popover,
+  sidebar,
+} from "e2e/support/helpers";
+
+import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
+import { openColumnOptions } from "./helpers/e2e-models-metadata-helpers";
+
+const { PRODUCTS_ID, PEOPLE_ID } = SAMPLE_DATABASE;
+
+describe("scenarios > model indexes", () => {
+  const pkRef = ["field", 3, null];
+  const valueRef = ["field", 2, null];
+  const modelId = 4;
+
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+    cy.intercept("GET", "/api/search?q=*").as("searchQuery");
+    cy.intercept("POST", "/api/dataset").as("dataset");
+    cy.intercept("POST", "/api/model-index").as("modelIndex");
+
+    cy.createQuestion({
+      name: "Products Model",
+      query: { "source-table": PRODUCTS_ID },
+      dataset: true,
+    });
+  });
+
+  it("should create a model index on product titles", () => {
+    cy.visit(`/model/${modelId}`);
+    cy.wait("@dataset");
+    openQuestionActions();
+    popover().findByText("Edit metadata").click();
+
+    cy.url().should("include", "/metadata");
+
+    cy.findByTestId("TableInteractive-root").findByTextEnsureVisible("Title");
+
+    openColumnOptions("Title");
+
+    sidebar()
+      .findByLabelText(/surface individual records/i)
+      .click();
+
+    cy.findByTestId("dataset-edit-bar").within(() => {
+      cy.button("Save changes").click();
+    });
+
+    cy.wait("@modelIndex").then(({ request, response }) => {
+      expect(request.body.pk_ref).to.deep.equal(pkRef);
+      expect(request.body.value_ref).to.deep.equal(valueRef);
+      expect(request.body.model_id).to.equal(modelId);
+
+      // this will likely change when this becomes an async process
+      expect(response.body.state).to.equal("indexed");
+      expect(response.body.id).to.equal(1);
+    });
+  });
+
+  it("should be able to search model index values and visit detail records", () => {
+    createModelIndex({ pkRef, valueRef, modelId });
+
+    cy.visit("/");
+
+    cy.findByTestId("app-bar")
+      .findByPlaceholderText("Search…")
+      .type("marble shoes");
+
+    cy.wait("@searchQuery");
+
+    cy.findByTestId("search-results-list")
+      .findByText("Small Marble Shoes")
+      .click();
+
+    cy.wait("@dataset");
+
+    cy.findByTestId("object-detail").within(() => {
+      cy.findByText("Product");
+      cy.findByText("Small Marble Shoes");
+      cy.findByText("Doohickey");
+    });
+  });
+
+  it.skip("should be able to see details of a record outside the first 2000", () => {
+    cy.createQuestion({
+      name: "People Model",
+      query: { "source-table": PEOPLE_ID },
+      dataset: true,
+    });
+    createModelIndex({
+      pkRef: ["field", 32, null],
+      valueRef: ["field", 35, null],
+      modelId: 5,
+    });
+
+    cy.visit("/");
+
+    cy.findByTestId("app-bar").findByPlaceholderText("Search…").type("anais");
+
+    cy.wait("@searchQuery");
+
+    cy.findByTestId("search-results-list").findByText("Anais Zieme").click();
+
+    cy.wait("@dataset");
+
+    cy.findByTestId("object-detail").within(() => {
+      cy.findByText(/We're a little lost/i).should("not.exist");
+    });
+  });
+});
+
+function createModelIndex({ pkRef, valueRef, modelId }) {
+  cy.request("POST", "/api/model-index", {
+    pk_ref: pkRef,
+    value_ref: valueRef,
+    model_id: modelId,
+  }).then(response => {
+    expect(response.body.state).to.equal("indexed");
+    expect(response.body.id).to.equal(1);
+  });
+}

--- a/frontend/src/metabase-lib/types/constants.js
+++ b/frontend/src/metabase-lib/types/constants.js
@@ -4,6 +4,7 @@ export const TYPE = cljs_TYPE;
 
 // primary field types used for picking operators, etc
 export const NUMBER = "NUMBER";
+export const INTEGER = "INTEGER";
 export const STRING = "STRING";
 export const STRING_LIKE = "STRING_LIKE";
 export const BOOLEAN = "BOOLEAN";
@@ -33,6 +34,10 @@ export const TYPE_HIERARCHIES = {
     base: [TYPE.Number],
     effective: [TYPE.Number],
     semantic: [TYPE.Number],
+  },
+  [INTEGER]: {
+    base: [TYPE.Integer],
+    effective: [TYPE.Integer],
   },
   [STRING]: {
     base: [TYPE.Text],

--- a/frontend/src/metabase-lib/types/utils/isa.js
+++ b/frontend/src/metabase-lib/types/utils/isa.js
@@ -12,6 +12,7 @@ import {
   STRING,
   STRING_LIKE,
   NUMBER,
+  INTEGER,
   BOOLEAN,
   SUMMABLE,
   SCOPE,
@@ -103,6 +104,7 @@ export function getFieldType(field) {
 
 export const isDate = isFieldType.bind(null, TEMPORAL);
 export const isNumeric = isFieldType.bind(null, NUMBER);
+export const isInteger = isFieldType.bind(null, INTEGER);
 export const isBoolean = isFieldType.bind(null, BOOLEAN);
 export const isString = isFieldType.bind(null, STRING);
 export const isSummable = isFieldType.bind(null, SUMMABLE);

--- a/frontend/src/metabase-lib/types/utils/isa.unit.spec.js
+++ b/frontend/src/metabase-lib/types/utils/isa.unit.spec.js
@@ -1,4 +1,8 @@
-import { getFieldType } from "metabase-lib/types/utils/isa";
+import {
+  getFieldType,
+  isString,
+  isInteger,
+} from "metabase-lib/types/utils/isa";
 import {
   TYPE,
   TEMPORAL,
@@ -105,6 +109,25 @@ describe("isa", () => {
 
     it("should know what it doesn't know", () => {
       expect(getFieldType({ base_type: "DERP DERP DERP" })).toEqual(undefined);
+    });
+  });
+
+  describe("isInteger", () => {
+    it("should know an integer", () => {
+      expect(isInteger({ base_type: TYPE.BigInteger })).toEqual(true);
+      expect(isInteger({ base_type: TYPE.Integer })).toEqual(true);
+      expect(isInteger({ base_type: TYPE.Float })).toEqual(false);
+      expect(isInteger({ base_type: TYPE.String })).toEqual(false);
+    });
+  });
+
+  describe("isString", () => {
+    it("should detect text", () => {
+      expect(isString({ base_type: TYPE.Text })).toEqual(true);
+    });
+
+    it("should know that booleans are not strings", () => {
+      expect(isString({ base_type: TYPE.Boolean })).toEqual(false);
     });
   });
 });

--- a/frontend/src/metabase-types/api/field.ts
+++ b/frontend/src/metabase-types/api/field.ts
@@ -1,5 +1,6 @@
 import { RowValue } from "./dataset";
 import { TableId } from "./table";
+import type { FieldReference } from "./query";
 
 export type FieldId = number;
 
@@ -98,4 +99,5 @@ export interface FieldValues {
 
 export type Field = Omit<ConcreteField, "id"> & {
   id?: FieldId;
+  field_ref?: FieldReference;
 };

--- a/frontend/src/metabase-types/api/index.ts
+++ b/frontend/src/metabase-types/api/index.ts
@@ -13,6 +13,7 @@ export * from "./foreign-key";
 export * from "./group";
 export * from "./metric";
 export * from "./models";
+export * from "./modelIndexes";
 export * from "./notifications";
 export * from "./permissions";
 export * from "./query";

--- a/frontend/src/metabase-types/api/mocks/index.ts
+++ b/frontend/src/metabase-types/api/mocks/index.ts
@@ -9,6 +9,7 @@ export * from "./dataset";
 export * from "./field";
 export * from "./metric";
 export * from "./models";
+export * from "./modelIndexes";
 export * from "./parameters";
 export * from "./query";
 export * from "./segment";

--- a/frontend/src/metabase-types/api/mocks/modelIndexes.ts
+++ b/frontend/src/metabase-types/api/mocks/modelIndexes.ts
@@ -1,0 +1,12 @@
+import { ModelIndex } from "metabase-types/api";
+
+export const createMockModelIndex = (
+  opts?: Partial<ModelIndex>,
+): ModelIndex => ({
+  id: 1,
+  model_id: 1,
+  pk_ref: ["field", 1, null],
+  value_ref: ["field", 2, null],
+  state: "indexed",
+  ...opts,
+});

--- a/frontend/src/metabase-types/api/modelIndexes.ts
+++ b/frontend/src/metabase-types/api/modelIndexes.ts
@@ -1,0 +1,19 @@
+import type { CardId } from "./card";
+import type { FieldReference } from "./query";
+
+export type ModelIndex = {
+  id: number;
+  model_id: CardId;
+  value_ref: FieldReference;
+  pk_ref: FieldReference;
+  state: "indexed" | "pending";
+};
+
+export type IndexedEntity = {
+  id: number;
+  model_id: CardId;
+  model: "indexed-entity";
+  model_name: string;
+  name: string;
+  pk_ref: FieldReference;
+};

--- a/frontend/src/metabase-types/api/search.ts
+++ b/frontend/src/metabase-types/api/search.ts
@@ -4,4 +4,5 @@ export type SearchModelType =
   | "dashboard"
   | "database"
   | "dataset"
-  | "table";
+  | "table"
+  | "indexed-entity";

--- a/frontend/src/metabase-types/store/entities.ts
+++ b/frontend/src/metabase-types/store/entities.ts
@@ -4,7 +4,9 @@ import {
   Dashboard,
   Database,
   Field,
+  IndexedEntity,
   Metric,
+  ModelIndex,
   NativeQuerySnippet,
   Schema,
   Segment,
@@ -20,6 +22,8 @@ export interface EntitiesState {
   databases: Record<string, Database>;
   schemas: Record<string, Schema>;
   tables: Record<string, Table>;
+  modelIndexes: Record<string, ModelIndex>;
+  indexedEntities: Record<string, IndexedEntity>;
   fields: Record<string, Field>;
   segments: Record<string, Segment>;
   metrics: Record<string, Metric>;

--- a/frontend/src/metabase-types/store/mocks/entities.ts
+++ b/frontend/src/metabase-types/store/mocks/entities.ts
@@ -15,5 +15,7 @@ export const createMockEntitiesState = (
   snippets: {},
   users: {},
   questions: {},
+  modelIndexes: {},
+  indexedEntities: {},
   ...opts,
 });

--- a/frontend/src/metabase/components/EditBar/EditBar.tsx
+++ b/frontend/src/metabase/components/EditBar/EditBar.tsx
@@ -14,6 +14,7 @@ type Props = {
   buttons: JSX.Element[];
   admin?: boolean;
   className?: string;
+  "data-testid"?: string;
 };
 
 function EditBar({
@@ -23,9 +24,14 @@ function EditBar({
   buttons,
   admin = false,
   className,
+  "data-testid": dataTestId,
 }: Props) {
   return (
-    <Root className={className} admin={admin}>
+    <Root
+      className={className}
+      admin={admin}
+      data-testid={dataTestId ?? "edit-bar"}
+    >
       <div>
         <EditIcon name="pencil" size={12} />
         <Title>{title}</Title>

--- a/frontend/src/metabase/entities/index.js
+++ b/frontend/src/metabase/entities/index.js
@@ -6,6 +6,9 @@ export { default as dashboards } from "./dashboards";
 export { default as databaseCandidates } from "./database-candidates";
 export { default as pulses } from "./pulses";
 export { default as questions } from "./questions";
+export { default as modelIndexes } from "./model-indexes";
+export { default as indexedEntities } from "./indexed-entities";
+
 export { default as timelines } from "./timelines";
 export { default as timelineEvents } from "./timeline-events";
 

--- a/frontend/src/metabase/entities/indexed-entities/index.ts
+++ b/frontend/src/metabase/entities/indexed-entities/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./indexed-entities";

--- a/frontend/src/metabase/entities/indexed-entities/indexed-entities.ts
+++ b/frontend/src/metabase/entities/indexed-entities/indexed-entities.ts
@@ -1,0 +1,21 @@
+/**
+ * An indexed entity is returned by the search endpoint and points to a single database record in a model
+ * This is a special case for entities, because it doesn't have its own API endpoints, but it needs
+ * to be treated as an entity (for now at least) so that it will play nicely with search
+ */
+
+import { createEntity } from "metabase/lib/entities";
+import { IndexedEntitySchema } from "metabase/schema";
+import { indexedEntity as indexedEntityUrl } from "metabase/lib/urls";
+
+const IndexedEntities = createEntity({
+  name: "indexedEntities",
+  nameOne: "indexedEntity",
+  schema: IndexedEntitySchema,
+  objectSelectors: {
+    getUrl: indexedEntityUrl,
+    getIcon: () => ({ name: "beaker" }),
+  },
+});
+
+export default IndexedEntities;

--- a/frontend/src/metabase/entities/model-indexes/actions.ts
+++ b/frontend/src/metabase/entities/model-indexes/actions.ts
@@ -1,0 +1,135 @@
+import _ from "underscore";
+import { dissocIn } from "icepick";
+
+import { Dispatch } from "metabase-types/store";
+import type { ModelIndex } from "metabase-types/api/modelIndexes";
+import type { FieldReference } from "metabase-types/api";
+import type Question from "metabase-lib/Question";
+import type Field from "metabase-lib/metadata/Field";
+
+import ModelIndexes from "./model-indexes";
+
+type FieldWithMaybeIndex = Field & {
+  should_index?: boolean;
+  field_ref: FieldReference;
+};
+
+export const updateModelIndexes =
+  (model: Question) => async (dispatch: Dispatch, getState: any) => {
+    const fields = model.getResultMetadata();
+
+    const fieldsWithIndexFlags = fields.filter(
+      (field: FieldWithMaybeIndex) => field.should_index !== undefined,
+    );
+
+    if (fieldsWithIndexFlags.length === 0) {
+      return;
+    }
+
+    const existingIndexes: ModelIndex[] =
+      ModelIndexes.selectors.getIndexesForModel(getState(), {
+        modelId: model.id(),
+      });
+
+    const newFieldsToIndex = getFieldsToIndex(
+      fieldsWithIndexFlags,
+      existingIndexes,
+    );
+    const indexIdsToRemove = getIndexIdsToRemove(
+      fieldsWithIndexFlags,
+      existingIndexes,
+    );
+
+    if (newFieldsToIndex.length) {
+      const pkRef = ModelIndexes.utils.getPkRef(fields);
+
+      await Promise.all(
+        newFieldsToIndex.map(field =>
+          ModelIndexes.api.create({
+            model_id: model.id(),
+            value_ref: field.field_ref,
+            pk_ref: pkRef,
+          }),
+        ),
+      );
+    }
+
+    if (indexIdsToRemove.length) {
+      await Promise.all(
+        indexIdsToRemove.map(indexId =>
+          ModelIndexes.api.delete({ id: indexId }),
+        ),
+      );
+    }
+
+    dispatch(ModelIndexes.actions.invalidateLists());
+  };
+
+function getFieldsToIndex(
+  fieldsWithIndexFlags: FieldWithMaybeIndex[],
+  existingIndexes: ModelIndex[],
+) {
+  // make sure none of these fields are already indexed by this model
+  const newFieldsToIndex = fieldsWithIndexFlags.filter(
+    field =>
+      field.should_index &&
+      !existingIndexes.some((index: ModelIndex) =>
+        _.isEqual(index.value_ref, field.field_ref),
+      ),
+  );
+
+  return newFieldsToIndex;
+}
+
+function getIndexIdsToRemove(
+  fieldsWithIndexFlags: FieldWithMaybeIndex[],
+  existingIndexes: ModelIndex[],
+) {
+  const indexIdsToRemove = fieldsWithIndexFlags.reduce(
+    (indexIdsToRemove: number[], field) => {
+      if (field.should_index) {
+        return indexIdsToRemove;
+      }
+
+      // make sure we're only removing already-indexed fields
+      const foundIndex = existingIndexes.find((index: ModelIndex) =>
+        _.isEqual(index.value_ref, field.field_ref),
+      );
+
+      if (foundIndex) {
+        indexIdsToRemove.push(foundIndex.id);
+      }
+
+      return indexIdsToRemove;
+    },
+    [],
+  );
+
+  return indexIdsToRemove;
+}
+
+export function cleanIndexFlags(model: Question) {
+  const fields = model.getResultMetadata();
+  const indexesToClean = fields.reduce(
+    (
+      indexesToClean: number[],
+      field: FieldWithMaybeIndex,
+      thisIndex: number,
+    ) => {
+      if (field.should_index !== undefined) {
+        indexesToClean.push(thisIndex);
+      }
+      return indexesToClean;
+    },
+    [],
+  );
+
+  const newResultMetadata = [...model.getResultMetadata()];
+  for (const index of indexesToClean) {
+    newResultMetadata[index] = dissocIn(newResultMetadata[index], [
+      "should_index",
+    ]);
+  }
+  const newModel = model.setResultsMetadata(newResultMetadata);
+  return newModel;
+}

--- a/frontend/src/metabase/entities/model-indexes/actions.ts
+++ b/frontend/src/metabase/entities/model-indexes/actions.ts
@@ -9,7 +9,7 @@ import type Field from "metabase-lib/metadata/Field";
 
 import ModelIndexes from "./model-indexes";
 
-type FieldWithMaybeIndex = Field & {
+export type FieldWithMaybeIndex = Field & {
   should_index?: boolean;
   field_ref: FieldReference;
 };

--- a/frontend/src/metabase/entities/model-indexes/actions.unit.spec.ts
+++ b/frontend/src/metabase/entities/model-indexes/actions.unit.spec.ts
@@ -1,0 +1,210 @@
+import fetchMock from "fetch-mock";
+import type { MockCall } from "fetch-mock";
+import {
+  createMockField as createBaseMockField,
+  createMockCard,
+  createMockModelIndex,
+} from "metabase-types/api/mocks";
+
+import { setupModelIndexEndpoints } from "__support__/server-mocks/model-indexes";
+
+import type { FieldReference, ModelIndex, Field } from "metabase-types/api";
+
+import Question from "metabase-lib/Question";
+
+import {
+  updateModelIndexes,
+  cleanIndexFlags,
+  FieldWithMaybeIndex,
+} from "./actions";
+
+const createMockField = (options?: Partial<FieldWithMaybeIndex>): Field => {
+  // @ts-expect-error we're shoving FieldWithMaybeIndex into Field
+  return createBaseMockField(options);
+};
+
+const createModelWithResultMetadata = (fields: Field[]) => {
+  return new Question(
+    createMockCard({ result_metadata: fields, dataset: true }),
+  );
+};
+
+describe("Entities > model-indexes > actions", () => {
+  describe("cleanIndexFlags", () => {
+    it("should remove should_index flag from fields", () => {
+      const model = createModelWithResultMetadata([
+        createMockField({ should_index: true }),
+        createMockField({ should_index: false }),
+        createMockField(),
+      ]);
+
+      const cleanedQuestion = cleanIndexFlags(model);
+
+      cleanedQuestion.getResultMetadata().forEach((field: any) => {
+        expect(field?.should_index).toBeUndefined();
+      });
+    });
+
+    it("should not mutate the original question", () => {
+      const model = createModelWithResultMetadata([
+        createMockField({ should_index: true }),
+        createMockField({ should_index: true }),
+      ]);
+
+      cleanIndexFlags(model);
+
+      model.getResultMetadata().forEach((field: any) => {
+        expect(field?.should_index).toBe(true);
+      });
+    });
+  });
+  describe("updateModelIndexes", () => {
+    it("should not do anything if there are no fields with should_index flag", async () => {
+      const model = createModelWithResultMetadata([
+        createMockField(),
+        createMockField(),
+      ]);
+
+      const mockDispatch = jest.fn();
+      const mockGetState = jest.fn();
+      await updateModelIndexes(model)(mockDispatch, mockGetState);
+
+      expect(mockDispatch).not.toHaveBeenCalled();
+      expect(mockGetState).not.toHaveBeenCalled();
+    });
+
+    it("should make a POST call for a newly-added index field", async () => {
+      const pkFieldRef: FieldReference = ["field", 1, null];
+      const indexFieldRef: FieldReference = ["field", 2, null];
+
+      const model = createModelWithResultMetadata([
+        createMockField({ field_ref: pkFieldRef, semantic_type: "type/PK" }),
+        createMockField({ should_index: true, field_ref: indexFieldRef }),
+        createMockField(),
+      ]);
+
+      setupModelIndexEndpoints(model.id(), []);
+
+      const mockDispatch = jest.fn();
+      const mockGetState = jest.fn(() => ({ entities: { modelIndexes: [] } }));
+      await updateModelIndexes(model)(mockDispatch, mockGetState);
+
+      expect(mockDispatch).toHaveBeenCalled();
+      expect(mockGetState).toHaveBeenCalled();
+
+      const [, options] = (await fetchMock.lastCall()) as MockCall;
+
+      expect(options?.method).toBe("POST");
+      // @ts-expect-error ???
+      const body = JSON.parse(await options?.body) as Partial<ModelIndex>;
+      expect(body.model_id).toBe(model.id());
+      expect(body.pk_ref).toEqual(pkFieldRef);
+      expect(body.value_ref).toEqual(indexFieldRef);
+    });
+
+    it("should make a DELETE call to remove an index field", async () => {
+      const pkFieldRef: FieldReference = ["field", 1, null];
+      const indexFieldRef: FieldReference = ["field", 2, null];
+
+      const model = createModelWithResultMetadata([
+        createMockField({ field_ref: pkFieldRef, semantic_type: "type/PK" }),
+        createMockField({ should_index: false, field_ref: indexFieldRef }),
+        createMockField(),
+      ]);
+
+      const existingModelIndex = createMockModelIndex({
+        id: 99,
+        value_ref: indexFieldRef,
+      });
+
+      setupModelIndexEndpoints(1, [existingModelIndex]);
+
+      const mockDispatch = jest.fn();
+      const mockGetState = jest.fn(() => ({
+        entities: {
+          modelIndexes: { 99: existingModelIndex },
+          modelIndexes_list: {
+            '{"model_id":1': {
+              list: [99],
+              metadata: {},
+            },
+          },
+        },
+      }));
+      await updateModelIndexes(model)(mockDispatch, mockGetState);
+
+      expect(mockDispatch).toHaveBeenCalled();
+      expect(mockGetState).toHaveBeenCalled();
+
+      const [url, options] = (await fetchMock.lastCall()) as MockCall;
+
+      expect(url).toContain("/api/model-index/99");
+      expect(options?.method).toBe("DELETE");
+    });
+
+    it("should not create a new index if there is already one for the field", async () => {
+      const pkFieldRef: FieldReference = ["field", 1, null];
+      const indexFieldRef: FieldReference = ["field", 2, null];
+
+      const model = createModelWithResultMetadata([
+        createMockField({ field_ref: pkFieldRef, semantic_type: "type/PK" }),
+        createMockField({ should_index: true, field_ref: indexFieldRef }),
+        createMockField(),
+      ]);
+
+      const existingModelIndex = createMockModelIndex({
+        id: 99,
+        value_ref: indexFieldRef,
+      });
+
+      setupModelIndexEndpoints(1, [existingModelIndex]);
+
+      const mockDispatch = jest.fn();
+      const mockGetState = jest.fn(() => ({
+        entities: {
+          modelIndexes: { 99: existingModelIndex },
+          modelIndexes_list: {
+            '{"model_id":1': {
+              list: [99],
+              metadata: {},
+            },
+          },
+        },
+      }));
+      await updateModelIndexes(model)(mockDispatch, mockGetState);
+
+      expect(mockDispatch).toHaveBeenCalled();
+      expect(mockGetState).toHaveBeenCalled();
+
+      const response = await fetchMock.lastCall();
+
+      // no calls to fetch
+      expect(response).toBeUndefined();
+    });
+
+    it("should not delete an index if there is no index for the field", async () => {
+      const pkFieldRef: FieldReference = ["field", 1, null];
+      const indexFieldRef: FieldReference = ["field", 2, null];
+
+      const model = createModelWithResultMetadata([
+        createMockField({ field_ref: pkFieldRef, semantic_type: "type/PK" }),
+        createMockField({ should_index: false, field_ref: indexFieldRef }),
+        createMockField(),
+      ]);
+
+      setupModelIndexEndpoints(model.id(), []);
+
+      const mockDispatch = jest.fn();
+      const mockGetState = jest.fn(() => ({ entities: { modelIndexes: [] } }));
+      await updateModelIndexes(model)(mockDispatch, mockGetState);
+
+      expect(mockDispatch).toHaveBeenCalled();
+      expect(mockGetState).toHaveBeenCalled();
+
+      const response = await fetchMock.lastCall();
+
+      // no calls to fetch
+      expect(response).toBeUndefined();
+    });
+  });
+});

--- a/frontend/src/metabase/entities/model-indexes/actions.unit.spec.ts
+++ b/frontend/src/metabase/entities/model-indexes/actions.unit.spec.ts
@@ -19,8 +19,7 @@ import {
 } from "./actions";
 
 const createMockField = (options?: Partial<FieldWithMaybeIndex>): Field => {
-  // @ts-expect-error we're shoving FieldWithMaybeIndex into Field
-  return createBaseMockField(options);
+  return createBaseMockField(options as Partial<Field>);
 };
 
 const createModelWithResultMetadata = (fields: Field[]) => {

--- a/frontend/src/metabase/entities/model-indexes/index.ts
+++ b/frontend/src/metabase/entities/model-indexes/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./model-indexes";

--- a/frontend/src/metabase/entities/model-indexes/model-indexes.ts
+++ b/frontend/src/metabase/entities/model-indexes/model-indexes.ts
@@ -1,0 +1,46 @@
+/**
+ * A Model index is a separate entity in the metabase backend which is used to index a particular field
+ * in a model in connection with a primary key, so that the model can be queried by the indexed field.
+ * This allows us to use search results to show a particular record in the model.
+ */
+
+import type { IndexedEntity } from "metabase-types/api/modelIndexes";
+import type { State } from "metabase-types/store";
+
+import { createEntity } from "metabase/lib/entities";
+import { ModelIndexApi } from "metabase/services";
+import { ModelIndexSchema } from "metabase/schema";
+
+import * as actions from "./actions";
+import * as utils from "./utils";
+
+const ModelIndexes = createEntity({
+  name: "modelIndexes",
+  nameOne: "modelIndex",
+  path: "/api/model-index",
+  schema: ModelIndexSchema,
+  api: {
+    ...ModelIndexApi,
+  },
+  actions,
+  utils,
+  writableProperties: ["name", "value_ref", "pk_ref", "model_id"],
+  objectSelectors: {
+    getUrl: (entity: IndexedEntity) => `/model/${entity.model_id}/${entity.id}`, // FIXME: move to URLS lib
+    getIcon: () => ({ name: "beaker" }),
+  },
+  // objectActions: {},
+  reducer: (state = {}, { type, payload }: { type: string; payload: any }) => {
+    return state;
+  },
+  selectors: {
+    getIndexesForModel: (state: State, { modelId }: { modelId: number }) => {
+      return Object.values(state.entities.modelIndexes).filter(
+        index => index.model_id === modelId,
+      );
+    },
+  },
+  // objectSelectors: {},
+});
+
+export default ModelIndexes;

--- a/frontend/src/metabase/entities/model-indexes/utils.ts
+++ b/frontend/src/metabase/entities/model-indexes/utils.ts
@@ -1,0 +1,25 @@
+import _ from "underscore";
+import type { Field } from "metabase-types/api";
+import type { ModelIndex } from "metabase-types/api/modelIndexes";
+import {
+  isString,
+  isPK,
+  isInteger,
+  isBoolean,
+} from "metabase-lib/types/utils/isa";
+import type FieldEntity from "metabase-lib/metadata/Field";
+import type Table from "metabase-lib/metadata/Table";
+
+const hasPk = (table?: Table) =>
+  !!table?.fields.some((field: FieldEntity) => isPK(field) && isInteger(field));
+
+export const canIndexField = (field: FieldEntity): boolean => {
+  return !!(isString(field) && !isBoolean(field) && hasPk(field?.table));
+};
+
+export const getPkRef = (fields?: Field[]) => fields?.find(isPK)?.field_ref;
+
+export const fieldHasIndex = (modelIndexes: ModelIndex[], field: Field) =>
+  !!modelIndexes.some((index: any) =>
+    _.isEqual(index.value_ref, field.field_ref),
+  );

--- a/frontend/src/metabase/lib/schema/schema.js
+++ b/frontend/src/metabase/lib/schema/schema.js
@@ -3,6 +3,10 @@ export const entityTypeForModel = model => {
   if (model === "card" || model === "dataset") {
     return "questions";
   }
+  if (model === "indexed-entity") {
+    // handle non-standard plural 🙃
+    return "indexedEntities";
+  }
   return `${model}s`;
 };
 

--- a/frontend/src/metabase/lib/urls/index.ts
+++ b/frontend/src/metabase/lib/urls/index.ts
@@ -5,6 +5,7 @@ export * from "./bookmarks";
 export * from "./browse";
 export * from "./collections";
 export * from "./dashboards";
+export * from "./indexed-entities";
 export * from "./misc";
 export * from "./models";
 export * from "./pulses";

--- a/frontend/src/metabase/lib/urls/indexed-entities.ts
+++ b/frontend/src/metabase/lib/urls/indexed-entities.ts
@@ -1,0 +1,5 @@
+import slugg from "slugg";
+import type { IndexedEntity } from "metabase-types/api";
+
+export const indexedEntity = (entity: IndexedEntity) =>
+  `/model/${entity.model_id}-${slugg(entity.model_name)}/${entity.id}`;

--- a/frontend/src/metabase/nav/components/AppBar/AppBar.tsx
+++ b/frontend/src/metabase/nav/components/AppBar/AppBar.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import useIsSmallScreen from "metabase/hooks/use-is-small-screen";
 import { CollectionId, User } from "metabase-types/api";
+import ErrorBoundary from "metabase/ErrorBoundary";
 import AppBarSmall from "./AppBarSmall";
 import AppBarLarge from "./AppBarLarge";
 import { AppBarRoot } from "./AppBar.styled";
@@ -26,7 +27,13 @@ const AppBar = (props: AppBarProps): JSX.Element => {
 
   return (
     <AppBarRoot data-testid="app-bar">
-      {isSmallScreen ? <AppBarSmall {...props} /> : <AppBarLarge {...props} />}
+      <ErrorBoundary>
+        {isSmallScreen ? (
+          <AppBarSmall {...props} />
+        ) : (
+          <AppBarLarge {...props} />
+        )}
+      </ErrorBoundary>
     </AppBarRoot>
   );
 };

--- a/frontend/src/metabase/query_builder/actions/core/core.js
+++ b/frontend/src/metabase/query_builder/actions/core/core.js
@@ -15,6 +15,8 @@ import { openUrl } from "metabase/redux/app";
 
 import Questions from "metabase/entities/questions";
 import Databases from "metabase/entities/databases";
+import ModelIndexes from "metabase/entities/model-indexes";
+
 import { fetchAlertsForQuestion } from "metabase/alert/alert";
 import {
   cardIsEquivalent,
@@ -224,6 +226,11 @@ export const apiUpdateQuestion = (question, { rerunQuery } = {}) => {
   return async (dispatch, getState) => {
     const originalQuestion = getOriginalQuestion(getState());
     question = question || getQuestion(getState());
+
+    if (question.isDataset()) {
+      await dispatch(ModelIndexes.actions.updateModelIndexes(question));
+      question = ModelIndexes.actions.cleanIndexFlags(question);
+    }
 
     rerunQuery = rerunQuery || getIsResultDirty(getState());
 

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.jsx
@@ -18,12 +18,15 @@ import TagEditorSidebar from "metabase/query_builder/components/template_tags/Ta
 import SnippetSidebar from "metabase/query_builder/components/template_tags/SnippetSidebar";
 import { calcInitialEditorHeight } from "metabase/query_builder/components/NativeQueryEditor/utils";
 
+import { modelIndexes } from "metabase/entities";
+
 import { setDatasetEditorTab } from "metabase/query_builder/actions";
 import {
   getDatasetEditorTab,
   getResultsMetadata,
   isResultsMetadataDirty,
 } from "metabase/query_builder/selectors";
+import { getMetadata } from "metabase/selectors/metadata";
 
 import { getSemanticTypeIcon } from "metabase/lib/schema_metadata";
 import { useToggle } from "metabase/hooks/use-toggle";
@@ -70,6 +73,7 @@ const propTypes = {
   handleResize: PropTypes.func.isRequired,
   runQuestionQuery: PropTypes.func.isRequired,
   onOpenModal: PropTypes.func.isRequired,
+  modelIndexes: PropTypes.array.isRequired,
 
   // Native editor sidebars
   isShowingTemplateTagsEditor: PropTypes.bool.isRequired,
@@ -85,6 +89,7 @@ const TABLE_HEADER_HEIGHT = 45;
 
 function mapStateToProps(state) {
   return {
+    metadata: getMetadata(state),
     datasetEditorTab: getDatasetEditorTab(state),
     isMetadataDirty: isResultsMetadataDirty(state),
     resultsMetadata: getResultsMetadata(state),
@@ -112,6 +117,7 @@ function getSidebar(
     toggleTemplateTagsEditor,
     toggleDataReference,
     toggleSnippetSidebar,
+    modelIndexes,
   } = props;
 
   if (datasetEditorTab === "metadata") {
@@ -132,6 +138,7 @@ function getSidebar(
         isLastField={isLastField}
         handleFirstFieldFocus={focusFirstField}
         onFieldMetadataChange={onFieldMetadataChange}
+        modelIndexes={modelIndexes}
       />
     );
   }
@@ -189,6 +196,7 @@ function DatasetEditor(props) {
     onSave,
     handleResize,
     onOpenModal,
+    modelIndexes = [],
   } = props;
 
   const fields = useMemo(
@@ -229,7 +237,7 @@ function DatasetEditor(props) {
   const focusedField = useMemo(() => {
     const field = fields[focusedFieldIndex];
     if (field) {
-      const fieldMetadata = metadata.field(field.id, field.table_id);
+      const fieldMetadata = metadata?.field?.(field.id, field.table_id);
       return {
         ...fieldMetadata,
         ...field,
@@ -253,7 +261,7 @@ function DatasetEditor(props) {
 
   const inheritMappedFieldProperties = useCallback(
     changes => {
-      const mappedField = metadata.field(changes.id).getPlainObject();
+      const mappedField = metadata.field?.(changes.id)?.getPlainObject();
       const inheritedProperties = _.pick(mappedField, ...FIELDS);
       return mappedField ? merge(inheritedProperties, changes) : changes;
     },
@@ -388,14 +396,17 @@ function DatasetEditor(props) {
     );
   }, [dataset, fields, isModelQueryDirty, isMetadataDirty]);
 
-  const sidebar = getSidebar(props, {
-    datasetEditorTab,
-    isQueryError: result?.error,
-    focusedField,
-    focusedFieldIndex,
-    focusFirstField,
-    onFieldMetadataChange,
-  });
+  const sidebar = getSidebar(
+    { ...props, modelIndexes },
+    {
+      datasetEditorTab,
+      isQueryError: result?.error,
+      focusedField,
+      focusedFieldIndex,
+      focusFirstField,
+      onFieldMetadataChange,
+    },
+  );
 
   return (
     <>
@@ -489,4 +500,10 @@ function DatasetEditor(props) {
 
 DatasetEditor.propTypes = propTypes;
 
-export default connect(mapStateToProps, mapDispatchToProps)(DatasetEditor);
+export default _.compose(
+  modelIndexes.loadList({
+    query: (_state, props) => ({ model_id: props?.question?.id() }),
+    loadingAndErrorWrapper: false,
+  }),
+  connect(mapStateToProps, mapDispatchToProps),
+)(DatasetEditor);

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.jsx
@@ -411,6 +411,7 @@ function DatasetEditor(props) {
   return (
     <>
       <DatasetEditBar
+        data-testid="dataset-edit-bar"
         title={dataset.displayName()}
         center={
           <EditorTabs

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetFieldMetadataSidebar/DatasetFieldMetadataSidebar.jsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetFieldMetadataSidebar/DatasetFieldMetadataSidebar.jsx
@@ -24,6 +24,7 @@ import ColumnSettings, {
   hasColumnSettingsWidgets,
 } from "metabase/visualizations/components/ColumnSettings";
 import { getGlobalSettingsForColumn } from "metabase/visualizations/lib/settings/column";
+import ModelIndexes from "metabase/entities/model-indexes";
 import { isSameField } from "metabase-lib/queries/utils/field-ref";
 import { isFK } from "metabase-lib/types/utils/isa";
 
@@ -45,6 +46,7 @@ const propTypes = {
   isLastField: PropTypes.bool.isRequired,
   handleFirstFieldFocus: PropTypes.func.isRequired,
   onFieldMetadataChange: PropTypes.func.isRequired,
+  modelIndexes: PropTypes.array.isRequired,
 };
 
 function getVisibilityTypeName(visibilityType) {
@@ -75,6 +77,8 @@ function getFormFields({ dataset, field }) {
       name: getVisibilityTypeName(type),
       value: type.id,
     }));
+
+  const canIndex = dataset.isSaved() && ModelIndexes.utils.canIndexField(field);
 
   return formFieldValues =>
     [
@@ -114,6 +118,11 @@ function getFormFields({ dataset, field }) {
         type: "radio",
         options: visibilityTypeOptions,
       },
+      canIndex && {
+        name: "should_index",
+        title: t`Surface individual records in search by matching against this column`,
+        type: "boolean",
+      },
     ].filter(Boolean);
 }
 
@@ -142,6 +151,7 @@ function DatasetFieldMetadataSidebar({
   isLastField,
   handleFirstFieldFocus,
   onFieldMetadataChange,
+  modelIndexes,
 }) {
   const displayNameInputRef = useRef();
   const [shouldAnimateFieldChange, setShouldAnimateFieldChange] =
@@ -167,12 +177,13 @@ function DatasetFieldMetadataSidebar({
       semantic_type: field.semantic_type,
       fk_target_field_id: field.fk_target_field_id || null,
       visibility_type: field.visibility_type || "normal",
+      should_index: ModelIndexes.utils.fieldHasIndex(modelIndexes, field),
     };
     if (dataset.isNative()) {
       values.id = field.id;
     }
     return values;
-  }, [field, dataset]);
+  }, [field, dataset, modelIndexes]);
 
   const form = useMemo(
     () => ({
@@ -290,6 +301,18 @@ function DatasetFieldMetadataSidebar({
     [onFieldMetadataChange],
   );
 
+  const onIndexChange = useCallback(
+    async value => {
+      // even though this isn't a real field metadata property, we want to hook into the
+      // question-saving process, so we'll use the same hook and remove this property before calling
+      // the API
+      onFieldMetadataChange({
+        should_index: value,
+      });
+    },
+    [onFieldMetadataChange],
+  );
+
   return (
     <SidebarContent>
       <AnimatableContent
@@ -365,6 +388,7 @@ function DatasetFieldMetadataSidebar({
                     denylist={HIDDEN_COLUMN_FORMATTING_OPTIONS}
                   />
                 )}
+                <FormField name="should_index" onChange={onIndexChange} />
               </SecondaryFormContainer>
             </Form>
           )}

--- a/frontend/src/metabase/schema.js
+++ b/frontend/src/metabase/schema.js
@@ -9,6 +9,8 @@ import { getUniqueFieldId } from "metabase-lib/metadata/utils/fields";
 export const ActionSchema = new schema.Entity("actions");
 export const UserSchema = new schema.Entity("users");
 export const QuestionSchema = new schema.Entity("questions");
+export const ModelIndexSchema = new schema.Entity("modelIndexes");
+export const IndexedEntitySchema = new schema.Entity("indexedEntities");
 export const BookmarkSchema = new schema.Entity("bookmarks");
 export const DashboardSchema = new schema.Entity("dashboards");
 export const PulseSchema = new schema.Entity("pulses");
@@ -111,6 +113,8 @@ TimelineSchema.define({
 export const ENTITIES_SCHEMA_MAP = {
   actions: ActionSchema,
   questions: QuestionSchema,
+  modelIndexes: ModelIndexSchema,
+  indexedEntity: IndexedEntitySchema,
   bookmarks: BookmarkSchema,
   dashboards: DashboardSchema,
   pulses: PulseSchema,

--- a/frontend/src/metabase/search/components/InfoText.jsx
+++ b/frontend/src/metabase/search/components/InfoText.jsx
@@ -48,6 +48,8 @@ export function InfoText({ result }) {
       return jt`Metric for ${(<TableLink result={result} />)}`;
     case "action":
       return jt`for ${result.model_name}`;
+    case "indexed-entity":
+      return jt`in ${result.model_name}`;
     default:
       return jt`${getTranslatedEntityName(result.model)} in ${formatCollection(
         result,

--- a/frontend/src/metabase/services.js
+++ b/frontend/src/metabase/services.js
@@ -112,6 +112,14 @@ export const CardApi = {
   parameterSearch: GET("/api/card/:cardId/params/:paramId/search/:query"),
 };
 
+export const ModelIndexApi = {
+  list: GET("/api/model-index"),
+  get: GET("/api/model-index/:id"),
+  create: POST("/api/model-index"),
+  update: PUT("/api/model-index/:id"),
+  delete: DELETE("/api/model-index/:id"),
+};
+
 export const DashboardApi = {
   list: GET("/api/dashboard"),
   // creates a new empty dashboard

--- a/frontend/test/__support__/server-mocks/model-indexes.ts
+++ b/frontend/test/__support__/server-mocks/model-indexes.ts
@@ -1,0 +1,19 @@
+import fetchMock from "fetch-mock";
+import type { ModelIndex, CardId } from "metabase-types/api";
+import { createMockModelIndex } from "metabase-types/api/mocks";
+
+export function setupModelIndexEndpoints(
+  modelId: CardId,
+  indexes: ModelIndex[],
+) {
+  fetchMock.get(`path:/api/model-index?model-id=${modelId}`, indexes);
+
+  indexes.forEach(index => {
+    fetchMock.delete(`path:/api/model-index/${index.id}`, 200);
+  });
+
+  fetchMock.post(`path:/api/model-index`, async url => {
+    const lastCall = fetchMock.lastCall(url);
+    return createMockModelIndex(await lastCall?.request?.json());
+  });
+}


### PR DESCRIPTION
Resolves https://github.com/metabase/metabase/issues/29819
Resolves https://github.com/metabase/metabase/issues/30167

### Description

Allows model columns to be indexed and searched globally 🥳 

### How to verify

Allow Indexes on a column by toggling the toggle in the model metadata sidebar

![Screen Shot 2023-04-13 at 12 06 30 PM](https://user-images.githubusercontent.com/30528226/231846314-47e47415-9651-447f-a58d-da9abcf10284.png)

Global search should surface items

![Screen Shot 2023-04-13 at 12 06 03 PM](https://user-images.githubusercontent.com/30528226/231846367-cb6d55d7-c286-4f37-a11e-9c4a8c9b504b.png)

> **Note**
> you may encounter apparently "broken" links when clicking on index items. this is a limitation with our object detail view which I'll be working on more in #30168 

- [x] Unit tests added

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30082)
<!-- Reviewable:end -->
