### PR TITLE
Force import redux hooks from metabase lib redux instead

### DIFF
--- a/frontend/src/metabase/.eslintrc
+++ b/frontend/src/metabase/.eslintrc
@@ -7,6 +7,13 @@
           "metabase-enterprise",
           "metabase-enterprise/*",
           "cljs/metabase.lib*"
+        ],
+        "paths": [
+          {
+            "name": "react-redux",
+            "importNames": ["useSelector", "useDispatch"],
+            "message": "Please import from `metabase/lib/redux` instead."
+          }
         ]
       }
     ]

--- a/frontend/src/metabase/.eslintrc
+++ b/frontend/src/metabase/.eslintrc
@@ -24,6 +24,21 @@
       "rules": {
         "no-console": 0
       }
+    },
+    {
+      "files": ["lib/redux/hooks.ts"],
+      "rules": {
+        "no-restricted-imports": [
+          "error",
+          {
+            "patterns": [
+              "metabase-enterprise",
+              "metabase-enterprise/*",
+              "cljs/metabase.lib*"
+            ]
+          }
+        ]
+      }
     }
   ]
 }

--- a/frontend/src/metabase/containers/SavedQuestionLoader.jsx
+++ b/frontend/src/metabase/containers/SavedQuestionLoader.jsx
@@ -1,8 +1,8 @@
 import { useState, useEffect } from "react";
 import _ from "underscore";
 import { useAsync } from "react-use";
-import { useSelector, useDispatch } from "react-redux";
 
+import { useSelector, useDispatch } from "metabase/lib/redux";
 import { loadMetadataForCard } from "metabase/questions/actions";
 import { getMetadata } from "metabase/selectors/metadata";
 

--- a/frontend/src/metabase/containers/UndoListing.jsx
+++ b/frontend/src/metabase/containers/UndoListing.jsx
@@ -1,9 +1,9 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { useSelector, useDispatch } from "react-redux";
 import { Motion, spring } from "react-motion";
 import { t } from "ttag";
 
+import { useSelector, useDispatch } from "metabase/lib/redux";
 import { capitalize, inflect } from "metabase/lib/formatting";
 import { dismissUndo, performUndo } from "metabase/redux/undo";
 

--- a/frontend/src/metabase/lib/redux/hooks.ts
+++ b/frontend/src/metabase/lib/redux/hooks.ts
@@ -1,9 +1,11 @@
 import type { ThunkDispatch, AnyAction } from "@reduxjs/toolkit";
 import type { TypedUseSelectorHook } from "react-redux";
+/* eslint-disable no-restricted-imports */
 import {
   useDispatch as useDispatchOriginal,
   useSelector as useSelectorOriginal,
 } from "react-redux";
+/* eslint-enable no-restricted-imports */
 
 import type { State } from "metabase-types/store";
 

--- a/frontend/src/metabase/lib/redux/hooks.ts
+++ b/frontend/src/metabase/lib/redux/hooks.ts
@@ -1,11 +1,9 @@
 import type { ThunkDispatch, AnyAction } from "@reduxjs/toolkit";
 import type { TypedUseSelectorHook } from "react-redux";
-/* eslint-disable no-restricted-imports */
 import {
   useDispatch as useDispatchOriginal,
   useSelector as useSelectorOriginal,
 } from "react-redux";
-/* eslint-enable no-restricted-imports */
 
 import type { State } from "metabase-types/store";
 

--- a/frontend/src/metabase/query_builder/containers/QueryViewer.tsx
+++ b/frontend/src/metabase/query_builder/containers/QueryViewer.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useMemo } from "react";
 import _ from "underscore";
-import { useSelector, useDispatch } from "react-redux";
 
+import { useSelector, useDispatch } from "metabase/lib/redux";
 import NativeQueryEditor from "metabase/query_builder/components/NativeQueryEditor";
 import ReadOnlyNotebook from "metabase/query_builder/components/notebook/ReadOnlyNotebook";
 

--- a/frontend/src/metabase/status/components/FileUploadStatus/FileUploadStatus.tsx
+++ b/frontend/src/metabase/status/components/FileUploadStatus/FileUploadStatus.tsx
@@ -1,6 +1,6 @@
 import React from "react";
-import { useSelector } from "react-redux";
 
+import { useSelector } from "metabase/lib/redux";
 import { getAllUploads } from "metabase/redux/uploads";
 import Collections from "metabase/entities/collections/collections";
 import { Collection } from "metabase-types/api";


### PR DESCRIPTION
[Discussion on Slack](https://metaboat.slack.com/archives/C505ZNNH4/p1681218249413089?thread_ts=1681218146.731799&cid=C505ZNNH4)


### Description

This ensures we have the correct state type without having to manually type
our state every time.

### How to verify

All CI checks are green. Or you could run `yarn lint-eslint` locally and not get any error.


### Checklist

- [ ] Tests have been added/updated to cover changes in this PR

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30389)
<!-- Reviewable:end -->
