### PR TITLE
Updates test runner and tests to use new mb.hawk namespaces

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -208,7 +208,7 @@
     com.gfredericks/test.chuck   {:mvn/version "0.2.14"}                    ; generating strings from regexes (useful with malli)
     djblue/portal                {:mvn/version "0.40.0"}                    ; ui for inspecting values
     io.github.camsaul/humane-are {:mvn/version "1.0.2"}
-    io.github.metabase/hawk      {:sha "45ed36008014f9ac1ea66beb56fb1c4c39f8342b"}
+    io.github.metabase/hawk      {:sha "70611745e3cb8b95d5793a88581d5c330148715b"}
     jonase/eastwood              {:mvn/version "1.3.0"}                     ; inspects namespaces and reports possible problems using tools.analyzer
     lambdaisland/deep-diff2      {:mvn/version "2.7.169"}                   ; way better diffs
     methodical/methodical        {:mvn/version "0.15.1"}                    ; drop-in replacements for Clojure multimethods and adds several advanced features
@@ -304,7 +304,7 @@
     cider/piggieback                   {:mvn/version "0.5.3"}
     cljs-bean/cljs-bean                {:mvn/version "1.9.0"}
     com.lambdaisland/glogi             {:mvn/version "1.2.164"}
-    io.github.metabase/hawk            {:sha "45ed36008014f9ac1ea66beb56fb1c4c39f8342b"}
+    io.github.metabase/hawk            {:sha "70611745e3cb8b95d5793a88581d5c330148715b"}
     ;; Forcibly targeting a newer release than ships by default with shadow-cljs 2.20.20.
     ;; It fixes an issue where TypeScript can't parse the `cljs_env.js` output file.
     org.clojure/google-closure-library {:mvn/version "0.0-20230227-c7c0a541"}
@@ -587,7 +587,7 @@
   ;;;
   ;;; clj -X:dev:drivers:build:build-dev:build-test
   :build-test
