### PR TITLE
Expand `EntityMenuItem` component test coverage

### DIFF
--- a/frontend/src/metabase/components/EntityMenuItem/EntityMenuItem.tsx
+++ b/frontend/src/metabase/components/EntityMenuItem/EntityMenuItem.tsx
@@ -32,7 +32,8 @@ const EntityMenuItem = ({
   onClose,
 }: EntityMenuItemProps): JSX.Element | null => {
   if (link && action) {
-    return <div />;
+    // You cannot specify both action and link props!
+    return null;
   }
 
   const content = (

--- a/frontend/src/metabase/components/EntityMenuItem/EntityMenuItem.unit.spec.js
+++ b/frontend/src/metabase/components/EntityMenuItem/EntityMenuItem.unit.spec.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { fireEvent, render, screen, getIcon } from "__support__/ui";
+import { fireEvent, render, screen, getIcon, queryIcon } from "__support__/ui";
 
 import EntityMenuItem from "metabase/components/EntityMenuItem";
 
@@ -40,6 +40,29 @@ describe("EntityMenuItem", () => {
 
         expect(screen.getByTestId("entity-menu-link")).toBeInTheDocument();
       });
+    });
+
+    it("should not render if both action and link props are present", () => {
+      render(
+        <EntityMenuItem
+          title="A pencil icon"
+          icon="pencil"
+          link="/derp"
+          action={() => ({})}
+        />,
+      );
+
+      expect(queryIcon("pencil")).not.toBeInTheDocument();
+      expect(screen.queryByText("A pencil icon")).not.toBeInTheDocument();
+      expect(screen.queryByTestId("entity-menu-link")).not.toBeInTheDocument();
+    });
+
+    it("should not render if neither action nor link props are present", () => {
+      render(<EntityMenuItem title="A pencil icon" icon="pencil" />);
+
+      expect(queryIcon("pencil")).not.toBeInTheDocument();
+      expect(screen.queryByText("A pencil icon")).not.toBeInTheDocument();
+      expect(screen.queryByTestId("entity-menu-link")).not.toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/metabase/components/EntityMenuItem/EntityMenuItem.unit.spec.js
+++ b/frontend/src/metabase/components/EntityMenuItem/EntityMenuItem.unit.spec.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { fireEvent, render, screen, getIcon, queryIcon } from "__support__/ui";
+import { fireEvent, render, screen, getIcon } from "__support__/ui";
 
 import EntityMenuItem from "metabase/components/EntityMenuItem";
 
@@ -44,25 +44,27 @@ describe("EntityMenuItem", () => {
 
     it("should not render if both action and link props are present", () => {
       render(
-        <EntityMenuItem
-          title="A pencil icon"
-          icon="pencil"
-          link="/derp"
-          action={() => ({})}
-        />,
+        <div data-testid="container">
+          <EntityMenuItem
+            title="A pencil icon"
+            icon="pencil"
+            link="/derp"
+            action={() => ({})}
+          />
+        </div>,
       );
 
-      expect(queryIcon("pencil")).not.toBeInTheDocument();
-      expect(screen.queryByText("A pencil icon")).not.toBeInTheDocument();
-      expect(screen.queryByTestId("entity-menu-link")).not.toBeInTheDocument();
+      expect(screen.getByTestId("container")).toBeEmptyDOMElement();
     });
 
     it("should not render if neither action nor link props are present", () => {
-      render(<EntityMenuItem title="A pencil icon" icon="pencil" />);
+      render(
+        <div data-testid="container">
+          <EntityMenuItem title="A pencil icon" icon="pencil" />
+        </div>,
+      );
 
-      expect(queryIcon("pencil")).not.toBeInTheDocument();
-      expect(screen.queryByText("A pencil icon")).not.toBeInTheDocument();
-      expect(screen.queryByTestId("entity-menu-link")).not.toBeInTheDocument();
+      expect(screen.getByTestId("container")).toBeEmptyDOMElement();
     });
   });
 });


### PR DESCRIPTION
This PR slightly changes the logic of the `EntityMenuItem` component so that it doesn't return an empty `div` for a scenario that should be no-op.

It then adds two new unit tests that both make sure we don't render anything (return `null`) in cases where:
- both `action` and `link` props are present
- neither `action` nor `link` props are present

**It bumps this particular component's coverage from 68.75% to 93.75%.**

---
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30615)
<!-- Reviewable:end -->
