### PR TITLE
Fixup Chromatic storybook build timeout

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -131,7 +131,7 @@ jobs:
         uses: chromaui/action@v1
         env:
           PUBLISH_CHROMATIC: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
-          CHROMATIC_TIMEOUT: 900000
+          STORYBOOK_BUILD_TIMEOUT: 900000
         if: env.PUBLISH_CHROMATIC != null
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Relates to https://github.com/metabase/metabase/pull/30758

### Description

This increases Chromatic build time timeout for github CI from default 10 minutes to 15 minutes. We need this to avoid fails for this job in our CI.

In the previous PR I used incorrect variable name.

### How to verify

Next CI runs for fe-chromatic should pass without timeout errors.
As a follow-up we should also analyze storybook build time and how we can optimize it and make it faster.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30798)
<!-- Reviewable:end -->
