### PR TITLE
Use FormProvider in SaveQuestionModal

### DIFF
--- a/frontend/src/metabase/containers/SaveQuestionModal.jsx
+++ b/frontend/src/metabase/containers/SaveQuestionModal.jsx
@@ -1,14 +1,22 @@
-/* eslint-disable react/prop-types */
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { CSSTransition, TransitionGroup } from "react-transition-group";
 import { t } from "ttag";
+import * as Yup from "yup";
 
-import Form, { FormField, FormFooter } from "metabase/containers/FormikForm";
 import ModalContent from "metabase/components/ModalContent";
-import Radio from "metabase/core/components/Radio";
-import validate from "metabase/lib/validate";
+import FormProvider from "metabase/core/components/FormProvider/FormProvider";
+import FormCollectionPicker from "metabase/collections/containers/FormCollectionPicker/FormCollectionPicker";
+import Form from "metabase/core/components/Form";
+import FormInput from "metabase/core/components/FormInput";
+import FormFooter from "metabase/core/components/FormFooter";
+import FormTextArea from "metabase/core/components/FormTextArea";
+import FormErrorMessage from "metabase/core/components/FormErrorMessage";
+import Button from "metabase/core/components/Button";
+import FormSubmitButton from "metabase/core/components/FormSubmitButton";
+import FormRadio from "metabase/core/components/FormRadio";
 import { canonicalCollectionId } from "metabase/collections/utils";
+import * as Errors from "metabase/core/utils/errors";
 
 import "./SaveQuestionModal.css";
 
@@ -22,6 +30,17 @@ const getSingleStepTitle = (questionType, showSaveType) => {
   }
 };
 
