### PR TITLE
Migrate field refs in result_metadata from legacy format

### DIFF
--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -14615,6 +14615,14 @@ databaseChangeLog:
         - customChange:
             class: "metabase.db.custom_migrations.MigrateLegacyColumnSettingsFieldRefs"
 
+  - changeSet:
+      id: v47.00-027
+      author: calherres
+      comment: Added 0.47.0 - Migrate field_ref in report_card.result_metadata from legacy format
+      changes:
+        - customChange:
+            class: "metabase.db.custom_migrations.MigrateLegacyResultMetadataFieldRefs"
+
 # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################

--- a/src/metabase/db/custom_migrations.clj
+++ b/src/metabase/db/custom_migrations.clj
@@ -241,4 +241,7 @@
                                         {:id                     id
                                          :result_metadata updated}))))
                             (t2/reducible-query {:select [:id :result_metadata]
-                                                 :from   [:report_card]})))))
+                                                 :from   [:report_card]
+                                                 :where  [:or
+                                                          [:<> :result_metadata nil]
+                                                          [:<> :result_metadata "[]"]]})))))

--- a/src/metabase/db/custom_migrations.clj
+++ b/src/metabase/db/custom_migrations.clj
@@ -242,6 +242,6 @@
                                          :result_metadata updated}))))
                             (t2/reducible-query {:select [:id :result_metadata]
                                                  :from   [:report_card]
-                                                 :where  [:or
+                                                 :where  [:and
                                                           [:<> :result_metadata nil]
                                                           [:<> :result_metadata "[]"]]})))))

--- a/test/metabase/db/custom_migrations_test.clj
+++ b/test/metabase/db/custom_migrations_test.clj
@@ -126,12 +126,16 @@
                              {"field_ref" ["field-id" 39]}
                              {"field_ref" ["field" 40 nil]}
                              {"field_ref" ["fk->" ["field-id" 39] ["field-id" 40]]}
-                             {"field_ref" ["fk->" 41 42]}]
+                             {"field_ref" ["fk->" 41 42]}
+                             {"field_ref" ["aggregation" 0]}
+                             {"field_ref" ["expression" "expr"]}]
             expected        [{"field_ref" ["field" "column_name" {"base-type" "type/Text"}]}
                              {"field_ref" ["field" 39 nil]}
                              {"field_ref" ["field" 40 nil]}
                              {"field_ref" ["field" 40 {"source-field" 39}]}
-                             {"field_ref" ["field" 42 {"source-field" 41}]}]
+                             {"field_ref" ["field" 42 {"source-field" 41}]}
+                             {"field_ref" ["aggregation" 0]}
+                             {"field_ref" ["expression" "expr"]}]
             user-id     (t2/insert-returning-pks! User {:first_name  "Howard"
                                                         :last_name   "Hughes"
                                                         :email       "howard@aircraft.com"

--- a/test/metabase/db/custom_migrations_test.clj
+++ b/test/metabase/db/custom_migrations_test.clj
@@ -9,7 +9,6 @@
    [clojurewerkz.quartzite.scheduler :as qs]
    [clojurewerkz.quartzite.triggers :as triggers]
    [metabase.db.schema-migrations-test.impl :as impl]
-   [metabase.mbql.normalize :as mbql.normalize]
    [metabase.models :refer [Card Database User]]
    [metabase.models.interface :as mi]
    [metabase.task :as task]
@@ -166,15 +165,15 @@
           (testing "legacy result_metadata are updated to the current format"
             (is (= (->> result_metadata
                         json/generate-string
-                        (#'mi/result-metadata-out)
+                        ((:out mi/transform-result-metadata))
                         json/generate-string)
                    migrated-result-metadata)))
           (testing "result_metadata is equivalent before and after migration"
             (is (= (->> result_metadata
                         json/generate-string
-                        (#'mi/result-metadata-out)
+                        ((:out mi/transform-result-metadata))
                         json/generate-string)
                    (-> migrated-result-metadata
                        json/parse-string
-                       (#'mi/result-metadata-out)
+                       ((:out mi/transform-result-metadata))
                        json/generate-string)))))))))

--- a/test/metabase/db/custom_migrations_test.clj
+++ b/test/metabase/db/custom_migrations_test.clj
@@ -120,7 +120,7 @@
                      (#'mi/migrate-viz-settings)))))))))
 
 (deftest migrate-legacy-result-metadata-field-refs-test
-  (testing "Migrations v47.00-027: update visualization_settings.column_settings legacy field refs"
+  (testing "Migrations v47.00-027: update report_card.result_metadata legacy field refs"
     (impl/test-migrations ["v47.00-027"] [migrate!]
       (let [result_metadata [{"field_ref" ["field-literal" "column_name" "type/Text"]}
                              {"field_ref" ["field-id" 39]}


### PR DESCRIPTION
Epic: https://github.com/metabase/metabase/issues/30789
Pursuant towards https://github.com/metabase/metabase/issues/27504.

This PR adds a clojure migration to update legacy field refs in result_metadata. The migration is required for #27487, where we are matching field refs in `report_card.visualization_settings.column_settings` with field refs in `report_card.result_metadata`. `report_card.visualization_settings.column_settings` was updated in #30460 from legacy format, so for the match to work correctly `report_card.result_metadata` needs to be updated to.

Everything in this PR mirrors https://github.com/metabase/metabase/pull/30460, the only difference is that we are migrating `field_refs` in `result_metadata` instead of the keys of `visualization_settings.column_settings`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30787)
<!-- Reviewable:end -->
