### PR TITLE
Don't search the text of native queries

### DIFF
--- a/src/metabase/api/search.clj
+++ b/src/metabase/api/search.clj
@@ -93,9 +93,7 @@
    :initial_sync_status :text
    ;; returned for Action
    :model_id            :integer
-   :model_name          :text
-   ;; returned for Card and Action
-   :dataset_query       :text))
+   :model_name          :text))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                               Shared Query Logic                                               |
@@ -191,26 +189,19 @@
   (str "%" s "%"))
 
 (defn- search-string-clause
-  [model query searchable-columns]
+  [query searchable-columns]
   (when query
     (into [:or]
           (for [column searchable-columns
                 token (search-util/tokenize (search-util/normalize query))]
-            (if (and (= model "card") (= column (keyword (name (model->alias model)) "dataset_query")))
-              [:and
-               [:= (keyword (name (model->alias model)) "query_type") "native"]
-               [:like
-                [:lower column]
-                (wildcard-match token)]]
-              [:like
-               [:lower column]
-               (wildcard-match token)])))))
+            [:like
+             [:lower column]
+             (wildcard-match token)]))))
 
 (s/defn ^:private base-where-clause-for-model :- [(s/one (s/enum :and := :inline) "type") s/Any]
   [model :- SearchableModel, {:keys [search-string archived?]} :- SearchContext]
   (let [archived-clause (archived-where-clause model archived?)
-        search-clause   (search-string-clause model
-                                              search-string
+        search-clause   (search-string-clause search-string
                                               (map (let [model-alias (name (model->alias model))]
                                                      (fn [column]
                                                        (keyword model-alias (name column))))

--- a/src/metabase/search/config.clj
+++ b/src/metabase/search/config.clj
@@ -75,7 +75,6 @@
 (defmethod searchable-columns-for-model "card"
   [_]
   [:name
-   :dataset_query
    :description])
 
 (defmethod searchable-columns-for-model "dataset"

--- a/src/metabase/search/config.clj
+++ b/src/metabase/search/config.clj
@@ -134,12 +134,11 @@
         [:model.collection_id        :collection_id]
         [:model.id                   :model_id]
         [:model.name                 :model_name]
-        [:query_action.database_id   :database_id]
-        [:query_action.dataset_query :dataset_query]))
+        [:query_action.database_id   :database_id]))
 
 (defmethod columns-for-model "card"
   [_]
-  (conj default-columns :collection_id :collection_position :dataset_query
+  (conj default-columns :collection_id :collection_position
         [:collection.name :collection_name]
         [:collection.authority_level :collection_authority_level]
         [{:select   [:status]
@@ -203,10 +202,3 @@
 (defmethod column->string :default
   [value _ _]
   value)
-
-(defmethod column->string [:card :dataset_query]
-  [value _ _]
-  (let [query (json/parse-string value true)]
-    (if (= "native" (:type query))
-      (-> query :native :query)
-      "")))

--- a/src/metabase/search/config.clj
+++ b/src/metabase/search/config.clj
@@ -1,6 +1,5 @@
 (ns metabase.search.config
   (:require
-   [cheshire.core :as json]
    [metabase.models
     :refer [Action Card Collection Dashboard Database Metric Segment Table]]
    [metabase.models.setting :refer [defsetting]]

--- a/src/metabase/search/scoring.clj
+++ b/src/metabase/search/scoring.clj
@@ -209,7 +209,6 @@
                           :name            collection_name
                           :authority_level collection_authority_level}
          :scores          all-scores)
-        (update :dataset_query #(some-> % json/parse-string mbql.normalize/normalize))
         (dissoc
          :collection_id
          :collection_name

--- a/src/metabase/search/scoring.clj
+++ b/src/metabase/search/scoring.clj
@@ -1,9 +1,7 @@
 (ns metabase.search.scoring
   (:require
-   [cheshire.core :as json]
    [clojure.string :as str]
    [java-time :as t]
-   [metabase.mbql.normalize :as mbql.normalize]
    [metabase.public-settings.premium-features :refer [defenterprise]]
    [metabase.search.config :as search-config]
    [metabase.search.util :as search-util]

--- a/test/metabase/api/search_test.clj
+++ b/test/metabase/api/search_test.clj
@@ -51,7 +51,6 @@
    :context                    nil
    :dashboardcard_count        nil
    :database_id                false
-   :dataset_query              nil
    :description                nil
    :id                         true
    :initial_sync_status        nil
@@ -85,8 +84,7 @@
 (defn- query-action
   [action-id]
   {:action_id     action-id
-   :database_id   (u/the-id (mt/db))
-   :dataset_query (mt/query venues)})
+   :database_id   (u/the-id (mt/db))})
 
 (def ^:private test-collection (make-result "collection test collection"
                                             :bookmark false
@@ -100,10 +98,9 @@
   (sorted-results
    [(make-result "dashboard test dashboard", :model "dashboard", :bookmark false)
     test-collection
-    (make-result "card test card", :model "card", :bookmark false, :dataset_query nil, :dashboardcard_count 0)
-    (make-result "dataset test dataset", :model "dataset", :bookmark false, :dataset_query nil, :dashboardcard_count 0)
-    (make-result "action test action", :model "action", :model_name (:name action-model-params), :model_id true,
-                 :dataset_query (update (mt/query venues) :type name), :database_id true)
+    (make-result "card test card", :model "card", :bookmark false, :dashboardcard_count 0)
+    (make-result "dataset test dataset", :model "dataset", :bookmark false, :dashboardcard_count 0)
+    (make-result "action test action", :model "action", :model_name (:name action-model-params), :model_id true, :database_id true)
     (merge
      (make-result "metric test metric", :model "metric", :description "Lookin' for a blueberry")
      (table-search-results))
@@ -233,7 +230,6 @@
              [:like [:lower :table_name]        "%foo%"] [:inline 0]
              [:like [:lower :table_description] "%foo%"] [:inline 0]
              [:like [:lower :model_name]        "%foo%"] [:inline 0]
-             [:like [:lower :dataset_query]     "%foo%"] [:inline 0]
              :else [:inline 1]]]
            (api.search/order-clause "Foo")))))
 
@@ -296,7 +292,7 @@
 (def ^:private dashboard-count-results
   (letfn [(make-card [dashboard-count]
             (make-result (str "dashboard-count " dashboard-count) :dashboardcard_count dashboard-count,
-                         :model "card", :bookmark false, :dataset_query nil))]
+                         :model "card", :bookmark false))]
     (set [(make-card 5)
           (make-card 3)
           (make-card 0)])))
@@ -649,21 +645,6 @@
             (mt/with-temp* [Dashboard [dashboard]]
               (t2/update! Pulse (:id pulse) {:dashboard_id (:id dashboard)})
               (is (= nil (search-for-pulses pulse))))))))))
