### PR TITLE
Backport recent_views in user-local settings (#29631) to 46 release branch

### DIFF
--- a/src/metabase/api/activity.clj
+++ b/src/metabase/api/activity.clj
@@ -4,9 +4,7 @@
    [compojure.core :refer [GET]]
    [medley.core :as m]
    [metabase.api.common :as api :refer [*current-user-id* define-routes]]
-   [metabase.db.connection :as mdb.connection]
    [metabase.events.view-log :as view-log]
-   [metabase.models.activity :refer [Activity]]
    [metabase.models.card :refer [Card]]
    [metabase.models.dashboard :refer [Dashboard]]
    [metabase.models.interface :as mi]
@@ -15,8 +13,7 @@
    [metabase.models.view-log :refer [ViewLog]]
    [metabase.util.honey-sql-2 :as h2x]
    [toucan.db :as db]
-   [toucan.hydrate :refer [hydrate]]
-   [toucan2.core :as t2]))
+   [toucan.hydrate :refer [hydrate]]))
 
 (defn- models-query
   [model ids]

--- a/src/metabase/api/activity.clj
+++ b/src/metabase/api/activity.clj
@@ -2,10 +2,11 @@
   (:require
    [clojure.string :as str]
    [compojure.core :refer [GET]]
-   [java-time :as t]
    [medley.core :as m]
    [metabase.api.common :as api :refer [*current-user-id* define-routes]]
    [metabase.db.connection :as mdb.connection]
+   [metabase.events.view-log :as view-log]
+   [metabase.models.activity :refer [Activity]]
    [metabase.models.card :refer [Card]]
    [metabase.models.dashboard :refer [Dashboard]]
    [metabase.models.interface :as mi]
@@ -114,83 +115,21 @@
 (def ^:private views-limit 8)
 (def ^:private card-runs-limit 8)
 
-(defn- bookmarks-query
-  [user-id]
-  (let [as-null (when (= (mdb.connection/db-type) :postgres) (h2x/->integer nil))]
-    {:select [[:type :model] [:item_id :model_id]]
-     :from   [[{:union-all [{:select [:card_id
-                                      [as-null :dashboard_id]
-                                      [as-null :collection_id]
-                                      [:card_id :item_id]
-                                      [(h2x/literal "card") :type]
-                                      :created_at]
-                             :from   [:card_bookmark]
-                             :where  [:= :user_id [:inline user-id]]}
-                            {:select [[as-null :card_id]
-                                      :dashboard_id
-                                      [as-null :collection_id]
-                                      [:dashboard_id :item_id]
-                                      [(h2x/literal "dashboard") :type]
-                                      :created_at]
-                             :from   [:dashboard_bookmark]
-                             :where  [:= :user_id [:inline user-id]]}]}
-               :bookmarks]]}))
-
-(defn- recent-views-for-user
-  [user-id]
-  (let [bookmarks (bookmarks-query user-id)
-        qe        {:select [[(h2x/literal "qe") :source]
-                            [:executor_id :user_id]
-                            :context
-                            [:started_at :timestamp]
-                            [(h2x/literal "card") :model]
-                            [:card_id :model_id]
-                            [false :dataset]]
-                   :from   :query_execution}
-        vl        {:select    [[(h2x/literal "vl") :source]
-                               :user_id
-                               [(h2x/literal "question") :context]
-                               :timestamp
-                               :model
-                               :model_id
-                               [:report_card.dataset :dataset]]
-                   :from      [:view_log]
-                   :left-join [:report_card
-                               [:and
-                                [:= :view_log.model (h2x/literal "card")]
-                                [:= :view_log.model_id :report_card.id]]]}
-        views     {:union-all [qe vl]}]
-    (t2/query
-     {:select   [[[:max :timestamp] :timestamp]
-                 :model
-                 :model_id]
-      :from     [[views :views]]
-      :where    [[:and
-                  [:= :user_id [:inline user-id]]
-                  [:>= :timestamp (t/minus (t/offset-date-time) (t/days 30))]
-                  [:not= :context (h2x/literal "pulse")]
-                  [:not= :context (h2x/literal "collection")]
-                  [:not= :context (h2x/literal "ad-hoc")]
-                  [:not= [:composite :context :model] [:composite (h2x/literal "dashboard") (h2x/literal "card")]]
-                  [:not= [:composite :source :model :dataset] [:composite (h2x/literal "vl") (h2x/literal "card") [:inline false]]]
-                  [:not-in [:composite :model :model_id] bookmarks]]]
-      :group-by [:model :model_id]
-      :order-by [[:timestamp :desc]]
-      :limit    [:inline 8]})))
-
 (api/defendpoint GET "/recent_views"
   "Get a list of 5 things the current user has been viewing most recently."
   []
-  (let [views (recent-views-for-user *current-user-id*)
+  (let [views            (view-log/user-recent-views)
         model->id->items (models-for-views views)]
     (->> (for [{:keys [model model_id] :as view-log} views
-               :let [model-object (-> (get-in model->id->items [model model_id])
-                                      (dissoc :dataset_query))]
-               :when (and model-object
-                          (mi/can-read? model-object)
-                          ;; hidden tables, archived cards/dashboards
-                          (not (or (:archived model-object)
-                                   (= (:visibility_type model-object) :hidden))))]
+               :let
+               [model-object (-> (get-in model->id->items [model model_id])
+                                 (dissoc :dataset_query))]
+               :when
+               (and model-object
+                    (mi/can-read? model-object)
+                    ;; hidden tables, archived cards/dashboards
+                    (not (or (:archived model-object)
+                             (= (:visibility_type model-object) :hidden))))]
            (cond-> (assoc view-log :model_object model-object)
              (:dataset model-object) (assoc :model "dataset")))
          (take 5))))

--- a/src/metabase/events.clj
+++ b/src/metabase/events.clj
@@ -133,4 +133,9 @@
   Expand the object when we need more metadata."
   [object]
   {:cached       (:cached object)
-   :ignore_cache (:ignore_cache object)})
+   :ignore_cache (:ignore_cache object)
+   ;; the :context key comes from qp middleware:
+   ;; `metabase.query-processor.middleware.process-userland-query/add-and-save-execution-info-xform!`
+   ;; and is important for distinguishing view events triggered when pinned cards are 'viewed'
+   ;; when a user opens a collection.
+   :context      (:context object)})

