### PR TITLE
[WIP] fix resize observer loop limit error

### DIFF
--- a/frontend/src/metabase/lib/resize-observer.ts
+++ b/frontend/src/metabase/lib/resize-observer.ts
@@ -7,9 +7,14 @@ function createResizeObserver() {
   const callbacksMap: Map<unknown, ResizeObserverCallback[]> = new Map();
 
   function handler(entries: ResizeObserverEntry[], observer: ResizeObserver) {
-    entries.forEach(entry => {
-      const entryCallbacks = callbacksMap.get(entry.target);
-      entryCallbacks?.forEach(callback => callback(entry, observer));
+    window.requestAnimationFrame(() => {
+      if (!Array.isArray(entries) || !entries.length) {
+        return;
+      }
+      entries.forEach(entry => {
+        const entryCallbacks = callbacksMap.get(entry.target);
+        entryCallbacks?.forEach(callback => callback(entry, observer));
+      });
     });
   }
 


### PR DESCRIPTION
we get a lot of errors, especially in e2e tests about the resize observer loop limit bing exceeded. this should clear those errors.

see: https://stackoverflow.com/questions/49384120/resizeobserver-loop-limit-exceeded

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30859)
<!-- Reviewable:end -->
