### PR TITLE
Remove caveats and points_of_interest from BE code

### DIFF
--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -414,13 +414,11 @@
   Usually, you just need write permissions for this Dashboard to do this (which means you have appropriate
   permissions for the Cards belonging to this Dashboard), but to change the value of `enable_embedding` you must be a
   superuser."
-  [id :as {{:keys [description name parameters caveats points_of_interest show_in_getting_started enable_embedding
+  [id :as {{:keys [description name parameters show_in_getting_started enable_embedding
                    embedding_params position archived collection_id collection_position cache_ttl]
             :as dash-updates} :body}]
   {name                    (s/maybe su/NonBlankString)
    description             (s/maybe s/Str)
-   caveats                 (s/maybe s/Str)
-   points_of_interest      (s/maybe s/Str)
    show_in_getting_started (s/maybe s/Bool)
    enable_embedding        (s/maybe s/Bool)
    embedding_params        (s/maybe su/EmbeddingParams)
@@ -442,7 +440,7 @@
       ;; non-nil
       (when-let [updates (not-empty (u/select-keys-when dash-updates
                                                         :present #{:description :position :collection_id :collection_position :cache_ttl}
-                                                        :non-nil #{:name :parameters :caveats :points_of_interest :show_in_getting_started :enable_embedding
+                                                        :non-nil #{:name :parameters :show_in_getting_started :enable_embedding
                                                                    :embedding_params :archived :auto_apply_filters}))]
         (t2/update! Dashboard id updates))))
   ;; now publish an event and return the updated Dashboard

--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -860,7 +860,7 @@
 #_{:clj-kondo/ignore [:deprecated-var]}
 (api/defendpoint-schema PUT "/:id"
   "Update a `Database`."
-  [id :as {{:keys [name engine details is_full_sync is_on_demand description caveats points_of_interest schedules
+  [id :as {{:keys [name engine details is_full_sync is_on_demand description schedules
                    auto_run_queries refingerprint cache_ttl settings]} :body}]
   {name               (s/maybe su/NonBlankString)
    engine             (s/maybe DBEngineString)
@@ -868,8 +868,6 @@
    details            (s/maybe su/Map)
    schedules          (s/maybe sync.schedules/ExpandedSchedulesMap)
    description        (s/maybe s/Str)   ; s/Str instead of su/NonBlankString because we don't care
-   caveats            (s/maybe s/Str)   ; whether someone sets these to blank strings
-   points_of_interest (s/maybe s/Str)
    auto_run_queries   (s/maybe s/Bool)
    cache_ttl          (s/maybe su/IntGreaterThanZero)
    settings           (s/maybe su/Map)}
@@ -900,8 +898,6 @@
                                    :is_full_sync       full-sync?
                                    :is_on_demand       (boolean is_on_demand)
                                    :description        description
-                                   :caveats            caveats
-                                   :points_of_interest points_of_interest
                                    :auto_run_queries   auto_run_queries}
                                   ;; upsert settings with a PATCH-style update. `nil` key means unset the Setting.
                                   (when (seq settings)

--- a/src/metabase/api/field.clj
+++ b/src/metabase/api/field.clj
@@ -130,14 +130,12 @@
 #_{:clj-kondo/ignore [:deprecated-var]}
 (api/defendpoint-schema PUT "/:id"
   "Update `Field` with ID."
-  [id :as {{:keys [caveats description display_name fk_target_field_id points_of_interest semantic_type
+  [id :as {{:keys [description display_name fk_target_field_id semantic_type
                    coercion_strategy visibility_type has_field_values settings nfc_path json_unfolding]
             :as   body} :body}]
-  {caveats            (s/maybe su/NonBlankString)
-   description        (s/maybe su/NonBlankString)
+  {description        (s/maybe su/NonBlankString)
    display_name       (s/maybe su/NonBlankString)
    fk_target_field_id (s/maybe su/IntGreaterThanZero)
-   points_of_interest (s/maybe su/NonBlankString)
    semantic_type      (s/maybe su/FieldSemanticOrRelationTypeKeywordOrString)
    coercion_strategy  (s/maybe su/CoercionStrategyKeywordOrString)
    visibility_type    (s/maybe FieldVisibilityType)
@@ -177,7 +175,7 @@
                                               :fk_target_field_id (when-not removed-fk? fk-target-field-id)
                                               :effective_type effective-type
                                               :coercion_strategy coercion-strategy)
-                                       :present #{:caveats :description :fk_target_field_id :points_of_interest :semantic_type :visibility_type
+                                       :present #{:description :fk_target_field_id :semantic_type :visibility_type
                                                   :coercion_strategy :effective_type :has_field_values :nfc_path :json_unfolding}
                                        :non-nil #{:display_name :settings}))))
     (when (some? json_unfolding)

--- a/src/metabase/api/metric.clj
+++ b/src/metabase/api/metric.clj
@@ -72,7 +72,7 @@
   [id {:keys [revision_message] :as body}]
   (let [existing   (api/write-check Metric id)
         clean-body (u/select-keys-when body
-                     :present #{:description :caveats :how_is_this_calculated :points_of_interest}
+                     :present #{:description :how_is_this_calculated}
                      :non-nil #{:archived :definition :name :show_in_getting_started})
         new-def    (->> clean-body :definition (mbql.normalize/normalize-fragment []))
         new-body   (merge
@@ -90,17 +90,15 @@
 #_{:clj-kondo/ignore [:deprecated-var]}
 (api/defendpoint-schema PUT "/:id"
   "Update a `Metric` with ID."
-  [id :as {{:keys [name definition revision_message archived caveats description how_is_this_calculated
-                   points_of_interest show_in_getting_started]
+  [id :as {{:keys [name definition revision_message archived description how_is_this_calculated
+                   show_in_getting_started]
             :as   body} :body}]
   {name                    (s/maybe su/NonBlankString)
    definition              (s/maybe su/Map)
    revision_message        su/NonBlankString
    archived                (s/maybe s/Bool)
-   caveats                 (s/maybe s/Str)
    description             (s/maybe s/Str)
    how_is_this_calculated  (s/maybe s/Str)
-   points_of_interest      (s/maybe s/Str)
    show_in_getting_started (s/maybe s/Bool)}
   (write-check-and-update-metric! id body))
 

--- a/src/metabase/api/segment.clj
+++ b/src/metabase/api/segment.clj
@@ -61,7 +61,7 @@
   [id {:keys [revision_message], :as body}]
   (let [existing   (api/write-check Segment id)
         clean-body (u/select-keys-when body
-                     :present #{:description :caveats :points_of_interest}
+                     :present #{:description}
                      :non-nil #{:archived :definition :name :show_in_getting_started})
         new-def    (->> clean-body :definition (mbql.normalize/normalize-fragment []))
         new-body   (merge
@@ -79,16 +79,14 @@
 #_{:clj-kondo/ignore [:deprecated-var]}
 (api/defendpoint-schema PUT "/:id"
   "Update a `Segment` with ID."
-  [id :as {{:keys [name definition revision_message archived caveats description points_of_interest
+  [id :as {{:keys [name definition revision_message archived description
                    show_in_getting_started]
             :as   body} :body}]
   {name                    (s/maybe su/NonBlankString)
    definition              (s/maybe su/Map)
    revision_message        su/NonBlankString
    archived                (s/maybe s/Bool)
-   caveats                 (s/maybe s/Str)
    description             (s/maybe s/Str)
-   points_of_interest      (s/maybe s/Str)
    show_in_getting_started (s/maybe s/Bool)}
   (write-check-and-update-segment! id body))
 

--- a/src/metabase/api/table.clj
+++ b/src/metabase/api/table.clj
@@ -63,7 +63,7 @@
   {id ms/PositiveInt}
   (when-let [changes (not-empty (u/select-keys-when body
                                   :non-nil [:display_name :show_in_getting_started :entity_type :field_order]
-                                  :present [:description :caveats :points_of_interest :visibility_type]))]
+                                  :present [:description :visibility_type]))]
     (api/check-500 (pos? (t2/update! Table id changes))))
   (let [updated-table        (t2/select-one Table :id id)
         changed-field-order? (not= (:field_order updated-table) (:field_order existing-table))]
@@ -101,14 +101,12 @@
 #_{:clj-kondo/ignore [:deprecated-var]}
 (api/defendpoint-schema PUT "/:id"
   "Update `Table` with ID."
-  [id :as {{:keys [display_name entity_type visibility_type description caveats points_of_interest
+  [id :as {{:keys [display_name entity_type visibility_type description
                    show_in_getting_started field_order], :as body} :body}]
   {display_name            (s/maybe su/NonBlankString)
    entity_type             (s/maybe su/EntityTypeKeywordOrString)
    visibility_type         (s/maybe TableVisibilityType)
    description             (s/maybe s/Str)
-   caveats                 (s/maybe s/Str)
-   points_of_interest      (s/maybe s/Str)
    show_in_getting_started (s/maybe s/Bool)
    field_order             (s/maybe FieldOrder)}
   (first (update-tables! [id] body)))
@@ -116,15 +114,13 @@
 #_{:clj-kondo/ignore [:deprecated-var]}
 (api/defendpoint-schema PUT "/"
   "Update all `Table` in `ids`."
-  [:as {{:keys [ids display_name entity_type visibility_type description caveats points_of_interest
+  [:as {{:keys [ids display_name entity_type visibility_type description
                 show_in_getting_started], :as body} :body}]
   {ids                     (su/non-empty [su/IntGreaterThanZero])
    display_name            (s/maybe su/NonBlankString)
    entity_type             (s/maybe su/EntityTypeKeywordOrString)
    visibility_type         (s/maybe TableVisibilityType)
    description             (s/maybe s/Str)
-   caveats                 (s/maybe s/Str)
-   points_of_interest      (s/maybe s/Str)
    show_in_getting_started (s/maybe s/Bool)}
   (update-tables! ids body))
 

--- a/src/metabase/models/dashboard.clj
+++ b/src/metabase/models/dashboard.clj
@@ -131,6 +131,7 @@
 (t2/define-after-select :model/Dashboard
   [dashboard]
   (-> dashboard
+      (dissoc :caveats :points_of_interest)
       public-settings/remove-public-uuid-if-public-sharing-is-disabled))
 
 (defmethod serdes/hash-fields :model/Dashboard

--- a/src/metabase/models/database.clj
+++ b/src/metabase/models/database.clj
@@ -90,7 +90,7 @@
   (letfn [(normalize-details [db]
             (binding [*normalizing-details* true]
               (driver/normalize-db-details driver db)))]
-    (cond-> database
+    (cond-> (dissoc database :caveats :points_of_interest)
       ;; TODO - this is only really needed for API responses. This should be a `hydrate` thing instead!
       (driver.impl/registered? driver)
       (assoc :features (driver.u/features driver database))

--- a/src/metabase/models/field.clj
+++ b/src/metabase/models/field.clj
@@ -161,6 +161,10 @@
   (let [defaults {:display_name (humanization/name->human-readable-name (:name field))}]
     (merge defaults field)))
 
+(t2/define-after-select :model/Field
+  [field]
+  (dissoc field :caveats :points_of_interest))
+
 ;;; Field permissions
 ;; There are several API endpoints where large instances can return many thousands of Fields. Normally Fields require
 ;; a DB call to fetch information about their Table, because a Field's permissions set is the same as its parent

--- a/src/metabase/models/metric.clj
+++ b/src/metabase/models/metric.clj
@@ -51,6 +51,10 @@
                            ::mi/entity-id    true})
   :pre-update pre-update})
 
+(t2/define-after-select :model/Metric
+  [metric]
+  (dissoc metric :caveats :points_of_interest))
+
 (mu/defn ^:private definition-description :- [:maybe ::lib.schema.common/non-blank-string]
   "Calculate a nice description of a Metric's definition."
   [metadata-provider :- lib.metadata/MetadataProvider

--- a/src/metabase/models/segment.clj
+++ b/src/metabase/models/segment.clj
@@ -51,6 +51,10 @@
   :hydration-keys (constantly [:segment])
   :pre-update     pre-update})
 
+(t2/define-after-select :model/Segment
+  [segment]
+  (dissoc segment :caveats :points_of_interest))
+
 (mu/defn ^:private definition-description :- [:maybe ::lib.schema.common/non-blank-string]
   "Calculate a nice description of a Segment's definition."
   [metadata-provider :- lib.metadata/MetadataProvider

--- a/src/metabase/models/table.clj
+++ b/src/metabase/models/table.clj
@@ -66,6 +66,10 @@
   [{:keys [db_id schema id]}]
   (t2/delete! Permissions :object [:like (str (perms/data-perms-path db_id schema id) "%")]))
 
+(t2/define-after-select :models/Table
+  [table]
+  (dissoc table :caveats :points_of_interest))
+
 (defmethod mi/perms-objects-set :model/Table
   [{db-id :db_id, schema :schema, table-id :id, :as table} read-or-write]
   ;; To read (e.g., fetch metadata) a Table you must have either self-service data permissions for the Table, or write

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -189,7 +189,6 @@
 
 (def ^:private dashboard-defaults
   {:archived                false
-   :caveats                 nil
    :collection_id           nil
    :collection_position     nil
    :collection              true
@@ -200,7 +199,6 @@
    :entity_id               true
    :made_public_by_id       nil
    :parameters              []
-   :points_of_interest      nil
    :cache_ttl               nil
    :position                nil
    :public_uuid             nil
@@ -595,24 +593,20 @@
 
 (deftest update-dashboard-guide-columns-test
   (testing "PUT /api/dashboard/:id"
-    (testing "allow `:caveats` and `:points_of_interest` to be empty strings, and `:show_in_getting_started` should be a boolean"
+    (testing "allow `:show_in_getting_started` should be a boolean"
       (mt/with-temp Dashboard [{dashboard-id :id} {:name "Test Dashboard"}]
         (with-dashboards-in-writeable-collection [dashboard-id]
           (is (= (merge dashboard-defaults {:name                    "Test Dashboard"
                                             :creator_id              (mt/user->id :rasta)
                                             :collection              false
                                             :collection_id           true
-                                            :caveats                 ""
-                                            :points_of_interest      ""
                                             :cache_ttl               1337
                                             :last-edit-info
                                             {:timestamp true, :id true, :first_name "Rasta"
                                              :last_name "Toucan", :email "rasta@metabase.com"}
                                             :show_in_getting_started true})
                  (dashboard-response (mt/user-http-request :rasta :put 200 (str "dashboard/" dashboard-id)
-                                                           {:caveats                 ""
-                                                            :points_of_interest      ""
-                                                            :cache_ttl               1337
+                                                           {:cache_ttl               1337
                                                             :show_in_getting_started true})))))))))
 
 (deftest update-dashboard-clear-description-test

--- a/test/metabase/api/field_test.clj
+++ b/test/metabase/api/field_test.clj
@@ -54,8 +54,6 @@
                                      :active                  true
                                      :id                      (mt/id :users)
                                      :db_id                   (mt/id)
-                                     :caveats                 nil
-                                     :points_of_interest      nil
                                      :show_in_getting_started false})
                  :semantic_type    "type/Name"
                  :name             "NAME"

--- a/test/metabase/api/metric_test.clj
+++ b/test/metabase/api/metric_test.clj
@@ -18,8 +18,6 @@
 (def ^:private metric-defaults
   {:description             nil
    :show_in_getting_started false
-   :caveats                 nil
-   :points_of_interest      nil
    :how_is_this_calculated  nil
    :created_at              true
    :updated_at              true
@@ -97,8 +95,6 @@
                                :crowberto :post 200 "metric" {:name                    "A Metric"
                                                               :description             "I did it!"
                                                               :show_in_getting_started false
-                                                              :caveats                 nil
-                                                              :points_of_interest      nil
                                                               :how_is_this_calculated  nil
                                                               :table_id                id
                                                               :definition              {:database 21
@@ -151,8 +147,6 @@
                 :name                    "Costa Rica"
                 :description             nil
                 :show_in_getting_started false
-                :caveats                 nil
-                :points_of_interest      nil
                 :how_is_this_calculated  nil
                 :table_id                456
                 :revision_message        "I got me some revisions"
@@ -253,8 +247,6 @@
                                               :name                    "One Metric to rule them all, one metric to define them"
                                               :description             "One metric to bring them all, and in the DataModel bind them"
                                               :show_in_getting_started false
-                                              :caveats                 nil
-                                              :points_of_interest      nil
                                               :how_is_this_calculated  nil
                                               :definition              {:database 123
                                                                         :query    {:filter [:= [:field 10 nil] 20]}}}]
@@ -310,16 +302,12 @@
                                                :name                    "One Metric to rule them all, one metric to define them"
                                                :description             "One metric to bring them all, and in the DataModel bind them"
                                                :show_in_getting_started false
-                                               :caveats                 nil
-                                               :points_of_interest      nil
                                                :how_is_this_calculated  nil
                                                :definition              {:creator_id              (mt/user->id :crowberto)
                                                                          :table_id                table-id
                                                                          :name                    "Reverted Metric Name"
                                                                          :description             nil
                                                                          :show_in_getting_started false
-                                                                         :caveats                 nil
-                                                                         :points_of_interest      nil
                                                                          :how_is_this_calculated  nil
                                                                          :definition              {:database 123
                                                                                                    :query    {:filter [:= [:field 10 nil] 20]}}}}]
@@ -330,8 +318,6 @@
                                                              :name                    "One Metric to rule them all, one metric to define them"
                                                              :description             "One metric to bring them all, and in the DataModel bind them"
                                                              :show_in_getting_started false
-                                                             :caveats                 nil
-                                                             :points_of_interest      nil
                                                              :how_is_this_calculated  nil
                                                              :definition              {:database 123
                                                                                        :query    {:filter [:= [:field 10 nil] 20]}}}
@@ -344,8 +330,6 @@
                                                           :name                    "Changed Metric Name"
                                                           :description             "One metric to bring them all, and in the DataModel bind them"
                                                           :show_in_getting_started false
-                                                          :caveats                 nil
-                                                          :points_of_interest      nil
                                                           :how_is_this_calculated  nil
                                                           :definition              {:database 123
                                                                                     :query    {:filter [:= [:field 10 nil] 20]}}}

--- a/test/metabase/api/segment_test.clj
+++ b/test/metabase/api/segment_test.clj
@@ -76,8 +76,6 @@
     (is (= {:name                    "A Segment"
             :description             "I did it!"
             :show_in_getting_started false
-            :caveats                 nil
-            :points_of_interest      nil
             :creator_id              (mt/user->id :crowberto)
             :creator                 (user-details (mt/fetch-user :crowberto))
             :entity_id               true
@@ -89,8 +87,6 @@
                                                    {:name                    "A Segment"
                                                     :description             "I did it!"
                                                     :show_in_getting_started false
-                                                    :caveats                 nil
-                                                    :points_of_interest      nil
                                                     :table_id                id
                                                     :definition              {:filter [:= [:field 10 nil] 20]}}))))))
 
@@ -132,8 +128,6 @@
       (is (= {:name                    "Costa Rica"
               :description             nil
               :show_in_getting_started false
-              :caveats                 nil
-              :points_of_interest      nil
               :creator_id              (mt/user->id :rasta)
               :creator                 (user-details (mt/fetch-user :rasta))
               :entity_id               true
@@ -148,15 +142,13 @@
                 :name                    "Costa Rica"
                 :description             nil
                 :show_in_getting_started false
-                :caveats                 nil
-                :points_of_interest      nil
                 :table_id                456
                 :revision_message        "I got me some revisions"
                 :definition              {:filter [:!= [:field 2 nil] "cans"]}})))))))
 
 (deftest partial-update-test
   (testing "PUT /api/segment/:id"
-    (testing "Can I update a segment's name without specifying `:points_of_interest` and `:show_in_getting_started`?"
+    (testing "Can I update a segment's name without specifying `:show_in_getting_started`?"
       (mt/with-temp Segment [segment]
         ;; just make sure API call doesn't barf
         (is (some? (mt/user-http-request :crowberto :put 200 (str "segment/" (u/the-id segment))
@@ -212,8 +204,6 @@
         (is (=? {:name                    "Toucans in the rainforest"
                  :description             "Lookin' for a blueberry"
                  :show_in_getting_started false
-                 :caveats                 nil
-                 :points_of_interest      nil
                  :creator_id              (mt/user->id :rasta)
                  :creator                 (user-details (mt/fetch-user :rasta))
                  :created_at              true
@@ -247,8 +237,6 @@
       (is (= {:name                    "Toucans in the rainforest"
               :description             "Lookin' for a blueberry"
               :show_in_getting_started false
-              :caveats                 nil
-              :points_of_interest      nil
               :creator_id              (mt/user->id :crowberto)
               :creator                 (user-details (mt/fetch-user :crowberto))
               :created_at              true
@@ -338,8 +326,6 @@
                                                  :name                    "One Segment to rule them all, one segment to define them"
                                                  :description             "One segment to bring them all, and in the DataModel bind them"
                                                  :show_in_getting_started false
-                                                 :caveats                 nil
-                                                 :points_of_interest      nil
                                                  :definition              {:filter [:= [:field 2 nil] "cans"]}}]
                     Revision [{revision-id :id} {:model       "Segment"
                                                  :model_id    id
@@ -348,8 +334,6 @@
                                                                :name                    "One Segment to rule them all, one segment to define them"
                                                                :description             "One segment to bring them all, and in the DataModel bind them"
                                                                :show_in_getting_started false
-                                                               :caveats                 nil
-                                                               :points_of_interest      nil
                                                                :definition              {:filter [:= [:field 2 nil] "cans"]}}
                                                  :is_creation true}]
                     Revision [_                 {:model    "Segment"
@@ -360,8 +344,6 @@
                                                             :name                    "Changed Segment Name"
                                                             :description             "One segment to bring them all, and in the DataModel bind them"
                                                             :show_in_getting_started false
-                                                            :caveats                 nil
-                                                            :points_of_interest      nil
                                                             :definition              {:filter [:= [:field 2 nil] "cans"]}}
                                                  :message  "updated"}]]
       (testing "the api response"

--- a/test/metabase/api/table_test.clj
+++ b/test/metabase/api/table_test.clj
@@ -40,8 +40,6 @@
     :is_full_sync                true
     :is_on_demand                false
     :description                 nil
-    :caveats                     nil
-    :points_of_interest          nil
     :features                    (mapv u/qualified-name (driver.u/features :h2 (mt/db)))
     :cache_field_values_schedule "0 50 0 * * ? *"
     :metadata_sync_schedule      "0 50 * * * ? *"
@@ -309,7 +307,7 @@
              (dissoc (mt/user-http-request :crowberto :get 200 (format "table/%d" (u/the-id table)))
                      :updated_at))))
     (testing "Can update description, caveat, points of interest to be empty (#11097)"
-      (doseq [property [:caveats :points_of_interest :description]]
+      (doseq [property [:description]]
         (mt/with-temp Table [table]
           (is (= ""
                  (get (mt/user-http-request :crowberto :put 200 (format "table/%d" (u/the-id table))
@@ -317,7 +315,7 @@
                       property))))))
 
     (testing "Don't change visibility_type when updating properties (#22287)"
-      (doseq [property [:caveats :points_of_interest :description :display_name]]
+      (doseq [property [:description :display_name]]
         (mt/with-temp Table [table {:visibility_type "hidden"}]
          (mt/user-http-request :crowberto :put 200 (format "table/%d" (u/the-id table))
                                                    {property (mt/random-name)})

--- a/test/metabase/events/revision_test.clj
+++ b/test/metabase/events/revision_test.clj
@@ -280,8 +280,6 @@
                                :entity_id               (:entity_id metric)
                                :how_is_this_calculated  nil
                                :show_in_getting_started false
-                               :caveats                 nil
-                               :points_of_interest      nil
                                :archived                false
                                :creator_id              (mt/user->id :rasta)
                                :definition              {:a "b"}}
@@ -310,8 +308,6 @@
                                :entity_id               (:entity_id metric)
                                :how_is_this_calculated  nil
                                :show_in_getting_started false
-                               :caveats                 nil
-                               :points_of_interest      nil
                                :archived                false
                                :creator_id              (mt/user->id :rasta)
                                :definition              {:a "b"}}
@@ -337,9 +333,7 @@
                                :description             "Lookin' for a blueberry"
                                :how_is_this_calculated  nil
                                :show_in_getting_started false
-                               :caveats                 nil
                                :entity_id               (:entity_id metric)
-                               :points_of_interest      nil
                                :archived                true
                                :creator_id              (mt/user->id :rasta)
                                :definition              {:a "b"}}
@@ -365,8 +359,6 @@
                 :object       {:name                    "Toucans in the rainforest"
                                :description             "Lookin' for a blueberry"
                                :show_in_getting_started false
-                               :caveats                 nil
-                               :points_of_interest      nil
                                :entity_id               (:entity_id segment)
                                :archived                false
                                :creator_id              (mt/user->id :rasta)
@@ -392,8 +384,6 @@
               :object       {:name                    "Toucans in the rainforest"
                              :description             "Lookin' for a blueberry"
                              :show_in_getting_started false
-                             :caveats                 nil
-                             :points_of_interest      nil
                              :entity_id               (:entity_id segment)
                              :archived                false
                              :creator_id              (mt/user->id :rasta)
@@ -421,8 +411,6 @@
               :object       {:name                    "Toucans in the rainforest"
                              :description             "Lookin' for a blueberry"
                              :show_in_getting_started false
-                             :caveats                 nil
-                             :points_of_interest      nil
                              :entity_id               (:entity_id segment)
                              :archived                true
                              :creator_id              (mt/user->id :rasta)

--- a/test/metabase/lib/temporal_bucket_test.cljc
+++ b/test/metabase/lib/temporal_bucket_test.cljc
@@ -81,7 +81,6 @@
                 :lib/source :source/fields
                 :lib/source-column-alias "CREATED_AT"
                 :settings nil
-                :caveats nil
                 :nfc-path nil
                 :database-type "TIMESTAMP WITH TIME ZONE"
                 :effective-type :type/DateTimeWithLocalTZ
@@ -90,7 +89,6 @@
                 :active true
                 :id 3068
                 :parent-id nil
-                :points-of-interest nil
                 :visibility-type :normal
                 :lib/desired-column-alias "CREATED_AT"
                 :display-name "Created At"

--- a/test/metabase/lib/test_metadata.cljc
+++ b/test/metabase/lib/test_metadata.cljc
@@ -145,7 +145,6 @@
    :fingerprint-version 0
    :has-field-values    :none
    :settings            nil
-   :caveats             nil
    :fk-target-field-id  nil
    :custom-position     0
    :effective-type      :type/BigInteger
@@ -162,7 +161,6 @@
    :database-required   false
    :fingerprint         nil
    :base-type           :type/BigInteger
-   :points-of-interest  nil
    :lib/type            :metadata/field})
 
 (defmethod field-metadata [:categories :name]
@@ -176,7 +174,6 @@
    :fingerprint-version 5
    :has-field-values    :list
    :settings            nil
-   :caveats             nil
    :fk-target-field-id  nil
    :custom-position     0
    :effective-type      :type/Text
@@ -199,7 +196,6 @@
                          :percent-state  0.0
                          :average-length 8.333333333333334}}}
    :base-type           :type/Text
-   :points-of-interest  nil
    :lib/type            :metadata/field})
 
 (defmethod table-metadata :categories
@@ -211,7 +207,6 @@
    :name                    "CATEGORIES"
    :fields                  [(field-metadata :categories :id)
                              (field-metadata :categories :name)]
-   :caveats                 nil
    :segments                []
    :active                  true
    :id                      (id :categories)
@@ -221,7 +216,6 @@
    :initial-sync-status     "complete"
    :display-name            "Categories"
    :metrics                 []
-   :points-of-interest      nil
    :lib/type                :metadata/table})
 
 (defmethod field-metadata [:checkins :id]
@@ -235,7 +229,6 @@
    :fingerprint-version 0
    :has-field-values    :none
    :settings            nil
-   :caveats             nil
    :fk-target-field-id  nil
    :custom-position     0
    :effective-type      :type/BigInteger
@@ -252,7 +245,6 @@
    :database-required   false
    :fingerprint         nil
    :base-type           :type/BigInteger
-   :points-of-interest  nil
    :lib/type            :metadata/field})
 
 (defmethod field-metadata [:checkins :date]
@@ -266,7 +258,6 @@
    :fingerprint-version 5
    :has-field-values    :none
    :settings            nil
-   :caveats             nil
    :fk-target-field-id  nil
    :custom-position     0
    :effective-type      :type/Date
@@ -284,7 +275,6 @@
    :fingerprint         {:global {:distinct-count 618, :nil% 0.0}
                          :type   #:type{:DateTime {:earliest "2013-01-03", :latest "2015-12-29"}}}
    :base-type           :type/Date
-   :points-of-interest  nil
    :lib/type            :metadata/field})
 
 (defmethod field-metadata [:checkins :user-id]
@@ -298,7 +288,6 @@
    :fingerprint-version 5
    :has-field-values    :none
    :settings            nil
-   :caveats             nil
    :fk-target-field-id  (id :users :id)
    :custom-position     0
    :effective-type      :type/Integer
@@ -315,7 +304,6 @@
    :database-required   false
    :fingerprint         {:global {:distinct-count 15, :nil% 0.0}}
    :base-type           :type/Integer
-   :points-of-interest  nil
    :lib/type            :metadata/field})
 
 (defmethod field-metadata [:checkins :venue-id]
@@ -329,7 +317,6 @@
    :fingerprint-version 5
    :has-field-values    :none
    :settings            nil
-   :caveats             nil
    :fk-target-field-id  (id :venues :id)
    :custom-position     0
    :effective-type      :type/Integer
@@ -346,7 +333,6 @@
    :database-required   false
    :fingerprint         {:global {:distinct-count 100, :nil% 0.0}}
    :base-type           :type/Integer
-   :points-of-interest  nil
    :lib/type            :metadata/field})
 
 (defmethod table-metadata :checkins
@@ -360,7 +346,6 @@
                              (field-metadata :checkins :date)
                              (field-metadata :checkins :user-id)
                              (field-metadata :checkins :venue-id)]
-   :caveats                 nil
    :segments                []
    :active                  true
    :id                      (id :checkins)
@@ -370,7 +355,6 @@
    :initial-sync-status     "complete"
    :display-name            "Checkins"
    :metrics                 []
-   :points-of-interest      nil
    :lib/type                :metadata/table})
 
 (defmethod field-metadata [:users :id]
@@ -384,7 +368,6 @@
    :fingerprint-version 0
    :has-field-values    :none
    :settings            nil
-   :caveats             nil
    :fk-target-field-id  nil
    :custom-position     0
    :effective-type      :type/BigInteger
@@ -401,7 +384,6 @@
    :database-required   false
    :fingerprint         nil
    :base-type           :type/BigInteger
-   :points-of-interest  nil
    :lib/type            :metadata/field})
 
 (defmethod field-metadata [:users :name]
@@ -415,7 +397,6 @@
    :fingerprint-version 5
    :has-field-values    :list
    :settings            nil
-   :caveats             nil
    :fk-target-field-id  nil
    :custom-position     0
    :effective-type      :type/Text
@@ -438,7 +419,6 @@
                                          :percent-state  0.0
                                          :average-length 13.266666666666667}}}
    :base-type           :type/Text
-   :points-of-interest  nil
    :lib/type            :metadata/field})
 
 (defmethod field-metadata [:users :last-login]
@@ -452,7 +432,6 @@
    :fingerprint-version 5
    :has-field-values    :none
    :settings            nil
-   :caveats             nil
    :fk-target-field-id  nil
    :custom-position     0
    :effective-type      :type/DateTime
@@ -470,7 +449,6 @@
    :fingerprint         {:global {:distinct-count 15, :nil% 0.0}
                          :type   #:type{:DateTime {:earliest "2014-01-01T08:30:00Z", :latest "2014-12-05T15:15:00Z"}}}
    :base-type           :type/DateTime
-   :points-of-interest  nil
    :lib/type            :metadata/field})
 
 (defmethod field-metadata [:users :password]
@@ -484,7 +462,6 @@
    :fingerprint-version 5
    :has-field-values    :list
    :settings            nil
-   :caveats             nil
    :fk-target-field-id  nil
    :custom-position     0
    :effective-type      :type/Text
@@ -507,7 +484,6 @@
                                          :percent-state  0.0
                                          :average-length 36.0}}}
    :base-type           :type/Text
-   :points-of-interest  nil
    :lib/type            :metadata/field})
 
 (defmethod table-metadata :users
@@ -521,7 +497,6 @@
                              (field-metadata :users :name)
                              (field-metadata :users :last-login)
                              (field-metadata :users :password)]
-   :caveats                 nil
    :segments                []
    :active                  true
    :id                      (id :users)
@@ -531,7 +506,6 @@
    :initial-sync-status     "complete"
    :display-name            "Users"
    :metrics                 []
-   :points-of-interest      nil
    :lib/type                :metadata/table})
 
 (defmethod field-metadata [:venues :id]
@@ -545,7 +519,6 @@
    :fingerprint-version 0
    :has-field-values    :none
    :settings            nil
-   :caveats             nil
    :fk-target-field-id  nil
    :custom-position     0
    :effective-type      :type/BigInteger
@@ -562,7 +535,6 @@
    :database-required   false
    :fingerprint         nil
    :base-type           :type/BigInteger
-   :points-of-interest  nil
    :lib/type            :metadata/field})
 
 (defmethod field-metadata [:venues :name]
@@ -576,7 +548,6 @@
    :fingerprint-version 5
    :has-field-values    :list
    :settings            nil
-   :caveats             nil
    :fk-target-field-id  nil
    :custom-position     0
    :effective-type      :type/Text
@@ -599,7 +570,6 @@
                                          :percent-state  0.0
                                          :average-length 15.63}}}
    :base-type           :type/Text
-   :points-of-interest  nil
    :lib/type            :metadata/field})
 
 (defmethod field-metadata [:venues :category-id]
@@ -613,7 +583,6 @@
    :fingerprint-version 5
    :has-field-values    :none
    :settings            nil
-   :caveats             nil
    :fk-target-field-id  (id :categories :id)
    :custom-position     0
    :effective-type      :type/Integer
@@ -630,7 +599,6 @@
    :database-required   false
    :fingerprint         {:global {:distinct-count 28, :nil% 0.0}}
    :base-type           :type/Integer
-   :points-of-interest  nil
    :lib/type            :metadata/field})
 
 (defmethod field-metadata [:venues :latitude]
@@ -644,7 +612,6 @@
    :fingerprint-version 5
    :has-field-values    :none
    :settings            nil
-   :caveats             nil
    :fk-target-field-id  nil
    :custom-position     0
    :effective-type      :type/Float
@@ -668,7 +635,6 @@
                                          :sd  3.4346725397190827
                                          :avg 35.505891999999996}}}
    :base-type           :type/Float
-   :points-of-interest  nil
    :lib/type            :metadata/field})
 
 (defmethod field-metadata [:venues :longitude]
@@ -682,7 +648,6 @@
    :fingerprint-version 5
    :has-field-values    :none
    :settings            nil
-   :caveats             nil
    :fk-target-field-id  nil
    :custom-position     0
    :effective-type      :type/Float
@@ -708,7 +673,6 @@
             :sd  14.162810671348238
             :avg -115.99848699999998}}}
    :base-type           :type/Float
-   :points-of-interest  nil
    :lib/type            :metadata/field})
 
 (defmethod field-metadata [:venues :price]
@@ -722,7 +686,6 @@
    :fingerprint-version 5
    :has-field-values    :list
    :settings            {:is_priceless true}
-   :caveats             nil
    :fk-target-field-id  nil
    :custom-position     0
    :effective-type      :type/Integer
@@ -746,7 +709,6 @@
                                          :sd  0.7713951678941896
                                          :avg 2.03}}}
    :base-type           :type/Integer
-   :points-of-interest  nil
    :lib/type            :metadata/field})
 
 (defmethod table-metadata :venues
@@ -762,7 +724,6 @@
                              (field-metadata :venues :latitude)
                              (field-metadata :venues :longitude)
                              (field-metadata :venues :price)]
