### PR TITLE
BE: Only return non-hidden fields with GET api/dashboard/:dashboard-id/dashcard/:dashcard-id/execute and public endpoint

### DIFF
--- a/src/metabase/actions/execution.clj
+++ b/src/metabase/actions/execution.clj
@@ -199,22 +199,22 @@
              (tru "Values can only be fetched for actions that require a Primary Key."))
   (let [implicit-action (keyword (:kind action))
         {:keys [prefetch-parameters]} (build-implicit-query action implicit-action request-parameters)
-        info             {:executed-by api/*current-user-id*
-                          :context :question
-                          :dashboard-id dashboard-id}
-        card             (t2/select-one Card :id (:model_id action))
+        info {:executed-by api/*current-user-id*
+              :context :question
+              :dashboard-id dashboard-id}
+        card (t2/select-one Card :id (:model_id action))
         ;; prefilling a form with day old data would be bad
-        result           (binding [persisted-info/*allow-persisted-substitution* false]
-                           (qp/process-query-and-save-execution!
-                            (qp.card/query-for-card card prefetch-parameters nil nil)
-                            info))
+        result (binding [persisted-info/*allow-persisted-substitution* false]
+                 (qp/process-query-and-save-execution!
+                  (qp.card/query-for-card card prefetch-parameters nil nil)
+                  info))
         ;; only expose values for fields that are not hidden
         hidden-param-ids (keep #(when (:hidden %) (:id %))
                                (vals (get-in action [:visualization_settings :fields])))
-        exposed-params   (-> (set (map :id (:parameters action)))
-                             (set/difference (set hidden-param-ids)))]
+        exposed-param-ids (-> (set (map :id (:parameters action)))
+                              (set/difference (set hidden-param-ids)))]
     (m/filter-keys
-      #(contains? exposed-params %)
+      #(contains? exposed-param-ids %)
       (zipmap
         (map (comp u/slugify :name) (get-in result [:data :cols]))
         (first (get-in result [:data :rows]))))))

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -3439,7 +3439,7 @@
               (testing "Prefetch should only return non-hidden fields"
                 (is (= {:id 1 :name "Red Medicine"} ; price is hidden
                        (mt/user-http-request :crowberto :get 200 (str execute-path "?parameters=" (json/encode {:id 1}))))))
-              #_(testing "Update should only allow name"
+              (testing "Update should only allow name"
                 (is (= {:rows-updated [1]}
                        (mt/user-http-request :crowberto :post 200 execute-path {:parameters {"id" 1 "name" "Blueberries"}})))
                 (is (partial= {:message "No destination parameter found for #{\"price\"}. Found: #{\"id\" \"name\"}"}

--- a/test/metabase/api/public_test.clj
+++ b/test/metabase/api/public_test.clj
@@ -398,6 +398,38 @@
           (is (= {:name true, :ordered_cards 0}
                  (fetch-public-dashboard dash))))))))
 
+(deftest public-dashboard-with-implicit-action-only-expose-unhidden-fields
+  (mt/with-temporary-setting-values [enable-public-sharing true]
+    (mt/test-drivers (mt/normal-drivers-with-feature :actions)
+      (mt/with-actions-test-data-tables #{"venues" "categories"}
+        (mt/with-actions-test-data-and-actions-enabled
+          (mt/with-actions [{card-id :id} {:dataset true, :dataset_query (mt/mbql-query venues {:fields [$id $name $price]})}
+                            {:keys [action-id]} {:type :implicit
+                                                 :kind "row/update"
+                                                 :visualization_settings {:fields {"id"    {:id     "id"
+                                                                                            :hidden false}
+                                                                                   "name"  {:id     "name"
+                                                                                            :hidden false}
+                                                                                   "price" {:id     "price"
+                                                                                            :hidden true}}}}]
+            (let [dashboard-uuid (str (UUID/randomUUID))]
+              (mt/with-temp* [Dashboard [{dashboard-id :id} {:public_uuid dashboard-uuid}]
+                              DashboardCard [dashcard {:dashboard_id dashboard-id
+                                                       :action_id    action-id
+                                                       :card_id      card-id}]]
+                (testing "Dashcard should only have id and name params"
+                  (is (partial= {:ordered_cards [{:action {:parameters [{:id "id"} {:id "name"}]}}]}
+                                (mt/user-http-request :crowberto :get 200 (format "public/dashboard/%s" dashboard-uuid)))))
+                (let [execute-path (format "public/dashboard/%s/dashcard/%s/execute" dashboard-uuid (:id dashcard))]
+                  (testing "Prefetch should only return non-hidden fields"
+                    (is (= {:id 1 :name "Red Medicine"} ; price is hidden
+                           (mt/user-http-request :crowberto :get 200 (str execute-path "?parameters=" (json/encode {:id 1}))))))
+                  (testing "Update should only allow name"
+                    (is (= {:rows-updated [1]}
+                           (mt/user-http-request :crowberto :post 200 execute-path {:parameters {"id" 1 "name" "Blueberries"}})))
+                    (is (partial= {:message "No destination parameter found for #{\"price\"}. Found: #{\"id\" \"name\"}"}
+                                  (mt/user-http-request :crowberto :post 400 execute-path {:parameters {"id" 1 "name" "Blueberries" "price" 1234}})))))))))))))
+
 
 ;;; --------------------------------- GET /api/public/dashboard/:uuid/card/:card-id ----------------------------------
 


### PR DESCRIPTION
Epic: https://github.com/metabase/metabase/issues/30016

Depends on https://github.com/metabase/metabase/pull/30904 for tests to pass

GET "api/dashboard/:dashboard-id/dashcard/:dashcard-id/execute" responses should only include values for non-hidden action fields. 

Similarly, GET "api/public/dashboard/:dashboard-uuid/dashcard/:dashcard-id/execute" responses should only include values for non-hidden action fields. 

This PR removes values for hidden fields for both endpoints.