### PR TITLE
Make CSV Discovery Easier

### DIFF
--- a/frontend/src/metabase/collections/components/CollectionHeader/CollectionHeader.styled.tsx
+++ b/frontend/src/metabase/collections/components/CollectionHeader/CollectionHeader.styled.tsx
@@ -25,7 +25,7 @@ export const HeaderActions = styled.div`
 `;
 
 interface CollectionHeaderButtonProps {
-  to: string;
+  to?: string;
 }
 
 export const CollectionHeaderButton = styled(

--- a/frontend/src/metabase/collections/components/CollectionHeader/CollectionHeader.tsx
+++ b/frontend/src/metabase/collections/components/CollectionHeader/CollectionHeader.tsx
@@ -7,7 +7,7 @@ import CollectionCaption from "./CollectionCaption";
 import CollectionBookmark from "./CollectionBookmark";
 import CollectionMenu from "./CollectionMenu";
 import CollectionTimeline from "./CollectionTimeline";
-import CollectionUpload from "./CollectionUpload";
+import { CollectionUpload } from "./CollectionUpload";
 
 import { HeaderActions, HeaderRoot } from "./CollectionHeader.styled";
 

--- a/frontend/src/metabase/collections/components/CollectionHeader/CollectionHeader.tsx
+++ b/frontend/src/metabase/collections/components/CollectionHeader/CollectionHeader.tsx
@@ -22,6 +22,7 @@ export interface CollectionHeaderProps {
   onDeleteBookmark: (collection: Collection) => void;
   onUpload: (file: File, collectionId: CollectionId) => void;
   canUpload: boolean;
+  uploadsEnabled: boolean;
 }
 
 const CollectionHeader = ({
@@ -35,7 +36,11 @@ const CollectionHeader = ({
   onDeleteBookmark,
   onUpload,
   canUpload,
+  uploadsEnabled,
 }: CollectionHeaderProps): JSX.Element => {
+  const showUploadButton =
+    collection.can_write && (canUpload || !uploadsEnabled);
+
   return (
     <HeaderRoot>
       <CollectionCaption
@@ -43,8 +48,13 @@ const CollectionHeader = ({
         onUpdateCollection={onUpdateCollection}
       />
       <HeaderActions data-testid="collection-menu">
-        {canUpload && (
-          <CollectionUpload collection={collection} onUpload={onUpload} />
+        {showUploadButton && (
+          <CollectionUpload
+            collection={collection}
+            uploadsEnabled={uploadsEnabled}
+            isAdmin={isAdmin}
+            onUpload={onUpload}
+          />
         )}
         <CollectionTimeline collection={collection} />
         <CollectionBookmark

--- a/frontend/src/metabase/collections/components/CollectionHeader/CollectionUpload.styled.tsx
+++ b/frontend/src/metabase/collections/components/CollectionHeader/CollectionUpload.styled.tsx
@@ -13,3 +13,30 @@ export const LoadingStateContainer = styled.div`
   height: 16px;
   color: ${color("brand")};
 `;
+
+export const InfoModalTitle = styled.h2`
+  text-align: center;
+  font-size: 1.375rem; // 22px 🤦‍♀️
+`;
+
+export const InfoModalBody = styled.div`
+  color: ${color("text-medium")};
+`;
+
+export const NewBadge = styled.div`
+  padding: 5px 10px;
+  font-size: 0.875rem;
+  font-weight: 700;
+  color: ${color("brand")};
+  background-color: ${color("brand-lighter")};
+  margin: 0 auto;
+  border-radius: 6px;
+`;
+
+export const InfoModalContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  align-items: center;
+  justify-content: center;
+`;

--- a/frontend/src/metabase/collections/components/CollectionHeader/CollectionUpload.tsx
+++ b/frontend/src/metabase/collections/components/CollectionHeader/CollectionUpload.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import { useState, ChangeEvent } from "react";
 import { t } from "ttag";
 
 import type { Collection, CollectionId } from "metabase-types/api";
@@ -13,18 +13,46 @@ import { MAX_UPLOAD_STRING } from "metabase/redux/uploads";
 
 import { CollectionHeaderButton } from "./CollectionHeader.styled";
 import { UploadInput } from "./CollectionUpload.styled";
+import { UploadInfoModal } from "./CollectionUploadInfoModal";
 
 const UPLOAD_FILE_TYPES = [".csv"];
 
 // eslint-disable-next-line import/no-default-export -- deprecated usage
 export default function ColllectionUpload({
   collection,
+  uploadsEnabled,
+  isAdmin,
   onUpload,
 }: {
   collection: Collection;
+  uploadsEnabled: boolean;
+  isAdmin: boolean;
   onUpload: (file: File, collectionId: CollectionId) => void;
 }) {
-  const handleFileUpload = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const [showInfoModal, setShowInfoModal] = useState(false);
+
+  if (!uploadsEnabled) {
+    return (
+      <>
+        <UploadTooltip collection={collection}>
+          <CollectionHeaderButton
+            aria-label={t`Upload data`}
+            icon="upload"
+            iconSize={20}
+            onClick={() => setShowInfoModal(true)}
+          />
+        </UploadTooltip>
+        {showInfoModal && (
+          <UploadInfoModal
+            isAdmin={isAdmin}
+            onClose={() => setShowInfoModal(false)}
+          />
+        )}
+      </>
+    );
+  }
+
+  const handleFileUpload = (event: ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];
     if (file !== undefined) {
       onUpload(file, collection.id);
@@ -32,19 +60,15 @@ export default function ColllectionUpload({
   };
 
   return (
-    <Tooltip
-      tooltip={
-        <TooltipContainer>
-          <TooltipTitle>{t`Upload data to ${collection.name}`}</TooltipTitle>
-          <TooltipSubtitle>{t`${UPLOAD_FILE_TYPES.join(
-            ",",
-          )} (${MAX_UPLOAD_STRING} max)`}</TooltipSubtitle>
-        </TooltipContainer>
-      }
-      placement="bottom"
-    >
+    <UploadTooltip collection={collection}>
       <label htmlFor="upload-csv">
-        <CollectionHeaderButton as="span" to="" icon="upload" iconSize={20} />
+        <CollectionHeaderButton
+          as="span"
+          to=""
+          icon="upload"
+          iconSize={20}
+          aria-label={t`Upload data`}
+        />
       </label>
       <UploadInput
         id="upload-csv"
@@ -53,6 +77,28 @@ export default function ColllectionUpload({
         onChange={handleFileUpload}
         data-testid="upload-input"
       />
-    </Tooltip>
+    </UploadTooltip>
   );
 }
+
+const UploadTooltip = ({
+  collection,
+  children,
+}: {
+  collection: Collection;
+  children: React.ReactNode;
+}) => (
+  <Tooltip
+    tooltip={
+      <TooltipContainer>
+        <TooltipTitle>{t`Upload data to ${collection.name}`}</TooltipTitle>
+        <TooltipSubtitle>{t`${UPLOAD_FILE_TYPES.join(
+          ",",
+        )} (${MAX_UPLOAD_STRING} max)`}</TooltipSubtitle>
+      </TooltipContainer>
+    }
+    placement="bottom"
+  >
+    {children}
+  </Tooltip>
+);

--- a/frontend/src/metabase/collections/components/CollectionHeader/CollectionUpload.tsx
+++ b/frontend/src/metabase/collections/components/CollectionHeader/CollectionUpload.tsx
@@ -17,8 +17,7 @@ import { UploadInfoModal } from "./CollectionUploadInfoModal";
 
 const UPLOAD_FILE_TYPES = [".csv"];
 
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export default function ColllectionUpload({
+export function CollectionUpload({
   collection,
   uploadsEnabled,
   isAdmin,

--- a/frontend/src/metabase/collections/components/CollectionHeader/CollectionUploadInfoModal.tsx
+++ b/frontend/src/metabase/collections/components/CollectionHeader/CollectionUploadInfoModal.tsx
@@ -1,0 +1,60 @@
+import { t } from "ttag";
+import Modal from "metabase/components/Modal";
+import Button from "metabase/core/components/Button";
+import Link from "metabase/core/components/Link";
+import ModalContent from "metabase/components/ModalContent";
+
+import {
+  InfoModalTitle,
+  InfoModalBody,
+  NewBadge,
+  InfoModalContainer,
+} from "./CollectionUpload.styled";
+
+export const UploadInfoModal = ({
+  isAdmin,
+  onClose,
+}: {
+  isAdmin: boolean;
+  onClose: () => void;
+}) => {
+  return (
+    <Modal small>
+      <ModalContent title=" " onClose={onClose}>
+        <InfoModalContainer>
+          <NewBadge>{t`New`}</NewBadge>
+          <InfoModalTitle>{t`Uploads CSVs to Metabase`}</InfoModalTitle>
+          {isAdmin ? (
+            <>
+              <InfoModalBody>
+                <p>
+                  {t`Team members will be able to upload CSV files and work with them just like any other data source`}
+                </p>
+                <p>
+                  {t`You'll be able to pick the default database where the data should be stored when enabling the feature.`}
+                </p>
+              </InfoModalBody>
+              <Button
+                as={Link}
+                to="/admin/settings/uploads"
+                primary
+                role="link"
+              >
+                {t`Enable in settings`}
+              </Button>
+            </>
+          ) : (
+            <>
+              <InfoModalBody>
+                <p>
+                  {t`You'll need to ask your admin to enable this feature to get started. Then, you'll be able to upload CSV files and work with them just like any other data source.`}
+                </p>
+              </InfoModalBody>
+              <Button onClick={onClose}>{t`Got it`}</Button>
+            </>
+          )}
+        </InfoModalContainer>
+      </ModalContent>
+    </Modal>
+  );
+};

--- a/frontend/src/metabase/collections/containers/CollectionContent.jsx
+++ b/frontend/src/metabase/collections/containers/CollectionContent.jsx
@@ -56,8 +56,9 @@ const itemKeyFn = item => `${item.id}:${item.model}`;
 
 function mapStateToProps(state, props) {
   const uploadDbId = getSetting(state, "uploads-database-id");
+  const uploadsEnabled = getSetting(state, "uploads-enabled");
   const canAccessUploadsDb =
-    getSetting(state, "uploads-enabled") &&
+    uploadsEnabled &&
     uploadDbId &&
     !!Databases.selectors.getObject(state, {
       entityId: uploadDbId,
@@ -67,7 +68,8 @@ function mapStateToProps(state, props) {
     isAdmin: getUserIsAdmin(state),
     isBookmarked: getIsBookmarked(state, props),
     isNavbarOpen: getIsNavbarOpen(state),
-    uploadsEnabled: canAccessUploadsDb,
+    uploadsEnabled,
+    canAccessUploadsDb,
   };
 }
 
@@ -91,6 +93,7 @@ function CollectionContent({
   openNavbar,
   uploadFile,
   uploadsEnabled,
+  canAccessUploadsDb,
 }) {
   const [isBookmarked, setIsBookmarked] = useState(false);
   const [selectedItems, setSelectedItems] = useState(null);
@@ -200,7 +203,8 @@ function CollectionContent({
     deleteBookmark(collectionId, "collection");
   };
 
-  const canUpload = uploadsEnabled && collection.can_write;
+  const canUpload =
+    uploadsEnabled && canAccessUploadsDb && collection.can_write;
 
   const dropzoneProps = canUpload ? getComposedDragProps(getRootProps()) : {};
 
@@ -251,6 +255,7 @@ function CollectionContent({
                   onCreateBookmark={handleCreateBookmark}
                   onDeleteBookmark={handleDeleteBookmark}
                   canUpload={canUpload}
+                  uploadsEnabled={uploadsEnabled}
                 />
               </ErrorBoundary>
               <ErrorBoundary>

--- a/frontend/src/metabase/status/components/FileUploadStatus/FileUploadStatus.unit.spec.tsx
+++ b/frontend/src/metabase/status/components/FileUploadStatus/FileUploadStatus.unit.spec.tsx
@@ -85,6 +85,7 @@ describe("FileUploadStatus", () => {
                 onCreateBookmark={jest.fn()}
                 onDeleteBookmark={jest.fn()}
                 canUpload
+                uploadsEnabled
               />
               <FileUploadStatus />
             </>
@@ -137,6 +138,7 @@ describe("FileUploadStatus", () => {
                   onCreateBookmark={jest.fn()}
                   onDeleteBookmark={jest.fn()}
                   canUpload
+                  uploadsEnabled
                 />
                 <FileUploadStatus />
               </>

--- a/frontend/src/metabase/status/components/FileUploadStatus/FileUploadStatus.unit.spec.tsx
+++ b/frontend/src/metabase/status/components/FileUploadStatus/FileUploadStatus.unit.spec.tsx
@@ -11,7 +11,10 @@ import FileUploadStatus from "./FileUploadStatus";
 
 describe("FileUploadStatus", () => {
   const firstCollectionId = 1;
-  const firstCollection = createMockCollection({ id: firstCollectionId });
+  const firstCollection = createMockCollection({
+    id: firstCollectionId,
+    can_write: true,
+  });
 
   const secondCollectionId = 2;
 


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/31262

### Description

- Show CSV upload button in collections if the user has `can_write` permissions on the collection AND (the user can actually upload, or uploads are disabled for the instance)
- If uploads are disabled, clicking the upload button:
  - shows admins a modal with instructions on how to enable, and a link to the upload settings
  - shows non-admins a modal with instructions about how to bug their admin 😁 

admin | non-admin
---|---
![Screen Shot 2023-06-05 at 3 07 06 PM](https://github.com/metabase/metabase/assets/30528226/5335ea86-fa96-4568-b934-0fb96c78bacb) | ![Screen Shot 2023-06-05 at 3 06 51 PM](https://github.com/metabase/metabase/assets/30528226/3dbb713f-bc61-4b51-84eb-9be6edb72d85)


### How to verify

Info Modal
- Disable uploads in settings > uploads
- navigate to a collection where you have write permissions
- click the upload button
- see a modal

Upload
- enable uploads in settings > uploads
- navigate to a colleciton where you have write permissions
- click the upload button
- see that you can upload

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
