### PR TITLE
Alternative GEOJSON.io fix (#30675)

### DIFF
--- a/test/metabase/api/login_history_test.clj
+++ b/test/metabase/api/login_history_test.clj
@@ -19,44 +19,60 @@
 (def ^:private ios-user-agent
   "Mozilla/5.0 (iPhone; CPU iPhone OS 10_3_1 like Mac OS X) AppleWebKit/603.1.30 (KHTML  like Gecko) Version/10.0 Mobile/14E304 Safari/602.1")
 
+(defn- if-non-nil
+  "Returns a schema that matches the provided value `v` if a value is non-nil, otherwise expects nil. Handling issues in
+  geojson.io."
+  [v]
+  (let [non-nil-check (cond-> v
+                        ;; regexes are matchers otherwise check for s/eq
+                        (not (instance? java.util.regex.Pattern v))
+                        (s/eq))]
+    (s/conditional some? non-nil-check nil? (s/eq nil))))
+
 (deftest login-history-test
   (testing "GET /api/login-history/current"
-    (let [session-id (str (java.util.UUID/randomUUID))]
+    (let [session-id (str (java.util.UUID/randomUUID))
+          device-id  "e9b49ec7-bc64-4a83-9b1a-ecd3ae26ba9d"]
       (mt/with-temp* [User         [user]
                       Session      [_ {:id session-id, :user_id (u/the-id user)}]
                       LoginHistory [_ {:timestamp          #t "2021-03-18T19:52:41.808482Z"
                                        :user_id            (u/the-id user)
-                                       :device_id          "e9b49ec7-bc64-4a83-9b1a-ecd3ae26ba9d"
+                                       :device_id          device-id
                                        :device_description windows-user-agent
                                        :ip_address         "185.233.100.23"
                                        :session_id         session-id}]
                       LoginHistory [_ {:timestamp          #t "2021-03-18T20:04:24.727300Z"
                                        :user_id            (u/the-id user)
-                                       :device_id          "e9b49ec7-bc64-4a83-9b1a-ecd3ae26ba9d"
+                                       :device_id          device-id
                                        :device_description "Apache-HttpClient/4.5.10 (Java/14.0.1)"
                                        :ip_address         "127.0.0.1"}]
                       LoginHistory [_ {:timestamp          #t "2021-03-18T20:55:50.955232Z"
                                        :user_id            (u/the-id user)
-                                       :device_id          "e9b49ec7-bc64-4a83-9b1a-ecd3ae26ba9d"
+                                       :device_id          device-id
                                        :device_description ios-user-agent
                                        :ip_address         "0:0:0:0:0:0:0:1"}]
                       LoginHistory [_ {:timestamp          #t "2021-03-18T19:52:20.172351Z"
                                        :user_id            (u/the-id user)
-                                       :device_id          "e9b49ec7-bc64-4a83-9b1a-ecd3ae26ba9d"
+                                       :device_id          device-id
                                        :device_description windows-user-agent
                                        :ip_address         "52.206.149.9"}]
                       ;; this one shouldn't show up because it's from a different User
                       LoginHistory [_ {:timestamp          #t "2021-03-17T19:00Z"
                                        :user_id            (mt/user->id :rasta)
-                                       :device_id          "e9b49ec7-bc64-4a83-9b1a-ecd3ae26ba9d"
+                                       :device_id          device-id
                                        :device_description windows-user-agent
                                        :ip_address         "52.206.149.9"}]]
+        ;; GeoJS is having issues. We have safe error handling so we expect either nil or the expected values.
+        ;; https://github.com/jloh/geojs/issues/48
+        ;; The timestamps will also need to be updated (to be in the TZ, not in Zulu time)
+        ;;
+        ;; A Slack reminder has been set to follow up on this
         (is (schema= [(s/one
                        {:timestamp          (s/eq "2021-03-18T20:55:50.955232Z")
                         :device_description (s/eq "Mobile Browser (Mobile Safari/iOS)")
                         :ip_address         (s/eq "0:0:0:0:0:0:0:1")
                         :active             (s/eq false)
-                        :location           (s/eq "Unknown location")
+                        :location           (if-non-nil "Unknown location")
                         :timezone           (s/eq nil)}
                        "localhost ipv6")
                       (s/one
@@ -64,7 +80,7 @@
                         :device_description (s/eq "Library (Apache-HttpClient/JVM (Java))")
                         :ip_address         (s/eq "127.0.0.1")
                         :active             (s/eq false)
-                        :location           (s/eq "Unknown location")
+                        :location           (if-non-nil "Unknown location")
                         :timezone           (s/eq nil)}
                        "localhost ipv4")
                       (s/one
@@ -72,15 +88,15 @@
                         :device_description (s/eq "Browser (Chrome/Windows)")
                         :ip_address         (s/eq "185.233.100.23")
                         :active             (s/eq true)
-                        :location           #"France"
-                        :timezone           (s/eq "CET")}
+                        :location           (if-non-nil #"France")
+                        :timezone           (if-non-nil "CET")}
                        "France")
                       (s/one
                        {:timestamp          (s/eq "2021-03-18T15:52:20.172351-04:00")
                         :device_description (s/eq "Browser (Chrome/Windows)")
                         :ip_address         (s/eq "52.206.149.9")
                         :active             (s/eq false)
-                        :location           (s/eq "Ashburn, Virginia, United States")
-                        :timezone           (s/eq "ET")}
+                        :location           (if-non-nil "Ashburn, Virginia, United States")
+                        :timezone           (if-non-nil "ET")}
                        "Virginia")]
                      (mt/client session-id :get 200 "login-history/current")))))))

