### PR TITLE
Fix mongo nested queries handling

### DIFF
--- a/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
@@ -1342,10 +1342,10 @@
   (if-let [source-query (-> inner-query :source-query)]
     (let [compiled (or (when-let [nq (:native source-query)]
                          (cond
-                           (string? nq)
+                           (string? (:query nq))
                            (-> source-query
                                (dissoc :native)
-                               (assoc :query (parse-query-string nq)))
+                               (assoc :query (parse-query-string (:query nq))))
 
                            :else
                            nq))

--- a/modules/drivers/mongo/test/metabase/driver/mongo_test.clj
+++ b/modules/drivers/mongo/test/metabase/driver/mongo_test.clj
@@ -7,9 +7,11 @@
             [metabase.db.metadata-queries :as metadata-queries]
             [metabase.driver :as driver]
             [metabase.driver.mongo :as mongo]
+            [metabase.driver.mongo.query-processor :as mongo.qp]
             [metabase.driver.mongo.util :as mongo.util]
             [metabase.driver.util :as driver.u]
             [metabase.mbql.util :as mbql.u]
+            [metabase.models.card :refer [Card]]
             [metabase.models.database :refer [Database]]
             [metabase.models.field :refer [Field]]
             [metabase.models.table :as table :refer [Table]]
@@ -119,6 +121,55 @@
                                 :type     :native
                                 :database (mt/id)})
              (m/dissoc-in [:data :results_metadata] [:data :insights]))))))
+
+(deftest nested-native-query-test
+  (mt/test-driver :mongo
+    (testing "Mbql query with nested native source query _returns correct results_"
+        (mt/with-temp Card [{:keys [id]} {:dataset_query {:type     :native
+                                                          :native   {:collection    "venues"
+                                                                     :query         native-query}
+                                                          :database (mt/id)}}]
+          (let [query (mt/mbql-query nil
+                        {:source-table (str "card__" id)
+                         :limit        1})]
+            (is (partial=
+                 {:status :completed
+                  :data   {:native_form {:collection "venues"
+                                         :query      (conj (mongo.qp/parse-query-string native-query)
+                                                           {"$limit" 1})}
+                           :rows        [[1]]}}
+                 (qp/process-query query))))))
+    (testing "Mbql query with nested native source query _aggregates_ correctly"
+      (let [query-str (str "[{\"$project\":\n"
+                           "   {\"_id\": \"$_id\",\n"
+                           "    \"name\": \"$name\",\n"
+                           "    \"category_id\": \"$category_id\",\n"
+                           "    \"latitude\": \"$latitude\",\n"
+                           "    \"longitude\": \"$longitude\",\n"
+                           "    \"price\": \"$price\"}\n"
+                           "}]")]
+        (mt/with-temp Card [{:keys [id]} {:dataset_query {:type     :native
+                                                          :native   {:collection    "venues"
+                                                                     :query         query-str}
+                                                          :database (mt/id)}}]
+          (let [query (mt/mbql-query venues
+                        {:source-table (str "card__" id)
+                         :aggregation [:count]
+                         :breakout [*category_id/Integer]
+                         :order-by [[:desc [:aggregation 0]]]
+                         :limit 5})]
+            (is (partial=
+                 {:status :completed
+                  :data   {:native_form
+                           {:collection "venues"
+                            :query (conj (mongo.qp/parse-query-string query-str)
+                                         {"$group" {"_id" {"category_id" "$category_id"}, "count" {"$sum" 1}}}
+                                         {"$sort" {"_id" 1}}
+                                         {"$project" {"_id" false, "category_id" "$_id.category_id", "count" true}}
+                                         {"$sort" {"count" -1, "category_id" 1}}
+                                         {"$limit" 5})}
+                           :rows [[7 10] [50 10] [40 9] [2 8] [5 7]]}}
+                 (qp/process-query query)))))))))
 
 ;; ## Tests for individual syncing functions
 

--- a/modules/drivers/mongo/test/metabase/driver/mongo_test.clj
+++ b/modules/drivers/mongo/test/metabase/driver/mongo_test.clj
@@ -124,7 +124,7 @@
 
 (deftest nested-native-query-test
   (mt/test-driver :mongo
-    (testing "Mbql query with nested native source query _returns correct results_"
+    (testing "Mbql query with nested native source query _returns correct results_ (#30112)"
         (mt/with-temp Card [{:keys [id]} {:dataset_query {:type     :native
                                                           :native   {:collection    "venues"
                                                                      :query         native-query}
@@ -139,7 +139,7 @@
                                                            {"$limit" 1})}
                            :rows        [[1]]}}
                  (qp/process-query query))))))
-    (testing "Mbql query with nested native source query _aggregates_ correctly"
+    (testing "Mbql query with nested native source query _aggregates_ correctly (#30112)"
       (let [query-str (str "[{\"$project\":\n"
                            "   {\"_id\": \"$_id\",\n"
                            "    \"name\": \"$name\",\n"

--- a/src/metabase/query_processor/middleware/fetch_source_query.clj
+++ b/src/metabase/query_processor/middleware/fetch_source_query.clj
@@ -115,11 +115,17 @@
        (let [collection (:collection native-query)]
          (cond-> native-query
                  ;; MongoDB native  queries consist of a collection and a pipelne (query)
-                 collection (update :native (fn [pipeline] {:collection collection
-                                                            :query      pipeline}))
+                 collection
+                 (update :native (fn [pipeline] {:collection collection
+                                                 :query      pipeline}))
+
                  ;; trim trailing comments from SQL, but not other types of native queries
-                 (string? (:native native-query)) (update :native (partial trim-sql-query card-id))
-                 (empty? template-tags) (dissoc :template-tags))))
+                 (and (str/blank? collection)
+                      (string? (:native native-query)))
+                 (update :native (partial trim-sql-query card-id))
+
+                 (empty? template-tags)
+                 (dissoc :template-tags))))
      (throw (ex-info (tru "Missing source query in Card {0}" card-id)
                      {:card card})))))
 

