### PR TITLE
Remove non-existent database key

### DIFF
--- a/frontend/src/metabase/reference/databases/DatabaseList.jsx
+++ b/frontend/src/metabase/reference/databases/DatabaseList.jsx
@@ -64,7 +64,7 @@ class DatabaseList extends Component {
                       <ListItem
                         id={database.id}
                         index={index}
-                        name={database.display_name || database.name}
+                        name={database.name}
                         description={database.description}
                         url={`/reference/databases/${database.id}`}
                         icon="database"


### PR DESCRIPTION
To the best of my knowledge, there is do `display_name` on the `database`.

[Git blame](https://github.com/metabase/metabase/blame/a96d81c4a6b3c6b64471074f22c2c7e2a404d284/frontend/src/metabase/reference/databases/DatabaseList.jsx#L49) shows that this section was showing both databases and tables six years ago. We then moved tables to a separate view but it seems we forgot to remove the `display_name` which exists only on tables and not on databases.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30678)
<!-- Reviewable:end -->
