### PR TITLE
BE: Only return non-hidden fields with GET api/public/dashboard/:uuid

### DIFF
--- a/frontend/src/metabase-types/api/actions.ts
+++ b/frontend/src/metabase-types/api/actions.ts
@@ -35,7 +35,7 @@ export interface WritebackActionBase {
 
 export type PublicWritebackAction = Pick<
   WritebackActionBase,
-  "id" | "name" | "parameters" | "visualization_settings"
+  "id" | "name" | "parameters" | "visualization_settings" | "database_id"
 >;
 
 export interface QueryAction {

--- a/frontend/src/metabase-types/api/mocks/actions.ts
+++ b/frontend/src/metabase-types/api/mocks/actions.ts
@@ -101,6 +101,7 @@ export const createMockPublicAction = (
 ): PublicWritebackAction => ({
   id: 1,
   name: "Public Action",
+  database_id: 1,
   parameters: [],
   ...opts,
 });

--- a/test/metabase/api/public_test.clj
+++ b/test/metabase/api/public_test.clj
@@ -398,6 +398,31 @@
           (is (= {:name true, :ordered_cards 0}
                  (fetch-public-dashboard dash))))))))
 
+(deftest get-public-dashboard-actions-test
+  (testing "GET /api/public/dashboard/:uuid"
+    (mt/with-actions-test-data-and-actions-enabled
+      (mt/with-temporary-setting-values [enable-public-sharing true]
+        (with-temp-public-dashboard [dash {:parameters []}]
+          (mt/with-actions [{:keys [action-id model-id]} {:visualization_settings {:fields {"id"   {:id     "id"
+                                                                                                    :hidden true}
+                                                                                            "name" {:id     "name"
+                                                                                                    :hidden false}}}}]
+            (mt/with-temp* [DashboardCard [_ {:dashboard_id (:id dash)
+                                              :action_id action-id
+                                              :card_id model-id}]]
+              (let [public-action (-> (client/client :get 200 (format "public/dashboard/%s" (:public_uuid dash)))
+                                      :ordered_cards first :action)]
+                (testing "hidden action fields should not be included in the response"
+                  (is (partial= [:name] ; id is hidden
+                                (-> public-action :visualization_settings :fields keys))))
+                (testing "the action should only include the columns shown for public actions"
+                  (= #{:name
+                       :id
+                       :database_id
+                       :visualization_settings
+                       :parameters}
+                     (set (keys public-action))))))))))))
+
 
 ;;; --------------------------------- GET /api/public/dashboard/:uuid/card/:card-id ----------------------------------
 
@@ -871,6 +896,7 @@
               (testing "Happy path -- should be able to fetch the Action"
                 (is (= #{:name
                          :id
+                         :database_id
                          :visualization_settings
                          :parameters}
                        (set (keys public-action)))))


### PR DESCRIPTION
Epic: https://github.com/metabase/metabase/issues/30016

GET "api/public/dashboard/:uuid" responses should only include data for non-hidden action fields. This PR removes hidden field and parameter data from action fields for public dashboards.