### PR TITLE
Don't allow pinned collection card overflow

### DIFF
--- a/frontend/src/metabase/collections/components/PinnedQuestionCard/PinnedQuestionCard.styled.tsx
+++ b/frontend/src/metabase/collections/components/PinnedQuestionCard/PinnedQuestionCard.styled.tsx
@@ -30,6 +30,7 @@ export interface CardRootProps {
 export const CardRoot = styled(Link)<CardRootProps>`
   position: relative;
   display: block;
+  overflow: hidden;
   height: ${props => props.isPreview && "15.625rem"};
   padding: 0.5rem 0;
   border: 1px solid ${color("border")};


### PR DESCRIPTION
### Description

[Slack Discussion](https://metaboat.slack.com/archives/C01LQQ2UW03/p1683544800874639)

This is a band-aid fix for https://github.com/metabase/metabase/issues/26981. The real issue there has to do with some complexities of when and how we measure visualization size/containers, and will probably take a good deal more time and engineering to dig into the real fix. This simply prevents card overflow so the bug doesn't obscure other nearby visualizations.

Before | After
--- | ---
![Screen Shot 2023-05-08 at 9 31 54 AM](https://user-images.githubusercontent.com/30528226/236865976-5e4ec780-0143-4043-9942-3a4d7e71327b.png) |  ![Screen Shot 2023-05-08 at 9 32 06 AM](https://user-images.githubusercontent.com/30528226/236865979-8dd20992-73d8-499a-b8e5-0f8270b64609.png)


This does not close the issue, but in the short-term, we can get this out in a point release to alleviate the pain for customers affected.

### How to verify

1. Pin a map card to a collection. 
2. See that on certain screen widths, the map is too large, but doesn't overflow the card container.


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30612)
<!-- Reviewable:end -->
