### PR TITLE
Reusable Common Link Variants

### DIFF
--- a/frontend/src/metabase/account/notifications/components/HelpModal/HelpModal.jsx
+++ b/frontend/src/metabase/account/notifications/components/HelpModal/HelpModal.jsx
@@ -3,8 +3,9 @@ import PropTypes from "prop-types";
 import { jt, t } from "ttag";
 import Settings from "metabase/lib/settings";
 import Button from "metabase/core/components/Button";
+import Link from "metabase/core/components/Link";
 import ModalContent from "metabase/components/ModalContent";
-import { ModalLink, ModalMessage } from "./HelpModal.styled";
+import { ModalMessage } from "./HelpModal.styled";
 
 const propTypes = {
   onClose: PropTypes.func,
@@ -40,9 +41,9 @@ HelpModal.propTypes = propTypes;
 
 const getAdminLink = (email, text) => {
   return email ? (
-    <ModalLink key="admin-link" href={`mailto:${email}`}>
+    <Link variant="brand" key="admin-link" href={`mailto:${email}`}>
       {text}
-    </ModalLink>
+    </Link>
   ) : (
     text
   );

--- a/frontend/src/metabase/account/notifications/components/HelpModal/HelpModal.styled.jsx
+++ b/frontend/src/metabase/account/notifications/components/HelpModal/HelpModal.styled.jsx
@@ -1,14 +1,4 @@
 import styled from "@emotion/styled";
-import { color } from "metabase/lib/colors";
-import Link from "metabase/core/components/Link";
-
-export const ModalLink = styled(Link)`
-  color: ${color("brand")};
-
-  &:hover {
-    text-decoration: underline;
-  }
-`;
 
 export const ModalMessage = styled.div`
   &:not(:last-child) {

--- a/frontend/src/metabase/account/notifications/components/NotificationCard/NotificationCard.jsx
+++ b/frontend/src/metabase/account/notifications/components/NotificationCard/NotificationCard.jsx
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import { t } from "ttag";
 import Settings from "metabase/lib/settings";
 import { formatDateTimeWithUnit } from "metabase/lib/formatting";
+import Link from "metabase/core/components/Link";
 import {
   canArchive,
   formatChannel,
@@ -15,7 +16,6 @@ import {
   NotificationDescription,
   NotificationCardRoot,
   NotificationMessage,
-  NotificationTitle,
 } from "./NotificationCard.styled";
 
 const propTypes = {
@@ -48,9 +48,9 @@ const NotificationCard = ({
   return (
     <NotificationCardRoot>
       <NotificationContent>
-        <NotificationTitle to={formatLink(item, type)}>
+        <Link variant="brandBold" to={formatLink(item, type)}>
           {formatTitle(item, type)}
-        </NotificationTitle>
+        </Link>
         <NotificationDescription>
           {item.channels.map((channel, index) => (
             <NotificationMessage key={index}>

--- a/frontend/src/metabase/account/notifications/components/NotificationCard/NotificationCard.styled.jsx
+++ b/frontend/src/metabase/account/notifications/components/NotificationCard/NotificationCard.styled.jsx
@@ -1,7 +1,6 @@
 import styled from "@emotion/styled";
 import { color } from "metabase/lib/colors";
 import Icon from "metabase/components/Icon";
-import Link from "metabase/core/components/Link";
 
 export const NotificationCardRoot = styled.div`
   display: flex;
@@ -18,15 +17,6 @@ export const NotificationCardRoot = styled.div`
 
 export const NotificationContent = styled.div`
   flex: 1 1 auto;
-`;
-
-export const NotificationTitle = styled(Link)`
-  color: ${color("brand")};
-  font-weight: bold;
-
-  &:hover {
-    text-decoration: underline;
-  }
 `;
 
 export const NotificationDescription = styled.div`

--- a/frontend/src/metabase/admin/app/components/DeprecationNotice/DeprecationNotice.styled.tsx
+++ b/frontend/src/metabase/admin/app/components/DeprecationNotice/DeprecationNotice.styled.tsx
@@ -1,7 +1,6 @@
 import styled from "@emotion/styled";
 import { color } from "metabase/lib/colors";
 import Icon from "metabase/components/Icon";
-import Link from "metabase/core/components/Link";
 
 export const NoticeRoot = styled.div`
   display: flex;
@@ -14,11 +13,6 @@ export const NoticeContent = styled.div`
   flex: 1 1 auto;
   margin: 0 0.75rem;
   color: ${color("text-dark")};
-`;
-
-export const NoticeLink = styled(Link)`
-  color: ${color("brand")};
-  font-weight: bold;
 `;
 
 export const NoticeWarningIcon = styled(Icon)`

--- a/frontend/src/metabase/admin/app/components/DeprecationNotice/DeprecationNotice.tsx
+++ b/frontend/src/metabase/admin/app/components/DeprecationNotice/DeprecationNotice.tsx
@@ -1,9 +1,9 @@
 import React from "react";
 import { jt, t } from "ttag";
+import Link from "metabase/core/components/Link";
 import {
   NoticeCloseIcon,
   NoticeContent,
-  NoticeLink,
   NoticeRoot,
   NoticeWarningIcon,
 } from "./DeprecationNotice.styled";
@@ -45,31 +45,35 @@ const getBannerContent = (
 
   if (hasSlackBot && hasDeprecatedDatabase) {
     return jt`You’re using a ${(
-      <NoticeLink
+      <Link
+        variant="brandBold"
         key="database"
         to={databaseListUrl}
-      >{t`Database driver`}</NoticeLink>
+      >{t`Database driver`}</Link>
     )} and a ${(
-      <NoticeLink
+      <Link
+        variant="brandBold"
         key="slack"
         to={slackSettingsUrl}
-      >{t`Slack bot integration`}</NoticeLink>
+      >{t`Slack bot integration`}</Link>
     )} which are now deprecated and will be removed in the next release. We recommend you ${(
       <strong key="upgrade">{t`upgrade`}</strong>
     )}.`;
   } else if (hasSlackBot) {
     return jt`Your Slack bot was deprecated but is still working. We recommend you delete the existing connection and ${(
-      <NoticeLink
+      <Link
+        variant="brandBold"
         key="slack"
         to={slackSettingsUrl}
-      >{t`upgrade to Slack Apps`}</NoticeLink>
+      >{t`upgrade to Slack Apps`}</Link>
     )}.`;
   } else if (hasDeprecatedDatabase) {
     return jt`You’re using a ${(
-      <NoticeLink
+      <Link
+        variant="brandBold"
         key="database"
         to={databaseListUrl}
-      >{t`Database driver`}</NoticeLink>
+      >{t`Database driver`}</Link>
     )} which is now deprecated and will be removed in the next release. We recommend you ${(
       <strong key="upgrade">{t`upgrade`}</strong>
     )}.`;

--- a/frontend/src/metabase/admin/tasks/containers/ModelCacheRefreshJobs/ModelCacheRefreshJobs.styled.tsx
+++ b/frontend/src/metabase/admin/tasks/containers/ModelCacheRefreshJobs/ModelCacheRefreshJobs.styled.tsx
@@ -1,7 +1,4 @@
 import styled from "@emotion/styled";
-
-import Link from "metabase/core/components/Link";
-
 import { color } from "metabase/lib/colors";
 
 export const ErrorBox = styled.div`
@@ -15,10 +12,6 @@ export const ErrorBox = styled.div`
   font-weight: 400;
   font-size: 12px;
   line-height: 20px;
-`;
-
-export const StyledLink = styled(Link)`
-  color: ${color("brand")};
 `;
 
 export const IconButtonContainer = styled.button`

--- a/frontend/src/metabase/admin/tasks/containers/ModelCacheRefreshJobs/ModelCacheRefreshJobs.tsx
+++ b/frontend/src/metabase/admin/tasks/containers/ModelCacheRefreshJobs/ModelCacheRefreshJobs.tsx
@@ -25,7 +25,6 @@ import {
   ErrorBox,
   IconButtonContainer,
   PaginationControlsContainer,
-  StyledLink,
 } from "./ModelCacheRefreshJobs.styled";
 
 type JobTableItemProps = {
@@ -69,10 +68,13 @@ function JobTableItem({ job, onRefresh }: JobTableItemProps) {
     <tr key={job.id}>
       <th>
         <span>
-          <StyledLink to={modelUrl}>{job.card_name}</StyledLink> {t`in`}{" "}
-          <StyledLink to={collectionUrl}>
+          <Link variant="brand" to={modelUrl}>
+            {job.card_name}
+          </Link>{" "}
+          {t`in`}{" "}
+          <Link variant="brand" to={collectionUrl}>
             {job.collection_name || t`Our analytics`}
-          </StyledLink>
+          </Link>
         </span>
       </th>
       <th>{renderStatus()}</th>

--- a/frontend/src/metabase/core/components/Link/Link.stories.tsx
+++ b/frontend/src/metabase/core/components/Link/Link.stories.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+import type { ComponentStory } from "@storybook/react";
+
+import Link from "./";
+
+export default {
+  title: "Core/Link",
+  component: Link,
+};
+
+const sampleStyle = {
+  padding: "10px",
+  display: "flex",
+  gap: "2rem",
+};
+
+const Template: ComponentStory<typeof Link> = args => {
+  return (
+    <div style={sampleStyle}>
+      <Link {...args}>Click Me</Link>
+    </div>
+  );
+};
+
+export const Default = Template.bind({});
+
+Default.args = {
+  to: "/foo/bar",
+  variant: "default",
+};

--- a/frontend/src/metabase/core/components/Link/Link.styled.tsx
+++ b/frontend/src/metabase/core/components/Link/Link.styled.tsx
@@ -1,6 +1,7 @@
 import styled from "@emotion/styled";
 import { display, space, hover, color } from "styled-system";
 import { Link } from "react-router";
+import { color as metabaseColor } from "metabase/lib/colors";
 import { shouldForwardNonTransientProp } from "metabase/lib/styling/emotion";
 import { focusOutlineStyle } from "metabase/core/style/input";
 
@@ -18,3 +19,20 @@ export const LinkRoot = styled(Link, {
 
   ${focusOutlineStyle("brand")};
 `;
+
+export const variants = {
+  default: LinkRoot,
+  brand: styled(LinkRoot)`
+    color: ${metabaseColor("brand")};
+    &:hover {
+      text-decoration: underline;
+    }
+  `,
+  brandBold: styled(LinkRoot)`
+    color: ${metabaseColor("brand")};
+    font-weight: bold;
+    &:hover {
+      text-decoration: underline;
+    }
+  `,
+};

--- a/frontend/src/metabase/core/components/Link/Link.styled.tsx
+++ b/frontend/src/metabase/core/components/Link/Link.styled.tsx
@@ -1,13 +1,16 @@
 import styled from "@emotion/styled";
+import { css } from "@emotion/react";
 import { display, space, hover, color } from "styled-system";
 import { Link } from "react-router";
 import { color as metabaseColor } from "metabase/lib/colors";
 import { shouldForwardNonTransientProp } from "metabase/lib/styling/emotion";
 import { focusOutlineStyle } from "metabase/core/style/input";
 
+import type { LinkProps } from "./types";
+
 export const LinkRoot = styled(Link, {
   shouldForwardProp: shouldForwardNonTransientProp,
-})`
+})<LinkProps>`
   ${display};
   ${space};
   ${hover};
@@ -18,17 +21,19 @@ export const LinkRoot = styled(Link, {
   transition: opacity 0.3s linear;
 
   ${focusOutlineStyle("brand")};
+
+  ${props => variants[props.variant ?? "default"] ?? ""}
 `;
 
 export const variants = {
-  default: LinkRoot,
-  brand: styled(LinkRoot)`
+  default: "",
+  brand: css`
     color: ${metabaseColor("brand")};
     &:hover {
       text-decoration: underline;
     }
   `,
-  brandBold: styled(LinkRoot)`
+  brandBold: css`
     color: ${metabaseColor("brand")};
     font-weight: bold;
     &:hover {

--- a/frontend/src/metabase/core/components/Link/Link.tsx
+++ b/frontend/src/metabase/core/components/Link/Link.tsx
@@ -1,10 +1,11 @@
 import React, { AnchorHTMLAttributes, CSSProperties, ReactNode } from "react";
 import Tooltip from "metabase/core/components/Tooltip";
 import { TooltipProps } from "metabase/core/components/Tooltip/Tooltip";
-import { LinkRoot } from "./Link.styled";
+import { LinkRoot, variants } from "./Link.styled";
 
 export interface LinkProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
   to: string;
+  variant?: "default" | "brand" | "brandBold";
   disabled?: boolean;
   className?: string;
   children?: ReactNode;
@@ -19,10 +20,13 @@ const Link = ({
   children,
   disabled,
   tooltip,
+  variant,
   ...props
 }: LinkProps): JSX.Element => {
+  const StyledLink = variant ? variants[variant] : LinkRoot;
+
   const link = (
-    <LinkRoot
+    <StyledLink
       {...props}
       to={to}
       disabled={disabled}
@@ -30,7 +34,7 @@ const Link = ({
       aria-disabled={disabled}
     >
       {children}
-    </LinkRoot>
+    </StyledLink>
   );
 
   const tooltipProps =

--- a/frontend/src/metabase/core/components/Link/Link.tsx
+++ b/frontend/src/metabase/core/components/Link/Link.tsx
@@ -1,19 +1,7 @@
-import React, { AnchorHTMLAttributes, CSSProperties, ReactNode } from "react";
+import React from "react";
 import Tooltip from "metabase/core/components/Tooltip";
-import { TooltipProps } from "metabase/core/components/Tooltip/Tooltip";
-import { LinkRoot, variants } from "./Link.styled";
-
-export interface LinkProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
-  to: string;
-  variant?: "default" | "brand" | "brandBold";
-  disabled?: boolean;
-  className?: string;
-  children?: ReactNode;
-  tooltip?: string | TooltipProps;
-  activeClassName?: string;
-  activeStyle?: CSSProperties;
-  onlyActiveOnIndex?: boolean;
-}
+import { LinkRoot } from "./Link.styled";
+import type { LinkProps } from "./types";
 
 const Link = ({
   to,
@@ -23,18 +11,17 @@ const Link = ({
   variant,
   ...props
 }: LinkProps): JSX.Element => {
-  const StyledLink = variant ? variants[variant] : LinkRoot;
-
   const link = (
-    <StyledLink
+    <LinkRoot
       {...props}
       to={to}
       disabled={disabled}
       tabIndex={disabled ? -1 : undefined}
       aria-disabled={disabled}
+      variant={variant}
     >
       {children}
-    </StyledLink>
+    </LinkRoot>
   );
 
   const tooltipProps =

--- a/frontend/src/metabase/core/components/Link/index.ts
+++ b/frontend/src/metabase/core/components/Link/index.ts
@@ -1,2 +1,3 @@
 export { default } from "./Link";
 export * from "./Link";
+export type { LinkProps } from "./types";

--- a/frontend/src/metabase/core/components/Link/types.ts
+++ b/frontend/src/metabase/core/components/Link/types.ts
@@ -1,0 +1,11 @@
+export interface LinkProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
+  to: string;
+  variant?: "default" | "brand" | "brandBold";
+  disabled?: boolean;
+  className?: string;
+  children?: ReactNode;
+  tooltip?: string | TooltipProps;
+  activeClassName?: string;
+  activeStyle?: CSSProperties;
+  onlyActiveOnIndex?: boolean;
+}

--- a/frontend/src/metabase/core/components/Link/types.ts
+++ b/frontend/src/metabase/core/components/Link/types.ts
@@ -1,3 +1,6 @@
+import type { AnchorHTMLAttributes, CSSProperties, ReactNode } from "react";
+import { TooltipProps } from "metabase/core/components/Tooltip/Tooltip";
+
 export interface LinkProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
   to: string;
   variant?: "default" | "brand" | "brandBold";

--- a/frontend/src/metabase/dashboard/components/Dashboard/DashboardEmptyState/DashboardEmptyState.jsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/DashboardEmptyState/DashboardEmptyState.jsx
@@ -2,9 +2,10 @@ import React from "react";
 import PropTypes from "prop-types";
 import { t } from "ttag";
 
+import Link from "metabase/core/components/Link";
 import Button from "metabase/core/components/Button";
 import EmptyState from "metabase/components/EmptyState";
-import { Container, BrandLink } from "./DashboardEmptyState.styled";
+import { Container } from "./DashboardEmptyState.styled";
 
 const propTypes = {
   isNightMode: PropTypes.bool.isRequired,
@@ -25,13 +26,14 @@ const DashboardEmptyState = ({ isNightMode, addQuestion, closeNavbar }) => (
             {t`Add a saved question`}
           </Button>
           {t`, or `}
-          <BrandLink
+          <Link
+            variant="brandBold"
             to="/question/new"
             className="text-bold text-brand"
             onClick={closeNavbar}
           >
             {t`ask a new one`}
-          </BrandLink>
+          </Link>
         </>
       }
     />

--- a/frontend/src/metabase/dashboard/components/Dashboard/DashboardEmptyState/DashboardEmptyState.styled.jsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/DashboardEmptyState/DashboardEmptyState.styled.jsx
@@ -1,16 +1,8 @@
 import styled from "@emotion/styled";
 import { space } from "metabase/styled-components/theme";
-import { color } from "metabase/lib/colors";
-
-import Link from "metabase/core/components/Link";
 
 export const Container = styled.div`
   box-sizing: border-box;
   color: ${({ isNightMode }) => (isNightMode ? "white" : "inherit")};
   margin-top: ${space(4)};
-`;
-
-export const BrandLink = styled(Link)`
-  color: ${color("brand")};
-  font-weight: bold;
 `;

--- a/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar.styled.tsx
@@ -1,7 +1,6 @@
 import styled from "@emotion/styled";
 
 import EditableText from "metabase/core/components/EditableText";
-import Link from "metabase/core/components/Link";
 
 import { color } from "metabase/lib/colors";
 
@@ -44,8 +43,4 @@ export const HeaderContainer = styled.div`
   align-items: baseline;
   justify-content: space-between;
   margin-top: 0.5rem;
-`;
-
-export const HeaderLink = styled(Link)`
-  color: ${color("brand")};
 `;

--- a/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar.tsx
@@ -8,6 +8,7 @@ import { PLUGIN_MODERATION, PLUGIN_CACHING } from "metabase/plugins";
 import MetabaseSettings from "metabase/lib/settings";
 import * as Urls from "metabase/lib/urls";
 
+import Link from "metabase/core/components/Link";
 import QuestionActivityTimeline from "metabase/query_builder/components/QuestionActivityTimeline";
 
 import Question from "metabase-lib/Question";
@@ -17,7 +18,6 @@ import {
   Root,
   ContentSection,
   HeaderContainer,
-  HeaderLink,
 } from "./QuestionInfoSidebar.styled";
 
 interface QuestionInfoSidebarProps {
@@ -56,9 +56,10 @@ export const QuestionInfoSidebar = ({
         <HeaderContainer>
           <h3>{t`About`}</h3>
           {question.isDataset() && (
-            <HeaderLink
+            <Link
+              variant="brand"
               to={Urls.modelDetail(question.card())}
-            >{t`Model details`}</HeaderLink>
+            >{t`Model details`}</Link>
           )}
         </HeaderContainer>
         <EditableText


### PR DESCRIPTION
### Description

We had a number of styled components that kept creating the same variants of our base link component over and over again. This is slow, annoying, and increases our bundle size.  Here, I extract the two most common link variant and use them where appropriate in the codebase.

The brand and boldBrand both have underline hover states.

![Screen Shot 2023-04-26 at 3 04 55 PM](https://user-images.githubusercontent.com/30528226/234703956-f0613905-0576-4543-a932-ecd551d58126.png)

This also adds a storybook story.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30404)
<!-- Reviewable:end -->
