### PR TITLE
Add field values to sample database mock preset

### DIFF
--- a/frontend/src/metabase-types/api/mocks/presets/sample_database.ts
+++ b/frontend/src/metabase-types/api/mocks/presets/sample_database.ts
@@ -1,4 +1,4 @@
-import { Database, Field, Table } from "metabase-types/api";
+import { Database, Field, FieldValues, Table } from "metabase-types/api";
 import {
   createMockDatabase,
   createMockTable,
@@ -62,6 +62,22 @@ export const REVIEWS = {
   RATING: 66,
   BODY: 70,
   CREATED_AT: 71,
+};
+
+// Note: don't assign field values to the field object itself
+// Field values are not included in the field object in the API response
+// Please use `setupFieldValuesEndpoints` utility from `__support__/server-mocks`
+
+export const PRODUCT_CATEGORY_VALUES: FieldValues = {
+  field_id: PRODUCTS.CATEGORY,
+  values: [["Doohickey"], ["Gadget"], ["Gizmo"], ["Widget"]],
+  has_more_values: false,
+};
+
+export const PRODUCT_VENDOR_VALUES: FieldValues = {
+  field_id: PRODUCTS.VENDOR,
+  values: [["Vendor 1"], ["Vendor 2"], ["Vendor 3"], ["Vendor 4"]],
+  has_more_values: true,
 };
 
 export const createSampleDatabase = (opts?: Partial<Database>): Database =>

--- a/frontend/src/metabase-types/api/mocks/presets/sample_database.ts
+++ b/frontend/src/metabase-types/api/mocks/presets/sample_database.ts
@@ -187,6 +187,7 @@ export const createOrdersIdField = (opts?: Partial<Field>): Field =>
     base_type: "type/BigInteger",
     effective_type: "type/BigInteger",
     semantic_type: "type/PK",
+    has_field_values: "none",
     fingerprint: null,
     ...opts,
   });
@@ -201,6 +202,7 @@ export const createOrdersUserIdField = (opts?: Partial<Field>): Field =>
     effective_type: "type/Integer",
     semantic_type: "type/FK",
     fk_target_field_id: PEOPLE.ID,