--- a/src/metabase/query_processor/middleware/fetch_source_query.clj
+++ b/src/metabase/query_processor/middleware/fetch_source_query.clj
@@ -120,7 +120,7 @@
                                                  :query      pipeline}))
 
                  ;; trim trailing comments from SQL, but not other types of native queries
-                 (and (str/blank? collection)
+                 (and (nil? collection)
                       (string? (:native native-query)))
                  (update :native (partial trim-sql-query card-id))
 

--- a/test/metabase/query_processor/middleware/fetch_source_query_test.clj
+++ b/test/metabase/query_processor/middleware/fetch_source_query_test.clj
@@ -352,4 +352,21 @@
                                   :collection  "checkins"
                                   :mbql?       true}
                 :database        (mt/id)}
+               (#'fetch-source-query/card-id->source-query-and-metadata card-id))))))
+  (testing "card-id->source-query-and-metadata-test should preserve mongodb native queries in string format"
+    (let [query-str (str "[{\"$project\":\n"
+                         "   {\"_id\":\"$_id\",\n"
+                         "    \"user_id\":\"$user_id\",\n"
+                         "    \"venue_id\": \"$venue_id\"}},\n"
+                         " {\"$limit\": 1048575}]")
+          query {:type     :native
+                 :native   {:query query-str
+                            :collection  "checkins"}
+                 :database (mt/id)}]
+      (mt/with-temp Card [{card-id :id} {:dataset_query query}]
+        (is (= {:source-metadata nil
+                :source-query    {:native      {:collection "checkins"
+                                                :query      query-str}
+                                  :collection  "checkins"}
+                :database        (mt/id)}
                (#'fetch-source-query/card-id->source-query-and-metadata card-id)))))))

--- a/test/metabase/query_processor/middleware/fetch_source_query_test.clj
+++ b/test/metabase/query_processor/middleware/fetch_source_query_test.clj
@@ -353,7 +353,7 @@
                                   :mbql?       true}
                 :database        (mt/id)}
                (#'fetch-source-query/card-id->source-query-and-metadata card-id))))))
-  (testing "card-id->source-query-and-metadata-test should preserve mongodb native queries in string format"
+  (testing "card-id->source-query-and-metadata-test should preserve mongodb native queries in string format (#30112)"
     (let [query-str (str "[{\"$project\":\n"
                          "   {\"_id\":\"$_id\",\n"
                          "    \"user_id\":\"$user_id\",\n"

--- a/test/metabase/query_processor_test/nested_queries_test.clj
+++ b/test/metabase/query_processor_test/nested_queries_test.clj
@@ -97,6 +97,18 @@
                     :aggregation  [:count]
                     :breakout     [$price]}))))))))
 
+(deftest mbql-source-query-aggregation-order-by-test
+  (mt/test-drivers (mt/normal-drivers-with-feature :nested-queries)
+    (testing "Source query with aggregation and order by produces expected results (#30874)."
+      (is (= [[7 10] [50 10] [40 9]]
+             (mt/rows
+               (mt/run-mbql-query venues
+                 {:source-query {:source-table $$venues
+                                 :aggregation  [:count]
+                                 :breakout     [$category_id]
+                                 :order-by     [[:desc [:aggregation 0]]]}
+                  :limit 3})))))))
+
 (deftest breakout-fk-column-test
   (mt/test-drivers (mt/normal-drivers-with-feature :nested-queries :foreign-keys)
     (testing "Test including a breakout of a nested query column that follows an FK"

--- a/test/metabase/query_processor_test/nested_queries_test.clj
+++ b/test/metabase/query_processor_test/nested_queries_test.clj
@@ -100,13 +100,15 @@
 (deftest mbql-source-query-aggregation-order-by-test
   (mt/test-drivers (mt/normal-drivers-with-feature :nested-queries)
     (testing "Source query with aggregation and order by produces expected results (#30874)."
-      (is (= [[7 10] [50 10] [40 9]]
-             (mt/rows
+      (is (= [[50 10] [7 10] [40 9]]
+             (mt/formatted-rows [int int]
                (mt/run-mbql-query venues
                  {:source-query {:source-table $$venues
                                  :aggregation  [:count]
                                  :breakout     [$category_id]
                                  :order-by     [[:desc [:aggregation 0]]]}
+                  :order-by [[:desc *count/Integer]
+                             [:desc $category_id]]
                   :limit 3})))))))
 
 (deftest breakout-fk-column-test


### PR DESCRIPTION
Closes #30112  #30874

### Description

Prior to this PR native source queries did not work. Problem was 1. sql trimming was executed on those queries with failure and 2. mismatch in parsing query from string.

Also nested mbql queries containing aggregation and sorting by that aggregation were failing. This was happening because of missing nesting index in call of `mbql.u/aggregation-at-index`.

As of now, both problems are solved.

### How to verify

Either run updated tests, or follow reproduction instructions from issues in question.

### Checklist

- [X] Tests have been added/updated to cover changes in this PR

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30877)
<!-- Reviewable:end -->
