### PR TITLE
BE: Create and delete visualization_settings.fields for implicit actions as parameters change

### DIFF
--- a/src/metabase/models/action.clj
+++ b/src/metabase/models/action.clj
@@ -265,10 +265,10 @@
                                                  [(:id card) (:database_id card)]))
         model-id->implicit-parameters (when (seq implicit-action-models)
                                         (implicit-action-parameters implicit-action-models))]
-    (for [{:keys [parameters] :as action} actions]
+    (for [action actions]
       (if (= (:type action) :implicit)
         (let [model-id        (:model_id action)
-              saved-params    (m/index-by :id parameters)
+              saved-params    (m/index-by :id (:parameters action))
               action-kind     (:kind action)
               implicit-params (cond->> (get model-id->implicit-parameters model-id)
                                 :always

--- a/src/metabase/models/action.clj
+++ b/src/metabase/models/action.clj
@@ -292,17 +292,17 @@
             (-> (assoc :parameters implicit-params)
                 (update-in [:visualization_settings :fields]
                            (fn [fields]
-                             (let [param-ids (map :id implicit-params)]
-                               (let [fields (->> (or fields {})
-                                                 ;; remove entries that don't match params
-                                                 (m/filter-keys (set param-ids)))]
-                                 ;; add default entries for params that don't have an entry
-                                 (reduce (fn [acc param-id]
-                                           (if (get acc param-id)
-                                             acc
-                                             (assoc acc param-id {:id param-id, :hidden false})))
-                                         fields
-                                         param-ids))))))))
+                             (let [param-ids (map :id implicit-params)
+                                   fields    (->> (or fields {})
+                                                  ;; remove entries that don't match params (in case of deleted columns)
+                                                  (m/filter-keys (set param-ids)))]
+                               ;; add default entries for params that don't have an entry
+                               (reduce (fn [acc param-id]
+                                         (if (contains? acc param-id)
+                                           acc
+                                           (assoc acc param-id {:id param-id, :hidden false})))
+                                       fields
+                                       param-ids)))))))
         action))))
 
 (defn select-action

--- a/test/metabase/models/action_test.clj
+++ b/test/metabase/models/action_test.clj
@@ -28,19 +28,46 @@
   (mt/test-drivers (mt/normal-drivers-with-feature :actions/custom)
     (mt/with-actions-test-data-and-actions-enabled
       (let [query (mt/mbql-query categories)]
-        (mt/with-actions [_model {:dataset         true
-                                  :dataset_query   query
-                                  :result_metadata (assoc-in (get-in (qp/process-query query) [:data :results_metadata :columns])
-                                                             [1 :display_name] "Display Name")}
-                          {:keys [action-id] :as _context} {:type :implicit}]
-          (is (partial= {:id          action-id
-                         :name        "Update Example"
-                         :database_id (mt/id)
-                         :parameters  [(if (= driver/*driver* :h2)
-                                         {:type :type/BigInteger}
-                                         {:type :type/Integer})
-                                       {:type :type/Text, :id "name" :display-name "Display Name"}]}
-                        (action/select-action :id action-id)))))))
+        (testing "Implicit actions parameters and visualization_settings should be hydrated from the query"
+          (mt/with-actions [_model {:dataset         true
+                                    :dataset_query   query
+                                    :result_metadata (assoc-in (qp/query->expected-cols (mt/mbql-query categories))
+                                                               [1 :display_name] "Display Name")}
+                            {:keys [action-id] :as _context} {:type :implicit}]
+            (is (partial= {:id                     action-id
+                           :name                   "Update Example"
+                           :database_id            (mt/id)
+                           :parameters             [{:type         (if (= driver/*driver* :h2) :type/BigInteger :type/Integer)
+                                                     :id           "id"
+                                                     :display-name "ID"}
+                                                    {:type         :type/Text
+                                                     :id           "name"
+                                                     :display-name "Display Name"}]
+                           :visualization_settings {:fields {"id"   {:id     "id"
+                                                                     :hidden false}
+                                                             "name" {:id     "name"
+                                                                     :hidden false}}}}
+                          (action/select-action :id action-id)))))
+        (testing "for implicit actions visualization_settings.fields, "
+          (mt/with-actions [_model {:dataset         true
+                                    :dataset_query   query
+                                    :result_metadata (qp/query->expected-cols (mt/mbql-query categories))}
+                            {:keys [action-id] :as _context} {:type :implicit
+                                                              :visualization_settings {:fields {"doesnt_exist" {:id     "doesnt_exist"
+                                                                                                                :hidden false}
+                                                                                                "id"           {:id     "id"
+                                                                                                                :hidden true}}}}]
+            (let [field-settings (get-in (action/select-action :id action-id) [:visualization_settings :fields])]
+              (testing "an existing entry should not update if there's a matching parameter"
+                (is (= {:id     "id"
+                        :hidden true}
+                       (get field-settings "id"))))
+              (testing "an existing entry should be deleted if there's not a matching parameter"
+                (is (not (contains? field-settings "doesnt_exist"))))
+              (testing "a entry with defaults should be created if there is a new matching parameter"
+                (is (= {:id "name"
+                        :hidden false}
+                       (get field-settings "name"))))))))))
   (testing "Implicit actions do not map parameters to json fields (parents or nested)"
     (mt/test-drivers (mt/normal-drivers-with-feature :actions/custom :nested-field-columns)
       (mt/dataset json


### PR DESCRIPTION
Epic: https://github.com/metabase/metabase/issues/30016

This PR makes two changes to implicit actions when they are selected from the database with `metabase.model.action/select-actions`:
- (1) Creates default entries with `hidden=false` in `action.visualization_settings.fields` for parameters that do not already have an entry
- (2) Removes entries in `action.visualization_settings.fields` not in implicit action parameters

The consequence is all new parameters will have `hidden=false` in `action.visualization_settings.fields`, and that `action.visualization_settings.fields` will always have exactly one entry for each parameter. Previously, `action.visualization_settings.fields` has never been set for implicit parameters.

### In more detail:

Implicit actions selected with `action/select-actions` now include entries in `visualization_settings.fields` by default. Before, implicit actions could never have `visualization_settings.fields` set to anything, only query actions did. Here's an example of a newly created implicit action with two parameters "id" and "name":
```clojure
{...
 :parameters [{:id "id",
               :display-name "ID",
               :target [:variable [:template-tag "id"]],
               :type :type/BigInteger,
               :required true,
               :is-auto-increment true}
              {:id "name",
               :display-name "Name",
               :target [:variable [:template-tag "name"]],
               :type :type/Text,
               :required true,
               :is-auto-increment false}],
 :visualization_settings {:fields {"id"   {:id     "id"
                                           :hidden false},
                                   "name" {:id     "name"
                                           :hidden false}}}}
```

Note entries in `visualization_settings.fields` only have `:id` and `:hidden` keys. Compared to query actions, this is a very different shape. For example, here is a newly created query action with two parameters: "id" and "name":

```clojure
{...
 :parameters [{:id "c5a87ee5-c109-4789-a681-23a279cc99ee",
               :type :number/=,
               :target [:variable [:template-tag "id"]],
               :name "ID",
               :slug "id",
               :hasVariableTemplateTagTarget true}
              {:id "2b52dc9c-ad86-412d-a4a9-d7907ccf9c81",
               :type :string/=,
               :target [:variable [:template-tag "name"]],
               :name "Name",
               :slug "name",
               :hasVariableTemplateTagTarget true}]
 :visualization_settings {:name "",
                          :type "button",
                          :description "",
                          :fields
                          {:c5a87ee5-c109-4789-a681-23a279cc99ee
                           {:description "",
                            :placeholder "",
                            :name "",
                            :width "medium",
                            :title "",
                            :hidden false,
                            :id "c5a87ee5-c109-4789-a681-23a279cc99ee",
                            :order 999,
                            :inputType "number",
                            :required true,
                            :fieldType "number"},
                           :2b52dc9c-ad86-412d-a4a9-d7907ccf9c81
                           {:description "",
                            :placeholder "",
                            :name "",
                            :width "medium",
                            :title "",
                            :hidden false,
                            :id "2b52dc9c-ad86-412d-a4a9-d7907ccf9c81",
                            :order 999,
                            :inputType "string",
                            :required true,
                            :fieldType "string"}},
                          :confirmMessage "",
                          :successMessage ""}}
```

Query actions also have `hidden` key that defaults to `false` when a parameter is created on the frontend. But they have many more default keys that can be set. This PR deliberately avoids setting all these defaults for implicit actions.

The FE will need to be refactored to allow differently shaped entries for `action.visualization_settings.fields` depending on whether the action is of type implicit or custom. For custom actions, the existing interface is here https://github.com/metabase/metabase/blob/1490fd9cc8d3b7a9ea97aabb49eccb9547dc073a/frontend/src/metabase-types/api/actions.ts#L131

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30870)
<!-- Reviewable:end -->
