### PR TITLE
Activate new tables at the end of database sync

### DIFF
--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -1175,7 +1175,7 @@ saved later when it is ready."
       (driver/drop-table driver db-id table-name)
       (throw (ex-info (tru "The CSV file was uploaded to {0}, but the table could not be created or found." schema+table-name)
                       {:status-code 422})))
-    (let [table (sync-tables/create-or-reactivate-table! database {:name table-name :schema actual-schema})]
+    (let [table (sync-tables/create-table! database {:name table-name :schema actual-schema})]
       (scan-and-sync-table! database table)
       (create-card!
        {:collection_id          collection-id,

--- a/src/metabase/api/notify.clj
+++ b/src/metabase/api/notify.clj
@@ -62,7 +62,7 @@
                                         {:schema schema_name :name table_name})
                                  table-in-db))
                              db-tables)]
-          (let [created (sync-tables/create-or-reactivate-table! database table)]
+          (let [created (sync-tables/create-table! database table)]
             (doto created
               sync/sync-table!
               sync-util/set-initial-table-sync-complete!))

--- a/src/metabase/sync/sync_metadata/tables.clj
+++ b/src/metabase/sync/sync_metadata/tables.clj
@@ -112,8 +112,6 @@
                                            ;; if this is a crufty table, mark initial sync as complete since we'll skip the subsequent sync steps
                                            :initial_sync_status (if is-crufty? "complete" "incomplete")))))
 
