### PR TITLE
Skip Flaky Revision History Test

### DIFF
--- a/e2e/test/scenarios/collections/revision-history.cy.spec.js
+++ b/e2e/test/scenarios/collections/revision-history.cy.spec.js
@@ -82,7 +82,8 @@ describe("revision history", () => {
               cy.findByText(/rearranged the cards/).should("not.exist");
             });
 
-            it("should be able to revert a dashboard (metabase#15237)", () => {
+            // skipped because it's super flaky in CI
+            it.skip("should be able to revert a dashboard (metabase#15237)", () => {
               visitDashboard(1);
               openRevisionHistory();
               clickRevert(/created this/);


### PR DESCRIPTION
### Description

We really don't like to do this, but at some point, a test is so flaky it's useless. Despite multiple attempt to fix the flake here, and it passing consistently locally, we can't get it to regularly pass in CI.

https://github.com/metabase/metabase/pull/30757
https://github.com/metabase/metabase/pull/30861

