### PR TITLE
Don't include `:effective-type` in ag/expression refs for now

### DIFF
--- a/src/metabase/lib/aggregation.cljc
+++ b/src/metabase/lib/aggregation.cljc
@@ -16,8 +16,7 @@
 (mu/defn column-metadata->aggregation-ref :- :mbql.clause/aggregation
   "Given `:metadata/field` column metadata for an aggregation, construct an `:aggregation` reference."
   [metadata :- lib.metadata/ColumnMetadata]
-  (let [options {:lib/uuid       (str (random-uuid))
-                 :effective-type ((some-fn :effective_type :base_type) metadata)}
+  (let [options {:lib/uuid (str (random-uuid))}
         index   (::aggregation-index metadata)]
     (assert (integer? index) "Metadata for an aggregation reference should include ::aggregation-index")
     [:aggregation options index]))

--- a/src/metabase/lib/expression.cljc
+++ b/src/metabase/lib/expression.cljc
@@ -21,9 +21,8 @@
 (mu/defn column-metadata->expression-ref :- :mbql.clause/expression
   "Given `:metadata/field` column metadata for an expression, construct an `:expression` reference."
   [metadata :- lib.metadata/ColumnMetadata]
-  (let [options {:lib/uuid       (str (random-uuid))
-                 :base-type      (:base_type metadata)
-                 :effective-type ((some-fn :effective_type :base_type) metadata)}]
+  (let [options {:lib/uuid  (str (random-uuid))
+                 :base-type (:base_type metadata)}]
     [:expression options (:name metadata)]))
 
 (mu/defn resolve-expression :- ::lib.schema.expression/expression

--- a/test/metabase/lib/order_by_test.cljc
+++ b/test/metabase/lib/order_by_test.cljc
@@ -643,9 +643,9 @@
             query' (lib/order-by query ag-ref)]
         (is (=? {:stages
                  [{:aggregation [[:avg {} [:+ {} [:field {} (meta/id :venues :price)] 1]]]
-                   :order-by    [[:asc {} [:aggregation {:effective-type :type/Float} 0]]]}]}
+                   :order-by    [[:asc {} [:aggregation {} 0]]]}]}
                 query'))
-        (is (=? [[:asc {} [:aggregation {:effective-type :type/Float} 0]]]
+        (is (=? [[:asc {} [:aggregation {} 0]]]
                (lib/order-bys query')))
         (is (=? [{:display_name "Average of Price + 1"
                   :direction    :asc}]

--- a/test/metabase/lib/stage_test.cljc
+++ b/test/metabase/lib/stage_test.cljc
@@ -172,7 +172,7 @@
                   (lib.metadata.calculation/metadata query')))
           (testing "Should be able to convert the metadata back into a reference"
             (let [[id-plus-1] (lib.metadata.calculation/metadata query')]
-              (is (=? [:expression {:base-type :type/Integer, :effective-type :type/Integer} "ID + 1"]
+              (is (=? [:expression {:base-type :type/Integer} "ID + 1"]
                       (lib/ref id-plus-1))))))))))
 
 (deftest ^:parallel query-with-source-card-include-implicit-columns-test


### PR DESCRIPTION
Including `:effective-type` in `:aggregation` and `:expression` references is currently causing problems in pMBQL -> legacy conversion and blocking merge of the FE order bys stuff, since it's not really important let's just remove it for now.

We're currently including `:effective-type` in `:aggregation` and `:expression` references more as a courtesy than anything else, we don't **need** this information since it can be recalculated. It does help with schema type checking, since the schema stuff happens outside of the context of a metadata provider and thus cannot resolve Field references, so having this info can help us do stricter type checking sometimes. But this is more of a nice-to-have than a requirement. Hopefully an additional layer of type-checking with Field-reference-resolution is something we can implement at some point. 

We can consider adding this stuff back in at some point after we get the FE green (see #29707), or maybe just leave it out for good -- since `:effective-type` can be calculated it can also change if an underlying Field changes or the coercion is changed; thus encoding it in the query could leave it subject to becoming out of date

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30156)
<!-- Reviewable:end -->
