### PR TITLE
Implement `fieldable-columns`; fix visible columns for joins with `:fields`

### DIFF
--- a/frontend/src/metabase-lib/fields.ts
+++ b/frontend/src/metabase-lib/fields.ts
@@ -17,3 +17,10 @@ export function withFields(
 ): Query {
   return ML.with_fields(query, stageIndex, newFields);
 }
+
+export function fieldableColumns(
+  query: Query,
+  stageIndex: number,
+): ColumnMetadata[] {
+  return ML.fieldable_columns(query, stageIndex);
+}

--- a/src/metabase/lib/aggregation.cljc
+++ b/src/metabase/lib/aggregation.cljc
@@ -317,17 +317,11 @@
     :operator (:short aggregation-operator)
     :args [column]}))
 
-(def ^:private SelectedColumnMetadata
-  [:merge
-   lib.metadata/ColumnMetadata
-   [:map
-    [:selected? {:optional true} :boolean]]])
-
 (def ^:private SelectedOperatorWithColumns
   [:merge
    ::lib.schema.aggregation/operator
    [:map
-    [:columns {:optional true} [:sequential SelectedColumnMetadata]]
+    [:columns {:optional true} [:sequential lib.metadata/ColumnMetadata]]
     [:selected? {:optional true} :boolean]]])
 
 (mu/defn selected-aggregation-operators :- [:maybe [:sequential SelectedOperatorWithColumns]]
@@ -346,8 +340,7 @@
                        (mapv (fn [col]
                                (let [a-ref (lib.ref/ref col)]
                                  (cond-> col
-                                   (or (lib.equality/= a-ref agg-col)
-                                       (lib.equality/= a-ref (lib.util/with-default-effective-type agg-col)))
+                                   (lib.equality/ref= a-ref agg-col)
                                    (assoc :selected? true))))
                              cols))))))
             agg-operators))))

--- a/src/metabase/lib/card.cljc
+++ b/src/metabase/lib/card.cljc
@@ -59,8 +59,8 @@
   (when-let [card (lib.metadata/card metadata-providerable card-id)]
     (card-metadata-columns metadata-providerable card)))
 
-(defmethod lib.metadata.calculation/projected-columns-method :metadata/card
-  [query _stage-number card unique-name-fn]
+(defmethod lib.metadata.calculation/visible-columns-method :metadata/card
+  [query _stage-number card {:keys [unique-name-fn], :as _options}]
   (mapv (fn [col]
           (assoc col :lib/desired-column-alias (unique-name-fn (:name col))))
         (card-metadata-columns query card)))

--- a/src/metabase/lib/card.cljc
+++ b/src/metabase/lib/card.cljc
@@ -59,7 +59,7 @@
   (when-let [card (lib.metadata/card metadata-providerable card-id)]
     (card-metadata-columns metadata-providerable card)))
 
-(defmethod lib.metadata.calculation/default-columns-method :metadata/card
+(defmethod lib.metadata.calculation/projected-columns-method :metadata/card
   [query _stage-number card unique-name-fn]
   (mapv (fn [col]
           (assoc col :lib/desired-column-alias (unique-name-fn (:name col))))

--- a/src/metabase/lib/core.cljc
+++ b/src/metabase/lib/core.cljc
@@ -136,7 +136,8 @@
    lower]
   [lib.field
    fields
-   with-fields]
+   with-fields
+   fieldable-columns]
   [lib.filter
    filter
    filters

--- a/src/metabase/lib/equality.cljc
+++ b/src/metabase/lib/equality.cljc
@@ -3,7 +3,8 @@
   (:refer-clojure :exclude [=])
   (:require
    [metabase.lib.dispatch :as lib.dispatch]
-   [metabase.lib.hierarchy :as lib.hierarchy]))
+   [metabase.lib.hierarchy :as lib.hierarchy]
+   [metabase.lib.util :as lib.util]))
 
 (defmulti =
   "Determine whether two already-normalized pMBQL maps, clauses, or other sorts of expressions are equal. The basic rule
@@ -85,3 +86,10 @@
     (map? x)                   ((get-method = :dispatch-type/map) x y)
     (sequential? x)            ((get-method = :dispatch-type/sequential) x y)
     :else                      (clojure.core/= x y)))
