### PR TITLE
Fix #29862: Metric tooltip description gets cut

### DIFF
--- a/frontend/src/metabase/core/components/Tooltip/Tooltip.tsx
+++ b/frontend/src/metabase/core/components/Tooltip/Tooltip.tsx
@@ -70,7 +70,7 @@ function Tooltip({
   isOpen,
   isPadded = true,
   preventOverflow = false,
-  maxWidth = 200,
+  maxWidth = 300,
 }: TooltipProps) {
   const visible = isOpen != null ? isOpen : undefined;
   const animationDuration = isReducedMotionPreferred() ? 0 : undefined;


### PR DESCRIPTION
**Problem:** When you create a long text description on a metric, it overflows out of the tool-tip

![image](https://user-images.githubusercontent.com/22608765/233471429-6b2f56a3-6c5b-47b0-9dfc-c4f891bea451.png)


**Context:** 
- Closes #29862 
  - The content of the tool-tip, `<QueryDefinitionTooltip />`, has width (250) which is larger than the maxWidth (200) of the tooltip container, `<Tooltip />`

**Desired Behavior:** 
- [ ] All text is visible and no text overflows outside of the tool-tip

**Solution Implementation:**
- Increase `maxWidth` of tool-tip to 300

![image](https://user-images.githubusercontent.com/22608765/233471092-22acb346-2063-4d79-bd29-9f32c62b4940.png)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30271)
<!-- Reviewable:end -->
