### PR TITLE
docs - update env vars doc

### DIFF
--- a/docs/configuring-metabase/environment-variables.md
+++ b/docs/configuring-metabase/environment-variables.md
@@ -1259,7 +1259,7 @@ Display the MetaBot character on the home page.
 Type: string<br>
 Default: `"en"`
 
-The default language for this Metabase instance. This only applies to emails, Pulses, etc. Users' browsers will specify the language used in the user interface.
+The default language for this Metabase instance. This setting applies to the Metabase UI, system emails, [dashboard subscriptions](../dashboards/subscriptions.md), and [alerts](../questions/sharing/alerts.md). People can override the default language from their [account settings](../people-and-groups/account-settings.md).
 
 ### `MB_SITE_NAME`
 


### PR DESCRIPTION
Update `MB_SITE_LOCALE` description to match the Admin settings description.

Mainly that the setting applies to the UI on top of emails and everything else.

Also replaced "pulses" with "dashboard subscriptions" (are we getting rid of the name "pulse"?)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30341)
<!-- Reviewable:end -->
