### PR TITLE
Use database features from API to determine whether a DB supports schema

### DIFF
--- a/frontend/src/metabase-types/api/database.ts
+++ b/frontend/src/metabase-types/api/database.ts
@@ -25,6 +25,7 @@ export type DatabaseFeature =
   | "standard-deviation-aggregations"
   | "persist-models"
   | "persist-models-enabled"
+  | "schemas"
   | "set-timezone"
   | "left-join"
   | "right-join"

--- a/frontend/src/metabase/admin/settings/components/UploadSettings/UploadSettings.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/components/UploadSettings/UploadSettings.unit.spec.tsx
@@ -24,6 +24,7 @@ const TEST_DATABASES = [
       createMockTable({ schema: "uploads" }),
       createMockTable({ schema: "top_secret" }),
     ],
+    features: ["schemas"],
   }),
   createMockDatabase({
     id: 2,
@@ -37,6 +38,7 @@ const TEST_DATABASES = [
     engine: "h2",
     settings: { "database-enable-actions": true },
     tables: [createMockTable({ schema: "public" })],
+    features: ["schemas"],
   }),
   createMockDatabase({
     id: 4,
@@ -50,6 +52,7 @@ const TEST_DATABASES = [
     engine: "h2",
     settings: { "database-enable-actions": true },
     tables: [],
+    features: ["schemas"],
   }),
 ];
 

--- a/frontend/src/metabase/admin/settings/components/UploadSettings/utils.ts
+++ b/frontend/src/metabase/admin/settings/components/UploadSettings/utils.ts
@@ -9,11 +9,7 @@ export const getDatabaseOptions = (databases: Database[]) =>
 export const getSchemaOptions = (schema: Schema[]) =>
   schema.map(s => ({ name: s.name, value: s.name }));
 
-// it would be nice if the API returned schema as a DB feature at a driver level,
-// but it doesn't do this yet
-const enginesWithSchema = ["postgres", "h2"];
-
-export const dbHasSchema = (databases: Database[], dbId: number) =>
-  enginesWithSchema.includes(
-    databases.find((db: Database) => db.id === dbId)?.engine ?? "",
-  );
+export const dbHasSchema = (databases: Database[], dbId: number): boolean =>
+  !!databases
+    .find((db: Database) => db.id === dbId)
+    ?.features.includes("schemas");

--- a/frontend/src/metabase/admin/settings/components/UploadSettings/utils.unit.spec.ts
+++ b/frontend/src/metabase/admin/settings/components/UploadSettings/utils.unit.spec.ts
@@ -25,11 +25,13 @@ describe("Admin > UploadSettings > utils", () => {
         id: 100,
         settings: { "database-enable-actions": true },
         engine: "postgres",
+        features: ["schemas"],
       }),
       createMockDatabase({
         id: 200,
         settings: { "database-enable-actions": false },
         engine: "h2",
+        features: ["schemas"],
       }),
       createMockDatabase({
         id: 300,


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/30604
Uses new API data from https://github.com/metabase/metabase/pull/30536

### Description

Instead of hard coding on the frontend that we shouldn't show the schema picker for mysql, this uses the "schemas" feature from the database API endpoint to determine whether a particular db supports schema. Works exactly how it did before, but in a way that will be far more extensible as we add more db support for actions.

![db-features-check](https://github.com/metabase/metabase/assets/30528226/0f5478db-2875-400d-b662-331b633c97a3)


### How to verify

1. go to admin upload settings with both postgres + mysql actions-enabled DBs
2. see that when you select a mysql database, it gives you a text input for a table prefix instead of a schema picker
3. see that postgres + h2 dbs give you a schema dropdown

### Checklist

- [x] Tests have been added/updated to cover changes in this PR

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30701)
<!-- Reviewable:end -->
