### PR TITLE
Fetch field icon from dimension instead of semantic_type (#28622)

### DIFF
--- a/frontend/src/metabase/query_builder/components/dataref/FieldList.tsx
+++ b/frontend/src/metabase/query_builder/components/dataref/FieldList.tsx
@@ -28,11 +28,12 @@ const FieldList = ({ fields, onFieldClick }: FieldListProps) => (
       </NodeListTitleText>
     </NodeListTitle>
     {fields.map(field => {
-      const tooltip = field.semantic_type ? null : t`Unknown type`;
+      const iconName = field.icon();
+      const tooltip = iconName === "unknown" ? t`Unknown type` : null;
       return (
         <li key={field.getUniqueId()}>
           <NodeListItemLink onClick={() => onFieldClick(field)}>
-            <NodeListItemIcon name={field.icon()} tooltip={tooltip} />
+            <NodeListItemIcon name={iconName} tooltip={tooltip} />
             <NodeListItemName>{field.name}</NodeListItemName>
           </NodeListItemLink>
         </li>

--- a/frontend/src/metabase/query_builder/components/dataref/FieldList.tsx
+++ b/frontend/src/metabase/query_builder/components/dataref/FieldList.tsx
@@ -1,5 +1,4 @@
 import { t, ngettext, msgid } from "ttag";
-import { getSemanticTypeIcon } from "metabase/lib/schema_metadata";
 import Field from "metabase-lib/metadata/Field";
 import {
   NodeListItemLink,
@@ -34,7 +33,7 @@ const FieldList = ({ fields, onFieldClick }: FieldListProps) => (
         <li key={field.getUniqueId()}>
           <NodeListItemLink onClick={() => onFieldClick(field)}>
             <NodeListItemIcon
-              name={getSemanticTypeIcon(field.semantic_type, "warning")}
+              name={field.dimension().icon()}
               tooltip={tooltip}
             />
             <NodeListItemName>{field.name}</NodeListItemName>

--- a/frontend/src/metabase/query_builder/components/dataref/FieldList.tsx
+++ b/frontend/src/metabase/query_builder/components/dataref/FieldList.tsx
@@ -32,10 +32,7 @@ const FieldList = ({ fields, onFieldClick }: FieldListProps) => (
       return (
         <li key={field.getUniqueId()}>
           <NodeListItemLink onClick={() => onFieldClick(field)}>
-            <NodeListItemIcon
-              name={field.dimension().icon()}
-              tooltip={tooltip}
-            />
+            <NodeListItemIcon name={field.icon()} tooltip={tooltip} />
             <NodeListItemName>{field.name}</NodeListItemName>
           </NodeListItemLink>
         </li>


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/28622

### Description

Use `field.dimension().icon()` instead of `field.semantic_type`

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Click on New -> Notebook -> Accounts
2. Verify Boolean and other icons are correct 

### Demo

![image](https://github.com/metabase/metabase/assets/23547158/257e3676-fe33-434b-8c3b-35c803e6c175)


### Checklist

- [ ] Tests have been added/updated to cover changes in this PR

### Notes
- Ive neglected to write unit test for this given that the preexisting components `TablePane` et al dont have any unit tests
- Also, potentially there are other components which use `getSemanticType` which would require analysis
