### PR TITLE
Pre-build the specific version and edition of MB

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -97,8 +97,6 @@ jobs:
       uses: ./.github/actions/prepare-backend
       with:
         m2-cache-key: pre-release-build
-    - name: Build
-      run: ./bin/build.sh
 
     - name: Determine the canonical version ## EE is always v1.x.y, OSS is always v0.x.y
       uses: actions/github-script@v6
@@ -118,13 +116,9 @@ jobs:
           }
           console.log("The canonical version of this", process.env.EDITION, "edition is", canonical_version);
           return canonical_version;
-    - name: Adjust the tag in the version.properties file
-      run: |
-        jar xf ./target/uberjar/metabase.jar version.properties
-        sed -i 's/tag=.*/tag=${{ steps.canonical_version.outputs.result }}/' version.properties
-        zip ./target/uberjar/metabase.jar version.properties
-    - name: Show the updated version.properties
-      run: echo "Updated version.properties:" && cat version.properties
+
+    - name: Build
+      run: ./bin/build.sh :edition :${{ matrix.edition }} :version ${{ steps.canonical_version.outputs.result }}
 
     - name: Prepare uberjar artifact
       uses: ./.github/actions/prepare-uberjar-artifact


### PR DESCRIPTION
Simply invoking `.bin/build.sh` will produce the uberjar without a version.
![image](https://github.com/metabase/metabase/assets/31325167/180d1805-f0ba-4e26-8dad-5b24052a4e6f)

This is why @ariya created #30915 in the first place.

But the build script already takes `:version` and `:edition` arguments. That is exactly what this PR is doing rather than manually unzipping the uberjar in order to tweak its `version.properties` file.