### PR TITLE
Fix sandbox table migrations for invalid perms table

### DIFF
--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -14253,10 +14253,7 @@ databaseChangeLog:
             SET permission_id = (
               SELECT p.id
               FROM permissions p
-              JOIN (
-                SELECT id, db_id, schema
-                FROM metabase_table
-              ) t ON t.id = s.table_id
+              JOIN metabase_table t ON t.id = s.table_id
               WHERE
                 p.object LIKE CONCAT('/db/', t.db_id, '/schema/', t.schema, '/table/', s.table_id, '/query/segmented/')
                 AND p.group_id = s.group_id

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -14255,9 +14255,9 @@ databaseChangeLog:
               FROM permissions p
               WHERE
                 p.object LIKE CONCAT('/db/',
-                                     (SELECT t.db_id FROM metabase_tables t WHERE t.id = s.table_id),
+                                     (SELECT t.db_id FROM metabase_table t WHERE t.id = s.table_id),
                                      '/schema/',
-                                     (SELECT t.schema FROM metabase_tables t WHERE t.id = s.table_id),
+                                     (SELECT t.schema FROM metabase_table t WHERE t.id = s.table_id),
                                      '/table/',
                                      s.table_id,
                                      '/query/segmented/')

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -14254,13 +14254,13 @@ databaseChangeLog:
               SELECT p.id
               FROM permissions p
               WHERE
-                p.object LIKE CONCAT('/db/',
-                                     (SELECT t.db_id FROM metabase_table t WHERE t.id = s.table_id),
-                                     '/schema/',
-                                     (SELECT t.schema FROM metabase_table t WHERE t.id = s.table_id),
-                                     '/table/',
-                                     s.table_id,
-                                     '/query/segmented/')
+                p.object = CONCAT('/db/',
+                                  (SELECT t.db_id FROM metabase_table t WHERE t.id = s.table_id),
+                                  '/schema/',
+                                  (SELECT t.schema FROM metabase_table t WHERE t.id = s.table_id),
+                                  '/table/',
+                                  s.table_id,
+                                  '/query/segmented/')
                 AND p.group_id = s.group_id
               LIMIT 1
             )

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -14255,9 +14255,9 @@ databaseChangeLog:
               FROM permissions p
               WHERE
                 p.object LIKE CONCAT('/db/',
-                                     (SELECT t.db_id FROM tables t WHERE t.id = s.table_id),
+                                     (SELECT t.db_id FROM metabase_tables t WHERE t.id = s.table_id),
                                      '/schema/',
-                                     (SELECT t.schema FROM tables t WHERE t.id = s.table_id),
+                                     (SELECT t.schema FROM metabase_tables t WHERE t.id = s.table_id),
                                      '/table/',
                                      s.table_id,
                                      '/query/segmented/')

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -14245,21 +14245,21 @@ databaseChangeLog:
   - changeSet:
       id: v46.00-088
       author: noahmoss
-      comment: Added 0.46.5 -- backfill `permission_id` values in `sandboxes`. This is a fixed verison of v46.00-066
-               which has been removed, since it had a bug that blocked a customer from upgrading.
+      comment: Added 0.46.5 -- backfill `permission_id` values in `sandboxes`. This is a fixed version of v46.00-066
+               which has been removed since it had a bug that blocked a customer from upgrading.
       changes:
         - sql: >-
-            UPDATE sandboxes s
+            UPDATE sandboxes
             SET permission_id = (
-              SELECT p.id
-              FROM permissions p
-              JOIN metabase_table t ON t.id = s.table_id
+              SELECT permissions.id
+              FROM permissions
+              JOIN metabase_table ON metabase_table.id = sandboxes.table_id
               WHERE
-                p.object LIKE CONCAT('/db/', t.db_id, '/schema/', t.schema, '/table/', s.table_id, '/query/segmented/')
-                AND p.group_id = s.group_id
+                permissions.object LIKE CONCAT('/db/', metabase_table.db_id, '/schema/', metabase_table.schema, '/table/', sandboxes.table_id, '/query/segmented/')
+                AND permissions.group_id = sandboxes.group_id
               LIMIT 1
             )
