### PR TITLE
Stress test E2E flake fixes

### DIFF
--- a/.github/workflows/e2e-stress-test-flake-fix.yml
+++ b/.github/workflows/e2e-stress-test-flake-fix.yml
@@ -100,6 +100,7 @@ jobs:
           yarn run test-cypress-run \
           --spec '${{ github.event.inputs.spec }}' \
           --env burn=${{ github.event.inputs.burn_rate }}
+          --config-file e2e/support/cypress-stress-test.config.js
         env:
           TERM: xterm
       - name: Upload Cypress Artifacts upon failure

--- a/.github/workflows/e2e-stress-test-flake-fix.yml
+++ b/.github/workflows/e2e-stress-test-flake-fix.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       artifact:
-        description: 'artifact id'
+        description: 'Artifact ID'
         type: string
         required: true
       spec:

--- a/.github/workflows/e2e-stress-test-flake-fix.yml
+++ b/.github/workflows/e2e-stress-test-flake-fix.yml
@@ -99,7 +99,7 @@ jobs:
         run: |
           yarn run test-cypress-run \
           --spec '${{ github.event.inputs.spec }}' \
-          --env burn=${{ github.event.inputs.burn_in }}
+          --env burn=${{ github.event.inputs.burn_in }} \
           --config-file e2e/support/cypress-stress-test.config.js
         env:
           TERM: xterm

--- a/.github/workflows/e2e-stress-test-flake-fix.yml
+++ b/.github/workflows/e2e-stress-test-flake-fix.yml
@@ -11,8 +11,8 @@ on:
         description: 'Relative path of the target spec'
         type: string
         required: true
-      burn_rate:
-        description: 'Burn through the test how many times? (e.g. 20)'
+      burn_in:
+        description: 'Number of times to run the test (e.g. 20)'
         type: string
         required: true
 
@@ -95,11 +95,11 @@ jobs:
         run: |
           jar xf target/uberjar/metabase.jar version.properties
           mv version.properties resources/
-      - name: Stress-test ${{ github.event.inputs.spec }} ${{ github.event.inputs.burn_rate }} times
+      - name: Stress-test ${{ github.event.inputs.spec }} ${{ github.event.inputs.burn_in }} times
         run: |
           yarn run test-cypress-run \
           --spec '${{ github.event.inputs.spec }}' \
-          --env burn=${{ github.event.inputs.burn_rate }}
+          --env burn=${{ github.event.inputs.burn_in }}
           --config-file e2e/support/cypress-stress-test.config.js
         env:
           TERM: xterm

--- a/.github/workflows/e2e-stress-test-flake-fix.yml
+++ b/.github/workflows/e2e-stress-test-flake-fix.yml
@@ -1,0 +1,113 @@
+name: E2E Stress Test Flake Fix
+
+on:
+  workflow_dispatch:
+    inputs:
+      artifact:
+        description: 'artifact id'
+        type: string
+        required: true
+      spec:
+        description: 'Relative path of the target spec'
+        type: string
+        required: true
+      burn_rate:
+        description: 'Burn through the test how many times? (e.g. 20)'
+        type: string
+        required: true
+
+jobs:
+  stress-test-flake-fix:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+    name: Stress test E2E flake fix
+    env:
+      DISPLAY: ""
+      QA_DB_ENABLED: true
+      MB_PREMIUM_EMBEDDING_TOKEN: ${{ secrets.ENTERPRISE_TOKEN }}
+      MB_SNOWPLOW_AVAILABLE: true
+      MB_SNOWPLOW_URL: "http://localhost:9090" # Snowplow micro
+      TZ: US/Pacific # to make node match the instance tz
+    services:
+      maildev:
+        image: maildev/maildev:2.0.5
+        ports:
+          - "1080:1080"
+          - "1025:1025"
+        credentials:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      openldap:
+        image: osixia/openldap:1.5.0
+        ports:
+          - "389:389"
+        credentials:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      postgres-sample:
+        image: metabase/qa-databases:postgres-sample-12
+        ports:
+          - "5404:5432"
+        credentials:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      mongo-sample:
+        image: metabase/qa-databases:mongo-sample-4.4
+        ports:
+          - 27004:27017
+        credentials:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      mysql-sample:
+        image: metabase/qa-databases:mysql-sample-8
+        ports:
+          - 3304:3306
+        credentials:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Download Metabase uberjar from a previously stored artifact
+        run: |
+          curl -L \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer $GITHUB_TOKEN" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/metabase/metabase/actions/artifacts/$ARTIFACT_ID/zip \
+            -o mb.zip
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ARTIFACT_ID: ${{ github.event.inputs.artifact }}
+      - name: Unzip Metabase artifact containing an uberjar
+        run: unzip mb.zip
+      - name: Prepare front-end environment
+        uses: ./.github/actions/prepare-frontend
+      - name: Prepare JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: 11
+          distribution: "temurin"
+      - name: Prepare Cypress environment
+        uses: ./.github/actions/prepare-cypress
+      - name: Run Snowplow micro
+        uses: ./.github/actions/run-snowplow-micro
+      - name: Get Metabase version info
+        run: |
+          jar xf target/uberjar/metabase.jar version.properties
+          mv version.properties resources/
+      - name: Stress-test ${{ github.event.inputs.spec }} ${{ github.event.inputs.burn_rate }} times
+        run: |
+          yarn run test-cypress-run \
+          --spec '${{ github.event.inputs.spec }}' \
+          --env burn=${{ github.event.inputs.burn_rate }}
+        env:
+          TERM: xterm
+      - name: Upload Cypress Artifacts upon failure
+        uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: cypress-failed-tests-recording
+          path: |
+            ./cypress
+            ./logs/test.log
+          if-no-files-found: ignore

