### PR TITLE
adding types to unblock master

### DIFF
--- a/frontend/src/metabase/components/DashboardSelector/DashboardSelector.tsx
+++ b/frontend/src/metabase/components/DashboardSelector/DashboardSelector.tsx
@@ -4,15 +4,15 @@ import TippyPopoverWithTrigger from "metabase/components/PopoverWithTrigger/Tipp
 import DashboardPicker from "metabase/containers/DashboardPicker";
 import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
 import { useDashboardQuery } from "metabase/common/hooks";
-import { Collection } from "metabase-types/api";
+import { Collection, DashboardId } from "metabase-types/api";
 import {
   DashboardPickerContainer,
   DashboardPickerButton,
 } from "./DashboardSelector.styled";
 
 interface DashboardSelectorProps {
-  onChange: (value?: number | null) => void;
-  value?: number;
+  onChange: (value?: number | null | string) => void;
+  value?: DashboardId;
   collectionFilter?: (collection: Collection) => boolean;
 }
 

--- a/frontend/src/metabase/home/homepage/components/Modals/CustomHomePageModal/CustomHomePageModal.tsx
+++ b/frontend/src/metabase/home/homepage/components/Modals/CustomHomePageModal/CustomHomePageModal.tsx
@@ -9,7 +9,7 @@ import ModalContent from "metabase/components/ModalContent";
 
 import { DashboardSelector } from "metabase/components/DashboardSelector/DashboardSelector";
 import Button from "metabase/core/components/Button/Button";
-import { Collection } from "metabase-types/api";
+import { Collection, DashboardId } from "metabase-types/api";
 
 const CUSTOM_HOMEPAGE_SETTING_KEY = "custom-homepage";
 const CUSTOM_HOMEPAGE_DASHBOARD_SETTING_KEY = "custom-homepage-dashboard";
@@ -23,7 +23,7 @@ export const CustomHomePageModal = ({
   isOpen,
   onClose,
 }: CustomHomePageModalProps) => {
-  const [dashboard, setDashboard] = useState<number>();
+  const [dashboard, setDashboard] = useState<DashboardId>();
   const dispatch = useDispatch();
 
   const handleSave = async () => {
@@ -37,7 +37,7 @@ export const CustomHomePageModal = ({
   };
 
   const handleChange = useCallback(
-    (value: number | null | undefined) => {
+    (value: number | null | undefined | string) => {
       if (value) {
         setDashboard(value);
       } else {


### PR DESCRIPTION
### Description
This is a temporary fix to unblock master. This will be followed up by a PR that will turn the item picker into a generically typed component so that we can ensure we are getting back proper types. In this particular instance, the ItemPickerId type doesn't quite work since if we are picking a dashboard, we should never have an ID that is Null, for example.
