### PR TITLE
MLv2: Fix matching of field literals to field integer IDs (#31487)

### DIFF
--- a/shared/src/metabase/mbql/util.cljc
+++ b/shared/src/metabase/mbql/util.cljc
@@ -709,8 +709,7 @@
   considered relevant when comparing clauses for equality."
   [field-or-ref]
   (update-field-options field-or-ref (partial into {} (remove (fn [[k _]]
-                                                                (when (keyword? k)
-                                                                  (namespace k)))))))
+                                                                (qualified-keyword? k))))))
 
 (defn referenced-field-ids
   "Find all the `:field` references with integer IDs in `coll`, which can be a full MBQL query, a snippet of MBQL, or a

--- a/src/metabase/lib/aggregation.cljc
+++ b/src/metabase/lib/aggregation.cljc
@@ -347,6 +347,8 @@
                      (fn [cols]
                        (mapv (fn [col]
                                (let [a-ref (lib.ref/ref col)]
+                                 ;; FIXME: This should use [[lib.equality/find-closest-matching-ref]] instead.
+                                 #_{:clj-kondo/ignore [:deprecated-var]}
                                  (cond-> col
                                    (lib.equality/ref= a-ref agg-col)
                                    (assoc :selected? true))))

--- a/src/metabase/lib/equality.cljc
+++ b/src/metabase/lib/equality.cljc
@@ -2,9 +2,13 @@
   "Logic for determining whether two pMBQL queries are equal."
   (:refer-clojure :exclude [=])
   (:require
+   [medley.core :as m]
    [metabase.lib.dispatch :as lib.dispatch]
    [metabase.lib.hierarchy :as lib.hierarchy]
-   [metabase.lib.util :as lib.util]))
+   [metabase.lib.metadata :as lib.metadata]
+   [metabase.lib.options :as lib.options]
+   [metabase.lib.util :as lib.util]
+   [metabase.mbql.util.match :as mbql.u.match]))
 
 (defmulti =
   "Determine whether two already-normalized pMBQL maps, clauses, or other sorts of expressions are equal. The basic rule
@@ -83,15 +87,61 @@
 (defmethod = :default
   [x y]
   (cond
-    (map? x)                   ((get-method = :dispatch-type/map) x y)
-    (sequential? x)            ((get-method = :dispatch-type/sequential) x y)
-    :else                      (clojure.core/= x y)))
+    (map? x)        ((get-method = :dispatch-type/map) x y)
+    (sequential? x) ((get-method = :dispatch-type/sequential) x y)
+    :else           (clojure.core/= x y)))
 
