### PR TITLE
Add GET "/most_recently_viewed_dashboard" endpoint

### DIFF
--- a/src/metabase/api/activity.clj
+++ b/src/metabase/api/activity.clj
@@ -209,6 +209,11 @@
              (:dataset model-object) (assoc :model "dataset")))
          (take 5))))
 
+(api/defendpoint GET "/most_recently_viewed_dashboard"
+  "Get the most recently viewed dashboard for the current user."
+  []
+  (view-log/most-recently-viewed-dashboard))
+
 (defn- official?
   "Returns true if the item belongs to an official collection. False otherwise. Assumes that `:authority_level` exists
   if the item can be placed in a collection."

--- a/src/metabase/api/activity.clj
+++ b/src/metabase/api/activity.clj
@@ -210,7 +210,8 @@
          (take 5))))
 
 (api/defendpoint GET "/most_recently_viewed_dashboard"
-  "Get the most recently viewed dashboard for the current user."
+  "Get the most recently viewed dashboard for the current user. Returns a 204 if the user has not viewed any dashboards
+   in the last 24 hours."
   []
   (view-log/most-recently-viewed-dashboard))
 

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -401,25 +401,28 @@
    collection_id           (s/maybe su/IntGreaterThanZero)
    collection_position     (s/maybe su/IntGreaterThanZero)
    cache_ttl               (s/maybe su/IntGreaterThanZero)}
