### PR TITLE
Fix type warning in loop

### DIFF
--- a/src/metabase/lib/util.cljc
+++ b/src/metabase/lib/util.cljc
@@ -80,7 +80,7 @@
             [:joins :conditions] (throw (ex-info (i18n/tru "Cannot remove the final join condition")
                                                  {:conditions (get-in stage location)}))
             [:joins :fields] (update-in stage (pop location) dissoc (peek location))))))
-            stage))
+    stage))
 
 ;;; TODO -- all of this `->pipeline` stuff should probably be merged into [[metabase.lib.convert]] at some point in
 ;;; the near future.
@@ -344,9 +344,9 @@
          (> cumulative-byte-count max-length-bytes) (subs s 0 (dec i))
          (>= i (count s))                           s
          :else                                      (recur (inc i)
-                                                           (+
-                                                            cumulative-byte-count
-                                                            (string-byte-count (string-character-at s i))))))
+                                                           (long (+
+                                                                  cumulative-byte-count
+                                                                  (string-byte-count (string-character-at s i)))))))
 
      :cljs
      (let [buf (js/Uint8Array. max-length-bytes)


### PR DESCRIPTION
Fix this warning on startup

```
util.cljc:346 recur arg for primitive local: cumulative_byte_count is not matching primitive, had: Object, needed: long
Auto-boxing loop arg: cumulative-byte-count
```


We still have 
```
operator.clj:172 recur arg for primitive local: sum is not matching primitive, had: Object, needed: long
Auto-boxing loop arg: sum
``` 
 but it's probably from a 3rd party lib.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30768)
<!-- Reviewable:end -->
