### PR TITLE
Fix row limit not set properly for notebook preview queries

### DIFF
--- a/e2e/test/scenarios/question/notebook.cy.spec.js
+++ b/e2e/test/scenarios/question/notebook.cy.spec.js
@@ -552,16 +552,34 @@ describe("scenarios > question > notebook", () => {
     });
   });
 
-  it("should properly render previews (metabase#28726)", () => {
+  it("should properly render previews (metabase#28726), (metabase#29959)", () => {
     openOrdersTable({ mode: "notebook" });
     cy.findByTestId("step-data-0-0").within(() => {
       cy.icon("play").click();
+      assertTableRowCount(10);
       cy.findByTextEnsureVisible("Subtotal");
       cy.findByTextEnsureVisible("Tax");
       cy.findByTextEnsureVisible("Total");
+      cy.icon("close").click();
+    });
+
+    cy.button("Row limit").click();
+    cy.findByTestId("step-limit-0-0").within(() => {
+      cy.findByPlaceholderText("Enter a limit").type("5");
+
+      cy.icon("play").click();
+      assertTableRowCount(5);
+
+      cy.findByDisplayValue("5").type("{selectall}50");
+      cy.button("Refresh").click();
+      assertTableRowCount(10);
     });
   });
 });
+
+function assertTableRowCount(expectedCount) {
+  cy.get(".Table-ID:not(.Table-FK)").should("have.length", expectedCount);
+}
 
 function addSimpleCustomColumn(name) {
   enterCustomColumnDetails({ formula: "C" });

--- a/frontend/src/metabase/query_builder/components/notebook/NotebookStepPreview.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/NotebookStepPreview.jsx
@@ -38,8 +38,9 @@ class NotebookStepPreview extends React.Component {
 
   getPreviewQuestion(step) {
     const query = step.previewQuery;
+    const hasSuitableLimit = query.hasLimit() && query.limit() < 10;
     return Question.create()
-      .setQuery(query.limit() < 10 ? query : query.updateLimit(10))
+      .setQuery(hasSuitableLimit ? query : query.updateLimit(10))
       .setDisplay("table")
       .setSettings({ "table.pivot": false });
   }


### PR DESCRIPTION
Fixes #29959

Fixes a regression caused by #29618 when row limit management was ported to metabase-lib v2 (MLv2). When a query doesn't have a limit, MLv2's `currentLimit` returns `null`, and the following check stopped working as before:

```ts
query.limit() < 10 ? query : query.updateLimit(10)
```

### How to verify

1. New > Question > Sample Database > Orders
2. Click the "preview" icon next to the data picker section
3. Ensure you can only see 10 rows
4. Click "Row limit" and enter a number below 10
5. Ensure you see the number of columns you specified
6. Set the limit to a number above 10
7. Ensure you can only see 10 rows 

### Demo

**Before**

https://user-images.githubusercontent.com/17258145/232035108-e8bc6e26-f204-48a0-9a48-14500bd5c447.mp4

**After**

https://user-images.githubusercontent.com/17258145/232035138-553f600e-c5fc-4705-91af-cab546601828.mp4


### Checklist

- [x] Tests have been added/updated to cover changes in this PR

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30105)
<!-- Reviewable:end -->
