### PR TITLE
Embedded link cards

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/LinkViz/LinkViz.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/LinkViz/LinkViz.tsx
@@ -124,7 +124,12 @@ function LinkViz({
 
     return (
       <DisplayLinkCardWrapper>
-        <CardLink to={wrappedEntity.getUrl()} target={target} rel="noreferrer">
+        <CardLink
+          to={wrappedEntity.getUrl()}
+          target={target}
+          rel="noreferrer"
+          role="link"
+        >
           <EntityDisplay entity={wrappedEntity} showDescription />
         </CardLink>
       </DisplayLinkCardWrapper>

--- a/frontend/src/metabase/visualizations/visualizations/LinkViz/LinkViz.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/LinkViz/LinkViz.tsx
@@ -13,6 +13,7 @@ import type {
 
 import { useToggle } from "metabase/hooks/use-toggle";
 import Search from "metabase/entities/search";
+import { isWithinIframe } from "metabase/lib/dom";
 
 import { isRestrictedLinkEntity } from "metabase-types/guards/dashboard";
 import {
@@ -119,9 +120,11 @@ function LinkViz({
       );
     }
 
+    const target = isWithinIframe() ? undefined : "_blank";
+
     return (
       <DisplayLinkCardWrapper>
-        <CardLink to={wrappedEntity.getUrl()} target="_blank" rel="noreferrer">
+        <CardLink to={wrappedEntity.getUrl()} target={target} rel="noreferrer">
           <EntityDisplay entity={wrappedEntity} showDescription />
         </CardLink>
       </DisplayLinkCardWrapper>

--- a/frontend/src/metabase/visualizations/visualizations/LinkViz/LinkViz.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/LinkViz/LinkViz.unit.spec.tsx
@@ -205,6 +205,38 @@ describe("LinkViz", () => {
       expect(screen.getByText("Table Uno")).toBeInTheDocument();
     });
 
+    it("sets embedded links to open in new tabs", () => {
+      setup({
+        isEditing: false,
+        dashcard: tableLinkDashcard,
+        settings:
+          tableLinkDashcard.visualization_settings as LinkCardVizSettings,
+      });
+
+      expect(screen.getByRole("link")).toHaveAttribute("target", "_blank");
+    });
+
+    it("sets embedded entity links to not open in new tabs", () => {
+      // here, we're mocking this appearing in an iframe by manipulating window.top !== window.self
+      const topCache = window.top;
+      // @ts-expect-error we need to delete this for it to actually update
+      delete window.top;
+      // @ts-expect-error it doesn't actually matter if this is valid
+      window.top = {};
+
+      setup({
+        isEditing: false,
+        dashcard: tableLinkDashcard,
+        settings:
+          tableLinkDashcard.visualization_settings as LinkCardVizSettings,
+      });
+
+      expect(screen.getByRole("link")).not.toHaveAttribute("target");
+      // @ts-expect-error we need to delete this for it to actually update
+      delete window.top;
+      window.top = topCache;
+    });
+
     it("clicking a search item should update the entity", async () => {
       setupSearchEndpoints([searchCardItem]);
 


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/30851

### Description

This update Link cards in embedded metabase to open their metabase content in the same metabase window.

![Screen Shot 2023-05-22 at 2 36 23 PM](https://github.com/metabase/metabase/assets/30528226/695adb46-2a73-4c8f-b43e-97f7ace025de)

Scenario | Embedded (full app or single dashboard) | Not Embedded
--- | --- | ---
internal metabase link | opens in same iframe | opens in new tab
external url | opens in new tab | opens in new tab

### How to verify

- add a link card to a dashboard that links to any internal metabase entity (like a question or a dashboard)
- You can mock the behavior of embedded metabase in local development as outlined [here](https://www.notion.so/metabase/Embedding-9d327a4178a14d24a18c8e7d5e4c2d78).
- clicking that link card on the dashboard should not open a new window
- if you have embedding paramaters like `top_nav=false` set, the top nav should not appear when you navigate through the internal links
- external url links should still spawn new tabs

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
