### PR TITLE
Repro #30743: Sorting on the breakout column in joined questions crashes

### DIFF
--- a/e2e/test/scenarios/joins/reproductions/30743-sort-on-breakout-column-crashes.cy.spec.js
+++ b/e2e/test/scenarios/joins/reproductions/30743-sort-on-breakout-column-crashes.cy.spec.js
@@ -1,0 +1,52 @@
+import {
+  restore,
+  visitQuestionAdhoc,
+  popover,
+  visualize,
+} from "e2e/support/helpers";
+import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
+import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
+
+const { ORDERS, ORDERS_ID, PRODUCTS, PRODUCTS_ID } = SAMPLE_DATABASE;
+
+const query = {
+  display: "table",
+  dataset_query: {
+    database: SAMPLE_DB_ID,
+    type: "query",
+    query: {
+      "source-table": ORDERS_ID,
+      joins: [
+        {
+          fields: "all",
+          "source-table": PRODUCTS_ID,
+          condition: [
+            "=",
+            ["field", ORDERS.PRODUCT_ID, null],
+            ["field", PRODUCTS.ID, { "join-alias": "Products" }],
+          ],
+          alias: "Products",
+        },
+      ],
+      aggregation: [["count"]],
+      breakout: [["field", PRODUCTS.CATEGORY, { "join-alias": "Products" }]],
+    },
+  },
+};
+
+describe.skip("issue 20743", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+
+    visitQuestionAdhoc(query, { mode: "notebook" });
+  });
+
+  it("should be possible to sort on the breakout column (metabase#20743)", () => {
+    cy.findByLabelText("Sort").click();
+    popover().contains("Category").click();
+
+    visualize();
+    cy.get(".bar").should("have.length", 4);
+  });
+});


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Reproduces #30743 

### How to test this manually?
- `yarn test-cypress-open`
- `e2e/test/scenarios/joins/reproductions/30743-sort-on-breakout-column-crashes.cy.spec.js`
- Unskip repro
- The test should fail until the related issue is fixed

### Additional notes:
- Once the issue is fixed, please remove the `.skip` part (unskip the test completely)
- Make sure the test is passing and
- Merge it together with the fix

### Screenshots:
![image](https://github.com/metabase/metabase/assets/31325167/29388d44-62cf-4029-9a70-73233ab540fd)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30755)
<!-- Reviewable:end -->
