### PR TITLE
FE: ellipsify column title in details modal to prevent text overflow

### DIFF
--- a/frontend/src/metabase/core/components/Ellipsified/Ellipsified.stories.tsx
+++ b/frontend/src/metabase/core/components/Ellipsified/Ellipsified.stories.tsx
@@ -1,0 +1,32 @@
+import type { ComponentStory } from "@storybook/react";
+import Ellipsified from "./Ellipsified";
+
+const testLabels = [
+  "Short Title",
+  "Long Title Wrapping to Next Line",
+  "Very____________LongTitleWithNoSpaces",
+  "Very Long Title With Spaces",
+  "VeryLongTitleWithNoSpaces and more words",
+  [1, 2, 3, 4, 5].map(i => `${i}_VeryLongTitleWithNoSpaces`).join(" "),
+];
+
+export default {
+  title: "Core/Ellipsified",
+  component: Ellipsified,
+};
+
+const Template: ComponentStory<typeof Ellipsified> = args => (
+  <ul style={{ maxWidth: 100 }}>
+    {testLabels.map((label: string) => (
+      <li style={{ marginTop: 10 }} key={label}>
+        <Ellipsified {...args}>{label}</Ellipsified>
+      </li>
+    ))}
+  </ul>
+);
+
+export const SingleLineEllipsify = Template.bind({});
+SingleLineEllipsify.args = { lines: 1 };
+
+export const MultiLineClamp = Template.bind({});
+MultiLineClamp.args = { lines: 8 };

--- a/frontend/src/metabase/core/components/Ellipsified/Ellipsified.styled.tsx
+++ b/frontend/src/metabase/core/components/Ellipsified/Ellipsified.styled.tsx
@@ -12,6 +12,7 @@ const clampCss = (props: EllipsifiedRootProps) => css`
   -webkit-line-clamp: ${props.lines};
   -webkit-box-orient: vertical;
   overflow: hidden;
+  overflow-wrap: break-word;
 `;
 
 interface EllipsifiedRootProps {

--- a/frontend/src/metabase/core/components/Ellipsified/Ellipsified.styled.tsx
+++ b/frontend/src/metabase/core/components/Ellipsified/Ellipsified.styled.tsx
@@ -20,5 +20,5 @@ interface EllipsifiedRootProps {
 }
 
 export const EllipsifiedRoot = styled.div<EllipsifiedRootProps>`
-  ${props => (props.lines ?? 1 > 1 ? clampCss(props) : ellipsifyCss)};
+  ${props => ((props.lines ?? 1) > 1 ? clampCss(props) : ellipsifyCss)};
 `;

--- a/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetailsTable.tsx
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetailsTable.tsx
@@ -49,8 +49,7 @@ export function DetailsTableCell({
 
   if (isColumnName) {
     const title = column !== null ? columnTitle : null;
-    const lineLimit = title?.match(/\s/) ? 10 : 1;
-    cellValue = <Ellipsified lines={lineLimit}>{title}</Ellipsified>;
+    cellValue = <Ellipsified lines={8}>{title}</Ellipsified>;
     clicked.column = column;
     isLink = false;
   } else {

--- a/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetailsTable.tsx
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetailsTable.tsx
@@ -8,6 +8,7 @@ import ExpandableString from "metabase/query_builder/components/ExpandableString
 import EmptyState from "metabase/components/EmptyState";
 
 import { formatValue, formatColumn } from "metabase/lib/formatting";
+import Ellipsified from "metabase/core/components/Ellipsified";
 import { isa, isID } from "metabase-lib/types/utils/isa";
 import { TYPE } from "metabase-lib/types/constants";
 import { findColumnIndexForColumnSetting } from "metabase-lib/queries/utils/dataset";
@@ -47,7 +48,9 @@ export function DetailsTableCell({
     columnSettings?.["_column_title_full"] || formatColumn(column);
 
   if (isColumnName) {
-    cellValue = column !== null ? columnTitle : null;
+    const cellText = column !== null ? columnTitle : null;
+    const cellLines = cellText?.includes(" ") ? 3 : 1;
+    cellValue = <Ellipsified lines={cellLines}>{cellText}</Ellipsified>;
     clicked.column = column;
     isLink = false;
   } else {

--- a/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetailsTable.tsx
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetailsTable.tsx
@@ -48,9 +48,9 @@ export function DetailsTableCell({
     columnSettings?.["_column_title_full"] || formatColumn(column);
 
   if (isColumnName) {
-    const cellText = column !== null ? columnTitle : null;
-    const cellLines = cellText?.includes(" ") ? 3 : 1;
-    cellValue = <Ellipsified lines={cellLines}>{cellText}</Ellipsified>;
+    const title = column !== null ? columnTitle : null;
+    const lineLimit = title?.match(/\s/) ? 10 : 1;
+    cellValue = <Ellipsified lines={lineLimit}>{title}</Ellipsified>;
     clicked.column = column;
     isLink = false;
   } else {


### PR DESCRIPTION
Closes #29282

### Expected behavior

The expected behavior wasn’t specified in the issue above.

@mazameli suggests:

> the problem seems to be the field names without spaces, like “detenteurCompanySize”, so yes, I think ellipsify+tooltip on those too-long column names is the way to go since we can’t wrap them

@alxnddr suggests that we break inside words instead, then limit the number of lines:

<img width="444" alt="CleanShot 2023-06-02 at 19 01 50@2x" src="https://github.com/metabase/metabase/assets/116838/889df9ce-8282-4e42-a43b-1c652ab96f32">


### Description

1. We use the existing `<Ellipsified>` component with `lines=8`, which will ellipsify+tooltip if the label exceeds 8 lines after wrapping.
2. We also add `overflow-wrap: break-words` to Ellipsified’s multiline clamp mode, so that unusually long words exceeding the width of a line will be broken up to wrap to the next line— which seems reasonable for the long column titles in the issue linked above.  *QUESTION:* are there cases where this is not desirable?
3. We stress test the Ellipsified component with a new storybook— showing the single-line vs multi-line modes for labels of different sizes.

### How to verify

To verify Ellipsified’s behavior, look at the [Ellipsified storybook](http://localhost:6006/?path=/story/core-ellipsified--single-line-ellipsify) after running `yarn run storybook`.

To verify that it works inside the Object Details component, I manually inserted long column titles with code in a separate branch:

1. Checkout the `details-column-overflow-test` branch
4. Go to [Browse Data > Sample Database > Accounts > View details of first account](http://localhost:3000/question?objectId=1#eyJkYXRhc2V0X3F1ZXJ5Ijp7ImRhdGFiYXNlIjoxLCJxdWVyeSI6eyJzb3VyY2UtdGFibGUiOjd9LCJ0eXBlIjoicXVlcnkifSwiZGlzcGxheSI6InRhYmxlIiwidmlzdWFsaXphdGlvbl9zZXR0aW5ncyI6e319)
5. Verify the tooltips and ellipsis are present where you expect.

### Demo

Storybook:

https://github.com/metabase/metabase/assets/116838/dcd8c514-f0ff-4de7-97b3-86e9ad06106c

Manual details component test:

https://github.com/metabase/metabase/assets/116838/29e6dbd8-cef5-4692-b073-9d15e7891387

### Checklist

- [ ] Check if `overflow-wrap: break-words` is not desirable in [the other multiline Ellipsified use case (where lines=2)](https://github.com/metabase/metabase/blob/9d888078273f5c97e782341f74fa8e31ce0870c5/frontend/src/metabase/visualizations/components/ScalarValue/ScalarValue.jsx#L74).
