### PR TITLE
Fix apply button showing up unnecessarily

### DIFF
--- a/e2e/test/scenarios/dashboard-filters/old-parameters.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/old-parameters.cy.spec.js
@@ -4,6 +4,8 @@ import {
   visitDashboard,
   rightSidebar,
   filterWidget,
+  editDashboard,
+  saveDashboard,
 } from "e2e/support/helpers";
 // NOTE: some overlap with parameters-embedded.cy.spec.js
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
@@ -79,11 +81,11 @@ describe("scenarios > dashboard > OLD parameters", () => {
       cy.findByText("Doohickey").should("not.exist");
 
       // test prevent auto-apply filters in slow dashboards metabase#29267
-      openDashboardSidebar();
+      toggleDashboardSidebar();
 
       filterWidget().findByText("Gadget").should("be.visible");
       rightSidebar().findByLabelText("Auto-apply filters").click();
-      filterWidget().button("Apply").should("not.exist");
+      cy.button("Apply").should("not.exist");
 
       cy.button("Category").click();
       popover().within(() => {
@@ -94,6 +96,26 @@ describe("scenarios > dashboard > OLD parameters", () => {
       cy.findByText("Rows 1-6 of 200").should("be.visible");
       cy.button("Apply").click();
       cy.findByText("Rows 1-6 of 53").should("be.visible");
+
+      // test that the apply button won't showup even when adding a new parameter or removing existing ones
+      toggleDashboardSidebar();
+      editDashboard();
+      cy.icon("filter").click();
+      popover().within(() => {
+        cy.findByText("Text or Category").click();
+        cy.findByText("Is").click();
+      });
+
+      saveDashboard();
+      cy.button("Apply").should("not.exist");
+
+      editDashboard();
+      cy.findByText("Text").within(() => {
+        cy.icon("gear").click();
+      });
+      cy.button("Remove").click();
+      saveDashboard();
+      cy.button("Apply").should("not.exist");
     });
   });
 
@@ -226,7 +248,7 @@ describe("scenarios > dashboard > OLD parameters", () => {
   });
 });
 
-function openDashboardSidebar() {
+function toggleDashboardSidebar() {
   cy.get("main header").within(() => {
     cy.icon("info").click();
   });

--- a/frontend/src/metabase/core/components/Button/Button.styled.tsx
+++ b/frontend/src/metabase/core/components/Button/Button.styled.tsx
@@ -10,6 +10,12 @@ export interface ButtonRootProps {
 export const ButtonRoot = styled.button<ButtonRootProps>`
   transition: all 200ms linear;
   flex-shrink: 0;
+  @media (prefers-reduced-motion) {
+    &,
+    &:hover {
+      transition: none;
+    }
+  }
 
   ${({ purple }) =>
     purple &&

--- a/frontend/src/metabase/dashboard/actions/data-fetching.js
+++ b/frontend/src/metabase/dashboard/actions/data-fetching.js
@@ -207,6 +207,7 @@ export const fetchDashboard = createThunkAction(
 
       return {
         ...normalize(result, dashboard), // includes `result` and `entities`
+        dashboard: result,
         dashboardId: dashId,
         parameterValues: parameterValuesById,
       };

--- a/frontend/src/metabase/dashboard/reducers.js
+++ b/frontend/src/metabase/dashboard/reducers.js
@@ -317,6 +317,15 @@ const draftParameterValues = handleActions(
         return state;
       },
     },
+    [FETCH_DASHBOARD]: {
+      next: (state, { payload }) => {
+        if (payload.dashboard.auto_apply_filters) {
+          return state;
+        }
+
+        return payload.parameterValues;
+      },
+    },
     [RESET]: { next: _state => ({}) },
     [Dashboards.actionTypes.UPDATE]: {
       next: (state, { payload }) => {


### PR DESCRIPTION
Part of the epic: https://github.com/metabase/metabase/issues/29267

### Description

This addressed the first issue in this comment: https://github.com/metabase/metabase/pull/30232#issuecomment-151541970

The second issue about the toast isn't directly tied to this feature, since that's how the toast is behaving. i.e. This feature doesn't change the way the toast show up yet.

The problem came from when we add or remove a aparmeter, we will update and fetch the dashboard, and that cause `dashboard.parameterValues` to be reset, so we need to make sure `draftParameterValues` are in sync with that, so we don't show the apply button unnecessarily.

### How to verify

Follow the steps in this comment: https://github.com/metabase/metabase/pull/30232#issuecomment-151541970

or

Run E2E tests in `e2e/test/scenarios/dashboard-filters/old-parameters.cy.spec.js`


### Checklist

- [X] Tests have been added/updated to cover changes in this PR

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30255)
<!-- Reviewable:end -->
