### PR TITLE
Remove millisecond unit from datetimeDiff docs

### DIFF
--- a/docs/questions/query-builder/expressions/datetimediff.md
+++ b/docs/questions/query-builder/expressions/datetimediff.md
@@ -29,7 +29,6 @@ title: DatetimeDiff
 - "hour"
 - "minute"
 - "second"
-- "millisecond"
 
 ## Calculating age
 


### PR DESCRIPTION
This PR removes `millisecond` as a unit for the `datetimeDiff` function. `millisecond` was never supported as a unit for `datetimeDiff`, even though it is for `datetimeAdd` and `datetimeSubtract`.

[Slack context.](https://metaboat.slack.com/archives/C01LQQ2UW03/p1683543901140019)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30749)
<!-- Reviewable:end -->
