### PR TITLE
Migrate notebook aggregations to MLv2 — Inline expressions (3)

### DIFF
--- a/frontend/src/metabase-types/api/query.ts
+++ b/frontend/src/metabase-types/api/query.ts
@@ -149,12 +149,7 @@ type SumAgg = ["sum", ConcreteFieldReference];
 type MinAgg = ["min", ConcreteFieldReference];
 type MaxAgg = ["max", ConcreteFieldReference];
 
-type MetricAgg = ["metric", MetricId];
-
-/**
- * An aggregation MBQL clause
- */
-export type Aggregation =
+type CommonAggregation =
   | CountAgg
   | CountFieldAgg
   | AvgAgg
@@ -164,8 +159,20 @@ export type Aggregation =
   | StdDevAgg
   | SumAgg
   | MinAgg
-  | MaxAgg
-  | MetricAgg;
+  | MaxAgg;
+
+type MetricAgg = ["metric", MetricId];
+
+type InlineExpressionAgg = [
+  "aggregation-options",
+  CommonAggregation,
+  { name: string; "display-name": string },
+];
+
+/**
+ * An aggregation MBQL clause
+ */
+export type Aggregation = CommonAggregation | MetricAgg | InlineExpressionAgg;
 
 type BreakoutClause = Breakout[];
 export type Breakout = ConcreteFieldReference;

--- a/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.tsx
+++ b/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.tsx
@@ -6,8 +6,8 @@ import { Icon } from "metabase/core/components/Icon";
 
 import { useToggle } from "metabase/hooks/use-toggle";
 