-   :caveats                 nil
    :segments                []
    :active                  true
    :id                      (id :venues)
@@ -772,7 +733,6 @@
    :initial-sync-status     "complete"
    :display-name            "Venues"
    :metrics                 []
-   :points-of-interest      nil
    :lib/type                :metadata/table})
 
  (defmethod field-metadata [:products :id]
@@ -786,7 +746,6 @@
     :fingerprint-version        0
     :has-field-values           nil
     :settings                   nil
-    :caveats                    nil
     :fk-target-field-id         nil
     :custom-position            0
     :effective-type             :type/BigInteger
@@ -803,7 +762,6 @@
     :database-required          false
     :fingerprint                nil
     :base-type                  :type/BigInteger
-    :points-of-interest         nil
     :lib/type                   :metadata/field})
 
 (defmethod field-metadata [:products :rating]
@@ -817,7 +775,6 @@
    :fingerprint-version        5
    :has-field-values           nil
    :settings                   nil
-   :caveats                    nil
    :fk-target-field-id         nil
    :custom-position            0
    :effective-type             :type/Float
@@ -840,7 +797,6 @@
                                                        :sd  1.3605488657451452
                                                        :avg 3.4715}}}
    :base-type                  :type/Float
-   :points-of-interest         nil
    :lib/type                   :metadata/field})
 
  (defmethod field-metadata [:products :category]
@@ -854,7 +810,6 @@
     :fingerprint-version        5
     :has-field-values           :auto-list
     :settings                   nil
-    :caveats                    nil
     :fk-target-field-id         nil
     :custom-position            0
     :effective-type             :type/Text
@@ -876,7 +831,6 @@
                                                       :percent-state  0.0
                                                       :average-length 6.375}}}
     :base-type                  :type/Text
