### PR TITLE
Fix #30494: fix subcollection apply logic

### DIFF
--- a/e2e/support/helpers/e2e-permissions-helpers.js
+++ b/e2e/support/helpers/e2e-permissions-helpers.js
@@ -61,11 +61,11 @@ export function assertPermissionTable(rows) {
 
 export function assertPermissionOptions(options) {
   popover().within(() => {
-    const elements = cy.findAllByRole("option");
-    elements.should("have.length", options.length);
-    elements.each(($accessEl, index) => {
-      cy.wrap($accessEl).findByText(options[index]);
-    });
+    cy.findAllByRole("option")
+      .should("have.length", options.length)
+      .each(($accessEl, index) => {
+        cy.wrap($accessEl).findByText(options[index]);
+      });
   });
 }
 

--- a/e2e/support/helpers/e2e-permissions-helpers.js
+++ b/e2e/support/helpers/e2e-permissions-helpers.js
@@ -16,7 +16,7 @@ export function modifyPermission(
   value,
   shouldPropagate = null,
 ) {
-  getPermissionRowPermissions(item).eq(permissionIndex).click();
+  selectPermissionRow(item, permissionIndex);
 
   popover().within(() => {
     if (shouldPropagate !== null) {
@@ -30,6 +30,10 @@ export function modifyPermission(
     }
     value && cy.findByText(value).click();
   });
+}
+
+export function selectPermissionRow(item, permissionIndex) {
+  getPermissionRowPermissions(item).eq(permissionIndex).click();
 }
 
 function getPermissionRowPermissions(item) {
@@ -51,6 +55,16 @@ export function assertPermissionTable(rows) {
 
     getPermissionRowPermissions(item).each(($permissionEl, index) => {
       cy.wrap($permissionEl).should("have.text", permissions[index]);
+    });
+  });
+}
+
+export function assertPermissionOptions(options) {
+  popover().within(() => {
+    const elements = cy.findAllByRole("option");
+    elements.should("have.length", options.length);
+    elements.each(($accessEl, index) => {
+      cy.wrap($accessEl).findByText(options[index]);
     });
   });
 }

--- a/e2e/test/scenarios/collections/reproductions/20911-include-subcollections-permissions.cy.spec.js
+++ b/e2e/test/scenarios/collections/reproductions/20911-include-subcollections-permissions.cy.spec.js
@@ -40,7 +40,7 @@ describe("issue 20911", () => {
     modifyPermission(
       "collection",
       COLLECTION_ACCESS_PERMISSION_INDEX,
-      null,
+      "No access",
       true,
     );
     modal().within(() => {

--- a/e2e/test/scenarios/permissions/admin-permissions.cy.spec.js
+++ b/e2e/test/scenarios/permissions/admin-permissions.cy.spec.js
@@ -203,6 +203,53 @@ describe("scenarios > admin > permissions", { tags: "@OSS" }, () => {
     });
   });
 
+  it("don't propagate permissions by checkbox without access select", () => {
+    cy.visit("/admin/permissions/collections");
+
+    const collections = ["Our analytics", "First collection"];
+    assertSidebarItems(collections);
+
+    selectSidebarItem("First collection");
+    assertSidebarItems([...collections, "Second collection"]);
+
+    selectSidebarItem("Second collection");
+
+    assertPermissionTable([
+      ["Administrators", "Curate"],
+      ["All Users", "No access"],
+      ["collection", "Curate"],
+      ["data", "No access"],
+      ["nosql", "No access"],
+      ["readonly", "View"],
+    ]);
+
+    modifyPermission(
+      "All Users",
+      COLLECTION_ACCESS_PERMISSION_INDEX,
+      "View",
+      false,
+    );
+
+    modifyPermission(
+      "All Users",
+      COLLECTION_ACCESS_PERMISSION_INDEX,
+      null,
+      true,
+    );
+
+    // Navigate to children
+    selectSidebarItem("Third collection");
+
+    assertPermissionTable([
+      ["Administrators", "Curate"],
+      ["All Users", "No access"], // Check permission hasn't been propagated
+      ["collection", "Curate"],
+      ["data", "No access"],
+      ["nosql", "No access"],
+      ["readonly", "View"],
+    ]);
+  });
+
   context("data permissions", () => {
     it("warns about leaving with unsaved changes", () => {
       cy.visit("/admin/permissions");

--- a/e2e/test/scenarios/permissions/admin-permissions.cy.spec.js
+++ b/e2e/test/scenarios/permissions/admin-permissions.cy.spec.js
@@ -5,12 +5,14 @@ import {
   describeEE,
   isOSS,
   assertPermissionTable,
+  assertPermissionOptions,
   modifyPermission,
   selectSidebarItem,
   assertSidebarItems,
   isPermissionDisabled,
   visitQuestion,
   visitDashboard,
+  selectPermissionRow,
 } from "e2e/support/helpers";
 
 import { SAMPLE_DB_ID, USER_GROUPS } from "e2e/support/cypress_data";
@@ -248,6 +250,25 @@ describe("scenarios > admin > permissions", { tags: "@OSS" }, () => {
       ["nosql", "No access"],
       ["readonly", "View"],
     ]);
+  });
+
+  it("show selected option for the collection with children", () => {
+    cy.visit("/admin/permissions/collections");
+
+    const collections = ["Our analytics", "First collection"];
+    assertSidebarItems(collections);
+
+    selectSidebarItem("First collection");
+    assertSidebarItems([...collections, "Second collection"]);
+
+    selectSidebarItem("Second collection");
+    selectPermissionRow("All Users", COLLECTION_ACCESS_PERMISSION_INDEX);
+    assertPermissionOptions(["Curate", "View", "No access"]);
+
+    selectSidebarItem("Third collection");
+    selectPermissionRow("All Users", COLLECTION_ACCESS_PERMISSION_INDEX);
+
+    assertPermissionOptions(["Curate", "View"]);
   });
 
   context("data permissions", () => {

--- a/frontend/src/metabase/admin/permissions/components/PermissionsSelect/PermissionsSelect.jsx
+++ b/frontend/src/metabase/admin/permissions/components/PermissionsSelect/PermissionsSelect.jsx
@@ -51,7 +51,6 @@ export const PermissionsSelect = memo(function PermissionsSelect({
 }) {
   const [toggleState, setToggleState] = useState(false);
   const selectedOption = options.find(option => option.value === value);
-  const selectableOptions = options.filter(option => option !== selectedOption);
 
   const selectedOptionValue = (
     <PermissionsSelectRoot
@@ -92,13 +91,14 @@ export const PermissionsSelect = memo(function PermissionsSelect({
     <PopoverWithTrigger
       disabled={isDisabled}
       triggerElement={selectedOptionValue}
+      onClose={() => setToggleState(false)}
       targetOffsetX={16}
       targetOffsetY={8}
     >
       {({ onClose }) => (
         <React.Fragment>
           <OptionsList role="listbox">
-            {selectableOptions.map(option => (
+            {options.map(option => (
               <OptionsListItem
                 role="option"
                 key={option.value}
@@ -131,14 +131,7 @@ export const PermissionsSelect = memo(function PermissionsSelect({
           {toggleLabel && (
             <ToggleContainer>
               <ToggleLabel>{toggleLabel}</ToggleLabel>
-              <Toggle
-                small
-                value={toggleState}
-                onChange={value => {
-                  setToggleState(value);
-                  onChange(selectedOption.value, value);
-                }}
-              />
+              <Toggle small value={toggleState} onChange={setToggleState} />
             </ToggleContainer>
           )}
         </React.Fragment>

--- a/frontend/src/metabase/admin/permissions/components/PermissionsSelect/PermissionsSelect.jsx
+++ b/frontend/src/metabase/admin/permissions/components/PermissionsSelect/PermissionsSelect.jsx
@@ -29,6 +29,7 @@ const propTypes = {
   actions: PropTypes.object,
   value: PropTypes.string.isRequired,
   toggleLabel: PropTypes.string,
+  hasChildren: PropTypes.bool,
   onChange: PropTypes.func.isRequired,
   onAction: PropTypes.func,
   isDisabled: PropTypes.bool,
@@ -42,6 +43,7 @@ export const PermissionsSelect = memo(function PermissionsSelect({
   actions,
   value,
   toggleLabel,
+  hasChildren,
   onChange,
   onAction,
   isDisabled,
@@ -51,6 +53,9 @@ export const PermissionsSelect = memo(function PermissionsSelect({
 }) {
   const [toggleState, setToggleState] = useState(false);
   const selectedOption = options.find(option => option.value === value);
+  const selectableOptions = hasChildren
+    ? options
+    : options.filter(option => option !== selectedOption);
 
   const selectedOptionValue = (
     <PermissionsSelectRoot
@@ -98,7 +103,7 @@ export const PermissionsSelect = memo(function PermissionsSelect({
       {({ onClose }) => (
         <React.Fragment>
           <OptionsList role="listbox">
-            {options.map(option => (
+            {selectableOptions.map(option => (
               <OptionsListItem
                 role="option"
                 key={option.value}
@@ -128,7 +133,7 @@ export const PermissionsSelect = memo(function PermissionsSelect({
             </ActionsList>
           )}
 
-          {toggleLabel && (
+          {hasChildren && (
             <ToggleContainer>
               <ToggleLabel>{toggleLabel}</ToggleLabel>
               <Toggle small value={toggleState} onChange={setToggleState} />

--- a/frontend/src/metabase/admin/permissions/selectors/collection-permissions.js
+++ b/frontend/src/metabase/admin/permissions/selectors/collection-permissions.js
@@ -188,6 +188,7 @@ export const getCollectionsPermissionEditor = createSelector(
         permissions: [
           {
             toggleLabel,
+            hasChildren,
             isDisabled: isAdmin,
             disabledTooltip: isAdmin
               ? UNABLE_TO_CHANGE_ADMIN_PERMISSIONS


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/30494

### Description

Change logic introduced in #30426 to have an additional option instead of applying 'Also change sub-collections' immediately 

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Log in as admin
2. Create a collection "Root"
3. Create a nested collection "Child"
4. Open permissions for the "Root" collection
5. Click "All Users" and click "Also change sub-collections" and turn it off back
6. Close the tooltip and check that there is a no changes 
8. Click "All Users" and change to "View" and click Save
9. Check that "View" is applied only for the "Root"
10. Open permissions again, click "All Users" option 
11. Click "Also change sub-collections" and select "View" again
12. Click Save 
13. Check that "View" is applied for the "Child" too

### Checklist

- [x] Tests have been added/updated to cover changes in this PR

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30531)
<!-- Reviewable:end -->
