### PR TITLE
Add onDisplayUpdate function to visualizations to update settings

### DIFF
--- a/e2e/test/scenarios/visualizations/reproductions/29030-bar-area-stacking.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/reproductions/29030-bar-area-stacking.cy.spec.js
@@ -1,0 +1,45 @@
+import { restore, visitQuestionAdhoc } from "e2e/support/helpers";
+import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
+import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
+
+const { ORDERS_ID, ORDERS, PEOPLE, PRODUCTS } = SAMPLE_DATABASE;
+
+const questionDetails = {
+  name: "29030",
+  dataset_query: {
+    type: "query",
+    query: {
+      "source-table": ORDERS_ID,
+      aggregation: [["count"]],
+      breakout: [
+        ["field", PEOPLE.SOURCE, { "source-field": ORDERS.USER_ID }],
+        ["field", PRODUCTS.CATEGORY, { "source-field": ORDERS.PRODUCT_ID }],
+      ],
+    },
+    database: SAMPLE_DB_ID,
+  },
+  display: "bar",
+  visualization_settings: {
+    "stackable.stack_type": "stacked",
+    "stackable.stack_display": "bar",
+  },
+};
+
+describe("issue 29030", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+
+    visitQuestionAdhoc(questionDetails);
+  });
+
+  it("pivot table should show standalone values when collapsed to the sub-level grouping (metabase#25250)", () => {
+    cy.findByTestId("viz-type-button").click();
+    cy.findByTestId("Area-button").click().click();
+    cy.findByTestId("sidebar-content").findByText("Display").click();
+
+    cy.findByTestId("sidebar-content").within(() => {
+      cy.icon("area").closest("li").should("have.attr", "aria-checked", "true");
+    });
+  });
+});

--- a/e2e/test/scenarios/visualizations/reproductions/29030-bar-area-stacking.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/reproductions/29030-bar-area-stacking.cy.spec.js
@@ -33,7 +33,7 @@ describe("issue 29030", () => {
     visitQuestionAdhoc(questionDetails);
   });
 