--- a/test/metabase/api/session_test.clj
+++ b/test/metabase/api/session_test.clj
@@ -82,8 +82,11 @@
                            "exception")
                     (s/one (s/eq "Authentication endpoint error")
                            "log message")]
-                   (first (mt/with-log-messages-for-level :error
-                            (mt/client :post 400 "session" {:email (:email user), :password "wooo"}))))))))
+                   (->> (mt/with-log-messages-for-level :error
+                          (mt/client :post 400 "session" {:email (:email user), :password "wooo"}))
+                        ;; geojson can throw errors and we want the authentication error
+                        (filter (fn [[_log-level _error message]] (= message "Authentication endpoint error")))
+                        first))))))
 
 (deftest login-validation-test
   (testing "POST /api/session"

--- a/test/metabase/server/request/util_test.clj
+++ b/test/metabase/server/request/util_test.clj
@@ -81,8 +81,9 @@
             (is (= "1.2.3.4"
                    (request.u/ip-address mock-request)))))))))
 
-(deftest geocode-ip-addresses-test
-  (are [ip-addresses expected] (schema= expected (request.u/geocode-ip-addresses ip-addresses))
+(deftest ^:parallel geocode-ip-addresses-test
+  (are [ip-addresses expected] (schema= (s/conditional some? expected nil? (s/eq nil))
+                                        (request.u/geocode-ip-addresses ip-addresses))
     ["8.8.8.8"]
     {(s/required-key "8.8.8.8") {:description (s/eq "Los Angeles, California, United States")
                                  :timezone    (s/eq (t/zone-id "America/Los_Angeles"))}}


### PR DESCRIPTION
Manual backport of https://github.com/metabase/metabase/pull/30675 . Had a conflict due to `^:parallel` metadata on `geocode-ip-addresses-test` test.

* Alternative GEOJSON.io fix

rather than not testing, just accept that we might get an expected location back or we might get nil. This actually represents how the application will behave and will seamlessly work as the service improves or continues throwing errors:

```shell
❯ curl "https://get.geojs.io/v1/ip/geo.json?ip=8.8.8.8,136.49.173.73,185.233.100.23"
<html>
<head><title>500 Internal Server Error</title></head>
<body>
<center><h1>500 Internal Server Error</h1></center>
<hr><center>openresty</center>
</body>
</html>

❯ curl "https://get.geojs.io/v1/ip/geo.json?ip=8.8.8.8,136.49.173.73"
[{"area_code":"0","organization_name":"GOOGLE","country_code":"US",
  "country_code3":"USA","continent_code":"NA","ip":"8.8.8.8",
  "region":"California","latitude":"34.0544","longitude":"-118.2441",
  "accuracy":5,"timezone":"America\/Los_Angeles","city":"Los Angeles",
  "organization":"AS15169 GOOGLE","asn":15169,"country":"United States"},
 {"area_code":"0","organization_name":"GOOGLE-FIBER","country_code":"US",
 "country_code3":"USA","continent_code":"NA","ip":"136.49.173.73",
 "region":"Texas","latitude":"30.2423","longitude":"-97.7672",
 "accuracy":5,"timezone":"America\/Chicago","city":"Austin",
 "organization":"AS16591 GOOGLE-FIBER","asn":16591,"country":"United States"}]
```

Changes are basically

```clojure
(schema= (s/conditional some? <original-expectation-schema>
                        nil?  (s/eq nil)
         response-from-geojson)
```

* Filter to login error messages

```clojure
(into [] (map (fn [[log-level error message]] [log-level (type error) message]))
      error-messages-captured-in-test)
[[:error
  clojure.lang.ExceptionInfo
  "Error geocoding IP addresses {:url https://get.geojs.io/v1/ip/geo.json?ip=127.0.0.1}"]
 [:error clojure.lang.ExceptionInfo "Authentication endpoint error"]]
 ```

* check timestamps with regex

seems like they fixed the service

```shell
curl "https://get.geojs.io/v1/ip/geo.json?ip=8.8.8.8,136.49.173.73,185.233.100.23" [{"country":"United States","latitude":"34.0544","longitude":"-118.2441","accuracy":5,"timezone":"America\/Los_Angeles","ip":"8.8.8.8","organization":"AS15169 GOOGLE","country_code3":"USA","asn":15169,"area_code":"0","organization_name":"GOOGLE","country_code":"US","city":"Los Angeles","continent_code":"NA","region":"California"},{"country":"United States","latitude":"30.2423","longitude":"-97.7672","accuracy":5,"timezone":"America\/Chicago","ip":"136.49.173.73","organization":"AS16591 GOOGLE-FIBER","country_code3":"USA","asn":16591,"area_code":"0","organization_name":"GOOGLE-FIBER","country_code":"US","city":"Austin","continent_code":"NA","region":"Texas"},{"country":"France","latitude":"48.8582","longitude":"2.3387","accuracy":500,"timezone":"Europe\/Paris","ip":"185.233.100.23","organization":"AS198985 AQUILENET","country_code3":"FRA","asn":198985,"area_code":"0","organization_name":"AQUILENET","country_code":"FR","continent_code":"EU"}]
```

whereas a few hours ago that returned a 500. And now the timestamps are different

```
;; from schema
"2021-03-18T19:52:41.808482Z"
;; results
"2021-03-18T20:52:41.808482+01:00"
```

kinda sick of dealing with this and don't want to deal with a schema
that matches "near" to a timestamp.

* Restore these

i copied changes over from tim's fix and it included these fixes. But
now the service is fixed and these are the original values from cam's
original fixes

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30696)
<!-- Reviewable:end -->
