### PR TITLE
Fixes SQL formatting of BigQuery native queries

### DIFF
--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
@@ -4,6 +4,7 @@
    [clojure.string :as str]
    [clojure.test :refer :all]
    [metabase.db.metadata-queries :as metadata-queries]
+   [metabase.db.query :as mdb.query]
    [metabase.driver :as driver]
    [metabase.driver.bigquery-cloud-sdk :as bigquery]
    [metabase.driver.bigquery-cloud-sdk.common :as bigquery.common]
@@ -495,3 +496,12 @@
                   ["2021-01-10T00:00:00Z" 6]]
                  (mt/rows
                   (qp/process-query query)))))))))
+
+(deftest format-sql-test
+  (mt/test-driver :bigquery-cloud-sdk
+     (testing "native queries are compiled and formatted without whitespace errors (#30676)"
+       (is (= (str "SELECT\n  count(*) AS `count`\nFROM\n  `v3_test_data.venues`")
+              (-> (mt/mbql-query venues {:aggregation [:count]})
+                  qp/compile-and-splice-parameters
+                  :query
+                  (mdb.query/format-sql :bigquery-cloud-sdk)))))))

--- a/src/metabase/db/query.clj
+++ b/src/metabase/db/query.clj
@@ -50,6 +50,7 @@
                                           :sparksql Dialect/SparkSql
                                           :sqlserver Dialect/TSql
                                           :oracle Dialect/PlSql
+                                          :bigquery-cloud-sdk Dialect/MySql
                                           Dialect/StandardSql))]
          (.format formatter sql))
        sql))))


### PR DESCRIPTION
The default SQL dialect was creating invalid SQL and adding spaces around identifiers with backticks in BigQuery SQL. Using the MySQL dialect seems to format things more correctly. Maybe we should skip formatting any dialect we don't know for sure we support?

Resolves #30676

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30824)
<!-- Reviewable:end -->
