### PR TITLE
[MLv2] New `fk_reference_name` for implicitly joinable column group

### DIFF
--- a/src/metabase/lib/util.cljc
+++ b/src/metabase/lib/util.cljc
@@ -407,3 +407,16 @@
          ;; truncate alias to 60 characters (actually 51 characters plus a hash).
          :unique-alias-fn (fn [original suffix]
                             (truncate-alias (str original \_ suffix))))))
+
+(def ^:private strip-id-regex
+  #?(:cljs (js/RegExp. " id$" "i")
+     ;; `(?i)` is JVM-specific magic to turn on the `i` case-insensitive flag.
+     :clj  #"(?i) id$"))
+
+(mu/defn strip-id :- :string
+  "Given a display name string like \"Product ID\", this will drop the trailing \"ID\" and trim whitespace.
+  Used to turn a FK field's name into a pseudo table name when implicitly joining."
+  [display-name :- :string]
+  (-> display-name
+      (str/replace strip-id-regex "")
+      str/trim))

--- a/test/metabase/lib/column_group_test.cljc
+++ b/test/metabase/lib/column_group_test.cljc
@@ -35,8 +35,9 @@
                 :display_name           "Venues"}
                {:is_from_join           false
                 :is_implicitly_joinable true
-                :name                   "CATEGORIES"
-                :display_name           "Categories"}]
+                :name                   "CATEGORY_ID"
+                :display_name           "Category ID"
+                :fk_reference_name      "Category"}]
               (for [group groups]
                 (lib/display-info query group)))))
     (testing `lib/columns-group-columns
@@ -72,7 +73,7 @@
               ::lib.column-group/columns    [{:display_name "User ID", :lib/source :source/card}
                                              {:display_name "Count", :lib/source :source/card}]}
              {::lib.column-group/group-type :group-type/join.implicit
-              :table-id                     (meta/id :users)
+              :fk-field-id                  (meta/id :checkins :user-id)
               ::lib.column-group/columns    [{:display_name "ID", :lib/source :source/implicitly-joinable}
                                              {:display_name "Name", :lib/source :source/implicitly-joinable}
                                              {:display_name "Last Login", :lib/source :source/implicitly-joinable}]}]
@@ -82,8 +83,9 @@
                 :display_name           "My Card"
                 :is_from_join           false
                 :is_implicitly_joinable false}
-               {:name                   "USERS"
-                :display_name           "Users"
+               {:name                   "USER_ID"
+                :display_name           "User ID"
+                :fk_reference_name      "User"
                 :is_from_join           false
                 :is_implicitly_joinable true}]
               (for [group groups]
@@ -147,8 +149,9 @@
                 :display_name           "Venues"}
                {:is_from_join           false
                 :is_implicitly_joinable true
-                :name                   "CATEGORIES"
-                :display_name           "Categories"}]
+                :name                   "CATEGORY_ID"
+                :display_name           "Category ID"
+                :fk_reference_name      "Category"}]
               (for [group groups]
                 (lib/display-info query group)))))
     (testing `lib/columns-group-columns
@@ -165,7 +168,7 @@
                                              {:display_name "Count", :lib/source :source/card}
                                              {:display_name "expr", :lib/source :source/expressions}]}
              {::lib.column-group/group-type :group-type/join.implicit
-              :table-id                     (meta/id :users)
+              :fk-field-id                  (meta/id :checkins :user-id)
               ::lib.column-group/columns    [{:display_name "ID", :lib/source :source/implicitly-joinable}
                                              {:display_name "Name", :lib/source :source/implicitly-joinable}
                                              {:display_name "Last Login", :lib/source :source/implicitly-joinable}] }]
@@ -175,8 +178,9 @@
                 :display_name           "My Card"
                 :is_from_join           false
                 :is_implicitly_joinable false}
-               {:name                   "USERS"
-                :display_name           "Users"
+               {:name                   "USER_ID"
+                :display_name           "User ID"
+                :fk_reference_name      "User"
                 :is_from_join           false
                 :is_implicitly_joinable true}]
               (for [group groups]

--- a/test/metabase/lib/util_test.cljc
+++ b/test/metabase/lib/util_test.cljc
@@ -307,3 +307,11 @@
              (unique-name-fn "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")))
       (is (= "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXY_1380b38f"
              (unique-name-fn "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"))))))
+
+(deftest ^:parallel strip-id-test
+  (are [exp in] (= exp (lib.util/strip-id in))
+    "foo"            "foo"
+    "Fancy Name"     "Fancy Name"
+    "Customer"       "Customer ID"
+    "Customer"       "Customer id"
+    "some id number" "some id number"))


### PR DESCRIPTION
When the FE is rendering implicitly joinable columns, it doesn't use the
target table name. Instead it uses the name of the FK field on the main
table. This is useful because there might be multiple FKs to the same
table with different meanings (eg. both `supplier_id` and `customer_id`
point to `PEOPLE`). In this example the `:fk_reference_name`s for the
column groups would be `Supplier` and `Customer`.

Fixes #30109

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30120)
<!-- Reviewable:end -->
