### PR TITLE
Includes data model with selective serialization, adds --no-settings

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/serialization/cmd.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/cmd.clj
@@ -186,8 +186,11 @@
   (mdb/setup-db!)
   (t2/select User) ;; TODO -- why??? [editor's note: this comment originally from Cam]
   (serdes/with-cache
-    (-> (v2.extract/extract (merge opts {:targets (v2.extract/make-targets-of-type "Collection" collections)
-                                         :user-id (t2/select-one-pk User :email user-email :is_superuser true)}))
+    (-> opts
+        (cond->
+         (seq collections) (assoc :targets (v2.extract/make-targets-of-type "Collection" collections))
+         user-email        (assoc :user-id (t2/select-one-pk User :email user-email :is_superuser true)))
+        v2.extract/extract
         (v2.storage/store! path)))
   (log/info (trs "Export to {0} complete!" path) (u/emoji "🚛💨 📦")))
 

--- a/enterprise/backend/src/metabase_enterprise/serialization/cmd.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/cmd.clj
@@ -186,8 +186,7 @@
   (mdb/setup-db!)
   (t2/select User) ;; TODO -- why??? [editor's note: this comment originally from Cam]
   (serdes/with-cache
-    (-> opts
-        (cond->
+    (-> (cond-> opts
          (seq collections) (assoc :targets (v2.extract/make-targets-of-type "Collection" collections))
          user-email        (assoc :user-id (t2/select-one-pk User :email user-email :is_superuser true)))
         v2.extract/extract

--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/extract.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/extract.clj
@@ -19,19 +19,19 @@
 
 (defn- model-set
   "Returns a set of models to export based on export opts"
-  [{:keys [include-field-values targets no-data-model]}]
+  [opts]
   (cond-> #{}
-    include-field-values
+    (:include-field-values opts)
     (conj "FieldValues")
 
-    ;; If `targets` is not specified, or if it is a non-empty collection, then we
-    ;; extract all content models. If `targets` is an empty collection, then do not export
-    ;; any content.
-    (or (nil? targets) (seq targets))
+    (not (:no-collections opts))
     (into serdes.models/content)
 
-    (not no-data-model)
-    (into serdes.models/data-model)))
+    (not (:no-data-model opts))
+    (into serdes.models/data-model)
+
+    (not (:no-settings opts))
+    (conj "Setting")))
 
 (defn targets-of-type
   "Returns target seq filtered on given model name"
@@ -178,15 +178,19 @@ Eg. if Dashboard B includes a Card A that is derived from a
     (escape-report analysis)
     ;; If it's nil, there are no errors, and we can proceed to do the dump.
     (let [closure  (descendants-closure targets)
+          models   (model-set opts)
           ;; filter the selected models based on user options
           by-model (-> (group-by first closure)
-                       (select-keys (model-set opts))
+                       (select-keys models)
                        (update-vals #(set (map second %))))]
-      (eduction (map (fn [[model ids]]
-                       (eduction (map #(serdes/extract-one model opts %))
-                                 (db/select-reducible (symbol model) :id [:in ids]))))
-                cat
-                by-model))))
+      (concat
+       (eduction (map (fn [[model ids]]
+                        (eduction (map #(serdes/extract-one model opts %))
+                                  (db/select-reducible (symbol model) :id [:in ids]))))
+                 cat
+                 by-model)
+       ;; extract all non-content entities like data model and settings if necessary
+       (eduction (map #(serdes/extract-all % opts)) cat (remove (set serdes.models/content) models))))))
 
 (defn extract
   "Returns a reducible stream of entities to serialize"

--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/models.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/models.clj
@@ -15,14 +15,14 @@
    "Collection"
    "Dashboard"
    "NativeQuerySnippet"
-   "Setting"
    "Timeline"])
 
 (def exported-models
   "The list of all models exported by serialization by default. Used for production code and by tests."
   (concat data-model
           content
-          ["FieldValues"]))
+          ["FieldValues"
+           "Setting"]))
 
 (def inlined-models
   "An additional list of models which are inlined into parent entities for serialization.

--- a/enterprise/backend/test/metabase_enterprise/serialization/api/serialize_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/api/serialize_test.clj
@@ -43,7 +43,7 @@
                  (path-files (apply u.files/get-path dir path-components)))]
          (is (= (map
                  #(.toString (u.files/get-path (System/getProperty "java.io.tmpdir") "serdes-dir" %))
-                 ["collections"])
+                 ["collections" "databases" "settings.yaml"])
                 (files)))
          (testing "subdirs"
            (testing "cards"

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
@@ -1287,12 +1287,16 @@
                        DashboardCard [_                       {:card_id      c4-id
                                                                :dashboard_id dash4-id}]]
 
+      (testing "selecting a collection includes settings and data model by default"
+        (is (= #{"Card" "Collection" "Dashboard" "Database" "Setting"}
+               (set (map (comp :model first serdes/path) (extract/extract {:targets [["Collection" coll1-id]]}))))))
+
       (testing "selecting a dashboard gets all cards its dashcards depend on"
         (testing "grandparent dashboard"
           (is (= #{[{:model "Dashboard" :id dash1-eid :label "dashboard_1"}]
                    [{:model "Card"      :id c1-1-eid  :label "question_1_1"}]
                    [{:model "Card"      :id c1-2-eid  :label "question_1_2"}]}
-                 (->> (extract/extract {:targets [["Dashboard" dash1-id]]})
+                 (->> (extract/extract {:targets [["Dashboard" dash1-id]] :no-settings true :no-data-model true})
                       (map serdes/path)
                       set))))
 
@@ -1300,7 +1304,7 @@
           (is (= #{[{:model "Dashboard" :id dash2-eid :label "dashboard_2"}]
                    [{:model "Card"      :id c2-1-eid  :label "question_2_1"}]
                    [{:model "Card"      :id c2-2-eid  :label "question_2_2"}]}
-                 (->> (extract/extract {:targets [["Dashboard" dash2-id]]})
+                 (->> (extract/extract {:targets [["Dashboard" dash2-id]] :no-settings true :no-data-model true})
                       (map serdes/path)
                       set))))
 
@@ -1308,7 +1312,7 @@
           (is (= #{[{:model "Dashboard" :id dash3-eid :label "dashboard_3"}]
                    [{:model "Card"      :id c3-1-eid  :label "question_3_1"}]
                    [{:model "Card"      :id c3-2-eid  :label "question_3_2"}]}
-                 (->> (extract/extract {:targets [["Dashboard" dash3-id]]})
+                 (->> (extract/extract {:targets [["Dashboard" dash3-id]] :no-settings true :no-data-model true})
                       (map serdes/path)
                       set))))
 
@@ -1319,7 +1323,7 @@
                     [{:model "Card"          :id c1-1-eid  :label "question_1_1"}]
                     ;; card that the card on dashboard linked to
                     [{:model "Card"          :id c1-2-eid  :label "question_1_2"}]}
-               (->> (extract/extract {:targets [["Dashboard" dash4-id]]})
+               (->> (extract/extract {:targets [["Dashboard" dash4-id]] :no-settings true :no-data-model true})
                     (map serdes/path)
                     set)))))
 
@@ -1341,17 +1345,17 @@
                                   [{:model "Card"          :id c1-3-eid  :label "question_1_3"}]}]
           (testing "grandchild collection has all its own contents"
             (is (= grandchild-paths ; Includes the third card not found in the collection
-                   (->> (extract/extract {:targets [["Collection" coll3-id]]})
+                   (->> (extract/extract {:targets [["Collection" coll3-id]] :no-settings true :no-data-model true})
                         (map serdes/path)
                         set))))
           (testing "middle collection has all its own plus the grandchild and its contents"
             (is (= (set/union middle-paths grandchild-paths)
-                   (->> (extract/extract {:targets [["Collection" coll2-id]]})
+                   (->> (extract/extract {:targets [["Collection" coll2-id]] :no-settings true :no-data-model true})
                         (map serdes/path)
                         set))))
           (testing "grandparent collection has all its own plus the grandchild and middle collections with contents"
             (is (= (set/union grandparent-paths middle-paths grandchild-paths)
-                   (->> (extract/extract {:targets [["Collection" coll1-id]]})
+                   (->> (extract/extract {:targets [["Collection" coll1-id]] :no-settings true :no-data-model true})
                         (map serdes/path)
                         set))))
 
@@ -1363,7 +1367,7 @@
                       [{:model "Card"          :id c1-1-eid  :label "question_1_1"}]
                       ;; card that the card on dashboard linked to
                       [{:model "Card"          :id c1-2-eid  :label "question_1_2"}]}
-                 (->> (extract/extract {:targets [["Collection" coll4-id]]})
+                 (->> (extract/extract {:targets [["Collection" coll4-id]] :no-settings true :no-data-model true})
                       (map serdes/path)
                       set)))))))))
 

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
@@ -1289,7 +1289,10 @@
 
       (testing "selecting a collection includes settings and data model by default"
         (is (= #{"Card" "Collection" "Dashboard" "Database" "Setting"}
-               (set (map (comp :model first serdes/path) (extract/extract {:targets [["Collection" coll1-id]]}))))))
+               (->> {:targets [["Collection" coll1-id]]}
+                    extract/extract
+                    (map (comp :model first serdes/path))
+                    set))))
 
       (testing "selecting a dashboard gets all cards its dashcards depend on"
         (testing "grandparent dashboard"

--- a/src/metabase/cmd.clj
+++ b/src/metabase/cmd.clj
@@ -212,9 +212,8 @@
                :update-fn (fnil conj [])]
               [nil "--collections ID_LIST"       "(Legacy-style) Export collections in comma-separated list of IDs, e.g. '123,456'."
                :parse-fn  (fn [s] (map #(Integer/parseInt %) (str/split s #"\s*,\s*")))]
-              ["-C" "--no-collections"           "Do not export any collections or contents; overrides -c."
-               :id        :collections
-               :update-fn (constantly [])]
+              ["-C" "--no-collections"           "Do not export any content in collections."]
+              ["-S" "--no-settings"              "Do not export settings.yaml"]
               ["-D" "--no-data-model"            "Do not export any data model entities; useful for subsequent exports."]
               ["-f" "--include-field-values"     "Include field values along with field metadata."]
               ["-s" "--include-database-secrets" "Include database connection details (in plain text; use caution)."]]}

--- a/test/metabase/cmd_test.clj
+++ b/test/metabase/cmd_test.clj
@@ -40,7 +40,7 @@
     (is (= '(metabase-enterprise.serialization.cmd/v1-dump "/path/" {:state :active})
            (cmd/dump "/path/" "--state" "active")))))
 
-(deftest export-command-test
+(deftest export-command-arg-parsing-test
   (are [cmd-args v2-dump-args] (= '(metabase-enterprise.serialization.cmd/v2-dump "/path/" v2-dump-args)
                                   (apply cmd/export "/path/" cmd-args))
     nil
@@ -56,7 +56,10 @@
     {:include-field-values true}
 
     ["--no-collections"]
-    {:collections []}
+    {:no-collections true}
+
+    ["--no-settings"]
+    {:no-settings true}
 
     ["--no-data-model"]
     {:no-data-model true}))


### PR DESCRIPTION
This is hopefully the last bit of refinement on the behavior of the `export` command, which adds a `--no-settings`/`-S` option and updates the behavior of selective serialization to include settings and data model by default.

All exports will include the data model and settings unless overridden, whether a collection is specified or not.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30741)
<!-- Reviewable:end -->
