### PR TITLE
Fix uploading SSL client key

### DIFF
--- a/e2e/test/scenarios/admin/databases/add-new-database.cy.spec.js
+++ b/e2e/test/scenarios/admin/databases/add-new-database.cy.spec.js
@@ -294,9 +294,11 @@ describe("admin > database > add", () => {
 
       mockUploadServiceAccountJSON(serviceAccountJSON);
       mockSuccessfulDatabaseSave().then(({ request: { body } }) => {
-        expect(body.details["service-account-json"]).to.equal(
-          serviceAccountJSON,
-        );
+        expect(
+          Cypress.Blob.blobToBinaryString(
+            Cypress.Blob.dataURLToBlob(body.details["service-account-json"]),
+          ),
+        ).to.equal(serviceAccountJSON);
       });
     });
 
@@ -309,9 +311,11 @@ describe("admin > database > add", () => {
 
       mockUploadServiceAccountJSON(serviceAccountJSON);
       mockSuccessfulDatabaseSave().then(({ request: { body } }) => {
-        expect(body.details["service-account-json"]).to.equal(
-          serviceAccountJSON,
-        );
+        expect(
+          Cypress.Blob.blobToBinaryString(
+            Cypress.Blob.dataURLToBlob(body.details["service-account-json"]),
+          ),
+        ).to.equal(serviceAccountJSON);
       });
     });
   });

--- a/frontend/src/metabase-types/api/settings.ts
+++ b/frontend/src/metabase-types/api/settings.ts
@@ -39,7 +39,6 @@ export interface EngineField {
   default?: unknown;
   options?: EngineFieldOption[];
   "visible-if"?: Record<string, unknown>;
-  "treat-before-posting"?: EngineFieldTreatType;
 }
 
 export type EngineFieldType =

--- a/frontend/src/metabase/components/form/widgets/FormTextFileWidget/FormTextFileWidget.tsx
+++ b/frontend/src/metabase/components/form/widgets/FormTextFileWidget/FormTextFileWidget.tsx
@@ -1,24 +1,22 @@
 import React, { ChangeEvent, FocusEvent } from "react";
 import FileInput from "metabase/core/components/FileInput";
