### PR TITLE
CI: for i18n workflow, install xgettext conditionally

### DIFF
--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -24,8 +24,13 @@ jobs:
       uses: ./.github/actions/prepare-backend
       with:
         m2-cache-key: 'i18n'
-    - run: sudo apt install gettext
-
+    - name: Install xgettext if necessary
+      run: |
+        if ! command -v xgettext > /dev/null; then
+          sudo apt install gettext
+        fi
+    - name: Check xgettext version
+      run: xgettext --version
     - name: Check i18n tags/make sure template can be built
       run: ./bin/i18n/update-translation-template
     - name: Verify i18n translations (.po files)


### PR DESCRIPTION
### Before

Always install xgettext (via `gettext` package)

### After

Check first, if it doesn't exist then go ahead and install it. Also print the version.

![image](https://github.com/metabase/metabase/assets/7288/a1ad16e1-25e5-4752-abd0-45904e2f4588)

Note that later xgettext gets more stricter, hence this prep work before bumping this workflow with latest Ubuntu (which has the stricter, updated xgettext).