### PR TITLE
Exclude yarn >=2 from engines in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "license": "private",
   "engines": {
     "node": ">=16",
-    "yarn": ">=1.12.3"
+    "yarn": "^1.12.3"
   },
   "dependencies": {
     "@emotion/react": "^11.7.1",


### PR DESCRIPTION
### Description

Update supported yarn version in `package.json` - exclude yarn >= 2 as the project currently works with yarn v1 only.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30752)
<!-- Reviewable:end -->
