### PR TITLE
[Manual backport] Fix models being broken after changing column order

### DIFF
--- a/e2e/test/scenarios/models/reproductions/29951-model-editor-results-metadata.cy.spec.js
+++ b/e2e/test/scenarios/models/reproductions/29951-model-editor-results-metadata.cy.spec.js
@@ -1,0 +1,61 @@
+import {
+  getNotebookStep,
+  openQuestionActions,
+  restore,
+} from "e2e/support/helpers";
+import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
+
+const { ORDERS_ID, ORDERS } = SAMPLE_DATABASE;
+
+const questionDetails = {
+  name: "29951",
+  query: {
+    "source-table": ORDERS_ID,
+    expressions: {
+      CC1: ["+", ["field", ORDERS.TOTAL], 1],
+      CC2: ["+", ["field", ORDERS.TOTAL], 1],
+    },
+  },
+  dataset: true,
+};
+
+describe("issue 29951", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+    cy.intercept("POST", "/api/dataset").as("dataset");
+    cy.intercept("PUT", "/api/card/*").as("updateCard");
+  });
+
+  it("should allow to run the model query after changing custom columns (metabase#29951)", () => {
+    cy.createQuestion(questionDetails, { visitQuestion: true });
+    cy.wait("@dataset");
+
+    openQuestionActions();
+    cy.findByText("Edit query definition").click();
+    removeExpression("CC2");
+    cy.findByRole("button", { name: "Save changes" }).click();
+    cy.wait("@updateCard");
+    cy.wait("@dataset");
+
+    dragColumn(0, 100);
+    cy.findAllByRole("button", { name: "Get Answer" }).first().click();
+    cy.wait("@dataset");
+    cy.findByText("Showing first 2,000 rows").should("be.visible");
+  });
+});
+
+const removeExpression = name => {
+  getNotebookStep("expression")
+    .findByText(name)
+    .findByLabelText("close icon")
+    .click();
+};
+
+const dragColumn = (index, distance) => {
+  cy.get(".react-draggable")
+    .eq(index)
+    .trigger("mousedown", 0, 0, { force: true })
+    .trigger("mousemove", distance, 0, { force: true })
+    .trigger("mouseup", distance, 0, { force: true });
+};

--- a/e2e/test/scenarios/models/reproductions/29951-model-editor-results-metadata.cy.spec.js
+++ b/e2e/test/scenarios/models/reproductions/29951-model-editor-results-metadata.cy.spec.js
@@ -39,7 +39,7 @@ describe("issue 29951", () => {
     cy.wait("@dataset");
 
     dragColumn(0, 100);
-    cy.findAllByRole("button", { name: "Get Answer" }).first().click();
+    cy.findAllByRole("button", { name: "play icon" }).first().click();
     cy.wait("@dataset");
     cy.findByText("Showing first 2,000 rows").should("be.visible");
   });

--- a/frontend/src/metabase/query_builder/actions/core/core.js
+++ b/frontend/src/metabase/query_builder/actions/core/core.js
@@ -224,7 +224,7 @@ export const apiUpdateQuestion = (question, { rerunQuery } = {}) => {
     const originalQuestion = getOriginalQuestion(getState());
     question = question || getQuestion(getState());
 
-    rerunQuery = rerunQuery || getIsResultDirty(getState());
+    rerunQuery = rerunQuery ?? getIsResultDirty(getState());
 
     // Needed for persisting visualization columns for pulses/alerts, see #6749
     const series = getTransformedSeries(getState());
@@ -263,9 +263,10 @@ export const apiUpdateQuestion = (question, { rerunQuery } = {}) => {
 
     dispatch.action(API_UPDATE_QUESTION, updatedQuestion.card());
 
+    const metadataOptions = { reload: question.isDataset() };
+    await dispatch(loadMetadataForCard(question.card(), metadataOptions));
+
     if (rerunQuery) {
-      const metadataOptions = { reload: question.isDataset() };
-      await dispatch(loadMetadataForCard(question.card(), metadataOptions));
       dispatch(runQuestionQuery());
     }
   };

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.jsx
@@ -182,6 +182,7 @@ function DatasetEditor(props) {
     height,
     isDirty: isModelQueryDirty,
     setQueryBuilderMode,
+    runQuestionQuery,
     setDatasetEditorTab,
     setFieldMetadata,
     onCancelDatasetChanges,
@@ -306,13 +307,14 @@ function DatasetEditor(props) {
     if (canBeDataset && isBrandNewDataset) {
       onOpenModal(MODAL_TYPES.SAVE);
     } else if (canBeDataset) {
-      await onSave(dataset.card());
-      setQueryBuilderMode("view");
+      await onSave(dataset.card(), { rerunQuery: false });
+      await setQueryBuilderMode("view");
+      runQuestionQuery();
     } else {
       onOpenModal(MODAL_TYPES.CAN_NOT_CREATE_MODEL);
       throw new Error(t`Variables in models aren't supported yet`);
     }
-  }, [dataset, onSave, setQueryBuilderMode, onOpenModal]);
+  }, [dataset, onSave, setQueryBuilderMode, runQuestionQuery, onOpenModal]);
 
   const handleColumnSelect = useCallback(
     column => {

--- a/frontend/src/metabase/query_builder/containers/QueryBuilder.jsx
+++ b/frontend/src/metabase/query_builder/containers/QueryBuilder.jsx
@@ -282,7 +282,7 @@ function QueryBuilder(props) {
   );
 
   const handleSave = useCallback(
-    async (card, { rerunQuery = false } = {}) => {
+    async (card, { rerunQuery } = {}) => {
       const questionWithUpdatedCard = question.setCard(card);
       await apiUpdateQuestion(questionWithUpdatedCard, { rerunQuery });
       if (!rerunQuery) {


### PR DESCRIPTION
Backports https://github.com/metabase/metabase/pull/30073

The conflict was that `onSave` method takes a `Card` in `0.46` and `Question` in `master`. No related to changes in this PR, but it was the same line where `onSave` was called, that's why there was a conflict.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30118)
<!-- Reviewable:end -->