-import ExpressionWidget from "metabase/query_builder/components/expressions/ExpressionWidget";
-import ExpressionWidgetHeader from "metabase/query_builder/components/expressions/ExpressionWidgetHeader";
+import { ExpressionWidget } from "metabase/query_builder/components/expressions/ExpressionWidget";
+import { ExpressionWidgetHeader } from "metabase/query_builder/components/expressions/ExpressionWidgetHeader";
 
 import type {
   Aggregation as LegacyAggregationClause,

--- a/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.tsx
+++ b/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.tsx
@@ -75,13 +75,19 @@ export function AggregationPicker({
   onSelectLegacy,
   onClose,
 }: AggregationPickerProps) {
-  const [operator, setOperator] = useState<Lib.AggregationOperator | null>(
-    getInitialOperator(query, stageIndex, operators),
-  );
   const [
     isEditingExpression,
     { turnOn: openExpressionEditor, turnOff: closeExpressionEditor },
   ] = useToggle(isExpressionEditorInitiallyOpen(legacyClause));
+
+  // For really simple inline expressions like Average([Price]),
+  // MLv2 can figure out that "Average" operator is used.
+  // We don't want that though, so we don't break navigation inside the picker
+  const [operator, setOperator] = useState<Lib.AggregationOperator | null>(
+    isEditingExpression
+      ? null
+      : getInitialOperator(query, stageIndex, operators),
+  );
 
   const operatorInfo = useMemo(
     () => (operator ? Lib.displayInfo(query, stageIndex, operator) : null),
@@ -201,6 +207,21 @@ export function AggregationPicker({
     [onSelectLegacy, onClose],
   );
 
+  if (isEditingExpression) {
+    return (
+      <ExpressionWidget
+        query={legacyQuery}
+        name={AGGREGATION.getName(legacyClause)}
+        expression={AGGREGATION.getContent(legacyClause)}
+        withName
+        startRule="aggregation"
+        header={<ExpressionWidgetHeader onBack={closeExpressionEditor} />}
+        onChangeExpression={handleExpressionChange}
+        onClose={closeExpressionEditor}
+      />
+    );
+  }
+
   if (operator && operatorInfo?.requiresColumn) {
     const columns = Lib.aggregationOperatorColumns(operator);
     const columnGroups = Lib.groupColumns(columns);
@@ -220,21 +241,6 @@ export function AggregationPicker({
           onClose={onClose}
         />
       </ColumnPickerContainer>
-    );
-  }
-
-  if (isEditingExpression) {
-    return (
-      <ExpressionWidget
-        query={legacyQuery}
-        name={AGGREGATION.getName(legacyClause)}
-        expression={AGGREGATION.getContent(legacyClause)}
-        withName
-        startRule="aggregation"
-        header={<ExpressionWidgetHeader onBack={closeExpressionEditor} />}
-        onChangeExpression={handleExpressionChange}
-        onClose={closeExpressionEditor}
-      />
     );
   }
 

--- a/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.tsx
+++ b/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.tsx
@@ -4,7 +4,10 @@ import { t } from "ttag";
 import AccordionList from "metabase/core/components/AccordionList";
 import { Icon } from "metabase/core/components/Icon";
 
+import type { Aggregation as LegacyAggregationClause } from "metabase-types/api";
 import * as Lib from "metabase-lib";
+import type LegacyAggregation from "metabase-lib/queries/structured/Aggregation";
+import type StructuredQuery from "metabase-lib/queries/StructuredQuery";
 
 import QueryColumnPicker from "../QueryColumnPicker";
 import {
@@ -22,8 +25,11 @@ interface AggregationPickerProps {
   query: Lib.Query;
   stageIndex: number;
   operators: Lib.AggregationOperator[];
+  legacyQuery: StructuredQuery;
+  legacyClause?: LegacyAggregation;
   maxHeight?: number;
   onSelect: (operator: Lib.Aggregatable) => void;
+  onSelectLegacy: (operator: LegacyAggregationClause) => void;
   onClose?: () => void;
 }
 
@@ -52,8 +58,11 @@ export function AggregationPicker({
   query,
   stageIndex,
   operators,
+  legacyQuery,
+  legacyClause,
   maxHeight = DEFAULT_MAX_HEIGHT,
   onSelect,
+  onSelectLegacy,
   onClose,
 }: AggregationPickerProps) {
   const [operator, setOperator] = useState<Lib.AggregationOperator | null>(

--- a/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.unit.spec.tsx
@@ -3,9 +3,10 @@ import { createMockMetadata } from "__support__/metadata";
 import { render, screen, within } from "__support__/ui";
 import { checkNotNull } from "metabase/core/utils/types";
 
-import type { Metric } from "metabase-types/api";
+import type { Metric, StructuredDatasetQuery } from "metabase-types/api";
 import { createMockMetric } from "metabase-types/api/mocks";
 import {
+  createAdHocCard,
   createSampleDatabase,
   createOrdersTable,
   createPeopleTable,
@@ -17,7 +18,9 @@ import {
   PRODUCTS,
 } from "metabase-types/api/mocks/presets";
 import * as Lib from "metabase-lib";
+import Question from "metabase-lib/Question";
 import type Metadata from "metabase-lib/metadata/Metadata";
+import type StructuredQuery from "metabase-lib/queries/StructuredQuery";
 import {
   createQuery,
   columnFinder,
@@ -95,6 +98,10 @@ function setup({
   metadata = createMetadata(),
   query = createQuery({ metadata }),
 }: SetupOpts = {}) {
+  const dataset_query = Lib.toLegacyQuery(query) as StructuredDatasetQuery;
+  const question = new Question(createAdHocCard({ dataset_query }), metadata);
+  const legacyQuery = question.query() as StructuredQuery;
+
   const clause = Lib.aggregations(query, 0)[0];
 
   const baseOperators = Lib.availableAggregationOperators(query, 0);
@@ -115,9 +122,11 @@ function setup({
   render(
     <AggregationPicker
       query={query}
+      legacyQuery={legacyQuery}
       stageIndex={0}
       operators={operators}
       onSelect={handleSelect}
+      onSelectLegacy={onSelectLegacy}
     />,
   );
 

--- a/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.unit.spec.tsx
@@ -20,6 +20,7 @@ import {
   ORDERS_ID,
   PRODUCTS_ID,
   PRODUCTS,
+  SAMPLE_DB_ID,
 } from "metabase-types/api/mocks/presets";
 import * as Lib from "metabase-lib";
 import Question from "metabase-lib/Question";
@@ -54,6 +55,24 @@ function createQueryWithMaxAggregation({
   const quantity = findColumn("ORDERS", "QUANTITY");
   const clause = Lib.aggregationClause(max, quantity);
   return Lib.aggregate(initialQuery, 0, clause);
+}
+
+function createQueryWithInlineExpression() {
+  return createQuery({
+    query: {
+      database: SAMPLE_DB_ID,
+      type: "query",
+      query: {
+        aggregation: [
+          [
+            "aggregation-options",
+            ["avg", ["field", ORDERS.QUANTITY, null]],
+            { name: "Avg Q", "display-name": "Avg Q" },
+          ],
+        ],
+      },
+    },
+  });
 }
 
 const TEST_METRIC = createMockMetric({
@@ -133,6 +152,7 @@ function setup({
     <AggregationPicker
       query={query}
       legacyQuery={legacyQuery}
+      legacyClause={legacyQuery.aggregations()[0]}
       stageIndex={0}
       operators={operators}
       onSelect={handleSelect}
@@ -388,6 +408,13 @@ describe("AggregationPicker", () => {
     it("shouldn't be available if database doesn't support custom expressions", () => {
       setup({ metadata: createMetadata({ hasExpressionSupport: false }) });
       expect(screen.queryByText("Custom Expression")).not.toBeInTheDocument();
+    });
+
+    it("should open the editor when an expression is used", async () => {
+      setup({ query: createQueryWithInlineExpression() });
+
+      expect(screen.getByText("Custom Expression")).toBeInTheDocument();
+      expect(screen.getByDisplayValue("Avg Q")).toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield/ExpressionEditorTextfield.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield/ExpressionEditorTextfield.tsx
@@ -47,6 +47,7 @@ interface ExpressionEditorTextfieldProps {
   startRule?: string;
   width?: number;
   reportTimezone?: string;
+  textAreaId?: string;
 
   onChange: (expression: Expression | null) => void;
   onError: (error: ErrorWithMessage | null) => void;
@@ -154,6 +155,13 @@ class ExpressionEditorTextfield extends React.Component<
       }
 
       this.triggerAutosuggest();
+    }
+  }
+
+  componentDidUpdate() {
+    const { textAreaId } = this.props;
+    if (this.input.current && textAreaId) {
+      this.input.current.editor.textInput.getElement().id = textAreaId;
     }
   }
 

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield/ExpressionEditorTextfield.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield/ExpressionEditorTextfield.tsx
@@ -161,7 +161,6 @@ class ExpressionEditorTextfield extends React.Component<
   componentDidUpdate() {
     const { textAreaId } = this.props;
     if (this.input.current && textAreaId) {
-      // @ts-expect-error — getElement is missing in ace types
       const textArea = this.input.current.editor.textInput.getElement?.();
       textArea?.setAttribute?.("id", textAreaId);
     }

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield/ExpressionEditorTextfield.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield/ExpressionEditorTextfield.tsx
@@ -161,7 +161,9 @@ class ExpressionEditorTextfield extends React.Component<
   componentDidUpdate() {
     const { textAreaId } = this.props;
     if (this.input.current && textAreaId) {
-      this.input.current.editor.textInput.getElement().id = textAreaId;
+      // @ts-expect-error — getElement is missing in ace types
+      const textArea = this.input.current.editor.textInput.getElement?.();
+      textArea?.setAttribute?.("id", textAreaId);
     }
   }
 

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.styled.tsx
@@ -16,7 +16,7 @@ export const ExpressionFieldWrapper = styled.div`
   padding: 1.5rem 1.5rem 1rem;
 `;
 
-export const FieldTitle = styled.div`
+export const FieldLabel = styled.label`
   display: flex;
   margin-bottom: 0.5rem;
 

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.tsx
@@ -14,7 +14,7 @@ import {
   ActionButtonsWrapper,
   Container,
   ExpressionFieldWrapper,
-  FieldTitle,
+  FieldLabel,
   FieldWrapper,
   Footer,
   InfoLink,
@@ -83,7 +83,7 @@ export const ExpressionWidget = (props: ExpressionWidgetProps): JSX.Element => {
     <Container>
       {header}
       <ExpressionFieldWrapper>
-        <FieldTitle>
+        <FieldLabel htmlFor="expression-content">
           {t`Expression`}
           <Tooltip
             tooltip={t`You can reference columns here in functions or equations, like: floor([Price] - [Discount]). Click for documentation.`}
@@ -98,7 +98,7 @@ export const ExpressionWidget = (props: ExpressionWidgetProps): JSX.Element => {
               <StyledFieldTitleIcon name="info" />
             </InfoLink>
           </Tooltip>
-        </FieldTitle>
+        </FieldLabel>
         <div ref={helpTextTargetRef}>
           <ExpressionEditorTextfield
             helpTextTarget={helpTextTargetRef.current}
@@ -107,6 +107,7 @@ export const ExpressionWidget = (props: ExpressionWidgetProps): JSX.Element => {
             name={name}
             query={query}
             reportTimezone={reportTimezone}
+            textAreaId="expression-content"
             onChange={handleExpressionChange}
             onCommit={handleCommit}
             onError={(errorMessage: string) => setError(errorMessage)}
@@ -115,8 +116,9 @@ export const ExpressionWidget = (props: ExpressionWidgetProps): JSX.Element => {
       </ExpressionFieldWrapper>
       {withName && (
         <FieldWrapper>
-          <FieldTitle>{t`Name`}</FieldTitle>
+          <FieldLabel htmlFor="expression-name">{t`Name`}</FieldLabel>
           <Input
+            id="expression-name"
             type="text"
             value={name}
             placeholder={t`Something nice and descriptive`}

--- a/frontend/src/types/ace-builds.d.ts
+++ b/frontend/src/types/ace-builds.d.ts
@@ -6,5 +6,8 @@ declare module "ace-builds" {
       // "commandKeyBinding" is not typed, but used in the code, and it works. So, adding an explicit typing here
       commandKeyBinding: Ace.CommandMap;
     }
+    interface TextInput {
+      getElement(): HTMLTextAreaElement;
+    }
   }
 }


### PR DESCRIPTION
Part of #31001

The third step in the notebook editor's `AggregateStep` migration. Adds support for inline expressions. Custom expressions themselves are not yet ported to MLv2, so for now we're using MLv1 to work with them.

> **Warning**
> This PR targets a feature branch and doesn't migrate `AggregateStep` features 1:1
> This branch is expected to have failing tests because parts of functionality are simply missing
> You can monitor the migration health with the last branch in the chain — #31530

### To Verify

For different kinds of questions (structured/native, based on raw data/models/questions, flat/multi-stage):

1. Open `/question/:id/notebook`
2. Click "Pick the metric you want to see"
3. Pick "Custom expression" at the very end of the picker
4. Try out different [expressions](https://www.metabase.com/docs/latest/questions/query-builder/expressions-list)
5. Overall ensure the behavior matches `master`

### Demo

https://github.com/metabase/metabase/assets/17258145/d27e472c-1560-4f08-adce-89589f705f29

