### PR TITLE
Fix syntax error in slack notifications script

### DIFF
--- a/.github/workflows/rerun-workflows.yml
+++ b/.github/workflows/rerun-workflows.yml
@@ -30,10 +30,6 @@ jobs:
             const MAX_ATTEMPTS = 2;
             const ATTEMPT = ${{ github.event.workflow_run.run_attempt }};
 
-            const author = `@${context.actor}`;
-            const breaking_commit = context.sha;
-            const branch = context.ref;
-
             if (ATTEMPT <= MAX_ATTEMPTS) {
               github.rest.actions.reRunWorkflowFailedJobs({
                 owner: context.repo.owner,
@@ -42,8 +38,12 @@ jobs:
               });
             } else {
               // notify slack of repeated failure
-              const WebClient = require('@slack/web-api');
+              const { WebClient } = require('@slack/web-api');
               const slack = new WebClient('${{ secrets.SLACK_BOT_TOKEN }}');
+
+              const author = `@${context.actor}`;
+              const breaking_commit = context.sha;
+              const branch = context.ref;
 
               await slack.chat.postMessage({
                 channel: 'engineering-ci',


### PR DESCRIPTION
### Description

Found another syntax error in this script. Tested it more thoroughly in a private repo, and was able to send a test message to the #bot-testing channel on slack.

![Screen Shot 2023-05-10 at 8 13 02 AM](https://github.com/metabase/metabase/assets/30528226/62b5f962-640a-4bed-b047-083428441244)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30660)
<!-- Reviewable:end -->
