### PR TITLE
Use `createMockMetadata` for MLv2 test helpers

### DIFF
--- a/frontend/src/metabase-lib/order_by.unit.spec.ts
+++ b/frontend/src/metabase-lib/order_by.unit.spec.ts
@@ -39,7 +39,7 @@ describe("order by", () => {
           name: "TITLE",
           displayName: "Title",
           effectiveType: "type/Text",
-          semanticType: "type/Category",
+          semanticType: "type/Title",
           isCalculated: false,
           isFromJoin: false,
           isFromPreviousStage: false,

--- a/frontend/src/metabase-lib/test-helpers.ts
+++ b/frontend/src/metabase-lib/test-helpers.ts
@@ -1,12 +1,17 @@
 /* istanbul ignore file */
 
-import {
-  SAMPLE_DATABASE,
-  metadata as SAMPLE_METADATA,
-} from "__support__/sample_database_fixture";
+import { createMockMetadata } from "__support__/metadata";
 import type { DatabaseId, DatasetQuery } from "metabase-types/api";
+import {
+  createSampleDatabase,
+  ORDERS_ID,
+} from "metabase-types/api/mocks/presets";
 import type Metadata from "./metadata/Metadata";
 import * as ML from "./v2";
+
+const SAMPLE_DATABASE = createSampleDatabase();
+
+const SAMPLE_METADATA = createMockMetadata({ databases: [SAMPLE_DATABASE] });
 
 export { SAMPLE_DATABASE, SAMPLE_METADATA };
 
@@ -26,7 +31,7 @@ export const DEFAULT_QUERY: DatasetQuery = {
   database: SAMPLE_DATABASE.id,
   type: "query",
   query: {
-    "source-table": SAMPLE_DATABASE.ORDERS.id,
+    "source-table": ORDERS_ID,
   },
 };
 


### PR DESCRIPTION
Switches MLv2 test helpers from deprecated sample database fixture to a combo of `createMockMetadata` and `createSampleDatabase`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30617)
<!-- Reviewable:end -->
