### PR TITLE
Fix revision failed to fetch and returns null pointer

### DIFF
--- a/src/metabase/models/revision.clj
+++ b/src/metabase/models/revision.clj
@@ -98,6 +98,7 @@
   (cond
     (:is_creation revision)  [(deferred-tru "created this")]
     (:is_reversion revision) [(deferred-tru "reverted to an earlier version")]
+    (nil? prev-revision)     [(deferred-tru "modified this")]
     :else                    (diff-strings model (:object prev-revision) (:object revision))))
 
 (defn- revision-description-info
@@ -110,7 +111,7 @@
                              ;; so there are cases when revision can comeback as `nil`.
                              ;; This is a safe guard for us to not display "Crowberto null" as
                              ;; description on UI
-                             (deferred-tru "made a revision."))
+                             (deferred-tru "created a revision with no change."))
      ;; this is used on FE
      :has_multiple_changes (> (count changes) 1)}))
 

--- a/src/metabase/models/revision.clj
+++ b/src/metabase/models/revision.clj
@@ -98,15 +98,16 @@
   (cond
     (:is_creation revision)  [(deferred-tru "created this")]
     (:is_reversion revision) [(deferred-tru "reverted to an earlier version")]
+    ;; We only keep [[revision/max-revisions]] number of revision per entity.
+    ;; prev-revision can be nil when we generate description for oldest revision
     (nil? prev-revision)     [(deferred-tru "modified this")]
     :else                    (diff-strings model (:object prev-revision) (:object revision))))
 
 (defn- revision-description-info
   [model prev-revision revision]
-  (let [changes     (revision-changes model prev-revision revision)
-        description (build-sentence changes)]
-    {:description          (if description
-                             description
+  (let [changes (revision-changes model prev-revision revision)]
+    {:description          (if (seq changes)
+                             (build-sentence changes)
                              ;; HACK: before #30285 we record revision even when there is nothing changed,
                              ;; so there are cases when revision can comeback as `nil`.
                              ;; This is a safe guard for us to not display "Crowberto null" as

--- a/src/metabase/models/revision.clj
+++ b/src/metabase/models/revision.clj
@@ -150,7 +150,8 @@
   (when-let [old-revisions (seq (drop max-revisions (map :id (t2/select [Revision :id]
                                                                :model    (name model)
                                                                :model_id id
-                                                               {:order-by [[:timestamp :desc]]}))))]
+                                                               {:order-by [[:timestamp :desc]
+                                                                           [:id :desc]]}))))]
     (t2/delete! Revision :id [:in old-revisions])))
 
 (defn push-revision!

--- a/src/metabase/models/revision.clj
+++ b/src/metabase/models/revision.clj
@@ -102,8 +102,15 @@
 
 (defn- revision-description-info
   [model prev-revision revision]
-  (let [changes (revision-changes model prev-revision revision)]
-    {:description          (build-sentence changes)
+  (let [changes     (revision-changes model prev-revision revision)
+        description (build-sentence changes)]
+    {:description          (if description
+                             description
+                             ;; HACK: before #30285 we record revision even when there is nothing changed,
+                             ;; so there are cases when revision can comeback as `nil`.
+                             ;; This is a safe guard for us to not display "Crowberto null" as
+                             ;; description on UI
+                             (deferred-tru "made a revision"))
      ;; this is used on FE
      :has_multiple_changes (> (count changes) 1)}))
 

--- a/src/metabase/models/revision.clj
+++ b/src/metabase/models/revision.clj
@@ -110,7 +110,7 @@
                              ;; so there are cases when revision can comeback as `nil`.
                              ;; This is a safe guard for us to not display "Crowberto null" as
                              ;; description on UI
-                             (deferred-tru "made a revision"))
+                             (deferred-tru "made a revision."))
      ;; this is used on FE
      :has_multiple_changes (> (count changes) 1)}))
 

--- a/src/metabase/models/revision/diff.clj
+++ b/src/metabase/models/revision/diff.clj
@@ -83,9 +83,7 @@
     (deferred-tru "changed this from a model to a saved question")
 
     [:display _ _]
