### PR TITLE
🤞  reduce revision history flakes 🤞 

### DIFF
--- a/e2e/test/scenarios/collections/revision-history.cy.spec.js
+++ b/e2e/test/scenarios/collections/revision-history.cy.spec.js
@@ -193,5 +193,6 @@ function openRevisionHistory() {
 
   rightSidebar().within(() => {
     cy.findByText("History");
+    cy.findByTestId("dashboard-history-list").should("be.visible");
   });
 }


### PR DESCRIPTION

🤞  maybe resolves https://github.com/metabase/metabase/issues/30848 🤞 

### Description

This test has been flaking massively lately. 

![Screen Shot 2023-05-18 at 2 26 36 PM](https://github.com/metabase/metabase/assets/30528226/ae2f6f18-ebe2-4d93-93fd-4cd5a7acea52)

There have been some recent changes to this sidebar to add additional props. These props seem to be causing re-renders.  Unfortunately, this component tree uses tons of props and tracking down which ones are causing the re-renders would be quite the task.

The test passes consistently locally, but on slower CI runners, I suspect the re-render is causing cypress to miss the elements its supposed to be finding. Waiting for the render of the history section could help 🤷

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30861)
<!-- Reviewable:end -->