+
+(defn ref=
+  "Are two refs `x` and `y` equal?"
+  [x y]
+  (or (= x y)
+      (= (lib.util/with-default-effective-type x)
+         (lib.util/with-default-effective-type y))))

--- a/src/metabase/lib/field.cljc
+++ b/src/metabase/lib/field.cljc
@@ -4,6 +4,7 @@
    [medley.core :as m]
    [metabase.lib.aggregation :as lib.aggregation]
    [metabase.lib.binning :as lib.binning]
+   [metabase.lib.equality :as lib.equality]
    [metabase.lib.expression :as lib.expression]
    [metabase.lib.join :as lib.join]
    [metabase.lib.metadata :as lib.metadata]
@@ -441,7 +442,7 @@
     (lib.join/joined-field-desired-alias join-alias (:name field-metadata))
     (:name field-metadata)))
 
-(defn with-fields
+(mu/defn with-fields :- ::lib.schema/query
   "Specify the `:fields` for a query. Pass `nil` or an empty sequence to remove `:fields`."
   ([xs]
    (fn [query stage-number]
@@ -450,7 +451,9 @@
   ([query xs]
    (with-fields query -1 xs))
 
-  ([query stage-number xs]
+  ([query        :- ::lib.schema/query
+    stage-number :- :int
+    xs]
    (let [xs (mapv (fn [x]
                     (lib.ref/ref (if (fn? x)
                                    (x query stage-number)
@@ -458,10 +461,41 @@
                   xs)]
      (lib.util/update-query-stage query stage-number u/assoc-dissoc :fields (not-empty xs)))))
 
-(defn fields
+(mu/defn fields :- [:maybe [:ref ::lib.schema/fields]]
   "Fetches the `:fields` for a query. Returns `nil` if there are no `:fields`. `:fields` should never be empty; this is
   enforced by the Malli schema."
   ([query]
    (fields query -1))
-  ([query stage-number]
+
+  ([query        :- ::lib.schema/query
+    stage-number :- :int]
    (:fields (lib.util/query-stage query stage-number))))
+
+(mu/defn fieldable-columns :- [:sequential lib.metadata/ColumnMetadata]
+  "Return a sequence of column metadatas for columns that you can specify in the `:fields` of a query. This is
+  basically just the columns returned by the source Table/Saved Question/Model or previous query stage.
+
+  Includes a `:selected?` key letting you know this column is already in `:fields` or not; if `:fields` is
+  unspecified, all these columns are returned by default, so `:selected?` is true for all columns (this is a little
+  strange but it matches the behavior of the QB UI)."
+  ([query]
+   (fieldable-columns query -1))
+
+  ([query :- ::lib.schema/query
+    stage-number :- :int]
+   (let [current-fields (fields query stage-number)
+         selected-column? (if (empty? current-fields)
+                            (constantly true)
+                            (fn [column]
+                              (let [col-ref (lib.ref/ref column)]
+                                (boolean
+                                 (some (fn [fields-ref]
+                                         (lib.equality/ref= col-ref fields-ref))
+                                       current-fields)))))]
+     (for [col (lib.metadata.calculation/visible-columns query
+                                                         stage-number
+                                                         (lib.util/query-stage query stage-number)
+                                                         {:include-joined?              false
+                                                          :include-expressions?         false
+                                                          :include-implicitly-joinable? false})]
+       (assoc col :selected? (selected-column? col))))))

--- a/src/metabase/lib/field.cljc
+++ b/src/metabase/lib/field.cljc
@@ -483,7 +483,7 @@
 
   ([query :- ::lib.schema/query
     stage-number :- :int]
-   (let [current-fields (fields query stage-number)
+   (let [current-fields   (fields query stage-number)
          selected-column? (if (empty? current-fields)
                             (constantly true)
                             (fn [column]
@@ -492,10 +492,11 @@
                                  (some (fn [fields-ref]
                                          (lib.equality/ref= col-ref fields-ref))
                                        current-fields)))))]
-     (for [col (lib.metadata.calculation/visible-columns query
-                                                         stage-number
-                                                         (lib.util/query-stage query stage-number)
-                                                         {:include-joined?              false
-                                                          :include-expressions?         false
-                                                          :include-implicitly-joinable? false})]
-       (assoc col :selected? (selected-column? col))))))
+     (mapv (fn [col]
+             (assoc col :selected? (selected-column? col)))
+           (lib.metadata.calculation/visible-columns query
+                                                     stage-number
+                                                     (lib.util/query-stage query stage-number)
+                                                     {:include-joined?              false
+                                                      :include-expressions?         false
+                                                      :include-implicitly-joinable? false})))))

--- a/src/metabase/lib/join.cljc
+++ b/src/metabase/lib/join.cljc
@@ -127,7 +127,7 @@
    field-name :- ::lib.schema.common/non-blank-string]
   (lib.util/format "%s__%s" join-alias field-name))
 
-(defmethod lib.metadata.calculation/default-columns-method :mbql/join
+(defmethod lib.metadata.calculation/projected-columns-method :mbql/join
   [query stage-number join unique-name-fn]
   ;; should be dev-facing-only so don't need to i18n
   (assert (:alias join) "Join must have an alias to determine column aliases!")
@@ -157,13 +157,13 @@
           joins)))
 
 (mu/defn all-joins-default-columns :- lib.metadata.calculation/ColumnsWithUniqueAliases
-  "Convenience for calling [[lib.metadata.calculation/default-columns]] on all of the joins in a query stage."
+  "Convenience for calling [[lib.metadata.calculation/projected-columns]] on all of the joins in a query stage."
   [query          :- ::lib.schema/query
    stage-number   :- :int
    unique-name-fn :- fn?]
   (into []
         (mapcat (fn [join]
-                  (lib.metadata.calculation/default-columns query stage-number join unique-name-fn)))
+                  (lib.metadata.calculation/projected-columns query stage-number join unique-name-fn)))
         (when-let [joins (:joins (lib.util/query-stage query stage-number))]
           (ensure-all-joins-have-aliases query stage-number joins))))
 

