### PR TITLE
fix selecting pinned items in collections

### DIFF
--- a/e2e/support/helpers/e2e-collection-helpers.js
+++ b/e2e/support/helpers/e2e-collection-helpers.js
@@ -50,3 +50,27 @@ export function openCollectionItemMenu(item, index = 0) {
     .closest("tr")
     .within(() => cy.icon("ellipsis").click());
 }
+
+export const getPinnedSection = () => {
+  return cy.findByTestId("pinned-items");
+};
+
+export const getUnpinnedSection = () => {
+  return cy.findByRole("table");
+};
+
+export const openPinnedItemMenu = name => {
+  getPinnedSection().within(() => {
+    cy.findByText(name)
+      .closest("a")
+      .within(() => cy.icon("ellipsis").click({ force: true }));
+  });
+};
+
+export const openUnpinnedItemMenu = name => {
+  getUnpinnedSection().within(() => {
+    cy.findByText(name)
+      .closest("tr")
+      .within(() => cy.icon("ellipsis").click());
+  });
+};

--- a/e2e/test/scenarios/collections/collection-pinned-overview.cy.spec.js
+++ b/e2e/test/scenarios/collections/collection-pinned-overview.cy.spec.js
@@ -1,4 +1,10 @@
-import { popover, restore } from "e2e/support/helpers";
+import {
+  popover,
+  restore,
+  getPinnedSection,
+  openPinnedItemMenu,
+  openUnpinnedItemMenu,
+} from "e2e/support/helpers";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 
 const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
@@ -204,31 +210,7 @@ describe("scenarios > collection pinned items overview", () => {
   });
 });
 
-const getPinnedSection = () => {
-  return cy.findByTestId("pinned-items");
-};
-
-const getUnpinnedSection = () => {
-  return cy.findByRole("table");
-};
-
 const openRootCollection = () => {
   cy.visit("/collection/root");
   cy.wait("@getPinnedItems");
-};
-
-const openPinnedItemMenu = name => {
-  getPinnedSection().within(() => {
-    cy.findByText(name)
-      .closest("a")
-      .within(() => cy.icon("ellipsis").click({ force: true }));
-  });
-};
-
-const openUnpinnedItemMenu = name => {
-  getUnpinnedSection().within(() => {
-    cy.findByText(name)
-      .closest("tr")
-      .within(() => cy.icon("ellipsis").click());
-  });
 };

--- a/e2e/test/scenarios/collections/collections.cy.spec.js
+++ b/e2e/test/scenarios/collections/collections.cy.spec.js
@@ -11,6 +11,7 @@ import {
   closeNavigationSidebar,
   openCollectionMenu,
   visitCollection,
+  openUnpinnedItemMenu,
 } from "e2e/support/helpers";
 import { USERS, USER_GROUPS } from "e2e/support/cypress_data";
 import { displaySidebarChildOf } from "./helpers/e2e-collections-sidebar.js";
@@ -22,6 +23,7 @@ describe("scenarios > collection defaults", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();
+    cy.intercept("GET", "/api/**/items?pinned_state*").as("getPinnedItems");
   });
 
   describe("new collection modal", () => {
@@ -454,11 +456,16 @@ describe("scenarios > collection defaults", () => {
           cy.icon("dash").should("exist");
           cy.icon("check").should("exist");
 
+          // Pin one item
+          openUnpinnedItemMenu("Orders, Count");
+          popover().findByText("Pin this").click();
+          cy.wait("@getPinnedItems");
+
           // Select all
           cy.findByLabelText("Select all items").click();
           cy.icon("dash").should("not.exist");
           // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-          cy.findByText("5 items selected");
+          cy.findByText("4 items selected");
 
           // Deselect all
           cy.findByLabelText("Select all items").click();

--- a/e2e/test/scenarios/collections/collections.cy.spec.js
+++ b/e2e/test/scenarios/collections/collections.cy.spec.js
@@ -12,6 +12,7 @@ import {
   openCollectionMenu,
   visitCollection,
   openUnpinnedItemMenu,
+  getPinnedSection,
 } from "e2e/support/helpers";
 import { USERS, USER_GROUPS } from "e2e/support/cypress_data";
 import { displaySidebarChildOf } from "./helpers/e2e-collections-sidebar.js";
@@ -449,17 +450,19 @@ describe("scenarios > collection defaults", () => {
         it("should be possible to apply bulk selection to all items (metabase#14705)", () => {
           cy.visit("/collection/root");
 
+          // Pin one item
+          openUnpinnedItemMenu("Orders, Count");
+          popover().findByText("Pin this").click();
+          getPinnedSection().within(() => {
+            cy.findByText("18,760");
+          });
+
           // Select one
           selectItemUsingCheckbox("Orders");
           // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
           cy.findByText("1 item selected").should("be.visible");
           cy.icon("dash").should("exist");
           cy.icon("check").should("exist");
-
-          // Pin one item
-          openUnpinnedItemMenu("Orders, Count");
-          popover().findByText("Pin this").click();
-          cy.wait("@getPinnedItems");
 
           // Select all
           cy.findByLabelText("Select all items").click();

--- a/frontend/src/metabase/collections/containers/CollectionContent.jsx
+++ b/frontend/src/metabase/collections/containers/CollectionContent.jsx
@@ -279,10 +279,9 @@ function CollectionContent({
                   }) => {
                     const hasPagination = metadata.total > PAGE_SIZE;
 
-                    const unselected = [
-                      ...pinnedItems,
-                      ...unpinnedItems,
-                    ].filter(item => !getIsSelected(item));
+                    const unselected = unpinnedItems.filter(
+                      item => !getIsSelected(item),
+                    );
                     const hasUnselected = unselected.length > 0;
 
                     const handleSelectAll = () => {


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/30571

### Description

Upon clicking the select all checkbox in the table in a collection, pinned items would also be selected, and the bulk move or achieve operation would apply to them as well.

This behavior is unintuivitve and perhaps erroneous because the pinned items do not appear in the table at all, so the user would next expect selecting all items in the table to select items outside of the table as well.

This PR fixes this behavior so that only items in the table are selected.

### How to verify

1. Create/go to any collection with pinned and unpinned items that you have edit permissions for (e.g. personal collection).
2. Check the box in the top-left corner of the table.
3. The number (`X items selected`) in the toast at the bottom should only be counting unpinned items in the table.
4. Clicking `Move` or `Archive` should only perform the action on those items, not the pinned ones.

### Demo

https://github.com/metabase/metabase/assets/37751258/4fb771ae-12fe-4003-b1bf-9a863bc1ccfc

### Checklist

- [x] Tests have been added/updated to cover changes in this PR

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30653)
<!-- Reviewable:end -->