-
-(deftest card-dataset-query-test
-  (testing "Search results should match a native query's dataset_query column, but not an MBQL query's one."
-    ;; https://github.com/metabase/metabase/issues/24132
-    (let [native-card {:name          "Another SQL query"
-                       :query_type    "native"
-                       :dataset_query (mt/native-query {:query "SELECT COUNT(1) AS aggregation FROM venues"})}]
-      (mt/with-temp* [Card [_mbql-card   {:name          "Venues Count"
-                                          :query_type    "query"
-                                          :dataset_query (mt/mbql-query venues {:aggregation [[:count]]})}]
-                      Card [_native-card native-card]
-                      Card [_dataset     (assoc native-card :name "Dataset" :dataset true)]]
-        (is (= ["Another SQL query" "Dataset"]
-               (->> (search-request-data :rasta :q "aggregation")
-                    (map :name))))))))
 
 (deftest search-db-call-count-test
   (t2.with-temp/with-temp

--- a/test/metabase/api/search_test.clj
+++ b/test/metabase/api/search_test.clj
@@ -84,7 +84,8 @@
 (defn- query-action
   [action-id]
   {:action_id     action-id
-   :database_id   (u/the-id (mt/db))})
+   :database_id   (u/the-id (mt/db))
+   :dataset_query (mt/query venues)})
 
 (def ^:private test-collection (make-result "collection test collection"
                                             :bookmark false

--- a/test/metabase/search/scoring_test.clj
+++ b/test/metabase/search/scoring_test.clj
@@ -273,20 +273,6 @@
                      {:weight 100 :score 0 :name "Some other score type"}])]
       (is (= 0 (:score (scoring/score-and-result "" {:name "racing yo" :model "card"})))))))
 
-(deftest ^:parallel serialize-test
-  (testing "It normalizes dataset queries from strings"
-    (let [query  {:type     :query
-                  :query    {:source-query {:source-table 1}}
-                  :database 1}
-          result {:name          "card"
-                  :model         "card"
-                  :dataset_query (json/generate-string query)}]
-      (is (= query (-> result (#'scoring/serialize {} {}) :dataset_query)))))
-  (testing "Doesn't error on other models without a query"
-    (is (nil? (-> {:name "dash" :model "dashboard"}
-                  (#'scoring/serialize {} {})
-                  :dataset_query)))))
-
 (deftest force-weight-test
   (is (= [{:weight 10}]
          (scoring/force-weight [{:weight 1}] 10)))

--- a/test/metabase/search/scoring_test.clj
+++ b/test/metabase/search/scoring_test.clj
@@ -1,6 +1,5 @@
 (ns metabase.search.scoring-test
   (:require
-   [cheshire.core :as json]
    [clojure.test :refer :all]
    [java-time :as t]
    [metabase.search.config :as search-config]


### PR DESCRIPTION
This PR resolves https://github.com/metabase/metabase/issues/30538 by exluding the text of native queries in searches.

The original PR that added native query text search is [here](https://github.com/metabase/metabase/pull/14583).

We intend to bring this functionality back in the future with full-text search indexing or advanced search options, but for now the performance cost is too high to justify searching the text in every query.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30779)
<!-- Reviewable:end -->
