### PR TITLE
CI on container build: parametrize the Docker Hub organization

### DIFF
--- a/.github/workflows/uberjar.yml
+++ b/.github/workflows/uberjar.yml
@@ -129,15 +129,15 @@ jobs:
         password: ${{ secrets.DOCKERHUB_TOKEN }}
     - name: Retag and push images if master (ee)
       if: ${{ (github.ref_name == 'master') && matrix.edition == 'ee' }}
-      run: docker tag localhost:5000/metabase-dev:${{ steps.extract_branch.outputs.branch }}-ee metabase/metabase-enterprise-head:latest && docker push metabase/metabase-enterprise-head:latest
+      run: docker tag localhost:5000/metabase-dev:${{ steps.extract_branch.outputs.branch }}-ee ${{ github.repository_owner }}/metabase-enterprise-head:latest && docker push ${{ github.repository_owner }}/metabase-enterprise-head:latest
 
     - name: Retag and push images if master (oss)
       if: ${{ (github.ref_name == 'master') && matrix.edition == 'oss' }}
-      run: docker tag localhost:5000/metabase-dev:${{ steps.extract_branch.outputs.branch }}-oss metabase/metabase-head:latest && docker push metabase/metabase-head:latest
+      run: docker tag localhost:5000/metabase-dev:${{ steps.extract_branch.outputs.branch }}-oss ${{ github.repository_owner }}/metabase-head:latest && docker push ${{ github.repository_owner }}/metabase-head:latest
 
     - name: Retag and push images if dev branch
       if: ${{ !(startsWith(github.ref_name,'master') || startsWith(github.ref_name,'backport')) && matrix.edition == 'ee' }}
-      run: docker tag localhost:5000/metabase-dev:${{ steps.extract_branch.outputs.branch }}-ee metabase/metabase-dev:${{ steps.extract_branch.outputs.branch }} && docker push metabase/metabase-dev:${{ steps.extract_branch.outputs.branch }}
+      run: docker tag localhost:5000/metabase-dev:${{ steps.extract_branch.outputs.branch }}-ee ${{ github.repository_owner }}/metabase-dev:${{ steps.extract_branch.outputs.branch }} && docker push ${{ github.repository_owner }}/metabase-dev:${{ steps.extract_branch.outputs.branch }}
 
     - name: Run Trivy vulnerability scanner if master (ee)
       if: ${{ (github.ref_name == 'master') && matrix.edition == 'ee' }}
@@ -145,7 +145,7 @@ jobs:
       env:
         TRIVY_OFFLINE_SCAN: true
       with:
-        image-ref: docker.io/metabase/metabase-enterprise-head:latest
+        image-ref: docker.io/${{ github.repository_owner }}/metabase-enterprise-head:latest
         format: sarif
         output: trivy-results.sarif
 
@@ -155,7 +155,7 @@ jobs:
       env:
         TRIVY_OFFLINE_SCAN: true
       with:
-        image-ref: docker.io/metabase/metabase-head:latest
+        image-ref: docker.io/${{ github.repository_owner }}/metabase-head:latest
         format: sarif
         output: trivy-results.sarif
 
@@ -165,7 +165,7 @@ jobs:
       env:
         TRIVY_OFFLINE_SCAN: true
       with:
-        image-ref: docker.io/metabase/metabase-dev:${{ steps.extract_branch.outputs.branch }}
+        image-ref: docker.io/${{ github.repository_owner }}/metabase-dev:${{ steps.extract_branch.outputs.branch }}
         format: sarif
         output: trivy-results.sarif
 
@@ -259,7 +259,7 @@ jobs:
         run: regctl registry set --tls disabled localhost:5000
       - name: Retag and push ubuntu-based images if master (ee)
         if: ${{ matrix.edition == 'ee' }}
-        run: regctl image copy localhost:5000/metabase-dev:${{ steps.extract_branch.outputs.branch }}-ee-ubuntu metabase/metabase-enterprise-head:latest-ubuntu
+        run: regctl image copy localhost:5000/metabase-dev:${{ steps.extract_branch.outputs.branch }}-ee-ubuntu ${{ github.repository_owner }}/metabase-enterprise-head:latest-ubuntu
       - name: Retag and push ubuntu-based images if master (oss)
         if: ${{ matrix.edition == 'oss' }}
-        run: regctl image copy localhost:5000/metabase-dev:${{ steps.extract_branch.outputs.branch }}-oss-ubuntu metabase/metabase-head:latest-ubuntu
+        run: regctl image copy localhost:5000/metabase-dev:${{ steps.extract_branch.outputs.branch }}-oss-ubuntu ${{ github.repository_owner }}/metabase-head:latest-ubuntu


### PR DESCRIPTION
For the workflow `uberjar.yml`, the name of the target Docker Hub organization is hardcoded. This means that any fork of this GitHub repo (e.g. a customer, an individual, an external contributor, etc) will fail running the said workflow. A sad consequence: it's hard to test `uberjar.yml` without being merge in this GitHub repo, leading to potential trial-and-error (and it happened already in the past).

In this PR, the name of the Docker Hub organization is set to the same name of the GitHub organization (the pattern we already adopted for the workflow `pre-release.yml` and `release.yml`). This way, the `uberjar.yml` workflow can run properly on a forked repo. **Major bonus**: we can properly test any future change to `uberjar.yml` by testing it extensively first on a fork.

### Before this PR

The workflow `uberjar.yml` fails unless it is executed in this very GitHub repo.

### After this PR

The workflow `uberjar.yml` runs properly. Illustrated here in the following screenshot, this is [a successful run](https://github.com/ariya/metabase/actions/runs/4868078014/jobs/8681350742) (on a forked repo: `github.com/ariya/metabase`) by pushing the built container image to `docker.io/ariya/metabase-head` (not hardcoded anymore to `docker.io/metabase/metabase-head`).

<img width="915" alt="image" src="https://user-images.githubusercontent.com/7288/235836060-6561bf72-e705-4027-8d04-f398879d8070.png">

Note that the GitHub Action log (for security reason) masked the full/proper name, hence it appears as `docker.io/***/metabase-head`)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30500)
<!-- Reviewable:end -->
