### PR TITLE
Add possibility to preserve initial form values

### DIFF
--- a/e2e/support/helpers/e2e-ui-elements-helpers.js
+++ b/e2e/support/helpers/e2e-ui-elements-helpers.js
@@ -121,3 +121,7 @@ export const undoToast = () => {
 export function dashboardCards() {
   return cy.get("#Dashboard-Cards-Container");
 }
+
+export function actionEditorModal() {
+  return cy.get(`.Modal[role="dialog"]`);
+}

--- a/e2e/support/helpers/e2e-ui-elements-helpers.js
+++ b/e2e/support/helpers/e2e-ui-elements-helpers.js
@@ -121,7 +121,3 @@ export const undoToast = () => {
 export function dashboardCards() {
   return cy.get("#Dashboard-Cards-Container");
 }
-
-export function actionEditorModal() {
-  return cy.get(`.Modal[role="dialog"]`);
-}

--- a/e2e/test/scenarios/actions/actions-on-dashboards.cy.spec.js
+++ b/e2e/test/scenarios/actions/actions-on-dashboards.cy.spec.js
@@ -1,3 +1,5 @@
+import { assocIn } from "icepick";
+import _ from "underscore";
 import {
   restore,
   queryWritableDB,
@@ -15,11 +17,14 @@ import {
   filterWidget,
   createImplicitAction,
   dragField,
+  createAction,
+  actionEditorModal,
 } from "e2e/support/helpers";
 
 import { many_data_types_rows } from "e2e/support/test_tables_data";
 
 import { WRITABLE_DB_ID } from "e2e/support/cypress_data";
+import { createMockActionParameter } from "metabase-types/api/mocks";
 import { addWidgetStringFilter } from "../native-filters/helpers/e2e-field-filter-helpers";
 
 const TEST_TABLE = "scoreboard_actions";
@@ -578,6 +583,167 @@ const MODEL_NAME = "Test Action Model";
             expect(row.timestamp).to.include(newTimeAdjusted);
             expect(row.datetimeTZ).to.include(newTimeAdjusted);
             expect(row.timestampTZ).to.include(newTimeAdjusted);
+          });
+        });
+      });
+
+      describe("editing action before executing it", () => {
+        const PG_DB_ID = 2;
+        const WRITABLE_TEST_TABLE = "scoreboard_actions";
+
+        const TEST_PARAMETER = createMockActionParameter({
+          id: "49596bcb-62bb-49d6-a92d-bf5dbfddf43b",
+          name: "Total",
+          slug: "total",
+          type: "number/=",
+          target: ["variable", ["template-tag", "total"]],
+        });
+
+        const TEST_TEMPLATE_TAG = {
+          id: TEST_PARAMETER.id,
+          type: "number",
+          name: TEST_PARAMETER.slug,
+          "display-name": TEST_PARAMETER.name,
+          slug: TEST_PARAMETER.slug,
+        };
+
+        const SAMPLE_QUERY_ACTION = {
+          name: "Demo Action",
+          type: "query",
+          parameters: [TEST_PARAMETER],
+          database_id: PG_DB_ID,
+          dataset_query: {
+            type: "native",
+            native: {
+              query: `UPDATE ORDERS SET TOTAL = TOTAL WHERE ID = {{ ${TEST_TEMPLATE_TAG.name} }}`,
+              "template-tags": {
+                [TEST_TEMPLATE_TAG.name]: TEST_TEMPLATE_TAG,
+              },
+            },
+            database: PG_DB_ID,
+          },
+          visualization_settings: {
+            fields: {
+              [TEST_PARAMETER.id]: {
+                id: TEST_PARAMETER.id,
+                required: true,
+                fieldType: "number",
+                inputType: "number",
+              },
+            },
+          },
+        };
+
+        const SAMPLE_WRITABLE_QUERY_ACTION = assocIn(
+          SAMPLE_QUERY_ACTION,
+          ["dataset_query", "native", "query"],
+          `UPDATE ${WRITABLE_TEST_TABLE} SET score = 22 WHERE id = {{ ${TEST_TEMPLATE_TAG.name} }}`,
+        );
+
+        beforeEach(() => {
+          resetTestTable({ type: dialect, table: TEST_COLUMNS_TABLE });
+          restore(`${dialect}-writable`);
+          cy.signInAsAdmin();
+          resyncDatabase({
+            dbId: WRITABLE_DB_ID,
+            tableName: TEST_COLUMNS_TABLE,
+          });
+          createModelFromTableName({
+            tableName: TEST_COLUMNS_TABLE,
+            modelName: MODEL_NAME,
+          });
+
+          cy.get("@modelId").then(modelId => {
+            createAction({
+              ...SAMPLE_WRITABLE_QUERY_ACTION,
+              model_id: modelId,
+            });
+          });
+
+          createDashboardWithActionButton({
+            actionName: SAMPLE_QUERY_ACTION.name,
+          });
+        });
+
+        it("allows to edit action title and field placeholder in action execute modal", () => {
+          clickHelper(SAMPLE_QUERY_ACTION.name);
+
+          modal().within(() => {
+            cy.icon("pencil").click();
+          });
+
+          actionEditorModal().within(() => {
+            cy.findByText(SAMPLE_QUERY_ACTION.name)
+              .click()
+              .clear()
+              .type("New action name");
+
+            cy.findByTestId("action-form-editor").within(() => {
+              cy.icon("gear").click();
+            });
+          });
+
+          popover().within(() => {
+            cy.findByText("Placeholder text").click().type("Test placeholder");
+          });
+
+          actionEditorModal().within(() => {
+            cy.button("Update").click();
+          });
+
+          modal().within(() => {
+            cy.findByTestId("modal-header").findByText("New action name");
+
+            cy.findAllByPlaceholderText("Test placeholder");
+          });
+        });
+
+        it("allows to edit action query and parameters in action execute modal", () => {
+          clickHelper(SAMPLE_QUERY_ACTION.name);
+
+          modal().within(() => {
+            cy.icon("pencil").click();
+          });
+
+          actionEditorModal().within(() => {
+            cy.findByTestId("native-query-editor").click();
+
+            cy.get(".ace_content").type(
+              _.times(23, () => "{leftArrow}")
+                .join("")
+                .concat("{backspace}{backspace}"),
+            );
+            cy.get(".ace_text-input").type(`{{ score }}`, {
+              force: true,
+              parseSpecialCharSequences: false,
+            });
+
+            cy.findByTestId("action-form-editor").within(() => {
+              cy.findAllByText("Number").click({ multiple: true });
+            });
+          });
+
+          actionEditorModal().within(() => {
+            cy.button("Update").click();
+          });
+
+          modal().within(() => {
+            cy.findByLabelText("Total").type(`123`);
+            cy.findByLabelText("Score").type(`345`);
+
+            cy.button(SAMPLE_QUERY_ACTION.name).click();
+          });
+
+          cy.wait("@executeAPI").then(interception => {
+            expect(
+              Object.values(interception.request.body.parameters)
+                .sort()
+                .join(","),
+            ).to.equal("123,345");
+          });
+
+          cy.findByTestId("toast-undo").within(() => {
+            cy.findByText(`Success! The action returned: {"rows-affected":0}`);
           });
         });
       });

--- a/frontend/src/metabase/actions/components/ActionForm/ActionForm.tsx
+++ b/frontend/src/metabase/actions/components/ActionForm/ActionForm.tsx
@@ -1,7 +1,7 @@
-import { forwardRef, Ref, useCallback, useMemo } from "react";
+import { useCallback, useMemo } from "react";
 import { t } from "ttag";
 
-import type { FormikHelpers, FormikProps } from "formik";
+import type { FormikHelpers } from "formik";
 
 import Button from "metabase/core/components/Button";
 import Form from "metabase/core/components/Form";
