### PR TITLE
[E2E] Fix ReplayIO recordings upload

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -225,7 +225,7 @@ jobs:
           RECORD_REPLAY_METADATA_TEST_RUN_ID: ${{ needs.test-run-id.outputs.testRunId }}
 
       - name: Upload Replay.io recordings
-        if: ${{ github.event_name == 'schedule' }}
+        if: github.event_name == 'schedule' && always()
         uses: replayio/action-upload@v0.4.7
         with:
           api-key: rwk_gXbvYctIcR6RZyEzUvby3gtkO4esrB2L321lkY8FSuQ


### PR DESCRIPTION
Replay.io core team told me that they don't always receive our recordings.
The related job is skipped when it's most needed - on failure.

Although `github.event_name == 'schedule'` resolves to `true`, it seems that the cause of this strange behavior lies in this:
https://docs.github.com/en/actions/learn-github-actions/expressions#status-check-functions

> **A default status check of success() is applied unless you include one of these functions.**