### PR TITLE
Exclude SSO group mappings settings from cache

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/sso/integrations/sso_settings.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/integrations/sso_settings.clj
@@ -88,6 +88,7 @@ on your IdP, this usually looks something like http://www.example.com/141xkex604
   ;; Should be in the form: {"groupName": [1, 2, 3]} where keys are SAML groups and values are lists of MB groups IDs
   (deferred-tru "JSON containing SAML to Metabase group mappings.")
   :type    :json
+  :cache?  false
   :default {}
   :setter (comp (partial setting/set-value-of-type! :json :saml-group-mappings) validate-group-mappings))
 
@@ -142,6 +143,7 @@ on your IdP, this usually looks something like http://www.example.com/141xkex604
   ;; Should be in the form: {"groupName": [1, 2, 3]} where keys are JWT groups and values are lists of MB groups IDs
   (deferred-tru "JSON containing JWT to Metabase group mappings.")
   :type    :json
+  :cache?  false
   :default {}
   :setter  (comp (partial setting/set-value-of-type! :json :jwt-group-mappings) validate-group-mappings))
 

--- a/src/metabase/integrations/ldap.clj
+++ b/src/metabase/integrations/ldap.clj
@@ -80,6 +80,7 @@
   ;; MB groups IDs
   (deferred-tru "JSON containing LDAP to Metabase group mappings.")
   :type    :json
+  :cache?  false
   :default {}
   :getter  (fn []
              (json/parse-string (setting/get-value-of-type :string :ldap-group-mappings) #(DN. (str %))))


### PR DESCRIPTION
Addresses https://github.com/metabase/metabase/issues/29912

Should be OK since these settings are read relatively infrequently (only on login or from the admin panel). See [this thread](https://metaboat.slack.com/archives/CKZEMT1MJ/p1686072846178359) for more details on customer's use case.

Excluded group mapping settings for JWT, SAML and LDAP for consistency.