### PR TITLE
Mark MLv1 limit methods as deprecated

### DIFF
--- a/frontend/src/metabase-lib/queries/StructuredQuery.ts
+++ b/frontend/src/metabase-lib/queries/StructuredQuery.ts
@@ -1103,17 +1103,26 @@ class StructuredQueryInner extends AtomicQuery {
   }
 
   // LIMIT
+  /**
+   * @deprecated use metabase-lib v2's currentLimit function
+   */
   limit(): Limit {
     const query = this.getMLv2Query();
     return ML.currentLimit(query);
   }
 
+  /**
+   * @deprecated use metabase-lib v2's limit function
+   */
   updateLimit(limit: Limit) {
     const query = this.getMLv2Query();
     const nextQuery = ML.limit(query, limit);
     return this.updateWithMLv2(nextQuery);
   }
 
+  /**
+   * @deprecated use metabase-lib v2's limit function
+   */
   clearLimit() {
     return this.updateLimit(null);
   }


### PR DESCRIPTION
Marks `StructuredQuery` limit methods as deprecated. Some methods were removed in #29618, but a few of them are still used in more complex methods or in places that would require more effort to be ported to MLv2. For now, this PR marks them as deprecated

⚠️ Using `[skip ci]` here

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30227)
<!-- Reviewable:end -->