+const SAVE_QUESTION_SCHEMA = Yup.object({
+  saveType: Yup.string().oneOf(["overwrite", "create"]),
+  name: Yup.string().when("saveType", {
+    // We don't care if the form is valid when overwrite mode is enabled,
+    // as original question's data will be submitted instead of the form values
+    is: value => value !== "overwrite",
+    then: Yup.string().required(Errors.required),
+    otherwise: Yup.string(),
+  }),
+});
+
 export default class SaveQuestionModal extends Component {
   static propTypes = {
     question: PropTypes.object.isRequired,
@@ -30,14 +49,7 @@ export default class SaveQuestionModal extends Component {
     onSave: PropTypes.func.isRequired,
     onClose: PropTypes.func.isRequired,
     multiStep: PropTypes.bool,
-  };
-
-  validateName = (name, { values }) => {
-    if (values.saveType !== "overwrite") {
-      // We don't care if the form is valid when overwrite mode is enabled,
-      // as original question's data will be submitted instead of the form values
-      return validate.required()(name);
-    }
+    initialCollectionId: PropTypes.number,
   };
 
   handleSubmit = async details => {
@@ -119,29 +131,28 @@ export default class SaveQuestionModal extends Component {
         title={title}
         onClose={this.props.onClose}
       >
-        <Form
+        <FormProvider
           initialValues={initialValues}
-          fields={[
-            { name: "saveType" },
-            {
-              name: "name",
-              validate: this.validateName,
-            },
-            { name: "description" },
-            { name: "collection_id" },
-          ]}
           onSubmit={this.handleSubmit}
-          overwriteOnInitialValuesChange
+          validationSchema={SAVE_QUESTION_SCHEMA}
+          enableReinitialize
         >
-          {({ values, Form }) => (
+          {({ values, isValid }) => (
             <Form>
-              <FormField
-                name="saveType"
-                title={t`Replace or save as new?`}
-                type={SaveTypeInput}
-                hidden={!showSaveType}
-                originalQuestion={originalQuestion}
-              />
+              {!!showSaveType && (
+                <FormRadio
+                  name="saveType"
+                  title={t`Replace or save as new?`}
+                  options={[
+                    {
+                      name: t`Replace original question, "${originalQuestion?.displayName()}"`,
+                      value: "overwrite",
+                    },
+                    { name: t`Save as new question`, value: "create" },
+                  ]}
+                  vertical
+                />
+              )}
               <TransitionGroup>
                 {values.saveType === "create" && (
                   <CSSTransition
@@ -152,49 +163,37 @@ export default class SaveQuestionModal extends Component {
                     }}
                   >
                     <div className="saveQuestionModalFields">
-                      <FormField
+                      <FormInput
                         autoFocus
                         name="name"
                         title={t`Name`}
                         placeholder={nameInputPlaceholder}
                       />
-                      <FormField
+                      <FormTextArea
                         name="description"
-                        type="text"
                         title={t`Description`}
                         placeholder={t`It's optional but oh, so helpful`}
                       />
-                      <FormField
+                      <FormCollectionPicker
                         name="collection_id"
                         title={t`Which collection should this go in?`}
-                        type="collection"
                       />
                     </div>
                   </CSSTransition>
                 )}
               </TransitionGroup>
-              <FormFooter submitTitle={t`Save`} onCancel={this.props.onClose} />
+              <FormFooter>
+                <FormErrorMessage inline />
+                <Button
+                  type="button"
+                  onClick={this.props.onClose}
+                >{t`Cancel`}</Button>
+                <FormSubmitButton title={t`Save`} disabled={!isValid} primary />
+              </FormFooter>
             </Form>
           )}
-        </Form>
+        </FormProvider>
       </ModalContent>
     );
   }
 }
-
-const SaveTypeInput = ({ field, originalQuestion }) => (
-  <Radio
-    {...field}
-    type={""}
-    options={[
-      {
-        name: t`Replace original question, "${
-          originalQuestion && originalQuestion.displayName()
-        }"`,
-        value: "overwrite",
-      },
-      { name: t`Save as new question`, value: "create" },
-    ]}
-    vertical
-  />
-);

--- a/frontend/src/metabase/containers/SaveQuestionModal.jsx
+++ b/frontend/src/metabase/containers/SaveQuestionModal.jsx
@@ -139,7 +139,7 @@ export default class SaveQuestionModal extends Component {
         >
           {({ values, isValid }) => (
             <Form>
-              {!!showSaveType && (
+              {showSaveType && (
                 <FormRadio
                   name="saveType"
                   title={t`Replace or save as new?`}

--- a/frontend/src/metabase/containers/SaveQuestionModal.jsx
+++ b/frontend/src/metabase/containers/SaveQuestionModal.jsx
@@ -31,13 +31,13 @@ const getSingleStepTitle = (questionType, showSaveType) => {
 };
 
 const SAVE_QUESTION_SCHEMA = Yup.object({
-  saveType: Yup.string().oneOf(["overwrite", "create"]),
+  saveType: Yup.string(),
   name: Yup.string().when("saveType", {
     // We don't care if the form is valid when overwrite mode is enabled,
     // as original question's data will be submitted instead of the form values
     is: value => value !== "overwrite",
     then: Yup.string().required(Errors.required),
-    otherwise: Yup.string(),
+    otherwise: Yup.string().nullable(true),
   }),
 });
 

--- a/frontend/src/metabase/containers/SaveQuestionModal.jsx
+++ b/frontend/src/metabase/containers/SaveQuestionModal.jsx
@@ -137,7 +137,7 @@ export default class SaveQuestionModal extends Component {
           validationSchema={SAVE_QUESTION_SCHEMA}
           enableReinitialize
         >
-          {({ values, isValid }) => (
+          {({ values }) => (
             <Form>
               {showSaveType && (
                 <FormRadio
@@ -188,7 +188,7 @@ export default class SaveQuestionModal extends Component {
                   type="button"
                   onClick={this.props.onClose}
                 >{t`Cancel`}</Button>
-                <FormSubmitButton title={t`Save`} disabled={!isValid} primary />
+                <FormSubmitButton title={t`Save`} primary />
               </FormFooter>
             </Form>
           )}


### PR DESCRIPTION
separated from https://github.com/metabase/metabase/pull/30224
related to https://github.com/metabase/metabase/issues/26178

### Description

Refactoring of the SaveQuestionModal form with the FormProvided way instead of current, which is deprecated.
This refactoring allows to bypass problems with types in https://github.com/metabase/metabase/pull/30224

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Edit a question and try to save it, you'll have a modal which provides you two ways of saving the question: as a new question or to replace existing one.

### Demo

https://www.loom.com/share/e24376da04824a608152ad3a2ae46920

### Checklist

- [x] Tests have been added/updated to cover changes in this PR

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30418)
<!-- Reviewable:end -->