--- a/src/metabase/lib/join.cljc
+++ b/src/metabase/lib/join.cljc
@@ -180,9 +180,9 @@
    stage-number   :- :int
    unique-name-fn :- fn?]
   (into []
-        (comp (mapcat (fn [join]
-                        (map (partial add-source-and-desired-aliases join unique-name-fn)
-                             (lib.metadata.calculation/metadata query stage-number join)))))
+        (mapcat (fn [join]
+                  (map (partial add-source-and-desired-aliases join unique-name-fn)
+                       (lib.metadata.calculation/metadata query stage-number join))))
         (when-let [joins (:joins (lib.util/query-stage query stage-number))]
           (ensure-all-joins-have-aliases query stage-number joins))))
 

--- a/src/metabase/lib/join.cljc
+++ b/src/metabase/lib/join.cljc
@@ -127,15 +127,18 @@
    field-name :- ::lib.schema.common/non-blank-string]
   (lib.util/format "%s__%s" join-alias field-name))
 
-(defmethod lib.metadata.calculation/visible-columns-method :mbql/join
-  [query stage-number join {:keys [unique-name-fn], :as _options}]
+(defn- add-source-and-desired-aliases
+  [join unique-name-fn col]
   ;; should be dev-facing-only so don't need to i18n
   (assert (:alias join) "Join must have an alias to determine column aliases!")
-  (mapv (fn [col]
-          (assoc col
-                 :lib/source-column-alias  (:name col)
-                 :lib/desired-column-alias (unique-name-fn (joined-field-desired-alias (:alias join) (:name col)))))
-        (lib.metadata.calculation/metadata query stage-number (dissoc join :fields))))
+  (assoc col
+         :lib/source-column-alias  (:name col)
+         :lib/desired-column-alias (unique-name-fn (joined-field-desired-alias (:alias join) (:name col)))))
+
+(defmethod lib.metadata.calculation/visible-columns-method :mbql/join
+  [query stage-number join {:keys [unique-name-fn], :as _options}]
+  (mapv (partial add-source-and-desired-aliases join unique-name-fn)
+        (lib.metadata.calculation/metadata query stage-number (assoc join :fields :all))))
 
 (def ^:private JoinsWithAliases
   "Schema for a sequence of joins that all have aliases."
@@ -156,14 +159,30 @@
               (not (:alias join)) (assoc :alias (unique-name-fn (default-join-alias query stage-number join)))))
           joins)))
 
