### PR TITLE
Axes grouping in static viz respects auto_split

### DIFF
--- a/src/metabase/pulse/render/body.clj
+++ b/src/metabase/pulse/render/body.clj
@@ -670,6 +670,17 @@
 
 (def ^:private axis-group-threshold 0.33)
 
+(defn- positions->group-positions
+  [positions]
+  (reduce-kv
+   (fn [acc k v]
+     (reduce (fn [result item]
+               (assoc result item k))
+             acc
+             v))
+   {}
+   positions))
+
 (defn- group-axes-at-once
   [joined-rows viz-settings]
   (let [;; a double-x-axis 'joined-row' looks like:
@@ -678,6 +689,7 @@
 
         ;; a single-x-axis 'joined-row' looks like:
         ;; [[grouping-key] [series-val-1 series-val-2 ...]]
+        autosplit?         (:graph.y_axis.auto_split viz-settings true)
         joined-rows-map    (if (= (count (ffirst joined-rows)) 2)
                              ;; double-x-axis
                              (-> (group-by (fn [[[_ x2] _]] x2) joined-rows)
@@ -699,6 +711,9 @@
       ;; if the chart is stacked, splitting the axes doesn't make sense, so we always put every series :left
       stacked? (into {} (map (fn [k] [k :left]) (keys joined-rows-map)))
 
+      ;; if autosplit is false, we respect manually specified positions and otherwise put axes :left
+      (not autosplit?) (positions->group-positions (update-keys positions (fn [v] (if (= v :unassigned) :left v))))
+
       ;; chart is not stacked, and there are some :unassigned series, so we try to group them
       unassigned?
       (let [lefts         (or (:left positions) [(first (:unassigned positions))])
@@ -718,8 +733,7 @@
                                       {:left [k]}
                                       {:right [k]}))
                                   (-> positions (dissoc :unassigned) (assoc :left lefts))))]
-        (into {} (apply concat (for [[pos ks] all-positions]
-                                 (map (fn [k] [k pos]) ks)))))
+        (positions->group-positions all-positions))
 
       ;; all series already have positions assigned
       ;; This comes from the user explicitly setting left or right on the series in the UI.

--- a/src/metabase/pulse/render/body.clj
+++ b/src/metabase/pulse/render/body.clj
@@ -617,8 +617,7 @@
       (and (= min-b max-b) (<= min-a min-b max-a)) 1
 
       ;; ranges overlap, let's calculate the percent overlap
-      (or (<= min-a min-b max-a)
-          (<= min-a max-b max-a)) (overlap vals-a vals-b)
+      (<= (max min-a min-b) (min max-a max-b)) (overlap vals-a vals-b)
 
       ;; no overlap, let's calculate a nearness value to use instead
       :else (nearness vals-a vals-b))))

--- a/src/metabase/pulse/render/body.clj
+++ b/src/metabase/pulse/render/body.clj
@@ -589,7 +589,7 @@
   The nearness is 1 - length(AD) / length(BC) or equivalently:
   length(AB) + length(CD) / length(AD)"
   [vals-a vals-b]
-  (let [[a b c d] (sort (concat vals-a vals-b))]
+  (let [[a b c d] (sort (concat ((juxt first last) vals-a) ((juxt first last) vals-b)))]
     (- 1 (double (/ (abs (- c b)) (abs (- a d)))))))
 
 (defn- axis-group-score

--- a/src/metabase/pulse/render/body.clj
+++ b/src/metabase/pulse/render/body.clj
@@ -578,28 +578,19 @@
     (/ (double overlap-width) (double max-width))))
 
 (defn- nearness
-  "Calculate the 'nearness' score for ranges specified by `vals-a` and `vals-b`.
+  "Calculate a 'nearness' score for ranges specified by `vals-a` and `vals-b`.
 
-  The nearness score is the percent of the total range that the 'valid range' covers IF,
-  the outer point's distance to the nearest range end covers less of the total range.
-  for visual:  *     *--------------*  <---- the 'pt' on the left is close enough."
+  The nearness score is the percent of the total range that the two ranges cover.
+  for visual:
+
+     A   B     C              D
+     *---*     *--------------*
+
+  The nearness is 1 - length(AD) / length(BC) or equivalently:
+  length(AB) + length(CD) / length(AD)"
   [vals-a vals-b]
-  (let [[min-a max-a]          (-> vals-a sort ((juxt first last)))
-        [min-b max-b]          (-> vals-b sort ((juxt first last)))]
-    (cond
-      (or (= min-a max-a) (= min-b max-b))
-      (let [pt                (if (= min-a max-a) min-a min-b)
-            [r1 r2]           (if (= min-a max-a) [min-b max-b] [min-a max-a])
-            total-range       (- (max pt r2) (min pt r1))
-            valid-range-score (/ (- r2 r1) total-range)
-            outer-pt-score    (/ (min (abs (- pt r1))
-                                      (abs (- pt r2)))
-                                 total-range)]
-        (if (>= valid-range-score outer-pt-score)
-          (double valid-range-score)
-          0))
-
-      :else 0)))
+  (let [[a b c d] (sort (concat vals-a vals-b))]
+    (- 1 (double (/ (abs (- c b)) (abs (- a d)))))))
 
 (defn- axis-group-score
   "Calculate the axis grouping threshold value for the ranges specified by `vals-a` and `vals-b`.

--- a/test/metabase/pulse/render/body_test.clj
+++ b/test/metabase/pulse/render/body_test.clj
@@ -644,6 +644,16 @@
                (filter #{"visx-axis-left" "visx-axis-right"}))]
    (into #{} xf nodes)))
 
+(deftest axes-group-scoring-test
+  (let [axis-group-score  #'body/axis-group-score]
+    (testing "Overlapped and 'near' ranges return scores between 0 and 1."
+      (is (<= 0.59 (axis-group-score [0 10] [1 7]) 0.61))
+      (is (<= 0.24 (axis-group-score [5 20] [0 10]) 0.26))
+      (is (<= 0.79 (axis-group-score [0 5] [7 10]) 0.81)))
+    (testing "'Degenerate' ranges will still score."
+      (is (= 1 (axis-group-score [0 10] [2 2])))
+      (is (<= 0.32 (axis-group-score [0 10] [30 30]) 0.34)))))
+
 (deftest reasonable-split-axes-test
   (let [rows [["Category" "Series A" "Series B"]
               ["A"        1          1.3]


### PR DESCRIPTION
Fixes: #20559

Two concerns:

- the setting 'split y-axis when necessary' in the UI can be toggled. It's often on, and we can perform grouping logic in the backend. But, when it's toggled OFF, we should respect any manually set axes positions, and otherwise assume that axes are on the :left. 
- The grouping/splitting logic in some static viz scenarios is still not working entirely, so this PR will work to correct these cases. The problem in this case was related to an incorrect case check for overlap. Now, `(<= (max min-a min-b) (min max-a max-b))` inside the function `axis-group-score` properly detects all overlap situations.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30344)
<!-- Reviewable:end -->
