### PR TITLE
Enable Replay asserts again

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -210,7 +210,6 @@ jobs:
           REPLAYIO_ENABLED: 1
           RECORD_REPLAY_METADATA_FILE: /tmp/replay-metadata.json
           RECORD_REPLAY_METADATA_TEST_RUN_ID: ${{ needs.test-run-id.outputs.testRunId }}
-          RECORD_REPLAY_DISABLE_ASSERTS: 1
 
       - name: Run EE Cypress tests on ${{ matrix.folder }} using Replay.io browser
         if: matrix.edition == 'ee' && github.event_name == 'schedule'
@@ -224,7 +223,6 @@ jobs:
           REPLAYIO_ENABLED: 1
           RECORD_REPLAY_METADATA_FILE: /tmp/replay-metadata.json
           RECORD_REPLAY_METADATA_TEST_RUN_ID: ${{ needs.test-run-id.outputs.testRunId }}
-          RECORD_REPLAY_DISABLE_ASSERTS: 1
 
       - name: Upload Replay.io recordings
         if: ${{ github.event_name == 'schedule' }}


### PR DESCRIPTION
In coordination with @jaril from Replay, this PR will enable replay asserts again. We've included them originally as a performance tweak, but now that tests are running on a regular basis, Replay's core team needs to have this removed.