### PR TITLE
BE: Disallow submitting hidden action parameters

### DIFF
--- a/src/metabase/actions/execution.clj
+++ b/src/metabase/actions/execution.clj
@@ -163,14 +163,15 @@
   "Check that the given request parameters do not contain any parameters that are not in the given set of destination parameter ids"
   [request-parameters destination-param-ids]
   (doseq [[parameter-id _value] request-parameters]
-    (when-not (contains? destination-param-ids parameter-id)
-      (throw (ex-info (tru "No destination parameter found for id {0}. Found: {1}"
-                           (pr-str parameter-id)
-                           (pr-str destination-param-ids))
-                      {:status-code            400
-                       :type                   qp.error-type/invalid-parameter
-                       :parameters             request-parameters
-                       :destination-parameters destination-param-ids})))))
+    (api/check (not (contains? destination-param-ids parameter-id))
+               400
+               {:status-code            400
+                :message                (tru "No destination parameter found for id {0}. Found: {1}"
+                                             (pr-str parameter-id)
+                                             (pr-str destination-param-ids))
+                :type                   qp.error-type/invalid-parameter
+                :parameters             request-parameters
+                :destination-parameters destination-param-ids})))
 
 (defn execute-action!
   "Execute the given action with the given parameters of shape `{<parameter-id> <value>}."

--- a/test/metabase/api/action_test.clj
+++ b/test/metabase/api/action_test.clj
@@ -595,6 +595,6 @@
                                                                                                 :hidden true}}}}]
         (testing "Hidden parameter should fail gracefully"
           (testing "GET /api/action/:id/execute"
-            (is (partial= {:message "No destination parameter found for id \"name\". Found: #{\"last_login\" \"id\"}"}
+            (is (partial= {:message "No destination parameter found for #{\"name\"}. Found: #{\"last_login\" \"id\"}"}
                           (mt/user-http-request :crowberto :post 400 (format "action/%s/execute" action-id)
                                                 {:parameters {:name "Darth Vader"}})))))))))

