### PR TITLE
[MLv2] Support `:case` expressions in aggregations

### DIFF
--- a/src/metabase/lib/common.cljc
+++ b/src/metabase/lib/common.cljc
@@ -28,8 +28,17 @@
   :hierarchy lib.hierarchy/hierarchy)
 
 (defmethod ->op-arg :default
-  [_query _stage-number x]
-  x)
+  [query stage-number x]
+  (if (and (vector? x)
+           (keyword? (first x)))
+    ;; MBQL clause
+    (mapv #(->op-arg query stage-number %) x)
+    ;; Something else - just return it
+    x))
+
+(defmethod ->op-arg :dispatch-type/sequential
+  [query stage-number xs]
+  (mapv #(->op-arg query stage-number %) xs))
 
 (defmethod ->op-arg :metadata/field
   [_query _stage-number field-metadata]

--- a/test/metabase/query_processor_test/test_mlv2.clj
+++ b/test/metabase/query_processor_test/test_mlv2.clj
@@ -42,13 +42,7 @@
      #{:datetime-add :datetime-subtract :convert-timezone}
      (mbql.u/match-one &match
        [_tag (_literal :guard string?) & _]
-       "#29910"))
-   ;; #29935: metadata for an `:aggregation` with a `:case` expression not working
-   (mbql.u/match-one legacy-query
-     {:aggregation aggregations}
-     (mbql.u/match-one aggregations
-       :case
-       "#29935"))))
+       "#29910"))))
 
 (defn- test-mlv2-metadata [original-query _qp-metadata]
   {:pre [(map? original-query)]}


### PR DESCRIPTION
Fixes #29935.

Part of the issue here was incorrect hand-rolling of the second
argument to `:case`, the default value. In the failing test case given
in #29935, it was written as `{:default 0}`. But that's accidentally
transferring for legacy MBQL works, where the default is an option and
the options come last rather than first in a clause.

This also fixes `lib.common/->op-arg` to make sure it recurses
properly. It wasn't recursing into lists or MBQL clauses, which left
unresolved `(fn [query stage] ...)` functions in eg. `:case`
alternatives, since those are nested inside lists.