-    (if v1
-      (deferred-tru "changed the display from {0} to {1}" (name v1) (name v2))
-      (deferred-tru "changed the display to {0}" (name v2)))
+    (deferred-tru "changed the display from {0} to {1}" (name v1) (name v2))
 
     [:result_metadata _ _]
     (deferred-tru "edited the metadata")

--- a/src/metabase/models/revision/diff.clj
+++ b/src/metabase/models/revision/diff.clj
@@ -83,7 +83,9 @@
     (deferred-tru "changed this from a model to a saved question")
 
     [:display _ _]
-    (deferred-tru "changed the display from {0} to {1}" (name v1) (name v2))
+    (if v1
+      (deferred-tru "changed the display from {0} to {1}" (name v1) (name v2))
+      (deferred-tru "changed the display to {0}" (name v2)))
 
     [:result_metadata _ _]
     (deferred-tru "edited the metadata")

--- a/test/metabase/api/revision_test.clj
+++ b/test/metabase/api/revision_test.clj
@@ -52,7 +52,7 @@
 (deftest no-revisions-test
   (testing "Loading revisions, where there are no revisions, should work"
     (t2.with-temp/with-temp [Card {:keys [id]}]
-      (is (= [{:user {}, :diff nil, :description nil, :has_multiple_changes false}]
+      (is (= [{:user {}, :diff nil, :description "made a revision.", :has_multiple_changes false}]
              (get-revisions :card id))))))
 
 ;; case with single creation revision

--- a/test/metabase/api/revision_test.clj
+++ b/test/metabase/api/revision_test.clj
@@ -1,17 +1,17 @@
 (ns metabase.api.revision-test
   (:require
-   [clojure.test :refer :all]
-   [metabase.models.card :refer [Card]]
-   [metabase.models.collection :refer [Collection]]
-   [metabase.models.dashboard :refer [Dashboard]]
-   [metabase.models.dashboard-card :refer [DashboardCard]]
-   [metabase.models.revision :as revision :refer [Revision]]
-   [metabase.test :as mt]
-   [metabase.test.data.users :as test.users]
-   [metabase.test.fixtures :as fixtures]
-   [metabase.util :as u]
-   [toucan2.core :as t2]
-   [toucan2.tools.with-temp :as t2.with-temp]))
+    [clojure.test :refer :all]
+    [metabase.models.card :refer [Card]]
+    [metabase.models.collection :refer [Collection]]
+    [metabase.models.dashboard :refer [Dashboard]]
+    [metabase.models.dashboard-card :refer [DashboardCard]]
+    [metabase.models.revision :as revision :refer [Revision]]
+    [metabase.test :as mt]
+    [metabase.test.data.users :as test.users]
+    [metabase.test.fixtures :as fixtures]
+    [metabase.util :as u]
+    [toucan2.core :as t2]
+    [toucan2.tools.with-temp :as t2.with-temp]))
 
 (use-fixtures :once (fixtures/initialize :db :test-users :web-server :events))
 
@@ -35,11 +35,11 @@
   "Fetch the latest version of a Dashboard and save a revision entry for it. Returns the fetched Dashboard."
   [dash-id is-creation? user]
   (revision/push-revision!
-   :object       (t2/select-one Dashboard :id dash-id)
-   :entity       Dashboard
-   :id           dash-id
-   :user-id      (test.users/user->id user)
-   :is-creation? is-creation?))
+    :object       (t2/select-one Dashboard :id dash-id)
+    :entity       Dashboard
+    :id           dash-id
+    :user-id      (test.users/user->id user)
+    :is-creation? is-creation?))
 
 ;;; # GET /revision
 
@@ -50,9 +50,9 @@
 
 ;; case with no revisions (maintains backwards compatibility with old installs before revisions)
 (deftest no-revisions-test
-  (testing "Loading revisions, where there are no revisions, should work"
+  (testing "Loading revisions, where there are no changes, should work"
     (t2.with-temp/with-temp [Card {:keys [id]}]
-      (is (= [{:user {}, :diff nil, :description "made a revision.", :has_multiple_changes false}]
+      (is (= [{:user {}, :diff nil, :description "modified this.", :has_multiple_changes false}]
              (get-revisions :card id))))))
 
 ;; case with single creation revision
@@ -68,6 +68,29 @@
                :has_multiple_changes false
                :description          "created this."}]
              (get-revisions :card id))))))
