### PR TITLE
4/x Follow up reviews and tests

### DIFF
--- a/frontend/src/metabase/components/AppBanner/AppBanner.tsx
+++ b/frontend/src/metabase/components/AppBanner/AppBanner.tsx
@@ -22,7 +22,7 @@ export const AppBanner = ({ location }: AppBannerProps) => {
     return (
       <PaymentBanner isAdmin={isAdmin} tokenStatusStatus={tokenStatusStatus} />
     );
-  } else {
-    return <DatabasePromptBanner location={location} />;
   }
+
+  return <DatabasePromptBanner location={location} />;
 };

--- a/frontend/src/metabase/nav/components/DatabasePromptBanner/DatabasePromptBanner.tsx
+++ b/frontend/src/metabase/nav/components/DatabasePromptBanner/DatabasePromptBanner.tsx
@@ -2,12 +2,8 @@ import { t } from "ttag";
 import type { Location } from "history";
 
 import Link from "metabase/core/components/Link/Link";
-import { useDatabaseListQuery } from "metabase/common/hooks";
-import { useSelector } from "metabase/lib/redux";
-import { getUserIsAdmin } from "metabase/selectors/user";
-import { getIsPaidPlan } from "metabase/selectors/settings";
 import { trackDatabasePromptBannerClicked } from "metabase/nav/analytics";
