### PR TITLE
allow renaming tabs by double clicking name

### DIFF
--- a/frontend/src/metabase/core/components/TabButton/TabButton.styled.tsx
+++ b/frontend/src/metabase/core/components/TabButton/TabButton.styled.tsx
@@ -18,11 +18,10 @@ export const TabButtonInputWrapper = styled.span`
 export const TabButtonInputResizer = styled.span`
   visibility: hidden;
   white-space: pre;
+  padding-right: 2px;
 `;
 
 export const TabButtonInput = styled.input<TabButtonProps & { value: string }>`
-  box-sizing: border-box;
-
   position: absolute;
   width: 100%;
   left: 0;

--- a/frontend/src/metabase/core/components/TabButton/TabButton.styled.tsx
+++ b/frontend/src/metabase/core/components/TabButton/TabButton.styled.tsx
@@ -21,6 +21,8 @@ export const TabButtonInputResizer = styled.span`
 `;
 
 export const TabButtonInput = styled.input<TabButtonProps & { value: string }>`
+  /* box-sizing: border-box; */
+
   position: absolute;
   width: 100%;
   left: 0;
@@ -40,6 +42,16 @@ export const TabButtonInput = styled.input<TabButtonProps & { value: string }>`
     css`
       pointer-events: none;
     `}
+
+  &:hover,
+  :focus {
+    ${props =>
+      (props.isSelected || !props.disabled) &&
+      css`
+        background-color: ${color("bg-medium")};
+        /* border: 1px solid ${color("brand")}; */
+      `}
+  }
 `;
 
 export const TabButtonRoot = styled.div<TabButtonProps>`

