### PR TITLE
fix width for tabs with long names

### DIFF
--- a/frontend/src/metabase/core/components/TabButton/TabButton.styled.tsx
+++ b/frontend/src/metabase/core/components/TabButton/TabButton.styled.tsx
@@ -9,8 +9,24 @@ export interface TabButtonProps {
   disabled?: boolean;
 }
 
+// Wrapper and Resizer are needed to auto-grow the input with its content
+// https://css-tricks.com/auto-growing-inputs-textareas/#aa-resizing-actual-input-elements
+export const TabButtonInputWrapper = styled.span`
+  position: relative;
+`;
+
+export const TabButtonInputResizer = styled.span`
+  visibility: hidden;
+  white-space: pre;
+  /* For some reason the computed font-size is wrong (14px when it should be 13.33px) when using 
+  the same rem value as in TabButtonRoot so we have to manually define it in px */
+  font-size: 13.33px;
+`;
+
 export const TabButtonInput = styled.input<TabButtonProps & { value: string }>`
-  width: ${props => `${props.value.length}ch`};
+  position: absolute;
+  width: 100%;
+  left: 0;
   padding: 0;
 
   border: none;

--- a/frontend/src/metabase/core/components/TabButton/TabButton.styled.tsx
+++ b/frontend/src/metabase/core/components/TabButton/TabButton.styled.tsx
@@ -18,9 +18,6 @@ export const TabButtonInputWrapper = styled.span`
 export const TabButtonInputResizer = styled.span`
   visibility: hidden;
   white-space: pre;
-  /* For some reason the computed font-size is wrong (14px when it should be 13.33px) when using 
-  the same rem value as in TabButtonRoot so we have to manually define it in px */
-  font-size: 13.33px;
 `;
 
 export const TabButtonInput = styled.input<TabButtonProps & { value: string }>`
@@ -34,6 +31,7 @@ export const TabButtonInput = styled.input<TabButtonProps & { value: string }>`
   background-color: transparent;
 
   color: ${props => (props.isSelected ? color("brand") : color("text-dark"))};
+  font-size: inherit;
   font-weight: bold;
   text-align: center;
 

--- a/frontend/src/metabase/core/components/TabButton/TabButton.tsx
+++ b/frontend/src/metabase/core/components/TabButton/TabButton.tsx
@@ -22,7 +22,13 @@ import {
   TabContext,
   TabContextType,
 } from "../Tab";
-import { TabButtonInput, TabButtonRoot, MenuButton } from "./TabButton.styled";
+import {
+  TabButtonInput,
+  TabButtonRoot,
+  MenuButton,
+  TabButtonInputWrapper,
+  TabButtonInputResizer,
+} from "./TabButton.styled";
 import TabButtonMenu from "./TabButtonMenu";
 
 export type TabButtonMenuAction<T> = (
@@ -108,20 +114,24 @@ const TabButton = forwardRef(function TabButton<T>(
       aria-label={label}
       id={getTabId(idPrefix, value)}
     >
-      <TabButtonInput
-        type="text"
-        value={label}
-        isSelected={isSelected}
-        disabled={!isEditing}
-        onChange={onEdit}
-        onKeyPress={handleInputKeyPress}
-        onFocus={e => e.currentTarget.select()}
-        onBlur={onFinishEditing}
-        aria-labelledby={getTabId(idPrefix, value)}
-        id={getTabButtonInputId(idPrefix, value)}
-        ref={inputRef}
-      />
-
+      <TabButtonInputWrapper>
+        <TabButtonInputResizer aria-hidden="true">
+          {label}
+        </TabButtonInputResizer>
+        <TabButtonInput
+          type="text"
+          value={label}
+          isSelected={isSelected}
+          disabled={!isEditing}
+          onChange={onEdit}
+          onKeyPress={handleInputKeyPress}
+          onFocus={e => e.currentTarget.select()}
+          onBlur={onFinishEditing}
+          aria-labelledby={getTabId(idPrefix, value)}
+          id={getTabButtonInputId(idPrefix, value)}
+          ref={inputRef}
+        />
+      </TabButtonInputWrapper>
       {showMenu && (
         <ControlledPopoverWithTrigger
           visible={isMenuOpen}


### PR DESCRIPTION
Part of epic https://github.com/metabase/metabase/issues/29502

### Description

Width for tabs was computed incorrectly. Initially it used the `ch` css unit to make the tab `N ch` width, where `N` is the number of characters in the tab name. This didn't work and became clearly incorrect as tab names grew longer, because `ch` units don't exactly match the length of a string of text, [as they are a fixed measurement the width of a `0` character.
](https://meyerweb.com/eric/thoughts/2018/06/28/what-is-the-css-ch-unit/)

This PR makes tabs correctly grow with their titles, by growing the width of the underlying `input` element using a hidden resizer element (see [CSS tricks article](https://css-tricks.com/auto-growing-inputs-textareas/#aa-resizing-actual-input-elements)).

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Create a dashboard with tabs.
2. Change the name of a tab.

### Demo

https://github.com/metabase/metabase/assets/37751258/0cc595ec-ced7-47c0-b459-76b78ff48f30

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR

_Is a style change so not easy to test._

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30540)
<!-- Reviewable:end -->
