### PR TITLE
Temporarily comment out the v47.00-032 migration to get stats back online

### DIFF
--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -14846,13 +14846,13 @@ databaseChangeLog:
                   update report_dashboardcard set size_x = size_x - (floor(cast(size_x + col + 1 as decimal) / 4) - floor(cast(col + 1 as decimal) / 4)) where size_x <> 1;
                   update report_dashboardcard set col    = col - floor(cast(col + 1 as decimal) / 4);
 
-                  #- changeSet:
-                  #    id: v47.00-032
-                  #    author: qnkhuat
-                  #    comment: Added 0.47.0 - migrate dashboard grid size from 18 to 24 for revisions
-                  #    changes:
-                  #      - customChange:
-                  #          class: "metabase.db.custom_migrations.RevisionDashboardMigrateGridFrom18To24"
+  #- changeSet:
+  #    id: v47.00-032
+  #    author: qnkhuat
+  #    comment: Added 0.47.0 - migrate dashboard grid size from 18 to 24 for revisions
+  #    changes:
+  #      - customChange:
+  #          class: "metabase.db.custom_migrations.RevisionDashboardMigrateGridFrom18To24"
 
   - changeSet:
       id: v47.00-035

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -14846,13 +14846,13 @@ databaseChangeLog:
                   update report_dashboardcard set size_x = size_x - (floor(cast(size_x + col + 1 as decimal) / 4) - floor(cast(col + 1 as decimal) / 4)) where size_x <> 1;
                   update report_dashboardcard set col    = col - floor(cast(col + 1 as decimal) / 4);
 
-  - changeSet:
-      id: v47.00-032
-      author: qnkhuat
-      comment: Added 0.47.0 - migrate dashboard grid size from 18 to 24 for revisions
-      changes:
-        - customChange:
-            class: "metabase.db.custom_migrations.RevisionDashboardMigrateGridFrom18To24"
+                  #- changeSet:
+                  #    id: v47.00-032
+                  #    author: qnkhuat
+                  #    comment: Added 0.47.0 - migrate dashboard grid size from 18 to 24 for revisions
+                  #    changes:
+                  #      - customChange:
+                  #          class: "metabase.db.custom_migrations.RevisionDashboardMigrateGridFrom18To24"
 
   - changeSet:
       id: v47.00-035