-;;; TODO I think to field refs with different `:base-type`s but with other info the same should probably be considered
-;;; the same, right? Like if we improve type calculation it shouldn't break existing queries
-(defn ref=
-  "Are two refs `x` and `y` equal?"
+(defn ^:deprecated ref=
+  "Are two refs `x` and `y` equal?
+
+  DEPRECATED: use [[find-closest-matching-ref]] instead. This does not work if things like `:base-type` are missing or
+  differ slightly, or handle `:binning` correctly, let alone when things are broken more significantly. If we improve
+  type calculation it shouldn't break existing queries... right?"
   [x y]
   (or (= x y)
       (= (lib.util/with-default-effective-type x)
          (lib.util/with-default-effective-type y))))
+
+(defn- update-options-remove-namespaced-keys [a-ref]
+  (lib.options/update-options a-ref (fn [options]
+                                      (into {} (remove (fn [[k _v]] (qualified-keyword? k))) options))))
+
+(defn find-closest-matching-ref
+  "Find the ref that most closely matches `a-ref` from a sequence of `refs`. This is meant to power things
+  like [[metabase.lib.breakout/breakoutable-columns]] which are supposed to include `:breakout-position` for columns
+  that are already present as a breakout; sometimes the column in the breakout does not exactly match what MLv2 would
+  have generated. So try to figure out which column it is referring to.
+
+  This first looks for a matching ref with a strict comparison, then in increasingly less-strict comparisons until it
+  finds something that matches. This is mostly to work around bugs like #31482 where MLv1 generated queries with
+  `:field` refs that did not include join aliases even tho the Fields came from joined Tables... we still know the
+  Fields are the same if they have the same IDs.
+
+  The three-arity version can also find matches between integer Field ID references like `[:field {} 1]` and
+  equivalent string column name field literal references like `[:field {} \"bird_type\"]` by resolving Field IDs using
+  a `metadata-providerable` (something that can be treated as a metadata provider, e.g. a `query` with a
+  MetadataProvider associated with it). This is the ultimately hacky workaround for totally busted legacy queries.
+  Note that this currently only works when `a-ref` is the one with the integer Field ID and `refs` have string literal
+  column names; it does not work the other way around. Luckily we currently don't have problems with MLv1/legacy
+  queries accidentally using string :field literals where it shouldn't have been doing so."
+  ([a-ref refs]
+   (loop [xform identity, more-xforms [ ;; ignore irrelevant keys from :binning options
+                                       #(lib.options/update-options % m/update-existing :binning dissoc :metadata-fn :lib/type)
+                                       ;; ignore namespaced keys
+                                       update-options-remove-namespaced-keys
+                                       ;; ignore type info
+                                       #(lib.options/update-options % dissoc :base-type :effective-type)
+                                       ;; ignore join alias
+                                       #(lib.options/update-options % dissoc :join-alias)]]
+     (or (let [a-ref (xform a-ref)]
+           (m/find-first #(= (xform %) a-ref)
+                         refs))
+         (when (seq more-xforms)
+           (recur (comp xform (first more-xforms)) (rest more-xforms))))))
+
+  ([metadata-providerable a-ref refs]
+   (or (find-closest-matching-ref a-ref refs)
+       (mbql.u.match/match-one a-ref
+         [:field opts (field-id :guard integer?)]
+         (when-let [field-name (:name (lib.metadata/field metadata-providerable field-id))]
+           (find-closest-matching-ref [:field opts field-name] refs))))))

--- a/src/metabase/lib/field.cljc
+++ b/src/metabase/lib/field.cljc
@@ -492,6 +492,8 @@
                               (let [col-ref (lib.ref/ref column)]
                                 (boolean
                                  (some (fn [fields-ref]
+                                         ;; FIXME: This should use [[lib.equality/find-closest-matching-ref]] instead.
+                                         #_{:clj-kondo/ignore [:deprecated-var]}
                                          (lib.equality/ref= col-ref fields-ref))
                                        current-fields)))))]
      (mapv (fn [col]

--- a/src/metabase/lib/util.cljc
+++ b/src/metabase/lib/util.cljc
@@ -244,6 +244,11 @@
     (when (pos? stage-number)
       (dec stage-number))))
 
+(defn first-stage?
+  "Whether a `stage-number` is referring to the first stage of a query or not."
+  [query stage-number]
+  (not (previous-stage-number query stage-number)))
+
 (defn next-stage-number
   "The index of the next stage, if there is one. `nil` if there is no next stage."
   [{:keys [stages], :as _query} stage-number]

--- a/test/metabase/lib/breakout_test.cljc
+++ b/test/metabase/lib/breakout_test.cljc
@@ -466,3 +466,31 @@
                                      (lib/with-join-alias (lib/field "CATEGORIES" "ID") "Categories"))])
                                   (lib/with-join-fields [(lib/with-join-alias (lib/field "CATEGORIES" "NAME") "Categories")])))
                     lib/breakoutable-columns))))))
+
+(deftest ^:parallel breakoutable-columns-broken-ref-should-be-selected-test
+  (testing "Field refs that differ from what we return should still show up as selected if they refer to the same Field (#31482)"
+    (doseq [[message field-ref] {;; this ref is basically what we [[lib/breakout]] would have added but doesn't
+                                 ;; contain type info, shouldn't matter tho.
+                                 "correct ref but missing :base-type/:effective-type"
+                                 [:field {:lib/uuid (str (random-uuid)), :join-alias "Categories"} (meta/id :categories :name)]
+
+                                 ;; this is a busted Field ref, it's referring to a Field from a joined Table but
+                                 ;; does not include `:join-alias`. It should still work anyway.
+                                 "busted ref"
+                                 [:field {:lib/uuid (str (random-uuid))} (meta/id :categories :name)]}]
+      (testing (str \newline message " ref = " (pr-str field-ref))
+        (let [query (-> (lib/query meta/metadata-provider (meta/table-metadata :venues))
+                        (lib/join (-> (lib/join-clause
+                                       (meta/table-metadata :categories)
+                                       [(lib/=
+                                         (lib/field "VENUES" "CATEGORY_ID")
+                                         (lib/with-join-alias (lib/field "CATEGORIES" "ID") "Categories"))])
+                                      (lib/with-join-alias "Categories")
+                                      (lib/with-join-fields [(lib/with-join-alias (lib/field "CATEGORIES" "NAME") "Categories")])))
+                        (lib/breakout field-ref))]
+          (is (= [field-ref]
+                 (lib/breakouts query)))
+          (is (=? {:name              "NAME"
+                   :breakout-position 0}
+                  (m/find-first #(= (:id %) (meta/id :categories :name))
+                                (lib/breakoutable-columns query)))))))))