-    :points-of-interest         nil
     :lib/type                   :metadata/field})
 
 (defmethod field-metadata [:products :price]
@@ -890,7 +844,6 @@
    :fingerprint-version        5
    :has-field-values           nil
    :settings                   nil
-   :caveats                    nil
    :fk-target-field-id         nil
    :custom-position            0
    :effective-type             :type/Float
@@ -913,7 +866,6 @@
                                                        :sd  21.711152906916283
                                                        :avg 55.746399999999994}}}
    :base-type                  :type/Float
-   :points-of-interest         nil
    :lib/type                   :metadata/field})
 
  (defmethod field-metadata [:products :title]
@@ -927,7 +879,6 @@
     :fingerprint-version        5
     :has-field-values           :auto-list
     :settings                   nil
-    :caveats                    nil
     :fk-target-field-id         nil
     :custom-position            0
     :effective-type             :type/Text
@@ -949,7 +900,6 @@
                                                       :percent-state  0.0
                                                       :average-length 21.495}}}
     :base-type                  :type/Text
-    :points-of-interest         nil
     :lib/type                   :metadata/field})
 
 (defmethod field-metadata [:products :created-at]
@@ -963,7 +913,6 @@
    :fingerprint-version        5
    :has-field-values           nil
    :settings                   nil
-   :caveats                    nil
    :fk-target-field-id         nil
    :custom-position            0
    :effective-type             :type/DateTimeWithLocalTZ
@@ -982,7 +931,6 @@
                                 :type   {:type/DateTime {:earliest "2016-04-26T19:29:55.147Z"
                                                          :latest   "2019-04-15T13:34:19.931Z"}}}
    :base-type                  :type/DateTimeWithLocalTZ
