### PR TITLE
Manual backport - Fix - Native editor buttons are incorrectly rendering on top of model metadata screen (#31142)

### DIFF
--- a/e2e/test/scenarios/native/reproductions/30680-native-editor-buttons.cy.spec.js
+++ b/e2e/test/scenarios/native/reproductions/30680-native-editor-buttons.cy.spec.js
@@ -1,0 +1,23 @@
+import { restore, runNativeQuery } from "e2e/support/helpers";
+
+describe("issue 30680", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+  });
+
+  it("should not render native editor buttons when 'Metadata' tab is open", () => {
+    cy.visit("/model/new");
+
+    cy.findByTestId("new-model-options")
+      .findByText("Use a native query")
+      .click();
+
+    cy.get(".ace_editor").type("select * from orders ");
+    runNativeQuery();
+
+    cy.findByTestId("editor-tabs-metadata-name").click();
+
+    cy.findByTestId("native-query-editor-sidebar").should("not.exist");
+  });
+});

--- a/frontend/src/metabase-types/store/entities.ts
+++ b/frontend/src/metabase-types/store/entities.ts
@@ -8,8 +8,10 @@ import {
   Database,
   Field,
   FieldId,
+  Metric,
   NativeQuerySnippet,
   NativeQuerySnippetId,
+  Segment,
   Table,
   User,
   UserId,
@@ -23,7 +25,10 @@ export interface EntitiesState {
   dashboards?: Record<DashboardId, Dashboard>;
   databases?: Record<number, Database>;
   fields?: Record<FieldId, Field>;
+  metrics?: Record<string, Metric>;
   tables?: Record<number | string, Table>;
+  schemas?: Record<string, Table["schema"]>;
+  segments: Record<string, Segment>;
   snippets?: Record<NativeQuerySnippetId, NativeQuerySnippet>;
   users?: Record<UserId, User>;
   questions?: Record<CardId, Card>;

--- a/frontend/src/metabase-types/store/entities.ts
+++ b/frontend/src/metabase-types/store/entities.ts
@@ -28,7 +28,7 @@ export interface EntitiesState {
   metrics?: Record<string, Metric>;
   tables?: Record<number | string, Table>;
   schemas?: Record<string, Table["schema"]>;
-  segments: Record<string, Segment>;
+  segments?: Record<string, Segment>;
   snippets?: Record<NativeQuerySnippetId, NativeQuerySnippet>;
   users?: Record<UserId, User>;
   questions?: Record<CardId, Card>;

--- a/frontend/src/metabase/models/containers/NewModelOptions/NewModelOptions.jsx
+++ b/frontend/src/metabase/models/containers/NewModelOptions/NewModelOptions.jsx
@@ -62,7 +62,7 @@ class NewModelOptions extends Component {
     const itemsCount = (hasDataAccess ? 1 : 0) + (hasNativeWrite ? 1 : 0);
 
     return (
-      <OptionsRoot>
+      <OptionsRoot data-testid="new-model-options">
         <Grid className="justifyCenter">
           {hasDataAccess && (
             <OptionsGridItem itemsCount={itemsCount}>

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.jsx
@@ -451,13 +451,21 @@ function DatasetEditor(props) {
       <Root>
         <MainContainer>
           <QueryEditorContainer isResizable={isEditingQuery}>
-            <DatasetQueryEditor
-              {...props}
-              isActive={isEditingQuery}
-              height={editorHeight}
-              viewHeight={height}
-              onResizeStop={handleResize}
-            />
+            {/**
+             * Optimization: DatasetQueryEditor can be expensive to re-render
+             * and we don't need it on the "Metadata" tab.
+             *
+             * @see https://github.com/metabase/metabase/pull/31142/files#r1211352364
+             */}
+            {isEditingQuery && editorHeight > 0 && (
+              <DatasetQueryEditor
+                {...props}
+                isActive={isEditingQuery}
+                height={editorHeight}
+                viewHeight={height}
+                onResizeStop={handleResize}
+              />
+            )}
           </QueryEditorContainer>
           <TableContainer isSidebarOpen={!!sidebar}>
             <DebouncedFrame className="flex-full" enabled>

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetQueryEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetQueryEditor.jsx
@@ -93,9 +93,4 @@ function DatasetQueryEditor({
 
 DatasetQueryEditor.propTypes = propTypes;
 
-export default React.memo(
-  DatasetQueryEditor,
-  // should prevent the editor from re-rendering in "metadata" mode
-  // when it's completely covered with the results table
-  (prevProps, nextProps) => prevProps.height === 0 && nextProps.height === 0,
-);
+export default React.memo(DatasetQueryEditor);

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetQueryEditor.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetQueryEditor.unit.spec.tsx
@@ -1,0 +1,178 @@
+import { screen } from "@testing-library/react";
+import React from "react";
+import _ from "underscore";
+
+import {
+  setupCollectionsEndpoints,
+  setupDatabasesEndpoints,
+  setupNativeQuerySnippetEndpoints,
+} from "__support__/server-mocks";
+import { renderWithProviders } from "__support__/ui";
+import { Card } from "metabase-types/api";
+import {
+  createMockCard,
+  createMockCollection,
+  createMockDatabase,
+  createMockNativeDatasetQuery,
+} from "metabase-types/api/mocks";
+import {
+  createMockEntitiesState,
+  createMockState,
+} from "metabase-types/store/mocks";
+import { checkNotNull } from "metabase/core/utils/types";
+import { getMetadata } from "metabase/selectors/metadata";
+
+const { NativeQueryEditor } = jest.requireActual(
+  "metabase/query_builder/components/NativeQueryEditor",
+);
+
+const TEST_DB = createMockDatabase();
+
+const TEST_NATIVE_CARD = createMockCard({
+  dataset_query: createMockNativeDatasetQuery({
+    type: "native",
+    database: TEST_DB.id,
+    native: {
+      query: "select * from orders",
+      "template-tags": undefined,
+    },
+  }),
+});
+
+const ROOT_COLLECTION = createMockCollection({ id: "root" });
+
+interface SetupOpts {
+  card?: Card;
+  height?: number;
+  isActive: boolean;
+  readOnly?: boolean;
+}
+
+const setup = async ({
+  card = TEST_NATIVE_CARD,
+  height = 300,
+  isActive,
+  readOnly = false,
+}: SetupOpts) => {
+  setupDatabasesEndpoints([TEST_DB]);
+  setupCollectionsEndpoints([ROOT_COLLECTION]);
+  setupNativeQuerySnippetEndpoints();
+
+  const storeInitialState = createMockState({
+    entities: createMockEntitiesState({
+      databases: [TEST_DB],
+      fields: {},
+      questions: [card],
+      tables: {},
+      metrics: {},
+      schemas: {},
+      segments: {},
+    }),
+  });
+  const metadata = getMetadata(storeInitialState);
+  const question = checkNotNull(metadata.question(card.id));
+  const query = question.query();
+  const DatasetQueryEditor = await importDatasetQueryEditor();
+
+  const { rerender } = renderWithProviders(
+    <DatasetQueryEditor
+      isActive={isActive}
+      height={height}
+      query={query}
+      question={question}
+      readOnly={readOnly}
+      onResizeStop={_.noop}
+    />,
+  );
+
+  return { query, question, rerender };
+};
+
+/**
+ * NativeQueryEditor is globally mocked in test/register-visualizations.js but
+ * its actual implementation is needed in this test suite because we need to
+ * investigate its children.
+ *
+ * We're actually testing NativeQueryEditor indirectly by using DatasetQueryEditor
+ * (which uses NativeQueryEditor), so the NativeQueryEditor has to be unmocked
+ * the moment we import DatasetQueryEditor.
+ *
+ * Unmocking happens in beforeEach, so we can really only import the component
+ * during the unit test.
+ *
+ * Should the import be at the beginning of this file, the mock NativeQueryEditor
+ * would have been used in tests instead of the actual implementation.
+ */
+const importDatasetQueryEditor = async () => {
+  const { default: DatasetQueryEditor } = await import(
+    "metabase/query_builder/components/DatasetEditor/DatasetQueryEditor"
+  );
+  return DatasetQueryEditor;
+};
+
+describe("DatasetQueryEditor", () => {
+  beforeEach(() => {
+    jest.unmock("metabase/query_builder/components/NativeQueryEditor");
+
+    jest
+      .spyOn(NativeQueryEditor.prototype, "loadAceEditor")
+      .mockImplementation(_.noop);
+  });
+
+  it("renders sidebar when query tab is active", async () => {
+    await setup({ isActive: true });
+
+    expect(
+      screen.getByTestId("native-query-editor-sidebar"),
+    ).toBeInTheDocument();
+  });
+
+  it("shows the native query editor container when query tab is active", async () => {
+    await setup({ isActive: true });
+
+    expect(screen.getByTestId("native-query-editor-container")).toBeVisible();
+  });
+
+  it("does not render sidebar when query tab is inactive", async () => {
+    await setup({ isActive: false });
+
+    expect(
+      screen.queryByTestId("native-query-editor-sidebar"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("hides the native query editor container when query tab is inactive", async () => {
+    await setup({ isActive: false });
+
+    expect(
+      screen.getByTestId("native-query-editor-container"),
+    ).not.toBeVisible();
+  });
+
+  it("re-renders DatasetQueryEditor when height is 0 and isActive prop changes", async () => {
+    const { query, question, rerender } = await setup({
+      height: 0,
+      isActive: true,
+    });
+    const DatasetQueryEditor = await importDatasetQueryEditor();
+
+    expect(
+      screen.getByTestId("native-query-editor-sidebar"),
+    ).toBeInTheDocument();
+
+    rerender(
+      <DatasetQueryEditor
+        isActive={false}
+        height={0}
+        query={query}
+        question={question}
+        readOnly={false}
+        onResizeStop={_.noop}
+      />,
+    );
+
+    expect(
+      screen.queryByTestId("native-query-editor-sidebar"),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor.jsx
@@ -56,7 +56,7 @@ import { NativeQueryEditorRoot } from "./NativeQueryEditor.styled";
 const AUTOCOMPLETE_DEBOUNCE_DURATION = 700;
 const AUTOCOMPLETE_CACHE_DURATION = AUTOCOMPLETE_DEBOUNCE_DURATION * 1.2; // tolerate 20%
 
-class NativeQueryEditor extends Component {
+export class NativeQueryEditor extends Component {
   _localUpdate = false;
 
   constructor(props) {
@@ -534,7 +534,10 @@ class NativeQueryEditor extends Component {
     );
 
     return (
-      <NativeQueryEditorRoot className="NativeQueryEditor bg-light full">
+      <NativeQueryEditorRoot
+        className="NativeQueryEditor bg-light full"
+        data-testid="native-query-editor-container"
+      >
         {hasTopBar && (
           <div className="flex align-center" data-testid="native-query-top-bar">
             <div className={!isNativeEditorOpen ? "hide sm-show" : ""}>

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditorSidebar/NativeQueryEditorSidebar.jsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditorSidebar/NativeQueryEditorSidebar.jsx
@@ -62,7 +62,7 @@ const NativeQueryEditorSidebar = props => {
   const canRunQuery = runQuery && cancelQuery;
 
   return (
-    <Container>
+    <Container data-testid="native-query-editor-sidebar">
       <DataReferenceButton {...props} size={ICON_SIZE} className="mt3" />
       <NativeVariablesButton {...props} size={ICON_SIZE} className="mt3" />
       {showSnippetSidebarButton && (

--- a/frontend/test/__support__/server-mocks/index.ts
+++ b/frontend/test/__support__/server-mocks/index.ts
@@ -6,6 +6,7 @@ export * from "./dashboard";
 export * from "./database";
 export * from "./dataset";
 export * from "./field";
+export * from "./native-query-snippet";
 export * from "./search";
 export * from "./session";
 export * from "./settings";

--- a/frontend/test/__support__/server-mocks/native-query-snippet.ts
+++ b/frontend/test/__support__/server-mocks/native-query-snippet.ts
@@ -1,0 +1,5 @@
+import fetchMock from "fetch-mock";
+
+export function setupNativeQuerySnippetEndpoints() {
+  fetchMock.get("path:/api/native-query-snippet", () => []);
+}


### PR DESCRIPTION
Manual backport of #31142 (which is a fix for #30680)

I had to replace `createSampleDatabase` with `createMockDatabase` and add missing `metrics`, `schemas`, and `segments` attributes in `EntitiesState` type (App will crash in test without these objects set in `state.entities`). `EntitiesState` type has been heavily refactored in `master` and eventually that version should be used.