@@ -38,6 +38,8 @@ interface ActionFormProps {
   // and they will be submitted together in batch.
   hiddenFields?: ParameterId[];
 
+  onChange?: (values: ParametersForActionExecution) => void;
+
   onSubmit: (
     parameters: ParametersForActionExecution,
     actions: FormikHelpers<ParametersForActionExecution>,
@@ -45,19 +47,15 @@ interface ActionFormProps {
   onClose?: () => void;
 }
 
-export type ActionFormRefData = FormikProps<ParametersForActionExecution>;
-
-const ActionForm = forwardRef(function ActionForm(
-  {
-    action,
-    initialValues: rawInitialValues = {},
-    hasPreservedInitialValues = false,
-    hiddenFields = [],
-    onSubmit,
-    onClose,
-  }: ActionFormProps,
-  ref: Ref<ActionFormRefData>,
-): JSX.Element {
+function ActionForm({
+  action,
+  initialValues: rawInitialValues = {},
+  hasPreservedInitialValues = false,
+  hiddenFields = [],
+  onChange,
+  onSubmit,
+  onClose,
+}: ActionFormProps): JSX.Element {
   const { initialValues, form, validationSchema, getCleanValues } =
     useActionForm({
       action,
@@ -92,9 +90,8 @@ const ActionForm = forwardRef(function ActionForm(
       validationSchema={validationSchema}
       onSubmit={handleSubmit}
       enableReinitialize
-      innerRef={ref}
     >
-      <Form role="form" data-testid="action-form">
+      <Form role="form" data-testid="action-form" onChange={onChange}>
         {editableFields.map(field => (
           <ActionFormFieldWidget key={field.name} formField={field} />
         ))}
@@ -110,7 +107,7 @@ const ActionForm = forwardRef(function ActionForm(
       </Form>
     </FormProvider>
   );
-});
+}
 
 // eslint-disable-next-line import/no-default-export -- deprecated usage
 export default ActionForm;

--- a/frontend/src/metabase/actions/components/ActionForm/ActionForm.tsx
+++ b/frontend/src/metabase/actions/components/ActionForm/ActionForm.tsx
@@ -29,6 +29,7 @@ import { ActionFormButtonContainer } from "./ActionForm.styled";
 interface ActionFormProps {
   action: WritebackAction;
   initialValues?: ActionFormInitialValues;
+  hasPreservedInitialValues?: boolean;
 
   // Parameters that shouldn't be displayed in the form
   // Can be used to "lock" certain parameter values.
@@ -50,6 +51,7 @@ const ActionForm = forwardRef(function ActionForm(
   {
     action,
     initialValues: rawInitialValues = {},
+    hasPreservedInitialValues = false,
     hiddenFields = [],
     onSubmit,
     onClose,
@@ -60,6 +62,7 @@ const ActionForm = forwardRef(function ActionForm(
     useActionForm({
       action,
       initialValues: rawInitialValues,
+      hasPreservedInitialValues,
     });
 
   const editableFields = useMemo(

--- a/frontend/src/metabase/actions/components/ActionForm/ActionForm.tsx
+++ b/frontend/src/metabase/actions/components/ActionForm/ActionForm.tsx
@@ -1,7 +1,7 @@
-import { useCallback, useMemo } from "react";
+import { forwardRef, Ref, useCallback, useMemo } from "react";
 import { t } from "ttag";
 
-import type { FormikHelpers } from "formik";
+import type { FormikHelpers, FormikProps } from "formik";
 
 import Button from "metabase/core/components/Button";
 import Form from "metabase/core/components/Form";
@@ -44,13 +44,18 @@ interface ActionFormProps {
   onClose?: () => void;
 }
 
-function ActionForm({
-  action,
-  initialValues: rawInitialValues = {},
-  hiddenFields = [],
-  onSubmit,
-  onClose,
-}: ActionFormProps): JSX.Element {
+export type ActionFormRefData = FormikProps<ParametersForActionExecution>;
+
+const ActionForm = forwardRef(function ActionForm(
+  {
+    action,
+    initialValues: rawInitialValues = {},
+    hiddenFields = [],
+    onSubmit,
+    onClose,
+  }: ActionFormProps,
+  ref: Ref<ActionFormRefData>,
+): JSX.Element {
   const { initialValues, form, validationSchema, getCleanValues } =
     useActionForm({
       action,
@@ -84,6 +89,7 @@ function ActionForm({
       validationSchema={validationSchema}
       onSubmit={handleSubmit}
       enableReinitialize
+      innerRef={ref}
     >
       <Form role="form" data-testid="action-form">
         {editableFields.map(field => (
@@ -101,7 +107,7 @@ function ActionForm({
       </Form>
     </FormProvider>
   );
-}
+});
 
 // eslint-disable-next-line import/no-default-export -- deprecated usage
 export default ActionForm;

--- a/frontend/src/metabase/actions/components/ActionForm/index.ts
+++ b/frontend/src/metabase/actions/components/ActionForm/index.ts
@@ -1,2 +1,3 @@
 // eslint-disable-next-line import/no-default-export -- deprecated usage
 export { default } from "./ActionForm";
+export type { ActionFormRefData } from "./ActionForm";

--- a/frontend/src/metabase/actions/components/ActionViz/Action.unit.spec.tsx
+++ b/frontend/src/metabase/actions/components/ActionViz/Action.unit.spec.tsx
@@ -346,18 +346,20 @@ describe("Actions > ActionViz > Action", () => {
 
       userEvent.click(editActionEl);
 
-      await screen.findByText("Action parameters");
+      const actionCreatorModal = await screen.findByTestId(
+        "action-creator-modal",
+      );
 
-      expect(screen.getByText("My Awesome Action")).toBeInTheDocument();
-
-      const cancelEditButton = screen.getByText("Cancel");
+      const cancelEditButton = within(actionCreatorModal).getByText("Cancel");
       expect(cancelEditButton).toBeInTheDocument();
 
       expect(screen.getByText("Update")).toBeInTheDocument();
 
       userEvent.click(cancelEditButton);
 
-      expect(screen.getByRole("dialog")).toBeInTheDocument();
+      expect(
+        screen.getByTestId("action-execution-form-modal"),
+      ).toBeInTheDocument();
       expect(screen.getByTestId("action-form")).toBeInTheDocument();
       expect(screen.getByLabelText("Parameter 1")).toBeInTheDocument();
     });
@@ -419,7 +421,7 @@ describe("Actions > ActionViz > Action", () => {
       expect(actionCreatorModal).not.toBeInTheDocument();
 
       expect(screen.getByLabelText("Parameter 1")).toHaveValue("Value 1");
-      expect(screen.getByLabelText("Parameter 2")).toHaveValue("123");
+      expect(screen.getByLabelText("Parameter 2")).toHaveValue(123);
     });
   });
 

--- a/frontend/src/metabase/actions/components/ActionViz/Action.unit.spec.tsx
+++ b/frontend/src/metabase/actions/components/ActionViz/Action.unit.spec.tsx
@@ -136,7 +136,7 @@ async function setup({
     setupActionEndpoints(ACTION);
   }
 
-  renderWithProviders(
+  const view = renderWithProviders(
     <Action
       dashboard={dashboard}
       dashcard={dashcard}
@@ -158,6 +158,8 @@ async function setup({
 
   // Wait until UI is ready
   await screen.findByRole("button");
+
+  return { view };
 }
 
 describe("Actions > ActionViz > Action", () => {
@@ -380,7 +382,7 @@ describe("Actions > ActionViz > Action", () => {
       userEvent.click(getIcon("pencil"));
 
       // wait for action edit form to be loaded
-      await screen.findByText("My Awesome Action");
+      await screen.findByTestId("action-form-editor");
 
       // edit action title
       const actionTitleField = screen.getByTestId("editable-text");
@@ -394,6 +396,30 @@ describe("Actions > ActionViz > Action", () => {
       expect(screen.getByRole("dialog")).toBeInTheDocument();
       expect(screen.getByTestId("action-form")).toBeInTheDocument();
       expect(screen.getByLabelText("Parameter 1")).toBeInTheDocument();
+    });
+
+    it("should preserve typed form values after action edit modal opening without editing", async () => {
+      await setup();
+
+      userEvent.click(screen.getByText("Click me"));
+
+      userEvent.type(screen.getByLabelText("Parameter 1"), "Value 1");
+      userEvent.type(screen.getByLabelText("Parameter 2"), "123");
+      userEvent.tab(); // blur field
+
+      userEvent.click(getIcon("pencil"));
+
+      // wait for action edit form to be loaded
+      const actionCreatorModal = await screen.findByTestId(
+        "action-creator-modal",
+      );
+
+      userEvent.click(within(actionCreatorModal).getByText("Cancel"));
+
+      expect(actionCreatorModal).not.toBeInTheDocument();
+
+      expect(screen.getByLabelText("Parameter 1")).toHaveValue("Value 1");
+      expect(screen.getByLabelText("Parameter 2")).toHaveValue("123");
     });
   });
 

--- a/frontend/src/metabase/actions/components/ActionViz/Action.unit.spec.tsx
+++ b/frontend/src/metabase/actions/components/ActionViz/Action.unit.spec.tsx
@@ -3,11 +3,18 @@ import userEvent from "@testing-library/user-event";
 
 import {
   getIcon,
+  queryIcon,
   renderWithProviders,
   screen,
   waitFor,
   within,
 } from "__support__/ui";
+import {
+  setupActionEndpoints,
+  setupCardsEndpoints,
+  setupDatabasesEndpoints,
+} from "__support__/server-mocks";
+import { createMockEntitiesState } from "__support__/store";
 
 import type { ActionDashboardCard, ParameterTarget } from "metabase-types/api";
 import {
@@ -17,9 +24,14 @@ import {
   createMockQueryAction,
   createMockImplicitQueryAction,
   createMockDashboard,
+  createMockCard,
+  createMockStructuredDatasetQuery,
+  createMockDatabase,
 } from "metabase-types/api/mocks";
-
 import { getActionIsEnabledInDatabase } from "metabase/dashboard/utils";
+import { checkNotNull } from "metabase/core/utils/types";
+
+import { Database } from "metabase-types/api";
 import Action, { ActionProps } from "./Action";
 
 const DASHBOARD_ID = 123;
@@ -32,6 +44,7 @@ const DATABASE_ID = 1;
 const ACTION = createMockQueryAction({
   name: "My Awesome Action",
   database_id: DATABASE_ID,
+  model_id: ACTION_MODEL_ID,
   parameters: [
     createMockActionParameter({
       id: "parameter_1",
@@ -60,12 +73,29 @@ const ACTION = createMockQueryAction({
   },
 });
 
+const DATABASE = createMockDatabase({
+  settings: {
+    "database-enable-actions": true,
+  },
+});
+
+const CARD = createMockCard({
+  id: ACTION_MODEL_ID,
+  database_id: DATABASE_ID,
+  dataset_query: createMockStructuredDatasetQuery({
+    database: DATABASE_ID,
+  }),
+  display: "action",
+  can_write: true,
+  dataset: true,
+});
+
 function createMockActionDashboardCard(
   opts: Partial<ActionDashboardCard> = {},
 ) {
   return _createMockActionDashboardCard({
     id: DASHCARD_ID,
-    card_id: ACTION_MODEL_ID,
+    card_id: CARD.id,
     dashboard_id: DASHBOARD_ID,
     action: ACTION,
     parameter_mappings: [
@@ -78,6 +108,7 @@ function createMockActionDashboardCard(
         target: ["variable", ["template-tag", "2"]],
       },
     ],
+    card: CARD,
     ...opts,
   });
 }
@@ -85,14 +116,24 @@ function createMockActionDashboardCard(
 type SetupOpts = Partial<ActionProps>;
 
 async function setup({
+  database = DATABASE,
   dashboard = createMockDashboard({ id: DASHBOARD_ID }),
   dashcard = createMockActionDashboardCard(),
   settings = {},
   parameterValues = {},
   ...props
-}: SetupOpts = {}) {
+}: SetupOpts & {
+  database?: Database;
+} = {}) {
+  const card = checkNotNull(dashcard.card);
+
   if (getActionIsEnabledInDatabase(dashcard)) {
     fetchMock.post(ACTION_EXEC_MOCK_PATH, { "rows-updated": [1] });
+
+    // for ActionCreator modal (action edit modal)
+    setupDatabasesEndpoints([database]);
+    setupCardsEndpoints([card]);
+    setupActionEndpoints(ACTION);
   }
 
   renderWithProviders(
@@ -106,6 +147,13 @@ async function setup({
       dispatch={jest.fn()}
       {...props}
     />,
+    {
+      storeInitialState: {
+        entities: createMockEntitiesState({
+          databases: [database],
+        }),
+      },
+    },
   );
 
   // Wait until UI is ready
@@ -203,7 +251,8 @@ describe("Actions > ActionViz > Action", () => {
         ["template-tag", "1"],
       ];
 
-      const action = createMockQueryAction({
+      const action = {
+        ...ACTION,
         parameters: [
           createMockActionParameter({
             id: parameterId,
@@ -220,7 +269,7 @@ describe("Actions > ActionViz > Action", () => {
             }),
           },
         },
-      });
+      };
 
       await setup({
         dashcard: createMockActionDashboardCard({
@@ -245,14 +294,106 @@ describe("Actions > ActionViz > Action", () => {
       );
 
       await waitFor(async () => {
-        const call = fetchMock.lastCall(ACTION_EXEC_MOCK_PATH);
-        expect(await call?.request?.json()).toEqual({
-          modelId: ACTION_MODEL_ID,
-          parameters: {
-            parameter_1: 44,
-          },
-        });
+        expect(fetchMock.called(ACTION_EXEC_MOCK_PATH)).toBe(true);
       });
+
+      const call = fetchMock.lastCall(ACTION_EXEC_MOCK_PATH);
+      expect(await call?.request?.json()).toEqual({
+        modelId: ACTION_MODEL_ID,
+        parameters: {
+          parameter_1: 44,
+        },
+      });
+    });
+
+    it("should NOT allow to edit underlying action if a user does not has edit permissions for this model", async () => {
+      await setup({
+        dashcard: createMockActionDashboardCard({
+          card: {
+            ...CARD,
+            can_write: false,
+          },
+        }),
+      });
+
+      userEvent.click(screen.getByText("Click me"));
+
+      expect(queryIcon("pencil")).not.toBeInTheDocument();
+    });
+
+    it("should NOT allow to edit underlying action if a user does not has edit permissions for this database", async () => {
+      const readOnlyDB: Database = {
+        ...DATABASE,
+        native_permissions: "read",
+      };
+
+      await setup({ database: readOnlyDB });
+
+      userEvent.click(screen.getByText("Click me"));
+
+      expect(queryIcon("pencil")).not.toBeInTheDocument();
+    });
+
+    it("should allow to edit underlying action if a user has edit permissions", async () => {
+      await setup();
+
+      userEvent.click(screen.getByText("Click me"));
+
+      const editActionEl = getIcon("pencil");
+      expect(editActionEl).toBeInTheDocument();
+
+      userEvent.click(editActionEl);
+
+      await screen.findByText("Action parameters");
+
+      expect(screen.getByText("My Awesome Action")).toBeInTheDocument();
+
+      const cancelEditButton = screen.getByText("Cancel");
+      expect(cancelEditButton).toBeInTheDocument();
+
+      expect(screen.getByText("Update")).toBeInTheDocument();
+
+      userEvent.click(cancelEditButton);
+
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+      expect(screen.getByTestId("action-form")).toBeInTheDocument();
+      expect(screen.getByLabelText("Parameter 1")).toBeInTheDocument();
+    });
+
+    it("should open action form after action editing", async () => {
+      const updatedTitle = "Test action title";
+      await setup();
+
+      fetchMock.putOnce(
+        `path:/api/action/${ACTION.id}`,
+        {
+          ...ACTION,
+          name: updatedTitle,
+        },
+        {
+          overwriteRoutes: true,
+        },
+      );
+
+      userEvent.click(screen.getByText("Click me"));
+
+      userEvent.click(getIcon("pencil"));
+
+      // wait for action edit form to be loaded
+      await screen.findByText("My Awesome Action");
+
+      // edit action title
+      const actionTitleField = screen.getByTestId("editable-text");
+      userEvent.type(actionTitleField, updatedTitle);
+      userEvent.tab(); // blur field
+
+      userEvent.click(await screen.findByText("Update"));
+
+      expect(fetchMock.called(`path:/api/action/${ACTION.id}`)).toBe(true);
+
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+      expect(screen.getByTestId("action-form")).toBeInTheDocument();
+      expect(screen.getByLabelText("Parameter 1")).toBeInTheDocument();
     });
   });
 

--- a/frontend/src/metabase/actions/components/ActionViz/ActionVizForm.tsx
+++ b/frontend/src/metabase/actions/components/ActionViz/ActionVizForm.tsx
@@ -82,9 +82,7 @@ function ActionVizForm({
     setShowEditModal(true);
   };
 
-  const closeEditModal = () => {
-    setShowEditModal(false);
-  };
+  const closeEditModal = () => setShowEditModal(false);
 
   if (shouldDisplayButton) {
     return (
@@ -104,6 +102,7 @@ function ActionVizForm({
             mappedParameters={mappedParameters}
             dashcardParamValues={dashcardParamValues}
             initialValues={formRef.current?.values}
+            hasPreservedInitialValues={!!formRef.current?.values}
             title={title}
             showConfirmMessage={showConfirmMessage}
             confirmMessage={action.visualization_settings?.confirmMessage}
@@ -118,7 +117,6 @@ function ActionVizForm({
             wide
             data-testid="action-creator-modal"
             onClose={closeEditModal}
-            closeOnClickOutside
           >
             <ActionCreator
               initialAction={action}

--- a/frontend/src/metabase/actions/components/ActionViz/ActionVizForm.tsx
+++ b/frontend/src/metabase/actions/components/ActionViz/ActionVizForm.tsx
@@ -14,7 +14,6 @@ import type {
 
 import ActionCreator from "metabase/actions/containers/ActionCreator/ActionCreator";
 import Modal from "metabase/components/Modal";
-import { ActionFormRefData } from "metabase/actions/components/ActionForm/ActionForm";
 import ActionParametersInputForm, {
   ActionParametersInputModal,
 } from "../../containers/ActionParametersInputForm";
@@ -60,7 +59,8 @@ function ActionVizForm({
   const [showEditModal, setShowEditModal] = useState(false);
   const title = getFormTitle(action);
 
-  const formRef = useRef<ActionFormRefData>(null);
+  // store values without rerender
+  const formValuesRef = useRef<ParametersForActionExecution | undefined>();
   const [formStoredValues, setFormStoredValues] = useState<
     ParametersForActionExecution | undefined
   >();
@@ -81,8 +81,12 @@ function ActionVizForm({
     return result;
   };
 
-  const handleActionEdit = () => {
-    setFormStoredValues(formRef.current?.values);
+  const handleFormChange = (values: ParametersForActionExecution) => {
+    formValuesRef.current = values;
+  };
+
+  const handleTriggerActionEdit = () => {
+    setFormStoredValues(formValuesRef.current);
 
     setShowEditModal(true);
   };
@@ -100,7 +104,6 @@ function ActionVizForm({
         />
         {showFormModal && (
           <ActionParametersInputModal
-            ref={formRef}
             action={action}
             dashboard={dashboard}
             dashcard={dashcard}
@@ -111,7 +114,10 @@ function ActionVizForm({
             title={title}
             showConfirmMessage={showConfirmMessage}
             confirmMessage={action.visualization_settings?.confirmMessage}
-            onActionEdit={canEditAction ? handleActionEdit : undefined}
+            onChange={handleFormChange}
+            onTriggerActionEdit={
+              canEditAction ? handleTriggerActionEdit : undefined
+            }
             onSubmit={onModalSubmit}
             onClose={() => setShowFormModal(false)}
             onCancel={() => setShowFormModal(false)}
@@ -147,7 +153,6 @@ function ActionVizForm({
         dashcard={dashcard}
         mappedParameters={mappedParameters}
         dashcardParamValues={dashcardParamValues}
-        initialValues={formRef.current?.values}
         onSubmit={onSubmit}
       />
     </FormWrapper>

--- a/frontend/src/metabase/actions/components/ActionViz/ActionVizForm.tsx
+++ b/frontend/src/metabase/actions/components/ActionViz/ActionVizForm.tsx
@@ -61,6 +61,9 @@ function ActionVizForm({
   const title = getFormTitle(action);
 
   const formRef = useRef<ActionFormRefData>(null);
+  const [formStoredValues, setFormStoredValues] = useState<
+    ParametersForActionExecution | undefined
+  >();
 
   // only show confirmation if there are no missing parameters
   const showConfirmMessage =
@@ -79,6 +82,8 @@ function ActionVizForm({
   };
 
   const handleActionEdit = () => {
+    setFormStoredValues(formRef.current?.values);
+
     setShowEditModal(true);
   };
 
@@ -101,8 +106,8 @@ function ActionVizForm({
             dashcard={dashcard}
             mappedParameters={mappedParameters}
             dashcardParamValues={dashcardParamValues}
-            initialValues={formRef.current?.values}
-            hasPreservedInitialValues={!!formRef.current?.values}
+            initialValues={formStoredValues}
+            hasPreservedInitialValues={!!formStoredValues}
             title={title}
             showConfirmMessage={showConfirmMessage}
             confirmMessage={action.visualization_settings?.confirmMessage}

--- a/frontend/src/metabase/actions/components/ActionViz/ActionVizForm.tsx
+++ b/frontend/src/metabase/actions/components/ActionViz/ActionVizForm.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 
 import { getFormTitle } from "metabase/actions/utils";
 
@@ -14,6 +14,7 @@ import type {
 
 import ActionCreator from "metabase/actions/containers/ActionCreator/ActionCreator";
 import Modal from "metabase/components/Modal";
+import { ActionFormRefData } from "metabase/actions/components/ActionForm/ActionForm";
 import ActionParametersInputForm, {
   ActionParametersInputModal,
 } from "../../containers/ActionParametersInputForm";
@@ -59,9 +60,16 @@ function ActionVizForm({
   const [showEditModal, setShowEditModal] = useState(false);
   const title = getFormTitle(action);
 
+  const formRef = useRef<ActionFormRefData>(null);
+
   // only show confirmation if there are no missing parameters
   const showConfirmMessage =
     shouldShowConfirmation(action) && missingParameters.length === 0;
+
+  const mixedDashcardParamValues = {
+    ...dashcardParamValues,
+    ...formRef.current?.values,
+  };
 
   const onClick = () => {
     setShowFormModal(true);
@@ -92,17 +100,18 @@ function ActionVizForm({
           focus={isEditingDashcard}
           onClick={onClick}
         />
-        {showFormModal && !showEditModal && (
+        {showFormModal && (
           <ActionParametersInputModal
+            ref={formRef}
             action={action}
             dashboard={dashboard}
             dashcard={dashcard}
             mappedParameters={mappedParameters}
-            dashcardParamValues={dashcardParamValues}
+            dashcardParamValues={mixedDashcardParamValues}
             title={title}
             showConfirmMessage={showConfirmMessage}
             confirmMessage={action.visualization_settings?.confirmMessage}
-            onEdit={canEditAction ? handleActionEdit : undefined}
+            onActionEdit={canEditAction ? handleActionEdit : undefined}
             onSubmit={onModalSubmit}
             onClose={() => setShowFormModal(false)}
             onCancel={() => setShowFormModal(false)}

--- a/frontend/src/metabase/actions/components/ActionViz/ActionVizForm.tsx
+++ b/frontend/src/metabase/actions/components/ActionViz/ActionVizForm.tsx
@@ -66,11 +66,6 @@ function ActionVizForm({
   const showConfirmMessage =
     shouldShowConfirmation(action) && missingParameters.length === 0;
 
-  const mixedDashcardParamValues = {
-    ...dashcardParamValues,
-    ...formRef.current?.values,
-  };
-
   const onClick = () => {
     setShowFormModal(true);
   };
@@ -107,7 +102,8 @@ function ActionVizForm({
             dashboard={dashboard}
             dashcard={dashcard}
             mappedParameters={mappedParameters}
-            dashcardParamValues={mixedDashcardParamValues}
+            dashcardParamValues={dashcardParamValues}
+            initialValues={formRef.current?.values}
             title={title}
             showConfirmMessage={showConfirmMessage}
             confirmMessage={action.visualization_settings?.confirmMessage}
@@ -118,7 +114,12 @@ function ActionVizForm({
           />
         )}
         {showEditModal && (
-          <Modal wide onClose={closeEditModal} closeOnClickOutside>
+          <Modal
+            wide
+            data-testid="action-creator-modal"
+            onClose={closeEditModal}
+            closeOnClickOutside
+          >
             <ActionCreator
               initialAction={action}
               action={action}
@@ -143,6 +144,7 @@ function ActionVizForm({
         dashcard={dashcard}
         mappedParameters={mappedParameters}
         dashcardParamValues={dashcardParamValues}
+        initialValues={formRef.current?.values}
         onSubmit={onSubmit}
       />
     </FormWrapper>

--- a/frontend/src/metabase/actions/containers/ActionCreator/ActionCreator.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/ActionCreator.tsx
@@ -38,6 +38,9 @@ interface OwnProps {
   actionId?: WritebackActionId;
   modelId?: CardId;
   databaseId?: DatabaseId;
+
+  action?: WritebackAction;
+
   onSubmit?: (action: WritebackAction) => void;
   onClose?: () => void;
 }
@@ -192,11 +195,15 @@ function ActionCreatorWithContext({
   initialAction,
   metadata,
   databaseId,
+  action,
   ...props
 }: Props) {
+  // This is needed in case we already have an action and pass it from the outside
+  const contextAction = action || initialAction;
+
   return (
     <ActionContext
-      initialAction={initialAction}
+      initialAction={contextAction}
       databaseId={databaseId}
       metadata={metadata}
     >

--- a/frontend/src/metabase/actions/containers/ActionParametersInputForm/ActionParametersInputForm.tsx
+++ b/frontend/src/metabase/actions/containers/ActionParametersInputForm/ActionParametersInputForm.tsx
@@ -33,6 +33,7 @@ export interface ActionParametersInputFormProps {
   dashcard?: ActionDashboardCard;
   mappedParameters?: WritebackParameter[];
   initialValues?: ParametersForActionExecution;
+  hasPreservedInitialValues?: boolean;
   dashcardParamValues?: ParametersForActionExecution;
   onSubmit: OnSubmitActionForm;
   onSubmitSuccess?: () => void;
@@ -48,6 +49,7 @@ const ActionParametersInputForm = forwardRef(function ActionParametersInputForm(
     mappedParameters = [],
     dashcardParamValues = {},
     initialValues: initialValuesProp = {},
+    hasPreservedInitialValues,
     dashboard,
     dashcard,
     onCancel,
@@ -137,6 +139,7 @@ const ActionParametersInputForm = forwardRef(function ActionParametersInputForm(
       ref={ref}
       action={action}
       initialValues={initialValues}
+      hasPreservedInitialValues={hasPreservedInitialValues}
       hiddenFields={hiddenFields}
       onSubmit={handleSubmit}
       onClose={onCancel}

--- a/frontend/src/metabase/actions/containers/ActionParametersInputForm/ActionParametersInputForm.tsx
+++ b/frontend/src/metabase/actions/containers/ActionParametersInputForm/ActionParametersInputForm.tsx
@@ -32,6 +32,7 @@ export interface ActionParametersInputFormProps {
   dashboard?: Dashboard;
   dashcard?: ActionDashboardCard;
   mappedParameters?: WritebackParameter[];
+  initialValues?: ParametersForActionExecution;
   dashcardParamValues?: ParametersForActionExecution;
   onSubmit: OnSubmitActionForm;
   onSubmitSuccess?: () => void;
@@ -46,6 +47,7 @@ const ActionParametersInputForm = forwardRef(function ActionParametersInputForm(
     action,
     mappedParameters = [],
     dashcardParamValues = {},
+    initialValues: initialValuesProp = {},
     dashboard,
     dashcard,
     onCancel,
@@ -67,8 +69,9 @@ const ActionParametersInputForm = forwardRef(function ActionParametersInputForm(
     () => ({
       ...prefetchedValues,
       ...dashcardParamValues,
+      ...initialValuesProp,
     }),
-    [prefetchedValues, dashcardParamValues],
+    [initialValuesProp, prefetchedValues, dashcardParamValues],
   );
 
   const hiddenFields = useMemo(

--- a/frontend/src/metabase/actions/containers/ActionParametersInputForm/ActionParametersInputForm.tsx
+++ b/frontend/src/metabase/actions/containers/ActionParametersInputForm/ActionParametersInputForm.tsx
@@ -1,4 +1,11 @@
-import { useCallback, useMemo, useState, useEffect } from "react";
+import {
+  useCallback,
+  useMemo,
+  useState,
+  useEffect,
+  forwardRef,
+  Ref,
+} from "react";
 import { t } from "ttag";
 import _ from "underscore";
 
@@ -6,7 +13,9 @@ import EmptyState from "metabase/components/EmptyState";
 
 import { ActionsApi, PublicApi } from "metabase/services";
 
-import ActionForm from "metabase/actions/components/ActionForm";
+import ActionForm, {
+  ActionFormRefData,
+} from "metabase/actions/components/ActionForm";
 import { getDashboardType } from "metabase/dashboard/utils";
 
 import type {
@@ -32,16 +41,19 @@ export interface ActionParametersInputFormProps {
 const shouldPrefetchValues = (action: WritebackAction) =>
   action.type === "implicit" && action.kind === "row/update";
 
-function ActionParametersInputForm({
-  action,
-  mappedParameters = [],
-  dashcardParamValues = {},
-  dashboard,
-  dashcard,
-  onCancel,
-  onSubmit,
-  onSubmitSuccess,
-}: ActionParametersInputFormProps) {
+const ActionParametersInputForm = forwardRef(function ActionParametersInputForm(
+  {
+    action,
+    mappedParameters = [],
+    dashcardParamValues = {},
+    dashboard,
+    dashcard,
+    onCancel,
+    onSubmit,
+    onSubmitSuccess,
+  }: ActionParametersInputFormProps,
+  ref: Ref<ActionFormRefData>,
+) {
   const [prefetchedValues, setPrefetchedValues] =
     useState<ParametersForActionExecution>({});
 
@@ -119,6 +131,7 @@ function ActionParametersInputForm({
 
   return (
     <ActionForm
+      ref={ref}
       action={action}
       initialValues={initialValues}
       hiddenFields={hiddenFields}
@@ -126,7 +139,7 @@ function ActionParametersInputForm({
       onClose={onCancel}
     />
   );
-}
+});
 
 // eslint-disable-next-line import/no-default-export -- deprecated usage
 export default ActionParametersInputForm;

--- a/frontend/src/metabase/actions/containers/ActionParametersInputForm/ActionParametersInputForm.tsx
+++ b/frontend/src/metabase/actions/containers/ActionParametersInputForm/ActionParametersInputForm.tsx
@@ -1,11 +1,4 @@
-import {
-  useCallback,
-  useMemo,
-  useState,
-  useEffect,
-  forwardRef,
-  Ref,
-} from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { t } from "ttag";
 import _ from "underscore";
 
@@ -13,18 +6,16 @@ import EmptyState from "metabase/components/EmptyState";
 
 import { ActionsApi, PublicApi } from "metabase/services";
 
-import ActionForm, {
-  ActionFormRefData,
-} from "metabase/actions/components/ActionForm";
+import ActionForm from "metabase/actions/components/ActionForm";
 import { getDashboardType } from "metabase/dashboard/utils";
 
 import type {
-  WritebackParameter,
-  OnSubmitActionForm,
-  Dashboard,
   ActionDashboardCard,
+  Dashboard,
+  OnSubmitActionForm,
   ParametersForActionExecution,
   WritebackAction,
+  WritebackParameter,
 } from "metabase-types/api";
 
 export interface ActionParametersInputFormProps {
@@ -35,6 +26,7 @@ export interface ActionParametersInputFormProps {
   initialValues?: ParametersForActionExecution;
   hasPreservedInitialValues?: boolean;
   dashcardParamValues?: ParametersForActionExecution;
+  onChange?: (values: ParametersForActionExecution) => void;
   onSubmit: OnSubmitActionForm;
   onSubmitSuccess?: () => void;
   onCancel?: () => void;
@@ -43,21 +35,19 @@ export interface ActionParametersInputFormProps {
 const shouldPrefetchValues = (action: WritebackAction) =>
   action.type === "implicit" && action.kind === "row/update";
 
-const ActionParametersInputForm = forwardRef(function ActionParametersInputForm(
-  {
-    action,
-    mappedParameters = [],
-    dashcardParamValues = {},
-    initialValues: initialValuesProp = {},
-    hasPreservedInitialValues,
-    dashboard,
-    dashcard,
-    onCancel,
-    onSubmit,
-    onSubmitSuccess,
-  }: ActionParametersInputFormProps,
-  ref: Ref<ActionFormRefData>,
-) {
+function ActionParametersInputForm({
+  action,
+  mappedParameters = [],
+  dashcardParamValues = {},
+  initialValues: initialValuesProp = {},
+  hasPreservedInitialValues,
+  dashboard,
+  dashcard,
+  onCancel,
+  onChange,
+  onSubmit,
+  onSubmitSuccess,
+}: ActionParametersInputFormProps) {
   const [prefetchedValues, setPrefetchedValues] =
     useState<ParametersForActionExecution>({});
 
@@ -136,16 +126,16 @@ const ActionParametersInputForm = forwardRef(function ActionParametersInputForm(
 
   return (
     <ActionForm
-      ref={ref}
       action={action}
       initialValues={initialValues}
       hasPreservedInitialValues={hasPreservedInitialValues}
       hiddenFields={hiddenFields}
+      onChange={onChange}
       onSubmit={handleSubmit}
       onClose={onCancel}
     />
   );
-});
+}
 
 // eslint-disable-next-line import/no-default-export -- deprecated usage
 export default ActionParametersInputForm;

--- a/frontend/src/metabase/actions/containers/ActionParametersInputForm/ActionParametersInputModal.tsx
+++ b/frontend/src/metabase/actions/containers/ActionParametersInputForm/ActionParametersInputModal.tsx
@@ -1,8 +1,10 @@
 import { t } from "ttag";
+import { forwardRef, Ref } from "react";
 import Modal from "metabase/components/Modal";
 import ModalContent, {
   ModalContentActionIcon,
 } from "metabase/components/ModalContent";
+import { ActionFormRefData } from "metabase/actions/components/ActionForm/ActionForm";
 import ActionParametersInputForm, {
   ActionParametersInputFormProps,
 } from "./ActionParametersInputForm";
@@ -11,40 +13,45 @@ interface ModalProps {
   title: string;
   showConfirmMessage?: boolean;
   confirmMessage?: string;
-  onEdit?: () => void;
+  onActionEdit?: () => void;
   onClose: () => void;
 }
 
 export type ActionParametersInputModalProps = ModalProps &
   ActionParametersInputFormProps;
 
-function ActionParametersInputModal({
-  title,
-  showConfirmMessage,
-  confirmMessage,
-  onEdit,
-  onClose,
-  ...formProps
-}: ActionParametersInputModalProps) {
-  return (
-    <Modal onClose={onClose}>
-      <ModalContent
-        title={title}
-        headerActions={
-          onEdit ? (
-            <ModalContentActionIcon name="pencil" onClick={onEdit} />
-          ) : undefined
-        }
-        onClose={onClose}
-      >
-        <>
-          {showConfirmMessage && <ConfirmMessage message={confirmMessage} />}
-          <ActionParametersInputForm {...formProps} />
-        </>
-      </ModalContent>
-    </Modal>
-  );
-}
+const ActionParametersInputModal = forwardRef(
+  function ActionParametersInputModal(
+    {
+      title,
+      showConfirmMessage,
+      confirmMessage,
+      onActionEdit,
+      onClose,
+      ...formProps
+    }: ActionParametersInputModalProps,
+    ref: Ref<ActionFormRefData>,
+  ) {
+    return (
+      <Modal onClose={onClose}>
+        <ModalContent
+          title={title}
+          headerActions={
+            onActionEdit ? (
+              <ModalContentActionIcon name="pencil" onClick={onActionEdit} />
+            ) : undefined
+          }
+          onClose={onClose}
+        >
+          <>
+            {showConfirmMessage && <ConfirmMessage message={confirmMessage} />}
+            <ActionParametersInputForm {...formProps} ref={ref} />
+          </>
+        </ModalContent>
+      </Modal>
+    );
+  },
+);
 
 const ConfirmMessage = ({ message }: { message?: string }) => (
   <div>{message ?? t`This action cannot be undone.`}</div>

--- a/frontend/src/metabase/actions/containers/ActionParametersInputForm/ActionParametersInputModal.tsx
+++ b/frontend/src/metabase/actions/containers/ActionParametersInputForm/ActionParametersInputModal.tsx
@@ -1,10 +1,8 @@
 import { t } from "ttag";
-import { forwardRef, Ref } from "react";
 import Modal from "metabase/components/Modal";
 import ModalContent, {
   ModalContentActionIcon,
 } from "metabase/components/ModalContent";
-import { ActionFormRefData } from "metabase/actions/components/ActionForm/ActionForm";
 import ActionParametersInputForm, {
   ActionParametersInputFormProps,
 } from "./ActionParametersInputForm";
@@ -13,45 +11,43 @@ interface ModalProps {
   title: string;
   showConfirmMessage?: boolean;
   confirmMessage?: string;
-  onActionEdit?: () => void;
+  onTriggerActionEdit?: () => void;
   onClose: () => void;
 }
 
 export type ActionParametersInputModalProps = ModalProps &
   ActionParametersInputFormProps;
 
-const ActionParametersInputModal = forwardRef(
-  function ActionParametersInputModal(
-    {
-      title,
-      showConfirmMessage,
-      confirmMessage,
-      onActionEdit,
-      onClose,
-      ...formProps
-    }: ActionParametersInputModalProps,
-    ref: Ref<ActionFormRefData>,
-  ) {
-    return (
-      <Modal data-testid="action-execution-form-modal" onClose={onClose}>
-        <ModalContent
-          title={title}
-          headerActions={
-            onActionEdit ? (
-              <ModalContentActionIcon name="pencil" onClick={onActionEdit} />
-            ) : undefined
-          }
-          onClose={onClose}
-        >
-          <>
-            {showConfirmMessage && <ConfirmMessage message={confirmMessage} />}
-            <ActionParametersInputForm {...formProps} ref={ref} />
-          </>
-        </ModalContent>
-      </Modal>
-    );
-  },
-);
+function ActionParametersInputModal({
+  title,
+  showConfirmMessage,
+  confirmMessage,
+  onTriggerActionEdit,
+  onClose,
+  ...formProps
+}: ActionParametersInputModalProps) {
+  return (
+    <Modal data-testid="action-execution-form-modal" onClose={onClose}>
+      <ModalContent
+        title={title}
+        headerActions={
+          onTriggerActionEdit ? (
+            <ModalContentActionIcon
+              name="pencil"
+              onClick={onTriggerActionEdit}
+            />
+          ) : undefined
+        }
+        onClose={onClose}
+      >
+        <>
+          {showConfirmMessage && <ConfirmMessage message={confirmMessage} />}
+          <ActionParametersInputForm {...formProps} />
+        </>
+      </ModalContent>
+    </Modal>
+  );
+}
 
 const ConfirmMessage = ({ message }: { message?: string }) => (
   <div>{message ?? t`This action cannot be undone.`}</div>

--- a/frontend/src/metabase/actions/containers/ActionParametersInputForm/ActionParametersInputModal.tsx
+++ b/frontend/src/metabase/actions/containers/ActionParametersInputForm/ActionParametersInputModal.tsx
@@ -1,7 +1,8 @@
 import { t } from "ttag";
 import Modal from "metabase/components/Modal";
-import ModalContent from "metabase/components/ModalContent";
-
+import ModalContent, {
+  ModalContentActionIcon,
+} from "metabase/components/ModalContent";
 import ActionParametersInputForm, {
   ActionParametersInputFormProps,
 } from "./ActionParametersInputForm";
@@ -10,6 +11,7 @@ interface ModalProps {
   title: string;
   showConfirmMessage?: boolean;
   confirmMessage?: string;
+  onEdit?: () => void;
   onClose: () => void;
 }
 
@@ -20,12 +22,21 @@ function ActionParametersInputModal({
   title,
   showConfirmMessage,
   confirmMessage,
+  onEdit,
   onClose,
   ...formProps
 }: ActionParametersInputModalProps) {
   return (
     <Modal onClose={onClose}>
-      <ModalContent title={title} onClose={onClose}>
+      <ModalContent
+        title={title}
+        headerActions={
+          onEdit ? (
+            <ModalContentActionIcon name="pencil" onClick={onEdit} />
+          ) : undefined
+        }
+        onClose={onClose}
+      >
         <>
           {showConfirmMessage && <ConfirmMessage message={confirmMessage} />}
           <ActionParametersInputForm {...formProps} />

--- a/frontend/src/metabase/actions/containers/ActionParametersInputForm/ActionParametersInputModal.tsx
+++ b/frontend/src/metabase/actions/containers/ActionParametersInputForm/ActionParametersInputModal.tsx
@@ -33,7 +33,7 @@ const ActionParametersInputModal = forwardRef(
     ref: Ref<ActionFormRefData>,
   ) {
     return (
-      <Modal onClose={onClose}>
+      <Modal data-testid="action-execution-form-modal" onClose={onClose}>
         <ModalContent
           title={title}
           headerActions={

--- a/frontend/src/metabase/actions/hooks/use-action-form/use-action-form.ts
+++ b/frontend/src/metabase/actions/hooks/use-action-form/use-action-form.ts
@@ -19,9 +19,14 @@ import {
 type Opts = {
   action: WritebackAction;
   initialValues?: ActionFormInitialValues;
+  hasPreservedInitialValues?: boolean;
 };
 
-function useActionForm({ action, initialValues = {} }: Opts) {
+function useActionForm({
+  action,
+  initialValues = {},
+  hasPreservedInitialValues = false,
+}: Opts) {
   const fieldSettings = useMemo(
     () =>
       action.visualization_settings?.fields ||
@@ -64,11 +69,17 @@ function useActionForm({ action, initialValues = {} }: Opts) {
       // For implicit update actions, we sometimes prefetch selected row values,
       // and pass them as initial values to prefill the form.
       // In that case, we want to return only changed values
-      return isImplicitUpdate
+      return isImplicitUpdate && !hasPreservedInitialValues
         ? getChangedValues(formatted, initialValues)
         : formatted;
     },
-    [action, initialValues, cleanedInitialValues, fieldSettings],
+    [
+      action,
+      initialValues,
+      cleanedInitialValues,
+      fieldSettings,
+      hasPreservedInitialValues,
+    ],
   );
 
   return {

--- a/frontend/src/metabase/actions/hooks/use-action-form/use-action-form.ts
+++ b/frontend/src/metabase/actions/hooks/use-action-form/use-action-form.ts
@@ -40,12 +40,18 @@ function useActionForm({ action, initialValues = {} }: Opts) {
   );
 
   const cleanedInitialValues = useMemo(() => {
-    const values = validationSchema.cast(initialValues);
+    const fieldKeys = action.parameters.map(({ id }) => id);
+    const matchedValues = _.pick(initialValues, (value, key) =>
+      fieldKeys.includes(key),
+    );
+
+    const values = validationSchema.cast(matchedValues);
+
     return _.mapObject(values, (value, fieldId) => {
       const formField = fieldSettings[fieldId];
       return formatInitialValue(value, formField?.inputType);
     });
-  }, [initialValues, fieldSettings, validationSchema]);
+  }, [action.parameters, initialValues, fieldSettings, validationSchema]);
 
   const getCleanValues = useCallback(
     (values: ParametersForActionExecution = {}) => {

--- a/frontend/src/metabase/actions/utils.ts
+++ b/frontend/src/metabase/actions/utils.ts
@@ -256,10 +256,11 @@ export const getForm = (
   };
 };
 
-const getFieldValidationType = ({
-  inputType,
-  defaultValue,
-}: FieldSettings): Yup.AnySchema => {
+const getFieldValidationType = (
+  fieldSettings: FieldSettings,
+): Yup.AnySchema => {
+  const { inputType, defaultValue, fieldType } = fieldSettings;
+
   switch (inputType) {
     case "number":
       return Yup.number()
@@ -275,6 +276,8 @@ const getFieldValidationType = ({
       return Yup.string()
         .nullable()
         .default(defaultValue != null ? String(defaultValue) : null);
+    case "select":
+      return getFieldValidationType({ ...fieldSettings, inputType: fieldType });
     default:
       return Yup.string()
         .nullable()

--- a/frontend/src/metabase/components/Modal/WindowModal.tsx
+++ b/frontend/src/metabase/components/Modal/WindowModal.tsx
@@ -17,6 +17,7 @@ export type WindowModalProps = BaseModalProps & {
   fullPageModal?: boolean;
   formModal?: boolean;
   style?: CSSProperties;
+  "data-testid"?: string;
 } & {
   [size in ModalSize]?: boolean;
 };
@@ -86,6 +87,7 @@ export class WindowModal extends Component<WindowModalProps> {
       isOpen,
       style,
       enableTransition,
+      "data-testid": dataTestId,
     } = this.props;
     const backdropClassnames =
       "flex justify-center align-center fixed top left bottom right";
@@ -113,6 +115,7 @@ export class WindowModal extends Component<WindowModalProps> {
               <div
                 className={cx(backdropClassName, backdropClassnames)}
                 style={style}
+                data-testid={dataTestId}
               >
                 {this._modalComponent()}
               </div>

--- a/frontend/src/metabase/components/ModalContent/ModalContent.stories.tsx
+++ b/frontend/src/metabase/components/ModalContent/ModalContent.stories.tsx
@@ -1,8 +1,7 @@
 import type { ComponentStory } from "@storybook/react";
 import { action } from "@storybook/addon-actions";
 import Modal from "metabase/components/Modal";
-import { ActionIcon } from "./ModalContent.styled";
-import ModalContent from "./ModalContent";
+import ModalContent, { ModalContentActionIcon } from "./index";
 
 export default {
   title: "Components/ModalContent",
@@ -48,7 +47,7 @@ WithHeaderActions.args = {
   ...args,
   headerActions: (
     <>
-      <ActionIcon name="pencil" onClick={action("Action1")} />
+      <ModalContentActionIcon name="pencil" onClick={action("Action1")} />
     </>
   ),
 };

--- a/frontend/src/metabase/components/ModalContent/ModalContent.styled.ts
+++ b/frontend/src/metabase/components/ModalContent/ModalContent.styled.ts
@@ -30,7 +30,7 @@ export const ActionsWrapper = styled.div`
   margin-right: -0.5rem;
 `;
 
-export const ActionIcon = styled(Icon)`
+export const ModalContentActionIcon = styled(Icon)`
   color: ${color("text-light")};
   cursor: pointer;
   padding: 0.5rem;

--- a/frontend/src/metabase/components/ModalContent/ModalContent.tsx
+++ b/frontend/src/metabase/components/ModalContent/ModalContent.tsx
@@ -2,7 +2,7 @@ import { Component, ReactNode } from "react";
 import PropTypes from "prop-types";
 import cx from "classnames";
 import {
-  ActionIcon,
+  ModalContentActionIcon,
   ActionsWrapper,
   HeaderContainer,
   HeaderText,
@@ -133,7 +133,11 @@ export const ModalHeader = ({
         <ActionsWrapper>
           {headerActions}
           {onClose && (
-            <ActionIcon name="close" size={actionIconSize} onClick={onClose} />
+            <ModalContentActionIcon
+              name="close"
+              size={actionIconSize}
+              onClick={onClose}
+            />
           )}
         </ActionsWrapper>
       )}

--- a/frontend/src/metabase/components/ModalContent/ModalContent.unit.spec.tsx
+++ b/frontend/src/metabase/components/ModalContent/ModalContent.unit.spec.tsx
@@ -1,6 +1,6 @@
 import userEvent from "@testing-library/user-event";
 import { getIcon, render } from "__support__/ui";
-import { ActionIcon } from "./ModalContent.styled";
+import { ModalContentActionIcon } from "./ModalContent.styled";
 import ModalContent, { ModalContentProps } from "./ModalContent";
 
 describe("ModalContent", () => {
@@ -19,7 +19,7 @@ describe("ModalContent", () => {
     const headerActionsEl = (
       <>
         {headerActions.map(({ icon, onClick }) => (
-          <ActionIcon key={icon} name={icon} onClick={onClick} />
+          <ModalContentActionIcon key={icon} name={icon} onClick={onClick} />
         ))}
       </>
     );

--- a/frontend/src/metabase/components/ModalContent/index.ts
+++ b/frontend/src/metabase/components/ModalContent/index.ts
@@ -1,3 +1,4 @@
 // eslint-disable-next-line import/no-default-export -- deprecated usage
 export { default } from "./ModalContent";
 export * from "./ModalContent";
+export { ModalContentActionIcon } from "./ModalContent.styled";

--- a/frontend/src/metabase/core/components/Form/Form.tsx
+++ b/frontend/src/metabase/core/components/Form/Form.tsx
@@ -1,16 +1,30 @@
-import { FormHTMLAttributes, forwardRef, Ref, SyntheticEvent } from "react";
+import {
+  FormHTMLAttributes,
+  forwardRef,
+  Ref,
+  SyntheticEvent,
+  useEffect,
+} from "react";
 import { useFormikContext } from "formik";
 
-export interface FormProps
-  extends Omit<FormHTMLAttributes<HTMLFormElement>, "onSubmit" | "onReset"> {
+export interface FormProps<Values>
+  extends Omit<
+    FormHTMLAttributes<HTMLFormElement>,
+    "onSubmit" | "onReset" | "onChange"
+  > {
+  onChange?: (values: Values) => void;
   disabled?: boolean;
 }
 
-const Form = forwardRef(function Form(
-  { disabled, ...props }: FormProps,
+const Form = forwardRef(function Form<Values>(
+  { disabled, onChange, ...props }: FormProps<Values>,
   ref: Ref<HTMLFormElement>,
 ) {
-  const { handleSubmit, handleReset } = useFormikContext();
+  const { handleSubmit, handleReset, values } = useFormikContext<Values>();
+
+  useEffect(() => {
+    onChange?.(values);
+  }, [onChange, values]);
 
   return (
     <form

--- a/frontend/src/metabase/dashboard/reducers.js
+++ b/frontend/src/metabase/dashboard/reducers.js
@@ -5,7 +5,7 @@ import _ from "underscore";
 import { handleActions, combineReducers } from "metabase/lib/redux";
 import Dashboards from "metabase/entities/dashboards";
 import Questions from "metabase/entities/questions";
-
+import Actions from "metabase/entities/actions";
 import { NAVIGATE_BACK_TO_DASHBOARD } from "metabase/query_builder/actions";
 
 import {
@@ -235,6 +235,20 @@ const dashcards = handleActions(
       _.mapObject(state, dashcard =>
         dashcard.card?.id === card?.id
           ? assocIn(dashcard, ["card"], card)
+          : dashcard,
+      ),
+    [Actions.actionTypes.UPDATE]: (state, { payload: { object: action } }) =>
+      _.mapObject(state, dashcard =>
+        dashcard.action?.id === action?.id
+          ? {
+              ...dashcard,
+              action: {
+                ...action,
+
+                database_enabled_actions:
+                  dashcard?.action.database_enabled_actions || false,
+              },
+            }
           : dashcard,
       ),
   },

--- a/frontend/src/metabase/lib/entities.js
+++ b/frontend/src/metabase/lib/entities.js
@@ -351,7 +351,7 @@ export function createEntity(def) {
   // HACK: the above actions return the normalizr results
   // (i.e. { entities, result }) rather than the loaded object(s), except
   // for fetch and fetchList when the data is cached, in which case it returns
-  // the noralized object.
+  // the normalized object.
   //
   // This is a problem when we use the result of one of the actions as though
   // though the action creator was an API client.


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/29866

### Description

Preserve typed form values in case of inline action edit

### Demo


https://github.com/metabase/metabase/assets/7983744/8377bf73-f572-4912-b149-38f027f5dde5



### Checklist

- [x] Tests have been added/updated to cover changes in this PR


### Known issues

- [x] You can close action call modal using "Esc" while you have action edit modal opened.
- [ ] There is an issue with restoring Select with numeric value after action edit.