### PR TITLE
Using LLM for Model Inference

### DIFF
--- a/src/metabase/api/metabot.clj
+++ b/src/metabase/api/metabot.clj
@@ -80,7 +80,7 @@
         context {:database    (metabot-util/denormalize-database database)
                  :user_prompt question
                  :prompt_task :infer_model}]
-    (if-some [model (metabot/match-best-model context)]
+    (if-some [model (metabot/infer-model context)]
       (let [context (merge context {:model model :prompt_task :infer_sql})
             dataset (infer-sql-or-throw context question)]
         (add-viz-to-dataset context dataset))

--- a/test/metabase/api/metabot_test.clj
+++ b/test/metabase/api/metabot_test.clj
@@ -32,23 +32,23 @@
                               :type     :query
                               :query    {:source-table (mt/id :orders)}}
                              :dataset true}]
-         (let [bot-message (format
-                            "You should do ```SELECT COUNT(*) FROM %s``` to do that."
-                            (metabot-util/normalize-name (:name orders-model)))
-               bot-sql     (metabot-util/extract-sql bot-message)
-               q           "How many orders do I have?"]
-           (with-redefs [metabot-client/*create-chat-completion-endpoint* (fn [{:keys [prompt_template]} _]
-                                                                            (case (keyword prompt_template)
-                                                                              :infer_sql {:choices [{:message {:content bot-message}}]}
-                                                                              {:choices [{:message {:content "{}"}}]}))
-                         metabot-client/*create-embedding-endpoint*       metabot-test/throw-on-embedding
-                         metabot-util/*prompt-templates*                  (constantly metabot-test/test-prompt-templates)]
-             (let [response (mt/user-http-request :rasta :post 200
-                                                  (format "/metabot/model/%s" (:id orders-model))
-                                                  {:question q})
-                   {:keys [query template-tags]} (get-in response [:card :dataset_query :native])]
-               (is (true? (str/ends-with? query bot-sql)))
-               (is (contains? template-tags (keyword (str "#" (:id orders-model)))))))))))))
+          (let [bot-message (format
+                             "You should do ```SELECT COUNT(*) FROM %s``` to do that."
+                             (metabot-util/normalize-name (:name orders-model)))
+                bot-sql     (metabot-util/extract-sql bot-message)
+                q           "How many orders do I have?"]
+            (with-redefs [metabot-client/*create-chat-completion-endpoint* (fn [{:keys [prompt_template]} _]
+                                                                             (case (keyword prompt_template)
+                                                                               :infer_sql {:choices [{:message {:content bot-message}}]}
+                                                                               {:choices [{:message {:content "{}"}}]}))
+                          metabot-client/*create-embedding-endpoint*       metabot-test/throw-on-embedding
+                          metabot-util/*prompt-templates*                  (constantly metabot-test/test-prompt-templates)]
+              (let [response (mt/user-http-request :rasta :post 200
+                                                   (format "/metabot/model/%s" (:id orders-model))
+                                                   {:question q})
+                    {:keys [query template-tags]} (get-in response [:card :dataset_query :native])]
+                (is (true? (str/ends-with? query bot-sql)))
+                (is (contains? template-tags (keyword (str "#" (:id orders-model)))))))))))))
 
 (deftest metabot-model-sad-path-test
   (testing "POST /api/metabot/model/:model-id produces a message when no SQL is found"
@@ -61,15 +61,15 @@
                               :type     :query
                               :query    {:source-table (mt/id :orders)}}
                              :dataset true}]
-         (let [bot-message "IDK what to do here"
-               q           "How many orders do I have?"]
-           (with-redefs [metabot-client/*create-chat-completion-endpoint* (metabot-test/test-bot-endpoint-single-message bot-message)
-                         metabot-client/*create-embedding-endpoint*       metabot-test/throw-on-embedding
-                         metabot-util/*prompt-templates*                  (constantly metabot-test/test-prompt-templates)]
-             (let [response (mt/user-http-request :rasta :post 400
-                                                  (format "/metabot/model/%s" (:id orders-model))
-                                                  {:question q})]
-               (is (true? (str/includes? response "didn't produce any SQL")))))))))))
+          (let [bot-message "IDK what to do here"
+                q           "How many orders do I have?"]
+            (with-redefs [metabot-client/*create-chat-completion-endpoint* (metabot-test/test-bot-endpoint-single-message bot-message)
+                          metabot-client/*create-embedding-endpoint*       metabot-test/throw-on-embedding
+                          metabot-util/*prompt-templates*                  (constantly metabot-test/test-prompt-templates)]
+              (let [response (mt/user-http-request :rasta :post 400
+                                                   (format "/metabot/model/%s" (:id orders-model))
+                                                   {:question q})]
+                (is (true? (str/includes? response "didn't produce any SQL")))))))))))
 
 (deftest metabot-database-happy-path-test
   (testing "POST /api/metabot/database/:database-id happy path"
@@ -82,24 +82,24 @@
                               :type     :query
                               :query    {:source-table (mt/id :orders)}}
                              :dataset true}]
-         (let [bot-model-selection (format "The best model is %s" (:id orders-model))
-               bot-sql-response    (format "you should do ```SELECT COUNT(*) FROM %s``` to do that."
-                                           (metabot-util/normalize-name (:name orders-model)))
-               bot-sql             (metabot-util/extract-sql bot-sql-response)
-               q                   "How many orders do I have?"]
-           (with-redefs [metabot-client/*create-chat-completion-endpoint* (fn [{:keys [prompt_template]} _]
-                                                                            (case (keyword prompt_template)
-                                                                              :infer_model {:choices [{:message {:content bot-model-selection}}]}
-                                                                              :infer_sql {:choices [{:message {:content bot-sql-response}}]}
-                                                                              {:choices [{:message {:content "{}"}}]}))
-                         metabot-client/*create-embedding-endpoint*       metabot-test/simple-embedding-stub
-                         metabot-util/*prompt-templates*                  (constantly metabot-test/test-prompt-templates)]
-             (let [response (mt/user-http-request :rasta :post 200
-                                                  (format "/metabot/database/%s" (mt/id))
-                                                  {:question q})
-                   {:keys [query template-tags]} (get-in response [:card :dataset_query :native])]
-               (is (true? (str/ends-with? query bot-sql)))
-               (is (contains? template-tags (keyword (str "#" (:id orders-model)))))))))))))
+          (let [bot-model-selection (format "The best model is %s" (:id orders-model))
+                bot-sql-response    (format "you should do ```SELECT COUNT(*) FROM %s``` to do that."
+                                            (metabot-util/normalize-name (:name orders-model)))
+                bot-sql             (metabot-util/extract-sql bot-sql-response)
+                q                   "How many orders do I have?"]
+            (with-redefs [metabot-client/*create-chat-completion-endpoint* (fn [{:keys [prompt_template]} _]
+                                                                             (case (keyword prompt_template)
+                                                                               :infer_model {:choices [{:message {:content bot-model-selection}}]}
+                                                                               :infer_sql {:choices [{:message {:content bot-sql-response}}]}
+                                                                               {:choices [{:message {:content "{}"}}]}))
+                          metabot-client/*create-embedding-endpoint*       metabot-test/simple-embedding-stub
+                          metabot-util/*prompt-templates*                  (constantly metabot-test/test-prompt-templates)]
+              (let [response (mt/user-http-request :rasta :post 200
+                                                   (format "/metabot/database/%s" (mt/id))
+                                                   {:question q})
+                    {:keys [query template-tags]} (get-in response [:card :dataset_query :native])]
+                (is (true? (str/ends-with? query bot-sql)))
+                (is (contains? template-tags (keyword (str "#" (:id orders-model)))))))))))))
 
 (deftest metabot-database-no-model-found-test
   (testing "With embeddings, you'll always get _some_ model, unless there aren't any at all."
@@ -112,37 +112,38 @@
                                :type     :query
                                :query    {:source-table (mt/id :orders)}}
                               :dataset false}]
-         (let [bot-message "Your prompt needs more details..."
-               q           "A not useful prompt"]
-           (with-redefs [metabot-client/*create-chat-completion-endpoint* (metabot-test/test-bot-endpoint-single-message bot-message)
-                         metabot-client/*create-embedding-endpoint*       metabot-test/simple-embedding-stub
-                         metabot-util/*prompt-templates*                  (constantly metabot-test/test-prompt-templates)]
-             (let [{:keys [message]} (mt/user-http-request :rasta :post 400
-                                                           (format "/metabot/database/%s" (mt/id))
-                                                           {:question q})]
-               (is (true? (str/includes? message (format "Query '%s' didn't find a good match to your data." q))))))))))))
+          (let [bot-message "Your prompt needs more details..."
+                q           "A not useful prompt"]
+            (with-redefs [metabot-client/*create-chat-completion-endpoint* (metabot-test/test-bot-endpoint-single-message bot-message)
+                          metabot-client/*create-embedding-endpoint*       metabot-test/simple-embedding-stub
+                          metabot-util/*prompt-templates*                  (constantly metabot-test/test-prompt-templates)]
+              (let [{:keys [message]} (mt/user-http-request :rasta :post 400
+                                                            (format "/metabot/database/%s" (mt/id))
+                                                            {:question q})]
+                (is (true? (str/includes? message (format "Query '%s' didn't find a good match to your data." q))))))))))))
 
 (deftest metabot-database-no-sql-found-test
-  (testing "When we can't find useful SQL, we return a message"
+  (testing "When we can't find sql from the selected model, we return a message"
     (mt/with-temporary-setting-values [is-metabot-enabled true]
       (mt/dataset sample-dataset
         (t2.with-temp/with-temp
-         [Card _orders-model {:name    "Orders Model"
-                              :dataset_query
-                              {:database (mt/id)
-                               :type     :query
-                               :query    {:source-table (mt/id :orders)}}
-                              :dataset true}]
-         (let [bot-message "Your prompt needs more details..."
-               q           "A not useful prompt"]
-           (with-redefs [metabot-client/*create-chat-completion-endpoint* (metabot-test/test-bot-endpoint-single-message bot-message)
-                         metabot-client/*create-embedding-endpoint*       metabot-test/simple-embedding-stub
-                         metabot-util/*prompt-templates*                  (constantly metabot-test/test-prompt-templates)]
-             (let [response (mt/user-http-request :rasta :post 400
-                                                  (format "/metabot/database/%s" (mt/id))
-                                                  {:question q})]
-               (is (true? (str/includes? response q)))
-               (is (true? (str/includes? response "didn't produce any SQL.")))))))))))
+         [Card orders-model {:name    "Orders Model"
+                             :dataset_query
+                             {:database (mt/id)
+                              :type     :query
+                              :query    {:source-table (mt/id :orders)}}
+                             :dataset true}]
+          (let [bot-message (format
+                             "Part 1 is %s but part 2 doesn't return SQL."
+                             (:id orders-model))
+                q           "orders model but nothing useful"]
+            (with-redefs [metabot-client/*create-chat-completion-endpoint* (metabot-test/test-bot-endpoint-single-message bot-message)
+                          metabot-client/*create-embedding-endpoint*       metabot-test/throw-on-embedding
+                          metabot-util/*prompt-templates*                  (constantly metabot-test/test-prompt-templates)]
+              (let [response (mt/user-http-request :rasta :post 400
+                                                   (format "/metabot/database/%s" (mt/id))
+                                                   {:question q})]
+                (is (true? (str/includes? response "didn't produce any SQL")))))))))))
 
 (deftest openai-40X-test
   ;; We can use the metabot-client/bot-endpoint redefs to simulate various failure modes in the bot server
@@ -156,17 +157,17 @@
                    :type     :query
                    :query    {:source-table (mt/id :orders)}}
                   :dataset true}]
-         (with-redefs [metabot-client/*create-chat-completion-endpoint* (fn [_ _]
-                                                                          (throw (ex-info
-                                                                                  "Too many requests"
-                                                                                  {:message "Too many requests"
-                                                                                   :status  429})))
-                       metabot-client/*create-embedding-endpoint*       metabot-test/simple-embedding-stub
-                       metabot-util/*prompt-templates*                  (constantly metabot-test/test-prompt-templates)]
-           (let [{:keys [message]} (mt/user-http-request :rasta :post 429
-                                                         (format "/metabot/database/%s" (mt/id))
-                                                         {:question "Doesn't matter"})]
-             (is (true? (str/includes? message "The bot server is under heavy load"))))))))
+          (with-redefs [metabot-client/*create-chat-completion-endpoint* (fn [_ _]
+                                                                           (throw (ex-info
+                                                                                   "Too many requests"
+                                                                                   {:message "Too many requests"
+                                                                                    :status  429})))
+                        metabot-client/*create-embedding-endpoint*       metabot-test/simple-embedding-stub
+                        metabot-util/*prompt-templates*                  (constantly metabot-test/test-prompt-templates)]
+            (let [{:keys [message]} (mt/user-http-request :rasta :post 429
+                                                          (format "/metabot/database/%s" (mt/id))
+                                                          {:question "Doesn't matter"})]
+              (is (true? (str/includes? message "The bot server is under heavy load"))))))))
     (testing "Not having the right API keys set returns a useful message"
       (mt/dataset sample-dataset
         (t2.with-temp/with-temp
@@ -176,17 +177,17 @@
                    :type     :query
                    :query    {:source-table (mt/id :orders)}}
                   :dataset true}]
-         (with-redefs [metabot-client/*create-chat-completion-endpoint* (fn [_ _]
-                                                                          (throw (ex-info
-                                                                                  "Unauthorized"
-                                                                                  {:message "Unauthorized"
-                                                                                   :status  401})))
-                       metabot-client/*create-embedding-endpoint*       metabot-test/simple-embedding-stub
-                       metabot-util/*prompt-templates*                  (constantly metabot-test/test-prompt-templates)]
-           (let [{:keys [message]} (mt/user-http-request :rasta :post 400
-                                                         (format "/metabot/database/%s" (mt/id))
-                                                         {:question "Doesn't matter"})]
-             (is (true? (str/includes? message "Bot credentials are incorrect or not set"))))))))
+          (with-redefs [metabot-client/*create-chat-completion-endpoint* (fn [_ _]
+                                                                           (throw (ex-info
+                                                                                   "Unauthorized"
+                                                                                   {:message "Unauthorized"
+                                                                                    :status  401})))
+                        metabot-client/*create-embedding-endpoint*       metabot-test/simple-embedding-stub
+                        metabot-util/*prompt-templates*                  (constantly metabot-test/test-prompt-templates)]
+            (let [{:keys [message]} (mt/user-http-request :rasta :post 400
+                                                          (format "/metabot/database/%s" (mt/id))
+                                                          {:question "Doesn't matter"})]
+              (is (true? (str/includes? message "Bot credentials are incorrect or not set"))))))))
     (testing "Too many tokens used returns a useful message"
       (mt/dataset sample-dataset
         (mt/with-temp* [Card [_

--- a/test/metabase/metabot/metabot_util_test.clj
+++ b/test/metabase/metabot/metabot_util_test.clj
@@ -107,10 +107,11 @@
                               :query    {:source-table (mt/id :orders)}}
                              :dataset true}]]
         (let [database (t2/select-one Database :id (mt/id))
-              {:keys [models sql_name]} (metabot-util/denormalize-database database)]
+              {:keys [models sql_name model_json_summary]} (metabot-util/denormalize-database database)]
           (is (=
                (count (t2/select Card :database_id (mt/id) :dataset true))
                (count models)))
+          (is (string? model_json_summary))
           (is (string? sql_name)))))))
 
 (deftest create-prompt-test


### PR DESCRIPTION
Inferencing for models was switched from an LLM to an embedding selector. Unfortunately, this did not do a very good job as too much context was not retained. This change goes back to using the LLM for model inferencing.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30267)
<!-- Reviewable:end -->
