### PR TITLE
5/x Add embedding tests

### DIFF
--- a/e2e/support/commands/database/addH2SampleDatabase.js
+++ b/e2e/support/commands/database/addH2SampleDatabase.js
@@ -1,9 +1,6 @@
 Cypress.Commands.add(
   "addH2SampleDatabase",
   ({ name, auto_run_queries = false, is_full_sync = false } = {}) => {
-    // IMPORTANT!
-    // TODO: Remove the following line when https://github.com/metabase/metabase/issues/24900 gets fixed.
-    cy.skipOn(true);
     cy.log(`Add another H2 sample database DB called "${name}"`);
     cy.request("POST", "/api/database", {
       engine: "h2",

--- a/e2e/test/scenarios/admin/databases/database-prompt-banner.cy.spec.js
+++ b/e2e/test/scenarios/admin/databases/database-prompt-banner.cy.spec.js
@@ -62,6 +62,7 @@ describe("banner", () => {
     it("should not render for public links", () => {
       visitPublicQuestion(QUESTION_ID);
 
+      cy.findByRole("heading", { name: "Orders" }).should("exist");
       cy.findAllByRole("banner")
         .first()
         .within(() => {
@@ -83,6 +84,7 @@ describe("banner", () => {
       };
       visitEmbeddedPage(payload);
 
+      cy.findByRole("heading", { name: "Orders" }).should("exist");
       cy.findAllByRole("banner")
         .first()
         .within(() => {
@@ -95,6 +97,9 @@ describe("banner", () => {
     describe("full-app embeddings", () => {
       it("should render database prompt banner when logged in as an admin, an instance is on a paid plan, only have a single sample dataset, and is not white labeling", () => {
         visitUrl({ url: "/", qs: { side_nav: false, logo: false } });
+
+        cy.findByRole("link", { name: "Metabase tips" }).should("exist");
+
         // Test that we're in full-app embedding since parameters are working.
         appBar().should("not.exist");
 
@@ -112,6 +117,9 @@ describe("banner", () => {
         cy.addH2SampleDatabase({ name: "H2 DB" });
 
         visitUrl({ url: "/", qs: { side_nav: false, logo: false } });
+
+        cy.findByRole("link", { name: "Metabase tips" }).should("exist");
+
         // Test that we're in full-app embedding since parameters are working.
         appBar().should("not.exist");
 

--- a/e2e/test/scenarios/admin/databases/database-prompt-banner.cy.spec.js
+++ b/e2e/test/scenarios/admin/databases/database-prompt-banner.cy.spec.js
@@ -6,8 +6,6 @@ import {
   expectNoBadSnowplowEvents,
   resetSnowplow,
   restore,
-  visitEmbeddedPage,
-  visitPublicQuestion,
 } from "e2e/support/helpers";
 
 describe("banner", () => {
@@ -58,41 +56,7 @@ describe("banner", () => {
   });
 
   describe("embeddings", () => {
-    const QUESTION_ID = 1;
-    it("should not render for public links", () => {
-      visitPublicQuestion(QUESTION_ID);
-
-      cy.findByRole("heading", { name: "Orders" }).should("exist");
-      cy.findAllByRole("banner")
-        .first()
-        .within(() => {
-          cy.findByText(
-            "Connect to your database to get the most from Metabase.",
-          ).should("not.exist");
-        });
-    });
-
-    it("should not render for signed embeds", () => {
-      cy.request("PUT", `/api/card/${QUESTION_ID}`, {
-        embedding_params: {},
-        enable_embedding: true,
-      });
-
-      const payload = {
-        resource: { question: 1 },
-        params: {},
-      };
-      visitEmbeddedPage(payload);
-
-      cy.findByRole("heading", { name: "Orders" }).should("exist");
-      cy.findAllByRole("banner")
-        .first()
-        .within(() => {
-          cy.findByText(
-            "Connect to your database to get the most from Metabase.",
-          ).should("not.exist");
-        });
-    });
+    // Public and signed embeds are tested in `PublicQuestion.unit.spec.tsx`
 
     describe("full-app embeddings", () => {
       it("should render database prompt banner when logged in as an admin, an instance is on a paid plan, only have a single sample dataset, and is not white labeling", () => {

--- a/e2e/test/scenarios/admin/databases/database-prompt-banner.cy.spec.js
+++ b/e2e/test/scenarios/admin/databases/database-prompt-banner.cy.spec.js
@@ -7,6 +7,7 @@ import {
   resetSnowplow,
   restore,
   visitEmbeddedPage,
+  visitPublicQuestion,
 } from "e2e/support/helpers";
 
 describe("banner", () => {
@@ -59,11 +60,7 @@ describe("banner", () => {
   describe("embeddings", () => {
     const QUESTION_ID = 1;
     it("should not render for public links", () => {
-      cy.request("POST", `/api/card/${QUESTION_ID}/public_link`, {}).then(
-        ({ body: { uuid } }) => {
-          cy.visit(`/public/question/${uuid}`);
-        },
-      );
+      visitPublicQuestion(QUESTION_ID);
 
       cy.findAllByRole("banner")
         .first()

--- a/e2e/test/scenarios/admin/databases/database-prompt-banner.cy.spec.js
+++ b/e2e/test/scenarios/admin/databases/database-prompt-banner.cy.spec.js
@@ -1,10 +1,12 @@
 import {
+  appBar,
   describeWithSnowplow,
   enableTracking,
   expectGoodSnowplowEvents,
   expectNoBadSnowplowEvents,
   resetSnowplow,
   restore,
+  visitEmbeddedPage,
 } from "e2e/support/helpers";
 
 describe("banner", () => {
@@ -13,7 +15,7 @@ describe("banner", () => {
     cy.signInAsAdmin();
   });
 
-  it("should show a database prompt banner when logged in as an admin, an instance is on a paid plan, and only have a single sample dataset", () => {
+  it("should show a database prompt banner when logged in as an admin, an instance is on a paid plan, only have a single sample dataset, and is not white labeling", () => {
     cy.visit("/");
     cy.findByRole("main").findByText("Loading...").should("not.exist");
 
@@ -53,6 +55,74 @@ describe("banner", () => {
         ).should("not.exist");
       });
   });
+
+  describe("embeddings", () => {
+    const QUESTION_ID = 1;
+    it("should not render for public links", () => {
+      cy.request("POST", `/api/card/${QUESTION_ID}/public_link`, {}).then(
+        ({ body: { uuid } }) => {
+          cy.visit(`/public/question/${uuid}`);
+        },
+      );
+
+      cy.findAllByRole("banner")
+        .first()
+        .within(() => {
+          cy.findByText(
+            "Connect to your database to get the most from Metabase.",
+          ).should("not.exist");
+        });
+    });
+
+    it("should not render for signed embeds", () => {
+      cy.request("PUT", `/api/card/${QUESTION_ID}`, {
+        embedding_params: {},
+        enable_embedding: true,
+      });
+
+      const payload = {
+        resource: { question: 1 },
+        params: {},
+      };
+      visitEmbeddedPage(payload);
+
+      cy.findAllByRole("banner")
+        .first()
+        .within(() => {
+          cy.findByText(
+            "Connect to your database to get the most from Metabase.",
+          ).should("not.exist");
+        });
+    });
+
+    describe("full-app embeddings", () => {
+      it("should render database prompt banner when logged in as an admin, an instance is on a paid plan, only have a single sample dataset, and is not white labeling", () => {
+        visitUrl({ url: "/", qs: { side_nav: false, logo: false } });
+        // Test that we're in full-app embedding since parameters are working.
+        appBar().should("not.exist");
+
+        cy.findAllByRole("banner")
+          .first()
+          .within(() => {
+            cy.findByText(
+              "Connect to your database to get the most from Metabase.",
+            ).should("exist");
+          });
+      });
+
+      it("should not render for any other condition", () => {
+        // Adding a second database should prevent the database prompt
+        cy.addH2SampleDatabase({ name: "H2 DB" });
+
+        visitUrl({ url: "/", qs: { side_nav: false, logo: false } });
+        // Test that we're in full-app embedding since parameters are working.
+        appBar().should("not.exist");
+
+        // Since there wouldn't be a database prompt banner, we can assert that there is no banner at all
+        cy.findAllByRole("banner").should("not.exist");
+      });
+    });
+  });
 });
 
 describeWithSnowplow(
@@ -89,3 +159,14 @@ describeWithSnowplow(
     });
   },
 );
+
+const visitUrl = url => {
+  cy.visit({
+    ...url,
+    onBeforeLoad(window) {
+      // cypress runs all tests in an iframe and the app uses this property to avoid embedding mode for all tests
+      // by removing the property the app would work in embedding mode
+      window.Cypress = undefined;
+    },
+  });
+};

--- a/frontend/src/metabase-types/api/card.ts
+++ b/frontend/src/metabase-types/api/card.ts
@@ -2,7 +2,7 @@ import type { DatabaseId } from "./database";
 import type { DashboardId, DashCardId } from "./dashboard";
 import type { Field } from "./field";
 import type { Parameter } from "./parameters";
-import type { DatasetQuery, FieldReference } from "./query";
+import type { DatasetQuery, FieldReference, PublicDatasetQuery } from "./query";
 import type { UserInfo } from "./user";
 
 export interface Card<Q = DatasetQuery> extends UnsavedCard<Q> {
@@ -25,6 +25,16 @@ export interface Card<Q = DatasetQuery> extends UnsavedCard<Q> {
   archived: boolean;
 
   creator?: UserInfo;
+}
+
+export interface PublicCard {
+  id: CardId;
+  name: string;
+  description: string | null;
+  display: CardDisplayType;
+  visualization_settings: VisualizationSettings;
+  parameters?: Parameter[];
+  dataset_query: PublicDatasetQuery;
 }
 
 export type CardDisplayType = string;

--- a/frontend/src/metabase-types/api/dataset.ts
+++ b/frontend/src/metabase-types/api/dataset.ts
@@ -72,6 +72,22 @@ export interface Dataset {
   status?: string;
 }
 
+export interface PublicDatasetData {
+  rows: RowValues[];
+  cols: DatasetColumn[];
+  rows_truncated: number;
+  // TODO: Correct this type
+  insights: any;
+  requested_timezone?: string;
+  results_timezone?: string;
+}
+
+export interface PublicDataset {
+  data: PublicDatasetData;
+  json_query?: JsonQuery;
+  status?: string;
+}
+
 export interface NativeQueryForm {
   query: string;
 }

--- a/frontend/src/metabase-types/api/mocks/card.ts
+++ b/frontend/src/metabase-types/api/mocks/card.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   ModerationReview,
   Card,
   UnsavedCard,
@@ -6,7 +6,9 @@ import {
   SeriesOrderSetting,
   StructuredDatasetQuery,
   NativeDatasetQuery,
+  PublicCard,
 } from "metabase-types/api";
+
 import {
   createMockNativeDatasetQuery,
   createMockStructuredDatasetQuery,
@@ -27,6 +29,18 @@ export const createMockCard = (opts?: Partial<Card>): Card => ({
   collection_id: null,
   last_query_start: null,
   archived: false,
+  ...opts,
+});
+
+export const createMockPublicCard = (
+  opts?: Partial<PublicCard>,
+): PublicCard => ({
+  id: 1,
+  name: "Question",
+  description: null,
+  display: "table",
+  dataset_query: { type: "query" },
+  visualization_settings: createMockVisualizationSettings(),
   ...opts,
 });
 

--- a/frontend/src/metabase-types/api/mocks/dataset.ts
+++ b/frontend/src/metabase-types/api/mocks/dataset.ts
@@ -1,7 +1,9 @@
-import {
+import type {
   Dataset,
   DatasetColumn,
   DatasetData,
+  PublicDataset,
+  PublicDatasetData,
   ResultsMetadata,
   TemplateTag,
 } from "metabase-types/api/dataset";
@@ -49,6 +51,34 @@ export const createMockDataset = ({
   ...opts
 }: MockDatasetOpts = {}) => ({
   data: createMockDatasetData(data),
+  database_id: 1,
+  row_count: 0,
+  running_time: 1000,
+  ...opts,
+});
+
+export const createMockPublicDatasetData = ({
+  cols = [
+    createMockColumn({
+      display_name: "NAME",
+      source: "native",
+      name: "NAME",
+    }),
+  ],
+  ...opts
+}: Partial<PublicDatasetData>): PublicDatasetData => ({
+  rows: [],
+  cols,
+  rows_truncated: 0,
+  insights: null,
+  ...opts,
+});
+
+export const createMockPublicDataset = ({
+  data = {},
+  ...opts
+}: MockDatasetOpts = {}): PublicDataset => ({
+  data: createMockPublicDatasetData(data),
   database_id: 1,
   row_count: 0,
   running_time: 1000,

--- a/frontend/src/metabase-types/api/query.ts
+++ b/frontend/src/metabase-types/api/query.ts
@@ -32,6 +32,21 @@ export interface NativeDatasetQuery {
 
 export type DatasetQuery = StructuredDatasetQuery | NativeDatasetQuery;
 
+interface PublicStructuredDatasetQuery {
+  type: "query";
+}
+
+interface PublicNativeDatasetQuery {
+  type: "native";
+  native: {
+    "template-tags"?: TemplateTags;
+  };
+}
+
+export type PublicDatasetQuery =
+  | PublicStructuredDatasetQuery
+  | PublicNativeDatasetQuery;
+
 export type DatetimeUnit =
   | "default"
   | "minute"

--- a/frontend/src/metabase/home/components/HomeHelpCard/HomeHelpCard.tsx
+++ b/frontend/src/metabase/home/components/HomeHelpCard/HomeHelpCard.tsx
@@ -1,12 +1,14 @@
 import { t } from "ttag";
 import MetabaseSettings from "metabase/lib/settings";
+import { useUniqueId } from "metabase/hooks/use-unique-id";
 import { CardIcon, CardRoot, CardTitle } from "./HomeHelpCard.styled";
 
 export const HomeHelpCard = (): JSX.Element => {
+  const cardTitleId = useUniqueId();
   return (
-    <CardRoot href={MetabaseSettings.learnUrl()}>
+    <CardRoot href={MetabaseSettings.learnUrl()} aria-labelledby={cardTitleId}>
       <CardIcon name="reference" />
-      <CardTitle>{t`Metabase tips`}</CardTitle>
+      <CardTitle id={cardTitleId}>{t`Metabase tips`}</CardTitle>
     </CardRoot>
   );
 };

--- a/frontend/src/metabase/public/containers/PublicQuestion/PublicQuestion.jsx
+++ b/frontend/src/metabase/public/containers/PublicQuestion/PublicQuestion.jsx
@@ -30,7 +30,7 @@ import { getCardUiParameters } from "metabase-lib/parameters/utils/cards";
 import { getParameterValuesBySlug } from "metabase-lib/parameters/utils/parameter-values";
 import { getParametersFromCard } from "metabase-lib/parameters/utils/template-tags";
 import { applyParameters } from "metabase-lib/queries/utils/card";
-import EmbedFrame from "../components/EmbedFrame";
+import EmbedFrame from "../../components/EmbedFrame";
 
 const mapStateToProps = state => ({
   metadata: getMetadata(state),
@@ -42,7 +42,7 @@ const mapDispatchToProps = {
   addFields,
 };
 
-class PublicQuestion extends Component {
+class PublicQuestionInner extends Component {
   constructor(props) {
     super(props);
     this.state = {
@@ -233,8 +233,8 @@ class PublicQuestion extends Component {
   }
 }
 
-export default _.compose(
+export const PublicQuestion = _.compose(
   connect(mapStateToProps, mapDispatchToProps),
   title(({ card }) => card && card.name),
   ExplicitSize({ refreshMode: "debounceLeading" }),
-)(PublicQuestion);
+)(PublicQuestionInner);

--- a/frontend/src/metabase/public/containers/PublicQuestion/PublicQuestion.unit.spec.tsx
+++ b/frontend/src/metabase/public/containers/PublicQuestion/PublicQuestion.unit.spec.tsx
@@ -1,0 +1,58 @@
+import { Route } from "react-router";
+
+import { renderWithProviders, screen, within } from "__support__/ui";
+import {
+  setupPublicCardQueryEndpoints,
+  setupPublicQuestionEndpoints,
+} from "__support__/server-mocks/public";
+import { createMockState } from "metabase-types/store/mocks";
+import {
+  createMockPublicCard,
+  createMockPublicDataset,
+} from "metabase-types/api/mocks";
+
+import { PublicQuestion } from "./PublicQuestion";
+
+const FAKE_UUID = "123456";
+
+const QUESTION_NAME = "Public question";
+
+async function setup() {
+  setupPublicQuestionEndpoints(
+    FAKE_UUID,
+    createMockPublicCard({ name: QUESTION_NAME }),
+  );
+  setupPublicCardQueryEndpoints(
+    FAKE_UUID,
+    createMockPublicDataset({
+      data: { rows: [["John W."]] },
+    }),
+  );
+
+  renderWithProviders(
+    <Route path="public/question/:uuid" component={PublicQuestion} />,
+    {
+      storeInitialState: createMockState(),
+      withRouter: true,
+      initialRoute: `public/question/${FAKE_UUID}`,
+    },
+  );
+  expect(await screen.findByText(QUESTION_NAME)).toBeInTheDocument();
+}
+
+describe("PublicQuestion", () => {
+  it("should render data", async () => {
+    await setup();
+    expect(screen.getByText("John W.")).toBeInTheDocument();
+  });
+
+  it("should not database prompt banner", async () => {
+    await setup();
+
+    // Since database prompt banner render as a banner. If we only find one banner
+    // that is showing the question name, we know that the database prompt banner is not showing.
+    expect(
+      within(screen.getByRole("banner")).getByText(QUESTION_NAME),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/metabase/public/containers/PublicQuestion/index.js
+++ b/frontend/src/metabase/public/containers/PublicQuestion/index.js
@@ -1,0 +1,1 @@
+export { PublicQuestion } from "./PublicQuestion";

--- a/frontend/src/metabase/routes-embed.jsx
+++ b/frontend/src/metabase/routes-embed.jsx
@@ -3,7 +3,7 @@ import { Route } from "react-router";
 import PublicNotFound from "metabase/public/components/PublicNotFound";
 
 import PublicApp from "metabase/public/containers/PublicApp";
-import PublicQuestion from "metabase/public/containers/PublicQuestion";
+import { PublicQuestion } from "metabase/public/containers/PublicQuestion";
 import PublicDashboard from "metabase/public/containers/PublicDashboard";
 
 export const getRoutes = store => (

--- a/frontend/src/metabase/routes-public.jsx
+++ b/frontend/src/metabase/routes-public.jsx
@@ -5,7 +5,7 @@ import PublicNotFound from "metabase/public/components/PublicNotFound";
 
 import PublicApp from "metabase/public/containers/PublicApp";
 import PublicAction from "metabase/public/containers/PublicAction";
-import PublicQuestion from "metabase/public/containers/PublicQuestion";
+import { PublicQuestion } from "metabase/public/containers/PublicQuestion";
 import PublicDashboard from "metabase/public/containers/PublicDashboard";
 
 export const getRoutes = store => (

--- a/frontend/src/metabase/routes.jsx
+++ b/frontend/src/metabase/routes.jsx
@@ -48,7 +48,7 @@ import getAdminRoutes from "metabase/admin/routes";
 import getCollectionTimelineRoutes from "metabase/timelines/collections/routes";
 import { getRoutes as getModelRoutes } from "metabase/models/routes";
 
-import PublicQuestion from "metabase/public/containers/PublicQuestion";
+import { PublicQuestion } from "metabase/public/containers/PublicQuestion";
 import PublicDashboard from "metabase/public/containers/PublicDashboard";
 import ArchiveDashboardModal from "metabase/dashboard/containers/ArchiveDashboardModal";
 import DashboardMoveModal from "metabase/dashboard/components/DashboardMoveModal";

--- a/frontend/src/metabase/selectors/embed.ts
+++ b/frontend/src/metabase/selectors/embed.ts
@@ -1,7 +1,7 @@
 import { isWithinIframe } from "metabase/lib/dom";
 import { State } from "metabase-types/store";
 
-export const getIsEmbedded = (state: State) => {
+export const getIsEmbedded = (_state?: State) => {
   return isWithinIframe();
 };
 

--- a/frontend/test/__support__/server-mocks/public.ts
+++ b/frontend/test/__support__/server-mocks/public.ts
@@ -1,0 +1,17 @@
+import fetchMock from "fetch-mock";
+
+import type { PublicCard, PublicDataset } from "metabase-types/api";
+
+export function setupPublicQuestionEndpoints(
+  uuid: string,
+  publicCard: PublicCard,
+) {
+  fetchMock.get(`path:/api/public/card/${uuid}`, publicCard);
+}
+
+export function setupPublicCardQueryEndpoints(
+  uuid: string,
+  publicDataset: PublicDataset,
+) {
+  fetchMock.get(`path:/api/public/card/${uuid}/query`, publicDataset);
+}


### PR DESCRIPTION
Epic: https://github.com/metabase/metabase/issues/31015
[Product doc](https://www.notion.so/metabase/Really-encourage-admins-to-add-a-DB-9c8c3a7d08ca45cb8672a154220f443e?pvs=4)

### Description

This PR adds missing embedding tests. (public links, signed embeds, full-app embeddings). [Context.](https://metaboat.slack.com/archives/C057T1QTB3L/p1686319589188869)

### How to verify

You could try testing embeddings manually. Basically only in full-app embedding that it's possible that the database prompt banner would be visible if:
1. User is an admin
2. Instance is on a paid plan
3. White label isn't enabled (only for Pro and Enterprise users, only if `application-name` is changed to something except **Metabase**)
4. The only connected database is a sample database

Other than that there shouldn't be any database prompt banner at all.

### Demo

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
