### PR TITLE
Make column group functions return plain arrays in JS

### DIFF
--- a/src/metabase/lib/column_group.cljc
+++ b/src/metabase/lib/column_group.cljc
@@ -85,7 +85,7 @@
 
     {::group-type :group-type/main}))
 
-(mu/defn ^:export group-columns :- [:sequential ColumnGroup]
+(mu/defn group-columns :- [:sequential ColumnGroup]
   "Given a group of columns returned by a function like [[metabase.lib.order-by/orderable-columns]], group the columns
   by Table or equivalent (e.g. Saved Question) so that they're in an appropriate shape for showing in the Query
   Builder. e.g a sequence of columns like
@@ -114,7 +114,7 @@
                  ::columns columns))
         (group-by column-group-info column-metadatas)))
 
-(mu/defn ^:export columns-group-columns :- [:sequential lib.metadata/ColumnMetadata]
+(mu/defn columns-group-columns :- [:sequential lib.metadata/ColumnMetadata]
   "Get the columns associated with a column group"
   [column-group :- ColumnGroup]
   (::columns column-group))

--- a/src/metabase/lib/js.cljs
+++ b/src/metabase/lib/js.cljs
@@ -5,12 +5,7 @@
    [metabase.lib.convert :as convert]
    [metabase.lib.core :as lib.core]
    [metabase.lib.js.metadata :as js.metadata]
-   [metabase.lib.metadata.calculation :as lib.metadata.calculation]
    [metabase.lib.metadata.protocols :as lib.metadata.protocols]
-   [metabase.lib.normalize :as lib.normalize]
-   [metabase.lib.order-by :as lib.order-by]
-   [metabase.lib.query :as lib.query]
-   [metabase.lib.remove-replace :as lib.remove-replace]
    [metabase.mbql.js :as mbql.js]
    [metabase.mbql.normalize :as mbql.normalize]
    [metabase.util :as u]
@@ -54,7 +49,7 @@
 (defn ^:export suggestedName
   "Return a nice description of a query."
   [query]
-  (lib.metadata.calculation/suggested-name query))
+  (lib.core/suggested-name query))
 
 (defn- pMBQL [query-map]
   (as-> query-map <>
@@ -77,7 +72,7 @@
   [database-id metadata query-map]
   (let [query-map (pMBQL query-map)]
     (log/debugf "query map: %s" (pr-str query-map))
-    (lib.query/query (metadataProvider database-id metadata) query-map)))
+    (lib.core/query (metadataProvider database-id metadata) query-map)))
 
 (defn- fix-namespaced-values
   "This converts namespaced keywords to strings as `\"foo/bar\"`.
@@ -104,7 +99,7 @@
   ([a-query]
    (orderable-columns a-query -1))
   ([a-query stage-number]
-   (to-array (lib.order-by/orderable-columns a-query stage-number))))
+   (to-array (lib.core/orderable-columns a-query stage-number))))
 
 (defn ^:export display-info
   "Given an opaque Cljs object, return a plain JS object with info you'd need to implement UI for it.
@@ -112,7 +107,7 @@
   ([a-query x]
    (display-info a-query -1 x))
   ([a-query stage-number x]
-   (-> (lib.metadata.calculation/display-info a-query stage-number x)
+   (-> (lib.core/display-info a-query stage-number x)
        (clj->js :keyword-fn u/qualified-name))))
 
 (defn ^:export order-by-clause
@@ -120,7 +115,7 @@
   ([a-query stage-number x]
    (order-by-clause a-query stage-number x nil))
   ([a-query stage-number x direction]
-   (lib.order-by/order-by-clause a-query stage-number (lib.normalize/normalize (js->clj x :keywordize-keys true)) direction)))
+   (lib.core/order-by-clause a-query stage-number (lib.core/normalize (js->clj x :keywordize-keys true)) direction)))
 
 (defn ^:export order-by
   "Add an `order-by` clause to `a-query`. Returns updated query."
@@ -131,7 +126,7 @@
    (order-by a-query -1 x direction))
 
   ([a-query stage-number x direction]
-   (lib.order-by/order-by a-query stage-number x (keyword direction))))
+   (lib.core/order-by a-query stage-number x (keyword direction))))
 
 (defn ^:export order-bys
   "Get the order-by clauses (as an array of opaque objects) in `a-query` at a given `stage-number`.
@@ -139,31 +134,31 @@
   ([a-query]
    (order-bys a-query -1))
   ([a-query stage-number]
-   (to-array (lib.order-by/order-bys a-query stage-number))))
+   (to-array (lib.core/order-bys a-query stage-number))))
 
 (defn ^:export change-direction
   "Flip the direction of `current-order-by` in `a-query`."
   [a-query current-order-by]
-  (lib.order-by/change-direction a-query current-order-by))
+  (lib.core/change-direction a-query current-order-by))
 
 (defn ^:export remove-clause
   "Removes the `target-clause` in the filter of the `query`."
   ([a-query clause]
    (remove-clause a-query -1 clause))
   ([a-query stage-number clause]
-   (lib.remove-replace/remove-clause
+   (lib.core/remove-clause
      a-query stage-number
-     (lib.normalize/normalize (js->clj clause :keywordize-keys true)))))
+     (lib.core/normalize (js->clj clause :keywordize-keys true)))))
 
 (defn ^:export replace-clause
   "Replaces the `target-clause` with `new-clause` in the `query` stage."
   ([a-query target-clause new-clause]
    (replace-clause a-query -1 target-clause new-clause))
   ([a-query stage-number target-clause new-clause]
-   (lib.remove-replace/replace-clause
+   (lib.core/replace-clause
      a-query stage-number
-     (lib.normalize/normalize (js->clj target-clause :keywordize-keys true))
-     (lib.normalize/normalize (js->clj new-clause :keywordize-keys true)))))
+     (lib.core/normalize (js->clj target-clause :keywordize-keys true))
+     (lib.core/normalize (js->clj new-clause :keywordize-keys true)))))
 
 (defn- prep-query-for-equals [a-query field-ids]
   (-> a-query
@@ -193,3 +188,34 @@
    (let [n1 (prep-query-for-equals query1 field-ids)
          n2 (prep-query-for-equals query2 field-ids)]
      (= n1 n2))))
+
+(defn ^:export group-columns
+  "Given a group of columns returned by a function like [[metabase.lib.js/orderable-columns]], group the columns
+  by Table or equivalent (e.g. Saved Question) so that they're in an appropriate shape for showing in the Query
+  Builder. e.g a sequence of columns like
+
+    [venues.id
+     venues.name
+     venues.category-id
+     ;; implicitly joinable
+     categories.id
+     categories.name]
+
+  would get grouped into groups like
+
+    [{::columns [venues.id
+                 venues.name
+                 venues.category-id]}
+     {::columns [categories.id
+                 categories.name]}]
+
+  Groups have the type `:metadata/column-group` and can be passed directly
+  to [[metabase.lib.js/display-info]].
+  Use [[metabase.lib.js/columns-group-columns]] to extract the columns from a group."
+  [column-metadatas]
+  (to-array (lib.core/group-columns column-metadatas)))
+
+(defn ^:export columns-group-columns
+  "Get the columns associated with a column group"
+  [column-group]
+  (to-array (lib.core/columns-group-columns column-group)))


### PR DESCRIPTION
Fixes #30090.

I've also cleaned up the import in `metabase.lib.js` so that the `metabase.lib.core` version of the functions is used when it exists.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30097)
<!-- Reviewable:end -->