-   :points-of-interest         nil
    :lib/type                   :metadata/field})
 
 (defmethod field-metadata [:products :vendor]
@@ -996,7 +944,6 @@
    :fingerprint-version        5
    :has-field-values           :auto-list
    :settings                   nil
-   :caveats                    nil
    :fk-target-field-id         nil
    :custom-position            0
    :effective-type             :type/Text
@@ -1018,7 +965,6 @@
                                                      :percent-state  0.0
                                                      :average-length 20.6}}}
    :base-type                  :type/Text
-   :points-of-interest         nil
    :lib/type                   :metadata/field})
 
 (defmethod field-metadata [:products :ean]
@@ -1032,7 +978,6 @@
    :fingerprint-version        5
    :has-field-values           :auto-list
    :settings                   nil
-   :caveats                    nil
    :fk-target-field-id         nil
    :custom-position            0
    :effective-type             :type/Text
@@ -1054,7 +999,6 @@
                                                      :percent-state  0.0
                                                      :average-length 13.0}}}
    :base-type                  :type/Text
-   :points-of-interest         nil
    :lib/type                   :metadata/field})
 
 (defmethod table-metadata :products
@@ -1064,7 +1008,6 @@
    :schema                  "PUBLIC"
    :show-in-getting-started false
    :name                    "PRODUCTS"
-   :caveats                 nil
    :active                  true
    :id                      (id :products)
    :db-id                   (id)
@@ -1072,7 +1015,6 @@
    :field-order             :database
    :initial-sync-status     "complete"
    :display-name            "Products"
-   :points-of-interest      nil
    :lib/type                :metadata/table
    :fields                  [(field-metadata :products :id)
                              (field-metadata :products :rating)
@@ -1094,7 +1036,6 @@
    :fingerprint-version        0
    :has-field-values           nil
    :settings                   nil
-   :caveats                    nil
    :fk-target-field-id         nil
    :custom-position            0
    :effective-type             :type/BigInteger
@@ -1111,7 +1052,6 @@
    :database-required          false
    :fingerprint                nil
    :base-type                  :type/BigInteger
-   :points-of-interest         nil
    :lib/type                   :metadata/field})
 
 (defmethod field-metadata [:orders :subtotal]
@@ -1125,7 +1065,6 @@
    :fingerprint-version        5
    :has-field-values           nil
    :settings                   nil
-   :caveats                    nil
    :fk-target-field-id         nil
    :custom-position            0
    :effective-type             :type/Float
@@ -1149,7 +1088,6 @@
                                           :sd  32.536819823931104
                                           :avg 77.012717}}}
    :base-type                  :type/Float