--- a/frontend/src/metabase/core/components/TabButton/TabButton.styled.tsx
+++ b/frontend/src/metabase/core/components/TabButton/TabButton.styled.tsx
@@ -21,14 +21,15 @@ export const TabButtonInputResizer = styled.span`
 `;
 
 export const TabButtonInput = styled.input<TabButtonProps & { value: string }>`
-  /* box-sizing: border-box; */
+  box-sizing: border-box;
 
   position: absolute;
   width: 100%;
   left: 0;
   padding: 0;
 
-  border: none;
+  border: 1px solid transparent;
+  border-radius: 4px;
   outline: none;
   background-color: transparent;
 
@@ -48,8 +49,7 @@ export const TabButtonInput = styled.input<TabButtonProps & { value: string }>`
     ${props =>
       (props.isSelected || !props.disabled) &&
       css`
-        background-color: ${color("bg-medium")};
-        /* border: 1px solid ${color("brand")}; */
+        border: 1px solid ${color("border")};
       `}
   }
 `;

--- a/frontend/src/metabase/core/components/TabButton/TabButton.tsx
+++ b/frontend/src/metabase/core/components/TabButton/TabButton.tsx
@@ -49,6 +49,7 @@ export interface TabButtonProps<T> extends HTMLAttributes<HTMLDivElement> {
   onEdit?: ChangeEventHandler<HTMLInputElement>;
   onFinishEditing?: () => void;
   isEditing?: boolean;
+  canEdit?: boolean;
   disabled?: boolean;
 }
 
@@ -62,6 +63,7 @@ const TabButton = forwardRef(function TabButton<T>(
     onFinishEditing,
     disabled = false,
     isEditing = false,
+    canEdit = true,
     showMenu: showMenuProp = true,
     ...props
   }: TabButtonProps<T>,
@@ -122,7 +124,7 @@ const TabButton = forwardRef(function TabButton<T>(
           type="text"
           value={label}
           isSelected={isSelected}
-          disabled={!isEditing}
+          disabled={!canEdit || (!isEditing && !isSelected)}
           onChange={onEdit}
           onKeyPress={handleInputKeyPress}
           onFocus={e => e.currentTarget.select()}

--- a/frontend/src/metabase/core/components/TabButton/TabButton.tsx
+++ b/frontend/src/metabase/core/components/TabButton/TabButton.tsx
@@ -31,6 +31,8 @@ import {
   TabButtonInputResizer,
 } from "./TabButton.styled";
 
+export const INPUT_WRAPPER_TEST_ID = "tab-button-input-wrapper";
+
 export type TabButtonMenuAction<T> = (
   context: TabContextType,
   value: T,
@@ -116,7 +118,10 @@ const _TabButton = forwardRef(function TabButton<T>(
       aria-label={label}
       id={getTabId(idPrefix, value)}
     >
-      <TabButtonInputWrapper onDoubleClick={onInputDoubleClick}>
+      <TabButtonInputWrapper
+        onDoubleClick={onInputDoubleClick}
+        data-testid={INPUT_WRAPPER_TEST_ID}
+      >
         <TabButtonInputResizer aria-hidden="true">
           {label}
         </TabButtonInputResizer>

--- a/frontend/src/metabase/core/components/TabButton/TabButton.unit.spec.tsx
+++ b/frontend/src/metabase/core/components/TabButton/TabButton.unit.spec.tsx
@@ -4,7 +4,11 @@ import userEvent from "@testing-library/user-event";
 import { getIcon } from "__support__/ui";
 
 import { TabRow } from "../TabRow";
-import { TabButton, RenameableTabButtonProps } from "./TabButton";
+import {
+  TabButton,
+  RenameableTabButtonProps,
+  INPUT_WRAPPER_TEST_ID,
+} from "./TabButton";
 
 function setup(props?: Partial<RenameableTabButtonProps<string>>) {
   const action = jest.fn();
@@ -62,6 +66,20 @@ describe("TabButton", () => {
 
     userEvent.click(getIcon("chevrondown"));
     (await screen.findByRole("option", { name: "Rename" })).click();
+
+    const newLabel = "A new label";
+    const inputEl = screen.getByRole("textbox");
+    userEvent.type(inputEl, newLabel);
+    fireEvent.keyPress(inputEl, { key: "Enter", charCode: 13 });
+
+    expect(onRename).toHaveBeenCalledWith(newLabel);
+    expect(await screen.findByDisplayValue(newLabel)).toBeInTheDocument();
+  });
+
+  it("should allow the user to rename via double click", async () => {
+    const { onRename } = setup();
+
+    userEvent.dblClick(screen.getByTestId(INPUT_WRAPPER_TEST_ID));
 
     const newLabel = "A new label";
     const inputEl = screen.getByRole("textbox");

--- a/frontend/src/metabase/core/components/TabButton/TabButton.unit.spec.tsx
+++ b/frontend/src/metabase/core/components/TabButton/TabButton.unit.spec.tsx
@@ -3,8 +3,8 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { getIcon } from "__support__/ui";
 
-import TabRow from "../TabRow";
-import TabButton, { RenameableTabButtonProps } from "./TabButton";
+import { TabRow } from "../TabRow";
+import { TabButton, RenameableTabButtonProps } from "./TabButton";
 
 function setup(props?: Partial<RenameableTabButtonProps<string>>) {
   const action = jest.fn();

--- a/frontend/src/metabase/core/components/TabButton/TabButtonMenu.tsx
+++ b/frontend/src/metabase/core/components/TabButton/TabButtonMenu.tsx
@@ -1,4 +1,5 @@
 import React, { useContext } from "react";
+
 import { TabContext } from "../Tab/TabContext";
 import { getTabButtonInputId } from "../Tab/utils";
 import { TabButtonMenuAction, TabButtonMenuItem } from "./TabButton";
@@ -10,8 +11,7 @@ interface TabButtonMenuProps<T> {
   closePopover: () => void;
 }
 
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export default function TabButtonMenu<T>({
+export function TabButtonMenu<T>({
   menuItems,
   value,
   closePopover,

--- a/frontend/src/metabase/core/components/TabButton/index.ts
+++ b/frontend/src/metabase/core/components/TabButton/index.ts
@@ -1,3 +1,2 @@
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export { default } from "./TabButton";
+export * from "./TabButton";
 export * from "./TabButton";

--- a/frontend/src/metabase/core/components/TabRow/TabRow.stories.tsx
+++ b/frontend/src/metabase/core/components/TabRow/TabRow.stories.tsx
@@ -2,12 +2,13 @@ import React, { useState } from "react";
 import type { ComponentStory } from "@storybook/react";
 import { useArgs } from "@storybook/client-api";
 
-import TabButton, {
+import {
+  TabButton,
   TabButtonMenuItem,
   TabButtonMenuAction,
 } from "../TabButton";
 import TabLink from "../TabLink";
-import TabRow from "./TabRow";
+import { TabRow } from "./TabRow";
 
 // eslint-disable-next-line import/no-default-export -- deprecated usage
 export default {

--- a/frontend/src/metabase/core/components/TabRow/TabRow.styled.tsx
+++ b/frontend/src/metabase/core/components/TabRow/TabRow.styled.tsx
@@ -3,7 +3,7 @@ import styled from "@emotion/styled";
 import { alpha, color } from "metabase/lib/colors";
 import BaseTabList from "metabase/core/components/TabList";
 import TabLink from "metabase/core/components/TabLink";
-import TabButton from "metabase/core/components/TabButton";
+import { TabButton } from "metabase/core/components/TabButton";
 import { space } from "metabase/styled-components/theme";
 
 export const TabList = styled(BaseTabList)`

