### PR TITLE
Revert "[MLv2] Drop `:effective-type` when converting to legacy MBQL"

### DIFF
--- a/src/metabase/lib/convert.cljc
+++ b/src/metabase/lib/convert.cljc
@@ -28,15 +28,15 @@
                        :else result))))
       (dissoc almost-stage location-key))))
 
-(def ^:private stage-keys
-  #{:aggregation :breakout :expressions :fields :filters :order-by :joins})
+(def ^:private stage-keys-to-clean
+  #{:expressions :joins :filters :order-by :aggregation :fields :breakout})
 
 (defn- clean-stage [almost-stage]
   (loop [almost-stage almost-stage
          removals []]
     (if-let [[error-type error-location] (->> (mc/explain ::lib.schema/stage.mbql almost-stage)
                                               :errors
-                                              (filter (comp stage-keys first :in))
+                                              (filter (comp stage-keys-to-clean first :in))
                                               (map (juxt :type :in))
                                               first)]
       (let [new-stage (clean-location almost-stage error-type error-location)]
@@ -75,6 +75,9 @@
 (defmethod ->pMBQL :mbql/query
   [query]
   query)
+
+(def ^:private stage-keys
+  [:aggregation :breakout :expressions :fields :filters :order-by :joins])
 
 (defmethod ->pMBQL :mbql.stage/mbql
   [stage]
@@ -142,15 +145,14 @@
   {:arglists '([x])}
   lib.dispatch/dispatch-value)
 
-(defn- drop-option? [x]
-  (or (and (qualified-keyword? x)
-           (= (namespace x) "lib"))
-      (#{:effective-type} x)))
+(defn- lib-key? [x]
+  (and (qualified-keyword? x)
+       (= (namespace x) "lib")))
 
 (defn- disqualify [x]
   (->> x
        keys
-       (remove drop-option?)
+       (remove lib-key?)
        (select-keys x)))
 
 (defn- aggregation->legacy-MBQL [[tag options & args]]

--- a/test/metabase/lib/convert_test.cljc
+++ b/test/metabase/lib/convert_test.cljc
@@ -193,14 +193,6 @@
              :source-table 224}
      :type :query}
 
-    {:database 1,
-     :type :query,
-     :query
-     {:source-table 2,
-      :aggregation [[:count]],
-      :breakout [[:field 14 {:temporal-unit :month}]],
-      :order-by [[:asc [:aggregation 0]]]}}
-
     {:database 23001
      :type     :query
      :query    {:source-table 224


### PR DESCRIPTION
Reverts metabase/metabase#30155

It's causing the shared CLJS tests to fail - concurrent edits? Tests not running properly? To be investigated shortly; let's get master green first.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30187)
<!-- Reviewable:end -->
