### PR TITLE
Notify slack of failing CI on master or release branches

### DIFF
--- a/.github/workflows/rerun-workflows.yml
+++ b/.github/workflows/rerun-workflows.yml
@@ -19,6 +19,10 @@ jobs:
           echo "View the failed run attempt (#${{ github.event.workflow_run.run_attempt }}) using the following link:" >> $GITHUB_STEP_SUMMARY
           echo "${{ github.event.workflow_run.html_url }}" >> $GITHUB_STEP_SUMMARY
 
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '16'
+      - run: npm install @slack/web-api
       - name: Trigger a re-run
         uses: actions/github-script@v6
         with:
@@ -26,10 +30,67 @@ jobs:
             const MAX_ATTEMPTS = 2;
             const ATTEMPT = ${{ github.event.workflow_run.run_attempt }};
 
+            const breaker = `@${context.actor}`;
+            const breaking_commit = context.sha;
+            const branch = context.ref;
+
             if (ATTEMPT <= MAX_ATTEMPTS) {
               github.rest.actions.reRunWorkflowFailedJobs({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 run_id: ${{ github.event.workflow_run.id }},
+              });
+            } else {
+              // notify slack of repeated failure
+              const WebClient = require('@slack/web-api');
+              const slack = new WebClient(${{ secrets.SLACK_BOT_TOKEN }});
+
+              await slack.chat.postMessage({
+                channel: 'engineering',
+                blocks: [
+                  {
+                    "type": "header",
+                    "text": {
+                      "type": "plain_text",
+                      "text": `:alert: CI is failing on ${branch} :alert:`,
+                      "emoji": true,
+                    }
+                  },
+                ],
+                attachments: [{
+                  color: '#f85149',
+                  blocks: [
+                    {
+                      "type": "section",
+                      "text": {
+                        "type": "mrkdwn",
+                        "text": `Commit <https://github.com/metabase/metabase/commit/${breaking_commit}|${breaking_commit.slice(-6)}> by ${breaker} has failing tests on the \`${branch}\` branch . :sad-panda:\nPlease fix ASAP. Emoji this message when it's fixed.`
+                      }
+                    },
+                    {
+                      "type": "actions",
+                      "elements": [
+                        {
+                          "type": "button",
+                          "text": {
+                            "type": "plain_text",
+                            "text": "Failing Commit",
+                            "emoji": true
+                          },
+                          "url": `https://github.com/metabase/metabase/commit/${breaking_commit}`
+                        },
+                        {
+                          "type": "button",
+                          "text": {
+                            "type": "plain_text",
+                            "text": "Recent commits to master",
+                            "emoji": true
+                          },
+                          "url": `https://github.com/metabase/metabase/commits/${branch}`
+                        }
+                      ]
+                    }
+                  ]
+                }]
               });
             }

--- a/.github/workflows/rerun-workflows.yml
+++ b/.github/workflows/rerun-workflows.yml
@@ -30,7 +30,7 @@ jobs:
             const MAX_ATTEMPTS = 2;
             const ATTEMPT = ${{ github.event.workflow_run.run_attempt }};
 
-            const breaker = `@${context.actor}`;
+            const author = `@${context.actor}`;
             const breaking_commit = context.sha;
             const branch = context.ref;
 
@@ -46,7 +46,7 @@ jobs:
               const slack = new WebClient(${{ secrets.SLACK_BOT_TOKEN }});
 
               await slack.chat.postMessage({
-                channel: 'engineering',
+                channel: 'engineering-ci',
                 blocks: [
                   {
                     "type": "header",
@@ -64,7 +64,7 @@ jobs:
                       "type": "section",
                       "text": {
                         "type": "mrkdwn",
-                        "text": `Commit <https://github.com/metabase/metabase/commit/${breaking_commit}|${breaking_commit.slice(-6)}> by ${breaker} has failing tests on the \`${branch}\` branch . :sad-panda:\nPlease fix ASAP. Emoji this message when it's fixed.`
+                        "text": `Commit <https://github.com/metabase/metabase/commit/${breaking_commit}|${breaking_commit.slice(0,7)}> by ${author} has failing tests on the \`${branch}\` branch . :sad-panda:\nPlease fix ASAP. Emoji this message when it's fixed.`
                       }
                     },
                     {


### PR DESCRIPTION
## Problem

Sometimes, we have CI failures on our master or release branches after merge, even when all CI checks were green on the feature branch. This can have a few causes:

1. Unmerged changes from the upstream branch caused bugs in conjunction with the feature branch,
2. Sometimes git merge logic just doesn't merge things correctly,
3. Sometimes our CI test are flaky.

Currently, we rely entirely on the diligence of @nemanjaglumac to regularly manually check the CI status on these branches, to figure out if there is a failure, and determine its cause.  This is not a sustainable system. Usually, the developer who made the change has the best context to determine what, if anything, is wrong with the merge commit, but it's also unreasonable for all developer to constantly be manually scanning the master and release branches for failures.

## Solution

This is an experiment, but this amends our failure-retry script (which only runs on master and release branches) and will send a message to the #engineering channel in slack if, after 2 retries, a CI workflow is still failing on master or a release branch.

![Screen Shot 2023-04-19 at 3 18 48 PM](https://user-images.githubusercontent.com/30528226/233204167-5214b725-4710-4394-992b-2105361a27c1.png)

The notification is intentionally VERY noisy, because once one bad commit gets into master, they're all going to be red, so we need people to jump in and get things fixed immediately.

## Limitations

- currently, we cannot actually @tag people's names in slack, because on the github side we will only have the commiter's github user id, which is likely different than their name in slack. 
- we could potentially get multiple failure messages if the same commit fails multiple check suites (e.g. 

## Todo before launch

- [x] Someone with access to our repo secrets needs to add the slack bot token as `SLACK_BOT_TOKEN`
- [x] I'll need to invite the bot to the engineering slack channel

## Potential future improvements

This little notification could get much fancier, but let's see how the simple version works first. Most of these enhancements involve having a persistent backend service (just a little node.js VM) running.

- We could possibly make a couple additional API calls to attempt some fuzzy matching between github user names and slack user names to get real @mentions.
- If we had a persistent  backend , we could set up return webhooks for our slack app, and could mark notifications as resolved in slack via button/dropdown/checkbox - we could even add resolution notes, etc.
- If we had a persistent backend, we could also cache information about failing commits and ensure that only 1 message per commit got sent
- With a persistent backend and resolution tracking we could only notify on the first commit in a chain of failures until the first known-bad commit is marked resolved.
- We could embed a random rotation of alarming GIFs in the slack message to make sure that we get peoples' attention

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30244)
<!-- Reviewable:end -->
