### PR TITLE
Keep original join-aliases in expected columns

### DIFF
--- a/src/metabase/query_processor.clj
+++ b/src/metabase/query_processor.clj
@@ -307,6 +307,10 @@
               (preprocess* query)))]
     (qp query nil nil)))
 
+(defn- restore-join-aliases [preprocessed-query]
+  (let [replacement (-> preprocessed-query :info :alias/escaped->original)]
+    (escape-join-aliases/restore-aliases preprocessed-query replacement)))
+
 (defn query->expected-cols
   "Return the `:cols` you would normally see in MBQL query results by preprocessing the query and calling `annotate` on
   it. This only works for pure MBQL queries, since it does not actually run the queries. Native queries or MBQL
@@ -314,16 +318,13 @@
   [{query-type :type, :as query}]
   (when-not (= (mbql.u/normalize-token query-type) :query)
     (throw (ex-info (tru "Can only determine expected columns for MBQL queries.")
-             {:type qp.error-type/qp})))
+                    {:type qp.error-type/qp})))
   ;; TODO - we should throw an Exception if the query has a native source query or at least warn about it. Need to
   ;; check where this is used.
   (qp.store/with-store
-    (let [preprocessed (preprocess query)]
+    (let [preprocessed (-> query preprocess restore-join-aliases)]
       (driver/with-driver (driver.u/database->driver (:database preprocessed))
-        (let [escaped->original (-> preprocessed :info :alias/escaped->original)
-              column-info (cond-> (annotate/merged-column-info preprocessed nil)
-                            (seq escaped->original) (escape-join-aliases/restore-aliases escaped->original))]
-          (not-empty (vec column-info)))))))
+        (not-empty (vec (annotate/merged-column-info preprocessed nil)))))))
 
 (defn compile
   "Return the native form for `query` (e.g. for a MBQL query on Postgres this would return a map containing the compiled

--- a/src/metabase/query_processor.clj
+++ b/src/metabase/query_processor.clj
@@ -320,7 +320,10 @@
   (qp.store/with-store
     (let [preprocessed (preprocess query)]
       (driver/with-driver (driver.u/database->driver (:database preprocessed))
-        (not-empty (vec (annotate/merged-column-info preprocessed nil)))))))
+        (let [escaped->original (-> preprocessed :info :alias/escaped->original)
+              column-info (cond-> (annotate/merged-column-info preprocessed nil)
+                            (seq escaped->original) (escape-join-aliases/restore-aliases escaped->original))]
+          (not-empty (vec column-info)))))))
 
 (defn compile
   "Return the native form for `query` (e.g. for a MBQL query on Postgres this would return a map containing the compiled

--- a/test/metabase/query_processor/util/add_alias_info_test.clj
+++ b/test/metabase/query_processor/util/add_alias_info_test.clj
@@ -5,7 +5,6 @@
    [clojure.walk :as walk]
    [metabase.driver :as driver]
    [metabase.driver.h2 :as h2]
-   [metabase.driver.util :as driver.u]
    [metabase.models.field :refer [Field]]
    [metabase.query-processor :as qp]
    [metabase.query-processor.middleware.fix-bad-references
@@ -575,36 +574,40 @@
   (testing "field_refs in expected columns have the original join aliases (#30648)"
     (mt/dataset sample-dataset
       (binding [driver/*driver* ::custom-escape-spaces-to-underscores]
-        (with-redefs [driver.u/database->driver (constantly ::custom-escape-spaces-to-underscores)]
-          (let [query
-                (mt/mbql-query
-                    products
-                    {:joins
-                     [{:source-query
-                       {:source-table $$orders
-                        :joins
-                        [{:source-table $$people
-                          :alias "People"
-                          :condition [:= $orders.user_id &People.people.id]
-                          :fields [&People.people.address]
-                          :strategy :left-join}]
-                        :fields [$orders.id &People.people.address]}
-                       :alias "Question 54"
-                       :condition [:= $id [:field %orders.id {:join-alias "Question 54"}]]
-                       :fields [[:field %orders.id {:join-alias "Question 54"}]
-                                [:field %people.address {:join-alias "Question 54"}]]
-                       :strategy :left-join}]
-                     :fields
-                     [!default.created_at
-                      [:field %orders.id {:join-alias "Question 54"}]
-                      [:field %people.address {:join-alias "Question 54"}]]})]
-            (is (=? [{:name "CREATED_AT"
-                      :field_ref [:field (mt/id :products :created_at) {:temporal-unit :default}]}
-                     {:name "ID"
-                      :field_ref [:field (mt/id :orders :id) {:join-alias "Question 54"}]}
-                     {:name "ADDRESS"
-                      :field_ref [:field (mt/id :people :address) {:join-alias "Question 54"}]}]
-                    (qp/query->expected-cols query)))))))))
+        (let [query
+              (mt/mbql-query
+               products
+                {:joins
+                 [{:source-query
+                   {:source-table $$orders
+                    :joins
+                    [{:source-table $$people
+                      :alias "People"
+                      :condition [:= $orders.user_id &People.people.id]
+                      :fields [&People.people.address]
+                      :strategy :left-join}]
+                    :fields [$orders.id &People.people.address]}
+                   :alias "Question 54"
+                   :condition [:= $id [:field %orders.id {:join-alias "Question 54"}]]
+                   :fields [[:field %orders.id {:join-alias "Question 54"}]
+                            [:field %people.address {:join-alias "Question 54"}]]
+                   :strategy :left-join}]
+                 :fields
+                 [!default.created_at
+                  [:field %orders.id {:join-alias "Question 54"}]
+                  [:field %people.address {:join-alias "Question 54"}]]})]
+          (is (=? [{:name "CREATED_AT"
+                    :field_ref [:field (mt/id :products :created_at) {:temporal-unit :default}]
+                    :display_name "Created At"}
+                   {:name "ID"
+                    :field_ref [:field (mt/id :orders :id) {:join-alias "Question 54"}]
+                    :display_name "Question 54 → ID"
+                    :source_alias "Question 54"}
+                   {:name "ADDRESS"
+                    :field_ref [:field (mt/id :people :address) {:join-alias "Question 54"}]
+                    :display_name "Question 54 → Address"
+                    :source_alias "Question 54"}]
+                  (qp/query->expected-cols query))))))))
 
 (deftest use-source-unique-aliases-test
   (testing "Make sure uniquified aliases in the source query end up getting used for `::add/source-alias`"

--- a/test/metabase/query_processor/util/add_alias_info_test.clj
+++ b/test/metabase/query_processor/util/add_alias_info_test.clj
@@ -5,6 +5,7 @@
    [clojure.walk :as walk]
    [metabase.driver :as driver]
    [metabase.driver.h2 :as h2]
+   [metabase.driver.util :as driver.u]
    [metabase.models.field :refer [Field]]
    [metabase.query-processor :as qp]
    [metabase.query-processor.middleware.fix-bad-references
@@ -569,6 +570,41 @@
                                :limit        1})
                             add-alias-info
                             :query)))))))))
+
+(deftest query->expected-cols-test
+  (testing "field_refs in expected columns have the original join aliases (#30648)"
+    (mt/dataset sample-dataset
+      (binding [driver/*driver* ::custom-escape-spaces-to-underscores]
+        (with-redefs [driver.u/database->driver (constantly ::custom-escape-spaces-to-underscores)]
+          (let [query
+                (mt/mbql-query
+                    products
+                    {:joins
+                     [{:source-query
+                       {:source-table $$orders
+                        :joins
+                        [{:source-table $$people
+                          :alias "People"
+                          :condition [:= $orders.user_id &People.people.id]
+                          :fields [&People.people.address]
+                          :strategy :left-join}]
+                        :fields [$orders.id &People.people.address]}
+                       :alias "Question 54"
+                       :condition [:= $id [:field %orders.id {:join-alias "Question 54"}]]
+                       :fields [[:field %orders.id {:join-alias "Question 54"}]
+                                [:field %people.address {:join-alias "Question 54"}]]
+                       :strategy :left-join}]
+                     :fields
+                     [!default.created_at
+                      [:field %orders.id {:join-alias "Question 54"}]
+                      [:field %people.address {:join-alias "Question 54"}]]})]
+            (is (=? [{:name "CREATED_AT"
+                      :field_ref [:field (mt/id :products :created_at) {:temporal-unit :default}]}
+                     {:name "ID"
+                      :field_ref [:field (mt/id :orders :id) {:join-alias "Question 54"}]}
+                     {:name "ADDRESS"
+                      :field_ref [:field (mt/id :people :address) {:join-alias "Question 54"}]}]
+                    (qp/query->expected-cols query)))))))))
 
 (deftest use-source-unique-aliases-test
   (testing "Make sure uniquified aliases in the source query end up getting used for `::add/source-alias`"


### PR DESCRIPTION
Fixes #30648.

The root cause of the bug was that the `result_metadata` generated for MBQL queries returned _escaped_ `join-alias`es (introduced by #28343), which in BigQuery's case means that spaces are converted underscores (`_`). These wrong join aliases could not be resolved in later stages and resulted in incorrect references.

Normally, the escaped aliases are replaced by original ones in the post processing step, but the post processing is not executed when calculating expected columns.

This PR makes sure the original aliases are restored in the expected columns.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30747)
<!-- Reviewable:end -->
