### PR TITLE
Update mapping modal state after inline change of the action

### DIFF
--- a/e2e/test/scenarios/dashboard/actions-on-dashboards.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/actions-on-dashboards.cy.spec.js
@@ -37,7 +37,6 @@ const MODEL_NAME = "Test Action Model";
           "getCardAssociations",
         );
         cy.intercept("GET", "/api/action").as("getActions");
-        cy.intercept("PUT", "/api/action/*").as("updateAction");
         cy.intercept("GET", "/api/action?model-id=*").as("getModelActions");
 
         cy.intercept(
@@ -313,106 +312,6 @@ const MODEL_NAME = "Test Action Model";
           );
         });
       });
-
-      // no need to run it for every db
-      if (dialect === "postgres") {
-        describe("Inline action edit", () => {
-          beforeEach(() => {
-            resetTestTable({ type: dialect, table: TEST_TABLE });
-            restore(`${dialect}-writable`);
-            cy.signInAsAdmin();
-            resyncDatabase({ dbId: WRITABLE_DB_ID, tableName: TEST_TABLE });
-            createModelFromTableName({
-              tableName: TEST_TABLE,
-              modelName: MODEL_NAME,
-            });
-          });
-
-          it("should reflect to updated action on mapping form", () => {
-            const ACTION_NAME = "Update Score";
-
-            cy.get("@modelId").then(id => {
-              cy.visit(`/model/${id}/detail`);
-              cy.wait([
-                "@getModel",
-                "@getModelActions",
-                "@getCardAssociations",
-              ]);
-            });
-
-            cy.findByRole("tab", { name: "Actions" }).click();
-
-            cy.findByTestId("model-actions-header")
-              .findByText("New action")
-              .click();
-
-            cy.findByRole("dialog").within(() => {
-              fillActionQuery(
-                `UPDATE ${TEST_TABLE} SET score = {{ new_score }} WHERE id = {{ id }}`,
-              );
-            });
-
-            cy.findByRole("dialog").within(() => {
-              cy.findByText("Save").click();
-            });
-
-            cy.findByPlaceholderText("My new fantastic action").type(
-              ACTION_NAME,
-            );
-            cy.findByTestId("create-action-form").button("Create").click();
-
-            cy.createDashboard({ name: "action packed dashboard" }).then(
-              ({ body: { id: dashboardId } }) => {
-                visitDashboard(dashboardId);
-              },
-            );
-
-            editDashboard();
-
-            setFilter("ID");
-            sidebar().within(() => {
-              cy.button("Done").click();
-            });
-
-            cy.button("Add action").click();
-            cy.get("aside").within(() => {
-              cy.findByPlaceholderText("Button text").clear().type(ACTION_NAME);
-              cy.button("Pick an action").click();
-            });
-
-            cy.wait("@getActions");
-
-            cy.findByRole("dialog").within(() => {
-              cy.findByText(MODEL_NAME).click();
-              cy.findByText(ACTION_NAME).click();
-
-              cy.findByText("New Score: required").should("not.exist");
-              cy.findByRole("button", { name: "Done" }).should("be.enabled");
-              cy.icon("pencil").click();
-            });
-
-            cy.wait("@getModel");
-
-            cy.findAllByRole("dialog")
-              .filter(":visible")
-              .within(() => {
-                cy.findByLabelText("New Score")
-                  .closest("[data-testid=preview-container]")
-                  .findByText("Show field")
-                  .click();
-
-                cy.findByRole("button", { name: "Update" }).click();
-              });
-
-            cy.wait("@updateAction");
-
-            cy.findByRole("dialog").within(() => {
-              cy.findByText("New Score: required");
-              cy.findByRole("button", { name: "Done" }).should("be.disabled");
-            });
-          });
-        });
-      }
 
       describe(`Actions Data Types`, () => {
         beforeEach(() => {
@@ -751,6 +650,113 @@ const MODEL_NAME = "Test Action Model";
     },
   );
 });
