### PR TITLE
CI on fuzzing: make sure Clojure is available (due to CLJS)

### DIFF
--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -18,6 +18,10 @@ jobs:
     - uses: actions/checkout@v3
     - name: Prepare front-end environment
       uses: ./.github/actions/prepare-frontend
+    - name: Prepare back-end environment
+      uses: ./.github/actions/prepare-backend
+      with:
+        m2-cache-key: 'cljs'
     - run: yarn test-unit frontend/test/metabase/lib/expressions/fuzz.tokenizer.unit.spec.js
       env:
         MB_FUZZ: 1
@@ -30,6 +34,10 @@ jobs:
     - uses: actions/checkout@v3
     - name: Prepare front-end environment
       uses: ./.github/actions/prepare-frontend
+    - name: Prepare back-end environment
+      uses: ./.github/actions/prepare-backend
+      with:
+        m2-cache-key: 'cljs'
     - run: yarn test-unit frontend/test/metabase/lib/expressions/fuzz.recursive-parser.unit.spec.js
       env:
         MB_FUZZ: 1


### PR DESCRIPTION
Running the fuzzer for custom expression now needs Clojure.

### Before this PR

The CI failed prematurely.

<img width="640" alt="image" src="https://user-images.githubusercontent.com/7288/235736590-bf46267f-bc84-4001-bcdf-ea22702c2fe0.png">

### After this PR

The tests run to completion, as expected.

<img width="640" alt="image" src="https://user-images.githubusercontent.com/7288/235736653-e816b25e-e357-48c0-bff5-69cb618c827c.png">

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30490)
<!-- Reviewable:end -->