+
+(deftest get-revision-for-entity-with-revision-exceeds-max-revision-test
+  (t2.with-temp/with-temp [Card {:keys [id] :as card}]
+    (create-card-revision! (:id card) true :rasta)
+    (doseq [i (range revision/max-revisions)]
+      (t2/update! :model/Card (:id card) {:name (format "New name %d" i)})
+      (create-card-revision! (:id card) false :rasta))
+    (is (= ["renamed this Card from \"New name 13\" to \"New name 14\"."
+            "renamed this Card from \"New name 12\" to \"New name 13\"."
+            "renamed this Card from \"New name 11\" to \"New name 12\"."
+            "renamed this Card from \"New name 10\" to \"New name 11\"."
+            "renamed this Card from \"New name 9\" to \"New name 10\"."
+            "renamed this Card from \"New name 8\" to \"New name 9\"."
+            "renamed this Card from \"New name 7\" to \"New name 8\"."
+            "renamed this Card from \"New name 6\" to \"New name 7\"."
+            "renamed this Card from \"New name 5\" to \"New name 6\"."
+            "renamed this Card from \"New name 4\" to \"New name 5\"."
+            "renamed this Card from \"New name 3\" to \"New name 4\"."
+            "renamed this Card from \"New name 2\" to \"New name 3\"."
+            "renamed this Card from \"New name 1\" to \"New name 2\"."
+            "renamed this Card from \"New name 0\" to \"New name 1\"."
+            "modified this."]
+           (map :description (get-revisions :card id))))))
 
 ;; case with multiple revisions, including reversion
 (deftest multiple-revisions-with-reversion-test
@@ -116,16 +139,16 @@
   (mapv #(dissoc % :id) objects))
 
 (def ^:private default-revision-card
- {:size_x                 4
-  :size_y                 4
-  :row                    0
-  :col                    0
-  :card_id                nil
-  :series                 []
-  :dashboard_tab_id       nil
-  :action_id              nil
-  :parameter_mappings     []
-  :visualization_settings {}})
+  {:size_x                 4
+   :size_y                 4
+   :row                    0
+   :col                    0
+   :card_id                nil
+   :series                 []
+   :dashboard_tab_id       nil
+   :action_id              nil
+   :parameter_mappings     []
+   :visualization_settings {}})
 
 (deftest revert-test
   (testing "Reverting through API works"
@@ -380,10 +403,10 @@
 
       ;; 1. add 2 cards
       (t2/insert-returning-pks! DashboardCard [{:dashboard_id dashboard-id
-                                                                   :size_x       4
-                                                                   :size_y       4
-                                                                   :col          1
-                                                                   :row          1}
+                                                :size_x       4
+                                                :size_y       4
+                                                :col          1
+                                                :row          1}
                                                {:dashboard_id dashboard-id
                                                 :size_x       4
                                                 :size_y       4

--- a/test/metabase/api/revision_test.clj
+++ b/test/metabase/api/revision_test.clj
@@ -1,17 +1,17 @@
 (ns metabase.api.revision-test
   (:require
-    [clojure.test :refer :all]
-    [metabase.models.card :refer [Card]]
-    [metabase.models.collection :refer [Collection]]
-    [metabase.models.dashboard :refer [Dashboard]]
-    [metabase.models.dashboard-card :refer [DashboardCard]]
-    [metabase.models.revision :as revision :refer [Revision]]
-    [metabase.test :as mt]
-    [metabase.test.data.users :as test.users]
-    [metabase.test.fixtures :as fixtures]
-    [metabase.util :as u]
-    [toucan2.core :as t2]
-    [toucan2.tools.with-temp :as t2.with-temp]))
+   [clojure.test :refer :all]
+   [metabase.models.card :refer [Card]]
+   [metabase.models.collection :refer [Collection]]
+   [metabase.models.dashboard :refer [Dashboard]]
+   [metabase.models.dashboard-card :refer [DashboardCard]]
+   [metabase.models.revision :as revision :refer [Revision]]
+   [metabase.test :as mt]
+   [metabase.test.data.users :as test.users]
+   [metabase.test.fixtures :as fixtures]
+   [metabase.util :as u]
+   [toucan2.core :as t2]
+   [toucan2.tools.with-temp :as t2.with-temp]))
 
 (use-fixtures :once (fixtures/initialize :db :test-users :web-server :events))
 
@@ -35,11 +35,11 @@
   "Fetch the latest version of a Dashboard and save a revision entry for it. Returns the fetched Dashboard."
   [dash-id is-creation? user]
   (revision/push-revision!
-    :object       (t2/select-one Dashboard :id dash-id)
-    :entity       Dashboard
-    :id           dash-id
-    :user-id      (test.users/user->id user)
-    :is-creation? is-creation?))
+   :object       (t2/select-one Dashboard :id dash-id)
+   :entity       Dashboard
+   :id           dash-id
+   :user-id      (test.users/user->id user)
+   :is-creation? is-creation?))
 
 ;;; # GET /revision
 

