### PR TITLE
docs - update sso route

### DIFF
--- a/docs/people-and-groups/authenticating-with-jwt.md
+++ b/docs/people-and-groups/authenticating-with-jwt.md
@@ -26,7 +26,7 @@ Currently, the only algorithm Metabase supports is [HS256](https://en.wikipedia.
 Assuming your site is localhost serving on port 3000:
 
 1. Person attempts to view a question, e.g., `http://localhost:3000/question/1-superb-question`.
-2. If the person isn't logged in, Metabase redirects them to `http://localhost:3000/auth/sso`.
+2. If the person isn't logged in, Metabase redirects them to `http://localhost:3000/auth/sso/`.
 3. Retaining the original `/question/1-superb-question` URI, Metabase redirects the person to the SSO provider (the authentication app).
 4. Person logs in using the basic form.
 5. In the event of a successful sign-in, your authentication app should issue a GET request to your Metabase endpoint with the token and the "return to" URI: `http://localhost:3000/auth/sso?jwt=TOKEN_GOES_HERE&return_to=/question/1-superb-question`.

--- a/docs/people-and-groups/authenticating-with-saml.md
+++ b/docs/people-and-groups/authenticating-with-saml.md
@@ -55,9 +55,9 @@ However, the names of the fields in the Metabase SAML form won't always match th
 
 ### URL the IdP should redirect back to
 
-The redirect URL is the web address that people will be sent to after signing in with your IdP. To redirect people to your Metabase, your redirect URL should be your Metabase [Site URL](../configuring-metabase/settings.md#site-url), with `/auth/sso` at the end.
+The redirect URL is the web address that people will be sent to after signing in with your IdP. To redirect people to your Metabase, your redirect URL should be your Metabase [Site URL](../configuring-metabase/settings.md#site-url), with `/auth/sso/` at the end.
 
-For example, if your Metabase Site URL is `https://metabase.yourcompany.com`, you'll use `https://metabase.yourcompany.com/auth/sso` as the redirect URL in your IdP's SAML form.
+For example, if your Metabase Site URL is `https://metabase.yourcompany.com`, you'll use `https://metabase.yourcompany.com/auth/sso/` as the redirect URL in your IdP's SAML form.
 
 Different IdPs use different names for the redirect URL. Here are some common examples:
 

--- a/docs/people-and-groups/saml-auth0.md
+++ b/docs/people-and-groups/saml-auth0.md
@@ -28,7 +28,7 @@ Enter “Metabase” as the application name with type “Regular Web Applicatio
 Now go to Settings tab inside Auth0's Metabase App and fill in the following values:
 
 - Application Login URI: the URL of your Metabase instance.
-- Allowed Callback URLs: the URL that's below **Configure your identity provider (IdP)** in SAML settings inside Metabase (it ends with /auth/sso).
+- Allowed Callback URLs: the URL that's below **Configure your identity provider (IdP)** in SAML settings inside Metabase (it ends with `/auth/sso/`).
 
 ![Auth0 SAML Settings Page](images/auth0callbackurl.png)
 

--- a/docs/people-and-groups/saml-okta.md
+++ b/docs/people-and-groups/saml-okta.md
@@ -10,7 +10,7 @@ title: SAML with Okta
 
 | Metabase SAML                       | Okta SAML                                                                                                                    |
 | ----------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| URL the IdP should redirect back to | Single sign-on URL. This is your Metabase [Site URL][site-url] -- it should start with `https://` and end with `/auth/sso`.  |
+| URL the IdP should redirect back to | Single sign-on URL. This is your Metabase [Site URL][site-url] -- it should start with `https://` and end with `/auth/sso/`.  |
 | SAML Application Name               | Audience URI (SP Entity ID)                                                                                                  |
 
 ### Setting attribute statements

--- a/docs/troubleshooting-guide/saml.md
+++ b/docs/troubleshooting-guide/saml.md
@@ -43,7 +43,7 @@ After filling out the authentication form with your identity provider, you go ba
 
 ## Is the SSO URL correct?
 
-Verify that the Single Sign On URL (or equivalent) that you enter on your SAML provider’s website has `/auth/sso` appended to it. For instance, if you want your users to end up at `https://metabase.mycompany.com`, the full URL should be `https://metabase.mycompany.com/auth/sso`.
+Verify that the Single Sign On URL (or equivalent) that you enter on your SAML provider’s website has `/auth/sso/` appended to it. For instance, if you want your users to end up at `https://metabase.mycompany.com`, the full URL should be `https://metabase.mycompany.com/auth/sso/`.
 
 ## Searching for private key and found a null
 


### PR DESCRIPTION
A customer pointed out that the trailing slash is needed for SSO routes.

The [API page](https://www.metabase.com/docs/latest/api/ee/sso) is correct (`/auth/sso/`):

![image](https://user-images.githubusercontent.com/22361741/236528708-aace6ff2-31ef-4f20-8878-a7b8050190ef.png)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30590)
<!-- Reviewable:end -->
