### PR TITLE
Ensure smooth audit-db syncs for h2, postgres, and mysql

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/audit_db.clj
+++ b/enterprise/backend/src/metabase_enterprise/audit_db.clj
@@ -56,6 +56,6 @@
 
 (defenterprise ensure-audit-db-installed!
   "EE implementation of `ensure-db-installed!`."
-  :feature :any
+  :feature :none
   []
   (ensure-db-installed!))

--- a/enterprise/backend/src/metabase_enterprise/audit_db.clj
+++ b/enterprise/backend/src/metabase_enterprise/audit_db.clj
@@ -20,15 +20,18 @@
   ([engine id]
    (if (t2/select-one Database :id id)
      (install-database! engine (inc id))
-     (t2/insert! Database {:is_audit         true
-                           :id               default-audit-db-id
-                           :name             "Audit Database"
-                           :description      "Internal Audit DB used to power metabase analytics."
-                           :engine           engine
-                           :is_full_sync     true
-                           :is_on_demand     false
-                           :creator_id       nil
-                           :auto_run_queries true}))))
+     (do
+       ;; guard against someone manually deletihng the audit-db entry, but not removing the audit-db permissions.
+       (t2/delete! :permissions {:where [:like :object (str "%/db/" id "/%")]})
+       (t2/insert! Database {:is_audit         true
+                             :id               default-audit-db-id
+                             :name             "Audit Database"
+                             :description      "Internal Audit DB used to power metabase analytics."
+                             :engine           engine
+                             :is_full_sync     true
+                             :is_on_demand     false
+                             :creator_id       nil
+                             :auto_run_queries true})))))
 
 (defn ensure-db-installed!
   "Called on app startup to ensure the existance of the audit db in enterprise apps.

--- a/enterprise/backend/src/metabase_enterprise/audit_db.clj
+++ b/enterprise/backend/src/metabase_enterprise/audit_db.clj
@@ -6,7 +6,7 @@
             [metabase.util.log :as log]
             [toucan2.core :as t2]))
 
