### PR TITLE
Add bucketing to sample database mock preset

### DIFF
--- a/frontend/src/metabase-types/api/field.ts
+++ b/frontend/src/metabase-types/api/field.ts
@@ -57,6 +57,12 @@ export type FieldDimension = {
   name: string;
 };
 
+export type FieldDimensionOption = {
+  name: string;
+  mbql: unknown[] | null;
+  type: string;
+};
+
 export interface ConcreteField {
   id: FieldId;
   table_id: TableId;
@@ -78,8 +84,11 @@ export interface ConcreteField {
   fk_target_field_id: FieldId | null;
   target?: Field;
   values?: FieldValue[];
-  dimensions?: FieldDimension[];
   settings?: FieldFormattingSettings;
+
+  dimensions?: FieldDimension[];
+  default_dimension_option?: FieldDimensionOption;
+  dimension_options?: FieldDimensionOption[];
 
   max_value?: number;
   min_value?: number;

--- a/frontend/src/metabase-types/api/mocks/presets/sample_database.ts
+++ b/frontend/src/metabase-types/api/mocks/presets/sample_database.ts
@@ -1,4 +1,10 @@
-import { Database, Field, FieldValues, Table } from "metabase-types/api";
+import {
+  Database,
+  Field,
+  FieldDimensionOption,
+  FieldValues,
+  Table,
+} from "metabase-types/api";
 import {
   createMockDatabase,
   createMockTable,
@@ -86,6 +92,24 @@ export const PEOPLE_SOURCE_VALUES: FieldValues = {
   has_more_values: false,
 };
 
+const DEFAULT_NUMERIC_BINNING_OPTION: FieldDimensionOption = {
+  name: "Auto bin",
+  mbql: ["field", null, { binning: { strategy: "default" } }],
+  type: "type/Number",
+};
+
+const DEFAULT_COORDINATE_BINNING_OPTION: FieldDimensionOption = {
+  name: "Auto bin",
+  mbql: ["field", null, { binning: { strategy: "default" } }],
+  type: "type/Coordinate",
+};
+
+const DEFAULT_TEMPORAL_BUCKETING_OPTION: FieldDimensionOption = {
+  name: "Day",
+  mbql: ["field", null, { "temporal-unit": "day" }],
+  type: "type/DateTime",
+};
+
 export const createSampleDatabase = (opts?: Partial<Database>): Database =>
   createMockDatabase({
     id: SAMPLE_DB_ID,
@@ -118,6 +142,7 @@ export const createOrdersTable = (opts?: Partial<Table>): Table =>
       createOrdersCreatedAtField(),
       createOrdersQuantityField(),
     ],
+    dimension_options: createTableDimensionOptions(),
     ...opts,
   });
 
@@ -143,6 +168,7 @@ export const createPeopleTable = (opts?: Partial<Table>): Table =>
       createPeopleLatitudeField(),
       createPeopleCreatedAtField(),
     ],
+    dimension_options: createTableDimensionOptions(),
     ...opts,
   });
 
@@ -163,6 +189,7 @@ export const createProductsTable = (opts?: Partial<Table>): Table =>
       createProductsRatingField(),
       createProductsCreatedAtField(),
     ],
+    dimension_options: createTableDimensionOptions(),
     ...opts,
   });
 
@@ -181,6 +208,7 @@ export const createReviewsTable = (opts?: Partial<Table>): Table =>
       createReviewsBodyField(),
       createReviewsCreatedAtField(),
     ],
+    dimension_options: createTableDimensionOptions(),
     ...opts,
   });
 
@@ -246,6 +274,8 @@ export const createOrdersSubtotalField = (opts?: Partial<Field>): Field =>
     effective_type: "type/Float",
     semantic_type: null,
     has_field_values: "none",
