### PR TITLE
Prototype of markdown truncating

### DIFF
--- a/frontend/src/metabase/collections/components/PinnedItemCard/PinnedItemCard.styled.tsx
+++ b/frontend/src/metabase/collections/components/PinnedItemCard/PinnedItemCard.styled.tsx
@@ -4,6 +4,7 @@ import { color } from "metabase/lib/colors";
 import { Icon } from "metabase/core/components/Icon";
 import Link from "metabase/core/components/Link";
 import Card from "metabase/components/Card";
+import Markdown from "metabase/core/components/Markdown";
 
 export const ItemCard = styled(Card)``;
 
@@ -37,11 +38,13 @@ export const Title = styled.div`
   overflow: hidden;
 `;
 
-export const Description = styled.div`
+export const TruncatedMarkdown = styled(Markdown)`
   color: ${color("text-medium")};
-  white-space: nowrap;
-  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 1;
+  -webkit-box-orient: vertical;
   overflow: hidden;
+  overflow-wrap: break-word;
 `;
 
 export const Body = styled.div`

--- a/frontend/src/metabase/collections/components/PinnedItemCard/PinnedItemCard.tsx
+++ b/frontend/src/metabase/collections/components/PinnedItemCard/PinnedItemCard.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import * as React from "react";
 import { t } from "ttag";
 
+import Markdown from "metabase/core/components/Markdown";
 import Tooltip from "metabase/core/components/Tooltip";
 
 import ActionMenu from "metabase/collections/components/ActionMenu";
@@ -13,13 +14,13 @@ import Database from "metabase-lib/metadata/Database";
 
 import {
   Body,
-  Description,
   Header,
   ActionsContainer,
   ItemCard,
   ItemIcon,
   ItemLink,
   Title,
+  TruncatedMarkdown,
 } from "./PinnedItemCard.styled";
 
 type Props = {
@@ -56,7 +57,6 @@ function PinnedItemCard({
   onMove,
 }: Props) {
   const [showTitleTooltip, setShowTitleTooltip] = useState(false);
-  const [showDescriptionTooltip, setShowDescriptionTooltip] = useState(false);
   const icon = item.getIcon().name;
   const { description, name, model } = item;
 
@@ -106,20 +106,17 @@ function PinnedItemCard({
             </Title>
           </Tooltip>
           <Tooltip
-            tooltip={description}
-            placement="bottom"
-            maxWidth={TOOLTIP_MAX_WIDTH}
-            isEnabled={showDescriptionTooltip}
+            tooltip={
+              <Markdown disallowHeading unstyleLinks>
+                {defaultedDescription ?? ""}
+              </Markdown>
+            }
           >
-            {defaultedDescription && (
-              <Description
-                onMouseEnter={e =>
-                  maybeEnableTooltip(e, setShowDescriptionTooltip)
-                }
-              >
-                {defaultedDescription}
-              </Description>
-            )}
+            <div>
+              <TruncatedMarkdown disallowHeading unstyleLinks>
+                {defaultedDescription ?? ""}
+              </TruncatedMarkdown>
+            </div>
           </Tooltip>
         </Body>
       </ItemCard>


### PR DESCRIPTION
Headings:
<img width="357" alt="Screenshot 2023-06-14 at 14 34 34" src="https://github.com/metabase/metabase/assets/8542534/03dee8a1-f703-43cc-8369-e98ebb437f0f">
<img width="726" alt="Screenshot 2023-06-14 at 14 34 25" src="https://github.com/metabase/metabase/assets/8542534/d57c4676-bfbe-4b7e-83e5-1a913f765969">

Styled text in the first line:
<img width="349" alt="Screenshot 2023-06-14 at 14 37 29" src="https://github.com/metabase/metabase/assets/8542534/fd94ccb6-4a74-47a3-b560-65087c8fffc1">
<img width="663" alt="Screenshot 2023-06-14 at 14 37 34" src="https://github.com/metabase/metabase/assets/8542534/d45235ad-8ea9-486e-932f-a6c3b50d4706">
 
Unstyled text:
<img width="352" alt="Screenshot 2023-06-14 at 14 36 59" src="https://github.com/metabase/metabase/assets/8542534/153e4f45-dc29-4f4b-8854-a84512592974">
<img width="662" alt="Screenshot 2023-06-14 at 14 37 06" src="https://github.com/metabase/metabase/assets/8542534/80a8a7a2-c5c7-43ed-8c83-809e6588963b">

