### PR TITLE
docs - update public links

### DIFF
--- a/docs/questions/sharing/public-links.md
+++ b/docs/questions/sharing/public-links.md
@@ -109,13 +109,13 @@ For example, to embed a dashboard with multiple appearance parameters:
 /dashboard/42#theme=night&titled=true&bordered=false
 ```
 
-To embed a question with multiple appearance parameters:
+To embed a question without filter widgets and without the download button:
 
 ```
-/question/42#theme=transparent&hide_download_button=true
+/question/42#hide_parameters=true&hide_download_button=true
 ```
 
-For more info about `hide_parameters`, see the next section on [Filter parameters](#filter-parameters).
+For more info about hiding filter widgets with `hide_parameters`, see the next section on [Filter parameters](#filter-parameters).
 
 ### Filter parameters
 

--- a/docs/questions/sharing/public-links.md
+++ b/docs/questions/sharing/public-links.md
@@ -95,7 +95,7 @@ To toggle appearance settings, add _hash_ parameters to the end of the public li
 | bordered                | true, false                                      |
 | titled                  | true, false                                      |
 | theme                   | null, transparent, night                         |
-| hide_parameters         | true, false                                      |      
+| hide_parameters         | [filter name](#filter-parameters)                |      
 | font¹                   | [font name](../../configuring-metabase/fonts.md) |
 | hide_download_button²   | true, false                                      |
 
@@ -112,7 +112,7 @@ For example, to embed a dashboard with multiple appearance parameters:
 To embed a question without filter widgets and without the download button:
 
 ```
-/question/42#hide_parameters=true&hide_download_button=true
+/question/42#hide_parameters=filter_name&hide_download_button=true
 ```
 
 For more info about hiding filter widgets with `hide_parameters`, see the next section on [Filter parameters](#filter-parameters).

--- a/docs/questions/sharing/public-links.md
+++ b/docs/questions/sharing/public-links.md
@@ -90,12 +90,6 @@ If you'd like to create a secure embed that prevents people from changing filter
 
 To toggle appearance settings, add _hash_ parameters to the end of the public link in your iframe's `src` attribute.
 
-For example, to embed a dashboard with a dark theme, original title, and no border:
-
-```
-/dashboard/42#theme=night&titled=true&bordered=false
-```
-
 | Parameter name          | Possible values                                  |
 | ----------------------- | ------------------------------------------------ |
 | bordered                | true, false                                      |
@@ -108,6 +102,18 @@ For example, to embed a dashboard with a dark theme, original title, and no bord
 ¹ Available on [paid plans](https://www.metabase.com/pricing).
 
 ² Available on [paid plans](https://www.metabase.com/pricing) and hides the download button on questions only (not dashboards).
+
+For example, to embed a dashboard with multiple appearance parameters:
+
+```
+/dashboard/42#theme=night&titled=true&bordered=false
+```
+
+To embed a question with multiple appearance parameters:
+
+```
+/question/42#theme=transparent&hide_download_button=true
+```
 
 For more info about `hide_parameters`, see the next section on [Filter parameters](#filter-parameters).
 


### PR DESCRIPTION
Separate dashboard and question embedding parameter examples 

To avoid confusion, e.g. when copy/pasting the code block and forgetting to change the dashboard link to a question link