### PR TITLE
Fix system time in `parameters/utils/mbql` tests

### DIFF
--- a/frontend/src/metabase-lib/parameters/utils/mbql.unit.spec.js
+++ b/frontend/src/metabase-lib/parameters/utils/mbql.unit.spec.js
@@ -17,6 +17,14 @@ describe("parameters/utils/mbql", () => {
   });
 
   describe("dateParameterValueToMBQL", () => {
+    const date = () =>
+      moment().utc().hours(0).minutes(0).seconds(0).milliseconds(0);
+
+    beforeEach(() => {
+      jest.useFakeTimers();
+      jest.setSystemTime(date().date(1).month(1).toDate());
+    });
+
     it("should parse past30days", () => {
       expect(dateParameterValueToMBQL("past30days", null)).toEqual([
         "time-interval",
@@ -166,9 +174,6 @@ describe("parameters/utils/mbql", () => {
         date().day(5).format("YYYY-MM-DD"),
       ]);
     });
-
-    const date = () =>
-      moment().utc().hours(0).minutes(0).seconds(0).milliseconds(0);
   });
 
   describe("stringParameterValueToMBQL", () => {


### PR DESCRIPTION
Fixes a flake in `metabase-lib/parameters/utils/mbql` tests. `dateParameterValueToMBQL` is sensitive to the current timestamp, fixed by mocking the system time with `jest.setSystemTime` that should guarantee tests running with identical datetime

Resolves https://github.com/metabase/metabase/issues/31116