### PR TITLE
Allow error detail display (for CSV uploads)

### DIFF
--- a/frontend/src/metabase/components/ErrorDetails/ErrorBox.tsx
+++ b/frontend/src/metabase/components/ErrorDetails/ErrorBox.tsx
@@ -1,0 +1,14 @@
+import type { ErrorDetails } from "./types";
+
+import { MonospaceErrorDisplay } from "./ErrorDetails.styled";
+
+export const ErrorBox = ({ children }: { children: ErrorDetails }) => (
+  <MonospaceErrorDisplay>
+    {/* ensure we don't try to render anything except a string */}
+    {typeof children === "string"
+      ? children
+      : typeof children.message === "string"
+      ? children.message
+      : String(children)}
+  </MonospaceErrorDisplay>
+);

--- a/frontend/src/metabase/components/ErrorDetails/ErrorDetails.styled.tsx
+++ b/frontend/src/metabase/components/ErrorDetails/ErrorDetails.styled.tsx
@@ -1,0 +1,13 @@
+import styled from "@emotion/styled";
+import { color } from "metabase/lib/colors";
+
+export const MonospaceErrorDisplay = styled.div`
+  font-family: monospace;
+  white-space: pre-wrap;
+  padding: 1rem;
+  margin-top: 0.5rem;
+  font-weight: bold;
+  border-radius: 0.5rem;
+  background-color: ${color("bg-light")};
+  border: 1px solid ${color("border")};
+`;

--- a/frontend/src/metabase/components/ErrorDetails/ErrorDetails.tsx
+++ b/frontend/src/metabase/components/ErrorDetails/ErrorDetails.tsx
@@ -2,7 +2,9 @@ import { useState } from "react";
 import { t } from "ttag";
 import cx from "classnames";
 
-import { ErrorDetailsProps } from "./types";
+import { ErrorBox } from "./ErrorBox";
+
+import type { ErrorDetailsProps } from "./types";
 
 // eslint-disable-next-line import/no-default-export -- deprecated usage
 export default function ErrorDetails({
@@ -32,17 +34,7 @@ export default function ErrorDetails({
         className={cx("pt3", centered ? "text-centered" : "text-left")}
       >
         <h2>{t`Here's the full error message`}</h2>
-        <div
-          style={{ fontFamily: "monospace" }}
-          className="QueryError2-detailBody bordered rounded bg-light text-bold p2 mt1"
-        >
-          {/* ensure we don't try to render anything except a string */}
-          {typeof details === "string"
-            ? details
-            : typeof details.message === "string"
-            ? details.message
-            : String(details)}
-        </div>
+        <ErrorBox>{details}</ErrorBox>
       </div>
     </div>
   );

--- a/frontend/src/metabase/components/ErrorDetails/ErrorDetails.unit.spec.tsx
+++ b/frontend/src/metabase/components/ErrorDetails/ErrorDetails.unit.spec.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from "@testing-library/react";
+
+import userEvent from "@testing-library/user-event";
+import ErrorDetails from "./ErrorDetails";
+
+const setup = (propOverrides?: object) => {
+  render(<ErrorDetails details={{ message: "uhoh" }} {...propOverrides} />);
+};
+
+describe("ErrorDetails", () => {
+  it("should render string errors", async () => {
+    setup({ details: "Oh no!" });
+    userEvent.click(screen.getByText("Show error details"));
+
+    expect(await screen.findByText("Oh no!")).toBeVisible();
+  });
+
+  it("should render message property errors", async () => {
+    setup({ details: { message: "Oh no!" } });
+    userEvent.click(screen.getByText("Show error details"));
+
+    expect(await screen.findByText("Oh no!")).toBeVisible();
+  });
+
+  it("should toggle details", async () => {
+    setup({ details: { message: "Oh no!" } });
+    expect(screen.queryByText("Oh no!")).not.toBeVisible();
+
+    userEvent.click(screen.getByText("Show error details"));
+
+    expect(await screen.findByText("Oh no!")).toBeVisible();
+  });
+});

--- a/frontend/src/metabase/components/ErrorDetails/index.ts
+++ b/frontend/src/metabase/components/ErrorDetails/index.ts
@@ -1,2 +1,3 @@
 // eslint-disable-next-line import/no-default-export -- deprecated usage
 export { default } from "./ErrorDetails";
+export { ErrorBox } from "./ErrorBox";

--- a/frontend/src/metabase/components/ErrorDetails/types.ts
+++ b/frontend/src/metabase/components/ErrorDetails/types.ts
@@ -1,5 +1,7 @@
+export type ErrorDetails = string | Record<string, any>;
+
 export interface ErrorDetailsProps {
-  details?: string | Record<string, any>;
+  details?: ErrorDetails;
   centered?: boolean;
   className?: string;
 }

--- a/frontend/src/metabase/redux/uploads.ts
+++ b/frontend/src/metabase/redux/uploads.ts
@@ -92,7 +92,7 @@ export const uploadFile = createThunkAction(
           uploadError({
             id,
             message: t`There was an error uploading the file`,
-            error: err?.data?.message ?? err?.data?.cause,
+            error: err?.data?.message ?? err?.data,
           }),
         );
       }

--- a/frontend/src/metabase/redux/uploads.ts
+++ b/frontend/src/metabase/redux/uploads.ts
@@ -23,6 +23,8 @@ export const UPLOAD_FILE_TO_COLLECTION_ERROR =
   "metabase/collection/UPLOAD_FILE_ERROR";
 export const UPLOAD_FILE_TO_COLLECTION_CLEAR =
   "metabase/collection/UPLOAD_FILE_CLEAR";
+export const UPLOAD_FILE_CLEAR_ALL =
+  "metabase/collection/UPLOAD_FILE_CLEAR_ALL";
 
 const MAX_UPLOAD_SIZE = 50 * 1024 * 1024;
 export const MAX_UPLOAD_STRING = "50";
@@ -33,6 +35,7 @@ const uploadStart = createAction(UPLOAD_FILE_TO_COLLECTION_START);
 const uploadEnd = createAction(UPLOAD_FILE_TO_COLLECTION_END);
 const uploadError = createAction(UPLOAD_FILE_TO_COLLECTION_ERROR);
 const clearUpload = createAction(UPLOAD_FILE_TO_COLLECTION_CLEAR);
+export const clearAllUploads = createAction(UPLOAD_FILE_CLEAR_ALL);
 
 export const getAllUploads = (state: State) => Object.values(state.upload);
 
@@ -83,16 +86,15 @@ export const uploadFile = createThunkAction(
         );
 
         dispatch(Collections.actions.invalidateLists());
+        clear();
       } catch (err: any) {
         dispatch(
           uploadError({
             id,
-            message:
-              err?.data?.message ?? t`There was an error uploading the file`,
+            message: t`There was an error uploading the file`,
+            error: err?.data?.message ?? err?.data?.cause,
           }),
         );
-      } finally {
-        clear();
       }
     },
 );