+    has_field_values: "none",
     fingerprint: createMockFingerprint({
       global: createMockGlobalFieldFingerprint({
         "distinct-count": 929,
@@ -219,6 +221,7 @@ export const createOrdersProductIdField = (opts?: Partial<Field>): Field =>
     effective_type: "type/Integer",
     semantic_type: "type/FK",
     fk_target_field_id: PRODUCTS.ID,
+    has_field_values: "none",
     fingerprint: createMockFingerprint({
       global: createMockGlobalFieldFingerprint({
         "distinct-count": 200,
@@ -236,6 +239,7 @@ export const createOrdersSubtotalField = (opts?: Partial<Field>): Field =>
     base_type: "type/Float",
     effective_type: "type/Float",
     semantic_type: null,
+    has_field_values: "none",
     fingerprint: createMockFingerprint({
       global: createMockGlobalFieldFingerprint({
         "distinct-count": 340,
@@ -263,6 +267,7 @@ export const createOrdersTaxField = (opts?: Partial<Field>): Field =>
     base_type: "type/Float",
     effective_type: "type/Float",
     semantic_type: null,
+    has_field_values: "none",
     fingerprint: createMockFingerprint({
       global: createMockGlobalFieldFingerprint({
         "distinct-count": 797,
@@ -290,6 +295,7 @@ export const createOrdersTotalField = (opts?: Partial<Field>): Field =>
     base_type: "type/Float",
     effective_type: "type/Float",
     semantic_type: null,
+    has_field_values: "none",
     fingerprint: createMockFingerprint({
       global: createMockGlobalFieldFingerprint({
         "distinct-count": 4426,
@@ -317,6 +323,7 @@ export const createOrdersDiscountField = (opts?: Partial<Field>): Field =>
     base_type: "type/Float",
     effective_type: "type/Float",
     semantic_type: "type/Discount",
+    has_field_values: "none",
     fingerprint: createMockFingerprint({
       global: createMockGlobalFieldFingerprint({
         "distinct-count": 701,
@@ -345,6 +352,7 @@ export const createOrdersCreatedAtField = (opts?: Partial<Field>): Field =>
     base_type: "type/DateTime",
     effective_type: "type/DateTime",
     semantic_type: "type/CreationTimestamp",
+    has_field_values: "none",
     fingerprint: createMockFingerprint({
       global: createMockGlobalFieldFingerprint({
         "distinct-count": 9998,
@@ -396,6 +404,7 @@ export const createPeopleIdField = (opts?: Partial<Field>): Field =>
     effective_type: "type/BigInteger",
     semantic_type: "type/PK",
     fingerprint: null,
+    has_field_values: "none",
     ...opts,
   });
 
@@ -408,6 +417,7 @@ export const createPeopleAddressField = (opts?: Partial<Field>): Field =>
     base_type: "type/Text",
     effective_type: "type/Text",
     semantic_type: null,
+    has_field_values: "search",
     fingerprint: createMockFingerprint({
       global: createMockGlobalFieldFingerprint({
         "distinct-count": 2490,
@@ -430,6 +440,7 @@ export const createPeopleEmailField = (opts?: Partial<Field>): Field =>
     base_type: "type/Text",
     effective_type: "type/Text",
     semantic_type: "type/Email",
+    has_field_values: "search",
     fingerprint: createMockFingerprint({
       global: createMockGlobalFieldFingerprint({
         "distinct-count": 2500,
@@ -453,6 +464,11 @@ export const createPeoplePasswordField = (opts?: Partial<Field>): Field =>
     base_type: "type/Text",
     effective_type: "type/Text",
     semantic_type: null,
+
+    // It's actually set to "search" in the original sample database,
+    // but it's handy having a string field with no values for testing
+    has_field_values: "none",
+
     fingerprint: createMockFingerprint({
       global: createMockGlobalFieldFingerprint({
         "distinct-count": 2500,
@@ -475,6 +491,7 @@ export const createPeopleNameField = (opts?: Partial<Field>): Field =>
     base_type: "type/Text",
     effective_type: "type/Text",
     semantic_type: "type/Name",
+    has_field_values: "search",
     fingerprint: createMockFingerprint({
       global: createMockGlobalFieldFingerprint({
         "distinct-count": 2499,
@@ -497,6 +514,7 @@ export const createPeopleCityField = (opts?: Partial<Field>): Field =>
     base_type: "type/Text",
     effective_type: "type/Text",
     semantic_type: "type/City",
+    has_field_values: "search",
     fingerprint: createMockFingerprint({
       global: createMockGlobalFieldFingerprint({
         "distinct-count": 1966,
@@ -520,6 +538,7 @@ export const createPeopleLongitudeField = (opts?: Partial<Field>): Field =>
     base_type: "type/Float",
     effective_type: "type/Float",
     semantic_type: "type/Longitude",
+    has_field_values: "none",
     fingerprint: createMockFingerprint({
       global: createMockGlobalFieldFingerprint({
         "distinct-count": 2491,
@@ -592,6 +611,7 @@ export const createPeopleBirthDateField = (opts?: Partial<Field>): Field =>
     base_type: "type/Date",
     effective_type: "type/Date",
     semantic_type: null,
+    has_field_values: "none",
     fingerprint: createMockFingerprint({
       global: createMockGlobalFieldFingerprint({
         "distinct-count": 2308,
@@ -615,6 +635,7 @@ export const createPeopleZipField = (opts?: Partial<Field>): Field =>
     base_type: "type/Text",
     effective_type: "type/Text",
     semantic_type: "type/ZipCode",
+    has_field_values: "search",
     fingerprint: createMockFingerprint({
       global: createMockGlobalFieldFingerprint({
         "distinct-count": 2234,
@@ -637,6 +658,7 @@ export const createPeopleLatitudeField = (opts?: Partial<Field>): Field =>
     base_type: "type/Float",
     effective_type: "type/Float",
     semantic_type: "type/Latitude",
+    has_field_values: "none",
     fingerprint: createMockFingerprint({
       global: createMockGlobalFieldFingerprint({
         "distinct-count": 2491,
@@ -688,6 +710,7 @@ export const createProductsIdField = (opts?: Partial<Field>): Field =>
     base_type: "type/BigInteger",
     effective_type: "type/BigInteger",
     semantic_type: "type/PK",
+    has_field_values: "none",
     fingerprint: null,
     ...opts,
   });
@@ -701,6 +724,7 @@ export const createProductsEanField = (opts?: Partial<Field>): Field =>
     base_type: "type/Text",
     effective_type: "type/Text",
     semantic_type: null,
+    has_field_values: "none",
     fingerprint: createMockFingerprint({
       global: createMockGlobalFieldFingerprint({
         "distinct-count": 200,
@@ -767,6 +791,7 @@ export const createProductsVendorField = (opts?: Partial<Field>): Field =>
     base_type: "type/Text",
     effective_type: "type/Text",
     semantic_type: "type/Company",
+    has_field_values: "search",
     fingerprint: createMockFingerprint({
       global: createMockGlobalFieldFingerprint({
         "distinct-count": 200,
@@ -789,6 +814,7 @@ export const createProductsPriceField = (opts?: Partial<Field>): Field =>
     base_type: "type/Float",
     effective_type: "type/Float",
     semantic_type: null,
+    has_field_values: "none",
     fingerprint: createMockFingerprint({
       global: createMockGlobalFieldFingerprint({
         "distinct-count": 170,
@@ -816,6 +842,7 @@ export const createProductsRatingField = (opts?: Partial<Field>): Field =>
     base_type: "type/Float",
     effective_type: "type/Float",
     semantic_type: "type/Score",
+    has_field_values: "none",
     fingerprint: createMockFingerprint({
       global: createMockGlobalFieldFingerprint({
         "distinct-count": 23,
@@ -843,6 +870,7 @@ export const createProductsCreatedAtField = (opts?: Partial<Field>): Field =>
     base_type: "type/DateTime",
     effective_type: "type/DateTime",
     semantic_type: "type/CreationTimestamp",
+    has_field_values: "none",
     fingerprint: createMockFingerprint({
       global: createMockGlobalFieldFingerprint({
         "distinct-count": 200,
@@ -865,6 +893,7 @@ export const createReviewsIdField = (opts?: Partial<Field>): Field =>
     display_name: "ID",
     base_type: "type/BigInteger",
     semantic_type: "type/PK",
+    has_field_values: "none",
     fingerprint: null,
     ...opts,
   });
@@ -879,6 +908,7 @@ export const createReviewsProductIdField = (opts?: Partial<Field>): Field =>
     effective_type: "type/Integer",
     semantic_type: "type/FK",
     fk_target_field_id: PRODUCTS.ID,
+    has_field_values: "none",
     fingerprint: createMockFingerprint({
       global: createMockGlobalFieldFingerprint({
         "distinct-count": 176,
@@ -897,6 +927,7 @@ export const createReviewsReviewerField = (opts?: Partial<Field>): Field =>
     base_type: "type/Text",
     effective_type: "type/Text",
     semantic_type: null,
+    has_field_values: "search",
     fingerprint: createMockFingerprint({
       global: createMockGlobalFieldFingerprint({
         "distinct-count": 1076,
@@ -947,6 +978,7 @@ export const createReviewsBodyField = (opts?: Partial<Field>): Field =>
     base_type: "type/Text",
     effective_type: "type/Text",
     semantic_type: "type/Description",
+    has_field_values: "search",
     fingerprint: createMockFingerprint({
       global: createMockGlobalFieldFingerprint({
         "distinct-count": 1112,

--- a/frontend/src/metabase-types/api/mocks/presets/sample_database.ts
+++ b/frontend/src/metabase-types/api/mocks/presets/sample_database.ts
@@ -80,6 +80,12 @@ export const PRODUCT_VENDOR_VALUES: FieldValues = {
   has_more_values: true,
 };
 
+export const PEOPLE_SOURCE_VALUES: FieldValues = {
+  field_id: PEOPLE.SOURCE,
+  values: [["Affiliate"], ["Facebook"], ["Google"], ["Organic"], ["Twitter"]],
+  has_more_values: false,
+};
+
 export const createSampleDatabase = (opts?: Partial<Database>): Database =>
   createMockDatabase({
     id: SAMPLE_DB_ID,


### PR DESCRIPTION
Adds `has_field_values` properties to mock sample database columns. Before they were not set explicitly and `createMockField` assigned `has_field_values: "list"` to everything. That makes it harder to test behaviors for fields with other `has_field_values` values. Also, exports a few preconfigured field values object. I believe we shouldn't add them as field `values` property — normally, they're not included in field objects and are fetched separately.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30655)
<!-- Reviewable:end -->
