### PR TITLE
docs - fix links

### DIFF
--- a/docs/people-and-groups/google-and-ldap.md
+++ b/docs/people-and-groups/google-and-ldap.md
@@ -137,5 +137,5 @@ On paid plans, you can require people to log in with SSO by disabling password a
 [google-saml-docs]: ./saml-google.md
 [jwt-docs]: ./authenticating-with-jwt.md
 [saml-docs]: ./authenticating-with-saml.md
-[user-attributes-docs]: ../permissions/data-sandboxes.md#getting-user-attributes
+[user-attributes-docs]: ../permissions/data-sandboxes.md#choosing-user-attributes-for-data-sandboxes
 [user-attributes-def]: https://www.metabase.com/glossary/attribute#user-attributes-in-metabase

--- a/docs/permissions/data-sandbox-examples.md
+++ b/docs/permissions/data-sandbox-examples.md
@@ -7,7 +7,7 @@ title: Data sandbox examples
 [Data sandboxes](./data-sandboxes.md) are a set of permissions that show different data to different people based on their user attributes. You can:
 
 - Restrict **rows** using a [basic sandbox](./data-sandboxes.md#basic-data-sandboxes-filter-by-a-column-in-the-table).
-- Restrict **columns** using a [custom sandbox](./data-sandboxes.md#custom-data-sandboxes-use-a-saved-question-to-create-a-custom-view-for-this-table). 
+- Restrict **columns** using a [custom sandbox](./data-sandboxes.md#custom-data-sandboxes-use-a-saved-question-to-create-a-custom-view-of-a-table). 
 
 Permissions are always a bit pesky to set up, so here are some examples to get you started. (The example happens to use a group called "Customers" but this works the same whether you're doing this for internal or external folks.)
 

--- a/docs/permissions/data-sandboxes.md
+++ b/docs/permissions/data-sandboxes.md
@@ -118,7 +118,7 @@ You can find a sample basic sandbox setup in the [Data sandbox examples](./data-
 
 - A [group](../people-and-groups/managing.md#groups) of people to be added to the advanced data sandbox.
 - An admin-only [collection](../exploration-and-organization/collections.md), with [collection permissions](../permissions/collections.md) set to **No access** for all groups except Administrators.
-- A [saved SQL question](../people-and-groups/) with the rows and columns to be displayed to the people in the custom sandbox, stored in the admin-only collection.
+- A [saved SQL question](../questions/native-editor/writing-sql.md) with the rows and columns to be displayed to the people in the custom sandbox, stored in the admin-only collection.
 - Optional: if you want to restrict **rows** in a custom sandbox, set up [user attributes](#choosing-user-attributes-for-data-sandboxes) for each of the people in the group.
 
 ### Creating a SQL question for Metabase to display in an custom sandbox

--- a/docs/questions/query-builder/expressions/case.md
+++ b/docs/questions/query-builder/expressions/case.md
@@ -334,7 +334,7 @@ case([Has Wings] = TRUE  AND [Has Face] = TRUE,  "Bird",
 [custom-expressions-doc]: ../expressions.md
 [custom-expressions-list]: ../expressions-list.md
 [custom-expressions-learn]: https://www.metabase.com/learn/questions/custom-expressions
-[data-sandboxing-docs]: ../../../permissions/data-sandboxes.md#filtering-a-sandboxed-table
+[data-sandboxing-docs]: ../../../permissions/data-sandboxes.md
 [data-types]: https://www.metabase.com/learn/databases/data-types-overview#examples-of-data-types
 [filter-learn]: https://www.metabase.com/learn/questions/searching-tables
 [notebook-editor-def]: https://www.metabase.com/glossary/notebook_editor

--- a/docs/troubleshooting-guide/sandboxing.md
+++ b/docs/troubleshooting-guide/sandboxing.md
@@ -176,6 +176,6 @@ The administrator can [create a new group][groups] to capture precisely who's al
 [row-permissions]: https://www.metabase.com/learn/permissions/data-sandboxing-row-permissions
 [sandboxing-your-data]: ../permissions/data-sandboxes.md
 [signed-embedding]: https://www.metabase.com/learn/customer-facing-analytics/embedding-charts-and-dashboards#enable-embedding-in-other-applications
-[sandbox-limitations]: ../enterprise-guide/data-sandboxes.html#current-limitations
+[sandbox-limitations]: ../permissions/data-sandboxes.md#limitations
 [troubleshooting-permissions]: ./permissions.md
-[unsupported-databases]: ../permissions/data-sandboxes.md#data-sandboxes-do-not-support-non-sql-databases
+[unsupported-databases]: ../permissions/data-sandboxes.md#limitations


### PR DESCRIPTION
Is it safe to ignore the `/cloud/docs` errors? Like these:

```
- ./_site/docs/latest/index.html
  *  internally linking to /cloud/docs, which does not exist (line 751)
     <a href="/cloud/docs">Metabase Cloud</a>
  *  internally linking to /docs/latest/cloud/start, which does not exist (line 705)
     <a href="/docs/latest/cloud/start">Documentation for Metabase Cloud and Store</a>
```

I was only expecting to see the broken Learn links!

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30702)
<!-- Reviewable:end -->
