### PR TITLE
Add styling to dropzone overlay

### DIFF
--- a/frontend/src/metabase/collections/components/UploadOverlay/UploadOverlay.styled.tsx
+++ b/frontend/src/metabase/collections/components/UploadOverlay/UploadOverlay.styled.tsx
@@ -1,5 +1,5 @@
 import styled from "@emotion/styled";
-import { color, alpha } from "metabase/lib/colors";
+import { color } from "metabase/lib/colors";
 
 export const DragOverlay = styled.div<{ isDragActive: boolean }>`
   position: absolute;
@@ -7,15 +7,24 @@ export const DragOverlay = styled.div<{ isDragActive: boolean }>`
   left: 0;
   right: 0;
   bottom: 0;
-  z-index: 1000;
-  background-color: ${alpha("white", 0.8)};
-  padding: 2rem;
-  font-size: 2rem;
-  color: ${color("text-dark")};
-  opacity: ${props => (props.isDragActive ? 1 : 0)};
-  transition: opacity 0.2s;
+  z-index: 1;
   display: flex;
-  align-items: center;
+  flex-direction: column;
   justify-content: center;
+  align-items: center;
+  gap: 1rem;
+
+  background-color: ${color("brand-lighter")};
+  opacity: ${props => (props.isDragActive ? 0.9 : 0)};
+  transition: opacity 0.2s;
+  border: 1px dashed ${color("brand")};
+  border-radius: 0.5rem;
+  margin: 0.5rem 4%;
+  padding: 4rem;
+
+  color: ${color("brand")};
+  font-size: 1.125rem;
+  font-weight: bold;
+
   pointer-events: none;
 `;

--- a/frontend/src/metabase/collections/components/UploadOverlay/UploadOverlay.tsx
+++ b/frontend/src/metabase/collections/components/UploadOverlay/UploadOverlay.tsx
@@ -1,16 +1,21 @@
 import React from "react";
 import { t } from "ttag";
 
+import type { Collection } from "metabase-types/api";
+import Icon from "metabase/components/Icon";
 import { DragOverlay } from "./UploadOverlay.styled";
 
 export default function UploadOverlay({
   isDragActive,
+  collection,
 }: {
   isDragActive: boolean;
+  collection: Collection;
 }) {
   return (
     <DragOverlay isDragActive={isDragActive}>
-      {t`Drop a CSV file to upload to this collection`}
+      <Icon name="arrow_up" />
+      <div>{t`Drop here to upload to ${collection.name}`}</div>
     </DragOverlay>
   );
 }

--- a/frontend/src/metabase/collections/containers/CollectionContent.jsx
+++ b/frontend/src/metabase/collections/containers/CollectionContent.jsx
@@ -203,7 +203,7 @@ function CollectionContent({
 
   const canUpload = uploadsEnabled && collection.can_write;
 
-  const rootProps = canUpload ? getRootProps() : {};
+  const dropzoneProps = canUpload ? getRootProps() : {};
 
   const unpinnedQuery = {
     collection: collectionId,
@@ -232,8 +232,13 @@ function CollectionContent({
         const hasPinnedItems = pinnedItems.length > 0;
 
         return (
-          <CollectionRoot {...rootProps}>
-            {canUpload && <UploadOverlay isDragActive={isDragActive} />}
+          <CollectionRoot {...dropzoneProps}>
+            {canUpload && (
+              <UploadOverlay
+                isDragActive={isDragActive}
+                collection={collection}
+              />
+            )}
             <CollectionMain>
               <Header
                 collection={collection}

--- a/frontend/src/metabase/collections/containers/CollectionContent.styled.tsx
+++ b/frontend/src/metabase/collections/containers/CollectionContent.styled.tsx
@@ -1,14 +1,16 @@
 import styled from "@emotion/styled";
 
 export const CollectionRoot = styled.div`
-  padding-top: 1rem;
-  min-height: 100%;
+  height: 100%;
+  overflow: hidden;
   position: relative;
 `;
 
 export const CollectionMain = styled.div`
   margin: 0 auto;
-  width: 90%;
+  overflow-y: auto;
+  max-height: 100%;
+  padding: 1rem 5%;
 `;
 
 export interface CollectionTableProps {

--- a/frontend/src/metabase/lib/colors/palette.ts
+++ b/frontend/src/metabase/lib/colors/palette.ts
@@ -59,6 +59,7 @@ const aliases: Record<string, (palette: ColorPalette) => string> = {
   pulse: palette => color("accent4", palette),
 
   "brand-light": palette => lighten(color("brand", palette), 0.532),
+  "brand-lighter": palette => lighten(color("brand", palette), 0.598), // #EEF6FC for brand
   focus: palette => getFocusColor("brand", palette),
 
   "accent0-light": palette => tint(color(`accent0`, palette)),


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/30563

### Description

- Adds styling to the dropzone overlay component
- reorganizes some of the component tree in the collection content component to get an element with a consistent height to overlay the dropzone onto
- The implementation differs from the design in that the design did not have the dropzone overlaid on the collection title - this would be prohibitively complex since the title can have any number of different heights and scroll positions. ([see discussion](https://metaboat.slack.com/archives/C04S696LRUM/p1683553725430539?thread_ts=1680019489.552709&cid=C04S696LRUM))

![dropZoneStyle](https://user-images.githubusercontent.com/30528226/236917137-79ca4ae9-fd88-46dd-8c5b-8e2c61b51431.gif)


### How to verify

- Enable uploads in metabase admin settings
- Navigate to a collection
- Drag a file into the collection

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30624)
<!-- Reviewable:end -->
