### PR TITLE
Move question's `apiGetResults` method from metabase-lib

### DIFF
--- a/frontend/src/metabase-types/api/database.ts
+++ b/frontend/src/metabase-types/api/database.ts
@@ -25,7 +25,11 @@ export type DatabaseFeature =
   | "standard-deviation-aggregations"
   | "persist-models"
   | "persist-models-enabled"
-  | "set-timezone";
+  | "set-timezone"
+  | "left-join"
+  | "right-join"
+  | "inner-join"
+  | "full-join";
 
 export interface Database extends DatabaseData {
   id: DatabaseId;

--- a/frontend/src/metabase-types/api/mocks/database.ts
+++ b/frontend/src/metabase-types/api/mocks/database.ts
@@ -12,6 +12,10 @@ export const COMMON_DATABASE_FEATURES: DatabaseFeature[] = [
   "nested-queries",
   "standard-deviation-aggregations",
   "persist-models",
+  "left-join",
+  "right-join",
+  "inner-join",
+  "full-join",
 ];
 
 export const createMockDatabase = (opts?: Partial<Database>): Database => ({

--- a/frontend/src/metabase/containers/QuestionResultLoader.jsx
+++ b/frontend/src/metabase/containers/QuestionResultLoader.jsx
@@ -2,6 +2,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { defer } from "metabase/lib/promise";
+import { runQuestionQuery } from "metabase/services";
 
 const propTypes = {
   question: PropTypes.object,
@@ -47,9 +48,6 @@ export class QuestionResultLoader extends React.Component {
     }
   }
 
-  /*
-   * load the result by calling question.apiGetResults
-   */
   async _loadResult(question, onLoad, keepPreviousWhileLoading) {
     const { collectionPreview } = this.props;
 
@@ -66,8 +64,7 @@ export class QuestionResultLoader extends React.Component {
           error: null,
         }));
 
-        // call apiGetResults and pass our cancel to allow for cancelation
-        const results = await question.apiGetResults({
+        const results = await runQuestionQuery(question, {
           cancelDeferred: this._cancelDeferred,
           collectionPreview,
         });

--- a/frontend/src/metabase/metabot/actions.ts
+++ b/frontend/src/metabase/metabot/actions.ts
@@ -1,5 +1,8 @@
 import { createAction } from "redux-actions";
-import { MetabotApi } from "metabase/services";
+import {
+  MetabotApi,
+  runQuestionQuery as apiRunQuestionQuery,
+} from "metabase/services";
 import { closeNavbar } from "metabase/redux/app";
 import { MetabotFeedbackType } from "metabase-types/api";
 import {
@@ -128,7 +131,7 @@ export const fetchQueryResults =
   (cancelQueryDeferred: Deferred) =>
   async (dispatch: Dispatch, getState: GetState) => {
     const question = getQuestion(getState());
-    const payload = await question?.apiGetResults({
+    const payload = await apiRunQuestionQuery(question, {
       cancelDeferred: cancelQueryDeferred,
     });
     dispatch({ type: FETCH_QUERY_RESULTS, payload });

--- a/frontend/src/metabase/query_builder/actions/querying.js
+++ b/frontend/src/metabase/query_builder/actions/querying.js
@@ -6,6 +6,7 @@ import * as MetabaseAnalytics from "metabase/lib/analytics";
 import { startTimer } from "metabase/lib/performance";
 import { defer } from "metabase/lib/promise";
 import { createThunkAction } from "metabase/lib/redux";
+import { runQuestionQuery as apiRunQuestionQuery } from "metabase/services";
 
 import { getMetadata } from "metabase/selectors/metadata";
 import { getSensibleDisplays } from "metabase/visualizations";
@@ -124,12 +125,11 @@ export const runQuestionQuery = ({
 
     const queryTimer = startTimer();
 
-    question
-      .apiGetResults({
-        cancelDeferred: cancelQueryDeferred,
-        ignoreCache: ignoreCache,
-        isDirty: cardIsDirty,
-      })
+    apiRunQuestionQuery(question, {
+      cancelDeferred: cancelQueryDeferred,
+      ignoreCache: ignoreCache,
+      isDirty: cardIsDirty,
+    })
       .then(queryResults => {
         queryTimer(duration =>
           MetabaseAnalytics.trackStructEvent(

--- a/frontend/src/metabase/services.unit.spec.ts
+++ b/frontend/src/metabase/services.unit.spec.ts
@@ -4,7 +4,12 @@ import { createEntitiesState } from "__support__/store";
 import { defer } from "metabase/lib/promise";
 import { getMetadata } from "metabase/selectors/metadata";
 
-import type { Card, UnsavedCard } from "metabase-types/api";
+import type {
+  Card,
+  DashboardId,
+  DashCardId,
+  UnsavedCard,
+} from "metabase-types/api";
 import {
   createMockCard,
   createMockUnsavedCard,
@@ -40,7 +45,12 @@ function createMockMetadata(card?: Card) {
   return getMetadata(state);
 }
 
-function createMockSavedQuestion(card?: Partial<Card>) {
+type DashboardAwareCard = Card & {
+  dashboardId?: DashboardId;
+  dashcardId?: DashCardId;
+};
+
+function createMockSavedQuestion(card?: Partial<DashboardAwareCard>) {
   const savedCard = createMockCard({ dataset_query: MOCK_QUERY, ...card });
   return createMockMetadata(savedCard).question(savedCard.id) as Question;
 }

--- a/frontend/src/metabase/services.unit.spec.ts
+++ b/frontend/src/metabase/services.unit.spec.ts
@@ -1,0 +1,189 @@
+import fetchMock from "fetch-mock";
+import { createEntitiesState } from "__support__/store";
+
+import { defer } from "metabase/lib/promise";
+import { getMetadata } from "metabase/selectors/metadata";
+
+import type { Card, UnsavedCard } from "metabase-types/api";
+import {
+  createMockCard,
+  createMockUnsavedCard,
+  createMockDataset,
+  createMockStructuredDatasetQuery,
+} from "metabase-types/api/mocks";
+import {
+  createSampleDatabase,
+  ORDERS_ID,
+  SAMPLE_DB_ID,
+} from "metabase-types/api/mocks/presets";
+import { createMockState } from "metabase-types/store/mocks";
+
+import Question from "metabase-lib/Question";
+
+import { runQuestionQuery } from "./services";
+
+const MOCK_QUERY = createMockStructuredDatasetQuery({
+  database: SAMPLE_DB_ID,
+  query: {
+    "source-table": ORDERS_ID,
+  },
+});
+
+function createMockMetadata(card?: Card) {
+  const database = createSampleDatabase();
+  const state = createMockState({
+    entities: createEntitiesState({
+      databases: [database],
+      questions: card ? [card] : [],
+    }),
+  });
+  return getMetadata(state);
+}
+
+function createMockSavedQuestion(card?: Partial<Card>) {
+  const savedCard = createMockCard({ dataset_query: MOCK_QUERY, ...card });
+  return createMockMetadata(savedCard).question(savedCard.id) as Question;
+}
+
+function createMockAdHocQuestion(card?: Partial<UnsavedCard>) {
+  const unsavedCard = createMockUnsavedCard({
+    dataset_query: MOCK_QUERY,
+    ...card,
+  });
+  return new Question(unsavedCard, createMockMetadata());
+}
+
+function getQueryEndpointPath(question: Question) {
+  const isPivot = question.display() === "pivot";
+  const { dashboardId, dashcardId } = question.card();
+  const isDashboard = dashboardId != null && dashcardId != null;
+
+  if (!question.isSaved()) {
+    return isPivot ? "path:/api/dataset/pivot" : "path:/api/dataset";
+  }
+
+  const id = question.id();
+
+  if (isDashboard) {
+    return isPivot
+      ? `path:/api/dashboard/pivot/${dashboardId}/dashcard/${dashcardId}/card/${id}/query`
+      : `path:/api/dashboard/${dashboardId}/dashcard/${dashcardId}/card/${id}/query`;
+  }
+
+  return isPivot
+    ? `path:/api/card/pivot/${question.id()}/query`
+    : `path:/api/card/${question.id()}/query`;
+}
+
+async function setupRunQuestionQuery(question: Question) {
+  const mockResult = createMockDataset();
+  fetchMock.post(getQueryEndpointPath(question), mockResult);
+  const result = await runQuestionQuery(question, { cancelDeferred: defer() });
+  return { result, mockResult };
+}
+
+describe("metabase/services > runQuestionQuery", () => {
+  describe("saved questions", () => {
+    it("should use the card query endpoint", async () => {
+      const question = createMockSavedQuestion();
+
+      await setupRunQuestionQuery(question);
+
+      const call = fetchMock.lastCall(`path:/api/card/${question.id()}/query`);
+      expect(await call?.request?.json()).toEqual({
+        collection_preview: false,
+        ignore_cache: false,
+        parameters: [],
+      });
+    });
+
+    it("should return query results", async () => {
+      const question = createMockSavedQuestion();
+      const { result, mockResult } = await setupRunQuestionQuery(question);
+      expect(result).toEqual([mockResult]);
+    });
+
+    it("should use the pivot endpoint for pivot tables", async () => {
+      const question = createMockSavedQuestion({ display: "pivot" });
+      await setupRunQuestionQuery(question);
+      const call = fetchMock.lastCall(
+        `path:/api/card/pivot/${question.id()}/query`,
+      );
+      expect(await call?.request?.json()).toEqual({
+        collection_preview: false,
+        ignore_cache: false,
+        parameters: [],
+      });
+    });
+
+    it("should use the dashboard card query endpoint in dashboard context", async () => {
+      const dashboardId = 2;
+      const dashcardId = 3;
+      const question = createMockSavedQuestion({ dashboardId, dashcardId });
+
+      await setupRunQuestionQuery(question);
+
+      const call = fetchMock.lastCall(
+        `path:/api/dashboard/${dashboardId}/dashcard/${dashcardId}/card/${question.id()}/query`,
+      );
+      expect(await call?.request?.json()).toEqual({
+        collection_preview: false,
+        ignore_cache: false,
+        parameters: [],
+      });
+    });
+
+    it("should use the dashboard pivot card query endpoint in dashboard context", async () => {
+      const dashboardId = 2;
+      const dashcardId = 3;
+      const question = createMockSavedQuestion({
+        dashboardId,
+        dashcardId,
+        display: "pivot",
+      });
+
+      await setupRunQuestionQuery(question);
+
+      const call = fetchMock.lastCall(
+        `path:/api/dashboard/pivot/${dashboardId}/dashcard/${dashcardId}/card/${question.id()}/query`,
+      );
+      expect(await call?.request?.json()).toEqual({
+        collection_preview: false,
+        ignore_cache: false,
+        parameters: [],
+      });
+    });
+  });
+
+  describe("ad-hoc questions", () => {
+    it("should use the dataset endpoint", async () => {
+      const question = createMockAdHocQuestion();
+
+      await setupRunQuestionQuery(question);
+
+      const call = fetchMock.lastCall("path:/api/dataset");
+      expect(await call?.request?.json()).toEqual({
+        ...question.datasetQuery(),
+        parameters: [],
+      });
+    });
+
+    it("should use the pivot dataset endpoint", async () => {
+      const question = createMockAdHocQuestion({ display: "pivot" });
+
+      await setupRunQuestionQuery(question);
+
+      const call = fetchMock.lastCall("path:/api/dataset/pivot");
+      expect(await call?.request?.json()).toEqual({
+        ...question.datasetQuery(),
+        parameters: [],
+      });
+    });
+
+    it("should return query results", async () => {
+      const question = createMockAdHocQuestion();
+      const { result, mockResult } = await setupRunQuestionQuery(question);
+      expect(result).toEqual([mockResult]);
+    });
+  });
+});


### PR DESCRIPTION
Epic #28034, #30237

Communicating with the server shouldn't be metabase-lib's concern, so this PR extracts the `Question's` `apiGetResults` method and moves it to a dedicated function in `metabase/services`.

### How to verify

🟢 CI should be green 🟢

### Checklist

- [x] Tests have been added/updated to cover changes in this PR

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30257)
<!-- Reviewable:end -->
