### PR TITLE
Update connection impersonation warning

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/advanced_permissions/components/RoleAccessWarning/RoleAccessWarning.styled.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/advanced_permissions/components/RoleAccessWarning/RoleAccessWarning.styled.tsx
@@ -1,0 +1,6 @@
+import styled from "@emotion/styled";
+import Alert from "metabase/core/components/Alert";
+
+export const RoleAttributeMappingAlert = styled(Alert)`
+  margin-bottom: 1rem;
+`;

--- a/enterprise/frontend/src/metabase-enterprise/advanced_permissions/components/RoleAccessWarning/RoleAccessWarning.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/advanced_permissions/components/RoleAccessWarning/RoleAccessWarning.tsx
@@ -3,6 +3,7 @@ import { t } from "ttag";
 import { Database } from "metabase-types/api";
 import * as Urls from "metabase/lib/urls";
 import Link from "metabase/core/components/Link";
+import { isEmpty } from "metabase/lib/validate";
 import { RoleAttributeMappingAlert } from "./RoleAccessWarning.styled";
 
 interface RoleAccessWarningProps {
@@ -12,10 +13,9 @@ interface RoleAccessWarningProps {
 const RoleAccessWarning = ({ database }: RoleAccessWarningProps) => {
   const databaseUser = database.details.user;
 
-  const text =
-    databaseUser == null
-      ? t`Make sure the main database credential has access to everything different user groups may need access to. It's what Metabase uses to sync table information.`
-      : t`${databaseUser} is the database user Metabase is using to connect to ${database.name}. Make sure that ${database.details.user} has access to everything in ${database.name} that all Metabase groups may need access to, as that database user account is what Metabase uses to sync table information.`;
+  const text = isEmpty(databaseUser)
+    ? t`Make sure the main database credential has access to everything different user groups may need access to. It's what Metabase uses to sync table information.`
+    : t`${databaseUser} is the database user Metabase is using to connect to ${database.name}. Make sure that ${database.details.user} has access to everything in ${database.name} that all Metabase groups may need access to, as that database user account is what Metabase uses to sync table information.`;
 
   return (
     <RoleAttributeMappingAlert icon="warning" variant="warning">

--- a/enterprise/frontend/src/metabase-enterprise/advanced_permissions/components/RoleAccessWarning/RoleAccessWarning.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/advanced_permissions/components/RoleAccessWarning/RoleAccessWarning.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+import { t } from "ttag";
+import { Database } from "metabase-types/api";
+import * as Urls from "metabase/lib/urls";
+import Link from "metabase/core/components/Link";
+import { RoleAttributeMappingAlert } from "./RoleAccessWarning.styled";
+
+interface RoleAccessWarningProps {
+  database: Database;
+}
+
+const RoleAccessWarning = ({ database }: RoleAccessWarningProps) => {
+  const databaseUser = database.details.user;
+
+  const text =
+    databaseUser == null
+      ? t`Make sure the main database credential has access to everything different user groups may need access to. It's what Metabase uses to sync table information.`
+      : t`${databaseUser} is the database user Metabase is using to connect to ${database.name}. Make sure that ${database.details.user} has access to everything in ${database.name} that all Metabase groups may need access to, as that database user account is what Metabase uses to sync table information.`;
+
+  return (
+    <RoleAttributeMappingAlert icon="warning" variant="warning">
+      {text}{" "}
+      <Link
+        className="link"
+        to={Urls.editDatabase(database.id) + (databaseUser ? "#user" : "")}
+      >{t`Edit settings`}</Link>
+    </RoleAttributeMappingAlert>
+  );
+};
+
+export default RoleAccessWarning;

--- a/enterprise/frontend/src/metabase-enterprise/advanced_permissions/components/RoleAccessWarning/RoleAccessWarning.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/advanced_permissions/components/RoleAccessWarning/RoleAccessWarning.unit.spec.tsx
@@ -1,0 +1,57 @@
+import React from "react";
+import { screen } from "@testing-library/react";
+import { Route } from "react-router";
+import { createMockDatabase } from "metabase-types/api/mocks";
+import { Database } from "metabase-types/api";
+import { renderWithProviders } from "__support__/ui";
+import RoleAccessWarning from "./RoleAccessWarning";
+
+const setup = (database: Database) => {
+  renderWithProviders(
+    <Route
+      path="*"
+      component={() => <RoleAccessWarning database={database} />}
+    />,
+    {
+      withRouter: true,
+    },
+  );
+};
+
+describe("RoleAccessWarning", () => {
+  it("should render correctly for databases without a user", () => {
+    setup(createMockDatabase());
+    expect(
+      screen.getByText(
+        "Make sure the main database credential has access to everything different user groups may need access to. It's what Metabase uses to sync table information.",
+      ),
+    ).toBeInTheDocument();
+
+    expect(screen.getByText(/edit settings/i)).toHaveAttribute(
+      "href",
+      "/admin/databases/1",
+    );
+  });
+
+  it("should render correct message for databases with a user", () => {
+    setup(
+      createMockDatabase({
+        name: "My Database",
+        details: {
+          user: "metabase_user",
+        },
+      }),
+    );
+
+    expect(
+      screen.getByText(
+        "metabase_user is the database user Metabase is using to connect to My Database. Make sure that metabase_user has access to everything in My Database that all Metabase groups may need access to, as that database user account is what Metabase uses to sync table information.",
+      ),
+    ).toBeInTheDocument();
+
+    expect(screen.getByText(/edit settings/i)).toHaveAttribute(
+      "href",
+      "/admin/databases/1#user",
+    );
+  });
+});

--- a/enterprise/frontend/src/metabase-enterprise/advanced_permissions/components/RoleAccessWarning/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/advanced_permissions/components/RoleAccessWarning/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./RoleAccessWarning";

--- a/enterprise/frontend/src/metabase-enterprise/advanced_permissions/components/RoleAttributeMappingModal/RoleAttributeMappingModalView.styled.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/advanced_permissions/components/RoleAttributeMappingModal/RoleAttributeMappingModalView.styled.tsx
@@ -1,5 +1,4 @@
 import styled from "@emotion/styled";
-import Alert from "metabase/core/components/Alert";
 
 export const RoleAttributeMappingModalViewRoot = styled.div`
   display: flex;
@@ -10,8 +9,4 @@ export const RoleAttributeMappingModalViewRoot = styled.div`
 
 export const RoleAttributeMappingDescription = styled.p`
   line-height: 1.4rem;
-`;
-
-export const RoleAttributeMappingAlert = styled(Alert)`
-  margin-bottom: 1rem;
 `;

--- a/enterprise/frontend/src/metabase-enterprise/advanced_permissions/components/RoleAttributeMappingModal/RoleAttributeMappingModalView.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/advanced_permissions/components/RoleAttributeMappingModal/RoleAttributeMappingModalView.tsx
@@ -1,7 +1,6 @@
 import React, { useMemo } from "react";
 import { t } from "ttag";
 import * as Yup from "yup";
-import Link from "metabase/core/components/Link";
 import FormSelect from "metabase/core/components/FormSelect";
 import FormProvider from "metabase/core/components/FormProvider";
 import FormSubmitButton from "metabase/core/components/FormSubmitButton";
@@ -18,10 +17,9 @@ import {
 import Alert from "metabase/core/components/Alert";
 import FormFooter from "metabase/core/components/FormFooter";
 import Button from "metabase/core/components/Button";
-import * as Urls from "metabase/lib/urls";
 import ExternalLink from "metabase/core/components/ExternalLink/ExternalLink";
+import RoleAccessWarning from "../RoleAccessWarning";
 import {
-  RoleAttributeMappingAlert,
   RoleAttributeMappingDescription,
   RoleAttributeMappingModalViewRoot,
 } from "./RoleAttributeMappingModalView.styled";
@@ -47,7 +45,6 @@ const RoleAttributeMappingModalView = ({
   onCancel,
 }: RoleAttributeMappingModalViewProps) => {
   const initialValues = mapping ?? ROLE_ATTRIBUTION_MAPPING_SCHEMA.getDefault();
-  const databaseUser = database.details.user;
 
   const hasAttributes = attributes.length > 0;
   const attributeOptions = useMemo(
@@ -83,15 +80,7 @@ const RoleAttributeMappingModalView = ({
                 options={attributeOptions}
               />
 
-              {databaseUser != null ? (
-                <RoleAttributeMappingAlert icon="warning" variant="warning">
-                  {t`${databaseUser} is the database user Metabase is using to connect to ${database.name}. Make sure that ${database.details.user} has access to everything in ${database.name} that all Metabase groups may need access to, as that database user account is what Metabase uses to sync table information.`}{" "}
-                  <Link
-                    className="link"
-                    to={Urls.editDatabase(database.id)}
-                  >{t`Edit settings`}</Link>
-                </RoleAttributeMappingAlert>
-              ) : null}
+              <RoleAccessWarning database={database} />
 
               <FormInput
                 infoTooltip={t`Users with empty attributes will run queries using this role. We also restore the connection to this role after every query.`}

--- a/frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx
+++ b/frontend/src/metabase/admin/databases/containers/DatabaseEditApp.jsx
@@ -125,6 +125,8 @@ class DatabaseEditApp extends Component {
       }
     };
 
+    const autofocusFieldName = window.location.hash.slice(1);
+
     return (
       <DatabaseEditRoot>
         <Breadcrumbs className="py4" crumbs={crumbs} />
@@ -142,6 +144,7 @@ class DatabaseEditApp extends Component {
                       <DatabaseForm
                         initialValues={database}
                         isAdvanced
+                        autofocusFieldName={autofocusFieldName}
                         onSubmit={handleSubmit}
                       />
                     </DatabaseEditForm>

--- a/frontend/src/metabase/databases/components/DatabaseDetailField/DatabaseDetailField.tsx
+++ b/frontend/src/metabase/databases/components/DatabaseDetailField/DatabaseDetailField.tsx
@@ -13,14 +13,19 @@ import { EngineFieldOverride } from "../../types";
 
 export interface DatabaseDetailFieldProps {
   field: EngineField;
+  autoFocus?: boolean;
 }
 
 const DatabaseDetailField = ({
   field,
+  autoFocus,
 }: DatabaseDetailFieldProps): JSX.Element => {
   const override = FIELD_OVERRIDES[field.name];
   const type = getFieldType(field, override);
-  const props = getFieldProps(field, override);
+  const props = {
+    autoFocus,
+    ...getFieldProps(field, override),
+  };
 
   if (typeof type === "function") {
     const Component = type;

--- a/frontend/src/metabase/databases/components/DatabaseForm/DatabaseForm.tsx
+++ b/frontend/src/metabase/databases/components/DatabaseForm/DatabaseForm.tsx
@@ -24,6 +24,7 @@ import { LinkButton, LinkFooter } from "./DatabaseForm.styled";
 export interface DatabaseFormProps {
   engines: Record<string, Engine>;
   initialValues?: DatabaseData;
+  autofocusFieldName?: string;
   isHosted?: boolean;
   isAdvanced?: boolean;
   isCachingEnabled?: boolean;
@@ -35,6 +36,7 @@ export interface DatabaseFormProps {
 const DatabaseForm = ({
   engines,
   initialValues: initialData,
+  autofocusFieldName,
   isHosted = false,
   isAdvanced = false,
   isCachingEnabled = false,
@@ -83,6 +85,7 @@ const DatabaseForm = ({
         engine={engine}
         engineKey={engineKey}
         engines={engines}
+        autofocusFieldName={autofocusFieldName}
         isHosted={isHosted}
         isAdvanced={isAdvanced}
         isCachingEnabled={isCachingEnabled}
@@ -97,6 +100,7 @@ interface DatabaseFormBodyProps {
   engine: Engine | undefined;
   engineKey: string | undefined;
   engines: Record<string, Engine>;
+  autofocusFieldName?: string;
   isHosted: boolean;
   isAdvanced: boolean;
   isCachingEnabled: boolean;
@@ -108,6 +112,7 @@ const DatabaseFormBody = ({
   engine,
   engineKey,
   engines,
+  autofocusFieldName,
   isHosted,
   isAdvanced,
   isCachingEnabled,
@@ -136,7 +141,12 @@ const DatabaseFormBody = ({
       />
       {engine && <DatabaseNameField engine={engine} />}
       {fields.map(field => (
-        <DatabaseDetailField key={field.name} field={field} />
+        <DatabaseDetailField
+          key={field.name}
+          field={field}
+          autoFocus={field.name === autofocusFieldName}
+          data-kek={field.name}
+        />
       ))}
       {isCachingEnabled && <PLUGIN_CACHING.DatabaseCacheTimeField />}
       <DatabaseFormFooter isAdvanced={isAdvanced} onCancel={onCancel} />


### PR DESCRIPTION
Epic https://github.com/metabase/metabase/issues/30020

### Description

Updates the connection impersonation warning when a db does not have a user. Here is the [figma](https://www.figma.com/file/0FbaSE58pGiAmnBk7Gd4ZF/Role-based-sandboxing?type=design&node-id=323-6939&t=sQDfvlvBfvknJSM2-0). 
Another change is that "Edit settings" leads to the database edit page and focuses on the user input if exists.

### How to verify

Run Metabase EE

- Go to admin -> people
- Edit any user details and add at least one attribute
- Go to admin -> permissions
- On any database whose config does not include a user (sample db) change the permission to "impersonated"
- Ensure it shows the role–attribute mapping modal with the updated warning
- On another db whose config includes a user change the permission to "impersonated"
- Ensure it shows the role–attribute mapping modal with the old warning that mentions the user
- Click on "Edit settings" and ensure it opens the DB editing page with the "user" field in focus

### Checklist

- [x] Tests have been added/updated to cover changes in this PR

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30554)
<!-- Reviewable:end -->
