### PR TITLE
Make it easier to clear the measure in "Summarize" without losing your dimensions

### DIFF
--- a/frontend/src/metabase-lib/queries/utils/query.js
+++ b/frontend/src/metabase-lib/queries/utils/query.js
@@ -114,10 +114,6 @@ function setAggregationClause(query, aggregationClause) {
     query = clearFields(query);
     query = clearOrderBy(query);
   }
-  // for bare rows we always clear out any dimensions because they don't make sense
-  if (isBareRows) {
-    query = clearBreakouts(query);
-  }
   return setClause("aggregation", query, aggregationClause);
 }
 function setBreakoutClause(query, breakoutClause) {


### PR DESCRIPTION
Closes #28609

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR

### Description

When you are in the query builder, and add a "Summarization" then you select your measure, and the dimensions that you want to break out your measure with. Let's say you want to change the measure that your using. If you click the measure directly, you can switch it out without losing your dimensions. But if you remove the measure, then you lose all your dimensions. Let's keep them around in this case.

### How to verify

1. Create a new question using the notebook editor
2. Select any data
3. In "Summarize" section pick any "metric"
4. In "Summarize" section pick any "column to group by"
5. Remove the metric picked in step 3

**Expected result**
- "Summarize" section is still visible
- "column to group by" selected in step 4 is still selected


### Demo

#### Before

https://github.com/metabase/metabase/assets/6830683/849120b5-a109-4fe5-987a-3eb3ceb3fbc9


#### After

https://github.com/metabase/metabase/assets/6830683/9ee0d400-cd1d-409a-a0f2-27721e66ab7b
