### PR TITLE
CI pre-release: Add sanity check

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -155,9 +155,69 @@ jobs:
     - name: Wait for Metabase to start
       run: while ! curl -s 'http://localhost:3000/api/health' | grep '{"status":"ok"}'; do sleep 1; done
 
+  run-sanity-check:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 15
+    needs: check-uberjar-health
+    strategy:
+      matrix:
+        edition: [oss, ee]
+    env:
+      MB_EDITION: ${{ matrix.edition }}
+      DISPLAY: ""
+      MB_PREMIUM_EMBEDDING_TOKEN: ${{ secrets.ENTERPRISE_TOKEN }}
+      MB_SNOWPLOW_AVAILABLE: true
+      MB_SNOWPLOW_URL: "http://localhost:9090" # Snowplow micro
+    services:
+      maildev:
+        image: maildev/maildev:2.0.5
+        ports:
+          - "1080:1080"
+          - "1025:1025"
+        credentials:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+    steps:
+    - name: Check out the code
+      uses: actions/checkout@v3
+      with:
+        ref: ${{ github.event.inputs.commit }}
+    - name: Prepare front-end environment
+      uses: ./.github/actions/prepare-frontend
+    - name: Prepare JDK 11
+      uses: actions/setup-java@v3
+      with:
+        java-version: 11
+        distribution: "temurin"
+    - name: Prepare Cypress environment
+      uses: ./.github/actions/prepare-cypress
+    - name: Run Snowplow micro
+      uses: ./.github/actions/run-snowplow-micro
+    - uses: actions/download-artifact@v3
+      name: Retrieve uberjar artifact for ${{ matrix.edition }}
+      with:
+        name: metabase-${{ matrix.edition }}-uberjar
+    - name: Get the version info
+      run: |
+        jar xf target/uberjar/metabase.jar version.properties
+        mv version.properties resources/
+    - name: Run a few important Cypress tests as sanity check
+      run: yarn test-cypress-run --folder onboarding
+      env:
+        TERM: xterm
+    - name: Upload Cypress Artifacts upon failure
+      uses: actions/upload-artifact@v3
+      if: failure()
+      with:
+        name: cypress-failed-tests-recording
+        path: |
+          ./cypress
+          ./logs/test.log
+        if-no-files-found: ignore
+
   containerize:
     runs-on: ubuntu-22.04
-    needs: check-uberjar-health
+    needs: run-sanity-check
     timeout-minutes: 15
     strategy:
       matrix:


### PR DESCRIPTION
### Before this PR

For the pre-release workflow, the Uberjar is launched and checked only for its health check API.

### After this PR

A small set of E2E tests are executed, thereby increasing the confidence that the built Uberjar is working properly.

![image](https://github.com/metabase/metabase/assets/7288/6ca913d2-0a26-489e-8ceb-a36d41d6cd94)
