### PR TITLE
Auditv2/dashboard header

### DIFF
--- a/frontend/src/metabase/dashboard/components/DashboardHeaderView.styled.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHeaderView.styled.tsx
@@ -45,6 +45,8 @@ export const HeaderCaptionContainer = styled.div`
   display: flex;
   padding-right: 2rem;
   right: 0.25rem;
+  display: flex;
+  align-items: center;
 `;
 
 export const HeaderCaption = styled(EditableText)`

--- a/frontend/src/metabase/dashboard/components/DashboardHeaderView.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHeaderView.tsx
@@ -11,10 +11,13 @@ import { t } from "ttag";
 import cx from "classnames";
 
 import { getScrollY } from "metabase/lib/dom";
-import { Dashboard } from "metabase-types/api";
+import { color } from "metabase/lib/colors";
+import { Collection, Dashboard } from "metabase-types/api";
 
+import Icon from "metabase/components/Icon";
 import EditBar from "metabase/components/EditBar";
 import HeaderModal from "metabase/components/HeaderModal";
+import Tooltip from "metabase/core/components/Tooltip/Tooltip";
 import {
   EditWarning,
   HeaderRow,
@@ -40,6 +43,7 @@ interface DashboardHeaderViewProps {
   isEditingInfo: boolean;
   isNavBarOpen: boolean;
   dashboard: Dashboard;
+  collection: Collection;
   isBadgeVisible: boolean;
   isLastEditInfoVisible: boolean;
   onHeaderModalDone: () => null;
@@ -60,6 +64,7 @@ function DashboardHeaderView({
   isEditing,
   isNavBarOpen,
   dashboard,
+  collection,
   isLastEditInfoVisible,
   onHeaderModalDone,
   onHeaderModalCancel,
@@ -150,6 +155,13 @@ function DashboardHeaderView({
                 data-testid="dashboard-name-heading"
                 onChange={handleUpdateCaption}
               />
+              {collection.type === "instance-analytics" && (
+                <Tooltip
+                  tooltip={t`This is a read-only Instance Analytics dashboard.`}
+                >
+                  <Icon name="beaker" color={color("brand")} />
+                </Tooltip>
+              )}
             </HeaderCaptionContainer>
             <HeaderBadges>
               {isLastEditInfoVisible && (

--- a/frontend/src/metabase/dashboard/components/DashboardHeaderView.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHeaderView.tsx
@@ -18,7 +18,10 @@ import Icon from "metabase/components/Icon";
 import EditBar from "metabase/components/EditBar";
 import HeaderModal from "metabase/components/HeaderModal";
 import { isInstanceAnalyticsCollection } from "metabase/collections/utils";
-import { getCollectionIcon } from "metabase/entities/collections";
+import {
+  getCollectionIcon,
+  getCollectionTooltip,
+} from "metabase/entities/collections";
 import {
   EditWarning,
   HeaderRow,
@@ -160,7 +163,7 @@ function DashboardHeaderView({
                 <Icon
                   {...getCollectionIcon(collection)}
                   color={color("brand")}
-                  tooltip={t`This is a read-only Instance Analytics dashboard.`}
+                  tooltip={getCollectionTooltip(collection, "dashboard")}
                 />
               )}
             </HeaderCaptionContainer>

--- a/frontend/src/metabase/dashboard/components/DashboardHeaderView.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHeaderView.tsx
@@ -17,7 +17,8 @@ import { Collection, Dashboard } from "metabase-types/api";
 import Icon from "metabase/components/Icon";
 import EditBar from "metabase/components/EditBar";
 import HeaderModal from "metabase/components/HeaderModal";
-import Tooltip from "metabase/core/components/Tooltip/Tooltip";
+import { isInstanceAnalyticsCollection } from "metabase/collections/utils";
+import { getCollectionIcon } from "metabase/entities/collections";
 import {
   EditWarning,
   HeaderRow,
@@ -155,12 +156,12 @@ function DashboardHeaderView({
                 data-testid="dashboard-name-heading"
                 onChange={handleUpdateCaption}
               />
-              {collection.type === "instance-analytics" && (
-                <Tooltip
+              {isInstanceAnalyticsCollection(collection) && (
+                <Icon
+                  {...getCollectionIcon(collection)}
+                  color={color("brand")}
                   tooltip={t`This is a read-only Instance Analytics dashboard.`}
-                >
-                  <Icon name="beaker" color={color("brand")} />
-                </Tooltip>
+                />
               )}
             </HeaderCaptionContainer>
             <HeaderBadges>

--- a/frontend/src/metabase/dashboard/containers/DashboardHeader.jsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardHeader.jsx
@@ -34,6 +34,8 @@ import { hasDatabaseActionsEnabled } from "metabase/dashboard/utils";
 import { saveDashboardPdf } from "metabase/visualizations/lib/save-dashboard-pdf";
 import { getSetting } from "metabase/selectors/settings";
 
+import Link from "metabase/core/components/Link/Link";
+import Collections from "metabase/entities/collections/collections";
 import DashboardHeaderView from "../components/DashboardHeaderView";
 import { SIDEBAR_NAME } from "../constants";
 import {
@@ -229,9 +231,11 @@ class DashboardHeader extends Component {
       isShowingDashboardInfoSidebar,
       closeSidebar,
       databases,
+      collection,
     } = this.props;
 
     const canEdit = dashboard.can_write && isEditable && !!dashboard;
+    const isAnalyticsDashboard = collection.type === "instance-analytics";
 
     const hasModelActionsEnabled = Object.values(databases).some(
       hasDatabaseActionsEnabled,
@@ -348,7 +352,18 @@ class DashboardHeader extends Component {
       });
     }
 
-    if (!isFullscreen && !isEditing && canEdit) {
+    if (isAnalyticsDashboard) {
+      buttons.push(
+        <Button
+          icon="clone"
+          data-metabase-event="Dashboard;Copy"
+          to={`${location.pathname}/copy`}
+          as={Link}
+        >{t`Make a copy`}</Button>,
+      );
+    }
+
+    if (!isFullscreen && !isEditing && !isAnalyticsDashboard && canEdit) {
       buttons.push(
         <Tooltip key="edit-dashboard" tooltip={t`Edit dashboard`}>
           <DashboardHeaderButton
@@ -363,7 +378,7 @@ class DashboardHeader extends Component {
       );
     }
 
-    if (!isFullscreen && !isEditing) {
+    if (!isFullscreen && !isEditing && !isAnalyticsDashboard) {
       extraButtons.push({
         title: t`Enter fullscreen`,
         icon: "expand",
@@ -405,7 +420,7 @@ class DashboardHeader extends Component {
 
     buttons.push(...getDashboardActions(this, this.props));
 
-    if (extraButtons.length > 0 && !isEditing) {
+    if (!isEditing) {
       buttons.push(
         ...[
           <DashboardHeaderActionDivider key="dashboard-button-divider" />,
@@ -427,6 +442,11 @@ class DashboardHeader extends Component {
               }
             />
           </Tooltip>,
+        ].filter(Boolean),
+      );
+
+      if (extraButtons.length > 0) {
+        buttons.push(
           <EntityMenu
             key="dashboard-action-menu-button"
             triggerAriaLabel="dashboard-menu-button"
@@ -434,7 +454,20 @@ class DashboardHeader extends Component {
             triggerIcon="ellipsis"
             tooltip={t`Move, archive, and more...`}
           />,
-        ].filter(Boolean),
+        );
+      }
+    }
+
+    if (isAnalyticsDashboard) {
+      buttons.push(
+        <DashboardHeaderButton
+          key="expand"
+          aria-label={t`Enter Fullscreen`}
+          data-metabase-event={`Dashboard;Fullscreen Mode;${!isFullscreen}`}
+          icon="expand"
+          className="text-brand-hover cursor-pointer"
+          onClick={e => onFullscreenChange(!isFullscreen, !e.altKey)}
+        />,
       );
     }
 
@@ -450,6 +483,7 @@ class DashboardHeader extends Component {
   render() {
     const {
       dashboard,
+      collection,
       isEditing,
       isFullscreen,
       isAdditionalInfoVisible,
@@ -466,6 +500,7 @@ class DashboardHeader extends Component {
         objectType="dashboard"
         analyticsContext="Dashboard"
         dashboard={dashboard}
+        collection={collection}
         isEditing={isEditing}
         isBadgeVisible={!isEditing && !isFullscreen && isAdditionalInfoVisible}
         isLastEditInfoVisible={hasLastEditInfo && isAdditionalInfoVisible}
@@ -489,5 +524,8 @@ class DashboardHeader extends Component {
 
 export default _.compose(
   Bookmark.loadList(),
+  Collections.load({
+    id: (state, props) => props.dashboard.collection_id || "root",
+  }),
   connect(mapStateToProps, mapDispatchToProps),
 )(DashboardHeader);

--- a/frontend/src/metabase/dashboard/containers/DashboardHeader.jsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardHeader.jsx
@@ -36,6 +36,7 @@ import { getSetting } from "metabase/selectors/settings";
 
 import Link from "metabase/core/components/Link/Link";
 import Collections from "metabase/entities/collections/collections";
+import { isInstanceAnalyticsCollection } from "metabase/collections/utils";
 import DashboardHeaderView from "../components/DashboardHeaderView";
 import { SIDEBAR_NAME } from "../constants";
 import {
@@ -235,7 +236,7 @@ class DashboardHeader extends Component {
     } = this.props;
 
     const canEdit = dashboard.can_write && isEditable && !!dashboard;
-    const isAnalyticsDashboard = collection.type === "instance-analytics";
+    const isAnalyticsDashboard = isInstanceAnalyticsCollection(collection);
 
     const hasModelActionsEnabled = Object.values(databases).some(
       hasDatabaseActionsEnabled,
@@ -363,7 +364,7 @@ class DashboardHeader extends Component {
       );
     }
 
-    if (!isFullscreen && !isEditing && !isAnalyticsDashboard && canEdit) {
+    if (!isFullscreen && !isEditing && canEdit) {
       buttons.push(
         <Tooltip key="edit-dashboard" tooltip={t`Edit dashboard`}>
           <DashboardHeaderButton

--- a/frontend/src/metabase/dashboard/containers/DashboardHeader.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardHeader.unit.spec.tsx
@@ -1,0 +1,68 @@
+import fetchMock from "fetch-mock";
+import {
+  renderWithProviders,
+  screen,
+  waitForElementToBeRemoved,
+} from "__support__/ui";
+import {
+  createMockCollection,
+  createMockDashboard,
+} from "metabase-types/api/mocks";
+import DashboardHeader from "./DashboardHeader";
+
+const setup = () => {
+  fetchMock.get(
+    "path:/api/collection/10",
+    createMockCollection({
+      name: "Performance",
+      id: 10,
+    }),
+  );
+
+  fetchMock.get("path:/api/bookmark", []);
+
+  const dashboard = createMockDashboard({
+    collection_id: 10,
+  });
+
+  renderWithProviders(
+    <DashboardHeader
+      dashboard={dashboard}
+      saveDashboardAndCards={jest.fn()}
+      setDashboardAttribute={jest.fn()}
+      onEditingChange={jest.fn()}
+      onRefreshPeriodChange={jest.fn()}
+      onNightModeChange={jest.fn()}
+      onFullscreenChange={jest.fn()}
+      onSharingClick={jest.fn()}
+      isFullscreen={false}
+      isNightMode={false}
+      setRefreshElapsedHook={jest.fn()}
+      addCardToDashboard={jest.fn()}
+      addTextDashCardToDashboard={jest.fn()}
+      addLinkDashCardToDashboard={jest.fn()}
+      isEditable={false}
+      isEditing={false}
+      databases={[]}
+      location={{ pathname: "/dashboard/2" }}
+    />,
+  );
+};
+
+describe("dashboard header", () => {
+  it("should render the correct buttons", async () => {
+    setup();
+    await waitForElementToBeRemoved(() => screen.queryByText("Loading..."));
+    expect(screen.getByText("Make a copy")).toBeInTheDocument();
+    expect(screen.getByRole("img", { name: /beaker/i })).toBeInTheDocument();
+
+    //Other buttons
+    expect(
+      screen.getByRole("button", { name: /bookmark/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /info/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /fullscreen/i }),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/metabase/dashboard/containers/DashboardHeader.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardHeader.unit.spec.tsx
@@ -14,8 +14,9 @@ const setup = () => {
   fetchMock.get(
     "path:/api/collection/10",
     createMockCollection({
-      name: "Performance",
+      name: "Custom Reports",
       id: 10,
+      type: "instance-analytics",
     }),
   );
 

--- a/frontend/src/metabase/entities/collections/utils.ts
+++ b/frontend/src/metabase/entities/collections/utils.ts
@@ -52,11 +52,12 @@ const collectionIconTooltipNameMap = {
   collection: t`collection`,
   question: t`question`,
   model: t`model`,
+  dashboard: t`dashboard`,
 };
 
 export const getCollectionTooltip = (
   collection: Partial<Collection>,
-  entity: "collection" | "question" | "model" = "collection",
+  entity: "collection" | "question" | "model" | "dashboard" = "collection",
 ) => {
   const entityText = collectionIconTooltipNameMap[entity];
 

--- a/frontend/src/metabase/entities/collections/utils.unit.spec.ts
+++ b/frontend/src/metabase/entities/collections/utils.unit.spec.ts
@@ -405,7 +405,7 @@ describe("entities > collections > utils", () => {
     const collection = createMockCollection({
       type: "instance-analytics",
     });
-    ["collection", "model", "question"].forEach(type => {
+    ["collection", "model", "question", "dashboard"].forEach(type => {
       it(`returns correct tooltip for instance analytics ${type}`, () => {
         expect(getCollectionTooltip(collection, type as any)).toContain(
           `Instance Analytics ${type}`,


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/31013

### Description
Adjusting the dashboard header for Instance Analytics Dashboards

### How to verify
Create a dashboard under an Instance Analytics collection (will likely need to do this in another branch)
Verify Header buttons have been adjusted, and a Beaker is shown next to the Dashboard name

### Demo
![image](https://github.com/metabase/metabase/assets/1328979/aa0a6ff1-9567-48b4-97b9-7864c23082b0)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