--- a/test/metabase/api/revision_test.clj
+++ b/test/metabase/api/revision_test.clj
@@ -50,7 +50,7 @@
 
 ;; case with no revisions (maintains backwards compatibility with old installs before revisions)
 (deftest no-revisions-test
-  (testing "Loading revisions, where there are no changes, should work"
+  (testing "Loading revisions, where there are no revisions, should work"
     (t2.with-temp/with-temp [Card {:keys [id]}]
       (is (= [{:user {}, :diff nil, :description "modified this.", :has_multiple_changes false}]
              (get-revisions :card id))))))

--- a/test/metabase/api/revision_test.clj
+++ b/test/metabase/api/revision_test.clj
@@ -70,12 +70,14 @@
              (get-revisions :card id))))))
 
 (deftest get-revision-for-entity-with-revision-exceeds-max-revision-test
-  (t2.with-temp/with-temp [Card {:keys [id] :as card}]
+  (t2.with-temp/with-temp [Card {:keys [id] :as card} {:name "A card"}]
     (create-card-revision! (:id card) true :rasta)
-    (doseq [i (range revision/max-revisions)]
+    (doseq [i (range (inc revision/max-revisions))]
       (t2/update! :model/Card (:id card) {:name (format "New name %d" i)})
       (create-card-revision! (:id card) false :rasta))
-    (is (= ["renamed this Card from \"New name 13\" to \"New name 14\"."
+
+    (is (= ["renamed this Card from \"New name 14\" to \"New name 15\"."
+            "renamed this Card from \"New name 13\" to \"New name 14\"."
             "renamed this Card from \"New name 12\" to \"New name 13\"."
             "renamed this Card from \"New name 11\" to \"New name 12\"."
             "renamed this Card from \"New name 10\" to \"New name 11\"."
@@ -88,7 +90,6 @@
             "renamed this Card from \"New name 3\" to \"New name 4\"."
             "renamed this Card from \"New name 2\" to \"New name 3\"."
             "renamed this Card from \"New name 1\" to \"New name 2\"."
-            "renamed this Card from \"New name 0\" to \"New name 1\"."
             "modified this."]
            (map :description (get-revisions :card id))))))
 

--- a/test/metabase/models/card_test.clj
+++ b/test/metabase/models/card_test.clj
@@ -640,71 +640,57 @@
 
 ;;; -------------------------------------------- Revision tests  --------------------------------------------
 
-(deftest diff-cards-str-test
-  (testing "update general info ---"
-    (is (= "added a description and renamed it from \"Diff Test\" to \"Diff Test Changed\"."
-           (build-sentence
-             (revision/diff-strings
-               :model/Card
-               {:name        "Diff Test"
-                :description nil}
-               {:name        "Diff Test Changed"
-                :description "foobar"}))))
+(deftest ^:parallel diff-cards-str-test
+  (are [x y expected] (= expected
+                       (build-sentence (revision/diff-strings :model/Card x y)))
+    {:name        "Diff Test"
+     :description nil}
+    {:name        "Diff Test Changed"
+     :description "foobar"}
+    "added a description and renamed it from \"Diff Test\" to \"Diff Test Changed\"."
 
-    (is (= "renamed this Card from \"Apple\" to \"Next\"."
-           (build-sentence
-             (revision/diff-strings
-               :model/Card
-               {:name "Apple"}
-               {:name "Next"}))))
+    {:name "Apple"}
+    {:name "Next"}
+    "renamed this Card from \"Apple\" to \"Next\"."
 
-    ;; multiple changes
-    (is (= "added a description and renamed it from \"Diff Test\" to \"Diff Test changed\"."
-           (build-sentence
-             (revision/diff-strings
-               :model/Card
-               {:name        "Diff Test"
-                :description nil}
-               {:name        "Diff Test changed"
-                :description "New description"})))))
+    {}
+    {:display :table}
+    "changed the display to table."
 
- (testing "update collection ---"
-   (is (= "moved this Card to Our analytics."
-          (build-sentence
-            (revision/diff-strings
-              :model/Card
-              {:name "Apple"}
-              {:name          "Apple"
-               :collection_id nil}))))
-  (t2.with-temp/with-temp
-    [Collection {coll-id :id} {:name "New collection"}]
-    (is (= "moved this Card to New collection."
-           (build-sentence
-             (revision/diff-strings
-               :model/Card
-               {:name "Apple"}
-               {:name          "Apple"
-                :collection_id coll-id}))))
-    (is (= "moved this Card from New collection to Our analytics."
-           (build-sentence
-             (revision/diff-strings
-               :model/Card
-               {:name "Apple"
-                :collection_id coll-id}
-               {:name          "Apple"
-                :collection_id nil})))))
+    {:display :table}
+    {:display :pie}
+    "changed the display from table to pie."
 
-  (t2.with-temp/with-temp
-    [Collection {coll-id-1 :id} {:name "Old collection"}
-     Collection {coll-id-2 :id} {:name "New collection"}]
-    (is (= "moved this Card from Old collection to New collection."
-           (build-sentence
-             (revision/diff-strings
-               :model/Card
-               {:name          "Apple"
-                :collection_id coll-id-1}
-               {:name          "Apple"
-                :collection_id coll-id-2})))))))
+    {:name        "Diff Test"
+     :description nil}
+    {:name        "Diff Test changed"
+     :description "New description"}
+    "added a description and renamed it from \"Diff Test\" to \"Diff Test changed\"."))
+
+
+(deftest diff-cards-str-update-collection--test
+ (t2.with-temp/with-temp
+     [Collection {coll-id-1 :id} {:name "Old collection"}
+      Collection {coll-id-2 :id} {:name "New collection"}]
+     (are [x y expected] (= expected
+                          (build-sentence (revision/diff-strings :model/Card x y)))
+
+       {:name "Apple"}
+       {:name          "Apple"
+        :collection_id coll-id-2}
+       "moved this Card to New collection."
+
+       {:name        "Diff Test"
+        :description nil}
+       {:name        "Diff Test changed"
+        :description "New description"}
+       "added a description and renamed it from \"Diff Test\" to \"Diff Test changed\"."
+
+       {:name          "Apple"
+        :collection_id coll-id-1}
+       {:name          "Apple"
+        :collection_id coll-id-2}
+       "moved this Card from Old collection to New collection.")))
 
 (defn- create-card-revision!
   "Fetch the latest version of a Dashboard and save a revision entry for it. Returns the fetched Dashboard."

--- a/test/metabase/models/card_test.clj
+++ b/test/metabase/models/card_test.clj
@@ -653,10 +653,6 @@
     {:name "Next"}
     "renamed this Card from \"Apple\" to \"Next\"."
 
-    {}
-    {:display :table}
-    "changed the display to table."
-
     {:display :table}
     {:display :pie}
     "changed the display from table to pie."

--- a/test/metabase/models/revision_test.clj
+++ b/test/metabase/models/revision_test.clj
@@ -188,7 +188,11 @@
                (assert (= 2 (count revisions)))
                (-> (revision/add-revision-details FakedCard (first revisions) (last revisions))
                    (dissoc :timestamp :id :model_id)
-                   mt/derecordize)))))))
+                   mt/derecordize))))))
+
+  (testing "test that we return a description even when there is nothing changes between revision"
+    (is (= (deferred-tru "made a revision")
+           (:description (revision/add-revision-details FakedCard nil nil))))))
 
 (deftest revisions+details-test
   (testing "Check that revisions+details pulls in user info and adds description"

--- a/test/metabase/models/revision_test.clj
+++ b/test/metabase/models/revision_test.clj
@@ -190,9 +190,13 @@
                    (dissoc :timestamp :id :model_id)
                    mt/derecordize))))))
 
