### PR TITLE
[Auditv2] Remove instance analytics dev mocks

### DIFF
--- a/frontend/src/metabase/entities/collections/collections.ts
+++ b/frontend/src/metabase/entities/collections/collections.ts
@@ -24,32 +24,6 @@ type EntityInCollection = {
   collection?: Collection;
 };
 
-// TODO FIXME DELETE THIS - mock for development only
-const addTypesToCollections = (collections: Collection[]) => {
-  const reservedNames = ["Instance analytics", "Audit", "Usage", "Performance"];
-
-  for (const col of collections) {
-    if (reservedNames.includes(col.name)) {
-      col.type = "instance-analytics";
-      col.can_write = false;
-    }
-
-    if (col.children) {
-      col.children = addTypesToCollections(col.children);
-    }
-  }
-
-  return collections;
-};
-
-const FAKE_ListCollections = async (params: any, ...args: any) => {
-  const fetchedCollections = await (params?.tree
-    ? listCollectionsTree(params, ...args)
-    : listCollections(params, ...args));
-
-  return addTypesToCollections(fetchedCollections);
-};
-
 const Collections = createEntity({
   name: "collections",
   path: "/api/collection",
@@ -59,16 +33,10 @@ const Collections = createEntity({
   displayNameMany: t`collections`,
 
   api: {
-    get: async (...params: any[]) => {
-      const response = await GET("/api/collection/:id")(params[0]);
-      return addTypesToCollections([response as unknown as Collection])[0];
-    },
     list: async (params: { tree?: boolean }, ...args: any) =>
       params?.tree
-        ? FAKE_ListCollections(params, ...args)
-        : FAKE_ListCollections(params, ...args),
-    // ? listCollectionsTree(params, ...args)
-    // : listCollections(params, ...args),
+        ? listCollectionsTree(params, ...args)
+        : listCollections(params, ...args),
   },
 
   objectActions: {

--- a/frontend/src/metabase/entities/questions.js
+++ b/frontend/src/metabase/entities/questions.js
@@ -3,7 +3,6 @@ import { updateIn } from "icepick";
 
 import { createEntity, undo } from "metabase/lib/entities";
 import * as Urls from "metabase/lib/urls";
-import { GET } from "metabase/lib/api";
 import { color } from "metabase/lib/colors";
 import {
   getMetadata,
@@ -26,22 +25,6 @@ const Questions = createEntity({
   name: "questions",
   nameOne: "question",
   path: "/api/card",
-  // FIXME temp mock code
-  api: {
-    get: async (...params) => {
-      const card = await GET(`/api/card/:id`)(params[0]);
-
-      if (
-        ["Audit", "Performance", "Usage", "Instance analytics"].includes(
-          card?.collection?.name,
-        )
-      ) {
-        card.collection.type = "instance-analytics";
-        card.can_write = false;
-      }
-      return card;
-    },
-  },
 
   objectActions: {
     setArchived: ({ id, dataset, model }, archived, opts) =>


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/31535

### Description

Now that we have the backend generating collections, etc, we can remove the front end dev mocks.

### How to verify

- spin up the EE backend on this branch
- see that you get an auto-generated instance analytics collection with a special icon
- Make your own collection called "Instance Analytics"
- see that it doesn't get a special icon