-(mu/defn all-joins-default-columns :- lib.metadata.calculation/ColumnsWithUniqueAliases
+(mu/defn all-joins-visible-columns :- lib.metadata.calculation/ColumnsWithUniqueAliases
   "Convenience for calling [[lib.metadata.calculation/visible-columns]] on all of the joins in a query stage."
   [query          :- ::lib.schema/query
    stage-number   :- :int
    unique-name-fn :- fn?]
   (into []
         (mapcat (fn [join]
-                  (lib.metadata.calculation/visible-columns query stage-number join {:unique-name-fn unique-name-fn})))
+                  (lib.metadata.calculation/visible-columns query
+                                                            stage-number
+                                                            join
+                                                            {:unique-name-fn               unique-name-fn
+                                                             :include-implicitly-joinable? false})))
+        (when-let [joins (:joins (lib.util/query-stage query stage-number))]
+          (ensure-all-joins-have-aliases query stage-number joins))))
+
+(mu/defn all-joins-metadata :- lib.metadata.calculation/ColumnsWithUniqueAliases
+  "Convenience for calling [[lib.metadata.calculation/metadata]] on all the joins in a query stage."
+  [query          :- ::lib.schema/query
+   stage-number   :- :int
+   unique-name-fn :- fn?]
+  (into []
+        (comp (mapcat (fn [join]
+                        (map (partial add-source-and-desired-aliases join unique-name-fn)
+                             (lib.metadata.calculation/metadata query stage-number join)))))
         (when-let [joins (:joins (lib.util/query-stage query stage-number))]
           (ensure-all-joins-have-aliases query stage-number joins))))
 

--- a/src/metabase/lib/js.cljs
+++ b/src/metabase/lib/js.cljs
@@ -402,3 +402,8 @@
    (with-fields a-query -1 new-fields))
   ([a-query stage-number new-fields]
    (lib.core/with-fields a-query stage-number new-fields)))
+
+(defn ^:export fieldable-columns
+  "Return a sequence of column metadatas for columns that you can specify in the `:fields` of a query."
+  [a-query stage-number]
+  (to-array (lib.core/fieldable-columns a-query stage-number)))

--- a/src/metabase/lib/metadata.cljc
+++ b/src/metabase/lib/metadata.cljc
@@ -93,7 +93,12 @@
    [:lib/source-column-alias {:optional true} [:maybe ::lib.schema.common/non-blank-string]]
    ;; the name we should export this column as, i.e. the RHS of a `SELECT <lhs> AS <rhs>` or equivalent. This is
    ;; guaranteed to be unique in each stage of the query.
