### PR TITLE
BE: Apply defaults when action params are not present in the execution request

### DIFF
--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -3079,6 +3079,13 @@
                 (is (= [1 "Shop"]
                        (mt/first-row
                          (mt/run-mbql-query categories {:filter [:= $id 1]})))))
+              (testing "Missing required parameter according to the template tag"
+                (is (partial= {:message "Error executing Action: Error building query parameter map: Error determining value for parameter \"id\": You'll need to pick a value for 'ID' before this query can run."}
+                              (mt/user-http-request :crowberto :post 500 execute-path
+                                                    {:parameters {"name" "Bird"}})))
+                (is (= [1 "Shop"]
+                       (mt/first-row
+                        (mt/run-mbql-query categories {:filter [:= $id 1]})))))
               (testing "Extra target parameter"
                 (is (partial= {:rows-affected 1}
                               (mt/user-http-request :crowberto :post 200 execute-path


### PR DESCRIPTION
Epic: https://github.com/metabase/metabase/issues/30016

Public actions will not have hidden parameters loaded on the FE anymore, and therefore can’t submit these parameters with a request to the POST "api/action/:uuid/execute" or POST "api/public/dashboard/:uuid/dashcard/:dashcard-id/execute" endpoints. This is a problem for hidden parameters with default values, because currently default values are applied as initial values in the FE form. This PR updates the BE to apply default values to missing parameters in the request parameters. Importantly, it does apply default values when the param is present in the request parameters but it's value is `null`. Before both cases (param null or missing) were treated identically by the BE.

The solution is best demonstrated with an example: 
```
imagine there is a basic create action with 
visualization_settings.fields = { id: "123", defaultValue: 1, ... }

before the change:
If request parameters = { "123": null }: "123" must be an optional parameter. In the SQL statement executed "123" would not be set. For a basic create action, "123" would either take on the database default, or null if there was no database default.
If request parameters = { }: same as above

after the change:
If request parameters = { "123": null }: same as before.
If request parameters = { }: "123" takes on the defaultValue in visualization_settings.fields
```

### Required FE changes:

The FE now needs to be deliberate about when to supply params with `null` values vs removing them from the map entirely. Using the example above, before the BE treated both `parameters = { "123": null }` and `parameters = { }` the identically. Now the difference matters. An empty optional field must consistently result in that param being included in the request parameters, but with a `null` value.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30900)
<!-- Reviewable:end -->
