### PR TITLE
[Model Indexes] Fix cache invalidation issue

### DIFF
--- a/e2e/test/scenarios/models/model-indexes.cy.spec.js
+++ b/e2e/test/scenarios/models/model-indexes.cy.spec.js
@@ -29,7 +29,7 @@ describe("scenarios > model indexes", () => {
     });
   });
 
-  it("should create and delete a model index on product titles", () => {
+  it("should create, delete, and re-create a model index on product titles", () => {
     cy.visit(`/model/${modelId}`);
     cy.wait("@dataset");
 
@@ -64,6 +64,27 @@ describe("scenarios > model indexes", () => {
     cy.wait("@modelIndexDelete").then(({ request, response }) => {
       expect(request.url).to.include("/api/model-index/1");
       expect(response.statusCode).to.equal(200);
+    });
+
+    cy.wait("@dataset");
+
+    editTitleMetadata();
+
+    sidebar()
+      .findByLabelText(/surface individual records/i)
+      .click();
+
+    cy.findByTestId("dataset-edit-bar").within(() => {
+      cy.button("Save changes").click();
+    });
+
+    // this tests redux cache invalidation (#31407)
+    cy.wait("@modelIndexCreate").then(({ request, response }) => {
+      expect(request.body.model_id).to.equal(modelId);
+
+      // this will likely change when this becomes an async process
+      expect(response.body.state).to.equal("indexed");
+      expect(response.body.id).to.equal(2);
     });
   });
 

--- a/frontend/src/metabase/entities/model-indexes/actions.ts
+++ b/frontend/src/metabase/entities/model-indexes/actions.ts
@@ -25,10 +25,10 @@ export const updateModelIndexes =
       return;
     }
 
-    const existingIndexes: ModelIndex[] = ModelIndexes.selectors.getList(
-      getState(),
-      { entityQuery: { model_id: model.id() } },
-    );
+    const existingIndexes: ModelIndex[] =
+      ModelIndexes.selectors.getList(getState(), {
+        entityQuery: { model_id: model.id() },
+      }) ?? [];
 
     const newFieldsToIndex = getFieldsToIndex(
       fieldsWithIndexFlags,
@@ -109,7 +109,7 @@ function getIndexIdsToRemove(
   return indexIdsToRemove;
 }
 
-export function cleanIndexFlags(fields: Field[]) {
+export function cleanIndexFlags(fields: Field[] = []) {
   const indexesToClean = fields.reduce(
     (
       indexesToClean: number[],

--- a/frontend/src/metabase/entities/model-indexes/actions.ts
+++ b/frontend/src/metabase/entities/model-indexes/actions.ts
@@ -25,10 +25,10 @@ export const updateModelIndexes =
       return;
     }
 
-    const existingIndexes: ModelIndex[] =
-      ModelIndexes.selectors.getIndexesForModel(getState(), {
-        modelId: model.id(),
-      });
+    const existingIndexes: ModelIndex[] = ModelIndexes.selectors.getList(
+      getState(),
+      { entityQuery: { model_id: model.id() } },
+    );
 
     const newFieldsToIndex = getFieldsToIndex(
       fieldsWithIndexFlags,

--- a/frontend/src/metabase/entities/model-indexes/actions.unit.spec.ts
+++ b/frontend/src/metabase/entities/model-indexes/actions.unit.spec.ts
@@ -85,7 +85,9 @@ describe("Entities > model-indexes > actions", () => {
       setupModelIndexEndpoints(model.id(), []);
 
       const mockDispatch = jest.fn();
-      const mockGetState = jest.fn(() => ({ entities: { modelIndexes: [] } }));
+      const mockGetState = jest.fn(() => ({
+        entities: { modelIndexes: {}, modelIndexes_list: {} },
+      }));
       await updateModelIndexes(model)(mockDispatch, mockGetState);
 
       expect(mockDispatch).toHaveBeenCalled();
@@ -113,6 +115,7 @@ describe("Entities > model-indexes > actions", () => {
 
       const existingModelIndex = createMockModelIndex({
         id: 99,
+        model_id: 1,
         value_ref: indexFieldRef,
       });
 
@@ -123,7 +126,7 @@ describe("Entities > model-indexes > actions", () => {
         entities: {
           modelIndexes: { 99: existingModelIndex },
           modelIndexes_list: {
-            '{"model_id":1': {
+            '{"model_id":1}': {
               list: [99],
               metadata: {},
             },
@@ -163,7 +166,7 @@ describe("Entities > model-indexes > actions", () => {
         entities: {
           modelIndexes: { 99: existingModelIndex },
           modelIndexes_list: {
-            '{"model_id":1': {
+            '{"model_id":1}': {
               list: [99],
               metadata: {},
             },
@@ -194,7 +197,9 @@ describe("Entities > model-indexes > actions", () => {
       setupModelIndexEndpoints(model.id(), []);
 
       const mockDispatch = jest.fn();
-      const mockGetState = jest.fn(() => ({ entities: { modelIndexes: [] } }));
+      const mockGetState = jest.fn(() => ({
+        entities: { modelIndexes: {}, modelIndexes_list: {} },
+      }));
       await updateModelIndexes(model)(mockDispatch, mockGetState);
 
       expect(mockDispatch).toHaveBeenCalled();

--- a/frontend/src/metabase/entities/model-indexes/model-indexes.ts
+++ b/frontend/src/metabase/entities/model-indexes/model-indexes.ts
@@ -5,7 +5,6 @@
  */
 
 import type { IndexedEntity } from "metabase-types/api/modelIndexes";
-import type { State } from "metabase-types/store";
 
 import { createEntity } from "metabase/lib/entities";
 import { ModelIndexApi } from "metabase/services";
@@ -29,16 +28,7 @@ export const ModelIndexes = createEntity({
     getUrl: (entity: IndexedEntity) => `/model/${entity.model_id}/${entity.id}`,
     getIcon: () => ({ name: "beaker" }),
   },
-  // objectActions: {},
   reducer: (state = {}, { type, payload }: { type: string; payload: any }) => {
     return state;
   },
-  selectors: {
-    getIndexesForModel: (state: State, { modelId }: { modelId: number }) => {
-      return Object.values(state.entities.modelIndexes).filter(
-        index => index.model_id === modelId,
-      );
-    },
-  },
-  // objectSelectors: {},
 });


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/31047

### Description

The issue:
> This one is pretty niche, but should still be handled:
> - if you enable model index on a field
> - then (without page refresh) disable a model-index on a field
> - then try to enable a model index on the same field
> - it fails silently 😢
> This is because for some reason, we're not properly invalidating the model-index entity cache, and the existing model-index doesn't get removed from the local redux store, and the logic that tries to prevent duplicate indexes from being created prevents an index from being created because the frontend thinks there's already and index on that model.

As it turns out I didn't need to make my own selector for selecting a list of model index entities, and doing so caused this bug because we keep the individual items cached and only invalidate the list of ids.

### How to verify

See repro in the issue, or run the e2e test.

- [x] Tests have been added/updated to cover changes in this PR
