### PR TITLE
CI: Use updated GitHub actions to avoid deprecation warnings

### DIFF
--- a/.github/workflows/uberjar.yml
+++ b/.github/workflows/uberjar.yml
@@ -102,11 +102,11 @@ jobs:
       run: mv bin/docker/target/uberjar/metabase.jar bin/docker/.
     - name: Set up Docker Buildx
       id: buildx
-      uses: docker/setup-buildx-action@v1
+      uses: docker/setup-buildx-action@v2.5.0
       with:
         driver-opts: network=host
     - name: Build ${{ matrix.edition }} container
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v3
       with:
         context: bin/docker/.
         platforms: linux/amd64
@@ -123,7 +123,7 @@ jobs:
       run: while ! curl -s 'http://localhost:3000/api/health' | grep '{"status":"ok"}'; do sleep 1; done
       timeout-minutes: 3
     - name: Login to Docker Hub
-      uses: docker/login-action@v1
+      uses: docker/login-action@v2
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -223,12 +223,12 @@ jobs:
           platforms: 'arm64'
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2.5.0
         with:
           driver-opts: network=host
       # Build experimental ubuntu-based images only for master
       - name: Build ${{ matrix.edition }} Ubuntu based multi-arch container
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: bin/docker/.
           platforms: linux/amd64,linux/arm64
@@ -246,7 +246,7 @@ jobs:
         run: while ! curl -s 'http://localhost:3001/api/health' | grep '{"status":"ok"}'; do sleep 1; done
         timeout-minutes: 3
       - name: Login to Docker Hub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}


### PR DESCRIPTION
### Before this PR

We witness lots of similar warnings:

![image](https://github.com/metabase/metabase/assets/7288/628294b5-9503-4b27-9b65-265bcfc273ac)


### After this PR

Those warnings are gone.