### PR TITLE
FE: Adjust FormField to be able to display checkbox with the label nice

### DIFF
--- a/frontend/src/metabase/actions/components/ActionForm/ActionForm.tsx
+++ b/frontend/src/metabase/actions/components/ActionForm/ActionForm.tsx
@@ -22,8 +22,7 @@ import type {
   WritebackAction,
 } from "metabase-types/api";
 
-import ActionFormFieldWidget from "../ActionFormFieldWidget";
-
+import { ActionFormFieldWidget } from "../ActionFormFieldWidget";
 import { ActionFormButtonContainer } from "./ActionForm.styled";
 
 interface ActionFormProps {

--- a/frontend/src/metabase/actions/components/ActionFormFieldWidget/ActionFormFieldWidget.tsx
+++ b/frontend/src/metabase/actions/components/ActionFormFieldWidget/ActionFormFieldWidget.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from "react";
+import React, { forwardRef, useState } from "react";
 
 import FormInputWidget from "metabase/core/components/FormInput";
 import FormTextAreaWidget from "metabase/core/components/FormTextArea";
@@ -8,6 +8,7 @@ import FormRadioWidget, {
 import FormSelectWidget from "metabase/core/components/FormSelect";
 import FormNumericInputWidget from "metabase/core/components/FormNumericInput";
 import FormBooleanWidget from "metabase/core/components/FormToggle";
+import CheckBox from "metabase/core/components/CheckBox";
 
 import type { InputComponentType } from "metabase-types/api";
 import type { ActionFormFieldProps } from "metabase/actions/types";
@@ -32,16 +33,24 @@ interface FormWidgetProps {
   formField: ActionFormFieldProps;
 }
 
-const ActionFormFieldWidget = forwardRef(function FormFieldWidget(
+export const ActionFormFieldWidget = forwardRef(function FormFieldWidget(
   { formField }: FormWidgetProps,
   ref: React.Ref<any>,
 ) {
+  const [hidden, setHidden] = useState(false);
   const Widget =
     (formField.type ? WIDGETS[formField.type] : FormInputWidget) ??
     FormInputWidget;
 
-  return <Widget {...formField} nullable ref={ref} />;
-});
+  const titleActions = (
+    <CheckBox
+      checked={!hidden}
+      label="Show Field"
+      onChange={() => setHidden(checked => !checked)}
+    />
+  );
 
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export default ActionFormFieldWidget;
+  return (
+    <Widget {...formField} titleActions={titleActions} nullable ref={ref} />
+  );
+});

--- a/frontend/src/metabase/actions/components/ActionFormFieldWidget/ActionFormFieldWidget.tsx
+++ b/frontend/src/metabase/actions/components/ActionFormFieldWidget/ActionFormFieldWidget.tsx
@@ -32,7 +32,7 @@ interface FormWidgetProps {
   formField: ActionFormFieldProps;
 }
 
-const ActionFormFieldWidget = forwardRef(function FormFieldWidget(
+export const ActionFormFieldWidget = forwardRef(function FormFieldWidget(
   { formField }: FormWidgetProps,
   ref: React.Ref<any>,
 ) {
@@ -42,6 +42,3 @@ const ActionFormFieldWidget = forwardRef(function FormFieldWidget(
 
   return <Widget {...formField} nullable ref={ref} />;
 });
-
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export default ActionFormFieldWidget;

--- a/frontend/src/metabase/actions/components/ActionFormFieldWidget/ActionFormFieldWidget.tsx
+++ b/frontend/src/metabase/actions/components/ActionFormFieldWidget/ActionFormFieldWidget.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useState } from "react";
+import React, { forwardRef } from "react";
 
 import FormInputWidget from "metabase/core/components/FormInput";
 import FormTextAreaWidget from "metabase/core/components/FormTextArea";
@@ -8,7 +8,6 @@ import FormRadioWidget, {
 import FormSelectWidget from "metabase/core/components/FormSelect";
 import FormNumericInputWidget from "metabase/core/components/FormNumericInput";
 import FormBooleanWidget from "metabase/core/components/FormToggle";
-import CheckBox from "metabase/core/components/CheckBox";
 
 import type { InputComponentType } from "metabase-types/api";
 import type { ActionFormFieldProps } from "metabase/actions/types";
@@ -33,24 +32,16 @@ interface FormWidgetProps {
   formField: ActionFormFieldProps;
 }
 
-export const ActionFormFieldWidget = forwardRef(function FormFieldWidget(
+const ActionFormFieldWidget = forwardRef(function FormFieldWidget(
   { formField }: FormWidgetProps,
   ref: React.Ref<any>,
 ) {
-  const [hidden, setHidden] = useState(false);
   const Widget =
     (formField.type ? WIDGETS[formField.type] : FormInputWidget) ??
     FormInputWidget;
 
-  const titleActions = (
-    <CheckBox
-      checked={!hidden}
-      label="Show Field"
-      onChange={() => setHidden(checked => !checked)}
-    />
-  );
-
-  return (
-    <Widget {...formField} titleActions={titleActions} nullable ref={ref} />
-  );
+  return <Widget {...formField} nullable ref={ref} />;
 });
+
+// eslint-disable-next-line import/no-default-export -- deprecated usage
+export default ActionFormFieldWidget;

--- a/frontend/src/metabase/actions/components/ActionFormFieldWidget/index.ts
+++ b/frontend/src/metabase/actions/components/ActionFormFieldWidget/index.ts
@@ -1,2 +1,1 @@
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export { default } from "./ActionFormFieldWidget";
+export { ActionFormFieldWidget } from "./ActionFormFieldWidget";

--- a/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/FormFieldEditor/FormFieldEditor.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/FormFieldEditor/FormFieldEditor.tsx
@@ -4,7 +4,7 @@ import { t } from "ttag";
 import Radio from "metabase/core/components/Radio";
 import { isNotNull } from "metabase/core/utils/types";
 
-import ActionFormFieldWidget from "metabase/actions/components/ActionFormFieldWidget";
+import { ActionFormFieldWidget } from "metabase/actions/components/ActionFormFieldWidget";
 import { getFieldTypes, getInputTypes } from "metabase/actions/constants";
 import { inputTypeHasOptions } from "metabase/actions/utils";
 

--- a/frontend/src/metabase/core/components/FormField/FormField.styled.tsx
+++ b/frontend/src/metabase/core/components/FormField/FormField.styled.tsx
@@ -102,3 +102,10 @@ export const FieldRoot = styled.div<FieldRootProps>`
     }
   }
 `;
+
+export const FieldTitleActions = styled.div`
+  margin-left: auto;
+  font-size: 0.77rem;
+  font-weight: 900;
+  color: ${color("text-medium")};
+`;

--- a/frontend/src/metabase/core/components/FormField/FormField.tsx
+++ b/frontend/src/metabase/core/components/FormField/FormField.tsx
@@ -17,7 +17,7 @@ import {
 
 export interface FormFieldProps extends HTMLAttributes<HTMLDivElement> {
   title?: string;
-  titleActions?: ReactNode;
+  actions?: ReactNode;
   description?: ReactNode;
   alignment?: FieldAlignment;
   orientation?: FieldOrientation;
@@ -31,7 +31,7 @@ export interface FormFieldProps extends HTMLAttributes<HTMLDivElement> {
 const FormField = forwardRef(function FormField(
   {
     title,
-    titleActions,
+    actions,
     description,
     alignment = "end",
     orientation = "vertical",
@@ -85,9 +85,7 @@ const FormField = forwardRef(function FormField(
                 )}
               </Tooltip>
             )}
-            {titleActions && (
-              <FieldTitleActions>{titleActions}</FieldTitleActions>
-            )}
+            {actions && <FieldTitleActions>{actions}</FieldTitleActions>}
           </FieldLabelContainer>
           {description && <FieldDescription>{description}</FieldDescription>}
         </FieldCaption>

--- a/frontend/src/metabase/core/components/FormField/FormField.tsx
+++ b/frontend/src/metabase/core/components/FormField/FormField.tsx
@@ -12,10 +12,12 @@ import {
   FieldLabelError,
   FieldRoot,
   OptionalTag,
+  FieldTitleActions,
 } from "./FormField.styled";
 
 export interface FormFieldProps extends HTMLAttributes<HTMLDivElement> {
   title?: string;
+  titleActions?: ReactNode;
   description?: ReactNode;
   alignment?: FieldAlignment;
   orientation?: FieldOrientation;
@@ -29,6 +31,7 @@ export interface FormFieldProps extends HTMLAttributes<HTMLDivElement> {
 const FormField = forwardRef(function FormField(
   {
     title,
+    titleActions,
     description,
     alignment = "end",
     orientation = "vertical",
@@ -81,6 +84,9 @@ const FormField = forwardRef(function FormField(
                   <FieldInfoIcon name="info" />
                 )}
               </Tooltip>
+            )}
+            {titleActions && (
+              <FieldTitleActions>{titleActions}</FieldTitleActions>
             )}
           </FieldLabelContainer>
           {description && <FieldDescription>{description}</FieldDescription>}

--- a/frontend/src/metabase/core/components/FormInput/FormInput.stories.tsx
+++ b/frontend/src/metabase/core/components/FormInput/FormInput.stories.tsx
@@ -21,7 +21,7 @@ export default {
   title: "Core/FormInput",
   component: FormInput,
   argTypes: {
-    titleActions: {
+    actions: {
       mapping: {
         Default: <TitleActions />,
       },
@@ -58,5 +58,5 @@ WithTitleAndActions.args = {
   title: "Title",
   description: "Description",
   optional: true,
-  titleActions: "Default",
+  actions: "Default",
 };

--- a/frontend/src/metabase/core/components/FormInput/FormInput.stories.tsx
+++ b/frontend/src/metabase/core/components/FormInput/FormInput.stories.tsx
@@ -1,13 +1,32 @@
-import React from "react";
+import React, { useState } from "react";
 import type { ComponentStory } from "@storybook/react";
 import Form from "../Form";
 import FormProvider from "../FormProvider";
+import CheckBox from "../CheckBox";
 import FormInput from "./FormInput";
+
+const TitleActions = () => {
+  const [checked, setChecked] = useState(true);
+  return (
+    <CheckBox
+      onChange={() => setChecked(checked => !checked)}
+      checked={checked}
+      label="Show field"
+    />
+  );
+};
 
 // eslint-disable-next-line import/no-default-export -- deprecated usage
 export default {
   title: "Core/FormInput",
   component: FormInput,
+  argTypes: {
+    titleActions: {
+      mapping: {
+        Default: <TitleActions />,
+      },
+    },
+  },
 };
 
 const Template: ComponentStory<typeof FormInput> = args => {
@@ -32,4 +51,12 @@ export const WithDescription = Template.bind({});
 WithDescription.args = {
   title: "Title",
   description: "Description",
+};
+
+export const WithTitleAndActions = Template.bind({});
+WithTitleAndActions.args = {
+  title: "Title",
+  description: "Description",
+  optional: true,
+  titleActions: "Default",
 };

--- a/frontend/src/metabase/core/components/FormInput/FormInput.tsx
+++ b/frontend/src/metabase/core/components/FormInput/FormInput.tsx
@@ -17,7 +17,7 @@ export interface FormInputProps
   > {
   name: string;
   title?: string;
-  titleActions?: ReactNode;
+  actions?: ReactNode;
   description?: ReactNode;
   nullable?: boolean;
   optional?: boolean;
@@ -29,7 +29,7 @@ const FormInput = forwardRef(function FormInput(
     className,
     style,
     title,
-    titleActions,
+    actions,
     description,
     nullable,
     optional,
@@ -53,7 +53,7 @@ const FormInput = forwardRef(function FormInput(
       className={className}
       style={style}
       title={title}
-      titleActions={titleActions}
+      actions={actions}
       description={description}
       htmlFor={id}
       error={touched ? error : undefined}

--- a/frontend/src/metabase/core/components/FormInput/FormInput.tsx
+++ b/frontend/src/metabase/core/components/FormInput/FormInput.tsx
@@ -17,6 +17,7 @@ export interface FormInputProps
   > {
   name: string;
   title?: string;
+  titleActions?: ReactNode;
   description?: ReactNode;
   nullable?: boolean;
   optional?: boolean;
@@ -28,6 +29,7 @@ const FormInput = forwardRef(function FormInput(
     className,
     style,
     title,
+    titleActions,
     description,
     nullable,
     optional,
@@ -51,6 +53,7 @@ const FormInput = forwardRef(function FormInput(
       className={className}
       style={style}
       title={title}
+      titleActions={titleActions}
       description={description}
       htmlFor={id}
       error={touched ? error : undefined}

--- a/frontend/src/metabase/core/components/FormNumericInput/FormNumericInput.tsx
+++ b/frontend/src/metabase/core/components/FormNumericInput/FormNumericInput.tsx
@@ -13,7 +13,7 @@ export interface FormNumericInputProps
   > {
   name: string;
   title?: string;
-  titleActions?: ReactNode;
+  actions?: ReactNode;
   description?: ReactNode;
   nullable?: boolean;
   optional?: boolean;
@@ -25,7 +25,7 @@ const FormNumericInput = forwardRef(function FormNumericInput(
     className,
     style,
     title,
-    titleActions,
+    actions,
     description,
     nullable,
     optional,
@@ -49,7 +49,7 @@ const FormNumericInput = forwardRef(function FormNumericInput(
       className={className}
       style={style}
       title={title}
-      titleActions={titleActions}
+      actions={actions}
       description={description}
       htmlFor={id}
       error={touched ? error : undefined}

--- a/frontend/src/metabase/core/components/FormNumericInput/FormNumericInput.tsx
+++ b/frontend/src/metabase/core/components/FormNumericInput/FormNumericInput.tsx
@@ -13,6 +13,7 @@ export interface FormNumericInputProps
   > {
   name: string;
   title?: string;
+  titleActions?: ReactNode;
   description?: ReactNode;
   nullable?: boolean;
   optional?: boolean;
@@ -24,6 +25,7 @@ const FormNumericInput = forwardRef(function FormNumericInput(
     className,
     style,
     title,
+    titleActions,
     description,
     nullable,
     optional,
@@ -47,6 +49,7 @@ const FormNumericInput = forwardRef(function FormNumericInput(
       className={className}
       style={style}
       title={title}
+      titleActions={titleActions}
       description={description}
       htmlFor={id}
       error={touched ? error : undefined}

--- a/frontend/src/metabase/core/components/FormRadio/FormRadio.tsx
+++ b/frontend/src/metabase/core/components/FormRadio/FormRadio.tsx
@@ -12,7 +12,7 @@ export interface FormRadioProps<
   > {
   name: string;
   title?: string;
-  titleActions?: ReactNode;
+  actions?: ReactNode;
   description?: ReactNode;
   optional?: boolean;
 }
@@ -26,7 +26,7 @@ const FormRadio = forwardRef(function FormRadio<
     className,
     style,
     title,
-    titleActions,
+    actions,
     description,
     optional,
     ...props
@@ -41,7 +41,7 @@ const FormRadio = forwardRef(function FormRadio<
       className={className}
       style={style}
       title={title}
-      titleActions={titleActions}
+      actions={actions}
       description={description}
       error={touched ? error : undefined}
       optional={optional}

--- a/frontend/src/metabase/core/components/FormRadio/FormRadio.tsx
+++ b/frontend/src/metabase/core/components/FormRadio/FormRadio.tsx
@@ -12,6 +12,7 @@ export interface FormRadioProps<
   > {
   name: string;
   title?: string;
+  titleActions?: ReactNode;
   description?: ReactNode;
   optional?: boolean;
 }
@@ -25,6 +26,7 @@ const FormRadio = forwardRef(function FormRadio<
     className,
     style,
     title,
+    titleActions,
     description,
     optional,
     ...props
@@ -39,6 +41,7 @@ const FormRadio = forwardRef(function FormRadio<
       className={className}
       style={style}
       title={title}
+      titleActions={titleActions}
       description={description}
       error={touched ? error : undefined}
       optional={optional}

--- a/frontend/src/metabase/core/components/FormSelect/FormSelect.tsx
+++ b/frontend/src/metabase/core/components/FormSelect/FormSelect.tsx
@@ -12,7 +12,7 @@ export interface FormSelectProps<TValue, TOption = SelectOption<TValue>>
   extends Omit<SelectProps<TValue, TOption>, "value"> {
   name: string;
   title?: string;
-  titleActions?: ReactNode;
+  actions?: ReactNode;
   description?: ReactNode;
   optional?: boolean;
 }
@@ -25,7 +25,7 @@ const FormSelect = forwardRef(function FormSelect<
     name,
     className,
     title,
-    titleActions,
+    actions,
     description,
     onChange,
     optional,
@@ -50,7 +50,7 @@ const FormSelect = forwardRef(function FormSelect<
       ref={ref}
       className={className}
       title={title}
-      titleActions={titleActions}
+      actions={actions}
       description={description}
       htmlFor={id}
       error={touched ? error : undefined}

--- a/frontend/src/metabase/core/components/FormSelect/FormSelect.tsx
+++ b/frontend/src/metabase/core/components/FormSelect/FormSelect.tsx
@@ -12,6 +12,7 @@ export interface FormSelectProps<TValue, TOption = SelectOption<TValue>>
   extends Omit<SelectProps<TValue, TOption>, "value"> {
   name: string;
   title?: string;
+  titleActions?: ReactNode;
   description?: ReactNode;
   optional?: boolean;
 }
@@ -24,6 +25,7 @@ const FormSelect = forwardRef(function FormSelect<
     name,
     className,
     title,
+    titleActions,
     description,
     onChange,
     optional,
@@ -48,6 +50,7 @@ const FormSelect = forwardRef(function FormSelect<
       ref={ref}
       className={className}
       title={title}
+      titleActions={titleActions}
       description={description}
       htmlFor={id}
       error={touched ? error : undefined}

--- a/frontend/src/metabase/core/components/FormTextArea/FormTextArea.tsx
+++ b/frontend/src/metabase/core/components/FormTextArea/FormTextArea.tsx
@@ -17,6 +17,7 @@ export interface FormTextAreaProps
   > {
   name: string;
   title?: string;
+  titleActions?: ReactNode;
   description?: ReactNode;
   nullable?: boolean;
   infoLabel?: string;
@@ -30,6 +31,7 @@ const FormTextArea = forwardRef(function FormTextArea(
     className,
     style,
     title,
+    titleActions,
     description,
     nullable,
     infoLabel,
@@ -55,6 +57,7 @@ const FormTextArea = forwardRef(function FormTextArea(
       className={className}
       style={style}
       title={title}
+      titleActions={titleActions}
       description={description}
       htmlFor={id}
       error={touched ? error : undefined}

--- a/frontend/src/metabase/core/components/FormTextArea/FormTextArea.tsx
+++ b/frontend/src/metabase/core/components/FormTextArea/FormTextArea.tsx
@@ -17,7 +17,7 @@ export interface FormTextAreaProps
   > {
   name: string;
   title?: string;
-  titleActions?: ReactNode;
+  actions?: ReactNode;
   description?: ReactNode;
   nullable?: boolean;
   infoLabel?: string;
@@ -31,7 +31,7 @@ const FormTextArea = forwardRef(function FormTextArea(
     className,
     style,
     title,
-    titleActions,
+    actions,
     description,
     nullable,
     infoLabel,
@@ -57,7 +57,7 @@ const FormTextArea = forwardRef(function FormTextArea(
       className={className}
       style={style}
       title={title}
-      titleActions={titleActions}
+      actions={actions}
       description={description}
       htmlFor={id}
       error={touched ? error : undefined}

--- a/frontend/src/metabase/core/components/FormToggle/FormToggle.tsx
+++ b/frontend/src/metabase/core/components/FormToggle/FormToggle.tsx
@@ -7,6 +7,7 @@ import FormField from "metabase/core/components/FormField";
 export interface FormToggleProps extends Omit<ToggleProps, "value" | "onBlur"> {
   name: string;
   title?: string;
+  titleActions?: ReactNode;
   description?: ReactNode;
   optional?: boolean;
 }
@@ -17,6 +18,7 @@ const FormToggle = forwardRef(function FormToggle(
     className,
     style,
     title,
+    titleActions,
     description,
     onChange,
     optional,

--- a/frontend/src/metabase/core/components/FormToggle/FormToggle.tsx
+++ b/frontend/src/metabase/core/components/FormToggle/FormToggle.tsx
@@ -7,7 +7,7 @@ import FormField from "metabase/core/components/FormField";
 export interface FormToggleProps extends Omit<ToggleProps, "value" | "onBlur"> {
   name: string;
   title?: string;
-  titleActions?: ReactNode;
+  actions?: ReactNode;
   description?: ReactNode;
   optional?: boolean;
 }
@@ -18,7 +18,7 @@ const FormToggle = forwardRef(function FormToggle(
     className,
     style,
     title,
-    titleActions,
+    actions,
     description,
     onChange,
     optional,


### PR DESCRIPTION
Extend FormField, so it will be able to show a checkbox

Example in storybook:
`/story/core-forminput--with-title-and-actions`

<img width="745" alt="image" src="https://github.com/metabase/metabase/assets/125459446/74a7ecda-f94e-42a3-a812-7910d334f577">
