### PR TITLE
Run i18n workflow on ubuntu 22.04

### DIFF
--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
 
   verify-i18n-files:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 15
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
One last attempt to run i18n workflow on Ubuntu 22.04 after #31360

If this is successful, it might close #28603