--- a/test/metabase/db/custom_migrations_test.clj
+++ b/test/metabase/db/custom_migrations_test.clj
@@ -345,56 +345,56 @@
                 :row 18}]
               (t2/select-fn-vec #(select-keys % [:id :row]) :model/DashboardCard :dashboard_id dashboard-id)))))))
 
-(deftest migrate-dashboard-revision-grid-from-18-to-24-test
-  (impl/test-migrations ["v47.00-032" "v47.00-033"] [migrate!]
-    (let [{:keys [db-type ^javax.sql.DataSource data-source]} mdb.connection/*application-db*
-          migrate-down! (partial db.setup/migrate! db-type data-source :down)
-          user-id      (first (t2/insert-returning-pks! User {:first_name  "Howard"
-                                                              :last_name   "Hughes"
-                                                              :email       "howard@aircraft.com"
-                                                              :password    "superstrong"
-                                                              :date_joined :%now}))
+#_(deftest migrate-dashboard-revision-grid-from-18-to-24-test
+    (impl/test-migrations ["v47.00-032" "v47.00-033"] [migrate!]
+      (let [{:keys [db-type ^javax.sql.DataSource data-source]} mdb.connection/*application-db*
+            migrate-down! (partial db.setup/migrate! db-type data-source :down)
+            user-id      (first (t2/insert-returning-pks! User {:first_name  "Howard"
+                                                                :last_name   "Hughes"
+                                                                :email       "howard@aircraft.com"
+                                                                :password    "superstrong"
+                                                                :date_joined :%now}))
 
-          cards        [{:row 15 :col 0  :size_x 12 :size_y 8}
-                        {:row 7  :col 12 :size_x 6  :size_y 8}
-                        {:row 2  :col 5  :size_x 5  :size_y 3}
-                        {:row 25 :col 0  :size_x 7  :size_y 10}
-                        {:row 2  :col 0  :size_x 5  :size_y 3}
-                        {:row 7  :col 6  :size_x 6  :size_y 8}
-                        {:row 25 :col 7  :size_x 11 :size_y 10}
-                        {:row 7  :col 0  :size_x 6  :size_y 4}
-                        {:row 23 :col 0  :size_x 18 :size_y 2}
-                        {:row 5  :col 0  :size_x 18 :size_y 2}
-                        {:row 0  :col 0  :size_x 18 :size_y 2}
-                        ;; these 2 last cases is a specical case where the last card has (width, height) = (1, 1)
-                        ;; it's to test an edge case to make sure downgrade from 24 -> 18 does not remove this card
-                        {:row 36 :col 0  :size_x 17 :size_y 1}
-                        {:row 36 :col 17 :size_x 1  :size_y 1}]
-          revision-id (first (t2/insert-returning-pks! 'Revision
-                                                        {:object   {:cards cards}
-                                                         :model    "Dashboard"
-                                                         :model_id 1
-                                                         :user_id  user-id}))]
+            cards        [{:row 15 :col 0  :size_x 12 :size_y 8}
+                          {:row 7  :col 12 :size_x 6  :size_y 8}
+                          {:row 2  :col 5  :size_x 5  :size_y 3}
+                          {:row 25 :col 0  :size_x 7  :size_y 10}
+                          {:row 2  :col 0  :size_x 5  :size_y 3}
+                          {:row 7  :col 6  :size_x 6  :size_y 8}
+                          {:row 25 :col 7  :size_x 11 :size_y 10}
+                          {:row 7  :col 0  :size_x 6  :size_y 4}
+                          {:row 23 :col 0  :size_x 18 :size_y 2}
+                          {:row 5  :col 0  :size_x 18 :size_y 2}
+                          {:row 0  :col 0  :size_x 18 :size_y 2}
+                          ;; these 2 last cases is a specical case where the last card has (width, height) = (1, 1)
+                          ;; it's to test an edge case to make sure downgrade from 24 -> 18 does not remove this card
+                          {:row 36 :col 0  :size_x 17 :size_y 1}
+                          {:row 36 :col 17 :size_x 1  :size_y 1}]
+            revision-id (first (t2/insert-returning-pks! 'Revision
+                                                          {:object   {:cards cards}
+                                                           :model    "Dashboard"
+                                                           :model_id 1
+                                                           :user_id  user-id}))]
 
-      (migrate!)
-      (testing "forward migration migrate correclty"
-        (is (= [{:row 15 :col 0  :size_x 16 :size_y 8}
-                {:row 7  :col 16 :size_x 8  :size_y 8}
-                {:row 2  :col 7  :size_x 6  :size_y 3}
-                {:row 25 :col 0  :size_x 9  :size_y 10}
-                {:row 2  :col 0  :size_x 7  :size_y 3}
-                {:row 7  :col 8  :size_x 8  :size_y 8}
-                {:row 25 :col 9  :size_x 15 :size_y 10}
-                {:row 7  :col 0  :size_x 8  :size_y 4}
-                {:row 23 :col 0  :size_x 24 :size_y 2}
-                {:row 5  :col 0  :size_x 24 :size_y 2}
-                {:row 0  :col 0  :size_x 24 :size_y 2}
-                {:row 36 :col 0  :size_x 23 :size_y 1}
-                {:row 36 :col 23 :size_x 1  :size_y 1}]
-               (t2/select-one-fn (comp :cards :object) :model/Revision :id revision-id))))
-     (migrate-down! 46)
-     (testing "downgrade works correctly"
-      (is (= cards (t2/select-one-fn (comp :cards :object) :model/Revision :id revision-id)))))))
+        (migrate!)
+        (testing "forward migration migrate correclty"
+          (is (= [{:row 15 :col 0  :size_x 16 :size_y 8}
+                  {:row 7  :col 16 :size_x 8  :size_y 8}
+                  {:row 2  :col 7  :size_x 6  :size_y 3}
+                  {:row 25 :col 0  :size_x 9  :size_y 10}
+                  {:row 2  :col 0  :size_x 7  :size_y 3}
+                  {:row 7  :col 8  :size_x 8  :size_y 8}
+                  {:row 25 :col 9  :size_x 15 :size_y 10}
+                  {:row 7  :col 0  :size_x 8  :size_y 4}
+                  {:row 23 :col 0  :size_x 24 :size_y 2}
+                  {:row 5  :col 0  :size_x 24 :size_y 2}
+                  {:row 0  :col 0  :size_x 24 :size_y 2}
+                  {:row 36 :col 0  :size_x 23 :size_y 1}
+                  {:row 36 :col 23 :size_x 1  :size_y 1}]
+                 (t2/select-one-fn (comp :cards :object) :model/Revision :id revision-id))))
+       (migrate-down! 46)
+       (testing "downgrade works correctly"
+        (is (= cards (t2/select-one-fn (comp :cards :object) :model/Revision :id revision-id)))))))
 
 (defn two-cards-overlap? [box1 box2]
   (let [{col1    :col


### PR DESCRIPTION
We're having a failure on stats running the `v47.00-032` migration, temporarily comment this out so we could get stats up. Will fix this later

For more context, follow this  [thread](https://metaboat.slack.com/archives/C010ZSXQY87/p1686550709839729)(long)

Additional info, when start stats we're getting this stacktrace

This migration was introduced in https://github.com/metabase/metabase/pull/31019
<details>
  <summary>stacktrace</summary>
 ```
 # (out) {"exception_class":"liquibase.exception.LiquibaseException","exception_message":"liquibase.exception.MigrationFailedException: Migration failed for change set migrations/000_migrations.yaml::v47.00-032::qnkhuat:
# (out)      Reason: clojure.lang.ExceptionInfo: null {:toucan2/context-trace [["execute SQL with class com.mchange.v2.c3p0.impl.NewProxyConnection" {:toucan2.jdbc.query/sql-args ["SELECT * FROM \"revision\" WHERE \"model\" = ?" "Dashboard"]}] ["resolve connection" {:toucan2.connection/connectable metabase.db.connection.ApplicationDB}] ["resolve connection" {:toucan2.connection/connectable :default}] ["resolve connection" {:toucan2.connection/connectable nil}] {:toucan2.pipeline/rf #object[clojure.core$completing$fn__8528 0x4e63dc38 "clojure.core$completing$fn__8528@4e63dc38"]} ["with compiled query" {:toucan2.pipeline/compiled-query ["SELECT * FROM \"revision\" WHERE \"model\" = ?" "Dashboard"]}] ["with built query" {:toucan2.pipeline/built-query {:select [:*], :from [:revision], :where [:= :model "Dashboard"]}}] ["with resolved query" {:toucan2.pipeline/resolved-query {:select [:*], :from [:revision], :where [:= :model "Dashboard"]}}] ["with parsed args" {:toucan2.pipeline/query-type :toucan.result-type/*, :toucan2.pipeline/parsed-args {:connectable nil, :queryable {:select [:*], :from [:revision], :where [:= :model "Dashboard"]}}}] ["with model" {:toucan2.pipeline/model nil}]]}","stacktrace":"liquibase.exception.LiquibaseException: liquibase.exception.MigrationFailedException: Migration failed for change set migrations/000_migrations.yaml::v47.00-032::qnkhuat:
# (out)      Reason: clojure.lang.ExceptionInfo: null {:toucan2/context-trace [["execute SQL with class com.mchange.v2.c3p0.impl.NewProxyConnection" {:toucan2.jdbc.query/sql-args ["SELECT * FROM \"revision\" WHERE \"model\" = ?" "Dashboard"]}] ["resolve connection" {:toucan2.connection/connectable metabase.db.connection.ApplicationDB}] ["resolve connection" {:toucan2.connection/connectable :default}] ["resolve connection" {:toucan2.connection/connectable nil}] {:toucan2.pipeline/rf #object[clojure.core$completing$fn__8528 0x4e63dc38 "clojure.core$completing$fn__8528@4e63dc38"]} ["with compiled query" {:toucan2.pipeline/compiled-query ["SELECT * FROM \"revision\" WHERE \"model\" = ?" "Dashboard"]}] ["with built query" {:toucan2.pipeline/built-query {:select [:*], :from [:revision], :where [:= :model "Dashboard"]}}] ["with resolved query" {:toucan2.pipeline/resolved-query {:select [:*], :from [:revision], :where [:= :model "Dashboard"]}}] ["with parsed args" {:toucan2.pipeline/query-type :toucan.result-type/*, :toucan2.pipeline/parsed-args {:connectable nil, :queryable {:select [:*], :from [:revision], :where [:= :model "Dashboard"]}}}] ["with model" {:toucan2.pipeline/model nil}]]}
# (out) 	at liquibase.changelog.ChangeLogIterator.run(ChangeLogIterator.java:126)
# (out) 	at liquibase.Liquibase.lambda$null$0(Liquibase.java:265)
# (out) 	at liquibase.Scope.lambda$child$0(Scope.java:180)
# (out) 	at liquibase.Scope.child(Scope.java:189)
# (out) 	at liquibase.Scope.child(Scope.java:179)
# (out) 	at liquibase.Scope.child(Scope.java:158)
# (out) 	at liquibase.Scope.child(Scope.java:243)
# (out) 	at liquibase.Liquibase.lambda$update$1(Liquibase.java:264)
# (out) 	at liquibase.Scope.lambda$child$0(Scope.java:180)
# (out) 	at liquibase.Scope.child(Scope.java:189)
# (out) 	at liquibase.Scope.child(Scope.java:179)
# (out) 	at liquibase.Scope.child(Scope.java:158)
# (out) 	at liquibase.Liquibase.runInScope(Liquibase.java:2405)
# (out) 	at liquibase.Liquibase.update(Liquibase.java:211)
# (out) 	at liquibase.Liquibase.update(Liquibase.java:197)
# (out) 	at liquibase.Liquibase.update(Liquibase.java:193)
# (out) 	at metabase.db.liquibase$migrate_up_if_needed_BANG_.invokeStatic(liquibase.clj:147)
# (out) 	at metabase.db.setup$fn__56690$migrate_BANG___56695$fn__56696$fn__56697.invoke(setup.clj:80)
# (out) 	at metabase.db.liquibase$fn__50392$do_with_liquibase__50397$fn__50398.invoke(liquibase.clj:64)
# (out) 	at metabase.db.liquibase$fn__50392$do_with_liquibase__50397.invoke(liquibase.clj:56)
# (out) 	at metabase.db.setup$fn__56690$migrate_BANG___56695$fn__56696.invoke(setup.clj:74)
# (out) 	at metabase.db.setup$fn__56690$migrate_BANG___56695.doInvoke(setup.clj:52)
# (out) 	at clojure.lang.RestFn.invoke(RestFn.java:445)
# (out) 	at metabase.db.setup$fn__56754$run_schema_migrations_BANG___56759$fn__56760.invoke(setup.clj:132)
# (out) 	at metabase.db.setup$fn__56754$run_schema_migrations_BANG___56759.invoke(setup.clj:126)
# (out) 	at metabase.db.setup$fn__56807$setup_db_BANG___56812$fn__56813$fn__56816$fn__56817.invoke(setup.clj:157)
# (out) 	at metabase.util.jvm$do_with_us_locale.invokeStatic(jvm.clj:239)
# (out) 	at metabase.db.setup$fn__56807$setup_db_BANG___56812$fn__56813$fn__56816.invoke(setup.clj:152)
# (out) 	at metabase.db.setup$fn__56807$setup_db_BANG___56812$fn__56813.invoke(setup.clj:152)
# (out) 	at metabase.db.setup$fn__56807$setup_db_BANG___56812.invoke(setup.clj:146)
# (out) 	at metabase.db$setup_db_BANG_$fn__56842.invoke(db.clj:66)
# (out) 	at metabase.db$setup_db_BANG_.invokeStatic(db.clj:61)
# (out) 	at metabase.core$init_BANG__STAR_.invokeStatic(core.clj:112)
# (out) 	at metabase.core$init_BANG_.invokeStatic(core.clj:151)
# (out) 	at metabase.core$start_normally.invokeStatic(core.clj:163)
# (out) 	at metabase.core$_main.invokeStatic(core.clj:199)
# (out) 	at metabase.core$_main.doInvoke(core.clj:195)
# (out) 	at clojure.lang.RestFn.invoke(RestFn.java:397)
# (out) 	at clojure.lang.AFn.applyToHelper(AFn.java:152)
# (out) 	at clojure.lang.RestFn.applyTo(RestFn.java:132)
# (out) 	at clojure.lang.Var.applyTo(Var.java:705)
# (out) 	at clojure.core$apply.invokeStatic(core.clj:667)
# (out) 	at metabase.bootstrap$_main.invokeStatic(bootstrap.clj:28)
# (out) 	at metabase.bootstrap$_main.doInvoke(bootstrap.clj:28)
# (out) 	at clojure.lang.RestFn.invoke(RestFn.java:397)
# (out) 	at clojure.lang.AFn.applyToHelper(AFn.java:152)
# (out) 	at clojure.lang.RestFn.applyTo(RestFn.java:132)
# (out) 	at metabase.bootstrap.main(Unknown Source)
# (out) Caused by: liquibase.exception.MigrationFailedException: Migration failed for change set migrations/000_migrations.yaml::v47.00-032::qnkhuat:
# (out)      Reason: clojure.lang.ExceptionInfo: null {:toucan2/context-trace [["execute SQL with class com.mchange.v2.c3p0.impl.NewProxyConnection" {:toucan2.jdbc.query/sql-args ["SELECT * FROM \"revision\" WHERE \"model\" = ?" "Dashboard"]}] ["resolve connection" {:toucan2.connection/connectable metabase.db.connection.ApplicationDB}] ["resolve connection" {:toucan2.connection/connectable :default}] ["resolve connection" {:toucan2.connection/connectable nil}] {:toucan2.pipeline/rf #object[clojure.core$completing$fn__8528 0x4e63dc38 "clojure.core$completing$fn__8528@4e63dc38"]} ["with compiled query" {:toucan2.pipeline/compiled-query ["SELECT * FROM \"revision\" WHERE \"model\" = ?" "Dashboard"]}] ["with built query" {:toucan2.pipeline/built-query {:select [:*], :from [:revision], :where [:= :model "Dashboard"]}}] ["with resolved query" {:toucan2.pipeline/resolved-query {:select [:*], :from [:revision], :where [:= :model "Dashboard"]}}] ["with parsed args" {:toucan2.pipeline/query-type :toucan.result-type/*, :toucan2.pipeline/parsed-args {:connectable nil, :queryable {:select [:*], :from [:revision], :where [:= :model "Dashboard"]}}}] ["with model" {:toucan2.pipeline/model nil}]]}
# (out) 	at liquibase.changelog.ChangeSet.execute(ChangeSet.java:696)
# (out) 	at liquibase.changelog.visitor.UpdateVisitor.visit(UpdateVisitor.java:56)
# (out) 	at liquibase.changelog.ChangeLogIterator$2.lambda$null$0(ChangeLogIterator.java:113)
# (out) 	at liquibase.Scope.lambda$child$0(Scope.java:180)
# (out) 	at liquibase.Scope.child(Scope.java:189)
# (out) 	at liquibase.Scope.child(Scope.java:179)
# (out) 	at liquibase.Scope.child(Scope.java:158)
# (out) 	at liquibase.changelog.ChangeLogIterator$2.lambda$run$1(ChangeLogIterator.java:112)
# (out) 	at liquibase.Scope.lambda$child$0(Scope.java:180)
# (out) 	at liquibase.Scope.child(Scope.java:189)
# (out) 	at liquibase.Scope.child(Scope.java:179)
# (out) 	at liquibase.Scope.child(Scope.java:158)
# (out) 	at liquibase.Scope.child(Scope.java:243)
# (out) 	at liquibase.changelog.ChangeLogIterator$2.run(ChangeLogIterator.java:93)
# (out) 	at liquibase.Scope.lambda$child$0(Scope.java:180)
# (out) 	at liquibase.Scope.child(Scope.java:189)
# (out) 	at liquibase.Scope.child(Scope.java:179)
# (out) 	at liquibase.Scope.child(Scope.java:158)
# (out) 	at liquibase.Scope.child(Scope.java:243)
# (out) 	at liquibase.Scope.child(Scope.java:247)
# (out) 	at liquibase.changelog.ChangeLogIterator.run(ChangeLogIterator.java:65)
# (out) 	... 47 more
# (out) Caused by: clojure.lang.ExceptionInfo: null {:toucan2/context-trace [["execute SQL with class com.mchange.v2.c3p0.impl.NewProxyConnection" {:toucan2.jdbc.query/sql-args ["SELECT * FROM \"revision\" WHERE \"model\" = ?" "Dashboard"]}] ["resolve connection" {:toucan2.connection/connectable metabase.db.connection.ApplicationDB}] ["resolve connection" {:toucan2.connection/connectable :default}] ["resolve connection" {:toucan2.connection/connectable nil}] {:toucan2.pipeline/rf #object[clojure.core$completing$fn__8528 0x4e63dc38 "clojure.core$completing$fn__8528@4e63dc38"]} ["with compiled query" {:toucan2.pipeline/compiled-query ["SELECT * FROM \"revision\" WHERE \"model\" = ?" "Dashboard"]}] ["with built query" {:toucan2.pipeline/built-query {:select [:*], :from [:revision], :where [:= :model "Dashboard"]}}] ["with resolved query" {:toucan2.pipeline/resolved-query {:select [:*], :from [:revision], :where [:= :model "Dashboard"]}}] ["with parsed args" {:toucan2.pipeline/query-type :toucan.result-type/*, :toucan2.pipeline/parsed-args {:connectable nil, :queryable {:select [:*], :from [:revision], :where [:= :model "Dashboard"]}}}] ["with model" {:toucan2.pipeline/model nil}]]}
# (out) 	at clojure.lang.Numbers.ops(Numbers.java:1095)
# (out) 	at clojure.lang.Numbers.add(Numbers.java:155)
# (out) 	at metabase.db.custom_migrations$migrate_dashboard_grid_from_18_to_24.invokeStatic(custom_migrations.clj:361)
# (out) 	at metabase.db.custom_migrations$migrate_dashboard_grid_from_18_to_24.invoke(custom_migrations.clj:355)
# (out) 	at clojure.core$map$fn__5935.invoke(core.clj:2770)
# (out) 	at clojure.lang.LazySeq.sval(LazySeq.java:42)
# (out) 	at clojure.lang.LazySeq.seq(LazySeq.java:51)
# (out) 	at clojure.lang.RT.seq(RT.java:535)
# (out) 	at clojure.core$seq__5467.invokeStatic(core.clj:139)
# (out) 	at clojure.core.protocols$seq_reduce.invokeStatic(protocols.clj:24)
# (out) 	at clojure.core.protocols$fn__8236.invokeStatic(protocols.clj:75)
# (out) 	at clojure.core.protocols$fn__8236.invoke(protocols.clj:75)
# (out) 	at clojure.core.protocols$fn__8178$G__8173__8191.invoke(protocols.clj:13)
# (out) 	at clojure.core$reduce.invokeStatic(core.clj:6886)
# (out) 	at cheshire.generate$generate.invokeStatic(generate.clj:133)
# (out) 	at cheshire.generate$generate.invoke(generate.clj:119)
# (out) 	at cheshire.generate$generate$fn__4025.invoke(generate.clj:125)
# (out) 	at clojure.core.protocols$iter_reduce.invokeStatic(protocols.clj:49)
# (out) 	at clojure.core.protocols$fn__8230.invokeStatic(protocols.clj:75)
# (out) 	at clojure.core.protocols$fn__8230.invoke(protocols.clj:75)
# (out) 	at clojure.core.protocols$fn__8178$G__8173__8191.invoke(protocols.clj:13)
# (out) 	at clojure.core$reduce.invokeStatic(core.clj:6886)
# (out) 	at cheshire.generate$generate.invokeStatic(generate.clj:125)
# (out) 	at cheshire.core$generate_string.invokeStatic(core.clj:77)
# (out) 	at cheshire.core$generate_string.invoke(core.clj:49)
# (out) 	at cheshire.core$generate_string.invokeStatic(core.clj:55)
# (out) 	at metabase.db.custom_migrations.RevisionDashboardMigrateGridFrom18To24$migrate_BANG___56300.invoke(custom_migrations.clj:386)
# (out) 	at clojure.core$run_BANG_$fn__8880.invoke(core.clj:7783)
# (out) 	at toucan2.pipeline$with_init$fn__26620.invoke(pipeline.clj:367)
# (out) 	at clojure.core$completing$fn__8528.invoke(core.clj:6931)
# (out) 	at toucan2.jdbc.result_set$reduce_result_set.invokeStatic(result_set.clj:159)
# (out) 	at toucan2.jdbc.result_set$reduce_result_set.invoke(result_set.clj:126)
# (out) 	at toucan2.jdbc.query$reduce_jdbc_query.invokeStatic(query.clj:51)
# (out) 	at toucan2.jdbc.query$reduce_jdbc_query.invoke(query.clj:22)
# (out) 	at toucan2.query_execution_backend.jdbc$transduce_execute_with_connection_primary_method_java_sql_Connection_default_default.invokeStatic(jdbc.clj:21)
# (out) 	at toucan2.query_execution_backend.jdbc$transduce_execute_with_connection_primary_method_java_sql_Connection_default_default.invoke(jdbc.clj:11)
# (out) 	at clojure.lang.AFn.applyToHelper(AFn.java:178)
# (out) 	at clojure.lang.AFn.applyTo(AFn.java:144)
# (out) 	at clojure.lang.AFunction$1.doInvoke(AFunction.java:31)
# (out) 	at clojure.lang.RestFn.applyTo(RestFn.java:137)
# (out) 	at clojure.core$apply.invokeStatic(core.clj:675)
# (out) 	at clojure.core$partial$fn__5908.doInvoke(core.clj:2639)
# (out) 	at clojure.lang.RestFn.applyTo(RestFn.java:146)
# (out) 	at clojure.lang.AFunction$1.doInvoke(AFunction.java:31)
# (out) 	at clojure.lang.RestFn.applyTo(RestFn.java:137)
# (out) 	at clojure.core$apply.invokeStatic(core.clj:667)
# (out) 	at methodical.impl.combo.threaded$fn__21802$fn__21803$fn__21810.invoke(threaded.clj:78)
# (out) 	at methodical.impl.combo.threaded$reducer_fn$fn__21772$fn__21776.invoke(threaded.clj:23)
# (out) 	at clojure.lang.ArrayChunk.reduce(ArrayChunk.java:58)
# (out) 	at clojure.core.protocols$fn__8244.invokeStatic(protocols.clj:136)
# (out) 	at clojure.core.protocols$fn__8244.invoke(protocols.clj:124)
# (out) 	at clojure.core.protocols$fn__8204$G__8199__8213.invoke(protocols.clj:19)
# (out) 	at clojure.core.protocols$seq_reduce.invokeStatic(protocols.clj:31)
# (out) 	at clojure.core.protocols$fn__8236.invokeStatic(protocols.clj:75)
# (out) 	at clojure.core.protocols$fn__8236.invoke(protocols.clj:75)
# (out) 	at clojure.core.protocols$fn__8178$G__8173__8191.invoke(protocols.clj:13)
# (out) 	at clojure.core$reduce.invokeStatic(core.clj:6886)
# (out) 	at methodical.impl.combo.threaded$reducer_fn$fn__21772.invoke(threaded.clj:20)
# (out) 	at clojure.core$comp$fn__5876.doInvoke(core.clj:2589)
# (out) 	at clojure.lang.RestFn.applyTo(RestFn.java:146)
# (out) 	at clojure.core$apply.invokeStatic(core.clj:675)
# (out) 	at methodical.impl.combo.threaded$combine_with_threader$fn__21782.doInvoke(threaded.clj:40)
# (out) 	at clojure.lang.RestFn.applyTo(RestFn.java:151)
# (out) 	at clojure.lang.AFunction$1.doInvoke(AFunction.java:31)
# (out) 	at clojure.lang.RestFn.applyTo(RestFn.java:137)
# (out) 	at clojure.core$apply.invokeStatic(core.clj:675)
# (out) 	at methodical.impl.standard$invoke_multifn.invokeStatic(standard.clj:65)
# (out) 	at methodical.impl.standard.StandardMultiFn.invoke(standard.clj:69)
# (out) 	at toucan2.pipeline$transduce_execute$with_connection_STAR___26530.invoke(pipeline.clj:86)
# (out) 	at toucan2.connection$bind_current_connectable_fn$fn__26143.invoke(connection.clj:104)
# (out) 	at toucan2.connection$bind_current_connectable_fn$fn__26143.invoke(connection.clj:104)
# (out) 	at toucan2.connection$bind_current_connectable_fn$fn__26143.invoke(connection.clj:104)
# (out) 	at toucan2.connection$do_with_connection_primary_method_javax_sql_DataSource.invokeStatic(connection.clj:213)
# (out) 	at toucan2.connection$do_with_connection_primary_method_javax_sql_DataSource.invoke(connection.clj:210)
# (out) 	at clojure.lang.AFn.applyToHelper(AFn.java:160)
# (out) 	at clojure.lang.AFn.applyTo(AFn.java:144)
# (out) 	at clojure.lang.AFunction$1.doInvoke(AFunction.java:31)
# (out) 	at clojure.lang.RestFn.invoke(RestFn.java:436)
# (out) 	at clojure.core$partial$fn__5908.invoke(core.clj:2642)
# (out) 	at clojure.lang.AFn.applyToHelper(AFn.java:156)
# (out) 	at clojure.lang.RestFn.applyTo(RestFn.java:132)
# (out) 	at clojure.lang.AFunction$1.doInvoke(AFunction.java:31)
# (out) 	at clojure.lang.RestFn.invoke(RestFn.java:421)
# (out) 	at methodical.impl.combo.threaded$fn__21802$fn__21803$fn__21804.invoke(threaded.clj:70)
# (out) 	at methodical.impl.combo.threaded$reducer_fn$fn__21772$fn__21776.invoke(threaded.clj:23)
# (out) 	at clojure.lang.ArrayChunk.reduce(ArrayChunk.java:58)
# (out) 	at clojure.core.protocols$fn__8244.invokeStatic(protocols.clj:136)
# (out) 	at clojure.core.protocols$fn__8244.invoke(protocols.clj:124)
# (out) 	at clojure.core.protocols$fn__8204$G__8199__8213.invoke(protocols.clj:19)
# (out) 	at clojure.core.protocols$seq_reduce.invokeStatic(protocols.clj:31)
# (out) 	at clojure.core.protocols$fn__8236.invokeStatic(protocols.clj:75)
# (out) 	at clojure.core.protocols$fn__8236.invoke(protocols.clj:75)
# (out) 	at clojure.core.protocols$fn__8178$G__8173__8191.invoke(protocols.clj:13)
# (out) 	at clojure.core$reduce.invokeStatic(core.clj:6886)
# (out) 	at methodical.impl.combo.threaded$reducer_fn$fn__21772.invoke(threaded.clj:20)
# (out) 	at clojure.core$comp$fn__5876.invoke(core.clj:2 

```
</details>