### PR TITLE
Add action edit modal call

### DIFF
--- a/e2e/support/helpers/e2e-ui-elements-helpers.js
+++ b/e2e/support/helpers/e2e-ui-elements-helpers.js
@@ -121,3 +121,7 @@ export const undoToast = () => {
 export function dashboardCards() {
   return cy.get("#Dashboard-Cards-Container");
 }
+
+export function actionEditorModal() {
+  return cy.get(`.Modal[role="dialog"]`);
+}

--- a/frontend/src/metabase/actions/components/ActionViz/Action.tsx
+++ b/frontend/src/metabase/actions/components/ActionViz/Action.tsx
@@ -2,10 +2,7 @@ import { useCallback, useMemo } from "react";
 import { t } from "ttag";
 import { connect } from "react-redux";
 import Tooltip from "metabase/core/components/Tooltip";
-import {
-  executeRowAction,
-  onUpdateDashCardAction,
-} from "metabase/dashboard/actions";
+import { executeRowAction } from "metabase/dashboard/actions";
 import { getEditingDashcardId } from "metabase/dashboard/selectors";
 import type { VisualizationProps } from "metabase/visualizations/types";
 import type {
@@ -32,19 +29,19 @@ interface OwnProps {
   dashcard: ActionDashboardCard;
   dashboard: Dashboard;
   parameterValues: { [id: string]: ParameterValueOrArray };
-
-  dispatch: Dispatch;
 }
 
 interface StateProps {
   isEditingDashcard: boolean;
+
+  dispatch: Dispatch;
 }
 
 export type ActionProps = Pick<VisualizationProps, "settings" | "isSettings"> &
   OwnProps &
   StateProps;
 
-function ActionComponent({
+const ActionComponent = ({
   dashcard,
   dashboard,
   dispatch,
@@ -52,7 +49,7 @@ function ActionComponent({
   settings,
   parameterValues,
   isEditingDashcard,
-}: ActionProps) {
+}: ActionProps) => {
   const { data: model } = useQuestionQuery({
     id: dashcard.card_id || dashcard.action?.model_id,
   });
@@ -108,15 +105,6 @@ function ActionComponent({
     [dashboard, dashcard, dispatch, shouldDisplayButton],
   );
 
-  const onActionEdit = (newAction: WritebackAction) => {
-    dispatch(
-      onUpdateDashCardAction({
-        id: dashcard.id,
-        action: newAction,
-      }),
-    );
-  };
-
   return (
     <ActionVizForm
       action={dashcard.action as WritebackAction}
@@ -131,10 +119,9 @@ function ActionComponent({
       isEditingDashcard={isEditingDashcard}
       canEditAction={canWrite}
       onSubmit={onSubmit}
-      onActionEdit={onActionEdit}
     />
   );
-}
+};
 
 const ConnectedActionComponent = connect()(ActionComponent);
 

--- a/frontend/src/metabase/actions/components/ActionViz/ActionVizForm.tsx
+++ b/frontend/src/metabase/actions/components/ActionViz/ActionVizForm.tsx
@@ -36,7 +36,7 @@ interface ActionFormProps {
   canEditAction: boolean | undefined;
   onSubmit: OnSubmitActionForm;
 
-  onActionEdit: (newAction: WritebackAction) => void;
+  onActionEdit?: (newAction: WritebackAction) => void;
 }
 
 function ActionVizForm({

--- a/frontend/src/metabase/actions/components/ActionViz/ActionVizForm.tsx
+++ b/frontend/src/metabase/actions/components/ActionViz/ActionVizForm.tsx
@@ -12,6 +12,8 @@ import type {
   WritebackParameter,
 } from "metabase-types/api";
 
+import ActionCreator from "metabase/actions/containers/ActionCreator/ActionCreator";
+import Modal from "metabase/components/Modal";
 import ActionParametersInputForm, {
   ActionParametersInputModal,
 } from "../../containers/ActionParametersInputForm";
@@ -31,7 +33,10 @@ interface ActionFormProps {
   isSettings: boolean;
   shouldDisplayButton: boolean;
   isEditingDashcard: boolean;
+  canEditAction: boolean | undefined;
   onSubmit: OnSubmitActionForm;
+
+  onActionEdit: (newAction: WritebackAction) => void;
 }
 
 function ActionVizForm({
@@ -45,9 +50,13 @@ function ActionVizForm({
   isSettings,
   shouldDisplayButton,
   isEditingDashcard,
+  canEditAction,
   onSubmit,
+
+  onActionEdit,
 }: ActionFormProps) {
   const [showModal, setShowModal] = useState(false);
+  const [showEditModal, setShowEditModal] = useState(false);
   const title = getFormTitle(action);
 
   // only show confirmation if there are no missing parameters
@@ -66,6 +75,14 @@ function ActionVizForm({
     return result;
   };
 
+  const handleActionEdit = () => {
+    setShowEditModal(true);
+  };
+
+  const closeEditModal = () => {
+    setShowEditModal(false);
+  };
+
   if (shouldDisplayButton) {
     return (
       <>
@@ -75,7 +92,7 @@ function ActionVizForm({
           focus={isEditingDashcard}
           onClick={onClick}
         />
-        {showModal && (
+        {showModal && !showEditModal && (
           <ActionParametersInputModal
             action={action}
             dashboard={dashboard}
@@ -85,10 +102,24 @@ function ActionVizForm({
             title={title}
             showConfirmMessage={showConfirmMessage}
             confirmMessage={action.visualization_settings?.confirmMessage}
+            onEdit={canEditAction ? handleActionEdit : undefined}
             onSubmit={onModalSubmit}
             onClose={() => setShowModal(false)}
             onCancel={() => setShowModal(false)}
           />
+        )}
+        {showEditModal && (
+          <Modal wide onClose={closeEditModal} closeOnClickOutside>
+            <ActionCreator
+              initialAction={action}
+              action={action}
+              modelId={action.model_id}
+              databaseId={action.database_id}
+              actionId={action.id}
+              onSubmit={onActionEdit}
+              onClose={closeEditModal}
+            />
+          </Modal>
         )}
       </>
     );

--- a/frontend/src/metabase/actions/components/ActionViz/ActionVizForm.tsx
+++ b/frontend/src/metabase/actions/components/ActionViz/ActionVizForm.tsx
@@ -55,7 +55,7 @@ function ActionVizForm({
 
   onActionEdit,
 }: ActionFormProps) {
-  const [showModal, setShowModal] = useState(false);
+  const [showFormModal, setShowFormModal] = useState(false);
   const [showEditModal, setShowEditModal] = useState(false);
   const title = getFormTitle(action);
 
@@ -64,13 +64,13 @@ function ActionVizForm({
     shouldShowConfirmation(action) && missingParameters.length === 0;
 
   const onClick = () => {
-    setShowModal(true);
+    setShowFormModal(true);
   };
 
   const onModalSubmit = async (params: ParametersForActionExecution) => {
     const result = await onSubmit(params);
     if (result.success) {
-      setShowModal(false);
+      setShowFormModal(false);
     }
     return result;
   };
@@ -92,7 +92,7 @@ function ActionVizForm({
           focus={isEditingDashcard}
           onClick={onClick}
         />
-        {showModal && !showEditModal && (
+        {showFormModal && !showEditModal && (
           <ActionParametersInputModal
             action={action}
             dashboard={dashboard}
@@ -104,8 +104,8 @@ function ActionVizForm({
             confirmMessage={action.visualization_settings?.confirmMessage}
             onEdit={canEditAction ? handleActionEdit : undefined}
             onSubmit={onModalSubmit}
-            onClose={() => setShowModal(false)}
-            onCancel={() => setShowModal(false)}
+            onClose={() => setShowFormModal(false)}
+            onCancel={() => setShowFormModal(false)}
           />
         )}
         {showEditModal && (

--- a/frontend/src/metabase/actions/containers/ActionCreator/ActionCreator.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/ActionCreator.tsx
@@ -38,6 +38,9 @@ interface OwnProps {
   actionId?: WritebackActionId;
   modelId?: CardId;
   databaseId?: DatabaseId;
+
+  action?: WritebackAction;
+
   onSubmit?: (action: WritebackAction) => void;
   onClose?: () => void;
 }
@@ -192,11 +195,15 @@ function ActionCreatorWithContext({
   initialAction,
   metadata,
   databaseId,
+  action,
   ...props
 }: Props) {
+  // This is needed in case we already have an action and pass it from the outside
+  const contextAction = action || initialAction;
+
   return (
     <ActionContext
-      initialAction={initialAction}
+      initialAction={contextAction}
       databaseId={databaseId}
       metadata={metadata}
     >

--- a/frontend/src/metabase/actions/containers/ActionParametersInputForm/ActionParametersInputModal.tsx
+++ b/frontend/src/metabase/actions/containers/ActionParametersInputForm/ActionParametersInputModal.tsx
@@ -1,7 +1,8 @@
 import { t } from "ttag";
 import Modal from "metabase/components/Modal";
-import ModalContent from "metabase/components/ModalContent";
-
+import ModalContent, {
+  ModalContentActionIcon,
+} from "metabase/components/ModalContent";
 import ActionParametersInputForm, {
   ActionParametersInputFormProps,
 } from "./ActionParametersInputForm";
@@ -10,6 +11,7 @@ interface ModalProps {
   title: string;
   showConfirmMessage?: boolean;
   confirmMessage?: string;
+  onEdit?: () => void;
   onClose: () => void;
 }
 
@@ -20,12 +22,21 @@ function ActionParametersInputModal({
   title,
   showConfirmMessage,
   confirmMessage,
+  onEdit,
   onClose,
   ...formProps
 }: ActionParametersInputModalProps) {
   return (
     <Modal onClose={onClose}>
-      <ModalContent title={title} onClose={onClose}>
+      <ModalContent
+        title={title}
+        headerActions={
+          onEdit ? (
+            <ModalContentActionIcon name="pencil" onClick={onEdit} />
+          ) : undefined
+        }
+        onClose={onClose}
+      >
         <>
           {showConfirmMessage && <ConfirmMessage message={confirmMessage} />}
           <ActionParametersInputForm {...formProps} />

--- a/frontend/src/metabase/components/ModalContent/ModalContent.stories.tsx
+++ b/frontend/src/metabase/components/ModalContent/ModalContent.stories.tsx
@@ -1,8 +1,7 @@
 import type { ComponentStory } from "@storybook/react";
 import { action } from "@storybook/addon-actions";
 import Modal from "metabase/components/Modal";
-import { ActionIcon } from "./ModalContent.styled";
-import ModalContent from "./ModalContent";
+import ModalContent, { ModalContentActionIcon } from "./index";
 
 export default {
   title: "Components/ModalContent",
@@ -48,7 +47,7 @@ WithHeaderActions.args = {
   ...args,
   headerActions: (
     <>
-      <ActionIcon name="pencil" onClick={action("Action1")} />
+      <ModalContentActionIcon name="pencil" onClick={action("Action1")} />
     </>
   ),
 };

--- a/frontend/src/metabase/components/ModalContent/ModalContent.styled.ts
+++ b/frontend/src/metabase/components/ModalContent/ModalContent.styled.ts
@@ -30,7 +30,7 @@ export const ActionsWrapper = styled.div`
   margin-right: -0.5rem;
 `;
 
-export const ActionIcon = styled(Icon)`
+export const ModalContentActionIcon = styled(Icon)`
   color: ${color("text-light")};
   cursor: pointer;
   padding: 0.5rem;

--- a/frontend/src/metabase/components/ModalContent/ModalContent.tsx
+++ b/frontend/src/metabase/components/ModalContent/ModalContent.tsx
@@ -3,7 +3,7 @@ import { Component, ReactNode } from "react";
 import PropTypes from "prop-types";
 import cx from "classnames";
 import {
-  ActionIcon,
+  ModalContentActionIcon,
   ActionsWrapper,
   HeaderContainer,
   HeaderText,
@@ -134,7 +134,11 @@ export const ModalHeader = ({
         <ActionsWrapper>
           {headerActions}
           {onClose && (
-            <ActionIcon name="close" size={actionIconSize} onClick={onClose} />
+            <ModalContentActionIcon
+              name="close"
+              size={actionIconSize}
+              onClick={onClose}
+            />
           )}
         </ActionsWrapper>
       )}

--- a/frontend/src/metabase/components/ModalContent/ModalContent.unit.spec.tsx
+++ b/frontend/src/metabase/components/ModalContent/ModalContent.unit.spec.tsx
@@ -1,6 +1,6 @@
 import userEvent from "@testing-library/user-event";
 import { getIcon, render } from "__support__/ui";
-import { ActionIcon } from "./ModalContent.styled";
+import { ModalContentActionIcon } from "./ModalContent.styled";
 import ModalContent, { ModalContentProps } from "./ModalContent";
 
 describe("ModalContent", () => {
@@ -19,7 +19,7 @@ describe("ModalContent", () => {
     const headerActionsEl = (
       <>
         {headerActions.map(({ icon, onClick }) => (
-          <ActionIcon key={icon} name={icon} onClick={onClick} />
+          <ModalContentActionIcon key={icon} name={icon} onClick={onClick} />
         ))}
       </>
     );

--- a/frontend/src/metabase/components/ModalContent/index.ts
+++ b/frontend/src/metabase/components/ModalContent/index.ts
@@ -1,3 +1,4 @@
 // eslint-disable-next-line import/no-default-export -- deprecated usage
 export { default } from "./ModalContent";
 export * from "./ModalContent";
+export { ModalContentActionIcon } from "./ModalContent.styled";

--- a/frontend/src/metabase/dashboard/actions/core.js
+++ b/frontend/src/metabase/dashboard/actions/core.js
@@ -54,7 +54,3 @@ export const onReplaceAllDashCardVisualizationSettings = createAction(
   REPLACE_ALL_DASHCARD_VISUALIZATION_SETTINGS,
   (id, settings) => ({ id, settings }),
 );
-
-export const UPDATE_DASHCARD_ACTION =
-  "metabase/dashboard/UPDATE_DASHCARD_ACTION";
-export const onUpdateDashCardAction = createAction(UPDATE_DASHCARD_ACTION);

--- a/frontend/src/metabase/dashboard/actions/core.js
+++ b/frontend/src/metabase/dashboard/actions/core.js
@@ -54,3 +54,7 @@ export const onReplaceAllDashCardVisualizationSettings = createAction(
   REPLACE_ALL_DASHCARD_VISUALIZATION_SETTINGS,
   (id, settings) => ({ id, settings }),
 );
+
+export const UPDATE_DASHCARD_ACTION =
+  "metabase/dashboard/UPDATE_DASHCARD_ACTION";
+export const onUpdateDashCardAction = createAction(UPDATE_DASHCARD_ACTION);

--- a/frontend/src/metabase/dashboard/reducers.js
+++ b/frontend/src/metabase/dashboard/reducers.js
@@ -5,7 +5,7 @@ import _ from "underscore";
 import { handleActions, combineReducers } from "metabase/lib/redux";
 import Dashboards from "metabase/entities/dashboards";
 import Questions from "metabase/entities/questions";
-
+import Actions from "metabase/entities/actions";
 import { NAVIGATE_BACK_TO_DASHBOARD } from "metabase/query_builder/actions";
 
 import {
@@ -43,7 +43,6 @@ import {
   UNDO_REMOVE_CARD_FROM_DASH,
   SHOW_AUTO_APPLY_FILTERS_TOAST,
   tabsReducer,
-  UPDATE_DASHCARD_ACTION,
 } from "./actions";
 import { isVirtualDashCard, syncParametersAndEmbeddingParams } from "./utils";
 import { INITIAL_DASHBOARD_STATE } from "./constants";
@@ -238,21 +237,20 @@ const dashcards = handleActions(
           ? assocIn(dashcard, ["card"], card)
           : dashcard,
       ),
-    [UPDATE_DASHCARD_ACTION]: (
-      state,
-      { payload: { id: dashcardId, action } },
-    ) => ({
-      ...state,
-      [dashcardId]: {
-        ...state[dashcardId],
-        action: {
-          ...action,
+    [Actions.actionTypes.UPDATE]: (state, { payload: { object: action } }) =>
+      _.mapObject(state, dashcard =>
+        dashcard.action?.id === action?.id
+          ? {
+              ...dashcard,
+              action: {
+                ...action,
 
-          database_enabled_actions:
-            state[dashcardId]?.action?.database_enabled_actions || false,
-        },
-      },
-    }),
+                database_enabled_actions:
+                  dashcard?.action.database_enabled_actions || false,
+              },
+            }
+          : dashcard,
+      ),
   },
   INITIAL_DASHBOARD_STATE.dashcards,
 );

--- a/frontend/src/metabase/dashboard/reducers.js
+++ b/frontend/src/metabase/dashboard/reducers.js
@@ -43,6 +43,7 @@ import {
   UNDO_REMOVE_CARD_FROM_DASH,
   SHOW_AUTO_APPLY_FILTERS_TOAST,
   tabsReducer,
+  UPDATE_DASHCARD_ACTION,
 } from "./actions";
 import { isVirtualDashCard, syncParametersAndEmbeddingParams } from "./utils";
 import { INITIAL_DASHBOARD_STATE } from "./constants";
@@ -237,6 +238,21 @@ const dashcards = handleActions(
           ? assocIn(dashcard, ["card"], card)
           : dashcard,
       ),
+    [UPDATE_DASHCARD_ACTION]: (
+      state,
+      { payload: { id: dashcardId, action } },
+    ) => ({
+      ...state,
+      [dashcardId]: {
+        ...state[dashcardId],
+        action: {
+          ...action,
+
+          database_enabled_actions:
+            state[dashcardId]?.action?.database_enabled_actions || false,
+        },
+      },
+    }),
   },
   INITIAL_DASHBOARD_STATE.dashcards,
 );

--- a/frontend/src/metabase/lib/entities.js
+++ b/frontend/src/metabase/lib/entities.js
@@ -351,7 +351,7 @@ export function createEntity(def) {
   // HACK: the above actions return the normalizr results
   // (i.e. { entities, result }) rather than the loaded object(s), except
   // for fetch and fetchList when the data is cached, in which case it returns
-  // the noralized object.
+  // the normalized object.
   //
   // This is a problem when we use the result of one of the actions as though
   // though the action creator was an API client.


### PR DESCRIPTION
Relates to https://github.com/metabase/metabase/issues/29866

### Description

I should be able to update / edit the action definition, (or do anything else I could normally do in that modal) and hit Update. I’m then sent back. 

### Demo


https://github.com/metabase/metabase/assets/7983744/7a84466e-477a-43e5-bc7d-31df9264cf9e



### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [x] Add more unit tests
- [x] Add e2e test