-import { PLUGIN_SELECTORS } from "metabase/plugins";
+import { useShouldShowDatabasePromptBanner } from "metabase/nav/hooks";
 
 import {
   ConnectDatabaseButton,
@@ -22,17 +18,7 @@ interface DatabasePromptBannerProps {
 }
 
 export function DatabasePromptBanner({ location }: DatabasePromptBannerProps) {
-  const isAdmin = useSelector(getUserIsAdmin);
-  const isPaidPlan = useSelector(getIsPaidPlan);
-  const { data: databases = [] } = useDatabaseListQuery({
-    enabled: isAdmin && isPaidPlan,
-  });
-  const onlyHaveSampleDatabase =
-    databases.length === 1 && databases[0].is_sample;
-  const isWhiteLabeling = useSelector(PLUGIN_SELECTORS.getIsWhiteLabeling);
-  const shouldShowDatabasePromptBanner =
-    isAdmin && isPaidPlan && onlyHaveSampleDatabase && !isWhiteLabeling;
-
+  const shouldShowDatabasePromptBanner = useShouldShowDatabasePromptBanner();
   if (!shouldShowDatabasePromptBanner) {
     return null;
   }

--- a/frontend/src/metabase/nav/components/DatabasePromptBanner/DatabasePromptBanner.unit.spec.tsx
+++ b/frontend/src/metabase/nav/components/DatabasePromptBanner/DatabasePromptBanner.unit.spec.tsx
@@ -69,7 +69,7 @@ async function setup({
   // Then we could safely assert that the banner is not rendered.
   // If we don't wait for this API call to finish, the banner could have rendered,
   // and the test would still pass.
-  if (isAdmin && isPaidPlan) {
+  if (isAdmin && isPaidPlan && !isWhiteLabeling) {
     await waitFor(() => {
       expect(fetchMock.called("path:/api/database")).toBe(true);
     });

--- a/frontend/src/metabase/nav/components/DatabasePromptBanner/DatabasePromptBanner.unit.spec.tsx
+++ b/frontend/src/metabase/nav/components/DatabasePromptBanner/DatabasePromptBanner.unit.spec.tsx
@@ -64,8 +64,7 @@ async function setup({
     },
   );
 
-  // 1. We will only call this endpoint when `isAdmin` and `isPaidPlan` are both true.
-  // 2. This check ensures the conditions for database prompt banner are all available.
+  // This check ensures the conditions for database prompt banner are all available.
   // Then we could safely assert that the banner is not rendered.
   // If we don't wait for this API call to finish, the banner could have rendered,
   // and the test would still pass.

--- a/frontend/src/metabase/nav/components/DatabasePromptBanner/DatabasePromptBanner.unit.spec.tsx
+++ b/frontend/src/metabase/nav/components/DatabasePromptBanner/DatabasePromptBanner.unit.spec.tsx
@@ -36,9 +36,9 @@ async function setup({
   isOnAdminAddDatabasePage = false,
 }: setupOpts = {}) {
   if (onlyHaveSampleDatabase) {
-    await setupDatabasesEndpoints([TEST_DB]);
+    setupDatabasesEndpoints([TEST_DB]);
   } else {
-    await setupDatabasesEndpoints([TEST_DB, DATA_WAREHOUSE_DB]);
+    setupDatabasesEndpoints([TEST_DB, DATA_WAREHOUSE_DB]);
   }
 
   const state = createMockState({

--- a/frontend/src/metabase/nav/components/PaymentBanner/PaymentBanner.unit.spec.tsx
+++ b/frontend/src/metabase/nav/components/PaymentBanner/PaymentBanner.unit.spec.tsx
@@ -78,43 +78,39 @@ describe("PaymentBanner", () => {
       {
         isAdmin: true,
         tokenStatusStatus: "past-due",
-        shouldRenderPaymentBanner: true,
+        hasBanner: true,
       },
       {
         isAdmin: true,
         tokenStatusStatus: "unpaid",
-        shouldRenderPaymentBanner: true,
+        hasBanner: true,
       },
       {
         isAdmin: true,
         tokenStatusStatus: "something-else",
-        shouldRenderPaymentBanner: false,
+        hasBanner: false,
       },
       {
         isAdmin: false,
         tokenStatusStatus: "past-due",
-        shouldRenderPaymentBanner: false,
+        hasBanner: false,
       },
       {
         isAdmin: false,
         tokenStatusStatus: "unpaid",
-        shouldRenderPaymentBanner: false,
+        hasBanner: false,
       },
       {
         isAdmin: false,
         tokenStatusStatus: "something-else",
-        shouldRenderPaymentBanner: false,
+        hasBanner: false,
       },
     ])(
       "should return `${shouldRenderPaymentBanner} when isAdmin: $isAdmin, and tokenStatusStatus: $tokenStatusStatus`",
-      ({
-        isAdmin,
-        tokenStatusStatus,
-        shouldRenderPaymentBanner: expectedShouldRenderPaymentBanner,
-      }) => {
+      ({ isAdmin, tokenStatusStatus, hasBanner }) => {
         expect(
           shouldRenderPaymentBanner({ isAdmin, tokenStatusStatus }),
-        ).toEqual(expectedShouldRenderPaymentBanner);
+        ).toEqual(hasBanner);
       },
     );
   });

--- a/frontend/src/metabase/nav/hooks.ts
+++ b/frontend/src/metabase/nav/hooks.ts
@@ -4,16 +4,16 @@ import { PLUGIN_SELECTORS } from "metabase/plugins";
 import { getIsPaidPlan } from "metabase/selectors/settings";
 import { getUserIsAdmin } from "metabase/selectors/user";
 
-export function useShouldShowDatabasePromptBanner() {
+export function useShouldShowDatabasePromptBanner(): boolean | undefined {
   const isAdmin = useSelector(getUserIsAdmin);
   const isPaidPlan = useSelector(getIsPaidPlan);
   const isWhiteLabeling = useSelector(PLUGIN_SELECTORS.getIsWhiteLabeling);
 
-  const { data: databases = [] } = useDatabaseListQuery({
+  const { data: databases } = useDatabaseListQuery({
     enabled: isAdmin && isPaidPlan && !isWhiteLabeling,
   });
   const onlyHaveSampleDatabase =
-    databases.length === 1 && databases[0].is_sample;
+    databases && databases.length === 1 && databases[0].is_sample;
 
   return isAdmin && isPaidPlan && !isWhiteLabeling && onlyHaveSampleDatabase;
 }

--- a/frontend/src/metabase/nav/hooks.ts
+++ b/frontend/src/metabase/nav/hooks.ts
@@ -1,0 +1,19 @@
+import { useDatabaseListQuery } from "metabase/common/hooks";
+import { useSelector } from "metabase/lib/redux";
+import { PLUGIN_SELECTORS } from "metabase/plugins";
+import { getIsPaidPlan } from "metabase/selectors/settings";
+import { getUserIsAdmin } from "metabase/selectors/user";
+
+export function useShouldShowDatabasePromptBanner() {
+  const isAdmin = useSelector(getUserIsAdmin);
+  const isPaidPlan = useSelector(getIsPaidPlan);
+  const isWhiteLabeling = useSelector(PLUGIN_SELECTORS.getIsWhiteLabeling);
+
+  const { data: databases = [] } = useDatabaseListQuery({
+    enabled: isAdmin && isPaidPlan && !isWhiteLabeling,
+  });
+  const onlyHaveSampleDatabase =
+    databases.length === 1 && databases[0].is_sample;
+
+  return isAdmin && isPaidPlan && !isWhiteLabeling && onlyHaveSampleDatabase;
+}

--- a/frontend/src/metabase/nav/hooks.ts
+++ b/frontend/src/metabase/nav/hooks.ts
@@ -8,12 +8,22 @@ export function useShouldShowDatabasePromptBanner(): boolean | undefined {
   const isAdmin = useSelector(getUserIsAdmin);
   const isPaidPlan = useSelector(getIsPaidPlan);
   const isWhiteLabeling = useSelector(PLUGIN_SELECTORS.getIsWhiteLabeling);
+  const isEligibleForDatabasePromptBanner =
+    isAdmin && isPaidPlan && !isWhiteLabeling;
 
   const { data: databases } = useDatabaseListQuery({
-    enabled: isAdmin && isPaidPlan && !isWhiteLabeling,
+    enabled: isEligibleForDatabasePromptBanner,
   });
-  const onlyHaveSampleDatabase =
-    databases && databases.length === 1 && databases[0].is_sample;
 
-  return isAdmin && isPaidPlan && !isWhiteLabeling && onlyHaveSampleDatabase;
+  if (!isEligibleForDatabasePromptBanner) {
+    return false;
+  }
+
+  if (databases === undefined) {
+    return undefined;
+  }
+
+  const onlyHasSampleDatabase =
+    databases.length === 1 && databases[0].is_sample;
+  return onlyHasSampleDatabase;
 }

--- a/frontend/src/metabase/nav/hooks.unit.spec.tsx
+++ b/frontend/src/metabase/nav/hooks.unit.spec.tsx
@@ -1,0 +1,195 @@
+import fetchMock from "fetch-mock";
+
+import { renderWithProviders, screen, waitFor } from "__support__/ui";
+import { setupEnterpriseTest } from "__support__/enterprise";
+import { mockSettings } from "__support__/settings";
+import { setupDatabasesEndpoints } from "__support__/server-mocks";
+import {
+  createMockDatabase,
+  createMockTokenFeatures,
+  createMockUser,
+} from "metabase-types/api/mocks";
+import { createMockState } from "metabase-types/store/mocks";
+import { createSampleDatabase } from "metabase-types/api/mocks/presets";
+
+import { useShouldShowDatabasePromptBanner } from "./hooks";
+
+interface setupOpts {
+  isAdmin?: boolean;
+  isPaidPlan?: boolean;
+  onlyHaveSampleDatabase?: boolean;
+  isOnAdminAddDatabasePage?: boolean;
+  isWhiteLabeling?: boolean;
+}
+const TEST_DB = createSampleDatabase();
+
+const DATA_WAREHOUSE_DB = createMockDatabase({ id: 2 });
+
+async function setup({
+  isAdmin = false,
+  isPaidPlan = false,
+  isWhiteLabeling = false,
+  onlyHaveSampleDatabase = false,
+}: setupOpts = {}) {
+  if (onlyHaveSampleDatabase) {
+    await setupDatabasesEndpoints([TEST_DB]);
+  } else {
+    await setupDatabasesEndpoints([TEST_DB, DATA_WAREHOUSE_DB]);
+  }
+
+  const state = createMockState({
+    currentUser: createMockUser({ is_superuser: isAdmin }),
+    settings: mockSettings({
+      "token-features": createMockTokenFeatures(
+        isPaidPlan ? { sso: true } : {},
+      ),
+      "application-name": isWhiteLabeling ? "Acme Corp." : "Metabase",
+    }),
+  });
+
+  function TestComponent() {
+    const shouldShowDatabasePromptBanner = useShouldShowDatabasePromptBanner();
+    return shouldShowDatabasePromptBanner ? (
+      <>showing database prompt banner</>
+    ) : (
+      <>hiding database prompt banner</>
+    );
+  }
+
+  renderWithProviders(<TestComponent />, {
+    storeInitialState: state,
+  });
+
+  // 1. We will only call this endpoint when `isAdmin` and `isPaidPlan` are both true.
+  // 2. This check ensures the conditions for database prompt banner are all available.
+  // Then we could safely assert that the banner is not rendered.
+  // If we don't wait for this API call to finish, the banner could have rendered,
+  // and the test would still pass.
+  if (isAdmin && isPaidPlan && !isWhiteLabeling) {
+    await waitFor(() => {
+      expect(fetchMock.called("path:/api/database")).toBe(true);
+    });
+  }
+}
+
+describe("useShouldShowDatabasePromptBanner", () => {
+  beforeEach(() => {
+    setupEnterpriseTest();
+  });
+
+  it("should render for admin user with paid plan and has only sample database, but not white-labeled", async () => {
+    await setup({
+      isAdmin: true,
+      isPaidPlan: true,
+      onlyHaveSampleDatabase: true,
+      isWhiteLabeling: false,
+    });
+
+    expect(screen.getByText("showing database prompt banner")).toBeVisible();
+  });
+
+  it.each([
+    {
+      isPaidPlan: true,
+      onlyHaveSampleDatabase: true,
+      isWhiteLabeling: true,
+    },
+    {
+      isPaidPlan: true,
+      onlyHaveSampleDatabase: true,
+      isWhiteLabeling: false,
+    },
+    {
+      isPaidPlan: true,
+      onlyHaveSampleDatabase: false,
+      isWhiteLabeling: true,
+    },
+    {
+      isPaidPlan: true,
+      onlyHaveSampleDatabase: false,
+      isWhiteLabeling: false,
+    },
+    {
+      isPaidPlan: false,
+      onlyHaveSampleDatabase: true,
+      isWhiteLabeling: true,
+    },
+    {
+      isPaidPlan: false,
+      onlyHaveSampleDatabase: true,
+      isWhiteLabeling: false,
+    },
+    {
+      isPaidPlan: false,
+      onlyHaveSampleDatabase: false,
+      isWhiteLabeling: true,
+    },
+    {
+      isPaidPlan: false,
+      onlyHaveSampleDatabase: false,
+      isWhiteLabeling: false,
+    },
+  ] as const)(
+    "should not render for non-admin users when isPaidPlan: $isPaidPlan, onlyHaveSampleDatabase: $onlyHaveSampleDatabase, isWhiteLabeling: $isWhiteLabeling",
+    async ({ isPaidPlan, onlyHaveSampleDatabase, isWhiteLabeling }) => {
+      await setup({
+        isAdmin: false,
+        isPaidPlan,
+        onlyHaveSampleDatabase,
+        isWhiteLabeling,
+      });
+
+      expect(screen.getByText("hiding database prompt banner")).toBeVisible();
+    },
+  );
+
+  it.each([
+    {
+      isPaidPlan: true,
+      onlyHaveSampleDatabase: true,
+      isWhiteLabeling: true,
+    },
+    {
+      isPaidPlan: true,
+      onlyHaveSampleDatabase: false,
+      isWhiteLabeling: true,
+    },
+    {
+      isPaidPlan: true,
+      onlyHaveSampleDatabase: false,
+      isWhiteLabeling: false,
+    },
+    {
+      isPaidPlan: false,
+      onlyHaveSampleDatabase: true,
+      isWhiteLabeling: true,
+    },
+    {
+      isPaidPlan: false,
+      onlyHaveSampleDatabase: true,
+      isWhiteLabeling: false,
+    },
+    {
+      isPaidPlan: false,
+      onlyHaveSampleDatabase: false,
+      isWhiteLabeling: true,
+    },
+    {
+      isPaidPlan: false,
+      onlyHaveSampleDatabase: false,
+      isWhiteLabeling: false,
+    },
+  ] as const)(
+    "should not render for admin users when isPaidPlan: $isPaidPlan, onlyHaveSampleDatabase: $onlyHaveSampleDatabase, isWhiteLabeling: $isWhiteLabeling",
+    async ({ isPaidPlan, onlyHaveSampleDatabase, isWhiteLabeling }) => {
+      await setup({
+        isAdmin: true,
+        isPaidPlan,
+        onlyHaveSampleDatabase,
+        isWhiteLabeling,
+      });
+
+      expect(screen.getByText("hiding database prompt banner")).toBeVisible();
+    },
+  );
+});

--- a/frontend/src/metabase/nav/hooks.unit.spec.tsx
+++ b/frontend/src/metabase/nav/hooks.unit.spec.tsx
@@ -96,6 +96,56 @@ describe("useShouldShowDatabasePromptBanner", () => {
     },
     {
       isPaidPlan: true,
+      onlyHaveSampleDatabase: false,
+      isWhiteLabeling: true,
+    },
+    {
+      isPaidPlan: true,
+      onlyHaveSampleDatabase: false,
+      isWhiteLabeling: false,
+    },
+    {
+      isPaidPlan: false,
+      onlyHaveSampleDatabase: true,
+      isWhiteLabeling: true,
+    },
+    {
+      isPaidPlan: false,
+      onlyHaveSampleDatabase: true,
+      isWhiteLabeling: false,
+    },
+    {
+      isPaidPlan: false,
+      onlyHaveSampleDatabase: false,
+      isWhiteLabeling: true,
+    },
+    {
+      isPaidPlan: false,
+      onlyHaveSampleDatabase: false,
+      isWhiteLabeling: false,
+    },
+  ] as const)(
+    "should not render for admin users when isPaidPlan: $isPaidPlan, onlyHaveSampleDatabase: $onlyHaveSampleDatabase, isWhiteLabeling: $isWhiteLabeling",
+    async ({ isPaidPlan, onlyHaveSampleDatabase, isWhiteLabeling }) => {
+      await setup({
+        isAdmin: true,
+        isPaidPlan,
+        onlyHaveSampleDatabase,
+        isWhiteLabeling,
+      });
+
+      expect(screen.getByText("hiding database prompt banner")).toBeVisible();
+    },
+  );
+
+  it.each([
+    {
+      isPaidPlan: true,
+      onlyHaveSampleDatabase: true,
+      isWhiteLabeling: true,
+    },
+    {
+      isPaidPlan: true,
       onlyHaveSampleDatabase: true,
       isWhiteLabeling: false,
     },
@@ -134,56 +184,6 @@ describe("useShouldShowDatabasePromptBanner", () => {
     async ({ isPaidPlan, onlyHaveSampleDatabase, isWhiteLabeling }) => {
       await setup({
         isAdmin: false,
-        isPaidPlan,
-        onlyHaveSampleDatabase,
-        isWhiteLabeling,
-      });
-
-      expect(screen.getByText("hiding database prompt banner")).toBeVisible();
-    },
-  );
-
-  it.each([
-    {
-      isPaidPlan: true,
-      onlyHaveSampleDatabase: true,
-      isWhiteLabeling: true,
-    },
-    {
-      isPaidPlan: true,
-      onlyHaveSampleDatabase: false,
-      isWhiteLabeling: true,
-    },
-    {
-      isPaidPlan: true,
-      onlyHaveSampleDatabase: false,
-      isWhiteLabeling: false,
-    },
-    {
-      isPaidPlan: false,
-      onlyHaveSampleDatabase: true,
-      isWhiteLabeling: true,
-    },
-    {
-      isPaidPlan: false,
-      onlyHaveSampleDatabase: true,
-      isWhiteLabeling: false,
-    },
-    {
-      isPaidPlan: false,
-      onlyHaveSampleDatabase: false,
-      isWhiteLabeling: true,
-    },
-    {
-      isPaidPlan: false,
-      onlyHaveSampleDatabase: false,
-      isWhiteLabeling: false,
-    },
-  ] as const)(
-    "should not render for admin users when isPaidPlan: $isPaidPlan, onlyHaveSampleDatabase: $onlyHaveSampleDatabase, isWhiteLabeling: $isWhiteLabeling",
-    async ({ isPaidPlan, onlyHaveSampleDatabase, isWhiteLabeling }) => {
-      await setup({
-        isAdmin: true,
         isPaidPlan,
         onlyHaveSampleDatabase,
         isWhiteLabeling,

--- a/frontend/src/metabase/nav/hooks.unit.spec.tsx
+++ b/frontend/src/metabase/nav/hooks.unit.spec.tsx
@@ -32,9 +32,9 @@ async function setup({
   onlyHaveSampleDatabase = false,
 }: setupOpts = {}) {
   if (onlyHaveSampleDatabase) {
-    await setupDatabasesEndpoints([TEST_DB]);
+    setupDatabasesEndpoints([TEST_DB]);
   } else {
-    await setupDatabasesEndpoints([TEST_DB, DATA_WAREHOUSE_DB]);
+    setupDatabasesEndpoints([TEST_DB, DATA_WAREHOUSE_DB]);
   }
 
   const state = createMockState({

--- a/frontend/src/metabase/nav/hooks.unit.spec.tsx
+++ b/frontend/src/metabase/nav/hooks.unit.spec.tsx
@@ -60,8 +60,7 @@ async function setup({
     storeInitialState: state,
   });
 
-  // 1. We will only call this endpoint when `isAdmin` and `isPaidPlan` are both true.
-  // 2. This check ensures the conditions for database prompt banner are all available.
+  // This check ensures the conditions for database prompt banner are all available.
   // Then we could safely assert that the banner is not rendered.
   // If we don't wait for this API call to finish, the banner could have rendered,
   // and the test would still pass.


### PR DESCRIPTION
Epic: https://github.com/metabase/metabase/issues/31015
[Product doc](https://www.notion.so/metabase/Really-encourage-admins-to-add-a-DB-9c8c3a7d08ca45cb8672a154220f443e?pvs=4)

### Description

This PR Addresses review feedback in https://github.com/metabase/metabase/pull/31210, by adding + reorganize tests so it's more readable and covers all cases.

Contexts:
- https://github.com/metabase/metabase/pull/31210#discussion_r1224189564
- https://metaboat.slack.com/archives/C057LE0Q4PQ/p1686587503768999

### How to verify
This PR only adds/restructure tests, but if you're curious about the feature you can test the following:

The database prompt banner would be visible if:
1. User is an admin
2. Instance is on a paid plan
3. White label isn't enabled (only for Pro and Enterprise users, only if `application-name` is changed to something except **Metabase**)
4. The only connected database is a sample database

Also, the database prompt banner will only appear in full-app embedding, but not public or signed embeds.

Other than that there shouldn't be any database prompt banner at all.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
