### PR TITLE
Fix dashboard description markdown overflow

### DIFF
--- a/frontend/src/metabase/core/components/EditableText/EditableText.styled.tsx
+++ b/frontend/src/metabase/core/components/EditableText/EditableText.styled.tsx
@@ -14,6 +14,7 @@ export const EditableTextRoot = styled.div<EditableTextRootProps>`
   padding: 0.25rem;
   border: 1px solid transparent;
   border-radius: 4px;
+  word-wrap: break-word;
 
   &:hover,
   &:focus-within {

--- a/frontend/src/metabase/core/components/EditableText/EditableText.styled.tsx
+++ b/frontend/src/metabase/core/components/EditableText/EditableText.styled.tsx
@@ -1,11 +1,11 @@
 import styled from "@emotion/styled";
 import { css } from "@emotion/react";
 import { color } from "metabase/lib/colors";
-import MarkdownBase from "../Markdown";
 
 export interface EditableTextRootProps {
   isEditing?: boolean;
   isDisabled: boolean;
+  isEditingMarkdown?: boolean;
 }
 
 export const EditableTextRoot = styled.div<EditableTextRootProps>`
@@ -27,12 +27,16 @@ export const EditableTextRoot = styled.div<EditableTextRootProps>`
       border-color: ${color("border")};
     `}
 
-  &:after {
-    content: attr(data-value);
-    visibility: hidden;
-    white-space: pre-wrap;
-    word-wrap: break-word;
-  }
+  ${({ isEditingMarkdown }) =>
+    isEditingMarkdown &&
+    css`
+      &:after {
+        content: attr(data-value);
+        visibility: hidden;
+        white-space: pre-wrap;
+        word-wrap: break-word;
+      }
+    `}
 `;
 
 export const EditableTextArea = styled.textarea`
@@ -57,8 +61,4 @@ export const EditableTextArea = styled.textarea`
   &:focus {
     cursor: text;
   }
-`;
-
-export const Markdown = styled(MarkdownBase)`
-  position: absolute;
 `;

--- a/frontend/src/metabase/core/components/EditableText/EditableText.tsx
+++ b/frontend/src/metabase/core/components/EditableText/EditableText.tsx
@@ -13,11 +13,8 @@ import {
 
 import { usePrevious } from "react-use";
 
-import {
-  EditableTextArea,
-  EditableTextRoot,
-  Markdown,
-} from "./EditableText.styled";
+import Markdown from "metabase/core/components/Markdown";
+import { EditableTextArea, EditableTextRoot } from "./EditableText.styled";
 
 export type EditableTextAttributes = Omit<
   HTMLAttributes<HTMLDivElement>,
@@ -133,6 +130,7 @@ const EditableText = forwardRef(function EditableText(
       ref={ref}
       isEditing={isEditing}
       isDisabled={isDisabled}
+      isEditingMarkdown={!shouldShowMarkdown}
       data-value={`${displayValue}\u00A0`}
       data-testid="editable-text"
     >


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/31326

### Description

There is an issue with markdown in dashboard description. It overflows its allocated area due to technical implementation. 
We decided to fix this.

### Demo


https://github.com/metabase/metabase/assets/7983744/1a917e84-b853-466b-bb3d-98044569dc60



### Checklist

- [x] Tests have been added/updated to cover changes in this PR