-  {:exec-fn   hawk.core/find-and-run-tests-cli
+  {:exec-fn   mb.hawk.core/find-and-run-tests-cli
    :exec-args {:only ["bin/build/test"]}}
 
 

--- a/dev/src/user.clj
+++ b/dev/src/user.clj
@@ -1,12 +1,12 @@
 (ns user
   (:require
-   [hawk.assert-exprs]
+   [mb.hawk.assert-exprs]
    [metabase.bootstrap]
    [metabase.test-runner.assert-exprs]))
 
 (comment metabase.bootstrap/keep-me
          ;; make sure stuff like `schema=` and what not are loaded
-         hawk.assert-exprs/keep-me
+         mb.hawk.assert-exprs/keep-me
          metabase.test-runner.assert-exprs/keep-me)
 
 (defn dev

--- a/test/metabase/api/common_test.clj
+++ b/test/metabase/api/common_test.clj
@@ -1,7 +1,7 @@
 (ns metabase.api.common-test
   (:require
    [clojure.test :refer :all]
-   [hawk.assert-exprs.approximately-equal :as hawk.approx]
+   [mb.hawk.assert-exprs.approximately-equal :as hawk.approx]
    [metabase.api.common :as api]
    [metabase.api.common.internal :as api.internal]
    [metabase.server.middleware.exceptions :as mw.exceptions]

--- a/test/metabase/query_processor_test.clj
+++ b/test/metabase/query_processor_test.clj
@@ -6,7 +6,7 @@
    [clojure.set :as set]
    [clojure.string :as str]
    [clojure.test :refer :all]
-   [hawk.init]
+   [mb.hawk.init]
    [metabase.db.connection :as mdb.connection]
    [metabase.driver :as driver]
    [metabase.models.field :refer [Field]]
@@ -44,7 +44,7 @@
   {:pre [(every? keyword? (cons feature more-features))]}
   ;; Can't use [[normal-drivers-with-feature]] during test initialization, because it means we end up having to load
   ;; plugins and a bunch of other nonsense.
-  (hawk.init/assert-tests-are-not-initializing (pr-str (list* 'normal-drivers-with-feature feature more-features)))
+  (mb.hawk.init/assert-tests-are-not-initializing (pr-str (list* 'normal-drivers-with-feature feature more-features)))
   (let [features (set (cons feature more-features))]
     (set (for [driver (normal-drivers)
                :let   [driver (tx/the-driver-with-test-extensions driver)]

--- a/test/metabase/test.clj
+++ b/test/metabase/test.clj
@@ -8,10 +8,10 @@
    [clojure.data]
    [clojure.test :refer :all]
    [environ.core :as env]
-   [hawk.init]
-   [hawk.parallel]
    [humane-are.core :as humane-are]
    [java-time :as t]
+   [mb.hawk.init]
+   [mb.hawk.parallel]
    [medley.core :as m]
    [metabase.actions.test-util :as actions.test-util]
    [metabase.config :as config]
@@ -285,7 +285,7 @@
 ;;; TODO -- move all the stuff below into some other namespace and import it here.
 
 (defn do-with-clock [clock thunk]
-  (hawk.parallel/assert-test-is-not-parallel "with-clock")
+  (mb.hawk.parallel/assert-test-is-not-parallel "with-clock")
   (testing (format "\nsystem clock = %s" (pr-str clock))
     (let [clock (cond
                   (t/clock? clock)           clock
@@ -418,6 +418,6 @@
           ;; TIMESTAMP columns (which only have second resolution by default)
           (dissoc things-in-both :created_at :updated_at)))))
    (fn [toucan-model]
-     (hawk.init/assert-tests-are-not-initializing (list 'object-defaults (symbol (name toucan-model))))
+     (mb.hawk.init/assert-tests-are-not-initializing (list 'object-defaults (symbol (name toucan-model))))
      (initialize/initialize-if-needed! :db)
      (t2.model/resolve-model toucan-model))))

--- a/test/metabase/test/data.clj
+++ b/test/metabase/test/data.clj
@@ -36,7 +36,7 @@
   (:require
    [clojure.test :as t]
    [colorize.core :as colorize]
-   [hawk.init]
+   [mb.hawk.init]
    [metabase.db :as mdb]
    [metabase.db.schema-migrations-test.impl
     :as schema-migrations-test.impl]
@@ -201,7 +201,7 @@
   "Get the ID of the current database or one of its Tables or Fields. Relies on the dynamic variable `*get-db*`, which
   can be rebound with `with-db`."
   ([]
-   (hawk.init/assert-tests-are-not-initializing "(mt/id ...) or (data/id ...)")
+   (mb.hawk.init/assert-tests-are-not-initializing "(mt/id ...) or (data/id ...)")
    (u/the-id (db)))
 
   ([table-name]

--- a/test/metabase/test/data/interface.clj
+++ b/test/metabase/test/data/interface.clj
@@ -9,7 +9,7 @@
    [clojure.string :as str]
    [clojure.tools.reader.edn :as edn]
    [environ.core :as env]
-   [hawk.init]
+   [mb.hawk.init]
    [medley.core :as m]
    [metabase.db :as mdb]
    [metabase.driver :as driver]
@@ -164,7 +164,7 @@
   "Like `driver/the-driver`, but guaranteed to return a driver with test extensions loaded, throwing an Exception
   otherwise. Loads driver and test extensions automatically if not already done."
   [driver]
-  (hawk.init/assert-tests-are-not-initializing (pr-str (list 'the-driver-with-test-extensions driver)))
+  (mb.hawk.init/assert-tests-are-not-initializing (pr-str (list 'the-driver-with-test-extensions driver)))
   (initialize/initialize-if-needed! :plugins)
   (let [driver (driver/the-initialized-driver driver)]
     (load-test-extensions-namespace-if-needed driver)

--- a/test/metabase/test/initialize.clj
+++ b/test/metabase/test/initialize.clj
@@ -2,7 +2,7 @@
   "Logic for initializing different components that need to be initialized when running tests."
   (:require
    [clojure.string :as str]
-   [hawk.init]
+   [mb.hawk.init]
    [metabase.config :as config]
    [metabase.plugins.classloader :as classloader]
    [metabase.util :as u]
@@ -55,7 +55,7 @@
   ;; `:plugins` initialization is ok when loading test namespaces. Nothing else is tho (e.g. starting up the
   ;; application DB, or starting up the web server).
   (when-not (= steps [:plugins])
-    (hawk.init/assert-tests-are-not-initializing (pr-str (cons 'initialize-if-needed! steps))))
+    (mb.hawk.init/assert-tests-are-not-initializing (pr-str (cons 'initialize-if-needed! steps))))
   (doseq [step steps
           :let [step (keyword step)]]
     (when-not (@initialized step)

--- a/test/metabase/test/redefs.clj
+++ b/test/metabase/test/redefs.clj
@@ -2,7 +2,7 @@
   "Redefinitions of vars from 3rd-party namespaces to make sure they do extra stuff we want (like initialize things if
   needed when running)."
   (:require
-   [hawk.parallel]
+   [mb.hawk.parallel]
    [metabase.plugins.classloader :as classloader]
    [methodical.core :as methodical]
    [toucan2.tools.with-temp :as t2.with-temp]))
@@ -19,7 +19,7 @@
   ;;
   ;; TODO -- there's not really a reason that we can't use with-temp in parallel tests -- it depends on the test -- so
   ;; once we're a little more comfortable with the current parallel stuff we should remove this restriction.
-  (hawk.parallel/assert-test-is-not-parallel "with-temp")
+  (mb.hawk.parallel/assert-test-is-not-parallel "with-temp")
   (next-method model attributes f))
 
 ;;; wrap `with-redefs-fn` (used by `with-redefs`) so it calls `assert-test-is-not-parallel`
@@ -27,7 +27,7 @@
 (defonce orig-with-redefs-fn with-redefs-fn)
 
 (defn new-with-redefs-fn [& args]
-  (hawk.parallel/assert-test-is-not-parallel "with-redefs")
+  (mb.hawk.parallel/assert-test-is-not-parallel "with-redefs")
   (apply orig-with-redefs-fn args))
 
 (alter-var-root #'with-redefs-fn (constantly new-with-redefs-fn))

--- a/test/metabase/test/util/log.clj
+++ b/test/metabase/test/util/log.clj
@@ -5,7 +5,7 @@
    #_{:clj-kondo/ignore [:discouraged-namespace]}
    [clojure.tools.logging :as log]
    [clojure.tools.logging.impl :as log.impl]
-   [hawk.parallel]
+   [mb.hawk.parallel]
    [metabase.plugins.classloader :as classloader]
    [net.cgrand.macrovich :as macros]
    [potemkin :as p]
@@ -130,7 +130,7 @@
      (.updateLoggers (logger-context)))))
 
 (defn do-with-log-level [a-namespace level thunk]
-  (hawk.parallel/assert-test-is-not-parallel "with-log-level")
+  (mb.hawk.parallel/assert-test-is-not-parallel "with-log-level")
   (ensure-unique-logger! a-namespace)
   (let [original-log-level (ns-log-level a-namespace)
         logger             (exact-ns-logger a-namespace)
@@ -216,7 +216,7 @@
     (:logs @state)))
 
 (defn do-with-log-messages-for-level [a-namespace level f]
-  (hawk.parallel/assert-test-is-not-parallel "with-log-messages-for-level")
+  (mb.hawk.parallel/assert-test-is-not-parallel "with-log-messages-for-level")
   (ensure-unique-logger! a-namespace)
   (let [state         (atom nil)
         appender-name (format "%s-%s-%s" `InMemoryAppender (logger-name a-namespace) (name level))

--- a/test/metabase/test/util/timezone.clj
+++ b/test/metabase/test/util/timezone.clj
@@ -1,7 +1,7 @@
 (ns metabase.test.util.timezone
   (:require
    [clojure.test :as t]
-   [hawk.parallel]
+   [mb.hawk.parallel]
    [metabase.driver :as driver]
    [metabase.test.initialize :as initialize])
   (:import
@@ -18,7 +18,7 @@
              (= original-system-property timezone-id))
       (thunk)
       (do
-        (hawk.parallel/assert-test-is-not-parallel "with-system-timezone-id")
+        (mb.hawk.parallel/assert-test-is-not-parallel "with-system-timezone-id")
         ;; only if the app DB is already set up, we need to make sure plugins are loaded and kill any connection pools that
         ;; might exist
         (when (initialize/initialized? :db)

--- a/test/metabase/test_runner.clj
+++ b/test/metabase/test_runner.clj
@@ -5,8 +5,8 @@
    [clojure.java.io :as io]
    [clojure.set :as set]
    [clojure.string :as str]
-   [hawk.core :as hawk]
    [humane-are.core :as humane-are]
+   [mb.hawk.core :as hawk]
    [metabase.bootstrap]
    [metabase.config :as config]
    [metabase.query-processor-test.test-mlv2 :as qp-test.mlv2]
@@ -90,9 +90,9 @@
 (defn find-and-run-tests-repl
   "Find and run tests from the REPL."
   [options]
-  (hawk.core/find-and-run-tests-repl (merge (default-options) options)))
+  (hawk/find-and-run-tests-repl (merge (default-options) options)))
 
 (defn find-and-run-tests-cli
   "Entrypoint for `clojure -X:test`."
   [options]
-  (hawk.core/find-and-run-tests-cli (merge (default-options) options)))
+  (hawk/find-and-run-tests-cli (merge (default-options) options)))


### PR DESCRIPTION
This updates our test runner to a recent version and updates our code to reflect the new namespaces.