### PR TITLE
Add string filter section title

### DIFF
--- a/frontend/src/metabase/modes/components/drill/QuickFilterDrill/QuickFilterDrill.tsx
+++ b/frontend/src/metabase/modes/components/drill/QuickFilterDrill/QuickFilterDrill.tsx
@@ -110,31 +110,31 @@ const QuickFilterDrill = ({
   return operators.map(operator => {
     const { name, filter, valueType } = operator;
 
-    if (OPERATORS_WITH_POPOVER.includes(name)) {
-      return {
-        name,
-        title: name,
-        section: "filter",
-        buttonType: "token-filter",
-        popover: getColumnFilterDrillPopover({
-          query,
-          initialFilter: filter,
-          addFilter: filter =>
-            quickFilterDrillQuestion({ clicked, filter }).card(),
-        }),
-        ...getOperatorOverrides(operator, value),
-      };
-    }
-
     return {
       name,
       title: name,
       section: "filter",
       buttonType: "token-filter",
-      question: () => quickFilterDrillQuestion({ clicked, filter }),
+
+      // show filter popover for special filters, question action for default ones
+      ...(OPERATORS_WITH_POPOVER.includes(name)
+        ? {
+            popover: getColumnFilterDrillPopover({
+              query,
+              initialFilter: filter,
+              addFilter: filter =>
+                quickFilterDrillQuestion({ clicked, filter }).card(),
+            }),
+          }
+        : {
+            question: () => quickFilterDrillQuestion({ clicked, filter }),
+          }),
+
       extra: () => ({
         valueType,
+        columnName: clicked.column?.display_name,
       }),
+
       ...getOperatorOverrides(operator, value),
     };
   });

--- a/frontend/src/metabase/visualizations/components/ChartClickActions/ChartClickActionsView.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/components/ChartClickActions/ChartClickActionsView.unit.spec.tsx
@@ -41,7 +41,7 @@ describe("ChartClickActionsView", () => {
       setup("REVIEWER", "christ");
 
       const sections = screen.getAllByTestId("drill-through-section");
-      expect(sections[2]).toHaveTextContent("Filter by this text");
+      expect(sections[2]).toHaveTextContent("Filter by Reviewer");
     });
 
     it("should render text filters for text column", () => {

--- a/frontend/src/metabase/visualizations/components/ChartClickActions/utils.ts
+++ b/frontend/src/metabase/visualizations/components/ChartClickActions/utils.ts
@@ -91,18 +91,30 @@ export const getGroupedAndSortedActions = (
 export const getGALabelForAction = (action: RegularClickAction) =>
   action ? `${action.section || ""}:${action.name || ""}` : null;
 
-const getFilterValueType = (actions: RegularClickAction[]): string =>
-  actions[0]?.extra?.().valueType as string;
+const getFilterValueType = (
+  actions: RegularClickAction[],
+): string | undefined => {
+  const value = actions[0]?.extra?.().valueType;
+  return typeof value === "string" ? value : undefined;
+};
+
+const getFilterColumnName = (
+  actions: RegularClickAction[],
+): string | undefined => {
+  const value = actions[0]?.extra?.().columnName;
+  return typeof value === "string" ? value : undefined;
+};
 
 export const getFilterSectionTitle = (actions: RegularClickAction[]) => {
   const valueType = getFilterValueType(actions);
+  const columnName = getFilterColumnName(actions);
 
   if (valueType === "date") {
     return t`Filter by this date`;
   }
 
   if (valueType === "text") {
-    return t`Filter by this text`;
+    return t`Filter by ${columnName || t`this text`}`;
   }
 
   return t`Filter by this value`;
@@ -142,7 +154,7 @@ export const getSectionContentDirection = (
     case "filter": {
       const valueType = getFilterValueType(actions);
 
-      if (["boolean", "numeric", "null"].includes(valueType)) {
+      if (valueType && ["boolean", "numeric", "null"].includes(valueType)) {
         return "row";
       }
       break;


### PR DESCRIPTION
Relates to https://github.com/metabase/metabase/issues/26836

### Description

Body/Comment/Description/long-text fields’ popover menus:
* Should now have a heading for the filter actions of the form Filter by {field display name}

### Demo



https://github.com/metabase/metabase/assets/7983744/22fa531c-98ea-43e8-b8a7-dd6d1684d854




### Checklist

- [x] Tests have been added/updated to cover changes in this PR

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30888)
<!-- Reviewable:end -->
