### PR TITLE
Migrate notebook aggregations to MLv2 — Metrics (2)

### DIFF
--- a/frontend/src/metabase-lib/aggregation.ts
+++ b/frontend/src/metabase-lib/aggregation.ts
@@ -3,6 +3,7 @@ import type {
   AggregationClause,
   AggregationOperator,
   ColumnMetadata,
+  MetricMetadata,
   Query,
 } from "./types";
 
@@ -29,7 +30,7 @@ export function selectedAggregationOperators(
 export function aggregate(
   query: Query,
   stageIndex: number,
-  clause: AggregationClause,
+  clause: AggregationClause | MetricMetadata,
 ): Query {
   return ML.aggregate(query, stageIndex, clause);
 }

--- a/frontend/src/metabase-lib/metadata.ts
+++ b/frontend/src/metabase-lib/metadata.ts
@@ -17,6 +17,8 @@ import type {
   ColumnGroup,
   ColumnMetadata,
   MetadataProvider,
+  MetricMetadata,
+  MetricDisplayInfo,
   OrderByClause,
   OrderByClauseDisplayInfo,
   TableDisplayInfo,
@@ -74,6 +76,11 @@ declare function DisplayInfoFn(
   stageIndex: number,
   bucket: Bucket,
 ): BucketDisplayInfo;
+declare function DisplayInfoFn(
+  query: Query,
+  stageIndex: number,
+  metric: MetricMetadata,
+): MetricDisplayInfo;
 
 // x can be any sort of opaque object, e.g. a clause or metadata map. Values returned depend on what you pass in, but it
 // should always have display_name... see :metabase.lib.metadata.calculation/display-info schema

--- a/frontend/src/metabase-lib/metadata/Table.ts
+++ b/frontend/src/metabase-lib/metadata/Table.ts
@@ -49,6 +49,10 @@ class Table {
     return this.fields ?? [];
   }
 
+  getMetrics() {
+    return this.metrics ?? [];
+  }
+
   isVirtualCard() {
     return isVirtualCardId(this.id);
   }

--- a/frontend/src/metabase-lib/query.ts
+++ b/frontend/src/metabase-lib/query.ts
@@ -1,6 +1,12 @@
 import * as ML from "cljs/metabase.lib.js";
 import type { DatabaseId, DatasetQuery } from "metabase-types/api";
-import type { Clause, ColumnMetadata, MetadataProvider, Query } from "./types";
+import type {
+  Clause,
+  ColumnMetadata,
+  MetadataProvider,
+  MetricMetadata,
+  Query,
+} from "./types";
 
 export function fromLegacyQuery(
   databaseId: DatabaseId,
@@ -38,7 +44,7 @@ export function replaceClause(
   query: Query,
   stageIndex: number,
   targetClause: Clause,
-  newClause: Clause | ColumnMetadata,
+  newClause: Clause | ColumnMetadata | MetricMetadata,
 ): Query {
   return ML.replace_clause(query, stageIndex, targetClause, newClause);
 }

--- a/frontend/src/metabase-lib/types.ts
+++ b/frontend/src/metabase-lib/types.ts
@@ -17,10 +17,10 @@ export type CardMetadata = unknown & { _opaque: typeof CardMetadata };
 declare const MetricMetadata: unique symbol;
 export type MetricMetadata = unknown & { _opaque: typeof MetricMetadata };
 
-export type Limit = number | null;
-
 declare const AggregationClause: unique symbol;
 export type AggregationClause = unknown & { _opaque: typeof AggregationClause };
+
+export type Aggregatable = AggregationClause | MetricMetadata;
 
 declare const AggregationOperator: unique symbol;
 export type AggregationOperator = unknown & {
@@ -43,6 +43,8 @@ export type Clause =
   | BreakoutClause
   | FilterClause
   | OrderByClause;
+
+export type Limit = number | null;
 
 declare const ColumnMetadata: unique symbol;
 export type ColumnMetadata = unknown & { _opaque: typeof ColumnMetadata };

--- a/frontend/src/metabase-lib/types.ts
+++ b/frontend/src/metabase-lib/types.ts
@@ -97,6 +97,14 @@ export type AggregationOperatorDisplayInfo = {
   selected?: boolean;
 };
 
+export type MetricDisplayInfo = {
+  name: string;
+  displayName: string;
+  longDisplayName: string;
+  description: string;
+  selected?: boolean;
+};
+
 export type ClauseDisplayInfo = Pick<
   ColumnDisplayInfo,
   "name" | "displayName" | "longDisplayName" | "table"

--- a/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.tsx
+++ b/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.tsx
@@ -6,6 +6,8 @@ import { Icon } from "metabase/core/components/Icon";
 
 import type { Aggregation as LegacyAggregationClause } from "metabase-types/api";
 import * as Lib from "metabase-lib";
+import * as AGGREGATION from "metabase-lib/queries/utils/aggregation";
+import type LegacyAggregation from "metabase-lib/queries/structured/Aggregation";
 import type StructuredQuery from "metabase-lib/queries/StructuredQuery";
 import Metric from "metabase-lib/metadata/Metric";
 
@@ -26,6 +28,7 @@ interface AggregationPickerProps {
   stageIndex: number;
   operators: Lib.AggregationOperator[];
   legacyQuery: StructuredQuery;
+  legacyClause?: LegacyAggregation;
   maxHeight?: number;
   onSelect: (operator: Lib.AggregationClause) => void;
   onSelectLegacy: (operator: LegacyAggregationClause) => void;
@@ -54,6 +57,7 @@ export function AggregationPicker({
   stageIndex,
   operators,
   legacyQuery,
+  legacyClause,
   maxHeight = DEFAULT_MAX_HEIGHT,
   onSelect,
   onSelectLegacy,
@@ -96,8 +100,16 @@ export function AggregationPicker({
   }, [query, legacyQuery, stageIndex, operators]);
 
   const checkIsItemSelected = useCallback(
-    (item: OperatorListItem) => item.selected,
-    [],
+    (item: ListItem) => {
+      if (isOperatorListItem(item)) {
+        return item.selected;
+      }
+      if (legacyClause) {
+        return AGGREGATION.getMetric(legacyClause) === item.id;
+      }
+      return false;
+    },
+    [legacyClause],
   );
 
   const handleOperatorSelect = useCallback(

--- a/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.tsx
+++ b/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.tsx
@@ -92,7 +92,7 @@ export function AggregationPicker({
       sections.push({
         name: t`Common Metrics`,
         items: metrics,
-        icon: "star_outline",
+        icon: "star",
       });
     }
 

--- a/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.tsx
+++ b/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.tsx
@@ -70,7 +70,9 @@ export function AggregationPicker({
 
   const sections = useMemo(() => {
     const sections: Section[] = [];
-    const metrics = legacyQuery.table()?.getMetrics() || [];
+
+    const unfilteredMetrics = legacyQuery.table()?.getMetrics() ?? [];
+    const metrics = unfilteredMetrics.filter(metric => !metric.archived);
 
     if (operators.length > 0) {
       sections.push({

--- a/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.tsx
+++ b/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.tsx
@@ -4,10 +4,7 @@ import { t } from "ttag";
 import AccordionList from "metabase/core/components/AccordionList";
 import { Icon } from "metabase/core/components/Icon";
 
-import type { Aggregation as LegacyAggregationClause } from "metabase-types/api";
 import * as Lib from "metabase-lib";
-import type LegacyAggregation from "metabase-lib/queries/structured/Aggregation";
-import type StructuredQuery from "metabase-lib/queries/StructuredQuery";
 
 import QueryColumnPicker from "../QueryColumnPicker";
 import {
@@ -25,11 +22,8 @@ interface AggregationPickerProps {
   query: Lib.Query;
   stageIndex: number;
   operators: Lib.AggregationOperator[];
-  legacyQuery: StructuredQuery;
-  legacyClause?: LegacyAggregation;
   maxHeight?: number;
   onSelect: (operator: Lib.AggregationClause | Lib.MetricMetadata) => void;
-  onSelectLegacy: (operator: LegacyAggregationClause) => void;
   onClose?: () => void;
 }
 
@@ -58,11 +52,8 @@ export function AggregationPicker({
   query,
   stageIndex,
   operators,
-  legacyQuery,
-  legacyClause,
   maxHeight = DEFAULT_MAX_HEIGHT,
   onSelect,
-  onSelectLegacy,
   onClose,
 }: AggregationPickerProps) {
   const [operator, setOperator] = useState<Lib.AggregationOperator | null>(

--- a/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.tsx
+++ b/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.tsx
@@ -23,7 +23,7 @@ interface AggregationPickerProps {
   stageIndex: number;
   operators: Lib.AggregationOperator[];
   maxHeight?: number;
-  onSelect: (operator: Lib.AggregationClause | Lib.MetricMetadata) => void;
+  onSelect: (operator: Lib.Aggregatable) => void;
   onClose?: () => void;
 }
 

--- a/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.unit.spec.tsx
@@ -1,11 +1,31 @@
 import userEvent from "@testing-library/user-event";
+import { createMockMetadata } from "__support__/metadata";
 import { render, screen, within } from "__support__/ui";
+import { checkNotNull } from "metabase/core/utils/types";
+
+import type { Metric, StructuredDatasetQuery } from "metabase-types/api";
+import { createMockMetric } from "metabase-types/api/mocks";
+import {
+  createAdHocCard,
+  createSampleDatabase,
+  createOrdersTable,
+  createPeopleTable,
+  createProductsTable,
+  createReviewsTable,
+  ORDERS,
+  ORDERS_ID,
+  PRODUCTS_ID,
+  PRODUCTS,
+} from "metabase-types/api/mocks/presets";
 import * as Lib from "metabase-lib";
+import Question from "metabase-lib/Question";
+import type StructuredQuery from "metabase-lib/queries/StructuredQuery";
 import {
   createQuery,
   columnFinder,
   findAggregationOperator,
 } from "metabase-lib/test-helpers";
+
 import { AggregationPicker } from "./AggregationPicker";
 
 function createQueryWithCountAggregation() {
@@ -27,17 +47,60 @@ function createQueryWithMaxAggregation() {
   return Lib.aggregate(initialQuery, 0, clause);
 }
 
-function setup({ query = createQuery() } = {}) {
+const TEST_METRIC = createMockMetric({
+  id: 1,
+  table_id: ORDERS_ID,
+  name: "Total Order Value",
+  description: "The total value of all orders",
+  definition: {
+    aggregation: [["sum", ["field", ORDERS.TOTAL, null]]],
+    "source-table": ORDERS_ID,
+  },
+});
+
+const PRODUCT_METRIC = createMockMetric({
+  id: 2,
+  table_id: PRODUCTS_ID,
+  name: "Average Rating",
+  definition: {
+    aggregation: [["avg", ["field", PRODUCTS.RATING, null]]],
+    "source-table": PRODUCTS_ID,
+  },
+});
+
+type SetupOpts = {
+  query?: Lib.Query;
+  metrics?: Metric[];
+};
+
+function setup({ query = createQuery(), metrics = [] }: SetupOpts = {}) {
+  const metadata = createMockMetadata({
+    databases: [
+      createSampleDatabase({
+        tables: [
+          createOrdersTable({ metrics }),
+          createPeopleTable(),
+          createProductsTable({ metrics: [PRODUCT_METRIC] }),
+          createReviewsTable(),
+        ],
+      }),
+    ],
+    metrics: [...metrics, PRODUCT_METRIC],
+  });
+
+  const dataset_query = Lib.toLegacyQuery(query) as StructuredDatasetQuery;
+  const question = new Question(createAdHocCard({ dataset_query }), metadata);
+  const legacyQuery = question.query() as StructuredQuery;
+
   const clause = Lib.aggregations(query, 0)[0];
 
+  const baseOperators = Lib.availableAggregationOperators(query, 0);
   const operators = clause
-    ? Lib.selectedAggregationOperators(
-        Lib.availableAggregationOperators(query, 0),
-        clause,
-      )
-    : Lib.availableAggregationOperators(query, 0);
+    ? Lib.selectedAggregationOperators(baseOperators, clause)
+    : baseOperators;
 
   const onSelect = jest.fn();
+  const onSelectLegacy = jest.fn();
 
   function handleSelect(clause: Lib.AggregationClause) {
     const nextQuery = Lib.aggregate(query, 0, clause);
@@ -49,9 +112,11 @@ function setup({ query = createQuery() } = {}) {
   render(
     <AggregationPicker
       query={query}
+      legacyQuery={legacyQuery}
       stageIndex={0}
       operators={operators}
       onSelect={handleSelect}
+      onSelectLegacy={onSelectLegacy}
     />,
   );
 
@@ -60,10 +125,23 @@ function setup({ query = createQuery() } = {}) {
     return lastCall?.[0];
   }
 
-  return { getRecentClause };
+  return { metadata, getRecentClause, onSelectLegacy };
 }
 
 describe("AggregationPicker", () => {
+  it("should allow switching between aggregation approaches", () => {
+    const { metadata, onSelectLegacy } = setup({
+      query: createQueryWithCountAggregation(),
+      metrics: [TEST_METRIC],
+    });
+    const metric = checkNotNull(metadata.metric(TEST_METRIC.id));
+
+    userEvent.click(screen.getByText("Common Metrics"));
+    userEvent.click(screen.getByText(TEST_METRIC.name));
+
+    expect(onSelectLegacy).toHaveBeenCalledWith(metric.aggregationClause());
+  });
+
   describe("basic operators", () => {
     it("should list basic operators", () => {
       setup();
@@ -205,6 +283,59 @@ describe("AggregationPicker", () => {
           displayName: "Max of Discount",
         }),
       );
+    });
+  });
+
+  describe("metrics", () => {
+    function setupMetrics(opts: SetupOpts = {}) {
+      const result = setup(opts);
+
+      // Expand the metrics section
+      userEvent.click(screen.getByText("Common Metrics"));
+
+      return result;
+    }
+
+    it("shouldn't show the metrics section when there're no metics", () => {
+      setup({ metrics: [] });
+      expect(screen.queryByText("Common Metrics")).not.toBeInTheDocument();
+    });
+
+    it("should list metrics for the query table", () => {
+      setupMetrics({ metrics: [TEST_METRIC] });
+      expect(screen.getByText(TEST_METRIC.name)).toBeInTheDocument();
+    });
+
+    it("shouldn't list metrics for other tables", () => {
+      setupMetrics({ metrics: [TEST_METRIC] });
+      expect(screen.queryByText(PRODUCT_METRIC.name)).not.toBeInTheDocument();
+    });
+
+    it("should show a description for each metric", () => {
+      setupMetrics({ metrics: [TEST_METRIC] });
+
+      const metricOption = screen.getByRole("option", {
+        name: TEST_METRIC.name,
+      });
+      const infoIcon = within(metricOption).getByRole("img", {
+        name: "question icon",
+      });
+      userEvent.hover(infoIcon);
+
+      expect(screen.getByRole("tooltip")).toHaveTextContent(
+        TEST_METRIC.description,
+      );
+    });
+
+    it("should allow picking a metric", () => {
+      const { metadata, onSelectLegacy } = setupMetrics({
+        metrics: [TEST_METRIC],
+      });
+      const metric = checkNotNull(metadata.metric(TEST_METRIC.id));
+
+      userEvent.click(screen.getByText(TEST_METRIC.name));
+
+      expect(onSelectLegacy).toHaveBeenCalledWith(metric.aggregationClause());
     });
   });
 });

--- a/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.unit.spec.tsx
@@ -58,8 +58,15 @@ const TEST_METRIC = createMockMetric({
   },
 });
 
-const PRODUCT_METRIC = createMockMetric({
+const ARCHIVED_METRIC = createMockMetric({
   id: 2,
+  table_id: ORDERS_ID,
+  name: "Archived Metric",
+  archived: true,
+});
+
+const PRODUCT_METRIC = createMockMetric({
+  id: 3,
   table_id: PRODUCTS_ID,
   name: "Average Rating",
   definition: {
@@ -325,6 +332,11 @@ describe("AggregationPicker", () => {
       expect(screen.getByRole("tooltip")).toHaveTextContent(
         TEST_METRIC.description,
       );
+    });
+
+    it("shouldn't display archived metrics", () => {
+      setupMetrics({ metrics: [TEST_METRIC, ARCHIVED_METRIC] });
+      expect(screen.queryByText(ARCHIVED_METRIC.name)).not.toBeInTheDocument();
     });
 
     it("should allow picking a metric", () => {

--- a/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.unit.spec.tsx
@@ -105,7 +105,7 @@ function setup({
   const onSelect = jest.fn();
   const onSelectLegacy = jest.fn();
 
-  function handleSelect(clause: Lib.AggregationClause | Lib.MetricMetadata) {
+  function handleSelect(clause: Lib.Aggregatable) {
     const nextQuery = Lib.aggregate(query, 0, clause);
     const aggregations = Lib.aggregations(nextQuery, 0);
     const recentAggregation = aggregations[aggregations.length - 1];

--- a/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.unit.spec.tsx
@@ -3,10 +3,9 @@ import { createMockMetadata } from "__support__/metadata";
 import { render, screen, within } from "__support__/ui";
 import { checkNotNull } from "metabase/core/utils/types";
 
-import type { Metric, StructuredDatasetQuery } from "metabase-types/api";
+import type { Metric } from "metabase-types/api";
 import { createMockMetric } from "metabase-types/api/mocks";
 import {
-  createAdHocCard,
   createSampleDatabase,
   createOrdersTable,
   createPeopleTable,
@@ -18,9 +17,7 @@ import {
   PRODUCTS,
 } from "metabase-types/api/mocks/presets";
 import * as Lib from "metabase-lib";
-import Question from "metabase-lib/Question";
 import type Metadata from "metabase-lib/metadata/Metadata";
-import type StructuredQuery from "metabase-lib/queries/StructuredQuery";
 import {
   createQuery,
   columnFinder,
@@ -98,10 +95,6 @@ function setup({
   metadata = createMetadata(),
   query = createQuery({ metadata }),
 }: SetupOpts = {}) {
-  const dataset_query = Lib.toLegacyQuery(query) as StructuredDatasetQuery;
-  const question = new Question(createAdHocCard({ dataset_query }), metadata);
-  const legacyQuery = question.query() as StructuredQuery;
-
   const clause = Lib.aggregations(query, 0)[0];
 
   const baseOperators = Lib.availableAggregationOperators(query, 0);
@@ -122,11 +115,9 @@ function setup({
   render(
     <AggregationPicker
       query={query}
-      legacyQuery={legacyQuery}
       stageIndex={0}
       operators={operators}
       onSelect={handleSelect}
-      onSelectLegacy={onSelectLegacy}
     />,
   );
 

--- a/frontend/src/metabase/query_builder/components/notebook/steps/AggregateStep/AggregateStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/AggregateStep/AggregateStep.tsx
@@ -1,6 +1,7 @@
 import { t } from "ttag";
 
 import * as Lib from "metabase-lib";
+import type StructuredQuery from "metabase-lib/queries/StructuredQuery";
 
 import type { NotebookStepUiComponentProps } from "../../types";
 import ClauseStep from "../ClauseStep";
@@ -72,42 +73,84 @@ export function AggregateStep({
       tetherOptions={aggTetherOptions}
       renderName={renderAggregationName}
       renderPopover={(aggregation, index) => (
-        <AggregationPicker
+        <AggregationPopover
           query={topLevelQuery}
-          legacyQuery={legacyQuery}
-          legacyClause={
-            typeof index === "number"
-              ? legacyQuery.aggregations()[index]
-              : undefined
-          }
           stageIndex={stageIndex}
-          operators={
-            aggregation
-              ? Lib.selectedAggregationOperators(operators, aggregation)
-              : operators
-          }
-          onSelect={newAggregation => {
-            const isUpdate = aggregation != null;
-            if (isUpdate) {
-              handleUpdateAggregation(aggregation, newAggregation);
-            } else {
-              handleAddAggregation(newAggregation);
-            }
-          }}
-          onSelectLegacy={newLegacyAggregation => {
-            const isUpdate = aggregation != null && typeof index === "number";
-            if (isUpdate) {
-              updateQuery(
-                legacyQuery.updateAggregation(index, newLegacyAggregation),
-              );
-            } else {
-              updateQuery(legacyQuery.aggregate(newLegacyAggregation));
-            }
-          }}
+          operators={operators}
+          clause={aggregation}
+          clauseIndex={index}
+          legacyQuery={legacyQuery}
+          onAddAggregation={handleAddAggregation}
+          onUpdateAggregation={handleUpdateAggregation}
+          onLegacyQueryChange={updateQuery}
         />
       )}
       onRemove={handleRemoveAggregation}
       data-testid="aggregate-step"
+    />
+  );
+}
+
+interface AggregationPopoverProps {
+  query: Lib.Query;
+  stageIndex: number;
+  operators: Lib.AggregationOperator[];
+  clause?: Lib.AggregationClause;
+  onUpdateAggregation: (
+    currentClause: Lib.AggregationClause,
+    nextClause: Lib.AggregationClause,
+  ) => void;
+  onAddAggregation: (aggregation: Lib.AggregationClause) => void;
+
+  legacyQuery: StructuredQuery;
+  clauseIndex?: number;
+  onLegacyQueryChange: (query: StructuredQuery) => void;
+}
+
+function AggregationPopover({
+  query,
+  stageIndex,
+  operators: baseOperators,
+  clause,
+  clauseIndex,
+  legacyQuery,
+  onAddAggregation,
+  onUpdateAggregation,
+  onLegacyQueryChange,
+}: AggregationPopoverProps) {
+  const isUpdate = clause != null && clauseIndex != null;
+
+  const operators = isUpdate
+    ? Lib.selectedAggregationOperators(baseOperators, clause)
+    : baseOperators;
+
+  const legacyClause = isUpdate
+    ? legacyQuery.aggregations()[clauseIndex]
+    : undefined;
+
+  return (
+    <AggregationPicker
+      query={query}
+      legacyQuery={legacyQuery}
+      legacyClause={legacyClause}
+      stageIndex={stageIndex}
+      operators={operators}
+      onSelect={aggregation => {
+        if (isUpdate) {
+          onUpdateAggregation(clause, aggregation);
+        } else {
+          onAddAggregation(aggregation);
+        }
+      }}
+      onSelectLegacy={newLegacyAggregation => {
+        if (isUpdate) {
+          onLegacyQueryChange(
+            legacyQuery.updateAggregation(clauseIndex, newLegacyAggregation),
+          );
+        } else {
+          onLegacyQueryChange(legacyQuery.aggregate(newLegacyAggregation));
+        }
+      }}
     />
   );
 }

--- a/frontend/src/metabase/query_builder/components/notebook/steps/AggregateStep/AggregateStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/AggregateStep/AggregateStep.tsx
@@ -20,7 +20,7 @@ const aggTetherOptions = {
 };
 
 export function AggregateStep({
-  query,
+  query: legacyQuery,
   topLevelQuery,
   step,
   color,
@@ -74,7 +74,12 @@ export function AggregateStep({
       renderPopover={(aggregation, index) => (
         <AggregationPicker
           query={topLevelQuery}
-          legacyQuery={query}
+          legacyQuery={legacyQuery}
+          legacyClause={
+            typeof index === "number"
+              ? legacyQuery.aggregations()[index]
+              : undefined
+          }
           stageIndex={stageIndex}
           operators={
             aggregation
@@ -92,9 +97,11 @@ export function AggregateStep({
           onSelectLegacy={newLegacyAggregation => {
             const isUpdate = aggregation != null && typeof index === "number";
             if (isUpdate) {
-              updateQuery(query.updateAggregation(index, newLegacyAggregation));
+              updateQuery(
+                legacyQuery.updateAggregation(index, newLegacyAggregation),
+              );
             } else {
-              updateQuery(query.aggregate(newLegacyAggregation));
+              updateQuery(legacyQuery.aggregate(newLegacyAggregation));
             }
           }}
         />

--- a/frontend/src/metabase/query_builder/components/notebook/steps/AggregateStep/AggregateStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/AggregateStep/AggregateStep.tsx
@@ -20,6 +20,7 @@ const aggTetherOptions = {
 };
 
 export function AggregateStep({
+  query,
   topLevelQuery,
   step,
   color,
@@ -70,9 +71,10 @@ export function AggregateStep({
       isLastOpened={isLastOpened}
       tetherOptions={aggTetherOptions}
       renderName={renderAggregationName}
-      renderPopover={aggregation => (
+      renderPopover={(aggregation, index) => (
         <AggregationPicker
           query={topLevelQuery}
+          legacyQuery={query}
           stageIndex={stageIndex}
           operators={
             aggregation
@@ -85,6 +87,14 @@ export function AggregateStep({
               handleUpdateAggregation(aggregation, newAggregation);
             } else {
               handleAddAggregation(newAggregation);
+            }
+          }}
+          onSelectLegacy={newLegacyAggregation => {
+            const isUpdate = aggregation != null && typeof index === "number";
+            if (isUpdate) {
+              updateQuery(query.updateAggregation(index, newLegacyAggregation));
+            } else {
+              updateQuery(query.aggregate(newLegacyAggregation));
             }
           }}
         />

--- a/frontend/src/metabase/query_builder/components/notebook/steps/AggregateStep/AggregateStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/AggregateStep/AggregateStep.tsx
@@ -105,6 +105,9 @@ interface AggregationPopoverProps {
   legacyQuery: StructuredQuery;
   clauseIndex?: number;
   onLegacyQueryChange: (query: StructuredQuery) => void;
+
+  // Implicitly passed by metabase/components/Triggerable
+  onClose?: () => void;
 }
 
 function AggregationPopover({
@@ -117,6 +120,7 @@ function AggregationPopover({
   onAddAggregation,
   onUpdateAggregation,
   onLegacyQueryChange,
+  onClose,
 }: AggregationPopoverProps) {
   const isUpdate = clause != null && clauseIndex != null;
 
@@ -151,6 +155,7 @@ function AggregationPopover({
           onLegacyQueryChange(legacyQuery.aggregate(newLegacyAggregation));
         }
       }}
+      onClose={onClose}
     />
   );
 }

--- a/frontend/src/metabase/query_builder/components/notebook/steps/AggregateStep/AggregateStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/AggregateStep/AggregateStep.tsx
@@ -35,16 +35,14 @@ export function AggregateStep({
     stageIndex,
   );
 
-  const handleAddAggregation = (
-    aggregation: Lib.AggregationClause | Lib.MetricMetadata,
-  ) => {
+  const handleAddAggregation = (aggregation: Lib.Aggregatable) => {
     const nextQuery = Lib.aggregate(topLevelQuery, stageIndex, aggregation);
     updateQuery(nextQuery);
   };
 
   const handleUpdateAggregation = (
     currentClause: Lib.AggregationClause,
-    nextClause: Lib.AggregationClause | Lib.MetricMetadata,
+    nextClause: Lib.Aggregatable,
   ) => {
     const nextQuery = Lib.replaceClause(
       topLevelQuery,
@@ -96,11 +94,9 @@ interface AggregationPopoverProps {
   clause?: Lib.AggregationClause;
   onUpdateAggregation: (
     currentClause: Lib.AggregationClause,
-    nextClause: Lib.AggregationClause | Lib.MetricMetadata,
+    nextClause: Lib.Aggregatable,
   ) => void;
-  onAddAggregation: (
-    aggregation: Lib.AggregationClause | Lib.MetricMetadata,
-  ) => void;
+  onAddAggregation: (aggregation: Lib.Aggregatable) => void;
 
   clauseIndex?: number;
 

--- a/frontend/src/metabase/query_builder/components/notebook/steps/AggregateStep/AggregateStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/AggregateStep/AggregateStep.tsx
@@ -37,14 +37,16 @@ export function AggregateStep({
     stageIndex,
   );
 
-  const handleAddAggregation = (aggregation: Lib.AggregationClause) => {
+  const handleAddAggregation = (
+    aggregation: Lib.AggregationClause | Lib.MetricMetadata,
+  ) => {
     const nextQuery = Lib.aggregate(topLevelQuery, stageIndex, aggregation);
     updateQuery(nextQuery);
   };
 
   const handleUpdateAggregation = (
     currentClause: Lib.AggregationClause,
-    nextClause: Lib.AggregationClause,
+    nextClause: Lib.AggregationClause | Lib.MetricMetadata,
   ) => {
     const nextQuery = Lib.replaceClause(
       topLevelQuery,
@@ -98,9 +100,11 @@ interface AggregationPopoverProps {
   clause?: Lib.AggregationClause;
   onUpdateAggregation: (
     currentClause: Lib.AggregationClause,
-    nextClause: Lib.AggregationClause,
+    nextClause: Lib.AggregationClause | Lib.MetricMetadata,
   ) => void;
-  onAddAggregation: (aggregation: Lib.AggregationClause) => void;
+  onAddAggregation: (
+    aggregation: Lib.AggregationClause | Lib.MetricMetadata,
+  ) => void;
 
   legacyQuery: StructuredQuery;
   clauseIndex?: number;

--- a/frontend/src/metabase/query_builder/components/notebook/steps/AggregateStep/AggregateStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/AggregateStep/AggregateStep.tsx
@@ -1,7 +1,6 @@
 import { t } from "ttag";
 
 import * as Lib from "metabase-lib";
-import type StructuredQuery from "metabase-lib/queries/StructuredQuery";
 
 import type { NotebookStepUiComponentProps } from "../../types";
 import ClauseStep from "../ClauseStep";
@@ -21,7 +20,6 @@ const aggTetherOptions = {
 };
 
 export function AggregateStep({
-  query: legacyQuery,
   topLevelQuery,
   step,
   color,
@@ -81,10 +79,8 @@ export function AggregateStep({
           operators={operators}
           clause={aggregation}
           clauseIndex={index}
-          legacyQuery={legacyQuery}
           onAddAggregation={handleAddAggregation}
           onUpdateAggregation={handleUpdateAggregation}
-          onLegacyQueryChange={updateQuery}
         />
       )}
       onRemove={handleRemoveAggregation}
@@ -106,9 +102,7 @@ interface AggregationPopoverProps {
     aggregation: Lib.AggregationClause | Lib.MetricMetadata,
   ) => void;
 
-  legacyQuery: StructuredQuery;
   clauseIndex?: number;
-  onLegacyQueryChange: (query: StructuredQuery) => void;
 
   // Implicitly passed by metabase/components/Triggerable
   onClose?: () => void;
@@ -120,10 +114,8 @@ function AggregationPopover({
   operators: baseOperators,
   clause,
   clauseIndex,
-  legacyQuery,
   onAddAggregation,
   onUpdateAggregation,
-  onLegacyQueryChange,
   onClose,
 }: AggregationPopoverProps) {
   const isUpdate = clause != null && clauseIndex != null;
@@ -132,15 +124,9 @@ function AggregationPopover({
     ? Lib.selectedAggregationOperators(baseOperators, clause)
     : baseOperators;
 
-  const legacyClause = isUpdate
-    ? legacyQuery.aggregations()[clauseIndex]
-    : undefined;
-
   return (
     <AggregationPicker
       query={query}
-      legacyQuery={legacyQuery}
-      legacyClause={legacyClause}
       stageIndex={stageIndex}
       operators={operators}
       onSelect={aggregation => {
@@ -148,15 +134,6 @@ function AggregationPopover({
           onUpdateAggregation(clause, aggregation);
         } else {
           onAddAggregation(aggregation);
-        }
-      }}
-      onSelectLegacy={newLegacyAggregation => {
-        if (isUpdate) {
-          onLegacyQueryChange(
-            legacyQuery.updateAggregation(clauseIndex, newLegacyAggregation),
-          );
-        } else {
-          onLegacyQueryChange(legacyQuery.aggregate(newLegacyAggregation));
         }
       }}
       onClose={onClose}


### PR DESCRIPTION
Part of #31001

The second step in the notebook editor's `AggregateStep` migration. Adds support for metrics (distinct entities that can be added in "Admin > Data Model").

We're about to rework Metrics and make them model-based. It didn't make a lot of sense to port legacy metrics to MLv2, so we're still using MLv1 here. I'm open for feedback on how to approach this (look at `legacyQuery` and `onChangeLegacy` props in `AggregationPicker`)

> **Warning**
> This PR targets a feature branch and doesn't migrate `AggregateStep` features 1:1
> This branch is expected to have failing tests because parts of functionality are simply missing
> You can monitor the migration health with the last branch in the chain — #31530

### To Verify

1. Sign in as Metabase admin
2. Open `/admin/datamodel/metrics` and add a few metrics
3. For different kinds of questions (structured/native, based on raw data/models/questions, flat/multi-stage):
   1. Open `/question/:id/notebook`
   2. Click "Pick the metric you want to see"
   3. Ensure you can see, apply, change, and remove metrics you've created at step 2
   4. Overall ensure the behavior matches `master`

### Demo

https://github.com/metabase/metabase/assets/17258145/dcb38d9e-52fa-4689-aaec-94cf0246cc42
