### PR TITLE
Rename migration and validate previous checksum

### DIFF
--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -14778,7 +14778,6 @@ databaseChangeLog:
       id: v47.00-027
       author: calherries
       comment: Added 0.47.0 - Migrate field_ref in report_card.result_metadata from legacy format
-      validCheckSum: 8:f38598170766acaaa8fd3b20ef683372
       changes:
         - customChange:
             class: "metabase.db.custom_migrations.MigrateLegacyResultMetadataFieldRefs"
@@ -14786,7 +14785,7 @@ databaseChangeLog:
   - changeSet:
       id: v47.00-028
       author: calherries
-      # The author and customChange.class was changed. It's ok to ignore this checkSum
+      # The customChange.class was changed. It's ok to ignore this checkSum
       validCheckSum: 8:f38598170766acaaa8fd3b20ef683372
       comment: Added 0.47.0 - Add join-alias to the report_card.visualization_settings.column_settings field refs
       changes:

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -14778,6 +14778,7 @@ databaseChangeLog:
       id: v47.00-027
       author: calherries
       comment: Added 0.47.0 - Migrate field_ref in report_card.result_metadata from legacy format
+      validCheckSum: 8:f38598170766acaaa8fd3b20ef683372
       changes:
         - customChange:
             class: "metabase.db.custom_migrations.MigrateLegacyResultMetadataFieldRefs"
@@ -14785,10 +14786,12 @@ databaseChangeLog:
   - changeSet:
       id: v47.00-028
       author: calherries
+      # The author and customChange.class was changed. It's ok to ignore this checkSum
+      validCheckSum: 8:f38598170766acaaa8fd3b20ef683372
       comment: Added 0.47.0 - Add join-alias to the report_card.visualization_settings.column_settings field refs
       changes:
         - customChange:
-            class: "metabase.db.custom_migrations.AddJoinAliasToVisualizationSettingsFieldRefs"
+            class: "metabase.db.custom_migrations.AddJoinAliasToColumnSettingsFieldRefs"
 
   - changeSet:
       id: v47.00-029

--- a/src/metabase/db/custom_migrations.clj
+++ b/src/metabase/db/custom_migrations.clj
@@ -288,7 +288,7 @@
                                  _ [[k v]]))
                              column_settings)))))))
 
-(define-reversible-migration AddJoinAliasToVisualizationSettingsFieldRefs
+(define-reversible-migration AddJoinAliasToColumnSettingsFieldRefs
   (let [update-one! (fn [{:keys [id visualization_settings] :as card}]
                       (let [updated (add-join-alias-to-column-settings-refs card)]
                         (when (not= visualization_settings updated)

--- a/test/metabase/db/custom_migrations_test.clj
+++ b/test/metabase/db/custom_migrations_test.clj
@@ -180,7 +180,7 @@
                        ((:out mi/transform-result-metadata))
                        json/generate-string)))))))))
 
-(deftest add-join-alias-to-visualization-settings-field-refs-test
+(deftest add-join-alias-to-column-settings-field-refs-test
   (testing "Migrations v47.00-028: update visualization_settings.column_settings legacy field refs"
     (impl/test-migrations ["v47.00-028"] [migrate!]
       (let [{:keys [db-type ^javax.sql.DataSource data-source]} mdb.connection/*application-db*


### PR DESCRIPTION
This PR didn't solve the issue: https://github.com/metabase/metabase/pull/31316. Because we also fixed the author the new checkSum is still different from the original.

This PR renames the migration again to the preferred name and instead introduces a validCheckSum to validate the original checksum.