### PR TITLE
[MLv2] Add JS wrappers for temporal bucketing. Rework `temporal-bucket`.

### DIFF
--- a/src/metabase/lib/core.cljc
+++ b/src/metabase/lib/core.cljc
@@ -198,5 +198,4 @@
    describe-relative-datetime
    available-temporal-buckets
    temporal-bucket
-   temporal-bucket-option
    with-temporal-bucket])

--- a/src/metabase/lib/js.cljs
+++ b/src/metabase/lib/js.cljs
@@ -186,14 +186,32 @@
 
 (defn ^:export available-binning-strategies
   "Get a list of available binning strategies for `x` (a field reference, generally) in the context of `a-query` and
-  optionally `stage-number`. The returned list contains opaque objects which should be passed to [[display-info]].
-
-  Returns `nil` if none are available."
+  optionally `stage-number`. The returned list contains opaque objects which should be passed to [[display-info]]."
   ([a-query x]
    (-> (lib.core/available-binning-strategies a-query x)
        to-array))
   ([a-query stage-number x]
-   (-> (available-binning-strategies a-query stage-number x)
+   (-> (lib.core/available-binning-strategies a-query stage-number x)
+       to-array)))
+
+(defn ^:export temporal-bucket
+  "Get the current temporal bucketing options associated with something, if any."
+  [x]
+  (lib.core/temporal-bucket x))
+
+(defn ^:export with-temporal-bucket
+  "Add a temporal bucketing option to an MBQL clause (or something that can be converted to an MBQL clause)."
+  [x bucketing-option]
+  (lib.core/with-temporal-bucket x bucketing-option))
+
+(defn ^:export available-temporal-buckets
+  "Get a list of available temporal bucketing options for `x` (a field reference, generally) in the context of `a-query`
+  and optionally `stage-number`. The returned list contains opaque objects which should be passed to [[display-info]]."
+  ([a-query x]
+   (-> (lib.core/available-temporal-buckets a-query x)
+       to-array))
+  ([a-query stage-number x]
+   (-> (lib.core/available-temporal-buckets a-query stage-number x)
        to-array)))
 
 (defn ^:export remove-clause

--- a/src/metabase/lib/temporal_bucket.cljc
+++ b/src/metabase/lib/temporal_bucket.cljc
@@ -144,15 +144,10 @@
   [_x]
   nil)
 
-(mu/defn temporal-bucket :- [:maybe ::lib.schema.temporal-bucketing/unit]
-  "Get the current temporal bucketing unit associated with something, if any."
-  [x]
-  (temporal-bucket-method x))
-
-(mu/defn temporal-bucket-option :- [:maybe ::lib.schema.temporal-bucketing/option]
+(mu/defn temporal-bucket :- [:maybe ::lib.schema.temporal-bucketing/option]
   "Get the current temporal bucketing option associated with something, if any."
   [x]
-  (when-let [unit (temporal-bucket x)]
+  (when-let [unit (temporal-bucket-method x)]
     {:lib/type :type/temporal-bucketing-option
      :unit unit}))
 

--- a/test/metabase/lib/field_test.cljc
+++ b/test/metabase/lib/field_test.cljc
@@ -136,13 +136,10 @@
     (let [field (f query -1)]
       (is (=? [:field {:temporal-unit :day-of-month} (meta/id :checkins :date)]
               field))
-      (testing "(lib/temporal-bucket <column-metadata>)"
-        (is (= :day-of-month
-               (lib/temporal-bucket (lib.metadata.calculation/metadata query -1 field)))))
       (testing "(lib/temporal-bucket <field-ref>)"
         (is (= {:lib/type :type/temporal-bucketing-option
                 :unit :day-of-month}
-               (lib/temporal-bucket-option field))))
+               (lib/temporal-bucket field))))
       (is (= "Date: Day of month"
              (lib.metadata.calculation/display-name query -1 field))))))
 
@@ -183,8 +180,9 @@
       (testing "should calculate correct effective type"
         (is (= effective-type
                (lib.metadata.calculation/type-of (:query temporal-bucketing-mock-metadata) x'))))
-      (testing "lib/temporal-bucket should return the unit"
-        (is (= unit
+      (testing "lib/temporal-bucket should return the option"
+        (is (= {:lib/type :type/temporal-bucketing-option
+                :unit     unit}
                (lib/temporal-bucket x')))
         (testing "should generate a :field ref with correct :temporal-unit"
           (is (=? [:field
@@ -197,7 +195,6 @@
       (testing "remove the temporal unit"
         (let [x'' (lib/with-temporal-bucket x' nil)]
           (is (nil? (lib/temporal-bucket x'')))
-          (is (nil? (lib/temporal-bucket-option x'')))
           (is (= x
                  x''))))
       (testing "change the temporal unit, THEN remove it"
@@ -226,7 +223,8 @@
                  (lib/available-temporal-buckets (:query temporal-bucketing-mock-metadata) x)))
           (testing "Bucketing with any of the options should work"
             (doseq [expected-option expected-options]
-              (is (= (:unit expected-option)
+              (is (= {:lib/type :type/temporal-bucketing-option
+                     :unit      (:unit expected-option)}
                      (lib/temporal-bucket (lib/with-temporal-bucket x expected-option))))))
           (testing "Bucket it, should still return the same available units"
             (is (= expected-options


### PR DESCRIPTION
This drops the original `temporal-bucket` (which returned only the unit,
eg. `:day-of-month`) and renames `temporal-bucket-option` to
`temporal-bucket`. This returns a map with the `:unit` and `:lib/type`,
so it plays nice with `display-info`.

Also fixed some docs and a lurking infinite loop in
`lib.js/available-binning-strategies` (it accidentally called itself
rather than `lib.core/available-binning-strategies`).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30846)
<!-- Reviewable:end -->
