### PR TITLE
Allow upload table prefixes on dbs with schema

### DIFF
--- a/frontend/src/metabase/admin/settings/components/UploadSettings/UploadSettings.tsx
+++ b/frontend/src/metabase/admin/settings/components/UploadSettings/UploadSettings.tsx
@@ -168,7 +168,7 @@ export function UploadSettingsView({
   };
 
   const showPrefix = !!dbId;
-  const hasValidSettings = dbId && !(showSchema && !schemaName);
+  const hasValidSettings = Boolean(dbId && (!showSchema || schemaName));
   const settingsChanged =
     dbId !== settings.uploads_database_id ||
     schemaName !== settings.uploads_schema_name ||

--- a/frontend/src/metabase/admin/settings/components/UploadSettings/UploadSettings.tsx
+++ b/frontend/src/metabase/admin/settings/components/UploadSettings/UploadSettings.tsx
@@ -167,8 +167,8 @@ export function UploadSettingsView({
       .catch(() => showError(disableErrorMessage));
   };
 
-  const showPrefix = dbId && !showSchema;
-  const hasValidSettings = dbId && (showPrefix || schemaName);
+  const showPrefix = !!dbId;
+  const hasValidSettings = dbId && !(showSchema && !schemaName);
   const settingsChanged =
     dbId !== settings.uploads_database_id ||
     schemaName !== settings.uploads_schema_name ||
@@ -188,7 +188,9 @@ export function UploadSettingsView({
               setDbId(e.target.value);
               if (e.target.value) {
                 resetButtons();
-                setTablePrefix(null);
+                dbHasSchema(databases, e.target.value)
+                  ? setTablePrefix(null)
+                  : setTablePrefix("upload_");
                 setSchemaName(null);
               }
             }}
@@ -221,7 +223,7 @@ export function UploadSettingsView({
             <SectionTitle>{t`Upload Table Prefix`}</SectionTitle>
             <Input
               value={tablePrefix ?? ""}
-              placeholder={t`uploaded_`}
+              placeholder={t`upload_`}
               onChange={e => {
                 resetButtons();
                 setTablePrefix(e.target.value);

--- a/frontend/src/metabase/admin/settings/components/UploadSettings/UploadSettings.tsx
+++ b/frontend/src/metabase/admin/settings/components/UploadSettings/UploadSettings.tsx
@@ -220,7 +220,7 @@ export function UploadSettingsView({
         )}
         {!!showPrefix && (
           <div>
-            <SectionTitle>{t`Upload Table Prefix`}</SectionTitle>
+            <SectionTitle>{t`Upload Table Prefix (optional)`}</SectionTitle>
             <Input
               value={tablePrefix ?? ""}
               placeholder={t`upload_`}

--- a/frontend/src/metabase/admin/settings/components/UploadSettings/UploadSettings.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/components/UploadSettings/UploadSettings.unit.spec.tsx
@@ -174,8 +174,9 @@ describe("Admin > Settings > UploadSetting", () => {
     const dbItem = await screen.findByText("Db Dos");
     userEvent.click(dbItem);
 
-    const prefixInput = await screen.findByPlaceholderText("uploaded_");
+    const prefixInput = await screen.findByPlaceholderText("upload_");
 
+    userEvent.clear(prefixInput);
     userEvent.type(prefixInput, "my_prefix_");
 
     userEvent.click(
@@ -190,6 +191,35 @@ describe("Admin > Settings > UploadSetting", () => {
     });
   });
 
+  it("should be able to submit a table prefix for databases with schema", async () => {
+    const { updateSpy } = setup();
+    userEvent.click(await screen.findByText("Select a database"));
+
+    const dbItem = await screen.findByText("Db Uno");
+    userEvent.click(dbItem);
+
+    const schemaDropdown = await screen.findByText("Select a schema");
+    userEvent.click(schemaDropdown);
+
+    const schemaItem = await screen.findByText("uploads");
+    userEvent.click(schemaItem);
+
+    const prefixInput = await screen.findByPlaceholderText("upload_");
+    userEvent.clear(prefixInput);
+    userEvent.type(prefixInput, "my_prefix_");
+
+    userEvent.click(
+      await screen.findByRole("button", { name: "Enable uploads" }),
+    );
+
+    expect(updateSpy).toHaveBeenCalledWith({
+      "uploads-enabled": true,
+      "uploads-database-id": 1,
+      "uploads-schema-name": "uploads",
+      "uploads-table-prefix": "my_prefix_",
+    });
+  });
+
   it("should call update methods on saveStatusRef", async () => {
     const { savingSpy, savedSpy } = setup();
     userEvent.click(await screen.findByText("Select a database"));
@@ -197,8 +227,9 @@ describe("Admin > Settings > UploadSetting", () => {
     const dbItem = await screen.findByText("Db Dos");
     userEvent.click(dbItem);
 
-    const prefixInput = await screen.findByPlaceholderText("uploaded_");
+    const prefixInput = await screen.findByPlaceholderText("upload_");
 
+    userEvent.clear(prefixInput);
     userEvent.type(prefixInput, "my_prefix_");
 
     userEvent.click(
@@ -225,7 +256,7 @@ describe("Admin > Settings > UploadSetting", () => {
       "uploads-enabled": true,
       "uploads-database-id": 2,
       "uploads-schema-name": null,
-      "uploads-table-prefix": null,
+      "uploads-table-prefix": "upload_",
     });
 
     expect(await screen.findByText(/There was a problem/i)).toBeInTheDocument();
@@ -457,7 +488,7 @@ describe("Admin > Settings > UploadSetting", () => {
         },
       });
 
-      const prefixInput = await screen.findByPlaceholderText("uploaded_");
+      const prefixInput = await screen.findByPlaceholderText("upload_");
       userEvent.clear(prefixInput);
       userEvent.type(prefixInput, "my_prefix_");
 
@@ -479,7 +510,7 @@ describe("Admin > Settings > UploadSetting", () => {
         () => new Promise(resolve => setTimeout(resolve, 500)),
       );
 
-      const prefixInput = await screen.findByPlaceholderText("uploaded_");
+      const prefixInput = await screen.findByPlaceholderText("upload_");
       userEvent.clear(prefixInput);
       userEvent.type(prefixInput, "my_prefix_");
 
@@ -506,7 +537,7 @@ describe("Admin > Settings > UploadSetting", () => {
         () => new Promise(resolve => setTimeout(resolve, 500)),
       );
 
-      const prefixInput = await screen.findByPlaceholderText("uploaded_");
+      const prefixInput = await screen.findByPlaceholderText("upload_");
       userEvent.clear(prefixInput);
       userEvent.type(prefixInput, "my_prefix_");
 
@@ -519,6 +550,7 @@ describe("Admin > Settings > UploadSetting", () => {
         screen.queryByRole("button", { name: "Update settings" }),
       ).not.toBeInTheDocument();
 
+      userEvent.clear(prefixInput);
       userEvent.type(prefixInput, "_2");
       expect(
         screen.getByRole("button", { name: "Update settings" }),


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/31396

### Description

In CSV upload settings:
- allows table prefixes for databases with schema
- auto-populates `upload_` as a table prefix for databases without schema

![Screen Shot 2023-06-07 at 12 53 08 PM](https://github.com/metabase/metabase/assets/30528226/fd664186-d6f1-4f8e-b6d8-d432f4d09566)

![Screen Shot 2023-06-07 at 12 53 15 PM](https://github.com/metabase/metabase/assets/30528226/6bf6065d-23e1-4b16-98b6-056814b6c64b)

### How to verify

- go to upload settings
- switch back and forth between postgres and mysql dbs

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