--- a/.github/workflows/e2e-stress-test-flake-fix.yml
+++ b/.github/workflows/e2e-stress-test-flake-fix.yml
@@ -19,7 +19,7 @@ on:
 jobs:
   stress-test-flake-fix:
     runs-on: ubuntu-22.04
-    timeout-minutes: 10
+    timeout-minutes: 20
     name: Stress test E2E flake fix
     env:
       DISPLAY: ""

--- a/docs/developers-guide/e2e-tests.md
+++ b/docs/developers-guide/e2e-tests.md
@@ -152,6 +152,6 @@ Please follow these steps:
 - Click on _Run workflow_ trigger next to "This workflow has a workflow_dispatch event trigger."
 1. Choose your own branch in the first field "Use workflow from" (this part is crucial!)
 2. Provide previously obtained artifact id to the related field
-3. Copy and paste the relative path of the spec you want to test (e.g. e2e/test/scenarios/onboarding/urls.cy.spec.js) - you don't have to wrap it in quotes
+3. Copy and paste the relative path of the spec you want to test (e.g. `e2e/test/scenarios/onboarding/urls.cy.spec.js`) - you don't have to wrap it in quotes
 4. Set the desired number of times to run the test
 5. Click the green "Run workflow" button and wait for the results

--- a/docs/developers-guide/e2e-tests.md
+++ b/docs/developers-guide/e2e-tests.md
@@ -155,5 +155,5 @@ Build + Docker Uberjar / Build MB ee" job and click on the _Details_ link next t
 1. Choose your own branch in the first field "Use workflow from" (this part is crucial!)
 2. Provide previously obtained artifact id to the related field
 3. Copy and paste the relative path of the spec you want to test (e.g. e2e/test/scenarios/onboarding/urls.cy.spec.js) - you don't have to wrap it in quotes
-4. Set the desired "Burn rate", which tells Cypress how many times to run the same test
+4. Set the desired number of times to run the test
 5. Click the green "Run workflow" button and wait for the results

--- a/docs/developers-guide/e2e-tests.md
+++ b/docs/developers-guide/e2e-tests.md
@@ -140,8 +140,7 @@ Please follow these steps:
 ### Obtain the artifact ID
 - Go to the latest successful commit on `master` branch
 - Click on the green checkmark next to that commit
