### PR TITLE
Updates Snowflake driver to decode uploaded private key file

### DIFF
--- a/modules/drivers/snowflake/resources/metabase-plugin.yaml
+++ b/modules/drivers/snowflake/resources/metabase-plugin.yaml
@@ -16,7 +16,7 @@ driver:
     - user
     - password
     - name: private-key
-      display-name: RSA private key (PEM)
+      display-name: RSA private key (PKCS#8/.p8)
       type: secret
       secret-kind: pem-cert
     - name: warehouse

--- a/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
+++ b/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
@@ -20,6 +20,7 @@
    [metabase.driver.sql.util :as sql.u]
    [metabase.driver.sql.util.unprepare :as unprepare]
    [metabase.driver.sync :as driver.s]
+   [metabase.driver.util :as driver.u]
    [metabase.models.secret :as secret]
    [metabase.query-processor.error-type :as qp.error-type]
    [metabase.query-processor.store :as qp.store]
@@ -30,8 +31,7 @@
    [metabase.util.honey-sql-2 :as h2x]
    [metabase.util.i18n :refer [trs tru]]
    [metabase.util.log :as log]
-   [ring.util.codec :as codec]
-   [metabase.driver.util :as driver.u])
+   [ring.util.codec :as codec])
   (:import
    (java.io File)
    (java.nio.charset StandardCharsets)

--- a/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
+++ b/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
@@ -30,7 +30,8 @@
    [metabase.util.honey-sql-2 :as h2x]
    [metabase.util.i18n :refer [trs tru]]
    [metabase.util.log :as log]
-   [ring.util.codec :as codec])
+   [ring.util.codec :as codec]
+   [metabase.driver.util :as driver.u])
   (:import
    (java.io File)
    (java.nio.charset StandardCharsets)
@@ -95,10 +96,11 @@
         private-key-file (handle-conn-uri user account private-key-file)))
 
     private-key-value
-    (let [private-key-str  (if (bytes? private-key-value)
-                             (String. ^bytes private-key-value StandardCharsets/UTF_8)
-                             private-key-value)
-          private-key-file (secret/value->file! {:connection-property-name "private-key-file" :value private-key-str})]
+    (let [private-key-val  (driver.u/decode-uploaded
+                            (if (bytes? private-key-value)
+                              (String. ^bytes private-key-value StandardCharsets/UTF_8)
+                              private-key-value))
+          private-key-file (secret/value->file! {:connection-property-name "private-key-file" :value private-key-val} "pem")]
       (handle-conn-uri details user account private-key-file))))
 
 (defmethod sql-jdbc.conn/connection-details->spec :snowflake

--- a/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
+++ b/modules/drivers/snowflake/src/metabase/driver/snowflake.clj
@@ -96,11 +96,13 @@
         private-key-file (handle-conn-uri user account private-key-file)))
 
     private-key-value
-    (let [private-key-val  (driver.u/decode-uploaded
-                            (if (bytes? private-key-value)
-                              (String. ^bytes private-key-value StandardCharsets/UTF_8)
-                              private-key-value))
-          private-key-file (secret/value->file! {:connection-property-name "private-key-file" :value private-key-val} "pem")]
+    (let [private-key-str      (if (bytes? private-key-value)
+                                 (String. ^bytes private-key-value StandardCharsets/UTF_8)
+                                 private-key-value)
+          private-key-file-val (cond-> private-key-str
+                                 (re-find driver.u/data-url-pattern private-key-str) driver.u/decode-uploaded)
+          private-key-file     (secret/value->file! {:connection-property-name "private-key-file"
+                                                     :value                    private-key-file-val})]
       (handle-conn-uri details user account private-key-file))))
 
 (defmethod sql-jdbc.conn/connection-details->spec :snowflake

--- a/src/metabase/driver/util.clj
+++ b/src/metabase/driver/util.clj
@@ -384,11 +384,15 @@
                 (assoc :visible-if v-ifs*))))
          final-props)))
 
+(def ^:private data-url-pattern #"^data:[^;]+;base64,")
+
 (defn decode-uploaded
   "Decode `uploaded-data` as an uploaded field.
   Optionally strip the Base64 MIME prefix."
-  ^bytes [uploaded-data]
-  (u/decode-base64-to-bytes (str/replace uploaded-data #"^data:[^;]+;base64," "")))
+  ^bytes [^String uploaded-data]
+  (if (re-find data-url-pattern uploaded-data)
+    (u/decode-base64-to-bytes (str/replace uploaded-data data-url-pattern ""))
+    (.getBytes uploaded-data "UTF-8")))
 
 (defn db-details-client->server
   "Currently, this transforms client side values for the various back into :type :secret for storage on the server.

--- a/src/metabase/driver/util.clj
+++ b/src/metabase/driver/util.clj
@@ -384,15 +384,14 @@
                 (assoc :visible-if v-ifs*))))
          final-props)))
 
-(def ^:private data-url-pattern #"^data:[^;]+;base64,")
+(def data-url-pattern
+  "A regex to match data-URL-encoded files uploaded via the frontend"
+  #"^data:[^;]+;base64,")
 
 (defn decode-uploaded
-  "Decode `uploaded-data` as an uploaded field.
-  Optionally strip the Base64 MIME prefix."
+  "Returns bytes from encoded frontend file upload string."
   ^bytes [^String uploaded-data]
-  (if (re-find data-url-pattern uploaded-data)
-    (u/decode-base64-to-bytes (str/replace uploaded-data data-url-pattern ""))
-    (.getBytes uploaded-data "UTF-8")))
+  (u/decode-base64-to-bytes (str/replace uploaded-data data-url-pattern "")))
 
 (defn db-details-client->server
   "Currently, this transforms client side values for the various back into :type :secret for storage on the server.

--- a/test/metabase/driver/util_test.clj
+++ b/test/metabase/driver/util_test.clj
@@ -226,7 +226,8 @@
                       :keystore-options        "uploaded"
                       ;; because treat-before-posting is base64 in the config for this property, simulate that happening
                       :keystore-value          (->> (.getBytes ks-val StandardCharsets/UTF_8)
-                                                    (.encodeToString (Base64/getEncoder)))
+                                                    (.encodeToString (Base64/getEncoder))
+                                                    (str "data:application/octet-stream;base64,"))
                       :keystore-password-value "my-keystore-pw"}
           transformed (driver.u/db-details-client->server :secret-test-driver db-details)]
       ;; compare all fields except `:keystore-value` as a single map

--- a/test/metabase/driver/util_test.clj
+++ b/test/metabase/driver/util_test.clj
@@ -239,6 +239,11 @@
       ;; the keystore-value should have been base64 decoded because of treat-before-posting being base64 (see above)
       (is (mt/secret-value-equals? ks-val (:keystore-value transformed))))))
 
+(deftest decode-uploaded-test
+  (are [expected base64] (= expected (String. (driver.u/decode-uploaded base64) "UTF-8"))
+    "hi" "aGk="
+    "hi" "data:application/octet-stream;base64,aGk="))
+
 (deftest semantic-version-gte-test
   (testing "semantic-version-gte works as expected"
     (is (true? (driver.u/semantic-version-gte [5 0] [4 0])))


### PR DESCRIPTION
This updates the Snowflake driver to call `metabase.driver.util/decode-uploaded` on the uploaded private key value.

Resolves #31273

While working on this, I found that the Snowflake driver requires a PKCS#8 (.p8) file for the private key, while the property display name just says "PEM", so I updated it to be more specific and to align with Snowflake docs.