### PR TITLE
Generate unique aliases for operations in aggregations

### DIFF
--- a/test/metabase/query_processor_test/expression_aggregations_test.clj
+++ b/test/metabase/query_processor_test/expression_aggregations_test.clj
@@ -143,6 +143,23 @@
                  {:aggregation [[:+ [:max $price] [:min [:- $price $id]]]]
                   :breakout    [$price]})))))))
 
+(deftest integer-aggregation-division-test
+  (testing "division of two sum aggregations (#30262)"
+    (mt/test-drivers (mt/normal-drivers-with-feature :expression-aggregations)
+      (mt/dataset sample-dataset
+        (testing "expression parts not selected"
+          (is (= [[27]]
+                 (mt/formatted-rows [int]
+                   (mt/run-mbql-query orders
+                     {:aggregation [[:/ [:sum $product_id] [:sum $quantity]]]})))))
+        (testing "expression parts also selected"
+         (is (= [[1885900 69540 27]]
+                (mt/formatted-rows [int int int]
+                  (mt/run-mbql-query orders
+                    {:aggregation [[:sum $product_id]
+                                   [:sum $quantity]
+                                   [:/ [:sum $product_id] [:sum $quantity]]]})))))))))
+
 (deftest aggregation-without-field-test
   (mt/test-drivers (mt/normal-drivers-with-feature :expression-aggregations)
     (testing "aggregation w/o field"


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/30262

### Description

The problem is that when the same operator (e.g., sum) occurs multiple times in a single aggregation expression (e.g., sum(tax)/sum(price)) the Mongo query processor generates the same alias for all of them. As a result, only one of these subexpressions is kept and the calculation is wrong.

The solution is to make sure each subexpression gets a unique alias.

### How to verify

The new automated test should pass.

In the UI the following nonsensical query should demonstrate the problem and the fix.

![image](https://user-images.githubusercontent.com/103100869/233730456-5c127912-5ff0-4c6b-83b3-993ff1318ae6.png)

### Demo

Before the fix:

![image](https://user-images.githubusercontent.com/103100869/233730113-bcfe88a9-9be1-434a-bb06-e64cca3c6773.png)

After the fix:

![image](https://user-images.githubusercontent.com/103100869/233730283-9f888193-9644-41fc-893c-916f1339ba9c.png)


### Checklist

- [x] Tests have been added/updated to cover changes in this PR

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30302)
<!-- Reviewable:end -->
