### PR TITLE
Hides malli's instrumentation messages

### DIFF
--- a/dev/src/dev.clj
+++ b/dev/src/dev.clj
@@ -61,7 +61,7 @@
   []
   (server/start-web-server! #'handler/app)
   (when config/is-dev?
-    (malli-dev/start!))
+    (with-out-str (malli-dev/start!)))
   (when-not @initialized?
     (init!)))
 

--- a/src/metabase/util/malli.cljc
+++ b/src/metabase/util/malli.cljc
@@ -65,8 +65,8 @@
    (clojure.core/defn instrument!
      "Instrument a [[metabase.util.malli/defn]]."
      [id]
-     (minst/instrument! {:filters [(minst/-filter-var #(-> % meta :validate! (= id)))]
-                         :report  explain-fn-fail!}))
+     (with-out-str (minst/instrument! {:filters [(minst/-filter-var #(-> % meta :validate! (= id)))]
+                                       :report  explain-fn-fail!})))
    :cljs
    (clojure.core/defn instrument!
      "Instrument a [[metabase.util.malli/defn]]. No-op for ClojureScript. Instrumentation currently only works in


### PR DESCRIPTION
Before:
```
❯ clj -M:"$ALIASES"
WARNING: abs already refers to: #'clojure.core/abs in namespace: clojure.algo.generic.math-functions, being replaced by: #'clojure.algo.generic.math-functions/abs
operator.clj:172 recur arg for primitive local: sum is not matching primitive, had: Object, needed: long
Auto-boxing loop arg: sum
Clojure 1.12.0-alpha2
user=> (do (dev) (start!))
Warning: environ value /Users/dan/.sdkman/candidates/java/current for key :java-home has been overwritten with /Users/dan/.sdkman/candidates/java/17.0.1-zulu/zulu-17.jdk/Contents/Home
2023-05-12 14:26:37,091 INFO metabase.util :: Maximum memory available to JVM: 8.0 GB
2023-05-12 14:26:47,248 INFO util.encryption :: Saved credentials encryption is DISABLED for this Metabase instance. 🔓
 For more information, see https://metabase.com/docs/latest/operations-guide/encrypting-database-details-at-rest.html
..instrumented #'metabase.util.malli/with-api-error-message
..instrumented #'metabase.util.honey-sql-2/identifier
..instrumented #'metabase.util.honey-sql-2/normalize-type-info
..instrumented #'metabase.util.honey-sql-2/with-database-type-info
..instrumented #'metabase.util.honey-sql-2/cast
..instrumented #'metabase.util.honey-sql-2/quoted-cast
```

After:

```
❯ clj -M:"$ALIASES"
WARNING: abs already refers to: #'clojure.core/abs in namespace: clojure.algo.generic.math-functions, being replaced by: #'clojure.algo.generic.math-functions/abs
operator.clj:172 recur arg for primitive local: sum is not matching primitive, had: Object, needed: long
Auto-boxing loop arg: sum
Clojure 1.12.0-alpha2
user=> (do (dev) (start!))
Warning: environ value /Users/dan/.sdkman/candidates/java/current for key :java-home has been overwritten with /Users/dan/.sdkman/candidates/java/17.0.1-zulu/zulu-17.jdk/Contents/Home
2023-05-12 15:11:21,678 INFO metabase.util :: Maximum memory available to JVM: 8.0 GB
2023-05-12 15:11:30,806 INFO util.encryption :: Saved credentials encryption is DISABLED for this Metabase instance. 🔓
 For more information, see https://metabase.com/docs/latest/operations-guide/encrypting-database-details-at-rest.html
util.cljc:346 recur arg for primitive local: cumulative_byte_count is not matching primitive, had: Object, needed: long
Auto-boxing loop arg: cumulative-byte-count
WARNING: infinite? already refers to: #'kixi.stats.math/infinite? in namespace: kixi.stats.core, being replaced by: #'clojure.core/infinite?
2023-05-12 15:11:55,615 INFO driver.impl :: Registered abstract driver :sql  🚚
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30737)
<!-- Reviewable:end -->
