### PR TITLE
Use regctl to push multi-arch image

### DIFF
--- a/.github/workflows/uberjar.yml
+++ b/.github/workflows/uberjar.yml
@@ -255,9 +255,11 @@ jobs:
         uses: regclient/actions/regctl-installer@main
         with:
           release: 'v0.4.7'
+      - name: Switch regctl to point to localhost:5000 via http
+        run: regctl registry set --tls disabled localhost:5000
       - name: Retag and push ubuntu-based images if master (ee)
         if: ${{ matrix.edition == 'ee' }}
-        run: regctl registry set --tls disabled localhost:5000 && regctl image copy localhost:5000/metabase-dev:${{ steps.extract_branch.outputs.branch }}-ee-ubuntu metabase/metabase-enterprise-head:latest-ubuntu
+        run: regctl image copy localhost:5000/metabase-dev:${{ steps.extract_branch.outputs.branch }}-ee-ubuntu metabase/metabase-enterprise-head:latest-ubuntu
       - name: Retag and push ubuntu-based images if master (oss)
         if: ${{ matrix.edition == 'oss' }}
-        run: regctl registry set --tls disabled localhost:5000 && regctl image copy localhost:5000/metabase-dev:${{ steps.extract_branch.outputs.branch }}-oss-ubuntu metabase/metabase-head:latest-ubuntu
+        run: regctl image copy localhost:5000/metabase-dev:${{ steps.extract_branch.outputs.branch }}-oss-ubuntu metabase/metabase-head:latest-ubuntu

--- a/.github/workflows/uberjar.yml
+++ b/.github/workflows/uberjar.yml
@@ -257,7 +257,7 @@ jobs:
           release: 'v0.4.7'
       - name: Retag and push ubuntu-based images if master (ee)
         if: ${{ matrix.edition == 'ee' }}
-        run: regctl image copy localhost:5000/metabase-dev:${{ steps.extract_branch.outputs.branch }}-ee-ubuntu metabase/metabase-enterprise-head:latest-ubuntu
+        run: regctl registry set --tls disabled localhost:5000 && regctl image copy localhost:5000/metabase-dev:${{ steps.extract_branch.outputs.branch }}-ee-ubuntu metabase/metabase-enterprise-head:latest-ubuntu
       - name: Retag and push ubuntu-based images if master (oss)
         if: ${{ matrix.edition == 'oss' }}
-        run: regctl image copy localhost:5000/metabase-dev:${{ steps.extract_branch.outputs.branch }}-oss-ubuntu metabase/metabase-head:latest-ubuntu
+        run: regctl registry set --tls disabled localhost:5000 && regctl image copy localhost:5000/metabase-dev:${{ steps.extract_branch.outputs.branch }}-oss-ubuntu metabase/metabase-head:latest-ubuntu

--- a/.github/workflows/uberjar.yml
+++ b/.github/workflows/uberjar.yml
@@ -251,10 +251,13 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       # Push experimental ubuntu image only for versions based on a master
+      - name: Install regctl
+        uses: regclient/actions/regctl-installer@main
+        with:
+          release: 'v0.4.7'
       - name: Retag and push ubuntu-based images if master (ee)
         if: ${{ matrix.edition == 'ee' }}
-        run: docker tag localhost:5000/metabase-dev:${{ steps.extract_branch.outputs.branch }}-ee-ubuntu metabase/metabase-enterprise-head:latest-ubuntu && docker push metabase/metabase-enterprise-head:latest-ubuntu
-
+        run: regctl image copy localhost:5000/metabase-dev:${{ steps.extract_branch.outputs.branch }}-ee-ubuntu metabase/metabase-enterprise-head:latest-ubuntu
       - name: Retag and push ubuntu-based images if master (oss)
         if: ${{ matrix.edition == 'oss' }}
-        run: docker tag localhost:5000/metabase-dev:${{ steps.extract_branch.outputs.branch }}-oss-ubuntu metabase/metabase-head:latest-ubuntu && docker push metabase/metabase-head:latest-ubuntu
+        run: regctl image copy localhost:5000/metabase-dev:${{ steps.extract_branch.outputs.branch }}-oss-ubuntu metabase/metabase-head:latest-ubuntu


### PR DESCRIPTION
Now the push of the Ubuntu image do it only for the amd64 arch (which is fine, but not exactly what we want), because the docker pull & docker push scheme only download the image for the platform of the runner.
This change replace that scheme to the way based on the [regctl](https://github.com/regclient/regclient) tool, which can sync between registries and do it for all available architectures for an image.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30101)
<!-- Reviewable:end -->
