### PR TITLE
Hide cards in email/slack subscriptions when empty setting

### DIFF
--- a/src/metabase/pulse.clj
+++ b/src/metabase/pulse.clj
@@ -73,10 +73,12 @@
                                     (qp/process-query-and-save-with-max-results-constraints!
                                      (assoc query :async? false)
                                      info)))]
-      {:card     card
-       :dashcard dashcard
-       :result   result
-       :type     :card})
+      (if (and (get-in dashcard [:visualization_settings :card.hide_empty]) (empty? (get-in result [:data :rows])))
+        nil
+        {:card     card
+         :dashcard dashcard
+         :result   result
+         :type     :card}))
     (catch Throwable e
       (log/warn e (trs "Error running query for Card {0}" card-or-id)))))
 

--- a/src/metabase/pulse.clj
+++ b/src/metabase/pulse.clj
@@ -39,6 +39,17 @@
 
 ;;; ------------------------------------------------- PULSE SENDING --------------------------------------------------
 
+(defn- is-card-empty?
+  "Check if the card is empty"
+  [card]
+  (if-let [result (:result card)]
+    (or (zero? (-> result :row_count))
+        ;; Many aggregations result in [[nil]] if there are no rows to aggregate after filters
+        (= [[nil]]
+           (-> result :data :rows)))
+    ;; Text cards have no result; treat as empty
+    true))
+
 (defn- merge-default-values
   "For the specific case of Dashboard Subscriptions we should use `:default` parameter values as the actual `:value` for
   the parameter if none is specified. Normally the FE client will take `:default` and pass it in as `:value` if it
@@ -73,8 +84,7 @@
                                     (qp/process-query-and-save-with-max-results-constraints!
                                      (assoc query :async? false)
                                      info)))]
-      (if (and (get-in dashcard [:visualization_settings :card.hide_empty]) (empty? (get-in result [:data :rows])))
-        nil
+      (when-not (and (get-in dashcard [:visualization_settings :card.hide_empty]) (is-card-empty? result))
         {:card     card
          :dashcard dashcard
          :result   result
@@ -334,17 +344,6 @@
                                          (assoc :image_url image-url)))))))
              []
              attachments))))
-
-(defn- is-card-empty?
-  "Check if the card is empty"
-  [card]
-  (if-let [result (:result card)]
-    (or (zero? (-> result :row_count))
-        ;; Many aggregations result in [[nil]] if there are no rows to aggregate after filters
-        (= [[nil]]
-           (-> result :data :rows)))
-    ;; Text cards have no result; treat as empty
-    true))
 
 (defn- are-all-parts-empty?
   "Do none of the cards have any results?"

--- a/test/metabase/dashboard_subscription_test.clj
+++ b/test/metabase/dashboard_subscription_test.clj
@@ -236,6 +236,15 @@
                        :result   (s/pred map?)
                        :type     (s/eq :card)}]
                      result)))))
+  (testing "hides empty card when card.hide_empty is true"
+    (mt/with-temp* [Card          [{card-id-1 :id}]
+                    Card          [{card-id-2 :id}]
+                    Dashboard     [{dashboard-id :id, :as dashboard} {:name "Birdfeed Usage"}]
+                    DashboardCard [_ {:dashboard_id dashboard-id :card_id card-id-1}]
+                    DashboardCard [_ {:dashboard_id dashboard-id :card_id card-id-2 :visualization_settings {:card.hide_empty true}}]
+                    User [{user-id :id}]]
+      (let [result (@#'metabase.pulse/execute-dashboard {:creator_id user-id} dashboard)]
+        (is (= (count result) 1)))))
   (testing "dashboard cards are ordered correctly -- by rows, and then by columns (#17419)"
     (mt/with-temp* [Card          [{card-id-1 :id}]
                     Card          [{card-id-2 :id}]


### PR DESCRIPTION
Related to https://github.com/metabase/metabase/issues/29175

### Description

If the setting is set and the card is empty, return no card.
