### PR TITLE
Add session when updating password as a user

### DIFF
--- a/frontend/src/metabase/services.js
+++ b/frontend/src/metabase/services.js
@@ -410,7 +410,7 @@ export const UserApi = {
   current: GET("/api/user/current"),
   // get:                         GET("/api/user/:userId"),
   update: PUT("/api/user/:id"),
-  update_password: PUT("/api/user/:id/password"),
+  update_password: POST("/api/user/:id/password"),
   update_qbnewb: PUT("/api/user/:id/modal/qbnewb"),
   delete: DELETE("/api/user/:userId"),
   reactivate: PUT("/api/user/:userId/reactivate"),

--- a/frontend/src/metabase/services.js
+++ b/frontend/src/metabase/services.js
@@ -410,7 +410,7 @@ export const UserApi = {
   current: GET("/api/user/current"),
   // get:                         GET("/api/user/:userId"),
   update: PUT("/api/user/:id"),
-  update_password: POST("/api/user/:id/password"),
+  update_password: PUT("/api/user/:id/password"),
   update_qbnewb: PUT("/api/user/:id/modal/qbnewb"),
   delete: DELETE("/api/user/:userId"),
   reactivate: PUT("/api/user/:userId/reactivate"),

--- a/src/metabase/api/user.clj
+++ b/src/metabase/api/user.clj
@@ -22,15 +22,12 @@
    [metabase.server.request.util :as request.u]
    [metabase.util :as u]
    [metabase.util.i18n :refer [tru]]
-   [metabase.util.log :as log]
    [metabase.util.password :as u.password]
    [metabase.util.schema :as su]
    [schema.core :as s]
    [toucan.db :as db]
    [toucan.hydrate :refer [hydrate]]
-   [toucan2.core :as t2]
-   [ring.util.response :as response]
-   [metabase.lib.schema.id :as id]))
+   [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
 

--- a/src/metabase/api/user.clj
+++ b/src/metabase/api/user.clj
@@ -389,7 +389,7 @@
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
 #_{:clj-kondo/ignore [:deprecated-var]}
-(api/defendpoint-schema POST "/:id/password"
+(api/defendpoint-schema PUT "/:id/password"
   "Update a user's password."
   [id :as {{:keys [password old_password]} :body, :as request}]
   {password su/ValidPassword}

--- a/test/metabase/api/user_test.clj
+++ b/test/metabase/api/user_test.clj
@@ -969,6 +969,20 @@
                                    {:password     "whateverUP12!!"
                                     :old_password "mismatched"}))))))
 
+(deftest reset-password-session-test
+  (testing "PUT /api/user/:id/password"
+    (testing "Test that we return a session if we are changing our own password"
+      (mt/with-temp User [user {:password "def", :is_superuser false}]
+        (let [creds           {:username (:email user), :password "def"}]
+          (is (schema= {:session_id (s/pred mt/is-uuid-string? "session")
+                        :success    (s/eq true)}
+                       (mt/client creds :put 200 (format "user/%d/password" (:id user)) {:password     "abc123!!DEF"
+                                                                                         :old_password "def"}))))))
+
+    (testing "Test that we don't return a session if we are changing our someone else's password as a superuser"
+      (mt/with-temp User [user {:password "def", :is_superuser false}]
+        (is (nil? (mt/user-http-request :crowberto :put 204 (format "user/%d/password" (:id user)) {:password     "abc123!!DEF"
+                                                                                                    :old_password "def"})))))))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                             Deleting (Deactivating) a User -- DELETE /api/user/:id                             |

--- a/test/metabase/api/user_test.clj
+++ b/test/metabase/api/user_test.clj
@@ -973,7 +973,7 @@
   (testing "PUT /api/user/:id/password"
     (testing "Test that we return a session if we are changing our own password"
       (mt/with-temp User [user {:password "def", :is_superuser false}]
-        (let [creds           {:username (:email user), :password "def"}]
+        (let [creds {:username (:email user), :password "def"}]
           (is (schema= {:session_id (s/pred mt/is-uuid-string? "session")
                         :success    (s/eq true)}
                        (mt/client creds :put 200 (format "user/%d/password" (:id user)) {:password     "abc123!!DEF"


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/5063

### Description

Calling the `/api/user/:id/password` as yourself should return a new session cookie.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Test resetting password as yourself
2. Test resetting password as superuser

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30125)
<!-- Reviewable:end -->