-import { FormField, TreatBeforePosting } from "./types";
+import { FormField } from "./types";
 
 export interface FormTextFileWidgetProps {
   field: FormField;
-  treatBeforePosting?: TreatBeforePosting;
 }
 
 const FormTextFileWidget = ({
   field,
-  treatBeforePosting,
 }: FormTextFileWidgetProps): JSX.Element => {
   const { name, autoFocus, onChange, onBlur } = field;
 
   const handleChange = async (event: ChangeEvent<HTMLInputElement>) => {
-    onChange(await getFieldValue(event.target, treatBeforePosting));
+    onChange(await getFieldValue(event.target));
   };
 
   const handleBlur = async (event: FocusEvent<HTMLInputElement>) => {
-    onBlur(await getFieldValue(event.target, treatBeforePosting));
+    onBlur(await getFieldValue(event.target));
   };
 
   return (
@@ -32,10 +30,7 @@ const FormTextFileWidget = ({
   );
 };
 
-const getFieldValue = (
-  { files }: HTMLInputElement,
-  treatBeforePosting?: TreatBeforePosting,
-): Promise<string> => {
+const getFieldValue = ({ files }: HTMLInputElement): Promise<string> => {
   return new Promise((resolve, reject) => {
     if (!files?.length) {
       resolve("");
@@ -45,12 +40,7 @@ const getFieldValue = (
     const reader = new FileReader();
     reader.onload = () => resolve(String(reader.result));
     reader.onerror = () => reject();
-
-    if (treatBeforePosting === "base64") {
-      reader.readAsDataURL(files[0]);
-    } else {
-      reader.readAsText(files[0]);
-    }
+    reader.readAsDataURL(files[0]);
   });
 };
 

--- a/frontend/src/metabase/components/form/widgets/FormTextFileWidget/types.ts
+++ b/frontend/src/metabase/components/form/widgets/FormTextFileWidget/types.ts
@@ -5,5 +5,3 @@ export interface FormField {
   onChange: (value: string) => void;
   onBlur: (value: string) => void;
 }
-
-export type TreatBeforePosting = "base64";

--- a/frontend/src/metabase/core/components/FormFileInput/FormFileInput.tsx
+++ b/frontend/src/metabase/core/components/FormFileInput/FormFileInput.tsx
@@ -10,12 +10,9 @@ import { useUniqueId } from "metabase/hooks/use-unique-id";
 import FileInput, { FileInputProps } from "metabase/core/components/FileInput";
 import FormField from "metabase/core/components/FormField";
 
-export type FormFileInputEncoding = "base64";
-
 export interface FormFileInputProps
   extends Omit<FileInputProps, "value" | "onChange" | "onBlur"> {
   name: string;
-  encoding?: FormFileInputEncoding;
   title?: string;
   description?: ReactNode;
   optional?: boolean;
@@ -24,7 +21,6 @@ export interface FormFileInputProps
 const FormFileInput = forwardRef(function FormFileInput(
   {
     name,
-    encoding,
     className,
     style,
     title,
@@ -39,9 +35,9 @@ const FormFileInput = forwardRef(function FormFileInput(
 
   const handleChange = useCallback(
     async (event: ChangeEvent<HTMLInputElement>) => {
-      setValue(await getFieldValue(event.target, encoding));
+      setValue(await getFieldValue(event.target));
     },
-    [encoding, setValue],
+    [setValue],
   );
 
   return (
@@ -66,10 +62,7 @@ const FormFileInput = forwardRef(function FormFileInput(
   );
 });
 
-const getFieldValue = (
-  { files }: HTMLInputElement,
-  encoding?: FormFileInputEncoding,
-): Promise<string> => {
+const getFieldValue = ({ files }: HTMLInputElement): Promise<string> => {
   return new Promise((resolve, reject) => {
     if (!files?.length) {
       resolve("");
@@ -79,12 +72,7 @@ const getFieldValue = (
     const reader = new FileReader();
     reader.onload = () => resolve(String(reader.result));
     reader.onerror = () => reject();
-
-    if (encoding === "base64") {
-      reader.readAsDataURL(files[0]);
-    } else {
-      reader.readAsText(files[0]);
-    }
+    reader.readAsDataURL(files[0]);
   });
 };
 

--- a/modules/drivers/oracle/test/metabase/driver/oracle_test.clj
+++ b/modules/drivers/oracle/test/metabase/driver/oracle_test.clj
@@ -395,8 +395,9 @@
                                          [(-> (assoc
                                                ssl-details
                                                :ssl-truststore-value
-                                               (.encodeToString (Base64/getEncoder)
-                                                                (mt/file->bytes (:ssl-truststore-path ssl-details)))
+                                               (str "data:application/octet-stream;base64,"
+                                                    (.encodeToString (Base64/getEncoder)
+                                                                     (mt/file->bytes (:ssl-truststore-path ssl-details))))
                                                :ssl-truststore-options
                                                "uploaded")
                                               (dissoc :ssl-truststore-path))

--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -710,7 +710,6 @@
   the details used to successfully connect. Otherwise returns a map with the connection error message. (This map will
   also contain the key `:valid` = `false`, which you can use to distinguish an error from valid details.)"
   [engine :- DBEngineString, details :- su/Map]
-  (log/debug "Database connection details" details)
   (let [;; Try SSL first if SSL is supported and not already enabled
         ;; If not successful or not applicable, details-with-ssl will be nil
         details-with-ssl (assoc details :ssl true)

--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -710,6 +710,7 @@
   the details used to successfully connect. Otherwise returns a map with the connection error message. (This map will
   also contain the key `:valid` = `false`, which you can use to distinguish an error from valid details.)"
   [engine :- DBEngineString, details :- su/Map]
+  (log/debug "Database connection details" details)
   (let [;; Try SSL first if SSL is supported and not already enabled
         ;; If not successful or not applicable, details-with-ssl will be nil
         details-with-ssl (assoc details :ssl true)

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -626,12 +626,12 @@
     "inet"  :type/IPAddress
     nil))
 
-(defn- pkcs-12-key-value?
-  "If a value was uploaded for the SSL key, return whether it's using the PKCS-12 format."
+(defn- key-file-ext
   [ssl-key-value]
   (when ssl-key-value
-    (= (second (re-find secret/uploaded-base-64-prefix-pattern ssl-key-value))
-       "x-pkcs12")))
+    (case (second (re-find secret/uploaded-base-64-prefix-pattern ssl-key-value))
+      "x-pkcs12" ".p12"
+      ".tmp")))
 
 (defn- ssl-params
   "Builds the params to include in the JDBC connection spec for an SSL connection."
@@ -655,7 +655,7 @@
       (assoc :sslrootcert (secret/value->file! ssl-root-cert :postgres))
 
       (has-value? ssl-client-key)
-      (assoc :sslkey (secret/value->file! ssl-client-key :postgres (when (pkcs-12-key-value? ssl-key-value) ".p12")))
+      (assoc :sslkey (secret/value->file! ssl-client-key :postgres (key-file-ext ssl-key-value)))
 
       (has-value? ssl-client-cert)
       (assoc :sslcert (secret/value->file! ssl-client-cert :postgres))

--- a/src/metabase/driver/util.clj
+++ b/src/metabase/driver/util.clj
@@ -387,11 +387,10 @@
   ^bytes [^String s]
   (when s
     (let [[match _ encoding ^String data] (re-find #"data:([\w-/]*);?(base64|),(.*)" s)]
-      (if match
+      (when match
         (case encoding
           "base64" (u/decode-base64-to-bytes data)
-          (.getBytes data "UTF-8"))
-        (.getBytes s "UTF-8")))))
+          (.getBytes data "UTF-8"))))))
 
 (defn db-details-client->server
   "Currently, this transforms client side values for the various back into :type :secret for storage on the server.
@@ -414,7 +413,8 @@
                          val-kw     (subprop "-value")
                          source-kw  (subprop "-source")
                          path       (path-kw acc)
-                         value      (maybe-decode-data-url (val-kw acc))]
+                         raw-val    (val-kw acc)
+                         value      (or (maybe-decode-data-url raw-val) raw-val)]
                      (cond-> (assoc acc val-kw value)
                        ;; keywords here are associated to nil, rather than being dissoced, because they will be merged
                        ;; with the existing db-details blob to produce the final details

--- a/src/metabase/models/secret.clj
+++ b/src/metabase/models/secret.clj
@@ -203,8 +203,8 @@
                 (String. ^bytes (:value (t2/select-one Secret :id id)) "UTF-8")
                 (value-kw details))]
     (case (options-kw details)
-      "uploaded" (String. ^bytes (driver.u/decode-uploaded value) "UTF-8")
-      "local" (slurp (if id value (path-kw details)))
+      "uploaded" (String. ^bytes (driver.u/maybe-decode-data-url value) "UTF-8")
+      "local"    (slurp (if id value (path-kw details)))
       value)))
 
 (def

--- a/test/metabase/driver/util_test.clj
+++ b/test/metabase/driver/util_test.clj
@@ -112,7 +112,6 @@
                                                      :ssl          true}}
                                      {:name                 "keystore-value"
                                       :type                 "textFile"
-                                      :treat-before-posting "base64"
                                       :visible-if           {:keystore-options "uploaded"}}
                                      {:name        "keystore-path"
                                       :type        "string"

--- a/test/metabase/driver/util_test.clj
+++ b/test/metabase/driver/util_test.clj
@@ -225,7 +225,8 @@
                       :keystore-options        "uploaded"
                       ;; because treat-before-posting is base64 in the config for this property, simulate that happening
                       :keystore-value          (->> (.getBytes ks-val StandardCharsets/UTF_8)
-                                                    (.encodeToString (Base64/getEncoder)))
+                                                    (.encodeToString (Base64/getEncoder))
+                                                    (str "data:application/octet-stream;base64,"))
                       :keystore-password-value "my-keystore-pw"}
           transformed (driver.u/db-details-client->server :secret-test-driver db-details)]
       ;; compare all fields except `:keystore-value` as a single map


### PR DESCRIPTION
This PR updates the frontend and backend to always encode all database connection property values that use file upload inputs. This allows binary files like DER to be used as a `:ssl-client-key` value.

I'm not certain but I think this regression was introduced with #26766. It looks like we stopped URL encoding any uploaded files, which was fine for pem, but not for binary formats.

Resolves #30717

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30801)
<!-- Reviewable:end -->