+    default_dimension_option: DEFAULT_NUMERIC_BINNING_OPTION,
+    dimension_options: createNumericFieldBinningOptions(),
     fingerprint: createMockFingerprint({
       global: createMockGlobalFieldFingerprint({
         "distinct-count": 340,
@@ -274,6 +304,8 @@ export const createOrdersTaxField = (opts?: Partial<Field>): Field =>
     effective_type: "type/Float",
     semantic_type: null,
     has_field_values: "none",
+    default_dimension_option: DEFAULT_NUMERIC_BINNING_OPTION,
+    dimension_options: createNumericFieldBinningOptions(),
     fingerprint: createMockFingerprint({
       global: createMockGlobalFieldFingerprint({
         "distinct-count": 797,
@@ -302,6 +334,8 @@ export const createOrdersTotalField = (opts?: Partial<Field>): Field =>
     effective_type: "type/Float",
     semantic_type: null,
     has_field_values: "none",
+    default_dimension_option: DEFAULT_NUMERIC_BINNING_OPTION,
+    dimension_options: createNumericFieldBinningOptions(),
     fingerprint: createMockFingerprint({
       global: createMockGlobalFieldFingerprint({
         "distinct-count": 4426,
@@ -330,6 +364,8 @@ export const createOrdersDiscountField = (opts?: Partial<Field>): Field =>
     effective_type: "type/Float",
     semantic_type: "type/Discount",
     has_field_values: "none",
+    default_dimension_option: DEFAULT_NUMERIC_BINNING_OPTION,
+    dimension_options: createNumericFieldBinningOptions(),
     fingerprint: createMockFingerprint({
       global: createMockGlobalFieldFingerprint({
         "distinct-count": 701,
@@ -359,6 +395,8 @@ export const createOrdersCreatedAtField = (opts?: Partial<Field>): Field =>
     effective_type: "type/DateTime",
     semantic_type: "type/CreationTimestamp",
     has_field_values: "none",
+    default_dimension_option: DEFAULT_TEMPORAL_BUCKETING_OPTION,
+    dimension_options: createTemporalFieldBucketingOptions(),
     fingerprint: createMockFingerprint({
       global: createMockGlobalFieldFingerprint({
         "distinct-count": 9998,
@@ -382,6 +420,8 @@ export const createOrdersQuantityField = (opts?: Partial<Field>): Field =>
     base_type: "type/Integer",
     effective_type: "type/Integer",
     semantic_type: "type/Quantity",
+    default_dimension_option: DEFAULT_NUMERIC_BINNING_OPTION,
+    dimension_options: createNumericFieldBinningOptions(),
     fingerprint: createMockFingerprint({
       global: createMockGlobalFieldFingerprint({
         "distinct-count": 62,
@@ -545,6 +585,8 @@ export const createPeopleLongitudeField = (opts?: Partial<Field>): Field =>
     effective_type: "type/Float",
     semantic_type: "type/Longitude",
     has_field_values: "none",
+    default_dimension_option: DEFAULT_COORDINATE_BINNING_OPTION,
+    dimension_options: createCoordinateFieldBinningOptions(),
     fingerprint: createMockFingerprint({
       global: createMockGlobalFieldFingerprint({
         "distinct-count": 2491,
@@ -618,6 +660,8 @@ export const createPeopleBirthDateField = (opts?: Partial<Field>): Field =>
     effective_type: "type/Date",
     semantic_type: null,
     has_field_values: "none",
+    default_dimension_option: DEFAULT_TEMPORAL_BUCKETING_OPTION,
+    dimension_options: createTemporalFieldBucketingOptions(),
     fingerprint: createMockFingerprint({
       global: createMockGlobalFieldFingerprint({
         "distinct-count": 2308,
@@ -665,6 +709,8 @@ export const createPeopleLatitudeField = (opts?: Partial<Field>): Field =>
     effective_type: "type/Float",
     semantic_type: "type/Latitude",
     has_field_values: "none",
+    default_dimension_option: DEFAULT_COORDINATE_BINNING_OPTION,
+    dimension_options: createCoordinateFieldBinningOptions(),
     fingerprint: createMockFingerprint({
       global: createMockGlobalFieldFingerprint({
         "distinct-count": 2491,
@@ -692,6 +738,8 @@ export const createPeopleCreatedAtField = (opts?: Partial<Field>): Field =>
     base_type: "type/DateTime",
     effective_type: "type/Text",
     semantic_type: "type/CreationTimestamp",
+    default_dimension_option: DEFAULT_TEMPORAL_BUCKETING_OPTION,
+    dimension_options: createTemporalFieldBucketingOptions(),
     fingerprint: createMockFingerprint({
       global: createMockGlobalFieldFingerprint({
         "distinct-count": 2500,
@@ -821,6 +869,8 @@ export const createProductsPriceField = (opts?: Partial<Field>): Field =>
     effective_type: "type/Float",
     semantic_type: null,
     has_field_values: "none",
+    default_dimension_option: DEFAULT_NUMERIC_BINNING_OPTION,
+    dimension_options: createNumericFieldBinningOptions(),
     fingerprint: createMockFingerprint({
       global: createMockGlobalFieldFingerprint({
         "distinct-count": 170,
@@ -849,6 +899,8 @@ export const createProductsRatingField = (opts?: Partial<Field>): Field =>
     effective_type: "type/Float",
     semantic_type: "type/Score",
     has_field_values: "none",
+    default_dimension_option: DEFAULT_NUMERIC_BINNING_OPTION,
+    dimension_options: createNumericFieldBinningOptions(),
     fingerprint: createMockFingerprint({
       global: createMockGlobalFieldFingerprint({
         "distinct-count": 23,
@@ -877,6 +929,8 @@ export const createProductsCreatedAtField = (opts?: Partial<Field>): Field =>
     effective_type: "type/DateTime",
     semantic_type: "type/CreationTimestamp",
     has_field_values: "none",
+    default_dimension_option: DEFAULT_TEMPORAL_BUCKETING_OPTION,
+    dimension_options: createTemporalFieldBucketingOptions(),
     fingerprint: createMockFingerprint({
       global: createMockGlobalFieldFingerprint({
         "distinct-count": 200,
@@ -1007,6 +1061,8 @@ export const createReviewsCreatedAtField = (opts?: Partial<Field>): Field =>
     base_type: "type/DateTime",
     effective_type: "type/DateTime",
     semantic_type: "type/CreationTimestamp",
+    default_dimension_option: DEFAULT_TEMPORAL_BUCKETING_OPTION,
+    dimension_options: createTemporalFieldBucketingOptions(),
     fingerprint: createMockFingerprint({
       global: createMockGlobalFieldFingerprint({
         "distinct-count": 1112,
@@ -1020,3 +1076,264 @@ export const createReviewsCreatedAtField = (opts?: Partial<Field>): Field =>
     }),
     ...opts,
   });
+
+function createTemporalBucketingOptions(): Record<
+  string,
+  FieldDimensionOption
+> {
+  return {
+    "0": {
+      name: "Day",
+      mbql: ["field", null, { "temporal-unit": "day" }],
+      type: "type/Date",
+    },
+    "1": {
+      name: "Week",
+      mbql: ["field", null, { "temporal-unit": "week" }],
+      type: "type/Date",
+    },
+    "2": {
+      name: "Month",
+      mbql: ["field", null, { "temporal-unit": "month" }],
+      type: "type/Date",
+    },
+    "3": {
+      name: "Quarter",
+      mbql: ["field", null, { "temporal-unit": "quarter" }],
+      type: "type/Date",
+    },
+    "4": {
+      name: "Year",
+      mbql: ["field", null, { "temporal-unit": "year" }],
+      type: "type/Date",
+    },
+    "5": {
+      name: "Day of Week",
+      mbql: ["field", null, { "temporal-unit": "day-of-week" }],
+      type: "type/Date",
+    },
+    "6": {
+      name: "Day of Month",
+      mbql: ["field", null, { "temporal-unit": "day-of-month" }],
+      type: "type/Date",
+    },
+    "7": {
+      name: "Day of Year",
+      mbql: ["field", null, { "temporal-unit": "day-of-year" }],
+      type: "type/Date",
+    },
+    "8": {
+      name: "Week of Year",
+      mbql: ["field", null, { "temporal-unit": "week-of-year" }],
+      type: "type/Date",
+    },
+    "9": {
+      name: "Month of Year",
+      mbql: ["field", null, { "temporal-unit": "month-of-year" }],
+      type: "type/Date",
+    },
+    "10": {
+      name: "Quarter of Year",
+      mbql: ["field", null, { "temporal-unit": "quarter-of-year" }],
+      type: "type/Date",
+    },
+    "11": {
+      name: "Minute",
+      mbql: ["field", null, { "temporal-unit": "minute" }],
+      type: "type/DateTime",
+    },
+    "12": {
+      name: "Hour",
+      mbql: ["field", null, { "temporal-unit": "hour" }],
+      type: "type/DateTime",
+    },
+    "13": {
+      name: "Day",
+      mbql: ["field", null, { "temporal-unit": "day" }],
+      type: "type/DateTime",
+    },
+    "14": {
+      name: "Week",
+      mbql: ["field", null, { "temporal-unit": "week" }],
+      type: "type/DateTime",
+    },
+    "15": {
+      name: "Month",
+      mbql: ["field", null, { "temporal-unit": "month" }],
+      type: "type/DateTime",
+    },
+    "16": {
+      name: "Quarter",
+      mbql: ["field", null, { "temporal-unit": "quarter" }],
+      type: "type/DateTime",
+    },
+    "17": {
+      name: "Year",
+      mbql: ["field", null, { "temporal-unit": "year" }],
+      type: "type/DateTime",
+    },
+    "18": {
+      name: "Minute of Hour",
+      mbql: ["field", null, { "temporal-unit": "minute-of-hour" }],
+      type: "type/DateTime",
+    },
+    "19": {
+      name: "Hour of Day",
+      mbql: ["field", null, { "temporal-unit": "hour-of-day" }],
+      type: "type/DateTime",
+    },
+    "20": {
+      name: "Day of Week",
+      mbql: ["field", null, { "temporal-unit": "day-of-week" }],
+      type: "type/DateTime",
+    },
+    "21": {
+      name: "Day of Month",
+      mbql: ["field", null, { "temporal-unit": "day-of-month" }],
+      type: "type/DateTime",
+    },
+    "22": {
+      name: "Day of Year",
+      mbql: ["field", null, { "temporal-unit": "day-of-year" }],
+      type: "type/DateTime",
+    },
+    "23": {
+      name: "Week of Year",
+      mbql: ["field", null, { "temporal-unit": "week-of-year" }],
+      type: "type/DateTime",
+    },
+    "24": {
+      name: "Month of Year",
+      mbql: ["field", null, { "temporal-unit": "month-of-year" }],
+      type: "type/DateTime",
+    },
+    "25": {
+      name: "Quarter of Year",
+      mbql: ["field", null, { "temporal-unit": "quarter-of-year" }],
+      type: "type/DateTime",
+    },
+    "26": {
+      name: "Minute",
+      mbql: ["field", null, { "temporal-unit": "minute" }],
+      type: "type/Time",
+    },
+    "27": {
+      name: "Hour",
+      mbql: ["field", null, { "temporal-unit": "hour" }],
+      type: "type/Time",
+    },
+    "28": {
+      name: "Minute of Hour",
+      mbql: ["field", null, { "temporal-unit": "minute-of-hour" }],
+      type: "type/Time",
+    },
+  };
+}
+``;
+function createNumericBinningOptions(): Record<string, FieldDimensionOption> {
+  return {
+    "29": {
+      name: "Auto bin",
+      mbql: ["field", null, { binning: { strategy: "default" } }],
+      type: "type/Number",
+    },
+    "30": {
+      name: "10 bins",
+      mbql: [
+        "field",
+        null,
+        { binning: { strategy: "num-bins", "num-bins": 10 } },
+      ],
+      type: "type/Number",
+    },
+    "31": {
+      name: "50 bins",
+      mbql: [
+        "field",
+        null,
+        { binning: { strategy: "num-bins", "num-bins": 50 } },
+      ],
+      type: "type/Number",
+    },
+    "32": {
+      name: "100 bins",
+      mbql: [
+        "field",
+        null,
+        { binning: { strategy: "num-bins", "num-bins": 100 } },
+      ],
+      type: "type/Number",
+    },
+    "33": { name: "Don't bin", mbql: null, type: "type/Number" },
+  };
+}
+
+function createCoordinateBinningOptions(): Record<
+  string,
+  FieldDimensionOption
+> {
+  return {
+    "34": {
+      name: "Auto bin",
+      mbql: ["field", null, { binning: { strategy: "default" } }],
+      type: "type/Coordinate",
+    },
+    "35": {
+      name: "Bin every 0.1 degrees",
+      mbql: [
+        "field",
+        null,
+        { binning: { strategy: "bin-width", "bin-width": 0.1 } },
+      ],
+      type: "type/Coordinate",
+    },
+    "36": {
+      name: "Bin every 1 degree",
+      mbql: [
+        "field",
+        null,
+        { binning: { strategy: "bin-width", "bin-width": 1 } },
+      ],
+      type: "type/Coordinate",
+    },
+    "37": {
+      name: "Bin every 10 degrees",
+      mbql: [
+        "field",
+        null,
+        { binning: { strategy: "bin-width", "bin-width": 10 } },
+      ],
+      type: "type/Coordinate",
+    },
+    "38": {
+      name: "Bin every 20 degrees",
+      mbql: [
+        "field",
+        null,
+        { binning: { strategy: "bin-width", "bin-width": 20 } },
+      ],
+      type: "type/Coordinate",
+    },
+    "39": { name: "Don't bin", mbql: null, type: "type/Coordinate" },
+  };
+}
+
+function createTableDimensionOptions() {
+  return {
+    ...createTemporalBucketingOptions(),
+    ...createNumericBinningOptions(),
+    ...createCoordinateBinningOptions(),
+  };
+}
+
+function createTemporalFieldBucketingOptions() {
+  return Object.values(createTemporalBucketingOptions());
+}
+
+function createNumericFieldBinningOptions() {
+  return Object.values(createNumericBinningOptions());
+}
+
+function createCoordinateFieldBinningOptions() {
+  return Object.values(createCoordinateBinningOptions());
+}

--- a/frontend/src/metabase-types/api/table.ts
+++ b/frontend/src/metabase-types/api/table.ts
@@ -1,6 +1,6 @@
 import type { Database, DatabaseId, InitialSyncStatus } from "./database";
 import type { ForeignKey } from "./foreign-key";
-import type { Field } from "./field";
+import type { Field, FieldDimensionOption } from "./field";
 import type { Metric } from "./metric";
 import type { Segment } from "./segment";
 
@@ -38,6 +38,7 @@ export interface Table {
   fields?: Field[];
   metrics?: Metric[];
   segments?: Segment[];
+  dimension_options?: Record<string, FieldDimensionOption>;
   field_order: TableFieldOrder;
 
   active: boolean;


### PR DESCRIPTION
Right now, fields in the mock sample database are not treated as binnable. This PR adds `dimension_options` and `default_dimension_option` mirror the real sample database to each field, so we can test binning and temporal bucketing with the mock database

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30656)
<!-- Reviewable:end -->
