### PR TITLE
[MLv2] Add methods for MLv2 clause validation in MLv1

### DIFF
--- a/frontend/src/metabase-lib/Dimension.ts
+++ b/frontend/src/metabase-lib/Dimension.ts
@@ -399,11 +399,16 @@ export default class Dimension {
     return this._query && this._query.dimensionForSourceQuery(this);
   }
 
+  getOptions() {
+    return this._options;
+  }
+
   /**
    * Get an option from the field options map, if there is one.
    */
   getOption(k: string): any {
-    return this._options && this._options[k];
+    const options = this.getOptions();
+    return options?.[k];
   }
 
   /*

--- a/frontend/src/metabase-lib/Dimension.ts
+++ b/frontend/src/metabase-lib/Dimension.ts
@@ -289,6 +289,10 @@ export default class Dimension {
     return new Field();
   }
 
+  getMLv1CompatibleDimension() {
+    return this;
+  }
+
   /**
    * The `name` appearing in the column object (except duplicates would normally be suffxied)
    */
@@ -849,6 +853,12 @@ export class FieldDimension extends Dimension {
     // Despite being unable to find a field, we _might_ still have enough data to know a few things about it.
     // For example, if we have an mbql field reference, it might contain a `base-type`
     return this._createFallbackField();
+  }
+
+  getMLv1CompatibleDimension() {
+    return this.isIntegerFieldId()
+      ? this.withoutOptions("base-type", "effective-type")
+      : this;
   }
 
   tableId() {

--- a/frontend/src/metabase-lib/queries/StructuredQuery.ts
+++ b/frontend/src/metabase-lib/queries/StructuredQuery.ts
@@ -1235,8 +1235,6 @@ class StructuredQueryInner extends AtomicQuery {
     return explicitJoins;
   }
 
-  // TODO Atte Keinänen 6/18/17: Refactor to dimensionOptions which takes a dimensionFilter
-  // See aggregationFieldOptions for an explanation why that covers more use cases
   dimensionOptions(
     dimensionFilter: DimensionFilterFn = dimension => true,
   ): DimensionOptions {
@@ -1304,6 +1302,54 @@ class StructuredQueryInner extends AtomicQuery {
     }
 
     return new DimensionOptions(dimensionOptions);
+  }
+
+  /**
+   * An extension of dimensionOptions that includes MLv2 friendly dimensions.
+   * MLv1 and MLv2 can produce different field references for the same field.
+   *
+   * Example: if a question is started from another question or model,
+   * MLv2 will always use field literals like [ "field", "TOTAL", { "base-type": "type/Float" } ],
+   * but MLv1 could trace it to a concrete field like [ "field", 1, null ].
+   *
+   * Because dimensionOptions is an MLv1 concept, in will only include concrete field refs in a case like that.
+   * This method will add a field literal for each concrete field ref in the question, so MLv1 will treat them as valid.
+   *
+   * ⚠️ Should ONLY be used for clauses' `isValid` checks.
+   */
+  dimensionOptionsForValidation(
+    dimensionFilter: DimensionFilter = dimension => true,
+  ): DimensionOptions {
+    const baseOptions = this.dimensionOptions(dimensionFilter);
+
+    const mlv2FriendlyDimensions: Dimension[] = [];
+
+    baseOptions.dimensions.forEach(dimension => {
+      if (dimension instanceof FieldDimension) {
+        const field = dimension.field();
+        const options = dimension.getOptions();
+
+        // MLv1 picks up join-alias from parent questions/models.
+        // They won't be available in MLv2's field literals,
+        // so we need to remove them.
+        const mlv2Options = _.omit(options, "join-alias");
+
+        if (isVirtualCardId(field.table_id)) {
+          const mlv2Dimension = Dimension.parseMBQL([
+            "field",
+            field.name,
+            mlv2Options,
+          ]);
+          mlv2FriendlyDimensions.push(mlv2Dimension);
+        }
+      }
+    });
+
+    return new DimensionOptions({
+      count: baseOptions.count + mlv2FriendlyDimensions.length,
+      dimensions: [...baseOptions.dimensions, ...mlv2FriendlyDimensions],
+      fks: baseOptions.fks,
+    });
   }
 
   // FIELD OPTIONS

--- a/frontend/src/metabase-lib/queries/structured/Breakout.ts
+++ b/frontend/src/metabase-lib/queries/structured/Breakout.ts
@@ -46,7 +46,12 @@ export default class Breakout extends MBQLClause {
    */
   isValid() {
     const query = this.query();
-    return !query || query.breakoutOptions(this).hasDimension(this.dimension());
+    return (
+      !query ||
+      query
+        .breakoutOptions(this)
+        .hasDimension(this.getMLv1CompatibleDimension())
+    );
   }
 
   /**

--- a/frontend/src/metabase-lib/queries/structured/Breakout.ts
+++ b/frontend/src/metabase-lib/queries/structured/Breakout.ts
@@ -46,12 +46,11 @@ export default class Breakout extends MBQLClause {
    */
   isValid() {
     const query = this.query();
-    return (
-      !query ||
-      query
-        .breakoutOptions(this)
-        .hasDimension(this.getMLv1CompatibleDimension())
-    );
+    if (!query) {
+      return true;
+    }
+    const dimension = this.dimension().getMLv1CompatibleDimension();
+    return query.breakoutOptions(this).hasDimension(dimension);
   }
 
   /**

--- a/frontend/src/metabase-lib/queries/structured/Filter.ts
+++ b/frontend/src/metabase-lib/queries/structured/Filter.ts
@@ -96,7 +96,7 @@ export default class Filter extends MBQLClause {
   isValid() {
     if (this.isStandard()) {
       // has an operator name and dimension or expression
-      const dimension = this.dimension();
+      const dimension = this.getMLv1CompatibleDimension();
 
       if (!dimension && isExpression(this[1])) {
         return true;

--- a/frontend/src/metabase-lib/queries/structured/Filter.ts
+++ b/frontend/src/metabase-lib/queries/structured/Filter.ts
@@ -96,7 +96,7 @@ export default class Filter extends MBQLClause {
   isValid() {
     if (this.isStandard()) {
       // has an operator name and dimension or expression
-      const dimension = this.getMLv1CompatibleDimension();
+      const dimension = this.dimension().getMLv1CompatibleDimension();
 
       if (!dimension && isExpression(this[1])) {
         return true;

--- a/frontend/src/metabase-lib/queries/structured/Join.ts
+++ b/frontend/src/metabase-lib/queries/structured/Join.ts
@@ -661,7 +661,7 @@ export default class Join extends MBQLObjectClause {
     const dimensions = [...this.parentDimensions(), ...this.joinDimensions()];
     return dimensions.every(
       dimension =>
-        dimensionOptions.hasDimension(dimension) || // For some GUI queries created in earlier versions of Metabase,
+        dimensionOptions.hasDimension(dimension.getMLv1CompatibleDimension()) || // For some GUI queries created in earlier versions of Metabase,
         // some dimensions are described as field literals
         // Usually it's [ "field", field_numeric_id, null|object ]
         // And field literals look like [ "field", "PRODUCT_ID", {'base-type': 'type/Integer' } ]

--- a/frontend/test/metabase-lib/lib/Dimension.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/Dimension.unit.spec.js
@@ -212,6 +212,14 @@ describe("Dimension", () => {
         ]);
       });
     });
+
+    describe("getMLv1CompatibleDimension", () => {
+      it("should return itself without changes by default", () => {
+        const productsCategory = metadata.field(PRODUCTS.CATEGORY);
+        const dimension = productsCategory.dimension();
+        expect(dimension.getMLv1CompatibleDimension()).toBe(dimension);
+      });
+    });
   });
 
   describe("Field with integer ID", () => {
@@ -310,6 +318,33 @@ describe("Dimension", () => {
 
           expect(field.id).toEqual(ORDERS.TOTAL);
           expect(field.base_type).toEqual("type/Float");
+        });
+      });
+
+      describe("getMLv1CompatibleDimension", () => {
+        it("should return itself without changes by default", () => {
+          const dimension = Dimension.parseMBQL(
+            ["field", ORDERS.TOTAL, null],
+            metadata,
+          );
+          expect(dimension.getMLv1CompatibleDimension()).toBe(dimension);
+        });
+
+        it("should strip away *-type options", () => {
+          const dimension = Dimension.parseMBQL(
+            [
+              "field",
+              ORDERS.TOTAL,
+              { "base-type": "type/Float", "effective-type": "type/Float" },
+            ],
+            metadata,
+          );
+
+          expect(dimension.getMLv1CompatibleDimension().mbql()).toEqual([
+            "field",
+            ORDERS.TOTAL,
+            null,
+          ]);
         });
       });
     });
@@ -416,6 +451,28 @@ describe("Dimension", () => {
           expect(fk._metadata).toEqual(metadata);
         });
       });
+      describe("getMLv1CompatibleDimension", () => {
+        it("should strip away *-type options", () => {
+          const dimension = Dimension.parseMBQL(
+            [
+              "field",
+              PRODUCTS.TITLE,
+              {
+                "base-type": "type/Text",
+                "effective-type": "type/Text",
+                "source-field": ORDERS.PRODUCT_ID,
+              },
+            ],
+            metadata,
+          );
+
+          expect(dimension.getMLv1CompatibleDimension().mbql()).toEqual([
+            "field",
+            PRODUCTS.TITLE,
+            { "source-field": ORDERS.PRODUCT_ID },
+          ]);
+        });
+      });
     });
   });
 
@@ -506,6 +563,28 @@ describe("Dimension", () => {
           expect(dimension.field().id).toEqual(PRODUCTS.CREATED_AT);
           expect(dimension.field().metadata).toEqual(metadata);
           expect(dimension.field().displayName()).toEqual("Created At");
+        });
+      });
+      describe("getMLv1CompatibleDimension", () => {
+        it("should strip away *-type options", () => {
+          const dimension = Dimension.parseMBQL(
+            [
+              "field",
+              ORDERS.CREATED_AT,
+              {
+                "base-type": "type/DateTime",
+                "effective-type": "type/DateTime",
+                "temporal-unit": "hour",
+              },
+            ],
+            metadata,
+          );
+
+          expect(dimension.getMLv1CompatibleDimension().mbql()).toEqual([
+            "field",
+            ORDERS.CREATED_AT,
+            { "temporal-unit": "hour" },
+          ]);
         });
       });
     });
@@ -752,6 +831,28 @@ describe("Dimension", () => {
             { "join-alias": "join1" },
           ]);
           expect(dimension.isSameBaseDimension(anotherDimension)).toBe(true);
+        });
+      });
+      describe("getMLv1CompatibleDimension", () => {
+        it("should strip away *-type options", () => {
+          const dimension = Dimension.parseMBQL(
+            [
+              "field",
+              ORDERS.TOTAL,
+              {
+                "base-type": "type/DateTime",
+                "effective-type": "type/DateTime",
+                "join-alias": "join1",
+              },
+            ],
+            metadata,
+          );
+
+          expect(dimension.getMLv1CompatibleDimension().mbql()).toEqual([
+            "field",
+            ORDERS.TOTAL,
+            { "join-alias": "join1" },
+          ]);
         });
       });
     });


### PR DESCRIPTION
Extracted from #30693

## Problem

MLv1 query has a "clean" mechanism that goes through different kinds of clauses, calls `isValid` on each, and removes ones returning `false`. Primarily, a validation check looks like [the one for breakouts](https://github.com/metabase/metabase/blob/f7caac7d00c8538d970b67e98d0d8ca2f34b5e55/frontend/src/metabase-lib/queries/structured/Breakout.ts#L49): we get a list of dimensions that can be used in a breakout, and check if breakout's dimension is present in that list. MLv2 clauses can look and behave slightly differently, and that doesn't play nicely with MLv1's validation. As a result, MLv2 clauses can be treated as invalid and get dropped from a query. 

### Examples

**Field reference options**

MLv2 adds `base-type` and `effective-type` to _each_ field reference, as opposed to only field literals in MLv1:

```js
// MLv1
[ "field", 1, null ]

// MLv2
[ "field", 1, { "effective-type": "type/Float" } ]
```

MLv1's clause validation methods use `dimensionOptions` to get a list of available dimensions. MLv1 doesn't add `effective-type` to concrete fields. So when a clause is built with MLv2, and it has an `effective-type`, we can't match it with a dimension from `dimensionOptions` because of it.

**Columns from questions or models**

In MLv1, if a column is coming from a source/joined question/model, sometimes it could be a concrete field, and sometimes it could be a field reference. In MLv2, it's always a field literal. So again, during clause validation it can be problematic to find matching field references.

### Why do we still use MLv1 validation

We're migrating to MLv2 step-by-step, so MLv2 and MLv1 have to co-exist for some time. In the notebook editor, the component receives an MLv1 query as input and bubbles up an MLv1 query when updates happen. Internally, some clauses are managed with MLv2, and we convert an MLv2 query back to MLv1 one. On the other hand, some clauses still use MLv1 and they have to go through the query clean phase. Also, some clauses can be added outside the notebook editor (e.g. filter modal and summarization sidebar in QB chill mode)

As a result, we need to make sure MLv2 clauses also pass MLv1's validation checks.

## Change

1. Adding the `getMLv1CompatibleDimension` method to `Dimension`. For `FieldDimensions`, it's going to ensure we're stripping out `base-type` and `effective-type` from concrete fields
2. Adding the `dimensionOptionsForValidation` method to `StructuredQuery`. It's going to append a filter literal analog for each concrete field reference, so we can safely validate an MLv2 clause.

You can see how it works in action on the breakouts MLv2 branch:

* [`breakoutOptions` now use `dimensionOptionsForValidation`](https://github.com/metabase/metabase/blob/ce90224b743e5345f821d7e218d753151e2a6a51/frontend/src/metabase-lib/queries/StructuredQuery.ts#L796)
* [breakout's `isValid` method now uses `getMLv1CompatibleDimension`](https://github.com/metabase/metabase/blob/ce90224b743e5345f821d7e218d753151e2a6a51/frontend/src/metabase-lib/queries/structured/Breakout.ts#L52)

## To Verify

CI should be green 🟢