### PR TITLE
Remove Currents.dev project ID

### DIFF
--- a/e2e/support/config.js
+++ b/e2e/support/config.js
@@ -120,7 +120,6 @@ const defaultConfig = {
 
 const mainConfig = {
   ...defaultConfig,
-  projectId: "KetpiS",
   viewportHeight: 800,
   viewportWidth: 1280,
   reporter: "mochawesome",


### PR DESCRIPTION
We stopped using Currents.dev analytics a few months ago.
This PR removes the stray project ID from E2E workflow.