-   :points-of-interest         nil
    :lib/type                   :metadata/field})
 
 (defmethod field-metadata [:orders :total]
@@ -1163,7 +1101,6 @@
    :fingerprint-version        5
    :has-field-values           nil
    :settings                   nil
-   :caveats                    nil
    :fk-target-field-id         nil
    :custom-position            0
    :effective-type             :type/Float
@@ -1187,7 +1124,6 @@
                                           :sd  34.264752087910324
                                           :avg 80.35850400000001}}}
    :base-type                  :type/Float
-   :points-of-interest         nil
    :lib/type                   :metadata/field})
 
 (defmethod field-metadata [:orders :tax]
@@ -1201,7 +1137,6 @@
    :fingerprint-version        5
    :has-field-values           nil
    :settings                   nil
-   :caveats                    nil
    :fk-target-field-id         nil
    :custom-position            0
    :effective-type             :type/Float
@@ -1225,7 +1160,6 @@
                                           :sd  2.3206651358900316
                                           :avg 3.8722100000000004}}}
    :base-type                  :type/Float
-   :points-of-interest         nil
    :lib/type                   :metadata/field})
 
 (defmethod field-metadata [:orders :discount]
@@ -1239,7 +1173,6 @@
    :fingerprint-version        5
    :has-field-values           nil
    :settings                   nil
-   :caveats                    nil
    :fk-target-field-id         nil
    :custom-position            0
    :effective-type             :type/Float
@@ -1262,7 +1195,6 @@
                                                        :sd  3.053736975739119
                                                        :avg 5.161009803921569}}}
    :base-type                  :type/Float
