### PR TITLE
Properly quote token in master test failure notification script

### DIFF
--- a/.github/workflows/rerun-workflows.yml
+++ b/.github/workflows/rerun-workflows.yml
@@ -43,7 +43,7 @@ jobs:
             } else {
               // notify slack of repeated failure
               const WebClient = require('@slack/web-api');
-              const slack = new WebClient(${{ secrets.SLACK_BOT_TOKEN }});
+              const slack = new WebClient('${{ secrets.SLACK_BOT_TOKEN }}');
 
               await slack.chat.postMessage({
                 channel: 'engineering-ci',


### PR DESCRIPTION
### Description

bugfix for https://github.com/metabase/metabase/pull/30244

see failure: https://github.com/metabase/metabase/actions/runs/4863119353/jobs/8671387520

I tested this in a personal repository to confirm I got the syntax right this time:

![Screen Shot 2023-05-03 at 5 46 54 AM](https://user-images.githubusercontent.com/30528226/235907269-f7242ca9-e18d-445c-a8cc-5fd79b704415.png)



<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30505)
<!-- Reviewable:end -->
