### PR TITLE
Create theme, doc and UI files for a basic Radio component

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,4 +1,6 @@
 import "metabase/css/index.css";
+import { MantineProvider } from "@mantine/core";
+import { theme } from "metabase/ui/theme";
 
 export const parameters = {
   actions: { argTypesRegex: "^on[A-Z].*" },
@@ -9,3 +11,18 @@ export const parameters = {
     },
   },
 };
+
+// Pasta from - https://mantine.dev/guides/storybook/
+
+function ThemeWrapper(props) {
+  return (
+    <MantineProvider theme={theme} withGlobalStyles withNormalizeCSS>
+      {props.children}
+    </MantineProvider>
+  );
+}
+
+// enhance your stories with decorator that uses ThemeWrapper
+export const decorators = [
+  renderStory => <ThemeWrapper>{renderStory()}</ThemeWrapper>,
+];

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import "metabase/css/index.css";
-import { MantineProvider } from "@mantine/core";
-import { theme } from "../frontend/src/metabase/ui/theme";
+import { ThemeProvider } from "../frontend/src/metabase/ui";
 
 export const parameters = {
   actions: { argTypesRegex: "^on[A-Z].*" },
@@ -13,14 +12,6 @@ export const parameters = {
   },
 };
 
-function ThemeWrapper(props) {
-  return (
-    <MantineProvider theme={theme} withNormalizeCSS>
-      {props.children}
-    </MantineProvider>
-  );
-}
-
 export const decorators = [
-  renderStory => <ThemeWrapper>{renderStory()}</ThemeWrapper>,
+  renderStory => <ThemeProvider>{renderStory()}</ThemeProvider>,
 ];

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,6 +1,7 @@
+import React from "react";
 import "metabase/css/index.css";
 import { MantineProvider } from "@mantine/core";
-import { theme } from "metabase/ui/theme";
+import { theme } from "../frontend/src/metabase/ui/theme";
 
 export const parameters = {
   actions: { argTypesRegex: "^on[A-Z].*" },

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -13,17 +13,14 @@ export const parameters = {
   },
 };
 
-// Pasta from - https://mantine.dev/guides/storybook/
-
 function ThemeWrapper(props) {
   return (
-    <MantineProvider theme={theme} withGlobalStyles withNormalizeCSS>
+    <MantineProvider theme={theme} withNormalizeCSS>
       {props.children}
     </MantineProvider>
   );
 }
 
-// enhance your stories with decorator that uses ThemeWrapper
 export const decorators = [
   renderStory => <ThemeWrapper>{renderStory()}</ThemeWrapper>,
 ];

--- a/frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx
+++ b/frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx
@@ -1,12 +1,11 @@
 import PropTypes from "prop-types";
 import { t } from "ttag";
 import { connect } from "react-redux";
-import { Group } from "@mantine/core";
 
 import * as Urls from "metabase/lib/urls";
 
 import AdminPaneLayout from "metabase/components/AdminPaneLayout";
-import { Radio } from "metabase/ui";
+import { Group, Radio } from "metabase/ui";
 import { getUserIsAdmin } from "metabase/selectors/user";
 
 import SearchInput from "../components/SearchInput";

--- a/frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx
+++ b/frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx
@@ -6,8 +6,7 @@ import { Group } from "@mantine/core";
 import * as Urls from "metabase/lib/urls";
 
 import AdminPaneLayout from "metabase/components/AdminPaneLayout";
-// import Radio from "metabase/core/components/Radio";
-import { Radio } from "metabase/ui/components/inputs/Radio";
+import { Radio } from "metabase/ui";
 import { getUserIsAdmin } from "metabase/selectors/user";
 
 import SearchInput from "../components/SearchInput";

--- a/frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx
+++ b/frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx
@@ -1,11 +1,13 @@
 import PropTypes from "prop-types";
 import { t } from "ttag";
 import { connect } from "react-redux";
+import { Group } from "@mantine/core";
 
 import * as Urls from "metabase/lib/urls";
 
 import AdminPaneLayout from "metabase/components/AdminPaneLayout";
-import Radio from "metabase/core/components/Radio";
+// import Radio from "metabase/core/components/Radio";
+import { Radio } from "metabase/ui/components/inputs/Radio";
 import { getUserIsAdmin } from "metabase/selectors/user";
 
 import SearchInput from "../components/SearchInput";
@@ -41,16 +43,20 @@ function PeopleListingApp({ children, isAdmin }) {
         onResetClick={() => updateSearchInputValue("")}
       />
       {isAdmin && (
-        <Radio
-          className="ml2 text-bold"
-          value={status}
-          options={[
-            { name: t`Active`, value: USER_STATUS.active },
-            { name: t`Deactivated`, value: USER_STATUS.deactivated },
-          ]}
-          showButtons
-          onChange={updateStatus}
-        />
+        <Radio.Group value={status} onChange={updateStatus}>
+          <Group>
+            <Radio
+              label={t`Active`}
+              value={USER_STATUS.active}
+              checked={status === USER_STATUS.active}
+            />
+            <Radio
+              label={t`Deactivated`}
+              value={USER_STATUS.deactivated}
+              checked={status === USER_STATUS.deactivated}
+            />
+          </Group>
+        </Radio.Group>
       )}
     </div>
   );

