### PR TITLE
allow undoing tab deletion

### DIFF
--- a/e2e/support/helpers/e2e-ui-elements-helpers.js
+++ b/e2e/support/helpers/e2e-ui-elements-helpers.js
@@ -111,3 +111,7 @@ export const dashboardParametersContainer = () => {
 export const undoToast = () => {
   return cy.findByTestId("toast-undo");
 };
+
+export function dashboardCards() {
+  return cy.get("#Dashboard-Cards-Container");
+}

--- a/e2e/test/scenarios/dashboard/tabs.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/tabs.cy.spec.js
@@ -4,7 +4,12 @@ import {
   visitDashboard,
   saveDashboard,
   openQuestionsSidebar,
+  undo,
 } from "e2e/support/helpers";
+
+function createNewTab() {
+  cy.findByLabelText("Create new tab").click();
+}
 
 describe("scenarios > dashboard tabs", () => {
   beforeEach(() => {
@@ -16,7 +21,7 @@ describe("scenarios > dashboard tabs", () => {
     visitDashboard(1);
 
     editDashboard();
-    cy.findByLabelText("Create new tab").click();
+    createNewTab();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Orders").should("not.exist");
 
@@ -26,6 +31,24 @@ describe("scenarios > dashboard tabs", () => {
     cy.findByText("Orders, Count").click();
     saveDashboard();
 
+    cy.findByRole("tab", { name: "Page 1" }).click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
+    cy.findByText("Orders, count").should("not.exist");
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
+    cy.findByText("Orders").should("be.visible");
+  });
+
+  it("should allow undoing a tab deletion", () => {
+    visitDashboard(1);
+    editDashboard();
+    createNewTab();
+
+    cy.findByRole("tab", { name: "Page 1" }).findByRole("button").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
+    cy.findByText("Delete").click();
+    cy.findByRole("tab", { name: "Page 1" }).should("not.exist");
+
+    undo();
     cy.findByRole("tab", { name: "Page 1" }).click();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Orders, count").should("not.exist");

--- a/e2e/test/scenarios/dashboard/tabs.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/tabs.cy.spec.js
@@ -5,6 +5,9 @@ import {
   saveDashboard,
   openQuestionsSidebar,
   undo,
+  dashboardCards,
+  sidebar,
+  popover,
 } from "e2e/support/helpers";
 
 function createNewTab() {
@@ -22,20 +25,24 @@ describe("scenarios > dashboard tabs", () => {
 
     editDashboard();
     createNewTab();
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Orders").should("not.exist");
+    dashboardCards().within(() => {
+      cy.findByText("Orders").should("not.exist");
+    });
 
     cy.icon("pencil").click();
     openQuestionsSidebar();
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Orders, Count").click();
+    sidebar().within(() => {
+      cy.findByText("Orders, Count").click();
+    });
     saveDashboard();
 
     cy.findByRole("tab", { name: "Page 1" }).click();
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Orders, count").should("not.exist");
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Orders").should("be.visible");
+    dashboardCards().within(() => {
+      cy.findByText("Orders, count").should("not.exist");
+    });
+    dashboardCards().within(() => {
+      cy.findByText("Orders").should("be.visible");
+    });
   });
 
   it("should allow undoing a tab deletion", () => {
@@ -44,15 +51,19 @@ describe("scenarios > dashboard tabs", () => {
     createNewTab();
 
     cy.findByRole("tab", { name: "Page 1" }).findByRole("button").click();
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Delete").click();
+    popover().within(() => {
+      cy.findByText("Delete").click();
+    });
     cy.findByRole("tab", { name: "Page 1" }).should("not.exist");
 
     undo();
     cy.findByRole("tab", { name: "Page 1" }).click();
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Orders, count").should("not.exist");
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Orders").should("be.visible");
+
+    dashboardCards().within(() => {
+      cy.findByText("Orders, count").should("not.exist");
+    });
+    dashboardCards().within(() => {
+      cy.findByText("Orders").should("be.visible");
+    });
   });
 });

--- a/frontend/src/metabase-types/store/dashboard.ts
+++ b/frontend/src/metabase-types/store/dashboard.ts
@@ -6,6 +6,8 @@ import type {
   DashCardDataMap,
   ParameterId,
   ParameterValueOrArray,
+  DashboardOrderedTab,
+  DashboardTabId,
 } from "metabase-types/api";
 
 export type DashboardSidebarName =
@@ -16,8 +18,16 @@ export type DashboardSidebarName =
   | "sharing"
   | "info";
 
-export type StoreDashboard = Omit<Dashboard, "ordered_cards"> & {
+export type StoreDashboardTab = DashboardOrderedTab & {
+  isRemoved?: boolean;
+};
+
+export type StoreDashboard = Omit<
+  Dashboard,
+  "ordered_cards" | "ordered_tabs"
+> & {
   ordered_cards: DashCardId[];
+  ordered_tabs?: StoreDashboardTab[];
 };
 
 export type StoreDashcard = DashboardOrderedCard & {
@@ -26,6 +36,14 @@ export type StoreDashcard = DashboardOrderedCard & {
 };
 
 export type SelectedTabId = DashboardId | null;
+
+export type TabDeletionId = number;
+
+export type TabDeletion = {
+  id: TabDeletionId;
+  tabId: DashboardTabId;
+  removedDashCardIds: DashCardId[];
+};
 
 export interface DashboardState {
   dashboardId: DashboardId | null;
@@ -65,4 +83,5 @@ export interface DashboardState {
     toastId: number | null;
     toastDashboardId: number | null;
   };
+  tabDeletions: Record<TabDeletionId, TabDeletion>;
 }

--- a/frontend/src/metabase-types/store/mocks/dashboard.ts
+++ b/frontend/src/metabase-types/store/mocks/dashboard.ts
@@ -28,5 +28,6 @@ export const createMockDashboardState = (
     toastId: null,
     toastDashboardId: null,
   },
+  tabDeletions: {},
   ...opts,
 });

--- a/frontend/src/metabase/dashboard/actions/save.js
+++ b/frontend/src/metabase/dashboard/actions/save.js
@@ -118,10 +118,12 @@ export const saveDashboardAndCards = createThunkAction(
           visualization_settings: dc.visualization_settings,
           parameter_mappings: dc.parameter_mappings,
         })),
-        ordered_tabs: (dashboard.ordered_tabs ?? []).map(({ id, name }) => ({
-          id,
-          name,
-        })),
+        ordered_tabs: (dashboard.ordered_tabs ?? [])
+          .filter(tab => !tab.isRemoved)
+          .map(({ id, name }) => ({
+            id,
+            name,
+          })),
       });
       dispatch(saveCardsAndTabs(updatedCardsAndTabs));
 

--- a/frontend/src/metabase/dashboard/components/DashboardSidebars.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardSidebars.jsx
@@ -2,7 +2,6 @@ import React, { useCallback } from "react";
 import PropTypes from "prop-types";
 import _ from "underscore";
 
-import { useSelector } from "metabase/lib/redux";
 import { SIDEBAR_NAME } from "metabase/dashboard/constants";
 
 import ParameterSidebar from "metabase/parameters/components/ParameterSidebar";
@@ -12,7 +11,6 @@ import ClickBehaviorSidebar from "./ClickBehaviorSidebar";
 import DashboardInfoSidebar from "./DashboardInfoSidebar";
 import { AddCardSidebar } from "./add-card-sidebar/AddCardSidebar";
 import { ActionSidebar } from "./ActionSidebar";
-import { getSelectedTabId } from "./DashboardTabs";
 
 DashboardSidebars.propTypes = {
   dashboard: PropTypes.object,
@@ -47,6 +45,7 @@ DashboardSidebars.propTypes = {
   closeSidebar: PropTypes.func.isRequired,
   setDashboardAttribute: PropTypes.func,
   saveDashboardAndCards: PropTypes.func,
+  selectedTabId: PropTypes.number,
 };
 
 export function DashboardSidebars({
@@ -75,18 +74,18 @@ export function DashboardSidebars({
   closeSidebar,
   setDashboardAttribute,
   saveDashboardAndCards,
+  selectedTabId,
 }) {
-  const tabId = useSelector(getSelectedTabId);
   const handleAddCard = useCallback(
     cardId => {
       addCardToDashboard({
         dashId: dashboard.id,
         cardId: cardId,
-        tabId,
+        tabId: selectedTabId,
       });
       MetabaseAnalytics.trackStructEvent("Dashboard", "Add Card");
     },
-    [addCardToDashboard, dashboard.id, tabId],
+    [addCardToDashboard, dashboard.id, selectedTabId],
   );
 
   if (isFullscreen) {

--- a/frontend/src/metabase/dashboard/components/DashboardTabs/useDashboardTabs.ts
+++ b/frontend/src/metabase/dashboard/components/DashboardTabs/useDashboardTabs.ts
@@ -1,4 +1,5 @@
 import { useMount } from "react-use";
+import { t } from "ttag";
 
 import { useDispatch, useSelector } from "metabase/lib/redux";
 import {
@@ -7,13 +8,13 @@ import {
   deleteTab as deleteTabAction,
   initTabs,
   selectTab as selectTabAction,
+  undoDeleteTab,
 } from "metabase/dashboard/actions";
-import { SelectedTabId, State } from "metabase-types/store";
-import { getDashboardId } from "metabase/dashboard/selectors";
+import { SelectedTabId } from "metabase-types/store";
+import { getDashboardId, getSelectedTabId } from "metabase/dashboard/selectors";
+import { addUndo } from "metabase/redux/undo";
 
-export function getSelectedTabId(state: State) {
-  return state.dashboard.selectedTabId;
-}
+let tabDeletionId = 1;
 
 export function useDashboardTabs() {
   const dispatch = useDispatch();
@@ -29,11 +30,28 @@ export function useDashboardTabs() {
 
   useMount(() => dispatch(initTabs()));
 
+  const deleteTab = (tabId: SelectedTabId) => {
+    const tabName = tabs.find(({ id }) => id === tabId)?.name;
+    if (!tabName) {
+      throw Error(`deleteTab was called but no tab with id ${tabId} was found`);
+    }
+    const id = tabDeletionId++;
+
+    dispatch(deleteTabAction({ tabId, tabDeletionId: id }));
+    dispatch(
+      addUndo({
+        message: t`Deleted "${tabName}"`,
+        undo: true,
+        action: () => dispatch(undoDeleteTab({ tabDeletionId: id })),
+      }),
+    );
+  };
+
   return {
     tabs,
     selectedTabId,
     createNewTab: () => dispatch(createNewTabAction()),
-    deleteTab: (tabId: SelectedTabId) => dispatch(deleteTabAction(tabId)),
+    deleteTab: (tabId: SelectedTabId) => deleteTab(tabId),
     renameTab: (tabId: SelectedTabId, name: string) =>
       dispatch(renameTabAction({ tabId, name })),
     selectTab: (tabId: SelectedTabId) => dispatch(selectTabAction({ tabId })),

--- a/frontend/src/metabase/dashboard/components/DashboardTabs/useDashboardTabs.ts
+++ b/frontend/src/metabase/dashboard/components/DashboardTabs/useDashboardTabs.ts
@@ -20,7 +20,9 @@ export function useDashboardTabs() {
   const dashboardId = useSelector(getDashboardId);
   const tabs = useSelector(state =>
     dashboardId
-      ? state.dashboard.dashboards[dashboardId].ordered_tabs ?? []
+      ? state.dashboard.dashboards[dashboardId].ordered_tabs?.filter(
+          tab => !tab.isRemoved,
+        ) ?? []
       : [],
   );
   const selectedTabId = useSelector(getSelectedTabId);
@@ -31,7 +33,7 @@ export function useDashboardTabs() {
     tabs,
     selectedTabId,
     createNewTab: () => dispatch(createNewTabAction()),
-    deleteTab: (tabId: SelectedTabId) => dispatch(deleteTabAction({ tabId })),
+    deleteTab: (tabId: SelectedTabId) => dispatch(deleteTabAction(tabId)),
     renameTab: (tabId: SelectedTabId, name: string) =>
       dispatch(renameTabAction({ tabId, name })),
     selectTab: (tabId: SelectedTabId) => dispatch(selectTabAction({ tabId })),

--- a/frontend/src/metabase/dashboard/constants.ts
+++ b/frontend/src/metabase/dashboard/constants.ts
@@ -34,6 +34,7 @@ export const INITIAL_DASHBOARD_STATE: DashboardState = {
     toastId: null,
     toastDashboardId: null,
   },
+  tabDeletions: {},
 };
 
 export const DASHBOARD_SLOW_TIMEOUT = 15 * 1000;

--- a/frontend/src/metabase/dashboard/containers/DashboardApp/DashboardApp.jsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardApp/DashboardApp.jsx
@@ -35,7 +35,6 @@ import Dashboards from "metabase/entities/dashboards";
 import { useDispatch } from "metabase/lib/redux";
 import { addUndo, dismissUndo } from "metabase/redux/undo";
 import { useUniqueId } from "metabase/hooks/use-unique-id";
-import { getSelectedTabId } from "metabase/dashboard/components/DashboardTabs";
 import * as dashboardActions from "../../actions";
 import {
   getIsEditing,
@@ -61,6 +60,7 @@ import {
   getIsHeaderVisible,
   getIsAdditionalInfoVisible,
   getIsAutoApplyFilters,
+  getSelectedTabId,
 } from "../../selectors";
 import { DASHBOARD_SLOW_TIMEOUT } from "../../constants";
 

--- a/frontend/src/metabase/dashboard/reducers.js
+++ b/frontend/src/metabase/dashboard/reducers.js
@@ -456,6 +456,7 @@ export default reduceReducers(
     autoApplyFilters,
     // Combined reducer needs to init state for every slice
     selectedTabId: (state = INITIAL_DASHBOARD_STATE.selectedTabId) => state,
+    tabDeletions: (state = INITIAL_DASHBOARD_STATE.tabDeletions) => state,
   }),
   tabsReducer,
 );

--- a/frontend/src/metabase/dashboard/reducers.unit.spec.js
+++ b/frontend/src/metabase/dashboard/reducers.unit.spec.js
@@ -42,6 +42,7 @@ describe("dashboard reducers", () => {
         toastId: null,
         toastDashboardId: null,
       },
+      tabDeletions: {},
     });
   });
 

--- a/frontend/src/metabase/dashboard/selectors/index.ts
+++ b/frontend/src/metabase/dashboard/selectors/index.ts
@@ -1,0 +1,2 @@
+export * from "./selectors";
+export * from "./selectors_typed";

--- a/frontend/src/metabase/dashboard/selectors/selectors.js
+++ b/frontend/src/metabase/dashboard/selectors/selectors.js
@@ -16,9 +16,9 @@ import { getEmbedOptions, getIsEmbedded } from "metabase/selectors/embed";
 
 import Question from "metabase-lib/Question";
 
-import { isVirtualDashCard } from "./utils";
+import { isVirtualDashCard } from "../utils";
+import { getDashboardId } from "./selectors_typed";
 
-export const getDashboardId = state => state.dashboard.dashboardId;
 export const getIsEditing = state => !!state.dashboard.isEditing;
 export const getDashboardBeforeEditing = state => state.dashboard.isEditing;
 export const getClickBehaviorSidebarDashcard = state => {

--- a/frontend/src/metabase/dashboard/selectors/selectors_typed.ts
+++ b/frontend/src/metabase/dashboard/selectors/selectors_typed.ts
@@ -1,0 +1,9 @@
+import type { State } from "metabase-types/store";
+
+export function getDashboardId(state: State) {
+  return state.dashboard.dashboardId;
+}
+
+export function getSelectedTabId(state: State) {
+  return state.dashboard.selectedTabId;
+}


### PR DESCRIPTION
Part of epic https://github.com/metabase/metabase/issues/29502

### Description

Initially when deleting tabs on dashboards, the tab and its cards would immediately be delete without warning. This PR adds an undo toast after a tab is delete, to give the user a chance to revert the change without having to cancel the entire edit.

### How to verify

1. Create dashboard with multiple tabs.
2. Delete a tab, should see undo toast.
3. Click on undo toast, deleted card and its tabs should reappear.

### Demo


https://github.com/metabase/metabase/assets/37751258/312684db-9980-49ae-ad47-ec3ea39d6361



### Checklist

- [x] Tests have been added/updated to cover changes in this PR

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30497)
<!-- Reviewable:end -->
