### PR TITLE
Csv/misc bugfixes

### DIFF
--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -14441,11 +14441,7 @@ databaseChangeLog:
             tableName: metabase_table
             columnName: name
             newDataType: varchar(256)
-      rollback:
-        - modifyDataType:
-            tableName: metabase_table
-            columnName: name
-            newDataType: varchar(254)
+      rollback: # no rollback needed, varchar(256) is backwards compatible
 
   - changeSet:
       id: v47.00-011
@@ -14456,11 +14452,7 @@ databaseChangeLog:
             tableName: metabase_table
             columnName: display_name
             newDataType: varchar(256)
-      rollback:
-        - modifyDataType:
-            tableName: metabase_table
-            columnName: display_name
-            newDataType: varchar(254)
+      rollback: # no rollback needed, varchar(256) is backwards compatible
 
   - changeSet:
       id: v47.00-012

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -14433,6 +14433,36 @@ databaseChangeLog:
             sql: UPDATE core_user SET google_auth = true, sso_source = NULL WHERE sso_source = 'google';
 
   - changeSet:
+      id: v47.00-010
+      author: tsmacdonald
+      comment: Added 0.47.0 - Make metabase_table.name long enough for H2 names
+      changes:
+        - modifyDataType:
+            tableName: metabase_table
+            columnName: name
+            newDataType: varchar(256)
+      rollback:
+        - modifyDataType:
+            tableName: metabase_table
+            columnName: name
+            newDataType: varchar(254)
+
+  - changeSet:
+      id: v47.00-011
+      author: tsmacdonald
+      comment: Added 0.47.0 - Make metabase_table.display_name long enough for H2 names
+      changes:
+        - modifyDataType:
+            tableName: metabase_table
+            columnName: display_name
+            newDataType: varchar(256)
+      rollback:
+        - modifyDataType:
+            tableName: metabase_table
+            columnName: display_name
+            newDataType: varchar(254)
+
+  - changeSet:
       id: v47.00-012
       author: qwef
       comment: Added 0.47.0 - Replace user google_auth and ldap_auth columns with sso_source values

--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -39,8 +39,8 @@
    [metabase.models.query :as query]
    [metabase.models.query.permissions :as query-perms]
    [metabase.models.revision.last-edit :as last-edit]
-   [metabase.models.setting :as setting]
    [metabase.models.timeline :as timeline]
+   [metabase.public-settings :as public-settings]
    [metabase.query-processor.async :as qp.async]
    [metabase.query-processor.card :as qp.card]
    [metabase.query-processor.pivot :as qp.pivot]
@@ -976,35 +976,23 @@ saved later when it is ready."
    query     ms/NonBlankString}
   (param-values (api/read-check Card card-id) param-key query))
 
