### PR TITLE
Fix the migration to increase grid of cards in revision table

### DIFF
--- a/src/metabase/db/custom_migrations.clj
+++ b/src/metabase/db/custom_migrations.clj
@@ -372,12 +372,14 @@
   (let [{:keys [row col size_x size_y]} (destructure-revision-card-sizes card)]
     ;; new_size_x = size_x + ((col + size_x + 1) // 3) - ((col + 1) // 3)
     ;; new_col = col + ((col + 1) // 3)
-    {:size_x (- (+ size_x
-                   (quot (+ col size_x 1) 3))
-                (quot (+ col 1) 3))
-     :col    (+ col (quot (+ col 1) 3))
-     :size_y size_y
-     :row    row}))
+    (merge
+      card
+      {:size_x (- (+ size_x
+                     (quot (+ col size_x 1) 3))
+                  (quot (+ col 1) 3))
+       :col    (+ col (quot (+ col 1) 3))
+       :size_y size_y
+       :row    row})))
 
 (defn- migrate-dashboard-grid-from-24-to-18
   "Mirror of the rollback algorithm we have in sql."
@@ -385,15 +387,17 @@
   (let [{:keys [row col size_x size_y]} (destructure-revision-card-sizes card)]
     ;; new_size_x = size_x - ((size_x + col + 1) // 4 - (col + 1) // 4)
     ;; new_col = col - (col + 1) // 4
-    {:size_x (if (= size_x 1)
-               1
-               (- size_x
-                  (-
-                   (quot (+ size_x col 1) 4)
-                   (quot (+ col 1) 4))))
-     :col    (- col (quot (+ col 1) 4))
-     :size_y size_y
-     :row    row}))
+    (merge
+      card
+      {:size_x (if (= size_x 1)
+                 1
+                 (- size_x
+                    (-
+                     (quot (+ size_x col 1) 4)
+                     (quot (+ col 1) 4))))
+       :col    (- col (quot (+ col 1) 4))
+       :size_y size_y
+       :row    row})))
 
 (define-reversible-migration RevisionDashboardMigrateGridFrom18To24
   (let [migrate! (fn [revision]

--- a/src/metabase/db/custom_migrations.clj
+++ b/src/metabase/db/custom_migrations.clj
@@ -372,14 +372,19 @@
   (let [{:keys [row col size_x size_y]} (destructure-revision-card-sizes card)]
     ;; new_size_x = size_x + ((col + size_x + 1) // 3) - ((col + 1) // 3)
     ;; new_col = col + ((col + 1) // 3)
-    (merge
-      card
-      {:size_x (- (+ size_x
-                     (quot (+ col size_x 1) 3))
-                  (quot (+ col 1) 3))
-       :col    (+ col (quot (+ col 1) 3))
-       :size_y size_y
-       :row    row})))
+    ;; need to wrap it a try catch in case anything weird could go wrong, for example
+    ;; sizes are string
+    (try
+     (merge
+       (dissoc card :sizeX :sizeY) ;; remove those legacy keys if exists
+       {:size_x (- (+ size_x
+                      (quot (+ col size_x 1) 3))
+                   (quot (+ col 1) 3))
+        :col    (+ col (quot (+ col 1) 3))
+        :size_y size_y
+        :row    row})
+     (catch Throwable _
+       card))))
 
 (defn- migrate-dashboard-grid-from-24-to-18
   "Mirror of the rollback algorithm we have in sql."
@@ -387,41 +392,37 @@
   (let [{:keys [row col size_x size_y]} (destructure-revision-card-sizes card)]
     ;; new_size_x = size_x - ((size_x + col + 1) // 4 - (col + 1) // 4)
     ;; new_col = col - (col + 1) // 4
-    (merge
-      card
-      {:size_x (if (= size_x 1)
-                 1
-                 (- size_x
-                    (-
-                     (quot (+ size_x col 1) 4)
-                     (quot (+ col 1) 4))))
-       :col    (- col (quot (+ col 1) 4))
-       :size_y size_y
-       :row    row})))
+    (try
+     (merge
+       card
+       {:size_x (if (= size_x 1)
+                  1
+                  (- size_x
+                     (-
+                      (quot (+ size_x col 1) 4)
+                      (quot (+ col 1) 4))))
+        :col    (- col (quot (+ col 1) 4))
+        :size_y size_y
+        :row    row})
+     (catch Throwable _
+       card))))
 
 (define-reversible-migration RevisionDashboardMigrateGridFrom18To24
   (let [migrate! (fn [revision]
                    (let [object (json/parse-string (:object revision) keyword)]
                      (when (seq (:cards object))
-                       (try
-                        (t2/query {:update :revision
-                                   :set {:object (json/generate-string (update object :cards #(map migrate-dashboard-grid-from-18-to-24 %)))}
-                                   :where [:= :id (:id revision)]})
-                        (catch Throwable
-                          _)))))]
-
+                       (t2/query {:update :revision
+                                  :set {:object (json/generate-string (update object :cards #(map migrate-dashboard-grid-from-18-to-24 %)))}
+                                  :where [:= :id (:id revision)]}))))]
     (run! migrate! (t2/reducible-query {:select [:*]
                                         :from   [:revision]
                                         :where  [:= :model "Dashboard"]})))
   (let [roll-back! (fn [revision]
                      (let [object (json/parse-string (:object revision) keyword)]
                        (when (seq (:cards object))
-                         (try
-                          (t2/query {:update :revision
+                         (t2/query {:update :revision
                                      :set {:object (json/generate-string (update object :cards #(map migrate-dashboard-grid-from-24-to-18 %)))}
-                                     :where [:= :id (:id revision)]})
-                          (catch Throwable
-                            _)))))]
+                                     :where [:= :id (:id revision)]}))))]
     (run! roll-back! (t2/reducible-query {:select [:*]
                                           :from   [:revision]
                                           :where  [:= :model "Dashboard"]}))))

--- a/test/metabase/db/custom_migrations_test.clj
+++ b/test/metabase/db/custom_migrations_test.clj
@@ -406,10 +406,11 @@
                                                               :password    "superstrong"
                                                               :date_joined :%now}))
 
