### PR TITLE
3/x Prevent rendering the database prompt banner when white labeling

### DIFF
--- a/e2e/test/scenarios/admin/databases/database-prompt-banner.cy.spec.js
+++ b/e2e/test/scenarios/admin/databases/database-prompt-banner.cy.spec.js
@@ -11,11 +11,12 @@ describe("banner", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();
-    cy.visit("/");
-    cy.findByRole("main").findByText("Loading...").should("not.exist");
   });
 
   it("should show a database prompt banner when logged in as an admin, an instance is on a paid plan, and only have a single sample dataset", () => {
+    cy.visit("/");
+    cy.findByRole("main").findByText("Loading...").should("not.exist");
+
     cy.findAllByRole("banner")
       .first()
       .within(() => {
@@ -37,6 +38,20 @@ describe("banner", () => {
       cy.findByLabelText("Database type").should("exist");
       cy.findByLabelText("Database name").should("exist");
     });
+  });
+
+  it("should not show a database prompt banner when logged in as an admin, an instance is on a paid plan, and only have a single sample dataset, but is white labeling", () => {
+    cy.request("PUT", "/api/setting/application-name", { value: "Acme Corp." });
+    cy.visit("/");
+    cy.findByRole("main").findByText("Loading...").should("not.exist");
+
+    cy.findAllByRole("banner")
+      .first()
+      .within(() => {
+        cy.findByText(
+          "Connect to your database to get the most from Metabase.",
+        ).should("not.exist");
+      });
   });
 });
 

--- a/enterprise/frontend/src/metabase-enterprise/settings/selectors.ts
+++ b/enterprise/frontend/src/metabase-enterprise/settings/selectors.ts
@@ -26,3 +26,7 @@ export const getHasCustomColors = (state: EnterpriseState) =>
 
 export const getLoadingMessage = (state: EnterpriseState) =>
   LOADING_MESSAGE_BY_SETTING[getSetting(state, "loading-message")];
+
+const DEFAULT_APPLICATION_NAME = "Metabase";
+export const getIsWhiteLabeling = (states: EnterpriseState) =>
+  getSetting(states, "application-name") !== DEFAULT_APPLICATION_NAME;

--- a/enterprise/frontend/src/metabase-enterprise/settings/selectors.ts
+++ b/enterprise/frontend/src/metabase-enterprise/settings/selectors.ts
@@ -1,15 +1,16 @@
 import { getSetting, getSettings } from "metabase/selectors/settings";
 import { LOADING_MESSAGE_BY_SETTING } from "../whitelabel/lib/loading-message";
+import type { EnterpriseSettings, EnterpriseState } from "./types";
 
 const DEFAULT_LOGO_URL = "app/assets/img/logo.svg";
 
