### PR TITLE
30190: GET /api/database/:id/schemas should return 404 if db not found

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
@@ -246,12 +246,16 @@
       (testing "If a non-admin has data model perms, but no data perms"
         (with-all-users-data-perms {db-id {:data       {:schemas :block :native :none}
                                            :data-model {:schemas :all}}}
-          (testing "and if data permissions are revoked, it should be a 403"
+          (testing "if include_editable_data_model=nil, it should be a 403"
             (is (= "You don't have permissions to do that."
                    (mt/user-http-request :rasta :get 403 (format "database/%d/schemas" db-id)))))
           (testing "and if include_editable_data_model=true, it should return values"
             (is (= ["schema1" "schema2"]
                    (mt/user-http-request :rasta :get 200 (format "database/%d/schemas" db-id)
+                                         :include_editable_data_model true))))
+          (testing "and if the database doesn't exist, it should be a 404"
+            (is (= "Not found."
+                   (mt/user-http-request :rasta :get 404 (format "database/%d/schemas" Integer/MAX_VALUE)
                                          :include_editable_data_model true))))))
       (testing "If include_editable_data_model=true and a non-admin does not have data model perms, it should return []"
         (with-all-users-data-perms {db-id {:data       {:schemas :block :native :none}

--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -1072,7 +1072,8 @@
                              (map :schema (f (map (fn [s] {:db_id id :schema s}) schemas)))
                              schemas)
                            (filter (partial can-read-schema? id) schemas)))]
-    (when-not include_editable_data_model
+    (if include_editable_data_model
+      (api/check-404 (t2/select-one Database id))
       (api/read-check Database id))
     (->> (t2/select-fn-set :schema Table
                            :db_id id :active true


### PR DESCRIPTION
This PR fixes a bug on the `30190-data-model-performance` feature branch ([PR](https://github.com/metabase/metabase/pull/30338)) where `GET /api/database/:id/schemas?include_hidden=true&include_editable_data_model=true` returns an empty list for a non-existing database, hovewer previously it returned an error (or 404).

Now it responds with a 404 again.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30434)
<!-- Reviewable:end -->