--- a/frontend/src/metabase/core/components/TabRow/TabRow.tsx
+++ b/frontend/src/metabase/core/components/TabRow/TabRow.tsx
@@ -57,9 +57,7 @@ function TabRowInner<T>({
 }
 
 const TabRowInnerWithSize = ExplicitSize()(TabRowInner);
-
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export default function TabRow<T>(props: TabListProps<T>) {
+export function TabRow<T>(props: TabListProps<T>) {
   return <TabRowInnerWithSize {...props} />;
 }
 

--- a/frontend/src/metabase/core/components/TabRow/TabRow.unit.spec.tsx
+++ b/frontend/src/metabase/core/components/TabRow/TabRow.unit.spec.tsx
@@ -2,8 +2,8 @@ import React, { useState } from "react";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
-import TabButton from "../TabButton";
-import TabRow from "./TabRow";
+import { TabButton } from "../TabButton";
+import { TabRow } from "./TabRow";
 
 const TestTabRow = () => {
   const [value, setValue] = useState(1);

--- a/frontend/src/metabase/core/components/TabRow/index.ts
+++ b/frontend/src/metabase/core/components/TabRow/index.ts
@@ -1,3 +1,2 @@
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export { default } from "./TabRow";
+export * from "./TabRow";
 export * from "./TabRow";

--- a/frontend/src/metabase/dashboard/components/DashboardTabs/DashboardTabs.styled.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardTabs/DashboardTabs.styled.tsx
@@ -1,7 +1,8 @@
 import React from "react";
 import styled from "@emotion/styled";
 
-import BaseTabButton, {
+import {
+  TabButton as BaseTabButton,
   RenameableTabButtonProps,
 } from "metabase/core/components/TabButton";
 import BaseButton from "metabase/core/components/Button";

--- a/frontend/src/metabase/dashboard/components/DashboardTabs/DashboardTabs.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardTabs/DashboardTabs.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { t } from "ttag";
 
-import TabRow from "metabase/core/components/TabRow";
+import { TabRow } from "metabase/core/components/TabRow";
 import { SelectedTabId } from "metabase-types/store";
 
 import {
@@ -40,7 +40,7 @@ export function DashboardTabs({ isEditing }: DashboardTabsProps) {
               value={tab.id}
               label={tab.name}
               onRename={name => renameTab(tab.id, name)}
-              canEdit={isEditing}
+              canRename={isEditing}
               showMenu={isEditing}
               menuItems={[
                 {

--- a/frontend/src/metabase/dashboard/components/DashboardTabs/DashboardTabs.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardTabs/DashboardTabs.tsx
@@ -40,6 +40,7 @@ export function DashboardTabs({ isEditing }: DashboardTabsProps) {
               value={tab.id}
               label={tab.name}
               onRename={name => renameTab(tab.id, name)}
+              canEdit={isEditing}
               showMenu={isEditing}
               menuItems={[
                 {

--- a/frontend/src/metabase/dashboard/components/DashboardTabs/DashboardTabs.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardTabs/DashboardTabs.unit.spec.tsx
@@ -9,6 +9,7 @@ import { ORDERS_ID, SAMPLE_DB_ID } from "metabase-types/api/mocks/presets";
 import { INITIAL_DASHBOARD_STATE } from "metabase/dashboard/constants";
 import { getDefaultTab } from "metabase/dashboard/actions";
 
+import { INPUT_WRAPPER_TEST_ID } from "metabase/core/components/TabButton";
 import { DashboardTabs } from "./DashboardTabs";
 
 const TEST_CARD = createMockCard({
@@ -282,6 +283,19 @@ describe("DashboardTabs", () => {
         setup();
         const newName = "A cool new name";
         await renameTab(1, newName);
+
+        expect(queryTab(newName)).toBeInTheDocument();
+      });
+
+      it("should allow renaming via double click", async () => {
+        setup();
+        const newName = "Another cool new name";
+        const inputWrapperEl = screen.getAllByTestId(INPUT_WRAPPER_TEST_ID)[0];
+        userEvent.dblClick(inputWrapperEl);
+
+        const inputEl = screen.getByRole("textbox", { name: "Page 1" });
+        userEvent.type(inputEl, newName);
+        fireEvent.keyPress(inputEl, { key: "Enter", charCode: 13 });
 
         expect(queryTab(newName)).toBeInTheDocument();
       });

--- a/frontend/src/metabase/models/components/ModelDetailPage/ModelDetailPage.styled.tsx
+++ b/frontend/src/metabase/models/components/ModelDetailPage/ModelDetailPage.styled.tsx
@@ -1,6 +1,6 @@
 import styled from "@emotion/styled";
 
-import BaseTabRow from "metabase/core/components/TabRow";
+import { TabRow as BaseTabRow } from "metabase/core/components/TabRow";
 import BaseTabPanel from "metabase/core/components/TabPanel";
 
 export const TabRow = styled(BaseTabRow)`


### PR DESCRIPTION
Part of epic https://github.com/metabase/metabase/issues/29502

### Description

Currently the only way to rename tabs is to open the menu and click the "Rename" option. This PR adds a faster way to rename by double clicking the tab name.

### How to verify

1. Create a dashboard with tabs.
2. While editing, double click the name of a tab.
3. Rename the tab then save.

### Demo

https://github.com/metabase/metabase/assets/37751258/786cb59a-a7af-4b17-bccc-63cac5be4a96

### Checklist

- [x] Tests have been added/updated to cover changes in this PR

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30465)
<!-- Reviewable:end -->