--- a/frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx
+++ b/frontend/src/metabase/admin/people/containers/PeopleListingApp.jsx
@@ -43,16 +43,8 @@ function PeopleListingApp({ children, isAdmin }) {
       {isAdmin && (
         <Radio.Group value={status} onChange={updateStatus}>
           <Group>
-            <Radio
-              label={t`Active`}
-              value={USER_STATUS.active}
-              checked={status === USER_STATUS.active}
-            />
-            <Radio
-              label={t`Deactivated`}
-              value={USER_STATUS.deactivated}
-              checked={status === USER_STATUS.deactivated}
-            />
+            <Radio label={t`Active`} value={USER_STATUS.active} />
+            <Radio label={t`Deactivated`} value={USER_STATUS.deactivated} />
           </Group>
         </Radio.Group>
       )}

--- a/frontend/src/metabase/app.js
+++ b/frontend/src/metabase/app.js
@@ -30,7 +30,6 @@ import "ee-plugins"; // eslint-disable-line import/no-unresolved, import/no-dupl
 
 import ReactDOM from "react-dom";
 import { Provider } from "react-redux";
-import { MantineProvider } from "@mantine/core";
 
 // router
 import { Router, useRouterHistory } from "react-router";
@@ -40,6 +39,7 @@ import { syncHistoryWithStore } from "react-router-redux";
 // drag and drop
 import HTML5Backend from "react-dnd-html5-backend";
 import { DragDropContextProvider } from "react-dnd";
+import { ThemeProvider } from "metabase/ui";
 import { refreshSiteSettings } from "metabase/redux/settings";
 import { initializeEmbedding } from "metabase/lib/embed";
 import api from "metabase/lib/api";
@@ -49,7 +49,6 @@ import registerVisualizations from "metabase/visualizations/register";
 import { PLUGIN_APP_INIT_FUCTIONS } from "metabase/plugins";
 
 import GlobalStyles from "metabase/styled-components/containers/GlobalStyles";
-import { theme } from "metabase/ui/theme";
 import { getStore } from "./store";
 
 // remove trailing slash
@@ -74,10 +73,10 @@ function _init(reducers, getRoutes, callback) {
   ReactDOM.render(
     <Provider store={store} ref={ref => (root = ref)}>
       <DragDropContextProvider backend={HTML5Backend} context={{ window }}>
-        <MantineProvider theme={theme} withNormalizeCSS>
+        <ThemeProvider>
           <GlobalStyles />
           <Router history={history}>{routes}</Router>
-        </MantineProvider>
+        </ThemeProvider>
       </DragDropContextProvider>
     </Provider>,
     document.getElementById("root"),

--- a/frontend/src/metabase/app.js
+++ b/frontend/src/metabase/app.js
@@ -74,7 +74,7 @@ function _init(reducers, getRoutes, callback) {
   ReactDOM.render(
     <Provider store={store} ref={ref => (root = ref)}>
       <DragDropContextProvider backend={HTML5Backend} context={{ window }}>
-        <MantineProvider theme={theme}>
+        <MantineProvider theme={theme} withNormalizeCSS>
           <GlobalStyles />
           <Router history={history}>{routes}</Router>
         </MantineProvider>

--- a/frontend/src/metabase/app.js
+++ b/frontend/src/metabase/app.js
@@ -30,7 +30,7 @@ import "ee-plugins"; // eslint-disable-line import/no-unresolved, import/no-dupl
 
 import ReactDOM from "react-dom";
 import { Provider } from "react-redux";
-import { ThemeProvider } from "@emotion/react";
+import { MantineProvider } from "@mantine/core";
 
 // router
 import { Router, useRouterHistory } from "react-router";
@@ -49,6 +49,7 @@ import registerVisualizations from "metabase/visualizations/register";
 import { PLUGIN_APP_INIT_FUCTIONS } from "metabase/plugins";
 
 import GlobalStyles from "metabase/styled-components/containers/GlobalStyles";
+import { theme } from "metabase/ui/theme";
 import { getStore } from "./store";
 
 // remove trailing slash
@@ -60,10 +61,6 @@ api.basename = BASENAME;
 const browserHistory = useRouterHistory(createHistory)({
   basename: BASENAME,
 });
-
-const theme = {
-  space: [4, 8, 16, 32, 64, 128],
-};
 
 function _init(reducers, getRoutes, callback) {
   const store = getStore(reducers, browserHistory);
@@ -77,10 +74,10 @@ function _init(reducers, getRoutes, callback) {
   ReactDOM.render(
     <Provider store={store} ref={ref => (root = ref)}>
       <DragDropContextProvider backend={HTML5Backend} context={{ window }}>
-        <ThemeProvider theme={theme}>
+        <MantineProvider theme={theme}>
           <GlobalStyles />
           <Router history={history}>{routes}</Router>
-        </ThemeProvider>
+        </MantineProvider>
       </DragDropContextProvider>
     </Provider>,
     document.getElementById("root"),

--- a/frontend/src/metabase/core/components/Radio/Radio.stories.tsx
+++ b/frontend/src/metabase/core/components/Radio/Radio.stories.tsx
@@ -3,7 +3,7 @@ import { useArgs } from "@storybook/client-api";
 import Radio from "./Radio";
 
 export default {
-  title: "Core/Radio",
+  title: "Deprecated/Radio",
   component: Radio,
 };
 

--- a/frontend/src/metabase/ui/components/ThemeProvider.tsx
+++ b/frontend/src/metabase/ui/components/ThemeProvider.tsx
@@ -1,0 +1,13 @@
+import { ReactNode } from "react";
+import { MantineProvider } from "@mantine/core";
+import { theme } from "metabase/ui";
+
+interface ThemeProviderProps {
+  children: ReactNode;
+}
+
+export const ThemeProvider = ({ children }: ThemeProviderProps) => (
+  <MantineProvider theme={theme} withNormalizeCSS>
+    {children}
+  </MantineProvider>
+);

--- a/frontend/src/metabase/ui/components/inputs/Radio/Radio.stories.mdx
+++ b/frontend/src/metabase/ui/components/inputs/Radio/Radio.stories.mdx
@@ -1,19 +1,11 @@
-import { Meta, Canvas } from "@storybook/blocks";
+import { Canvas, Story, Meta } from "@storybook/addon-docs";
 import { Radio } from "./";
-import { Box } from "@mantine/core";
 
-<Meta title="Inputs/Radio/Overview" />
+<Meta title="Inputs/Radio & Radio Group" component={Radio} />
 
-# Radio
+# Radio & Radio.Group
 
 Our themed wrapper around [Mantine Radio](https://mantine.dev/core/radio/)
-
-<Box my={5}>
-  <Radio.Group label="Pick a data type">
-    <Radio label="Date" value="date" />
-    <Radio label="Birthday" value="birthday" />
-  </Radio.Group>
-</Box>
 
 ## Docs
 
@@ -23,3 +15,43 @@ Our themed wrapper around [Mantine Radio](https://mantine.dev/core/radio/)
 ## Caveats
 
 - As of right now, don't use the size prop.
+- Please don't use the `error` prop on Radio components (We'll standardize on this as other inputs get converted).
+
+## Usage
+
+In almost all circumstances you'll want to use `<Raio.Group>` to provide a set of options.
+
+## General
+
+<Canvas>
+  <Story name="Default">
+    <Radio.Group>
+      <Radio label="Yes" value="yes" checked />
+      <Radio label="No" value="no" />
+    </Radio.Group>
+  </Story>
+</Canvas>
+
+## Disabled
+
+<Canvas>
+  <Story name="Disabled">
+    <Radio.Group>
+      <Radio label="Yes" value="yes" disabled />
+      <Radio label="No" value="no" disabled checked />
+    </Radio.Group>
+  </Story>
+</Canvas>
+
+## Using the Radio group props
+
+You can use `label` and `description` on the Radio.Group component to provide a label and description for the set of choices.
+
+<Canvas>
+  <Story name="Radio Group props">
+    <Radio.Group label="A set of options" description="Choose one please">
+      <Radio label="I cannot be selected" checked disabled />
+      <Radio label="Select another me" />
+    </Radio.Group>
+  </Story>
+</Canvas>

--- a/frontend/src/metabase/ui/components/inputs/Radio/Radio.stories.mdx
+++ b/frontend/src/metabase/ui/components/inputs/Radio/Radio.stories.mdx
@@ -5,7 +5,11 @@ import { Radio } from "./";
 
 # Radio & Radio.Group
 
-Our themed wrapper around [Mantine Radio](https://mantine.dev/core/radio/)
+Our themed wrapper around [Mantine Radio](https://mantine.dev/core/radio/).
+
+## When to use Radio
+
+Radio buttons allow users to select a single option from a list of mutually exclusive options. All possible options are exposed up front for users to compare.
 
 ## Docs
 
@@ -17,16 +21,18 @@ Our themed wrapper around [Mantine Radio](https://mantine.dev/core/radio/)
 - As of right now, don't use the size prop.
 - Please don't use the `error` prop on Radio components (We'll standardize on this as other inputs get converted).
 
-## Usage
+## Usage guidelines
 
-In almost all circumstances you'll want to use `<Raio.Group>` to provide a set of options.
+- **Limit usage to 5 options max**. Radio buttons should be used when there are 2-3 options to choose from. If there are more than 5 options, consider using a [Select](../Select) or [Checkbox](../Checkbox) instead.
+- For option ordering, try to use your best judgement on a sensible order. For example, Yes should come before No. Alphabetical ordering is usually a good fallback if there's no inherent order in your set of choices.
+- In almost all circumstances you'll want to use `<Raio.Group>` to provide a set of options and help with defaultValues and state management between them.
 
 ## General
 
 <Canvas>
   <Story name="Default">
-    <Radio.Group>
-      <Radio label="Yes" value="yes" checked />
+    <Radio.Group defaultValue="yes">
+      <Radio label="Yes" value="yes" />
       <Radio label="No" value="no" />
     </Radio.Group>
   </Story>
@@ -36,9 +42,35 @@ In almost all circumstances you'll want to use `<Raio.Group>` to provide a set o
 
 <Canvas>
   <Story name="Disabled">
-    <Radio.Group>
+    <Radio.Group value="yes">
       <Radio label="Yes" value="yes" disabled />
-      <Radio label="No" value="no" disabled checked />
+      <Radio label="No" value="no" disabled />
+    </Radio.Group>
+  </Story>
+</Canvas>
+
+## Description
+
+If needed you can add a description value to a radio button to give more context about the choice.
+
+<Canvas>
+  <Story name="Descriptions">
+    <Radio.Group defaultValue="chocolate">
+      <Radio
+        label="Chocolate"
+        value="chocolate"
+        description="One of our most popular flavors"
+      />
+      <Radio
+        label="Vanilla"
+        value="vanilla"
+        description="A classic for all seasons"
+      />
+      <Radio
+        label="Swirl"
+        value="swirl"
+        description="Why not have it both ways?"
+      />
     </Radio.Group>
   </Story>
 </Canvas>
@@ -49,9 +81,18 @@ You can use `label` and `description` on the Radio.Group component to provide a 
 
 <Canvas>
   <Story name="Radio Group props">
-    <Radio.Group label="A set of options" description="Choose one please">
-      <Radio label="I cannot be selected" checked disabled />
-      <Radio label="Select another me" />
+    <Radio.Group
+      label="A set of options"
+      description="You could so something like this if there was a deprecated setting that a user needs to update."
+      defaultValue="one"
+    >
+      <Radio label="Old bad setting" value="one" disabled />
+      <Radio label="A better newer setting" value="two" />
     </Radio.Group>
   </Story>
 </Canvas>
+
+## Related components
+
+- Select
+- Checkbox

--- a/frontend/src/metabase/ui/components/inputs/Radio/Radio.stories.mdx
+++ b/frontend/src/metabase/ui/components/inputs/Radio/Radio.stories.mdx
@@ -2,21 +2,24 @@ import { Meta, Canvas } from "@storybook/blocks";
 import { Radio } from "./";
 import { Box } from "@mantine/core";
 
-<Meta title="Inputs/Select/Overview" />
+<Meta title="Inputs/Radio/Overview" />
 
 # Radio
 
 Our themed wrapper around [Mantine Radio](https://mantine.dev/core/radio/)
 
 <Box my={5}>
-  <Radio data={[{ name: "Date", value: "date" }]} label="Pick a data type" />
+  <Radio.Group label="Pick a data type">
+    <Radio label="Date" value="date" />
+    <Radio label="Birthday" value="birthday" />
+  </Radio.Group>
 </Box>
 
 ## Docs
 
-- [Figma File]()
+- [Figma File](https://www.figma.com/file/7LCGPhkbJdrhdIaeiU1O9c/Input-%2F-Radio?type=design&node-id=1%3A96&t=S6gieWhmvLP15ARp-1)
 - [Mantine Radio Docs](https://mantine.dev/core/radio/)
 
 ## Caveats
 
-No caveats at this time.
+- As of right now, don't use the size prop.

--- a/frontend/src/metabase/ui/components/inputs/Radio/Radio.stories.mdx
+++ b/frontend/src/metabase/ui/components/inputs/Radio/Radio.stories.mdx
@@ -1,0 +1,22 @@
+import { Meta, Canvas } from "@storybook/blocks";
+import { Radio } from "./";
+import { Box } from "@mantine/core";
+
+<Meta title="Inputs/Select/Overview" />
+
+# Radio
+
+Our themed wrapper around [Mantine Radio](https://mantine.dev/core/radio/)
+
+<Box my={5}>
+  <Radio data={[{ name: "Date", value: "date" }]} label="Pick a data type" />
+</Box>
+
+## Docs
+
+- [Figma File]()
+- [Mantine Radio Docs](https://mantine.dev/core/radio/)
+
+## Caveats
+
+No caveats at this time.

--- a/frontend/src/metabase/ui/components/inputs/Radio/index.tsx
+++ b/frontend/src/metabase/ui/components/inputs/Radio/index.tsx
@@ -1,0 +1,1 @@
+export { Radio } from "@mantine/core";

--- a/frontend/src/metabase/ui/index.ts
+++ b/frontend/src/metabase/ui/index.ts
@@ -1,1 +1,5 @@
+export { ThemeProvider } from "metabase/ui/components/ThemeProvider";
+export { theme } from "metabase/ui/theme";
+
+// Inputs
 export { Radio } from "metabase/ui/components/inputs/Radio";

--- a/frontend/src/metabase/ui/index.ts
+++ b/frontend/src/metabase/ui/index.ts
@@ -1,5 +1,8 @@
 export { ThemeProvider } from "metabase/ui/components/ThemeProvider";
 export { theme } from "metabase/ui/theme";
 
+// General helpers
+export { Group } from "@mantine/core";
+
 // Inputs
 export { Radio } from "metabase/ui/components/inputs/Radio";

--- a/frontend/src/metabase/ui/index.ts
+++ b/frontend/src/metabase/ui/index.ts
@@ -1,0 +1,1 @@
+export { Radio } from "metabase/ui/components/inputs/Radio";

--- a/frontend/src/metabase/ui/theme.ts
+++ b/frontend/src/metabase/ui/theme.ts
@@ -4,10 +4,11 @@ import { color } from "metabase/lib/colors";
 
 export const theme: MantineThemeOverride = {
   colors: {
-    brand: [color("brand")],
-    text: [color("text-dark"), color("text-medium")],
+    brand: [color("brand-light"), color("brand")],
+    text: [color("text-light"), color("text-medium"), color("text-dark")],
   },
   primaryColor: "brand",
+  primaryShade: 1,
   fontFamily: "Lato, sans-serif",
   components: {
     Radio: {
@@ -17,16 +18,10 @@ export const theme: MantineThemeOverride = {
             marginBottom: theme.spacing.xs,
           },
           label: {
-            color: theme.colors.text[0],
+            color: theme.colors.text[2],
             marginLeft: "-2px",
             fontWeight: 700,
             fontSize: "14px",
-          },
-          radio: {
-            "&:checked": {
-              backgroundColor: theme.colors.brand[0],
-              borderColor: theme.colors.brand[0],
-            },
           },
         };
       },
@@ -34,6 +29,10 @@ export const theme: MantineThemeOverride = {
     RadioGroup: {
       styles(theme) {
         return {
+          label: {
+            fontWeight: 700,
+            color: theme.colors.text[2],
+          },
           description: {
             marginBottom: theme.spacing.xs,
           },

--- a/frontend/src/metabase/ui/theme.ts
+++ b/frontend/src/metabase/ui/theme.ts
@@ -22,6 +22,21 @@ export const theme: MantineThemeOverride = {
             fontWeight: 700,
             fontSize: "14px",
           },
+          radio: {
+            "&:checked": {
+              backgroundColor: theme.colors.brand[0],
+              borderColor: theme.colors.brand[0],
+            },
+          },
+        };
+      },
+    },
+    RadioGroup: {
+      styles(theme) {
+        return {
+          description: {
+            marginBottom: theme.spacing.xs,
+          },
         };
       },
     },

--- a/frontend/src/metabase/ui/theme.ts
+++ b/frontend/src/metabase/ui/theme.ts
@@ -1,9 +1,29 @@
 import type { MantineThemeOverride } from "@mantine/core";
 
+import { color } from "metabase/lib/colors";
+
 export const theme: MantineThemeOverride = {
   colors: {
-    green: ["green", "green"],
+    brand: [color("brand")],
+    text: [color("text-dark"), color("text-medium")],
   },
-  primaryColor: "green",
+  primaryColor: "brand",
   fontFamily: "Lato, sans-serif",
+  components: {
+    Radio: {
+      styles(theme) {
+        return {
+          root: {
+            marginBottom: theme.spacing.xs,
+          },
+          label: {
+            color: theme.colors.text[0],
+            marginLeft: "-2px",
+            fontWeight: 700,
+            fontSize: "14px",
+          },
+        };
+      },
+    },
+  },
 };

--- a/frontend/src/metabase/ui/theme.ts
+++ b/frontend/src/metabase/ui/theme.ts
@@ -1,0 +1,9 @@
+import type { MantineThemeOverride } from "@mantine/core";
+
+export const theme: MantineThemeOverride = {
+  colors: {
+    green: ["green", "green"],
+  },
+  primaryColor: "green",
+  fontFamily: "Lato, sans-serif",
+};

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "@dnd-kit/sortable": "^7.0.2",
     "@emotion/react": "^11.7.1",
     "@emotion/styled": "^11.6.0",
+    "@mantine/core": "^6.0.13",
+    "@mantine/hooks": "^6.0.13",
     "@react-oauth/google": "^0.4.0",
     "@reduxjs/toolkit": "^1.9.3",
     "@snowplow/browser-tracker": "^3.1.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4442,6 +4442,34 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
+"@floating-ui/core@^1.2.6":
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/@floating-ui/core/-/core-1.2.6.tgz#d21ace437cc919cdd8f1640302fa8851e65e75c0"
+  integrity sha512-EvYTiXet5XqweYGClEmpu3BoxmsQ4hkj3QaYA6qEnigCWffTP3vNRwBReTdrwDwo7OoJ3wM8Uoe9Uk4n+d4hfg==
+
+"@floating-ui/dom@^1.2.1":
+  version "1.2.9"
+  resolved "https://registry.yarnpkg.com/@floating-ui/dom/-/dom-1.2.9.tgz#b9ed1c15d30963419a6736f1b7feb350dd49c603"
+  integrity sha512-sosQxsqgxMNkV3C+3UqTS6LxP7isRLwX8WMepp843Rb3/b0Wz8+MdUkxJksByip3C2WwLugLHN1b4ibn//zKwQ==
+  dependencies:
+    "@floating-ui/core" "^1.2.6"
+
+"@floating-ui/react-dom@^1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@floating-ui/react-dom/-/react-dom-1.3.0.tgz#4d35d416eb19811c2b0e9271100a6aa18c1579b3"
+  integrity sha512-htwHm67Ji5E/pROEAr7f8IKFShuiCKHwUC/UY4vC3I5jiSvGFAYnSYiZO5MlGmads+QqvUkR9ANHEguGrDv72g==
+  dependencies:
+    "@floating-ui/dom" "^1.2.1"
+
+"@floating-ui/react@^0.19.1":
+  version "0.19.2"
+  resolved "https://registry.yarnpkg.com/@floating-ui/react/-/react-0.19.2.tgz#c6e4d2097ed0dca665a7c042ddf9cdecc95e9412"
+  integrity sha512-JyNk4A0Ezirq8FlXECvRtQOX/iBe5Ize0W/pLkrZjfHW9GUV7Xnq6zm6fyZuQzaHHqEnVizmvlA96e1/CkZv+w==
+  dependencies:
+    "@floating-ui/react-dom" "^1.3.0"
+    aria-hidden "^1.1.3"
+    tabbable "^6.0.1"
+
 "@gar/promisify@^1.0.1":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@gar/promisify/-/promisify-1.1.2.tgz#30aa825f11d438671d585bd44e7fd564535fc210"
@@ -4887,6 +4915,36 @@
   resolved "https://registry.yarnpkg.com/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz#b2ac626d6cb9c8718ab459166d4bb405b8ffa78b"
   integrity sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A==
 
+"@mantine/core@^6.0.13":
+  version "6.0.13"
+  resolved "https://registry.yarnpkg.com/@mantine/core/-/core-6.0.13.tgz#f05a952e1e2e3cc6eb24d4d77b6c96a1c23fb0bb"
+  integrity sha512-FjVUGgat2qISV9WD1maVJa81y7H0JjKJ3m0cJj65PzgrXT20hzdEda7S3i4j+a8vUnx+836x5q/yS+RDHvoSlA==
+  dependencies:
+    "@floating-ui/react" "^0.19.1"
+    "@mantine/styles" "6.0.13"
+    "@mantine/utils" "6.0.13"
+    "@radix-ui/react-scroll-area" "1.0.2"
+    react-remove-scroll "^2.5.5"
+    react-textarea-autosize "8.3.4"
+
+"@mantine/hooks@^6.0.13":
+  version "6.0.13"
+  resolved "https://registry.yarnpkg.com/@mantine/hooks/-/hooks-6.0.13.tgz#d90fa315ee30a900e0d9a460c6bb00c9a65f18e0"
+  integrity sha512-fHuE3zXo5OP/Q1dMOTnegU6U+tI9GuhO2tgOz6szVuOxrrk0Hzuq1Na9NUSv27HShSRbAfQk+hvyIh+iVV7KXA==
+
+"@mantine/styles@6.0.13":
+  version "6.0.13"
+  resolved "https://registry.yarnpkg.com/@mantine/styles/-/styles-6.0.13.tgz#a3dc542e1613e7cc461dd8b11c6069b5dd8143d7"
+  integrity sha512-+27oX8ObiBv8jHHDxXKjqe+7cfTJyaAV/Ie00T49EE4LuHuS6nL4vlXHmqamFtDCj2ypEWBV0sdXDev/DNAXSg==
+  dependencies:
+    clsx "1.1.1"
+    csstype "3.0.9"
+
+"@mantine/utils@6.0.13":
+  version "6.0.13"
+  resolved "https://registry.yarnpkg.com/@mantine/utils/-/utils-6.0.13.tgz#a7adc128a2e7c07031c7221c1533800d0c80279a"
+  integrity sha512-iqIU9wurqAeccVbWjM0yr1JGne5VP+ob55M03QAXOEN4+ck93VDTjCkZJR2RFhDcs5q0twQFoOmU/gULR8aKIA==
+
 "@mdx-js/mdx@^1.6.22":
   version "1.6.22"
   resolved "https://registry.yarnpkg.com/@mdx-js/mdx/-/mdx-1.6.22.tgz#8a723157bf90e78f17dc0f27995398e6c731f1ba"
@@ -5159,6 +5217,96 @@
   version "2.10.2"
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.10.2.tgz#0798c03351f0dea1a5a4cabddf26a55a7cbee590"
   integrity sha512-IXf3XA7+XyN7CP9gGh/XB0UxVMlvARGEgGXLubFICsUMGz6Q+DU+i4gGlpOxTjKvXjkJDJC8YdqdKkDj9qZHEQ==
+
+"@radix-ui/number@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/number/-/number-1.0.0.tgz#4c536161d0de750b3f5d55860fc3de46264f897b"
+  integrity sha512-Ofwh/1HX69ZfJRiRBMTy7rgjAzHmwe4kW9C9Y99HTRUcYLUuVT0KESFj15rPjRgKJs20GPq8Bm5aEDJ8DuA3vA==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+
+"@radix-ui/primitive@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/primitive/-/primitive-1.0.0.tgz#e1d8ef30b10ea10e69c76e896f608d9276352253"
+  integrity sha512-3e7rn8FDMin4CgeL7Z/49smCA3rFYY3Ha2rUQ7HRWFadS5iCRw08ZgVT1LaNTCNqgvrUiyczLflrVrF0SRQtNA==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+
+"@radix-ui/react-compose-refs@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-compose-refs/-/react-compose-refs-1.0.0.tgz#37595b1f16ec7f228d698590e78eeed18ff218ae"
+  integrity sha512-0KaSv6sx787/hK3eF53iOkiSLwAGlFMx5lotrqD2pTjB18KbybKoEIgkNZTKC60YECDQTKGTRcDBILwZVqVKvA==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+
+"@radix-ui/react-context@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-context/-/react-context-1.0.0.tgz#f38e30c5859a9fb5e9aa9a9da452ee3ed9e0aee0"
+  integrity sha512-1pVM9RfOQ+n/N5PJK33kRSKsr1glNxomxONs5c49MliinBY6Yw2Q995qfBUUo0/Mbg05B/sGA0gkgPI7kmSHBg==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+
+"@radix-ui/react-direction@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-direction/-/react-direction-1.0.0.tgz#a2e0b552352459ecf96342c79949dd833c1e6e45"
+  integrity sha512-2HV05lGUgYcA6xgLQ4BKPDmtL+QbIZYH5fCOTAOOcJ5O0QbWS3i9lKaurLzliYUDhORI2Qr3pyjhJh44lKA3rQ==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+
+"@radix-ui/react-presence@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-presence/-/react-presence-1.0.0.tgz#814fe46df11f9a468808a6010e3f3ca7e0b2e84a"
+  integrity sha512-A+6XEvN01NfVWiKu38ybawfHsBjWum42MRPnEuqPsBZ4eV7e/7K321B5VgYMPv3Xx5An6o1/l9ZuDBgmcmWK3w==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-compose-refs" "1.0.0"
+    "@radix-ui/react-use-layout-effect" "1.0.0"
+
+"@radix-ui/react-primitive@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-primitive/-/react-primitive-1.0.1.tgz#c1ebcce283dd2f02e4fbefdaa49d1cb13dbc990a"
+  integrity sha512-fHbmislWVkZaIdeF6GZxF0A/NH/3BjrGIYj+Ae6eTmTCr7EB0RQAAVEiqsXK6p3/JcRqVSBQoceZroj30Jj3XA==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-slot" "1.0.1"
+
+"@radix-ui/react-scroll-area@1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-scroll-area/-/react-scroll-area-1.0.2.tgz#26c906d351b56835c0301126b24574c9e9c7b93b"
+  integrity sha512-k8VseTxI26kcKJaX0HPwkvlNBPTs56JRdYzcZ/vzrNUkDlvXBy8sMc7WvCpYzZkHgb+hd72VW9MqkqecGtuNgg==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/number" "1.0.0"
+    "@radix-ui/primitive" "1.0.0"
+    "@radix-ui/react-compose-refs" "1.0.0"
+    "@radix-ui/react-context" "1.0.0"
+    "@radix-ui/react-direction" "1.0.0"
+    "@radix-ui/react-presence" "1.0.0"
+    "@radix-ui/react-primitive" "1.0.1"
+    "@radix-ui/react-use-callback-ref" "1.0.0"
+    "@radix-ui/react-use-layout-effect" "1.0.0"
+
+"@radix-ui/react-slot@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-slot/-/react-slot-1.0.1.tgz#e7868c669c974d649070e9ecbec0b367ee0b4d81"
+  integrity sha512-avutXAFL1ehGvAXtPquu0YK5oz6ctS474iM3vNGQIkswrVhdrS52e3uoMQBzZhNRAIE0jBnUyXWNmSjGHhCFcw==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-compose-refs" "1.0.0"
+
+"@radix-ui/react-use-callback-ref@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.0.0.tgz#9e7b8b6b4946fe3cbe8f748c82a2cce54e7b6a90"
+  integrity sha512-GZtyzoHz95Rhs6S63D2t/eqvdFCm7I+yHMLVQheKM7nBD8mbZIt+ct1jz4536MDnaOGKIxynJ8eHTkVGVVkoTg==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+
+"@radix-ui/react-use-layout-effect@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.0.0.tgz#2fc19e97223a81de64cd3ba1dc42ceffd82374dc"
+  integrity sha512-6Tpkq+R6LOlmQb1R5NNETLG0B4YP0wc+klfXafpUCj6JGyaUc8il7/kUZ7m59rGbXGczE9Bs+iz2qloqsZBduQ==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
 
 "@react-oauth/google@^0.4.0":
   version "0.4.0"
@@ -9074,6 +9222,13 @@ argparse@^2.0.1:
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
   integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
 
+aria-hidden@^1.1.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/aria-hidden/-/aria-hidden-1.2.3.tgz#14aeb7fb692bbb72d69bebfa47279c1fd725e954"
+  integrity sha512-xcLxITLe2HYa1cnYnwCjkOO1PqUHQpozB8x9AR0OgWN2woOBi5kSDVxKfd0b7sb1hw5qFeJhXm9H1nu3xSfLeQ==
+  dependencies:
+    tslib "^2.0.0"
+
 aria-query@^4.2.2:
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-4.2.2.tgz#0d2ca6c9aceb56b8977e9fed6aed7e15bbd2f83b"
@@ -10720,7 +10875,7 @@ clone-response@^1.0.2:
   dependencies:
     mimic-response "^1.0.0"
 
-clsx@^1.0.4:
+clsx@1.1.1, clsx@^1.0.4:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.1.1.tgz#98b3134f9abbdf23b2663491ace13c5c03a73188"
   integrity sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA==
@@ -11581,6 +11736,11 @@ cssstyle@^2.3.0:
   dependencies:
     cssom "~0.3.6"
 
+csstype@3.0.9:
+  version "3.0.9"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.0.9.tgz#6410af31b26bd0520933d02cbc64fce9ce3fbf0b"
+  integrity sha512-rpw6JPxK6Rfg1zLOYCSwle2GFOOsnjmDYDaBwEcwoOg4qlsIVCN789VkBZDJAGi4T07gI4YSutR43t9Zz4Lzuw==
+
 csstype@^3.0.2:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.0.3.tgz#2b410bbeba38ba9633353aff34b05d9755d065f8"
@@ -12097,6 +12257,11 @@ detect-newline@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-3.1.0.tgz#576f5dfc63ae1a192ff192d8ad3af6308991b651"
   integrity sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==
+
+detect-node-es@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/detect-node-es/-/detect-node-es-1.1.0.tgz#163acdf643330caa0b4cd7c21e7ee7755d6fa493"
+  integrity sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==
 
 detect-node@^2.0.4:
   version "2.0.4"
@@ -14284,6 +14449,11 @@ get-intrinsic@^1.1.3, get-intrinsic@^1.2.0:
     function-bind "^1.1.1"
     has "^1.0.3"
     has-symbols "^1.0.3"
+
+get-nonce@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/get-nonce/-/get-nonce-1.0.1.tgz#fdf3f0278073820d2ce9426c18f07481b1e0cdf3"
+  integrity sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==
 
 get-own-enumerable-property-symbols@^2.0.1:
   version "2.0.1"
@@ -21050,6 +21220,25 @@ react-refresh@^0.13.0:
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.13.0.tgz#cbd01a4482a177a5da8d44c9755ebb1f26d5a1c1"
   integrity sha512-XP8A9BT0CpRBD+NYLLeIhld/RqG9+gktUjW1FkE+Vm7OCinbG1SshcK5tb9ls4kzvjZr9mOQc7HYgBngEyPAXg==
 
+react-remove-scroll-bar@^2.3.4:
+  version "2.3.4"
+  resolved "https://registry.yarnpkg.com/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.4.tgz#53e272d7a5cb8242990c7f144c44d8bd8ab5afd9"
+  integrity sha512-63C4YQBUt0m6ALadE9XV56hV8BgJWDmmTPY758iIJjfQKt2nYwoUrPk0LXRXcB/yIj82T1/Ixfdpdk68LwIB0A==
+  dependencies:
+    react-style-singleton "^2.2.1"
+    tslib "^2.0.0"
+
+react-remove-scroll@^2.5.5:
+  version "2.5.6"
+  resolved "https://registry.yarnpkg.com/react-remove-scroll/-/react-remove-scroll-2.5.6.tgz#7510b8079e9c7eebe00e65a33daaa3aa29a10336"
+  integrity sha512-bO856ad1uDYLefgArk559IzUNeQ6SWH4QnrevIUjH+GczV56giDfl3h0Idptf2oIKxQmd1p9BN25jleKodTALg==
+  dependencies:
+    react-remove-scroll-bar "^2.3.4"
+    react-style-singleton "^2.2.1"
+    tslib "^2.1.0"
+    use-callback-ref "^1.3.0"
+    use-sidecar "^1.1.2"
+
 react-resizable@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/react-resizable/-/react-resizable-3.0.1.tgz#9709831809d87d3abe861df7fe691e6103f27dc1"
@@ -21103,6 +21292,24 @@ react-sortable-hoc@^1.11.0:
     "@babel/runtime" "^7.2.0"
     invariant "^2.2.4"
     prop-types "^15.5.7"
+
+react-style-singleton@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/react-style-singleton/-/react-style-singleton-2.2.1.tgz#f99e420492b2d8f34d38308ff660b60d0b1205b4"
+  integrity sha512-ZWj0fHEMyWkHzKYUr2Bs/4zU6XLmq9HsgBURm7g5pAVfyn49DgUiNgY2d4lXRlYSiCif9YBGpQleewkcqddc7g==
+  dependencies:
+    get-nonce "^1.0.0"
+    invariant "^2.2.4"
+    tslib "^2.0.0"
+
+react-textarea-autosize@8.3.4:
+  version "8.3.4"
+  resolved "https://registry.yarnpkg.com/react-textarea-autosize/-/react-textarea-autosize-8.3.4.tgz#270a343de7ad350534141b02c9cb78903e553524"
+  integrity sha512-CdtmP8Dc19xL8/R6sWvtknD/eCXkQr30dtvC4VmGInhRsfF8X/ihXCq6+9l9qbxmKRiq407/7z5fxE7cVWQNgQ==
+  dependencies:
+    "@babel/runtime" "^7.10.2"
+    use-composed-ref "^1.3.0"
+    use-latest "^1.2.1"
 
 react-textarea-autosize@^5.2.1:
   version "5.2.1"
@@ -23334,6 +23541,11 @@ synchronous-promise@^2.0.15:
   resolved "https://registry.yarnpkg.com/synchronous-promise/-/synchronous-promise-2.0.15.tgz#07ca1822b9de0001f5ff73595f3d08c4f720eb8e"
   integrity sha512-k8uzYIkIVwmT+TcglpdN50pS2y1BDcUnBPK9iJeGu0Pl1lOI8pD6wtzgw91Pjpe+RxtTncw32tLxs/R0yNL2Mg==
 
+tabbable@^6.0.1:
+  version "6.1.2"
+  resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-6.1.2.tgz#b0d3ca81d582d48a80f71b267d1434b1469a3703"
+  integrity sha512-qCN98uP7i9z0fIS4amQ5zbGBOq+OSigYeGvPy7NDk8Y9yncqDZ9pRPgfsc2PJIVM9RrJj7GIfuRgmjoUU9zTHQ==
+
 table@^6.0.9:
   version "6.8.0"
   resolved "https://registry.yarnpkg.com/table/-/table-6.8.0.tgz#87e28f14fa4321c3377ba286f07b79b281a3b3ca"
@@ -24347,6 +24559,30 @@ url@^0.11.0:
     punycode "1.3.2"
     querystring "0.2.0"
 
+use-callback-ref@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/use-callback-ref/-/use-callback-ref-1.3.0.tgz#772199899b9c9a50526fedc4993fc7fa1f7e32d5"
+  integrity sha512-3FT9PRuRdbB9HfXhEq35u4oZkvpJ5kuYbpqhCfmiZyReuRgpnhDlbr2ZEnnuS0RrJAPn6l23xjFg9kpDM+Ms7w==
+  dependencies:
+    tslib "^2.0.0"
+
+use-composed-ref@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/use-composed-ref/-/use-composed-ref-1.3.0.tgz#3d8104db34b7b264030a9d916c5e94fbe280dbda"
+  integrity sha512-GLMG0Jc/jiKov/3Ulid1wbv3r54K9HlMW29IWcDFPEqFkSO2nS0MuefWgMJpeHQ9YJeXDL3ZUF+P3jdXlZX/cQ==
+
+use-isomorphic-layout-effect@^1.1.1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.2.tgz#497cefb13d863d687b08477d9e5a164ad8c1a6fb"
+  integrity sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==
+
+use-latest@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/use-latest/-/use-latest-1.2.1.tgz#d13dfb4b08c28e3e33991546a2cee53e14038cf2"
+  integrity sha512-xA+AVm/Wlg3e2P/JiItTziwS7FK92LWrDB0p+hgXloIMuVCeJJ8v6f0eeHyPZaJrM+usM1FkFfbNCrJGs8A/zw==
+  dependencies:
+    use-isomorphic-layout-effect "^1.1.1"
+
 use-memo-one@^1.1.1:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/use-memo-one/-/use-memo-one-1.1.3.tgz#2fd2e43a2169eabc7496960ace8c79efef975e99"
@@ -24358,6 +24594,14 @@ use-resize-observer@^9.1.0:
   integrity sha512-R25VqO9Wb3asSD4eqtcxk8sJalvIOYBqS8MNZlpDSQ4l4xMQxC/J7Id9HoTqPq8FwULIn0PVW+OAqF2dyYbjow==
   dependencies:
     "@juggle/resize-observer" "^3.3.1"
+
+use-sidecar@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/use-sidecar/-/use-sidecar-1.1.2.tgz#2f43126ba2d7d7e117aa5855e5d8f0276dfe73c2"
+  integrity sha512-epTbsLuzZ7lPClpz2TyryBfztm7m+28DlEv2ZCQ3MDr5ssiwyOwGH/e5F9CkfWjJ1t4clvI58yF822/GUkjjhw==
+  dependencies:
+    detect-node-es "^1.1.0"
+    tslib "^2.0.0"
 
 use-sync-external-store@^1.0.0:
   version "1.2.0"


### PR DESCRIPTION
Our first Mantine powered Metabase UI component. I ended up doing several more steps from #31258 as part of verifying that everything was working and feeling good.

- Wraps Matine's radio component and adds Metabase specific styling via the theme file
- Integrates the Mantine theme into app.js
- Adds basic documentation w/ links to our Figma component and the Mantine docs.
- Replaces our simplest Radio usage with the new Mantine based radio.
- Adds a `@deprecated` warning for existing Radio usage. 

<img width="1764" alt="Screen Shot 2023-06-05 at 10 19 53 AM" src="https://github.com/metabase/metabase/assets/5248953/4daa56f2-d695-4251-a9bc-8f5e200313e4">

## ToDos
- [x] Clean up `preview.tsx` code comments
- [x] Styling for `description`
- [x] Double check consistency between Figma component and code.

## How to verify
- Run `yarn storybook` locally. You should see the `Radio and Radio group` set of stories and examples
- Go to `admin/people` and you should see the new working Radio button to flip between Active and Deactivated user accounts.

