### PR TITLE
Snowplow tracking for dashboard tab creations and deletions

### DIFF
--- a/snowplow/iglu-client-embedded/schemas/com.metabase/dashboardtab/jsonschema/1-0-0
+++ b/snowplow/iglu-client-embedded/schemas/com.metabase/dashboardtab/jsonschema/1-0-0
@@ -1,0 +1,47 @@
+{
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "description": "Dashboard tab events",
+  "self": {
+    "vendor": "com.metabase",
+    "name": "dashboardtab",
+    "format": "jsonschema",
+    "version": "1-0-0"
+  },
+  "type": "object",
+  "properties": {
+    "event": {
+      "description": "Event name",
+      "type": "string",
+      "enum": [
+        "dashboard_tab_created",
+        "dashboard_tab_deleted"
+      ],
+      "maxLength": 128
+    },
+    "dashboard_id": {
+      "description": "Unique identifier for an dashboard within the Metabase instance",
+      "type": ["integer", "null"],
+      "minimum": 0,
+      "maximum": 2147483647
+    },
+    "num_tabs": {
+      "description": "Number of tabs affected after the event",
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 2147483647
+    },
+    "total_num_tabs": {
+      "description": "Total number of active tabs after the events",
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 2147483647
+    }
+  },
+  "required": [
+    "event",
+    "dashboard_id",
+    "num_tabs",
+    "total_num_tabs"
+  ],
+  "additionalProperties": true
+}

