### PR TITLE
Ignore provided metadata on new cards

### DIFF
--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -246,11 +246,6 @@
             valid-metadata?)
        ;; only sent valid metadata in the edit. Metadata might be the same, might be different. We save in either case
        (and (nil? query)
-            valid-metadata?)
-
-       ;; copying card and reusing existing metadata
-       (and (nil? original-query)
-            query
             valid-metadata?))
       (do
         (log/debug (trs "Reusing provided metadata"))

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -543,6 +543,53 @@
                                            "card"
                                            (assoc card :result_metadata []))))))))
 
+(deftest save-new-card-with-result-metadata-test
+  (mt/with-model-cleanup [:model/Card]
+    (testing "we should ignore result_metadata on new Cards"
+      (let [saved-query (mt/mbql-query venues {:fields [$id $name]})
+            old-metadata (->> (qp/process-query (mt/mbql-query venues))
+                              :data
+                              :results_metadata
+                              :columns
+                              (mapv #(m/update-existing % :display_name u/upper-case-en)))
+            expected-metadata (->> (qp/process-query saved-query)
+                                   :data
+                                   :results_metadata
+                                   :columns
+                                   (mapv #(select-keys % #{:id :name :display_name})))
+            {card-id :id} (mt/user-http-request :rasta
+                                                :post
+                                                200
+                                                "card"
+                                                (merge (mt/with-temp-defaults :model/Card)
+                                                       {:dataset_query saved-query
+                                                        :result_metadata old-metadata}))]
+        (is (=? {:result_metadata expected-metadata}
+                (mt/user-http-request :rasta :get 200 (str "card/" card-id))))))
+    (testing "we should incorporate result_metadata on new Models"
+      (let [saved-query (mt/mbql-query venues {:fields [$id $name]})
+            old-metadata (->> (qp/process-query (mt/mbql-query venues))
+                             :data
+                             :results_metadata
+                             :columns
+                             (mapv #(m/update-existing % :display_name u/upper-case-en)))
+            expected-metadata (->> (qp/process-query saved-query)
+                                   :data
+                                   :results_metadata
+                                   :columns
+                                   (mapv #(-> (select-keys % #{:id :name :display_name})
+                                              (m/update-existing :display_name u/upper-case-en))))
+            {card-id :id} (mt/user-http-request :rasta
+                                                :post
+                                                200
+                                                "card"
+                                                (merge (mt/with-temp-defaults :model/Card)
+                                                       {:dataset true
+                                                        :dataset_query saved-query
+                                                        :result_metadata old-metadata}))]
+        (is (=? {:result_metadata expected-metadata}
+                (mt/user-http-request :rasta :get 200 (str "card/" card-id))))))))
+
 (deftest cache-ttl-save
   (testing "POST /api/card/:id"
     (testing "saving cache ttl by post actually saves it"


### PR DESCRIPTION
Fixes #30610

Removed an optimization that was put in place for copying cards that trusted the front end to pass in the correct `result_metadata`. Now, on new cards we ignore the passed in metadata and recalculate fresh. On models, however, we recalculate fresh metadata and combine it with the provided metadata.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30640)
<!-- Reviewable:end -->
