### PR TITLE
Ensure download perms are properly enforced on dashcards

### DIFF
--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -219,16 +219,16 @@
       ;; have a hydration key and an id. moderation_reviews currently aren't batch hydrated but i'm worried they
       ;; cannot be in this situation
       (t2/hydrate [:ordered_cards
-                [:card [:moderation_reviews :moderator_details]]
-                :series
-                :dashcard/action
-                :dashcard/linkcard-info]
-               :ordered_tabs
-               :collection_authority_level
-               :can_write
-               :param_fields
-               :param_values
-               :collection)
+                   [:card [:moderation_reviews :moderator_details]]
+                   :series
+                   :dashcard/action
+                   :dashcard/linkcard-info]
+                  :ordered_tabs
+                  :collection_authority_level
+                  :can_write
+                  :param_fields
+                  :param_values
+                  :collection)
       collection.root/hydrate-root-collection
       api/read-check
       api/check-not-archived
@@ -1013,6 +1013,7 @@
               :dashcard-id   dashcard-id
               :export-format export-format
               :parameters    (json/parse-string parameters keyword)
+              :context       (api.dataset/export-format->context export-format)
               :constraints   nil
               ;; TODO -- passing this `:middleware` map is a little repetitive, need to think of a way to not have to
               ;; specify this all over the codebase any time we want to do a query with an export format. Maybe this

--- a/test/metabase/query_processor/streaming_test.clj
+++ b/test/metabase/query_processor/streaming_test.clj
@@ -262,7 +262,7 @@
 
                   :card
                   (let [results (mt/user-http-request user :post 200
-                                                      (format "card/%d/query/%s" (u/the-id dashboard) (name export-format))
+                                                      (format "card/%d/query/%s" (u/the-id card) (name export-format))
                                                       {:request-options {:as (if (= export-format :xlsx) :byte-array :string)}})]
                     ((-> assertions export-format) results))
 

--- a/test/metabase/query_processor/streaming_test.clj
+++ b/test/metabase/query_processor/streaming_test.clj
@@ -6,7 +6,7 @@
    [clojure.test :refer :all]
    [medley.core :as m]
    [metabase.api.embed-test :as embed-test]
-   [metabase.models.card :as card :refer [Card]]
+   [metabase.models :refer [Card Dashboard DashboardCard]]
    [metabase.query-processor :as qp]
    [metabase.query-processor.context :as qp.context]
    [metabase.query-processor.streaming :as qp.streaming]
@@ -243,11 +243,13 @@
       (mt/with-temporary-setting-values [enable-public-sharing true
                                          enable-embedding      true]
         (embed-test/with-new-secret-key
-          (t2.with-temp/with-temp [Card card (if viz-settings
-                                               (assoc card-defaults :visualization_settings viz-settings)
-                                               card-defaults)]
+          (t2.with-temp/with-temp [Card          card      (if viz-settings
+                                                             (assoc card-defaults :visualization_settings viz-settings)
+                                                             card-defaults)
+                                   Dashboard     dashboard {:name "Test Dashboard"}
+                                   DashboardCard dashcard  {:card_id (u/the-id card) :dashboard_id (u/the-id dashboard)}]
             (doseq [export-format (keys assertions)
-                    endpoint      (or endpoints [:dataset :card :public :embed])]
+                    endpoint      (or endpoints [:dataset :card :dashboard :public :embed])]
               (testing endpoint
                 (case endpoint
                   :dataset
@@ -260,7 +262,17 @@
 
                   :card
                   (let [results (mt/user-http-request user :post 200
-                                                      (format "card/%d/query/%s" (:id card) (name export-format))
+                                                      (format "card/%d/query/%s" (u/the-id dashboard) (name export-format))
+                                                      {:request-options {:as (if (= export-format :xlsx) :byte-array :string)}})]
+                    ((-> assertions export-format) results))
+
+                  :dashboard
+                  (let [results (mt/user-http-request user :post 200
+                                                      (format "dashboard/%d/dashcard/%d/card/%d/query/%s"
+                                                              (u/the-id dashboard)
+                                                              (u/the-id dashcard)
+                                                              (u/the-id card)
+                                                              (name export-format))
                                                       {:request-options {:as (if (= export-format :xlsx) :byte-array :string)}})]
                     ((-> assertions export-format) results))
 


### PR DESCRIPTION
Resolves https://github.com/metabase/metabase/issues/31393

The `:context` for downloads going through the `/api/dashboard` export endpoint was not being properly set, so the QP middleware was not detecting these queries as export queries but rather as normal ones. I've fixed this, and added this endpoint to the export testing infra so that it's included in all existing export tests.