### PR TITLE
Tree shake the backend code

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -478,7 +478,6 @@
   metabase.models.json-migration/def-json-migration                                    clj-kondo.lint-as/def-catch-all
   metabase.models.setting.multi-setting/define-multi-setting                           clojure.core/def
   metabase.models.setting/defsetting                                                   clj-kondo.lint-as/def-catch-all
-  metabase.public-settings.premium-features/defenterprise                              clj-kondo.lint-as/def-catch-all
   metabase.public-settings.premium-features/defenterprise-schema                       clj-kondo.lint-as/def-catch-all
   metabase.public-settings.premium-features/define-premium-feature                     clojure.core/def
   metabase.pulse-test/with-pulse-for-card                                              clojure.core/let
@@ -545,6 +544,7 @@
    metabase.async.streaming-response-test/with-start-execution-chan                                                          hooks.common/with-one-binding
    metabase.db.schema-migrations-test.impl/test-migrations                                                                   hooks.metabase.db.schema-migrations-test.impl/test-migrations
    metabase.dashboard-subscription-test/with-link-card-fixture-for-dashboard                                                 hooks.common/let-second
+   metabase.driver.bigquery-cloud-sdk-test/calculate-bird-scarcity                                                           hooks.metabase.query-processor-test.expressions-test/calculate-bird-scarcity
    metabase.mbql.schema.macros/defclause                                                                                     hooks.metabase.mbql.schemas.macros/defclause
    metabase.models.collection-test/with-collection-hierarchy                                                                 hooks.common/let-one-with-optional-value
    metabase.models.collection-test/with-personal-and-impersonal-collections                                                  hooks.common/with-two-bindings
@@ -555,6 +555,7 @@
    metabase.models.pulse-test/with-pulse-in-collection                                                                       hooks.common/with-four-bindings
    metabase.models.setting.multi-setting/define-multi-setting                                                                hooks.metabase.models.setting/defsetting
    metabase.models.setting/defsetting                                                                                        hooks.metabase.models.setting/defsetting
+   metabase.public-settings.premium-features/defenterprise                                                                   hooks.metabase.public-settings.premium-features/defenterprise
    metabase.pulse.test-util/checkins-query-card                                                                              hooks.metabase.test.data/$ids
    metabase.query-processor-test.expressions-test/calculate-bird-scarcity                                                    hooks.metabase.query-processor-test.expressions-test/calculate-bird-scarcity
    metabase.query-processor-test.filter-test/count-with-filter-clause                                                        hooks.metabase.test.data/$ids

