### PR TITLE
Add optional message to error boundaries

### DIFF
--- a/frontend/src/metabase/ErrorBoundary.tsx
+++ b/frontend/src/metabase/ErrorBoundary.tsx
@@ -6,6 +6,7 @@ export default class ErrorBoundary extends React.Component<
   {
     onError?: (errorInfo: ErrorInfo) => void;
     errorComponent?: ComponentType;
+    message?: string;
   },
   {
     hasError: boolean;
@@ -38,7 +39,7 @@ export default class ErrorBoundary extends React.Component<
       const ErrorComponent = this.props.errorComponent
         ? this.props.errorComponent
         : SmallGenericError;
-      return <ErrorComponent />;
+      return <ErrorComponent message={this.props.message} />;
     }
 
     return this.props.children;


### PR DESCRIPTION
### Description

background: https://github.com/metabase/metabase/pull/30587#pullrequestreview-1415336800

Adds optional `message` prop to error boundaries - allows devs to specify a more detailed error message on a case-by-case basis

**Generic Message**
``` 
<ErrorBoundary>
```
![image](https://user-images.githubusercontent.com/22608765/236548864-2a793848-8e99-4eec-96a7-cb5065523f0f.png)

**Message Pass-through**

``` 
<ErrorBoundary message="Somethings gone wrong in the header">
```
![image](https://user-images.githubusercontent.com/22608765/236549015-0fdaaed9-8fdf-45d4-8486-b3fc366a403c.png)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30620)
<!-- Reviewable:end -->
