### PR TITLE
Fix a typo in the datetime-diff feature flag for postgres DB

### DIFF
--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -47,7 +47,7 @@
 
 (driver/register! :postgres, :parent :sql-jdbc)
 
-(doseq [[feature supported?] {:datetime-dff true
+(doseq [[feature supported?] {:datetime-diff true
                               :persist-models true
                               :convert-timezone true
                               :now true}]


### PR DESCRIPTION
Fixing a typo after https://github.com/metabase/metabase/pull/29516/

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30619)
<!-- Reviewable:end -->
