### PR TITLE
Fix `validate-github-release` step

### DIFF
--- a/bin/build/src/release/common/github.clj
+++ b/bin/build/src/release/common/github.clj
@@ -11,7 +11,7 @@
 
 (defn github-api-request-headers []
   {"Content-Type"  "application/json"
-   "Authorization" (format "token %s" (u/env-or-throw :github-token))})
+   "Authorization" (format "Bearer %s" (u/env-or-throw :github-token))})
 
 (defn- GET [endpoint]
   (-> (http/get (str (github-api-base) endpoint) {:headers (github-api-request-headers)})


### PR DESCRIPTION
The release script fails to parse draft releases.
If we look at the official documentation, there is this important note:
> Information about published releases are available to everyone.
> **Only users with push access will receive listings for draft releases.**

https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28#list-releases

So, we need to authenticate with the token with push permissions. The token used during the release definitely has the right permissions, so somehting else must be wrong.

Looking further at the documentation we see the example for `curl`:
```bash
curl -L \
  -H "Accept: application/vnd.github+json" \
  -H "Authorization: Bearer <YOUR-TOKEN>"\
  -H "X-GitHub-Api-Version: 2022-11-28" \
  https://api.github.com/repos/OWNER/REPO/releases
```

Either GitHub changed the "Authorization" header at some point, or this step never worked because it was using `token` instead of `Bearer`.

[Fix: #31378]

### How to test?
Either heavily adjust the release script and make it work in your Metabase fork, or wait until the next minor release where we can test it and make sure that the validation step doesn't fail anymore.
