### PR TITLE
Sets imported serialized DB initial_sync_status=complete

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/e2e_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/e2e_test.clj
@@ -336,8 +336,8 @@
                               clean-entity)))))
 
               (testing "for Databases"
-                (doseq [{:keys [name] :as coll} (get @entities "Database")]
-                  (is (= (clean-entity coll)
+                (doseq [{:keys [name] :as db} (get @entities "Database")]
+                  (is (= (assoc (clean-entity db) :initial_sync_status "complete")
                          (->> (t2/select-one 'Database :name name)
                               (serdes/extract-one "Database" {})
                               clean-entity)))))

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
@@ -163,6 +163,7 @@
             (reset! db2d (t2/select-one Database :name (:name @db2s)))
 
             (is (= 3 (t2/count Database)))
+            (is (every? #(= "complete" (:initial_sync_status %)) (t2/select Database)))
             (is (= #{"db1" "db2" "test-data"}
                    (t2/select-fn-set :name Database)))
             (is (= #{(:id @db1d) (:id @db2d)}

--- a/src/metabase/models/database.clj
+++ b/src/metabase/models/database.clj
@@ -205,8 +205,12 @@
                            :existing-engine existing-engine
                            :new-engine      new-engine})))))))
 
-(defn- pre-insert [database]
-  (handle-secrets-changes (merge {:details {} :initial_sync_status "incomplete"} database)))
+(defn- pre-insert [{:keys [details initial_sync_status], :as database}]
+   (-> database
+       (cond->
+        (not details)             (assoc :details {})
+        (not initial_sync_status) (assoc :initial_sync_status "incomplete"))
+       handle-secrets-changes))
 
 (defmethod mi/perms-objects-set Database
   [{db-id :id} read-or-write]

--- a/src/metabase/models/database.clj
+++ b/src/metabase/models/database.clj
@@ -205,11 +205,8 @@
                            :existing-engine existing-engine
                            :new-engine      new-engine})))))))
 
-(defn- pre-insert [{:keys [details], :as database}]
-  (-> (cond-> database
-        (not details) (assoc :details {}))
-      handle-secrets-changes
-      (assoc :initial_sync_status "incomplete")))
+(defn- pre-insert [database]
+  (handle-secrets-changes (merge {:details {} :initial_sync_status "incomplete"} database)))
 
 (defmethod mi/perms-objects-set Database
   [{db-id :id} read-or-write]
@@ -323,7 +320,8 @@
   [database]
   (-> database
       serdes/load-xform-basics
-      (update :creator_id serdes/*import-user*)))
+      (update :creator_id serdes/*import-user*)
+      (assoc :initial_sync_status "complete")))
 
 (defmethod serdes/load-insert! "Database" [_ ingested]
   (let [m (get-method serdes/load-insert! :default)]


### PR DESCRIPTION
When serialized DBs are imported, we should set the `initial_sync_status` to `'complete'` since the DB is essentially already synced. This prevents several issues in the frontend when dealing with imported DBs.

Resolves #29687

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30143)
<!-- Reviewable:end -->
