### PR TITLE
Remove `it.skip` from test for #15387

### DIFF
--- a/e2e/test/scenarios/native/snippets/snippets.cy.spec.js
+++ b/e2e/test/scenarios/native/snippets/snippets.cy.spec.js
@@ -81,7 +81,7 @@ describe("scenarios > question > snippets", () => {
     cy.get(".ScalarValue").contains("2");
   });
 
-  it.skip("should update the snippet and apply it to the current query (metabase#15387)", () => {
+  it("should update the snippet and apply it to the current query (metabase#15387)", () => {
     // Create snippet 1
     cy.request("POST", "/api/native-query-snippet", {
       content: "ORDERS",


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/15387

### Description

We were able to reproduce this issue's bug in `v0.38.2`, but in our current version of `0.46.4` we were not able to reproduce the bug, and snippets within the SQL editor seem to be working as expected. This PR just adds the (now passing) test that Nemanja had written to ensure that there are no regressions on this behavior.

### How to verify
Instructions to reproduce the bug on `0.38.2` are written [here](https://github.com/metabase/metabase/issues/15387#issuecomment-810164011). 