-(defn- value-or-throw!
-  [value ^String message]
-  (let [test-fn (if (string? value) str/blank? nil?)]
-    (if (test-fn value)
-      (throw (Exception. message))
-      value)))
-
-(defn- get-setting-or-throw!
-  [setting-name]
-  (value-or-throw! (setting/get setting-name)
-                   (trs "You must set the `{0}` before uploading files." (name setting-name))))
-
 (defn upload-csv!
   "Main entry point for CSV uploading. Coordinates detecting the schema, inserting it into an appropriate database,
   syncing and scanning the new data, and creating an appropriate model. May throw validation or DB errors."
   [collection-id filename csv-file]
-  (when (not (setting/get :uploads-enabled))
+  (when (not (public-settings/uploads-enabled))
     (throw (Exception. "Uploads are not enabled.")))
   (collection/check-write-perms-for-collection collection-id)
-  (let [db-id             (get-setting-or-throw! :uploads-database-id)
+  (let [db-id             (public-settings/uploads-database-id)
         database          (or (t2/select-one Database :id db-id)
                               (throw (Exception. (tru "The uploads database does not exist."))))
-        schema-name       (setting/get :uploads-schema-name)
+        schema-name       (public-settings/uploads-schema-name)
         filename-prefix   (or (second (re-matches #"(.*)\.csv$" filename))
                               filename)
         driver            (driver.u/database->driver database)
         _                 (or (driver/database-supports? driver :uploads nil)
                               (throw (Exception. (tru "Uploads are not supported on {0} databases." (str/capitalize (name driver))))))
-        table-name        (->> (str (setting/get :uploads-table-prefix) filename-prefix)
+        table-name        (->> (str (public-settings/uploads-table-prefix) filename-prefix)
                                (upload/unique-table-name driver))
         schema+table-name (if (str/blank? schema-name)
                             table-name

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -818,6 +818,12 @@
 ;;; |                                                    Upload                                                      |
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
+(defmulti table-name-length-limit
+  "Return the maximum number of characters allowed in a table name, or `nil` if there is no limit."
+  {:added "0.47.0", :arglists '([driver])}
+  dispatch-on-initialized-driver
+  :hierarchy #'hierarchy)
+
 (defmulti create-table
   "Create a table named `table-name`. If the table already exists it will throw an error."
   {:added "0.47.0", :arglists '([driver db-id table-name col->type])}

--- a/src/metabase/driver/h2.clj
+++ b/src/metabase/driver/h2.clj
@@ -528,3 +528,8 @@
     ::upload/boolean     "BOOLEAN"
     ::upload/date        "DATE"
     ::upload/datetime    "TIMESTAMP"))
+
+(defmethod driver/table-name-length-limit :h2
+  [_driver]
+  ;; http://www.h2database.com/html/advanced.html#limits_limitations
+  256)

--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -620,3 +620,8 @@
     ::upload/boolean     "BOOLEAN"
     ::upload/date        "DATE"
     ::upload/datetime    "TIMESTAMP"))
+
+(defmethod driver/table-name-length-limit :mysql
+  [_driver]
+  ;; https://dev.mysql.com/doc/refman/8.0/en/identifier-length.html
+  64)

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -764,3 +764,8 @@
     ::upload/boolean     "BOOLEAN"
     ::upload/date        "DATE"
     ::upload/datetime    "TIMESTAMP"))
+
+(defmethod driver/table-name-length-limit :postgres
+  [_driver]
+  ;; https://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS
+  63)

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -768,4 +768,6 @@
 (defmethod driver/table-name-length-limit :postgres
   [_driver]
   ;; https://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS
+  ;; This could be incorrect if Postgres has been compiled with a value for NAMEDATALEN other than the default (64), but
+  ;; that seems unlikely and there's not an easy way to find out.
   63)

--- a/src/metabase/driver/sql_jdbc.clj
+++ b/src/metabase/driver/sql_jdbc.clj
@@ -103,7 +103,8 @@
 (defn- create-table-sql
   [table-name col->type]
   (first (sql/format {:create-table (keyword table-name)
-                      :with-columns (map (fn [kv] (map keyword kv)) col->type)})))
+                      :with-columns (map (fn [kv] (map keyword kv)) col->type)}
+                     :quoted true)))
 
 (defmethod driver/create-table :sql-jdbc
   [_driver db-id table-name col->type]
@@ -112,7 +113,8 @@
 
 (defmethod driver/drop-table :sql-jdbc
   [_driver db-id table-name]
-  (let [sql (first (sql/format {:drop-table [:if-exists (keyword table-name)]}))]
+  (let [sql (first (sql/format {:drop-table [:if-exists (keyword table-name)]}
+                               :quoted true))]
     (qp.writeback/execute-write-sql! db-id sql)))
 
 (defmethod driver/insert-into :sql-jdbc
@@ -121,7 +123,8 @@
         columns    (map keyword column-names)
         sqls       (map #(sql/format {:insert-into table-name
                                       :columns     columns
-                                      :values      %})
+                                      :values      %}
+                                     :quoted true)
                         (partition-all 100 values))]
     ;; We need to partition the insert into multiple statements for both performance and correctness.
     ;;

--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -122,16 +122,16 @@
   (let [normalized (u/slugify (str/trim raw-name))]
     (if-not (str/blank? normalized)
       normalized
-      (format "unnamed-column-%s" (inc index)))))
+      (format "unnamed_column_%s" (inc index)))))
 
 (defn- deduplicate
   "Add `new-name` to the vector (must be a vector so that `conj` works!) of `names-so-far`, adding a unique suffix if
   necessary."
   [names-so-far new-name]
   (if (some #(= % new-name) names-so-far)
-    (if-let [dupe-number (second (re-matches #".*-(\d+)" new-name))]
-      (recur names-so-far (str/replace new-name #"-\d+$" (str "-" (inc (parse-long dupe-number)))))
-      (recur names-so-far (str new-name "-1")))
+    (if-let [dupe-number (second (re-matches #".*_(\d+)" new-name))]
+      (recur names-so-far (str/replace new-name #"_\d+$" (str "_" (inc (parse-long dupe-number)))))
+      (recur names-so-far (str new-name "_1")))
     (conj names-so-far new-name)))
 
 (defn- rows->schema

--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -195,11 +195,21 @@
 (defn unique-table-name
   "Append the current datetime to the given name to create a unique table name. The resulting name will be short enough for the given driver (truncating the supplised `table-name` if necessary)."
   [driver table-name]
-  (let [time-format "_yyyyMMddHHmmss"]
-    (str (subs (u/slugify table-name) 0 (min (count table-name)
-                                             (- (driver/table-name-length-limit driver) (count time-format))))
+  (let [time-format                 "_yyyyMMddHHmmss"
+        acceptable-length           (min (count table-name)
+                                         (- (driver/table-name-length-limit driver) (count time-format)))
+        truncated-name-without-time (subs (u/slugify table-name) 0 acceptable-length)]
+    (str truncated-name-without-time
          (t/format time-format (t/local-date-time)))))
 
+(def max-sample-rows "Maximum number of values to use for detecting a column's type" 1000)
+
+(defn- sample-rows
+  "Returns an improper subset of the rows no longer than [[max-sample-rows]]. Takes an evenly-distributed sample (not
+  just the first n)."
+  [rows]
+  (take max-sample-rows (take-nth (max 1 (long (/ (count rows) max-sample-rows)))
+                                  rows)))
 (defn detect-schema
   "Returns an ordered map of `normalized-column-name -> type` for the given CSV file. The CSV file *must* have headers as the
   first row. Supported types are:
@@ -216,7 +226,7 @@
   [csv-file]
   (with-open [reader (io/reader csv-file)]
     (let [[header & rows] (csv/read-csv reader)]
-      (rows->schema header rows))))
+      (rows->schema header (sample-rows rows)))))
 
 (defn load-from-csv
   "Loads a table from a CSV file. If the table already exists, it will throw an error. Returns nil."

--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -129,9 +129,9 @@
   necessary."
   [names-so-far new-name]
   (if (some #(= % new-name) names-so-far)
-    (if-let [dupe-number (second (re-matches #".*-duplicate-(\d+)" new-name))]
+    (if-let [dupe-number (second (re-matches #".*-(\d+)" new-name))]
       (recur names-so-far (str/replace new-name #"-\d+$" (str "-" (inc (parse-long dupe-number)))))
-      (recur names-so-far (str new-name "-duplicate-1")))
+      (recur names-so-far (str new-name "-1")))
     (conj names-so-far new-name)))
 
 (defn- rows->schema

--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -117,9 +117,16 @@
   [n values]
   (first (partition n n (repeat nil) values)))
 
+(defn- normalize-column-name
+  [[raw-name index]]
+  (let [normalized (u/slugify (str/trim raw-name))]
+    (if-not (str/blank? normalized)
+      normalized
+      (format "unnamed-column-%s" (inc index)))))
+
 (defn- rows->schema
   [header rows]
-  (let [normalized-header (map (comp u/slugify str/trim) header)
+  (let [normalized-header (map normalize-column-name (map vector header (range)))
         column-count      (count normalized-header)]
     (->> rows
          (map row->types)

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -2561,7 +2561,7 @@
           ;; create not_public schema in the db
           (let [details (mt/dbdef->connection-details driver/*driver* :db {:database-name (:name (mt/db))})]
             (jdbc/execute! (sql-jdbc.conn/connection-details->spec driver/*driver* details)
-                           ["CREATE SCHEMA not_public;"]))
+                           ["CREATE SCHEMA \"not_public\";"]))
           (mt/with-temporary-setting-values [uploads-enabled      true
                                              uploads-database-id  db-id
                                              uploads-schema-name  "not_public"

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -281,10 +281,11 @@
                         card-3 :rasta]
         (with-cards-in-readable-collection [card-1 card-2 card-3 card-4]
           (testing "\nShould return cards that were recently viewed by current user only"
-            (is (= ["Card 3"
-                    "Card 4"
-                    "Card 1"]
-                   (map :name (mt/user-http-request :rasta :get 200 "card", :f :recent))))))))))
+            (let [recent-card-names (->> (mt/user-http-request :rasta :get 200 "card", :f :recent)
+                                         (map :name)
+                                         (filter #{"Card 1" "Card 2" "Card 3" "Card 4"}))]
+              (is (= ["Card 3" "Card 4" "Card 1"]
+                     recent-card-names)))))))))
 
 (deftest filter-by-popular-test
   (testing "GET /api/card?f=popular"
@@ -300,9 +301,12 @@
         (with-cards-in-readable-collection [card-1 card-2 card-3]
           (testing (str "`f=popular` should return cards sorted by number of ViewLog entries for all users; cards with "
                         "no entries should be excluded")
-            (is (= ["Card 3"
-                    "Card 2"]
-                   (map :name (mt/user-http-request :rasta :get 200 "card", :f :popular))))))))))
+            (let [popular-card-names (->> (mt/user-http-request :rasta :get 200 "card", :f :popular)
+                                          (map :name)
+                                          (filter #{"Card 1" "Card 2" "Card 3"}))]
+              (is (= ["Card 3"
+                      "Card 2"]
+                     popular-card-names)))))))))
 
 (deftest filter-by-archived-test
   (testing "GET /api/card?f=archived"

--- a/test/metabase/upload_test.clj
+++ b/test/metabase/upload_test.clj
@@ -347,7 +347,7 @@
           (let [table (t2/select-one Table :db_id (mt/id))]
             (is (=? {:name #"(?i)upload_test"} table))
             (testing "Check the data was uploaded into the table correctly"
-              (is (= ["unnamed_column_1", "ship_name", "unnamed_column_3"]
+              (is (= ["unnamed_column", "ship_name", "unnamed_column_2"]
                      (column-names-for-table table))))))))))
 
 (deftest load-from-csv-duplicate-names-test
@@ -358,15 +358,15 @@
          driver/*driver*
          (mt/id)
          "upload_test"
-         (csv-file-with ["unknown,unknown,unknown"
-                         "1,Serenity,Malcolm Reynolds"
-                         "2,Millennium Falcon, Han Solo"]))
+         (csv-file-with ["unknown,unknown,unknown,unknown_2"
+                         "1,Serenity,Malcolm Reynolds,Pistol"
+                         "2,Millennium Falcon, Han Solo,Blaster"]))
         (testing "Table and Fields exist after sync"
           (sync/sync-database! (mt/db))
           (let [table (t2/select-one Table :db_id (mt/id))]
             (is (=? {:name #"(?i)upload_test"} table))
             (testing "Check the data was uploaded into the table correctly"
-              (is (= ["unknown", "unknown_1", "unknown_2"]
+              (is (= ["unknown", "unknown_2", "unknown_3", "unknown_2_2"]
                      (column-names-for-table table))))))))))
 
 (deftest load-from-csv-reserved-db-words-test

--- a/test/metabase/upload_test.clj
+++ b/test/metabase/upload_test.clj
@@ -170,10 +170,11 @@
                             "2022-02-01,2023-02-29,2022-01-01T00:00:00,2023-02-29T00:00:00"]))))))
 
 (deftest unique-table-name-test
-  (testing "File name is slugified"
-    (is (=? #"my_file_name_\d+" (#'upload/unique-table-name "my file name"))))
-  (testing "semicolons are removed"
-    (is (nil? (re-find #";" (#'upload/unique-table-name "some text; -- DROP TABLE.csv"))))))
+  (mt/test-driver (mt/normal-drivers-with-feature :uploads)
+    (testing "File name is slugified"
+      (is (=? #"my_file_name_\d+" (#'upload/unique-table-name driver/*driver* "my file name"))))
+    (testing "semicolons are removed"
+      (is (nil? (re-find #";" (#'upload/unique-table-name driver/*driver* "some text; -- DROP TABLE.csv")))))))
 
 (deftest load-from-csv-table-name-test
   (testing "Upload a CSV file"

--- a/test/metabase/upload_test.clj
+++ b/test/metabase/upload_test.clj
@@ -367,7 +367,7 @@
               (let [col-names (->> (mt/run-mbql-query upload_test)
                                    (mt/cols)
                                    (map :name))]
-                (is (= ["unknown", "unknown_duplicate_1", "unknown_duplicate_2"]
+                (is (= ["unknown", "unknown_1", "unknown_2"]
                        col-names))))))))))
 
 (deftest load-from-csv-failed-test

--- a/test/metabase/upload_test.clj
+++ b/test/metabase/upload_test.clj
@@ -8,6 +8,7 @@
    [metabase.sync :as sync]
    [metabase.test :as mt]
    [metabase.upload :as upload]
+   [metabase.util :as u]
    [toucan2.core :as t2])
   (:import
    [java.io File]))
@@ -345,7 +346,7 @@
                                    (mt/cols)
                                    (map :name))]
                 (is (= ["unnamed_column_1", "ship_name", "unnamed_column_3"]
-                       col-names))))))))))
+                       (map u/lower-case-en col-names)))))))))))
 
 (deftest load-from-csv-duplicate-names-test
   (testing "Upload a CSV file with duplicate column names"


### PR DESCRIPTION
Fixes #30181 , which is just working through this list of problem CSVs: https://www.notion.so/metabase/9b4b30602feb40d7bb8405b1bdb76b75?v=a83d09fef7254d5b8ba796111c1f647d&p=c32a6331281d492fba06cef0539ef865&pm=s

There are three main problems:

* We were barfing on blank columns. This now replaces blank column names with `Unnamed Column X` (where `X` is the index of the column)
* Very long filenames were causing issues since the DB would silently truncate them and our `(t2/select Table :name the-name-we-provided)` was breaking. There were several ways I could've gone on this, but I opted to truncate the table name ourselves (so we can pretend we control it). There are of course different length limits for different DB engines :facepalm: . 
* Duplicate column names were causing problems. We now rename `foo, foo, foo` to `foo, foo-1, foo-2`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30219)
<!-- Reviewable:end -->
