### PR TITLE
MLv2: Fix matching of field literals to field integer IDs

### DIFF
--- a/shared/src/metabase/mbql/util.cljc
+++ b/shared/src/metabase/mbql/util.cljc
@@ -709,8 +709,7 @@
   considered relevant when comparing clauses for equality."
   [field-or-ref]
   (update-field-options field-or-ref (partial into {} (remove (fn [[k _]]
-                                                                (when (keyword? k)
-                                                                  (namespace k)))))))
+                                                                (qualified-keyword? k))))))
 
 (defn referenced-field-ids
   "Find all the `:field` references with integer IDs in `coll`, which can be a full MBQL query, a snippet of MBQL, or a

--- a/src/metabase/lib/aggregation.cljc
+++ b/src/metabase/lib/aggregation.cljc
@@ -347,6 +347,8 @@
                      (fn [cols]
                        (mapv (fn [col]
                                (let [a-ref (lib.ref/ref col)]
+                                 ;; FIXME: This should use [[lib.equality/find-closest-matching-ref]] instead.
+                                 #_{:clj-kondo/ignore [:deprecated-var]}
                                  (cond-> col
                                    (lib.equality/ref= a-ref agg-col)
                                    (assoc :selected? true))))

--- a/src/metabase/lib/equality.cljc
+++ b/src/metabase/lib/equality.cljc
@@ -2,9 +2,13 @@
   "Logic for determining whether two pMBQL queries are equal."
   (:refer-clojure :exclude [=])
   (:require
+   [medley.core :as m]
    [metabase.lib.dispatch :as lib.dispatch]
    [metabase.lib.hierarchy :as lib.hierarchy]
-   [metabase.lib.util :as lib.util]))
+   [metabase.lib.metadata :as lib.metadata]
+   [metabase.lib.options :as lib.options]
+   [metabase.lib.util :as lib.util]
+   [metabase.mbql.util.match :as mbql.u.match]))
 
 (defmulti =
   "Determine whether two already-normalized pMBQL maps, clauses, or other sorts of expressions are equal. The basic rule
@@ -83,15 +87,61 @@
 (defmethod = :default
   [x y]
   (cond
-    (map? x)                   ((get-method = :dispatch-type/map) x y)
-    (sequential? x)            ((get-method = :dispatch-type/sequential) x y)
-    :else                      (clojure.core/= x y)))
+    (map? x)        ((get-method = :dispatch-type/map) x y)
+    (sequential? x) ((get-method = :dispatch-type/sequential) x y)
+    :else           (clojure.core/= x y)))
 
