### PR TITLE
[Model Indexes] Allow Updating Metadata at the same time as adding an index

### DIFF
--- a/e2e/test/scenarios/models/model-indexes.cy.spec.js
+++ b/e2e/test/scenarios/models/model-indexes.cy.spec.js
@@ -29,7 +29,7 @@ describe("scenarios > model indexes", () => {
     });
   });
 
-  it("should create and delete a model index on product titles", () => {
+  it("should create, delete, and re-create a model index on product titles", () => {
     cy.visit(`/model/${modelId}`);
     cy.wait("@dataset");
 
@@ -64,6 +64,27 @@ describe("scenarios > model indexes", () => {
     cy.wait("@modelIndexDelete").then(({ request, response }) => {
       expect(request.url).to.include("/api/model-index/1");
       expect(response.statusCode).to.equal(200);
+    });
+
+    cy.wait("@dataset");
+
+    editTitleMetadata();
+
+    sidebar()
+      .findByLabelText(/surface individual records/i)
+      .click();
+
+    cy.findByTestId("dataset-edit-bar").within(() => {
+      cy.button("Save changes").click();
+    });
+
+    // this tests redux cache invalidation (#31407)
+    cy.wait("@modelIndexCreate").then(({ request, response }) => {
+      expect(request.body.model_id).to.equal(modelId);
+
+      // this will likely change when this becomes an async process
+      expect(response.body.state).to.equal("indexed");
+      expect(response.body.id).to.equal(2);
     });
   });
 

--- a/frontend/src/metabase/entities/model-indexes/actions.ts
+++ b/frontend/src/metabase/entities/model-indexes/actions.ts
@@ -107,8 +107,7 @@ function getIndexIdsToRemove(
   return indexIdsToRemove;
 }
 
-export function cleanIndexFlags(model: Question) {
-  const fields = model.getResultMetadata();
+export function cleanIndexFlags(fields: Field[]) {
   const indexesToClean = fields.reduce(
     (
       indexesToClean: number[],
@@ -123,12 +122,11 @@ export function cleanIndexFlags(model: Question) {
     [],
   );
 
-  const newResultMetadata = [...model.getResultMetadata()];
+  const newResultMetadata = [...fields];
   for (const index of indexesToClean) {
     newResultMetadata[index] = dissocIn(newResultMetadata[index], [
       "should_index",
     ]);
   }
-  const newModel = model.setResultsMetadata(newResultMetadata);
-  return newModel;
+  return newResultMetadata;
 }

--- a/frontend/src/metabase/entities/model-indexes/actions.ts
+++ b/frontend/src/metabase/entities/model-indexes/actions.ts
@@ -42,15 +42,17 @@ export const updateModelIndexes =
     if (newFieldsToIndex.length) {
       const pkRef = ModelIndexes.utils.getPkRef(fields);
 
-      await Promise.all(
-        newFieldsToIndex.map(field =>
-          ModelIndexes.api.create({
-            model_id: model.id(),
-            value_ref: field.field_ref,
-            pk_ref: pkRef,
-          }),
-        ),
-      );
+      if (pkRef) {
+        await Promise.all(
+          newFieldsToIndex.map(field =>
+            ModelIndexes.api.create({
+              model_id: model.id(),
+              value_ref: field.field_ref,
+              pk_ref: pkRef,
+            }),
+          ),
+        );
+      }
     }
 
     if (indexIdsToRemove.length) {

--- a/frontend/src/metabase/entities/model-indexes/actions.ts
+++ b/frontend/src/metabase/entities/model-indexes/actions.ts
@@ -26,9 +26,9 @@ export const updateModelIndexes =
     }
 
     const existingIndexes: ModelIndex[] =
-      ModelIndexes.selectors.getIndexesForModel(getState(), {
-        modelId: model.id(),
-      });
+      ModelIndexes.selectors.getList(getState(), {
+        entityQuery: { model_id: model.id() },
+      }) ?? [];
 
     const newFieldsToIndex = getFieldsToIndex(
       fieldsWithIndexFlags,
@@ -109,7 +109,7 @@ function getIndexIdsToRemove(
   return indexIdsToRemove;
 }
 
-export function cleanIndexFlags(fields: Field[]) {
+export function cleanIndexFlags(fields: Field[] = []) {
   const indexesToClean = fields.reduce(
     (
       indexesToClean: number[],

--- a/frontend/src/metabase/entities/model-indexes/actions.unit.spec.ts
+++ b/frontend/src/metabase/entities/model-indexes/actions.unit.spec.ts
@@ -37,9 +37,9 @@ describe("Entities > model-indexes > actions", () => {
         createMockField(),
       ]);
 
-      const cleanedQuestion = cleanIndexFlags(model);
+      const cleanedFields = cleanIndexFlags(model.getResultMetadata());
 
-      cleanedQuestion.getResultMetadata().forEach((field: any) => {
+      cleanedFields.forEach((field: any) => {
         expect(field?.should_index).toBeUndefined();
       });
     });
@@ -50,7 +50,7 @@ describe("Entities > model-indexes > actions", () => {
         createMockField({ should_index: true }),
       ]);
 
-      cleanIndexFlags(model);
+      cleanIndexFlags(model.getResultMetadata());
 
       model.getResultMetadata().forEach((field: any) => {
         expect(field?.should_index).toBe(true);

--- a/frontend/src/metabase/entities/model-indexes/actions.unit.spec.ts
+++ b/frontend/src/metabase/entities/model-indexes/actions.unit.spec.ts
@@ -85,7 +85,9 @@ describe("Entities > model-indexes > actions", () => {
       setupModelIndexEndpoints(model.id(), []);
 
       const mockDispatch = jest.fn();
-      const mockGetState = jest.fn(() => ({ entities: { modelIndexes: [] } }));
+      const mockGetState = jest.fn(() => ({
+        entities: { modelIndexes: {}, modelIndexes_list: {} },
+      }));
       await updateModelIndexes(model)(mockDispatch, mockGetState);
 
       expect(mockDispatch).toHaveBeenCalled();
@@ -113,6 +115,7 @@ describe("Entities > model-indexes > actions", () => {
 
       const existingModelIndex = createMockModelIndex({
         id: 99,
+        model_id: 1,
         value_ref: indexFieldRef,
       });
 
@@ -123,7 +126,7 @@ describe("Entities > model-indexes > actions", () => {
         entities: {
           modelIndexes: { 99: existingModelIndex },
           modelIndexes_list: {
-            '{"model_id":1': {
+            '{"model_id":1}': {
               list: [99],
               metadata: {},
             },
@@ -163,7 +166,7 @@ describe("Entities > model-indexes > actions", () => {
         entities: {
           modelIndexes: { 99: existingModelIndex },
           modelIndexes_list: {
-            '{"model_id":1': {
+            '{"model_id":1}': {
               list: [99],
               metadata: {},
             },
@@ -194,7 +197,9 @@ describe("Entities > model-indexes > actions", () => {
       setupModelIndexEndpoints(model.id(), []);
 
       const mockDispatch = jest.fn();
-      const mockGetState = jest.fn(() => ({ entities: { modelIndexes: [] } }));
+      const mockGetState = jest.fn(() => ({
+        entities: { modelIndexes: {}, modelIndexes_list: {} },
+      }));
       await updateModelIndexes(model)(mockDispatch, mockGetState);
 
       expect(mockDispatch).toHaveBeenCalled();

--- a/frontend/src/metabase/entities/model-indexes/model-indexes.ts
+++ b/frontend/src/metabase/entities/model-indexes/model-indexes.ts
@@ -5,7 +5,6 @@
  */
 
 import type { IndexedEntity } from "metabase-types/api/modelIndexes";
-import type { State } from "metabase-types/store";
 
 import { createEntity } from "metabase/lib/entities";
 import { ModelIndexApi } from "metabase/services";
@@ -29,16 +28,7 @@ export const ModelIndexes = createEntity({
     getUrl: (entity: IndexedEntity) => `/model/${entity.model_id}/${entity.id}`,
     getIcon: () => ({ name: "beaker" }),
   },
-  // objectActions: {},
   reducer: (state = {}, { type, payload }: { type: string; payload: any }) => {
     return state;
   },
-  selectors: {
-    getIndexesForModel: (state: State, { modelId }: { modelId: number }) => {
-      return Object.values(state.entities.modelIndexes).filter(
-        index => index.model_id === modelId,
-      );
-    },
-  },
-  // objectSelectors: {},
 });


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/31046

### Description

The update logic for models was such that we were adding model indexes before doing other metadata updates. This works fine so long as no primary keys were changed at the same time as you were adding a model index, but that's not ideal.  This moves adding model indexes to AFTER we update the underlying card an its metadata so that the model index can be aware of the newly-updated model metadata.  This required some changes in the logic to how we clean some local flags up to avoid them getting sent to the API.

https://www.loom.com/share/e5aa39042b474f86b07222e4f3759587

### How to verify

1. Open a model and edit it so that it has no primary keys defined, then save it.
2. Open the model metadata again, assign a primary key, and then add a model index on a string column
3. See that the update succeeds and you can now search on that column.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
