### PR TITLE
Merge Track disabling auto-apply filters in Snowplow to master #30796

### DIFF
--- a/frontend/src/metabase/dashboard/actions/parameters.js
+++ b/frontend/src/metabase/dashboard/actions/parameters.js
@@ -26,6 +26,7 @@ import {
 } from "../selectors";
 
 import { isVirtualDashCard } from "../utils";
+import { trackAutoApplyFiltersDisabled } from "../analytics";
 
 import { setDashboardAttributes, setDashCardAttributes } from "./core";
 import { setSidebar, closeSidebar } from "./ui";
@@ -334,13 +335,18 @@ export const toggleAutoApplyFilters = createThunkAction(
   isEnabled => (dispatch, getState) => {
     const dashboardId = getDashboardId(getState());
 
-    dispatch(
-      setDashboardAttributes({
-        id: dashboardId,
-        attributes: { auto_apply_filters: isEnabled },
-      }),
-    );
-    dispatch(saveDashboardAndCards(true));
+    if (dashboardId) {
+      dispatch(
+        setDashboardAttributes({
+          id: dashboardId,
+          attributes: { auto_apply_filters: isEnabled },
+        }),
+      );
+      dispatch(saveDashboardAndCards(true));
+      if (!isEnabled) {
+        trackAutoApplyFiltersDisabled(dashboardId);
+      }
+    }
   },
 );
 

--- a/frontend/src/metabase/dashboard/analytics.ts
+++ b/frontend/src/metabase/dashboard/analytics.ts
@@ -1,0 +1,8 @@
+import { trackSchemaEvent } from "metabase/lib/analytics";
+
+export const trackAutoApplyFiltersDisabled = (dashboardId: number) => {
+  trackSchemaEvent("dashboard", "1-0-1", {
+    event: "auto_apply_filters_disabled",
+    dashboard_id: dashboardId,
+  });
+};

--- a/frontend/src/metabase/dashboard/analytics.ts
+++ b/frontend/src/metabase/dashboard/analytics.ts
@@ -1,6 +1,7 @@
 import { trackSchemaEvent } from "metabase/lib/analytics";
+import type { DashboardId } from "metabase-types/api";
 
-export const trackAutoApplyFiltersDisabled = (dashboardId: number) => {
+export const trackAutoApplyFiltersDisabled = (dashboardId: DashboardId) => {
   trackSchemaEvent("dashboard", "1-0-1", {
     event: "auto_apply_filters_disabled",
     dashboard_id: dashboardId,

--- a/frontend/src/metabase/dashboard/components/DashboardInfoSidebar.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardInfoSidebar.tsx
@@ -15,11 +15,15 @@ import Revision from "metabase/entities/revisions";
 import { getRevisionEventsForTimeline } from "metabase/lib/revisions";
 import { getUser } from "metabase/selectors/user";
 
-import { revertToRevision } from "metabase/dashboard/actions";
+import {
+  revertToRevision,
+  toggleAutoApplyFilters,
+} from "metabase/dashboard/actions";
 
 import Toggle from "metabase/core/components/Toggle";
 import FormField from "metabase/core/components/FormField";
 import { useUniqueId } from "metabase/hooks/use-unique-id";
+import { useDispatch } from "metabase/lib/redux";
 import {
   DashboardInfoSidebarRoot,
   HistoryHeader,
@@ -67,12 +71,12 @@ const DashboardInfoSidebar = ({
     [saveDashboardAndCards, setDashboardAttribute],
   );
 
+  const dispatch = useDispatch();
   const handleToggleAutoApplyFilters = useCallback(
     (isAutoApplyingFilters: boolean) => {
-      setDashboardAttribute("auto_apply_filters", isAutoApplyingFilters);
-      saveDashboardAndCards(true);
+      dispatch(toggleAutoApplyFilters(isAutoApplyingFilters));
     },
-    [saveDashboardAndCards, setDashboardAttribute],
+    [dispatch],
   );
 
   const events = useMemo(

--- a/snowplow/iglu-client-embedded/schemas/com.metabase/dashboard/jsonschema/1-0-1
+++ b/snowplow/iglu-client-embedded/schemas/com.metabase/dashboard/jsonschema/1-0-1
@@ -1,0 +1,43 @@
+{
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "description": "Dashboard events",
+  "self": {
+    "vendor": "com.metabase",
+    "name": "dashboard",
+    "format": "jsonschema",
+    "version": "1-0-0"
+  },
+  "type": "object",
+  "properties": {
+    "event": {
+      "description": "Event name",
+      "type": "string",
+      "enum": [
+        "dashboard_created",
+        "question_added_to_dashboard",
+        "auto_apply_filters_disabled"
+      ],
+      "maxLength": 1024
+    },
+    "dashboard_id": {
+      "description": "Unique identifier for a dashboard within the Metabase instance",
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 2147483647
+    },
+    "question_id": {
+      "description": "Unique identifier for a question added to a dashboard",
+      "type": [
+        "integer",
+        "null"
+      ],
+      "minimum": 0,
+      "maximum": 2147483647
+    }
+  },
+  "required": [
+    "event",
+    "dashboard_id"
+  ],
+  "additionalProperties": true
+}


### PR DESCRIPTION
> **Note**
> This PR is merging the integration branch `30796-track-disabling-auto-apply-filters-in-snowplow` into `master`


Epic: #30796
Tracking reference: https://www.notion.so/metabase/Auto-apply-filters-disabled-56d9cf1c39cc459c84025fbd9fa5ba32

### Description

Track when users disable auto-apply filters in a dashboard

### How to verify
1. Follow [these steps](https://www.notion.so/metabase/Snowplow-integration-5da1f874beda4153b4fccfa6c1e77caa) to setup Snowplow micro locally
1. Open a dashboard with questions and filters mapped to them.
1. Open the info sidebar -> Toggle off "Auto-apply filters".
1. Change filters. The button to apply the changes should appear.
1. Click the button. Only then the dashboard should be reloaded with new filter values.
1. Visit http://localhost:9090/micro/good to see if the event is there


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
