### PR TITLE
Generically typed item picker

### DIFF
--- a/frontend/src/metabase/collections/containers/FormCollectionPicker/FormCollectionPicker.tsx
+++ b/frontend/src/metabase/collections/containers/FormCollectionPicker/FormCollectionPicker.tsx
@@ -37,8 +37,6 @@ export interface FormCollectionPickerProps
   type?: "collections" | "snippet-collections";
 }
 
-const ITEM_PICKER_MODELS = ["collection"];
-
 function ItemName({
   id,
   type = "collections",
@@ -106,9 +104,9 @@ function FormCollectionPicker({
       return (
         <PopoverItemPicker
           value={{ id: value, model: "collection" }}
-          models={ITEM_PICKER_MODELS}
+          models={["collection"]}
           entity={entity}
-          onChange={({ id }: { id: CollectionId }) => {
+          onChange={({ id }) => {
             setValue(id);
             closePopover();
           }}

--- a/frontend/src/metabase/components/DashboardSelector/DashboardSelector.tsx
+++ b/frontend/src/metabase/components/DashboardSelector/DashboardSelector.tsx
@@ -10,7 +10,7 @@ import {
 } from "./DashboardSelector.styled";
 
 interface DashboardSelectorProps {
-  onChange: (value?: number | null | string) => void;
+  onChange: (value?: DashboardId) => void;
   value?: DashboardId;
   collectionFilter?: (collection: Collection) => boolean;
 }

--- a/frontend/src/metabase/containers/DashboardPicker.tsx
+++ b/frontend/src/metabase/containers/DashboardPicker.tsx
@@ -1,9 +1,10 @@
-import { CollectionId } from "metabase-types/api";
-import ItemPicker, { PickerValue, PickerItemId } from "./ItemPicker";
+import React from "react";
+import { CollectionId, DashboardId } from "metabase-types/api";
+import ItemPicker, { PickerValue } from "./ItemPicker";
 
 export interface DashboardPickerProps {
-  value?: PickerItemId;
-  onChange: (dashboardId: PickerItemId | undefined) => void;
+  value?: DashboardId;
+  onChange: (dashboardId: DashboardId) => void;
   collectionId?: CollectionId;
 }
 
@@ -13,13 +14,11 @@ const DashboardPicker = ({
   collectionId,
   ...props
 }: DashboardPickerProps) => (
-  <ItemPicker
+  <ItemPicker<DashboardId>
     {...props}
     initialOpenCollectionId={collectionId}
     value={value === undefined ? undefined : { model: "dashboard", id: value }}
-    onChange={(dashboard: PickerValue) =>
-      onChange(dashboard ? dashboard.id : undefined)
-    }
+    onChange={dashboard => onChange(dashboard.id)}
     models={["dashboard"]}
   />
 );

--- a/frontend/src/metabase/containers/DashboardPicker.tsx
+++ b/frontend/src/metabase/containers/DashboardPicker.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { CollectionId, DashboardId } from "metabase-types/api";
-import ItemPicker, { PickerValue } from "./ItemPicker";
+import ItemPicker from "./ItemPicker";
 
 export interface DashboardPickerProps {
   value?: DashboardId;
@@ -14,7 +14,7 @@ const DashboardPicker = ({
   collectionId,
   ...props
 }: DashboardPickerProps) => (
-  <ItemPicker<DashboardId>
+  <ItemPicker
     {...props}
     initialOpenCollectionId={collectionId}
     value={value === undefined ? undefined : { model: "dashboard", id: value }}

--- a/frontend/src/metabase/containers/DashboardPicker.tsx
+++ b/frontend/src/metabase/containers/DashboardPicker.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { CollectionId, DashboardId } from "metabase-types/api";
 import ItemPicker from "./ItemPicker";
 

--- a/frontend/src/metabase/containers/ItemPicker/Item.tsx
+++ b/frontend/src/metabase/containers/ItemPicker/Item.tsx
@@ -3,23 +3,23 @@ import _ from "underscore";
 
 import { Icon, IconName, IconProps } from "metabase/core/components/Icon";
 
-import type { PickerItem, PickerItemId } from "./types";
+import type { PickerItem } from "./types";
 
 import { ItemRoot, ItemContent, ItemTitle, ExpandButton } from "./Item.styled";
 
-interface Props {
-  item: PickerItem;
+interface Props<T> {
+  item: PickerItem<T>;
   name: string;
   icon: IconName | IconProps;
   color: string;
   selected: boolean;
   canSelect: boolean;
   hasChildren?: boolean;
-  onChange: (item: PickerItem) => void;
-  onChangeOpenCollectionId?: (id: PickerItemId) => void;
+  onChange: (item: PickerItem<T>) => void;
+  onChangeOpenCollectionId?: (id: T) => void;
 }
 
-function Item({
+function Item<T>({
   item,
   name,
   icon,
@@ -29,7 +29,7 @@ function Item({
   hasChildren,
   onChange,
   onChangeOpenCollectionId,
-}: Props) {
+}: Props<T>) {
   const handleClick = useMemo(() => {
     if (canSelect) {
       return () => onChange(item);

--- a/frontend/src/metabase/containers/ItemPicker/Item.tsx
+++ b/frontend/src/metabase/containers/ItemPicker/Item.tsx
@@ -7,19 +7,19 @@ import type { PickerItem } from "./types";
 
 import { ItemRoot, ItemContent, ItemTitle, ExpandButton } from "./Item.styled";
 
-interface Props<T> {
-  item: PickerItem<T>;
+interface Props<TId> {
+  item: PickerItem<TId>;
   name: string;
   icon: IconName | IconProps;
   color: string;
   selected: boolean;
   canSelect: boolean;
   hasChildren?: boolean;
-  onChange: (item: PickerItem<T>) => void;
-  onChangeOpenCollectionId?: (id: T) => void;
+  onChange: (item: PickerItem<TId>) => void;
+  onChangeOpenCollectionId?: (id: TId) => void;
 }
 
-function Item<T>({
+function Item<TId>({
   item,
   name,
   icon,
@@ -29,7 +29,7 @@ function Item<T>({
   hasChildren,
   onChange,
   onChangeOpenCollectionId,
-}: Props<T>) {
+}: Props<TId>) {
   const handleClick = useMemo(() => {
     if (canSelect) {
       return () => onChange(item);

--- a/frontend/src/metabase/containers/ItemPicker/ItemPicker.tsx
+++ b/frontend/src/metabase/containers/ItemPicker/ItemPicker.tsx
@@ -239,28 +239,15 @@ function ItemPicker<T>({
 }
 
 // eslint-disable-next-line import/no-default-export -- deprecated usage
-// export default _.compose(
-//   entityObjectLoader({
-//     id: "root",
-//     entityType: getEntityLoaderType,
-//     loadingAndErrorWrapper: false,
-//   }),
-//   entityListLoader({
-//     entityType: getEntityLoaderType,
-//     loadingAndErrorWrapper: false,
-//   }),
-//   connect(mapStateToProps),
-// )(ItemPicker);
-
-export default (function <T>() {
-  return entityObjectLoader({
+export default _.compose(
+  entityObjectLoader({
     id: "root",
     entityType: getEntityLoaderType,
     loadingAndErrorWrapper: false,
-  })(
-    entityListLoader({
-      entityType: getEntityLoaderType,
-      loadingAndErrorWrapper: false,
-    }),
-  )(connect(mapStateToProps)(ItemPicker<T>));
-} as React.FC);
+  }),
+  entityListLoader({
+    entityType: getEntityLoaderType,
+    loadingAndErrorWrapper: false,
+  }),
+  connect(mapStateToProps),
+)(ItemPicker) as <T>(props: OwnProps<T>) => JSX.Element;

--- a/frontend/src/metabase/containers/ItemPicker/ItemPicker.tsx
+++ b/frontend/src/metabase/containers/ItemPicker/ItemPicker.tsx
@@ -146,7 +146,6 @@ function ItemPicker<T>({
       if (!value || !item) {
         return false;
       }
-      console.log(value);
       const isSameModel = item.model === value.model || models.length === 1;
       return isSameModel && getItemId(item) === getItemId(value);
     },
@@ -197,7 +196,7 @@ function ItemPicker<T>({
         item.model === "collection" &&
         isRootCollection(item as unknown as Collection)
       ) {
-        onChange({ id: null, model: "collection" } as PickerItem<T>);
+        onChange({ id: null, model: "collection" } as unknown as PickerItem<T>);
       } else {
         onChange(item);
       }

--- a/frontend/src/metabase/containers/ItemPicker/ItemPicker.tsx
+++ b/frontend/src/metabase/containers/ItemPicker/ItemPicker.tsx
@@ -27,15 +27,15 @@ import type {
 import ItemPickerView from "./ItemPickerView";
 import { ScrollAwareLoadingAndErrorWrapper } from "./ItemPicker.styled";
 
-interface OwnProps<T> {
-  value?: PickerValue<T>;
+interface OwnProps<TId> {
+  value?: PickerValue<TId>;
   models: PickerModel[];
   entity?: typeof Collections; // collections/snippets entity
   showSearch?: boolean;
   showScroll?: boolean;
   className?: string;
   style?: React.CSSProperties;
-  onChange: (value: PickerValue<T>) => void;
+  onChange: (value: PickerValue<TId>) => void;
   initialOpenCollectionId?: CollectionId;
   collectionFilter?: (collection: Collection) => boolean;
 }
@@ -45,7 +45,7 @@ interface StateProps {
   getCollectionIcon: (collection: Collection) => IconProps;
 }
 
-type Props<T> = OwnProps<T> & StateProps;
+type Props<TId> = OwnProps<TId> & StateProps;
 
 function canWriteToCollectionOrChildren(collection: Collection) {
   return (
@@ -54,7 +54,7 @@ function canWriteToCollectionOrChildren(collection: Collection) {
   );
 }
 
-function mapStateToProps<T>(state: State, props: OwnProps<T>) {
+function mapStateToProps<TId>(state: State, props: OwnProps<TId>) {
   const entity = props.entity || Collections;
   return {
     collectionsById: entity.selectors.getExpandedCollectionsById(state, props),
@@ -62,11 +62,11 @@ function mapStateToProps<T>(state: State, props: OwnProps<T>) {
   };
 }
 
-function getEntityLoaderType<T>(state: State, props: OwnProps<T>) {
+function getEntityLoaderType<TId>(state: State, props: OwnProps<TId>) {
   return props.entity?.name ?? "collections";
 }
 
-function getItemId<T>(item: PickerItem<T> | PickerValue<T>) {
+function getItemId<TId>(item: PickerItem<TId> | PickerValue<TId>) {
   if (!item) {
     return;
   }
@@ -76,7 +76,7 @@ function getItemId<T>(item: PickerItem<T> | PickerValue<T>) {
   return item.id;
 }
 
-function ItemPicker<T>({
+function ItemPicker<TId>({
   value,
   models,
   collectionsById,
@@ -87,7 +87,7 @@ function ItemPicker<T>({
   onChange,
   getCollectionIcon,
   initialOpenCollectionId = "root",
-}: Props<T>) {
+}: Props<TId>) {
   const [openCollectionId, setOpenCollectionId] = useState<CollectionId>(
     initialOpenCollectionId,
   );
@@ -116,7 +116,7 @@ function ItemPicker<T>({
         model: "collection",
       }));
 
-    return collectionItems as CollectionPickerItem<T>[];
+    return collectionItems as CollectionPickerItem<TId>[];
   }, [openCollection, models]);
 
   const crumbs = useMemo(
@@ -142,7 +142,7 @@ function ItemPicker<T>({
   }, [models, searchString, openCollectionId]);
 
   const checkIsItemSelected = useCallback(
-    (item: PickerItem<T>) => {
+    (item: PickerItem<TId>) => {
       if (!value || !item) {
         return false;
       }
@@ -153,7 +153,7 @@ function ItemPicker<T>({
   );
 
   const checkCollectionMaybeHasChildren = useCallback(
-    (collection: CollectionPickerItem<T>) => {
+    (collection: CollectionPickerItem<TId>) => {
       if (isPickingNotCollection) {
         // Non-collection models (e.g. questions, dashboards)
         // are loaded on-demand so we don't know ahead of time
@@ -174,7 +174,7 @@ function ItemPicker<T>({
   );
 
   const checkHasWritePermissionForItem = useCallback(
-    (item: PickerItem<T>) => {
+    (item: PickerItem<TId>) => {
       // if user is selecting a collection, they must have a `write` access to it
       if (models.includes("collection") && item.model === "collection") {
         return item.can_write;
@@ -191,12 +191,15 @@ function ItemPicker<T>({
   );
 
   const handleChange = useCallback(
-    (item: PickerItem<T>) => {
+    (item: PickerItem<TId>) => {
       if (
         item.model === "collection" &&
         isRootCollection(item as unknown as Collection)
       ) {
-        onChange({ id: null, model: "collection" } as unknown as PickerItem<T>);
+        onChange({
+          id: null,
+          model: "collection",
+        } as unknown as PickerItem<TId>);
       } else {
         onChange(item);
       }
@@ -249,4 +252,4 @@ export default _.compose(
     loadingAndErrorWrapper: false,
   }),
   connect(mapStateToProps),
-)(ItemPicker) as <T>(props: OwnProps<T>) => JSX.Element;
+)(ItemPicker) as <TId>(props: OwnProps<TId>) => JSX.Element;

--- a/frontend/src/metabase/containers/ItemPicker/ItemPickerView.tsx
+++ b/frontend/src/metabase/containers/ItemPicker/ItemPickerView.tsx
@@ -27,14 +27,14 @@ import {
   SearchToggle,
 } from "./ItemPicker.styled";
 
-interface SearchEntityListLoaderProps {
-  list: PickerItem[];
+interface SearchEntityListLoaderProps<T> {
+  list: PickerItem<T>[];
 }
 
-interface Props {
+interface Props<T> {
   models: PickerModel[];
   openCollection: Collection;
-  collections: CollectionPickerItem[];
+  collections: CollectionPickerItem<T>[];
   searchString: string;
   searchQuery: SearchQuery;
   showSearch?: boolean;
@@ -42,20 +42,20 @@ interface Props {
   crumbs: any[];
   className?: string;
   style?: React.CSSProperties;
-  onChange: (item: PickerItem) => void;
+  onChange: (item: PickerItem<T>) => void;
   onSearchStringChange: (searchString: string) => void;
-  onOpenCollectionChange: (collectionId: PickerItem["id"]) => void;
+  onOpenCollectionChange: (collectionId: PickerItem<T>["id"]) => void;
   checkCollectionMaybeHasChildren: (
-    collection: CollectionPickerItem,
+    collection: CollectionPickerItem<T>,
   ) => boolean;
-  checkIsItemSelected: (item: PickerItem) => boolean;
-  checkHasWritePermissionForItem: (item: PickerItem) => boolean;
+  checkIsItemSelected: (item: PickerItem<T>) => boolean;
+  checkHasWritePermissionForItem: (item: PickerItem<T>) => boolean;
   getCollectionIcon: (collection: Collection) => IconProps;
 }
 
 const getDefaultCollectionIconColor = () => color("text-light");
 
-function ItemPickerView({
+function ItemPickerView<T>({
   collections,
   models,
   searchString,
@@ -72,7 +72,7 @@ function ItemPickerView({
   checkIsItemSelected,
   checkHasWritePermissionForItem,
   getCollectionIcon,
-}: Props) {
+}: Props<T>) {
   const [isSearchEnabled, setIsSearchEnabled] = useState(false);
 
   const isPickingNotCollection = models.some(model => model !== "collection");
@@ -134,7 +134,7 @@ function ItemPickerView({
   ]);
 
   const renderCollectionListItem = useCallback(
-    (collection: CollectionPickerItem) => {
+    (collection: CollectionPickerItem<T>) => {
       const hasChildren = checkCollectionMaybeHasChildren(collection);
 
       // NOTE: this assumes the only reason you'd be selecting a collection is to modify it in some way
@@ -174,7 +174,7 @@ function ItemPickerView({
   );
 
   const renderCollectionContentListItem = useCallback(
-    (item: PickerItem) => {
+    (item: PickerItem<T>) => {
       const hasPermission = checkHasWritePermissionForItem(item);
 
       if (
@@ -187,7 +187,7 @@ function ItemPickerView({
       ) {
         return (
           <Item
-            key={item.id}
+            key={`${item.id}`}
             item={item}
             name={item.getName()}
             color={item.getColor()}
@@ -217,7 +217,7 @@ function ItemPickerView({
         {!searchString && collections.map(renderCollectionListItem)}
         {canFetch && (
           <Search.ListLoader query={searchQuery} wrapped>
-            {({ list }: SearchEntityListLoaderProps) => (
+            {({ list }: SearchEntityListLoaderProps<T>) => (
               <div>{list.map(renderCollectionContentListItem)}</div>
             )}
           </Search.ListLoader>

--- a/frontend/src/metabase/containers/ItemPicker/ItemPickerView.tsx
+++ b/frontend/src/metabase/containers/ItemPicker/ItemPickerView.tsx
@@ -27,14 +27,14 @@ import {
   SearchToggle,
 } from "./ItemPicker.styled";
 
-interface SearchEntityListLoaderProps<T> {
-  list: PickerItem<T>[];
+interface SearchEntityListLoaderProps<TId> {
+  list: PickerItem<TId>[];
 }
 
-interface Props<T> {
+interface Props<TId> {
   models: PickerModel[];
   openCollection: Collection;
-  collections: CollectionPickerItem<T>[];
+  collections: CollectionPickerItem<TId>[];
   searchString: string;
   searchQuery: SearchQuery;
   showSearch?: boolean;
@@ -42,20 +42,20 @@ interface Props<T> {
   crumbs: any[];
   className?: string;
   style?: React.CSSProperties;
-  onChange: (item: PickerItem<T>) => void;
+  onChange: (item: PickerItem<TId>) => void;
   onSearchStringChange: (searchString: string) => void;
-  onOpenCollectionChange: (collectionId: PickerItem<T>["id"]) => void;
+  onOpenCollectionChange: (collectionId: PickerItem<TId>["id"]) => void;
   checkCollectionMaybeHasChildren: (
-    collection: CollectionPickerItem<T>,
+    collection: CollectionPickerItem<TId>,
   ) => boolean;
-  checkIsItemSelected: (item: PickerItem<T>) => boolean;
-  checkHasWritePermissionForItem: (item: PickerItem<T>) => boolean;
+  checkIsItemSelected: (item: PickerItem<TId>) => boolean;
+  checkHasWritePermissionForItem: (item: PickerItem<TId>) => boolean;
   getCollectionIcon: (collection: Collection) => IconProps;
 }
 
 const getDefaultCollectionIconColor = () => color("text-light");
 
-function ItemPickerView<T>({
+function ItemPickerView<TId>({
   collections,
   models,
   searchString,
@@ -72,7 +72,7 @@ function ItemPickerView<T>({
   checkIsItemSelected,
   checkHasWritePermissionForItem,
   getCollectionIcon,
-}: Props<T>) {
+}: Props<TId>) {
   const [isSearchEnabled, setIsSearchEnabled] = useState(false);
 
   const isPickingNotCollection = models.some(model => model !== "collection");
@@ -134,7 +134,7 @@ function ItemPickerView<T>({
   ]);
 
   const renderCollectionListItem = useCallback(
-    (collection: CollectionPickerItem<T>) => {
+    (collection: CollectionPickerItem<TId>) => {
       const hasChildren = checkCollectionMaybeHasChildren(collection);
 
       // NOTE: this assumes the only reason you'd be selecting a collection is to modify it in some way
@@ -174,7 +174,7 @@ function ItemPickerView<T>({
   );
 
   const renderCollectionContentListItem = useCallback(
-    (item: PickerItem<T>) => {
+    (item: PickerItem<TId>) => {
       const hasPermission = checkHasWritePermissionForItem(item);
 
       if (
@@ -217,7 +217,7 @@ function ItemPickerView<T>({
         {!searchString && collections.map(renderCollectionListItem)}
         {canFetch && (
           <Search.ListLoader query={searchQuery} wrapped>
-            {({ list }: SearchEntityListLoaderProps<T>) => (
+            {({ list }: SearchEntityListLoaderProps<TId>) => (
               <div>{list.map(renderCollectionContentListItem)}</div>
             )}
           </Search.ListLoader>

--- a/frontend/src/metabase/containers/ItemPicker/types.ts
+++ b/frontend/src/metabase/containers/ItemPicker/types.ts
@@ -4,12 +4,10 @@ import type { Collection } from "metabase-types/api";
 
 export type PickerModel = "card" | "collection" | "dataset" | "dashboard";
 
-export type PickerItemId = string | number | null;
+export type PickerValue<T> = { id: T; model: PickerModel };
 
-export type PickerValue = { id: PickerItemId; model: PickerModel };
-
-export type PickerItem = {
-  id: PickerItemId;
+export type PickerItem<T> = {
+  id: T;
   model: PickerModel;
   collection_id: Collection["id"];
   can_write: boolean;
@@ -20,7 +18,7 @@ export type PickerItem = {
   getIcon: () => IconProps;
 };
 
-export type CollectionPickerItem = PickerItem & Collection;
+export type CollectionPickerItem<T> = PickerItem<T> & Collection;
 
 export type SearchQuery = {
   q?: string;

--- a/frontend/src/metabase/containers/ItemPicker/types.ts
+++ b/frontend/src/metabase/containers/ItemPicker/types.ts
@@ -4,10 +4,10 @@ import type { Collection } from "metabase-types/api";
 
 export type PickerModel = "card" | "collection" | "dataset" | "dashboard";
 
-export type PickerValue<T> = { id: T; model: PickerModel };
+export type PickerValue<TId> = { id: TId; model: PickerModel };
 
-export type PickerItem<T> = {
-  id: T;
+export type PickerItem<TId> = {
+  id: TId;
   model: PickerModel;
   collection_id: Collection["id"];
   can_write: boolean;

--- a/frontend/src/metabase/home/components/CustomHomePageModal/CustomHomePageModal.tsx
+++ b/frontend/src/metabase/home/components/CustomHomePageModal/CustomHomePageModal.tsx
@@ -37,7 +37,7 @@ export const CustomHomePageModal = ({
   };
 
   const handleChange = useCallback(
-    (value: DashboardId | null | undefined) => {
+    (value?: DashboardId) => {
       if (value) {
         setDashboardId(value);
       } else {

--- a/frontend/src/metabase/models/containers/FormModelPicker/FormModelPicker.tsx
+++ b/frontend/src/metabase/models/containers/FormModelPicker/FormModelPicker.tsx
@@ -13,7 +13,6 @@ import FormField from "metabase/core/components/FormField";
 import SelectButton from "metabase/core/components/SelectButton";
 import TippyPopoverWithTrigger from "metabase/components/PopoverWithTrigger/TippyPopoverWithTrigger";
 import { useQuestionQuery } from "metabase/common/hooks";
-import type { CardId } from "metabase-types/api";
 
 import { PopoverItemPicker, MIN_POPOVER_WIDTH } from "./FormModelPicker.styled";
 
@@ -22,8 +21,6 @@ export interface FormModelPickerProps extends HTMLAttributes<HTMLDivElement> {
   title?: string;
   placeholder?: string;
 }
-
-const ITEM_PICKER_MODELS = ["dataset"];
 
 function FormModelPicker({
   className,
@@ -83,8 +80,8 @@ function FormModelPicker({
       return (
         <PopoverItemPicker
           value={{ id: value, model: "dataset" }}
-          models={ITEM_PICKER_MODELS}
-          onChange={({ id }: { id: CardId }) => {
+          models={["dataset"]}
+          onChange={({ id }) => {
             setValue(id);
             closePopover();
           }}


### PR DESCRIPTION
### Description
This is a followup to https://github.com/metabase/metabase/pull/31033. This should ensure that types are properly derived in the `onChange` prop of the `<ItemPicker>`. I've also updated the types used by the Custom Homepage Dashboard feature to properly use the `DashboardId` type
