### PR TITLE
Fix join alias display name calculation with legacy metadata

### DIFF
--- a/src/metabase/lib/field.cljc
+++ b/src/metabase/lib/field.cljc
@@ -83,14 +83,6 @@
     (when (seq stage-columns)
       (resolve-column-name-in-metadata column-name stage-columns))))
 
-(mu/defn ^:private resolve-column-name-in-join :- [:maybe lib.metadata/ColumnMetadata]
-  [query        :- ::lib.schema/query
-   stage-number :- :int
-   column-name  :- ::lib.schema.common/non-blank-string
-   join-alias   :- [:maybe ::lib.schema.common/non-blank-string]]
-  (let [join-metadata (lib.metadata.calculation/metadata query stage-number (lib.join/resolve-join query stage-number join-alias))]
-    (resolve-column-name-in-metadata column-name join-metadata)))
-
 (mu/defn ^:private resolve-field-metadata :- lib.metadata/ColumnMetadata
   "Resolve metadata for a `:field` ref. This is part of the implementation
   for [[lib.metadata.calculation/metadata-method]] a `:field` clause."
@@ -111,10 +103,9 @@
      {::temporal-unit unit})
    (cond
      (integer? id-or-name) (resolve-field-id query id-or-name)
-     join-alias            (or (resolve-column-name-in-join query stage-number id-or-name join-alias)
-                               {:lib/type    :metadata/field
-                                :name        id-or-name
-                                ::join-alias join-alias})
+     join-alias            {:lib/type    :metadata/field
+                            :name        id-or-name
+                            ::join-alias join-alias}
      :else                 (or (resolve-column-name query stage-number id-or-name)
                                {:lib/type :metadata/field
                                 :name     id-or-name}))))
@@ -187,13 +178,19 @@
                        field-name         :name
                        temporal-unit      :unit
                        binning            ::binning
-                       join-alias         :source_alias
+                       join-alias         :source-alias
                        fk-field-id        :fk-field-id
                        table-id           :table-id
                        :as                field-metadata} style]
   (let [field-display-name (or field-display-name
                                (u.humanization/name->human-readable-name :simple field-name))
-        join-display-name  (when (= style :long)
+        join-display-name  (when (and (= style :long)
+                                      ;; don't prepend a join display name if `:display-name` already contains one!
+                                      ;; Legacy result metadata might include it for joined Fields, don't want to add
+                                      ;; it twice. Otherwise we'll end up with display names like
+                                      ;;
+                                      ;;    Products → Products → Category
+                                      (not (str/includes? field-display-name " → ")))
                              (or
                                (when fk-field-id
                                  ;; Implicitly joined column pickers don't use the target table's name, they use the FK field's name with
@@ -207,9 +204,7 @@
                                        lib.util/strip-id)
                                    (let [table (lib.metadata/table query table-id)]
                                      (lib.metadata.calculation/display-name query stage-number table style))))
-                               (when join-alias
-                                 (let [join (lib.join/resolve-join query stage-number join-alias)]
-                                   (lib.metadata.calculation/display-name query stage-number join style)))))
+                               (or join-alias (::join-alias field-metadata))))
         display-name       (if join-display-name
                              (str join-display-name " → " field-display-name)
                              field-display-name)]
@@ -226,7 +221,7 @@
    [_tag {:keys [binning join-alias temporal-unit source-field], :as _opts} _id-or-name, :as field-clause]
    style]
   (if-let [field-metadata (cond-> (resolve-field-metadata query stage-number field-clause)
-                            join-alias    (assoc :source_alias join-alias)
+                            join-alias    (assoc :source-alias join-alias)
                             temporal-unit (assoc :unit temporal-unit)
                             binning       (assoc ::binning binning)
                             source-field  (assoc :fk-field-id source-field))]

--- a/src/metabase/lib/join.cljc
+++ b/src/metabase/lib/join.cljc
@@ -89,7 +89,7 @@
    stage-number    :- :int
    column-metadata :- lib.metadata/ColumnMetadata
    join-alias      :- ::lib.schema.common/non-blank-string]
