### PR TITLE
Adds encoding to field props for database inputs

### DIFF
--- a/frontend/src/metabase/databases/components/DatabaseDetailField/DatabaseDetailField.tsx
+++ b/frontend/src/metabase/databases/components/DatabaseDetailField/DatabaseDetailField.tsx
@@ -62,7 +62,7 @@ const getFieldProps = (field: EngineField, override?: EngineFieldOverride) => {
     title: override?.title ?? field["display-name"],
     description: override?.description ?? field.description,
     placeholder: placeholder != null ? String(placeholder) : undefined,
-    encoding: override ? null : field["treat-before-posting"],
+    encoding: field["treat-before-posting"],
   };
 };
 

--- a/frontend/src/metabase/databases/components/DatabaseDetailField/DatabaseDetailField.tsx
+++ b/frontend/src/metabase/databases/components/DatabaseDetailField/DatabaseDetailField.tsx
@@ -62,6 +62,7 @@ const getFieldProps = (field: EngineField, override?: EngineFieldOverride) => {
     title: override?.title ?? field["display-name"],
     description: override?.description ?? field.description,
     placeholder: placeholder != null ? String(placeholder) : undefined,
+    encoding: override ? null : field["treat-before-posting"],
   };
 };
 


### PR DESCRIPTION
This is a second attempt at #30801 with no noise. This just forwards the `treat-before-posting` property on to the new file input as `encoding` in the DB field props.

Resolves #30717

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30812)
<!-- Reviewable:end -->
