### PR TITLE
Manual backport  Do not create new revision when revert dashboard

### DIFF
--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -585,7 +585,8 @@
   {dashcardId su/IntStringGreaterThanZero}
   (api/check-not-archived (api/write-check Dashboard id))
   (when-let [dashboard-card (db/select-one DashboardCard :id (Integer/parseInt dashcardId))]
-    (api/check-500 (dashboard-card/delete-dashboard-card! dashboard-card api/*current-user-id*))
+    (api/check-500 (dashboard-card/delete-dashboard-card! (:id dashboard-card)))
+    (events/publish-event! :dashboard-remove-cards {:id id :actor_id api/*current-user-id* :dashcards [dashboard-card]})
     api/generic-204-no-content))
 
 #_{:clj-kondo/ignore [:deprecated-var]}

--- a/src/metabase/models/dashboard.clj
+++ b/src/metabase/models/dashboard.clj
@@ -191,7 +191,7 @@
             current-card    (id->current-card dashcard-id)]
         (cond
           ;; If card is in current-cards but not serialized-cards then we need to delete it
-          (not serialized-card) (dashboard-card/delete-dashboard-card! current-card user-id)
+          (not serialized-card) (dashboard-card/delete-dashboard-card! (:id current-card))
 
           ;; If card is in serialized-cards but not current-cards we need to add it
           (not current-card) (dashboard-card/create-dashboard-card! (assoc serialized-card

--- a/src/metabase/models/dashboard_card.clj
+++ b/src/metabase/models/dashboard_card.clj
@@ -170,7 +170,7 @@
   (into {}
         (filter (fn [[k v]]
                   (not= v (get old k)))
-         new)))
+                new)))
 
 (s/defn update-dashboard-card!
   "Updates an existing DashboardCard including all DashboardCardSeries.

--- a/src/metabase/models/dashboard_card.clj
+++ b/src/metabase/models/dashboard_card.clj
@@ -5,7 +5,6 @@
    [metabase.db :as mdb]
    [metabase.db.query :as mdb.query]
    [metabase.db.util :as mdb.u]
-   [metabase.events :as events]
    [metabase.models.card :refer [Card]]
    [metabase.models.dashboard-card-series :refer [DashboardCardSeries]]
    [metabase.models.interface :as mi]

--- a/src/metabase/models/dashboard_card.clj
+++ b/src/metabase/models/dashboard_card.clj
@@ -170,7 +170,7 @@
   (into {}
         (filter (fn [[k v]]
                   (not= v (get old k)))
-        new)))
+         new)))
 
 (s/defn update-dashboard-card!
   "Updates an existing DashboardCard including all DashboardCardSeries.
@@ -235,14 +235,11 @@
 
 (defn delete-dashboard-card!
   "Delete a DashboardCard."
-  [dashboard-card user-id]
-  {:pre [(map? dashboard-card)
-         (integer? user-id)]}
-  (let [{:keys [id]} (dashboard dashboard-card)]
-    (db/transaction
-      (db/delete! PulseCard :dashboard_card_id (:id dashboard-card))
-      (db/delete! DashboardCard :id (:id dashboard-card)))
-    (events/publish-event! :dashboard-remove-cards {:id id :actor_id user-id :dashcards [dashboard-card]})))
+  [dashboard-card-id]
+  {:pre [(integer? dashboard-card-id)]}
+  (db/transaction
+    (db/delete! PulseCard :dashboard_card_id dashboard-card-id)
+    (db/delete! DashboardCard :id dashboard-card-id)))
 
 ;;; ----------------------------------------------- Link cards ----------------------------------------------------
 

--- a/test/metabase/api/revision_test.clj
+++ b/test/metabase/api/revision_test.clj
@@ -228,7 +228,7 @@
         (revision/revert! :entity Dashboard :id dashboard-id :user-id (mt/user->id :crowberto) :revision-id earlier-revision-id))
 
       (testing "we have 4 revisions after revert"
-        (is (= [{:description "removed a card.", :is_creation false, :is_reversion true}
+        (is (= [{:description nil, :is_creation false, :is_reversion true}
                 {:description "removed a card.", :is_creation false, :is_reversion false}
                 {:description "added a card.", :is_creation false, :is_reversion false}
                 {:description "rearranged the cards.", :is_creation true, :is_reversion false}]

--- a/test/metabase/api/revision_test.clj
+++ b/test/metabase/api/revision_test.clj
@@ -219,18 +219,10 @@
         (create-dashboard-revision! dashboard false :crowberto))
 
       (testing "we have 3 revisions before reverting "
-        (is (= [{:description "removed a card.", :is_creation false, :is_reversion false}
-                {:description "added a card.", :is_creation false, :is_reversion false}
-                {:description "rearranged the cards.", :is_creation true, :is_reversion false}]
-               (map #(select-keys % [:description :is_creation :is_reversion])
-                    (mt/user-http-request :crowberto :get 200 "revision" :entity "dashboard" :id dashboard-id)))))
+        (is (= 3 (count (mt/user-http-request :crowberto :get 200 "revision" :entity "dashboard" :id dashboard-id)))))
+
       (let [earlier-revision-id (t2/select-one-pk Revision :model "Dashboard" :model_id dashboard-id {:order-by [[:timestamp :desc]]})]
         (revision/revert! :entity Dashboard :id dashboard-id :user-id (mt/user->id :crowberto) :revision-id earlier-revision-id))
 
       (testing "we have 4 revisions after revert"
-        (is (= [{:description nil, :is_creation false, :is_reversion true}
-                {:description "removed a card.", :is_creation false, :is_reversion false}
-                {:description "added a card.", :is_creation false, :is_reversion false}
-                {:description "rearranged the cards.", :is_creation true, :is_reversion false}]
-               (map #(select-keys % [:description :is_creation :is_reversion])
-                    (mt/user-http-request :crowberto :get 200 "revision" :entity "dashboard" :id dashboard-id))))))))
+        (is (= 4 (count (mt/user-http-request :crowberto :get 200 "revision" :entity "dashboard" :id dashboard-id))))))))

--- a/test/metabase/api/revision_test.clj
+++ b/test/metabase/api/revision_test.clj
@@ -12,7 +12,8 @@
    [metabase.util :as u]
    [toucan.db :as db]
    [toucan.util.test :as tt]
-   [toucan2.core :as t2]))
+   [toucan2.core :as t2]
+   [toucan2.tools.with-temp :as t2.with-temp]))
 
 (use-fixtures :once (fixtures/initialize :db :test-users :web-server))
 
@@ -190,3 +191,46 @@
           ;; with-non-admin-groups-no-root-collection-perms wrapper)
           (is (= "You don't have permissions to do that."
                  (mt/user-http-request :rasta :post "revision/revert" update-req))))))))
+
+(deftest revert-does-not-create-new-revision
+  (testing "revert a dashboard that previously added cards should not recreate duplicate revisions(#30869)"
+    (t2.with-temp/with-temp
+      [Dashboard  {dashboard-id :id
+                   :as dashboard}   {:name "A dashboard"}]
+      ;; 0. create the dashboard
+      (create-dashboard-revision! dashboard true :crowberto)
+
+      ;; 1. add 2 cards
+      (let [[dashcard-id-1] (t2/insert-returning-pks! DashboardCard [{:dashboard_id dashboard-id
+                                                                      :size_x       4
+                                                                      :size_y       4
+                                                                      :col          1
+                                                                      :row          1}
+                                                                     {:dashboard_id dashboard-id
+                                                                      :size_x       4
+                                                                      :size_y       4
+                                                                      :col          1
+                                                                      :row          1}])]
+
+        (create-dashboard-revision! dashboard false :crowberto)
+
+        ;; 2. delete 1 card
+        (t2/delete! DashboardCard :id dashcard-id-1)
+        (create-dashboard-revision! dashboard false :crowberto))
+
+      (testing "we have 3 revisions before reverting "
+        (is (= [{:description "removed a card.", :is_creation false, :is_reversion false}
+                {:description "added a card.", :is_creation false, :is_reversion false}
+                {:description "rearranged the cards.", :is_creation true, :is_reversion false}]
+               (map #(select-keys % [:description :is_creation :is_reversion])
+                    (mt/user-http-request :crowberto :get 200 "revision" :entity "dashboard" :id dashboard-id)))))
+      (let [earlier-revision-id (t2/select-one-pk Revision :model "Dashboard" :model_id dashboard-id {:order-by [[:timestamp :desc]]})]
+        (revision/revert! :entity Dashboard :id dashboard-id :user-id (mt/user->id :crowberto) :revision-id earlier-revision-id))
+
+      (testing "we have 4 revisions after revert"
+        (is (= [{:description "removed a card.", :is_creation false, :is_reversion true}
+                {:description "removed a card.", :is_creation false, :is_reversion false}
+                {:description "added a card.", :is_creation false, :is_reversion false}
+                {:description "rearranged the cards.", :is_creation true, :is_reversion false}]
+               (map #(select-keys % [:description :is_creation :is_reversion])
+                    (mt/user-http-request :crowberto :get 200 "revision" :entity "dashboard" :id dashboard-id))))))))

--- a/test/metabase/models/dashboard_test.clj
+++ b/test/metabase/models/dashboard_test.clj
@@ -150,7 +150,7 @@
                                :series  true}]}
                (update serialized-dashboard :cards check-ids))))
       (testing "delete the dashcard and modify the dash attributes"
-        (dashboard-card/delete-dashboard-card! dashboard-card (test.users/user->id :rasta))
+        (dashboard-card/delete-dashboard-card! (:id dashboard-card))
         (db/update! Dashboard dashboard-id
           :name        "Revert Test"
           :description "something")


### PR DESCRIPTION
Manual backport of https://github.com/metabase/metabase/pull/30868

The change is not identical because the API in master has changed -- we no longer has the `DELETE /api/dashboard/:id/cards` in master.

But the idea should be the same, the event should be fired from API only, not when we revert the dashboard