### PR TITLE
Fix v1 dump command errors when logging entities

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/serialization/names.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/names.clj
@@ -21,7 +21,8 @@
    [metabase.util.schema :as su]
    [ring.util.codec :as codec]
    [schema.core :as s]
-   [toucan2.core :as t2]))
+   [toucan2.core :as t2]
+   [toucan2.protocols :as t2.protocols]))
 
 (set! *warn-on-reflection* true)
 
@@ -338,7 +339,7 @@
 
 (defn name-for-logging
   "Return a string representation of entity suitable for logs"
-  ([entity] (name-for-logging (name entity) entity))
+  ([entity] (name-for-logging (or (t2.protocols/model entity) (name entity)) entity))
   ([model {:keys [name id]}]
    (cond
      (and name id) (format "%s \"%s\" (ID %s)" model name id)

--- a/enterprise/backend/src/metabase_enterprise/serialization/names.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/names.clj
@@ -339,7 +339,7 @@
 
 (defn name-for-logging
   "Return a string representation of entity suitable for logs"
-  ([entity] (name-for-logging (or (t2.protocols/model entity) (name entity)) entity))
+  ([entity] (name-for-logging (t2.protocols/model entity) entity))
   ([model {:keys [name id]}]
    (cond
      (and name id) (format "%s \"%s\" (ID %s)" model name id)

--- a/enterprise/backend/test/metabase_enterprise/serialization/names_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/names_test.clj
@@ -98,9 +98,10 @@
             (is (some? (:table ctx)))))))))
 
 (deftest name-for-logging-test
-  (testing "with Toucan 2 records (#29322)"
+  (testing "serialization logging name generation from Toucan 2 records (#29322)"
     (mt/with-temp* [Collection [{collection-id :id} {:name         "A Collection"}]
-                    Card       [_                   {:name         "A Card"
+                    Card       [{card-id :id}       {:name         "A Card"
                                                      :collection_id collection-id}]]
-      (is (= ":metabase.models.collection/Collection \"A Collection\" (ID 1)" (names/name-for-logging (t2/select-one 'Collection))))
-      (is (= ":model/Card \"A Card\" (ID 1)" (names/name-for-logging (t2/select-one 'Card)))))))
+      (are [model s id] (= (format s id) (names/name-for-logging (t2/select-one model :id id)))
+        'Collection ":metabase.models.collection/Collection \"A Collection\" (ID %d)" collection-id
+        'Card       ":model/Card \"A Card\" (ID %d)" card-id))))

--- a/enterprise/backend/test/metabase_enterprise/serialization/names_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/names_test.clj
@@ -99,5 +99,8 @@
 
 (deftest name-for-logging-test
   (testing "with Toucan 2 records (#29322)"
-    (mt/with-temp* [Collection [{} {:name "Some Collection"}]]
-      (is (= ":metabase.models.collection/Collection \"Some Collection\" (ID 1)" (names/name-for-logging (t2/select-one 'Collection)))))))
+    (mt/with-temp* [Collection [{collection-id :id} {:name         "A Collection"}]
+                    Card       [_                   {:name         "A Card"
+                                                     :collection_id collection-id}]]
+      (is (= ":metabase.models.collection/Collection \"A Collection\" (ID 1)" (names/name-for-logging (t2/select-one 'Collection))))
+      (is (= ":model/Card \"A Card\" (ID 1)" (names/name-for-logging (t2/select-one 'Card)))))))

--- a/enterprise/backend/test/metabase_enterprise/serialization/names_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/names_test.clj
@@ -96,3 +96,8 @@
                              "/databases/Fingerprint test-data copy/schemas/public/tables/users/fields/id"} fq-name))
             (is (map? ctx))
             (is (some? (:table ctx)))))))))
+
+(deftest name-for-logging-test
+  (testing "with Toucan 2 records (#29322)"
+    (mt/with-temp* [Collection [{} {:name "Some Collection"}]]
+      (is (= ":metabase.models.collection/Collection \"Some Collection\" (ID 1)" (names/name-for-logging (t2/select-one 'Collection)))))))


### PR DESCRIPTION
We previously relied on Toucan records implementing `clojure.lang.Named` to get the model name from a record, but Toucan 2 now exposes the record's model through `t2.protocols/model`.

Resolves #29322

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30463)
<!-- Reviewable:end -->
