### PR TITLE
Undo renaming `AddJoinAliasToVisualizationSettingsFieldRefs` migration

### DIFF
--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -14776,7 +14776,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v47.00-027
-      author: calherres
+      author: calherries
       comment: Added 0.47.0 - Migrate field_ref in report_card.result_metadata from legacy format
       changes:
         - customChange:
@@ -14784,7 +14784,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v47.00-028
-      author: calherres
+      author: calherries
       comment: Added 0.47.0 - Add join-alias to the report_card.visualization_settings.column_settings field refs
       changes:
         - customChange:

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -14788,7 +14788,7 @@ databaseChangeLog:
       comment: Added 0.47.0 - Add join-alias to the report_card.visualization_settings.column_settings field refs
       changes:
         - customChange:
-            class: "metabase.db.custom_migrations.AddJoinAliasToColumnSettingsFieldRefs"
+            class: "metabase.db.custom_migrations.AddJoinAliasToVisualizationSettingsFieldRefs"
 
   - changeSet:
       id: v47.00-029

--- a/src/metabase/db/custom_migrations.clj
+++ b/src/metabase/db/custom_migrations.clj
@@ -288,7 +288,7 @@
                                  _ [[k v]]))
                              column_settings)))))))
 
-(define-reversible-migration AddJoinAliasToColumnSettingsFieldRefs
+(define-reversible-migration AddJoinAliasToVisualizationSettingsFieldRefs
   (let [update-one! (fn [{:keys [id visualization_settings] :as card}]
                       (let [updated (add-join-alias-to-column-settings-refs card)]
                         (when (not= visualization_settings updated)

--- a/test/metabase/db/custom_migrations_test.clj
+++ b/test/metabase/db/custom_migrations_test.clj
@@ -180,7 +180,7 @@
                        ((:out mi/transform-result-metadata))
                        json/generate-string)))))))))
 
-(deftest add-join-alias-to-column-settings-field-refs-test
+(deftest add-join-alias-to-visualization-settings-field-refs-test
   (testing "Migrations v47.00-028: update visualization_settings.column_settings legacy field refs"
     (impl/test-migrations ["v47.00-028"] [migrate!]
       (let [{:keys [db-type ^javax.sql.DataSource data-source]} mdb.connection/*application-db*


### PR DESCRIPTION
In [this previous PR of mine](https://github.com/metabase/metabase/pull/31150/files), I renamed this migration from `AddJoinAliasToVisualizationSettingsFieldRefs` to `AddJoinAliasToColumnSettingsFieldRefs` for very minor reasons.

It's breaking instances that had previously migrated (like stats.metabase.com), so the easiest solution is to reverse the renaming.

[Slack context](https://metaboat.slack.com/archives/C078VCLF3/p1685811153672259?thread_ts=1684966196.696409&cid=C078VCLF3)