### PR TITLE
Fix inlined number params in native queries

### DIFF
--- a/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
+++ b/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
@@ -26,8 +26,6 @@
    [metabase.util :as u]
    [metabase.util.date-2 :as u.date]
    [metabase.util.honey-sql-2 :as h2x]
-   #_{:clj-kondo/ignore [:discouraged-namespace]}
-   [metabase.util.honeysql-extensions :as hx]
    [metabase.util.i18n :refer [trs tru]]
    [metabase.util.log :as log]
    [ring.util.codec :as codec])

--- a/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
+++ b/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
@@ -383,7 +383,7 @@
   (sql-jdbc/query driver database {:select [:*]
                                    :from   [[(qp.store/with-store
                                                (qp.store/fetch-and-store-database! (u/the-id database))
-                                               (binding [hx/*honey-sql-version* (sql.qp/honey-sql-version driver)]
+                                               (sql.qp/with-driver-honey-sql-version driver
                                                  (sql.qp/->honeysql driver table)))]]}))
 
 (defmethod driver/describe-database :snowflake [driver database]

--- a/src/metabase/driver/sql/parameters/substitution.clj
+++ b/src/metabase/driver/sql/parameters/substitution.clj
@@ -71,7 +71,7 @@
 
 (s/defmethod ->prepared-substitution [:sql Number] :- PreparedStatementSubstitution
   [driver num]
-  (honeysql->prepared-stmt-subs driver (sql.qp/inline-num num)))
+  (honeysql->prepared-stmt-subs driver (sql.qp/with-driver-honey-sql-version driver (sql.qp/inline-num num))))
 
 (s/defmethod ->prepared-substitution [:sql Boolean] :- PreparedStatementSubstitution
   [driver b]

--- a/src/metabase/driver/sql/parameters/substitution.clj
+++ b/src/metabase/driver/sql/parameters/substitution.clj
@@ -251,7 +251,7 @@
    For non-date Fields, this is just a quoted identifier; for dates, the SQL includes appropriately bucketing based on
    the `param-type`."
   [driver field param-type]
-  (binding [hx/*honey-sql-version* (sql.qp/honey-sql-version driver)]
+  (sql.qp/with-driver-honey-sql-version driver
     (->> (field->clause driver field param-type)
          (sql.qp/->honeysql driver)
          (honeysql->replacement-snippet-info driver)
@@ -267,7 +267,7 @@
     (cond
       (params.ops/operator? param-type)
       (let [[snippet & args]
-            (binding [hx/*honey-sql-version* (sql.qp/honey-sql-version driver)]
+            (sql.qp/with-driver-honey-sql-version driver
               (as-> (assoc params :target [:template-tag (field->clause driver field param-type)]) form
                 (params.ops/to-clause form)
                 (mbql.u/desugar-filter-clause form)

--- a/src/metabase/driver/sql/parameters/substitution.clj
+++ b/src/metabase/driver/sql/parameters/substitution.clj
@@ -23,7 +23,6 @@
    [metabase.query-processor.util.add-alias-info :as add]
    [metabase.util :as u]
    [metabase.util.date-2 :as u.date]
-   [metabase.util.honeysql-extensions :as hx]
    [metabase.util.i18n :refer [tru]]
    [metabase.util.schema :as su]
    [schema.core :as s])

--- a/src/metabase/driver/sql/query_processor.clj
+++ b/src/metabase/driver/sql/query_processor.clj
@@ -108,6 +108,7 @@
 
 (defmacro with-driver-honey-sql-version
   "Evaluates body with the appropriate driver version of honey sql bound"
+  {:style/indent 1}
   [driver & body]
   `(binding [hx/*honey-sql-version* (honey-sql-version ~driver)]
      ~@body))

--- a/src/metabase/driver/sql/query_processor.clj
+++ b/src/metabase/driver/sql/query_processor.clj
@@ -106,6 +106,12 @@
     2
     1))
 
+(defmacro with-driver-honey-sql-version
+  "Evaluates body with the appropriate driver version of honey sql bound"
+  [driver & body]
+  `(binding [hx/*honey-sql-version* (honey-sql-version ~driver)]
+     ~@body))
+
 (defn inline-num
   "Wrap number `n` in `:inline` when targeting Honey SQL 2."
   {:added "0.46.0"}

--- a/src/metabase/driver/sql/util.clj
+++ b/src/metabase/driver/sql/util.clj
@@ -26,7 +26,7 @@
   SQL. For HoneySQL forms, `Identifier` is converted to SQL automatically when it is compiled."
   [driver :- s/Keyword identifier-type :- hx/IdentifierType & components]
   (first
-   (binding [hx/*honey-sql-version* (sql.qp/honey-sql-version driver)]
+   (sql.qp/with-driver-honey-sql-version driver
      (sql.qp/format-honeysql driver (apply hx/identifier identifier-type components)))))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+

--- a/src/metabase/driver/sql_jdbc.clj
+++ b/src/metabase/driver/sql_jdbc.clj
@@ -26,7 +26,7 @@
                (sql.qp/format-honeysql driver honeysql-form)))
 
   ([driver database table honeysql-form]
-   (let [table-identifier (binding [hx/*honey-sql-version* (sql.qp/honey-sql-version driver)]
+   (let [table-identifier (sql.qp/with-driver-honey-sql-version driver
                             (->> (hx/identifier :table (:schema table) (:name table))
                                  (sql.qp/->honeysql driver)
                                  sql.qp/maybe-wrap-unaliased-expr))]

--- a/src/metabase/driver/sql_jdbc/actions.clj
+++ b/src/metabase/driver/sql_jdbc/actions.clj
@@ -81,7 +81,7 @@
                      (let [col-name                         (u/qualified-name col-name)
                            {base-type :base_type :as field} (get column->field col-name)]
                        (if-let [sql-type (type->sql-type base-type)]
-                         (binding [hx/*honey-sql-version* (sql.qp/honey-sql-version driver)]
+                         (sql.qp/with-driver-honey-sql-version driver
                            (hx/cast sql-type value))
                          (try
                            (sql.qp/->honeysql driver [:value value field])

--- a/src/metabase/driver/sql_jdbc/sync/describe_database.clj
+++ b/src/metabase/driver/sql_jdbc/sync/describe_database.clj
@@ -52,7 +52,7 @@
    schema :- [:maybe :string] ; I think technically some DBs like SQL Server support empty schema and table names
    table  :- :string]
   ;; Using our SQL compiler here to get portable LIMIT (e.g. `SELECT TOP n ...` for SQL Server/Oracle)
-  (binding [hx/*honey-sql-version* (sql.qp/honey-sql-version driver)]
+  (sql.qp/with-driver-honey-sql-version driver
     (let [tru      (sql.qp/->honeysql driver true)
           table    (sql.qp/->honeysql driver (hx/identifier :table schema table))
           honeysql (case (long hx/*honey-sql-version*)

--- a/src/metabase/driver/sql_jdbc/sync/describe_table.clj
+++ b/src/metabase/driver/sql_jdbc/sync/describe_table.clj
@@ -62,7 +62,7 @@
   [driver schema table]
   {:pre [(string? table)]}
   ;; Using our SQL compiler here to get portable LIMIT (e.g. `SELECT TOP n ...` for SQL Server/Oracle)
-  (binding [hx/*honey-sql-version* (sql.qp/honey-sql-version driver)]
+  (sql.qp/with-driver-honey-sql-version driver
     (let [honeysql {:select [:*]
                     :from   [(sql.qp/maybe-wrap-unaliased-expr (sql.qp/->honeysql driver (hx/identifier :table schema table)))]
                     :where  [:not= (sql.qp/inline-num 1) (sql.qp/inline-num 1)]}
@@ -402,7 +402,7 @@
           json-fields           (filter #(isa? (:base-type %) :type/JSON) table-fields)]
       (if (nil? (seq json-fields))
         #{}
-        (binding [hx/*honey-sql-version* (sql.qp/honey-sql-version driver)]
+        (sql.qp/with-driver-honey-sql-version driver
           (let [json-field-names (mapv #(apply hx/identifier :field (into table-identifier-info [(:name %)])) json-fields)
                 table-identifier (apply hx/identifier :table table-identifier-info)
                 sql-args         (sql.qp/format-honeysql driver {:select (mapv sql.qp/maybe-wrap-unaliased-expr json-field-names)

--- a/test/metabase/driver/sql/query_processor_test.clj
+++ b/test/metabase/driver/sql/query_processor_test.clj
@@ -247,7 +247,7 @@
                                               :display_name  "ID"
                                               :fingerprint   nil
                                               :base_type     :type/Integer}))
-      (binding [hx/*honey-sql-version* (sql.qp/honey-sql-version driver)]
+      (sql.qp/with-driver-honey-sql-version driver
         (let [join (sql.qp/join->honeysql
                     driver
                     {:source-query {:native "SELECT * FROM VENUES;", :params []}
@@ -1052,7 +1052,7 @@
                    :friday
                    :saturday]]
         (metabase.test/with-temporary-setting-values [start-of-week day]
-          (binding [hx/*honey-sql-version* (sql.qp/honey-sql-version driver/*driver*)]
+          (sql.qp/with-driver-honey-sql-version driver/*driver*
             (let [sql-args (-> (sql.qp/format-honeysql driver/*driver* (sql.qp/date driver/*driver* :day-of-week :x))
                                vec
                                (update 0 #(str/split-lines (mdb.query/format-sql % driver/*driver*))))]

--- a/test/metabase/query_processor_test/date_bucketing_test.clj
+++ b/test/metabase/query_processor_test/date_bucketing_test.clj
@@ -905,7 +905,7 @@
                                  ;; TODO -- make 'insert-rows-using-statements?` a multimethod so we don't need to
                                  ;; hardcode the whitelist here.
                                  (not (#{:vertica :bigquery-cloud-sdk} driver/*driver*)))
-                          (binding [hx/*honey-sql-version* (sql.qp/honey-sql-version driver/*driver*)]
+                          (sql.qp/with-driver-honey-sql-version driver/*driver*
                             (sql.qp/compiled
                              (sql.qp/add-interval-honeysql-form driver/*driver*
                                                                 (sql.qp/current-datetime-honeysql-form driver/*driver*)
@@ -1263,7 +1263,7 @@
                           #t "2022-03-31T00:00:00"
                           #t "2022-03-31T00:00:00-00:00"]]
           (testing (format "%d %s ^%s %s" n unit (.getCanonicalName (class t)) (pr-str t))
-            (binding [hx/*honey-sql-version* (sql.qp/honey-sql-version driver/*driver*)]
+            (sql.qp/with-driver-honey-sql-version driver/*driver*
               (let [march-31     (sql.qp/->honeysql driver/*driver* [:absolute-datetime t :day])
                     june-31      (sql.qp/add-interval-honeysql-form driver/*driver* march-31 n unit)
                     checkins     (mt/with-everything-store

--- a/test/metabase/query_processor_test/parameters_test.clj
+++ b/test/metabase/query_processor_test/parameters_test.clj
@@ -373,3 +373,21 @@
               (is (some (fn [[_orders-id _orders-created-at _people-state people-name _people-source :as _row]]
                           (= people-name "Emilie Goyette"))
                         rows)))))))))
+
+(deftest inlined-number-test
+  (testing "Number parameters are inlined into the SQL query and not parameterized (#29690)"
+    (mt/dataset sample-dataset
+      (is (= {:query  "SELECT NOW() - INTERVAL '30 DAYS'"
+              :params []}
+             (qp/compile-and-splice-parameters
+              {:type       :native
+               :native     {:query         "SELECT NOW() - INTERVAL '{{n}} DAYS'"
+                            :template-tags {"n"
+                                            {:name         "n"
+                                             :display-name "n"
+                                             :type         :number}}}
+               :database   (mt/id)
+               :parameters [{:type :number
+                             :target [:variable [:template-tag "n"]]
+                             :slug "n"
+                             :value "30"}]}))))))

--- a/test/metabase/query_processor_test/parameters_test.clj
+++ b/test/metabase/query_processor_test/parameters_test.clj
@@ -195,7 +195,7 @@
 
     (testing "Comma-separated numbers"
       (is (= {:query  "SELECT * FROM VENUES WHERE \"PUBLIC\".\"VENUES\".\"PRICE\" IN (1, 2)"
-              :params nil}
+              :params []}
              (qp/compile-and-splice-parameters
               {:type       :native
                :native     {:query         "SELECT * FROM VENUES WHERE {{price}}"
@@ -232,7 +232,7 @@
 
     (testing "Multi-line comments"
       (is (= {:query  "SELECT * FROM VENUES WHERE\n/*\n{{ignoreme}}\n*/ \"PUBLIC\".\"VENUES\".\"PRICE\" IN (1, 2)"
-              :params nil}
+              :params []}
              (qp/compile-and-splice-parameters
               {:type       :native
                :native     {:query         "SELECT * FROM VENUES WHERE\n/*\n{{ignoreme}}\n*/ {{price}}"

--- a/test/metabase/query_processor_test/timezones_test.clj
+++ b/test/metabase/query_processor_test/timezones_test.clj
@@ -114,7 +114,7 @@
   "Map with different types of native params queries, used in test below. Key is a description of the type of native
   params in the query."
   []
-  (binding [hx/*honey-sql-version* (sql.qp/honey-sql-version driver/*driver*)]
+  (sql.qp/with-driver-honey-sql-version driver/*driver*
     {"variable w/ single date"
      {:native     {:query         (honeysql->sql
                                    {:select   (mapv #(sql.qp/maybe-wrap-unaliased-expr (field-identifier :users %))

--- a/test/metabase/test/data/sql/ddl.clj
+++ b/test/metabase/test/data/sql/ddl.clj
@@ -113,5 +113,5 @@
 
 (defmethod insert-rows-ddl-statements :sql/test-extensions
   [driver table-identifier row-or-rows]
-  (binding [hx/*honey-sql-version* (sql.qp/honey-sql-version driver)]
+  (sql.qp/with-driver-honey-sql-version driver
     [(sql.qp/format-honeysql driver (insert-rows-honeysql-form driver table-identifier row-or-rows))]))

--- a/test/metabase/test/data/sql_jdbc/load_data.clj
+++ b/test/metabase/test/data/sql_jdbc/load_data.clj
@@ -213,7 +213,7 @@
   "Default implementation of `create-db!` for SQL drivers."
   {:arglists '([driver dbdef & {:keys [skip-drop-db?]}])}
   [driver {:keys [table-definitions], :as dbdef} & options]
-  (binding [hx/*honey-sql-version* (sql.qp/honey-sql-version driver)]
+  (sql.qp/with-driver-honey-sql-version driver
     ;; first execute statements to drop the DB if needed (this will do nothing if `skip-drop-db?` is true)
     (doseq [statement (apply ddl/drop-db-ddl-statements driver dbdef options)]
       (execute/execute-sql! driver :server dbdef statement))


### PR DESCRIPTION
Native query parameters like in `...INTERVAL '{{days}} days'` were broken due to generating incorrect inlining forms for the HoneySQL version in-use. This PR fixes number parameter inlining and adds a `sql.qp/with-driver-honey-sql-version` macro and updates places where we previously bound `*honey-sql-version*` based on a driver.

Resolves #29690, resolves #30103

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30265)
<!-- Reviewable:end -->
