### PR TITLE
Move registration of email metrics into metabase.analytics.prometheus

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -552,6 +552,7 @@
    metabase.db.schema-migrations-test.impl/test-migrations                                                                   hooks.metabase.db.schema-migrations-test.impl/test-migrations
    metabase.dashboard-subscription-test/with-link-card-fixture-for-dashboard                                                 hooks.common/let-second
    metabase.driver.bigquery-cloud-sdk-test/calculate-bird-scarcity                                                           hooks.metabase.query-processor-test.expressions-test/calculate-bird-scarcity
+   metabase.email-test/with-prometheus-registry                                                                              hooks.common/with-one-binding
    metabase.mbql.schema.macros/defclause                                                                                     hooks.metabase.mbql.schemas.macros/defclause
    metabase.models.collection-test/with-collection-hierarchy                                                                 hooks.common/let-one-with-optional-value
    metabase.models.collection-test/with-personal-and-impersonal-collections                                                  hooks.common/with-two-bindings

--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -552,7 +552,6 @@
    metabase.db.schema-migrations-test.impl/test-migrations                                                                   hooks.metabase.db.schema-migrations-test.impl/test-migrations
    metabase.dashboard-subscription-test/with-link-card-fixture-for-dashboard                                                 hooks.common/let-second
    metabase.driver.bigquery-cloud-sdk-test/calculate-bird-scarcity                                                           hooks.metabase.query-processor-test.expressions-test/calculate-bird-scarcity
-   metabase.email-test/with-prometheus-registry                                                                              hooks.common/with-one-binding
    metabase.mbql.schema.macros/defclause                                                                                     hooks.metabase.mbql.schemas.macros/defclause
    metabase.models.collection-test/with-collection-hierarchy                                                                 hooks.common/let-one-with-optional-value
    metabase.models.collection-test/with-personal-and-impersonal-collections                                                  hooks.common/with-two-bindings

--- a/src/metabase/analytics/prometheus.clj
+++ b/src/metabase/analytics/prometheus.clj
@@ -9,6 +9,7 @@
    [iapetos.collector :as collector]
    [iapetos.collector.ring :as collector.ring]
    [iapetos.core :as prometheus]
+   [metabase.email :as email]
    [metabase.models.setting :as setting :refer [defsetting]]
    [metabase.server :as server]
    [metabase.troubleshooting :as troubleshooting]
@@ -220,6 +221,7 @@
       (locking #'system
         (when-not system
           (let [sys (make-prometheus-system port "metabase-registry")]
+            (email/setup-metrics! (.-registry ^PrometheusSystem sys))
             (alter-var-root #'system (constantly sys))))))))
 
 (defn shutdown!
@@ -229,6 +231,7 @@
     (locking #'system
       (when system
         (try (stop-web-server system)
+             (email/shutdown-metrics!)
              (alter-var-root #'system (constantly nil))
              (log/info (trs "Prometheus web-server shut down"))
              (catch Exception e

--- a/src/metabase/email.clj
+++ b/src/metabase/email.clj
@@ -1,6 +1,6 @@
 (ns metabase.email
   (:require
-   [iapetos.core :as prometheus]
+   [metabase.analytics.prometheus :as prometheus]
    [metabase.models.setting :as setting :refer [defsetting]]
    [metabase.util :as u]
    [metabase.util.i18n :refer [deferred-tru trs tru]]
@@ -10,7 +10,6 @@
    [postal.support :refer [make-props]]
    [schema.core :as s])
   (:import
-   (iapetos.registry IapetosRegistry)
    (javax.mail Session)))
 
 (set! *warn-on-reflection* true)
@@ -72,26 +71,6 @@
              (when (some? new-value)
                (assert (#{:tls :ssl :none :starttls} (keyword new-value))))
              (setting/set-value-of-type! :keyword :email-smtp-security new-value)))
-
-(defonce ^:private ^{:doc "Prometheus registry for email-related metrics collectors."} ^IapetosRegistry registry nil)
-
-(defn setup-metrics!
-  "Register metrics collectors for the email subsystem."
-  [global-registry]
-  (alter-var-root #'registry (constantly
-                               (-> global-registry
-                                   (prometheus/subsystem "email")
-                                   (prometheus/register
-                                     (prometheus/counter :metabase/messages
-                                                         {:description (tru "Number of emails sent.")})
-                                     (prometheus/counter :metabase/message-errors
-                                                         {:description (tru "Number of errors when sending emails.")}))))))
-
-(defn shutdown-metrics!
-  "Clear metrics collectors of the email subsystem."
-  []
-  (prometheus/clear registry)
-  (alter-var-root #'registry (constantly nil)))
 
 ;; ## PUBLIC INTERFACE
 
@@ -162,10 +141,10 @@
                   (when-let [reply-to (email-reply-to)]
                     {:reply-to reply-to})))
     (catch Throwable e
-      (some-> registry :metabase/message-errors prometheus/inc)
+      (prometheus/inc :metabase-email-message-errors)
       (throw e))
     (finally
-      (some-> registry :metabase/messages prometheus/inc))))
+      (prometheus/inc :metabase-email-messages))))
 
 (def ^:private SMTPStatus
   "Schema for the response returned by various functions in [[metabase.email]]. Response will be a map with the key

--- a/test/metabase/analytics/prometheus_test.clj
+++ b/test/metabase/analytics/prometheus_test.clj
@@ -152,3 +152,15 @@
                                    (metric-lines port))]
         (is (seq (set/intersection expected-lines actual-lines))
             "Registry does not have c3p0 metrics in it")))))