--- a/src/metabase/analytics/snowplow.clj
+++ b/src/metabase/analytics/snowplow.clj
@@ -135,15 +135,16 @@
 (def ^:private schema->version
   "The most recent version for each event schema. This should be updated whenever a new version of a schema is added
   to SnowcatCloud, at the same time that the data sent to the collector is updated."
-  {::account   "1-0-0"
-   ::invite    "1-0-1"
-   ::dashboard "1-0-0"
-   ::database  "1-0-0"
-   ::instance  "1-1-0"
-   ::metabot   "1-0-0"
-   ::timeline  "1-0-0"
-   ::task      "1-0-0"
-   ::action    "1-0-0"})
+  {::account      "1-0-0"
+   ::invite       "1-0-1"
+   ::dashboard    "1-0-0"
+   ::dashboardtab "1-0-0"
+   ::database     "1-0-0"
+   ::instance     "1-1-0"
+   ::metabot      "1-0-0"
+   ::timeline     "1-0-0"
+   ::task         "1-0-0"
+   ::action       "1-0-0"})
 
 (defn- app-db-type
   "Returns the type of the Metabase application database as a string (e.g. PostgreSQL, MySQL)"
@@ -206,6 +207,8 @@
    ::action-updated                 ::action
    ::action-deleted                 ::action
    ::action-executed                ::action
+   ::dashboard-tabs-created         ::dashboardtab
+   ::dashboard-tabs-deleted         ::dashboardtab
    ::metabot-feedback-received      ::metabot})
 
 (defn track-event!

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -590,7 +590,10 @@
         _                                       (when (seq to-update)
                                                   (update-tabs! dashboard to-update))]
     {:temp->real-tab-ids temp-tab-id->tab-id
-     :deleted-tab-ids    to-delete-ids}))
+     :deleted-tab-ids    to-delete-ids
+     :num-tabs-created   (count to-create)
+     :num-tabs-deleted   (count to-delete)
+     :total-num-tabs     (+ (count to-create) (count to-update))}))
 
 (defn- create-dashcards!
   [dashboard dashcards]
@@ -681,21 +684,37 @@
       (throw (ex-info (tru "This dashboard has tab, makes sure every card has a tab")
                       {:status-code 400})))
     (api/check-500
-      (t2/with-transaction [_conn]
-        (let [{:keys [temp->real-tab-ids
-                      deleted-tab-ids]} (do-update-tabs! dashboard (:ordered_tabs dashboard) new-tabs)
-              current-cards             (cond->> (:ordered_cards dashboard)
-                                          (seq deleted-tab-ids)
-                                          (remove (fn [card]
-                                                   (contains? deleted-tab-ids (:dashboard_tab_id card)))))
-              new-cards                 (cond->> cards
-                                          ;; fixup the temporary tab ids with the real ones
-                                          (seq temp->real-tab-ids)
-                                          (map (fn [card]
-                                                 (if-let [real-tab-id (get temp->real-tab-ids (:dashboard_tab_id card))]
-                                                   (assoc card :dashboard_tab_id real-tab-id)
-                                                   card))))]
-          (do-update-dashcards! dashboard current-cards new-cards))
+      (let [tabs-stats-atom (atom nil)]
+        (t2/with-transaction [_conn]
+          (let [{:keys [temp->real-tab-ids
+                        deleted-tab-ids]
+                 :as tab-stats}           (do-update-tabs! dashboard (:ordered_tabs dashboard) new-tabs)
+                current-cards             (cond->> (:ordered_cards dashboard)
+                                            (seq deleted-tab-ids)
+                                            (remove (fn [card]
+                                                      (contains? deleted-tab-ids (:dashboard_tab_id card)))))
+                new-cards                 (cond->> cards
+                                            ;; fixup the temporary tab ids with the real ones
+                                            (seq temp->real-tab-ids)
+                                            (map (fn [card]
+                                                   (if-let [real-tab-id (get temp->real-tab-ids (:dashboard_tab_id card))]
+                                                     (assoc card :dashboard_tab_id real-tab-id)
+                                                     card))))]
+            (do-update-dashcards! dashboard current-cards new-cards)
+            (reset! tabs-stats-atom (select-keys tab-stats [:num-tabs-created :num-tabs-deleted :total-num-tabs]))))
+        (when-let [{:keys [num-tabs-created num-tabs-deleted total-num-tabs]} @tabs-stats-atom]
+          (when (pos-int? num-tabs-created)
+            (snowplow/track-event! ::snowplow/dashboard-tabs-created
+                                   api/*current-user-id*
+                                   {:dashboard-id  (:id dashboard)
+                                    :num-tabs       num-tabs-created
+                                    :total-num-tabs total-num-tabs}))
+          (when (pos-int? num-tabs-deleted)
+            (snowplow/track-event! ::snowplow/dashboard-tabs-deleted
+                                   api/*current-user-id*
+                                   {:dashboard-id  (:id dashboard)
+                                    :num-tabs       num-tabs-deleted
+                                    :total-num-tabs total-num-tabs})))
         true))
     {:cards        (t2/hydrate (dashboard/ordered-cards id) :series)
      :ordered_tabs (dashboard/ordered-tabs id)}))

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -702,7 +702,7 @@
                                                      card))))]
             (do-update-dashcards! dashboard current-cards new-cards)
             (reset! tabs-stats-atom (select-keys tab-stats [:num-tabs-created :num-tabs-deleted :total-num-tabs]))))
-        (when-let [{:keys [num-tabs-created num-tabs-deleted total-num-tabs]} @tabs-stats-atom]
+        (let [{:keys [num-tabs-created num-tabs-deleted total-num-tabs]} @tabs-stats-atom]
           (when (pos-int? num-tabs-created)
             (snowplow/track-event! ::snowplow/dashboard-tabs-created
                                    api/*current-user-id*

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -1268,12 +1268,6 @@
   [id]
   (t2/hydrate (t2/select-one DashboardCard :id id) :series))
 
-(defn- current-tabs
-  "Returns the current ordered tabs of a dashboard."
-  [dashboard-id]
-  (-> dashboard-id
-      dashboard/ordered-tabs))
-
 (defn- current-cards
   "Returns the current ordered cards of a dashboard."
   [dashboard-id]
@@ -1629,7 +1623,7 @@
     (testing "send nothing if tabs are unchanged"
       (snowplow-test/with-fake-snowplow-collector
         (mt/user-http-request :rasta :put 200 (format "dashboard/%d/cards" dashboard-id)
-                              {:ordered_tabs  (current-tabs dashboard-id)
+                              {:ordered_tabs  (dashboard/ordered-tabs dashboard-id)
                                :cards         []})
         (is (= 0 (count (snowplow-test/pop-event-data-and-user-id!))))))))
 

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -1268,6 +1268,12 @@
   [id]
   (t2/hydrate (t2/select-one DashboardCard :id id) :series))
 
+(defn- current-tabs
+  "Returns the current ordered tabs of a dashboard."
+  [dashboard-id]
+  (-> dashboard-id
+      dashboard/ordered-tabs))
+
 (defn- current-cards
   "Returns the current ordered cards of a dashboard."
   [dashboard-id]
@@ -1589,6 +1595,43 @@
                                                        :col     1
                                                        :row     1})
                                       :ordered_tabs (dashboard/ordered-tabs dashboard-id)})))))))
+
+(deftest update-tabs-track-snowplow-test
+  (t2.with-temp/with-temp
+    [Dashboard               {dashboard-id :id}  {}
+     :model/DashboardTab     {dashtab-id-1 :id}  {:name "Tab 1" :dashboard_id dashboard-id :position 0}
+     :model/DashboardTab     {dashtab-id-2 :id}  {:name "Tab 2" :dashboard_id dashboard-id :position 1}
+     :model/DashboardTab     _                   {:name "Tab 3" :dashboard_id dashboard-id :position 2}]
+    (testing "create and delete tabs events are tracked"
+      (snowplow-test/with-fake-snowplow-collector
+        (mt/user-http-request :rasta :put 200 (format "dashboard/%d/cards" dashboard-id)
+                              {:ordered_tabs  [{:id   dashtab-id-1
+                                                :name "Tab 1 edited"}
+                                               {:id   dashtab-id-2
+                                                :name "Tab 2"}
+                                               {:id   -1
+                                                :name "New tab 1"}
+                                               {:id   -2
+                                                :name "New tab 2"}]
+                               :cards         []})
+        (is (= [{:data {"dashboard_id"   dashboard-id
+                        "num_tabs"       2
+                        "total_num_tabs" 4
+                        "event"          "dashboard_tabs_created"}
+                 :user-id (str (mt/user->id :rasta))}
+                {:data {"dashboard_id"   dashboard-id
+                        "num_tabs"       1
+                        "total_num_tabs" 4
+                        "event"          "dashboard_tabs_deleted"},
+                 :user-id (str (mt/user->id :rasta))}]
+               (take-last 2 (snowplow-test/pop-event-data-and-user-id!))))))
+
+    (testing "send nothing if tabs are unchanged"
+      (snowplow-test/with-fake-snowplow-collector
+        (mt/user-http-request :rasta :put 200 (format "dashboard/%d/cards" dashboard-id)
+                              {:ordered_tabs  (current-tabs dashboard-id)
+                               :cards         []})
+        (is (= 0 (count (snowplow-test/pop-event-data-and-user-id!))))))))
 
 ;;; -------------------------------------- Create dashcards tests ---------------------------------------
 


### PR DESCRIPTION
Epic https://github.com/metabase/metabase/issues/29502

This adds 2 new snowplow tracking events that are speced in :
- [create](https://www.notion.so/metabase/0df8245abb8f46edbede12065d65e774?v=86c486a9c8904fb0ab086ad389f63f81&p=efd196c90d694efeb1b594f308f29fd5&pm=s)
- [delete](https://www.notion.so/metabase/0df8245abb8f46edbede12065d65e774?v=86c486a9c8904fb0ab086ad389f63f81&p=60efb251281441fe8c0820cf70ee6236&pm=s)

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30844)
<!-- Reviewable:end -->
