### PR TITLE
Fix loading data in metadata editor for users with data model permissions

### DIFF
--- a/e2e/test/scenarios/admin/datamodel/editor.cy.spec.js
+++ b/e2e/test/scenarios/admin/datamodel/editor.cy.spec.js
@@ -31,7 +31,7 @@ describe("scenarios > admin > datamodel > editor", () => {
 
     it("should allow changing the table name", () => {
       visitOrdersTableEditor();
-      setInputValue("Orders", "New orders");
+      setValueAndBlurInput("Orders", "New orders");
       cy.wait("@updateTable");
       cy.findByText("Updated table display_name");
 
@@ -45,7 +45,7 @@ describe("scenarios > admin > datamodel > editor", () => {
 
     it("should allow changing the table description", () => {
       visitOrdersTableEditor();
-      setInputValue(ORDERS_DESCRIPTION, "New description");
+      setValueAndBlurInput(ORDERS_DESCRIPTION, "New description");
       cy.wait("@updateTable");
       cy.findByText("Updated table description");
 
@@ -56,7 +56,7 @@ describe("scenarios > admin > datamodel > editor", () => {
 
     it("should allow clearing the table description", () => {
       visitOrdersTableEditor();
-      clearInputValue(ORDERS_DESCRIPTION);
+      clearAndBlurInput(ORDERS_DESCRIPTION);
       cy.wait("@updateTable");
       cy.findByText("Updated table description");
 
@@ -94,7 +94,9 @@ describe("scenarios > admin > datamodel > editor", () => {
 
     it("should allow changing the field name", () => {
       visitOrdersTableEditor();
-      getFieldSection("TAX").within(() => setInputValue("Tax", "New tax"));
+      getFieldSection("TAX").within(() =>
+        setValueAndBlurInput("Tax", "New tax"),
+      );
       cy.wait("@updateField");
       cy.findByText("Updated New tax").should("be.visible");
 
@@ -106,7 +108,7 @@ describe("scenarios > admin > datamodel > editor", () => {
     it("should allow changing the field description", () => {
       visitOrdersTableEditor();
       getFieldSection("TOTAL").within(() =>
-        setInputValue("The total billed amount.", "New description"),
+        setValueAndBlurInput("The total billed amount.", "New description"),
       );
       cy.wait("@updateField");
       cy.findByText("Updated Total").should("be.visible");
@@ -121,7 +123,7 @@ describe("scenarios > admin > datamodel > editor", () => {
     it("should allow clearing the field description", () => {
       visitOrdersTableEditor();
       getFieldSection("TOTAL").within(() =>
-        clearInputValue("The total billed amount."),
+        clearAndBlurInput("The total billed amount."),
       );
       cy.wait("@updateField");
       cy.findByText("Updated Total").should("be.visible");
@@ -225,7 +227,7 @@ describe("scenarios > admin > datamodel > editor", () => {
     it("should allow changing the table name with data model permissions only", () => {
       cy.signIn("none");
       visitOrdersTableEditor();
-      setInputValue("Orders", "New orders");
+      setValueAndBlurInput("Orders", "New orders");
       cy.wait("@updateTable");
       cy.findByText("Updated table display_name");
       cy.signOut();
@@ -242,7 +244,9 @@ describe("scenarios > admin > datamodel > editor", () => {
     it("should allow changing the field name with data model permissions only", () => {
       cy.signIn("none");
       visitOrdersTableEditor();
-      getFieldSection("TAX").within(() => setInputValue("Tax", "New tax"));
+      getFieldSection("TAX").within(() =>
+        setValueAndBlurInput("Tax", "New tax"),
+      );
       cy.wait("@updateField");
       cy.findByText("Updated New tax").should("be.visible");
 
@@ -261,7 +265,7 @@ describe("scenarios > admin > datamodel > editor", () => {
 
     it("should be able to select and update a table in a database without schemas", () => {
       visitOrdersTableEditor("QA MySQL8");
-      setInputValue("Orders", "New orders");
+      setValueAndBlurInput("Orders", "New orders");
       cy.wait("@updateTable");
     });
 
@@ -283,11 +287,11 @@ const visitOrdersTableEditor = (database = "Sample Database") => {
   cy.wait("@fetchMetadata");
 };
 
-const setInputValue = (oldValue, newValue) => {
+const setValueAndBlurInput = (oldValue, newValue) => {
   cy.findByDisplayValue(oldValue).clear().type(newValue).blur();
 };
 
-const clearInputValue = oldValue => {
+const clearAndBlurInput = oldValue => {
   cy.findByDisplayValue(oldValue).clear().blur();
 };
 

--- a/e2e/test/scenarios/admin/datamodel/editor.cy.spec.js
+++ b/e2e/test/scenarios/admin/datamodel/editor.cy.spec.js
@@ -1,19 +1,20 @@
 import {
+  describeEE,
   openOrdersTable,
   popover,
   restore,
   startNewQuestion,
 } from "e2e/support/helpers";
-import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
+import { SAMPLE_DB_ID, USER_GROUPS } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 
 const { ORDERS_ID, ORDERS } = SAMPLE_DATABASE;
+const { ALL_USERS_GROUP } = USER_GROUPS;
 const ORDERS_DESCRIPTION =
   "Confirmed Sample Company orders for a product, from a user.";
+
 describe("scenarios > admin > datamodel > editor", () => {
   beforeEach(() => {
-    restore();
-    cy.signInAsAdmin();
     cy.intercept("GET", "/api/database/*/schema/*").as("fetchTables");
     cy.intercept("GET", "/api/table/*/query_metadata*").as("fetchMetadata");
     cy.intercept("PUT", "/api/table").as("updateTables");
@@ -22,196 +23,240 @@ describe("scenarios > admin > datamodel > editor", () => {
     cy.intercept("PUT", "/api/table/*/fields/order").as("updateFieldOrder");
   });
 
-  it("should allow changing the table name", () => {
-    visitOrdersTableEditor();
-    setInputValue("Orders", "New orders");
-    cy.wait("@updateTable");
-    cy.findByText("Updated table display_name");
-
-    startNewQuestion();
-    popover().within(() => {
-      cy.findByText("Sample Database").click();
-      cy.findByText("People").should("be.visible");
-      cy.findByText("New orders").should("be.visible");
-    });
-  });
-
-  it("should allow changing the table description", () => {
-    visitOrdersTableEditor();
-    setInputValue(ORDERS_DESCRIPTION, "New description");
-    cy.wait("@updateTable");
-    cy.findByText("Updated table description");
-
-    cy.visit(`/reference/databases/${SAMPLE_DB_ID}/tables/${ORDERS_ID}`);
-    cy.findByText("Orders").should("be.visible");
-    cy.findByText("New description").should("be.visible");
-  });
-
-  it("should allow clearing the table description", () => {
-    visitOrdersTableEditor();
-    clearInputValue(ORDERS_DESCRIPTION);
-    cy.wait("@updateTable");
-    cy.findByText("Updated table description");
-
-    cy.visit(`/reference/databases/${SAMPLE_DB_ID}/tables/${ORDERS_ID}`);
-    cy.findByText("Orders").should("be.visible");
-    cy.findByText("No description yet").should("be.visible");
-  });
-
-  it("should allow changing the table visibility", () => {
-    visitOrdersTableEditor();
-    cy.findByText("Hidden").click();
-    cy.wait("@updateTable");
-    cy.findByText("Updated table visibility_type");
-    cy.findByText("5 Hidden Tables").should("be.visible");
-
-    startNewQuestion();
-    popover().within(() => {
-      cy.findByText("Sample Database").click();
-      cy.findByText("People").should("be.visible");
-      cy.findByText("Orders").should("not.exist");
+  describe("metadata editing", () => {
+    beforeEach(() => {
+      restore();
+      cy.signInAsAdmin();
     });
 
-    visitOrdersTableEditor();
-    cy.findByText("Queryable").click();
-    cy.wait("@updateTable");
-    cy.findByText("4 Hidden Tables").should("be.visible");
+    it("should allow changing the table name", () => {
+      visitOrdersTableEditor();
+      setInputValue("Orders", "New orders");
+      cy.wait("@updateTable");
+      cy.findByText("Updated table display_name");
 
-    startNewQuestion();
-    popover().within(() => {
-      cy.findByText("Sample Database").click();
-      cy.findByText("People").should("be.visible");
+      startNewQuestion();
+      popover().within(() => {
+        cy.findByText("Sample Database").click();
+        cy.findByText("People").should("be.visible");
+        cy.findByText("New orders").should("be.visible");
+      });
+    });
+
+    it("should allow changing the table description", () => {
+      visitOrdersTableEditor();
+      setInputValue(ORDERS_DESCRIPTION, "New description");
+      cy.wait("@updateTable");
+      cy.findByText("Updated table description");
+
+      cy.visit(`/reference/databases/${SAMPLE_DB_ID}/tables/${ORDERS_ID}`);
       cy.findByText("Orders").should("be.visible");
+      cy.findByText("New description").should("be.visible");
+    });
+
+    it("should allow clearing the table description", () => {
+      visitOrdersTableEditor();
+      clearInputValue(ORDERS_DESCRIPTION);
+      cy.wait("@updateTable");
+      cy.findByText("Updated table description");
+
+      cy.visit(`/reference/databases/${SAMPLE_DB_ID}/tables/${ORDERS_ID}`);
+      cy.findByText("Orders").should("be.visible");
+      cy.findByText("No description yet").should("be.visible");
+    });
+
+    it("should allow changing the table visibility", () => {
+      visitOrdersTableEditor();
+      cy.findByText("Hidden").click();
+      cy.wait("@updateTable");
+      cy.findByText("Updated table visibility_type");
+      cy.findByText("5 Hidden Tables").should("be.visible");
+
+      startNewQuestion();
+      popover().within(() => {
+        cy.findByText("Sample Database").click();
+        cy.findByText("People").should("be.visible");
+        cy.findByText("Orders").should("not.exist");
+      });
+
+      visitOrdersTableEditor();
+      cy.findByText("Queryable").click();
+      cy.wait("@updateTable");
+      cy.findByText("4 Hidden Tables").should("be.visible");
+
+      startNewQuestion();
+      popover().within(() => {
+        cy.findByText("Sample Database").click();
+        cy.findByText("People").should("be.visible");
+        cy.findByText("Orders").should("be.visible");
+      });
+    });
+
+    it("should allow changing the field name", () => {
+      visitOrdersTableEditor();
+      getFieldSection("TAX").within(() => setInputValue("Tax", "New tax"));
+      cy.findByText("Updated New tax").should("be.visible");
+      cy.wait("@updateField");
+
+      openOrdersTable();
+      cy.findByText("New tax").should("be.visible");
+      cy.findByText("Tax").should("not.exist");
+    });
+
+    it("should allow changing the field description", () => {
+      visitOrdersTableEditor();
+      getFieldSection("TOTAL").within(() =>
+        setInputValue("The total billed amount.", "New description"),
+      );
+      cy.findByText("Updated Total").should("be.visible");
+      cy.wait("@updateField");
+
+      cy.visit(
+        `/reference/databases/${SAMPLE_DB_ID}/tables/${ORDERS_ID}/fields/${ORDERS.TOTAL}`,
+      );
+      cy.findByText("Total").should("be.visible");
+      cy.findByText("New description").should("be.visible");
+    });
+
+    it("should allow clearing the field description", () => {
+      visitOrdersTableEditor();
+      getFieldSection("TOTAL").within(() =>
+        clearInputValue("The total billed amount."),
+      );
+      cy.findByText("Updated Total").should("be.visible");
+      cy.wait("@updateField");
+
+      cy.visit(
+        `/reference/databases/${SAMPLE_DB_ID}/tables/${ORDERS_ID}/fields/${ORDERS.TOTAL}`,
+      );
+      cy.findByText("Total").should("be.visible");
+      cy.findByText("No description yet").should("be.visible");
+    });
+
+    it("should allow changing the field visibility", () => {
+      visitOrdersTableEditor();
+      getFieldSection("TAX").findByText("Everywhere").click();
+      setSelectValue("Do not include");
+      cy.findByText("Updated Tax").should("be.visible");
+      cy.wait("@updateField");
+
+      openOrdersTable();
+      cy.findByText("Total").should("be.visible");
+      cy.findByText("Tax").should("not.exist");
+    });
+
+    it("should allow changing the field semantic type and currency", () => {
+      visitOrdersTableEditor();
+      getFieldSection("TAX").findByText("No semantic type").click();
+      searchAndSelectValue("Currency");
+      cy.findByText("Updated Tax").should("be.visible");
+      cy.wait("@updateField");
+
+      getFieldSection("TAX").findByText("US Dollar").click();
+      searchAndSelectValue("Canadian Dollar");
+      cy.wait("@updateField");
+
+      openOrdersTable();
+      cy.findByText("Tax (CA$)").should("be.visible");
+    });
+
+    it("should allow changing the field foreign key target", () => {
+      visitOrdersTableEditor();
+      getFieldSection("USER_ID").findByText("People → ID").click();
+      setSelectValue("Products → ID");
+      cy.findByText("Updated User ID").should("be.visible");
+      cy.wait("@updateField");
+
+      startNewQuestion();
+      popover().within(() => {
+        cy.findByText("Sample Database").click();
+        cy.findByText("Orders").click();
+      });
+      cy.icon("join_left_outer").click();
+      popover().within(() => {
+        cy.findByText("Products").click();
+      });
+      cy.findByText("User ID").should("be.visible");
+    });
+
+    it("should allow sorting fields", () => {
+      visitOrdersTableEditor();
+
+      cy.findByLabelText("Sort").click();
+      popover().findByText("Alphabetical").click();
+      cy.wait("@updateTable");
+
+      moveField(3);
+      cy.wait("@updateFieldOrder");
+
+      openOrdersTable();
+      cy.findAllByTestId("header-cell")
+        .first()
+        .should("have.text", "Product ID");
+    });
+
+    it("should allow hiding and restoring all tables in a schema", () => {
+      visitOrdersTableEditor();
+      cy.findByText("4 Queryable Tables").should("be.visible");
+      cy.findByLabelText("Hide all").click();
+      cy.wait("@updateTables");
+
+      visitOrdersTableEditor();
+      cy.findByText("8 Hidden Tables").should("be.visible");
+      cy.findByLabelText("Unhide all").click();
+      cy.wait("@updateTables");
+      cy.findByText("8 Queryable Tables").should("be.visible");
     });
   });
 
-  it("should allow changing the field name", () => {
-    visitOrdersTableEditor();
-    getFieldSection("TAX").within(() => setInputValue("Tax", "New tax"));
-    cy.findByText("Updated New tax").should("be.visible");
-    cy.wait("@updateField");
-
-    openOrdersTable();
-    cy.findByText("New tax").should("be.visible");
-    cy.findByText("Tax").should("not.exist");
-  });
-
-  it("should allow changing the field description", () => {
-    visitOrdersTableEditor();
-    getFieldSection("TOTAL").within(() =>
-      setInputValue("The total billed amount.", "New description"),
-    );
-    cy.findByText("Updated Total").should("be.visible");
-    cy.wait("@updateField");
-
-    cy.visit(
-      `/reference/databases/${SAMPLE_DB_ID}/tables/${ORDERS_ID}/fields/${ORDERS.TOTAL}`,
-    );
-    cy.findByText("Total").should("be.visible");
-    cy.findByText("New description").should("be.visible");
-  });
-
-  it("should allow clearing the field description", () => {
-    visitOrdersTableEditor();
-    getFieldSection("TOTAL").within(() =>
-      clearInputValue("The total billed amount."),
-    );
-    cy.findByText("Updated Total").should("be.visible");
-    cy.wait("@updateField");
-
-    cy.visit(
-      `/reference/databases/${SAMPLE_DB_ID}/tables/${ORDERS_ID}/fields/${ORDERS.TOTAL}`,
-    );
-    cy.findByText("Total").should("be.visible");
-    cy.findByText("No description yet").should("be.visible");
-  });
-
-  it("should allow changing the field visibility", () => {
-    visitOrdersTableEditor();
-    getFieldSection("TAX").findByText("Everywhere").click();
-    setSelectValue("Do not include");
-    cy.findByText("Updated Tax").should("be.visible");
-    cy.wait("@updateField");
-
-    openOrdersTable();
-    cy.findByText("Total").should("be.visible");
-    cy.findByText("Tax").should("not.exist");
-  });
-
-  it("should allow changing the field semantic type and currency", () => {
-    visitOrdersTableEditor();
-    getFieldSection("TAX").findByText("No semantic type").click();
-    searchAndSelectValue("Currency");
-    cy.findByText("Updated Tax").should("be.visible");
-    cy.wait("@updateField");
-
-    getFieldSection("TAX").findByText("US Dollar").click();
-    searchAndSelectValue("Canadian Dollar");
-    cy.wait("@updateField");
-
-    openOrdersTable();
-    cy.findByText("Tax (CA$)").should("be.visible");
-  });
-
-  it("should allow changing the field foreign key target", () => {
-    visitOrdersTableEditor();
-    getFieldSection("USER_ID").findByText("People → ID").click();
-    setSelectValue("Products → ID");
-    cy.findByText("Updated User ID").should("be.visible");
-    cy.wait("@updateField");
-
-    startNewQuestion();
-    popover().within(() => {
-      cy.findByText("Sample Database").click();
-      cy.findByText("Orders").click();
+  describeEE("data model permissions", () => {
+    beforeEach(() => {
+      restore();
+      cy.signInAsAdmin();
+      cy.updatePermissionsGraph({
+        [ALL_USERS_GROUP]: {
+          [SAMPLE_DB_ID]: {
+            "data-model": { schemas: { PUBLIC: { [ORDERS_ID]: "all" } } },
+          },
+        },
+      });
     });
-    cy.icon("join_left_outer").click();
-    popover().within(() => {
-      cy.findByText("Products").click();
+
+    it("should allow changing the table name with data model permissions only", () => {
+      cy.signIn("none");
+      visitOrdersTableEditor();
+      setInputValue("Orders", "New orders");
+      cy.wait("@updateTable");
+      cy.findByText("Updated table display_name");
+      cy.signOut();
+
+      cy.signInAsNormalUser();
+      startNewQuestion();
+      popover().within(() => {
+        cy.findByText("Sample Database").click();
+        cy.findByText("People").should("be.visible");
+        cy.findByText("New orders").should("be.visible");
+      });
     });
-    cy.findByText("User ID").should("be.visible");
+
+    it("should allow changing the field name with data model permissions only", () => {
+      cy.signIn("none");
+      visitOrdersTableEditor();
+      getFieldSection("TAX").within(() => setInputValue("Tax", "New tax"));
+      cy.findByText("Updated New tax").should("be.visible");
+      cy.wait("@updateField");
+
+      cy.signInAsNormalUser();
+      openOrdersTable();
+      cy.findByText("New tax").should("be.visible");
+      cy.findByText("Tax").should("not.exist");
+    });
   });
 
-  it("should allow sorting fields", () => {
-    visitOrdersTableEditor();
-
-    cy.findByLabelText("Sort").click();
-    popover().findByText("Alphabetical").click();
-    cy.wait("@updateTable");
-
-    moveField(3);
-    cy.wait("@updateFieldOrder");
-
-    openOrdersTable();
-    cy.findAllByTestId("header-cell").first().should("have.text", "Product ID");
-  });
-
-  it("should allow hiding and restoring all tables in a schema", () => {
-    visitOrdersTableEditor();
-    cy.findByText("4 Queryable Tables").should("be.visible");
-    cy.findByLabelText("Hide all").click();
-    cy.wait("@updateTables");
-
-    visitOrdersTableEditor();
-    cy.findByText("8 Hidden Tables").should("be.visible");
-    cy.findByLabelText("Unhide all").click();
-    cy.wait("@updateTables");
-    cy.findByText("8 Queryable Tables").should("be.visible");
-  });
-});
-
-describe(
-  "scenarios > admin > datamodel > editor",
-  { tags: ["@external"] },
-  () => {
+  describe("databases without schemas", { tags: ["@external"] }, () => {
     beforeEach(() => {
       restore("mysql-8");
       cy.signInAsAdmin();
-      cy.intercept("GET", "/api/database").as("fetchDatabases");
-      cy.intercept("GET", "/api/database/*/schema/*").as("fetchTables");
-      cy.intercept("GET", "/api/table/*/query_metadata*").as("fetchMetadata");
-      cy.intercept("PUT", "/api/table/*").as("updateTable");
-      cy.intercept("PUT", "/api/field/*").as("updateField");
     });
 
     it("should be able to select and update a table in a database without schemas", () => {
@@ -226,8 +271,8 @@ describe(
       setSelectValue("Do not include");
       cy.wait("@updateField");
     });
-  },
-);
+  });
+});
 
 const visitOrdersTableEditor = (database = "Sample Database") => {
   cy.visit("/admin/datamodel");

--- a/e2e/test/scenarios/admin/datamodel/editor.cy.spec.js
+++ b/e2e/test/scenarios/admin/datamodel/editor.cy.spec.js
@@ -33,7 +33,7 @@ describe("scenarios > admin > datamodel > editor", () => {
       visitOrdersTableEditor();
       setValueAndBlurInput("Orders", "New orders");
       cy.wait("@updateTable");
-      cy.findByText("Updated table display_name");
+      cy.findByText("Updated Table display_name");
 
       startNewQuestion();
       popover().within(() => {
@@ -47,7 +47,7 @@ describe("scenarios > admin > datamodel > editor", () => {
       visitOrdersTableEditor();
       setValueAndBlurInput(ORDERS_DESCRIPTION, "New description");
       cy.wait("@updateTable");
-      cy.findByText("Updated table description");
+      cy.findByText("Updated Table description");
 
       cy.visit(`/reference/databases/${SAMPLE_DB_ID}/tables/${ORDERS_ID}`);
       cy.findByText("Orders").should("be.visible");
@@ -58,7 +58,7 @@ describe("scenarios > admin > datamodel > editor", () => {
       visitOrdersTableEditor();
       clearAndBlurInput(ORDERS_DESCRIPTION);
       cy.wait("@updateTable");
-      cy.findByText("Updated table description");
+      cy.findByText("Updated Table description");
 
       cy.visit(`/reference/databases/${SAMPLE_DB_ID}/tables/${ORDERS_ID}`);
       cy.findByText("Orders").should("be.visible");
@@ -69,7 +69,7 @@ describe("scenarios > admin > datamodel > editor", () => {
       visitOrdersTableEditor();
       cy.findByText("Hidden").click();
       cy.wait("@updateTable");
-      cy.findByText("Updated table visibility_type");
+      cy.findByText("Updated Table visibility_type");
       cy.findByText("5 Hidden Tables").should("be.visible");
 
       startNewQuestion();
@@ -229,7 +229,7 @@ describe("scenarios > admin > datamodel > editor", () => {
       visitOrdersTableEditor();
       setValueAndBlurInput("Orders", "New orders");
       cy.wait("@updateTable");
-      cy.findByText("Updated table display_name");
+      cy.findByText("Updated Table display_name");
       cy.signOut();
 
       cy.signInAsNormalUser();

--- a/e2e/test/scenarios/admin/datamodel/editor.cy.spec.js
+++ b/e2e/test/scenarios/admin/datamodel/editor.cy.spec.js
@@ -95,8 +95,8 @@ describe("scenarios > admin > datamodel > editor", () => {
     it("should allow changing the field name", () => {
       visitOrdersTableEditor();
       getFieldSection("TAX").within(() => setInputValue("Tax", "New tax"));
-      cy.findByText("Updated New tax").should("be.visible");
       cy.wait("@updateField");
+      cy.findByText("Updated New tax").should("be.visible");
 
       openOrdersTable();
       cy.findByText("New tax").should("be.visible");
@@ -108,8 +108,8 @@ describe("scenarios > admin > datamodel > editor", () => {
       getFieldSection("TOTAL").within(() =>
         setInputValue("The total billed amount.", "New description"),
       );
-      cy.findByText("Updated Total").should("be.visible");
       cy.wait("@updateField");
+      cy.findByText("Updated Total").should("be.visible");
 
       cy.visit(
         `/reference/databases/${SAMPLE_DB_ID}/tables/${ORDERS_ID}/fields/${ORDERS.TOTAL}`,
@@ -123,8 +123,8 @@ describe("scenarios > admin > datamodel > editor", () => {
       getFieldSection("TOTAL").within(() =>
         clearInputValue("The total billed amount."),
       );
-      cy.findByText("Updated Total").should("be.visible");
       cy.wait("@updateField");
+      cy.findByText("Updated Total").should("be.visible");
 
       cy.visit(
         `/reference/databases/${SAMPLE_DB_ID}/tables/${ORDERS_ID}/fields/${ORDERS.TOTAL}`,
@@ -137,8 +137,8 @@ describe("scenarios > admin > datamodel > editor", () => {
       visitOrdersTableEditor();
       getFieldSection("TAX").findByText("Everywhere").click();
       setSelectValue("Do not include");
-      cy.findByText("Updated Tax").should("be.visible");
       cy.wait("@updateField");
+      cy.findByText("Updated Tax").should("be.visible");
 
       openOrdersTable();
       cy.findByText("Total").should("be.visible");
@@ -149,8 +149,8 @@ describe("scenarios > admin > datamodel > editor", () => {
       visitOrdersTableEditor();
       getFieldSection("TAX").findByText("No semantic type").click();
       searchAndSelectValue("Currency");
-      cy.findByText("Updated Tax").should("be.visible");
       cy.wait("@updateField");
+      cy.findByText("Updated Tax").should("be.visible");
 
       getFieldSection("TAX").findByText("US Dollar").click();
       searchAndSelectValue("Canadian Dollar");
@@ -164,8 +164,8 @@ describe("scenarios > admin > datamodel > editor", () => {
       visitOrdersTableEditor();
       getFieldSection("USER_ID").findByText("People → ID").click();
       setSelectValue("Products → ID");
-      cy.findByText("Updated User ID").should("be.visible");
       cy.wait("@updateField");
+      cy.findByText("Updated User ID").should("be.visible");
 
       startNewQuestion();
       popover().within(() => {
@@ -243,8 +243,8 @@ describe("scenarios > admin > datamodel > editor", () => {
       cy.signIn("none");
       visitOrdersTableEditor();
       getFieldSection("TAX").within(() => setInputValue("Tax", "New tax"));
-      cy.findByText("Updated New tax").should("be.visible");
       cy.wait("@updateField");
+      cy.findByText("Updated New tax").should("be.visible");
 
       cy.signInAsNormalUser();
       openOrdersTable();

--- a/e2e/test/scenarios/admin/datamodel/reproductions/21984-data-model-registered-as-view.cy.spec.js
+++ b/e2e/test/scenarios/admin/datamodel/reproductions/21984-data-model-registered-as-view.cy.spec.js
@@ -15,7 +15,7 @@ describe("issue 21984", () => {
     cy.signInAsAdmin();
 
     cy.visit(reviewsDataModelPage);
-    cy.wait(["@tableMetadata", "@tableMetadata"]);
+    cy.wait("@tableMetadata");
 
     cy.findByDisplayValue("ID");
   });

--- a/frontend/src/metabase-lib/metadata/Field.ts
+++ b/frontend/src/metabase-lib/metadata/Field.ts
@@ -63,6 +63,7 @@ const LONG_TEXT_MIN = 80;
 class FieldInner extends Base {
   id: number | FieldRef;
   name: string;
+  display_name: string;
   description: string | null;
   semantic_type: string | null;
   fingerprint?: FieldFingerprint;

--- a/frontend/src/metabase/admin/datamodel/metadata/components/FieldVisibilityPicker/FieldVisibilityPicker.tsx
+++ b/frontend/src/metabase/admin/datamodel/metadata/components/FieldVisibilityPicker/FieldVisibilityPicker.tsx
@@ -11,7 +11,7 @@ import Field from "metabase-lib/metadata/Field";
 interface FieldVisibilityPickerProps {
   className?: string;
   field: Field;
-  onUpdateField: (updates: Partial<Field>) => void;
+  onUpdateField: (field: Field, updates: Partial<Field>) => void;
 }
 
 const FieldVisibilityPicker = ({
@@ -21,7 +21,7 @@ const FieldVisibilityPicker = ({
 }: FieldVisibilityPickerProps) => {
   const handleChange = useCallback(
     (event: SelectChangeEvent<FieldVisibilityType>) => {
-      onUpdateField({ id: field.id, visibility_type: event.target.value });
+      onUpdateField(field, { visibility_type: event.target.value });
     },
     [field, onUpdateField],
   );

--- a/frontend/src/metabase/admin/datamodel/metadata/components/MetadataTable/MetadataTable.tsx
+++ b/frontend/src/metabase/admin/datamodel/metadata/components/MetadataTable/MetadataTable.tsx
@@ -28,13 +28,6 @@ import {
 
 type MetadataTabType = "columns" | "original_schema";
 
-const TABLE_QUERY = {
-  include_sensitive_fields: true,
-  ...PLUGIN_FEATURE_LEVEL_PERMISSIONS.dataModelQueryProps,
-};
-
-const FIELDS_QUERY = PLUGIN_FEATURE_LEVEL_PERMISSIONS.dataModelQueryProps;
-
 const METADATA_TAB_OPTIONS = [
   { name: t`Columns`, value: "columns" },
   { name: t`Original schema`, value: "original_schema" },
@@ -100,8 +93,8 @@ const MetadataTable = ({
   onUpdateTable,
 }: MetadataTableProps) => {
   const { loading, error } = useAsync(async () => {
-    await onFetchIdFields({ id: selectedDatabaseId }, FIELDS_QUERY);
-    await onFetchMetadata({ id: selectedTableId }, { params: TABLE_QUERY });
+    await onFetchIdFields({ id: selectedDatabaseId }, getFieldsQuery());
+    await onFetchMetadata({ id: selectedTableId }, { params: getTableQuery() });
   }, [selectedDatabaseId, selectedTableId]);
 
   if (table == null || loading || error != null) {
@@ -357,5 +350,13 @@ const TableTabSection = ({ tab, onChangeTab }: MetadataTabSectionProps) => {
     </div>
   );
 };
+
+const getTableQuery = () => ({
+  include_sensitive_fields: true,
+  ...PLUGIN_FEATURE_LEVEL_PERMISSIONS.dataModelQueryProps,
+});
+
+const getFieldsQuery = () =>
+  PLUGIN_FEATURE_LEVEL_PERMISSIONS.dataModelQueryProps;
 
 export default connect(mapStateToProps, mapDispatchToProps)(MetadataTable);

--- a/frontend/src/metabase/admin/datamodel/metadata/components/MetadataTable/MetadataTable.tsx
+++ b/frontend/src/metabase/admin/datamodel/metadata/components/MetadataTable/MetadataTable.tsx
@@ -33,6 +33,8 @@ const TABLE_QUERY = {
   ...PLUGIN_FEATURE_LEVEL_PERMISSIONS.dataModelQueryProps,
 };
 
+const FIELDS_QUERY = PLUGIN_FEATURE_LEVEL_PERMISSIONS.dataModelQueryProps;
+
 const METADATA_TAB_OPTIONS = [
   { name: t`Columns`, value: "columns" },
   { name: t`Original schema`, value: "original_schema" },
@@ -63,7 +65,7 @@ interface StateProps {
 
 interface DispatchProps {
   onFetchMetadata: (table: HasTableId, opts: HasRequestParams) => Promise<void>;
-  onFetchIdFields: (database: HasDatabaseId) => Promise<void>;
+  onFetchIdFields: (database: HasDatabaseId, params: unknown) => Promise<void>;
   onUpdateTable: (table: Table, name: string, value: unknown) => void;
 }
 
@@ -82,7 +84,7 @@ const mapStateToProps = (
 });
 
 const mapDispatchToProps: DispatchProps = {
-  onFetchMetadata: Tables.actions.fetchMetadataAndForeignTables,
+  onFetchMetadata: Tables.actions.fetchMetadata,
   onFetchIdFields: Databases.objectActions.fetchIdfields,
   onUpdateTable: Tables.actions.updateProperty,
 };
@@ -97,13 +99,10 @@ const MetadataTable = ({
   onFetchIdFields,
   onUpdateTable,
 }: MetadataTableProps) => {
-  const { loading, error } = useAsync(() => {
-    return onFetchMetadata({ id: selectedTableId }, { params: TABLE_QUERY });
-  }, [selectedTableId]);
-
-  useAsync(() => {
-    return onFetchIdFields({ id: selectedDatabaseId });
-  }, [selectedDatabaseId]);
+  const { loading, error } = useAsync(async () => {
+    await onFetchIdFields({ id: selectedDatabaseId }, FIELDS_QUERY);
+    await onFetchMetadata({ id: selectedTableId }, { params: TABLE_QUERY });
+  }, [selectedDatabaseId, selectedTableId]);
 
   if (table == null || loading || error != null) {
     return <LoadingAndErrorWrapper loading={loading} error={error} />;

--- a/frontend/src/metabase/admin/datamodel/metadata/components/MetadataTable/MetadataTable.tsx
+++ b/frontend/src/metabase/admin/datamodel/metadata/components/MetadataTable/MetadataTable.tsx
@@ -141,7 +141,7 @@ const MetadataTableView = ({
   );
 
   const handleChangeDescription = useCallback(
-    (description: string) => {
+    (description: string | null) => {
       onUpdateTable(table, "description", description);
     },
     [table, onUpdateTable],
@@ -183,7 +183,7 @@ interface TableTitleSectionProps {
   table: Table;
   tab: MetadataTabType;
   onChangeName: (name: string) => void;
-  onChangeDescription: (description: string) => void;
+  onChangeDescription: (description: string | null) => void;
 }
 
 const TableTitleSection = ({
@@ -205,7 +205,11 @@ const TableTitleSection = ({
 
   const handleDescriptionChange = useCallback(
     (event: ChangeEvent<HTMLInputElement>) => {
-      onChangeDescription(event.target.value);
+      if (event.target.value) {
+        onChangeDescription(event.target.value);
+      } else {
+        onChangeDescription(null);
+      }
     },
     [onChangeDescription],
   );

--- a/frontend/src/metabase/admin/datamodel/metadata/components/MetadataTableColumn/MetadataTableColumn.tsx
+++ b/frontend/src/metabase/admin/datamodel/metadata/components/MetadataTableColumn/MetadataTableColumn.tsx
@@ -60,7 +60,11 @@ const MetadataTableColumn = ({
 
   const handleChangeDescription = useCallback(
     (event: ChangeEvent<HTMLInputElement>) => {
-      onUpdateField(field, { description: event.target.value });
+      if (event.target.value) {
+        onUpdateField(field, { description: event.target.value });
+      } else {
+        onUpdateField(field, { description: null });
+      }
     },
     [field, onUpdateField],
   );

--- a/frontend/src/metabase/admin/datamodel/metadata/components/MetadataTableColumn/MetadataTableColumn.tsx
+++ b/frontend/src/metabase/admin/datamodel/metadata/components/MetadataTableColumn/MetadataTableColumn.tsx
@@ -6,6 +6,7 @@ import * as Urls from "metabase/lib/urls";
 import Fields from "metabase/entities/fields";
 import Button from "metabase/core/components/Button/Button";
 import { DatabaseId, SchemaId, TableId } from "metabase-types/api";
+import { Dispatch } from "metabase-types/store";
 import Field from "metabase-lib/metadata/Field";
 import FieldVisibilityPicker from "../FieldVisibilityPicker";
 import SemanticTypeAndTargetPicker from "../SemanticTypeAndTargetPicker";
@@ -21,14 +22,21 @@ interface OwnProps {
 }
 
 interface DispatchProps {
-  onUpdateField: (updates: Partial<Field>) => void;
+  onUpdateField: (field: Field, updates: Partial<Field>) => void;
 }
 
 type MetadataTableColumnProps = OwnProps & DispatchProps;
 
-const mapDispatchToProps: DispatchProps = {
-  onUpdateField: Fields.actions.updateField,
-};
+const mapDispatchToProps = (dispatch: Dispatch): DispatchProps => ({
+  onUpdateField: (field, updates) =>
+    dispatch(
+      Fields.actions.updateField({
+        id: field.id,
+        display_name: field.displayName(),
+        ...updates,
+      }),
+    ),
+});
 
 const MetadataTableColumn = ({
   field,
@@ -42,7 +50,7 @@ const MetadataTableColumn = ({
   const handleChangeName = useCallback(
     (event: ChangeEvent<HTMLInputElement>) => {
       if (event.target.value) {
-        onUpdateField({ id: field.id, name: event.target.value });
+        onUpdateField(field, { display_name: event.target.value });
       } else {
         event.target.value = field.displayName();
       }
@@ -52,7 +60,7 @@ const MetadataTableColumn = ({
 
   const handleChangeDescription = useCallback(
     (event: ChangeEvent<HTMLInputElement>) => {
-      onUpdateField({ id: field.id, description: event.target.value });
+      onUpdateField(field, { description: event.target.value });
     },
     [field, onUpdateField],
   );

--- a/frontend/src/metabase/admin/datamodel/metadata/components/SemanticTypeAndTargetPicker/SemanticTypeAndTargetPicker.tsx
+++ b/frontend/src/metabase/admin/datamodel/metadata/components/SemanticTypeAndTargetPicker/SemanticTypeAndTargetPicker.tsx
@@ -45,7 +45,7 @@ interface SemanticTypeAndTargetPickerProps {
   field: Field;
   idFields: Field[];
   hasSeparator?: boolean;
-  onUpdateField: (updates: Partial<Field>) => void;
+  onUpdateField: (field: Field, updates: Partial<Field>) => void;
 }
 
 const SemanticTypeAndTargetPicker = ({
@@ -68,13 +68,12 @@ const SemanticTypeAndTargetPicker = ({
         field.target.id != null &&
         isTypeFK(field.semantic_type)
       ) {
-        onUpdateField({
-          id: field.id,
+        onUpdateField(field, {
           semantic_type: semanticType,
           fk_target_field_id: null,
         });
       } else {
-        onUpdateField({ id: field.id, semantic_type: semanticType });
+        onUpdateField(field, { semantic_type: semanticType });
       }
 
       trackStructEvent("Data Model", "Update Field Special-Type", semanticType);
@@ -84,8 +83,7 @@ const SemanticTypeAndTargetPicker = ({
 
   const handleChangeCurrency = useCallback(
     ({ target: { value: currency } }: SelectChangeEvent<string>) => {
-      onUpdateField({
-        id: field.id,
+      onUpdateField(field, {
         settings: { ...field.settings, currency },
       });
       trackStructEvent("Data Model", "Update Currency Type", currency);
@@ -95,7 +93,7 @@ const SemanticTypeAndTargetPicker = ({
 
   const handleChangeTarget = useCallback(
     ({ target: { value: fk_target_field_id } }: SelectChangeEvent<FieldId>) => {
-      onUpdateField({ id: field.id, fk_target_field_id });
+      onUpdateField(field, { fk_target_field_id });
       trackStructEvent("Data Model", "Update Field Target");
     },
     [field, onUpdateField],

--- a/frontend/src/metabase/entities/tables.js
+++ b/frontend/src/metabase/entities/tables.js
@@ -80,7 +80,7 @@ const Tables = createEntity({
       return Tables.actions.update(
         entityObject,
         { [name]: value },
-        notify(opts, `table ${name}`, t`updated`),
+        notify(opts, `Table ${name}`, t`updated`),
       );
     },
     // loads `query_metadata` for a single table

--- a/frontend/src/metabase/entities/tables.js
+++ b/frontend/src/metabase/entities/tables.js
@@ -80,7 +80,7 @@ const Tables = createEntity({
       return Tables.actions.update(
         entityObject,
         { [name]: value },
-        notify(opts, `Table ${name}`, t`updated`),
+        notify(opts, `table ${name}`, t`updated`),
       );
     },
     // loads `query_metadata` for a single table


### PR DESCRIPTION
Epic https://github.com/metabase/metabase/issues/30190
Milestone https://github.com/metabase/metabase/pull/30338

Changes:
- Fixes metadata fetching when foreign key tables are not available. It turned out that `idfields` endpoint hydrates tables for its fields so there is no need to call `query_metadata` for foreign key tables, which caused issues.
- Fixes updating table/field name/description
- Adds e2e tests for all the failed cases
- Restructured e2e tests for the editor to share the same setup

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30416)
<!-- Reviewable:end -->
