### PR TITLE
Return user-local settings from api/session/properties

### DIFF
--- a/src/metabase/api/session.clj
+++ b/src/metabase/api/session.clj
@@ -278,7 +278,8 @@
 
 #_{:clj-kondo/ignore [:deprecated-var]}
 (api/defendpoint-schema GET "/properties"
-  "Get all global properties and their values. These are the specific `Settings` which are meant to be public."
+  "Get all properties and their values. These are the specific `Settings` that are readable by the current user, or are
+  public if no user is logged in."
   []
   (setting/user-readable-values-map (setting/current-user-readable-visibilities)))
 
@@ -340,7 +341,7 @@
         (throw (ex-info (tru "Email for pulse-id doesn't exist.")
                         {:type        type
                          :status-code 400}))))
-               {:status :success}))
+    {:status :success}))
 
 (api/defendpoint POST "/pulse/unsubscribe/undo"
   "Allow non-users to undo an unsubscribe from pulses/subscriptions, with the hash given through email."
@@ -356,7 +357,7 @@
         (throw (ex-info (tru "Email for pulse-id already exists.")
                         {:type        type
                          :status-code 400}))
-        (t2/update! PulseChannel (:id pulse-channel) (update-in pulse-channel [:details :emails] conj email)))))
-  {:status :success})
+        (t2/update! PulseChannel (:id pulse-channel) (update-in pulse-channel [:details :emails] conj email))))
+    {:status :success}))
 
 (api/define-routes +log-all-request-failures)

--- a/src/metabase/models/setting.clj
+++ b/src/metabase/models/setting.clj
@@ -50,8 +50,8 @@
 
   * `:only` means this Setting can *only* have a User- or Database-local value and cannot have a 'normal' site-wide
   value. It cannot be set via env var. Default values are still allowed for User- and Database-local-only Settings.
-  User- and Database-local-only Settings are never returned by [[writable-settings]] or
-  [[user-readable-values-map]] regardless of their [[Visibility]].
+  Database-local-only Settings are never returned by [[writable-settings]] or [[user-readable-values-map]] regardless of
+  their [[Visibility]].
 
   * `:allowed` means this Setting can be User- or Database-local and can also have a normal site-wide value; if both
   are specified, the User- or Database-specific value will be returned preferentially when we are in the context of a
@@ -359,10 +359,16 @@
   (setting-name [this]
     (name this)))
 
+(defn- database-local-only? [setting]
+  (= (:database-local (resolve-setting setting)) :only))
+
+(defn- user-local-only? [setting]
+  (= (:user-local (resolve-setting setting)) :only))
+
 (defn- allows-site-wide-values? [setting]
   (and
-   (not= (:database-local (resolve-setting setting)) :only)
-   (not= (:user-local (resolve-setting setting)) :only)))
+   (not (database-local-only? setting))
+   (not (user-local-only? setting))))
 
 (defn- allows-database-local-values? [setting]
   (#{:only :allowed} (:database-local (resolve-setting setting))))
@@ -1222,7 +1228,7 @@
     (into
      {}
      (comp (filter (fn [[_setting-name setting]]
-                     (and (allows-site-wide-values? setting)
+                     (and (not (database-local-only? setting))
                           (can-read-setting? setting visibilities))))
            (map (fn [[setting-name]]
                   [setting-name (get setting-name)])))


### PR DESCRIPTION
User-local settings were previously excluded from the `user-readable-values-map` function which powers `/api/session/properties`, but there wasn't really a specific reason for this. I've changed it to include them, and only exclude database-local settings.

Requested by @npfitz in [this thread](https://metaboat.slack.com/archives/C056QEW4KNF/p1686242269819509)