### PR TITLE
remove withNormalizeCSS from MantineProvider

### DIFF
--- a/frontend/src/metabase/ui/components/ThemeProvider.tsx
+++ b/frontend/src/metabase/ui/components/ThemeProvider.tsx
@@ -7,7 +7,5 @@ interface ThemeProviderProps {
 }
 
 export const ThemeProvider = ({ children }: ThemeProviderProps) => (
-  <MantineProvider theme={theme} withNormalizeCSS>
-    {children}
-  </MantineProvider>
+  <MantineProvider theme={theme}>{children}</MantineProvider>
 );


### PR DESCRIPTION
The addition of `withNormalizeCSS` was resetting our input font family to just `sans-serif` and causing information display issues. We could likely include this later on once we're using Mantine based input fields, but for a piece by piece integration, it was a bit premature to do it.

Before the fix
<img width="981" alt="Screen Shot 2023-06-07 at 8 46 21 PM" src="https://github.com/metabase/metabase/assets/5248953/13bbe092-3482-49a3-8b94-f81c9b9490ba">

After the fix
<img width="978" alt="Screen Shot 2023-06-07 at 8 46 04 PM" src="https://github.com/metabase/metabase/assets/5248953/52e30e20-eab2-468f-b8b1-5d11f20e4a64">
