### PR TITLE
Increase the request timeout for Percy model editor spec

### DIFF
--- a/e2e/test/visual/models/editor.cy.spec.js
+++ b/e2e/test/visual/models/editor.cy.spec.js
@@ -3,8 +3,11 @@ import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 
 const { ORDERS, ORDERS_ID, PRODUCTS, PRODUCTS_ID } = SAMPLE_DATABASE;
 
-// Temporarily skip to prevent failures on master
-describe.skip("visual tests > models > editor", () => {
+// The card query is failry complex one and it takes a long time to complete
+// on slow machines, like the ones used in CI.
+// We've seen timeouts with the Cypress default `requestTimeout` of 5000ms
+// for the `cardQuery` route. Hence, why we need to increase it to 30000ms.
+describe("visual tests > models > editor", { requestTimeout: 30000 }, () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();

--- a/e2e/test/visual/models/editor.cy.spec.js
+++ b/e2e/test/visual/models/editor.cy.spec.js
@@ -3,10 +3,10 @@ import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 
 const { ORDERS, ORDERS_ID, PRODUCTS, PRODUCTS_ID } = SAMPLE_DATABASE;
 
-// The card query is failry complex one and it takes a long time to complete
+// The card query is fairly complex one and it takes a long time to complete
 // on slow machines, like the ones used in CI.
-// We've seen timeouts with the Cypress default `requestTimeout` of 5000ms
-// for the `cardQuery` route. Hence, why we need to increase it to 30000ms.
+// We've seen timeouts with the Cypress default `requestTimeout` of 5,000ms
+// for the `cardQuery` route. Hence, why we need to increase it to 30,000ms.
 describe("visual tests > models > editor", { requestTimeout: 30000 }, () => {
   beforeEach(() => {
     restore();


### PR DESCRIPTION
Following the https://github.com/metabase/metabase/pull/30175, this PR now increases the request timeout setting for this particular spec.

Our approach to visual regression testing is to use more complex setups and more complex queries. With the general slowdown of GitHub's default hosted runners, this can lead to failures like this one:
![image](https://user-images.githubusercontent.com/31325167/232729009-d7707007-3521-48fe-b586-27644d04cea6.png)

I was able to reproduce that failure locally by using the 4x CPU slowdown in dev tools.
Initially I increased the timeout to 10000ms and it seemed to work ok. But then I used 6x CPU slowdown and saw failures even with the timeout of 15000ms. In the end decided to bump it to 30000ms.

The interesting part that needs further investigation is that all these failures started happening (more frequently at least) after https://github.com/metabase/metabase/pull/30096 has been merged to `master`. @snoe this might point to some performance degradation in the `/api/card/:id/query` endpoint. Please take a look.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30176)
<!-- Reviewable:end -->
