### PR TITLE
bump timeout of waiting for a request to be resolved in percy specs

### DIFF
--- a/e2e/test/visual/models/editor.cy.spec.js
+++ b/e2e/test/visual/models/editor.cy.spec.js
@@ -18,7 +18,7 @@ describe("visual tests > models > editor", () => {
         query: GUI_QUERY,
       }).then(({ body: { id: MODEL_ID } }) => {
         cy.visit(`/model/${MODEL_ID}/query`);
-        cy.wait("@cardQuery");
+        cy.wait("@cardQuery", { timeout: 10000 });
         cy.findByText(/Doing science/).should("not.exist");
         cy.wait(100); // waits for the colums widths calculation
         cy.createPercySnapshot(


### PR DESCRIPTION
[Slack thread](https://metaboat.slack.com/archives/C5XHN8GLW/p1681751747218989)

### Description

CI agents are slow enough so that the default 5 seconds timeout in `editor.cy.spec.js -> renders query editor correctly` is too short.

### How to verify

CI must be green

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30164)
<!-- Reviewable:end -->