-;; TODO - should we make this logic case-insensitive like it is for fields?
-
 (s/defn ^:private create-tables-as-inactive!
   "Create NEW-TABLES for database. Tables have active=false."
   [database :- i/DatabaseInstance, new-tables :- [i/DatabaseMetadataTable]]
@@ -186,6 +184,7 @@
          [new-tables old-tables] (data/diff
                                   (strip-desc db-tables)
                                   (strip-desc our-metadata))
+         ;; TODO - should we make this logic case-insensitive like it is for fields?
          to-create-tables        (remove (fn [new-table]
                                            (contains? inactive-tables (select-keys new-table [:name :schema])))
                                          new-tables)

--- a/src/metabase/sync/sync_metadata/tables.clj
+++ b/src/metabase/sync/sync_metadata/tables.clj
@@ -221,7 +221,8 @@
       :total-tables   (count our-metadata)})))
 
 (defn activate-new-tables!
-  "Activate any tables that are currently inactive but are present in the db-metadata."
+  "Activate any tables that are currently inactive but are present in the db-metadata. These are either tables that have
+   just been created or were already existing and inactive."
   [database db-metadata]
   (let [db-tables             (strip-desc (table-set db-metadata))
         active-tables         (map (partial into {})

--- a/src/metabase/sync/sync_metadata/tables.clj
+++ b/src/metabase/sync/sync_metadata/tables.clj
@@ -227,14 +227,13 @@
     (t2/update! Table existing-id {:active true})))
 
 (defn activate-new-tables!
-  "Activate any tables that were newly created or previously inactive but are now present in the db-metadata."
+  "Activate any tables that are currently inactive but are present in the db-metadata."
   [database db-metadata]
   (let [db-tables    (table-set db-metadata)
         our-metadata (our-metadata database)
         [new-tables] (data/diff db-tables our-metadata)]
-    (when (seq new-tables)
-      (sync-util/with-error-handling (format "Error reactivating tables for %s"
-                                             (sync-util/name-for-logging database))
-        (doseq [table new-tables]
-          (activate-table! database table))))
+    (sync-util/with-error-handling (format "Error reactivating tables for %s"
+                                           (sync-util/name-for-logging database))
+      (doseq [table new-tables]
+        (activate-table! database table)))
     {:updated-tables new-tables}))

--- a/src/metabase/sync/sync_metadata/tables.clj
+++ b/src/metabase/sync/sync_metadata/tables.clj
@@ -176,7 +176,7 @@
   ([database :- i/DatabaseInstance db-metadata]
    ;; determine what's changed between what info we have and what's in the DB
    (let [db-tables               (table-set db-metadata)
-         our-metadata            (our-metadata database) ;; now includes active=true
+         our-metadata            (our-metadata database)
          inactive-tables         (set (map (partial into {})
                                            (t2/select [Table :name :schema]
                                                       :db_id  (u/the-id database)

--- a/src/metabase/sync/sync_metadata/tables.clj
+++ b/src/metabase/sync/sync_metadata/tables.clj
@@ -116,7 +116,7 @@
 
 (s/defn ^:private create-tables-as-inactive!
   "Create NEW-TABLES for database. Tables have active=false."
-  [database :- i/DatabaseInstance, new-tables :- #{i/DatabaseMetadataTable}]
+  [database :- i/DatabaseInstance, new-tables :- [i/DatabaseMetadataTable]]
   (log/info (trs "Found new tables:")
             (for [table new-tables]
               (sync-util/name-for-logging (mi/instance Table table))))
@@ -195,7 +195,7 @@
        (sync-util/with-error-handling (format "Error updating database metadata for %s"
                                               (sync-util/name-for-logging database))
          (update-database-metadata! database db-metadata)))
-     ;; create new tables as needed
+     ;; create new tables as needed. Set them to inactive until all their fields are synced
      (when (seq to-create-tables)
        (sync-util/with-error-handling (format "Error creating tables for %s"
                                               (sync-util/name-for-logging database))

--- a/test/metabase/sync/sync_metadata/tables_test.clj
+++ b/test/metabase/sync/sync_metadata/tables_test.clj
@@ -42,6 +42,15 @@
       (is (= {"Table 1" true, "Table 2" false, "Table 3" false}
              (t2/select-fn->fn :name :active Table, :db_id (u/the-id db)))))))
 
+(deftest activate-tables!-test
+  (testing "`activate-new-tables!` should activate tables that are currently inactive but in the DB metadata"
+    (mt/with-temp* [Database [db]
+                    Table    [_table-1 {:name "Table 1", :db_id (u/the-id db), :schema "Schema 1", :active true}]
+                    Table    [_table-2 {:name "Table 2", :db_id (u/the-id db), :schema "Schema 2", :active false}]]
+      (#'sync-tables/activate-new-tables! db {:tables #{{:name "Table 1", :schema "Schema 1"}
+                                                        {:name "Table 2", :schema "Schema 2"}}})
+      (is (= {"Table 1" true, "Table 2" true}
+             (t2/select-fn->fn :name :active Table, :db_id (u/the-id db)))))))
 
 (deftest retire-tables-test
   (testing "`retire-tables!` should retire the Table(s) passed to it, not all Tables in the DB -- see #9593"

--- a/test/metabase/sync/sync_metadata_test.clj
+++ b/test/metabase/sync/sync_metadata_test.clj
@@ -22,7 +22,8 @@
 
 (deftest survive-table-errors
   (testing "Make sure we survive table sync failing"
-    (sync-survives-crash? sync-tables/create-or-reactivate-tables!)
+    (sync-survives-crash? sync-tables/create-tables!)
+    (sync-survives-crash? sync-tables/activate-new-tables!)
     (sync-survives-crash? sync-tables/retire-tables!)
     (sync-survives-crash? sync-tables/update-table-description!)))
 

--- a/test/metabase/sync/sync_metadata_test.clj
+++ b/test/metabase/sync/sync_metadata_test.clj
@@ -22,7 +22,7 @@
 
 (deftest survive-table-errors
   (testing "Make sure we survive table sync failing"
-    (sync-survives-crash? sync-tables/create-tables!)
+    (sync-survives-crash? sync-tables/create-tables-as-inactive!)
     (sync-survives-crash? sync-tables/activate-new-tables!)
     (sync-survives-crash? sync-tables/retire-tables!)
     (sync-survives-crash? sync-tables/update-table-description!)))


### PR DESCRIPTION
Resolves https://github.com/metabase/metabase/issues/31082

This PR changes the sync steps in `metabase.sync.sync-metadata/make-sync-steps` that run when a database is sync'd, so that new and inactive tables are not activated until the end of the sync steps. This means that only after new tables and their fields are fully sync'd, the tables will finally show up in the app as active.

Summary of changes:
1) The `sync-tables-and-database!` now creates new tables with `active=false` instead of `active=true`, and doesn't activate existing tables by setting `active=true`.
2) There's a new step at the end of the sync, `activate-tables!` that activates newly created tables in step 1 and activates the existing tables that would have been activated previously in step 1.