### PR TITLE
Manual backport: Fix v1 dump command error when logging entities (#30…

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/serialization/names.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/names.clj
@@ -21,7 +21,8 @@
    [metabase.util.schema :as su]
    [ring.util.codec :as codec]
    [schema.core :as s]
-   [toucan.db :as db]))
+   [toucan.db :as db]
+   [toucan2.protocols :as t2.protocols]))
 
 (set! *warn-on-reflection* true)
 
@@ -338,7 +339,7 @@
 
 (defn name-for-logging
   "Return a string representation of entity suitable for logs"
-  ([entity] (name-for-logging (name entity) entity))
+  ([entity] (name-for-logging (t2.protocols/model entity) entity))
   ([model {:keys [name id]}]
    (cond
      (and name id) (format "%s \"%s\" (ID %s)" model name id)

--- a/enterprise/backend/test/metabase_enterprise/serialization/names_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/names_test.clj
@@ -96,3 +96,12 @@
                              "/databases/Fingerprint test-data copy/schemas/public/tables/users/fields/id"} fq-name))
             (is (map? ctx))
             (is (some? (:table ctx)))))))))
+
+(deftest name-for-logging-test
+  (testing "serialization logging name generation from Toucan 2 records (#29322)"
+    (mt/with-temp* [Collection [{collection-id :id} {:name         "A Collection"}]
+                    Card       [{card-id :id}       {:name         "A Card"
+                                                     :collection_id collection-id}]]
+      (are [model s id] (= (format s id) (names/name-for-logging (db/select-one model :id id)))
+        'Collection ":metabase.models.collection/Collection \"A Collection\" (ID %d)" collection-id
+        'Card       ":metabase.models.card/Card \"A Card\" (ID %d)" card-id))))


### PR DESCRIPTION
Manual backport for this issue because there are conflicts in the Toucan namespace references in v1 dump between v46 and v47.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30498)
<!-- Reviewable:end -->