-(def ^:private default-admin-db-id 13371337)
+(def ^:private default-audit-db-id 13371337)
 
 (defn- install-database!
   "Creates the audit db, a clone of the app db used for auditing purposes.
@@ -16,12 +16,12 @@
 
   - In the unlikely case that a user has many many databases in Metabase, and ensure there can Never be a collision, we
   do a quick check here and pick a new ID if it would have collided. Similar to finding an open port number."
-  ([engine] (install-database! engine default-admin-db-id))
+  ([engine] (install-database! engine default-audit-db-id))
   ([engine id]
    (if (t2/select-one Database :id id)
      (install-database! engine (inc id))
      (t2/insert! Database {:is_audit         true
-                           :id               default-admin-db-id
+                           :id               default-audit-db-id
                            :name             "Audit Database"
                            :description      "Internal Audit DB used to power metabase analytics."
                            :engine           engine

--- a/enterprise/backend/test/metabase_enterprise/audit_db_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/audit_db_test.clj
@@ -2,7 +2,6 @@
   (:require [clojure.test :refer [deftest is]]
             [metabase-enterprise.audit-db :as audit-db]
             [metabase.models.database :refer [Database]]
-            [metabase.util.log :as log]
             [toucan2.core :as t2]))
 
 (deftest audit-db-is-installed-then-left-alone
@@ -19,5 +18,4 @@
       (finally
         (t2/delete! Database :is_audit true)
         (when original-audit-db
-          (log/fatal (str "Original Audit DB: " (pr-str original-audit-db)))
-          (#'t2/insert! Database original-audit-db))))))
+          (audit-db/ensure-audit-db-installed!))))))

--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -966,10 +966,10 @@
 ;; Currently these match the titles of the admin UI buttons that call these endpoints
 
 ;; Should somehow trigger sync-database/sync-database!
-#_{:clj-kondo/ignore [:deprecated-var]}
-(api/defendpoint-schema POST "/:id/sync_schema"
+(api/defendpoint POST "/:id/sync_schema"
   "Trigger a manual update of the schema metadata for this `Database`."
   [id]
+  {id ms/PositiveInt}
   ;; just wrap this in a future so it happens async
   (let [db (api/write-check (t2/select-one Database :id id))]
     (future
@@ -998,10 +998,10 @@
   true)
 
 ;; Should somehow trigger cached-values/cache-field-values-for-database!
-#_{:clj-kondo/ignore [:deprecated-var]}
-(api/defendpoint-schema POST "/:id/rescan_values"
+(api/defendpoint POST "/:id/rescan_values"
   "Trigger a manual scan of the field values for this `Database`."
   [id]
+  {id ms/PositiveInt}
   ;; just wrap this is a future so it happens async
   (let [db (api/write-check (t2/select-one Database :id id))]
     ;; Override *current-user-permissions-set* so that permission checks pass during sync. If a user has DB detail perms

--- a/src/metabase/core.clj
+++ b/src/metabase/core.clj
@@ -93,8 +93,7 @@
 (defenterprise ensure-audit-db-installed!
   "OSS implementation of `audit-db/ensure-db-installed!`, which is an enterprise feature, so does nothing in the OSS
   version."
-  metabase-enterprise.audit-db
-  [])
+  metabase-enterprise.audit-db [] ::noop)
 
 (defn- init!*
   "General application initialization function which should be run once at application startup."

--- a/src/metabase/driver/h2.clj
+++ b/src/metabase/driver/h2.clj
@@ -467,7 +467,8 @@
 (defmethod sql-jdbc.conn/connection-details->spec :h2
   [_ details]
   {:pre [(map? details)]}
-  (mdb.spec/spec :h2 (update details :db connection-string-set-safe-options)))
+  (mdb.spec/spec :h2 (cond-> details
+                       (string? (:db details)) (update :db connection-string-set-safe-options))))
 
 (defmethod sql-jdbc.sync/active-tables :h2
   [& args]

--- a/src/metabase/sync/util.clj
+++ b/src/metabase/sync/util.clj
@@ -304,7 +304,7 @@
 
 (defmethod name-for-logging Database
   [{database-name :name, id :id, engine :engine,}]
-  (trs "{0} Database {1} ''{2}''" (name engine) (or id "") database-name))
+  (trs "{0} Database {1} ''{2}''" (name engine) (str (or id "")) database-name))
 
 (defmethod name-for-logging Table [{schema :schema, id :id, table-name :name}]
   (trs "Table {0} ''{1}''" (or id "") (str (when (seq schema) (str schema ".")) table-name)))

--- a/test/metabase/driver/h2_test.clj
+++ b/test/metabase/driver/h2_test.clj
@@ -292,9 +292,8 @@
 (deftest syncable-audit-db-test
   (mt/test-driver :h2
     (when config/ee-available?
-      (testing "spec obtained from application db has no connection string, and that works OK."
-        (is (try (log/fatal (str "ZZZZZZ\n" (dissoc
-                                             (sql-jdbc.conn/connection-details->spec :h2 (metabase.driver.sql-jdbc.connection/db->pooled-connection-spec mdb.connection/*application-db*))
-                                             :datasource)))
-                 true
-                 (catch Exception _ false)))))))
+      (testing "spec obtained from audit db has no connection string, and that works OK."
+        (is (= {:something "good"}
+               (->> (t2/select-one-fn :id 'Database :is_audit true)
+                    metabase.driver.sql-jdbc.connection/db->pooled-connection-spec
+                    (sql-jdbc.conn/connection-details->spec :h2))))))))

--- a/test/metabase/driver/h2_test.clj
+++ b/test/metabase/driver/h2_test.clj
@@ -4,7 +4,6 @@
    [clojure.string :as str]
    [clojure.test :refer :all]
    [metabase.config :as config]
-   [metabase.db.connection :as mdb.connection]
    [metabase.db.spec :as mdb.spec]
    [metabase.driver :as driver]
    [metabase.driver.h2 :as h2]
@@ -14,7 +13,7 @@
    [metabase.query-processor :as qp]
    [metabase.test :as mt]
    [metabase.util :as u]
-   [metabase.util.log :as log]))
+   [toucan2.core :as t2]))
 
 ;; TODO: remove hx from this test
 #_{:clj-kondo/ignore [:discouraged-namespace]}

--- a/test/metabase/driver/h2_test.clj
+++ b/test/metabase/driver/h2_test.clj
@@ -14,8 +14,11 @@
    [metabase.query-processor :as qp]
    [metabase.test :as mt]
    [metabase.util :as u]
-   [metabase.util.honeysql-extensions :as hx]
    [metabase.util.log :as log]))
+
+;; TODO: remove hx from this test
+#_{:clj-kondo/ignore [:discouraged-namespace]}
+(require '[metabase.util.honeysql-extensions :as hx])
 
 (set! *warn-on-reflection* true)
 

--- a/test/metabase/driver/h2_test.clj
+++ b/test/metabase/driver/h2_test.clj
@@ -286,8 +286,10 @@
 
 (deftest syncable-audit-db-test
   (mt/test-driver :h2
-    (testing "spec obtained from application db has no connection string, and that works OK."
-      (is (= {:classname "org.h2.Driver" :subprotocol "h2" :subname "h2.db"}
-             (dissoc
-              (sql-jdbc.conn/connection-details->spec :h2 (metabase.driver.sql-jdbc.connection/db->pooled-connection-spec mdb.connection/*application-db*))
-              :datasource))))))
+    (when config/ee-available?
+      (testing "spec obtained from application db has no connection string, and that works OK."
+        (is (try (dissoc
+                  (sql-jdbc.conn/connection-details->spec :h2 (metabase.driver.sql-jdbc.connection/db->pooled-connection-spec mdb.connection/*application-db*))
+                  :datasource)
+                 true
+                 (catch Exception _ false)))))))

--- a/test/metabase/driver/h2_test.clj
+++ b/test/metabase/driver/h2_test.clj
@@ -3,6 +3,7 @@
    [clojure.java.jdbc :as jdbc]
    [clojure.string :as str]
    [clojure.test :refer :all]
+   [metabase.config :as config]
    [metabase.db.connection :as mdb.connection]
    [metabase.db.spec :as mdb.spec]
    [metabase.driver :as driver]
@@ -13,7 +14,8 @@
    [metabase.query-processor :as qp]
    [metabase.test :as mt]
    [metabase.util :as u]
-   [metabase.util.honeysql-extensions :as hx]))
+   [metabase.util.honeysql-extensions :as hx]
+   [metabase.util.log :as log]))
 
 (set! *warn-on-reflection* true)
 
@@ -288,8 +290,8 @@
   (mt/test-driver :h2
     (when config/ee-available?
       (testing "spec obtained from application db has no connection string, and that works OK."
-        (is (try (dissoc
-                  (sql-jdbc.conn/connection-details->spec :h2 (metabase.driver.sql-jdbc.connection/db->pooled-connection-spec mdb.connection/*application-db*))
-                  :datasource)
+        (is (try (log/fatal (str "ZZZZZZ\n" (dissoc
+                                             (sql-jdbc.conn/connection-details->spec :h2 (metabase.driver.sql-jdbc.connection/db->pooled-connection-spec mdb.connection/*application-db*))
+                                             :datasource)))
                  true
                  (catch Exception _ false)))))))

--- a/test/metabase/driver/h2_test.clj
+++ b/test/metabase/driver/h2_test.clj
@@ -288,12 +288,10 @@
         (is (= #{"PUBLIC"}
                (driver/syncable-schemas driver/*driver* (mt/id))))))))
 
-
-
 (defenterprise ^:private ensure-audit-db-installed!
   "A test implementation of `audit-db/ensure-db-installed!`, used to setup the audit-db for testing."
   metabase-enterprise.audit-db
-  [])
+  [] ::noop)
 
 (def ^:private audit-db-expected-id 13371337)
 
@@ -301,7 +299,7 @@
   (mt/test-driver :h2
     (when config/ee-available?
       (let [original-audit-db (t2/select-one 'Database :is_audit true)]
-        (ensure-audit-db-installed!)
+        (is (not= ::noop (ensure-audit-db-installed!)) "Make sure we call the right ensure-audit-db-installed! impl")
         (try
           (testing "spec obtained from audit db has no connection string, and that works OK."
             (let [audit-db-id (t2/select-one-fn :id 'Database :is_audit true)]

--- a/test/metabase/driver/h2_test.clj
+++ b/test/metabase/driver/h2_test.clj
@@ -3,15 +3,16 @@
    [clojure.java.jdbc :as jdbc]
    [clojure.string :as str]
    [clojure.test :refer :all]
+   [metabase.db.connection :as mdb.connection]
    [metabase.db.spec :as mdb.spec]
    [metabase.driver :as driver]
    [metabase.driver.h2 :as h2]
+   [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
    [metabase.driver.sql.query-processor :as sql.qp]
    [metabase.models :refer [Database]]
    [metabase.query-processor :as qp]
    [metabase.test :as mt]
    [metabase.util :as u]
-   #_{:clj-kondo/ignore [:discouraged-namespace]}
    [metabase.util.honeysql-extensions :as hx]))
 
 (set! *warn-on-reflection* true)
@@ -281,3 +282,12 @@
       (mt/with-empty-db
         (is (= #{"PUBLIC"}
                (driver/syncable-schemas driver/*driver* (mt/id))))))))
+
+
+(deftest syncable-audit-db-test
+  (mt/test-driver :h2
+    (testing "spec obtained from application db has no connection string, and that works OK."
+      (is (= {:classname "org.h2.Driver" :subprotocol "h2" :subname "h2.db"}
+             (dissoc
+              (sql-jdbc.conn/connection-details->spec :h2 (metabase.driver.sql-jdbc.connection/db->pooled-connection-spec mdb.connection/*application-db*))
+              :datasource))))))

--- a/test/metabase/driver/h2_test.clj
+++ b/test/metabase/driver/h2_test.clj
@@ -4,15 +4,14 @@
    [clojure.string :as str]
    [clojure.test :refer :all]
    [metabase.config :as config]
+   [metabase.core :as mbc]
    [metabase.db.spec :as mdb.spec]
    [metabase.driver :as driver]
    [metabase.driver.h2 :as h2]
    [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
    [metabase.driver.sql.query-processor :as sql.qp]
    [metabase.models :refer [Database]]
-   [metabase.public-settings.premium-features :refer [defenterprise]]
    [metabase.query-processor :as qp]
-   [metabase.core :as mbc]
    [metabase.test :as mt]
    [metabase.util :as u]
    [toucan2.core :as t2]))
@@ -25,6 +24,7 @@
 
 (use-fixtures :each (fn [thunk]
                       ;; Make sure we're in Honey SQL 2 mode for all the little SQL snippets we're compiling in these tests.
+                      #_{:clj-kondo/ignore [:unresolved-var]}
                       (binding [hx/*honey-sql-version* 2]
                         (thunk))))
 
@@ -289,12 +289,11 @@
         (is (= #{"PUBLIC"}
                (driver/syncable-schemas driver/*driver* (mt/id))))))))
 
-(def ^:private audit-db-expected-id 13371337)
-
 (deftest syncable-audit-db-test
   (mt/test-driver :h2
     (when config/ee-available?
-      (let [original-audit-db (t2/select-one 'Database :is_audit true)]
+      (let [audit-db-expected-id 13371337
+            original-audit-db    (t2/select-one 'Database :is_audit true)]
         (is (not= ::mbc/noop (mbc/ensure-audit-db-installed!))
             "Make sure we call the right ensure-audit-db-installed! impl")
         (try


### PR DESCRIPTION
resolves #30887

For audit-db, we pass in the app-db's `javax.sql.DataSource`, and when it's an h2 app-db, it won't have a connection string. If the db details are lacking a connetion string we shouldn't try to update it. This was causing a failure on h2 audit-db syncs.


---

- fixes typo: default-admin-db-id -> default-audit-db-id

- print db id without locale settings in `name-for-logging`
  - we probably never had a database with and id > 1000, but it would print like `1,000` in logs, when we'd prefer `1000`.

- remove 2 more `defendpoint-schema` forms

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30885)
<!-- Reviewable:end -->
