### PR TITLE
Adds support for options in template tags

### DIFF
--- a/shared/src/metabase/mbql/schema.cljc
+++ b/shared/src/metabase/mbql/schema.cljc
@@ -1145,7 +1145,9 @@
     :dimension   field
     ;; which type of widget the frontend should show for this Field Filter; this also affects which parameter types
     ;; are allowed to be specified for it.
-    :widget-type (s/recursive #'WidgetType)}))
+    :widget-type (s/recursive #'WidgetType)
+    ;; optional map to be appended to filter clause
+    (s/optional-key :options) {s/Keyword s/Any}}))
 
 (def raw-value-template-tag-types
   "Set of valid values of `:type` for raw value template tags."

--- a/src/metabase/driver/common/parameters/values.clj
+++ b/src/metabase/driver/common/parameters/values.clj
@@ -102,9 +102,10 @@
   multiple values."
   [tag :- mbql.s/TemplateTag params :- (s/maybe [mbql.s/Parameter])]
   (let [matching-params  (tag-params tag params)
+        tag-opts         (:options tag)
         normalize-params (fn [params]
                            ;; remove `:target` which is no longer needed after this point.
-                           (let [params (map #(dissoc % :target) params)]
+                           (let [params (map #(merge {:options tag-opts} (dissoc % :target)) params)]
                              (if (= (count params) 1)
                                (first params)
                                params)))]
@@ -116,7 +117,7 @@
      ;; otherwise, attempt to fall back to the default value specified as part of the template tag.
      (when-let [tag-default (:default tag)]
        {:type    (:widget-type tag :dimension) ; widget-type is the actual type of the default value if set
-        :options (:options tag)
+        :options tag-opts
         :value   tag-default})
      ;; if that doesn't exist, see if the matching parameters specified default values This can be the case if the
      ;; parameters came from a Dashboard -- Dashboard parameter mappings can specify their own defaults -- but we want

--- a/src/metabase/driver/common/parameters/values.clj
+++ b/src/metabase/driver/common/parameters/values.clj
@@ -115,8 +115,9 @@
        (normalize-params matching-params))
      ;; otherwise, attempt to fall back to the default value specified as part of the template tag.
      (when-let [tag-default (:default tag)]
-       {:type  (:widget-type tag :dimension) ; widget-type is the actual type of the default value if set
-        :value tag-default})
+       {:type    (:widget-type tag :dimension) ; widget-type is the actual type of the default value if set
+        :options (:options tag)
+        :value   tag-default})
      ;; if that doesn't exist, see if the matching parameters specified default values This can be the case if the
      ;; parameters came from a Dashboard -- Dashboard parameter mappings can specify their own defaults -- but we want
      ;; the defaults specified in the template tag to take precedence if both are specified

--- a/src/metabase/driver/common/parameters/values.clj
+++ b/src/metabase/driver/common/parameters/values.clj
@@ -104,9 +104,9 @@
   (let [matching-params  (tag-params tag params)
         tag-opts         (:options tag)
         normalize-params (fn [params]
-                           ;; remove `:target` which is no longer needed after this point.
+                           ;; remove `:target` which is no longer needed after this point, and add any tag options
                            (let [params (map #(cond-> (dissoc % :target)
-                                                tag-opts (assoc :options tag-opts))
+                                                (seq tag-opts) (assoc :options tag-opts))
                                              params)]
                              (if (= (count params) 1)
                                (first params)
@@ -118,9 +118,9 @@
        (normalize-params matching-params))
      ;; otherwise, attempt to fall back to the default value specified as part of the template tag.
      (when-let [tag-default (:default tag)]
-       {:type    (:widget-type tag :dimension) ; widget-type is the actual type of the default value if set
-        :options tag-opts
-        :value   tag-default})
+       (cond-> {:type    (:widget-type tag :dimension) ; widget-type is the actual type of the default value if set
+                :value   tag-default}
+         tag-opts (assoc :options tag-opts)))
      ;; if that doesn't exist, see if the matching parameters specified default values This can be the case if the
      ;; parameters came from a Dashboard -- Dashboard parameter mappings can specify their own defaults -- but we want
      ;; the defaults specified in the template tag to take precedence if both are specified

--- a/src/metabase/driver/common/parameters/values.clj
+++ b/src/metabase/driver/common/parameters/values.clj
@@ -105,7 +105,9 @@
         tag-opts         (:options tag)
         normalize-params (fn [params]
                            ;; remove `:target` which is no longer needed after this point.
-                           (let [params (map #(merge {:options tag-opts} (dissoc % :target)) params)]
+                           (let [params (map #(cond-> (dissoc % :target)
+                                                tag-opts (assoc :options tag-opts))
+                                             params)]
                              (if (= (count params) 1)
                                (first params)
                                params)))]


### PR DESCRIPTION
This allows template tags to contain `:options` which will be added to the MBQL expansion result, so that template tags can specify options like `:case-sensitive false`.

This adds tests for case-insensitive field filters, but not through template tags. The upcoming frontend PR for this feature should be a better place to add tests for the template tag feature via the UI.

Resolves #29887

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30901)
<!-- Reviewable:end -->
