### PR TITLE
Clj kondo fix `defclause` analysis

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -449,8 +449,6 @@
     toucan.db                                                       db
     toucan.models                                                   models}}
 
-  :metabase/disallow-invoking-model         {:level :warning}
-  :metabase/disallow-class-or-type-on-model {:level :warning}}
 
  :lint-as
  {clojure.core.logic/defne                                                             clj-kondo.lint-as/def-catch-all
@@ -477,7 +475,6 @@
   metabase.driver.sql-jdbc.connection/with-connection-spec-for-testing-connection      clojure.core/let
   metabase.driver.sql-jdbc.execute.diagnostic/capturing-diagnostic-info                clojure.core/fn
   metabase.integrations.ldap/with-ldap-connection                                      clojure.core/fn
-  metabase.mbql.schema.macros/defclause                                                clj-kondo.lint-as/def-catch-all
   metabase.models.collection-test/with-collection-in-location                          clojure.core/let
   metabase.models.json-migration/def-json-migration                                    clj-kondo.lint-as/def-catch-all
   metabase.models.setting.multi-setting/define-multi-setting                           clojure.core/def
@@ -549,6 +546,7 @@
    metabase.async.streaming-response-test/with-start-execution-chan                                                          hooks.common/with-one-binding
    metabase.db.schema-migrations-test.impl/test-migrations                                                                   hooks.metabase.db.schema-migrations-test.impl/test-migrations
    metabase.dashboard-subscription-test/with-link-card-fixture-for-dashboard                                                 hooks.common/let-second
+   metabase.mbql.schema.macros/defclause                                                                                     hooks.metabase.mbql.schemas.macros/defclause
    metabase.models.collection-test/with-collection-hierarchy                                                                 hooks.common/let-one-with-optional-value
    metabase.models.collection-test/with-personal-and-impersonal-collections                                                  hooks.common/with-two-bindings
    metabase.models.dashboard-test/with-dash-in-collection                                                                    hooks.common/with-three-bindings

--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -447,8 +447,7 @@
     ring.adapter.jetty9.servlet                                     servlet
     saml20-clj.core                                                 saml
     toucan.db                                                       db
-    toucan.models                                                   models}}
-
+    toucan.models                                                   models}}}
 
  :lint-as
  {clojure.core.logic/defne                                                             clj-kondo.lint-as/def-catch-all

--- a/.clj-kondo/hooks/metabase/mbql/schemas/macros.clj
+++ b/.clj-kondo/hooks/metabase/mbql/schemas/macros.clj
@@ -1,32 +1,46 @@
 (ns hooks.metabase.mbql.schemas.macros
   (:require [clj-kondo.hooks-api :as hooks]))
 
+(defn- unwrap-defclause-clause-name
+  "The `clause-name-form` can be either a plain symbol, or a vector like `[var-name mbql-clause-name]`. For the vector
+  form, we are only interested in the `var-name`. For a plain symbol, the two names are the same. Return a token node."
+  [clause-name-form]
+  (-> (if (hooks/vector-node? clause-name-form)
+        (first (:children clause-name-form))
+        clause-name-form)
+      (with-meta (meta clause-name-form))))
+
+(defn- collect-defclause-body-schemas
+  "Collect the argument schemas in the body of a `defclause` form into a vector node.
+
+  The body is a sequence of <argument-name> <argument-schema> pairs. We can ignore the argument names.
+
+  <argument-schema> can optionally be wrapped be `(optional ...)` or `(rest ...)`... we can ignore these."
+  [arg-specs]
+  (hooks/vector-node
+   (for [[_arg-name arg-schema] (partition-all 2 arg-specs)
+         :let                   [arg-schema (if (and (hooks/list-node? arg-schema)
+                                                     ('#{optional rest} (hooks/sexpr (first (:children arg-schema)))))
+                                              (-> (second (:children arg-schema))
+                                                  (with-meta (meta arg-schema)))
+                                              arg-schema)]]
+     arg-schema)))
+
 (defn defclause
   "e.g.
 
     (defclause [ag:var var] field-or-expression FieldOrExpressionDef)
     =>
-    (def ag:var [FieldOrExpressionDef])
-
-  1. The `clause-name` can be either a plain symbol, or a vector like `[var-name mbql-clause-name]`. For the vector
-     form, we are only interested in the `var-name`. For a plain symbol, the two names are the same.
-
-  2. The body is a sequence of <argument-name> <argument-schema> pairs. We can ignore the argument names."
+    (def ag:var [FieldOrExpressionDef])"
   [{:keys [node]}]
-  (let [[_defclause clause-name & arg-specs] (:children node)
-        clause-name                          (-> (if (hooks/vector-node? clause-name)
-                                                   (first (:children clause-name))
-                                                   clause-name)
-                                                 (with-meta (meta clause-name)))
-        args                                 (mapv second (partition-all 2 arg-specs))
-        node'                                 (-> (hooks/list-node
-                                                   (list
-                                                    (hooks/token-node 'def)
-                                                    clause-name
-                                                    (hooks/string-node "Docstring.")
-                                                    (hooks/vector-node args)))
-                                                  (with-meta (meta node)))]
-    {:node node'}))
+  (let [[_defclause clause-name-form & arg-specs] (:children node)]
+    {:node (-> (hooks/list-node
+                (list
+                 (hooks/token-node 'def)
+                 (unwrap-defclause-clause-name clause-name-form)
+                 (hooks/string-node "Docstring.")
+                 (collect-defclause-body-schemas arg-specs)))
+               (with-meta (meta node)))}))
 
 (comment
   (defn- defclause* [form]
@@ -42,7 +56,13 @@
   (defn- x []
     (defclause* '(defclause [ag:var var]
                    field-or-expression FieldOrExpressionDef)))
+  ;; =>
+  (def ag:var "Docstring." [FieldOrExpressionDef])
 
   (defn- y []
     (defclause* '(defclause var
-                   field-or-expression FieldOrExpressionDef))))
+                   x (some-list-schema)
+                   y (optional FieldOrExpressionDef)
+                   z (rest (some-other-schema)))))
+  ;; =>
+  (def var "Docstring." [(some-list-schema) FieldOrExpressionDef (some-other-schema)]))

