### PR TITLE
🍒 [CI] Improve FE sources glob pattern to exclude unit tests (#30639)

### DIFF
--- a/.github/file-paths.yaml
+++ b/.github/file-paths.yaml
@@ -13,8 +13,8 @@ shared_specs: &shared_specs
 
 frontend_sources: &frontend_sources
   - *shared_sources
-  - "enterprise/frontend/**"
-  - "frontend/!(test)/**"
+  - "enterprise/frontend/!(test)**/**/{!(*.spec),}.{js,jsx,ts,tsx,css}"
+  - "frontend/!(test)**/**/{!(*.spec),}.{js,jsx,ts,tsx,css}"
   - "yarn.lock"
   - "**/tsconfig*.json"
   - "package.json"


### PR DESCRIPTION
Manual backport of https://github.com/metabase/metabase/pull/30639.
For some reason, the `backport` label didn't do its job.