### PR TITLE
Add a prometheus metric for emails sent

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -559,7 +559,6 @@
    metabase.db.schema-migrations-test.impl/test-migrations                                                                   hooks.metabase.db.schema-migrations-test.impl/test-migrations
    metabase.dashboard-subscription-test/with-link-card-fixture-for-dashboard                                                 hooks.common/let-second
    metabase.driver.bigquery-cloud-sdk-test/calculate-bird-scarcity                                                           hooks.metabase.query-processor-test.expressions-test/calculate-bird-scarcity
-   metabase.email-test/with-prometheus-registry                                                                              hooks.common/with-one-binding
    metabase.mbql.schema.macros/defclause                                                                                     hooks.metabase.mbql.schemas.macros/defclause
    metabase.models.collection-test/with-collection-hierarchy                                                                 hooks.common/let-one-with-optional-value
    metabase.models.collection-test/with-personal-and-impersonal-collections                                                  hooks.common/with-two-bindings

--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -559,6 +559,7 @@
    metabase.db.schema-migrations-test.impl/test-migrations                                                                   hooks.metabase.db.schema-migrations-test.impl/test-migrations
    metabase.dashboard-subscription-test/with-link-card-fixture-for-dashboard                                                 hooks.common/let-second
    metabase.driver.bigquery-cloud-sdk-test/calculate-bird-scarcity                                                           hooks.metabase.query-processor-test.expressions-test/calculate-bird-scarcity
+   metabase.email-test/with-prometheus-registry                                                                              hooks.common/with-one-binding
    metabase.mbql.schema.macros/defclause                                                                                     hooks.metabase.mbql.schemas.macros/defclause
    metabase.models.collection-test/with-collection-hierarchy                                                                 hooks.common/let-one-with-optional-value
    metabase.models.collection-test/with-personal-and-impersonal-collections                                                  hooks.common/with-two-bindings

--- a/src/metabase/analytics/prometheus.clj
+++ b/src/metabase/analytics/prometheus.clj
@@ -9,6 +9,7 @@
    [iapetos.collector :as collector]
    [iapetos.collector.ring :as collector.ring]
    [iapetos.core :as prometheus]
+   [metabase.email :as email]
    [metabase.models.setting :as setting :refer [defsetting]]
    [metabase.server :as server]
    [metabase.troubleshooting :as troubleshooting]
@@ -220,6 +221,7 @@
       (locking #'system
         (when-not system
           (let [sys (make-prometheus-system port "metabase-registry")]
+            (email/setup-metrics! (.-registry ^PrometheusSystem sys))
             (alter-var-root #'system (constantly sys))))))))
 
 (defn shutdown!
@@ -229,6 +231,7 @@
     (locking #'system
       (when system
         (try (stop-web-server system)
+             (email/shutdown-metrics!)
              (alter-var-root #'system (constantly nil))
              (log/info (trs "Prometheus web-server shut down"))
              (catch Exception e

--- a/src/metabase/analytics/prometheus.clj
+++ b/src/metabase/analytics/prometheus.clj
@@ -6,13 +6,12 @@
   Api is quite simple: [[setup!]] and [[shutdown!]]. After that you can retrieve metrics from
   http://localhost:<prometheus-server-port>/metrics."
   (:require
+   [clojure.java.jmx :as jmx]
    [iapetos.collector :as collector]
    [iapetos.collector.ring :as collector.ring]
    [iapetos.core :as prometheus]
-   [metabase.email :as email]
    [metabase.models.setting :as setting :refer [defsetting]]
    [metabase.server :as server]
-   [metabase.troubleshooting :as troubleshooting]
    [metabase.util.i18n :refer [deferred-trs trs]]
    [metabase.util.log :as log]
    [potemkin :as p]
@@ -23,6 +22,7 @@
    (io.prometheus.client.hotspot GarbageCollectorExports MemoryPoolsExports StandardExports ThreadExports)
    (io.prometheus.client.jetty JettyStatisticsCollector)
    (java.util ArrayList List)
+   (javax.management ObjectName)
    (org.eclipse.jetty.server Server)))
 
 (set! *warn-on-reflection* true)
@@ -45,8 +45,6 @@
                                                raw-value))))]
                   (setting/get-raw-value :prometheus-server-port integer? parse))))
 
-(defonce ^:private ^{:doc "Prometheus System for prometheus metrics"} system nil)
-
 (p.types/defprotocol+ PrometheusActions
   (stop-web-server [this]))
 
@@ -58,6 +56,8 @@
     (when-let [^Server web-server web-server]
       (.stop web-server))))
 
