### PR TITLE
[MLv2] Keep order-by in sync when replacing breakouts

### DIFF
--- a/test/metabase/lib/remove_replace_test.cljc
+++ b/test/metabase/lib/remove_replace_test.cljc
@@ -2,6 +2,7 @@
   (:require
    #?@(:cljs ([metabase.test-runner.assert-exprs.approximately-equal]))
    [clojure.test :refer [deftest is testing]]
+   [medley.core :as m]
    [metabase.lib.core :as lib]
    [metabase.lib.dev :as lib.dev]
    [metabase.lib.test-metadata :as meta]))
@@ -388,3 +389,81 @@
                   ;; TODO Should be able to create a ref with lib/field [#29763]
                   (lib/filter (lib/= [:field {:lib/uuid (str (random-uuid)) :base-type :type/Integer} "a"] 1))
                   (lib/replace-clause 0 expr-a (lib/field "VENUES" "PRICE"))))))))
+
+(deftest ^:parallel replace-breakout-binned-or-bucketed-test
+  (testing "issue #30980"
+    (testing "Bucketing"
+      (let [query (lib/query-for-table-name meta/metadata-provider "USERS")
+            breakout-col (->> (lib/breakoutable-columns query)
+                              (m/find-first (comp #{"LAST_LOGIN"} :name)))
+            month (->> (lib/available-temporal-buckets query breakout-col)
+                       (m/find-first (comp #{:month} :unit))
+                       (lib/with-temporal-bucket breakout-col))
+            day (->> (lib/available-temporal-buckets query breakout-col)
+                     (m/find-first (comp #{:day} :unit))
+                     (lib/with-temporal-bucket breakout-col))
+            q2 (-> query
+                   (lib/breakout month))
+            cols (lib/orderable-columns q2)
+            q3 (-> q2
+                   (lib/order-by (first cols))
+                   (lib/replace-clause (first (lib/breakouts q2)) day))
+            q4 (lib/replace-clause q3 (first (lib/breakouts q3)) month)]
+        (is (= :day (:temporal-unit (second (last (first (lib/order-bys q3)))))))
+        (is (= :month (:temporal-unit (second (last (first (lib/order-bys q4)))))))))
+    (testing "Binning"
+      (let [query (lib/query-for-table-name meta/metadata-provider "VENUES")
+            breakout-col (->> (lib/breakoutable-columns query)
+                              (m/find-first (comp #{"PRICE"} :name)))
+            ten (->> (lib/available-binning-strategies query breakout-col)
+                     (m/find-first (comp #{"10 bins"} :display-name))
+                     (lib/with-binning breakout-col))
+            hundo (->> (lib/available-binning-strategies query breakout-col)
+                       (m/find-first (comp #{"100 bins"} :display-name))
+                       (lib/with-binning breakout-col))
+            q2 (-> query
+                   (lib/breakout ten))
+            cols (lib/orderable-columns q2)
+            q3 (-> q2
+                   (lib/order-by (first cols))
+                   (lib/replace-clause (first (lib/breakouts q2)) hundo))
+            q4 (lib/replace-clause q3 (first (lib/breakouts q3)) ten)]
+        (is (= 100 (:num-bins (:binning (second (last (first (lib/order-bys q3))))))))
+        (is (= 10 (:num-bins (:binning (second (last (first (lib/order-bys q4))))))))))
+    (testing "Replace the correct order-by bin when multiple"
+      (let [query (lib/query-for-table-name meta/metadata-provider "VENUES")
+            breakout-col (->> (lib/breakoutable-columns query)
+                              (m/find-first (comp #{"PRICE"} :name)))
+            ten (->> (lib/available-binning-strategies query breakout-col)
+                     (m/find-first (comp #{"10 bins"} :display-name))
+                     (lib/with-binning breakout-col))
+            fiddy (->> (lib/available-binning-strategies query breakout-col)
+                       (m/find-first (comp #{"50 bins"} :display-name))
+                       (lib/with-binning breakout-col))
+            hundo (->> (lib/available-binning-strategies query breakout-col)
+                       (m/find-first (comp #{"100 bins"} :display-name))
+                       (lib/with-binning breakout-col))
+            auto (->> (lib/available-binning-strategies query breakout-col)
+                      (m/find-first (comp #{"Auto bin"} :display-name))
+                      (lib/with-binning breakout-col))
+            q2 (-> query
+                   (lib/breakout auto)
+                   (lib/breakout ten)
+                   (lib/breakout hundo))
+            cols (lib/orderable-columns q2)
+            q3 (-> q2
+                   (lib/order-by (first cols))
+                   (lib/order-by (second cols))
+                   (lib/order-by (last cols)))
+            ten-breakout (second (lib/breakouts q3))]
+        (is (= ["Price: Auto binned" "Price: 10 bins" "Price: 100 bins"]
+               (map (comp :display-name #(lib/display-info q2 %)) cols)))
+        (is (= 10 (-> ten-breakout second :binning :num-bins)))
+        (is (=? [{:strategy :default} {:num-bins 10} {:num-bins 100}]
+                (map (comp :binning second last)
+                     (lib/order-bys q3))))
+        (is (=? [{:strategy :default} {:num-bins 50} {:num-bins 100}]
+                (map (comp :binning second last)
+                     (-> q3
+                         (lib/replace-clause ten-breakout fiddy)
+                         lib/order-bys))))))))


### PR DESCRIPTION
Fixes #30980

In MLv1 breakout that were ordered by the user were kept in sync when changing the bucket or binning on a breakout. Order by was also removed if the field changed or if the breakout was removed.

This maintains the behavior.