### PR TITLE
[E2E] Fix joins flakes

### DIFF
--- a/e2e/support/helpers/e2e-notebook-helpers.js
+++ b/e2e/support/helpers/e2e-notebook-helpers.js
@@ -61,3 +61,24 @@ export function addSummaryGroupingField({ field, stage = 0, index = 0 }) {
     cy.findByText(field).click();
   });
 }
+
+export function selectSavedQuestionsToJoin(
+  firstQuestionName,
+  secondQuestionName,
+) {
+  cy.intercept("GET", "/api/database/*/schemas").as("loadSchemas");
+  // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
+  cy.findByText("Saved Questions").click();
+  // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
+  cy.findByText(firstQuestionName).click();
+  cy.wait("@loadSchemas");
+
+  // join to question b
+  cy.icon("join_left_outer").click();
+
+  popover().within(() => {
+    cy.findByTextEnsureVisible("Sample Database").click();
+    cy.findByTextEnsureVisible("Saved Questions").click();
+    cy.findByText(secondQuestionName).click();
+  });
+}

--- a/e2e/test/scenarios/joins/joins.cy.spec.js
+++ b/e2e/test/scenarios/joins/joins.cy.spec.js
@@ -118,21 +118,7 @@ describe("scenarios > question > joined questions", () => {
 
     // start a custom question with question a
     startNewQuestion();
-    cy.intercept("GET", "/api/database/*/schemas").as("loadSchemas");
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Saved Questions").click();
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("question a").click();
-    cy.wait("@loadSchemas");
-
-    // join to question b
-    cy.icon("join_left_outer").click();
-
-    popover().within(() => {
-      cy.findByTextEnsureVisible("Sample Database").click();
-      cy.findByTextEnsureVisible("Saved Questions").click();
-      cy.findByText("question b").click();
-    });
+    selectSavedQuestionsToJoin("question a", "question b");
 
     // select the join columns
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -224,10 +210,6 @@ describe("scenarios > question > joined questions", () => {
   });
 
   it("should join saved questions that themselves contain joins (metabase#12928)", () => {
-    cy.intercept("GET", "/api/table/card__*/query_metadata").as(
-      "cardQueryMetadata",
-    );
-
     // Save Question 1
     cy.createQuestion({
       name: "12928_Q1",
@@ -287,22 +269,7 @@ describe("scenarios > question > joined questions", () => {
 
     // Join two previously saved questions
     startNewQuestion();
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Saved Questions").click();
-
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("12928_Q1").click();
-    cy.wait("@cardQueryMetadata");
-
-    cy.icon("join_left_outer").click();
-
-    popover().within(() => {
-      cy.findByTextEnsureVisible("Saved Questions").click();
-    });
-
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("12928_Q2").click();
-    cy.wait("@cardQueryMetadata");
+    selectSavedQuestionsToJoin("12928_Q1", "12928_Q2");
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains(/Products? → Category/).click();
@@ -516,5 +483,23 @@ function selectFromDropdown(option, clickOpts) {
 function assertDimensionName(type, name) {
   cy.findByTestId(`${type}-dimension`).within(() => {
     cy.findByText(name);
+  });
+}
+
+function selectSavedQuestionsToJoin(firstQuestionName, secondQuestionName) {
+  cy.intercept("GET", "/api/database/*/schemas").as("loadSchemas");
+  // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
+  cy.findByText("Saved Questions").click();
+  // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
+  cy.findByText(firstQuestionName).click();
+  cy.wait("@loadSchemas");
+
+  // join to question b
+  cy.icon("join_left_outer").click();
+
+  popover().within(() => {
+    cy.findByTextEnsureVisible("Sample Database").click();
+    cy.findByTextEnsureVisible("Saved Questions").click();
+    cy.findByText(secondQuestionName).click();
   });
 }

--- a/e2e/test/scenarios/joins/joins.cy.spec.js
+++ b/e2e/test/scenarios/joins/joins.cy.spec.js
@@ -9,6 +9,7 @@ import {
   visitQuestionAdhoc,
   enterCustomColumnDetails,
   openProductsTable,
+  selectSavedQuestionsToJoin,
 } from "e2e/support/helpers";
 
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
@@ -483,23 +484,5 @@ function selectFromDropdown(option, clickOpts) {
 function assertDimensionName(type, name) {
   cy.findByTestId(`${type}-dimension`).within(() => {
     cy.findByText(name);
-  });
-}
-
-function selectSavedQuestionsToJoin(firstQuestionName, secondQuestionName) {
-  cy.intercept("GET", "/api/database/*/schemas").as("loadSchemas");
-  // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-  cy.findByText("Saved Questions").click();
-  // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-  cy.findByText(firstQuestionName).click();
-  cy.wait("@loadSchemas");
-
-  // join to question b
-  cy.icon("join_left_outer").click();
-
-  popover().within(() => {
-    cy.findByTextEnsureVisible("Sample Database").click();
-    cy.findByTextEnsureVisible("Saved Questions").click();
-    cy.findByText(secondQuestionName).click();
   });
 }

--- a/e2e/test/scenarios/joins/joins.cy.spec.js
+++ b/e2e/test/scenarios/joins/joins.cy.spec.js
@@ -118,15 +118,18 @@ describe("scenarios > question > joined questions", () => {
 
     // start a custom question with question a
     startNewQuestion();
+    cy.intercept("GET", "/api/database/*/schemas").as("loadSchemas");
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Saved Questions").click();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("question a").click();
+    cy.wait("@loadSchemas");
 
     // join to question b
     cy.icon("join_left_outer").click();
 
     popover().within(() => {
+      cy.findByTextEnsureVisible("Sample Database").click();
       cy.findByTextEnsureVisible("Saved Questions").click();
       cy.findByText("question b").click();
     });

--- a/e2e/test/scenarios/joins/reproductions/17767-cannot-join-on-aggregation-with-implicit-joins.cy.spec.js
+++ b/e2e/test/scenarios/joins/reproductions/17767-cannot-join-on-aggregation-with-implicit-joins.cy.spec.js
@@ -9,6 +9,7 @@ const questionDetails = {
     "source-table": ORDERS_ID,
     aggregation: [["count"]],
     breakout: [["field", PRODUCTS.ID, { "source-field": ORDERS.PRODUCT_ID }]],
+    limit: 2,
   },
 };
 

--- a/e2e/test/scenarios/joins/reproductions/18502-cannot-join-two-saved-questions-same-table.cy.spec.js
+++ b/e2e/test/scenarios/joins/reproductions/18502-cannot-join-two-saved-questions-same-table.cy.spec.js
@@ -1,8 +1,8 @@
 import {
   restore,
-  popover,
   visualize,
   startNewQuestion,
+  selectSavedQuestionsToJoin,
 } from "e2e/support/helpers";
 
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
@@ -26,18 +26,7 @@ describe("issue 18502", () => {
     cy.createQuestion(question2);
 
     startNewQuestion();
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Saved Questions").click();
-
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("18502#1").click();
-    cy.icon("join_left_outer").click();
-    cy.wait("@getCollectionContent");
-
-    popover().within(() => {
-      cy.findByTextEnsureVisible("Saved Questions").click();
-      cy.findByText("18502#2").click();
-    });
+    selectSavedQuestionsToJoin("18502#1", "18502#2");
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Created At").click();

--- a/e2e/test/scenarios/joins/reproductions/18512-cannot-join-two-saved-questions-with-same-implicit-explicit-grouped-field.cy.spec.js
+++ b/e2e/test/scenarios/joins/reproductions/18512-cannot-join-two-saved-questions-with-same-implicit-explicit-grouped-field.cy.spec.js
@@ -3,6 +3,7 @@ import {
   popover,
   visualize,
   startNewQuestion,
+  selectSavedQuestionsToJoin,
 } from "e2e/support/helpers";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 
@@ -20,26 +21,11 @@ describe("issue 18512", () => {
   });
 
   it("should join two saved questions with the same implicit/explicit grouped field (metabase#18512)", () => {
-    cy.intercept("/api/table/card__*/query_metadata").as("cardQueryMetadata");
-
     cy.createQuestion(question1);
     cy.createQuestion(question2);
 
     startNewQuestion();
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Saved Questions").click();
-
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("18512#1").click();
-    cy.wait("@cardQueryMetadata");
-
-    cy.icon("join_left_outer").click();
-
-    popover().within(() => {
-      cy.findByTextEnsureVisible("Saved Questions").click();
-      cy.findByText("18512#2").click();
-      cy.wait("@cardQueryMetadata");
-    });
+    selectSavedQuestionsToJoin("18512#1", "18512#2");
 
     popover().findByText("Products → Created At").click();
     popover().findByText("Products → Created At").click();


### PR DESCRIPTION
The credit for this fix goes to @NevRA who discovered the root cause.

We need to wait for the `GET` request to get all schemas if we want to have a predictable content in the popover. It's explained in this issue: https://github.com/metabase/metabase/issues/28798

tl;dr
Waiting for schemas to load will result in
![image](https://user-images.githubusercontent.com/31325167/222220630-6490fb23-8810-4bb2-bf90-d9bed183eaa6.png)

If test proceeds faster and it doesn't wait for schemas to load, that will result in
![image](https://user-images.githubusercontent.com/31325167/222220608-f0d8f523-98fc-4715-b8be-3246278aa8b3.png)

---

### The fix
Most of these flakes had the same root cause explained above. The tests were trying to find "Saved questions" in a popover (screenshot 2) because the runner and the network were so slow that the `GET` request for schemas didn't happen before the test continued to click.

We now explicitly wait for this request in order to continue.

The only exception in the root cause was repro for #17767.
This flake has a different cause than the rest of the flakes in this PR.
The request `POST /api/dataset` is timing out in CI. It takes more than
30 seconds to complete, and Cypress times out in meantime.

This is suspiciously slow, even for CI.
I'm trying to limit the number of results by limiting rows in the original
query. This reduces the number of total results (after the join) from
1,136 rows to just 9.

---
I've stress-tested a lot of these tests and the fix seems to be working consistently wherever applied:
- https://github.com/metabase/metabase/actions/runs/5224668064/jobs/9433148236 (please note that this run timed out, but you can see from the results that it ran some of the affected tests and they are consistently passing 20x
- https://github.com/metabase/metabase/actions/runs/5224672432/jobs/9433158002