### PR TITLE
Fix export collection selection

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/serialization/cmd.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/cmd.clj
@@ -186,8 +186,10 @@
   (mdb/setup-db!)
   (t2/select User) ;; TODO -- why??? [editor's note: this comment originally from Cam]
   (serdes/with-cache
-    (-> (v2.extract/extract (merge opts {:targets (v2.extract/make-targets-of-type "Collection" collections)
-                                         :user-id (t2/select-one-pk User :email user-email :is_superuser true)}))
+    (-> opts
+        (assoc :targets (when collections (v2.extract/make-targets-of-type "Collection" collections)))
+        (assoc :user-id (when user-email (t2/select-one-pk User :email user-email :is_superuser true)))
+        v2.extract/extract
         (v2.storage/store! path)))
   (log/info (trs "Export to {0} complete!" path) (u/emoji "🚛💨 📦")))
 

--- a/enterprise/backend/test/metabase_enterprise/serialization/cmd_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/cmd_test.clj
@@ -4,6 +4,8 @@
    [clojure.test :refer :all]
    [metabase-enterprise.serialization.load :as load]
    [metabase-enterprise.serialization.test-util :as ts]
+   [metabase-enterprise.serialization.v2.extract :as v2.extract]
+   [metabase-enterprise.serialization.v2.storage :as v2.storage]
    [metabase.cmd :as cmd]
    [metabase.models :refer [Card Dashboard DashboardCard Database User]]
    [metabase.test :as mt]
@@ -11,9 +13,7 @@
    [metabase.util :as u]
    [metabase.util.log :as log]
    [metabase.util.yaml :as yaml]
-   [toucan2.core :as t2]
-   [metabase-enterprise.serialization.v2.extract :as v2.extract]
-   [metabase-enterprise.serialization.v2.storage :as v2.storage])
+   [toucan2.core :as t2])
   (:import
    (java.util UUID)))
 


### PR DESCRIPTION
This fixes an issue in the enterprise command invocation of extract functions. Tests have been added to check the `--user` and `--collection` option handling behavior at this level.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30651)
<!-- Reviewable:end -->
