### PR TITLE
Fix object detail view appearing up on every arrow key

### DIFF
--- a/e2e/test/scenarios/question/nulls.cy.spec.js
+++ b/e2e/test/scenarios/question/nulls.cy.spec.js
@@ -38,7 +38,7 @@ describe("scenarios > question > null", () => {
     cy.findByText("13571").click();
 
     cy.log("'No Results since at least v0.34.3");
-    cy.get("#detail-shortcut").click();
+    cy.findByTestId("detail-shortcut").click();
     cy.findByRole("dialog").within(() => {
       cy.findByText(/Discount/i);
       cy.findByText("Empty");

--- a/e2e/test/scenarios/visualizations/reproductions/30039-object-detail-navigation.cy.spec.js
+++ b/e2e/test/scenarios/visualizations/reproductions/30039-object-detail-navigation.cy.spec.js
@@ -1,0 +1,22 @@
+import { openNativeEditor, restore, runNativeQuery } from "e2e/support/helpers";
+
+describe("issue 30039", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsNormalUser();
+  });
+
+  it("should not trigger object detail navigation after the modal was closed (metabase#30039)", () => {
+    openNativeEditor().type("select * from ORDERS LIMIT 2");
+    runNativeQuery();
+    cy.findAllByTestId("detail-shortcut").first().click();
+    cy.findByTestId("object-detail").should("be.visible");
+
+    cy.realPress("{esc}");
+    cy.findByTestId("object-detail").should("not.exist");
+
+    cy.get("@editor").type("{downArrow};");
+    runNativeQuery();
+    cy.findByTestId("object-detail").should("not.exist");
+  });
+});

--- a/frontend/src/metabase/App.tsx
+++ b/frontend/src/metabase/App.tsx
@@ -1,8 +1,7 @@
-import { ReactNode, useState } from "react";
+import { ReactNode, useEffect, useState } from "react";
 import { connect } from "react-redux";
 import { Location } from "history";
 
-import { useMount } from "react-use";
 import ScrollToTop from "metabase/hoc/ScrollToTop";
 import {
   Archived,
@@ -91,9 +90,9 @@ function App({
 }: AppProps) {
   const [viewportElement, setViewportElement] = useState<HTMLElement | null>();
 
-  useMount(() => {
+  useEffect(() => {
     initializeIframeResizer();
-  });
+  }, []);
 
   return (
     <ErrorBoundary onError={onError}>

--- a/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterModal/BulkFilterFieldSearch.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterModal/BulkFilterFieldSearch.tsx
@@ -1,8 +1,6 @@
 import { useEffect, useState, useRef } from "react";
 import { t } from "ttag";
 
-import { useMount } from "react-use";
-
 import {
   SearchContainer,
   SearchInput,
@@ -19,7 +17,7 @@ export const FieldSearch = ({
   const [showSearch, setShowSearch] = useState(false);
   const inputRef = useRef<HTMLInputElement | null>(null);
 
-  useMount(() => {
+  useEffect(() => {
     const searchToggleListener = (e: KeyboardEvent) => {
       if ((e.ctrlKey || e.metaKey) && e.key === "k") {
         setShowSearch(true);
@@ -27,7 +25,7 @@ export const FieldSearch = ({
     };
     window.addEventListener("keydown", searchToggleListener);
     return () => window.removeEventListener("keydown", searchToggleListener);
-  });
+  }, []);
 
   const shouldClose = () => {
     const input = inputRef.current;

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
@@ -2,7 +2,7 @@ import { useEffect, useCallback, useState } from "react";
 import PropTypes from "prop-types";
 import { t } from "ttag";
 import cx from "classnames";
-import { usePrevious, useMount } from "react-use";
+import { usePrevious } from "react-use";
 
 import * as Urls from "metabase/lib/urls";
 import { useDispatch, useSelector } from "metabase/lib/redux";
@@ -213,12 +213,12 @@ function SavedQuestionLeftSide(props) {
 
   const [showSubHeader, setShowSubHeader] = useState(true);
 
-  useMount(() => {
+  useEffect(() => {
     const timerId = setTimeout(() => {
       setShowSubHeader(false);
     }, 4000);
     return () => clearTimeout(timerId);
-  });
+  }, []);
 
   const hasLastEditInfo = question.lastEditInfo() != null;
   const isDataset = question.isDataset();

--- a/frontend/src/metabase/query_builder/containers/QueryBuilder.jsx
+++ b/frontend/src/metabase/query_builder/containers/QueryBuilder.jsx
@@ -293,12 +293,12 @@ function QueryBuilder(props) {
 
   useMount(() => {
     initializeQB(location, params);
-  }, []);
+  });
 
-  useMount(() => {
+  useEffect(() => {
     window.addEventListener("resize", forceUpdateDebounced);
     return () => window.removeEventListener("resize", forceUpdateDebounced);
-  }, []);
+  });
 
   const isExistingModelDirty = useMemo(
     () => isModelQueryDirty || isMetadataDirty,

--- a/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetail.tsx
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetail.tsx
@@ -188,6 +188,10 @@ export function ObjectDetailView({
   });
 
   useEffect(() => {
+    if (hasNotFoundError) {
+      return;
+    }
+
     const onKeyDown = (event: KeyboardEvent) => {
       const capturedKeys: Record<string, () => void> = {
         ArrowUp: viewPreviousObjectDetail,
@@ -206,7 +210,12 @@ export function ObjectDetailView({
 
     window.addEventListener("keydown", onKeyDown, true);
     return () => window.removeEventListener("keydown", onKeyDown, true);
-  }, [viewPreviousObjectDetail, viewNextObjectDetail, closeObjectDetail]);
+  }, [
+    hasNotFoundError,
+    viewPreviousObjectDetail,
+    viewNextObjectDetail,
+    closeObjectDetail,
+  ]);
 
   useEffect(() => {
     if (maybeLoading && pkIndex !== undefined) {

--- a/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetail.tsx
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetail.tsx
@@ -3,7 +3,7 @@ import { connect } from "react-redux";
 import _ from "underscore";
 import { t } from "ttag";
 
-import { useMount, usePrevious } from "react-use";
+import { useMount, usePrevious, useUnmount } from "react-use";
 import { State } from "metabase-types/store";
 import type {
   ConcreteTableId,
@@ -186,10 +186,10 @@ export function ObjectDetailView({
       loadFKReferences();
     }
     window.addEventListener("keydown", onKeyDown, true);
+  });
 
-    return () => {
-      window.removeEventListener("keydown", onKeyDown, true);
-    };
+  useUnmount(() => {
+    window.removeEventListener("keydown", onKeyDown, true);
   });
 
   useEffect(() => {

--- a/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.jsx
+++ b/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.jsx
@@ -1137,7 +1137,6 @@ export default _.compose(
 
 const DetailShortcut = forwardRef((_props, ref) => (
   <div
-    id="detail-shortcut"
     className="TableInteractive-cellWrapper cursor-pointer"
     ref={ref}
     style={{
@@ -1148,6 +1147,7 @@ const DetailShortcut = forwardRef((_props, ref) => (
       width: SIDEBAR_WIDTH,
       zIndex: 3,
     }}
+    data-testid="detail-shortcut"
   >
     <Tooltip tooltip={t`View Details`}>
       <Button


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/30039
Caused by https://github.com/metabase/metabase/pull/28203

Fixes wrong usages of `useMount` hook where it was expected that the "cleanup" function is executed. 

How to verify:
- I'd suggest reverting the fix and running the e2e test; it should fail. The test should pass with the fix applied.

Before

<img width="1462" alt="Screenshot 2023-06-12 at 17 44 28" src="https://github.com/metabase/metabase/assets/8542534/96f6521f-cab1-4695-a8f7-3e8ccd0ef833">

After

<img width="1465" alt="Screenshot 2023-06-12 at 17 44 47" src="https://github.com/metabase/metabase/assets/8542534/acb0869c-4e55-4896-9bd6-0886215c2b77">
