### PR TITLE
Updating StringInputWidget to use underscore instead of lodash

### DIFF
--- a/frontend/src/metabase/parameters/components/widgets/StringInputWidget/StringInputWidget.tsx
+++ b/frontend/src/metabase/parameters/components/widgets/StringInputWidget/StringInputWidget.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { t } from "ttag";
-import { isEqual, isString, isEmpty } from "lodash";
+import { isEqual, isString, isEmpty } from "underscore";
 
 import TokenField, { parseStringValue } from "metabase/components/TokenField";
 import {


### PR DESCRIPTION
### Description
While poking around the build package I saw that we were still including the lodash package. It turned out that we had 1 component that was still importing functions from lodash. I've swapped them out and confirmed that the entire lodash package is no longer present in the bundle using [webpack visualizer](https://chrisbateman.github.io/webpack-visualizer/)

### How to verify
See screenshot
### Demo
Before - After. Small decrease in package size
![image](https://user-images.githubusercontent.com/1328979/235949354-9ebadc3f-f92b-439c-909f-15b10cfde1ad.png)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR - component already has unit tests and they continue to pass

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30528)
<!-- Reviewable:end -->