-  (testing "test that we return a description even when there is nothing changes between revision"
-    (is (= (deferred-tru "made a revision.")
-           (:description (revision/add-revision-details FakedCard nil nil))))))
+  (testing "test that we return a description even when there is no change between revision"
+    (is (= "created a revision with no change."
+           (str (:description (revision/add-revision-details FakedCard {:name "Apple"} {:name "Apple"}))))))
+
+  (testing "that we return a descrtiopn when there is no previous revision"
+    (is (= "modified this."
+           (str (:description (revision/add-revision-details FakedCard {:name "Apple"} nil)))))))
 
 (deftest revisions+details-test
   (testing "Check that revisions+details pulls in user info and adds description"
@@ -207,7 +211,7 @@
                 :diff                 {:o1 nil
                                        :o2 {:name "Tips Created by Day", :serialized true}}
                 :has_multiple_changes false
-                :description          "made a revision."})]
+                :description          "modified this."})]
              (->> (revision/revisions+details FakedCard card-id)
                   (map #(dissoc % :timestamp :id :model_id))
                   (map #(update % :description str))))))))
@@ -237,7 +241,7 @@
                 :diff                 {:o1 nil
                                        :o2 {:name "Tips Created by Day", :serialized true}}
                 :has_multiple_changes false
-                :description          "made a revision."})]
+                :description          "modified this."})]
              (->> (revision/revisions+details FakedCard card-id)
                   (map #(dissoc % :timestamp :id :model_id))
                   (map #(update % :description str))))))))

--- a/test/metabase/models/revision_test.clj
+++ b/test/metabase/models/revision_test.clj
@@ -191,7 +191,7 @@
                    mt/derecordize))))))
 
   (testing "test that we return a description even when there is nothing changes between revision"
-    (is (= (deferred-tru "made a revision")
+    (is (= (deferred-tru "made a revision.")
            (:description (revision/add-revision-details FakedCard nil nil))))))
 
 (deftest revisions+details-test
@@ -207,9 +207,10 @@
                 :diff                 {:o1 nil
                                        :o2 {:name "Tips Created by Day", :serialized true}}
                 :has_multiple_changes false
-                :description          nil})]
+                :description          "made a revision."})]
              (->> (revision/revisions+details FakedCard card-id)
-                  (map #(dissoc % :timestamp :id :model_id))))))))
+                  (map #(dissoc % :timestamp :id :model_id))
+                  (map #(update % :description str))))))))
 
 (deftest defer-to-describe-diff-test
   (testing "Check that revisions properly defer to describe-diff"
@@ -236,9 +237,10 @@
                 :diff                 {:o1 nil
                                        :o2 {:name "Tips Created by Day", :serialized true}}
                 :has_multiple_changes false
-                :description          nil})]
+                :description          "made a revision."})]
              (->> (revision/revisions+details FakedCard card-id)
-                  (map #(dissoc % :timestamp :id :model_id))))))))
+                  (map #(dissoc % :timestamp :id :model_id))
+                  (map #(update % :description str))))))))
 
 ;;; # REVERT
 


### PR DESCRIPTION
This PR does 2 things:
1. fix a bug when fetching revision that might result in 500 with a null pointer error (see comment)
2. Put a safeguard to return a "You created a revision with no change." description when the revision contains no diff

Repro for the 1st bug:
1. Created a question with a breakout
2. save
3. change the display type(to bar or sth compatible)
4. change the name 15 times ( basically util when you see the You created this  revision got deleted)