+(defonce ^:private ^{:doc "Prometheus System for prometheus metrics"} ^PrometheusSystem system nil)
+
 (declare setup-metrics! start-web-server!)
 
 (defn- make-prometheus-system
@@ -65,7 +65,7 @@
   serving metrics from that port."
   [port registry-name]
   (try
-    (let [registry (setup-metrics! registry-name)
+    (let [registry   (setup-metrics! registry-name)
           web-server (start-web-server! port registry)]
       (->PrometheusSystem registry web-server))
     (catch Exception e
@@ -76,7 +76,7 @@
 ;;; Collectors
 
 (defn c3p0-stats
-  "Takes `raw-stats` from [[metabase.troubleshooting/connection-pool-info]] and groups by each property type rather than each database.
+  "Takes `raw-stats` from [[connection-pool-info]] and groups by each property type rather than each database.
   {\"metabase-postgres-app-db\" {:numConnections 15,
                                  :numIdleConnections 15,
                                  :numBusyConnections 0,
@@ -143,11 +143,21 @@
                        raw-label))))
     arr))
 
+(defn- conn-pool-bean-diag-info [acc ^ObjectName jmx-bean]
+  (let [bean-id   (.getCanonicalName jmx-bean)
+        props     [:numConnections :numIdleConnections :numBusyConnections
+                   :minPoolSize :maxPoolSize :numThreadsAwaitingCheckoutDefaultUser]]
+    (assoc acc (jmx/read bean-id :dataSourceName) (jmx/read bean-id props))))
+
+(defn connection-pool-info
+  "Builds a map of info about the current c3p0 connection pools managed by this Metabase instance."
+  []
+  (reduce conn-pool-bean-diag-info {} (jmx/mbean-names "com.mchange.v2.c3p0:type=PooledDataSource,*")))
+
 (def c3p0-collector
   "c3p0 collector delay"
   (letfn [(collect-metrics []
-            (-> (troubleshooting/connection-pool-info)
-                :connection-pools
+            (-> (connection-pool-info)
                 c3p0-stats
                 stats->prometheus))]
     (delay
@@ -193,7 +203,12 @@
     (apply prometheus/register registry
            (concat (jvm-collectors)
                    (jetty-collectors)
-                   [@c3p0-collector]))))
+                   [@c3p0-collector]
+                   ; Iapetos will use "default" if we do not provide a namespace, so explicitly set `metabase-email`:
+                   [(prometheus/counter :metabase-email/messages
+                                        {:description (trs "Number of emails sent.")})
+                    (prometheus/counter :metabase-email/message-errors
+                                        {:description (trs "Number of errors when sending emails.")})]))))
 
 (defn- start-web-server!
   "Start the prometheus web-server. If [[prometheus-server-port]] is not set it will throw."
@@ -221,7 +236,6 @@
       (locking #'system
         (when-not system
           (let [sys (make-prometheus-system port "metabase-registry")]
-            (email/setup-metrics! (.-registry ^PrometheusSystem sys))
             (alter-var-root #'system (constantly sys))))))))
 
 (defn shutdown!
@@ -231,11 +245,18 @@
     (locking #'system
       (when system
         (try (stop-web-server system)
-             (email/shutdown-metrics!)
+             (prometheus/clear (.-registry system))
              (alter-var-root #'system (constantly nil))
              (log/info (trs "Prometheus web-server shut down"))
              (catch Exception e
                (log/warn e (trs "Error stopping prometheus web-server"))))))))
+
+#_{:clj-kondo/ignore [:redefined-var]}
+(defn inc
+  "Call iapetos.core/inc on the metric in the global registry,
+   if it has already been initialized and the metric is registered."
+  [metric]
+  (some-> system .-registry metric prometheus/inc))
 
 (comment
   (require 'iapetos.export)

--- a/src/metabase/api/util.clj
+++ b/src/metabase/api/util.clj
@@ -4,6 +4,7 @@
   (:require
    [compojure.core :refer [GET POST]]
    [crypto.random :as crypto-random]
+   [metabase.analytics.prometheus :as prometheus]
    [metabase.analytics.stats :as stats]
    [metabase.api.common :as api]
    [metabase.api.common.validation :as validation]
@@ -54,8 +55,8 @@
   "Returns database connection pool info for the current Metabase instance."
   []
   (validation/check-has-application-permission :monitoring)
-  (let [pool-info (troubleshooting/connection-pool-info)
+  (let [pool-info (prometheus/connection-pool-info)
         headers   {"Content-Disposition" "attachment; filename=\"connection_pool_info.json\""}]
-    (assoc (response/response pool-info) :headers headers, :status 200)))
+    (assoc (response/response {:connection-pools pool-info}) :headers headers, :status 200)))
 
 (api/define-routes)

--- a/src/metabase/email.clj
+++ b/src/metabase/email.clj
@@ -1,6 +1,6 @@
 (ns metabase.email
   (:require
-   [iapetos.core :as prometheus]
+   [metabase.analytics.prometheus :as prometheus]
    [metabase.models.setting :as setting :refer [defsetting]]
    [metabase.util :as u]
    [metabase.util.i18n :refer [deferred-tru trs tru]]
@@ -10,7 +10,6 @@
    [postal.support :refer [make-props]]
    [schema.core :as s])
   (:import
-   (iapetos.registry IapetosRegistry)
    (javax.mail Session)))
 
 (set! *warn-on-reflection* true)
@@ -72,26 +71,6 @@
              (when (some? new-value)
                (assert (#{:tls :ssl :none :starttls} (keyword new-value))))
              (setting/set-value-of-type! :keyword :email-smtp-security new-value)))
-
-(defonce ^:private ^{:doc "Prometheus registry for email-related metrics collectors."} ^IapetosRegistry registry nil)
-
-(defn setup-metrics!
-  "Register metrics collectors for the email subsystem."
-  [global-registry]
-  (alter-var-root #'registry (constantly
-                               (-> global-registry
-                                   (prometheus/subsystem "email")
-                                   (prometheus/register
-                                     (prometheus/counter :metabase/messages
-                                                         {:description (tru "Number of emails sent.")})
-                                     (prometheus/counter :metabase/message-errors
-                                                         {:description (tru "Number of errors when sending emails.")}))))))
-
-(defn shutdown-metrics!
-  "Clear metrics collectors of the email subsystem."
-  []
-  (prometheus/clear registry)
-  (alter-var-root #'registry (constantly nil)))
 
 ;; ## PUBLIC INTERFACE
 
@@ -162,10 +141,10 @@
                   (when-let [reply-to (email-reply-to)]
                     {:reply-to reply-to})))
     (catch Throwable e
-      (some-> registry :metabase/message-errors prometheus/inc)
+      (prometheus/inc :metabase-email/message-errors)
       (throw e))
     (finally
-      (some-> registry :metabase/messages prometheus/inc))))
+      (prometheus/inc :metabase-email/messages))))
 
 (def ^:private SMTPStatus
   "Schema for the response returned by various functions in [[metabase.email]]. Response will be a map with the key

--- a/src/metabase/troubleshooting.clj
+++ b/src/metabase/troubleshooting.clj
@@ -1,13 +1,10 @@
 (ns metabase.troubleshooting
   (:require
-   [clojure.java.jmx :as jmx]
    [metabase.analytics.stats :as stats]
    [metabase.config :as config]
    [metabase.db :as mdb]
    [metabase.driver :as driver]
-   [toucan2.core :as t2])
-  (:import
-   (javax.management ObjectName)))
+   [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
 
@@ -43,15 +40,3 @@
    :run-mode                     (config/config-kw :mb-run-mode)
    :version                      config/mb-version-info
    :settings                     {:report-timezone (driver/report-timezone)}})
-
-(defn- conn-pool-bean-diag-info [acc ^ObjectName jmx-bean]
-  (let [bean-id   (.getCanonicalName jmx-bean)
-        props     [:numConnections :numIdleConnections :numBusyConnections
-                   :minPoolSize :maxPoolSize :numThreadsAwaitingCheckoutDefaultUser]]
-      (assoc acc (jmx/read bean-id :dataSourceName) (jmx/read bean-id props))))
-
-(defn connection-pool-info
-  "Builds a map of info about the current c3p0 connection pools managed by this Metabase instance."
-  []
-  (->> (reduce conn-pool-bean-diag-info {} (jmx/mbean-names "com.mchange.v2.c3p0:type=PooledDataSource,*"))
-       (assoc {} :connection-pools)))

--- a/test/metabase/email_test.clj
+++ b/test/metabase/email_test.clj
@@ -3,16 +3,14 @@
   (:require
    [clojure.java.io :as io]
    [clojure.test :refer :all]
-   [iapetos.core :as prometheus]
-   [iapetos.registry :as registry]
    [medley.core :as m]
+   [metabase.analytics.prometheus :as prometheus]
    [metabase.email :as email]
    [metabase.test.data.users :as test.users]
    [metabase.test.util :as tu]
    [metabase.util :refer [prog1]]
    [postal.message :as message])
   (:import
-   (io.prometheus.client CollectorRegistry)
    (java.io File)
    (javax.activation MimeType)))
 
@@ -89,15 +87,6 @@
   [& body]
   {:style/indent 0}
   `(do-with-fake-inbox (fn [] ~@body)))
-
-(defmacro with-prometheus-registry
-  "Run tests with a new Prometheus collector registry bound as the `email/registry` global
-  and provides raw Prometheus `CollectorRegistry` as binding symbol in [registry]."
-  [[registry] & body]
-  `(do (email/setup-metrics! (prometheus/collector-registry (name (gensym "test-registry"))))
-       (let [~registry ^CollectorRegistry (registry/raw (deref #'email/registry))]
-         (try ~@body
-              (finally (email/shutdown-metrics!))))))
 
 (defn- create-email-body->regex-fn
   "Returns a function expecting the email body structure. It will apply the regexes in `regex-seq` over the body and
@@ -250,23 +239,27 @@
               :message      "101. Metabase will make you a better person")
              (@inbox "test@test.com")))))
     (testing "metrics collection"
-      (with-prometheus-registry [registry]
-        (with-fake-inbox
-          (email/send-message!
-           :subject      "101 Reasons to use Metabase"
-           :recipients   ["test@test.com"]
-           :message-type :html
-           :message      "101. Metabase will make you a better person"))
-        (is (< 0 (.getSampleValue registry "metabase_email_messages_total")))))
+      (let [calls (atom nil)]
+        (with-redefs [prometheus/inc #(swap! calls conj %)]
+          (with-fake-inbox
+            (email/send-message!
+             :subject      "101 Reasons to use Metabase"
+             :recipients   ["test@test.com"]
+             :message-type :html
+             :message      "101. Metabase will make you a better person")))
+        (is (= 1 (count (filter #{:metabase-email/messages} @calls))))
+        (is (= 0 (count (filter #{:metabase-email/message-errors} @calls))))))
     (testing "error metrics collection"
-      (with-prometheus-registry [registry]
-        (with-redefs [email/send-email! (fn [_ _] (throw (Exception. "test-exception")))]
+      (let [calls (atom nil)]
+        (with-redefs [prometheus/inc #(swap! calls conj %)
+                      email/send-email! (fn [_ _] (throw (Exception. "test-exception")))]
           (email/send-message!
             :subject      "101 Reasons to use Metabase"
             :recipients   ["test@test.com"]
             :message-type :html
             :message      "101. Metabase will make you a better person"))
-        (is (< 0 (.getSampleValue registry "metabase_email_message_errors_total")))))
+        (is (= 1 (count (filter #{:metabase-email/messages} @calls))))
+        (is (= 1 (count (filter #{:metabase-email/message-errors} @calls))))))
     (testing "basic sending without email-from-name"
       (tu/with-temporary-setting-values [email-from-name nil]
         (is (=


### PR DESCRIPTION
# Context

In order to be able to alert operators to Metabase instances sending excessive
amounts of emails, we need to measure the number of emails sent.

# Notes

To break a dependency cycle (^1) `connection-pool-info` was moved from
`metabase.troubleshooting` to `metabase.analytics.prometheus` and
`GET "/diagnostic_info/connection_pool_info"` in `metabase.api.util`
was adjusted accordingly.

(^1): metabase.analytics.prometheus -> metabase.troubleshooting -> metabase.analytics.stats -> metabase.email -> metabase.analytics.prometheus, and longer variations.

# Acceptance test

* On a Metabase instance with `MB_PROMETHEUS_SERVER_PORT` set, check
  `localhost:<port>/metrics` and find the number of successfully sent emails
  (e.g. when inviting users) in the `metabase_email_messages_total` sample and
  the number of failures in the `metabase_email_message_errors_total` sample,
  both without any labels.

Closes: https://github.com/metabase/metabase/issues/30241
