### PR TITLE
Fixed MB_JETTY_PORT env var

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -265,8 +265,7 @@
   :run
   {:main-opts ["-m" "metabase.bootstrap"]
    :jvm-opts  ["-Dmb.run.mode=dev"
-               "-Djava.awt.headless=true"                   ; prevent Java icon from randomly popping up in macOS dock
-               "-Dmb.jetty.port=3000"]}
+               "-Djava.awt.headless=true"]}                   ; prevent Java icon from randomly popping up in macOS dock
 
   ;; alias for CI-specific options.
   :ci


### PR DESCRIPTION
### Description

When we run MB in dev mode locally, `-Dmb.jetty.port=3000` overrides `MB_JETTY_PORT`, so we can't specify a custom port via environment variables. You will get the following warning:
> Warning: environ value 1111 for key :mb-jetty-port has been overwritten with 3000 

Without `-Dmb.jetty.port=3000`, we still will use `3000` as default port because of `:mb-jetty-port` in `config.clj` but will have the ability to specify a custom without code changes.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Run MB locally via `MB_JETTY_PORT=12345 yarn dev`
2. Check that app available on `localhost:12345`

