### PR TITLE
Change email notification url to allow for non-Metabase users to unsubscribe from alerts

### DIFF
--- a/src/metabase/email/messages.clj
+++ b/src/metabase/email/messages.clj
@@ -7,6 +7,7 @@
    [hiccup.core :refer [html]]
    [java-time :as t]
    [medley.core :as m]
+   [metabase.api.session :as api.session]
    [metabase.config :as config]
    [metabase.db.query :as mdb.query]
    [metabase.driver :as driver]
@@ -102,7 +103,6 @@
    :colorTextLight            style/color-text-light
    :colorTextMedium           style/color-text-medium
    :colorTextDark             style/color-text-dark
-   :notificationManagementUrl (urls/notification-management-url)
    :siteUrl                   (public-settings/site-url)})
 
 ;;; ### Public Interface
@@ -299,14 +299,18 @@
                               (some :dashboard_id cards))]
     {:pulseLink (urls/dashboard-url dashboard-id)}))
 
-(defn- pulse-context [pulse dashboard]
+(defn- pulse-context [pulse dashboard non-user-email]
   (merge (common-context)
          {:emailType                 "pulse"
           :title                     (:name pulse)
           :titleUrl                  (params/dashboard-url (:id dashboard) (params/parameters pulse dashboard))
           :dashboardDescription      (:description dashboard)
           :creator                   (-> pulse :creator :common_name)
-          :sectionStyle              (style/style (style/section-style))}
+          :sectionStyle              (style/style (style/section-style))
+          :notificationManagementUrl (if (nil? non-user-email)
+                                       (urls/notification-management-url)
+                                       ;; TODO: change this to whatever FE URL we chooseg
+                                       (str (urls/notification-management-url) "?hashdata=" (api.session/generate-hash (:id pulse) non-user-email)))}
          (pulse-link-context pulse)))
 
 (defn- create-temp-file
@@ -485,10 +489,10 @@
 
 (defn render-pulse-email
   "Take a pulse object and list of results, returns an array of attachment objects for an email"
-  [timezone pulse dashboard results]
+  [timezone pulse dashboard results non-user-email]
   (render-message-body pulse
                        :pulse
-                       (pulse-context pulse dashboard)
+                       (pulse-context pulse dashboard non-user-email)
                        timezone
                        dashboard
                        (assoc-attachment-booleans pulse results)))

--- a/src/metabase/email/messages.clj
+++ b/src/metabase/email/messages.clj
@@ -307,6 +307,9 @@
           :dashboardDescription      (:description dashboard)
           :creator                   (-> pulse :creator :common_name)
           :sectionStyle              (style/style (style/section-style))
+          :notificationText          (if (nil? non-user-email)
+                                       "Manage your subscriptions"
+                                       "Unsubscribe")
           :notificationManagementUrl (if (nil? non-user-email)
                                        (urls/notification-management-url)
                                        ;; TODO: change this to whatever FE URL we chooseg

--- a/src/metabase/email/pulse.mustache
+++ b/src/metabase/email/pulse.mustache
@@ -144,7 +144,7 @@
             <hr style="border-width: 0; background: #F0F0F0; height: 1px; margin-top: 20px; margin-bottom: 20px;">
             <div class="footer" style="font-size: 11px; width: max-content; margin: 0 auto">
               Sent from <a href="{{siteUrl}}" style="color: {{applicationColor}}">{{siteUrl}}</a>.
-              <a href="{{notificationManagementUrl}}" style="color: {{applicationColor}}">Manage your subscriptions</a>
+              <a href="{{notificationManagementUrl}}" style="color: {{applicationColor}}">{{notificationText}}</a>
             </div>
           </div>
         </td>

--- a/src/metabase/pulse.clj
+++ b/src/metabase/pulse.clj
@@ -380,14 +380,22 @@
   [{pulse-id :id, pulse-name :name, dashboard-id :dashboard_id, :as pulse} results {:keys [recipients]}]
   (log/debug (u/format-color 'cyan (trs "Sending Pulse ({0}: {1}) with {2} Cards via email"
                                         pulse-id (pr-str pulse-name) (count results))))
-  (let [email-recipients (filterv u/email? (map :email recipients))
-        query-results    (filter :card results)
-        timezone         (-> query-results first :card defaulted-timezone)
-        dashboard        (update (t2/select-one Dashboard :id dashboard-id) :description markdown/process-markdown :html)]
-    {:subject      (subject pulse)
-     :recipients   email-recipients
-     :message-type :attachments
-     :message      (messages/render-pulse-email timezone pulse dashboard results)}))
+  (let [user-recipients     (filter (fn [recipient] (and (u/email? (:email recipient))
+                                                         (some? (:id recipient)))) recipients)
+        non-user-recipients (filter (fn [recipient] (and (u/email? (:email recipient))
+                                                         (nil? (:id recipient)))) recipients)
+        query-results       (filter :card results)
+        timezone            (-> query-results first :card defaulted-timezone)
+        dashboard           (update (t2/select-one Dashboard :id dashboard-id) :description markdown/process-markdown :html)
+        email-to-users      [{:subject      (subject pulse)
+                              :recipients   (mapv :email user-recipients)
+                              :message-type :attachments
+                              :message      (messages/render-pulse-email timezone pulse dashboard results nil)}]]
+    (concat email-to-users (for [email (map :email non-user-recipients)]
+                             {:subject      (subject pulse)
+                              :recipients   [email]
+                              :message-type :attachments
+                              :message      (messages/render-pulse-email timezone pulse dashboard results email)}))))
 
 (defmethod notification [:pulse :slack]
   [{pulse-id :id, pulse-name :name, dashboard-id :dashboard_id, :as pulse}
@@ -478,15 +486,16 @@
           (throw e))))))
 
 (defmethod send-notification! :email
-  [{:keys [subject recipients message-type message]}]
-  (try
-    (email/send-message-or-throw! {:subject      subject
-                                   :recipients   recipients
-                                   :message-type message-type
-                                   :message      message})
-    (catch ExceptionInfo e
-      (when (not= :smtp-host-not-set (:cause (ex-data e)))
-        (throw e)))))
+  [emails]
+  (doseq [{:keys [subject recipients message-type message]} emails]
+    (try
+      (email/send-message-or-throw! {:subject      subject
+                                     :recipients   recipients
+                                     :message-type message-type
+                                     :message      message})
+      (catch ExceptionInfo e
+        (when (not= :smtp-host-not-set (:cause (ex-data e)))
+          (throw e))))))
 
 (declare ^:private reconfigure-retrying)
 


### PR DESCRIPTION

### Description

Send different email for non users.

### How to verify

1. Test email sending for a combination of users and non-users

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30831)
<!-- Reviewable:end -->