-   [:lib/desired-column-alias {:optional true} [:maybe [:string {:min 1, :max 60}]]]])
+   [:lib/desired-column-alias {:optional true} [:maybe [:string {:min 1, :max 60}]]]
+   ;; when column metadata is returned by certain things
+   ;; like [[metabase.lib.aggregation/selected-aggregation-operators]] or [[metabase.lib.field/fieldable-columns]], it
+   ;; might include this key, which tells you whether or not that column is currently selected or not already, e.g.
+   ;; for [[metabase.lib.field/fieldable-columns]] it means its already present in `:fields`
+   [:selected? {:optional true} :boolean]])
 
 (def ^:private CardMetadata
   "More or less the same as a [[metabase.models.card]], but with kebab-case keys. Note that the `:dataset-query` is not

--- a/src/metabase/lib/stage.cljc
+++ b/src/metabase/lib/stage.cljc
@@ -305,7 +305,7 @@
           column-metadatas)))
 
 (defmethod lib.metadata.calculation/visible-columns-method ::stage
-  [query stage-number stage {:keys [unique-name-fn], :as _options}]
+  [query stage-number stage {:keys [unique-name-fn include-implicitly-joinable?], :as _options}]
   (let [query   (lib.util/update-query-stage query stage-number (fn [stage]
                                                                   (-> stage
                                                                       (dissoc :fields :breakout :aggregation)
@@ -315,7 +315,8 @@
         columns (lib.metadata.calculation/projected-columns query stage-number stage unique-name-fn)]
     (concat
      columns
-     (implicitly-joinable-columns query stage-number columns unique-name-fn))))
+     (when include-implicitly-joinable?
+       (implicitly-joinable-columns query stage-number columns unique-name-fn)))))
 
 (mu/defn append-stage :- ::lib.schema/query
   "Adds a new blank stage to the end of the pipeline"

--- a/src/metabase/lib/stage.cljc
+++ b/src/metabase/lib/stage.cljc
@@ -147,7 +147,8 @@
    unique-name-fn  :- fn?]
   (when-let [card-id (lib.util/string-table-id->card-id source-table-id)]
     (when-let [card (lib.metadata/card query card-id)]
-      (lib.metadata.calculation/projected-columns query stage-number card unique-name-fn))))
+      (lib.metadata.calculation/visible-columns query stage-number card {:unique-name-fn               unique-name-fn
+                                                                         :include-implicitly-joinable? false}))))
 
 (mu/defn ^:private expressions-metadata :- [:maybe lib.metadata.calculation/ColumnsWithUniqueAliases]
   [query           :- ::lib.schema/query
@@ -161,6 +162,41 @@
                   :lib/source-column-alias  (:name expression)
                   :lib/desired-column-alias (unique-name-fn (:name expression)))
            (u/assoc-default :effective-type (or base-type :type/*)))))))
+
+(defn- implicitly-joinable-columns
+  "Columns that are implicitly joinable from some other columns in `column-metadatas`. To be joinable, the column has to
+  have appropriate FK metadata, i.e. have an `:fk-target-field-id` pointing to another Field. (I think we only include
+  this information for Databases that support FKs and joins, so I don't think we need to do an additional DB feature
+  check here.)
+
+  This does not include columns from any Tables that are already explicitly joined, and does not include multiple
+  versions of a column when there are multiple pathways to it (i.e. if there is more than one FK to a Table). This
+  behavior matches how things currently work in MLv1, at least for order by; we can adjust as needed in the future if
+  it turns out we do need that stuff.
+
+  Does not include columns that would be implicitly joinable via multiple hops."
+  [query stage-number column-metadatas unique-name-fn]
+  (let [existing-table-ids (into #{} (map :table-id) column-metadatas)]
+    (into []
+          (comp (filter :fk-target-field-id)
+                (m/distinct-by :fk-target-field-id)
+                (map (fn [{source-field-id :id, :keys [fk-target-field-id]}]
+                       (-> (lib.metadata/field query fk-target-field-id)
+                           (assoc ::source-field-id source-field-id))))
+                (remove #(contains? existing-table-ids (:table-id %)))
+                (m/distinct-by :table-id)
+                (mapcat (fn [{:keys [table-id], ::keys [source-field-id]}]
+                          (let [table-metadata (lib.metadata/table query table-id)
+                                options        {:unique-name-fn               unique-name-fn
+                                                :include-implicitly-joinable? false}]
+                            (for [field (lib.metadata.calculation/visible-columns-method query stage-number table-metadata options)
+                                  :let  [field (assoc field
+                                                      :fk-field-id              source-field-id
+                                                      :lib/source               :source/implicitly-joinable
+                                                      :lib/source-column-alias  (:name field))]]
+                              (assoc field :lib/desired-column-alias (unique-name-fn
+                                                                      (lib.field/desired-alias query field))))))))
+          column-metadatas)))
 
 ;;; Calculate the columns to return if `:aggregations`/`:breakout`/`:fields` are unspecified.
 ;;;
@@ -181,35 +217,56 @@
 ;;; PLUS
 ;;;
 ;;; 3. Columns added by joins at this stage
-(defmethod lib.metadata.calculation/projected-columns-method ::stage
-  [query stage-number _stage unique-name-fn]
+(mu/defn ^:private previous-stage-or-source-visible-columns :- lib.metadata.calculation/ColumnsWithUniqueAliases
+  "Return columns from the previous query stage or source Table/Card."
+  [query                                 :- ::lib.schema/query
+   stage-number                          :- :int
+   {:keys [unique-name-fn], :as options} :- lib.metadata.calculation/VisibleColumnsOptions]
+  (or
+   ;; 1a. columns returned by previous stage
+   (previous-stage-metadata query stage-number unique-name-fn)
+   ;; 1b or 1c
+   (let [{:keys [source-table], :as this-stage} (lib.util/query-stage query stage-number)]
+     (or
+      ;; 1b: default visible Fields for the source Table
+      (when (integer? source-table)
+        (let [table-metadata (lib.metadata/table query source-table)]
+          (lib.metadata.calculation/visible-columns query stage-number table-metadata options)))
+      ;; 1c. Metadata associated with a saved Question
+      (when (string? source-table)
+        (saved-question-metadata query stage-number source-table unique-name-fn))
+      ;; 1d: `:lib/stage-metadata` for the (presumably native) query
+      (for [col (:columns (:lib/stage-metadata this-stage))]
+        (assoc col
+               :lib/source :source/native
+               :lib/source-column-alias  (:name col)
+               ;; these should already be unique, but run them thru `unique-name-fn` anyway to make sure anything
+               ;; that gets added later gets deduplicated from these.
+               :lib/desired-column-alias (unique-name-fn (:name col))))))))
+
+(mu/defn ^:private existing-visible-columns :- lib.metadata.calculation/ColumnsWithUniqueAliases
+  [query        :- ::lib.schema/query
+   stage-number :- :int
+   {:keys [unique-name-fn include-joined? include-expressions?], :as options} :- lib.metadata.calculation/VisibleColumnsOptions]
   (concat
    ;; 1: columns from the previous stage, source table or query
-   (or
-    ;; 1a. columns returned by previous stage
-    (previous-stage-metadata query stage-number unique-name-fn)
-    ;; 1b or 1c
-    (let [{:keys [source-table], :as this-stage} (lib.util/query-stage query stage-number)]
-      (or
-       ;; 1b: default visible Fields for the source Table
-       (when (integer? source-table)
-         (let [table-metadata (lib.metadata/table query source-table)]
-           (lib.metadata.calculation/projected-columns query stage-number table-metadata unique-name-fn)))
-       ;; 1c. Metadata associated with a saved Question
-       (when (string? source-table)
-         (saved-question-metadata query stage-number source-table unique-name-fn))
-       ;; 1d: `:lib/stage-metadata` for the (presumably native) query
-       (for [col (:columns (:lib/stage-metadata this-stage))]
-         (assoc col
-                :lib/source :source/native
-                :lib/source-column-alias  (:name col)
-                ;; these should already be unique, but run them thru `unique-name-fn` anyway to make sure anything
-                ;; that gets added later gets deduplicated from these.
-                :lib/desired-column-alias (unique-name-fn (:name col)))))))
+   (previous-stage-or-source-visible-columns query stage-number options)
    ;; 2: expressions (aka calculated columns) added in this stage
-   (expressions-metadata query stage-number unique-name-fn)
+   (when include-expressions?
+     (expressions-metadata query stage-number unique-name-fn))
    ;; 3: columns added by joins at this stage
-   (lib.join/all-joins-default-columns query stage-number unique-name-fn)))
+   (when include-joined?
+     (lib.join/all-joins-default-columns query stage-number unique-name-fn))))
+
+(defmethod lib.metadata.calculation/visible-columns-method ::stage
+  [query stage-number _stage {:keys [unique-name-fn include-implicitly-joinable?], :as options}]
+  (let [;; query   (lib.util/update-query-stage query stage-number dissoc :fields :breakout :aggregation)
+        existing-columns (existing-visible-columns query stage-number options)]
+    (concat
+     existing-columns
+     ;; add implicitly joinable columns if desired
+     (when include-implicitly-joinable?
+       (implicitly-joinable-columns query stage-number existing-columns unique-name-fn)))))
 
 (mu/defn ^:private stage-metadata :- [:maybe lib.metadata.calculation/ColumnsWithUniqueAliases]
   "Return results metadata about the expected columns in an MBQL query stage. If the query has
@@ -240,7 +297,10 @@
                           (lib.join/all-joins-default-columns query stage-number unique-name-fn))))
 
         :else
-        (lib.metadata.calculation/projected-columns query stage-number (lib.util/query-stage query stage-number) unique-name-fn))))))
+        (lib.metadata.calculation/visible-columns query
+                                                  stage-number
+                                                  (lib.util/query-stage query stage-number)
+                                                  {:unique-name-fn unique-name-fn}))))))
 
 (defmethod lib.metadata.calculation/metadata-method ::stage
   [query stage-number _stage]
@@ -270,53 +330,6 @@
                                             previous-stage-number
                                             (lib.util/query-stage query previous-stage-number)
                                             style))))
-
-(defn- implicitly-joinable-columns
-  "Columns that are implicitly joinable from some other columns in `column-metadatas`. To be joinable, the column has to
-  have appropriate FK metadata, i.e. have an `:fk-target-field-id` pointing to another Field. (I think we only include
-  this information for Databases that support FKs and joins, so I don't think we need to do an additional DB feature
-  check here.)
-
-  This does not include columns from any Tables that are already explicitly joined, and does not include multiple
-  versions of a column when there are multiple pathways to it (i.e. if there is more than one FK to a Table). This
-  behavior matches how things currently work in MLv1, at least for order by; we can adjust as needed in the future if
-  it turns out we do need that stuff.
-
-  Does not include columns that would be implicitly joinable via multiple hops."
-  [query stage-number column-metadatas unique-name-fn]
-  (let [existing-table-ids (into #{} (map :table-id) column-metadatas)]
-    (into []
-          (comp (filter :fk-target-field-id)
-                (m/distinct-by :fk-target-field-id)
-                (map (fn [{source-field-id :id, :keys [fk-target-field-id]}]
-                       (-> (lib.metadata/field query fk-target-field-id)
-                           (assoc ::source-field-id source-field-id))))
-                (remove #(contains? existing-table-ids (:table-id %)))
-                (m/distinct-by :table-id)
-                (mapcat (fn [{:keys [table-id], ::keys [source-field-id]}]
-                          (let [table-metadata (lib.metadata/table query table-id)]
-                            (for [field (lib.metadata.calculation/projected-columns query stage-number table-metadata unique-name-fn)
-                                  :let  [field (assoc field
-                                                      :fk-field-id              source-field-id
-                                                      :lib/source               :source/implicitly-joinable
-                                                      :lib/source-column-alias  (:name field))]]
-                              (assoc field :lib/desired-column-alias (unique-name-fn
-                                                                      (lib.field/desired-alias query field))))))))
-          column-metadatas)))
-
-(defmethod lib.metadata.calculation/visible-columns-method ::stage
-  [query stage-number stage {:keys [unique-name-fn include-implicitly-joinable?], :as _options}]
-  (let [query   (lib.util/update-query-stage query stage-number (fn [stage]
-                                                                  (-> stage
-                                                                      (dissoc :fields :breakout :aggregation)
-                                                                      (m/update-existing :joins (fn [joins]
-                                                                                                  (for [join joins]
-                                                                                                    (assoc join :fields :all)))))))
-        columns (lib.metadata.calculation/projected-columns query stage-number stage unique-name-fn)]
-    (concat
-     columns
-     (when include-implicitly-joinable?
-       (implicitly-joinable-columns query stage-number columns unique-name-fn)))))
 
 (mu/defn append-stage :- ::lib.schema/query
   "Adds a new blank stage to the end of the pipeline"

--- a/src/metabase/lib/table.cljc
+++ b/src/metabase/lib/table.cljc
@@ -57,8 +57,8 @@
              [(or position 0) (u/lower-case-en (or field-name ""))])
            field-metadatas))
 
-(defmethod lib.metadata.calculation/projected-columns-method :metadata/table
-  [query _stage-number table-metadata unique-name-fn]
+(defmethod lib.metadata.calculation/visible-columns-method :metadata/table
+  [query _stage-number table-metadata {:keys [unique-name-fn], :as _options}]
   (when-let [field-metadatas (lib.metadata/fields query (:id table-metadata))]
     (->> field-metadatas
          remove-hidden-default-fields

--- a/src/metabase/lib/table.cljc
+++ b/src/metabase/lib/table.cljc
@@ -57,7 +57,7 @@
              [(or position 0) (u/lower-case-en (or field-name ""))])
            field-metadatas))
 
-(defmethod lib.metadata.calculation/default-columns-method :metadata/table
+(defmethod lib.metadata.calculation/projected-columns-method :metadata/table
   [query _stage-number table-metadata unique-name-fn]
   (when-let [field-metadatas (lib.metadata/fields query (:id table-metadata))]
     (->> field-metadatas

--- a/src/metabase/lib/util.cljc
+++ b/src/metabase/lib/util.cljc
@@ -422,7 +422,9 @@
   [query]
   (-> query :stages first :source-table))
 
-(defn unique-name-generator
+(mu/defn unique-name-generator :- [:=>
+                                   [:cat ::lib.schema.common/non-blank-string]
+                                   ::lib.schema.common/non-blank-string]
   "Create a new function with the signature
 
     (f str) => str

--- a/test/metabase/lib/breakout_test.cljc
+++ b/test/metabase/lib/breakout_test.cljc
@@ -441,3 +441,23 @@
         (testing "description"
           (is (= "Grouped by Expr"
                  (lib/describe-query query'))))))))
+
+(deftest ^:parallel breakoutable-columns-include-all-visible-columns-test
+  (testing "Include all visible columns, not just projected ones (#31233)"
+    (is (= ["ID"
+            "NAME"
+            "CATEGORY_ID"
+            "LATITUDE"
+            "LONGITUDE"
+            "PRICE"
+            "Categories__ID" ; this column is not projected, but should still be returned.
+            "Categories__NAME"]
+           (map :lib/desired-column-alias
+                (-> (lib/query meta/metadata-provider (meta/table-metadata :venues))
+                    (lib/join (-> (lib/join-clause
+                                   (meta/table-metadata :categories)
+                                   [(lib/=
+                                     (lib/field "VENUES" "CATEGORY_ID")
+                                     (lib/with-join-alias (lib/field "CATEGORIES" "ID") "Categories"))])
+                                  (lib/with-join-fields [(lib/with-join-alias (lib/field "CATEGORIES" "NAME") "Categories")])))
+                    lib/breakoutable-columns))))))

--- a/test/metabase/lib/field_test.cljc
+++ b/test/metabase/lib/field_test.cljc
@@ -484,3 +484,26 @@
               (is (has-fields? query)
                   "sanity check")
               (is (not (has-fields? query'))))))))))
+
+(deftest ^:parallel fieldable-columns-test
+  (testing "query with no :fields"
+    (is (=? [{:lib/desired-column-alias "ID", :selected? true}
+             {:lib/desired-column-alias "NAME", :selected? true}
+             {:lib/desired-column-alias "CATEGORY_ID", :selected? true}
+             {:lib/desired-column-alias "LATITUDE", :selected? true}
+             {:lib/desired-column-alias "LONGITUDE", :selected? true}
+             {:lib/desired-column-alias "PRICE", :selected? true}]
+            (lib/fieldable-columns (lib/query-for-table-name meta/metadata-provider "VENUES"))))))
+
+(deftest ^:parallel fieldable-columns-query-with-fields-test
+  (testing "query with :fields"
+    (is (=? [{:lib/desired-column-alias "ID", :selected? true}
+             {:lib/desired-column-alias "NAME", :selected? true}
+             {:lib/desired-column-alias "CATEGORY_ID", :selected? false}
+             {:lib/desired-column-alias "LATITUDE", :selected? false}
+             {:lib/desired-column-alias "LONGITUDE", :selected? false}
+             {:lib/desired-column-alias "PRICE", :selected? false}]
+            (-> (lib/query-for-table-name meta/metadata-provider "VENUES")
+                (lib/with-fields [(meta/field-metadata :venues :id)
+                                  (meta/field-metadata :venues :name)])
+                lib/fieldable-columns )))))

--- a/test/metabase/lib/metadata/calculation_test.cljc
+++ b/test/metabase/lib/metadata/calculation_test.cljc
@@ -58,3 +58,23 @@
             "Product → Rating"
             "Product → Created At"]
            results))))
+
+(deftest ^:parallel visible-columns-test
+  (testing "Include all visible columns, not just projected ones (#31233)"
+    (is (= ["ID"
+            "NAME"
+            "CATEGORY_ID"
+            "LATITUDE"
+            "LONGITUDE"
+            "PRICE"
+            "Categories__ID"            ; this column is not projected, but should still be returned.
+            "Categories__NAME"]
+           (map :lib/desired-column-alias
+                (-> (lib/query meta/metadata-provider (meta/table-metadata :venues))
+                    (lib/join (-> (lib/join-clause
+                                   (meta/table-metadata :categories)
+                                   [(lib/=
+                                     (lib/field "VENUES" "CATEGORY_ID")
+                                     (lib/with-join-alias (lib/field "CATEGORIES" "ID") "Categories"))])
+                                  (lib/with-join-fields [(lib/with-join-alias (lib/field "CATEGORIES" "NAME") "Categories")])))
+                    lib.metadata.calculation/visible-columns))))))


### PR DESCRIPTION
Resolves #31010
Fixes #31223

As part of this I combined `default-columns` and `visible-columns` into a single method with an options map since they both actually returned some variation of the columns that were currently visible in the query; I started this in PR #31227 but after realizing it needed more work I rolled it into this PR