### PR TITLE
[MLv2] Make stage index explicit

### DIFF
--- a/frontend/src/metabase-lib/breakout.ts
+++ b/frontend/src/metabase-lib/breakout.ts
@@ -1,28 +1,21 @@
 import * as ML from "cljs/metabase.lib.js";
 import type { Clause, ColumnMetadata, Query } from "./types";
 
-const DEFAULT_STAGE_INDEX = -1;
-
 export function breakoutableColumns(
   query: Query,
-  stageIndex = DEFAULT_STAGE_INDEX,
+  stageIndex: number,
 ): ColumnMetadata[] {
   return ML.breakoutable_columns(query, stageIndex);
 }
 
-export function breakouts(
-  query: Query,
-  stageIndex = DEFAULT_STAGE_INDEX,
-): Clause[] {
+export function breakouts(query: Query, stageIndex: number): Clause[] {
   return ML.breakouts(query, stageIndex);
 }
 
-declare function BreakoutFn(query: Query, column: ColumnMetadata): Query;
-
-declare function BreakoutFn(
+export function breakout(
   query: Query,
   stageIndex: number,
   column: ColumnMetadata,
-): Query;
-
-export const breakout: typeof BreakoutFn = ML.breakout;
+): Query {
+  return ML.breakout(query, stageIndex, column);
+}

--- a/frontend/src/metabase-lib/breakout.unit.spec.ts
+++ b/frontend/src/metabase-lib/breakout.unit.spec.ts
@@ -6,17 +6,17 @@ describe("breakout", () => {
     const query = createQuery();
     const findBreakoutableColumn = columnFinder(
       query,
-      ML.breakoutableColumns(query),
+      ML.breakoutableColumns(query, 0),
     );
 
     it("should handle no breakout clauses", () => {
-      expect(ML.breakouts(query)).toHaveLength(0);
+      expect(ML.breakouts(query, 0)).toHaveLength(0);
     });
 
     it("should update the query", () => {
       const productTitle = findBreakoutableColumn("PRODUCTS", "TITLE");
-      const nextQuery = ML.breakout(query, productTitle);
-      const breakouts = ML.breakouts(nextQuery);
+      const nextQuery = ML.breakout(query, 0, productTitle);
+      const breakouts = ML.breakouts(nextQuery, 0);
 
       expect(breakouts).toHaveLength(1);
       expect(ML.displayName(nextQuery, breakouts[0])).toBe("Title");
@@ -25,26 +25,28 @@ describe("breakout", () => {
     it("should preserve breakout positions between v1-v2 roundtrip", () => {
       const query = createQuery();
       const taxColumn = findBreakoutableColumn("ORDERS", "TAX");
-      const nextQuery = ML.breakout(query, taxColumn);
-      const nextQueryColumns = ML.breakoutableColumns(nextQuery);
+      const nextQuery = ML.breakout(query, 0, taxColumn);
+      const nextQueryColumns = ML.breakoutableColumns(nextQuery, 0);
       const nextTaxColumn = columnFinder(nextQuery, nextQueryColumns)(
         "ORDERS",
         "TAX",
       );
 
-      expect(ML.displayInfo(nextQuery, nextTaxColumn).breakoutPosition).toBe(0);
+      expect(ML.displayInfo(nextQuery, 0, nextTaxColumn).breakoutPosition).toBe(
+        0,
+      );
 
       const roundtripQuery = createQuery({
         query: ML.toLegacyQuery(nextQuery),
       });
-      const roundtripQueryColumns = ML.breakoutableColumns(roundtripQuery);
+      const roundtripQueryColumns = ML.breakoutableColumns(roundtripQuery, 0);
       const roundtripTaxColumn = columnFinder(
         roundtripQuery,
         roundtripQueryColumns,
       )("ORDERS", "TAX");
 
       expect(
-        ML.displayInfo(roundtripQuery, roundtripTaxColumn).breakoutPosition,
+        ML.displayInfo(roundtripQuery, 0, roundtripTaxColumn).breakoutPosition,
       ).toBe(0);
     });
   });
@@ -53,23 +55,24 @@ describe("breakout", () => {
     const query = createQuery();
     const findBreakoutableColumn = columnFinder(
       query,
-      ML.breakoutableColumns(query),
+      ML.breakoutableColumns(query, 0),
     );
 
     it("should update the query", () => {
       const productTitle = findBreakoutableColumn("PRODUCTS", "TITLE");
       const productCategory = findBreakoutableColumn("PRODUCTS", "CATEGORY");
 
-      const breakoutQuery = ML.breakout(query, productTitle);
-      const breakouts = ML.breakouts(breakoutQuery);
+      const breakoutQuery = ML.breakout(query, 0, productTitle);
+      const breakouts = ML.breakouts(breakoutQuery, 0);
 
       expect(breakouts).toHaveLength(1);
       const nextQuery = ML.replaceClause(
         breakoutQuery,
+        0,
         breakouts[0],
         productCategory,
       );
-      const nextBreakouts = ML.breakouts(nextQuery);
+      const nextBreakouts = ML.breakouts(nextQuery, 0);
       expect(ML.displayName(nextQuery, nextBreakouts[0])).toBe("Category");
       expect(breakouts[0]).not.toEqual(nextBreakouts[0]);
     });
@@ -79,18 +82,18 @@ describe("breakout", () => {
     const query = createQuery();
     const findBreakoutableColumn = columnFinder(
       query,
-      ML.breakoutableColumns(query),
+      ML.breakoutableColumns(query, 0),
     );
 
     it("should update the query", () => {
       const productTitle = findBreakoutableColumn("PRODUCTS", "TITLE");
 
-      const breakoutQuery = ML.breakout(query, productTitle);
-      const breakouts = ML.breakouts(breakoutQuery);
+      const breakoutQuery = ML.breakout(query, 0, productTitle);
+      const breakouts = ML.breakouts(breakoutQuery, 0);
       expect(breakouts).toHaveLength(1);
 
-      const nextQuery = ML.removeClause(breakoutQuery, breakouts[0]);
-      expect(ML.breakouts(nextQuery)).toHaveLength(0);
+      const nextQuery = ML.removeClause(breakoutQuery, 0, breakouts[0]);
+      expect(ML.breakouts(nextQuery, 0)).toHaveLength(0);
     });
   });
 });

--- a/frontend/src/metabase-lib/limit.ts
+++ b/frontend/src/metabase-lib/limit.ts
@@ -1,21 +1,15 @@
 import * as ML from "cljs/metabase.lib.limit";
 import type { Query, Limit } from "./types";
 
-const DEFAULT_STAGE_INDEX = -1;
-
-export function currentLimit(
-  query: Query,
-  stageIndex = DEFAULT_STAGE_INDEX,
-): Limit {
+export function currentLimit(query: Query, stageIndex: number): Limit {
   return ML.current_limit(query, stageIndex);
 }
 
-declare function LimitFn(query: Query, limit: Limit): Query;
-declare function LimitFn(query: Query, stageIndex: number, limit: Limit): Query;
+export function limit(query: Query, stageIndex: number, limit: Limit): Query {
+  return ML.limit(query, stageIndex, limit);
+}
 
-export const limit: typeof LimitFn = ML.limit;
-
-export function hasLimit(query: Query, stageIndex = DEFAULT_STAGE_INDEX) {
+export function hasLimit(query: Query, stageIndex: number) {
   const limit = currentLimit(query, stageIndex);
   return typeof limit === "number" && limit > 0;
 }

--- a/frontend/src/metabase-lib/metadata.ts
+++ b/frontend/src/metabase-lib/metadata.ts
@@ -27,14 +27,17 @@ export function displayName(query: Query, clause: Clause): string {
 
 declare function DisplayInfoFn(
   query: Query,
+  stageIndex: number,
   columnMetadata: ColumnMetadata,
 ): ColumnDisplayInfo;
 declare function DisplayInfoFn(
   query: Query,
+  stageIndex: number,
   columnGroup: ColumnGroup,
 ): ColumnDisplayInfo | TableDisplayInfo;
 declare function DisplayInfoFn(
   query: Query,
+  stageIndex: number,
   orderByClause: OrderByClause,
 ): OrderByClauseDisplayInfo;
 

--- a/frontend/src/metabase-lib/order_by.ts
+++ b/frontend/src/metabase-lib/order_by.ts
@@ -7,54 +7,40 @@ import type {
   Query,
 } from "./types";
 
-const DEFAULT_STAGE_INDEX = -1;
-
 export function orderableColumns(
   query: Query,
-  stageIndex = DEFAULT_STAGE_INDEX,
+  stageIndex: number,
 ): ColumnMetadata[] {
   return ML.orderable_columns(query, stageIndex);
 }
 
-export function orderBys(
-  query: Query,
-  stageIndex = DEFAULT_STAGE_INDEX,
-): OrderByClause[] {
+export function orderBys(query: Query, stageIndex: number): OrderByClause[] {
   return ML.order_bys(query, stageIndex);
 }
 
-declare function OrderByFn(
-  query: Query,
-  column: ColumnMetadata | OrderByClause,
-  direction?: OrderByDirection,
-): Query;
-
-declare function OrderByFn(
+export function orderBy(
   query: Query,
   stageIndex: number,
   column: ColumnMetadata | OrderByClause,
   direction?: OrderByDirection,
-): Query;
+): Query {
+  return ML.order_by(query, stageIndex, column, direction);
+}
 
-export const orderBy: typeof OrderByFn = ML.order_by;
-
-declare function OrderByClauseFn(
+export function orderByClause(
   query: Query,
   stageNumber: number,
   column: ColumnMetadata,
   direction?: OrderByDirection,
-): OrderByClause;
-
-export const orderByClause: typeof OrderByClauseFn = ML.order_by_clause;
+): OrderByClause {
+  return ML.order_by_clause(query, stageNumber, column, direction);
+}
 
 export function changeDirection(query: Query, clause: OrderByClause): Query {
   return ML.change_direction(query, clause);
 }
 
-export function clearOrderBys(
-  query: Query,
-  stageIndex = DEFAULT_STAGE_INDEX,
-): Query {
+export function clearOrderBys(query: Query, stageIndex: number): Query {
   let current = query;
   orderBys(query, stageIndex).forEach(clause => {
     current = removeClause(query, stageIndex, clause);

--- a/frontend/src/metabase-lib/order_by.unit.spec.ts
+++ b/frontend/src/metabase-lib/order_by.unit.spec.ts
@@ -11,12 +11,15 @@ import * as ML from "./v2";
 describe("order by", () => {
   describe("orderableColumns", () => {
     const query = createQuery();
-    const findOrderableColumn = columnFinder(query, ML.orderableColumns(query));
+    const findOrderableColumn = columnFinder(
+      query,
+      ML.orderableColumns(query, 0),
+    );
 
     it("returns metadata for columns in the source table", () => {
       const ordersID = findOrderableColumn("ORDERS", "ID");
 
-      expect(ML.displayInfo(query, ordersID)).toEqual(
+      expect(ML.displayInfo(query, 0, ordersID)).toEqual(
         expect.objectContaining({
           name: "ID",
           displayName: "ID",
@@ -40,7 +43,7 @@ describe("order by", () => {
     it("returns metadata for columns in implicitly joinable tables", () => {
       const productsTitle = findOrderableColumn("PRODUCTS", "TITLE");
 
-      expect(ML.displayInfo(query, productsTitle)).toEqual(
+      expect(ML.displayInfo(query, 0, productsTitle)).toEqual(
         expect.objectContaining({
           name: "TITLE",
           displayName: "Title",
@@ -82,11 +85,11 @@ describe("order by", () => {
         },
       });
 
-      const columns = ML.orderableColumns(query);
+      const columns = ML.orderableColumns(query, 0);
 
       const productsTitle = columns.find(
         (columnMetadata: ML.ColumnMetadata) => {
-          const displayInfo = ML.displayInfo(query, columnMetadata);
+          const displayInfo = ML.displayInfo(query, 0, columnMetadata);
           return (
             displayInfo.displayName === "Title" &&
             displayInfo.table?.displayName === "Product Model"
@@ -94,7 +97,9 @@ describe("order by", () => {
         },
       );
 
-      expect(ML.displayInfo(query, productsTitle as ML.ColumnMetadata)).toEqual(
+      expect(
+        ML.displayInfo(query, 0, productsTitle as ML.ColumnMetadata),
+      ).toEqual(
         expect.objectContaining({
           name: field.name,
           displayName: field.display_name,
@@ -107,42 +112,47 @@ describe("order by", () => {
     it("should preserve order-by positions between v1-v2 roundtrip", () => {
       const query = createQuery();
       const taxColumn = findOrderableColumn("ORDERS", "TAX");
-      const nextQuery = ML.orderBy(query, taxColumn);
-      const nextQueryColumns = ML.orderableColumns(nextQuery);
+      const nextQuery = ML.orderBy(query, 0, taxColumn);
+      const nextQueryColumns = ML.orderableColumns(nextQuery, 0);
       const nextTaxColumn = columnFinder(nextQuery, nextQueryColumns)(
         "ORDERS",
         "TAX",
       );
 
-      expect(ML.displayInfo(nextQuery, nextTaxColumn).orderByPosition).toBe(0);
+      expect(ML.displayInfo(nextQuery, 0, nextTaxColumn).orderByPosition).toBe(
+        0,
+      );
 
       const roundtripQuery = createQuery({
         query: ML.toLegacyQuery(nextQuery),
       });
-      const roundtripQueryColumns = ML.orderableColumns(roundtripQuery);
+      const roundtripQueryColumns = ML.orderableColumns(roundtripQuery, 0);
       const roundtripTaxColumn = columnFinder(
         roundtripQuery,
         roundtripQueryColumns,
       )("ORDERS", "TAX");
 
       expect(
-        ML.displayInfo(roundtripQuery, roundtripTaxColumn).orderByPosition,
+        ML.displayInfo(roundtripQuery, 0, roundtripTaxColumn).orderByPosition,
       ).toBe(0);
     });
   });
 
   describe("add order by", () => {
     const query = createQuery();
-    const findOrderableColumn = columnFinder(query, ML.orderableColumns(query));
+    const findOrderableColumn = columnFinder(
+      query,
+      ML.orderableColumns(query, 0),
+    );
 
     it("should handle no order by clauses", () => {
-      expect(ML.orderBys(query)).toHaveLength(0);
+      expect(ML.orderBys(query, 0)).toHaveLength(0);
     });
 
     it("should update the query", () => {
       const productTitle = findOrderableColumn("PRODUCTS", "TITLE");
-      const nextQuery = ML.orderBy(query, productTitle);
-      const orderBys = ML.orderBys(nextQuery);
+      const nextQuery = ML.orderBy(query, 0, productTitle);
+      const orderBys = ML.orderBys(nextQuery, 0);
 
       expect(orderBys).toHaveLength(1);
       expect(ML.displayName(nextQuery, orderBys[0])).toBe("Title ascending");
@@ -151,22 +161,26 @@ describe("order by", () => {
 
   describe("replace order by", () => {
     const query = createQuery();
-    const findOrderableColumn = columnFinder(query, ML.orderableColumns(query));
+    const findOrderableColumn = columnFinder(
+      query,
+      ML.orderableColumns(query, 0),
+    );
 
     it("should update the query", () => {
       const productTitle = findOrderableColumn("PRODUCTS", "TITLE");
       const productCategory = findOrderableColumn("PRODUCTS", "CATEGORY");
 
-      const orderedQuery = ML.orderBy(query, productTitle);
-      const orderBys = ML.orderBys(orderedQuery);
+      const orderedQuery = ML.orderBy(query, 0, productTitle);
+      const orderBys = ML.orderBys(orderedQuery, 0);
 
       expect(orderBys).toHaveLength(1);
       const nextQuery = ML.replaceClause(
         orderedQuery,
+        0,
         orderBys[0],
-        ML.orderByClause(orderedQuery, -1, productCategory, "desc"),
+        ML.orderByClause(orderedQuery, 0, productCategory, "desc"),
       );
-      const nextOrderBys = ML.orderBys(nextQuery);
+      const nextOrderBys = ML.orderBys(nextQuery, 0);
       expect(ML.displayName(nextQuery, nextOrderBys[0])).toBe(
         "Category descending",
       );
@@ -176,17 +190,20 @@ describe("order by", () => {
 
   describe("remove order by", () => {
     const query = createQuery();
-    const findOrderableColumn = columnFinder(query, ML.orderableColumns(query));
+    const findOrderableColumn = columnFinder(
+      query,
+      ML.orderableColumns(query, 0),
+    );
 
     it("should update the query", () => {
       const productTitle = findOrderableColumn("PRODUCTS", "TITLE");
 
-      const orderedQuery = ML.orderBy(query, productTitle);
-      const orderBys = ML.orderBys(orderedQuery);
+      const orderedQuery = ML.orderBy(query, 0, productTitle);
+      const orderBys = ML.orderBys(orderedQuery, 0);
       expect(orderBys).toHaveLength(1);
 
-      const nextQuery = ML.removeClause(orderedQuery, orderBys[0]);
-      expect(ML.orderBys(nextQuery)).toHaveLength(0);
+      const nextQuery = ML.removeClause(orderedQuery, 0, orderBys[0]);
+      expect(ML.orderBys(nextQuery, 0)).toHaveLength(0);
     });
   });
 });

--- a/frontend/src/metabase-lib/queries/StructuredQuery.ts
+++ b/frontend/src/metabase-lib/queries/StructuredQuery.ts
@@ -553,9 +553,9 @@ class StructuredQueryInner extends AtomicQuery {
     return ML.orderBys(query).length > 0;
   }
 
-  hasLimit() {
+  hasLimit(stageIndex = this.queries().length - 1) {
     const query = this.getMLv2Query();
-    return ML.hasLimit(query);
+    return ML.hasLimit(query, stageIndex);
   }
 
   hasFields() {
@@ -1064,9 +1064,9 @@ class StructuredQueryInner extends AtomicQuery {
   /**
    * @deprecated use metabase-lib v2's limit function
    */
-  updateLimit(limit: Limit) {
+  updateLimit(limit: Limit, stageIndex = this.queries().length - 1) {
     const query = this.getMLv2Query();
-    const nextQuery = ML.limit(query, limit);
+    const nextQuery = ML.limit(query, stageIndex, limit);
     return this.updateWithMLv2(nextQuery);
   }
 

--- a/frontend/src/metabase-lib/queries/StructuredQuery.ts
+++ b/frontend/src/metabase-lib/queries/StructuredQuery.ts
@@ -1056,9 +1056,9 @@ class StructuredQueryInner extends AtomicQuery {
   /**
    * @deprecated use metabase-lib v2's currentLimit function
    */
-  limit(): Limit {
+  limit(stageIndex = this.queries().length - 1): Limit {
     const query = this.getMLv2Query();
-    return ML.currentLimit(query);
+    return ML.currentLimit(query, stageIndex);
   }
 
   /**

--- a/frontend/src/metabase-lib/query.ts
+++ b/frontend/src/metabase-lib/query.ts
@@ -18,6 +18,14 @@ export function suggestedName(query: Query): string {
   return ML.suggestedName(query);
 }
 
+export function appendStage(query: Query): Query {
+  return ML.append_stage(query);
+}
+
+export function dropStage(query: Query, stageIndex: number): Query {
+  return ML.drop_stage(query, stageIndex);
+}
+
 export function removeClause(
   query: Query,
   stageIndex: number,

--- a/frontend/src/metabase-lib/query.ts
+++ b/frontend/src/metabase-lib/query.ts
@@ -18,25 +18,19 @@ export function suggestedName(query: Query): string {
   return ML.suggestedName(query);
 }
 
-declare function RemoveClauseFn(query: Query, targetClause: Clause): Query;
-declare function RemoveClauseFn(
+export function removeClause(
   query: Query,
   stageIndex: number,
   targetClause: Clause,
-): Query;
+): Query {
+  return ML.remove_clause(query, stageIndex, targetClause);
+}
 
-export const removeClause: typeof RemoveClauseFn = ML.remove_clause;
-
-declare function ReplaceClauseFn(
-  query: Query,
-  targetClause: Clause,
-  newClause: Clause | ColumnMetadata,
-): Query;
-declare function ReplaceClauseFn(
+export function replaceClause(
   query: Query,
   stageIndex: number,
   targetClause: Clause,
   newClause: Clause | ColumnMetadata,
-): Query;
-
-export const replaceClause: typeof ReplaceClauseFn = ML.replace_clause;
+): Query {
+  return ML.replace_clause(query, stageIndex, targetClause, newClause);
+}

--- a/frontend/src/metabase-lib/test-helpers.ts
+++ b/frontend/src/metabase-lib/test-helpers.ts
@@ -52,7 +52,7 @@ export const columnFinder =
   (query: ML.Query, columns: ML.ColumnMetadata[]) =>
   (tableName: string, columnName: string): ML.ColumnMetadata => {
     const column = columns.find(column => {
-      const displayInfo = ML.displayInfo(query, column);
+      const displayInfo = ML.displayInfo(query, 0, column);
       return (
         displayInfo?.table?.name === tableName &&
         displayInfo?.name === columnName

--- a/frontend/src/metabase/common/components/QueryColumnPicker/QueryColumnPicker.tsx
+++ b/frontend/src/metabase/common/components/QueryColumnPicker/QueryColumnPicker.tsx
@@ -12,6 +12,7 @@ const DEFAULT_MAX_HEIGHT = 610;
 interface QueryColumnPickerProps {
   className?: string;
   query: Lib.Query;
+  stageIndex: number;
   columnGroups: Lib.ColumnGroup[];
   maxHeight?: number;
   onSelect: (column: Lib.ColumnMetadata) => void;
@@ -31,6 +32,7 @@ type Sections = {
 function QueryColumnPicker({
   className,
   query,
+  stageIndex,
   columnGroups,
   maxHeight = DEFAULT_MAX_HEIGHT,
   onSelect,
@@ -39,10 +41,10 @@ function QueryColumnPicker({
   const sections: Sections[] = useMemo(
     () =>
       columnGroups.map(group => {
-        const groupInfo = Lib.displayInfo(query, group);
+        const groupInfo = Lib.displayInfo(query, stageIndex, group);
 
         const items = Lib.getColumnsFromColumnGroup(group).map(column => {
-          const displayInfo = Lib.displayInfo(query, column);
+          const displayInfo = Lib.displayInfo(query, stageIndex, column);
           return {
             ...displayInfo,
             column,
@@ -55,7 +57,7 @@ function QueryColumnPicker({
           items,
         };
       }),
-    [query, columnGroups],
+    [query, stageIndex, columnGroups],
   );
 
   const handleSelect = useCallback(

--- a/frontend/src/metabase/common/components/QueryColumnPicker/QueryColumnPicker.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/QueryColumnPicker/QueryColumnPicker.unit.spec.tsx
@@ -7,22 +7,25 @@ import QueryColumnPicker from "./QueryColumnPicker";
 
 type SetupOpts = {
   query?: Lib.Query;
+  stageIndex?: number;
   columnGroups?: Lib.ColumnGroup[];
 };
 
 function setup({
   query = createQuery(),
-  columnGroups = Lib.groupColumns(Lib.orderableColumns(query)),
+  stageIndex = 0,
+  columnGroups = Lib.groupColumns(Lib.orderableColumns(query, stageIndex)),
 }: SetupOpts = {}) {
   const onSelect = jest.fn();
   const onClose = jest.fn();
 
-  const [sampleColumn] = Lib.orderableColumns(query);
-  const sampleColumnInfo = Lib.displayInfo(query, sampleColumn);
+  const [sampleColumn] = Lib.orderableColumns(query, stageIndex);
+  const sampleColumnInfo = Lib.displayInfo(query, stageIndex, sampleColumn);
 
   render(
     <QueryColumnPicker
       query={query}
+      stageIndex={stageIndex}
       columnGroups={columnGroups}
       onSelect={onSelect}
       onClose={onClose}

--- a/frontend/src/metabase/common/utils/columns.unit.spec.ts
+++ b/frontend/src/metabase/common/utils/columns.unit.spec.ts
@@ -4,7 +4,7 @@ import { getColumnIcon } from "./columns";
 
 describe("common/utils/columns", () => {
   const query = createQuery();
-  const columns = Lib.orderableColumns(query);
+  const columns = Lib.orderableColumns(query, 0);
   const getColumn = columnFinder(query, columns);
 
   const pkColumn = getColumn("ORDERS", "ID");

--- a/frontend/src/metabase/query_builder/actions/query-updates.ts
+++ b/frontend/src/metabase/query_builder/actions/query-updates.ts
@@ -14,7 +14,7 @@ export const setLimit =
       return;
     }
     const query = question._getMLv2Query();
-    const nextQuery = Lib.limit(query, limit);
+    const nextQuery = Lib.limit(query, -1, limit);
     const nextLegacyQuery = Lib.toLegacyQuery(nextQuery);
     const nextQuestion = question.setDatasetQuery(nextLegacyQuery);
     dispatch(updateQuestion(nextQuestion, { run: true }));

--- a/frontend/src/metabase/query_builder/components/notebook/NotebookSteps/NotebookSteps.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/NotebookSteps/NotebookSteps.tsx
@@ -74,7 +74,9 @@ function NotebookSteps({
       } else {
         const updatedLegacyQuery = Lib.toLegacyQuery(query);
         const updatedQuestion = question.setDatasetQuery(updatedLegacyQuery);
-        await updateQuestion(updatedQuestion);
+        const updatedQuery = updatedQuestion.query() as StructuredQuery;
+        const cleanQuestion = updatedQuery.cleanNesting().question();
+        await updateQuestion(cleanQuestion);
       }
 
       // mark the step as "closed" since we can assume

--- a/frontend/src/metabase/query_builder/components/notebook/steps/LimitStep/LimitStep.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/LimitStep/LimitStep.unit.spec.tsx
@@ -7,7 +7,7 @@ import { createMockNotebookStep, DEFAULT_QUERY } from "../../test-utils";
 import LimitStep from "./LimitStep";
 
 const DEFAULT_LIMIT = 10;
-const QUERY_WITH_LIMIT = Lib.limit(DEFAULT_QUERY, DEFAULT_LIMIT);
+const QUERY_WITH_LIMIT = Lib.limit(DEFAULT_QUERY, 0, DEFAULT_LIMIT);
 
 function setup(step = createMockNotebookStep()) {
   const updateQuery = jest.fn();
@@ -51,7 +51,7 @@ describe("LimitStep", () => {
 
     fireEvent.change(limitInput, { target: { value: "52" } });
 
-    expect(Lib.currentLimit(getNextQuery())).toBe(52);
+    expect(Lib.currentLimit(getNextQuery(), 0)).toBe(52);
   });
 
   it("should update the limit", () => {
@@ -61,7 +61,7 @@ describe("LimitStep", () => {
     const limitInput = screen.getByPlaceholderText("Enter a limit");
     fireEvent.change(limitInput, { target: { value: "1000" } });
 
-    expect(Lib.currentLimit(getNextQuery())).toBe(1000);
+    expect(Lib.currentLimit(getNextQuery(), 0)).toBe(1000);
   });
 
   it("shouldn't update the limit if zero provided", () => {

--- a/frontend/src/metabase/query_builder/components/notebook/steps/SortStep/SortStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/SortStep/SortStep.tsx
@@ -61,13 +61,14 @@ function SortStep({
       isLastOpened={isLastOpened}
       renderName={clause => (
         <SortDisplayName
-          displayInfo={Lib.displayInfo(topLevelQuery, clause)}
+          displayInfo={Lib.displayInfo(topLevelQuery, stageIndex, clause)}
           onToggleSortDirection={() => handleToggleOrderByDirection(clause)}
         />
       )}
       renderPopover={clause => (
         <SortColumnPicker
           query={topLevelQuery}
+          stageIndex={stageIndex}
           columnGroups={groupedColumns}
           onSelect={(column: Lib.ColumnMetadata) => {
             const isUpdate = clause != null;

--- a/frontend/src/metabase/query_builder/components/notebook/steps/SortStep/SortStep.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/SortStep/SortStep.unit.spec.tsx
@@ -11,9 +11,9 @@ import SortStep from "./SortStep";
 
 function createQueryWithOrderBy(direction: Lib.OrderByDirection = "asc") {
   const initialQuery = createQuery();
-  const [column] = Lib.orderableColumns(initialQuery);
-  const query = Lib.orderBy(initialQuery, column, direction);
-  return { query, columnInfo: Lib.displayInfo(query, column) };
+  const [column] = Lib.orderableColumns(initialQuery, 0);
+  const query = Lib.orderBy(initialQuery, 0, column, direction);
+  return { query, columnInfo: Lib.displayInfo(query, 0, column) };
 }
 
 function setup(step = createMockNotebookStep()) {
@@ -38,8 +38,8 @@ function setup(step = createMockNotebookStep()) {
 
   function gerRecentOrderByClause() {
     const query = getNextQuery();
-    const clause = Lib.orderBys(query)[0];
-    return Lib.displayInfo(query, clause);
+    const clause = Lib.orderBys(query, 0)[0];
+    return Lib.displayInfo(query, 0, clause);
   }
 
   return { getNextQuery, gerRecentOrderByClause, updateQuery };
@@ -137,6 +137,6 @@ describe("SortStep", () => {
     userEvent.click(getIcon("close"));
 
     const nextQuery = getNextQuery();
-    expect(Lib.orderBys(nextQuery)).toHaveLength(0);
+    expect(Lib.orderBys(nextQuery, 0)).toHaveLength(0);
   });
 });

--- a/frontend/src/metabase/query_builder/components/view/QuestionRowCount/QuestionRowCount.tsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionRowCount/QuestionRowCount.tsx
@@ -91,7 +91,7 @@ function QuestionRowCount({
     question.isStructured() && question.query().isEditable();
 
   const limit = canChangeLimit
-    ? Lib.currentLimit(question._getMLv2Query())
+    ? Lib.currentLimit(question._getMLv2Query(), 0)
     : null;
 
   if (loading) {
@@ -154,7 +154,7 @@ const formatRowCount = (count: number) => {
 };
 
 function getLimitMessage(question: Question, result: Dataset): string {
-  const limit = Lib.currentLimit(question._getMLv2Query());
+  const limit = Lib.currentLimit(question._getMLv2Query(), 0);
   const isValidLimit =
     typeof limit === "number" && limit > 0 && limit < HARD_ROW_LIMIT;
 

--- a/frontend/src/metabase/query_builder/components/view/QuestionRowCount/QuestionRowCount.tsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionRowCount/QuestionRowCount.tsx
@@ -91,7 +91,7 @@ function QuestionRowCount({
     question.isStructured() && question.query().isEditable();
 
   const limit = canChangeLimit
-    ? Lib.currentLimit(question._getMLv2Query(), 0)
+    ? Lib.currentLimit(question._getMLv2Query(), -1)
     : null;
 
   if (loading) {
@@ -154,7 +154,7 @@ const formatRowCount = (count: number) => {
 };
 
 function getLimitMessage(question: Question, result: Dataset): string {
-  const limit = Lib.currentLimit(question._getMLv2Query(), 0);
+  const limit = Lib.currentLimit(question._getMLv2Query(), -1);
   const isValidLimit =
     typeof limit === "number" && limit > 0 && limit < HARD_ROW_LIMIT;
 

--- a/frontend/src/metabase/query_builder/components/view/QuestionRowCount/QuestionRowCount.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionRowCount/QuestionRowCount.unit.spec.tsx
@@ -48,8 +48,8 @@ type SetupOpts = {
 function patchQuestion(question: Question) {
   if (question.isStructured()) {
     const query = question._getMLv2Query();
-    const [sampleColumn] = Lib.orderableColumns(query);
-    const nextQuery = Lib.orderBy(query, sampleColumn);
+    const [sampleColumn] = Lib.orderableColumns(query, 0);
+    const nextQuery = Lib.orderBy(query, 0, sampleColumn);
     return question.setDatasetQuery(Lib.toLegacyQuery(nextQuery));
   } else {
     const query = question.query() as NativeQuery;


### PR DESCRIPTION
We ran into a few issues when an incorrect query stage index was passed to MLv2 functions. The stage index argument is optional and, when omitted, is defaulted to `-1` (the last stage). This turned out to be easy to mess up, so this PR makes the stage index explicitly required for all the TypeScript MLv2 wrappers.

Apart from that, adds `append-stage` and `drop-stage` helpers that made it possible to avoid stage index hacks in the notebook editor (also removed)