### PR TITLE
`visible-columns` should return all columns from joins regardless of `:fields`

### DIFF
--- a/src/metabase/lib/card.cljc
+++ b/src/metabase/lib/card.cljc
@@ -59,7 +59,7 @@
   (when-let [card (lib.metadata/card metadata-providerable card-id)]
     (card-metadata-columns metadata-providerable card)))
 
-(defmethod lib.metadata.calculation/default-columns-method :metadata/card
+(defmethod lib.metadata.calculation/projected-columns-method :metadata/card
   [query _stage-number card unique-name-fn]
   (mapv (fn [col]
           (assoc col :lib/desired-column-alias (unique-name-fn (:name col))))

--- a/src/metabase/lib/join.cljc
+++ b/src/metabase/lib/join.cljc
@@ -127,7 +127,7 @@
    field-name :- ::lib.schema.common/non-blank-string]
   (lib.util/format "%s__%s" join-alias field-name))
 
-(defmethod lib.metadata.calculation/default-columns-method :mbql/join
+(defmethod lib.metadata.calculation/projected-columns-method :mbql/join
   [query stage-number join unique-name-fn]
   ;; should be dev-facing-only so don't need to i18n
   (assert (:alias join) "Join must have an alias to determine column aliases!")
@@ -157,13 +157,13 @@
           joins)))
 
 (mu/defn all-joins-default-columns :- lib.metadata.calculation/ColumnsWithUniqueAliases
-  "Convenience for calling [[lib.metadata.calculation/default-columns]] on all of the joins in a query stage."
+  "Convenience for calling [[lib.metadata.calculation/projected-columns]] on all of the joins in a query stage."
   [query          :- ::lib.schema/query
    stage-number   :- :int
    unique-name-fn :- fn?]
   (into []
         (mapcat (fn [join]
-                  (lib.metadata.calculation/default-columns query stage-number join unique-name-fn)))
+                  (lib.metadata.calculation/projected-columns query stage-number join unique-name-fn)))
         (when-let [joins (:joins (lib.util/query-stage query stage-number))]
           (ensure-all-joins-have-aliases query stage-number joins))))
 

--- a/src/metabase/lib/stage.cljc
+++ b/src/metabase/lib/stage.cljc
@@ -305,7 +305,7 @@
           column-metadatas)))
 
 (defmethod lib.metadata.calculation/visible-columns-method ::stage
-  [query stage-number stage {:keys [unique-name-fn], :as _options}]
+  [query stage-number stage {:keys [unique-name-fn include-implicitly-joinable?], :as _options}]
   (let [query   (lib.util/update-query-stage query stage-number (fn [stage]
                                                                   (-> stage
                                                                       (dissoc :fields :breakout :aggregation)
@@ -315,7 +315,8 @@
         columns (lib.metadata.calculation/projected-columns query stage-number stage unique-name-fn)]
     (concat
      columns
-     (implicitly-joinable-columns query stage-number columns unique-name-fn))))
+     (when include-implicitly-joinable?
+       (implicitly-joinable-columns query stage-number columns unique-name-fn)))))
 
 (mu/defn append-stage :- ::lib.schema/query
   "Adds a new blank stage to the end of the pipeline"

--- a/src/metabase/lib/table.cljc
+++ b/src/metabase/lib/table.cljc
@@ -57,7 +57,7 @@
              [(or position 0) (u/lower-case-en (or field-name ""))])
            field-metadatas))
 
-(defmethod lib.metadata.calculation/default-columns-method :metadata/table
+(defmethod lib.metadata.calculation/projected-columns-method :metadata/table
   [query _stage-number table-metadata unique-name-fn]
   (when-let [field-metadatas (lib.metadata/fields query (:id table-metadata))]
     (->> field-metadatas

--- a/test/metabase/lib/breakout_test.cljc
+++ b/test/metabase/lib/breakout_test.cljc
@@ -441,3 +441,23 @@
         (testing "description"
           (is (= "Grouped by Expr"
                  (lib/describe-query query'))))))))
+
+(deftest ^:parallel breakoutable-columns-include-all-visible-columns-test
+  (testing "Include all visible columns, not just projected ones (#31233)"
+    (is (= ["ID"
+            "NAME"
+            "CATEGORY_ID"
+            "LATITUDE"
+            "LONGITUDE"
+            "PRICE"
+            "Categories__ID" ; this column is not projected, but should still be returned.
+            "Categories__NAME"]
+           (map :lib/desired-column-alias
+                (-> (lib/query meta/metadata-provider (meta/table-metadata :venues))
+                    (lib/join (-> (lib/join-clause
+                                   (meta/table-metadata :categories)
+                                   [(lib/=
+                                     (lib/field "VENUES" "CATEGORY_ID")
+                                     (lib/with-join-alias (lib/field "CATEGORIES" "ID") "Categories"))])
+                                  (lib/with-join-fields [(lib/with-join-alias (lib/field "CATEGORIES" "NAME") "Categories")])))
+                    lib/breakoutable-columns))))))

--- a/test/metabase/lib/metadata/calculation_test.cljc
+++ b/test/metabase/lib/metadata/calculation_test.cljc
@@ -58,3 +58,23 @@
             "Product → Rating"
             "Product → Created At"]
            results))))
+
+(deftest ^:parallel visible-columns-test
+  (testing "Include all visible columns, not just projected ones (#31233)"
+    (is (= ["ID"
+            "NAME"
+            "CATEGORY_ID"
+            "LATITUDE"
+            "LONGITUDE"
+            "PRICE"
+            "Categories__ID"            ; this column is not projected, but should still be returned.
+            "Categories__NAME"]
+           (map :lib/desired-column-alias
+                (-> (lib/query meta/metadata-provider (meta/table-metadata :venues))
+                    (lib/join (-> (lib/join-clause
+                                   (meta/table-metadata :categories)
+                                   [(lib/=
+                                     (lib/field "VENUES" "CATEGORY_ID")
+                                     (lib/with-join-alias (lib/field "CATEGORIES" "ID") "Categories"))])
+                                  (lib/with-join-fields [(lib/with-join-alias (lib/field "CATEGORIES" "NAME") "Categories")])))
+                    lib.metadata.calculation/visible-columns))))))


### PR DESCRIPTION
It turns out this was only a problem with joins with explicit `:fields`. Fixes `visible-columns` so `:fields` is ignored and `visible-columns` returns all fields for the joins.

As part of this I renamed `lib.metadata.calculation/default-columns` to `projected-columns` to make its purpose a little clearer, since it was tripping me up a bit. I expanded the docstrings for that and `visible-columns` a bit as well. I also backported the changes I made in #31226 to `visible-columns` (add option to not return implicitly joinable) to avoid merge conflicts when that lands

Fixes #31223