### PR TITLE
Allow default export in stories

### DIFF
--- a/frontend/src/metabase/.eslintrc
+++ b/frontend/src/metabase/.eslintrc
@@ -26,6 +26,12 @@
       }
     },
     {
+      "files": ["**/*.stories.tsx"],
+      "rules": {
+        "import/no-default-export": 0
+      }
+    },
+    {
       "files": ["lib/redux/hooks.ts"],
       "rules": {
         "no-restricted-imports": [

--- a/frontend/src/metabase/admin/app/components/DeprecationNotice/DeprecationNotice.stories.tsx
+++ b/frontend/src/metabase/admin/app/components/DeprecationNotice/DeprecationNotice.stories.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import type { ComponentStory } from "@storybook/react";
 import DeprecationNotice from "./DeprecationNotice";
 
-// eslint-disable-next-line import/no-default-export -- deprecated usage
 export default {
   title: "Admin/App/DeprecationNotice",
   component: DeprecationNotice,

--- a/frontend/src/metabase/admin/settings/slack/components/SlackSetup/SlackSetup.stories.tsx
+++ b/frontend/src/metabase/admin/settings/slack/components/SlackSetup/SlackSetup.stories.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import type { ComponentStory } from "@storybook/react";
 import SlackSetup from "./SlackSetup";
 
-// eslint-disable-next-line import/no-default-export -- deprecated usage
 export default {
   title: "Admin/Settings/Slack/SlackSetup",
   component: SlackSetup,

--- a/frontend/src/metabase/admin/settings/slack/components/SlackStatus/SlackStatus.stories.tsx
+++ b/frontend/src/metabase/admin/settings/slack/components/SlackStatus/SlackStatus.stories.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import type { ComponentStory } from "@storybook/react";
 import SlackStatus from "./SlackStatus";
 
-// eslint-disable-next-line import/no-default-export -- deprecated usage
 export default {
   title: "Admin/Settings/Slack/SlackStatus",
   component: SlackStatus,

--- a/frontend/src/metabase/collections/components/PinnedItemCard/PinnedItemCard.stories.tsx
+++ b/frontend/src/metabase/collections/components/PinnedItemCard/PinnedItemCard.stories.tsx
@@ -4,7 +4,6 @@ import { action } from "@storybook/addon-actions";
 import type { ComponentStory } from "@storybook/react";
 import PinnedItemCard from "./PinnedItemCard";
 
-// eslint-disable-next-line import/no-default-export -- deprecated usage
 export default {
   title: "Collections/PinnedItemCard",
   component: PinnedItemCard,

--- a/frontend/src/metabase/components/Calendar/Calendar.stories.tsx
+++ b/frontend/src/metabase/components/Calendar/Calendar.stories.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import type { ComponentStory } from "@storybook/react";
 import Calendar from "./Calendar";
 
-// eslint-disable-next-line import/no-default-export -- deprecated usage
 export default {
   title: "Core/Calendar",
   component: Calendar,

--- a/frontend/src/metabase/components/DateMonthYearWidget/DateMonthYearWidget.stories.tsx
+++ b/frontend/src/metabase/components/DateMonthYearWidget/DateMonthYearWidget.stories.tsx
@@ -3,7 +3,6 @@ import type { ComponentStory } from "@storybook/react";
 import { useArgs } from "@storybook/client-api";
 import DateMonthYearWidget from "./DateMonthYearWidget";
 
-// eslint-disable-next-line import/no-default-export -- deprecated usage
 export default {
   title: "Parameters/DateMonthYearWidget",
   component: DateMonthYearWidget,

--- a/frontend/src/metabase/components/DateQuarterYearWidget/DateQuarterYearWidget.stories.tsx
+++ b/frontend/src/metabase/components/DateQuarterYearWidget/DateQuarterYearWidget.stories.tsx
@@ -3,7 +3,6 @@ import type { ComponentStory } from "@storybook/react";
 import { useArgs } from "@storybook/client-api";
 import DateQuarterYearWidget from "./DateQuarterYearWidget";
 
-// eslint-disable-next-line import/no-default-export -- deprecated usage
 export default {
   title: "Parameters/DateQuarterYearWidget",
   component: DateQuarterYearWidget,

--- a/frontend/src/metabase/components/DateRelativeWidget/DateRelativeWidget.stories.tsx
+++ b/frontend/src/metabase/components/DateRelativeWidget/DateRelativeWidget.stories.tsx
@@ -3,7 +3,6 @@ import type { ComponentStory } from "@storybook/react";
 import { useArgs } from "@storybook/client-api";
 import DateRelativeWidget from "./DateRelativeWidget";
 
-// eslint-disable-next-line import/no-default-export -- deprecated usage
 export default {
   title: "Parameters/DateRelativeWidget",
   component: DateRelativeWidget,

--- a/frontend/src/metabase/components/EntityMenu.stories.tsx
+++ b/frontend/src/metabase/components/EntityMenu.stories.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import type { ComponentStory } from "@storybook/react";
 import EntityMenu from "./EntityMenu";
 
-// eslint-disable-next-line import/no-default-export -- deprecated usage
 export default {
   title: "Components/Entity Menu",
   component: EntityMenu,

--- a/frontend/src/metabase/components/HelpCard/HelpCard.stories.tsx
+++ b/frontend/src/metabase/components/HelpCard/HelpCard.stories.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import type { ComponentStory } from "@storybook/react";
 import HelpCard from "./HelpCard";
 
-// eslint-disable-next-line import/no-default-export -- deprecated usage
 export default {
   title: "Components/HelpCard",
   component: HelpCard,

--- a/frontend/src/metabase/components/Icon/Icon.stories.tsx
+++ b/frontend/src/metabase/components/Icon/Icon.stories.tsx
@@ -5,7 +5,6 @@ import styled from "@emotion/styled";
 import { ICON_PATHS } from "metabase/icon_paths";
 import Icon from "./Icon";
 
-// eslint-disable-next-line import/no-default-export -- deprecated usage
 export default {
   title: "Components/Icon",
   component: Icon,

--- a/frontend/src/metabase/components/SchedulePicker/SchedulePicker.stories.tsx
+++ b/frontend/src/metabase/components/SchedulePicker/SchedulePicker.stories.tsx
@@ -5,7 +5,6 @@ import { useArgs } from "@storybook/client-api";
 
 import SchedulePicker from "./SchedulePicker";
 
-// eslint-disable-next-line import/no-default-export -- deprecated usage
 export default {
   title: "Components/SchedulePicker",
   component: SchedulePicker,

--- a/frontend/src/metabase/components/SegmentedControl/SegmentedControl.stories.tsx
+++ b/frontend/src/metabase/components/SegmentedControl/SegmentedControl.stories.tsx
@@ -5,7 +5,6 @@ import { useArgs } from "@storybook/client-api";
 
 import { SegmentedControl } from "./SegmentedControl";
 
-// eslint-disable-next-line import/no-default-export -- deprecated usage
 export default {
   title: "Components/SegmentedControl",
   component: SegmentedControl,

--- a/frontend/src/metabase/components/SelectList/SelectListItem.stories.tsx
+++ b/frontend/src/metabase/components/SelectList/SelectListItem.stories.tsx
@@ -2,7 +2,6 @@ import React, { useState } from "react";
 import type { ComponentStory } from "@storybook/react";
 import SelectList from "./SelectList";
 
-// eslint-disable-next-line import/no-default-export -- deprecated usage
 export default {
   title: "Core/SelectList",
   component: SelectList,

--- a/frontend/src/metabase/components/TextWidget/TextWidget.stories.tsx
+++ b/frontend/src/metabase/components/TextWidget/TextWidget.stories.tsx
@@ -3,7 +3,6 @@ import type { ComponentStory } from "@storybook/react";
 import { useArgs } from "@storybook/client-api";
 import TextWidget from "./TextWidget";
 
-// eslint-disable-next-line import/no-default-export -- deprecated usage
 export default {
   title: "Parameters/TextWidget",
   component: TextWidget,

--- a/frontend/src/metabase/components/Toaster/Toaster.stories.tsx
+++ b/frontend/src/metabase/components/Toaster/Toaster.stories.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import type { ComponentStory } from "@storybook/react";
 import Toaster from "./Toaster";
 
-// eslint-disable-next-line import/no-default-export -- deprecated usage
 export default {
   title: "Dashboard/Toaster",
   component: Toaster,

--- a/frontend/src/metabase/components/TokenFieldItem/TokenFieldItem.stories.tsx
+++ b/frontend/src/metabase/components/TokenFieldItem/TokenFieldItem.stories.tsx
@@ -4,7 +4,6 @@ import type { ComponentStory } from "@storybook/react";
 import Icon from "../Icon";
 import { TokenFieldItem, TokenFieldAddon } from "./TokenFieldItem.styled";
 
-// eslint-disable-next-line import/no-default-export -- deprecated usage
 export default {
   title: "Core/TokenFieldItem",
   component: TokenFieldItem,

--- a/frontend/src/metabase/components/UserAvatar/UserAvartar.stories.tsx
+++ b/frontend/src/metabase/components/UserAvatar/UserAvartar.stories.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import type { ComponentStory } from "@storybook/react";
 import UserAvatar from "./UserAvatar";
 
-// eslint-disable-next-line import/no-default-export -- deprecated usage
 export default {
   title: "Components/UserAvatar",
   component: UserAvatar,

--- a/frontend/src/metabase/components/YearPicker/YearPicker.stories.tsx
+++ b/frontend/src/metabase/components/YearPicker/YearPicker.stories.tsx
@@ -3,7 +3,6 @@ import type { ComponentStory } from "@storybook/react";
 import { useArgs } from "@storybook/client-api";
 import YearPicker from "./YearPicker";
 
-// eslint-disable-next-line import/no-default-export -- deprecated usage
 export default {
   title: "Parameters/YearPicker",
   component: YearPicker,

--- a/frontend/src/metabase/core/components/Alert/Alert.stories.tsx
+++ b/frontend/src/metabase/core/components/Alert/Alert.stories.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import type { ComponentStory } from "@storybook/react";
 import Alert from "./Alert";
 
-// eslint-disable-next-line import/no-default-export -- deprecated usage
 export default {
   title: "Core/Alert",
   component: Alert,

--- a/frontend/src/metabase/core/components/BookmarkToggle/BookmarkToggle.stories.tsx
+++ b/frontend/src/metabase/core/components/BookmarkToggle/BookmarkToggle.stories.tsx
@@ -3,7 +3,6 @@ import type { ComponentStory } from "@storybook/react";
 import { useArgs } from "@storybook/client-api";
 import BookmarkToggle from "./BookmarkToggle";
 
-// eslint-disable-next-line import/no-default-export -- deprecated usage
 export default {
   title: "Core/BookmarkToggle",
   component: BookmarkToggle,

--- a/frontend/src/metabase/core/components/Button/Button.stories.tsx
+++ b/frontend/src/metabase/core/components/Button/Button.stories.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import type { ComponentStory } from "@storybook/react";
 import Button from "./Button";
 
-// eslint-disable-next-line import/no-default-export -- deprecated usage
 export default {
   title: "Core/Button",
   component: Button,

--- a/frontend/src/metabase/core/components/ButtonGroup/ButtonGroup.stories.tsx
+++ b/frontend/src/metabase/core/components/ButtonGroup/ButtonGroup.stories.tsx
@@ -3,7 +3,6 @@ import type { ComponentStory } from "@storybook/react";
 import Button from "../Button";
 import ButtonGroup from "./ButtonGroup";
 
-// eslint-disable-next-line import/no-default-export -- deprecated usage
 export default {
   title: "Core/ButtonGroup",
   component: ButtonGroup,

--- a/frontend/src/metabase/core/components/CheckBox/CheckBox.stories.tsx
+++ b/frontend/src/metabase/core/components/CheckBox/CheckBox.stories.tsx
@@ -3,7 +3,6 @@ import type { ComponentStory } from "@storybook/react";
 import { useArgs } from "@storybook/client-api";
 import CheckBox from "./CheckBox";
 
-// eslint-disable-next-line import/no-default-export -- deprecated usage
 export default {
   title: "Core/CheckBox",
   component: CheckBox,

--- a/frontend/src/metabase/core/components/ColorInput/ColorInput.stories.tsx
+++ b/frontend/src/metabase/core/components/ColorInput/ColorInput.stories.tsx
@@ -3,7 +3,6 @@ import type { ComponentStory } from "@storybook/react";
 import { useArgs } from "@storybook/client-api";
 import ColorInput from "./ColorInput";
 
-// eslint-disable-next-line import/no-default-export -- deprecated usage
 export default {
   title: "Core/ColorInput",
   component: ColorInput,

--- a/frontend/src/metabase/core/components/ColorPicker/ColorPicker.stories.tsx
+++ b/frontend/src/metabase/core/components/ColorPicker/ColorPicker.stories.tsx
@@ -4,7 +4,6 @@ import { useArgs } from "@storybook/client-api";
 import { color } from "metabase/lib/colors";
 import ColorPicker from "./ColorPicker";
 
-// eslint-disable-next-line import/no-default-export -- deprecated usage
 export default {
   title: "Core/ColorPicker",
   component: ColorPicker,

--- a/frontend/src/metabase/core/components/ColorPill/ColorPill.stories.tsx
+++ b/frontend/src/metabase/core/components/ColorPill/ColorPill.stories.tsx
@@ -3,7 +3,6 @@ import type { ComponentStory } from "@storybook/react";
 import { color } from "metabase/lib/colors";
 import ColorPill from "./ColorPill";
 
-// eslint-disable-next-line import/no-default-export -- deprecated usage
 export default {
   title: "Core/ColorPill",
   component: ColorPill,

--- a/frontend/src/metabase/core/components/ColorRange/ColorRange.stories.tsx
+++ b/frontend/src/metabase/core/components/ColorRange/ColorRange.stories.tsx
@@ -3,7 +3,6 @@ import type { ComponentStory } from "@storybook/react";
 import { color } from "metabase/lib/colors";
 import ColorRange from "./ColorRange";
 
-// eslint-disable-next-line import/no-default-export -- deprecated usage
 export default {
   title: "Core/ColorRange",
   component: ColorRange,

--- a/frontend/src/metabase/core/components/ColorRangeSelector/ColorRangeSelector.stories.tsx
+++ b/frontend/src/metabase/core/components/ColorRangeSelector/ColorRangeSelector.stories.tsx
@@ -4,7 +4,6 @@ import { useArgs } from "@storybook/client-api";
 import { color } from "metabase/lib/colors";
 import ColorRangeSelector from "./ColorRangeSelector";
 
-// eslint-disable-next-line import/no-default-export -- deprecated usage
 export default {
   title: "Core/ColorRangeSelector",
   component: ColorRangeSelector,

--- a/frontend/src/metabase/core/components/ColorSelector/ColorSelector.stories.tsx
+++ b/frontend/src/metabase/core/components/ColorSelector/ColorSelector.stories.tsx
@@ -4,7 +4,6 @@ import { useArgs } from "@storybook/client-api";
 import { color } from "metabase/lib/colors";
 import ColorSelector from "./ColorSelector";
 
-// eslint-disable-next-line import/no-default-export -- deprecated usage
 export default {
   title: "Core/ColorSelector",
   component: ColorSelector,

--- a/frontend/src/metabase/core/components/DateInput/DateInput.stories.tsx
+++ b/frontend/src/metabase/core/components/DateInput/DateInput.stories.tsx
@@ -3,7 +3,6 @@ import { Moment } from "moment-timezone";
 import type { ComponentStory } from "@storybook/react";
 import DateInput from "./DateInput";
 
-// eslint-disable-next-line import/no-default-export -- deprecated usage
 export default {
   title: "Core/DateInput",
   component: DateInput,

--- a/frontend/src/metabase/core/components/DateSelector/DateSelector.stories.tsx
+++ b/frontend/src/metabase/core/components/DateSelector/DateSelector.stories.tsx
@@ -3,7 +3,6 @@ import moment from "moment-timezone";
 import type { ComponentStory } from "@storybook/react";
 import DateSelector from "./DateSelector";
 
-// eslint-disable-next-line import/no-default-export -- deprecated usage
 export default {
   title: "Core/DateSelector",
   component: DateSelector,

--- a/frontend/src/metabase/core/components/DateWidget/DateWidget.stories.tsx
+++ b/frontend/src/metabase/core/components/DateWidget/DateWidget.stories.tsx
@@ -3,7 +3,6 @@ import { Moment } from "moment-timezone";
 import type { ComponentStory } from "@storybook/react";
 import DateWidget from "./DateWidget";
 
-// eslint-disable-next-line import/no-default-export -- deprecated usage
 export default {
   title: "Core/DateWidget",
   component: DateWidget,

--- a/frontend/src/metabase/core/components/EditableText/EditableText.stories.tsx
+++ b/frontend/src/metabase/core/components/EditableText/EditableText.stories.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import type { ComponentStory } from "@storybook/react";
 import EditableText from "./EditableText";
 
-// eslint-disable-next-line import/no-default-export -- deprecated usage
 export default {
   title: "Core/EditableText",
   component: EditableText,

--- a/frontend/src/metabase/core/components/ExternalLink/ExternalLink.stories.tsx
+++ b/frontend/src/metabase/core/components/ExternalLink/ExternalLink.stories.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import type { ComponentStory } from "@storybook/react";
 import ExternalLink from "./ExternalLink";
 
-// eslint-disable-next-line import/no-default-export -- deprecated usage
 export default {
   title: "Core/ExternalLink",
   component: ExternalLink,

--- a/frontend/src/metabase/core/components/FileInput/FileInput.stories.tsx
+++ b/frontend/src/metabase/core/components/FileInput/FileInput.stories.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import type { ComponentStory } from "@storybook/react";
 import FileInput from "./FileInput";
 
-// eslint-disable-next-line import/no-default-export -- deprecated usage
 export default {
   title: "Core/FileInput",
   component: FileInput,

--- a/frontend/src/metabase/core/components/FormCheckBox/FormCheckBox.stories.tsx
+++ b/frontend/src/metabase/core/components/FormCheckBox/FormCheckBox.stories.tsx
@@ -4,7 +4,6 @@ import Form from "../Form";
 import FormProvider from "../FormProvider";
 import FormCheckBox from "./FormCheckBox";
 
-// eslint-disable-next-line import/no-default-export -- deprecated usage
 export default {
   title: "Core/FormCheckBox",
   component: FormCheckBox,

--- a/frontend/src/metabase/core/components/FormDateInput/FormDateInput.stories.tsx
+++ b/frontend/src/metabase/core/components/FormDateInput/FormDateInput.stories.tsx
@@ -4,7 +4,6 @@ import Form from "../Form";
 import FormProvider from "../FormProvider";
 import FormDateInput from "./FormDateInput";
 
-// eslint-disable-next-line import/no-default-export -- deprecated usage
 export default {
   title: "Core/FormDateInput",
   component: FormDateInput,

--- a/frontend/src/metabase/core/components/FormField/FormField.stories.tsx
+++ b/frontend/src/metabase/core/components/FormField/FormField.stories.tsx
@@ -6,7 +6,6 @@ import { useArgs } from "@storybook/client-api";
 import Toggle from "../Toggle/Toggle";
 import FormField from "./FormField";
 
-// eslint-disable-next-line import/no-default-export -- deprecated usage
 export default {
   title: "Core/FormField",
   component: FormField,

--- a/frontend/src/metabase/core/components/FormNumericInput/FormNumericInput.stories.tsx
+++ b/frontend/src/metabase/core/components/FormNumericInput/FormNumericInput.stories.tsx
@@ -4,7 +4,6 @@ import Form from "../Form";
 import FormProvider from "../FormProvider";
 import FormNumericInput from "./FormNumericInput";
 
-// eslint-disable-next-line import/no-default-export -- deprecated usage
 export default {
   title: "Core/FormNumericInput",
   component: FormNumericInput,

--- a/frontend/src/metabase/core/components/FormRadio/FormRadio.stories.tsx
+++ b/frontend/src/metabase/core/components/FormRadio/FormRadio.stories.tsx
@@ -10,7 +10,6 @@ const TEST_OPTIONS = [
   { name: "Bar", value: "bar" },
 ];
 
-// eslint-disable-next-line import/no-default-export -- deprecated usage
 export default {
   title: "Core/FormRadio",
   component: FormRadio,

--- a/frontend/src/metabase/core/components/FormSelect/FormSelect.stories.tsx
+++ b/frontend/src/metabase/core/components/FormSelect/FormSelect.stories.tsx
@@ -10,7 +10,6 @@ const TEST_OPTIONS = [
   { name: "Bar", value: "bar" },
 ];
 
-// eslint-disable-next-line import/no-default-export -- deprecated usage
 export default {
   title: "Core/FormSelect",
   component: FormSelect,

--- a/frontend/src/metabase/core/components/FormTextArea/FormTextArea.stories.tsx
+++ b/frontend/src/metabase/core/components/FormTextArea/FormTextArea.stories.tsx
@@ -4,7 +4,6 @@ import Form from "../Form";
 import FormProvider from "../FormProvider";
 import FormTextArea from "./FormTextArea";
 
-// eslint-disable-next-line import/no-default-export -- deprecated usage
 export default {
   title: "Core/FormTextArea",
   component: FormTextArea,

--- a/frontend/src/metabase/core/components/FormToggle/FormToggle.stories.tsx
+++ b/frontend/src/metabase/core/components/FormToggle/FormToggle.stories.tsx
@@ -4,7 +4,6 @@ import Form from "../Form";
 import FormProvider from "../FormProvider";
 import FormToggle from "./FormToggle";
 
-// eslint-disable-next-line import/no-default-export -- deprecated usage
 export default {
   title: "Core/FormToggle",
   component: FormToggle,

--- a/frontend/src/metabase/core/components/Input/Input.stories.tsx
+++ b/frontend/src/metabase/core/components/Input/Input.stories.tsx
@@ -2,7 +2,6 @@ import React, { useState } from "react";
 import type { ComponentStory } from "@storybook/react";
 import Input from "./Input";
 
-// eslint-disable-next-line import/no-default-export -- deprecated usage
 export default {
   title: "Core/Input",
   component: Input,

--- a/frontend/src/metabase/core/components/Link/Link.stories.tsx
+++ b/frontend/src/metabase/core/components/Link/Link.stories.tsx
@@ -3,7 +3,6 @@ import type { ComponentStory } from "@storybook/react";
 
 import Link from "./";
 
-// eslint-disable-next-line import/no-default-export -- deprecated usage
 export default {
   title: "Core/Link",
   component: Link,

--- a/frontend/src/metabase/core/components/Markdown/Markdown.stories.tsx
+++ b/frontend/src/metabase/core/components/Markdown/Markdown.stories.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import type { ComponentStory } from "@storybook/react";
 import Markdown from "./Markdown";
 
-// eslint-disable-next-line import/no-default-export -- deprecated usage
 export default {
   title: "Core/Markdown",
   component: Markdown,

--- a/frontend/src/metabase/core/components/NumericInput/NumericInput.stories.tsx
+++ b/frontend/src/metabase/core/components/NumericInput/NumericInput.stories.tsx
@@ -2,7 +2,6 @@ import React, { useState } from "react";
 import type { ComponentStory } from "@storybook/react";
 import NumericInput from "./NumericInput";
 
-// eslint-disable-next-line import/no-default-export -- deprecated usage
 export default {
   title: "Core/NumericInput",
   component: NumericInput,

--- a/frontend/src/metabase/core/components/Radio/Radio.stories.tsx
+++ b/frontend/src/metabase/core/components/Radio/Radio.stories.tsx
@@ -3,7 +3,6 @@ import type { ComponentStory } from "@storybook/react";
 import { useArgs } from "@storybook/client-api";
 import Radio from "./Radio";
 
-// eslint-disable-next-line import/no-default-export -- deprecated usage
 export default {
   title: "Core/Radio",
   component: Radio,

--- a/frontend/src/metabase/core/components/Select/Select.stories.tsx
+++ b/frontend/src/metabase/core/components/Select/Select.stories.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import type { ComponentStory } from "@storybook/react";
 import Select from "./Select";
 
-// eslint-disable-next-line import/no-default-export -- deprecated usage
 export default {
   title: "Core/Select",
   component: Select,

--- a/frontend/src/metabase/core/components/SelectButton/SelectButton.stories.tsx
+++ b/frontend/src/metabase/core/components/SelectButton/SelectButton.stories.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import type { ComponentStory } from "@storybook/react";
 import SelectButton from "./SelectButton";
 
-// eslint-disable-next-line import/no-default-export -- deprecated usage
 export default {
   title: "Core/SelectButton",
   component: SelectButton,

--- a/frontend/src/metabase/core/components/Slider/Slider.stories.tsx
+++ b/frontend/src/metabase/core/components/Slider/Slider.stories.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import type { ComponentStory } from "@storybook/react";
 import Slider from "./Slider";
 
-// eslint-disable-next-line import/no-default-export -- deprecated usage
 export default {
   title: "Core/Slider",
   component: Slider,

--- a/frontend/src/metabase/core/components/TabContent/TabContent.stories.tsx
+++ b/frontend/src/metabase/core/components/TabContent/TabContent.stories.tsx
@@ -6,7 +6,6 @@ import TabList from "../TabList";
 import TabPanel from "../TabPanel";
 import TabContent from "./TabContent";
 
-// eslint-disable-next-line import/no-default-export -- deprecated usage
 export default {
   title: "Core/TabContent",
   component: TabContent,

--- a/frontend/src/metabase/core/components/TabList/TabList.stories.tsx
+++ b/frontend/src/metabase/core/components/TabList/TabList.stories.tsx
@@ -5,7 +5,6 @@ import Tab from "../Tab";
 
 import TabList from "./TabList";
 
-// eslint-disable-next-line import/no-default-export -- deprecated usage
 export default {
   title: "Core/TabList",
   component: TabList,

--- a/frontend/src/metabase/core/components/TabRow/TabRow.stories.tsx
+++ b/frontend/src/metabase/core/components/TabRow/TabRow.stories.tsx
@@ -10,7 +10,6 @@ import {
 import TabLink from "../TabLink";
 import { TabRow } from "./TabRow";
 
-// eslint-disable-next-line import/no-default-export -- deprecated usage
 export default {
   title: "Core/TabRow",
   component: TabRow,

--- a/frontend/src/metabase/core/components/TextArea/TextArea.stories.tsx
+++ b/frontend/src/metabase/core/components/TextArea/TextArea.stories.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import type { ComponentStory } from "@storybook/react";
 import TextArea from "./TextArea";
 
-// eslint-disable-next-line import/no-default-export -- deprecated usage
 export default {
   title: "Core/Text Area",
   component: TextArea,

--- a/frontend/src/metabase/core/components/TimeInput/TimeInput.stories.tsx
+++ b/frontend/src/metabase/core/components/TimeInput/TimeInput.stories.tsx
@@ -3,7 +3,6 @@ import moment from "moment-timezone";
 import type { ComponentStory } from "@storybook/react";
 import TimeInput from "./TimeInput";
 
-// eslint-disable-next-line import/no-default-export -- deprecated usage
 export default {
   title: "Core/TimeInput",
   component: TimeInput,

--- a/frontend/src/metabase/core/components/Toggle/Toggle.stories.tsx
+++ b/frontend/src/metabase/core/components/Toggle/Toggle.stories.tsx
@@ -3,7 +3,6 @@ import type { ComponentStory } from "@storybook/react";
 import { useArgs } from "@storybook/client-api";
 import Toggle from "./Toggle";
 
-// eslint-disable-next-line import/no-default-export -- deprecated usage
 export default {
   title: "Core/Toggle",
   component: Toggle,

--- a/frontend/src/metabase/core/components/Tooltip/Tooltip.stories.tsx
+++ b/frontend/src/metabase/core/components/Tooltip/Tooltip.stories.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import type { ComponentStory } from "@storybook/react";
 import Tooltip from "./Tooltip";
 
-// eslint-disable-next-line import/no-default-export -- deprecated usage
 export default {
   title: "Core/Tooltip",
   component: Tooltip,

--- a/frontend/src/metabase/databases/components/DatabaseEngineWarning/DatabaseEngineWarning.stories.tsx
+++ b/frontend/src/metabase/databases/components/DatabaseEngineWarning/DatabaseEngineWarning.stories.tsx
@@ -6,7 +6,6 @@ import {
 } from "metabase-types/api/mocks";
 import DatabaseEngineWarning from "./DatabaseEngineWarning";
 
-// eslint-disable-next-line import/no-default-export -- deprecated usage
 export default {
   title: "Databases/DatabaseEngineWarning",
   component: DatabaseEngineWarning,

--- a/frontend/src/metabase/databases/components/DatabaseForm/DatabaseForm.stories.tsx
+++ b/frontend/src/metabase/databases/components/DatabaseForm/DatabaseForm.stories.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import type { ComponentStory } from "@storybook/react";
 import DatabaseForm from "./DatabaseForm";
 
-// eslint-disable-next-line import/no-default-export -- deprecated usage
 export default {
   title: "Databases/DatabaseForm",
   component: DatabaseForm,

--- a/frontend/src/metabase/databases/components/DatabaseHelpCard/DatabaseHelpCard.stories.tsx
+++ b/frontend/src/metabase/databases/components/DatabaseHelpCard/DatabaseHelpCard.stories.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import type { ComponentStory } from "@storybook/react";
 import DatabaseHelpCard from "./DatabaseHelpCard";
 
-// eslint-disable-next-line import/no-default-export -- deprecated usage
 export default {
   title: "Databases/DatabaseHelpCard",
   component: DatabaseHelpCard,

--- a/frontend/src/metabase/parameters/components/widgets/NumberInputWidget/NumberInputWidget.stories.tsx
+++ b/frontend/src/metabase/parameters/components/widgets/NumberInputWidget/NumberInputWidget.stories.tsx
@@ -3,7 +3,6 @@ import type { ComponentStory } from "@storybook/react";
 import { useArgs } from "@storybook/client-api";
 import NumberInputWidget from "./NumberInputWidget";
 
-// eslint-disable-next-line import/no-default-export -- deprecated usage
 export default {
   title: "Parameters/NumberInputWidget",
   component: NumberInputWidget,

--- a/frontend/src/metabase/parameters/components/widgets/StringInputWidget/StringInputWidget.stories.tsx
+++ b/frontend/src/metabase/parameters/components/widgets/StringInputWidget/StringInputWidget.stories.tsx
@@ -3,7 +3,6 @@ import type { ComponentStory } from "@storybook/react";
 import { useArgs } from "@storybook/client-api";
 import StringInputWidget from "./StringInputWidget";
 
-// eslint-disable-next-line import/no-default-export -- deprecated usage
 export default {
   title: "Parameters/StringInputWidget",
   component: StringInputWidget,

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorHelpText.stories.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorHelpText.stories.tsx
@@ -8,7 +8,6 @@ import ExpressionEditorHelpText, {
   ExpressionEditorHelpTextProps,
 } from "./ExpressionEditorHelpText";
 
-// eslint-disable-next-line import/no-default-export -- deprecated usage
 export default {
   title: "Query Builder/ExpressionEditorHelpText",
   component: ExpressionEditorHelpText,

--- a/frontend/src/metabase/static-viz/containers/StaticChart/StaticChart.stories.tsx
+++ b/frontend/src/metabase/static-viz/containers/StaticChart/StaticChart.stories.tsx
@@ -5,7 +5,6 @@ import StaticChart from "./StaticChart";
 import { STATIC_CHART_DEFAULT_OPTIONS, STATIC_CHART_TYPES } from "./constants";
 import { StaticChartProps } from "./types";
 
-// eslint-disable-next-line import/no-default-export -- deprecated usage
 export default {
   title: "static-viz/StaticChart",
   component: StaticChart,

--- a/frontend/src/metabase/status/components/FileUploadStatusLarge/FileUploadStatusLarge.stories.tsx
+++ b/frontend/src/metabase/status/components/FileUploadStatusLarge/FileUploadStatusLarge.stories.tsx
@@ -3,7 +3,6 @@ import type { ComponentStory } from "@storybook/react";
 import { createMockCollection } from "metabase-types/api/mocks";
 import FileUploadStatusLarge from "./FileUploadStatusLarge";
 
-// eslint-disable-next-line import/no-default-export -- deprecated usage
 export default {
   title: "Status/FileUploadStatusLarge",
   component: FileUploadStatusLarge,

--- a/frontend/src/metabase/timelines/common/components/TimelinePicker/TimelinePicker.stories.tsx
+++ b/frontend/src/metabase/timelines/common/components/TimelinePicker/TimelinePicker.stories.tsx
@@ -7,7 +7,6 @@ import {
 import { Timeline } from "metabase-types/api";
 import TimelinePicker from "./TimelinePicker";
 
-// eslint-disable-next-line import/no-default-export -- deprecated usage
 export default {
   title: "Timelines/TimelinePicker",
   component: TimelinePicker,

--- a/frontend/src/metabase/visualizations/components/skeletons/ChartSkeleton/ChartSkeleton.stories.tsx
+++ b/frontend/src/metabase/visualizations/components/skeletons/ChartSkeleton/ChartSkeleton.stories.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import type { ComponentStory } from "@storybook/react";
 import ChartSkeleton from "./ChartSkeleton";
 
-// eslint-disable-next-line import/no-default-export -- deprecated usage
 export default {
   title: "Visualizations/ChartSkeleton",
   component: ChartSkeleton,

--- a/frontend/src/metabase/visualizations/components/skeletons/StaticSkeleton/StaticSkeleton.stories.tsx
+++ b/frontend/src/metabase/visualizations/components/skeletons/StaticSkeleton/StaticSkeleton.stories.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import type { ComponentStory } from "@storybook/react";
 import StaticSkeleton from "./StaticSkeleton";
 
-// eslint-disable-next-line import/no-default-export -- deprecated usage
 export default {
   title: "Visualizations/StaticSkeleton",
   component: StaticSkeleton,

--- a/frontend/src/metabase/visualizations/shared/components/RowChart/RowChart.stories.tsx
+++ b/frontend/src/metabase/visualizations/shared/components/RowChart/RowChart.stories.tsx
@@ -5,7 +5,6 @@ import { getStaticChartTheme } from "metabase/static-viz/components/RowChart/the
 import { color } from "metabase/lib/colors";
 import { RowChart } from "./RowChart";
 
-// eslint-disable-next-line import/no-default-export -- deprecated usage
 export default {
   title: "Visualizations/shared/RowChart",
   component: RowChart,


### PR DESCRIPTION
We use a special syntax in stories with `export default`,  so it doens't make sense to forbid default export there