### PR TITLE
fix teams definition

### DIFF
--- a/.github/team.json
+++ b/.github/team.json
@@ -2,7 +2,7 @@
   "teams": [
     {
       "name": "App Viz",
-      "label": ".Team/Viz 📊",
+      "label": ".Team/Viz :bar_chart:",
       "members": [
         "alxnddr",
         "iethree",
@@ -13,7 +13,7 @@
     },
     {
       "name": "Query Builder",
-      "label": ".Team/QueryBuilder 🧮",
+      "label": ".Team/QueryBuilder :abacus:",
       "members": [
         "ranquild",
         "WiNloSt",
@@ -24,12 +24,12 @@
     },
     {
       "name": "App BE",
-      "label": ".Team/Backend 🥞",
+      "label": ".Team/Backend :pancakes:",
       "members": ["dpsutton", "tsmacdonald", "qnkhuat", "calherries"]
     },
     {
       "name": "Query Processor",
-      "label": ".Team/QueryProcessor 🛠️",
+      "label": ".Team/QueryProcessor :hammer_and_wrench:",
       "members": [
         "camsaul",
         "kulyk",
@@ -41,7 +41,7 @@
     },
     {
       "name": "Fun Police",
-      "label": ".Team/FunPolice 👮",
+      "label": ".Team/FunPolice :police_officer:",
       "members": ["noahmoss", "escherize", "adam-james-v"]
     }
   ]


### PR DESCRIPTION
### Description

Fixes teams definitions because our labels use own github emoji codes instead of emojis

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30479)
<!-- Reviewable:end -->
