### PR TITLE
Unskip repro for #30743; it was fixed by #30755

### DIFF
--- a/e2e/test/scenarios/joins/reproductions/30743-sort-on-breakout-column-crashes.cy.spec.js
+++ b/e2e/test/scenarios/joins/reproductions/30743-sort-on-breakout-column-crashes.cy.spec.js
@@ -10,7 +10,6 @@ import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 const { ORDERS, ORDERS_ID, PRODUCTS, PRODUCTS_ID } = SAMPLE_DATABASE;
 
 const query = {
-  display: "table",
   dataset_query: {
     database: SAMPLE_DB_ID,
     type: "query",
@@ -34,7 +33,7 @@ const query = {
   },
 };
 
-describe.skip("issue 20743", () => {
+describe("issue 30743", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();
@@ -42,7 +41,7 @@ describe.skip("issue 20743", () => {
     visitQuestionAdhoc(query, { mode: "notebook" });
   });
 
-  it("should be possible to sort on the breakout column (metabase#20743)", () => {
+  it("should be possible to sort on the breakout column (metabase#30743)", () => {
     cy.findByLabelText("Sort").click();
     popover().contains("Category").click();
 


### PR DESCRIPTION
Just removing the unnecessary setting of `display: table` since the test
expects the default bars

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30850)
<!-- Reviewable:end -->
