### PR TITLE
Remove POST api/database/:id/sync endpoint

### DIFF
--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -945,7 +945,7 @@
   api/generic-204-no-content)
 
 
-;;; ------------------------------------------ POST /api/database/:id/sync -------------------------------------------
+;;; ------------------------------------------ POST /api/database/:id/sync_schema -------------------------------------------
 
 ;; Should somehow trigger sync-database/sync-database!
 (api/defendpoint POST "/:id/sync_schema"
@@ -971,6 +971,8 @@
     ;; avoid n+1
     (t2/update! Table {:id [:in (map :id tables)]} {:initial_sync_status "complete"}))
   {:status :ok})
+
+;;; ------------------------------------------ POST /api/database/:id/rescan_values -------------------------------------------
 
 ;; TODO - do we also want an endpoint to manually trigger analysis. Or separate ones for classification/fingerprinting?
 

--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -947,21 +947,6 @@
 
 ;;; ------------------------------------------ POST /api/database/:id/sync -------------------------------------------
 
-;; TODO - Shouldn't we just check for superuser status instead of write checking?
-;; NOTE Atte: This becomes maybe obsolete
-#_{:clj-kondo/ignore [:deprecated-var]}
-(api/defendpoint-schema POST "/:id/sync"
-  "Update the metadata for this `Database`. This happens asynchronously."
-  [id]
-  ;; just publish a message and let someone else deal with the logistics
-  ;; TODO - does this make any more sense having this extra level of indirection?
-  ;; Why not just use a future?
-  (events/publish-event! :database-trigger-sync (api/write-check Database id))
-  {:status :ok})
-
-;; NOTE Atte Keinänen: If you think that these endpoints could have more descriptive names, please change them.
-;; Currently these match the titles of the admin UI buttons that call these endpoints
-
 ;; Should somehow trigger sync-database/sync-database!
 (api/defendpoint POST "/:id/sync_schema"
   "Trigger a manual update of the schema metadata for this `Database`."

--- a/src/metabase/events/sync_database.clj
+++ b/src/metabase/events/sync_database.clj
@@ -12,9 +12,7 @@
 
 (def ^:private sync-database-topics
   "The `Set` of event topics which are subscribed to for use in database syncing."
-  #{:database-create
-    ;; published by POST /api/database/:id/sync -- a message to start syncing the DB right away
-    :database-trigger-sync})
+  #{:database-create})
 
 (defonce ^:private ^{:doc "Channel for receiving event notifications we want to subscribe to for database sync events."}
   sync-database-channel

--- a/test/metabase/sync/analyze_test.clj
+++ b/test/metabase/sync/analyze_test.clj
@@ -172,7 +172,7 @@
 (defn- api-sync!
   "Trigger a sync of `table` via the API."
   [table]
-  (mt/user-http-request :crowberto :post 200 (format "database/%d/sync" (:db_id table))))
+  (mt/user-http-request :crowberto :post 200 (format "database/%d/sync_schema" (:db_id table))))
 
 ;; use these functions to create fake Tables & Fields that are actually backed by something real in the database.
 ;; Otherwise when we go to resync them the logic will figure out Table/Field doesn't exist and mark it as inactive


### PR DESCRIPTION
Resolves https://github.com/metabase/metabase/issues/31544

This endpoint is unused on the FE. This PR removes it.