### PR TITLE
Refactor `ListItem` component

### DIFF
--- a/frontend/src/metabase/components/ListItem/ListItem.jsx
+++ b/frontend/src/metabase/components/ListItem/ListItem.jsx
@@ -9,7 +9,7 @@ import S from "metabase/components/List/List.css";
 import Icon from "metabase/components/Icon";
 
 //TODO: extend this to support functionality required for questions
-const ListItem = ({ index, name, description, placeholder, url, icon }) => (
+const ListItem = ({ name, description, placeholder, url, icon }) => (
   <Link to={url} className="text-brand-hover">
     <Card hoverable className="mb2 p3 bg-white rounded bordered">
       <div className={cx(S.item)}>
@@ -39,7 +39,6 @@ const ListItem = ({ index, name, description, placeholder, url, icon }) => (
 
 ListItem.propTypes = {
   name: PropTypes.string.isRequired,
-  index: PropTypes.number.isRequired,
   url: PropTypes.string,
   description: PropTypes.string,
   placeholder: PropTypes.string,

--- a/frontend/src/metabase/components/ListItem/ListItem.jsx
+++ b/frontend/src/metabase/components/ListItem/ListItem.jsx
@@ -44,8 +44,6 @@ ListItem.propTypes = {
   description: PropTypes.string,
   placeholder: PropTypes.string,
   icon: PropTypes.string,
-  isEditing: PropTypes.bool,
-  field: PropTypes.object,
 };
 
 export default React.memo(ListItem);

--- a/frontend/src/metabase/components/ListItem/ListItem.jsx
+++ b/frontend/src/metabase/components/ListItem/ListItem.jsx
@@ -8,7 +8,6 @@ import Card from "metabase/components/Card";
 import S from "metabase/components/List/List.css";
 import Icon from "metabase/components/Icon";
 
-//TODO: extend this to support functionality required for questions
 const ListItem = ({ name, description, placeholder, url, icon }) => (
   <Link to={url} className="text-brand-hover">
     <Card hoverable className="mb2 p3 bg-white rounded bordered">

--- a/frontend/src/metabase/components/ListItem/ListItem.jsx
+++ b/frontend/src/metabase/components/ListItem/ListItem.jsx
@@ -9,31 +9,33 @@ import S from "metabase/components/List/List.css";
 import Icon from "metabase/components/Icon";
 
 const ListItem = ({ name, description, placeholder, url, icon }) => (
-  <Link to={url} className="text-brand-hover">
-    <Card hoverable className="mb2 p3 bg-white rounded bordered">
-      <div className={cx(S.item)}>
-        <div className={S.itemIcons}>
-          {icon && <Icon className={S.chartIcon} name={icon} size={16} />}
-        </div>
-        <div className={S.itemBody}>
-          <div className={S.itemTitle}>
-            <Ellipsified
-              className={S.itemName}
-              tooltip={name}
-              tooltipMaxWidth="100%"
-            >
-              <h3>{name}</h3>
-            </Ellipsified>
+  <li className="relative">
+    <Link to={url} className="text-brand-hover">
+      <Card hoverable className="mb2 p3 bg-white rounded bordered">
+        <div className={cx(S.item)}>
+          <div className={S.itemIcons}>
+            {icon && <Icon className={S.chartIcon} name={icon} size={16} />}
           </div>
-          {(description || placeholder) && (
-            <div className={cx(S.itemSubtitle)}>
-              {description || placeholder}
+          <div className={S.itemBody}>
+            <div className={S.itemTitle}>
+              <Ellipsified
+                className={S.itemName}
+                tooltip={name}
+                tooltipMaxWidth="100%"
+              >
+                <h3>{name}</h3>
+              </Ellipsified>
             </div>
-          )}
+            {(description || placeholder) && (
+              <div className={cx(S.itemSubtitle)}>
+                {description || placeholder}
+              </div>
+            )}
+          </div>
         </div>
-      </div>
-    </Card>
-  </Link>
+      </Card>
+    </Link>
+  </li>
 );
 
 ListItem.propTypes = {

--- a/frontend/src/metabase/components/ListItem/ListItem.unit.spec.js
+++ b/frontend/src/metabase/components/ListItem/ListItem.unit.spec.js
@@ -6,12 +6,9 @@ import ListItem from "./ListItem";
 const ITEM_NAME = "Table Foo";
 const ITEM_DESCRIPTION = "Nice table description.";
 
-function setup({ name, index = 0, ...opts }) {
+function setup({ name, ...opts }) {
   return renderWithProviders(
-    <Route
-      path="/"
-      component={() => <ListItem name={name} index={index} {...opts} />}
-    />,
+    <Route path="/" component={() => <ListItem name={name} {...opts} />} />,
     { withRouter: true },
   );
 }

--- a/frontend/src/metabase/reference/databases/DatabaseList.jsx
+++ b/frontend/src/metabase/reference/databases/DatabaseList.jsx
@@ -62,7 +62,6 @@ class DatabaseList extends Component {
                   {databases.map(database => (
                     <li className="relative" key={database.id}>
                       <ListItem
-                        id={database.id}
                         name={database.name}
                         description={database.description}
                         url={`/reference/databases/${database.id}`}

--- a/frontend/src/metabase/reference/databases/DatabaseList.jsx
+++ b/frontend/src/metabase/reference/databases/DatabaseList.jsx
@@ -59,11 +59,10 @@ class DatabaseList extends Component {
             Object.keys(entities).length > 0 ? (
               <div className="wrapper">
                 <List>
-                  {databases.map((database, index) => (
+                  {databases.map(database => (
                     <li className="relative" key={database.id}>
                       <ListItem
                         id={database.id}
-                        index={index}
                         name={database.name}
                         description={database.description}
                         url={`/reference/databases/${database.id}`}

--- a/frontend/src/metabase/reference/databases/DatabaseList.jsx
+++ b/frontend/src/metabase/reference/databases/DatabaseList.jsx
@@ -60,14 +60,13 @@ class DatabaseList extends Component {
               <div className="wrapper">
                 <List>
                   {databases.map(database => (
-                    <li className="relative" key={database.id}>
-                      <ListItem
-                        name={database.name}
-                        description={database.description}
-                        url={`/reference/databases/${database.id}`}
-                        icon="database"
-                      />
-                    </li>
+                    <ListItem
+                      key={database.id}
+                      name={database.name}
+                      description={database.description}
+                      url={`/reference/databases/${database.id}`}
+                      icon="database"
+                    />
                   ))}
                 </List>
               </div>

--- a/frontend/src/metabase/reference/databases/TableList.jsx
+++ b/frontend/src/metabase/reference/databases/TableList.jsx
@@ -44,7 +44,6 @@ const mapDispatchToProps = {
 const createListItem = entity => (
   <li className="relative" key={entity.id}>
     <ListItem
-      id={entity.id}
       name={entity.display_name || entity.name}
       description={entity.description}
       url={`/reference/databases/${entity.db_id}/tables/${entity.id}`}

--- a/frontend/src/metabase/reference/databases/TableList.jsx
+++ b/frontend/src/metabase/reference/databases/TableList.jsx
@@ -41,11 +41,10 @@ const mapDispatchToProps = {
   ...metadataActions,
 };
 
-const createListItem = (entity, index) => (
+const createListItem = entity => (
   <li className="relative" key={entity.id}>
     <ListItem
       id={entity.id}
-      index={index}
       name={entity.display_name || entity.name}
       description={entity.description}
       url={`/reference/databases/${entity.db_id}/tables/${entity.id}`}

--- a/frontend/src/metabase/reference/databases/TableList.jsx
+++ b/frontend/src/metabase/reference/databases/TableList.jsx
@@ -42,14 +42,13 @@ const mapDispatchToProps = {
 };
 
 const createListItem = entity => (
-  <li className="relative" key={entity.id}>
-    <ListItem
-      name={entity.display_name || entity.name}
-      description={entity.description}
-      url={`/reference/databases/${entity.db_id}/tables/${entity.id}`}
-      icon="table2"
-    />
-  </li>
+  <ListItem
+    key={entity.id}
+    name={entity.display_name || entity.name}
+    description={entity.description}
+    url={`/reference/databases/${entity.db_id}/tables/${entity.id}`}
+    icon="table2"
+  />
 );
 
 const createSchemaSeparator = table => (

--- a/frontend/src/metabase/reference/databases/TableQuestions.jsx
+++ b/frontend/src/metabase/reference/databases/TableQuestions.jsx
@@ -84,7 +84,6 @@ class TableQuestions extends Component {
                       entity.name && (
                         <li className="relative" key={entity.id}>
                           <ListItem
-                            id={entity.id}
                             name={entity.display_name || entity.name}
                             description={t`Created ${moment(
                               entity.created_at,

--- a/frontend/src/metabase/reference/databases/TableQuestions.jsx
+++ b/frontend/src/metabase/reference/databases/TableQuestions.jsx
@@ -82,16 +82,15 @@ class TableQuestions extends Component {
                       entity &&
                       entity.id &&
                       entity.name && (
-                        <li className="relative" key={entity.id}>
-                          <ListItem
-                            name={entity.display_name || entity.name}
-                            description={t`Created ${moment(
-                              entity.created_at,
-                            ).fromNow()} by ${entity.creator.common_name}`}
-                            url={Urls.question(entity)}
-                            icon={visualizations.get(entity.display).iconName}
-                          />
-                        </li>
+                        <ListItem
+                          key={entity.id}
+                          name={entity.display_name || entity.name}
+                          description={t`Created ${moment(
+                            entity.created_at,
+                          ).fromNow()} by ${entity.creator.common_name}`}
+                          url={Urls.question(entity)}
+                          icon={visualizations.get(entity.display).iconName}
+                        />
                       ),
                   )}
                 </List>

--- a/frontend/src/metabase/reference/databases/TableQuestions.jsx
+++ b/frontend/src/metabase/reference/databases/TableQuestions.jsx
@@ -78,14 +78,13 @@ class TableQuestions extends Component {
               <div className="wrapper wrapper--trim">
                 <List>
                   {Object.values(entities).map(
-                    (entity, index) =>
+                    entity =>
                       entity &&
                       entity.id &&
                       entity.name && (
                         <li className="relative" key={entity.id}>
                           <ListItem
                             id={entity.id}
-                            index={index}
                             name={entity.display_name || entity.name}
                             description={t`Created ${moment(
                               entity.created_at,

--- a/frontend/src/metabase/reference/metrics/MetricList.jsx
+++ b/frontend/src/metabase/reference/metrics/MetricList.jsx
@@ -63,14 +63,13 @@ class MetricList extends Component {
               <div className="wrapper wrapper--trim">
                 <List>
                   {Object.values(entities).map(
-                    (entity, index) =>
+                    entity =>
                       entity &&
                       entity.id &&
                       entity.name && (
                         <li className="relative" key={entity.id}>
                           <ListItem
                             id={entity.id}
-                            index={index}
                             name={entity.display_name || entity.name}
                             description={entity.description}
                             url={`/reference/metrics/${entity.id}`}

--- a/frontend/src/metabase/reference/metrics/MetricList.jsx
+++ b/frontend/src/metabase/reference/metrics/MetricList.jsx
@@ -69,7 +69,6 @@ class MetricList extends Component {
                       entity.name && (
                         <li className="relative" key={entity.id}>
                           <ListItem
-                            id={entity.id}
                             name={entity.display_name || entity.name}
                             description={entity.description}
                             url={`/reference/metrics/${entity.id}`}

--- a/frontend/src/metabase/reference/metrics/MetricList.jsx
+++ b/frontend/src/metabase/reference/metrics/MetricList.jsx
@@ -67,14 +67,13 @@ class MetricList extends Component {
                       entity &&
                       entity.id &&
                       entity.name && (
-                        <li className="relative" key={entity.id}>
-                          <ListItem
-                            name={entity.display_name || entity.name}
-                            description={entity.description}
-                            url={`/reference/metrics/${entity.id}`}
-                            icon="ruler"
-                          />
-                        </li>
+                        <ListItem
+                          key={entity.id}
+                          name={entity.display_name || entity.name}
+                          description={entity.description}
+                          url={`/reference/metrics/${entity.id}`}
+                          icon="ruler"
+                        />
                       ),
                   )}
                 </List>

--- a/frontend/src/metabase/reference/metrics/MetricQuestions.jsx
+++ b/frontend/src/metabase/reference/metrics/MetricQuestions.jsx
@@ -82,14 +82,13 @@ class MetricQuestions extends Component {
               <div className="wrapper wrapper--trim">
                 <List>
                   {Object.values(entities).map(
-                    (entity, index) =>
+                    entity =>
                       entity &&
                       entity.id &&
                       entity.name && (
                         <li className="relative" key={entity.id}>
                           <ListItem
                             id={entity.id}
-                            index={index}
                             name={entity.display_name || entity.name}
                             description={t`Created ${moment(
                               entity.created_at,

--- a/frontend/src/metabase/reference/metrics/MetricQuestions.jsx
+++ b/frontend/src/metabase/reference/metrics/MetricQuestions.jsx
@@ -86,16 +86,15 @@ class MetricQuestions extends Component {
                       entity &&
                       entity.id &&
                       entity.name && (
-                        <li className="relative" key={entity.id}>
-                          <ListItem
-                            name={entity.display_name || entity.name}
-                            description={t`Created ${moment(
-                              entity.created_at,
-                            ).fromNow()} by ${entity.creator.common_name}`}
-                            url={Urls.question(entity)}
-                            icon={visualizations.get(entity.display).iconName}
-                          />
-                        </li>
+                        <ListItem
+                          key={entity.id}
+                          name={entity.display_name || entity.name}
+                          description={t`Created ${moment(
+                            entity.created_at,
+                          ).fromNow()} by ${entity.creator.common_name}`}
+                          url={Urls.question(entity)}
+                          icon={visualizations.get(entity.display).iconName}
+                        />
                       ),
                   )}
                 </List>

--- a/frontend/src/metabase/reference/metrics/MetricQuestions.jsx
+++ b/frontend/src/metabase/reference/metrics/MetricQuestions.jsx
@@ -88,7 +88,6 @@ class MetricQuestions extends Component {
                       entity.name && (
                         <li className="relative" key={entity.id}>
                           <ListItem
-                            id={entity.id}
                             name={entity.display_name || entity.name}
                             description={t`Created ${moment(
                               entity.created_at,

--- a/frontend/src/metabase/reference/segments/SegmentList.jsx
+++ b/frontend/src/metabase/reference/segments/SegmentList.jsx
@@ -67,14 +67,13 @@ class SegmentList extends Component {
                       entity &&
                       entity.id &&
                       entity.name && (
-                        <li className="relative" key={entity.id}>
-                          <ListItem
-                            name={entity.display_name || entity.name}
-                            description={entity.description}
-                            url={`/reference/segments/${entity.id}`}
-                            icon="segment"
-                          />
-                        </li>
+                        <ListItem
+                          key={entity.id}
+                          name={entity.display_name || entity.name}
+                          description={entity.description}
+                          url={`/reference/segments/${entity.id}`}
+                          icon="segment"
+                        />
                       ),
                   )}
                 </List>

--- a/frontend/src/metabase/reference/segments/SegmentList.jsx
+++ b/frontend/src/metabase/reference/segments/SegmentList.jsx
@@ -69,7 +69,6 @@ class SegmentList extends Component {
                       entity.name && (
                         <li className="relative" key={entity.id}>
                           <ListItem
-                            id={entity.id}
                             name={entity.display_name || entity.name}
                             description={entity.description}
                             url={`/reference/segments/${entity.id}`}

--- a/frontend/src/metabase/reference/segments/SegmentList.jsx
+++ b/frontend/src/metabase/reference/segments/SegmentList.jsx
@@ -63,14 +63,13 @@ class SegmentList extends Component {
               <div className="wrapper wrapper--trim">
                 <List>
                   {Object.values(entities).map(
-                    (entity, index) =>
+                    entity =>
                       entity &&
                       entity.id &&
                       entity.name && (
                         <li className="relative" key={entity.id}>
                           <ListItem
                             id={entity.id}
-                            index={index}
                             name={entity.display_name || entity.name}
                             description={entity.description}
                             url={`/reference/segments/${entity.id}`}

--- a/frontend/src/metabase/reference/segments/SegmentQuestions.jsx
+++ b/frontend/src/metabase/reference/segments/SegmentQuestions.jsx
@@ -85,16 +85,15 @@ class SegmentQuestions extends Component {
                       entity &&
                       entity.id &&
                       entity.name && (
-                        <li className="relative" key={entity.id}>
-                          <ListItem
-                            name={entity.display_name || entity.name}
-                            description={t`Created ${moment(
-                              entity.created_at,
-                            ).fromNow()} by ${entity.creator.common_name}`}
-                            url={Urls.question(entity)}
-                            icon={visualizations.get(entity.display).iconName}
-                          />
-                        </li>
+                        <ListItem
+                          key={entity.id}
+                          name={entity.display_name || entity.name}
+                          description={t`Created ${moment(
+                            entity.created_at,
+                          ).fromNow()} by ${entity.creator.common_name}`}
+                          url={Urls.question(entity)}
+                          icon={visualizations.get(entity.display).iconName}
+                        />
                       ),
                   )}
                 </List>

--- a/frontend/src/metabase/reference/segments/SegmentQuestions.jsx
+++ b/frontend/src/metabase/reference/segments/SegmentQuestions.jsx
@@ -87,7 +87,6 @@ class SegmentQuestions extends Component {
                       entity.name && (
                         <li className="relative" key={entity.id}>
                           <ListItem
-                            id={entity.id}
                             name={entity.display_name || entity.name}
                             description={t`Created ${moment(
                               entity.created_at,

--- a/frontend/src/metabase/reference/segments/SegmentQuestions.jsx
+++ b/frontend/src/metabase/reference/segments/SegmentQuestions.jsx
@@ -81,14 +81,13 @@ class SegmentQuestions extends Component {
               <div className="wrapper wrapper--trim">
                 <List>
                   {Object.values(entities).map(
-                    (entity, index) =>
+                    entity =>
                       entity &&
                       entity.id &&
                       entity.name && (
                         <li className="relative" key={entity.id}>
                           <ListItem
                             id={entity.id}
-                            index={index}
                             name={entity.display_name || entity.name}
                             description={t`Created ${moment(
                               entity.created_at,


### PR DESCRIPTION
After adding test coverage for the `ListItem` component in https://github.com/metabase/metabase/pull/30635, I felt it's now safe to refactor it.

This PR removes some unused and obsolete props to reduce the confusion:
- `index`
- `isEditing` and
- `field`

It then removes the `id` prop that was passed down to this component from the parent but didn't have literally any meaning in this context.

It finally slurps the `li` HTML element inside the `ListItem` component, which prevents the weird practice of defining the `li` in the parent and then rendering its contents with the `ListItem`. Basically this:
```javascript
<Parent>
  <li>
    <ListItem />
  </li>
</Parent>
```

now becomes this
```javascript
<Parent>
  <ListItem />
</Parent>
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30650)
<!-- Reviewable:end -->