-  (let [dash-before-update (api/write-check Dashboard id)]
-    ;; Do various permissions checks as needed
-    (collection/check-allowed-to-change-collection dash-before-update dash-updates)
-    (check-allowed-to-change-embedding dash-before-update dash-updates)
-    (t2/with-transaction [_conn]
-      ;; If the dashboard has an updated position, or if the dashboard is moving to a new collection, we might need to
-      ;; adjust the collection position of other dashboards in the collection
-      (api/maybe-reconcile-collection-position! dash-before-update dash-updates)
-      ;; description, position, collection_id, and collection_position are allowed to be `nil`. Everything else must be
-      ;; non-nil
-      (when-let [updates (not-empty (u/select-keys-when dash-updates
-                                      :present #{:description :position :collection_id :collection_position :cache_ttl}
-                                      :non-nil #{:name :parameters :caveats :points_of_interest :show_in_getting_started :enable_embedding
-                                                 :embedding_params :archived :auto_apply_filters}))]
-        (t2/update! Dashboard id updates))))
-  ;; now publish an event and return the updated Dashboard
-  (let [dashboard (t2/select-one Dashboard :id id)]
-    (events/publish-event! :dashboard-update (assoc dashboard :actor_id api/*current-user-id*))
-    (assoc dashboard :last-edit-info (last-edit/edit-information-for-user @api/*current-user*))))
+  (let [dash-before-update (api/write-check Dashboard id)
+        updates            (u/select-keys-when dash-updates
+                                               :present #{:description :position :collection_id :collection_position :cache_ttl}
+                                               :non-nil #{:name :parameters :caveats :points_of_interest :show_in_getting_started :enable_embedding
+                                                          :embedding_params :archived :auto_apply_filters})]
+    (if (some? (second (clojure.data/diff dash-before-updates updates)))
+      (do
+        ;; Do various permissions checks as needed
+        (collection/check-allowed-to-change-collection dash-before-update dash-updates)
+        (check-allowed-to-change-embedding dash-before-update dash-updates)
+        (t2/with-transaction [_conn]
+          ;; If the dashboard has an updated position, or if the dashboard is moving to a new collection, we might need to
+          ;; adjust the collection position of other dashboards in the collection
+          (api/maybe-reconcile-collection-position! dash-before-update dash-updates)
+          ;; description, position, collection_id, and collection_position are allowed to be `nil`. Everything else must be
+          ;; non-nil
+          (when (seq updates)
+            (t2/update! Dashboard id updates)))
+        (let [dashboard (t2/select-one Dashboard :id id)]
+          (events/publish-event! :dashboard-update (assoc dashboard :actor_id api/*current-user-id*))
+          (assoc dashboard :last-edit-info (last-edit/edit-information-for-user @api/*current-user*))))
+      dash-before-update)))
 
 ;; TODO - We can probably remove this in the near future since it should no longer be needed now that we're going to
 ;; be setting `:archived` to `true` via the `PUT` endpoint instead

--- a/src/metabase/events/view_log.clj
+++ b/src/metabase/events/view_log.clj
@@ -125,7 +125,7 @@
 
 (defn- record-view!
   "Simple base function for recording a view of a given `model` and `model-id` by a certain `user`."
-  [model model-id user-id metadata]
+  [model model-id user-id]
   ;; TODO - we probably want a little code that prunes old entries so that this doesn't get too big
   (t2/insert! ViewLog
               :user_id  user-id

--- a/src/metabase/events/view_log.clj
+++ b/src/metabase/events/view_log.clj
@@ -125,7 +125,7 @@
 
 (defn- record-view!
   "Simple base function for recording a view of a given `model` and `model-id` by a certain `user`."
-  [model model-id user-id]
+  [model model-id user-id metadata]
   ;; TODO - we probably want a little code that prunes old entries so that this doesn't get too big
   (t2/insert! ViewLog
               :user_id  user-id

--- a/test/metabase/api/activity_test.clj
+++ b/test/metabase/api/activity_test.clj
@@ -92,10 +92,10 @@
                   Dashboard [dash-1 {:name        "rand-name2"
                                      :description "rand-name2"
                                      :creator_id  (mt/user->id :crowberto)}]
-                  Dashboard Table
-                  [dash-2 {:name        "rand-name2"
-                           :description "rand-name2"
-                           :creator_id  (mt/user->id :crowberto)}]     [table-1 {:name "rand-name"}]]
+                  Dashboard [dash-2 {:name        "rand-name2"
+                                     :description "rand-name2"
+                                     :creator_id  (mt/user->id :crowberto)}]
+                  Table     [table-1 {:name "rand-name"}]]
     (testing "recent_views endpoint shows the current user's recently viewed items."
       (mt/with-model-cleanup [ViewLog]
         (mt/with-test-user :crowberto

--- a/test/metabase/api/activity_test.clj
+++ b/test/metabase/api/activity_test.clj
@@ -84,6 +84,41 @@
                        :when    (contains? these-activity-ids (u/the-id activity))]
                    (dissoc activity :timestamp)))))))))
 
+(deftest most-recently-viewed-dashboard-views-test
+  (mt/with-temp* [Card      [card-1 {:name                   "rand-name"
+                                     :creator_id             (mt/user->id :crowberto)
+                                     :display                "table"
+                                     :visualization_settings {}}]
+                  Dashboard [dash-1 {:name        "rand-name2"
+                                     :description "rand-name2"
+                                     :creator_id  (mt/user->id :crowberto)}]
+                  Dashboard Table
+                  [dash-2 {:name        "rand-name2"
+                           :description "rand-name2"
+                           :creator_id  (mt/user->id :crowberto)}]     [table-1 {:name "rand-name"}]]
+    (testing "recent_views endpoint shows the current user's recently viewed items."
+      (mt/with-model-cleanup [ViewLog]
+        (mt/with-test-user :crowberto
+          (mt/with-temporary-setting-values [user-recent-views []]
+            (doseq [event [{:topic :dashboard-read :item dash-1}
+                           {:topic :dashboard-read :item dash-2}
+                           {:topic :card-query :item card-1}
+                           {:topic :table-read :item table-1}]]
+              (view-log/handle-view-event!
+               ;; view log entries look for the `:actor_id` in the item being viewed to set that view's :user_id
+               (assoc-in event [:item :actor_id] (mt/user->id :crowberto))))
+            (testing "No duplicates or archived items are returned."
+              (is (= (u/the-id dash-2)
+                     (mt/user-http-request :crowberto :get 200 "activity/most_recently_viewed_dashboard"))))))
+        (mt/with-test-user :rasta
+          (mt/with-temporary-setting-values [user-recent-views []]
+            (testing "If nothing has been viewed, return a 204"
+              (is (nil? (mt/user-http-request :crowberto :get 204 "activity/most_recently_viewed_dashboard"))))
+            (view-log/handle-view-event! {:topic :dashboard-read :item (assoc dash-1 :actor_id (mt/user->id :rasta))})
+            (testing "Only the user's own views are returned."
+              (is (= (u/the-id dash-1)
+                     (mt/user-http-request :rasta :get 200 "activity/most_recently_viewed_dashboard"))))))))))
+
 (deftest recent-views-test
   (mt/with-temp* [Card      [card1 {:name                   "rand-name"
                                     :creator_id             (mt/user->id :crowberto)

--- a/test/metabase/api/activity_test.clj
+++ b/test/metabase/api/activity_test.clj
@@ -96,7 +96,7 @@
                                      :description "rand-name2"
                                      :creator_id  (mt/user->id :crowberto)}]
                   Table     [table-1 {:name "rand-name"}]]
-    (testing "recent_views endpoint shows the current user's recently viewed items."
+    (testing "most_recently_viewed_dashboard endpoint shows the current user's most recently viewed dashboard."
       (mt/with-model-cleanup [ViewLog]
         (mt/with-test-user :crowberto
           (mt/with-temporary-setting-values [user-recent-views []]


### PR DESCRIPTION
Pursuant to https://github.com/metabase/metabase/issues/30140
Epic: https://github.com/metabase/metabase/issues/29666

I chose to create an endpoint specifically for this task, `GET "/most_recently_viewed_dashboard"`. We already keep track of the most recently used dashboard in a user-local setting called `most-recently-viewed-dashboard`, so we can use it for this task for best performance. Implementing a general API endpoint that can work for any model would be much harder because of the way `recent_views` is optimized for its current job.

An important note is that the response will have a 204 status if the user has not viewed any dashboards in the last 24 hours.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30323)
<!-- Reviewable:end -->
