### PR TITLE
Track slowly loading dashboard

### DIFF
--- a/frontend/src/metabase/dashboard/actions/data-fetching.js
+++ b/frontend/src/metabase/dashboard/actions/data-fetching.js
@@ -367,6 +367,7 @@ export const fetchCardData = createThunkAction(
         dashcard_id: dashcard.id,
         card_id: card.id,
         result: cancelled ? null : result,
+        currentTime: performance.now(),
       };
     };
   },
@@ -392,6 +393,8 @@ export const fetchDashboardCardData = createThunkAction(
     Promise.all(promises).then(() => {
       dispatch(loadingComplete());
     });
+
+    return { currentTime: performance.now() };
   },
 );
 

--- a/frontend/src/metabase/dashboard/constants.js
+++ b/frontend/src/metabase/dashboard/constants.js
@@ -6,3 +6,5 @@ export const SIDEBAR_NAME = {
   sharing: "sharing",
   info: "info",
 };
+
+export const DASHBOARD_SLOW_TIMEOUT = 15 * 1000;

--- a/frontend/src/metabase/dashboard/reducers.js
+++ b/frontend/src/metabase/dashboard/reducers.js
@@ -362,25 +362,23 @@ const loadingDashCards = handleActions(
       },
     },
     [FETCH_DASHBOARD_CARD_DATA]: {
-      next: state => ({
+      next: (state, { payload: { currentTime } }) => ({
         ...state,
         loadingStatus: state.dashcardIds.length > 0 ? "running" : "idle",
-        startTime:
-          state.dashcardIds.length > 0 &&
-          // check that performance is defined just in case
-          typeof performance === "object"
-            ? performance.now()
-            : null,
+        startTime: state.dashcardIds.length > 0 && currentTime,
       }),
     },
     [FETCH_CARD_DATA]: {
-      next: (state, { payload: { dashcard_id } }) => {
+      next: (state, { payload: { dashcard_id, currentTime } }) => {
         const loadingIds = state.loadingIds.filter(id => id !== dashcard_id);
         return {
           ...state,
           loadingIds,
           ...(loadingIds.length === 0
-            ? { startTime: null, loadingStatus: "complete" }
+            ? {
+                endTime: currentTime,
+                loadingStatus: "complete",
+              }
             : {}),
         };
       },
@@ -391,7 +389,6 @@ const loadingDashCards = handleActions(
         return {
           ...state,
           loadingIds,
-          ...(loadingIds.length === 0 ? { startTime: null } : {}),
         };
       },
     },
@@ -406,6 +403,7 @@ const loadingDashCards = handleActions(
     dashcardIds: [],
     loadingIds: [],
     startTime: null,
+    endTime: null,
     loadingStatus: "idle",
   },
 );

--- a/frontend/src/metabase/dashboard/selectors.js
+++ b/frontend/src/metabase/dashboard/selectors.js
@@ -7,7 +7,10 @@ import { LOAD_COMPLETE_FAVICON } from "metabase/hoc/Favicon";
 import { getDashboardUiParameters } from "metabase/parameters/utils/dashboards";
 import { getParameterMappingOptions as _getParameterMappingOptions } from "metabase/parameters/utils/mapping-options";
 
-import { SIDEBAR_NAME } from "metabase/dashboard/constants";
+import {
+  DASHBOARD_SLOW_TIMEOUT,
+  SIDEBAR_NAME,
+} from "metabase/dashboard/constants";
 
 import { getEmbedOptions, getIsEmbedded } from "metabase/selectors/embed";
 
@@ -41,6 +44,20 @@ export const getIsLoadingComplete = state =>
 
 export const getLoadingStartTime = state =>
   state.dashboard.loadingDashCards.startTime;
+export const getLoadingEndTime = state =>
+  state.dashboard.loadingDashCards.endTime;
+
+export const getIsSlowDashboard = createSelector(
+  [getLoadingStartTime, getLoadingEndTime],
+  (startTime, endTime) => {
+    if (startTime != null && endTime != null) {
+      return endTime - startTime > DASHBOARD_SLOW_TIMEOUT;
+    } else {
+      return false;
+    }
+  },
+);
+
 export const getIsAddParameterPopoverOpen = state =>
   state.dashboard.isAddParameterPopoverOpen;
 

--- a/frontend/src/metabase/hoc/TitleWithLoadingTime.jsx
+++ b/frontend/src/metabase/hoc/TitleWithLoadingTime.jsx
@@ -6,8 +6,8 @@ import title from "metabase/hoc/Title";
 const SECONDS_UNTIL_DISPLAY = 10;
 
 export default startTimePropName => ComposedComponent =>
-  title(({ [startTimePropName]: startTime }) => {
-    if (startTime == null) {
+  title(({ [startTimePropName]: startTime, isRunning }) => {
+    if (startTime == null || !isRunning) {
       return "";
     }
     const totalSeconds = (performance.now() - startTime) / 1000;


### PR DESCRIPTION
Proof of concept that we can re-use existing dashboard loading code to track whether the dashboard is loading slowly. We could use existing selectors to show the toast like this:

```
const isSlowDashboard = useSelector(getIsSlowDashboard);
const isLoadingComplete = useSelector(getIsLoadingComplete);
const dispatch = useDispatch();

useEffect(() => {
  if (isLoadingComplete && isSlowDashboard) {
    dispatch(addUndo({ message: "123" }));
  }
}, [isLoadingComplete, isSlowDashboard, dispatch]);

```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30556)
<!-- Reviewable:end -->