--- a/.clj-kondo/hooks/metabase/models/interface.clj
+++ b/.clj-kondo/hooks/metabase/models/interface.clj
@@ -4,14 +4,15 @@
 (defn define-hydration-method
   "This is used for both [[metabase.models.interface/define-simple-hydration-method]] and
   for [[metabase.models.interface/define-batched-hydration-method]]."
-  [{{[_define-simple-hydration-method fn-name hydration-key & fn-tail] :children} :node}]
-  (let [node (hooks/list-node
-              (list
-               (hooks/token-node 'do)
-               hydration-key
-               (hooks/list-node
-                (list*
-                 (hooks/token-node 'defn)
-                 fn-name
-                 fn-tail))))]
+  [{{[_define-simple-hydration-method fn-name hydration-key & fn-tail] :children, :as node} :node}]
+  (let [node (-> (hooks/list-node
+                  (list
+                   (hooks/token-node 'do)
+                   hydration-key
+                   (hooks/list-node
+                    (list*
+                     (hooks/token-node 'defn)
+                     fn-name
+                     fn-tail))))
+                 (with-meta (update (meta node) :clj-kondo/ignore #(hooks/vector-node (cons :clojure-lsp/unused-public-var (:children %))))))]
     {:node node}))

--- a/.clj-kondo/hooks/metabase/public_settings/premium_features.clj
+++ b/.clj-kondo/hooks/metabase/public_settings/premium_features.clj
@@ -1,0 +1,63 @@
+(ns hooks.metabase.public-settings.premium-features
+  (:require
+   [clj-kondo.hooks-api :as hooks]))
+
+(defn defenterprise [{node :node}]
+  (let [[_defenterprise fn-name & args] (:children node)
+        [docstring & args]              (if (hooks/string-node? (first args))
+                                          args
+                                          (cons nil args))
+        [_enterprise-namespace & args]   (if (hooks/token-node? (first args))
+                                           args
+                                           (cons nil args))
+        [options fn-tail]               (loop [options (hooks/map-node []), [x y & more :as args] args]
+                                          (if (hooks/keyword-node? x)
+                                            (recur (update options :children concat [x y]) more)
+                                            [options args]))]
+    {:node (hooks/list-node
+            (list
+             (hooks/token-node 'let)
+             (hooks/vector-node
+              [(hooks/token-node '_options) options])
+             (-> (hooks/list-node
+                  (concat
+                   (filter some?
+                           (list (hooks/token-node 'defn)
+                                 fn-name
+                                 docstring))
+                   fn-tail))
+                 (with-meta (update (meta node) :clj-kondo/ignore #(hooks/vector-node (cons :clojure-lsp/unused-public-var (:children %))))))))}))
+
+(comment
+  (defn- defenterprise* [form]
+    (hooks/sexpr
+     (:node
+      (defenterprise
+        {:node
+         (hooks/parse-string
+          (with-out-str
+            (clojure.pprint/pprint
+             form)))}))))
+
+  (defn- x []
+    (defenterprise*
+      '(defenterprise score-result
+         "Scoring implementation that adds score for items in official collections."
+         :feature :any
+         :fallback score-result-fallback
+         [result]
+         (conj (scoring/weights-and-scores result)
+               {:weight 2
+                :score  (official-collection-score result)
+                :name   "official collection score"}
+               {:weight 2
+                :score  (verified-score result)
+                :name   "verified"}))))
+
+  (defn- y []
+    (defenterprise*
+      '(defenterprise score-result
+         "Score a result, returning a collection of maps with score and weight."
+         metabase-enterprise.search.scoring
+         [result]
+         (weights-and-scores result)))))

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -73,30 +73,32 @@ jobs:
         /work/enterprise/backend/test
         /work/shared/src
         /work/shared/test
-        /work/modules/drivers/sparksql/src
-        /work/modules/drivers/sparksql/test
-        /work/modules/drivers/vertica/src
-        /work/modules/drivers/vertica/test
+        /work/modules/drivers/athena/src
+        /work/modules/drivers/athena/test
+        /work/modules/drivers/bigquery-cloud-sdk/src
+        /work/modules/drivers/bigquery-cloud-sdk/test
+        /work/modules/drivers/druid/src
+        /work/modules/drivers/druid/test
+        /work/modules/drivers/googleanalytics/src
+        /work/modules/drivers/googleanalytics/test
         /work/modules/drivers/mongo/src
         /work/modules/drivers/mongo/test
         /work/modules/drivers/oracle/src
         /work/modules/drivers/oracle/test
-        /work/modules/drivers/sqlite/src
-        /work/modules/drivers/sqlite/test
-        /work/modules/drivers/bigquery-cloud-sdk/src
-        /work/modules/drivers/bigquery-cloud-sdk/test
+        /work/modules/drivers/presto-jdbc/src
+        /work/modules/drivers/presto-jdbc/test
         /work/modules/drivers/redshift/src
         /work/modules/drivers/redshift/test
         /work/modules/drivers/snowflake/src
         /work/modules/drivers/snowflake/test
-        /work/modules/drivers/googleanalytics/src
-        /work/modules/drivers/googleanalytics/test
-        /work/modules/drivers/druid/src
-        /work/modules/drivers/druid/test
+        /work/modules/drivers/sparksql/src
+        /work/modules/drivers/sparksql/test
+        /work/modules/drivers/sqlite/src
+        /work/modules/drivers/sqlite/test
         /work/modules/drivers/sqlserver/src
         /work/modules/drivers/sqlserver/test
-        /work/modules/drivers/presto-jdbc/src
-        /work/modules/drivers/presto-jdbc/test
+        /work/modules/drivers/vertica/src
+        /work/modules/drivers/vertica/test
 
   be-linter-eastwood:
     needs: files-changed

--- a/enterprise/backend/src/metabase_enterprise/enhancements/models/native_query_snippet/permissions.clj
+++ b/enterprise/backend/src/metabase_enterprise/enhancements/models/native_query_snippet/permissions.clj
@@ -32,7 +32,7 @@
 (defenterprise can-create?
   "Can the current User save a new Snippet with the values in `m`?"
   :feature :any
-  [model m]
+  [_model m]
   (has-parent-collection-perms? m :write))
 
 (defenterprise can-update?

--- a/modules/drivers/athena/test/metabase/driver/athena_test.clj
+++ b/modules/drivers/athena/test/metabase/driver/athena_test.clj
@@ -1,6 +1,7 @@
 (ns metabase.driver.athena-test
   (:require
    [clojure.test :refer :all]
+   #_{:clj-kondo/ignore [:discouraged-namespace]}
    [honeysql.format :as hformat]
    [metabase.driver :as driver]
    [metabase.driver.athena :as athena]
@@ -9,6 +10,7 @@
    [metabase.public-settings.premium-features :as premium-features]
    [metabase.query-processor :as qp]
    [metabase.test :as mt]
+   #_{:clj-kondo/ignore [:discouraged-namespace]}
    [metabase.util.honeysql-extensions :as hx]))
 
 (def ^:private nested-schema

--- a/shared/src/metabase/mbql/predicates.cljc
+++ b/shared/src/metabase/mbql/predicates.cljc
@@ -7,14 +7,6 @@
 ;; This namespace only covers a few things, please add more stuff here as we write the functions so we can use them
 ;; elsewhere
 
-(def ^{:arglists '([unit])} TimeUnit?
-  "Is `unit` a datetime bucketing unit referring only to time, such as `hour` or `minute`?"
-  (complement (s/checker mbql.s/TimeUnit)))
-
-(def ^{:arglists '([unit])} DateUnit?
-  "Is `unit` a valid date bucketing unit?"
-  (complement (s/checker mbql.s/DateUnit)))
-
 (def ^{:arglists '([unit])} DateTimeUnit?
   "Is `unit` a valid datetime bucketing unit?"
   (complement (s/checker mbql.s/DateTimeUnit)))

--- a/shared/src/metabase/mbql/schema.cljc
+++ b/shared/src/metabase/mbql/schema.cljc
@@ -442,14 +442,6 @@
      (integer? id-or-name))
    "Must be a :field with an integer Field ID."))
 
-(def ^{:clause-name :field, :added "0.39.0"} field:name
-  "Schema for a `:field` clause, with the added constraint that it must use an string Field name."
-  (s/constrained
-   field
-   (fn [[_ id-or-name]]
-     (string? id-or-name))
-   "Must be a :field with a string Field name."))
-
 (def ^:private Field*
   (one-of expression field))
 
@@ -1522,11 +1514,6 @@
    :string/does-not-contain {:type :string, :operator :unary, :allowed-for #{:string/does-not-contain}}
    :string/ends-with        {:type :string, :operator :unary, :allowed-for #{:string/ends-with}}
    :string/starts-with      {:type :string, :operator :unary, :allowed-for #{:string/starts-with}}})
-
-(defn valid-parameter-type?
-  "Whether `param-type` is a valid non-abstract parameter type."
-  [param-type]
-  (get parameter-types param-type))
 
 (def ParameterType
   "Schema for valid values of `:type` for a [[Parameter]]."

--- a/shared/src/metabase/mbql/util.cljc
+++ b/shared/src/metabase/mbql/util.cljc
@@ -459,27 +459,6 @@
   [[_ id]]
   (ga-id? id))
 
-(defn temporal-field?
-  "Is `field` used to record something date or time related, i.e. does `field` have a base type or semantic type that
-  derives from `:type/Temporal`?"
-  [field]
-  (or (isa? (:base_type field)    :type/Temporal)
-      (isa? (:semantic_type field) :type/Temporal)))
-
-(defn time-field?
-  "Is `field` used to record a time of day (e.g. hour/minute/second), but not the date itself? i.e. does `field` have a
-  base type or semantic type that derives from `:type/Time`?"
-  [field]
-  (or (isa? (:base_type field)    :type/Time)
-      (isa? (:semantic_type field) :type/Time)))
-
-(defn temporal-but-not-time-field?
-  "Does `field` have a base type or semantic type that derives from `:type/Temporal`, but not `:type/Time`? (i.e., is
-  Field a Date or DateTime?)"
-  [field]
-  (and (temporal-field? field)
-       (not (time-field? field))))
-
 ;;; --------------------------------- Unique names & transforming ags to have names ----------------------------------
 
 (defn unique-name-generator

--- a/src/metabase/api/permission_graph.clj
+++ b/src/metabase/api/permission_graph.clj
@@ -128,23 +128,6 @@
    [:groups [:map-of GroupId [:maybe StrictDbGraph]]]
    [:revision int?]])
 
-;;; --------------------------------------------- Collection Permissions ---------------------------------------------
-
-(s/def ::collections
-  (s/map-of (s/or :identity ::id
-                  :str->kw  #{"root"})
-            (s/or :str->kw #{"read" "write" "none"})))
-
-(s/def ::collection-graph
-  (s/map-of ::id ::collections))
-
-(s/def :metabase.api.permission-graph.collection/groups
-  (s/map-of ::id
-            ::collection-graph
-            :conform-keys true))
-
-(s/def ::collection-permissions-graph
-  (s/keys :req-un [:metabase.api.permission-graph.collection/groups]))
 
 ;;; --------------------------------------------- Execution Permissions ----------------------------------------------
 

--- a/src/metabase/automagic_dashboards/filters.clj
+++ b/src/metabase/automagic_dashboards/filters.clj
@@ -10,10 +10,6 @@
    [schema.core :as s]
    [toucan2.core :as t2]))
 
-(def ^{:arglists '([form])} field-reference?
-  "Is given form an MBQL field reference?"
-  (complement (s/checker mbql.s/field)))
-
 (s/defn field-reference->id :- (s/maybe (s/cond-pre su/NonBlankString su/IntGreaterThanZero))
   "Extract field ID from a given field reference form."
   [clause]

--- a/src/metabase/models/dashboard_card.clj
+++ b/src/metabase/models/dashboard_card.clj
@@ -89,12 +89,6 @@
 
 ;;; --------------------------------------------------- HYDRATION ----------------------------------------------------
 
-(defn dashboard
-  "Return the Dashboard associated with the DashboardCard."
-  [{:keys [dashboard_id]}]
-  {:pre [(integer? dashboard_id)]}
-  (t2/select-one 'Dashboard, :id dashboard_id))
-
 (mi/define-simple-hydration-method series
   :series
   "Return the `Cards` associated as additional series on this DashboardCard."

--- a/src/metabase/models/field_values.clj
+++ b/src/metabase/models/field_values.clj
@@ -267,7 +267,7 @@
 (defenterprise hash-key-for-sandbox
   "Return a hash-key that will be used for sandboxed fieldvalues."
   metabase-enterprise.sandbox.models.params.field-values
-  [field-id]
+  [_field-id]
   nil)
 
 (defn default-hash-key-for-linked-filters

--- a/src/metabase/models/moderation_review.clj
+++ b/src/metabase/models/moderation_review.clj
@@ -19,15 +19,16 @@
   "Schema of valid statuses"
   (apply s/enum statuses))
 
-;; TODO: Appears to be unused, remove?
-(def ReviewChanges
-  "Schema for a ModerationReview that's being updated (so most keys are optional)"
-  {(s/optional-key :id)                  su/IntGreaterThanZero
-   (s/optional-key :moderated_item_id)   su/IntGreaterThanZero
-   (s/optional-key :moderated_item_type) moderation/moderated-item-types
-   (s/optional-key :status)              Statuses
-   (s/optional-key :text)                (s/maybe s/Str)
-   s/Any                                 s/Any})
+;;; currently unused, but I'm leaving this in commented out because it serves as documentation
+(comment
+  (def ReviewChanges
+    "Schema for a ModerationReview that's being updated (so most keys are optional)"
+    {(s/optional-key :id)                  su/IntGreaterThanZero
+     (s/optional-key :moderated_item_id)   su/IntGreaterThanZero
+     (s/optional-key :moderated_item_type) moderation/moderated-item-types
+     (s/optional-key :status)              Statuses
+     (s/optional-key :text)                (s/maybe s/Str)
+     s/Any                                 s/Any}))
 
 (models/defmodel ModerationReview :moderation_review)
 

--- a/src/metabase/models/permissions.clj
+++ b/src/metabase/models/permissions.clj
@@ -394,11 +394,6 @@
       (throw (ex-info "Unclassified data path!!" {:data-path data-path :result result})))
     (first result)))
 
-(def segmented-perm-regex
-  "Regex that matches a segmented permission. Used internally for some EE stuff
-  e.g. [[metabase-enterprise.sandbox.api.util/segmented-user?]]."
-  (re-pattern (str #"^/db/\d+/schema/" path-char "*" #"/table/\d+/query/segmented/$")))
-
 (defn- escape-path-component
   "Escape slashes in something that might be passed as a string part of a permissions path (e.g. DB schema name or
   Collection name).
@@ -532,12 +527,6 @@
 
   ([database-or-id schema-name table-or-id]
    (str (data-perms-path (u/the-id database-or-id) schema-name (u/the-id table-or-id)) "query/segmented/")))
-
-(s/defn execute-query-perms-path :- PathSchema
-  "Return the execute query action permissions path for a database.
-   This grants you permissions to run arbitary query actions."
-  [database-or-id :- MapOrID]
-  (str "/execute" (data-perms-path database-or-id)))
 
 (s/defn database-block-perms-path :- PathSchema
   "Return the permissions path for the Block 'anti-permissions'. Block anti-permissions means a User cannot run a query

--- a/src/metabase/models/pulse.clj
+++ b/src/metabase/models/pulse.clj
@@ -154,20 +154,6 @@
   [_pulse]
   [:name (serdes/hydrated-hash :collection) :created_at])
 
-(def ^:private ^:dynamic *automatically-archive-when-last-channel-is-deleted*
-  "Should we automatically archive a Pulse when its last `PulseChannel` is deleted? Normally we do, but this is disabled
-  in [[update-notification-channels!]] which creates/deletes/updates several channels sequentially."
-  true)
-
-(defn will-delete-channel
-  "This function is called by [[metabase.models.pulse-channel/pre-delete]] when the `PulseChannel` is about to be
-  deleted. Archives `Pulse` if the channel being deleted is its last channel."
-  [{pulse-id :pulse_id, pulse-channel-id :id}]
-  (when *automatically-archive-when-last-channel-is-deleted*
-    (let [other-channels-count (t2/count PulseChannel :pulse_id pulse-id, :id [:not= pulse-channel-id])]
-      (when (zero? other-channels-count)
-        (t2/update! Pulse pulse-id {:archived true})))))
-
 ;;; ---------------------------------------------------- Schemas -----------------------------------------------------
 
 (def AlertConditions
@@ -472,7 +458,7 @@
       "Cannot have channels without a :channel_type attribute")
     ;; don't automatically archive this Pulse if we end up deleting its last PulseChannel -- we're probably replacing
     ;; it with a new one immediately thereafter.
-    (binding [*automatically-archive-when-last-channel-is-deleted* false]
+    (binding [pulse-channel/*archive-parent-pulse-when-last-channel-is-deleted* false]
       ;; for each of our possible channel types call our handler function
       (doseq [[channel-type] pulse-channel/channel-types]
         (handle-channel channel-type)))))

--- a/src/metabase/models/pulse_channel_recipient.clj
+++ b/src/metabase/models/pulse_channel_recipient.clj
@@ -1,17 +1,22 @@
 (ns metabase.models.pulse-channel-recipient
   (:require
-   [metabase.models.interface :as mi]
-   [metabase.plugins.classloader :as classloader]
-   [toucan.models :as models]))
+   [toucan.models :as models]
+   [toucan2.core :as t2]))
 
 (models/defmodel PulseChannelRecipient :pulse_channel_recipient)
 
-(defn- pre-delete [pcr]
-  ;; call [[metabase.models.pulse-channel/will-delete-recipient]] to let it know we're about to delete this
-  ;; PulseChannelRecipient; that function will decide whether to automatically delete the PulseChannel as well.
-  (classloader/require 'metabase.models.pulse-channel)
-  ((resolve 'metabase.models.pulse-channel/will-delete-recipient) pcr))
-
-(mi/define-methods
- PulseChannelRecipient
- {:pre-delete pre-delete})
+;;; Deletes `PulseChannel` if the recipient being deleted is its last recipient. (This only applies
+;;; to PulseChannels with User subscriptions; Slack PulseChannels and ones with email address subscriptions are not
+;;; automatically deleted.
+(t2/define-before-delete PulseChannelRecipient
+  [{channel-id :pulse_channel_id, pulse-channel-recipient-id :id}]
+  (let [other-recipients-count (t2/count PulseChannelRecipient
+                                         :pulse_channel_id channel-id
+                                         :id               [:not= pulse-channel-recipient-id])
+        last-recipient?        (zero? other-recipients-count)]
+    (when last-recipient?
+      ;; make sure this channel doesn't have any email-address (non-User) recipients.
+      (let [details              (t2/select-one-fn :details :metabase.models.pulse-channel/PulseChannel :id channel-id)
+            has-email-addresses? (seq (:emails details))]
+        (when-not has-email-addresses?
+          (t2/delete! :metabase.models.pulse-channel/PulseChannel :id channel-id))))))

--- a/src/metabase/models/user.clj
+++ b/src/metabase/models/user.clj
@@ -182,17 +182,6 @@
    ;; is_group_manager only included if `advanced-permissions` is enabled
    (schema/optional-key :is_group_manager) schema/Bool})
 
-(schema/defn user-group-memberships :- (schema/maybe [UserGroupMembership])
-  "Return a list of group memberships a User belongs to.
-  Group membership is a map  with 2 keys [:id :is_group_manager], in which `is_group_manager` will only returned if
-  advanced-permissions is available."
-  [user-or-id]
-  (when user-or-id
-    (let [selector (cond-> [PermissionsGroupMembership [:group_id :id]]
-                     (premium-features/enable-advanced-permissions?)
-                     (conj :is_group_manager))]
-      (t2/select selector :user_id (u/the-id user-or-id)))))
-
 ;;; -------------------------------------------------- Permissions ---------------------------------------------------
 
 (defn permissions-set

--- a/src/metabase/query_processor/error_type.clj
+++ b/src/metabase/query_processor/error_type.clj
@@ -8,11 +8,6 @@
 (def ^:private hierarchy
   (make-hierarchy))
 
-(defn known-error-types
-  "Set of all known QP error types."
-  []
-  (descendants hierarchy :error))
-
 (defn known-error-type?
   "Is `error-type` a known QP error type (i.e., one defined with `deferror` above)?"
   [error-type]
@@ -78,11 +73,6 @@
 (deferror server
   "Generic ancestor type for all *unexpected* server-side errors. Equivalent of a HTTP 5xx status code."
   :parent :error)
-
-(defn server-error?
-  "Is `error-type` a server error type, the equivalent of an HTTP 5xx status code?"
-  [error-type]
-  (isa? hierarchy error-type :server))
 
 (deferror timed-out
   "Error type if query fails to return the first row of results after some timeout."

--- a/src/metabase/sync/interface.clj
+++ b/src/metabase/sync/interface.clj
@@ -47,9 +47,11 @@
    :fields                       #{TableMetadataField}
    (s/optional-key :description) (s/maybe s/Str)})
 
-(def NestedFCMetadata
-  "Schema for the expected output of `describe-nested-field-columns`."
-  (s/maybe #{TableMetadataField}))
+;;; not actually used; leaving here for now because it serves as documentation
+(comment
+  (def NestedFCMetadata
+    "Schema for the expected output of [[metabase.driver.sql-jdbc.sync/describe-nested-field-columns]]."
+    (s/maybe #{TableMetadataField})))
 
 (def FKMetadataEntry
   "Schema for an individual entry in `FKMetadata`."
@@ -67,10 +69,9 @@
 ;; out from the ns declaration when running `cljr-clean-ns`. Plus as a bonus in the future we could add additional
 ;; validations to these, e.g. requiring that a Field have a base_type
 
-(def DatabaseInstance             "Schema for a valid instance of a Metabase Database." (mi/InstanceOf Database))
-(def TableInstance                "Schema for a valid instance of a Metabase Table."    (mi/InstanceOf Table))
-(def FieldInstance                "Schema for a valid instance of a Metabase Field."    (mi/InstanceOf Field))
-(def ResultColumnMetadataInstance "Schema for result column metadata."                  su/Map)
+(def DatabaseInstance "Schema for a valid instance of a Metabase Database." (mi/InstanceOf Database))
+(def TableInstance    "Schema for a valid instance of a Metabase Table."    (mi/InstanceOf Table))
+(def FieldInstance    "Schema for a valid instance of a Metabase Field."    (mi/InstanceOf Field))
 
 
 ;;; +----------------------------------------------------------------------------------------------------------------+

--- a/src/metabase/util/date_2.clj
+++ b/src/metabase/util/date_2.clj
@@ -460,11 +460,6 @@
       (compare (.addTo (period-duration d1) t)
                (.addTo (period-duration d2) t)))))
 
-(defn less-than-period-duration?
-  "True if period/duration `d1` is shorter than period/duration `d2`."
-  [d1 d2]
-  (neg? (compare-period-durations d1 d2)))
-
 (defn greater-than-period-duration?
   "True if period/duration `d1` is longer than period/duration `d2`."
   [d1 d2]

--- a/src/metabase/util/schema.clj
+++ b/src/metabase/util/schema.clj
@@ -276,11 +276,6 @@
   (with-api-error-message (s/pred #(isa? (keyword %) :Semantic/*) (deferred-tru "Valid field semantic type (keyword or string)"))
     (deferred-tru "value must be a valid field semantic type (keyword or string).")))
 
-(def FieldRelationTypeKeywordOrString
-  "Like `FieldRelationType` but accepts either a keyword or string."
-  (with-api-error-message (s/pred #(isa? (keyword %) :Relation/*) (deferred-tru "Valid field relation type (keyword or string)"))
-    (deferred-tru "value must be a valid field relation type (keyword or string).")))
-
 (def FieldSemanticOrRelationTypeKeywordOrString
   "Like `FieldSemanticOrRelationType` but accepts either a keyword or string."
   (with-api-error-message (s/pred (fn [k]
@@ -333,12 +328,6 @@
    Something that adheres to this schema is guaranteed to to work with `Integer/parseInt`."
   (with-api-error-message (s/constrained s/Str #(u/ignore-exceptions (< 0 (Integer/parseInt %))))
     (deferred-tru "value must be a valid integer greater than zero.")))
-
-(def IntStringGreaterThanOrEqualToZero
-  "Schema for a string that can be parsed as an integer, and is greater than or equal to zero.
-   Something that adheres to this schema is guaranteed to to work with `Integer/parseInt`."
-  (with-api-error-message (s/constrained s/Str #(u/ignore-exceptions (<= 0 (Integer/parseInt %))))
-    (deferred-tru "value must be a valid integer greater than or equal to zero.")))
 
 (defn- boolean-string? ^Boolean [s]
   (boolean (when (string? s)

--- a/test/metabase/public_settings/premium_features_test.clj
+++ b/test/metabase/public_settings/premium_features_test.clj
@@ -210,7 +210,7 @@
   "Returns a greeting for a user. Only EE version is defined with defenterprise-schema."
   metabase-enterprise.util-test
   [username]
-  (format "Hi %s, you're an OSS customer!"))
+  (format "Hi %s, you're an OSS customer!" username))
 
 (deftest defenterprise-schema-test
   (when-not config/ee-available?

--- a/test/metabase/query_processor/test_util.clj
+++ b/test/metabase/query_processor/test_util.clj
@@ -8,18 +8,12 @@
   (:require
    [clojure.test :refer :all]
    [metabase.driver :as driver]
-   [metabase.mbql.util :as mbql.u]
-   [metabase.models.field :refer [Field]]
-   [metabase.models.table :refer [Table]]
    [metabase.query-processor :as qp]
-   [metabase.query-processor.middleware.add-implicit-joins :as qp.add-implicit-joins]
    [metabase.query-processor.store :as qp.store]
    [metabase.query-processor.timezone :as qp.timezone]
    [metabase.test.data :as data]
-   [metabase.util :as u]
    [metabase.util.schema :as su]
-   [schema.core :as s]
-   [toucan2.core :as t2]))
+   [schema.core :as s]))
 
 ;; TODO - I don't think we different QP test util namespaces? We should roll this namespace into
 ;; `metabase.query-processor-test`
@@ -69,22 +63,6 @@
   [{:keys [database]}]
   (qp.store/fetch-and-store-database! database))
 
-(defn store-referenced-tables!
-  "Store any Tables referenced in `query` in the QP Store."
-  [query]
-  (when-let [table-ids (seq
-                        (flatten
-                         (mbql.u/match query
-                           (m :guard (every-pred map? (comp integer? :source-table)))
-                           (cons (:source-table m)  (recur (dissoc m :source-table))))))]
-    (qp.store/fetch-and-store-tables! table-ids)))
-
-(defn store-referenced-fields!
-  "Store any Fields referenced (by ID) in `query` in the QP Store."
-  [query]
-  (when-let [field-ids (seq (mbql.u/match query [:field-id id] id))]
-    (qp.store/fetch-and-store-fields! field-ids)))
-
 (defn store-contents
   "Fetch the names of all the objects currently in the QP Store."
   []
@@ -110,16 +88,6 @@
                      (throw (ex-info "Missing [:data :results_metadata :columns] from query results" results)))]
     {:dataset_query   query
      :result_metadata metadata}))
-
-(defn fk-table-alias-name
-  "Get the name that will be used for the alias for an implicit join (i.e., a join added as a result of using an `:fk->`
-  clause somewhere in the query.)
-
-    (fk-table-alias-name (data/id :categories) (data/id :venues :category_id)) ;; -> \"CATEGORIES__via__CATEGORY_ID\""
-  [table-or-id field-or-id]
-  (#'qp.add-implicit-joins/join-alias
-   (t2/select-one-fn :name Table :id (u/the-id table-or-id))
-   (t2/select-one-fn :name Field :id (u/the-id field-or-id))))
 
 
 ;;; ------------------------------------------------- Timezone Stuff -------------------------------------------------

--- a/test/metabase/query_processor_test.clj
+++ b/test/metabase/query_processor_test.clj
@@ -7,7 +7,6 @@
    [clojure.string :as str]
    [clojure.test :refer :all]
    [hawk.init]
-   [medley.core :as m]
    [metabase.db.connection :as mdb.connection]
    [metabase.driver :as driver]
    [metabase.models.field :refer [Field]]
@@ -169,23 +168,6 @@
   ([table-kw field-kw]
    (field-literal-col (col table-kw field-kw))))
 
-(defn field-literal-col-keep-extra-cols
-  "Return expected `:cols` info for a Field that was referred to as a `:field-literal`. This differs from
-  `field-literal-col` in that it doesn't remove columns like `:description` -- in some cases metadata will come back
-  with these cols, and in some it won't -- I think it has to do with whether the Card had `:source_metadata` saved for
-  it.
-
-    (field-literal-col-keep-extra-cols :venues :price)
-    (field-literal-col-keep-extra-cols (aggregate-col :count))"
-  {:arglists '([col] [table-kw field-kw])}
-  ([{field-name :name, base-type :base_type, :as col}]
-   (assoc col
-          :field_ref [:field field-name {:base-type base-type}]
-          :source    :fields))
-
-  ([table-kw field-kw]
-   (field-literal-col-keep-extra-cols (col table-kw field-kw))))
-
 (defn fk-col
   "Return expected `:cols` info for a Field that came in via an implicit join (i.e, via an `fk->` clause)."
   [source-table-kw source-field-kw, dest-table-kw dest-field-kw]
@@ -219,18 +201,6 @@
   "Return expected `:cols` info for a Field from a native query or native source query."
   [table-kw field-kw]
   (native-query-col* (data/id) (data/id table-kw) (data/id table-kw field-kw)))
-
-(defn ^:deprecated booleanize-native-form
-  "Convert `:native_form` attribute to a boolean to make test results comparisons easier. Remove `data.results_metadata`
-  as well since it just takes a lot of space and the checksum can vary based on whether encryption is enabled.
-
-  DEPRECATED: Just use `qp.test/rows`, `qp.test/row-and-cols`, or `qp.test/rows+column-names` instead, combined with
-  functions like `col` as needed."
-  [m]
-  (-> m
-      (update-in [:data :native_form] boolean)
-      (m/dissoc-in [:data :results_metadata])
-      (m/dissoc-in [:data :insights])))
 
 (defmulti format-rows-fns
   "Return vector of functions (or floating-point numbers, for rounding; see `format-rows-by`) to use to format result

--- a/test/metabase/test/data/sql.clj
+++ b/test/metabase/test/data/sql.clj
@@ -109,7 +109,6 @@
       (qualify-and-quote driver database-name table-name field-name)
       field-comment)))
 
-
 (defmulti inline-table-comment-sql
   "Return an inline `COMMENT` statement for a table."
   {:arglists '([driver comment])}
@@ -117,13 +116,6 @@
   :hierarchy #'driver/hierarchy)
 
 (defmethod inline-table-comment-sql :sql/test-extensions [_ _] nil)
-
-(defn standard-inline-table-comment-sql
-  "Implementation of `inline-table-comment-sql` for driver test extenstions that wish to use it."
-  [_ table-comment]
-  (when (seq table-comment)
-    (format "COMMENT '%s'" table-comment)))
-
 
 (defmulti standalone-table-comment-sql
   "Return standalone `COMMENT` statement for a table."

--- a/test/metabase/test/data/sql_jdbc/load_data.clj
+++ b/test/metabase/test/data/sql_jdbc/load_data.clj
@@ -23,9 +23,9 @@
 
 (defmulti load-data!
   "Load the rows for a specific table (which has already been created) into a DB. `load-data-chunked!` is the default
-  implementation (see below); several other implementations like `load-data-all-at-once!` and
-  `load-data-one-at-a-time!` are already defined; see below. It will likely take some experimentation to see which
-  implementation works correctly and performs best with your driver."
+  implementation (see below); several other implementations like `load-data-all-at-once!` are already defined; see
+  below. It will likely take some experimentation to see which implementation works correctly and performs best with
+  your driver."
   {:arglists '([driver dbdef tabledef])}
   tx/dispatch-on-driver-with-test-extensions
   :hierarchy #'driver/hierarchy)
@@ -74,7 +74,7 @@
 
 (defn load-data-add-ids
   "Middleware function intended for use with `make-load-data-fn`. Add IDs to each row, presumabily for doing a parallel
-  insert. This function should go before `load-data-chunked` or `load-data-one-at-a-time` in the `make-load-data-fn`
+  insert. This function should go before `load-data-chunked` in the `make-load-data-fn`
   args."
   [insert!]
   (fn [rows]
@@ -91,12 +91,6 @@
   ([map-fn insert!]            (load-data-chunked map-fn *chunk-size* insert!))
   ([map-fn chunk-size insert!] (fn [rows]
                                  (dorun (map-fn insert! (partition-all chunk-size rows))))))
-
-(defn load-data-one-at-a-time
-  "Middleware function intended for use with `make-load-data-fn`. Insert rows one at a time."
-  ([insert!]        (load-data-one-at-a-time map insert!))
-  ([map-fn insert!] (fn [rows]
-                      (dorun (map-fn insert! rows)))))
 
 
 ;;; -------------------------------- Making a load-data! impl with make-load-data-fn ---------------------------------
@@ -146,10 +140,6 @@
   "Implementation of `load-data!`. Insert rows in chunks of [[*chunk-size*]] (default 200) at a time."
   (make-load-data-fn load-data-chunked))
 
-(def ^{:arglists '([driver dbdef tabledef])} load-data-one-at-a-time!
-  "Implementation of `load-data!`. Insert rows one at a time."
-  (make-load-data-fn load-data-one-at-a-time))
-
 (def ^{:arglists '([driver dbdef tabledef])} load-data-add-ids!
   "Implementation of `load-data!`. Insert all rows at once; add IDs."
   (make-load-data-fn load-data-add-ids))
@@ -157,20 +147,6 @@
 (def ^{:arglists '([driver dbdef tabledef])} load-data-add-ids-chunked!
   "Implementation of `load-data!`. Insert rows in chunks of [[*chunk-size*]] (default 200) at a time; add IDs."
   (make-load-data-fn load-data-add-ids load-data-chunked))
-
-(def ^{:arglists '([driver dbdef tabledef])} load-data-one-at-a-time-add-ids!
-  "Implementation of `load-data!` that inserts rows one at a time, but adds IDs."
-  (make-load-data-fn load-data-add-ids load-data-one-at-a-time))
-
-(def ^{:arglists '([driver dbdef tabledef])} load-data-chunked-parallel!
-  "Implementation of `load-data!`. Insert rows in chunks of [[*chunk-size*]] (default 200) at a time, in parallel."
-  (make-load-data-fn load-data-add-ids (partial load-data-chunked pmap)))
-
-(def ^{:arglists '([driver dbdef tabledef])} load-data-one-at-a-time-parallel!
-  "Implementation of `load-data!`. Insert rows one at a time, in parallel."
-  (make-load-data-fn load-data-add-ids (partial load-data-one-at-a-time pmap)))
-;; ^ the parallel versions aren't neccesarily faster than the sequential versions for all drivers so make sure to do
-;; some profiling in order to pick the appropriate implementation
 
 ;; Default impl
 

--- a/test/metabase/test/data/users.clj
+++ b/test/metabase/test/data/users.clj
@@ -123,14 +123,6 @@
     {:username email
      :password password}))
 
-(def ^{:arglists '([id])} id->user
-  "Reverse of `user->id`.
-
-    (id->user 4) -> :rasta"
-  (let [m (delay (zipmap (map user->id usernames) usernames))]
-    (fn [id]
-      (@m id))))
-
 (defonce ^:private tokens (atom {}))
 
 (s/defn username->token :- u/uuid-regex

--- a/test/metabase/test/util.clj
+++ b/test/metabase/test/util.clj
@@ -820,16 +820,6 @@
     :else
     x))
 
-(defmacro exception-and-message
-  "Invokes `body`, catches the exception and returns a map with the exception class, message and data"
-  [& body]
-  `(try
-     ~@body
-     (catch Exception e#
-       {:ex-class (class e#)
-        :msg      (.getMessage e#)
-        :data     (ex-data e#)})))
-
 (defn call-with-locale
   "Sets the default locale temporarily to `locale-tag`, then invokes `f` and reverts the locale change"
   [locale-tag f]


### PR DESCRIPTION
Now that I fixed `clojure-lsp` in https://github.com/metabase/metabase/pull/30202 I can finally do some tree shaking with it.

Deleted is a ton of orphaned nonsense we no longer use. I left a lot of stuff in that we'll probably use in the future, such as the Malli versions of our Schema utils

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30214)
<!-- Reviewable:end -->
