### PR TITLE
Updates v1 dump to extract field values in batches of 32K fields

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/serialization/cmd.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/cmd.clj
@@ -166,7 +166,7 @@
     (dump/dump path
                databases
                tables
-               (field/with-values fields)
+               (mapcat field/with-values (u/batches-of 32000 fields))
                metrics
                (select-segments-in-tables tables state)
                collections

--- a/src/metabase/util.cljc
+++ b/src/metabase/util.cljc
@@ -472,6 +472,11 @@
                (str/replace s #"\s" "")
                (re-matches #"^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$" s)))))
 
+(defn batches-of
+  "Returns coll split into seqs of up to n items"
+  [n coll]
+  (partition n n nil coll))
+
 (def ^{:arglists '([n])} safe-inc
   "Increment `n` if it is non-`nil`, otherwise return `1` (e.g. as if incrementing `0`)."
   (fnil inc 0))


### PR DESCRIPTION
This is a simple fix for v1 `dump` from a Postgres app DB when a database contains many fields. Using batches of 32K just in case this might avoid some problem with another app DB driver 🤷 

This is a very specific fix, and I prepared but discarded a few other commits that approached it from the `metabase.models.interface` side and made every batched hydration function split things into further batches, but this is less code overall and will be removed when the v1 commands are removed.

This fix is verified manually since it's a fairly niche case on deprecated code. I cherry picked this commit onto `release-x.46.x` to test it and it solves the problem there, too.

Resolves #31230