### PR TITLE
[E2E] Chain the custom `icon` command

### DIFF
--- a/e2e/support/commands/ui/icon.js
+++ b/e2e/support/commands/ui/icon.js
@@ -1,3 +1,15 @@
-Cypress.Commands.add("icon", icon_name => {
-  cy.get(`.Icon-${icon_name}`);
-});
+Cypress.Commands.add(
+  "icon",
+  {
+    prevSubject: "optional",
+  },
+  (subject, icon_name) => {
+    const SELECTOR = `.Icon-${icon_name}`;
+
+    if (subject) {
+      cy.wrap(subject).find(SELECTOR);
+    } else {
+      cy.get(SELECTOR);
+    }
+  },
+);

--- a/e2e/support/helpers/e2e-collection-helpers.js
+++ b/e2e/support/helpers/e2e-collection-helpers.js
@@ -14,7 +14,7 @@ export function getCollectionActions() {
 }
 
 export function openCollectionMenu() {
-  getCollectionActions().within(() => cy.icon("ellipsis").click());
+  getCollectionActions().icon("ellipsis").click();
 }
 
 export function getSidebarSectionTitle(name) {
@@ -45,10 +45,7 @@ export function getPersonalCollectionName(user) {
 }
 
 export function openCollectionItemMenu(item, index = 0) {
-  cy.findAllByText(item)
-    .eq(index)
-    .closest("tr")
-    .within(() => cy.icon("ellipsis").click());
+  cy.findAllByText(item).eq(index).closest("tr").icon("ellipsis").click();
 }
 
 export const getPinnedSection = () => {
@@ -70,8 +67,6 @@ export const openPinnedItemMenu = name => {
 
 export const openUnpinnedItemMenu = name => {
   getUnpinnedSection().within(() => {
-    cy.findByText(name)
-      .closest("tr")
-      .within(() => cy.icon("ellipsis").click());
+    cy.findByText(name).closest("tr").icon("ellipsis").click();
   });
 };

--- a/e2e/support/helpers/e2e-ui-elements-helpers.js
+++ b/e2e/support/helpers/e2e-ui-elements-helpers.js
@@ -67,9 +67,7 @@ export function filterWidget() {
 }
 
 export const openQuestionActions = () => {
-  cy.findByTestId("qb-header-action-panel").within(() => {
-    cy.icon("ellipsis").click();
-  });
+  cy.findByTestId("qb-header-action-panel").icon("ellipsis").click();
 };
 
 export const collectionTable = () => {

--- a/e2e/test/scenarios/collections/permissions.cy.spec.js
+++ b/e2e/test/scenarios/collections/permissions.cy.spec.js
@@ -442,7 +442,7 @@ function clickButton(name) {
 
 function pinItem(item) {
   openCollectionItemMenu(item);
-  popover().within(() => cy.icon("pin").click());
+  popover().icon("pin").click();
 }
 
 function exposeChildrenFor(collectionName) {

--- a/e2e/test/scenarios/custom-column/cc-data-type.cy.spec.js
+++ b/e2e/test/scenarios/custom-column/cc-data-type.cy.spec.js
@@ -138,7 +138,7 @@ describe("scenarios > question > custom column > data type", () => {
 function addCustomColumns(columns) {
   cy.wrap(columns).each((column, index) => {
     if (index) {
-      getNotebookStep("expression").within(() => cy.icon("add").click());
+      getNotebookStep("expression").icon("add").click();
     } else {
       cy.findByText("Custom column").click();
     }

--- a/e2e/test/scenarios/onboarding/home/homepage.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/home/homepage.cy.spec.js
@@ -215,11 +215,9 @@ describe("scenarios > home > custom homepage", () => {
 });
 
 const pinItem = name => {
-  cy.findByText(name)
-    .closest("tr")
-    .within(() => cy.icon("ellipsis").click());
+  cy.findByText(name).closest("tr").icon("ellipsis").click();
 
-  popover().within(() => cy.icon("pin").click());
+  popover().icon("pin").click();
 };
 
 const getXrayCandidates = () => [

--- a/e2e/test/scenarios/organization/moderation-question.cy.spec.js
+++ b/e2e/test/scenarios/organization/moderation-question.cy.spec.js
@@ -142,12 +142,12 @@ describeEE("scenarios > saved question moderation", () => {
 
       cy.findByPlaceholderText("Search…").type("orders{enter}");
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("Orders, Count").icon("verified");
+      cy.findByText("Orders, Count").parent().icon("verified");
 
       cy.visit("/collection/root");
 
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("Orders, Count").icon("verified");
+      cy.findByText("Orders, Count").closest("td").icon("verified");
     });
   });
 });

--- a/e2e/test/scenarios/organization/timelines-collection.cy.spec.js
+++ b/e2e/test/scenarios/organization/timelines-collection.cy.spec.js
@@ -568,7 +568,7 @@ describe("scenarios > organization > timelines > collection", () => {
       cy.wait("@updateTimeline");
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("No timelines found");
-      getModal().within(() => cy.icon("chevronleft").click());
+      getModal().icon("chevronleft").click();
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Releases");
     });
@@ -599,7 +599,7 @@ describe("scenarios > organization > timelines > collection", () => {
       cy.wait("@deleteTimeline");
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("No timelines found");
-      getModal().within(() => cy.icon("chevronleft").click());
+      getModal().icon("chevronleft").click();
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Our analytics events");
     });
@@ -749,11 +749,7 @@ const getModal = () => {
 };
 
 const openMenu = name => {
-  return cy
-    .findByText(name)
-    .parent()
-    .parent()
-    .within(() => cy.icon("ellipsis").click());
+  return cy.findByText(name).parent().parent().icon("ellipsis").click();
 };
 
 const setFormattingSettings = settings => {

--- a/e2e/test/scenarios/organization/timelines-question.cy.spec.js
+++ b/e2e/test/scenarios/organization/timelines-question.cy.spec.js
@@ -117,7 +117,7 @@ describe("scenarios > organization > timelines > question", () => {
       cy.icon("calendar").click();
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Releases").should("be.visible");
-      rightSidebar().within(() => cy.icon("ellipsis").click());
+      rightSidebar().icon("ellipsis").click();
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Edit event").click();
 
@@ -149,7 +149,7 @@ describe("scenarios > organization > timelines > question", () => {
       cy.icon("calendar").click();
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Builds").should("be.visible");
-      rightSidebar().within(() => cy.icon("ellipsis").click());
+      rightSidebar().icon("ellipsis").click();
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Move event").click();
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -177,7 +177,7 @@ describe("scenarios > organization > timelines > question", () => {
       cy.icon("calendar").click();
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Releases").should("be.visible");
-      rightSidebar().within(() => cy.icon("ellipsis").click());
+      rightSidebar().icon("ellipsis").click();
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Archive event").click();
       cy.wait("@updateEvent");
@@ -436,7 +436,7 @@ describe("scenarios > organization > timelines > question", () => {
       cy.findByText("Releases").should("be.visible");
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Add an event").should("not.exist");
-      rightSidebar().within(() => cy.icon("ellipsis").should("not.exist"));
+      rightSidebar().icon("ellipsis").should("not.exist");
     });
   });
 });

--- a/e2e/test/scenarios/question/reproductions/28874-notebook-pivot.cy.spec.js
+++ b/e2e/test/scenarios/question/reproductions/28874-notebook-pivot.cy.spec.js
@@ -31,9 +31,7 @@ describe("issue 28874", () => {
     visitQuestionAdhoc(questionDetails, { mode: "notebook" });
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Product ID")
-      .parent()
-      .within(() => cy.icon("close").click());
+    cy.findByText("Product ID").parent().icon("close").click();
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Product ID").should("not.exist");

--- a/e2e/test/scenarios/question/reproductions/29082-quick-filter-null.cy.spec.js
+++ b/e2e/test/scenarios/question/reproductions/29082-quick-filter-null.cy.spec.js
@@ -39,7 +39,7 @@ describe("issue 29082", () => {
     cy.findByText("Discount is empty").should("exist");
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Discount is empty").within(() => cy.icon("close").click());
+    cy.findByText("Discount is empty").icon("close").click();
     cy.wait("@dataset");
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Showing 11 rows").should("exist");

--- a/e2e/test/scenarios/question/settings.cy.spec.js
+++ b/e2e/test/scenarios/question/settings.cy.spec.js
@@ -181,14 +181,14 @@ describe("scenarios > question > settings", () => {
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Conditional Formatting"); // confirm it's open
       cy.get(".TableInteractive").findByText("Subtotal").click(); // open subtotal column header actions
-      popover().within(() => cy.icon("gear").click()); // open subtotal column settings
+      popover().icon("gear").click(); // open subtotal column settings
 
       //cy.findByText("Table options").should("not.exist"); // no longer displaying the top level settings
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Separator style"); // shows subtotal column settings
 
       cy.get(".TableInteractive").findByText("Created At").click(); // open created_at column header actions
-      popover().within(() => cy.icon("gear").click()); // open created_at column settings
+      popover().icon("gear").click(); // open created_at column settings
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Date style"); // shows created_at column settings
     });


### PR DESCRIPTION
We have a handy custom Cypress command called `icon` that allows one to quickly grab icon(s) on the page. The previous implementation meant that Cypress **always** searches ALL icons from the root.

After this PR it should be possible to search for the specific icon within the scope of the previous subject.
```js
// You no longer need to do this
cy.get("parent").within(() => {
  cy.icon("foo");
});

// This is perfectly fine
cy.get("parent").icon("foo");
```

### How to test?
I've applied this change to all helpers and to every single e2e spec where the `.within()` pattern was used. If the new implementation is correct, all tests should still pass.