-            WHERE permission_id is NULL;
+            WHERE permission_id IS NULL;
       rollback:
         # not required, new values added here do not need to be dropped
 

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -14245,18 +14245,21 @@ databaseChangeLog:
   - changeSet:
       id: v46.00-088
       author: noahmoss
-      comment: Added 0.46.5 -- backfill `permission_id` values in `sandboxes`. This is a fixed version of v46.00-066
-               which has been removed since it had a bug that blocked a customer from upgrading.
+      comment: Added 0.46.5 -- backfill `permission_id` values in `sandboxes`. This is a fixed verison of v46.00-066
+               which has been removed, since it had a bug that blocked a customer from upgrading.
       changes:
         - sql: >-
-            UPDATE sandboxes
+            UPDATE sandboxes s
             SET permission_id = (
-              SELECT permissions.id
-              FROM permissions
-              JOIN metabase_table ON metabase_table.id = sandboxes.table_id
+              SELECT p.id
+              FROM permissions p
+              JOIN (
+                SELECT id, db_id, schema
+                FROM metabase_table
+              ) t ON t.id = s.table_id
               WHERE
-                permissions.object LIKE CONCAT('/db/', metabase_table.db_id, '/schema/', metabase_table.schema, '/table/', sandboxes.table_id, '/query/segmented/')
-                AND permissions.group_id = sandboxes.group_id
+                p.object LIKE CONCAT('/db/', t.db_id, '/schema/', t.schema, '/table/', s.table_id, '/query/segmented/')
+                AND p.group_id = s.group_id
               LIMIT 1
             )
             WHERE permission_id IS NULL;

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -14158,33 +14158,6 @@ databaseChangeLog:
               remarks: The ID of the corresponding permissions path for this sandbox
 
   - changeSet:
-      id: v46.00-066
-      author: noahmoss
-      comment: Added 0.46.0 -- backfill `permission_id` values in `sandboxes`
-      changes:
-        - sql: >-
-            UPDATE sandboxes s
-            SET permission_id = (
-              SELECT id
-              FROM permissions p
-              WHERE
-                p.object LIKE CONCAT('%/table/', s.table_id, '/query/segmented/')
-                AND p.group_id = s.group_id
-            );
-      rollback:
-        # not required, new values added here are dropped in the rollback of v46.00-065
-
-  - changeSet:
-      id: v46.00-067
-      author: noahmoss
-      comment: Added 0.46.0 -- remove orphaned entries in `sandboxes`
-      changes:
-        - sql: >-
-            DELETE FROM sandboxes
-            WHERE permission_id IS NULL;
-      rollback: # not required, orphaned sandboxes should not be re-added to the DB
-
-  - changeSet:
       id: v46.00-070
       author: calherries
       comment: Added 0.46.0 - add entity_id column to action
@@ -14214,45 +14187,6 @@ databaseChangeLog:
             tableName: report_card
             columnName: updated_at
             newDataType: DATETIME
-
-  - changeSet:
-      id: v46.00-075
-      author: noahmoss
-      comment: Add foreign key constraint on sandboxes.permission_id
-      changes:
-        - addForeignKeyConstraint:
-            baseTableName: sandboxes
-            baseColumnNames: permission_id
-            referencedTableName: permissions
-            referencedColumnNames: id
-            constraintName: fk_sandboxes_ref_permissions
-            nullable: true
-      rollback:
-      # Not required because a rollback would drop the `permission_id` column anyway
-
-  - changeSet:
-      id: v46.00-076
-      author: noahmoss
-      comment: Remove foreign key constraint on sandboxes.permission_id
-      changes:
-        - dropForeignKeyConstraint:
-            baseTableName: sandboxes
-            constraintName: fk_sandboxes_ref_permissions
-      rollback:
-      # Not required because a rollback would drop the `permission_id` column anyway
-
-  - changeSet:
-      id: v46.00-077
-      author: noahmoss
-      comment: Add foreign key constraint on sandboxes.permission_id with the appropriate onDelete policy
-      changes:
-        - addForeignKeyConstraint:
-            baseTableName: sandboxes
-            baseColumnNames: permission_id
-            referencedTableName: permissions
-            referencedColumnNames: id
-            constraintName: fk_sandboxes_ref_permissions
-            onDelete: CASCADE
 
   - changeSet:
       id: v46.00-079
