### PR TITLE
[E2E] Fix ReplayIO missing metadata

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -207,7 +207,7 @@ jobs:
           --browser "replay-chromium"
         env:
           TERM: xterm
-          REPLAYIO_ENABLED: 1
+          CYPRESS_REPLAYIO_ENABLED: 1
           RECORD_REPLAY_METADATA_FILE: /tmp/replay-metadata.json
           RECORD_REPLAY_METADATA_TEST_RUN_ID: ${{ needs.test-run-id.outputs.testRunId }}
 
@@ -220,7 +220,7 @@ jobs:
           --browser "replay-chromium"
         env:
           TERM: xterm
-          REPLAYIO_ENABLED: 1
+          CYPRESS_REPLAYIO_ENABLED: 1
           RECORD_REPLAY_METADATA_FILE: /tmp/replay-metadata.json
           RECORD_REPLAY_METADATA_TEST_RUN_ID: ${{ needs.test-run-id.outputs.testRunId }}
 

--- a/e2e/support/config.js
+++ b/e2e/support/config.js
@@ -23,7 +23,7 @@ const isQaDatabase = process.env["QA_DB_ENABLED"];
 const sourceVersion = process.env["CROSS_VERSION_SOURCE"];
 const targetVersion = process.env["CROSS_VERSION_TARGET"];
 
-const runWithReplay = process.env["REPLAYIO_ENABLED"];
+const runWithReplay = process.env["CYPRESS_REPLAYIO_ENABLED"];
 
 // This function is called when a project is opened or re-opened (e.g. due to
 // the project's config changing)

--- a/e2e/support/cypress.js
+++ b/e2e/support/cypress.js
@@ -11,12 +11,12 @@ import "@cypress/skip-test/support";
 import "@percy/cypress";
 import "./commands";
 
-const { env } = require("node:process");
-const runWithReplay = env["REPLAYIO_ENABLED"];
+const runWithReplay = Cypress.env("REPLAYIO_ENABLED");
 
 if (runWithReplay) {
   require("@replayio/cypress/support");
 }
+
 require("cy-verify-downloads").addCustomCommand();
 
 Cypress.on("uncaught:exception", (err, runnable) => false);


### PR DESCRIPTION
@jaril informed me that Replay.io is missing metadata from Metabase E2E tests. Apparently trying to access system environment variable from Cypress support file didn't work.

The solution for this is to prefix the environment variable with `CYPRESS_` and then to read it using `Cypress.env()`

This is what Cypress documentation suggests:
https://docs.cypress.io/guides/guides/environment-variables#Option-3-CYPRESS_