@@ -137,6 +139,9 @@ const upload = handleActions<
     },
     [UPLOAD_FILE_TO_COLLECTION_CLEAR]: {
       next: (state, { payload: { id } }) => dissocIn(state, [id]),
+    },
+    [UPLOAD_FILE_CLEAR_ALL]: {
+      next: () => ({}),
     },
   },
   {},

--- a/frontend/src/metabase/redux/uploads.unit.spec.js
+++ b/frontend/src/metabase/redux/uploads.unit.spec.js
@@ -37,7 +37,7 @@ describe("csv uploads", () => {
 
     beforeEach(() => {
       dispatch = jest.fn();
-      jest.useFakeTimers().setSystemTime(now);
+      jest.useFakeTimers({ advanceTimers: true }).setSystemTime(now);
     });
 
     afterAll(() => {
@@ -94,14 +94,8 @@ describe("csv uploads", () => {
         type: UPLOAD_FILE_TO_COLLECTION_ERROR,
         payload: {
           id: now,
-          message: "It's dead Jim",
-        },
-      });
-
-      expect(dispatch).toHaveBeenCalledWith({
-        type: UPLOAD_FILE_TO_COLLECTION_CLEAR,
-        payload: {
-          id: now,
+          message: "There was an error uploading the file",
+          error: "It's dead Jim",
         },
       });
     });
@@ -126,13 +120,6 @@ describe("csv uploads", () => {
         payload: {
           id: now,
           message: `You cannot upload files larger than ${MAX_UPLOAD_STRING}mb`,
-        },
-      });
-
-      expect(dispatch).toHaveBeenCalledWith({
-        type: UPLOAD_FILE_TO_COLLECTION_CLEAR,
-        payload: {
-          id: now,
         },
       });
     });

