### PR TITLE
[TEMP] Disable the failing percy spec

### DIFF
--- a/e2e/test/visual/models/editor.cy.spec.js
+++ b/e2e/test/visual/models/editor.cy.spec.js
@@ -3,7 +3,8 @@ import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 
 const { ORDERS, ORDERS_ID, PRODUCTS, PRODUCTS_ID } = SAMPLE_DATABASE;
 
-describe("visual tests > models > editor", () => {
+// Temporarily skip to prevent failures on master
+describe.skip("visual tests > models > editor", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();


### PR DESCRIPTION
Master has been broken due to the percy failures since https://github.com/metabase/metabase/pull/30096.
This PR will just temporarily skip the breaking spec to unblock everyone. I'll try to debug and fix those failures in meantime.

![image](https://user-images.githubusercontent.com/31325167/232716330-94333774-9084-4877-a92f-52026f5c513e.png)


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30175)
<!-- Reviewable:end -->
