### PR TITLE
Unskip pMBQL conversion tests for #29936

### DIFF
--- a/test/metabase/query_processor_test/test_mlv2.clj
+++ b/test/metabase/query_processor_test/test_mlv2.clj
@@ -62,13 +62,7 @@
      {:aggregation aggregations}
      (mbql.u/match-one aggregations
        :case
-       "#29935"))
-   ;; #29936: metadata for an `:aggregation` that is a `:metric`
-   (mbql.u/match-one legacy-query
-     {:aggregation aggregations}
-     (mbql.u/match-one aggregations
-       :metric
-       "#29936"))))
+       "#29935"))))
 
 (defn- test-mlv2-metadata [original-query _qp-metadata]
   {:pre [(map? original-query)]}


### PR DESCRIPTION
It looks like #29936 was inadvertently fixed at some point, so this PR just enables the tests for it.

Fixes #29936