### PR TITLE
break words inside tooltips to prevent overflow

### DIFF
--- a/frontend/src/metabase/components/Popover/Popover.css
+++ b/frontend/src/metabase/components/Popover/Popover.css
@@ -38,6 +38,7 @@
   font-size: 12px;
   border-radius: 6px;
   box-shadow: 0 4px 10px var(--color-shadow);
+  overflow-wrap: break-word;
 }
 
 .tippy-box[data-theme~="tooltip"] .tippy-content {

--- a/frontend/src/metabase/core/components/Tooltip/Tooltip.stories.tsx
+++ b/frontend/src/metabase/core/components/Tooltip/Tooltip.stories.tsx
@@ -25,3 +25,10 @@ CustomContent.args = {
     </div>
   ),
 };
+
+export const LongScalarString = Template.bind({});
+LongScalarString.args = {
+  tooltip:
+    "looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong string",
+  isOpen: true,
+};


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/21229

### Description

Break words to prevent hidden overflow in tooltips.

### How to verify

I added a Tooltip storybook with a long string

http://localhost:6006/?path=/story/core-tooltip--long-scalar-string

<img width="564" alt="CleanShot 2023-06-05 at 16 08 23@2x" src="https://github.com/metabase/metabase/assets/116838/f446a56d-bfdd-424b-81b0-461217e738d7">