-          cards        [{:row 0 :col 0 :size_x 4 :size_y 4}          ;; correct case
-                        {:row 0 :col 0 :sizeX 4 :sizeY 4}            ;; sizeX and sizeY are legacy names
-                        {:row nil :col nil :size_x nil :size_y nil}  ;; contains nil fields
-                        {:row "x" :col "x" :size_x "x" :size_y "x"}] ;; string values need to be skipped
+          cards        [{:id 1 :row 0 :col 0 :size_x 4 :size_y 4}          ; correct case
+                        {:id 2 :row 0 :col 0 :sizeX 4 :sizeY 4}            ; sizeX and sizeY are legacy names
+                        {:id 3 :row nil :col nil :size_x nil :size_y nil}  ; contains nil fields
+                        {:id 4 :row "x" :col "x" :size_x "x" :size_y "x"}  ; string values need to be skipped
+                        {:id 5 :row 0 :col 0 :size_x 4 :size_y 4 :series [1 2 3]}]  ; include keys other than size
           revision-id (first (t2/insert-returning-pks! 'Revision
                                                        {:object   {:cards cards}
                                                         :model    "Dashboard"
@@ -418,18 +419,20 @@
 
       (migrate!)
       (testing "forward migration migrate correclty and ignore failures"
-        (is (= [{:row 0, :col 0, :size_x 4, :size_y 4}
-                {:row 0, :col 0, :sizeX 4, :sizeY 4}
-                {:row nil, :col nil, :size_x nil, :size_y nil}
-                {:row "x", :col "x", :size_x "x", :size_y "x"}]
+        (is (= [{:id 1 :row 0, :col 0, :size_x 4, :size_y 4}
+                {:id 2 :row 0, :col 0, :sizeX 4, :sizeY 4}
+                {:id 3 :row nil, :col nil, :size_x nil, :size_y nil}
+                {:id 4 :row "x", :col "x", :size_x "x", :size_y "x"}
+                {:id 5 :row 0 :col 0 :size_x 4 :size_y 4 :series [1 2 3]}]
                (t2/select-one-fn (comp :cards :object) :model/Revision :id revision-id))))
       (migrate-down! 46)
 
       (testing "downgrade works correctly and ignore failures"
-        (is (= [{:row 0, :col 0, :size_x 4, :size_y 4}
-                {:row 0, :col 0, :sizeX 4, :sizeY 4}
-                {:row nil, :col nil, :size_x nil, :size_y nil}
-                {:row "x", :col "x", :size_x "x", :size_y "x"}]
+        (is (= [{:id 1 :row 0, :col 0, :size_x 4, :size_y 4}
+                {:id 2 :row 0, :col 0, :sizeX 4, :sizeY 4}
+                {:id 3 :row nil, :col nil, :size_x nil, :size_y nil}
+                {:id 4 :row "x", :col "x", :size_x "x", :size_y "x"}
+                {:id 5 :row 0 :col 0 :size_x 4 :size_y 4 :series [1 2 3]}]
                (t2/select-one-fn (comp :cards :object) :model/Revision :id revision-id)))))))
 
 (defn two-cards-overlap? [box1 box2]

--- a/test/metabase/db/custom_migrations_test.clj
+++ b/test/metabase/db/custom_migrations_test.clj
@@ -419,19 +419,19 @@
 
       (migrate!)
       (testing "forward migration migrate correclty and ignore failures"
-        (is (= [{:id 1 :row 0, :col 0, :size_x 4, :size_y 4}
-                {:id 2 :row 0, :col 0, :sizeX 4, :sizeY 4}
-                {:id 3 :row nil, :col nil, :size_x nil, :size_y nil}
-                {:id 4 :row "x", :col "x", :size_x "x", :size_y "x"}
-                {:id 5 :row 0 :col 0 :size_x 4 :size_y 4 :series [1 2 3]}]
+        (is (= [{:id 1 :row 0 :col 0 :size_x 5 :size_y 4}
+                {:id 2 :row 0 :col 0 :size_x 5 :size_y 4}
+                {:id 3 :row 0 :col 0 :size_x 5 :size_y 4}
+                {:id 4 :row "x" :col "x" :size_x "x" :size_y "x"}
+                {:id 5 :row 0 :col 0 :size_x 5 :size_y 4 :series [1 2 3]}]
                (t2/select-one-fn (comp :cards :object) :model/Revision :id revision-id))))
       (migrate-down! 46)
 
       (testing "downgrade works correctly and ignore failures"
-        (is (= [{:id 1 :row 0, :col 0, :size_x 4, :size_y 4}
-                {:id 2 :row 0, :col 0, :sizeX 4, :sizeY 4}
-                {:id 3 :row nil, :col nil, :size_x nil, :size_y nil}
-                {:id 4 :row "x", :col "x", :size_x "x", :size_y "x"}
+        (is (= [{:id 1 :row 0 :col 0 :size_x 4 :size_y 4}
+                {:id 2 :row 0 :col 0 :size_x 4 :size_y 4}
+                {:id 3 :size_y 4 :size_x 4 :col 0 :row 0}
+                {:id 4 :row "x" :col "x" :size_x "x" :size_y "x"}
                 {:id 5 :row 0 :col 0 :size_x 4 :size_y 4 :series [1 2 3]}]
                (t2/select-one-fn (comp :cards :object) :model/Revision :id revision-id)))))))
 


### PR DESCRIPTION
In https://github.com/metabase/metabase/pull/31019 I wrote a migration `v47.00-032` where I updated the cards size of dashboard in the revision table, but I made a mistake in the migration where I removed all keys other than `:size_x, :size_y, :row, :col`, this will break revision feature for all dashboards because it depends on having `:id` to work correctly.

Example: 

```
before the migration, a revision for dashboard can contains
{:object {:card {:id 1 :row 0 :col 0  :size_x 3 :size_y 3}
                {:id 2 :row 3  :col 0 :size_x 3 :size_y 3}}


after the migration, it will be
{:object {:card {:row 0 :col 0  :size_x 3 :size_y 3}
                {:row 3  :col 0 :size_x 3 :size_y 3}}
```

notice the `:id` key in each card is removed, and it's required for revision to work properly

This PR makes sure we post-merge the change, not replace it.
