### PR TITLE
fix dashcards crash

### DIFF
--- a/frontend/src/metabase/visualizations/lib/settings/visualization.js
+++ b/frontend/src/metabase/visualizations/lib/settings/visualization.js
@@ -1,4 +1,5 @@
 import { t } from "ttag";
+import { assocIn } from "icepick";
 import { getVisualizationRaw } from "metabase/visualizations";
 import { isVirtualDashCard } from "metabase/dashboard/utils";
 import { normalizeFieldRef } from "metabase-lib/queries/utils/dataset";
@@ -64,12 +65,14 @@ function normalizeColumnSettings(columnSettings) {
 }
 
 export function getStoredSettingsForSeries(series) {
-  const storedSettings =
+  let storedSettings =
     (series && series[0] && series[0].card.visualization_settings) || {};
   if (storedSettings.column_settings) {
     // normalize any settings stored under old style keys: [ref, [fk->, 1, 2]]
-    storedSettings.column_settings = normalizeColumnSettings(
-      storedSettings.column_settings,
+    storedSettings = assocIn(
+      storedSettings,
+      ["column_settings"],
+      normalizeColumnSettings(storedSettings.column_settings),
     );
   }
   return storedSettings;

--- a/frontend/src/metabase/visualizations/lib/settings/visualization.unit.spec.js
+++ b/frontend/src/metabase/visualizations/lib/settings/visualization.unit.spec.js
@@ -1,3 +1,4 @@
+import icepick from "icepick";
 // NOTE: need to load visualizations first for getSettings to work
 import "metabase/visualizations/index";
 
@@ -163,6 +164,30 @@ describe("visualization_settings", () => {
         { card: { visualization_settings: { foo: "bar" } } },
       ]);
       expect(settings).toEqual({ foo: "bar" });
+    });
+    it("should work correctly with frozen objects", () => {
+      const settings = getStoredSettingsForSeries(
+        icepick.freeze([
+          {
+            card: {
+              visualization_settings: {
+                column_settings: {
+                  '["name","A"]': {
+                    number_style: "currency",
+                  },
+                },
+              },
+            },
+          },
+        ]),
+      );
+      expect(settings).toEqual({
+        column_settings: {
+          '["name","A"]': {
+            number_style: "currency",
+          },
+        },
+      });
     });
   });
   describe("table.cell_column", () => {


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/31040

### Description

We use icepick in many places but not everywhere which led to the situation where the settings code tried to mutate frozen js objects which let to this bug.

### How to verify

Create the following question Q1:
`SELECT
  CAST("PUBLIC"."ANALYTIC_EVENTS"."TIMESTAMP" AS date) AS "day",
  COUNT(*) AS "Events"
FROM
  "PUBLIC"."ANALYTIC_EVENTS"
GROUP BY
  CAST("PUBLIC"."ANALYTIC_EVENTS"."TIMESTAMP" AS date)
ORDER BY
  CAST("PUBLIC"."ANALYTIC_EVENTS"."TIMESTAMP" AS date) ASC`

Make it a line chart, change the Y-axis setting "Minimum number of decimal places" -> 2

Create another question Q2:
Orders Count by Created At

1. New Dashboard -> Add Q2
2. Add a series Q1 -> Save
3. Refresh the page -> Ensure it does not crash

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
