### PR TITLE
[MLv2] Clean query to remove any parts that fail schema validation

### DIFF
--- a/src/metabase/lib/convert.cljc
+++ b/src/metabase/lib/convert.cljc
@@ -28,7 +28,7 @@
                        :else result))))
       (dissoc almost-stage location-key))))
 
-(defn- clean-last-stage [almost-stage]
+(defn- clean-stage [almost-stage]
   (reduce
     (fn [almost-stage top-level-clause]
       (loop [almost-stage almost-stage
@@ -48,13 +48,13 @@
 
 (defn- clean [almost-query]
   (loop [almost-query almost-query
-         stage-index (dec (count (:stages almost-query)))]
-    (let [last-stage (nth (:stages almost-query) stage-index)
-          new-stage (clean-last-stage last-stage)]
-      (if (= last-stage new-stage)
-        (if (= stage-index 0)
+         stage-index 0]
+    (let [current-stage (nth (:stages almost-query) stage-index)
+          new-stage (clean-stage current-stage)]
+      (if (= current-stage new-stage)
+        (if (= stage-index (dec (count (:stages almost-query))))
           almost-query
-          (recur almost-query (dec stage-index)))
+          (recur almost-query (inc stage-index)))
         (recur (update almost-query :stages assoc stage-index new-stage) stage-index)))))
 
 (defmulti ->pMBQL

--- a/src/metabase/lib/convert.cljc
+++ b/src/metabase/lib/convert.cljc
@@ -7,7 +7,6 @@
    [metabase.lib.options :as lib.options]
    [metabase.lib.schema :as lib.schema]
    [metabase.lib.util :as lib.util]
-   [metabase.shared.util.i18n :as i18n]
    [metabase.util :as u]))
 
 (defn- clean-location [almost-query error-type error-location]

--- a/src/metabase/lib/join.cljc
+++ b/src/metabase/lib/join.cljc
@@ -299,13 +299,13 @@
      (lib.util/update-query-stage query stage-number update :joins (fn [joins]
                                                                      (conj (vec joins) new-join))))))
 
-(mu/defn joins :- ::lib.schema.join/joins
+(mu/defn joins :- [:maybe ::lib.schema.join/joins]
   "Get all joins in a specific `stage` of a `query`. If `stage` is unspecified, returns joins in the final stage of the
   query."
   ([query]
    (joins query -1))
   ([query        :- ::lib.schema/query
-    stage-number :- ::lib.schema.common/int-greater-than-or-equal-to-zero]
+    stage-number :- :int]
    (not-empty (get (lib.util/query-stage query stage-number) :joins))))
 
 (mu/defn implicit-join-name :- ::lib.schema.common/non-blank-string

--- a/src/metabase/lib/metric.cljc
+++ b/src/metabase/lib/metric.cljc
@@ -22,10 +22,11 @@
       definition
       ;; legacy; needs conversion
       (->
-       (lib.convert/legacy-query-from-inner-query nil definition)
-       mbql.normalize/normalize
-       lib.convert/->pMBQL
-       (lib.util/query-stage -1)))))
+        ;; database-id cannot be nil, but gets thrown out
+        (lib.convert/legacy-query-from-inner-query #?(:clj Integer/MAX_VALUE :cljs js/Number.MAX_SAFE_INTEGER) definition)
+        mbql.normalize/normalize
+        lib.convert/->pMBQL
+        (lib.util/query-stage -1)))))
 
 (defmethod lib.metadata.calculation/type-of-method :metadata/metric
   [query stage-number metric-metadata]

--- a/test/metabase/lib/convert_test.cljc
+++ b/test/metabase/lib/convert_test.cljc
@@ -273,7 +273,7 @@
                  :query {:joins [{:source-table 3
                                   ;; Invalid condition makes the join invalid
                                   :condition [:= [:field 2 nil] [:xfield 2 nil]]}]
-                            :source-table 4}}
+                         :source-table 4}}
                  lib.convert/->pMBQL
                  lib/joins)))
     (is (nil? (->

--- a/test/metabase/lib/convert_test.cljc
+++ b/test/metabase/lib/convert_test.cljc
@@ -240,14 +240,14 @@
                {:type :query}))))
     (is (= {:type :query
             :database 1
-            :query nil}
+            :query {}}
             (lib.convert/->legacy-MBQL
               (lib.convert/->pMBQL
                 {:type :query
                  :database 1}))))
     (is (= {:type :query
             :database 1
-            :query nil}
+            :query {}}
            (lib.convert/->legacy-MBQL
              (lib.convert/->pMBQL
                {:type :query

--- a/test/metabase/lib/convert_test.cljc
+++ b/test/metabase/lib/convert_test.cljc
@@ -230,22 +230,29 @@
                 :source-table 4}}))
 
 (deftest ^:parallel clean-test
-  (testing "hopeless queries"
-    (are [query] (thrown-with-msg?
-                   #?(:clj Exception :cljs js/Error)
-                   #"Cannot clean query"
-                   (-> query
-                       lib.convert/->pMBQL))
-      ;; no nothing
-      {:type :query}
-      ;; no query
-      {:type :query
-       :database 1}
-      ;; no source table
-      {:type :query
-       :database 1
-       :query {}}))
-  (testing "cleaning"
+  (testing "irrecoverable queries"
+    ;; Eventually we should get to a place where ->pMBQL throws an exception here,
+    ;; but legacy e2e tests make this impossible right now
+    (is (= {:type :query
+            :query {}}
+           (lib.convert/->legacy-MBQL
+             (lib.convert/->pMBQL
+               {:type :query}))))
+    (is (= {:type :query
+            :database 1
+            :query {}}
+            (lib.convert/->legacy-MBQL
+              (lib.convert/->pMBQL
+                {:type :query
+                 :database 1}))))
+    (is (= {:type :query
+            :database 1
+            :query {}}
+           (lib.convert/->legacy-MBQL
+             (lib.convert/->pMBQL
+               {:type :query
+                :database 1})))))
+  (testing "recoverable queries"
     (is (nil? (->
                 {:database 1
                  :type :query

--- a/test/metabase/lib/convert_test.cljc
+++ b/test/metabase/lib/convert_test.cljc
@@ -229,7 +229,7 @@
                 :limit        1
                 :source-table 4}}))
 
-(deftest clean-test
+(deftest ^:parallel clean-test
   (testing "hopeless queries"
     (are [query] (thrown-with-msg?
                    #?(:clj Exception :cljs js/Error)

--- a/test/metabase/lib/convert_test.cljc
+++ b/test/metabase/lib/convert_test.cljc
@@ -240,14 +240,14 @@
                {:type :query}))))
     (is (= {:type :query
             :database 1
-            :query {}}
+            :query nil}
             (lib.convert/->legacy-MBQL
               (lib.convert/->pMBQL
                 {:type :query
                  :database 1}))))
     (is (= {:type :query
             :database 1
-            :query {}}
+            :query nil}
            (lib.convert/->legacy-MBQL
              (lib.convert/->pMBQL
                {:type :query

--- a/test/metabase/lib/metric_test.cljc
+++ b/test/metabase/lib/metric_test.cljc
@@ -16,7 +16,8 @@
     :fields   [(meta/field-metadata :venues :price)]
     :metrics  [{:id         100
                 :name       "My Metric"
-                :definition {:aggregation [[:sum [:field (meta/id :venues :price) nil]]]
+                :definition {:source-table (meta/id :venues)
+                             :aggregation [[:sum [:field (meta/id :venues :price) nil]]]
                              :filter      [:= [:field (meta/id :venues :price) nil] 4]}}]}))
 
 (deftest ^:parallel metric-display-name-test


### PR DESCRIPTION
Resolves #30083
Discussion: https://metaboat.slack.com/archives/C04DN5VRQM6/p1681405672824099

As part of conversion from legacy -> pMBQL the query will be cleaned so that any invalid (i.e. does not conform to schema) parts of the query are chopped off.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30096)
<!-- Reviewable:end -->
