### PR TITLE
Fixes IP geocoding test

### DIFF
--- a/test/metabase/server/request/util_test.clj
+++ b/test/metabase/server/request/util_test.clj
@@ -79,8 +79,8 @@
 (deftest ^:parallel geocode-ip-addresses-test
   (are [ip-addresses expected] (schema= expected (request.u/geocode-ip-addresses ip-addresses))
     ["8.8.8.8"]
-    {(s/required-key "8.8.8.8") {:description (s/eq "United States")
-                                 :timezone    (s/eq (t/zone-id "America/Chicago"))}}
+    {(s/required-key "8.8.8.8") {:description (s/eq "Los Angeles, California, United States")
+                                 :timezone    (s/eq (t/zone-id "America/Los_Angeles"))}}
 
     ;; this is from the MaxMind sample high-risk IP address list https://www.maxmind.com/en/high-risk-ip-sample-list
     ["185.233.100.23"]


### PR DESCRIPTION
Simple fix to adapt to a change in results from the geocoding service. I didn't see any obvious stable test values in the service's docs, but they may exist.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30605)
<!-- Reviewable:end -->
