### PR TITLE
Manual backport - Respect alphabetical order of collections in "Move" modal (#31355)

### DIFF
--- a/frontend/src/metabase/entities/collections/collections.ts
+++ b/frontend/src/metabase/entities/collections/collections.ts
@@ -83,9 +83,8 @@ const Collections = createEntity({
       [
         state => Collections.selectors.getList(state),
         getUserPersonalCollectionId,
-        (_state, props) => props?.collectionFilter,
       ],
-      (collections, currentUserPersonalCollectionId, collectionFilter) =>
+      (collections, currentUserPersonalCollectionId) =>
         getExpandedCollectionsById(
           collections || [],
           currentUserPersonalCollectionId,

--- a/frontend/src/metabase/entities/collections/collections.ts
+++ b/frontend/src/metabase/entities/collections/collections.ts
@@ -80,10 +80,14 @@ const Collections = createEntity({
 
   selectors: {
     getExpandedCollectionsById: createSelector(
-      [state => state.entities.collections || {}, getUserPersonalCollectionId],
-      (collections, currentUserPersonalCollectionId) =>
+      [
+        state => Collections.selectors.getList(state),
+        getUserPersonalCollectionId,
+        (_state, props) => props?.collectionFilter,
+      ],
+      (collections, currentUserPersonalCollectionId, collectionFilter) =>
         getExpandedCollectionsById(
-          Object.values(collections),
+          collections || [],
           currentUserPersonalCollectionId,
         ),
     ),

--- a/frontend/src/metabase/entities/snippet-collections.js
+++ b/frontend/src/metabase/entities/snippet-collections.js
@@ -45,9 +45,8 @@ const SnippetCollections = createEntity({
 
   selectors: {
     getExpandedCollectionsById: createSelector(
-      state => state.entities.snippetCollections || {},
-      collections =>
-        getExpandedCollectionsById(Object.values(collections), null),
+      state => SnippetCollections.selectors.getList(state) || [],
+      collections => getExpandedCollectionsById(collections, null),
     ),
   },
 


### PR DESCRIPTION
Manual backport of #31355 (which is a fix for #31294 and #31425)