### PR TITLE
Allow Object Detail to show out-of-range detail items

### DIFF
--- a/e2e/test/scenarios/visualizations/object_detail.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/object_detail.cy.spec.js
@@ -35,6 +35,12 @@ const TEST_QUESTION = {
   },
 };
 
+const TEST_PEOPLE_QUESTION = {
+  query: {
+    "source-table": PEOPLE_ID,
+  },
+};
+
 describe("scenarios > question > object details", () => {
   beforeEach(() => {
     restore();
@@ -119,7 +125,25 @@ describe("scenarios > question > object details", () => {
     cy.createQuestion(TEST_QUESTION).then(({ body: { id } }) => {
       cy.visit(`/question/${id}/${FILTERED_OUT_ID}`);
       cy.wait("@cardQuery");
-      cy.findByText("The page you asked for couldn't be found.");
+      cy.findByRole("dialog").within(() => {
+        cy.findByText(/We're a little lost/i);
+      });
+    });
+  });
+
+  it("can view details of an out-of-range record", () => {
+    cy.intercept("POST", "/api/card/*/query").as("cardQuery");
+    // since we only fetch 2000 rows, this ID is out of range
+    // and has to be fetched separately
+    const OUT_OF_RANGE_ID = 2150;
+
+    cy.createQuestion(TEST_PEOPLE_QUESTION).then(({ body: { id } }) => {
+      cy.visit(`/question/${id}/${OUT_OF_RANGE_ID}`);
+      cy.wait("@cardQuery");
+      cy.findByTestId("object-detail").within(() => {
+        // should appear in header and body of the modal
+        cy.findAllByText(/Marcelina Kuhn/i).should("have.length", 2);
+      });
     });
   });
 
@@ -182,7 +206,9 @@ describe("scenarios > question > object details", () => {
 
     openProductsTable({ limit: 5 });
 
-    cy.findByTextEnsureVisible("Rustic Paper Wallet").click();
+    cy.findByTestId("TableInteractive-root")
+      .findByTextEnsureVisible("Rustic Paper Wallet")
+      .click();
 
     cy.location("search").should("eq", "?objectId=Rustic%20Paper%20Wallet");
     cy.findByTestId("object-detail").contains("Rustic Paper Wallet");
@@ -276,56 +302,64 @@ function changeSorting(columnName, direction) {
   cy.wait("@dataset");
 }
 
-['postgres', 'mysql'].forEach(dialect => {
-  describe(`Object Detail > composite keys (${dialect})`, { tags: ['@external'] }, () => {
-    const TEST_TABLE = "composite_pk_table";
+["postgres", "mysql"].forEach(dialect => {
+  describe(
+    `Object Detail > composite keys (${dialect})`,
+    { tags: ["@external"] },
+    () => {
+      const TEST_TABLE = "composite_pk_table";
 
-    beforeEach(() => {
-      resetTestTable({ type: dialect, table: TEST_TABLE });
-      restore(`${dialect}-writable`);
-      cy.signInAsAdmin();
-      resyncDatabase({ dbId: WRITABLE_DB_ID, tableName: TEST_TABLE });
-    });
-
-    it('can show object detail modal for items with composite keys', () => {
-      getTableId({ name: TEST_TABLE }).then(tableId => {
-        cy.visit(`/question#?db=${WRITABLE_DB_ID}&table=${tableId}`);
+      beforeEach(() => {
+        resetTestTable({ type: dialect, table: TEST_TABLE });
+        restore(`${dialect}-writable`);
+        cy.signInAsAdmin();
+        resyncDatabase({ dbId: WRITABLE_DB_ID, tableName: TEST_TABLE });
       });
 
-      cy.icon('expand').first().click();
+      it("can show object detail modal for items with composite keys", () => {
+        getTableId({ name: TEST_TABLE }).then(tableId => {
+          cy.visit(`/question#?db=${WRITABLE_DB_ID}&table=${tableId}`);
+        });
 
-      cy.findByRole('dialog').within(() => {
-        cy.findAllByText("Duck").should('have.length', 2);
-        cy.icon('chevrondown').click();
-        cy.findAllByText("Horse").should('have.length', 2);
+        cy.icon("expand").first().click();
+
+        cy.findByRole("dialog").within(() => {
+          cy.findAllByText("Duck").should("have.length", 2);
+          cy.icon("chevrondown").click();
+          cy.findAllByText("Horse").should("have.length", 2);
+        });
       });
-    });
-  });
+    },
+  );
 
-  describe(`Object Detail > no primary keys (${dialect})`, { tags: ['@external'] }, () => {
-    const TEST_TABLE = "no_pk_table";
+  describe(
+    `Object Detail > no primary keys (${dialect})`,
+    { tags: ["@external"] },
+    () => {
+      const TEST_TABLE = "no_pk_table";
 
-    beforeEach(() => {
-      resetTestTable({ type: dialect, table: TEST_TABLE });
-      restore(`${dialect}-writable`);
-      cy.signInAsAdmin();
-      resyncDatabase({ dbId: WRITABLE_DB_ID, tableName: TEST_TABLE });
-    });
-
-    it('can show object detail modal for items with no primary key', () => {
-      getTableId({ name: TEST_TABLE }).then(tableId => {
-        cy.visit(`/question#?db=${WRITABLE_DB_ID}&table=${tableId}`);
+      beforeEach(() => {
+        resetTestTable({ type: dialect, table: TEST_TABLE });
+        restore(`${dialect}-writable`);
+        cy.signInAsAdmin();
+        resyncDatabase({ dbId: WRITABLE_DB_ID, tableName: TEST_TABLE });
       });
 
-      cy.icon('expand').first().click();
+      it("can show object detail modal for items with no primary key", () => {
+        getTableId({ name: TEST_TABLE }).then(tableId => {
+          cy.visit(`/question#?db=${WRITABLE_DB_ID}&table=${tableId}`);
+        });
 
-      cy.findByRole('dialog').within(() => {
-        cy.findAllByText("Duck").should('have.length', 2);
-        cy.icon('chevrondown').click();
-        cy.findAllByText("Horse").should('have.length', 2);
+        cy.icon("expand").first().click();
+
+        cy.findByRole("dialog").within(() => {
+          cy.findAllByText("Duck").should("have.length", 2);
+          cy.icon("chevrondown").click();
+          cy.findAllByText("Horse").should("have.length", 2);
+        });
       });
-    });
-  });
+    },
+  );
 });
 
 describe(`Object Detail > public`, () => {
@@ -334,40 +368,40 @@ describe(`Object Detail > public`, () => {
     cy.signInAsAdmin();
   });
 
-  it('can view a public object detail question', () => {
-
-    cy.createQuestion({ ...TEST_QUESTION, display: 'object' }).then(
+  it("can view a public object detail question", () => {
+    cy.createQuestion({ ...TEST_QUESTION, display: "object" }).then(
       ({ body: { id: questionId } }) => {
         visitPublicQuestion(questionId);
       },
     );
-    cy.icon('warning').should('not.exist');
+    cy.icon("warning").should("not.exist");
 
-    cy.findByTestId('object-detail').within(() => {
-      cy.findByText('User ID').should('be.visible');
-      cy.findByText('1283').should('be.visible');
+    cy.findByTestId("object-detail").within(() => {
+      cy.findByText("User ID").should("be.visible");
+      cy.findByText("1283").should("be.visible");
     });
 
-    cy.findByTestId('pagination-footer').within(() => {
-      cy.findByText("Item 1 of 3").should('be.visible');
+    cy.findByTestId("pagination-footer").within(() => {
+      cy.findByText("Item 1 of 3").should("be.visible");
     });
   });
 
-  it('can view an object detail question on a public dashboard', () => {
-    cy.createQuestionAndDashboard({ questionDetails: { ...TEST_QUESTION, display: 'object' } }).then(
-      ({ body: { dashboard_id } }) => {
-        visitPublicDashboard(dashboard_id);
-      });
-
-    cy.icon('warning').should('not.exist');
-
-    cy.findByTestId('object-detail').within(() => {
-      cy.findByText('User ID').should('be.visible');
-      cy.findByText('1283').should('be.visible');
+  it("can view an object detail question on a public dashboard", () => {
+    cy.createQuestionAndDashboard({
+      questionDetails: { ...TEST_QUESTION, display: "object" },
+    }).then(({ body: { dashboard_id } }) => {
+      visitPublicDashboard(dashboard_id);
     });
 
-    cy.findByTestId('pagination-footer').within(() => {
-      cy.findByText("Item 1 of 3").should('be.visible');
+    cy.icon("warning").should("not.exist");
+
+    cy.findByTestId("object-detail").within(() => {
+      cy.findByText("User ID").should("be.visible");
+      cy.findByText("1283").should("be.visible");
+    });
+
+    cy.findByTestId("pagination-footer").within(() => {
+      cy.findByText("Item 1 of 3").should("be.visible");
     });
   });
 });

--- a/frontend/src/metabase/components/ErrorDetails/types.ts
+++ b/frontend/src/metabase/components/ErrorDetails/types.ts
@@ -1,5 +1,5 @@
 export interface ErrorDetailsProps {
-  details: string | Record<string, any>;
+  details?: string | Record<string, any>;
   centered?: boolean;
   className?: string;
 }

--- a/frontend/src/metabase/containers/ErrorPages.tsx
+++ b/frontend/src/metabase/containers/ErrorPages.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import { t } from "ttag";
 import { color } from "metabase/lib/colors";
 
+import type { ErrorDetailsProps } from "metabase/components/ErrorDetails/types";
 import Icon from "metabase/components/Icon";
 import EmptyState from "metabase/components/EmptyState";
 import ErrorDetails from "metabase/components/ErrorDetails/ErrorDetails";
@@ -14,6 +15,10 @@ export const GenericError = ({
   title = t`Something's gone wrong`,
   message = t`We've run into an error. You can try refreshing the page, or just go back.`,
   details,
+}: {
+  title?: string;
+  message?: string;
+  details: ErrorDetailsProps["details"];
 }) => (
   <ErrorPageRoot>
     <EmptyState
@@ -27,12 +32,18 @@ export const GenericError = ({
   </ErrorPageRoot>
 );
 
-export const NotFound = () => (
+export const NotFound = ({
+  title = t`We're a little lost...`,
+  message = t`The page you asked for couldn't be found.`,
+}: {
+  title?: string;
+  message?: string;
+}) => (
   <ErrorPageRoot>
     <EmptyState
       illustrationElement={<img src={NoResults} />}
-      title={t`We're a little lost...`}
-      message={t`The page you asked for couldn't be found.`}
+      title={title}
+      message={message}
     />
   </ErrorPageRoot>
 );
@@ -46,7 +57,13 @@ export const Unauthorized = () => (
   </ErrorPageRoot>
 );
 
-export const Archived = ({ entityName, linkTo }) => (
+export const Archived = ({
+  entityName,
+  linkTo,
+}: {
+  entityName: string;
+  linkTo: string;
+}) => (
   <ErrorPageRoot>
     <EmptyState
       title={t`This ${entityName} has been archived`}

--- a/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetail.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetail.styled.tsx
@@ -61,6 +61,9 @@ export const CloseButton = styled.div`
 
 export const ErrorWrapper = styled.div`
   height: 480px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 `;
 
 type GridContainerProps = { cols?: number };

--- a/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetail.tsx
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetail.tsx
@@ -11,7 +11,6 @@ import type {
   VisualizationSettings,
 } from "metabase-types/api";
 import { DatasetData } from "metabase-types/types/Dataset";
-import { isEmpty } from "metabase/lib/validate";
 
 import Button from "metabase/core/components/Button";
 import { NotFound } from "metabase/containers/ErrorPages";
@@ -151,14 +150,17 @@ export function ObjectDetailView({
   const prevTableForeignKeys = usePrevious(tableForeignKeys);
   const [data, setData] = useState<DatasetData>(passedData);
 
-  const pkIndex = useMemo(
-    () => passedData?.cols?.findIndex(isPK),
-    [passedData],
-  );
+  const pkIndex = useMemo(() => {
+    const pkCount = passedData?.cols?.filter(isPK)?.length;
+    if (pkCount !== 1) {
+      return undefined;
+    }
+    return passedData?.cols?.findIndex(isPK);
+  }, [passedData]);
   const zoomedRow = useMemo(
     () =>
       passedZoomedRow ||
-      (!isEmpty(pkIndex) &&
+      (pkIndex !== undefined &&
         data.rows.find(row => row[pkIndex] === zoomedRowID)) ||
       undefined,
     [passedZoomedRow, pkIndex, data, zoomedRowID],

--- a/frontend/src/metabase/visualizations/components/ObjectDetail/utils.ts
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/utils.ts
@@ -8,6 +8,7 @@ import type { TableId, VisualizationSettings } from "metabase-types/api";
 import {
   getIsPKFromTablePredicate,
   isEntityName,
+  isPK,
 } from "metabase-lib/types/utils/isa";
 import Question from "metabase-lib/Question";
 import Table from "metabase-lib/metadata/Table";
@@ -112,3 +113,13 @@ export const getIdValue = ({
 export function getSingleResultsRow(data: DatasetData) {
   return data.rows.length === 1 ? data.rows[0] : null;
 }
+
+export const getSinglePKIndex = (cols: Column[]) => {
+  const pkCount = cols?.filter(isPK)?.length;
+  if (pkCount !== 1) {
+    return undefined;
+  }
+  const index = cols?.findIndex(isPK);
+
+  return index === -1 ? undefined : index;
+};

--- a/frontend/src/metabase/visualizations/components/ObjectDetail/utils.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/utils.unit.spec.ts
@@ -9,7 +9,12 @@ import type { DatetimeUnit } from "metabase-types/api";
 import { Card } from "metabase-types/types/Card";
 import Question from "metabase-lib/Question";
 
-import { getObjectName, getDisplayId, getIdValue } from "./utils";
+import {
+  getObjectName,
+  getDisplayId,
+  getIdValue,
+  getSinglePKIndex,
+} from "./utils";
 
 const card = {
   id: 1,
@@ -218,6 +223,24 @@ describe("ObjectDetail utils", () => {
       });
 
       expect(id).toBe(22);
+    });
+  });
+
+  describe("getSinglePKIndex", () => {
+    it("should return the index of the single PK column", () => {
+      expect(getSinglePKIndex([idCol, qtyCol, nameCol])).toBe(0);
+      expect(getSinglePKIndex([qtyCol, idCol, nameCol])).toBe(1);
+      expect(getSinglePKIndex([qtyCol, nameCol, idCol])).toBe(2);
+    });
+
+    it("should return undefined if there are multiple PKs", () => {
+      expect(getSinglePKIndex([idCol, productIdCol, qtyCol, nameCol])).toBe(
+        undefined,
+      );
+    });
+
+    it("should return undefined if there are no PKs", () => {
+      expect(getSinglePKIndex([qtyCol, nameCol])).toBe(undefined);
     });
   });
 });


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/30168

### Description

Currently, Metabase fetches only the first 2000 results for any given query. Object detail currently pulls its data from existing query results, rather than running its own query, so that even if a given row should technically be part of a query, it will not show up in object detail.

This will become a major problem with the introduction of entity indexes, where we index up to 5000 records in a model and we want to link to them directly. But even now, it's kind of lame state of affairs that you can't create a permalink to a single record by its primary key.

Here, I solve this by allowing the object detail model itself to try to fetch an additional record if it is missing data. It simply adds a PK filter to its query, and if that query returns a row, it displays it.

Before | After
--- | ---
![Screen Shot 2023-04-26 at 1 41 43 PM](https://user-images.githubusercontent.com/30528226/234685191-d81519cb-7a21-4da9-b6f8-9d7b1382f774.png) | ![Screen Shot 2023-04-26 at 1 40 52 PM](https://user-images.githubusercontent.com/30528226/234685192-1aed16b0-d17e-4ad1-b484-f5becf8be3b9.png)

(while I was at it, I added the ability to set a custom description for the not found error component, and while I was doing that I converted that file into typescript)

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Create a new question or model on a table with more than 2000 rows, like the `People` table in the test DB.
2. When the question is saved, simply add a `/{id}` to the url to trigger the object detail-showing behavior: e.g. `http://localhost:3000/model/125-people-model/2150`
3. You should see the record! In the network inspector you should see two calls to `/api/dataset`, the second one should fetch a single row - the out of range one!
4. If you try a truly non-existent record (try 4000 on the people table) you should still get not found error, but BONUS! it no longer says "The page you asked for couldn't be found", but more sensibly: "We couldn't find that record"

### Checklist

- [x] Tests have been added/updated to cover changes in this PR

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30399)
<!-- Reviewable:end -->
