### PR TITLE
Ignore Twitter links in markdown link checker

### DIFF
--- a/.mlc_config.json
+++ b/.mlc_config.json
@@ -5,6 +5,9 @@
     },
     {
       "pattern": "^https://docs.cypress.io/"
+    },
+    {
+      "pattern": "^https://twitter.com/"
     }
   ],
   "timeout": "180s",


### PR DESCRIPTION
The most recent failure:
https://github.com/metabase/metabase/actions/runs/4917971573/jobs/8783874484?pr=30318

Rerun doesn't seem to help.
Twitter might be blocking automated visits.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30621)
<!-- Reviewable:end -->
