### PR TITLE
FE: Add e2e tests for hidden actions fields at model page and public action page

### DIFF
--- a/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/FormFieldEditor/FormFieldEditor.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/FormFieldEditor/FormFieldEditor.tsx
@@ -100,7 +100,7 @@ function FormFieldEditor({
   };
 
   return (
-    <FormFieldContainer>
+    <FormFieldContainer data-testid={`form-field-container-${field.name}`}>
       <EditorContainer>
         <Column>{isEditable && <DragHandle name="grabber" />}</Column>
         <Column full>

--- a/frontend/src/metabase/actions/containers/ActionParametersInputForm/ActionParametersInputForm.tsx
+++ b/frontend/src/metabase/actions/containers/ActionParametersInputForm/ActionParametersInputForm.tsx
@@ -59,10 +59,17 @@ function ActionParametersInputForm({
     [prefetchedValues, dashcardParamValues],
   );
 
-  const hiddenFields = useMemo(
-    () => mappedParameters.map(parameter => parameter.id),
-    [mappedParameters],
-  );
+  const hiddenFields = useMemo(() => {
+    const hiddenFieldIds = Object.values(
+      action.visualization_settings?.fields ?? {},
+    )
+      .filter(field => field.hidden)
+      .map(field => field.id);
+
+    return mappedParameters
+      .map(parameter => parameter.id)
+      .concat(hiddenFieldIds);
+  }, [mappedParameters, action.visualization_settings?.fields]);
 
   const fetchInitialValues = useCallback(async () => {
     const prefetchEndpoint =


### PR DESCRIPTION
Epic: https://github.com/metabase/metabase/issues/30016

depends on https://github.com/metabase/metabase/pull/31225

### Description

Adds e2e tests and actually hides hidden fields for action execution

### Covered:
- public actions with hidden fields
- hide/show action field at model page
- execute action at model page

### Not covered:
- execute action at dashboard
- error flow (required field is marked as hidden)
