### PR TITLE
[MLv2] Don't allow adding an expression with the same name as a column

### DIFF
--- a/src/metabase/lib/expression.cljc
+++ b/src/metabase/lib/expression.cljc
@@ -18,6 +18,7 @@
    [metabase.lib.util :as lib.util]
    [metabase.shared.util.i18n :as i18n]
    [metabase.types :as types]
+   [metabase.util :as u]
    [metabase.util.malli :as mu]))
 
 (mu/defn column-metadata->expression-ref :- :mbql.clause/expression
@@ -185,12 +186,22 @@
   [query stage-number [_coalesce _opts expr _null-expr]]
   (lib.metadata.calculation/column-name query stage-number expr))
 
+(defn- unique-name? [query stage-number expression-name]
+  (let [stage (lib.util/query-stage query stage-number)
+        cols  (lib.metadata.calculation/visible-columns query stage-number stage)
+        names (set (for [{col :name} cols]
+                     (u/lower-case-en col)))]
+    (not (names (u/lower-case-en expression-name)))))
+
 (mu/defn expression :- ::lib.schema/query
   "Adds an expression to query."
   ([query expression-name an-expression-clause]
    (expression query -1 expression-name an-expression-clause))
   ([query stage-number expression-name an-expression-clause]
    (let [stage-number (or stage-number -1)]
+     (when-not (unique-name? query stage-number expression-name)
+       (throw (ex-info "Expression name conflicts with a column in the same query stage"
+                       {:expression-name expression-name})))
      (lib.util/update-query-stage
        query stage-number
        update :expressions

--- a/test/metabase/lib/expression_test.cljc
+++ b/test/metabase/lib/expression_test.cljc
@@ -248,4 +248,17 @@
               :display-name "expr"}]
             (-> (lib/query-for-table-name meta/metadata-provider "VENUES")
                 (lib/expression "expr" (lib/absolute-datetime "2020" :month))
-                lib/expressions-metadata)))))
+                lib/expressions-metadata))))
+  (testing "collisions with other column names are detected and rejected"
+    (let [query (lib/query-for-table-name meta/metadata-provider "CATEGORIES")
+          ex    (try
+                  (lib/expression query "ID" (lib/field "CATEGORIES" "NAME"))
+                  nil
+                  (catch #?(:clj clojure.lang.ExceptionInfo :cljs js/Error) e
+                    e))]
+      (is (some? ex)
+          "Expected adding a conflicting expression to throw")
+      (is (= "Expression name conflicts with a column in the same query stage"
+             (ex-message ex)))
+      (is (= {:expression-name "ID"}
+             (ex-data ex))))))


### PR DESCRIPTION
This was causing ambiguous references, since `order-by` clauses
reference columns from previous stages by name.

Fixes #30401.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30809)
<!-- Reviewable:end -->
