### PR TITLE
Keep the metadata from the tables list for questions

### DIFF
--- a/src/metabase/lib/join.cljc
+++ b/src/metabase/lib/join.cljc
@@ -72,7 +72,7 @@
       (:display-name (lib.metadata/table query source-table))
       ;; handle card__<id> source tables.
       (let [card-id (lib.util/string-table-id->card-id source-table)]
-        (i18n/tru "Saved Question #{0}" card-id)))
+        (i18n/tru "Question {0}" card-id)))
     (i18n/tru "Native Query")))
 
 (defmethod lib.metadata.calculation/display-info-method :mbql/join

--- a/src/metabase/lib/js/metadata.cljs
+++ b/src/metabase/lib/js/metadata.cljs
@@ -195,6 +195,13 @@
     :metrics
     :table})
 
+(defn- parse-field-id
+  [id]
+  (cond-> id
+    ;; sometimes instead of an ID we get a field reference
+    ;; with the name of the column in the second position
+    (vector? id) second))
+
 (defmethod parse-field-fn :field
   [_object-type]
   (fn [k v]
@@ -208,6 +215,7 @@
       :has-field-values  (keyword v)
       :semantic-type     (keyword v)
       :visibility-type   (keyword v)
+      :id                (parse-field-id v)
       v)))
 
 (defmethod parse-objects-default-key :field
@@ -221,7 +229,15 @@
 (defmethod excluded-keys :card
   [_object-type]
   #{:database
+    :db
     :dimension-options
+    :fks
+    :metadata
+    :metrics
+    :plain-object
+    :segments
+    :schema
+    :schema-name
     :table})
 
 (defn- parse-fields [fields]

--- a/src/metabase/lib/js/metadata.cljs
+++ b/src/metabase/lib/js/metadata.cljs
@@ -253,6 +253,7 @@
          ;; _plainObject can contain field names in the field property
          ;; instead of the field objects themselves.  Removing this
          ;; property makes sure we parse the real fields.
+         gobject/clone
          (doto (gobject/remove "_plainObject"))
          parse-card
          (assoc :id id))


### PR DESCRIPTION
As the screenshot below shows, `Question`s don't contain all metadata directly, (occasionally?) these have to be merged in from the corresponding `Table` metadata. Previously, the question metadata would overwrite the table metadata and the field information would get lots. In this PR the two sources of information are merged.

Another quirk is that the `_plainObject` we usually prefer doesn't contain the actual fields just the names of them which would lead to errors. This PR just removes the `_plainObject` field. I'm not sure if this is OK, do we own this metadata object or is this side effect visible (and so potentially harmful) at other places?

![Screenshot 2023-05-30 at 20 08 53](https://github.com/metabase/metabase/assets/103100869/2fb10e73-9a95-43c1-9fca-59e0bb2a8752)