-  it("pivot table should show standalone values when collapsed to the sub-level grouping (metabase#25250)", () => {
+  it("stacking type should update when transitioning between area and bar charts (29030)", () => {
     cy.findByTestId("viz-type-button").click();
     cy.findByTestId("Area-button").click().click();
     cy.findByTestId("sidebar-content").findByText("Display").click();

--- a/frontend/src/metabase/components/SegmentedControl/SegmentedControl.tsx
+++ b/frontend/src/metabase/components/SegmentedControl/SegmentedControl.tsx
@@ -63,7 +63,7 @@ export function SegmentedControl<Value extends SegmentedControlValue = number>({
     option => option.value === value,
   );
   return (
-    <SegmentedList {...props}>
+    <SegmentedList {...props} role="radiogroup">
       {options.map((option, index) => {
         const isSelected = index === selectedOptionIndex;
         const id = `${name}-${option.value}`;
@@ -81,6 +81,8 @@ export function SegmentedControl<Value extends SegmentedControlValue = number>({
             variant={variant}
             selectedColor={selectedColor}
             inactiveColor={inactiveColor}
+            role="radio"
+            aria-checked={isSelected}
           >
             <SegmentedItemLabel
               id={labelId}

--- a/frontend/src/metabase/query_builder/actions/core/updateQuestion.ts
+++ b/frontend/src/metabase/query_builder/actions/core/updateQuestion.ts
@@ -3,7 +3,7 @@ import { assocIn } from "icepick";
 
 import { loadMetadataForCard } from "metabase/questions/actions";
 
-import { Dataset, Series, VisualizationSettings } from "metabase-types/api";
+import { Dataset, Series } from "metabase-types/api";
 import { Dispatch, GetState, QueryBuilderMode } from "metabase-types/store";
 import Question from "metabase-lib/Question";
 import NativeQuery from "metabase-lib/queries/NativeQuery";
@@ -100,7 +100,6 @@ export type UpdateQuestionOpts = {
   run?: boolean | "auto";
   shouldUpdateUrl?: boolean;
   shouldStartAdHocQuestion?: boolean;
-  onDisplayUpdate?: (settings: VisualizationSettings) => VisualizationSettings;
 };
 
 /**
@@ -113,7 +112,6 @@ export const updateQuestion = (
     run = false,
     shouldStartAdHocQuestion = true,
     shouldUpdateUrl = false,
-    onDisplayUpdate,
   }: UpdateQuestionOpts = {},
 ) => {
   return async (dispatch: Dispatch, getState: GetState) => {
@@ -203,11 +201,6 @@ export const updateQuestion = (
     if (newQuestion.isNative()) {
       const parameters = getTemplateTagParametersFromCard(newQuestion.card());
       newQuestion = newQuestion.setParameters(parameters);
-    }
-
-    if (onDisplayUpdate) {
-      const newSettings = onDisplayUpdate(newQuestion.settings());
-      newQuestion.updateSettings(newSettings);
     }
 
     await dispatch({

--- a/frontend/src/metabase/query_builder/actions/core/updateQuestion.ts
+++ b/frontend/src/metabase/query_builder/actions/core/updateQuestion.ts
@@ -3,7 +3,7 @@ import { assocIn } from "icepick";
 
 import { loadMetadataForCard } from "metabase/questions/actions";
 
-import { Dataset, Series } from "metabase-types/api";
+import { Dataset, Series, VisualizationSettings } from "metabase-types/api";
 import { Dispatch, GetState, QueryBuilderMode } from "metabase-types/store";
 import Question from "metabase-lib/Question";
 import NativeQuery from "metabase-lib/queries/NativeQuery";
@@ -100,6 +100,7 @@ export type UpdateQuestionOpts = {
   run?: boolean | "auto";
   shouldUpdateUrl?: boolean;
   shouldStartAdHocQuestion?: boolean;
+  onDisplayUpdate?: (settings: VisualizationSettings) => VisualizationSettings;
 };
 
 /**
@@ -112,6 +113,7 @@ export const updateQuestion = (
     run = false,
     shouldStartAdHocQuestion = true,
     shouldUpdateUrl = false,
+    onDisplayUpdate,
   }: UpdateQuestionOpts = {},
 ) => {
   return async (dispatch: Dispatch, getState: GetState) => {
@@ -201,6 +203,11 @@ export const updateQuestion = (
     if (newQuestion.isNative()) {
       const parameters = getTemplateTagParametersFromCard(newQuestion.card());
       newQuestion = newQuestion.setParameters(parameters);
+    }
+
+    if (onDisplayUpdate) {
+      const newSettings = onDisplayUpdate(newQuestion.settings());
+      newQuestion.updateSettings(newSettings);
     }
 
     await dispatch({

--- a/frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.tsx
@@ -99,10 +99,17 @@ const ChartTypeSidebar = ({
       if (display === question.display()) {
         openChartSettings(e);
       } else {
-        const newQuestion = question.setDisplay(display).lockDisplay(); // prevent viz auto-selection
+        let newQuestion = question.setDisplay(display).lockDisplay(); // prevent viz auto-selection
+        const visualization = visualizations.get(display);
+        if (visualization.onDisplayUpdate) {
+          const updatedSettings = visualization.onDisplayUpdate(
+            newQuestion.settings(),
+          );
+          newQuestion = newQuestion.updateSettings(updatedSettings);
+        }
+
         updateQuestion(newQuestion, {
           shouldUpdateUrl: question.query().isEditable(),
-          onDisplayUpdate: visualizations.get(display).onDisplayUpdate,
         });
         setUIControls({ isShowingRawTable: false });
       }

--- a/frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.tsx
@@ -8,6 +8,8 @@ import visualizations from "metabase/visualizations";
 import { sanatizeResultData } from "metabase/visualizations/shared/utils/data";
 import { Visualization } from "metabase/visualizations/shared/types/visualization";
 
+import { UpdateQuestionOpts } from "metabase/query_builder/actions";
+
 import Question from "metabase-lib/Question";
 import Query from "metabase-lib/queries/Query";
 
@@ -48,10 +50,7 @@ interface ChartTypeSidebarProps {
     showSidebarTitle: boolean;
   }) => void;
   onCloseChartType: () => void;
-  updateQuestion: (
-    question: Question,
-    props: { reload: boolean; shouldUpdateUrl: boolean },
-  ) => void;
+  updateQuestion: (question: Question, props: UpdateQuestionOpts) => void;
   setUIControls: (props: { isShowingRawTable: boolean }) => void;
   query: Query;
 }
@@ -101,10 +100,9 @@ const ChartTypeSidebar = ({
         openChartSettings(e);
       } else {
         const newQuestion = question.setDisplay(display).lockDisplay(); // prevent viz auto-selection
-
         updateQuestion(newQuestion, {
-          reload: false,
           shouldUpdateUrl: question.query().isEditable(),
+          onDisplayUpdate: visualizations.get(display).onDisplayUpdate,
         });
         setUIControls({ isShowingRawTable: false });
       }

--- a/frontend/src/metabase/visualizations/visualizations/AreaChart.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/AreaChart.jsx
@@ -38,4 +38,11 @@ export default class AreaChart extends LineAreaBarChart {
     [0, "card", "display"],
     "area",
   );
+
+  static onDisplayUpdate = settings => {
+    if (settings["stackable.stack_display"]) {
+      settings["stackable.stack_display"] = "area";
+    }
+    return settings;
+  };
 }

--- a/frontend/src/metabase/visualizations/visualizations/BarChart.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/BarChart.jsx
@@ -35,4 +35,11 @@ export default class BarChart extends LineAreaBarChart {
     [0, "card", "display"],
     "bar",
   );
+
+  static onDisplayUpdate = settings => {
+    if (settings["stackable.stack_display"]) {
+      settings["stackable.stack_display"] = "bar";
+    }
+    return settings;
+  };
 }


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/29030

### Description
Fixes the issue by adding the ability to update settings on visualizations when the display is changed (which is not actually a viz setting, but a card setting). This `onDisplayUpdate` function is passed current viz settings, and has the option to return new ones. To fix the linked issue, it updates the value of `stackable.stack_display` if it's been set.


### How to verify
1. New question -> Sample Dataset -> Orders
2. Count, Group by User Source and Product Category. Click Visualize
3. Set visualization to be a bar chart, then go to display and set stacking to stack.
4. Set stacked chart type to area, then back to bar. 
5. Change the viz type to area. Stacked chart type should change to area as well.

### Demo
![chrome_dhZE5K7b77](https://github.com/metabase/metabase/assets/1328979/de972b25-b60b-4cbb-aefb-07539b9ef4c6)


### Checklist

- [x] Tests have been added/updated to cover changes in this PR

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30773)
<!-- Reviewable:end -->
