### PR TITLE
Add test for question title overflow

### DIFF
--- a/e2e/test/scenarios/question/saved.cy.spec.js
+++ b/e2e/test/scenarios/question/saved.cy.spec.js
@@ -250,4 +250,22 @@ describe("scenarios > question > saved", () => {
         assertColumnResized();
       });
   });
+
+  it("should always be possible to view the full text of the saved question", () => {
+    visitQuestion(1);
+    cy.findByTestId("saved-question-header-title").click();
+    cy.findByTestId("saved-question-header-title").clear();
+    cy.findByTestId("saved-question-header-title").type(
+      "Space, the final frontier. These are the voyages of the Starship Enterprise.",
+    );
+    cy.findByTestId("saved-question-header-title").blur();
+    cy.findByTestId("saved-question-header-title").should("be.visible");
+
+    cy.findByTestId("saved-question-header-title")
+      .should("be.visible")
+      .should($el => {
+        const heightDifference = $el[0].clientHeight - $el[0].scrollHeight;
+        expect(heightDifference).to.eq(0);
+      });
+  });
 });

--- a/e2e/test/scenarios/question/saved.cy.spec.js
+++ b/e2e/test/scenarios/question/saved.cy.spec.js
@@ -251,21 +251,20 @@ describe("scenarios > question > saved", () => {
       });
   });
 
-  it("should always be possible to view the full text of the saved question", () => {
+  it("should always be possible to view the full title text of the saved question", () => {
     visitQuestion(1);
-    cy.findByTestId("saved-question-header-title").click();
-    cy.findByTestId("saved-question-header-title").clear();
-    cy.findByTestId("saved-question-header-title").type(
+    const savedQuestionTitle = cy.findByTestId("saved-question-header-title");
+    savedQuestionTitle.clear();
+    savedQuestionTitle.type(
       "Space, the final frontier. These are the voyages of the Starship Enterprise.",
     );
-    cy.findByTestId("saved-question-header-title").blur();
-    cy.findByTestId("saved-question-header-title").should("be.visible");
+    savedQuestionTitle.blur();
 
-    cy.findByTestId("saved-question-header-title")
-      .should("be.visible")
-      .should($el => {
-        const heightDifference = $el[0].clientHeight - $el[0].scrollHeight;
-        expect(heightDifference).to.eq(0);
-      });
+    savedQuestionTitle.should("be.visible").should($el => {
+      // clientHeight: height of the textarea
+      // scrollHeight: height of the text content, including content not visible on the screen
+      const heightDifference = $el[0].clientHeight - $el[0].scrollHeight;
+      expect(heightDifference).to.eq(0);
+    });
   });
 });


### PR DESCRIPTION
### Description

Adds a test for #31421 by checking whether the text overflows outside the title text area in a question

### How to verify

1. Go to a question
2. Type a long name and click away
3. Make sure you can still see the whole question name

### Demo

https://github.com/metabase/metabase/assets/25306947/582f6e8a-275d-414f-8fb8-1ba33e4a1937


Video of the test failing with `withNormalizeCSS` and then passing without it

https://github.com/metabase/metabase/assets/25306947/cf9cab4b-2adb-4b34-bbd5-6d9cd71d4b9e



### Checklist

- [x] Tests have been added/updated to cover changes in this PR
