### PR TITLE
Migrate notebook aggregations to MLv2 — Operators (1)

### DIFF
--- a/e2e/test/scenarios/question/reproductions/20627-nested-long-names-wrong-aliases.cy.spec.js
+++ b/e2e/test/scenarios/question/reproductions/20627-nested-long-names-wrong-aliases.cy.spec.js
@@ -10,7 +10,7 @@ import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 
 const { ORDERS, PRODUCTS_ID } = SAMPLE_DATABASE;
 
-const newColumnName = "Product ID with a very long name";
+const foreignKeyColumnName = "Surprisingly long and awesome Product ID";
 const newTableName = "Products with a very long name";
 
 describe("issue 20627", () => {
@@ -18,7 +18,7 @@ describe("issue 20627", () => {
     restore();
     cy.signInAsAdmin();
 
-    renameColumn(ORDERS.PRODUCT_ID, newColumnName);
+    renameColumn(ORDERS.PRODUCT_ID, foreignKeyColumnName);
     renameTable(PRODUCTS_ID, newTableName);
   });
 
@@ -38,7 +38,7 @@ describe("issue 20627", () => {
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Pick a column to group by").click();
     popover().within(() => {
-      cy.contains(newTableName).click();
+      cy.findByText(newTableName).click();
 
       cy.findByText("Category").click();
     });

--- a/frontend/src/metabase-lib/aggregation.ts
+++ b/frontend/src/metabase-lib/aggregation.ts
@@ -5,6 +5,7 @@ import {
   aggregate as _aggregate,
   aggregations as _aggregations,
   aggregation_clause,
+  selected_aggregation_operators,
 } from "cljs/metabase.lib.aggregation";
 import type {
   AggregationClause,
@@ -13,11 +14,9 @@ import type {
   Query,
 } from "./types";
 
-const DEFAULT_STAGE_INDEX = -1;
-
 export function availableAggregationOperators(
   query: Query,
-  stageIndex = DEFAULT_STAGE_INDEX,
+  stageIndex: number,
 ): AggregationOperator[] {
   return to_array(available_aggregation_operators(query, stageIndex));
 }
@@ -28,18 +27,24 @@ export function aggregationOperatorColumns(
   return to_array(aggregation_operator_columns(operator));
 }
 
-declare function Aggregate(query: Query, clause: AggregationClause): Query;
-declare function Aggregate(
+export function selectedAggregationOperators(
+  operators: AggregationOperator[],
+  clause: AggregationClause,
+): AggregationOperator[] {
+  return to_array(selected_aggregation_operators(operators, clause));
+}
+
+export function aggregate(
   query: Query,
   stageIndex: number,
   clause: AggregationClause,
-): Query;
-
-export const aggregate: typeof Aggregate = _aggregate;
+): Query {
+  return _aggregate(query, stageIndex, clause);
+}
 
 export function aggregations(
   query: Query,
-  stageIndex = DEFAULT_STAGE_INDEX,
+  stageIndex: number,
 ): AggregationClause[] {
   return to_array(_aggregations(query, stageIndex));
 }

--- a/frontend/src/metabase-lib/aggregation.ts
+++ b/frontend/src/metabase-lib/aggregation.ts
@@ -1,0 +1,52 @@
+import { to_array } from "cljs/cljs.core";
+import {
+  available_aggregation_operators,
+  aggregation_operator_columns,
+  aggregate as _aggregate,
+  aggregations as _aggregations,
+  aggregation_clause,
+} from "cljs/metabase.lib.aggregation";
+import type {
+  AggregationClause,
+  AggregationOperator,
+  ColumnMetadata,
+  Query,
+} from "./types";
+
+const DEFAULT_STAGE_INDEX = -1;
+
+export function availableAggregationOperators(
+  query: Query,
+  stageIndex = DEFAULT_STAGE_INDEX,
+): AggregationOperator[] {
+  return to_array(available_aggregation_operators(query, stageIndex));
+}
+
+export function aggregationOperatorColumns(
+  operator: AggregationOperator,
+): ColumnMetadata[] {
+  return to_array(aggregation_operator_columns(operator));
+}
+
+declare function Aggregate(query: Query, clause: AggregationClause): Query;
+declare function Aggregate(
+  query: Query,
+  stageIndex: number,
+  clause: AggregationClause,
+): Query;
+
+export const aggregate: typeof Aggregate = _aggregate;
+
+export function aggregations(
+  query: Query,
+  stageIndex = DEFAULT_STAGE_INDEX,
+): AggregationClause[] {
+  return to_array(_aggregations(query, stageIndex));
+}
+
+export function aggregationClause(
+  operator: AggregationOperator,
+  column?: ColumnMetadata,
+): AggregationClause {
+  return aggregation_clause(operator, column);
+}

--- a/frontend/src/metabase-lib/aggregation.ts
+++ b/frontend/src/metabase-lib/aggregation.ts
@@ -1,12 +1,4 @@
-import { to_array } from "cljs/cljs.core";
-import {
-  available_aggregation_operators,
-  aggregation_operator_columns,
-  aggregate as _aggregate,
-  aggregations as _aggregations,
-  aggregation_clause,
-  selected_aggregation_operators,
-} from "cljs/metabase.lib.aggregation";
+import * as ML from "cljs/metabase.lib.js";
 import type {
   AggregationClause,
   AggregationOperator,
@@ -18,20 +10,20 @@ export function availableAggregationOperators(
   query: Query,
   stageIndex: number,
 ): AggregationOperator[] {
-  return to_array(available_aggregation_operators(query, stageIndex));
+  return ML.available_aggregation_operators(query, stageIndex);
 }
 
 export function aggregationOperatorColumns(
   operator: AggregationOperator,
 ): ColumnMetadata[] {
-  return to_array(aggregation_operator_columns(operator));
+  return ML.aggregation_operator_columns(operator);
 }
 
 export function selectedAggregationOperators(
   operators: AggregationOperator[],
   clause: AggregationClause,
 ): AggregationOperator[] {
-  return to_array(selected_aggregation_operators(operators, clause));
+  return ML.selected_aggregation_operators(operators, clause);
 }
 
 export function aggregate(
@@ -39,19 +31,19 @@ export function aggregate(
   stageIndex: number,
   clause: AggregationClause,
 ): Query {
-  return _aggregate(query, stageIndex, clause);
+  return ML.aggregate(query, stageIndex, clause);
 }
 
 export function aggregations(
   query: Query,
   stageIndex: number,
 ): AggregationClause[] {
-  return to_array(_aggregations(query, stageIndex));
+  return ML.aggregations(query, stageIndex);
 }
 
 export function aggregationClause(
   operator: AggregationOperator,
   column?: ColumnMetadata,
 ): AggregationClause {
-  return aggregation_clause(operator, column);
+  return ML.aggregation_clause(operator, column);
 }

--- a/frontend/src/metabase-lib/metadata.ts
+++ b/frontend/src/metabase-lib/metadata.ts
@@ -3,6 +3,10 @@ import * as ML_MetadataCalculation from "cljs/metabase.lib.metadata.calculation"
 import type { DatabaseId } from "metabase-types/api";
 import type Metadata from "./metadata/Metadata";
 import type {
+  AggregationClause,
+  AggregationClauseDisplayInfo,
+  AggregationOperator,
+  AggregationOperatorDisplayInfo,
   BreakoutClause,
   BreakoutClauseDisplayInfo,
   Bucket,
@@ -43,13 +47,23 @@ declare function DisplayInfoFn(
 declare function DisplayInfoFn(
   query: Query,
   stageIndex: number,
-  orderByClause: OrderByClause,
-): OrderByClauseDisplayInfo;
+  aggregationClause: AggregationClause,
+): AggregationClauseDisplayInfo;
+declare function DisplayInfoFn(
+  query: Query,
+  stageIndex: number,
+  aggregationOperator: AggregationOperator,
+): AggregationOperatorDisplayInfo;
 declare function DisplayInfoFn(
   query: Query,
   stageIndex: number,
   breakoutClause: BreakoutClause,
 ): BreakoutClauseDisplayInfo;
+declare function DisplayInfoFn(
+  query: Query,
+  stageIndex: number,
+  orderByClause: OrderByClause,
+): OrderByClauseDisplayInfo;
 declare function DisplayInfoFn(
   query: Query,
   stageIndex: number,

--- a/frontend/src/metabase-lib/queries/structured/Aggregation.ts
+++ b/frontend/src/metabase-lib/queries/structured/Aggregation.ts
@@ -251,7 +251,17 @@ export default class Aggregation extends MBQLClause {
    */
   dimension(): Dimension | null | undefined {
     if (this.isStandard() && this.length > 1) {
-      return this._query.parseFieldReference(this.getFieldReference());
+      const dimension = this._query.parseFieldReference(
+        this.getFieldReference(),
+      );
+      if (!dimension) {
+        return;
+      }
+      const field = dimension.field();
+      const isConcreteField = typeof field?.id === "number";
+      return isConcreteField
+        ? dimension.withoutOptions("base-type", "effective-type")
+        : dimension;
     }
   }
 

--- a/frontend/src/metabase-lib/queries/structured/Aggregation.ts
+++ b/frontend/src/metabase-lib/queries/structured/Aggregation.ts
@@ -254,14 +254,7 @@ export default class Aggregation extends MBQLClause {
       const dimension = this._query.parseFieldReference(
         this.getFieldReference(),
       );
-      if (!dimension) {
-        return;
-      }
-      const field = dimension.field();
-      const isConcreteField = typeof field?.id === "number";
-      return isConcreteField
-        ? dimension.withoutOptions("base-type", "effective-type")
-        : dimension;
+      return dimension?.getMLv1CompatibleDimension?.();
     }
   }
 

--- a/frontend/src/metabase-lib/test-helpers.ts
+++ b/frontend/src/metabase-lib/test-helpers.ts
@@ -103,9 +103,10 @@ export const findAggregationOperator = (
   query: ML.Query,
   operatorShortName: string,
 ) => {
-  const operators = ML.availableAggregationOperators(query);
+  const operators = ML.availableAggregationOperators(query, 0);
   const operator = operators.find(
-    operator => ML.displayInfo(query, operator).short === operatorShortName,
+    operator =>
+      ML.displayInfo(query, 0, operator).shortName === operatorShortName,
   );
   if (!operator) {
     throw new Error(`Could not find aggregation operator ${operatorShortName}`);

--- a/frontend/src/metabase-lib/test-helpers.ts
+++ b/frontend/src/metabase-lib/test-helpers.ts
@@ -98,3 +98,17 @@ export const findTemporalBucket = (
   }
   return bucket;
 };
+
+export const findAggregationOperator = (
+  query: ML.Query,
+  operatorShortName: string,
+) => {
+  const operators = ML.availableAggregationOperators(query);
+  const operator = operators.find(
+    operator => ML.displayInfo(query, operator).short === operatorShortName,
+  );
+  if (!operator) {
+    throw new Error(`Could not find aggregation operator ${operatorShortName}`);
+  }
+  return operator;
+};

--- a/frontend/src/metabase-lib/types.ts
+++ b/frontend/src/metabase-lib/types.ts
@@ -77,14 +77,17 @@ export type ColumnDisplayInfo = {
 
   breakoutPosition?: number;
   orderByPosition?: number;
+  selected?: boolean; // used in aggregations
 };
 
 export type AggregationOperatorDisplayInfo = {
   columnName: string;
   displayName: string;
   description: string;
-  short: string;
+  shortName: string;
   requiresColumn: boolean;
+
+  selected?: boolean;
 };
 
 export type ClauseDisplayInfo = Pick<

--- a/frontend/src/metabase-lib/types.ts
+++ b/frontend/src/metabase-lib/types.ts
@@ -16,6 +16,14 @@ export type CardMetadata = unknown & { _opaque: typeof CardMetadata };
 
 export type Limit = number | null;
 
+declare const AggregationClause: unique symbol;
+export type AggregationClause = unknown & { _opaque: typeof AggregationClause };
+
+declare const AggregationOperator: unique symbol;
+export type AggregationOperator = unknown & {
+  _opaque: typeof AggregationOperator;
+};
+
 declare const BreakoutClause: unique symbol;
 export type BreakoutClause = unknown & { _opaque: typeof BreakoutClause };
 
@@ -27,7 +35,7 @@ export type OrderByDirection = "asc" | "desc";
 declare const FilterClause: unique symbol;
 export type FilterClause = unknown & { _opaque: typeof FilterClause };
 
-export type Clause = BreakoutClause | OrderByClause | FilterClause;
+export type Clause = AggregationClause | BreakoutClause | FilterClause | OrderByClause;
 
 declare const ColumnMetadata: unique symbol;
 export type ColumnMetadata = unknown & { _opaque: typeof ColumnMetadata };
@@ -71,10 +79,20 @@ export type ColumnDisplayInfo = {
   orderByPosition?: number;
 };
 
+export type AggregationOperatorDisplayInfo = {
+  columnName: string;
+  displayName: string;
+  description: string;
+  short: string;
+  requiresField: boolean;
+};
+
 export type ClauseDisplayInfo = Pick<
   ColumnDisplayInfo,
   "name" | "displayName" | "longDisplayName" | "table"
 >;
+
+export type AggregationClauseDisplayInfo = ClauseDisplayInfo;
 
 export type BreakoutClauseDisplayInfo = ClauseDisplayInfo;
 

--- a/frontend/src/metabase-lib/types.ts
+++ b/frontend/src/metabase-lib/types.ts
@@ -84,7 +84,7 @@ export type AggregationOperatorDisplayInfo = {
   displayName: string;
   description: string;
   short: string;
-  requiresField: boolean;
+  requiresColumn: boolean;
 };
 
 export type ClauseDisplayInfo = Pick<

--- a/frontend/src/metabase-lib/types.ts
+++ b/frontend/src/metabase-lib/types.ts
@@ -35,7 +35,11 @@ export type OrderByDirection = "asc" | "desc";
 declare const FilterClause: unique symbol;
 export type FilterClause = unknown & { _opaque: typeof FilterClause };
 
-export type Clause = AggregationClause | BreakoutClause | FilterClause | OrderByClause;
+export type Clause =
+  | AggregationClause
+  | BreakoutClause
+  | FilterClause
+  | OrderByClause;
 
 declare const ColumnMetadata: unique symbol;
 export type ColumnMetadata = unknown & { _opaque: typeof ColumnMetadata };

--- a/frontend/src/metabase-lib/v2.ts
+++ b/frontend/src/metabase-lib/v2.ts
@@ -1,5 +1,6 @@
 // Note: only metabase-lib v2 exports should be added here
 
+export * from "./aggregation";
 export * from "./binning";
 export * from "./breakout";
 export * from "./column_types";

--- a/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.styled.tsx
+++ b/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.styled.tsx
@@ -1,0 +1,12 @@
+import styled from "@emotion/styled";
+
+export const InfoIconContainer = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  padding-right: 0.5rem;
+
+  opacity: 0.7;
+  cursor: pointer;
+`;

--- a/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.styled.tsx
+++ b/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.styled.tsx
@@ -1,4 +1,30 @@
 import styled from "@emotion/styled";
+import { color } from "metabase/lib/colors";
+
+export const ColumnPickerContainer = styled.div`
+  min-width: 300px;
+`;
+
+export const ColumnPickerHeaderContainer = styled.div`
+  display: flex;
+  align-items: center;
+  padding: 1rem 0.5rem;
+  border-bottom: 1px solid ${color("border")};
+  color: ${color("text-medium")};
+`;
+
+export const ColumnPickerHeaderTitleContainer = styled.a`
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+  gap: 0.5rem;
+`;
+
+export const ColumnPickerHeaderTitle = styled.span`
+  display: inline-block;
+  font-weight: 700;
+  font-size: 1.17em;
+`;
 
 export const InfoIconContainer = styled.div`
   display: flex;

--- a/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.tsx
+++ b/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.tsx
@@ -14,6 +14,7 @@ const DEFAULT_MAX_HEIGHT = 610;
 interface AggregationPickerProps {
   className?: string;
   query: Lib.Query;
+  stageIndex: number;
   operators: Lib.AggregationOperator[];
   maxHeight?: number;
   onSelect: (operator: Lib.AggregationClause) => void;
@@ -33,6 +34,7 @@ type Section = {
 export function AggregationPicker({
   className,
   query,
+  stageIndex,
   operators,
   maxHeight = DEFAULT_MAX_HEIGHT,
   onSelect,
@@ -49,13 +51,15 @@ export function AggregationPicker({
     if (hasOperators) {
       sections.push({
         name: t`Basic Metrics`,
-        items: operators.map(operator => getOperatorListItem(query, operator)),
+        items: operators.map(operator =>
+          getOperatorListItem(query, stageIndex, operator),
+        ),
         icon: "table2",
       });
     }
 
     return sections;
-  }, [query, operators]);
+  }, [query, stageIndex, operators]);
 
   const handleOperatorSelect = useCallback(
     (item: OperatorListItem) => {
@@ -89,6 +93,7 @@ export function AggregationPicker({
       <QueryColumnPicker
         className={className}
         query={query}
+        stageIndex={stageIndex}
         columnGroups={columnGroups}
         maxHeight={maxHeight}
         onSelect={handleColumnSelect}
@@ -129,9 +134,10 @@ function renderItemExtra(item: OperatorListItem) {
 
 function getOperatorListItem(
   query: Lib.Query,
+  stageIndex: number,
   operator: Lib.AggregationOperator,
 ): OperatorListItem {
-  const operatorInfo = Lib.displayInfo(query, operator);
+  const operatorInfo = Lib.displayInfo(query, stageIndex, operator);
   return {
     ...operatorInfo,
     operator,

--- a/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.tsx
+++ b/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.tsx
@@ -59,7 +59,7 @@ export function AggregationPicker({
 
   const handleOperatorSelect = useCallback(
     (item: OperatorListItem) => {
-      if (item.requiresField) {
+      if (item.requiresColumn) {
         setOperator(item.operator);
       } else {
         const clause = Lib.aggregationClause(item.operator);

--- a/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.tsx
+++ b/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { t } from "ttag";
 
 import AccordionList from "metabase/core/components/AccordionList";

--- a/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.tsx
+++ b/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.tsx
@@ -118,6 +118,7 @@ export function AggregationPicker({
           query={query}
           stageIndex={stageIndex}
           columnGroups={columnGroups}
+          hasTemporalBucketing
           maxHeight={maxHeight}
           checkIsColumnSelected={checkColumnSelected}
           onSelect={handleColumnSelect}

--- a/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.tsx
+++ b/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.tsx
@@ -1,0 +1,139 @@
+import React, { useCallback, useMemo, useState } from "react";
+import { t } from "ttag";
+
+import AccordionList from "metabase/core/components/AccordionList";
+import Icon from "metabase/components/Icon";
+
+import * as Lib from "metabase-lib";
+
+import QueryColumnPicker from "../QueryColumnPicker";
+import { InfoIconContainer } from "./AggregationPicker.styled";
+
+const DEFAULT_MAX_HEIGHT = 610;
+
+interface AggregationPickerProps {
+  className?: string;
+  query: Lib.Query;
+  operators: Lib.AggregationOperator[];
+  maxHeight?: number;
+  onSelect: (operator: Lib.AggregationClause) => void;
+  onClose?: () => void;
+}
+
+type OperatorListItem = Lib.AggregationOperatorDisplayInfo & {
+  operator: Lib.AggregationOperator;
+};
+
+type Section = {
+  name: string;
+  items: OperatorListItem[];
+  icon?: string;
+};
+
+export function AggregationPicker({
+  className,
+  query,
+  operators,
+  maxHeight = DEFAULT_MAX_HEIGHT,
+  onSelect,
+  onClose,
+}: AggregationPickerProps) {
+  const [operator, setOperator] = useState<Lib.AggregationOperator | null>(
+    null,
+  );
+
+  const sections = useMemo(() => {
+    const sections: Section[] = [];
+    const hasOperators = operators.length > 0;
+
+    if (hasOperators) {
+      sections.push({
+        name: t`Basic Metrics`,
+        items: operators.map(operator => getOperatorListItem(query, operator)),
+        icon: "table2",
+      });
+    }
+
+    return sections;
+  }, [query, operators]);
+
+  const handleOperatorSelect = useCallback(
+    (item: OperatorListItem) => {
+      if (item.requiresField) {
+        setOperator(item.operator);
+      } else {
+        const clause = Lib.aggregationClause(item.operator);
+        onSelect(clause);
+        onClose?.();
+      }
+    },
+    [onSelect, onClose],
+  );
+
+  const handleColumnSelect = useCallback(
+    (column: Lib.ColumnMetadata) => {
+      if (!operator) {
+        return;
+      }
+      const clause = Lib.aggregationClause(operator, column);
+      onSelect(clause);
+      onClose?.();
+    },
+    [operator, onSelect, onClose],
+  );
+
+  if (operator) {
+    const columns = Lib.aggregationOperatorColumns(operator);
+    const columnGroups = Lib.groupColumns(columns);
+    return (
+      <QueryColumnPicker
+        className={className}
+        query={query}
+        columnGroups={columnGroups}
+        maxHeight={maxHeight}
+        onSelect={handleColumnSelect}
+        onClose={onClose}
+      />
+    );
+  }
+
+  return (
+    <AccordionList
+      className={className}
+      sections={sections}
+      maxHeight={maxHeight}
+      alwaysExpanded={false}
+      onChange={handleOperatorSelect}
+      renderItemName={renderItemName}
+      renderItemDescription={omitItemDescription}
+      renderItemExtra={renderItemExtra}
+    />
+  );
+}
+
+function renderItemName(item: OperatorListItem) {
+  return item.displayName;
+}
+
+function omitItemDescription() {
+  return null;
+}
+
+function renderItemExtra(item: OperatorListItem) {
+  return (
+    <InfoIconContainer>
+      <Icon name="question" size={20} tooltip={item.description} />
+    </InfoIconContainer>
+  );
+}
+
+function getOperatorListItem(
+  query: Lib.Query,
+  operator: Lib.AggregationOperator,
+): OperatorListItem {
+  const operatorInfo = Lib.displayInfo(query, operator);
+  return {
+    ...operatorInfo,
+    operator,
+  };
+}

--- a/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.tsx
+++ b/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.tsx
@@ -2,7 +2,7 @@ import { useCallback, useMemo, useState } from "react";
 import { t } from "ttag";
 
 import AccordionList from "metabase/core/components/AccordionList";
-import Icon from "metabase/components/Icon";
+import { Icon } from "metabase/core/components/Icon";
 
 import * as Lib from "metabase-lib";
 

--- a/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.unit.spec.tsx
@@ -120,7 +120,7 @@ describe("AggregationPicker", () => {
 
       expect(getRecentClause()).toEqual(
         expect.objectContaining({
-          name: "avg_QUANTITY",
+          name: "avg",
           displayName: "Average of Quantity",
         }),
       );
@@ -135,7 +135,7 @@ describe("AggregationPicker", () => {
 
       expect(getRecentClause()).toEqual(
         expect.objectContaining({
-          name: "avg_RATING",
+          name: "avg",
           displayName: "Average of Rating",
         }),
       );
@@ -159,9 +159,10 @@ describe("AggregationPicker", () => {
         "aria-selected",
         "true",
       );
-      expect(
-        screen.getByRole("option", { name: "Discount" }),
-      ).not.toHaveAttribute("aria-selected");
+      expect(screen.getByRole("option", { name: "Discount" })).toHaveAttribute(
+        "aria-selected",
+        "false",
+      );
     });
 
     it("shouldn't list columns for column-less operators", () => {
@@ -185,7 +186,7 @@ describe("AggregationPicker", () => {
 
       expect(getRecentClause()).toEqual(
         expect.objectContaining({
-          name: "avg_QUANTITY",
+          name: "avg",
           displayName: "Average of Quantity",
         }),
       );
@@ -196,12 +197,12 @@ describe("AggregationPicker", () => {
         query: createQueryWithMaxAggregation(),
       });
 
-      userEvent.click(screen.getByText("Quantity"));
+      userEvent.click(screen.getByText("Discount"));
 
       expect(getRecentClause()).toEqual(
         expect.objectContaining({
-          name: "max_QUANTITY",
-          displayName: "Max of Quantity",
+          name: "max",
+          displayName: "Max of Discount",
         }),
       );
     });

--- a/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.unit.spec.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import userEvent from "@testing-library/user-event";
 import { render, screen, within } from "__support__/ui";
 import * as Lib from "metabase-lib";

--- a/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.unit.spec.tsx
@@ -6,19 +6,20 @@ import { createQuery } from "metabase-lib/test-helpers";
 import { AggregationPicker } from "./AggregationPicker";
 
 function setup({ query = createQuery() } = {}) {
-  const operators = Lib.availableAggregationOperators(query);
+  const operators = Lib.availableAggregationOperators(query, 0);
   const onSelect = jest.fn();
 
   function handleSelect(clause: Lib.AggregationClause) {
-    const nextQuery = Lib.aggregate(query, clause);
-    const aggregations = Lib.aggregations(nextQuery);
+    const nextQuery = Lib.aggregate(query, 0, clause);
+    const aggregations = Lib.aggregations(nextQuery, 0);
     const recentAggregation = aggregations[aggregations.length - 1];
-    onSelect(Lib.displayInfo(nextQuery, recentAggregation));
+    onSelect(Lib.displayInfo(nextQuery, 0, recentAggregation));
   }
 
   render(
     <AggregationPicker
       query={query}
+      stageIndex={0}
       operators={operators}
       onSelect={handleSelect}
     />,

--- a/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.unit.spec.tsx
@@ -1,0 +1,113 @@
+import React from "react";
+import userEvent from "@testing-library/user-event";
+import { render, screen, within } from "__support__/ui";
+import * as Lib from "metabase-lib";
+import { createQuery } from "metabase-lib/test-helpers";
+import { AggregationPicker } from "./AggregationPicker";
+
+function setup({ query = createQuery() } = {}) {
+  const operators = Lib.availableAggregationOperators(query);
+  const onSelect = jest.fn();
+
+  function handleSelect(clause: Lib.AggregationClause) {
+    const nextQuery = Lib.aggregate(query, clause);
+    const aggregations = Lib.aggregations(nextQuery);
+    const recentAggregation = aggregations[aggregations.length - 1];
+    onSelect(Lib.displayInfo(nextQuery, recentAggregation));
+  }
+
+  render(
+    <AggregationPicker
+      query={query}
+      operators={operators}
+      onSelect={handleSelect}
+    />,
+  );
+
+  function getRecentClause() {
+    const [lastCall] = onSelect.mock.calls.slice(-1);
+    return lastCall?.[0];
+  }
+
+  return { getRecentClause };
+}
+
+describe("AggregationPicker", () => {
+  describe("basic operators", () => {
+    it("should list basic operators", () => {
+      setup();
+
+      expect(screen.getByText("Basic Metrics")).toBeInTheDocument();
+
+      [
+        "Count of rows",
+        "Sum of ...",
+        "Average of ...",
+        "Number of distinct values of ...",
+        "Cumulative sum of ...",
+        "Cumulative count of rows",
+        "Standard deviation of ...",
+        "Minimum of ...",
+        "Maximum of ...",
+      ].forEach(name => {
+        expect(screen.getByRole("option", { name })).toBeInTheDocument();
+      });
+    });
+
+    it("should show operator descriptions", () => {
+      setup();
+
+      const sumOfOption = screen.getByRole("option", { name: "Sum of ..." });
+      const infoIcon = within(sumOfOption).getByRole("img", {
+        name: "question icon",
+      });
+      userEvent.hover(infoIcon);
+
+      expect(screen.getByRole("tooltip")).toHaveTextContent(
+        "Sum of all the values of a column",
+      );
+    });
+
+    it("should apply a column-less operator", () => {
+      const { getRecentClause } = setup();
+
+      userEvent.click(screen.getByText("Count of rows"));
+
+      expect(getRecentClause()).toEqual(
+        expect.objectContaining({
+          name: "count",
+          displayName: "Count",
+        }),
+      );
+    });
+
+    it("should apply an operator requiring columns", () => {
+      const { getRecentClause } = setup();
+
+      userEvent.click(screen.getByText("Average of ..."));
+      userEvent.click(screen.getByText("Quantity"));
+
+      expect(getRecentClause()).toEqual(
+        expect.objectContaining({
+          name: "avg_QUANTITY",
+          displayName: "Average of Quantity",
+        }),
+      );
+    });
+
+    it("should allow picking a foreign column", () => {
+      const { getRecentClause } = setup();
+
+      userEvent.click(screen.getByText("Average of ..."));
+      userEvent.click(screen.getByText("Product"));
+      userEvent.click(screen.getByText("Rating"));
+
+      expect(getRecentClause()).toEqual(
+        expect.objectContaining({
+          name: "avg_RATING",
+          displayName: "Average of Rating",
+        }),
+      );
+    });
+  });
+});

--- a/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.unit.spec.tsx
@@ -2,11 +2,42 @@ import React from "react";
 import userEvent from "@testing-library/user-event";
 import { render, screen, within } from "__support__/ui";
 import * as Lib from "metabase-lib";
-import { createQuery } from "metabase-lib/test-helpers";
+import {
+  createQuery,
+  columnFinder,
+  findAggregationOperator,
+} from "metabase-lib/test-helpers";
 import { AggregationPicker } from "./AggregationPicker";
 
+function createQueryWithCountAggregation() {
+  const initialQuery = createQuery();
+  const count = findAggregationOperator(initialQuery, "count");
+  const clause = Lib.aggregationClause(count);
+  return Lib.aggregate(initialQuery, 0, clause);
+}
+
+function createQueryWithMaxAggregation() {
+  const initialQuery = createQuery();
+  const max = findAggregationOperator(initialQuery, "max");
+  const findColumn = columnFinder(
+    initialQuery,
+    Lib.aggregationOperatorColumns(max),
+  );
+  const quantity = findColumn("ORDERS", "QUANTITY");
+  const clause = Lib.aggregationClause(max, quantity);
+  return Lib.aggregate(initialQuery, 0, clause);
+}
+
 function setup({ query = createQuery() } = {}) {
-  const operators = Lib.availableAggregationOperators(query, 0);
+  const clause = Lib.aggregations(query, 0)[0];
+
+  const operators = clause
+    ? Lib.selectedAggregationOperators(
+        Lib.availableAggregationOperators(query, 0),
+        clause,
+      )
+    : Lib.availableAggregationOperators(query, 0);
+
   const onSelect = jest.fn();
 
   function handleSelect(clause: Lib.AggregationClause) {
@@ -107,6 +138,71 @@ describe("AggregationPicker", () => {
         expect.objectContaining({
           name: "avg_RATING",
           displayName: "Average of Rating",
+        }),
+      );
+    });
+
+    it("should highlight selected operator", () => {
+      setup({ query: createQueryWithCountAggregation() });
+
+      expect(
+        screen.getByRole("option", { name: "Count of rows" }),
+      ).toHaveAttribute("aria-selected", "true");
+      expect(
+        screen.getByRole("option", { name: "Sum of ..." }),
+      ).not.toHaveAttribute("aria-selected");
+    });
+
+    it("should highlight selected operator column", () => {
+      setup({ query: createQueryWithMaxAggregation() });
+
+      expect(screen.getByRole("option", { name: "Quantity" })).toHaveAttribute(
+        "aria-selected",
+        "true",
+      );
+      expect(
+        screen.getByRole("option", { name: "Discount" }),
+      ).not.toHaveAttribute("aria-selected");
+    });
+
+    it("shouldn't list columns for column-less operators", () => {
+      setup();
+
+      userEvent.click(screen.getByText("Count of rows"));
+
+      expect(screen.queryByText("Quantity")).not.toBeInTheDocument();
+      // check that we're still in the same step
+      expect(screen.getByText("Average of ...")).toBeInTheDocument();
+    });
+
+    it("should allow to change an operator for existing aggregation", () => {
+      const { getRecentClause } = setup({
+        query: createQueryWithMaxAggregation(),
+      });
+
+      userEvent.click(screen.getByText("Maximum of ...")); // go back
+      userEvent.click(screen.getByText("Average of ..."));
+      userEvent.click(screen.getByText("Quantity"));
+
+      expect(getRecentClause()).toEqual(
+        expect.objectContaining({
+          name: "avg_QUANTITY",
+          displayName: "Average of Quantity",
+        }),
+      );
+    });
+
+    it("should allow to change a column for existing aggregation", () => {
+      const { getRecentClause } = setup({
+        query: createQueryWithMaxAggregation(),
+      });
+
+      userEvent.click(screen.getByText("Quantity"));
+
+      expect(getRecentClause()).toEqual(
+        expect.objectContaining({
+          name: "max_QUANTITY",
+          displayName: "Max of Quantity",
         }),
       );
     });

--- a/frontend/src/metabase/common/components/AggregationPicker/index.ts
+++ b/frontend/src/metabase/common/components/AggregationPicker/index.ts
@@ -1,0 +1,1 @@
+export * from "./AggregationPicker";

--- a/frontend/src/metabase/query_builder/components/AggregationPopover/AggregationPopover.jsx
+++ b/frontend/src/metabase/query_builder/components/AggregationPopover/AggregationPopover.jsx
@@ -24,6 +24,9 @@ const CUSTOM_SECTION_NAME = t`Custom Expression`;
 
 const COMMON_AGGREGATIONS = new Set(["count"]);
 
+/**
+ * @deprecated use MLv2 + metabase/common/components/AggregationPicker
+ */
 export default class AggregationPopover extends Component {
   constructor(props, context) {
     super(props, context);

--- a/frontend/src/metabase/query_builder/components/notebook/NotebookStep/steps.ts
+++ b/frontend/src/metabase/query_builder/components/notebook/NotebookStep/steps.ts
@@ -8,7 +8,7 @@ import DataStep from "../steps/DataStep";
 import JoinStep from "../steps/JoinStep";
 import ExpressionStep from "../steps/ExpressionStep";
 import FilterStep from "../steps/FilterStep";
-import AggregateStep from "../steps/AggregateStep";
+import { AggregateStep } from "../steps/AggregateStep";
 import BreakoutStep from "../steps/BreakoutStep";
 import SummarizeStep from "../steps/SummarizeStep";
 import SortStep from "../steps/SortStep";

--- a/frontend/src/metabase/query_builder/components/notebook/steps/AggregateStep/AggregateStep.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/AggregateStep/AggregateStep.styled.tsx
@@ -1,0 +1,7 @@
+import styled from "@emotion/styled";
+import { AggregationPicker as BaseAggregationPicker } from "metabase/common/components/AggregationPicker";
+import { color } from "metabase/lib/colors";
+
+export const AggregationPicker = styled(BaseAggregationPicker)`
+  color: ${color("summarize")};
+`;

--- a/frontend/src/metabase/query_builder/components/notebook/steps/AggregateStep/AggregateStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/AggregateStep/AggregateStep.tsx
@@ -3,8 +3,8 @@ import { t } from "ttag";
 import AggregationPopover from "metabase/query_builder/components/AggregationPopover";
 
 import type { Aggregation as IAggregation } from "metabase-types/api";
-import type { NotebookStepUiComponentProps } from "../types";
-import ClauseStep from "./ClauseStep";
+import type { NotebookStepUiComponentProps } from "../../types";
+import ClauseStep from "../ClauseStep";
 
 const aggTetherOptions = {
   attachment: "top left",
@@ -18,7 +18,7 @@ const aggTetherOptions = {
   ],
 };
 
-function AggregateStep({
+export function AggregateStep({
   color,
   query,
   updateQuery,
@@ -51,6 +51,3 @@ function AggregateStep({
     />
   );
 }
-
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export default AggregateStep;

--- a/frontend/src/metabase/query_builder/components/notebook/steps/AggregateStep/AggregateStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/AggregateStep/AggregateStep.tsx
@@ -74,7 +74,11 @@ export function AggregateStep({
         <AggregationPicker
           query={topLevelQuery}
           stageIndex={stageIndex}
-          operators={operators}
+          operators={
+            aggregation
+              ? Lib.selectedAggregationOperators(operators, aggregation)
+              : operators
+          }
           onSelect={newAggregation => {
             const isUpdate = aggregation != null;
             if (isUpdate) {

--- a/frontend/src/metabase/query_builder/components/notebook/steps/AggregateStep/AggregateStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/AggregateStep/AggregateStep.tsx
@@ -54,12 +54,12 @@ export function AggregateStep({
   };
 
   const handleRemoveAggregation = (aggregation: Lib.AggregationClause) => {
-    const nextQuery = Lib.removeClause(topLevelQuery, aggregation);
+    const nextQuery = Lib.removeClause(topLevelQuery, stageIndex, aggregation);
     updateQuery(nextQuery);
   };
 
   const renderAggregationName = (aggregation: Lib.AggregationClause) =>
-    Lib.displayInfo(topLevelQuery, aggregation).displayName;
+    Lib.displayInfo(topLevelQuery, stageIndex, aggregation).displayName;
 
   return (
     <ClauseStep
@@ -73,6 +73,7 @@ export function AggregateStep({
       renderPopover={aggregation => (
         <AggregationPicker
           query={topLevelQuery}
+          stageIndex={stageIndex}
           operators={operators}
           onSelect={newAggregation => {
             const isUpdate = aggregation != null;

--- a/frontend/src/metabase/query_builder/components/notebook/steps/AggregateStep/AggregateStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/AggregateStep/AggregateStep.tsx
@@ -59,7 +59,7 @@ export function AggregateStep({
   };
 
   const renderAggregationName = (aggregation: Lib.AggregationClause) =>
-    Lib.displayInfo(topLevelQuery, stageIndex, aggregation).displayName;
+    Lib.displayInfo(topLevelQuery, stageIndex, aggregation).longDisplayName;
 
   return (
     <ClauseStep

--- a/frontend/src/metabase/query_builder/components/notebook/steps/AggregateStep/AggregateStep.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/AggregateStep/AggregateStep.unit.spec.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import userEvent from "@testing-library/user-event";
 import { render, screen, getIcon } from "__support__/ui";
 import * as Lib from "metabase-lib";

--- a/frontend/src/metabase/query_builder/components/notebook/steps/AggregateStep/AggregateStep.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/AggregateStep/AggregateStep.unit.spec.tsx
@@ -1,0 +1,116 @@
+import React from "react";
+import userEvent from "@testing-library/user-event";
+import { render, screen, getIcon } from "__support__/ui";
+import * as Lib from "metabase-lib";
+import {
+  createQuery,
+  columnFinder,
+  findAggregationOperator,
+} from "metabase-lib/test-helpers";
+import { createMockNotebookStep } from "../../test-utils";
+import { AggregateStep } from "./AggregateStep";
+
+function createAggregatedQuery() {
+  const initialQuery = createQuery();
+  const average = findAggregationOperator(initialQuery, "avg");
+  const findColumn = columnFinder(
+    initialQuery,
+    Lib.aggregationOperatorColumns(average),
+  );
+  const quantity = findColumn("ORDERS", "QUANTITY");
+  const clause = Lib.aggregationClause(average, quantity);
+  return Lib.aggregate(initialQuery, clause);
+}
+
+function setup(step = createMockNotebookStep()) {
+  const updateQuery = jest.fn();
+
+  render(
+    <AggregateStep
+      step={step}
+      query={step.query}
+      topLevelQuery={step.topLevelQuery}
+      color="summarize"
+      isLastOpened={false}
+      reportTimezone="UTC"
+      updateQuery={updateQuery}
+    />,
+  );
+
+  function getNextQuery() {
+    const [lastCall] = updateQuery.mock.calls.slice(-1);
+    return lastCall[0];
+  }
+
+  function getRecentAggregationClause() {
+    const query = getNextQuery();
+    const [clause] = Lib.aggregations(query);
+    return Lib.displayInfo(query, clause);
+  }
+
+  return {
+    getNextQuery,
+    getRecentAggregationClause,
+    updateQuery,
+  };
+}
+
+describe("AggregateStep", () => {
+  it("should render correctly without an aggregation", () => {
+    setup();
+    expect(
+      screen.getByText("Pick the metric you want to see"),
+    ).toBeInTheDocument();
+  });
+
+  it("should render correctly with an aggregation", () => {
+    setup(createMockNotebookStep({ topLevelQuery: createAggregatedQuery() }));
+    expect(screen.getByText("Average of Quantity")).toBeInTheDocument();
+  });
+
+  it("should add an aggregation with a basic operator", () => {
+    const { getRecentAggregationClause } = setup();
+
+    userEvent.click(screen.getByText("Pick the metric you want to see"));
+    userEvent.click(screen.getByText("Average of ..."));
+    userEvent.click(screen.getByText("Quantity"));
+
+    const clause = getRecentAggregationClause();
+    expect(clause).toEqual(
+      expect.objectContaining({
+        name: "avg_QUANTITY",
+        displayName: "Average of Quantity",
+      }),
+    );
+  });
+
+  it("should change an aggregation operator", () => {
+    const { getNextQuery, getRecentAggregationClause } = setup(
+      createMockNotebookStep({ topLevelQuery: createAggregatedQuery() }),
+    );
+
+    userEvent.click(screen.getByText("Average of Quantity"));
+    userEvent.click(screen.getByText("Count of rows"));
+
+    const nextQuery = getNextQuery();
+    const clause = getRecentAggregationClause();
+    expect(Lib.aggregations(nextQuery)).toHaveLength(1);
+    expect(clause).toEqual(
+      expect.objectContaining({
+        name: "count",
+        displayName: "Count",
+      }),
+    );
+  });
+
+  it("should remove an aggregation", () => {
+    const { getNextQuery } = setup(
+      createMockNotebookStep({ topLevelQuery: createAggregatedQuery() }),
+    );
+
+    userEvent.click(getIcon("close"));
+
+    const nextQuery = getNextQuery();
+    expect(Lib.aggregations(nextQuery)).toHaveLength(0);
+  });
+});

--- a/frontend/src/metabase/query_builder/components/notebook/steps/AggregateStep/AggregateStep.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/AggregateStep/AggregateStep.unit.spec.tsx
@@ -92,7 +92,7 @@ describe("AggregateStep", () => {
     const clause = getRecentAggregationClause();
     expect(clause).toEqual(
       expect.objectContaining({
-        name: "avg_QUANTITY",
+        name: "avg",
         displayName: "Average of Quantity",
       }),
     );
@@ -131,7 +131,7 @@ describe("AggregateStep", () => {
     expect(Lib.aggregations(nextQuery, 0)).toHaveLength(1);
     expect(clause).toEqual(
       expect.objectContaining({
-        name: "avg_TOTAL",
+        name: "avg",
         displayName: "Average of Total",
       }),
     );

--- a/frontend/src/metabase/query_builder/components/notebook/steps/AggregateStep/AggregateStep.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/AggregateStep/AggregateStep.unit.spec.tsx
@@ -19,7 +19,7 @@ function createAggregatedQuery() {
   );
   const quantity = findColumn("ORDERS", "QUANTITY");
   const clause = Lib.aggregationClause(average, quantity);
-  return Lib.aggregate(initialQuery, clause);
+  return Lib.aggregate(initialQuery, 0, clause);
 }
 
 function setup(step = createMockNotebookStep()) {
@@ -44,8 +44,8 @@ function setup(step = createMockNotebookStep()) {
 
   function getRecentAggregationClause() {
     const query = getNextQuery();
-    const [clause] = Lib.aggregations(query);
-    return Lib.displayInfo(query, clause);
+    const [clause] = Lib.aggregations(query, 0);
+    return Lib.displayInfo(query, 0, clause);
   }
 
   return {
@@ -94,7 +94,7 @@ describe("AggregateStep", () => {
 
     const nextQuery = getNextQuery();
     const clause = getRecentAggregationClause();
-    expect(Lib.aggregations(nextQuery)).toHaveLength(1);
+    expect(Lib.aggregations(nextQuery, 0)).toHaveLength(1);
     expect(clause).toEqual(
       expect.objectContaining({
         name: "count",
@@ -111,6 +111,6 @@ describe("AggregateStep", () => {
     userEvent.click(getIcon("close"));
 
     const nextQuery = getNextQuery();
-    expect(Lib.aggregations(nextQuery)).toHaveLength(0);
+    expect(Lib.aggregations(nextQuery, 0)).toHaveLength(0);
   });
 });

--- a/frontend/src/metabase/query_builder/components/notebook/steps/AggregateStep/AggregateStep.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/AggregateStep/AggregateStep.unit.spec.tsx
@@ -10,14 +10,17 @@ import {
 import { createMockNotebookStep } from "../../test-utils";
 import { AggregateStep } from "./AggregateStep";
 
-function createAggregatedQuery() {
+function createAggregatedQuery({
+  table = "ORDERS",
+  column = "QUANTITY",
+}: { table?: string; column?: string } = {}) {
   const initialQuery = createQuery();
   const average = findAggregationOperator(initialQuery, "avg");
   const findColumn = columnFinder(
     initialQuery,
     Lib.aggregationOperatorColumns(average),
   );
-  const quantity = findColumn("ORDERS", "QUANTITY");
+  const quantity = findColumn(table, column);
   const clause = Lib.aggregationClause(average, quantity);
   return Lib.aggregate(initialQuery, 0, clause);
 }
@@ -66,6 +69,18 @@ describe("AggregateStep", () => {
   it("should render correctly with an aggregation", () => {
     setup(createMockNotebookStep({ topLevelQuery: createAggregatedQuery() }));
     expect(screen.getByText("Average of Quantity")).toBeInTheDocument();
+  });
+
+  it("should use foreign key name for foreign table columns", () => {
+    setup(
+      createMockNotebookStep({
+        topLevelQuery: createAggregatedQuery({
+          table: "PRODUCTS",
+          column: "RATING",
+        }),
+      }),
+    );
+    expect(screen.getByText("Average of Product → Rating")).toBeInTheDocument();
   });
 
   it("should add an aggregation with a basic operator", () => {

--- a/frontend/src/metabase/query_builder/components/notebook/steps/AggregateStep/AggregateStep.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/AggregateStep/AggregateStep.unit.spec.tsx
@@ -90,6 +90,7 @@ describe("AggregateStep", () => {
     );
 
     userEvent.click(screen.getByText("Average of Quantity"));
+    userEvent.click(screen.getByText("Average of ...")); // go back to operator selection
     userEvent.click(screen.getByText("Count of rows"));
 
     const nextQuery = getNextQuery();
@@ -99,6 +100,25 @@ describe("AggregateStep", () => {
       expect.objectContaining({
         name: "count",
         displayName: "Count",
+      }),
+    );
+  });
+
+  it("should change an aggregation column", () => {
+    const { getNextQuery, getRecentAggregationClause } = setup(
+      createMockNotebookStep({ topLevelQuery: createAggregatedQuery() }),
+    );
+
+    userEvent.click(screen.getByText("Average of Quantity"));
+    userEvent.click(screen.getByText("Total"));
+
+    const nextQuery = getNextQuery();
+    const clause = getRecentAggregationClause();
+    expect(Lib.aggregations(nextQuery, 0)).toHaveLength(1);
+    expect(clause).toEqual(
+      expect.objectContaining({
+        name: "avg_TOTAL",
+        displayName: "Average of Total",
       }),
     );
   });

--- a/frontend/src/metabase/query_builder/components/notebook/steps/AggregateStep/index.ts
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/AggregateStep/index.ts
@@ -1,0 +1,1 @@
+export * from "./AggregateStep";

--- a/frontend/src/metabase/query_builder/components/notebook/steps/SummarizeStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/SummarizeStep.tsx
@@ -1,7 +1,7 @@
 import { t } from "ttag";
 
 import type { NotebookStepUiComponentProps } from "../types";
-import AggregateStep from "./AggregateStep";
+import { AggregateStep } from "./AggregateStep";
 import BreakoutStep from "./BreakoutStep";
 import { StepContainer, StepLabel, StepRoot } from "./SummarizeStep.styled";
 


### PR DESCRIPTION
Part of #31001

Adds TypeScript wrappers for MLv2 aggregation functions and _partially_ migrates notebook's `AggregateStep` to MLv2.
This is the first step in this migration, and it only migrates common operators like count, average, max, min, etc

> **Warning**
> This PR targets a feature branch and doesn't migrate `AggregateStep` features 1:1
> This branch is expected to have failing tests because parts of functionality are simply missing
> You can monitor the migration health with the last branch in the chain — #31530

Also, there's a known BE issue that temporal columns are not highlighted as selected — #31555

### To Verify

For different kinds of questions (structured/native, based on raw data/models/questions, flat/multi-stage):

1. Open `/question/:id/notebook`
2. Play around with the aggregation step ("Pick the metric you want to see")
3. Try out different column types (real/computed, with/without binning, with/without temporal bucketing)
4. Overall ensure the behavior matches `master`

### Demo

https://github.com/metabase/metabase/assets/17258145/21d4d939-5e09-480a-b399-323aad377f99
