### PR TITLE
Migrate field refs in visualization_settings.column_settings from legacy format

### DIFF
--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -14509,7 +14509,7 @@ databaseChangeLog:
       comment: Added 0.47.0 - Migrate the report_card.visualization_settings.column_settings field refs from legacy format
       changes:
         - customChange:
-            class: "metabase.db.custom_migrations.MigrateLegacyVisualizationSettings"
+            class: "metabase.db.custom_migrations.MigrateLegacyColumnSettingsFieldRefs"
 
 # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -14509,7 +14509,7 @@ databaseChangeLog:
       comment: Added 0.47.0 - Migrate the report_card.visualization_settings.column_settings field refs from legacy format
       changes:
         - customChange:
-            class: "metabase.db.custom_migrations.UpdateLegacyColumnSettingsFieldRefs"
+            class: "metabase.db.custom_migrations.MigrateLegacyVisualizationSettings"
 
 # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -14503,6 +14503,14 @@ databaseChangeLog:
                   constraints:
                     nullable: false
 
+  - changeSet:
+      id: v47.00-016
+      author: calherres
+      comment: Added 0.47.0 - Migrate the report_card.visualization_settings.column_settings field refs from legacy format
+      changes:
+        - customChange:
+            class: "metabase.db.custom_migrations.UpdateLegacyColumnSettingsFieldRefs"
+
 # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################

--- a/src/metabase/db/custom_migrations.clj
+++ b/src/metabase/db/custom_migrations.clj
@@ -8,17 +8,20 @@
 
    If you need to use code from elsewhere, consider copying it into this namespace to minimize risk of the code changing behaviour."
   (:require
+   [clojure.core.match :refer [match]]
    [cheshire.core :as json]
    [clojure.set :as set]
    [clojurewerkz.quartzite.jobs :as jobs]
    [clojurewerkz.quartzite.scheduler :as qs]
    [clojurewerkz.quartzite.triggers :as triggers]
+   [medley.core :as m]
    [metabase.db.connection :as mdb.connection]
    [metabase.plugins.classloader :as classloader]
    [metabase.util.honey-sql-2 :as h2x]
    [metabase.util.log :as log]
    [toucan2.core :as t2]
-   [toucan2.execute :as t2.execute])
+   [toucan2.execute :as t2.execute]
+   [clojure.test :refer :all])
   (:import
    (liquibase.change.custom CustomTaskChange CustomTaskRollback)
    (liquibase.exception ValidationErrors)))
@@ -170,3 +173,38 @@
       (t2/query-one {:update :metabase_field
                      :set    {:json_unfolding true}
                      :where  [:in :metabase_field.id field-ids-to-update]}))))
+
+(defn update-legacy-field-refs [viz-settings]
+  (let [old-to-new (fn [old]
+                     (match old
+                       ["ref" ref] ["ref" (match ref
+                                            ["field-id" x] ["field" x nil]
+                                            ["field-literal" x y] ["field" x {"base-type" y}]
+                                            ["fk->" x y] (let [x (match x
+                                                                   [_x0 x1] x1
+                                                                   x x)
+                                                               y (match y
+                                                                   [_y0 y1] y1
+                                                                   y y)]
+                                                           ["field" y {:source-field x}])
+                                            ref ref)]
+                       k k))]
+    (-> viz-settings
+        (json/parse-string)
+        (m/update-existing "column_settings" update-keys
+                           (fn [k]
+                             (-> k
+                                 (json/parse-string)
+                                 (vec)
+                                 (old-to-new)
+                                 (json/generate-string))))
+        (json/generate-string))))
+
+(define-migration UpdateLegacyColumnSettingsFieldRefs
+  (let [id+visualization_settings (->> (t2/query {:select [:id :visualization_settings]
+                                                  :from   [:report_card]})
+                                       (map #(update % :visualization_settings update-legacy-field-refs)))]
+    (doseq [{:keys [id visualization_settings]} id+visualization_settings]
+      (t2/query-one {:update :report_card
+                     :set    {:visualization_settings visualization_settings}
+                     :where  [:= :id id]}))))

--- a/src/metabase/db/custom_migrations.clj
+++ b/src/metabase/db/custom_migrations.clj
@@ -174,7 +174,7 @@
                      :set    {:json_unfolding true}
                      :where  [:in :metabase_field.id field-ids-to-update]}))))
 