--- a/src/metabase/events/view_log.clj
+++ b/src/metabase/events/view_log.clj
@@ -74,7 +74,7 @@
                                 [:= :view_log.model (h2x/literal "card")]
                                 [:= :view_log.model_id :report_card.id]]]}
         views     {:union-all [qe vl]}]
-    (t2/query
+    (db/query
      {:select   [[[:max :timestamp] :timestamp]
                  :model
                  :model_id]

--- a/src/metabase/events/view_log.clj
+++ b/src/metabase/events/view_log.clj
@@ -1,8 +1,15 @@
 (ns metabase.events.view-log
   (:require
    [clojure.core.async :as a]
+   [java-time :as t]
+   [metabase.api.common :as api]
+   [metabase.db.connection :as mdb.connection]
    [metabase.events :as events]
+   [metabase.models.setting :as setting :refer [defsetting]]
    [metabase.models.view-log :refer [ViewLog]]
+   [metabase.server.middleware.session :as mw.session]
+   [metabase.util.honey-sql-2 :as h2x]
+   [metabase.util.i18n :as i18n :refer [deferred-tru]]
    [metabase.util.log :as log]
    [toucan.db :as db]))
 
@@ -19,6 +26,101 @@
   (a/chan))
 
 
+;;; ## ---------------------------------------- PER-USER VIEWS ----------------------------------------
+
+(defn- bookmarks-query
+  [user-id]
+  (let [as-null (when (= (mdb.connection/db-type) :postgres) (h2x/->integer nil))]
+    {:select [[:type :model] [:item_id :model_id]]
+     :from   [[{:union-all [{:select [:card_id
+                                      [as-null :dashboard_id]
+                                      [as-null :collection_id]
+                                      [:card_id :item_id]
+                                      [(h2x/literal "card") :type]
+                                      :created_at]
+                             :from   [:card_bookmark]
+                             :where  [:= :user_id [:inline user-id]]}
+                            {:select [[as-null :card_id]
+                                      :dashboard_id
+                                      [as-null :collection_id]
+                                      [:dashboard_id :item_id]
+                                      [(h2x/literal "dashboard") :type]
+                                      :created_at]
+                             :from   [:dashboard_bookmark]
+                             :where  [:= :user_id [:inline user-id]]}]}
+               :bookmarks]]}))
+
+(defn- recent-views-from-view-log
+  [user-id]
+  (let [bookmarks (bookmarks-query user-id)
+        qe        {:select [[(h2x/literal "qe") :source]
+                            [:executor_id :user_id]
+                            :context
+                            [:started_at :timestamp]
+                            [(h2x/literal "card") :model]
+                            [:card_id :model_id]
+                            [false :dataset]]
+                   :from   :query_execution}
+        vl        {:select    [[(h2x/literal "vl") :source]
+                               :user_id
+                               [(h2x/literal "question") :context]
+                               :timestamp
+                               :model
+                               :model_id
+                               [:report_card.dataset :dataset]]
+                   :from      [:view_log]
+                   :left-join [:report_card
+                               [:and
+                                [:= :view_log.model (h2x/literal "card")]
+                                [:= :view_log.model_id :report_card.id]]]}
+        views     {:union-all [qe vl]}]
+    (t2/query
+     {:select   [[[:max :timestamp] :timestamp]
+                 :model
+                 :model_id]
+      :from     [[views :views]]
+      :where    [[:and
+                  [:= :user_id [:inline user-id]]
+                  [:>= :timestamp (t/minus (t/offset-date-time) (t/days 30))]
+                  [:not= :context (h2x/literal "pulse")]
+                  [:not= :context (h2x/literal "collection")]
+                  [:not= :context (h2x/literal "ad-hoc")]
+                  [:not= [:composite :context :model] [:composite (h2x/literal "dashboard") (h2x/literal "card")]]
+                  [:not= [:composite :source :model :dataset] [:composite (h2x/literal "vl") (h2x/literal "card") [:inline false]]]
+                  [:not-in [:composite :model :model_id] bookmarks]]]
+      :group-by [:model :model_id]
+      :order-by [[:timestamp :desc]]
+      :limit    [:inline 8]})))
+
+(defsetting user-recent-views
+  (deferred-tru "List of the 10 most recently viewed items for the user.")
+  :user-local :only
+  :type :json
+  :getter (fn []
+            (let [value (setting/get-value-of-type :json :user-recent-views)]
+              (if value
+                (vec value)
+                (let [views (mapv #(select-keys % [:model :model_id])
+                                  (recent-views-from-view-log api/*current-user-id*))]
+                  (setting/set-value-of-type! :json :user-recent-views views)
+                  views)))))
+
+;; TODO: remove this setting as part of Audit V2 project.
+(defsetting most-recently-viewed-dashboard
+  (deferred-tru "The Dashboard that the user has most recently viewed within the last 24 hours.")
+  :user-local :only
+  :type :json
+  :getter (fn []
+            (let [{:keys [id timestamp] :as value} (setting/get-value-of-type :json :most-recently-viewed-dashboard)
+                  yesterday                        (t/minus (t/zoned-date-time) (t/hours 24))]
+              ;; If the latest view is older than 24 hours, return 'nil'
+              (when (and value (t/after? (t/zoned-date-time timestamp) yesterday))
+                id)))
+  :setter (fn [id]
+            (when id
+              ;; given a dashboard's ID, save it with a timestamp of 'now', for comparing later in the getter
+              (setting/set-value-of-type! :json :most-recently-viewed-dashboard {:id id :timestamp (t/zoned-date-time)}))))
+
 ;;; ## ---------------------------------------- EVENT PROCESSING ----------------------------------------
 
 (defn- record-view!
@@ -31,20 +133,33 @@
     :model_id model-id
     :metadata metadata))
 
+(defn- update-users-recent-views!
+  [user-id model model-id]
+  (mw.session/with-current-user user-id
+    (let [view        {:model    (name model)
+                       :model_id model-id}
+          prior-views (remove #{view} (user-recent-views))]
+      (when (= model "dashboard") (most-recently-viewed-dashboard! model-id))
+      (when-not ((set prior-views) view)
+        (let [new-views (vec (take 10 (conj prior-views view)))]
+          (user-recent-views! new-views))))))
+
 (defn handle-view-event!
   "Handle processing for a single event notification received on the view-log-channel"
   [event]
   ;; try/catch here to prevent individual topic processing exceptions from bubbling up.  better to handle them here.
   (try
     (when-let [{topic :topic object :item} event]
-      (record-view!
-        (events/topic->model topic)
-        (events/object->model-id topic object)
-        (events/object->user-id object)
-        (events/object->metadata object)))
+      (let [model                          (events/topic->model topic)
+            model-id                       (events/object->model-id topic object)
+            user-id                        (events/object->user-id object)
+            {:keys [context] :as metadata} (events/object->metadata object)]
+        (when (and (#{:card-query :dashboard-read :table-read} topic)
+                   ((complement #{:collection :dashboard}) context)) ;; we don't want to count pinned card views
+          (update-users-recent-views! user-id model model-id))
+        (record-view! model model-id user-id metadata)))
     (catch Throwable e
       (log/warn (format "Failed to process activity event. %s" (:topic event)) e))))
-
 
 ;;; ## ---------------------------------------- LIFECYLE ----------------------------------------
 

--- a/src/metabase/events/view_log.clj
+++ b/src/metabase/events/view_log.clj
@@ -4,6 +4,7 @@
    [java-time :as t]
    [metabase.api.common :as api]
    [metabase.db.connection :as mdb.connection]
+   [metabase.db.query :as mdb.query]
    [metabase.events :as events]
    [metabase.models.setting :as setting :refer [defsetting]]
    [metabase.models.view-log :refer [ViewLog]]
@@ -74,7 +75,7 @@
                                 [:= :view_log.model (h2x/literal "card")]
                                 [:= :view_log.model_id :report_card.id]]]}
         views     {:union-all [qe vl]}]
-    (db/query
+    (mdb.query/query
      {:select   [[[:max :timestamp] :timestamp]
                  :model
                  :model_id]

--- a/src/metabase/query_processor/middleware/process_userland_query.clj
+++ b/src/metabase/query_processor/middleware/process_userland_query.clj
@@ -94,6 +94,7 @@
          (events/publish-event! :card-query {:card_id      (:card_id execution-info)
                                              :actor_id     (:executor_id execution-info)
                                              :cached       (:cached acc)
+                                             :context      (:context execution-info)
                                              :ignore_cache (get-in execution-info [:json_query :middleware :ignore-cached-results?])}))
        (save-successful-query-execution! (:cached acc) execution-info @row-count)
        (rf (if (map? acc)

--- a/src/metabase/server/handler.clj
+++ b/src/metabase/server/handler.clj
@@ -23,11 +23,7 @@
 (extend-protocol ring.protocols/StreamableResponseBody
   ;; java.lang.Double, java.lang.Long, and java.lang.Boolean will be given a Content-Type of "application/json; charset=utf-8"
   ;; so they should be strings, and will be parsed into their respective values.
-  java.lang.Double
-  (write-body-to-stream [num response output-stream]
-    (ring.protocols/write-body-to-stream (str num) response output-stream))
-
-  java.lang.Long
+  java.lang.Number
   (write-body-to-stream [num response output-stream]
     (ring.protocols/write-body-to-stream (str num) response output-stream))
 

--- a/test/metabase/api/activity_test.clj
+++ b/test/metabase/api/activity_test.clj
@@ -3,6 +3,7 @@
   (:require
    [clojure.test :refer :all]
    [java-time :as t]
+   [metabase.events.view-log :as view-log]
    [metabase.models.card :refer [Card]]
    [metabase.models.dashboard :refer [Dashboard]]
    [metabase.models.query-execution :refer [QueryExecution]]
@@ -16,35 +17,6 @@
 (set! *warn-on-reflection* true)
 
 (use-fixtures :once (fixtures/initialize :db))
-
-;;; GET /recent_views
-
-;; Things we are testing for:
-;;  1. ordering is sorted by most recent
-;;  2. results are filtered to current user
-;;  3. `:model_object` is hydrated in each result
-;;  4. we filter out entries where `:model_object` is nil (object doesn't exist)
-
-(defn- create-views!
-  "Insert views [user-id model model-id]. Views are entered a second apart with last view as most recent."
-  [views]
-  (let [start-time (t/offset-date-time)
-        views (->> (map (fn [[user model model-id] seconds-ago]
-                          (case model
-                            "card" {:executor_id user :card_id model-id
-                                    :context :question
-                                    :hash (qp.util/query-hash {})
-                                    :running_time 1
-                                    :result_rows 1
-                                    :native false
-                                    :started_at (t/plus start-time (t/seconds (- seconds-ago)))}
-                            {:user_id user, :model model, :model_id model-id
-                             :timestamp (t/plus start-time (t/seconds (- seconds-ago)))}))
-                        (reverse views)
-                        (range))
-                   (group-by #(if (:card_id %) :card :other)))]
-    (db/insert-many! ViewLog (:other views))
-    (db/insert-many! QueryExecution (:card views))))
 
 (deftest recent-views-test
   (mt/with-temp* [Card      [card1 {:name                   "rand-name"
@@ -67,22 +39,62 @@
                                       :creator_id             (mt/user->id :crowberto)
                                       :display                "table"
                                       :visualization_settings {}}]]
-    (mt/with-model-cleanup [ViewLog QueryExecution]
-      (create-views! [[(mt/user->id :crowberto) "card"      (:id dataset)]
-                      [(mt/user->id :crowberto) "card"      (:id card1)]
-                      [(mt/user->id :crowberto) "card"      36478]
-                      [(mt/user->id :crowberto) "dashboard" (:id dash)]
-                      [(mt/user->id :crowberto) "table"     (:id table1)]
-                      ;; most recent for crowberto are archived card and hidden table
-                      [(mt/user->id :crowberto) "card"      (:id archived)]
-                      [(mt/user->id :crowberto) "table"     (:id hidden-table)]
-                      [(mt/user->id :rasta)     "card"      (:id card1)]])
-      (let [recent-views (mt/user-http-request :crowberto :get 200 "activity/recent_views")]
-        (is (partial= [{:model "table"     :model_id (:id table1)}
-                       {:model "dashboard" :model_id (:id dash)}
-                       {:model "card"      :model_id (:id card1)}
-                       {:model "dataset"   :model_id (:id dataset)}]
-                      recent-views))))))
+    (testing "recent_views endpoint shows the current user's recently viewed items."
+      (mt/with-model-cleanup [ViewLog]
+        (mt/with-test-user :crowberto
+          (mt/with-temporary-setting-values [user-recent-views []]
+            (doseq [event [{:topic :card-query :item dataset}
+                           {:topic :card-query :item dataset}
+                           {:topic :card-query :item card1}
+                           {:topic :card-query :item card1}
+                           {:topic :card-query :item card1}
+                           {:topic :dashboard-read :item dash}
+                           {:topic :card-query :item card1}
+                           {:topic :dashboard-read :item dash}
+                           {:topic :table-read :item table1}
+                           {:topic :card-query :item archived}
+                           {:topic :table-read :item hidden-table}]]
+              (view-log/handle-view-event!
+               ;; view log entries look for the `:actor_id` in the item being viewed to set that view's :user_id
+               (assoc-in event [:item :actor_id] (mt/user->id :crowberto))))
+            (testing "No duplicates or archived items are returned."
+              (let [recent-views (mt/user-http-request :crowberto :get 200 "activity/recent_views")]
+                (is (partial=
+                     [{:model "table" :model_id (u/the-id table1)}
+                      {:model "dashboard" :model_id (u/the-id dash)}
+                      {:model "card" :model_id (u/the-id card1)}
+                      {:model "dataset" :model_id (u/the-id dataset)}]
+                     recent-views))))))
+        (mt/with-test-user :rasta
+          (mt/with-temporary-setting-values [user-recent-views []]
+            (view-log/handle-view-event! {:topic :card-query :item (assoc dataset :actor_id (mt/user->id :rasta))})
+            (view-log/handle-view-event! {:topic :card-query :item (assoc card1 :actor_id (mt/user->id :crowberto))})
+            (testing "Only the user's own views are returned."
+              (let [recent-views (mt/user-http-request :rasta :get 200 "activity/recent_views")]
+                (is (partial=
+                     [{:model "dataset" :model_id (u/the-id dataset)}]
+                     (reverse recent-views)))))))))))
+
+(defn- create-views!
+  "Insert views [user-id model model-id]. Views are entered a second apart with last view as most recent."
+  [views]
+  (let [start-time (t/offset-date-time)
+        views (->> (map (fn [[user model model-id] seconds-ago]
+                          (case model
+                            "card" {:executor_id user :card_id model-id
+                                    :context :question
+                                    :hash (qp.util/query-hash {})
+                                    :running_time 1
+                                    :result_rows 1
+                                    :native false
+                                    :started_at (t/plus start-time (t/seconds (- seconds-ago)))}
+                            {:user_id user, :model model, :model_id model-id
+                             :timestamp (t/plus start-time (t/seconds (- seconds-ago)))}))
+                        (reverse views)
+                        (range))
+                   (group-by #(if (:card_id %) :card :other)))]
+    (db/insert! ViewLog (:other views))
+    (db/insert! QueryExecution (:card views))))
 
 (deftest popular-items-test
   (mt/with-temp* [Card      [card1 {:name                   "rand-name"

--- a/test/metabase/api/activity_test.clj
+++ b/test/metabase/api/activity_test.clj
@@ -12,6 +12,7 @@
    [metabase.query-processor.util :as qp.util]
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]
+   [metabase.util :as u]
    [toucan.db :as db]))
 
 (set! *warn-on-reflection* true)

--- a/test/metabase/events/view_log_test.clj
+++ b/test/metabase/events/view_log_test.clj
@@ -1,9 +1,12 @@
 (ns metabase.events.view-log-test
   (:require
    [clojure.test :refer :all]
+   [java-time :as t]
    [metabase.events.view-log :as view-log]
    [metabase.models :refer [Card Dashboard Table User ViewLog]]
+   [metabase.models.setting :as setting]
    [metabase.test :as mt]
+   [metabase.util :as u]
    [toucan.db :as db]))
 
 (deftest card-create-test
@@ -38,7 +41,7 @@
     (is (= {:user_id  (:id user)
             :model    "card"
             :model_id (:id card)
-            :metadata {:cached false :ignore_cache true}}
+            :metadata {:cached false :ignore_cache true :context nil}}
            (mt/derecordize
             (db/select-one [ViewLog :user_id :model :model_id :metadata], :user_id (:id user)))))))
 
@@ -64,3 +67,68 @@
             :model_id (:id dashboard)}
            (mt/derecordize
             (db/select-one [ViewLog :user_id :model :model_id], :user_id (:id user)))))))
+
+(deftest user-recent-views-test
+  (mt/with-temp* [Card      [card1 {:name                   "rand-name"
+                                    :creator_id             (mt/user->id :crowberto)
+                                    :display                "table"
+                                    :visualization_settings {}}]
+                  Card      [archived  {:name                   "archived-card"
+                                        :creator_id             (mt/user->id :crowberto)
+                                        :display                "table"
+                                        :archived               true
+                                        :visualization_settings {}}]
+                  Dashboard [dash {:name        "rand-name2"
+                                   :description "rand-name2"
+                                   :creator_id  (mt/user->id :crowberto)}]
+                  Table     [table1 {:name "rand-name"}]
+                  Table     [hidden-table {:name            "hidden table"
+                                           :visibility_type "hidden"}]
+                  Card      [dataset {:name                   "rand-name"
+                                      :dataset                true
+                                      :creator_id             (mt/user->id :crowberto)
+                                      :display                "table"
+                                      :visualization_settings {}}]]
+    (mt/with-model-cleanup [ViewLog]
+      (testing "User's recent views are updated when card/dashboard/table-read events occur."
+        (mt/with-test-user :crowberto
+          (view-log/user-recent-views! []) ;; ensure no views from any other tests/temp items exist
+          (doseq [event [{:topic :card-query :item dataset} ;; oldest view
+                         {:topic :card-query :item dataset}
+                         {:topic :card-query :item card1}
+                         {:topic :card-query :item card1}
+                         {:topic :card-query :item card1}
+                         {:topic :dashboard-read :item dash}
+                         {:topic :card-query :item card1}
+                         {:topic :dashboard-read :item dash}
+                         {:topic :table-read :item table1}
+                         {:topic :card-query :item archived}
+                         {:topic :table-read :item hidden-table}]]
+            (view-log/handle-view-event!
+             ;; view log entries look for the `:actor_id` in the item being viewed to set that view's :user_id
+             (assoc-in event [:item :actor_id] (mt/user->id :crowberto))))
+          (let [recent-views (mt/with-test-user :crowberto (view-log/user-recent-views))]
+            (is (=
+                 [{:model "table" :model_id (u/the-id hidden-table)}
+                  {:model "card" :model_id (u/the-id archived)}
+                  {:model "table" :model_id (u/the-id table1)}
+                  {:model "dashboard" :model_id (u/the-id dash)}
+                  {:model "card" :model_id (u/the-id card1)}
+                  {:model "card" :model_id (u/the-id dataset)}]
+                 recent-views))))))))
+
+(deftest most-recently-viewed-dashboard-test
+  (mt/with-temp Dashboard [dash {:name "Look at this Distinguished Dashboard!"}]
+    (mt/with-model-cleanup [ViewLog]
+      (testing "When a user views a dashboard, most-recently-viewed-dashboard is updated with that id."
+        (mt/with-test-user :crowberto (setting/set-value-of-type! :json :most-recently-viewed-dashboard nil))
+        (view-log/handle-view-event! {:topic :dashboard-read
+                                      :metadata {:context "question"}
+                                      :item  (assoc dash :actor_id (mt/user->id :crowberto))})
+        (is (= (u/the-id dash) (mt/with-test-user :crowberto (view-log/most-recently-viewed-dashboard)))))
+      (testing "When the user's most recent dashboard view is older than 24 hours, return `nil`."
+        (mt/with-test-user :crowberto
+          (setting/set-value-of-type! :json :most-recently-viewed-dashboard
+                                      {:id        (u/the-id dash)
+                                       :timestamp (t/minus (t/zoned-date-time) (t/hours 25))}))
+        (is (= nil (mt/with-test-user :crowberto (view-log/most-recently-viewed-dashboard))))))))


### PR DESCRIPTION
Manual backport of https://github.com/metabase/metabase/pull/29631/ to 46 so that it can be included in the next minor release. Adam was the original developer of this and he's currently out, but I don't remember there being specific blockers to backporting.