### PR TITLE
🍒 Fix webpack dependabot issue (#29431)

### DIFF
--- a/package.json
+++ b/package.json
@@ -261,7 +261,7 @@
     "source-map-loader": "^4.0.1",
     "style-loader": "3.3.1",
     "typescript": "^4.7.2",
-    "webpack": "5.75.0",
+    "webpack": "5.76.0",
     "webpack-cli": "5.0.1",
     "webpack-dev-server": "4.11.1",
     "webpack-notifier": "1.15.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -22194,10 +22194,10 @@ webpack@4:
     watchpack "^1.7.4"
     webpack-sources "^1.4.1"
 
-webpack@5.75.0, "webpack@>=4.43.0 <6.0.0":
-  version "5.75.0"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.75.0.tgz#1e440468647b2505860e94c9ff3e44d5b582c152"
-  integrity sha512-piaIaoVJlqMsPtX/+3KTTO6jfvrSYgauFVdt8cr9LTHKmcq/AMd4mhzsiP7ZF/PGRNPGA8336jldh9l2Kt2ogQ==
+webpack@5.76.0, "webpack@>=4.43.0 <6.0.0":
+  version "5.76.0"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.76.0.tgz#f9fb9fb8c4a7dbdcd0d56a98e56b8a942ee2692c"
+  integrity sha512-l5sOdYBDunyf72HW8dF23rFtWq/7Zgvt/9ftMof71E/yUb1YLOBmTgA2K4vQthB3kotMrSj609txVE0dnr2fjA==
   dependencies:
     "@types/eslint-scope" "^3.7.3"
     "@types/estree" "^0.0.51"


### PR DESCRIPTION
Although we upgraded Webpack two times since this change, let's backport only the minimum necessary change in order to resolve the dependabot issue in the current release.

Other upgrades on `master`:
1. #30559
2. #31240