--- a/frontend/src/metabase/status/components/FileUploadStatus/FileUploadStatus.unit.spec.tsx
+++ b/frontend/src/metabase/status/components/FileUploadStatus/FileUploadStatus.unit.spec.tsx
@@ -128,7 +128,9 @@ describe("FileUploadStatus", () => {
     fetchMock.post(
       "path:/api/card/from-csv",
       {
-        throws: { data: { message: "It's dead Jim" } },
+        throws: {
+          data: { message: "Something went wrong", cause: "It's dead Jim" },
+        },
         status: 400,
       },
       { delay: 1000 },
@@ -173,9 +175,14 @@ describe("FileUploadStatus", () => {
     jest.advanceTimersByTime(500);
 
     expect(
-      await screen.findByText("Error uploading your File"),
+      await screen.findByText("There was an error uploading the file"),
     ).toBeInTheDocument();
-    expect(await screen.findByText("It's dead Jim")).toBeInTheDocument();
+
+    userEvent.click(await screen.findByText("Show error details"));
+
+    expect(await screen.findByRole("dialog")).toBeInTheDocument();
+
+    expect(await screen.findByText("Something went wrong")).toBeInTheDocument();
   });
 
   describe("loading state", () => {

--- a/frontend/src/metabase/status/components/FileUploadStatusLarge/FileUploadErrorModal.tsx
+++ b/frontend/src/metabase/status/components/FileUploadStatusLarge/FileUploadErrorModal.tsx
@@ -1,0 +1,20 @@
+import { t } from "ttag";
+import { Box } from "@mantine/core";
+import Modal from "metabase/components/Modal";
+import ModalContent from "metabase/components/ModalContent";
+
+export const FileUploadErrorModal = ({
+  onClose,
+  children,
+}: {
+  onClose: () => void;
+  children: React.ReactNode;
+}) => {
+  return (
+    <Modal small>
+      <ModalContent title={t`Upload error details`} onClose={onClose}>
+        <Box p="md">{children}</Box>
+      </ModalContent>
+    </Modal>
+  );
+};

--- a/frontend/src/metabase/status/components/FileUploadStatusLarge/FileUploadErrorModal.tsx
+++ b/frontend/src/metabase/status/components/FileUploadStatusLarge/FileUploadErrorModal.tsx
@@ -1,19 +1,19 @@
 import { t } from "ttag";
-import { Box } from "@mantine/core";
 import Modal from "metabase/components/Modal";
 import ModalContent from "metabase/components/ModalContent";
+import { ErrorBox } from "metabase/components/ErrorDetails";
 
 export const FileUploadErrorModal = ({
   onClose,
   children,
 }: {
   onClose: () => void;
-  children: React.ReactNode;
+  children: string;
 }) => {
   return (
     <Modal small>
       <ModalContent title={t`Upload error details`} onClose={onClose}>
-        <Box p="md">{children}</Box>
+        <ErrorBox>{children}</ErrorBox>
       </ModalContent>
     </Modal>
   );

--- a/frontend/src/metabase/status/components/FileUploadStatusLarge/FileUploadStatusLarge.tsx
+++ b/frontend/src/metabase/status/components/FileUploadStatusLarge/FileUploadStatusLarge.tsx
@@ -1,7 +1,9 @@
 import { useState } from "react";
 import { useInterval } from "react-use";
 import { t } from "ttag";
+import { Box, Stack } from "metabase/ui";
 import Link from "metabase/core/components/Link";
+import Button from "metabase/core/components/Button";
 import { Collection } from "metabase-types/api";
 import { FileUpload } from "metabase-types/store/upload";
 
@@ -12,22 +14,29 @@ import {
 } from "metabase/lib/uploads";
 
 import StatusLarge from "../StatusLarge";
+import { FileUploadErrorModal } from "./FileUploadErrorModal";
 
 const UPLOAD_MESSAGE_UPDATE_INTERVAL = 30 * 1000;
 
 export interface FileUploadLargeProps {
   collection: Collection;
   uploads: FileUpload[];
+  resetUploads: () => void;
   isActive?: boolean;
 }
 
 const FileUploadLarge = ({
   collection,
   uploads,
+  resetUploads,
   isActive,
-}: FileUploadLargeProps): JSX.Element => {
+}: FileUploadLargeProps) => {
   const [loadingTime, setLoadingTime] = useState(0);
+  const [errorMessage, setErrorMessage] = useState<string | undefined>(
+    undefined,
+  );
 
+  const hasError = uploads.some(isUploadAborted);
   const isLoading = uploads.some(isUploadInProgress);
 
   useInterval(
@@ -48,14 +57,31 @@ const FileUploadLarge = ({
       id: upload.id,
       title: getName(upload),
       icon: "model",
-      description: getDescription(upload),
+      description: Description({ upload, setErrorMessage }),
       isInProgress: isUploadInProgress(upload),
       isCompleted: isUploadCompleted(upload),
       isAborted: isUploadAborted(upload),
     })),
   };
 
-  return <StatusLarge status={status} isActive={isActive} />;
+  if (Object.keys(uploads).length === 0) {
+    return null;
+  }
+
+  return (
+    <>
+      <StatusLarge
+        status={status}
+        isActive={isActive || hasError}
+        onDismiss={hasError ? resetUploads : undefined}
+      />
+      {errorMessage && (
+        <FileUploadErrorModal onClose={() => setErrorMessage(undefined)}>
+          {errorMessage}
+        </FileUploadErrorModal>
+      )}
+    </>
+  );
 };
 
 const getName = (upload: FileUpload) => {
@@ -91,12 +117,30 @@ const getLoadingMessage = (time: number) => {
   return `${loadingMessages[index]} …`;
 };
 
-const getDescription = (upload: FileUpload) => {
+const Description = ({
+  upload,
+  setErrorMessage,
+}: {
+  upload: FileUpload;
+  setErrorMessage: (msg?: string) => void;
+}) => {
   if (upload.status === "complete") {
     return <Link to={`/model/${upload.modelId}`}>Start exploring</Link>;
-  } else if (upload.status === "error") {
-    return upload.message;
   }
+
+  if (upload.status === "error") {
+    return (
+      <Stack align="start" spacing="xs">
+        <Box>{upload.message}</Box>
+        {upload.error && (
+          <Button onClick={() => setErrorMessage(upload.error)} onlyText>
+            {t`Show error details`}
+          </Button>
+        )}
+      </Stack>
+    );
+  }
+
   return "";
 };
 

--- a/frontend/src/metabase/status/components/FileUploadStatusLarge/FileUploadStatusLarge.tsx
+++ b/frontend/src/metabase/status/components/FileUploadStatusLarge/FileUploadStatusLarge.tsx
@@ -77,7 +77,7 @@ const FileUploadLarge = ({
       />
       {errorMessage && (
         <FileUploadErrorModal onClose={() => setErrorMessage(undefined)}>
-          {errorMessage}
+          {String(errorMessage)}
         </FileUploadErrorModal>
       )}
     </>

--- a/frontend/src/metabase/status/components/StatusLarge/StatusLarge.styled.tsx
+++ b/frontend/src/metabase/status/components/StatusLarge/StatusLarge.styled.tsx
@@ -36,9 +36,9 @@ export const StatusBody = styled.div`
   background-color: ${color("white")};
 `;
 
-export const StatusCardRoot = styled.div`
+export const StatusCardRoot = styled.div<{ hasBody?: boolean }>`
   display: flex;
-  align-items: center;
+  align-items: ${props => (props.hasBody ? "flex-start" : "center")};
   margin: 0.75rem;
 `;
 

--- a/frontend/src/metabase/status/components/StatusLarge/StatusLarge.tsx
+++ b/frontend/src/metabase/status/components/StatusLarge/StatusLarge.tsx
@@ -35,13 +35,15 @@ export interface StatusLargeProps {
   status: Status;
   isActive?: boolean;
   onCollapse?: () => void;
+  onDismiss?: () => void;
 }
 
 const StatusLarge = ({
   status,
   isActive,
   onCollapse,
-}: StatusLargeProps): JSX.Element => {
+  onDismiss,
+}: StatusLargeProps) => {
   return (
     <StatusRoot role="status">
       <StatusHeader>
@@ -49,6 +51,11 @@ const StatusLarge = ({
         {onCollapse && (
           <StatusToggle onClick={onCollapse}>
             <Icon name="chevrondown" />
+          </StatusToggle>
+        )}
+        {onDismiss && (
+          <StatusToggle onClick={onDismiss}>
+            <Icon name="close" />
           </StatusToggle>
         )}
       </StatusHeader>
@@ -80,7 +87,7 @@ const StatusCard = ({
   }
 
   return (
-    <StatusCardRoot key={id}>
+    <StatusCardRoot key={id} hasBody={!!description}>
       <StatusCardIcon>
         <Icon name={icon as unknown as IconName} />
       </StatusCardIcon>


### PR DESCRIPTION
Partly handles  https://github.com/metabase/metabase/issues/31397

### Description

Allows the File Upload Status message to 
- stay open when a file upload errors
- spawn a detail modal to hold error messages
- be dismissible when there are error messages
![upload-error-details](https://github.com/metabase/metabase/assets/30528226/d1d36050-e7df-49a4-94e1-561333430a8c)

![Screen Shot 2023-06-20 at 3 01 07 PM](https://github.com/metabase/metabase/assets/30528226/6b424108-c091-4cf4-a5b6-7c0cd231670c)

Also extracts the error display subcomponent from the one used in the query builder to be reusable.

### How to verify

Upload a csv file that throws an error, see that you see a short generic message in the notification container, but can open up a detail modal with more info.

The CSVs marked `broken` [here](https://www.notion.so/metabase/9b4b30602feb40d7bb8405b1bdb76b75?v=a83d09fef7254d5b8ba796111c1f647d&p=49d34d6aee8249aba14560c22a73caf8&pm=s) should give you errors locally


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
