### PR TITLE
Expand the test coverage for `ListItem` component

### DIFF
--- a/frontend/src/metabase/components/ListItem/ListItem.unit.spec.js
+++ b/frontend/src/metabase/components/ListItem/ListItem.unit.spec.js
@@ -1,0 +1,61 @@
+import React from "react";
+import { Route } from "react-router";
+import { screen, getIcon, renderWithProviders } from "__support__/ui";
+import ListItem from "./ListItem";
+
+const ITEM_NAME = "Table Foo";
+const ITEM_DESCRIPTION = "Nice table description.";
+
+function setup({ name, index = 0, ...opts }) {
+  return renderWithProviders(
+    <Route
+      path="/"
+      component={() => <ListItem name={name} index={index} {...opts} />}
+    />,
+    { withRouter: true },
+  );
+}
+
+describe("ListItem", () => {
+  it("should render", () => {
+    setup({
+      name: ITEM_NAME,
+      description: ITEM_DESCRIPTION,
+      icon: "table",
+      url: "/foo",
+    });
+
+    expect(screen.getByText(ITEM_NAME)).toBeInTheDocument();
+    expect(screen.getByText(ITEM_DESCRIPTION)).toBeInTheDocument();
+    expect(getIcon("table")).toBeInTheDocument();
+    expect(screen.getByRole("link")).toHaveProperty(
+      "href",
+      "http://localhost/foo",
+    );
+  });
+
+  it("should render with just the name", () => {
+    setup({ name: ITEM_NAME });
+    expect(screen.getByText(ITEM_NAME)).toBeInTheDocument();
+  });
+
+  it("should display the placeholder if there's no description", () => {
+    setup({ name: ITEM_NAME, placeholder: "Placeholder text" });
+
+    expect(screen.getByText(ITEM_NAME)).toBeInTheDocument();
+    expect(screen.getByText("Placeholder text")).toBeInTheDocument();
+  });
+
+  it("should display the description and omit the placeholder if both are present", () => {
+    setup({
+      name: ITEM_NAME,
+      description: ITEM_DESCRIPTION,
+      placeholder: "Placeholder text",
+      width: "200px",
+    });
+
+    expect(screen.getByText(ITEM_NAME)).toBeInTheDocument();
+    expect(screen.getByText(ITEM_DESCRIPTION)).toBeInTheDocument();
+    expect(screen.queryByText("Placeholder text")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/metabase/components/ListItem/ListItem.unit.spec.js
+++ b/frontend/src/metabase/components/ListItem/ListItem.unit.spec.js
@@ -51,7 +51,6 @@ describe("ListItem", () => {
       name: ITEM_NAME,
       description: ITEM_DESCRIPTION,
       placeholder: "Placeholder text",
-      width: "200px",
     });
 
     expect(screen.getByText(ITEM_NAME)).toBeInTheDocument();


### PR DESCRIPTION
The current coverage for this component is 33%.
![image](https://github.com/metabase/metabase/assets/31325167/7a3eeac9-abce-42f7-b897-f46862a5e630)

All lines should be covered after this PR.
![image](https://github.com/metabase/metabase/assets/31325167/54e1ce7f-b2b6-4922-b79e-43de5622fa8a)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30635)
<!-- Reviewable:end -->