-const hasCustomColors = settingValues => {
+const hasCustomColors = (settingValues: EnterpriseSettings) => {
   const applicationColors =
     settingValues["application-colors"] || settingValues.application_colors;
   return Object.keys(applicationColors || {}).length > 0;
 };
 
-const getCustomLogoUrl = settingValues => {
+const getCustomLogoUrl = (settingValues: EnterpriseSettings) => {
   return (
     settingValues["application-logo-url"] ||
     settingValues.application_logo_url ||
@@ -17,9 +18,11 @@ const getCustomLogoUrl = settingValues => {
   );
 };
 
-export const getLogoUrl = state => getCustomLogoUrl(getSettings(state));
+export const getLogoUrl = (state: EnterpriseState) =>
+  getCustomLogoUrl(getSettings(state));
 
-export const getHasCustomColors = state => hasCustomColors(getSettings(state));
+export const getHasCustomColors = (state: EnterpriseState) =>
+  hasCustomColors(getSettings(state));
 
-export const getLoadingMessage = state =>
+export const getLoadingMessage = (state: EnterpriseState) =>
   LOADING_MESSAGE_BY_SETTING[getSetting(state, "loading-message")];

--- a/enterprise/frontend/src/metabase-enterprise/settings/selectors.ts
+++ b/enterprise/frontend/src/metabase-enterprise/settings/selectors.ts
@@ -4,12 +4,6 @@ import type { EnterpriseSettings, EnterpriseState } from "./types";
 
 const DEFAULT_LOGO_URL = "app/assets/img/logo.svg";
 
-const hasCustomColors = (settingValues: EnterpriseSettings) => {
-  const applicationColors =
-    settingValues["application-colors"] || settingValues.application_colors;
-  return Object.keys(applicationColors || {}).length > 0;
-};
-
 const getCustomLogoUrl = (settingValues: EnterpriseSettings) => {
   return (
     settingValues["application-logo-url"] ||
@@ -20,9 +14,6 @@ const getCustomLogoUrl = (settingValues: EnterpriseSettings) => {
 
 export const getLogoUrl = (state: EnterpriseState) =>
   getCustomLogoUrl(getSettings(state));
-
-export const getHasCustomColors = (state: EnterpriseState) =>
-  hasCustomColors(getSettings(state));
 
 export const getLoadingMessage = (state: EnterpriseState) =>
   LOADING_MESSAGE_BY_SETTING[getSetting(state, "loading-message")];

--- a/enterprise/frontend/src/metabase-enterprise/settings/selectors.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/settings/selectors.unit.spec.ts
@@ -1,0 +1,112 @@
+import {
+  createMockSettingsState,
+  createMockState,
+} from "metabase-types/store/mocks";
+
+import { getHasCustomColors, getLoadingMessage, getLogoUrl } from "./selectors";
+
+describe("getHasCustomColors", () => {
+  it('should return `true` if "application-colors" has values', () => {
+    const states = createMockState({
+      settings: createMockSettingsState({
+        "application-colors": {
+          brand: "#123456",
+        },
+      }),
+    });
+
+    expect(getHasCustomColors(states)).toBe(true);
+  });
+
+  it('should return `false` if "application-colors" has no values', () => {
+    const states = createMockState({
+      settings: createMockSettingsState({
+        "application-colors": {},
+      }),
+    });
+
+    expect(getHasCustomColors(states)).toBe(false);
+  });
+
+  it('should return `false` if "application-colors" is not set', () => {
+    const states = createMockState({
+      settings: createMockSettingsState(),
+    });
+
+    expect(getHasCustomColors(states)).toBe(false);
+  });
+});
+
+describe("getLogoUrl", () => {
+  it('should return default logo url if "application-logo-url" is not set', () => {
+    const states = createMockState({
+      settings: createMockSettingsState(),
+    });
+
+    const expectedDefaultLogoUrl = "app/assets/img/logo.svg";
+
+    expect(getLogoUrl(states)).toBe(expectedDefaultLogoUrl);
+  });
+
+  it('should return default logo url if "application-logo-url" has no values', () => {
+    const states = createMockState({
+      settings: createMockSettingsState({
+        "application-logo-url": undefined,
+      }),
+    });
+
+    const expectedDefaultLogoUrl = "app/assets/img/logo.svg";
+
+    expect(getLogoUrl(states)).toBe(expectedDefaultLogoUrl);
+  });
+
+  it('should return custom logo url if "application-logo-url" is set', () => {
+    const customLogoDataUrl = "data:image/png;base64,aaaaaaaaaaaaaaaaaaaaaa";
+    const states = createMockState({
+      settings: createMockSettingsState({
+        "application-logo-url": customLogoDataUrl,
+      }),
+    });
+
+    expect(getLogoUrl(states)).toBe(customLogoDataUrl);
+  });
+});
+
+describe("getLoadingMessage", () => {
+  it('should show correct loading message when "loading-message" is set to "doing-science"', () => {
+    const states = createMockState({
+      settings: createMockSettingsState({
+        "loading-message": "doing-science",
+      }),
+    });
+
+    const expectedLoadingMessage = "Doing science...";
+
+    expect(getLoadingMessage(states)).toBe(expectedLoadingMessage);
+  });
+
+  it('should show correct loading message when "loading-message" is set to "running-query"', () => {
+    const states = createMockState({
+      settings: createMockSettingsState({
+        "loading-message": "loading-results",
+      }),
+    });
+
+    const expectedLoadingMessage = "Loading results...";
+    ("");
+
+    expect(getLoadingMessage(states)).toBe(expectedLoadingMessage);
+  });
+
+  it('should show correct loading message when "loading-message" is set to "loading-results"', () => {
+    const states = createMockState({
+      settings: createMockSettingsState({
+        "loading-message": "running-query",
+      }),
+    });
+
+    const expectedLoadingMessage = "Running query...";
+
+    expect(getLoadingMessage(states)).toBe(expectedLoadingMessage);
+  });
+});

--- a/enterprise/frontend/src/metabase-enterprise/settings/selectors.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/settings/selectors.unit.spec.ts
@@ -3,7 +3,12 @@ import {
   createMockState,
 } from "metabase-types/store/mocks";
 
-import { getHasCustomColors, getLoadingMessage, getLogoUrl } from "./selectors";
+import {
+  getHasCustomColors,
+  getIsWhiteLabeling,
+  getLoadingMessage,
+  getLogoUrl,
+} from "./selectors";
 
 describe("getHasCustomColors", () => {
   it('should return `true` if "application-colors" has values', () => {
@@ -108,5 +113,27 @@ describe("getLoadingMessage", () => {
     const expectedLoadingMessage = "Running query...";
 
     expect(getLoadingMessage(states)).toBe(expectedLoadingMessage);
+  });
+});
+
+describe("getIsWhiteLabeling", () => {
+  it('should return `false` if "application-name" is not changed', () => {
+    const states = createMockState({
+      settings: createMockSettingsState({
+        "application-name": "Metabase",
+      }),
+    });
+
+    expect(getIsWhiteLabeling(states)).toBe(false);
+  });
+
+  it('should return `true` if "application-name" is changed', () => {
+    const states = createMockState({
+      settings: createMockSettingsState({
+        "application-name": "Acme Corp.",
+      }),
+    });
+
+    expect(getIsWhiteLabeling(states)).toBe(true);
   });
 });

--- a/enterprise/frontend/src/metabase-enterprise/settings/selectors.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/settings/selectors.unit.spec.ts
@@ -3,44 +3,7 @@ import {
   createMockState,
 } from "metabase-types/store/mocks";
 
-import {
-  getHasCustomColors,
-  getIsWhiteLabeling,
-  getLoadingMessage,
-  getLogoUrl,
-} from "./selectors";
-
-describe("getHasCustomColors", () => {
-  it('should return `true` if "application-colors" has values', () => {
-    const states = createMockState({
-      settings: createMockSettingsState({
-        "application-colors": {
-          brand: "#123456",
-        },
-      }),
-    });
-
-    expect(getHasCustomColors(states)).toBe(true);
-  });
-
-  it('should return `false` if "application-colors" has no values', () => {
-    const states = createMockState({
-      settings: createMockSettingsState({
-        "application-colors": {},
-      }),
-    });
-
-    expect(getHasCustomColors(states)).toBe(false);
-  });
-
-  it('should return `false` if "application-colors" is not set', () => {
-    const states = createMockState({
-      settings: createMockSettingsState(),
-    });
-
-    expect(getHasCustomColors(states)).toBe(false);
-  });
-});
+import { getIsWhiteLabeling, getLoadingMessage, getLogoUrl } from "./selectors";
 
 describe("getLogoUrl", () => {
   it('should return default logo url if "application-logo-url" is not set', () => {

--- a/enterprise/frontend/src/metabase-enterprise/settings/types.ts
+++ b/enterprise/frontend/src/metabase-enterprise/settings/types.ts
@@ -1,0 +1,23 @@
+import { Settings } from "metabase-types/api";
+import { State } from "metabase-types/store";
+
+export interface EnterpriseState extends State {
+  settings: EnterpriseSettingsState;
+}
+
+interface EnterpriseSettingsState {
+  values: EnterpriseSettings;
+}
+
+export interface EnterpriseSettings extends Settings {
+  "application-colors"?: Record<string, string>;
+  "application-logo-url"?: string;
+  /**
+   * @deprecated
+   */
+  application_logo_url?: string;
+  /**
+   * @deprecated
+   */
+  application_colors?: string;
+}

--- a/enterprise/frontend/src/metabase-enterprise/settings/types.ts
+++ b/enterprise/frontend/src/metabase-enterprise/settings/types.ts
@@ -16,8 +16,4 @@ export interface EnterpriseSettings extends Settings {
    * @deprecated
    */
   application_logo_url?: string;
-  /**
-   * @deprecated
-   */
-  application_colors?: string;
 }

--- a/enterprise/frontend/src/metabase-enterprise/whitelabel/index.js
+++ b/enterprise/frontend/src/metabase-enterprise/whitelabel/index.js
@@ -10,6 +10,7 @@ import {
 import { hasPremiumFeature } from "metabase-enterprise/settings";
 import {
   getHasCustomColors,
+  getIsWhiteLabeling,
   getLoadingMessage,
 } from "metabase-enterprise/settings/selectors";
 import MetabaseSettings from "metabase/lib/settings";
@@ -112,3 +113,4 @@ if (hasPremiumFeature("whitelabel")) {
 // these selectors control whitelabeling UI
 PLUGIN_SELECTORS.getHasCustomColors = getHasCustomColors;
 PLUGIN_SELECTORS.getLoadingMessage = getLoadingMessage;
+PLUGIN_SELECTORS.getIsWhiteLabeling = getIsWhiteLabeling;

--- a/enterprise/frontend/src/metabase-enterprise/whitelabel/index.js
+++ b/enterprise/frontend/src/metabase-enterprise/whitelabel/index.js
@@ -9,7 +9,6 @@ import {
 
 import { hasPremiumFeature } from "metabase-enterprise/settings";
 import {
-  getHasCustomColors,
   getIsWhiteLabeling,
   getLoadingMessage,
 } from "metabase-enterprise/settings/selectors";
@@ -111,6 +110,5 @@ if (hasPremiumFeature("whitelabel")) {
 }
 
 // these selectors control whitelabeling UI
-PLUGIN_SELECTORS.getHasCustomColors = getHasCustomColors;
 PLUGIN_SELECTORS.getLoadingMessage = getLoadingMessage;
 PLUGIN_SELECTORS.getIsWhiteLabeling = getIsWhiteLabeling;

--- a/frontend/src/metabase-types/store/mocks/settings.ts
+++ b/frontend/src/metabase-types/store/mocks/settings.ts
@@ -1,9 +1,11 @@
 import type { Settings } from "metabase-types/api";
 import type { SettingsState } from "metabase-types/store";
+import type { EnterpriseSettings } from "metabase-enterprise/settings/types";
+
 import { createMockSettings } from "metabase-types/api/mocks";
 
 export const createMockSettingsState = (
-  opts?: Partial<Settings>,
+  opts?: Partial<Settings> | Partial<EnterpriseSettings>,
 ): SettingsState => ({
   values: createMockSettings(opts),
 });

--- a/frontend/src/metabase-types/store/mocks/state.ts
+++ b/frontend/src/metabase-types/store/mocks/state.ts
@@ -1,5 +1,6 @@
 import { State } from "metabase-types/store";
 import { createMockUser } from "metabase-types/api/mocks";
+import { EnterpriseState } from "metabase-enterprise/settings/types";
 import { createMockAdminState } from "./admin";
 import { createMockAppState } from "./app";
 import { createMockDashboardState } from "./dashboard";
@@ -12,7 +13,9 @@ import { createMockSettingsState } from "./settings";
 import { createMockSetupState } from "./setup";
 import { createMockUploadState } from "./upload";
 
-export const createMockState = (opts?: Partial<State>): State => ({
+export const createMockState = (
+  opts?: Partial<State> | Partial<EnterpriseState>,
+): State => ({
   admin: createMockAdminState(),
   app: createMockAppState(),
   currentUser: createMockUser(),

--- a/frontend/src/metabase/nav/components/DatabasePromptBanner/DatabasePromptBanner.tsx
+++ b/frontend/src/metabase/nav/components/DatabasePromptBanner/DatabasePromptBanner.tsx
@@ -7,6 +7,7 @@ import { useSelector } from "metabase/lib/redux";
 import { getUserIsAdmin } from "metabase/selectors/user";
 import { getIsPaidPlan } from "metabase/selectors/settings";
 import { trackDatabasePromptBannerClicked } from "metabase/nav/analytics";
+import { PLUGIN_SELECTORS } from "metabase/plugins";
 
 import {
   ConnectDatabaseButton,
@@ -28,8 +29,9 @@ export function DatabasePromptBanner({ location }: DatabasePromptBannerProps) {
   });
   const onlyHaveSampleDatabase =
     databases.length === 1 && databases[0].is_sample;
+  const isWhiteLabeling = useSelector(PLUGIN_SELECTORS.getIsWhiteLabeling);
   const shouldShowDatabasePromptBanner =
-    isAdmin && isPaidPlan && onlyHaveSampleDatabase;
+    isAdmin && isPaidPlan && onlyHaveSampleDatabase && !isWhiteLabeling;
 
   if (!shouldShowDatabasePromptBanner) {
     return null;

--- a/frontend/src/metabase/plugins/index.ts
+++ b/frontend/src/metabase/plugins/index.ts
@@ -88,7 +88,6 @@ export const PLUGIN_IS_PASSWORD_USER: ((user: User) => boolean)[] = [];
 
 // selectors that customize behavior between app versions
 export const PLUGIN_SELECTORS = {
-  getHasCustomColors: (_state: State) => false,
   canWhitelabel: (_state: State) => false,
   getLoadingMessage: (_state: State) => t`Doing science...`,
   getIsWhiteLabeling: (_state: State) => false,

--- a/frontend/src/metabase/plugins/index.ts
+++ b/frontend/src/metabase/plugins/index.ts
@@ -88,9 +88,10 @@ export const PLUGIN_IS_PASSWORD_USER: ((user: User) => boolean)[] = [];
 
 // selectors that customize behavior between app versions
 export const PLUGIN_SELECTORS = {
-  getHasCustomColors: (state: State) => false,
-  canWhitelabel: (state: State) => false,
-  getLoadingMessage: (state: State) => t`Doing science...`,
+  getHasCustomColors: (_state: State) => false,
+  canWhitelabel: (_state: State) => false,
+  getLoadingMessage: (_state: State) => t`Doing science...`,
+  getIsWhiteLabeling: (_state: State) => false,
 };
 
 export const PLUGIN_FORM_WIDGETS: Record<string, React.ComponentType<any>> = {};


### PR DESCRIPTION
Epic: https://github.com/metabase/metabase/issues/31015
[Product doc](https://www.notion.so/metabase/Really-encourage-admins-to-add-a-DB-9c8c3a7d08ca45cb8672a154220f443e?pvs=4)

### Description

This PR adds an additional condition to not render the database prompt banner when white labeling.

### How to verify

Follows the steps in https://github.com/metabase/metabase/pull/31210, but add one additional conditional condition
- For pro/enterprise instances, modify the `application-name` to something else that's not `Metabase`. After `application-name` is changed we considered the instance to be white labeling and won't render the database prompt banner no matter what

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
