### PR TITLE
[CI, E2E] Fix revision history flake

### DIFF
--- a/e2e/test/scenarios/collections/revision-history.cy.spec.js
+++ b/e2e/test/scenarios/collections/revision-history.cy.spec.js
@@ -185,9 +185,12 @@ function visitAndEditDashboard(id) {
 }
 
 function openRevisionHistory() {
+  cy.intercept("GET", "/api/revision*").as("revisionHistory");
   cy.get("main header").within(() => {
     cy.icon("info").click();
   });
+  cy.wait("@revisionHistory");
+
   rightSidebar().within(() => {
     cy.findByText("History");
   });


### PR DESCRIPTION
This should fix the revision-history flake that's been plaguing the CI.

Links to the failed runs recorded by DeploySentinel start here:
https://github.com/metabase/metabase/actions/runs/4978776331/jobs/8909895346?pr=30249#step:12:1126

Every single failed run doesn't contain a GET request to the revision endpoint.
This PR explicitly waits for that request.

![image](https://github.com/metabase/metabase/assets/31325167/0bd70df3-f8e2-4270-8a9a-dc570fe7705b)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30757)
<!-- Reviewable:end -->
