### PR TITLE
Upgrade `org.xerial:sqlite-jdbc` to `v3.41.2.2`

### DIFF
--- a/modules/drivers/sqlite/deps.edn
+++ b/modules/drivers/sqlite/deps.edn
@@ -2,4 +2,4 @@
  ["src" "resources"]
 
  :deps
- {org.xerial/sqlite-jdbc {:mvn/version "3.41.0.0"}}}
+ {org.xerial/sqlite-jdbc {:mvn/version "3.41.2.2"}}}


### PR DESCRIPTION
This should resolve code scanning alert found by Trivy scan.
https://github.com/metabase/metabase/security/code-scanning/95
