### PR TITLE
Csv: Sync but don't scan

### DIFF
--- a/e2e/test/scenarios/collections/uploads.cy.spec.js
+++ b/e2e/test/scenarios/collections/uploads.cy.spec.js
@@ -13,6 +13,7 @@ const testFiles = [
   {
     fileName: "dog_breeds.csv",
     tableName: "dog_breeds",
+    humanName: "Dog Breeds",
     rowCount: 97,
   },
   {

--- a/e2e/test/scenarios/collections/uploads.cy.spec.js
+++ b/e2e/test/scenarios/collections/uploads.cy.spec.js
@@ -18,6 +18,7 @@ const testFiles = [
   {
     fileName: "star_wars_characters.csv",
     tableName: "star_wars_characters",
+    humanName: "Star Wars Characters",
     rowCount: 87,
   },
 ];
@@ -143,7 +144,7 @@ function uploadFile(testFile, dialect) {
   cy.get("main").within(() => cy.findByText("Uploads Collection"));
 
   cy.findByTestId("collection-table").within(() => {
-    cy.findByText(testFile.tableName); // TODO: we should humanize model names
+    cy.findByText(testFile.humanName);
   });
 
   cy.findByRole("status").within(() => {

--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -24,6 +24,7 @@
             ViewLog]]
    [metabase.models.card :as card]
    [metabase.models.collection :as collection]
+   [metabase.models.humanization :as humanization]
    [metabase.models.interface :as mi]
    [metabase.models.moderation-review :as moderation-review]
    [metabase.models.params :as params]
@@ -1174,7 +1175,7 @@ saved later when it is ready."
                                :query    {:source-table table-id}
                                :type     :query}
       :display                :table
-      :name                   filename-prefix
+      :name                   (humanization/name->human-readable-name filename-prefix)
       :visualization_settings {}})))
 
 (api/defendpoint ^:multipart POST "/from-csv"

--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -57,7 +57,6 @@
    [toucan2.core :as t2])
   (:import
    (clojure.core.async.impl.channels ManyToManyChannel)
-   (java.io File)
    (java.util UUID)))
 
 (set! *warn-on-reflection* true)
@@ -1153,7 +1152,6 @@ saved later when it is ready."
                             table-name
                             (str schema-name "." table-name))
         _load!            (upload/load-from-csv driver db-id schema+table-name csv-file)
-        _delete-file      (.delete ^File csv-file)
         ;; We only need to get the Table created now; no need for a full scan
         _sync!            (sync/sync-database! database {:scan :schema})
         table-id          (t2/select-one-fn :id Table :db_id db-id :%lower.name table-name)]

--- a/src/metabase/driver/sql_jdbc.clj
+++ b/src/metabase/driver/sql_jdbc.clj
@@ -11,7 +11,6 @@
    [metabase.driver.sql-jdbc.sync.interface :as sql-jdbc.sync.interface]
    [metabase.driver.sql.query-processor :as sql.qp]
    [metabase.driver.sync :as driver.s]
-   [metabase.driver.util :as driver.u]
    [metabase.query-processor.writeback :as qp.writeback]
    [metabase.util.honeysql-extensions :as hx]))
 
