### PR TITLE
Fix MLv1-MLv2 validation for aggregations and expressions

### DIFF
--- a/frontend/src/metabase-lib/Dimension.ts
+++ b/frontend/src/metabase-lib/Dimension.ts
@@ -1307,6 +1307,10 @@ export class ExpressionDimension extends Dimension {
     });
   }
 
+  getMLv1CompatibleDimension() {
+    return this.withoutOptions("base-type", "effective-type");
+  }
+
   icon(): string {
     const field = this.field();
     return field ? field.icon() : "unknown";

--- a/frontend/src/metabase-lib/Dimension.ts
+++ b/frontend/src/metabase-lib/Dimension.ts
@@ -1485,6 +1485,10 @@ export class AggregationDimension extends Dimension {
     });
   }
 
+  getMLv1CompatibleDimension() {
+    return this.withoutOptions("base-type", "effective-type");
+  }
+
   /**
    * Raw aggregation
    */
@@ -1531,6 +1535,19 @@ export class AggregationDimension extends Dimension {
 
   mbql() {
     return ["aggregation", this._aggregationIndex, this._options];
+  }
+
+  withoutOptions(...options: string[]): AggregationDimension {
+    if (!this._options) {
+      return this;
+    }
+
+    return new AggregationDimension(
+      this._aggregationIndex,
+      _.omit(this._options, ...options),
+      this._metadata,
+      this._query,
+    );
   }
 
   icon() {

--- a/frontend/src/metabase-lib/queries/structured/Aggregation.ts
+++ b/frontend/src/metabase-lib/queries/structured/Aggregation.ts
@@ -159,7 +159,7 @@ export default class Aggregation extends MBQLClause {
     if (this.hasOptions()) {
       return this.aggregation().isValid();
     } else if (this.isStandard() && this.dimension()) {
-      const dimension = this.dimension();
+      const dimension = this.dimension()?.getMLv1CompatibleDimension();
       const aggregationOperator = this.query().aggregationOperator(this[0]);
       return (
         aggregationOperator &&

--- a/frontend/test/metabase-lib/lib/Dimension.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/Dimension.unit.spec.js
@@ -755,6 +755,28 @@ describe("Dimension", () => {
           });
         });
       });
+
+      describe("getMLv1CompatibleDimension", () => {
+        it("should strip away *-type options", () => {
+          const dimension = Dimension.parseMBQL(
+            [
+              "expression",
+              "Hello World",
+              {
+                "base-type": "type/Text",
+                "effective-type": "type/Text",
+              },
+            ],
+            metadata,
+          );
+
+          expect(dimension.getMLv1CompatibleDimension().mbql()).toEqual([
+            "expression",
+            "Hello World",
+            null,
+          ]);
+        });
+      });
     });
 
     describe("dimensions()", () => {

--- a/frontend/test/metabase-lib/lib/Dimension.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/Dimension.unit.spec.js
@@ -990,6 +990,28 @@ describe("Dimension", () => {
           expect(base_type).toBe("type/Integer");
         });
       });
+
+      describe("getMLv1CompatibleDimension", () => {
+        it("should strip away *-type options", () => {
+          const dimension = Dimension.parseMBQL(
+            [
+              "aggregation",
+              1,
+              {
+                "base-type": "type/Integer",
+                "effective-type": "type/Integer",
+              },
+            ],
+            metadata,
+          );
+
+          expect(dimension.getMLv1CompatibleDimension().mbql()).toEqual([
+            "aggregation",
+            1,
+            null,
+          ]);
+        });
+      });
     });
   });
 


### PR DESCRIPTION
Follow up on #31144

Adds `getMLv1CompatibleDimension` to `AggregationDimension` and `ExpressionDimension`, they also should drop `effective-type` and `base-type` options for field references