### PR TITLE
Remove infinite recursion when resolving fields by name

### DIFF
--- a/src/metabase/lib/field.cljc
+++ b/src/metabase/lib/field.cljc
@@ -87,7 +87,8 @@
         ;; we should look in to fixing this if we can.
         stage-columns (or (:metabase.lib.stage/cached-metadata stage)
                           (get-in stage [:lib/stage-metadata :columns])
-                          (lib.metadata.calculation/visible-columns query stage-number stage)
+                          (when (string? (:source-table stage))
+                            (lib.metadata.calculation/visible-columns query stage-number stage))
                           (log/warn (i18n/tru "Cannot resolve column {0}: stage has no metadata" (pr-str column-name))))]
     (when (seq stage-columns)
       (resolve-column-name-in-metadata column-name stage-columns))))

--- a/src/metabase/lib/join.cljc
+++ b/src/metabase/lib/join.cljc
@@ -109,7 +109,11 @@
 (defmethod lib.metadata.calculation/metadata-method :mbql/join
   [query stage-number {:keys [fields stages], join-alias :alias, :or {fields :none}, :as _join}]
   (when-not (= fields :none)
-    (let [join-query (assoc query :stages stages)
+    (let [ensure-previous-stages-have-metadata (resolve 'metabase.lib.stage/ensure-previous-stages-have-metadata)
+          join-query (cond-> (assoc query :stages stages)
+                       ensure-previous-stages-have-metadata
+                       (ensure-previous-stages-have-metadata -1))
+          _ (tap> join-query)
           field-metadatas (if (= fields :all)
                             (lib.metadata.calculation/metadata join-query -1 (peek stages))
                             (for [field-ref fields

--- a/src/metabase/lib/join.cljc
+++ b/src/metabase/lib/join.cljc
@@ -113,7 +113,6 @@
           join-query (cond-> (assoc query :stages stages)
                        ensure-previous-stages-have-metadata
                        (ensure-previous-stages-have-metadata -1))
-          _ (tap> join-query)
           field-metadatas (if (= fields :all)
                             (lib.metadata.calculation/metadata join-query -1 (peek stages))
                             (for [field-ref fields

--- a/src/metabase/lib/js.cljs
+++ b/src/metabase/lib/js.cljs
@@ -6,6 +6,7 @@
    [metabase.lib.core :as lib.core]
    [metabase.lib.js.metadata :as js.metadata]
    [metabase.lib.metadata.protocols :as lib.metadata.protocols]
+   [metabase.lib.stage :as lib.stage]
    [metabase.mbql.js :as mbql.js]
    [metabase.mbql.normalize :as mbql.normalize]
    [metabase.util :as u]
@@ -118,7 +119,9 @@
   ([a-query x]
    (display-info a-query -1 x))
   ([a-query stage-number x]
-   (-> (lib.core/display-info a-query stage-number x)
+   (-> a-query
+       (lib.stage/ensure-previous-stages-have-metadata stage-number)
+       (lib.core/display-info stage-number x)
        (update-keys u/->camelCaseEn)
        (update :table update-keys u/->camelCaseEn)
        (clj->js :keyword-fn u/qualified-name))))

--- a/src/metabase/lib/stage.cljc
+++ b/src/metabase/lib/stage.cljc
@@ -34,7 +34,7 @@
    {:aggregation (partial mapv lib.normalize/normalize)
     :filters     (partial mapv lib.normalize/normalize)}))
 
-(mu/defn ^:private ensure-previous-stages-have-metadata :- ::lib.schema/query
+(mu/defn ensure-previous-stages-have-metadata :- ::lib.schema/query
   "Recursively calculate the metadata for the previous stages and add it to them, we'll need it for metadata
   calculations for `stage-number` and we don't want to have to calculate it more than once..."
   [query        :- ::lib.schema/query
@@ -288,6 +288,7 @@
 (defmethod lib.metadata.calculation/visible-columns-method ::stage
   [query stage-number _stage {:keys [unique-name-fn include-implicitly-joinable?], :as options}]
   (let [;; query   (lib.util/update-query-stage query stage-number dissoc :fields :breakout :aggregation)
+        query            (ensure-previous-stages-have-metadata query stage-number)
         existing-columns (existing-visible-columns query stage-number options)]
     (->> (concat
            existing-columns
@@ -353,16 +354,17 @@
 
 (defmethod lib.metadata.calculation/display-name-method :mbql.stage/mbql
   [query stage-number _stage style]
-  (or
-   (not-empty
-    (let [descriptions (for [k display-name-parts]
-                         (lib.metadata.calculation/describe-top-level-key query stage-number k))]
-      (str/join ", " (remove str/blank? descriptions))))
-   (when-let [previous-stage-number (lib.util/previous-stage-number query stage-number)]
-     (lib.metadata.calculation/display-name query
-                                            previous-stage-number
-                                            (lib.util/query-stage query previous-stage-number)
-                                            style))))
+  (let [query (ensure-previous-stages-have-metadata query stage-number)]
+    (or
+     (not-empty
+      (let [descriptions (for [k display-name-parts]
+                           (lib.metadata.calculation/describe-top-level-key query stage-number k))]
+        (str/join ", " (remove str/blank? descriptions))))
+     (when-let [previous-stage-number (lib.util/previous-stage-number query stage-number)]
+       (lib.metadata.calculation/display-name query
+                                              previous-stage-number
+                                              (lib.util/query-stage query previous-stage-number)
+                                              style)))))
 
 (mu/defn append-stage :- ::lib.schema/query
   "Adds a new blank stage to the end of the pipeline"


### PR DESCRIPTION
Fixes #31469.

Always trying getting the visible columns of the stage when resolving fields by name can lead to infinite loops.
This PR ensures that the stage metadata cache is set for previous stages and gets the visible columns only when a saved question has missing metadata.