### PR TITLE
Fix models sometimes missing from native query reference autocomplete results

### DIFF
--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -518,7 +518,8 @@
                              (and (empty? search-id) (not-empty search-name))
                              [:like [:lower :report_card.name] (str "%" search-name "%")])]
                 :left-join [[:collection :collection] [:= :collection.id :report_card.collection_id]]
-                :order-by [[:report_card.id :desc]]
+                :order-by [[:dataset :desc]         ; prioritize models
+                           [:report_card.id :desc]] ; then most recently created
                 :limit    50})))
 
 (defn- autocomplete-fields [db-id search-string limit]


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/31063

This PR solves the issue by prioritizing models over questions in the results from the GET `/api/database/:id/card_autocomplete_suggestions` endpoint.