### PR TITLE
[MLv2] Change how `TemplateTag.widget-type` works for field filters

### DIFF
--- a/frontend/src/metabase-lib/parameters/utils/template-tag-options.ts
+++ b/frontend/src/metabase-lib/parameters/utils/template-tag-options.ts
@@ -33,15 +33,20 @@ export function getParameterOptionsForField(field: Field) {
     });
 }
 
+function fallbackParameterWidgetType(tag: TemplateTag): "none" | undefined {
+  return tag.type === "dimension" ? "none" : undefined;
+}
+
 export function getDefaultParameterWidgetType(tag: TemplateTag, field: Field) {
   const options = getParameterOptionsForField(field);
   if (options.length === 0) {
-    return undefined;
+    return fallbackParameterWidgetType(tag);
   }
 
   const widgetType = tag["widget-type"];
   if (
     widgetType != null &&
+    widgetType !== "none" &&
     options.some(option => option.type === widgetType)
   ) {
     return widgetType;

--- a/frontend/src/metabase-lib/parameters/utils/template-tags.ts
+++ b/frontend/src/metabase-lib/parameters/utils/template-tags.ts
@@ -58,7 +58,9 @@ export function getTemplateTagParameters(
   return tags
     .filter(
       tag =>
-        tag.type != null && (tag["widget-type"] || tag.type !== "dimension"),
+        tag.type != null &&
+        ((tag["widget-type"] && tag["widget-type"] !== "none") ||
+          tag.type !== "dimension"),
     )
     .map(tag => getTemplateTagParameter(tag, parametersById[tag.id]));
 }

--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.jsx
@@ -64,7 +64,7 @@ export class TagEditorParam extends Component {
         type: type,
         default: undefined,
         dimension: undefined,
-        "widget-type": undefined,
+        "widget-type": type === "dimension" ? "none" : undefined,
       });
     }
   }
@@ -230,11 +230,7 @@ export class TagEditorParam extends Component {
             <Select
               className="block"
               value={this.getFilterWidgetTypeValue(tag, widgetOptions)}
-              onChange={e =>
-                this.setWidgetType(
-                  e.target.value === "none" ? undefined : e.target.value,
-                )
-              }
+              onChange={e => this.setWidgetType(e.target.value)}
               isInitiallyOpen={!tag["widget-type"] && hasWidgetOptions}
               placeholder={t`Select…`}
             >
@@ -304,7 +300,7 @@ export class TagEditorParam extends Component {
 
         {((tag.type !== "dimension" && tag.required) ||
           tag.type === "dimension" ||
-          tag["widget-type"]) && (
+          (tag["widget-type"] && tag["widget-type"] !== "none")) && (
           <InputContainer lessBottomPadding>
             <ContainerLabel>{t`Default filter widget value`}</ContainerLabel>
             <DefaultParameterValueWidget

--- a/shared/src/metabase/mbql/schema.cljc
+++ b/shared/src/metabase/mbql/schema.cljc
@@ -1136,7 +1136,7 @@
     ;; whether or not a value for this parameter is required in order to run the query
     (s/optional-key :required) s/Bool}))
 
-(declare ParameterType)
+(declare ParameterType WidgetType)
 
 ;; Example:
 ;;
@@ -1154,7 +1154,7 @@
     :dimension   field
     ;; which type of widget the frontend should show for this Field Filter; this also affects which parameter types
     ;; are allowed to be specified for it.
-    :widget-type (s/recursive #'ParameterType)}))
+    :widget-type (s/recursive #'WidgetType)}))
 
 (def raw-value-template-tag-types
   "Set of valid values of `:type` for raw value template tags."
@@ -1532,6 +1532,10 @@
 (def ParameterType
   "Schema for valid values of `:type` for a [[Parameter]]."
   (apply s/enum (keys parameter-types)))
+
+(def WidgetType
+  "Schema for valid values of `:widget-type` for a [[TemplateTag:FieldFilter]]."
+  (apply s/enum (cons :none (keys parameter-types))))
 
 ;; the next few clauses are used for parameter `:target`... this maps the parameter to an actual template tag in a
 ;; native query or Field for MBQL queries.

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -184,7 +184,8 @@
   ;; NOTE: this should mirror `getTemplateTagParameters` in frontend/src/metabase/parameters/utils/cards.js
   (for [[_ {tag-type :type, widget-type :widget-type, :as tag}] (get-in card [:dataset_query :native :template-tags])
         :when                         (and tag-type
-                                           (or widget-type (not= tag-type :dimension)))]
+                                           (or (and widget-type (not= widget-type :none))
+                                               (not= tag-type :dimension)))]
     {:id      (:id tag)
      :type    (or widget-type (cond (= tag-type :date)   :date/single
                                     (= tag-type :string) :string/=

--- a/src/metabase/query_processor/card.clj
+++ b/src/metabase/query_processor/card.clj
@@ -108,7 +108,8 @@
              ;; specified by `:widget-type`. Non-Field-filter parameters just have `:type`. So prefer
              ;; `:widget-type` if available but fall back to `:type` if not.
              (cond
-               (= tag-type :dimension)
+               (and (= tag-type :dimension)
+                    (not= widget-type :none))
                [param-name widget-type]
 
                (contains? mbql.s/raw-value-template-tag-types tag-type)
@@ -135,7 +136,7 @@
 
   Background: some more-specific parameter types aren't allowed for certain types of parameters.
   See [[metabase.mbql.schema/parameter-types]] for details."
-  [parameter-name widget-type :- mbql.s/ParameterType parameter-value-type :- mbql.s/ParameterType]
+  [parameter-name widget-type :- mbql.s/WidgetType parameter-value-type :- mbql.s/ParameterType]
   (when-not (allowed-parameter-type-for-template-tag-widget-type? parameter-value-type widget-type)
     (let [allowed-types (allowed-parameter-types-for-template-tag-widget-type widget-type)]
       (throw (ex-info (tru "Invalid parameter type {0} for parameter {1}. Parameter type must be one of: {2}"

--- a/src/metabase/query_processor/dashboard.clj
+++ b/src/metabase/query_processor/dashboard.clj
@@ -65,7 +65,8 @@
       (when (:type request-param)
         (qp.card/check-allowed-parameter-value-type
          param-id
-         (or (when (= (:type matching-param) :dimension)
+         (or (when (and (= (:type matching-param) :dimension)
+                        (not= (:widget-type matching-param) :none))
                (:widget-type matching-param))
              (:type matching-param))
          (:type request-param)))


### PR DESCRIPTION
The current state is a collection of hacks to preserve some legacy
behavior (eg. normalization sets a blank `widget-type` to `"category"`)
and it doesn't work properly right now.

An example of a currently-broken case:
- `SELECT * FROM Orders WHERE {{tag}}`
- Set it to a Field Filter and select People > LONGITUDE
  - Or some other field for which type we don't have a widget.
- It shows "None" as the widget type, and the widget isn't shown at the
  top.
- Save the question and reopen it.
- Now the widget is visible (and a bit broken) as a `"category"` type.

This is because on reading from the appdb it gets normalized.

This PR uses `"none"` properly for cases where there are no widget
options for the field type (eg. longitude), and updates all the usage
sites to properly handle `"none"` rather than missing/undefined.

Existing saved questions with a blank `widget-type` will continue to
"work" as they currently do.

Fixes #30193.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30191)
<!-- Reviewable:end -->
