### PR TITLE
SQL snippets permission fix

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/enhancements/models/native_query_snippet/permissions.clj
+++ b/enterprise/backend/src/metabase_enterprise/enhancements/models/native_query_snippet/permissions.clj
@@ -24,7 +24,7 @@
     (snippet.perms/has-any-native-permissions?)
     (has-parent-collection-perms? snippet :read)))
   ([model id]
-   (can-read? (t2/select-one [model :collection_id] :id id) :read)))
+   (can-read? (t2/select-one [model :collection_id] :id id))))
 
 (defenterprise can-write?
   "Can the current User edit this `snippet`?"
@@ -35,7 +35,7 @@
     (snippet.perms/has-any-native-permissions?)
     (has-parent-collection-perms? snippet :write)))
   ([model id]
-   (can-write? (t2/select-one [model :collection_id] :id id) :write)))
+   (can-write? (t2/select-one [model :collection_id] :id id))))
 
 (defenterprise can-create?
   "Can the current User save a new Snippet with the values in `m`?"

--- a/enterprise/backend/src/metabase_enterprise/enhancements/models/native_query_snippet/permissions.clj
+++ b/enterprise/backend/src/metabase_enterprise/enhancements/models/native_query_snippet/permissions.clj
@@ -51,8 +51,8 @@
   :feature :any
   [snippet changes]
   (and
+   (not (mt.api.u/segmented-user?))
    (snippet.perms/has-any-native-permissions?)
    (has-parent-collection-perms? snippet :write)
-   (not (mt.api.u/segmented-user?))
    (or (not (contains? changes :collection_id))
        (has-parent-collection-perms? changes :write))))

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
@@ -15,7 +15,7 @@
    [metabase.util :as u]
    [toucan2.core :as t2]))
 
