### PR TITLE
Make bucketing options opaque

### DIFF
--- a/src/metabase/lib/core.cljc
+++ b/src/metabase/lib/core.cljc
@@ -190,4 +190,5 @@
    describe-relative-datetime
    available-temporal-buckets
    temporal-bucket
+   temporal-bucket-option
    with-temporal-bucket])

--- a/src/metabase/lib/field.cljc
+++ b/src/metabase/lib/field.cljc
@@ -276,10 +276,10 @@
   [_query _stage-number field-metadata]
   (let [effective-type ((some-fn :effective-type :base-type) field-metadata)]
     (cond
-      (isa? effective-type :type/DateTime) lib.schema.temporal-bucketing/datetime-bucketing-units
-      (isa? effective-type :type/Date)     lib.schema.temporal-bucketing/date-bucketing-units
-      (isa? effective-type :type/Time)     lib.schema.temporal-bucketing/time-bucketing-units
-      :else                                #{})))
+      (isa? effective-type :type/DateTime) lib.temporal-bucket/datetime-bucket-options
+      (isa? effective-type :type/Date)     lib.temporal-bucket/date-bucket-options
+      (isa? effective-type :type/Time)     lib.temporal-bucket/time-bucket-options
+      :else                                [])))
 
 (defmethod lib.join/current-join-alias-method :field
   [[_tag opts]]

--- a/src/metabase/lib/schema/temporal_bucketing.cljc
+++ b/src/metabase/lib/schema/temporal_bucketing.cljc
@@ -4,61 +4,100 @@
    [clojure.set :as set]
    [metabase.util.malli.registry :as mr]))
 
+(def ordered-date-extraction-units
+  "Units that you can EXTRACT from a date or datetime. These return integers in temporal bucketing expressions.
+  The front end shows the options in this order."
+  [:day-of-week
+   :day-of-month
+   :day-of-year
+   :week-of-year
+   :month-of-year
+   :quarter-of-year
+   :year])
+
 (def date-extraction-units
   "Units that you can EXTRACT from a date or datetime. These return integers in temporal bucketing expressions."
-  #{:day-of-week
-    :day-of-month
-    :day-of-year
-    :week-of-year
-    :month-of-year
-    :quarter-of-year
-    :year})
+  (set ordered-date-extraction-units))
 
 (mr/def ::unit.date.extract
   (into [:enum {:error/message "Valid date extraction unit"}] date-extraction-units))
 
-(def date-truncation-units
+(def ordered-date-truncation-units
   "Units that you can TRUNCATE a date or datetime to. In temporal bucketing expressions these return a `:type/Date`.
+  The front end shows the options in this order."
+  [:day :week :month :quarter :year])
 
-  Note: `:year` could work as either an extract or a truncation unit, but I think we're mostly using it as extract for
-  the time being. So it is is not included here."
-  #{:day :week :month :quarter})
+(def date-truncation-units
+  "Units that you can TRUNCATE a date or datetime to. In temporal bucketing expressions these return a `:type/Date`."
+  (set ordered-date-truncation-units))
 
 (mr/def ::unit.date.truncate
   (into [:enum {:error/message "Valid date truncation unit"}] date-truncation-units))
 
+(def ordered-date-bucketing-units
+  "Valid date or datetime bucketing units for either truncation or extraction operations.
+  The front end shows the options in this order."
+  (into [] (distinct) (concat ordered-date-truncation-units ordered-date-extraction-units)))
+
 (def date-bucketing-units
   "Valid date or datetime bucketing units for either truncation or extraction operations."
-  (set/union date-extraction-units date-truncation-units))
+  (set ordered-date-bucketing-units))
 
 (mr/def ::unit.date
   (into [:enum {:error/message "Valid date bucketing unit"}] date-bucketing-units))
 
+(def ordered-time-extraction-units
+  "Units that you can EXTRACT from a time or datetime. These return integers in temporal bucketing expressions.
+  The front end shows the options in this order."
+  [:minute-of-hour :hour-of-day])
+
 (def time-extraction-units
   "Units that you can EXTRACT from a time or datetime. These return integers in temporal bucketing expressions."
-  #{:minute-of-hour :hour-of-day})
+  (set ordered-time-extraction-units))
 
 (mr/def ::unit.time.extract
   (into [:enum {:error/message "Valid time extraction unit"}] time-extraction-units))
 
+(def ordered-time-truncation-units
+  "Units you can TRUNCATE a time or datetime to. These return the same type as the expression being bucketed in temporal
+  bucketing expressions. The front end shows the options in this order."
+  [:millisecond :second :minute :hour])
+
 (def time-truncation-units
   "Units you can TRUNCATE a time or datetime to. These return the same type as the expression being bucketed in temporal
   bucketing expressions."
-  #{:millisecond :second :minute :hour})
+  (set ordered-time-truncation-units))
 
 (mr/def ::unit.time.truncate
   (into [:enum {:error/message "Valid time truncation unit"}] time-truncation-units))
 
+(def ordered-time-bucketing-units
+  "Valid time bucketing units for either truncation or extraction operations.
+  The front end shows the options in this order."
+  (into []
+        (comp (remove #{:millisecond :second})
+              (distinct))
+        (concat ordered-time-truncation-units ordered-time-extraction-units)))
+
 (def time-bucketing-units
   "Valid time bucketing units for either truncation or extraction operations."
-  (set/union time-extraction-units time-truncation-units))
+  (set ordered-time-extraction-units))
 
 (mr/def ::unit.time
   (into [:enum {:error/message "Valid time bucketing unit"}] time-bucketing-units))
 
+(def ordered-datetime-bucketing-units
+  "Valid datetime bucketing units for either truncation or extraction operations.
+  The front end shows the options in this order."
+  (into []
+        (comp (remove #{:millisecond :second})
+              (distinct))
+        (concat ordered-time-truncation-units ordered-date-truncation-units
+                ordered-time-extraction-units ordered-date-extraction-units)))
+
 (def datetime-bucketing-units
   "Valid datetime bucketing units for either truncation or extraction operations."
-  (set/union date-bucketing-units time-bucketing-units))
+  (set ordered-datetime-bucketing-units))
 
 (mr/def ::unit.date-time
   (into [:enum {:error/message "Valid datetime bucketing unit"}] datetime-bucketing-units))
@@ -108,3 +147,9 @@
 
 (mr/def ::unit.date-time.interval
   (into [:enum {:error/message "Valid datetime interval unit"}] datetime-interval-units))
+
+(mr/def ::option
+  [:map
+   [:lib/type [:= :type/temporal-bucketing-option]]
+   [:unit ::unit]
+   [:default {:optional true} :boolean]])


### PR DESCRIPTION
Fixes #30364.
Fixes #30365.
Fixes #30367.
Fixes #30368.

The order of the options and the default option are the same as returned by the `GET /api/table/:id/query_metadata` endpoint. As discussed in #30368, the default is not always what is shown in the FE by default.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30424)
<!-- Reviewable:end -->
