### PR TITLE
[E2E] Fix 18630 repro flake

### DIFF
--- a/e2e/test/scenarios/joins/reproductions/18630-field-literals-in-joins.cy.spec.js
+++ b/e2e/test/scenarios/joins/reproductions/18630-field-literals-in-joins.cy.spec.js
@@ -58,7 +58,9 @@ describe("issue 18630", () => {
     cy.createQuestion(questionDetails, { visitQuestion: true });
 
     // The query runs and we assert the page is not blank,
-    // rather than an infinite loop and stack overflow.
+    // which was caused by an infinite loop and a stack overflow.
     cy.findByDisplayValue(questionDetails.name);
+    cy.get(".cellData").contains("29494 Anderson Drive");
+    cy.findByTestId("question-row-count").should("have.text", "Showing 3 rows");
   });
 });

--- a/e2e/test/scenarios/joins/reproductions/18630-field-literals-in-joins.cy.spec.js
+++ b/e2e/test/scenarios/joins/reproductions/18630-field-literals-in-joins.cy.spec.js
@@ -46,6 +46,7 @@ describe("issue 18630", () => {
         alias: "People",
       },
     ],
+    limit: 3,
   };
 
   it("should normally open queries with field literals in joins (metabase#18630)", () => {

--- a/e2e/test/scenarios/joins/reproductions/18630-field-literals-in-joins.cy.spec.js
+++ b/e2e/test/scenarios/joins/reproductions/18630-field-literals-in-joins.cy.spec.js
@@ -49,16 +49,16 @@ describe("issue 18630", () => {
     limit: 3,
   };
 
+  const questionDetails = {
+    name: "18630",
+    query: QUERY_WITH_FIELD_CLAUSE,
+  };
+
   it("should normally open queries with field literals in joins (metabase#18630)", () => {
-    cy.createQuestion(
-      { query: QUERY_WITH_FIELD_CLAUSE },
-      { visitQuestion: true },
-    );
+    cy.createQuestion(questionDetails, { visitQuestion: true });
 
     // The query runs and we assert the page is not blank,
     // rather than an infinite loop and stack overflow.
-    // 'test question' is the name of the question.
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("test question");
+    cy.findByDisplayValue(questionDetails.name);
   });
 });

--- a/e2e/test/scenarios/joins/reproductions/18630-field-literals-in-joins.cy.spec.js
+++ b/e2e/test/scenarios/joins/reproductions/18630-field-literals-in-joins.cy.spec.js
@@ -1,12 +1,10 @@
 import { restore } from "e2e/support/helpers";
-
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 
 const { ORDERS, ORDERS_ID, PEOPLE, PEOPLE_ID } = SAMPLE_DATABASE;
 
 describe("issue 18630", () => {
   beforeEach(() => {
-    cy.intercept("POST", "/api/dataset").as("dataset");
     restore();
     cy.signInAsAdmin();
   });


### PR DESCRIPTION
Example of the failed run:
https://github.com/metabase/metabase/actions/runs/5252834840/jobs/9491715650

Recording of that failed run:
https://www.deploysentinel.com/ci/runs/64883c9fe3bc99e51f21227a

Cause
```
CypressError
CypressError: Timed out retrying after 30000ms:
`cy.wait()` timed out waiting `30000ms` for the 1st response to the route: `cardQuery`.
No response ever occurred.
```

### The fix
Adding a limit to the source query should improve the performance.

### Additional notes
This PR also improves assertions in two ways:
- It uses semantic selector which now searches for the explicit question name (this fixes eslint error)
- It adds a few more assertions that should increase the confidence in this test[^1]

### Tests
Stress-test this fix by running it 20 times:
https://github.com/metabase/metabase/actions/runs/5255922018/jobs/9496483621

```
  issue 18630
    ✓ should normally open queries with field literals in joins (metabase#18630): burning 1 of 20 (9294ms)
    ✓ should normally open queries with field literals in joins (metabase#18630): burning 2 of 20 (7006ms)
    ✓ should normally open queries with field literals in joins (metabase#18630): burning 3 of 20 (7724ms)
    ✓ should normally open queries with field literals in joins (metabase#18630): burning 4 of 20 (5865ms)
    ✓ should normally open queries with field literals in joins (metabase#18630): burning 5 of 20 (6279ms)
    ✓ should normally open queries with field literals in joins (metabase#18630): burning 6 of 20 (6030ms)
    ✓ should normally open queries with field literals in joins (metabase#18630): burning 7 of 20 (6131ms)
    ✓ should normally open queries with field literals in joins (metabase#18630): burning 8 of 20 (5684ms)
    ✓ should normally open queries with field literals in joins (metabase#18630): burning 9 of 20 (5195ms)
    ✓ should normally open queries with field literals in joins (metabase#18630): burning 10 of 20 (4475ms)
    ✓ should normally open queries with field literals in joins (metabase#18630): burning 11 of 20 (4966ms)
    ✓ should normally open queries with field literals in joins (metabase#18630): burning 12 of 20 (5141ms)
    ✓ should normally open queries with field literals in joins (metabase#18630): burning 13 of 20 (5351ms)
    ✓ should normally open queries with field literals in joins (metabase#18630): burning 14 of 20 (4493ms)
    ✓ should normally open queries with field literals in joins (metabase#18630): burning 15 of 20 (4441ms)
    ✓ should normally open queries with field literals in joins (metabase#18630): burning 16 of 20 (4374ms)
    ✓ should normally open queries with field literals in joins (metabase#18630): burning 17 of 20 (4877ms)
    ✓ should normally open queries with field literals in joins (metabase#18630): burning 18 of 20 (4428ms)
    ✓ should normally open queries with field literals in joins (metabase#18630): burning 19 of 20 (4663ms)
    ✓ should normally open queries with field literals in joins (metabase#18630): burning 20 of 20 (5366ms)
```

[^1]: The previous assertion was making sure the test name loaded, but that didn't mean the query results loaded as well. This PR fixes that.