### PR TITLE
Handle case when table is not found after uploading CSV

### DIFF
--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -1153,6 +1153,10 @@ saved later when it is ready."
         _                 (upload/load-from-csv driver db-id schema+table-name csv-file)
         _                 (sync/sync-database! database)
         table-id          (t2/select-one-fn :id Table :db_id db-id :%lower.name table-name)]
+    (when (nil? table-id)
+      (driver/drop-table driver db-id table-name)
+      (throw (ex-info (tru "The CSV file was uploaded to {0} but the table could not be found on sync." schema+table-name)
+                      {:status-code 422})))
     (create-card!
      {:collection_id          collection-id,
       :dataset                true


### PR DESCRIPTION
During CSV upload, we (1) create a table with a certain name and schema, then (2) sync, then (3) look for the table in `metabase_table`.

This PR handles the case when the table can't be found in `metabase_table` at step (3), by raising an error with a helpful error message and deleting the table.

It can happen if the table is uploaded to a schema that is excluded with the schema filters for the database
https://files.slack.com/files-pri/T078VCLCR-F0593NQ70HJ/screenshot_2023-05-23_at_12.18.05.png

But this is just one known example of why a table might not be found. We should catch this when it happens and raise an error for our future selves to debug more easily.

[Slack context](https://metaboat.slack.com/archives/C04S696LRUM/p1684833546373069?thread_ts=1684419451.537999&cid=C04S696LRUM)