### PR TITLE
Release script: exclude EBS artifact publish from manual steps

### DIFF
--- a/bin/build/src/release.clj
+++ b/bin/build/src/release.clj
@@ -22,7 +22,6 @@
    :upload-uberjar                      uberjar/upload-uberjar!
    :push-git-tags                       git-tags/push-tags!
    :publish-draft-release               draft-release/create-draft-release!
-   :publish-elastic-beanstalk-artifacts eb/publish-elastic-beanstalk-artifacts!
    :update-version-info                 version-info/update-version-info!))
 
 (defn- do-steps! [steps]
@@ -55,4 +54,4 @@
       (c/set-edition! (if (str/starts-with? (c/version) "0") :oss :ee))
       (c/set-branch! "release-x.y.z") ;; FIXME: branch is irrelevant for CD run
       (u/announce (format "Preparing Elastic Beanstalk artifacts for version %s" (c/version)))
-      (do-steps! [:publish-elastic-beanstalk-artifacts]))))
+      (eb/publish-elastic-beanstalk-artifacts!))))


### PR DESCRIPTION
After PR #28516 is merge, there is no need anymore for the release manager to create and publish EBS (Elastic Beanstalk) artifacts, as it is now is taken care automatically (see `.github/workflow/release.yml`), once the release tag (e.g. `v1.x.y` and `v0.x.y`, for the EE and OSS respectively) is pushed to this repository.

### Before this PR

The release manager manually runs a release script when doing a release. One step in that release script is to build and publish EBS artifacts.


### After this PR

The step in publish EBS artifacts gone. Instead, the process is replaced by the release workflow (`release.yml`).

Example of such a run: https://github.com/metabase/metabase/actions/runs/5071492376/jobs/9108071086