### PR TITLE
Fix how notebook editor manages stage index for MLv2 + MLv1

### DIFF
--- a/frontend/src/metabase/query_builder/components/notebook/NotebookStep/NotebookStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/NotebookStep/NotebookStep.tsx
@@ -30,11 +30,6 @@ function hasLargeButton(action: NotebookStepAction) {
   return !STEP_UI[action.type].compact;
 }
 
-function getTestId(step: INotebookStep) {
-  const { type, stageIndex, itemIndex } = step;
-  return `step-${type}-${stageIndex || 0}-${itemIndex || 0}`;
-}
-
 interface NotebookStepProps {
   step: INotebookStep;
   sourceQuestion?: Question;
@@ -116,7 +111,7 @@ function NotebookStep({
     <ExpandingContent isInitiallyOpen={!isLastOpened} isOpen>
       <StepRoot
         className="hover-parent hover--visibility"
-        data-testid={getTestId(step)}
+        data-testid={step.testID}
       >
         <StepHeader color={color}>
           {title}

--- a/frontend/src/metabase/query_builder/components/notebook/lib/steps.ts
+++ b/frontend/src/metabase/query_builder/components/notebook/lib/steps.ts
@@ -196,6 +196,12 @@ function getStageSteps(
     );
   };
 
+  const getTestId = (step: NotebookStepDef, itemIndex: number | null) => {
+    const isValidItemIndex = itemIndex != null && itemIndex > 0;
+    const finalItemIndex = isValidItemIndex ? itemIndex : 0;
+    return `step-${step.type}-${_stageIndex}-${finalItemIndex}`;
+  };
+
   function getStep(STEP: NotebookStepDef, itemIndex: number | null = null) {
     const id = getId(STEP, itemIndex);
     const stageIndex = getMLv2StageIndex(_stageIndex, STEP.type, isLastStage);
@@ -214,6 +220,7 @@ function getStageSteps(
           STEP.active(stageQuery, itemIndex, topLevelQuery, stageIndex) ||
           openSteps[id]
         ),
+      testID: getTestId(STEP, itemIndex),
       revert: STEP.revert
         ? (query: StructuredQuery) =>
             STEP.revert

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep.jsx
@@ -55,6 +55,7 @@ const stepShape = {
   visible: PropTypes.bool.isRequired,
   stageIndex: PropTypes.number.isRequired,
   itemIndex: PropTypes.number,
+  testID: PropTypes.string.isRequired,
   update: PropTypes.func.isRequired,
   revert: PropTypes.func.isRequired,
   clean: PropTypes.func.isRequired,

--- a/frontend/src/metabase/query_builder/components/notebook/steps/LimitStep/LimitStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/LimitStep/LimitStep.tsx
@@ -13,13 +13,15 @@ function LimitStep({
   color,
   updateQuery,
 }: NotebookStepUiComponentProps) {
-  const limit = Lib.currentLimit(topLevelQuery, step.stageIndex);
+  const { stageIndex } = step;
+
+  const limit = Lib.currentLimit(topLevelQuery, stageIndex);
   const value = typeof limit === "number" ? limit : "";
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const nextLimit = parseInt(e.target.value, 0);
     if (nextLimit >= 1) {
-      updateQuery(Lib.limit(topLevelQuery, step.stageIndex, nextLimit));
+      updateQuery(Lib.limit(topLevelQuery, stageIndex, nextLimit));
     }
   };
 

--- a/frontend/src/metabase/query_builder/components/notebook/test-utils.ts
+++ b/frontend/src/metabase/query_builder/components/notebook/test-utils.ts
@@ -8,14 +8,19 @@ export const DEFAULT_QUESTION = getSavedStructuredQuestion();
 export const DEFAULT_LEGACY_QUERY = DEFAULT_QUESTION.query() as StructuredQuery;
 export const DEFAULT_QUERY = DEFAULT_QUESTION._getMLv2Query();
 
-export function createMockNotebookStep(
-  opts: Partial<NotebookStep> = {},
-): NotebookStep {
+export function createMockNotebookStep({
+  id = "test-step",
+  type = "data",
+  stageIndex = 0,
+  itemIndex = 0,
+  ...opts
+}: Partial<NotebookStep> = {}): NotebookStep {
   return {
-    id: "test-step",
-    type: "data",
-    stageIndex: 0,
-    itemIndex: 0,
+    id,
+    type,
+    stageIndex,
+    itemIndex,
+    testID: `step-${type}-${stageIndex}-${itemIndex}`,
     topLevelQuery: DEFAULT_QUERY,
     query: DEFAULT_LEGACY_QUERY,
     valid: true,

--- a/frontend/src/metabase/query_builder/components/notebook/types.ts
+++ b/frontend/src/metabase/query_builder/components/notebook/types.ts
@@ -31,6 +31,7 @@ export interface NotebookStep {
   valid: boolean;
   active: boolean;
   visible: boolean;
+  testID: string;
   revert: NotebookStepFn<StructuredQuery | null> | null;
   clean: NotebookStepFn<StructuredQuery>;
   update: (datasetQuery: DatasetQuery) => StructuredQuery;


### PR DESCRIPTION
Epic #28034, pulled out from #29842.

Fixes how the notebook editor assigns stage indexes to step components (join / filter / summarize sections). Right now, the editor creates stage steps upfront, i.e. it's possible to have a sort step for stage 2 even though stage 2 doesn't exist yet. MLv1 (metabase-lib v1) is fine with it, but MLv2 is more strict (throws when trying to reference a stage that doesn't exist). So for the last stage index, we should prefer using `-1`, which instructs MLv2 to use the last stage. Also, moves notebook step test ID generation to `lib/steps`, so stage index management is consolidated in that single place.

### How to verify

🟢 CI should be green 🟢

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30185)
<!-- Reviewable:end -->
