### PR TITLE
Fix values source modal not handling not having access to the root collection

### DIFF
--- a/frontend/src/metabase/containers/DataPicker/CardPicker/CardPickerContainer.tsx
+++ b/frontend/src/metabase/containers/DataPicker/CardPicker/CardPickerContainer.tsx
@@ -38,7 +38,7 @@ interface CardPickerStateProps {
 interface CollectionsLoaderProps {
   collectionTree: Collection[];
   collections: Collection[];
-  rootCollection: Collection;
+  rootCollection?: Collection;
   allLoading: boolean;
 }
 

--- a/frontend/src/metabase/containers/DataPicker/CardPicker/utils.ts
+++ b/frontend/src/metabase/containers/DataPicker/CardPicker/utils.ts
@@ -33,7 +33,7 @@ export function buildCollectionTree({
   targetModel = "question",
 }: {
   collections: Collection[];
-  rootCollection: Collection;
+  rootCollection: Collection | undefined;
   currentUser: User;
   targetModel?: "model" | "question";
 }) {

--- a/frontend/src/metabase/parameters/components/ValuesSourceModal/ValuesSourceCardModal.tsx
+++ b/frontend/src/metabase/parameters/components/ValuesSourceModal/ValuesSourceCardModal.tsx
@@ -15,6 +15,7 @@ import Questions from "metabase/entities/questions";
 import Collections from "metabase/entities/collections";
 import Tables from "metabase/entities/tables";
 import { getMetadata } from "metabase/selectors/metadata";
+import { coerceCollectionId } from "metabase/collections/utils";
 import {
   Card,
   CardId,
@@ -201,7 +202,7 @@ export default _.compose(
   }),
   Collections.load({
     id: (state: State, { card }: ModalCardProps) =>
-      card?.collection_id ?? "root",
+      card ? coerceCollectionId(card.collection_id) : undefined,
     LoadingAndErrorWrapper: ModalLoadingAndErrorWrapper,
   }),
   connect(mapStateToProps, mapDispatchToProps),

--- a/frontend/src/metabase/parameters/components/ValuesSourceModal/ValuesSourceModal.unit.spec.tsx
+++ b/frontend/src/metabase/parameters/components/ValuesSourceModal/ValuesSourceModal.unit.spec.tsx
@@ -261,7 +261,7 @@ describe("ValuesSourceModal", () => {
       ).toBeInTheDocument();
     });
 
-    it("should allow searching for a card without access to the root collection", async () => {
+    it("should allow searching for a card without access to the root collection (metabase#30355)", async () => {
       await setup({
         hasCollectionAccess: false,
       });

--- a/frontend/src/metabase/parameters/components/ValuesSourceModal/ValuesSourceModal.unit.spec.tsx
+++ b/frontend/src/metabase/parameters/components/ValuesSourceModal/ValuesSourceModal.unit.spec.tsx
@@ -1,12 +1,7 @@
 import React from "react";
 import userEvent from "@testing-library/user-event";
 import { ROOT_COLLECTION } from "metabase/entities/collections";
-import {
-  Card,
-  Collection,
-  Database,
-  ParameterValues,
-} from "metabase-types/api";
+import { Card, ParameterValues } from "metabase-types/api";
 import {
   createMockCard,
   createMockCollection,
@@ -380,8 +375,6 @@ describe("ValuesSourceModal", () => {
 interface SetupOpts {
   parameter?: UiParameter;
   parameterValues?: ParameterValues;
-  databases?: Database[];
-  collections?: Collection[];
   cards?: Card[];
   hasCollectionAccess?: boolean;
   hasParameterValuesError?: boolean;
@@ -390,12 +383,12 @@ interface SetupOpts {
 const setup = async ({
   parameter = createMockUiParameter(),
   parameterValues = createMockParameterValues(),
-  databases = [createMockDatabase()],
-  collections = [createMockCollection(ROOT_COLLECTION)],
   cards = [],
   hasCollectionAccess = true,
   hasParameterValuesError = false,
 }: SetupOpts = {}) => {
+  const databases = [createMockDatabase()];
+  const collections = [createMockCollection(ROOT_COLLECTION)];
   const onSubmit = jest.fn();
   const onClose = jest.fn();
 

--- a/frontend/src/metabase/parameters/components/ValuesSourceModal/ValuesSourceModal.unit.spec.tsx
+++ b/frontend/src/metabase/parameters/components/ValuesSourceModal/ValuesSourceModal.unit.spec.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import userEvent from "@testing-library/user-event";
 import { ROOT_COLLECTION } from "metabase/entities/collections";
-import { Card, ParameterValues } from "metabase-types/api";
+import { Card, Collection, ParameterValues } from "metabase-types/api";
 import {
   createMockCard,
   createMockCollection,
@@ -14,6 +14,7 @@ import {
   setupErrorParameterValuesEndpoints,
   setupParameterValuesEndpoints,
   setupUnauthorizedCardsEndpoints,
+  setupUnauthorizedCollectionsEndpoints,
 } from "__support__/server-mocks";
 import { renderWithProviders, screen, waitFor } from "__support__/ui";
 import Field from "metabase-lib/metadata/Field";
@@ -23,8 +24,8 @@ import ValuesSourceModal from "./ValuesSourceModal";
 
 describe("ValuesSourceModal", () => {
   describe("fields source", () => {
-    it("should show a message about not connected fields", () => {
-      setup();
+    it("should show a message about not connected fields", async () => {
+      await setup();
 
       expect(
         screen.getByText(/You haven’t connected a field to this filter/),
@@ -32,7 +33,7 @@ describe("ValuesSourceModal", () => {
     });
 
     it("should show a message about missing field values", async () => {
-      setup({
+      await setup({
         parameter: createMockUiParameter({
           fields: [new Field(createMockField({ id: 1 }))],
         }),
@@ -42,12 +43,12 @@ describe("ValuesSourceModal", () => {
       });
 
       expect(
-        await screen.findByText(/We don’t have any cached values/),
+        screen.getByText(/We don’t have any cached values/),
       ).toBeInTheDocument();
     });
 
     it("should show field values", async () => {
-      setup({
+      await setup({
         parameter: createMockUiParameter({
           fields: [
             new Field(createMockField({ id: 1 })),
@@ -59,13 +60,11 @@ describe("ValuesSourceModal", () => {
         }),
       });
 
-      await waitFor(() => {
-        expect(screen.getByRole("textbox")).toHaveValue("A\nB\nC");
-      });
+      expect(screen.getByRole("textbox")).toHaveValue("A\nB\nC");
     });
 
-    it("should not show the fields option for variable template tags", () => {
-      setup({
+    it("should not show the fields option for variable template tags", async () => {
+      await setup({
         parameter: createMockUiParameter({
           hasVariableTemplateTagTarget: true,
         }),
@@ -79,8 +78,8 @@ describe("ValuesSourceModal", () => {
       ).toBeChecked();
     });
 
-    it("should preserve custom list option for variable template tags", () => {
-      setup({
+    it("should preserve custom list option for variable template tags", async () => {
+      await setup({
         parameter: createMockUiParameter({
           values_source_type: "static-list",
           hasVariableTemplateTagTarget: true,
@@ -91,7 +90,7 @@ describe("ValuesSourceModal", () => {
     });
 
     it("should copy field values when switching to custom list", async () => {
-      setup({
+      await setup({
         parameter: createMockUiParameter({
           fields: [
             new Field(createMockField({ id: 1 })),
@@ -105,10 +104,7 @@ describe("ValuesSourceModal", () => {
           values: [["C"], ["D"]],
         }),
       });
-
-      await waitFor(() => {
-        expect(screen.getByRole("textbox")).toHaveValue("C\nD");
-      });
+      expect(screen.getByRole("textbox")).toHaveValue("C\nD");
 
       userEvent.click(screen.getByRole("radio", { name: "Custom list" }));
       expect(screen.getByRole("radio", { name: "Custom list" })).toBeChecked();
@@ -116,7 +112,7 @@ describe("ValuesSourceModal", () => {
     });
 
     it("should not overwrite custom list values when field values are empty", async () => {
-      setup({
+      await setup({
         parameter: createMockUiParameter({
           fields: [
             new Field(createMockField({ id: 1 })),
@@ -130,9 +126,8 @@ describe("ValuesSourceModal", () => {
           values: [],
         }),
       });
-
       expect(
-        await screen.findByText(/We don’t have any cached values/),
+        screen.getByText(/We don’t have any cached values/),
       ).toBeInTheDocument();
 
       userEvent.click(screen.getByRole("radio", { name: "Custom list" }));
@@ -143,7 +138,7 @@ describe("ValuesSourceModal", () => {
 
   describe("card source", () => {
     it("should show a message when there are no text columns", async () => {
-      setup({
+      await setup({
         parameter: createMockUiParameter({
           values_source_type: "card",
           values_source_config: {
@@ -159,12 +154,12 @@ describe("ValuesSourceModal", () => {
       });
 
       expect(
-        await screen.findByText(/This question doesn’t have any text columns/),
+        screen.getByText(/This question doesn’t have any text columns/),
       ).toBeInTheDocument();
     });
 
     it("should allow to select only text fields", async () => {
-      const { onSubmit } = setup({
+      const { onSubmit } = await setup({
         parameter: createMockUiParameter({
           values_source_type: "card",
           values_source_config: {
@@ -193,9 +188,7 @@ describe("ValuesSourceModal", () => {
         ],
       });
 
-      userEvent.click(
-        await screen.findByRole("button", { name: /Pick a column/ }),
-      );
+      userEvent.click(screen.getByRole("button", { name: /Pick a column/ }));
       expect(
         screen.queryByRole("heading", { name: "ID" }),
       ).not.toBeInTheDocument();
@@ -209,7 +202,7 @@ describe("ValuesSourceModal", () => {
     });
 
     it("should show card values", async () => {
-      setup({
+      await setup({
         parameter: createMockUiParameter({
           values_source_type: "card",
           values_source_config: {
@@ -236,13 +229,11 @@ describe("ValuesSourceModal", () => {
         ],
       });
 
-      await waitFor(() => {
-        expect(screen.getByRole("textbox")).toHaveValue("A\nB\nC");
-      });
+      expect(screen.getByRole("textbox")).toHaveValue("A\nB\nC");
     });
 
     it("should display a message when the user has no access to the card", async () => {
-      setup({
+      await setup({
         parameter: createMockUiParameter({
           values_source_type: "card",
           values_source_config: {
@@ -255,16 +246,16 @@ describe("ValuesSourceModal", () => {
             name: "Products",
           }),
         ],
-        hasDataAccess: false,
+        hasCollectionAccess: false,
       });
 
       expect(
-        await screen.findByText("You don't have permissions to do that."),
+        screen.getByText("You don't have permissions to do that."),
       ).toBeInTheDocument();
     });
 
     it("should display a message when there is an error in the underlying query", async () => {
-      setup({
+      await setup({
         parameter: createMockUiParameter({
           values_source_type: "card",
           values_source_config: {
@@ -290,12 +281,12 @@ describe("ValuesSourceModal", () => {
       });
 
       expect(
-        await screen.findByText("An error occurred in your query"),
+        screen.getByText("An error occurred in your query"),
       ).toBeInTheDocument();
     });
 
     it("should copy card values when switching to custom list", async () => {
-      setup({
+      await setup({
         parameter: createMockUiParameter({
           values_source_type: "card",
           values_source_config: {
@@ -321,10 +312,7 @@ describe("ValuesSourceModal", () => {
           }),
         ],
       });
-
-      await waitFor(() => {
-        expect(screen.getByRole("textbox")).toHaveValue("A\nB\nC");
-      });
+      expect(screen.getByRole("textbox")).toHaveValue("A\nB\nC");
 
       userEvent.click(screen.getByRole("radio", { name: "Custom list" }));
       expect(screen.getByRole("radio", { name: "Custom list" })).toBeChecked();
@@ -333,8 +321,8 @@ describe("ValuesSourceModal", () => {
   });
 
   describe("list source", () => {
-    it("should set static list values", () => {
-      const { onSubmit } = setup();
+    it("should set static list values", async () => {
+      const { onSubmit } = await setup();
 
       userEvent.click(screen.getByRole("radio", { name: "Custom list" }));
       userEvent.type(screen.getByRole("textbox"), "Gadget\nWidget");
@@ -345,8 +333,8 @@ describe("ValuesSourceModal", () => {
       });
     });
 
-    it("should preserve the list when changing the source type", () => {
-      setup({
+    it("should preserve the list when changing the source type", async () => {
+      await setup({
         parameter: createMockUiParameter({
           values_source_type: "static-list",
           values_source_config: {
@@ -369,22 +357,24 @@ interface SetupOpts {
   parameter?: UiParameter;
   parameterValues?: ParameterValues;
   cards?: Card[];
-  hasDataAccess?: boolean;
+  collections?: Collection[];
+  hasCollectionAccess?: boolean;
   hasParameterValuesError?: boolean;
 }
 
-const setup = ({
+const setup = async ({
   parameter = createMockUiParameter(),
   parameterValues = createMockParameterValues(),
   cards = [],
-  hasDataAccess = true,
+  collections = [createMockCollection(ROOT_COLLECTION)],
+  hasCollectionAccess = true,
   hasParameterValuesError = false,
 }: SetupOpts = {}) => {
   const onSubmit = jest.fn();
   const onClose = jest.fn();
 
-  if (hasDataAccess) {
-    setupCollectionsEndpoints([createMockCollection(ROOT_COLLECTION)]);
+  if (hasCollectionAccess) {
+    setupCollectionsEndpoints(collections);
     setupCardsEndpoints(cards);
 
     if (!hasParameterValuesError) {
@@ -393,6 +383,7 @@ const setup = ({
       setupErrorParameterValuesEndpoints();
     }
   } else {
+    setupUnauthorizedCollectionsEndpoints(collections);
     setupUnauthorizedCardsEndpoints(cards);
   }
 
@@ -403,6 +394,10 @@ const setup = ({
       onClose={onClose}
     />,
   );
+
+  await waitFor(() => {
+    expect(screen.queryByText(/Loading/)).not.toBeInTheDocument();
+  });
 
   return { onSubmit };
 };

--- a/frontend/test/__support__/server-mocks/collection.ts
+++ b/frontend/test/__support__/server-mocks/collection.ts
@@ -7,6 +7,7 @@ import {
   getCollectionVirtualSchemaName,
   SAVED_QUESTIONS_VIRTUAL_DB_ID,
 } from "metabase-lib/metadata/utils/saved-questions";
+import { PERMISSION_ERROR } from "./constants";
 
 export function setupCollectionsEndpoints(collections: Collection[]) {
   fetchMock.get("path:/api/collection/root", ROOT_COLLECTION);
@@ -57,4 +58,17 @@ export function setupCollectionVirtualSchemaEndpoints(
 
   fetchMock.get(urls.questions, questionVirtualTables);
   fetchMock.get(urls.models, modelVirtualTables);
+}
+
+export function setupUnauthorizedCollectionEndpoints(collection: Collection) {
+  fetchMock.get(`path:/api/card/${collection.id}`, {
+    status: 403,
+    body: PERMISSION_ERROR,
+  });
+}
+
+export function setupUnauthorizedCollectionsEndpoints(
+  collections: Collection[],
+) {
+  collections.forEach(setupUnauthorizedCollectionEndpoints);
 }

--- a/frontend/test/__support__/server-mocks/collection.ts
+++ b/frontend/test/__support__/server-mocks/collection.ts
@@ -61,7 +61,7 @@ export function setupCollectionVirtualSchemaEndpoints(
 }
 
 export function setupUnauthorizedCollectionEndpoints(collection: Collection) {
-  fetchMock.get(`path:/api/card/${collection.id}`, {
+  fetchMock.get(`path:/api/collection/${collection.id}`, {
     status: 403,
     body: PERMISSION_ERROR,
   });


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/30355

How to test:
- Add a collection in "Our analytics" and add a question to it
- Add another user in Admin -> People
- Revoke "Our analytics" permissions in Admin -> Permissions for All users. The new user would have access to the inner collection but not the root one
- Log in as the new user
- Go to the created collection -> New -> Dashboard -> Filter -> Text or Category -> Is -> Dropdown list -> Edit
- From model or saved question -> Pick question 
- Make sure it's possible to select a question in this case

<img width="1728" alt="Screenshot 2023-04-26 at 14 08 27" src="https://user-images.githubusercontent.com/8542534/234557556-c657ee25-c8aa-4dd7-888a-4339ee596b2b.png">

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30384)
<!-- Reviewable:end -->
