### PR TITLE
[E2E] Do not hardcode admin id

### DIFF
--- a/e2e/snapshot-creators/default.cy.snap.js
+++ b/e2e/snapshot-creators/default.cy.snap.js
@@ -67,8 +67,11 @@ describe("snapshots", () => {
         });
       },
     );
-    // Dismiss `it's ok to play around` modal for admin
-    cy.request("PUT", `/api/user/1/modal/qbnewb`, {});
+
+    cy.request("GET", "/api/user/current").then(({ body: { id } }) => {
+      // Dismiss `it's ok to play around` modal for admin
+      cy.request("PUT", `/api/user/${id}/modal/qbnewb`);
+    });
   }
 
   function updateSettings() {


### PR DESCRIPTION
We're trying to minimize the amount of hard coded IDs (or any other data) in E2E tests. This change doesn't assume admin's ID is always going to be `1`. It fetches the id from the current user instead.

This should make test more resilient to change.