### PR TITLE
Fix stress-test E2E workfwlow

### DIFF
--- a/e2e/support/config.js
+++ b/e2e/support/config.js
@@ -105,14 +105,14 @@ const defaultConfig = {
   videoUploadOnPasses: false,
   chromeWebSecurity: false,
   modifyObstructiveCode: false,
-};
-
-const mainConfig = {
-  ...defaultConfig,
   // New `specPattern` is the combination of the old:
   //   1. testFiles and
   //   2. integrationFolder
   specPattern: "e2e/test/**/*.cy.spec.js",
+};
+
+const mainConfig = {
+  ...defaultConfig,
   projectId: "KetpiS",
   viewportHeight: 800,
   viewportWidth: 1280,


### PR DESCRIPTION
@uladzimirdev discovered that the stress test workflow cannot find spec files:
https://github.com/metabase/metabase/actions/runs/5069135771/jobs/9102972944#step:11:129

```
Can't run because no spec files were found.

We searched for specs matching this glob pattern:

  > /home/runner/work/metabase/metabase/e2e/test/scenarios/collections/revision-history.cy.spec.js
Could not find Cypress test run results
```

This was my mistake and something I forgot to address in #30940 after https://github.com/metabase/metabase/pull/30940/commits/3535cb67450783215e801845a780d6db0bae17af

## The Fix
After this PR, the default config will already contain the spec pattern. Any other config that builds on top of it can either inherit or override the spec pattern.