### PR TITLE
Updates Postgres format-interval to accept decimal numbers

### DIFF
--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -240,7 +240,7 @@
   ;; I tried to write this with Malli but couldn't figure out how to make it work. See
   ;; https://metaboat.slack.com/archives/CKZEMT1MJ/p1676076592468909
   [_fn [amount unit]]
-  {:pre [(int? amount)
+  {:pre [(number? amount)
          (#{:millisecond :second :minute :hour :day :week :month :year} unit)]}
   [(format "INTERVAL '%s %s'" (num amount) (name unit))])
 

--- a/test/metabase/driver/postgres_test.clj
+++ b/test/metabase/driver/postgres_test.clj
@@ -54,13 +54,14 @@
 (deftest ^:parallel interval-test
   (is (= ["INTERVAL '2 day'"]
          (sql/format-expr [::postgres/interval 2 :day])))
+  (is (= ["INTERVAL '-2.5 year'"]
+         (sql/format-expr [::postgres/interval -2.5 :year])))
   (are [amount unit msg] (thrown-with-msg?
                           AssertionError
                           msg
                           (sql/format-expr [::postgres/interval amount unit]))
-    2.0  :day  #"\QAssert failed: (int? amount)\E"
-    "2"  :day  #"\QAssert failed: (int? amount)\E"
-    :day 2     #"\QAssert failed: (int? amount)\E"
+    "2"  :day  #"\QAssert failed: (number? amount)\E"
+    :day 2     #"\QAssert failed: (number? amount)\E"
     2    "day" #"\QAssert failed: (#{:day :hour :week :second :month :year :millisecond :minute} unit)\E"
     2    2     #"\QAssert failed: (#{:day :hour :week :second :month :year :millisecond :minute} unit)\E"
     2    :can  #"\QAssert failed: (#{:day :hour :week :second :month :year :millisecond :minute} unit)\E"))


### PR DESCRIPTION
This updates the postgres `format-interval` function to allow decimal numbers as well as ints from the UI.

Resolves #29638

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30849)
<!-- Reviewable:end -->
