### PR TITLE
fix metabot error state is not cleared

### DIFF
--- a/frontend/src/metabase/metabot/components/Metabot/Metabot.unit.spec.tsx
+++ b/frontend/src/metabase/metabot/components/Metabot/Metabot.unit.spec.tsx
@@ -84,11 +84,14 @@ const setupMetabotDatabaseEndpoints = (couldGenerateCard = true) => {
 
 const setupMetabotModelEndpoints = (couldGenerateCard = true) => {
   if (couldGenerateCard) {
-    setupMetabotModelEndpoint(MODEL.id(), GENERATED_CARD);
-    setupCardDataset({
-      row_count: 1,
-      data: { rows: [[RESULT_VALUE]] },
-    });
+    setupMetabotModelEndpoint(MODEL.id(), GENERATED_CARD, true);
+    setupCardDataset(
+      {
+        row_count: 1,
+        data: { rows: [[RESULT_VALUE]] },
+      },
+      true,
+    );
   } else {
     setupBadRequestMetabotModelEndpoint(MODEL.id());
   }
@@ -160,7 +163,7 @@ describe("Metabot", () => {
       expect(screen.getByText("How did I do?")).toBeInTheDocument();
     });
 
-    it("should show an error when a query could not be generates", async () => {
+    it("should show an error when a query could not be generated", async () => {
       setupMetabotModelEndpoints(false);
       setup({ entityType: "model", model: MODEL });
 
@@ -169,6 +172,13 @@ describe("Metabot", () => {
       );
       expect(await screen.findByText(API_ERROR)).toBeInTheDocument();
       expect(screen.queryByText("How did I do?")).not.toBeInTheDocument();
+
+      // The error state get cleared
+      setupMetabotModelEndpoints(true);
+
+      userEvent.click(screen.getByRole("button", { name: /get answer/i }));
+      expect(await screen.findByText("Here you go!")).toBeInTheDocument();
+      expect(await screen.findByText(RESULT_VALUE)).toBeInTheDocument();
     });
   });
 

--- a/frontend/src/metabase/metabot/reducers.js
+++ b/frontend/src/metabase/metabot/reducers.js
@@ -94,6 +94,8 @@ export const queryError = handleActions(
     [RUN_QUESTION_QUERY_REJECTED]: { next: (state, { payload }) => payload },
     [RESET]: { next: () => null },
     [CANCEL_QUERY]: { next: () => null },
+    [RUN_PROMPT_QUERY]: { next: () => null },
+    [RUN_QUESTION_QUERY]: { next: () => null },
   },
   null,
 );

--- a/frontend/test/__support__/server-mocks/dataset.ts
+++ b/frontend/test/__support__/server-mocks/dataset.ts
@@ -12,6 +12,11 @@ export function setupErrorParameterValuesEndpoints() {
   fetchMock.post("path:/api/dataset/parameter/values", 500);
 }
 
-export function setupCardDataset(options: MockDatasetOpts = {}) {
-  fetchMock.post("path:/api/dataset", createMockDataset(options));
+export function setupCardDataset(
+  options: MockDatasetOpts = {},
+  overwriteRoutes = false,
+) {
+  fetchMock.post("path:/api/dataset", createMockDataset(options), {
+    overwriteRoutes,
+  });
 }

--- a/frontend/test/__support__/server-mocks/metabot.ts
+++ b/frontend/test/__support__/server-mocks/metabot.ts
@@ -1,11 +1,19 @@
 import fetchMock from "fetch-mock";
 import { Card, DatabaseId } from "metabase-types/api";
 
-export function setupMetabotModelEndpoint(modelId: number, card: Card) {
-  fetchMock.post(`path:/api/metabot/model/${modelId}`, {
-    card,
-    prompt_template_versions: [],
-  });
+export function setupMetabotModelEndpoint(
+  modelId: number,
+  card: Card,
+  overwriteRoutes = false,
+) {
+  fetchMock.post(
+    `path:/api/metabot/model/${modelId}`,
+    {
+      card,
+      prompt_template_versions: [],
+    },
+    { overwriteRoutes },
+  );
 }
 
 export function setupMetabotDatabaseEndpoint(


### PR DESCRIPTION
[Slack convo](https://metaboat.slack.com/archives/C04UU13442K/p1681773715570959)

### Description

Fixes the error state of Metabot is not get cleared after a failed prompt.

### How to verify

Run Metabase with Metabot — set openai API keys, enable Metabot in settings

1. On the main page enter any prompt that should result in an error for instance "yugergoadfo8724bhsd" and press enter
2. Ensure it shows an error
3. Enter a valid prompt that should work and press enter
4. Ensure it shows the results

### Checklist

- [x] Tests have been added/updated to cover changes in this PR

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30212)
<!-- Reviewable:end -->
