### PR TITLE
Add missing reverse migration for AddJoinAliasToVisualizationSettingsFieldRefs

### DIFF
--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -14788,7 +14788,7 @@ databaseChangeLog:
       comment: Added 0.47.0 - Add join-alias to the report_card.visualization_settings.column_settings field refs
       changes:
         - customChange:
-            class: "metabase.db.custom_migrations.AddJoinAliasToVisualizationSettingsFieldRefs"
+            class: "metabase.db.custom_migrations.AddJoinAliasToColumnSettingsFieldRefs"
 
   - changeSet:
       id: v47.00-029

--- a/src/metabase/db/custom_migrations.clj
+++ b/src/metabase/db/custom_migrations.clj
@@ -304,6 +304,7 @@
                             (t2/reducible-query {:select [:id :visualization_settings :result_metadata]
                                                  :from   [:report_card]
                                                  :where  [:and
+                                                          [= :query_type "query"]
                                                           [:like :visualization_settings "%column_settings%"]
                                                           [:like :result_metadata "%join-alias%"]]}))))
   (let [update! (fn [{:keys [id visualization_settings]}]
@@ -318,6 +319,7 @@
                             (t2/reducible-query {:select [:id :visualization_settings]
                                                  :from   [:report_card]
                                                  :where  [:and
+                                                          [= :query_type "query"]
                                                           [:like :visualization_settings "%column_settings%"]
                                                           [:like :visualization_settings "%join-alias%"]]})))))
 

--- a/src/metabase/db/custom_migrations.clj
+++ b/src/metabase/db/custom_migrations.clj
@@ -304,7 +304,9 @@
                             (t2/reducible-query {:select [:id :visualization_settings :result_metadata]
                                                  :from   [:report_card]
                                                  :where  [:and
-                                                          [= :query_type "query"]
+                                                          [:or
+                                                           [:= :query_type nil]
+                                                           [:= :query_type "query"]]
                                                           [:like :visualization_settings "%\"column_settings\"%"]
                                                           [:like :result_metadata "%\"join-alias\"%"]]}))))
   (let [update! (fn [{:keys [id visualization_settings]}]
@@ -319,7 +321,9 @@
                             (t2/reducible-query {:select [:id :visualization_settings]
                                                  :from   [:report_card]
                                                  :where  [:and
-                                                          [= :query_type "query"]
+                                                          [:or
+                                                           [:= :query_type nil]
+                                                           [:= :query_type "query"]]
                                                           [:like :visualization_settings "%\"column_settings\":%"]
                                                           [:like :visualization_settings "%\"join-alias\":%"]]})))))
 

--- a/src/metabase/db/custom_migrations.clj
+++ b/src/metabase/db/custom_migrations.clj
@@ -305,8 +305,8 @@
                                                  :from   [:report_card]
                                                  :where  [:and
                                                           [= :query_type "query"]
-                                                          [:like :visualization_settings "%column_settings%"]
-                                                          [:like :result_metadata "%join-alias%"]]}))))
+                                                          [:like :visualization_settings "%\"column_settings\"%"]
+                                                          [:like :result_metadata "%\"join-alias\"%"]]}))))
   (let [update! (fn [{:keys [id visualization_settings]}]
                   (t2/query-one {:update :report_card
                                  :set    {:visualization_settings visualization_settings}
@@ -320,8 +320,8 @@
                                                  :from   [:report_card]
                                                  :where  [:and
                                                           [= :query_type "query"]
-                                                          [:like :visualization_settings "%column_settings%"]
-                                                          [:like :visualization_settings "%join-alias%"]]})))))
+                                                          [:like :visualization_settings "%\"column_settings\":%"]
+                                                          [:like :visualization_settings "%\"join-alias\":%"]]})))))
 
 (defn- update-card-row-on-downgrade-for-dashboard-tab
   [dashboard-id]

--- a/src/metabase/db/custom_migrations.clj
+++ b/src/metabase/db/custom_migrations.clj
@@ -290,11 +290,11 @@
 
 (define-reversible-migration AddJoinAliasToColumnSettingsFieldRefs
   (let [update-one! (fn [{:keys [id visualization_settings] :as card}]
-                  (let [updated (add-join-alias-to-column-settings-refs card)]
-                    (when (not= visualization_settings updated)
-                      (t2/query-one {:update :report_card
-                                     :set    {:visualization_settings updated}
-                                     :where  [:= :id id]}))))]
+                      (let [updated (add-join-alias-to-column-settings-refs card)]
+                        (when (not= visualization_settings updated)
+                          (t2/query-one {:update :report_card
+                                         :set    {:visualization_settings updated}
+                                         :where  [:= :id id]}))))]
     (run! update-one! (t2/reducible-query {:select [:id :visualization_settings :result_metadata]
                                            :from   [:report_card]
                                            :where  [:and
@@ -303,23 +303,23 @@
                                                      [:= :query_type "query"]]
                                                     [:like :visualization_settings "%\\\\\"ref\\\\\",[\\\\\"field%"]
                                                     [:like :result_metadata "%\"join-alias\"%"]]})))
