### PR TITLE
Adding beforeUnload hook to Status Listing

### DIFF
--- a/frontend/src/metabase-types/store/mocks/upload.ts
+++ b/frontend/src/metabase-types/store/mocks/upload.ts
@@ -1,7 +1,7 @@
 import { FileUpload } from "../upload";
 
-export const createMockUploadState = () => {
-  return {};
+export const createMockUploadState = (uploads = {}) => {
+  return { ...uploads };
 };
 
 export const createMockUpload = (props?: Partial<FileUpload>): FileUpload => {

--- a/frontend/src/metabase/redux/uploads.ts
+++ b/frontend/src/metabase/redux/uploads.ts
@@ -34,10 +34,10 @@ const uploadEnd = createAction(UPLOAD_FILE_TO_COLLECTION_END);
 const uploadError = createAction(UPLOAD_FILE_TO_COLLECTION_ERROR);
 const clearUpload = createAction(UPLOAD_FILE_TO_COLLECTION_CLEAR);
 
-export const getAllUploads = (state: State) =>
-  Object.values(state.upload);
+export const getAllUploads = (state: State) => Object.values(state.upload);
 
-export const hasActiveUploads = (state: State) => getAllUploads(state).some(upload => upload.status === "in-progress");
+export const hasActiveUploads = (state: State) =>
+  getAllUploads(state).some(upload => upload.status === "in-progress");
 
 export const uploadFile = createThunkAction(
   UPLOAD_FILE_TO_COLLECTION,

--- a/frontend/src/metabase/redux/uploads.ts
+++ b/frontend/src/metabase/redux/uploads.ts
@@ -35,7 +35,9 @@ const uploadError = createAction(UPLOAD_FILE_TO_COLLECTION_ERROR);
 const clearUpload = createAction(UPLOAD_FILE_TO_COLLECTION_CLEAR);
 
 export const getAllUploads = (state: State) =>
-  Object.keys(state.upload).map(key => state.upload[key]);
+  Object.values(state.upload);
+
+export const hasActiveUploads = (state: State) => getAllUploads(state).some(upload => upload.status === "in-progress");
 
 export const uploadFile = createThunkAction(
   UPLOAD_FILE_TO_COLLECTION,

--- a/frontend/src/metabase/status/components/StatusListing/StatusListing.tsx
+++ b/frontend/src/metabase/status/components/StatusListing/StatusListing.tsx
@@ -1,7 +1,8 @@
 import React from "react";
 import { t } from "ttag";
-import { useSelector } from "react-redux";
 import { useBeforeUnload } from "react-use";
+
+import { useSelector } from "metabase/lib/redux";
 
 import { getUserIsAdmin, getUser } from "metabase/selectors/user";
 import { hasActiveUploads } from "metabase/redux/uploads";

--- a/frontend/src/metabase/status/components/StatusListing/StatusListing.tsx
+++ b/frontend/src/metabase/status/components/StatusListing/StatusListing.tsx
@@ -1,27 +1,26 @@
 import React from "react";
-import { connect } from "react-redux";
+import { t } from "ttag";
+import { useSelector } from "react-redux";
+import { useBeforeUnload } from "react-use";
 
 import { getUserIsAdmin, getUser } from "metabase/selectors/user";
-import type { State } from "metabase-types/store";
+import { hasActiveUploads } from "metabase/redux/uploads";
 
 import DatabaseStatus from "../../containers/DatabaseStatus";
 import FileUploadStatus from "../FileUploadStatus";
 import { StatusListingRoot } from "./StatusListing.styled";
 
-const mapStateToProps = (state: State) => ({
-  isAdmin: getUserIsAdmin(state),
-  isLoggedIn: !!getUser(state),
-});
+const StatusListingView = () => {
+  const isLoggedIn = !!useSelector(getUser);
+  const isAdmin = useSelector(getUserIsAdmin);
 
-export interface StatusListingProps {
-  isAdmin: boolean;
-  isLoggedIn: boolean;
-}
+  const uploadInProgress = useSelector(hasActiveUploads);
 
-export const StatusListingView = ({
-  isAdmin,
-  isLoggedIn,
-}: StatusListingProps) => {
+  useBeforeUnload(
+    uploadInProgress,
+    t`CSV Upload in progress. Are you sure you want to leave?`,
+  );
+
   if (!isLoggedIn) {
     return null;
   }
@@ -34,4 +33,4 @@ export const StatusListingView = ({
   );
 };
 
-export default connect(mapStateToProps)(StatusListingView);
+export default StatusListingView;

--- a/frontend/src/metabase/status/components/StatusListing/StatusListing.unit.spec.tsx
+++ b/frontend/src/metabase/status/components/StatusListing/StatusListing.unit.spec.tsx
@@ -1,36 +1,79 @@
 import React from "react";
 import { renderWithProviders, screen } from "__support__/ui";
 import { setupCollectionsEndpoints } from "__support__/server-mocks";
-import { createMockCollection } from "metabase-types/api/mocks";
+import { createMockCollection, createMockUser } from "metabase-types/api/mocks";
 
-import {
-  StatusListingView as StatusListing,
-  StatusListingProps,
-} from "./StatusListing";
+import { createMockState, createMockUpload } from "metabase-types/store/mocks";
+import { FileUploadState } from "metabase-types/store/upload";
+import StatusListing from "./StatusListing";
 
+// calls event handler in the mockEventListener that matches the eventName
+// and uses the mockEvent to hold the callback's return value
+const callMockEvent = (
+  mockEventListener: jest.SpyInstance,
+  eventName: string,
+): {
+  preventDefault: jest.Mock;
+  returnValue?: string;
+} => {
+  const mockEvent = {
+    preventDefault: jest.fn(),
+  };
+
+  mockEventListener.mock.calls
+    .filter(([event]) => eventName === event)
+    .forEach(([_, callback]) => callback(mockEvent));
+  return mockEvent;
+};
 const DatabaseStatusMock = () => <div>DatabaseStatus</div>;
 
 jest.mock("../../containers/DatabaseStatus", () => DatabaseStatusMock);
 
-const setup = (options?: Partial<StatusListingProps>) => {
-  setupCollectionsEndpoints([createMockCollection()]);
+interface setupProps {
+  isAdmin?: boolean;
+  upload?: FileUploadState;
+}
 
-  return renderWithProviders(<StatusListing isAdmin isLoggedIn {...options} />);
+const setup = ({ isAdmin = false, upload = {} }: setupProps = {}) => {
+  setupCollectionsEndpoints([createMockCollection({})]);
+
+  return renderWithProviders(<StatusListing />, {
+    storeInitialState: createMockState({
+      currentUser: createMockUser({
+        is_superuser: isAdmin,
+      }),
+      upload,
+    }),
+  });
 };
 
 describe("StatusListing", () => {
   it("should render database statuses for admins", () => {
-    setup({
-      isAdmin: true,
-      isLoggedIn: true,
-    });
-
+    setup({ isAdmin: true });
     expect(screen.getByText("DatabaseStatus")).toBeInTheDocument();
   });
 
   it("should not render database statuses for non-admins", () => {
-    renderWithProviders(<StatusListing isAdmin={false} isLoggedIn />);
-
+    setup();
     expect(screen.queryByText("DatabaseStatus")).not.toBeInTheDocument();
+  });
+
+  it("should not render if no one is logged in", () => {
+    setupCollectionsEndpoints([createMockCollection({})]);
+    renderWithProviders(<StatusListing />);
+    expect(screen.queryByText("DatabaseStatus")).not.toBeInTheDocument();
+  });
+
+  it("should give an alert if a user navigates away from the page during an upload", () => {
+    const mockEventListener = jest.spyOn(window, "addEventListener");
+
+    const mockUpload = createMockUpload();
+    setup({ isAdmin: true, upload: { [mockUpload.id]: mockUpload } });
+
+    const mockEvent = callMockEvent(mockEventListener, "beforeunload");
+    expect(mockEvent.returnValue).toEqual(
+      "CSV Upload in progress. Are you sure you want to leave?",
+    );
+    expect(mockEvent.preventDefault).toHaveBeenCalled();
   });
 });

--- a/frontend/test/__support__/events.ts
+++ b/frontend/test/__support__/events.ts
@@ -1,0 +1,25 @@
+type MockEvent = {
+  preventDefault: jest.Mock;
+  returnValue?: string;
+};
+
+type CallMockEventType = (
+  mockEventListener: jest.SpyInstance,
+  eventName: string,
+) => MockEvent;
+
+// calls event handler in the mockEventListener that matches the eventName
+// and uses the mockEvent to hold the callback's return value
+export const callMockEvent: CallMockEventType = (
+  mockEventListener: jest.SpyInstance,
+  eventName: string,
+) => {
+  const mockEvent = {
+    preventDefault: jest.fn(),
+  };
+
+  mockEventListener.mock.calls
+    .filter(([event]) => eventName === event)
+    .forEach(([_, callback]) => callback(mockEvent));
+  return mockEvent;
+};


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/30229

~🚧🚧WIP - Waiting for https://github.com/metabase/metabase/pull/30292 to merge and I'll update my test to use the `callMockEvent()` function~

### Description
Adds a browser alert if a user attempts to leave metabase while a CSV upload is happening

### How to verify
Try to reload the page while uploading a CSV

### Checklist
- [x] Tests have been added/updated to cover changes in this PR

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30372)
<!-- Reviewable:end -->
