### PR TITLE
Reduce number of E2E test retries

### DIFF
--- a/e2e/support/config.js
+++ b/e2e/support/config.js
@@ -132,7 +132,7 @@ const mainConfig = {
     json: true,
   },
   retries: {
-    runMode: 5,
+    runMode: 4,
     openMode: 0,
   },
 };


### PR DESCRIPTION
Five retries is an overkill.
The situation with E2E flakes is much better now and we should dial the number of retries at least to four.

I spent some time analyzing flakes in the DeploySentinel analytics dashboard and have never seen a test that failed four times but then succeeded on the fifth run.