### PR TITLE
Fix typo in js.clj

### DIFF
--- a/modules/drivers/druid/src/metabase/driver/druid/js.clj
+++ b/modules/drivers/druid/src/metabase/driver/druid/js.clj
@@ -61,7 +61,7 @@
 
 
 (defn or
-  "Interpose the JavaScript or operator (`||`) betwen `args`, and wrap the entire expression in parens.
+  "Interpose the JavaScript or operator (`||`) between `args`, and wrap the entire expression in parens.
 
      (or :x :y) -> \"(x || y)\""
   ^String [& args]


### PR DESCRIPTION




### Description

Fixed typo.
```
betwen -> between
```

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30847)
<!-- Reviewable:end -->
