### PR TITLE
Fix metabase-lib/metadata/Metadata type

### DIFF
--- a/frontend/src/metabase-lib/metadata/Field.ts
+++ b/frontend/src/metabase-lib/metadata/Field.ts
@@ -80,7 +80,7 @@ class FieldInner extends Base {
   table_id?: Table["id"];
   target?: Field;
   fk_target_field_id?: Field["id"] | null;
-  name_field?: Field["id"];
+  name_field?: Field;
   remapping?: unknown;
   has_field_values?: FieldValuesType;
   has_more_values?: boolean;

--- a/frontend/src/metabase-lib/metadata/Metadata.ts
+++ b/frontend/src/metabase-lib/metadata/Metadata.ts
@@ -59,7 +59,7 @@ class Metadata {
     return Object.values(this.segments);
   }
 
-  segment(segmentId: SegmentId | undefined | number): Segment | null {
+  segment(segmentId: SegmentId | undefined | null): Segment | null {
     return (segmentId != null && this.segments[segmentId]) || null;
   }
 
@@ -75,7 +75,7 @@ class Metadata {
     return (schemaId != null && this.schemas[schemaId]) || null;
   }
 
-  table(tableId: TableId | undefined | number): Table | null {
+  table(tableId: TableId | undefined | null): Table | null {
     return (tableId != null && this.tables[tableId]) || null;
   }
 

--- a/frontend/src/metabase-lib/metadata/Metadata.ts
+++ b/frontend/src/metabase-lib/metadata/Metadata.ts
@@ -28,7 +28,7 @@ import { getUniqueFieldId } from "./utils/fields";
 export default class Metadata extends Base {
   databases: Record<string, Database>;
   schemas: Record<string, Schema>;
-  tables: Record<string, TableId>;
+  tables: Record<string, Table>;
   fields: Record<string, Field>;
   metrics: Record<string, Metric>;
   segments: Record<string, Segment>;

--- a/frontend/src/metabase-lib/metadata/Metadata.ts
+++ b/frontend/src/metabase-lib/metadata/Metadata.ts
@@ -95,7 +95,7 @@ class Metadata {
 
   field(
     fieldId: FieldId | FieldReference | undefined | null,
-    tableId?: Table["id"] | undefined | null,
+    tableId?: TableId | undefined | null,
   ): Field | null {
     if (fieldId == null) {
       return null;

--- a/frontend/src/metabase-lib/metadata/Metadata.ts
+++ b/frontend/src/metabase-lib/metadata/Metadata.ts
@@ -1,8 +1,14 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-nocheck
 import _ from "underscore";
+import {
+  CardId,
+  DatabaseId,
+  FieldId,
+  MetricId,
+  SchemaId,
+  SegmentId,
+  TableId,
+} from "metabase-types/api";
 import type Question from "../Question";
-import Base from "./Base";
 import type Database from "./Database";
 import type Table from "./Table";
 import type Schema from "./Schema";
@@ -11,34 +17,20 @@ import type Metric from "./Metric";
 import type Segment from "./Segment";
 import { getUniqueFieldId } from "./utils/fields";
 
-/**
- * @typedef { import("./Metadata").DatabaseId } DatabaseId
- * @typedef { import("./Metadata").SchemaId } SchemaId
- * @typedef { import("./Metadata").TableId } TableId
- * @typedef { import("./Metadata").FieldId } FieldId
- * @typedef { import("./Metadata").MetricId } MetricId
- * @typedef { import("./Metadata").SegmentId } SegmentId
- */
-
-/**
- * Wrapper class for the entire metadata store
- */
-
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export default class Metadata extends Base {
-  databases: Record<string, Database>;
-  schemas: Record<string, Schema>;
-  tables: Record<string, Table>;
-  fields: Record<string, Field>;
-  metrics: Record<string, Metric>;
-  segments: Record<string, Segment>;
-  questions: Record<string, Question>;
+class Metadata {
+  databases: Record<string, Database> = {};
+  schemas: Record<string, Schema> = {};
+  tables: Record<string, Table> = {};
+  fields: Record<string, Field> = {};
+  metrics: Record<string, Metric> = {};
+  segments: Record<string, Segment> = {};
+  questions: Record<string, Question> = {};
 
   /**
    * @deprecated this won't be sorted or filtered in a meaningful way
    * @returns {Database[]}
    */
-  databasesList({ savedQuestions = true } = {}) {
+  databasesList({ savedQuestions = true } = {}): Database[] {
     return _.chain(this.databases)
       .values()
       .filter(db => savedQuestions || !db.is_saved_questions)
@@ -50,7 +42,7 @@ export default class Metadata extends Base {
    * @deprecated this won't be sorted or filtered in a meaningful way
    * @returns {Table[]}
    */
-  tablesList() {
+  tablesList(): Table[] {
     return Object.values(this.tables);
   }
 
@@ -58,61 +50,36 @@ export default class Metadata extends Base {
    * @deprecated this won't be sorted or filtered in a meaningful way
    * @returns {Metric[]}
    */
-  metricsList() {
+  metricsList(): Metric[] {
     return Object.values(this.metrics);
   }
 
-  /**
-   * @deprecated this won't be sorted or filtered in a meaningful way
-   * @returns {Segment[]}
-   */
-  segmentsList() {
+  segmentsList(): Segment[] {
     return Object.values(this.segments);
   }
 
-  /**
-   * @param {SegmentId} segmentId
-   * @returns {?Segment}
-   */
-  segment(segmentId) {
+  segment(segmentId: SegmentId | undefined | number): Segment | null {
     return (segmentId != null && this.segments[segmentId]) || null;
   }
 
-  /**
-   * @param {MetricId} metricId
-   * @returns {?Metric}
-   */
-  metric(metricId): Metric | null {
+  metric(metricId: MetricId | undefined | null): Metric | null {
     return (metricId != null && this.metrics[metricId]) || null;
   }
 
-  /**
-   * @param {DatabaseId} databaseId
-   * @returns {?Database}
-   */
-  database(databaseId): Database | null {
+  database(databaseId: DatabaseId | undefined | null): Database | null {
     return (databaseId != null && this.databases[databaseId]) || null;
   }
 
-  /**
-   * @param {SchemaId} schemaId
-   * @returns {Schema}
-   */
-  schema(schemaId): Schema | null {
+  schema(schemaId: SchemaId | undefined | null): Schema | null {
     return (schemaId != null && this.schemas[schemaId]) || null;
   }
 
-  /**
-   *
-   * @param {TableId} tableId
-   * @returns {?Table}
-   */
-  table(tableId): Table | null {
+  table(tableId: TableId | undefined | number): Table | null {
     return (tableId != null && this.tables[tableId]) || null;
   }
 
   field(
-    fieldId: Field["id"] | Field["name"] | undefined | null,
+    fieldId: FieldId | string | undefined | null,
     tableId?: Table["id"] | undefined | null,
   ): Field | null {
     if (fieldId == null) {
@@ -127,7 +94,10 @@ export default class Metadata extends Base {
     return this.fields[uniqueId] || null;
   }
 
-  question(cardId): Question | null {
+  question(cardId: CardId | undefined | null): Question | null {
     return (cardId != null && this.questions[cardId]) || null;
   }
 }
+
+// eslint-disable-next-line import/no-default-export -- deprecated usage
+export default Metadata;

--- a/frontend/src/metabase-lib/metadata/Metadata.ts
+++ b/frontend/src/metabase-lib/metadata/Metadata.ts
@@ -18,6 +18,16 @@ import type Metric from "./Metric";
 import type Segment from "./Segment";
 import { getUniqueFieldId } from "./utils/fields";
 
+interface MetadataOpts {
+  databases?: Record<string, Database>;
+  schemas?: Record<string, Schema>;
+  tables?: Record<string, Table>;
+  fields?: Record<string, Field>;
+  metrics?: Record<string, Metric>;
+  segments?: Record<string, Segment>;
+  questions?: Record<string, Question>;
+}
+
 class Metadata {
   databases: Record<string, Database> = {};
   schemas: Record<string, Schema> = {};
@@ -26,6 +36,10 @@ class Metadata {
   metrics: Record<string, Metric> = {};
   segments: Record<string, Segment> = {};
   questions: Record<string, Question> = {};
+
+  constructor(opts?: MetadataOpts) {
+    Object.assign(this, opts);
+  }
 
   /**
    * @deprecated this won't be sorted or filtered in a meaningful way

--- a/frontend/src/metabase-lib/metadata/Metadata.ts
+++ b/frontend/src/metabase-lib/metadata/Metadata.ts
@@ -3,6 +3,7 @@ import {
   CardId,
   DatabaseId,
   FieldId,
+  FieldReference,
   MetricId,
   SchemaId,
   SegmentId,
@@ -79,7 +80,7 @@ class Metadata {
   }
 
   field(
-    fieldId: FieldId | string | undefined | null,
+    fieldId: FieldId | FieldReference | undefined | null,
     tableId?: Table["id"] | undefined | null,
   ): Field | null {
     if (fieldId == null) {
@@ -88,8 +89,9 @@ class Metadata {
 
     const uniqueId = getUniqueFieldId({
       id: fieldId,
-      table_id: tableId,
-    } as Field);
+      name: "",
+      table_id: tableId ?? undefined,
+    });
 
     return this.fields[uniqueId] || null;
   }

--- a/frontend/src/metabase-lib/metadata/Metadata.unit.spec.ts
+++ b/frontend/src/metabase-lib/metadata/Metadata.unit.spec.ts
@@ -1,7 +1,6 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 import Metadata from "./Metadata";
-import Base from "./Base";
 import Database from "./Database";
 import Table from "./Table";
 import Schema from "./Schema";
@@ -14,8 +13,7 @@ describe("Metadata", () => {
     it("should create an instance of Metadata", () => {
       expect(new Metadata()).toBeInstanceOf(Metadata);
     });
-    it("should add `object` props to the instance (because it extends Base)", () => {
-      expect(new Metadata()).toBeInstanceOf(Base);
+    it("should add `object` props to the instance", () => {
       expect(
         new Metadata({
           foo: "bar",

--- a/frontend/src/metabase-lib/metadata/utils/fields.ts
+++ b/frontend/src/metabase-lib/metadata/utils/fields.ts
@@ -33,7 +33,9 @@ export function getIconForField(fieldOrColumn: any) {
   return type && ICON_MAPPING[type] ? ICON_MAPPING[type] : "unknown";
 }
 
-export function getUniqueFieldId(field: Field): number | string {
+export function getUniqueFieldId(
+  field: Pick<Field, "id" | "name" | "table_id">,
+): number | string {
   const { table_id } = field;
   const fieldIdentifier = getFieldIdentifier(field);
 
@@ -44,7 +46,9 @@ export function getUniqueFieldId(field: Field): number | string {
   return fieldIdentifier;
 }
 
-function getFieldIdentifier(field: Field): number | string {
+function getFieldIdentifier(
+  field: Pick<Field, "id" | "name">,
+): number | string {
   const { id, name } = field;
   if (Array.isArray(id)) {
     return id[1];

--- a/frontend/src/metabase-types/api/mocks/schema.ts
+++ b/frontend/src/metabase-types/api/mocks/schema.ts
@@ -62,6 +62,7 @@ export const createMockNormalizedFieldDimension = ({
 });
 
 export const createMockNormalizedField = ({
+  uniqueId = "1",
   target,
   table,
   name_field,
@@ -69,7 +70,7 @@ export const createMockNormalizedField = ({
   ...opts
 }: Partial<NormalizedField>): NormalizedField => ({
   ...createMockField(opts),
-  uniqueId: "1",
+  uniqueId,
   target,
   table,
   name_field,

--- a/frontend/src/metabase-types/api/mocks/schema.ts
+++ b/frontend/src/metabase-types/api/mocks/schema.ts
@@ -69,6 +69,7 @@ export const createMockNormalizedField = ({
   ...opts
 }: Partial<NormalizedField>): NormalizedField => ({
   ...createMockField(opts),
+  uniqueId: "1",
   target,
   table,
   name_field,

--- a/frontend/src/metabase-types/api/schema.ts
+++ b/frontend/src/metabase-types/api/schema.ts
@@ -46,6 +46,7 @@ export interface NormalizedFieldDimension
 
 export interface NormalizedField
   extends Omit<Field, "target" | "table" | "name_field" | "dimensions"> {
+  uniqueId: string;
   target?: FieldId;
   table?: TableId;
   name_field?: FieldId;

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/data-sidebar.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/data-sidebar.ts
@@ -129,7 +129,7 @@ export const getDataFocusSidebar: Selector<State, DataSidebarProps | null> =
         return getDatabasesSidebar(metadata);
       }
 
-      const database = getDatabase(metadata, databaseId);
+      const database = getDatabase(metadata, parseInt(databaseId));
 
       return getTablesSidebar(database, schemaName, tableId);
     },

--- a/frontend/src/metabase/admin/permissions/utils/metadata.ts
+++ b/frontend/src/metabase/admin/permissions/utils/metadata.ts
@@ -1,9 +1,6 @@
 import Metadata from "metabase-lib/metadata/Metadata";
 
-export const getDatabase = (
-  metadata: Metadata,
-  databaseId: number | string,
-) => {
+export const getDatabase = (metadata: Metadata, databaseId: number) => {
   const database = metadata.database(databaseId);
 
   if (!database) {

--- a/frontend/src/metabase/selectors/metadata.ts
+++ b/frontend/src/metabase/selectors/metadata.ts
@@ -137,8 +137,8 @@ export const getMetadata: (
       schema.database = hydrateSchemaDatabase(schema, metadata);
     });
     Object.values(metadata.tables).forEach(table => {
-      table.db = metadata.database(table.db_id || table.db) ?? undefined;
-      table.schema = metadata.schema(table.schema) ?? undefined;
+      table.db = hydrateTableDatabase(table, metadata);
+      table.schema = hydrateTableSchema(table, metadata);
       table.fields = hydrateTableFields(table, metadata);
       table.segments = hydrateTableSegments(table, metadata);
       table.metrics = hydrateTableMetrics(table, metadata);
@@ -288,6 +288,20 @@ function hydrateSchemaTables(schema: Schema, metadata: Metadata): Table[] {
       Object.values(metadata.tables).filter(
         table => table.schema && table.schema.id === schema.id,
       );
+}
+
+function hydrateTableDatabase(
+  table: Table,
+  metadata: Metadata,
+): Database | undefined {
+  return metadata.database(table.getPlainObject().db) || undefined;
+}
+
+function hydrateTableSchema(
+  table: Table,
+  metadata: Metadata,
+): Schema | undefined {
+  return metadata.schema(table.getPlainObject().schema) ?? undefined;
 }
 
 function hydrateTableFields(table: Table, metadata: Metadata): Field[] {

--- a/frontend/src/metabase/selectors/metadata.ts
+++ b/frontend/src/metabase/selectors/metadata.ts
@@ -137,7 +137,7 @@ export const getMetadata: (
       schema.database = hydrateSchemaDatabase(schema, metadata);
     });
     Object.values(metadata.tables).forEach(table => {
-      table.db = hydrateTableDatabase(table, metadata);
+      table.db = metadata.database(table.db_id) || undefined;
       table.schema = hydrateTableSchema(table, metadata);
       table.fields = hydrateTableFields(table, metadata);
       table.segments = hydrateTableSegments(table, metadata);
@@ -271,7 +271,8 @@ function hydrateSchemaDatabase(
   schema: Schema,
   metadata: Metadata,
 ): Database | undefined {
-  return metadata.database(schema.getPlainObject().database) ?? undefined;
+  const databaseId = schema.getPlainObject().database;
+  return metadata.database(databaseId) ?? undefined;
 }
 
 function hydrateSchemaTables(schema: Schema, metadata: Metadata): Table[] {
@@ -290,18 +291,12 @@ function hydrateSchemaTables(schema: Schema, metadata: Metadata): Table[] {
       );
 }
 
-function hydrateTableDatabase(
-  table: Table,
-  metadata: Metadata,
-): Database | undefined {
-  return metadata.database(table.getPlainObject().db) || undefined;
-}
-
 function hydrateTableSchema(
   table: Table,
   metadata: Metadata,
 ): Schema | undefined {
-  return metadata.schema(table.getPlainObject().schema) ?? undefined;
+  const schemaId = table.getPlainObject().schema;
+  return metadata.schema(schemaId) ?? undefined;
 }
 
 function hydrateTableFields(table: Table, metadata: Metadata): Field[] {

--- a/frontend/src/metabase/selectors/metadata.ts
+++ b/frontend/src/metabase/selectors/metadata.ts
@@ -150,14 +150,14 @@ export const getMetadata: (
       schema.tables = hydrateSchemaTables(schema, metadata);
     });
     Object.values(metadata.segments).forEach(segment => {
-      segment.table = metadata.table(segment.table_id) ?? undefined;
+      segment.table = hydrateSegmentTable(segment, metadata);
     });
     Object.values(metadata.metrics).forEach(metric => {
-      metric.table = metadata.table(metric.table_id) ?? undefined;
+      metric.table = hydrateMetricTable(metric, metadata);
     });
     Object.values(metadata.fields).forEach(field => {
-      field.table = metadata.table(field.table_id) ?? undefined;
-      field.target = metadata.field(field.fk_target_field_id) ?? undefined;
+      field.table = hydrateFieldTable(field, metadata);
+      field.target = hydrateFieldTarget(field, metadata);
       field.name_field = hydrateNameField(field, metadata);
       field.values = getFieldValues(field);
       field.remapping = new Map(getRemappings(field));
@@ -322,6 +322,20 @@ function hydrateTableMetrics(table: Table, metadata: Metadata): Metric[] {
   return metricIds.map(id => metadata.metric(id)).filter(isNotNull);
 }
 
+function hydrateFieldTable(
+  field: Field,
+  metadata: Metadata,
+): Table | undefined {
+  return metadata.table(field.table_id) ?? undefined;
+}
+
+function hydrateFieldTarget(
+  field: Field,
+  metadata: Metadata,
+): Field | undefined {
+  return metadata.field(field.fk_target_field_id) ?? undefined;
+}
+
 function hydrateNameField(field: Field, metadata: Metadata): Field | undefined {
   const nameFieldId = field.getPlainObject().name_field;
   if (nameFieldId != null) {
@@ -329,4 +343,18 @@ function hydrateNameField(field: Field, metadata: Metadata): Field | undefined {
   } else if (field.table && field.isPK()) {
     return field.table.getFields().find(f => f.isEntityName());
   }
+}
+
+function hydrateSegmentTable(
+  segment: Segment,
+  metadata: Metadata,
+): Table | undefined {
+  return metadata.table(segment.table_id) ?? undefined;
+}
+
+function hydrateMetricTable(
+  metric: Metric,
+  metadata: Metadata,
+): Table | undefined {
+  return metadata.table(metric.table_id) ?? undefined;
 }

--- a/frontend/src/metabase/selectors/metadata.ts
+++ b/frontend/src/metabase/selectors/metadata.ts
@@ -277,18 +277,17 @@ function hydrateSchemaDatabase(
 
 function hydrateSchemaTables(schema: Schema, metadata: Metadata): Table[] {
   const tableIds = schema.getPlainObject().tables;
-  return tableIds
-    ? // use the schema tables if they exist
-      tableIds.map(table => metadata.table(table)).filter(isNotNull)
-    : schema.database && schema.database.getTables().length > 0
-    ? // if the schema has a database with tables, use those
-      schema.database
-        .getTables()
-        .filter(table => table.schema_name === schema.name)
-    : // otherwise use any loaded tables that match the schema id
-      Object.values(metadata.tables).filter(
-        table => table.schema && table.schema.id === schema.id,
-      );
+  if (tableIds) {
+    return tableIds.map(table => metadata.table(table)).filter(isNotNull);
+  } else if (schema.database && schema.database.getTables().length > 0) {
+    return schema.database
+      .getTables()
+      .filter(table => table.schema_name === schema.name);
+  } else {
+    return Object.values(metadata.tables).filter(
+      table => table.schema && table.schema.id === schema.id,
+    );
+  }
 }
 
 function hydrateTableDatabase(

--- a/frontend/src/metabase/selectors/metadata.ts
+++ b/frontend/src/metabase/selectors/metadata.ts
@@ -137,7 +137,7 @@ export const getMetadata: (
       schema.database = hydrateSchemaDatabase(schema, metadata);
     });
     Object.values(metadata.tables).forEach(table => {
-      table.db = metadata.database(table.db_id) || undefined;
+      table.db = hydrateTableDatabase(table, metadata);
       table.schema = hydrateTableSchema(table, metadata);
       table.fields = hydrateTableFields(table, metadata);
       table.segments = hydrateTableSegments(table, metadata);
@@ -289,6 +289,14 @@ function hydrateSchemaTables(schema: Schema, metadata: Metadata): Table[] {
       Object.values(metadata.tables).filter(
         table => table.schema && table.schema.id === schema.id,
       );
+}
+
+function hydrateTableDatabase(
+  table: Table,
+  metadata: Metadata,
+): Database | undefined {
+  const { db, db_id } = table.getPlainObject();
+  return metadata.database(db ?? db_id) ?? undefined;
 }
 
 function hydrateTableSchema(

--- a/frontend/src/metabase/selectors/metadata.ts
+++ b/frontend/src/metabase/selectors/metadata.ts
@@ -131,18 +131,12 @@ export const getMetadata: (
     Object.values(metadata.schemas).forEach(schema => {
       schema.database = hydrateSchemaDatabase(schema, metadata);
     });
-
-    // table
     Object.values(metadata.tables).forEach(table => {
+      table.db = metadata.database(table.db_id || table.db) ?? undefined;
+      table.schema = metadata.schema(table.schema) ?? undefined;
       table.fields = hydrateTableFields(table, metadata);
       table.segments = hydrateTableSegments(table, metadata);
       table.metrics = hyrdateTableMetrics(table, metadata);
-    });
-    Object.values(metadata.tables).forEach(table => {
-      table.db = metadata.database(table.db_id || table.db) ?? undefined;
-    });
-    Object.values(metadata.tables).forEach(table => {
-      table.schema = metadata.schema(table.schema) ?? undefined;
     });
     Object.values(metadata.databases).forEach(database => {
       database.schemas = hydrateDatabaseSchemas(database, metadata);

--- a/frontend/src/metabase/selectors/metadata.ts
+++ b/frontend/src/metabase/selectors/metadata.ts
@@ -49,7 +49,11 @@ const getNormalizedTables = createSelector(
   (tables, includeHiddenTables) =>
     includeHiddenTables
       ? tables
-      : filterValues(tables, table => table.visibility_type == null),
+      : Object.fromEntries(
+          Object.entries(tables).filter(
+            ([, table]) => table.visibility_type == null,
+          ),
+        ),
 );
 
 const getNormalizedFieldsUnfiltered = (state: State) => state.entities.fields;
@@ -64,17 +68,19 @@ const getNormalizedFields = createSelector(
     getIncludeSensitiveFields,
   ],
   (fields, tables, includeHiddenTables, includeSensitiveFields) =>
-    filterValues(fields, field => {
-      const table = tables[field.table_id];
+    Object.fromEntries(
+      Object.entries(fields).filter(([, field]) => {
+        const table = tables[field.table_id];
 
-      const shouldIncludeTable =
-        !table || table.visibility_type == null || includeHiddenTables;
+        const shouldIncludeTable =
+          !table || table.visibility_type == null || includeHiddenTables;
 
-      const shouldIncludeField =
-        field.visibility_type !== "sensitive" || includeSensitiveFields;
+        const shouldIncludeField =
+          field.visibility_type !== "sensitive" || includeSensitiveFields;
 
-      return shouldIncludeTable && shouldIncludeField;
-    }),
+        return shouldIncludeTable && shouldIncludeField;
+      }),
+    ),
 );
 
 const getNormalizedMetrics = (state: State) => state.entities.metrics;
@@ -307,14 +313,4 @@ function createSegment(
 
 function createQuestion(card: Card, metadata: Metadata): Question {
   return new Question(card, metadata);
-}
-
-function filterValues<T>(obj: Record<string, T>, pred: (obj: T) => boolean) {
-  const filtered: Record<string, T> = {};
-  for (const [k, v] of Object.entries(obj)) {
-    if (pred(v)) {
-      filtered[k] = v;
-    }
-  }
-  return filtered;
 }

--- a/frontend/src/metabase/selectors/metadata.ts
+++ b/frontend/src/metabase/selectors/metadata.ts
@@ -103,47 +103,26 @@ export const getMetadata: (
   (databases, schemas, tables, fields, segments, metrics, questions) => {
     const metadata = new Metadata();
 
-    metadata.databases = copyObjects(
-      metadata,
-      databases,
-      createDatabase,
-      database => database.id,
+    metadata.databases = Object.fromEntries(
+      Object.values(databases).map(d => [d.id, createDatabase(d, metadata)]),
     );
-    metadata.schemas = copyObjects(
-      metadata,
-      schemas,
-      createSchema,
-      schema => schema.id,
+    metadata.schemas = Object.fromEntries(
+      Object.values(schemas).map(s => [s.id, createSchema(s, metadata)]),
     );
-    metadata.tables = copyObjects(
-      metadata,
-      tables,
-      createTable,
-      table => table.id,
+    metadata.tables = Object.fromEntries(
+      Object.values(tables).map(t => [t.id, createTable(t, metadata)]),
     );
-    metadata.fields = copyObjects(
-      metadata,
-      fields,
-      createField,
-      field => field.uniqueId,
+    metadata.fields = Object.fromEntries(
+      Object.values(fields).map(f => [f.uniqueId, createField(f, metadata)]),
     );
-    metadata.segments = copyObjects(
-      metadata,
-      segments,
-      createSegment,
-      segment => segment.id,
+    metadata.segments = Object.fromEntries(
+      Object.values(segments).map(s => [s.id, createSegment(s, metadata)]),
     );
-    metadata.metrics = copyObjects(
-      metadata,
-      metrics,
-      createMetric,
-      metric => metric.id,
+    metadata.metrics = Object.fromEntries(
+      Object.values(metrics).map(m => [m.id, createMetric(m, metadata)]),
     );
-    metadata.questions = copyObjects(
-      metadata,
-      questions,
-      createQuestion,
-      card => card.id,
+    metadata.questions = Object.fromEntries(
+      Object.values(questions).map(c => [c.id, createQuestion(c, metadata)]),
     );
 
     // database
@@ -327,22 +306,6 @@ function createSegment(segment: NormalizedSegment, metadata: Metadata) {
 
 function createQuestion(card: Card, metadata: Metadata) {
   return new Question(card, metadata);
-}
-
-function copyObjects<RawObject, MetadataObject>(
-  metadata: Metadata,
-  objects: Record<string, RawObject>,
-  getInstance: (object: RawObject, metadata: Metadata) => MetadataObject,
-  getInstanceId: (object: RawObject) => string | number | undefined,
-) {
-  const copies: Record<string, MetadataObject> = {};
-  for (const object of Object.values(objects)) {
-    const objectId = getInstanceId(object);
-    if (objectId != null) {
-      copies[objectId] = getInstance(object, metadata);
-    }
-  }
-  return copies;
 }
 
 // calls a function to derive the value of a property for every object


### PR DESCRIPTION
Epic https://github.com/metabase/metabase/issues/30763

Further refactors `getMetadata` selector to be typecast free and type safe. Also fixes types in `Metadata` class and removes typescript ignore comments. For `getMetadata`, I've moved hydration code to separate functions, and fixed cases where it relied on hydrated properties being overwritten by using `getPlainObject` explicitly. 

Next steps:
- Move table and filter filtering logic to the selector body
- Move selector body to `metabase-lib`, like `Metadata.create({ databases, ... })` or something like that

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30808)
<!-- Reviewable:end -->
