### PR TITLE
auto assign PR authors, add teams labels, add PRs to the project board

### DIFF
--- a/.github/team.json
+++ b/.github/team.json
@@ -1,0 +1,48 @@
+{
+  "teams": [
+    {
+      "name": "App Viz",
+      "label": ".Team/Viz 📊",
+      "members": [
+        "alxnddr",
+        "iethree",
+        "npfitz",
+        "EmmadUsmani",
+        "JesseSDevaney"
+      ]
+    },
+    {
+      "name": "Query Builder",
+      "label": ".Team/QueryBuilder 🧮",
+      "members": [
+        "ranquild",
+        "WiNloSt",
+        "deniskaber",
+        "oisincoveney",
+        "uladzimirdev"
+      ]
+    },
+    {
+      "name": "App BE",
+      "label": ".Team/Backend 🥞",
+      "members": ["dpsutton", "tsmacdonald", "qnkhuat", "calherries"]
+    },
+    {
+      "name": "Query Processor",
+      "label": ".Team/QueryProcessor 🛠️",
+      "members": [
+        "camsaul",
+        "kulyk",
+        "snoe",
+        "bshepherdson",
+        "john-metabase",
+        "metamben"
+      ]
+    },
+    {
+      "name": "Fun Police",
+      "label": ".Team/FunPolice 👮",
+      "members": ["noahmoss", "escherize", "adam-james-v"]
+    }
+  ]
+}

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -1,0 +1,59 @@
+name: Auto assign pull requests
+
+on:
+  pull_request:
+    types:
+      - opened
+
+jobs:
+  update_pr:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: tibdex/github-app-token@v1.6.0
+        id: generate-token
+        with:
+          app_id: ${{ secrets.METABASE_BOT_APP_ID }}
+          private_key: ${{ secrets.METABASE_BOT_APP_PRIVATE_KEY }}
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Assign author and their team. Returns true if team exists.
+        id: auto-assign
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ steps.generate-token.outputs.token }}
+          script: |
+            const fs = require('fs');
+            const teamConfig = JSON.parse(fs.readFileSync('.github/team.json', 'utf-8'));
+            const prAuthor = context.payload.pull_request.user.login;
+            const prNumber = context.payload.pull_request.number;
+
+            // Assign PR author
+            await github.rest.issues.addAssignees({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              assignees: [prAuthor]
+            });
+
+            const team = teamConfig.teams.find(t => t.members.includes(prAuthor));
+            if (!team) {
+              console.log('You are not assigned to any team. If you need one, update .github/team.json');
+              return false;
+            }
+
+            // Add team label
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              labels: [team.label]
+            });
+
+            return true;
+      - uses: actions/add-to-project@v0.5.0
+        if: ${{ fromJSON(steps.auto-assign.outputs.result) }}
+        with:
+          project-url: https://github.com/orgs/metabase/projects/50/views/1
+          github-token: ${{ steps.generate-token.outputs.token }}


### PR DESCRIPTION
### Description

Automatically assigns PR authors, adds team labels, and adds PRs to the project board so you don't have to do it manually every time. The project board workflow will put PRs in the "In Progress" column for you:
<img width="802" alt="Screen Shot 2023-04-30 at 11 14 29 PM" src="https://user-images.githubusercontent.com/14301985/235391868-19f8e22a-aeb0-40f7-8d35-566861495d04.png">

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30455)
<!-- Reviewable:end -->
