### PR TITLE
Restrict uploading to people with data access to DB

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
@@ -692,7 +692,7 @@
                                          uploads-database-id  db-id
                                          uploads-schema-name  nil
                                          uploads-table-prefix "uploaded_magic_"]
-        (with-all-users-data-perms {db-id {:details :no}}
+        (with-all-users-data-perms {db-id {:data {:native :none, :schemas :none}}}
           (is (thrown-with-msg?
                clojure.lang.ExceptionInfo
                #"You don't have permissions to do that\."

--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -1152,6 +1152,7 @@ saved later when it is ready."
   (let [db-id             (public-settings/uploads-database-id)
         database          (or (t2/select-one Database :id db-id)
                               (throw (Exception. (tru "The uploads database does not exist."))))
+        _check_perms      (api/check-403 (mi/can-write? database))
         driver            (driver.u/database->driver database)
         schema-name       (public-settings/uploads-schema-name)
         _check-schema     (when-not (or (nil? schema-name)

--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -1152,7 +1152,7 @@ saved later when it is ready."
   (let [db-id             (public-settings/uploads-database-id)
         database          (or (t2/select-one Database :id db-id)
                               (throw (Exception. (tru "The uploads database does not exist."))))
-        _check_perms      (api/check-403 (mi/can-write? database))
+        _check_perms      (api/check-403 (mi/can-read? database))
         driver            (driver.u/database->driver database)
         schema-name       (public-settings/uploads-schema-name)
         _check-schema     (when-not (or (nil? schema-name)

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -34,6 +34,7 @@
             Timeline
             TimelineEvent
             ViewLog]]
+   [metabase.models.interface :as mi]
    [metabase.models.moderation-review :as moderation-review]
    [metabase.models.permissions :as perms]
    [metabase.models.permissions-group :as perms-group]
@@ -2819,17 +2820,22 @@
   ([collection-id]
    (upload-example-csv! collection-id true))
   ([collection-id grant-permission?]
-   (let [file        (upload-test/csv-file-with
-                      ["id, name"
-                       "1, Luke Skywalker"
-                       "2, Darth Vader"]
-                      "example_csv_file")
-         group-id    (u/the-id (perms-group/all-users))]
-     (when grant-permission?
-       (perms/grant-permissions! group-id (perms/data-perms-path (mt/id))))
-     (u/prog1
-       (mt/with-current-user (mt/user->id :rasta)
-         (api.card/upload-csv! collection-id "example_csv_file.csv" file))))))
+   (mt/with-current-user (mt/user->id :rasta)
+     (let [file              (upload-test/csv-file-with
+                              ["id, name"
+                               "1, Luke Skywalker"
+                               "2, Darth Vader"]
+                              "example_csv_file")
+           group-id          (u/the-id (perms-group/all-users))
+           can-already-read? (mi/can-read? (mt/db))
+           grant?            (and (not can-already-read?)
+                                  grant-permission?)]
+       (when grant?
+         (perms/grant-permissions! group-id (perms/data-perms-path (mt/id))))
+       (u/prog1
+         (api.card/upload-csv! collection-id "example_csv_file.csv" file)
+         (when grant?
+           (perms/revoke-data-perms! group-id (mt/id))))))))
 
 (deftest upload-csv!-schema-test
   (mt/test-drivers (disj (mt/normal-drivers-with-feature :uploads) :mysql) ; MySQL doesn't support schemas

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -39,7 +39,6 @@
    [metabase.models.permissions-group :as perms-group]
    [metabase.models.revision :as revision :refer [Revision]]
    [metabase.models.user :refer [User]]
-   [metabase.plugins.classloader :as classloader]
    [metabase.query-processor :as qp]
    [metabase.query-processor.async :as qp.async]
    [metabase.query-processor.card :as qp.card]
@@ -2825,17 +2824,12 @@
                        "1, Luke Skywalker"
                        "2, Darth Vader"]
                       "example_csv_file")
-         group-id    (u/the-id (perms-group/all-users))
-         grant-perms (or (and grant-permission?
-                              (u/ignore-exceptions
-                                (classloader/require 'metabase-enterprise.advanced-permissions.models.permissions)
-                                (resolve 'metabase-enterprise.advanced-permissions.models.permissions/update-db-details-permissions!)))
-                         (fn [_ _ _]))]
-     (grant-perms group-id (mt/id) :yes)
+         group-id    (u/the-id (perms-group/all-users))]
+     (when grant-permission?
+       (perms/grant-permissions! group-id (perms/data-perms-path (mt/id))))
      (u/prog1
        (mt/with-current-user (mt/user->id :rasta)
-         (api.card/upload-csv! collection-id "example_csv_file.csv" file))
-       (grant-perms group-id (mt/id) :no)))))
+         (api.card/upload-csv! collection-id "example_csv_file.csv" file))))))
 
 (deftest upload-csv!-schema-test
   (mt/test-drivers (disj (mt/normal-drivers-with-feature :uploads) :mysql) ; MySQL doesn't support schemas

--- a/test/metabase/test/util.clj
+++ b/test/metabase/test/util.clj
@@ -393,28 +393,28 @@
                              (t2/select-one-fn :value Setting :key setting-k)
                              (#'setting/get setting-k))]
         (try
-         (if raw-setting?
-           (upsert-raw-setting! original-value setting-k value)
-           (setting/set! setting-k value))
-         (testing (colorize/blue (format "\nSetting %s = %s\n" (keyword setting-k) (pr-str value)))
-           (thunk))
-         (catch Throwable e
-           (throw (ex-info (str "Error in with-temporary-setting-values: " (ex-message e))
-                           {:setting  setting-k
-                            :location (symbol (name (:namespace setting)) (name setting-k))
-                            :value    value}
-                           e)))
-         (finally
-          (try
-           (if raw-setting?
-             (restore-raw-setting! original-value setting-k)
-             (setting/set! setting-k original-value))
-           (catch Throwable e
-             (throw (ex-info (str "Error restoring original Setting value: " (ex-message e))
-                             {:setting        setting-k
-                              :location       (symbol (name (:namespace setting)) setting-k)
-                              :original-value original-value}
-                             e))))))))))
+          (if raw-setting?
+            (upsert-raw-setting! original-value setting-k value)
+            (setting/set! setting-k value))
+          (testing (colorize/blue (format "\nSetting %s = %s\n" (keyword setting-k) (pr-str value)))
+            (thunk))
+          (catch Throwable e
+            (throw (ex-info (str "Error in with-temporary-setting-values: " (ex-message e))
+                            {:setting  setting-k
+                             :location (symbol (name (:namespace setting)) (name setting-k))
+                             :value    value}
+                            e)))
+          (finally
+            (try
+              (if raw-setting?
+                (restore-raw-setting! original-value setting-k)
+                (setting/set! setting-k original-value))
+              (catch Throwable e
+                (throw (ex-info (str "Error restoring original Setting value: " (ex-message e))
+                                {:setting        setting-k
+                                 :location       (symbol (name (:namespace setting)) setting-k)
+                                 :original-value original-value}
+                                e))))))))))
 
 (defmacro with-temporary-setting-values
   "Temporarily bind the site-wide values of one or more `Settings`, execute body, and re-establish the original values.


### PR DESCRIPTION
(EE only)

Users should only be able to upload a CSV file if they have data access to the uploads database.

See @luizarakaki 's message here: https://metaboat.slack.com/archives/C04S696LRUM/p1686157356642389?thread_ts=1686151054.039889&cid=C04S696LRUM


NB: in non-EE contexts, the big perm check is a few lines above: the user having write perms for the collection the CSV is being uploaded to