### PR TITLE
fix frontend dev for safari

### DIFF
--- a/src/metabase/server/middleware/security.clj
+++ b/src/metabase/server/middleware/security.clj
@@ -60,7 +60,7 @@
                                      "https://www.google-analytics.com")
                                    ;; for webpack hot reloading
                                    (when config/is-dev?
-                                     "*:8080")
+                                     "http://localhost:8080")
                                    ;; for react dev tools to work in Firefox until resolution of
                                    ;; https://github.com/facebook/react/issues/17997
                                    (when config/is-dev?

--- a/src/metabase/util.cljc
+++ b/src/metabase/util.cljc
@@ -706,7 +706,7 @@
       [;; strip out any current symbols
        [#"[^\d,.-]+"          ""]
        ;; now strip out any thousands separators
-       [#"(?<=\d)[,.](\d{3})" "$1"]
+       [#"[,.](\d{3})" "$1"]
        ;; now replace a comma decimal seperator with a period
        [#","                  "."]
        ;; move minus sign at end to front

--- a/src/metabase/util.cljc
+++ b/src/metabase/util.cljc
@@ -706,7 +706,7 @@
       [;; strip out any current symbols
        [#"[^\d,.-]+"          ""]
        ;; now strip out any thousands separators
-       [#"[,.](\d{3})" "$1"]
+       [#"(?<=\d)[,.](\d{3})" "$1"]
        ;; now replace a comma decimal seperator with a period
        [#","                  "."]
        ;; move minus sign at end to front


### PR DESCRIPTION
## Description

Content Security Policy for `script-src` is `*:8080`, causing the errors below when loading http://localhost:3000 in Safari.  Maybe safari doesn’t like asterisks in the policy pattern anymore?  Setting it to `http://localhost:8080` made the errors go away.

    ```
    [Error] Refused to load http://localhost:8080/app/dist/runtime.hot.bundle.js?082aa3024750fd9ba8c7 because it does not appear in the script-src directive of the Content Security Policy.
    [Error] Refused to load http://localhost:8080/app/dist/vendor.hot.bundle.js?13591091791f90b83abf because it does not appear in the script-src directive of the Content Security Policy.
    [Error] Refused to load http://localhost:8080/app/dist/styles.hot.bundle.js?5c4237d32fedd3e1e105 because it does not appear in the script-src directive of the Content Security Policy.
    [Error] Refused to load http://localhost:8080/app/dist/app-main.hot.bundle.js?165fb99b5e07640afb2a because it does not appear in the script-src directive of the Content Security Policy.
    ```

## How to verify

Make sure http://localhost:3000 loads in Safari.
