### PR TITLE
[MLv2] Change expressions map into a vector of expressions

### DIFF
--- a/src/metabase/lib/convert.cljc
+++ b/src/metabase/lib/convert.cljc
@@ -102,7 +102,14 @@
 
 (defmethod ->pMBQL :mbql.stage/mbql
   [stage]
-  (let [aggregations (->pMBQL (:aggregation stage))]
+  (let [aggregations (->pMBQL (:aggregation stage))
+        expressions (->> stage
+                         :expressions
+                         (mapv (fn [[k v]]
+                                 (-> v
+                                     ->pMBQL
+                                     (lib.util/named-expression-clause k))))
+                         not-empty)]
     (binding [*legacy-index->pMBQL-uuid* (into {}
                                                (map-indexed (fn [idx [_tag {ag-uuid :lib/uuid}]]
                                                               [idx ag-uuid]))
@@ -112,8 +119,8 @@
           (if-not (get stage k)
             stage
             (update stage k ->pMBQL)))
-        (m/assoc-some stage :aggregation aggregations)
-        (disj stage-keys :aggregation)))))
+        (m/assoc-some stage :aggregation aggregations :expressions expressions)
+        (disj stage-keys :aggregation :expressions)))))
 
 (defmethod ->pMBQL :mbql/join
   [join]
@@ -370,8 +377,18 @@
             (-> stage
                 disqualify
                 (m/update-existing :aggregation #(mapv aggregation->legacy-MBQL %))
+                (m/update-existing :expressions (fn [expressions]
+                                                  (into {}
+                                                        (for [expression expressions
+                                                              :let [legacy-clause (->legacy-MBQL expression)]]
+                                                          [(lib.util/expression-name expression)
+                                                           ;; We wrap literals in :value ->pMBQL
+                                                           ;; so unwrap this direction
+                                                           (if (= :value (first legacy-clause))
+                                                             (second legacy-clause)
+                                                             legacy-clause)]))))
                 (update-list->legacy-boolean-expression :filters :filter))
-            (disj stage-keys :aggregation :filters))))
+            (disj stage-keys :aggregation :filters :expressions))))
 
 (defmethod ->legacy-MBQL :mbql.stage/native [stage]
   (-> stage

--- a/src/metabase/lib/dev.cljc
+++ b/src/metabase/lib/dev.cljc
@@ -69,7 +69,8 @@
    (fn [query stage-number]
      (case expression-or-aggregation
        :expression
-       (if (contains? (:expressions (lib.util/query-stage query stage-number)) index-or-name)
+       (if (some (comp #{index-or-name} lib.util/expression-name)
+                 (:expressions (lib.util/query-stage query stage-number)))
          (lib.options/ensure-uuid [:expression {} index-or-name])
          (throw (ex-info (str "Undefined expression " index-or-name)
                          {:expression-name index-or-name

--- a/src/metabase/lib/schema.cljc
+++ b/src/metabase/lib/schema.cljc
@@ -52,7 +52,7 @@
    [:ref ::id/table-card-id-string]])
 
 (defn- expression-ref-error-for-stage [stage]
-  (let [expression-names (set (keys (:expressions stage)))]
+  (let [expression-names (into #{} (map (comp :lib/expression-name second)) (:expressions stage))]
     (mbql.match/match-one (dissoc stage :joins :lib/stage-metadata)
       [:expression _opts (expression-name :guard (complement expression-names))]
       (str "Invalid :expression reference: no expression named " (pr-str expression-name)))))

--- a/src/metabase/lib/schema/expression.cljc
+++ b/src/metabase/lib/schema/expression.cljc
@@ -153,7 +153,5 @@
 
 ;;; the `:expressions` definition map as found as a top-level key in an MBQL stage
 (mr/def ::expressions
-  [:map-of
-   {:min 1, :error/message ":expressions definition map of expression name -> expression"}
-   ::common/non-blank-string
-   ::expression])
+  [:sequential {:min 1} [:and [:ref ::expression]
+                         [:cat :any [:map [:lib/expression-name :string]] [:* :any]]]])

--- a/src/metabase/lib/util.cljc
+++ b/src/metabase/lib/util.cljc
@@ -63,7 +63,7 @@
     (if (clause? clause)
       clause
       [:value {:lib/uuid (str (random-uuid))
-               :effective-type (lib.schema.expression/type-of 1)}
+               :effective-type (lib.schema.expression/type-of clause)}
        clause])
     [1 :lib/expression-name] a-name))
 

--- a/src/metabase/lib/util.cljc
+++ b/src/metabase/lib/util.cljc
@@ -14,6 +14,7 @@
    [metabase.lib.options :as lib.options]
    [metabase.lib.schema :as lib.schema]
    [metabase.lib.schema.common :as lib.schema.common]
+   [metabase.lib.schema.expression :as lib.schema.expression]
    [metabase.lib.schema.id :as lib.schema.id]
    [metabase.mbql.util :as mbql.u]
    [metabase.shared.util.i18n :as i18n]
@@ -49,18 +50,36 @@
   (when (clause? clause)
     (get-in clause [1 :lib/uuid])))
 
+(defn expression-name
+  "Returns the :lib/expression-name of `clause`. Returns nil if `clause` is not a clause."
+  [clause]
+  (when (clause? clause)
+    (get-in clause [1 :lib/expression-name])))
+
+(defn named-expression-clause
+  "Top level expressions must be clauses with :lib/expression-name, so if we get a literal, wrap it in :value."
+  [clause a-name]
+  (assoc-in
+    (if (clause? clause)
+      clause
+      [:value {:lib/uuid (str (random-uuid))
+               :effective-type (lib.schema.expression/type-of 1)}
+       clause])
+    [1 :lib/expression-name] a-name))
+
 (defn replace-clause
   "Replace the `target-clause` in `stage` `location` with `new-clause`.
    If a clause has :lib/uuid equal to the `target-clause` it is swapped with `new-clause`.
    If `location` contains no clause with `target-clause` no replacement happens."
   [stage location target-clause new-clause]
   {:pre [(clause? target-clause)]}
-  (m/update-existing-in
-    stage
-    location
-    (fn [clause-or-clauses]
-      (if (= :expressions (first location))
-        new-clause
+  (let [new-clause (if (= :expressions (first location))
+                     (named-expression-clause new-clause (expression-name target-clause))
+                     new-clause)]
+    (m/update-existing-in
+      stage
+      location
+      (fn [clause-or-clauses]
         (->> (for [clause clause-or-clauses]
                (if (= (clause-uuid clause) (clause-uuid target-clause))
                  new-clause
@@ -77,9 +96,7 @@
   (if-let [target (get-in stage location)]
     (let [target-uuid (clause-uuid target-clause)
           [first-loc last-loc] [(first location) (last location)]
-          result (if (= :expressions first-loc)
-                   nil
-                   (into [] (remove (comp #{target-uuid} clause-uuid)) target))]
+          result (into [] (remove (comp #{target-uuid} clause-uuid)) target)]
       (cond
         (seq result)
         (assoc-in stage location result)

--- a/test/metabase/lib/aggregation_test.cljc
+++ b/test/metabase/lib/aggregation_test.cljc
@@ -168,10 +168,11 @@
              :display-name "Sum of double-price"}
             (col-info-for-aggregation-clause
              (lib.tu/venues-query-with-last-stage
-              {:expressions {"double-price" [:*
-                                             {:lib/uuid (str (random-uuid))}
-                                             (lib.tu/field-clause :venues :price {:base-type :type/Integer})
-                                             2]}})
+               {:expressions [[:*
+                               {:lib/uuid (str (random-uuid))
+                                :lib/expression-name "double-price"}
+                               (lib.tu/field-clause :venues :price {:base-type :type/Integer})
+                               2]]})
              [:sum
               {:lib/uuid (str (random-uuid))}
               [:expression {:base-type :type/Integer, :lib/uuid (str (random-uuid))} "double-price"]])))))
@@ -396,10 +397,8 @@
                  [{:lib/type :mbql.stage/mbql,
                    :source-table int?,
                    :expressions
-                   {"double-price"
-                    [:* {} [:field {:base-type :type/Integer, :effective-type :type/Integer} int?] 2]
-                    "budget?"
-                    [:< {} [:field {:base-type :type/Integer, :effective-type :type/Integer} int?] 2]}
+                   [[:* {:lib/expression-name "double-price"} [:field {:base-type :type/Integer, :effective-type :type/Integer} int?] 2]
+                    [:< {:lib/expression-name "budget?"} [:field {:base-type :type/Integer, :effective-type :type/Integer} int?] 2]]
                    :aggregation
                    [[:sum {} [:expression {} "double-price"]]
                     [:count {}]

--- a/test/metabase/lib/convert_test.cljc
+++ b/test/metabase/lib/convert_test.cljc
@@ -268,7 +268,12 @@
      :parameters [{:target [:dimension [:field 16 {:source-field 5}]],
                    :type :category,
                    :value [:param-value]}],
-     :type :native}))
+     :type :native}
+
+    {:database 1
+     :type     :query
+     :query    {:source-table 224
+                :expressions {"a" 1}}}))
 
 (deftest ^:parallel round-trip-options-test
   (testing "Round-tripping (p)MBQL caluses with options (#30280)"

--- a/test/metabase/lib/expression_test.cljc
+++ b/test/metabase/lib/expression_test.cljc
@@ -259,14 +259,14 @@
 
 (deftest ^:parallel literal-expression-test
   (is (=? [{:lib/type :metadata/field,
-            :base-type :type/Number,
+            :base-type :type/Integer,
             :name "expr",
             :display-name "expr",
             :lib/source :source/expressions}]
           (-> (lib/query-for-table-name meta/metadata-provider "VENUES")
               (lib/expression "expr" 100)
               (lib/expressions-metadata))))
-  (is (=? [[:value {:lib/expression-name "expr" :effective-type :type/Number} 100]]
+  (is (=? [[:value {:lib/expression-name "expr" :effective-type :type/Integer} 100]]
           (-> (lib/query-for-table-name meta/metadata-provider "VENUES")
               (lib/expression "expr" 100)
               (lib/expressions))))

--- a/test/metabase/lib/remove_replace_test.cljc
+++ b/test/metabase/lib/remove_replace_test.cljc
@@ -197,7 +197,7 @@
   (let [query (-> (lib/query-for-table-name meta/metadata-provider "VENUES")
                   (lib/expression "a" (lib/field "VENUES" "ID"))
                   (lib/expression "b" (lib/field "VENUES" "PRICE")))
-        {expr-a "a" expr-b "b" :as expressions} (lib/expressions query)]
+        [expr-a expr-b :as expressions] (lib/expressions query)]
     (is (= 2 (count expressions)))
     (is (= 1 (-> query
                  (lib/remove-clause expr-a)
@@ -208,7 +208,7 @@
                   (lib/remove-clause expr-b)
                   (lib/expressions))))
     (testing "removing with dependent should cascade"
-      (is (=? {:stages [{:expressions {"b" expr-b} :order-by (symbol "nil #_\"key is not present.\"")}
+      (is (=? {:stages [{:expressions [expr-b] :order-by (symbol "nil #_\"key is not present.\"")}
                         (complement :filters)]}
               (-> query
                 (lib/order-by (lib.dev/ref-lookup :expression "a"))
@@ -367,20 +367,21 @@
   (let [query (-> (lib/query-for-table-name meta/metadata-provider "VENUES")
                   (lib/expression "a" (lib/field (meta/id :venues :id)))
                   (lib/expression "b" (lib/field (meta/id :venues :name))))
-        {expr-a "a" expr-b "b" :as expressions} (lib/expressions query)
+        [expr-a expr-b :as expressions] (lib/expressions query)
         replaced (-> query
                      (lib/replace-clause expr-a (lib/field (meta/id :venues :price))))
-        {_repl-expr-a "a" repl-expr-b "b" :as replaced-expressions} (lib/expressions replaced)]
+        [_repl-expr-a repl-expr-b :as replaced-expressions] (lib/expressions replaced)]
     (is (= 2 (count expressions)))
-    (is (=? {"a" [:field {} (meta/id :venues :price)]}
+    (is (=? [[:field {:lib/expression-name "a"} (meta/id :venues :price)]
+             expr-b]
             replaced-expressions))
     (is (not= expressions replaced-expressions))
     (is (= 2 (count replaced-expressions)))
     (is (= expr-b repl-expr-b))
     (testing "replacing with dependent should cascade"
       (is (=? {:stages [{:aggregation (symbol "nil #_\"key is not present.\"")
-                         :expressions {"a" [:field {} (meta/id :venues :price)]
-                                       "b" expr-b}}
+                         :expressions [[:field {:lib/expression-name "a"} (meta/id :venues :price)]
+                                       expr-b]}
                         (complement :filters)]}
               (-> query
                   (lib/aggregate (lib/sum (lib.dev/ref-lookup :expression "a")))
@@ -388,7 +389,12 @@
                   (lib/append-stage)
                   ;; TODO Should be able to create a ref with lib/field [#29763]
                   (lib/filter (lib/= [:field {:lib/uuid (str (random-uuid)) :base-type :type/Integer} "a"] 1))
-                  (lib/replace-clause 0 expr-a (lib/field "VENUES" "PRICE"))))))))
+                  (lib/replace-clause 0 expr-a (lib/field "VENUES" "PRICE"))))))
+    (testing "replace with literal expression"
+      (is (=? {:stages [{:expressions [[:value {:lib/expression-name "a" :effective-type :type/Integer} 999]
+                                       expr-b]}]}
+              (-> query
+                  (lib/replace-clause 0 expr-a 999)))))))
 
 (deftest ^:parallel replace-order-by-breakout-col-test
   (testing "issue #30980"

--- a/test/metabase/lib/schema/expression/conditional_test.cljc
+++ b/test/metabase/lib/schema/expression/conditional_test.cljc
@@ -63,13 +63,13 @@
         :database     (meta/id)
         :stages       [{:lib/type     :mbql.stage/mbql,
                         :source-table (meta/id :venues)
-                        :expressions  {"expr"
-                                       [:coalesce
-                                        {:lib/uuid "455a9f5e-4996-4df9-82aa-01bc083b2efe"}
+                        :expressions  [[:coalesce
+                                        {:lib/uuid "455a9f5e-4996-4df9-82aa-01bc083b2efe"
+                                         :lib/expression-name "expr"}
                                         [:field
                                          {:base-type :type/Text, :lib/uuid "68443c43-f9de-45e3-9f30-8dfd5fef5af6"}
                                          (meta/id :venues :name)]
-                                        "bar"]}}]})))
+                                        "bar"]]}]})))
 
 (deftest ^:parallel case-type-of-with-fields-only-test
   ;; Ideally expression/type-of should have enough information to determine the types of fields.

--- a/test/metabase/lib/schema_test.cljc
+++ b/test/metabase/lib/schema_test.cljc
@@ -68,7 +68,8 @@
 
 (def ^:private valid-expression
   [:+
-   {:lib/uuid (str (random-uuid))}
+   {:lib/uuid (str (random-uuid))
+    :lib/expression-name "price + 2"}
    [:field
     {:lib/uuid (str (random-uuid))}
     2]
@@ -79,15 +80,15 @@
                          (me/humanize (mc/explain ::lib.schema/stage stage)))
     {:lib/type     :mbql.stage/mbql
      :source-table 1
-     :expressions  {"price + 2" valid-expression}
+     :expressions  [valid-expression]
      :fields       [[:expression {:lib/uuid (str (random-uuid))} "price + 2"]]}
     nil
 
     {:lib/type     :mbql.stage/mbql
      :source-table 1
-     :expressions  {"price + 1" valid-expression}
-     :fields       [[:expression {:lib/uuid (str (random-uuid))} "price + 2"]]}
-    ["Invalid :expression reference: no expression named \"price + 2\""]
+     :expressions  [valid-expression]
+     :fields       [[:expression {:lib/uuid (str (random-uuid))} "price + 1"]]}
+    ["Invalid :expression reference: no expression named \"price + 1\""]
 
     {:lib/type     :mbql.stage/mbql
      :source-table 1
@@ -107,7 +108,7 @@
                                     [:field {:join-alias "Q1", :lib/uuid (str (random-uuid))} 2]]]
                      :stages      [{:lib/type     :mbql.stage/mbql
                                     :source-table 3
-                                    :expressions  {"price + 2" valid-expression}
+                                    :expressions  [valid-expression]
                                     :order-by     [[:asc
                                                     {:lib/uuid (str (random-uuid))}
                                                     [:expression {:lib/uuid (str (random-uuid))} "price + 2"]]]}

--- a/test/metabase/lib/stage_test.cljc
+++ b/test/metabase/lib/stage_test.cljc
@@ -75,8 +75,8 @@
   (let [query (-> (lib/query-for-table-name meta/metadata-provider "VENUES")
                   (lib/expression "ID + 1" (lib/+ (lib/field "VENUES" "ID") 1))
                   (lib/expression "ID + 2" (lib/+ (lib/field "VENUES" "ID") 2)))]
-    (is (=? {:stages [{:expressions {"ID + 1" [:+ {} [:field {} (meta/id :venues :id)] 1]
-                                     "ID + 2" [:+ {} [:field {} (meta/id :venues :id)] 2]}}]}
+    (is (=? {:stages [{:expressions [[:+ {:lib/expression-name "ID + 1"} [:field {} (meta/id :venues :id)] 1]
+                                     [:+ {:lib/expression-name "ID + 2"} [:field {} (meta/id :venues :id)] 2]]}]}
             query))
     query))
 
@@ -108,8 +108,8 @@
                                                       [:field {} (meta/id :venues :category-id)]
                                                       [:field {:join-alias "Cat"} (meta/id :categories :id)]]]
                                         :fields     :all}]
-                         :expressions {"ID + 1" [:+ {} [:field {} (meta/id :venues :id)] 1]
-                                       "ID + 2" [:+ {} [:field {} (meta/id :venues :id)] 2]}}]}
+                         :expressions [[:+ {:lib/expression-name "ID + 1"} [:field {} (meta/id :venues :id)] 1]
+                                       [:+ {:lib/expression-name "ID + 2"} [:field {} (meta/id :venues :id)] 2]]}]}
               query))
       (let [metadata (lib.metadata.calculation/metadata query)]
         (is (=? [{:id (meta/id :venues :id), :name "ID", :lib/source :source/table-defaults}
@@ -160,8 +160,8 @@
               id-plus-1))
       (let [query' (-> query
                        (lib/with-fields [id-plus-1]))]
-        (is (=? {:stages [{:expressions {"ID + 1" [:+ {} [:field {} (meta/id :venues :id)] 1]
-                                         "ID + 2" [:+ {} [:field {} (meta/id :venues :id)] 2]}
+        (is (=? {:stages [{:expressions [[:+ {:lib/expression-name "ID + 1"} [:field {} (meta/id :venues :id)] 1]
+                                         [:+ {:lib/expression-name "ID + 2"} [:field {} (meta/id :venues :id)] 2]]
                            :fields      [[:expression {} "ID + 1"]]}]}
                 query'))
         (testing "If `:fields` is specified, expressions should only come back if they are in `:fields`"


### PR DESCRIPTION
Looking at https://github.com/metabase/metabase/issues/31155

In the UI, custom expressions are an ordered list, but the implementation is a map (created by assoc). Two issues with the map:
With enough expressions they will likely start jumping around as new ones are added/removed.
It's difficult to enforce a dependency of expressions. In the example, these two expressions reference each other but really we should only allow expressions to reference ones to the left of themselves.
In mlv1, the expression editor is presented all existing expressions even itself.

So changing expressions from
`{:expressions {"a" [:+ {...} 1 1]}}`
to
`{:expressions [[:+ {:lib/expression-name "a"} 1 1]]}`
will allow us enforce this ordering and only show valid expressionable columns

Not that this requires us to wrap literal expressions in `:value`
