### PR TITLE
Set primary key of implicit_action table to action_id

### DIFF
--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -14842,7 +14842,7 @@ databaseChangeLog:
   - changeSet:
       id: v47.00-037
       author: calherries
-      comment: Added 0.47.0 - Set primary key to action_id for implicit_action table
+      comment: Added 0.47.0 - Add foreign key constraint on implicit_action.action_id
       changes:
         - addForeignKeyConstraint:
             baseTableName: implicit_action

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -14812,14 +14812,22 @@ databaseChangeLog:
                   defaultValue: null
                   remarks: 'This is used to differentiate instance-analytics collections from all other collections.'
 
-- changeSet:
-    id: v47.00-035
-    author: calherries
-    comment: Added 0.47.0 - Drop foreign key constraint on implicit_action.action_id
-    changes:
-      - dropForeignKeyConstraint:
-          baseTableName: implicit_action
-          constraintName: fk_implicit_action_action_id
+  - changeSet:
+      id: v47.00-035
+      author: calherries
+      comment: Added 0.47.0 - Drop foreign key constraint on implicit_action.action_id
+      changes:
+        - dropForeignKeyConstraint:
+            baseTableName: implicit_action
+            constraintName: fk_implicit_action_action_id
+      rollback:
+        - addForeignKeyConstraint:
+            baseTableName: implicit_action
+            baseColumnNames: action_id
+            referencedTableName: action
+            referencedColumnNames: id
+            constraintName: fk_implicit_action_action_id
+            onDelete: CASCADE
 
   - changeSet:
       id: v47.00-036

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -14812,15 +14812,37 @@ databaseChangeLog:
                   defaultValue: null
                   remarks: 'This is used to differentiate instance-analytics collections from all other collections.'
 
+- changeSet:
+    id: v47.00-035
+    author: calherries
+    comment: Added 0.47.0 - Drop foreign key constraint on implicit_action.action_id
+    changes:
+      - dropForeignKeyConstraint:
+          baseTableName: implicit_action
+          constraintName: fk_implicit_action_action_id
+
   - changeSet:
-      id: v47.00-035
+      id: v47.00-036
       author: calherries
-      comment: Added 0.47.0  - Set primary key to action_id for implicit_action table
+      comment: Added 0.47.0 - Set primary key to action_id for implicit_action table
       changes:
         - addPrimaryKey:
             tableName: implicit_action
             columnNames: action_id
             constraintName: pk_implicit_action
+
+  - changeSet:
+      id: v47.00-037
+      author: calherries
+      comment: Added 0.47.0 - Set primary key to action_id for implicit_action table
+      changes:
+        - addForeignKeyConstraint:
+            baseTableName: implicit_action
+            baseColumnNames: action_id
+            referencedTableName: action
+            referencedColumnNames: id
+            constraintName: fk_implicit_action_action_id
+            onDelete: CASCADE
 
 
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -14812,6 +14812,17 @@ databaseChangeLog:
                   defaultValue: null
                   remarks: 'This is used to differentiate instance-analytics collections from all other collections.'
 
+  - changeSet:
+      id: v47.00-035
+      author: calherries
+      comment: Added 0.47.0  - Set primary key to action_id for implicit_action table
+      changes:
+        - addPrimaryKey:
+            tableName: implicit_action
+            columnNames: action_id
+            constraintName: pk_implicit_action
+
+
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################


### PR DESCRIPTION
Resolves https://github.com/metabase/metabase/issues/31140

This PR sets the PK of the `implicit_action` table to the `action_id` column.

Previously the `implicit_action` table had no primary key.