-;;; TODO I think to field refs with different `:base-type`s but with other info the same should probably be considered
-;;; the same, right? Like if we improve type calculation it shouldn't break existing queries
-(defn ref=
-  "Are two refs `x` and `y` equal?"
+(defn ^:deprecated ref=
+  "Are two refs `x` and `y` equal?
+
+  DEPRECATED: use [[find-closest-matching-ref]] instead. This does not work if things like `:base-type` are missing or
+  differ slightly, or handle `:binning` correctly, let alone when things are broken more significantly. If we improve
+  type calculation it shouldn't break existing queries... right?"
   [x y]
   (or (= x y)
       (= (lib.util/with-default-effective-type x)
          (lib.util/with-default-effective-type y))))
+
+(defn- update-options-remove-namespaced-keys [a-ref]
+  (lib.options/update-options a-ref (fn [options]
+                                      (into {} (remove (fn [[k _v]] (qualified-keyword? k))) options))))
+
+(defn find-closest-matching-ref
+  "Find the ref that most closely matches `a-ref` from a sequence of `refs`. This is meant to power things
+  like [[metabase.lib.breakout/breakoutable-columns]] which are supposed to include `:breakout-position` for columns
+  that are already present as a breakout; sometimes the column in the breakout does not exactly match what MLv2 would
+  have generated. So try to figure out which column it is referring to.
+
+  This first looks for a matching ref with a strict comparison, than in increasingly less-strict comparisons until it
+  finds something that matches. This is mostly to work around buts like #31482 where MLv1 generated queries with
+  `:field` refs that did not include join aliases even tho the Fields came from joined Tables... we still know the
+  Fields are the same if they have the same IDs.
+
+  The three-arity version can also find matches between integer Field ID references like `[:field {} 1]` and
+  equivalent string column name field literal references like `[:field {} \"bird_type\"]` by resolving Field IDs using
+  a `metadata-providerable` (something that can be treated as a metadata provider, e.g. a `query` with a
+  MetadataProvider associated with it). This is the ultimately hacky workaround for totally busted legacy queries.
+  Note that this currently only works when `a-ref` is the one with the integer Field ID and `refs` have string literal
+  column names; it does not work the other way around. Luckily we currently don't have problems with MLv1/legacy
+  queries accidentally using string :field literals where it shouldn't have been doing so."
+  ([a-ref refs]
+   (loop [xform identity, more-xforms [ ;; ignore irrelevant keys from :binning options
+                                       #(lib.options/update-options % m/update-existing :binning dissoc :metadata-fn :lib/type)
+                                       ;; ignore namespaced keys
+                                       update-options-remove-namespaced-keys
+                                       ;; ignore type info
+                                       #(lib.options/update-options % dissoc :base-type :effective-type)
+                                       ;; ignore join alias
+                                       #(lib.options/update-options % dissoc :join-alias)]]
+     (or (let [a-ref (xform a-ref)]
+           (m/find-first #(= (xform %) a-ref)
+                         refs))
+         (when (seq more-xforms)
+           (recur (comp xform (first more-xforms)) (rest more-xforms))))))
+
+  ([metadata-providerable a-ref refs]
+   (or (find-closest-matching-ref a-ref refs)
+       (mbql.u.match/match-one a-ref
+         [:field opts (field-id :guard integer?)]
+         (when-let [field-name (:name (lib.metadata/field metadata-providerable field-id))]
+           (find-closest-matching-ref [:field opts field-name] refs))))))

--- a/src/metabase/lib/equality.cljc
+++ b/src/metabase/lib/equality.cljc
@@ -112,8 +112,8 @@
   that are already present as a breakout; sometimes the column in the breakout does not exactly match what MLv2 would
   have generated. So try to figure out which column it is referring to.
 
-  This first looks for a matching ref with a strict comparison, than in increasingly less-strict comparisons until it
-  finds something that matches. This is mostly to work around buts like #31482 where MLv1 generated queries with
+  This first looks for a matching ref with a strict comparison, then in increasingly less-strict comparisons until it
+  finds something that matches. This is mostly to work around bugs like #31482 where MLv1 generated queries with
   `:field` refs that did not include join aliases even tho the Fields came from joined Tables... we still know the
   Fields are the same if they have the same IDs.
 

--- a/src/metabase/lib/field.cljc
+++ b/src/metabase/lib/field.cljc
@@ -506,6 +506,8 @@
                               (let [col-ref (lib.ref/ref column)]
                                 (boolean
                                  (some (fn [fields-ref]
+                                         ;; FIXME: This should use [[lib.equality/find-closest-matching-ref]] instead.
+                                         #_{:clj-kondo/ignore [:deprecated-var]}
                                          (lib.equality/ref= col-ref fields-ref))
                                        current-fields)))))]
      (mapv (fn [col]

--- a/test/metabase/lib/equality_test.cljc
+++ b/test/metabase/lib/equality_test.cljc
@@ -201,8 +201,8 @@
     [:field {:base-type :type/Integer} 1]
 
     [:field {:join-alias "J"} 1]
-    [[:field {:join-alias "J"} 1]
-     [:field {:join-alias "J"} 2]]
+    [[:field {:join-alias "I"} 1]
+     [:field {:join-alias "J"} 1]]
     [:field {:join-alias "J"} 1]
 
     ;; if no strict match, should ignore type info and return first match

--- a/test/metabase/lib/field_test.cljc
+++ b/test/metabase/lib/field_test.cljc
@@ -201,7 +201,11 @@
                             :long-display-name "Products → Category"
                             :effective-type    :type/Text}]
                           (map (partial lib/display-info query')
-                               (lib/breakouts query')))))))))))))
+                               (lib/breakouts query'))))
+                  (is (=? {:display-name      "Products → Category"
+                           :breakout-position 0}
+                          (m/find-first #(= (:id %) (meta/id :products :category))
+                                        (lib/breakoutable-columns query')))))))))))))
 
 (deftest ^:parallel unresolved-lib-field-with-temporal-bucket-test
   (let [query (lib/query-for-table-name meta/metadata-provider "CHECKINS")


### PR DESCRIPTION
Fixes #31368 (second part of the fix)

Logic for calculating existing `:breakout-position` in `breakoutable-columns` did not work correctly if the `:field` references from an existing query converted from legacy differed even slightly from the expected ones generated by MLv2... this was completely broken in legacy queries that had slightly different type info, or a different/missing join alias, or that used literal column string names instead of integer IDs. 

This is an overhaul to how we calculate whether something is selected or not.

Previously we looked at all the columns returned by `breakoutable-columns` and determined whether they matched existing `breakouts`, and, if so, gave them a `breakout-index`. The new fix here is to instead loop over all the `breakouts` and find the column from `breakoutable-columns` that most closely matches it, doing increasingly less-strict checks until we find the closest match. This way every existing breakout should have one match; it should be enough to work around completely busted references in busted legacy queries. 