### PR TITLE
[E2E] Chain the custom `button` command

### DIFF
--- a/e2e/support/commands/ui/button.js
+++ b/e2e/support/commands/ui/button.js
@@ -1,3 +1,18 @@
-Cypress.Commands.add("button", (button_name, timeout) => {
-  cy.findByRole("button", { name: button_name, timeout: timeout });
-});
+Cypress.Commands.add(
+  "button",
+  {
+    prevSubject: "optional",
+  },
+  (subject, button_name, timeout) => {
+    const config = {
+      name: button_name,
+      timeout,
+    };
+
+    if (subject) {
+      cy.wrap(subject).findByRole("button", config);
+    } else {
+      cy.findByRole("button", config);
+    }
+  },
+);

--- a/e2e/test/scenarios/collections/collections.cy.spec.js
+++ b/e2e/test/scenarios/collections/collections.cy.spec.js
@@ -505,6 +505,7 @@ describe("scenarios > collection defaults", () => {
 
           // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
           cy.findByText(/item(s)? selected/)
+            .parent()
             .button("Archive")
             .click();
 
@@ -522,6 +523,7 @@ describe("scenarios > collection defaults", () => {
 
           // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
           cy.findByText(/item(s)? selected/)
+            .parent()
             .button("Move")
             .click();
 

--- a/e2e/test/scenarios/custom-column/reproductions/19745-cc-nested-query-remove-expressions.cy.spec.js
+++ b/e2e/test/scenarios/custom-column/reproductions/19745-cc-nested-query-remove-expressions.cy.spec.js
@@ -104,6 +104,6 @@ function removeAllExpressions() {
 function updateQuestion() {
   cy.intercept("PUT", "/api/card/*").as("updateQuestion");
   cy.findByText("Save").click();
-  modal().within(() => cy.button("Save").click());
+  modal().button("Save").click();
   cy.wait("@updateQuestion");
 }

--- a/e2e/test/scenarios/models/reproductions/28971-filters-model-new-model.cy.spec.js
+++ b/e2e/test/scenarios/models/reproductions/28971-filters-model-new-model.cy.spec.js
@@ -29,7 +29,7 @@ describe("issue 28971", () => {
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     popover().within(() => cy.findByText("Orders").click());
     cy.button("Save").click();
-    modal().within(() => cy.button("Save").click());
+    modal().button("Save").click();
     cy.wait("@createCard");
 
     filter();

--- a/e2e/test/scenarios/organization/timelines-collection.cy.spec.js
+++ b/e2e/test/scenarios/organization/timelines-collection.cy.spec.js
@@ -252,7 +252,7 @@ describe("scenarios > organization > timelines > collection", () => {
       cy.findByText("Move event").click();
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Releases").click();
-      getModal().within(() => cy.button("Move").click());
+      getModal().button("Move").click();
       cy.wait("@updateEvent");
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("RC2").should("not.exist");
@@ -284,7 +284,7 @@ describe("scenarios > organization > timelines > collection", () => {
       cy.findByText("Move event").click();
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Releases").click();
-      getModal().within(() => cy.button("Move").click());
+      getModal().button("Move").click();
       cy.wait("@updateEvent");
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("RC2").should("not.exist");


### PR DESCRIPTION
This is the equivalent of #31161.

As with the other PR, this one also removes the need to use `.within()`
```js
// You no longer need to do this
cy.get("parent").within(() => {
  cy.button("foo");
});

// This is perfectly fine
cy.get("parent").button("foo");
```

And it also reveled wrong implementation in one spec.

### How to test?

I've applied this change to all helpers and to every single e2e spec where the .within() pattern was used. If the new implementation is correct, all tests should still pass.