### PR TITLE
Removes :result_metadata from non-model card serialization

### DIFF
--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -434,8 +434,8 @@
 (defmethod serdes/extract-query "Card" [_ opts]
   (serdes/extract-query-collections Card opts))
 
-(defn- export-result-metadata [metadata]
-  (when metadata
+(defn- export-result-metadata [card metadata]
+  (when (and (:dataset card) metadata)
     (for [m metadata]
       (-> m
           (m/update-existing :table_id  serdes/*export-table-fk*)
@@ -474,7 +474,7 @@
         (update :parameters             serdes/export-parameters)
         (update :parameter_mappings     serdes/export-parameter-mappings)
         (update :visualization_settings serdes/export-visualization-settings)
-        (update :result_metadata        export-result-metadata))
+        (update :result_metadata        (partial export-result-metadata card)))
     (catch Exception e
       (throw (ex-info "Failed to export Card" {:card card} e)))))
 


### PR DESCRIPTION
This updates extract-one for Cards to only include `:result_metadata` when `:dataset` is `true`.

Resolves #30150

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30151)
<!-- Reviewable:end -->
