### PR TITLE
[MLv2] Make expression and aggregation options survive conversion

### DIFF
--- a/src/metabase/lib/convert.cljc
+++ b/src/metabase/lib/convert.cljc
@@ -120,9 +120,10 @@
                                [x y])]
     (lib.options/ensure-uuid [:field options id-or-name])))
 
-(defmethod ->pMBQL :value
-  [[_tag value opts]]
-  (lib.options/ensure-uuid [:value opts value]))
+(doseq [tag [:value :aggregation :expression]]
+  (defmethod ->pMBQL tag
+    [[tag value opts]]
+    (lib.options/ensure-uuid [tag opts value])))
 
 (defmethod ->pMBQL :aggregation-options
   [[_tag aggregation options]]

--- a/test/metabase/lib/convert_test.cljc
+++ b/test/metabase/lib/convert_test.cljc
@@ -166,6 +166,10 @@
 
     [:value nil {:base_type :type/Number}]
 
+    [:aggregation 0 {:effective-type "type/Integer"}]
+
+    [:expression "expr" {:effective-type "type/Integer"}]
+
     [:case [[[:< [:field 1 nil] 10] [:value nil {:base_type :type/Number}]] [[:> [:field 2 nil] 2] 10]]]
 
     {:database 67


### PR DESCRIPTION
Bug fix see [discussion here](https://metaboat.slack.com/archives/C04DN5VRQM6/p1681732360827569)
```
[:aggregation 0 {:effective-type "type/Integer"}]
=> 
[:aggregation {:lib/uuid "b290b73a-6b35-451c-8cd4-506b307c8db4"} 0 {:effective-type "type/Integer"}]
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30147)
<!-- Reviewable:end -->
