### PR TITLE
[MLv2] Make long display name available.

### DIFF
--- a/frontend/src/metabase-lib/order_by.unit.spec.ts
+++ b/frontend/src/metabase-lib/order_by.unit.spec.ts
@@ -20,6 +20,7 @@ describe("order by", () => {
         expect.objectContaining({
           name: "ID",
           displayName: "ID",
+          longDisplayName: "ID",
           effectiveType: "type/BigInteger",
           semanticType: "type/PK",
           isCalculated: false,
@@ -29,6 +30,7 @@ describe("order by", () => {
           table: {
             name: "ORDERS",
             displayName: "Orders",
+            longDisplayName: "Orders",
             isSourceTable: true,
           },
         }),
@@ -42,6 +44,7 @@ describe("order by", () => {
         expect.objectContaining({
           name: "TITLE",
           displayName: "Title",
+          longDisplayName: "Products → Title",
           effectiveType: "type/Text",
           semanticType: "type/Title",
           isCalculated: false,
@@ -51,6 +54,7 @@ describe("order by", () => {
           table: {
             name: "PRODUCTS",
             displayName: "Products",
+            longDisplayName: "Products",
             isSourceTable: false,
           },
         }),

--- a/src/metabase/lib/js.cljs
+++ b/src/metabase/lib/js.cljs
@@ -113,6 +113,16 @@
        (update :table update-keys u/->camelCaseEn)
        (clj->js :keyword-fn u/qualified-name))))
 
+(defn ^:export display-name
+  "Given an opaque Cljs object, return a plain JS object with a name useful for display.
+  See `:metabase.lib.metadata.calculation/display-name` ."
+  ([a-query x]
+   (display-name a-query -1 x))
+  ([a-query stage-number x]
+   (display-name a-query stage-number x "default"))
+  ([a-query stage-number x style]
+   (lib.core/display-name a-query stage-number x (keyword style))))
+
 (defn ^:export order-by-clause
   "Create an order-by clause independently of a query, e.g. for `replace` or whatever."
   ([a-query stage-number x]

--- a/src/metabase/lib/js.cljs
+++ b/src/metabase/lib/js.cljs
@@ -113,16 +113,6 @@
        (update :table update-keys u/->camelCaseEn)
        (clj->js :keyword-fn u/qualified-name))))
 
-(defn ^:export display-name
-  "Given an opaque Cljs object, return a plain JS object with a name useful for display.
-  See `:metabase.lib.metadata.calculation/display-name` ."
-  ([a-query x]
-   (display-name a-query -1 x))
-  ([a-query stage-number x]
-   (display-name a-query stage-number x "default"))
-  ([a-query stage-number x style]
-   (lib.core/display-name a-query stage-number x (keyword style))))
-
 (defn ^:export order-by-clause
   "Create an order-by clause independently of a query, e.g. for `replace` or whatever."
   ([a-query stage-number x]

--- a/src/metabase/lib/metadata/calculation.cljc
+++ b/src/metabase/lib/metadata/calculation.cljc
@@ -255,6 +255,7 @@
 (mr/register! ::display-info
   [:map
    [:display-name :string]
+   [:long-display-name {:optional true} :string]
    ;; for things that have a Table, e.g. a Field
    [:table {:optional true} [:maybe [:ref ::display-info]]]
    ;; these are derived from the `:lib/source`/`:metabase.lib.metadata/column-source`, but instead of using that value
@@ -305,6 +306,8 @@
      ;; TODO -- not 100% convinced the FE should actually have access to `:name`, can't it use `:display-name`
      ;; everywhere? Determine whether or not this is the case.
      (select-keys x-metadata [:name :display-name :semantic-type])
+     (when-let [long-display-name (display-name query stage-number x :long)]
+       {:long-display-name long-display-name})
      ;; don't return `:base-type`, FE should just use `:effective-type` everywhere and not even need to know
      ;; `:base-type` exists.
      (when-let [effective-type ((some-fn :effective-type :base-type) x-metadata)]

--- a/test/metabase/lib/metadata/calculation_test.cljc
+++ b/test/metabase/lib/metadata/calculation_test.cljc
@@ -14,3 +14,11 @@
                                    "TOTAL"]))]
       (is (= "Venues, Sorted by Total ascending"
              (lib.metadata.calculation/suggested-name query))))))
+
+(deftest ^:parallel long-display-name-test
+  (let [query (lib/query-for-table-name meta/metadata-provider "VENUES")
+        results (->> query
+                     lib.metadata.calculation/visible-columns
+                     (map (comp :long-display-name #(lib/display-info query 0 %))))]
+    (is (= ["ID" "Name" "Category ID" "Latitude" "Longitude" "Price" "Categories → ID" "Categories → Name"]
+           results))))


### PR DESCRIPTION
Fixes #30857 
Export `display-name` function and adds `long-display-name` to `display-info` results.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30882)
<!-- Reviewable:end -->