+
+(deftest inc-server-test
+  (testing "inc has no effect if system is not setup"
+    (is (not (thrown? (prometheus/inc :metabase-email-messages)))))
+  (testing "inc has no effect when called with unknown metric"
+    (with-prometheus-system [_ system]
+      (is (not (thrown? (prometheus/inc :unknown-metric))))
+      (is (== 0 (.getSampleValue (.-registry system) "unknown_metric_total")))))
+  (testing "inc is recorded for known metrics"
+    (with-prometheus-system [_ system]
+      (is (not (thrown? (prometheus/inc :metabase-email-messages))))
+      (is (< 0 (.getSampleValue (.-registry system) "metabase_email_messages_total"))))))

--- a/test/metabase/email_test.clj
+++ b/test/metabase/email_test.clj
@@ -3,16 +3,14 @@
   (:require
    [clojure.java.io :as io]
    [clojure.test :refer :all]
-   [iapetos.core :as prometheus]
-   [iapetos.registry :as registry]
    [medley.core :as m]
+   [metabase.analytics.prometheus :as prometheus]
    [metabase.email :as email]
    [metabase.test.data.users :as test.users]
    [metabase.test.util :as tu]
    [metabase.util :refer [prog1]]
    [postal.message :as message])
   (:import
-   (io.prometheus.client CollectorRegistry)
    (java.io File)
    (javax.activation MimeType)))
 
@@ -89,15 +87,6 @@
   [& body]
   {:style/indent 0}
   `(do-with-fake-inbox (fn [] ~@body)))
-
-(defmacro with-prometheus-registry
-  "Run tests with a new Prometheus collector registry bound as the `email/registry` global
-  and provides raw Prometheus `CollectorRegistry` as binding symbol in [registry]."
-  [[registry] & body]
-  `(do (email/setup-metrics! (prometheus/collector-registry (name (gensym "test-registry"))))
-       (let [~registry ^CollectorRegistry (registry/raw (deref #'email/registry))]
-         (try ~@body
-              (finally (email/shutdown-metrics!))))))
 
 (defn- create-email-body->regex-fn
   "Returns a function expecting the email body structure. It will apply the regexes in `regex-seq` over the body and
@@ -250,23 +239,27 @@
               :message      "101. Metabase will make you a better person")
              (@inbox "test@test.com")))))
     (testing "metrics collection"
-      (with-prometheus-registry [registry]
-        (with-fake-inbox
-          (email/send-message!
-           :subject      "101 Reasons to use Metabase"
-           :recipients   ["test@test.com"]
-           :message-type :html
-           :message      "101. Metabase will make you a better person"))
-        (is (< 0 (.getSampleValue registry "metabase_email_messages_total")))))
+      (let [calls (atom nil)]
+        (with-redefs [prometheus/inc #(swap! calls conj %)]
+          (with-fake-inbox
+            (email/send-message!
+             :subject      "101 Reasons to use Metabase"
+             :recipients   ["test@test.com"]
+             :message-type :html
+             :message      "101. Metabase will make you a better person")))
+        (is (< 0 (count (filter :metabase-email-messages @calls))))
+        (is (= 0 (count (filter :metabase-email-message-errors @calls))))))
     (testing "error metrics collection"
-      (with-prometheus-registry [registry]
-        (with-redefs [email/send-email! (fn [_ _] (throw (Exception. "test-exception")))]
+      (let [calls (atom nil)]
+        (with-redefs [prometheus/inc #(swap! calls conj %)
+                      email/send-email! (fn [_ _] (throw (Exception. "test-exception")))]
           (email/send-message!
             :subject      "101 Reasons to use Metabase"
             :recipients   ["test@test.com"]
             :message-type :html
             :message      "101. Metabase will make you a better person"))
-        (is (< 0 (.getSampleValue registry "metabase_email_message_errors_total")))))
+        (is (= 0 (count (filter :metabase-email-messages @calls))))
+        (is (< 0 (count (filter :metabase-email-message-errors @calls))))))
     (testing "basic sending without email-from-name"
       (tu/with-temporary-setting-values [email-from-name nil]
         (is (=


### PR DESCRIPTION
Alternative to https://github.com/metabase/metabase/pull/31333.

This approach suffers from dependency cycles:
* metabase.analytics.prometheus -> metabase.troubleshooting -> metabase.analytics.stats -> metabase.integrations.slack -> metabase.email.messages -> metabase.email -> metabase.analytics.prometheus
* metabase.analytics.prometheus -> metabase.troubleshooting -> metabase.analytics.stats -> metabase.email -> metabase.analytics.prometheus
* metabase.analytics.prometheus -> metabase.troubleshooting -> metabase.analytics.stats -> metabase.models -> metabase.models.login-history -> metabase.email.messages -> metabase.email -> metabase.analytics.prometheus
