### PR TITLE
[CI] Bump timeout in stress-test workflow

### DIFF
--- a/.github/workflows/e2e-stress-test-flake-fix.yml
+++ b/.github/workflows/e2e-stress-test-flake-fix.yml
@@ -19,7 +19,7 @@ on:
 jobs:
   stress-test-flake-fix:
     runs-on: ubuntu-22.04
-    timeout-minutes: 20
+    timeout-minutes: 60
     name: Stress test E2E flake fix
     env:
       DISPLAY: ""


### PR DESCRIPTION
Stress-testing a spec with a lot of tests can easily time out before 20 minutes mark. This commit is bumping that timeout to 60 minutes.