-   :points-of-interest         nil
    :lib/type                   :metadata/field})
 
 (defmethod field-metadata [:orders :quantity]
@@ -1276,7 +1208,6 @@
    :fingerprint-version        5
    :has-field-values           :auto-list
    :settings                   nil
-   :caveats                    nil
    :fk-target-field-id         nil
    :custom-position            0
    :effective-type             :type/Integer
@@ -1299,7 +1230,6 @@
                                                        :sd  4.214258386403798
                                                        :avg 3.7015}}}
    :base-type                  :type/Integer
-   :points-of-interest         nil
    :lib/type                   :metadata/field})
 
 (defmethod field-metadata [:orders :created-at]
@@ -1313,7 +1243,6 @@
    :fingerprint-version        5
    :has-field-values           nil
    :settings                   nil
-   :caveats                    nil
    :fk-target-field-id         nil
    :custom-position            0
    :effective-type             :type/DateTimeWithLocalTZ
@@ -1332,7 +1261,6 @@
                                 :type   {:type/DateTime {:earliest "2016-04-30T18:56:13.352Z"
                                                          :latest   "2020-04-19T14:07:15.657Z"}}}
    :base-type                  :type/DateTimeWithLocalTZ
-   :points-of-interest         nil
    :lib/type                   :metadata/field})
 
 (defmethod field-metadata [:orders :product-id]
@@ -1346,7 +1274,6 @@
    :fingerprint-version        5
    :has-field-values           nil
    :settings                   nil
-   :caveats                    nil
    :fk-target-field-id         (id :products :id)
    :custom-position            0
    :effective-type             :type/Integer
@@ -1363,7 +1290,6 @@
    :database-required          false
    :fingerprint                {:global {:distinct-count 200, :nil% 0.0}}
    :base-type                  :type/Integer
-   :points-of-interest         nil
    :lib/type                   :metadata/field})
 
 (defmethod field-metadata [:orders :user-id]
@@ -1377,7 +1303,6 @@
    :fingerprint-version        5
    :has-field-values           nil
    :settings                   nil
-   :caveats                    nil
    :fk-target-field-id         (id :people :id)
    :custom-position            0
    :effective-type             :type/Integer
@@ -1394,7 +1319,6 @@
    :database-required          false
    :fingerprint                {:global {:distinct-count 929, :nil% 0.0}}
    :base-type                  :type/Integer
-   :points-of-interest         nil
    :lib/type                   :metadata/field})
 
 (defmethod table-metadata :orders
@@ -1404,7 +1328,6 @@
    :schema                  "PUBLIC"
    :show-in-getting-started false
    :name                    "ORDERS"
-   :caveats                 nil
    :active                  true
    :id                      (id :orders)
    :db-id                   (id)
@@ -1412,7 +1335,6 @@
    :field-order             :database
    :initial-sync-status     "complete"
    :display-name            "Orders"
-   :points-of-interest      nil
    :lib/type                :metadata/table
    :fields                  [(field-metadata :orders :id)
                              (field-metadata :orders :subtotal)
@@ -1435,7 +1357,6 @@
    :fingerprint-version        0
    :has-field-values           nil
    :settings                   nil
-   :caveats                    nil
    :fk-target-field-id         nil
    :custom-position            0
    :effective-type             :type/BigInteger
@@ -1452,7 +1373,6 @@
    :database-required          false
    :fingerprint                nil
    :base-type                  :type/BigInteger
-   :points-of-interest         nil
    :lib/type                   :metadata/field})
 
 (defmethod field-metadata [:people :state]
@@ -1466,7 +1386,6 @@
    :fingerprint-version        5
    :has-field-values           :auto-list
    :settings                   nil
-   :caveats                    nil
    :fk-target-field-id         nil
    :custom-position            0
    :effective-type             :type/Text
@@ -1488,7 +1407,6 @@
                                                      :percent-state  1.0
                                                      :average-length 2.0}}}
    :base-type                  :type/Text