+
+describe(
+  "Action Parameters Mapping",
+  { tags: ["@external", "@actions"] },
+  () => {
+    beforeEach(() => {
+      cy.intercept("GET", /\/api\/card\/\d+/).as("getModel");
+      cy.intercept("GET", "/api/card?f=using_model&model_id=**").as(
+        "getCardAssociations",
+      );
+      cy.intercept("GET", "/api/action").as("getActions");
+      cy.intercept("PUT", "/api/action/*").as("updateAction");
+      cy.intercept("GET", "/api/action?model-id=*").as("getModelActions");
+    });
+
+    describe("Inline action edit", () => {
+      beforeEach(() => {
+        resetTestTable({ type: "postgres", table: TEST_TABLE });
+        restore("postgres-writable");
+        cy.signInAsAdmin();
+        resyncDatabase({ dbId: WRITABLE_DB_ID, tableName: TEST_TABLE });
+        createModelFromTableName({
+          tableName: TEST_TABLE,
+          modelName: MODEL_NAME,
+        });
+      });
+
+      it("should reflect to updated action on mapping form", () => {
+        const ACTION_NAME = "Update Score";
+
+        cy.get("@modelId").then(id => {
+          cy.visit(`/model/${id}/detail`);
+          cy.wait(["@getModel", "@getModelActions", "@getCardAssociations"]);
+        });
+
+        cy.findByRole("tab", { name: "Actions" }).click();
+
+        cy.findByTestId("model-actions-header")
+          .findByText("New action")
+          .click();
+
+        cy.findByRole("dialog").within(() => {
+          fillActionQuery(
+            `UPDATE ${TEST_TABLE} SET score = {{ new_score }} WHERE id = {{ id }}`,
+          );
+        });
+
+        cy.findByRole("dialog").within(() => {
+          cy.findByText("Save").click();
+        });
+
+        cy.findByPlaceholderText("My new fantastic action").type(ACTION_NAME);
+        cy.findByTestId("create-action-form").button("Create").click();
+
+        cy.createDashboard({ name: "action packed dashboard" }).then(
+          ({ body: { id: dashboardId } }) => {
+            visitDashboard(dashboardId);
+          },
+        );
+
+        editDashboard();
+
+        setFilter("ID");
+        sidebar().within(() => {
+          cy.button("Done").click();
+        });
+
+        cy.button("Add action").click();
+        cy.get("aside").within(() => {
+          cy.findByPlaceholderText("Button text").clear().type(ACTION_NAME);
+          cy.button("Pick an action").click();
+        });
+
+        cy.wait("@getActions");
+
+        cy.findByRole("dialog").within(() => {
+          cy.findByText(MODEL_NAME).click();
+          cy.findByText(ACTION_NAME).click();
+
+          cy.findByText("New Score: required").should("not.exist");
+          cy.findByRole("button", { name: "Done" }).should("be.enabled");
+          cy.icon("pencil").click();
+        });
+
+        cy.wait("@getModel");
+
+        cy.findAllByRole("dialog")
+          .filter(":visible")
+          .within(() => {
+            cy.findByLabelText("New Score")
+              .closest("[data-testid=preview-container]")
+              .findByText("Show field")
+              .click();
+
+            cy.findByRole("button", { name: "Update" }).click();
+          });
+
+        cy.wait("@updateAction");
+
+        cy.findByRole("dialog").within(() => {
+          cy.findByText("New Score: required");
+          cy.findByRole("button", { name: "Done" }).should("be.disabled");
+        });
+      });
+    });
+  },
+);
 
 function createDashboardWithActionButton({
   actionName,

--- a/e2e/test/scenarios/dashboard/actions-on-dashboards.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/actions-on-dashboards.cy.spec.js
@@ -37,6 +37,7 @@ const MODEL_NAME = "Test Action Model";
           "getCardAssociations",
         );
         cy.intercept("GET", "/api/action").as("getActions");
+        cy.intercept("PUT", "/api/action/*").as("updateAction");
         cy.intercept("GET", "/api/action?model-id=*").as("getModelActions");
 
         cy.intercept(
@@ -312,6 +313,106 @@ const MODEL_NAME = "Test Action Model";
           );
         });
       });
