### PR TITLE
CI: Avoid the deprecated set-output

### DIFF
--- a/.github/workflows/uberjar.yml
+++ b/.github/workflows/uberjar.yml
@@ -87,8 +87,10 @@ jobs:
     steps:
     - name: Extract and clean branch name
       shell: bash
-      run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/} | sed 's/[^-._a-zA-Z0-9]/-/g')"
+      run: echo "branch=$(echo $GITHUB_REF_NAME | sed 's/[^-._a-zA-Z0-9]/-/g')" >> $GITHUB_OUTPUT
       id: extract_branch
+    - name: Verify the intended tag of the container image
+      run: echo "Container image will be tagged as ${{ steps.extract_branch.outputs.branch }}-${{ matrix.edition }}"
     - name: Check out the code (Dockerfile needed)
       uses: actions/checkout@v3
       with:
@@ -203,8 +205,10 @@ jobs:
     steps:
       - name: Extract and clean branch name
         shell: bash
-        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/} | sed 's/[^-._a-zA-Z0-9]/-/g')"
+        run: echo "branch=$(echo $GITHUB_REF_NAME | sed 's/[^-._a-zA-Z0-9]/-/g')" >> $GITHUB_OUTPUT
         id: extract_branch
+      - name: Verify the intended tag of the container image
+        run: echo "Container image will be tagged as ${{ steps.extract_branch.outputs.branch }}-${{ matrix.edition }}"
       - name: Check out the code (Dockerfile needed)
         uses: actions/checkout@v3
         with:


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

### Before this PR

When the `uberjar.yml` workflow finishes, we can witness a bunch of `set-output` deprecation warnings:

![image](https://github.com/metabase/metabase/assets/7288/826d6c8a-5fd9-4816-88b8-e96a76f9de78)

### After this PR

Those warnings are gone!

### Note

I also checked that the use of `GITHUB_REF_NAME` is still working to get (and to clean) the branch name:

![image](https://github.com/metabase/metabase/assets/7288/3af07cc1-a8d7-4626-a174-50f0b7cc2c93)
