### PR TITLE
Fix Expression Dimension Test

### DIFF
--- a/frontend/test/metabase-lib/lib/Dimension.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/Dimension.unit.spec.js
@@ -773,7 +773,6 @@ describe("Dimension", () => {
           expect(dimension.getMLv1CompatibleDimension().mbql()).toEqual([
             "expression",
             "Hello World",
-            null,
           ]);
         });
       });


### PR DESCRIPTION
Remove `null` from `Dimension > ExpressionDimension > INSTANCE METHODS > getMLv1CompatibleDimension > should strip away *-type options`