### PR TITLE
fix database info banner link

### DIFF
--- a/frontend/src/metabase/databases/components/DatabaseInfoField/DatabaseInfoField.styled.tsx
+++ b/frontend/src/metabase/databases/components/DatabaseInfoField/DatabaseInfoField.styled.tsx
@@ -1,9 +1,6 @@
 import styled from "@emotion/styled";
-import { color } from "metabase/lib/colors";
+import Banner from "metabase/components/Banner";
 
-export const InfoBanner = styled.div`
-  padding: 0.75rem;
-  border-radius: 6px;
-  color: ${color("text-medium")};
-  background-color: ${color("bg-light")};
+export const InfoBanner = styled(Banner)`
+  margin-bottom: 0.5rem;
 `;

--- a/frontend/src/metabase/databases/components/DatabaseInfoField/DatabaseInfoField.unit.spec.tsx
+++ b/frontend/src/metabase/databases/components/DatabaseInfoField/DatabaseInfoField.unit.spec.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import DatabaseInfoField from "./DatabaseInfoField";
+
+describe("DatabaseInfoField", () => {
+  it("renders markdown links", () => {
+    const content = 'Text "[link](https://www.metabase.com/)';
+    render(<DatabaseInfoField placeholder={content} />);
+
+    const link = screen.getByRole("link");
+
+    expect(link).toHaveTextContent("link");
+    expect(link).toHaveAttribute("href", "https://www.metabase.com/");
+  });
+});


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/30317

### Description

Fixes markdown links are not rendered in database edit form info banners.

### How to verify

In `src/metabase/public_settings.clj` replace `cloud-gateway-ips` with:
```
(defsetting cloud-gateway-ips
  (deferred-tru "Metabase Cloud gateway IP addresses, to configure connections to DBs behind firewalls")
  :visibility :public
  :type       :json
  :setter     :none
  :getter     (fn []
                  (fetch-cloud-gateway-ips-fn)))
```

1. As an admin go to http://localhost:3000/admin/databases/create
2. Ensure the banner has properly rendered markdown with a link

### Demo

<img width="742" alt="Screen Shot 2023-04-24 at 1 53 05 PM" src="https://user-images.githubusercontent.com/14301985/234064086-efe6bd52-4782-4af8-867c-0bd785c4d6fa.png">

### Checklist

- [x] Tests have been added/updated to cover changes in this PR

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30330)
<!-- Reviewable:end -->
