### PR TITLE
Alternative GEOJSON.io fix

### DIFF
--- a/test/metabase/api/login_history_test.clj
+++ b/test/metabase/api/login_history_test.clj
@@ -63,7 +63,7 @@
         ;;
         ;; A Slack reminder has been set to follow up on this
         (is (schema= [(s/one
-                       {:timestamp          (s/eq "2021-03-18T20:55:50.955232Z")
+                       {:timestamp          #"2021-03-18T"
                         :device_description (s/eq "Mobile Browser (Mobile Safari/iOS)")
                         :ip_address         (s/eq "0:0:0:0:0:0:0:1")
                         :active             (s/eq false)
@@ -71,7 +71,7 @@
                         :timezone           (s/eq nil)}
                        "localhost ipv6")
                       (s/one
-                       {:timestamp          (s/eq "2021-03-18T20:04:24.7273Z")
+                       {:timestamp          #"2021-03-18T"
                         :device_description (s/eq "Library (Apache-HttpClient/JVM (Java))")
                         :ip_address         (s/eq "127.0.0.1")
                         :active             (s/eq false)
@@ -79,7 +79,7 @@
                         :timezone           (s/eq nil)}
                        "localhost ipv4")
                       (s/one
-                       {:timestamp          (s/eq "2021-03-18T19:52:41.808482Z")
+                       {:timestamp          #"2021-03-18T"
                         :device_description (s/eq "Browser (Chrome/Windows)")
                         :ip_address         (s/eq "185.233.100.23")
                         :active             (s/eq true)
@@ -87,7 +87,7 @@
                         :timezone           (if-non-nil "CET")}
                        "France")
                       (s/one
-                       {:timestamp          (s/eq "2021-03-18T19:52:20.172351Z")
+                       {:timestamp          #"2021-03-18T"
                         :device_description (s/eq "Browser (Chrome/Windows)")
                         :ip_address         (s/eq "52.206.149.9")
                         :active             (s/eq false)

--- a/test/metabase/api/login_history_test.clj
+++ b/test/metabase/api/login_history_test.clj
@@ -63,7 +63,7 @@
         ;;
         ;; A Slack reminder has been set to follow up on this
         (is (schema= [(s/one
-                       {:timestamp          #"2021-03-18T"
+                       {:timestamp          (s/eq "2021-03-18T20:55:50.955232Z")
                         :device_description (s/eq "Mobile Browser (Mobile Safari/iOS)")
                         :ip_address         (s/eq "0:0:0:0:0:0:0:1")
                         :active             (s/eq false)
@@ -71,7 +71,7 @@
                         :timezone           (s/eq nil)}
                        "localhost ipv6")
                       (s/one
-                       {:timestamp          #"2021-03-18T"
+                       {:timestamp          (s/eq "2021-03-18T20:04:24.7273Z")
                         :device_description (s/eq "Library (Apache-HttpClient/JVM (Java))")
                         :ip_address         (s/eq "127.0.0.1")
                         :active             (s/eq false)
@@ -79,7 +79,7 @@
                         :timezone           (s/eq nil)}
                        "localhost ipv4")
                       (s/one
-                       {:timestamp          #"2021-03-18T"
+                       {:timestamp          (s/eq "2021-03-18T20:52:41.808482+01:00")
                         :device_description (s/eq "Browser (Chrome/Windows)")
                         :ip_address         (s/eq "185.233.100.23")
                         :active             (s/eq true)
@@ -87,7 +87,7 @@
                         :timezone           (if-non-nil "CET")}
                        "France")
                       (s/one
-                       {:timestamp          #"2021-03-18T"
+                       {:timestamp          (s/eq "2021-03-18T15:52:20.172351-04:00")
                         :device_description (s/eq "Browser (Chrome/Windows)")
                         :ip_address         (s/eq "52.206.149.9")
                         :active             (s/eq false)

--- a/test/metabase/api/login_history_test.clj
+++ b/test/metabase/api/login_history_test.clj
@@ -14,44 +14,60 @@
 (def ^:private ios-user-agent
   "Mozilla/5.0 (iPhone; CPU iPhone OS 10_3_1 like Mac OS X) AppleWebKit/603.1.30 (KHTML  like Gecko) Version/10.0 Mobile/14E304 Safari/602.1")
 
+(defn- if-non-nil
+  "Returns a schema that matches the provided value `v` if a value is non-nil, otherwise expects nil. Handling issues in
+  geojson.io."
+  [v]
+  (let [non-nil-check (cond-> v
+                        ;; regexes are matchers otherwise check for s/eq
+                        (not (instance? java.util.regex.Pattern v))
+                        (s/eq))]
+    (s/conditional some? non-nil-check nil? (s/eq nil))))
+
 (deftest login-history-test
   (testing "GET /api/login-history/current"
-    (let [session-id (str (java.util.UUID/randomUUID))]
+    (let [session-id (str (java.util.UUID/randomUUID))
+          device-id  "e9b49ec7-bc64-4a83-9b1a-ecd3ae26ba9d"]
       (mt/with-temp* [User         [user]
                       Session      [_ {:id session-id, :user_id (u/the-id user)}]
                       LoginHistory [_ {:timestamp          #t "2021-03-18T19:52:41.808482Z"
                                        :user_id            (u/the-id user)
-                                       :device_id          "e9b49ec7-bc64-4a83-9b1a-ecd3ae26ba9d"
+                                       :device_id          device-id
                                        :device_description windows-user-agent
                                        :ip_address         "185.233.100.23"
                                        :session_id         session-id}]
                       LoginHistory [_ {:timestamp          #t "2021-03-18T20:04:24.727300Z"
                                        :user_id            (u/the-id user)
-                                       :device_id          "e9b49ec7-bc64-4a83-9b1a-ecd3ae26ba9d"
+                                       :device_id          device-id
                                        :device_description "Apache-HttpClient/4.5.10 (Java/14.0.1)"
                                        :ip_address         "127.0.0.1"}]
                       LoginHistory [_ {:timestamp          #t "2021-03-18T20:55:50.955232Z"
                                        :user_id            (u/the-id user)
-                                       :device_id          "e9b49ec7-bc64-4a83-9b1a-ecd3ae26ba9d"
+                                       :device_id          device-id
                                        :device_description ios-user-agent
                                        :ip_address         "0:0:0:0:0:0:0:1"}]
                       LoginHistory [_ {:timestamp          #t "2021-03-18T19:52:20.172351Z"
                                        :user_id            (u/the-id user)
-                                       :device_id          "e9b49ec7-bc64-4a83-9b1a-ecd3ae26ba9d"
+                                       :device_id          device-id
                                        :device_description windows-user-agent
                                        :ip_address         "52.206.149.9"}]
                       ;; this one shouldn't show up because it's from a different User
                       LoginHistory [_ {:timestamp          #t "2021-03-17T19:00Z"
                                        :user_id            (mt/user->id :rasta)
-                                       :device_id          "e9b49ec7-bc64-4a83-9b1a-ecd3ae26ba9d"
+                                       :device_id          device-id
                                        :device_description windows-user-agent
                                        :ip_address         "52.206.149.9"}]]
+        ;; GeoJS is having issues. We have safe error handling so we expect either nil or the expected values.
+        ;; https://github.com/jloh/geojs/issues/48
+        ;; The timestamps will also need to be updated (to be in the TZ, not in Zulu time)
+        ;;
+        ;; A Slack reminder has been set to follow up on this
         (is (schema= [(s/one
                        {:timestamp          (s/eq "2021-03-18T20:55:50.955232Z")
                         :device_description (s/eq "Mobile Browser (Mobile Safari/iOS)")
                         :ip_address         (s/eq "0:0:0:0:0:0:0:1")
                         :active             (s/eq false)
-                        :location           (s/eq "Unknown location")
+                        :location           (if-non-nil "Unknown location")
                         :timezone           (s/eq nil)}
                        "localhost ipv6")
                       (s/one
@@ -59,23 +75,23 @@
                         :device_description (s/eq "Library (Apache-HttpClient/JVM (Java))")
                         :ip_address         (s/eq "127.0.0.1")
                         :active             (s/eq false)
-                        :location           (s/eq "Unknown location")
+                        :location           (if-non-nil "Unknown location")
                         :timezone           (s/eq nil)}
                        "localhost ipv4")
                       (s/one
-                       {:timestamp          (s/eq "2021-03-18T20:52:41.808482+01:00")
+                       {:timestamp          (s/eq "2021-03-18T19:52:41.808482Z")
                         :device_description (s/eq "Browser (Chrome/Windows)")
                         :ip_address         (s/eq "185.233.100.23")
                         :active             (s/eq true)
-                        :location           #"France"
-                        :timezone           (s/eq "CET")}
+                        :location           (if-non-nil #"France")
+                        :timezone           (if-non-nil "CET")}
                        "France")
                       (s/one
-                       {:timestamp          (s/eq "2021-03-18T15:52:20.172351-04:00")
+                       {:timestamp          (s/eq "2021-03-18T19:52:20.172351Z")
                         :device_description (s/eq "Browser (Chrome/Windows)")
                         :ip_address         (s/eq "52.206.149.9")
                         :active             (s/eq false)
-                        :location           (s/eq "Ashburn, Virginia, United States")
-                        :timezone           (s/eq "ET")}
+                        :location           (if-non-nil "Ashburn, Virginia, United States")
+                        :timezone           (if-non-nil "ET")}
                        "Virginia")]
                      (mt/client session-id :get 200 "login-history/current")))))))

--- a/test/metabase/api/session_test.clj
+++ b/test/metabase/api/session_test.clj
@@ -82,8 +82,11 @@
                            "exception")
                     (s/one (s/eq "Authentication endpoint error")
                            "log message")]
-                   (first (mt/with-log-messages-for-level :error
-                            (mt/client :post 400 "session" {:email (:email user), :password "wooo"}))))))))
+                   (->> (mt/with-log-messages-for-level :error
+                          (mt/client :post 400 "session" {:email (:email user), :password "wooo"}))
+                        ;; geojson can throw errors and we want the authentication error
+                        (filter (fn [[_log-level _error message]] (= message "Authentication endpoint error")))
+                        first))))))
 
 (deftest ^:parallel login-validation-test
   (testing "POST /api/session"

--- a/test/metabase/server/request/util_test.clj
+++ b/test/metabase/server/request/util_test.clj
@@ -77,7 +77,8 @@
                    (request.u/ip-address mock-request)))))))))
 
 (deftest ^:parallel geocode-ip-addresses-test
-  (are [ip-addresses expected] (schema= expected (request.u/geocode-ip-addresses ip-addresses))
+  (are [ip-addresses expected] (schema= (s/conditional some? expected nil? (s/eq nil))
+                                        (request.u/geocode-ip-addresses ip-addresses))
     ["8.8.8.8"]
     {(s/required-key "8.8.8.8") {:description (s/eq "Los Angeles, California, United States")
                                  :timezone    (s/eq (t/zone-id "America/Los_Angeles"))}}


### PR DESCRIPTION
Fixes failing CI issues. GeoJSON is throwing 500 errors for some ip addresses. Our code catches and returns nil but this affects our checks in CI.

https://github.com/metabase/metabase/pull/30658 attempts to fix by using a library to intercept and return saved api responses. This approach extends the tests to accept nil as a response.

I prefer this approach as some responses still work and we should check their shape. And for the ones that fail, we allow for nil, which is essentially what the application does in practice.

rather than not testing, just accept that we might get an expected location back or we might get nil. This actually represents how the application will behave and will seamlessly work as the service improves or continues throwing errors:

#### Stats where the UI shows login history with no location attached. It gracefully degrades to nil values
![image](https://github.com/metabase/metabase/assets/6377293/a8cc54b6-53be-4aef-a88c-451b768dcede)


```shell
❯ curl "https://get.geojs.io/v1/ip/geo.json?ip=8.8.8.8,136.49.173.73,185.233.100.23"
<html>
<head><title>500 Internal Server Error</title></head>
<body>
<center><h1>500 Internal Server Error</h1></center>
<hr><center>openresty</center>
</body>
</html>

❯ curl "https://get.geojs.io/v1/ip/geo.json?ip=8.8.8.8,136.49.173.73"
[{"area_code":"0","organization_name":"GOOGLE","country_code":"US",
  "country_code3":"USA","continent_code":"NA","ip":"8.8.8.8",
  "region":"California","latitude":"34.0544","longitude":"-118.2441",
  "accuracy":5,"timezone":"America\/Los_Angeles","city":"Los Angeles",
  "organization":"AS15169 GOOGLE","asn":15169,"country":"United States"},
 {"area_code":"0","organization_name":"GOOGLE-FIBER","country_code":"US",
 "country_code3":"USA","continent_code":"NA","ip":"136.49.173.73",
 "region":"Texas","latitude":"30.2423","longitude":"-97.7672",
 "accuracy":5,"timezone":"America\/Chicago","city":"Austin",
 "organization":"AS16591 GOOGLE-FIBER","asn":16591,"country":"United States"}]
```

Changes are basically

```clojure
(schema= (s/conditional some? <original-expectation-schema>
                        nil?  (s/eq nil)
         response-from-geojson)
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30675)
<!-- Reviewable:end -->
