### PR TITLE
MLv2: fix cached metadata provider accidentally returning tombstone `::nil` for objects that don't exist

### DIFF
--- a/src/metabase/lib/metadata/cached_provider.cljc
+++ b/src/metabase/lib/metadata/cached_provider.cljc
@@ -14,7 +14,8 @@
 (defn- store-in-cache! [cache ks value]
   (let [value (if (some? value) value ::nil)]
     (swap! cache assoc-in ks value)
-    value))
+    (when-not (= value ::nil)
+      value)))
 
 (defn- store-database! [cache database-metadata]
   (let [database-metadata (-> database-metadata

--- a/test/metabase/lib/metadata/jvm_test.clj
+++ b/test/metabase/lib/metadata/jvm_test.clj
@@ -8,11 +8,18 @@
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.metadata.calculation :as lib.metadata.calculation]
    [metabase.lib.metadata.jvm :as lib.metadata.jvm]
+   [metabase.lib.metadata.protocols :as lib.metadata.protocols]
    [metabase.test :as mt]))
 
 (deftest ^:parallel fetch-field-test
   (let [field (#'lib.metadata.jvm/fetch-instance :metadata/field (mt/id :categories :id))]
     (is (not (me/humanize (mc/validate lib.metadata/ColumnMetadata field))))))
+
+(deftest ^:parallel fetch-database-test
+  (is (=? {:lib/type :metadata/database}
+          (lib.metadata/database (lib.metadata.jvm/application-database-metadata-provider (mt/id)))))
+  (testing "Should return nil correctly"
+    (is (nil? (lib.metadata.protocols/database (lib.metadata.jvm/application-database-metadata-provider Integer/MAX_VALUE))))))
 
 (deftest ^:parallel saved-question-metadata-test
   (let [card  {:dataset-query {:database (mt/id)


### PR DESCRIPTION
If an object doesn't exist the cached metadata provider was supposed to record this fact by saving the tombstone `::nil` in the cache, however there was a bug in the code and this tombstone could get returned sometimes rather than `nil` like we'd expect. 