### PR TITLE
Increase Chromatic build time timeout for github CI

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -131,6 +131,7 @@ jobs:
         uses: chromaui/action@v1
         env:
           PUBLISH_CHROMATIC: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          CHROMATIC_TIMEOUT: 900000
         if: env.PUBLISH_CHROMATIC != null
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Description

This increases Chromatic build time timeout for github CI from default 10 minutes to 15 minutes. We need this to avoid fails for this job in our CI.

### How to verify

Next CI runs for fe-chromatic should pass without timeout errors.
As a follow-up we should also analyze storybook build time and how we can optimize it and make it faster.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30758)
<!-- Reviewable:end -->
