### PR TITLE
For a breakout on a custom column, hide the binning/bucketing options

### DIFF
--- a/e2e/test/scenarios/custom-column/custom-column.cy.spec.js
+++ b/e2e/test/scenarios/custom-column/custom-column.cy.spec.js
@@ -7,7 +7,6 @@ import {
   openPeopleTable,
   visitQuestionAdhoc,
   enterCustomColumnDetails,
-  getBinningButtonForDimension,
   filter,
 } from "e2e/support/helpers";
 
@@ -38,7 +37,7 @@ describe("scenarios > question > custom column", () => {
     cy.get(".Visualization").contains("Math");
   });
 
-  it("should allow choosing a binning for a numeric custom column", () => {
+  it("should not show binning for a numeric custom column", () => {
     openOrdersTable({ mode: "notebook" });
     cy.icon("add_data").click();
 
@@ -54,22 +53,20 @@ describe("scenarios > question > custom column", () => {
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Pick a column to group by").click();
+    // Check no binning options are shown.
+    popover()
+      .findByText("Half Price")
+      .closest(".List-item")
+      .find(".Field-extra")
+      .should("be.empty");
     popover().findByText("Half Price").click();
 
     cy.get("[data-testid='step-summarize-0-0']")
       .findByText("Half Price")
-      .click();
-    getBinningButtonForDimension({
-      name: "Half Price",
-    }).click();
-
-    popover().last().findByText("10 bins").click();
-
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Half Price: 10 bins").should("be.visible");
+      .should("be.visible");
   });
 
-  it("should allow choosing a temporal unit for a date/time custom column", () => {
+  it("should not show temporal units for a date/time custom column", () => {
     openOrdersTable({ mode: "notebook" });
     cy.icon("add_data").click();
 
@@ -85,22 +82,19 @@ describe("scenarios > question > custom column", () => {
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Pick a column to group by").click();
+    popover()
+      .findByText("Product Date")
+      .closest(".List-item")
+      .find(".Field-extra")
+      .should("be.empty");
     popover().findByText("Product Date").click();
 
     cy.get("[data-testid='step-summarize-0-0']")
       .findByText("Product Date")
-      .click();
-    getBinningButtonForDimension({
-      name: "Product Date",
-    }).click();
-
-    popover().last().findByText("Month of year").click();
-
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Product Date: Month of year").should("be.visible");
+      .should("be.visible");
   });
 
-  it("should allow choosing a binning for a coordinate custom column", () => {
+  it("should not show binning options for a coordinate custom column", () => {
     openPeopleTable({ mode: "notebook" });
     cy.icon("add_data").click();
 
@@ -116,17 +110,16 @@ describe("scenarios > question > custom column", () => {
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Pick a column to group by").click();
+    popover()
+      .findByText("UserLAT")
+      .closest(".List-item")
+      .find(".Field-extra")
+      .should("be.empty");
     popover().findByText("UserLAT").click();
 
-    cy.get("[data-testid='step-summarize-0-0']").findByText("UserLAT").click();
-    getBinningButtonForDimension({
-      name: "UserLAT",
-    }).click();
-
-    popover().last().findByText("Bin every 10 degrees").click();
-
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("UserLAT: 10°").should("be.visible");
+    cy.get("[data-testid='step-summarize-0-0']")
+      .findByText("UserLAT")
+      .should("be.visible");
   });
 
   // flaky test (#19454)

--- a/frontend/src/metabase/query_builder/components/DimensionList.jsx
+++ b/frontend/src/metabase/query_builder/components/DimensionList.jsx
@@ -87,6 +87,8 @@ export default class DimensionList extends Component {
       enableSubDimensions &&
       // Do not display sub dimension if this is an FK (metabase#16787)
       !item.dimension?.field().isFK() &&
+      // Or if this is a custom expression (metabase#11371)
+      !item.dimension?.isExpression() &&
       !surpressSubDimensions &&
       item.dimension.dimensions();
 


### PR DESCRIPTION
This has never worked (see #11371) and produces bad results which group
by every individual value of the column, rather than binning/bucketing
correctly.

This can theoretically be supported, but needs BE work to construct
correct queries. To be addressed after MLv2.

