### PR TITLE
Lower threshold for redshift expiration to 1 hour

### DIFF
--- a/modules/drivers/redshift/test/metabase/test/data/redshift.clj
+++ b/modules/drivers/redshift/test/metabase/test/data/redshift.clj
@@ -92,7 +92,7 @@
 
 (def ^Long HOURS-BEFORE-EXPIRED-THRESHOLD
   "Number of hours that elapse before a persisted schema is considered expired."
-  6)
+  1)
 
 (defn- classify-cache-schemas
   "Classifies the persistence cache schemas. Returns a map with where each value is a (possibly empty) sequence of


### PR DESCRIPTION
Each test run can create schemas where we put persisted models. Normally these are thrown away when the test runner disconnects the db. But cloud is a persistent resource and they don't just fall away automatically.

We create a cache_info table in each persisted schema:

```sql
-- postgres/redshift
test-data=# select * from metabase_cache_424a9_379.cache_info ;
       key        |                value
------------------+--------------------------------------
 settings-version | 1
 created-at       | 2023-03-29T14:16:24.849866Z
 instance-uuid    | 407e4ba8-2bab-470f-aeb5-9fc63fd18c4e
 instance-name    | Metabase Test
(4 rows)
```

And we delete these schemas in redshift when creating our test databases when their `created-at` is over 6 hours old.

At the moment, there are (`(count (:all-schemas info))`) 420 schemas in redshift that we use on CI. 122 of those are cache schemas. Under a 6 hour threshold, 121 are recent. Under a 1 hour threshold, 2 are recent.

We've run out of tables in CI so I'm lowering the threshold for what "recent" is.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30806)
<!-- Reviewable:end -->
