### PR TITLE
CI: Prerelease workflow improvements

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -6,16 +6,70 @@ on:
       commit:
         description: 'A full-length commit SHA-1 hash'
         required: true
+      version:
+        description: 'Intended version for the release'
+        required: true
 
 env:
   MAX_HASH_LENGTH: 8
   CUSTOM_REPO: ${{ secrets.CUSTOM_RELEASE_REPO }}
 
 jobs:
+  check-commit:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+    steps:
+    - name: Ensure that the intended version (${{ github.event.inputs.version }}) was never released before
+      run: |
+        echo "Checking if ${{ github.event.inputs.version }} conflicts with a past release..."
+        CANONICAL_REFS=https://github.com/metabase/metabase/archive/refs
+        URL=${CANONICAL_REFS}/tags/${{ github.event.inputs.version }}.zip
+        HTTP_CODE=$(curl -s -L -o /dev/null --head -w "%{HTTP_CODE}" ${URL})
+        if [[ $HTTP_CODE =~ "200" ]]; then
+          echo "ERROR: that version was already released in the past."
+          echo "ABORT!"
+          exit -1
+        else
+          if [[ $HTTP_CODE =~ "404" ]]; then
+            echo "That version has not been released yet."
+            echo "Proceeding to the next step..."
+            exit 0
+          else
+            echo "ERROR: Unhandled case of HTTP $HTTP_CODE while checking ${URL}"
+            echo "ABORT!"
+            exit -1
+          fi
+        fi
+
+    - name: Check out the code to verify the release branch
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0  # IMPORTANT! to get all the branches
+    - name: Ensure that the specified commit exists in the latest release branch
+      run: |
+        echo "Checking if the specified commit is in a release branch..."
+        COMMIT=${{ github.event.inputs.commit }}
+        git branch -a --contains $COMMIT > branches.txt
+        if [[ $(grep -c master branches.txt) =~ 1 ]]; then
+          echo "Found in master branch. ABORT!"
+          exit -1
+        fi
+        if [[ $(grep -c 'release-x' branches.txt) =~ 1 ]]; then
+          echo "Found the commit $COMMIT in:"
+          git branch -a --contains $COMMIT
+          echo "Proceeding to the next step..."
+          exit 0
+        else
+          echo "Commit $COMMIT is not found in a single release branch"
+          echo "ABORT!."
+          exit -1
+        fi
+
   build:
     if: ${{ github.repository }} != 'metabase/metabase'
-    name: Build Metabase ${{ matrix.edition }} @${{ github.event.inputs.commit }}
     runs-on: ubuntu-22.04
+    needs: check-commit
+    name: Build Metabase ${{ matrix.edition }} @${{ github.event.inputs.commit }}
     timeout-minutes: 40
     strategy:
       matrix:

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -7,7 +7,7 @@ on:
         description: 'A full-length commit SHA-1 hash'
         required: true
       version:
-        description: 'Intended version for the release'
+        description: 'Intended version (e.g. v0.46.3)'
         required: true
 
 env:
@@ -21,7 +21,13 @@ jobs:
     steps:
     - name: Ensure that the intended version (${{ github.event.inputs.version }}) was never released before
       run: |
-        echo "Checking if ${{ github.event.inputs.version }} conflicts with a past release..."
+        if [[ "${{ github.event.inputs.version }}" = v* ]]; then
+          echo "Checking if ${{ github.event.inputs.version }} conflicts with a past release..."
+        else
+          echo "ERROR: the intended version must start with 'v', e.g. 'v0.46.3."
+          echo "ABORT!"
+          exit -1
+        fi
         CANONICAL_REFS=https://github.com/metabase/metabase/archive/refs
         URL=${CANONICAL_REFS}/tags/${{ github.event.inputs.version }}.zip
         HTTP_CODE=$(curl -s -L -o /dev/null --head -w "%{HTTP_CODE}" ${URL})


### PR DESCRIPTION
### Before this PR

Invoking the workflow only requires giving a specific SHA1 commit.

![image](https://github.com/metabase/metabase/assets/7288/427d628a-06d8-4df3-a1ab-bfbaff610e64)


### After this PR

In addition to the specific SHA1 commit, another value is required: the intended version this pre-release is supposed to be. Note that it is a prerelease, so there is no actual release to the outside world (e.g. file upload, container update, etc). The sole purpose is to carry out a sequence of sanity checks purely within the CI.

![image](https://github.com/metabase/metabase/assets/7288/c522c237-fc0f-46a8-bc67-0908fcd4ed60)

The first sanity check is prevent overriding a previous release.

![Screenshot_20230517_052944](https://github.com/metabase/metabase/assets/7288/ba49da9c-8df8-4485-bf7b-fcca628a3d62)

Another sanity check is to ensure that the chosen commit exists in a release branch. Accidental release from the master branch, instead of the appropriate release branch, happened in the past so this check offers a modest protection against that mistake.

![Screenshot_20230517_053003](https://github.com/metabase/metabase/assets/7288/dc63aae5-549b-476b-b15c-ddea313358ba)

Note: the additional value supplied to the workflow, i.e. the intended version, will be used in a follow-up enhancement to the workflow.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30819)
<!-- Reviewable:end -->