--- a/test/metabase/api/action_test.clj
+++ b/test/metabase/api/action_test.clj
@@ -538,7 +538,7 @@
 
 (deftest parameter-ignore-test
   (mt/with-actions-test-data-tables #{"users"}
-    (mt/with-actions-enabled
+    (mt/with-actions-test-data-and-actions-enabled
       (mt/with-actions [_ {:dataset true :dataset_query (mt/mbql-query users)}
                         {action-id :action-id} {:type :implicit :kind "row/update"}]
         (testing "It strips out nil values"
@@ -546,45 +546,37 @@
                                                    :post 200
                                                    (format "action/%s/execute" action-id)
                                                    {:parameters {:id 1 :name % :last_login nil}})]
-            (try
-              (run-action! "Darth Vader")
-              (let [[new-name last-login] (first (mt/rows (mt/run-mbql-query users {:breakout [$name $last_login] :filter [:= $id 1]})))]
-                (is (= "Darth Vader" new-name))
-                (is (some? last-login)))
-              (finally
-                (run-action! "Plato Yeshua")))))))))
+            (run-action! "Darth Vader")
+            (let [[new-name last-login] (first (mt/rows (mt/run-mbql-query users {:breakout [$name $last_login] :filter [:= $id 1]})))]
+              (is (= "Darth Vader" new-name))
+              (is (some? last-login)))))))))
 
 (deftest parameter-default-test
   (mt/with-actions-test-data-tables #{"users"}
-    (mt/with-actions-enabled
-      (mt/with-actions [_ {:dataset true :dataset_query (mt/mbql-query users)}
-                        {action-id :action-id} {:type :implicit :kind "row/update"
-                                                :visualization_settings {:fields {"last_login" {:id           "last_login"
-                                                                                                :defaultValue "2023-04-01T00:00:00Z"}}}}]
-        (testing "Missing parameters should be filled in with default values"
-          (let [run-action! #(mt/user-http-request :crowberto
-                                                   :post 200
-                                                   (format "action/%s/execute" action-id)
-                                                   {:parameters (merge {:id 1} %)})]
-            (try
+    (mt/with-actions-test-data-and-actions-enabled
+      (mt/with-actions-enabled
+        (mt/with-actions [_ {:dataset true :dataset_query (mt/mbql-query users)}
+                          {action-id :action-id} {:type :implicit :kind "row/update"
+                                                  :visualization_settings {:fields {"last_login" {:id           "last_login"
+                                                                                                  :defaultValue "2023-04-01T00:00:00Z"}}}}]
+          (testing "Missing parameters should be filled in with default values"
+            (let [run-action! #(mt/user-http-request :crowberto
+                                                     :post 200
+                                                     (format "action/%s/execute" action-id)
+                                                     {:parameters (merge {:id 1} %)})]
               (run-action! {:name "Darth Vader"})
               (let [[new-name last-login] (first (mt/rows (mt/run-mbql-query users {:breakout [$name $last_login] :filter [:= $id 1]})))]
                 (is (= "Darth Vader" new-name))
-                (is (= "2023-04-01T00:00:00Z" last-login)))
-              (finally
-                (run-action! {:name "Plato Yeshua" :last_login "2014-04-01T00:00:00Z"})))))
-        (testing "{<param-id>: null} means a parameter is missing, and should not be replaced with a default value"
-          (let [run-action! #(mt/user-http-request :crowberto
-                                                   :post 200
-                                                   (format "action/%s/execute" action-id)
-                                                   {:parameters (merge {:id 1} %)})]
-            (try
+                (is (= "2023-04-01T00:00:00Z" last-login)))))
+          (testing "{<param-id>: null} means a parameter is missing, and should not be replaced with a default value"
+            (let [run-action! #(mt/user-http-request :crowberto
+                                                     :post 200
+                                                     (format "action/%s/execute" action-id)
+                                                     {:parameters (merge {:id 1} %)})]
               (run-action! {:name "Darth Vader" :last_login nil})
               (let [[new-name last-login] (first (mt/rows (mt/run-mbql-query users {:breakout [$name $last_login] :filter [:= $id 1]})))]
                 (is (= "Darth Vader" new-name))
-                (is (= "2014-04-01T00:00:00Z" last-login)))
-              (finally
-                (run-action! {:name "Plato Yeshua" :last_login "2014-04-01T00:00:00Z"})))))))))
+                (is (= "2023-04-01T00:00:00Z" last-login))))))))))
 
 (deftest hidden-parameter-test
   (mt/with-actions-test-data-tables #{"users"}

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -3143,7 +3143,7 @@
                        (mt/user-http-request :crowberto :post 400 execute-path
                                              {:parameters {"id" 1 "fail" "true"}}))))
               (testing "Extra parameter should fail gracefully"
-                (is (partial= {:message "No destination parameter found for id \"extra\". Found: #{\"id\" \"fail\"}"}
+                (is (partial= {:message "No destination parameter found for #{\"extra\"}. Found: #{\"id\" \"fail\"}"}
                               (mt/user-http-request :crowberto :post 400 execute-path
                                                     {:parameters {"extra" 1}}))))
               (testing "Missing parameter should fail gracefully"
@@ -3236,7 +3236,7 @@
                           DashboardCard [{dashcard-id :id} {:dashboard_id dashboard-id
                                                             :action_id    action-id
                                                             :card_id      model-id}]]
-            (is (partial= {:message "No destination parameter found for id \"name\". Found: #{\"last_login\" \"id\"}"}
+            (is (partial= {:message "No destination parameter found for #{\"name\"}. Found: #{\"last_login\" \"id\"}"}
                           (mt/user-http-request :crowberto :post 400 (format "dashboard/%s/dashcard/%s/execute"
                                                                              dashboard-id
                                                                              dashcard-id)

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -3219,10 +3219,15 @@
                 (is (partial= {:message "No destination parameter found for #{\"extra\"}. Found: #{\"id\"}"}
                               (mt/user-http-request :crowberto :post 400 execute-path
                                                     {:parameters {"extra" 1 "id" 1}}))))
+              (testing "Extra parameter should fail even if it's a model field"
+                (is (partial= {:message "No destination parameter found for #{\"name\"}. Found: #{\"id\"}"}
+                              (mt/user-http-request :crowberto :post 400 execute-path
+                                                    {:parameters {"id"   1
+                                                                  "name" "Birds"}}))))
               (testing "Missing pk parameter should fail gracefully"
                 (is (partial= "Missing primary key parameter: \"id\""
                               (mt/user-http-request :crowberto :post 400 execute-path
-                                                    {:parameters {"name" "Birds"}})))))))))))
+                                                    {:parameters {}})))))))))))
 
 (deftest dashcard-hidden-parameter-test
   (mt/with-actions-test-data-tables #{"users"}

--- a/test/metabase/api/public_test.clj
+++ b/test/metabase/api/public_test.clj
@@ -424,11 +424,11 @@
                   (testing "Prefetch should only return non-hidden fields"
                     (is (= {:id 1 :name "Red Medicine"} ; price is hidden
                            (mt/user-http-request :crowberto :get 200 (str execute-path "?parameters=" (json/encode {:id 1}))))))
-                  (testing "Update should only allow name"
+                  (testing "Update should not allow hidden fields to be updated"
                     (is (= {:rows-updated [1]}
                            (mt/user-http-request :crowberto :post 200 execute-path {:parameters {"id" 1 "name" "Blueberries"}})))
-                    (is (partial= {:message "No destination parameter found for #{\"price\"}. Found: #{\"id\" \"name\"}"}
-                                  (mt/user-http-request :crowberto :post 400 execute-path {:parameters {"id" 1 "name" "Blueberries" "price" 1234}})))))))))))))
+                    (is (= "An error occurred."
+                           (mt/user-http-request :crowberto :post 400 execute-path {:parameters {"id" 1 "name" "Blueberries" "price" 1234}})))))))))))))
 
 (deftest get-public-dashboard-actions-test
   (testing "GET /api/public/dashboard/:uuid"


### PR DESCRIPTION
Epic: https://github.com/metabase/metabase/issues/30016

Depends on #30900, but should be merged into `30016/main`

Currently, we raise an error if the params of a POST request to "api/action/:uuid/execute" or "api/public/dashboard/:uuid/dashcard/:dashcard-id/execute" contain a key that doesn't equal one of the action's parameter IDs. This PR extends this, so that if a key matches a _hidden_ parameter ID, the same error is raised as if the parameter didn't exist at all.

As an example, if a parameter with an ID "name" is hidden (i.e. has `hidden=true` in `visualization_settings.fields`), then a request to `POST /api/action/:id/execute` with the params `{ "name": "Darth Vadar" }` should raise an error, because "name" is supplied even though it's hidden. The error message is identical to that raised if the param ID doesn't exist for the action.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30904)
<!-- Reviewable:end -->
