### PR TITLE
Fix missing confirmation when running an action without parameters in dashboards

### DIFF
--- a/frontend/src/metabase/actions/components/ActionViz/Action.unit.spec.tsx
+++ b/frontend/src/metabase/actions/components/ActionViz/Action.unit.spec.tsx
@@ -176,13 +176,29 @@ describe("Actions > ActionViz > Action", () => {
       expect(screen.getByRole("button")).toHaveTextContent("Please Click Me");
     });
 
-    it("clicking an action button should open a modal action form", async () => {
+    it("clicking an action button with parameters should open a modal action form", async () => {
       await setup();
 
       userEvent.click(screen.getByRole("button"));
       expect(screen.getByRole("dialog")).toBeInTheDocument();
       expect(screen.getByTestId("action-form")).toBeInTheDocument();
       expect(screen.getByLabelText("Parameter 1")).toBeInTheDocument();
+    });
+
+    it("clicking an action button without parameters should open a confirmation modal", async () => {
+      await setup({
+        dashcard: createMockActionDashboardCard({
+          action: createMockQueryAction({
+            database_id: DATABASE.id,
+          }),
+          parameter_mappings: [],
+        }),
+      });
+
+      userEvent.click(screen.getByRole("button"));
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+      expect(screen.getByTestId("action-form")).toBeInTheDocument();
+      expect(screen.queryByLabelText(/^Parameter/)).not.toBeInTheDocument();
     });
 
     it("the modal should have the action name as a title", async () => {

--- a/frontend/src/metabase/actions/components/ActionViz/Action.unit.spec.tsx
+++ b/frontend/src/metabase/actions/components/ActionViz/Action.unit.spec.tsx
@@ -2,7 +2,13 @@ import React from "react";
 import fetchMock from "fetch-mock";
 import userEvent from "@testing-library/user-event";
 
-import { renderWithProviders, screen, getIcon, waitFor } from "__support__/ui";
+import {
+  getIcon,
+  renderWithProviders,
+  screen,
+  waitFor,
+  within,
+} from "__support__/ui";
 import {
   setupDatabasesEndpoints,
   setupUnauthorizedDatabasesEndpoints,
@@ -258,6 +264,13 @@ describe("Actions > ActionViz > Action", () => {
       });
 
       userEvent.click(screen.getByRole("button", { name: "Click me" }));
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+      expect(screen.getByTestId("action-form")).toBeInTheDocument();
+      userEvent.click(
+        within(screen.getByRole("dialog")).getByRole("button", {
+          name: action.name,
+        }),
+      );
 
       await waitFor(async () => {
         const call = fetchMock.lastCall(ACTION_EXEC_MOCK_PATH);

--- a/frontend/src/metabase/actions/components/ActionViz/ActionVizForm.tsx
+++ b/frontend/src/metabase/actions/components/ActionViz/ActionVizForm.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from "react";
 
-import useActionForm from "metabase/actions/hooks/use-action-form";
 import { getFormTitle } from "metabase/actions/utils";
 
 import type {
@@ -50,21 +49,13 @@ function ActionVizForm({
 }: ActionFormProps) {
   const [showModal, setShowModal] = useState(false);
   const title = getFormTitle(action);
-  const { getCleanValues } = useActionForm({
-    action,
-    initialValues: dashcardParamValues,
-  });
 
   // only show confirmation if there are no missing parameters
   const showConfirmMessage =
-    shouldShowConfirmation(action) && !missingParameters.length;
+    shouldShowConfirmation(action) && missingParameters.length === 0;
 
   const onClick = () => {
-    if (missingParameters.length > 0 || showConfirmMessage) {
-      setShowModal(true);
-    } else {
-      onSubmit(getCleanValues());
-    }
+    setShowModal(true);
   };
 
   const onModalSubmit = async (params: ParametersForActionExecution) => {


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/28981

### Description

Always show action confirmation modal in the dashboard, regardless of missing parameters (just like in data model actions).

### Demo

#### Before

https://github.com/metabase/metabase/assets/6830683/f60a33c2-a5f6-4569-aefe-2b1d30381cde

#### After

https://github.com/metabase/metabase/assets/6830683/df866833-f5fb-406d-a354-a6f00ff75752
