### PR TITLE
Specify baseUrl for e2e tests

### DIFF
--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../tsconfig.base.json",
   "compilerOptions": {
+    "baseUrl": "./",
     "types": ["cypress", "@testing-library/cypress"],
     "paths": {
       "*": ["../frontend/src/*"],


### PR DESCRIPTION
### Description

This change should fix a problem with alias resolution in e2e config. After changing folder structure for e2e, cross version tests started failing https://github.com/metabase/metabase/actions/runs/4843505758/jobs/8631176359

Current change fixed the problem for cros version tests https://github.com/metabase/metabase/actions/runs/4865327854

### How to verify

e2e tests should pass

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30496)
<!-- Reviewable:end -->
