### PR TITLE
Make CSV "Start Exploring" Link Actually Start Exploring

### DIFF
--- a/e2e/test/scenarios/collections/uploads.cy.spec.js
+++ b/e2e/test/scenarios/collections/uploads.cy.spec.js
@@ -67,6 +67,13 @@ describe("CSV Uploading", { tags: ["@external", "@actions"] }, () => {
             cy.findByText(testFile.tableName); // TODO: we should humanize model names
           });
 
+          cy.findByRole("status").within(() => {
+            cy.findByText("Start exploring").click();
+          });
+
+          cy.url().should("include", `/model/4`);
+          cy.findByTestId("TableInteractive-root");
+
           const tableQuery = `SELECT * FROM information_schema.tables WHERE table_name LIKE 'upload_${testFile.tableName}_%' ORDER BY table_name DESC LIMIT 1;`;
 
           queryWritableDB(tableQuery, dialect).then(result => {

--- a/frontend/src/metabase/redux/uploads.ts
+++ b/frontend/src/metabase/redux/uploads.ts
@@ -27,7 +27,7 @@ export const UPLOAD_FILE_TO_COLLECTION_CLEAR =
 const MAX_UPLOAD_SIZE = 200 * 1024 * 1024; // 200MB
 const MAX_UPLOAD_STRING = "200MB";
 
-const CLEAR_AFTER_MS = 5000;
+const CLEAR_AFTER_MS = 8000;
 
 const uploadStart = createAction(UPLOAD_FILE_TO_COLLECTION_START);
 const uploadEnd = createAction(UPLOAD_FILE_TO_COLLECTION_END);
@@ -76,7 +76,7 @@ export const uploadFile = createThunkAction(
         dispatch(
           uploadEnd({
             id,
-            modelId: response.model_id,
+            modelId: response,
           }),
         );
 

--- a/frontend/src/metabase/redux/uploads.unit.spec.js
+++ b/frontend/src/metabase/redux/uploads.unit.spec.js
@@ -10,13 +10,13 @@ import {
 
 const now = Date.now();
 
+const NOTIFICATION_DELAY = 9000;
+
 const mockUploadCSV = (valid = true) => {
   fetchMock.post(
     "path:/api/card/from-csv",
     valid
-      ? {
-          model_id: 3,
-        }
+      ? "3"
       : {
           throws: { data: { message: "It's dead Jim" } },
         },
@@ -47,7 +47,7 @@ describe("csv uploads", () => {
       mockUploadCSV();
 
       await uploadFile(file, "root")(dispatch);
-      jest.advanceTimersByTime(6000);
+      jest.advanceTimersByTime(NOTIFICATION_DELAY);
 
       expect(dispatch).toHaveBeenCalledWith({
         type: UPLOAD_FILE_TO_COLLECTION_START,
@@ -78,7 +78,7 @@ describe("csv uploads", () => {
       mockUploadCSV(false);
 
       await uploadFile(file, "root")(dispatch);
-      jest.advanceTimersByTime(6000);
+      jest.advanceTimersByTime(NOTIFICATION_DELAY);
 
       expect(dispatch).toHaveBeenCalledWith({
         type: UPLOAD_FILE_TO_COLLECTION_START,
@@ -109,7 +109,7 @@ describe("csv uploads", () => {
       const bigFile = new File([""], "test.csv");
       Object.defineProperty(bigFile, "size", { value: 200 * 1024 * 1024 + 1 });
       await uploadFile(bigFile, "root")(dispatch);
-      jest.advanceTimersByTime(6000);
+      jest.advanceTimersByTime(NOTIFICATION_DELAY);
 
       expect(dispatch).toHaveBeenCalledWith({
         type: UPLOAD_FILE_TO_COLLECTION_START,

--- a/frontend/src/metabase/status/components/FileUploadStatus/FileUploadStatus.unit.spec.tsx
+++ b/frontend/src/metabase/status/components/FileUploadStatus/FileUploadStatus.unit.spec.tsx
@@ -70,7 +70,7 @@ describe("FileUploadStatus", () => {
   });
 
   it("Should show a start exploring link on completion", async () => {
-    fetchMock.post("path:/api/card/from-csv", { model_id: 3 }, { delay: 1000 });
+    fetchMock.post("path:/api/card/from-csv", "3", { delay: 1000 });
 
     renderWithProviders(
       <Route

--- a/frontend/src/metabase/status/components/FileUploadStatusLarge/FileUploadStatusLarge.tsx
+++ b/frontend/src/metabase/status/components/FileUploadStatusLarge/FileUploadStatusLarge.tsx
@@ -27,7 +27,7 @@ const FileUploadLarge = ({
     title: getTitle(uploads, collection),
     items: uploads.map(upload => ({
       id: upload.id,
-      title: upload.name,
+      title: getName(upload),
       icon: "model",
       description: getDescription(upload),
       isInProgress: isUploadInProgress(upload),
@@ -37,6 +37,13 @@ const FileUploadLarge = ({
   };
 
   return <StatusLarge status={status} isActive={isActive} />;
+};
+
+const getName = (upload: FileUpload) => {
+  if (upload.status === "complete") {
+    return <Link to={`/model/${upload.modelId}`}>{upload.name}</Link>;
+  }
+  return upload.name;
 };
 
 const getTitle = (uploads: FileUpload[], collection: Collection) => {

--- a/frontend/src/metabase/status/components/StatusLarge/StatusLarge.tsx
+++ b/frontend/src/metabase/status/components/StatusLarge/StatusLarge.tsx
@@ -24,7 +24,7 @@ type Status = {
 
 type StatusItem = {
   id?: number;
-  title: string;
+  title: string | JSX.Element;
   icon: string;
   description?: string | JSX.Element;
   isInProgress: boolean;


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/30419

### Description

- backend: now returns a model id
- frontend: now has somewhere to send you when a CSV is uploaded
- frontend: extends the timeout for removing the status popover to give you more time to click
- frontend: makes the model name and the start exploring both clickable links

![Screen Shot 2023-04-27 at 9 52 58 AM](https://user-images.githubusercontent.com/30528226/234930183-e9b7ba2b-8386-4d60-bcee-04a9ce99d03a.png)

### How to verify

1. Upload a CSV
2. When it's done, click on its name in the notification
3. You should navigate to the newly-created model


### Checklist

- [x] Tests have been added/updated to cover changes in this PR

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30421)
<!-- Reviewable:end -->
