### PR TITLE
CSV upload loading messages

### DIFF
--- a/frontend/src/metabase/status/components/FileUploadStatus/FileUploadStatus.unit.spec.tsx
+++ b/frontend/src/metabase/status/components/FileUploadStatus/FileUploadStatus.unit.spec.tsx
@@ -25,6 +25,10 @@ describe("FileUploadStatus", () => {
     ]);
   });
 
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
   it("Should group uploads by collection", async () => {
     const uploadOne = createMockUpload({
       collectionId: firstCollectionId,
@@ -69,6 +73,7 @@ describe("FileUploadStatus", () => {
   });
 
   it("Should show a start exploring link on completion", async () => {
+    jest.useFakeTimers({ advanceTimers: true });
     fetchMock.post("path:/api/card/from-csv", "3", { delay: 1000 });
 
     renderWithProviders(
@@ -101,20 +106,21 @@ describe("FileUploadStatus", () => {
       new File(["foo, bar"], "test.csv", { type: "text/csv" }),
     );
 
+    jest.advanceTimersByTime(500);
+
     expect(
       await screen.findByText("Uploading data to Collection …"),
     ).toBeInTheDocument();
 
+    jest.advanceTimersByTime(1000);
+
     expect(
-      await screen.findByRole(
-        "link",
-        { name: "Start exploring" },
-        { timeout: 5000 },
-      ),
+      await screen.findByRole("link", { name: "Start exploring" }),
     ).toHaveAttribute("href", "/model/3");
   });
 
   it("Should show an error message on error", async () => {
+    jest.useFakeTimers({ advanceTimers: true });
     fetchMock.post(
       "path:/api/card/from-csv",
       {
@@ -153,23 +159,23 @@ describe("FileUploadStatus", () => {
       new File(["foo, bar"], "test.csv", { type: "text/csv" }),
     );
 
+    jest.advanceTimersByTime(500);
+
     expect(
       await screen.findByText("Uploading data to Collection …"),
     ).toBeInTheDocument();
 
+    jest.advanceTimersByTime(500);
+
     expect(
-      await screen.findByText(
-        "Error uploading your File",
-        {},
-        { timeout: 3000 },
-      ),
+      await screen.findByText("Error uploading your File"),
     ).toBeInTheDocument();
     expect(await screen.findByText("It's dead Jim")).toBeInTheDocument();
   });
 
   describe("loading state", () => {
     it("should rotate loading messages after 30 seconds", async () => {
-      jest.useFakeTimers();
+      jest.useFakeTimers({ advanceTimers: true });
       fetchMock.post("path:/api/card/from-csv", "3", { delay: 90 * 1000 });
 
       renderWithProviders(
@@ -221,14 +227,8 @@ describe("FileUploadStatus", () => {
       jest.advanceTimersByTime(30 * 1000);
 
       expect(
-        await screen.findByRole(
-          "link",
-          { name: "Start exploring" },
-          { timeout: 5000 },
-        ),
+        await screen.findByRole("link", { name: "Start exploring" }),
       ).toHaveAttribute("href", "/model/3");
-
-      jest.useRealTimers();
     });
   });
 });

--- a/frontend/src/metabase/status/components/FileUploadStatus/FileUploadStatus.unit.spec.tsx
+++ b/frontend/src/metabase/status/components/FileUploadStatus/FileUploadStatus.unit.spec.tsx
@@ -54,11 +54,11 @@ describe("FileUploadStatus", () => {
     });
 
     expect(
-      await screen.findByText("Uploading data to Collection..."),
+      await screen.findByText("Uploading data to Collection …"),
     ).toBeInTheDocument();
 
     expect(
-      await screen.findByText("Uploading data to Second Collection..."),
+      await screen.findByText("Uploading data to Second Collection …"),
     ).toBeInTheDocument();
 
     expect(await screen.findByText("test.csv")).toBeInTheDocument();
@@ -102,7 +102,7 @@ describe("FileUploadStatus", () => {
     );
 
     expect(
-      await screen.findByText("Uploading data to Collection..."),
+      await screen.findByText("Uploading data to Collection …"),
     ).toBeInTheDocument();
 
     expect(
@@ -154,7 +154,7 @@ describe("FileUploadStatus", () => {
     );
 
     expect(
-      await screen.findByText("Uploading data to Collection..."),
+      await screen.findByText("Uploading data to Collection …"),
     ).toBeInTheDocument();
 
     expect(

--- a/frontend/src/metabase/status/components/FileUploadStatusLarge/FileUploadStatusLarge.tsx
+++ b/frontend/src/metabase/status/components/FileUploadStatusLarge/FileUploadStatusLarge.tsx
@@ -1,3 +1,5 @@
+import { useState } from "react";
+import { useInterval } from "react-use";
 import { t } from "ttag";
 import Link from "metabase/core/components/Link";
 import { Collection } from "metabase-types/api";
@@ -11,6 +13,8 @@ import {
 
 import StatusLarge from "../StatusLarge";
 
+const UPLOAD_MESSAGE_UPDATE_INTERVAL = 30 * 1000;
+
 export interface FileUploadLargeProps {
   collection: Collection;
   uploads: FileUpload[];
@@ -22,8 +26,24 @@ const FileUploadLarge = ({
   uploads,
   isActive,
 }: FileUploadLargeProps): JSX.Element => {
+  const [loadingTime, setLoadingTime] = useState(0);
+
+  const isLoading = uploads.some(isUploadInProgress);
+
+  useInterval(
+    () => {
+      setLoadingTime(loadingTime + 1);
+    },
+    isLoading ? UPLOAD_MESSAGE_UPDATE_INTERVAL : null,
+  ); // null pauses the timer
+
+  const title =
+    isLoading && loadingTime > 0
+      ? getLoadingMessage(loadingTime)
+      : getTitle(uploads, collection);
+
   const status = {
-    title: getTitle(uploads, collection),
+    title,
     items: uploads.map(upload => ({
       id: upload.id,
       title: getName(upload),
@@ -54,8 +74,21 @@ const getTitle = (uploads: FileUpload[], collection: Collection) => {
   } else if (isError) {
     return t`Error uploading your File`;
   } else {
-    return t`Uploading data to ${collection.name}...`;
+    return t`Uploading data to ${collection.name} …`;
   }
+};
+
+const loadingMessages = [
+  t`Getting our ducks in a row`,
+  t`Still working`,
+  t`Arranging bits and bytes`,
+  t`Doing the heavy lifting`,
+  t`Pushing some pixels`,
+];
+
+const getLoadingMessage = (time: number) => {
+  const index = time % loadingMessages.length;
+  return `${loadingMessages[index]} …`;
 };
 
 const getDescription = (upload: FileUpload) => {


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/31214

### Description

Updates loading message in the database status popover every 30 seconds for long uploads.

(sped up for demo)
![loading-messages](https://github.com/metabase/metabase/assets/30528226/cabd2be7-2ae0-40e3-bfed-05a96517db2e)


### How to verify

- upload a CSV that takes more than 30 seconds to process [like this one](https://www.notion.so/metabase/nba-player-box-score-stats-4cabf8ddbe8a43948abfe9910029a80a)
- see the loading message change every 30 seconds


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
