### PR TITLE
Do not record revision if the object is not changed.

### DIFF
--- a/src/metabase/models/revision.clj
+++ b/src/metabase/models/revision.clj
@@ -135,16 +135,16 @@
          (integer? id)
          (t2/exists? entity :id id)
          (map? object)]}
-  (let [object      (serialize-instance entity id (dissoc object :message))
-        last-object (t2/select-one-fn :object Revision :model (name entity) :model_id id {:order-by [[:id :desc]]})]
+  (let [serialized-object (serialize-instance entity id (dissoc object :message))
+        last-object       (t2/select-one-fn :object Revision :model (name entity) :model_id id {:order-by [[:id :desc]]})]
     ;; make sure we still have a map after calling out serialization function
-    (assert (map? object))
-    (when-not (= object last-object)
+    (assert (map? serialized-object))
+    (when-not (= serialized-object last-object)
       (t2/insert! Revision
                   :model        (name entity)
                   :model_id     id
                   :user_id      user-id
-                  :object       object
+                  :object       serialized-object
                   :is_creation  is-creation?
                   :is_reversion false
                   :message      message)

--- a/test/metabase/api/revision_test.clj
+++ b/test/metabase/api/revision_test.clj
@@ -178,6 +178,8 @@
       (mt/with-temp* [Collection [collection {:name "Personal collection"}]
                       Dashboard  [dashboard {:collection_id (u/the-id collection) :name "Personal dashboard"}]]
         (create-dashboard-revision! dashboard true :crowberto)
+        ;; update so that the revision is accepted
+        (t2/update! Dashboard :id (:id dashboard) {:name "Personal dashboard edited"})
         (create-dashboard-revision! dashboard false :crowberto)
         (let [dashboard-id          (u/the-id dashboard)
               [_ {prev-rev-id :id}] (revision/revisions Dashboard dashboard-id)


### PR DESCRIPTION
Fixes #30030

The change is to make sure we only record a revision only when the object changes. (Check this comment for the reasoning https://github.com/metabase/metabase/issues/30030#issuecomment-1517629594. )

I think this is safe and it should be implemented a long time ago.

In fact, the way we display revision on FE is kinda a hack. Currently, if you edit the dashboard, we record at least 3 revisions with the same object, but if you open the details on FE, it only says there is one revision.
The reason for this is FE intelligently does a diff between revisions to filter out only the one that changes... not sure why we did it that way but I think it should be implemented in the BE from start.

---
Product also can't think of any reasons why we need revision without changes ([thread](https://metaboat.slack.com/archives/C01LQQ2UW03/p1682079144330459?thread_ts=1682078063.301779&cid=C01LQQ2UW03))


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30285)
<!-- Reviewable:end -->
