### PR TITLE
Update broken link to google standard sql

### DIFF
--- a/docs/databases/connections/bigquery.md
+++ b/docs/databases/connections/bigquery.md
@@ -165,7 +165,7 @@ Once you've completed these steps, you'll be able to ask questions and create da
 
 ## Using Legacy SQL
 
-As of version 0.30.0, Metabase tells BigQuery to interpret SQL queries as [Standard SQL](https://cloud.google.com/bigquery/docs/reference/standard-sql/). If you prefer using [Legacy SQL](https://cloud.google.com/bigquery/docs/reference/legacy-sql) instead, you can tell Metabase to do so by including a `#legacySQL` directive at the beginning of your query, for example:
+As of version 0.30.0, Metabase tells BigQuery to interpret SQL queries as [Standard SQL (GoogleSQL)](https://cloud.google.com/bigquery/docs/introduction-sql). If you prefer using [Legacy SQL](https://cloud.google.com/bigquery/docs/reference/legacy-sql) instead, you can tell Metabase to do so by including a `#legacySQL` directive at the beginning of your query, for example:
 
 ```sql
 #legacySQL


### PR DESCRIPTION
last version of the link led to http://web.archive.org/web/20190724201428/https://cloud.google.com/bigquery/docs/reference/standard-sql/

<img width="1439" alt="image" src="https://github.com/metabase/metabase/assets/125459446/60a40049-3cb1-4755-9aef-15b8226bf49a">
seems google later added a redirect to https://cloud.google.com/bigquery/docs/reference/standard-sql/enabling-standard-sql, then another redirect https://cloud.google.com/bigquery/docs/introduction-sql

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30753)
<!-- Reviewable:end -->
