### PR TITLE
Makes the grid migration for cards in revision safer by hanlding errors

### DIFF
--- a/resources/migrations/000_migrations.yaml
+++ b/resources/migrations/000_migrations.yaml
@@ -14850,6 +14850,7 @@ databaseChangeLog:
       id: v47.00-032
       author: qnkhuat
       comment: Added 0.47.0 - migrate dashboard grid size from 18 to 24 for revisions
+      validCheckSum: ANY
       changes:
         - customChange:
             class: "metabase.db.custom_migrations.RevisionDashboardMigrateGridFrom18To24"

--- a/src/metabase/db/custom_migrations.clj
+++ b/src/metabase/db/custom_migrations.clj
@@ -352,49 +352,72 @@
   (run! update-card-row-on-downgrade-for-dashboard-tab
         (eduction (map :dashboard_id) (t2/reducible-query {:select-distinct [:dashboard_id]
                                                            :from            [:dashboard_tab]}))))
+
+(defn- destructure-revision-card-sizes
+  "Perform the best effort to destructure card sizes in revision.
+  The card in revision contains legacy field name and maybe even lacking fields."
+  [card]
+  {:size_x (or (get card :size_x)
+               (get card :sizeX)
+               4)
+   :size_y (or (get card :size_y)
+               (get card :sizeY)
+               4)
+   :row    (or (get card :row) 0)
+   :col    (or (get card :col) 0)})
+
 (defn- migrate-dashboard-grid-from-18-to-24
   "Mirror of the forward algorithm we have in sql."
-  [{:keys [row col size_x size_y]}]
-  ;; new_size_x = size_x + ((col + size_x + 1) // 3) - ((col + 1) // 3)
-  ;; new_col = col + ((col + 1) // 3)
-  {:size_x (- (+ size_x
-                 (quot (+ col size_x 1) 3))
-              (quot (+ col 1) 3))
-   :col    (+ col (quot (+ col 1) 3))
-   :size_y size_y
-   :row    row})
+  [card]
+  (let [{:keys [row col size_x size_y]} (destructure-revision-card-sizes card)]
+    ;; new_size_x = size_x + ((col + size_x + 1) // 3) - ((col + 1) // 3)
+    ;; new_col = col + ((col + 1) // 3)
+    {:size_x (- (+ size_x
+                   (quot (+ col size_x 1) 3))
+                (quot (+ col 1) 3))
+     :col    (+ col (quot (+ col 1) 3))
+     :size_y size_y
+     :row    row}))
 
 (defn- migrate-dashboard-grid-from-24-to-18
   "Mirror of the rollback algorithm we have in sql."
-  [{:keys [row col size_x size_y]}]
-  ;; new_size_x = size_x - ((size_x + col + 1) // 4 - (col + 1) // 4)
-  ;; new_col = col - (col + 1) // 4
-  {:size_x (if (= size_x 1)
-             1
-             (- size_x
-               (-
-                (quot (+ size_x col 1) 4)
-                (quot (+ col 1) 4))))
-   :col    (- col (quot (+ col 1) 4))
-   :size_y size_y
-   :row    row})
+  [card]
+  (let [{:keys [row col size_x size_y]} (destructure-revision-card-sizes card)]
+    ;; new_size_x = size_x - ((size_x + col + 1) // 4 - (col + 1) // 4)
+    ;; new_col = col - (col + 1) // 4
+    {:size_x (if (= size_x 1)
+               1
+               (- size_x
+                  (-
+                   (quot (+ size_x col 1) 4)
+                   (quot (+ col 1) 4))))
+     :col    (- col (quot (+ col 1) 4))
+     :size_y size_y
+     :row    row}))
 
 (define-reversible-migration RevisionDashboardMigrateGridFrom18To24
   (let [migrate! (fn [revision]
                    (let [object (json/parse-string (:object revision) keyword)]
                      (when (seq (:cards object))
-                       (t2/query {:update :revision
-                                  :set {:object (json/generate-string (update object :cards #(map migrate-dashboard-grid-from-18-to-24 %)))}
-                                  :where [:= :id (:id revision)]}))))]
+                       (try
+                        (t2/query {:update :revision
+                                   :set {:object (json/generate-string (update object :cards #(map migrate-dashboard-grid-from-18-to-24 %)))}
+                                   :where [:= :id (:id revision)]})
+                        (catch Throwable
+                          _)))))]
+
     (run! migrate! (t2/reducible-query {:select [:*]
                                         :from   [:revision]
                                         :where  [:= :model "Dashboard"]})))
   (let [roll-back! (fn [revision]
                      (let [object (json/parse-string (:object revision) keyword)]
                        (when (seq (:cards object))
-                         (t2/query {:update :revision
-                                    :set {:object (json/generate-string (update object :cards #(map migrate-dashboard-grid-from-24-to-18 %)))}
-                                    :where [:= :id (:id revision)]}))))]
+                         (try
+                          (t2/query {:update :revision
+                                     :set {:object (json/generate-string (update object :cards #(map migrate-dashboard-grid-from-24-to-18 %)))}
+                                     :where [:= :id (:id revision)]})
+                          (catch Throwable
+                            _)))))]
     (run! roll-back! (t2/reducible-query {:select [:*]
                                           :from   [:revision]
                                           :where  [:= :model "Dashboard"]}))))


### PR DESCRIPTION
In [Dashboard grid from 18 to 24](https://github.com/metabase/metabase/pull/31019) we introduced the `v47.00-032` migration which will migrate grid sizes for cards in `revision` table.

One problem is that cards in revision can have legacy fields name or even be broken, here are some examples:
- sizeX, sizeY instead of size_x, size_y
- row, col can be nil

so I decided to make the migration safer and even put a try-catch around updating, this should be okay cause all we do is update revisions for dashboard. For failed cases, it's okay for us to let it be, cause those dashboards might not be frequently updated anyway.


For a longer context check out this [discussion](https://metaboat.slack.com/archives/C010ZSXQY87/p1686550709839729) on slack