### PR TITLE
yarn upgrade ace-builds

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -8884,9 +8884,9 @@ accepts@~1.3.8:
     negotiator "0.6.3"
 
 ace-builds@^1.4.13:
-  version "1.4.13"
-  resolved "https://registry.yarnpkg.com/ace-builds/-/ace-builds-1.4.13.tgz#186f42d3849ebcc6a48b93088a058489897514c1"
-  integrity sha512-SOLzdaQkY6ecPKYRDDg+MY1WoGgXA34cIvYJNNoBMGGUswHmlauU2Hy0UL96vW0Fs/LgFbMUjD+6vqzWTldIYQ==
+  version "1.22.1"
+  resolved "https://registry.yarnpkg.com/ace-builds/-/ace-builds-1.22.1.tgz#3d765d1cfffc79226e372b6353750fd997816154"
+  integrity sha512-o5RGTPBIiRxguWNors3pT6KuLqj0a2NvNLoqir7/2LLiFm34PJV3BMq4sl9kjPayo4+lmd99m6zAq+XPdhyHQA==
 
 acorn-globals@^7.0.0:
   version "7.0.1"


### PR DESCRIPTION
Closes #30144

### Description

Fixed upstream keyword typo in Ace editor lib: https://github.com/ajaxorg/ace/pull/5195

The diff is all that changed after running:

```
yarn upgrade ace-builds
```

### How to verify

1. If you don’t have a MySQL database, use [run-mariadb-latest.sh](https://github.com/metabase/dev-scripts/blob/master/run-mariadb-latest.sh) in dev-scripts.
2. New SQL Query
3. Type `group`
4. Verify `group_concat` is present and not `groupby_concat`

### Demo

<img width="614" alt="CleanShot 2023-06-12 at 12 44 44@2x" src="https://github.com/metabase/metabase/assets/116838/7505e8d2-93cf-4c4c-81e6-a59e4ed645f2">
