### PR TITLE
Wait for db delete request to resolve before closing modal

### DIFF
--- a/frontend/src/metabase/admin/databases/components/DeleteDatabaseModel/DeleteDatabaseModal.tsx
+++ b/frontend/src/metabase/admin/databases/components/DeleteDatabaseModel/DeleteDatabaseModal.tsx
@@ -67,8 +67,7 @@ const DeleteDatabaseModal = ({
     e.preventDefault();
 
     try {
-      onDelete(database);
-      // immediately call on close because database deletion should be non blocking
+      await onDelete(database);
       onClose();
     } catch (error) {
       setError(error);

--- a/frontend/src/metabase/admin/databases/database.js
+++ b/frontend/src/metabase/admin/databases/database.js
@@ -225,8 +225,8 @@ export const deleteDatabase = function (databaseId, isDetailView = true) {
   return async function (dispatch, getState) {
     try {
       dispatch({ type: DELETE_DATABASE_STARTED, payload: databaseId });
-      dispatch(push("/admin/databases/"));
       await dispatch(Databases.actions.delete({ id: databaseId }));
+      dispatch(push("/admin/databases/"));
       MetabaseAnalytics.trackStructEvent(
         "Databases",
         "Delete",


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/30152

### Description

In some cases, our tests for database deletion were hitting a race condition where we would re-fetch our database list before the deletion was complete. This adds a simple `await` to make the DELETE request blocking to avoid this race condition.

![Screen Shot 2023-04-18 at 11 10 55 AM](https://user-images.githubusercontent.com/30528226/232856071-68d61ce6-18d0-4f9b-b3b2-a12367bc1cdc.png)

### How to verify

I was not able to reproduce this through manual testing, but the race condition did manifest in my local cypress environment. After the change, the test passes!

![Screen Shot 2023-04-18 at 11 22 26 AM](https://user-images.githubusercontent.com/30528226/232856051-2f0f8127-b731-47fc-a757-ed804c757233.png)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30194)
<!-- Reviewable:end -->
