### PR TITLE
use d3-selection api for adding timeline events icons

### DIFF
--- a/frontend/src/metabase/visualizations/lib/timelines.js
+++ b/frontend/src/metabase/visualizations/lib/timelines.js
@@ -148,21 +148,17 @@ function renderEventTicks({
     .attr("transform", (d, i) => `translate(${eventPoints[i]}, 0)`);
 
   eventTicks
-    .insert(d => {
-      const group = document.createElementNS("http://www.w3.org/2000/svg", "g");
+    .append("g")
+    .attr("transform", getIconTransform())
+    .html(d => {
       const icon = getIcon(d);
-      const iconSvgText = Icons[icon].source;
-
-      group.innerHTML = iconSvgText;
-      const svg = group.firstChild;
-      svg.classList.add("event-icon");
-      svg.setAttribute("width", ICON_SIZE);
-      svg.setAttribute("height", ICON_SIZE);
-      svg.setAttribute("aria-label", `${icon} icon`);
-
-      return group;
+      return Icons[icon].source;
     })
-    .attr("transform", () => getIconTransform());
+    .select("svg")
+    .attr("width", RECT_SIZE)
+    .attr("height", RECT_SIZE)
+    .attr("class", "event-icon")
+    .attr("aria-label", d => `${getIcon(d)} icon`);
 
   eventTicks
     .append("rect")


### PR DESCRIPTION
### Description

Use `d3-selection` API for appending timeline events icons.

### How to verify

1) New question -> Orders: Count by Created At -> Save
2) Add timeline events to the folder of the question
3) Open the question and ensure timeline events icons are visible

### Demo

<img width="1356" alt="Screen Shot 2023-06-02 at 3 21 37 PM" src="https://github.com/metabase/metabase/assets/14301985/a5e97df5-ff2f-46d7-9039-6a2e3fb18ef0">

### Checklist

- [n/a] Tests have been added/updated to cover changes in this PR — no functional changes, specs exist