@@ -147,7 +146,6 @@
 (defmethod driver/syncable-schemas :sql-jdbc
   [driver database]
   (with-open [conn ^java.sql.Connection (jdbc/get-connection (sql-jdbc.conn/db->pooled-connection-spec database))]
-    (let [schema-filter-prop   (driver.u/find-schema-filters-prop driver)
-          [inclusion-patterns
-           exclusion-patterns] (driver.s/db-details->schema-filter-patterns (:name schema-filter-prop) database)]
+    (let [[inclusion-patterns
+           exclusion-patterns] (driver.s/db-details->schema-filter-patterns database)]
       (into #{} (sql-jdbc.sync.interface/filtered-syncable-schemas driver conn (.getMetaData conn) inclusion-patterns exclusion-patterns)))))

--- a/src/metabase/driver/sync.clj
+++ b/src/metabase/driver/sync.clj
@@ -48,7 +48,7 @@
 (def ^:private schema-patterns->filter-fn (memoize schema-patterns->filter-fn*))
 
 (defn include-schema?
-  "Returns true of the given `schema-name` should be included/synced, considering the given `inclusion-patterns` and
+  "Returns true if the given `schema-name` should be included/synced, considering the given `inclusion-patterns` and
   `exclusion-patterns`. Patterns are comma-separated, and can contain wildcard characters (`*`)."
   {:added "0.42.0"}
   [inclusion-patterns exclusion-patterns schema-name]

--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -14,7 +14,6 @@
    [metabase.search.util :as search-util]
    [metabase.util :as u])
   (:import
-   (java.io File)
    (java.text NumberFormat)
    (java.util Locale)))
 
@@ -296,17 +295,15 @@
 (defn load-from-csv
   "Loads a table from a CSV file. If the table already exists, it will throw an error. Returns nil. Deletes the file
   after loading."
-  [driver db-id table-name ^File csv-file]
+  [driver db-id table-name csv-file]
   (let [col->upload-type   (detect-schema csv-file)
         col->database-type (update-vals col->upload-type (partial driver/upload-type->database-type driver))
         column-names       (keys col->upload-type)]
     (driver/create-table driver db-id table-name col->database-type)
     (try
       (let [rows (parsed-rows col->upload-type csv-file)]
-        (driver/insert-into driver db-id table-name column-names rows)
-        (.delete csv-file))
+        (driver/insert-into driver db-id table-name column-names rows))
       (catch Throwable e
         (driver/drop-table driver db-id table-name)
-        (.delete csv-file)
         (throw (ex-info (ex-message e) {}))))
     nil))

--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -14,6 +14,7 @@
    [metabase.search.util :as search-util]
    [metabase.util :as u])
   (:import
+   (java.io File)
    (java.text NumberFormat)
    (java.util Locale)))
 
@@ -295,15 +296,17 @@
 (defn load-from-csv
   "Loads a table from a CSV file. If the table already exists, it will throw an error. Returns nil. Deletes the file
   after loading."
-  [driver db-id table-name csv-file]
+  [driver db-id table-name ^File csv-file]
   (let [col->upload-type   (detect-schema csv-file)
         col->database-type (update-vals col->upload-type (partial driver/upload-type->database-type driver))
         column-names       (keys col->upload-type)]
     (driver/create-table driver db-id table-name col->database-type)
     (try
       (let [rows (parsed-rows col->upload-type csv-file)]
-        (driver/insert-into driver db-id table-name column-names rows))
+        (driver/insert-into driver db-id table-name column-names rows)
+        (.delete csv-file))
       (catch Throwable e
         (driver/drop-table driver db-id table-name)
+        (.delete csv-file)
         (throw (ex-info (ex-message e) {}))))
     nil))

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -2933,7 +2933,7 @@
                    (= :schema-filters (keyword (:type conn-prop))))
                  (driver/connection-properties driver))))
 
-(deftest upload-csv!-schema-doesnt-sync-test
+(deftest upload-csv!-schema-does-not-sync-test
   ;; Just test with postgres because failure should be independent of the driver
   (mt/test-driver :postgres
     (mt/with-empty-db
@@ -2953,7 +2953,7 @@
                  (catch Exception e
                    (is (= {:status-code 422}
                           (ex-data e)))
-                   (is (re-matches #"^The CSV file was uploaded to public\.example(.*) but the table could not be created or found\.$"
+                   (is (re-matches #"^The schema public is not syncable\.$"
                                    (.getMessage e))))))
           (testing "\nThe table should be deleted"
             (is (false? (let [details (mt/dbdef->connection-details driver/*driver* :db {:database-name (:name (mt/db))})]

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -2953,7 +2953,7 @@
                  (catch Exception e
                    (is (= {:status-code 422}
                           (ex-data e)))
-                   (is (re-matches #"^The CSV file was uploaded to public\.example(.*) but the table could not be found on sync\.$"
+                   (is (re-matches #"^The CSV file was uploaded to public\.example(.*) but the table could not be created or found\.$"
                                    (.getMessage e))))))
           (testing "\nThe table should be deleted"
             (is (false? (let [details (mt/dbdef->connection-details driver/*driver* :db {:database-name (:name (mt/db))})]

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -2820,9 +2820,9 @@
               ["id, name"
                "1, Luke Skywalker"
                "2, Darth Vader"]
-              "example")]
+              "example_csv_file")]
     (mt/with-current-user (mt/user->id :rasta)
-      (api.card/upload-csv! collection-id "example.csv" file))))
+      (api.card/upload-csv! collection-id "example_csv_file.csv" file))))
 
 (deftest upload-csv!-schema-test
   (mt/test-drivers (disj (mt/normal-drivers-with-feature :uploads) :mysql) ; MySQL doesn't support schemas
@@ -2845,7 +2845,7 @@
                                           :query    {:source-table (:id new-table)}
                                           :type     :query}
                        :creator_id       (mt/user->id :rasta)
-                       :name             "example"
+                       :name             "Example Csv File"
                        :collection_id    nil} new-model))
               (is (=? {:name #"(?i)example(.*)"
                        :schema #"(?i)not_public"}
@@ -2866,7 +2866,7 @@
                                              uploads-table-prefix "uploaded_magic_"]
             (let [new-model (upload-example-csv! nil)
                   new-table (t2/select-one Table :db_id db-id)]
-              (is (= "example" (:name new-model)))
+              (is (= "Example Csv File" (:name new-model)))
               (is (=? {:name #"(?i)uploaded_magic_example(.*)"}
                       new-table))
               (if (= driver/*driver* :mysql)


### PR DESCRIPTION
Speeds things up; no need for a full scan. See discussion on Slack about whether we should scan at all.

Also deletes the uploaded file after we're done with it. Originally had that logic in the API endpoint but it's more bulletproof to have it in the `upload` ns so we can have it in the `catch` as well.

No tests since this is a performance improvement—if the existing tests pass that's good enough for me.