### PR TITLE
Fix warnings about passing wrong attributes to DOM node

### DIFF
--- a/frontend/src/metabase/core/components/SelectButton/SelectButton.styled.tsx
+++ b/frontend/src/metabase/core/components/SelectButton/SelectButton.styled.tsx
@@ -1,4 +1,5 @@
 import styled from "@emotion/styled";
+import { ComponentPropsWithRef } from "react";
 import { color } from "metabase/lib/colors";
 import { Icon } from "metabase/core/components/Icon";
 import { space } from "metabase/styled-components/theme";
@@ -55,7 +56,15 @@ interface SelectButtonIconProps {
   highlighted: boolean;
 }
 
-export const SelectButtonIcon = styled(Icon)<SelectButtonIconProps>`
+export const SelectButtonIcon = styled(
+  ({
+    hasValue,
+    highlighted,
+    ...rest
+  }: SelectButtonIconProps & ComponentPropsWithRef<typeof Icon>) => (
+    <Icon {...rest} />
+  ),
+)`
   display: flex;
   margin-left: auto;
   color: ${({ hasValue, highlighted }) =>


### PR DESCRIPTION
Before:

<img width="977" alt="image" src="https://github.com/metabase/metabase/assets/125459446/d01ba90c-239f-40a0-85d9-f18d15c73350">
<img width="1055" alt="image" src="https://github.com/metabase/metabase/assets/125459446/d5ea7883-85b0-421e-a2d9-5741a11d6500">

After:
<img width="699" alt="image" src="https://github.com/metabase/metabase/assets/125459446/58e6d188-28b5-458a-a903-1a20cfbf07a0">
