### PR TITLE
Fix not able to Enable/Disable Actions when Choose when syncs and scans happen is Enabled

### DIFF
--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -902,6 +902,11 @@
                                    :caveats            caveats
                                    :points_of_interest points_of_interest
                                    :auto_run_queries   auto_run_queries}
+                                  ;; upsert settings with a PATCH-style update. `nil` key means unset the Setting.
+                                  (when (seq settings)
+                                    {:settings (into {}
+                                                     (remove (fn [[_k v]] (nil? v)))
+                                                     (merge (:settings existing-database) settings))})
                                   (cond
                                     ;; transition back to metabase managed schedules. the schedule
                                     ;; details, even if provided, are ignored. database is the
@@ -912,15 +917,7 @@
 
                                     ;; if user is controlling schedules
                                     (:let-user-control-scheduling details)
-                                    (sync.schedules/schedule-map->cron-strings (sync.schedules/scheduling schedules))
-
-                                    ;; upsert settings with a PATCH-style update. `nil` key means unset
-                                    ;; the Setting.
-                                    (seq settings)
-                                    {:settings (into {}
-                                                     (remove (fn [[_k v]] (nil? v)))
-                                                     (merge (:settings existing-database)
-                                                            settings))})))
+                                    (sync.schedules/schedule-map->cron-strings (sync.schedules/scheduling schedules)))))
         ;; do nothing in the case that user is not in control of
         ;; scheduling. leave them as they are in the db
 

--- a/test/metabase/api/database_test.clj
+++ b/test/metabase/api/database_test.clj
@@ -371,16 +371,16 @@
 
 (deftest enable-model-actions-with-user-controlled-scheduling-test
   (testing "Should be able to enable/disable actions for a database with user-controlled scheduling (metabase#30699)"
-    (mt/with-temp Database [_ {:details  {:let-user-control-scheduling true}
-                               :settings {:database-enable-actions true}}]
+    (mt/with-temp Database [{db-id :id} {:details  {:let-user-control-scheduling true}
+                                         :settings {:database-enable-actions true}}]
       (is (false? (get-in (mt/user-http-request :crowberto
                                                 :put 200
-                                                (format "database/%s" 1)
+                                                (format "database/%s" db-id)
                                                 {:settings {:database-enable-actions false}})
                           [:settings :database-enable-actions])))
       (is (true? (get-in (mt/user-http-request :crowberto
                                                :put 200
-                                               (format "database/%s" 1)
+                                               (format "database/%s" db-id)
                                                {:settings {:database-enable-actions true}})
                          [:settings :database-enable-actions]))))))
 

--- a/test/metabase/api/database_test.clj
+++ b/test/metabase/api/database_test.clj
@@ -369,6 +369,21 @@
             (let [curr-db (t2/select-one [Database :cache_ttl], :id db-id)]
               (is (= nil (:cache_ttl curr-db))))))))))
 
+(deftest enable-model-actions-with-user-controlled-scheduling-test
+  (testing "Should be able to enable/disable actions for a database with user-controlled scheduling (metabase#30699)"
+    (mt/with-temp Database [_ {:details  {:let-user-control-scheduling true}
+                               :settings {:database-enable-actions true}}]
+      (is (false? (get-in (mt/user-http-request :crowberto
+                                                :put 200
+                                                (format "database/%s" 1)
+                                                {:settings {:database-enable-actions false}})
+                          [:settings :database-enable-actions])))
+      (is (true? (get-in (mt/user-http-request :crowberto
+                                               :put 200
+                                               (format "database/%s" 1)
+                                               {:settings {:database-enable-actions true}})
+                         [:settings :database-enable-actions]))))))
+
 (deftest fetch-database-metadata-test
   (testing "GET /api/database/:id/metadata"
     (is (= (merge (dissoc (mt/object-defaults Database) :details)


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/30699