### PR TITLE
docs - add note about env var command

### DIFF
--- a/src/metabase/cmd.clj
+++ b/src/metabase/cmd.clj
@@ -152,7 +152,8 @@
 
 (defn ^:command environment-variables-documentation
   "Generates a markdown file containing documentation for environment variables relevant to configuring Metabase.
-  The command only includes environment variables registered as defsettings."
+  The command only includes environment variables registered as defsettings.
+  For a full list of environment variables, see https://www.metabase.com/docs/latest/configuring-metabase/environment-variables."
   []
   (classloader/require 'metabase.cmd.env-var-dox)
   ((resolve 'metabase.cmd.env-var-dox/generate-dox!)))

--- a/src/metabase/cmd.clj
+++ b/src/metabase/cmd.clj
@@ -151,7 +151,8 @@
   ((resolve 'metabase.cmd.endpoint-dox/generate-dox!)))
 
 (defn ^:command environment-variables-documentation
-  "Generates a markdown file containing documentation for environment variables relevant to configuring Metabase."
+  "Generates a markdown file containing documentation for environment variables relevant to configuring Metabase.
+  The command only includes environment variables registered as defsettings."
   []
   (classloader/require 'metabase.cmd.env-var-dox)
   ((resolve 'metabase.cmd.env-var-dox/generate-dox!)))


### PR DESCRIPTION
Adds note to docstring for env var command for when people run the `help` command.

As to why the command only includes environment variables registered as defsettings, see https://github.com/metabase/metabase/issues/26911.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metabase/metabase/30907)
<!-- Reviewable:end -->
