### PR TITLE
fixed typo in CustomHomePageModal

### DIFF
--- a/frontend/src/metabase/home/components/Modals/CustomHomePageModal/CustomHomePageModal.tsx
+++ b/frontend/src/metabase/home/components/Modals/CustomHomePageModal/CustomHomePageModal.tsx
@@ -61,7 +61,7 @@ export const CustomHomePageModal = ({
           </Button>,
         ]}
       >
-        <p>{t`Pick one of your dashboards to serve as homepage. Users wihtout dashboard access will be directed to the default homepage. You can update or reset this anytime in Admin Settings > Settings > General`}</p>
+        <p>{t`Pick one of your dashboards to serve as homepage. Users without dashboard access will be directed to the default homepage. You can update or reset this anytime in Admin Settings > Settings > General`}</p>
         <DashboardSelector
           value={dashboard}
           onChange={handleChange}


### PR DESCRIPTION
### Description
Fixing a typo in the Custom Homepage Dashboard Modal in the homepage, from wihtout -> without

### How to verify
Login as an admin, and click "Customize" on the homepage. Verify the modal has no typos 

### Demo
![image](https://github.com/metabase/metabase/assets/1328979/c43e24a5-bcfc-40ff-b453-bb51b7710416)

### Checklist

- [n/a] Tests have been added/updated to cover changes in this PR
