### PR TITLE
i18n: permit both the singular and plural for field and metric

### DIFF
--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
 
   verify-i18n-files:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 15
     steps:
     - uses: actions/checkout@v3

--- a/src/metabase/automagic_dashboards/core.clj
+++ b/src/metabase/automagic_dashboards/core.clj
@@ -34,7 +34,7 @@
    [metabase.sync.analyze.classify :as classify]
    [metabase.util :as u]
    [metabase.util.date-2 :as u.date]
-   [metabase.util.i18n :as i18n :refer [deferred-tru trs tru]]
+   [metabase.util.i18n :as i18n :refer [deferred-tru trs tru deferred-trun]]
    [metabase.util.log :as log]
    [metabase.util.schema :as su]
    [ring.util.codec :as codec]
@@ -186,7 +186,7 @@
   (let [table (->> metric :table_id (t2/select-one Table :id))]
     {:entity       metric
      :full-name    (if (:id metric)
-                     (tru "{0} metric" (:name metric))
+                     (deferred-trun "{0} metric" "{0} metrics" (:name metric))
                      (:name metric))
      :short-name   (:name metric)
      :source       table
@@ -200,7 +200,7 @@
   [field]
   (let [table (field/table field)]
     {:entity       field
-     :full-name    (tru "{0} field" (:display_name field))
+     :full-name    (deferred-trun "{0} field" "{0} fields" (:display_name field))
      :short-name   (:display_name field)
      :source       table
      :database     (:db_id table)


### PR DESCRIPTION
This issue is discovered due to xgettext version 0.21 in Ubuntu 22.04, vs xgettext version 0.19.8.1 in Ubuntu 20.04.
See also https://savannah.gnu.org/bugs/?56919.

In addition, earlier this led me into discovering #31480 (fixed already).

### Before this PR

Running `./bin/i18n/update-translation-template` on Ubuntu 22.04 will fail with the following error:

```
msgcat: msgid '{0} field' is used without plural and with plural.
msgcat: msgid '{0} metric' is used without plural and with plural.
```

This is because `field` and `metric` are already being used in its plural and singular forms in the front-end code (e.g. in `frontend/src/metabase/models/components/ModelDetailPage/ModelSchemaDetails/ModelSchemaDetails.tsx`), but each is still used _only_ in its singular form in `src/metabase/automagic_dashboards/core.clj`. Hence, when `msgcat` attempts to combine the frontend and backend message catalogs, it complained with the above message.

### After this PR

Running `./bin/i18n/update-translation-template` on Ubuntu 22.04 will yield no error at all.

Looking at the combined message catalogs, as generated in `locales/metabase.pot`, the messages for `field` and `metric` are indeed correct!

```
#: frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx:24
#: metabase/automagic_dashboards/core.clj:193                                           
#, fuzzy, javascript-format
msgid "{0} metric"
msgid_plural "{0} metrics"
msgstr[0] ""

#: frontend/src/metabase/models/components/ModelDetailPage/ModelSchemaDetails/ModelSchemaDetails.tsx:37
#: metabase/automagic_dashboards/core.clj:207
#, fuzzy, javascript-format                                                             
msgid "{0} field"
msgid_plural "{0} fields"
msgstr[0] ""
```