-(defn update-legacy-field-refs [viz-settings]
+(defn- update-legacy-field-refs [viz-settings]
   (let [old-to-new (fn [old]
                      (match old
                        ["ref" ref] ["ref" (match ref

--- a/src/metabase/db/custom_migrations.clj
+++ b/src/metabase/db/custom_migrations.clj
@@ -9,13 +9,12 @@
    If you need to use code from elsewhere, consider copying it into this namespace to minimize risk of the code changing behaviour."
   (:require
    [cheshire.core :as json]
-   [clojure.core.match :refer [match]]
    [clojure.set :as set]
    [clojurewerkz.quartzite.jobs :as jobs]
    [clojurewerkz.quartzite.scheduler :as qs]
    [clojurewerkz.quartzite.triggers :as triggers]
-   [medley.core :as m]
    [metabase.db.connection :as mdb.connection]
+   [metabase.models.interface :as mi]
    [metabase.plugins.classloader :as classloader]
    [metabase.util.honey-sql-2 :as h2x]
    [metabase.util.log :as log]
@@ -173,36 +172,16 @@
                      :set    {:json_unfolding true}
                      :where  [:in :metabase_field.id field-ids-to-update]}))))
 
-(defn- update-legacy-field-refs [viz-settings]
-  (let [old-to-new (fn [old]
-                     (match old
-                       ["ref" ref] ["ref" (match ref
-                                            ["field-id" x] ["field" x nil]
-                                            ["field-literal" x y] ["field" x {"base-type" y}]
-                                            ["fk->" x y] (let [x (match x
-                                                                   [_x0 x1] x1
-                                                                   x x)
-                                                               y (match y
-                                                                   [_y0 y1] y1
-                                                                   y y)]
-                                                           ["field" y {:source-field x}])
-                                            ref ref)]
-                       k k))]
-    (-> viz-settings
-        (json/parse-string)
-        (m/update-existing "column_settings" update-keys
-                           (fn [k]
-                             (-> k
-                                 (json/parse-string)
-                                 (vec)
-                                 (old-to-new)
-                                 (json/generate-string))))
-        (json/generate-string))))
-
-(define-migration UpdateLegacyColumnSettingsFieldRefs
+(define-migration MigrateLegacyVisualizationSettings
   (let [id+visualization_settings (->> (t2/query {:select [:id :visualization_settings]
                                                   :from   [:report_card]})
-                                       (map #(update % :visualization_settings update-legacy-field-refs)))]
+                                       (keep (fn [{:keys [id visualization_settings]}]
+                                               (let [updated (-> visualization_settings
+                                                                 (:out mi/transform-visualization-settings)
+                                                                 (:in mi/transform-visualization-settings))]
+                                                 (when (not= visualization_settings updated)
+                                                   {:id                     id
+                                                    :visualization_settings updated})))))]
     (doseq [{:keys [id visualization_settings]} id+visualization_settings]
       (t2/query-one {:update :report_card
                      :set    {:visualization_settings visualization_settings}

--- a/src/metabase/db/custom_migrations.clj
+++ b/src/metabase/db/custom_migrations.clj
@@ -177,8 +177,8 @@
                                                   :from   [:report_card]})
                                        (keep (fn [{:keys [id visualization_settings]}]
                                                (let [updated (-> visualization_settings
-                                                                 (:out mi/transform-visualization-settings)
-                                                                 (:in mi/transform-visualization-settings))]
+                                                                 ((:out mi/transform-visualization-settings))
+                                                                 ((:in mi/transform-visualization-settings)))]
                                                  (when (not= visualization_settings updated)
                                                    {:id                     id
                                                     :visualization_settings updated})))))]

--- a/src/metabase/db/custom_migrations.clj
+++ b/src/metabase/db/custom_migrations.clj
@@ -8,8 +8,8 @@
 
    If you need to use code from elsewhere, consider copying it into this namespace to minimize risk of the code changing behaviour."
   (:require
-   [clojure.core.match :refer [match]]
    [cheshire.core :as json]
+   [clojure.core.match :refer [match]]
    [clojure.set :as set]
    [clojurewerkz.quartzite.jobs :as jobs]
    [clojurewerkz.quartzite.scheduler :as qs]
@@ -20,8 +20,7 @@
    [metabase.util.honey-sql-2 :as h2x]
    [metabase.util.log :as log]
    [toucan2.core :as t2]
-   [toucan2.execute :as t2.execute]
-   [clojure.test :refer :all])
+   [toucan2.execute :as t2.execute])
   (:import
    (liquibase.change.custom CustomTaskChange CustomTaskRollback)
    (liquibase.exception ValidationErrors)))

--- a/test/metabase/db/custom_migrations_test.clj
+++ b/test/metabase/db/custom_migrations_test.clj
@@ -89,9 +89,18 @@
                                                         :collection_id          nil})]
         (migrate!)
         (is (= expected
-               (-> (t2/query {:select [:visualization_settings]
-                              :from   [:report_card]
-                              :where  [:= :id card-id]})
-                   first
+               (-> (t2/query-one {:select [:visualization_settings]
+                                  :from   [:report_card]
+                                  :where  [:= :id card-id]})
                    :visualization_settings
-                   mi/json-out-without-keywordization)))))))
+                   (mi/json-out-without-keywordization))))
+        (is (= (-> expected
+                   (mi/normalize-visualization-settings)
+                   (#'mi/migrate-viz-settings))
+               (-> (t2/query-one {:select [:visualization_settings]
+                                  :from   [:report_card]
+                                  :where  [:= :id card-id]})
+                   :visualization_settings
+                   (mi/json-out-without-keywordization)
+                   (mi/normalize-visualization-settings)
+                   (#'mi/migrate-viz-settings))))))))

--- a/test/metabase/db/custom_migrations_test.clj
+++ b/test/metabase/db/custom_migrations_test.clj
@@ -1,14 +1,20 @@
 (ns metabase.db.custom-migrations-test
   "Tests to make sure the custom migrations work as expected."
   (:require
+   [cheshire.core :as json]
    [clojure.test :refer :all]
    [clojurewerkz.quartzite.jobs :as jobs]
    [clojurewerkz.quartzite.schedule.cron :as cron]
    [clojurewerkz.quartzite.scheduler :as qs]
    [clojurewerkz.quartzite.triggers :as triggers]
    [metabase.db.schema-migrations-test.impl :as impl]
+   [metabase.models.interface :as mi]
+   [metabase.models :refer [User
+                            Database
+                            Card]]
    [metabase.task :as task]
-   [metabase.test.fixtures :as fixtures]))
+   [metabase.test.fixtures :as fixtures]
+   [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
 
@@ -44,3 +50,48 @@
                    (is (nil? (qs/get-job (@#'task/scheduler) (jobs/key abandonment-emails-job-key))))
                    (is (nil? (qs/get-trigger (@#'task/scheduler) (triggers/key abandonment-emails-trigger-key)))))))
            (finally (task/stop-scheduler!))))))
+
+(deftest migrate-legacy-column-settings-field-refs-test
+  (testing "Migrations v46.00-044: update visualization_settings.column_settings legacy field refs"
+    (impl/test-migrations ["v47.00-016"] [migrate!]
+      (let [visualization-settings
+            {"column_settings" {"[\"ref\",[\"field-id\",39]]"                                 {"column_title" "ID1"}
+                                "[\"ref\",[\"field\",40,null]]"                               {"column_title" "ID2"}
+                                "[\"ref\",[\"fk->\",[\"field-id\",39],[\"field-id\",40]]]"    {"column_title" "ID3"}
+                                "[\"ref\",[\"fk->\",41,42]]"                                  {"column_title" "ID4"}
+                                "[\"ref\",[\"field-literal\",\"column_name\",\"type/Text\"]]" {"column_title" "ID5"}
+                                "[\"name\",\"column_name\"]"                                  {"column_title" "ID6"}}}
+            expected
+            {"column_settings" {"[\"ref\",[\"field\",39,null]]"                                       {"column_title" "ID1"}
+                                "[\"ref\",[\"field\",40,null]]"                                       {"column_title" "ID2"}
+                                "[\"ref\",[\"field\",40,{\"source-field\":39}]]"                      {"column_title" "ID3"}
+                                "[\"ref\",[\"field\",42,{\"source-field\":41}]]"                      {"column_title" "ID4"}
+                                "[\"ref\",[\"field\",\"column_name\",{\"base-type\":\"type/Text\"}]]" {"column_title" "ID5"}
+                                "[\"name\",\"column_name\"]"                                          {"column_title" "ID6"}}}
+            user-id     (t2/insert-returning-pks! User {:first_name  "Howard"
+                                                        :last_name   "Hughes"
+                                                        :email       "howard@aircraft.com"
+                                                        :password    "superstrong"
+                                                        :date_joined :%now})
+            database-id (t2/insert-returning-pks! Database {:name       "DB"
+                                                     :engine     "h2"
+                                                     :created_at :%now
+                                                     :updated_at :%now
+                                                     :details    "{}"})
+            card-id     (t2/insert-returning-pks! Card {:name                   "My Saved Question"
+                                                        :created_at             :%now
+                                                        :updated_at             :%now
+                                                        :creator_id             user-id
+                                                        :display                "table"
+                                                        :dataset_query          "{}"
+                                                        :visualization_settings (json/generate-string visualization-settings)
+                                                        :database_id            database-id
+                                                        :collection_id          nil})]
+        (migrate!)
+        (is (= expected
+               (-> (t2/query {:select [:visualization_settings]
+                              :from   [:report_card]
+                              :where  [:= :id card-id]})
+                   first
+                   :visualization_settings
+                   mi/json-out-without-keywordization)))))))

--- a/test/metabase/db/custom_migrations_test.clj
+++ b/test/metabase/db/custom_migrations_test.clj
@@ -8,10 +8,10 @@
    [clojurewerkz.quartzite.scheduler :as qs]
    [clojurewerkz.quartzite.triggers :as triggers]
    [metabase.db.schema-migrations-test.impl :as impl]
-   [metabase.models.interface :as mi]
    [metabase.models :refer [User
                             Database
                             Card]]
+   [metabase.models.interface :as mi]
    [metabase.task :as task]
    [metabase.test.fixtures :as fixtures]
    [toucan2.core :as t2]))
@@ -74,10 +74,10 @@
                                                         :password    "superstrong"
                                                         :date_joined :%now})
             database-id (t2/insert-returning-pks! Database {:name       "DB"
-                                                     :engine     "h2"
-                                                     :created_at :%now
-                                                     :updated_at :%now
-                                                     :details    "{}"})
+                                                            :engine     "h2"
+                                                            :created_at :%now
+                                                            :updated_at :%now
+                                                            :details    "{}"})
             card-id     (t2/insert-returning-pks! Card {:name                   "My Saved Question"
                                                         :created_at             :%now
                                                         :updated_at             :%now

--- a/test/metabase/db/custom_migrations_test.clj
+++ b/test/metabase/db/custom_migrations_test.clj
@@ -52,7 +52,7 @@
            (finally (task/stop-scheduler!))))))
 
 (deftest migrate-legacy-column-settings-field-refs-test
-  (testing "Migrations v46.00-044: update visualization_settings.column_settings legacy field refs"
+  (testing "Migrations v47.00-016: update visualization_settings.column_settings legacy field refs"
     (impl/test-migrations ["v47.00-016"] [migrate!]
       (let [visualization-settings
             {"column_settings" {"[\"ref\",[\"field-id\",39]]"                                 {"column_title" "ID1"}

--- a/test/metabase/db/custom_migrations_test.clj
+++ b/test/metabase/db/custom_migrations_test.clj
@@ -90,19 +90,21 @@
                                                         :database_id            database-id
                                                         :collection_id          nil})]
         (migrate!)
-        (is (= expected
-               (-> (t2/query-one {:select [:visualization_settings]
-                                  :from   [:report_card]
-                                  :where  [:= :id card-id]})
-                   :visualization_settings
-                   (mi/json-out-without-keywordization))))
-        (is (= (-> expected
-                   (mi/normalize-visualization-settings)
-                   (#'mi/migrate-viz-settings))
-               (-> (t2/query-one {:select [:visualization_settings]
-                                  :from   [:report_card]
-                                  :where  [:= :id card-id]})
-                   :visualization_settings
-                   (mi/json-out-without-keywordization)
-                   (mi/normalize-visualization-settings)
-                   (#'mi/migrate-viz-settings))))))))
+        (testing "legacy column_settings are upated"
+         (is (= expected
+                (-> (t2/query-one {:select [:visualization_settings]
+                                   :from   [:report_card]
+                                   :where  [:= :id card-id]})
+                    :visualization_settings
+                    (mi/json-out-without-keywordization)))))
+        (testing "visualization_settings are equivalent before and after migration"
+          (is (= (-> expected
+                     (mi/normalize-visualization-settings)
+                     (#'mi/migrate-viz-settings))
+                 (-> (t2/query-one {:select [:visualization_settings]
+                                    :from   [:report_card]
+                                    :where  [:= :id card-id]})
+                     :visualization_settings
+                     (mi/json-out-without-keywordization)
+                     (mi/normalize-visualization-settings)
+                     (#'mi/migrate-viz-settings)))))))))

--- a/test/metabase/db/custom_migrations_test.clj
+++ b/test/metabase/db/custom_migrations_test.clj
@@ -55,19 +55,21 @@
   (testing "Migrations v47.00-016: update visualization_settings.column_settings legacy field refs"
     (impl/test-migrations ["v47.00-016"] [migrate!]
       (let [visualization-settings
-            {"column_settings" {"[\"ref\",[\"field-id\",39]]"                                 {"column_title" "ID1"}
-                                "[\"ref\",[\"field\",40,null]]"                               {"column_title" "ID2"}
-                                "[\"ref\",[\"fk->\",[\"field-id\",39],[\"field-id\",40]]]"    {"column_title" "ID3"}
-                                "[\"ref\",[\"fk->\",41,42]]"                                  {"column_title" "ID4"}
-                                "[\"ref\",[\"field-literal\",\"column_name\",\"type/Text\"]]" {"column_title" "ID5"}
-                                "[\"name\",\"column_name\"]"                                  {"column_title" "ID6"}}}
+            {"column_settings" (-> {["name" "column_name"]                              {"column_title" "ID6"},
+                                    ["ref" ["field-literal" "column_name" "type/Text"]] {"column_title" "ID5"},
+                                    ["ref" ["field-id" 39]]                             {"column_title" "ID1"},
+                                    ["ref" ["field" 40 nil]]                            {"column_title" "ID2"},
+                                    ["ref" ["fk->" ["field-id" 39] ["field-id" 40]]]    {"column_title" "ID3"},
+                                    ["ref" ["fk->" 41 42]]                              {"column_title" "ID4"}}
+                                   (update-keys json/generate-string))}
             expected
-            {"column_settings" {"[\"ref\",[\"field\",39,null]]"                                       {"column_title" "ID1"}
-                                "[\"ref\",[\"field\",40,null]]"                                       {"column_title" "ID2"}
-                                "[\"ref\",[\"field\",40,{\"source-field\":39}]]"                      {"column_title" "ID3"}
-                                "[\"ref\",[\"field\",42,{\"source-field\":41}]]"                      {"column_title" "ID4"}
-                                "[\"ref\",[\"field\",\"column_name\",{\"base-type\":\"type/Text\"}]]" {"column_title" "ID5"}
-                                "[\"name\",\"column_name\"]"                                          {"column_title" "ID6"}}}
+            {"column_settings" (-> {["name" "column_name"]                                    {"column_title" "ID6"},
+                                    ["ref" ["field" "column_name" {"base-type" "type/Text"}]] {"column_title" "ID5"},
+                                    ["ref" ["field" 39 nil]]                                  {"column_title" "ID1"},
+                                    ["ref" ["field" 40 nil]]                                  {"column_title" "ID2"},
+                                    ["ref" ["field" 40 {"source-field" 39}]]                  {"column_title" "ID3"},
+                                    ["ref" ["field" 42 {"source-field" 41}]]                  {"column_title" "ID4"}}
+                                   (update-keys json/generate-string))}
             user-id     (t2/insert-returning-pks! User {:first_name  "Howard"
                                                         :last_name   "Hughes"
                                                         :email       "howard@aircraft.com"

--- a/test/metabase/db/custom_migrations_test.clj
+++ b/test/metabase/db/custom_migrations_test.clj
@@ -95,25 +95,25 @@
                                     :from   [:report_card]
                                     :where  [:= :id card-id]})
                      :visualization_settings
-                     (mi/json-out-without-keywordization)))))
+                     json/parse-string))))
         (testing "legacy column_settings are updated to the current format"
           (is (= (-> visualization-settings
-                     (mi/normalize-visualization-settings)
+                     mi/normalize-visualization-settings
                      (#'mi/migrate-viz-settings)
-                     (walk/stringify-keys))
+                     walk/stringify-keys)
                  (-> (t2/query-one {:select [:visualization_settings]
                                     :from   [:report_card]
                                     :where  [:= :id card-id]})
                      :visualization_settings
-                     (mi/json-out-without-keywordization)))))
+                     json/parse-string))))
         (testing "visualization_settings are equivalent before and after migration"
           (is (= (-> visualization-settings
-                     (mi/normalize-visualization-settings)
+                     mi/normalize-visualization-settings
                      (#'mi/migrate-viz-settings))
                  (-> (t2/query-one {:select [:visualization_settings]
                                     :from   [:report_card]
                                     :where  [:= :id card-id]})
                      :visualization_settings
-                     (mi/json-out-without-keywordization)
-                     (mi/normalize-visualization-settings)
+                     json/parse-string
+                     mi/normalize-visualization-settings
                      (#'mi/migrate-viz-settings)))))))))


### PR DESCRIPTION
This PR includes a clojure migration migration updates the field refs in visualization_settings.column_settings from legacy formats (e.g. `["field-id",<id>]` to `["field",<id>,null]`). I recommend reading [the test](https://github.com/metabase/metabase/blob/b67d87e97a4964ab0750db74733e97d1a60a99f3/test/metabase/db/custom_migrations_test.clj#L54).

It is a prerequisite to make https://github.com/metabase/metabase/pull/27487 easier to solve.

A previous attempt at this problem was here: https://github.com/metabase/metabase/pull/27660. It was before clojure migrations.

## Example transformations:

(in EDN for clarity, but the transformations are still done with JSON strings in the DB)
```
[:field-id 12] 
-> [:field 12 null]

[:field-literal "name" :type/Text]
-> [:field "name" {:base-type :type/Text}]

[:fk-> [:field-id 12] [:field-id 11]] 
-> [:field 11 {:source-field 12}]

[:fk-> 12 11]                                   
-> [:field 11 {:source-field 12}]
```
Note normalizing other legacy field tags (like datetime-field or binning-strategy) is not needed here. In the past these field tags were removed to get the unwrapped field ref (aka base dimension field ref) before persisting them in column_settings.

## Why do this now?
https://github.com/metabase/metabase/pull/27487 requires another migration (probably even bigger) following this to the field refs in visualization_settings.column_settings, see https://github.com/metabase/metabase/pull/27487.
It is simpler to do that migration if the field refs are standardized in one format first.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30460)
<!-- Reviewable:end -->