-  (let [update! (fn [{:keys [id visualization_settings]}]
-                  (let [updated (-> visualization_settings
-                                    json/parse-string
-                                    remove-join-alias-from-column-settings-field-refs
-                                    json/generate-string)]
-                    (when (not= visualization_settings updated)
-                      (t2/query-one {:update :report_card
-                                     :set    {:visualization_settings updated}
-                                     :where  [:= :id id]}))))]
-    (run! update! (t2/reducible-query {:select [:id :visualization_settings]
-                                       :from   [:report_card]
-                                       :where  [:and
-                                                [:or
-                                                 [:= :query_type nil]
-                                                 [:= :query_type "query"]]
-                                                [:like :visualization_settings "%\"ref\\\\\",[\\\\\"field%"]
-                                                [:like :visualization_settings "%\\\\\"join-alias\\\\\"%"]]}))))
+  (let [update-one! (fn [{:keys [id visualization_settings]}]
+                      (let [updated (-> visualization_settings
+                                        json/parse-string
+                                        remove-join-alias-from-column-settings-field-refs
+                                        json/generate-string)]
+                        (when (not= visualization_settings updated)
+                          (t2/query-one {:update :report_card
+                                         :set    {:visualization_settings updated}
+                                         :where  [:= :id id]}))))]
+    (run! update-one! (t2/reducible-query {:select [:id :visualization_settings]
+                                           :from   [:report_card]
+                                           :where  [:and
+                                                    [:or
+                                                     [:= :query_type nil]
+                                                     [:= :query_type "query"]]
+                                                    [:like :visualization_settings "%\"ref\\\\\",[\\\\\"field%"]
+                                                    [:like :visualization_settings "%\\\\\"join-alias\\\\\"%"]]}))))
 
 (defn- update-card-row-on-downgrade-for-dashboard-tab
   [dashboard-id]

--- a/test/metabase/db/custom_migrations_test.clj
+++ b/test/metabase/db/custom_migrations_test.clj
@@ -180,7 +180,7 @@
                        ((:out mi/transform-result-metadata))
                        json/generate-string)))))))))
 
-(deftest add-join-alias-to-visualization-settings-field-refs-test
+(deftest add-join-alias-to-column-settings-field-refs-test
   (testing "Migrations v47.00-028: update visualization_settings.column_settings legacy field refs"
     (impl/test-migrations ["v47.00-028"] [migrate!]
       (let [{:keys [db-type ^javax.sql.DataSource data-source]} mdb.connection/*application-db*

--- a/test/metabase/db/custom_migrations_test.clj
+++ b/test/metabase/db/custom_migrations_test.clj
@@ -239,7 +239,7 @@
                      :visualization_settings
                      json/parse-string))))
         (db.setup/migrate! db-type data-source :down 46)
-        (testing "After reversing the migration, column_settings field refs are updated to remove the join-alias"
+        (testing "After reversing the migration, column_settings field refs are updated to remove join-alias"
           (is (= visualization-settings
                  (-> (t2/query-one {:select [:visualization_settings]
                                     :from   [:report_card]

--- a/test/metabase/db/custom_migrations_test.clj
+++ b/test/metabase/db/custom_migrations_test.clj
@@ -183,7 +183,8 @@
 (deftest add-join-alias-to-visualization-settings-field-refs-test
   (testing "Migrations v47.00-028: update visualization_settings.column_settings legacy field refs"
     (impl/test-migrations ["v47.00-028"] [migrate!]
-      (let [result_metadata
+      (let [{:keys [db-type ^javax.sql.DataSource data-source]} mdb.connection/*application-db*
+            result_metadata
             [{:field_ref [:field 1 nil]}
              {:field_ref [:field 1 {:join-alias "Self-joined Table"}]}
              {:field_ref [:field 2 {:source-field 3}]}
@@ -230,8 +231,16 @@
                                                         :database_id            database-id
                                                         :collection_id          nil})]
         (migrate!)
-        (testing "column_settings field refs are updated"
+        (testing "After the migration, column_settings field refs are updated to include join-alias"
           (is (= expected
+                 (-> (t2/query-one {:select [:visualization_settings]
+                                    :from   [:report_card]
+                                    :where  [:= :id card-id]})
+                     :visualization_settings
+                     json/parse-string))))
+        (db.setup/migrate! db-type data-source :down 46)
+        (testing "After reversing the migration, column_settings field refs are updated to remove the join-alias"
+          (is (= visualization-settings
                  (-> (t2/query-one {:select [:visualization_settings]
                                     :from   [:report_card]
                                     :where  [:= :id card-id]})


### PR DESCRIPTION
Epic: https://github.com/metabase/metabase/issues/30789

This PR adds a reverse migration to the existing custom migration `AddJoinAliasToVisualizationSettingsFieldRefs`, removing the `join-alias` in `visualization_settings.column_settings` keys that were added by the forward migration.

PR for forward migration: https://github.com/metabase/metabase/pull/30460

### Why is this needed now?

Previously I thought that the forward migration was always backwards compatible. It is backwards compatible for queries with self-joins, because there would still be a field ref in visualization_settings without a join-alias after the migration. But it is not backwards compatible in the rare case when there are two columns with the same name, but from two different joined questions. In that case, the migration will produce two field refs with a join-alias, and the migration would not be backwards compatible.