### PR TITLE
Fix basic actions aren't showing in the order of CUD

### DIFF
--- a/frontend/src/metabase/entities/actions/actions.ts
+++ b/frontend/src/metabase/entities/actions/actions.ts
@@ -57,11 +57,14 @@ const defaultImplicitActionCreateOptions = {
 const enableImplicitActionsForModel =
   async (modelId: number, options = defaultImplicitActionCreateOptions) =>
   async (dispatch: Dispatch) => {
-    if (options.insert) {
+    // We're ordering actions that's most recently created first.
+    // So if we want to show Create, Update, Delete, then we need
+    // to create them in the reverse order.
+    if (options.delete) {
       await ActionsApi.create({
-        name: t`Create`,
+        name: t`Delete`,
         type: "implicit",
-        kind: "row/create",
+        kind: "row/delete",
         model_id: modelId,
       });
     }
@@ -75,11 +78,11 @@ const enableImplicitActionsForModel =
       });
     }
 
-    if (options.delete) {
+    if (options.insert) {
       await ActionsApi.create({
-        name: t`Delete`,
+        name: t`Create`,
         type: "implicit",
-        kind: "row/delete",
+        kind: "row/create",
         model_id: modelId,
       });
     }

--- a/frontend/src/metabase/models/components/ModelDetailPage/ModelActionDetails/ModelActionDetails.tsx
+++ b/frontend/src/metabase/models/components/ModelDetailPage/ModelActionDetails/ModelActionDetails.tsx
@@ -218,7 +218,7 @@ function NoActionsState({
 
 function mostRecentFirst(action: WritebackAction) {
   const createdAt = parseTimestamp(action["created_at"]);
-  return -createdAt.unix();
+  return -createdAt.valueOf();
 }
 
 // eslint-disable-next-line import/no-default-export -- deprecated usage


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/29593

### Description

Previously, the test would fail intermittently because we were ordering actions by their created UNIX seconds. And in Cypress environment, the requests are fast and are usually created in the same second. That means we would show the basic actions in the order they're created. However, sometimes the actions that are created after another can be finished in the next second and this is when things start to get a little weird.

We are showing the latest created actions first, so when that happens, the last created action is shown first so the order could be e.g. Delete, Create, Update given that Create and Update are created in for example, second 1 and Delete is created in second 2.

So, to fix this problem, we should order actions by their created millisecond instead, and revert the order of basic action creation from Create, Update, Delete to Delete, Update, Create to account for the actual sorting.

### How to verify

1. Run the test `should allow CRUD operations on model actions` in `e2e/test/scenarios/models/model-actions.cy.spec.js` as many times as you like and it shouldn't fail once. I tested by looping the test 20 times, and it did not fail. Usually, you could see it fails after less than 10 tries.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