-(defn do-with-all-user-data-perms
+(defn- do-with-all-user-data-perms
   [graph f]
   (let [all-users-group-id  (u/the-id (perms-group/all-users))
         current-graph       (get-in (perms/data-perms-graph) [:groups all-users-group-id])]
@@ -30,7 +30,7 @@
           (u/ignore-exceptions
            (@#'perms/update-group-permissions! all-users-group-id current-graph)))))))
 
-(defmacro with-all-users-data-perms
+(defmacro ^:private with-all-users-data-perms
   "Runs `body` with perms for the All Users group temporarily set to the values in `graph`. Also enables the advanced
   permissions feature flag, and clears the (5 second TTL) cache used for Field permissions, for convenience."
   [graph & body]

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
@@ -15,7 +15,7 @@
    [metabase.util :as u]
    [toucan2.core :as t2]))
 
-(defn- do-with-all-user-data-perms
+(defn do-with-all-user-data-perms
   [graph f]
   (let [all-users-group-id  (u/the-id (perms-group/all-users))
         current-graph       (get-in (perms/data-perms-graph) [:groups all-users-group-id])]
@@ -30,7 +30,7 @@
           (u/ignore-exceptions
            (@#'perms/update-group-permissions! all-users-group-id current-graph)))))))
 
-(defmacro ^:private with-all-users-data-perms
+(defmacro with-all-users-data-perms
   "Runs `body` with perms for the All Users group temporarily set to the values in `graph`. Also enables the advanced
   permissions feature flag, and clears the (5 second TTL) cache used for Field permissions, for convenience."
   [graph & body]

--- a/enterprise/backend/test/metabase_enterprise/enhancements/models/native_query_snippet/permissions_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/enhancements/models/native_query_snippet/permissions_test.clj
@@ -36,6 +36,7 @@
     (testing "if EE perms are enabled: "
       (premium-features-test/with-premium-features #{:enhancements}
         (testing "should be allowed if you have collection perms, native perms for at least one DB, and are not sandboxed"
+          (perms/grant-native-readwrite-permissions! (perms-group/all-users) (mt/id))
           (grant-collection-perms!)
           (test-perms* true))
         (testing "should NOT be allowed if you do not have collection perms"
@@ -73,7 +74,7 @@
     (test-with-root-collection-and-collection
      (fn [coll snippet]
        (test-perms
-        :has-perms-for-obj?    #(mi/can-create? NativeQuerySnippet (dissoc snippet :id))
+        :has-perms-for-obj?       #(mi/can-create? NativeQuerySnippet (dissoc snippet :id))
         :grant-collection-perms!  #(perms/grant-collection-readwrite-permissions! (perms-group/all-users) coll)
         :revoke-collection-perms! #(perms/revoke-collection-permissions! (perms-group/all-users) coll))))))
 

--- a/enterprise/backend/test/metabase_enterprise/enhancements/models/native_query_snippet/permissions_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/enhancements/models/native_query_snippet/permissions_test.clj
@@ -29,14 +29,13 @@
       (premium-features-test/with-premium-features #{}
         (testing "should NOT be allowed if you don't have native perms for at least one DB"
           (test-perms* false))
-        (testing "should be allowed if you don't have native perms for at least one DB"
+        (testing "should be allowed if you have native perms for at least one DB"
           (perms/grant-native-readwrite-permissions! (perms-group/all-users) (mt/id))
           (test-perms* true))))
 
     (testing "if EE perms are enabled: "
       (premium-features-test/with-premium-features #{:enhancements}
         (testing "should be allowed if you have collection perms, native perms for at least one DB, and are not sandboxed"
-          (perms/grant-native-readwrite-permissions! (perms-group/all-users) (mt/id))
           (grant-collection-perms!)
           (test-perms* true))
         (testing "should NOT be allowed if you do not have collection perms"

--- a/enterprise/backend/test/metabase_enterprise/enhancements/models/native_query_snippet/permissions_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/enhancements/models/native_query_snippet/permissions_test.clj
@@ -1,17 +1,19 @@
 (ns metabase-enterprise.enhancements.models.native-query-snippet.permissions-test
   (:require
    [clojure.test :refer :all]
+   [metabase-enterprise.test :as met]
    [metabase.models :refer [Collection NativeQuerySnippet]]
    [metabase.models.collection :as collection]
    [metabase.models.interface :as mi]
    [metabase.models.permissions :as perms]
    [metabase.models.permissions-group :as perms-group]
-   [metabase.public-settings.premium-features-test :as premium-features-test]
+   [metabase.public-settings.premium-features-test
+    :as premium-features-test]
    [metabase.test :as mt]))
 
 (def ^:private root-collection (assoc collection/root-collection :name "Root Collection", :namespace "snippets"))
 
-(defn- test-perms [& {:keys [has-perms-for-obj? has-perms-for-id? grant-collection-perms!]}]
+(defn- test-perms [& {:keys [has-perms-for-obj? has-perms-for-id? grant-collection-perms! revoke-collection-perms!]}]
   (letfn [(test-perms* [expected]
             (mt/with-test-user :rasta
               (when has-perms-for-obj?
@@ -22,15 +24,31 @@
                 (testing "has perms for model + ID?"
                   (is (= expected
                          (has-perms-for-id?)))))))]
-    (testing "should be allowed if EE perms aren't enabled"
+    (testing "if EE perms aren't enabled: "
+      (perms/revoke-native-permissions! (perms-group/all-users) (mt/id))
       (premium-features-test/with-premium-features #{}
-        (test-perms* true)))
-    (premium-features-test/with-premium-features #{:enhancements}
-      (testing "should NOT be allowed if EE perms are enabled and you do not have perms"
-        (test-perms* false))
-      (testing "should be allowed if you have perms"
-        (grant-collection-perms!)
-        (test-perms* true)))))
+        (testing "should NOT be allowed if you don't have native perms for at least one DB"
+          (test-perms* false))
+        (testing "should be allowed if you don't have native perms for at least one DB"
+          (perms/grant-native-readwrite-permissions! (perms-group/all-users) (mt/id))
+          (test-perms* true))))
+
+    (testing "if EE perms are enabled: "
+      (premium-features-test/with-premium-features #{:enhancements}
+        (testing "should be allowed if you have collection perms, native perms for at least one DB, and are not sandboxed"
+          (grant-collection-perms!)
+          (test-perms* true))
+        (testing "should NOT be allowed if you do not have collection perms"
+          (revoke-collection-perms!)
+          (test-perms* false)
+          (grant-collection-perms!))
+        (testing "should NOT be allowed if you do not have native query perms for at least one DB"
+          (perms/revoke-native-permissions! (perms-group/all-users) (mt/id))
+          (test-perms* false)
+          (perms/grant-native-readwrite-permissions! (perms-group/all-users) (mt/id)))
+        (testing "should NOT be allowed if you are sandboxed"
+          (met/with-gtaps {:gtaps {:venues {:query (mt/mbql-query venues)}}}
+            (test-perms* false)))))))
 
 (defn- test-with-root-collection-and-collection [f]
   (mt/with-non-admin-groups-no-root-collection-for-namespace-perms "snippets"
@@ -45,23 +63,26 @@
     (test-with-root-collection-and-collection
      (fn [coll snippet]
        (test-perms
-        :has-perms-for-obj?      #(mi/can-read? snippet)
-        :has-perms-for-id?       #(mi/can-read? NativeQuerySnippet (:id snippet))
-        :grant-collection-perms! #(perms/grant-collection-read-permissions! (perms-group/all-users) coll))))))
+        :has-perms-for-obj?       #(mi/can-read? snippet)
+        :has-perms-for-id?        #(mi/can-read? NativeQuerySnippet (:id snippet))
+        :grant-collection-perms!  #(perms/grant-collection-read-permissions! (perms-group/all-users) coll)
+        :revoke-collection-perms! #(perms/revoke-collection-permissions! (perms-group/all-users) coll))))))
 
 (deftest create-perms-test
   (testing "create a Snippet"
     (test-with-root-collection-and-collection
      (fn [coll snippet]
        (test-perms
-        :has-perms-for-object?   #(mi/can-create? NativeQuerySnippet (dissoc snippet :id))
-        :grant-collection-perms! #(perms/grant-collection-readwrite-permissions! (perms-group/all-users) coll))))))
+        :has-perms-for-obj?    #(mi/can-create? NativeQuerySnippet (dissoc snippet :id))
+        :grant-collection-perms!  #(perms/grant-collection-readwrite-permissions! (perms-group/all-users) coll)
+        :revoke-collection-perms! #(perms/revoke-collection-permissions! (perms-group/all-users) coll))))))
 
 (deftest update-perms-test
   (testing "update a Snippet"
     (test-with-root-collection-and-collection
      (fn [coll snippet]
        (test-perms
-        :has-perms-for-obj?      #(mi/can-write? snippet)
-        :has-perms-for-id?       #(mi/can-write? NativeQuerySnippet (:id snippet))
-        :grant-collection-perms! #(perms/grant-collection-readwrite-permissions! (perms-group/all-users) coll))))))
+        :has-perms-for-obj?       #(mi/can-write? snippet)
+        :has-perms-for-id?        #(mi/can-write? NativeQuerySnippet (:id snippet))
+        :grant-collection-perms!  #(perms/grant-collection-readwrite-permissions! (perms-group/all-users) coll)
+        :revoke-collection-perms! #(perms/revoke-collection-permissions! (perms-group/all-users) coll))))))

--- a/src/metabase/models/native_query_snippet/permissions.clj
+++ b/src/metabase/models/native_query_snippet/permissions.clj
@@ -32,7 +32,8 @@
 (defenterprise can-create?
   "Can the current User save a new Snippet with the values in `m`?"
   metabase-enterprise.enhancements.models.native-query-snippet.permissions
-  [_ _] (has-any-native-permissions?))
+  [_ _]
+  (has-any-native-permissions?))
 
 (defenterprise can-update?
   "Can the current User apply a map of `changes` to a `snippet`?"

--- a/src/metabase/models/native_query_snippet/permissions.clj
+++ b/src/metabase/models/native_query_snippet/permissions.clj
@@ -1,28 +1,41 @@
 (ns metabase.models.native-query-snippet.permissions
   "NativeQuerySnippets have different permissions implementations. In Metabase CE, anyone can read/edit/create all
-  NativeQuerySnippets. EE has a more advanced implementation."
+  NativeQuerySnippets if they have native query perms for at least one database. EE has a more advanced implementation."
   (:require
+   [metabase.api.common :as api]
+   [metabase.models.permissions :as perms]
    [metabase.public-settings.premium-features :refer [defenterprise]]))
+
+(defn has-any-native-permissions?
+  "Checks whether the current user has native query permissions for any database."
+  []
+  (perms/set-has-any-native-query-permissions? @api/*current-user-permissions-set*))
 
 (defenterprise can-read?
   "Can the current User read this `snippet`?"
   metabase-enterprise.enhancements.models.native-query-snippet.permissions
-  ([_] true)
-  ([_ _] true))
+  ([_]
+   (has-any-native-permissions?))
+
+  ([_ _]
+   (has-any-native-permissions?)))
 
 (defenterprise can-write?
   "Can the current User edit this `snippet`?"
   metabase-enterprise.enhancements.models.native-query-snippet.permissions
-  ([_] true)
-  ([_ _] true))
+  ([_]
+   (has-any-native-permissions?))
+
+  ([_ _]
+   (has-any-native-permissions?)))
 
 (defenterprise can-create?
   "Can the current User save a new Snippet with the values in `m`?"
   metabase-enterprise.enhancements.models.native-query-snippet.permissions
-  [_ _] true)
+  [_ _] (has-any-native-permissions?))
 
 (defenterprise can-update?
   "Can the current User apply a map of `changes` to a `snippet`?"
   metabase-enterprise.enhancements.models.native-query-snippet.permissions
   [_ _]
-  true)
+  (has-any-native-permissions?))

--- a/src/metabase/models/permissions.clj
+++ b/src/metabase/models/permissions.clj
@@ -647,7 +647,7 @@
   (boolean
     ;; Matches "/", "/db/:id/", or "/db/:id/native/"
     (some
-     #(first (re-find #"^/(db/\d+/(native/))?$" %))
+     #(first (re-find #"^/(db/\d+/(native/)?)?$" %))
      permissions-set)))
 
 (s/defn set-has-application-permission-of-type? :- s/Bool

--- a/src/metabase/models/permissions.clj
+++ b/src/metabase/models/permissions.clj
@@ -641,6 +641,15 @@
   (every? (partial set-has-partial-permissions? permissions-set)
           paths-set))
 
+(s/defn set-has-any-native-query-permissions? :- s/Bool
+  "Do the permission paths in `permission-set` grant native query access to any database?"
+  [permissions-set]
+  (boolean
+    ;; Matches "/", "/db/:id/", or "/db/:id/native/"
+    (some
+     #(first (re-find #"^/(db/\d+/(native/))?$" %))
+     permissions-set)))
+
 (s/defn set-has-application-permission-of-type? :- s/Bool
   "Does `permissions-set` grant *full* access to a application permission of type `perm-type`?"
   [permissions-set perm-type]

--- a/test/metabase/api/native_query_snippet_test.clj
+++ b/test/metabase/api/native_query_snippet_test.clj
@@ -5,7 +5,10 @@
    [clojure.test :refer :all]
    [metabase.models :refer [Collection]]
    [metabase.models.native-query-snippet :refer [NativeQuerySnippet]]
+   [metabase.models.permissions :as perms]
+   [metabase.models.permissions-group :as perms-group]
    [metabase.test :as mt]
+   [metabase.util :as u]
    [metabase.util.schema :as su]
    [schema.core :as s]
    [toucan.util.test :as tt]
@@ -23,7 +26,14 @@
   (str/starts-with? (or (get-in response [:errors :name]) "")
                     "snippet names cannot include"))
 
+(defn- grant-native-perms
+  "Grants native query perms for the All Users group to the test database if not already granted."
+  []
+  (u/ignore-exceptions
+   (perms/grant-native-readwrite-permissions! (perms-group/all-users) (mt/id))))
+
 (deftest list-snippets-api-test
+  (grant-native-perms)
   (testing "GET /api/native-query-snippet"
     (mt/with-temp* [NativeQuerySnippet [snippet-1 {:content "1"
                                                    :name    "snippet_1"}]
@@ -39,6 +49,7 @@
               (is (contains? snippets-from-api (select-keys snippet-2 test-snippet-fields))))))))))
 
 (deftest read-snippet-api-test
+  (grant-native-perms)
   (testing "GET /api/native-query-snippet/:id"
     (mt/with-temp NativeQuerySnippet [snippet {:content "-- SQL comment here"
                                                :name    "comment"}]
@@ -50,6 +61,7 @@
                      (select-keys snippet-from-api test-snippet-fields))))))))))
 
 (deftest create-snippet-api-test
+  (grant-native-perms)
   (testing "POST /api/native-query-snippet"
     (testing "new snippet field validation"
       (is (= {:errors {:content "value must be a string."}}
@@ -107,6 +119,7 @@
         (t2/delete! NativeQuerySnippet :name "test-snippet")))))
 
 (deftest create-snippet-in-collection-test
+  (grant-native-perms)
   (testing "POST /api/native-query-snippet"
     (testing "\nShould be able to create a Snippet in a Collection"
       (letfn [(create! [expected-status-code collection-id]
@@ -139,6 +152,7 @@
                  (:response (create! 404 Integer/MAX_VALUE)))))))))
 
 (deftest update-snippet-api-test
+  (grant-native-perms)
   (testing "PUT /api/native-query-snippet/:id"
     (mt/with-temp NativeQuerySnippet [snippet {:content "-- SQL comment here"
                                                :name    "comment"}]
@@ -147,9 +161,8 @@
                                 "non-admin user should be able to update" :rasta}]
           (testing message
             (let [updated-desc    "Updated description."
-                  updated-snippet (mt/user-http-request user
-                                   :put 200 (snippet-url (:id snippet))
-                                   {:description updated-desc})]
+                  updated-snippet (mt/user-http-request user :put 200 (snippet-url (:id snippet))
+                                                        {:description updated-desc})]
               (is (= updated-desc (:description updated-snippet)))))))
 
       (testing "Attempting to change Snippet's name to one that's already in use should throw an error"
@@ -172,6 +185,7 @@
                  (t2/select-one-fn :creator_id NativeQuerySnippet :id (:id snippet)))))))))
 
 (deftest update-snippet-collection-test
+  (grant-native-perms)
   (testing "PUT /api/native-query-snippet/:id"
     (testing "\nChange collection_id"
       (tt/with-temp* [Collection [collection-1 {:name "a Collection", :namespace "snippets"}]

--- a/test/metabase/models/permissions_test.clj
+++ b/test/metabase/models/permissions_test.clj
@@ -602,6 +602,29 @@
              (perms/set-has-partial-permissions-for-set? perms paths))))))
 
 
+;;; -------------------------------------- set-has-any-native-query-permissions? ---------------------------------------
+
+(deftest set-has-any-native-query-permissions?-test
+  (doseq [[expected inputs]
+          {true
+           [#{"/"}
+            #{"/db/1/"}
+            #{"/db/1/native/"}
+            #{"/db/1/" "/db/2/schema/PUBLIC/table/1/"}
+            #{"/db/1/native/" "/db/2/schema/PUBLIC/table/1/"}]
+
+           false
+           [#{}
+            #{"/db/1"}
+            #{"/db/1/native"}
+            #{"/db/1/schema/"}
+            #{"/db/1/schema/PUBLIC/table/1/"}]}
+          input inputs]
+    (testing (pr-str (list 'set-has-any-native-query-permissions?-test input))
+      (is (= expected
+             (perms/set-has-any-native-query-permissions? input))))))
+
+
 ;;; ------------------------------------ perms-objects-set-for-parent-collection -------------------------------------
 
 (deftest perms-objects-set-for-parent-collection-test


### PR DESCRIPTION
This is a PR for the SQL snippets permission fix that was released last week, to get it into `master` on the main repo.

Has already been reviewed in https://github.com/metabase/metabase-private/pull/40