@@ -14307,6 +14241,50 @@ databaseChangeLog:
       changes:
         - customChange:
             class: "metabase.db.custom_migrations.DeleteAbandonmentEmailTask"
+
+  - changeSet:
+      id: v46.00-088
+      author: noahmoss
+      comment: Added 0.46.5 -- backfill `permission_id` values in `sandboxes`. This is a fixed verison of v46.00-066
+               which has been removed, since it had a bug that blocked a customer from upgrading.
+      changes:
+        - sql: >-
+            UPDATE sandboxes s
+            SET permission_id = (
+              SELECT p.id
+              FROM permissions p
+              JOIN metabase_table t ON t.id = s.table_id
+              WHERE
+                p.object LIKE CONCAT('/db/', t.db_id, '/schema/', t.schema, '/table/', s.table_id, '/query/segmented/')
+                AND p.group_id = s.group_id
+              LIMIT 1
+            )
+            WHERE permission_id is NULL;
+      rollback:
+        # not required, new values added here do not need to be dropped
+
+  - changeSet:
+      id: v46.00-089
+      author: noahmoss
+      comment: Added 0.46.5 -- remove orphaned entries in `sandboxes`
+      changes:
+        - sql: >-
+            DELETE FROM sandboxes
+            WHERE permission_id IS NULL;
+      rollback: # not required, orphaned sandboxes should not be re-added to the DB
+
+  - changeSet:
+      id: v46.00-090
+      author: noahmoss
+      comment: Add foreign key constraint on sandboxes.permission_id
+      changes:
+        - addForeignKeyConstraint:
+            baseTableName: sandboxes
+            baseColumnNames: permission_id
+            referencedTableName: permissions
+            referencedColumnNames: id
+            constraintName: fk_sandboxes_ref_permissions
+            onDelete: CASCADE
 
   - changeSet:
       id: v47.00-001

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -14253,9 +14253,14 @@ databaseChangeLog:
             SET permission_id = (
               SELECT p.id
               FROM permissions p
-              JOIN metabase_table t ON t.id = s.table_id
               WHERE
-                p.object LIKE CONCAT('/db/', t.db_id, '/schema/', t.schema, '/table/', s.table_id, '/query/segmented/')
+                p.object LIKE CONCAT('/db/',
+                                     (SELECT t.db_id FROM tables t WHERE t.id = s.table_id),
+                                     '/schema/',
+                                     (SELECT t.schema FROM tables t WHERE t.id = s.table_id),
+                                     '/table/',
+                                     s.table_id,
+                                     '/query/segmented/')
                 AND p.group_id = s.group_id
               LIMIT 1
             )

--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -14277,6 +14277,8 @@ databaseChangeLog:
       id: v46.00-090
       author: noahmoss
       comment: Add foreign key constraint on sandboxes.permission_id
+      # This is a revised version of a prior migration (v46.00-075) so it may fail due to the FK constriant already existing
+      failOnError: false
       changes:
         - addForeignKeyConstraint:
             baseTableName: sandboxes


### PR DESCRIPTION
Resolves https://github.com/metabase/metabase/issues/30872

I added a migration in 46 to add a new `permission_id` column to the `sandboxes` table and backfill it by looking for the permission path corresponding to each sandbox. However it assumed that only one permission path would exist for any given table ID, since table IDs should be distinct, even between databases.

At least one customer has an app DB that breaks this invariant, with permission paths that look like this:
* `/db/1/schema/PUBLIC/table/4/query/segmented/`
* `/db/1/schema//table/4/query/segmented/`

i.e. the same table ID, but one path with the schema and one path without it.

I'm still not sure how this would come about naturally—it may have been due to using the API to update permissions, and not having enough validation on the backend to error in this case. It doesn't seem to break anything though, aside from this particular migration. So I've removed the migration and rewritten it to match on the entire expected permission path. I've also removed & re-added a few subsequent migrations that depend on this one, so that they also run for this customer's instance. For all other instances, these should be no-ops, since they are fully idempotent.