### PR TITLE
docs - update alert docs

### DIFF
--- a/docs/permissions/notifications.md
+++ b/docs/permissions/notifications.md
@@ -17,7 +17,7 @@ Notification **recipients** can see whatever the notification **creator** can se
 From [Account settings](../people-and-groups/account-settings.md), all accounts can:
 
 - Create [alerts](../questions/sharing/alerts.md) and [dashboard subscriptions](../dashboards/subscriptions.md#setting-up-a-dashboard-subscription).
-- Add new recipients to alerts and subscriptions that they own.
+- Add new recipients to dashboard subscriptions that they own. Non-admins can only add themselves to alerts.
 - Unsubscribe from any alert or subscription.
 
 When a notification creator adds new recipients to an alert or subscription, Metabase will display data to the recipients using the **creator's** [data permissions](../permissions/data.md) and [collection permissions](../permissions/collections.md).

--- a/docs/questions/sharing/alerts.md
+++ b/docs/questions/sharing/alerts.md
@@ -75,7 +75,6 @@ Admins get special privileges with alerts.
 ### Everyone
 
 - Everyone can edit alerts that they've set up (but not alerts set up by other people).
-- Everyone can add any Metabase user account, email address, or even a Slack channel as a recipient of an alert that they created (but not alerts created by others).
 - Everyone can view and unsubscribe from all alerts they receive by clicking on the **gear** icon in the upper right and navigating to **Account settings** > **Notifications**.
 
 ## Avoid changing the name of the alerted channel in Slack


### PR DESCRIPTION
Walks back what nonadmins can do with alerts. Only admins can add other people to alerts.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30625)
<!-- Reviewable:end -->