--- a/test/metabase/lib/equality_test.cljc
+++ b/test/metabase/lib/equality_test.cljc
@@ -4,6 +4,7 @@
    [clojure.test.check.generators :as gen]
    [malli.generator :as mg]
    [metabase.lib.equality :as lib.equality]
+   [metabase.lib.test-metadata :as meta]
    [metabase.util :as u]
    [metabase.util.malli.registry :as mr]))
 
@@ -183,3 +184,43 @@
           y (mg/generate schema {:seed seed})]
       (testing (str \newline (u/pprint-to-str (list `lib.equality/= (list 'quote x) (list 'quote y))))
         (is (lib.equality/= x y))))))
+
+(deftest ^:parallel find-closest-matching-ref-test
+  (are [a-ref refs expected] (= expected
+                                (lib.equality/find-closest-matching-ref a-ref refs))
+    ;; strict matching
+    [:field {} 1]
+    [[:field {} 1]
+     [:field {} 2]
+     [:field {} 3]]
+    [:field {} 1]
+
+    [:field {:base-type :type/Integer} 1]
+    [[:field {:base-type :type/Number} 1]
+     [:field {:base-type :type/Integer} 1]]
+    [:field {:base-type :type/Integer} 1]
+
+    [:field {:join-alias "J"} 1]
+    [[:field {:join-alias "I"} 1]
+     [:field {:join-alias "J"} 1]]
+    [:field {:join-alias "J"} 1]
+
+    ;; if no strict match, should ignore type info and return first match
+    [:field {:base-type :type/Float} 1]
+    [[:field {:base-type :type/Number} 1]
+     [:field {:base-type :type/Integer} 1]]
+    [:field {:base-type :type/Number} 1]
+
+    ;; if no exact match, ignore :join-alias
+    [:field {} 1]
+    [[:field {:join-alias "J"} 1]
+     [:field {:join-alias "J"} 2]]
+    [:field {:join-alias "J"} 1]))
+
+(deftest ^:parallel find-closest-matching-ref-3-arity-test
+  (is (= [:field {} "CATEGORY"]
+         (lib.equality/find-closest-matching-ref
+          meta/metadata-provider
+          [:field {} (meta/id :products :category)]
+          [[:field {} "ID"]
+           [:field {} "CATEGORY"]]))))

--- a/test/metabase/lib/field_test.cljc
+++ b/test/metabase/lib/field_test.cljc
@@ -160,7 +160,7 @@
 
                                   "Card with result metadata"
                                   (assoc card-def :result-metadata result-metadata)}]
-        (testing message
+        (testing (str \newline message)
           (let [metadata-provider (lib.metadata.composed-provider/composed-metadata-provider
                                    (lib.tu/mock-metadata-provider
                                     {:cards [card-def]})
@@ -618,4 +618,4 @@
             (-> (lib/query-for-table-name meta/metadata-provider "VENUES")
                 (lib/with-fields [(meta/field-metadata :venues :id)
                                   (meta/field-metadata :venues :name)])
-                lib/fieldable-columns )))))
+                lib/fieldable-columns)))))


### PR DESCRIPTION
Backport #31487 and [4fb1f3c](https://github.com/metabase/metabase/pull/31524/commits/4fb1f3c820341c36d03c01a25d4717a9694ac3ed) from the QP MLv2 breakouts branch to `master`