### PR TITLE
Make "Don't bin" a proper binning strategy

### DIFF
--- a/shared/src/metabase/mbql/schema.cljc
+++ b/shared/src/metabase/mbql/schema.cljc
@@ -321,7 +321,7 @@
 
 (def BinningStrategyName
   "Schema for a valid value for the `strategy-name` param of a [[field]] clause with `:binning` information."
-  (s/enum :num-bins :bin-width :default))
+  (s/enum :num-bins :bin-width :default :dont-bin))
 
 (defn- validate-bin-width [schema]
   (s/constrained

--- a/src/metabase/lib/binning.cljc
+++ b/src/metabase/lib/binning.cljc
@@ -82,7 +82,7 @@
 
 (defn- dont-bin []
   {:display-name (i18n/tru "Don''t bin")
-   :mbql         nil})
+   :mbql         {:strategy :dont-bin}})
 
 (defn- with-binning-option-type [m]
   (assoc m :lib/type ::binning-option))
@@ -126,6 +126,7 @@
       :bin-width (str (fmt.num/format-number bin-width {})
                       (when (isa? (:semantic-type field-metadata) :type/Coordinate)
                         "°"))
+      :dont-bin  (i18n/tru "Unbinned")
       :default   (i18n/tru "Auto binned"))))
 
 (defmethod lib.metadata.calculation/display-info-method ::binning-option

--- a/src/metabase/lib/schema/binning.cljc
+++ b/src/metabase/lib/schema/binning.cljc
@@ -9,7 +9,7 @@
    [metabase.util.malli.registry :as mr]))
 
 (mr/def ::binning-strategies
-  [:enum :bin-width :default :num-bins])
+  [:enum :bin-width :default :num-bins :dont-bin])
 
 (mr/def ::binning
   [:and
@@ -17,9 +17,9 @@
     [:strategy  [:ref ::binning-strategies]]
     [:bin-width {:optional true} pos?]
     [:num-bins  {:optional true} ::lib.schema.common/int-greater-than-zero]]
-   [:fn {:error/message "if :strategy is not :default, the matching key :bin-width or :num-bins must also be set"}
+   [:fn {:error/message "if :strategy is not :default or :dont-bin, the matching key :bin-width or :num-bins must also be set"}
     #(when-let [strat (:strategy %)]
-       (or (= strat :default)
+       (or (contains? #{:default :dont-bin} strat)
            (contains? % strat)))]])
 
 (mr/def ::binning-option


### PR DESCRIPTION
Fixes #31399.

Initially I tried to make this symmetrical to how MLv1 does things. That means that `"Don't bin"` is not a binning strategy that we set. But this makes it unnecessarily difficult do distinguish the case when `"Don't bin"` was actively set from the case when no binning strategy has been chosen at all. I tried keeping `:binning` with a `nil` value in the options and the metadata but that didn't work (smoothly). Also, in MLv1 `"Unbinned"` is set in frontend code, which I don't like.

**TODO**
- [ ] add backend tests
- [ ] fix existing failing tests
- [ ] when a binning strategy has been selected for a column, the other columns are shown as if they had the same binning set (see screenshot), I guess this has to be fixed in the frontend, but I want to check

![image](https://github.com/metabase/metabase/assets/103100869/df436b51-769c-421e-bdb5-bf4d204c56f5)
