### PR TITLE
Auditv2 - Frontend for instance analytics questions + models

### DIFF
--- a/frontend/src/metabase-lib/Question.ts
+++ b/frontend/src/metabase-lib/Question.ts
@@ -24,6 +24,7 @@ import { memoizeClass, sortObject } from "metabase-lib/utils";
 
 import type {
   Card as CardObject,
+  Collection,
   CollectionId,
   DatabaseId,
   DatasetColumn,
@@ -900,6 +901,10 @@ class QuestionInner {
 
   collectionId(): number | null | undefined {
     return this._card && this._card.collection_id;
+  }
+
+  collectionType(): Pick<Collection, "type"> {
+    return this._card?.collection?.type;
   }
 
   setCollectionId(collectionId: number | null | undefined) {

--- a/frontend/src/metabase/collections/utils.ts
+++ b/frontend/src/metabase/collections/utils.ts
@@ -13,7 +13,9 @@ export function isPersonalCollection(collection: Partial<Collection>): boolean {
   return typeof collection.personal_owner_id === "number";
 }
 
-export function isInstanceAnalyticsCollection(collection: Collection): boolean {
+export function isInstanceAnalyticsCollection(
+  collection: Partial<Collection>,
+): boolean {
   return collection.type === "instance-analytics";
 }
 

--- a/frontend/src/metabase/entities/collections/utils.ts
+++ b/frontend/src/metabase/entities/collections/utils.ts
@@ -22,7 +22,7 @@ export function normalizedCollection(collection: Collection) {
 }
 
 export function getCollectionIcon(
-  collection: Collection,
+  collection: Partial<Collection>,
   { tooltip = "default" } = {},
 ) {
   if (collection.id === PERSONAL_COLLECTIONS.id) {
@@ -48,10 +48,21 @@ export function getCollectionIcon(
     : { name: "folder" };
 }
 
-export const getCollectionTooltip = (collection: Collection) => {
+const collectionIconTooltipNameMap = {
+  collection: t`collection`,
+  question: t`question`,
+  model: t`model`,
+};
+
+export const getCollectionTooltip = (
+  collection: Partial<Collection>,
+  entity: "collection" | "question" | "model" = "collection",
+) => {
+  const entityText = collectionIconTooltipNameMap[entity];
+
   switch (collection.type) {
     case "instance-analytics":
-      return t`This is a read-only Instance Analytics collection`;
+      return t`This is a read-only Instance Analytics ${entityText}.`;
     default:
       return undefined;
   }

--- a/frontend/src/metabase/entities/collections/utils.unit.spec.ts
+++ b/frontend/src/metabase/entities/collections/utils.unit.spec.ts
@@ -1,7 +1,11 @@
 import { setupEnterpriseTest } from "__support__/enterprise";
 import { createMockCollection } from "metabase-types/api/mocks";
 import { PERSONAL_COLLECTIONS } from "./constants";
-import { buildCollectionTree, getCollectionIcon } from "./utils";
+import {
+  buildCollectionTree,
+  getCollectionIcon,
+  getCollectionTooltip,
+} from "./utils";
 
 describe("entities > collections > utils", () => {
   describe("buildCollectionTree", () => {
@@ -394,6 +398,23 @@ describe("entities > collections > utils", () => {
           });
         });
       });
+    });
+  });
+
+  describe("getCollectionTooltip", () => {
+    const collection = createMockCollection({
+      type: "instance-analytics",
+    });
+    ["collection", "model", "question"].forEach(type => {
+      it(`returns correct tooltip for instance analytics ${type}`, () => {
+        expect(getCollectionTooltip(collection, type as any)).toContain(
+          `Instance Analytics ${type}`,
+        );
+      });
+    });
+
+    it(`returns empty tooltip for regular collections`, () => {
+      expect(getCollectionTooltip(createMockCollection())).toBe(undefined);
     });
   });
 });

--- a/frontend/src/metabase/entities/questions.js
+++ b/frontend/src/metabase/entities/questions.js
@@ -33,7 +33,7 @@ const Questions = createEntity({
 
       if (
         ["Audit", "Performance", "Usage", "Instance analytics"].includes(
-          card.collection.name,
+          card?.collection?.name,
         )
       ) {
         card.collection.type = "instance-analytics";

--- a/frontend/src/metabase/entities/questions.js
+++ b/frontend/src/metabase/entities/questions.js
@@ -3,6 +3,7 @@ import { updateIn } from "icepick";
 
 import { createEntity, undo } from "metabase/lib/entities";
 import * as Urls from "metabase/lib/urls";
+import { GET } from "metabase/lib/api";
 import { color } from "metabase/lib/colors";
 import {
   getMetadata,
@@ -25,6 +26,22 @@ const Questions = createEntity({
   name: "questions",
   nameOne: "question",
   path: "/api/card",
+  // FIXME temp mock code
+  api: {
+    get: async (...params) => {
+      const card = await GET(`/api/card/:id`)(params[0]);
+
+      if (
+        ["Audit", "Performance", "Usage", "Instance analytics"].includes(
+          card.collection.name,
+        )
+      ) {
+        card.collection.type = "instance-analytics";
+        card.can_write = false;
+      }
+      return card;
+    },
+  },
 
   objectActions: {
     setArchived: ({ id, dataset, model }, archived, opts) =>

--- a/frontend/src/metabase/query_builder/components/SavedQuestionHeaderButton/CollectionIcon.tsx
+++ b/frontend/src/metabase/query_builder/components/SavedQuestionHeaderButton/CollectionIcon.tsx
@@ -1,0 +1,36 @@
+import { PLUGIN_MODERATION } from "metabase/plugins";
+import {
+  getCollectionIcon,
+  getCollectionTooltip,
+} from "metabase/entities/collections";
+import { color } from "metabase/lib/colors";
+import Icon from "metabase/components/Icon";
+
+import type { Collection } from "metabase-types/api";
+import type Question from "metabase-lib/Question";
+
+// sometimes we want to show an icon on the question
+// based on the collection it's in
+export const CollectionIcon = ({
+  collection,
+  question,
+}: {
+  collection: Collection;
+  question: Question;
+}) => {
+  if (!collection?.type) {
+    return <PLUGIN_MODERATION.QuestionModerationIcon question={question} />;
+  }
+
+  const icon = getCollectionIcon(collection);
+  const tooltip = getCollectionTooltip(
+    collection,
+    question.isDataset() ? "model" : "question",
+  );
+
+  if (!icon) {
+    return null;
+  }
+
+  return <Icon name={icon.name} color={color("brand")} tooltip={tooltip} />;
+};

--- a/frontend/src/metabase/query_builder/components/SavedQuestionHeaderButton/SavedQuestionHeaderButton.jsx
+++ b/frontend/src/metabase/query_builder/components/SavedQuestionHeaderButton/SavedQuestionHeaderButton.jsx
@@ -1,6 +1,6 @@
 import { t } from "ttag";
 import PropTypes from "prop-types";
-import { PLUGIN_MODERATION } from "metabase/plugins";
+import { CollectionIcon } from "./CollectionIcon";
 import { HeaderRoot, HeaderTitle } from "./SavedQuestionHeaderButton.styled";
 
 SavedQuestionHeaderButton.propTypes = {
@@ -19,7 +19,11 @@ function SavedQuestionHeaderButton({ question, onSave }) {
         onChange={onSave}
         data-testid="saved-question-header-title"
       />
-      <PLUGIN_MODERATION.QuestionModerationIcon question={question} />
+
+      <CollectionIcon
+        collection={question?._card?.collection}
+        question={question}
+      />
     </HeaderRoot>
   );
 }

--- a/frontend/src/metabase/query_builder/components/SavedQuestionHeaderButton/SavedQuestionHeaderButton.unit.spec.js
+++ b/frontend/src/metabase/query_builder/components/SavedQuestionHeaderButton/SavedQuestionHeaderButton.unit.spec.js
@@ -2,6 +2,7 @@ import userEvent from "@testing-library/user-event";
 
 import { setupEnterpriseTest } from "__support__/enterprise";
 import { createMockMetadata } from "__support__/metadata";
+import { createMockCollection } from "metabase-types/api/mocks";
 import { renderWithProviders, screen, getIcon } from "__support__/ui";
 
 import { createSampleDatabase } from "metabase-types/api/mocks/presets";
@@ -29,6 +30,7 @@ describe("SavedQuestionHeaderButton", () => {
       name: "foo",
       moderation_reviews: [],
       can_write: true,
+      collection: createMockCollection(),
     },
     metadata,
   );
@@ -62,12 +64,31 @@ describe("SavedQuestionHeaderButton", () => {
         { status: null },
         { most_recent: true, status: "verified" },
       ],
+      collection: createMockCollection(),
     });
 
     it("should have an additional icon to signify the question's moderation status", () => {
       setupEnterpriseTest();
       setup({ question });
       expect(getIcon("verified")).toBeInTheDocument();
+    });
+  });
+
+  describe("when the question is in an instance analytics collection", () => {
+    const question = new Question(
+      {
+        name: "foo",
+        collection: createMockCollection({
+          id: "1",
+          type: "instance-analytics",
+        }),
+      },
+      metadata,
+    );
+
+    it("should have an additional icon to signify the question's collection type", () => {
+      setup({ question });
+      expect(getIcon("beaker")).toBeInTheDocument();
     });
   });
 });


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/31014

### Description

Shows instance analytics icons and appropriate tooltips for questions + models.

![Screen Shot 2023-05-31 at 12 47 24 PM](https://github.com/metabase/metabase/assets/30528226/d1cdb0cc-4dad-403e-8186-c4fc23f3b0c4)

![Screen Shot 2023-05-31 at 12 47 09 PM](https://github.com/metabase/metabase/assets/30528226/66830aff-386c-4cda-a089-b8fdedcf49cc)

### How to verify

- Create a question or a model under a collection called "Instance analytics"
- The entity loader has been temporarily tweaked to mock the `instance-analytics` type on any questions in this collection
- Save any question or model in that collection
- see that when opened, any of these questions have a little icon by the title with an appropriate tooltip

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
