### PR TITLE
Fix types in permissions selectors

### DIFF
--- a/frontend/src/metabase/admin/permissions/pages/DataPermissionsPage/DataPermissionsPage.jsx
+++ b/frontend/src/metabase/admin/permissions/pages/DataPermissionsPage/DataPermissionsPage.jsx
@@ -93,6 +93,8 @@ DataPermissionsPage.propTypes = propTypes;
 
 export default _.compose(
   Groups.loadList(),
-  Databases.loadList(),
+  Databases.loadList({
+    selectorName: "getListUnfiltered",
+  }),
   connect(mapStateToProps, mapDispatchToProps),
 )(DataPermissionsPage);

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/diff.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/diff.ts
@@ -1,37 +1,11 @@
 import { createSelector } from "@reduxjs/toolkit";
-import type { Selector } from "@reduxjs/toolkit";
 import _ from "underscore";
 
 import { diffDataPermissions } from "metabase/admin/permissions/utils/graph";
-import Groups from "metabase/entities/groups";
 import { PLUGIN_DATA_PERMISSIONS } from "metabase/plugins";
-
-import { Database } from "metabase-types/api";
+import { Group } from "metabase-types/api";
 import { State } from "metabase-types/store";
-import { isVirtualCardId } from "metabase-lib/metadata/utils/saved-questions";
-
-const getDatabasesWithTables: Selector<State, Database[]> = createSelector(
-  (state: State) => state.entities.databases,
-  (state: State) => state.entities.tables,
-  (databases, tables) => {
-    if (!databases || !tables) {
-      return [];
-    }
-    const databasesList = Object.values(databases);
-    const tablesList = Object.values(tables);
-
-    return databasesList.map(database => {
-      const databaseTables = tablesList.filter(
-        table => table.db_id === database.id && !isVirtualCardId(table.id),
-      );
-
-      return {
-        ...database,
-        tables: databaseTables,
-      };
-    });
-  },
-);
+import Database from "metabase-lib/metadata/Database";
 
 export const getIsDirty = createSelector(
   (state: State) => state.admin.permissions.dataPermissions,
@@ -41,9 +15,14 @@ export const getIsDirty = createSelector(
     !_.isEqual(permissions, originalPermissions) || hasExtraChanges,
 );
 
+interface DiffProps {
+  databases: Database[];
+  groups: Group[];
+}
+
 export const getDiff = createSelector(
-  getDatabasesWithTables,
-  Groups.selectors.getList,
+  (state: State, { databases }: DiffProps) => databases,
+  (state: State, { groups }: DiffProps) => groups,
   (state: State) => state.admin.permissions.dataPermissions,
   (state: State) => state.admin.permissions.originalDataPermissions,
   (databases, groups, permissions, originalPermissions) =>

--- a/frontend/src/metabase/admin/permissions/utils/graph/permissions-diff.ts
+++ b/frontend/src/metabase/admin/permissions/utils/graph/permissions-diff.ts
@@ -1,9 +1,9 @@
 import type {
   ConcreteTableId,
-  Database,
   Group,
   GroupsPermissions,
 } from "metabase-types/api";
+import Database from "metabase-lib/metadata/Database";
 import {
   getFieldsPermission,
   getNativePermission,

--- a/frontend/src/metabase/entities/databases.js
+++ b/frontend/src/metabase/entities/databases.js
@@ -12,7 +12,11 @@ import { DatabaseSchema } from "metabase/schema";
 import Fields from "metabase/entities/fields";
 import Schemas from "metabase/entities/schemas";
 
-import { getMetadata, getFields } from "metabase/selectors/metadata";
+import {
+  getMetadata,
+  getFields,
+  getMetadataUnfiltered,
+} from "metabase/selectors/metadata";
 
 // OBJECT ACTIONS
 export const FETCH_DATABASE_METADATA =
@@ -74,6 +78,16 @@ const Databases = createEntity({
 
   selectors: {
     getObject: (state, { entityId }) => getMetadata(state).database(entityId),
+    // these unfiltered selectors include hidden tables/fields for display in the admin panel
+    getObjectUnfiltered: (state, { entityId }) =>
+      getMetadataUnfiltered(state).database(entityId),
+    getListUnfiltered: (state, { entityQuery }) => {
+      const entityIds =
+        Databases.selectors.getEntityIds(state, { entityQuery }) ?? [];
+      return entityIds.map(entityId =>
+        Databases.selectors.getObjectUnfiltered(state, { entityId }),
+      );
+    },
 
     getHasSampleDatabase: (state, props) =>
       _.any(Databases.selectors.getList(state, props), db => db.is_sample),


### PR DESCRIPTION
- Uses correct type for `Database.loadList` - it should be from `metabase-lib`
- Uses data from the loader instead of constructing the graph manually from raw normalized objects

How to test:
- Admin -> Permissions
- Make sure it's possible to select databases, tables, groups

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30530)
<!-- Reviewable:end -->
