### PR TITLE
Add warning message when editing data model segments and metrics

### DIFF
--- a/frontend/src/metabase/admin/datamodel/components/FormInput/FormInput.tsx
+++ b/frontend/src/metabase/admin/datamodel/components/FormInput/FormInput.tsx
@@ -14,6 +14,7 @@ const FormInput = forwardRef(function FormInput(
   return (
     <FormInputRoot
       {...props}
+      value={props.value ?? ""}
       ref={ref}
       className={cx("input", className)}
       type="text"

--- a/frontend/src/metabase/admin/datamodel/components/MetricForm/MetricForm.tsx
+++ b/frontend/src/metabase/admin/datamodel/components/MetricForm/MetricForm.tsx
@@ -7,6 +7,7 @@ import { formatValue } from "metabase/lib/formatting";
 import Button from "metabase/core/components/Button";
 import FieldSet from "metabase/components/FieldSet";
 import { Metric, StructuredQuery } from "metabase-types/api";
+import useBeforeUnload from "metabase/hooks/use-before-unload";
 import * as Q from "metabase-lib/queries/utils/query";
 import FormInput from "../FormInput";
 import FormLabel from "../FormLabel";
@@ -42,12 +43,15 @@ const MetricForm = ({
 }: MetricFormProps): JSX.Element => {
   const isNew = metric == null;
 
-  const { isValid, getFieldProps, getFieldMeta, handleSubmit } = useFormik({
-    initialValues: metric ?? {},
-    isInitialValid: false,
-    validate: getFormErrors,
-    onSubmit,
-  });
+  const { isValid, getFieldProps, getFieldMeta, handleSubmit, dirty } =
+    useFormik({
+      initialValues: metric ?? {},
+      isInitialValid: false,
+      validate: getFormErrors,
+      onSubmit,
+    });
+
+  useBeforeUnload(dirty);
 
   return (
     <FormRoot onSubmit={handleSubmit}>

--- a/frontend/src/metabase/admin/datamodel/components/MetricForm/MetricForm.unit.spec.tsx
+++ b/frontend/src/metabase/admin/datamodel/components/MetricForm/MetricForm.unit.spec.tsx
@@ -21,7 +21,11 @@ const setup = () => {
 };
 
 describe("MetricForm", () => {
-  it("should render", async () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("should have beforeunload event when user makes edits to a metric", async () => {
     const { mockEventListener } = setup();
 
     const descriptionInput = screen.getByPlaceholderText(
@@ -29,15 +33,19 @@ describe("MetricForm", () => {
     );
     userEvent.type(descriptionInput, "01189998819991197253");
 
-    await waitFor(() => {
-      screen.debug(undefined, 1000000);
+    const mockEvent = await waitFor(() => {
+      return callMockEvent(mockEventListener, "beforeunload");
     });
+    expect(mockEvent.preventDefault).toHaveBeenCalled();
+    expect(mockEvent.returnValue).toBe(BEFORE_UNLOAD_UNSAVED_MESSAGE);
+  });
+
+  it("should not have an beforeunload event when metric is unedited", async () => {
+    const { mockEventListener } = setup();
 
     const mockEvent = callMockEvent(mockEventListener, "beforeunload");
 
-    expect(mockEvent.preventDefault).toHaveBeenCalled();
-    expect(mockEvent.returnValue).toBe(BEFORE_UNLOAD_UNSAVED_MESSAGE);
-
-    expect(true).toBe(true);
+    expect(mockEvent.preventDefault).not.toHaveBeenCalled();
+    expect(mockEvent.returnValue).toBe(undefined);
   });
 });

--- a/frontend/src/metabase/admin/datamodel/components/MetricForm/MetricForm.unit.spec.tsx
+++ b/frontend/src/metabase/admin/datamodel/components/MetricForm/MetricForm.unit.spec.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+import userEvent from "@testing-library/user-event";
+import { renderWithProviders, screen, waitFor } from "__support__/ui";
+import MetricApp from "metabase/admin/datamodel/containers/MetricApp";
+import { Route } from "metabase/hoc/Title";
+import { callMockEvent } from "__support__/events";
+import { BEFORE_UNLOAD_UNSAVED_MESSAGE } from "metabase/hooks/use-before-unload";
+
+const setup = () => {
+  renderWithProviders(
+    <Route path="/admin/datamodel/metric/create" component={MetricApp} />,
+    {
+      initialRoute: "/admin/datamodel/metric/create",
+      withRouter: true,
+    },
+  );
+
+  const mockEventListener = jest.spyOn(window, "addEventListener");
+
+  return { mockEventListener };
+};
+
+describe("MetricForm", () => {
+  it("should render", async () => {
+    const { mockEventListener } = setup();
+
+    const descriptionInput = screen.getByPlaceholderText(
+      "Something descriptive but not too long",
+    );
+    userEvent.type(descriptionInput, "01189998819991197253");
+
+    await waitFor(() => {
+      screen.debug(undefined, 1000000);
+    });
+
+    const mockEvent = callMockEvent(mockEventListener, "beforeunload");
+
+    expect(mockEvent.preventDefault).toHaveBeenCalled();
+    expect(mockEvent.returnValue).toBe(BEFORE_UNLOAD_UNSAVED_MESSAGE);
+
+    expect(true).toBe(true);
+  });
+});

--- a/frontend/src/metabase/admin/datamodel/components/PartialQueryBuilder.jsx
+++ b/frontend/src/metabase/admin/datamodel/components/PartialQueryBuilder.jsx
@@ -21,7 +21,7 @@ import withTableMetadataLoaded from "../hoc/withTableMetadataLoaded";
 class PartialQueryBuilder extends Component {
   static propTypes = {
     onChange: PropTypes.func.isRequired,
-    table: PropTypes.object.isRequired,
+    table: PropTypes.object,
     updatePreviewSummary: PropTypes.func.isRequired,
     previewSummary: PropTypes.string,
   };

--- a/frontend/src/metabase/admin/datamodel/components/SegmentForm/SegmentForm.tsx
+++ b/frontend/src/metabase/admin/datamodel/components/SegmentForm/SegmentForm.tsx
@@ -7,6 +7,7 @@ import { formatValue } from "metabase/lib/formatting";
 import Button from "metabase/core/components/Button/Button";
 import FieldSet from "metabase/components/FieldSet";
 import { Segment, StructuredQuery } from "metabase-types/api";
+import useBeforeUnload from "metabase/hooks/use-before-unload";
 import * as Q from "metabase-lib/queries/utils/query";
 import FormInput from "../FormInput";
 import FormLabel from "../FormLabel";
@@ -41,12 +42,15 @@ const SegmentForm = ({
 }: SegmentFormProps): JSX.Element => {
   const isNew = segment == null;
 
-  const { isValid, getFieldProps, getFieldMeta, handleSubmit } = useFormik({
-    initialValues: segment ?? {},
-    isInitialValid: false,
-    validate: getFormErrors,
-    onSubmit,
-  });
+  const { isValid, getFieldProps, getFieldMeta, handleSubmit, dirty } =
+    useFormik({
+      initialValues: segment ?? {},
+      isInitialValid: false,
+      validate: getFormErrors,
+      onSubmit,
+    });
+
+  useBeforeUnload(dirty);
 
   return (
     <FormRoot onSubmit={handleSubmit}>

--- a/frontend/src/metabase/admin/datamodel/components/SegmentForm/SegmentForm.unit.spec.tsx
+++ b/frontend/src/metabase/admin/datamodel/components/SegmentForm/SegmentForm.unit.spec.tsx
@@ -1,0 +1,181 @@
+import React from "react";
+import { Link } from "react-router";
+import { useFormik } from "formik";
+import type { FieldInputProps } from "formik";
+import { t } from "ttag";
+import { formatValue } from "metabase/lib/formatting";
+import Button from "metabase/core/components/Button/Button";
+import FieldSet from "metabase/components/FieldSet";
+import { Segment, StructuredQuery } from "metabase-types/api";
+import useBeforeUnload from "metabase/hooks/use-before-unload";
+import * as Q from "metabase-lib/queries/utils/query";
+import FormInput from "../FormInput";
+import FormLabel from "../FormLabel";
+import FormTextArea from "../FormTextArea";
+import PartialQueryBuilder from "../PartialQueryBuilder";
+import {
+  FormRoot,
+  FormSection,
+  FormBody,
+  FormBodyContent,
+  FormFooter,
+  FormFooterContent,
+  FormSubmitButton,
+} from "./SegmentForm.styled";
+
+const QUERY_BUILDER_FEATURES = {
+  filter: true,
+};
+
+export interface SegmentFormProps {
+  segment?: Segment;
+  previewSummary?: string;
+  updatePreviewSummary: (previewSummary: string) => void;
+  onSubmit: (values: Partial<Segment>) => void;
+}
+
+const SegmentForm = ({
+  segment,
+  previewSummary,
+  updatePreviewSummary,
+  onSubmit,
+}: SegmentFormProps): JSX.Element => {
+  const isNew = segment == null;
+
+  const { isValid, getFieldProps, getFieldMeta, handleSubmit, dirty } =
+    useFormik({
+      initialValues: segment ?? {},
+      isInitialValid: false,
+      validate: getFormErrors,
+      onSubmit,
+    });
+
+  useBeforeUnload(dirty);
+
+  return (
+    <FormRoot onSubmit={handleSubmit}>
+      <FormBody>
+        <FormLabel
+          title={isNew ? t`Create Your Segment` : t`Edit Your Segment`}
+          description={
+            isNew
+              ? t`Select and add filters to create your new segment.`
+              : t`Make changes to your segment and leave an explanatory note.`
+          }
+        >
+          <PartialQueryBuilder
+            {...getQueryBuilderProps(getFieldProps("definition"))}
+            features={QUERY_BUILDER_FEATURES}
+            canChangeTable={isNew}
+            previewSummary={getResultSummary(previewSummary)}
+            updatePreviewSummary={updatePreviewSummary}
+          />
+        </FormLabel>
+        <FormBodyContent>
+          <FormLabel
+            title={t`Name Your Segment`}
+            description={t`Give your segment a name to help others find it.`}
+          >
+            <FormInput
+              {...getFieldProps("name")}
+              {...getFieldMeta("name")}
+              placeholder={t`Something descriptive but not too long`}
+            />
+          </FormLabel>
+          <FormLabel
+            title={t`Describe Your Segment`}
+            description={t`Give your segment a description to help others understand what it's about.`}
+          >
+            <FormTextArea
+              {...getFieldProps("description")}
+              {...getFieldMeta("description")}
+              placeholder={t`This is a good place to be more specific about less obvious segment rules`}
+            />
+          </FormLabel>
+          {!isNew && (
+            <FieldSet legend={t`Reason For Changes`} noPadding={false}>
+              <FormLabel
+                description={t`Leave a note to explain what changes you made and why they were required.`}
+              >
+                <FormTextArea
+                  {...getFieldProps("revision_message")}
+                  {...getFieldMeta("revision_message")}
+                  placeholder={t`This will show up in the revision history for this segment to help everyone remember why things changed`}
+                />
+              </FormLabel>
+              <FormFooterContent>
+                <SegmentFormActions isValid={isValid} />
+              </FormFooterContent>
+            </FieldSet>
+          )}
+        </FormBodyContent>
+      </FormBody>
+      {isNew && (
+        <FormFooter>
+          <FormSection>
+            <SegmentFormActions isValid={isValid} />
+          </FormSection>
+        </FormFooter>
+      )}
+    </FormRoot>
+  );
+};
+
+interface SegmentFormActionsProps {
+  isValid: boolean;
+}
+
+const SegmentFormActions = ({
+  isValid,
+}: SegmentFormActionsProps): JSX.Element => {
+  return (
+    <div>
+      <FormSubmitButton type="submit" primary={isValid} disabled={!isValid}>
+        {t`Save changes`}
+      </FormSubmitButton>
+      <Button as={Link} to="/admin/datamodel/segments">
+        {t`Cancel`}
+      </Button>
+    </div>
+  );
+};
+
+const getResultSummary = (previewSummary?: string) => {
+  return previewSummary ? t`${formatValue(previewSummary)} rows` : "";
+};
+
+const getFormErrors = (values: Partial<Segment>) => {
+  const errors: Record<string, string> = {};
+
+  if (!values.name) {
+    errors.name = t`Name is required`;
+  }
+
+  if (!values.description) {
+    errors.description = t`Description is required`;
+  }
+
+  if (values.id != null && !values.revision_message) {
+    errors.revision_message = t`Revision message is required`;
+  }
+
+  const filters = values.definition && Q.getFilters(values.definition);
+  if (!filters || filters.length === 0) {
+    errors.definition = t`At least one filter is required`;
+  }
+
+  return errors;
+};
+
+const getQueryBuilderProps = ({
+  name,
+  value,
+  onChange,
+}: FieldInputProps<StructuredQuery>) => {
+  return {
+    value,
+    onChange: (value: StructuredQuery) => onChange({ target: { name, value } }),
+  };
+};
+
+export default SegmentForm;

--- a/frontend/src/metabase/admin/datamodel/components/SegmentForm/SegmentForm.unit.spec.tsx
+++ b/frontend/src/metabase/admin/datamodel/components/SegmentForm/SegmentForm.unit.spec.tsx
@@ -1,181 +1,51 @@
 import React from "react";
-import { Link } from "react-router";
-import { useFormik } from "formik";
-import type { FieldInputProps } from "formik";
-import { t } from "ttag";
-import { formatValue } from "metabase/lib/formatting";
-import Button from "metabase/core/components/Button/Button";
-import FieldSet from "metabase/components/FieldSet";
-import { Segment, StructuredQuery } from "metabase-types/api";
-import useBeforeUnload from "metabase/hooks/use-before-unload";
-import * as Q from "metabase-lib/queries/utils/query";
-import FormInput from "../FormInput";
-import FormLabel from "../FormLabel";
-import FormTextArea from "../FormTextArea";
-import PartialQueryBuilder from "../PartialQueryBuilder";
-import {
-  FormRoot,
-  FormSection,
-  FormBody,
-  FormBodyContent,
-  FormFooter,
-  FormFooterContent,
-  FormSubmitButton,
-} from "./SegmentForm.styled";
+import userEvent from "@testing-library/user-event";
+import { renderWithProviders, screen, waitFor } from "__support__/ui";
+import { Route } from "metabase/hoc/Title";
+import { callMockEvent } from "__support__/events";
+import { BEFORE_UNLOAD_UNSAVED_MESSAGE } from "metabase/hooks/use-before-unload";
+import SegmentApp from "metabase/admin/datamodel/containers/SegmentApp";
 
-const QUERY_BUILDER_FEATURES = {
-  filter: true,
+const setup = () => {
+  renderWithProviders(
+    <Route path="/admin/datamodel/segment/create" component={SegmentApp} />,
+    {
+      initialRoute: "/admin/datamodel/segment/create",
+      withRouter: true,
+    },
+  );
+
+  const mockEventListener = jest.spyOn(window, "addEventListener");
+
+  return { mockEventListener };
 };
 
-export interface SegmentFormProps {
-  segment?: Segment;
-  previewSummary?: string;
-  updatePreviewSummary: (previewSummary: string) => void;
-  onSubmit: (values: Partial<Segment>) => void;
-}
+describe("SegmentForm", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
 
-const SegmentForm = ({
-  segment,
-  previewSummary,
-  updatePreviewSummary,
-  onSubmit,
-}: SegmentFormProps): JSX.Element => {
-  const isNew = segment == null;
+  it("should have beforeunload event when user makes edits to a segment", async () => {
+    const { mockEventListener } = setup();
 
-  const { isValid, getFieldProps, getFieldMeta, handleSubmit, dirty } =
-    useFormik({
-      initialValues: segment ?? {},
-      isInitialValid: false,
-      validate: getFormErrors,
-      onSubmit,
+    const descriptionInput = screen.getByPlaceholderText(
+      "Something descriptive but not too long",
+    );
+    userEvent.type(descriptionInput, "01189998819991197253");
+
+    const mockEvent = await waitFor(() => {
+      return callMockEvent(mockEventListener, "beforeunload");
     });
+    expect(mockEvent.preventDefault).toHaveBeenCalled();
+    expect(mockEvent.returnValue).toBe(BEFORE_UNLOAD_UNSAVED_MESSAGE);
+  });
 
-  useBeforeUnload(dirty);
+  it("should not have an beforeunload event when metric is segment", async () => {
+    const { mockEventListener } = setup();
 
-  return (
-    <FormRoot onSubmit={handleSubmit}>
-      <FormBody>
-        <FormLabel
-          title={isNew ? t`Create Your Segment` : t`Edit Your Segment`}
-          description={
-            isNew
-              ? t`Select and add filters to create your new segment.`
-              : t`Make changes to your segment and leave an explanatory note.`
-          }
-        >
-          <PartialQueryBuilder
-            {...getQueryBuilderProps(getFieldProps("definition"))}
-            features={QUERY_BUILDER_FEATURES}
-            canChangeTable={isNew}
-            previewSummary={getResultSummary(previewSummary)}
-            updatePreviewSummary={updatePreviewSummary}
-          />
-        </FormLabel>
-        <FormBodyContent>
-          <FormLabel
-            title={t`Name Your Segment`}
-            description={t`Give your segment a name to help others find it.`}
-          >
-            <FormInput
-              {...getFieldProps("name")}
-              {...getFieldMeta("name")}
-              placeholder={t`Something descriptive but not too long`}
-            />
-          </FormLabel>
-          <FormLabel
-            title={t`Describe Your Segment`}
-            description={t`Give your segment a description to help others understand what it's about.`}
-          >
-            <FormTextArea
-              {...getFieldProps("description")}
-              {...getFieldMeta("description")}
-              placeholder={t`This is a good place to be more specific about less obvious segment rules`}
-            />
-          </FormLabel>
-          {!isNew && (
-            <FieldSet legend={t`Reason For Changes`} noPadding={false}>
-              <FormLabel
-                description={t`Leave a note to explain what changes you made and why they were required.`}
-              >
-                <FormTextArea
-                  {...getFieldProps("revision_message")}
-                  {...getFieldMeta("revision_message")}
-                  placeholder={t`This will show up in the revision history for this segment to help everyone remember why things changed`}
-                />
-              </FormLabel>
-              <FormFooterContent>
-                <SegmentFormActions isValid={isValid} />
-              </FormFooterContent>
-            </FieldSet>
-          )}
-        </FormBodyContent>
-      </FormBody>
-      {isNew && (
-        <FormFooter>
-          <FormSection>
-            <SegmentFormActions isValid={isValid} />
-          </FormSection>
-        </FormFooter>
-      )}
-    </FormRoot>
-  );
-};
+    const mockEvent = callMockEvent(mockEventListener, "beforeunload");
 
-interface SegmentFormActionsProps {
-  isValid: boolean;
-}
-
-const SegmentFormActions = ({
-  isValid,
-}: SegmentFormActionsProps): JSX.Element => {
-  return (
-    <div>
-      <FormSubmitButton type="submit" primary={isValid} disabled={!isValid}>
-        {t`Save changes`}
-      </FormSubmitButton>
-      <Button as={Link} to="/admin/datamodel/segments">
-        {t`Cancel`}
-      </Button>
-    </div>
-  );
-};
-
-const getResultSummary = (previewSummary?: string) => {
-  return previewSummary ? t`${formatValue(previewSummary)} rows` : "";
-};
-
-const getFormErrors = (values: Partial<Segment>) => {
-  const errors: Record<string, string> = {};
-
-  if (!values.name) {
-    errors.name = t`Name is required`;
-  }
-
-  if (!values.description) {
-    errors.description = t`Description is required`;
-  }
-
-  if (values.id != null && !values.revision_message) {
-    errors.revision_message = t`Revision message is required`;
-  }
-
-  const filters = values.definition && Q.getFilters(values.definition);
-  if (!filters || filters.length === 0) {
-    errors.definition = t`At least one filter is required`;
-  }
-
-  return errors;
-};
-
-const getQueryBuilderProps = ({
-  name,
-  value,
-  onChange,
-}: FieldInputProps<StructuredQuery>) => {
-  return {
-    value,
-    onChange: (value: StructuredQuery) => onChange({ target: { name, value } }),
-  };
-};
-
-export default SegmentForm;
+    expect(mockEvent.preventDefault).not.toHaveBeenCalled();
+    expect(mockEvent.returnValue).toBe(undefined);
+  });
+});


### PR DESCRIPTION
### Description

Adds a warning message when a user tries to refresh/close/navigate away from the page before saving any changes that they have made to their data models's segments and metrics.

### How to verify

1. Go to Metabase Admin > Data Model
2. Click on Segments or Models, and try to add one
3. Make any change (i.e. add a description) and try to close/refresh the tab. The browser should popup with a "Are you sure" prompt.

### Demo

_Upload a demo video or before/after screenshots if sensible or remove the section_

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30458)
<!-- Reviewable:end -->