-  (let [column-metadata (assoc column-metadata :source_alias join-alias)
+  (let [column-metadata (assoc column-metadata :source-alias join-alias)
         col             (-> (assoc column-metadata
                                    :display-name (lib.metadata.calculation/display-name query stage-number column-metadata)
                                    :lib/source   :source/joins)

--- a/src/metabase/lib/stage.cljc
+++ b/src/metabase/lib/stage.cljc
@@ -319,7 +319,7 @@
         field-cols
         (do (doall field-cols)          ; force generation of unique names before join columns
             (into []
-                  (m/distinct-by #(dissoc % :source_alias :lib/source :lib/source-uuid :lib/desired-column-alias))
+                  (m/distinct-by #(dissoc % :source-alias :lib/source :lib/source-uuid :lib/desired-column-alias))
                   (concat field-cols
                           (lib.join/all-joins-metadata query stage-number unique-name-fn))))
 

--- a/test/metabase/lib/breakout_test.cljc
+++ b/test/metabase/lib/breakout_test.cljc
@@ -178,14 +178,14 @@
                    {:lib/type     :metadata/field
                     :name         "ID"
                     :display-name "ID"
-                    :source_alias "Cat"
+                    :source-alias "Cat"
                     :id           (meta/id :categories :id)
                     :table-id     (meta/id :categories)
                     :base-type    :type/BigInteger}
                    {:lib/type     :metadata/field
                     :name         "NAME"
                     :display-name "Name"
-                    :source_alias "Cat"
+                    :source-alias "Cat"
                     :id           (meta/id :categories :name)
                     :table-id     (meta/id :categories)
                     :base-type    :type/Text}]

--- a/test/metabase/lib/field_test.cljc
+++ b/test/metabase/lib/field_test.cljc
@@ -103,16 +103,16 @@
                                :lib/options  {:lib/uuid "fdcfaa06-8e65-471d-be5a-f1e821022482"}
                                :source-table (meta/id :venues)
                                :fields       [[:field
-                                               {:join-alias "CATEGORIES__via__CATEGORY_ID"
+                                               {:join-alias "Categories"
                                                 :lib/uuid   "8704e09b-496e-4045-8148-1eef28e96b51"}
                                                (meta/id :categories :name)]]
                                :joins        [{:lib/type    :mbql/join
                                                :lib/options {:lib/uuid "490a5abb-54c2-4e62-9196-7e9e99e8d291"}
-                                               :alias       "CATEGORIES__via__CATEGORY_ID"
+                                               :alias       "Categories"
                                                :conditions  [[:=
                                                               {:lib/uuid "cc5f6c43-1acb-49c2-aeb5-e3ff9c70541f"}
                                                               (lib.tu/field-clause :venues :category-id)
-                                                              (lib.tu/field-clause :categories :id {:join-alias "CATEGORIES__via__CATEGORY_ID"})]]
+                                                              (lib.tu/field-clause :categories :id {:join-alias "Categories"})]]
                                                :strategy    :left-join
                                                :fk-field-id (meta/id :venues :category-id)
                                                :stages      [{:lib/type     :mbql.stage/mbql
@@ -121,7 +121,7 @@
                :database     (meta/id)
                :lib/metadata meta/metadata-provider}
         field [:field
-               {:join-alias "CATEGORIES__via__CATEGORY_ID"
+               {:join-alias "Categories"
                 :lib/uuid   "8704e09b-496e-4045-8148-1eef28e96b51"}
                (meta/id :categories :name)]]
     (are [style expected] (= expected
@@ -130,6 +130,66 @@
       :long    "Categories → Name")
     (is (=? {:display-name "Name"}
             (lib.metadata.calculation/metadata query -1 field)))))
+
+(deftest ^:parallel legacy-query-joined-field-display-name-test
+  (testing "Should calculate correct display names for joined fields when source query is a legacy MBQL query (#31368)"
+    (let [card-query      {:database (meta/id)
+                           :type     :query
+                           :query    {:source-table (meta/id :orders)
+                                      :joins        [{:fields       :all
+                                                      :source-table (meta/id :products)
+                                                      :alias        "Products"
+                                                      :condition    [:=
+                                                                     [:field (meta/id :orders :product-id) nil]
+                                                                     [:field (meta/id :products :id) {:join-alias "Products"}]]}]}}
+          card-def        {:id            1
+                           :name          "Card 1"
+                           :dataset-query card-query}
+          ;; legacy result metadata will already include the Join name in the `:display-name`, so simulate that. Make
+          ;; sure we're not including it twice.
+          result-metadata (for [col (lib.metadata.calculation/metadata
+                                     (lib/saved-question-query
+                                      meta/metadata-provider
+                                      {:dataset-query card-query}))]
+                            (cond-> col
+                              (:source-alias col)
+                              (update :display-name (fn [display-name]
+                                                      (str (:source-alias col) " → " display-name)))))]
+      (doseq [[message card-def] {"Card with no result metadata"
+                                  card-def
+
+                                  "Card with result metadata"
+                                  (assoc card-def :result-metadata result-metadata)}]
+        (testing message
+          (let [metadata-provider (lib.metadata.composed-provider/composed-metadata-provider
+                                   (lib.tu/mock-metadata-provider
+                                    {:cards [card-def]})
+                                   meta/metadata-provider)
+                legacy-query      {:database (meta/id)
+                                   :type     :query
+                                   :query    {:source-table "card__1"}}
+                query             (lib/query metadata-provider legacy-query)
+                breakoutable-cols (lib/breakoutable-columns query)
+                breakout-col      (m/find-first (fn [col]
+                                                  (= (:id col) (meta/id :products :category)))
+                                                breakoutable-cols)]
+            (testing (str "\nbreakoutable-cols =\n" (u/pprint-to-str breakoutable-cols))
+              (is (some? breakout-col)))
+            (when breakout-col
+              (is (=? {:long-display-name "Products → Category"}
+                      (lib/display-info query breakout-col)))
+              (let [query' (lib/breakout query breakout-col)]
+                (is (=? {:stages
+                         [{:lib/type     :mbql.stage/mbql
+                           :source-table "card__1"
+                           :breakout     [[:field {:join-alias "Products"} "CATEGORY"]]}]}
+                        query'))
+                (is (=? [{:name              "CATEGORY"
+                          :display-name      "Category"
+                          :long-display-name "Products → Category"
+                          :effective-type    :type/Text}]
+                        (map (partial lib/display-info query')
+                             (lib/breakouts query'))))))))))))
 
 (deftest ^:parallel unresolved-lib-field-with-temporal-bucket-test
   (let [query (lib/query-for-table-name meta/metadata-provider "CHECKINS")

--- a/test/metabase/lib/join_test.cljc
+++ b/test/metabase/lib/join_test.cljc
@@ -115,7 +115,7 @@
               (lib.metadata.calculation/metadata query -1 query))))))
 
 (deftest ^:parallel col-info-explicit-join-test
-  (testing "Display name for a joined field should include a nice name for the join; include other info like :source_alias"
+  (testing "Display name for a joined field should include a nice name for the join; include other info like :source-alias"
     (let [query {:lib/type     :mbql/query
                  :stages       [{:lib/type     :mbql.stage/mbql
                                  :lib/options  {:lib/uuid "fdcfaa06-8e65-471d-be5a-f1e821022482"}

--- a/test/metabase/lib/metadata/jvm_test.clj
+++ b/test/metabase/lib/metadata/jvm_test.clj
@@ -78,7 +78,7 @@
                 :id (mt/id :orders :product_id)
                 :lib/desired-column-alias "Orders__PRODUCT_ID"
                 :display-name "Product ID"
-                :source_alias "Orders"}
+                :source-alias "Orders"}
                {:metabase.lib.field/join-alias "Orders"
                 :lib/type :metadata/field
                 :base-type :type/Integer
@@ -88,5 +88,5 @@
                 :effective-type :type/Integer
                 :lib/desired-column-alias "Orders__sum"
                 :display-name "Sum"
-                :source_alias "Orders"}]
+                :source-alias "Orders"}]
               (lib.metadata.calculation/metadata mlv2-query))))))

--- a/test/metabase/lib/order_by_test.cljc
+++ b/test/metabase/lib/order_by_test.cljc
@@ -287,14 +287,14 @@
                  {:lib/type     :metadata/field
                   :name         "ID"
                   :display-name "ID"
-                  :source_alias "Cat"
+                  :source-alias "Cat"
                   :id           (meta/id :categories :id)
                   :table-id     (meta/id :categories)
                   :base-type    :type/BigInteger}
                  {:lib/type     :metadata/field
                   :name         "NAME"
                   :display-name "Name"
-                  :source_alias "Cat"
+                  :source-alias "Cat"
                   :id           (meta/id :categories :name)
                   :table-id     (meta/id :categories)
                   :base-type    :type/Text}]
@@ -585,7 +585,7 @@
                {:display-name "ID",   :lib/source :source/joins}
                {:display-name "Name", :lib/source :source/joins}]
               (lib/orderable-columns query)))
-      (let [query' (lib/order-by query (m/find-first #(and (= (:source_alias %) "Cat")
+      (let [query' (lib/order-by query (m/find-first #(and (= (:source-alias %) "Cat")
                                                            (= (:display-name %) "Name"))
                                                      (lib/orderable-columns query)))]
         (is (=? [{:display-name "ID",          :lib/source :source/table-defaults}

--- a/test/metabase/lib/stage_test.cljc
+++ b/test/metabase/lib/stage_test.cljc
@@ -123,14 +123,14 @@
                  {:id                       (meta/id :categories :id)
                   :name                     "ID"
                   :lib/source               :source/joins
-                  :source_alias             "Cat"
+                  :source-alias             "Cat"
                   :display-name             "ID"
                   :lib/source-column-alias  "ID"
                   :lib/desired-column-alias "Cat__ID"}
                  {:id                       (meta/id :categories :name)
                   :name                     "NAME"
                   :lib/source               :source/joins
-                  :source_alias             "Cat"
+                  :source-alias             "Cat"
                   :display-name             "Name"
                   :lib/source-column-alias  "NAME"
                   :lib/desired-column-alias "Cat__NAME"}]
@@ -144,8 +144,8 @@
                   "Price"
                   "ID + 1"
                   "ID + 2"
-                  "Categories → ID"
-                  "Categories → Name"]
+                  "Cat → ID"
+                  "Cat → Name"]
                  (mapv #(lib.metadata.calculation/display-name query -1 % :long) metadata))))))))
 
 (deftest ^:parallel metadata-with-fields-only-include-expressions-in-fields-test


### PR DESCRIPTION
Fixes #31368

This makes the following changes:

1. Use the join alias directly in the `:long-display-name` for a column without attempting to resolve the join. This fixes issues where the join is unresolvable because it lives in the Saved Question we are using as the source query. This matches the old behavior of MLv1 so there was really no need to try to resolve the joins in the first place
2. Do not prepend a join name to the `display-name` if it already has ` → ` in it. QP results metadata includes it in the display name for joined columns; this prevents columns like `Products → Products → Category` from showing up. It seems like QP `:display-name` in results metadata actually corresponds to `:long-display-name` in MLv2... I would like to fix this in a better way but the quick and dirty fix will do for now to unblock merging breakouts I think. I've opened #31415 to fix this in a nicer way when we get some free cycles
3. Use `:source-alias` in MLv2 column metadata, not `:source_alias`. This was something I forgot to update when we did the `kebab-case` stuff, and could cause things to break because `:source_alias` in result metadata would get normalized to `:source-alias` and then wouldn't be seen by MLv2

These fixes in combination solve #31368 on the breakouts branch

For testing convenience I've also created #31416 which is a version of this targeting [mlv2-fe/break-out-support-notebook](https://github.com/metabase/metabase/tree/mlv2-fe/break-out-support-notebook), I don't know how it's possible but the backend on that branch has drifted enough that this one is not a clean merge into that branch. Wouldn't it make sense to just fix things in master so we can just do `git merge master` in that branch periodically? 🤷 