-   :points-of-interest         nil
    :lib/type                   :metadata/field})
 
 (defmethod field-metadata [:people :city]
@@ -1502,7 +1420,6 @@
    :fingerprint-version        5
    :has-field-values           nil
    :settings                   nil
-   :caveats                    nil
    :fk-target-field-id         nil
    :custom-position            0
    :effective-type             :type/Text
@@ -1524,7 +1441,6 @@
                                                      :percent-state  0.002
                                                      :average-length 8.284}}}
    :base-type                  :type/Text
-   :points-of-interest         nil
    :lib/type                   :metadata/field})
 
 (defmethod field-metadata [:people :address]
@@ -1538,7 +1454,6 @@
    :fingerprint-version        5
    :has-field-values           nil
    :settings                   nil
-   :caveats                    nil
    :fk-target-field-id         nil
    :custom-position            0
    :effective-type             :type/Text
@@ -1560,7 +1475,6 @@
                                                      :percent-state  0.0
                                                      :average-length 20.85}}}
    :base-type                  :type/Text
-   :points-of-interest         nil
    :lib/type                   :metadata/field})
 
 (defmethod field-metadata [:people :name]
@@ -1574,7 +1488,6 @@
    :fingerprint-version        5
    :has-field-values           nil
    :settings                   nil
-   :caveats                    nil
    :fk-target-field-id         nil
    :custom-position            0
    :effective-type             :type/Text
@@ -1596,7 +1509,6 @@
                                                      :percent-state  0.0
                                                      :average-length 13.532}}}
    :base-type                  :type/Text
-   :points-of-interest         nil
    :lib/type                   :metadata/field})
 
 (defmethod field-metadata [:people :source]
@@ -1610,7 +1522,6 @@
    :fingerprint-version        5
    :has-field-values           :auto-list
    :settings                   nil
-   :caveats                    nil
    :fk-target-field-id         nil
    :custom-position            0
    :effective-type             :type/Text
@@ -1632,7 +1543,6 @@
                                                      :percent-state  0.0
                                                      :average-length 7.4084}}}
    :base-type                  :type/Text
-   :points-of-interest         nil
    :lib/type                   :metadata/field})
 
 (defmethod field-metadata [:people :zip]
@@ -1646,7 +1556,6 @@
    :fingerprint-version        5
    :has-field-values           nil
    :settings                   nil
-   :caveats                    nil
    :fk-target-field-id         nil
    :custom-position            0
    :effective-type             :type/Text
@@ -1668,7 +1577,6 @@
                                                      :percent-state  0.0
                                                      :average-length 5.0}}}
    :base-type                  :type/Text
-   :points-of-interest         nil
    :lib/type                   :metadata/field})
 
 (defmethod field-metadata [:people :latitude]
@@ -1682,7 +1590,6 @@
    :fingerprint-version        5
    :has-field-values           nil
    :settings                   nil
-   :caveats                    nil
    :fk-target-field-id         nil
    :custom-position            0
    :effective-type             :type/Float
@@ -1705,7 +1612,6 @@
                                                        :sd  6.390832341883712
                                                        :avg 39.87934670484002}}}
    :base-type                  :type/Float
-   :points-of-interest         nil
    :lib/type                   :metadata/field})
 
 (defmethod field-metadata [:people :password]
@@ -1719,7 +1625,6 @@
    :fingerprint-version        5
    :has-field-values           nil
    :settings                   nil
-   :caveats                    nil
    :fk-target-field-id         nil
    :custom-position            0
    :effective-type             :type/Text
@@ -1741,7 +1646,6 @@
                                                      :percent-state  0.0
                                                      :average-length 36.0}}}
    :base-type                  :type/Text
-   :points-of-interest         nil
    :lib/type                   :metadata/field})
 
 (defmethod field-metadata [:people :birth-date]
@@ -1755,7 +1659,6 @@
    :fingerprint-version        5
    :has-field-values           nil
    :settings                   nil
-   :caveats                    nil
    :fk-target-field-id         nil
    :custom-position            0
    :effective-type             :type/Date
@@ -1774,7 +1677,6 @@
    {:global {:distinct-count 2308, :nil% 0.0}
     :type   {:type/DateTime {:earliest "1958-04-26", :latest "2000-04-03"}}}
    :base-type                  :type/Date
-   :points-of-interest         nil
    :lib/type                   :metadata/field})
 
 (defmethod field-metadata [:people :longitude]
@@ -1788,7 +1690,6 @@
    :fingerprint-version        5
    :has-field-values           nil
    :settings                   nil
-   :caveats                    nil
    :fk-target-field-id         nil
    :custom-position            0
    :effective-type             :type/Float
@@ -1811,7 +1712,6 @@
                                                        :sd  15.399698968175663
                                                        :avg -95.18741780363999}}}
    :base-type                  :type/Float
-   :points-of-interest         nil
    :lib/type                   :metadata/field})
 
 (defmethod field-metadata [:people :email]
@@ -1825,7 +1725,6 @@
    :fingerprint-version        5
    :has-field-values           nil
    :settings                   nil
-   :caveats                    nil
    :fk-target-field-id         nil
    :custom-position            0
    :effective-type             :type/Text
@@ -1847,7 +1746,6 @@
                                                      :percent-state  0.0
                                                      :average-length 24.1824}}}
    :base-type                  :type/Text
