### PR TITLE
Handle api errors in entity hooks

### DIFF
--- a/frontend/src/metabase/common/hooks/use-database-query/use-database-query.unit.spec.tsx
+++ b/frontend/src/metabase/common/hooks/use-database-query/use-database-query.unit.spec.tsx
@@ -1,7 +1,11 @@
 import React from "react";
 import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
 import { createMockDatabase } from "metabase-types/api/mocks";
-import { setupDatabasesEndpoints } from "__support__/server-mocks";
+import {
+  PERMISSION_ERROR,
+  setupDatabasesEndpoints,
+  setupUnauthorizedDatabasesEndpoints,
+} from "__support__/server-mocks";
 import {
   renderWithProviders,
   screen,
@@ -23,8 +27,17 @@ const TestComponent = () => {
   return <div>{data.name}</div>;
 };
 
-const setup = () => {
-  setupDatabasesEndpoints([TEST_DATABASE]);
+interface SetupOpts {
+  hasDataAccess?: boolean;
+}
+
+const setup = ({ hasDataAccess = true }: SetupOpts = {}) => {
+  if (hasDataAccess) {
+    setupDatabasesEndpoints([TEST_DATABASE]);
+  } else {
+    setupUnauthorizedDatabasesEndpoints([TEST_DATABASE]);
+  }
+
   renderWithProviders(<TestComponent />);
 };
 
@@ -38,5 +51,11 @@ describe("useDatabaseQuery", () => {
     setup();
     await waitForElementToBeRemoved(() => screen.queryByText("Loading..."));
     expect(screen.getByText(TEST_DATABASE.name)).toBeInTheDocument();
+  });
+
+  it("should show error from the response", async () => {
+    setup({ hasDataAccess: false });
+    await waitForElementToBeRemoved(() => screen.queryByText("Loading..."));
+    expect(screen.getByText(PERMISSION_ERROR)).toBeInTheDocument();
   });
 });

--- a/frontend/src/metabase/common/hooks/use-entity-list-query/use-entity-list-query.ts
+++ b/frontend/src/metabase/common/hooks/use-entity-list-query/use-entity-list-query.ts
@@ -54,7 +54,8 @@ export const useEntityListQuery = <TItem, TQuery>(
   const dispatch = useDispatch();
   useEffect(() => {
     if (enabled) {
-      dispatch(fetchList(entityQuery, { reload }));
+      const action = dispatch(fetchList(entityQuery, { reload }));
+      Promise.resolve(action).catch(() => undefined);
     }
   }, [dispatch, fetchList, entityQuery, reload, enabled]);
 

--- a/frontend/src/metabase/common/hooks/use-entity-list-query/use-entity-list-query.ts
+++ b/frontend/src/metabase/common/hooks/use-entity-list-query/use-entity-list-query.ts
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useDeepCompareEffect } from "react-use";
 import type { Action } from "@reduxjs/toolkit";
 import { useDispatch, useSelector } from "metabase/lib/redux";
 import { State } from "metabase-types/store";
