### PR TITLE
Fix typo in password reset email template

### DIFF
--- a/e2e/support/commands/api/question.js
+++ b/e2e/support/commands/api/question.js
@@ -106,7 +106,7 @@ function question(
     if (loadMetadata || visitQuestion) {
       dataset
         ? cy.intercept("POST", `/api/dataset`).as("dataset")
-        : // We need to use the wildcard becase endpoint for pivot tables has the following format: `/api/card/pivot/${id}/query`
+        : // We need to use the wildcard because endpoint for pivot tables has the following format: `/api/card/pivot/${id}/query`
           cy
             .intercept("POST", `/api/card/**/${body.id}/query`)
             .as(interceptAlias);

--- a/e2e/support/helpers/e2e-misc-helpers.js
+++ b/e2e/support/helpers/e2e-misc-helpers.js
@@ -124,7 +124,7 @@ export function visitQuestion(id) {
   // In case we use this function multiple times in a test, make sure aliases are unique for each question
   const alias = "cardQuery" + id;
 
-  // We need to use the wildcard becase endpoint for pivot tables has the following format: `/api/card/pivot/${id}/query`
+  // We need to use the wildcard because endpoint for pivot tables has the following format: `/api/card/pivot/${id}/query`
   cy.intercept("POST", `/api/card/**/${id}/query`).as(alias);
 
   cy.visit(`/question/${id}`);

--- a/src/metabase/email/password_reset.mustache
+++ b/src/metabase/email/password_reset.mustache
@@ -6,7 +6,7 @@
     {{/google}}
     {{^google}}
       {{#nonGoogleSSO}}
-        <p>We can't reset your password becase you're using single sign-on to log in to {{applicationName}}. Use the
+        <p>We can't reset your password because you're using single sign-on to log in to {{applicationName}}. Use the
         "Sign in with SSO" button on the log in page. To change your password, you'll need to contact an administrator.</p>
         <a href="{{siteUrl}}">Go to {{applicationName}}</a>
       {{/nonGoogleSSO}}


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/30349

### Description

Small change to fix the typo of `becase` -> `because` in the email template. Found this when I received the password reset email with the incorrect spelling.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. On the login page, click on email login and forget password
2. If your account is an SSO account, you will receive an email with the incorrect spelling.
3. After this change, spelling will be corrected 

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30348)
<!-- Reviewable:end -->
