### PR TITLE
Mark table sync status as complete after syncing

### DIFF
--- a/src/metabase/sync.clj
+++ b/src/metabase/sync.clj
@@ -60,9 +60,11 @@
   "Perform all the different sync operations synchronously for a given `table`. Since often called on a sequence of
   tables, caller should check if can connect."
   [table :- i/TableInstance]
-  (sync-metadata/sync-table-metadata! table)
-  (analyze/analyze-table! table)
-  (field-values/update-field-values-for-table! table))
+  (doto table
+    (sync-metadata/sync-table-metadata!)
+    (analyze/analyze-table!)
+    (field-values/update-field-values-for-table!)
+    (sync-util/set-initial-table-sync-complete!)))
 
 (s/defn refingerprint-field!
   "Refingerprint a field, usually after its type changes. Checks if can connect to database, returning

--- a/test/metabase/sync_test.clj
+++ b/test/metabase/sync_test.clj
@@ -234,15 +234,16 @@
     (sync/sync-table! table)
     (is (= (merge
             (table-defaults)
-            {:schema       "default"
-             :name         "movie"
-             :display_name "Movie"
-             :fields       [(field:movie-id)
-                            (assoc (field:movie-studio)
-                                   :fk_target_field_id false
-                                   :semantic_type nil
-                                   :has_field_values :auto-list)
-                            (field:movie-title)]})
+            {:schema              "default"
+             :name                "movie"
+             :display_name        "Movie"
+             :initial_sync_status "complete"
+             :fields              [(field:movie-id)
+                                   (assoc (field:movie-studio)
+                                          :fk_target_field_id false
+                                          :semantic_type nil
+                                          :has_field_values :auto-list)
+                                   (field:movie-title)]})
            (table-details (t2/select-one Table :id (:id table)))))))
 
 ;; !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!


### PR DESCRIPTION
This was needed for uploading CSVs (which only syncs tables, not the whole DB), and I don't see why it shouldn't be true for anything that calls `sync-table!`