-   :points-of-interest         nil
    :lib/type                   :metadata/field})
 
 (defmethod field-metadata [:people :created-at]
@@ -1861,7 +1759,6 @@
    :fingerprint-version        5
    :has-field-values           nil
    :settings                   nil
-   :caveats                    nil
    :fk-target-field-id         nil
    :custom-position            0
    :effective-type             :type/DateTimeWithLocalTZ
@@ -1880,7 +1777,6 @@
                                 :type   {:type/DateTime {:earliest "2016-04-19T21:35:18.752Z"
                                                          :latest   "2019-04-19T14:06:27.3Z"}}}
    :base-type                  :type/DateTimeWithLocalTZ
-   :points-of-interest         nil
    :lib/type                   :metadata/field})
 
 (defmethod table-metadata :people
@@ -1890,7 +1786,6 @@
    :schema                  "PUBLIC"
    :show-in-getting-started false
    :name                    "PEOPLE"
-   :caveats                 nil
    :active                  true
    :id                      (id :people)
    :db-id                   (id)
@@ -1898,7 +1793,6 @@
    :field-order             :database
    :initial-sync-status     "complete"
    :display-name            "People"
-   :points-of-interest      nil
    :lib/type                :metadata/table
    :fields                  [(field-metadata :people :id)
                              (field-metadata :people :state)
@@ -1925,7 +1819,6 @@
    :fingerprint-version        0
    :has-field-values           nil
    :settings                   nil
-   :caveats                    nil
    :fk-target-field-id         nil
    :custom-position            0
    :effective-type             :type/BigInteger
@@ -1942,7 +1835,6 @@
    :database-required          false
    :fingerprint                nil
    :base-type                  :type/BigInteger
-   :points-of-interest         nil
    :lib/type                   :metadata/field})
 
 (defmethod field-metadata [:reviews :created-at]
@@ -1956,7 +1848,6 @@
    :fingerprint-version        5
    :has-field-values           nil
    :settings                   nil
-   :caveats                    nil
    :fk-target-field-id         nil
    :custom-position            0
    :effective-type             :type/DateTimeWithLocalTZ
@@ -1975,7 +1866,6 @@
                                 :type   {:type/DateTime {:earliest "2016-06-03T00:37:05.818Z"
                                                          :latest   "2020-04-19T14:15:25.677Z"}}}
    :base-type                  :type/DateTimeWithLocalTZ
-   :points-of-interest         nil
    :lib/type                   :metadata/field})
 
 (defmethod field-metadata [:reviews :rating]
@@ -1989,7 +1879,6 @@
    :fingerprint-version        5
    :has-field-values           :auto-list
    :settings                   nil
-   :caveats                    nil
    :fk-target-field-id         nil
    :custom-position            0
    :effective-type             :type/Integer
@@ -2012,7 +1901,6 @@
                                                        :sd  1.0443899855660577
                                                        :avg 3.987410071942446}}}
    :base-type                  :type/Integer
-   :points-of-interest         nil
    :lib/type                   :metadata/field})
 
 (defmethod field-metadata [:reviews :reviewer]
@@ -2026,7 +1914,6 @@
    :fingerprint-version        5
    :has-field-values           nil
    :settings                   nil
-   :caveats                    nil
    :fk-target-field-id         nil
    :custom-position            0
    :effective-type             :type/Text
@@ -2048,7 +1935,6 @@
                                                      :percent-state  0.001798561151079137
                                                      :average-length 9.972122302158274}}}
    :base-type                  :type/Text
-   :points-of-interest         nil
    :lib/type                   :metadata/field})
 
 (defmethod field-metadata [:reviews :body]
@@ -2062,7 +1948,6 @@
    :fingerprint-version        5
    :has-field-values           nil
    :settings                   nil
-   :caveats                    nil
    :fk-target-field-id         nil
    :custom-position            0
    :effective-type             :type/Text
@@ -2084,7 +1969,6 @@
                                                      :percent-state  0.0
                                                      :average-length 177.41996402877697}}}
    :base-type                  :type/Text
-   :points-of-interest         nil
    :lib/type                   :metadata/field})
 
 (defmethod field-metadata [:reviews :product-id]
@@ -2098,7 +1982,6 @@
    :fingerprint-version        5
    :has-field-values           nil
    :settings                   nil
-   :caveats                    nil
    :fk-target-field-id         (id :products :id)
    :custom-position            0
    :effective-type             :type/Integer
@@ -2115,7 +1998,6 @@
    :database-required          false
    :fingerprint                {:global {:distinct-count 176, :nil% 0.0}}
    :base-type                  :type/Integer
-   :points-of-interest         nil
    :lib/type                   :metadata/field})
 
 (defmethod table-metadata :reviews
@@ -2125,7 +2007,6 @@
    :schema                  "PUBLIC"
    :show-in-getting-started false
    :name                    "REVIEWS"
-   :caveats                 nil
    :active                  true
    :id                      (id :reviews)
    :db-id                   (id)
@@ -2133,7 +2014,6 @@
    :field-order             :database
    :initial-sync-status     "complete"
    :display-name            "Reviews"
-   :points-of-interest      nil
    :lib/type                :metadata/table
    :fields                  [(field-metadata :reviews :id)
                              (field-metadata :reviews :created-at)
@@ -2176,7 +2056,6 @@
    :metadata-sync-schedule      "0 50 * * * ? *"
    :name                        "test-data"
    :settings                    nil
-   :caveats                     nil
    :tables                      [(table-metadata :categories)
                                  (table-metadata :checkins)
                                  (table-metadata :users)
@@ -2196,7 +2075,6 @@
    :initial-sync-status         "complete"
    :dbms-version                {:flavor "H2", :version "2.1.212 (2022-04-09)", :semantic-version [2 1]}
    :refingerprint               nil
-   :points-of-interest          nil
    :lib/type                    :metadata/database})
 
 (def metadata-provider

--- a/test/metabase/models/metric_test.clj
+++ b/test/metabase/models/metric_test.clj
@@ -17,8 +17,6 @@
   {:description             nil
    :how_is_this_calculated  nil
    :show_in_getting_started false
-   :caveats                 nil
-   :points_of_interest      nil
    :archived                false
    :entity_id               true
    :definition              nil})

--- a/test/metabase/models/segment_test.clj
+++ b/test/metabase/models/segment_test.clj
@@ -44,8 +44,6 @@
             :name                    "Toucans in the rainforest"
             :description             "Lookin' for a blueberry"
             :show_in_getting_started false
-            :caveats                 nil
-            :points_of_interest      nil
             :entity_id               (:entity_id segment)
             :definition              {:filter [:> [:field 4 nil] "2014-10-19"]}
             :archived                false}

--- a/test/metabase/test/mock/util.clj
+++ b/test/metabase/test/mock/util.clj
@@ -3,8 +3,6 @@
 (def table-defaults
   {:description             nil
    :entity_type             nil
-   :caveats                 nil
-   :points_of_interest      nil
    :show_in_getting_started false
    :schema                  nil
    :fields                  []
@@ -19,8 +17,6 @@
 (def field-defaults
   {:description        nil
    :table_id           true
-   :caveats            nil
-   :points_of_interest nil
    :fk_target_field_id false
    :database_is_auto_increment false
    :updated_at         true


### PR DESCRIPTION
Resolves the BE part of https://github.com/metabase/metabase/issues/31203

The Data Reference at `/reference` was the only part of the UI that references `points_of_interest` and `caveats` fields for metrics, segments, dashboards, tables, fields, and databases. It has been removed from the FE (PR:  https://github.com/metabase/metabase/pull/30709). This PR removes almost all of the BE code related to these fields, but keeps the data intact in the database in case we want to create a new data reference UI.

There are no other changes required, since all the endpoints used by the data reference pane are still in use by other parts of the UI.

[Slack context](https://metaboat.slack.com/archives/C01NT034X2B/p1683826153102389)

Note to self: this PR contains changes adding `caveats` and `points_of_interest` references https://github.com/metabase/metabase/pull/31118. Needs checking before merging this PR.