### PR TITLE
FE: show a banner for public action with hidden required field

### DIFF
--- a/frontend/src/metabase-types/api/mocks/actions.ts
+++ b/frontend/src/metabase-types/api/mocks/actions.ts
@@ -128,3 +128,12 @@ export const createMockFieldSettings = (
   width: "medium",
   ...opts,
 });
+
+export const createMockImplicitActionFieldSettings = (
+  opts?: Partial<FieldSettings>,
+) =>
+  ({
+    id: "",
+    hidden: false,
+    ...opts,
+  } as FieldSettings);

--- a/frontend/src/metabase/actions/containers/ActionCreator/ActionCreatorView.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/ActionCreatorView.tsx
@@ -21,6 +21,7 @@ import {
 import { isNotNull } from "metabase/core/utils/types";
 import type { ActionFormSettings, WritebackAction } from "metabase-types/api";
 
+import { isActionPublic } from "metabase/actions/utils";
 import type { ActionCreatorUIProps, SideView } from "./types";
 import InlineActionSettings, {
   ActionSettingsTriggerButton,
@@ -125,6 +126,7 @@ export default function ActionCreatorView({
               parameters={action.parameters ?? []}
               formSettings={formSettings}
               isEditable={isEditable && canChangeFieldSettings}
+              isPublic={isActionPublic(action)}
               onChange={onChangeFormSettings}
             />
           ) : activeSideView === "dataReference" ? (

--- a/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/FormCreator.styled.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/FormCreator.styled.tsx
@@ -2,24 +2,24 @@ import styled from "@emotion/styled";
 import { Icon } from "metabase/core/components/Icon";
 import ExternalLink from "metabase/core/components/ExternalLink";
 
-import { color, lighten } from "metabase/lib/colors";
+import { color, lighten, alpha } from "metabase/lib/colors";
 import { space } from "metabase/styled-components/theme";
 
 export const FormContainer = styled.div`
-  flex: 1 1 0;
-  margin: 1rem 1.5rem;
+  display: flex;
+  gap: ${space(2)};
+  padding: 0 1.5rem 1rem;
   transition: flex 500ms ease-in-out;
   background-color: ${color("white")};
+  flex-direction: column;
 `;
 
 export const FormFieldEditorDragContainer = styled.div`
   margin-bottom: ${space(1)};
 `;
 
-export const InfoText = styled.span`
-  display: block;
+export const InfoText = styled.div`
   color: ${color("text-medium")};
-  margin-bottom: 2rem;
 `;
 
 export const FieldSettingsButtonsContainer = styled.div`
@@ -82,4 +82,12 @@ export const TopRightIcon = styled(Icon)`
   position: absolute;
   top: 0;
   right: 0;
+`;
+
+export const WarningBanner = styled.div`
+  padding: ${space(2)};
+  border: 1px solid ${color("warning")};
+  border-radius: ${space(1)};
+  background: ${alpha("warning", 0.1)};
+  line-height: 1.25rem;
 `;

--- a/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/FormCreator.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/FormCreator.tsx
@@ -38,6 +38,7 @@ import {
   FormContainer,
   FormFieldEditorDragContainer,
   InfoText,
+  WarningBanner,
 } from "./FormCreator.styled";
 
 // FormEditor's can't be submitted as it serves as a form preview
@@ -47,6 +48,7 @@ interface FormCreatorProps {
   parameters: Parameter[];
   formSettings?: ActionFormSettings;
   isEditable: boolean;
+  isPublic: boolean;
   onChange: (formSettings: ActionFormSettings) => void;
 }
 
@@ -54,6 +56,7 @@ function FormCreator({
   parameters,
   formSettings: passedFormSettings,
   isEditable,
+  isPublic,
   onChange,
 }: FormCreatorProps) {
   const [formSettings, setFormSettings] = useState<ActionFormSettings>(
@@ -151,12 +154,26 @@ function FormCreator({
     >{t`Learn more`}</ExternalLink>
   );
 
+  const showWarning =
+    isPublic &&
+    form.fields.some(field => {
+      const settings = fieldSettings[field.name];
+
+      return settings.hidden && !field.optional;
+    });
+
   return (
     <SidebarContent title={t`Action parameters`}>
       <FormContainer>
         <InfoText>
           {jt`Configure your parameters' types and properties here. The values for these parameters can come from user input, or from a dashboard filter. ${docsLink}`}
         </InfoText>
+        {showWarning && (
+          <WarningBanner data-testid="action-warning-banner">
+            <b>{t`Heads up.`}</b>{" "}
+            {t`Your action is public and has a hidden required field. There's a good chance this will cause the action to fail.`}
+          </WarningBanner>
+        )}
         <FormProvider
           enableReinitialize
           initialValues={displayValues}

--- a/frontend/src/metabase/actions/containers/ActionCreator/InlineActionSettings.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/InlineActionSettings.tsx
@@ -27,7 +27,7 @@ import Modal from "metabase/components/Modal";
 import { useToggle } from "metabase/hooks/use-toggle";
 import CopyWidget from "metabase/components/CopyWidget";
 
-import { isSavedAction } from "../../utils";
+import { isActionPublic, isSavedAction } from "../../utils";
 import {
   ActionSettingsContent,
   CopyWidgetContainer,
@@ -134,7 +134,7 @@ const InlineActionSettings = ({
           >
             <Toggle
               id={`${id}-public`}
-              value={action.public_uuid != null}
+              value={isActionPublic(action)}
               onChange={handleTogglePublic}
             />
           </FormField>

--- a/frontend/src/metabase/actions/utils.ts
+++ b/frontend/src/metabase/actions/utils.ts
@@ -229,7 +229,9 @@ const getFormField = (
       parameter.id,
     description: fieldSettings.description ?? "",
     placeholder: fieldSettings?.placeholder,
-    optional: !fieldSettings.required,
+    // fieldSettings for implicit actions contain only `hidden` and `id`
+    // in this case we rely on required settings of parameter
+    optional: fieldSettings.required === false || parameter.required === false,
     field: fieldSettings.field,
   };
 
@@ -330,4 +332,8 @@ export const getSubmitButtonLabel = (action: WritebackAction): string => {
   }
 
   return action.name;
+};
+
+export const isActionPublic = (action: Partial<WritebackAction>) => {
+  return action.public_uuid != null;
 };


### PR DESCRIPTION
Epic: https://github.com/metabase/metabase/issues/30016

### Description

For a public action with hidden required fields during editing we need to show a warning banner for user, so he will understand that the public action might be broken.

### Design

<img width="1175" alt="image" src="https://github.com/metabase/metabase/assets/125459446/7aacdd20-a053-4031-ba3a-5e8abb047eae">

https://www.figma.com/file/KR5LAZlsMriM9XdsYRHkFA/Allow-users-to-hide-action-form-fields?type=design&node-id=73-693&t=durqtIMRWIRP9K34-0

### Demo

https://www.loom.com/share/ddd1f8e3ab0c41b48cee5617b5e25837

### Additions
 
- [x] rework css for FormCreator: replaced margin with padding, used flex-gap for spacing
- [x] unit test for showing banner
- [x] fix wrongly showing `(optional)` subtitle for required fields in implicit actions
- [ ] e2e test?