+
+      // no need to run it for every db
+      if (dialect === "postgres") {
+        describe("Inline action edit", () => {
+          beforeEach(() => {
+            resetTestTable({ type: dialect, table: TEST_TABLE });
+            restore(`${dialect}-writable`);
+            cy.signInAsAdmin();
+            resyncDatabase({ dbId: WRITABLE_DB_ID, tableName: TEST_TABLE });
+            createModelFromTableName({
+              tableName: TEST_TABLE,
+              modelName: MODEL_NAME,
+            });
+          });
+
+          it("should reflect to updated action on mapping form", () => {
+            const ACTION_NAME = "Update Score";
+
+            cy.get("@modelId").then(id => {
+              cy.visit(`/model/${id}/detail`);
+              cy.wait([
+                "@getModel",
+                "@getModelActions",
+                "@getCardAssociations",
+              ]);
+            });
+
+            cy.findByRole("tab", { name: "Actions" }).click();
+
+            cy.findByTestId("model-actions-header")
+              .findByText("New action")
+              .click();
+
+            cy.findByRole("dialog").within(() => {
+              fillActionQuery(
+                `UPDATE ${TEST_TABLE} SET score = {{ new_score }} WHERE id = {{ id }}`,
+              );
+            });
+
+            cy.findByRole("dialog").within(() => {
+              cy.findByText("Save").click();
+            });
+
+            cy.findByPlaceholderText("My new fantastic action").type(
+              ACTION_NAME,
+            );
+            cy.findByTestId("create-action-form").button("Create").click();
+
+            cy.createDashboard({ name: "action packed dashboard" }).then(
+              ({ body: { id: dashboardId } }) => {
+                visitDashboard(dashboardId);
+              },
+            );
+
+            editDashboard();
+
+            setFilter("ID");
+            sidebar().within(() => {
+              cy.button("Done").click();
+            });
+
+            cy.button("Add action").click();
+            cy.get("aside").within(() => {
+              cy.findByPlaceholderText("Button text").clear().type(ACTION_NAME);
+              cy.button("Pick an action").click();
+            });
+
+            cy.wait("@getActions");
+
+            cy.findByRole("dialog").within(() => {
+              cy.findByText(MODEL_NAME).click();
+              cy.findByText(ACTION_NAME).click();
+
+              cy.findByText("New Score: required").should("not.exist");
+              cy.findByRole("button", { name: "Done" }).should("be.enabled");
+              cy.icon("pencil").click();
+            });
+
+            cy.wait("@getModel");
+
+            cy.findAllByRole("dialog")
+              .filter(":visible")
+              .within(() => {
+                cy.findByLabelText("New Score")
+                  .closest("[data-testid=preview-container]")
+                  .findByText("Show field")
+                  .click();
+
+                cy.findByRole("button", { name: "Update" }).click();
+              });
+
+            cy.wait("@updateAction");
+
+            cy.findByRole("dialog").within(() => {
+              cy.findByText("New Score: required");
+              cy.findByRole("button", { name: "Done" }).should("be.disabled");
+            });
+          });
+        });
+      }
 
       describe(`Actions Data Types`, () => {
         beforeEach(() => {

--- a/frontend/src/metabase/actions/components/ActionViz/ActionDashcardSettings.tsx
+++ b/frontend/src/metabase/actions/components/ActionViz/ActionDashcardSettings.tsx
@@ -7,7 +7,7 @@ import EmptyState from "metabase/components/EmptyState";
 
 import MetabaseSettings from "metabase/lib/settings";
 
-import { ConnectedActionPicker } from "metabase/actions/containers/ActionPicker/ActionPicker";
+import { ConnectedActionPicker } from "metabase/actions/containers/ActionPicker";
 import { setActionForDashcard } from "metabase/dashboard/actions";
 
 import type {

--- a/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/FormFieldEditor/FormFieldEditor.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/FormFieldEditor/FormFieldEditor.tsx
@@ -128,7 +128,7 @@ function FormFieldEditor({
           <Subtitle>{t`Appearance`}</Subtitle>
         </Column>
       </EditorContainer>
-      <PreviewContainer>
+      <PreviewContainer data-testid="preview-container">
         <Column />
         <Column full>
           <InputContainer>

--- a/frontend/src/metabase/actions/containers/ActionPicker/ActionPicker.tsx
+++ b/frontend/src/metabase/actions/containers/ActionPicker/ActionPicker.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from "react";
+import { useState, useMemo, MouseEvent } from "react";
 import { t } from "ttag";
 import _ from "underscore";
 
@@ -24,8 +24,7 @@ import {
   NewActionButton,
 } from "./ActionPicker.styled";
 
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export default function ActionPicker({
+export function ActionPicker({
   models,
   actions,
   onClick,
@@ -93,6 +92,10 @@ function ModelActionPicker({
 
   const hasCurrentAction = currentAction?.model_id === model.id;
 
+  const handleModalSubmit = (updatedAction: WritebackAction) => {
+    onClick(updatedAction);
+  };
+
   return (
     <>
       <ModelCollapseSection
@@ -114,7 +117,10 @@ function ModelActionPicker({
                   <EditButton
                     icon="pencil"
                     onlyIcon
-                    onClick={() => {
+                    onClick={(event: MouseEvent<HTMLButtonElement>) => {
+                      // we have a click listener on the parent
+                      event.stopPropagation();
+
                       setEditingActionId(action.id);
                       toggleIsActionCreatorVisible();
                     }}
@@ -142,6 +148,7 @@ function ModelActionPicker({
             databaseId={model.database_id}
             actionId={editingActionId}
             onClose={closeModal}
+            onSubmit={handleModalSubmit}
           />
         </Modal>
       )}

--- a/frontend/src/metabase/actions/containers/ActionPicker/index.ts
+++ b/frontend/src/metabase/actions/containers/ActionPicker/index.ts
@@ -1,2 +1,1 @@
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export { default } from "./ActionPicker";
+export { ActionPicker, ConnectedActionPicker } from "./ActionPicker";


### PR DESCRIPTION
Epic: https://github.com/metabase/metabase/issues/30016

## Description
Update action parameters mapping form after inline change of the action

## Testing
- revert changes except e2e test, it should fail

### Before 
https://www.loom.com/share/e093661d289448c58d25170d47af2d15

### After
https://www.loom.com/share/004011781d82422fa04d5bceaff5482a