### PR TITLE
Fix `Card.tsx` padding

### DIFF
--- a/frontend/src/metabase/components/Card/Card.tsx
+++ b/frontend/src/metabase/components/Card/Card.tsx
@@ -10,7 +10,6 @@ type CardProps = {
 };
 
 const Card = styled.div<CardProps>`
-  padding: 1rem;
   background-color: ${props => (props.dark ? color("text-dark") : "white")};
   border: 1px solid
     ${props => (props.dark ? "transparent" : color("bg-medium"))};

--- a/frontend/src/metabase/components/Card/Card.tsx
+++ b/frontend/src/metabase/components/Card/Card.tsx
@@ -10,6 +10,7 @@ type CardProps = {
 };
 
 const Card = styled.div<CardProps>`
+  padding: 1rem;
   background-color: ${props => (props.dark ? color("text-dark") : "white")};
   border: 1px solid
     ${props => (props.dark ? "transparent" : color("bg-medium"))};

--- a/frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx
+++ b/frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx
@@ -273,7 +273,7 @@ const SuggestionsList = ({ suggestions, section }) => (
               className="mb1 block hover-parent hover--visibility text-brand-hover"
               data-metabase-event={`Auto Dashboard;Click Related;${s}`}
             >
-              <Card p={2} hoverable>
+              <Card className="p2" hoverable>
                 <ItemContent>
                   <Icon
                     name={RELATED_CONTENT[s].icon}


### PR DESCRIPTION
This commit fixes a visual regression in the `Card.tsx` component, which happened after we removed the styled system in #31306.

The regression happened [due to this diff](https://github.com/metabase/metabase/pull/31306/files#diff-f6034db99d769043f8c1a6ffa32f5f52d3d2fff3efdc88b77fd6cd0645eb51efL14-L15):
```diff
const Card = styled.div<CardProps>`
-  ${width}
-  ${space}
```


### Screenshots
Before #31306
```css
.css-tnu81r-Card {
    padding: 16px;
    background-color: white;
    border: 1px solid #EDF2F5;
    border-radius: 6px;
    box-shadow: 0 7px 20px rgba(0,0,0,0.08);
    line-height: 24px;
}
```

<img width="542" alt="image" src="https://github.com/metabase/metabase/assets/31325167/5fd417ba-72a9-4d71-9332-fb319cd5e779">


After #31306 
```css
.css-opmloa-Card {
    background-color: white;
    border: 1px solid #EDF2F5;
    border-radius: 6px;
    box-shadow: 0 7px 20px rgba(0,0,0,0.08);
    line-height: 24px;
}
```

<img width="569" alt="image" src="https://github.com/metabase/metabase/assets/31325167/24af23fb-c7ba-46b8-8983-fb61772e21d2">


After the fix
```css
.css-1fwdw5c-Card {
    padding: 1rem;
    background-color: white;
    border: 1px solid #EDF2F5;
    border-radius: 6px;
    box-shadow: 0 7px 20px rgba(0,0,0,0.08);
    line-height: 24px;
}
```
<img width="563" alt="image" src="https://github.com/metabase/metabase/assets/31325167/47f87d57-9a13-4254-bbb9-e6e959ab8396">
