### PR TITLE
Make sure plurals get included properly when generating POT file

### DIFF
--- a/bin/build/src/i18n/enumerate.clj
+++ b/bin/build/src/i18n/enumerate.clj
@@ -90,7 +90,7 @@
                              (apply str (rest i18n-string)))]
       (merge {:message message}
              (when (string? pl-i18n-string)
-               {:message-pl i18n-string})))))
+               {:message-pl pl-i18n-string})))))
 
 (defn- analyze-translations
   "Takes roots to grasp returning a map of :file, :line, :original (the original form), and :message. If identifying the


### PR DESCRIPTION
Resolves https://github.com/metabase/metabase/issues/31480

Simple fix, the singular translation was being included in the POT file where it should have been the plural translation 🤦‍♂️ 