### PR TITLE
Don't try to update recent views if no user-id is passed

### DIFF
--- a/src/metabase/events/view_log.clj
+++ b/src/metabase/events/view_log.clj
@@ -135,14 +135,15 @@
 
 (defn- update-users-recent-views!
   [user-id model model-id]
-  (mw.session/with-current-user user-id
-    (let [view        {:model    (name model)
-                       :model_id model-id}
-          prior-views (remove #{view} (user-recent-views))]
-      (when (= model "dashboard") (most-recently-viewed-dashboard! model-id))
-      (when-not ((set prior-views) view)
-        (let [new-views (vec (take 10 (conj prior-views view)))]
-          (user-recent-views! new-views))))))
+  (when user-id
+    (mw.session/with-current-user user-id
+      (let [view        {:model    (name model)
+                         :model_id model-id}
+            prior-views (remove #{view} (user-recent-views))]
+        (when (= model "dashboard") (most-recently-viewed-dashboard! model-id))
+        (when-not ((set prior-views) view)
+          (let [new-views (vec (take 10 (conj prior-views view)))]
+            (user-recent-views! new-views)))))))
 
 (defn handle-view-event!
   "Handle processing for a single event notification received on the view-log-channel"


### PR DESCRIPTION
Quick fix for an [exception being thrown](https://metaboat.slack.com/archives/CKZEMT1MJ/p1685113701449159) when calling `update-users-recent-views!` when embedded cards are viewed. Since no user-id is associated with an embedded card view, user-local settings don't work in this context, causing the exception. So we should just skip this code when `user-id` is `nil`.