### PR TITLE
Correct prop-types

### DIFF
--- a/frontend/src/metabase/components/Badge/Badge.styled.jsx
+++ b/frontend/src/metabase/components/Badge/Badge.styled.jsx
@@ -11,9 +11,16 @@ const propTypes = {
   to: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
   activeColor: PropTypes.string,
   inactiveColor: PropTypes.string,
+  isSingleLine: PropTypes.boolean,
 };
 
-function RawMaybeLink({ to, activeColor, inactiveColor, ...props }) {
+function RawMaybeLink({
+  to,
+  activeColor,
+  inactiveColor,
+  isSingleLine,
+  ...props
+}) {
   return to ? <Link to={to} {...props} /> : <span {...props} />;
 }
 

--- a/frontend/src/metabase/dashboard/containers/DashboardHeader.jsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardHeader.jsx
@@ -97,7 +97,10 @@ class DashboardHeader extends Component {
     onChangeLocation: PropTypes.func.isRequired,
 
     toggleSidebar: PropTypes.func.isRequired,
-    sidebar: PropTypes.string.isRequired,
+    sidebar: PropTypes.shape({
+      name: PropTypes.string,
+      props: PropTypes.object,
+    }).isRequired,
     setSidebar: PropTypes.func.isRequired,
     closeSidebar: PropTypes.func.isRequired,
     addActionToDashboard: PropTypes.func.isRequired,

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
@@ -346,7 +346,7 @@ ViewTitleHeaderRightSide.propTypes = {
   onOpenQuestionInfo: PropTypes.func,
   onCloseQuestionInfo: PropTypes.func,
   isShowingQuestionInfoSidebar: PropTypes.bool,
-  onModelPersistenceChange: PropTypes.bool,
+  onModelPersistenceChange: PropTypes.func,
   onQueryChange: PropTypes.func,
 };
 


### PR DESCRIPTION
Fix prop-types for annoying warnings in console.

separated from https://github.com/metabase/metabase/pull/30224

### RawMaybeLink 
`isSingleLine` shouldn't be passed to `a`

### onModelPersistenceChange
it's used as a function

### sidebar
it's a shape in other places

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30406)
<!-- Reviewable:end -->
