### PR TITLE
Add tests for schema endpoints

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/advanced_permissions/common.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_permissions/common.clj
@@ -64,8 +64,8 @@
     :else
     (filter
      (fn [{db-id :db_id schema :schema}]
-       (perms/set-has-full-permissions? @api/*current-user-permissions-set*
-                                        (perms/feature-perms-path :data-model :all db-id schema)))
+       (perms/set-has-partial-permissions? @api/*current-user-permissions-set*
+                                           (perms/feature-perms-path :data-model :all db-id schema)))
      schema)))
 
 (defn filter-databases-by-data-model-perms

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
@@ -268,12 +268,11 @@
                    (mt/user-http-request :rasta :get 200 (format "database/%d/schemas" db-id)
                                          :include_editable_data_model true)))))
 
-        ;; TODO: check that this is the desired behaviour
         (testing "If include_editable_data_model=true and a non-admin has data model perms for a single table in a schema,
-                  it should not return the schema"
+                  it should return the schema"
           (with-all-users-data-perms {db-id {:data       {:schemas :all :native :write}
                                              :data-model {:schemas {"schema1" {(u/the-id t1) :all}}}}}
-            (is (= []
+            (is (= ["schema1"]
                    (mt/user-http-request :rasta :get 200 (format "database/%d/schemas" db-id)
                                          :include_editable_data_model true)))))))))
 

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
@@ -169,7 +169,7 @@
         (mt/user-http-request :rasta :get 200 (format "database/%d/idfields?include_editable_data_model=true" (mt/id)))))))
 
 (deftest get-schema-with-advanced-perms-test
-  (testing "Permissions: We can verify include_editable_data_model flag works for the `/:id/schema/:schema` and `/:id/schemas` endpoints"
+  (testing "Permissions: We can verify include_editable_data_model flag works for the `/:id/schema/:schema` endpoint"
     (mt/with-temp* [Database [{db-id :id}]
                     Table    [_t1 {:db_id db-id, :schema "schema1", :name "t1"}]
                     Table    [_t2 {:db_id db-id, :schema "schema2"}]
@@ -184,7 +184,16 @@
                                                     :include_editable_data_model true)))))
           (testing "/:id/schema/:schema when permissions are revoked is a 403"
             (is (= "You don't have permissions to do that."
-                   (mt/user-http-request :rasta :get 403 (format "database/%d/schema/%s" db-id "schema1"))))))
+                   (mt/user-http-request :rasta :get 403 (format "database/%d/schema/%s" db-id "schema1"))))))))))
+
+(deftest get-schemas-with-advanced-perms-test
+  (testing "Permissions: We can verify include_editable_data_model flag works for the `/:id/:schemas` endpoint"
+    (mt/with-temp* [Database [{db-id :id}]
+                    Table    [_t1 {:db_id db-id, :schema "schema1", :name "t1"}]
+                    Table    [_t2 {:db_id db-id, :schema "schema2"}]
+                    Table    [_t3 {:db_id db-id, :schema "schema1", :name "t3"}]]
+      (with-all-users-data-perms {db-id {:data       {:schemas :all :native :write}
+                                         :data-model {:schemas :all}}}
         (testing "Testing /:id/schemas variants"
           (perms/revoke-data-perms! (perms-group/all-users) db-id)
           (testing "/:id/schemas when permissions are revoked but include_editable_data_model=true returns values"

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
@@ -174,7 +174,7 @@
                     Table    [t1 {:db_id db-id, :schema "schema1", :name "t1"}]
                     Table    [_t2 {:db_id db-id, :schema "schema2"}]
                     Table    [t3 {:db_id db-id, :schema "schema1", :name "t3"}]]
-      (with-all-users-data-perms {db-id {:data       {:schemas :all :native :write}
+      (with-all-users-data-perms {db-id {:data       {:schemas :block :native :none}
                                          :data-model {:schemas :all}}}
         (perms/revoke-data-perms! (perms-group/all-users) db-id)
         (testing "If data permissions are revoked, it should be a 403"
@@ -187,7 +187,7 @@
 
       (testing "If include_editable_data_model=true and a non-admin does not have data model perms, it should respond
                 with a 404"
-        (with-all-users-data-perms {db-id {:data       {:schemas :all :native :write}
+        (with-all-users-data-perms {db-id {:data       {:schemas :block :native :none}
                                            :data-model {:schemas :none}}}
           (is (= "Not found."
                  (mt/user-http-request :rasta :get 404 (format "database/%d/schema/%s" db-id "schema1")
@@ -195,7 +195,7 @@
 
       (testing "If include_editable_data_model=true and a non-admin has data model perms for a single table in a schema,
                 the table is returned"
-        (with-all-users-data-perms {db-id {:data       {:schemas :all :native :write}
+        (with-all-users-data-perms {db-id {:data       {:schemas :block :native :none}
                                            :data-model {:schemas {"schema1" {(u/the-id t1) :all
                                                                              (u/the-id t3) :none}}}}}
           (is (= ["t1"]
@@ -208,7 +208,7 @@
                     Table    [t1 {:db_id db-id, :schema nil, :name "t1"}]
                     Table    [_t2 {:db_id db-id, :schema "public"}]
                     Table    [t3 {:db_id db-id, :schema "", :name "t3"}]]
-      (with-all-users-data-perms {db-id {:data       {:schemas :all :native :write}
+      (with-all-users-data-perms {db-id {:data       {:schemas :block :native :none}
                                          :data-model {:schemas :all}}}
         (perms/revoke-data-perms! (perms-group/all-users) db-id)
         (testing "If data permissions are revoked, it should be a 403"
@@ -222,7 +222,7 @@
 
       (testing "If include_editable_data_model=true and a non-admin does not have data model perms, it should respond
                 with a 404"
-        (with-all-users-data-perms {db-id {:data       {:schemas :all :native :write}
+        (with-all-users-data-perms {db-id {:data       {:schemas :block :native :none}
                                            :data-model {:schemas :none}}}
           (is (= "Not found."
                  (mt/user-http-request :rasta :get 404 (format "database/%d/schema/" db-id)
@@ -230,7 +230,7 @@
 
       (testing "If include_editable_data_model=true and a non-admin has data model perms for a single table in an empty
                 string schema, it should return the table"
-        (with-all-users-data-perms {db-id {:data       {:schemas :all :native :write}
+        (with-all-users-data-perms {db-id {:data       {:schemas :block :native :none}
                                            :data-model {:schemas {"" {(u/the-id t1) :all
                                                                       (u/the-id t3) :none}}}}}
           (is (= ["t1"]
@@ -243,7 +243,7 @@
                     Table    [t1 {:db_id db-id, :schema "schema1", :name "t1"}]
                     Table    [_t2 {:db_id db-id, :schema "schema2"}]
                     Table    [_t3 {:db_id db-id, :schema "schema1", :name "t3"}]]
-      (with-all-users-data-perms {db-id {:data       {:schemas :all :native :write}
+      (with-all-users-data-perms {db-id {:data       {:schemas :block :native :none}
                                          :data-model {:schemas :all}}}
         (perms/revoke-data-perms! (perms-group/all-users) db-id)
         (testing "If data permissions are revoked, it should be a 403"
@@ -254,7 +254,7 @@
                  (mt/user-http-request :rasta :get 200 (format "database/%d/schemas" db-id)
                                        :include_editable_data_model true))))
         (testing "If include_editable_data_model=true and a non-admin does not have data model perms, it should return []"
-          (with-all-users-data-perms {db-id {:data       {:schemas :all :native :write}
+          (with-all-users-data-perms {db-id {:data       {:schemas :block :native :none}
                                              :data-model {:schemas :none}}}
             (is (= []
                    (mt/user-http-request :rasta :get 200 (format "database/%d/schemas" db-id)
@@ -262,7 +262,7 @@
 
         (testing "If include_editable_data_model=true and a non-admin has data model perms for a schema,
                   it should return the schema"
-          (with-all-users-data-perms {db-id {:data       {:schemas :all :native :write}
+          (with-all-users-data-perms {db-id {:data       {:schemas :block :native :none}
                                              :data-model {:schemas {"schema1" :all}}}}
             (is (= ["schema1"]
                    (mt/user-http-request :rasta :get 200 (format "database/%d/schemas" db-id)
@@ -270,7 +270,7 @@
 
         (testing "If include_editable_data_model=true and a non-admin has data model perms for a single table in a schema,
                   it should return the schema"
-          (with-all-users-data-perms {db-id {:data       {:schemas :all :native :write}
+          (with-all-users-data-perms {db-id {:data       {:schemas :block :native :none}
                                              :data-model {:schemas {"schema1" {(u/the-id t1) :all}}}}}
             (is (= ["schema1"]
                    (mt/user-http-request :rasta :get 200 (format "database/%d/schemas" db-id)

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
@@ -176,15 +176,14 @@
                     Table    [_t3 {:db_id db-id, :schema "schema1", :name "t3"}]]
       (with-all-users-data-perms {db-id {:data       {:schemas :all :native :write}
                                          :data-model {:schemas :all}}}
-        (testing "Testing /:id/schema/:schema variants"
-          (perms/revoke-data-perms! (perms-group/all-users) db-id)
-          (testing "/:id/schema/:schema when permissions are revoked but include_editable_data_model=true returns values"
-            (is (= ["t1" "t3"]
-                   (map :name (mt/user-http-request :rasta :get 200 (format "database/%d/schema/%s" db-id "schema1")
-                                                    :include_editable_data_model true)))))
-          (testing "/:id/schema/:schema when permissions are revoked is a 403"
-            (is (= "You don't have permissions to do that."
-                   (mt/user-http-request :rasta :get 403 (format "database/%d/schema/%s" db-id "schema1"))))))))))
+        (perms/revoke-data-perms! (perms-group/all-users) db-id)
+        (testing "Should return values when permissions are revoked but include_editable_data_model=true"
+          (is (= ["t1" "t3"]
+                 (map :name (mt/user-http-request :rasta :get 200 (format "database/%d/schema/%s" db-id "schema1")
+                                                  :include_editable_data_model true)))))
+        (testing "Should be a 403 when permissions are revoked"
+          (is (= "You don't have permissions to do that."
+                 (mt/user-http-request :rasta :get 403 (format "database/%d/schema/%s" db-id "schema1")))))))))
 
 (deftest get-schemas-with-advanced-perms-test
   (testing "Permissions: We can verify include_editable_data_model flag works for the `/:id/:schemas` endpoint"
@@ -194,15 +193,14 @@
                     Table    [_t3 {:db_id db-id, :schema "schema1", :name "t3"}]]
       (with-all-users-data-perms {db-id {:data       {:schemas :all :native :write}
                                          :data-model {:schemas :all}}}
-        (testing "Testing /:id/schemas variants"
-          (perms/revoke-data-perms! (perms-group/all-users) db-id)
-          (testing "/:id/schemas when permissions are revoked but include_editable_data_model=true returns values"
-            (is (= ["schema1" "schema2"]
-                   (mt/user-http-request :rasta :get 200 (format "database/%d/schemas" db-id)
-                                         :include_editable_data_model true))))
-          (testing "/:id/schemas when permissions are revoked is a 403"
-            (is (= "You don't have permissions to do that."
-                   (mt/user-http-request :rasta :get 403 (format "database/%d/schemas" db-id))))))))))
+        (perms/revoke-data-perms! (perms-group/all-users) db-id)
+        (testing "Should return values when permissions are revoked but include_editable_data_model=true"
+          (is (= ["schema1" "schema2"]
+                 (mt/user-http-request :rasta :get 200 (format "database/%d/schemas" db-id)
+                                       :include_editable_data_model true))))
+        (testing "Should be a 403 when permissions are revoked"
+          (is (= "You don't have permissions to do that."
+                 (mt/user-http-request :rasta :get 403 (format "database/%d/schemas" db-id)))))))))
 
 (deftest update-field-test
   (mt/with-temp Field [{field-id :id, table-id :table_id} {:name "Field Test"}]

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
@@ -242,7 +242,7 @@
     (mt/with-temp* [Database [{db-id :id}]
                     Table    [t1 {:db_id db-id, :schema "schema1", :name "t1"}]
                     Table    [_t2 {:db_id db-id, :schema "schema2"}]
-                    Table    [t3 {:db_id db-id, :schema "schema1", :name "t3"}]]
+                    Table    [_t3 {:db_id db-id, :schema "schema1", :name "t3"}]]
       (with-all-users-data-perms {db-id {:data       {:schemas :all :native :write}
                                          :data-model {:schemas :all}}}
         (perms/revoke-data-perms! (perms-group/all-users) db-id)

--- a/frontend/src/metabase/entities/schemas.js
+++ b/frontend/src/metabase/entities/schemas.js
@@ -16,7 +16,9 @@ import {
 
 // This is a weird entity because we don't have actual schema objects
 
-const listDatabaseSchemas = GET("/api/database/:dbId/schemas");
+const listDatabaseSchemas = GET(
+  "/api/database/:dbId/schemas?include_editable_data_model=true",
+);
 const getSchemaTables = GET("/api/database/:dbId/schema/:schemaName");
 const getVirtualDatasetTables = GET("/api/database/:dbId/datasets/:schemaName");
 

--- a/frontend/src/metabase/entities/schemas.js
+++ b/frontend/src/metabase/entities/schemas.js
@@ -16,9 +16,7 @@ import {
 
 // This is a weird entity because we don't have actual schema objects
 
-const listDatabaseSchemas = GET(
-  "/api/database/:dbId/schemas?include_editable_data_model=true",
-);
+const listDatabaseSchemas = GET("/api/database/:dbId/schemas");
 const getSchemaTables = GET("/api/database/:dbId/schema/:schemaName");
 const getVirtualDatasetTables = GET("/api/database/:dbId/datasets/:schemaName");
 

--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -1061,19 +1061,20 @@
   [id include_editable_data_model]
   {id                          ms/PositiveInt
    include_editable_data_model [:maybe ms/BooleanString]}
-  (api/read-check Database id)
+  (when-not include_editable_data_model
+    (api/read-check Database id))
   (let [include_editable_data_model (Boolean/parseBoolean include_editable_data_model)
-        filter-schemas (fn [schemas]
-                         (if include_editable_data_model
-                           (if-let [f (u/ignore-exceptions
-                                       (classloader/require 'metabase-enterprise.advanced-permissions.common)
-                                       (resolve 'metabase-enterprise.advanced-permissions.common/filter-schema-by-data-model-perms))]
-                             (map :schema (f (map (fn [s] {:db_id id :schema s}) schemas)))
-                             schemas)
-                           (filter (partial can-read-schema? id) schemas)))]
+        filter-schemas              (fn [schemas]
+                                      (if include_editable_data_model
+                                        (if-let [f (u/ignore-exceptions
+                                                     (classloader/require 'metabase-enterprise.advanced-permissions.common)
+                                                     (resolve 'metabase-enterprise.advanced-permissions.common/filter-schema-by-data-model-perms))]
+                                          (map :schema (f (map (fn [s] {:db_id id :schema s}) schemas)))
+                                          schemas)
+                                        (filter (partial can-read-schema? id) schemas)))]
     (->> (t2/select-fn-set :schema Table
                            :db_id id :active true
-                         ;; a non-nil value means Table is hidden -- see [[metabase.models.table/visibility-types]]
+                           ;; a non-nil value means Table is hidden -- see [[metabase.models.table/visibility-types]]
                            :visibility_type nil
                            {:order-by [[:%lower.schema :asc]]})
          filter-schemas

--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -1061,8 +1061,6 @@
   [id include_editable_data_model]
   {id                          ms/PositiveInt
    include_editable_data_model [:maybe ms/BooleanString]}
-  (when-not include_editable_data_model
-    (api/read-check Database id))
   (let [include_editable_data_model (Boolean/parseBoolean include_editable_data_model)
         filter-schemas              (fn [schemas]
                                       (if include_editable_data_model
@@ -1072,6 +1070,8 @@
                                           (map :schema (f (map (fn [s] {:db_id id :schema s}) schemas)))
                                           schemas)
                                         (filter (partial can-read-schema? id) schemas)))]
+    (when-not include_editable_data_model
+      (api/read-check Database id))
     (->> (t2/select-fn-set :schema Table
                            :db_id id :active true
                            ;; a non-nil value means Table is hidden -- see [[metabase.models.table/visibility-types]]
@@ -1113,8 +1113,8 @@
    (schema-tables-list db-id schema nil nil))
   ([db-id schema include_hidden include_editable_data_model]
    (when-not include_editable_data_model
-     (api/read-check Database db-id))
-   (api/check-403 (can-read-schema? db-id schema))
+     (api/read-check Database db-id)
+     (api/check-403 (can-read-schema? db-id schema)))
    (let [tables (if include_hidden
                   (t2/select Table
                              :db_id db-id

--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -1067,8 +1067,8 @@
         filter-schemas              (fn [schemas]
                                       (if include_editable_data_model
                                         (if-let [f (u/ignore-exceptions
-                                                     (classloader/require 'metabase-enterprise.advanced-permissions.common)
-                                                     (resolve 'metabase-enterprise.advanced-permissions.common/filter-schema-by-data-model-perms))]
+                                                    (classloader/require 'metabase-enterprise.advanced-permissions.common)
+                                                    (resolve 'metabase-enterprise.advanced-permissions.common/filter-schema-by-data-model-perms))]
                                           (map :schema (f (map (fn [s] {:db_id id :schema s}) schemas)))
                                           schemas)
                                         (filter (partial can-read-schema? id) schemas)))]


### PR DESCRIPTION
Epic: https://github.com/metabase/metabase/issues/30190

This PR adds more tests that were missing when https://github.com/metabase/metabase/issues/30306 was merged accidentally. It includes the new tests Adam wrote in https://github.com/metabase/metabase/pull/30340.

Reviewers: see https://github.com/metabase/metabase/compare/master...30190-data-model-performance for the BE changes these tests are meant to cover.

It adds tests around permissions for the three endpoints:
- GET `/api/database/:id/schemas`
- GET `/api/database/:id/schema/:id`
- GET `/api/database/:id/schema`

I also did some refactoring of the tests to group them by endpoint, and by permissions related vs non-permissions related. I think it's easier to spot the similarities and differences between the endpoints this way.

The PR also includes a bug fix, indicated in the comments.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30352)
<!-- Reviewable:end -->
