### PR TITLE
Replaces MultipleValues/CommaSeparatedNumbers with vectors

### DIFF
--- a/modules/drivers/mongo/src/metabase/driver/mongo/parameters.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo/parameters.clj
@@ -21,7 +21,7 @@
   (:import
    (java.time ZoneOffset)
    (java.time.temporal Temporal)
-   (metabase.driver.common.parameters CommaSeparatedNumbers Date MultipleValues)))
+   (metabase.driver.common.parameters Date)))
 
 (set! *warn-on-reflection* true)
 
@@ -39,10 +39,6 @@
     (sequential? x)
     (format "{$in: [%s]}" (str/join ", " (map (partial param-value->str field) x)))
 
-    ;; MultipleValues get converted as sequences
-    (instance? MultipleValues x)
-    (recur field (:values x))
-
     ;; Date = the Parameters Date type, not an java.util.Date or java.sql.Date type
     ;; convert to a `Temporal` instance and recur
     (instance? Date x)
@@ -59,10 +55,6 @@
     ;; convert temporal types to ISODate("2019-12-09T...") (etc.)
     (instance? Temporal x)
     (format "ISODate(\"%s\")" (u.date/format x))
-
-    ;; there's a special record type for sequences of numbers; pull the sequence it wraps out and recur
-    (instance? CommaSeparatedNumbers x)
-    (recur field (:numbers x))
 
     ;; for everything else, splice it in as its string representation
     :else

--- a/src/metabase/driver/common/parameters.clj
+++ b/src/metabase/driver/common/parameters.clj
@@ -2,8 +2,7 @@
   "Various record types below are used as a convenience for differentiating the different param types."
   (:require
    [potemkin.types :as p.types]
-   [pretty.core :as pretty]
-   [schema.core :as s]))
+   [pretty.core :as pretty]))
 
 ;; "FieldFilter" is something that expands to a clause like "some_field BETWEEN 1 AND 10"
 ;;
@@ -74,38 +73,10 @@
   (pretty [_]
     (list (pretty/qualify-symbol-for-*ns* `->DateRange) start end)))
 
-;; List of numbers to faciliate things like using params in a SQL `IN` clause. This is supported by both regular
-;; filter clauses (e.g. `IN ({{ids}})` and in field filters. Field filters also support sequences of values other than
-;; numbers, but these don't have a special record type. (TODO - we don't need a record type here, either. Just use a
-;; sequence)
-;;
-;; `numbers` are a sequence of `[java.lang.Number]`
-(p.types/defrecord+ CommaSeparatedNumbers [numbers]
-  pretty/PrettyPrintable
-  (pretty [_]
-    (list (pretty/qualify-symbol-for-*ns* `->CommaSeparatedNumbers) numbers)))
-
 (def no-value
   "Convenience for representing an *optional* parameter present in a query but whose value is unspecified in the param
   values."
   ::no-value)
-
-(def SingleValue
-  "Schema for a valid *single* value for a param. As of 0.28.0 params can either be single-value or multiple value."
-  (s/cond-pre (s/eq no-value)
-              CommaSeparatedNumbers
-              FieldFilter
-              Date
-              s/Num
-              s/Str
-              s/Bool))
-
-;; Sequence of multiple values for generating a SQL IN() clause. vales
-;; `values` are a sequence of `[SingleValue]`
-(p.types/defrecord+ MultipleValues [values]
-  pretty/PrettyPrintable
-  (pretty [_]
-    (list (pretty/qualify-symbol-for-*ns* `->MultipleValues) values)))
 
 (p.types/defrecord+ Param [k]
   pretty/PrettyPrintable

--- a/src/metabase/util.cljc
+++ b/src/metabase/util.cljc
@@ -444,6 +444,13 @@
     arg
     [arg]))
 
+(defn many-or-one
+  "Returns coll if it has multiple elements, or else returns its only element"
+  [coll]
+  (if (next coll)
+    coll
+    (first coll)))
+
 (defn select-nested-keys
   "Like `select-keys`, but can also handle nested keypaths:
 

--- a/test/metabase/driver/common/parameters/values_test.clj
+++ b/test/metabase/driver/common/parameters/values_test.clj
@@ -47,7 +47,7 @@
              (#'params.values/value-for-tag
               {:name "number_filter", :display-name "ID", :type :number, :required true, :default "100"}
               [{:type :number/=, :value ["20"], :target [:variable [:template-tag "number_filter"]]}])))
-      (is (= (params/map->CommaSeparatedNumbers {:numbers [20 40]})
+      (is (= [20 40]
              (#'params.values/value-for-tag
               {:name "number_filter", :display-name "ID", :type :number, :required true, :default "100"}
               [{:type :number/=, :value ["20" "40"], :target [:variable [:template-tag "number_filter"]]}]))))


### PR DESCRIPTION
Please excuse the random out-of-band PR. I noticed the `CommaSeparatedNumbers` type had a `TODO` about removing it, and I followed the same rationale through to `MultipleValues`. Multi-valued param values are now just vectors of values.