### PR TITLE
[Milestone] Add action edit in action execute modal (#31171)

### DIFF
--- a/e2e/support/helpers/e2e-ui-elements-helpers.js
+++ b/e2e/support/helpers/e2e-ui-elements-helpers.js
@@ -121,3 +121,7 @@ export const undoToast = () => {
 export function dashboardCards() {
   return cy.get("#Dashboard-Cards-Container");
 }
+
+export function actionEditorModal() {
+  return cy.get(`.Modal[role="dialog"]`);
+}

--- a/e2e/support/helpers/e2e-ui-elements-helpers.js
+++ b/e2e/support/helpers/e2e-ui-elements-helpers.js
@@ -121,7 +121,3 @@ export const undoToast = () => {
 export function dashboardCards() {
   return cy.get("#Dashboard-Cards-Container");
 }
-
-export function actionEditorModal() {
-  return cy.get(`.Modal[role="dialog"]`);
-}

--- a/e2e/test/scenarios/actions/actions-on-dashboards.cy.spec.js
+++ b/e2e/test/scenarios/actions/actions-on-dashboards.cy.spec.js
@@ -18,7 +18,6 @@ import {
   createImplicitAction,
   dragField,
   createAction,
-  actionEditorModal,
 } from "e2e/support/helpers";
 
 import { many_data_types_rows } from "e2e/support/test_tables_data";
@@ -668,7 +667,7 @@ const MODEL_NAME = "Test Action Model";
         it("allows to edit action title and field placeholder in action execute modal", () => {
           clickHelper(SAMPLE_QUERY_ACTION.name);
 
-          modal().within(() => {
+          getActionParametersInputModal().within(() => {
             cy.icon("pencil").click();
           });
 
@@ -691,7 +690,7 @@ const MODEL_NAME = "Test Action Model";
             cy.button("Update").click();
           });
 
-          modal().within(() => {
+          getActionParametersInputModal().within(() => {
             cy.findByTestId("modal-header").findByText("New action name");
 
             cy.findAllByPlaceholderText("Test placeholder");
@@ -701,7 +700,7 @@ const MODEL_NAME = "Test Action Model";
         it("allows to edit action query and parameters in action execute modal", () => {
           clickHelper(SAMPLE_QUERY_ACTION.name);
 
-          modal().within(() => {
+          getActionParametersInputModal().within(() => {
             cy.icon("pencil").click();
           });
 
@@ -727,7 +726,7 @@ const MODEL_NAME = "Test Action Model";
             cy.button("Update").click();
           });
 
-          modal().within(() => {
+          getActionParametersInputModal().within(() => {
             cy.findByLabelText("Total").type(`123`);
             cy.findByLabelText("Score").type(`345`);
 
@@ -818,3 +817,11 @@ const clickHelper = buttonName => {
   cy.wait(100);
   cy.button(buttonName).click();
 };
+
+function actionEditorModal() {
+  return cy.findByTestId("action-editor-modal");
+}
+
+function getActionParametersInputModal() {
+  return cy.findByTestId("action-parameters-input-modal");
+}

--- a/e2e/test/scenarios/actions/actions-on-dashboards.cy.spec.js
+++ b/e2e/test/scenarios/actions/actions-on-dashboards.cy.spec.js
@@ -1,3 +1,5 @@
+import { assocIn } from "icepick";
+import _ from "underscore";
 import {
   restore,
   queryWritableDB,
@@ -15,11 +17,14 @@ import {
   filterWidget,
   createImplicitAction,
   dragField,
+  createAction,
+  actionEditorModal,
 } from "e2e/support/helpers";
 
 import { many_data_types_rows } from "e2e/support/test_tables_data";
 
 import { WRITABLE_DB_ID } from "e2e/support/cypress_data";
+import { createMockActionParameter } from "metabase-types/api/mocks";
 import { addWidgetStringFilter } from "../native-filters/helpers/e2e-field-filter-helpers";
 
 const TEST_TABLE = "scoreboard_actions";
@@ -578,6 +583,167 @@ const MODEL_NAME = "Test Action Model";
             expect(row.timestamp).to.include(newTimeAdjusted);
             expect(row.datetimeTZ).to.include(newTimeAdjusted);
             expect(row.timestampTZ).to.include(newTimeAdjusted);
+          });
+        });
+      });
+
+      describe("editing action before executing it", () => {
+        const PG_DB_ID = 2;
+        const WRITABLE_TEST_TABLE = "scoreboard_actions";
+
+        const TEST_PARAMETER = createMockActionParameter({
+          id: "49596bcb-62bb-49d6-a92d-bf5dbfddf43b",
+          name: "Total",
+          slug: "total",
+          type: "number/=",
+          target: ["variable", ["template-tag", "total"]],
+        });
+
+        const TEST_TEMPLATE_TAG = {
+          id: TEST_PARAMETER.id,
+          type: "number",
+          name: TEST_PARAMETER.slug,
+          "display-name": TEST_PARAMETER.name,
+          slug: TEST_PARAMETER.slug,
+        };
+
+        const SAMPLE_QUERY_ACTION = {
+          name: "Demo Action",
+          type: "query",
+          parameters: [TEST_PARAMETER],
+          database_id: PG_DB_ID,
+          dataset_query: {
+            type: "native",
+            native: {
+              query: `UPDATE ORDERS SET TOTAL = TOTAL WHERE ID = {{ ${TEST_TEMPLATE_TAG.name} }}`,
+              "template-tags": {
+                [TEST_TEMPLATE_TAG.name]: TEST_TEMPLATE_TAG,
+              },
+            },
+            database: PG_DB_ID,
+          },
+          visualization_settings: {
+            fields: {
+              [TEST_PARAMETER.id]: {
+                id: TEST_PARAMETER.id,
+                required: true,
+                fieldType: "number",
+                inputType: "number",
+              },
+            },
+          },
+        };
+
+        const SAMPLE_WRITABLE_QUERY_ACTION = assocIn(
+          SAMPLE_QUERY_ACTION,
+          ["dataset_query", "native", "query"],
+          `UPDATE ${WRITABLE_TEST_TABLE} SET score = 22 WHERE id = {{ ${TEST_TEMPLATE_TAG.name} }}`,
+        );
+
+        beforeEach(() => {
+          resetTestTable({ type: dialect, table: TEST_COLUMNS_TABLE });
+          restore(`${dialect}-writable`);
+          cy.signInAsAdmin();
+          resyncDatabase({
+            dbId: WRITABLE_DB_ID,
+            tableName: TEST_COLUMNS_TABLE,
+          });
+          createModelFromTableName({
+            tableName: TEST_COLUMNS_TABLE,
+            modelName: MODEL_NAME,
+          });
+
+          cy.get("@modelId").then(modelId => {
+            createAction({
+              ...SAMPLE_WRITABLE_QUERY_ACTION,
+              model_id: modelId,
+            });
+          });
+
+          createDashboardWithActionButton({
+            actionName: SAMPLE_QUERY_ACTION.name,
+          });
+        });
+
+        it("allows to edit action title and field placeholder in action execute modal", () => {
+          clickHelper(SAMPLE_QUERY_ACTION.name);
+
+          modal().within(() => {
+            cy.icon("pencil").click();
+          });
+
+          actionEditorModal().within(() => {
+            cy.findByText(SAMPLE_QUERY_ACTION.name)
+              .click()
+              .clear()
+              .type("New action name");
+
+            cy.findByTestId("action-form-editor").within(() => {
+              cy.icon("gear").click();
+            });
+          });
+
+          popover().within(() => {
+            cy.findByText("Placeholder text").click().type("Test placeholder");
+          });
+
+          actionEditorModal().within(() => {
+            cy.button("Update").click();
+          });
+
+          modal().within(() => {
+            cy.findByTestId("modal-header").findByText("New action name");
+
+            cy.findAllByPlaceholderText("Test placeholder");
+          });
+        });
+
+        it("allows to edit action query and parameters in action execute modal", () => {
+          clickHelper(SAMPLE_QUERY_ACTION.name);
+
+          modal().within(() => {
+            cy.icon("pencil").click();
+          });
+
+          actionEditorModal().within(() => {
+            cy.findByTestId("native-query-editor").click();
+
+            cy.get(".ace_content").type(
+              _.times(23, () => "{leftArrow}")
+                .join("")
+                .concat("{backspace}{backspace}"),
+            );
+            cy.get(".ace_text-input").type(`{{ score }}`, {
+              force: true,
+              parseSpecialCharSequences: false,
+            });
+
+            cy.findByTestId("action-form-editor").within(() => {
+              cy.findAllByText("Number").click({ multiple: true });
+            });
+          });
+
+          actionEditorModal().within(() => {
+            cy.button("Update").click();
+          });
+
+          modal().within(() => {
+            cy.findByLabelText("Total").type(`123`);
+            cy.findByLabelText("Score").type(`345`);
+
+            cy.button(SAMPLE_QUERY_ACTION.name).click();
+          });
+
+          cy.wait("@executeAPI").then(interception => {
+            expect(
+              Object.values(interception.request.body.parameters)
+                .sort()
+                .join(","),
+            ).to.equal("123,345");
+          });
+
+          cy.findByTestId("toast-undo").within(() => {
+            cy.findByText(`Success! The action returned: {"rows-affected":0}`);
           });
         });
       });

--- a/frontend/src/metabase/actions/components/ActionViz/Action.tsx
+++ b/frontend/src/metabase/actions/components/ActionViz/Action.tsx
@@ -51,7 +51,7 @@ const ActionComponent = ({
   isEditingDashcard,
 }: ActionProps) => {
   const { data: model } = useQuestionQuery({
-    id: dashcard.card_id || dashcard.action?.model_id,
+    id: dashcard.action?.model_id,
   });
 
   const actionSettings = dashcard.action?.visualization_settings;

--- a/frontend/src/metabase/actions/components/ActionViz/Action.unit.spec.tsx
+++ b/frontend/src/metabase/actions/components/ActionViz/Action.unit.spec.tsx
@@ -96,6 +96,7 @@ function createMockActionDashboardCard(
   return _createMockActionDashboardCard({
     id: DASHCARD_ID,
     card_id: CARD.id,
+    card: CARD,
     dashboard_id: DASHBOARD_ID,
     action: ACTION,
     parameter_mappings: [
@@ -108,7 +109,6 @@ function createMockActionDashboardCard(
         target: ["variable", ["template-tag", "2"]],
       },
     ],
-    card: CARD,
     ...opts,
   });
 }
@@ -217,6 +217,7 @@ describe("Actions > ActionViz > Action", () => {
         dashcard: createMockActionDashboardCard({
           action: createMockQueryAction({
             database_id: DATABASE_ID,
+            model_id: ACTION_MODEL_ID,
           }),
           parameter_mappings: [],
         }),
@@ -344,18 +345,22 @@ describe("Actions > ActionViz > Action", () => {
 
       userEvent.click(editActionEl);
 
-      await screen.findByText("Action parameters");
+      const editorModal = await screen.findByTestId("action-editor-modal");
 
-      expect(screen.getByText("My Awesome Action")).toBeInTheDocument();
+      expect(
+        within(editorModal).getByText("My Awesome Action"),
+      ).toBeInTheDocument();
 
-      const cancelEditButton = screen.getByText("Cancel");
+      const cancelEditButton = within(editorModal).getByText("Cancel");
       expect(cancelEditButton).toBeInTheDocument();
 
-      expect(screen.getByText("Update")).toBeInTheDocument();
+      expect(within(editorModal).getByText("Update")).toBeInTheDocument();
 
       userEvent.click(cancelEditButton);
 
-      expect(screen.getByRole("dialog")).toBeInTheDocument();
+      expect(
+        screen.getByTestId("action-parameters-input-modal"),
+      ).toBeInTheDocument();
       expect(screen.getByTestId("action-form")).toBeInTheDocument();
       expect(screen.getByLabelText("Parameter 1")).toBeInTheDocument();
     });
@@ -380,18 +385,20 @@ describe("Actions > ActionViz > Action", () => {
       userEvent.click(getIcon("pencil"));
 
       // wait for action edit form to be loaded
-      await screen.findByText("My Awesome Action");
+      const editorModal = await screen.findByTestId("action-editor-modal");
 
       // edit action title
-      const actionTitleField = screen.getByTestId("editable-text");
+      const actionTitleField = within(editorModal).getByTestId("editable-text");
       userEvent.type(actionTitleField, updatedTitle);
       userEvent.tab(); // blur field
 
-      userEvent.click(await screen.findByText("Update"));
+      userEvent.click(within(editorModal).getByText("Update"));
 
       expect(fetchMock.called(`path:/api/action/${ACTION.id}`)).toBe(true);
 
-      expect(screen.getByRole("dialog")).toBeInTheDocument();
+      expect(
+        screen.getByTestId("action-parameters-input-modal"),
+      ).toBeInTheDocument();
       expect(screen.getByTestId("action-form")).toBeInTheDocument();
       expect(screen.getByLabelText("Parameter 1")).toBeInTheDocument();
     });
@@ -500,6 +507,7 @@ describe("Actions > ActionViz > Action", () => {
           action: createMockImplicitQueryAction({
             name: "My Delete Action",
             kind: "row/delete",
+            model_id: ACTION_MODEL_ID,
             parameters: [
               createMockActionParameter({
                 id: "1",

--- a/frontend/src/metabase/actions/components/ActionViz/Action.unit.spec.tsx
+++ b/frontend/src/metabase/actions/components/ActionViz/Action.unit.spec.tsx
@@ -3,11 +3,18 @@ import userEvent from "@testing-library/user-event";
 
 import {
   getIcon,
+  queryIcon,
   renderWithProviders,
   screen,
   waitFor,
   within,
 } from "__support__/ui";
+import {
+  setupActionEndpoints,
+  setupCardsEndpoints,
+  setupDatabasesEndpoints,
+} from "__support__/server-mocks";
+import { createMockEntitiesState } from "__support__/store";
 
 import type { ActionDashboardCard, ParameterTarget } from "metabase-types/api";
 import {
@@ -17,9 +24,14 @@ import {
   createMockQueryAction,
   createMockImplicitQueryAction,
   createMockDashboard,
+  createMockCard,
+  createMockStructuredDatasetQuery,
+  createMockDatabase,
 } from "metabase-types/api/mocks";
-
 import { getActionIsEnabledInDatabase } from "metabase/dashboard/utils";
+import { checkNotNull } from "metabase/core/utils/types";
+
+import { Database } from "metabase-types/api";
 import Action, { ActionProps } from "./Action";
 
 const DASHBOARD_ID = 123;
@@ -32,6 +44,7 @@ const DATABASE_ID = 1;
 const ACTION = createMockQueryAction({
   name: "My Awesome Action",
   database_id: DATABASE_ID,
+  model_id: ACTION_MODEL_ID,
   parameters: [
     createMockActionParameter({
       id: "parameter_1",
@@ -60,12 +73,29 @@ const ACTION = createMockQueryAction({
   },
 });
 
+const DATABASE = createMockDatabase({
+  settings: {
+    "database-enable-actions": true,
+  },
+});
+
+const CARD = createMockCard({
+  id: ACTION_MODEL_ID,
+  database_id: DATABASE_ID,
+  dataset_query: createMockStructuredDatasetQuery({
+    database: DATABASE_ID,
+  }),
+  display: "action",
+  can_write: true,
+  dataset: true,
+});
+
 function createMockActionDashboardCard(
   opts: Partial<ActionDashboardCard> = {},
 ) {
   return _createMockActionDashboardCard({
     id: DASHCARD_ID,
-    card_id: ACTION_MODEL_ID,
+    card_id: CARD.id,
     dashboard_id: DASHBOARD_ID,
     action: ACTION,
     parameter_mappings: [
@@ -78,6 +108,7 @@ function createMockActionDashboardCard(
         target: ["variable", ["template-tag", "2"]],
       },
     ],
+    card: CARD,
     ...opts,
   });
 }
@@ -85,14 +116,24 @@ function createMockActionDashboardCard(
 type SetupOpts = Partial<ActionProps>;
 
 async function setup({
+  database = DATABASE,
   dashboard = createMockDashboard({ id: DASHBOARD_ID }),
   dashcard = createMockActionDashboardCard(),
   settings = {},
   parameterValues = {},
   ...props
-}: SetupOpts = {}) {
+}: SetupOpts & {
+  database?: Database;
+} = {}) {
+  const card = checkNotNull(dashcard.card);
+
   if (getActionIsEnabledInDatabase(dashcard)) {
     fetchMock.post(ACTION_EXEC_MOCK_PATH, { "rows-updated": [1] });
+
+    // for ActionCreator modal (action edit modal)
+    setupDatabasesEndpoints([database]);
+    setupCardsEndpoints([card]);
+    setupActionEndpoints(ACTION);
   }
 
   renderWithProviders(
@@ -106,6 +147,13 @@ async function setup({
       dispatch={jest.fn()}
       {...props}
     />,
+    {
+      storeInitialState: {
+        entities: createMockEntitiesState({
+          databases: [database],
+        }),
+      },
+    },
   );
 
   // Wait until UI is ready
@@ -203,7 +251,8 @@ describe("Actions > ActionViz > Action", () => {
         ["template-tag", "1"],
       ];
 
-      const action = createMockQueryAction({
+      const action = {
+        ...ACTION,
         parameters: [
           createMockActionParameter({
             id: parameterId,
@@ -220,7 +269,7 @@ describe("Actions > ActionViz > Action", () => {
             }),
           },
         },
-      });
+      };
 
       await setup({
         dashcard: createMockActionDashboardCard({
@@ -245,14 +294,106 @@ describe("Actions > ActionViz > Action", () => {
       );
 
       await waitFor(async () => {
-        const call = fetchMock.lastCall(ACTION_EXEC_MOCK_PATH);
-        expect(await call?.request?.json()).toEqual({
-          modelId: ACTION_MODEL_ID,
-          parameters: {
-            parameter_1: 44,
-          },
-        });
+        expect(fetchMock.called(ACTION_EXEC_MOCK_PATH)).toBe(true);
       });
+
+      const call = fetchMock.lastCall(ACTION_EXEC_MOCK_PATH);
+      expect(await call?.request?.json()).toEqual({
+        modelId: ACTION_MODEL_ID,
+        parameters: {
+          parameter_1: 44,
+        },
+      });
+    });
+
+    it("should NOT allow to edit underlying action if a user does not has edit permissions for this model", async () => {
+      await setup({
+        dashcard: createMockActionDashboardCard({
+          card: {
+            ...CARD,
+            can_write: false,
+          },
+        }),
+      });
+
+      userEvent.click(screen.getByText("Click me"));
+
+      expect(queryIcon("pencil")).not.toBeInTheDocument();
+    });
+
+    it("should NOT allow to edit underlying action if a user does not has edit permissions for this database", async () => {
+      const readOnlyDB: Database = {
+        ...DATABASE,
+        native_permissions: "read",
+      };
+
+      await setup({ database: readOnlyDB });
+
+      userEvent.click(screen.getByText("Click me"));
+
+      expect(queryIcon("pencil")).not.toBeInTheDocument();
+    });
+
+    it("should allow to edit underlying action if a user has edit permissions", async () => {
+      await setup();
+
+      userEvent.click(screen.getByText("Click me"));
+
+      const editActionEl = getIcon("pencil");
+      expect(editActionEl).toBeInTheDocument();
+
+      userEvent.click(editActionEl);
+
+      await screen.findByText("Action parameters");
+
+      expect(screen.getByText("My Awesome Action")).toBeInTheDocument();
+
+      const cancelEditButton = screen.getByText("Cancel");
+      expect(cancelEditButton).toBeInTheDocument();
+
+      expect(screen.getByText("Update")).toBeInTheDocument();
+
+      userEvent.click(cancelEditButton);
+
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+      expect(screen.getByTestId("action-form")).toBeInTheDocument();
+      expect(screen.getByLabelText("Parameter 1")).toBeInTheDocument();
+    });
+
+    it("should open action form after action editing", async () => {
+      const updatedTitle = "Test action title";
+      await setup();
+
+      fetchMock.putOnce(
+        `path:/api/action/${ACTION.id}`,
+        {
+          ...ACTION,
+          name: updatedTitle,
+        },
+        {
+          overwriteRoutes: true,
+        },
+      );
+
+      userEvent.click(screen.getByText("Click me"));
+
+      userEvent.click(getIcon("pencil"));
+
+      // wait for action edit form to be loaded
+      await screen.findByText("My Awesome Action");
+
+      // edit action title
+      const actionTitleField = screen.getByTestId("editable-text");
+      userEvent.type(actionTitleField, updatedTitle);
+      userEvent.tab(); // blur field
+
+      userEvent.click(await screen.findByText("Update"));
+
+      expect(fetchMock.called(`path:/api/action/${ACTION.id}`)).toBe(true);
+
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+      expect(screen.getByTestId("action-form")).toBeInTheDocument();
+      expect(screen.getByLabelText("Parameter 1")).toBeInTheDocument();
     });
   });
 

--- a/frontend/src/metabase/actions/components/ActionViz/ActionParameterMapper.tsx
+++ b/frontend/src/metabase/actions/components/ActionViz/ActionParameterMapper.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from "react";
+import { useCallback, useMemo } from "react";
 import { t } from "ttag";
 import { connect } from "react-redux";
 
@@ -16,6 +16,7 @@ import type {
   WritebackParameter,
   WritebackAction,
 } from "metabase-types/api";
+import { sortActionParams } from "metabase/actions/utils";
 import type Question from "metabase-lib/Question";
 
 import {
@@ -55,8 +56,18 @@ export const ActionParameterMappingForm = ({
   setParameterMapping,
 }: ActionParameterMapperProps & DispatchProps) => {
   const action = passedAction ?? dashcard?.action;
-  const actionParameters = action?.parameters ?? [];
+
   const dashboardParameters = dashboard.parameters ?? [];
+
+  const sortedParameters = useMemo(() => {
+    const actionParameters = action?.parameters ?? [];
+
+    return actionParameters && action?.visualization_settings?.fields
+      ? [...actionParameters].sort(
+          sortActionParams(action?.visualization_settings),
+        )
+      : [];
+  }, [action]);
 
   const currentMappings = Object.fromEntries(
     dashcard.parameter_mappings?.map(mapping => [
@@ -79,7 +90,7 @@ export const ActionParameterMappingForm = ({
 
   return (
     <div>
-      {actionParameters.map((actionParam: WritebackParameter) => (
+      {sortedParameters.map((actionParam: WritebackParameter) => (
         <ParameterFormSection key={actionParam.id}>
           <ParameterFormLabel>
             {actionParam.name ?? actionParam.id}
@@ -100,7 +111,7 @@ export const ActionParameterMappingForm = ({
           />
         </ParameterFormSection>
       ))}
-      {actionParameters.length === 0 && (
+      {sortedParameters.length === 0 && (
         <EmptyState message={t`This action has no parameters to map`} />
       )}
     </div>

--- a/frontend/src/metabase/actions/components/ActionViz/ActionParameterMapper.tsx
+++ b/frontend/src/metabase/actions/components/ActionViz/ActionParameterMapper.tsx
@@ -66,7 +66,7 @@ export const ActionParameterMappingForm = ({
       ? [...actionParameters].sort(
           sortActionParams(action?.visualization_settings),
         )
-      : [];
+      : actionParameters || [];
   }, [action]);
 
   const currentMappings = Object.fromEntries(

--- a/frontend/src/metabase/actions/components/ActionViz/ActionVizForm.tsx
+++ b/frontend/src/metabase/actions/components/ActionViz/ActionVizForm.tsx
@@ -92,7 +92,7 @@ function ActionVizForm({
           focus={isEditingDashcard}
           onClick={onClick}
         />
-        {showFormModal && !showEditModal && (
+        {showFormModal && (
           <ActionParametersInputModal
             action={action}
             dashboard={dashboard}
@@ -109,7 +109,7 @@ function ActionVizForm({
           />
         )}
         {showEditModal && (
-          <Modal wide onClose={closeEditModal} closeOnClickOutside>
+          <Modal wide onClose={closeEditModal}>
             <ActionCreator
               initialAction={action}
               action={action}

--- a/frontend/src/metabase/actions/components/ActionViz/ActionVizForm.tsx
+++ b/frontend/src/metabase/actions/components/ActionViz/ActionVizForm.tsx
@@ -109,7 +109,11 @@ function ActionVizForm({
           />
         )}
         {showEditModal && (
-          <Modal wide onClose={closeEditModal}>
+          <Modal
+            wide
+            data-testid="action-editor-modal"
+            onClose={closeEditModal}
+          >
             <ActionCreator
               initialAction={action}
               action={action}

--- a/frontend/src/metabase/actions/containers/ActionCreator/ActionCreator.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/ActionCreator.tsx
@@ -38,6 +38,9 @@ interface OwnProps {
   actionId?: WritebackActionId;
   modelId?: CardId;
   databaseId?: DatabaseId;
+
+  action?: WritebackAction;
+
   onSubmit?: (action: WritebackAction) => void;
   onClose?: () => void;
 }
@@ -192,11 +195,15 @@ function ActionCreatorWithContext({
   initialAction,
   metadata,
   databaseId,
+  action,
   ...props
 }: Props) {
+  // This is needed in case we already have an action and pass it from the outside
+  const contextAction = action || initialAction;
+
   return (
     <ActionContext
-      initialAction={initialAction}
+      initialAction={contextAction}
       databaseId={databaseId}
       metadata={metadata}
     >

--- a/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/FormCreator.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/FormCreator.tsx
@@ -27,7 +27,6 @@ import {
   getForm,
   getFormValidationSchema,
   getDefaultFormSettings,
-  sortActionParams,
 } from "../../../utils";
 import { syncFieldsWithParameters } from "../utils";
 import { reorderFields } from "./utils";
@@ -88,11 +87,6 @@ function FormCreator({
     [validationSchema],
   );
 
-  const sortedParams = useMemo(
-    () => parameters.sort(sortActionParams(formSettings)),
-    [parameters, formSettings],
-  );
-
   const handleDragEnd = useCallback(
     ({ source, destination }: DropResult) => {
       if (!formSettings.fields) {
@@ -132,7 +126,7 @@ function FormCreator({
     [formSettings],
   );
 
-  if (!sortedParams.length) {
+  if (!parameters.length) {
     return (
       <SidebarContent>
         <FormContainer>

--- a/frontend/src/metabase/actions/containers/ActionParametersInputForm/ActionParametersInputForm.unit.spec.tsx
+++ b/frontend/src/metabase/actions/containers/ActionParametersInputForm/ActionParametersInputForm.unit.spec.tsx
@@ -3,7 +3,7 @@ import fetchMock from "fetch-mock";
 import userEvent from "@testing-library/user-event";
 import { waitFor } from "@testing-library/react";
 
-import { render, screen } from "__support__/ui";
+import { getIcon, render, screen } from "__support__/ui";
 
 import {
   createMockActionDashboardCard,
@@ -64,7 +64,7 @@ function setup(options?: Partial<ActionParametersInputModalProps>) {
   render(<ActionParametersInputForm {...defaultProps} {...options} />);
 }
 
-async function setupModal(options?: any) {
+async function setupModal(options?: Partial<ActionParametersInputModalProps>) {
   render(
     <ActionParametersInputModal
       title="Test Modal"
@@ -248,13 +248,29 @@ describe("Actions > ActionParametersInputForm", () => {
           type: "implicit",
           kind: "row/delete",
         }),
-        missingParameters: [],
         showConfirmMessage: true,
       });
 
       expect(
         screen.getByText(/this action cannot be undone/i),
       ).toBeInTheDocument();
+    });
+
+    it("should render action edit action icon if onEdit is passed", async () => {
+      const onEditMock = jest.fn();
+
+      await setupModal({ onEdit: onEditMock });
+
+      const editActionTrigger = getIcon("pencil");
+      expect(editActionTrigger).toBeInTheDocument();
+
+      userEvent.hover(editActionTrigger);
+
+      expect(screen.getByText("Edit this action")).toBeInTheDocument();
+
+      userEvent.click(editActionTrigger);
+
+      expect(onEditMock).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/frontend/src/metabase/actions/containers/ActionParametersInputForm/ActionParametersInputModal.tsx
+++ b/frontend/src/metabase/actions/containers/ActionParametersInputForm/ActionParametersInputModal.tsx
@@ -32,7 +32,11 @@ function ActionParametersInputModal({
         title={title}
         headerActions={
           onEdit ? (
-            <ModalContentActionIcon name="pencil" onClick={onEdit} />
+            <ModalContentActionIcon
+              name="pencil"
+              tooltip={t`Edit this action`}
+              onClick={onEdit}
+            />
           ) : undefined
         }
         onClose={onClose}

--- a/frontend/src/metabase/actions/containers/ActionParametersInputForm/ActionParametersInputModal.tsx
+++ b/frontend/src/metabase/actions/containers/ActionParametersInputForm/ActionParametersInputModal.tsx
@@ -1,7 +1,8 @@
 import { t } from "ttag";
 import Modal from "metabase/components/Modal";
-import ModalContent from "metabase/components/ModalContent";
-
+import ModalContent, {
+  ModalContentActionIcon,
+} from "metabase/components/ModalContent";
 import ActionParametersInputForm, {
   ActionParametersInputFormProps,
 } from "./ActionParametersInputForm";
@@ -10,6 +11,7 @@ interface ModalProps {
   title: string;
   showConfirmMessage?: boolean;
   confirmMessage?: string;
+  onEdit?: () => void;
   onClose: () => void;
 }
 
@@ -20,12 +22,21 @@ function ActionParametersInputModal({
   title,
   showConfirmMessage,
   confirmMessage,
+  onEdit,
   onClose,
   ...formProps
 }: ActionParametersInputModalProps) {
   return (
     <Modal onClose={onClose}>
-      <ModalContent title={title} onClose={onClose}>
+      <ModalContent
+        title={title}
+        headerActions={
+          onEdit ? (
+            <ModalContentActionIcon name="pencil" onClick={onEdit} />
+          ) : undefined
+        }
+        onClose={onClose}
+      >
         <>
           {showConfirmMessage && <ConfirmMessage message={confirmMessage} />}
           <ActionParametersInputForm {...formProps} />

--- a/frontend/src/metabase/actions/containers/ActionParametersInputForm/ActionParametersInputModal.tsx
+++ b/frontend/src/metabase/actions/containers/ActionParametersInputForm/ActionParametersInputModal.tsx
@@ -27,7 +27,7 @@ function ActionParametersInputModal({
   ...formProps
 }: ActionParametersInputModalProps) {
   return (
-    <Modal onClose={onClose}>
+    <Modal data-testid="action-parameters-input-modal" onClose={onClose}>
       <ModalContent
         title={title}
         headerActions={

--- a/frontend/src/metabase/components/Modal/WindowModal.tsx
+++ b/frontend/src/metabase/components/Modal/WindowModal.tsx
@@ -17,6 +17,7 @@ export type WindowModalProps = BaseModalProps & {
   fullPageModal?: boolean;
   formModal?: boolean;
   style?: CSSProperties;
+  "data-testid"?: string;
 } & {
   [size in ModalSize]?: boolean;
 };
@@ -86,6 +87,7 @@ export class WindowModal extends Component<WindowModalProps> {
       isOpen,
       style,
       enableTransition,
+      "data-testid": dataTestId,
     } = this.props;
     const backdropClassnames =
       "flex justify-center align-center fixed top left bottom right";
@@ -113,6 +115,7 @@ export class WindowModal extends Component<WindowModalProps> {
               <div
                 className={cx(backdropClassName, backdropClassnames)}
                 style={style}
+                data-testid={dataTestId}
               >
                 {this._modalComponent()}
               </div>

--- a/frontend/src/metabase/components/ModalContent/ModalContent.stories.tsx
+++ b/frontend/src/metabase/components/ModalContent/ModalContent.stories.tsx
@@ -1,8 +1,7 @@
 import type { ComponentStory } from "@storybook/react";
 import { action } from "@storybook/addon-actions";
 import Modal from "metabase/components/Modal";
-import { ActionIcon } from "./ModalContent.styled";
-import ModalContent from "./ModalContent";
+import ModalContent, { ModalContentActionIcon } from "./index";
 
 export default {
   title: "Components/ModalContent",
@@ -48,7 +47,7 @@ WithHeaderActions.args = {
   ...args,
   headerActions: (
     <>
-      <ActionIcon name="pencil" onClick={action("Action1")} />
+      <ModalContentActionIcon name="pencil" onClick={action("Action1")} />
     </>
   ),
 };

--- a/frontend/src/metabase/components/ModalContent/ModalContent.styled.ts
+++ b/frontend/src/metabase/components/ModalContent/ModalContent.styled.ts
@@ -30,7 +30,7 @@ export const ActionsWrapper = styled.div`
   margin-right: -0.5rem;
 `;
 
-export const ActionIcon = styled(Icon)`
+export const ModalContentActionIcon = styled(Icon)`
   color: ${color("text-light")};
   cursor: pointer;
   padding: 0.5rem;

--- a/frontend/src/metabase/components/ModalContent/ModalContent.tsx
+++ b/frontend/src/metabase/components/ModalContent/ModalContent.tsx
@@ -2,7 +2,7 @@ import { Component, ReactNode } from "react";
 import PropTypes from "prop-types";
 import cx from "classnames";
 import {
-  ActionIcon,
+  ModalContentActionIcon,
   ActionsWrapper,
   HeaderContainer,
   HeaderText,
@@ -133,7 +133,11 @@ export const ModalHeader = ({
         <ActionsWrapper>
           {headerActions}
           {onClose && (
-            <ActionIcon name="close" size={actionIconSize} onClick={onClose} />
+            <ModalContentActionIcon
+              name="close"
+              size={actionIconSize}
+              onClick={onClose}
+            />
           )}
         </ActionsWrapper>
       )}

--- a/frontend/src/metabase/components/ModalContent/ModalContent.unit.spec.tsx
+++ b/frontend/src/metabase/components/ModalContent/ModalContent.unit.spec.tsx
@@ -1,6 +1,6 @@
 import userEvent from "@testing-library/user-event";
 import { getIcon, render } from "__support__/ui";
-import { ActionIcon } from "./ModalContent.styled";
+import { ModalContentActionIcon } from "./ModalContent.styled";
 import ModalContent, { ModalContentProps } from "./ModalContent";
 
 describe("ModalContent", () => {
@@ -19,7 +19,7 @@ describe("ModalContent", () => {
     const headerActionsEl = (
       <>
         {headerActions.map(({ icon, onClick }) => (
-          <ActionIcon key={icon} name={icon} onClick={onClick} />
+          <ModalContentActionIcon key={icon} name={icon} onClick={onClick} />
         ))}
       </>
     );

--- a/frontend/src/metabase/components/ModalContent/index.ts
+++ b/frontend/src/metabase/components/ModalContent/index.ts
@@ -1,3 +1,4 @@
 // eslint-disable-next-line import/no-default-export -- deprecated usage
 export { default } from "./ModalContent";
 export * from "./ModalContent";
+export { ModalContentActionIcon } from "./ModalContent.styled";

--- a/frontend/src/metabase/dashboard/reducers.js
+++ b/frontend/src/metabase/dashboard/reducers.js
@@ -5,7 +5,7 @@ import _ from "underscore";
 import { handleActions, combineReducers } from "metabase/lib/redux";
 import Dashboards from "metabase/entities/dashboards";
 import Questions from "metabase/entities/questions";
-
+import Actions from "metabase/entities/actions";
 import { NAVIGATE_BACK_TO_DASHBOARD } from "metabase/query_builder/actions";
 
 import {
@@ -235,6 +235,20 @@ const dashcards = handleActions(
       _.mapObject(state, dashcard =>
         dashcard.card?.id === card?.id
           ? assocIn(dashcard, ["card"], card)
+          : dashcard,
+      ),
+    [Actions.actionTypes.UPDATE]: (state, { payload: { object: action } }) =>
+      _.mapObject(state, dashcard =>
+        dashcard.action?.id === action?.id
+          ? {
+              ...dashcard,
+              action: {
+                ...action,
+
+                database_enabled_actions:
+                  dashcard?.action.database_enabled_actions || false,
+              },
+            }
           : dashcard,
       ),
   },

--- a/frontend/src/metabase/lib/entities.js
+++ b/frontend/src/metabase/lib/entities.js
@@ -351,7 +351,7 @@ export function createEntity(def) {
   // HACK: the above actions return the normalizr results
   // (i.e. { entities, result }) rather than the loaded object(s), except
   // for fetch and fetchList when the data is cached, in which case it returns
-  // the noralized object.
+  // the normalized object.
   //
   // This is a problem when we use the result of one of the actions as though
   // though the action creator was an API client.


### PR DESCRIPTION
Milestone of https://github.com/metabase/metabase/issues/29866

### Description

I should be able to update / edit the action definition, (or do anything else I could normally do in that modal) and hit Update. I’m then sent back. 

### Demo


https://github.com/metabase/metabase/assets/7983744/7a84466e-477a-43e5-bc7d-31df9264cf9e