-- Choose either "E2E Tests / build (ee)" job or "
-Build + Docker Uberjar / Build MB ee" job and click on the _Details_ link next to it (it will take you to that job's summary page within a related workflow)
+- Choose either "E2E Tests / build (ee)" job or "Build + Docker Uberjar / Build MB ee" job and click on the _Details_ link next to it (it will take you to that job's summary page within a related workflow)
 - Click on the workflow _Summary_
 - Scroll to the bottom of the page where you'll find the _Artifacts_ section that contains `metabase-oss-uberjar` and `metabase-ee-uberjar` artifacts
 - Right click on any of the two (but prefer EE one, unless you specifically need to test OSS changes) and copy its link

--- a/docs/developers-guide/e2e-tests.md
+++ b/docs/developers-guide/e2e-tests.md
@@ -127,3 +127,33 @@ These are the tags currently in use:
 
 - `@external` - tests that require an external docker container to run
 - `@actions` - tests that use metabase actions and mutate data in a data source
+
+## How to stress-test a flake fix?
+
+Fixing a flaky test locally doesn't mean the fix works in GitHub's CI environment. The only way to be sure the fix works is to stress-test it in CI. That's what `.github/workflows/e2e-stress-test-flake-fix.yml` is made for. It allows you to quickly test the fix in your branch without waiting for the full build to complete.
+
+Please follow these steps:
+### Prepare
+- Create a new branch with your proposed fix and push it to the remote
+- Either skip opening a PR altogether or open a **draft** pull request
+- Ideally, isolate only the offending test within the spec using `it.only` or `describe.only`
+
+### Obtain the artifact ID
+- Go to the latest successful commit on `master` branch
+- Click on the green checkmark next to that commit
+- Choose either "E2E Tests / build (ee)" job or "
+Build + Docker Uberjar / Build MB ee" job and click on the _Details_ link next to it (it will take you to that job's summary page within a related workflow)
+- Click on the workflow _Summary_
+- Scroll to the bottom of the page where you'll find the _Artifacts_ section that contains `metabase-oss-uberjar` and `metabase-ee-uberjar` artifacts
+- Right click on any of the two (but prefer EE one, unless you specifically need to test OSS changes) and copy its link
+- The link will look like this: `https://github.com/metabase/metabase/suites/13087680507/artifacts/710350560`
+- `710350560` is the artifact id that you'll need in the next step
+
+### Trigger the stress-test workflow manually
+- Go to `https://github.com/metabase/metabase/actions/workflows/e2e-flake-fix-stress-test.yml`
+- Click on _Run workflow_ trigger next to "This workflow has a workflow_dispatch event trigger."
+1. Choose your own branch in the first field "Use workflow from" (this part is crucial!)
+2. Provide previously obtained artifact id to the related field
+3. Copy and paste the relative path of the spec you want to test (e.g. e2e/test/scenarios/onboarding/urls.cy.spec.js) - you don't have to wrap it in quotes
+4. Set the desired "Burn rate", which tells Cypress how many times to run the same test
+5. Click the green "Run workflow" button and wait for the results

--- a/docs/developers-guide/e2e-tests.md
+++ b/docs/developers-guide/e2e-tests.md
@@ -136,7 +136,6 @@ Please follow these steps:
 ### Prepare
 - Create a new branch with your proposed fix and push it to the remote
 - Either skip opening a PR altogether or open a **draft** pull request
-- Ideally, isolate only the offending test within the spec using `it.only` or `describe.only`
 
 ### Obtain the artifact ID
 - Go to the latest successful commit on `master` branch

--- a/e2e/support/config.js
+++ b/e2e/support/config.js
@@ -147,9 +147,15 @@ const crossVersionTargetConfig = {
   specPattern: "e2e/test/scenarios/cross-version/target/**/*.cy.spec.js",
 };
 
+const stressTestConfig = {
+  ...defaultConfig,
+  retries: 0,
+};
+
 module.exports = {
   mainConfig,
   snapshotsConfig,
+  stressTestConfig,
   crossVersionSourceConfig,
   crossVersionTargetConfig,
 };

--- a/e2e/support/cypress-stress-test.config.js
+++ b/e2e/support/cypress-stress-test.config.js
@@ -1,0 +1,4 @@
+const { defineConfig } = require("cypress");
+const { stressTestConfig } = require("./config");
+
+module.exports = defineConfig({ e2e: stressTestConfig });


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
It adds a workflow to our test suite that allows anyone to fairly confidently test their attempted E2E flake fix. We've seen in the past that a few successful runs don't provide enough confidence in the fix. Running the fix locally on (generally) beefy and high-end machines provides even less confidence that the supposed fix will actually work in the GitHub CI environment.

It also adds a section to the dev documentation that explains how to use this workflow.

### Goals
Have the ability to quickly stress-test a specific spec or a test in a spec X number of times and have a feedback within 10 minutes.

### Non-goals
- Have a highly sophisticated and customizable workflow that would predict all possible edge cases (we should rather improve it only once we hit a limitation of the current approach)
- Have a smart workflow that would go and fetch the latest available artifact on its own (although, this is non inconceivable in the near future)

Example of the successful run from my Metabase fork:
![Screenshot 2023-05-23 at 15 53 08](https://github.com/metabase/metabase/assets/31325167/6e603d03-bc52-4119-be12-189b0e35a15f)