--- a/.clj-kondo/hooks/metabase/mbql/schemas/macros.clj
+++ b/.clj-kondo/hooks/metabase/mbql/schemas/macros.clj
@@ -1,0 +1,48 @@
+(ns hooks.metabase.mbql.schemas.macros
+  (:require [clj-kondo.hooks-api :as hooks]))
+
+(defn defclause
+  "e.g.
+
+    (defclause [ag:var var] field-or-expression FieldOrExpressionDef)
+    =>
+    (def ag:var [FieldOrExpressionDef])
+
+  1. The `clause-name` can be either a plain symbol, or a vector like `[var-name mbql-clause-name]`. For the vector
+     form, we are only interested in the `var-name`. For a plain symbol, the two names are the same.
+
+  2. The body is a sequence of <argument-name> <argument-schema> pairs. We can ignore the argument names."
+  [{:keys [node]}]
+  (let [[_defclause clause-name & arg-specs] (:children node)
+        clause-name                          (-> (if (hooks/vector-node? clause-name)
+                                                   (first (:children clause-name))
+                                                   clause-name)
+                                                 (with-meta (meta clause-name)))
+        args                                 (mapv second (partition-all 2 arg-specs))
+        node'                                 (-> (hooks/list-node
+                                                   (list
+                                                    (hooks/token-node 'def)
+                                                    clause-name
+                                                    (hooks/string-node "Docstring.")
+                                                    (hooks/vector-node args)))
+                                                  (with-meta (meta node)))]
+    {:node node'}))
+
+(comment
+  (defn- defclause* [form]
+    (hooks/sexpr
+     (:node
+      (defclause
+        {:node
+         (hooks/parse-string
+          (with-out-str
+            (clojure.pprint/pprint
+             form)))}))))
+
+  (defn- x []
+    (defclause* '(defclause [ag:var var]
+                   field-or-expression FieldOrExpressionDef)))
+
+  (defn- y []
+    (defclause* '(defclause var
+                   field-or-expression FieldOrExpressionDef))))

--- a/shared/src/metabase/mbql/schema.cljc
+++ b/shared/src/metabase/mbql/schema.cljc
@@ -979,7 +979,6 @@
 (defclause ^{:requires-features #{:standard-deviation-aggregations}} stddev
   field-or-expression FieldOrExpressionDef)
 
-(declare ag:var) ;; for clj-kondo
 (defclause ^{:requires-features #{:standard-deviation-aggregations}} [ag:var var]
   field-or-expression FieldOrExpressionDef)
 


### PR DESCRIPTION
`clj-kondo.lint-as/def-catch-all` was not appropriate here, we really needed a custom hook.

This fixes broken `clojure-lsp` analysis 

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30202)
<!-- Reviewable:end -->
