### PR TITLE
Add extra header actions to ModalContent component

### DIFF
--- a/frontend/src/metabase/components/ModalContent/ModalContent.stories.tsx
+++ b/frontend/src/metabase/components/ModalContent/ModalContent.stories.tsx
@@ -19,7 +19,7 @@ const Template: ComponentStory<typeof ModalContent> = args => {
 
 const args = {
   id: "id",
-  title: "Modal title",
+  title: "Long Modal title Long Modal title Long Modal title Long Modal title",
   centeredTitle: false,
   children: <>Content</>,
   fullPageModal: false,

--- a/frontend/src/metabase/components/ModalContent/ModalContent.stories.tsx
+++ b/frontend/src/metabase/components/ModalContent/ModalContent.stories.tsx
@@ -2,11 +2,24 @@ import React from "react";
 import type { ComponentStory } from "@storybook/react";
 import { action } from "@storybook/addon-actions";
 import Modal from "metabase/components/Modal";
+import { ActionIcon } from "./ModalContent.styled";
 import ModalContent from "./ModalContent";
 
 export default {
   title: "Components/ModalContent",
   component: ModalContent,
+  argTypes: {
+    children: {
+      table: {
+        disable: true,
+      },
+    },
+    headerActions: {
+      table: {
+        disable: true,
+      },
+    },
+  },
 };
 
 const Template: ComponentStory<typeof ModalContent> = args => {
@@ -34,14 +47,9 @@ Default.args = {
 export const WithHeaderActions = Template.bind({});
 WithHeaderActions.args = {
   ...args,
-  headerActions: [
-    {
-      icon: "pencil",
-      onClick: action("Action1"),
-    },
-    {
-      icon: "bolt",
-      onClick: action("Action2"),
-    },
-  ],
+  headerActions: (
+    <>
+      <ActionIcon name="pencil" onClick={action("Action1")} />
+    </>
+  ),
 };

--- a/frontend/src/metabase/components/ModalContent/ModalContent.stories.tsx
+++ b/frontend/src/metabase/components/ModalContent/ModalContent.stories.tsx
@@ -1,0 +1,47 @@
+import React from "react";
+import type { ComponentStory } from "@storybook/react";
+import { action } from "@storybook/addon-actions";
+import Modal from "metabase/components/Modal";
+import ModalContent from "./ModalContent";
+
+export default {
+  title: "Components/ModalContent",
+  component: ModalContent,
+};
+
+const Template: ComponentStory<typeof ModalContent> = args => {
+  return (
+    <Modal>
+      <ModalContent {...args} />
+    </Modal>
+  );
+};
+
+const args = {
+  id: "id",
+  title: "Modal title",
+  centeredTitle: false,
+  children: <>Content</>,
+  fullPageModal: false,
+  onClose: action("onClose"),
+};
+
+export const Default = Template.bind({});
+Default.args = {
+  ...args,
+};
+
+export const WithHeaderActions = Template.bind({});
+WithHeaderActions.args = {
+  ...args,
+  headerActions: [
+    {
+      icon: "pencil",
+      onClick: action("Action1"),
+    },
+    {
+      icon: "bolt",
+      onClick: action("Action2"),
+    },
+  ],
+};

--- a/frontend/src/metabase/components/ModalContent/ModalContent.styled.ts
+++ b/frontend/src/metabase/components/ModalContent/ModalContent.styled.ts
@@ -15,6 +15,12 @@ export const HeaderContainer = styled.div`
   align-items: flex-start;
 `;
 
+export const HeaderText = styled.h2`
+  font-weight: 700;
+
+  flex-grow: 1;
+`;
+
 export const ActionsWrapper = styled.div`
   display: flex;
   flex-direction: row;

--- a/frontend/src/metabase/components/ModalContent/ModalContent.styled.ts
+++ b/frontend/src/metabase/components/ModalContent/ModalContent.styled.ts
@@ -2,17 +2,26 @@ import styled from "@emotion/styled";
 import Icon from "metabase/components/Icon";
 import { color } from "metabase/lib/colors";
 
-export const ActionsWrapper = styled.div`
-  position: absolute;
-  top: 0;
-  right: 0;
-  padding: 1.5rem;
+export const HeaderContainer = styled.div`
+  padding: 2rem;
+  width: 100%;
 
-  z-index: 2;
+  flex-shrink: 0;
 
   display: flex;
   flex-direction: row;
   gap: 0.5rem;
+
+  align-items: flex-start;
+`;
+
+export const ActionsWrapper = styled.div`
+  display: flex;
+  flex-direction: row;
+  gap: 0.5rem;
+
+  margin-top: -0.5rem;
+  margin-right: -0.5rem;
 `;
 
 export const ActionIcon = styled(Icon)`

--- a/frontend/src/metabase/components/ModalContent/ModalContent.styled.ts
+++ b/frontend/src/metabase/components/ModalContent/ModalContent.styled.ts
@@ -1,0 +1,26 @@
+import styled from "@emotion/styled";
+import Icon from "metabase/components/Icon";
+import { color } from "metabase/lib/colors";
+
+export const ActionsWrapper = styled.div`
+  position: absolute;
+  top: 0;
+  right: 0;
+  padding: 1.5rem;
+
+  z-index: 2;
+
+  display: flex;
+  flex-direction: row;
+  gap: 0.5rem;
+`;
+
+export const ActionIcon = styled(Icon)`
+  color: ${color("text-light")};
+  cursor: pointer;
+  padding: 0.5rem;
+
+  &:hover {
+    color: ${color("text-medium")};
+  }
+`;

--- a/frontend/src/metabase/components/ModalContent/ModalContent.tsx
+++ b/frontend/src/metabase/components/ModalContent/ModalContent.tsx
@@ -17,11 +17,6 @@ export interface ModalContentProps extends CommonModalProps {
   className?: string;
 }
 
-export interface ModalHeaderAction {
-  icon: string;
-  onClick: () => void;
-}
-
 interface CommonModalProps {
   // takes over the entire screen
   fullPageModal?: boolean;
@@ -29,7 +24,7 @@ interface CommonModalProps {
   formModal?: boolean;
   centeredTitle?: boolean;
 
-  headerActions?: ModalHeaderAction[];
+  headerActions?: ReactNode;
   onClose?: () => void;
 }
 
@@ -45,12 +40,7 @@ export default class ModalContent extends Component<ModalContentProps> {
     // standard modal
     formModal: PropTypes.bool,
 
-    headerActions: PropTypes.arrayOf(
-      PropTypes.shape({
-        icon: PropTypes.string,
-        onClick: PropTypes.func,
-      }),
-    ),
+    headerActions: PropTypes.any,
   };
 
   static defaultProps = {
@@ -126,7 +116,7 @@ export const ModalHeader = ({
   headerActions,
   onClose,
 }: ModalHeaderProps) => {
-  const hasActions = !!headerActions?.length || !!onClose;
+  const hasActions = !!headerActions || !!onClose;
   const actionIconSize = fullPageModal ? 24 : 16;
 
   return (
@@ -141,14 +131,7 @@ export const ModalHeader = ({
 
       {hasActions && (
         <ActionsWrapper>
-          {headerActions?.map(({ icon, onClick }) => (
-            <ActionIcon
-              key={icon}
-              name={icon}
-              size={actionIconSize}
-              onClick={onClick}
-            />
-          ))}
+          {headerActions}
           {onClose && (
             <ActionIcon name="close" size={actionIconSize} onClick={onClose} />
           )}

--- a/frontend/src/metabase/components/ModalContent/ModalContent.tsx
+++ b/frontend/src/metabase/components/ModalContent/ModalContent.tsx
@@ -5,6 +5,7 @@ import {
   ActionIcon,
   ActionsWrapper,
   HeaderContainer,
+  HeaderText,
 } from "./ModalContent.styled";
 
 export interface ModalContentProps extends CommonModalProps {
@@ -129,14 +130,14 @@ export const ModalHeader = ({
   const actionIconSize = fullPageModal ? 24 : 16;
 
   return (
-    <HeaderContainer>
-      <h2
-        className={cx("text-bold", {
+    <HeaderContainer data-testid="modal-header">
+      <HeaderText
+        className={cx({
           "text-centered": fullPageModal || centeredTitle,
         })}
       >
         {children}
-      </h2>
+      </HeaderText>
 
       {hasActions && (
         <ActionsWrapper>

--- a/frontend/src/metabase/components/ModalContent/ModalContent.tsx
+++ b/frontend/src/metabase/components/ModalContent/ModalContent.tsx
@@ -1,14 +1,22 @@
 import React, { Component, ReactNode } from "react";
 import PropTypes from "prop-types";
 import cx from "classnames";
-import Icon from "metabase/components/Icon";
+import { ActionIcon, ActionsWrapper } from "./ModalContent.styled";
 
 interface ModalContentProps extends CommonModalProps {
   id?: string;
   title: string;
-  onClose?: () => void;
-  className?: string;
   footer?: ReactNode;
+  children: ReactNode;
+  headerActions?: ModalHeaderAction[];
+
+  className?: string;
+  onClose?: () => void;
+}
+
+interface ModalHeaderAction {
+  icon: string;
+  onClick: () => void;
 }
 
 interface CommonModalProps {
@@ -30,6 +38,13 @@ export default class ModalContent extends Component<ModalContentProps> {
     fullPageModal: PropTypes.bool,
     // standard modal
     formModal: PropTypes.bool,
+
+    headerActions: PropTypes.arrayOf(
+      PropTypes.shape({
+        icon: PropTypes.string,
+        onClick: PropTypes.func,
+      }),
+    ),
   };
 
   static defaultProps = {
@@ -54,7 +69,10 @@ export default class ModalContent extends Component<ModalContentProps> {
       className,
       fullPageModal,
       formModal,
+      headerActions,
     } = this.props;
+
+    const hasActions = !!headerActions?.length || !!onClose;
 
     return (
       <div
@@ -67,14 +85,26 @@ export default class ModalContent extends Component<ModalContentProps> {
           { pb4: formModal && !footer },
         )}
       >
-        {onClose && (
-          <Icon
-            className="text-light text-medium-hover cursor-pointer absolute z2 m2 p2 top right"
-            name="close"
-            size={fullPageModal ? 24 : 16}
-            onClick={onClose}
-          />
+        {hasActions && (
+          <ActionsWrapper>
+            {headerActions?.map(({ icon, onClick }) => (
+              <ActionIcon
+                key={icon}
+                name={icon}
+                size={fullPageModal ? 24 : 16}
+                onClick={onClick}
+              />
+            ))}
+            {onClose && (
+              <ActionIcon
+                name="close"
+                size={fullPageModal ? 24 : 16}
+                onClick={onClose}
+              />
+            )}
+          </ActionsWrapper>
         )}
+
         {title && (
           <ModalHeader
             fullPageModal={fullPageModal}

--- a/frontend/src/metabase/components/ModalContent/ModalContent.tsx
+++ b/frontend/src/metabase/components/ModalContent/ModalContent.tsx
@@ -1,20 +1,22 @@
 import React, { Component, ReactNode } from "react";
 import PropTypes from "prop-types";
 import cx from "classnames";
-import { ActionIcon, ActionsWrapper } from "./ModalContent.styled";
+import {
+  ActionIcon,
+  ActionsWrapper,
+  HeaderContainer,
+} from "./ModalContent.styled";
 
-interface ModalContentProps extends CommonModalProps {
+export interface ModalContentProps extends CommonModalProps {
   id?: string;
   title: string;
   footer?: ReactNode;
   children: ReactNode;
-  headerActions?: ModalHeaderAction[];
 
   className?: string;
-  onClose?: () => void;
 }
 
-interface ModalHeaderAction {
+export interface ModalHeaderAction {
   icon: string;
   onClick: () => void;
 }
@@ -25,6 +27,9 @@ interface CommonModalProps {
   // standard modal
   formModal?: boolean;
   centeredTitle?: boolean;
+
+  headerActions?: ModalHeaderAction[];
+  onClose?: () => void;
 }
 
 // eslint-disable-next-line import/no-default-export -- deprecated usage
@@ -72,8 +77,6 @@ export default class ModalContent extends Component<ModalContentProps> {
       headerActions,
     } = this.props;
 
-    const hasActions = !!headerActions?.length || !!onClose;
-
     return (
       <div
         id={this.props.id}
@@ -85,31 +88,13 @@ export default class ModalContent extends Component<ModalContentProps> {
           { pb4: formModal && !footer },
         )}
       >
-        {hasActions && (
-          <ActionsWrapper>
-            {headerActions?.map(({ icon, onClick }) => (
-              <ActionIcon
-                key={icon}
-                name={icon}
-                size={fullPageModal ? 24 : 16}
-                onClick={onClick}
-              />
-            ))}
-            {onClose && (
-              <ActionIcon
-                name="close"
-                size={fullPageModal ? 24 : 16}
-                onClick={onClose}
-              />
-            )}
-          </ActionsWrapper>
-        )}
-
         {title && (
           <ModalHeader
             fullPageModal={fullPageModal}
             centeredTitle={centeredTitle}
             formModal={formModal}
+            headerActions={headerActions}
+            onClose={onClose}
           >
             {title}
           </ModalHeader>
@@ -137,19 +122,40 @@ export const ModalHeader = ({
   children,
   fullPageModal,
   centeredTitle,
-}: ModalHeaderProps) => (
-  <div className={cx("ModalHeader flex-no-shrink px4 py4 full")}>
-    <h2
-      className={cx(
-        "text-bold",
-        { "text-centered": fullPageModal || centeredTitle },
-        { mr4: !fullPageModal },
+  headerActions,
+  onClose,
+}: ModalHeaderProps) => {
+  const hasActions = !!headerActions?.length || !!onClose;
+  const actionIconSize = fullPageModal ? 24 : 16;
+
+  return (
+    <HeaderContainer>
+      <h2
+        className={cx("text-bold", {
+          "text-centered": fullPageModal || centeredTitle,
+        })}
+      >
+        {children}
+      </h2>
+
+      {hasActions && (
+        <ActionsWrapper>
+          {headerActions?.map(({ icon, onClick }) => (
+            <ActionIcon
+              key={icon}
+              name={icon}
+              size={actionIconSize}
+              onClick={onClick}
+            />
+          ))}
+          {onClose && (
+            <ActionIcon name="close" size={actionIconSize} onClick={onClose} />
+          )}
+        </ActionsWrapper>
       )}
-    >
-      {children}
-    </h2>
-  </div>
-);
+    </HeaderContainer>
+  );
+};
 
 interface ModalBodyProps extends CommonModalProps {
   children: ReactNode;

--- a/frontend/src/metabase/components/ModalContent/ModalContent.unit.spec.tsx
+++ b/frontend/src/metabase/components/ModalContent/ModalContent.unit.spec.tsx
@@ -1,14 +1,12 @@
 import React from "react";
 import userEvent from "@testing-library/user-event";
 import { getIcon, render } from "__support__/ui";
-import ModalContent, {
-  ModalContentProps,
-  ModalHeaderAction,
-} from "./ModalContent";
+import { ActionIcon } from "./ModalContent.styled";
+import ModalContent, { ModalContentProps } from "./ModalContent";
 
 describe("ModalContent", () => {
   it("should render header action buttons", () => {
-    const headerActions: ModalHeaderAction[] = [
+    const headerActions = [
       {
         icon: "pencil",
         onClick: jest.fn(),
@@ -19,7 +17,15 @@ describe("ModalContent", () => {
       },
     ];
 
-    setup({ headerActions });
+    const headerActionsEl = (
+      <>
+        {headerActions.map(({ icon, onClick }) => (
+          <ActionIcon key={icon} name={icon} onClick={onClick} />
+        ))}
+      </>
+    );
+
+    setup({ headerActions: headerActionsEl });
 
     headerActions.forEach(({ icon, onClick }) => {
       const iconEl = getIcon(icon);

--- a/frontend/src/metabase/components/ModalContent/ModalContent.unit.spec.tsx
+++ b/frontend/src/metabase/components/ModalContent/ModalContent.unit.spec.tsx
@@ -1,0 +1,55 @@
+import React from "react";
+import userEvent from "@testing-library/user-event";
+import { getIcon, render } from "__support__/ui";
+import ModalContent, {
+  ModalContentProps,
+  ModalHeaderAction,
+} from "./ModalContent";
+
+describe("ModalContent", () => {
+  it("should render header action buttons", () => {
+    const headerActions: ModalHeaderAction[] = [
+      {
+        icon: "pencil",
+        onClick: jest.fn(),
+      },
+      {
+        icon: "bolt",
+        onClick: jest.fn(),
+      },
+    ];
+
+    setup({ headerActions });
+
+    headerActions.forEach(({ icon, onClick }) => {
+      const iconEl = getIcon(icon);
+      expect(iconEl).toBeInTheDocument();
+
+      userEvent.click(iconEl);
+
+      expect(onClick).toHaveBeenCalledTimes(1);
+    });
+  });
+});
+
+function setup({
+  id = "id",
+  title = "Long Modal title Long Modal title Long Modal title",
+  centeredTitle = false,
+  children = <>Content</>,
+  fullPageModal = false,
+  onClose = jest.fn,
+  ...extraProps
+}: Partial<ModalContentProps> = {}) {
+  const props = {
+    id,
+    title,
+    centeredTitle,
+    children,
+    fullPageModal,
+    onClose,
+    ...extraProps,
+  };
+
+  render(<ModalContent {...props} />);
+}


### PR DESCRIPTION
Relates to https://github.com/metabase/metabase/issues/29866

### Description

This adds possibility to add extra actions to Modal header. We will need this functionality in the next parts of this epic.

### Demo


https://github.com/metabase/metabase/assets/7983744/4244f110-517e-4333-a3f0-01c9f9c3b6cf


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
