### PR TITLE
[E2E] Fix question moderation flake

### DIFF
--- a/e2e/test/scenarios/organization/moderation-question.cy.spec.js
+++ b/e2e/test/scenarios/organization/moderation-question.cy.spec.js
@@ -147,7 +147,7 @@ function verifyQuestion() {
   openQuestionActions();
   cy.findByTextEnsureVisible("Verify this question").click();
 
-  cy.wait("@loadCard").should(({ response: { body } }) => {
+  cy.wait("@loadCard").then(({ response: { body } }) => {
     const { moderation_reviews } = body;
 
     /**


### PR DESCRIPTION
Flaky run
https://www.deploysentinel.com/ci/runs/64411039bf53614f32e1fcdd


> CypressError: `cy.should()` failed because you invoked a command inside the callback. `cy.should()` retries the inner function, which would result in commands being added to the queue multiple times. Use `cy.then()` instead of `cy.should()`, or move any commands outside the callback function.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30252)
<!-- Reviewable:end -->