@@ -52,7 +52,7 @@ export const useEntityListQuery = <TItem, TQuery>(
   const error = useSelector(state => getError(state, options));
 
   const dispatch = useDispatch();
-  useEffect(() => {
+  useDeepCompareEffect(() => {
     if (enabled) {
       const action = dispatch(fetchList(entityQuery, { reload }));
       Promise.resolve(action).catch(() => undefined);

--- a/frontend/src/metabase/common/hooks/use-entity-query/use-entity-query.ts
+++ b/frontend/src/metabase/common/hooks/use-entity-query/use-entity-query.ts
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useDeepCompareEffect } from "react-use";
 import type { Action } from "@reduxjs/toolkit";
 import { useDispatch, useSelector } from "metabase/lib/redux";
 import { State } from "metabase-types/store";
@@ -61,7 +61,7 @@ export const useEntityQuery = <TId, TItem, TQuery>(
   const error = useSelector(state => getError(state, options));
 
   const dispatch = useDispatch();
-  useEffect(() => {
+  useDeepCompareEffect(() => {
     if (entityId != null && enabled) {
       const query = { ...entityQuery, id: entityId };
       const action = dispatch(fetch(query, { reload, requestType }));

--- a/frontend/src/metabase/common/hooks/use-entity-query/use-entity-query.ts
+++ b/frontend/src/metabase/common/hooks/use-entity-query/use-entity-query.ts
@@ -64,7 +64,8 @@ export const useEntityQuery = <TId, TItem, TQuery>(
   useEffect(() => {
     if (entityId != null && enabled) {
       const query = { ...entityQuery, id: entityId };
-      dispatch(fetch(query, { reload, requestType }));
+      const action = dispatch(fetch(query, { reload, requestType }));
+      Promise.resolve(action).catch(() => undefined);
     }
   }, [dispatch, fetch, entityId, entityQuery, enabled, reload, requestType]);
 

--- a/frontend/src/metabase/common/hooks/use-schema-list-query/use-schema-list-query.unit.spec.tsx
+++ b/frontend/src/metabase/common/hooks/use-schema-list-query/use-schema-list-query.unit.spec.tsx
@@ -1,7 +1,11 @@
 import React from "react";
 import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
 import { createMockDatabase, createMockTable } from "metabase-types/api/mocks";
-import { setupDatabasesEndpoints } from "__support__/server-mocks";
+import {
+  PERMISSION_ERROR,
+  setupDatabasesEndpoints,
+  setupUnauthorizedDatabasesEndpoints,
+} from "__support__/server-mocks";
 import {
   renderWithProviders,
   screen,
@@ -37,8 +41,17 @@ const TestComponent = () => {
   );
 };
 
-const setup = () => {
-  setupDatabasesEndpoints([TEST_DATABASE]);
+interface SetupOpts {
+  hasDataAccess?: boolean;
+}
+
+const setup = ({ hasDataAccess = true }: SetupOpts = {}) => {
+  if (hasDataAccess) {
+    setupDatabasesEndpoints([TEST_DATABASE]);
+  } else {
+    setupUnauthorizedDatabasesEndpoints([TEST_DATABASE]);
+  }
+
   renderWithProviders(<TestComponent />);
 };
 
@@ -52,5 +65,11 @@ describe("useSchemaListQuery", () => {
     setup();
     await waitForElementToBeRemoved(() => screen.queryByText("Loading..."));
     expect(screen.getByText(TEST_TABLE.schema)).toBeInTheDocument();
+  });
+
+  it("should show error from the response", async () => {
+    setup({ hasDataAccess: false });
+    await waitForElementToBeRemoved(() => screen.queryByText("Loading..."));
+    expect(screen.getByText(PERMISSION_ERROR)).toBeInTheDocument();
   });
 });

--- a/frontend/test/__support__/server-mocks/database.ts
+++ b/frontend/test/__support__/server-mocks/database.ts
@@ -64,6 +64,8 @@ export function setupUnauthorizedDatabaseEndpoints(db: Database) {
     status: 403,
     body: PERMISSION_ERROR,
   });
+
+  setupUnauthorizedSchemaEndpoints(db);
 }
 
 export function setupUnauthorizedDatabasesEndpoints(dbs: Database[]) {

--- a/frontend/test/__support__/server-mocks/index.ts
+++ b/frontend/test/__support__/server-mocks/index.ts
@@ -4,6 +4,7 @@ export * from "./alert";
 export * from "./bookmark";
 export * from "./card";
 export * from "./collection";
+export * from "./constants";
 export * from "./dashboard";
 export * from "./database";
 export * from "./dataset";


### PR DESCRIPTION
Use the same approach used in entity loader HoCs https://github.com/metabase/metabase/blob/bc360e61e9658fcdf004b21d5f6ddac93b83fe11/frontend/src/metabase/entities/containers/EntityObjectLoader.jsx#L64

Also fixes and issue with constant reloading due to entity query reference being changed. This is also similar to the HoCs https://github.com/metabase/metabase/blob/bc360e61e9658fcdf004b21d5f6ddac93b83fe11/frontend/src/metabase/entities/containers/EntityObjectLoader.jsx#L30

I've added tests for both cases - where we load an entity by id and the list. These tests should pass

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30687)
<!-- Reviewable:end -->
